### PR TITLE
fix(ratelimit): clamp over-long Anthropic window cooldowns so recovered accounts re-enter the pool

### DIFF
--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -179,6 +179,22 @@ const (
 	// is still limited it simply 429s again and is re-cooled. See
 	// ratelimit_service_tk_openai_reset_clamp.go (upstream Wei-Shaw/sub2api#1981).
 	SettingKeyOpenAIMaxRateLimitCooldownSeconds = "tk_openai_max_rate_limit_cooldown_seconds"
+
+	// SettingKeyAnthropicMaxRateLimitCooldownSeconds caps how long an Anthropic
+	// account may stay rate-limited from a single upstream unified-window (5h/7d)
+	// 429 reset. Unlike its OpenAI twin this is DEFAULT-ON: when unset / blank /
+	// non-numeric / negative it falls back to defaultAnthropicMaxRateLimitCooldownSeconds
+	// (3600s). An explicit "0" disables it (trust the upstream reset verbatim).
+	//
+	// Rationale (prod 2026-06, edge-us6 account oh-3-a): Anthropic's unified 7d
+	// window is rolling — utilization that was >=1.0 at the moment of the 429
+	// decays below the limit hours later as old usage ages out, but the upstream
+	// reset header points at the conservative weekly boundary (days away). Trusting
+	// it verbatim benches a recovered account for days; on a thin/SPOF edge that is
+	// a full anthropic outage. Clamping lets natural traffic re-probe the account
+	// after the ceiling (a still-exhausted window simply 429s again and re-cools).
+	// See ratelimit_service_tk_anthropic_reset_clamp.go.
+	SettingKeyAnthropicMaxRateLimitCooldownSeconds = "tk_anthropic_max_rate_limit_cooldown_seconds"
 )
 
 // LinuxDoConnectSyntheticEmailDomain 是 LinuxDo Connect 用户的合成邮箱后缀（RFC 保留域名）。

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -1637,8 +1637,10 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 			return true
 		}
 		// TK: 账号级 429 附上触发的上游用量窗口（5h/7d），进飞书摘要细分。
-		s.notifyAccountSchedulingBlocked(account, result.resetAt, "429", tkAnthropicWindowLabel(result))
-		if err := s.accountRepo.SetRateLimited(ctx, account.ID, result.resetAt); err != nil {
+		// clamp 只作用于调度冷却 reset；session window gauge 仍用原始上游窗口。
+		clampedReset := s.tkClampAnthropicWindowReset(ctx, account.ID, result.resetAt)
+		s.notifyAccountSchedulingBlocked(account, clampedReset, "429", tkAnthropicWindowLabel(result))
+		if err := s.accountRepo.SetRateLimited(ctx, account.ID, clampedReset); err != nil {
 			slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
 			return false
 		}
@@ -1647,7 +1649,7 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 		// （与模型级冷却路径共用 tkUpdateAnthropic5hSessionWindow，保证两条路径写入一致）
 		s.tkUpdateAnthropic5hSessionWindow(ctx, account.ID, result)
 
-		slog.Info("anthropic_account_rate_limited", "account_id", account.ID, "reset_at", result.resetAt, "reset_in", time.Until(result.resetAt).Truncate(time.Second))
+		slog.Info("anthropic_account_rate_limited", "account_id", account.ID, "reset_at", clampedReset, "original_reset_at", result.resetAt, "reset_in", time.Until(clampedReset).Truncate(time.Second))
 		return true
 	}
 
@@ -1710,21 +1712,25 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 
 	resetAt := time.Unix(ts, 0)
 
+	// TK: clamp scheduling cooldown only (anthropic-only path — reached via the
+	// anthropic-ratelimit-unified-reset header). 5h window gauge keeps original.
+	clampedReset := s.tkClampAnthropicWindowReset(ctx, account.ID, resetAt)
+
 	// 标记限流状态
-	s.notifyAccountSchedulingBlocked(account, resetAt, "429")
-	if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
+	s.notifyAccountSchedulingBlocked(account, clampedReset, "429")
+	if err := s.accountRepo.SetRateLimited(ctx, account.ID, clampedReset); err != nil {
 		slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
 		return false
 	}
 
