### PR TITLE
feat(ops): 给 ops_error_logs 分区(WAVE 2)— 动态捕获索引 + id 索引

### DIFF
--- a/backend/internal/repository/pgpartition_integration_test.go
+++ b/backend/internal/repository/pgpartition_integration_test.go
@@ -122,3 +122,39 @@ func TestPgPartition_DropExpiredByData(t *testing.T) {
 	require.False(t, hasOld, "expired partition (all data < cutoff) must be dropped")
 	require.True(t, hasCur, "partition with recent data must be kept")
 }
+
+// TestPgPartition_OpsErrorLogsConvertedByMigration proves tk_037 (WAVE 2) converts
+// ops_error_logs in the REAL migration sequence — applying its dynamic index capture/replay
+// against the real ~18-index schema (incl trigram + partial), reassigning the id sequence
+// to the parent (R-001), and adding the id index that the UpdateErrorResolution WHERE id=$1
+// path needs after the PK is dropped.
+func TestPgPartition_OpsErrorLogsConvertedByMigration(t *testing.T) {
+	ctx := context.Background()
+	ok, err := pgpartition.IsPartitioned(ctx, integrationDB, "ops_error_logs")
+	require.NoError(t, err)
+	require.True(t, ok, "tk_037 must convert ops_error_logs to a partitioned table")
+
+	var seqOwner string
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT t.relname FROM pg_depend d
+		JOIN pg_class s ON s.oid = d.objid AND s.relname = 'ops_error_logs_id_seq'
+		JOIN pg_class t ON t.oid = d.refobjid
+		WHERE d.deptype = 'a'`).Scan(&seqOwner))
+	require.Equal(t, "ops_error_logs", seqOwner, "id sequence must be owned by the parent")
+
+	var hasIDIndex bool
+	require.NoError(t, integrationDB.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM pg_indexes WHERE tablename='ops_error_logs' AND indexname='idx_ops_error_logs_id')`).Scan(&hasIDIndex))
+	require.True(t, hasIDIndex, "the id index for UpdateErrorResolution (WHERE id=$1) must exist")
+
+	// The resolution UPDATE (non-key columns, WHERE id) must work post-conversion.
+	id := int64(0)
+	require.NoError(t, integrationDB.QueryRowContext(ctx,
+		`INSERT INTO ops_error_logs(created_at, error_phase, error_type) VALUES (now(), 'test', 'test') RETURNING id`).Scan(&id))
+	res, err := integrationDB.ExecContext(ctx,
+		`UPDATE ops_error_logs SET resolved=true, resolved_at=now(), resolved_by_user_id=1 WHERE id=$1`, id)
+	require.NoError(t, err)
+	n, _ := res.RowsAffected()
+	require.Equal(t, int64(1), n, "UPDATE ... WHERE id must affect exactly the one row")
+	_, _ = integrationDB.ExecContext(ctx, `DELETE FROM ops_error_logs WHERE id=$1`, id)
+}

