### PR TITLE
perf(admin): back Users + Dashboard aggregations with per-(user,platform,day) rollup

### DIFF
--- a/backend/internal/repository/dashboard_aggregation_repo.go
+++ b/backend/internal/repository/dashboard_aggregation_repo.go
@@ -96,6 +96,12 @@ func (r *dashboardAggregationRepository) aggregateRangeInTx(ctx context.Context,
 	if err := r.upsertDailyAggregates(ctx, dayStart, dayEnd); err != nil {
 		return err
 	}
+	// TK: per-(user, platform, day) rollup feeding the admin Users page +
+	// dashboard spending-ranking widget. Aggregates the same day window from raw
+	// usage_logs (see dashboard_aggregation_repo_tk_user_platform.go).
+	if err := r.upsertUserPlatformDailyAggregates(ctx, dayStart, dayEnd); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -152,6 +158,11 @@ func (r *dashboardAggregationRepository) recomputeRangeInTx(ctx context.Context,
 	if _, err := r.sql.ExecContext(ctx, "DELETE FROM usage_dashboard_daily_users WHERE bucket_date >= $1::date AND bucket_date < $2::date", dayStart, dayEnd); err != nil {
 		return err
 	}
+	// TK: clear the per-(user, platform, day) rollup for the window so a row that
+	// dropped to zero after a usage_logs rollback does not linger before rebuild.
+	if err := r.deleteUserPlatformDailyRange(ctx, dayStart, dayEnd); err != nil {
+		return err
+	}
 
 	if err := r.insertHourlyActiveUsers(ctx, hourStart, hourEnd); err != nil {
 		return err
@@ -163,6 +174,10 @@ func (r *dashboardAggregationRepository) recomputeRangeInTx(ctx context.Context,
 		return err
 	}
 	if err := r.upsertDailyAggregates(ctx, dayStart, dayEnd); err != nil {
+		return err
+	}
+	// TK: rebuild the per-(user, platform, day) rollup for the window.
+	if err := r.upsertUserPlatformDailyAggregates(ctx, dayStart, dayEnd); err != nil {
 		return err
 	}
 	return nil
@@ -204,6 +219,10 @@ func (r *dashboardAggregationRepository) CleanupAggregates(ctx context.Context, 
 		return err
 	}
 	if _, err := r.sql.ExecContext(ctx, "DELETE FROM usage_dashboard_daily_users WHERE bucket_date < $1::date", dailyCutoffUTC); err != nil {
+		return err
+	}
+	// TK: prune the per-(user, platform, day) rollup with the same daily cutoff.
+	if err := r.cleanupUserPlatformDaily(ctx, dailyCutoffUTC); err != nil {
 		return err
 	}
 	return nil

--- a/backend/internal/repository/dashboard_aggregation_repo_tk_user_platform.go
+++ b/backend/internal/repository/dashboard_aggregation_repo_tk_user_platform.go
@@ -15,22 +15,16 @@ import (
 // this table and today's partial day from raw usage_logs, so "today" numbers
 // stay exact while history is served from the rollup.
 //
-// The effective-platform expression MUST stay identical to the live queries'
-// usageLogEffectivePlatformExpr -- COALESCE(NULLIF(g.platform,''), a.platform)
-// -- or the rollup would partition by a different platform than the page shows.
-
-// usageDashboardUserPlatformDailyExpr is the effective-platform projection used
-// when building the rollup. It mirrors usageLogEffectivePlatformExpr but is
-// pinned here so a change to one is a visible diff against the other.
-const usageDashboardUserPlatformDailyExpr = "COALESCE(NULLIF(g.platform,''), a.platform)"
+// The effective-platform projection is the SAME usageLogEffectivePlatformExpr
+// the live queries use (same package), so the rollup partitions by exactly the
+// platform the page shows -- no second copy to keep in sync.
 
 // upsertUserPlatformDailyAggregates rebuilds the per-(user, platform, day) rows
 // for the given local-day window directly from raw usage_logs. requests and all
 // token/cost sums include every row (actual_cost = 0 included) because the
 // ranking consumer counts them unconditionally; the billed-only consumer filters
-// at read time. Rows with a NULL effective platform (no group, no account) are
-// skipped: they cannot contribute to a per-platform breakdown and never carry
-// cost in practice.
+// at read time. A NULL/empty effective platform is coalesced to the empty string
+// (not dropped) so its cost still reaches the user total via the reads.
 func (r *dashboardAggregationRepository) upsertUserPlatformDailyAggregates(ctx context.Context, dayStart, dayEnd time.Time) error {
 	tzName := timezone.Name()
 	query := `
@@ -44,7 +38,7 @@ func (r *dashboardAggregationRepository) upsertUserPlatformDailyAggregates(ctx c
 				-- '' into the user total (just not into the per-platform breakdown),
 				-- so completed-day totals match the legacy "count every row"
 				-- semantics. platform is part of the PK, so it cannot be NULL.
-				COALESCE(` + usageDashboardUserPlatformDailyExpr + `, '') AS platform,
+				COALESCE(` + usageLogEffectivePlatformExpr + `, '') AS platform,
 				ul.input_tokens AS input_tokens,
 				ul.output_tokens AS output_tokens,
 				ul.cache_creation_tokens AS cache_creation_tokens,

--- a/backend/internal/repository/dashboard_aggregation_repo_tk_user_platform.go
+++ b/backend/internal/repository/dashboard_aggregation_repo_tk_user_platform.go
@@ -1,0 +1,125 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+)
+
+// TK: per-(user, effective-platform, day) rollup feeder. Backs the two heaviest
+// admin-page aggregations (GetBatchUserUsageStats / GetUserSpendingRanking) by
+// pre-aggregating completed days so those pages stop scanning the full 30-day
+// window of usage_logs (~1.25M rows / 845K buffers on prod). The live read path
+// (see usage_log_repo_tk_user_platform_rollup.go) reads completed days from
+// this table and today's partial day from raw usage_logs, so "today" numbers
+// stay exact while history is served from the rollup.
+//
+// The effective-platform expression MUST stay identical to the live queries'
+// usageLogEffectivePlatformExpr -- COALESCE(NULLIF(g.platform,''), a.platform)
+// -- or the rollup would partition by a different platform than the page shows.
+
+// usageDashboardUserPlatformDailyExpr is the effective-platform projection used
+// when building the rollup. It mirrors usageLogEffectivePlatformExpr but is
+// pinned here so a change to one is a visible diff against the other.
+const usageDashboardUserPlatformDailyExpr = "COALESCE(NULLIF(g.platform,''), a.platform)"
+
+// upsertUserPlatformDailyAggregates rebuilds the per-(user, platform, day) rows
+// for the given local-day window directly from raw usage_logs. requests and all
+// token/cost sums include every row (actual_cost = 0 included) because the
+// ranking consumer counts them unconditionally; the billed-only consumer filters
+// at read time. Rows with a NULL effective platform (no group, no account) are
+// skipped: they cannot contribute to a per-platform breakdown and never carry
+// cost in practice.
+func (r *dashboardAggregationRepository) upsertUserPlatformDailyAggregates(ctx context.Context, dayStart, dayEnd time.Time) error {
+	tzName := timezone.Name()
+	query := `
+		WITH per_row AS (
+			SELECT
+				(ul.created_at AT TIME ZONE $3)::date AS bucket_date,
+				ul.user_id AS user_id,
+				` + usageDashboardUserPlatformDailyExpr + ` AS platform,
+				ul.input_tokens AS input_tokens,
+				ul.output_tokens AS output_tokens,
+				ul.cache_creation_tokens AS cache_creation_tokens,
+				ul.cache_read_tokens AS cache_read_tokens,
+				ul.actual_cost AS actual_cost
+			FROM usage_logs ul
+			LEFT JOIN groups g ON g.id = ul.group_id
+			LEFT JOIN accounts a ON a.id = ul.account_id
+			WHERE ul.created_at >= $1 AND ul.created_at < $2
+		),
+		rolled AS (
+			SELECT
+				bucket_date,
+				user_id,
+				platform,
+				COUNT(*) AS total_requests,
+				COALESCE(SUM(input_tokens), 0) AS input_tokens,
+				COALESCE(SUM(output_tokens), 0) AS output_tokens,
+				COALESCE(SUM(cache_creation_tokens), 0) AS cache_creation_tokens,
+				COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+				COALESCE(SUM(actual_cost), 0) AS actual_cost
+			FROM per_row
+			WHERE platform IS NOT NULL AND platform <> ''
+			GROUP BY bucket_date, user_id, platform
+		)
+		INSERT INTO usage_dashboard_user_platform_daily (
+			bucket_date,
+			user_id,
+			platform,
+			total_requests,
+			input_tokens,
+			output_tokens,
+			cache_creation_tokens,
+			cache_read_tokens,
+			actual_cost,
+			computed_at
+		)
+		SELECT
+			bucket_date,
+			user_id,
+			platform,
+			total_requests,
+			input_tokens,
+			output_tokens,
+			cache_creation_tokens,
+			cache_read_tokens,
+			actual_cost,
+			NOW()
+		FROM rolled
+		ON CONFLICT (bucket_date, user_id, platform)
+		DO UPDATE SET
+			total_requests = EXCLUDED.total_requests,
+			input_tokens = EXCLUDED.input_tokens,
+			output_tokens = EXCLUDED.output_tokens,
+			cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+			cache_read_tokens = EXCLUDED.cache_read_tokens,
+			actual_cost = EXCLUDED.actual_cost,
+			computed_at = EXCLUDED.computed_at
+	`
+	_, err := r.sql.ExecContext(ctx, query, dayStart, dayEnd, tzName)
+	return err
+}
+
+// deleteUserPlatformDailyRange clears the per-(user, platform, day) rows for a
+// local-day window before a recompute, so a row that dropped to zero (e.g. logs
+// were deleted) does not linger. Mirrors the recompute discipline of the
+// upstream usage_dashboard_daily rebuild.
+func (r *dashboardAggregationRepository) deleteUserPlatformDailyRange(ctx context.Context, dayStart, dayEnd time.Time) error {
+	_, err := r.sql.ExecContext(ctx,
+		"DELETE FROM usage_dashboard_user_platform_daily WHERE bucket_date >= $1::date AND bucket_date < $2::date",
+		dayStart, dayEnd,
+	)
+	return err
+}
+
+// cleanupUserPlatformDaily prunes rollup rows older than the daily retention
+// cutoff, matching CleanupAggregates' treatment of usage_dashboard_daily.
+func (r *dashboardAggregationRepository) cleanupUserPlatformDaily(ctx context.Context, dailyCutoff time.Time) error {
+	_, err := r.sql.ExecContext(ctx,
+		"DELETE FROM usage_dashboard_user_platform_daily WHERE bucket_date < $1::date",
+		dailyCutoff.UTC(),
+	)
+	return err
+}

--- a/backend/internal/repository/dashboard_aggregation_repo_tk_user_platform.go
+++ b/backend/internal/repository/dashboard_aggregation_repo_tk_user_platform.go
@@ -38,7 +38,13 @@ func (r *dashboardAggregationRepository) upsertUserPlatformDailyAggregates(ctx c
 			SELECT
 				(ul.created_at AT TIME ZONE $3)::date AS bucket_date,
 				ul.user_id AS user_id,
-				` + usageDashboardUserPlatformDailyExpr + ` AS platform,
+				-- A NULL/empty effective platform (no group platform and no/blank
+				-- account platform) is coalesced to '' rather than dropped: the
+				-- ranking read sums across ALL platforms and the batch read folds
+				-- '' into the user total (just not into the per-platform breakdown),
+				-- so completed-day totals match the legacy "count every row"
+				-- semantics. platform is part of the PK, so it cannot be NULL.
+				COALESCE(` + usageDashboardUserPlatformDailyExpr + `, '') AS platform,
 				ul.input_tokens AS input_tokens,
 				ul.output_tokens AS output_tokens,
 				ul.cache_creation_tokens AS cache_creation_tokens,
@@ -61,7 +67,6 @@ func (r *dashboardAggregationRepository) upsertUserPlatformDailyAggregates(ctx c
 				COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
 				COALESCE(SUM(actual_cost), 0) AS actual_cost
 			FROM per_row
-			WHERE platform IS NOT NULL AND platform <> ''
 			GROUP BY bucket_date, user_id, platform
 		)
 		INSERT INTO usage_dashboard_user_platform_daily (

--- a/backend/internal/repository/usage_log_repo.go
+++ b/backend/internal/repository/usage_log_repo.go
@@ -2381,78 +2381,13 @@ func (r *usageLogRepository) GetUserSpendingRanking(ctx context.Context, startTi
 		limit = 12
 	}
 
-	query := `
-		WITH user_spend AS (
-			SELECT
-				u.user_id,
-				COALESCE(us.email, '') as email,
-				COALESCE(SUM(u.actual_cost), 0) as actual_cost,
-				COUNT(*) as requests,
-				COALESCE(SUM(u.input_tokens + u.output_tokens + u.cache_creation_tokens + u.cache_read_tokens), 0) as tokens
-			FROM usage_logs u
-			LEFT JOIN users us ON u.user_id = us.id
-			WHERE u.created_at >= $1 AND u.created_at < $2
-			GROUP BY u.user_id, us.email
-		),
-		ranked AS (
-			SELECT
-				user_id,
-				email,
-				actual_cost,
-				requests,
-				tokens,
-				COALESCE(SUM(actual_cost) OVER (), 0) as total_actual_cost,
-				COALESCE(SUM(requests) OVER (), 0) as total_requests,
-				COALESCE(SUM(tokens) OVER (), 0) as total_tokens
-			FROM user_spend
-			ORDER BY actual_cost DESC, tokens DESC, user_id ASC
-			LIMIT $3
-		)
-		SELECT
-			user_id,
-			email,
-			actual_cost,
-			requests,
-			tokens,
-			total_actual_cost,
-			total_requests,
-			total_tokens
-		FROM ranked
-		ORDER BY actual_cost DESC, tokens DESC, user_id ASC
-	`
-
-	rows, err := r.sql.QueryContext(ctx, query, startTime, endTime, limit)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if closeErr := rows.Close(); closeErr != nil && err == nil {
-			err = closeErr
-			result = nil
-		}
-	}()
-
-	ranking := make([]UserSpendingRankingItem, 0)
-	totalActualCost := 0.0
-	totalRequests := int64(0)
-	totalTokens := int64(0)
-	for rows.Next() {
-		var row UserSpendingRankingItem
-		if err = rows.Scan(&row.UserID, &row.Email, &row.ActualCost, &row.Requests, &row.Tokens, &totalActualCost, &totalRequests, &totalTokens); err != nil {
-			return nil, err
-		}
-		ranking = append(ranking, row)
-	}
-	if err = rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return &UserSpendingRankingResponse{
-		Ranking:         ranking,
-		TotalActualCost: totalActualCost,
-		TotalRequests:   totalRequests,
-		TotalTokens:     totalTokens,
-	}, nil
+	// TK: served from the per-(user, platform, day) rollup for completed days plus
+	// raw usage_logs for the partial/today slices (see
+	// usage_log_repo_tk_user_platform_rollup.go). The legacy CTE scanned the full
+	// created_at window of usage_logs (845K buffers / 1.65s on prod); the rollup
+	// reads ~hundreds of rows. Window totals, top-N ordering, and per-user email
+	// are reconstructed in Go to match the legacy output byte-for-byte.
+	return r.getUserSpendingRankingRollup(ctx, startTime, endTime, limit)
 }
 
 // UserDashboardStats 用户仪表盘统计
@@ -2892,10 +2827,9 @@ func normalizePositiveInt64IDs(ids []int64) []int64 {
 // GetBatchUserUsageStats gets today and total actual_cost for multiple users within a time range.
 // If startTime is zero, defaults to 30 days ago.
 func (r *usageLogRepository) GetBatchUserUsageStats(ctx context.Context, userIDs []int64, startTime, endTime time.Time) (map[int64]*BatchUserUsageStats, error) {
-	result := make(map[int64]*BatchUserUsageStats)
 	normalizedUserIDs := normalizePositiveInt64IDs(userIDs)
 	if len(normalizedUserIDs) == 0 {
-		return result, nil
+		return make(map[int64]*BatchUserUsageStats), nil
 	}
 
 	// 默认最近 30 天
@@ -2906,62 +2840,14 @@ func (r *usageLogRepository) GetBatchUserUsageStats(ctx context.Context, userIDs
 		endTime = time.Now()
 	}
 
-	for _, id := range normalizedUserIDs {
-		result[id] = &BatchUserUsageStats{UserID: id}
-	}
-
-	// GROUP BY (user_id, effective_platform) 一次查询同时得到总值与按平台拆分。
-	// 应用层把同一 user_id 的多行累加为总值，并把非空 platform 行收集到 ByPlatform。
-	query := `
-		SELECT
-			ul.user_id,
-			` + usageLogEffectivePlatformExpr + ` as platform,
-			COALESCE(SUM(ul.actual_cost) FILTER (WHERE ul.created_at >= $2 AND ul.created_at < $3), 0) as total_cost,
-			COALESCE(SUM(ul.actual_cost) FILTER (WHERE ul.created_at >= $4), 0) as today_cost
-		FROM usage_logs ul
-		LEFT JOIN groups g ON g.id = ul.group_id
-		LEFT JOIN accounts a ON a.id = ul.account_id
-		WHERE ul.user_id = ANY($1)
-		  AND ul.created_at >= LEAST($2, $4)
-		  AND ` + usageLogSuccessFilterUL + `
-		GROUP BY ul.user_id, ` + usageLogEffectivePlatformExpr + `
-	`
-	today := timezone.Today()
-	rows, err := r.sql.QueryContext(ctx, query, pq.Array(normalizedUserIDs), startTime, endTime, today)
-	if err != nil {
-		return nil, err
-	}
-	for rows.Next() {
-		var userID int64
-		var platform sql.NullString
-		var total float64
-		var todayTotal float64
-		if err := rows.Scan(&userID, &platform, &total, &todayTotal); err != nil {
-			_ = rows.Close()
-			return nil, err
-		}
-		stats, ok := result[userID]
-		if !ok {
-			continue
-		}
-		stats.TotalActualCost += total
-		stats.TodayActualCost += todayTotal
-		if platform.Valid && platform.String != "" {
-			stats.ByPlatform = append(stats.ByPlatform, PlatformUsage{
-				Platform:        platform.String,
-				TotalActualCost: total,
-				TodayActualCost: todayTotal,
-			})
-		}
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	// TK: read completed days from the per-(user, platform, day) rollup and the
+	// partial/today slices from raw usage_logs (see
+	// usage_log_repo_tk_user_platform_rollup.go). The legacy single-query
+	// implementation scanned the full 30-day window of usage_logs (~1.25M rows /
+	// 845K buffers / 2.7s on prod) — a wide-window aggregation no index can serve.
+	// Output is byte-identical to the legacy path; the rollup reader pre-seeds an
+	// entry for every requested user so users with no usage still appear.
+	return r.getBatchUserUsageStatsRollup(ctx, normalizedUserIDs, startTime, endTime)
 }
 
 // BatchAPIKeyUsageStats represents usage stats for a single API key

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
@@ -509,32 +510,51 @@ func TestUsageLogRepositoryGetStatsWithFiltersAlwaysReturnsAccountCost(t *testin
 }
 
 func TestUsageLogRepositoryGetUserSpendingRanking(t *testing.T) {
+	// Pin UTC so the day-aligned window below has no partial-boundary raw
+	// remainder regardless of the host's local timezone (the rollup window
+	// decomposition floors/ceils to the server timezone).
+	require.NoError(t, timezone.Init("UTC"))
+
 	db, mock := newSQLMock(t)
 	repo := &usageLogRepository{sql: db}
 
+	// A historical, day-aligned window entirely before today: the rollup-backed
+	// path (usage_log_repo_tk_user_platform_rollup.go) serves it wholly from
+	// usage_dashboard_user_platform_daily (no raw remainder), then enriches each
+	// row with the user email and assembles window totals + top-N ordering in Go.
 	start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(24 * time.Hour)
 
-	rows := sqlmock.NewRows([]string{"user_id", "email", "actual_cost", "requests", "tokens", "total_actual_cost", "total_requests", "total_tokens"}).
-		AddRow(int64(2), "beta@example.com", 12.5, int64(9), int64(900), 40.0, int64(30), int64(2600)).
-		AddRow(int64(1), "alpha@example.com", 12.5, int64(8), int64(800), 40.0, int64(30), int64(2600)).
-		AddRow(int64(3), "gamma@example.com", 4.25, int64(5), int64(300), 40.0, int64(30), int64(2600))
+	// Rollup aggregate per user, deliberately out of rank order to prove the Go
+	// sort (cost DESC, tokens DESC, user_id ASC).
+	rollupRows := sqlmock.NewRows([]string{"user_id", "actual_cost", "total_requests", "tokens"}).
+		AddRow(int64(3), 4.25, int64(5), int64(300)).
+		AddRow(int64(1), 12.5, int64(8), int64(800)).
+		AddRow(int64(2), 12.5, int64(9), int64(900))
+	mock.ExpectQuery("FROM usage_dashboard_user_platform_daily").
+		WithArgs(start, end).
+		WillReturnRows(rollupRows)
 
-	mock.ExpectQuery("WITH user_spend AS \\(").
-		WithArgs(start, end, 12).
-		WillReturnRows(rows)
+	// Email enrichment for the users seen in the window.
+	emailRows := sqlmock.NewRows([]string{"id", "email"}).
+		AddRow(int64(1), "alpha@example.com").
+		AddRow(int64(2), "beta@example.com").
+		AddRow(int64(3), "gamma@example.com")
+	mock.ExpectQuery("SELECT id, COALESCE\\(email").
+		WillReturnRows(emailRows)
 
 	got, err := repo.GetUserSpendingRanking(context.Background(), start, end, 12)
 	require.NoError(t, err)
 	require.Equal(t, &usagestats.UserSpendingRankingResponse{
 		Ranking: []usagestats.UserSpendingRankingItem{
+			// cost tie (12.5) broken by tokens DESC: user 2 (900) before user 1 (800).
 			{UserID: 2, Email: "beta@example.com", ActualCost: 12.5, Requests: 9, Tokens: 900},
 			{UserID: 1, Email: "alpha@example.com", ActualCost: 12.5, Requests: 8, Tokens: 800},
 			{UserID: 3, Email: "gamma@example.com", ActualCost: 4.25, Requests: 5, Tokens: 300},
 		},
-		TotalActualCost: 40.0,
-		TotalRequests:   30,
-		TotalTokens:     2600,
+		TotalActualCost: 29.25,
+		TotalRequests:   22,
+		TotalTokens:     2000,
 	}, got)
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/backend/internal/repository/usage_log_repo_tk_user_platform_rollup.go
+++ b/backend/internal/repository/usage_log_repo_tk_user_platform_rollup.go
@@ -1,0 +1,403 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"sort"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
+	"github.com/lib/pq"
+)
+
+// userSpendAgg accumulates a single user's window aggregate while merging the
+// rollup and raw-remainder reads.
+type userSpendAgg struct {
+	cost     float64
+	requests int64
+	tokens   int64
+}
+
+// TK: rollup-backed read paths for the two heaviest admin-page aggregations.
+//
+// Both previously scanned the full 30-day created_at window of usage_logs
+// (~1.25M rows / 845K buffers / 2.7s on prod). A wide-window aggregation over
+// ~half a 2-month table cannot be sped up by ANY index — the planner correctly
+// prefers a bitmap heap scan, and forcing a covering/partial index is the same
+// cost or worse (verified by EXPLAIN ANALYZE at prod scale). The structural fix
+// is to read pre-aggregated per-(user, platform, day) rows from
+// usage_dashboard_user_platform_daily (~hundreds of rows, sub-millisecond)
+// instead of the raw logs.
+//
+// Exact-semantics decomposition (works for ANY [start,end) window and timezone):
+//
+//	[start, end) = rawHead ∪ rollupMiddle ∪ rawTail
+//
+//	  rollupMiddle = [ceilDay(start), floorDay(min(end, today)))  -- FULL completed
+//	                 server-TZ days strictly inside the window, served by the rollup
+//	  rawHead      = [start, ceilDay(start))                      -- partial leading day
+//	  rawTail      = [max(rollupEnd, start), end)                 -- partial trailing day
+//	                 plus all of today (today's bucket is still mutating)
+//
+// The rollup only ever covers complete, immutable past days, so it reproduces
+// the raw sum exactly; every partial/today slice is read live from usage_logs (a
+// narrow created_at window the existing index serves cheaply). This keeps "today"
+// numbers exact and bounds rollup staleness to one aggregation interval (~1 min),
+// well inside the page's existing 30s cache.
+
+// usageRollupWindow describes how a [start,end) window splits into a completed-day
+// rollup span and the raw remainder(s).
+type usageRollupWindow struct {
+	rollupStartDay time.Time // inclusive, server-TZ midnight; zero if no rollup span
+	rollupEndDay   time.Time // exclusive, server-TZ midnight; zero if no rollup span
+	hasRollup      bool
+	rawSpans       [][2]time.Time // half-open [from,to) raw remainders to read from usage_logs
+}
+
+// planUsageRollupWindow computes the decomposition above. `now` and the
+// server-TZ day boundaries are taken from the timezone package so the day grain
+// matches usage_dashboard_user_platform_daily.bucket_date exactly.
+func planUsageRollupWindow(start, end time.Time) usageRollupWindow {
+	today := timezone.Today()
+
+	// Last instant the rollup may cover: completed days only, never today, never
+	// past the window end.
+	cap := today
+	if end.Before(cap) {
+		cap = end
+	}
+
+	rollupStart := ceilDayServerTZ(start)
+	rollupEnd := timezone.StartOfDay(cap) // floor to server-TZ midnight
+
+	w := usageRollupWindow{}
+	if rollupEnd.After(rollupStart) {
+		w.hasRollup = true
+		w.rollupStartDay = rollupStart
+		w.rollupEndDay = rollupEnd
+		// Raw head: the partial leading day before the first full rollup day.
+		if rollupStart.After(start) {
+			w.rawSpans = append(w.rawSpans, [2]time.Time{start, rollupStart})
+		}
+		// Raw tail: from the end of the rollup span to the window end (covers the
+		// partial trailing day and all of today).
+		if end.After(rollupEnd) {
+			w.rawSpans = append(w.rawSpans, [2]time.Time{rollupEnd, end})
+		}
+	} else {
+		// No complete day fits — serve the whole window from raw logs.
+		if end.After(start) {
+			w.rawSpans = append(w.rawSpans, [2]time.Time{start, end})
+		}
+	}
+	return w
+}
+
+// ceilDayServerTZ returns the start of the first full server-TZ day at or after t.
+func ceilDayServerTZ(t time.Time) time.Time {
+	floor := timezone.StartOfDay(t)
+	if floor.Equal(t.In(floor.Location())) {
+		return floor
+	}
+	return floor.Add(24 * time.Hour)
+}
+
+// getBatchUserUsageStatsRollup answers GetBatchUserUsageStats from the rollup for
+// completed days plus raw usage_logs for the partial/today slices. Output is
+// byte-identical to the legacy single-query path: per-(user, effective-platform)
+// total_cost over [startTime,endTime) and today_cost over [today, ...). Only
+// billed rows (actual_cost > 0) contribute, matching usageLogSuccessFilterUL.
+func (r *usageLogRepository) getBatchUserUsageStatsRollup(ctx context.Context, userIDs []int64, startTime, endTime time.Time) (map[int64]*BatchUserUsageStats, error) {
+	result := make(map[int64]*BatchUserUsageStats, len(userIDs))
+	for _, id := range userIDs {
+		result[id] = &BatchUserUsageStats{UserID: id}
+	}
+
+	today := timezone.Today()
+	// Accumulate per (user, platform) so we can emit ByPlatform deterministically.
+	type key struct {
+		user     int64
+		platform string
+	}
+	type acc struct {
+		total float64
+		today float64
+	}
+	agg := make(map[key]*acc)
+	add := func(user int64, platform string, total, todayCost float64) {
+		if platform == "" {
+			return
+		}
+		k := key{user: user, platform: platform}
+		a, ok := agg[k]
+		if !ok {
+			a = &acc{}
+			agg[k] = a
+		}
+		a.total += total
+		a.today += todayCost
+	}
+
+	win := planUsageRollupWindow(startTime, endTime)
+
+	// Rollup portion: completed days only. By construction these days are < today,
+	// so they never carry today_cost; only billed rows are summed (actual_cost is
+	// the rollup's own sum, but a per-day row may include zero-cost rows in its
+	// request count — for cost the sum already excludes nothing, and zero-cost
+	// adds 0, so the billed-only total equals the rollup actual_cost sum).
+	if win.hasRollup {
+		const q = `
+			SELECT user_id, platform, COALESCE(SUM(actual_cost), 0)
+			FROM usage_dashboard_user_platform_daily
+			WHERE user_id = ANY($1)
+			  AND bucket_date >= $2::date AND bucket_date < $3::date
+			GROUP BY user_id, platform
+		`
+		rows, err := r.sql.QueryContext(ctx, q, pq.Array(userIDs), win.rollupStartDay, win.rollupEndDay)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var uid int64
+			var platform string
+			var total float64
+			if err := rows.Scan(&uid, &platform, &total); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			add(uid, platform, total, 0)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Raw portion: each partial/today slice. today_cost is the part of the slice
+	// that is >= today.
+	for _, span := range win.rawSpans {
+		from, to := span[0], span[1]
+		const q = `
+			SELECT
+				ul.user_id,
+				` + usageLogEffectivePlatformExpr + ` AS platform,
+				COALESCE(SUM(ul.actual_cost), 0) AS total_cost,
+				COALESCE(SUM(ul.actual_cost) FILTER (WHERE ul.created_at >= $4), 0) AS today_cost
+			FROM usage_logs ul
+			LEFT JOIN groups g ON g.id = ul.group_id
+			LEFT JOIN accounts a ON a.id = ul.account_id
+			WHERE ul.user_id = ANY($1)
+			  AND ul.created_at >= $2 AND ul.created_at < $3
+			  AND ` + usageLogSuccessFilterUL + `
+			GROUP BY ul.user_id, ` + usageLogEffectivePlatformExpr + `
+		`
+		rows, err := r.sql.QueryContext(ctx, q, pq.Array(userIDs), from, to, today)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var uid int64
+			var platform sql.NullString
+			var total, todayCost float64
+			if err := rows.Scan(&uid, &platform, &total, &todayCost); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			if platform.Valid {
+				add(uid, platform.String, total, todayCost)
+			}
+		}
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	for k, a := range agg {
+		stats, ok := result[k.user]
+		if !ok {
+			continue
+		}
+		stats.TotalActualCost += a.total
+		stats.TodayActualCost += a.today
+		stats.ByPlatform = append(stats.ByPlatform, usagestats.PlatformUsage{
+			Platform:        k.platform,
+			TotalActualCost: a.total,
+			TodayActualCost: a.today,
+		})
+	}
+	return result, nil
+}
+
+// getUserSpendingRankingRollup answers GetUserSpendingRanking from the rollup for
+// completed days plus raw usage_logs for the partial/today slices. Unlike the
+// batch path, this counts requests and sums tokens over EVERY row (including
+// actual_cost = 0): the rollup's total_requests / token columns already include
+// zero-cost rows, and the raw slices use no actual_cost filter, so the merged
+// totals match the legacy CTE exactly. email + ordering + window totals are
+// derived in Go to preserve the legacy output shape.
+func (r *usageLogRepository) getUserSpendingRankingRollup(ctx context.Context, startTime, endTime time.Time, limit int) (*UserSpendingRankingResponse, error) {
+	byUser := make(map[int64]*userSpendAgg)
+	addRow := func(user int64, cost float64, reqs, toks int64) {
+		a, ok := byUser[user]
+		if !ok {
+			a = &userSpendAgg{}
+			byUser[user] = a
+		}
+		a.cost += cost
+		a.requests += reqs
+		a.tokens += toks
+	}
+
+	win := planUsageRollupWindow(startTime, endTime)
+
+	if win.hasRollup {
+		const q = `
+			SELECT
+				user_id,
+				COALESCE(SUM(actual_cost), 0),
+				COALESCE(SUM(total_requests), 0),
+				COALESCE(SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens), 0)
+			FROM usage_dashboard_user_platform_daily
+			WHERE bucket_date >= $1::date AND bucket_date < $2::date
+			GROUP BY user_id
+		`
+		rows, err := r.sql.QueryContext(ctx, q, win.rollupStartDay, win.rollupEndDay)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var uid, reqs, toks int64
+			var cost float64
+			if err := rows.Scan(&uid, &cost, &reqs, &toks); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			addRow(uid, cost, reqs, toks)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, span := range win.rawSpans {
+		from, to := span[0], span[1]
+		const q = `
+			SELECT
+				user_id,
+				COALESCE(SUM(actual_cost), 0),
+				COUNT(*),
+				COALESCE(SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens), 0)
+			FROM usage_logs
+			WHERE created_at >= $1 AND created_at < $2
+			GROUP BY user_id
+		`
+		rows, err := r.sql.QueryContext(ctx, q, from, to)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var uid, reqs, toks int64
+			var cost float64
+			if err := rows.Scan(&uid, &cost, &reqs, &toks); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			addRow(uid, cost, reqs, toks)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	return r.assembleUserSpendingRanking(ctx, byUser, limit)
+}
+
+// assembleUserSpendingRanking turns the per-user aggregate into the legacy
+// response: window totals over ALL users, top-N ordered by (actual_cost DESC,
+// tokens DESC, user_id ASC), each item enriched with the user email.
+func (r *usageLogRepository) assembleUserSpendingRanking(ctx context.Context, byUser map[int64]*userSpendAgg, limit int) (*UserSpendingRankingResponse, error) {
+	// Window-wide totals across every user (the legacy SUM() OVER ()).
+	resp := &UserSpendingRankingResponse{Ranking: make([]UserSpendingRankingItem, 0, len(byUser))}
+	userIDs := make([]int64, 0, len(byUser))
+	for uid, a := range byUser {
+		resp.TotalActualCost += a.cost
+		resp.TotalRequests += a.requests
+		resp.TotalTokens += a.tokens
+		userIDs = append(userIDs, uid)
+	}
+
+	emails, err := r.fetchUserEmails(ctx, userIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]UserSpendingRankingItem, 0, len(byUser))
+	for uid, a := range byUser {
+		items = append(items, UserSpendingRankingItem{
+			UserID:     uid,
+			Email:      emails[uid],
+			ActualCost: a.cost,
+			Requests:   a.requests,
+			Tokens:     a.tokens,
+		})
+	}
+	sortUserSpendingRankingItems(items)
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	resp.Ranking = items
+	return resp, nil
+}
+
+// fetchUserEmails loads id→email for the given users (LEFT JOIN users semantics:
+// a missing user maps to ""). Mirrors the legacy COALESCE(us.email,”).
+func (r *usageLogRepository) fetchUserEmails(ctx context.Context, userIDs []int64) (map[int64]string, error) {
+	emails := make(map[int64]string, len(userIDs))
+	if len(userIDs) == 0 {
+		return emails, nil
+	}
+	rows, err := r.sql.QueryContext(ctx, "SELECT id, COALESCE(email, '') FROM users WHERE id = ANY($1)", pq.Array(userIDs))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var id int64
+		var email string
+		if err := rows.Scan(&id, &email); err != nil {
+			return nil, err
+		}
+		emails[id] = email
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return emails, nil
+}
+
+// sortUserSpendingRankingItems applies the legacy ORDER BY actual_cost DESC,
+// tokens DESC, user_id ASC.
+func sortUserSpendingRankingItems(items []UserSpendingRankingItem) {
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := items[i], items[j]
+		if a.ActualCost != b.ActualCost {
+			return a.ActualCost > b.ActualCost
+		}
+		if a.Tokens != b.Tokens {
+			return a.Tokens > b.Tokens
+		}
+		return a.UserID < b.UserID
+	})
+}

--- a/backend/internal/repository/usage_log_repo_tk_user_platform_rollup.go
+++ b/backend/internal/repository/usage_log_repo_tk_user_platform_rollup.go
@@ -115,25 +115,38 @@ func (r *usageLogRepository) getBatchUserUsageStatsRollup(ctx context.Context, u
 	}
 
 	today := timezone.Today()
-	// Accumulate per (user, platform) so we can emit ByPlatform deterministically.
-	type key struct {
-		user     int64
-		platform string
-	}
+	// Two accumulators mirror the legacy single-query semantics exactly: the
+	// per-user total includes EVERY row (even one whose effective platform is
+	// empty), while the per-(user, platform) breakdown excludes empty-platform
+	// rows. (Empty platform is near-impossible — accounts.platform is NOT NULL —
+	// but the legacy query still folded such rows into the user total, so we do
+	// too.)
 	type acc struct {
 		total float64
 		today float64
 	}
-	agg := make(map[key]*acc)
+	type key struct {
+		user     int64
+		platform string
+	}
+	userTotal := make(map[int64]*acc)
+	byPlat := make(map[key]*acc)
 	add := func(user int64, platform string, total, todayCost float64) {
+		ut, ok := userTotal[user]
+		if !ok {
+			ut = &acc{}
+			userTotal[user] = ut
+		}
+		ut.total += total
+		ut.today += todayCost
 		if platform == "" {
 			return
 		}
 		k := key{user: user, platform: platform}
-		a, ok := agg[k]
+		a, ok := byPlat[k]
 		if !ok {
 			a = &acc{}
-			agg[k] = a
+			byPlat[k] = a
 		}
 		a.total += total
 		a.today += todayCost
@@ -206,9 +219,10 @@ func (r *usageLogRepository) getBatchUserUsageStatsRollup(ctx context.Context, u
 				_ = rows.Close()
 				return nil, err
 			}
-			if platform.Valid {
-				add(uid, platform.String, total, todayCost)
-			}
+			// platform.String is "" when NULL, which add() folds into the user
+			// total without emitting a ByPlatform entry — matching the legacy query
+			// that summed every row into the total regardless of platform.
+			add(uid, platform.String, total, todayCost)
 		}
 		if err := rows.Close(); err != nil {
 			return nil, err
@@ -218,18 +232,20 @@ func (r *usageLogRepository) getBatchUserUsageStatsRollup(ctx context.Context, u
 		}
 	}
 
-	for k, a := range agg {
-		stats, ok := result[k.user]
-		if !ok {
-			continue
+	for uid, a := range userTotal {
+		if stats, ok := result[uid]; ok {
+			stats.TotalActualCost += a.total
+			stats.TodayActualCost += a.today
 		}
-		stats.TotalActualCost += a.total
-		stats.TodayActualCost += a.today
-		stats.ByPlatform = append(stats.ByPlatform, usagestats.PlatformUsage{
-			Platform:        k.platform,
-			TotalActualCost: a.total,
-			TodayActualCost: a.today,
-		})
+	}
+	for k, a := range byPlat {
+		if stats, ok := result[k.user]; ok {
+			stats.ByPlatform = append(stats.ByPlatform, usagestats.PlatformUsage{
+				Platform:        k.platform,
+				TotalActualCost: a.total,
+				TodayActualCost: a.today,
+			})
+		}
 	}
 	return result, nil
 }

--- a/backend/internal/repository/usage_log_repo_tk_user_platform_rollup_integration_test.go
+++ b/backend/internal/repository/usage_log_repo_tk_user_platform_rollup_integration_test.go
@@ -200,3 +200,53 @@ func (s *UsageLogRepoSuite) TestRollupParity_EqualsLegacyRawScan() {
 	s.Require().NoError(err)
 	s.InDelta(refCost, batch[user.ID].TotalActualCost, 1e-9, "rollup batch total must equal raw window sum")
 }
+
+// TestRollupParity_EmptyEffectivePlatform locks the edge case where a completed
+// day's effective platform is empty (account.platform = ” and group.platform =
+// ”, a storable-but-near-impossible state since accounts.platform is NOT NULL
+// without a non-empty CHECK). The legacy queries folded such rows into the user
+// TOTAL (ranking groups only by user_id; batch sums every row into the total but
+// only emits non-empty platforms in ByPlatform). The rollup must preserve that:
+// the feeder coalesces empty platform to ” instead of dropping the row, and the
+// reads fold ” into the total without emitting an empty ByPlatform entry.
+func (s *UsageLogRepoSuite) TestRollupParity_EmptyEffectivePlatform() {
+	today := timezone.Today()
+	user := mustCreateUser(s.T(), s.client, &service.User{Email: "rollup-empty@test.com"})
+	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-rollup-empty", Name: "k"})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-empty-acc", Platform: service.PlatformAnthropic})
+	grp := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-empty-grp", Platform: service.PlatformAnthropic})
+
+	// Force both platforms empty so COALESCE(NULLIF(g.platform,''), a.platform) = ''.
+	_, err := s.repo.sql.ExecContext(s.ctx, "UPDATE accounts SET platform = '' WHERE id = $1", acc.ID)
+	s.Require().NoError(err)
+	_, err = s.repo.sql.ExecContext(s.ctx, "UPDATE groups SET platform = '' WHERE id = $1", grp.ID)
+	s.Require().NoError(err)
+
+	// One billed row on a completed day -> served from the rollup, not raw.
+	s.rollupParityCreateLog(user, key, acc, grp.ID, 7, 11, 0, 0, 0.55, today.Add(-3*24*time.Hour).Add(8*time.Hour))
+
+	aggRepo := newDashboardAggregationRepositoryWithSQL(s.tx)
+	start := today.Add(-30 * 24 * time.Hour)
+	s.Require().NoError(aggRepo.AggregateRange(s.ctx, start, today))
+
+	// Ranking: the empty-platform row must contribute to the user total.
+	resp, err := s.repo.GetUserSpendingRanking(s.ctx, start, today, 12)
+	s.Require().NoError(err)
+	var got UserSpendingRankingItem
+	for _, it := range resp.Ranking {
+		if it.UserID == user.ID {
+			got = it
+		}
+	}
+	s.InDelta(0.55, got.ActualCost, 1e-9, "empty-platform row must count in ranking total")
+	s.Equal(int64(1), got.Requests)
+	s.Equal(int64(18), got.Tokens) // 7+11
+
+	// Batch: total includes the empty-platform row, ByPlatform omits the '' entry.
+	batch, err := s.repo.GetBatchUserUsageStats(s.ctx, []int64{user.ID}, start, today)
+	s.Require().NoError(err)
+	s.InDelta(0.55, batch[user.ID].TotalActualCost, 1e-9, "empty-platform row must count in batch total")
+	for _, p := range batch[user.ID].ByPlatform {
+		s.NotEqual("", p.Platform, "ByPlatform must not contain an empty-platform entry")
+	}
+}

--- a/backend/internal/repository/usage_log_repo_tk_user_platform_rollup_integration_test.go
+++ b/backend/internal/repository/usage_log_repo_tk_user_platform_rollup_integration_test.go
@@ -1,0 +1,202 @@
+//go:build integration
+
+package repository
+
+import (
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+func indexByPlatform(rows []usagestats.PlatformUsage) map[string]usagestats.PlatformUsage {
+	out := make(map[string]usagestats.PlatformUsage, len(rows))
+	for _, r := range rows {
+		out[r.Platform] = r
+	}
+	return out
+}
+
+// rollupParityCreateLog inserts a usage log pinned to a group (so the
+// COALESCE(g.platform, a.platform) effective-platform path is exercised) at a
+// chosen instant, and returns the contribution it makes to the reference totals.
+func (s *UsageLogRepoSuite) rollupParityCreateLog(user *service.User, apiKey *service.APIKey, account *service.Account, groupID int64, in, out, cacheCreate, cacheRead int, cost float64, createdAt time.Time) {
+	gid := groupID
+	log := &service.UsageLog{
+		UserID:              user.ID,
+		APIKeyID:            apiKey.ID,
+		AccountID:           account.ID,
+		GroupID:             &gid,
+		Model:               "claude-3",
+		InputTokens:         in,
+		OutputTokens:        out,
+		CacheCreationTokens: cacheCreate,
+		CacheReadTokens:     cacheRead,
+		TotalCost:           cost,
+		ActualCost:          cost,
+		CreatedAt:           createdAt,
+	}
+	_, err := s.repo.Create(s.ctx, log)
+	s.Require().NoError(err)
+}
+
+// TestRollupParity_BatchAndRanking is the load-bearing equality test: it builds a
+// fixture spanning multiple users, multiple effective platforms (including a
+// group platform that OVERRIDES its account's platform via COALESCE), several
+// completed days, zero-cost rows, and today's partial day; populates the
+// per-(user, platform, day) rollup via AggregateRange; then asserts both
+// rollup-backed read paths equal an independently hand-computed reference (the
+// numbers the legacy raw-scan queries produced). Covers the default 30-day
+// window and the narrow today-only window.
+func (s *UsageLogRepoSuite) TestRollupParity_BatchAndRanking() {
+	now := time.Now()
+	today := timezone.Today()
+	// Instants: two completed past days + today (after midnight).
+	day5 := today.Add(-5 * 24 * time.Hour).Add(9 * time.Hour)
+	day2 := today.Add(-2 * 24 * time.Hour).Add(14 * time.Hour)
+	todayPoint := today.Add(3 * time.Hour)
+	if todayPoint.After(now) {
+		todayPoint = now.Add(-time.Minute)
+	}
+
+	user1 := mustCreateUser(s.T(), s.client, &service.User{Email: "rollup-u1@test.com"})
+	user2 := mustCreateUser(s.T(), s.client, &service.User{Email: "rollup-u2@test.com"})
+	key1 := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user1.ID, Key: "sk-rollup-1", Name: "k"})
+	key2 := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user2.ID, Key: "sk-rollup-2", Name: "k"})
+	accAnthropic := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-acc-anthropic", Platform: service.PlatformAnthropic})
+	accOpenAI := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-acc-openai", Platform: service.PlatformOpenAI})
+	// Anthropic account, but the group platform is openai -> COALESCE must report openai.
+	grpAnthropic := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-grp-anthropic", Platform: service.PlatformAnthropic})
+	grpOpenAI := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-grp-openai", Platform: service.PlatformOpenAI})
+
+	// user1, anthropic platform:
+	//   day5: 0.50 (10/20 tok), day2: 0.30 (10/20), today: 0.10 (10/20)
+	//   day2 also one ZERO-cost row (5/5 tok) -> counts in requests/tokens, not in billed total
+	s.rollupParityCreateLog(user1, key1, accAnthropic, grpAnthropic.ID, 10, 20, 0, 0, 0.50, day5)
+	s.rollupParityCreateLog(user1, key1, accAnthropic, grpAnthropic.ID, 10, 20, 0, 0, 0.30, day2)
+	s.rollupParityCreateLog(user1, key1, accAnthropic, grpAnthropic.ID, 5, 5, 0, 0, 0.00, day2)
+	s.rollupParityCreateLog(user1, key1, accAnthropic, grpAnthropic.ID, 10, 20, 0, 0, 0.10, todayPoint)
+	// user1, openai platform (anthropic account + openai group, COALESCE override):
+	//   day5: 0.40 (10/20 + 2/3 cache)
+	s.rollupParityCreateLog(user1, key1, accAnthropic, grpOpenAI.ID, 10, 20, 2, 3, 0.40, day5)
+
+	// user2, openai platform:
+	//   day2: 0.70, today: 0.20
+	s.rollupParityCreateLog(user2, key2, accOpenAI, grpOpenAI.ID, 10, 20, 0, 0, 0.70, day2)
+	s.rollupParityCreateLog(user2, key2, accOpenAI, grpOpenAI.ID, 10, 20, 0, 0, 0.20, todayPoint)
+
+	// Populate the rollup over the completed-day span (today is read from raw).
+	aggRepo := newDashboardAggregationRepositoryWithSQL(s.tx)
+	s.Require().NoError(aggRepo.AggregateRange(s.ctx, today.Add(-30*24*time.Hour), today), "AggregateRange")
+
+	// --- GetBatchUserUsageStats (default 30d window) ---
+	stats, err := s.repo.GetBatchUserUsageStats(s.ctx, []int64{user1.ID, user2.ID}, time.Time{}, time.Time{})
+	s.Require().NoError(err)
+	s.Require().Len(stats, 2)
+
+	// user1 total: 0.50+0.30+0.00+0.10 (anthropic) + 0.40 (openai) = 1.30; today 0.10
+	s.InDelta(1.30, stats[user1.ID].TotalActualCost, 1e-9)
+	s.InDelta(0.10, stats[user1.ID].TodayActualCost, 1e-9)
+	b1 := indexByPlatform(stats[user1.ID].ByPlatform)
+	s.InDelta(0.90, b1[service.PlatformAnthropic].TotalActualCost, 1e-9) // 0.50+0.30+0.10
+	s.InDelta(0.10, b1[service.PlatformAnthropic].TodayActualCost, 1e-9)
+	s.InDelta(0.40, b1[service.PlatformOpenAI].TotalActualCost, 1e-9, "COALESCE(g.platform,a.platform) override -> openai")
+	s.InDelta(0.00, b1[service.PlatformOpenAI].TodayActualCost, 1e-9)
+
+	// user2 total: 0.70+0.20 = 0.90; today 0.20; openai only
+	s.InDelta(0.90, stats[user2.ID].TotalActualCost, 1e-9)
+	s.InDelta(0.20, stats[user2.ID].TodayActualCost, 1e-9)
+	b2 := indexByPlatform(stats[user2.ID].ByPlatform)
+	s.InDelta(0.90, b2[service.PlatformOpenAI].TotalActualCost, 1e-9)
+	s.InDelta(0.20, b2[service.PlatformOpenAI].TodayActualCost, 1e-9)
+
+	// --- GetBatchUserUsageStats: narrow today-only window ---
+	narrow, err := s.repo.GetBatchUserUsageStats(s.ctx, []int64{user1.ID, user2.ID}, today, now.Add(time.Hour))
+	s.Require().NoError(err)
+	s.InDelta(0.10, narrow[user1.ID].TotalActualCost, 1e-9)
+	s.InDelta(0.10, narrow[user1.ID].TodayActualCost, 1e-9)
+	s.InDelta(0.20, narrow[user2.ID].TotalActualCost, 1e-9)
+	s.InDelta(0.20, narrow[user2.ID].TodayActualCost, 1e-9)
+
+	// --- GetUserSpendingRanking (default 30d window, includes today) ---
+	resp, err := s.repo.GetUserSpendingRanking(s.ctx, today.Add(-30*24*time.Hour), now.Add(time.Hour), 12)
+	s.Require().NoError(err)
+	rank := make(map[int64]UserSpendingRankingItem)
+	for _, it := range resp.Ranking {
+		rank[it.UserID] = it
+	}
+	// user1: cost 1.30, requests 5 (incl. zero-cost), tokens:
+	//   day5 30 + day2 30 + day2zero 10 + today 30 + openai(30+5cache) 35 = 135
+	s.InDelta(1.30, rank[user1.ID].ActualCost, 1e-9)
+	s.Equal(int64(5), rank[user1.ID].Requests, "zero-cost row must count")
+	s.Equal(int64(135), rank[user1.ID].Tokens)
+	s.Equal("rollup-u1@test.com", rank[user1.ID].Email)
+	// user2: cost 0.90, requests 2, tokens 60
+	s.InDelta(0.90, rank[user2.ID].ActualCost, 1e-9)
+	s.Equal(int64(2), rank[user2.ID].Requests)
+	s.Equal(int64(60), rank[user2.ID].Tokens)
+
+	// Window totals across both users.
+	s.InDelta(2.20, resp.TotalActualCost, 1e-9)
+	s.Equal(int64(7), resp.TotalRequests)
+	s.Equal(int64(195), resp.TotalTokens)
+
+	// Ordering: user1 (1.30) before user2 (0.90).
+	s.Require().GreaterOrEqual(len(resp.Ranking), 2)
+	s.Equal(user1.ID, resp.Ranking[0].UserID)
+}
+
+// TestRollupParity_EqualsLegacyRawScan cross-checks the rollup path against a
+// direct raw-usage_logs computation of the SAME semantics for a randomized-ish
+// fixture, so the parity is asserted against an independent SQL reference rather
+// than only hand-computed constants.
+func (s *UsageLogRepoSuite) TestRollupParity_EqualsLegacyRawScan() {
+	today := timezone.Today()
+	user := mustCreateUser(s.T(), s.client, &service.User{Email: "rollup-legacy@test.com"})
+	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-rollup-legacy", Name: "k"})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-legacy-acc", Platform: service.PlatformAnthropic})
+	grp := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-legacy-grp", Platform: service.PlatformAnthropic})
+
+	// Spread rows across 4 completed days; the rollup must equal the raw window sum.
+	for d := 1; d <= 4; d++ {
+		ts := today.Add(time.Duration(-d) * 24 * time.Hour).Add(time.Duration(d) * time.Hour)
+		s.rollupParityCreateLog(user, key, acc, grp.ID, d, d*2, 0, 0, float64(d)*0.11, ts)
+	}
+
+	aggRepo := newDashboardAggregationRepositoryWithSQL(s.tx)
+	start := today.Add(-30 * 24 * time.Hour)
+	s.Require().NoError(aggRepo.AggregateRange(s.ctx, start, today))
+
+	// Reference: legacy raw computation of total actual_cost over [start, today),
+	// run through the same executor (tx) the repo uses so it sees the same data.
+	var refCost float64
+	var refReqs int64
+	var refTokens int64
+	rows, err := s.repo.sql.QueryContext(s.ctx, `
+		SELECT COALESCE(SUM(actual_cost),0), COUNT(*),
+		       COALESCE(SUM(input_tokens+output_tokens+cache_creation_tokens+cache_read_tokens),0)
+		FROM usage_logs WHERE user_id = $1 AND created_at >= $2 AND created_at < $3
+	`, user.ID, start, today)
+	s.Require().NoError(err)
+	s.Require().True(rows.Next())
+	s.Require().NoError(rows.Scan(&refCost, &refReqs, &refTokens))
+	s.Require().NoError(rows.Close())
+
+	resp, err := s.repo.GetUserSpendingRanking(s.ctx, start, today, 12)
+	s.Require().NoError(err)
+	var got UserSpendingRankingItem
+	for _, it := range resp.Ranking {
+		if it.UserID == user.ID {
+			got = it
+		}
+	}
+	s.InDelta(refCost, got.ActualCost, 1e-9, "rollup ranking cost must equal raw window sum")
+	s.Equal(refReqs, got.Requests, "rollup ranking requests must equal raw window count")
+	s.Equal(refTokens, got.Tokens, "rollup ranking tokens must equal raw window sum")
+
+	// Batch total over the same [start, today) window (no today slice here).
+	batch, err := s.repo.GetBatchUserUsageStats(s.ctx, []int64{user.ID}, start, today)
+	s.Require().NoError(err)
+	s.InDelta(refCost, batch[user.ID].TotalActualCost, 1e-9, "rollup batch total must equal raw window sum")
+}

--- a/backend/internal/repository/usage_log_repo_tk_user_platform_rollup_test.go
+++ b/backend/internal/repository/usage_log_repo_tk_user_platform_rollup_test.go
@@ -1,0 +1,142 @@
+//go:build unit
+
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPlanUsageRollupWindow verifies the [start,end) -> rollup + raw remainder
+// decomposition that keeps the rollup-backed reads byte-exact. The key
+// invariants: (1) the rollup span only ever covers FULL completed server-TZ days
+// strictly before today; (2) the raw remainders exactly cover the rest of the
+// window (partial head day + partial tail/today) with no gap and no overlap.
+func TestPlanUsageRollupWindow(t *testing.T) {
+	today := timezone.Today()
+	day := 24 * time.Hour
+
+	t.Run("default 30d window splits into rollup middle + partial head + today tail", func(t *testing.T) {
+		// startTime is mid-day 30 days ago (the GetBatchUserUsageStats default).
+		start := today.Add(-30 * day).Add(9 * time.Hour)
+		end := today.Add(15 * time.Hour) // some point during today
+		w := planUsageRollupWindow(start, end)
+
+		require.True(t, w.hasRollup)
+		// First full day is the day after the partial start day.
+		require.Equal(t, today.Add(-29*day), w.rollupStartDay)
+		// Rollup ends at start-of-today (today's bucket is excluded).
+		require.Equal(t, today, w.rollupEndDay)
+		// Two raw remainders: partial head [start, ceilDay(start)) and tail [today, end).
+		require.Len(t, w.rawSpans, 2)
+		require.Equal(t, start, w.rawSpans[0][0])
+		require.Equal(t, today.Add(-29*day), w.rawSpans[0][1])
+		require.Equal(t, today, w.rawSpans[1][0])
+		require.Equal(t, end, w.rawSpans[1][1])
+		assertWindowCoverage(t, start, end, w)
+	})
+
+	t.Run("day-aligned window has no partial head", func(t *testing.T) {
+		start := today.Add(-7 * day) // exactly midnight 7 days ago
+		end := today                 // exactly start of today
+		w := planUsageRollupWindow(start, end)
+
+		require.True(t, w.hasRollup)
+		require.Equal(t, start, w.rollupStartDay)
+		require.Equal(t, today, w.rollupEndDay)
+		// No raw remainder: the window is exactly 7 completed days.
+		require.Empty(t, w.rawSpans)
+		assertWindowCoverage(t, start, end, w)
+	})
+
+	t.Run("today-only window is fully raw", func(t *testing.T) {
+		start := today
+		end := today.Add(10 * time.Hour)
+		w := planUsageRollupWindow(start, end)
+
+		require.False(t, w.hasRollup)
+		require.Len(t, w.rawSpans, 1)
+		require.Equal(t, start, w.rawSpans[0][0])
+		require.Equal(t, end, w.rawSpans[0][1])
+		assertWindowCoverage(t, start, end, w)
+	})
+
+	t.Run("sub-day window inside today is fully raw", func(t *testing.T) {
+		start := today.Add(2 * time.Hour)
+		end := today.Add(5 * time.Hour)
+		w := planUsageRollupWindow(start, end)
+
+		require.False(t, w.hasRollup)
+		require.Len(t, w.rawSpans, 1)
+		assertWindowCoverage(t, start, end, w)
+	})
+
+	t.Run("purely historical window (ends before today) uses rollup, no today tail", func(t *testing.T) {
+		start := today.Add(-10 * day)
+		end := today.Add(-3 * day) // day-aligned, all completed
+		w := planUsageRollupWindow(start, end)
+
+		require.True(t, w.hasRollup)
+		require.Equal(t, start, w.rollupStartDay)
+		require.Equal(t, end, w.rollupEndDay)
+		require.Empty(t, w.rawSpans)
+		assertWindowCoverage(t, start, end, w)
+	})
+
+	t.Run("historical window with partial tail day reads tail from raw", func(t *testing.T) {
+		start := today.Add(-10 * day)
+		end := today.Add(-3 * day).Add(6 * time.Hour) // partial last day
+		w := planUsageRollupWindow(start, end)
+
+		require.True(t, w.hasRollup)
+		require.Equal(t, start, w.rollupStartDay)
+		require.Equal(t, today.Add(-3*day), w.rollupEndDay)
+		require.Len(t, w.rawSpans, 1)
+		require.Equal(t, today.Add(-3*day), w.rawSpans[0][0])
+		require.Equal(t, end, w.rawSpans[0][1])
+		assertWindowCoverage(t, start, end, w)
+	})
+
+	t.Run("window shorter than one full day but spanning midnight is fully raw", func(t *testing.T) {
+		// start yesterday 23:00, end today 01:00 -> no FULL completed day fits.
+		start := today.Add(-1 * time.Hour)
+		end := today.Add(1 * time.Hour)
+		w := planUsageRollupWindow(start, end)
+
+		require.False(t, w.hasRollup)
+		require.Len(t, w.rawSpans, 1)
+		assertWindowCoverage(t, start, end, w)
+	})
+}
+
+// assertWindowCoverage proves the decomposition partitions [start,end) with no
+// gap and no overlap: concatenating the rollup span (if any) and the raw spans,
+// sorted, must reconstruct exactly [start,end).
+func assertWindowCoverage(t *testing.T, start, end time.Time, w usageRollupWindow) {
+	t.Helper()
+	type seg struct{ from, to time.Time }
+	segs := make([]seg, 0, 3)
+	if w.hasRollup {
+		segs = append(segs, seg{w.rollupStartDay, w.rollupEndDay})
+	}
+	for _, s := range w.rawSpans {
+		segs = append(segs, seg{s[0], s[1]})
+	}
+	// sort by from
+	for i := 0; i < len(segs); i++ {
+		for j := i + 1; j < len(segs); j++ {
+			if segs[j].from.Before(segs[i].from) {
+				segs[i], segs[j] = segs[j], segs[i]
+			}
+		}
+	}
+	require.NotEmpty(t, segs, "window must be covered")
+	require.True(t, segs[0].from.Equal(start), "coverage must start at window start")
+	for i := 1; i < len(segs); i++ {
+		require.True(t, segs[i-1].to.Equal(segs[i].from), "segments must be contiguous (no gap/overlap)")
+	}
+	require.True(t, segs[len(segs)-1].to.Equal(end), "coverage must end at window end")
+}

--- a/backend/migrations/tk_034_usage_dashboard_user_platform_daily.sql
+++ b/backend/migrations/tk_034_usage_dashboard_user_platform_daily.sql
@@ -1,0 +1,53 @@
+-- TK-only per-(user, effective-platform, day) rollup table that backs the two
+-- heaviest admin-page aggregations. Both previously scanned the full 30-day
+-- created_at window of usage_logs (2.37M rows / 2.3 GB on prod): a wide-window
+-- aggregation that touches ~half the table, which NO index can speed up (the
+-- planner correctly prefers a bitmap heap scan, so a covering index is refused).
+-- The only structural fix is to pre-aggregate the historical days so the page
+-- reads tens-to-hundreds of rollup rows instead of ~1.25M raw rows:
+--
+--   * GetUserSpendingRanking (dashboard spending-ranking widget): EXPLAIN
+--     ANALYZE 1,655 ms / 845K buffers.
+--   * GetBatchUserUsageStats (admin Users page usage columns): EXPLAIN
+--     ANALYZE 2,738 ms / 845K buffers + JIT.
+--
+-- Grain: one row per (user_id, platform, bucket_date). "platform" is the SAME
+-- effective platform the live queries compute -- COALESCE(NULLIF(g.platform,''),
+-- a.platform) -- so the rollup carries the per-platform breakdown
+-- GetBatchUserUsageStats.ByPlatform needs (the existing usage_dashboard_daily
+-- rollup is system-wide only and cannot serve it).
+--
+-- Metrics: actual_cost + the four token columns + request count, enough to
+-- reconstruct both queries' outputs byte-for-byte for completed days. requests
+-- and tokens are summed over EVERY row (including actual_cost = 0) because
+-- GetUserSpendingRanking counts/sums them unconditionally; consumers that want
+-- the billed-only total (GetBatchUserUsageStats) filter actual_cost in the
+-- read path, not here.
+--
+-- Staleness boundary: this table is populated by DashboardAggregationService
+-- (watermark-driven, ~1 min interval). The read path reads COMPLETED past days
+-- from here and reads TODAY's partial day from raw usage_logs (a narrow window
+-- the created_at index serves cheaply), so live "today" numbers are always
+-- exact and history is at most one aggregation interval stale -- well inside the
+-- UI's existing 30s cache tolerance.
+
+CREATE TABLE IF NOT EXISTS usage_dashboard_user_platform_daily (
+    bucket_date           DATE NOT NULL,
+    user_id               BIGINT NOT NULL,
+    platform              VARCHAR(50) NOT NULL,
+    total_requests        BIGINT NOT NULL DEFAULT 0,
+    input_tokens          BIGINT NOT NULL DEFAULT 0,
+    output_tokens         BIGINT NOT NULL DEFAULT 0,
+    cache_creation_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_read_tokens     BIGINT NOT NULL DEFAULT 0,
+    actual_cost           DECIMAL(20, 10) NOT NULL DEFAULT 0,
+    computed_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (bucket_date, user_id, platform)
+);
+
+-- Read paths filter/aggregate by user_id over a date range (Users page batch
+-- lookup) and scan a date range across all users (spending ranking). A
+-- (user_id, bucket_date) secondary index serves the former; the PK's leading
+-- bucket_date serves the latter.
+CREATE INDEX IF NOT EXISTS idx_usage_dashboard_upd_user_date
+    ON usage_dashboard_user_platform_daily (user_id, bucket_date);

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2911,9 +2911,9 @@
       "must_contain": [
         "func (r *dashboardAggregationRepository) upsertUserPlatformDailyAggregates(",
         "INSERT INTO usage_dashboard_user_platform_daily",
-        "const usageDashboardUserPlatformDailyExpr = \"COALESCE(NULLIF(g.platform,''), a.platform)\""
+        "COALESCE(` + usageLogEffectivePlatformExpr + `, '') AS platform"
       ],
-      "rationale": "TK feeder that populates the per-(user, platform, day) rollup table (tk_034) backing the admin Users page + dashboard spending-ranking widget. This is the write half of the perf fix that replaced the full 30-day usage_logs scan (845K buffers / 2.7s on prod) with pre-aggregated reads. The effective-platform projection MUST stay identical to usageLogEffectivePlatformExpr or the rollup partitions by a different platform than the page shows; this sentinel pins the upsert, the target table, and the platform expression so an upstream merge / refactor cannot silently drop the feeder or drift the platform grain."
+      "rationale": "TK feeder that populates the per-(user, platform, day) rollup table (tk_034) backing the admin Users page + dashboard spending-ranking widget. This is the write half of the perf fix that replaced the full 30-day usage_logs scan (845K buffers / 2.7s on prod) with pre-aggregated reads. The effective-platform projection reuses the live queries' usageLogEffectivePlatformExpr (same package) so the rollup partitions by exactly the platform the page shows; this sentinel pins the upsert, the target table, and that the platform projection reuses the shared expression so an upstream merge / refactor cannot silently drop the feeder or drift the platform grain."
     },
     {
       "path": "backend/internal/repository/dashboard_aggregation_repo.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2905,6 +2905,42 @@
         "return nil, ErrThinPoolAllExcluded"
       ],
       "rationale": "Injection point of the thin-pool guard inside the Layer-2 load-balance empty-pool branch of SelectAccountWithLoadAwareness (right after the #845 account_scheduling_loadbalance_no_candidates WARN). It sums every non-exclusion per-gate counter into otherFilters and, on a thin exclusion-only empty pool, returns ErrThinPoolAllExcluded instead of ErrNoAvailableAccounts so the handler's HandleSelectionExhausted retries the lone account (short backoff, bounded by MaxSwitches) rather than fast-failing with a client 429. Single-block insertion into an upstream-shaped file; an upstream merge resolving this branch could silently drop it. Pins the predicate call + sentinel return + WARN marker."
+    },
+    {
+      "path": "backend/internal/repository/dashboard_aggregation_repo_tk_user_platform.go",
+      "must_contain": [
+        "func (r *dashboardAggregationRepository) upsertUserPlatformDailyAggregates(",
+        "INSERT INTO usage_dashboard_user_platform_daily",
+        "const usageDashboardUserPlatformDailyExpr = \"COALESCE(NULLIF(g.platform,''), a.platform)\""
+      ],
+      "rationale": "TK feeder that populates the per-(user, platform, day) rollup table (tk_034) backing the admin Users page + dashboard spending-ranking widget. This is the write half of the perf fix that replaced the full 30-day usage_logs scan (845K buffers / 2.7s on prod) with pre-aggregated reads. The effective-platform projection MUST stay identical to usageLogEffectivePlatformExpr or the rollup partitions by a different platform than the page shows; this sentinel pins the upsert, the target table, and the platform expression so an upstream merge / refactor cannot silently drop the feeder or drift the platform grain."
+    },
+    {
+      "path": "backend/internal/repository/dashboard_aggregation_repo.go",
+      "must_contain": [
+        "if err := r.upsertUserPlatformDailyAggregates(ctx, dayStart, dayEnd); err != nil {",
+        "if err := r.deleteUserPlatformDailyRange(ctx, dayStart, dayEnd); err != nil {",
+        "if err := r.cleanupUserPlatformDaily(ctx, dailyCutoffUTC); err != nil {"
+      ],
+      "rationale": "Thin injection of the per-(user, platform, day) rollup feeder into the upstream-shaped aggregation repo: the upsert call lives in both aggregateRangeInTx and recomputeRangeInTx, the range delete in recomputeRangeInTx (so a zeroed day does not linger after a usage_logs rollback), and the retention prune in CleanupAggregates. These are single-line hooks into upstream-shaped functions; an upstream merge resolving DashboardAggregationService could silently drop them, leaving the rollup unpopulated and the admin pages reading stale/empty history. Pins all three call sites."
+    },
+    {
+      "path": "backend/internal/repository/usage_log_repo_tk_user_platform_rollup.go",
+      "must_contain": [
+        "func (r *usageLogRepository) getBatchUserUsageStatsRollup(",
+        "func (r *usageLogRepository) getUserSpendingRankingRollup(",
+        "func planUsageRollupWindow(start, end time.Time) usageRollupWindow",
+        "FROM usage_dashboard_user_platform_daily"
+      ],
+      "rationale": "TK read half of the rollup perf fix: GetBatchUserUsageStats and GetUserSpendingRanking are served from usage_dashboard_user_platform_daily for completed days plus raw usage_logs for the partial/today slices. planUsageRollupWindow is the exact-semantics window decomposition (full completed server-TZ days from the rollup, partial head/tail + today from raw) that keeps output byte-identical to the legacy raw-scan queries. Pins both read entry points, the decomposition function, and the rollup table read so a merge cannot silently revert the pages to the slow full-window scan."
+    },
+    {
+      "path": "backend/internal/repository/usage_log_repo.go",
+      "must_contain": [
+        "return r.getBatchUserUsageStatsRollup(ctx, normalizedUserIDs, startTime, endTime)",
+        "return r.getUserSpendingRankingRollup(ctx, startTime, endTime, limit)"
+      ],
+      "rationale": "The two upstream-shaped admin aggregation methods (GetBatchUserUsageStats / GetUserSpendingRanking) now delegate to the rollup-backed readers instead of scanning the full 30-day usage_logs window. These one-line delegations are exactly the kind of edit an upstream merge could overwrite by restoring the old inline CTE/FILTER query, silently re-introducing the 845K-buffer / 2.7s regression. Pins both delegation calls."
     }
   ]
 }


### PR DESCRIPTION
## Problem (measured on prod, instance i-0e43099f…)

The two heaviest admin-page queries each scan the full 30-day `created_at` window of `usage_logs` (2,374,705 rows / 2.3 GB / ~2 months) — a wide-window aggregation that touches **~half the table**:

| Query | Backs | EXPLAIN ANALYZE |
|---|---|---|
| `GetBatchUserUsageStats` | Users page usage columns | **2,738 ms**, 845K buffers, parallel index-scan over 1.25M rows + JIT 451ms |
| `GetUserSpendingRanking` | Dashboard spending-ranking widget | **1,655 ms**, 845K buffers, full window CTE + window-function |

## Rollup vs index decision

I first tried covering/partial indexes on `usage_logs`. **EXPLAIN ANALYZE at prod scale (2.4M rows / 60 days) proves no index helps this access pattern** — the planner correctly refuses the covering index even at a 7-day window (12% of rows) and prefers a bitmap heap scan; forcing the index is the same cost or *worse* (100K buffers / 62ms vs 3.5K buffers / 24ms). A wide-window aggregation over half a table is irreducibly a heap scan. The existing `usage_dashboard_*` rollup is **system-wide totals only** (no per-user / per-platform grain), so it cannot serve these.

**Chosen fix (both queries): a per-(user, effective-platform, day) rollup.**

- New table `usage_dashboard_user_platform_daily` (migration `tk_034`), fed by the existing `DashboardAggregationService` (watermark-driven, ~1 min interval) via thin hooks into `AggregateRange` / `RecomputeRange` / `CleanupAggregates`.
- The rollup's platform is the **same** `COALESCE(NULLIF(g.platform,''), a.platform)` the live queries use, so it carries the per-platform breakdown `ByPlatform` needs.
- Metrics: `actual_cost` + 4 token columns + request count (requests/tokens include zero-cost rows because `GetUserSpendingRanking` counts them unconditionally; the billed-only consumer filters at read time).

## Before / after (measured at 2.4M-row / 60-day scale)

| Query | Before (raw scan) | After (rollup read) |
|---|---|---|
| Batch user usage | 845K buffers / ~2.7s | **19 buffers / 0.35 ms** |
| Spending ranking | 845K buffers / ~1.65s | **22 buffers / 0.15 ms** |

Rollup is ~hundreds of rows (27 users × ~2 platforms × 30 days) vs 1.25M raw rows.

## Staleness tradeoff (exact semantics preserved)

The read path (`usage_log_repo_tk_user_platform_rollup.go`) decomposes any `[start,end)` window:

```
[start,end) = rawHead ∪ rollupMiddle ∪ rawTail
  rollupMiddle = full completed server-TZ days  → rollup (immutable, exact)
  rawHead/rawTail = partial head/tail + ALL of today → raw usage_logs (live)
```

- **Today is always read live** from `usage_logs` (a narrow `created_at` window the existing index serves cheaply) → today's numbers are exact, never stale.
- Completed days are immutable, so the rollup reproduces the raw sum byte-for-byte; staleness is bounded to one aggregation interval (~1 min) — well inside the page's existing **30s cache**.
- For odd sub-day / cross-TZ windows where no full server-TZ day fits, the whole window falls back to raw — exact, never wrong.
- One-time deploy transient: until the first watermark-driven aggregation backfills the retention window (90 days, one background scan), history reads as empty — identical to the existing system-wide rollup's cold start; self-heals in minutes.

## Migration

- `backend/migrations/tk_034_usage_dashboard_user_platform_daily.sql` — **CREATE TABLE IF NOT EXISTS** + `CREATE INDEX IF NOT EXISTS` on a **new empty table**. No `CONCURRENTLY` needed (no lock on `usage_logs`; the new table has zero rows). Idempotent.
- No `ent/schema/` change: covering/partial index variants are SQL-migration-only here, matching the existing `usage_logs` index convention (the ent schema explicitly notes partial indexes live in SQL migrations).

## §5 convergence

TK rollup write + read logic lives in `*_tk_*.go` companions; upstream-shaped files (`dashboard_aggregation_repo.go`, `usage_log_repo.go`) get thin one-line hooks. **5 new `gateway-tk` sentinels** pin every injection point so an upstream merge can't silently revert the perf fix or drift the platform grain.

## Tests

- `usage_log_repo_tk_user_platform_rollup_test.go` (unit): `planUsageRollupWindow` decomposition — 7 cases proving the window is partitioned with no gap/overlap (default 30d, day-aligned, today-only, sub-day, historical, partial tail, midnight-spanning).
- `usage_log_repo_tk_user_platform_rollup_integration_test.go`: two parity tests over a multi-user / multi-platform / multi-day fixture incl. the `COALESCE(g.platform,a.platform)` override, zero-cost rows, today + narrow window, and an **independent raw-scan cross-check** asserting rollup == raw window sum.
- Updated the stale `GetUserSpendingRanking` sqlmock test to the new rollup+email query shape.

## Validation (all green locally)

- `go build ./...` ✅
- `go test -tags=unit ./...` ✅ (54 pkgs)
- `go test -tags=integration ./...` ✅ (0 FAIL)
- `golangci-lint run ./...` ✅ 0 issues
- `scripts/preflight.sh` ✅ PASS (incl. all sentinel registries, newapi compat-pool, catalog serving, registry-update gate)

no-web-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)