### PR TITLE
perf(admin): memoize per-row template helpers in Users/Channels/Accounts tables

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 489,
-  "hash": "352a15d3b2027649c6fa66082386394af31652d57c38c41b7d08c17e0d306662",
+  "hash": "ee5622e266c12579ee30edec7b1155e038d650265aa473406cb83e530d883ba7",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -221,17 +221,17 @@
               <PlatformTypeBadge :platform="row.platform" :type="row.type" :plan-type="row.credentials?.plan_type" :privacy-mode="row.extra?.privacy_mode" :subscription-expires-at="row.credentials?.subscription_expires_at" />
               <ChannelTypeBadge :platform="row.platform" :channel-type="row.channel_type" />
               <span
-                v-if="getOpenAICompactLabel(row)"
-                :class="['inline-block rounded px-1.5 py-0.5 text-[10px] font-medium', getOpenAICompactClass(row)]"
-                :title="getOpenAICompactTitle(row)"
+                v-if="platformTypeBadgesById[row.id].openaiCompactLabel"
+                :class="['inline-block rounded px-1.5 py-0.5 text-[10px] font-medium', platformTypeBadgesById[row.id].openaiCompactClass]"
+                :title="platformTypeBadgesById[row.id].openaiCompactTitle"
               >
-                {{ getOpenAICompactLabel(row) }}
+                {{ platformTypeBadgesById[row.id].openaiCompactLabel }}
               </span>
               <span
-                v-if="getAntigravityTierLabel(row)"
-                :class="['inline-block rounded px-1.5 py-0.5 text-[10px] font-medium', getAntigravityTierClass(row)]"
+                v-if="platformTypeBadgesById[row.id].antigravityTierLabel"
+                :class="['inline-block rounded px-1.5 py-0.5 text-[10px] font-medium', platformTypeBadgesById[row.id].antigravityTierClass]"
               >
-                {{ getAntigravityTierLabel(row) }}
+                {{ platformTypeBadgesById[row.id].antigravityTierLabel }}
               </span>
             </div>
           </template>
@@ -1102,6 +1102,37 @@ function getAntigravityTierClass(row: any): string {
     default: return ''
   }
 }
+
+// Memoized platform_type badge derivation keyed by account id. The cell reads
+// platformTypeBadgesById[row.id] instead of calling 5 helpers (each re-walking
+// row.extra) per row on every reactivity tick. Recomputes only when the account
+// list changes; reuses the upstream helpers so each field is byte-identical to
+// the per-call path.
+const platformTypeBadgesById = computed<Record<number, {
+  openaiCompactLabel: string | null
+  openaiCompactClass: string
+  openaiCompactTitle: string
+  antigravityTierLabel: string | null
+  antigravityTierClass: string
+}>>(() => {
+  const byId: Record<number, {
+    openaiCompactLabel: string | null
+    openaiCompactClass: string
+    openaiCompactTitle: string
+    antigravityTierLabel: string | null
+    antigravityTierClass: string
+  }> = {}
+  for (const row of accounts.value) {
+    byId[row.id] = {
+      openaiCompactLabel: getOpenAICompactLabel(row),
+      openaiCompactClass: getOpenAICompactClass(row),
+      openaiCompactTitle: getOpenAICompactTitle(row),
+      antigravityTierLabel: getAntigravityTierLabel(row),
+      antigravityTierClass: getAntigravityTierClass(row),
+    }
+  }
+  return byId
+})
 
 // All available columns
 //

--- a/frontend/src/views/admin/ChannelsView.vue
+++ b/frontend/src/views/admin/ChannelsView.vue
@@ -795,8 +795,21 @@ function togglePlatform(platform: GroupPlatform) {
   }
 }
 
+// Memoized platform → groups partition. Built once per allGroups change so the
+// dialog's per-platform v-for (and per-group conflict rendering) reads O(1)
+// instead of re-filtering the whole allGroups array on every keystroke/render.
+const groupsByPlatform = computed(() => {
+  const map = new Map<GroupPlatform, AdminGroup[]>()
+  for (const g of allGroups.value) {
+    const bucket = map.get(g.platform)
+    if (bucket) bucket.push(g)
+    else map.set(g.platform, [g])
+  }
+  return map
+})
+
 function getGroupsForPlatform(platform: GroupPlatform): AdminGroup[] {
-  return allGroups.value.filter(g => g.platform === platform)
+  return groupsByPlatform.value.get(platform) ?? []
 }
 
 // ── Group helpers ──

--- a/frontend/src/views/admin/UsersView.vue
+++ b/frontend/src/views/admin/UsersView.vue
@@ -326,12 +326,12 @@
             <div v-if="allGroups.length > 0" class="flex flex-col gap-1">
               <!-- 专属分组行 -->
               <span
-                v-if="getUserGroups(row).exclusive.length > 0"
+                v-if="userGroupsById[row.id].exclusive.length > 0"
                 class="group/ex relative inline-flex cursor-pointer items-center gap-1 whitespace-nowrap text-xs"
                 @click.stop="toggleExpandedGroup(row.id)"
               >
                 <Icon name="shield" size="xs" class="h-3.5 w-3.5 text-purple-500 dark:text-purple-400" />
