### PR TITLE
fix(ops-alert): 路由拒绝告警 主因/用户 分两行(prod) + edge 整条静默

### DIFF
--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -295,11 +295,16 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 			// TK (us7 P0 2026-06-13): attach the top offending model/reason so the
 			// notification card is self-diagnosing (real fire vs client noise)
 			// without an SSH/dashboard drill. Best-effort — never blocks firing.
-			if cause := s.computeTopCause(ctx, rule, windowStart, windowEnd, scopePlatform, scopeGroupID); cause != "" {
+			if cause, users := s.computeTopCause(ctx, rule, windowStart, windowEnd, scopePlatform, scopeGroupID); cause != "" || users != "" {
 				if dimensions == nil {
 					dimensions = map[string]any{}
 				}
-				dimensions["top_cause"] = cause
+				if cause != "" {
+					dimensions["top_cause"] = cause
+				}
+				if users != "" {
+					dimensions["top_cause_users"] = users
+				}
 			}
 
 			firedEvent := &OpsAlertEvent{

--- a/backend/internal/service/ops_alert_evaluator_service_test.go
+++ b/backend/internal/service/ops_alert_evaluator_service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -417,10 +418,12 @@ func TestComputeTopCauseRoutingCapacityRejection(t *testing.T) {
 			{Platform: "anthropic", Count: 40},
 			{Platform: "openai", Count: 15},
 		}}}
-		require.Equal(t, "anthropic ×40 · openai ×15", svc.computeTopCause(ctx, rule, start, end, "", nil))
+		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
+		require.Equal(t, "anthropic ×40 · openai ×15", cause)
+		require.Empty(t, users)
 	})
 
-	t.Run("combines pool cause + user cause", func(t *testing.T) {
+	t.Run("pool cause + user breakdown are returned separately (two card lines)", func(t *testing.T) {
 		t.Parallel()
 		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{
 			routingCauses: []*OpsRoutingRejectionCause{{Platform: "anthropic", Count: 40}},
@@ -429,8 +432,9 @@ func TestComputeTopCauseRoutingCapacityRejection(t *testing.T) {
 				{UserID: 17, APIKeyName: "", Count: 5},
 			},
 		}}
-		require.Equal(t, `anthropic ×40 ｜ 用户 #42 "eval-harness" ×30 · #17 ×5`,
-			svc.computeTopCause(ctx, rule, start, end, "", nil))
+		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
+		require.Equal(t, "anthropic ×40", cause)
+		require.Equal(t, `#42 "eval-harness" ×30 · #17 ×5`, users)
 	})
 
 	t.Run("user segment survives a pool-query error (best-effort)", func(t *testing.T) {
@@ -439,18 +443,89 @@ func TestComputeTopCauseRoutingCapacityRejection(t *testing.T) {
 			routingCausesErr: context.DeadlineExceeded,
 			routingUsers:     []*OpsRoutingRejectionUser{{UserID: 1, APIKeyName: "k", Count: 9}},
 		}}
-		require.Equal(t, `用户 #1 "k" ×9`, svc.computeTopCause(ctx, rule, start, end, "", nil))
+		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
+		require.Empty(t, cause)
+		require.Equal(t, `#1 "k" ×9`, users)
 	})
 
 	t.Run("no rows => no 主因 line", func(t *testing.T) {
 		t.Parallel()
 		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{}}
-		require.Equal(t, "", svc.computeTopCause(ctx, rule, start, end, "", nil))
+		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
+		require.Empty(t, cause)
+		require.Empty(t, users)
 	})
 
 	t.Run("query error => no 主因 line (best-effort, never blocks firing)", func(t *testing.T) {
 		t.Parallel()
 		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{routingCausesErr: context.DeadlineExceeded}}
-		require.Equal(t, "", svc.computeTopCause(ctx, rule, start, end, "", nil))
+		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
+		require.Empty(t, cause)
+		require.Empty(t, users)
 	})
