### PR TITLE
feat(newapi): serve doubao-seedance video on volcengine account 7

### DIFF
--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "TokenKey served-models MANIFEST — the single declarative source of intent for 'TK serves model M on platform P via an account credentials.model_mapping whitelist, at price π, display=yes/no'. This is a THIN INTENT layer ABOVE the two existing mechanisms it must agree with: (1) per-account credentials.model_mapping (the runtime servable WHITELIST, set by tk_NNN_*_model_mapping*.sql migrations and admin-UI edits), and (2) tk_pricing_overlay.json + the runtime litellm mirror (the PRICE). It is NOT a replacement for either — its projections must AGREE with them, and scripts/checks/catalog-serving-drift.py asserts that agreement (drift guard). SCOPE: ONLY the TK-curated, account-model_mapping-served newapi long-tail (qwen/deepseek families on the two dedicated single-account groups). NOT the litellm catalog, NOT the four native-platform first-class catalogs (anthropic/openai/gemini/antigravity — those have Go servable-allowlist maps in pricing_catalog_supported_models_tk.go), NOT grok (native seventh platform served by platform routing + ch48, not by a 39/60 model_mapping). Consumers: drift guard (now), tokenkey-onboard-model skill (now), future newapi reconciler (//go:embed of THIS file). Co-located with tk_pricing_overlay.json so the same Go package can embed both and the same preflight can parse both.",
+  "_doc": "TokenKey served-models MANIFEST — the single declarative source of intent for 'TK serves model M on platform P via an account credentials.model_mapping whitelist, at price π, display=yes/no'. This is a THIN INTENT layer ABOVE the two existing mechanisms it must agree with: (1) per-account credentials.model_mapping (the runtime servable WHITELIST, set by tk_NNN_*_model_mapping*.sql migrations and admin-UI edits), and (2) tk_pricing_overlay.json + the runtime litellm mirror (the PRICE). It is NOT a replacement for either — its projections must AGREE with them, and scripts/checks/catalog-serving-drift.py asserts that agreement (drift guard). SCOPE: ONLY the TK-curated, account-model_mapping-served newapi long-tail — the qwen/deepseek chat families on their two dedicated single-account groups, plus the volcengine account 7 doubao-seedance VIDEO family (channel_type 45, mode=video_generation, per-second priced in the overlay). NOT the litellm catalog, NOT the four native-platform first-class catalogs (anthropic/openai/gemini/antigravity — those have Go servable-allowlist maps in pricing_catalog_supported_models_tk.go), NOT grok (native seventh platform served by platform routing + ch48, not by a 39/60 model_mapping). Consumers: drift guard (now), tokenkey-onboard-model skill (now), future newapi reconciler (//go:embed of THIS file). Co-located with tk_pricing_overlay.json so the same Go package can embed both and the same preflight can parse both.",
   "_schema": {
     "version": 1,
     "entry_key": "<platform>/<model_id>",
@@ -7,7 +7,7 @@
       "platform": "account/group platform string; for this manifest always 'newapi' (the fifth platform). MUST equal the served account's accounts.platform.",
       "model_id": "the client-facing model id that must appear as a KEY in the served account's credentials.model_mapping whitelist (identity-mapped: key==value for these accounts).",
       "served_on": "string list of accounts.id (as strings) whose credentials.model_mapping MUST advertise model_id. For the seed every entry is a single dedicated account. This is the #812-catching anchor: the guard scans tk_*_model_mapping*.sql for model_id under each listed account.",
-      "channel_type": "the newapi channel_type of the serving account (17=Ali/DashScope, 43=DeepSeek). Documents the upstream adaptor; not asserted against DB (admin-UI editable) but recorded for the reconciler.",
+      "channel_type": "the newapi channel_type of the serving account (17=Ali/DashScope, 43=DeepSeek, 45=VolcEngine). Documents the upstream adaptor; not asserted against DB (admin-UI editable) but recorded for the reconciler.",
       "price_source": "one of 'overlay' (priced in tk_pricing_overlay.json), 'mirror' (priced by the runtime litellm/Wei-Shaw mirror under the bare key — overlay deliberately absent because the mirror already carries a non-zero price), 'channel' (priced via channel_model_pricing DB rows). The guard resolves price differently per source.",
       "price_key": "the key under which the price resolves in the named source (overlay JSON key, or mirror/litellm key, or channel pricing model id). Usually == model_id.",
       "display": "bool. true => model_id MUST be present in the platform's Go servable-allowlist map (pricing_catalog_supported_models_tk.go). newapi has NO such map, so every seed entry is false (catalog renders these via price-presence passthrough, not via a map). Reserved true for a future curated newapi map.",
@@ -182,6 +182,54 @@
       "price_key": "qwen3-235b-a22b",
       "display": false,
       "notes": "Qwen account 60. Flagship open-source Qwen3 MoE (235B total / 22B active). Mapped by tk_032 (identity whitelist merge). Priced in overlay (added 2026-06-18, same per-token rates as qwen3-32b). Added per customer request: the Qwen group previously listed only the smaller Qwen3 models."
+    },
+    "newapi/doubao-seedance-1-0-pro-250528": {
+      "platform": "newapi",
+      "model_id": "doubao-seedance-1-0-pro-250528",
+      "served_on": [
+        "7"
+      ],
+      "channel_type": 45,
+      "price_source": "overlay",
+      "price_key": "doubao-seedance-1-0-pro-250528",
+      "display": false,
+      "notes": "volcengine account 7 (VolcEngine Ark, channel_type=45). Seedance VIDEO model, mapped by tk_033 (identity whitelist merge). Priced in overlay (output_cost_per_second, VolcEngine Ark official page). Added per the vol-test investigation: account 7's model_mapping was a chat-only whitelist (doubao-seed/glm), so seedance video requests were filtered out by the scheduler (IsModelSupported) -> 400 Unsupported model."
+    },
+    "newapi/doubao-seedance-1-5-pro-251215": {
+      "platform": "newapi",
+      "model_id": "doubao-seedance-1-5-pro-251215",
+      "served_on": [
+        "7"
+      ],
+      "channel_type": 45,
+      "price_source": "overlay",
+      "price_key": "doubao-seedance-1-5-pro-251215",
+      "display": false,
+      "notes": "volcengine account 7. Seedance 1.5-pro VIDEO model, mapped by tk_033. Priced in overlay (output_cost_per_second, VolcEngine Ark official 1080p-with-audio max tier)."
+    },
+    "newapi/doubao-seedance-2-0-260128": {
+      "platform": "newapi",
+      "model_id": "doubao-seedance-2-0-260128",
+      "served_on": [
+        "7"
+      ],
+      "channel_type": 45,
+      "price_source": "overlay",
+      "price_key": "doubao-seedance-2-0-260128",
+      "display": false,
+      "notes": "volcengine account 7. Seedance 2.0 VIDEO model, mapped by tk_033. Priced in overlay (output_cost_per_second, VolcEngine Ark official 1080p text/image-to-video tier). NOTE: video-input continuation is rejected upstream of pricing by the video submit guard until re-priced."
+    },
+    "newapi/doubao-seedance-2-0-fast-260128": {
+      "platform": "newapi",
+      "model_id": "doubao-seedance-2-0-fast-260128",
+      "served_on": [
+        "7"
+      ],
+      "channel_type": 45,
+      "price_source": "overlay",
+      "price_key": "doubao-seedance-2-0-fast-260128",
+      "display": false,
+      "notes": "volcengine account 7. Seedance 2.0-fast VIDEO model, mapped by tk_033. Priced in overlay (output_cost_per_second, VolcEngine Ark official 720p max-output tier)."
     }
   }
 }

