### PR TITLE
feat(openai-scheduler): window-aware soft scheduling to cut GPT-line failover hops

### DIFF
--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -428,6 +428,14 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 	if !s.isAccountRequestCompatible(ctx, account, req) {
 		return nil, false, nil
 	}
+	// TK window guard (isSticky=true): a sticky-bound account keeps serving its
+	// own session up to NotSchedulable; only once it is essentially at its codex
+	// window cap do we skip the sticky hit and fall through to load-balance. The
+	// binding is left intact (NOT deleted) so the session resumes on this account
+	// after its window resets — unlike the hard-invalidation branches around it.
+	if !s.service.isAccountSchedulableForOpenAIWindow(ctx, account, true) {
+		return nil, false, nil
+	}
 	if !s.isAccountTransportCompatible(account, req.RequiredTransport) {
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
@@ -991,6 +999,9 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 
 	filtered := make([]*Account, 0, len(accounts))
 	loadReq := make([]AccountWithConcurrency, 0, len(accounts))
+	// TK window guard: accounts dropped PURELY by the codex 5h/7d window guard,
+	// retained for the never-empty-pool fallback below.
+	var windowDropped []*Account
 	for i := range accounts {
 		account := &accounts[i]
 		if req.ExcludedIDs != nil {
@@ -1020,11 +1031,30 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 		if needsUpstreamCheck && s.service.isUpstreamModelRestrictedByChannel(ctx, *req.GroupID, account, req.RequestedModel, req.RequireCompact) {
 			continue
 		}
+		// TK window guard (isSticky=false, fresh load-balance): steer new traffic
+		// away from a codex account approaching its 5h/7d window before it 429s.
+		// Applied LAST so windowDropped holds only otherwise-valid candidates.
+		if !s.service.isAccountSchedulableForOpenAIWindow(ctx, account, false) {
+			windowDropped = append(windowDropped, account)
+			continue
+		}
 		filtered = append(filtered, account)
 		loadReq = append(loadReq, AccountWithConcurrency{
 			ID:             account.ID,
 			MaxConcurrency: account.EffectiveLoadFactor(),
 		})
+	}
+	// never-empty-pool: the window guard must not turn a non-empty schedulable
+	// pool into an empty-pool 429. If every otherwise-valid candidate was dropped
+	// purely by the window guard, re-admit the one with the most headroom.
+	if len(filtered) == 0 && len(windowDropped) > 0 {
+		if acc := leastUtilizedOpenAIAccount(windowDropped, time.Now()); acc != nil {
+			filtered = append(filtered, acc)
+			loadReq = append(loadReq, AccountWithConcurrency{
+				ID:             acc.ID,
+				MaxConcurrency: acc.EffectiveLoadFactor(),
+			})
+		}
 	}
 	if len(filtered) == 0 {
 		// TK: when the schedulable pool was emptied PURELY because no account serves

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -798,7 +798,11 @@ func TestOpenAIGatewayService_SelectAccountForModelWithExclusions_AutoPauseBy7dT
 
 func TestOpenAIGatewayService_SelectAccountForModelWithExclusions_UnconfiguredThresholdKeepsLegacyBehavior(t *testing.T) {
 	ctx := context.Background()
-	primary := Account{ID: 35301, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, Extra: map[string]any{"codex_5h_used_percent": 99.0, "codex_7d_used_percent": 99.0}}
+	// This test isolates AUTO-PAUSE semantics (unconfigured threshold => no pause),
+	// so the orthogonal default-ON window guard is disabled on the high-usage
+	// account; the window guard's own behaviour is covered in
+	// openai_account_scheduler_tk_window_sched_test.go.
+	primary := Account{ID: 35301, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, Extra: map[string]any{"codex_5h_used_percent": 99.0, "codex_7d_used_percent": 99.0, "openai_window_guard_disabled": true}}
 	secondary := Account{ID: 35302, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 5}
 	svc := &OpenAIGatewayService{accountRepo: schedulerTestOpenAIAccountRepo{accounts: []Account{primary, secondary}}, cfg: &config.Config{}}
 
@@ -850,6 +854,9 @@ func TestOpenAIGatewayService_SelectAccountForModelWithExclusions_PerAccountDisa
 		Extra: map[string]any{
 			"codex_5h_used_percent":  99.0,
 			"auto_pause_5h_disabled": true,
+			// Isolate this test to AUTO-PAUSE semantics; the orthogonal default-ON
+			// window guard would otherwise also drop this 99%-used account.
+			"openai_window_guard_disabled": true,
 		},
 	}
 	secondary := Account{ID: 35702, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 5}

--- a/backend/internal/service/openai_account_scheduler_tk_window_sched.go
+++ b/backend/internal/service/openai_account_scheduler_tk_window_sched.go
@@ -30,8 +30,8 @@ const (
 	// load-balance traffic); above that => avoided, unless it is the only
 	// headroom left in the pool. Operators override via the ops settings or
 	// per-account Extra; see resolveOpenAIWindowStickyThresholds.
-	openAIWindowStickyThresholdDefault = 0.85
-	openAIWindowStickyReserveDefault   = 0.12
+	openAIWindowStickyThresholdDefault = 0.95
+	openAIWindowStickyReserveDefault   = 0.04
 )
 
 // openAIAccountWindowUtilization returns the WORSE (higher) of the account's 5h

--- a/backend/internal/service/openai_account_scheduler_tk_window_sched.go
+++ b/backend/internal/service/openai_account_scheduler_tk_window_sched.go
@@ -1,0 +1,163 @@
+package service
+
+import (
+	"context"
+	"time"
+)
+
+// Window-aware soft scheduling for the OpenAI/GPT line — the twin of the
+// Anthropic window-cost tri-state filter (GatewayService.isAccountSchedulable
+// ForWindowCost / Account.CheckWindowCostSchedulability). It steers new
+// load-balance traffic away from an account approaching its codex 5h/7d usage
+// window BEFORE it 429s, cutting avoidable failover hops, while keeping the
+// account available for its own sticky sessions (prompt-cache affinity).
+//
+// Two differences from the Anthropic twin, by necessity:
+//   - Denominator is codex used-percent (the upstream's OWN limit), not a $
+//     business budget with headroom below the real limit. Excluding near 100%
+//     therefore risks emptying a thin pool into a worse "no available accounts"
+//     429, so the OpenAI side adds a never-empty-pool fallback
+//     (leastUtilizedOpenAIAccount) that the Anthropic twin does not need.
+//   - Signal source is account.Extra codex_5h/7d_used_percent (already captured
+//     per-response and mirrored into the scheduler cache), read via the existing
+//     resolveOpenAIQuotaUtilization with its used<=0 / window-reset / >2h-stale
+//     guards. Accounts with no codex snapshot (newapi/compat, openai-apikey)
+//     produce no signal and are never restricted (fail-open).
+const (
+	// Built-in defaults (the guard is default-ON). util at/below the threshold
+	// => fully schedulable; threshold..threshold+reserve => sticky-only (the
+	// account keeps serving its own sticky sessions but takes no new
+	// load-balance traffic); above that => avoided, unless it is the only
+	// headroom left in the pool. Operators override via the ops settings or
+	// per-account Extra; see resolveOpenAIWindowStickyThresholds.
+	openAIWindowStickyThresholdDefault = 0.85
+	openAIWindowStickyReserveDefault   = 0.12
+)
+
+// openAIAccountWindowUtilization returns the WORSE (higher) of the account's 5h
+// and 7d codex utilization in [0,1], and ok=false when there is no usable signal
+// in either window. resolveOpenAIQuotaUtilization already returns ok=false for a
+// missing snapshot, a window that has already reset, a >2h-stale snapshot, and
+// used<=0, so all of those inherit the fail-open contract here.
+func openAIAccountWindowUtilization(account *Account, now time.Time) (float64, bool) {
+	if account == nil || len(account.Extra) == 0 {
+		return 0, false
+	}
+	util, ok := 0.0, false
+	if u, k := resolveOpenAIQuotaUtilization(account.Extra, "5h", now); k {
+		util, ok = u, true
+	}
+	if u, k := resolveOpenAIQuotaUtilization(account.Extra, "7d", now); k && u > util {
+		util, ok = u, true
+	}
+	return util, ok
+}
+
+// CheckOpenAIWindowSchedulability mirrors Account.CheckWindowCostSchedulability
+// but keys off codex used-percent utilization instead of $ window cost:
+//   - util < stickyThreshold                     -> Schedulable
+//   - stickyThreshold <= util < +stickyReserve   -> StickyOnly
+//   - util >= stickyThreshold + stickyReserve     -> NotSchedulable
+//
+// A non-positive or out-of-range stickyThreshold disables the restriction.
+func CheckOpenAIWindowSchedulability(util, stickyThreshold, stickyReserve float64) WindowCostSchedulability {
+	if stickyThreshold <= 0 || stickyThreshold >= 1 {
+		return WindowCostSchedulable
+	}
+	if util < stickyThreshold {
+		return WindowCostSchedulable
+	}
+	if stickyReserve < 0 {
+		stickyReserve = 0
+	}
+	if util < stickyThreshold+stickyReserve {
+		return WindowCostStickyOnly
+	}
+	return WindowCostNotSchedulable
+}
+
+// resolveOpenAIWindowStickyThresholds resolves (threshold, reserve, enabled) for
+// an account with precedence: per-account Extra override -> global ops setting ->
+// built-in default. enabled=false short-circuits the guard (global kill-switch
+// or per-account disable). Mirrors resolveOpenAIQuotaAutoPauseThresholds and the
+// window_cost_limit / window_cost_sticky_reserve precedence on the Anthropic side.
+//
+// Note: the global override is read from the auto-pause settings carried on the
+// request context (seeded once per selection by withOpenAIQuotaAutoPauseContext).
+// On code paths that do not seed it the built-in defaults still apply, so the
+// guard stays default-ON everywhere; only the operator override is context-gated.
+func resolveOpenAIWindowStickyThresholds(ctx context.Context, account *Account) (threshold, reserve float64, enabled bool) {
+	settings := openAIQuotaAutoPauseSettingsFromContext(ctx)
+	if settings.WindowStickyGuardDisabled {
+		return 0, 0, false
+	}
+	if account != nil && resolveAccountExtraBool(account.Extra, "openai_window_guard_disabled") {
+		return 0, 0, false
+	}
+
+	threshold = openAIWindowStickyThresholdDefault
+	reserve = openAIWindowStickyReserveDefault
+	if settings.WindowStickyThreshold > 0 {
+		threshold = settings.WindowStickyThreshold
+	}
+	if settings.WindowStickyReserve > 0 {
+		reserve = settings.WindowStickyReserve
+	}
+	if account != nil {
+		if v, ok := resolveAccountExtraNumber(account.Extra, "openai_window_sticky_threshold"); ok && v > 0 {
+			threshold = v
+		}
+		if v, ok := resolveAccountExtraNumber(account.Extra, "openai_window_sticky_reserve"); ok && v >= 0 {
+			reserve = v
+		}
+	}
+	return clamp01(threshold), clamp01(reserve), true
+}
+
+// isAccountSchedulableForOpenAIWindow is the OpenAI twin of GatewayService.is
+// AccountSchedulableForWindowCost. isSticky=true keeps StickyOnly accounts (a
+// sticky-session re-validation); isSticky=false (fresh load-balance selection)
+// drops them. Fail-open: no signal / disabled guard => schedulable.
+func (s *OpenAIGatewayService) isAccountSchedulableForOpenAIWindow(ctx context.Context, account *Account, isSticky bool) bool {
+	if account == nil {
+		return true
+	}
+	threshold, reserve, enabled := resolveOpenAIWindowStickyThresholds(ctx, account)
+	if !enabled {
+		return true
+	}
+	util, ok := openAIAccountWindowUtilization(account, time.Now())
+	if !ok {
+		return true
+	}
+	switch CheckOpenAIWindowSchedulability(util, threshold, reserve) {
+	case WindowCostStickyOnly:
+		return isSticky
+	case WindowCostNotSchedulable:
+		return false
+	default:
+		return true
+	}
+}
+
+// leastUtilizedOpenAIAccount returns the account with the most window headroom
+// (lowest utilization) among a set that was dropped purely by the window guard.
+// It backs the never-empty-pool fallback: when the guard would otherwise empty a
+// non-empty candidate pool, the coolest dropped account is re-admitted so the
+// request still routes (better than an empty-pool 429). No-signal accounts count
+// as utilization 0 (max headroom).
+func leastUtilizedOpenAIAccount(dropped []*Account, now time.Time) *Account {
+	var best *Account
+	bestUtil := 2.0 // utilization is in [0,1]; 2.0 is an above-range sentinel
+	for _, acc := range dropped {
+		util, ok := openAIAccountWindowUtilization(acc, now)
+		if !ok {
+			util = 0
+		}
+		if best == nil || util < bestUtil {
+			bestUtil = util
+			best = acc
+		}
+	}
+	return best
+}

--- a/backend/internal/service/openai_account_scheduler_tk_window_sched_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_window_sched_test.go
@@ -191,3 +191,91 @@ func TestSelectBestAccount_WindowGuard_NeverEmptiesPool(t *testing.T) {
 	require.NotNil(t, account)
 	require.Equal(t, int64(36102), account.ID, "never-empty-pool fallback must serve the coolest account, not error")
 }
+
+// Integration through the LEGACY load-aware path (selectAccountWithLoadAwareness),
+// which is the DEFAULT prod path (advanced scheduler off) and the one that served
+// the reported gpt-5.5 incident.
+func TestSelectAccountWithScheduler_LegacyWindowGuard_RoutesAwayFromHotAccount(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+	ctx := context.Background()
+	groupID := int64(10301)
+	now := time.Now().Format(time.RFC3339)
+	accounts := []Account{
+		{ID: 38001, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0,
+			Extra: map[string]any{"codex_5h_used_percent": 99.0, "codex_usage_updated_at": now}},
+		{ID: 38002, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 5,
+			Extra: map[string]any{"codex_5h_used_percent": 10.0, "codex_usage_updated_at": now}},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:              &schedulerTestGatewayCache{},
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+	require.False(t, svc.isOpenAIAdvancedSchedulerEnabled(ctx))
+
+	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(38002), selection.Account.ID, "legacy path: hot 99% account skipped despite better priority")
+}
+
+func TestSelectAccountWithScheduler_LegacyWindowGuard_NeverEmptiesPool(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+	ctx := context.Background()
+	groupID := int64(10302)
+	now := time.Now().Format(time.RFC3339)
+	accounts := []Account{
+		{ID: 38101, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0,
+			Extra: map[string]any{"codex_5h_used_percent": 99.5, "codex_usage_updated_at": now}},
+		{ID: 38102, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 5,
+			Extra: map[string]any{"codex_5h_used_percent": 98.0, "codex_usage_updated_at": now}},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:              &schedulerTestGatewayCache{},
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(38102), selection.Account.ID, "legacy never-empty-pool: coolest of the all-hot pool is served, not an error")
+}
+
+// Integration through the ADVANCED scheduler (selectByLoadBalance + weighted TopK).
+func TestSelectAccountWithScheduler_AdvancedWindowGuard_RoutesAwayFromHotAccount(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+	ctx := context.Background()
+	groupID := int64(10303)
+	now := time.Now().Format(time.RFC3339)
+	accounts := []Account{
+		{ID: 39001, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0,
+			Extra: map[string]any{"codex_5h_used_percent": 99.0, "codex_usage_updated_at": now}},
+		{ID: 39002, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 5,
+			Extra: map[string]any{"codex_5h_used_percent": 10.0, "codex_usage_updated_at": now}},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:              &schedulerTestGatewayCache{},
+		cfg:                cfg,
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+	require.True(t, svc.isOpenAIAdvancedSchedulerEnabled(ctx))
+
+	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(39002), selection.Account.ID, "advanced path: hot 99% account excluded from the weighted TopK pool")
+}

--- a/backend/internal/service/openai_account_scheduler_tk_window_sched_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_window_sched_test.go
@@ -94,21 +94,23 @@ func TestIsAccountSchedulableForOpenAIWindow(t *testing.T) {
 		require.True(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(50), true))
 	})
 	t.Run("sticky-only band: kept for sticky, dropped for load-balance", func(t *testing.T) {
-		require.False(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(90), false))
-		require.True(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(90), true))
+		// default band is [95%, 99%): 97% is sticky-only.
+		require.False(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(97), false))
+		require.True(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(97), true))
 	})
 	t.Run("not-schedulable band: dropped even for sticky", func(t *testing.T) {
-		require.False(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(99), false))
-		require.False(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(99), true))
+		// default avoid edge is 99%; 99.5% is unambiguously NotSchedulable.
+		require.False(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(99.5), false))
+		require.False(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(99.5), true))
 	})
 	t.Run("per-account disable => schedulable", func(t *testing.T) {
-		acc := hot(99)
+		acc := hot(99.5)
 		acc.Extra["openai_window_guard_disabled"] = true
 		require.True(t, svc.isAccountSchedulableForOpenAIWindow(ctx, acc, false))
 	})
 	t.Run("global kill-switch => schedulable", func(t *testing.T) {
 		disabledCtx := withOpenAIQuotaAutoPauseSettings(ctx, OpsOpenAIAccountQuotaAutoPauseSettings{WindowStickyGuardDisabled: true})
-		require.True(t, svc.isAccountSchedulableForOpenAIWindow(disabledCtx, hot(99), false))
+		require.True(t, svc.isAccountSchedulableForOpenAIWindow(disabledCtx, hot(99.5), false))
 	})
 	t.Run("operator threshold override widens the schedulable range", func(t *testing.T) {
 		// With threshold 0.98 + reserve 0.02, a 96%-used account is schedulable.

--- a/backend/internal/service/openai_account_scheduler_tk_window_sched_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_window_sched_test.go
@@ -1,0 +1,193 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckOpenAIWindowSchedulability_Boundaries(t *testing.T) {
+	const (
+		threshold = 0.85
+		reserve   = 0.12 // NotSchedulable at >= 0.97
+	)
+	cases := []struct {
+		name string
+		util float64
+		want WindowCostSchedulability
+	}{
+		{"well below", 0.50, WindowCostSchedulable},
+		{"just below threshold", 0.84, WindowCostSchedulable},
+		{"at threshold => sticky-only", 0.85, WindowCostStickyOnly},
+		{"inside reserve band", 0.96, WindowCostStickyOnly},
+		{"at hard edge => not schedulable", 0.97, WindowCostNotSchedulable},
+		{"above hard edge", 0.999, WindowCostNotSchedulable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, CheckOpenAIWindowSchedulability(tc.util, threshold, reserve))
+		})
+	}
+}
+
+func TestCheckOpenAIWindowSchedulability_DisabledThreshold(t *testing.T) {
+	// A non-positive or >=1 threshold disables the restriction entirely.
+	require.Equal(t, WindowCostSchedulable, CheckOpenAIWindowSchedulability(0.99, 0, 0.12))
+	require.Equal(t, WindowCostSchedulable, CheckOpenAIWindowSchedulability(0.99, 1.0, 0.12))
+}
+
+func TestOpenAIAccountWindowUtilization(t *testing.T) {
+	now := time.Now()
+
+	t.Run("no extra => no signal", func(t *testing.T) {
+		_, ok := openAIAccountWindowUtilization(&Account{}, now)
+		require.False(t, ok)
+	})
+	t.Run("takes the worse of 5h/7d", func(t *testing.T) {
+		acc := &Account{Extra: map[string]any{"codex_5h_used_percent": 60.0, "codex_7d_used_percent": 90.0}}
+		util, ok := openAIAccountWindowUtilization(acc, now)
+		require.True(t, ok)
+		require.InDelta(t, 0.90, util, 1e-9)
+	})
+	t.Run("stale snapshot => no signal", func(t *testing.T) {
+		acc := &Account{Extra: map[string]any{
+			"codex_5h_used_percent": 99.0,
+			"codex_usage_updated_at": now.Add(-3 * time.Hour).Format(time.RFC3339),
+		}}
+		_, ok := openAIAccountWindowUtilization(acc, now)
+		require.False(t, ok, "snapshot older than 2h must not produce a signal (fail-open)")
+	})
+	t.Run("already-reset window => no signal", func(t *testing.T) {
+		acc := &Account{Extra: map[string]any{
+			"codex_5h_used_percent": 99.0,
+			"codex_5h_reset_at":     now.Add(-1 * time.Minute).Format(time.RFC3339),
+		}}
+		_, ok := openAIAccountWindowUtilization(acc, now)
+		require.False(t, ok, "a window whose reset time has passed must not produce a signal")
+	})
+}
+
+func TestIsAccountSchedulableForOpenAIWindow(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	ctx := context.Background()
+	now := time.Now()
+	hot := func(p float64) *Account {
+		return &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: map[string]any{
+			"codex_5h_used_percent":  p,
+			"codex_usage_updated_at": now.Format(time.RFC3339),
+		}}
+	}
+
+	t.Run("nil account => schedulable", func(t *testing.T) {
+		require.True(t, svc.isAccountSchedulableForOpenAIWindow(ctx, nil, false))
+	})
+	t.Run("no signal => schedulable (newapi/compat path)", func(t *testing.T) {
+		require.True(t, svc.isAccountSchedulableForOpenAIWindow(ctx, &Account{Platform: PlatformNewAPI}, false))
+	})
+	t.Run("cool account => schedulable both ways", func(t *testing.T) {
+		require.True(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(50), false))
+		require.True(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(50), true))
+	})
+	t.Run("sticky-only band: kept for sticky, dropped for load-balance", func(t *testing.T) {
+		require.False(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(90), false))
+		require.True(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(90), true))
+	})
+	t.Run("not-schedulable band: dropped even for sticky", func(t *testing.T) {
+		require.False(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(99), false))
+		require.False(t, svc.isAccountSchedulableForOpenAIWindow(ctx, hot(99), true))
+	})
+	t.Run("per-account disable => schedulable", func(t *testing.T) {
+		acc := hot(99)
+		acc.Extra["openai_window_guard_disabled"] = true
+		require.True(t, svc.isAccountSchedulableForOpenAIWindow(ctx, acc, false))
+	})
+	t.Run("global kill-switch => schedulable", func(t *testing.T) {
+		disabledCtx := withOpenAIQuotaAutoPauseSettings(ctx, OpsOpenAIAccountQuotaAutoPauseSettings{WindowStickyGuardDisabled: true})
+		require.True(t, svc.isAccountSchedulableForOpenAIWindow(disabledCtx, hot(99), false))
+	})
+	t.Run("operator threshold override widens the schedulable range", func(t *testing.T) {
+		// With threshold 0.98 + reserve 0.02, a 96%-used account is schedulable.
+		overrideCtx := withOpenAIQuotaAutoPauseSettings(ctx, OpsOpenAIAccountQuotaAutoPauseSettings{
+			WindowStickyThreshold: 0.98, WindowStickyReserve: 0.02,
+		})
+		require.True(t, svc.isAccountSchedulableForOpenAIWindow(overrideCtx, hot(96), false))
+	})
+}
+
+func TestResolveOpenAIWindowStickyThresholds_Precedence(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("built-in defaults when unconfigured", func(t *testing.T) {
+		th, res, enabled := resolveOpenAIWindowStickyThresholds(ctx, &Account{})
+		require.True(t, enabled)
+		require.InDelta(t, openAIWindowStickyThresholdDefault, th, 1e-9)
+		require.InDelta(t, openAIWindowStickyReserveDefault, res, 1e-9)
+	})
+	t.Run("per-account Extra overrides global", func(t *testing.T) {
+		globalCtx := withOpenAIQuotaAutoPauseSettings(ctx, OpsOpenAIAccountQuotaAutoPauseSettings{
+			WindowStickyThreshold: 0.90, WindowStickyReserve: 0.05,
+		})
+		acc := &Account{Extra: map[string]any{"openai_window_sticky_threshold": 0.70, "openai_window_sticky_reserve": 0.10}}
+		th, res, enabled := resolveOpenAIWindowStickyThresholds(globalCtx, acc)
+		require.True(t, enabled)
+		require.InDelta(t, 0.70, th, 1e-9)
+		require.InDelta(t, 0.10, res, 1e-9)
+	})
+	t.Run("global kill-switch disables", func(t *testing.T) {
+		disabledCtx := withOpenAIQuotaAutoPauseSettings(ctx, OpsOpenAIAccountQuotaAutoPauseSettings{WindowStickyGuardDisabled: true})
+		_, _, enabled := resolveOpenAIWindowStickyThresholds(disabledCtx, &Account{})
+		require.False(t, enabled)
+	})
+}
+
+func TestLeastUtilizedOpenAIAccount(t *testing.T) {
+	now := time.Now()
+	a := &Account{ID: 1, Extra: map[string]any{"codex_5h_used_percent": 99.0, "codex_usage_updated_at": now.Format(time.RFC3339)}}
+	b := &Account{ID: 2, Extra: map[string]any{"codex_5h_used_percent": 98.0, "codex_usage_updated_at": now.Format(time.RFC3339)}}
+	c := &Account{ID: 3, Extra: map[string]any{"codex_5h_used_percent": 99.5, "codex_usage_updated_at": now.Format(time.RFC3339)}}
+	best := leastUtilizedOpenAIAccount([]*Account{a, b, c}, now)
+	require.NotNil(t, best)
+	require.Equal(t, int64(2), best.ID, "the account with the most headroom (lowest used%) wins")
+
+	require.Nil(t, leastUtilizedOpenAIAccount(nil, now))
+}
+
+// Integration through the priority+LRU selection path (SelectAccountForModel
+// WithExclusions -> selectBestAccount): a near-limit account is steered away in
+// favour of a cool one, but is still served when it is the only headroom left.
+func TestSelectBestAccount_WindowGuard_RoutesAwayFromHotAccount(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().Format(time.RFC3339)
+	hot := Account{ID: 36001, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0,
+		Extra: map[string]any{"codex_5h_used_percent": 99.0, "codex_usage_updated_at": now}}
+	cool := Account{ID: 36002, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 5,
+		Extra: map[string]any{"codex_5h_used_percent": 10.0, "codex_usage_updated_at": now}}
+	svc := &OpenAIGatewayService{accountRepo: schedulerTestOpenAIAccountRepo{accounts: []Account{hot, cool}}, cfg: &config.Config{}}
+
+	account, err := svc.SelectAccountForModelWithExclusions(ctx, nil, "", "gpt-5.1", nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	require.Equal(t, int64(36002), account.ID, "the hot (99%) account must be skipped in favour of the cool one despite higher priority")
+}
+
+func TestSelectBestAccount_WindowGuard_NeverEmptiesPool(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().Format(time.RFC3339)
+	// Both accounts are over the hard edge; the guard must not produce an
+	// empty-pool error — it re-admits the one with the most headroom.
+	hotter := Account{ID: 36101, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0,
+		Extra: map[string]any{"codex_5h_used_percent": 99.5, "codex_usage_updated_at": now}}
+	lessHot := Account{ID: 36102, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 5,
+		Extra: map[string]any{"codex_5h_used_percent": 98.0, "codex_usage_updated_at": now}}
+	svc := &OpenAIGatewayService{accountRepo: schedulerTestOpenAIAccountRepo{accounts: []Account{hotter, lessHot}}, cfg: &config.Config{}}
+
+	account, err := svc.SelectAccountForModelWithExclusions(ctx, nil, "", "gpt-5.1", nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	require.Equal(t, int64(36102), account.ID, "never-empty-pool fallback must serve the coolest account, not error")
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1826,6 +1826,13 @@ func (s *OpenAIGatewayService) tryStickySessionHit(ctx context.Context, groupID 
 		}
 		return nil
 	}
+	// TK window guard (isSticky=true): keep serving the sticky session up to
+	// NotSchedulable; only once the bound account is essentially at its codex
+	// window cap do we skip the hit and fall through to load-balance. The binding
+	// is left intact (NOT deleted) so the session resumes after the window resets.
+	if !s.isAccountSchedulableForOpenAIWindow(ctx, account, true) {
+		return nil
+	}
 	if s.isOpenAIAccountRuntimeBlocked(account) {
 		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 		return nil
@@ -1866,6 +1873,9 @@ func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *i
 	selectedCompactTier := -1
 	compactBlocked := false
 	needsUpstreamCheck := s.needsUpstreamChannelRestrictionCheck(ctx, groupID)
+	// TK window guard: accounts dropped PURELY by the codex 5h/7d window guard,
+	// retained for the never-empty-pool fallback below.
+	var windowDropped []*Account
 
 	for i := range accounts {
 		acc := &accounts[i]
@@ -1901,6 +1911,14 @@ func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *i
 			}
 		}
 
+		// TK window guard (isSticky=false, fresh load-balance): steer new traffic
+		// away from a codex account approaching its 5h/7d window before it 429s.
+		// Applied LAST so windowDropped holds only otherwise-valid candidates.
+		if !s.isAccountSchedulableForOpenAIWindow(ctx, fresh, false) {
+			windowDropped = append(windowDropped, fresh)
+			continue
+		}
+
 		// 选择优先级最高且最久未使用的账号
 		// Select highest priority and least recently used
 		if selected == nil {
@@ -1922,6 +1940,13 @@ func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *i
 			selected = fresh
 			selectedCompactTier = compactTier
 		}
+	}
+
+	// never-empty-pool: the window guard must not turn a non-empty pool into an
+	// empty-pool 429. If every otherwise-valid candidate was dropped purely by the
+	// window guard, re-admit the one with the most headroom.
+	if selected == nil && len(windowDropped) > 0 {
+		selected = leastUtilizedOpenAIAccount(windowDropped, time.Now())
 	}
 
 	return selected, compactBlocked
@@ -2051,6 +2076,15 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 				if !clearSticky && !account.IsOpenAICompatPoolMember(groupPlatform) {
 					_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 				}
+				// TK window guard (isSticky=true): if the bound account is at its
+				// codex window cap (NotSchedulable), mark it sticky-clear so the hit
+				// is skipped and the request falls through to Layer 2 load-balance.
+				// The binding is NOT deleted here (the delete branches above already
+				// ran for genuine clear-sticky reasons), so the session resumes on
+				// this account after its window resets.
+				if !clearSticky && !s.isAccountSchedulableForOpenAIWindow(ctx, account, true) {
+					clearSticky = true
+				}
 				if !clearSticky && isOpenAIAccountEligibleForRequest(ctx, account, requestedModel, groupPlatform, requireCompact) {
 					account = s.recheckOpenAICompatAccountFromDB(ctx, account, requestedModel, groupPlatform, requireCompact)
 					if account == nil {
@@ -2094,6 +2128,9 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	// ============ Layer 2: Load-aware selection ============
 	baseCandidateCount := 0
 	candidates := make([]*Account, 0, len(accounts))
+	// TK window guard: accounts dropped PURELY by the codex 5h/7d window guard,
+	// retained for the never-empty-pool fallback below.
+	var windowDropped []*Account
 	for i := range accounts {
 		acc := &accounts[i]
 		if isExcluded(acc.ID) {
@@ -2120,8 +2157,25 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, acc, requestedModel, requireCompact) {
 			continue
 		}
+		// TK window guard (isSticky=false, fresh load-balance): steer new traffic
+		// away from a codex account approaching its 5h/7d window before it 429s.
+		// Applied LAST so windowDropped holds only otherwise-valid candidates.
+		if !s.isAccountSchedulableForOpenAIWindow(ctx, acc, false) {
+			windowDropped = append(windowDropped, acc)
+			continue
+		}
 		baseCandidateCount++
 		candidates = append(candidates, acc)
+	}
+
+	// never-empty-pool: the window guard must not turn a non-empty schedulable
+	// pool into an empty-pool 429. If every otherwise-valid candidate was dropped
+	// purely by the window guard, re-admit the one with the most headroom.
+	if len(candidates) == 0 && len(windowDropped) > 0 {
+		if acc := leastUtilizedOpenAIAccount(windowDropped, time.Now()); acc != nil {
+			baseCandidateCount++
+			candidates = append(candidates, acc)
+		}
 	}
 
 	if len(candidates) == 0 {

--- a/backend/internal/service/ops_settings.go
+++ b/backend/internal/service/ops_settings.go
@@ -543,6 +543,8 @@ func normalizeOpsAdvancedSettings(cfg *OpsAdvancedSettings) {
 	}
 	cfg.OpenAIAccountQuotaAutoPause.DefaultThreshold5h = clampOpsQuotaAutoPauseThreshold(cfg.OpenAIAccountQuotaAutoPause.DefaultThreshold5h)
 	cfg.OpenAIAccountQuotaAutoPause.DefaultThreshold7d = clampOpsQuotaAutoPauseThreshold(cfg.OpenAIAccountQuotaAutoPause.DefaultThreshold7d)
+	cfg.OpenAIAccountQuotaAutoPause.WindowStickyThreshold = clampOpsQuotaAutoPauseThreshold(cfg.OpenAIAccountQuotaAutoPause.WindowStickyThreshold)
+	cfg.OpenAIAccountQuotaAutoPause.WindowStickyReserve = clampOpsQuotaAutoPauseThreshold(cfg.OpenAIAccountQuotaAutoPause.WindowStickyReserve)
 	cfg.DataRetention.CleanupSchedule = strings.TrimSpace(cfg.DataRetention.CleanupSchedule)
 	if cfg.DataRetention.CleanupSchedule == "" {
 		cfg.DataRetention.CleanupSchedule = opsCleanupDefaultSchedule

--- a/backend/internal/service/ops_settings_models.go
+++ b/backend/internal/service/ops_settings_models.go
@@ -154,6 +154,16 @@ type OpsAdvancedSettings struct {
 type OpsOpenAIAccountQuotaAutoPauseSettings struct {
 	DefaultThreshold5h float64 `json:"default_threshold_5h"`
 	DefaultThreshold7d float64 `json:"default_threshold_7d"`
+	// TK: window-aware soft scheduling guard (twin of the anthropic window-cost
+	// tri-state). Steers new load-balance traffic away from a codex account
+	// approaching its 5h/7d window before it 429s, to cut failover hops. The
+	// guard is default-ON via built-in thresholds (openAIWindowStickyThreshold
+	// Default / ReserveDefault); these fields are operator overrides only. A
+	// zero-value struct => guard ON with built-in defaults. WindowStickyGuard
+	// Disabled is the global kill-switch (zero-value=false=ON, no redeploy).
+	WindowStickyGuardDisabled bool    `json:"window_sticky_guard_disabled"`
+	WindowStickyThreshold     float64 `json:"window_sticky_threshold"`
+	WindowStickyReserve       float64 `json:"window_sticky_reserve"`
 }
 
 type OpsDataRetentionSettings struct {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3109,7 +3109,7 @@
         "func CheckOpenAIWindowSchedulability(",
         "func (s *OpenAIGatewayService) isAccountSchedulableForOpenAIWindow(",
         "func leastUtilizedOpenAIAccount(",
-        "openAIWindowStickyThresholdDefault = 0.85"
+        "openAIWindowStickyThresholdDefault = 0.95"
       ],
       "rationale": "OpenAI/GPT-line window-aware soft scheduler — the twin of the anthropic window-cost tri-state filter (gateway_service.go isAccountSchedulableForWindowCost / account.go CheckWindowCostSchedulability). Steers new load-balance traffic away from a codex account approaching its 5h/7d usage window BEFORE it 429s, cutting avoidable failover hops (prod: 139 absorbed 429s on one gpt-5.5 account, all recovered via failover at the cost of a wasted hop each). Tri-state Schedulable/StickyOnly/NotSchedulable on the already-captured codex_5h/7d_used_percent (resolveOpenAIQuotaUtilization, fail-open on no-signal/stale/reset). The whole hop-reduction behaviour lives here; an upstream merge or refactor deleting this companion silently reverts the GPT line to window-blind load-balancing. Anchors the tri-state predicate, the scheduler method, the never-empty-pool fallback, and the default sticky threshold."
     },

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3102,6 +3102,34 @@
         "service.EdgeAccountOpClearRateLimit"
       ],
       "rationale": "Prod admin thin-proxy handler mapping POST|DELETE|GET /admin/edge-accounts/:edge/accounts/:id/<op> onto the aggregator's ForwardAccountOp (admin-JWT gated, inherited from /admin). Relays the edge's credential-free response verbatim; unknown edge -> 404, unreachable -> 502. Guards the prod proxy entry against silent deletion that would break inline edge-account management."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler_tk_window_sched.go",
+      "must_contain": [
+        "func CheckOpenAIWindowSchedulability(",
+        "func (s *OpenAIGatewayService) isAccountSchedulableForOpenAIWindow(",
+        "func leastUtilizedOpenAIAccount(",
+        "openAIWindowStickyThresholdDefault = 0.85"
+      ],
+      "rationale": "OpenAI/GPT-line window-aware soft scheduler — the twin of the anthropic window-cost tri-state filter (gateway_service.go isAccountSchedulableForWindowCost / account.go CheckWindowCostSchedulability). Steers new load-balance traffic away from a codex account approaching its 5h/7d usage window BEFORE it 429s, cutting avoidable failover hops (prod: 139 absorbed 429s on one gpt-5.5 account, all recovered via failover at the cost of a wasted hop each). Tri-state Schedulable/StickyOnly/NotSchedulable on the already-captured codex_5h/7d_used_percent (resolveOpenAIQuotaUtilization, fail-open on no-signal/stale/reset). The whole hop-reduction behaviour lives here; an upstream merge or refactor deleting this companion silently reverts the GPT line to window-blind load-balancing. Anchors the tri-state predicate, the scheduler method, the never-empty-pool fallback, and the default sticky threshold."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler.go",
+      "must_contain": [
+        "s.service.isAccountSchedulableForOpenAIWindow(ctx, account, false)",
+        "s.service.isAccountSchedulableForOpenAIWindow(ctx, account, true)",
+        "leastUtilizedOpenAIAccount(windowDropped, time.Now())"
+      ],
+      "rationale": "Advanced-scheduler wiring of the OpenAI window guard (see openai_account_scheduler_tk_window_sched.go): selectByLoadBalance applies it with isSticky=false (drops near-limit accounts from fresh selection) and selectBySessionHash with isSticky=true (keeps a StickyOnly account for its own session, preserving prompt-cache). The never-empty-pool fallback re-admits the coolest dropped account so the guard can never empty a thin pool into a worse no-available-accounts 429 — necessary because codex used% IS the upstream's own limit, unlike the anthropic $-budget twin. Dropping these one-line hooks silently disables the guard on the advanced path; anchors them so merge drift fails preflight + the upstream-merge PR shape check."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "s.isAccountSchedulableForOpenAIWindow(ctx, acc, false)",
+        "s.isAccountSchedulableForOpenAIWindow(ctx, account, true)",
+        "leastUtilizedOpenAIAccount(windowDropped, time.Now())"
+      ],
+      "rationale": "Legacy + priority/LRU wiring of the OpenAI window guard across the remaining candidate-filter selection paths: selectAccountWithLoadAwareness Layer-2 (isSticky=false) + Layer-1 sticky (isSticky=true, marks clearSticky so the hit falls through without deleting the binding), selectBestAccount (isSticky=false; used by count_tokens failover + gemini-compat) and tryStickySessionHit (isSticky=true). selectAccountWithLoadAwareness is the DEFAULT prod path (advanced scheduler defaults off), so this is the load-bearing wiring for the reported incident; never-empty-pool fallback present here too. Anchors the hooks so an upstream merge cannot silently drop the guard call and revert the GPT line to window-blind selection."
     }
   ]
 }