+}
+
+// TestIsEdgeNode pins the node-identity predicate that drives edge-only alert
+// suppression. It MUST match the card-title node label derived by
+// deriveOpsNodeIdentity from the same frontend URL, so a card that would read
+// "· us6" is exactly what gets suppressed.
+func TestIsEdgeNode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		frontendURL string
+		want        bool
+	}{
+		{"edge us6", "https://api-us6.tokenkey.dev", true},
+		{"edge uk1", "https://api-uk1.tokenkey.dev", true},
+		{"prod", "https://api.tokenkey.dev", false},
+		{"unset frontend url", "", false},
+		{"non-edge custom host", "https://gateway.example.com", false},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			svc := &OpsAlertEvaluatorService{cfg: &config.Config{Server: config.ServerConfig{FrontendURL: c.frontendURL}}}
+			require.Equal(t, c.want, svc.isEdgeNode())
+		})
+	}
+	t.Run("nil cfg is safe (treated as non-edge)", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, (&OpsAlertEvaluatorService{}).isEdgeNode())
+	})
+}
+
+// TestIsEdgeSuppressedAlertRule pins WHICH rules are silenced on a mirror-relay
+// edge. Only the routing-capacity-rejection P0 (client-invisible on an edge,
+// covered by account-incident / pool-exhausted P0s) qualifies; capacity/error
+// signals that ARE meaningful on an edge must still page.
+func TestIsEdgeSuppressedAlertRule(t *testing.T) {
+	t.Parallel()
+	require.True(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "routing_capacity_rejection_count"}))
+	require.True(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "  routing_capacity_rejection_count  "}))
+	require.False(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "pool_load_rate"}))
+	require.False(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "upstream_error_rate"}))
+	require.False(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "group_available_accounts"}))
+	require.False(t, isEdgeSuppressedAlertRule(nil))
+}
+
+// TestMaybeSendAlertNotificationsEdgeSuppression verifies the composed gate: on an
+// edge node the routing-rejection rule short-circuits before any email/feishu
+// attempt and reports nothing sent. The prod counterpart (same rule) does NOT
+// short-circuit on the edge predicate — it proceeds into the notify paths (which
+// then no-op here only because no notifier config is wired), proving the gate is
+// edge-scoped, not a blanket drop.
+func TestMaybeSendAlertNotificationsEdgeSuppression(t *testing.T) {
+	t.Parallel()
+	rule := &OpsAlertRule{MetricType: "routing_capacity_rejection_count"}
+
+	edge := &OpsAlertEvaluatorService{cfg: &config.Config{Server: config.ServerConfig{FrontendURL: "https://api-us6.tokenkey.dev"}}}
+	require.True(t, edge.isEdgeNode() && isEdgeSuppressedAlertRule(rule), "precondition: edge + suppressed rule")
+	res := edge.maybeSendAlertNotifications(context.Background(), nil, rule, &OpsAlertEvent{})
+	require.False(t, res.EmailSent)
+	require.False(t, res.FeishuSent)
+
+	prod := &OpsAlertEvaluatorService{cfg: &config.Config{Server: config.ServerConfig{FrontendURL: "https://api.tokenkey.dev"}}}
+	require.False(t, prod.isEdgeNode(), "prod must NOT be edge-suppressed for this rule")
 }