--- a/backend/migrations/tk_033_seedance_video_model_mapping.sql
+++ b/backend/migrations/tk_033_seedance_video_model_mapping.sql
@@ -1,0 +1,73 @@
+-- Migration: tk_033_seedance_video_model_mapping
+--
+-- Advertise the doubao-seedance VIDEO models on the volcengine account (id=7),
+-- so the volcengine group (and the china group it also belongs to) can serve
+-- async video generation (/v1/video/generations):
+--   - account 7 "volcengine" (VolcEngine Ark, channel_type=45):
+--       doubao-seedance-1-0-pro-250528
+--       doubao-seedance-1-5-pro-251215
+--       doubao-seedance-2-0-260128
+--       doubao-seedance-2-0-fast-260128
+--
+-- Why (prod 2026-06-19, vol-test investigation): account 7's
+-- credentials.model_mapping was an identity WHITELIST listing ONLY chat/LLM
+-- models (glm-4-7, doubao-seed-* chat, doubao-1-5-* chat). A non-empty
+-- model_mapping is a strict allowlist (service.Account.IsModelSupported): the
+-- OpenAI-compat scheduler's candidate filter
+-- (openai_account_scheduler.go isAccountRequestCompatible -> IsModelSupported)
+-- dropped account 7 for any seedance video request, emptying the single-account
+-- pool. That surfaced as HTTP 400 "Unsupported model: doubao-seedance-..."
+-- (openAICompatNoCandidateError -> ErrUnsupportedModel), so seedance video could
+-- never be generated through the vol-test key even though the account is a
+-- correctly-configured VolcEngine Ark video channel (platform=newapi,
+-- channel_type=45, base_url=https://ark.cn-beijing.volces.com, api_key set).
+--
+-- Merging the four seedance ids into the whitelist (identity mapping) makes the
+-- bridge advertise + route them to VolcEngine Ark; the request then passes the
+-- scheduler and is dispatched via the new-api doubao task adaptor.
+--
+-- Pricing already shipped in backend/internal/service/tk_pricing_overlay.json
+-- (each model carries output_cost_per_second from the VolcEngine Ark official
+-- model-pricing page; per-second video billing uses output_cost_per_second).
+-- The overlay is compile-embedded, so the whitelist add lands on an image that
+-- already prices these names — no $0 / unpriced-400 window for the four ids.
+-- (The seedance *lite-t2v / *lite-i2v variants are deliberately NOT priced and
+-- NOT added here — they would hit the unpriced-media 400 until priced.)
+--
+-- Merge (jsonb ||) preserves the existing chat identity-whitelist entries; only
+-- the four new identity keys are added, so the chat models the account already
+-- serves keep working. Raw-SQL account mutation bypasses the Ent
+-- snapshot-refresh hooks, so enqueue a scheduler_outbox account_changed event
+-- (pattern: tk_022 / tk_024 / tk_027 / tk_029 / tk_032) so the running scheduler
+-- sees the change without a restart.
+--
+-- Idempotent + cross-deployment safe: guarded by (id, name, platform='newapi',
+-- channel_type=45) so re-running merges the same keys (no-op) and a bare id
+-- colliding with an unrelated account in another DB cannot match.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+-- volcengine account 7: add the four priced doubao-seedance VIDEO models.
+WITH upd_volcengine AS (
+    UPDATE accounts
+    SET credentials = jsonb_set(
+            credentials,
+            '{model_mapping}',
+            COALESCE(credentials -> 'model_mapping', '{}'::jsonb) || '{
+                "doubao-seedance-1-0-pro-250528": "doubao-seedance-1-0-pro-250528",
+                "doubao-seedance-1-5-pro-251215": "doubao-seedance-1-5-pro-251215",
+                "doubao-seedance-2-0-260128": "doubao-seedance-2-0-260128",
+                "doubao-seedance-2-0-fast-260128": "doubao-seedance-2-0-fast-260128"
+            }'::jsonb
+        ),
+        updated_at = NOW()
+    WHERE id = 7
+      AND name = 'volcengine'
+      AND platform = 'newapi'
+      AND channel_type = 45
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd_volcengine;


### PR DESCRIPTION
## 背景 / 根因

`vol-test` API key(分组 `volcengine`,账号 7)无法生成 seedance 视频,尽管账号 7 是**配置正确的 VolcEngine Ark 视频渠道**:

```
platform=newapi  type=apikey  channel_type=45  status=active  schedulable=true
base_url=https://ark.cn-beijing.volces.com  api_key 已设
分组 5 (volcengine, platform=newapi)  key vol-test → 分组 5
```

根因(已用线上数据 + 代码坐实):账号 7 的 `credentials.model_mapping` 是只含聊天模型的 identity 白名单(`glm-4-7-251222`、`doubao-seed-*` 聊天、`doubao-1-5-*` 聊天),**没有任何 seedance 视频模型**。

非空 `model_mapping` 是**严格白名单**(`service.Account.IsModelSupported`,`account.go:639`)。OpenAI-compat 调度器的候选过滤会剔除不支持所请求模型的账号(`openai_account_scheduler.go:1144` `isAccountRequestCompatible → IsModelSupported`);账号 7 是分组 5 的唯一成员,于是任何 seedance 请求都把池子清空,表现为 **HTTP 400 `Unsupported model: doubao-seedance-…`**(`openai_account_scheduler_tk_errors.go` `openAICompatNoCandidateError → ErrUnsupportedModel`)。佐证:账号 7 的聊天模型 `glm-4-7-251222` 调用成功(06-17 计费 15 次)——同账号、同 key,仅 mapping 把视频挡在外面。

## 改了什么

经 `tokenkey-onboard-model` 流水线(manifest 意图 → 迁移投影 → drift 守卫)在账号 7 上架 4 个**已定价**的 seedance 视频模型:

- `backend/internal/service/tk_served_models.json`:新增 4 条 manifest(`served_on=["7"]`、`channel_type=45`、`price_source=overlay`、`display=false`),并把 scope 文档 / schema 注记扩到账号 7 视频。
- `backend/migrations/tk_033_seedance_video_model_mapping.sql`:用 `jsonb ||` 把 4 个 id(identity)合并进账号 7 的 `model_mapping`(保留原聊天白名单),并 enqueue `scheduler_outbox account_changed` 让运行中的调度器免重启生效。

上架的 4 个(均已在 `tk_pricing_overlay.json` 带 `output_cost_per_second`,VolcEngine Ark 官方价,过 unpriced 闸 + `catalog-serving-drift` A1/A3):

- `doubao-seedance-1-0-pro-250528`
- `doubao-seedance-1-5-pro-251215`
- `doubao-seedance-2-0-260128`
- `doubao-seedance-2-0-fast-260128`

seedance `*-lite-t2v` / `*-lite-i2v` 故意**排除**——overlay 未定价,加了也会撞 unpriced-400;定价是另一件事。

## 验证

- `python3 scripts/checks/catalog-serving-drift.py` → ok(18 条;新增 4 条过 A1 价 + A3 迁移)
- `python3 scripts/checks/pricing-overlay.py --quiet` → ok
- `bash scripts/preflight.sh` → PASS

合并 + 部署后,迁移内的 `scheduler_outbox` 让其生效;livefire = 用 vol-test key 发一条 `POST /v1/video/generations`(`model: doubao-seedance-1-0-pro-250528`)应返回 `vt_` 任务 id 并轮询出视频。

## 标记

- `sentinel-registry-reviewed` —— 本 PR 唯一改动面是 TK 专属的 `tk_served_models.json`,已由 `catalog-serving-drift.py` 完整守护;`pricing-availability.json` 的 sentinel 钉的是 Go 可用性 tap 点 / companion 文件(上游 merge 丢失风险),不针对 manifest 数据条目,故无需新增锚点。
- `no-web-impact` —— 仅后端数据 + 迁移;无前端 bundle 改动(条目 `display=false`)。

> 注:本 worktree 未配 `upstream` remote,`scripts/upstream/check-drift.sh` 取不到 `upstream/main`;本 PR 纯 TK 数据、无上游形状文件,drift 风险为零。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
