### PR TITLE
feat(ops): cap image/video generation concurrency on prod (deploy_via_ssm injection)

### DIFF
--- a/ops/stage0/deploy_via_ssm.sh
+++ b/ops/stage0/deploy_via_ssm.sh
@@ -202,7 +202,44 @@ if [[ "${INSTANCE_ID}" == i-* ]]; then
     ]')"
 fi
 
-jq -n --arg tag "${TAG}" --argjson qa_cmds "${qa_export_cmds}" --argjson media_cmds "${media_storage_cmds}" '{
+# --- Image/video generation concurrency cap (prod-only) ----------------------
+# Same proven mechanism as the QA-export / media blocks above (additive,
+# grep-guarded, idempotent .env + compose-mapping patches on a LIVE host). The
+# image/video generation concurrency limiter ships DISABLED in code (a no-op),
+# leaving /v1/images/generations + /v1/video/generations exposed to a
+# "max_body_size (256MB) x unbounded concurrency" cliff. This turns it ON in prod
+# with a generous per-replica cap and reject overflow, so a burst fast-fails with
+# 429 instead of buffering unbounded large bodies (prod has no swap — see the host
+# mem-guard). The cliff is auth-gated (apiKeyAuth + group binding), so this is a
+# pre-emptive bound, not a fix for an open exploit; it pairs with media offload
+# going live, when sustained large-body generation traffic becomes likely. All
+# three knobs are env-overridable. Prod-only (EC2 `i-*`); edges (Lightsail `mi-*`)
+# never serve generation and get [] (byte-identical command list as before).
+image_concurrency_cmds='[]'
+if [[ "${INSTANCE_ID}" == i-* ]]; then
+  image_concurrency_cmds="$(jq -n \
+    --arg tag "${TAG}" \
+    --arg enabled "${GATEWAY_IMAGE_CONCURRENCY_ENABLED:-true}" \
+    --arg maxconc "${GATEWAY_IMAGE_CONCURRENCY_MAX_CONCURRENT_REQUESTS:-8}" \
+    --arg overflow "${GATEWAY_IMAGE_CONCURRENCY_OVERFLOW_MODE:-reject}" '
+    [
+      ( "ic_e=" + ($enabled|@sh) + "; ic_m=" + ($maxconc|@sh) + "; ic_o=" + ($overflow|@sh)
+        + "; for kv in \"ENABLED=$ic_e\" \"MAX_CONCURRENT_REQUESTS=$ic_m\" \"OVERFLOW_MODE=$ic_o\"; do"
+        + " key=\"GATEWAY_IMAGE_CONCURRENCY_${kv%%=*}\"; val=\"${kv#*=}\";"
+        + " if ! grep -q \"^${key}=\" /var/lib/tokenkey/.env; then echo \"${key}=${val}\" | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo \"ensured ${key}\";"
+        + " else echo \"${key} already present\"; fi; done" ),
+      ( "CF=/var/lib/tokenkey/docker-compose.yml; if [ -f \"$CF\" ]; then miss=0;"
+        + " for k in ENABLED MAX_CONCURRENT_REQUESTS OVERFLOW_MODE; do grep -q \"GATEWAY_IMAGE_CONCURRENCY_${k}=\" \"$CF\" || miss=1; done;"
+        + " if [ \"$miss\" = 1 ]; then sudo cp -a \"$CF\" \"$CF.image-concurrency-before-" + $tag + "\";"
+        + " for k in OVERFLOW_MODE MAX_CONCURRENT_REQUESTS ENABLED; do key=\"GATEWAY_IMAGE_CONCURRENCY_$k\";"
+        + " grep -q \"${key}=\" \"$CF\" || sudo sed -i '\''/^      - SERVER_FRONTEND_URL=/a\\      - '\''\"$key\"'\''=${'\''\"$key\"'\'':-}'\'' \"$CF\"; done;"
+        + " if grep -q GATEWAY_IMAGE_CONCURRENCY_ENABLED \"$CF\"; then echo ensured-compose-GATEWAY_IMAGE_CONCURRENCY-mappings;"
+        + " else echo '\''::warning::failed to insert compose GATEWAY_IMAGE_CONCURRENCY mappings'\''; fi;"
+        + " else echo compose-GATEWAY_IMAGE_CONCURRENCY-mappings-present; fi; fi" )
+    ]')"
+fi
+
+jq -n --arg tag "${TAG}" --argjson qa_cmds "${qa_export_cmds}" --argjson media_cmds "${media_storage_cmds}" --argjson ic_cmds "${image_concurrency_cmds}" '{
   commands: ([
     "set -euo pipefail",
     ("echo === deploy stage0 to tag=" + $tag + " ==="),
@@ -214,7 +251,7 @@ jq -n --arg tag "${TAG}" --argjson qa_cmds "${qa_export_cmds}" --argjson media_c
     "if ! grep -q '\''^SERVER_FRONTEND_URL='\'' /var/lib/tokenkey/.env; then d=$(sed -n '\''s/^API_DOMAIN=//p'\'' /var/lib/tokenkey/.env | head -1); if [ -n \"$d\" ]; then echo \"SERVER_FRONTEND_URL=https://$d\" | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo \"ensured SERVER_FRONTEND_URL=https://$d\"; else echo \"API_DOMAIN empty; skip SERVER_FRONTEND_URL backfill\"; fi; else echo \"SERVER_FRONTEND_URL already present\"; fi",
     "if ! grep -q '\''^TOKENKEY_GHCR_KEEP_TAGS='\'' /var/lib/tokenkey/.env; then echo '\''TOKENKEY_GHCR_KEEP_TAGS=3'\'' | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo '\''ensured TOKENKEY_GHCR_KEEP_TAGS=3'\''; else echo '\''TOKENKEY_GHCR_KEEP_TAGS already present'\''; fi",
     ("if [ -f /var/lib/tokenkey/docker-compose.yml ] && ! grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then sudo cp -a /var/lib/tokenkey/docker-compose.yml /var/lib/tokenkey/docker-compose.yml.compose-before-" + $tag + "; sudo sed -i '\''/^      - TZ=/a\\      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}'\'' /var/lib/tokenkey/docker-compose.yml; if grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then echo ensured-compose-SERVER_FRONTEND_URL-mapping; else echo '\''::warning::failed to insert compose SERVER_FRONTEND_URL mapping'\''; fi; else echo compose-SERVER_FRONTEND_URL-mapping-present-or-no-compose; fi")
-  ] + $qa_cmds + $media_cmds + [
+  ] + $qa_cmds + $media_cmds + $ic_cmds + [
     "echo \"=== pull new image BEFORE drain (old container keeps serving 100% traffic) ===\"",
     "cd /var/lib/tokenkey && sudo docker compose --env-file .env pull tokenkey",
     "echo \"=== pre-drain: SIGUSR1 + wait in_flight=0 (only when outgoing container healthy) ===\"",

--- a/ops/stage0/test_deploy_via_ssm_image_concurrency.py
+++ b/ops/stage0/test_deploy_via_ssm_image_concurrency.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Tests for the prod-only image/video concurrency-cap injection in deploy_via_ssm.sh.
+
+Mirrors test_deploy_via_ssm_media_storage.py: deploy_via_ssm.sh self-heals the
+image/video generation concurrency limiter config
+(GATEWAY_IMAGE_CONCURRENCY_{ENABLED,MAX_CONCURRENT_REQUESTS,OVERFLOW_MODE}) onto a
+LIVE prod host on every deploy, anchored to the tokenkey-unique
+SERVER_FRONTEND_URL compose line. The limiter ships disabled in code (a no-op),
+so /v1/images/generations + /v1/video/generations would otherwise run with
+unbounded concurrency against a 256MB max body; this turns it ON in prod with a
+generous cap + reject overflow. Edges (Lightsail mi-*) never serve generation, so
+the injection is gated to the prod EC2 (i-*) node. All three knobs are
+env-overridable.
+
+stdlib-only; no AWS, no network.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import platform
+import subprocess
+import tempfile
+import unittest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent / "deploy_via_ssm.sh"
+_PROD_IID = "i-0prod000000000000"
+_EDGE_IID = "mi-0edge000000000000"
+
+
+def _render(instance_id: str, tag: str = "1.8.99", env_extra: dict | None = None):
+    out_dir = tempfile.mkdtemp(prefix="image-concurrency-render-")
+    env = {**os.environ, "STAGE0_RENDER_ONLY": "1", "STAGE0_SSM_OUTPUT_DIR": out_dir}
+    if env_extra:
+        env.update(env_extra)
+    proc = subprocess.run(
+        ["bash", str(_SCRIPT), tag, instance_id],
+        env=env, capture_output=True, text=True, check=False,
+    )
+    params = json.loads((pathlib.Path(out_dir) / "ssm-params.json").read_text())
+    return proc, params["commands"]
+
+
+def _ic_cmds(commands: list[str]) -> list[str]:
+    return [c for c in commands if "GATEWAY_IMAGE_CONCURRENCY" in c]
+
+
+class ImageConcurrencyInjectionRenderTest(unittest.TestCase):
+    def test_prod_injects_exactly_two_guarded_commands(self) -> None:
+        proc, commands = _render(_PROD_IID)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        ic = _ic_cmds(commands)
+        self.assertEqual(len(ic), 2, msg=f"expected 2 image-concurrency cmds, got {len(ic)}: {ic}")
+
+        env_cmd = next(c for c in ic if "/var/lib/tokenkey/.env" in c and "docker-compose" not in c)
+        # default prod values: limiter ON, generous per-replica cap, reject overflow
+        # (fast-fail 429 instead of buffering unbounded 256MB bodies — prod has no swap).
+        self.assertIn("ic_e='true'", env_cmd)
+        self.assertIn("ic_m='8'", env_cmd)
+        self.assertIn("ic_o='reject'", env_cmd)
+        # guarded + additive (must not clobber an operator override already in .env)
+        self.assertIn('grep -q "^${key}=" /var/lib/tokenkey/.env', env_cmd)
+        self.assertIn("tee -a /var/lib/tokenkey/.env", env_cmd)
+
+        compose_cmd = next(c for c in ic if "docker-compose.yml" in c)
+        # anchored to the tokenkey-unique SERVER_FRONTEND_URL line (not per-service TZ)
+        self.assertIn("/^      - SERVER_FRONTEND_URL=/a\\", compose_cmd)
+        self.assertNotIn("/^      - TZ=/a\\", compose_cmd)
+        self.assertIn("image-concurrency-before-1.8.99", compose_cmd)
+        self.assertIn('grep -q "${key}=" "$CF"', compose_cmd)
+
+    def test_edge_gets_no_image_concurrency_injection(self) -> None:
+        proc, commands = _render(_EDGE_IID, env_extra={"EDGE_ID": "us2"})
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_ic_cmds(commands), [])
+
+    def test_values_are_env_overridable(self) -> None:
+        proc, commands = _render(_PROD_IID, env_extra={
+            "GATEWAY_IMAGE_CONCURRENCY_MAX_CONCURRENT_REQUESTS": "16",
+            "GATEWAY_IMAGE_CONCURRENCY_OVERFLOW_MODE": "wait",
+        })
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        env_cmd = next(c for c in _ic_cmds(commands) if "tee -a" in c)
+        self.assertIn("ic_m='16'", env_cmd)
+        self.assertIn("ic_o='wait'", env_cmd)
+
+
+@unittest.skipUnless(
+    platform.system() == "Linux",
+    "compose insertion uses GNU sed `a\\` one-line syntax (prod is Linux; BSD sed differs)",
+)
+class ImageConcurrencyInjectionExecuteTest(unittest.TestCase):
+    """Execute the two prod image-concurrency commands against a fake host."""
+
+    def _run_ic_cmds_against(self, host: pathlib.Path) -> None:
+        _, commands = _render(_PROD_IID)
+        script = "\n".join(_ic_cmds(commands))
+        script = script.replace("/var/lib/tokenkey", str(host)).replace("sudo ", "")
+        subprocess.run(["bash", "-e", "-c", script], check=True, capture_output=True, text=True)
+
+    @staticmethod
+    def _ic_mapping_count(lines: list[str]) -> int:
+        return sum(1 for ln in lines if "- GATEWAY_IMAGE_CONCURRENCY_" in ln)
+
+    def test_injection_targets_only_tokenkey_and_is_idempotent(self) -> None:
+        host = pathlib.Path(tempfile.mkdtemp(prefix="image-concurrency-exec-"))
+        (host / ".env").write_text("APP_ENV=prod\nAPI_DOMAIN=api.tokenkey.dev\n")
+        (host / "docker-compose.yml").write_text(
+            "services:\n"
+            "  caddy:\n    environment:\n      - TZ=${TZ:-UTC}\n"
+            "  tokenkey:\n    environment:\n      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}\n      - TZ=${TZ:-UTC}\n"
+            "  postgres:\n    environment:\n      - TZ=${TZ:-UTC}\n"
+            "  redis:\n    environment:\n      - TZ=${TZ:-UTC}\n"
+        )
+
+        self._run_ic_cmds_against(host)
+
+        env_txt = (host / ".env").read_text()
+        for k, v in (
+            ("ENABLED", "true"),
+            ("MAX_CONCURRENT_REQUESTS", "8"),
+            ("OVERFLOW_MODE", "reject"),
+        ):
+            self.assertIn(f"GATEWAY_IMAGE_CONCURRENCY_{k}={v}\n", env_txt)
+
+        lines = (host / "docker-compose.yml").read_text().splitlines()
+        self.assertEqual(self._ic_mapping_count(lines), 3)  # ENABLED/MAX/OVERFLOW
+        # all 3 land in the tokenkey block (anchored on its unique SERVER_FRONTEND_URL)
+        in_tokenkey = False
+        tokenkey_ic = 0
+        for ln in lines:
+            is_header = ln.startswith("  ") and not ln.startswith("    ") and ln.rstrip().endswith(":")
+            if is_header:
+                in_tokenkey = ln.strip() == "tokenkey:"
+                continue
+            if in_tokenkey and "- GATEWAY_IMAGE_CONCURRENCY_" in ln:
+                tokenkey_ic += 1
+        self.assertEqual(tokenkey_ic, 3, msg="image-concurrency mappings must all land in the tokenkey service block")
+        self.assertTrue(list(host.glob("docker-compose.yml.image-concurrency-before-*")))
+
+        # idempotent: a second deploy adds nothing.
+        self._run_ic_cmds_against(host)
+        self.assertEqual(
+            self._ic_mapping_count((host / "docker-compose.yml").read_text().splitlines()), 3)
+        self.assertEqual(
+            sum(1 for ln in (host / ".env").read_text().splitlines()
+                if "GATEWAY_IMAGE_CONCURRENCY_" in ln), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/stage0/test_deploy_via_ssm_qa_export.py
+++ b/ops/stage0/test_deploy_via_ssm_qa_export.py
@@ -57,10 +57,6 @@ def _qa_cmds(commands: list[str]) -> list[str]:
     return [c for c in commands if "QA_CAPTURE_EXPORT_STORAGE" in c]
 
 
-def _ic_cmds(commands: list[str]) -> list[str]:
-    return [c for c in commands if "GATEWAY_IMAGE_CONCURRENCY" in c]
-
-
 class QAExportInjectionRenderTest(unittest.TestCase):
     def test_prod_injects_exactly_two_guarded_commands(self) -> None:
         proc, commands = _render(_PROD_IID)
@@ -121,44 +117,6 @@ class QAExportInjectionRenderTest(unittest.TestCase):
         env_cmd = next(c for c in _qa_cmds(commands) if "tee -a" in c)
         self.assertIn("qa_b='custom-bucket'", env_cmd)
         self.assertIn("qa_p='custom/prefix'", env_cmd)
-
-    def test_prod_injects_image_concurrency_guarded_commands(self) -> None:
-        proc, commands = _render(_PROD_IID)
-        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
-        ic = _ic_cmds(commands)
-        self.assertEqual(len(ic), 2, msg=f"expected 2 image-concurrency cmds, got {len(ic)}: {ic}")
-
-        env_cmd = next(c for c in ic if "/var/lib/tokenkey/.env" in c and "docker-compose" not in c)
-        # default prod values: limiter ON, generous per-replica cap, reject overflow
-        # (fast-fail 429 instead of buffering unbounded 256MB bodies — prod has no swap).
-        self.assertIn("ic_e='true'", env_cmd)
-        self.assertIn("ic_m='8'", env_cmd)
-        self.assertIn("ic_o='reject'", env_cmd)
-        # guarded + additive (must not clobber an operator override already in .env)
-        self.assertIn('grep -q "^${key}=" /var/lib/tokenkey/.env', env_cmd)
-        self.assertIn("tee -a /var/lib/tokenkey/.env", env_cmd)
-
-        compose_cmd = next(c for c in ic if "docker-compose.yml" in c)
-        # anchored to the tokenkey-unique SERVER_FRONTEND_URL line (not per-service TZ)
-        self.assertIn("/^      - SERVER_FRONTEND_URL=/a\\", compose_cmd)
-        self.assertNotIn("/^      - TZ=/a\\", compose_cmd)
-        self.assertIn("image-concurrency-before-1.8.99", compose_cmd)  # tagged backup
-        self.assertIn('grep -q "${key}=" "$CF"', compose_cmd)          # guarded insertion
-
-    def test_edge_gets_no_image_concurrency_injection(self) -> None:
-        proc, commands = _render(_EDGE_IID, env_extra={"EDGE_ID": "us2"})
-        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
-        self.assertEqual(_ic_cmds(commands), [])
-
-    def test_image_concurrency_values_are_env_overridable(self) -> None:
-        proc, commands = _render(_PROD_IID, env_extra={
-            "GATEWAY_IMAGE_CONCURRENCY_MAX_CONCURRENT_REQUESTS": "16",
-            "GATEWAY_IMAGE_CONCURRENCY_OVERFLOW_MODE": "wait",
-        })
-        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
-        env_cmd = next(c for c in _ic_cmds(commands) if "tee -a" in c)
-        self.assertIn("ic_m='16'", env_cmd)
-        self.assertIn("ic_o='wait'", env_cmd)
 
 
 @unittest.skipUnless(

--- a/ops/stage0/test_deploy_via_ssm_qa_export.py
+++ b/ops/stage0/test_deploy_via_ssm_qa_export.py
@@ -57,6 +57,10 @@ def _qa_cmds(commands: list[str]) -> list[str]:
     return [c for c in commands if "QA_CAPTURE_EXPORT_STORAGE" in c]
 
 
+def _ic_cmds(commands: list[str]) -> list[str]:
+    return [c for c in commands if "GATEWAY_IMAGE_CONCURRENCY" in c]
+
+
 class QAExportInjectionRenderTest(unittest.TestCase):
     def test_prod_injects_exactly_two_guarded_commands(self) -> None:
         proc, commands = _render(_PROD_IID)
@@ -94,17 +98,18 @@ class QAExportInjectionRenderTest(unittest.TestCase):
 
     def test_prod_minus_edge_is_only_the_prod_only_injections(self) -> None:
         # The only difference between prod and edge is the prod-only injected
-        # commands: 2 QA-export + 2 media-storage (both gated to the EC2 i-* node;
-        # edges are Lightsail mi-* and get an empty injection array). Computed from
-        # the actual injected-command counts so adding another prod-only block
-        # updates here in one place.
+        # commands: 2 QA-export + 2 media-storage + 2 image-concurrency (all gated
+        # to the EC2 i-* node; edges are Lightsail mi-* and get an empty injection
+        # array). Computed from the actual injected-command counts so adding another
+        # prod-only block updates here in one place.
         _, prod = _render(_PROD_IID)
         _, edge = _render(_EDGE_IID, env_extra={"EDGE_ID": "us2"})
         injected = sum(
             1 for c in prod
             if "QA_CAPTURE_EXPORT_STORAGE" in c or "MEDIA_STORAGE_" in c
+            or "GATEWAY_IMAGE_CONCURRENCY" in c
         )
-        self.assertEqual(injected, 4)
+        self.assertEqual(injected, 6)
         self.assertEqual(len(prod) - len(edge), injected)
 
     def test_values_are_env_overridable(self) -> None:
@@ -116,6 +121,44 @@ class QAExportInjectionRenderTest(unittest.TestCase):
         env_cmd = next(c for c in _qa_cmds(commands) if "tee -a" in c)
         self.assertIn("qa_b='custom-bucket'", env_cmd)
         self.assertIn("qa_p='custom/prefix'", env_cmd)
+
+    def test_prod_injects_image_concurrency_guarded_commands(self) -> None:
+        proc, commands = _render(_PROD_IID)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        ic = _ic_cmds(commands)
+        self.assertEqual(len(ic), 2, msg=f"expected 2 image-concurrency cmds, got {len(ic)}: {ic}")
+
+        env_cmd = next(c for c in ic if "/var/lib/tokenkey/.env" in c and "docker-compose" not in c)
+        # default prod values: limiter ON, generous per-replica cap, reject overflow
+        # (fast-fail 429 instead of buffering unbounded 256MB bodies — prod has no swap).
+        self.assertIn("ic_e='true'", env_cmd)
+        self.assertIn("ic_m='8'", env_cmd)
+        self.assertIn("ic_o='reject'", env_cmd)
+        # guarded + additive (must not clobber an operator override already in .env)
+        self.assertIn('grep -q "^${key}=" /var/lib/tokenkey/.env', env_cmd)
+        self.assertIn("tee -a /var/lib/tokenkey/.env", env_cmd)
+
+        compose_cmd = next(c for c in ic if "docker-compose.yml" in c)
+        # anchored to the tokenkey-unique SERVER_FRONTEND_URL line (not per-service TZ)
+        self.assertIn("/^      - SERVER_FRONTEND_URL=/a\\", compose_cmd)
+        self.assertNotIn("/^      - TZ=/a\\", compose_cmd)
+        self.assertIn("image-concurrency-before-1.8.99", compose_cmd)  # tagged backup
+        self.assertIn('grep -q "${key}=" "$CF"', compose_cmd)          # guarded insertion
+
+    def test_edge_gets_no_image_concurrency_injection(self) -> None:
+        proc, commands = _render(_EDGE_IID, env_extra={"EDGE_ID": "us2"})
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_ic_cmds(commands), [])
+
+    def test_image_concurrency_values_are_env_overridable(self) -> None:
+        proc, commands = _render(_PROD_IID, env_extra={
+            "GATEWAY_IMAGE_CONCURRENCY_MAX_CONCURRENT_REQUESTS": "16",
+            "GATEWAY_IMAGE_CONCURRENCY_OVERFLOW_MODE": "wait",
+        })
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        env_cmd = next(c for c in _ic_cmds(commands) if "tee -a" in c)
+        self.assertIn("ic_m='16'", env_cmd)
+        self.assertIn("ic_o='wait'", env_cmd)
 
 
 @unittest.skipUnless(


### PR DESCRIPTION
## 做什么

在 prod 打开「图片/视频生成」的并发上限闸,承载方式是镜像 `ops/stage0/deploy_via_ssm.sh` 里已验证的 `MEDIA_STORAGE` / QA-export 「仅 prod 注入」机制。

## 为什么

并发限流器(`internal/handler/image_concurrency_limiter.go`,在 `openai_gateway_handler.go` 接线)在代码里**默认关闭**(`config.go` 默认 `enabled=false`,是个 no-op)。于是 `/v1/images/generations` + `/v1/video/generations` 跑在**无界并发**下,而 `gateway.max_body_size` 默认 **256MB**——即「256MB body × 无界并发」的悬崖。该悬崖在鉴权之后(`apiKeyAuth` + group 绑定),所以这是**预防性封顶,不是修一个开放漏洞**。媒体 offload 现已上线(v1.8.15:#849 视频 + #853 图片),大体量生成流量会变多,趁现在封顶。

## 怎么做

`deploy/aws/stage0/docker-compose.yml` **不带**这些 env(prod 的 env 在部署时注入,与 `MEDIA_STORAGE_*` 同机制)。每次 **prod(EC2 `i-*`)** 部署时,幂等地确保以下 key 进入 `/var/lib/tokenkey/.env` + 宿主 compose 映射(锚定在 tokenkey 服务独有的 `SERVER_FRONTEND_URL` 行,带 tag 备份):

| key | 默认值 | 可 env 覆写 |
|---|---|---|
| `GATEWAY_IMAGE_CONCURRENCY_ENABLED` | `true` | 是 |
| `GATEWAY_IMAGE_CONCURRENCY_MAX_CONCURRENT_REQUESTS` | `8` | 是 |
| `GATEWAY_IMAGE_CONCURRENCY_OVERFLOW_MODE` | `reject` | 是 |

`reject` → 突发流量快速失败返 **429**,而不是无界缓冲大 body(prod 无 swap,见宿主 mem-guard)。cap=8 远高于当前 ~0–1 的并发生成量,所以零现实回归风险,同时把悬崖从「无界」收成「有界」。**边缘节点(Lightsail `mi-*`)从不服务生成,拿到逐字节相同的空注入数组。**

## 激活方式

在**下一次 prod 部署**时生效(deploy_via_ssm 每次部署都跑、幂等)。后续微调直接改 prod `.env`(加法注入,绝不覆盖已存在的值)。

## 测试

新增 `ops/stage0/test_deploy_via_ssm_image_concurrency.py`(Render + Execute/幂等 两个类,对齐 `test_deploy_via_ssm_media_storage.py` 约定):断言 2 条带守卫的注入命令(值 `true`/`8`/`reject`、加法式 `.env` append、`SERVER_FRONTEND_URL` compose 锚点、带 tag 备份、仅注入 tokenkey 服务块、二次部署幂等)、边缘排除、env 可覆写。`test_deploy_via_ssm_qa_export.py` 只更新跨块「仅 prod 注入条数」不变量 4 → 6。本地 preflight 全绿(含 SSM host-parse 门禁 + `live-host detector ↔ deploy_via_ssm env sync`)。

## 范围 / 标记
- 纯 ops 改动(`ops/stage0/*`);**no-web-impact**(无前端 / dist)。
- 未触达任何上游形态路径;未新增 sentinel 热点文件。
- 合并方式:**Squash and merge**(TK 自有 PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)