### PR TITLE
feat(grok): native xAI video generation arm (submit/poll, channel_type=0)

### DIFF
--- a/backend/internal/engine/capability_tk_grok_video.go
+++ b/backend/internal/engine/capability_tk_grok_video.go
@@ -1,0 +1,29 @@
+package engine
+
+import "github.com/Wei-Shaw/sub2api/internal/domain"
+
+// IsVideoSupportedForAccount reports whether an account can serve video
+// generation, accounting for grok's native (non-task-adaptor) video path.
+//
+// The canonical video path is the new-api task-adaptor model: a positive
+// channel_type whose numeric value maps to a registered new-api TaskAdaptor
+// (see IsVideoSupportedChannelType — the single source of truth for the
+// newapi/openai bridge video path). grok is the deliberate exception: it is a
+// native xAI-OAuth platform whose accounts run channel_type=0 and forward raw
+// Bearer to api.x.ai/v1 (no new-api channel). grok serves video through TK's
+// own grok-native arm (POST api.x.ai/v1/videos/generations + poll
+// GET /v1/videos/{request_id}), NOT through a new-api TaskAdaptor — so it
+// qualifies for video WITHOUT a task adaptor and at channel_type=0.
+//
+// This is intentionally a SEPARATE predicate from IsVideoSupportedChannelType
+// (which stays channel_type-derived and unchanged) so the two never drift: a
+// future upstream merge touching the task-adaptor registry cannot silently flip
+// grok's video eligibility, and a grok account is never mistaken for a newapi
+// channel by the channel_type>0 gate. Callers on the video path use THIS
+// predicate; the channel_type-derived one stays for the bridge dispatch gates.
+func IsVideoSupportedForAccount(platform string, channelType int) bool {
+	if platform == domain.PlatformGrok {
+		return true
+	}
+	return IsVideoSupportedChannelType(channelType)
+}

