### PR TITLE
feat(pricing): onboard 豆包 seedream 生图到账号 7

### DIFF
--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -230,6 +230,18 @@
       "price_key": "doubao-seedance-2-0-fast-260128",
       "display": false,
       "notes": "volcengine account 7. Seedance 2.0-fast VIDEO model, mapped by tk_033. Priced in overlay (output_cost_per_second, VolcEngine Ark official 720p max-output tier)."
+    },
+    "newapi/doubao-seedream-4-0-250828": {
+      "platform": "newapi",
+      "model_id": "doubao-seedream-4-0-250828",
+      "served_on": [
+        "7"
+      ],
+      "channel_type": 45,
+      "price_source": "overlay",
+      "price_key": "doubao-seedream-4-0-250828",
+      "display": false,
+      "notes": "volcengine account 7 (VolcEngine Ark, channel_type=45). Seedream 4.0 IMAGE model (/v1/images/generations), mapped by tk_035 (identity whitelist merge). Priced in overlay (output_cost_per_image, VolcEngine Ark official 0.2 CNY/image / 6.7). Added per the vol-test investigation 2026-06-20: account 7's model_mapping was a chat+seedance-video whitelist with NO seedream image id, so a universal-key /v1/images/generations request for doubao-seedream-4-0-250828 emptied the single-account pool -> 429 'No available accounts' (ops_error_logs phase=routing). ONLY the prefixed id is served+mapped: the no-prefix overlay alias seedream-4-0-250828 returned HTTP 404 on a direct Ark data-plane activation probe (2026-06-20) and is intentionally NOT a manifest entry / not model_mapped (priced only for billing-key parity)."
     }
   }
 }