-                <span class="font-medium text-purple-600 dark:text-purple-400">{{ getUserGroups(row).exclusive.length }}</span>
+                <span class="font-medium text-purple-600 dark:text-purple-400">{{ userGroupsById[row.id].exclusive.length }}</span>
                 <span class="text-gray-500 dark:text-dark-400">{{ t('admin.users.exclusiveLabel') }}</span>
                 <!-- Hover tooltip（操作菜单未打开时显示） -->
                 <div
@@ -340,7 +340,7 @@
                 >
                   <div class="absolute left-4 bottom-full border-4 border-transparent border-b-gray-900 dark:border-b-dark-600"></div>
                   <div class="flex flex-col gap-0.5 whitespace-nowrap">
-                    <span v-for="g in getUserGroups(row).exclusive" :key="g.id">{{ g.name }}</span>
+                    <span v-for="g in userGroupsById[row.id].exclusive" :key="g.id">{{ g.name }}</span>
                   </div>
                 </div>
                 <!-- 点击展开分组操作菜单 -->
@@ -352,7 +352,7 @@
                     {{ t('admin.users.clickToReplace') }}
                   </div>
                   <div
-                    v-for="g in getUserGroups(row).exclusive"
+                    v-for="g in userGroupsById[row.id].exclusive"
                     :key="g.id"
                     class="flex cursor-pointer items-center gap-2 px-3 py-2 text-gray-700 transition-colors hover:bg-primary-50 hover:text-primary-600 dark:text-dark-200 dark:hover:bg-primary-900/30 dark:hover:text-primary-400"
                     @click.stop="openGroupReplace(row, g)"
@@ -364,23 +364,23 @@
               </span>
               <!-- 公开分组行 -->
               <span
-                v-if="getUserGroups(row).publicGroups.length > 0"
+                v-if="userGroupsById[row.id].publicGroups.length > 0"
                 class="group/pub relative inline-flex cursor-default items-center gap-1 whitespace-nowrap text-xs"
               >
                 <Icon name="globe" size="xs" class="h-3.5 w-3.5 text-gray-400 dark:text-dark-500" />
-                <span class="font-medium text-gray-600 dark:text-dark-300">{{ getUserGroups(row).publicGroups.length }}</span>
+                <span class="font-medium text-gray-600 dark:text-dark-300">{{ userGroupsById[row.id].publicGroups.length }}</span>
                 <span class="text-gray-400 dark:text-dark-500">{{ t('admin.users.publicLabel') }}</span>
                 <!-- Tooltip: 向下弹出 -->
                 <div class="pointer-events-none absolute left-0 top-full z-50 mt-1.5 rounded bg-gray-900 px-2.5 py-1.5 text-xs text-white opacity-0 shadow-lg transition-opacity duration-75 group-hover/pub:opacity-100 dark:bg-dark-600">
                   <div class="absolute left-4 bottom-full border-4 border-transparent border-b-gray-900 dark:border-b-dark-600"></div>
                   <div class="flex flex-col gap-0.5 whitespace-nowrap">
-                    <span v-for="g in getUserGroups(row).publicGroups" :key="g.id">{{ g.name }}</span>
+                    <span v-for="g in userGroupsById[row.id].publicGroups" :key="g.id">{{ g.name }}</span>
                   </div>
                 </div>
               </span>
               <!-- 都没有 -->
               <span
-                v-if="getUserGroups(row).exclusive.length === 0 && getUserGroups(row).publicGroups.length === 0"
+                v-if="userGroupsById[row.id].exclusive.length === 0 && userGroupsById[row.id].publicGroups.length === 0"
                 class="text-xs text-gray-400 dark:text-dark-500"
               >-</span>
             </div>
@@ -1074,6 +1074,20 @@ const getUserGroups = (user: AdminUser) => {
   }
   return { exclusive, publicGroups }
 }
