### PR TITLE
fix(admin): grant exclusive-group membership when setting per-user 专属倍率/RPM

### DIFF
--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -2366,6 +2366,18 @@ func (s *adminServiceImpl) BatchSetGroupRateMultipliers(ctx context.Context, gro
 			return fmt.Errorf("rate_multiplier must be > 0 (user_id=%d)", e.UserID)
 		}
 	}
+	// 专属分组：先确保 entries 中的用户拥有 allowed_groups 成员资格，再写入专属倍率。
+	// 否则「在分组页通过专属倍率添加用户」只写了 user_group_rate 行、未授予访问权，用户页的
+	// 专属分组复选框仍未勾选（必须重新指定），用户实际也无法绑定该专属分组（CanBindGroup）。
+	// 先授权后写倍率：任一步失败都不会留下「有倍率无访问」的不一致态。
+	userIDs := make([]int64, 0, len(entries))
+	for _, e := range entries {
+		userIDs = append(userIDs, e.UserID)
+	}
+	// TK(exclusive-membership rate-path): keep this hook on upstream merge — pinned by scripts/sentinels/gateway-tk.json
+	if err := s.grantExclusiveGroupMembership(ctx, groupID, userIDs); err != nil {
+		return err
+	}
 	return s.userGroupRateRepo.SyncGroupRateMultipliers(ctx, groupID, entries)
 }
 
@@ -2392,12 +2404,92 @@ func (s *adminServiceImpl) BatchSetGroupRPMOverrides(ctx context.Context, groupI
 			return infraerrors.BadRequest("INVALID_RPM_OVERRIDE", fmt.Sprintf("rpm_override must be >= 0 (user_id=%d)", e.UserID))
 		}
 	}
+	// 专属分组：为被设置 rpm_override（非清空）的用户补齐 allowed_groups 成员资格，
+	// 与专属倍率保持同一语义——在分组页给某用户设专属配置即视为加入该专属分组。
+	// nil（清空）条目不授权。
+	userIDs := make([]int64, 0, len(entries))
+	for _, e := range entries {
+		if e.RPMOverride != nil {
+			userIDs = append(userIDs, e.UserID)
+		}
+	}
+	// TK(exclusive-membership rpm-path): keep this hook on upstream merge — pinned by scripts/sentinels/gateway-tk.json
+	if err := s.grantExclusiveGroupMembership(ctx, groupID, userIDs); err != nil {
+		return err
+	}
 	if err := s.userGroupRateRepo.SyncGroupRPMOverrides(ctx, groupID, entries); err != nil {
 		return err
 	}
 	// RPM override 已嵌入 auth cache snapshot (v7)，变更后必须失效相关缓存。
 	if s.authCacheInvalidator != nil {
 		s.authCacheInvalidator.InvalidateAuthCacheByGroupID(ctx, groupID)
+	}
+	return nil
+}
+
+// grantExclusiveGroupMembership 为指定用户增量授予某专属标准分组的 allowed_groups 成员资格。
+//
+// 背景：分组页的「专属倍率 / RPM 覆盖」弹窗只写 user_group_rate 表，而专属分组的访问权由
+// user_allowed_groups 边（user.AllowedGroups）控制。两者各自独立存储，导致「在分组页通过专属
+// 倍率添加用户」后，用户页的专属分组复选框仍未勾选、用户实际也无法绑定该专属分组。本方法把
+// 「在分组页设置专属配置」与「成为该专属分组成员」对齐，复用 AdminUpdateAPIKeyGroupID /
+// ReplaceUserGroup 既有的授权语义（s.userRepo.AddGroupToAllowedGroups 幂等、冲突忽略）。
+//
+// 仅追加、从不撤销：使用默认倍率的成员在 user_group_rate 中没有行、不会出现在弹窗列表里，
+// 若按列表反向同步成员资格会误删这些成员。成员资格的移除仍由用户页（唯一权威入口）负责。
+// 仅对专属且非订阅型的标准分组生效：公开分组人人可用、订阅型分组走订阅授权。
+// groupRepo / userRepo 为 nil（部分单测仅装配 userGroupRateRepo）时安全降级为 no-op。
+func (s *adminServiceImpl) grantExclusiveGroupMembership(ctx context.Context, groupID int64, userIDs []int64) error {
+	if len(userIDs) == 0 || s.groupRepo == nil || s.userRepo == nil {
+		return nil
+	}
+	group, err := s.groupRepo.GetByID(ctx, groupID)
+	if err != nil {
+		return err
+	}
+	if !group.IsExclusive || group.IsSubscriptionType() {
+		return nil
+	}
+
+	// 去重，避免对同一用户重复 upsert。
+	seen := make(map[int64]struct{}, len(userIDs))
+	uniqueIDs := make([]int64, 0, len(userIDs))
+	for _, uid := range userIDs {
+		if _, ok := seen[uid]; ok {
+			continue
+		}
+		seen[uid] = struct{}{}
+		uniqueIDs = append(uniqueIDs, uid)
+	}
+
+	// 事务保证多用户授权的原子性（与 ReplaceUserGroup 一致；entClient 为 nil 时降级为无事务）。
+	opCtx := ctx
+	var tx *dbent.Tx
+	if s.entClient != nil {
+		var txErr error
+		tx, txErr = s.entClient.Tx(ctx)
+		if txErr != nil {
+			return fmt.Errorf("begin transaction: %w", txErr)
+		}
+		defer func() { _ = tx.Rollback() }()
+		opCtx = dbent.NewTxContext(ctx, tx)
+	}
+	for _, uid := range uniqueIDs {
+		if err := s.userRepo.AddGroupToAllowedGroups(opCtx, uid, groupID); err != nil {
+			return fmt.Errorf("add group %d to user %d allowed groups: %w", groupID, uid, err)
+		}
+	}
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit transaction: %w", err)
+		}
+	}
+
+	// allowed_groups 参与 API Key 鉴权（CanBindGroup），提交后失效受影响用户的鉴权缓存。
+	if s.authCacheInvalidator != nil {
+		for _, uid := range uniqueIDs {
+			s.authCacheInvalidator.InvalidateAuthCacheByUserID(ctx, uid)
+		}
 	}
 	return nil
 }

