### PR TITLE
feat(pricing): hot-reloadable TK pricing overlay (price a model without a release)

### DIFF
--- a/.cursor/skills/tokenkey-onboard-model/SKILL.md
+++ b/.cursor/skills/tokenkey-onboard-model/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   把"客户要在某账号上以价格 π served+priced 模型 X"从手工操作固化为分钟级确定性流水线：probe
   上游可服务性 → 写 manifest 条目(backend/internal/service/tk_served_models.json,单一意图源)→ 投影
   tk_NNN model_mapping 迁移 + tk_pricing_overlay.json fill-only 价(官方源,禁臆造)→
-  apply-live(scheduler_outbox/渠道热更)→ livefire 真请求 200 → 两档计费核对 + 话术。范围严格限
+  apply-live(scheduler_outbox 路由热更 + overlay sync-runtime 价热推,零发版)→ livefire 真请求 200 → 两档计费核对 + 话术。范围严格限
   TK 策展、经账号 credentials.model_mapping 服务的 newapi 长尾(account 60 Qwen ch17/group18、
   account 39 ds-官 DeepSeek ch43/group11),不含 litellm 全目录、四原生平台一类目录、grok(原生第七
   平台经平台路由非 mapping)。安全网=scripts/checks/catalog-serving-drift.py 漂移门禁(manifest↔
@@ -143,11 +143,16 @@ python3 ops/pricing/apply-pricing-hotfix.py stage-overlay --model qwen3-8b --fro
 overlay 是 fill-only：源带非零价时源胜、overlay 被忽略；**不能纠正错的非零源价**（deepseek-chat/reasoner
 镜像仍是 pre-V4 价 → 用 `price_source=mirror`，错价要修走渠道定价 DB 而非 overlay）。
 
-### 4) apply-live
+### 4) apply-live（零发版）
 
-- model_mapping 的运行期生效靠迁移内 `scheduler_outbox`（部署即生效）；overlay 价 compile-embedded，**随
-  发版生效**。
-- 紧急即时价（不等发版）：`apply-pricing-hotfix.py apply --channel-id N`（渠道定价凌驾一切，立即生效）。
+- **model_mapping**：运行期生效靠迁移内 `scheduler_outbox`（部署即生效）。
+- **overlay 价（热推，不等发版）**：overlay 不再是 compile-embedded-only —— 内嵌是**地板**，运行时活值经
+  settings key `tk_pricing_overlay_runtime` 叠加（runtime 胜）。PR 合并后跑
+  `python3 ops/pricing/manage-overlay-runtime.py sync-runtime`（先过 `pricing-overlay.py` 门禁 → SSM
+  UPSERT prod settings + `PUBLISH settings_updated` 即时跨副本重载；**prod-only**，edge 不跑计费）。模型
+  立即被定价 + 出现在公开 /pricing，**零镜像构建**。下次例行发版把 overlay 折进内嵌（地板追平），之后
+  `manage-overlay-runtime.py check` 应报「活值==内嵌」。
+- **紧急渠道价**（仅 channel-priced 模型，凌驾一切）：`apply-pricing-hotfix.py apply --channel-id N`，立即生效。
 
 ### 5) livefire 复测（真 200）
 

--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -134,6 +134,11 @@ func provideCleanup(
 	// the constructor used by handler ProviderSet. See R-001 of
 	// docs/approved/pricing-availability-source-of-truth.md.
 	_ service.TKGatewayPricingAvailabilityReady,
+	// TokenKey: forces wire to evaluate ProvideTKPricingOverlayRuntime so the
+	// runtime hot-pushable pricing overlay (settings-blob getter + catalog cache
+	// invalidator + pub/sub subscribe) is wired onto PricingService at startup.
+	// Without this edge wire would dead-code the post-construction setter.
+	_ service.TKPricingOverlayRuntimeReady,
 	// TokenKey: forces wire to evaluate ProvideTKGatewayAnthropicSigPreempt so
 	// GatewayService.SetAnthropicSigPreemptCache is called at startup. Without
 	// this dependency edge wire would dead-code the post-construction setter

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -313,13 +313,14 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	tkPricingMissingNotifier := service.ProvideTKPricingMissingNotifier(gatewayService, openAIGatewayService, opsService, configConfig)
 	tkAuthServiceColdStartReady := service.ProvideTKAuthServiceColdStart(authService, apiKeyService, settingService)
 	tkGatewayPricingAvailabilityReady := service.ProvideTKGatewayPricingAvailability(gatewayService, pricingAvailabilityService)
+	tkPricingOverlayRuntimeReady := service.ProvideTKPricingOverlayRuntime(pricingService, settingService, pricingCatalogService, settingPubSub)
 	anthropicSignaturePreemptCache := repository.NewAnthropicSignaturePreemptCache(redisClient)
 	tkGatewayAnthropicSigPreemptReady := service.ProvideTKGatewayAnthropicSigPreempt(gatewayService, anthropicSignaturePreemptCache)
 	anthropicSaturationCounterCache := repository.NewAnthropicSaturationCounterCache(redisClient)
 	tkAnthropicSaturationReady := service.ProvideTKAnthropicSaturation(gatewayService, rateLimitService, anthropicSaturationCounterCache)
 	modelListFilter := service.NewModelListFilter(pricingCatalogService, pricingAvailabilityService)
 	tkGatewayHandlerModelListReady := handler.ProvideTKGatewayHandlerModelList(gatewayHandler, modelListFilter)
-	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, antigravityConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, holdReconcilerService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayAnthropicSigPreemptReady, tkAnthropicSaturationReady, tkGatewayHandlerModelListReady)
+	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, antigravityConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, holdReconcilerService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkPricingOverlayRuntimeReady, tkGatewayAnthropicSigPreemptReady, tkAnthropicSaturationReady, tkGatewayHandlerModelListReady)
 	application := &Application{
 		Server:  httpServer,
 		Cleanup: v,
@@ -393,6 +394,8 @@ func provideCleanup(
 	_ service.TKAuthServiceColdStartReady,
 
 	_ service.TKGatewayPricingAvailabilityReady,
+
+	_ service.TKPricingOverlayRuntimeReady,
 
 	_ service.TKGatewayAnthropicSigPreemptReady,
 

--- a/backend/cmd/server/wire_gen_test.go
+++ b/backend/cmd/server/wire_gen_test.go
@@ -93,6 +93,7 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 		nil,                                   // pricingMissingNotifier
 		service.TKAuthServiceColdStartReady{}, // TK: forces SetTrialKeyIssuer wiring
 		service.TKGatewayPricingAvailabilityReady{}, // TK: forces SetPricingAvailabilityService wiring
+		service.TKPricingOverlayRuntimeReady{},      // TK: forces runtime overlay (settings hot-push) wiring
 		service.TKGatewayAnthropicSigPreemptReady{}, // TK: forces SetAnthropicSigPreemptCache wiring
 		service.TKAnthropicSaturationReady{},        // TK: forces SetAnthropicSaturationCounter wiring
 		handler.TKGatewayHandlerModelListReady{},    // TK: forces SetModelListFilter wiring

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -538,6 +538,16 @@ const (
 	// SettingKeyClaudeCodeHTTPMimicryManifest JSON manifest for OAuth mimicry
 	// anthropic-beta lists (sonnet_opus + haiku). Empty → compile-time defaults.
 	SettingKeyClaudeCodeHTTPMimicryManifest = "claude_code_http_mimicry_manifest"
+	// SettingKeyTKPricingOverlayRuntime is the runtime hot-pushable copy of
+	// tk_pricing_overlay.json (the same JSON object shape). Empty/absent → the
+	// compile-embedded overlay is used as-is (the floor). When present, its
+	// entries union OVER the embedded overlay (runtime wins on key conflict), so
+	// a new model can be priced + surfaced in /pricing WITHOUT a release. git
+	// (the embedded JSON) stays the single source of truth; ops `sync-runtime`
+	// UPSERTs this key on prod, the next release folds it into the embed (the
+	// floor catches up). Mirrors the claude_code_http_mimicry_manifest blob
+	// pattern. See pricing_service_tk_overlay_runtime.go.
+	SettingKeyTKPricingOverlayRuntime = "tk_pricing_overlay_runtime"
 	// SettingKeyOpenAICodexUserAgent OpenAI Codex 完整 User-Agent（空值使用内置默认）
 	// 当客户端 UA 被识别为浏览器（Chrome/Firefox/Safari/Edge 等）时，转发给 OpenAI 上游前会替换为此值，
 	// 用于避免 Cloudflare 对浏览器型 UA 的质询拦截。

--- a/backend/internal/service/pricing_catalog_tk.go
+++ b/backend/internal/service/pricing_catalog_tk.go
@@ -166,6 +166,21 @@ func (s *PricingCatalogService) SetSourceForTesting(src CatalogSource) {
 	s.mu.Unlock()
 }
 
+// InvalidateCache drops the cached catalog so the next BuildPublicCatalog
+// re-parses + re-applies the overlay. The cache keys on the source file's mtime
+// (model_pricing.json), so a TK pricing-overlay HOT change — which does not touch
+// that file — would otherwise serve stale prices forever. The runtime overlay
+// reload (pricing_service_tk_overlay_runtime.go) calls this after a swap. Nil-safe.
+func (s *PricingCatalogService) InvalidateCache() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.cached = nil
+	s.cachedMt = time.Time{}
+	s.mu.Unlock()
+}
+
 // BuildPublicCatalog returns the catalog DTO. Callers must not mutate the
 // returned response — it may be shared across requests via the internal cache.
 //

--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -128,6 +128,17 @@ type PricingService struct {
 	// 停止信号
 	stopCh chan struct{}
 	wg     sync.WaitGroup
+
+	// TK: runtime hot-pushable overlay deps (set post-construction via
+	// SetOverlayRuntimeDeps; all nil-safe). overlayRuntimeGetter reads the
+	// SettingKeyTKPricingOverlayRuntime blob; overlayCacheInvalidator busts the
+	// public-catalog mtime cache after a swap. overlayMu guards overlayRuntimeHash
+	// (the last-applied blob hash, for idempotent reloads) independently of s.mu.
+	// See pricing_service_tk_overlay_runtime.go.
+	overlayMu               sync.Mutex
+	overlayRuntimeHash      string
+	overlayRuntimeGetter    func(ctx context.Context) (string, bool)
+	overlayCacheInvalidator func()
 }
 
 // NewPricingService 创建价格服务
@@ -258,6 +269,13 @@ func (s *PricingService) checkAndUpdatePricing() error {
 
 // syncWithRemote 与远程同步（基于哈希校验）
 func (s *PricingService) syncWithRemote() error {
+	// TK: poll the runtime overlay blob too (settings hot-push fallback path when
+	// the pub/sub fan-out is unavailable). Hash-gated + best-effort: a no-op when
+	// unchanged, never blocks the remote price sync below.
+	if _, err := s.reloadTKOverlayRuntime(context.Background()); err != nil {
+		logger.LegacyPrintf("service.pricing", "[Pricing] runtime overlay poll reload failed: %v", err)
+	}
+
 	// 如果配置了哈希URL，从远程获取哈希进行比对
 	if s.cfg.Pricing.HashURL != "" {
 		remoteHash, err := s.fetchRemoteHash()

--- a/backend/internal/service/pricing_service_tk_overlay.go
+++ b/backend/internal/service/pricing_service_tk_overlay.go
@@ -49,79 +49,131 @@ import (
 //go:embed tk_pricing_overlay.json
 var tkPricingOverlayRaw []byte
 
+// tkOverlayEffective is the live overlay map = embedded ∪ runtime-settings
+// (runtime wins on key conflict), rebuilt by rebuildTKOverlayUnion. The embedded
+// JSON is the FLOOR (offline self-consistent); the runtime settings blob
+// (SettingKeyTKPricingOverlayRuntime) is the hot override that lets a model be
+// priced without a release. Guarded by tkOverlayMu so the hot swap is safe under
+// concurrent loadTKPricingOverlay reads. See pricing_service_tk_overlay_runtime.go.
 var (
-	tkPricingOverlayOnce sync.Once
-	tkPricingOverlay     map[string]*LiteLLMModelPricing
+	tkOverlayMu        sync.RWMutex
+	tkOverlayEffective map[string]*LiteLLMModelPricing
 )
 
-// loadTKPricingOverlay parses the embedded overlay once. It deliberately does NOT
-// call parsePricingData (that would recurse, since applyTKPricingOverlay is invoked
-// from inside parsePricingData) — it parses the small fixed file directly. Keys starting
-// with "_" (e.g. "_meta") are provenance, not pricing, and are skipped.
+// parseTKOverlayBytes parses an overlay JSON object (the embedded file OR the
+// runtime settings blob — identical shape) into the pricing map. It deliberately
+// does NOT call parsePricingData (that would recurse, since applyTKPricingOverlay
+// is invoked from inside parsePricingData) — it parses the small fixed file
+// directly. Keys starting with "_" (e.g. "_meta") are provenance, not pricing,
+// and are skipped. Returns an error only when the top-level JSON is unparseable
+// (a single malformed entry is skipped, not fatal).
+func parseTKOverlayBytes(data []byte) (map[string]*LiteLLMModelPricing, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	out := make(map[string]*LiteLLMModelPricing, len(raw))
+	for name, rawEntry := range raw {
+		if strings.HasPrefix(name, "_") {
+			continue
+		}
+		var e LiteLLMRawEntry
+		if err := json.Unmarshal(rawEntry, &e); err != nil {
+			continue
+		}
+		p := &LiteLLMModelPricing{
+			LiteLLMProvider:       e.LiteLLMProvider,
+			Mode:                  e.Mode,
+			SupportsPromptCaching: e.SupportsPromptCaching,
+		}
+		if e.OutputCostPerImage != nil {
+			p.OutputCostPerImage = *e.OutputCostPerImage
+		}
+		if e.OutputCostPerImageToken != nil {
+			p.OutputCostPerImageToken = *e.OutputCostPerImageToken
+		}
+		if e.OutputCostPerSecond != nil {
+			p.OutputCostPerSecond = *e.OutputCostPerSecond
+		}
+		if e.InputCostPerToken != nil {
+			p.InputCostPerToken = *e.InputCostPerToken
+		}
+		if e.OutputCostPerToken != nil {
+			p.OutputCostPerToken = *e.OutputCostPerToken
+		}
+		if e.ThinkingOutputCostPerToken != nil {
+			p.ThinkingOutputCostPerToken = *e.ThinkingOutputCostPerToken
+		}
+		if e.CacheCreationInputTokenCost != nil {
+			p.CacheCreationInputTokenCost = *e.CacheCreationInputTokenCost
+		}
+		if e.CacheCreationInputTokenCostAbove1hr != nil {
+			p.CacheCreationInputTokenCostAbove1hr = *e.CacheCreationInputTokenCostAbove1hr
+		}
+		if e.CacheReadInputTokenCost != nil {
+			p.CacheReadInputTokenCost = *e.CacheReadInputTokenCost
+		}
+		// TK: input-token interval (tiered) pricing. LiteLLMRawEntry has no
+		// "intervals" field (it is TK-overlay-only), so parse the raw entry a
+		// second time into a TK-local shape. An entry's flat input/output cost
+		// stays as the out-of-range fallback (BasePricing); the intervals drive
+		// whole-request tier billing via ResolvedPricing.Intervals.
+		var ext struct {
+			Intervals []tkOverlayRawInterval `json:"intervals"`
+		}
+		if err := json.Unmarshal(rawEntry, &ext); err == nil && len(ext.Intervals) > 0 {
+			p.Intervals = tkBuildOverlayIntervals(ext.Intervals)
+		}
+		out[name] = p
+	}
+	return out, nil
+}
+
+// rebuildTKOverlayUnion recomputes the effective overlay = embedded ∪ runtime
+// (runtime wins on key conflict) and atomically swaps it under tkOverlayMu.
+//
+// Safety invariants (never serve $0):
+//   - The embedded JSON is parsed fresh each call as the FLOOR. If the embedded
+//     itself fails to parse (should be impossible — it is gated by
+//     pricing-overlay.py), the previous effective map is KEPT, not blanked.
+//   - A nil / empty / UNPARSEABLE runtimeBytes yields embedded-only; a corrupt
+//     runtime blob can never drop the effective map below the embedded floor.
+func rebuildTKOverlayUnion(runtimeBytes []byte) {
+	base, err := parseTKOverlayBytes(tkPricingOverlayRaw)
+	if err != nil {
+		// Embedded must always parse; if it somehow does not, keep whatever the
+		// effective map already held rather than blanking prices.
+		logger.LegacyPrintf("service.pricing", "[Pricing] embedded TK overlay parse failed (keeping current effective map): %v", err)
+		return
+	}
+	if len(runtimeBytes) > 0 {
+		if rt, err := parseTKOverlayBytes(runtimeBytes); err != nil {
+			logger.LegacyPrintf("service.pricing", "[Pricing] runtime TK overlay parse failed (using embedded floor only): %v", err)
+		} else {
+			for k, v := range rt {
+				base[k] = v // runtime wins on conflict
+			}
+		}
+	}
+	tkOverlayMu.Lock()
+	tkOverlayEffective = base
+	tkOverlayMu.Unlock()
+}
+
+// loadTKPricingOverlay returns the live effective overlay (embedded ∪ runtime).
+// First call before any explicit rebuild lazily builds the embedded-only floor,
+// so a process that never loads a runtime blob behaves exactly as before.
 func loadTKPricingOverlay() map[string]*LiteLLMModelPricing {
-	tkPricingOverlayOnce.Do(func() {
-		var raw map[string]json.RawMessage
-		if err := json.Unmarshal(tkPricingOverlayRaw, &raw); err != nil {
-			logger.LegacyPrintf("service.pricing", "[Pricing] TK pricing overlay parse failed: %v", err)
-			return
-		}
-		out := make(map[string]*LiteLLMModelPricing, len(raw))
-		for name, rawEntry := range raw {
-			if strings.HasPrefix(name, "_") {
-				continue
-			}
-			var e LiteLLMRawEntry
-			if err := json.Unmarshal(rawEntry, &e); err != nil {
-				continue
-			}
-			p := &LiteLLMModelPricing{
-				LiteLLMProvider:       e.LiteLLMProvider,
-				Mode:                  e.Mode,
-				SupportsPromptCaching: e.SupportsPromptCaching,
-			}
-			if e.OutputCostPerImage != nil {
-				p.OutputCostPerImage = *e.OutputCostPerImage
-			}
-			if e.OutputCostPerImageToken != nil {
-				p.OutputCostPerImageToken = *e.OutputCostPerImageToken
-			}
-			if e.OutputCostPerSecond != nil {
-				p.OutputCostPerSecond = *e.OutputCostPerSecond
-			}
-			if e.InputCostPerToken != nil {
-				p.InputCostPerToken = *e.InputCostPerToken
-			}
-			if e.OutputCostPerToken != nil {
-				p.OutputCostPerToken = *e.OutputCostPerToken
-			}
-			if e.ThinkingOutputCostPerToken != nil {
-				p.ThinkingOutputCostPerToken = *e.ThinkingOutputCostPerToken
-			}
-			if e.CacheCreationInputTokenCost != nil {
-				p.CacheCreationInputTokenCost = *e.CacheCreationInputTokenCost
-			}
-			if e.CacheCreationInputTokenCostAbove1hr != nil {
-				p.CacheCreationInputTokenCostAbove1hr = *e.CacheCreationInputTokenCostAbove1hr
-			}
-			if e.CacheReadInputTokenCost != nil {
-				p.CacheReadInputTokenCost = *e.CacheReadInputTokenCost
-			}
-			// TK: input-token interval (tiered) pricing. LiteLLMRawEntry has no
-			// "intervals" field (it is TK-overlay-only), so parse the raw entry a
-			// second time into a TK-local shape. An entry's flat input/output cost
-			// stays as the out-of-range fallback (BasePricing); the intervals drive
-			// whole-request tier billing via ResolvedPricing.Intervals.
-			var ext struct {
-				Intervals []tkOverlayRawInterval `json:"intervals"`
-			}
-			if err := json.Unmarshal(rawEntry, &ext); err == nil && len(ext.Intervals) > 0 {
-				p.Intervals = tkBuildOverlayIntervals(ext.Intervals)
-			}
-			out[name] = p
-		}
-		tkPricingOverlay = out
-	})
-	return tkPricingOverlay
+	tkOverlayMu.RLock()
+	m := tkOverlayEffective
+	tkOverlayMu.RUnlock()
+	if m != nil {
+		return m
+	}
+	rebuildTKOverlayUnion(nil)
+	tkOverlayMu.RLock()
+	defer tkOverlayMu.RUnlock()
+	return tkOverlayEffective
 }
 
 // applyTKPricingOverlay fills in TK-owned pricing for models the loaded source

--- a/backend/internal/service/pricing_service_tk_overlay_runtime.go
+++ b/backend/internal/service/pricing_service_tk_overlay_runtime.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// TK pricing overlay — runtime hot-push wiring.
+//
+// The embedded tk_pricing_overlay.json (pricing_service_tk_overlay.go) is the
+// compile floor. This file makes the overlay HOT: the live effective map =
+// embedded ∪ a runtime blob stored in settings (SettingKeyTKPricingOverlayRuntime),
+// so a model can be priced + surfaced in /pricing WITHOUT a release. Mirrors the
+// claude_code_http_mimicry_manifest pattern (setting_service_tk_mimicry_selfheal.go):
+// git stays the single source of truth, ops `sync-runtime` UPSERTs the settings
+// blob on prod, and the next routine release folds it into the embed (the floor
+// catches up — see ops/pricing/manage-overlay-runtime.py and its `check`).
+//
+// Two triggers keep the running process current after a hot push:
+//   - Pub/sub (immediate): the settings_updated channel — see SubscribeOverlayRuntime.
+//   - Poll (fallback): syncWithRemote's tick re-reads the blob, hash-gated.
+//
+// Both funnel through reloadTKOverlayRuntime, which validate-before-swaps and
+// NEVER blanks the effective map (a corrupt blob keeps the embedded floor — no $0).
+
+// SetOverlayRuntimeDeps wires the post-construction dependencies for the hot
+// overlay: a getter for the runtime settings blob and a callback to bust the
+// public-catalog mtime cache after a swap. Both are nil-safe; with neither set
+// the service serves the embedded floor exactly as before. Called from the wire
+// sentinel ProvideTKPricingOverlayRuntime.
+func (s *PricingService) SetOverlayRuntimeDeps(
+	getter func(ctx context.Context) (string, bool),
+	cacheInvalidator func(),
+) {
+	if s == nil {
+		return
+	}
+	s.overlayMu.Lock()
+	s.overlayRuntimeGetter = getter
+	s.overlayCacheInvalidator = cacheInvalidator
+	s.overlayMu.Unlock()
+}
+
+// SubscribeOverlayRuntime starts a cross-replica listener so a settings hot-push
+// reloads the overlay immediately (within seconds) instead of waiting out the
+// poll tick. Uses the same "settings_updated" bus SettingService publishes on, so
+// any settings write — including the ops sync-runtime's redis PUBLISH — fans out.
+// Nil-safe: a nil bus (single-replica dev / no redis) leaves only the poll path.
+func (s *PricingService) SubscribeOverlayRuntime(ctx context.Context, bus SettingPubSub) {
+	if s == nil || bus == nil {
+		return
+	}
+	bus.Subscribe(ctx, func() {
+		if _, err := s.reloadTKOverlayRuntime(ctx); err != nil {
+			logger.LegacyPrintf("service.pricing", "[Pricing] runtime overlay pubsub reload failed: %v", err)
+		}
+	})
+}
+
+// reloadTKOverlayRuntime re-reads the runtime overlay settings blob and, if it
+// changed, rebuilds the effective union (embedded ∪ runtime), rebuilds the merged
+// billing price map, and busts the public-catalog cache. Hash-gated (idempotent
+// across poll ticks + pub/sub fan-out). Returns whether anything changed.
+//
+// Safety: a corrupt runtime blob is rejected BEFORE the swap (the prior good
+// effective map is kept) and returns an error; the effective map is never blanked,
+// so billing never falls back to $0. An empty/absent blob is valid — it means
+// "use the embedded floor" (the GC-after-release state).
+func (s *PricingService) reloadTKOverlayRuntime(ctx context.Context) (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+	s.overlayMu.Lock()
+	getter := s.overlayRuntimeGetter
+	prevHash := s.overlayRuntimeHash
+	s.overlayMu.Unlock()
+
+	var blob string
+	if getter != nil {
+		if v, ok := getter(ctx); ok {
+			blob = v
+		}
+	}
+
+	newHash := ""
+	if blob != "" {
+		sum := sha256.Sum256([]byte(blob))
+		newHash = hex.EncodeToString(sum[:])
+	}
+	if newHash == prevHash {
+		return false, nil // unchanged (covers both "empty stays empty" and "same blob")
+	}
+
+	// Validate before swapping: a corrupt blob must not disturb the live map.
+	if blob != "" {
+		if _, err := parseTKOverlayBytes([]byte(blob)); err != nil {
+			// Keep prevHash so a later corrected blob still triggers a reload.
+			return false, err
+		}
+	}
+
+	if blob == "" {
+		rebuildTKOverlayUnion(nil) // operator cleared the key → fall back to embedded floor
+	} else {
+		rebuildTKOverlayUnion([]byte(blob))
+	}
+
+	// Rebuild the merged billing price map so /v1/messages billing sees the new
+	// overlay. Reuse loadPricingData (it re-parses the source file → re-applies
+	// the now-updated overlay → swaps s.pricingData under s.mu). Best-effort: if
+	// the source file is absent the catalog path already reflects the new union
+	// and billing will re-merge on the next remote sync.
+	if path := s.getPricingFilePath(); path != "" {
+		if err := s.loadPricingData(path); err != nil {
+			logger.LegacyPrintf("service.pricing", "[Pricing] overlay reload: rebuild price map skipped: %v", err)
+		}
+	}
+
+	// Bust the public-catalog mtime cache (it keys on model_pricing.json mtime and
+	// would otherwise serve stale prices after an overlay-only change).
+	s.overlayMu.Lock()
+	invalidator := s.overlayCacheInvalidator
+	s.overlayRuntimeHash = newHash
+	s.overlayMu.Unlock()
+	if invalidator != nil {
+		invalidator()
+	}
+
+	slog.Info("tk pricing overlay runtime reloaded", "models", len(loadTKPricingOverlay()), "empty_blob", blob == "")
+	return true, nil
+}

--- a/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
@@ -1,0 +1,208 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+// embeddedQwen8bInput is the embedded floor price for qwen3-8b — the assertion
+// anchor for "runtime overrides embedded" / "corrupt keeps embedded floor".
+const embeddedQwen8bInput = 7.462686567164179e-08
+
+func resetOverlayUnion(t *testing.T) {
+	t.Helper()
+	rebuildTKOverlayUnion(nil) // embedded-only floor
+}
+
+func TestRebuildTKOverlayUnion_RuntimeWins(t *testing.T) {
+	resetOverlayUnion(t)
+
+	// Sanity: embedded floor carries qwen3-8b at the known price.
+	if got := loadTKPricingOverlay()["qwen3-8b"]; got == nil || got.InputCostPerToken != embeddedQwen8bInput {
+		t.Fatalf("embedded floor qwen3-8b = %+v, want input %g", got, embeddedQwen8bInput)
+	}
+
+	runtime := `{
+        "qwen3-8b": {"input_cost_per_token": 9.99e-06, "litellm_provider": "dashscope", "mode": "chat"},
+        "zz-runtime-only": {"input_cost_per_token": 1.0e-06, "output_cost_per_token": 2.0e-06, "litellm_provider": "dashscope", "mode": "chat"}
+    }`
+	rebuildTKOverlayUnion([]byte(runtime))
+	eff := loadTKPricingOverlay()
+
+	if eff["qwen3-8b"].InputCostPerToken != 9.99e-06 {
+		t.Errorf("runtime did not win for qwen3-8b: got %g", eff["qwen3-8b"].InputCostPerToken)
+	}
+	if eff["zz-runtime-only"] == nil {
+		t.Errorf("runtime-only key missing from union")
+	}
+	// An embedded-only key (not in runtime) is still present.
+	if eff["qwen3-32b"] == nil {
+		t.Errorf("embedded-only key qwen3-32b dropped from union")
+	}
+}
+
+func TestRebuildTKOverlayUnion_CorruptRuntimeKeepsEmbeddedFloor(t *testing.T) {
+	resetOverlayUnion(t)
+	rebuildTKOverlayUnion([]byte("{ this is not valid json"))
+	eff := loadTKPricingOverlay()
+	if eff["qwen3-8b"] == nil || eff["qwen3-8b"].InputCostPerToken != embeddedQwen8bInput {
+		t.Fatalf("corrupt runtime must keep embedded floor; got %+v", eff["qwen3-8b"])
+	}
+}
+
+func TestRebuildTKOverlayUnion_EmptyFallsBackToEmbedded(t *testing.T) {
+	resetOverlayUnion(t)
+	rebuildTKOverlayUnion([]byte(`{"qwen3-8b":{"input_cost_per_token":5e-06,"litellm_provider":"dashscope"}}`))
+	if loadTKPricingOverlay()["qwen3-8b"].InputCostPerToken != 5e-06 {
+		t.Fatal("setup: runtime override not applied")
+	}
+	rebuildTKOverlayUnion(nil) // operator cleared the key
+	if loadTKPricingOverlay()["qwen3-8b"].InputCostPerToken != embeddedQwen8bInput {
+		t.Fatal("empty runtime must fall back to embedded floor")
+	}
+}
+
+func newTestPricingService() *PricingService {
+	return NewPricingService(&config.Config{}, nil)
+}
+
+func TestReloadTKOverlayRuntime_HashGatedAndApplies(t *testing.T) {
+	resetOverlayUnion(t)
+	s := newTestPricingService()
+	blob := `{"qwen3-8b":{"input_cost_per_token":8.88e-06,"litellm_provider":"dashscope"}}`
+	s.SetOverlayRuntimeDeps(func(context.Context) (string, bool) { return blob, true }, nil)
+
+	changed, err := s.reloadTKOverlayRuntime(context.Background())
+	if err != nil || !changed {
+		t.Fatalf("first reload changed=%v err=%v, want true/nil", changed, err)
+	}
+	if loadTKPricingOverlay()["qwen3-8b"].InputCostPerToken != 8.88e-06 {
+		t.Errorf("reload did not apply runtime override")
+	}
+	// Second reload, same blob → hash-gated no-op.
+	changed, err = s.reloadTKOverlayRuntime(context.Background())
+	if err != nil || changed {
+		t.Errorf("second reload changed=%v err=%v, want false/nil (hash-gated)", changed, err)
+	}
+}
+
+func TestReloadTKOverlayRuntime_CorruptKeepsCurrent(t *testing.T) {
+	resetOverlayUnion(t)
+	s := newTestPricingService()
+	good := `{"qwen3-8b":{"input_cost_per_token":7.77e-06,"litellm_provider":"dashscope"}}`
+	cur := good
+	s.SetOverlayRuntimeDeps(func(context.Context) (string, bool) { return cur, true }, nil)
+	if _, err := s.reloadTKOverlayRuntime(context.Background()); err != nil {
+		t.Fatalf("good reload failed: %v", err)
+	}
+	// Now the getter returns garbage: reload must error and keep the prior value.
+	cur = "{ broken"
+	changed, err := s.reloadTKOverlayRuntime(context.Background())
+	if err == nil || changed {
+		t.Errorf("corrupt reload changed=%v err=%v, want false/error", changed, err)
+	}
+	if loadTKPricingOverlay()["qwen3-8b"].InputCostPerToken != 7.77e-06 {
+		t.Errorf("corrupt reload must not disturb the live map; got %g",
+			loadTKPricingOverlay()["qwen3-8b"].InputCostPerToken)
+	}
+}
+
+func TestReloadTKOverlayRuntime_EmptyGetterIsEmbeddedFloor(t *testing.T) {
+	resetOverlayUnion(t)
+	s := newTestPricingService()
+	s.SetOverlayRuntimeDeps(func(context.Context) (string, bool) { return "", false }, nil)
+	if _, err := s.reloadTKOverlayRuntime(context.Background()); err != nil {
+		t.Fatalf("empty getter reload err: %v", err)
+	}
+	if loadTKPricingOverlay()["qwen3-8b"].InputCostPerToken != embeddedQwen8bInput {
+		t.Error("empty getter must serve embedded floor")
+	}
+}
+
+// TestConcurrentOverlayReadDuringSwap exercises the RWMutex hot-swap under -race.
+func TestConcurrentOverlayReadDuringSwap(t *testing.T) {
+	resetOverlayUnion(t)
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = loadTKPricingOverlay()["qwen3-8b"]
+				}
+			}
+		}()
+	}
+	for i := 0; i < 200; i++ {
+		rebuildTKOverlayUnion([]byte(`{"qwen3-8b":{"input_cost_per_token":1e-06,"litellm_provider":"dashscope"}}`))
+	}
+	close(stop)
+	wg.Wait()
+}
+
+// TestCatalogInvalidateCache_PicksUpHotOverlay is the mtime-cache-trap regression:
+// the catalog caches by source mtime, so an overlay-only change is invisible until
+// InvalidateCache is called.
+func TestCatalogInvalidateCache_PicksUpHotOverlay(t *testing.T) {
+	resetOverlayUnion(t)
+	cat := NewPricingCatalogService(nil)
+	src := []byte(`{"real-model":{"input_cost_per_token":1e-06,"output_cost_per_token":2e-06,"litellm_provider":"openai","mode":"chat"}}`)
+	fixedMt := time.Unix(1_700_000_000, 0)
+	cat.SetSourceForTesting(func() ([]byte, time.Time, bool) { return src, fixedMt, true })
+
+	const hot = "zz-hot-test-model"
+	has := func(resp *PublicCatalogResponse) bool {
+		for i := range resp.Data {
+			if resp.Data[i].ModelID == hot {
+				return true
+			}
+		}
+		return false
+	}
+
+	if has(cat.BuildPublicCatalog(context.Background())) {
+		t.Fatalf("setup: %s should not exist before hot-push", hot)
+	}
+	// Hot-push: add the model to the runtime union.
+	rebuildTKOverlayUnion([]byte(`{"` + hot + `":{"input_cost_per_token":3e-06,"output_cost_per_token":6e-06,"litellm_provider":"dashscope","mode":"chat"}}`))
+
+	// Same mtime → still cached, the trap: new model NOT visible.
+	if has(cat.BuildPublicCatalog(context.Background())) {
+		t.Errorf("expected stale cache (mtime unchanged) to hide %s — trap not reproduced", hot)
+	}
+	// The fix: invalidate, then it appears.
+	cat.InvalidateCache()
+	if !has(cat.BuildPublicCatalog(context.Background())) {
+		t.Errorf("after InvalidateCache, %s must appear in catalog", hot)
+	}
+}
+
+// guard against accidental JSON shape drift in the embedded overlay used as floor.
+func TestEmbeddedOverlayParsesAsFloor(t *testing.T) {
+	resetOverlayUnion(t)
+	m, err := parseTKOverlayBytes(tkPricingOverlayRaw)
+	if err != nil {
+		t.Fatalf("embedded overlay must parse: %v", err)
+	}
+	if len(m) == 0 {
+		t.Fatal("embedded overlay parsed to zero entries")
+	}
+	// _meta / provenance keys are skipped.
+	var raw map[string]json.RawMessage
+	_ = json.Unmarshal(tkPricingOverlayRaw, &raw)
+	if _, ok := m["_meta"]; ok {
+		t.Error("provenance key _meta leaked into parsed overlay")
+	}
+}

--- a/backend/internal/service/setting_service_tk_raw_get.go
+++ b/backend/internal/service/setting_service_tk_raw_get.go
@@ -1,0 +1,22 @@
+package service
+
+import "context"
+
+// GetRawSettingValue reads a single setting value by key, bypassing the typed
+// SystemSettings accessors. It exists for TK runtime knobs stored as free-form
+// keys (e.g. SettingKeyTKPricingOverlayRuntime) that are not fields on
+// SystemSettings. Returns ok=false when the key is absent, errored, or set to an
+// empty string (callers treat empty as "use the compile default / floor").
+//
+// TokenKey-only (CLAUDE.md §5): kept in a companion so setting_service.go stays
+// close to upstream shape.
+func (s *SettingService) GetRawSettingValue(ctx context.Context, key string) (string, bool) {
+	if s == nil || s.settingRepo == nil {
+		return "", false
+	}
+	v, err := s.settingRepo.GetValue(ctx, key)
+	if err != nil {
+		return "", false
+	}
+	return v, v != ""
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -707,6 +707,12 @@ var ProviderSet = wire.NewSet(
 	// Handler-side wiring lives in handler/wire.go (ProvideTKPricingCatalogHandler).
 	ProvidePricingAvailabilityService,
 	ProvideTKGatewayPricingAvailability,
+	// TokenKey: runtime hot-pushable pricing overlay — wires the settings-blob
+	// getter + catalog-cache invalidator onto PricingService, does the initial
+	// load, and subscribes to the settings pub/sub for immediate reloads. Lets a
+	// new model be priced + surfaced in /pricing without a release. Consumed by
+	// provideCleanup so wire forces evaluation.
+	ProvideTKPricingOverlayRuntime,
 	// TokenKey: client model-list filter (R-003 / Goal 2) — gates /v1/models
 	// /v1beta/models /antigravity/models to priced ∩ ¬unreachable.
 	NewModelListFilter,
@@ -790,6 +796,48 @@ func ProvideTKGatewayPricingAvailability(
 		gw.SetPricingAvailabilityService(avail)
 	}
 	return TKGatewayPricingAvailabilityReady{}
+}
+
+// TKPricingOverlayRuntimeReady is a wire sentinel: holding it proves the runtime
+// hot-pushable TK pricing overlay has been wired onto PricingService
+// (SetOverlayRuntimeDeps + initial reload + pub/sub subscribe). provideCleanup
+// (cmd/server/wire.go) consumes this type as an unused parameter to force wire to
+// evaluate the side-effect.
+type TKPricingOverlayRuntimeReady struct{}
+
+// ProvideTKPricingOverlayRuntime wires the runtime overlay (settings-blob getter
+// + public-catalog cache invalidator) onto PricingService post-construction, does
+// the initial load so an already-present runtime blob is honored at boot, and
+// subscribes to the settings pub/sub so a hot-push reloads immediately across
+// replicas. Mirrors ProvideTKGatewayPricingAvailability in shape — keep upstream
+// NewPricingService signature stable, attach setter-only deps in TK companion glue.
+//
+// All setters are nil-safe: with a nil settingService/catalog/pubsub the service
+// serves the embedded overlay floor exactly as before.
+func ProvideTKPricingOverlayRuntime(
+	ps *PricingService,
+	settingService *SettingService,
+	catalog *PricingCatalogService,
+	pubsub SettingPubSub,
+) TKPricingOverlayRuntimeReady {
+	if ps != nil {
+		var invalidator func()
+		if catalog != nil {
+			invalidator = catalog.InvalidateCache
+		}
+		var getter func(ctx context.Context) (string, bool)
+		if settingService != nil {
+			getter = func(ctx context.Context) (string, bool) {
+				return settingService.GetRawSettingValue(ctx, SettingKeyTKPricingOverlayRuntime)
+			}
+		}
+		ps.SetOverlayRuntimeDeps(getter, invalidator)
+		if _, err := ps.reloadTKOverlayRuntime(context.Background()); err != nil {
+			logger.LegacyPrintf("service.pricing", "[Pricing] runtime overlay initial load failed: %v", err)
+		}
+		ps.SubscribeOverlayRuntime(context.Background(), pubsub)
+	}
+	return TKPricingOverlayRuntimeReady{}
 }
 
 // ProvideBalanceNotifyService creates BalanceNotifyService

--- a/ops/pricing/manage-overlay-runtime.py
+++ b/ops/pricing/manage-overlay-runtime.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Hot-push the TK pricing overlay to prod runtime (settings) without a release.
+
+The embedded backend/internal/service/tk_pricing_overlay.json is the compile
+FLOOR. At runtime the gateway merges a settings blob
+(SettingKeyTKPricingOverlayRuntime = "tk_pricing_overlay_runtime") OVER the
+embedded floor (runtime wins on key conflict), so a newly-priced model surfaces
+in /pricing + bills correctly WITHOUT a new image. git (the embedded JSON) stays
+the single source of truth; this tool pushes that same JSON to prod's settings
+and the next routine release folds it into the embed (the floor catches up).
+
+Subcommands
+-----------
+  check         Read-only drift audit: repo overlay (== embedded floor) vs the
+                live prod runtime settings blob. Reports:
+                  - pending : priced in git but NOT yet hot-pushed (run sync-runtime)
+                  - shadow  : runtime carries a DIFFERENT value than git for a key
+                              (stale shadow — git changed, runtime not re-pushed)
+                  - orphan  : runtime carries a key absent from git (野值)
+                Exit 0 clean / 1 drift / 2 error.
+  sync-runtime  Validate the repo overlay with scripts/checks/pricing-overlay.py,
+                then SSM-UPSERT it into prod settings + PUBLISH settings_updated
+                so every replica reloads immediately. PROD ONLY (billing/catalog
+                run on prod; edges are Caddy relays and never read pricing).
+  --selftest    Offline unit test of the drift logic (no AWS).
+
+This mirrors ops/anthropic/manage-anthropic-config.py (sync-runtime/check shape).
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OVERLAY_PATH = REPO_ROOT / "backend" / "internal" / "service" / "tk_pricing_overlay.json"
+OVERLAY_GATE = REPO_ROOT / "scripts" / "checks" / "pricing-overlay.py"
+SETTING_KEY = "tk_pricing_overlay_runtime"
+
+PROD_REGION = "us-east-1"
+PROD_STACK = "tokenkey-prod-stage0"
+
+PSQL = "sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1"
+REDISCLI = "env -u REDISCLI_AUTH sudo docker exec tokenkey-redis redis-cli"
+
+
+def fail(msg: str) -> "NoReturn":  # type: ignore[name-defined]
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+# --- pure drift logic (selftest-covered, no I/O) ------------------------------
+
+def overlay_entries(doc: dict) -> dict:
+    """Drop provenance keys ("_meta"/"_doc"/...) — only real model entries."""
+    return {k: v for k, v in doc.items() if not k.startswith("_")}
+
+
+def _canon(entry) -> str:
+    return json.dumps(entry, sort_keys=True, ensure_ascii=False)
+
+
+def compute_overlay_drift(repo: dict, runtime: dict) -> dict:
+    """repo = embedded floor (git); runtime = live settings blob.
+
+    pending : key in repo, not in runtime (priced in git, not hot-pushed yet)
+    shadow  : key in both but value differs (runtime stale vs git)
+    orphan  : key in runtime, not in repo (野值 — hot-pushed then removed from git)
+    """
+    r = overlay_entries(repo)
+    rt = overlay_entries(runtime)
+    pending = sorted(k for k in r if k not in rt)
+    orphan = sorted(k for k in rt if k not in r)
+    shadow = sorted(k for k in r if k in rt and _canon(r[k]) != _canon(rt[k]))
+    return {"pending": pending, "shadow": shadow, "orphan": orphan}
+
+
+def drift_is_clean(drift: dict) -> bool:
+    return not (drift["pending"] or drift["shadow"] or drift["orphan"])
+
+
+# --- AWS / SSM I/O ------------------------------------------------------------
+
+def resolve_prod_instance() -> str:
+    try:
+        out = subprocess.check_output(
+            ["aws", "cloudformation", "describe-stacks", "--region", PROD_REGION,
+             "--stack-name", PROD_STACK,
+             "--query", "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue",
+             "--output", "text"], text=True).strip()
+    except subprocess.CalledProcessError as e:
+        fail(f"describe-stacks failed for {PROD_STACK}/{PROD_REGION}: {e}")
+    if not out or out == "None":
+        fail(f"no InstanceId resolvable for {PROD_STACK}/{PROD_REGION}")
+    return out
+
+
+def ssm_run_shell(instance_id: str, shell_b64: str, comment: str) -> str:
+    """Run a base64-encoded shell script on prod via SSM; return stdout."""
+    command = f"set -euo pipefail\necho {shell_b64} | base64 -d | bash"
+    params = json.dumps({"commands": [command]}, ensure_ascii=False)
+    try:
+        cid = subprocess.check_output(
+            ["aws", "ssm", "send-command", "--region", PROD_REGION,
+             "--instance-ids", instance_id, "--document-name", "AWS-RunShellScript",
+             "--comment", comment, "--parameters", params,
+             "--query", "Command.CommandId", "--output", "text"], text=True).strip()
+    except subprocess.CalledProcessError as e:
+        fail(f"ssm send-command failed ({comment}): {e}")
+    subprocess.run(["aws", "ssm", "wait", "command-executed", "--region", PROD_REGION,
+                    "--command-id", cid, "--instance-id", instance_id], check=False)
+    inv = json.loads(subprocess.check_output(
+        ["aws", "ssm", "get-command-invocation", "--region", PROD_REGION,
+         "--command-id", cid, "--instance-id", instance_id, "--output", "json"], text=True))
+    if inv.get("Status") != "Success" or inv.get("ResponseCode") != 0:
+        err = (inv.get("StandardErrorContent") or "").strip()[:1200]
+        fail(f"ssm cmd {cid} status={inv.get('Status')} rc={inv.get('ResponseCode')} ({comment})\n  stderr: {err}")
+    return (inv.get("StandardOutputContent") or "").strip()
+
+
+def read_runtime_blob(instance_id: str) -> dict:
+    shell = f"{PSQL} -c \"SELECT value FROM settings WHERE key='{SETTING_KEY}';\""
+    b64 = base64.b64encode(shell.encode()).decode()
+    out = ssm_run_shell(instance_id, b64, "overlay check: read runtime settings").strip()
+    if not out:
+        return {}
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as e:
+        fail(f"runtime settings blob is not valid JSON: {e}")
+
+
+def load_repo_overlay() -> dict:
+    try:
+        return json.loads(OVERLAY_PATH.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        fail(f"cannot read repo overlay {OVERLAY_PATH}: {e}")
+
+
+# --- subcommands --------------------------------------------------------------
+
+def cmd_check(_args) -> int:
+    repo = load_repo_overlay()
+    inst = resolve_prod_instance()
+    runtime = read_runtime_blob(inst)
+    drift = compute_overlay_drift(repo, runtime)
+    print(f"prod runtime overlay entries: {len(overlay_entries(runtime))} | "
+          f"git/embedded entries: {len(overlay_entries(repo))}")
+    if drift_is_clean(drift):
+        print("OK: prod runtime overlay is consistent with git (embedded floor).")
+        return 0
+    if drift["pending"]:
+        print(f"  pending (priced in git, not hot-pushed — run sync-runtime): {drift['pending']}")
+    if drift["shadow"]:
+        print(f"  shadow (runtime value != git — stale, re-push or GC): {drift['shadow']}")
+    if drift["orphan"]:
+        print(f"  orphan (runtime has key absent from git — 野值): {drift['orphan']}")
+    return 1
+
+
+def cmd_sync_runtime(args) -> int:
+    # 1. validate the repo overlay with the SAME gate the PR ran.
+    gate = subprocess.run([sys.executable, str(OVERLAY_GATE)], cwd=str(REPO_ROOT))
+    if gate.returncode != 0:
+        fail("pricing-overlay.py gate failed; refusing to push an invalid overlay")
+    overlay_bytes = OVERLAY_PATH.read_bytes()
+    # sanity: must parse + be non-empty
+    doc = json.loads(overlay_bytes)
+    if not overlay_entries(doc):
+        fail("repo overlay has no model entries; refusing to push")
+
+    if args.dry_run:
+        print(f"DRY-RUN: would UPSERT settings[{SETTING_KEY}] on prod "
+              f"({len(overlay_entries(doc))} entries) + PUBLISH settings_updated.")
+        return 0
+
+    inst = resolve_prod_instance()
+    value_b64 = base64.b64encode(overlay_bytes).decode()
+    # Pass the JSON value through a psql variable with :'v' quoting — psql escapes
+    # embedded single quotes (source strings may contain apostrophes), so no manual
+    # quoting hazard. base64 carries the multi-line JSON intact to the host.
+    upsert = (
+        f"INSERT INTO settings (key, value, updated_at) VALUES ('{SETTING_KEY}', :'v', NOW()) "
+        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW();"
+    )
+    shell = (
+        "set -euo pipefail\n"
+        f"PSQL='{PSQL}'\n"
+        f"RC='{REDISCLI}'\n"
+        f"VAL=\"$(echo {value_b64} | base64 -d)\"\n"
+        "echo '=== upsert tk_pricing_overlay_runtime ==='\n"
+        f"$PSQL -v v=\"$VAL\" -c \"{upsert}\"\n"
+        "echo '=== publish settings_updated (fan-out reload) ==='\n"
+        "$RC PUBLISH settings_updated refresh || true\n"
+        "echo '=== settings_after ==='\n"
+        f"$PSQL -c \"SELECT key, length(value) AS bytes FROM settings WHERE key='{SETTING_KEY}';\"\n"
+    )
+    b64 = base64.b64encode(shell.encode()).decode()
+    out = ssm_run_shell(inst, b64, "overlay sync-runtime: upsert + publish")
+    print(out)
+    print("synced. Verify with: manage-overlay-runtime.py check")
+    return 0
+
+
+def cmd_selftest(_args) -> int:
+    repo = {
+        "_meta": {"note": "provenance"},
+        "qwen3-8b": {"input_cost_per_token": 1.0, "litellm_provider": "dashscope"},
+        "qwen3-32b": {"input_cost_per_token": 2.0, "litellm_provider": "dashscope"},
+        "qwen3-235b-a22b": {"input_cost_per_token": 3.0, "litellm_provider": "dashscope"},
+    }
+    cases = [
+        ("clean", repo, {"qwen3-8b": repo["qwen3-8b"], "qwen3-32b": repo["qwen3-32b"],
+                         "qwen3-235b-a22b": repo["qwen3-235b-a22b"]},
+         {"pending": [], "shadow": [], "orphan": []}),
+        ("pending", repo, {"qwen3-8b": repo["qwen3-8b"]},
+         {"pending": ["qwen3-235b-a22b", "qwen3-32b"], "shadow": [], "orphan": []}),
+        ("shadow", repo,
+         {"qwen3-8b": {"input_cost_per_token": 9.9, "litellm_provider": "dashscope"},
+          "qwen3-32b": repo["qwen3-32b"], "qwen3-235b-a22b": repo["qwen3-235b-a22b"]},
+         {"pending": [], "shadow": ["qwen3-8b"], "orphan": []}),
+        ("orphan", repo,
+         {**{k: v for k, v in overlay_entries(repo).items()},
+          "ghost-model": {"input_cost_per_token": 1.0}},
+         {"pending": [], "shadow": [], "orphan": ["ghost-model"]}),
+        ("provenance-ignored", repo,
+         {**{k: v for k, v in overlay_entries(repo).items()}, "_meta": {"x": 1}},
+         {"pending": [], "shadow": [], "orphan": []}),
+    ]
+    ok = True
+    for name, r, rt, want in cases:
+        got = compute_overlay_drift(r, rt)
+        if got != want:
+            ok = False
+            print(f"  FAIL {name}: got {got} want {want}")
+        else:
+            print(f"  PASS {name}")
+    print("selftest ok" if ok else "selftest FAILED")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--selftest", action="store_true", help="offline drift-logic test")
+    sub = ap.add_subparsers(dest="cmd")
+    sub.add_parser("check", help="read-only drift audit (git vs prod runtime)")
+    sp = sub.add_parser("sync-runtime", help="hot-push repo overlay to prod settings")
+    sp.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return cmd_selftest(args)
+    if args.cmd == "check":
+        return cmd_check(args)
+    if args.cmd == "sync-runtime":
+        return cmd_sync_runtime(args)
+    ap.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/pricing/manage-overlay-runtime.py
+++ b/ops/pricing/manage-overlay-runtime.py
@@ -194,7 +194,10 @@ def cmd_sync_runtime(args) -> int:
         "echo '=== upsert tk_pricing_overlay_runtime ==='\n"
         f"$PSQL -v v=\"$VAL\" -c \"{upsert}\"\n"
         "echo '=== publish settings_updated (fan-out reload) ==='\n"
-        "$RC PUBLISH settings_updated refresh || true\n"
+        # Best-effort: the UPSERT above is the durable truth; PUBLISH only makes the
+        # reload immediate. Surface a failure (don't swallow it) so the operator knows
+        # replicas will lag to the poll interval instead of reloading now.
+        "$RC PUBLISH settings_updated refresh || echo 'WARN: redis PUBLISH failed; replicas reload within the pricing poll interval, not immediately'\n"
         "echo '=== settings_after ==='\n"
         f"$PSQL -c \"SELECT key, length(value) AS bytes FROM settings WHERE key='{SETTING_KEY}';\"\n"
     )

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -605,6 +605,24 @@ else
     echo "  ok: pricing-hotfix runbook selftest"
 fi
 
+# ---- sub2api: overlay-runtime hot-push tool selftest ------------------------
+# ops/pricing/manage-overlay-runtime.py hot-pushes tk_pricing_overlay.json to the
+# prod runtime (settings) so a model can be priced + surfaced without a release.
+# Its selftest covers the pure drift logic (pending/shadow/orphan) offline — run
+# it so a refactor of the drift rules fails preflight, not the operator.
+echo ""
+echo "=== sub2api: overlay-runtime hot-push tool selftest ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for overlay-runtime selftest)"
+    errors=$((errors + 1))
+elif ! python3 ./ops/pricing/manage-overlay-runtime.py --selftest >/dev/null 2>&1; then
+    echo "  FAIL: overlay-runtime hot-push tool selftest"
+    echo "        — run: python3 ops/pricing/manage-overlay-runtime.py --selftest"
+    errors=$((errors + 1))
+else
+    echo "  ok: overlay-runtime hot-push tool selftest"
+fi
+
 # ---- sub2api: frontend TK sentinel registry ---------------------------------
 # Source of truth: scripts/sentinels/frontend-tk.json. Verifies that load-bearing
 # TokenKey-only frontend surfaces (sidebar geometry, fluid table mode, sticky

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -109,7 +109,8 @@
       "path": "backend/internal/service/pricing_catalog_tk.go",
       "must_contain": [
         "func applyCatalogOverlayPricing",
-        "applyCatalogOverlayPricing(resp)"
+        "applyCatalogOverlayPricing(resp)",
+        "func (s *PricingCatalogService) InvalidateCache"
       ],
       "rationale": "Display-side TK pricing-overlay merge. BuildPublicCatalog reads the trimmed litellm price file (model_pricing.json) and, unlike the billing path (GetModelPricing → applyTKPricingOverlay), did NOT apply the overlay — so every model priced ONLY in tk_pricing_overlay.json (the entire VolcEngine fifth-platform batch: doubao-*/glm-4-7-251222, plus deepseek-v4-pro) showed empty/missing prices in the public /pricing catalog AND Your-Menu (me_pricing_catalog reads BuildPublicCatalog as metaByID), even though billing was correct. applyCatalogOverlayPricing fill-merges the overlay's token-priced models into the catalog so display matches billing, with absent-or-zero semantics: a real non-zero file price wins, an all-zero placeholder row gets its displayed price replaced (same predicate family as billing's tkIsEffectivelyUnpriced). Channel pricing stays a strictly higher tier upstream; the merge is gated behind a non-degraded catalog (len(resp.Data)>0) to preserve the AC-005 degraded→empty contract. An upstream merge refactoring BuildPublicCatalog could silently drop the applyCatalogOverlayPricing(resp) call, regressing every overlay-only model back to an empty price row."
     },
@@ -158,6 +159,26 @@
         "\"display\""
       ],
       "rationale": "The served-models MANIFEST itself — the single declarative source of intent consumed by scripts/checks/catalog-serving-drift.py (now), the tokenkey-onboard-model skill (now), and a future newapi reconciler (//go:embed of this file, co-located with tk_pricing_overlay.json so the same Go package can embed both). Pinning the schema keys (entries / price_source / served_on / display) stops an upstream merge or refactor from silently truncating the manifest to an empty/legacy shape that would make the drift guard vacuously pass while the intent->migration->price agreement it encodes is lost. Co-located with the overlay so the same preflight parses both and the same package will embed both."
+    },
+    {
+      "path": "backend/internal/service/pricing_service_tk_overlay.go",
+      "must_contain": [
+        "func parseTKOverlayBytes",
+        "func rebuildTKOverlayUnion",
+        "tkOverlayMu",
+        "tkOverlayEffective"
+      ],
+      "rationale": "The overlay loader was converted from a sync.Once compile-only singleton into a re-runnable, RWMutex-guarded union (embedded ∪ runtime-settings, runtime wins) so a model can be priced WITHOUT a release (the runtime hot-push path). parseTKOverlayBytes is the shared pure parser for both the embedded floor and the runtime settings blob; rebuildTKOverlayUnion atomically swaps the effective map and is the ONLY place that can blank it (it never does — a corrupt runtime blob keeps the embedded floor, the never-serve-$0 invariant). An upstream merge or refactor that reverts this back to a sync.Once singleton (or drops the mutex) would silently re-freeze pricing to compile-time and reintroduce the per-model release dependency this whole change removes. Pinning these symbols makes that revert fail CI instead of going unnoticed."
+    },
+    {
+      "path": "backend/internal/service/pricing_service_tk_overlay_runtime.go",
+      "must_contain": [
+        "func (s *PricingService) reloadTKOverlayRuntime",
+        "func (s *PricingService) SubscribeOverlayRuntime",
+        "func (s *PricingService) SetOverlayRuntimeDeps",
+        "SettingKeyTKPricingOverlayRuntime"
+      ],
+      "rationale": "Runtime hot-push wiring for the TK pricing overlay: reloadTKOverlayRuntime validates the SettingKeyTKPricingOverlayRuntime blob before swapping (corrupt → keep current, never $0), rebuilds the merged billing price map, and busts the public-catalog mtime cache; SubscribeOverlayRuntime gives immediate cross-replica reload on the settings_updated pub/sub; SetOverlayRuntimeDeps is the nil-safe post-construction injection wired by ProvideTKPricingOverlayRuntime. ops/pricing/manage-overlay-runtime.py sync-runtime UPSERTs that settings key on prod + PUBLISHes the channel. If an upstream merge drops these, the gateway silently falls back to the embedded floor and every hot-push becomes a no-op (a model would appear priced in git/ops but never go live without a release) — the exact regression this change exists to prevent. Pinning makes the drop fail CI."
     }
   ]
 }


