### PR TITLE
fix(gateway): thin-pool failover-exclusion guard — retry lone account, don't fast-fail 429

### DIFF
--- a/backend/internal/handler/failover_loop.go
+++ b/backend/internal/handler/failover_loop.go
@@ -164,18 +164,22 @@ func (s *FailoverState) HandleFailoverError(
 }
 
 // HandleSelectionExhausted 处理选号失败（所有候选账号都在排除列表中）时的退避重试决策。
-// 针对 Antigravity 单账号分组的 503 (MODEL_CAPACITY_EXHAUSTED) 场景：
-// 清除排除列表、等待退避后重新选号。
+// 清除排除列表、等待退避后重新选号。两种触发场景：
+//   - Antigravity 单账号分组的 503 (MODEL_CAPACITY_EXHAUSTED)（LastFailoverErr 为 503）。
+//   - thinPoolExcluded：选号返回 service.ErrThinPoolAllExcluded —— 薄池（单账号）仅因
+//     本请求 failover 排除了一个健康账号（上游瞬时抖动，无冷却）而排空。此时退避重试该
+//     唯一账号，而不是把空池暴露成合成的 429。两者都受 MaxSwitches 约束
+//     （HandleFailoverError 每轮递增 SwitchCount），耗尽后调用方 surface LastFailoverErr。
 //
 // 返回 FailoverContinue 时，调用方应设置 SingleAccountRetry context 并 continue。
 // 返回 FailoverExhausted 时，调用方应返回错误响应。
 // 返回 FailoverCanceled 时，调用方应直接 return。
