### PR TITLE
chore(sentinels): 守护 /admin/users last_used_at 查询形态(perf-query-shape registry)

### DIFF
--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -42,6 +42,12 @@ name: Upstream Merge PR Shape
 #      these are small upstream-hotspot injections that otherwise compile
 #      cleanly when silently reverted (incl. prod-to-sibling Claude sticky
 #      session header + ParsedRequest Gin fallback, and bridge metadata).
+#   5d. Every performance-critical query SHAPE listed in
+#      `scripts/sentinels/perf-query-shape.json` survives the merge. These
+#      regress semantically-invisibly (a revert returns identical results so no
+#      test catches it), so a merge could otherwise silently restore the slow
+#      form (e.g. /admin/users last_used_at reverting to a full-table
+#      `ANY($1) GROUP BY` seq scan, ~1.3s on prod — PR #877).
 #   6. The QA evidence redaction contract stays aligned: if logredact's
 #      default sensitive-key set changes, `scripts/sentinels/redaction.json`
 #      and every outward `redaction_version` literal must move in the same
@@ -364,6 +370,29 @@ jobs:
           if ! python3 ./scripts/sentinels/check-gateway-tk.py; then
             echo "::error::Upstream merge regressed at least one gateway TK sentinel."
             echo "::error::Restore the dropped / reverted TK gateway hook in this merge PR."
+            echo "::error::Do NOT 'fix' by deleting the sentinel entry."
+            exit 1
+          fi
+
+      - name: Check 5d — perf query-shape sentinels still intact after merge
+        run: |
+          # Single source of truth: scripts/sentinels/perf-query-shape.json. Same
+          # script that scripts/preflight.sh runs locally, so a green local
+          # preflight implies a green check here. Guards performance-critical
+          # query SHAPES whose regression is semantically invisible — a revert
+          # returns identical results so no test catches it, and an EXPLAIN-plan
+          # test is unreliable on small fixtures. An upstream merge can silently
+          # restore the slow form with all tests green (e.g. /admin/users
+          # GetLatestUsedAtByUserIDs reverting to a full-table ANY($1) GROUP BY
+          # seq scan, ~1.3s on prod — PR #877).
+          if [ ! -f ./scripts/sentinels/check-perf-query-shape.py ]; then
+            echo "::error::scripts/sentinels/check-perf-query-shape.py missing."
+            echo "::error::Per CLAUDE.md §5 minimum-invasion guidance, this guard cannot be silently disabled."
+            exit 1
+          fi
+          if ! python3 ./scripts/sentinels/check-perf-query-shape.py; then
+            echo "::error::Upstream merge regressed at least one perf query-shape sentinel."
+            echo "::error::Restore the efficient query shape in this merge PR (re-measure if you rewrote it)."
             echo "::error::Do NOT 'fix' by deleting the sentinel entry."
             exit 1
           fi

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -419,6 +419,26 @@ else
     echo "  ok: all newapi sentinels intact"
 fi
 
+# ---- sub2api: perf query-shape sentinel registry ----------------------------
+# Source of truth: scripts/sentinels/perf-query-shape.json. Guards
+# performance-critical query SHAPES whose regression is semantically invisible
+# (a revert returns identical results, so no test catches it; an EXPLAIN-plan
+# test is unreliable on small fixtures since the planner seq-scans tiny tables
+# regardless of shape). First entry: /admin/users GetLatestUsedAtByUserIDs must
+# stay a per-user LATERAL index probe and not revert to the full-table
+# `ANY($1) GROUP BY` seq scan (~1.3s on prod, 2.4M rows). See PR #877.
+echo ""
+echo "=== sub2api: perf query-shape sentinel registry ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required to read perf-query-shape.json)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/sentinels/check-perf-query-shape.py --quiet; then
+    # check-perf-query-shape.py already printed the actionable failure.
+    errors=$((errors + 1))
+else
+    echo "  ok: all perf query-shape sentinels intact"
+fi
+
 # ---- sub2api: kiro sentinel registry ----------------------------------------
 # Source of truth: scripts/sentinels/kiro.json. Verifies that every load-bearing
 # surface of the sixth platform (`kiro`, AWS Kiro / CodeWhisperer) — the vendored

