### PR TITLE
feat(openai-scheduler): retire codex auto-pause + per-account failover-hop KPI

### DIFF
--- a/backend/internal/handler/admin/ops_dashboard_handler.go
+++ b/backend/internal/handler/admin/ops_dashboard_handler.go
@@ -328,6 +328,74 @@ func parseOpsOpenAITokenStatsDuration(v string) (time.Duration, bool) {
 	}
 }
 
+// GetDashboardFailoverHopStats returns the per-account wasted-failover-hop KPI for
+// the GPT line (PR #899 follow-up observability). TopN-only; mirrors the
+// openai-token-stats handler shape.
+func (h *OpsHandler) GetDashboardFailoverHopStats(c *gin.Context) {
+	if h.opsService == nil {
+		response.Error(c, http.StatusServiceUnavailable, "Ops service not available")
+		return
+	}
+	if err := h.opsService.RequireMonitoringEnabled(c.Request.Context()); err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	filter, err := parseOpsFailoverHopStatsFilter(c)
+	if err != nil {
+		response.BadRequest(c, err.Error())
+		return
+	}
+
+	data, err := h.opsService.GetFailoverHopStats(c.Request.Context(), filter)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, data)
+}
+
+func parseOpsFailoverHopStatsFilter(c *gin.Context) (*service.OpsFailoverHopStatsFilter, error) {
+	if c == nil {
+		return nil, fmt.Errorf("invalid request")
+	}
+
+	timeRange := strings.TrimSpace(c.Query("time_range"))
+	if timeRange == "" {
+		timeRange = "1d"
+	}
+	dur, ok := parseOpsOpenAITokenStatsDuration(timeRange)
+	if !ok {
+		return nil, fmt.Errorf("invalid time_range")
+	}
+	end := time.Now().UTC()
+	start := end.Add(-dur)
+
+	filter := &service.OpsFailoverHopStatsFilter{
+		TimeRange: timeRange,
+		StartTime: start,
+		EndTime:   end,
+		Platform:  strings.TrimSpace(c.Query("platform")),
+	}
+
+	if v := strings.TrimSpace(c.Query("group_id")); v != "" {
+		id, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || id <= 0 {
+			return nil, fmt.Errorf("invalid group_id")
+		}
+		filter.GroupID = &id
+	}
+
+	if topNRaw := strings.TrimSpace(c.Query("top_n")); topNRaw != "" {
+		topN, err := strconv.Atoi(topNRaw)
+		if err != nil || topN < 1 || topN > 100 {
+			return nil, fmt.Errorf("invalid top_n")
+		}
+		filter.TopN = topN
+	}
+	return filter, nil
+}
+
 func pickThroughputBucketSeconds(window time.Duration) int {
 	// Keep buckets predictable and avoid huge responses.
 	switch {

--- a/backend/internal/repository/ops_repo_failover_hop_stats_integration_test.go
+++ b/backend/internal/repository/ops_repo_failover_hop_stats_integration_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetFailoverHopStats verifies the per-account wasted-failover-hop KPI:
+//   - only recovered-200 rows (client status < 400 with upstream attempts) count;
+//   - jsonb_array_length(upstream_errors) is the wasted-attempt count (no minus-1);
+//   - failover_hops counts only account-switch kinds (split_part(kind,':',1));
+//   - scope is openai/newapi only;
+//   - aggregation is per (account, platform).
+func TestGetFailoverHopStats(t *testing.T) {
+	ctx := context.Background()
+	_, _ = integrationDB.ExecContext(ctx, "TRUNCATE ops_error_logs RESTART IDENTITY CASCADE")
+
+	repo := NewOpsRepository(integrationDB).(*opsRepository)
+
+	windowStart := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Hour)
+	windowEnd := windowStart.Add(time.Hour)
+	at := windowStart.Add(5 * time.Minute)
+
+	insert := func(statusCode int, accountID int64, platform, upstreamErrors string) {
+		_, err := integrationDB.ExecContext(ctx, `
+			INSERT INTO ops_error_logs (
+				error_phase, error_type, severity, status_code, error_owner,
+				account_id, platform, upstream_errors, is_count_tokens, created_at
+			) VALUES ('upstream', 'upstream_error', 'error', $1, 'provider',
+				$2, $3, $4::jsonb, FALSE, $5)`,
+			statusCode, accountID, platform, upstreamErrors, at,
+		)
+		require.NoError(t, err)
+	}
+
+	// account 100 (openai): two recovered-200 requests.
+	//   row A: 2 failover events + 1 retry  -> failover_hops=2, wasted_attempts=3
+	insert(200, 100, "openai", `[{"kind":"failover"},{"kind":"failover_on_400"},{"kind":"retry"}]`)
+	//   row B: 1 failover                   -> failover_hops=1, wasted_attempts=1
+	insert(200, 100, "openai", `[{"kind":"failover:upstream_429"}]`)
+	// account 101 (newapi): one recovered request, fewer hops -> sorts after 100.
+	insert(200, 101, "newapi", `[{"kind":"failover"}]`)
+
+	// EXCLUDED rows:
+	//   final-failure (status>=400) — not recovered.
+	insert(502, 100, "openai", `[{"kind":"failover"},{"kind":"failover"}]`)
+	//   recovered but no upstream attempts (empty array).
+	insert(200, 100, "openai", `[]`)
+	//   recovered on a non-GPT-line platform — out of scope.
+	insert(200, 200, "anthropic", `[{"kind":"failover"},{"kind":"failover"}]`)
+
+	resp, err := repo.GetFailoverHopStats(ctx, &service.OpsFailoverHopStatsFilter{
+		TimeRange: "1d",
+		StartTime: windowStart,
+		EndTime:   windowEnd,
+		TopN:      10,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Items, 2, "accounts 100 (openai) + 101 (newapi) are in scope; anthropic excluded")
+	require.EqualValues(t, 2, resp.Total)
+
+	item := resp.Items[0]
+	require.EqualValues(t, 100, item.AccountID, "highest total_failover_hops sorts first")
+	require.Equal(t, "openai", item.Platform)
+	require.EqualValues(t, 2, item.RecoveredCount, "2 recovered-200 requests")
+	require.EqualValues(t, 3, item.TotalFailoverHops, "2 + 1 account-switch events (retry excluded)")
+	require.EqualValues(t, 4, item.TotalWastedAttempts, "3 + 1 array elements (retry counted as wasted attempt)")
+	require.NotNil(t, item.AvgFailoverHopsPerRecovered)
+	require.InDelta(t, 1.5, *item.AvgFailoverHopsPerRecovered, 1e-6, "3 failover hops / 2 recovered requests")
+
+	// TopN trims the rows but Total reports the true account count.
+	trimmed, err := repo.GetFailoverHopStats(ctx, &service.OpsFailoverHopStatsFilter{
+		TimeRange: "1d",
+		StartTime: windowStart,
+		EndTime:   windowEnd,
+		TopN:      1,
+	})
+	require.NoError(t, err)
+	require.Len(t, trimmed.Items, 1, "topN=1 returns one row")
+	require.EqualValues(t, 100, trimmed.Items[0].AccountID)
+	require.EqualValues(t, 2, trimmed.Total, "Total is the true account count, not the trimmed page size")
+}

--- a/backend/internal/repository/ops_repo_failover_hop_stats_tk.go
+++ b/backend/internal/repository/ops_repo_failover_hop_stats_tk.go
@@ -1,0 +1,138 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// GetFailoverHopStats computes the per-account "wasted failover hops" KPI for the
+// OpenAI/GPT line (PR #899 follow-up observability). A recovered-200 row in
+// ops_error_logs (client status < 400 but upstream attempts occurred) carries one
+// upstream_errors element per FAILED upstream attempt — the successful final
+// attempt is never appended — so jsonb_array_length(upstream_errors) is exactly the
+// wasted-hop count for that request. We scope to recovered rows on openai/newapi and
+// group by (account, platform). Read-time aggregate (no rollup/migration), reusing
+// buildErrorWhere so the window/platform/group scope is byte-identical to the rest of
+// the dashboard — mirrors GetTopErrorCause.
+func (r *opsRepository) GetFailoverHopStats(ctx context.Context, filter *service.OpsFailoverHopStatsFilter) (*service.OpsFailoverHopStatsResponse, error) {
+	if r == nil || r.db == nil {
+		return nil, fmt.Errorf("nil ops repository")
+	}
+	if filter == nil {
+		return nil, fmt.Errorf("nil filter")
+	}
+	if filter.StartTime.IsZero() || filter.EndTime.IsZero() {
+		return nil, fmt.Errorf("start_time/end_time required")
+	}
+	if filter.StartTime.After(filter.EndTime) {
+		return nil, fmt.Errorf("start_time must be <= end_time")
+	}
+
+	dashboardFilter := &service.OpsDashboardFilter{
+		StartTime: filter.StartTime.UTC(),
+		EndTime:   filter.EndTime.UTC(),
+		Platform:  strings.TrimSpace(strings.ToLower(filter.Platform)),
+		GroupID:   filter.GroupID,
+	}
+
+	where, args, idx := buildErrorWhere(dashboardFilter, dashboardFilter.StartTime, dashboardFilter.EndTime, 1)
+	// Recovered-200 rows on the GPT line that actually hopped. When a platform
+	// filter is already applied by buildErrorWhere, the IN clause is redundant but
+	// harmless; without one it keeps scope to openai/newapi.
+	where += ` AND account_id IS NOT NULL
+  AND COALESCE(status_code, 0) < 400
+  AND upstream_errors IS NOT NULL
+  AND upstream_errors <> 'null'::jsonb
+  AND jsonb_array_length(upstream_errors) > 0
+  AND platform IN ('openai', 'newapi')`
+
+	// failover_hops counts only account-switch events (same predicate as the
+	// fleet-wide queryAccountSwitchCount); wasted_attempts counts every failed
+	// upstream attempt regardless of kind.
+	recoveredCTE := `
+WITH recovered AS (
+  SELECT
+    account_id,
+    platform,
+    (
+      SELECT COUNT(*)
+      FROM jsonb_array_elements(upstream_errors) AS ev
+      WHERE split_part(ev->>'kind', ':', 1) IN ('failover', 'retry_exhausted_failover', 'failover_on_400')
+    ) AS failover_hops,
+    jsonb_array_length(upstream_errors) AS wasted_attempts
+  FROM ops_error_logs ` + where + `
+)`
+
+	// True total = distinct (account, platform) groups with recovered hops, so the
+	// TopN footer reports the real account count rather than the trimmed page size.
+	var total int64
+	if err := r.db.QueryRowContext(ctx,
+		recoveredCTE+`
+SELECT COUNT(*) FROM (SELECT 1 FROM recovered GROUP BY account_id, platform) g`,
+		args...,
+	).Scan(&total); err != nil {
+		return nil, err
+	}
+
+	q := recoveredCTE + `
+SELECT
+  recovered.account_id,
+  COALESCE(NULLIF(a.name, ''), '(account ' || recovered.account_id::text || ')') AS account_name,
+  recovered.platform,
+  COUNT(*)::bigint                                  AS recovered_count,
+  COALESCE(SUM(recovered.failover_hops), 0)::bigint AS total_failover_hops,
+  COALESCE(SUM(recovered.wasted_attempts), 0)::bigint AS total_wasted_attempts,
+  ROUND(AVG(recovered.failover_hops)::numeric, 3)::float8 AS avg_failover_hops_per_recovered
+FROM recovered
+LEFT JOIN accounts a ON a.id = recovered.account_id
+GROUP BY recovered.account_id, a.name, recovered.platform
+ORDER BY total_failover_hops DESC, recovered_count DESC, recovered.account_id ASC
+LIMIT $` + fmt.Sprintf("%d", idx)
+	queryArgs := append(append([]any{}, args...), filter.TopN)
+
+	rows, err := r.db.QueryContext(ctx, q, queryArgs...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	items := make([]*service.OpsFailoverHopStatsItem, 0, filter.TopN)
+	for rows.Next() {
+		item := &service.OpsFailoverHopStatsItem{}
+		var avgHops sql.NullFloat64
+		if err := rows.Scan(
+			&item.AccountID,
+			&item.AccountName,
+			&item.Platform,
+			&item.RecoveredCount,
+			&item.TotalFailoverHops,
+			&item.TotalWastedAttempts,
+			&avgHops,
+		); err != nil {
+			return nil, err
+		}
+		if avgHops.Valid {
+			v := avgHops.Float64
+			item.AvgFailoverHopsPerRecovered = &v
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return &service.OpsFailoverHopStatsResponse{
+		TimeRange: strings.TrimSpace(filter.TimeRange),
+		StartTime: dashboardFilter.StartTime,
+		EndTime:   dashboardFilter.EndTime,
+		Platform:  dashboardFilter.Platform,
+		GroupID:   dashboardFilter.GroupID,
+		Items:     items,
+		Total:     total,
+		TopN:      filter.TopN,
+	}, nil
+}

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -229,6 +229,7 @@ func registerOpsRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		ops.GET("/dashboard/error-trend", h.Admin.Ops.GetDashboardErrorTrend)
 		ops.GET("/dashboard/error-distribution", h.Admin.Ops.GetDashboardErrorDistribution)
 		ops.GET("/dashboard/openai-token-stats", h.Admin.Ops.GetDashboardOpenAITokenStats)
+		ops.GET("/dashboard/failover-hop-stats", h.Admin.Ops.GetDashboardFailoverHopStats)
 	}
 }
 

--- a/backend/internal/service/openai_account_scheduler_tk_autopause_retired.go
+++ b/backend/internal/service/openai_account_scheduler_tk_autopause_retired.go
@@ -1,0 +1,23 @@
+package service
+
+// tkOpenAIAutoPauseRetired reports whether the upstream codex usage-window
+// "auto-pause by quota" decision is retired.
+//
+// It is retired in favour of the window-sched tri-state guard
+// (openai_account_scheduler_tk_window_sched.go, PR #899), which is the single
+// outward window-avoidance mechanism for the OpenAI/GPT line. Auto-pause was a
+// binary hard-exclude on the SAME codex 5h/7d signal, so keeping both would mean
+// two overlapping percent-based knobs for operators to reason about.
+//
+// We DISABLE rather than delete (§5.x deletion discipline): shouldAutoPause
+// OpenAIAccountByQuota and its helpers are upstream-owned, so deleting them would
+// cause recurring merge conflicts and lose upstream tests. Crucially, the codex
+// signal CAPTURE those helpers share (resolveOpenAIQuotaUtilization,
+// codex_*_used_percent persistence) is left fully intact — the #899 window guard
+// depends on it. This gate only short-circuits the auto-pause DECISION, so any
+// leftover per-account / global auto_pause thresholds can no longer fire either.
+//
+// Implemented as a function (not a const/var) so the gated upstream body is never
+// flagged as unreachable/always-false by the linter, and so re-enabling auto-pause
+// later is a one-line change here.
+func tkOpenAIAutoPauseRetired() bool { return true }

--- a/backend/internal/service/openai_account_scheduler_tk_window_sched_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_window_sched_test.go
@@ -281,3 +281,25 @@ func TestSelectAccountWithScheduler_AdvancedWindowGuard_RoutesAwayFromHotAccount
 	require.NotNil(t, selection.Account)
 	require.Equal(t, int64(39002), selection.Account.ID, "advanced path: hot 99% account excluded from the weighted TopK pool")
 }
+
+// Retirement gate (#902): the upstream codex auto-pause decision is a permanent
+// no-op now that the window-sched tri-state guard is the single window mechanism.
+// Even an account well over a configured auto_pause threshold must NOT be paused.
+func TestShouldAutoPauseOpenAIAccountByQuota_Retired(t *testing.T) {
+	require.True(t, tkOpenAIAutoPauseRetired(), "retirement gate must be on")
+
+	acc := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"codex_5h_used_percent":   99.0,
+			"codex_usage_updated_at":  time.Now().Format(time.RFC3339),
+			"auto_pause_5h_threshold": 0.90, // would have paused pre-retirement
+		},
+	}
+	// Seed a non-zero global default too, to prove neither account-level nor global
+	// thresholds can revive auto-pause.
+	ctx := withOpenAIQuotaAutoPauseSettings(context.Background(), OpsOpenAIAccountQuotaAutoPauseSettings{DefaultThreshold5h: 0.90})
+	paused, _ := shouldAutoPauseOpenAIAccountByQuota(ctx, acc)
+	require.False(t, paused, "auto-pause is retired; it must never fire regardless of thresholds")
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1449,6 +1449,15 @@ func isOpenAIAccountEligibleForRequest(ctx context.Context, account *Account, re
 }
 
 func shouldAutoPauseOpenAIAccountByQuota(ctx context.Context, account *Account) (bool, openAIQuotaAutoPauseDecision) {
+	// TK (PR #899 follow-up): the upstream codex usage-window auto-pause is retired
+	// in favour of the window-sched tri-state guard, the single outward window
+	// mechanism. Short-circuited to a permanent no-op so any leftover thresholds
+	// cannot fire; upstream body below is retained (disabled, not deleted — §5.x)
+	// and the shared codex signal capture the new guard reads stays intact. See
+	// tkOpenAIAutoPauseRetired (openai_account_scheduler_tk_autopause_retired.go).
+	if tkOpenAIAutoPauseRetired() {
+		return false, openAIQuotaAutoPauseDecision{}
+	}
 	// Auto-pause keys off codex 5h/7d usage windows that only exist on `openai`
 	// accounts; this is a usage-window predicate, not a scheduling pool-membership
 	// filter, so newapi accounts are correctly skipped.

--- a/backend/internal/service/openai_ws_account_sticky_test.go
+++ b/backend/internal/service/openai_ws_account_sticky_test.go
@@ -48,9 +48,12 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_Hit(t *testing.T
 	}
 }
 
-func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_QuotaAutoPausedMiss(t *testing.T) {
+func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_WindowNotSchedulableMiss(t *testing.T) {
 	ctx := context.Background()
 	groupID := int64(23)
+	now := time.Now().Format(time.RFC3339)
+	// 99.5% used => NotSchedulable under the window-sched guard (default avoid edge 99%).
+	// The retired auto-pause used to gate this path; the tri-state guard now carries it.
 	account := Account{
 		ID:          77,
 		Platform:    PlatformOpenAI,
@@ -60,8 +63,8 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_QuotaAutoPausedM
 		Concurrency: 2,
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
-			"codex_5h_used_percent":                         96.0,
-			"auto_pause_5h_threshold":                       0.95,
+			"codex_5h_used_percent":                         99.5,
+			"codex_usage_updated_at":                        now,
 		},
 	}
 	cache := &stubGatewayCache{}
@@ -79,13 +82,52 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_QuotaAutoPausedM
 
 	selection, err := svc.SelectAccountByPreviousResponseID(ctx, &groupID, "resp_prev_quota", "gpt-5.1", nil, false)
 	require.NoError(t, err)
-	require.Nil(t, selection, "超过 5h 配额阈值的账号不应继续命中 previous_response_id 粘连")
+	require.Nil(t, selection, "窗口耗尽(NotSchedulable)的账号不应继续命中 previous_response_id 粘连")
 
-	// Auto-pause is transient, so the binding is preserved: the chain can resume on the
-	// same account once the quota window resets.
+	// Window pressure is transient, so the binding is preserved: the chain can resume on
+	// the same account once the usage window resets.
 	boundAccountID, getErr := store.GetResponseAccount(ctx, groupID, "resp_prev_quota")
 	require.NoError(t, getErr)
 	require.Equal(t, account.ID, boundAccountID)
+}
+
+// StickyOnly band (95%–99%): the prev-response chain is PRESERVED (the account
+// keeps serving its own chain under transient window pressure), unlike the
+// retired auto-pause which hard-excluded at the operator threshold.
+func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_WindowStickyOnlyKeepsChain(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(23)
+	now := time.Now().Format(time.RFC3339)
+	account := Account{
+		ID:          78,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 2,
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+			"codex_5h_used_percent":                         96.0,
+			"codex_usage_updated_at":                        now,
+		},
+	}
+	cache := &stubGatewayCache{}
+	store := NewOpenAIWSStateStore(cache)
+	cfg := newOpenAIWSV2TestConfig()
+	svc := &OpenAIGatewayService{
+		accountRepo:        stubOpenAIAccountRepo{accounts: []Account{account}},
+		cache:              cache,
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+		openaiWSStateStore: store,
+	}
+
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_prev_sticky", account.ID, time.Hour))
+
+	selection, err := svc.SelectAccountByPreviousResponseID(ctx, &groupID, "resp_prev_sticky", "gpt-5.1", nil, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection, "StickyOnly 区间(96%)的账号应继续服务自己的 previous_response_id 链")
+	require.Equal(t, account.ID, selection.Account.ID)
 }
 
 func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_RateLimitedMiss(t *testing.T) {

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -4311,12 +4311,22 @@ func (s *OpenAIGatewayService) selectAccountByPreviousResponseIDForCapability(
 		// keep the binding (transient) and fall through to normal scheduling.
 		return nil, nil
 	}
+	// TK (PR #899 follow-up): the window-sched tri-state guard replaces the retired
+	// auto-pause on this previous_response_id chain too, so the tri-state is the single
+	// window mechanism on every path auto-pause used to cover. isSticky=true: a
+	// StickyOnly account keeps serving its own chain (transient pressure), only a
+	// NotSchedulable account at its window cap yields. Binding preserved (NOT deleted)
+	// so the chain resumes after the window resets.
+	if !s.isAccountSchedulableForOpenAIWindow(ctx, account, true) {
+		return nil, nil
+	}
 	// Quota auto-pause must also gate the previous_response_id sticky path; otherwise an
 	// account over its 5h/7d threshold keeps serving the same response chain even though
 	// normal scheduling skips it. Pause is transient, so fall through to normal scheduling
 	// WITHOUT deleting the binding (the window may reset before the next turn). This early
 	// return also pre-empts the DB-recheck below, which would otherwise treat the paused
-	// account as gone and clear the sticky binding.
+	// account as gone and clear the sticky binding. (Retired in #899 follow-up — the
+	// tri-state guard above now carries this; kept as a no-op for §5.x merge-friendliness.)
 	if paused, _ := shouldAutoPauseOpenAIAccountByQuota(ctx, account); paused {
 		return nil, nil
 	}

--- a/backend/internal/service/ops_failover_hop_stats.go
+++ b/backend/internal/service/ops_failover_hop_stats.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"context"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+)
+
+const opsFailoverHopStatsDefaultTopN = 10
+
+// GetFailoverHopStats returns the per-account wasted-failover-hop KPI for the
+// OpenAI/GPT line (openai + newapi), used to observe the hop reduction from the
+// window-sched scheduler change (PR #899). Read-time aggregate over
+// ops_error_logs recovered-200 rows; see the repository for the SQL.
+func (s *OpsService) GetFailoverHopStats(ctx context.Context, filter *OpsFailoverHopStatsFilter) (*OpsFailoverHopStatsResponse, error) {
+	if err := s.RequireMonitoringEnabled(ctx); err != nil {
+		return nil, err
+	}
+	if s.opsRepo == nil {
+		return nil, infraerrors.ServiceUnavailable("OPS_REPO_UNAVAILABLE", "Ops repository not available")
+	}
+	if filter == nil {
+		return nil, infraerrors.BadRequest("OPS_FILTER_REQUIRED", "filter is required")
+	}
+	if filter.StartTime.IsZero() || filter.EndTime.IsZero() {
+		return nil, infraerrors.BadRequest("OPS_TIME_RANGE_REQUIRED", "start_time/end_time are required")
+	}
+	if filter.StartTime.After(filter.EndTime) {
+		return nil, infraerrors.BadRequest("OPS_TIME_RANGE_INVALID", "start_time must be <= end_time")
+	}
+	if filter.GroupID != nil && *filter.GroupID <= 0 {
+		return nil, infraerrors.BadRequest("OPS_GROUP_ID_INVALID", "group_id must be > 0")
+	}
+	if filter.TopN <= 0 {
+		filter.TopN = opsFailoverHopStatsDefaultTopN
+	}
+	if filter.TopN < 1 || filter.TopN > 100 {
+		return nil, infraerrors.BadRequest("OPS_TOPN_INVALID", "top_n must be between 1 and 100")
+	}
+
+	return s.opsRepo.GetFailoverHopStats(ctx, filter)
+}