+
+// Memoized per-user group resolution keyed by user id. The groups cell reads
+// userGroupsById[row.id] instead of calling getUserGroups(row) ~8× per render,
+// so unrelated reactivity (hover/sort/filter/menu-open) no longer re-walks the
+// whole allGroups catalog per row × 8. Recomputes only when allGroups or the
+// visible user list changes; reuses the upstream getUserGroups so the resolved
+// value is byte-identical to the per-call path.
+const userGroupsById = computed<Record<number, ReturnType<typeof getUserGroups>>>(() => {
+  const byId: Record<number, ReturnType<typeof getUserGroups>> = {}
+  for (const user of sortedUsers.value) {
+    byId[user.id] = getUserGroups(user)
+  }
+  return byId
+})
 
 // Group filter options: "All Groups" + active exclusive groups (value = group name for fuzzy match)
 const groupFilterOptions = computed(() => {

--- a/frontend/src/views/admin/__tests__/AccountsView.platformTypeMemo.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.platformTypeMemo.spec.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import AccountsView from '../AccountsView.vue'
+
+// Proves the platformTypeBadgesById memoized map (which the platform_type cell
+// reads instead of calling 5 helpers — each re-walking row.extra — per row per
+// render) produces byte-identical badge output to the per-call path AND stays
+// reactive to row-list changes.
+
+const {
+  listAccounts,
+  listWithEtag,
+  getBatchTodayStats,
+  getAllProxies,
+  getAllGroups
+} = vi.hoisted(() => ({
+  listAccounts: vi.fn(),
+  listWithEtag: vi.fn(),
+  getBatchTodayStats: vi.fn(),
+  getAllProxies: vi.fn(),
+  getAllGroups: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    accounts: {
+      list: listAccounts,
+      listWithEtag,
+      getBatchTodayStats,
+      delete: vi.fn(),
+      batchClearError: vi.fn(),
+      batchRefresh: vi.fn(),
+      toggleSchedulable: vi.fn()
+    },
+    proxies: {
+      getAll: getAllProxies
+    },
+    groups: {
+      getAll: getAllGroups
+    }
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess: vi.fn(),
+    showInfo: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    token: 'test-token'
+  })
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+// Mirror the upstream openai-compact state machine the badge derives from, so we
+// can compute the expected label independently of the component.
+const refOpenAICompactLabel = (row: any): string | null => {
+  if (row.platform !== 'openai' || (row.type !== 'oauth' && row.type !== 'apikey')) return null
+  const extra = row.extra as Record<string, unknown> | undefined
+  const mode = typeof extra?.openai_compact_mode === 'string' ? extra.openai_compact_mode : 'auto'
+  let state: 'supported' | 'unsupported' | 'unknown'
+  if (mode === 'force_on') state = 'supported'
+  else if (mode === 'force_off') state = 'unsupported'
+  else if (typeof extra?.openai_compact_supported === 'boolean') state = extra.openai_compact_supported ? 'supported' : 'unsupported'
+  else state = 'unknown'
+  return {
+    supported: 'admin.accounts.openai.compactSupported',
+    unsupported: 'admin.accounts.openai.compactUnsupported',
+    unknown: 'admin.accounts.openai.compactUnknown'
+  }[state]
+}
+
+const refAntigravityTierLabel = (row: any): string | null => {
+  if (row.platform !== 'antigravity') return null
+  const lca = row.extra?.load_code_assist as Record<string, unknown> | undefined
+  const tier = (lca?.paidTier as any)?.id ?? (lca?.currentTier as any)?.id ?? null
+  switch (tier) {
+    case 'free-tier': return 'admin.accounts.tier.free'
+    case 'g1-pro-tier': return 'admin.accounts.tier.pro'
+    case 'g1-ultra-tier': return 'admin.accounts.tier.ultra'
+    default: return null
+  }
+}
+
+// Stub renders only the platform_type cell, surfacing the openai-compact and
+// antigravity badge text so the DOM exposes the memoized derivation. The two
+// child badges are stubbed to bare markers (their content is orthogonal).
+const DataTableStub = {
+  props: ['columns', 'data'],
+  emits: ['sort'],
+  template: `
+    <div>
+      <button data-test="trigger-reload" @click="$emit('sort', 'name', 'desc')">reload</button>
+      <div v-for="row in data" :key="row.id" :data-test="'row-' + row.id">
+        <slot name="cell-platform_type" :row="row" />
+      </div>
+    </div>
+  `
+}
+
+const mountAccounts = () =>
+  mount(AccountsView, {
+    global: {
+      stubs: {
+        AppLayout: { template: '<div><slot /></div>' },
+        TablePageLayout: {
+          template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
+        },
+        DataTable: DataTableStub,
+        Pagination: true,
+        ConfirmDialog: true,
+        AccountTableActions: { template: '<div><slot name="beforeCreate" /><slot name="after" /></div>' },
+        AccountTableFilters: { template: '<div></div>' },
+        AccountBulkActionsBar: true,
+        AccountActionMenu: true,
+        ImportDataModal: true,
+        ReAuthAccountModal: true,
+        AccountTestModal: true,
+        AccountStatsModal: true,
+        ScheduledTestsPanel: true,
+        SyncFromCrsModal: true,
+        TempUnschedStatusModal: true,
+        ErrorPassthroughRulesModal: true,
+        TLSFingerprintProfilesModal: true,
+        CreateAccountModal: true,
+        EditAccountModal: true,
+        BulkEditAccountModal: true,
+        PlatformTypeBadge: true,
+        ChannelTypeBadge: true,
+        AccountCapacityCell: true,
+        AccountStatusIndicator: true,
+        AccountTodayStatsCell: true,
+        AccountGroupsCell: true,
+        AccountUsageCell: true,
+        Icon: true
+      }
+    }
+  })
+
+const accountRow = (over: Record<string, unknown>) => ({
+  id: 1,
+  name: 'acc',
+  platform: 'anthropic',
+  type: 'oauth',
+  status: 'active',
+  schedulable: true,
+  created_at: '2026-03-07T10:00:00Z',
+  updated_at: '2026-03-07T10:00:00Z',
+  ...over
+})
+
+// The badge text the platform_type cell renders for a given row (compact label
+// + antigravity tier label), read straight from the DOM.
+const renderedBadgeTexts = (wrapper: ReturnType<typeof mount>, id: number) =>
+  wrapper
+    .get(`[data-test="row-${id}"]`)
+    .findAll('span')
+    .map(s => s.text())
+    .filter(Boolean)
+
+describe('admin AccountsView platformTypeBadgesById memoization', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    listAccounts.mockReset()
+    listWithEtag.mockReset()
+    getBatchTodayStats.mockReset()
+    getAllProxies.mockReset()
+    getAllGroups.mockReset()
+
+    listWithEtag.mockResolvedValue({ notModified: true, etag: null, data: null })
+    getBatchTodayStats.mockResolvedValue({ stats: {} })
+    getAllProxies.mockResolvedValue([])
+    getAllGroups.mockResolvedValue([])
+  })
+
+  it('renders the same openai-compact and antigravity tier badges the per-call helpers would', async () => {
+    const openaiRow = accountRow({
+      id: 1, platform: 'openai', type: 'apikey',
+      extra: { openai_compact_mode: 'force_on' }
+    })
+    const antigravityRow = accountRow({
+      id: 2, platform: 'antigravity', type: 'oauth',
+      extra: { load_code_assist: { paidTier: { id: 'g1-ultra-tier' } } }
+    })
+    const plainRow = accountRow({ id: 3, platform: 'anthropic', type: 'oauth' })
+
+    listAccounts.mockResolvedValue({
+      items: [openaiRow, antigravityRow, plainRow],
+      total: 3, page: 1, page_size: 20, pages: 1
+    })
+
+    const wrapper = mountAccounts()
+    await flushPromises()
+
+    // openai row → compact "supported" badge, no antigravity badge.
+    expect(refOpenAICompactLabel(openaiRow)).toBe('admin.accounts.openai.compactSupported')
+    expect(renderedBadgeTexts(wrapper, 1)).toContain('admin.accounts.openai.compactSupported')
+
+    // antigravity row → ultra tier badge, no compact badge.
+    expect(refAntigravityTierLabel(antigravityRow)).toBe('admin.accounts.tier.ultra')
+    expect(renderedBadgeTexts(wrapper, 2)).toContain('admin.accounts.tier.ultra')
+
+    // plain anthropic row → neither extra badge.
+    expect(refOpenAICompactLabel(plainRow)).toBeNull()
+    expect(refAntigravityTierLabel(plainRow)).toBeNull()
+    expect(renderedBadgeTexts(wrapper, 3)).not.toContain('admin.accounts.openai.compactSupported')
+    expect(renderedBadgeTexts(wrapper, 3)).not.toContain('admin.accounts.tier.ultra')
+  })
+
+  it('updates the rendered badges when the account list changes', async () => {
+    listAccounts.mockResolvedValue({
+      items: [accountRow({ id: 1, platform: 'openai', type: 'apikey', extra: { openai_compact_mode: 'force_on' } })],
+      total: 1, page: 1, page_size: 20, pages: 1
+    })
+
+    const wrapper = mountAccounts()
+    await flushPromises()
+    expect(renderedBadgeTexts(wrapper, 1)).toContain('admin.accounts.openai.compactSupported')
+
+    // Reload with a different row whose extra flips the compact state → the memo,
+    // keyed off the account list, must re-derive on the SAME instance.
+    listAccounts.mockResolvedValue({
+      items: [accountRow({ id: 5, platform: 'openai', type: 'apikey', extra: { openai_compact_mode: 'force_off' } })],
+      total: 1, page: 1, page_size: 20, pages: 1
+    })
+    await wrapper.get('[data-test="trigger-reload"]').trigger('click')
+    await flushPromises()
+
+    expect(renderedBadgeTexts(wrapper, 5)).toContain('admin.accounts.openai.compactUnsupported')
+    expect(renderedBadgeTexts(wrapper, 5)).not.toContain('admin.accounts.openai.compactSupported')
+  })
+})

