### PR TITLE
fix(gateway): hard-exclude sustainedly-saturated anthropic mirror stubs

### DIFF
--- a/backend/internal/repository/anthropic_saturation_counter_cache.go
+++ b/backend/internal/repository/anthropic_saturation_counter_cache.go
@@ -13,17 +13,6 @@ const (
 	anthropicSaturationCountPrefix = "anthropic_saturation_count:account:"
 	anthropicSaturationFirstPrefix = "anthropic_saturation_first:account:"
 	anthropicSaturationLastPrefix  = "anthropic_saturation_last:account:"
-
-	// anthropicSaturationStreakTTLSeconds is the SLIDING TTL of the firstSeen /
-	// lastSeen streak keys (refreshed on every hit). It bounds the max gap between
-	// two consecutive capacity-envelope hits that still counts as ONE continuous
-	// streak: gaps longer than this expire the keys and reset the streak (so an
-	// edge that recovered then later re-failed starts a fresh streak, not a
-	// resumed one). MUST stay > the sustained-saturation min-age gate in the
-	// service layer (anthropicSustainedSaturationMinAgeSeconds) so a genuinely
-	// sustained outage can accumulate enough span to trip the hard floor before
-	// its keys expire. Self-clearing: once hits stop the keys lapse on their own.
-	anthropicSaturationStreakTTLSeconds = 150
 )
 
 // anthropicSaturationIncrScript atomically maintains TWO things per account:
@@ -89,9 +78,12 @@ func anthropicSaturationLastKey(accountID int64) string {
 	return fmt.Sprintf("%s%d", anthropicSaturationLastPrefix, accountID)
 }
 
