### PR TITLE
fix(admin): allow grok as a group platform (7th-platform DTO enum gap)

### DIFF
--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -84,7 +84,7 @@ func NewGroupHandler(adminService service.AdminService, dashboardService *servic
 type CreateGroupRequest struct {
 	Name             string             `json:"name" binding:"required"`
 	Description      string             `json:"description"`
-	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity newapi kiro"`
+	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity newapi kiro grok"`
 	RateMultiplier   float64            `json:"rate_multiplier"`
 	IsExclusive      bool               `json:"is_exclusive"`
 	SubscriptionType string             `json:"subscription_type" binding:"omitempty,oneof=standard subscription"`
@@ -129,7 +129,7 @@ type CreateGroupRequest struct {
 type UpdateGroupRequest struct {
 	Name             string             `json:"name"`
 	Description      *string            `json:"description"`
-	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity newapi kiro"`
+	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity newapi kiro grok"`
 	RateMultiplier   *float64           `json:"rate_multiplier"`
 	IsExclusive      *bool              `json:"is_exclusive"`
 	Status           string             `json:"status" binding:"omitempty,oneof=active inactive"`

--- a/backend/internal/handler/admin/group_handler_platform_binding_test.go
+++ b/backend/internal/handler/admin/group_handler_platform_binding_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/engine"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -153,4 +154,118 @@ func TestUpdateGroupRequest_AcceptsNewAPIPlatform(t *testing.T) {
 	r.ServeHTTP(rec, req)
 
 	require.Equalf(t, http.StatusOK, rec.Code, "newapi must be a valid platform value on update; body=%s", rec.Body.String())
+}
+
+// TestCreateGroupRequest_AcceptsGrokPlatform is the regression guard for the
+// same bug class as newapi/kiro above, re-introduced by the seventh platform
+// (grok, #791): platform="grok" accounts could be created and the scheduler
+// (engine.AllSchedulingPlatforms / IsOpenAICompatPoolMember) plus the frontend
+// GATEWAY_PLATFORMS already supported grok groups, but `oneof=... newapi kiro`
+// rejected `platform: "grok"` group creation, so grok accounts had no
+// schedulable group. Only these two DTO enums lagged.
+func TestCreateGroupRequest_AcceptsGrokPlatform(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/groups", func(c *gin.Context) {
+		var req CreateGroupRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"platform": req.Platform})
+	})
+
+	body, _ := json.Marshal(map[string]any{
+		"name":     "grok-prod",
+		"platform": "grok",
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/groups", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	require.Equalf(t, http.StatusOK, rec.Code, "grok must be a valid platform value; body=%s", rec.Body.String())
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, "grok", resp["platform"])
+}
+
+// TestUpdateGroupRequest_AcceptsGrokPlatform mirrors the create-side grok guard
+// for the update path; both DTOs had the same gap pre-fix.
+func TestUpdateGroupRequest_AcceptsGrokPlatform(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.PUT("/groups/:id", func(c *gin.Context) {
+		var req UpdateGroupRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"platform": req.Platform})
+	})
+
+	body, _ := json.Marshal(map[string]any{
+		"platform": "grok",
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/groups/1", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	require.Equalf(t, http.StatusOK, rec.Code, "grok must be a valid platform value on update; body=%s", rec.Body.String())
+}
+
+// TestGroupRequest_PlatformEnumCoversAllSchedulingPlatforms is the drift guard
+// that turns this thrice-recurring bug class (newapi, kiro #481, grok #791)
+// into a mechanical check, per the "no soft rule without a check" discipline.
+// engine.AllSchedulingPlatforms() is the single source of truth for "which
+// platforms have a scheduling pool"; every one of them MUST be an accepted
+// group Platform value on BOTH the create and update DTOs, otherwise that
+// platform's accounts can be created but have no schedulable group. When the
+// eighth platform is appended to AllSchedulingPlatforms() this test fails until
+// both `oneof` binding tags in group_handler.go are updated — forcing the fix
+// instead of silently shipping the gap a fourth time.
+func TestGroupRequest_PlatformEnumCoversAllSchedulingPlatforms(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	createRouter := gin.New()
+	createRouter.POST("/groups", func(c *gin.Context) {
+		var req CreateGroupRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"platform": req.Platform})
+	})
+	updateRouter := gin.New()
+	updateRouter.PUT("/groups/:id", func(c *gin.Context) {
+		var req UpdateGroupRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"platform": req.Platform})
+	})
+
+	for _, platform := range engine.AllSchedulingPlatforms() {
+		t.Run(platform, func(t *testing.T) {
+			createBody, _ := json.Marshal(map[string]any{"name": platform + "-grp", "platform": platform})
+			createRec := httptest.NewRecorder()
+			createReq := httptest.NewRequest(http.MethodPost, "/groups", bytes.NewReader(createBody))
+			createReq.Header.Set("Content-Type", "application/json")
+			createRouter.ServeHTTP(createRec, createReq)
+			require.Equalf(t, http.StatusOK, createRec.Code,
+				"scheduling platform %q must be accepted by CreateGroupRequest.Platform oneof — add it to the group_handler.go binding tag; body=%s",
+				platform, createRec.Body.String())
+
+			updateBody, _ := json.Marshal(map[string]any{"platform": platform})
+			updateRec := httptest.NewRecorder()
+			updateReq := httptest.NewRequest(http.MethodPut, "/groups/1", bytes.NewReader(updateBody))
+			updateReq.Header.Set("Content-Type", "application/json")
+			updateRouter.ServeHTTP(updateRec, updateReq)
+			require.Equalf(t, http.StatusOK, updateRec.Code,
+				"scheduling platform %q must be accepted by UpdateGroupRequest.Platform oneof — add it to the group_handler.go binding tag; body=%s",
+				platform, updateRec.Body.String())
+		})
+	}
 }

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -136,6 +136,11 @@
       "path": "backend/internal/service/grok_test.go",
       "must_contain": ["TestTkIsGrokEntitlement403", "TestGrokTokenRefresher_CanRefreshNeedsRefresh"],
       "rationale": "Load-bearing QA evidence for the Heavy-403 entitlement classifier (the pool-kill-amplifier guard) and the refresher gating/expiry-window logic. Losing it removes the regression guard around grok's two most failure-prone pure-logic surfaces."