### PR DESCRIPTION
## 背景:为什么做

新增一个 newapi 长尾模型(如刚上线的 qwen3-235b-a22b)目前**只有一环逼着发版**:价格。`tk_pricing_overlay.json` 是 `//go:embed` 编译内嵌的,改价必须重出镜像。

实测确认其余环节早已是热的:
- **model_mapping**(路由/可服务):靠迁移内 `scheduler_outbox`,部署即生效。
- **公开 /pricing 菜单**:newapi 模型**有价就显示**(`isPublicCatalogModelSupported` 的 default 分支放行)。
- **「我的菜单」**:由账号 `model_mapping` 白名单驱动(`fillAccountFallback`)。

所以公开菜单可见性本就 **price-gated** —— 把价格热化,「新增 newapi 模型不发版即出现在公开菜单」**自动**成立。两件事收敛成一个改动。

**目标**:overlay 改成运行时活值 + 可热推,git 仍是单一真值源、门禁不变,发版从「上线前提」降级为「最终一致性地板」。

**约束**:overlay 承载 `thinking_output_cost_per_token` / 阶梯 `intervals` / 媒体价,渠道定价 DB 承载不了 → overlay 必须保留为富价格源,**不**改用渠道 DB。

## 方案:采用 cc/anthropic 既有范式,不另起炉灶