### PR DESCRIPTION
## 问题

线上观测（GPT 线）：user16 的 gpt-5.5，account 64 出现 **139 次上游 429，全部经 failover 恢复成 200** —— 客户端零真失败，但**每一次被吸收的 429 都是一次本可避免的 failover 多跳**：请求先落到一个即将限流的账号、吃一个 429，再 failover 到一个凉账号才 200。「压力从 63 转到 64」正是「只看并发 LoadRate、对上游用量窗口无感」的均衡签名。

根因：OpenAI/GPT 选号器只按 priority + 并发 LoadRate + 队列 + EWMA error/ttft 排序，**对 5h/7d 用量窗口完全无感**。而预测信号（`codex_5h/7d_used_percent`）其实每个响应都已写入 `account.Extra` 并被调度快照携带，只是此前唯一消费者是一个默认关闭的二值 auto-pause。

## 方案 —— 移植 Anthropic 的运行时窗口机制（不是另造一个）

Anthropic 路径用一个**候选过滤层的三态可调度过滤器**（`isAccountSchedulableForWindowCost` / `CheckWindowCostSchedulability`：Schedulable / StickyOnly / NotSchedulable）+ 显式 `isSticky` 穿透，主动避开接近上限的账号。本 PR 给 OpenAI 造它的**孪生兄弟**：

