### PR TITLE
fix(admin): kiro edge panel showed anthropic pool; indent edge panel under row

### DIFF
--- a/backend/internal/service/edge_accounts_aggregator_tk.go
+++ b/backend/internal/service/edge_accounts_aggregator_tk.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -653,7 +654,12 @@ func (a *EdgeAccountsAggregator) fetchEdgeAccounts(ctx context.Context, t edgeTa
 		res.Error = "no http client"
 		return res
 	}
-	endpoint := t.baseURL + "/api/v1/edge/accounts?platform=" + platform
+	// url.QueryEscape the platform: per-stub fan-out now derives it from the stub's
+	// operator-set credentials.mirror_platform (edgeStubPoolPlatform), not a fixed
+	// constant, so escape it like the sibling fetchEdgeCapacity does — a stray space/&
+	// must not corrupt the query. (A constant platform escapes to itself, so the
+	// per-edge overview path is unaffected.)
+	endpoint := t.baseURL + "/api/v1/edge/accounts?platform=" + url.QueryEscape(platform)
 	if t.groupScopeCaller {
 		// Per-stub: ask the edge to narrow to this key's group (precise correspondence).
 		endpoint += "&group_scope=caller"

--- a/backend/internal/service/edge_accounts_aggregator_tk.go
+++ b/backend/internal/service/edge_accounts_aggregator_tk.go
@@ -452,11 +452,37 @@ func discoverStubTargets(accounts []Account, re *regexp.Regexp) []edgeTarget {
 			tempUnschedulableUntil: acct.TempUnschedulableUntil,
 			groups:                 stubGroupNames(acct),
 			stubAccountID:          acct.ID,
-			platform:               acct.Platform,
+			platform:               edgeStubPoolPlatform(acct),
 			groupScopeCaller:       true,
 		})
 	}
 	return targets
+}
+
+// edgeStubPoolPlatform resolves the EDGE-POOL platform a mirror stub represents for
+// the per-stub fan-out (the inline /accounts panel) — which decides both the
+// ?platform= the edge is queried with AND the StubPlatform footnote.
+//
+// A mirror stub's OWN account platform is only its TRANSPORT shape: kiro rides the
+// same anthropic-apikey relay as the cc-<edge> stubs (platform=anthropic), so reading
+// acct.Platform makes a kiro stub query the edge's anthropic pool — the wrong pool it
+// merely shares a host with (e.g. cc-us6 and kiro-us6 both point at api-us6, so the
+// kiro panel showed the anthropic oh-3-a account). credentials.mirror_platform is the
+// authoritative declaration of which edge pool the stub represents — the SAME field
+// surface-C's capacity mirror keys on (see mirrorCapacityPlatform). Non-empty
+// mirror_platform wins; otherwise fall back to the stub's own platform so native
+// openai/grok/antigravity stubs (no mirror_platform) stay correct. Unlike
+// mirrorCapacityPlatform, the empty default is acct.Platform (NOT anthropic): the
+// per-stub path spans all edgeStubPlatforms, so coercing empty to anthropic would
+// mis-route a native non-anthropic stub.
+func edgeStubPoolPlatform(acct *Account) string {
+	if acct == nil {
+		return ""
+	}
+	if mp := strings.ToLower(strings.TrimSpace(acct.GetCredential("mirror_platform"))); mp != "" {
+		return mp
+	}
+	return acct.Platform
 }
 
 // discoverEdgeTargets filters the anthropic accounts down to mirror stubs and