-	// 根据重置时间反推5h窗口
+	// 根据重置时间反推5h窗口（用原始上游 reset，clamp 只作用于调度冷却）
 	windowEnd := resetAt
 	windowStart := resetAt.Add(-5 * time.Hour)
 	if err := s.accountRepo.UpdateSessionWindow(ctx, account.ID, &windowStart, &windowEnd, "rejected"); err != nil {
 		slog.Warn("rate_limit_update_session_window_failed", "account_id", account.ID, "error", err)
 	}
 
-	slog.Info("account_rate_limited", "account_id", account.ID, "reset_at", resetAt)
+	slog.Info("account_rate_limited", "account_id", account.ID, "reset_at", clampedReset, "original_reset_at", resetAt)
 	return true
 }
 
@@ -1930,17 +1936,23 @@ func (s *RateLimitService) persistAnthropicExhaustedWindowLimit(ctx context.Cont
 		return true
 	}
 
-	s.notifyAccountSchedulingBlocked(account, limit.resetAt, limit.reason)
-	if err := s.accountRepo.SetRateLimited(ctx, account.ID, limit.resetAt); err != nil {
+	// TK: clamp the SCHEDULING cooldown only. Anthropic's unified 7d window is
+	// rolling, so the upstream reset (a conservative weekly boundary, days out) far
+	// outlives the account's actual recovery; clamping lets traffic re-probe it.
+	// The 5h session-window gauge below keeps the ORIGINAL upstream window.
+	clampedReset := s.tkClampAnthropicWindowReset(ctx, account.ID, limit.resetAt)
+	s.notifyAccountSchedulingBlocked(account, clampedReset, limit.reason)
+	if err := s.accountRepo.SetRateLimited(ctx, account.ID, clampedReset); err != nil {
 		slog.Warn("anthropic_window_rate_limit_set_failed",
 			"account_id", account.ID,
 			"window", limit.window,
-			"reset_at", limit.resetAt,
+			"reset_at", clampedReset,
 			"error", err)
 		return true
 	}
 	// TK: record the 5h session window for operator usage gauge (same invariant
 	// as the account-level path in handle429 via tkUpdateAnthropic5hSessionWindow).
+	// Uses the ORIGINAL upstream window, not the clamped scheduling reset.
 	if limit.window == "5h" {
 		windowEnd := limit.resetAt
 		windowStart := windowEnd.Add(-5 * time.Hour)
@@ -1951,8 +1963,9 @@ func (s *RateLimitService) persistAnthropicExhaustedWindowLimit(ctx context.Cont
 	slog.Info("anthropic_window_rate_limited",
 		"account_id", account.ID,
 		"window", limit.window,
-		"reset_at", limit.resetAt,
-		"reset_in", time.Until(limit.resetAt).Truncate(time.Second))
+		"reset_at", clampedReset,
+		"original_reset_at", limit.resetAt,
+		"reset_in", time.Until(clampedReset).Truncate(time.Second))
 	return true
 }
 

--- a/backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// defaultAnthropicMaxRateLimitCooldownSeconds is the DEFAULT-ON ceiling (1h)
+// applied to Anthropic unified-window (5h/7d) 429 cooldowns when the operator
+// has not configured SettingKeyAnthropicMaxRateLimitCooldownSeconds. An explicit
+// "0" disables clamping (trust the upstream reset verbatim).
+const defaultAnthropicMaxRateLimitCooldownSeconds = 3600
+
+// AnthropicMaxRateLimitCooldownSeconds returns the ceiling (seconds) for how long
+// an Anthropic account may stay rate-limited from a single upstream unified-window
+// 429 reset.
+//
+// Unlike its OpenAI twin (OpenAIMaxRateLimitCooldownSeconds, default-off), this is
+// DEFAULT-ON: an unset / blank / non-numeric / negative value falls back to
+// defaultAnthropicMaxRateLimitCooldownSeconds. Only an explicit, non-negative
+// integer overrides it; "0" disables clamping.
+//
+// TK (sibling of upstream Wei-Shaw/sub2api#1981; see
+// ratelimit_service_tk_anthropic_reset_clamp.go package doc).
+func (s *SettingService) AnthropicMaxRateLimitCooldownSeconds(ctx context.Context) int {
+	if s == nil || s.settingRepo == nil {
+		return defaultAnthropicMaxRateLimitCooldownSeconds
+	}
+	vals, err := s.settingRepo.GetMultiple(ctx, []string{SettingKeyAnthropicMaxRateLimitCooldownSeconds})
+	if err != nil {
+		return defaultAnthropicMaxRateLimitCooldownSeconds
+	}
+	raw := strings.TrimSpace(vals[SettingKeyAnthropicMaxRateLimitCooldownSeconds])
+	if raw == "" {
+		return defaultAnthropicMaxRateLimitCooldownSeconds
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 0 {
+		// Malformed config must not silently disable a safety default — fall back
+		// to the default-on ceiling rather than to 0 (which would mean "trust the
+		// multi-day upstream reset", the exact bug this guards against).
+		return defaultAnthropicMaxRateLimitCooldownSeconds
+	}
+	return v
+}
+
+// tkClampAnthropicWindowReset clamps an upstream-provided Anthropic unified-window
+// 429 reset time to now+ceiling.
+//
+// TK: Anthropic's unified 5h/7d windows are rolling — a 429 fired when utilization
+// momentarily hit >=1.0 carries a reset header pointing at the conservative window
+// boundary (a 7d reset can be days out), but the account's rolling utilization
+// often drops back below the limit well before then as old usage ages out. Trusting
+// the reset verbatim benches a recovered account until the boundary; on a thin/SPOF
+// edge that is a multi-day anthropic outage (prod 2026-06, edge-us6 oh-3-a). Clamping
+// the SCHEDULING cooldown lets natural request traffic re-probe the account after the
+// ceiling — a still-exhausted window simply 429s again and is re-cooled ("traffic as
+// the probe": no background prober, and overage=org_level_disabled means a re-probe
+// just 429s without consuming tokens).
+//
+// This only affects the cooldown reset passed to SetRateLimited. The passive usage
+// gauges (session_window / passive_usage_*) are written from the ORIGINAL upstream
+// window values by the callers, so the operator-facing utilization view is unchanged.
+func (s *RateLimitService) tkClampAnthropicWindowReset(ctx context.Context, accountID int64, resetAt time.Time) time.Time {
+	if s == nil || s.settingService == nil {
+		return resetAt
+	}
+	maxSeconds := s.settingService.AnthropicMaxRateLimitCooldownSeconds(ctx)
+	if maxSeconds <= 0 {
+		return resetAt
+	}
+	ceiling := time.Now().Add(time.Duration(maxSeconds) * time.Second)
+	if resetAt.After(ceiling) {
+		slog.Info("anthropic_rate_limit_reset_clamped",
+			"account_id", accountID,
+			"original_reset", resetAt,
+			"clamped_reset", ceiling,
+			"max_cooldown_seconds", maxSeconds)
+		return ceiling
+	}
+	return resetAt
+}

--- a/backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp_test.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp_test.go
@@ -1,0 +1,139 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func settingServiceWithAnthropicMaxCooldown(val string) *SettingService {
+	vals := map[string]string{}
+	if val != "" {
+		vals[SettingKeyAnthropicMaxRateLimitCooldownSeconds] = val
+	}
+	return NewSettingService(&tkThrottleSettingRepo{vals: vals}, &config.Config{})
+}
+
+// Unlike the OpenAI twin this is DEFAULT-ON: unset/blank/malformed/negative all
+// fall back to 3600 (the safety default), and only an explicit "0" disables it.
+func TestAnthropicMaxRateLimitCooldownSeconds(t *testing.T) {
+	ctx := context.Background()
+	require.Equal(t, 3600, settingServiceWithAnthropicMaxCooldown("").AnthropicMaxRateLimitCooldownSeconds(ctx), "unset => default ON 3600")
+	require.Equal(t, 3600, settingServiceWithAnthropicMaxCooldown("-1").AnthropicMaxRateLimitCooldownSeconds(ctx), "negative => default, never silently disable")
+	require.Equal(t, 3600, settingServiceWithAnthropicMaxCooldown("nope").AnthropicMaxRateLimitCooldownSeconds(ctx), "malformed => default, never silently disable")
+	require.Equal(t, 0, settingServiceWithAnthropicMaxCooldown("0").AnthropicMaxRateLimitCooldownSeconds(ctx), "explicit 0 => disabled")
+	require.Equal(t, 1800, settingServiceWithAnthropicMaxCooldown("1800").AnthropicMaxRateLimitCooldownSeconds(ctx), "explicit positive override")
+}
+
+func TestTkClampAnthropicWindowReset(t *testing.T) {
+	ctx := context.Background()
+	sevenDays := time.Now().Add(7 * 24 * time.Hour)
+
+	t.Run("default-on clamps a far-future reset to now+1h", func(t *testing.T) {
+		svc := &RateLimitService{settingService: settingServiceWithAnthropicMaxCooldown("")}
+		got := svc.tkClampAnthropicWindowReset(ctx, 1, sevenDays)
+		require.WithinDuration(t, time.Now().Add(time.Hour), got, 2*time.Second, "default-on must clamp a 7d reset to now+1h")
+	})
+
+	t.Run("explicit 0 disables, returns reset verbatim", func(t *testing.T) {
+		svc := &RateLimitService{settingService: settingServiceWithAnthropicMaxCooldown("0")}
+		got := svc.tkClampAnthropicWindowReset(ctx, 1, sevenDays)
+		require.WithinDuration(t, sevenDays, got, time.Second, "explicit 0 must trust the upstream reset verbatim")
+	})
+
+	t.Run("custom ceiling honored", func(t *testing.T) {
+		svc := &RateLimitService{settingService: settingServiceWithAnthropicMaxCooldown("1800")}
+		got := svc.tkClampAnthropicWindowReset(ctx, 1, sevenDays)
+		require.WithinDuration(t, time.Now().Add(30*time.Minute), got, 2*time.Second, "7d reset must be clamped to now+30m")
+	})
+
+	t.Run("near reset within ceiling is preserved", func(t *testing.T) {
+		svc := &RateLimitService{settingService: settingServiceWithAnthropicMaxCooldown("3600")}
+		near := time.Now().Add(5 * time.Minute)
+		got := svc.tkClampAnthropicWindowReset(ctx, 1, near)
+		require.WithinDuration(t, near, got, time.Second, "a reset within the ceiling must be preserved")
+	})
+
+	t.Run("nil settingService is a no-op", func(t *testing.T) {
+		svc := &RateLimitService{}
+		got := svc.tkClampAnthropicWindowReset(ctx, 1, sevenDays)
+		require.WithinDuration(t, sevenDays, got, time.Second)
+	})
+}
+
+// anthropicClampRepoStub records both the scheduling cooldown (SetRateLimited)
+// and the usage gauge (UpdateSessionWindow) so a test can assert the clamp
+// touches ONLY the scheduling reset.
+type anthropicClampRepoStub struct {
+	mockAccountRepoForGemini
+	rateLimitReset   time.Time
+	rateLimitCalls   int
+	sessionWindowEnd time.Time
+	sessionCalls     int
+}
+
+func (r *anthropicClampRepoStub) SetRateLimited(_ context.Context, _ int64, resetAt time.Time) error {
+	r.rateLimitCalls++
+	r.rateLimitReset = resetAt
+	return nil
+}
+
+func (r *anthropicClampRepoStub) UpdateSessionWindow(_ context.Context, _ int64, _ *time.Time, windowEnd *time.Time, _ string) error {
+	r.sessionCalls++
+	if windowEnd != nil {
+		r.sessionWindowEnd = *windowEnd
+	}
+	return nil
+}
+
+// persistAnthropicExhaustedWindowLimit is the path oh-3-a actually hit. Assert the
+// default-on clamp shortens the SCHEDULING cooldown but leaves the 5h usage-gauge
+// window at the ORIGINAL upstream value.
+func TestPersistAnthropicExhaustedWindowLimit_ClampsSchedulingNotGauge(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("7d window: scheduling reset clamped to now+1h", func(t *testing.T) {
+		repo := &anthropicClampRepoStub{}
+		svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+		svc.SetSettingService(settingServiceWithAnthropicMaxCooldown("")) // default-on
+
+		original := time.Now().Add(72 * time.Hour)
+		headers := http.Header{}
+		headers.Set("anthropic-ratelimit-unified-7d-utilization", "1.0")
+		headers.Set("anthropic-ratelimit-unified-7d-reset", strconv.FormatInt(original.Unix(), 10))
+
+		account := &Account{ID: 6, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+		require.True(t, svc.persistAnthropicExhaustedWindowLimit(ctx, account, headers))
+
+		require.Equal(t, 1, repo.rateLimitCalls)
+		require.WithinDuration(t, time.Now().Add(time.Hour), repo.rateLimitReset, 2*time.Second, "scheduling cooldown must be clamped to now+1h, not the 3d upstream reset")
+		require.True(t, repo.rateLimitReset.Before(original.Add(-time.Hour)), "clamped reset must be well before the upstream 3d reset")
+		require.Zero(t, repo.sessionCalls, "7d window does not touch the 5h session gauge")
+	})
+
+	t.Run("5h window: gauge keeps original upstream window, scheduling clamped", func(t *testing.T) {
+		repo := &anthropicClampRepoStub{}
+		svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+		svc.SetSettingService(settingServiceWithAnthropicMaxCooldown("")) // default-on
+
+		originalEnd := time.Now().Add(4 * time.Hour) // > 1h ceiling, within 6h max-age
+		headers := http.Header{}
+		headers.Set("anthropic-ratelimit-unified-5h-status", "rejected")
+		headers.Set("anthropic-ratelimit-unified-5h-reset", strconv.FormatInt(originalEnd.Unix(), 10))
+
+		account := &Account{ID: 6, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+		require.True(t, svc.persistAnthropicExhaustedWindowLimit(ctx, account, headers))
+
+		require.Equal(t, 1, repo.rateLimitCalls)
+		require.WithinDuration(t, time.Now().Add(time.Hour), repo.rateLimitReset, 2*time.Second, "scheduling cooldown clamped to now+1h")
+		require.Equal(t, 1, repo.sessionCalls)
+		require.WithinDuration(t, originalEnd, repo.sessionWindowEnd, 2*time.Second, "usage gauge window-end must stay at the ORIGINAL upstream 5h reset, not the clamp")
+	})
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1352,6 +1352,7 @@
       "must_contain": [
         "tkIsAnthropicClientInducedBadRequest(responseBody)",
         "s.tkClampOpenAIRateLimitReset(ctx, account.ID",
+        "s.tkClampAnthropicWindowReset(ctx, account.ID",
         "tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody)",
         "anthropic_downstream_no_available_accounts_skip_penalty"
       ],
@@ -1372,6 +1373,15 @@
         "SettingKeyOpenAIMaxRateLimitCooldownSeconds"
       ],
       "rationale": "TK#1981: opt-in (default OFF) clamp of long OpenAI 429 reset windows. Guards the capability against silent upstream-merge deletion."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp.go",
+      "must_contain": [
+        "func (s *RateLimitService) tkClampAnthropicWindowReset",
+        "SettingKeyAnthropicMaxRateLimitCooldownSeconds",
+        "defaultAnthropicMaxRateLimitCooldownSeconds = 3600"
+      ],
+      "rationale": "TK (sibling of #1981, default-ON ceiling 1h): clamp of long Anthropic unified 5h/7d 429 reset windows. Anthropic's 7d window is rolling, so the upstream reset (a conservative weekly boundary) far outlives the account's actual recovery; without the clamp a recovered account is benched for days (prod 2026-06 edge-us6 oh-3-a). Guards the capability — and its default-on ceiling — against silent upstream-merge deletion or a default flip back to OFF."
     },
     {
       "path": "backend/internal/service/openai_gateway_tk_failover_encrypted_reasoning.go",


### PR DESCRIPTION
## 背景（线上排障)

edge-us6 单账号 `oh-3-a`(id=6)「当前 429 但 7d 没满」。实测 + 日志定死根因:

- 18:12:58 一条 `anthropic_window_rate_limited {account_id:6, window:"7d", reset_at:"2026-06-22T01:00Z"}` 把**账号级** `rate_limit_reset_at` 钉到上游给的周边界。写它的是 `persistAnthropicExhaustedWindowLimit`(`HandleUpstreamError`,在 `handle429` 之前)。
- 它只在 `isAnthropicWindowExceeded("7d")=true` 触发;`surpassed-threshold` 实测是浮点(`0.75`/`1.0`),代码 `EqualFold(st,"true")` 永不命中,故触发**必然意味着 18:12 时聚合 `unified-7d-utilization ≥ 1.0`**(账号级真满,当时冷却**正确**)。
- 但直连上游实测(us6 边、复刻 Claude Code 头):`unified-7d-utilization=0.89`、`5h=0.0`,**opus 与 sonnet 请求都 200**(账号早已恢复)。Anthropic 的 7d 是**滚动衰减窗**:util 从 ≥1.0 退到 0.89,TK 却把冷却钉到保守周边界且**永不复检**,在单账号 SPOF 边上让健康账号黑屏 ~3.5 天。

OpenAI 路径早有 `tkClampOpenAIRateLimitReset`(#1981),**Anthropic 路径缺这块**——本 PR 补上。

## 改动(纯后端)

镜像已有的 OpenAI 孪生 `ratelimit_service_tk_openai_reset_clamp.go`,差异只有**默认值**:

- 新增 `ratelimit_service_tk_anthropic_reset_clamp.go`:`AnthropicMaxRateLimitCooldownSeconds`(**默认开,3600s**;unset/空/非数字/负数→3600,显式 `0`→关闭) + `tkClampAnthropicWindowReset`。
- `SettingKeyAnthropicMaxRateLimitCooldownSeconds = "tk_anthropic_max_rate_limit_cooldown_seconds"`(`domain_constants.go`,纯插入)。
- 在 `ratelimit_service.go` 的 **3 个 Anthropic 窗口冷却写入点**(`persistAnthropicExhaustedWindowLimit` + `handle429` 的 per-window / 聚合兜底)钳制 `SetRateLimited` 入参。**只钳调度冷却;`session_window` / `passive_usage_*` 用量 gauge 仍写原始上游窗口**——运维看到的利用率不变。
- 仍满则复检即再 429 自愈(overage=`org_level_disabled`,复检不耗 token)。运维可 `tk_anthropic_max_rate_limit_cooldown_seconds=0` 关闭。
- 加 sentinel 锚点(`scripts/sentinels/gateway-tk.json`):pin 注入点 + 新文件 + 默认值常量,防上游 merge 静默删除或把默认翻回 OFF。

## 为什么只做这一件(乔布斯复审,砍掉了原计划的另两块)

- **「model-family 分桶」已存在且正常工作 → 零新代码。** `tkTryAnthropicModelScopedCooldown` + `model_rate_limits["anthropic:class:*"]` 这套接缝是活的:真·per-class 429(聚合有余量、某 class 子桶满)会被 model-scope、sibling 继续可调度。oh-3-a 没被 model-scope,是因为它本就是账号级聚合真满(account-global 正确),不是缺功能。
- **「补 7d_opus 桶上卡片」是空的。** 实测 opus 请求上游**不返回** `unified-7d_opus-*`(opus 走聚合 7d);卡片已显示聚合 7d。本 PR 落地后账号最多钉 ~1h,困惑自消。

## 测试

`ratelimit_service_tk_anthropic_reset_clamp_test.go`:
- 默认开语义(unset/负数/非法→3600,显式 `0`→关,自定义→生效)。
- clamp 行为(7d→now+1h,近 reset 保留,nil settingService no-op)。
- `persistAnthropicExhaustedWindowLimit` 端到端:7d 窗调度 reset 被钳到 now+1h;5h 窗调度被钳、而 `UpdateSessionWindow` 仍写**原始** 4h 窗(坐实「只钳调度、不污染 gauge」)。

`go test -tags=unit ./...` 全量绿、`golangci-lint run ./...` 0 issues、`scripts/preflight.sh` PASS。

## 发版后验证(只读)

grep `anthropic_rate_limit_reset_clamped`>0;`scan-edge-health.sh --edges us6` 看 oh-3-a 重新可调度、`no_available_429` 归零;`probe-caps.sh` 看 `rate_limit_reset_at` 被钳到 ~1h 而非 6-22。canary 一个 edge 再全网。

合并方式:**Squash and merge**(TK feature)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