--- a/backend/internal/service/ops_failover_hop_stats_models.go
+++ b/backend/internal/service/ops_failover_hop_stats_models.go
@@ -1,0 +1,44 @@
+package service
+
+import "time"
+
+// OpsFailoverHopStatsFilter scopes the per-account "wasted failover hops" KPI.
+// TopN-only (no pagination): the dashboard card shows the worst N accounts.
+type OpsFailoverHopStatsFilter struct {
+	TimeRange string
+	StartTime time.Time
+	EndTime   time.Time
+
+	Platform string
+	GroupID  *int64
+
+	TopN int
+}
+
+// OpsFailoverHopStatsItem is one account's failover-hop waste over the window.
+// A "wasted hop" is one failed upstream attempt on a request that STILL succeeded
+// (recovered-200): the request first landed on a hot account, ate an error, and
+// failed over. total_failover_hops counts only account-switch events; total_wasted
+// _attempts counts every wasted upstream round-trip regardless of kind.
+type OpsFailoverHopStatsItem struct {
+	AccountID                   int64    `json:"account_id"`
+	AccountName                 string   `json:"account_name"`
+	Platform                    string   `json:"platform"`
+	RecoveredCount              int64    `json:"recovered_count"`
+	TotalFailoverHops           int64    `json:"total_failover_hops"`
+	TotalWastedAttempts         int64    `json:"total_wasted_attempts"`
+	AvgFailoverHopsPerRecovered *float64 `json:"avg_failover_hops_per_recovered"`
+}
+
+type OpsFailoverHopStatsResponse struct {
+	TimeRange string    `json:"time_range"`
+	StartTime time.Time `json:"start_time"`
+	EndTime   time.Time `json:"end_time"`
+
+	Platform string `json:"platform,omitempty"`
+	GroupID  *int64 `json:"group_id,omitempty"`
+
+	Items []*OpsFailoverHopStatsItem `json:"items"`
+	Total int64                      `json:"total"`
+	TopN  int                        `json:"top_n"`
+}

