### PR TITLE
fix(account): platform allowlist on create + platform-aware GetBaseURL fallback

### DIFF
--- a/backend/internal/handler/admin/account_handler_tk_newapi_validate.go
+++ b/backend/internal/handler/admin/account_handler_tk_newapi_validate.go
@@ -1,13 +1,44 @@
 package admin
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Wei-Shaw/sub2api/internal/domain"
+	"github.com/Wei-Shaw/sub2api/internal/engine"
 )
 
+// tkValidateAccountPlatform rejects an account whose platform is not a real
+// scheduling platform. The group create/update path already enforces this via a
+// binding `oneof`, but the account path historically only had `binding:"required"`
+// (no allowlist), so a typo'd or invented platform string (e.g. "volcengine"
+// instead of the newapi platform + channel_type=45) was stored verbatim. Such an
+// account can never join any scheduling pool — pool membership is strict platform
+// equality (engine.IsOpenAICompatPoolMember / per-platform buckets) — so it
+// silently fails with empty-pool 429s ("No available accounts") and no hint that
+// the platform string itself is invalid. Validating against
+// engine.AllSchedulingPlatforms() (the single source of truth for "platforms that
+// have a scheduling pool") closes that asymmetry; adding a future platform there
+// extends this check automatically.
+func tkValidateAccountPlatform(platform string) string {
+	for _, p := range engine.AllSchedulingPlatforms() {
+		if platform == p {
+			return ""
+		}
+	}
+	return fmt.Sprintf(
+		"platform %q is not a valid account platform (must be one of: %s)",
+		platform, strings.Join(engine.AllSchedulingPlatforms(), ", "),
+	)
+}
+
 // tkValidateNewAPIAccountCreate returns a user-facing error message, or empty if OK.