--- a/scripts/sentinels/check-perf-query-shape.py
+++ b/scripts/sentinels/check-perf-query-shape.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+check-perf-query-shape.py — verify that performance-critical query SHAPES are
+still present in the working tree.
+
+Reads `scripts/sentinels/perf-query-shape.json` (single source of truth) and
+for each entry verifies:
+
+  1. The file at `path` exists.
+  2. Every literal string in `must_contain` appears at least once in the file.
+  3. Every literal string in `must_not_contain` is absent from the file.
+
+Exit codes:
+  0  — all sentinels intact.
+  1  — at least one sentinel missing or has lost a required shape anchor.
+  2  — registry file missing or malformed.
+
+Usage:
+  python3 scripts/sentinels/check-perf-query-shape.py
+  python3 scripts/sentinels/check-perf-query-shape.py --quiet   # only print failures
+  python3 scripts/sentinels/check-perf-query-shape.py --json    # machine-readable report
+
+Why this exists:
+  Some performance fixes hinge on a SQL/query shape whose regression is
+  semantically invisible — a revert returns byte-identical results, so no
+  unit/integration test catches it, and an EXPLAIN-plan test is unreliable on
+  small fixtures (the planner seq-scans tiny tables regardless of shape). The
+  guarded shapes live in upstream-shaped files that upstream actively churns,
+  so an upstream merge can silently restore the slow form with all tests green.
+  Listing the load-bearing shape anchors in scripts/sentinels/perf-query-shape.json
+  and gating both pre-commit (scripts/preflight.sh) and upstream merge PRs
+  (.github/workflows/upstream-merge-pr-shape.yml) on this script upgrades the
+  inline "do NOT simplify this back" comment from "reviewer must remember" to
+  "merge will fail". See PR #877 for the first guarded shape.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REGISTRY_PATH = REPO_ROOT / "scripts" / "sentinels" / "perf-query-shape.json"
+
+
+def load_registry() -> dict:
+    if not REGISTRY_PATH.is_file():
+        print(
+            f"FATAL: registry file not found: {REGISTRY_PATH.relative_to(REPO_ROOT)}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    try:
+        with REGISTRY_PATH.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        print(
+            f"FATAL: registry file is not valid JSON: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if "sentinels" not in data or not isinstance(data["sentinels"], list):
+        print("FATAL: registry missing 'sentinels' array.", file=sys.stderr)
+        sys.exit(2)
+    return data
+
+
+def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
+    """Returns (ok, list_of_failure_messages)."""
+    path_str = entry.get("path")
+    if not path_str:
+        return False, ["entry missing 'path'"]
+    file_path = REPO_ROOT / path_str
+    if not file_path.is_file():
+        return False, [f"file missing: {path_str}"]
+    must_contain = entry.get("must_contain") or []
+    must_not_contain = entry.get("must_not_contain") or []
+    if not must_contain and not must_not_contain:
+        return True, []
+    try:
+        content = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return False, [f"cannot read {path_str}: {exc}"]
+    failures: list[str] = []
+    for needle in must_contain:
+        if needle not in content:
+            failures.append(f"missing literal `{needle}` in {path_str}")
+    for needle in must_not_contain:
+        if needle in content:
+            failures.append(f"forbidden literal `{needle}` still present in {path_str}")
+    return (len(failures) == 0), failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quiet", action="store_true", help="only print failures")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit a machine-readable JSON report on stdout",
+    )
+    args = parser.parse_args()
+
+    registry = load_registry()
+    sentinels = registry["sentinels"]
+
+    results = []
+    fail_count = 0
+    for entry in sentinels:
+        ok, failures = check_sentinel(entry)
+        if not ok:
+            fail_count += 1
+        results.append(
+            {
+                "path": entry.get("path"),
+                "ok": ok,
+                "failures": failures,
+                "rationale": entry.get("rationale", ""),
+            }
+        )
+
+    if args.json:
+        json.dump(
+            {"total": len(sentinels), "failed": fail_count, "results": results},
+            sys.stdout,
+            indent=2,
+        )
+        sys.stdout.write("\n")
+    else:
+        if not args.quiet:
+            print(f"perf query-shape sentinels: checking {len(sentinels)} entries from "
+                  f"{REGISTRY_PATH.relative_to(REPO_ROOT)}")
+        for r in results:
+            if r["ok"]:
+                if not args.quiet:
+                    print(f"  ok: {r['path']}")
+            else:
+                print(f"  FAIL: {r['path']}")
+                for msg in r["failures"]:
+                    print(f"        - {msg}")
+                if r["rationale"]:
+                    print(f"        why it matters: {r['rationale']}")
+        if fail_count == 0:
+            if not args.quiet:
+                print(f"perf query-shape sentinels: PASS ({len(sentinels)}/{len(sentinels)} intact)")
+        else:
+            print(
+                f"perf query-shape sentinels: FAIL ({fail_count}/{len(sentinels)} regressed)",
+                file=sys.stderr,
+            )
+            print(
+                "  Source of truth: scripts/sentinels/perf-query-shape.json",
+                file=sys.stderr,
+            )
+            print(
+                "  If a guarded shape was intentionally rewritten to a different "
+                "efficient form, update the must_contain anchors (and re-measure) "
+                "in the same commit. Do NOT silently delete entries.",
+                file=sys.stderr,
+            )
+
+    return 0 if fail_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sentinels/merge-gate-parity.json
+++ b/scripts/sentinels/merge-gate-parity.json
@@ -8,6 +8,7 @@
     "scripts/sentinels/check-brand.py",
     "scripts/sentinels/check-frontend-tk.py",
     "scripts/sentinels/check-gateway-tk.py",
+    "scripts/sentinels/check-perf-query-shape.py",
     "scripts/sentinels/check-redaction-version.py",
     "scripts/sentinels/check-trajectory-hooks.py",
     "scripts/sentinels/check-terminal-events.py",

--- a/scripts/sentinels/perf-query-shape.json
+++ b/scripts/sentinels/perf-query-shape.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "rationale": "Performance-critical SQL/query SHAPES whose regression is SEMANTICALLY INVISIBLE: a revert returns byte-identical results, so no unit/integration test can catch it, and an EXPLAIN-plan assertion is unreliable on small test fixtures (Postgres seq-scans tiny tables regardless of query shape). The only reliable mechanical guard is a source-substring assertion that the efficient shape is still present. These live in upstream-shaped files that upstream actively churns, so an upstream merge (or a well-meaning 'simplify' refactor) can silently restore the slow form with all tests green. Single source of truth read by both scripts/preflight.sh (perf query-shape sentinel section, always) and .github/workflows/upstream-merge-pr-shape.yml (on merge/upstream-* PRs). If you intentionally change one of these shapes to a DIFFERENT efficient form, update the must_contain anchors in the SAME commit (and re-measure) — do NOT silently delete entries to make the gate pass.",
+  "sentinels": [
+    {
+      "path": "backend/internal/repository/user_repo.go",
+      "must_contain": [
+        "FROM unnest($1::bigint[]) AS u(uid)",
+        "CROSS JOIN LATERAL"
+      ],
+      "rationale": "GetLatestUsedAtByUserIDs feeds /admin/users and is called unconditionally on every Users-page load. It MUST stay a per-user LATERAL MAX so each user resolves via an Index Only Scan Backward on idx_usage_logs_user_created. Reverting to `SELECT user_id, MAX(created_at) ... WHERE user_id = ANY($1) GROUP BY user_id` makes Postgres full Seq-Scan usage_logs (prod: 2.4M rows / 2.3 GB → ~1.3s vs ~0.4ms — measured in PR #877). The revert is semantically identical (same returned map), so the integration test TestGetLatestUsedAtByUserIDs_UsesUsageLogs stays green either way — this sentinel is the only thing that catches the perf regression."
+    }
+  ]
+}


