### PR TITLE
feat(openai-scheduler): retire codex auto-pause — window-sched guard is the single window mechanism

### DIFF
--- a/backend/internal/service/openai_account_scheduler_tk_autopause_retired.go
+++ b/backend/internal/service/openai_account_scheduler_tk_autopause_retired.go
@@ -1,0 +1,23 @@
+package service
+
+// tkOpenAIAutoPauseRetired reports whether the upstream codex usage-window
+// "auto-pause by quota" decision is retired.
+//
+// It is retired in favour of the window-sched tri-state guard
+// (openai_account_scheduler_tk_window_sched.go, PR #899), which is the single
+// outward window-avoidance mechanism for the OpenAI/GPT line. Auto-pause was a
+// binary hard-exclude on the SAME codex 5h/7d signal, so keeping both would mean
+// two overlapping percent-based knobs for operators to reason about.
+//
+// We DISABLE rather than delete (§5.x deletion discipline): shouldAutoPause
+// OpenAIAccountByQuota and its helpers are upstream-owned, so deleting them would
+// cause recurring merge conflicts and lose upstream tests. Crucially, the codex
+// signal CAPTURE those helpers share (resolveOpenAIQuotaUtilization,
+// codex_*_used_percent persistence) is left fully intact — the #899 window guard
+// depends on it. This gate only short-circuits the auto-pause DECISION, so any
+// leftover per-account / global auto_pause thresholds can no longer fire either.
+//
+// Implemented as a function (not a const/var) so the gated upstream body is never
+// flagged as unreachable/always-false by the linter, and so re-enabling auto-pause
+// later is a one-line change here.
+func tkOpenAIAutoPauseRetired() bool { return true }

--- a/backend/internal/service/openai_account_scheduler_tk_window_sched_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_window_sched_test.go
@@ -281,3 +281,25 @@ func TestSelectAccountWithScheduler_AdvancedWindowGuard_RoutesAwayFromHotAccount
 	require.NotNil(t, selection.Account)
 	require.Equal(t, int64(39002), selection.Account.ID, "advanced path: hot 99% account excluded from the weighted TopK pool")
 }
+
+// Retirement gate (#902): the upstream codex auto-pause decision is a permanent
+// no-op now that the window-sched tri-state guard is the single window mechanism.
+// Even an account well over a configured auto_pause threshold must NOT be paused.
+func TestShouldAutoPauseOpenAIAccountByQuota_Retired(t *testing.T) {
+	require.True(t, tkOpenAIAutoPauseRetired(), "retirement gate must be on")
+
+	acc := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"codex_5h_used_percent":   99.0,
+			"codex_usage_updated_at":  time.Now().Format(time.RFC3339),
+			"auto_pause_5h_threshold": 0.90, // would have paused pre-retirement
+		},
+	}
+	// Seed a non-zero global default too, to prove neither account-level nor global
+	// thresholds can revive auto-pause.
+	ctx := withOpenAIQuotaAutoPauseSettings(context.Background(), OpsOpenAIAccountQuotaAutoPauseSettings{DefaultThreshold5h: 0.90})
+	paused, _ := shouldAutoPauseOpenAIAccountByQuota(ctx, acc)
+	require.False(t, paused, "auto-pause is retired; it must never fire regardless of thresholds")
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1449,6 +1449,15 @@ func isOpenAIAccountEligibleForRequest(ctx context.Context, account *Account, re
 }
 
 func shouldAutoPauseOpenAIAccountByQuota(ctx context.Context, account *Account) (bool, openAIQuotaAutoPauseDecision) {
+	// TK (PR #899 follow-up): the upstream codex usage-window auto-pause is retired
+	// in favour of the window-sched tri-state guard, the single outward window
+	// mechanism. Short-circuited to a permanent no-op so any leftover thresholds
+	// cannot fire; upstream body below is retained (disabled, not deleted — §5.x)
+	// and the shared codex signal capture the new guard reads stays intact. See
+	// tkOpenAIAutoPauseRetired (openai_account_scheduler_tk_autopause_retired.go).
+	if tkOpenAIAutoPauseRetired() {
+		return false, openAIQuotaAutoPauseDecision{}
+	}
 	// Auto-pause keys off codex 5h/7d usage windows that only exist on `openai`
 	// accounts; this is a usage-window predicate, not a scheduling pool-membership
 	// filter, so newapi accounts are correctly skipped.

--- a/backend/internal/service/openai_ws_account_sticky_test.go
+++ b/backend/internal/service/openai_ws_account_sticky_test.go
@@ -48,9 +48,12 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_Hit(t *testing.T
 	}
 }
 
