### PR TITLE
fix(grok): 注册 /videos/generations 别名,修通 prod→edge grok 视频中继

### DIFF
--- a/backend/internal/server/routes/gateway_test.go
+++ b/backend/internal/server/routes/gateway_test.go
@@ -137,8 +137,10 @@ func TestGatewayRoutesVideoGenerationPathsAreRegistered(t *testing.T) {
 	postPaths := []string{
 		"/v1/video/generations",
 		"/v1/videos",
+		"/v1/videos/generations", // xAI-shaped alias (grok native arm / prod→edge relay)
 		"/video/generations",
 		"/videos",
+		"/videos/generations",
 	}
 	for _, path := range postPaths {
 		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"model":"doubao-seedance","prompt":"x"}`))
@@ -174,8 +176,10 @@ func TestGatewayRoutesVideoGenerationRejectsNonCompatPlatform(t *testing.T) {
 	for _, path := range []string{
 		"/v1/video/generations",
 		"/v1/videos",
+		"/v1/videos/generations",
 		"/video/generations",
 		"/videos",
+		"/videos/generations",
 	} {
 		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"model":"any","prompt":"x"}`))
 		req.Header.Set("Content-Type", "application/json")

--- a/backend/internal/server/routes/gateway_tk_openai_compat_handlers.go
+++ b/backend/internal/server/routes/gateway_tk_openai_compat_handlers.go
@@ -156,14 +156,15 @@ func tkOpenAICompatVideoFetchHandler(h *handler.Handlers) gin.HandlerFunc {
 	}
 }
 
-// registerTKOpenAICompatVideoRoutes wires the four async video task routes
-// (POST submit + GET fetch, both at `/video/generations` and the OpenAI-compat
-// alias `/videos`). Called once per scope from gateway.go so the upstream-shape
-// file holds a single helper invocation per scope instead of eight inline
-// route registrations + comments — keeps `gateway.go` close to upstream and
-// makes "add a sixth video alias" a single-file change here. The two scopes
-// behave identically; gateway.go passes its own pre-built middleware chain
-// for the no-prefix scope.
+// registerTKOpenAICompatVideoRoutes wires the async video task routes: POST
+// submit at `/video/generations`, the OpenAI-compat alias `/videos`, and the
+// xAI-shaped alias `/videos/generations` (needed for the prod→edge grok relay,
+// see below); GET fetch at `/video/generations/:task_id` and `/videos/:task_id`.
+// Called once per scope from gateway.go so the upstream-shape file holds a
+// single helper invocation per scope instead of inline route registrations +
+// comments — keeps `gateway.go` close to upstream and makes "add another video
+// alias" a single-file change here. The two scopes behave identically;
+// gateway.go passes its own pre-built middleware chain for the no-prefix scope.
 //
 // Supported channel types are auto-derived from `relay.GetTaskAdaptor`
 // (currently 45 = VolcEngine / Doubao Seedance, 54 = DoubaoVideo); adding a
@@ -175,6 +176,16 @@ func registerTKOpenAICompatVideoRoutes(group *gin.RouterGroup, h *handler.Handle
 	group.GET("/video/generations/:task_id", fetch)
 	group.POST("/videos", submit)
 	group.GET("/videos/:task_id", fetch)
+	// `/videos/generations` is xAI's exact video-submit path shape (grok's
+	// native arm POSTs `{base}/videos/generations`). Registering it makes the
+	// gateway accept that shape too, which is REQUIRED for the prod→edge grok
+	// relay: a prod grok mirror account (platform=grok) forwards a video submit
+	// to `api-<edge>.tokenkey.dev/v1/videos/generations`, and the edge gateway
+	// must route it (grok chat/image relay works only because their xAI paths —
+	// /chat/completions, /images/generations — already coincide with gateway
+	// routes; the video path did not). Same submit handler; GET fetch already
+	// matches `/videos/:task_id`, so no fetch alias is needed.
+	group.POST("/videos/generations", submit)
 }
 
 // registerTKOpenAICompatVideoRoutesNoPrefix mirrors the above for the
