### PR TITLE
fix(antigravity): default missing contents[] role to "user" for cloudcode-pa generateContent

### DIFF
--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -2186,6 +2186,13 @@ func (s *AntigravityGatewayService) ForwardGemini(ctx context.Context, c *gin.Co
 		return nil, s.writeGoogleError(c, http.StatusBadRequest, "Invalid request body")
 	}
 
+	// TK: cloudcode-pa (Vertex-side v1internal) requires `role` on every
+	// contents[] entry even for single-turn — unlike the public AI Studio Gemini
+	// API where it is optional. Default a missing role to "user" (what every real
+	// client already sends) so a public-spec body no longer 400s upstream. See
+	// antigravity_gateway_service_tk_role_default.go.
+	injectedBody = tkEnsureGeminiContentRoles(injectedBody)
+
 	// 清理 Schema
 	if cleanedBody, err := cleanGeminiRequest(injectedBody); err == nil {
 		injectedBody = cleanedBody

--- a/backend/internal/service/antigravity_gateway_service_tk_role_default.go
+++ b/backend/internal/service/antigravity_gateway_service_tk_role_default.go
@@ -1,0 +1,73 @@
+package service
+
+import "encoding/json"
+
+// tkEnsureGeminiContentRoles defaults a missing `role` on each `contents[]`
+// entry of a native Gemini generateContent body to "user".
+//
+// Why this exists (root cause, prod-confirmed 2026-06-20):
+//
+// TokenKey's /antigravity/v1beta/models/{model}:generateContent surface forwards
+// to Google cloudcode-pa, which is the Vertex-side (Gemini Enterprise / v1internal)
+// endpoint — NOT the public AI Studio Gemini API. On the public Gemini API the
+// `role` field on a Content is OPTIONAL for single-turn requests (the server
+// infers "user"); on the Vertex / cloudcode-pa side it is REQUIRED even for a
+// single turn. A request body coded to the public spec, e.g.
+//
+//	{"contents":[{"parts":[{"text":"Reply OK"}]}]}
+//
+// therefore comes back from cloudcode-pa as:
+//
+//	400 {"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT"}}
+//
+// Live-fire proof on prod account 62 (gemini-3-flash-agent), same body minus/plus role:
+//   - {"contents":[{"parts":[...]}]}                 -> 400 INVALID_ARGUMENT
+//   - {"contents":[{"role":"user","parts":[...]}]}   -> 200 OK
+//   - generationConfig present but role absent       -> 400 (role, not gencfg, is the gate)
+//
+// Real clients (the Antigravity IDE, the Gemini SDKs, python-requests examples)
+// always emit `role`, which is why native traffic that carries it succeeds
+// (gemini-2.5-flash-lite: 8478 served-200 via /v1beta/models). Defaulting the
+// missing role to the value every real client already sends is therefore
+// fingerprint-neutral: it produces exactly the bytes a compliant client would
+// have sent, never altering an explicitly-provided role.
+//
+// On any parse problem the original body is returned unchanged so the existing
+// downstream handling (and upstream's own error) is preserved.
+func tkEnsureGeminiContentRoles(body []byte) []byte {
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return body
+	}
+
+	contents, ok := payload["contents"].([]any)
+	if !ok || len(contents) == 0 {
+		return body
+	}
+
+	modified := false
+	for _, item := range contents {
+		content, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		role, hasRole := content["role"]
+		if hasRole {
+			if roleStr, ok := role.(string); ok && roleStr != "" {
+				continue
+			}
+		}
+		content["role"] = "user"
+		modified = true
+	}
+
+	if !modified {
+		return body
+	}
+
+	patched, err := json.Marshal(payload)
+	if err != nil {
+		return body
+	}
+	return patched
+}