-func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_QuotaAutoPausedMiss(t *testing.T) {
+func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_WindowNotSchedulableMiss(t *testing.T) {
 	ctx := context.Background()
 	groupID := int64(23)
+	now := time.Now().Format(time.RFC3339)
+	// 99.5% used => NotSchedulable under the window-sched guard (default avoid edge 99%).
+	// The retired auto-pause used to gate this path; the tri-state guard now carries it.
 	account := Account{
 		ID:          77,
 		Platform:    PlatformOpenAI,
@@ -60,8 +63,8 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_QuotaAutoPausedM
 		Concurrency: 2,
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
-			"codex_5h_used_percent":                         96.0,
-			"auto_pause_5h_threshold":                       0.95,
+			"codex_5h_used_percent":                         99.5,
+			"codex_usage_updated_at":                        now,
 		},
 	}
 	cache := &stubGatewayCache{}
@@ -79,13 +82,52 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_QuotaAutoPausedM
 
 	selection, err := svc.SelectAccountByPreviousResponseID(ctx, &groupID, "resp_prev_quota", "gpt-5.1", nil, false)
 	require.NoError(t, err)
-	require.Nil(t, selection, "超过 5h 配额阈值的账号不应继续命中 previous_response_id 粘连")
+	require.Nil(t, selection, "窗口耗尽(NotSchedulable)的账号不应继续命中 previous_response_id 粘连")
 
-	// Auto-pause is transient, so the binding is preserved: the chain can resume on the
-	// same account once the quota window resets.
+	// Window pressure is transient, so the binding is preserved: the chain can resume on
+	// the same account once the usage window resets.
 	boundAccountID, getErr := store.GetResponseAccount(ctx, groupID, "resp_prev_quota")
 	require.NoError(t, getErr)
 	require.Equal(t, account.ID, boundAccountID)
+}
+
+// StickyOnly band (95%–99%): the prev-response chain is PRESERVED (the account
+// keeps serving its own chain under transient window pressure), unlike the
+// retired auto-pause which hard-excluded at the operator threshold.
+func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_WindowStickyOnlyKeepsChain(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(23)
+	now := time.Now().Format(time.RFC3339)
+	account := Account{
+		ID:          78,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 2,
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+			"codex_5h_used_percent":                         96.0,
+			"codex_usage_updated_at":                        now,
+		},
+	}
+	cache := &stubGatewayCache{}
+	store := NewOpenAIWSStateStore(cache)
+	cfg := newOpenAIWSV2TestConfig()
+	svc := &OpenAIGatewayService{
+		accountRepo:        stubOpenAIAccountRepo{accounts: []Account{account}},
+		cache:              cache,
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+		openaiWSStateStore: store,
+	}
+
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_prev_sticky", account.ID, time.Hour))
+
+	selection, err := svc.SelectAccountByPreviousResponseID(ctx, &groupID, "resp_prev_sticky", "gpt-5.1", nil, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection, "StickyOnly 区间(96%)的账号应继续服务自己的 previous_response_id 链")
+	require.Equal(t, account.ID, selection.Account.ID)
 }
 
 func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_RateLimitedMiss(t *testing.T) {

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -4311,12 +4311,22 @@ func (s *OpenAIGatewayService) selectAccountByPreviousResponseIDForCapability(
 		// keep the binding (transient) and fall through to normal scheduling.
 		return nil, nil
 	}
+	// TK (PR #899 follow-up): the window-sched tri-state guard replaces the retired
+	// auto-pause on this previous_response_id chain too, so the tri-state is the single
+	// window mechanism on every path auto-pause used to cover. isSticky=true: a
+	// StickyOnly account keeps serving its own chain (transient pressure), only a
+	// NotSchedulable account at its window cap yields. Binding preserved (NOT deleted)
+	// so the chain resumes after the window resets.
+	if !s.isAccountSchedulableForOpenAIWindow(ctx, account, true) {
+		return nil, nil
+	}
 	// Quota auto-pause must also gate the previous_response_id sticky path; otherwise an
 	// account over its 5h/7d threshold keeps serving the same response chain even though
 	// normal scheduling skips it. Pause is transient, so fall through to normal scheduling
 	// WITHOUT deleting the binding (the window may reset before the next turn). This early
 	// return also pre-empts the DB-recheck below, which would otherwise treat the paused
-	// account as gone and clear the sticky binding.
+	// account as gone and clear the sticky binding. (Retired in #899 follow-up — the
+	// tri-state guard above now carries this; kept as a no-op for §5.x merge-friendliness.)
 	if paused, _ := shouldAutoPauseOpenAIAccountByQuota(ctx, account); paused {
 		return nil, nil
 	}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 496,
-  "hash": "3c50424811cd09a0167d4a5ad951949dc995368d06786f3fcc54251a44607f75",
+  "hash": "07b7b40eade863866d7025c114f438cfd1679f1f3b5c47489e2a9b5139ab60a1",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1910,8 +1910,14 @@
         </div>
       </div>
 
+      <!-- TK (PR #899 follow-up): the codex usage-window auto-pause is retired — the
+           window-sched tri-state guard is now the single window-avoidance mechanism
+           (backend defaults 95% sticky-only / 99% avoid, with a global kill-switch and
+           per-account override). These per-account 5h/7d threshold controls are hidden;
+           the v-model refs + save path are kept so any previously-stored thresholds
+           round-trip harmlessly. Re-enable by dropping the `false &&`. -->
       <div
-        v-if="account?.platform === 'openai'"
+        v-if="false && account?.platform === 'openai'"
         class="border-t border-gray-200 pt-4 dark:border-dark-600 space-y-4"
       >
         <div class="space-y-2">

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -339,48 +339,9 @@ describe('EditAccountModal', () => {
     ])
   })
 
