### PR TITLE
fix(video): route universal-key video submit by its request model

### DIFF
--- a/backend/internal/server/middleware/universal_routing_tk.go
+++ b/backend/internal/server/middleware/universal_routing_tk.go
@@ -80,7 +80,16 @@ func MaybeResolveUniversal(c *gin.Context, apiKey *service.APIKey, resolver *ser
 
 // peekUniversalModel 取请求模型名（仅作平台偏好提示）。body 类端点读 body 后“原样还原”
 // （连同原始头），让后续 handler 的 body 读取行为字节级不受影响；gemini 取 URL；
-// images/edits 与 video 是 multipart/poll，不读 body（候选平台已足够窄）。
+// images/edits 是 multipart（不读 body）。
+//
+// video：POST 提交（submit）是 JSON body，必须读出模型名 —— 候选平台 [openai, newapi]
+// 跨多个后端组（如 google-vertex ch41 / volcengine ch45 才支持视频，而 deepseek ch43 /
+// Qwen ch17 不支持）。不取模型则 resolver 退回“按 sort_order/id 确定性挑组”，会把视频
+// 请求落到一个非视频渠道的组，selected account 的 channel_type 在 handler 视频门
+// （engine.IsVideoSupportedForAccount）处被拒，表现为“全局视频 400”。读模型后既能经
+// 「组已服务模型集」收敛到对的组、又能让平台 hint（veo→gemini、seedance→newapi）偏向。
+// GET 轮询（poll）无 body、无模型：poll 用 VideoTaskCache 里 submit 时固定的上游路由，
+// 不重新选号，故 model="" 安全（任一 openai-compat 组即满足路由层的平台门）。
 func peekUniversalModel(c *gin.Context, shape service.UniversalShape) string {
 	switch shape {
 	case service.ShapeGemini:
@@ -88,8 +97,13 @@ func peekUniversalModel(c *gin.Context, shape service.UniversalShape) string {
 			return geminiModelFromAction(ma)
 		}
 		return c.Param("model")
-	case service.ShapeOpenAIImagesEdit, service.ShapeOpenAIVideo:
-		return "" // multipart / 轮询：无需模型
+	case service.ShapeOpenAIImagesEdit:
+		return "" // multipart：无需模型
+	case service.ShapeOpenAIVideo:
+		if c.Request != nil && strings.EqualFold(c.Request.Method, http.MethodPost) {
+			return peekModelFromJSONBody(c) // submit：JSON body 含 model
+		}
+		return "" // poll（GET）：无 body、无需模型
 	default:
 		return peekModelFromJSONBody(c)
 	}

--- a/backend/internal/server/middleware/universal_routing_tk_test.go
+++ b/backend/internal/server/middleware/universal_routing_tk_test.go
@@ -261,6 +261,64 @@ func TestMaybeResolveUniversal_InternalErrorIs500Not403(t *testing.T) {
 	}
 }
 
+// Regression for the "prod 视频全局宕" incident (fix/video-channel-type-selection):
+// a universal key POSTing /v1/video/generations must peek the JSON body's model so the
+// resolver converges onto the video-capable backing group. Before the fix the video
+// shape returned model="" unconditionally, so the resolver fell back to the
+// deterministic sort_order/id pick and could land on a NON-video newapi group
+// (e.g. deepseek ch43 / Qwen ch17), whose selected account then failed the handler's
+// engine.IsVideoSupportedForAccount gate → "channel_type does not support video
+// generation" for every video request. Here group 30 (vertex) serves "veo-3.1...",
+// group 31 (deepseek) does not; the resolver must pick 30 even though 30 sorts after 31.
+func TestMaybeResolveUniversal_VideoSubmitPeeksModelAndRoutesToVideoGroup(t *testing.T) {
+	const videoModel = "veo-3.1-generate-001"
+	vertexGroup := activeGroup(30, service.PlatformNewAPI) // serves video, sorts AFTER 31 by id
+	deepseekGroup := activeGroup(31, service.PlatformNewAPI)
+
+	resolver := service.NewUniversalRoutingResolver(&stubSpanLister{groups: []service.Group{deepseekGroup, vertexGroup}})
+	// Wire the served-model truth source: only the vertex group declares the video model.
+	resolver.SetAvailableModelsProvider(func(_ context.Context, groupID *int64, _ string) []string {
+		if groupID != nil && *groupID == vertexGroup.ID {
+			return []string{videoModel}
+		}
+		return []string{"deepseek-chat"}
+	})
+
+	// No gin router here, so c.FullPath() is empty; MaybeResolveUniversal falls back
+	// to c.Request.URL.Path, which UniversalShapeForRequest matches to ShapeOpenAIVideo.
+	c, _ := newTestCtx(http.MethodPost, "/v1/video/generations", `{"model":"`+videoModel+`","prompt":"a cat"}`)
+	apiKey := &service.APIKey{ID: 1, UserID: 1, RoutingMode: service.RoutingModeUniversal}
+
+	if handled := MaybeResolveUniversal(c, apiKey, resolver); handled {
+		t.Fatalf("video submit resolve should succeed (continue auth)")
+	}
+	if apiKey.GroupID == nil || *apiKey.GroupID != vertexGroup.ID {
+		t.Fatalf("video submit must route to the video-serving group %d, got %v", vertexGroup.ID, apiKey.GroupID)
+	}
+	// Body must still be readable by the downstream VideoSubmit handler.
+	rest, _ := io.ReadAll(c.Request.Body)
+	if !strings.Contains(string(rest), `"model":"`+videoModel+`"`) {
+		t.Fatalf("video submit body not restored after peek: %q", string(rest))
+	}
+}
+
+// The GET poll path carries no body and no model — it must NOT attempt to read a
+// body (poll uses the VideoTaskCache's submit-time pinned upstream route, not a
+// fresh selection), and any openai-compat group satisfies the route-layer platform
+// gate. Asserts poll resolves model-lessly without erroring.
+func TestMaybeResolveUniversal_VideoPollNoBodyResolves(t *testing.T) {
+	resolver := service.NewUniversalRoutingResolver(&stubSpanLister{groups: []service.Group{activeGroup(30, service.PlatformNewAPI)}})
+	c, _ := newTestCtx(http.MethodGet, "/v1/video/generations/vt_abc", "")
+	apiKey := &service.APIKey{ID: 1, UserID: 1, RoutingMode: service.RoutingModeUniversal}
+
+	if handled := MaybeResolveUniversal(c, apiKey, resolver); handled {
+		t.Fatalf("video poll resolve should succeed model-lessly")
+	}
+	if apiKey.GroupID == nil || *apiKey.GroupID != 30 {
+		t.Fatalf("video poll should route to the only eligible newapi group, got %v", apiKey.GroupID)
+	}
+}
+
 func TestMaybeResolveUniversal_SkipEndpointNoSwap(t *testing.T) {
 	c, _ := newTestCtx(http.MethodGet, "/v1/models", "")
 	resolver := service.NewUniversalRoutingResolver(&stubSpanLister{groups: []service.Group{activeGroup(20, service.PlatformOpenAI)}})


### PR DESCRIPTION
## 根因

prod (1.8.23) 上**所有视频请求 400 失败**(近 24h `usage_logs` veo/seedance 成功数 = 0),报错 `Selected account's channel_type does not support video generation`(`backend/internal/handler/openai_gateway_tk_video.go:181`)。

谓词 `engine.IsVideoSupportedForAccount("newapi",41/45)` 本身返回 `true`(已在 pinned 代码实测)。真因在 **universal-key 路由选错组**:

- `backend/internal/server/middleware/universal_routing_tk.go` 的 `peekUniversalModel` 对 `ShapeOpenAIVideo` **无条件返回 `""`**,把「submit(POST,body 含 model)」和「poll(GET,本就无 model)」一锅端。
- `model=""` 时 resolver (`universal_routing_tk_resolver.go`) **跳过**「组已服务模型集」收敛(line 127 要求 `model != ""`)**和**平台 hint(`universalModelPlatformHint("")=""`),退回「按 sort_order/id 确定性挑组」,从 key 主人**全部 openai/newapi 组**里盲选。
- 候选平台 `capabilityPlatforms(BridgeEndpointVideoSubmit) = [openai, newapi]`,于是可能落到非视频 newapi 组(prod 实有:deepseek ch43 / Qwen ch17 / grok ch1),其选中账号 `channel_type` 在视频门处被拒 → 全局 400。
- **生图不受影响**的原因:`ShapeOpenAIImages` 走 default 分支读 body 取到真 model;只有 images/edits 与 video 被短路成 `""`。

**引入点:** universal key (#878, v1.8.20)。在它之前 key 绑定固定组,视频正常。`#876`(grok 视频 arm)只让视频门对 grok 更宽松,与本回归无关。

**prod 只读取证(SSM):** ops_error_logs 近 24h 全是该 400(veo + seedance 都中招,account_id 为空——门在 `setOpsSelectedAccount` 之前触发);video-capable 账号(47/57/58/59 ch41 在 group 16 google-vertex、7 ch45 在 group 5/19)均 active+schedulable+平台 newapi。

## 修复

`backend/internal/server/middleware/universal_routing_tk.go`:`peekUniversalModel` 对 `ShapeOpenAIVideo` 在 **POST(submit)** 时读 JSON body 取 model(body 字节级原样还原,与 chat 同一机制),让 resolver 收敛到真正服务该视频模型的组 + 平台 hint 偏向(veo→gemini、seedance→newapi);**GET(poll)** 保持 `model=""`——poll 用 `VideoTaskCache` submit 时固定的上游路由、不重新选号,任一 openai-compat 组即满足路由层平台门。

## 测试 / 门禁

- `go build ./...` ✅
- `go test -tags=unit ./internal/engine ./internal/handler ./internal/service ./internal/server/middleware` ✅ 全绿(新增 2 个回归测试:submit 取 model 路由到视频组、poll 无 model 解析)
- `golangci-lint run ./internal/server/middleware/...` ✅ 0 issues
- `scripts/preflight.sh` ✅ PASS(含 sentinel 完整性 331/331)

## Markers

- `sentinel-registry-reviewed` — 本 PR 编辑了已锚定文件 `universal_routing_tk.go`(含删除行),已复核该 surface:4 条 sentinel 锚点(`MaybeResolveUniversal`、`apiKey.Group = backing`、`apiKey.GroupID = &backing.ID`、body-restore 行)全部保留,无需新增锚点。
- 无 upstream-shaped 路径改动(仅 `*_tk_*.go` + `*_test.go`),`upstream-override-marker` 自动通过、无需 marker。

🤖 Generated with [Claude Code](https://claude.com/claude-code)