--- a/backend/migrations/tk_035_seedream_image_model_mapping.sql
+++ b/backend/migrations/tk_035_seedream_image_model_mapping.sql
@@ -1,0 +1,74 @@
+-- Migration: tk_035_seedream_image_model_mapping
+--
+-- Advertise the doubao-seedream IMAGE model on the volcengine account (id=7),
+-- so the volcengine/newapi compat pool can serve synchronous image generation
+-- (/v1/images/generations) through the new-api volcengine adaptor:
+--   - account 7 "volcengine" (VolcEngine Ark, channel_type=45):
+--       doubao-seedream-4-0-250828
+--
+-- Why (prod 2026-06-20, vol-test investigation): a universal-key request for
+-- POST /v1/images/generations model "doubao-seedream-4-0-250828" returned
+-- HTTP 429 "No available accounts" (ops_error_logs phase=routing). Root cause:
+-- account 7's credentials.model_mapping is a strict identity WHITELIST that
+-- listed only chat/LLM ids (glm-4-7, doubao-seed-* chat, doubao-1-5-*) and the
+-- four seedance VIDEO ids (tk_033) — but NO seedream IMAGE id. A non-empty
+-- model_mapping is an allowlist (service.Account.IsModelSupported): the
+-- universal-key resolver (which since #887 converges to the set of models a
+-- group actually serves) + the OpenAI-compat scheduler candidate filter
+-- (openai_account_scheduler.go isAccountRequestCompatible -> IsModelSupported)
+-- both dropped account 7 for the seedream request, emptying the single-account
+-- pool and surfacing as a 429 empty-pool error. The account is otherwise a
+-- correctly-configured VolcEngine Ark image channel (platform=newapi,
+-- channel_type=45, base_url=https://ark.cn-beijing.volces.com, api_key set);
+-- a direct Ark data-plane activation probe confirmed the api_key serves
+-- doubao-seedream-4-0-250828 (HTTP 200).
+--
+-- ONLY the prefixed id is mapped. The new-api volcengine ModelList
+-- (relay/channel/volcengine/constants.go) and tk_pricing_overlay.json both
+-- carry a no-prefix alias "seedream-4-0-250828", but the Ark data-plane
+-- activation probe returned HTTP 404 (unsupported) for the no-prefix form on
+-- account 7's upstream. Advertising a 404 id in the allowlist would route real
+-- requests to an upstream that rejects them, so the alias is deliberately NOT
+-- added to the model_mapping (it remains overlay-priced purely for billing-key
+-- parity in case the relay ever rewrites to it; it is not a served name here).
+--
+-- Pricing already shipped in backend/internal/service/tk_pricing_overlay.json
+-- (doubao-seedream-4-0-250828 carries output_cost_per_image from the VolcEngine
+-- Ark official model-pricing page, 0.2 CNY/image / 6.7 = 0.0298507 USD/image).
+-- The overlay is compile-embedded, so the whitelist add lands on an image that
+-- already prices the id — no $0 / unpriced-400 window.
+--
+-- Merge (jsonb ||) preserves the existing chat + seedance identity-whitelist
+-- entries; only the one new identity key is added, so everything the account
+-- already serves keeps working. Raw-SQL account mutation bypasses the Ent
+-- snapshot-refresh hooks, so enqueue a scheduler_outbox account_changed event
+-- (pattern: tk_022 / tk_024 / tk_027 / tk_029 / tk_032 / tk_033) so the running
+-- scheduler sees the change without a restart.
+--
+-- Idempotent + cross-deployment safe: guarded by (id, name, platform='newapi',
+-- channel_type=45) so re-running merges the same key (no-op) and a bare id
+-- colliding with an unrelated account in another DB cannot match.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+-- volcengine account 7: add the priced doubao-seedream IMAGE model.
+WITH upd_volcengine AS (
+    UPDATE accounts
+    SET credentials = jsonb_set(
+            credentials,
+            '{model_mapping}',
+            COALESCE(credentials -> 'model_mapping', '{}'::jsonb) || '{
+                "doubao-seedream-4-0-250828": "doubao-seedream-4-0-250828"
+            }'::jsonb
+        ),
+        updated_at = NOW()
+    WHERE id = 7
+      AND name = 'volcengine'
+      AND platform = 'newapi'
+      AND channel_type = 45
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd_volcengine;


### PR DESCRIPTION
## 问题

经 universal key 打 `POST /v1/images/generations` model `doubao-seedream-4-0-250828` → **429 空池**(`ops_error_logs` phase=routing, "No available accounts")。

根因:账号 7(volcengine, newapi, channel_type=45, group gid=5)的 `credentials.model_mapping` 是 chat+seedance-video 的严格 identity 白名单,**没有任何 seedream 生图 id**。非空 model_mapping 是 allowlist(`IsModelSupported`),universal resolver(#887 后收敛到「组真正服务的模型集」)+ OpenAI-compat scheduler candidate filter 都把账号 7 从单账号池里 drop 掉 → 空池 429。`doubao-seedream-4-0-250828` **已在 `tk_pricing_overlay.json` 定价**(`output_cost_per_image`=0.0298507,0.2 CNY/image÷6.7,VolcEngine Ark 官方页),new-api ch45 volcengine 适配器也支持生图。纯 provisioning 缺口,同 grok 账号 65 范式。

## 改动(按 tokenkey-onboard-model skill 投影)

- `tk_served_models.json`:新增 `newapi/doubao-seedream-4-0-250828` 条目(served_on=["7"]、channel_type=45、price_source=overlay、display=false)。纯插入(12 行新增,0 删除)。
- `tk_035_seedream_image_model_mapping.sql`:`jsonb ||` 把前缀 id 合进账号 7 model_mapping + `scheduler_outbox account_changed` 热更(模板 tk_033;按 `(id=7, name, platform='newapi', channel_type=45)` 守卫,幂等跨部署安全)。
- overlay 已有非零价 → 不动。

## Activation truth(prod 只读探测,2026-06-20)

直接 VolcEngine Ark 数据面 activation probe(prod SSM,账号 7 的 api_key):
- `doubao-seedream-4-0-250828` → **HTTP 200 servable**
- `seedream-4-0-250828`(overlay 里的无前缀别名)→ **HTTP 404 unsupported**

故**只**映前缀 id。无前缀别名上游 404,advertising 它会把真实请求路由到拒绝的上游,因此**故意不**写进 model_mapping(它在 overlay 仅作 billing-key parity 占位,非 served 名)。账号 7 当前 model_mapping 已含全部 4 个 seedance video id(tk_033)但无 seedream image。

## 验证

- `catalog-serving-drift.py` 绿(19 条 manifest 三方一致;新条目 A3 由 tk_035 的 `id=7`+`"doubao-seedream-4-0-250828"` file-level 共现满足)
- `scripts/preflight.sh` PASS(pre-commit 跑过完整版,含 pricing overlay / catalog-serving-drift / SQL coverage / sentinel registry)
- `go build ./...` 通过、`go test -tags=unit ./internal/service/...` 通过
- upstream-override-marker:无 upstream-shaped 路径(tk_*.sql + manifest JSON 均 TK-only)→ 无需 marker;registry-update-gate 绿(manifest 改动为纯插入)

## 待人执行的 prod 写入

迁移会在下次发版随容器自动应用。如需**零发版立即生效**,在 prod 执行(只动 model_mapping、保留 api_key/base_url,带 scheduler_outbox 热更),即 tk_035 的等价 SQL。详见 PR 描述下方运维说明 / 报告。

## 待发版 livefire

发版/apply 后经 universal key 真打 `POST /v1/images/generations` model `doubao-seedream-4-0-250828` 复测 200,并核对一条 usage_log 按 `output_cost_per_image` 计费。

no-web-impact