-	it('submits OpenAI quota auto-pause thresholds in extra', async () => {
-	  const account = buildAccount()
-	  account.extra = {
-		auto_pause_5h_threshold: 0.9,
-		auto_pause_7d_threshold: 0.8
-	  }
-	  updateAccountMock.mockReset()
-	  checkMixedChannelRiskMock.mockReset()
-	  checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
-	  updateAccountMock.mockResolvedValue(account)
-
-	  const wrapper = mountModal(account)
-
-	  await wrapper.get('[data-testid="auto-pause-5h-threshold"]').setValue('95')
-	  await wrapper.get('[data-testid="auto-pause-7d-threshold"]').setValue('96')
-	  await wrapper.get('form#edit-account-form').trigger('submit.prevent')
-
-	  expect(updateAccountMock).toHaveBeenCalledTimes(1)
-	  expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.auto_pause_5h_threshold).toBe(0.95)
-	  expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.auto_pause_7d_threshold).toBe(0.96)
-	})
-
-	it('submits OpenAI quota auto-pause disable flag in extra', async () => {
-	  // Toggling the per-account disable flag must persist as auto_pause_5h_disabled
-	  // so an admin can exempt one account from auto-pause even when a global default
-	  // threshold is configured (otherwise leaving the threshold blank would silently
-	  // fall back to the global default).
-	  const account = buildAccount()
-	  updateAccountMock.mockReset()
-	  checkMixedChannelRiskMock.mockReset()
-	  checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
-	  updateAccountMock.mockResolvedValue(account)
-
-	  const wrapper = mountModal(account)
-
-	  await wrapper.get('[data-testid="auto-pause-5h-disabled"]').trigger('click')
-	  await wrapper.get('form#edit-account-form').trigger('submit.prevent')
-
-	  expect(updateAccountMock).toHaveBeenCalledTimes(1)
-	  expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.auto_pause_5h_disabled).toBe(true)
-	  expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.auto_pause_7d_disabled).toBeUndefined()
-	})
+	// NOTE: the per-account OpenAI quota auto-pause threshold/disable controls were
+	// retired in the PR #899 follow-up (superseded by the window-sched tri-state guard)
+	// and their UI is hidden, so the tests that drove those controls were removed.
 
   it('keeps at least one OpenAI APIKey endpoint capability selected', async () => {
     const account = buildAccount()

--- a/frontend/src/views/admin/ops/components/OpsSettingsDialog.vue
+++ b/frontend/src/views/admin/ops/components/OpsSettingsDialog.vue
@@ -525,8 +525,10 @@ async function saveAllSettings() {
             </div>
           </div>
 
-          <!-- OpenAI 账号配额自动暂停（全局默认阈值） -->
-          <div class="space-y-3">
+          <!-- TK (PR #899 follow-up): OpenAI 账号配额自动暂停已退役 —— 由 window-sched
+               三态守卫统一承载（默认 95% 仅粘性 / 99% 避开，含全局开关与账号级覆写）。
+               全局阈值控件隐藏（refs/保存保留以便旧值无害回传）。去掉 v-if="false" 可恢复。 -->
+          <div v-if="false" class="space-y-3">
             <h5 class="text-xs font-semibold text-gray-700 dark:text-gray-300">{{ t('admin.ops.settings.openaiQuotaAutoPause') }}</h5>
             <p class="text-xs text-gray-500">{{ t('admin.ops.settings.openaiQuotaAutoPauseHint') }}</p>
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3130,6 +3130,27 @@
         "leastUtilizedOpenAIAccount(windowDropped, time.Now())"
       ],
       "rationale": "Legacy + priority/LRU wiring of the OpenAI window guard across the remaining candidate-filter selection paths: selectAccountWithLoadAwareness Layer-2 (isSticky=false) + Layer-1 sticky (isSticky=true, marks clearSticky so the hit falls through without deleting the binding), selectBestAccount (isSticky=false; used by count_tokens failover + gemini-compat) and tryStickySessionHit (isSticky=true). selectAccountWithLoadAwareness is the DEFAULT prod path (advanced scheduler defaults off), so this is the load-bearing wiring for the reported incident; never-empty-pool fallback present here too. Anchors the hooks so an upstream merge cannot silently drop the guard call and revert the GPT line to window-blind selection."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler_tk_autopause_retired.go",
+      "must_contain": [
+        "func tkOpenAIAutoPauseRetired() bool { return true }"
+      ],
+      "rationale": "PR #902: retires the upstream codex usage-window auto-pause in favour of the window-sched tri-state guard (the single window mechanism). This gate disables (does NOT delete — §5.x) shouldAutoPauseOpenAIAccountByQuota by short-circuiting it; the upstream code + the shared codex signal capture the #899 guard reads stay intact. Anchors the gate so an upstream merge cannot silently flip auto-pause back on."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "if tkOpenAIAutoPauseRetired() {"
+      ],
+      "rationale": "PR #902 injection: the retirement short-circuit at the top of shouldAutoPauseOpenAIAccountByQuota. Pure-insertion guard returning a permanent no-op. If an upstream merge drops this one line, auto-pause silently revives and re-overlaps the window-sched guard — a silent regression. Anchor pins the injection."
+    },
+    {
+      "path": "backend/internal/service/openai_ws_forwarder.go",
+      "must_contain": [
+        "if !s.isAccountSchedulableForOpenAIWindow(ctx, account, true) {"
+      ],
+      "rationale": "PR #902 coverage parity: the window-sched tri-state guard now gates the previous_response_id chain (SelectAccountByPreviousResponseID) too, replacing the retired auto-pause that used to gate this path. isSticky=true keeps a StickyOnly account's chain, only a NotSchedulable account yields. If an upstream merge drops this line the prev-response path loses window coverage silently. Anchor pins the injection."
     }
   ]
 }