-func (c *anthropicSaturationCounterCache) IncrementSaturation(ctx context.Context, accountID int64, windowSeconds int) (int64, error) {
+func (c *anthropicSaturationCounterCache) IncrementSaturation(ctx context.Context, accountID int64, windowSeconds, streakTTLSeconds int) (int64, error) {
 	if windowSeconds <= 0 {
 		return 0, fmt.Errorf("invalid window: %d", windowSeconds)
+	}
+	if streakTTLSeconds <= 0 {
+		return 0, fmt.Errorf("invalid streak ttl: %d", streakTTLSeconds)
 	}
 	keys := []string{
 		anthropicSaturationKey(accountID),
@@ -100,7 +92,7 @@ func (c *anthropicSaturationCounterCache) IncrementSaturation(ctx context.Contex
 	}
 	count, err := anthropicSaturationIncrScript.Run(
 		ctx, c.rdb, keys,
-		windowSeconds, anthropicSaturationStreakTTLSeconds,
+		windowSeconds, streakTTLSeconds,
 	).Int64()
 	if err != nil {
 		return 0, fmt.Errorf("increment anthropic saturation: %w", err)
@@ -162,18 +154,7 @@ func (c *anthropicSaturationCounterCache) GetSaturationBatch(ctx context.Context
 		return nil, fmt.Errorf("mget anthropic saturation: %w", err)
 	}
 	for i, v := range vals {
-		if v == nil {
-			continue
-		}
-		s, ok := v.(string)
-		if !ok {
-			continue
-		}
-		n, convErr := strconv.ParseInt(s, 10, 64)
-		if convErr != nil {
-			continue
-		}
-		if n != 0 {
+		if n := parseRedisInt64(v); n != 0 {
 			out[accountIDs[i]] = n
 		}
 	}

--- a/backend/internal/repository/anthropic_saturation_counter_cache.go
+++ b/backend/internal/repository/anthropic_saturation_counter_cache.go
@@ -9,24 +9,61 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-const anthropicSaturationCountPrefix = "anthropic_saturation_count:account:"
+const (
+	anthropicSaturationCountPrefix = "anthropic_saturation_count:account:"
+	anthropicSaturationFirstPrefix = "anthropic_saturation_first:account:"
+	anthropicSaturationLastPrefix  = "anthropic_saturation_last:account:"
 
-// anthropicSaturationIncrScript atomically INCRs the per-account saturation
-// counter; if it just became 1 (the key was absent/expired) it EXPIREs the key
-// to windowSec. A sustained burst therefore keeps the ORIGINAL fixed window
-// instead of sliding it forward on every hit — once the edge recovers and the
-// hits stop, the key expires and the count (and the scheduler's penalty) clears
-// on its own.
+	// anthropicSaturationStreakTTLSeconds is the SLIDING TTL of the firstSeen /
+	// lastSeen streak keys (refreshed on every hit). It bounds the max gap between
+	// two consecutive capacity-envelope hits that still counts as ONE continuous
+	// streak: gaps longer than this expire the keys and reset the streak (so an
+	// edge that recovered then later re-failed starts a fresh streak, not a
+	// resumed one). MUST stay > the sustained-saturation min-age gate in the
+	// service layer (anthropicSustainedSaturationMinAgeSeconds) so a genuinely
+	// sustained outage can accumulate enough span to trip the hard floor before
+	// its keys expire. Self-clearing: once hits stop the keys lapse on their own.
+	anthropicSaturationStreakTTLSeconds = 150
+)
+
+// anthropicSaturationIncrScript atomically maintains TWO things per account:
 //
-// KEYS[1] = count key, ARGV[1] = windowSec. Returns: count.
+//  1. The fixed-window count (KEYS[1]): INCR, and on first hit EXPIRE to
+//     windowSec. A sustained burst keeps the ORIGINAL fixed window instead of
+//     sliding it — once the edge recovers and hits stop, the count (and the
+//     bounded soft preference it drives) clears on its own.
+//  2. The sliding streak pair (KEYS[2]=firstSeen, KEYS[3]=lastSeen): firstSeen is
+//     set once per streak (NX) and lastSeen on every hit; BOTH carry a sliding TTL
+//     refreshed each hit. Their span (lastSeen-firstSeen) is the sustained-
+//     saturation signal that drives the HARD exclusion. The sliding TTL means a
+//     gap longer than streakTTL expires the pair and resets the streak.
+//
+// The streak epochs are stamped with the Redis server clock (redis.call('TIME')),
+// so the sustained signal span (lastSeen-firstSeen) is computed from two values on
+// the SAME clock — no app/Redis skew, and the predicate needs no wall clock at all.
+//
+// KEYS[1]=count, KEYS[2]=firstSeen, KEYS[3]=lastSeen.
+// ARGV[1]=windowSec, ARGV[2]=streakTTLSec. Returns: count.
 var anthropicSaturationIncrScript = redis.NewScript(`
-	local key = KEYS[1]
-	local window = tonumber(ARGV[1])
+	local countKey = KEYS[1]
+	local firstKey = KEYS[2]
+	local lastKey  = KEYS[3]
+	local window   = tonumber(ARGV[1])
+	local streakTTL= tonumber(ARGV[2])
+	local now      = redis.call('TIME')[1]
 
-	local count = redis.call('INCR', key)
+	local count = redis.call('INCR', countKey)
 	if count == 1 then
-		redis.call('EXPIRE', key, window)
+		redis.call('EXPIRE', countKey, window)
 	end
+
+	-- firstSeen: set once per streak (NX); SET NX EX already stamps the TTL, so
+	-- only slide it on the not-set (key-exists) branch.
+	if redis.call('SET', firstKey, now, 'NX', 'EX', streakTTL) == false then
+		redis.call('EXPIRE', firstKey, streakTTL)
+	end
+	-- lastSeen: always overwrite + (re)stamp the sliding TTL.
+	redis.call('SET', lastKey, now, 'EX', streakTTL)
 
 	return count
 `)
@@ -44,16 +81,71 @@ func anthropicSaturationKey(accountID int64) string {
 	return fmt.Sprintf("%s%d", anthropicSaturationCountPrefix, accountID)
 }
 
+func anthropicSaturationFirstKey(accountID int64) string {
+	return fmt.Sprintf("%s%d", anthropicSaturationFirstPrefix, accountID)
+}
+
+func anthropicSaturationLastKey(accountID int64) string {
+	return fmt.Sprintf("%s%d", anthropicSaturationLastPrefix, accountID)
+}
+
 func (c *anthropicSaturationCounterCache) IncrementSaturation(ctx context.Context, accountID int64, windowSeconds int) (int64, error) {
 	if windowSeconds <= 0 {
 		return 0, fmt.Errorf("invalid window: %d", windowSeconds)
 	}
-	key := anthropicSaturationKey(accountID)
-	count, err := anthropicSaturationIncrScript.Run(ctx, c.rdb, []string{key}, windowSeconds).Int64()
+	keys := []string{
+		anthropicSaturationKey(accountID),
+		anthropicSaturationFirstKey(accountID),
+		anthropicSaturationLastKey(accountID),
+	}
+	count, err := anthropicSaturationIncrScript.Run(
+		ctx, c.rdb, keys,
+		windowSeconds, anthropicSaturationStreakTTLSeconds,
+	).Int64()
 	if err != nil {
 		return 0, fmt.Errorf("increment anthropic saturation: %w", err)
 	}
 	return count, nil
+}
+
+// GetSaturationStreakBatch reads the firstSeen/lastSeen streak pair for each id in
+// one MGET (2 keys per account). Accounts with no active streak (both keys
+// absent/expired) are omitted from the result.
+func (c *anthropicSaturationCounterCache) GetSaturationStreakBatch(ctx context.Context, accountIDs []int64) (map[int64]service.AnthropicSaturationStreak, error) {
+	out := make(map[int64]service.AnthropicSaturationStreak, len(accountIDs))
+	if len(accountIDs) == 0 {
+		return out, nil
+	}
+	keys := make([]string, 0, len(accountIDs)*2)
+	for _, id := range accountIDs {
+		keys = append(keys, anthropicSaturationFirstKey(id), anthropicSaturationLastKey(id))
+	}
+	vals, err := c.rdb.MGet(ctx, keys...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("mget anthropic saturation streak: %w", err)
+	}
+	for i, id := range accountIDs {
+		first := parseRedisInt64(vals[2*i])
+		last := parseRedisInt64(vals[2*i+1])
+		if first > 0 || last > 0 {
+			out[id] = service.AnthropicSaturationStreak{FirstSeenUnix: first, LastSeenUnix: last}
+		}
+	}
+	return out, nil
+}
+
+// parseRedisInt64 converts an MGet element (string or nil) to int64; non-string /
+// unparseable / absent values yield 0.
+func parseRedisInt64(v any) int64 {
+	s, ok := v.(string)
+	if !ok {
+		return 0
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 func (c *anthropicSaturationCounterCache) GetSaturationBatch(ctx context.Context, accountIDs []int64) (map[int64]int64, error) {

--- a/backend/internal/repository/anthropic_saturation_counter_cache_test.go
+++ b/backend/internal/repository/anthropic_saturation_counter_cache_test.go
@@ -97,3 +97,65 @@ func TestAnthropicSaturationCounter_InvalidWindow(t *testing.T) {
 	_, err := cache.IncrementSaturation(context.Background(), 1, 0)
 	require.Error(t, err)
 }
+
+func TestAnthropicSaturationCounter_StreakFirstSeenNXLastSeenOverwrites(t *testing.T) {
+	cache, mr := newSaturationTestCache(t)
+	ctx := context.Background()
+
+	// Single fresh hit: firstSeen == lastSeen (span 0), both = current Redis TIME.
+	_, err := cache.IncrementSaturation(ctx, 5, 90)
+	require.NoError(t, err)
+	got, err := cache.GetSaturationStreakBatch(ctx, []int64{5})
+	require.NoError(t, err)
+	require.Positive(t, got[5].FirstSeenUnix)
+	require.Equal(t, got[5].FirstSeenUnix, got[5].LastSeenUnix, "single hit => span 0")
+
+	// Seed a pre-existing streak that started long ago (miniredis TIME is real
+	// wall-clock and not moved by FastForward, so seed explicit epochs). The next
+	// hit must PRESERVE firstSeen (set-once / NX) and OVERWRITE lastSeen to now, so
+	// the streak span reflects the real outage duration — the sustained signal.
+	mr.Set(anthropicSaturationFirstKey(7), "1000")
+	mr.Set(anthropicSaturationLastKey(7), "1000")
+	_, err = cache.IncrementSaturation(ctx, 7, 90)
+	require.NoError(t, err)
+	got, err = cache.GetSaturationStreakBatch(ctx, []int64{7})
+	require.NoError(t, err)
+	require.Equal(t, int64(1000), got[7].FirstSeenUnix, "firstSeen is set-once (NX), preserved across hits")
+	require.Greater(t, got[7].LastSeenUnix, int64(1000), "lastSeen is overwritten to now each hit")
+	require.Greater(t, got[7].LastSeenUnix-got[7].FirstSeenUnix, int64(120), "span grows with the streak (sustained)")
+}
+
+func TestAnthropicSaturationCounter_StreakSelfClearsAfterTTL(t *testing.T) {
+	cache, mr := newSaturationTestCache(t)
+	ctx := context.Background()
+
+	_, err := cache.IncrementSaturation(ctx, 8, 90)
+	require.NoError(t, err)
+	got, err := cache.GetSaturationStreakBatch(ctx, []int64{8})
+	require.NoError(t, err)
+	require.Contains(t, got, int64(8), "streak present right after a hit")
+
+	// No further hits for longer than the sliding streak TTL => keys expire and the
+	// streak self-clears (edge recovered), so the stub is re-included.
+	mr.FastForward((anthropicSaturationStreakTTLSeconds + 5) * time.Second)
+	got, err = cache.GetSaturationStreakBatch(ctx, []int64{8})
+	require.NoError(t, err)
+	require.Empty(t, got, "streak must self-clear after TTL of silence")
+}
+
+func TestAnthropicSaturationCounter_StreakBatchAbsentAndEmpty(t *testing.T) {
+	cache, _ := newSaturationTestCache(t)
+	ctx := context.Background()
+
+	_, err := cache.IncrementSaturation(ctx, 1, 90)
+	require.NoError(t, err)
+	out, err := cache.GetSaturationStreakBatch(ctx, []int64{1, 2})
+	require.NoError(t, err)
+	require.Contains(t, out, int64(1))
+	_, has2 := out[2]
+	require.False(t, has2, "account with no streak must be absent")
+
+	empty, err := cache.GetSaturationStreakBatch(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}

--- a/backend/internal/repository/anthropic_saturation_counter_cache_test.go
+++ b/backend/internal/repository/anthropic_saturation_counter_cache_test.go
@@ -31,7 +31,7 @@ func TestAnthropicSaturationCounter_IncrementAndGet(t *testing.T) {
 
 	// Three increments => count 3, batch read reflects it without mutating.
 	for i := 1; i <= 3; i++ {
-		c, incErr := cache.IncrementSaturation(ctx, 7, 90)
+		c, incErr := cache.IncrementSaturation(ctx, 7, 90, 150)
 		require.NoError(t, incErr)
 		require.Equal(t, int64(i), c)
 	}
@@ -46,7 +46,7 @@ func TestAnthropicSaturationCounter_FixedWindowTTLSelfClears(t *testing.T) {
 	cache, mr := newSaturationTestCache(t)
 	ctx := context.Background()
 
-	_, err := cache.IncrementSaturation(ctx, 42, 90)
+	_, err := cache.IncrementSaturation(ctx, 42, 90, 150)
 	require.NoError(t, err)
 	// TTL is set on the first INCR (key was absent).
 	ttl := mr.TTL(anthropicSaturationKey(42))
@@ -55,7 +55,7 @@ func TestAnthropicSaturationCounter_FixedWindowTTLSelfClears(t *testing.T) {
 	// Subsequent increments within the window keep the ORIGINAL window (TTL is
 	// only (re)set when the key was absent), so the window does not slide forever.
 	mr.FastForward(30 * time.Second)
-	_, err = cache.IncrementSaturation(ctx, 42, 90)
+	_, err = cache.IncrementSaturation(ctx, 42, 90, 150)
 	require.NoError(t, err)
 	ttlAfter := mr.TTL(anthropicSaturationKey(42))
 	require.LessOrEqual(t, ttlAfter, 60*time.Second, "window must not slide forward on later hits")
@@ -72,10 +72,10 @@ func TestAnthropicSaturationCounter_GetBatch(t *testing.T) {
 	ctx := context.Background()
 
 	for i := 0; i < 5; i++ {
-		_, err := cache.IncrementSaturation(ctx, 1, 90)
+		_, err := cache.IncrementSaturation(ctx, 1, 90, 150)
 		require.NoError(t, err)
 	}
-	_, err := cache.IncrementSaturation(ctx, 2, 90)
+	_, err := cache.IncrementSaturation(ctx, 2, 90, 150)
 	require.NoError(t, err)
 
 	// id 3 never incremented => absent.
@@ -92,10 +92,12 @@ func TestAnthropicSaturationCounter_GetBatch(t *testing.T) {
 	require.Empty(t, empty)
 }
 
-func TestAnthropicSaturationCounter_InvalidWindow(t *testing.T) {
+func TestAnthropicSaturationCounter_InvalidArgs(t *testing.T) {
 	cache, _ := newSaturationTestCache(t)
-	_, err := cache.IncrementSaturation(context.Background(), 1, 0)
-	require.Error(t, err)
+	_, err := cache.IncrementSaturation(context.Background(), 1, 0, 150)
+	require.Error(t, err, "non-positive window rejected")
+	_, err = cache.IncrementSaturation(context.Background(), 1, 90, 0)
+	require.Error(t, err, "non-positive streak ttl rejected")
 }
 
 func TestAnthropicSaturationCounter_StreakFirstSeenNXLastSeenOverwrites(t *testing.T) {
@@ -103,7 +105,7 @@ func TestAnthropicSaturationCounter_StreakFirstSeenNXLastSeenOverwrites(t *testi
 	ctx := context.Background()
 
 	// Single fresh hit: firstSeen == lastSeen (span 0), both = current Redis TIME.
-	_, err := cache.IncrementSaturation(ctx, 5, 90)
+	_, err := cache.IncrementSaturation(ctx, 5, 90, 150)
 	require.NoError(t, err)
 	got, err := cache.GetSaturationStreakBatch(ctx, []int64{5})
 	require.NoError(t, err)
@@ -116,7 +118,7 @@ func TestAnthropicSaturationCounter_StreakFirstSeenNXLastSeenOverwrites(t *testi
 	// the streak span reflects the real outage duration — the sustained signal.
 	mr.Set(anthropicSaturationFirstKey(7), "1000")
 	mr.Set(anthropicSaturationLastKey(7), "1000")
-	_, err = cache.IncrementSaturation(ctx, 7, 90)
+	_, err = cache.IncrementSaturation(ctx, 7, 90, 150)
 	require.NoError(t, err)
 	got, err = cache.GetSaturationStreakBatch(ctx, []int64{7})
 	require.NoError(t, err)
@@ -129,7 +131,8 @@ func TestAnthropicSaturationCounter_StreakSelfClearsAfterTTL(t *testing.T) {
 	cache, mr := newSaturationTestCache(t)
 	ctx := context.Background()
 
-	_, err := cache.IncrementSaturation(ctx, 8, 90)
+	const streakTTL = 150 // streak TTL passed below; service owns the canonical const
+	_, err := cache.IncrementSaturation(ctx, 8, 90, streakTTL)
 	require.NoError(t, err)
 	got, err := cache.GetSaturationStreakBatch(ctx, []int64{8})
 	require.NoError(t, err)
@@ -137,7 +140,7 @@ func TestAnthropicSaturationCounter_StreakSelfClearsAfterTTL(t *testing.T) {
 
 	// No further hits for longer than the sliding streak TTL => keys expire and the
 	// streak self-clears (edge recovered), so the stub is re-included.
-	mr.FastForward((anthropicSaturationStreakTTLSeconds + 5) * time.Second)
+	mr.FastForward((streakTTL + 5) * time.Second)
 	got, err = cache.GetSaturationStreakBatch(ctx, []int64{8})
 	require.NoError(t, err)
 	require.Empty(t, got, "streak must self-clear after TTL of silence")
@@ -147,7 +150,7 @@ func TestAnthropicSaturationCounter_StreakBatchAbsentAndEmpty(t *testing.T) {
 	cache, _ := newSaturationTestCache(t)
 	ctx := context.Background()
 
-	_, err := cache.IncrementSaturation(ctx, 1, 90)
+	_, err := cache.IncrementSaturation(ctx, 1, 90, 150)
 	require.NoError(t, err)
 	out, err := cache.GetSaturationStreakBatch(ctx, []int64{1, 2})
 	require.NoError(t, err)

--- a/backend/internal/service/anthropic_saturation_counter.go
+++ b/backend/internal/service/anthropic_saturation_counter.go
@@ -18,9 +18,15 @@ import "context"
 // with no separate clear-on-200 hook, marker, or cooldown state.
 type AnthropicSaturationCounterCache interface {
 	// IncrementSaturation records one downstream-capacity hit for accountID. The
-	// counter is a fixed window with TTL=windowSeconds (the TTL is set only when
-	// an empty key is first INCR'd, so a sustained burst keeps the original
-	// window rather than sliding it forward indefinitely). Returns the new count.
+	// fixed-window count has TTL=windowSeconds (set only when an empty key is
+	// first INCR'd, so a sustained burst keeps the original window rather than
+	// sliding it forward indefinitely). Returns the new fixed-window count.
+	//
+	// The SAME call also maintains a sliding "streak" pair (firstSeen + lastSeen
+	// epochs, sliding TTL refreshed on every hit) used by the sustained-saturation
+	// HARD exclusion (GetSaturationStreakBatch). The fixed count drives the bounded
+	// soft preference; the streak span drives the hard floor. Both are fed from the
+	// single increment site (recordAnthropicStubSaturation), so they stay in sync.
 	IncrementSaturation(ctx context.Context, accountID int64, windowSeconds int) (count int64, err error)
 
 	// GetSaturationBatch returns the current in-window counts for accountIDs in a
@@ -28,4 +34,25 @@ type AnthropicSaturationCounterCache interface {
 	// scores a whole candidate set per selection, so a batch read avoids N
 	// sequential Redis calls on the hot path.
 	GetSaturationBatch(ctx context.Context, accountIDs []int64) (map[int64]int64, error)
+
+	// GetSaturationStreakBatch returns the per-account sliding-streak state
+	// (firstSeen/lastSeen epochs) for accountIDs in one round trip. Missing/expired
+	// keys are absent from the map. Used by the sustained-saturation HARD exclusion
+	// (tkFilterSustainedlySaturated): a stub whose continuous-saturation streak has
+	// spanned >= a minimum age is dead long enough to route around entirely, not
+	// just de-prioritize. The streak keys self-clear via their sliding TTL once the
+	// edge recovers and hits stop.
+	GetSaturationStreakBatch(ctx context.Context, accountIDs []int64) (map[int64]AnthropicSaturationStreak, error)
+}
+
+// AnthropicSaturationStreak is the sliding continuous-saturation streak state for
+// one mirror stub. FirstSeenUnix is the epoch of the first hit of the current
+// streak (set once, refreshed-TTL each hit); LastSeenUnix is the epoch of the most
+// recent hit. The streak duration LastSeenUnix-FirstSeenUnix is the sustained
+// signal: it can only reach the minimum age via continuous hits over real wall
+// time, so a transient burst (span ~seconds) can never satisfy it. Both zero =>
+// no active streak (keys absent/expired).
+type AnthropicSaturationStreak struct {
+	FirstSeenUnix int64
+	LastSeenUnix  int64
 }

--- a/backend/internal/service/anthropic_saturation_counter.go
+++ b/backend/internal/service/anthropic_saturation_counter.go
@@ -23,11 +23,14 @@ type AnthropicSaturationCounterCache interface {
 	// sliding it forward indefinitely). Returns the new fixed-window count.
 	//
 	// The SAME call also maintains a sliding "streak" pair (firstSeen + lastSeen
-	// epochs, sliding TTL refreshed on every hit) used by the sustained-saturation
-	// HARD exclusion (GetSaturationStreakBatch). The fixed count drives the bounded
-	// soft preference; the streak span drives the hard floor. Both are fed from the
-	// single increment site (recordAnthropicStubSaturation), so they stay in sync.
-	IncrementSaturation(ctx context.Context, accountID int64, windowSeconds int) (count int64, err error)
+	// epochs, TTL=streakTTLSeconds refreshed on every hit) used by the sustained-
+	// saturation HARD exclusion (GetSaturationStreakBatch). The fixed count drives
+	// the bounded soft preference; the streak span drives the hard floor. Both are
+	// fed from the single increment site (recordAnthropicStubSaturation), so they
+	// stay in sync. streakTTLSeconds is passed (not a repo constant) so it lives in
+	// the same package as the min-age gate it must exceed — see the invariant test
+	// in gateway_service_tk_sustained_saturation_test.go.
+	IncrementSaturation(ctx context.Context, accountID int64, windowSeconds, streakTTLSeconds int) (count int64, err error)
 
 	// GetSaturationBatch returns the current in-window counts for accountIDs in a
 	// single round trip (MGET). Missing/expired keys map to 0. The scheduler

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1952,6 +1952,13 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 			}
 		}
 
+		// TK: drop sustainedly-saturated stubs (edge dead for a sustained window)
+		// from the routed set too, with an all-saturated last-resort guard. The
+		// soft +1000 preference is NOT applied on the routing path, so without this
+		// a routed dead stub would keep being picked first. See
+		// gateway_service_tk_sustained_saturation.go.
+		routingCandidates = s.tkFilterSustainedlySaturated(ctx, routingCandidates)
+
 		if len(routingCandidates) > 0 {
 			// 1.5. 在路由账号范围内检查粘性会话
 			if sessionHash != "" && stickyAccountID > 0 {
@@ -2363,6 +2370,14 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 		}
 		return nil, ErrNoAvailableAccounts
 	}
+
+	// TK: hard-exclude sustainedly-saturated anthropic mirror stubs (edge dead for
+	// a sustained window) from the load-balance + Layer-3 fallback candidate set,
+	// with an all-saturated last-resort guard. This is the hard tier above the
+	// bounded soft preference (computeAnthropicSaturationPenalties) and is what
+	// actually keeps traffic off a 30m-dead stub. See
+	// gateway_service_tk_sustained_saturation.go.
+	candidates = s.tkFilterSustainedlySaturated(ctx, candidates)
 
 	accountLoads := make([]AccountWithConcurrency, 0, len(candidates))
 	for _, acc := range candidates {

--- a/backend/internal/service/gateway_service_tk_saturation_penalty_test.go
+++ b/backend/internal/service/gateway_service_tk_saturation_penalty_test.go
@@ -22,7 +22,7 @@ type fakeSaturationCache struct {
 	streakErr error
 }
 
-func (f *fakeSaturationCache) IncrementSaturation(_ context.Context, accountID int64, _ int) (int64, error) {
+func (f *fakeSaturationCache) IncrementSaturation(_ context.Context, accountID int64, _, _ int) (int64, error) {
 	if f.counts == nil {
 		f.counts = map[int64]int64{}
 	}

--- a/backend/internal/service/gateway_service_tk_saturation_penalty_test.go
+++ b/backend/internal/service/gateway_service_tk_saturation_penalty_test.go
@@ -16,8 +16,10 @@ import (
 // fakeSaturationCache implements AnthropicSaturationCounterCache from a static
 // per-account count map, so score-side tests run without Redis.
 type fakeSaturationCache struct {
-	counts map[int64]int64
-	getErr error
+	counts    map[int64]int64
+	streaks   map[int64]AnthropicSaturationStreak
+	getErr    error
+	streakErr error
 }
 
 func (f *fakeSaturationCache) IncrementSaturation(_ context.Context, accountID int64, _ int) (int64, error) {
@@ -36,6 +38,19 @@ func (f *fakeSaturationCache) GetSaturationBatch(_ context.Context, ids []int64)
 	for _, id := range ids {
 		if n := f.counts[id]; n != 0 {
 			out[id] = n
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeSaturationCache) GetSaturationStreakBatch(_ context.Context, ids []int64) (map[int64]AnthropicSaturationStreak, error) {
+	if f.streakErr != nil {
+		return nil, f.streakErr
+	}
+	out := map[int64]AnthropicSaturationStreak{}
+	for _, id := range ids {
+		if st, ok := f.streaks[id]; ok {
+			out[id] = st
 		}
 	}
 	return out, nil

--- a/backend/internal/service/gateway_service_tk_sustained_saturation.go
+++ b/backend/internal/service/gateway_service_tk_sustained_saturation.go
@@ -1,0 +1,140 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+)
+
+// TK — anthropic SUSTAINEDLY-saturated mirror-stub HARD exclusion.
+//
+// Problem (prod, recurring): prod reaches Anthropic only through per-edge api-key
+// mirror "stub" accounts (cc-<edge>) that forward to one Edge gateway. When an
+// edge's sole OAuth account is window-rate-limited (~30m+), the edge returns
+// TokenKey's own header-less capacity envelope ("No available accounts" 429 /
+// "Upstream rate limit exceeded" 502). The skip predicates
+// (tkSkipDownstreamNoAvailableAccountsPenalty / tkIsAnthropicNonAuthoritative429)
+// correctly suppress cooldown + fail over — but DELIBERATELY keep the stub fully
+// schedulable (the 2026-05-31 "503 amplifier" fix: cooling stubs on a transient
+// edge blip collapses the whole pool). The consequence for a stub whose edge is
+// dead for a SUSTAINED window: the stub is never marked unschedulable, ties its
+// healthy siblings on base priority, and — because LRU favours the perpetually-
+// failing stub (its LastUsedAt only advances on SUCCESS) — keeps getting picked
+// FIRST every request, wasting a failover hop on the dead edge and (when that hop
+// + edge latency exceeds the client's timeout) starving healthy siblings while
+// the client retries. Operator-disabling the stub fixes it instantly because that
+// is a HARD exclusion (Schedulable=false) — the exact primitive the existing
+// bounded soft de-prioritization (gateway_service_tk_saturation_penalty.go) never
+// performs.
+//
+// This file adds the missing primitive: a HARD-but-SHORT, self-clearing exclusion
+// for a stub that has been CONTINUOUSLY saturated for at least a minimum age. It
+// is the hard tier above the soft +1000 preference (which stays for the moderate /
+// young-saturation case), and it is amplifier-safe BY CONSTRUCTION:
+//
+//   - Distinguishes "edge dead 30m" from "edge transiently dry 5s" via the streak
+//     SPAN (lastSeen-firstSeen), which can only reach the min-age via continuous
+//     hits over real wall time. A 3-request burst (span ~seconds) can NEVER trip
+//     it, so it cannot reproduce the 503-amplifier collapse.
+//   - Span-based, not rate-based: robust at LOW traffic (a few hits/min sustained
+//     for >= min-age still trips it), where the fixed-window count never could.
+//   - Never empties the pool: the all-saturated last-resort guard keeps every
+//     candidate when exclusion would leave nothing schedulable.
+//   - Self-clearing: recomputed live each selection from the short sliding-TTL
+//     streak keys; once the edge recovers and hits stop, the keys expire and the
+//     stub is re-included with no cooldown state, no SetTempUnschedulable, no
+//     ladder advance.
+//   - Request-owned policy 429s never feed the counter (recordAnthropicStubSaturation
+//     is only reached on the downstream-capacity skip branches), so the same-text /
+//     request-owned breaker is untouched.
+//
+// Shares the kill-switch (SettingKeyAnthropicSaturatedStubDeprioritizeEnabled) and
+// the Redis counter (tkAnthropicSaturationCounter) with the soft preference; when
+// either is unset the whole feature is inert.
+
+// anthropicSustainedSaturationMinAgeSeconds is the minimum continuous-saturation
+// streak SPAN (lastSeen-firstSeen) at which a mirror stub is treated as
+// sustainedly dead and HARD-excluded from selection. A span this large requires
+// capacity-envelope hits spanning >= this many seconds within the sliding streak
+// window, which a transient blip / request burst cannot produce. MUST stay <
+// anthropicSaturationStreakTTLSeconds (repository layer) so the streak keys do not
+// expire before the span can accumulate.
+const anthropicSustainedSaturationMinAgeSeconds int64 = 120
+
+// tkIsAnthropicStubSustainedlySaturated reports whether a streak state represents
+// a sustained outage: a real, non-zero streak whose span has reached the min age.
+// Pure; no I/O, no clock — the span is computed entirely from the stored epochs
+// (lastSeen is the most recent hit), so it is deterministic and trivially
+// testable. A span >= min-age implies >= 2 hits spanning that duration, so a
+// single stray hit (firstSeen==lastSeen => span 0) never qualifies.
+func tkIsAnthropicStubSustainedlySaturated(st AnthropicSaturationStreak) bool {
+	if st.FirstSeenUnix <= 0 || st.LastSeenUnix <= 0 {
+		return false
+	}
+	return st.LastSeenUnix-st.FirstSeenUnix >= anthropicSustainedSaturationMinAgeSeconds
+}
+
+// tkFilterSustainedlySaturated removes sustainedly-saturated anthropic mirror
+// stubs from a selection candidate set, with an all-saturated last-resort guard.
+// Returns the input unchanged when the feature is off / inert, when there is < 2
+// candidates (cannot drop without emptying), or when applying the exclusion would
+// leave nothing schedulable (all candidates saturated). Best-effort: any Redis
+// error leaves the candidate set untouched — selection must never fail because the
+// streak counter is unavailable.
+//
+// Called on the Layer-1 (model-routing) and Layer-2 (load-aware) candidate sets so
+// the exclusion covers BOTH paths — unlike the soft preference, which the routing
+// path never applies.
+func (s *GatewayService) tkFilterSustainedlySaturated(ctx context.Context, candidates []*Account) []*Account {
+	if s == nil || s.tkAnthropicSaturationCounter == nil || len(candidates) < 2 {
+		return candidates
+	}
+	if s.settingService != nil && !s.settingService.IsAnthropicSaturatedStubDeprioritizeEnabled(ctx) {
+		return candidates
+	}
+
+	ids := make([]int64, 0, len(candidates))
+	for _, acc := range candidates {
+		if acc != nil && acc.Platform == PlatformAnthropic {
+			ids = append(ids, acc.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return candidates
+	}
+
+	states, err := s.tkAnthropicSaturationCounter.GetSaturationStreakBatch(ctx, ids)
+	if err != nil {
+		slog.Warn("anthropic_sustained_saturation_read_failed", "error", err)
+		return candidates
+	}
+	if len(states) == 0 {
+		return candidates
+	}
+
+	kept := make([]*Account, 0, len(candidates))
+	var dropped []int64
+	for _, acc := range candidates {
+		if acc != nil && acc.Platform == PlatformAnthropic {
+			if st, ok := states[acc.ID]; ok && tkIsAnthropicStubSustainedlySaturated(st) {
+				dropped = append(dropped, acc.ID)
+				continue
+			}
+		}
+		kept = append(kept, acc)
+	}
+
+	// All-saturated last-resort guard: never empty the pool. If nothing was
+	// dropped, or dropping would leave zero candidates, keep the original set
+	// (the bounded soft preference still de-prioritizes them relative to any
+	// healthier stub).
+	if len(dropped) == 0 || len(kept) == 0 {
+		return candidates
+	}
+
+	slog.Info("anthropic_sustained_saturation_excluded",
+		"excluded_account_ids", dropped,
+		"kept", len(kept),
+		"candidates", len(candidates),
+		"min_age_seconds", anthropicSustainedSaturationMinAgeSeconds)
+	return kept
+}

--- a/backend/internal/service/gateway_service_tk_sustained_saturation_test.go
+++ b/backend/internal/service/gateway_service_tk_sustained_saturation_test.go
@@ -14,6 +14,16 @@ func anthropicAcct(id int64) *Account {
 	return &Account{ID: id, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
 }
 
+// Load-bearing invariant, mechanized (was a prose comment across two packages):
+// the streak keys' sliding TTL must EXCEED the min-age gate, otherwise the keys
+// expire before a span can reach the min age and the hard exclusion silently
+// never fires. Both constants now live in package service so this guard can see
+// them; if a future edit narrows the margin the build fails here, not in prod.
+func TestSustainedSaturation_StreakTTLExceedsMinAge(t *testing.T) {
+	require.Greater(t, int64(anthropicSaturationStreakTTLSeconds), anthropicSustainedSaturationMinAgeSeconds,
+		"streak TTL must exceed the sustained min-age gate, else the streak expires before its span can reach the gate (silent feature death)")
+}
+
 func acctIDs(accs []*Account) map[int64]bool {
 	out := make(map[int64]bool, len(accs))
 	for _, a := range accs {

--- a/backend/internal/service/gateway_service_tk_sustained_saturation_test.go
+++ b/backend/internal/service/gateway_service_tk_sustained_saturation_test.go
@@ -1,0 +1,154 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func anthropicAcct(id int64) *Account {
+	return &Account{ID: id, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+}
+
+func acctIDs(accs []*Account) map[int64]bool {
+	out := make(map[int64]bool, len(accs))
+	for _, a := range accs {
+		out[a.ID] = true
+	}
+	return out
+}
+
+// --- predicate ---
+
+func TestIsSustainedlySaturated_Predicate(t *testing.T) {
+	min := anthropicSustainedSaturationMinAgeSeconds
+	cases := []struct {
+		name string
+		st   AnthropicSaturationStreak
+		want bool
+	}{
+		{"zero state", AnthropicSaturationStreak{}, false},
+		{"first only", AnthropicSaturationStreak{FirstSeenUnix: 1000}, false},
+		{"last only", AnthropicSaturationStreak{LastSeenUnix: 1000}, false},
+		{"single stray hit (span 0)", AnthropicSaturationStreak{FirstSeenUnix: 1000, LastSeenUnix: 1000}, false},
+		// AMPLIFIER REGRESSION GUARD: a short burst (span < min age) is NEVER
+		// sustained, so a 3-request edge blip can never be hard-excluded.
+		{"young burst (span 5s)", AnthropicSaturationStreak{FirstSeenUnix: 1000, LastSeenUnix: 1005}, false},
+		{"just below min age", AnthropicSaturationStreak{FirstSeenUnix: 1000, LastSeenUnix: 1000 + min - 1}, false},
+		{"exactly min age", AnthropicSaturationStreak{FirstSeenUnix: 1000, LastSeenUnix: 1000 + min}, true},
+		{"well past min age (30m dead edge)", AnthropicSaturationStreak{FirstSeenUnix: 1000, LastSeenUnix: 1000 + 1800}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, tkIsAnthropicStubSustainedlySaturated(c.st))
+		})
+	}
+}
+
+// --- filter ---
+
+func sustainedGW(t *testing.T, streaks map[int64]AnthropicSaturationStreak) *GatewayService {
+	t.Helper()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{streaks: streaks})
+	return gw
+}
+
+// sustained = a streak whose span comfortably exceeds the min age.
+func sustainedStreak() AnthropicSaturationStreak {
+	return AnthropicSaturationStreak{FirstSeenUnix: 1000, LastSeenUnix: 1000 + anthropicSustainedSaturationMinAgeSeconds + 60}
+}
+
+func TestFilterSustained_DropsDeadStubKeepsHealthy(t *testing.T) {
+	resetSatCache()
+	// cc-us2 (46) sustainedly saturated, cc-us4 (51) healthy (no streak).
+	gw := sustainedGW(t, map[int64]AnthropicSaturationStreak{46: sustainedStreak()})
+	in := []*Account{anthropicAcct(46), anthropicAcct(51)}
+	out := gw.tkFilterSustainedlySaturated(context.Background(), in)
+	require.Len(t, out, 1)
+	require.Equal(t, int64(51), out[0].ID, "dead cc-us2 dropped, healthy cc-us4 kept")
+}
+
+func TestFilterSustained_AllSaturatedLastResortGuard(t *testing.T) {
+	resetSatCache()
+	// Both sustainedly saturated => guard keeps the full set (never empty the pool).
+	gw := sustainedGW(t, map[int64]AnthropicSaturationStreak{
+		46: sustainedStreak(),
+		51: sustainedStreak(),
+	})
+	in := []*Account{anthropicAcct(46), anthropicAcct(51)}
+	out := gw.tkFilterSustainedlySaturated(context.Background(), in)
+	require.Len(t, out, 2, "all-saturated => keep all (last-resort guard)")
+	require.True(t, acctIDs(out)[46] && acctIDs(out)[51])
+}
+
+func TestFilterSustained_YoungBurstNotExcluded(t *testing.T) {
+	resetSatCache()
+	// 503-amplifier regression guard: a burst (young span) on cc-us2 must NOT be
+	// excluded even with a healthy sibling present.
+	gw := sustainedGW(t, map[int64]AnthropicSaturationStreak{
+		46: {FirstSeenUnix: 1000, LastSeenUnix: 1003}, // span 3s
+	})
+	in := []*Account{anthropicAcct(46), anthropicAcct(51)}
+	out := gw.tkFilterSustainedlySaturated(context.Background(), in)
+	require.Len(t, out, 2, "young burst must not be hard-excluded")
+}
+
+func TestFilterSustained_NonAnthropicUntouched(t *testing.T) {
+	resetSatCache()
+	// A non-anthropic candidate is never consulted/excluded; the sustained
+	// anthropic stub is dropped because a healthy candidate (the non-anthropic
+	// one) remains.
+	gw := sustainedGW(t, map[int64]AnthropicSaturationStreak{46: sustainedStreak()})
+	openai := &Account{ID: 99, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	in := []*Account{anthropicAcct(46), openai}
+	out := gw.tkFilterSustainedlySaturated(context.Background(), in)
+	require.Len(t, out, 1)
+	require.Equal(t, int64(99), out[0].ID)
+}
+
+func TestFilterSustained_SingleCandidateUnchanged(t *testing.T) {
+	resetSatCache()
+	// < 2 candidates => cannot drop without emptying => unchanged even if dead.
+	gw := sustainedGW(t, map[int64]AnthropicSaturationStreak{46: sustainedStreak()})
+	in := []*Account{anthropicAcct(46)}
+	out := gw.tkFilterSustainedlySaturated(context.Background(), in)
+	require.Len(t, out, 1)
+	require.Equal(t, int64(46), out[0].ID)
+}
+
+func TestFilterSustained_KillSwitchOff(t *testing.T) {
+	resetSatCache()
+	gw := sustainedGW(t, map[int64]AnthropicSaturationStreak{46: sustainedStreak()})
+	gw.settingService = NewSettingService(
+		&satSettingRepoStub{values: map[string]string{
+			SettingKeyAnthropicSaturatedStubDeprioritizeEnabled: "false",
+		}},
+		&config.Config{},
+	)
+	in := []*Account{anthropicAcct(46), anthropicAcct(51)}
+	out := gw.tkFilterSustainedlySaturated(context.Background(), in)
+	require.Len(t, out, 2, "kill-switch off => no exclusion")
+	resetSatCache()
+}
+
+func TestFilterSustained_NilCacheInert(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{} // no counter wired
+	in := []*Account{anthropicAcct(46), anthropicAcct(51)}
+	out := gw.tkFilterSustainedlySaturated(context.Background(), in)
+	require.Len(t, out, 2, "nil cache => feature inert")
+}
+
+func TestFilterSustained_ReadErrorSafe(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{streakErr: context.DeadlineExceeded})
+	in := []*Account{anthropicAcct(46), anthropicAcct(51)}
+	out := gw.tkFilterSustainedlySaturated(context.Background(), in)
+	require.Len(t, out, 2, "read error => candidate set untouched (selection never fails on counter)")
+}

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
@@ -81,7 +81,7 @@ func TestRateLimitService_HandleUpstreamError_DownstreamNoAvailable429_DoesNotPe
 // side test (read methods are unused on the rate-limit side).
 type fakeSaturationCounterRL struct{ incrementIDs []int64 }
 
-func (f *fakeSaturationCounterRL) IncrementSaturation(_ context.Context, accountID int64, _ int) (int64, error) {
+func (f *fakeSaturationCounterRL) IncrementSaturation(_ context.Context, accountID int64, _, _ int) (int64, error) {
 	f.incrementIDs = append(f.incrementIDs, accountID)
 	return int64(len(f.incrementIDs)), nil
 }

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
@@ -88,6 +88,9 @@ func (f *fakeSaturationCounterRL) IncrementSaturation(_ context.Context, account
 func (f *fakeSaturationCounterRL) GetSaturationBatch(_ context.Context, _ []int64) (map[int64]int64, error) {
 	return map[int64]int64{}, nil
 }
+func (f *fakeSaturationCounterRL) GetSaturationStreakBatch(_ context.Context, _ []int64) (map[int64]AnthropicSaturationStreak, error) {
+	return map[int64]AnthropicSaturationStreak{}, nil
+}
 
 // The saturation feature MUST feed the de-prioritization counter on the skip
 // path while NEVER advancing the 3/3 ladder or writing temp_unschedulable /

--- a/backend/internal/service/ratelimit_service_tk_saturation.go
+++ b/backend/internal/service/ratelimit_service_tk_saturation.go
@@ -37,6 +37,19 @@ const (
 	// no-available hits (e.g. one momentary edge burst) never trip it; only a
 	// SUSTAINED pattern does.
 	anthropicSaturationThreshold int64 = 4
+
+	// anthropicSaturationStreakTTLSeconds is the SLIDING TTL of the firstSeen /
+	// lastSeen streak keys (refreshed on every hit), feeding the sustained-
+	// saturation HARD exclusion. It bounds the max gap between two consecutive
+	// capacity-envelope hits that still counts as ONE continuous streak; a longer
+	// gap expires the keys and resets the streak (so a recovered-then-re-failed
+	// edge starts fresh). It lives here — in the same package as
+	// anthropicSustainedSaturationMinAgeSeconds, which it MUST exceed so a span can
+	// reach the min age before the keys expire — and is passed into the counter
+	// (not a repo constant) so the invariant is intra-package and test-guarded
+	// (TestSustainedSaturation_StreakTTLExceedsMinAge). See
+	// gateway_service_tk_sustained_saturation.go.
+	anthropicSaturationStreakTTLSeconds = 150
 )
 
 // SetAnthropicSaturationCounter wires the Redis-backed saturation counter into
@@ -57,7 +70,7 @@ func (s *RateLimitService) recordAnthropicStubSaturation(ctx context.Context, ac
 	if s == nil || s.anthropicSaturationCounter == nil {
 		return
 	}
-	count, err := s.anthropicSaturationCounter.IncrementSaturation(ctx, accountID, anthropicSaturationWindowSeconds)
+	count, err := s.anthropicSaturationCounter.IncrementSaturation(ctx, accountID, anthropicSaturationWindowSeconds, anthropicSaturationStreakTTLSeconds)
 	if err != nil {
 		slog.Warn("anthropic_stub_saturation_increment_failed",
 			"account_id", accountID,

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2523,10 +2523,12 @@
       "must_contain": [
         "func NewAnthropicSaturationCounterCache(",
         "anthropic_saturation_count:account:",
+        "anthropic_saturation_first:account:",
         "anthropicSaturationIncrScript",
-        "func (c *anthropicSaturationCounterCache) GetSaturationBatch("
+        "func (c *anthropicSaturationCounterCache) GetSaturationBatch(",
+        "func (c *anthropicSaturationCounterCache) GetSaturationStreakBatch("
       ],
-      "rationale": "Redis-backed fixed-window counter for the saturation de-prioritization. The INCR+EXPIRE-on-first-hit Lua keeps the ORIGINAL window (no sliding) so the count tracks a sustained burst and self-clears on TTL; GetSaturationBatch (MGET) is the scheduler's per-selection hot-path read. Deleting this repo file breaks the wire provider and disables the feature."
+      "rationale": "Redis-backed counter for the saturation routing-away. The INCR+EXPIRE-on-first-hit Lua keeps the ORIGINAL fixed window for the soft-preference count (GetSaturationBatch); the SAME Lua also maintains the sliding firstSeen/lastSeen streak pair (Redis-clock stamped) whose span feeds the sustained-saturation HARD exclusion (GetSaturationStreakBatch). Deleting this repo file breaks the wire provider and disables both the soft preference and the hard floor."
     },
     {
       "path": "backend/internal/service/setting_service_tk_saturation.go",
@@ -3155,6 +3157,24 @@
         "if !s.isAccountSchedulableForOpenAIWindow(ctx, account, true) {"
       ],
       "rationale": "PR #902 coverage parity: the window-sched tri-state guard now gates the previous_response_id chain (SelectAccountByPreviousResponseID) too, replacing the retired auto-pause that used to gate this path. isSticky=true keeps a StickyOnly account's chain, only a NotSchedulable account yields. If an upstream merge drops this line the prev-response path loses window coverage silently. Anchor pins the injection."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_sustained_saturation.go",
+      "must_contain": [
+        "func tkIsAnthropicStubSustainedlySaturated(",
+        "func (s *GatewayService) tkFilterSustainedlySaturated(",
+        "anthropicSustainedSaturationMinAgeSeconds int64 = 120",
+        "anthropic_sustained_saturation_excluded"
+      ],
+      "rationale": "Hard tier of the anthropic saturated mirror-stub routing-away (prod 2026-06-21): a stub whose continuous-saturation streak SPAN (lastSeen-firstSeen) has reached the min age is HARD-excluded from selection, not just soft de-prioritized. This is the primitive that actually keeps traffic off a 30m-dead edge — the soft +1000 preference (gateway_service_tk_saturation_penalty.go) only reorders and, at low/bursty traffic with a fixed-window count and LRU favouring the perpetually-failing stub, lets the dead stub keep being picked first (prod incident: cc-us2 hogging scheduling while healthy cc-us4 starves at 0/70, client retries). Amplifier-safe by construction: a transient burst's span can never reach the min age, so it can never reproduce the 2026-05-31 503 amplifier; all-saturated last-resort guard never empties the pool; self-clearing via the sliding streak TTL (no cooldown, no SetTempUnschedulable, no ladder). Deleting this file silently re-breaks prod failover."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "s.tkFilterSustainedlySaturated(ctx, candidates)",
+        "s.tkFilterSustainedlySaturated(ctx, routingCandidates)"
+      ],
+      "rationale": "Load-bearing wiring of the sustained-saturation HARD exclusion into BOTH the Layer-2 load-aware candidate set and the Layer-1 model-routing candidate set. These two thin calls are what actually route traffic away from a sustainedly-dead mirror stub; if an upstream merge reverts gateway_service.go they vanish and a 30m-dead stub is silently re-included as a first-class, LRU-preferred candidate, re-breaking prod failover (cc-us2 hogging scheduling while cc-us4 starves). See gateway_service_tk_sustained_saturation.go."
     }
   ]
 }


### PR DESCRIPTION
## 问题（线上反复出现）

某 prod `cc-<edge>` anthropic api-key **镜像 stub**，当它唯一的 edge 被窗口限流后，会**一直接请求而不转去健康的兄弟 stub**——线上现象：**cc-us2 间歇 2/70、健康的 cc-us4 一直 0/70、客户端反复重试**；一旦运维把 cc-us2 关掉调度，流量立刻落到 cc-us4。

根因（代码追踪 + 对抗性交叉验证 + 线上 SSM 核实）：

- edge 空池快速失败返回的是**无头** `429 "No available accounts"`。按 2026-05-31「503 放大器」修复，跳过谓词（`tkSkipDownstreamNoAvailableAccountsPenalty` / `tkIsAnthropicNonAuthoritative429`）**故意不冷却 stub**——这对瞬时抖动是对的，但也意味着 edge **持续**死掉时 stub 仍 `IsSchedulable()`。
- 所有 cc-* 的 `accounts.priority=1`，cc-us2 与 cc-us4 平级；`selectByLRU` 又**偏向一直失败的 stub**（`LastUsedAt` 只在转发**成功**时更新）。于是死 stub 每个请求都被**优先**选中，在死 edge 上白白浪费一跳，把健康兄弟饿死、客户端只能重试。
- 唯一的纠偏——软性 `+1000` 降权——太弱：只**重排不排除**、**固定 90s 窗计数对速率敏感**（低流量永远不触发）、且 **model-routing 路径上根本没接**。
- 关掉调度立刻好，是因为那是**硬排除**（`Schedulable=false`）——正是软层从不执行的那个原语。

线上核实（只读 SSM）：降权 kill-switch 默认**开**；edge 信封确认无头（`anthropic_downstream_no_available_accounts_skip_penalty` 近 2h 全池 ~12k 次）；涉事 stub **无** custom-error-codes（排除原地重试）、**无** model routing（排除 routing 路径粘死）。

## 修复 — Option A：持续饱和的硬性短命排除

补上缺失的原语：**连续饱和 ≥ 一个最小时长**的 stub 从选号中**硬排除**（软层之上的硬档，软层原样保留作为亚阈值档）。

- **滑动 `firstSeen`/`lastSeen` 流对**（Redis 时钟戳）由既有饱和计数器的同一次自增维护；**span（lastSeen-firstSeen）**就是持续信号——任意流量速率下都稳健，固定窗计数做不到。
- `tkIsAnthropicStubSustainedlySaturated` + `tkFilterSustainedlySaturated`（新 `*_tk_*.go` companion），接入 **Layer-1 routing 与 Layer-2 负载均衡两个候选集**，带**全员饱和兜底**（永不排空池）。

### 为什么不会重蹈 503 放大器
- **结构上天然安全**：瞬时 burst 的 span 永远到不了最小时长（120s），3 个请求的抖动**结构上不可能**触发硬档——只有真正持续的故障才会。
- **不是冷却语义**：从不 `SetTempUnschedulable`/`SetRateLimited`/进 3/3 阶梯；每次选号按短 TTL 流键现算 → edge 恢复**自动解除**。
- **request-owned 429 不受影响**：它们在 `recordAnthropicStubSaturation` 之前返回，永不喂计数器，熔断器不受触碰。

## 测试
- 谓词表测试含 **503-放大器回归守卫**（年轻 span / 单次命中 ⇒ 不算持续）。
- 过滤器测试：丢死 stub / 留健康；**全员饱和兜底**；年轻 burst 不排除；非 anthropic 不动；单候选不变；kill-switch 关；nil cache；读错安全降级。
- Redis 实现测试：`firstSeen` set-once(NX) vs `lastSeen` overwrite；流键滑动 TTL 后自清；absent/empty。
- **不变量已机械化**（自审 R-001）：`streakTTL(150) > minAge(120)` 原为跨两包的 prose 注释、违反则**静默失效**；现将两常量收敛进 service 同包并加 `TestSustainedSaturation_StreakTTLExceedsMinAge`，未来收窄余量会**编译期失败而非线上**。
- `go test -tags=unit ./...` 全绿 · 集成 tag vet 干净 · `golangci-lint` 0 issues · 完整 `scripts/preflight.sh` PASS。

## 审查说明
- 软层（`gateway_service_tk_saturation_penalty.go`）刻意原样不动。
- 新载荷面已由 `scripts/sentinels/gateway-tk.json` 的**哨兵锚点**保护（companion + 两条 `gateway_service.go` 注入行 + cache 流面），无需 `sentinel-registry-reviewed` marker。
- `gateway_service.go` 改动为**纯插入**；`anthropic_saturation_counter_cache.go` 的删除被哨兵覆盖——upstream-override 门禁按覆盖通过。
- 已 rebase 到最新 origin/main（与 PR #902 的 gateway-tk.json 哨兵冲突已解，两侧条目均保留）。

no-web-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
