### PR TITLE
feat(alert): pair pool-exhausted P0 with a pool-recovered green card

### DIFF
--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -177,7 +177,12 @@ type TKAccountIncidentNotifier struct {
 	digest            map[string]*accountIncidentDigestEntry // reasonClass -> 聚合条目
 	active            map[int64]map[string]*activeIncident   // accountID -> reasonClass -> 活跃事件(恢复台账)
 	recoverySentAt    map[int64]time.Time                    // 恢复绿卡去重: accountID -> 上次发送
-	poolExhaustSentAt map[string]time.Time                   // 平台池全不可调度 P0 去重: platform -> 上次发送
+	poolExhaustSentAt map[string]time.Time                   // 平台池全不可调度 P0「待恢复」台账: platform -> 告警时刻(兼作 10min 去重)
+
+	// poolSchedulableCounter 由 RateLimitService 注入(见 ProvideTKAccountIncidentNotifier),
+	// 返回某平台当前可调度账号数。池恢复轮询据此把空池火警闭环成「池已恢复」绿卡。
+	// 为 nil 时(如单测直接构造 notifier)恢复轮询自动降级为 no-op,不影响既有空池火警。
+	poolSchedulableCounter func(ctx context.Context, platform string) (int, error)
 
 	stopCh   chan struct{}
 	stopOnce sync.Once
@@ -203,12 +208,13 @@ func newTKAccountIncidentNotifier(cfgProvider opsFeishuConfigProvider, siteID st
 	return n
 }
 
-// Start 启动后台聚合 flush ticker。必须配对 Stop()。
+// Start 启动后台聚合 flush ticker + 池恢复轮询。必须配对 Stop()。
 func (n *TKAccountIncidentNotifier) Start() {
 	if n == nil {
 		return
 	}
 	go n.digestLoop()
+	go n.poolRecoveryLoop()
 }
 
 // Stop 优雅停 ticker,供 wire cleanup 调用。幂等。

--- a/backend/internal/service/account_incident_notifier_tk_pool.go
+++ b/backend/internal/service/account_incident_notifier_tk_pool.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 )
@@ -15,6 +17,28 @@ import (
 // 本卡片在"最后一个可调度账号被封"的那一刻即时发出（事件驱动,非轮询）,
 // 把发现时间从 ~10 分钟压到秒级。
 const accountIncidentPoolExhaustedDedupeWindow = 10 * time.Minute
+
+// 池恢复轮询：空池火警(NotifyPlatformPoolExhausted)只解决「发现」,不解决「闭环」——
+// 运维收到 P0 后开始补号,却没有信号告诉他「池已经回来了,可以停手」。最常见的恢复路径
+// 是**冷却到期自愈**(压垮池的那个账号 until 到点自动重新可调度),而到期是被动的、不触发
+// 任何事件,所以恢复无法事件驱动,只能轮询。这条轮询只在「确有平台处于空池告警态」时才查库
+// (poolExhaustSentAt 非空),健康常态下零 DB 负担。恢复与空池火警严格 1:1 配对:只有发过红卡
+// 的平台才会发对应绿卡,发后即从台账摘除——天然杜绝独立绿卡刷屏。
+const (
+	poolRecoveryCheckInterval = 30 * time.Second
+	poolRecoveryCheckTimeout  = 5 * time.Second
+)
+
+// SetPoolSchedulableCounter 注入「某平台当前可调度账号数」查询(由 RateLimitService 提供)。
+// 在 Start() 前调用;nil 时池恢复轮询降级为 no-op。
+func (n *TKAccountIncidentNotifier) SetPoolSchedulableCounter(fn func(ctx context.Context, platform string) (int, error)) {
+	if n == nil {
+		return
+	}
+	n.mu.Lock()
+	n.poolSchedulableCounter = fn
+	n.mu.Unlock()
+}
 
 // NotifyPlatformPoolExhausted 发送平台池全不可调度 P0 卡片。按 platform 去重
 // （冷却风暴里每个后续账号封锁都会再触发一次池级检查,只发第一张）。
@@ -70,4 +94,104 @@ func poolExhaustedAdvice(platform string) string {
 		return "先跑 ops/observability/scan-edge-health.sh 看各 edge 自身健康;若 reason 是 anthropic_upstream_error 且各账号几乎同秒进入冷却,优先怀疑单请求确定性 429(如长上下文 usage-credits 策略拒绝)被 failover 扇出,而非账号/edge 真实故障。"
 	}
 	return "该平台号池已空,需立即为该平台补充可调度账号;若现有账号均健康却仍不可调度,多为并发/会话席位被打满或集中冷却,核对各账号 concurrency/max_sessions 余量与冷却状态。"
+}
+
+// poolRecoveryLoop 周期性把「待恢复」台账里的平台拉回——查到可调度账号数 > 0 即发绿卡闭环。
+func (n *TKAccountIncidentNotifier) poolRecoveryLoop() {
+	if n == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Warn("pool_recovery_loop_panic_recovered", "panic", r)
+		}
+	}()
+	for {
+		timer := time.NewTimer(poolRecoveryCheckInterval)
+		select {
+		case <-n.stopCh:
+			timer.Stop()
+			return
+		case <-timer.C:
+			n.checkPoolRecovery()
+		}
+	}
+}
+
+// checkPoolRecovery 遍历当前处于空池告警态的平台,逐个查可调度账号数;> 0 则发「池已恢复」
+// 绿卡并把该平台从台账摘除。摘除前在锁内复核仍在台账(防与并发的再次空池/重复恢复竞态),
+// 保证每个平台一次恢复事件只发一张绿卡。
+func (n *TKAccountIncidentNotifier) checkPoolRecovery() {
+	if n == nil {
+		return
+	}
+	n.mu.Lock()
+	counter := n.poolSchedulableCounter
+	if counter == nil || len(n.poolExhaustSentAt) == 0 {
+		n.mu.Unlock()
+		return
+	}
+	pending := make(map[string]time.Time, len(n.poolExhaustSentAt))
+	for platform, sentAt := range n.poolExhaustSentAt {
+		pending[platform] = sentAt
+	}
+	n.mu.Unlock()
+
+	for platform, firstAlert := range pending {
+		ctx, cancel := context.WithTimeout(context.Background(), poolRecoveryCheckTimeout)
+		count, err := counter(ctx, platform)
+		cancel()
+		if err != nil {
+			slog.Warn("pool_recovery_check_query_failed", "platform", platform, "error", err)
+			continue
+		}
+		if count <= 0 {
+			continue
+		}
+		// 复核仍待恢复后再摘除+发卡。若期间已被其它路径摘除(如重复触发),跳过不重发。
+		n.mu.Lock()
+		if _, still := n.poolExhaustSentAt[platform]; !still {
+			n.mu.Unlock()
+			continue
+		}
+		delete(n.poolExhaustSentAt, platform)
+		n.mu.Unlock()
+
+		now := n.currentTime()
+		title := fmt.Sprintf("TokenKey 平台池已恢复 [%s]", n.siteID)
+		body := buildPoolRecoveredText(n.siteID, platform, count, firstAlert, now)
+		n.send(title, "green", body, fmt.Sprintf("platform=%s recovered count=%d", platform, count))
+	}
+}
+
+func buildPoolRecoveredText(site, platform string, schedulable int, firstAlert, now time.Time) string {
+	durText := "未知"
+	if !firstAlert.IsZero() {
+		d := now.Sub(firstAlert)
+		if d < 0 {
+			d = 0
+		}
+		durText = formatPoolOutageDuration(d)
+	}
+	return fmt.Sprintf("**节点**：%s\n**平台**：%s\n**事件**：该平台已重新有可调度账号,流量恢复正常\n**当前可调度账号数**：%d\n**空池持续时长**：%s\n**时间**：%s\n\n**说明**：无需继续补号。若为冷却到期自愈,后续仍可能复发,关注是否反复触发。",
+		escapeFeishuText(site),
+		escapeFeishuText(strings.TrimSpace(platform)),
+		schedulable,
+		escapeFeishuText(durText),
+		escapeFeishuText(formatAlertTime(now)),
+	)
+}
+
+// formatPoolOutageDuration 把空池持续时长渲染成「X分Y秒 / X分 / Y秒」的中文短串。
+func formatPoolOutageDuration(d time.Duration) string {
+	total := int(d.Round(time.Second).Seconds())
+	if total < 60 {
+		return fmt.Sprintf("%d秒", total)
+	}
+	m := total / 60
+	s := total % 60
+	if s == 0 {
+		return fmt.Sprintf("%d分", m)
+	}
+	return fmt.Sprintf("%d分%d秒", m, s)
 }