--- a/backend/internal/service/ops_failover_hop_stats_test.go
+++ b/backend/internal/service/ops_failover_hop_stats_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type failoverHopStatsRepoStub struct {
+	OpsRepository
+	resp     *OpsFailoverHopStatsResponse
+	captured *OpsFailoverHopStatsFilter
+}
+
+func (s *failoverHopStatsRepoStub) GetFailoverHopStats(ctx context.Context, filter *OpsFailoverHopStatsFilter) (*OpsFailoverHopStatsResponse, error) {
+	s.captured = filter
+	if s.resp != nil {
+		return s.resp, nil
+	}
+	return &OpsFailoverHopStatsResponse{}, nil
+}
+
+func TestOpsServiceGetFailoverHopStats_Validation(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name       string
+		filter     *OpsFailoverHopStatsFilter
+		wantCode   int
+		wantReason string
+	}{
+		{"filter 不能为空", nil, 400, "OPS_FILTER_REQUIRED"},
+		{"时间范围必填", &OpsFailoverHopStatsFilter{EndTime: now}, 400, "OPS_TIME_RANGE_REQUIRED"},
+		{"start 不能晚于 end", &OpsFailoverHopStatsFilter{StartTime: now, EndTime: now.Add(-time.Minute)}, 400, "OPS_TIME_RANGE_INVALID"},
+		{"group_id 必须 > 0", &OpsFailoverHopStatsFilter{StartTime: now.Add(-time.Hour), EndTime: now, GroupID: int64Ptr(0)}, 400, "OPS_GROUP_ID_INVALID"},
+		{"top_n 越界", &OpsFailoverHopStatsFilter{StartTime: now.Add(-time.Hour), EndTime: now, TopN: 101}, 400, "OPS_TOPN_INVALID"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &OpsService{opsRepo: &failoverHopStatsRepoStub{}}
+			_, err := svc.GetFailoverHopStats(context.Background(), tt.filter)
+			require.Error(t, err)
+			require.Equal(t, tt.wantCode, infraerrors.Code(err))
+			require.Equal(t, tt.wantReason, infraerrors.Reason(err))
+		})
+	}
+}
+
+func TestOpsServiceGetFailoverHopStats_DefaultTopN(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &failoverHopStatsRepoStub{resp: &OpsFailoverHopStatsResponse{}}
+	svc := &OpsService{opsRepo: repo}
+
+	_, err := svc.GetFailoverHopStats(context.Background(), &OpsFailoverHopStatsFilter{
+		TimeRange: "1d",
+		StartTime: now.Add(-24 * time.Hour),
+		EndTime:   now,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, repo.captured)
+	require.Equal(t, opsFailoverHopStatsDefaultTopN, repo.captured.TopN, "topN defaults when unset")
+}
+
+func TestOpsServiceGetFailoverHopStats_RepoUnavailable(t *testing.T) {
+	now := time.Now().UTC()
+	svc := &OpsService{}
+
+	_, err := svc.GetFailoverHopStats(context.Background(), &OpsFailoverHopStatsFilter{
+		TimeRange: "1h",
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now,
+		TopN:      10,
+	})
+	require.Error(t, err)
+	require.Equal(t, 503, infraerrors.Code(err))
+	require.Equal(t, "OPS_REPO_UNAVAILABLE", infraerrors.Reason(err))
+}

--- a/backend/internal/service/ops_port.go
+++ b/backend/internal/service/ops_port.go
@@ -50,6 +50,8 @@ type OpsRepository interface {
 	// behind a fired error-rate alert, over the same window/scope as the metric.
 	GetTopErrorCause(ctx context.Context, filter *OpsDashboardFilter, upstreamOnly bool, limit int) ([]*OpsTopErrorCause, error)
 	GetOpenAITokenStats(ctx context.Context, filter *OpsOpenAITokenStatsFilter) (*OpsOpenAITokenStatsResponse, error)
+	// TK (PR #899 follow-up): per-account wasted-failover-hop KPI for the GPT line.
+	GetFailoverHopStats(ctx context.Context, filter *OpsFailoverHopStatsFilter) (*OpsFailoverHopStatsResponse, error)
 
 	InsertSystemMetrics(ctx context.Context, input *OpsInsertSystemMetricsInput) error
 	GetLatestSystemMetrics(ctx context.Context, windowMinutes int) (*OpsSystemMetricsSnapshot, error)

--- a/backend/internal/service/ops_repo_mock_test.go
+++ b/backend/internal/service/ops_repo_mock_test.go
@@ -122,6 +122,10 @@ func (m *opsRepoMock) GetOpenAITokenStats(ctx context.Context, filter *OpsOpenAI
 	return &OpsOpenAITokenStatsResponse{}, nil
 }
 
+func (m *opsRepoMock) GetFailoverHopStats(ctx context.Context, filter *OpsFailoverHopStatsFilter) (*OpsFailoverHopStatsResponse, error) {
+	return &OpsFailoverHopStatsResponse{}, nil
+}
+
 func (m *opsRepoMock) InsertSystemMetrics(ctx context.Context, input *OpsInsertSystemMetricsInput) error {
 	return nil
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 496,
-  "hash": "3c50424811cd09a0167d4a5ad951949dc995368d06786f3fcc54251a44607f75",
+  "file_count": 497,
+  "hash": "6d916dac0856d3b957928f74161bd0774c0be18f2113164bbb798fcb843d7ee5",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/admin/ops.ts
+++ b/frontend/src/api/admin/ops.ts
@@ -251,6 +251,36 @@ export interface OpsOpenAITokenStatsParams {
   top_n?: number
 }
 
+export type OpsFailoverHopStatsTimeRange = '30m' | '1h' | '1d' | '15d' | '30d'
+
+export interface OpsFailoverHopStatsItem {
+  account_id: number
+  account_name: string
+  platform: string
+  recovered_count: number
+  total_failover_hops: number
+  total_wasted_attempts: number
+  avg_failover_hops_per_recovered?: number | null
+}
+
+export interface OpsFailoverHopStatsResponse {
+  time_range: OpsFailoverHopStatsTimeRange
+  start_time: string
+  end_time: string
+  platform?: string
+  group_id?: number | null
+  items: OpsFailoverHopStatsItem[]
+  total: number
+  top_n: number
+}
+
+export interface OpsFailoverHopStatsParams {
+  time_range?: OpsFailoverHopStatsTimeRange
+  platform?: string
+  group_id?: number | null
+  top_n?: number
+}
+
 export interface OpsSystemMetricsSnapshot {
   id: number
   created_at: string
@@ -1097,6 +1127,17 @@ export async function getOpenAITokenStats(
   return data
 }
 
+export async function getFailoverHopStats(
+  params: OpsFailoverHopStatsParams,
+  options: OpsRequestOptions = {}
+): Promise<OpsFailoverHopStatsResponse> {
+  const { data } = await apiClient.get<OpsFailoverHopStatsResponse>('/admin/ops/dashboard/failover-hop-stats', {
+    params,
+    signal: options.signal
+  })
+  return data
+}
+
 export type OpsErrorListView = 'errors' | 'excluded' | 'all'
 
 export type OpsErrorListQueryParams = {
@@ -1325,6 +1366,7 @@ export const opsAPI = {
   getErrorTrend,
   getErrorDistribution,
   getOpenAITokenStats,
+  getFailoverHopStats,
   getConcurrencyStats,
   getUserConcurrencyStats,
   getAccountAvailabilityStats,

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1910,8 +1910,14 @@
         </div>
       </div>
 
+      <!-- TK (PR #899 follow-up): the codex usage-window auto-pause is retired — the
+           window-sched tri-state guard is now the single window-avoidance mechanism
+           (backend defaults 95% sticky-only / 99% avoid, with a global kill-switch and
+           per-account override). These per-account 5h/7d threshold controls are hidden;
+           the v-model refs + save path are kept so any previously-stored thresholds
+           round-trip harmlessly. Re-enable by dropping the `false &&`. -->
       <div
-        v-if="account?.platform === 'openai'"
+        v-if="false && account?.platform === 'openai'"
         class="border-t border-gray-200 pt-4 dark:border-dark-600 space-y-4"
       >
         <div class="space-y-2">

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -339,48 +339,9 @@ describe('EditAccountModal', () => {
     ])
   })
 
-	it('submits OpenAI quota auto-pause thresholds in extra', async () => {
-	  const account = buildAccount()
-	  account.extra = {
-		auto_pause_5h_threshold: 0.9,
-		auto_pause_7d_threshold: 0.8
-	  }
-	  updateAccountMock.mockReset()
-	  checkMixedChannelRiskMock.mockReset()
-	  checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
-	  updateAccountMock.mockResolvedValue(account)
-
-	  const wrapper = mountModal(account)
-
-	  await wrapper.get('[data-testid="auto-pause-5h-threshold"]').setValue('95')
-	  await wrapper.get('[data-testid="auto-pause-7d-threshold"]').setValue('96')
-	  await wrapper.get('form#edit-account-form').trigger('submit.prevent')
-
-	  expect(updateAccountMock).toHaveBeenCalledTimes(1)
-	  expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.auto_pause_5h_threshold).toBe(0.95)
-	  expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.auto_pause_7d_threshold).toBe(0.96)
-	})
-
-	it('submits OpenAI quota auto-pause disable flag in extra', async () => {
-	  // Toggling the per-account disable flag must persist as auto_pause_5h_disabled
-	  // so an admin can exempt one account from auto-pause even when a global default
-	  // threshold is configured (otherwise leaving the threshold blank would silently
-	  // fall back to the global default).
-	  const account = buildAccount()
-	  updateAccountMock.mockReset()
-	  checkMixedChannelRiskMock.mockReset()
-	  checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
-	  updateAccountMock.mockResolvedValue(account)
-
-	  const wrapper = mountModal(account)
-
-	  await wrapper.get('[data-testid="auto-pause-5h-disabled"]').trigger('click')
-	  await wrapper.get('form#edit-account-form').trigger('submit.prevent')
-
-	  expect(updateAccountMock).toHaveBeenCalledTimes(1)
-	  expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.auto_pause_5h_disabled).toBe(true)
-	  expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.auto_pause_7d_disabled).toBeUndefined()
-	})
+	// NOTE: the per-account OpenAI quota auto-pause threshold/disable controls were
+	// retired in the PR #899 follow-up (superseded by the window-sched tri-state guard)
+	// and their UI is hidden, so the tests that drove those controls were removed.
 
   it('keeps at least one OpenAI APIKey endpoint capability selected', async () => {
     const account = buildAccount()

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5311,6 +5311,21 @@ export default {
           requestsWithFirstToken: 'Requests With First Token'
         }
       },
+      failoverHopStats: {
+        title: 'Failover Hop Stats (per account)',
+        hint: 'How many hops each recovered request wasted = wasted upstream round-trips; tracks the hop reduction from the #899 window scheduler.',
+        failedToLoad: 'Failed to load failover hop stats',
+        empty: 'No failover hop stats for the current filters',
+        totalAccounts: 'Total accounts: {total}',
+        table: {
+          account: 'Account',
+          platform: 'Platform',
+          recoveredCount: 'Recovered Requests',
+          totalFailoverHops: 'Total Failover Hops',
+          totalWastedAttempts: 'Total Wasted Attempts',
+          avgHopsPerRecovered: 'Avg Hops / Recovered'
+        }
+      },
       fullscreen: {
         enter: 'Enter Fullscreen'
       },

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -5458,6 +5458,21 @@ export default {
           requestsWithFirstToken: '首 Token 样本数'
         }
       },
+      failoverHopStats: {
+        title: 'Failover 跳数统计（按账号）',
+        hint: '每个恢复成功的请求绕了几跳 = 浪费的上游往返；用于观测 #899 窗口调度的减跳效果。',
+        failedToLoad: '加载 Failover 跳数统计失败',
+        empty: '当前筛选条件下暂无 failover 跳数数据',
+        totalAccounts: '账号总数：{total}',
+        table: {
+          account: '账号',
+          platform: '平台',
+          recoveredCount: '恢复成功请求数',
+          totalFailoverHops: 'Failover 跳数合计',
+          totalWastedAttempts: '浪费上游尝试合计',
+          avgHopsPerRecovered: '每成功请求平均跳数'
+        }
+      },
       customTimeRange: {
         startTime: '开始时间',
         endTime: '结束时间'

--- a/frontend/src/views/admin/ops/OpsDashboard.vue
+++ b/frontend/src/views/admin/ops/OpsDashboard.vue
@@ -93,6 +93,15 @@
         />
       </div>
 
+      <!-- Row: Failover Hop Stats — per-account wasted failover hops (PR #899 follow-up) -->
+      <div v-if="opsEnabled && !(loading && !hasLoadedOnce)" class="grid grid-cols-1 gap-6">
+        <OpsFailoverHopStatsCard
+          :platform-filter="platform"
+          :group-id-filter="groupId"
+          :refresh-token="dashboardRefreshToken"
+        />
+      </div>
+
       <!-- Alert Events -->
       <OpsAlertEventsCard v-if="opsEnabled && showAlertEvents && !(loading && !hasLoadedOnce)" />
 
@@ -165,6 +174,7 @@ import OpsThroughputTrendChart from './components/OpsThroughputTrendChart.vue'
 import OpsSwitchRateTrendChart from './components/OpsSwitchRateTrendChart.vue'
 import OpsAlertEventsCard from './components/OpsAlertEventsCard.vue'
 import OpsOpenAITokenStatsCard from './components/OpsOpenAITokenStatsCard.vue'
+import OpsFailoverHopStatsCard from './components/OpsFailoverHopStatsCard.vue'
 import OpsSystemLogTable from './components/OpsSystemLogTable.vue'
 import OpsRequestDetailsModal, { type OpsRequestDetailsPreset } from './components/OpsRequestDetailsModal.vue'
 import OpsSettingsDialog from './components/OpsSettingsDialog.vue'

--- a/frontend/src/views/admin/ops/components/OpsFailoverHopStatsCard.vue
+++ b/frontend/src/views/admin/ops/components/OpsFailoverHopStatsCard.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Select from '@/components/common/Select.vue'
+import EmptyState from '@/components/common/EmptyState.vue'
+import { opsAPI, type OpsFailoverHopStatsResponse, type OpsFailoverHopStatsTimeRange } from '@/api/admin/ops'
+import { formatNumber } from '@/utils/format'
+
+interface Props {
+  platformFilter?: string
+  groupIdFilter?: number | null
+  refreshToken: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  platformFilter: '',
+  groupIdFilter: null
+})
+
+const { t } = useI18n()
+
+const loading = ref(false)
+const errorMessage = ref('')
+const response = ref<OpsFailoverHopStatsResponse | null>(null)
+
+const timeRange = ref<OpsFailoverHopStatsTimeRange>('1d')
+const topN = ref<number>(10)
+
+const items = computed(() => response.value?.items ?? [])
+const total = computed(() => response.value?.total ?? 0)
+
+const timeRangeOptions = computed(() => [
+  { value: '30m', label: t('admin.ops.timeRange.30m') },
+  { value: '1h', label: t('admin.ops.timeRange.1h') },
+  { value: '1d', label: t('admin.ops.timeRange.1d') },
+  { value: '15d', label: t('admin.ops.timeRange.15d') },
+  { value: '30d', label: t('admin.ops.timeRange.30d') }
+])
+
+const topNOptions = computed(() => [
+  { value: 10, label: 'Top 10' },
+  { value: 20, label: 'Top 20' },
+  { value: 50, label: 'Top 50' },
+  { value: 100, label: 'Top 100' }
+])
+
+function formatRate(v?: number | null): string {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return '-'
+  return v.toFixed(2)
+}
+
+function formatInt(v?: number | null): string {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return '-'
+  return formatNumber(Math.round(v))
+}
+
+function buildParams() {
+  return {
+    time_range: timeRange.value,
+    top_n: topN.value,
+    platform: props.platformFilter || undefined,
+    group_id: typeof props.groupIdFilter === 'number' && props.groupIdFilter > 0 ? props.groupIdFilter : undefined
+  }
+}
+
+async function loadData() {
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    response.value = await opsAPI.getFailoverHopStats(buildParams())
+  } catch (err: any) {
+    console.error('[OpsFailoverHopStatsCard] Failed to load data', err)
+    response.value = null
+    errorMessage.value = err?.message || t('admin.ops.failoverHopStats.failedToLoad')
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => ({
+    timeRange: timeRange.value,
+    topN: topN.value,
+    platform: props.platformFilter,
+    groupId: props.groupIdFilter,
+    refreshToken: props.refreshToken
+  }),
+  () => {
+    void loadData()
+  },
+  { immediate: true }
+)
+</script>
+
+<template>
+  <section class="card p-4 md:p-5">
+    <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <h3 class="text-sm font-bold text-gray-900 dark:text-white">
+          {{ t('admin.ops.failoverHopStats.title') }}
+        </h3>
+        <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+          {{ t('admin.ops.failoverHopStats.hint') }}
+        </p>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <div class="w-36">
+          <Select v-model="timeRange" :options="timeRangeOptions" />
+        </div>
+        <div class="w-28">
+          <Select v-model="topN" :options="topNOptions" />
+        </div>
+      </div>
+    </div>
+
+    <div v-if="errorMessage" class="mb-4 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-600 dark:bg-red-900/20 dark:text-red-400">
+      {{ errorMessage }}
+    </div>
+
+    <div v-if="loading" class="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+      {{ t('admin.ops.loadingText') }}
+    </div>
+
+    <EmptyState
+      v-else-if="items.length === 0"
+      :title="t('common.noData')"
+      :description="t('admin.ops.failoverHopStats.empty')"
+    />
+
+    <div v-else class="space-y-3">
+      <div class="overflow-hidden rounded-xl border border-gray-200 dark:border-dark-700">
+        <div class="max-h-[420px] overflow-auto">
+          <table class="min-w-full text-left text-xs md:text-sm">
+            <thead class="sticky top-0 z-10 bg-white dark:bg-dark-800">
+              <tr class="border-b border-gray-200 text-gray-500 dark:border-dark-700 dark:text-gray-400">
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.failoverHopStats.table.account') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.failoverHopStats.table.platform') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.failoverHopStats.table.recoveredCount') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.failoverHopStats.table.totalFailoverHops') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.failoverHopStats.table.totalWastedAttempts') }}</th>
+                <th class="px-2 py-2 font-semibold">{{ t('admin.ops.failoverHopStats.table.avgHopsPerRecovered') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="row in items"
+                :key="row.account_id"
+                class="border-b border-gray-100 text-gray-700 last:border-b-0 dark:border-dark-800 dark:text-gray-200"
+              >
+                <td class="px-2 py-2 font-medium">{{ row.account_name }}</td>
+                <td class="px-2 py-2">{{ row.platform }}</td>
+                <td class="px-2 py-2">{{ formatInt(row.recovered_count) }}</td>
+                <td class="px-2 py-2">{{ formatInt(row.total_failover_hops) }}</td>
+                <td class="px-2 py-2">{{ formatInt(row.total_wasted_attempts) }}</td>
+                <td class="px-2 py-2">{{ formatRate(row.avg_failover_hops_per_recovered) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="mt-3 text-xs text-gray-500 dark:text-gray-400">
+        {{ t('admin.ops.failoverHopStats.totalAccounts', { total }) }}
+      </div>
+    </div>
+  </section>
+</template>

--- a/frontend/src/views/admin/ops/components/OpsSettingsDialog.vue
+++ b/frontend/src/views/admin/ops/components/OpsSettingsDialog.vue
@@ -525,8 +525,10 @@ async function saveAllSettings() {
             </div>
           </div>
 
-          <!-- OpenAI 账号配额自动暂停（全局默认阈值） -->
-          <div class="space-y-3">
+          <!-- TK (PR #899 follow-up): OpenAI 账号配额自动暂停已退役 —— 由 window-sched
+               三态守卫统一承载（默认 95% 仅粘性 / 99% 避开，含全局开关与账号级覆写）。
+               全局阈值控件隐藏（refs/保存保留以便旧值无害回传）。去掉 v-if="false" 可恢复。 -->
+          <div v-if="false" class="space-y-3">
             <h5 class="text-xs font-semibold text-gray-700 dark:text-gray-300">{{ t('admin.ops.settings.openaiQuotaAutoPause') }}</h5>
             <p class="text-xs text-gray-500">{{ t('admin.ops.settings.openaiQuotaAutoPauseHint') }}</p>
 

--- a/frontend/src/views/admin/ops/components/__tests__/OpsFailoverHopStatsCard.spec.ts
+++ b/frontend/src/views/admin/ops/components/__tests__/OpsFailoverHopStatsCard.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import OpsFailoverHopStatsCard from '../OpsFailoverHopStatsCard.vue'
+
+const mockGetFailoverHopStats = vi.fn()
+
+vi.mock('@/api/admin/ops', () => ({
+  opsAPI: {
+    getFailoverHopStats: (...args: any[]) => mockGetFailoverHopStats(...args),
+  },
+}))
+
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-i18n')>()
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+const SelectStub = defineComponent({
+  name: 'SelectControlStub',
+  props: {
+    modelValue: { type: [String, Number], default: '' },
+  },
+  emits: ['update:modelValue'],
+  template: '<div class="select-stub" />',
+})
+
+const EmptyStateStub = defineComponent({
+  name: 'EmptyState',
+  props: {
+    title: { type: String, default: '' },
+    description: { type: String, default: '' },
+  },
+  template: '<div class="empty-state">{{ title }}|{{ description }}</div>',
+})
+
+const sampleResponse = {
+  time_range: '1d' as const,
+  start_time: '2026-06-20T00:00:00Z',
+  end_time: '2026-06-21T00:00:00Z',
+  platform: 'openai',
+  group_id: 7,
+  items: [
+    {
+      account_id: 64,
+      account_name: 'cc-gpt-64',
+      platform: 'openai',
+      recovered_count: 139,
+      total_failover_hops: 139,
+      total_wasted_attempts: 160,
+      avg_failover_hops_per_recovered: 1.0,
+    },
+  ],
+  total: 1,
+  top_n: 10,
+}
+
+function mountCard(props: Record<string, any> = {}) {
+  return mount(OpsFailoverHopStatsCard, {
+    props: { refreshToken: 0, ...props },
+    global: {
+      stubs: { Select: SelectStub, EmptyState: EmptyStateStub },
+    },
+  })
+}
+
+describe('OpsFailoverHopStatsCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('默认加载并透传 platform/group/top_n，支持时间窗口切换', async () => {
+    mockGetFailoverHopStats.mockResolvedValue(sampleResponse)
+
+    const wrapper = mountCard({ platformFilter: 'openai', groupIdFilter: 7 })
+    await flushPromises()
+
+    expect(mockGetFailoverHopStats).toHaveBeenCalledWith(
+      expect.objectContaining({ time_range: '1d', platform: 'openai', group_id: 7, top_n: 10 })
+    )
+
+    const selects = wrapper.findAllComponents(SelectStub)
+    await selects[0].vm.$emit('update:modelValue', '1h')
+    await flushPromises()
+    expect(mockGetFailoverHopStats).toHaveBeenCalledWith(
+      expect.objectContaining({ time_range: '1h', platform: 'openai', group_id: 7 })
+    )
+  })
+
+  it('切换 TopN 触发按参数请求', async () => {
+    mockGetFailoverHopStats.mockResolvedValue(sampleResponse)
+    const wrapper = mountCard()
+    await flushPromises()
+
+    const selects = wrapper.findAllComponents(SelectStub)
+    await selects[1].vm.$emit('update:modelValue', 50)
+    await flushPromises()
+    expect(mockGetFailoverHopStats).toHaveBeenCalledWith(expect.objectContaining({ top_n: 50 }))
+  })
+
+  it('渲染账号行', async () => {
+    mockGetFailoverHopStats.mockResolvedValue(sampleResponse)
+    const wrapper = mountCard()
+    await flushPromises()
+    expect(wrapper.text()).toContain('cc-gpt-64')
+    expect(wrapper.find('.max-h-\\[420px\\]').exists()).toBe(true)
+  })
+
+  it('空数据显示空态', async () => {
+    mockGetFailoverHopStats.mockResolvedValue({ ...sampleResponse, items: [], total: 0 })
+    const wrapper = mountCard()
+    await flushPromises()
+    expect(wrapper.find('.empty-state').exists()).toBe(true)
+  })
+
+  it('接口异常显示错误提示', async () => {
+    mockGetFailoverHopStats.mockRejectedValue(new Error('加载失败'))
+    const wrapper = mountCard()
+    await flushPromises()
+    expect(wrapper.text()).toContain('加载失败')
+  })
+})

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3134,6 +3134,27 @@
         "leastUtilizedOpenAIAccount(windowDropped, time.Now())"
       ],
       "rationale": "Legacy + priority/LRU wiring of the OpenAI window guard across the remaining candidate-filter selection paths: selectAccountWithLoadAwareness Layer-2 (isSticky=false) + Layer-1 sticky (isSticky=true, marks clearSticky so the hit falls through without deleting the binding), selectBestAccount (isSticky=false; used by count_tokens failover + gemini-compat) and tryStickySessionHit (isSticky=true). selectAccountWithLoadAwareness is the DEFAULT prod path (advanced scheduler defaults off), so this is the load-bearing wiring for the reported incident; never-empty-pool fallback present here too. Anchors the hooks so an upstream merge cannot silently drop the guard call and revert the GPT line to window-blind selection."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler_tk_autopause_retired.go",
+      "must_contain": [
+        "func tkOpenAIAutoPauseRetired() bool { return true }"
+      ],
+      "rationale": "PR #902: retires the upstream codex usage-window auto-pause in favour of the window-sched tri-state guard (the single window mechanism). This gate disables (does NOT delete — §5.x) shouldAutoPauseOpenAIAccountByQuota by short-circuiting it; the upstream code + the shared codex signal capture the #899 guard reads stay intact. Anchors the gate so an upstream merge cannot silently flip auto-pause back on."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "if tkOpenAIAutoPauseRetired() {"
+      ],
+      "rationale": "PR #902 injection: the retirement short-circuit at the top of shouldAutoPauseOpenAIAccountByQuota. Pure-insertion guard returning a permanent no-op. If an upstream merge drops this one line, auto-pause silently revives and re-overlaps the window-sched guard — a silent regression. Anchor pins the injection."
+    },
+    {
+      "path": "backend/internal/service/openai_ws_forwarder.go",
+      "must_contain": [
+        "if !s.isAccountSchedulableForOpenAIWindow(ctx, account, true) {"
+      ],
+      "rationale": "PR #902 coverage parity: the window-sched tri-state guard now gates the previous_response_id chain (SelectAccountByPreviousResponseID) too, replacing the retired auto-pause that used to gate this path. isSticky=true keeps a StickyOnly account's chain, only a NotSchedulable account yields. If an upstream merge drops this line the prev-response path loses window coverage silently. Anchor pins the injection."
     }
   ]
 }