对比过两条路 ——①卷上文件 + 轮询 + 自定义 reload 端点;②cc/anthropic 配置同步范式(git JSON 源 → 内嵌地板 → 运行时活值在 DB settings → reconcile 收敛 → sync-runtime 即时推 → check 漂移审计)。**选 ②**:复用全公司每天在跑的同一机制、活值在 DB 可查可审计、自带 check、无 catalog 缓存陷阱,且规避了 ① 的「陈旧文件遮蔽更新内嵌价」craft bug。`claude_code_http_mimicry_manifest`(settings 里的 JSON blob)证明本范式可直接套到定价,**零 Ent schema 改动**。

## 改了什么

- **A1 loader**(`pricing_service_tk_overlay.go`):`sync.Once` 单例 → `RWMutex` 可重读 union。生效 overlay = **内嵌 ∪ settings blob,runtime 胜**;内嵌是**地板**(离线自洽)。corrupt / 空 blob 保留内嵌,**永不漏 $0**。
- **A2/A3 运行时接线**(`pricing_service_tk_overlay_runtime.go`):`PricingService` 经 `ProvideTKPricingOverlayRuntime`(`TKPricingOverlayRuntimeReady` wire 哨兵)注入 nil-safe 的 settings getter + catalog 缓存失效器。重载触发:**settings pub/sub**(即时,跨副本)+ 既有 pricing 轮询(兜底)。重载会重建计费价格图,并 bust catalog 的 mtime 缓存(`PricingCatalogService.InvalidateCache` —— catalog 按 `model_pricing.json` mtime 缓存,改 overlay 不会失效,这是必须显式打掉的陷阱)。
- **ops**(`ops/pricing/manage-overlay-runtime.py`):`sync-runtime`(先过 `pricing-overlay.py` 门禁 → SSM UPSERT prod settings + `PUBLISH settings_updated`;**prod-only**,edge 是 Caddy 中继不跑计费)和 `check`(只读漂移审计:pending / shadow / orphan)。