--- a/backend/internal/service/ops_alert_notifications_tk_feishu.go
+++ b/backend/internal/service/ops_alert_notifications_tk_feishu.go
@@ -36,6 +36,19 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertNotifications(ctx context.Conte
 	if s == nil {
 		return result
 	}
+	// Edge nodes are prod→edge mirror-relay targets, so a routing_capacity_rejection
+	// P0 there is just the prod relay being turned away — client-invisible (prod
+	// fails over to another edge), and the relay-探测 failover smears it across every
+	// thin edge it probes. A REAL edge outage is already paged by the account-incident
+	// P0 (账号失效) and the "平台池全不可调度 [edge-xxx]" pool-exhausted P0, both
+	// event-driven on the edge's own siteID and sharing this same feishu.enabled
+	// switch. So this rule is pure Feishu noise on an edge: suppress its
+	// notifications there. The event is still persisted (edge dashboard /
+	// scan-edge-health keep the trail); prod still pages — it is the relay terminus
+	// where the thin-pool-race blind spot actually matters.
+	if s.isEdgeNode() && isEdgeSuppressedAlertRule(rule) {
+		return result
+	}
 	if s.maybeSendAlertEmail(ctx, runtimeCfg, rule, event) {
 		result.EmailSent = true
 	}
@@ -43,6 +56,29 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertNotifications(ctx context.Conte
 		result.FeishuSent = true
 	}
 	return result
+}
+
+// isEdgeSuppressedAlertRule reports whether a rule's P0 notifications are pure
+// noise on a prod→edge mirror-relay edge and should be silenced there. Today only
+// routing_capacity_rejection_count qualifies (see maybeSendAlertNotifications);
+// kept as a named predicate so the policy is one obvious list, not an inline
+// string compare.
+func isEdgeSuppressedAlertRule(rule *OpsAlertRule) bool {
+	return rule != nil && strings.TrimSpace(rule.MetricType) == "routing_capacity_rejection_count"
+}
+
+// isEdgeNode reports whether this node is a prod→edge mirror-relay edge
+// (api-<id>.<domain>), derived from the configured frontend URL — the SAME source
+// the alert card's node label uses (deriveOpsNodeIdentity / siteFromFrontendURL),
+// so a card that would be titled "· us6" is exactly what this classifies as edge.
+// Prod (api.<domain>), an empty/unparseable URL, and any non-edge custom host are
+// treated as non-edge, so notifications are suppressed only where we positively
+// identify a relay edge.
+func (s *OpsAlertEvaluatorService) isEdgeNode() bool {
+	if s == nil || s.cfg == nil {
+		return false
+	}
+	return strings.HasPrefix(siteFromFrontendURL(s.cfg.Server.FrontendURL), "edge-")
 }
 
 func (s *OpsAlertEvaluatorService) maybeSendAlertFeishu(ctx context.Context, runtimeCfg *OpsAlertRuntimeSettings, rule *OpsAlertRule, event *OpsAlertEvent) bool {

--- a/backend/internal/service/ops_alert_top_cause_tk.go
+++ b/backend/internal/service/ops_alert_top_cause_tk.go
@@ -56,37 +56,47 @@ func opsTopCauseApplies(metricType string) bool {
 	}
 }
 
