### PR TITLE
perf(admin): defer modal setup + shallowRef list to cut accounts/users first-paint

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 496,
-  "hash": "3c50424811cd09a0167d4a5ad951949dc995368d06786f3fcc54251a44607f75",
+  "hash": "8a32de0e97cc558ebbd5bc44582b67665402558957fffb495fbfe866e59d5e77",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 496,
-  "hash": "8a32de0e97cc558ebbd5bc44582b67665402558957fffb495fbfe866e59d5e77",
+  "hash": "861bf5230dd20849b092248c601fa2b772a29ace5466eb77f10f995e3097f592",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/e2e/admin-modals.e2e.ts
+++ b/frontend/e2e/admin-modals.e2e.ts
@@ -1,0 +1,106 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// Admin first-paint smoke — closes the validation gap for PR #900 (latch-lazy-mount of the
+// admin Accounts/Users modals). It asserts, against the REAL admin UI:
+//
+//   (1) DEFERRAL — on /admin/accounts first paint, the account Edit/Create modals' setup()
+//       does NOT run, proven by the absence of their setup request (GET
+//       /admin/settings/web-search-emulation, which on this page is fired ONLY by those two
+//       modals). This is the headline Phase A win and is selector-free / deterministic.
+//   (2) LATCH MOUNTS ON DEMAND — clicking a trigger mounts the modal (role="dialog" appears)
+//       and closes cleanly. Edit additionally proves DEFERRAL-NOT-REMOVAL: web-search-emulation
+//       fires only AFTER the modal opens.
+//   (3) Users modals mount on demand the same way.
+//
+// Run like studio.e2e.ts: against a locally deployed Stage0 stack (E2E_BASE_URL or
+// localhost:8080) with an admin login and ≥1 account/user seeded. Not wired into CI (needs a
+// live stack). The 28 modals all share the identical `v-if="lazyMount(key, showX)"` pattern, so
+// Edit/Import/Create here exercise the mechanism for all; extend the per-trigger checks by
+// giving more triggers a data-testid.
+
+const EMAIL = process.env.E2E_EMAIL || 'admin@tokenkey.local'
+const PASS = process.env.E2E_PASSWORD || 'Admin12345!'
+
+const WEB_SEARCH_EMULATION = /\/admin\/settings\/web-search-emulation\b/
+
+async function login(page: Page): Promise<void> {
+  await page.goto('/login')
+  await page.locator('input[type=email]').first().fill(EMAIL)
+  await page.locator('input[type=password]').first().fill(PASS)
+  await page.locator('button[type=submit]').first().click()
+  await page.waitForURL((u) => !u.pathname.includes('/login'), { timeout: 20_000 })
+}
+
+// Collect every request URL from now on; returns a live array + a helper.
+function recordRequests(page: Page): { urls: string[]; seen: (re: RegExp) => boolean } {
+  const urls: string[] = []
+  page.on('request', (r) => urls.push(r.url()))
+  return { urls, seen: (re: RegExp) => urls.some((u) => re.test(u)) }
+}
+
+const dialog = (page: Page) => page.locator('[role="dialog"]')
+
+async function closeDialog(page: Page): Promise<void> {
+  await page.keyboard.press('Escape')
+  await expect(dialog(page)).toHaveCount(0, { timeout: 5_000 })
+}
+
+test('accounts first paint defers account-modal setup (no web-search-emulation, no dialog)', async ({ page }) => {
+  await login(page)
+  const rec = recordRequests(page)
+  await page.goto('/admin/accounts')
+  await page.waitForLoadState('networkidle')
+
+  // No modal is mounted on first paint…
+  await expect(dialog(page)).toHaveCount(0)
+  // …and the Edit/Create modals' setup request was NOT fired (their setup() never ran).
+  expect(rec.seen(WEB_SEARCH_EMULATION), 'web-search-emulation must NOT fire before any modal opens').toBe(false)
+  await page.screenshot({ path: 'e2e/artifacts/admin-accounts-first-paint.png', fullPage: true })
+})
+
+test('accounts modals mount on demand via the latch (Import; Edit fires setup only on open)', async ({ page }) => {
+  await login(page)
+  const rec = recordRequests(page)
+  await page.goto('/admin/accounts')
+  await page.waitForLoadState('networkidle')
+
+  // Import is a toolbar modal (no row needed): clicking mounts it on demand.
+  await page.getByTestId('account-import-btn').click()
+  await expect(dialog(page)).toBeVisible({ timeout: 10_000 })
+  await closeDialog(page)
+
+  // Edit is the heavy modal whose setup() fetches web-search-emulation. It needs a row.
+  const rows = page.locator('table tbody tr')
+  if ((await rows.count()) === 0) {
+    console.warn('[admin-modals] no account rows seeded — Edit-open check skipped')
+    return
+  }
+  expect(rec.seen(WEB_SEARCH_EMULATION), 'still deferred before opening Edit').toBe(false)
+  await page.getByTestId('account-edit-btn').first().click()
+  await expect(dialog(page)).toBeVisible({ timeout: 10_000 })
+  // Deferral-not-removal: the setup request fires now that the modal mounted.
+  await expect.poll(() => rec.seen(WEB_SEARCH_EMULATION), { timeout: 10_000 }).toBe(true)
+  await page.screenshot({ path: 'e2e/artifacts/admin-accounts-edit-open.png', fullPage: true })
+  await closeDialog(page)
+})
+
+test('users modals mount on demand via the latch (Create; Edit if rows seeded)', async ({ page }) => {
+  await login(page)
+  await page.goto('/admin/users')
+  await page.waitForLoadState('networkidle')
+  await expect(dialog(page)).toHaveCount(0)
+
+  await page.getByTestId('user-create-btn').click()
+  await expect(dialog(page)).toBeVisible({ timeout: 10_000 })
+  await closeDialog(page)
+
+  const rows = page.locator('table tbody tr')
+  if ((await rows.count()) === 0) {
+    console.warn('[admin-modals] no user rows seeded — Edit-open check skipped')
+    return
+  }
+  await page.getByTestId('user-edit-btn').first().click()
+  await expect(dialog(page)).toBeVisible({ timeout: 10_000 })
+  await page.screenshot({ path: 'e2e/artifacts/admin-users-edit-open.png', fullPage: true })
+  await closeDialog(page)
+})