+    },
+    {
+      "path": "backend/internal/handler/admin/group_handler.go",
+      "must_contain": ["antigravity newapi kiro grok"],
+      "rationale": "grok must be an accepted group Platform value on the create/update admin DTOs (CreateGroupRequest/UpdateGroupRequest `oneof`). TK has appended a platform to this exact binding three times (newapi, kiro #481, grok #791); an upstream merge that reverts the oneof to the upstream/earlier platform set silently strips grok (and kiro/newapi), leaving platform=grok accounts with no schedulable group. Pinning the extended enum tail makes such a revert fail the merge sentinel check."
     }
   ]
 }


### PR DESCRIPTION
## 问题

在管理后台用 `platform="grok"` 建组(或改组)会失败,返回 **HTTP 400**。线上 edge-us4(`tokenkey-edge-us-or1-ls`)实测:两次 `POST /api/v1/admin/groups` 都在 **2–9ms** 内返回 400 —— 即在入参绑定阶段就被拒,根本没到 DB。前端把它收敛成笼统的 `创建分组失败`(catch 读的是 `error.response.data.detail`,而 axios 拦截器从不设这个字段 —— 另一处独立小毛病,本 PR 不修)。

## 根因

管理后台 group DTO 的 `oneof` 绑定只白名单了前六个平台:

```go
Platform string `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity newapi kiro"`
```

`grok`(第七平台,#791)其实在别处**已经全部接好**:

- 调度:`engine.AllSchedulingPlatforms()` / `engine.OpenAICompatPlatforms()` 都含 grok;`IsOpenAICompatPoolMember(grok 账号, grok 组) == true`。
- 前端:`GATEWAY_PLATFORMS`(`frontend/src/constants/gatewayPlatforms.ts`)的下拉框给得出 Grok。

于是表单让你选 Grok、POST `platform:"grok"`,**只有这两个 DTO 枚举把它拒掉**。结果 `platform=grok` 账号**没有任何可调度的组**。这是**第三次**同类缺口 —— `newapi` 和 `kiro`(#481)各被坑过一次、且都是这样修的,测试文件里两条历史都有记录。

## 修复

- `group_handler.go`:给 `CreateGroupRequest` / `UpdateGroupRequest` 的 `Platform` `oneof` 枚举各补 `grok`。
- `group_handler_platform_binding_test.go`:
  - `TestCreateGroupRequest_AcceptsGrokPlatform` + `TestUpdateGroupRequest_AcceptsGrokPlatform`(对齐 kiro 的写法)。
  - `TestGroupRequest_PlatformEnumCoversAllSchedulingPlatforms` —— **运行期漂移守卫**:断言 `engine.AllSchedulingPlatforms()` 里每个平台都被两个 DTO 接受。当第八个平台加进调度注册表却忘了更新绑定标签时,这条测试直接红。
- `scripts/sentinels/grok.json`:把 `group_handler.go` 按枚举尾 `antigravity newapi kiro grok` 钉成 sentinel —— **合并期**覆写防护,上游 merge 若回退这行(悄悄抹掉 grok/kiro/newapi)会让 sentinel 检查失败。两层防护是有意为之:这一行已经回归 3 次了。

## 验证

- `go build ./...` ✓ · `go test -tags=unit ./...` ✓(后端全量)
- 新增 + 既有平台绑定测试 ✓(漂移守卫覆盖 anthropic/gemini/openai/antigravity/newapi/kiro/grok)
- `scripts/preflight.sh` ✓ · `check-grok.py` ✓(28/28)
- `upstream-override-marker`:**verified coverage** —— `group_handler.go` 已被 `scripts/sentinels/grok.json` 钉住(无需 opt-out marker)。
- 纯后端/运维改动 → `no-web-impact`。

## 合并后的运营收尾(发版 + edge-us4 升级之后)

本 PR 只解开建组被 400 的 UI 路径,**本身不接通 grok**。需在 edge-us4 上:建一个 `platform=grok` 的组、把 grok 账号(id=6,`grok-or1-ls-b`)加进去、置 `schedulable=true`,并发一次真请求验证它是不是 **Heavy** 号(标准 xAI OAuth 会 403)。prod 侧目前也没有任何 grok 镜像组/账号 —— 若要对外可用,需照 cc-edges/kiro-edges 模式另补一步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
