### PR TITLE
fix(grok): include grok in OpenAI-compat capability gate so grok accounts schedule

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1275,8 +1275,11 @@ func (a *Account) openAIEndpointCapabilitySet() (map[string]bool, bool) {
 }
 
 func (a *Account) SupportsOpenAIImageCapability(capability OpenAIImagesCapability) bool {
-	// newapi 走 OpenAI 协议与同一套 image 能力；与 IsOpenAICompatPoolMember 一致
-	if !a.IsOpenAI() && a.Platform != PlatformNewAPI {
+	// openai / newapi / grok 走同一套 OpenAI 协议与 image 能力；用 compat-pool 平台
+	// 谓词作单一真值源（含 grok 第七平台），避免硬编码 openai||newapi 列表漏掉新平台。
+	// 历史 bug：只判 IsOpenAI()||newapi 时 grok 账号被 accountSupportsOpenAICapabilities
+	// 在每个 chat completions 选号上排除，导致 grok 全程 "no available accounts"。
+	if !IsOpenAICompatPlatform(a.Platform) {
 		return false
 	}
 	switch capability {

--- a/backend/internal/service/account_tk_grok_capability_test.go
+++ b/backend/internal/service/account_tk_grok_capability_test.go
@@ -1,0 +1,52 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for the grok (seventh platform) direct-scheduling bug.
+//
+// Every OpenAI-compat selection runs each candidate through
+// accountSupportsOpenAICapabilities (openai_account_scheduler.go). For a grok
+// account that funnels into Account.SupportsOpenAIImageCapability, which
+// hardcoded an "openai || newapi" allowlist and never included grok. So a
+// schedulable grok account in a grok group was silently excluded on EVERY chat
+// completions request, and the gateway fast-failed with "no available accounts"
+// (excluded_account_count=0). grok was never exercised in production (first /
+// only grok account, last_used=never), so this latent gap only surfaced on the
+// first real request.
+//
+// The capability gate must treat grok like the other OpenAI-compat platforms
+// (openai / newapi): grok rides the same OpenAI wire protocol and image surface.
+func TestGrokAccount_PassesOpenAICompatCapabilityGate(t *testing.T) {
+	grok := &Account{
+		ID:          1,
+		Platform:    PlatformGrok,
+		Type:        AccountTypeOAuth,
+		ChannelType: 0,
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	// Chat-completions selection passes requiredImageCapability="" (no image
+	// requirement). The grok account MUST NOT be excluded by the capability gate.
+	require.True(t,
+		accountSupportsOpenAICapabilities(grok, OpenAIEndpointCapabilityChatCompletions, ""),
+		"grok account must pass the OpenAI-compat capability gate for chat completions",
+	)
+
+	// The underlying image-capability predicate must recognize grok as an
+	// OpenAI-compat platform (true for the no-requirement case).
+	require.True(t, grok.SupportsOpenAIImageCapability(""),
+		"grok must be recognized as an OpenAI-compat platform")
+
+	// grok image generation (oauth account) is also supported.
+	require.True(t, grok.SupportsOpenAIImageCapability(OpenAIImagesCapabilityBasic),
+		"grok oauth account supports basic image capability")
+	require.True(t, grok.SupportsOpenAIImageCapability(OpenAIImagesCapabilityNative),
+		"grok oauth account supports native image capability")
+}

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -141,6 +141,16 @@
       "path": "backend/internal/handler/admin/group_handler.go",
       "must_contain": ["antigravity newapi kiro grok"],
       "rationale": "grok must be an accepted group Platform value on the create/update admin DTOs (CreateGroupRequest/UpdateGroupRequest `oneof`). TK has appended a platform to this exact binding three times (newapi, kiro #481, grok #791); an upstream merge that reverts the oneof to the upstream/earlier platform set silently strips grok (and kiro/newapi), leaving platform=grok accounts with no schedulable group. Pinning the extended enum tail makes such a revert fail the merge sentinel check."
+    },
+    {
+      "path": "backend/internal/service/account.go",
+      "must_contain": ["IsOpenAICompatPlatform(a.Platform)"],
+      "rationale": "grok must be INSIDE the OpenAI-compat image-capability gate. accountSupportsOpenAICapabilities (openai_account_scheduler.go) runs Account.SupportsOpenAIImageCapability on EVERY OpenAI-compat candidate selection; for a non-openai account that predicate IS the gate. It previously hardcoded `!a.IsOpenAI() && a.Platform != PlatformNewAPI`, silently excluding every grok account so all grok chat/image requests fast-failed with 'no available accounts' (excluded_account_count=0) — the marquee first-real-use scheduling bug (grok last_used=never until then; survived restart because it is a deterministic logic gate). Switching it to IsOpenAICompatPlatform(a.Platform) (the openai/newapi/grok single-source predicate) fixed it. No compile error and no other test pinned this line, so an upstream merge that reverts it to the hardcoded openai||newapi list would silently re-break grok scheduling — this anchor catches that revert."
+    },
+    {
+      "path": "backend/internal/service/account_tk_grok_capability_test.go",
+      "must_contain": ["TestGrokAccount_PassesOpenAICompatCapabilityGate"],
+      "rationale": "Load-bearing QA evidence for the grok OpenAI-compat capability gate (see the account.go anchor above). Guards against silent re-introduction of the 'grok excluded from every OpenAI-compat selection' bug."
     }
   ]
 }


### PR DESCRIPTION
## 问题

可调度的 `platform=grok` 账号放进 `platform=grok` 组后，**永远选不中** —— 每个 grok chat-completions 请求秒级 `429 "no available accounts"`（`excluded_account_count=0`），尽管账号 schedulable、OAuth token 健康、已在 grok 组里。重启/重新发版都不变 → 确定性。

## 根因

每个 OpenAI 兼容选号都会让候选账号过 `accountSupportsOpenAICapabilities`，它对非 openai 账号返回 `Account.SupportsOpenAIImageCapability(requiredImageCapability)`。该谓词硬编码了 `openai || newapi` 白名单：

```go
if !a.IsOpenAI() && a.Platform != PlatformNewAPI {
    return false
}
```

它从没为 grok（第七平台，#791）更新过。于是 grok 账号在**每个** chat-completions 请求上都被这道资格门判 `false` → 排除 → `ErrNoAvailableAccounts`。因为 grok 在生产里从没被真实调度过（首个/唯一 grok 账号，`last_used=never`），这个潜伏缺口直到首次真实使用才暴露。

这也解释了为什么重启/重新发版都不管用：这是**确定性逻辑门**，不是状态陈旧。（`newapi` 能跑因为在白名单里；`openai` 走 `IsOpenAI()`。）

诊断细节：请求确实到达 edge、组/平台/账号都正确解析为 grok；`excluded_account_count=0` 是 handler 自己的计数，不代表池空 —— 池里有账号，是被这道资格门剔除的。

## 修复

改用 canonical 的 `IsOpenAICompatPlatform(a.Platform)` 单一真值谓词（openai/newapi/grok）替代硬编码列表，任何未来兼容平台自动纳入，避免再次漏掉。

## 测试

新增 `account_tk_grok_capability_test.go` 回归测试：断言 grok 账号通过 OpenAI 兼容资格门（chat + image）。修复前失败、修复后通过。`go test -tags=unit ./...` 全绿，preflight 全绿。

no-web-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)