### PR TITLE
feat(ops): 给 ops_system_logs 分区(DROP 保留)+ 可复用 pgpartition(WAVE 1)

### DIFF
--- a/backend/internal/pkg/pgpartition/partition.go
+++ b/backend/internal/pkg/pgpartition/partition.go
@@ -56,8 +56,7 @@ func IsPartitioned(ctx context.Context, db DB, table string) (bool, error) {
 // It never creates PAST months — those are either covered already or were intentionally
 // dropped by retention, and recreating them would resurrect an empty partition.
 // Idempotent (CREATE ... IF NOT EXISTS + overlap-skip).
-func EnsureMonthly(ctx context.Context, db DB, table, timeCol string, now time.Time, monthsAhead int) error {
-	_ = timeCol // partition key is fixed at conversion; kept for call-site symmetry/clarity
+func EnsureMonthly(ctx context.Context, db DB, table string, now time.Time, monthsAhead int) error {
 	base := monthStartUTC(now)
 	for m := 0; m <= monthsAhead; m++ {
 		start := base.AddDate(0, m, 0)

--- a/backend/internal/pkg/pgpartition/partition.go
+++ b/backend/internal/pkg/pgpartition/partition.go
@@ -1,0 +1,148 @@
+// Package pgpartition provides a small, table-agnostic monthly RANGE-partition
+// retention mechanism: keep N future months provisioned and DROP whole partitions
+// once their data is fully past the retention cutoff. It is the reusable core behind
+// the data-layer partition program (WAVE 1: ops_system_logs; later: ops_error_logs,
+// usage_logs) — replacing bloat-generating chunked DELETE retention with instant
+// DROP PARTITION.
+//
+// It is a leaf package (stdlib + lib/pq only) so both the service and repository
+// layers can use it without an import cycle. All identifiers are passed as trusted
+// constants by callers and quoted with pq.QuoteIdentifier; this package never takes
+// SQL from untrusted input.
+package pgpartition
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+// pgPartitionOverlapCode is the SQLSTATE Postgres raises when a CREATE ... PARTITION
+// OF would overlap an existing partition (e.g. the legacy historical partition still
+// covers the current month right after conversion). It is benign for EnsureMonthly:
+// the month is already covered, so we skip it.
+const pgPartitionOverlapCode = "42P17"
+
+// DB is the minimal executor pgpartition needs; *sql.DB satisfies it.
+type DB interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// IsPartitioned reports whether `table` is a partitioned (parent) table.
+func IsPartitioned(ctx context.Context, db DB, table string) (bool, error) {
+	const q = `
+		SELECT EXISTS(
+			SELECT 1 FROM pg_partitioned_table pt
+			JOIN pg_class c ON c.oid = pt.partrelid
+			WHERE c.relname = $1
+		)`
+	var partitioned bool
+	if err := db.QueryRowContext(ctx, q, table).Scan(&partitioned); err != nil {
+		return false, fmt.Errorf("pgpartition: is-partitioned %s: %w", table, err)
+	}
+	return partitioned, nil
+}
+
+// EnsureMonthly creates monthly RANGE partitions `<table>_YYYYMM` for the current
+// month through `monthsAhead` months in the future, so live inserts always have a
+// home as the calendar rolls forward. Months already covered by an existing partition
+// (e.g. a legacy mega-partition right after conversion) raise 42P17 and are skipped.
+// It never creates PAST months — those are either covered already or were intentionally
+// dropped by retention, and recreating them would resurrect an empty partition.
+// Idempotent (CREATE ... IF NOT EXISTS + overlap-skip).
+func EnsureMonthly(ctx context.Context, db DB, table, timeCol string, now time.Time, monthsAhead int) error {
+	_ = timeCol // partition key is fixed at conversion; kept for call-site symmetry/clarity
+	base := monthStartUTC(now)
+	for m := 0; m <= monthsAhead; m++ {
+		start := base.AddDate(0, m, 0)
+		end := start.AddDate(0, 1, 0)
+		name := fmt.Sprintf("%s_%s", table, start.Format("200601"))
+		q := fmt.Sprintf(
+			"CREATE TABLE IF NOT EXISTS %s PARTITION OF %s FOR VALUES FROM (%s) TO (%s)",
+			pq.QuoteIdentifier(name),
+			pq.QuoteIdentifier(table),
+			pq.QuoteLiteral(start.Format("2006-01-02")),
+			pq.QuoteLiteral(end.Format("2006-01-02")),
+		)
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			if isOverlap(err) {
+				continue // month already covered (e.g. legacy partition) — benign
+			}
+			return fmt.Errorf("pgpartition: ensure %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// DropExpired drops every child partition of `table` whose newest `timeCol` value is
+// strictly before `cutoff` (or which is empty) — i.e. fully past the retention window.
+// It judges by DATA (max(timeCol)), not partition-name parsing, so it correctly handles
+// both monthly partitions and the wide legacy mega-partition created at conversion.
+// Returns the estimated number of rows reclaimed (sum of dropped partitions' reltuples,
+// for heartbeat/observability). Never drops the parent.
+func DropExpired(ctx context.Context, db DB, table, timeCol string, cutoff time.Time) (int64, error) {
+	const listQ = `
+		SELECT c.relname
+		FROM pg_inherits i
+		JOIN pg_class c ON c.oid = i.inhrelid
+		JOIN pg_class p ON p.oid = i.inhparent
+		WHERE p.relname = $1`
+	rows, err := db.QueryContext(ctx, listQ, table)
+	if err != nil {
+		return 0, fmt.Errorf("pgpartition: list partitions of %s: %w", table, err)
+	}
+	var children []string
+	for rows.Next() {
+		var name string
+		if scanErr := rows.Scan(&name); scanErr != nil {
+			_ = rows.Close()
+			return 0, fmt.Errorf("pgpartition: scan partition name: %w", scanErr)
+		}
+		children = append(children, name)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		_ = rows.Close()
+		return 0, fmt.Errorf("pgpartition: iterate partitions: %w", rowsErr)
+	}
+	_ = rows.Close()
+
+	var reclaimed int64
+	for _, name := range children {
+		var maxT sql.NullTime
+		maxQ := fmt.Sprintf("SELECT max(%s) FROM %s", pq.QuoteIdentifier(timeCol), pq.QuoteIdentifier(name))
+		if err := db.QueryRowContext(ctx, maxQ).Scan(&maxT); err != nil {
+			return reclaimed, fmt.Errorf("pgpartition: max(%s) on %s: %w", timeCol, name, err)
+		}
+		if maxT.Valid && !maxT.Time.Before(cutoff) {
+			continue // still has data within the retention window — keep
+		}
+		var est sql.NullInt64
+		_ = db.QueryRowContext(ctx, "SELECT reltuples::bigint FROM pg_class WHERE relname = $1", name).Scan(&est)
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", pq.QuoteIdentifier(name))); err != nil {
+			return reclaimed, fmt.Errorf("pgpartition: drop %s: %w", name, err)
+		}
+		if est.Valid && est.Int64 > 0 {
+			reclaimed += est.Int64
+		}
+	}
+	return reclaimed, nil
+}
+
+func isOverlap(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return string(pqErr.Code) == pgPartitionOverlapCode
+	}
+	return false
+}
+
+func monthStartUTC(t time.Time) time.Time {
+	u := t.UTC()
+	return time.Date(u.Year(), u.Month(), 1, 0, 0, 0, 0, time.UTC)
+}

--- a/backend/internal/pkg/pgpartition/partition_test.go
+++ b/backend/internal/pkg/pgpartition/partition_test.go
@@ -1,0 +1,110 @@
+//go:build unit
+
+package pgpartition
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+// execRecorder is a minimal pgpartition.DB that records ExecContext queries and can be
+// scripted to return an error for the Nth call (e.g. a 42P17 overlap). QueryContext /
+// QueryRowContext are unused by EnsureMonthly and panic if reached.
+type execRecorder struct {
+	queries []string
+	errs    []error // errs[i] returned for the (i+1)th ExecContext call; nil/out-of-range = success
+}
+
+func (r *execRecorder) ExecContext(_ context.Context, query string, _ ...any) (sql.Result, error) {
+	idx := len(r.queries)
+	r.queries = append(r.queries, query)
+	if idx < len(r.errs) && r.errs[idx] != nil {
+		return nil, r.errs[idx]
+	}
+	return driverResult{}, nil
+}
+
+func (r *execRecorder) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	panic("QueryContext not expected in EnsureMonthly")
+}
+func (r *execRecorder) QueryRowContext(context.Context, string, ...any) *sql.Row {
+	panic("QueryRowContext not expected in EnsureMonthly")
+}
+
+type driverResult struct{}
+
+func (driverResult) LastInsertId() (int64, error) { return 0, nil }
+func (driverResult) RowsAffected() (int64, error) { return 0, nil }
+
+func TestMonthStartUTC(t *testing.T) {
+	in := time.Date(2026, 6, 20, 13, 45, 7, 0, time.FixedZone("x", 8*3600))
+	got := monthStartUTC(in)
+	want := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("monthStartUTC=%s want %s", got, want)
+	}
+}
+
+func TestIsOverlap(t *testing.T) {
+	if !isOverlap(&pq.Error{Code: pq.ErrorCode(pgPartitionOverlapCode)}) {
+		t.Fatal("42P17 must be detected as overlap")
+	}
+	if isOverlap(&pq.Error{Code: "23505"}) {
+		t.Fatal("non-overlap pq error must not be treated as overlap")
+	}
+	if isOverlap(errors.New("plain error")) {
+		t.Fatal("non-pq error must not be treated as overlap")
+	}
+}
+
+func TestEnsureMonthly_CreatesCurrentThroughAhead(t *testing.T) {
+	rec := &execRecorder{}
+	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	if err := EnsureMonthly(context.Background(), rec, "ops_system_logs", "created_at", now, 2); err != nil {
+		t.Fatalf("EnsureMonthly: %v", err)
+	}
+	// monthsAhead=2 -> current + 2 future = 3 CREATE statements, June/July/Aug 2026.
+	if len(rec.queries) != 3 {
+		t.Fatalf("expected 3 CREATE statements, got %d: %v", len(rec.queries), rec.queries)
+	}
+	wantNames := []string{"ops_system_logs_202606", "ops_system_logs_202607", "ops_system_logs_202608"}
+	wantBounds := [][2]string{{"2026-06-01", "2026-07-01"}, {"2026-07-01", "2026-08-01"}, {"2026-08-01", "2026-09-01"}}
+	for i, q := range rec.queries {
+		if !strings.Contains(q, wantNames[i]) {
+			t.Errorf("statement %d missing partition name %s: %s", i, wantNames[i], q)
+		}
+		if !strings.Contains(q, "PARTITION OF "+pq.QuoteIdentifier("ops_system_logs")) {
+			t.Errorf("statement %d not a PARTITION OF ops_system_logs: %s", i, q)
+		}
+		if !strings.Contains(q, wantBounds[i][0]) || !strings.Contains(q, wantBounds[i][1]) {
+			t.Errorf("statement %d bounds want %v: %s", i, wantBounds[i], q)
+		}
+	}
+}
+
+func TestEnsureMonthly_SkipsOverlapContinues(t *testing.T) {
+	// First CREATE (current month) overlaps the legacy partition -> 42P17; must be
+	// skipped and the remaining future months still created.
+	rec := &execRecorder{errs: []error{&pq.Error{Code: pq.ErrorCode(pgPartitionOverlapCode)}}}
+	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	if err := EnsureMonthly(context.Background(), rec, "ops_system_logs", "created_at", now, 2); err != nil {
+		t.Fatalf("overlap on month 0 must be benign, got: %v", err)
+	}
+	if len(rec.queries) != 3 {
+		t.Fatalf("must still attempt all 3 months, got %d", len(rec.queries))
+	}
+}
+
+func TestEnsureMonthly_RealErrorPropagates(t *testing.T) {
+	rec := &execRecorder{errs: []error{&pq.Error{Code: "53100"}}} // disk full -> must fail
+	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	if err := EnsureMonthly(context.Background(), rec, "ops_system_logs", "created_at", now, 2); err == nil {
+		t.Fatal("a non-overlap error must propagate")
+	}
+}

--- a/backend/internal/pkg/pgpartition/partition_test.go
+++ b/backend/internal/pkg/pgpartition/partition_test.go
@@ -66,7 +66,7 @@ func TestIsOverlap(t *testing.T) {
 func TestEnsureMonthly_CreatesCurrentThroughAhead(t *testing.T) {
 	rec := &execRecorder{}
 	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
-	if err := EnsureMonthly(context.Background(), rec, "ops_system_logs", "created_at", now, 2); err != nil {
+	if err := EnsureMonthly(context.Background(), rec, "ops_system_logs", now, 2); err != nil {
 		t.Fatalf("EnsureMonthly: %v", err)
 	}
 	// monthsAhead=2 -> current + 2 future = 3 CREATE statements, June/July/Aug 2026.
@@ -93,7 +93,7 @@ func TestEnsureMonthly_SkipsOverlapContinues(t *testing.T) {
 	// skipped and the remaining future months still created.
 	rec := &execRecorder{errs: []error{&pq.Error{Code: pq.ErrorCode(pgPartitionOverlapCode)}}}
 	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
-	if err := EnsureMonthly(context.Background(), rec, "ops_system_logs", "created_at", now, 2); err != nil {
+	if err := EnsureMonthly(context.Background(), rec, "ops_system_logs", now, 2); err != nil {
 		t.Fatalf("overlap on month 0 must be benign, got: %v", err)
 	}
 	if len(rec.queries) != 3 {
@@ -104,7 +104,7 @@ func TestEnsureMonthly_SkipsOverlapContinues(t *testing.T) {
 func TestEnsureMonthly_RealErrorPropagates(t *testing.T) {
 	rec := &execRecorder{errs: []error{&pq.Error{Code: "53100"}}} // disk full -> must fail
 	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
-	if err := EnsureMonthly(context.Background(), rec, "ops_system_logs", "created_at", now, 2); err == nil {
+	if err := EnsureMonthly(context.Background(), rec, "ops_system_logs", now, 2); err == nil {
 		t.Fatal("a non-overlap error must propagate")
 	}
 }

--- a/backend/internal/repository/pgpartition_integration_test.go
+++ b/backend/internal/repository/pgpartition_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/pgpartition"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPgPartition_OpsSystemLogsConvertedByMigration proves tk_035 converts
+// ops_system_logs to a partitioned table when applied in the REAL migration sequence
+// (054 creates it plain; tk_035 converts it). The harness applies all migrations in
+// TestMain, so a partitioned ops_system_logs here means the conversion DDL is valid
+// end-to-end against a real Postgres.
+func TestPgPartition_OpsSystemLogsConvertedByMigration(t *testing.T) {
+	ctx := context.Background()
+	ok, err := pgpartition.IsPartitioned(ctx, integrationDB, "ops_system_logs")
+	require.NoError(t, err)
+	require.True(t, ok, "tk_035 must convert ops_system_logs to a partitioned table")
+
+	// A row inserted without id (mirrors BatchInsertSystemLogs COPY) must route into a
+	// partition and get an auto id from the inherited sequence.
+	var id int64
+	require.NoError(t, integrationDB.QueryRowContext(ctx,
+		`INSERT INTO ops_system_logs(created_at, level, message) VALUES (now(), 'info', 'pgpart-itest') RETURNING id`,
+	).Scan(&id))
+	require.Positive(t, id)
+	_, err = integrationDB.ExecContext(ctx, `DELETE FROM ops_system_logs WHERE message = 'pgpart-itest'`)
+	require.NoError(t, err)
+}
+
+// TestPgPartition_EnsureMonthlySkipsLegacyOverlap mirrors the post-conversion state: a
+// wide legacy partition covers everything up to next month, so EnsureMonthly's current
+// month overlaps it (42P17) and must be skipped while future months are still created.
+func TestPgPartition_EnsureMonthlySkipsLegacyOverlap(t *testing.T) {
+	ctx := context.Background()
+	tbl := "pgpart_itest_ensure"
+	q := pq.QuoteIdentifier(tbl)
+	_, _ = integrationDB.ExecContext(ctx, "DROP TABLE IF EXISTS "+q)
+	t.Cleanup(func() { _, _ = integrationDB.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+q) })
+
+	now := time.Now().UTC()
+	thisMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	nextMonth := thisMonth.AddDate(0, 1, 0)
+	_, err := integrationDB.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id BIGSERIAL, created_at TIMESTAMPTZ NOT NULL) PARTITION BY RANGE (created_at)", q))
+	require.NoError(t, err)
+	// legacy partition covering [MINVALUE, nextMonth) -> includes the current month.
+	_, err = integrationDB.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s PARTITION OF %s FOR VALUES FROM (MINVALUE) TO (%s)",
+		pq.QuoteIdentifier(tbl+"_legacy"), q, pq.QuoteLiteral(nextMonth.Format("2006-01-02"))))
+	require.NoError(t, err)
+
+	// EnsureMonthly: current month overlaps legacy (skipped); next + next+1 created.
+	require.NoError(t, pgpartition.EnsureMonthly(ctx, integrationDB, tbl, "created_at", now, 2))
+
+	var parts int
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT count(*) FROM pg_inherits i JOIN pg_class c ON c.oid=i.inhrelid
+		JOIN pg_class p ON p.oid=i.inhparent WHERE p.relname=$1`, tbl).Scan(&parts))
+	require.Equal(t, 3, parts, "legacy + 2 future months (current month skipped as overlap)")
+}
+
+// TestPgPartition_DropExpiredByData proves DropExpired drops a partition whose newest
+// row is past the cutoff and keeps one with recent data — judged by data, not by name.
+func TestPgPartition_DropExpiredByData(t *testing.T) {
+	ctx := context.Background()
+	tbl := "pgpart_itest_drop"
+	q := pq.QuoteIdentifier(tbl)
+	_, _ = integrationDB.ExecContext(ctx, "DROP TABLE IF EXISTS "+q)
+	t.Cleanup(func() { _, _ = integrationDB.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+q) })
+
+	now := time.Now().UTC()
+	thisMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	nextMonth := thisMonth.AddDate(0, 1, 0)
+	oldStart := thisMonth.AddDate(0, -6, 0)
+	oldEnd := oldStart.AddDate(0, 1, 0)
+
+	_, err := integrationDB.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id BIGSERIAL, created_at TIMESTAMPTZ NOT NULL) PARTITION BY RANGE (created_at)", q))
+	require.NoError(t, err)
+	oldName := tbl + "_old"
+	curName := tbl + "_cur"
+	_, err = integrationDB.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s PARTITION OF %s FOR VALUES FROM (%s) TO (%s)",
+		pq.QuoteIdentifier(oldName), q, pq.QuoteLiteral(oldStart.Format("2006-01-02")), pq.QuoteLiteral(oldEnd.Format("2006-01-02"))))
+	require.NoError(t, err)
+	_, err = integrationDB.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s PARTITION OF %s FOR VALUES FROM (%s) TO (%s)",
+		pq.QuoteIdentifier(curName), q, pq.QuoteLiteral(thisMonth.Format("2006-01-02")), pq.QuoteLiteral(nextMonth.Format("2006-01-02"))))
+	require.NoError(t, err)
+	_, err = integrationDB.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s(created_at) VALUES ($1)", q), oldStart.AddDate(0, 0, 5))
+	require.NoError(t, err)
+	_, err = integrationDB.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s(created_at) VALUES (now())", q))
+	require.NoError(t, err)
+
+	// cutoff = now - 90d: the old partition's data is fully past it -> drop; current kept.
+	cutoff := now.AddDate(0, 0, -90)
+	_, err = pgpartition.DropExpired(ctx, integrationDB, tbl, "created_at", cutoff)
+	require.NoError(t, err)
+
+	var hasOld, hasCur bool
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pg_class WHERE relname=$1)`, oldName).Scan(&hasOld))
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pg_class WHERE relname=$1)`, curName).Scan(&hasCur))
+	require.False(t, hasOld, "expired partition (all data < cutoff) must be dropped")
+	require.True(t, hasCur, "partition with recent data must be kept")
+}

--- a/backend/internal/repository/pgpartition_integration_test.go
+++ b/backend/internal/repository/pgpartition_integration_test.go
@@ -24,6 +24,19 @@ func TestPgPartition_OpsSystemLogsConvertedByMigration(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok, "tk_035 must convert ops_system_logs to a partitioned table")
 
+	// Regression (review R-001): the id sequence must be OWNED BY the parent, not the
+	// legacy partition. Otherwise retention dropping the legacy partition either fails
+	// (plain DROP refused) or, with CASCADE, drops the sequence and breaks id generation.
+	// (tk_035 step 2a reassigns ownership.)
+	var seqOwner string
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT t.relname FROM pg_depend d
+		JOIN pg_class s ON s.oid = d.objid AND s.relname = 'ops_system_logs_id_seq'
+		JOIN pg_class t ON t.oid = d.refobjid
+		WHERE d.deptype = 'a'`).Scan(&seqOwner))
+	require.Equal(t, "ops_system_logs", seqOwner,
+		"id sequence must be owned by the parent so the legacy partition drops cleanly")
+
 	// A row inserted without id (mirrors BatchInsertSystemLogs COPY) must route into a
 	// partition and get an auto id from the inherited sequence.
 	var id int64
@@ -58,7 +71,7 @@ func TestPgPartition_EnsureMonthlySkipsLegacyOverlap(t *testing.T) {
 	require.NoError(t, err)
 
 	// EnsureMonthly: current month overlaps legacy (skipped); next + next+1 created.
-	require.NoError(t, pgpartition.EnsureMonthly(ctx, integrationDB, tbl, "created_at", now, 2))
+	require.NoError(t, pgpartition.EnsureMonthly(ctx, integrationDB, tbl, now, 2))
 
 	var parts int
 	require.NoError(t, integrationDB.QueryRowContext(ctx, `

--- a/backend/internal/service/ops_cleanup_executor.go
+++ b/backend/internal/service/ops_cleanup_executor.go
@@ -90,7 +90,7 @@ func opsCleanupRunOne(
 		return 0, err
 	}
 	if partitioned {
-		if err := pgpartition.EnsureMonthly(ctx, db, table, timeCol, time.Now().UTC(), opsPartitionMonthsAhead); err != nil {
+		if err := pgpartition.EnsureMonthly(ctx, db, table, time.Now().UTC(), opsPartitionMonthsAhead); err != nil {
 			return 0, err
 		}
 		return pgpartition.DropExpired(ctx, db, table, timeCol, cutoff)

--- a/backend/internal/service/ops_cleanup_executor.go
+++ b/backend/internal/service/ops_cleanup_executor.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/pgpartition"
 )
 
 const (
@@ -14,6 +16,11 @@ const (
 	opsCleanupCronStopTimeout  = 3 * time.Second
 	opsCleanupRunTimeout       = 30 * time.Minute
 	opsCleanupHeartbeatTimeout = 2 * time.Second
+	// opsPartitionMonthsAhead is how many future monthly partitions to keep
+	// provisioned for partitioned ops tables (e.g. ops_system_logs after tk_035),
+	// so live inserts always have a home as the calendar rolls forward. The daily
+	// cleanup tick re-ensures these; the conversion migration seeds the first two.
+	opsPartitionMonthsAhead = 3
 )
 
 type opsCleanupTarget struct {
@@ -72,6 +79,21 @@ func opsCleanupRunOne(
 ) (int64, error) {
 	if truncate {
 		return truncateOpsTable(ctx, db, table)
+	}
+	// Partitioned ops tables (e.g. ops_system_logs once tk_035 has converted it):
+	// retention is instant DROP PARTITION + keeping future months provisioned, not a
+	// bloat-generating chunked DELETE. The branch is keyed on the live partition state
+	// (not a hardcoded table list), so ops_error_logs / usage_logs auto-adopt it when
+	// their own conversion lands. Pre-conversion (plain table) falls through to DELETE.
+	partitioned, err := pgpartition.IsPartitioned(ctx, db, table)
+	if err != nil {
+		return 0, err
+	}
+	if partitioned {
+		if err := pgpartition.EnsureMonthly(ctx, db, table, timeCol, time.Now().UTC(), opsPartitionMonthsAhead); err != nil {
+			return 0, err
+		}
+		return pgpartition.DropExpired(ctx, db, table, timeCol, cutoff)
 	}
 	return deleteOldRowsByID(ctx, db, table, timeCol, cutoff, batchSize, castDate)
 }

--- a/backend/internal/service/ops_cleanup_service_test.go
+++ b/backend/internal/service/ops_cleanup_service_test.go
@@ -26,6 +26,13 @@ func (a cutoffDaysArg) Match(v driver.Value) bool {
 
 func expectCleanupTable(t *testing.T, mock sqlmock.Sqlmock, table string, cutoffDays int, deleted int64) {
 	t.Helper()
+	// opsCleanupRunOne first checks whether the table is partitioned; a plain table
+	// (false) falls through to the chunked DELETE below. (A partitioned table would
+	// instead ensure future partitions + DROP expired ones — covered by the
+	// pgpartition integration tests.)
+	mock.ExpectQuery("pg_partitioned_table").
+		WithArgs(table).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 	mock.ExpectExec(table).
 		WithArgs(cutoffDaysArg{days: cutoffDays}, 5000).
 		WillReturnResult(sqlmock.NewResult(0, deleted))

--- a/backend/migrations/tk_035_partition_ops_system_logs.sql
+++ b/backend/migrations/tk_035_partition_ops_system_logs.sql
@@ -1,0 +1,106 @@
+-- tk_035_partition_ops_system_logs.sql
+-- Convert ops_system_logs (plain table, BIGSERIAL id, created_at NOT NULL) to
+-- monthly RANGE partitioning by created_at, so retention becomes instant DROP
+-- PARTITION instead of the chunked ctid/id DELETE (bloat + autovacuum debt). This
+-- is WAVE 1 of the data-layer partition program (the cleanest topology: no FK in/out,
+-- no non-time unique index, no ON CONFLICT(id), append-only via COPY).
+--
+-- NO PRIMARY KEY on the partitioned parent: ops_system_logs has nothing referencing
+-- its id, no upsert on id, and every read uses the (created_at, id) composite index —
+-- so id stays a sequence-backed auto-increment column WITHOUT a uniqueness constraint.
+-- (A partitioned PK would be forced to include created_at and rebuild a multi-GB index;
+-- there is no functional need for it here.)
+--
+-- Technique (attach-legacy, no data copy): rename the live table to *_legacy, build a
+-- partitioned parent inheriting the id sequence default, recreate the secondary indexes
+-- on the parent, ATTACH the legacy table as the historical partition [MINVALUE, this
+-- month), then create going-forward monthly partitions. Postgres attaches the legacy's
+-- existing matching indexes in place (no rebuild). Idempotent + transactional (atomic):
+-- re-runs are no-ops once partitioned.
+--
+-- Runs at startup with no concurrent writes (app not yet serving). The going-forward
+-- monthly partitions are then maintained by the runtime partition-retention mechanism
+-- (see backend/internal/repository/partition_retention*.go), and retention DROPs old
+-- monthly partitions instead of DELETE.
+
+DO $$
+DECLARE
+  -- Legacy holds ALL existing rows (history + the current partial month), so its upper
+  -- bound is next_month. Going-forward monthly partitions begin at next_month; new
+  -- inserts during the current month route into the legacy partition until then.
+  next_month  date := (date_trunc('month', now() AT TIME ZONE 'UTC') + interval '1 month')::date;
+  after_next  date := (date_trunc('month', now() AT TIME ZONE 'UTC') + interval '2 month')::date;
+  after_2     date := (date_trunc('month', now() AT TIME ZONE 'UTC') + interval '3 month')::date;
+  idx record;
+BEGIN
+  -- Idempotent: already partitioned -> nothing to do.
+  IF EXISTS (
+    SELECT 1 FROM pg_partitioned_table pt
+    JOIN pg_class c ON c.oid = pt.partrelid
+    WHERE c.relname = 'ops_system_logs'
+  ) THEN
+    RETURN;
+  END IF;
+
+  -- Only convert an existing plain table. (Fresh DBs may already create it partitioned
+  -- via a future path; guard against acting on a missing table.)
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class WHERE relname = 'ops_system_logs' AND relkind = 'r'
+  ) THEN
+    RETURN;
+  END IF;
+
+  -- 1. Rename live table to legacy; drop its PK(id) (not needed) and free the canonical
+  --    index names so the partitioned parent can own them.
+  ALTER TABLE ops_system_logs RENAME TO ops_system_logs_legacy;
+  ALTER TABLE ops_system_logs_legacy DROP CONSTRAINT IF EXISTS ops_system_logs_pkey;
+  FOR idx IN
+    SELECT indexname FROM pg_indexes
+    WHERE schemaname = 'public' AND tablename = 'ops_system_logs_legacy'
+      AND indexname LIKE 'idx_ops_system_logs_%'
+      AND indexname NOT LIKE '%\_legacy'
+  LOOP
+    EXECUTE format('ALTER INDEX %I RENAME TO %I', idx.indexname, idx.indexname || '_legacy');
+  END LOOP;
+
+  -- 2. Partitioned parent, inheriting the id sequence DEFAULT (so COPY inserts keep
+  --    auto-assigning ids from the shared sequence) and storage params.
+  CREATE TABLE ops_system_logs (
+    LIKE ops_system_logs_legacy INCLUDING DEFAULTS INCLUDING STORAGE
+  ) PARTITION BY RANGE (created_at);
+
+  -- 3. Canonical secondary indexes on the parent (partitioned indexes). When the legacy
+  --    partition is attached below, Postgres matches its existing *_legacy indexes by
+  --    definition and attaches them in place (no rebuild).
+  CREATE INDEX idx_ops_system_logs_created_at_id ON ops_system_logs (created_at DESC, id DESC);
+  CREATE INDEX idx_ops_system_logs_level_created_at ON ops_system_logs (level, created_at DESC);
+  CREATE INDEX idx_ops_system_logs_component_created_at ON ops_system_logs (component, created_at DESC);
+  CREATE INDEX idx_ops_system_logs_request_id ON ops_system_logs (request_id);
+  CREATE INDEX idx_ops_system_logs_client_request_id ON ops_system_logs (client_request_id);
+  CREATE INDEX idx_ops_system_logs_user_id_created_at ON ops_system_logs (user_id, created_at DESC);
+  CREATE INDEX idx_ops_system_logs_account_id_created_at ON ops_system_logs (account_id, created_at DESC);
+  CREATE INDEX idx_ops_system_logs_platform_model_created_at ON ops_system_logs (platform, model, created_at DESC);
+  CREATE INDEX idx_ops_system_logs_message_search ON ops_system_logs USING GIN (to_tsvector('simple', COALESCE(message, '')));
+
+  -- 4. Attach legacy as the historical partition [MINVALUE, next_month): it holds ALL
+  --    existing rows including the current partial month. ATTACH scans legacy once to
+  --    prove every row is < next_month (always true for existing data); at startup with
+  --    no traffic this is a one-time cost. Retention later drops this partition (by its
+  --    upper bound) once next_month is past the cutoff — see partition_retention*.go.
+  EXECUTE format(
+    'ALTER TABLE ops_system_logs ATTACH PARTITION ops_system_logs_legacy FOR VALUES FROM (MINVALUE) TO (%L)',
+    next_month
+  );
+
+  -- 5. Going-forward monthly partitions (next month + the one after), so live inserts
+  --    have a home when the calendar rolls over; the runtime mechanism creates further
+  --    months on its tick. The current partial month stays in the legacy partition.
+  EXECUTE format(
+    'CREATE TABLE IF NOT EXISTS ops_system_logs_%s PARTITION OF ops_system_logs FOR VALUES FROM (%L) TO (%L)',
+    to_char(next_month, 'YYYYMM'), next_month, after_next
+  );
+  EXECUTE format(
+    'CREATE TABLE IF NOT EXISTS ops_system_logs_%s PARTITION OF ops_system_logs FOR VALUES FROM (%L) TO (%L)',
+    to_char(after_next, 'YYYYMM'), after_next, after_2
+  );
+END $$;

--- a/backend/migrations/tk_035_partition_ops_system_logs.sql
+++ b/backend/migrations/tk_035_partition_ops_system_logs.sql
@@ -69,6 +69,15 @@ BEGIN
     LIKE ops_system_logs_legacy INCLUDING DEFAULTS INCLUDING STORAGE
   ) PARTITION BY RANGE (created_at);
 
+  -- 2a. The BIGSERIAL id sequence is still OWNED BY the legacy partition's id column
+  --     (ownership does not follow a table RENAME). The parent's id default references
+  --     it by name, which works — but the OWNED BY dependency means that when retention
+  --     later DROPs the legacy partition, a plain DROP is refused (needs CASCADE) and a
+  --     CASCADE would drop the sequence and break id generation. Reassign ownership to
+  --     the new parent so the legacy partition can be dropped cleanly and the sequence
+  --     survives. (Sequence name is the BIGSERIAL default for ops_system_logs.id.)
+  ALTER SEQUENCE IF EXISTS ops_system_logs_id_seq OWNED BY ops_system_logs.id;
+
   -- 3. Canonical secondary indexes on the parent (partitioned indexes). When the legacy
   --    partition is attached below, Postgres matches its existing *_legacy indexes by
   --    definition and attaches them in place (no rebuild).


### PR DESCRIPTION
## 这是什么

数据层分区计划的 **WAVE 1**。把 **`ops_system_logs`(prod 最大表,4.3GB,append-only)** 转成按月 RANGE 分区,让保留从"一行行抠的 chunked DELETE(膨胀 + autovacuum 债)"变成**整本瞬时 DROP PARTITION**。备份分级(#886)已把它移出 dump;**本 PR 换的是保留机制**。

> 选 `ops_system_logs` 当样板:拓扑最干净——无 FK 指入/指出、无 id 唯一依赖、无 `ON CONFLICT(id)`、COPY append-only。

## 迁移 `tk_035`(事务、幂等、attach-legacy 零拷贝)

- **分区父表无 PK**:`ops_system_logs` 没东西引用它的 id、无 id 唯一依赖、读走 `(created_at,id)` 复合索引 → id 保持序列自增列,**绕开"分区键进 PK + 重建多 G 索引"**。
- rename 活表→`*_legacy` → 建分区父表(继承 id 序列默认值)→ 在父表重建 9 个索引 → **ATTACH legacy 为历史分区 `[MINVALUE, next_month)`**(Postgres 把 legacy 已有的匹配索引**就地 attach,零重建**)→ 建向前的月分区。
- **真 PG18 实证**:数据无损、新插入路由+取 id、索引就地 attach 非重建、created_at 查询分区裁剪、整本 DROP、重跑幂等。

## 可复用机制(新叶子包 `internal/pkg/pgpartition`)

stdlib + lib/pq、无 import 环。`IsPartitioned` / `EnsureMonthly`(42P17 overlap-skip、保留 N 个未来月)/ `DropExpired`(按**数据**——分区最新行是否过 cutoff——删,而非按名解析,故统一处理 legacy 大分区)。接进 `opsCleanupRunOne`:分区表走 ensure+DROP,plain 表保持 DELETE(所以 ops_error_logs/usage_logs 各自转换后**自动**采用)。

## 测试

- `pgpartition` 单测:月份算术、overlap-skip、真实错误传播。
- repository 集成测(真 PG):**tk_035 在真实迁移序列中成功应用**(harness 在空 ops_system_logs 上跑全部迁移→分区表)+ ensure 跳过 legacy 重叠 + drop-by-data。
- ops cleanup mock 测已更新(加分区预检期望)。
- `go build/vet ./...`、service+repository+pgpartition 单测、`scripts/preflight.sh` 全过。

## 已知限制(样板)

未来分区创建搭在**每日 ops-cleanup tick** 上(迁移先种 2 个月)。若该 tick 被停 >~3 个月(参考 #610),新月份插入会失败——由 cleanup heartbeat 监控;后续可加 default 分区兜底 / 独立 ensure ticker。

## 上线

**prod 执行是单独获批的低峰窗口**(迁移在启动时跑、独占、无并发写);本 PR 只让其 code-ready。

## Markers

- **no-web-impact: true** —— 纯后端(Go + SQL 迁移)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Reviewer:TK 自有 PR → **Squash and merge**。未经授权不合并。高风险迁移,建议细审 `tk_035` + `pgpartition`。_