### PR TITLE
perf(admin): collapse Groups/EdgeAccounts N+1 fan-outs + defer Settings/Ops frontend loads

### DIFF
--- a/backend/internal/repository/account_repo_tk_capacity_batch.go
+++ b/backend/internal/repository/account_repo_tk_capacity_batch.go
@@ -1,0 +1,108 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	dbent "github.com/Wei-Shaw/sub2api/ent"
+	dbaccount "github.com/Wei-Shaw/sub2api/ent/account"
+	dbaccountgroup "github.com/Wei-Shaw/sub2api/ent/accountgroup"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// ListSchedulableByGroupIDs is the batched sibling of ListSchedulableByGroupID.
+//
+// TK perf: GroupCapacityService.GetAllGroupCapacity used to call
+// ListSchedulableByGroupID once per active group — and each call fans out into
+// queryAccountsByGroup + accountsToService (loadProxies + loadAccountGroups),
+// i.e. ~4 serial DB round-trips per group. With dozens of active groups the
+// admin Groups page paid hundreds of serialized round-trips on every open /
+// refresh / filter change. This method loads the schedulable accounts for ALL
+// requested groups in one AccountGroup query (WithAccount eager-load), then
+// enriches the de-duplicated union of accounts via a single accountsToService
+// call, so the whole capacity summary costs ~3 DB round-trips regardless of
+// group count.
+//
+// Semantics are identical to calling ListSchedulableByGroupID per group: the
+// same account predicates (active + schedulable + not temp-unschedulable + not
+// expired + not overloaded + not rate-limited), the same priority ordering, the
+// same per-account enrichment. A group with no schedulable accounts is simply
+// absent from the returned map (the caller treats a missing/empty slice as a
+// zero-capacity group, matching the old per-group len(accounts)==0 branch).
+func (r *accountRepository) ListSchedulableByGroupIDs(ctx context.Context, groupIDs []int64) (map[int64][]service.Account, error) {
+	result := make(map[int64][]service.Account, len(groupIDs))
+	if len(groupIDs) == 0 {
+		return result, nil
+	}
+
+	now := time.Now()
+	rows, err := r.client.AccountGroup.Query().
+		Where(
+			dbaccountgroup.GroupIDIn(groupIDs...),
+			// Mirror queryAccountsByGroup's schedulable predicate set exactly.
+			dbaccountgroup.HasAccountWith(
+				dbaccount.DeletedAtIsNil(),
+				dbaccount.StatusEQ(service.StatusActive),
+				dbaccount.SchedulableEQ(true),
+				tempUnschedulablePredicate(),
+				notExpiredPredicate(now),
+				dbaccount.Or(dbaccount.OverloadUntilIsNil(), dbaccount.OverloadUntilLTE(now)),
+				dbaccount.Or(dbaccount.RateLimitResetAtIsNil(), dbaccount.RateLimitResetAtLTE(now)),
+			),
+		).
+		Order(
+			dbaccountgroup.ByPriority(),
+			dbaccountgroup.ByAccountField(dbaccount.FieldPriority),
+		).
+		WithAccount().
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build per-group ordered unique account-ID lists and the de-duplicated
+	// union of underlying ent accounts (so accountsToService enriches each
+	// account exactly once, even when it belongs to multiple requested groups).
+	orderedIDsByGroup := make(map[int64][]int64, len(groupIDs))
+	perGroupSeen := make(map[int64]map[int64]struct{}, len(groupIDs))
+	unionAccounts := make([]*dbent.Account, 0, len(rows))
+	unionSeen := make(map[int64]struct{}, len(rows))
+	for _, ag := range rows {
+		if ag.Edges.Account == nil {
+			continue
+		}
+		seen := perGroupSeen[ag.GroupID]
+		if seen == nil {
+			seen = make(map[int64]struct{})
+			perGroupSeen[ag.GroupID] = seen
+		}
+		if _, dup := seen[ag.AccountID]; !dup {
+			seen[ag.AccountID] = struct{}{}
+			orderedIDsByGroup[ag.GroupID] = append(orderedIDsByGroup[ag.GroupID], ag.AccountID)
+		}
+		if _, dup := unionSeen[ag.AccountID]; !dup {
+			unionSeen[ag.AccountID] = struct{}{}
+			unionAccounts = append(unionAccounts, ag.Edges.Account)
+		}
+	}
+
+	svcAccounts, err := r.accountsToService(ctx, unionAccounts)
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[int64]service.Account, len(svcAccounts))
+	for _, acc := range svcAccounts {
+		byID[acc.ID] = acc
+	}
+
+	for gid, ids := range orderedIDsByGroup {
+		accs := make([]service.Account, 0, len(ids))
+		for _, id := range ids {
+			if acc, ok := byID[id]; ok {
+				accs = append(accs, acc)
+			}
+		}
+		result[gid] = accs
+	}
+	return result, nil
+}