### PR DESCRIPTION
## 背景

PR #899 加的 window-sched 三态守卫（95% 仅粘性 / 99% 避开）与**上游自带的** codex 用量窗口「auto-pause by quota」重叠——两套都读同一个 codex used% 信号、都做「按额度避让」。本 PR 退役 auto-pause，让三态守卫成为 OpenAI/GPT 线**唯一对外的**窗口避让机制。

## 为什么是「禁用」而非「删除」（§5.x）

auto-pause（`shouldAutoPauseOpenAIAccountByQuota`、`OpsOpenAIAccountQuotaAutoPause`、连同 codex 信号采集）**是上游 Wei-Shaw/sub2api 的代码**。删除会带来永久合并冲突 + 丢上游测试，且**三态守卫依赖同一套信号采集**（`resolveOpenAIQuotaUtilization` / `codex_*_used_percent`）。所以只**短路决策、保留代码**。

## 改动

- **后端**：纯插入的 TK 门（`tkOpenAIAutoPauseRetired`）把 `shouldAutoPauseOpenAIAccountByQuota` 短路成永久 no-op，顺带让任何遗留的 per-account/global 阈值也不再触发。上游函数体 + 共享的 codex 信号采集**原样保留可编译**（merge-friendly）。
- **覆盖等价（关键）**：auto-pause 还覆盖了 `previous_response_id` 续链路径（`openai_ws_forwarder.go`）——三态守卫现也接入该路径（`isSticky=true`：StickyOnly 账号继续服务自己的链，仅 NotSchedulable 账号让位），使三态**完整接管** auto-pause 的全部覆盖面（其余 fresh-recheck 站点操作的是已过滤候选，无缺口）。
- **前端**：隐藏账号弹窗（EditAccountModal）与 Ops 设置（OpsSettingsDialog）里的配额 auto-pause 阈值控件（v-model refs/保存保留以便旧值无害回传）。**不相关的「过期自动暂停」开关原样不动**。