--- a/backend/internal/service/account_incident_notifier_tk_pool_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_pool_test.go
@@ -3,6 +3,8 @@
 package service
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -53,4 +55,83 @@ func TestNotifyPlatformPoolExhausted_SendsP0AndDedupes(t *testing.T) {
 	require.Contains(t, openaiBody, PlatformOpenAI)
 	require.Contains(t, openaiBody, "补充可调度账号")
 	require.NotContains(t, openaiBody, "scan-edge-health.sh")
+}
+
+func TestCheckPoolRecovery_SendsGreenCardPairedWithExhaust(t *testing.T) {
+	provider := &fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 4)}
+	fixedNow := time.Date(2026, 6, 11, 6, 49, 0, 0, time.UTC)
+	n := newTestNotifier(provider, doer, fixedNow)
+
+	// Counter is the recovery poll's single source of truth: 0 while exhausted,
+	// then flips to >0 once an account becomes schedulable again.
+	var schedulable int64
+	n.SetPoolSchedulableCounter(func(_ context.Context, _ string) (int, error) {
+		return int(atomic.LoadInt64(&schedulable)), nil
+	})
+
+	trigger := &Account{ID: 7, Name: "openai-us3", Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	until := fixedNow.Add(10 * time.Minute)
+
+	// 1) Pool exhausted → red P0 card, platform tracked as pending-recovery.
+	n.NotifyPlatformPoolExhausted(PlatformOpenAI, trigger, until, "429_fallback")
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pool-exhausted P0 card was not sent")
+	}
+	require.Equal(t, 1, doer.callCount())
+
+	// 2) Still empty → recovery poll must NOT send anything.
+	n.checkPoolRecovery()
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 1, doer.callCount(), "recovery card must not fire while pool is still empty")
+
+	// 3) An account comes back → recovery poll sends a green card.
+	atomic.StoreInt64(&schedulable, 2)
+	n.checkPoolRecovery()
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pool-recovered green card was not sent")
+	}
+	require.Equal(t, 2, doer.callCount())
+	body := doer.lastBody()
+	require.Contains(t, body, "平台池已恢复")
+	require.Contains(t, body, PlatformOpenAI)
+	require.Contains(t, body, "无需继续补号")
+
+	// 4) Recovery is 1:1 with exhaust: platform was removed from the ledger, so a
+	// second poll (still recovered) must not re-send.
+	n.checkPoolRecovery()
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 2, doer.callCount(), "recovery must not re-fire for an already-recovered platform")
+}
+
+func TestCheckPoolRecovery_NoCounterIsNoop(t *testing.T) {
+	provider := &fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 4)}
+	fixedNow := time.Date(2026, 6, 11, 6, 49, 0, 0, time.UTC)
+	n := newTestNotifier(provider, doer, fixedNow)
+
+	trigger := &Account{ID: 7, Name: "openai-us3", Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	n.NotifyPlatformPoolExhausted(PlatformOpenAI, trigger, fixedNow.Add(10*time.Minute), "429_fallback")
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pool-exhausted P0 card was not sent")
+	}
+
+	// No counter injected (mirrors a notifier built without a RateLimitService):
+	// recovery poll degrades to a no-op, never sends.
+	n.checkPoolRecovery()
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 1, doer.callCount(), "recovery poll must be a no-op when no schedulable counter is wired")
+}
+
+func TestFormatPoolOutageDuration(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "45秒", formatPoolOutageDuration(45*time.Second))
+	require.Equal(t, "2分", formatPoolOutageDuration(2*time.Minute))
+	require.Equal(t, "2分30秒", formatPoolOutageDuration(2*time.Minute+30*time.Second))
 }