--- a/backend/internal/service/admin_service_group_rate_test.go
+++ b/backend/internal/service/admin_service_group_rate_test.go
@@ -223,3 +223,130 @@ func TestAdminService_BatchSetGroupRPMOverrides(t *testing.T) {
 		require.Zero(t, repo.rpmSyncedGroupID)
 	})
 }
+
+// TestAdminService_BatchSet_ExclusiveGroupMembership 锁定修复：在分组页通过「专属倍率 / RPM
+// 覆盖」给用户设值时，专属分组必须同时把用户加入 allowed_groups，否则用户页看不到该专属分组
+// （bug：必须重新指定）。复用 admin_service_apikey_test.go / admin_service_update_balance_test.go
+// 的同包 unit stub。
+func TestAdminService_BatchSet_ExclusiveGroupMembership(t *testing.T) {
+	exclusiveStandard := func() *groupRepoStubForGroupUpdate {
+		return &groupRepoStubForGroupUpdate{group: &Group{
+			ID: 10, Name: "Exclusive", Status: StatusActive,
+			IsExclusive: true, SubscriptionType: SubscriptionTypeStandard,
+		}}
+	}
+
+	t.Run("rate: exclusive group grants membership and syncs", func(t *testing.T) {
+		rateRepo := &userGroupRateRepoStubForGroupRate{}
+		groupRepo := exclusiveStandard()
+		userRepo := &userRepoStubForGroupUpdate{}
+		cache := &authCacheInvalidatorStub{}
+		svc := &adminServiceImpl{
+			userGroupRateRepo: rateRepo, groupRepo: groupRepo,
+			userRepo: userRepo, authCacheInvalidator: cache,
+		}
+
+		err := svc.BatchSetGroupRateMultipliers(context.Background(), 10,
+			[]GroupRateMultiplierInput{{UserID: 42, RateMultiplier: 1.5}})
+		require.NoError(t, err)
+		// 成员资格被授予
+		require.True(t, userRepo.addGroupCalled)
+		require.Equal(t, int64(42), userRepo.addedUserID)
+		require.Equal(t, int64(10), userRepo.addedGroupID)
+		require.Equal(t, int64(10), groupRepo.lastGetByIDArg)
+		// 鉴权缓存按用户失效
+		require.Equal(t, []int64{42}, cache.userIDs)
+		// 专属倍率仍写入
+		require.Equal(t, int64(10), rateRepo.syncedGroupID)
+	})
+
+	t.Run("rate: non-exclusive group skips membership but still syncs", func(t *testing.T) {
+		rateRepo := &userGroupRateRepoStubForGroupRate{}
+		groupRepo := &groupRepoStubForGroupUpdate{group: &Group{
+			ID: 10, Name: "Public", Status: StatusActive,
+			IsExclusive: false, SubscriptionType: SubscriptionTypeStandard,
+		}}
+		userRepo := &userRepoStubForGroupUpdate{}
+		svc := &adminServiceImpl{userGroupRateRepo: rateRepo, groupRepo: groupRepo, userRepo: userRepo}
+
+		err := svc.BatchSetGroupRateMultipliers(context.Background(), 10,
+			[]GroupRateMultiplierInput{{UserID: 42, RateMultiplier: 1.5}})
+		require.NoError(t, err)
+		require.False(t, userRepo.addGroupCalled)
+		require.Equal(t, int64(10), rateRepo.syncedGroupID)
+	})
+
+	t.Run("rate: subscription-type exclusive group skips membership", func(t *testing.T) {
+		rateRepo := &userGroupRateRepoStubForGroupRate{}
+		groupRepo := &groupRepoStubForGroupUpdate{group: &Group{
+			ID: 10, Name: "Sub", Status: StatusActive,
+			IsExclusive: true, SubscriptionType: SubscriptionTypeSubscription,
+		}}
+		userRepo := &userRepoStubForGroupUpdate{}
+		svc := &adminServiceImpl{userGroupRateRepo: rateRepo, groupRepo: groupRepo, userRepo: userRepo}
+
+		err := svc.BatchSetGroupRateMultipliers(context.Background(), 10,
+			[]GroupRateMultiplierInput{{UserID: 42, RateMultiplier: 1.5}})
+		require.NoError(t, err)
+		require.False(t, userRepo.addGroupCalled)
+		require.Equal(t, int64(10), rateRepo.syncedGroupID)
+	})
+
+	t.Run("rate: membership add failure aborts before writing rate", func(t *testing.T) {
+		rateRepo := &userGroupRateRepoStubForGroupRate{}
+		groupRepo := exclusiveStandard()
+		userRepo := &userRepoStubForGroupUpdate{addGroupErr: errors.New("db error")}
+		svc := &adminServiceImpl{userGroupRateRepo: rateRepo, groupRepo: groupRepo, userRepo: userRepo}
+
+		err := svc.BatchSetGroupRateMultipliers(context.Background(), 10,
+			[]GroupRateMultiplierInput{{UserID: 42, RateMultiplier: 1.5}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "add group")
+		require.True(t, userRepo.addGroupCalled)
+		// 关键：成员资格失败时不得写入专属倍率，避免「有倍率无访问」不一致态
+		require.Zero(t, rateRepo.syncedGroupID)
+	})
+
+	t.Run("rate: nil groupRepo (legacy wiring) is a no-op grant, still syncs", func(t *testing.T) {
+		rateRepo := &userGroupRateRepoStubForGroupRate{}
+		svc := &adminServiceImpl{userGroupRateRepo: rateRepo}
+
+		err := svc.BatchSetGroupRateMultipliers(context.Background(), 10,
+			[]GroupRateMultiplierInput{{UserID: 42, RateMultiplier: 1.5}})
+		require.NoError(t, err)
+		require.Equal(t, int64(10), rateRepo.syncedGroupID)
+	})
+
+	t.Run("rpm: exclusive group grants membership for non-nil override", func(t *testing.T) {
+		rateRepo := &userGroupRateRepoStubForGroupRate{}
+		groupRepo := exclusiveStandard()
+		userRepo := &userRepoStubForGroupUpdate{}
+		cache := &authCacheInvalidatorStub{}
+		svc := &adminServiceImpl{
+			userGroupRateRepo: rateRepo, groupRepo: groupRepo,
+			userRepo: userRepo, authCacheInvalidator: cache,
+		}
+		override := 20
+
+		err := svc.BatchSetGroupRPMOverrides(context.Background(), 10,
+			[]GroupRPMOverrideInput{{UserID: 42, RPMOverride: &override}})
+		require.NoError(t, err)
+		require.True(t, userRepo.addGroupCalled)
+		require.Equal(t, int64(42), userRepo.addedUserID)
+		require.Equal(t, int64(10), userRepo.addedGroupID)
+		require.Equal(t, int64(10), rateRepo.rpmSyncedGroupID)
+	})
+
+	t.Run("rpm: clear-only entry (nil override) does not grant membership", func(t *testing.T) {
+		rateRepo := &userGroupRateRepoStubForGroupRate{}
+		groupRepo := exclusiveStandard()
+		userRepo := &userRepoStubForGroupUpdate{}
+		svc := &adminServiceImpl{userGroupRateRepo: rateRepo, groupRepo: groupRepo, userRepo: userRepo}
+
+		err := svc.BatchSetGroupRPMOverrides(context.Background(), 10,
+			[]GroupRPMOverrideInput{{UserID: 42, RPMOverride: nil}})
+		require.NoError(t, err)
+		require.False(t, userRepo.addGroupCalled)
+		require.Equal(t, int64(10), rateRepo.rpmSyncedGroupID)
+	})
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2874,6 +2874,15 @@
         "thinkingRefModelForAnthropicCompat(originalModel)"
       ],
       "rationale": "Wiring of the compat-path thinking-reference helper in the Gemini messages-compat signature-retry. This is the ODD-ONE-OUT call site (keys on originalModel, not mappedModel); anchoring the wrapped call ensures an upstream merge cannot silently swap it to mappedModel (which would classify the gemini backend as non-strict and skip the required thinking-block strip, 400-ing the request)."
+    },
+    {
+      "path": "backend/internal/service/admin_service.go",
+      "must_contain": [
+        "func (s *adminServiceImpl) grantExclusiveGroupMembership(ctx context.Context, groupID int64, userIDs []int64) error {",
+        "TK(exclusive-membership rate-path): keep this hook on upstream merge",
+        "TK(exclusive-membership rpm-path): keep this hook on upstream merge"
+      ],
+      "rationale": "Groups-page 专属倍率/RPM 'add user' must also grant user_allowed_groups membership for exclusive (non-subscription) standard groups, mirroring upstream's own AdminUpdateAPIKeyGroupID / ReplaceUserGroup pattern (see PR #863). Membership (user_allowed_groups, gated by User.CanBindGroup) and per-user rate (user_group_rate) are SEPARATE stores; the upstream-owned BatchSetGroupRateMultipliers / BatchSetGroupRPMOverrides only wrote the rate row, so a user added via the groups page showed up unchecked on the users page and could not bind the exclusive group. The two grant hooks are small and compile-clean if dropped, and the regression test lives in an upstream-owned file (admin_service_group_rate_test.go) so a merge could revert hook+test together silently. This TK-owned, merge-survivable sentinel pins the helper definition plus both per-path call-site markers, so an upstream merge that rewrites either method FAILS the check instead of silently reintroducing the bug."
     }
   ]
 }