- 新 TK 伴随文件 `openai_account_scheduler_tk_window_sched.go`：`CheckOpenAIWindowSchedulability`（复用 `WindowCostSchedulability` 枚举）+ `isAccountSchedulableForOpenAIWindow`，经已有的 `resolveOpenAIQuotaUtilization` 读 `max(used_5h, used_7d)`（内建 used<=0 / 窗口已重置 / >2h 陈旧 三道守卫，**fail-open** —— 无信号账号 newapi/compat/apikey 一律不受限）。
- 接入**全部三条**候选过滤选号路径，`isSticky` 显式穿透（load-balance 传 `false` 剔除近限账号；sticky 传 `true` 保留给其自身会话、不破坏 prompt-cache）：advanced `selectByLoadBalance`/`selectBySessionHash`、legacy `selectAccountWithLoadAwareness`（Layer-1 sticky + Layer-2，**prod 默认路径**、被报案例所在）、以及 `selectBestAccount`/`tryStickySessionHit`（count_tokens failover + gemini-compat）。
- **never-empty-pool 护栏**（`leastUtilizedOpenAIAccount`）：这是对 Anthropic 孪生唯一必要的偏离 —— codex used% 就是上游自己的限额（非有冗余的 $ 业务预算），近 100% 排除可能把薄池掏空成更糟的「no available accounts」429。护栏回收 used% 最低（最有余量）的账号，保证**绝不比现状差**。
- **默认 ON**：**95% 起 sticky-only、99% 起避开**（`stickyThresholdDefault=0.95` + `reserveDefault=0.04`）。operator 可经 `OpsOpenAIAccountQuotaAutoPauseSettings` 覆写阈值 + **全局 kill-switch**，账号级 `Extra` 亦可覆写。既有二值 auto-pause 保持不动。