--- a/backend/internal/service/edge_accounts_aggregator_tk_test.go
+++ b/backend/internal/service/edge_accounts_aggregator_tk_test.go
@@ -450,19 +450,28 @@ func TestDiscoverStubTargets(t *testing.T) {
 	disabled.Status = StatusDisabled
 	noKey := mk(6, PlatformOpenAI, "https://api-uk8.tokenkey.dev", "")
 
+	// kiro mirror stub: TRANSPORT platform is anthropic-apikey, but
+	// credentials.mirror_platform=kiro declares it represents the edge's KIRO pool.
+	// It SHARES the edge host (api-us4) with the anthropic stub k1 — the exact
+	// cc-us6 / kiro-us6 topology — so the fan-out must query platform=kiro for it,
+	// not the anthropic pool they co-locate on.
+	kiroMirror := mk(8, PlatformAnthropic, "https://api-us4.tokenkey.dev", "k8")
+	kiroMirror.Credentials["mirror_platform"] = "kiro"
+
 	accounts := []Account{
 		mk(1, PlatformAnthropic, "https://api-us4.tokenkey.dev", "k1"),
 		mk(2, PlatformOpenAI, "https://api-us4.tokenkey.dev", "k2"), // SAME edge host — NOT deduped
 		mk(3, PlatformGrok, "https://api-us4.tokenkey.dev", "k3"),
-		disabled, // skipped (disabled)
-		noKey,    // skipped (no api_key)
+		kiroMirror, // SAME edge host as k1 — kiro pool via mirror_platform, NOT anthropic
+		disabled,   // skipped (disabled)
+		noKey,      // skipped (no api_key)
 		// non-edge base_url → not a stub
 		{ID: 7, Platform: PlatformGemini, Type: AccountTypeAPIKey, Status: StatusActive,
 			Credentials: map[string]any{"base_url": "https://generativelanguage.googleapis.com"}},
 	}
 
 	targets := discoverStubTargets(accounts, edgeIDPattern)
-	require.Len(t, targets, 3) // three distinct stubs on one edge, NOT deduped
+	require.Len(t, targets, 4) // four distinct stubs on one edge, NOT deduped
 
 	byID := map[int64]edgeTarget{}
 	for _, tg := range targets {
@@ -473,4 +482,34 @@ func TestDiscoverStubTargets(t *testing.T) {
 	require.Equal(t, PlatformAnthropic, byID[1].platform)
 	require.Equal(t, PlatformOpenAI, byID[2].platform)
 	require.Equal(t, PlatformGrok, byID[3].platform)
+	// The kiro mirror stub fans out as KIRO (from mirror_platform), NOT anthropic
+	// (its transport platform) — the fix for the cc-us6/kiro-us6 mixing bug.
+	require.Equal(t, PlatformKiro, byID[8].platform)
+}
+
+// TestEdgeStubPoolPlatform covers the transport-vs-pool resolution: a stub's
+// credentials.mirror_platform (when set) is the authoritative edge pool, otherwise
+// the stub's own platform. This is what keeps the kiro mirror stub (anthropic
+// transport) from querying the anthropic pool it shares an edge host with.
+func TestEdgeStubPoolPlatform(t *testing.T) {
+	mk := func(platform string, cred map[string]any) *Account {
+		return &Account{Platform: platform, Type: AccountTypeAPIKey, Credentials: cred}
+	}
+	cases := []struct {
+		name string
+		acc  *Account
+		want string
+	}{
+		{"anthropic stub, no mirror_platform → anthropic", mk(PlatformAnthropic, map[string]any{}), PlatformAnthropic},
+		{"kiro mirror over anthropic transport → kiro", mk(PlatformAnthropic, map[string]any{"mirror_platform": "kiro"}), PlatformKiro},
+		{"empty mirror_platform falls back to own platform (NOT anthropic)", mk(PlatformOpenAI, map[string]any{"mirror_platform": "  "}), PlatformOpenAI},
+		{"mirror_platform is trimmed + lowercased", mk(PlatformAnthropic, map[string]any{"mirror_platform": " Kiro "}), PlatformKiro},
+		{"native openai stub, no mirror_platform → openai", mk(PlatformOpenAI, nil), PlatformOpenAI},
+		{"nil account → empty", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, edgeStubPoolPlatform(tc.acc))
+		})
+	}
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 497,
-  "hash": "8abd416209c992695fe2c8885565630dd868ab8e7e84474c801091b8e3e6c876",
+  "hash": "a9bc2ecdc17c1c4f5f298f1e1a9e9b4c722142bec2d1ec502759cbcbccfa640c",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/admin/account/EdgeAccountPanelTk.vue
+++ b/frontend/src/components/admin/account/EdgeAccountPanelTk.vue
@@ -1,8 +1,13 @@
 <template>
-  <!-- Sticky-left so the focused edge panel stays readable at the left edge as the
-       wide prod table scrolls horizontally; capped width with an inner overflow-x
-       so a busy edge's sub-table scrolls internally rather than overflowing. -->
-  <div class="dt-edge-panel sticky left-0 my-1 w-fit max-w-[min(100%,76rem)] overflow-hidden rounded-lg border border-primary-200 bg-primary-50/40 shadow-sm dark:border-dark-600 dark:bg-dark-800/60">
+  <!-- Indented + sticky-left so the panel nests under its parent stub row's data
+       columns (left edge aligned with the name column at --select-col-width, past the
+       checkbox) instead of jutting out at the table's absolute left, AND stays readable
+       at that offset as the wide prod table scrolls horizontally. --select-col-width is
+       only defined inside .table-wrapper (table mode), so the fallback 0px leaves the
+       mobile card render (outside .table-wrapper) un-indented. Capped width (minus the
+       indent) with an inner overflow-x so a busy edge's sub-table scrolls internally
+       rather than overflowing. -->
+  <div class="dt-edge-panel sticky left-[var(--select-col-width,0px)] ml-[var(--select-col-width,0px)] my-1 w-fit max-w-[min(100%_-_var(--select-col-width,0px),76rem)] overflow-hidden rounded-lg border border-primary-200 bg-primary-50/40 shadow-sm dark:border-dark-600 dark:bg-dark-800/60">
     <!-- Edge header -->
     <div class="flex flex-wrap items-center justify-between gap-2 border-b border-primary-100 px-4 py-2.5 dark:border-dark-700">
       <div class="flex min-w-0 items-center gap-2.5">


### PR DESCRIPTION
## 问题

在 edge `us6` 上，prod 侧有两个共用同一 edge host（`api-us6.tokenkey.dev`）的镜像 stub：

- **cc-us6** —— anthropic 中继（分组 `cc-edges`）
- **kiro-us6** —— kiro 中继（分组 `kiro-edges`，自带独立 api-key）

两者都是 `platform=anthropic, type=apikey` —— 这只是它们的**传输形态**。kiro stub 通过 `credentials.mirror_platform=kiro` 声明自己代表的 edge 池。但在 prod `/accounts` 页面展开 **kiro-us6** 时，显示的却是 anthropic 账号 `oh-3-a`（"anthropic 全池"），而不是 kiro edge 账号 —— 两个 stub 在视觉上被**混用**了。

此外，edge 展开面板紧贴表格最左侧渲染，整体杵在父行内容的左边（布局对齐的视觉体验问题）。

## 根因与修复

inline 面板的 per-stub 扇出（`discoverStubTargets`）用 `acct.Platform` 去查每个 edge —— 两个 stub 都是 `anthropic`，于是 kiro stub 也去查 edge 的 **anthropic** 池。

修复：从 `credentials.mirror_platform` 解析 edge **池**平台（缺省回落到 stub 自身平台），这正是 surface-C 容量镜像（`mirrorCapacityPlatform`）一直在用的**权威字段**。线上数据可印证：kiro-us6 早已显示 **1/5** 容量（kiro 池），而非 **0/50**（anthropic 池）—— 容量路径用了 `mirror_platform`，账号扇出路径却没用。现在 kiro stub 按 `platform=kiro` 扇出，kiro edge 账号正确显示，脚注变为 "kiro 全池"。

原生非 anthropic 的 stub（无 `mirror_platform`）不受影响 —— 回落到自身平台（缺省回落到 `acct.Platform`，而**非** anthropic，这点与 `mirrorCapacityPlatform` 不同，因为 per-stub 路径横跨所有平台，把空值强行当 anthropic 会错路由原生非 anthropic stub）。

附带（self-review R-001）：per-stub 平台现在来自 operator 设置的 `mirror_platform` 而非固定常量，故在 `fetchEdgeAccounts` 拼 URL 时对其做 `url.QueryEscape`，与姊妹函数 `fetchEdgeCapacity` 保持一致，避免异常字符破坏 query。

**视觉：** 把面板按 `var(--select-col-width)` 右移，使其嵌套在父行数据列之下。该 CSS 变量仅定义在 `.table-wrapper` 内，故 `0px` 回落让移动端卡片渲染（在 `.table-wrapper` 之外）保持不缩进；面板宽度上限相应减去缩进量以避免横向溢出。

## 测试

- `TestDiscoverStubTargets`：新增一个与 anthropic stub 共用 edge host 的 `mirror_platform=kiro` stub —— 断言它按 `kiro` 扇出，而非 `anthropic`。
- 新增 `TestEdgeStubPoolPlatform`：覆盖传输形态 vs 池平台的解析（mirror_platform 优先；空值回落到自身平台而非 anthropic；trim/小写；nil 安全）。

## 自检清单

- [x] `go test -tags=unit ./...` 通过；`go build ./...` 通过
- [x] 前端 lint / typecheck / build 通过；50 个 edge 相关 vitest 通过
- [x] `pnpm build` 重跑 → 提交 `frontend-source.json` dist manifest（本 PR 有 web 影响，非 no-web-impact）
- [x] `scripts/preflight.sh` PASS；upstream-override-marker（verified sentinel coverage）、registry-update-gate、main-ancestry-anchor 本地全绿
- [x] 未删除任何 upstream 符号；改动在 `*_tk.go` 内为加法、在 TK-only `.vue` 内为呈现层调整

`sentinel-registry-reviewed`：`EdgeAccountPanelTk.vue` 已被 `scripts/sentinels/frontend-tk.json` pin。本次改动只调整根容器的布局 class + 注释（呈现层），三个 pin 的锚点（`EdgeAccountActionMenuTk` / `openEdgeManage` / `clearRateLimit`）均保持完好，未新增承载性 surface，故无需新增锚点。

> 合并方式：**Squash and merge**（TK 自有 fix，遵循规则 §5.y）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