--- a/backend/migrations/tk_037_partition_ops_error_logs.sql
+++ b/backend/migrations/tk_037_partition_ops_error_logs.sql
@@ -1,0 +1,96 @@
+-- tk_037_partition_ops_error_logs.sql
+-- WAVE 2 of the data-layer partition program. Converts ops_error_logs (1.4GB) to monthly
+-- RANGE partitioning so retention becomes instant DROP PARTITION instead of chunked DELETE.
+-- Same attach-legacy technique as tk_035 (ops_system_logs), with two differences:
+--   (1) ops_error_logs has ~18 indexes (incl trigram + partial), so instead of hardcoding
+--       them we CAPTURE pg_get_indexdef() before the rename and REPLAY them on the parent —
+--       robust to every index without transcription risk;
+--   (2) UpdateErrorResolution does `UPDATE ops_error_logs SET resolved... WHERE id = $1`,
+--       which the dropped PK(id) used to serve, so we add a plain index on id. The resolution
+--       UPDATE only touches non-key columns, so RANGE(created_at) partitioning is valid (no
+--       cross-partition row movement).
+--
+-- NO PRIMARY KEY on the partitioned parent (no FK references it, no ON CONFLICT(id), no
+-- non-time unique index) — id stays a sequence-backed auto-increment column. The id
+-- sequence ownership is reassigned to the new parent so retention can DROP the legacy
+-- partition cleanly (cf tk_035 review finding R-001). Idempotent, transactional, runs at
+-- startup with no concurrent writes.
+
+DO $$
+DECLARE
+  next_month date := (date_trunc('month', now() AT TIME ZONE 'UTC') + interval '1 month')::date;
+  after_next date := (date_trunc('month', now() AT TIME ZONE 'UTC') + interval '2 month')::date;
+  after_2    date := (date_trunc('month', now() AT TIME ZONE 'UTC') + interval '3 month')::date;
+  idx_defs   text[];
+  idx_names  text[];
+  d text;
+  n text;
+BEGIN
+  -- Idempotent: already partitioned -> nothing to do.
+  IF EXISTS (
+    SELECT 1 FROM pg_partitioned_table pt
+    JOIN pg_class c ON c.oid = pt.partrelid
+    WHERE c.relname = 'ops_error_logs'
+  ) THEN
+    RETURN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'ops_error_logs' AND relkind = 'r') THEN
+    RETURN;
+  END IF;
+
+  -- 1. Capture every non-PK index definition (they reference 'ops_error_logs', which becomes
+  --    the new parent) and the index names to rename on the legacy table. Done BEFORE any
+  --    rename so the captured CREATE INDEX statements target the soon-to-exist parent.
+  SELECT array_agg(pg_get_indexdef(x.indexrelid) ORDER BY i.relname),
+         array_agg(i.relname ORDER BY i.relname)
+  INTO idx_defs, idx_names
+  FROM pg_index x
+  JOIN pg_class i ON i.oid = x.indexrelid
+  JOIN pg_class t ON t.oid = x.indrelid
+  WHERE t.relname = 'ops_error_logs' AND NOT x.indisprimary;
+
+  -- 2. Rename live table -> legacy, drop its PK(id), free the canonical index names.
+  ALTER TABLE ops_error_logs RENAME TO ops_error_logs_legacy;
+  ALTER TABLE ops_error_logs_legacy DROP CONSTRAINT IF EXISTS ops_error_logs_pkey;
+  IF idx_names IS NOT NULL THEN
+    FOREACH n IN ARRAY idx_names LOOP
+      EXECUTE format('ALTER INDEX %I RENAME TO %I', n, n || '_legacy');
+    END LOOP;
+  END IF;
+
+  -- 3. Partitioned parent (no PK), inheriting the id sequence DEFAULT + storage. Reassign
+  --    the sequence ownership from the legacy partition to the parent (tk_035 R-001).
+  CREATE TABLE ops_error_logs (
+    LIKE ops_error_logs_legacy INCLUDING DEFAULTS INCLUDING STORAGE
+  ) PARTITION BY RANGE (created_at);
+  ALTER SEQUENCE IF EXISTS ops_error_logs_id_seq OWNED BY ops_error_logs.id;
+
+  -- 4. Re-add the id index (UpdateErrorResolution's WHERE id = $1 was served by the PK),
+  --    then replay all captured index definitions on the parent (canonical names). When the
+  --    legacy partition is attached, its renamed *_legacy indexes match these by definition
+  --    and attach in place (no rebuild); only idx_ops_error_logs_id is built on legacy (it
+  --    lacked one after the PK drop) — cheap at this table's size.
+  CREATE INDEX idx_ops_error_logs_id ON ops_error_logs (id);
+  IF idx_defs IS NOT NULL THEN
+    FOREACH d IN ARRAY idx_defs LOOP
+      EXECUTE d;
+    END LOOP;
+  END IF;
+
+  -- 5. Attach legacy as the historical partition [MINVALUE, next_month) (all existing rows
+  --    incl the current partial month).
+  EXECUTE format(
+    'ALTER TABLE ops_error_logs ATTACH PARTITION ops_error_logs_legacy FOR VALUES FROM (MINVALUE) TO (%L)',
+    next_month
+  );
+
+  -- 6. Going-forward monthly partitions.
+  EXECUTE format(
+    'CREATE TABLE IF NOT EXISTS ops_error_logs_%s PARTITION OF ops_error_logs FOR VALUES FROM (%L) TO (%L)',
+    to_char(next_month, 'YYYYMM'), next_month, after_next
+  );
+  EXECUTE format(
+    'CREATE TABLE IF NOT EXISTS ops_error_logs_%s PARTITION OF ops_error_logs FOR VALUES FROM (%L) TO (%L)',
+    to_char(after_next, 'YYYYMM'), after_next, after_2
+  );
+END $$;


### PR DESCRIPTION
## 这是什么

数据层分区计划的 **WAVE 2**。把 `ops_error_logs`(1.4GB)转月分区(DROP 保留),沿用 tk_035 的 attach-legacy 套路 + **复用 `pgpartition` 机制和分区感知的 ops cleanup 分支**——**零 Go 改动**(ops_error_logs 分区后自动采用 ensure+DROP)。

## 两个 ops_error_logs 特有点(都在 tk_037 处理)

1. **~18 个索引(含 trigram + partial)**:不硬编码,而是转换前 `pg_get_indexdef()` **捕获**、在父表 **replay** —— 对每个索引都健壮、零转写风险。也是更干净的可复用转换模式。
2. **`UpdateErrorResolution` 的 `UPDATE ... WHERE id=$1`**:原本走 PK(id),无 PK 父表后**补一个 id 普通索引**。该 UPDATE 只改非 key 列 → RANGE(created_at) 分区有效(无跨分区行移动)。

并**从一开始带上 tk_035 的 R-001 修复**:把 id 序列归属移到父表,保留才能干净 DROP legacy。

## 验证

- **PG18 实证**:trigram + partial 索引保住、`UPDATE WHERE id` 工作、DROP legacy + 序列存活、数据无损。
- **CI 集成 harness**:在**真 18-索引 schema**、完整迁移序列里应用 tk_037 + 断言(分区/序列归属/id 索引/UPDATE)。
- `go build`、单测、集成测(真 PG,4 条全过)、`scripts/preflight.sh` 全过。

## 迁移号

`tk_037`(tk_036 已被 #881 的告警迁移占用;memory 的迁移号碰撞提示救了一次)。

## 上线

prod 执行是**单独获批低峰窗口**(启动时独占跑);本 PR 只让其 code-ready。

## 已知限制(承自 WAVE 1)

未来分区创建搭每日 cleanup tick(迁移种 2 月);停 >~3 月插入会失败,heartbeat 监控。回顾里列的「加 default 兜底」可作后续统一硬化。

## Markers

- **no-web-impact: true** —— 纯 SQL 迁移 + 测试,无前后端代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Reviewer:TK 自有 PR → **Squash and merge**。高风险迁移,建议 /xj-review 细审 tk_037。未经授权不合并。_