+// Called by all three account-creation paths (single Create, BatchCreate, import),
+// so the platform-allowlist check below guards every persisted account.
 func tkValidateNewAPIAccountCreate(platform string, channelType int, credentials map[string]any) string {
+	if msg := tkValidateAccountPlatform(platform); msg != "" {
+		return msg
+	}
 	if channelType < 0 {
 		return "channel_type must be >= 0"
 	}

--- a/backend/internal/handler/admin/account_handler_tk_platform_validate_test.go
+++ b/backend/internal/handler/admin/account_handler_tk_platform_validate_test.go
@@ -1,0 +1,72 @@
+//go:build unit
+
+package admin
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+	"github.com/Wei-Shaw/sub2api/internal/engine"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkValidateAccountPlatform(t *testing.T) {
+	t.Run("every scheduling platform is accepted", func(t *testing.T) {
+		for _, p := range engine.AllSchedulingPlatforms() {
+			require.Empty(t, tkValidateAccountPlatform(p), "platform %q should be valid", p)
+		}
+		// Spot-check the literals so a future rename of a constant is caught here too.
+		for _, p := range []string{
+			domain.PlatformAnthropic, domain.PlatformOpenAI, domain.PlatformGemini,
+			domain.PlatformAntigravity, domain.PlatformNewAPI, domain.PlatformKiro,
+			domain.PlatformGrok,
+		} {
+			require.Empty(t, tkValidateAccountPlatform(p), "platform %q should be valid", p)
+		}
+	})
+
+	t.Run("invalid platform strings are rejected", func(t *testing.T) {
+		// "volcengine" is the canonical trap: it is a channel_type (45) on the
+		// newapi platform, NOT a platform of its own. Persisting it silently
+		// produced an account that never joins any scheduling pool.
+		for _, bad := range []string{"volcengine", "doubao", "", "Anthropic", "newapi ", "vertex"} {
+			msg := tkValidateAccountPlatform(bad)
+			require.NotEmpty(t, msg, "platform %q should be rejected", bad)
+			require.Contains(t, msg, "not a valid account platform")
+		}
+	})
+}
+
+func TestTkValidateNewAPIAccountCreate_PlatformAllowlist(t *testing.T) {
+	t.Run("invalid platform rejected before newapi-specific checks", func(t *testing.T) {
+		msg := tkValidateNewAPIAccountCreate("volcengine", 45, map[string]any{
+			"base_url": "https://ark.cn-beijing.volces.com",
+			"api_key":  "sk-x",
+		})
+		require.Contains(t, msg, "not a valid account platform")
+	})
+
+	t.Run("valid newapi account still enforces channel_type + base_url", func(t *testing.T) {
+		// channel_type missing for newapi
+		require.Contains(t,
+			tkValidateNewAPIAccountCreate(domain.PlatformNewAPI, 0, map[string]any{"base_url": "https://x"}),
+			"channel_type must be > 0",
+		)
+		// base_url missing for newapi
+		require.Contains(t,
+			tkValidateNewAPIAccountCreate(domain.PlatformNewAPI, 45, map[string]any{}),
+			"base_url is required",
+		)
+		// fully valid newapi (VolcEngine video channel)
+		require.Empty(t,
+			tkValidateNewAPIAccountCreate(domain.PlatformNewAPI, 45, map[string]any{
+				"base_url": "https://ark.cn-beijing.volces.com",
+				"api_key":  "sk-x",
+			}),
+		)
+	})
+
+	t.Run("valid non-newapi account passes", func(t *testing.T) {
+		require.Empty(t, tkValidateNewAPIAccountCreate(domain.PlatformAnthropic, 0, map[string]any{}))
+	})
+}

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -751,7 +751,24 @@ func (a *Account) GetBaseURL() string {
 	}
 	baseURL := a.GetCredential("base_url")
 	if baseURL == "" {
-		return "https://api.anthropic.com"
+		// A blank base_url falls back to the Anthropic endpoint ONLY for accounts
+		// that actually speak it: the anthropic platform (and legacy rows with an
+		// empty platform string, which predate multi-platform support and were
+		// all anthropic). For any OTHER platform (newapi / openai / gemini / grok /
+		// kiro) silently returning the Anthropic host sends the request to the
+		// wrong upstream — e.g. a VolcEngine Ark account (platform=newapi,
+		// channel_type=45) with a blank base_url would POST to api.anthropic.com
+		// and return a baffling Anthropic 404/401. Return empty instead so the
+		// platform-specific resolver (newapi_bridge_usage Ark/OpenAI fallback) or a
+		// clean upstream failure applies. Create-time validation already requires
+		// base_url for newapi; this is the safety net for the update path and any
+		// legacy rows. Anthropic-context callers (gateway_service forward /
+		// count_tokens, upstream_models sync) already re-default empty to
+		// api.anthropic.com at their own call sites, so this is non-regressive.
+		if a.Platform == PlatformAnthropic || a.Platform == "" {
+			return "https://api.anthropic.com"
+		}
+		return ""
 	}
 	if a.Platform == PlatformAntigravity {
 		return strings.TrimRight(baseURL, "/") + "/antigravity"

--- a/backend/internal/service/account_base_url_test.go
+++ b/backend/internal/service/account_base_url_test.go
@@ -65,6 +65,47 @@ func TestGetBaseURL(t *testing.T) {
 			},
 			expected: "",
 		},
+		{
+			// Regression: a blank base_url on a non-anthropic platform must NOT
+			// silently fall back to api.anthropic.com (it would POST a VolcEngine
+			// Ark / newapi request to the Anthropic host and return a baffling 404).
+			name: "newapi apikey without base_url returns empty (no anthropic fallback)",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformNewAPI,
+				Credentials: map[string]any{},
+			},
+			expected: "",
+		},
+		{
+			name: "openai apikey without base_url returns empty (no anthropic fallback)",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformOpenAI,
+				Credentials: map[string]any{},
+			},
+			expected: "",
+		},
+		{
+			name: "newapi apikey with custom base_url is returned verbatim",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformNewAPI,
+				Credentials: map[string]any{"base_url": "https://ark.cn-beijing.volces.com"},
+			},
+			expected: "https://ark.cn-beijing.volces.com",
+		},
+		{
+			// Legacy rows with an empty platform string predate multi-platform
+			// support and were all anthropic — keep the historical default.
+			name: "legacy empty-platform apikey without base_url keeps anthropic default",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    "",
+				Credentials: map[string]any{},
+			},
+			expected: "https://api.anthropic.com",
+		},
 	}
 
 	for _, tt := range tests {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1618,9 +1618,10 @@
       "must_contain": [
         "ensureAntigravityDefaultPassthroughs(result, []string{",
         "\"gemini-3-flash-agent\",",
-        "\"gemini-pro-agent\","
+        "\"gemini-pro-agent\",",
+        "a.Platform == PlatformAnthropic || a.Platform == \"\""
       ],
-      "rationale": "Antigravity 自定义-映射账号的 safety-net 透传列表（GetModelMapping 内）。这是 antigravity gemini-only 服务面的「五面」之一：公共目录 / UseKeyModal 宣告可服务的 wire id，若自定义 model_mapping 账号未显式声明，必须由此列表补 identity 透传，否则静默 404（xj-review R / memory antigravity_claude_exclude_per_account_not_global_default）。2026-06-15（PR #774）起该列表已移除上游 deprecated 的 gemini-3.1-pro-high（identity 透传 → 400），等价档走 gemini-pro-agent。上游 merge 若删除 ensureAntigravityDefaultPassthroughs 调用或丢失 gemini-pro-agent / gemini-3-flash-agent 成员，自定义账号会静默拒绝可服务模型——本 sentinel 守护该调用与收敛后的成员。"
+      "rationale": "Two load-bearing TK behaviors in account.go. (1) Antigravity 自定义-映射账号的 safety-net 透传列表（GetModelMapping 内）：antigravity gemini-only 服务面的「五面」之一，公共目录 / UseKeyModal 宣告可服务的 wire id，若自定义 model_mapping 账号未显式声明，必须由此列表补 identity 透传，否则静默 404（xj-review R / memory antigravity_claude_exclude_per_account_not_global_default）。2026-06-15（PR #774）起该列表已移除上游 deprecated 的 gemini-3.1-pro-high（identity 透传 → 400），等价档走 gemini-pro-agent。上游 merge 若删除 ensureAntigravityDefaultPassthroughs 调用或丢失 gemini-pro-agent / gemini-3-flash-agent 成员，自定义账号会静默拒绝可服务模型。 (2) GetBaseURL 的平台感知空-base_url 兜底（`a.Platform == PlatformAnthropic || a.Platform == \"\"`）：空 base_url 仅对 anthropic（及 legacy 空 platform）账号回退 api.anthropic.com；其它平台（newapi/openai/gemini/grok/kiro）返回空，避免把 VolcEngine Ark 等 newapi 请求静默发往 Anthropic 主机（baffling 404）。上游 merge 若把 GetBaseURL 还原成无条件 `return \"https://api.anthropic.com\"`，本 anchor 会丢失——sentinel 即在此处拦截回退。"
     },
     {
       "path": "backend/internal/handler/gateway_handler_tk_model_list.go",


### PR DESCRIPTION
## 背景

排查 `vol-test` key / `volcengine`(newapi, channel_type=45)账号无法生成 seedance 视频时发现(根因另由 #861 修复——该账号的 `model_mapping` 缺 seedance)。账号 7 本身配置正确,但排查中翻出两个真实的潜伏 bug,都会**静默搞坏一个 newapi 账号并抛出莫名其妙的错误**,与我们想保留的上游行为无关。

## Bug 1 —— 账号创建无 platform 白名单(与分组不对称)

**影响**:账号可以存进一个非法 `platform` 字符串然后永不调度,且无任何诊断。

- 账号 create / batch / import 三条路径的 `platform` 只绑 `binding:"required"`——**没有 `oneof`**(`account_handler.go:103`/`:169`/`:2213`;`admin_service.go:2657`/`account_service.go:176` 原样存)。
- **分组**路径早已强制 `oneof=anthropic openai gemini antigravity newapi kiro grok`(`group_handler.go:87/132`)。于是分组拒绝 `"volcengine"`,账号却**接受**。
- `"volcengine"` 是经典陷阱:它是 **newapi** 平台上的 `channel_type`(45),不是独立平台。池成员判定是严格平台相等(`engine.IsOpenAICompatPoolMember` / per-platform 桶),所以 `platform="volcengine"` 的账号**进不了任何池**,每个请求都空池快失败 **HTTP 429 "No available accounts"**——完全看不出是平台字符串的问题。

**修复**:在 `tkValidateNewAPIAccountCreate` 里用 `engine.AllSchedulingPlatforms()`(可调度平台的单一真值源)校验 platform;该函数已被三条 create 路径调用(`account_handler.go:530` Create、`:1364` BatchCreate、`account_data.go:698` import)。未来新增平台自动纳入校验。非法平台现在返回清晰 400:`platform "volcengine" is not a valid account platform (must be one of: …)`。

## Bug 2 —— `GetBaseURL()` 对所有平台的空 base_url 都回退 `api.anthropic.com`

**影响**:非 anthropic 的 apikey 账号空 base_url 会把请求发到 Anthropic 主机,返回莫名其妙的 Anthropic 404/401,而不是干净失败。

- `Account.GetBaseURL()`(`account.go:748`)对**任何**平台的空 base_url 都返回硬编码 `"https://api.anthropic.com"`。newapi(VolcEngine Ark, channel_type=45)账号空 base_url 会 POST 到 `https://api.anthropic.com/api/v3/contents/generations/tasks`。
- `newapi_bridge_usage.go:72` 里的平台特定兜底(`if baseURL == "" && Platform != newapi`)因此是**死代码**——GetBaseURL 永不返回空。

**修复**:仅对 `anthropic` 平台(及 legacy 空 platform 行,历史上都是 anthropic)回退 anthropic 默认;其它平台返回 `""`,交给平台特定 resolver(newapi Ark/OpenAI 兜底)或干净的上游失败。

**非回归**:anthropic 类调用方(`gateway_service` forward/count_tokens 在 `:6374/:7260/:10962/:11020`、`upstream_models` sync 在 `:179`)各自已在调用点把空 base_url 兜回 `api.anthropic.com`;已设 base_url 的账号完全不受影响(只改空-base_url 分支)。create 期已强制 newapi 必填 base_url,这是 update 路径 / legacy 行的安全网。

## 测试

- `account_base_url_test.go`:newapi/openai 空 base_url → `""`(不回退 anthropic);newapi 带 base_url 原样返回;legacy 空 platform 保留 anthropic 默认;原 anthropic/antigravity 用例不变。
- `account_handler_tk_platform_validate_test.go`(新):`engine.AllSchedulingPlatforms()` 每个成员被接受;`"volcengine"`/`"doubao"`/`""`/拼写错误被拒;create 路径集成(非法平台在 newapi channel_type/base_url 检查之前就被拒)。

## 验证

- `go build ./...`、`go test -tags=unit ./...`、`golangci-lint run ./internal/service/... ./internal/handler/admin/...` → 全绿
- `bash scripts/preflight.sh` → PASS

## Sentinel

在 `scripts/sentinels/gateway-tk.json`(`account.go` 条目)钉住平台感知的 GetBaseURL 兜底(`a.Platform == PlatformAnthropic || a.Platform == ""`),防止未来 `git merge upstream/main` 把它静默还原成无条件 anthropic 默认。注册表已在本 PR 用真实锚点更新,registry-update 闸自然通过。`no-web-impact`:仅后端 Go。

> 注:本 worktree 未配 `upstream` remote,`scripts/upstream/check-drift.sh` 取不到 `upstream/main`。两处都是 TK 自有行为(账号 create 校验 + 一个已被 sentinel 跟踪的 TK 修复方法),上游 drift 风险低;override-marker 闸确认 "no upstream-shaped paths changed"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