--- a/backend/internal/repository/account_repo_tk_capacity_batch_integration_test.go
+++ b/backend/internal/repository/account_repo_tk_capacity_batch_integration_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package repository
+
+import (
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// TestListSchedulableByGroupIDs_EqualsPerGroup pins the batched
+// ListSchedulableByGroupIDs SQL to the per-group ListSchedulableByGroupID it
+// replaces in GroupCapacityService. The batch method hand-mirrors
+// queryAccountsByGroup's schedulable predicate set, so this guards against that
+// copy drifting (e.g. a future upstream change to the predicate) by asserting,
+// on a real Postgres, that for every requested group the batch returns exactly
+// the per-group schedulable account set — including a group whose account is
+// shared with another group, and a group with no schedulable accounts (which
+// must be absent from the result map, the contract GetAllGroupCapacity relies on
+// to emit a zero-capacity summary).
+func (s *AccountRepoSuite) TestListSchedulableByGroupIDs_EqualsPerGroup() {
+	now := time.Now()
+	g1 := mustCreateGroup(s.T(), s.client, &service.Group{Name: "gb-1"})
+	g2 := mustCreateGroup(s.T(), s.client, &service.Group{Name: "gb-2"})
+	g3 := mustCreateGroup(s.T(), s.client, &service.Group{Name: "gb-3-empty"})
+
+	// g1: one schedulable + one overloaded (must be filtered out).
+	ok1 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "b-ok1", Schedulable: true})
+	mustBindAccountToGroup(s.T(), s.client, ok1.ID, g1.ID, 1)
+	future := now.Add(10 * time.Minute)
+	over := mustCreateAccount(s.T(), s.client, &service.Account{Name: "b-over", Schedulable: true, OverloadUntil: &future})
+	mustBindAccountToGroup(s.T(), s.client, over.ID, g1.ID, 2)
+
+	// shared account bound to BOTH g1 and g2 (exercises the union de-dup).
+	shared := mustCreateAccount(s.T(), s.client, &service.Account{Name: "b-shared", Schedulable: true})
+	mustBindAccountToGroup(s.T(), s.client, shared.ID, g1.ID, 3)
+	mustBindAccountToGroup(s.T(), s.client, shared.ID, g2.ID, 1)
+
+	// g2: shared + one manually non-schedulable (must be filtered out).
+	// (mustCreateAccount forces Schedulable=true, so flip it off explicitly.)
+	noSched := mustCreateAccount(s.T(), s.client, &service.Account{Name: "b-nosched", Schedulable: true})
+	mustBindAccountToGroup(s.T(), s.client, noSched.ID, g2.ID, 2)
+	s.Require().NoError(s.repo.SetSchedulable(s.ctx, noSched.ID, false), "SetSchedulable false")
+
+	// g3: only a rate-limited account -> empty schedulable set.
+	rl := mustCreateAccount(s.T(), s.client, &service.Account{Name: "b-rl", Schedulable: true})
+	mustBindAccountToGroup(s.T(), s.client, rl.ID, g3.ID, 1)
+	s.Require().NoError(s.repo.SetRateLimited(s.ctx, rl.ID, now.Add(10*time.Minute)), "SetRateLimited")
+
+	groupIDs := []int64{g1.ID, g2.ID, g3.ID}
+	batch, err := s.repo.ListSchedulableByGroupIDs(s.ctx, groupIDs)
+	s.Require().NoError(err, "ListSchedulableByGroupIDs")
+
+	// Equivalence: every requested group's batch set == the per-group set.
+	for _, gid := range groupIDs {
+		want, perr := s.repo.ListSchedulableByGroupID(s.ctx, gid)
+		s.Require().NoError(perr, "ListSchedulableByGroupID(%d)", gid)
+		s.Require().ElementsMatch(idsOfAccounts(want), idsOfAccounts(batch[gid]),
+			"group %d: batch schedulable set must equal per-group", gid)
+	}
+
+	// Spot-check the expected filtering.
+	s.Require().ElementsMatch([]int64{ok1.ID, shared.ID}, idsOfAccounts(batch[g1.ID]),
+		"g1 schedulable = ok1 + shared (overloaded excluded)")
+	s.Require().ElementsMatch([]int64{shared.ID}, idsOfAccounts(batch[g2.ID]),
+		"g2 schedulable = shared (non-schedulable excluded)")
+
+	// A group with no schedulable accounts is absent from the map (zero-capacity contract).
+	_, present := batch[g3.ID]
+	s.Require().False(present, "group with no schedulable accounts must be absent from the batch map")
+}