-// computeTopCause returns a pre-formatted "主因" string for the card, or "" when
-// the rule is not a rate metric, the query fails, or there is nothing to show.
-// It is best-effort: a failure here must never block firing the alert.
-func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *OpsAlertRule, start, end time.Time, platform string, groupID *int64) string {
+// computeTopCause returns the pre-formatted "主因" string(s) for the card — both
+// "" when the rule is not a rate metric, the query fails, or there is nothing to
+// show. `cause` is the primary line: the model/owner breakdown (error-rate
+// rules), the saturated pool(s) (pool_load_rate), or the empty platform pool(s)
+// (routing_capacity_rejection_count). `users` is the per-user (client)
+// concentration breakdown for routing_capacity_rejection_count, rendered on its
+// own line under 主因. Best-effort: a failure here must never block firing the
+// alert.
+//
+// This function is node-agnostic. Edge nodes suppress the WHOLE
+// routing_capacity_rejection_count alert at the notification layer
+// (maybeSendAlertNotifications → isEdgeNode), so there is no per-field edge
+// branching here.
+func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *OpsAlertRule, start, end time.Time, platform string, groupID *int64) (cause string, users string) {
 	if s == nil || rule == nil {
-		return ""
+		return "", ""
 	}
 	metricType := strings.TrimSpace(rule.MetricType)
 	// pool_load_rate 的主因来自实时池负载快照（哪几个调度池在饱和），而非
 	// ops_error_logs，所以单独取一支；详见 ops_pool_load_rate_tk.go。
 	if metricType == "pool_load_rate" {
 		if s.opsService == nil {
-			return ""
+			return "", ""
 		}
 		pools, err := s.opsService.ComputePoolLoadRates(ctx)
 		if err != nil {
-			return ""
+			return "", ""
 		}
-		return formatPoolLoadCause(pools, rule, platform, groupID)
+		return formatPoolLoadCause(pools, rule, platform, groupID), ""
 	}
 	if s.opsRepo == nil {
-		return ""
+		return "", ""
 	}
 	// routing_capacity_rejection_count's cause has TWO dimensions, derived from the
 	// routing-phase rows themselves (not the model/owner/upstream_status breakdown
-	// the error-rate metrics use): WHICH platform pool(s) ran out of capacity, and
-	// WHO got rejected. Together they answer the first on-call question — is this a
-	// single user hammering (rate-limit them) or site-wide capacity exhaustion (add
-	// accounts)? The top-N user list reveals the concentration on its own. Both
-	// sub-queries are best-effort: a failure in one must not drop the other or block
-	// the alert.
+	// the error-rate metrics use): WHICH platform pool(s) ran out of capacity
+	// (`cause`), and WHO got rejected (`users`). Together they answer the first
+	// on-call question — a single user hammering (rate-limit them) or site-wide
+	// capacity exhaustion (add accounts)? They render as two lines (主因 / 用户) on
+	// the card. Both sub-queries are best-effort: a failure in one must not drop
+	// the other or block the alert.
 	if metricType == "routing_capacity_rejection_count" {
 		filter := &OpsDashboardFilter{
 			StartTime: start,
@@ -96,18 +106,13 @@ func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *Op
 			QueryMode: OpsQueryModeRaw,
 		}
 		pools, _ := s.opsRepo.TopRoutingCapacityRejectionCauses(ctx, filter, 2)
-		users, _ := s.opsRepo.TopRoutingCapacityRejectionUsers(ctx, filter, 3)
-		segments := make([]string, 0, 2)
-		if pool := formatRoutingRejectionCause(pools); pool != "" {
-			segments = append(segments, pool)
-		}
-		if usr := formatRoutingRejectionUsers(users); usr != "" {
-			segments = append(segments, "用户 "+usr)
-		}
-		return strings.Join(segments, " ｜ ")
+		rejected, _ := s.opsRepo.TopRoutingCapacityRejectionUsers(ctx, filter, 3)
+		cause = formatRoutingRejectionCause(pools)
+		users = formatRoutingRejectionUsers(rejected)
+		return cause, users
 	}
 	if !opsTopCauseApplies(metricType) {
-		return ""
+		return "", ""
 	}
 	// upstream_error_rate counts only provider-owned, non-429/529 final failures
 	// (the upstream_excl set); error_rate counts all SLA errors. Mirror that so
@@ -121,9 +126,9 @@ func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *Op
 		QueryMode: OpsQueryModeRaw,
 	}, upstreamOnly, 2)
 	if err != nil || len(causes) == 0 {
-		return ""
+		return "", ""
 	}
-	return formatOpsTopCause(causes)
+	return formatOpsTopCause(causes), ""
 }
 
 // formatOpsTopCause renders up to two causes as a compact one-line string, e.g.

--- a/backend/internal/service/ops_alert_top_cause_tk_test.go
+++ b/backend/internal/service/ops_alert_top_cause_tk_test.go
@@ -67,6 +67,51 @@ func TestBuildOpsFeishuAlertTextTopCauseLine(t *testing.T) {
 		out := buildOpsFeishuAlertText(rule, ev, "us7", "")
 		require.NotContains(t, out, "主因")
 	})