### PR DESCRIPTION
## 问题

在 `/admin/groups`,通过某个**专属分组**的「专属倍率」弹窗(为用户设置专属计费倍率)添加用户后,该分组**不会**出现在 `/admin/users` 该用户的分组里——管理员必须重新指定一次。该用户实际上也绑定/使用不了这个分组。

## 根因

「成员资格」和「专属倍率」是**两套独立存储**:

| 概念 | 存储 | 由谁写入 |
| --- | --- | --- |
| 专属分组**成员资格**(访问门禁,`User.CanBindGroup`) | `user_allowed_groups` 边(`user.AllowedGroups`) | 用户页复选框 |
| 每用户**倍率 / RPM** 覆盖 | `user_group_rate` 表 | 分组页 专属倍率 / RPM 弹窗 |

分组页保存走 `BatchSetGroupRateMultipliers → SyncGroupRateMultipliers`(裸 SQL),**只写倍率行、从不写 `allowed_groups` 成员资格**。对专属分组而言,倍率因此不可达(没有访问权),用户页读 `user.allowed_groups` → 复选框始终未勾选。

> 这两个方法是**上游(Wei-Shaw/sub2api)所有**;上游自己的 `AdminUpdateAPIKeyGroupID` / `ReplaceUserGroup` 路径其实**已经**会授予成员资格,只有这两条批量写入路径漏了。本 PR 即把它们补齐到上游自身的同一套语义。

