### PR TITLE
fix(alerts): suppress platform-pool-exhausted P0 for transient cooldowns, keep it for sustained

### DIFF
--- a/backend/internal/service/ratelimit_service_tk_pool_exhausted.go
+++ b/backend/internal/service/ratelimit_service_tk_pool_exhausted.go
@@ -17,15 +17,25 @@ import (
 const (
 	tkPoolExhaustedCheckDelay   = 2 * time.Second
 	tkPoolExhaustedCheckTimeout = 5 * time.Second
+
+	// tkPoolExhaustedTransientCooldown 是「瞬时 drain vs 持续故障」的判别阈值。
+	// Anthropic 冷却阶梯 anthropicCooldownTierLadder=[30s,2m,10m]:单次 529/503 走
+	// tier-0(~30s)秒级自愈;**持续** 529/503 才经 3/3 升级进 tier-1(2m)/tier-2(10m)。
+	// 60s 卡在 tier-0 与 tier-1 之间——本次冷却剩余 ≤60s = 单次瞬时(去噪),>60s = 账号
+	// 已因连续错误升级 = 真持续故障(P0)。
+	tkPoolExhaustedTransientCooldown = 60 * time.Second
 )
 
 // tkPoolExhaustedEnabled 报告某平台是否启用"平台池全不可调度"即时 P0 检查。
 //
 // 从硬编码白名单(anthropic/openai/gemini)改为派生:任何非空平台都纳入。平台名
 // 直接来自被封账号自身(notifyAccountSchedulingBlocked),不该枚举——新平台
-// (kiro/grok/antigravity/newapi…)一上线就自动有空池火警,零代码改动。触发仍受
-// 「该平台 ListSchedulableByPlatform 真为 0」+ 每平台 10min 去重双重收口,健康
-// 多账号平台永不误报。
+// (kiro/grok/antigravity/newapi…)一上线就自动有空池火警,零代码改动。触发受三重收口:
+// 「该平台 ListSchedulableByPlatform 真为 0」+「本次冷却**非瞬时**(剩余 > 60s,即连续
+// 529/503 已经 3/3 升级到 tier-1/2,而非单次 tier-0 自愈)」+ 每平台 10min 去重。
+// **瞬时** drain(单次上游冷却秒级自愈,单账号 edge 上拓扑保证会反复响)降级为
+// platform_pool_transient_drain WARN,不再 P0;**持续** 529/503(账号已升级到长冷却,含
+// 2026-06-11 七号同倒的 10min 全池崩塌)仍即时 P0——见 tkPlatformPoolExhaustedCheck。
 //
 // 注意 newapi 是「一个平台、多互不可替代上游」:这条平台级火警只在 newapi 所有
 // channel 全空时才响(粗粒度兜底);单 channel 的容量饱和由 pool_load_rate 指标按
@@ -66,6 +76,28 @@ func (s *RateLimitService) tkPlatformPoolExhaustedCheck(ctx context.Context, pla
 		return
 	}
 	if len(accounts) > 0 {
+		return
+	}
+	// 「瞬时 vs 持续」降噪(承接 2026-06-18 决策:瞬时去掉、连续保留)。判别用本次冷却
+	// 的剩余时长:单次 529/503 走 tier-0(~30s)秒级自愈——单账号 edge 上这种 drain 是
+	// 拓扑保证会反复响的噪声(实测 edge-us7 2026-06-18: 30s 冷却、857:1 服务比、1 请求
+	// 受影响,prod→edge 镜像中继已 failover 同级兄弟 edge 承接),不该 P0。**持续** 529/503
+	// 才会经 3/3 阶梯升级进 tier-1(2m)/tier-2(10m),届时剩余时长 > 60s = 账号因连续错误
+	// 升级 = 真持续故障(含 2026-06-11 七号同倒的 10min 全池崩塌),必须 P0。
+	// until 缺失(零值)= 无法判定瞬时 → 保守 P0(宁可多报不可漏报)。
+	//
+	// 不变量(降噪安全性依据):until 是**触发本次空池的那个账号**的冷却终点,而正是
+	// 这个账号会在 until 时刻把池重新填上——所以剩余短 ⇒ 池近期必自愈,抑制安全;池里
+	// 若还有别的账号在更长冷却也不延长空窗(本账号先回来扛流量)。若本账号到点又立刻
+	// 失败,error_count 累加触发阶梯升级,下一次触发的 until 就 > 60s → 照常 P0。即使别的
+	// 账号反而更早到点(本账号冷却长),那也只是 until 高估空窗 → 偏向多报,不会漏报。
+	remaining := time.Until(until)
+	if !until.IsZero() && remaining <= tkPoolExhaustedTransientCooldown {
+		slog.Warn("platform_pool_transient_drain",
+			"platform", platform,
+			"trigger_account_id", trigger.ID,
+			"trigger_reason", reason,
+			"cooldown_remaining_seconds", int(remaining.Seconds()))
 		return
 	}
 	slog.Error("platform_pool_exhausted",

--- a/backend/internal/service/ratelimit_service_tk_pool_exhausted_test.go
+++ b/backend/internal/service/ratelimit_service_tk_pool_exhausted_test.go
@@ -51,6 +51,53 @@ func TestTkPlatformPoolExhaustedCheck_FiresOnEmptyPool(t *testing.T) {
 	require.Equal(t, []string{PlatformAnthropic}, notifier.pools)
 }
 
+// Transient drain (edge-us7 2026-06-18): the edge's only anthropic account hits a
+// single upstream 529, gets a ~30s tier-0 overload cooldown, and the pool momentarily
+// reads 0 schedulable — but it self-heals in seconds (prod→edge mirror relay fails
+// over to sibling edges meanwhile). A short cooldown (<= 60s) means tier-0 transient,
+// not a sustained outage, so it must NOT page P0 — it downgrades to a WARN.
+func TestTkPlatformPoolExhaustedCheck_TransientCooldownDoesNotPage(t *testing.T) {
+	repo := &poolExhaustedRepoStub{schedulable: nil}
+	notifier := &poolExhaustedNotifierStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAccountIncidentNotifier(notifier)
+	trigger := &Account{ID: 1, Name: "edge-ls-oh-4-d", Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	service.tkPlatformPoolExhaustedCheck(context.Background(), PlatformAnthropic, trigger, time.Now().Add(30*time.Second), "529")
+
+	require.Empty(t, notifier.pools, "transient ~30s tier-0 cooldown must not page P0 (self-heals)")
+}
+
+// Continuous 529/503 escalates via the 3/3 ladder into tier-1 (2m) / tier-2 (10m). A
+// long remaining cooldown (> 60s) means the account is in a sustained outage — that
+// MUST still page immediately, on a single-account edge as much as a multi-account
+// pool (the 2026-06-11 seven-stub collapse was 10m cooldowns).
+func TestTkPlatformPoolExhaustedCheck_SustainedCooldownPages(t *testing.T) {
+	repo := &poolExhaustedRepoStub{schedulable: nil}
+	notifier := &poolExhaustedNotifierStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAccountIncidentNotifier(notifier)
+	trigger := &Account{ID: 1, Name: "edge-ls-oh-4-d", Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	service.tkPlatformPoolExhaustedCheck(context.Background(), PlatformAnthropic, trigger, time.Now().Add(2*time.Minute), "529")
+
+	require.Equal(t, []string{PlatformAnthropic}, notifier.pools, "sustained (tier-1+) cooldown must page P0 even for a single account")
+}
+
+// Conservative fail-open: a zero/unknown cooldown time cannot be proven transient, so
+// keep the P0 — better a spurious page than a missed real collapse.
+func TestTkPlatformPoolExhaustedCheck_ZeroUntilFailsOpenToPage(t *testing.T) {
+	repo := &poolExhaustedRepoStub{schedulable: nil}
+	notifier := &poolExhaustedNotifierStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAccountIncidentNotifier(notifier)
+	trigger := &Account{ID: 1, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	service.tkPlatformPoolExhaustedCheck(context.Background(), PlatformAnthropic, trigger, time.Time{}, "529")
+
+	require.Equal(t, []string{PlatformAnthropic}, notifier.pools, "zero/unknown until must fail open to P0, not silently suppress")
+}
+
 func TestTkPlatformPoolExhaustedCheck_QuietWhenPoolHasCapacity(t *testing.T) {
 	repo := &poolExhaustedRepoStub{schedulable: []Account{{ID: 1, Platform: PlatformAnthropic}}}
 	notifier := &poolExhaustedNotifierStub{}


### PR DESCRIPTION
## 背景：edge-us7 平台池清零告警（2026-06-18 21:25 北京时间）

告警「TokenKey 平台池全不可调度 [edge-us7] / anthropic」深挖后确认是**单账号 edge 撞 Anthropic 瞬时 529**，30s 自愈，无故障：account#1 `edge-ls-oh-4-d`（该 edge 唯一 anthropic 账号）13:25:20 收 `529 Overloaded` → 30s tier-0 overload 冷却 → 池→0 → P0 → 13:25:50 恢复。3h 服务比 **857:1（0.999）**，1 个请求受影响。

## 改动（按 review 反馈定型为「瞬时 vs 持续」轴）

`platform_pool_exhausted` P0 在 `schedulable==0` 即发。单账号 edge 上每次**瞬时**上游抖动都会触发它（拓扑保证的噪声）。**正确判别是瞬时 vs 持续，不是单账号 vs 多账号**——Anthropic 冷却阶梯 `[30s,2m,10m]` 本就编码了它：单次 529/503 走 tier-0（~30s），**持续** 529/503 才经 3/3 升级进 tier-1(2m)/tier-2(10m)。

于是按**本次冷却剩余时长**收口：
- 剩余 **≤ 60s**（tier-0 单次瞬时）→ 降级 `platform_pool_transient_drain` **WARN**，不 P0。
- 剩余 **> 60s**（tier-1/2，账号因连续错误升级，含 2026-06-11 七号同倒的 10min 全池崩塌）→ **P0**，不变。
- `until` 零值/未知 → **fail-open 发 P0**（无法证明瞬时）。

这样**单账号 edge 的持续故障仍会即时 P0**（正是该被叫醒的），只去掉每次瞬时抖动的噪声。prod 不受影响（真崩塌都是升级后的长冷却 >60s）。SPOF 配号风险仍由 edge-health-watch 的 🟡 thin posture 覆盖，永久死号由永久失效 P0 覆盖。`NotifyPlatformPoolExhausted` dispatch + 4 条 gateway-tk sentinel anchor 全保留。

> 注：早期版本曾按 roster≥2 收口（单账号永不 P0），review 指出会误杀**单账号 edge 的持续 529/503**——已改为本时长轴。

## 验证
- `go build ./...` ok
- `go test -tags=unit ./...` 全绿（pool-exhausted 9 例：瞬时 30s 不报 / 持续 2m 报 / until 零值 fail-open 报 / 空池 10min 报 / 有容量不报 / 查询错不报 / 多平台 …）
- `scripts/preflight.sh` PASS（gateway-tk sentinel anchors intact）

## Rollout
纯后端、零迁移、零 schema、`*_tk_*.go` only。**根治单账号 edge 脆弱性仍是补到 ≥2 账号**（us6→us7→us3→us2→uk1；uk2/uk3 补号或下线），属运维动作，不在本 PR。

no-web-impact
sentinel-registry-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)