### PR TITLE
fix(infra): trim stage0-backups Description under CFN 1024-char limit

### DIFF
--- a/deploy/aws/cloudformation/stage0-backups.yaml
+++ b/deploy/aws/cloudformation/stage0-backups.yaml
@@ -1,24 +1,16 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >
-  tokenkey (sub2api fork) Stage 0: off-box pg_dump backup bucket for the PG
-  ledger. Standalone stack so the live prod instance stack is NOT modified —
-  the bucket policy grants the existing app InstanceRole s3:PutObject via an
-  account-root principal narrowed by an aws:PrincipalArn condition (same-account
-  S3 either/or authorization), so no update-stack on tokenkey-prod-stage0.
-  tokenkey-pgdump.sh (hourly) copies each fresh dump here when
-  TOKENKEY_PGDUMP_S3_URI is set in /var/lib/tokenkey/.env. Lifecycle expires
-  copies after RetentionDays; no versioning (each key is a unique timestamp).
-
-  ALSO holds the QA trajectory export bucket (durable export ZIPs + presigned
-  downloads, qa_capture.export_storage) — same standalone-stack + direct-role-ARN
-  pattern, so enabling QA S3 export needs no prod-instance-stack update either.
-  See docs/qa-export-s3-and-auto-archive.md.
-
-  ALSO holds the GENERATED-MEDIA bucket (media_storage): the gateway offloads
-  generated video (image later) here and returns a short-lived presigned URL
-  instead of streaming a 10-20 MB inline-base64 body. Same direct-role-ARN
-  pattern; presigned links are signed by the instance role (no long-lived key)
-  and the media/ prefix expires after MediaRetentionDays (default 1).
+  tokenkey (sub2api fork) Stage 0 standalone S3 stack — does NOT modify the live
+  prod instance stack: each bucket policy grants the existing app InstanceRole
+  directly (same-account resource-based grant), so no update-stack on
+  tokenkey-prod-stage0. Holds three buckets, all direct-role-ARN pattern:
+  (1) pg_dump ledger backups (tokenkey-pgdump.sh hourly; RetentionDays);
+  (2) QA trajectory exports (qa_capture.export_storage; QaExportsRetentionDays;
+  see docs/qa-export-s3-and-auto-archive.md);
+  (3) generated-media offload (media_storage): the gateway uploads generated
+  video here and returns a short-lived instance-role-signed presigned URL instead
+  of streaming a 10-20 MB inline-base64 body; media/ prefix, MediaRetentionDays
+  (default 1). No versioning (keys are unique).
 
 Parameters:
   ProjectName:


### PR DESCRIPTION
## 背景
#849 在 `stage0-backups.yaml` 的 `Description` 加了 media 桶段落,使其达 **1235 字符 > CloudFormation 硬上限 1024**,导致 `aws cloudformation validate-template` 与任何 deploy 直接失败(灾备/调保留期时会踩)。

建 prod media 桶时已用**本地裁剪版**模板部署成功(桶/policy/lifecycle 全部正确、已上线 `tokenkey-prod-media-682751977094`);本 PR 把同样的裁剪落到 main,让 `tokenkey-stage0-backups` 栈未来可正常 validate/deploy。

## 改动
- **仅 Description 文本**裁剪(1235→767 字符),把三个桶的说明合并精简。
- **无任何资源/参数变更**:MediaBucket / MediaBucketPolicy / lifecycle / MediaRetentionDays 全部不动。
- 已验证裁剪后 `validate-template` 通过。

## markers
- `no-web-impact`(纯 CFN 模板文本)。无 upstream-shaped / sentinel 命中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)