--- a/backend/internal/engine/capability_tk_grok_video_test.go
+++ b/backend/internal/engine/capability_tk_grok_video_test.go
@@ -1,0 +1,42 @@
+//go:build unit
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+)
+
+// TestIsVideoSupportedForAccount pins the platform-aware video gate: grok is
+// eligible at channel_type=0 (native xAI OAuth, no task adaptor), while every
+// other platform still falls back to the channel_type-derived predicate
+// (IsVideoSupportedChannelType). This guards the deliberate grok exception from
+// drifting back into the channel_type-only gate, which would re-block grok video.
+func TestIsVideoSupportedForAccount(t *testing.T) {
+	cases := []struct {
+		name        string
+		platform    string
+		channelType int
+		want        bool
+	}{
+		// grok: always eligible regardless of channel_type (native arm, ct=0).
+		{"grok_ct0", domain.PlatformGrok, 0, true},
+		{"grok_ct_negative", domain.PlatformGrok, -1, true},
+		{"grok_ct_positive", domain.PlatformGrok, 45, true},
+		// non-grok: defers to the channel_type-derived registry predicate.
+		{"openai_ct0_unsupported", domain.PlatformOpenAI, 0, false},
+		{"anthropic_ct0_unsupported", domain.PlatformAnthropic, 0, false},
+		{"newapi_volcengine_supported", domain.PlatformNewAPI, 45, true},
+		{"newapi_doubao_video_supported", domain.PlatformNewAPI, 54, true},
+		{"newapi_unknown_unsupported", domain.PlatformNewAPI, 9999, false},
+		{"empty_platform_ct0", "", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsVideoSupportedForAccount(tc.platform, tc.channelType); got != tc.want {
+				t.Fatalf("IsVideoSupportedForAccount(%q, %d) = %v, want %v", tc.platform, tc.channelType, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -171,9 +171,12 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 		return
 	}
 	account := selection.Account
-	if !engine.IsVideoSupportedChannelType(account.ChannelType) {
-		// channel_type=0 (incomplete account) and channel_type with no task
-		// adaptor (e.g. plain OpenAI account asked to do video) collapse into
+	// Platform-aware video gate: the newapi/openai path requires a channel_type
+	// whose value maps to a new-api TaskAdaptor; grok (channel_type=0 native
+	// OAuth) qualifies via its native arm. See engine.IsVideoSupportedForAccount.
+	if !engine.IsVideoSupportedForAccount(account.Platform, account.ChannelType) {
+		// channel_type=0 non-grok (incomplete account) and channel_type with no
+		// task adaptor (e.g. plain OpenAI account asked to do video) collapse into
 		// the same user-facing error: this group is not configured for video.
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Selected account's channel_type does not support video generation")
 		return
@@ -355,6 +358,10 @@ func (h *OpenAIGatewayHandler) VideoFetch(c *gin.Context) {
 		ChannelType:    rec.ChannelType,
 		BaseURL:        rec.BaseURL,
 		APIKey:         rec.APIKey,
+		// Platform + AccountID drive the grok-native poll branch (channel_type=0,
+		// re-resolve a fresh rotating OAuth Bearer). Ignored by the bridge path.
+		Platform:  rec.Platform,
+		AccountID: rec.AccountID,
 	}
 	out, err := h.gatewayService.ForwardAsVideoFetchDispatched(c.Request.Context(), c, in)
 	if err != nil {

--- a/backend/internal/relay/bridge/video_relay.go
+++ b/backend/internal/relay/bridge/video_relay.go
@@ -59,6 +59,14 @@ type VideoFetchInput struct {
 	ChannelType    int
 	BaseURL        string
 	APIKey         string
+	// Platform + AccountID support the grok-native video poll path (platform=grok,
+	// channel_type=0), which does NOT go through the new-api task adaptor. The
+	// bridge fetch ignores both; the TK service layer branches on Platform=="grok"
+	// to a native poll and re-resolves a fresh OAuth Bearer via AccountID (the
+	// pinned APIKey may be a rotated/stale grok token by poll time). Empty/zero
+	// for the bridge (channel_type>0) path — fully backward compatible.
+	Platform  string
+	AccountID int64
 }
 
 // VideoFetchOutcome holds the upstream raw response and the parsed status

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go
@@ -55,6 +55,13 @@ func (s *OpenAIGatewayService) ForwardAsVideoSubmitDispatched(
 	publicTaskID string,
 	body []byte,
 ) (*bridge.TaskSubmitOutcome, error) {
+	// grok (seventh platform) serves video through the native xAI OAuth video API
+	// (POST api.x.ai/v1/videos/generations), NOT the new-api task-adaptor bridge —
+	// it is channel_type=0 native OAuth with no TaskAdaptor. Branch before the
+	// bridge-eligibility / channel_type gates below, which are the newapi path.
+	if account != nil && account.IsGrok() {
+		return s.grokNativeVideoSubmit(ctx, c, account, publicTaskID, body)
+	}
 	if !s.ShouldDispatchToNewAPIBridge(account, BridgeEndpointVideoSubmit) {
 		return nil, &NewAPIRelayError{Err: errBridgeMissingCredential("channel_type")}
 	}
@@ -99,6 +106,12 @@ func (s *OpenAIGatewayService) ForwardAsVideoFetchDispatched(
 	c *gin.Context,
 	in bridge.VideoFetchInput,
 ) (*bridge.VideoFetchOutcome, error) {
+	// grok (seventh platform) poll: native xAI OAuth video poll, channel_type=0,
+	// re-resolves a fresh Bearer via in.AccountID. Branch before the bridge's
+	// channel_type>0 gate (the newapi task-adaptor path).
+	if in.Platform == PlatformGrok {
+		return s.grokNativeVideoFetch(ctx, in)
+	}
 	if in.ChannelType <= 0 || strings.TrimSpace(in.UpstreamTaskID) == "" {
 		return nil, errors.New("video fetch requires channel_type and upstream_task_id")
 	}

--- a/backend/internal/service/openai_gateway_grok_video_tk.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk.go
@@ -267,13 +267,28 @@ func buildGrokVideoSubmitResponse(publicTaskID, model string) []byte {
 // videoTerminalOutcome vocabulary. xAI uses queued/processing/done/failed/
 // expired; the handler keys terminal-success retention on "success"/"succeeded"
 // and terminal-failure refund on "failure"/"failed".
+//
+// "expired" is deliberately NOT mapped to a terminal status — it falls through
+// as a non-terminal passthrough, exactly like the bridge/new-api path (whose
+// videoTerminalOutcome only recognizes failure/failed + success/succeeded and
+// never treats "expired" as terminal). The reason is money-safety on the
+// submit-time billing model: the user is charged once at submit, a "done" poll
+// is billed-and-KEPT, and "expired" can be the RESULT-TTL state observed AFTER
+// a successful "done" (the clip URL aged out). If "expired" triggered the
+// terminal-failure refund, a user who already received and was billed for a
+// "done" clip would get refunded on a later poll — a refund-after-success leak.
+// Leaving it non-terminal means a genuinely-never-completed task simply stops
+// at the record TTL (no auto-refund, same as every other video channel); the
+// rare true-expiry refund is a support action, which is the correct trade for
+// not leaking money. "canceled" stays terminal-failure: a cancel cannot follow
+// a "done", so its refund is always for an unconsumed task.
 func normalizeGrokVideoStatus(xaiStatus string) string {
 	switch strings.ToLower(strings.TrimSpace(xaiStatus)) {
 	case "done", "success", "succeeded", "completed":
 		return "success"
-	case "failed", "failure", "expired", "canceled", "cancelled":
+	case "failed", "failure", "canceled", "cancelled":
 		return "failure"
 	default:
-		return xaiStatus // queued / processing → non-terminal
+		return xaiStatus // queued / processing / expired → non-terminal (see above)
 	}
 }

--- a/backend/internal/service/openai_gateway_grok_video_tk.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk.go
@@ -1,0 +1,279 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	"go.uber.org/zap"
+)
+
+// Grok-native video generation arm.
+//
+// Video on TokenKey is normally a new-api task-adaptor path (channel_type>0).
+// grok is the seventh platform: native xAI OAuth, account channel_type=0, raw
+// Bearer to api.x.ai/v1 — it has no new-api TaskAdaptor. xAI exposes an
+// OpenAI-shaped async video API on the SAME OAuth surface grok chat/image use:
+//
+//	POST {base}/videos/generations  {model,prompt,duration,...}  -> {"request_id": "..."}
+//	GET  {base}/videos/{request_id}  -> {"status":"done","video":{"url":...,"duration":N},"usage":{...}}
+//
+// So grok video is served by THIS native submit/poll arm instead of the bridge.
+// It returns the exact bridge.TaskSubmitOutcome / bridge.VideoFetchOutcome
+// shapes the handler already consumes, so everything downstream (vt_ public id,
+// VideoTaskCache record, balance hold, per-second billing, terminal refund, S3
+// offload, ownership-404) is reused verbatim — only the upstream calls are new.
+//
+// Heavy-only: api.x.ai/v1 is entitlement-gated to SuperGrok Heavy; a standard
+// account 403s on /videos exactly as on chat. We surface that as a clean
+// honesty-403 (no failover, no penalty), reusing tkIsGrokEntitlement403.
+
+// grokNativeVideoSubmit POSTs the client's video request to xAI's OAuth video
+// endpoint and writes the OpenAI-Video submit acknowledgement (carrying TK's
+// public task id) to the gin response — mirroring the bridge contract that the
+// dispatch writes the wire body and the handler does NOT call c.JSON again.
+func (s *OpenAIGatewayService) grokNativeVideoSubmit(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	publicTaskID string,
+	body []byte,
+) (*bridge.TaskSubmitOutcome, error) {
+	reqModel := gjson.GetBytes(body, "model").String()
+	if reqModel == "" {
+		return nil, fmt.Errorf("grok video submit: model is required")
+	}
+	// Honor a per-account model_mapping if any (account 6 has none → passthrough),
+	// identical to the chat raw path.
+	billingModel := resolveOpenAIForwardModel(account, reqModel, "")
+	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
+	upstreamBody := body
+	if upstreamModel != "" && upstreamModel != reqModel {
+		upstreamBody = ReplaceModelInBody(body, upstreamModel)
+	}
+
+	token := account.GetGrokAccessToken()
+	if token == "" {
+		return nil, fmt.Errorf("grok account %d missing access_token", account.ID)
+	}
+	base, err := s.validateUpstreamBaseURL(account.GetGrokBaseURL())
+	if err != nil {
+		return nil, fmt.Errorf("invalid grok base_url: %w", err)
+	}
+	url := strings.TrimRight(base, "/") + "/videos/generations"
+
+	respBody, status, herr := s.grokVideoHTTP(ctx, account, http.MethodPost, url, token, upstreamBody)
+	if herr != nil {
+		return nil, herr
+	}
+	if status >= 400 {
+		return nil, s.grokVideoUpstreamError(status, respBody)
+	}
+	upstreamTaskID := gjson.GetBytes(respBody, "request_id").String()
+	if upstreamTaskID == "" {
+		upstreamTaskID = gjson.GetBytes(respBody, "id").String()
+	}
+	if upstreamTaskID == "" {
+		return nil, fmt.Errorf("grok video submit: upstream returned no request_id")
+	}
+
+	// Write the OpenAI-Video submit acknowledgement carrying TK's PUBLIC id (the
+	// client polls GET /v1/videos/{id} with it; the registry maps public→upstream).
+	c.Header("Content-Type", "application/json")
+	c.Status(http.StatusOK)
+	_, _ = c.Writer.Write(buildGrokVideoSubmitResponse(publicTaskID, reqModel))
+
+	logger.L().Info("openai_gateway.grok_native_video_submit",
+		zap.Int64("account_id", account.ID),
+		zap.String("model", reqModel),
+		zap.String("upstream_task_id", upstreamTaskID),
+	)
+
+	return &bridge.TaskSubmitOutcome{
+		PublicTaskID:   publicTaskID,
+		UpstreamTaskID: upstreamTaskID,
+		UpstreamModel:  upstreamModel,
+		OriginModel:    reqModel,
+		ChannelType:    account.ChannelType, // 0 for grok native — pinned on the record
+		BaseURL:        base,
+		APIKey:         token,
+	}, nil
+}
+
+// grokNativeVideoFetch polls xAI for a previously-submitted grok video task.
+// The fetch is account-agnostic at the bridge boundary, but grok's OAuth Bearer
+// rotates (GrokTokenRefresher), so the pinned record APIKey may be stale by poll
+// time — we re-resolve a FRESH token via in.AccountID instead of trusting it.
+func (s *OpenAIGatewayService) grokNativeVideoFetch(
+	ctx context.Context,
+	in bridge.VideoFetchInput,
+) (*bridge.VideoFetchOutcome, error) {
+	if strings.TrimSpace(in.UpstreamTaskID) == "" {
+		return nil, errors.New("grok video fetch requires upstream_task_id")
+	}
+	base := strings.TrimRight(in.BaseURL, "/")
+	token := in.APIKey
+	var account *Account
+	if in.AccountID > 0 {
+		if acc, err := s.accountRepo.GetByID(ctx, in.AccountID); err == nil && acc != nil && acc.IsGrok() {
+			account = acc
+			if fresh := acc.GetGrokAccessToken(); fresh != "" {
+				token = fresh // re-resolve: the pinned record token may be a rotated/stale Bearer
+			}
+			if b, verr := s.validateUpstreamBaseURL(acc.GetGrokBaseURL()); verr == nil && b != "" {
+				base = strings.TrimRight(b, "/")
+			}
+		}
+	}
+	if token == "" {
+		return nil, errors.New("grok video fetch: no usable access token")
+	}
+	url := base + "/videos/" + in.UpstreamTaskID
+
+	respBody, status, herr := s.grokVideoHTTP(ctx, account, http.MethodGet, url, token, nil)
+	if herr != nil {
+		return nil, herr
+	}
+	if status >= 400 {
+		return nil, s.grokVideoUpstreamError(status, respBody)
+	}
+
+	xaiStatus := gjson.GetBytes(respBody, "status").String()
+	// Surface a top-level video_url on success so the client / Studio reads it the
+	// same way it reads the bridge's normalized (and S3-offloaded) shape, while the
+	// rest of xAI's body passes through untouched.
+	out := respBody
+	if videoURL := gjson.GetBytes(respBody, "video.url").String(); videoURL != "" {
+		if b, serr := sjson.SetBytes(respBody, "video_url", videoURL); serr == nil {
+			out = b
+		}
+	}
+
+	return &bridge.VideoFetchOutcome{
+		RawResponse: out,
+		// Normalize xAI's status enum (queued/processing/done/failed/expired) into
+		// the handler's videoTerminalOutcome vocabulary (success/failure/other) so
+		// terminal-success retention + terminal-failure refund fire correctly.
+		Status: normalizeGrokVideoStatus(xaiStatus),
+	}, nil
+}
+
+// grokVideoHTTP issues a single grok-OAuth request to xAI's video API via the
+// shared upstream HTTP client (proxy + per-account concurrency honored). Bodies
+// are small JSON (request_id on submit; status+url on poll), so reading fully is
+// fine. account may be nil on the fetch path (used only for proxy/concurrency).
+func (s *OpenAIGatewayService) grokVideoHTTP(
+	ctx context.Context,
+	account *Account,
+	method, url, token string,
+	body []byte,
+) ([]byte, int, error) {
+	upstreamCtx, release := detachUpstreamContext(ctx)
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(upstreamCtx, method, url, rdr)
+	release()
+	if err != nil {
+		return nil, 0, fmt.Errorf("build grok video request: %w", err)
+	}
+	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	proxyURL := ""
+	accID := int64(0)
+	concurrency := 0
+	if account != nil {
+		if account.Proxy != nil {
+			proxyURL = account.Proxy.URL()
+		}
+		accID = account.ID
+		concurrency = account.Concurrency
+	}
+	resp, err := s.httpUpstream.Do(req, proxyURL, accID, concurrency)
+	if err != nil {
+		return nil, 0, fmt.Errorf("grok video upstream request failed: %s", sanitizeUpstreamErrorMessage(err.Error()))
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, rerr := io.ReadAll(resp.Body)
+	if rerr != nil {
+		return nil, resp.StatusCode, fmt.Errorf("read grok video response: %w", rerr)
+	}
+	return respBody, resp.StatusCode, nil
+}
+
+// grokVideoUpstreamError maps an xAI video error response to a client error.
+// A Heavy-only entitlement 403 is surfaced as a clean honesty-403 (skip-retry,
+// no penalty), identical to the grok chat posture; other statuses pass through.
+func (s *OpenAIGatewayService) grokVideoUpstreamError(status int, body []byte) error {
+	msg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(body)))
+	if tkIsGrokEntitlement403(status, body) {
+		return &NewAPIRelayError{Err: newapitypes.NewErrorWithStatusCode(
+			errors.New(tkGrokEntitlement403ClientMessage(msg)),
+			newapitypes.ErrorCodeInvalidRequest,
+			http.StatusForbidden,
+			newapitypes.ErrOptionWithSkipRetry(),
+		)}
+	}
+	clientStatus := http.StatusBadGateway
+	if status >= 400 && status < 500 {
+		clientStatus = status
+	}
+	if msg == "" {
+		msg = "grok video upstream error"
+	}
+	return &NewAPIRelayError{Err: newapitypes.NewErrorWithStatusCode(
+		errors.New(msg),
+		newapitypes.ErrorCodeInvalidRequest,
+		clientStatus,
+		newapitypes.ErrOptionWithSkipRetry(),
+	)}
+}
+
+// buildGrokVideoSubmitResponse builds an OpenAI-Video-compatible submit
+// acknowledgement carrying TK's public task id. The client extracts `id` and
+// polls GET /v1/videos/{id}; TK resolves it to the pinned upstream request_id.
+func buildGrokVideoSubmitResponse(publicTaskID, model string) []byte {
+	payload := map[string]any{
+		"id":         publicTaskID,
+		"object":     "video",
+		"model":      model,
+		"status":     "queued",
+		"progress":   0,
+		"created_at": time.Now().Unix(),
+	}
+	b, _ := json.Marshal(payload)
+	return b
+}
+
+// normalizeGrokVideoStatus maps xAI's video status enum onto the handler's
+// videoTerminalOutcome vocabulary. xAI uses queued/processing/done/failed/
+// expired; the handler keys terminal-success retention on "success"/"succeeded"
+// and terminal-failure refund on "failure"/"failed".
+func normalizeGrokVideoStatus(xaiStatus string) string {
+	switch strings.ToLower(strings.TrimSpace(xaiStatus)) {
+	case "done", "success", "succeeded", "completed":
+		return "success"
+	case "failed", "failure", "expired", "canceled", "cancelled":
+		return "failure"
+	default:
+		return xaiStatus // queued / processing → non-terminal
+	}
+}

--- a/backend/internal/service/openai_gateway_grok_video_tk_test.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk_test.go
@@ -25,10 +25,12 @@ func TestNormalizeGrokVideoStatus(t *testing.T) {
 		// terminal failure
 		{"failed", "failure"},
 		{"failure", "failure"},
-		{"expired", "failure"},
 		{"canceled", "failure"},
 		{"cancelled", "failure"},
-		// non-terminal: passthrough verbatim so the poller keeps polling
+		// non-terminal: passthrough verbatim so the poller keeps polling.
+		// "expired" is intentionally HERE (not failure): refunding on expired
+		// would leak money when it follows a billed-and-kept "done" (result TTL).
+		{"expired", "expired"},
 		{"queued", "queued"},
 		{"processing", "processing"},
 		{"", ""},

--- a/backend/internal/service/openai_gateway_grok_video_tk_test.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk_test.go
@@ -1,0 +1,84 @@
+//go:build unit
+
+package service
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestNormalizeGrokVideoStatus pins the mapping from xAI's video status enum
+// (queued/processing/done/failed/expired) onto the handler's videoTerminalOutcome
+// vocabulary (success/failure/non-terminal-passthrough). A drift here would
+// either skip terminal-success S3 retention or skip the terminal-failure refund.
+func TestNormalizeGrokVideoStatus(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// terminal success (case-insensitive)
+		{"done", "success"},
+		{"Done", "success"},
+		{"success", "success"},
+		{"succeeded", "success"},
+		{"completed", "success"},
+		// terminal failure
+		{"failed", "failure"},
+		{"failure", "failure"},
+		{"expired", "failure"},
+		{"canceled", "failure"},
+		{"cancelled", "failure"},
+		// non-terminal: passthrough verbatim so the poller keeps polling
+		{"queued", "queued"},
+		{"processing", "processing"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := normalizeGrokVideoStatus(tc.in); got != tc.want {
+				t.Fatalf("normalizeGrokVideoStatus(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildGrokVideoSubmitResponse verifies the synchronous submit
+// acknowledgement carries TK's PUBLIC task id (the client polls
+// GET /v1/videos/{id} with it) and the OpenAI-Video submit shape the handler
+// contract expects (queued / progress 0 / created_at stamped).
+func TestBuildGrokVideoSubmitResponse(t *testing.T) {
+	const publicID = "vt_abc123"
+	const model = "grok-imagine-video"
+
+	raw := buildGrokVideoSubmitResponse(publicID, model)
+
+	var got struct {
+		ID        string `json:"id"`
+		Object    string `json:"object"`
+		Model     string `json:"model"`
+		Status    string `json:"status"`
+		Progress  int    `json:"progress"`
+		CreatedAt int64  `json:"created_at"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("submit ack is not valid JSON: %v (%s)", err, raw)
+	}
+	if got.ID != publicID {
+		t.Fatalf("id = %q, want public task id %q (client must poll with TK's id, not the upstream request_id)", got.ID, publicID)
+	}
+	if got.Object != "video" {
+		t.Fatalf("object = %q, want %q", got.Object, "video")
+	}
+	if got.Model != model {
+		t.Fatalf("model = %q, want %q", got.Model, model)
+	}
+	if got.Status != "queued" {
+		t.Fatalf("status = %q, want %q", got.Status, "queued")
+	}
+	if got.Progress != 0 {
+		t.Fatalf("progress = %d, want 0", got.Progress)
+	}
+	if got.CreatedAt <= 0 {
+		t.Fatalf("created_at = %d, want a positive unix timestamp", got.CreatedAt)
+	}
+}

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -16,6 +16,13 @@
     "output_cost_per_image": 0.07,
     "source": "xAI official API list (x.ai/api), captured 2026-06; grok-imagine-image-quality $0.05/img@1K, $0.07/img@2K — priced at the 2K worst case (conservative, never under-bills; the OpenAI /v1/images path passes no size param). Replaced the retired grok-imagine-image-pro 2026-05-15. Verify in console.x.ai."
   },
+  "grok-imagine-video": {
+    "litellm_provider": "xai",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.08,
+    "source": "xAI official video pricing (docs.x.ai/developers/models/grok-imagine-video, captured 2026-06-19): output $0.05/s base (480p text-to-video), 720p output $0.07/s, +$0.01/s when image is used as input. TK bills a single flat per-OUTPUT-second rate (no resolution/input granularity), set to the MAX reachable tier 720p+image-input = $0.07+$0.01 = $0.08/s so cheaper combos over- not under-charge (same MAX-tier convention as veo/doubao). Cross-checked live 2026-06-19 against api.x.ai/v1/videos via a grok OAuth Heavy account: a 5s text-to-video reported usage.cost_in_usd_ticks=2500000000 = $0.25 ($0.05/s), confirming 1 tick = 1e-10 USD (grok-imagine-image 2e8 ticks = its known $0.02). video_url (continuation) input is rejected at submit (unpriced under per-output-second); only first-frame image_url input is allowed. failure_billing=success_only: xAI bills generated output seconds, and TokenKey's terminal-failure refund reverses the submit-time charge.",
+    "failure_billing": "success_only"
+  },
   "grok-code-fast-1": {
     "litellm_provider": "xai",
     "mode": "chat",

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -69,8 +69,8 @@
     },
     {
       "path": "backend/internal/service/tk_pricing_overlay.json",
-      "must_contain": ["grok-imagine-image"],
-      "rationale": "Grok image pricing rows. Image models with no usable static price are REJECTED with a pre-spend 400 by TkImageModelUnpriced — so losing these rows makes grok image generation fail outright (not just bill $0)."
+      "must_contain": ["grok-imagine-image", "grok-imagine-video"],
+      "rationale": "Grok image AND video pricing rows. Image models with no usable static price are REJECTED with a pre-spend 400 by TkImageModelUnpriced, and video models likewise by TkVideoModelUnpriced — so losing these rows makes grok image/video generation fail outright (not just bill $0). grok-imagine-video is priced per output second at the MAX reachable tier ($0.08/s, 720p+input) per the overlay's never-under-charge convention."
     },
     {
       "path": "backend/migrations/tk_028_allow_grok_model_availability_platform.sql",
@@ -151,6 +151,36 @@
       "path": "backend/internal/service/account_tk_grok_capability_test.go",
       "must_contain": ["TestGrokAccount_PassesOpenAICompatCapabilityGate"],
       "rationale": "Load-bearing QA evidence for the grok OpenAI-compat capability gate (see the account.go anchor above). Guards against silent re-introduction of the 'grok excluded from every OpenAI-compat selection' bug."
+    },
+    {
+      "path": "backend/internal/engine/capability_tk_grok_video.go",
+      "must_contain": ["func IsVideoSupportedForAccount", "domain.PlatformGrok"],
+      "rationale": "The platform-aware video eligibility predicate. Video on TK is otherwise channel_type-derived (IsVideoSupportedChannelType, false for channel_type<=0); grok is native xAI OAuth at channel_type=0 with NO new-api task adaptor, so it would be rejected by the channel_type gate. IsVideoSupportedForAccount adds the grok exception WITHOUT touching the channel_type predicate (deliberately separate so the two never drift). Losing this re-blocks grok video at the handler gate with a 400 'channel_type has no video task adaptor'."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_grok_video_tk.go",
+      "must_contain": ["func (s *OpenAIGatewayService) grokNativeVideoSubmit", "func (s *OpenAIGatewayService) grokNativeVideoFetch", "/videos/generations"],
+      "rationale": "The grok-native video arm: submit (POST api.x.ai/v1/videos/generations -> request_id) + poll (GET api.x.ai/v1/videos/{id}) over the grok OAuth Bearer, returning the same bridge.TaskSubmitOutcome/VideoFetchOutcome shapes the handler consumes so the vt_ public id, VideoTaskCache record, balance hold, per-second billing, terminal refund, S3 offload and ownership-404 are all reused. Video has no new-api TaskAdaptor for xAI (GetTaskAdaptor has no xai entry), so this native arm is grok video's ONLY code path — losing it makes grok video fail outright."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go",
+      "must_contain": ["account.IsGrok()", "grokNativeVideoSubmit", "in.Platform == PlatformGrok", "grokNativeVideoFetch"],
+      "rationale": "The two dispatch seams that route grok to the native video arm BEFORE the new-api bridge gates: submit branches on account.IsGrok() before ShouldDispatchToNewAPIBridge/channel_type, fetch branches on in.Platform==PlatformGrok before the channel_type>0 gate. Losing either sends grok video down the bridge path, which hard-fails (no xAI task adaptor / channel_type=0)."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_tk_video.go",
+      "must_contain": ["engine.IsVideoSupportedForAccount(account.Platform, account.ChannelType)", "Platform:", "AccountID:"],
+      "rationale": "The video submit handler gate uses the platform-aware IsVideoSupportedForAccount (not the channel_type-only predicate) so grok passes, and the VideoFetchInput it builds carries Platform + AccountID so the poll path can branch to grokNativeVideoFetch and re-resolve a fresh (rotated) grok OAuth Bearer by account id. Reverting the gate to IsVideoSupportedChannelType re-blocks grok; dropping Platform/AccountID strands the grok poll (it would fall through to the bridge fetch and fail)."
+    },
+    {
+      "path": "backend/internal/engine/capability_tk_grok_video_test.go",
+      "must_contain": ["TestIsVideoSupportedForAccount"],
+      "rationale": "Load-bearing QA evidence for the platform-aware video gate (see capability_tk_grok_video.go above): pins grok eligible at channel_type=0 while non-grok still defers to the channel_type-derived predicate. Guards against a revert silently re-blocking grok video."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_grok_video_tk_test.go",
+      "must_contain": ["TestNormalizeGrokVideoStatus", "TestBuildGrokVideoSubmitResponse"],
+      "rationale": "Load-bearing QA evidence for the grok-native video arm: the xAI status-enum -> videoTerminalOutcome mapping (drift would skip terminal-success retention or terminal-failure refund) and the submit acknowledgement shape (must carry TK's public task id, not the upstream request_id)."
     }
   ]
 }


### PR DESCRIPTION
## 背景

grok 是第七平台（原生 xAI OAuth，`channel_type=0`，**没有 new-api task adaptor**），走不了 TokenKey 现有的 bridge-only 视频路径（`IsVideoSupportedChannelType` 对 `ct<=0` 恒为 false）。但 xAI 在 grok chat/image **同一条** OAuth 通道上提供了 OpenAI 形状的异步视频 API，所以本 PR 新增一条 **grok 原生视频臂**，在 bridge 闸门之前把 grok 分流过去。

设计核心是**最大化复用、只新增上游调用**：原生臂返回的就是 handler 已经在消费的 `bridge.TaskSubmitOutcome` / `VideoFetchOutcome` 形状，因此 `vt_` 公共 id、`VideoTaskCache` 记录、余额预扣、按秒计费、终态退款、S3 落地、归属 404 **全部原样复用**。

## 改动清单

- **`engine.IsVideoSupportedForAccount(platform, channelType)`** — 平台感知的视频闸门。grok 在 `ct=0` 即可服务；其它平台仍回落到 `IsVideoSupportedChannelType`。**刻意独立**于 channel_type 谓词，防止将来 upstream merge 改 task-adaptor 注册表时静默翻掉 grok 的资格。
- **`service.grokNativeVideoSubmit` / `grokNativeVideoFetch`** — `POST api.x.ai/v1/videos/generations` → `request_id`；`GET /videos/{id}` → 归一化 status + 顶层 `video_url`。poll 时**按 account id 重解析新鲜 OAuth Bearer**（GrokTokenRefresher 会轮换，记录里钉的 token 可能已过期）。Heavy-only 403 走既有 `tkIsGrokEntitlement403` → 干净 honesty-403，不 failover、不惩罚。
- **dispatch + handler 分支**：grok 在 `ShouldDispatchToNewAPIBridge` / `channel_type>0` 之前分流；`VideoFetchInput` 新增 `Platform` + `AccountID` 供 poll 分支使用（bridge 路径忽略，完全向后兼容）。
- **`tk_pricing_overlay.json`** — `grok-imagine-video` 定价 **\$0.08/s**（720p+图输入最高档，永不少扣惯例），`mode=video_generation`、`failure_billing=success_only`。官方 xAI 价（\$0.05/s 基价、720p 输出 \$0.07/s、图输入 +\$0.01/s）+ 实测探针交叉验证（1 tick = 1e-10 USD，对照已知 \$0.02 图片价坐实）。
- **`scripts/sentinels/grok.json`** — 为 6 个新增/改动视频面 + 2 个 QA 测试加锚点（registry-update gate 靠覆盖满足，无需 marker）。

## 自审发现与修复（xj-review #876）

- **R-001（medium，已修，commit `860933db1`）**：`normalizeGrokVideoStatus` 原本把 xAI `"expired"` 映射成 `"failure"`，会触发 handler 的删除 + 终态退款。由于视频是**提交时一次性计费**、`"done"` 轮询是**已计费且保留**，若 `"expired"` 出现在一次成功的 `"done"` **之后**（结果 URL 到期），用户已收到并被计费的视频会在后续轮询里被退款 —— 一次**退款后仍持有**的资损；同时也偏离了 canonical bridge 路径（其 `videoTerminalOutcome` 只认 failure/success，从不把 expired 当终态）。**改法**：把 `"expired"` 落到非终态 passthrough（与 bridge 路径一致），真正未完成的任务自然停在记录 TTL（不自动退款，与其它所有视频渠道一致），罕见的真到期退款转为人工处理 —— 这是在资金面上不漏钱的正确取舍。`"canceled"` 仍保留为终态失败（cancel 不会跟在 done 之后，退款总是针对未消费任务）。

## 测试

- `engine.TestIsVideoSupportedForAccount`（grok 在 ct=0 通过；非 grok 回落 channel_type）
- `service.TestNormalizeGrokVideoStatus`（xAI 枚举 → 终态词表；含 R-001 的 expired→非终态断言）
- `service.TestBuildGrokVideoSubmitResponse`（提交回执携带 TK 公共 id 而非上游 request_id）
- `go build ./...`、完整 `go test -tags=unit ./...`、`scripts/preflight.sh` 全绿

## 收尾验证计划（合并后）

收尾 livefire 会是 grok 视频**经 prod→edge 中继真打**（用 prod grok 组 key），而非直连 `api.x.ai`。

no-web-impact