### PR TITLE
fix(kiro): streaming message_start 发真实 input_tokens(修计费漏)

### DIFF
--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -217,6 +217,11 @@ func (s *KiroGatewayService) forwardStreaming(
 		flusher: flusher,
 		model:   model,
 		msgID:   requestID,
+		// Estimate input tokens up-front (pure function of the request) so the
+		// first message_start emitted mid-stream carries the real prompt count
+		// instead of 0 — the prod relay bills off the parsed SSE usage. See the
+		// inputTokens field doc in kiro_sse_encoder.go.
+		inputTokens: kiroproto.EstimateInputTokens(req),
 	}
 
 	var (
@@ -289,7 +294,9 @@ func (s *KiroGatewayService) forwardStreaming(
 	}
 
 	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
-	inputTokens := kiroproto.EstimateInputTokens(req)
+	// inputTokens was already computed for the encoder (message_start.usage); reuse
+	// it for the ForwardResult so the two never drift.
+	inputTokens := enc.inputTokens
 	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, toolUses)
 
 	// Upstream succeeded but produced no content (enc.started still false):

--- a/backend/internal/service/kiro_sse_encoder.go
+++ b/backend/internal/service/kiro_sse_encoder.go
@@ -29,6 +29,14 @@ type kiroSSEEncoder struct {
 	model   string
 	msgID   string
 
+	// inputTokens is the locally-estimated prompt token count (Kiro upstream
+	// reports none). It is computable from the request up-front, so the caller
+	// sets it before streaming starts and writeMessageStart emits it in
+	// message_start.usage.input_tokens. Without this the streamed SSE carried
+	// input_tokens=0, and the prod relay (which bills off the parsed SSE usage)
+	// recorded every streamed Kiro request at input=0 → systematic under-billing.
+	inputTokens int
+
 	started     bool          // message_start has been emitted
 	openBlock   kiroBlockKind // currently open content block
 	blockIndex  int           // index of the currently open / next block
@@ -64,7 +72,7 @@ func (e *kiroSSEEncoder) writeMessageStart() {
 			"stop_reason":   nil,
 			"stop_sequence": nil,
 			"usage": map[string]any{
-				"input_tokens":  0,
+				"input_tokens":  e.inputTokens,
 				"output_tokens": 0,
 			},
 		},

--- a/backend/internal/service/kiro_sse_encoder_tk_input_tokens_test.go
+++ b/backend/internal/service/kiro_sse_encoder_tk_input_tokens_test.go
@@ -1,0 +1,45 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Regression: the streaming Kiro SSE encoder must emit the locally-estimated
+// prompt token count in message_start.usage.input_tokens. It used to hardcode 0,
+// so every streamed Kiro request billed at input=0 on the prod relay (which bills
+// off the parsed SSE usage) — systematic under-billing. See the inputTokens field
+// doc + kiro_gateway_service.go.
+func TestKiroSSEEncoder_MessageStartCarriesInputTokens(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &kiroSSEEncoder{w: &buf, model: "claude-sonnet-4-6", msgID: "msg_x", inputTokens: 1234}
+
+	enc.writeMessageStart()
+
+	out := buf.String()
+	if !strings.Contains(out, "message_start") {
+		t.Fatalf("expected a message_start event, got: %s", out)
+	}
+	if !strings.Contains(out, `"input_tokens":1234`) {
+		t.Fatalf("message_start must carry estimated input_tokens=1234, got: %s", out)
+	}
+	// message_start always reports output_tokens=0 (output accrues via message_delta).
+	if !strings.Contains(out, `"output_tokens":0`) {
+		t.Fatalf("message_start should report output_tokens=0, got: %s", out)
+	}
+}
+
+// Default (zero) inputTokens still renders 0 — guards against a nil/omitted field
+// regression and documents that an unset estimate degrades to the old behavior
+// rather than panicking.
+func TestKiroSSEEncoder_MessageStartZeroInputTokens(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &kiroSSEEncoder{w: &buf, model: "claude-sonnet-4-6", msgID: "msg_y"}
+	enc.writeMessageStart()
+	if !strings.Contains(buf.String(), `"input_tokens":0`) {
+		t.Fatalf("unset inputTokens should render 0, got: %s", buf.String())
+	}
+}


### PR DESCRIPTION
## 现象(prod 实证)

kiro 组(gid=17)近 30 天 **29 笔 / 26 笔 input+output 双 0**,几乎全 $0 计费——长期存在的收入漏。

## 根因(live trace 钉死)

kiro 在 prod **无原生账号**,经 anthropic-apikey 镜像账号(66)**中继到 us6 edge**;kiro 的 token 估算(`estimate.go`,自 v1.8.0 就在)跑在 **edge**,**prod 按解析 edge 返回的 SSE usage 计费**。

streaming SSE encoder 的 `kiroSSEEncoder.writeMessageStart()` 把 `usage.input_tokens` **硬编码成 0**,`EstimateInputTokens(req)` 算出的 prompt 数从不注入流。本机打一个流式 kiro 请求抓 SSE:

```
message_start  → usage.input_tokens = 0     ← bug
message_delta  → usage.output_tokens = 9
```

prod 据此记 **in=0 / out=9**(cost 仅 $0.000135)。**output 链路完全正常**(估算 → message_delta → prod);**唯一漏在 input**——而 input 通常是大头(prompt + context + system),正是计费漏主因。(排除「空响应」:本次是有内容的成功响应。)

## 修复

`kiroSSEEncoder` 增 `inputTokens` 字段;流开始前由 `EstimateInputTokens(req)`(纯函数、不依赖响应)算好,`message_start` 发真实值;`ForwardResult` 复用同一值避免漂移。output_tokens 路径不动(本就经 message_delta 正确)。非流式路径(`KiroToClaudeResponse` 已带 input)本就正确,不动。

## 验证

- `go build ./...`、`go test -tags=unit ./internal/service/...`(新增 2 个 encoder 回归测试:message_start 携带估算 input、unset 退化为 0)、`golangci-lint` 0 issues、`scripts/preflight.sh` PASS(kiro sentinel intact)。
- **待发版 + edge rollout 后**(kiro 估算在 edge 跑),再本机重打流式 kiro、对照 usage_log 确认 input 非零入账。

no-web-impact: 纯后端,无 frontend。

sentinel-registry-reviewed: 改动的 `kiro_gateway_service.go` / `kiro_sse_encoder.go` 已被 `scripts/sentinels/kiro.json` 锚定(preflight 确认 intact);新增的是 `*_test.go` 回归测试,不引入新 load-bearing 面,无需新建 sentinel 类目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)