### PR TITLE
feat(gateway): Universal Key 按「组已服务模型集」路由 + newapi model_mapping 不变量

### DIFF
--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -152,6 +152,13 @@ func provideCleanup(
 	// GatewayHandler.SetModelListFilter is called at startup. See R-003 /
 	// Goal 2 of docs/approved/pricing-availability-source-of-truth.md.
 	_ handler.TKGatewayHandlerModelListReady,
+	// TokenKey: forces wire to evaluate ProvideTKUniversalModelsProvider so the
+	// universal-key resolver's "group served-model set" truth source
+	// (GatewayService.GetAvailableModels) is wired onto APIKeyService at startup.
+	// Without this edge wire dead-codes the post-construction setter and the
+	// resolver silently falls back to platform-level routing. See
+	// docs/approved/universal-key-routing.md.
+	_ service.TKUniversalModelsProviderReady,
 ) func() {
 	return func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -323,7 +323,8 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	tkAnthropicSaturationReady := service.ProvideTKAnthropicSaturation(gatewayService, rateLimitService, anthropicSaturationCounterCache)
 	modelListFilter := service.NewModelListFilter(pricingCatalogService, pricingAvailabilityService)
 	tkGatewayHandlerModelListReady := handler.ProvideTKGatewayHandlerModelList(gatewayHandler, modelListFilter)
-	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, antigravityConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, holdReconcilerService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkPricingOverlayRuntimeReady, tkGatewayAnthropicSigPreemptReady, tkAnthropicSaturationReady, tkGatewayHandlerModelListReady)
+	tkUniversalModelsProviderReady := service.ProvideTKUniversalModelsProvider(apiKeyService, gatewayService)
+	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, antigravityConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, holdReconcilerService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkPricingOverlayRuntimeReady, tkGatewayAnthropicSigPreemptReady, tkAnthropicSaturationReady, tkGatewayHandlerModelListReady, tkUniversalModelsProviderReady)
 	application := &Application{
 		Server:  httpServer,
 		Cleanup: v,
@@ -405,6 +406,8 @@ func provideCleanup(
 	_ service.TKAnthropicSaturationReady,
 
 	_ handler.TKGatewayHandlerModelListReady,
+
+	_ service.TKUniversalModelsProviderReady,
 ) func() {
 	return func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/backend/cmd/server/wire_gen_test.go
+++ b/backend/cmd/server/wire_gen_test.go
@@ -97,6 +97,7 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 		service.TKGatewayAnthropicSigPreemptReady{}, // TK: forces SetAnthropicSigPreemptCache wiring
 		service.TKAnthropicSaturationReady{},        // TK: forces SetAnthropicSaturationCounter wiring
 		handler.TKGatewayHandlerModelListReady{},    // TK: forces SetModelListFilter wiring
+		service.TKUniversalModelsProviderReady{},    // TK: forces universal-key models-provider wiring
 	)
 
 	require.NotPanics(t, func() {

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -189,6 +189,11 @@ func (s *AccountService) Create(ctx context.Context, req CreateAccountRequest) (
 		account.AutoPauseOnExpired = true
 	}
 
+	// newapi 多 vendor 平台账号必须声明非空 model_mapping(不变量;见 account_service_tk_newapi_mapping.go)。
+	if err := validateNewapiAccountModelMapping(account.Platform, account.Credentials); err != nil {
+		return nil, err
+	}
+
 	if err := s.accountRepo.Create(ctx, account); err != nil {
 		return nil, fmt.Errorf("create account: %w", err)
 	}
@@ -310,6 +315,15 @@ func (s *AccountService) Update(ctx context.Context, id int64, req UpdateAccount
 	// 先验证分组是否存在（在任何写操作之前）
 	if req.GroupIDs != nil {
 		if err := s.validateGroupIDsExist(ctx, *req.GroupIDs); err != nil {
+			return nil, err
+		}
+	}
+
+	// newapi 多 vendor 平台账号必须声明非空 model_mapping(不变量;见 account_service_tk_newapi_mapping.go)。
+	// 仅在本次更新**设置了 credentials** 时校验:避免对存量空映射账号(如未修复的 grok 账号 65)
+	// 的无关字段编辑(改 priority/notes 等)误拦——存量违例由 ops 审计 + 路由层兜底。
+	if req.Credentials != nil {
+		if err := validateNewapiAccountModelMapping(account.Platform, account.Credentials); err != nil {
 			return nil, err
 		}
 	}

--- a/backend/internal/service/account_service_tk_newapi_mapping.go
+++ b/backend/internal/service/account_service_tk_newapi_mapping.go
@@ -1,0 +1,50 @@
+package service
+
+import infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+
+// newapi 账号 model_mapping 不变量(非对称)。
+//
+// newapi 是**多 vendor** 平台(一个平台下 deepseek / Qwen / volcengine / google-vertex /
+// grok / … 多个 vendor 组,按 channel_type 区分)。空 model_mapping 在多 vendor 平台是配置
+// 缺失:全能 Key 解析器无法据此判别该账号到底服务哪些模型,会按平台名误路由(grok 账号 65
+// 无声明即栽于此)。故强制 newapi 账号声明非空 model_mapping。
+//
+// 原生单 vendor 平台(anthropic / openai / gemini / antigravity)保留「空映射=透传该平台
+// 全部模型」——零维护、忠于上游,不受此约束。
+//
+// 三道闸之一(写时挡);另两道:路由层对 newapi 空映射组不匹配(universal_routing_tk_serving.go)、
+// ops 实时审计(ops/newapi/audit-model-mapping.py)。见 docs/approved/universal-key-routing.md。
+
+// ErrNewapiModelMappingRequired 是 newapi 账号缺/空 model_mapping 时的写时校验错误。
+var ErrNewapiModelMappingRequired = infraerrors.BadRequest(
+	"NEWAPI_MODEL_MAPPING_REQUIRED",
+	"newapi 账号必须声明非空 credentials.model_mapping(多 vendor 平台空映射会导致全能 Key 误路由)",
+)
+
+// validateNewapiAccountModelMapping 仅对 platform==newapi 强制非空 model_mapping。
+func validateNewapiAccountModelMapping(platform string, credentials map[string]any) error {
+	if platform != PlatformNewAPI {
+		return nil
+	}
+	if !newapiModelMappingDeclared(credentials) {
+		return ErrNewapiModelMappingRequired
+	}
+	return nil
+}
+
+// newapiModelMappingDeclared 判定 credentials 是否声明了非空 model_mapping(原始声明,不走
+// GetModelMapping 的平台默认回退——要的是「显式声明」而非「被默认填充」)。
+func newapiModelMappingDeclared(credentials map[string]any) bool {
+	raw, ok := credentials["model_mapping"]
+	if !ok {
+		return false
+	}
+	switch m := raw.(type) {
+	case map[string]any:
+		return len(m) > 0
+	case map[string]string:
+		return len(m) > 0
+	default:
+		return false
+	}
+}

--- a/backend/internal/service/api_key_service.go
+++ b/backend/internal/service/api_key_service.go
@@ -253,6 +253,16 @@ func (s *APIKeyService) UniversalResolver() *UniversalRoutingResolver {
 	return s.universalResolver
 }
 
+// SetUniversalAvailableModelsProvider 后期绑定全能 Key 解析器的「组可服务模型集」真值源
+// (GatewayService.GetAvailableModels)。构造期 GatewayService 尚不存在,故经 wire 就绪钩子
+// 在两者构造后注入(见 wire.go ProvideTKUniversalModelsProvider)。nil-safe。
+func (s *APIKeyService) SetUniversalAvailableModelsProvider(p availableModelsProvider) {
+	if s == nil || s.universalResolver == nil {
+		return
+	}
+	s.universalResolver.SetAvailableModelsProvider(p)
+}
+
 // SetRateLimitCacheInvalidator sets the optional rate limit cache invalidator.
 // Called after construction (e.g. in wire) to avoid circular dependencies.
 func (s *APIKeyService) SetRateLimitCacheInvalidator(inv RateLimitCacheInvalidator) {

--- a/backend/internal/service/universal_routing_tk_resolver.go
+++ b/backend/internal/service/universal_routing_tk_resolver.go
@@ -27,6 +27,12 @@ type UniversalRoutingResolver struct {
 	sf    singleflight.Group
 	mu    sync.RWMutex
 	cache map[int64]*spanCacheEntry
+
+	// modelsProvider 是「组可服务模型集」真值源(GatewayService.GetAvailableModels),
+	// 经 APIKeyService.SetUniversalAvailableModelsProvider 在 GatewayService 构造后绑定
+	// (避免构造期环)。受 mu 保护。nil = 未接线/降级 → Resolve 退回平台级现状(安全兜底)。
+	// 见 universal_routing_tk_serving.go。
+	modelsProvider availableModelsProvider
 }
 
 // availableGroupsLister 由 *APIKeyService 满足，给出某用户当前有权绑定的全部分组
@@ -61,6 +67,25 @@ func NewUniversalRoutingResolver(lister availableGroupsLister) *UniversalRouting
 	}
 }
 
+// SetAvailableModelsProvider 后期注入「组可服务模型集」真值源(见 universal_routing_tk_serving.go)。
+// 由 APIKeyService.SetUniversalAvailableModelsProvider 在 GatewayService 构造后调用。nil-safe。
+func (r *UniversalRoutingResolver) SetAvailableModelsProvider(p availableModelsProvider) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.modelsProvider = p
+	r.mu.Unlock()
+}
+
+// providerSnapshot 取当前 provider(受 mu 保护读)。
+func (r *UniversalRoutingResolver) providerSnapshot() availableModelsProvider {
+	r.mu.RLock()
+	p := r.modelsProvider
+	r.mu.RUnlock()
+	return p
+}
+
 // Resolve 返回该请求应落到的后端组。shape 为入口端点形状，model 为请求模型名（可空，
 // 仅作平台偏好提示），forcedPlatform 非空时（如 /antigravity）只在该平台内解析。
 func (r *UniversalRoutingResolver) Resolve(ctx context.Context, apiKey *APIKey, shape UniversalShape, model, forcedPlatform string) (*Group, error) {
@@ -93,6 +118,24 @@ func (r *UniversalRoutingResolver) Resolve(ctx context.Context, apiKey *APIKey, 
 	}
 	if len(eligible) == 0 {
 		return nil, ErrUniversalNoEntitledGroup
+	}
+
+	// 模型服务真值收敛:把 eligible 收敛到“真正服务该模型”的组(见 universal_routing_tk_serving.go)。
+	// 仅当有模型名 + provider 已接线时执行;收敛后非空则用收敛集(deepseek/qwen/imagen/veo/
+	// seedance 等落到声明了该模型的对的组),否则退回原 eligible —— 安全兜底:provider 取数失败/
+	// 无组声明该模型时不比现状更严,继续按平台+hint 挑(gpt-image 这类无账号者仍会被下游诚实拒绝)。
+	if model != "" {
+		if provider := r.providerSnapshot(); provider != nil {
+			served := make([]Group, 0, len(eligible))
+			for i := range eligible {
+				if groupServesModel(ctx, provider, eligible[i], model) {
+					served = append(served, eligible[i])
+				}
+			}
+			if len(served) > 0 {
+				eligible = served
+			}
+		}
 	}
 
 	// 模型平台提示：若提示命中且跨度内有该平台的 eligible 组，仅在这些组里挑（偏向，

--- a/backend/internal/service/universal_routing_tk_serving.go
+++ b/backend/internal/service/universal_routing_tk_serving.go
@@ -1,0 +1,62 @@
+package service
+
+import "context"
+
+// 全能 Key 解析的「组已服务模型集」真值过滤。
+//
+// 背景:旧解析器只按 平台 + 模型名前缀 hint 盲选后端组,对「某组账号到底服不服务这个
+// 具体模型」零可见 —— newapi 平台底下多个 vendor 组(deepseek/Qwen/volcengine/
+// google-vertex/grok/…,多组是按 vendor 专属倍率计费的有意设计)里盲选必投错组 →
+// 下游 `no available accounts`。本文件给解析器加一道「组是否真服务该模型」的判别,
+// 复用 GatewayService.GetAvailableModels(与 /v1/models 同一真值)。
+//
+// 判别按组的服务集来源非对称分流(见 docs/approved/universal-key-routing.md):
+//   - GetAvailableModels 返回非 nil(组有显式 model_mapping,含全部 newapi vendor 组)
+//     → 精确成员判定 M ∈ served。把 deepseek/qwen/imagen/veo/seedance 落到声明了该
+//     模型的组,排除别的 vendor 组。
+//   - 返回 nil(native 空映射:anthropic/openai/gemini/antigravity 等单一 vendor 平台
+//     的「空=透传」)→ 用模型平台 hint == 组平台 判别(单 vendor 平台无歧义,且能匹配
+//     尚未进白名单的新模型)。
+//   - 返回 nil 且组平台为 newapi(多 vendor)→ 不匹配(空映射在多 vendor 平台是配置缺失,
+//     不能靠前缀 hint 撞;由写时校验 + ops 审计 + 路由层共同拦截)。
+
+// availableModelsProvider 返回某组(按 platform)当前可调度账号 model_mapping 键的并集;
+// 无任何账号声明映射时返回 nil(native/permissive)。由 GatewayService.GetAvailableModels
+// 满足,经 APIKeyService 后期绑定(避免构造期 GatewayService 尚不存在的环;见 wire.go
+// ProvideTKUniversalModelsProvider)。provider 为 nil(未接线/降级)时,解析器退回平台级
+// 现状行为 —— 安全兜底,绝不黑洞 universal 流量。
+type availableModelsProvider func(ctx context.Context, groupID *int64, platform string) []string
+
+// groupServesModel 判定组 g 是否真服务模型 model(上述三分流)。provider 非 nil 由调用方保证。
+func groupServesModel(ctx context.Context, provider availableModelsProvider, g Group, model string) bool {
+	gid := g.ID
+	served := provider(ctx, &gid, g.Platform)
+	if served != nil {
+		// 组有显式 model_mapping → 精确成员判定。
+		return modelInServedSet(model, served, g.Platform)
+	}
+	// served == nil:native/permissive(无账号声明映射,或 provider 取数失败)。
+	if g.Platform == PlatformNewAPI {
+		// 多 vendor 平台的空映射 = 配置缺失,不靠 hint 撞(防 openai 名/其它 vendor 误投)。
+		return false
+	}
+	// 单 vendor 原生平台:模型平台 hint == 组平台。
+	return universalModelPlatformHint(model) == g.Platform
+}
+
+// modelInServedSet 判定 model 是否在组的显式服务集里(精确 + 归一,与 IsModelSupported 同口径)。
+func modelInServedSet(model string, served []string, platform string) bool {
+	for _, m := range served {
+		if m == model {
+			return true
+		}
+	}
+	if norm := normalizeRequestedModelForLookup(platform, model); norm != model {
+		for _, m := range served {
+			if m == norm {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -1,0 +1,154 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+// servedProvider 构造一个按 group id 返回显式服务集的 provider stub。
+// 缺席的 id 返回 nil(= native/无声明映射)。
+func servedProvider(byGroup map[int64][]string) availableModelsProvider {
+	return func(_ context.Context, gid *int64, _ string) []string {
+		if gid == nil {
+			return nil
+		}
+		return byGroup[*gid] // 缺席 → nil(native)
+	}
+}
+
+// 核心:newapi 平台多 vendor 组,按「组已服务模型集」精确落到对的组,而非盲选 tiebreaker。
+func TestResolve_NewapiPicksGroupThatServesModel(t *testing.T) {
+	ctx := context.Background()
+	// 两个 newapi vendor 组:deepseek(gid=11)、Qwen(gid=18)。盲选会按 tiebreaker 取 11。
+	span := []Group{
+		grp(11, PlatformNewAPI, 10, false),
+		grp(18, PlatformNewAPI, 20, false),
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		11: {"deepseek-chat", "deepseek-reasoner"},
+		18: {"qwen-max", "qwen-plus"},
+	}))
+	key := universalKey(1)
+
+	g, err := r.Resolve(ctx, key, ShapeOpenAIChat, "qwen-max", "")
+	if err != nil || g == nil || g.ID != 18 {
+		t.Fatalf("qwen-max 应落 Qwen 组 gid=18, got=%v err=%v", g, err)
+	}
+	g, err = r.Resolve(ctx, key, ShapeOpenAIChat, "deepseek-chat", "")
+	if err != nil || g == nil || g.ID != 11 {
+		t.Fatalf("deepseek-chat 应落 deepseek 组 gid=11, got=%v err=%v", g, err)
+	}
+}
+
+// openai 中继组(native 空映射)不得撞 newapi vendor 模型;但其自身平台模型仍命中。
+func TestResolve_NativeEmptyMappingDoesNotMatchOtherVendor(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(2, PlatformOpenAI, 5, false),    // 中继组,nil served
+		grp(11, PlatformNewAPI, 10, false),  // deepseek
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		11: {"deepseek-chat"},
+		// gid=2 缺席 → nil(native openai)
+	}))
+	key := universalKey(1)
+
+	// deepseek-chat 必须落 newapi(11),不能被 openai 空映射组(2)撞走。
+	g, err := r.Resolve(ctx, key, ShapeOpenAIChat, "deepseek-chat", "")
+	if err != nil || g == nil || g.ID != 11 {
+		t.Fatalf("deepseek-chat 应落 gid=11, got=%v err=%v", g, err)
+	}
+	// gpt-5 命中 openai 空映射组(native hint==platform)。
+	g, err = r.Resolve(ctx, key, ShapeOpenAIChat, "gpt-5", "")
+	if err != nil || g == nil || g.ID != 2 {
+		t.Fatalf("gpt-5 应落 openai gid=2, got=%v err=%v", g, err)
+	}
+}
+
+// imagen 走 newapi google-vertex 组(显式声明),不落 openai 组。
+func TestResolve_ImagenPicksVertexNewapiGroup(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(2, PlatformOpenAI, 5, false),    // openai 中继,nil served(不支持 imagen)
+		grp(16, PlatformNewAPI, 10, false),  // google-vertex
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		16: {"imagen-4.0-fast-generate-001", "veo-3.1-generate-001"},
+	}))
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIImages, "imagen-4.0-fast-generate-001", "")
+	if err != nil || g == nil || g.ID != 16 {
+		t.Fatalf("imagen 应落 vertex newapi 组 gid=16, got=%v err=%v", g, err)
+	}
+}
+
+// 回归:原生 anthropic 组(nil served)claude-* 仍正常解析(按 tiebreaker)。
+func TestResolve_NativeAnthropicRegression(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(1, PlatformAnthropic, 5, false),
+		grp(15, PlatformAnthropic, 10, false),
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{})) // 全 native(nil)
+	g, err := r.Resolve(ctx, universalKey(1), ShapeAnthropicMessages, "claude-sonnet-4-6", "")
+	if err != nil || g == nil || g.ID != 1 {
+		t.Fatalf("claude 应落 anthropic gid=1(tiebreaker), got=%v err=%v", g, err)
+	}
+}
+
+// 安全兜底:provider 未接线(nil)→ 退回平台级现状(不因新逻辑改变行为)。
+func TestResolve_NilProviderFallsBackToPlatformLevel(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(11, PlatformNewAPI, 20, false),
+		grp(18, PlatformNewAPI, 10, false), // 更小 sort_order → tiebreaker 胜出
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	// 不设 provider。
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIChat, "deepseek-chat", "")
+	if err != nil || g == nil || g.ID != 18 {
+		t.Fatalf("无 provider 应退回平台级 tiebreaker(gid=18), got=%v err=%v", g, err)
+	}
+}
+
+// 安全兜底:无组声明该模型(served 全空)→ 不硬 403,退回 eligible 由下游裁决。
+func TestResolve_NoServingGroupFallsBackNotHard403(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{grp(11, PlatformNewAPI, 10, false)}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		11: {"deepseek-chat"}, // 不含 gpt-image
+	}))
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIChat, "some-unmapped-model", "")
+	if err != nil || g == nil || g.ID != 11 {
+		t.Fatalf("无组声明该模型应退回 eligible(gid=11),由下游诚实拒绝;got=%v err=%v", g, err)
+	}
+}
+
+func TestValidateNewapiAccountModelMapping(t *testing.T) {
+	nonEmpty := map[string]any{"model_mapping": map[string]any{"deepseek-chat": "deepseek-chat"}}
+	empty := map[string]any{"model_mapping": map[string]any{}}
+	absent := map[string]any{"api_key": "sk-x"}
+
+	if err := validateNewapiAccountModelMapping(PlatformNewAPI, nonEmpty); err != nil {
+		t.Fatalf("newapi 非空映射应通过, got %v", err)
+	}
+	if err := validateNewapiAccountModelMapping(PlatformNewAPI, empty); err == nil {
+		t.Fatal("newapi 空映射应拒绝")
+	}
+	if err := validateNewapiAccountModelMapping(PlatformNewAPI, absent); err == nil {
+		t.Fatal("newapi 缺映射应拒绝")
+	}
+	// 原生平台空映射放行(透传)。
+	if err := validateNewapiAccountModelMapping(PlatformAnthropic, absent); err != nil {
+		t.Fatalf("anthropic 空映射应放行, got %v", err)
+	}
+	if err := validateNewapiAccountModelMapping(PlatformOpenAI, empty); err != nil {
+		t.Fatalf("openai 空映射应放行, got %v", err)
+	}
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -707,6 +707,10 @@ var ProviderSet = wire.NewSet(
 	// Handler-side wiring lives in handler/wire.go (ProvideTKPricingCatalogHandler).
 	ProvidePricingAvailabilityService,
 	ProvideTKGatewayPricingAvailability,
+	// TokenKey: wires GatewayService.GetAvailableModels onto the universal-key
+	// resolver (APIKeyService) post-construction so resolution filters candidate
+	// groups by the models they actually serve. Consumed by provideCleanup.
+	ProvideTKUniversalModelsProvider,
 	// TokenKey: runtime hot-pushable pricing overlay — wires the settings-blob
 	// getter + catalog-cache invalidator onto PricingService, does the initial
 	// load, and subscribes to the settings pub/sub for immediate reloads. Lets a
@@ -796,6 +800,32 @@ func ProvideTKGatewayPricingAvailability(
 		gw.SetPricingAvailabilityService(avail)
 	}
 	return TKGatewayPricingAvailabilityReady{}
+}
+
+// TKUniversalModelsProviderReady is a wire sentinel: holding it proves
+// APIKeyService.SetUniversalAvailableModelsProvider has been called with
+// GatewayService.GetAvailableModels, so the universal-key resolver can filter
+// candidate groups by which models they actually serve. provideCleanup
+// (cmd/server/wire.go) consumes this type as an unused parameter to force wire
+// to evaluate the side-effect.
+type TKUniversalModelsProviderReady struct{}
+
+// ProvideTKUniversalModelsProvider wires the "group served-model set" truth
+// source (GatewayService.GetAvailableModels — the same source /v1/models uses)
+// onto the universal-key resolver post-construction. APIKeyService constructs
+// the resolver before GatewayService exists, so this late binding avoids the
+// construction cycle. Mirrors ProvideTKGatewayPricingAvailability in shape.
+//
+// Setter is nil-safe; if either dep is nil the resolver keeps its safe
+// platform-level fallback. See docs/approved/universal-key-routing.md.
+func ProvideTKUniversalModelsProvider(
+	api *APIKeyService,
+	gw *GatewayService,
+) TKUniversalModelsProviderReady {
+	if api != nil && gw != nil {
+		api.SetUniversalAvailableModelsProvider(gw.GetAvailableModels)
+	}
+	return TKUniversalModelsProviderReady{}
 }
 
 // TKPricingOverlayRuntimeReady is a wire sentinel: holding it proves the runtime

--- a/docs/approved/universal-key-routing.md
+++ b/docs/approved/universal-key-routing.md
@@ -70,9 +70,26 @@ GPT 请求按 GPT 组的价/倍率,每用户还能有自己的专属倍率。
     `/v1/images/edits` → `[openai]`。
   - `/v1beta/models/*` POST → `[gemini, antigravity]`;GET 元数据(含 `/v1/models`)→ 跳过。
 - 解析器 `universal_routing_tk_resolver.go`:取(短 TTL 缓存的)权限跨度 `GetAvailableGroups` →
-  跨度 ∩ 候选平台(active)→ 用 **模型平台提示**(grok→grok、gpt→openai、seedream→newapi,
-  best-effort 偏好非硬过滤)偏向 → **确定性挑选(持订阅优先 → `group.sort_order` → id)**。
-  空 → 按入口协议形状写 403"该模型不在你的套餐内"。
+  跨度 ∩ 候选平台(active)→ **「组已服务模型集」真值过滤(见下)** → **确定性挑选(持订阅优先
+  → `group.sort_order` → id)**。空 → 按入口协议形状写 403"该模型不在你的套餐内"。
+
+  **模型/模态服务真值过滤(`universal_routing_tk_serving.go`)**:旧版仅用前缀 hint(best-effort
+  偏好)选平台,对「某组账号到底服不服务这个模型」零可见 —— newapi 多 vendor 平台(deepseek/
+  Qwen/volcengine/google-vertex/grok/…)里盲选必投错组 → 下游 `no available accounts`。现改为
+  按组的服务集来源**非对称**判别(真值源 = `GatewayService.GetAvailableModels`,与 `/v1/models`
+  同源):
+  - 组有显式 `model_mapping`(含全部 newapi vendor 组)→ 精确成员判定 `M ∈ served`(deepseek/
+    qwen/imagen/veo/seedance 落到声明该模型的组,排除别的 vendor 组);
+  - 组无显式映射(native 空映射:anthropic/openai/gemini/antigravity 单一 vendor 平台的「空=透传」)
+    → 前缀 hint == 组平台(单 vendor 无歧义,且匹配未进白名单的新模型);
+  - 组无显式映射且平台为 newapi(多 vendor)→ **不匹配**(空映射是配置缺失,见非对称不变量)。
+  收敛后非空则用收敛集,否则**退回平台级**(安全兜底:provider 取数失败/无组声明该模型时不比
+  现状更严,由下游诚实拒绝;provider 经 wire 就绪钩子 `ProvideTKUniversalModelsProvider` 后期绑定,
+  未接线时整体退回旧行为)。
+
+  **非对称 model_mapping 不变量**:newapi(多 vendor)账号必须声明非空 `model_mapping`;原生单
+  vendor 平台保留「空=透传」。三道闸:写时挡(`AccountService` → `ErrNewapiModelMappingRequired`)、
+  路由时拒(上述 newapi-空映射不匹配)、ops 实时审计(`ops/newapi/audit-model-mapping.py`,prod-only)。
 - 替换:`apiKey.Group/GroupID` = 后端组。**不设 `ForcePlatform`** —— 替换组本身就让下游按该组
   平台派生(保留 anthropic+antigravity 混合调度等普通组语义);仅 **读取** 已有 ForcePlatform
   (如 `/antigravity` 路由)把候选限制在该平台内,从不覆盖显式 force。

--- a/ops/newapi/audit-model-mapping.py
+++ b/ops/newapi/audit-model-mapping.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""TokenKey newapi account model_mapping audit (read-only, prod-only).
+
+The non-symmetric model_mapping invariant (docs/approved/universal-key-routing.md):
+``platform=newapi`` is a **multi-vendor** platform (deepseek / Qwen / volcengine /
+google-vertex / grok / … share one platform, split by ``channel_type``). An empty
+``credentials.model_mapping`` on a newapi account is a configuration gap: the
+universal-key resolver cannot tell which models that account serves, so it routes
+by platform name and mis-routes (the grok account #65 with no mapping was exactly
+this). Native single-vendor platforms (anthropic/openai/gemini/antigravity) keep
+"empty = pass-through" and are NOT subject to this invariant.
+
+Three enforcement gates: (1) write-time validation in AccountService
+(ErrNewapiModelMappingRequired), (2) route-time reject in the resolver
+(universal_routing_tk_serving.go), (3) **this** live audit for pre-existing rows
+the write-time gate can't see. newapi accounts live only on the prod control-plane
+DB (edges are anthropic relays), so this is prod-only.
+
+A **violation** is any non-deleted ``platform=newapi`` account whose
+``credentials.model_mapping`` is absent or has zero keys.
+
+Exit codes (mirror the post-release checks): ``0`` = no violations (green);
+``1`` = violations found (yellow); ``2`` = could not run (yellow). Read-only —
+never mutates. stdlib-only; reuses ops/stage0 SSM identity helper.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+PROD_TARGET = {"region": "us-east-1", "stack": "tokenkey-prod-stage0", "label": "prod"}
+
+# Read-only snapshot: each newapi account + its model_mapping key count.
+NEWAPI_ACCOUNTS_SQL = (
+    "SELECT COALESCE(json_agg(json_build_object("
+    "'id', a.id, 'name', a.name, 'channel_type', a.channel_type, "
+    "'status', a.status, 'schedulable', a.schedulable, "
+    "'mapping_keys', COALESCE((SELECT count(*) FROM jsonb_object_keys("
+    "COALESCE(a.credentials->'model_mapping', '{}'::jsonb))), 0)"
+    "))::text, '[]') "
+    "FROM accounts a WHERE a.platform = 'newapi' AND a.deleted_at IS NULL;"
+)
+
+# ops-sql-coverage gate (scripts/checks/ops-sql-coverage.py): every SQL-shaped
+# symbol must be enumerated for the real-Postgres self-check or exempted.
+SELF_CHECK_EXEMPT: dict[str, str] = {
+    "ssm_run_sql": "executes SQL over SSM, does not build it",
+}
+
+
+def iter_self_check_sql() -> list[tuple[str, str]]:
+    """(label, rendered_sql) for the ops-sql-coverage real-Postgres self-check."""
+    return [
+        ("NEWAPI_ACCOUNTS_SQL", NEWAPI_ACCOUNTS_SQL),
+    ]
+
+
+def fail(msg: str) -> None:
+    print(f"audit-model-mapping: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+def _load(rel: str, name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / rel)
+    if spec is None or spec.loader is None:
+        fail(f"cannot load {rel}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(name, mod)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_SSM = _load("ops/stage0/edge_ssm_execution.py", "tk_edge_ssm_execution")
+
+
+def ssm_run_sql(region: str, instance_id: str, sql: str, comment: str) -> str:
+    remote = "sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -t -A -v ON_ERROR_STOP=1"
+    command = f"set -euo pipefail\n{remote} <<'SQL'\n{sql}\nSQL"
+    params = json.dumps({"commands": [command]}, ensure_ascii=False)
+    try:
+        cid = subprocess.check_output(
+            ["aws", "ssm", "send-command", "--region", region,
+             "--instance-ids", instance_id, "--document-name", "AWS-RunShellScript",
+             "--comment", comment, "--parameters", params,
+             "--query", "Command.CommandId", "--output", "text"],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError as e:
+        fail(f"ssm send-command failed ({comment}): {e}")
+    subprocess.run(
+        ["aws", "ssm", "wait", "command-executed", "--region", region,
+         "--command-id", cid, "--instance-id", instance_id],
+        check=False,
+    )
+    inv = json.loads(
+        subprocess.check_output(
+            ["aws", "ssm", "get-command-invocation", "--region", region,
+             "--command-id", cid, "--instance-id", instance_id, "--output", "json"],
+            text=True,
+        )
+    )
+    if inv.get("Status") != "Success" or inv.get("ResponseCode") != 0:
+        err = (inv.get("StandardErrorContent") or "").strip()[:1200]
+        fail(f"ssm cmd {cid} status={inv.get('Status')} rc={inv.get('ResponseCode')} ({comment})\n  stderr: {err}")
+    return (inv.get("StandardOutputContent") or "").strip()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="audit newapi account model_mapping invariant (prod-only)")
+    ap.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = ap.parse_args()
+
+    inst = _SSM.cfn_resolve_instance_id(PROD_TARGET["region"], PROD_TARGET["stack"])
+    out = ssm_run_sql(PROD_TARGET["region"], inst, NEWAPI_ACCOUNTS_SQL, "newapi model_mapping audit")
+    try:
+        accounts = json.loads(out) if out else []
+    except json.JSONDecodeError:
+        fail(f"unexpected psql output: {out[:300]}")
+
+    violations = [a for a in accounts if int(a.get("mapping_keys", 0)) == 0]
+    result = {
+        "target": "prod",
+        "newapi_account_count": len(accounts),
+        "violation_count": len(violations),
+        "violations": [
+            {"id": a["id"], "name": a["name"], "channel_type": a.get("channel_type"),
+             "status": a.get("status"), "schedulable": a.get("schedulable")}
+            for a in violations
+        ],
+    }
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print(f"newapi accounts: {len(accounts)}  violations (empty model_mapping): {len(violations)}")
+        for a in violations:
+            print(f"  VIOLATION account={a['id']} ({a['name']}) ct={a.get('channel_type')} "
+                  f"status={a.get('status')} schedulable={a.get('schedulable')}")
+        if not violations:
+            print("  OK: every newapi account declares a non-empty model_mapping")
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 背景与问题

Universal Key（#878）旧解析器选后端组只看 **平台 + 模型名前缀 hint（软偏好）+ tiebreaker**，对「某组账号到底服不服务这个具体模型」**完全没有可见性**。

而 `newapi` 是多 vendor 平台——deepseek / Qwen / volcengine / google-vertex / grok 各自独立成组，按 vendor 专属倍率计费（多组是有意设计，不是冗余）。盲选必然投错组 → 下游直接 `no available accounts`。用 `ops/test/gateway_full_matrix_test.sh`（#883）实跑 prod 坐实：deepseek / qwen / imagen / veo / seedance / grok 全部 SKIP。

## 解决方案：路由前按「组已服务模型集」真值收敛

在 `universal_routing_tk_serving.go` + resolver 里，于**平台过滤之后、tiebreaker 之前**，按「组已服务模型集」真值（`GatewayService.GetAvailableModels`，与 `/v1/models` 同源）把候选组收敛到「真正服务该模型」的集合。

判别按服务集来源**非对称分流**：

| 组的服务集来源 | 判别方式 |
| --- | --- |
| 有显式 `model_mapping`（含全部 newapi vendor 组） | 精确成员判定 `M ∈ served` |
| native 空映射、单 vendor 平台（anthropic/openai/gemini/antigravity） | 前缀 hint == 组平台（无歧义，且能匹配尚未进白名单的新模型） |
| newapi 空映射（多 vendor） | 不匹配（空映射 = 配置缺失，不靠 hint 撞） |

**安全兜底**：收敛后非空才采用收敛集，否则退回平台级现状行为；provider 经 wire 就绪钩子 `ProvideTKUniversalModelsProvider` 后期绑定以破构造环（`APIKeyService` 先于 `GatewayService` 构造）——**未接线时整体退回旧行为，绝不黑洞 universal 流量**。

## 配套：newapi model_mapping 非对称不变量（三道闸）

- **写时挡**：`AccountService` 创建/更新 newapi 空映射账号 → `ErrNewapiModelMappingRequired`。`Update` 仅在本次设置 credentials 时校验，不误拦存量账号的无关编辑。
- **路由时拒**：上述 newapi 空映射在路由层不匹配（见判别表第三行）。
- **实时审计**：`ops/newapi/audit-model-mapping.py`（prod-only SSM 只读），实跑确认账号 65（grok-us4）是当前唯一违例。

原生单 vendor 平台保留「空 = 透传」语义（零维护、忠于上游）。

## 效果

- deepseek / qwen / imagen / veo / seedance 落到声明了该模型的对的组。
- **grok**：待补账号 65 的 `model_mapping`（在册模型 + 上游 id 是业务配置，作为后续 ops 动作单独确认后写入，**不在本 PR**）后，resolver 自动选中。
- **gpt-image**：无任何生图账号 → 仍诚实 SKIP（provisioning 缺口，非路由可解）。
- anthropic / openai / gemini 原生通路 **不回归**。

## 验证

- **单测**（7 例，`go test -tags=unit ./...` 全绿）：resolver 三分流（deepseek/qwen/imagen 落对组、openai 空映射不撞 deepseek、native claude/gpt 回归）+ provider-nil / 无服务组 fallback + 写时校验。
- `go build ./...`、`golangci-lint`（改动包 0 issues）、`go generate ./cmd/server`（wire 无环）。
- `scripts/preflight.sh` 全绿（含 ops SQL 覆盖 + ops-tool-orphan）。
- `ops/newapi/audit-model-mapping.py` 实跑 prod：8 个 newapi 账号，1 违例（账号 65）。

## 关键正确性说明（reviewer 关注点）

非对称判别依赖 `GatewayService.GetAvailableModels` 的 **nil-vs-非空契约**：该函数**恰好**在「无任何可调度账号声明 model_mapping」时返回 `nil`，且返回非 nil 时必非空（`gateway_service.go`）。因此 `served != nil` ⟺「组有显式映射」，判别无静默破绽。

## marker

- **no-web-impact**：纯后端路由 + ops 脚本，无 frontend 改动。
- **upstream-touch-trivial**：对 upstream-shaped 文件的改动无 upstream-merge revert 风险——`account_service.go` / `api_key_service.go` 为纯插入（新增校验调用 + setter，无删除）；`cmd/server/wire_gen.go` 是 `go generate` 重生成产物（派生，非手写逻辑），未来上游合并会重新生成而非手改。无 upstream 符号删除。
- **sentinel-registry-reviewed**：新增 `universal_routing_tk_serving.go` / `account_service_tk_newapi_mapping.go` 等 TK companion 由单测 + wire 就绪 sentinel（`TKUniversalModelsProviderReady`）覆盖，无 newapi 删除风险面，无需新建 sentinel 类目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