## 修复

新增 `adminServiceImpl.grantExclusiveGroupMembership(ctx, groupID, userIDs)`,接到 `BatchSetGroupRateMultipliers` 与 `BatchSetGroupRPMOverrides` 两条路径上:

- **仅对「专属、非订阅」标准分组生效**(公开分组人人可用;订阅型分组走订阅授权)——与既有 `AdminUpdateAPIKeyGroupID` / `ReplaceUserGroup` 同一道闸。
- **仅追加、从不撤销。** 用默认倍率的成员在 `user_group_rate` 里没有行,若按倍率列表反向同步成员资格会误删他们。成员资格的移除仍由用户页(唯一权威入口)负责。这是有意为之、已注释的取舍。
- **先授权、后写入**:事务保护、幂等(`AddGroupToAllowedGroups`),并按用户失效鉴权缓存——任一步失败都不会留下「有倍率、无访问」的不一致态。
- RPM 路径只为非空(非清空)覆盖授权(清空不等于授予)。
- `groupRepo` / `userRepo` 为 nil 时安全降级 no-op(旧的/部分装配的单测不受影响)。

前端无需改动:`allowed_groups` 补齐后,用户页复选框自然反映。

## upstream merge 覆写防护

`admin_service.go` 与回归测试文件均为**上游所有**,未来 upstream merge 若重写这两个方法,可能把小 hook 连同测试一起**静默回退**(纯单测守不住——测试和 hook 同在上游文件里会被一起改掉)。因此在 `scripts/sentinels/gateway-tk.json`(**TK 自有、merge-survivable**)固定:helper 定义 + 两条 per-path `TK(exclusive-membership …)` 标记。该 sentinel 由通用 `check-gateway-tk.py` 校验,已接入 preflight 与 upstream-merge PR-shape workflow——未来 merge 丢掉任一 hook 会让检查**失败**而非静默复发。