## 验证

- `go build ./...` ✅ · `go test -tags=unit ./...`（全后端）✅ · `golangci-lint run ./...` 0 issues ✅ · `scripts/preflight.sh`（含全部 sub2api 检查）PASS ✅
- 新增表驱动 + 集成测试：三态边界、fail-open（无信号/陈旧/已重置）、sticky vs load-balance、never-empty-pool、账号级 + 全局 disable、operator 覆写；并经 `SelectAccountWithScheduler` 覆盖 **legacy（prod 默认）与 advanced 两条路径** + never-empty-pool。两个 auto-pause 专项测试经 `openai_window_guard_disabled` 与本守卫隔离。
- 上线后用 `ops_error_logs` 中 recovered-200 行的 `jsonb_array_length(upstream_errors)` 均值，按 account 对照前后 hop 数。

## 规则合规（§5.y）

- 对上游形态文件（`openai_account_scheduler.go`、`openai_gateway_service.go`、`ops_settings*.go`）的改动均为**纯插入**（唯一一处会产生删除的改动已重写为插入式），新逻辑全在 `*_tk_*.go` 伴随文件。upstream-override 门禁：clean。
- 新增 load-bearing TK 面 → 向 `scripts/sentinels/gateway-tk.json` **新增 3 条 sentinel 锚点**（伴随文件 + 两个接线文件），对镜 `gateway_service_tk_sticky_saturation.go` 先例；registry-update 门禁经锚点满足（无需 body marker）。
- `no-web-impact`（纯后端）。合并方式：**Squash and merge**（TK 特性 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)