## 验证

- `go build ./...` ✅ · `go test -tags=unit ./...`（全后端）✅ · `make test-frontend`（CI critical vitest 7 文件 91 测试）✅ · `pnpm typecheck` + `lint:check` ✅ · `scripts/preflight.sh`（含全部 sub2api 检查）PASS ✅ · 前端 dist manifest 已重建（`frontend-source.json`）。
- 测试：prev-response 配额未命中改为断言窗口守卫（NotSchedulable 未命中 + StickyOnly 续链保留两条）；新增退役门的**直接 no-op 断言**（99% + 账号级/全局阈值都设了仍不暂停）；退役 UI 的账号弹窗 spec 已移除。
- 注：`EditAccountModal.spec.ts` 另有 2 个 **既存红**（`codex-image-bridge-enabled` / model-mappings，与本 PR 无关，已在干净 origin/main 上复现），不在 CI critical 子集内。

## 规则合规

- 上游形态文件（`openai_gateway_service.go`、`openai_ws_forwarder.go`）改动为**纯插入**（无删除）。
- **后端 load-bearing 注入已加 sentinel 锚点**（gateway-tk.json，真·防覆盖）：退役门 `tkOpenAIAutoPauseRetired` + 其在 `shouldAutoPauseOpenAIAccountByQuota` 的短路注入 + `openai_ws_forwarder.go` 的 prev-response 窗口守卫注入——上游 merge 不能静默复活 auto-pause 或丢掉 prev-response 覆盖。
- 两处**前端 UI 隐藏**（隐藏既有控件，无 load-bearing 逻辑被删、无 upstream-merge revert 风险，已逐一审查）：EditAccountModal 由 registry-update 门确认（sentinel-registry-reviewed）；OpsSettingsDialog 由 upstream-override 门确认（upstream-touch-trivial）。
- 本 PR **有前端改动**（非 no-web-impact）。合并方式：**Squash and merge**（TK 特性 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)