@@ -194,4 +205,7 @@ func registerTKOpenAICompatVideoRoutesNoPrefix(r *gin.Engine, h *handler.Handler
 	r.GET("/video/generations/:task_id", chain(fetch)...)
 	r.POST("/videos", chain(submit)...)
 	r.GET("/videos/:task_id", chain(fetch)...)
+	// xAI-shaped submit alias — see registerTKOpenAICompatVideoRoutes (required
+	// for the prod→edge grok video relay).
+	r.POST("/videos/generations", chain(submit)...)
 }

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -184,7 +184,7 @@
     },
     {
       "path": "backend/internal/server/routes/gateway_tk_openai_compat_handlers.go",
-      "must_contain": ["/videos/generations"],
+      "must_contain": [".POST(\"/videos/generations\""],
       "rationale": "The xAI-shaped video submit alias POST /videos/generations (plural videos + /generations), registered in BOTH the /v1 group and the no-prefix scope. This is the path grok's native arm POSTs to ({base}/videos/generations); the gateway's canonical video routes are /video/generations (singular) + /videos (no suffix), which do NOT match it. Without this alias the prod->edge grok video relay 404s at submit: a prod grok mirror account forwards to api-<edge>.tokenkey.dev/v1/videos/generations and the edge gateway has no such route (grok chat/image relay works only because /chat/completions and /images/generations already coincide with gateway routes). Losing this alias silently re-breaks the relay while direct-to-xAI still works, so no other test would catch it."
     }
   ]

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -181,6 +181,11 @@
       "path": "backend/internal/service/openai_gateway_grok_video_tk_test.go",
       "must_contain": ["TestNormalizeGrokVideoStatus", "TestBuildGrokVideoSubmitResponse"],
       "rationale": "Load-bearing QA evidence for the grok-native video arm: the xAI status-enum -> videoTerminalOutcome mapping (drift would skip terminal-success retention or terminal-failure refund) and the submit acknowledgement shape (must carry TK's public task id, not the upstream request_id)."
+    },
+    {
+      "path": "backend/internal/server/routes/gateway_tk_openai_compat_handlers.go",
+      "must_contain": ["/videos/generations"],
+      "rationale": "The xAI-shaped video submit alias POST /videos/generations (plural videos + /generations), registered in BOTH the /v1 group and the no-prefix scope. This is the path grok's native arm POSTs to ({base}/videos/generations); the gateway's canonical video routes are /video/generations (singular) + /videos (no suffix), which do NOT match it. Without this alias the prod->edge grok video relay 404s at submit: a prod grok mirror account forwards to api-<edge>.tokenkey.dev/v1/videos/generations and the edge gateway has no such route (grok chat/image relay works only because /chat/completions and /images/generations already coincide with gateway routes). Losing this alias silently re-breaks the relay while direct-to-xAI still works, so no other test would catch it."
     }
   ]
 }


### PR DESCRIPTION
## 背景:在 v1.8.20 收尾 rollout 的 livefire 前抓到的真实 bug

#876 的 grok 原生视频臂 `grokNativeVideoSubmit` POST 到 `{base}/videos/generations`(xAI 的**真实**路径)。

- **直连 edge 真号**:base=`api.x.ai/v1` → `api.x.ai/v1/videos/generations`,正确。
- **prod→edge 中继**:prod 的 grok 镜像号(platform=grok)把 submit 转发到 `api-<edge>.tokenkey.dev/v1/videos/generations` —— 但 TokenKey 网关只注册了 `/video/generations`(单数)和 `/videos`(无后缀),**两者都不匹配 `/videos/generations`**,所以 edge 网关对这个 submit **404**。

grok 的 chat/image 中继之所以能通,是因为它们的 xAI 路径(`/chat/completions`、`/images/generations`)恰好和网关路由重合;video 路径不重合 —— 这正是收尾 livefire(prod→edge 中继)会撞上的失败,在 livefire 前用代码审查抓到。

> 注:之前的"视频可行性验证"是 `curl` 直打 `api.x.ai`(绕过 TokenKey 网关),所以 TokenKey 网关的 grok 视频路径**从未**端到端跑过 —— 既没经网关直连、也没经中继。

## 改动

- 在 `/v1` group 与无前缀两个 scope 都注册 `POST /videos/generations` 别名(同一个 `VideoSubmit` handler,同一道 OpenAI-compat group 闸门 —— grok 已在 `OpenAICompatPlatforms()` 内)。GET fetch 已经命中 `/videos/:task_id`,无需别名。
- 完整中继链路因此打通:`client→prod /v1/video/generations → prod 镜像 native arm → edge /v1/videos/generations → edge 真号 native arm → api.x.ai/v1/videos/generations`。
- 加 grok.json sentinel 锚定该别名(中继的承重面;**直连 xAI 不经它也能跑,所以没有别的测试能抓到回归**)。
- `gateway_test.go` 在「已注册路径」和「非 compat 平台拒绝」两组断言里都加上新路径。

## 测试

- `TestGatewayRoutesVideoGenerationPathsAreRegistered` / `...RejectsNonCompatPlatform`(含 `/v1/videos/generations` + `/videos/generations`)
- `go build ./...`、相关 unit 测试、`scripts/preflight.sh` 全绿(grok sentinel 37/37,registry-update gate 靠 grok.json 覆盖满足)

## 后续

合并后随 **v1.8.21** 一起发版,重新部署 edge-us4 + prod,再做 grok 视频经 prod→edge 中继的收尾 livefire。

no-web-impact