--- a/frontend/e2e/admin-modals.e2e.ts
+++ b/frontend/e2e/admin-modals.e2e.ts
@@ -41,7 +41,15 @@ function recordRequests(page: Page): { urls: string[]; seen: (re: RegExp) => boo
 const dialog = (page: Page) => page.locator('[role="dialog"]')
 
 async function closeDialog(page: Page): Promise<void> {
-  await page.keyboard.press('Escape')
+  // BaseDialog's header button (aria-label="Close modal") deterministically emits close.
+  // Fall back to Escape (closeOnEscape default) for any modal without the X.
+  const x = page.locator('[role="dialog"] button[aria-label="Close modal"]').last()
+  if (await x.count()) {
+    await x.click({ timeout: 5_000 }).catch(() => {})
+  }
+  if ((await dialog(page).count()) > 0) {
+    await page.keyboard.press('Escape')
+  }
   await expect(dialog(page)).toHaveCount(0, { timeout: 5_000 })
 }
 
@@ -69,14 +77,15 @@ test('accounts modals mount on demand via the latch (Import; Edit fires setup on
   await expect(dialog(page)).toBeVisible({ timeout: 10_000 })
   await closeDialog(page)
 
-  // Edit is the heavy modal whose setup() fetches web-search-emulation. It needs a row.
-  const rows = page.locator('table tbody tr')
-  if ((await rows.count()) === 0) {
+  // Edit is the heavy modal whose setup() fetches web-search-emulation. It needs a real row;
+  // guard on the edit button itself (an empty-state table can still render a <tr>).
+  const editBtn = page.getByTestId('account-edit-btn')
+  if ((await editBtn.count()) === 0) {
     console.warn('[admin-modals] no account rows seeded — Edit-open check skipped')
     return
   }
   expect(rec.seen(WEB_SEARCH_EMULATION), 'still deferred before opening Edit').toBe(false)
-  await page.getByTestId('account-edit-btn').first().click()
+  await editBtn.first().click()
   await expect(dialog(page)).toBeVisible({ timeout: 10_000 })
   // Deferral-not-removal: the setup request fires now that the modal mounted.
   await expect.poll(() => rec.seen(WEB_SEARCH_EMULATION), { timeout: 10_000 }).toBe(true)
@@ -94,12 +103,12 @@ test('users modals mount on demand via the latch (Create; Edit if rows seeded)',
   await expect(dialog(page)).toBeVisible({ timeout: 10_000 })
   await closeDialog(page)
 
-  const rows = page.locator('table tbody tr')
-  if ((await rows.count()) === 0) {
+  const userEditBtn = page.getByTestId('user-edit-btn')
+  if ((await userEditBtn.count()) === 0) {
     console.warn('[admin-modals] no user rows seeded — Edit-open check skipped')
     return
   }
-  await page.getByTestId('user-edit-btn').first().click()
+  await userEditBtn.first().click()
   await expect(dialog(page)).toBeVisible({ timeout: 10_000 })
   await page.screenshot({ path: 'e2e/artifacts/admin-users-edit-open.png', fullPage: true })
   await closeDialog(page)

--- a/frontend/src/composables/__tests__/useTableLoader.spec.ts
+++ b/frontend/src/composables/__tests__/useTableLoader.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { watch, nextTick } from 'vue'
 import { useTableLoader } from '@/composables/useTableLoader'
 
 // Mock @vueuse/core 的 useDebounceFn
@@ -246,6 +247,47 @@ describe('useTableLoader', () => {
 
       // 不应抛出
       await load()
+    })
+  })
+
+  // --- shallowRef 语义（perf:消除列表深代理）---
+  describe('shallowRef 列表语义', () => {
+    it('整体替换数组（load / setItems）会触发响应', async () => {
+      const fetchFn = createMockFetchFn([{ id: 1 }], 1, 1)
+      const { items, load, setItems } = useTableLoader<{ id: number }, any>({ fetchFn })
+
+      const seen: number[] = []
+      watch(items, (v) => seen.push(v.length))
+
+      await load()
+      await nextTick()
+      expect(items.value).toHaveLength(1)
+      expect(seen).toContain(1) // load 的整体替换触发了 watcher
+
+      setItems([{ id: 2 }, { id: 3 }])
+      await nextTick()
+      expect(items.value).toHaveLength(2)
+      expect(seen).toContain(2) // setItems 的整体替换也触发
+    })
+
+    it('in-place 改行不触发，refreshItems() 逃生口才触发（shallow 契约）', async () => {
+      const fetchFn = createMockFetchFn([{ id: 1, name: 'a' }], 1, 1)
+      const { items, load, refreshItems } = useTableLoader<{ id: number; name: string }, any>({ fetchFn })
+      await load()
+
+      let fires = 0
+      watch(items, () => { fires++ })
+
+      // 直接改嵌套字段:shallowRef 不追踪 → watcher 不触发
+      items.value[0].name = 'b'
+      await nextTick()
+      expect(items.value[0].name).toBe('b')
+      expect(fires).toBe(0)
+
+      // 逃生口:显式触发后 watcher 才响应
+      refreshItems()
+      await nextTick()
+      expect(fires).toBe(1)
     })
   })
 })

--- a/frontend/src/composables/useTableLoader.ts
+++ b/frontend/src/composables/useTableLoader.ts
@@ -1,4 +1,4 @@
-import { ref, reactive, onUnmounted, toRaw } from 'vue'
+import { ref, shallowRef, triggerRef, reactive, onUnmounted, toRaw } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import type { BasePaginationResponse, FetchOptions } from '@/types'
 import { getPersistedPageSize, setPersistedPageSize } from './usePersistedPageSize'
@@ -24,7 +24,12 @@ interface TableLoaderOptions<T, P> {
 export function useTableLoader<T, P extends Record<string, any>>(options: TableLoaderOptions<T, P>) {
   const { fetchFn, initialParams, pageSize, debounceMs = 300 } = options
 
-  const items = ref<T[]>([])
+  // shallowRef (not ref): list rows are display data assigned wholesale (new array identity)
+  // on every load, and per-row derived data lives in id-keyed side-maps — never mutated in
+  // place — so deep reactivity is pure cost (proxying ~pageSize × dozens-of-fields synchronously
+  // before render). The canonical update is replace-the-array (load / setItems). If a caller
+  // ever must mutate a row in place, it MUST call refreshItems() so consumers re-render.
+  const items = shallowRef<T[]>([])
   const loading = ref(false)
   const params = reactive<P>({ ...(initialParams || {}) } as P)
   const pagination = reactive<PaginationState>({
@@ -76,6 +81,16 @@ export function useTableLoader<T, P extends Record<string, any>>(options: TableL
     return load()
   }
 
+  // Canonical row update: replace the array (new identity → shallowRef reactivity fires).
+  const setItems = (next: T[]) => {
+    items.value = next
+  }
+  // Escape hatch for the rare in-place mutation of an existing row (shallowRef does not
+  // track nested writes): call after mutating so consumers re-render.
+  const refreshItems = () => {
+    triggerRef(items)
+  }
+
   const debouncedReload = useDebounceFn(reload, debounceMs)
 
   const handlePageChange = (page: number) => {
@@ -103,6 +118,8 @@ export function useTableLoader<T, P extends Record<string, any>>(options: TableL
     pagination,
     load,
     reload,
+    setItems,
+    refreshItems,
     debouncedReload,
     handlePageChange,
     handlePageSizeChange

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -401,14 +401,15 @@
       </template>
       <template #pagination><Pagination v-if="pagination.total > 0" :page="pagination.page" :total="pagination.total" :page-size="pagination.page_size" @update:page="handlePageChange" @update:pageSize="handlePageSizeChange" /></template>
     </TablePageLayout>
-    <CreateAccountModal :show="showCreate" :proxies="proxies" :groups="groups" @close="showCreate = false" @created="reload" />
-    <EditAccountModal :show="showEdit" :account="edAcc" :proxies="proxies" :groups="groups" @close="showEdit = false" @updated="handleAccountUpdated" />
-    <ReAuthAccountModal :show="showReAuth" :account="reAuthAcc" @close="closeReAuthModal" @reauthorized="handleAccountUpdated" />
-    <AccountTestModal :show="showTest" :account="testingAcc" @close="closeTestModal" />
-    <AccountStatsModal :show="showStats" :account="statsAcc" @close="closeStatsModal" />
-    <ScheduledTestsPanel :show="showSchedulePanel" :account-id="scheduleAcc?.id ?? null" :model-options="scheduleModelOptions" @close="closeSchedulePanel" />
-    <AccountActionMenu :show="menu.show" :account="menu.acc" :position="menu.pos" @close="menu.show = false" @test="handleTest" @stats="handleViewStats" @schedule="handleSchedule" @reauth="handleReAuth" @refresh-token="handleRefresh" @recover-state="handleRecoverState" @reset-quota="handleResetQuota" @set-privacy="handleSetPrivacy" @set-tier="tierCtl.open" />
+    <CreateAccountModal v-if="lazyMount('create', showCreate)" :show="showCreate" :proxies="proxies" :groups="groups" @close="showCreate = false" @created="reload" />
+    <EditAccountModal v-if="lazyMount('edit', showEdit)" :show="showEdit" :account="edAcc" :proxies="proxies" :groups="groups" @close="showEdit = false" @updated="handleAccountUpdated" />
+    <ReAuthAccountModal v-if="lazyMount('reauth', showReAuth)" :show="showReAuth" :account="reAuthAcc" @close="closeReAuthModal" @reauthorized="handleAccountUpdated" />
+    <AccountTestModal v-if="lazyMount('test', showTest)" :show="showTest" :account="testingAcc" @close="closeTestModal" />
+    <AccountStatsModal v-if="lazyMount('stats', showStats)" :show="showStats" :account="statsAcc" @close="closeStatsModal" />
+    <ScheduledTestsPanel v-if="lazyMount('schedule', showSchedulePanel)" :show="showSchedulePanel" :account-id="scheduleAcc?.id ?? null" :model-options="scheduleModelOptions" @close="closeSchedulePanel" />
+    <AccountActionMenu v-if="lazyMount('menu', menu.show)" :show="menu.show" :account="menu.acc" :position="menu.pos" @close="menu.show = false" @test="handleTest" @stats="handleViewStats" @schedule="handleSchedule" @reauth="handleReAuth" @refresh-token="handleRefresh" @recover-state="handleRecoverState" @reset-quota="handleResetQuota" @set-privacy="handleSetPrivacy" @set-tier="tierCtl.open" />
     <AccountTierModal
+      v-if="lazyMount('tier', tierCtl.show.value)"
       :show="tierCtl.show.value"
       :account="tierCtl.target.value"
       :model-value="tierCtl.selectedTier.value"
@@ -418,9 +419,10 @@
       @apply="tierCtl.apply"
       @close="tierCtl.close"
     />
-    <SyncFromCrsModal :show="showSync" @close="showSync = false" @synced="reload" />
-    <ImportDataModal :show="showImportData" @close="showImportData = false" @imported="handleDataImported" />
+    <SyncFromCrsModal v-if="lazyMount('sync', showSync)" :show="showSync" @close="showSync = false" @synced="reload" />
+    <ImportDataModal v-if="lazyMount('import', showImportData)" :show="showImportData" @close="showImportData = false" @imported="handleDataImported" />
     <BulkEditAccountModal
+      v-if="lazyMount('bulk', showBulkEdit)"
       :show="showBulkEdit"
       :account-ids="selIds"
       :selected-platforms="selPlatforms"
@@ -431,17 +433,17 @@
       @close="showBulkEdit = false"
       @updated="handleBulkUpdated"
     />
-    <TempUnschedStatusModal :show="showTempUnsched" :account="tempUnschedAcc" @close="showTempUnsched = false" @reset="handleTempUnschedReset" />
-    <ConfirmDialog :show="showDeleteDialog" :title="t('admin.accounts.deleteAccount')" :message="t('admin.accounts.deleteConfirm', { name: deletingAcc?.name })" :confirm-text="t('common.delete')" :cancel-text="t('common.cancel')" :danger="true" @confirm="confirmDelete" @cancel="showDeleteDialog = false" />
-    <ConfirmDialog :show="showExportDataDialog" :title="t('admin.accounts.dataExport')" :message="t('admin.accounts.dataExportConfirmMessage')" :confirm-text="t('admin.accounts.dataExportConfirm')" :cancel-text="t('common.cancel')" @confirm="handleExportData" @cancel="showExportDataDialog = false">
+    <TempUnschedStatusModal v-if="lazyMount('tempUnsched', showTempUnsched)" :show="showTempUnsched" :account="tempUnschedAcc" @close="showTempUnsched = false" @reset="handleTempUnschedReset" />
+    <ConfirmDialog v-if="lazyMount('delete', showDeleteDialog)" :show="showDeleteDialog" :title="t('admin.accounts.deleteAccount')" :message="t('admin.accounts.deleteConfirm', { name: deletingAcc?.name })" :confirm-text="t('common.delete')" :cancel-text="t('common.cancel')" :danger="true" @confirm="confirmDelete" @cancel="showDeleteDialog = false" />
+    <ConfirmDialog v-if="lazyMount('exportData', showExportDataDialog)" :show="showExportDataDialog" :title="t('admin.accounts.dataExport')" :message="t('admin.accounts.dataExportConfirmMessage')" :confirm-text="t('admin.accounts.dataExportConfirm')" :cancel-text="t('common.cancel')" @confirm="handleExportData" @cancel="showExportDataDialog = false">
       <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
         <input type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500" v-model="includeProxyOnExport" />
         <span>{{ t('admin.accounts.dataExportIncludeProxies') }}</span>
       </label>
     </ConfirmDialog>
-    <ErrorPassthroughRulesModal :show="showErrorPassthrough" @close="showErrorPassthrough = false" />
-    <TLSFingerprintProfilesModal :show="showTLSFingerprintProfiles" @close="showTLSFingerprintProfiles = false" />
-    <TierTemplatesModal :show="showTierTemplates" @close="showTierTemplates = false" />
+    <ErrorPassthroughRulesModal v-if="lazyMount('errPass', showErrorPassthrough)" :show="showErrorPassthrough" @close="showErrorPassthrough = false" />
+    <TLSFingerprintProfilesModal v-if="lazyMount('tls', showTLSFingerprintProfiles)" :show="showTLSFingerprintProfiles" @close="showTLSFingerprintProfiles = false" />
+    <TierTemplatesModal v-if="lazyMount('tierTpl', showTierTemplates)" :show="showTierTemplates" @close="showTierTemplates = false" />
   </AppLayout>
 </template>
 
@@ -568,6 +570,16 @@ const statsAcc = ref<Account | null>(null)
 const showSchedulePanel = ref(false)
 const scheduleAcc = ref<Account | null>(null)
 const scheduleModelOptions = ref<SelectOption[]>([])
+
+// Lazy-mount latch for action-triggered overlays (modals/drawers/menus): a modal mounts
+// the first time its show flag goes true and then stays mounted, so first paint runs none
+// of their setup() (some, e.g. Edit/Create, fire admin API calls at setup) while open/close
+// transitions and reopen behavior stay identical to always-mounted. Keyed by a stable string.
+const everOpened = reactive(new Set<string>())
+const lazyMount = (key: string, show: boolean): boolean => {
+  if (show) everOpened.add(key)
+  return everOpened.has(key)
+}
 const togglingSchedulable = ref<number | null>(null)
 const menu = reactive<{show:boolean, acc:Account|null, pos:{top:number, left:number}|null}>({ show: false, acc: null, pos: null })
 const exportingData = ref(false)

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -139,7 +139,7 @@
               </div>
             </template>
             <template #beforeCreate>
-              <button @click="showImportData = true" class="btn btn-secondary">
+              <button data-testid="account-import-btn" @click="showImportData = true" class="btn btn-secondary">
                 {{ t('admin.accounts.dataImport') }}
               </button>
               <button @click="openExportDataDialog" class="btn btn-secondary">
@@ -382,7 +382,7 @@
           </template>
           <template #cell-actions="{ row }">
             <div class="flex items-center gap-1">
-              <button @click="handleEdit(row)" class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-primary-600 dark:hover:bg-dark-700 dark:hover:text-primary-400">
+              <button data-testid="account-edit-btn" @click="handleEdit(row)" class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-primary-600 dark:hover:bg-dark-700 dark:hover:text-primary-400">
                 <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
                 <span class="text-xs">{{ t('common.edit') }}</span>
               </button>

--- a/frontend/src/views/admin/UsersView.vue
+++ b/frontend/src/views/admin/UsersView.vue
@@ -249,7 +249,7 @@
             </button>
 
             <!-- Create User Button (full width on mobile, auto width on desktop) -->
-            <button @click="showCreateModal = true" class="btn btn-primary flex-1 md:flex-initial">
+            <button data-testid="user-create-btn" @click="showCreateModal = true" class="btn btn-primary flex-1 md:flex-initial">
               <Icon name="plus" size="md" class="mr-2" />
               {{ t('admin.users.createUser') }}
             </button>
@@ -592,6 +592,7 @@
             <div class="flex items-center gap-1">
               <!-- Edit Button -->
               <button
+                data-testid="user-edit-btn"
                 @click="handleEdit(row)"
                 class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-primary-600 dark:hover:bg-dark-700 dark:hover:text-primary-400"
               >

--- a/frontend/src/views/admin/UsersView.vue
+++ b/frontend/src/views/admin/UsersView.vue
@@ -747,27 +747,28 @@
       </div>
     </Teleport>
 
-    <ConfirmDialog :show="showDeleteDialog" :title="t('admin.users.deleteUser')" :message="t('admin.users.deleteConfirm', { email: deletingUser?.email })" :danger="true" @confirm="confirmDelete" @cancel="showDeleteDialog = false" />
-    <UserCreateModal :show="showCreateModal" @close="showCreateModal = false" @success="loadUsers" />
-    <InviteTrialModal :show="showInviteTrialModal" :seed="inviteSeed" @close="showInviteTrialModal = false" @success="loadUsers" />
-    <UserEditModal :show="showEditModal" :user="editingUser" @close="closeEditModal" @success="loadUsers" />
+    <ConfirmDialog v-if="lazyMount('delete', showDeleteDialog)" :show="showDeleteDialog" :title="t('admin.users.deleteUser')" :message="t('admin.users.deleteConfirm', { email: deletingUser?.email })" :danger="true" @confirm="confirmDelete" @cancel="showDeleteDialog = false" />
+    <UserCreateModal v-if="lazyMount('create', showCreateModal)" :show="showCreateModal" @close="showCreateModal = false" @success="loadUsers" />
+    <InviteTrialModal v-if="lazyMount('invite', showInviteTrialModal)" :show="showInviteTrialModal" :seed="inviteSeed" @close="showInviteTrialModal = false" @success="loadUsers" />
+    <UserEditModal v-if="lazyMount('edit', showEditModal)" :show="showEditModal" :user="editingUser" @close="closeEditModal" @success="loadUsers" />
     <UserPlatformQuotaModal
+      v-if="lazyMount('platformQuota', showPlatformQuotaModal)"
       :show="showPlatformQuotaModal"
       :user="platformQuotaUser"
       @close="closePlatformQuotaModal"
       @success="loadUsers"
     />
-    <UserApiKeysModal :show="showApiKeysModal" :user="viewingUser" @close="closeApiKeysModal" />
-    <UserAllowedGroupsModal :show="showAllowedGroupsModal" :user="allowedGroupsUser" @close="closeAllowedGroupsModal" @success="loadUsers" />
-    <UserBalanceModal :show="showBalanceModal" :user="balanceUser" :operation="balanceOperation" @close="closeBalanceModal" @success="loadUsers" />
-    <UserBalanceHistoryModal :show="showBalanceHistoryModal" :user="balanceHistoryUser" @close="closeBalanceHistoryModal" @deposit="handleDepositFromHistory" @withdraw="handleWithdrawFromHistory" />
-    <GroupReplaceModal :show="showGroupReplaceModal" :user="groupReplaceUser" :old-group="groupReplaceOldGroup" :all-groups="allGroups" @close="closeGroupReplaceModal" @success="loadUsers" />
-    <UserAttributesConfigModal :show="showAttributesModal" @close="handleAttributesModalClose" />
+    <UserApiKeysModal v-if="lazyMount('apiKeys', showApiKeysModal)" :show="showApiKeysModal" :user="viewingUser" @close="closeApiKeysModal" />
+    <UserAllowedGroupsModal v-if="lazyMount('allowedGroups', showAllowedGroupsModal)" :show="showAllowedGroupsModal" :user="allowedGroupsUser" @close="closeAllowedGroupsModal" @success="loadUsers" />
+    <UserBalanceModal v-if="lazyMount('balance', showBalanceModal)" :show="showBalanceModal" :user="balanceUser" :operation="balanceOperation" @close="closeBalanceModal" @success="loadUsers" />
+    <UserBalanceHistoryModal v-if="lazyMount('balanceHistory', showBalanceHistoryModal)" :show="showBalanceHistoryModal" :user="balanceHistoryUser" @close="closeBalanceHistoryModal" @deposit="handleDepositFromHistory" @withdraw="handleWithdrawFromHistory" />
+    <GroupReplaceModal v-if="lazyMount('groupReplace', showGroupReplaceModal)" :show="showGroupReplaceModal" :user="groupReplaceUser" :old-group="groupReplaceOldGroup" :all-groups="allGroups" @close="closeGroupReplaceModal" @success="loadUsers" />
+    <UserAttributesConfigModal v-if="lazyMount('attributes', showAttributesModal)" :show="showAttributesModal" @close="handleAttributesModalClose" />
   </AppLayout>
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted, onUnmounted } from 'vue'
+import { ref, shallowRef, reactive, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
@@ -1013,7 +1014,10 @@ const columns = computed<Column[]>(() =>
   )
 )
 
-const users = ref<AdminUser[]>([])
+// shallowRef: the user list is replaced wholesale on every load (line ~1619) and all per-row
+// derived data (usage/attributes/quota) lives in id-keyed side-maps, never mutated in place —
+// so deep reactivity is pure cost. Any future in-place row edit must reassign users.value.
+const users = shallowRef<AdminUser[]>([])
 const loading = ref(false)
 const searchQuery = ref('')
 const USER_SORT_STORAGE_KEY = 'admin-users-table-sort'
@@ -1338,6 +1342,15 @@ const showApiKeysModal = ref(false)
 const showAttributesModal = ref(false)
 const showPlatformQuotaModal = ref(false)
 const editingUser = ref<AdminUser | null>(null)
+
+// Lazy-mount latch for action-triggered modals: a modal mounts the first time its show flag
+// goes true and then stays mounted, keeping first paint free of every modal's setup() while
+// open/close transitions and reopen behavior stay identical to always-mounted.
+const everOpened = reactive(new Set<string>())
+const lazyMount = (key: string, show: boolean): boolean => {
+  if (show) everOpened.add(key)
+  return everOpened.has(key)
+}
 const deletingUser = ref<AdminUser | null>(null)
 const viewingUser = ref<AdminUser | null>(null)
 const platformQuotaUser = ref<AdminUser | null>(null)


### PR DESCRIPTION
## 背景

原始诉求:prod admin UI「很多页面很慢很卡(accounts/users/dashboard)」。一路只读实测(SSM 直连 prod)定位:

- **后端已不慢**:accounts ~15ms、users ~13-23ms、dashboard 各 widget ~10-27ms 服务端耗时(#874 rollup + #877 LATERAL 已生效)。
- **bundle 不大**(~232KB gz 入口)、**DataTable 已虚拟化**、accounts 扇出已批量。
- 用户实测确认主页面「首屏到可交互**还明显卡**」→ 残留瓶颈在**前端视图渲染重量**。本 PR 修两条已确认的结构性根因(低风险、系统性)。

## 改动

### Phase A — modal latch 懒挂载
`AccountsView` 17 个、`UsersView` 11 个 action-triggered 浮层原本以 `:show` **无 v-if 全量挂载**,首屏即跑每个 `setup()`。新增 `lazyMount(key, show)`(首开才挂载、之后常驻):

- 首屏不再跑这 ~28 个 `setup()`——尤其 `EditAccountModal`/`CreateAccountModal` 在 setup 顶层**无条件发的 admin API**(`getWebSearchEmulationConfig` + `getSettings`)不再与列表请求争抢。
- `:show` 仍驱动 `BaseDialog` 内部开合过渡;**首开后行为与全量挂载完全一致**(保留关闭过渡、重开不重发 setup)。

### Phase B — 列表 shallowRef
共享 `useTableLoader` 的 `items` 改 `shallowRef`(+ 加性 `setItems`/`refreshItems` 逃生口),`UsersView` 的 `users` 改 `shallowRef`。审计确认两视图**所有 list 写入都是整数组替换**、per-row 派生数据(today-stats/usage/attributes/quota)都在**按 id 的 side-map**、**零 in-place 行改写** → 深响应式是纯成本(每次加载对 ~pageSize × 数十字段同步深代理后才渲染)。

## 验证

- `pnpm typecheck` / `pnpm lint:check` 全绿;`pnpm test` 相关 spec 22 passed(useTableLoader 增 shallowRef 响应 + 逃生口用例;AccountsView/UsersView 既有 memo spec 已覆盖「数组替换后仍响应」)。
- `pnpm build` 重生成 dist + frontend-source.json(已提交)。
- `scripts/preflight.sh` PASS。
- **Phase A 确定性验证(建议合并后做)**:用现有 Playwright harness(localhost:8080)抓 `/admin/accounts` trace,断言首屏(未开任何 modal 前)不再触发 `getWebSearchEmulationConfig`/`getSettings`(网络调用计数最干净)。Phase B 收益需 prod 形状数据,用 `performance.mark` 或实测前后对比。

## Markers

- **sentinel-registry-reviewed** —— `AccountsView.vue` 被 `scripts/sentinels/frontend-tk.json` 覆盖,本 PR 有删除行(modal 行 `:show=` → `v-if=...`)。已逐条复核:其锚点全是表格布局/wrap 策略/EdgeAccountPanelTk/notes/RPM memo,**均未触及**;latch 是加性行为,无 load-bearing 契约移除,无需新增锚点(preflight「all frontend TK sentinels intact」亦确认)。
- **upstream-touch-trivial** —— `useTableLoader.ts`(shallowRef 一行 + 加性 setItems/refreshItems)与 `UsersView.vue`(加性 lazyMount helper + modal v-if + users shallowRef)是加性 perf 优化、非 load-bearing 契约;未来 upstream 合并若触及会以**冲突**显现(非静默回退)且易复用,无 revert 风险需锚点。AccountsView 已被 frontend-tk.json 覆盖、自动通过。
- **no-web-impact: false** —— 本就是前端改动。

## 后续(不在本 PR)

- **AccountsView 路由 chunk 595KB(123KB gz)**:由静态导入的重 modal 主导(EditAccountModal ~2789 行、CreateAccountModal ~3619 行)。下一步用 `defineAsyncComponent` 把这些 modal 拆出 chunk(与 latch 协同:首开才 fetch),进一步砍该路由首屏 parse 成本。
- **dashboard/user-breakdown ~1.5s**:钻取子表走原始 30 天 usage_logs 聚合,未走 #874 rollup(独立后端小 PR)。
- **ops 分区 DEFAULT 兜底**:已上线 ops_system_logs/ops_error_logs 加 catch-all 防 cleanup tick 停摆丢日志(独立小 PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