## 验证

- 已 rebase 到最新 `origin/main`(含 grok 第七平台 #791、traj 导出 #792 等);clean auto-merge 后已**重新构建 + 跑全量 service 单测**确认合并态正确(非仅「无冲突」)。
- `go build ./...` ✅
- `go test -tags=unit ./...` ✅ —— `admin_service_group_rate_test.go` 新增 7 个子测试(专属:授权+写入;非专属/订阅型:跳过;授权失败必须在写入前中止;nil-groupRepo no-op;RPM 非空授权;RPM 仅清空跳过)
- `golangci-lint run ./internal/service/...` → 0 issues ✅
- `scripts/preflight.sh`(`PREFLIGHT_BASE=origin/main`)→ PASS ✅;upstream-override 门禁(纯插入)+ sentinel registry-update 门禁(已加锚点)均 rc=0,**无需 PR body marker**。
- 对抗式多 agent review(4 视角 + 逐条证伪):6 条原始发现 → 仅 2 条坐实,均为 completeness 级(一条是用户页移除路径上既有、与本 PR 无关的 `rpm_override` 清理不对称;一条文档偏好)。无正确性 / 回归缺陷。

## 评审说明

- 纯后端改动,无 Web surface 变更(`no-web-impact`)。
- 纯插入 diff(228+/0−),未删除任何上游文件。
- 合并方式:**Squash and merge**(TK fix)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