--- a/backend/internal/service/account_usage_service_tk_passive_batch.go
+++ b/backend/internal/service/account_usage_service_tk_passive_batch.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -60,13 +61,54 @@ func (s *AccountUsageService) GetPassiveUsageBatch(ctx context.Context, accountI
 		if !account.IsAnthropicOAuthOrSetupToken() && !account.IsOpenAIOAuth() {
 			continue
 		}
-		usage, perr := s.GetPassiveUsage(ctx, account.ID)
+		// TK perf: the account is already fully loaded (GetByIDs above), so build
+		// the passive usage straight from it instead of GetPassiveUsage(ctx, ID),
+		// which would re-issue a per-account GetByID (a PK lookup + a groups join)
+		// for data we already hold. With the window-stats cache prewarmed above,
+		// that GetByID was the last residual per-account DB round-trip in this
+		// fan-out. See getPassiveUsageForAccount.
+		usage, perr := s.getPassiveUsageForAccount(ctx, account)
 		if perr != nil || usage == nil {
 			continue
 		}
 		result[account.ID] = usage
 	}
 	return result
+}
+
+// getPassiveUsageForAccount builds the passive UsageInfo from an already-loaded
+// *Account, skipping the GetByID that GetPassiveUsage(ctx, accountID) performs.
+//
+// It MUST stay byte-identical to GetPassiveUsage's body after its GetByID
+// (account_usage_service.go). GetPassiveUsage is an upstream-owned method, so
+// rather than refactor it to delegate here (an upstream edit), the post-fetch
+// logic is mirrored in this TK companion. Drift is caught mechanically by
+// TestGetPassiveUsageBatch_EqualsSinglePerAccount, which asserts this batch
+// path (now routed through getPassiveUsageForAccount) matches the per-account
+// GetPassiveUsage output.
+func (s *AccountUsageService) getPassiveUsageForAccount(ctx context.Context, account *Account) (*UsageInfo, error) {
+	if account == nil {
+		return nil, fmt.Errorf("get account failed: nil account")
+	}
+
+	// OpenAI OAuth (codex): rebuilt from Extra's codex_*_used_percent passive
+	// sampling, never probing upstream — same source as GetPassiveUsage.
+	if account.IsOpenAIOAuth() {
+		return s.buildPassiveOpenAIUsage(account), nil
+	}
+
+	if !account.IsAnthropicOAuthOrSetupToken() {
+		return nil, fmt.Errorf("passive usage only supported for Anthropic OAuth/SetupToken accounts")
+	}
+
+	info := s.estimateSetupTokenUsage(account)
+	info.Source = "passive"
+	info.UpdatedAt = parseExtraSampledAt(account.Extra["passive_usage_sampled_at"])
+	info.SevenDay = buildPassiveWindow(account.Extra, "passive_usage_7d_utilization", "passive_usage_7d_reset")
+	info.SevenDaySonnet = buildPassiveWindow(account.Extra, "passive_usage_7d_sonnet_utilization", "passive_usage_7d_sonnet_reset")
+	s.addWindowStats(ctx, account, info)
+
+	return info, nil
 }
 
 // prefetchWindowStatsForPassive 把被动路径需要的窗口统计批量查询并写入