### PR DESCRIPTION
合并自 #902 + #903（两个 #899 的 follow-up 合成一个 PR），已 rebase 到当前 origin/main。

## 背景

PR #899 把 GPT 线选号改成窗口感知三态软避让（95% 仅粘性 / 99% 避开），减少 failover 多跳。本 PR 是它的两个配套收尾，合在一起评审：

## ① 退役上游 codex auto-pause（让三态成唯一对外机制）

window-sched 三态守卫与**上游自带的** codex 用量窗口 auto-pause 重叠（同一信号、同一「按额度避让」）。退役 auto-pause——**禁用而非删除（§5.x）**：

- 纯插入 TK 门 `tkOpenAIAutoPauseRetired` 把 `shouldAutoPauseOpenAIAccountByQuota` 短路成永久 no-op；上游函数体 + 三态守卫依赖的 codex 信号采集**原样保留可编译**。
- **覆盖等价**：三态守卫现也接入 `previous_response_id` 续链路径（`openai_ws_forwarder.go`，`isSticky=true`），完整接管 auto-pause 覆盖面。
- 前端隐藏账号弹窗 + Ops 设置里的配额 auto-pause 控件（refs/保存保留以便旧值无害回传）；不动「过期自动暂停」。
- load-bearing 注入已 anchor 进 `gateway-tk.json`。