--- a/frontend/src/views/admin/__tests__/ChannelsView.groupsByPlatformMemo.spec.ts
+++ b/frontend/src/views/admin/__tests__/ChannelsView.groupsByPlatformMemo.spec.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import type { AdminGroup } from '@/types'
+import ChannelsView from '../ChannelsView.vue'
+
+// Proves getGroupsForPlatform — now backed by the groupsByPlatform memoized map
+// instead of re-filtering allGroups on every render/keystroke — renders exactly
+// the platform's groups (byte-identical to the old filter) AND stays reactive to
+// allGroups changes when the dialog is reopened.
+
+const {
+  listChannels,
+  getAllGroups,
+  getWebSearchEmulationConfig
+} = vi.hoisted(() => ({
+  listChannels: vi.fn(),
+  getAllGroups: vi.fn(),
+  getWebSearchEmulationConfig: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    channels: {
+      list: listChannels,
+      create: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      syncPricingModels: vi.fn()
+    },
+    groups: {
+      getAll: getAllGroups
+    },
+    settings: {
+      getWebSearchEmulationConfig
+    },
+    accounts: {
+      list: vi.fn(),
+      getById: vi.fn()
+    }
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess: vi.fn(),
+    showInfo: vi.fn()
+  })
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string, _params?: unknown, fallback?: string) => fallback ?? key
+    })
+  }
+})
+
+const makeGroup = (over: Partial<AdminGroup>): AdminGroup => ({
+  id: 0,
+  name: 'g',
+  platform: 'anthropic',
+  status: 'active',
+  subscription_type: 'standard',
+  is_exclusive: false,
+  rate_multiplier: 1,
+  account_count: 0,
+  ...over
+} as unknown as AdminGroup)
+
+// Reference = the exact per-call filter getGroupsForPlatform replaced.
+const refGroupsForPlatform = (groups: AdminGroup[], platform: string) =>
+  groups.filter(g => g.platform === platform)
+
+const mountChannels = () =>
+  mount(ChannelsView, {
+    global: {
+      stubs: {
+        AppLayout: { template: '<div><slot /></div>' },
+        TablePageLayout: {
+          template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
+        },
+        DataTable: { props: ['columns', 'data'], template: '<div></div>' },
+        Pagination: true,
+        ConfirmDialog: true,
+        EmptyState: true,
+        Select: true,
+        // BaseDialog renders its default + footer slots only when shown,
+        // mirroring prod (the cancel button lives in the footer slot).
+        BaseDialog: {
+          props: ['show'],
+          template: '<div v-if="show" data-test="dialog"><slot /><slot name="footer" /></div>'
+        },
+        PlatformIcon: true,
+        Toggle: true,
+        PricingEntryCard: true,
+        Icon: true
+      }
+    }
+  })
+
+// Enable a platform section and switch to its tab, then read the rendered group
+// checkbox labels (the v-for over getGroupsForPlatform).
+const openPlatformTab = async (wrapper: ReturnType<typeof mount>, platformKey: string) => {
+  await wrapper.get('button.btn-primary').trigger('click') // openCreateDialog
+  await flushPromises()
+  // The platform-enable checkbox is the one inside the label whose span text is
+  // `admin.groups.platforms.<platform>` (NOT the "restrict models" checkbox).
+  const platformLabel = wrapper
+    .get('[data-test="dialog"]')
+    .findAll('label')
+    .find(l => l.text().includes(`admin.groups.platforms.${platformKey}`))
+  if (!platformLabel) throw new Error(`platform toggle for ${platformKey} not found`)
+  await platformLabel.get('input[type="checkbox"]').trigger('change') // togglePlatform
+  await flushPromises()
+  // Click the now-rendered platform tab to make its content visible.
+  const tab = wrapper
+    .get('[data-test="dialog"]')
+    .findAll('button.channel-tab')
+    .find(b => b.text().includes(`admin.groups.platforms.${platformKey}`))
+  if (tab) await tab.trigger('click')
+  await flushPromises()
+}
+
+const renderedGroupNames = (wrapper: ReturnType<typeof mount>) =>
+  wrapper
+    .get('[data-test="dialog"]')
+    .findAll('label span.font-medium')
+    .map(s => s.text())
+
+describe('admin ChannelsView groupsByPlatform memoization', () => {
+  beforeEach(() => {
+    listChannels.mockReset()
+    getAllGroups.mockReset()
+    getWebSearchEmulationConfig.mockReset()
+
+    listChannels.mockResolvedValue({ items: [], total: 0, page: 1, page_size: 20, pages: 0 })
+    getWebSearchEmulationConfig.mockResolvedValue({ enabled: false })
+  })
+
+  it('renders exactly the platform-filtered groups the per-call filter would', async () => {
+    const groups = [
+      makeGroup({ id: 1, name: 'Anthropic-A', platform: 'anthropic' }),
+      makeGroup({ id: 2, name: 'Anthropic-B', platform: 'anthropic' }),
+      makeGroup({ id: 3, name: 'OpenAI-X', platform: 'openai' }),
+      makeGroup({ id: 4, name: 'Gemini-Y', platform: 'gemini' })
+    ]
+    getAllGroups.mockResolvedValue(groups)
+
+    const wrapper = mountChannels()
+    await flushPromises()
+    await openPlatformTab(wrapper, 'anthropic')
+
+    const expected = refGroupsForPlatform(groups, 'anthropic').map(g => g.name)
+    expect(expected).toEqual(['Anthropic-A', 'Anthropic-B'])
+
+    const names = renderedGroupNames(wrapper)
+    expect(names).toEqual(expected)
+    expect(names).not.toContain('OpenAI-X')
+    expect(names).not.toContain('Gemini-Y')
+  })
+
+  it('reflects an updated allGroups set when the dialog is reopened', async () => {
+    getAllGroups.mockResolvedValue([
+      makeGroup({ id: 1, name: 'Anthropic-A', platform: 'anthropic' })
+    ])
+
+    const wrapper = mountChannels()
+    await flushPromises()
+    await openPlatformTab(wrapper, 'anthropic')
+    expect(renderedGroupNames(wrapper)).toEqual(['Anthropic-A'])
+
+    // close dialog
+    await wrapper.get('[data-test="dialog"] button.btn-secondary').trigger('click')
+    await flushPromises()
+
+    // allGroups changes upstream; reopening triggers loadGroups() → the memo
+    // must re-partition from the new catalog.
+    getAllGroups.mockResolvedValue([
+      makeGroup({ id: 1, name: 'Anthropic-A', platform: 'anthropic' }),
+      makeGroup({ id: 9, name: 'Anthropic-Added', platform: 'anthropic' })
+    ])
+    await openPlatformTab(wrapper, 'anthropic')
+
+    expect(renderedGroupNames(wrapper)).toEqual(['Anthropic-A', 'Anthropic-Added'])
+  })
+})