--- a/backend/internal/service/ratelimit_service_tk_pool_exhausted.go
+++ b/backend/internal/service/ratelimit_service_tk_pool_exhausted.go
@@ -44,6 +44,20 @@ func tkPoolExhaustedEnabled(platform string) bool {
 	return strings.TrimSpace(platform) != ""
 }
 
+// countSchedulableByPlatform 返回某平台当前可调度账号数,供 notifier 的池恢复轮询用。
+// 与 tkPlatformPoolExhaustedCheck 共用 ListSchedulableByPlatform 这一个真值源——空池
+// 火警和「池已恢复」绿卡看的是同一把尺子,不会出现一端判空、另一端判有的口径漂移。
+func (s *RateLimitService) countSchedulableByPlatform(ctx context.Context, platform string) (int, error) {
+	if s == nil || s.accountRepo == nil {
+		return 0, nil
+	}
+	accounts, err := s.accountRepo.ListSchedulableByPlatform(ctx, platform)
+	if err != nil {
+		return 0, err
+	}
+	return len(accounts), nil
+}
+
 func (s *RateLimitService) tkCheckPlatformPoolExhausted(account *Account, until time.Time, reason string) {
 	if s == nil || account == nil || s.incidentNotifier == nil || s.accountRepo == nil {
 		return

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -959,6 +959,11 @@ func ProvideTKAccountIncidentNotifier(
 		provider = ops
 	}
 	n := newTKAccountIncidentNotifier(provider, site)
+	// 注入可调度账号计数,让 notifier 的池恢复轮询能把空池火警闭环成「池已恢复」绿卡。
+	// 必须在 Start() 前设好(虽然轮询每拍重读,设早一拍更稳)。rl 为 nil 时轮询自动 no-op。
+	if rl != nil {
+		n.SetPoolSchedulableCounter(rl.countSchedulableByPlatform)
+	}
 	n.Start()
 	if rl != nil {
 		rl.SetAccountIncidentNotifier(n)


### PR DESCRIPTION
## 背景 / 痛点

线上 P0 空池火警（`TokenKey 平台池全不可调度`）只解决「发现」，不解决「闭环」——运维收到告警后开始补号，却**没有信号告诉他「池已经回来了，可以停手」**，造成运营运维不便（用户原话场景：openai 池降为 0 → P0 → 配号，但无恢复通知）。

## 关键判断

最常见的恢复路径是**冷却到期自愈**（压垮池那个账号的 `until` 到点后自动重新可调度）。到期是**被动的、不触发任何事件**——所以恢复**无法事件驱动，只能轮询**。

## 方案

- **notifier 新增 30s 池恢复轮询**，复用其已有的 ticker / `stopCh` / 去重台账 / 发送机制；喂一个由 `RateLimitService` 注入的可调度账号计数闭包 `countSchedulableByPlatform`，与空池火警**共用 `ListSchedulableByPlatform` 同一真值源**，两端口径不漂移。
- **零常态开销**：仅在确有平台处于空池告警态（`poolExhaustSentAt` 非空）时才查库；健康常态下不触库。
- **恢复与火警严格 1:1 配对**：只有发过红卡的平台才会发对应绿卡，发后即从台账摘除，锁内复核防竞态——天然杜绝独立绿卡刷屏。**源无关**：冷却到期 / admin 补号 / clear 事件，任何让池回血的路径都被捕获。
- **安全降级**：counter 为 nil（单测直接构造 / wire 中 rl 为 nil）时轮询自动 no-op，既有空池火警不受影响。

绿卡内容：平台、当前可调度账号数、**空池持续时长**、「无需继续补号」提示。

## 改动（5 文件，纯 TK）

| 文件 | 改动 |
|---|---|
| `ratelimit_service_tk_pool_exhausted.go` | `countSchedulableByPlatform` 计数方法（纯插入）|
| `account_incident_notifier_tk.go` | 加 counter 字段 + `Start()` 拉起 `poolRecoveryLoop` |
| `account_incident_notifier_tk_pool.go` | 轮询循环 + 恢复检查 + 绿卡文案 + 时长格式化 + setter（纯插入）|
| `wire.go` | `ProvideTKAccountIncidentNotifier` 注入 counter（5 行纯插入）|
| `account_incident_notifier_tk_pool_test.go` | 4 个测试：恢复配对 / 空池不发 / 无 counter no-op / 时长格式化 |

无接口变更、无 stub 改动、无 schema / 前端影响。

## 验证

- `go build ./...` ✅ ／ `go vet -tags=unit ./internal/service` ✅
- 全量 service unit 测试 ✅（含新增 4 个）
- `golangci-lint run ./internal/service/...` 0 issues ✅
- `scripts/preflight.sh` **PASS** ✅

## Marker

sentinel-registry-reviewed

> 该 marker 用于 sentinel registry update gate：本 PR 唯一带删除行的文件 `account_incident_notifier_tk.go` 的「删除」仅为注释文案精炼（把 `poolExhaustSentAt` 注释更新为「待恢复台账」语义、`Start()` 注释补充轮询），**未删除任何 load-bearing 符号或 sentinel 锚点**（所有 sentinel-intact 检查均 green）。新增逻辑落在既有已塑形的 `*_tk_pool.go`，未新增需要锚定的 TK companion 文件。已审阅确认无需新增 anchor。

🤖 Generated with [Claude Code](https://claude.com/claude-code)