### PR TITLE
chore(edge): decommission uk2/uk3 from the Lightsail edge fleet

### DIFF
--- a/.github/workflows/deploy-edge-lightsail-stage0.yml
+++ b/.github/workflows/deploy-edge-lightsail-stage0.yml
@@ -19,8 +19,6 @@ on:
         type: choice
         options:
           - uk1
-          - uk2
-          - uk3
           - us1
           - us2
           - us3

--- a/deploy/aws/lightsail/edge-targets-lightsail.json
+++ b/deploy/aws/lightsail/edge-targets-lightsail.json
@@ -175,40 +175,6 @@
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us7",
       "purpose": "us-east-2-ohio-egress (rehomed 2026-06-05 to adopted console-created edge-ls-us-oh-4; corrected 2026-06-08: live static IP is StaticIp-oh-4-b/18.188.207.95 not StaticIp-oh-4/3.139.183.116 — A record was stale at the dead 3.139.183.116)"
-    },
-    "uk2": {
-      "deployable": true,
-      "profile": "edge-lightsail-minimal",
-      "swap_gib": 2,
-      "lightsail_region": "eu-west-2",
-      "ec2_equivalent_region": "eu-west-2",
-      "availability_zone": "eu-west-2a",
-      "domain": "api-uk2.tokenkey.dev",
-      "porkbun_a_ipv4": "35.176.1.19",
-      "instance_name": "edge-ls-uk-2",
-      "static_ip_name": "StaticIp-uk-2",
-      "bundle_id": "micro_3_0",
-      "blueprint_id": "amazon_linux_2023",
-      "monthly_budget_usd": 12,
-      "ssm_prefix": "/tokenkey/lightsail/uk2",
-      "purpose": "uk-egress-lightsail-prod-relay (adopted console-created edge-ls-uk-2 / StaticIp-uk-2)"
-    },
-    "uk3": {
-      "deployable": true,
-      "profile": "edge-lightsail-minimal",
-      "swap_gib": 2,
-      "lightsail_region": "eu-west-2",
-      "ec2_equivalent_region": "eu-west-2",
-      "availability_zone": "eu-west-2a",
-      "domain": "api-uk3.tokenkey.dev",
-      "porkbun_a_ipv4": "13.135.19.214",
-      "instance_name": "edge-ls-uk-3",
-      "static_ip_name": "StaticIp-uk-3",
-      "bundle_id": "micro_3_0",
-      "blueprint_id": "amazon_linux_2023",
-      "monthly_budget_usd": 12,
-      "ssm_prefix": "/tokenkey/lightsail/uk3",
-      "purpose": "uk-egress-lightsail-prod-relay (adopted console-created edge-ls-uk-3 / StaticIp-uk-3)"
     }
   }
 }

--- a/scripts/checks/workflow-edge-coverage.json
+++ b/scripts/checks/workflow-edge-coverage.json
@@ -13,8 +13,6 @@
       "required_set": "all-deployable",
       "opt_out_edges": [
         {"id": "uk1", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},
-        {"id": "uk2", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},
-        {"id": "uk3", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},
         {"id": "us2", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},
         {"id": "us3", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},
         {"id": "us4", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},


### PR DESCRIPTION
## What

Remove the **uk2 / uk3** edges from the deployable Lightsail fleet. The physical AWS teardown was done out of band; this PR brings the repo registry in sync.

## Why safe (verified before teardown)

- **No prod routing impact**: prod's anthropic mirror pool is `cc-uk1 / cc-us2..us7` — there is **no `cc-uk2` / `cc-uk3`**. A `SELECT … WHERE base_url ILIKE '%uk2/uk3%'` on prod returned **0 rows**, so no prod failover path relayed through these edges.
- **Not a fingerprint egress**: active local cc0 egress is `3.148.79.145`; uk2=`35.176.1.19` / uk3=`13.135.19.214` and no local tunnel config references them.
- **No traffic**: both edges served **0 non-health requests** in the 60m before teardown.

## Out-of-band AWS teardown (already done)

- Deleted Lightsail instances `edge-ls-uk-2` / `edge-ls-uk-3` (eu-west-2)
- Released Static IPs `StaticIp-uk-2` (35.176.1.19) / `StaticIp-uk-3` (13.135.19.214)
- Deleted SSM params `/tokenkey/lightsail/uk{2,3}/*` (10 params)

## This PR

- `edge-targets-lightsail.json`: drop uk2 / uk3 targets → out of `--list-deployable`
- `deploy-edge-lightsail-stage0.yml`: drop uk2 / uk3 from the `edge_id` choices
- `workflow-edge-coverage.json`: drop the now-stale uk2 / uk3 opt_out entries (Gate C treats an opt_out for a non-deployable edge as a hard failure)

## Follow-up (manual, no repo tooling)

- Delete DNS A records `api-uk2.tokenkey.dev` / `api-uk3.tokenkey.dev` on Porkbun to avoid dangling-DNS takeover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)