--- a/frontend/src/views/admin/__tests__/UsersView.groupsMemo.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsersView.groupsMemo.spec.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import type { AdminGroup, AdminUser } from '@/types'
+import UsersView from '../UsersView.vue'
+
+// Proves the userGroupsById memoized map (which the groups cell reads instead of
+// calling getUserGroups(row) ~8× per render) produces byte-identical rendered
+// output to the per-call path AND stays reactive to allGroups / row-list changes.
+
+const {
+  listUsers,
+  getAllGroups,
+  getBatchUsersUsage,
+  listEnabledDefinitions,
+  getBatchUserAttributes
+} = vi.hoisted(() => ({
+  listUsers: vi.fn(),
+  getAllGroups: vi.fn(),
+  getBatchUsersUsage: vi.fn(),
+  listEnabledDefinitions: vi.fn(),
+  getBatchUserAttributes: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    users: {
+      list: listUsers,
+      toggleStatus: vi.fn(),
+      delete: vi.fn()
+    },
+    groups: {
+      getAll: getAllGroups
+    },
+    dashboard: {
+      getBatchUsersUsage
+    },
+    userAttributes: {
+      listEnabledDefinitions,
+      getBatchUserAttributes
+    }
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess: vi.fn()
+  })
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+const makeGroup = (over: Partial<AdminGroup>): AdminGroup => ({
+  id: 0,
+  name: 'g',
+  platform: 'anthropic',
+  status: 'active',
+  subscription_type: 'standard',
+  is_exclusive: false,
+  rate_multiplier: 1,
+  // The remaining AdminGroup fields are irrelevant to getUserGroups; cast keeps
+  // the fixture minimal while satisfying the type at the call sites we exercise.
+  ...over
+} as unknown as AdminGroup)
+
+const makeUser = (over: Partial<AdminUser>): AdminUser => ({
+  id: 1,
+  username: 'u',
+  email: 'u@example.com',
+  role: 'user',
+  balance: 0,
+  concurrency: 1,
+  status: 'active',
+  allowed_groups: [],
+  balance_notify_enabled: false,
+  balance_notify_threshold: null,
+  balance_notify_extra_emails: [],
+  created_at: '2026-04-17T00:00:00Z',
+  updated_at: '2026-04-17T00:00:00Z',
+  notes: '',
+  last_active_at: '2026-04-16T02:00:00Z',
+  last_used_at: '2026-04-17T02:00:00Z',
+  current_concurrency: 0,
+  ...over
+} as unknown as AdminUser)
+
+// Reference implementation = the exact per-call logic the memo replaces.
+const refGetUserGroups = (user: AdminUser, groups: AdminGroup[]) => {
+  const exclusive: AdminGroup[] = []
+  const publicGroups: AdminGroup[] = []
+  for (const g of groups) {
+    if (g.status !== 'active' || g.subscription_type !== 'standard') continue
+    if (g.is_exclusive) {
+      if (user.allowed_groups?.includes(g.id)) exclusive.push(g)
+    } else {
+      publicGroups.push(g)
+    }
+  }
+  return { exclusive, publicGroups }
+}
+
+const DataTableStub = {
+  props: ['columns', 'data'],
+  emits: ['sort'],
+  template: `
+    <div>
+      <button data-test="trigger-reload" @click="$emit('sort', 'created_at', 'desc')">reload</button>
+      <div v-for="row in data" :key="row.id" :data-test="'row-' + row.id">
+        <slot name="cell-groups" :row="row" />
+      </div>
+    </div>
+  `
+}
+
+const mountUsers = () =>
+  mount(UsersView, {
+    global: {
+      stubs: {
+        AppLayout: { template: '<div><slot /></div>' },
+        TablePageLayout: {
+          template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
+        },
+        DataTable: DataTableStub,
+        Pagination: true,
+        ConfirmDialog: true,
+        EmptyState: true,
+        GroupBadge: true,
+        Select: true,
+        UserAttributesConfigModal: true,
+        UserConcurrencyCell: true,
+        UserCreateModal: true,
+        InviteTrialModal: true,
+        UserEditModal: true,
+        UserApiKeysModal: true,
+        UserAllowedGroupsModal: true,
+        UserBalanceModal: true,
+        UserBalanceHistoryModal: true,
+        GroupReplaceModal: true,
+        UserPlatformQuotaModal: true,
+        UserPlatformQuotaCell: true,
+        PlatformUsageBreakdown: true,
+        PlatformCostCell: true,
+        // Render group names verbatim so the DOM exposes the resolved exclusive/
+        // public partition for assertion.
+        Icon: { props: ['name'], template: '<i :data-icon="name"></i>' },
+        Teleport: true
+      }
+    }
+  })
+
+// Extract the exclusive + public group-name lists the cell rendered for a row,
+// by reading the tooltip <span> lists (one per exclusive group, one per public).
+const renderedGroupsForRow = (wrapper: ReturnType<typeof mount>, userId: number) => {
+  const rowEl = wrapper.get(`[data-test="row-${userId}"]`)
+  const exclusiveIcon = rowEl.find('[data-icon="shield"]')
+  const publicIcon = rowEl.find('[data-icon="globe"]')
+  // The numeric badge directly follows each icon; group names live in the
+  // hover tooltips. We assert on the tooltip name lists for byte-fidelity.
+  const allNameSpans = rowEl.findAll('span').map(s => s.text())
+  return { hasExclusive: exclusiveIcon.exists(), hasPublic: publicIcon.exists(), allNameSpans }
+}
+
+describe('admin UsersView userGroupsById memoization', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    // The "groups" column is hidden by default; reveal it so onMounted calls
+    // loadAllGroups() and the groups cell renders the memoized partition.
+    localStorage.setItem('user-hidden-columns', JSON.stringify([]))
+    localStorage.setItem('user-column-settings-version', '3')
+
+    listUsers.mockReset()
+    getAllGroups.mockReset()
+    getBatchUsersUsage.mockReset()
+    listEnabledDefinitions.mockReset()
+    getBatchUserAttributes.mockReset()
+
+    getBatchUsersUsage.mockResolvedValue({ stats: {} })
+    listEnabledDefinitions.mockResolvedValue([])
+    getBatchUserAttributes.mockResolvedValue({ values: {} })
+  })
+
+  it('renders the same exclusive/public partition the per-call getUserGroups would', async () => {
+    const groups = [
+      makeGroup({ id: 10, name: 'Exclusive-A', is_exclusive: true }),
+      makeGroup({ id: 11, name: 'Exclusive-B', is_exclusive: true }),
+      makeGroup({ id: 20, name: 'Public-X', is_exclusive: false }),
+      // Disabled + non-standard groups must be excluded by both paths.
+      makeGroup({ id: 30, name: 'Disabled', is_exclusive: true, status: 'disabled' }),
+      makeGroup({ id: 31, name: 'Subscription', is_exclusive: false, subscription_type: 'subscription' })
+    ]
+    const user = makeUser({ id: 7, allowed_groups: [10] })
+
+    listUsers.mockResolvedValue({ items: [user], total: 1, page: 1, page_size: 20, pages: 1 })
+    getAllGroups.mockResolvedValue(groups)
+
+    const wrapper = mountUsers()
+    await flushPromises()
+
+    const expected = refGetUserGroups(user, groups)
+    expect(expected.exclusive.map(g => g.name)).toEqual(['Exclusive-A'])
+    expect(expected.publicGroups.map(g => g.name)).toEqual(['Public-X'])
+
+    const rendered = renderedGroupsForRow(wrapper, 7)
+    expect(rendered.hasExclusive).toBe(true)
+    expect(rendered.hasPublic).toBe(true)
+    // Exactly the expected group names appear; excluded ones do not.
+    expect(rendered.allNameSpans).toContain('Exclusive-A')
+    expect(rendered.allNameSpans).toContain('Public-X')
+    expect(rendered.allNameSpans).not.toContain('Exclusive-B')
+    expect(rendered.allNameSpans).not.toContain('Disabled')
+    expect(rendered.allNameSpans).not.toContain('Subscription')
+  })
+
+  it('updates the rendered partition when the visible row list changes', async () => {
+    const groups = [
+      makeGroup({ id: 10, name: 'Exclusive-A', is_exclusive: true }),
+      makeGroup({ id: 11, name: 'Exclusive-B', is_exclusive: true }),
+      makeGroup({ id: 20, name: 'Public-X', is_exclusive: false })
+    ]
+    getAllGroups.mockResolvedValue(groups)
+
+    // First load: user can see Exclusive-A only.
+    listUsers.mockResolvedValue({
+      items: [makeUser({ id: 7, allowed_groups: [10] })],
+      total: 1, page: 1, page_size: 20, pages: 1
+    })
+
+    const wrapper = mountUsers()
+    await flushPromises()
+
+    expect(renderedGroupsForRow(wrapper, 7).allNameSpans).toContain('Exclusive-A')
+    expect(renderedGroupsForRow(wrapper, 7).allNameSpans).not.toContain('Exclusive-B')
+
+    // Reload with a different user (different id + different allowed_groups) →
+    // the memo, keyed off the row list, must re-derive on the SAME instance.
+    listUsers.mockResolvedValue({
+      items: [makeUser({ id: 9, allowed_groups: [11] })],
+      total: 1, page: 1, page_size: 20, pages: 1
+    })
+    await wrapper.get('[data-test="trigger-reload"]').trigger('click')
+    await flushPromises()
+
+    const rendered = renderedGroupsForRow(wrapper, 9)
+    expect(rendered.allNameSpans).toContain('Exclusive-B')
+    expect(rendered.allNameSpans).not.toContain('Exclusive-A')
+    expect(rendered.allNameSpans).toContain('Public-X')
+  })
+})