--- a/backend/internal/service/group_capacity_service.go
+++ b/backend/internal/service/group_capacity_service.go
@@ -44,6 +44,14 @@ func NewGroupCapacityService(
 
 // GetAllGroupCapacity returns capacity summary for all active groups.
 func (s *GroupCapacityService) GetAllGroupCapacity(ctx context.Context) ([]GroupCapacitySummary, error) {
+	// TK perf: when the repo supports batch loading (production path), collapse
+	// the per-group N+1 below into a constant number of DB + Redis round-trips.
+	// Falls through to the original per-group loop for repos that don't (test
+	// stubs). Output is byte-identical — see group_capacity_service_tk_batch.go.
+	if out, ok, err := s.getAllGroupCapacityBatched(ctx); ok {
+		return out, err
+	}
+
 	groups, err := s.groupRepo.ListActive(ctx)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/group_capacity_service_tk_batch.go
+++ b/backend/internal/service/group_capacity_service_tk_batch.go
@@ -1,0 +1,152 @@
+package service
+
+import (
+	"context"
+	"time"
+)
+
+// schedulableGroupBatchRepo is the optional batch capability the real
+// AccountRepository (repository.accountRepository) implements. The capacity
+// service type-asserts its accountRepo for it so the fast path activates in
+// production while test stubs (which only implement the per-group method) fall
+// back to the original loop in GetAllGroupCapacity. This keeps the perf rewrite
+// entirely in TK companion files — no change to the AccountRepository interface
+// and therefore no churn across its mocks.
+type schedulableGroupBatchRepo interface {
+	ListSchedulableByGroupIDs(ctx context.Context, groupIDs []int64) (map[int64][]Account, error)
+}
+
+// getAllGroupCapacityBatched collapses GetAllGroupCapacity's per-group N+1
+// (~4 DB + ~3 Redis round-trips PER active group, all serial) into a constant
+// number of round-trips: one batched account load for every group, then a
+// single GetAccountConcurrencyBatch / GetActiveSessionCountBatch / GetRPMBatch
+// over the de-duplicated union of all accounts, folded back per group.
+//
+// It returns ok=false when the underlying repo does not implement the batch
+// method, so GetAllGroupCapacity falls through to its original per-group loop.
+// When ok=true the result (and any error) is authoritative.
+//
+// Output is byte-identical to the per-group path:
+//   - groups with no schedulable accounts still emit a zero-capacity summary
+//     (the old getGroupCapacity returned GroupCapacitySummary{} + nil, which the
+//     caller appended with GroupID set);
+//   - per-account concurrency/session/RPM values are independent of which group
+//     queried them, so a unioned batch yields the same numbers as N per-group
+//     batches;
+//   - sessions are only summed for groups whose Σ max_sessions > 0, and RPM only
+//     for groups with Σ base_rpm > 0 OR a group-level rpm_limit, exactly as
+//     getGroupCapacity gated them;
+//   - rpm_max is overridden by group.rpm_limit when that L1 ceiling is set.
+func (s *GroupCapacityService) getAllGroupCapacityBatched(ctx context.Context) ([]GroupCapacitySummary, bool, error) {
+	batchRepo, ok := s.accountRepo.(schedulableGroupBatchRepo)
+	if !ok {
+		return nil, false, nil
+	}
+
+	groups, err := s.groupRepo.ListActive(ctx)
+	if err != nil {
+		return nil, true, err
+	}
+	if len(groups) == 0 {
+		return []GroupCapacitySummary{}, true, nil
+	}
+
+	groupIDs := make([]int64, len(groups))
+	for i := range groups {
+		groupIDs[i] = groups[i].ID
+	}
+
+	accountsByGroup, err := batchRepo.ListSchedulableByGroupIDs(ctx, groupIDs)
+	if err != nil {
+		return nil, true, err
+	}
+
+	// Union of all account IDs (dedup) + per-account session idle timeout, so the
+	// three Redis batch calls run once across the whole set instead of per group.
+	unionIDs := make([]int64, 0, len(accountsByGroup))
+	unionSeen := make(map[int64]struct{}, len(accountsByGroup))
+	sessionTimeouts := make(map[int64]time.Duration)
+	for _, accounts := range accountsByGroup {
+		for i := range accounts {
+			acc := &accounts[i]
+			if _, dup := unionSeen[acc.ID]; !dup {
+				unionSeen[acc.ID] = struct{}{}
+				unionIDs = append(unionIDs, acc.ID)
+			}
+			if ms := acc.GetMaxSessions(); ms > 0 {
+				timeout := time.Duration(acc.GetSessionIdleTimeoutMinutes()) * time.Minute
+				if timeout <= 0 {
+					timeout = 5 * time.Minute
+				}
+				sessionTimeouts[acc.ID] = timeout
+			}
+		}
+	}
+
+	concurrencyMap, _ := s.concurrencyService.GetAccountConcurrencyBatch(ctx, unionIDs)
+
+	var sessionsMap map[int64]int
+	if len(sessionTimeouts) > 0 && s.sessionLimitCache != nil {
+		sessionsMap, _ = s.sessionLimitCache.GetActiveSessionCountBatch(ctx, unionIDs, sessionTimeouts)
+	}
+
+	var rpmMap map[int64]int
+	if s.rpmCache != nil {
+		rpmMap, _ = s.rpmCache.GetRPMBatch(ctx, unionIDs)
+	}
+
+	results := make([]GroupCapacitySummary, 0, len(groups))
+	for i := range groups {
+		g := &groups[i]
+		summary := GroupCapacitySummary{GroupID: g.ID}
+		accounts := accountsByGroup[g.ID]
+		if len(accounts) == 0 {
+			results = append(results, summary)
+			continue
+		}
+
+		var concurrencyMax, sessionsMax, rpmMax int
+		var concurrencyUsed int
+		for j := range accounts {
+			acc := &accounts[j]
+			concurrencyMax += acc.Concurrency
+			concurrencyUsed += concurrencyMap[acc.ID]
+			if ms := acc.GetMaxSessions(); ms > 0 {
+				sessionsMax += ms
+			}
+			if rpm := acc.GetBaseRPM(); rpm > 0 {
+				rpmMax += rpm
+			}
+		}
+
+		var sessionsUsed int
+		if sessionsMax > 0 {
+			for j := range accounts {
+				sessionsUsed += sessionsMap[accounts[j].ID]
+			}
+		}
+
+		var rpmUsed int
+		if rpmMax > 0 || g.RPMLimit > 0 {
+			for j := range accounts {
+				rpmUsed += rpmMap[accounts[j].ID]
+			}
+		}
+
+		// group.rpm_limit (L1 gate) wins over Σ base_rpm when set — see the
+		// matching note in getGroupCapacity.
+		if g.RPMLimit > 0 {
+			rpmMax = g.RPMLimit
+		}
+
+		summary.ConcurrencyUsed = concurrencyUsed
+		summary.ConcurrencyMax = concurrencyMax
+		summary.SessionsUsed = sessionsUsed
+		summary.SessionsMax = sessionsMax
+		summary.RPMUsed = rpmUsed
+		summary.RPMMax = rpmMax
+		results = append(results, summary)
+	}
+
+	return results, true, nil
+}

--- a/backend/internal/service/group_capacity_service_tk_batch_test.go
+++ b/backend/internal/service/group_capacity_service_tk_batch_test.go
@@ -1,0 +1,149 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// --- lightweight stubs (embed the interfaces, override only what's exercised) ---
+
+type gcapAccountRepoBatch struct {
+	AccountRepository
+	byGroup map[int64][]Account
+}
+
+func (r *gcapAccountRepoBatch) ListSchedulableByGroupID(_ context.Context, groupID int64) ([]Account, error) {
+	return append([]Account(nil), r.byGroup[groupID]...), nil
+}
+
+func (r *gcapAccountRepoBatch) ListSchedulableByGroupIDs(_ context.Context, groupIDs []int64) (map[int64][]Account, error) {
+	out := make(map[int64][]Account, len(groupIDs))
+	for _, gid := range groupIDs {
+		if accs, ok := r.byGroup[gid]; ok && len(accs) > 0 {
+			out[gid] = append([]Account(nil), accs...)
+		}
+	}
+	return out, nil
+}
+
+// gcapAccountRepoPerGroup deliberately does NOT implement ListSchedulableByGroupIDs,
+// so the type-assertion in getAllGroupCapacityBatched fails and GetAllGroupCapacity
+// falls back to its original per-group loop.
+type gcapAccountRepoPerGroup struct {
+	AccountRepository
+	byGroup map[int64][]Account
+}
+
+func (r *gcapAccountRepoPerGroup) ListSchedulableByGroupID(_ context.Context, groupID int64) ([]Account, error) {
+	return append([]Account(nil), r.byGroup[groupID]...), nil
+}
+
+type gcapGroupRepo struct {
+	GroupRepository
+	groups []Group
+}
+
+func (r *gcapGroupRepo) ListActive(_ context.Context) ([]Group, error) {
+	return append([]Group(nil), r.groups...), nil
+}
+
+type gcapConcCache struct {
+	ConcurrencyCache
+	counts map[int64]int
+}
+
+func (c *gcapConcCache) GetAccountConcurrencyBatch(_ context.Context, ids []int64) (map[int64]int, error) {
+	out := make(map[int64]int, len(ids))
+	for _, id := range ids {
+		out[id] = c.counts[id]
+	}
+	return out, nil
+}
+
+type gcapSessCache struct {
+	SessionLimitCache
+	counts map[int64]int
+}
+
+func (c *gcapSessCache) GetActiveSessionCountBatch(_ context.Context, ids []int64, _ map[int64]time.Duration) (map[int64]int, error) {
+	out := make(map[int64]int, len(ids))
+	for _, id := range ids {
+		out[id] = c.counts[id]
+	}
+	return out, nil
+}
+
+type gcapRPMCache struct {
+	RPMCache
+	counts map[int64]int
+}
+
+func (c *gcapRPMCache) GetRPMBatch(_ context.Context, ids []int64) (map[int64]int, error) {
+	out := make(map[int64]int, len(ids))
+	for _, id := range ids {
+		out[id] = c.counts[id]
+	}
+	return out, nil
+}
+
+// TestGetAllGroupCapacity_BatchEqualsPerGroup proves the batched fast path emits
+// the byte-identical []GroupCapacitySummary the original per-group loop produces,
+// and pins the expected aggregation (including a zero-account group, a group whose
+// rpm_limit overrides Σ base_rpm, and an account shared across two groups).
+func TestGetAllGroupCapacity_BatchEqualsPerGroup(t *testing.T) {
+	a1 := Account{ID: 1, Concurrency: 4, Extra: map[string]any{"max_sessions": 10, "base_rpm": 30, "session_idle_timeout_minutes": 3}}
+	a2 := Account{ID: 2, Concurrency: 2, Extra: map[string]any{"max_sessions": 5}}
+	a3 := Account{ID: 3, Concurrency: 1} // no sessions, no base_rpm
+
+	byGroup := map[int64][]Account{
+		1: {a1, a2}, // two accounts
+		2: {a3},     // rpm_limit override applies (a3 has no base_rpm)
+		3: {},       // empty -> zero-capacity summary, still emitted
+		4: {a1},     // a1 shared with group 1 (multi-membership)
+	}
+	groups := []Group{{ID: 1}, {ID: 2, RPMLimit: 100}, {ID: 3}, {ID: 4}}
+
+	concCounts := map[int64]int{1: 2, 2: 1, 3: 0}
+	sessCounts := map[int64]int{1: 3, 2: 4}
+	rpmCounts := map[int64]int{1: 7, 2: 0, 3: 5}
+
+	newSvc := func(repo AccountRepository) *GroupCapacityService {
+		return NewGroupCapacityService(
+			repo,
+			&gcapGroupRepo{groups: groups},
+			NewConcurrencyService(&gcapConcCache{counts: concCounts}),
+			&gcapSessCache{counts: sessCounts},
+			&gcapRPMCache{counts: rpmCounts},
+		)
+	}
+
+	batchSvc := newSvc(&gcapAccountRepoBatch{byGroup: byGroup})
+	perGroupSvc := newSvc(&gcapAccountRepoPerGroup{byGroup: byGroup})
+
+	got, err := batchSvc.GetAllGroupCapacity(context.Background())
+	if err != nil {
+		t.Fatalf("batch path error: %v", err)
+	}
+	fallback, err := perGroupSvc.GetAllGroupCapacity(context.Background())
+	if err != nil {
+		t.Fatalf("fallback path error: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, fallback) {
+		t.Fatalf("batch path != per-group fallback\nbatch=%+v\nfallback=%+v", got, fallback)
+	}
+
+	want := []GroupCapacitySummary{
+		{GroupID: 1, ConcurrencyUsed: 3, ConcurrencyMax: 6, SessionsUsed: 7, SessionsMax: 15, RPMUsed: 7, RPMMax: 30},
+		{GroupID: 2, ConcurrencyUsed: 0, ConcurrencyMax: 1, SessionsUsed: 0, SessionsMax: 0, RPMUsed: 5, RPMMax: 100},
+		{GroupID: 3},
+		{GroupID: 4, ConcurrencyUsed: 2, ConcurrencyMax: 4, SessionsUsed: 3, SessionsMax: 10, RPMUsed: 7, RPMMax: 30},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected capacity\n got=%+v\nwant=%+v", got, want)
+	}
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 495,
-  "hash": "e8b276547c3865cfee4f7d7bdaa29c00ad34d4e56e65f80f604c0b962c3e98c1",
+  "hash": "731804b48bfb9bbd8d03837a16b90241fc1fc9e1cccdb4dd9f09a9d13d9d9389",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -6537,7 +6537,10 @@
             </div>
           </div>
 
-          <EmailTemplateEditor />
+          <!-- Perf: v-if so the editor only mounts when the Email tab is opened,
+               not on every Settings load (it sits inside the v-show'd email panel
+               which otherwise builds its whole subtree on first render). -->
+          <EmailTemplateEditor v-if="activeTab === 'email'" />
 
           <!-- Balance Low Notification -->
           <div class="card">
@@ -6679,7 +6682,10 @@
       </form>
 
         <!-- Tab: Backup (must stay outside main form — backup UI may contain nested forms) -->
-        <div v-show="activeTab === 'backup'">
+        <!-- Perf: v-if (not v-show) so BackupSettings only mounts — and only fires
+             its s3-config/schedule/backups XHRs — when the Backup tab is opened,
+             instead of on every Settings page load (default tab is 'general'). -->
+        <div v-if="activeTab === 'backup'">
           <BackupSettings />
         </div>
 

--- a/frontend/src/views/admin/ops/OpsDashboard.vue
+++ b/frontend/src/views/admin/ops/OpsDashboard.vue
@@ -783,11 +783,18 @@ onMounted(async () => {
   // Load thresholds configuration
   loadThresholds()
 
+  // Perf: kick off the core dashboard data fetch in parallel with the
+  // advanced-settings load instead of serializing behind it. snapshot-v2 does
+  // not depend on advanced settings — those only feed display toggles + the
+  // auto-refresh countdown applied below — so awaiting them first just burned
+  // ~1 RTT of dead time before the first dashboard byte on a cold tab.
+  const dataPromise = opsEnabled.value ? fetchData() : null
+
   // Load auto refresh settings
   await loadDashboardAdvancedSettings()
 
-  if (opsEnabled.value) {
-    await fetchData()
+  if (dataPromise) {
+    await dataPromise
   }
 
   // Start auto refresh if enabled


### PR DESCRIPTION
## 这个 PR 做什么

对后台管理界面做了一次逐页延迟审计（24 个页面，自动追踪 前端→API→后端→SQL 并对抗式复核），定位到两处确认为 **HIGH** 的后端 N+1 扇出（都在默认加载路径上），外加两处干净的前端加载路径优化。本 PR 只合入**已验证、纯提速、输出字节级不变**的改动，全部最小侵入（逻辑落在 TK 伴生文件；上游文件只留极薄注入点）。

### 后端（输出字节级不变，有测试）

- **Groups 容量汇总 N+1（影响 prod + edge，头号发现）。** `GetAllGroupCapacity` 过去对**每一个**活跃分组各跑一遍「查可调度账号 + 问 Redis 并发/会话/RPM」——即每个分组约 4 次串行 DB + 约 3 次串行 Redis 往返，每次打开 / 刷新 / 筛选 Groups 页都重来，几十个分组就是几百次串行往返。新增批量快路径：一条 `account_groups` 查询取回所有分组的可调度账号，再把账号 ID 取并集后做**单次** `GetAccountConcurrencyBatch` / `GetActiveSessionCountBatch` / `GetRPMBatch`，最后按分组折回——把往返次数压成与分组数无关的常量。新逻辑全在 TK 伴生文件（`account_repo_tk_capacity_batch.go`、`group_capacity_service_tk_batch.go`）；上游方法只加一个**纯插入**的快路径入口，原逐组循环作为 fallback 保留（供未实现批量方法的 repo / 测试桩走）。由等价性 + 正确性单测 `TestGetAllGroupCapacity_BatchEqualsPerGroup` 守护；批量 SQL 与逐组 SQL 的等价由集成测试 `TestListSchedulableByGroupIDs_EqualsPerGroup` 在真实 Postgres 上守护。

- **EdgeAccounts 被动用量 N+1（影响 edge）。** `GetPassiveUsageBatch` 已用 `GetByIDs` 一次性载入全部账号，但循环里又对每个 OAuth 账号调 `GetPassiveUsage(ctx, id)`，后者再 `GetByID` 重查一遍（PK 查询 + 分组 join）——查的正是手里已有的数据。改为经 `getPassiveUsageForAccount` 直接用已载入的 `*Account` 构建，去掉这趟跨 edge 扇出（约每 15~30s 一次）里最后一处逐账号 DB 往返。其与单查路径的字节级等价由既有 live parity 测试 `TestGetPassiveUsageBatch_EqualsSinglePerAccount` 守护。

### 前端（typecheck / lint / build 全绿）

- **Ops 监控页：** 把核心面板数据请求与 advanced-settings 加载并行发起，不再串行等在它后面（冷启动省约 1 个 RTT）。
- **Settings 设置页：** 用 `v-if` 关住 `BackupView`（3 个 XHR）与 `EmailTemplateEditor`，让它们只在切到对应标签页时才挂载，而不是每次打开设置页（默认标签是 `general`）就全挂上、连备份页的 3 个请求都替你发了。

## 验证

- `go build ./...` ✓ · `go test -tags=unit ./...`（55 包）✓ · `go test -tags=integration ./internal/repository/`（新增等价性测试）✓ · `golangci-lint`（改动包）✓
- `pnpm typecheck` ✓ · `eslint`（改动文件）✓ · `pnpm build` ✓（dist `frontend-source.json` 已重建）
- `scripts/preflight.sh` PASS（已 rebase 到当前 `origin/main`）

## Marker / 纪律

- **`upstream-touch-trivial`** —— 本 PR 触及的上游形态文件都是纯提速、无上游合并回退风险（reviewer 已审）：`group_capacity_service.go` 是纯插入快路径（原循环保留）；`OpsDashboard.vue` 把两个 await 的挂载调用改成并行；`SettingsView.vue` 把两个子组件挂载从 `v-show` 改成 `v-if`。没有任何一处删除上游功能 / 路由 / 符号，因此即便将来上游合并把它们盖回，丢的也只是一处提速、不会回退行为。
- **`sentinel-registry-reviewed`** —— 新增的 `*_tk_*.go` 伴生文件（`account_repo_tk_capacity_batch.go`、`group_capacity_service_tk_batch.go`）是纯提速批量 helper，**不是**承载第五平台 / 网关的关键面，故不适用 sentinel 锚点；已对照注册表复核，无需新增锚点。
- 不改任何 API / 路由 / 契约。含前端改动（有 web impact），故无需 `no-web-impact`。不删除任何上游符号。

## 暂缓（拆成单独、经验证后的后续 PR）

- 带数据库迁移的后端：Dashboard model-stats / users-trend rollup、ChannelMonitor 7d 走现成日度 rollup、`idx_user_affiliates_created_at`、ILIKE→pg_trgm GIN —— 这些都要先在 prod 真表上跑 `EXPLAIN ANALYZE`、确认索引/rollup 真能命中（避开「有索引=快」的陷阱），并上 canary。
- 前端深改：图表懒加载（需抽出 chart 子组件以保住 `BaseDialog` 的离场动画）与 Settings 全量 `v-show`→`v-if`（10.2k 行文件里 12 个同条件面板，有结构性回归面）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