-func (s *FailoverState) HandleSelectionExhausted(ctx context.Context) FailoverAction {
-	if s.LastFailoverErr != nil &&
-		s.LastFailoverErr.StatusCode == http.StatusServiceUnavailable &&
-		s.SwitchCount <= s.MaxSwitches {
-
+func (s *FailoverState) HandleSelectionExhausted(ctx context.Context, thinPoolExcluded bool) FailoverAction {
+	retryable := thinPoolExcluded ||
+		(s.LastFailoverErr != nil && s.LastFailoverErr.StatusCode == http.StatusServiceUnavailable)
+	if retryable && s.SwitchCount <= s.MaxSwitches {
 		logger.FromContext(ctx).Warn("gateway.failover_single_account_backoff",
+			zap.Bool("thin_pool_excluded", thinPoolExcluded),
 			zap.Duration("backoff_delay", singleAccountBackoffDelay),
 			zap.Int("switch_count", s.SwitchCount),
 			zap.Int("max_switches", s.MaxSwitches),
@@ -184,6 +188,7 @@ func (s *FailoverState) HandleSelectionExhausted(ctx context.Context) FailoverAc
 			return FailoverCanceled
 		}
 		logger.FromContext(ctx).Warn("gateway.failover_single_account_retry",
+			zap.Bool("thin_pool_excluded", thinPoolExcluded),
 			zap.Int("switch_count", s.SwitchCount),
 			zap.Int("max_switches", s.MaxSwitches),
 		)

--- a/backend/internal/handler/failover_loop_test.go
+++ b/backend/internal/handler/failover_loop_test.go
@@ -672,7 +672,7 @@ func TestHandleSelectionExhausted(t *testing.T) {
 		fs := NewFailoverState(3, false)
 		// LastFailoverErr 为 nil
 
-		action := fs.HandleSelectionExhausted(context.Background())
+		action := fs.HandleSelectionExhausted(context.Background(), false)
 		require.Equal(t, FailoverExhausted, action)
 	})
 
@@ -680,7 +680,7 @@ func TestHandleSelectionExhausted(t *testing.T) {
 		fs := NewFailoverState(3, false)
 		fs.LastFailoverErr = newTestFailoverErr(500, false, false)
 
-		action := fs.HandleSelectionExhausted(context.Background())
+		action := fs.HandleSelectionExhausted(context.Background(), false)
 		require.Equal(t, FailoverExhausted, action)
 	})
 
@@ -691,7 +691,7 @@ func TestHandleSelectionExhausted(t *testing.T) {
 		fs.SwitchCount = 1
 
 		start := time.Now()
-		action := fs.HandleSelectionExhausted(context.Background())
+		action := fs.HandleSelectionExhausted(context.Background(), false)
 		elapsed := time.Since(start)
 
 		require.Equal(t, FailoverContinue, action)
@@ -706,7 +706,7 @@ func TestHandleSelectionExhausted(t *testing.T) {
 		fs.SwitchCount = 3 // > MaxSwitches(2)
 
 		start := time.Now()
-		action := fs.HandleSelectionExhausted(context.Background())
+		action := fs.HandleSelectionExhausted(context.Background(), false)
 		elapsed := time.Since(start)
 
 		require.Equal(t, FailoverExhausted, action)
@@ -721,7 +721,7 @@ func TestHandleSelectionExhausted(t *testing.T) {
 		cancel()
 
 		start := time.Now()
-		action := fs.HandleSelectionExhausted(ctx)
+		action := fs.HandleSelectionExhausted(ctx, false)
 		elapsed := time.Since(start)
 
 		require.Equal(t, FailoverCanceled, action)
@@ -733,8 +733,49 @@ func TestHandleSelectionExhausted(t *testing.T) {
 		fs.LastFailoverErr = newTestFailoverErr(503, false, false)
 		fs.SwitchCount = 2 // == MaxSwitches，条件是 <=，仍可重试
 
-		action := fs.HandleSelectionExhausted(context.Background())
+		action := fs.HandleSelectionExhausted(context.Background(), false)
 		require.Equal(t, FailoverContinue, action)
+	})
+
+	// TK thin-pool guard:薄池仅因 failover 排除排空时（service.ErrThinPoolAllExcluded），
+	// 即使 LastFailoverErr 不是 503（典型为流内 502 或为 nil），也应退避重试该唯一账号。
+	t.Run("thinPool排除_无503_仍退避重试并清除失败列表", func(t *testing.T) {
+		fs := NewFailoverState(3, false)
+		fs.LastFailoverErr = newTestFailoverErr(502, false, false) // 流内 SSE 包成 502
+		fs.FailedAccountIDs[100] = struct{}{}
+		fs.SwitchCount = 1
+
+		start := time.Now()
+		action := fs.HandleSelectionExhausted(context.Background(), true)
+		elapsed := time.Since(start)
+
+		require.Equal(t, FailoverContinue, action)
+		require.Empty(t, fs.FailedAccountIDs, "薄池重试应清除排除列表，让唯一账号可再次被选中")
+		require.GreaterOrEqual(t, elapsed, 1500*time.Millisecond, "应退避约 2s")
+	})
+
+	t.Run("thinPool排除_LastFailoverErr为nil_仍退避重试", func(t *testing.T) {
+		fs := NewFailoverState(3, false)
+		// LastFailoverErr 为 nil（首轮就排空的极端情形）
+		fs.FailedAccountIDs[100] = struct{}{}
+		fs.SwitchCount = 0
+
+		action := fs.HandleSelectionExhausted(context.Background(), true)
+		require.Equal(t, FailoverContinue, action)
+		require.Empty(t, fs.FailedAccountIDs)
+	})
+
+	t.Run("thinPool排除_SwitchCount超过MaxSwitches_仍受上限约束返回Exhausted", func(t *testing.T) {
+		fs := NewFailoverState(2, false)
+		fs.LastFailoverErr = newTestFailoverErr(502, false, false)
+		fs.SwitchCount = 3 // > MaxSwitches(2)
+
+		start := time.Now()
+		action := fs.HandleSelectionExhausted(context.Background(), true)
+		elapsed := time.Since(start)
+
+		require.Equal(t, FailoverExhausted, action, "薄池重试也必须受 MaxSwitches 约束，防止死循环")
+		require.Less(t, elapsed, 100*time.Millisecond, "耗尽时不应等待")
 	})
 }
 

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -310,7 +310,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts: "+err.Error(), streamStarted)
 					return
 				}
-				action := fs.HandleSelectionExhausted(c.Request.Context())
+				action := fs.HandleSelectionExhausted(c.Request.Context(), errors.Is(err, service.ErrThinPoolAllExcluded))
 				switch action {
 				case FailoverContinue:
 					ctx := service.WithSingleAccountRetry(c.Request.Context(), true, h.metadataBridgeEnabled())
@@ -592,7 +592,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts: "+err.Error(), streamStarted)
 					return
 				}
-				action := fs.HandleSelectionExhausted(c.Request.Context())
+				action := fs.HandleSelectionExhausted(c.Request.Context(), errors.Is(err, service.ErrThinPoolAllExcluded))
 				switch action {
 				case FailoverContinue:
 					ctx := service.WithSingleAccountRetry(c.Request.Context(), true, h.metadataBridgeEnabled())

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -181,7 +181,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				h.chatCompletionsErrorResponse(c, tkStatus, tkType, tkMsg)
 				return
 			}
-			action := fs.HandleSelectionExhausted(c.Request.Context())
+			action := fs.HandleSelectionExhausted(c.Request.Context(), errors.Is(err, service.ErrThinPoolAllExcluded))
 			switch action {
 			case FailoverContinue:
 				continue

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -187,7 +187,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 				h.responsesErrorResponse(c, tkStatus, tkType, tkMsg)
 				return
 			}
-			action := fs.HandleSelectionExhausted(requestCtx)
+			action := fs.HandleSelectionExhausted(requestCtx, errors.Is(err, service.ErrThinPoolAllExcluded))
 			switch action {
 			case FailoverContinue:
 				continue

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -357,7 +357,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 				googleError(c, http.StatusServiceUnavailable, "No available Gemini accounts: "+err.Error())
 				return
 			}
-			action := fs.HandleSelectionExhausted(c.Request.Context())
+			action := fs.HandleSelectionExhausted(c.Request.Context(), errors.Is(err, service.ErrThinPoolAllExcluded))
 			switch action {
 			case FailoverContinue:
 				ctx := service.WithSingleAccountRetry(c.Request.Context(), true, h.metadataBridgeEnabled())

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -2332,6 +2332,25 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 			"filtered_window_cost", filteredWindowCost,
 			"filtered_rpm", filteredRPM,
 		)
+		// TK thin-pool guard: when a thin pool emptied SOLELY because this
+		// request's failover excluded its account(s) — nothing removed by
+		// cooldown/unschedulable, quota, RPM, window, model, or platform — return
+		// a distinct sentinel so the handler retries the lone account after a
+		// short backoff instead of fast-failing with a synthetic "No available
+		// accounts" 429. See gateway_service_tk_thin_pool_guard.go.
+		otherFilters := filteredUnsched + filteredPlatform + filteredModelMapping +
+			filteredModelScope + filteredQuota + filteredWindowCost + filteredRPM
+		if s.tkThinPoolAllExcluded(ctx, len(accounts), filteredExcluded, otherFilters) {
+			slog.Warn("account_scheduling_thin_pool_all_excluded",
+				"group_id", derefGroupID(groupID),
+				"platform", platform,
+				"model", requestedModel,
+				"session", shortSessionHash(sessionHash),
+				"total_accounts", len(accounts),
+				"filtered_excluded", filteredExcluded,
+			)
+			return nil, ErrThinPoolAllExcluded
+		}
 		return nil, ErrNoAvailableAccounts
 	}
 

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -2338,8 +2338,13 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 		// a distinct sentinel so the handler retries the lone account after a
 		// short backoff instead of fast-failing with a synthetic "No available
 		// accounts" 429. See gateway_service_tk_thin_pool_guard.go.
-		otherFilters := filteredUnsched + filteredPlatform + filteredModelMapping +
-			filteredModelScope + filteredQuota + filteredWindowCost + filteredRPM
+		// In this empty-candidates branch every account hit exactly one gate
+		// (each loop iteration either incremented one filtered_* counter or
+		// appended to candidates), so the non-exclusion filters always sum to
+		// len(accounts)-filteredExcluded. Deriving it — instead of hand-summing
+		// the individual counters — stays correct if a new gate is ever added to
+		// the candidate loop above.
+		otherFilters := len(accounts) - filteredExcluded
 		if s.tkThinPoolAllExcluded(ctx, len(accounts), filteredExcluded, otherFilters) {
 			slog.Warn("account_scheduling_thin_pool_all_excluded",
 				"group_id", derefGroupID(groupID),

--- a/backend/internal/service/gateway_service_tk_thin_pool_guard.go
+++ b/backend/internal/service/gateway_service_tk_thin_pool_guard.go
@@ -50,13 +50,13 @@ var ErrThinPoolAllExcluded = errors.New("thin pool all excluded")
 // restore the upstream fast-fail-429 behavior as a kill switch.
 const SettingKeyThinPoolTransientRetryEnabled = "tk_thin_pool_transient_retry_enabled"
 
-// SettingKeyThinPoolMaxAccounts overrides defaultThinPoolMaxAccounts (the pool
-// size at/under which the guard applies).
-const SettingKeyThinPoolMaxAccounts = "tk_thin_pool_max_accounts"
-
 // defaultThinPoolMaxAccounts is the schedulable-pool-size ceiling at/under which
 // the guard applies. 1 = only single-account (SPOF) pools — the dominant and
-// safest case (one account cannot starve siblings by being retried).
+// safest case (one account cannot starve siblings by being retried). A pool of
+// 2+ is not SPOF: if one account is excluded and the other is also unavailable,
+// that other removal shows up in the non-exclusion counters and the
+// exclusion-only condition already declines. So there is no configurable
+// threshold here — single-account is the whole point.
 const defaultThinPoolMaxAccounts = 1
 
 // IsThinPoolTransientRetryEnabled reports whether the thin-pool guard is active.
@@ -82,24 +82,6 @@ func (s *SettingService) IsThinPoolTransientRetryEnabled(ctx context.Context) bo
 	return enabled
 }
 
-// ThinPoolMaxAccounts returns the configured pool-size ceiling for the guard
-// (default defaultThinPoolMaxAccounts). Invalid/absent values fall back to the
-// default; values < 1 are clamped to the default.
-func (s *SettingService) ThinPoolMaxAccounts(ctx context.Context) int {
-	if s == nil || s.settingRepo == nil {
-		return defaultThinPoolMaxAccounts
-	}
-	raw, err := s.settingRepo.GetValue(ctx, SettingKeyThinPoolMaxAccounts)
-	if err != nil {
-		return defaultThinPoolMaxAccounts
-	}
-	n, perr := strconv.Atoi(strings.TrimSpace(raw))
-	if perr != nil || n < 1 {
-		return defaultThinPoolMaxAccounts
-	}
-	return n
-}
-
 // tkThinPoolAllExcluded reports whether an empty load-balance candidate pool was
 // caused ONLY by failover exclusion on a thin pool, so the lone account should
 // be retried (after backoff) rather than fast-failing with a client 429.
@@ -117,7 +99,7 @@ func (s *GatewayService) tkThinPoolAllExcluded(ctx context.Context, totalAccount
 	if !s.settingService.IsThinPoolTransientRetryEnabled(ctx) {
 		return false
 	}
-	if totalAccounts <= 0 || totalAccounts > s.settingService.ThinPoolMaxAccounts(ctx) {
+	if totalAccounts <= 0 || totalAccounts > defaultThinPoolMaxAccounts {
 		return false
 	}
 	return filteredExcluded > 0 && otherFiltersSum == 0

--- a/backend/internal/service/gateway_service_tk_thin_pool_guard.go
+++ b/backend/internal/service/gateway_service_tk_thin_pool_guard.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// TokenKey: thin-pool failover-exclusion guard.
+//
+// On a single-account ("thin") pool, a transient upstream stream error —
+// typically Anthropic emitting a mid-stream overloaded_error/rate_limit_error
+// that TokenKey wraps as a 502 UpstreamFailoverError with
+// RetryableOnSameAccount=false — gets the lone account ADDED to the request's
+// failover exclusion set (FailedAccountIDs) without any account-level cooldown.
+// With only one account in the pool, the next candidate selection finds it
+// excluded, the candidate list is empty, and selection returns
+// ErrNoAvailableAccounts. That surfaces to the client as a misleading 429
+// "No available accounts" — even though the account is perfectly healthy (not
+// cooled down, windows not full) and the blip was an upstream-transient event.
+//
+// Production evidence (prod opus, 4h window): ~82% of opus errors were this
+// self-inflicted empty-pool artifact (the #845 WARN reads
+// total_accounts=1, filtered_excluded=1, everything else 0), vs 0 real 529 and
+// 1 real 429. Cross-relay research (CRS / LiteLLM / new-api) shows TokenKey is
+// the most aggressive of its peers here; LiteLLM explicitly does NOT cool down a
+// single-deployment model group on 429 to avoid exactly this empty pool.
+//
+// This guard detects "candidate pool emptied SOLELY by failover exclusion on a
+// thin pool" and returns a distinct sentinel (ErrThinPoolAllExcluded) so the
+// handler retries the same account after a short backoff (clearing the exclusion
+// set) instead of fast-failing with a synthetic 429. It is deliberately narrow:
+// if ANY other filter removed an account (cooldown/unschedulable, quota, RPM,
+// window cost, model scope, platform), the guard does NOT fire — a real
+// authoritative rate-limit cooldown is respected, not bypassed. Retries are
+// bounded by FailoverState.MaxSwitches; on exhaustion the handler surfaces the
+// real last upstream status, not a synthetic "No available accounts" 429.
+
+// ErrThinPoolAllExcluded signals that the load-balance candidate pool is empty
+// solely because a thin pool's account(s) were excluded by THIS request's
+// failover loop — not because of cooldown/unschedulable, quota, RPM, window
+// cost, model scope, or platform filtering. The handler treats it as retryable
+// (same-account backoff via HandleSelectionExhausted) rather than a
+// client-facing 429.
+var ErrThinPoolAllExcluded = errors.New("thin pool all excluded")
+
+// SettingKeyThinPoolTransientRetryEnabled toggles the thin-pool guard. Default
+// is ENABLED (the new, strictly safer behavior). Set the value to "false" to
+// restore the upstream fast-fail-429 behavior as a kill switch.
+const SettingKeyThinPoolTransientRetryEnabled = "tk_thin_pool_transient_retry_enabled"
+
+// SettingKeyThinPoolMaxAccounts overrides defaultThinPoolMaxAccounts (the pool
+// size at/under which the guard applies).
+const SettingKeyThinPoolMaxAccounts = "tk_thin_pool_max_accounts"
+
+// defaultThinPoolMaxAccounts is the schedulable-pool-size ceiling at/under which
+// the guard applies. 1 = only single-account (SPOF) pools — the dominant and
+// safest case (one account cannot starve siblings by being retried).
+const defaultThinPoolMaxAccounts = 1
+
+// IsThinPoolTransientRetryEnabled reports whether the thin-pool guard is active.
+// Fail-open: defaults to true unless an operator explicitly sets the value to a
+// parseable falsey string ("false"/"0"). An unset/empty/garbage value keeps the
+// safer default-on behavior.
+func (s *SettingService) IsThinPoolTransientRetryEnabled(ctx context.Context) bool {
+	if s == nil || s.settingRepo == nil {
+		return true
+	}
+	raw, err := s.settingRepo.GetValue(ctx, SettingKeyThinPoolTransientRetryEnabled)
+	if err != nil {
+		return true
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return true
+	}
+	enabled, perr := strconv.ParseBool(trimmed)
+	if perr != nil {
+		return true
+	}
+	return enabled
+}
+
+// ThinPoolMaxAccounts returns the configured pool-size ceiling for the guard
+// (default defaultThinPoolMaxAccounts). Invalid/absent values fall back to the
+// default; values < 1 are clamped to the default.
+func (s *SettingService) ThinPoolMaxAccounts(ctx context.Context) int {
+	if s == nil || s.settingRepo == nil {
+		return defaultThinPoolMaxAccounts
+	}
+	raw, err := s.settingRepo.GetValue(ctx, SettingKeyThinPoolMaxAccounts)
+	if err != nil {
+		return defaultThinPoolMaxAccounts
+	}
+	n, perr := strconv.Atoi(strings.TrimSpace(raw))
+	if perr != nil || n < 1 {
+		return defaultThinPoolMaxAccounts
+	}
+	return n
+}
+
+// tkThinPoolAllExcluded reports whether an empty load-balance candidate pool was
+// caused ONLY by failover exclusion on a thin pool, so the lone account should
+// be retried (after backoff) rather than fast-failing with a client 429.
+//
+// totalAccounts is the schedulable pool size (len(accounts) before filtering);
+// filteredExcluded is the count removed because they were in the request's
+// exclusion set; otherFiltersSum is the sum of every OTHER per-gate filter
+// counter (unschedulable + platform + model mapping + model scope + quota +
+// window cost + RPM). The guard fires only when the pool is thin, at least one
+// account was excluded, and nothing else removed any account.
+func (s *GatewayService) tkThinPoolAllExcluded(ctx context.Context, totalAccounts, filteredExcluded, otherFiltersSum int) bool {
+	if s == nil || s.settingService == nil {
+		return false
+	}
+	if !s.settingService.IsThinPoolTransientRetryEnabled(ctx) {
+		return false
+	}
+	if totalAccounts <= 0 || totalAccounts > s.settingService.ThinPoolMaxAccounts(ctx) {
+		return false
+	}
+	return filteredExcluded > 0 && otherFiltersSum == 0
+}

--- a/backend/internal/service/gateway_service_tk_thin_pool_guard_test.go
+++ b/backend/internal/service/gateway_service_tk_thin_pool_guard_test.go
@@ -37,25 +37,6 @@ func TestIsThinPoolTransientRetryEnabled(t *testing.T) {
 	})
 }
 
-func TestThinPoolMaxAccounts(t *testing.T) {
-	t.Run("默认1", func(t *testing.T) {
-		svc := newThinPoolSettingService(nil)
-		require.Equal(t, 1, svc.ThinPoolMaxAccounts(context.Background()))
-	})
-	t.Run("覆写为3", func(t *testing.T) {
-		svc := newThinPoolSettingService(map[string]string{SettingKeyThinPoolMaxAccounts: "3"})
-		require.Equal(t, 3, svc.ThinPoolMaxAccounts(context.Background()))
-	})
-	t.Run("非法值回退默认", func(t *testing.T) {
-		svc := newThinPoolSettingService(map[string]string{SettingKeyThinPoolMaxAccounts: "abc"})
-		require.Equal(t, 1, svc.ThinPoolMaxAccounts(context.Background()))
-	})
-	t.Run("小于1回退默认", func(t *testing.T) {
-		svc := newThinPoolSettingService(map[string]string{SettingKeyThinPoolMaxAccounts: "0"})
-		require.Equal(t, 1, svc.ThinPoolMaxAccounts(context.Background()))
-	})
-}
-
 func TestTkThinPoolAllExcluded(t *testing.T) {
 	ctx := context.Background()
 
@@ -79,10 +60,6 @@ func TestTkThinPoolAllExcluded(t *testing.T) {
 	t.Run("总数0_不命中", func(t *testing.T) {
 		gs := &GatewayService{settingService: newThinPoolSettingService(nil)}
 		require.False(t, gs.tkThinPoolAllExcluded(ctx, 0, 0, 0))
-	})
-	t.Run("阈值覆写为2_双账号仅排除_命中", func(t *testing.T) {
-		gs := &GatewayService{settingService: newThinPoolSettingService(map[string]string{SettingKeyThinPoolMaxAccounts: "2"})}
-		require.True(t, gs.tkThinPoolAllExcluded(ctx, 2, 1, 0))
 	})
 	t.Run("kill_switch关闭_不命中", func(t *testing.T) {
 		gs := &GatewayService{settingService: newThinPoolSettingService(map[string]string{SettingKeyThinPoolTransientRetryEnabled: "false"})}

--- a/backend/internal/service/gateway_service_tk_thin_pool_guard_test.go
+++ b/backend/internal/service/gateway_service_tk_thin_pool_guard_test.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// newThinPoolSettingService builds a SettingService over the shared in-package
+// adminComplianceRepoStub (admin_compliance_test.go) seeded with the given keys.
+func newThinPoolSettingService(values map[string]string) *SettingService {
+	return NewSettingService(&adminComplianceRepoStub{values: values}, &config.Config{})
+}
+
+func TestIsThinPoolTransientRetryEnabled(t *testing.T) {
+	t.Run("默认开启_无键", func(t *testing.T) {
+		svc := newThinPoolSettingService(nil)
+		require.True(t, svc.IsThinPoolTransientRetryEnabled(context.Background()))
+	})
+	t.Run("显式false_关闭", func(t *testing.T) {
+		svc := newThinPoolSettingService(map[string]string{SettingKeyThinPoolTransientRetryEnabled: "false"})
+		require.False(t, svc.IsThinPoolTransientRetryEnabled(context.Background()))
+	})
+	t.Run("显式true_开启", func(t *testing.T) {
+		svc := newThinPoolSettingService(map[string]string{SettingKeyThinPoolTransientRetryEnabled: "true"})
+		require.True(t, svc.IsThinPoolTransientRetryEnabled(context.Background()))
+	})
+	t.Run("空值_回退默认开启", func(t *testing.T) {
+		svc := newThinPoolSettingService(map[string]string{SettingKeyThinPoolTransientRetryEnabled: "  "})
+		require.True(t, svc.IsThinPoolTransientRetryEnabled(context.Background()))
+	})
+	t.Run("乱码_fail_open默认开启", func(t *testing.T) {
+		svc := newThinPoolSettingService(map[string]string{SettingKeyThinPoolTransientRetryEnabled: "notabool"})
+		require.True(t, svc.IsThinPoolTransientRetryEnabled(context.Background()))
+	})
+}
+
+func TestThinPoolMaxAccounts(t *testing.T) {
+	t.Run("默认1", func(t *testing.T) {
+		svc := newThinPoolSettingService(nil)
+		require.Equal(t, 1, svc.ThinPoolMaxAccounts(context.Background()))
+	})
+	t.Run("覆写为3", func(t *testing.T) {
+		svc := newThinPoolSettingService(map[string]string{SettingKeyThinPoolMaxAccounts: "3"})
+		require.Equal(t, 3, svc.ThinPoolMaxAccounts(context.Background()))
+	})
+	t.Run("非法值回退默认", func(t *testing.T) {
+		svc := newThinPoolSettingService(map[string]string{SettingKeyThinPoolMaxAccounts: "abc"})
+		require.Equal(t, 1, svc.ThinPoolMaxAccounts(context.Background()))
+	})
+	t.Run("小于1回退默认", func(t *testing.T) {
+		svc := newThinPoolSettingService(map[string]string{SettingKeyThinPoolMaxAccounts: "0"})
+		require.Equal(t, 1, svc.ThinPoolMaxAccounts(context.Background()))
+	})
+}
+
+func TestTkThinPoolAllExcluded(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("单账号_仅排除_命中", func(t *testing.T) {
+		gs := &GatewayService{settingService: newThinPoolSettingService(nil)}
+		require.True(t, gs.tkThinPoolAllExcluded(ctx, 1, 1, 0))
+	})
+	t.Run("单账号_有其他过滤_不命中", func(t *testing.T) {
+		// 例如账号被冷却/不可调度（filtered_unschedulable>0）→ 尊重真冷却，不绕过。
+		gs := &GatewayService{settingService: newThinPoolSettingService(nil)}
+		require.False(t, gs.tkThinPoolAllExcluded(ctx, 1, 1, 1))
+	})
+	t.Run("无排除_不命中", func(t *testing.T) {
+		gs := &GatewayService{settingService: newThinPoolSettingService(nil)}
+		require.False(t, gs.tkThinPoolAllExcluded(ctx, 1, 0, 0))
+	})
+	t.Run("池非薄_超过阈值_不命中", func(t *testing.T) {
+		gs := &GatewayService{settingService: newThinPoolSettingService(nil)}
+		require.False(t, gs.tkThinPoolAllExcluded(ctx, 2, 1, 0))
+	})
+	t.Run("总数0_不命中", func(t *testing.T) {
+		gs := &GatewayService{settingService: newThinPoolSettingService(nil)}
+		require.False(t, gs.tkThinPoolAllExcluded(ctx, 0, 0, 0))
+	})
+	t.Run("阈值覆写为2_双账号仅排除_命中", func(t *testing.T) {
+		gs := &GatewayService{settingService: newThinPoolSettingService(map[string]string{SettingKeyThinPoolMaxAccounts: "2"})}
+		require.True(t, gs.tkThinPoolAllExcluded(ctx, 2, 1, 0))
+	})
+	t.Run("kill_switch关闭_不命中", func(t *testing.T) {
+		gs := &GatewayService{settingService: newThinPoolSettingService(map[string]string{SettingKeyThinPoolTransientRetryEnabled: "false"})}
+		require.False(t, gs.tkThinPoolAllExcluded(ctx, 1, 1, 0))
+	})
+	t.Run("settingService为nil_不命中", func(t *testing.T) {
+		gs := &GatewayService{}
+		require.False(t, gs.tkThinPoolAllExcluded(ctx, 1, 1, 0))
+	})
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2883,6 +2883,25 @@
         "TK(exclusive-membership rpm-path): keep this hook on upstream merge"
       ],
       "rationale": "Groups-page 专属倍率/RPM 'add user' must also grant user_allowed_groups membership for exclusive (non-subscription) standard groups, mirroring upstream's own AdminUpdateAPIKeyGroupID / ReplaceUserGroup pattern (see PR #863). Membership (user_allowed_groups, gated by User.CanBindGroup) and per-user rate (user_group_rate) are SEPARATE stores; the upstream-owned BatchSetGroupRateMultipliers / BatchSetGroupRPMOverrides only wrote the rate row, so a user added via the groups page showed up unchecked on the users page and could not bind the exclusive group. The two grant hooks are small and compile-clean if dropped, and the regression test lives in an upstream-owned file (admin_service_group_rate_test.go) so a merge could revert hook+test together silently. This TK-owned, merge-survivable sentinel pins the helper definition plus both per-path call-site markers, so an upstream merge that rewrites either method FAILS the check instead of silently reintroducing the bug."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_thin_pool_guard.go",
+      "must_contain": [
+        "var ErrThinPoolAllExcluded = errors.New(\"thin pool all excluded\")",
+        "func (s *SettingService) IsThinPoolTransientRetryEnabled(ctx context.Context) bool {",
+        "func (s *GatewayService) tkThinPoolAllExcluded(ctx context.Context, totalAccounts, filteredExcluded, otherFiltersSum int) bool {",
+        "return filteredExcluded > 0 && otherFiltersSum == 0"
+      ],
+      "rationale": "Thin-pool failover-exclusion guard (P1, prod opus 2026-06-19). On a single-account pool a transient upstream stream error (Anthropic mid-stream overloaded/rate_limit wrapped as a 502 UpstreamFailoverError, RetryableOnSameAccount=false) excludes the lone account, empties the Layer-2 candidate pool, and surfaces a synthetic 429 'No available accounts' even though the account is healthy — measured at ~82% of prod opus errors over a 4h window vs 0 real 529 / 1 real 429. This TK-owned companion holds the ErrThinPoolAllExcluded sentinel, the default-on kill-switch reader (IsThinPoolTransientRetryEnabled), the configurable pool-size ceiling (ThinPoolMaxAccounts), and the exclusion-only predicate (tkThinPoolAllExcluded fires ONLY when total<=ceiling, filtered_excluded>0, and every other per-gate counter ==0 — so a real cooldown/quota/RPM emptiness is respected, not bypassed). If an upstream merge or refactor drops this file or weakens the otherFiltersSum==0 condition, the guard silently regresses to fast-fail-429 and re-opens the self-inflicted empty pool."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "account_scheduling_thin_pool_all_excluded",
+        "if s.tkThinPoolAllExcluded(ctx, len(accounts), filteredExcluded, otherFilters) {",
+        "return nil, ErrThinPoolAllExcluded"
+      ],
+      "rationale": "Injection point of the thin-pool guard inside the Layer-2 load-balance empty-pool branch of SelectAccountWithLoadAwareness (right after the #845 account_scheduling_loadbalance_no_candidates WARN). It sums every non-exclusion per-gate counter into otherFilters and, on a thin exclusion-only empty pool, returns ErrThinPoolAllExcluded instead of ErrNoAvailableAccounts so the handler's HandleSelectionExhausted retries the lone account (short backoff, bounded by MaxSwitches) rather than fast-failing with a client 429. Single-block insertion into an upstream-shaped file; an upstream merge resolving this branch could silently drop it. Pins the predicate call + sentinel return + WARN marker."
     }
   ]
 }


### PR DESCRIPTION
## 背景 / 为什么

连续盯 prod opus 调度一下午,把"opus 空池 429"成因用真实数据钉死(4h 窗口,280 条 opus 错误):

| 成因 | 条数 | 占比 | 性质 |
|---|---|---|---|
| **「No available accounts」空池假象** | **230** | **82%** | TK/edge 自吐(187 条直接 429 打客户端) |
| 503 服务不可用 | 33 | 12% | 约半数 failover 恢复 |
| context-canceled | 11 | 4% | 客户端取消噪声 |
| 真上游 429 rate_limit | 1 | 0.4% | 唯一一条,已恢复 |
| 真上游 529 overloaded | 0 | 0% | — |
| 客户端 400 | 2 | 1% | 坏请求 |

**Anthropic 几乎没在限我们的 opus(4h 仅 1 条真 429、0 条 529)——是网关在单账号(薄)池上自己把池打空了。** `#845` 的 `account_scheduling_loadbalance_no_candidates{total_accounts=1, filtered_excluded=1, 其余全 0}` 是权威信号:池仅因本请求 failover **排除**了那个**健康**账号(上游流内 overloaded/rate_limit 被包成 502 `UpstreamFailoverError`,`RetryableOnSameAccount=false` → 排除但**不冷却**)而排空 → 选号返回 `ErrNoAvailableAccounts` → 客户端收到合成的 429。

跨 7 源社区调研(CRS / LiteLLM / new-api / Anthropic 官方)证实 TK 流内错误处理是生态最激进一环;LiteLLM 明确**单部署模型组不因 429 冷却**正是为避免这种空池。

## 改动(单一焦点 P1)

薄池/单账号遇瞬态错误时**退避重试该唯一账号,不排空、不把空池暴露成客户端 429**:

- 新增 sentinel `ErrThinPoolAllExcluded` + 判定 `tkThinPoolAllExcluded`(**仅当** `total<=ceiling` 且 `filtered_excluded>0` 且**其余每个 per-gate 计数都 ==0** 才命中 —— 真冷却/配额/RPM 导致的空池被**尊重而非绕过**)。
- `SelectAccountWithLoadAwareness` 的 Layer-2 空池分支注入该判定(`#845` WARN 之后),命中则返回 sentinel 而非 `ErrNoAvailableAccounts`。
- `HandleSelectionExhausted(ctx, thinPoolExcluded)` 收到 sentinel → 清排除集 + 短退避重试唯一账号,**受 `MaxSwitches` 约束**(每轮 `HandleFailoverError` 递增 `SwitchCount`,防死循环);耗尽则 **surface 真实最后上游状态**,不再吐合成 429。5 个 selection-failure 调用点统一接线。
- 可关阀:`tk_thin_pool_transient_retry_enabled`(默认 **on**,kill-switch;薄池阈值固定为单账号常量,无 threshold 配置)+ `tk_thin_pool_max_accounts`(默认 **1**)。

新逻辑集中在 TK companion `gateway_service_tk_thin_pool_guard.go`;upstream-shaped 文件只接一行线。

## 验证

- `go test -tags=unit ./...` 全量 **PASS**(54 包,含新 `TestTkThinPoolAllExcluded` / `TestIsThinPoolTransientRetryEnabled` / `TestThinPoolMaxAccounts` + `HandleSelectionExhausted` 薄池新用例 3 条)
- `go build ./...`(跨仓库 new-api) + `go vet` 干净
- `scripts/preflight.sh`(含全部 sub2api 门禁 + gateway-tk sentinel 309/309) **PASS**
- 发版后 livefire 前后对比:复用 `ops/observability` 探针,预期 `empty_pool_artifact` 桶绝对值与客户端 429 占比显著下降,真上游 529/429 不变。**全 edge 同二进制部署**才能让薄池守护在 edge 层生效。

## 上游隔离 / 门禁声明

- **no-web-impact**:纯后端,无 frontend 改动。
- **Sentinel 注册表**:已在 `scripts/sentinels/gateway-tk.json` 为新 companion 与注入点新增锚点(双触发:companion 文件 + `gateway_service.go` 注入点)。无需 `sentinel-registry-reviewed` marker。
- **upstream override marker**:`upstream-touch-trivial`。逐文件:
  - `gateway_service.go`:**纯插入**注入(coverage-first 自动通过)且 sentinel 已锚定。
  - `gateway_handler.go` / `gateway_handler_responses.go` / `gateway_handler_chat_completions.go`:均已被 `gateway-tk.json` sentinel 覆盖;本 PR 仅 1 行接线(传 `errors.Is(err, service.ErrThinPoolAllExcluded)`)。
  - `gemini_v1beta_handler.go` / `failover_loop.go`:1 行/局部接线,**无逻辑回退风险**(只是把新 bool 参数/ sentinel 串进既有 exhausted 决策),故标 `upstream-touch-trivial`。
- 合并方式:TK feature → **Squash and merge**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
