### PR TITLE
perf(admin): /admin/users last_used_at — per-user LATERAL index probe (~1.3s → ~0.5ms)

### DIFF
--- a/backend/internal/repository/user_repo.go
+++ b/backend/internal/repository/user_repo.go
@@ -629,11 +629,24 @@ func (r *userRepository) GetLatestUsedAtByUserIDs(ctx context.Context, userIDs [
 		return nil, fmt.Errorf("sql executor is not configured")
 	}
 
+	// TK perf: a single `WHERE user_id = ANY($1) GROUP BY user_id` over usage_logs
+	// makes Postgres Seq Scan the whole table — it does NOT skip-scan the
+	// idx_usage_logs_user_created (user_id, created_at) index for ANY-array
+	// grouping. On prod (~2.4M rows) that was ~1.3s and dominated the /admin/users
+	// page latency. Rewriting it as a per-user LATERAL MAX turns it into N cheap
+	// Index Only Scan Backward probes on that index (~0.4ms for a page of users).
+	// Semantics are identical: the WHERE drops users with no usage_logs (the old
+	// GROUP BY likewise produced no row for them). Keep this shape — do NOT
+	// "simplify" it back to GROUP BY.
 	const query = `
-		SELECT user_id, MAX(created_at) AS last_used_at
-		FROM usage_logs
-		WHERE user_id = ANY($1)
-		GROUP BY user_id
+		SELECT u.uid, m.last_used_at
+		FROM unnest($1::bigint[]) AS u(uid)
+		CROSS JOIN LATERAL (
+			SELECT MAX(created_at) AS last_used_at
+			FROM usage_logs
+			WHERE user_id = u.uid
+		) m
+		WHERE m.last_used_at IS NOT NULL
 	`
 
 	rows, err := r.sql.QueryContext(ctx, query, pq.Array(userIDs))


### PR DESCRIPTION
## 做了什么

`/admin/users` 在 prod 上**每次加载都要 ~1.0–1.5s**。根因:`ListUsers`(`admin_service.go`)无条件调用 `GetLatestUsedAtByUserIDs`(`user_repo.go`),其查询为:

```sql
SELECT user_id, MAX(created_at) FROM usage_logs
WHERE user_id = ANY($1) GROUP BY user_id   -- 无时间下限
```

Postgres 对这种 `= ANY(array) GROUP BY` 的形态**会全表 Seq Scan `usage_logs`**——它**不会**对 `idx_usage_logs_user_created (user_id, created_at)` 做 skip-scan,索引完全用不上。

## Prod 实测证据(image `1.8.19`,即 #874 已发版之后;`usage_logs` = 239 万行 / 2.3 GB)

对线上真库跑 `EXPLAIN ANALYZE`:

| 查询 | 执行计划 | 耗时 |
|---|---|---|
| 现状 `ANY($1) GROUP BY` | **Parallel Seq Scan,全部 239 万行** | **1323 ms** |
| 本 PR(`unnest` + 每用户 `LATERAL MAX`) | **Index Only Scan Backward** ×27 次探针 | **0.4 ms** |

约 **2000×** 提速。这条**不在 #874 修复范围内**(已核:`caba513c4` 没有触碰 `GetLatestUsedAtByUserIDs`)——#874 发版到 `1.8.19` 后实测 `/admin/users` 仍 ~1.0s。

## 怎么改

把批量查询改写为 `unnest($1::bigint[])` + 每用户 `CROSS JOIN LATERAL (SELECT MAX(created_at) ...)`,让每个用户走一次廉价索引探针。索引已存在,**不需要新建索引、不需要 rollup、不需要迁移**。

**语义完全等价**:没有 `usage_logs` 的用户仍然不会出现在结果 map 里(旧的 `GROUP BY` 本就不为他们产行;新查询用 `WHERE m.last_used_at IS NOT NULL` 把他们丢掉)。该语义由既有集成测试 `TestGetLatestUsedAtByUserIDs_UsesUsageLogs`(真 Postgres)钉死——已通过。

## 验证

- `go build ./...` ✓ · `go vet ./internal/repository/` ✓
- `go test -tags=integration ./internal/repository/`(真 PG / testcontainers)✓
- `go test -tags=unit ./internal/repository/... ./internal/service/... ./internal/handler/admin/...` ✓
- `scripts/preflight.sh` ✓(含 sub2api 全套门禁,PASS)

## Markers

- **no-web-impact: true** —— 纯后端查询改写,未触碰任何前端 surface。
- **upstream-touch-trivial** —— `backend/internal/repository/user_repo.go` 属 upstream-shaped 路径,但这是对 TK 自己加的 `GetLatestUsedAtByUserIDs` helper(`beeab54ae` 引入)的自包含改写,无 upstream-merge revert 风险,行为保持不变,且由既有集成测试覆盖。

## 上下文

这是一次 prod admin UI 性能排查的 **P0**。其余项各自独立开 PR:
- 宽窗 dashboard 聚合(`user-breakdown` / `model-stats` / `users-trend`)直扫 `usage_logs`——默认 24h 很快,选 7/14/30 天则 0.8–1.8s 一个;rollup 缺口(#874 的 rollup 只覆盖 ranking + batch-stats 两个 user 维度)。
- 前端冷加载:`AccountsView` 弹窗密集的路由 chunk(117KB gz);i18n 语言包(~94KB gz)在 `app.mount()` 之前被 `await` 阻塞首屏。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Reviewer:按规则 §5.y,这是 TK 自有 PR → **Squash and merge**。未经明确授权不合并。_