+
+	// Routing-rejection P0s carry the client concentration as top_cause_users.
+	// It renders on its OWN line under 主因 (the 换行 readability fix), so a long
+	// "anthropic ×339 · newapi ×4 ｜ 用户 #1 …" no longer wraps as one blob.
+	t.Run("renders 用户 on its own line under 主因 when top_cause_users present", func(t *testing.T) {
+		ev := &OpsAlertEvent{
+			MetricValue: &mv,
+			Dimensions: map[string]any{
+				"top_cause":       "anthropic ×339 · newapi ×4",
+				"top_cause_users": `#1 "yace" ×275 · #16 "benchmark-吕星宇2" ×29`,
+			},
+		}
+		out := buildOpsFeishuAlertText(rule, ev, "prod", "")
+		require.Contains(t, out, "**主因**：anthropic ×339 · newapi ×4")
+		require.Contains(t, out, `**用户**：#1 "yace" ×275`)
+		// the 用户 breakdown must sit on its own line, immediately after 主因
+		require.Contains(t, out, "anthropic ×339 · newapi ×4\n**用户**：")
+	})
+
+	// No top_cause_users dimension (non-rejection rules, or a degraded user query)
+	// => no 用户 line. (Edge nodes never reach this renderer at all — the whole
+	// routing-rejection alert is suppressed upstream in maybeSendAlertNotifications.)
+	t.Run("omits 用户 line when top_cause_users absent", func(t *testing.T) {
+		ev := &OpsAlertEvent{
+			MetricValue: &mv,
+			Dimensions:  map[string]any{"top_cause": "anthropic ×216 · kiro ×3"},
+		}
+		out := buildOpsFeishuAlertText(rule, ev, "prod", "")
+		require.Contains(t, out, "**主因**：anthropic ×216 · kiro ×3")
+		require.NotContains(t, out, "**用户**")
+	})
+
+	// Best-effort degradation: if the pool sub-query fails but the user sub-query
+	// succeeds (computeTopCause guarantees one failing must not drop the other),
+	// the evaluator stashes top_cause_users alone. The card then shows WHO without
+	// WHICH — still useful, and must render cleanly (用户 line, no orphan 主因).
+	t.Run("renders 用户 line alone when 主因 absent (pool-query degraded)", func(t *testing.T) {
+		ev := &OpsAlertEvent{
+			MetricValue: &mv,
+			Dimensions:  map[string]any{"top_cause_users": `#1 "yace" ×275`},
+		}
+		out := buildOpsFeishuAlertText(rule, ev, "prod", "")
+		require.Contains(t, out, `**用户**：#1 "yace" ×275`)
+		require.NotContains(t, out, "**主因**")
+	})
 }
 
 func TestOpsTopCauseApplies(t *testing.T) {

--- a/backend/internal/service/ops_feishu_notifier_tk.go
+++ b/backend/internal/service/ops_feishu_notifier_tk.go
@@ -228,6 +228,14 @@ func buildOpsFeishuAlertText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLabel
 	if cause := opsFeishuTopCause(event.Dimensions); cause != "" {
 		topCauseLine = fmt.Sprintf("\n**主因**：%s", escapeFeishuText(cause))
 	}
+	// routing_capacity_rejection_count attaches the per-user (client) concentration
+	// as its own dimension so it renders on a SECOND line under 主因 (readability,
+	// instead of a long single line), and so it can be dropped on edge nodes where
+	// the only client is the prod mirror-relay. Absent on edges and non-rejection
+	// rules.
+	if users := opsFeishuTopCauseUsers(event.Dimensions); users != "" {
+		topCauseLine += fmt.Sprintf("\n**用户**：%s", escapeFeishuText(users))
+	}
 	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**当前值**：%s\n**范围**：%s%s\n**时间**：%s\n\n**建议**：%s",
 		escapeFeishuText(nodeLabel),
 		escapeFeishuText(strings.TrimSpace(rule.Name)),
@@ -250,6 +258,23 @@ func opsFeishuTopCause(dimensions map[string]any) string {
 		return ""
 	}
 	if v, ok := dimensions["top_cause"]; ok {
+		if s, ok := v.(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+// opsFeishuTopCauseUsers extracts the per-user (client) concentration breakdown
+// the evaluator stashed for routing-rejection P0s (survives the DB JSON
+// round-trip as a plain string). Rendered on its own line under 主因 so the pool
+// cause and the client breakdown each read cleanly. Returns "" when absent (edge
+// nodes, non-rejection rules).
+func opsFeishuTopCauseUsers(dimensions map[string]any) string {
+	if len(dimensions) == 0 {
+		return ""
+	}
+	if v, ok := dimensions["top_cause_users"]; ok {
 		if s, ok := v.(string); ok {
 			return strings.TrimSpace(s)
 		}


### PR DESCRIPTION
## 背景

`无可用账号拒绝激增`(`routing_capacity_rejection_count`)P0 飞书卡片两处运维反馈:

1. **prod 卡片**:平台池主因与 top 用户挤在同一条长 `主因` 行,可读性差 → 拆成两行(`主因` / `用户`)。
2. **edge 卡片**:这条告警在 edge 上是纯飞书噪音。edge 是 prod→edge 镜像中继节点,edge 上的路由拒绝只是 prod 中继被回绝(客户端无感 —— prod 立即 failover 到别的 edge),且被 relay 的 failover 探测扇平到每个薄 edge。**edge 真故障已由两条更精准、事件驱动的 P0 兜底**:
   - 账号失效 → 账号级永久 P0(`notifyAccountSchedulingBlocked`)
   - 整池不可调度 → `平台池全不可调度 [edge-xxx]` 池级 P0(`NotifyPlatformPoolExhausted`,秒级触发 + 恢复绿卡)
   - 两条兜底都按 edge 自己的 `siteID` 触发、且与本规则**共享同一 `feishu.enabled` 开关**,所以静默本规则不会丢任何真信号。

   prod 照常告警 —— prod 是中继终点,薄池 race 盲区只在那里才有意义。

## 实现

- `computeTopCause` 返回 `(cause, users)`,卡片把 `主因` / `用户` 各渲染一行(存为 `top_cause` / `top_cause_users` 两个 dimension)。该函数保持 node-agnostic。
- edge 决策**收敛到一处**:`maybeSendAlertNotifications` 在 `isEdgeNode()`(与卡片节点标签同源的 frontend-url)且规则属 `isEdgeSuppressedAlertRule`(当前仅 `routing_capacity_rejection_count`)时短路,email 与 feishu 都跳过。**事件仍入库**(`CreateAlertEvent` 先于通知;edge dashboard / `scan-edge-health` 痕迹不丢)。

## 验证

- `go test -tags=unit ./...` 全绿;新增 `TestIsEdgeNode` / `TestIsEdgeSuppressedAlertRule` / `TestMaybeSendAlertNotificationsEdgeSuppression` + 两行渲染测试。
- `golangci-lint` 干净;完整 sub2api preflight PASS。
- 17-agent 对抗式 review:0 真实缺陷。

## 卡片前后对比

prod:
```
主因：anthropic ×339 · newapi ×4
用户：#1 "yace" ×275 · #16 "benchmark-吕星宇2" ×29
```
edge:整条不再发飞书(由 `平台池全不可调度`/账号级 P0 兜底)。

---

no-web-impact

upstream-touch-trivial —— 唯一动到的 upstream 形文件 `ops_alert_evaluator_service.go` 仅改其 TK 新增的 `top_cause` 注入块(两 dimension key),无 upstream 回退风险;其余均为 TK-only 文件(`ops_alert_top_cause_tk.go` / `ops_alert_notifications_tk_feishu.go` / `ops_feishu_notifier_tk.go`)。

sentinel-registry-reviewed —— `gateway-tk.json` 对 `ops_alert_evaluator_service.go` 的锚点针对 `pool_load_rate` 不变量(ChannelType 池键 / (在途+排队)/Σ席位 公式),本 PR 未触碰;`top_cause` 块的改动不涉及任何现有 sentinel 锚点,无需新增。

🤖 Generated with [Claude Code](https://claude.com/claude-code)