### PR DESCRIPTION
## Problem

The admin Users / Channels / Accounts tables felt laggy (\"卡\") on hover / sort / filter / menu-open / dialog keystrokes. Root cause: several cells called **plain (non-computed) helper functions inside the template**, so they re-ran on every reactivity tick — turning unrelated reactivity into O(rows × catalog) work.

- `UsersView.vue` — the groups cell called `getUserGroups(row)` ~8× per row, each looping the entire `allGroups` array → cost = rows × allGroups × 8 on every tick.
- `ChannelsView.vue` — `getGroupsForPlatform(section.platform)` re-filtered `allGroups` in a per-platform `v-for` (plus per-group rendering) on every dialog render/keystroke.
- `AccountsView.vue` — the `platform_type` cell called 5 helpers per row, several re-walking `row.extra` each call.

## Fix

Precompute **memoized maps** and read those in the templates instead of calling functions per render. Each memo layer **calls the existing upstream helper once per row** (rather than reimplementing it), so output is byte-identical to the per-call path and the upstream functions stay referenced (rule §5.x — no upstream symbol deleted).

| View | Cell | Memoization shape |
|---|---|---|
| `UsersView.vue` | `#cell-groups` | `userGroupsById` computed keyed by user id, built from `sortedUsers` × `allGroups`, calling upstream `getUserGroups` once per visible row. Template reads `userGroupsById[row.id]`. |
| `ChannelsView.vue` | dialog group picker | `groupsByPlatform` computed (`Map` built once per `allGroups` change). `getGroupsForPlatform` keeps its name/signature/return semantics but becomes an O(1) map read. Per-group conflict lookups already read the `groupToChannelMap` computed (unchanged). |
| `AccountsView.vue` | `#cell-platform_type` | `platformTypeBadgesById` computed keyed by account id, calling the 5 upstream helpers once per row; the cell reads precomputed label/class/title strings. |

Reactivity preserved: the memos depend on `allGroups` / the row list / `accounts` (the loader replaces row objects + reassigns the array on any change), so badges/groups update exactly as before.

This is a **pure-frontend display-derivation perf change** — no API or data-shape change. It touches web, so `no-web-impact` does not apply; the embedded `dist` manifest (`frontend-source.json`) is rebuilt and committed.

## Tests

New vitest spec per view (run locally / on full runs; not in the CI critical subset by design):

- `UsersView.groupsMemo.spec.ts` — renders the same exclusive/public partition the per-call `getUserGroups` would; updates when the visible row list changes.
- `ChannelsView.groupsByPlatformMemo.spec.ts` — renders exactly the platform-filtered groups; reflects an updated `allGroups` set on dialog reopen.
- `AccountsView.platformTypeMemo.spec.ts` — renders the same openai-compact / antigravity-tier badges; updates when the account list changes.

Each spec asserts equivalence against an independent reference implementation of the upstream logic AND drives a reactivity change on the same component instance.

## Verification

- `pnpm build` — dist regenerated, `frontend-source.json` committed; freshness `--check` ok.
- `pnpm typecheck` — clean.
- `pnpm lint:check` — clean.
- vitest: 3 new specs (6 tests) pass; critical CI subset (91 tests) + all admin view specs (97 tests) pass — no regression.
- `scripts/preflight.sh` — PASS.

## sentinel-registry-reviewed

`AccountsView.vue` is pinned in `scripts/sentinels/frontend-tk.json`. This PR edits only the `#cell-platform_type` block and appends one `computed`; it touches **none** of the pinned anchors (`<TablePageLayout fluid>`, `:sticky-edge-hints=\"false\"`, `Wrap-first column policy`, `wrap(...)`, `current.current_rpm`, `v-if=\"row.notes\"`, the `ID: {{ row.id }}` line). Preflight confirms all frontend TK sentinels remain intact — no new anchor required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## upstream-touch-trivial

The edits to `UsersView.vue` / `ChannelsView.vue` / `AccountsView.vue` carry **no upstream-merge revert risk**: they are thin display-derivation hooks (a template reads a memoized map instead of calling a plain function; `ChannelsView.getGroupsForPlatform` keeps its name/signature/return). Every upstream-owned helper is preserved and still called — no upstream symbol is deleted or rewritten, so a future upstream merge has nothing to silently clobber. Reviewer-audited as trivial per rule §5.y.1.