### PR TITLE
fix(gateway): clear sticky binding to a sustainedly-saturated anthropic stub

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -2142,8 +2142,13 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 		if accountID > 0 && !isExcluded(accountID) {
 			account, ok := accountByID[accountID]
 			if ok {
-				// 检查账户是否需要清理粘性会话绑定
-				clearSticky := shouldClearStickySession(account, requestedModel) || s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)
+				// 检查账户是否需要清理粘性会话绑定。TK: 额外在「持续饱和」时清除——
+				// 见 gateway_service_tk_sticky_saturation.go。仅接在这一条 Layer-1.5
+				// 路径，因为清除后落到 Layer-2 负载均衡，那里才有 saturation 惩罚
+				// (computeAnthropicSaturationPenalties) 把被清的 stub 排到健康兄弟之后；
+				// legacy selectAccountForModel* 路径无此惩罚，清了可能原地回选同一 stub。
+				clearSticky := shouldClearStickySession(account, requestedModel) ||
+					s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)
 				if clearSticky {
 					slog.Debug("sticky.layer1_5_no_routing_clear",
 						"account_id", accountID,
@@ -3422,7 +3427,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 					account, err := s.getSchedulableAccount(ctx, accountID)
 					// 检查账号分组归属和平台匹配（确保粘性会话不会跨分组或跨平台）
 					if err == nil {
-						clearSticky := shouldClearStickySession(account, requestedModel) || s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)
+						clearSticky := shouldClearStickySession(account, requestedModel)
 						if clearSticky {
 							_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 						}
@@ -3543,7 +3548,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 				account, err := s.getSchedulableAccount(ctx, accountID)
 				// 检查账号分组归属和平台匹配（确保粘性会话不会跨分组或跨平台）
 				if err == nil {
-					clearSticky := shouldClearStickySession(account, requestedModel) || s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)
+					clearSticky := shouldClearStickySession(account, requestedModel)
 					if clearSticky {
 						_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 					}
@@ -3681,7 +3686,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 					account, err := s.getSchedulableAccount(ctx, accountID)
 					// 检查账号分组归属和有效性：原生平台直接匹配，antigravity 需要启用混合调度
 					if err == nil {
-						clearSticky := shouldClearStickySession(account, requestedModel) || s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)
+						clearSticky := shouldClearStickySession(account, requestedModel)
 						if clearSticky {
 							_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 						}
@@ -3804,7 +3809,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 				account, err := s.getSchedulableAccount(ctx, accountID)
 				// 检查账号分组归属和有效性：原生平台直接匹配，antigravity 需要启用混合调度
 				if err == nil {
-					clearSticky := shouldClearStickySession(account, requestedModel) || s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)
+					clearSticky := shouldClearStickySession(account, requestedModel)
 					if clearSticky {
 						_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 					}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -2143,7 +2143,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 			account, ok := accountByID[accountID]
 			if ok {
 				// 检查账户是否需要清理粘性会话绑定
-				clearSticky := shouldClearStickySession(account, requestedModel)
+				clearSticky := shouldClearStickySession(account, requestedModel) || s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)
 				if clearSticky {
 					slog.Debug("sticky.layer1_5_no_routing_clear",
 						"account_id", accountID,
@@ -3422,7 +3422,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 					account, err := s.getSchedulableAccount(ctx, accountID)
 					// 检查账号分组归属和平台匹配（确保粘性会话不会跨分组或跨平台）
 					if err == nil {
-						clearSticky := shouldClearStickySession(account, requestedModel)
+						clearSticky := shouldClearStickySession(account, requestedModel) || s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)
 						if clearSticky {
 							_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 						}
@@ -3543,7 +3543,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 				account, err := s.getSchedulableAccount(ctx, accountID)
 				// 检查账号分组归属和平台匹配（确保粘性会话不会跨分组或跨平台）
 				if err == nil {
-					clearSticky := shouldClearStickySession(account, requestedModel)
+					clearSticky := shouldClearStickySession(account, requestedModel) || s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)
 					if clearSticky {
 						_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 					}
@@ -3681,7 +3681,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 					account, err := s.getSchedulableAccount(ctx, accountID)
 					// 检查账号分组归属和有效性：原生平台直接匹配，antigravity 需要启用混合调度
 					if err == nil {
-						clearSticky := shouldClearStickySession(account, requestedModel)
+						clearSticky := shouldClearStickySession(account, requestedModel) || s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)
 						if clearSticky {
 							_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 						}
@@ -3804,7 +3804,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 				account, err := s.getSchedulableAccount(ctx, accountID)
 				// 检查账号分组归属和有效性：原生平台直接匹配，antigravity 需要启用混合调度
 				if err == nil {
-					clearSticky := shouldClearStickySession(account, requestedModel)
+					clearSticky := shouldClearStickySession(account, requestedModel) || s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)
 					if clearSticky {
 						_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 					}

--- a/backend/internal/service/gateway_service_tk_sticky_saturation.go
+++ b/backend/internal/service/gateway_service_tk_sticky_saturation.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+)
+
+// TK — sticky-side completion of the anthropic saturated mirror-stub
+// de-prioritization (see gateway_service_tk_saturation_penalty.go for the
+// Layer-2 load-balance score side and ratelimit_service_tk_saturation.go for
+// the increment side + the prod problem statement).
+//
+// Problem (prod, 2026-06-19 evidence): prod reaches Anthropic only through
+// per-edge apikey mirror "stub" accounts (cc-us5 …) that forward to a SPOF
+// edge. When that edge's single OAuth account is upstream-rate-limited, the
+// edge returns TokenKey's own "No available accounts" 429; HandleUpstreamError
+// correctly SKIPS the cooldown ladder (counting it once caused the 2026-05-31
+// "503 amplifier") and instead feeds the bounded saturation counter. The
+// Layer-2 load-balance ranking then de-prioritizes the saturated stub. BUT the
+// sticky-session paths (Layer-1.5 inline block in SelectAccountWithLoadAwareness
+// and the legacy sticky blocks in selectAccountForModelWithPlatform /
+// selectAccountWithMixedScheduling, also used by the count_tokens failover)
+// honor a bound stub via shouldClearStickySession, which only inspects
+// IsSchedulable()+model-rate-limit — both stay true for a saturated stub by
+// design. So a session bound to a dead edge keeps selecting it FIRST and paying
+// a wasted failover hop on every request, with zero prompt-cache benefit (the
+// request fails over to a DIFFERENT edge, so affinity to the dead stub is
+// already worthless). prod 24h: cc-us5 alone took 1590 such hits.
+//
+// tkShouldClearStickyForSaturation augments the existing clearSticky decision
+// at each sticky-honor site: when the bound anthropic stub is SUSTAINEDLY
+// saturated (live in-window count >= anthropicSaturationThreshold), the binding
+// is cleared so the next selection rebinds to a healthy sibling via the
+// load-balance path. It is a routing PREFERENCE, NOT a cooldown — it reuses the
+// SAME clear+fall-through mechanism the existing unschedulable check already
+// triggers, never calls SetTempUnschedulable / SetRateLimited / advances the
+// 3/3 ladder, and is self-clearing (the counter has a ~90s TTL, so once the
+// edge recovers the binding can re-form). Amplifier-safe: clearing a sticky
+// binding never removes the stub from the candidate set; if it is the only
+// candidate the load-balance path still selects it.
+//
+// Deliberately gated tight so steady-state prompt-cache affinity is untouched:
+// only platform=anthropic, only when the de-prioritize feature is enabled
+// (shared kill-switch SettingKeyAnthropicSaturatedStubDeprioritizeEnabled), and
+// only at/above the same SUSTAINED threshold (4) the Layer-2 penalty uses — so a
+// transient blip (1-3 hits/90s) never clears a binding. Best-effort: a nil
+// counter, disabled feature, or any Redis error leaves the binding untouched
+// (selection must never fail because the preference counter is unavailable).
+//
+// Logs (Info) exactly when it decides to clear — the existing sticky.* logs are
+// slog.Debug (off in prod), so this single low-volume line (≈ once per affected
+// session per saturation episode, since the cleared binding is not re-entered)
+// is how ops sees the sticky side engage.
+func (s *GatewayService) tkShouldClearStickyForSaturation(ctx context.Context, account *Account, sessionHash string) bool {
+	if s == nil || s.tkAnthropicSaturationCounter == nil || account == nil {
+		return false
+	}
+	if account.Platform != PlatformAnthropic {
+		return false
+	}
+	if s.settingService != nil && !s.settingService.IsAnthropicSaturatedStubDeprioritizeEnabled(ctx) {
+		return false
+	}
+	counts, err := s.tkAnthropicSaturationCounter.GetSaturationBatch(ctx, []int64{account.ID})
+	if err != nil {
+		return false
+	}
+	count := counts[account.ID]
+	if count < anthropicSaturationThreshold {
+		return false
+	}
+	slog.Info("anthropic_sticky_cleared_saturated_stub",
+		"account_id", account.ID,
+		"recent_count", count,
+		"threshold", anthropicSaturationThreshold,
+		"window_seconds", anthropicSaturationWindowSeconds,
+		"session", shortSessionHash(sessionHash),
+	)
+	return true
+}

--- a/backend/internal/service/gateway_service_tk_sticky_saturation.go
+++ b/backend/internal/service/gateway_service_tk_sticky_saturation.go
@@ -17,21 +17,25 @@ import (
 // correctly SKIPS the cooldown ladder (counting it once caused the 2026-05-31
 // "503 amplifier") and instead feeds the bounded saturation counter. The
 // Layer-2 load-balance ranking then de-prioritizes the saturated stub. BUT the
-// sticky-session paths (Layer-1.5 inline block in SelectAccountWithLoadAwareness
-// and the legacy sticky blocks in selectAccountForModelWithPlatform /
-// selectAccountWithMixedScheduling, also used by the count_tokens failover)
-// honor a bound stub via shouldClearStickySession, which only inspects
+// Layer-1.5 sticky block in SelectAccountWithLoadAwareness honors a bound stub
+// via shouldClearStickySession, which only inspects
 // IsSchedulable()+model-rate-limit — both stay true for a saturated stub by
 // design. So a session bound to a dead edge keeps selecting it FIRST and paying
 // a wasted failover hop on every request, with zero prompt-cache benefit (the
 // request fails over to a DIFFERENT edge, so affinity to the dead stub is
 // already worthless). prod 24h: cc-us5 alone took 1590 such hits.
 //
-// tkShouldClearStickyForSaturation augments the existing clearSticky decision
-// at each sticky-honor site: when the bound anthropic stub is SUSTAINEDLY
-// saturated (live in-window count >= anthropicSaturationThreshold), the binding
-// is cleared so the next selection rebinds to a healthy sibling via the
-// load-balance path. It is a routing PREFERENCE, NOT a cooldown — it reuses the
+// tkShouldClearStickyForSaturation augments the clearSticky decision in the
+// Layer-1.5 block ONLY: when the bound anthropic stub is SUSTAINEDLY saturated
+// (live in-window count >= anthropicSaturationThreshold), the binding is cleared
+// so the request falls through to Layer-2, where computeAnthropicSaturationPenalties
+// applies the +1000 penalty and selection lands on a healthy sibling that is then
+// re-bound. It is deliberately NOT wired into the legacy
+// selectAccountForModelWithPlatform / selectAccountWithMixedScheduling sticky
+// blocks (count_tokens failover / LoadBatchEnabled=false): those re-select by raw
+// priority with NO saturation penalty, so clearing there could re-pick the SAME
+// saturated stub and re-bind it, churning the binding + this log for no benefit.
+// It is a routing PREFERENCE, NOT a cooldown — it reuses the
 // SAME clear+fall-through mechanism the existing unschedulable check already
 // triggers, never calls SetTempUnschedulable / SetRateLimited / advances the
 // 3/3 ladder, and is self-clearing (the counter has a ~90s TTL, so once the

--- a/backend/internal/service/gateway_service_tk_sticky_saturation_test.go
+++ b/backend/internal/service/gateway_service_tk_sticky_saturation_test.go
@@ -1,0 +1,91 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// Reuses fakeSaturationCache, satSettingRepoStub and resetSatCache from
+// gateway_service_tk_saturation_penalty_test.go (same package + build tag).
+
+func anthropicStub(id int64) *Account {
+	return &Account{ID: id, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+}
+
+func TestShouldClearStickyForSaturation_ThresholdBoundary(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{counts: map[int64]int64{
+		1: anthropicSaturationThreshold - 1, // just below => keep binding
+		2: anthropicSaturationThreshold,     // at threshold => clear (sustained)
+		3: anthropicSaturationThreshold + 9, // well above => clear
+		4: 0,                                // no hits => keep
+	}})
+
+	require.False(t, gw.tkShouldClearStickyForSaturation(context.Background(), anthropicStub(1), "sess"),
+		"transient blip below threshold must NOT clear the binding (preserves prompt-cache affinity)")
+	require.True(t, gw.tkShouldClearStickyForSaturation(context.Background(), anthropicStub(2), "sess"),
+		"sustained saturation at threshold must clear")
+	require.True(t, gw.tkShouldClearStickyForSaturation(context.Background(), anthropicStub(3), "sess"))
+	require.False(t, gw.tkShouldClearStickyForSaturation(context.Background(), anthropicStub(4), "sess"))
+}
+
+func TestShouldClearStickyForSaturation_NonAnthropicIgnored(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{counts: map[int64]int64{9: 100}})
+	openai := &Account{ID: 9, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	require.False(t, gw.tkShouldClearStickyForSaturation(context.Background(), openai, "sess"),
+		"saturation counter is anthropic-only; other platforms must never be cleared by it")
+}
+
+func TestShouldClearStickyForSaturation_NilCounterIsNoop(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{} // no counter wired => feature inert
+	require.False(t, gw.tkShouldClearStickyForSaturation(context.Background(), anthropicStub(1), "sess"))
+}
+
+func TestShouldClearStickyForSaturation_NilAccount(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{counts: map[int64]int64{1: 100}})
+	require.False(t, gw.tkShouldClearStickyForSaturation(context.Background(), nil, "sess"))
+}
+
+func TestShouldClearStickyForSaturation_ReadErrorIsBestEffort(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{getErr: context.DeadlineExceeded})
+	require.False(t, gw.tkShouldClearStickyForSaturation(context.Background(), anthropicStub(1), "sess"),
+		"redis error must not clear a binding (selection must never fail on the preference counter)")
+}
+
+func TestShouldClearStickyForSaturation_KillSwitchOff(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{counts: map[int64]int64{1: 100}})
+	gw.settingService = NewSettingService(
+		&satSettingRepoStub{values: map[string]string{
+			SettingKeyAnthropicSaturatedStubDeprioritizeEnabled: "false",
+		}},
+		&config.Config{},
+	)
+	require.False(t, gw.tkShouldClearStickyForSaturation(context.Background(), anthropicStub(1), "sess"),
+		"kill-switch off => sticky binding untouched (shares the de-prioritize feature switch)")
+	resetSatCache()
+}
+
+func TestShouldClearStickyForSaturation_KillSwitchDefaultOn(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{counts: map[int64]int64{1: anthropicSaturationThreshold}})
+	gw.settingService = NewSettingService(&satSettingRepoStub{values: map[string]string{}}, &config.Config{})
+	require.True(t, gw.tkShouldClearStickyForSaturation(context.Background(), anthropicStub(1), "sess"),
+		"unset switch => default ON => sustained saturation clears")
+	resetSatCache()
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -16,7 +16,7 @@
       "must_contain": [
         "s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)"
       ],
-      "rationale": "Load-bearing wiring of the sticky saturated-stub clear: appended to the clearSticky decision at every anthropic sticky-honor site (Layer-1.5 inline block in SelectAccountWithLoadAwareness plus the legacy selectAccountForModelWithPlatform / selectAccountWithMixedScheduling blocks, the latter also used by the count_tokens failover). If an upstream merge drops this one-line hook the helper in gateway_service_tk_sticky_saturation.go becomes dead and sticky-bound sessions silently revert to selecting a saturated dead-edge stub first. Anchors the hook so merge drift is caught by preflight + the upstream-merge PR shape check."
+      "rationale": "Load-bearing wiring of the sticky saturated-stub clear: appended to the clearSticky decision in the Layer-1.5 block of SelectAccountWithLoadAwareness (the prod LoadBatchEnabled path). Wired here ONLY because clearing falls through to Layer-2 where computeAnthropicSaturationPenalties de-prioritizes the cleared stub and selection lands on a healthy sibling; the legacy selectAccountForModel* sticky blocks lack that penalty so the hook is intentionally absent there (clearing would re-pick the same stub). If an upstream merge drops this one-line hook the helper in gateway_service_tk_sticky_saturation.go becomes dead and sticky-bound sessions silently revert to selecting a saturated dead-edge stub first. Anchors the hook so merge drift is caught by preflight + the upstream-merge PR shape check."
     },
     {
       "path": "backend/cmd/server/main.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3,6 +3,22 @@
   "rationale": "Load-bearing TokenKey gateway/service injections that intentionally live in upstream-shaped hotspot files. These touches are small and compile-clean if dropped, so upstream merges can silently revert them unless preflight and upstream-merge PR shape check their literal hooks.",
   "sentinels": [
     {
+      "path": "backend/internal/service/gateway_service_tk_sticky_saturation.go",
+      "must_contain": [
+        "func (s *GatewayService) tkShouldClearStickyForSaturation(",
+        "count < anthropicSaturationThreshold",
+        "anthropic_sticky_cleared_saturated_stub"
+      ],
+      "rationale": "Sticky-side completion of the anthropic saturated mirror-stub de-prioritization (prod 2026-06-19). The Layer-2 penalty (gateway_service_tk_saturation_penalty.go) de-prioritizes a saturated stub, but the sticky-honor paths bind a session to a specific stub via shouldClearStickySession, which only inspects IsSchedulable()+model-rate-limit — both stay true for a saturated stub by design — so a session bound to a dead edge keeps selecting it FIRST and pays a wasted failover hop every request (prod 24h: cc-us5 alone 1590 hits, 0 client-facing exhaustion). This helper clears the binding when the bound anthropic stub is SUSTAINEDLY saturated (count >= anthropicSaturationThreshold) so the next selection rebinds to a healthy sibling. PREFERENCE not cooldown: never SetTempUnschedulable / advances the 3/3 ladder (would re-create the 2026-05-31 503 amplifier), reuses the existing clear+fall-through, self-clearing via the 90s counter TTL, shares the IsAnthropicSaturatedStubDeprioritizeEnabled kill-switch. Dropping this file silently reverts sticky-bound sessions to hammering a dead edge for the whole outage."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "s.tkShouldClearStickyForSaturation(ctx, account, sessionHash)"
+      ],
+      "rationale": "Load-bearing wiring of the sticky saturated-stub clear: appended to the clearSticky decision at every anthropic sticky-honor site (Layer-1.5 inline block in SelectAccountWithLoadAwareness plus the legacy selectAccountForModelWithPlatform / selectAccountWithMixedScheduling blocks, the latter also used by the count_tokens failover). If an upstream merge drops this one-line hook the helper in gateway_service_tk_sticky_saturation.go becomes dead and sticky-bound sessions silently revert to selecting a saturated dead-edge stub first. Anchors the hook so merge drift is caught by preflight + the upstream-merge PR shape check."
+    },
+    {
       "path": "backend/cmd/server/main.go",
       "must_contain": [
         "protocols.SetUnencryptedHTTP2(true)",


### PR DESCRIPTION
## 背景与问题（证据驱动）

prod 经 per-edge apikey 镜像 stub（`cc-us5` …）中继到 edge。edge 池空时返回 `429 "No available accounts"`，prod **正确地不冷却 stub**（跳过 3/3 ladder，避免 2026-05-31 的「503 放大器」），改喂一个有界、自清除的 saturation 去优先级：阈值 4 次/90s 窗 → **Layer-2 负载均衡** 给 `+1000` 有效优先级（`computeAnthropicSaturationPenalties`），把饱和 stub 排到健康兄弟之后。

但 `SelectAccountWithLoadAwareness` 的 **Layer-1.5 sticky** 经 `shouldClearStickySession` 守住绑定，该函数只看 `IsSchedulable()`+模型限流——二者对饱和 stub 恒为真——所以绑定到死 edge 的 sticky 会话**每个请求仍先按到它再 failover**，白付一跳；而绑定到死 edge 的 prompt-cache 亲和性本就失效（请求改由别的 edge 服务）。

**prod 日志实证（2026-06-19，prod 24h + edge 自身 9h）**
- `downstream_no_available_accounts_skip_penalty` = **3467**，95% 集中在 15:00–17:00 UTC 突发，`cc-us5(id50)=1590` / `cc-us7(id54)=1607` 占 92%。
- `stub_saturated_deprioritized` 阈值跨越 = 137（Layer-2 去优先级在工作）。
- **客户端零影响**：prod 26389 served / 0 no-available / 0 exhausted；edge us5/us7 = degraded SPOF（各 1 账号反复打满窗）。属健壮性/效率改进，非客户端止血。
- 闭环铁证：cc-us5 在所有优先级层都被压到最后（裸 `priority:3` + 饱和 `+1000`）却仍吃 1590 跳；而 0 exhaustion 证明健康兄弟有余量 → 负载均衡不会选被去优先级的 stub → 唯一解释是 **sticky 守着永不清除的陈旧绑定**。

## 改动

新增 `tkShouldClearStickyForSaturation`，**只**接在 `SelectAccountWithLoadAwareness` 的 Layer-1.5 `clearSticky` 决策（prod `LoadBatchEnabled` 主 `/v1/messages` 路径）。绑定的 anthropic stub **持续饱和**（`count >= anthropicSaturationThreshold`）时清绑定 → 落到 **Layer-2**（那里有 `+1000` 惩罚）→ 选中健康兄弟并**重绑到它**。

**为什么只接这一处**（self-review 收窄，见下）：清除要「有效」，必须落到带 saturation 惩罚的选择路径；只有 Layer-2 有该惩罚。legacy `selectAccountForModelWithPlatform` / `selectAccountWithMixedScheduling`（count_tokens failover / `LoadBatchEnabled=false`）按**裸优先级**重选、无惩罚——在那里清绑定可能原地回选同一饱和 stub 并重绑，**每请求 churn + 日志刷屏、零收益**。故刻意不接。

**PREFERENCE 不是 cooldown**：复用既有 clear+fall-through，从不 `SetTempUnschedulable`/进 3/3 ladder（不重建放大器），共用 `IsAnthropicSaturatedStubDeprioritizeEnabled` kill-switch（默认 on），90s 计数 TTL 自清除，且仅在与 Layer-2 同一 SUSTAINED 阈值(4)之上触发——瞬时 blip 不动绑定，**稳态 prompt-cache 命中率不受影响**。

### 范围裁定
- ✅ Layer-1.5 sticky 持续饱和清/重绑 —— 唯一命中证据且「有效」的修复。
- ❌ Layer-1 模型路由接 effectivePriority —— anthropic `messages_dispatch_model_config` 为空（走 sticky 非 Layer-1）+ saturation 仅 anthropic 维度，恒 0 惩罚=死代码。
- ❌ legacy/Layer-3 兜底 —— 无 Layer-2 惩罚，清了会原地回选（见上），故不接。

## self-review（xj-review #882）
首版误把 hook 接到全部 5 处 sticky 站点；自审 R-001 发现 4 处 legacy 路径无 saturation 惩罚、清绑定会 churn+刷日志无收益，已收窄回单一 Layer-1.5 路径（即本 PR 当前形态），并在 helper 文档 + sentinel rationale 记录「为何单点」。

## 门禁
- `go test -tags=unit ./...` 全绿（54 pkg）；`go test -tags=integration ./internal/service/...` 绿；`golangci-lint` 0 issues；`go build ./...` OK；`scripts/preflight.sh`（含全部 sub2api 检查）PASS。
- 7 项单测覆盖 helper：阈值边界 / 非 anthropic / nil counter / nil account / Redis 错误 best-effort / kill-switch on·off。
- **Sentinel**：为新文件 `gateway_service_tk_sticky_saturation.go` 与 `gateway_service.go` 里的 hook 接线各加了 `gateway-tk.json` 锚点（满足 sentinel registry update gate，并防上游合并静默 revert）。
- **Upstream-override**：`gateway_service.go` 已被 `gateway-tk.json` 覆盖（coverage-first 自动通过）；仅一行 additive hook，无 upstream 符号删除。
- 纯后端：`no-web-impact`。

## 验证（发版后）
按 `tokenkey-online-log-troubleshooting` §8.5：prod grep 新 marker `anthropic_sticky_cleared_saturated_stub`（应在 us5/us7 饱和窗出现、量有界），对照 `downstream_no_available_accounts_skip_penalty` 在 cc-us5/cc-us7 的量应下降；served_200 / 0 exhausted 保持；命中率（usage_logs cache_read 占比）无回退。

> Merge：本 PR 为 TK fix，用 **Squash and merge**（WIP 中间 commit 会被压平）。
