### PR TITLE
fix(ratelimit): default-on the OpenAI/NewAPI window-cooldown clamp (parity with Anthropic)

### DIFF
--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -170,14 +170,16 @@ const (
 	SettingKeyOpenAIImplicitThrottleCooldownSeconds = "tk_openai_implicit_throttle_cooldown_seconds"
 
 	// SettingKeyOpenAIMaxRateLimitCooldownSeconds caps how long an OpenAI-compat
-	// account may stay rate-limited from a single upstream 429 reset. Default ""
-	// / "0" = disabled (trust the upstream reset verbatim — current behavior).
-	// When set to a positive integer N, an upstream reset farther out than N
-	// seconds (e.g. a 7-day window-exhaustion reset) is clamped to now+N so the
-	// account re-enters the pool after N seconds and is re-probed by natural
-	// request traffic instead of sitting idle until the full upstream reset. If it
-	// is still limited it simply 429s again and is re-cooled. See
-	// ratelimit_service_tk_openai_reset_clamp.go (upstream Wei-Shaw/sub2api#1981).
+	// (OpenAI + NewAPI) account may stay rate-limited from a single upstream
+	// window-exhaustion 429 reset. DEFAULT-ON (ceiling 3600s), in lockstep with
+	// SettingKeyAnthropicMaxRateLimitCooldownSeconds: unset / blank / non-numeric
+	// / negative → 3600; an explicit "0" disables it (trust the upstream reset
+	// verbatim). An upstream reset farther out than the ceiling (e.g. a 7-day
+	// window-exhaustion reset) is clamped to now+ceiling so the account re-enters
+	// the pool and is re-probed by natural request traffic instead of sitting idle
+	// until the full upstream reset; if still limited it simply 429s again and is
+	// re-cooled. See ratelimit_service_tk_openai_reset_clamp.go (upstream
+	// Wei-Shaw/sub2api#1981; default flipped ON for parity with the Anthropic clamp).
 	SettingKeyOpenAIMaxRateLimitCooldownSeconds = "tk_openai_max_rate_limit_cooldown_seconds"
 
 	// SettingKeyAnthropicMaxRateLimitCooldownSeconds caps how long an Anthropic

--- a/backend/internal/service/ratelimit_service_tk_openai_reset_clamp.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_reset_clamp.go
@@ -8,30 +8,46 @@ import (
 	"time"
 )
 
-// OpenAIMaxRateLimitCooldownSeconds returns the opt-in ceiling (seconds) for how
-// long an OpenAI-compat account may stay rate-limited from a single upstream 429
-// reset. Returns 0 — disabled, trust the upstream reset verbatim — when unset,
-// blank, non-numeric, or negative.
+// defaultOpenAIMaxRateLimitCooldownSeconds is the DEFAULT-ON ceiling (1h) applied
+// to OpenAI-compat (OpenAI + NewAPI) window-exhaustion 429 cooldowns when the
+// operator has not configured SettingKeyOpenAIMaxRateLimitCooldownSeconds. An
+// explicit "0" disables clamping (trust the upstream reset verbatim). Kept in
+// lockstep with defaultAnthropicMaxRateLimitCooldownSeconds.
+const defaultOpenAIMaxRateLimitCooldownSeconds = 3600
+
+// OpenAIMaxRateLimitCooldownSeconds returns the ceiling (seconds) for how long an
+// OpenAI-compat account may stay rate-limited from a single upstream window 429
+// reset.
 //
-// TK (upstream Wei-Shaw/sub2api#1981).
+// DEFAULT-ON, mirroring AnthropicMaxRateLimitCooldownSeconds: an unset / blank /
+// non-numeric / negative value falls back to defaultOpenAIMaxRateLimitCooldownSeconds.
+// Only an explicit, non-negative integer overrides it; "0" disables clamping.
+//
+// TK (upstream Wei-Shaw/sub2api#1981; default flipped ON for parity with the
+// Anthropic clamp — both windows clear well before the upstream reset).
 func (s *SettingService) OpenAIMaxRateLimitCooldownSeconds(ctx context.Context) int {
 	if s == nil || s.settingRepo == nil {
-		return 0
+		return defaultOpenAIMaxRateLimitCooldownSeconds
 	}
 	vals, err := s.settingRepo.GetMultiple(ctx, []string{SettingKeyOpenAIMaxRateLimitCooldownSeconds})
 	if err != nil {
-		return 0
+		return defaultOpenAIMaxRateLimitCooldownSeconds
 	}
-	v, err := strconv.Atoi(strings.TrimSpace(vals[SettingKeyOpenAIMaxRateLimitCooldownSeconds]))
+	raw := strings.TrimSpace(vals[SettingKeyOpenAIMaxRateLimitCooldownSeconds])
+	if raw == "" {
+		return defaultOpenAIMaxRateLimitCooldownSeconds
+	}
+	v, err := strconv.Atoi(raw)
 	if err != nil || v < 0 {
-		return 0
+		// Malformed config must not silently disable the safety default.
+		return defaultOpenAIMaxRateLimitCooldownSeconds
 	}
 	return v
 }
 
 // tkClampOpenAIRateLimitReset clamps an upstream-provided OpenAI 429 reset time
-// to now+ceiling when the opt-in SettingKeyOpenAIMaxRateLimitCooldownSeconds is
-// configured.
+// to now+ceiling (default-on; SettingKeyOpenAIMaxRateLimitCooldownSeconds=0
+// disables it).
 //
 // TK (upstream Wei-Shaw/sub2api#1981): OpenAI window-exhaustion 429s carry a
 // reset that can be hours or a full 7 days out (calculateOpenAI429ResetTime).
@@ -40,7 +56,8 @@ func (s *SettingService) OpenAIMaxRateLimitCooldownSeconds(ctx context.Context) 
 // accounts" / 503 despite spare capacity. Clamping lets the account re-enter the
 // pool after the ceiling so live traffic re-probes it (a fresh 429 re-cools it).
 // This is "traffic as the probe" — no separate background prober, no extra
-// upstream cost, and strictly opt-in (ceiling 0 = disabled, no behavior change).
+// upstream cost. Default-on (ceiling 1h) for parity with the Anthropic clamp;
+// set the ceiling to 0 to disable and trust the upstream reset verbatim.
 func (s *RateLimitService) tkClampOpenAIRateLimitReset(ctx context.Context, accountID int64, resetAt time.Time) time.Time {
 	if s == nil || s.settingService == nil {
 		return resetAt

--- a/backend/internal/service/ratelimit_service_tk_openai_reset_clamp_test.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_reset_clamp_test.go
@@ -19,13 +19,15 @@ func settingServiceWithMaxCooldown(val string) *SettingService {
 	return NewSettingService(&tkThrottleSettingRepo{vals: vals}, &config.Config{})
 }
 
+// DEFAULT-ON (flipped for parity with the Anthropic clamp): unset/blank/malformed/
+// negative fall back to 3600; only an explicit "0" disables it.
 func TestOpenAIMaxRateLimitCooldownSeconds(t *testing.T) {
 	ctx := context.Background()
-	require.Equal(t, 0, settingServiceWithMaxCooldown("").OpenAIMaxRateLimitCooldownSeconds(ctx), "default disabled")
-	require.Equal(t, 0, settingServiceWithMaxCooldown("0").OpenAIMaxRateLimitCooldownSeconds(ctx))
-	require.Equal(t, 0, settingServiceWithMaxCooldown("-1").OpenAIMaxRateLimitCooldownSeconds(ctx))
-	require.Equal(t, 0, settingServiceWithMaxCooldown("nope").OpenAIMaxRateLimitCooldownSeconds(ctx))
-	require.Equal(t, 3600, settingServiceWithMaxCooldown("3600").OpenAIMaxRateLimitCooldownSeconds(ctx))
+	require.Equal(t, 3600, settingServiceWithMaxCooldown("").OpenAIMaxRateLimitCooldownSeconds(ctx), "unset => default ON 3600")
+	require.Equal(t, 3600, settingServiceWithMaxCooldown("-1").OpenAIMaxRateLimitCooldownSeconds(ctx), "negative => default, never silently disable")
+	require.Equal(t, 3600, settingServiceWithMaxCooldown("nope").OpenAIMaxRateLimitCooldownSeconds(ctx), "malformed => default, never silently disable")
+	require.Equal(t, 0, settingServiceWithMaxCooldown("0").OpenAIMaxRateLimitCooldownSeconds(ctx), "explicit 0 => disabled")
+	require.Equal(t, 1800, settingServiceWithMaxCooldown("1800").OpenAIMaxRateLimitCooldownSeconds(ctx), "explicit positive override")
 }
 
 // upstream Wei-Shaw/sub2api#1981: opt-in clamp of long upstream resets.
@@ -33,16 +35,16 @@ func TestTkClampOpenAIRateLimitReset(t *testing.T) {
 	ctx := context.Background()
 	sevenDays := time.Now().Add(7 * 24 * time.Hour)
 
-	t.Run("disabled returns reset verbatim", func(t *testing.T) {
-		svc := &RateLimitService{settingService: settingServiceWithMaxCooldown("")}
+	t.Run("explicit 0 disables, returns reset verbatim", func(t *testing.T) {
+		svc := &RateLimitService{settingService: settingServiceWithMaxCooldown("0")}
 		got := svc.tkClampOpenAIRateLimitReset(ctx, 1, sevenDays)
-		require.WithinDuration(t, sevenDays, got, time.Second, "default OFF must not change the upstream reset")
+		require.WithinDuration(t, sevenDays, got, time.Second, "explicit 0 must trust the upstream reset verbatim")
 	})
 
-	t.Run("enabled clamps a far-future reset to the ceiling", func(t *testing.T) {
-		svc := &RateLimitService{settingService: settingServiceWithMaxCooldown("3600")}
+	t.Run("default-on clamps a far-future reset to now+1h", func(t *testing.T) {
+		svc := &RateLimitService{settingService: settingServiceWithMaxCooldown("")}
 		got := svc.tkClampOpenAIRateLimitReset(ctx, 1, sevenDays)
-		require.WithinDuration(t, time.Now().Add(time.Hour), got, 2*time.Second, "7d reset must be clamped to now+1h")
+		require.WithinDuration(t, time.Now().Add(time.Hour), got, 2*time.Second, "default-on must clamp a 7d reset to now+1h")
 	})
 
 	t.Run("enabled leaves a near reset untouched", func(t *testing.T) {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1370,9 +1370,10 @@
       "path": "backend/internal/service/ratelimit_service_tk_openai_reset_clamp.go",
       "must_contain": [
         "func (s *RateLimitService) tkClampOpenAIRateLimitReset",
-        "SettingKeyOpenAIMaxRateLimitCooldownSeconds"
+        "SettingKeyOpenAIMaxRateLimitCooldownSeconds",
+        "defaultOpenAIMaxRateLimitCooldownSeconds = 3600"
       ],
-      "rationale": "TK#1981: opt-in (default OFF) clamp of long OpenAI 429 reset windows. Guards the capability against silent upstream-merge deletion."
+      "rationale": "TK#1981: default-ON (ceiling 1h, flipped for parity with the Anthropic clamp) clamp of long OpenAI/NewAPI window-exhaustion 429 reset windows. Guards the capability — and its default-on ceiling — against silent upstream-merge deletion or a default flip back to OFF."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp.go",


### PR DESCRIPTION
## 背景

`tkClampOpenAIRateLimitReset`(TK 实现的上游 issue Wei-Shaw/sub2api#1981)目前**默认关**。排查发现:**这是 PR #455 一次性 remediate 7 个 issue 时的保守选择("默认不改行为"),不是技术原因**——clamp 自己的文档注释就断言 OpenAI 窗口"在上游 reset 之前就已恢复",和 Anthropic clamp 默认开的滚动恢复前提**完全一致**。`#1981` 是上游 issue(bug 报告),clamp 本身是 TK-only 文件,上游 sub2api 没有这个能力。

→ 没有特别原因,按对称性应打开。本 PR 把 `OpenAIMaxRateLimitCooldownSeconds` 翻成**默认开(上限 3600s)**,与 `AnthropicMaxRateLimitCooldownSeconds`(#856)**逐字对称**:unset/空/非数字/负数→3600,显式 `0` 关闭。

## 改动(纯后端)

- `ratelimit_service_tk_openai_reset_clamp.go`:加 `defaultOpenAIMaxRateLimitCooldownSeconds = 3600`,accessor 翻默认开(与 Anthropic 版逐字一致);更新注释(不再 opt-in)。
- `domain_constants.go`:更新 setting 注释为默认开。
- 测试:default→3600、显式 `0`→关、负数/非法→3600、自定义→生效;clamp 的"disabled"用例改用显式 `0`,新增"default-on 钳到 now+1h"。
- sentinel:`gateway-tk.json` 加 `defaultOpenAIMaxRateLimitCooldownSeconds = 3600` 锚点,防默认被静默翻回关。

## 影响 / 风险(诚实披露)

- **解决了 #856 review 里的 L-2**:两个近同名 accessor 默认值相反的维护者意外点,现一致。
- **爆炸半径比 #856 广**:这条 clamp **同时覆盖 NewAPI 第五平台账号**(走 body-parse 路径)。
- **证据弱于 Anthropic**:Anthropic 默认开有实测铁证(7d 从 1.0 衰减 + 双 class 200);OpenAI/NewAPI **没有现成 live-fire**,依据是 #1981 既有前提 + "错了也无害"——仍真满则复检即再 429、不耗 token、自愈再冷却。
- 运维 `tk_openai_max_rate_limit_cooldown_seconds=0` 可随时关回原行为。

## 验证

`go test -tags=unit ./...` 全量绿、service 包全量绿、`golangci-lint` 0 issues、`scripts/preflight.sh` PASS。

sentinel-registry-reviewed

合并方式:**Squash and merge**(TK fix)。与 #856 独立,任一先合另一方做 trivial rebase。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