### PR DESCRIPTION
## 背景

#877 把 `GetLatestUsedAtByUserIDs` 从全表 `ANY($1) GROUP BY` seq scan(prod ~1.3s)改成了每用户 `LATERAL` 索引探针(~0.4ms)。问题在于:**这个回退是语义等价的**——返回完全相同的 map,所以:

- 任何 unit / 集成测试都抓不到回退(既有 `TestGetLatestUsedAtByUserIDs_UsesUsageLogs` 两种写法都绿)。
- EXPLAIN-计划断言型测试在小测试表上不可靠(planner 对两种写法都 seq scan)。

而 `GetLatestUsedAtByUserIDs` 是 **upstream 自有符号**,位于 `user_repo.go` —— 一个 upstream **持续在改**的文件(最近就有 `329414ea4 feat(admin): /admin/users 按 API Key 分组过滤` 动这块)。所以下次 upstream 合并完全可能在所有测试全绿的情况下**静默把慢形态恢复回去**。

这正是 sentinel registry 存在的 backward-drift 场景(对照 newapi:也是"被 upstream 静默回退多次后才加的守卫")。我在 #877 里留的 `// do NOT simplify back to GROUP BY` 只是软注释,本 PR 把它硬化成机械门禁。

## 做了什么

新增一个 **`perf-query-shape`** sentinel registry,语义范畴 = "性能关键、但回退语义不可见(测试抓不到)的查询形态":