## ② 每账号「浪费跳数」KPI 看板（量化减跳效果）

- read-time 聚合 over `ops_error_logs` recovered-200 行（`jsonb_array_length(upstream_errors)` = 浪费跳数，无 -1），按 `(account, platform)` 限 openai/newapi。**无迁移**，镜像 `GetOpenAITokenStats` 全链路（repo→service→port→handler→route）。
- 新卡片 `OpsFailoverHopStatsCard.vue`（TopN，真实账号 Total）+ 中英 i18n。

## 验证（合并分支整体）

- `go build ./...` ✅ · `go test -tags=unit ./...` ✅ · `go test -tags=integration`（hop-stats）✅ · `golangci-lint` 0 issues ✅ · `pnpm typecheck`+`lint:check` ✅ · `make test-frontend`（91 测试）✅ · `scripts/preflight.sh`（含全部 sub2api 检查）PASS ✅ · 前端 dist 重建。
- 测试：退役 no-op 直断言 + prev-response NotSchedulable/StickyOnly；hop-stats Postgres 集成测试（recovered 闸门 / 数组无-1 / kind 谓词 / 平台范围 / 按账号聚合 / 真实 Total）+ service 校验 + 卡片 spec。
- 注：`EditAccountModal.spec.ts` 有 2 个**既存红**（`codex-image-bridge-enabled`/model-mappings，与本 PR 无关，干净 main 上同样红），不在 CI critical 子集。

## 规则合规

- 上游形态文件改动均为**纯插入**；后端 load-bearing 注入已 anchor（真·防覆盖）；新 ops repo 用 `_tk.go` 后缀（非 hotspot）。
- 两处前端 UI 隐藏（隐藏既有控件、无 load-bearing 逻辑删除、无 upstream-merge revert 风险，逐一审过）：sentinel-registry-reviewed；upstream-touch-trivial
- **有前端改动**（非 no-web-impact）。合并方式：**Squash and merge**（TK 特性 PR）。Supersedes #902, #903。

🤖 Generated with [Claude Code](https://claude.com/claude-code)