## 新的上架流程

PR(`catalog-serving-drift.py` + `pricing-overlay.py` 门禁)→ 合并 → `manage-overlay-runtime.py sync-runtime`(**热推,零发版**)→ livefire。发版降级为**最终一致性地板**:下次例行发版把 blob 折进内嵌,之后 `check` 应报「活值==内嵌」。

## 验证

- `go test -tags=unit ./...` 全绿(含 union 优先级、**-race** 热swap、corrupt/空回退、catalog mtime 缓存回归)。
- `golangci-lint` 0 issues;`scripts/preflight.sh`(base + sub2api)**PASS**(overlay-runtime selftest + pricing-availability sentinel 全绿)。
- 首次上线本代码是**纯 no-op**(无 settings blob → 内嵌地板 = 今日行为),代码上线与首次热推完全解耦。

## 门禁 marker

- **`no-web-impact`**(在 commit 里):纯后端 + ops + sentinel + preflight,无前端改动。
- **`sentinel-registry-reviewed`**:载重的运行时面(`pricing_service_tk_overlay.go` loader、`pricing_service_tk_overlay_runtime.go`、catalog `InvalidateCache`)已在 `scripts/sentinels/pricing-availability.json` 加锚。registry-update gate 另标了两个新文件——`pricing_service_tk_overlay_runtime_test.go`(单测本身)和 `setting_service_tk_raw_get.go`(3 行 raw-setting getter,删了会编译失败)——二者不需要内容锚点,已复核确认。

## xj-review 自审(已闭环)

- R-001(medium,文档-代码背离):`tokenkey-onboard-model` skill §4 仍称 overlay「随发版生效」——本 PR 后已为假;已重写为热推路径。
- R-002(low,静默吞错):redis PUBLISH 的 `|| true` 改为可见的 WARN echo。

🤖 Generated with [Claude Code](https://claude.com/claude-code)