- `scripts/sentinels/perf-query-shape.json` —— 首条 entry 断言 `user_repo.go` 必须包含 `unnest($1::bigint[]) AS u(uid)` + `CROSS JOIN LATERAL`(回退到 GROUP BY 会让这俩字符串消失 → 失败)。
- `scripts/sentinels/check-perf-query-shape.py` —— 通用 `must_contain` checker(与 `check-newapi.py` 同引擎)。
- `scripts/preflight.sh` —— 新增一节(每个 PR 都跑)。
- `.github/workflows/upstream-merge-pr-shape.yml` —— **Check 5d**(在 `merge/upstream-*` PR 上跑,这才是真正拦 upstream 合并回退的那道)。
- `scripts/sentinels/merge-gate-parity.json` —— 注册新 checker,让 preflight ↔ merge-gate 的 parity 守卫保持同步(这条 parity 门一开始就拦住了我漏注册,已补)。

> 用 `must_contain`(非 `must_not_contain`)是有意的:坏形态 `WHERE user_id = ANY($1) GROUP BY user_id` 这串字符**就在 #877 的解释性注释里**,用 `must_not_contain` 会立刻误报。正向锚点更稳。

这个 registry 也是后续同类"语义不可见性能形态不变量"的归宿(比如 P2 dashboard rollup 改完后的"必须读 rollup、不许直扫 usage_logs")。

## 验证

- 正向:`check-perf-query-shape.py` 在当前树 PASS。
- 负向:临时模拟把 LATERAL 改回 → checker 退出码 1 并精确报缺失锚点,文件已还原。
- `scripts/preflight.sh` ✓ PASS(含新 section + merge-gate parity 同步)。

## Markers

- **no-web-impact: true** —— 纯 CI / tooling(scripts/sentinels + workflow + preflight),无任何后端/前端代码改动。
- 未触碰任何 upstream-shaped 路径(全是新增 + CI 配置),故无需 upstream-override marker(本地 gate 已确认 `ok`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Reviewer:TK 自有 PR → **Squash and merge**。未经明确授权不合并。_