--- a/backend/internal/service/antigravity_gateway_service_tk_role_default_test.go
+++ b/backend/internal/service/antigravity_gateway_service_tk_role_default_test.go
@@ -1,0 +1,102 @@
+//go:build unit
+
+package service
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTkEnsureGeminiContentRoles(t *testing.T) {
+	roleOf := func(t *testing.T, body []byte, idx int) (string, bool) {
+		t.Helper()
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		contents, _ := payload["contents"].([]any)
+		if idx >= len(contents) {
+			t.Fatalf("content idx %d out of range (len=%d)", idx, len(contents))
+		}
+		c, _ := contents[idx].(map[string]any)
+		r, ok := c["role"]
+		if !ok {
+			return "", false
+		}
+		s, _ := r.(string)
+		return s, true
+	}
+
+	t.Run("missing role defaults to user (the prod 400 → 200 fix)", func(t *testing.T) {
+		in := []byte(`{"contents":[{"parts":[{"text":"Reply OK"}]}]}`)
+		out := tkEnsureGeminiContentRoles(in)
+		role, ok := roleOf(t, out, 0)
+		if !ok || role != "user" {
+			t.Fatalf("expected role=user, got role=%q ok=%v", role, ok)
+		}
+	})
+
+	t.Run("explicit role is preserved (user)", func(t *testing.T) {
+		in := []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+		out := tkEnsureGeminiContentRoles(in)
+		role, _ := roleOf(t, out, 0)
+		if role != "user" {
+			t.Fatalf("expected role preserved=user, got %q", role)
+		}
+	})
+
+	t.Run("explicit model role is never overwritten", func(t *testing.T) {
+		in := []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]},{"role":"model","parts":[{"text":"ok"}]}]}`)
+		out := tkEnsureGeminiContentRoles(in)
+		if r, _ := roleOf(t, out, 0); r != "user" {
+			t.Fatalf("content[0] role changed: %q", r)
+		}
+		if r, _ := roleOf(t, out, 1); r != "model" {
+			t.Fatalf("content[1] model role overwritten: %q", r)
+		}
+	})
+
+	t.Run("empty-string role is treated as missing and defaulted", func(t *testing.T) {
+		in := []byte(`{"contents":[{"role":"","parts":[{"text":"hi"}]}]}`)
+		out := tkEnsureGeminiContentRoles(in)
+		role, _ := roleOf(t, out, 0)
+		if role != "user" {
+			t.Fatalf("expected empty role defaulted to user, got %q", role)
+		}
+	})
+
+	t.Run("mixed: only the role-less entry gets a role", func(t *testing.T) {
+		in := []byte(`{"contents":[{"role":"model","parts":[{"text":"a"}]},{"parts":[{"text":"b"}]}]}`)
+		out := tkEnsureGeminiContentRoles(in)
+		if r, _ := roleOf(t, out, 0); r != "model" {
+			t.Fatalf("content[0] role changed: %q", r)
+		}
+		if r, _ := roleOf(t, out, 1); r != "user" {
+			t.Fatalf("content[1] should default to user, got %q", r)
+		}
+	})
+
+	t.Run("invalid JSON returns original body untouched", func(t *testing.T) {
+		in := []byte(`{not json`)
+		out := tkEnsureGeminiContentRoles(in)
+		if string(out) != string(in) {
+			t.Fatalf("expected passthrough on invalid JSON, got %q", out)
+		}
+	})
+
+	t.Run("no contents key returns original body untouched", func(t *testing.T) {
+		in := []byte(`{"systemInstruction":{"parts":[{"text":"x"}]}}`)
+		out := tkEnsureGeminiContentRoles(in)
+		if string(out) != string(in) {
+			t.Fatalf("expected passthrough when contents absent, got %q", out)
+		}
+	})
+
+	t.Run("all roles present returns original bytes (no rewrite)", func(t *testing.T) {
+		in := []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+		out := tkEnsureGeminiContentRoles(in)
+		if string(out) != string(in) {
+			t.Fatalf("expected identical bytes when no change needed, got %q", out)
+		}
+	})
+}


### PR DESCRIPTION
## 概述

antigravity 的 `generateContent` 网关侧**健壮性加固**:把缺失的 `contents[].role` 默认成 `"user"`,让按公开 Gemini 规范(role 单轮可选)编写的请求体不再被上游拒。

> 关系说明:antigravity 行的 SKIP 已由组合 PR #892 的**测试侧** role 修复解决(livefire 200)。本 PR 是**网关侧**的额外健壮性,**可选** —— 价值在于让 TokenKey 对外宣称的「Gemini-native 面」真正 honor 公开 Gemini 契约(role 可选),而不是把 Vertex/cloudcode-pa 的 role-必填怪癖透传给客户端。

## 根因(prod 实证 2026-06-20)

`/antigravity/v1beta/models/{model}:generateContent` 转发到 Google **cloudcode-pa**,即 **Vertex 侧(Gemini Enterprise / v1internal)** 端点,**不是**公开的 AI Studio Gemini API。公开 API 上 `Content.role` 单轮**可选**(服务端推断 user);Vertex/cloudcode-pa 侧**单轮也必填**。按公开规范写的瘦 body `{"contents":[{"parts":[{"text":"..."}]}]}` 因此被上游合法返回 400 INVALID_ARGUMENT。

prod 账号 62(`gemini-3-flash-agent`)同 body 加减 role 实测:
- 无 role → 400 INVALID_ARGUMENT
- `role:"user"` → 200 OK
- 只加 `generationConfig` 不加 role → 仍 400(**role 是闸门,gencfg 不是**)

真实客户端(Antigravity IDE、Gemini SDK、python-requests 示例)**都带 role**,所以原生流量成功(`gemini-2.5-flash-lite` 经 `/v1beta/models` 已 served-200 共 8478 次)。

## 修复

新增 TK 伴生文件 `antigravity_gateway_service_tk_role_default.go`:`tkEnsureGeminiContentRoles()` 把每个 `contents[]` 条目缺失/空的 `role` 默认成 `"user"`,**从不覆盖显式 role**(user/model 保留,混合 body 只补缺的那条)。`antigravity_gateway_service.go` 仅加一行 hook(纯插入)。

**指纹中性**:补出的正是所有真实客户端已经发的字节,把请求规整得更像 IDE,不是更不像;且当所有 role 都在场时**原样返回原始字节、不重新序列化**(单测 `all roles present returns original bytes` 锁定),故对携带 role 的真实流量字节级零影响。**fail-safe**:任何解析失败都返回原 body,保留既有下游处理与上游自身错误。

## 验证

- `go build ./...` OK;`tkEnsureGeminiContentRoles` 8 个子用例全过(缺 role 默认、显式保留、model 永不覆盖、空串视为缺失、混合、非法 JSON 原样、无 contents 原样、全 role 在场返回原始字节)。
- `golangci-lint`(改动包)0 issues;`scripts/preflight.sh` PASS(antigravity 指纹 sentinel intact)。
- 已 rebase 到当前 `origin/main`(含 #892),与 #892 无文件重叠。

no-web-impact: 无 frontend 改动,纯后端网关健壮性。

sentinel-registry-reviewed: 新增 `antigravity_gateway_service_tk_role_default.go` 为 *_tk_* 伴生(请求规整 helper),不引入新的 load-bearing 指纹面(指纹由既有 antigravity sentinel 守护,preflight 已确认 intact),无需新建 sentinel 类目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)