### PR TITLE
fix(ops): attribute routing-capacity rejections per platform×user in P0 alert

### DIFF
--- a/backend/internal/repository/ops_repo_routing_capacity_rejection_integration_test.go
+++ b/backend/internal/repository/ops_repo_routing_capacity_rejection_integration_test.go
@@ -70,14 +70,18 @@ func TestRoutingCapacityRejectionCountIsolatesRoutingPhase(t *testing.T) {
 
 	// Self-diagnosing 主因 breakdown: only routing rows, grouped by platform,
 	// descending — so the P0 card names which pool is empty. The non-routing
-	// anthropic/openai rows above must NOT leak into these counts.
-	causes, err := repo.TopRoutingCapacityRejectionCauses(ctx, filter, 2)
+	// anthropic/openai rows above must NOT leak into these counts. These routing
+	// rows carry NULL user_id, so they count toward each platform's total but
+	// surface no nested user (Count includes NULL-user rows; Users excludes them).
+	platforms, err := repo.TopRoutingCapacityRejectionByPlatform(ctx, filter, 2, 3)
 	require.NoError(t, err)
-	require.Len(t, causes, 2)
-	require.Equal(t, "anthropic", causes[0].Platform)
-	require.EqualValues(t, 2, causes[0].Count)
-	require.Equal(t, "openai", causes[1].Platform)
-	require.EqualValues(t, 1, causes[1].Count)
+	require.Len(t, platforms, 2)
+	require.Equal(t, "anthropic", platforms[0].Platform)
+	require.EqualValues(t, 2, platforms[0].Count)
+	require.Empty(t, platforms[0].Users, "NULL-user routing rows count toward the total but surface no user")
+	require.Equal(t, "openai", platforms[1].Platform)
+	require.EqualValues(t, 1, platforms[1].Count)
+	require.Empty(t, platforms[1].Users)
 
 	// Cross-check the blind spot: the three routing rows are business-limited →
 	// excluded from the ratio metrics' numerator AND denominator, which is exactly
@@ -90,12 +94,16 @@ func TestRoutingCapacityRejectionCountIsolatesRoutingPhase(t *testing.T) {
 		"business-limited routing/auth/request rows are excluded from the SLA error count")
 }
 
-// TestTopRoutingCapacityRejectionUsers pins the WHO breakdown that names the
-// rejected users on the P0 card: grouped by (user_id, api_key_id) over routing
-// rows only, ordered by count, with the api-key NAME resolved via join (live key)
-// or the deleted-key snapshot (hard-deleted key). Unattributable rows (NULL
-// user_id) and non-routing rows are excluded.
-func TestTopRoutingCapacityRejectionUsers(t *testing.T) {
+// TestTopRoutingCapacityRejectionByPlatform pins the JOINT breakdown that powers
+// the P0 card's single 主因 line: per platform, the total rejection Count (ALL
+// routing rows, including NULL-user) plus the top contributing users (user id +
+// api-key NAME, resolved by join or deleted-key snapshot) over routing rows with
+// user_id IS NOT NULL, ranked within each platform. The headline case is a user
+// that spans TWO platforms (via two keys) — it must be attributed to BOTH pools
+// with the right per-platform key name, which the old two marginal queries could
+// not express. Non-routing rows are excluded; NULL-user rows count toward Count
+// but never appear as a nested user. All names below are synthetic.
+func TestTopRoutingCapacityRejectionByPlatform(t *testing.T) {
 	ctx := context.Background()
 	_, _ = integrationDB.ExecContext(ctx, "TRUNCATE ops_error_logs RESTART IDENTITY CASCADE")
 
@@ -105,51 +113,70 @@ func TestTopRoutingCapacityRejectionUsers(t *testing.T) {
 	windowEnd := windowStart.Add(time.Hour)
 	at := windowStart.Add(5 * time.Minute)
 
-	// A real user + live api_key, for the join (live-name) path. Cleaned up after
-	// (api_keys cascades on user delete) so the shared integration DB stays tidy.
-	var liveUserID, liveKeyID int64
+	// A real user with two live api_keys — one used on each platform, so the same
+	// user surfaces under both pools with its respective key name (the cross-platform
+	// case the joint view fixes). Cleaned up after (api_keys cascade on user delete).
+	var liveUserID, keyAnthropicID, keyNewapiID int64
 	require.NoError(t, integrationDB.QueryRowContext(ctx,
 		`INSERT INTO users (email, password_hash) VALUES ($1, 'x') RETURNING id`,
-		"routing-users-test@example.com").Scan(&liveUserID))
+		"routing-byplatform-test@example.com").Scan(&liveUserID))
 	t.Cleanup(func() {
 		_, _ = integrationDB.ExecContext(context.Background(), "DELETE FROM users WHERE id = $1", liveUserID)
 	})
 	require.NoError(t, integrationDB.QueryRowContext(ctx,
 		`INSERT INTO api_keys (user_id, key, name) VALUES ($1, $2, $3) RETURNING id`,
-		liveUserID, "sk-routing-users-test", "eval-harness").Scan(&liveKeyID))
+		liveUserID, "sk-routing-byplatform-a", "eval-harness").Scan(&keyAnthropicID))
+	require.NoError(t, integrationDB.QueryRowContext(ctx,
+		`INSERT INTO api_keys (user_id, key, name) VALUES ($1, $2, $3) RETURNING id`,
+		liveUserID, "sk-routing-byplatform-b", "ci-runner").Scan(&keyNewapiID))
 
-	insert := func(phase string, userID, apiKeyID *int64, deletedKeyName string) {
+	insert := func(phase, platform string, userID, apiKeyID *int64, deletedKeyName string) {
 		_, err := integrationDB.ExecContext(ctx, `
 			INSERT INTO ops_error_logs (
 				error_phase, error_type, severity, status_code, error_owner,
-				user_id, api_key_id, deleted_key_name, is_business_limited, created_at
-			) VALUES ($1, 'api_error', 'error', 429, 'platform', $2, $3, $4, true, $5)`,
-			phase, userID, apiKeyID, deletedKeyName, at)
+				platform, user_id, api_key_id, deleted_key_name, is_business_limited, created_at
+			) VALUES ($1, 'api_error', 'error', 429, 'platform', $2, $3, $4, $5, true, $6)`,
+			phase, platform, userID, apiKeyID, deletedKeyName, at)
 		require.NoError(t, err)
 	}
 	i64 := func(v int64) *int64 { return &v }
 
-	// Live user/key — 2 routing rejections → name resolved from api_keys join.
-	insert("routing", i64(liveUserID), i64(liveKeyID), "")
-	insert("routing", i64(liveUserID), i64(liveKeyID), "")
-	// Hard-deleted key — 1 routing rejection, api_key_id has no api_keys row →
-	// name from the deleted-key snapshot.
-	insert("routing", i64(9001), i64(987654321), "snap-key")
+	// anthropic: live user/eval-harness ×3, hard-deleted-key user 9001/snap-key ×1
+	// (no api_keys row → snapshot fallback), plus one NULL-user routing row.
+	insert("routing", "anthropic", i64(liveUserID), i64(keyAnthropicID), "")
+	insert("routing", "anthropic", i64(liveUserID), i64(keyAnthropicID), "")
+	insert("routing", "anthropic", i64(liveUserID), i64(keyAnthropicID), "")
+	insert("routing", "anthropic", i64(9001), i64(987654321), "snap-key")
+	insert("routing", "anthropic", nil, nil, "")
+	// newapi: the SAME live user, its OTHER key — cross-platform attribution.
+	insert("routing", "newapi", i64(liveUserID), i64(keyNewapiID), "")
 	// Must NOT count: non-routing row for the live user.
-	insert("auth", i64(liveUserID), i64(liveKeyID), "")
-	// Must NOT count: routing row with NULL user_id (unattributable).
-	insert("routing", nil, nil, "")
+	insert("auth", "anthropic", i64(liveUserID), i64(keyAnthropicID), "")
 
 	filter := &service.OpsDashboardFilter{StartTime: windowStart, EndTime: windowEnd, QueryMode: service.OpsQueryModeRaw}
-	users, err := repo.TopRoutingCapacityRejectionUsers(ctx, filter, 3)
+	platforms, err := repo.TopRoutingCapacityRejectionByPlatform(ctx, filter, 2, 3)
 	require.NoError(t, err)
-	require.Len(t, users, 2, "two attributable users; NULL-user and non-routing rows excluded")
+	require.Len(t, platforms, 2)
 
-	// Ordered by count desc: live user (2) then snapshot user (1).
-	require.Equal(t, liveUserID, users[0].UserID)
-	require.Equal(t, "eval-harness", users[0].APIKeyName, "live key name resolved via api_keys join")
-	require.EqualValues(t, 2, users[0].Count)
-	require.EqualValues(t, 9001, users[1].UserID)
-	require.Equal(t, "snap-key", users[1].APIKeyName, "hard-deleted key name from snapshot fallback")
-	require.EqualValues(t, 1, users[1].Count)
+	// anthropic: total 5 (3 + 1 + 1 NULL-user); nested users exclude the NULL-user
+	// row, ordered by count desc, names resolved (live join + deleted-key snapshot).
+	require.Equal(t, "anthropic", platforms[0].Platform)
+	require.EqualValues(t, 5, platforms[0].Count, "platform total includes the NULL-user routing row")
+	require.Len(t, platforms[0].Users, 2, "NULL-user row contributes to Count but not to Users")
+	require.Equal(t, liveUserID, platforms[0].Users[0].UserID)
+	require.Equal(t, "eval-harness", platforms[0].Users[0].APIKeyName, "live key name via api_keys join")
+	require.EqualValues(t, 3, platforms[0].Users[0].Count)
+	require.EqualValues(t, 9001, platforms[0].Users[1].UserID)
+	require.Equal(t, "snap-key", platforms[0].Users[1].APIKeyName, "hard-deleted key name from snapshot fallback")
+	require.EqualValues(t, 1, platforms[0].Users[1].Count)
+
+	// newapi: the same live user, its other key — proof the joint view attributes a
+	// cross-platform user to BOTH pools with the right per-platform key, which the
+	// old marginal lines smeared into one ambiguous number.
+	require.Equal(t, "newapi", platforms[1].Platform)
+	require.EqualValues(t, 1, platforms[1].Count)
+	require.Len(t, platforms[1].Users, 1)
+	require.Equal(t, liveUserID, platforms[1].Users[0].UserID)
+	require.Equal(t, "ci-runner", platforms[1].Users[0].APIKeyName)
+	require.EqualValues(t, 1, platforms[1].Users[0].Count)
 }

--- a/backend/internal/repository/ops_repo_routing_capacity_tk.go
+++ b/backend/internal/repository/ops_repo_routing_capacity_tk.go
@@ -54,14 +54,29 @@ FROM ops_error_logs
 	return n, nil
 }
 
-// TopRoutingCapacityRejectionCauses returns the top-`limit` platforms by
-// routing-phase rejection count over the filter window/scope, descending. It
-// lets a fired routing_capacity_rejection_count P0 card name WHICH platform
-// pool(s) ran out of capacity — the platform comes from the API key's group
-// (apiKey.Group.Platform), so it is populated even though no account was
-// selected (see ops_error_logger.go). Best-effort: the caller drops the cause
-// line on any error rather than blocking the alert.
-func (r *opsRepository) TopRoutingCapacityRejectionCauses(ctx context.Context, filter *service.OpsDashboardFilter, limit int) ([]*service.OpsRoutingRejectionCause, error) {
+// TopRoutingCapacityRejectionByPlatform returns, for the top-`platformLimit`
+// platforms by routing-phase rejection count over the filter window/scope, each
+// platform's total rejection count and its top-`usersPerPlatform` contributing
+// users (numeric user id + count, descending). It powers the
+// routing_capacity_rejection_count P0 card's single joint "主因" line, which names
+// WHICH pool(s) ran out of capacity AND WHO inside each pool is driving the
+// rejections — the platform→user attribution the two old marginal queries
+// (platform-only + user-only) could not express, since a user spanning two
+// platforms smeared across both margins.
+//
+// platform, user_id and api_key_id are all populated from the authenticated key
+// on every routing rejection (ops_error_logger.go, same block), so attribution is
+// reliable even though no account was selected. Two queries assembled in Go:
+//   - platform totals: COUNT(*) over ALL routing rows per platform — faithful to
+//     the metric, so rows with no attributable user_id are still counted;
+//   - per-platform users: COUNT(*) per (platform, user_id, api_key_id) over routing
+//     rows with user_id IS NOT NULL, window-ranked within each platform, with the
+//     operator-assigned api-key NAME resolved by a LEFT JOIN to api_keys (or the
+//     deleted-key snapshot for a hard-deleted key). The key SECRET is never read.
+//
+// Best-effort: the caller drops the 主因 line on any error rather than blocking the
+// alert.
+func (r *opsRepository) TopRoutingCapacityRejectionByPlatform(ctx context.Context, filter *service.OpsDashboardFilter, platformLimit, usersPerPlatform int) ([]*service.OpsRoutingRejectionPlatform, error) {
 	if r == nil || r.db == nil {
 		return nil, fmt.Errorf("nil ops repository")
 	}
@@ -71,99 +86,103 @@ func (r *opsRepository) TopRoutingCapacityRejectionCauses(ctx context.Context, f
 	if filter.StartTime.IsZero() || filter.EndTime.IsZero() {
 		return nil, fmt.Errorf("start_time/end_time required")
 	}
-	if limit <= 0 {
-		limit = 2
+	if platformLimit <= 0 {
+		platformLimit = 2
+	}
+	if usersPerPlatform <= 0 {
+		usersPerPlatform = 3
 	}
 
-	where, args, next := buildErrorWhere(filter, filter.StartTime.UTC(), filter.EndTime.UTC(), 1)
-	q := `SELECT COALESCE(NULLIF(TRIM(platform), ''), '(unknown)') AS platform, COUNT(*) AS cnt
+	// Query A — platform totals (top-platformLimit, INCLUDES rows with NULL
+	// user_id so the per-platform count stays faithful to the overall metric).
+	whereA, argsA, nextA := buildErrorWhere(filter, filter.StartTime.UTC(), filter.EndTime.UTC(), 1)
+	qA := `SELECT COALESCE(NULLIF(TRIM(platform), ''), '(unknown)') AS platform, COUNT(*) AS cnt
 FROM ops_error_logs
-` + where + `
+` + whereA + `
   AND error_phase = 'routing'
 GROUP BY 1
 ORDER BY cnt DESC, platform ASC
-LIMIT $` + strconv.Itoa(next)
-	args = append(args, limit)
+LIMIT $` + strconv.Itoa(nextA)
+	argsA = append(argsA, platformLimit)
 
-	rows, err := r.db.QueryContext(ctx, q, args...)
+	rowsA, err := r.db.QueryContext(ctx, qA, argsA...)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = rows.Close() }()
+	defer func() { _ = rowsA.Close() }()
 
-	out := make([]*service.OpsRoutingRejectionCause, 0, limit)
-	for rows.Next() {
-		var c service.OpsRoutingRejectionCause
-		if err := rows.Scan(&c.Platform, &c.Count); err != nil {
+	out := make([]*service.OpsRoutingRejectionPlatform, 0, platformLimit)
+	idx := make(map[string]int, platformLimit)
+	for rowsA.Next() {
+		var p service.OpsRoutingRejectionPlatform
+		if err := rowsA.Scan(&p.Platform, &p.Count); err != nil {
 			return nil, err
 		}
-		out = append(out, &c)
+		idx[p.Platform] = len(out)
+		out = append(out, &p)
 	}
-	if err := rows.Err(); err != nil {
+	if err := rowsA.Err(); err != nil {
 		return nil, err
 	}
-	return out, nil
-}
-
-// TopRoutingCapacityRejectionUsers returns the top-`limit` (user, api-key) buckets
-// by routing-phase rejection count over the filter window/scope, descending — so
-// the P0 card can name WHO is being rejected and tell a single user hammering from
-// a site-wide shortage. user_id and api_key_id are populated from the
-// authenticated key on every routing rejection (ops_error_logger.go, same block as
-// platform), so attribution is reliable even though no account was selected.
-//
-// The operator-assigned key NAME is resolved by a join to api_keys (kept regardless
-// of soft-delete — the on-call wants the label even for a just-deleted key), with a
-// fallback to the deleted-key snapshot (ops_error_logs.deleted_key_name) for a
-// hard-deleted key. The key SECRET/prefix is never read. The shared error filter is
-// applied on the inner aggregate (no join there → no column ambiguity); the join
-// only resolves a handful of grouped rows by api_keys PK, so it stays cheap.
-func (r *opsRepository) TopRoutingCapacityRejectionUsers(ctx context.Context, filter *service.OpsDashboardFilter, limit int) ([]*service.OpsRoutingRejectionUser, error) {
-	if r == nil || r.db == nil {
-		return nil, fmt.Errorf("nil ops repository")
-	}
-	if filter == nil {
-		return nil, fmt.Errorf("nil filter")
-	}
-	if filter.StartTime.IsZero() || filter.EndTime.IsZero() {
-		return nil, fmt.Errorf("start_time/end_time required")
-	}
-	if limit <= 0 {
-		limit = 3
+	if len(out) == 0 {
+		return out, nil
 	}
 
-	where, args, next := buildErrorWhere(filter, filter.StartTime.UTC(), filter.EndTime.UTC(), 1)
-	q := `SELECT g.user_id,
-       COALESCE(NULLIF(TRIM(ak.name), ''), NULLIF(TRIM(g.deleted_key_name), ''), '') AS key_name,
-       g.cnt
+	// Query B — top contributing users per platform (user_id IS NOT NULL),
+	// window-ranked within each platform. Bucketed by (platform, user_id, api_key_id)
+	// so a user's distinct keys surface separately (each with its own name); the
+	// api-key NAME is resolved by a LEFT JOIN to api_keys, with the deleted-key
+	// snapshot as fallback. Platforms outside Query A's top set are dropped in Go,
+	// so no platform-id array param is needed.
+	whereB, argsB, nextB := buildErrorWhere(filter, filter.StartTime.UTC(), filter.EndTime.UTC(), 1)
+	qB := `SELECT platform, user_id, key_name, cnt
 FROM (
-  SELECT user_id, api_key_id, MAX(deleted_key_name) AS deleted_key_name, COUNT(*) AS cnt
-  FROM ops_error_logs
-  ` + where + `
-    AND error_phase = 'routing'
-    AND user_id IS NOT NULL
-  GROUP BY user_id, api_key_id
-) g
-LEFT JOIN api_keys ak ON ak.id = g.api_key_id
-ORDER BY g.cnt DESC, g.user_id ASC
-LIMIT $` + strconv.Itoa(next)
-	args = append(args, limit)
+  SELECT platform, user_id, key_name, cnt,
+         ROW_NUMBER() OVER (PARTITION BY platform ORDER BY cnt DESC, user_id ASC, key_name ASC) AS rn
+  FROM (
+    SELECT g.platform,
+           g.user_id,
+           COALESCE(NULLIF(TRIM(ak.name), ''), NULLIF(TRIM(g.deleted_key_name), ''), '') AS key_name,
+           g.cnt
+    FROM (
+      SELECT COALESCE(NULLIF(TRIM(platform), ''), '(unknown)') AS platform,
+             user_id,
+             api_key_id,
+             MAX(deleted_key_name) AS deleted_key_name,
+             COUNT(*) AS cnt
+      FROM ops_error_logs
+      ` + whereB + `
+        AND error_phase = 'routing'
+        AND user_id IS NOT NULL
+      GROUP BY 1, user_id, api_key_id
+    ) g
+    LEFT JOIN api_keys ak ON ak.id = g.api_key_id
+  ) named
+) ranked
+WHERE rn <= $` + strconv.Itoa(nextB) + `
+ORDER BY platform ASC, cnt DESC, user_id ASC, key_name ASC`
+	argsB = append(argsB, usersPerPlatform)
 
-	rows, err := r.db.QueryContext(ctx, q, args...)
+	rowsB, err := r.db.QueryContext(ctx, qB, argsB...)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = rows.Close() }()
+	defer func() { _ = rowsB.Close() }()
 
-	out := make([]*service.OpsRoutingRejectionUser, 0, limit)
-	for rows.Next() {
-		var u service.OpsRoutingRejectionUser
-		if err := rows.Scan(&u.UserID, &u.APIKeyName, &u.Count); err != nil {
+	for rowsB.Next() {
+		var (
+			platform string
+			u        service.OpsRoutingRejectionUser
+		)
+		if err := rowsB.Scan(&platform, &u.UserID, &u.APIKeyName, &u.Count); err != nil {
 			return nil, err
 		}
-		out = append(out, &u)
+		if i, ok := idx[platform]; ok {
+			user := u
+			out[i].Users = append(out[i].Users, &user)
+		}
 	}
-	if err := rows.Err(); err != nil {
+	if err := rowsB.Err(); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/backend/internal/repository/ops_repo_routing_capacity_tk.go
+++ b/backend/internal/repository/ops_repo_routing_capacity_tk.go
@@ -57,7 +57,7 @@ FROM ops_error_logs
 // TopRoutingCapacityRejectionByPlatform returns, for the top-`platformLimit`
 // platforms by routing-phase rejection count over the filter window/scope, each
 // platform's total rejection count and its top-`usersPerPlatform` contributing
-// users (numeric user id + count, descending). It powers the
+// users (user id + api-key name + count, descending). It powers the
 // routing_capacity_rejection_count P0 card's single joint "主因" line, which names
 // WHICH pool(s) ran out of capacity AND WHO inside each pool is driving the
 // rejections — the platform→user attribution the two old marginal queries

--- a/backend/internal/service/ops_alert_evaluator_service_test.go
+++ b/backend/internal/service/ops_alert_evaluator_service_test.go
@@ -20,10 +20,8 @@ type stubOpsRepo struct {
 
 	routingRejections    int64
 	routingRejectionsErr error
-	routingCauses        []*OpsRoutingRejectionCause
-	routingCausesErr     error
-	routingUsers         []*OpsRoutingRejectionUser
-	routingUsersErr      error
+	routingByPlatform    []*OpsRoutingRejectionPlatform
+	routingByPlatformErr error
 }
 
 func (s *stubOpsRepo) GetDashboardOverview(ctx context.Context, filter *OpsDashboardFilter) (*OpsDashboardOverview, error) {
@@ -43,18 +41,11 @@ func (s *stubOpsRepo) CountRoutingCapacityRejections(ctx context.Context, filter
 	return s.routingRejections, nil
 }
 
-func (s *stubOpsRepo) TopRoutingCapacityRejectionCauses(ctx context.Context, filter *OpsDashboardFilter, limit int) ([]*OpsRoutingRejectionCause, error) {
-	if s.routingCausesErr != nil {
-		return nil, s.routingCausesErr
+func (s *stubOpsRepo) TopRoutingCapacityRejectionByPlatform(ctx context.Context, filter *OpsDashboardFilter, platformLimit, usersPerPlatform int) ([]*OpsRoutingRejectionPlatform, error) {
+	if s.routingByPlatformErr != nil {
+		return nil, s.routingByPlatformErr
 	}
-	return s.routingCauses, nil
-}
-
-func (s *stubOpsRepo) TopRoutingCapacityRejectionUsers(ctx context.Context, filter *OpsDashboardFilter, limit int) ([]*OpsRoutingRejectionUser, error) {
-	if s.routingUsersErr != nil {
-		return nil, s.routingUsersErr
-	}
-	return s.routingUsers, nil
+	return s.routingByPlatform, nil
 }
 
 // GetTopErrorCause is overridden (the embedded OpsRepository is nil) so the
@@ -401,9 +392,11 @@ func TestComputeRuleMetricRoutingCapacityRejectionCount(t *testing.T) {
 }
 
 // TestComputeTopCauseRoutingCapacityRejection pins the self-diagnosing 主因 line
-// for the empty-pool P0: the card names WHICH platform pool(s) are out of
-// capacity (like pool_load_rate / error-rate cards do), instead of carrying a
-// bare number that forces the on-call to drill the dashboard.
+// for the empty-pool P0: a single JOINT breakdown naming WHICH platform pool(s)
+// are out of capacity AND WHO inside each pool is driving it (user id + api-key
+// name + count), instead of two un-cross-referenceable marginal lines. `users` is
+// always empty now — the standalone 用户 line is retired. Example names here are
+// synthetic.
 func TestComputeTopCauseRoutingCapacityRejection(t *testing.T) {
 	t.Parallel()
 
@@ -412,40 +405,30 @@ func TestComputeTopCauseRoutingCapacityRejection(t *testing.T) {
 	ctx := context.Background()
 	rule := &OpsAlertRule{MetricType: "routing_capacity_rejection_count"}
 
-	t.Run("names the offending pools", func(t *testing.T) {
+	t.Run("joint per-platform breakdown with nested users", func(t *testing.T) {
 		t.Parallel()
-		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{routingCauses: []*OpsRoutingRejectionCause{
-			{Platform: "anthropic", Count: 40},
-			{Platform: "openai", Count: 15},
+		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{routingByPlatform: []*OpsRoutingRejectionPlatform{
+			{Platform: "anthropic", Count: 40, Users: []*OpsRoutingRejectionUser{
+				{UserID: 1, APIKeyName: "eval-harness", Count: 30},
+				{UserID: 16, APIKeyName: "mobile-app", Count: 10},
+			}},
+			{Platform: "newapi", Count: 8, Users: []*OpsRoutingRejectionUser{
+				{UserID: 16, APIKeyName: "ci-runner", Count: 8},
+			}},
 		}}}
 		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
-		require.Equal(t, "anthropic ×40 · openai ×15", cause)
-		require.Empty(t, users)
+		require.Equal(t, `anthropic ×40（#1 "eval-harness" ×30 · #16 "mobile-app" ×10） · newapi ×8（#16 "ci-runner" ×8）`, cause)
+		require.Empty(t, users, "standalone 用户 line is retired for new events")
 	})
 
-	t.Run("pool cause + user breakdown are returned separately (two card lines)", func(t *testing.T) {
+	t.Run("platform with no attributable users renders bare", func(t *testing.T) {
 		t.Parallel()
-		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{
-			routingCauses: []*OpsRoutingRejectionCause{{Platform: "anthropic", Count: 40}},
-			routingUsers: []*OpsRoutingRejectionUser{
-				{UserID: 42, APIKeyName: "eval-harness", Count: 30},
-				{UserID: 17, APIKeyName: "", Count: 5},
-			},
-		}}
+		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{routingByPlatform: []*OpsRoutingRejectionPlatform{
+			{Platform: "anthropic", Count: 40},
+		}}}
 		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
 		require.Equal(t, "anthropic ×40", cause)
-		require.Equal(t, `#42 "eval-harness" ×30 · #17 ×5`, users)
-	})
-
-	t.Run("user segment survives a pool-query error (best-effort)", func(t *testing.T) {
-		t.Parallel()
-		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{
-			routingCausesErr: context.DeadlineExceeded,
-			routingUsers:     []*OpsRoutingRejectionUser{{UserID: 1, APIKeyName: "k", Count: 9}},
-		}}
-		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
-		require.Empty(t, cause)
-		require.Equal(t, `#1 "k" ×9`, users)
+		require.Empty(t, users)
 	})
 
 	t.Run("no rows => no 主因 line", func(t *testing.T) {
@@ -458,7 +441,7 @@ func TestComputeTopCauseRoutingCapacityRejection(t *testing.T) {
 
 	t.Run("query error => no 主因 line (best-effort, never blocks firing)", func(t *testing.T) {
 		t.Parallel()
-		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{routingCausesErr: context.DeadlineExceeded}}
+		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{routingByPlatformErr: context.DeadlineExceeded}}
 		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
 		require.Empty(t, cause)
 		require.Empty(t, users)

--- a/backend/internal/service/ops_alert_top_cause_tk.go
+++ b/backend/internal/service/ops_alert_top_cause_tk.go
@@ -24,19 +24,26 @@ type OpsTopErrorCause struct {
 	Count          int64
 }
 
-// OpsRoutingRejectionCause is one platform bucket of routing-phase capacity
-// rejections, used to name the empty pool(s) on a
-// routing_capacity_rejection_count P0 card.
-type OpsRoutingRejectionCause struct {
+// OpsRoutingRejectionPlatform is one platform bucket of routing-phase capacity
+// rejections on a routing_capacity_rejection_count P0 card: the platform whose
+// pool ran out of capacity, its total rejection Count (ALL routing rows for the
+// platform, including any with no attributable user), and the top contributing
+// users nested under it. The nested shape answers, in one line, both "which pool
+// is empty" AND "who inside it is driving the rejections" — the platform→user
+// attribution two separate marginal queries (platform-only + user-only) could not
+// express, because a user spanning two platforms smeared across both margins.
+type OpsRoutingRejectionPlatform struct {
 	Platform string
 	Count    int64
+	Users    []*OpsRoutingRejectionUser
 }
 
 // OpsRoutingRejectionUser is one (user, api-key) bucket of routing-phase capacity
-// rejections, used to name WHO is being rejected on a
-// routing_capacity_rejection_count P0 card. APIKeyName is the operator-assigned
-// key label (resolved from api_keys.name, or the deleted-key snapshot for a
-// hard-deleted key); the key secret/prefix is NEVER surfaced in an alert.
+// rejections nested under a platform. APIKeyName is the operator-assigned key
+// label (resolved from api_keys.name, or the deleted-key snapshot for a
+// hard-deleted key) so the on-call can pin the offending client; the key
+// secret/prefix is NEVER surfaced. The label is user-controlled, so it is
+// markdown-defanged before rendering (see sanitizeFeishuLabel).
 type OpsRoutingRejectionUser struct {
 	UserID     int64
 	APIKeyName string
@@ -89,14 +96,18 @@ func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *Op
 	if s.opsRepo == nil {
 		return "", ""
 	}
-	// routing_capacity_rejection_count's cause has TWO dimensions, derived from the
+	// routing_capacity_rejection_count's cause is a single JOINT breakdown over the
 	// routing-phase rows themselves (not the model/owner/upstream_status breakdown
-	// the error-rate metrics use): WHICH platform pool(s) ran out of capacity
-	// (`cause`), and WHO got rejected (`users`). Together they answer the first
-	// on-call question — a single user hammering (rate-limit them) or site-wide
-	// capacity exhaustion (add accounts)? They render as two lines (主因 / 用户) on
-	// the card. Both sub-queries are best-effort: a failure in one must not drop
-	// the other or block the alert.
+	// the error-rate metrics use): the top platform pool(s) that ran out of
+	// capacity, each with its top contributing users nested inline (internal user id
+	// + api-key name, never the secret). One line answers the first
+	// on-call question WITH attribution — is the shortage one user hammering
+	// (rate-limit them) or spread across many (add accounts)? — which the old two
+	// separate marginal queries (platform-only + user-only) could not, since a user
+	// spanning two platforms smeared across both. `users` is left empty (the
+	// standalone 用户 line is retired); the notifier keeps its reader for
+	// already-stored historical events. Best-effort: a failure must not block the
+	// alert.
 	if metricType == "routing_capacity_rejection_count" {
 		filter := &OpsDashboardFilter{
 			StartTime: start,
@@ -105,11 +116,8 @@ func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *Op
 			GroupID:   groupID,
 			QueryMode: OpsQueryModeRaw,
 		}
-		pools, _ := s.opsRepo.TopRoutingCapacityRejectionCauses(ctx, filter, 2)
-		rejected, _ := s.opsRepo.TopRoutingCapacityRejectionUsers(ctx, filter, 3)
-		cause = formatRoutingRejectionCause(pools)
-		users = formatRoutingRejectionUsers(rejected)
-		return cause, users
+		platforms, _ := s.opsRepo.TopRoutingCapacityRejectionByPlatform(ctx, filter, 2, 3)
+		return formatRoutingRejectionByPlatform(platforms), ""
 	}
 	if !opsTopCauseApplies(metricType) {
 		return "", ""
@@ -164,20 +172,34 @@ func formatOpsTopCause(causes []*OpsTopErrorCause) string {
 	return strings.Join(parts, " · ")
 }
 
-// formatRoutingRejectionCause renders the top routing-rejection platforms as a
-// compact one-line cause, e.g. "anthropic ×40 · openai ×15". The on-call reads
-// it as "these pools are out of capacity — add accounts / check that edge".
-func formatRoutingRejectionCause(causes []*OpsRoutingRejectionCause) string {
+// formatRoutingRejectionByPlatform renders the joint platform×user breakdown as a
+// single compact line, e.g.
+//
+//	anthropic ×40（#1 "eval-harness" ×30 · #2 "mobile-app" ×10） · openai ×8（#5 "ci-runner" ×8）
+//
+// Each platform shows its total rejection count and, in full-width parens, its top
+// contributing users (internal user id + the operator-assigned api-key NAME, never
+// the key secret). A platform with no attributable user renders bare
+// ("anthropic ×40"). The on-call reads it as "these pools are out of capacity, and
+// within each pool these clients are driving it", telling a single user hammering
+// from a site-wide shortage while keeping per-platform attribution. Capped at the
+// top 2 platforms (the repo already limits; the cap here is defensive). Returns ""
+// when there is nothing to show.
+func formatRoutingRejectionByPlatform(platforms []*OpsRoutingRejectionPlatform) string {
 	parts := make([]string, 0, 2)
-	for _, c := range causes {
-		if c == nil || c.Count <= 0 {
+	for _, p := range platforms {
+		if p == nil || p.Count <= 0 {
 			continue
 		}
-		platform := strings.TrimSpace(c.Platform)
-		if platform == "" {
-			platform = "(unknown)"
+		name := strings.TrimSpace(p.Platform)
+		if name == "" {
+			name = "(unknown)"
 		}
-		parts = append(parts, fmt.Sprintf("%s ×%d", platform, c.Count))
+		seg := fmt.Sprintf("%s ×%d", name, p.Count)
+		if nested := formatRejectionUserSegments(p.Users); nested != "" {
+			seg += "（" + nested + "）"
+		}
+		parts = append(parts, seg)
 		if len(parts) >= 2 {
 			break
 		}
@@ -185,29 +207,33 @@ func formatRoutingRejectionCause(causes []*OpsRoutingRejectionCause) string {
 	return strings.Join(parts, " · ")
 }
 
-// formatRoutingRejectionUsers renders the top rejected users as a compact
-// one-line cause, e.g. `#42 "eval-harness" ×30 · #17 "mobile-app" ×12 · #9 ×8`.
-// Shows the internal user id + the operator-assigned api-key NAME (NEVER the key
-// secret) so the on-call can tell a single user hammering from a site-wide
-// shortage and, if needed, pin the offending key by its label. Capped at 3 — the
-// card answers "who", not "everyone".
-func formatRoutingRejectionUsers(users []*OpsRoutingRejectionUser) string {
+// formatRejectionUserSegments renders up to 3 nested users joined by " · ". Skips
+// nil/non-positive entries; returns "" when none remain.
+func formatRejectionUserSegments(users []*OpsRoutingRejectionUser) string {
 	parts := make([]string, 0, 3)
 	for _, u := range users {
 		if u == nil || u.Count <= 0 {
 			continue
 		}
-		seg := fmt.Sprintf("#%d", u.UserID)
-		if name := sanitizeFeishuLabel(u.APIKeyName); name != "" {
-			seg += fmt.Sprintf(" %q", truncateRunes(name, 24))
-		}
-		seg += fmt.Sprintf(" ×%d", u.Count)
-		parts = append(parts, seg)
+		parts = append(parts, formatRejectionUserSegment(u))
 		if len(parts) >= 3 {
 			break
 		}
 	}
 	return strings.Join(parts, " · ")
+}
+
+// formatRejectionUserSegment renders one nested user as `#<id> "<name>" ×<n>`,
+// falling back to `#<id> ×<n>` when the api-key name is blank. The name is
+// user-controlled, so it is markdown-defanged and rune-truncated before it lands
+// in the operator's lark_md card.
+func formatRejectionUserSegment(u *OpsRoutingRejectionUser) string {
+	seg := fmt.Sprintf("#%d", u.UserID)
+	if name := sanitizeFeishuLabel(u.APIKeyName); name != "" {
+		seg += fmt.Sprintf(" %q", truncateRunes(name, 24))
+	}
+	seg += fmt.Sprintf(" ×%d", u.Count)
+	return seg
 }
 
 // feishuLabelSanitizer defangs lark_md control characters in a user-controlled

--- a/backend/internal/service/ops_alert_top_cause_tk_test.go
+++ b/backend/internal/service/ops_alert_top_cause_tk_test.go
@@ -76,12 +76,12 @@ func TestBuildOpsFeishuAlertTextTopCauseLine(t *testing.T) {
 			MetricValue: &mv,
 			Dimensions: map[string]any{
 				"top_cause":       "anthropic ×339 · newapi ×4",
-				"top_cause_users": `#1 "yace" ×275 · #16 "benchmark-吕星宇2" ×29`,
+				"top_cause_users": `#1 "eval-harness" ×275 · #16 "mobile-app" ×29`,
 			},
 		}
 		out := buildOpsFeishuAlertText(rule, ev, "prod", "")
 		require.Contains(t, out, "**主因**：anthropic ×339 · newapi ×4")
-		require.Contains(t, out, `**用户**：#1 "yace" ×275`)
+		require.Contains(t, out, `**用户**：#1 "eval-harness" ×275`)
 		// the 用户 breakdown must sit on its own line, immediately after 主因
 		require.Contains(t, out, "anthropic ×339 · newapi ×4\n**用户**：")
 	})
@@ -106,10 +106,10 @@ func TestBuildOpsFeishuAlertTextTopCauseLine(t *testing.T) {
 	t.Run("renders 用户 line alone when 主因 absent (pool-query degraded)", func(t *testing.T) {
 		ev := &OpsAlertEvent{
 			MetricValue: &mv,
-			Dimensions:  map[string]any{"top_cause_users": `#1 "yace" ×275`},
+			Dimensions:  map[string]any{"top_cause_users": `#1 "eval-harness" ×275`},
 		}
 		out := buildOpsFeishuAlertText(rule, ev, "prod", "")
-		require.Contains(t, out, `**用户**：#1 "yace" ×275`)
+		require.Contains(t, out, `**用户**：#1 "eval-harness" ×275`)
 		require.NotContains(t, out, "**主因**")
 	})
 }
@@ -125,105 +125,103 @@ func TestOpsTopCauseApplies(t *testing.T) {
 	require.False(t, opsTopCauseApplies("routing_capacity_rejection_count"))
 }
 
-// TestFormatRoutingRejectionCause pins the empty-pool P0 card's 主因 line: which
-// platform pool(s) ran out of capacity, so the on-call knows where to add
-// accounts / which edge to check without drilling the dashboard.
-func TestFormatRoutingRejectionCause(t *testing.T) {
-	t.Run("two platforms joined", func(t *testing.T) {
-		require.Equal(t, "anthropic ×40 · openai ×15", formatRoutingRejectionCause([]*OpsRoutingRejectionCause{
+// TestFormatRoutingRejectionByPlatform pins the empty-pool P0 card's joint 主因
+// line: each platform pool that ran out of capacity, with its top contributing
+// users nested inline (user id + operator-assigned api-key NAME, never the secret).
+// This is the platform→user attribution the old two marginal lines could not
+// express. Example names here are synthetic.
+func TestFormatRoutingRejectionByPlatform(t *testing.T) {
+	t.Run("joint per-platform breakdown with nested users", func(t *testing.T) {
+		require.Equal(t,
+			`anthropic ×40（#1 "eval-harness" ×30 · #16 "mobile-app" ×10） · newapi ×8（#16 "ci-runner" ×8）`,
+			formatRoutingRejectionByPlatform([]*OpsRoutingRejectionPlatform{
+				{Platform: "anthropic", Count: 40, Users: []*OpsRoutingRejectionUser{
+					{UserID: 1, APIKeyName: "eval-harness", Count: 30},
+					{UserID: 16, APIKeyName: "mobile-app", Count: 10},
+				}},
+				{Platform: "newapi", Count: 8, Users: []*OpsRoutingRejectionUser{
+					{UserID: 16, APIKeyName: "ci-runner", Count: 8},
+				}},
+			}))
+	})
+
+	t.Run("platform with no attributable users renders bare", func(t *testing.T) {
+		require.Equal(t, "anthropic ×40", formatRoutingRejectionByPlatform([]*OpsRoutingRejectionPlatform{
 			{Platform: "anthropic", Count: 40},
-			{Platform: "openai", Count: 15},
 		}))
 	})
 
-	t.Run("capped at two even if more passed", func(t *testing.T) {
-		require.Equal(t, "anthropic ×40 · openai ×15", formatRoutingRejectionCause([]*OpsRoutingRejectionCause{
-			{Platform: "anthropic", Count: 40},
-			{Platform: "openai", Count: 15},
-			{Platform: "gemini", Count: 3},
+	t.Run("missing key name falls back to user id only", func(t *testing.T) {
+		require.Equal(t, "anthropic ×5（#9 ×5）", formatRoutingRejectionByPlatform([]*OpsRoutingRejectionPlatform{
+			{Platform: "anthropic", Count: 5, Users: []*OpsRoutingRejectionUser{{UserID: 9, APIKeyName: "", Count: 5}}},
 		}))
+	})
+
+	t.Run("capped at two platforms, three users each", func(t *testing.T) {
+		require.Equal(t,
+			`anthropic ×9（#1 "a" ×4 · #2 "b" ×3 · #3 "c" ×2） · openai ×5`,
+			formatRoutingRejectionByPlatform([]*OpsRoutingRejectionPlatform{
+				{Platform: "anthropic", Count: 9, Users: []*OpsRoutingRejectionUser{
+					{UserID: 1, APIKeyName: "a", Count: 4},
+					{UserID: 2, APIKeyName: "b", Count: 3},
+					{UserID: 3, APIKeyName: "c", Count: 2},
+					{UserID: 4, APIKeyName: "d", Count: 1},
+				}},
+				{Platform: "openai", Count: 5},
+				{Platform: "gemini", Count: 3},
+			}))
 	})
 
 	t.Run("blank platform defaults safely", func(t *testing.T) {
-		require.Equal(t, "(unknown) ×5", formatRoutingRejectionCause([]*OpsRoutingRejectionCause{
+		require.Equal(t, "(unknown) ×5", formatRoutingRejectionByPlatform([]*OpsRoutingRejectionPlatform{
 			{Platform: "", Count: 5},
 		}))
 	})
 
-	t.Run("non-positive counts skipped", func(t *testing.T) {
-		require.Equal(t, "anthropic ×40", formatRoutingRejectionCause([]*OpsRoutingRejectionCause{
+	t.Run("non-positive platform and user counts skipped", func(t *testing.T) {
+		require.Equal(t, "anthropic ×40（#7 ×4）", formatRoutingRejectionByPlatform([]*OpsRoutingRejectionPlatform{
 			{Platform: "openai", Count: 0},
-			{Platform: "anthropic", Count: 40},
+			{Platform: "anthropic", Count: 40, Users: []*OpsRoutingRejectionUser{
+				{UserID: 3, APIKeyName: "x", Count: 0},
+				{UserID: 7, APIKeyName: "", Count: 4},
+			}},
 		}))
-	})
-
-	t.Run("empty input is empty string", func(t *testing.T) {
-		require.Equal(t, "", formatRoutingRejectionCause(nil))
-	})
-}
-
-// TestFormatRoutingRejectionUsers pins the WHO line on the empty-pool P0 card:
-// user id + operator-assigned api-key NAME (never the secret), so the on-call can
-// tell a single user hammering from a site-wide shortage.
-func TestFormatRoutingRejectionUsers(t *testing.T) {
-	t.Run("user + key name + count", func(t *testing.T) {
-		require.Equal(t, `#42 "eval-harness" ×30 · #17 "mobile-app" ×12`,
-			formatRoutingRejectionUsers([]*OpsRoutingRejectionUser{
-				{UserID: 42, APIKeyName: "eval-harness", Count: 30},
-				{UserID: 17, APIKeyName: "mobile-app", Count: 12},
-			}))
-	})
-
-	t.Run("missing key name falls back to user only", func(t *testing.T) {
-		require.Equal(t, "#9 ×8", formatRoutingRejectionUsers([]*OpsRoutingRejectionUser{
-			{UserID: 9, APIKeyName: "", Count: 8},
-		}))
-	})
-
-	t.Run("capped at three", func(t *testing.T) {
-		require.Equal(t, `#1 "a" ×9 · #2 "b" ×8 · #3 "c" ×7`,
-			formatRoutingRejectionUsers([]*OpsRoutingRejectionUser{
-				{UserID: 1, APIKeyName: "a", Count: 9},
-				{UserID: 2, APIKeyName: "b", Count: 8},
-				{UserID: 3, APIKeyName: "c", Count: 7},
-				{UserID: 4, APIKeyName: "d", Count: 6},
-			}))
 	})
 
 	t.Run("long key name is truncated to 24 runes", func(t *testing.T) {
-		got := formatRoutingRejectionUsers([]*OpsRoutingRejectionUser{
-			{UserID: 5, APIKeyName: "this-is-a-very-long-api-key-name-that-should-truncate", Count: 3},
+		got := formatRoutingRejectionByPlatform([]*OpsRoutingRejectionPlatform{
+			{Platform: "anthropic", Count: 3, Users: []*OpsRoutingRejectionUser{
+				{UserID: 5, APIKeyName: "this-is-a-very-long-api-key-name-that-should-truncate", Count: 3},
+			}},
 		})
-		// first 24 runes of the name, then an ellipsis
-		require.Equal(t, `#5 "this-is-a-very-long-api-…" ×3`, got)
+		require.Equal(t, `anthropic ×3（#5 "this-is-a-very-long-api-…" ×3）`, got)
 	})
 
-	t.Run("non-positive counts skipped, empty is empty", func(t *testing.T) {
-		require.Equal(t, "#7 ×4", formatRoutingRejectionUsers([]*OpsRoutingRejectionUser{
-			{UserID: 3, APIKeyName: "x", Count: 0},
-			{UserID: 7, APIKeyName: "", Count: 4},
-		}))
-		require.Equal(t, "", formatRoutingRejectionUsers(nil))
+	t.Run("empty input is empty string", func(t *testing.T) {
+		require.Equal(t, "", formatRoutingRejectionByPlatform(nil))
 	})
 
 	// SECURITY: the api-key name is user-controlled and rendered in an operator's
-	// lark_md P0 card, where escapeFeishuText only handles & < >. A markdown link
-	// in the name would otherwise render as a clickable phishing link in the ops
-	// channel. The name must be defanged.
+	// lark_md P0 card, where escapeFeishuText only handles & < >. A markdown link in
+	// the name would otherwise render as a clickable phishing link. It must be
+	// defanged. (Payloads below are synthetic.)
 	t.Run("markdown link in key name is neutralized (no phishing injection)", func(t *testing.T) {
-		got := formatRoutingRejectionUsers([]*OpsRoutingRejectionUser{
-			{UserID: 42, APIKeyName: "[free credits](http://evil)", Count: 30},
+		got := formatRoutingRejectionByPlatform([]*OpsRoutingRejectionPlatform{
+			{Platform: "anthropic", Count: 30, Users: []*OpsRoutingRejectionUser{
+				{UserID: 42, APIKeyName: "[free credits](http://evil)", Count: 30},
+			}},
 		})
 		require.NotContains(t, got, "[", "link-open bracket must be defanged")
 		require.NotContains(t, got, "](", "lark_md link syntax must not survive")
-		require.NotContains(t, got, ")", "link-close paren must be defanged")
 		require.Contains(t, got, "#42")
 		require.Contains(t, got, "×30")
 	})
 
 	t.Run("emphasis/code/table markers defanged (no card-layout bleed)", func(t *testing.T) {
-		got := formatRoutingRejectionUsers([]*OpsRoutingRejectionUser{
-			{UserID: 7, APIKeyName: "promo*bold*_it_`code`|x", Count: 5},
+		got := formatRoutingRejectionByPlatform([]*OpsRoutingRejectionPlatform{
+			{Platform: "anthropic", Count: 5, Users: []*OpsRoutingRejectionUser{
+				{UserID: 7, APIKeyName: "promo*bold*_it_`code`|x", Count: 5},
+			}},
 		})
 		for _, bad := range []string{"*", "`", "_", "|"} {
 			require.NotContains(t, got, bad, "markdown marker %q must be defanged", bad)

--- a/backend/internal/service/ops_port.go
+++ b/backend/internal/service/ops_port.go
@@ -32,16 +32,14 @@ type OpsRepository interface {
 	// Drives the routing_capacity_rejection_count P0 alert; see
 	// CountRoutingCapacityRejections impl + tk_035 seed.
 	CountRoutingCapacityRejections(ctx context.Context, filter *OpsDashboardFilter) (int64, error)
-	// TopRoutingCapacityRejectionCauses returns the top-N platforms by
-	// routing-phase rejection count over the filter window/scope, so a fired
-	// routing_capacity_rejection_count P0 card can name WHICH pool is empty
-	// (self-diagnosing, like the pool_load_rate / error-rate cards).
-	TopRoutingCapacityRejectionCauses(ctx context.Context, filter *OpsDashboardFilter, limit int) ([]*OpsRoutingRejectionCause, error)
-	// TopRoutingCapacityRejectionUsers returns the top-N (user, api-key) buckets by
-	// routing-phase rejection count over the filter window/scope, so the same P0
-	// card can name WHO is being rejected (a single user hammering vs a site-wide
-	// shortage). The api-key NAME is resolved by join; the key secret is never read.
-	TopRoutingCapacityRejectionUsers(ctx context.Context, filter *OpsDashboardFilter, limit int) ([]*OpsRoutingRejectionUser, error)
+	// TopRoutingCapacityRejectionByPlatform returns, for the top-platformLimit
+	// platforms by routing-phase rejection count over the filter window/scope, each
+	// platform's total rejection count plus its top-usersPerPlatform contributing
+	// users (user id + api-key name + count). This single JOINT breakdown
+	// lets a fired routing_capacity_rejection_count P0 card name WHICH pool(s) ran
+	// out of capacity AND WHO inside each pool is driving it — the platform→user
+	// attribution the old two separate marginal queries could not express.
+	TopRoutingCapacityRejectionByPlatform(ctx context.Context, filter *OpsDashboardFilter, platformLimit, usersPerPlatform int) ([]*OpsRoutingRejectionPlatform, error)
 	GetThroughputTrend(ctx context.Context, filter *OpsDashboardFilter, bucketSeconds int) (*OpsThroughputTrendResponse, error)
 	GetLatencyHistogram(ctx context.Context, filter *OpsDashboardFilter) (*OpsLatencyHistogramResponse, error)
 	GetErrorTrend(ctx context.Context, filter *OpsDashboardFilter, bucketSeconds int) (*OpsErrorTrendResponse, error)

--- a/backend/internal/service/ops_repo_mock_test.go
+++ b/backend/internal/service/ops_repo_mock_test.go
@@ -90,11 +90,7 @@ func (m *opsRepoMock) CountRoutingCapacityRejections(ctx context.Context, filter
 	return 0, nil
 }
 
-func (m *opsRepoMock) TopRoutingCapacityRejectionCauses(ctx context.Context, filter *OpsDashboardFilter, limit int) ([]*OpsRoutingRejectionCause, error) {
-	return nil, nil
-}
-
-func (m *opsRepoMock) TopRoutingCapacityRejectionUsers(ctx context.Context, filter *OpsDashboardFilter, limit int) ([]*OpsRoutingRejectionUser, error) {
+func (m *opsRepoMock) TopRoutingCapacityRejectionByPlatform(ctx context.Context, filter *OpsDashboardFilter, platformLimit, usersPerPlatform int) ([]*OpsRoutingRejectionPlatform, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## 背景

P0 告警「无可用账号拒绝激增」(`routing_capacity_rejection_count`) 的飞书卡片,把**平台维度**和**用户维度**渲染成了对同一批 routing 拒绝行(`ops_error_logs` 中 `error_phase='routing'`)做的**两次相互独立的边际 `GROUP BY` 聚合**——从不联表。运维因此无法读出**哪个用户造成了哪个平台的拒绝**;而一个用户若用不同 api-key 横跨两个平台,会被拆散到两条边际里,彼此对不上。

本 PR 把这两次单维聚合换成**一次联合聚合**:`主因` 行按平台展开,每个平台内联嵌套各自 top 用户(用户 id + api-key 名称):

```
主因：anthropic ×40（#1 "eval-harness" ×30 · #16 "mobile-app" ×10） · newapi ×8（#16 "ci-runner" ×8）
```

(示例名为合成名,非真实数据。)

数据本身完全支持这种联合归因:每条 routing 拒绝行都同时写入了 `platform`、`user_id`、`api_key_id`(`ops_error_logger.go` 同一 block)。这是纯查询/展示缺口,不是数据缺口。

## 实现

- 新增仓库方法 `TopRoutingCapacityRejectionByPlatform`——两条查询在 Go 端拼装:
  - **平台总数**:对每个平台的 ALL routing 行 `COUNT(*)`(含无可归因 `user_id` 的行,忠实于告警指标);
  - **每平台 top 用户**:对 `user_id IS NOT NULL` 的 routing 行按 `(platform, user_id, api_key_id)` 聚合,`ROW_NUMBER() OVER (PARTITION BY platform …)` 在每个平台内排名,api-key **名称**经 `api_keys` LEFT JOIN 解析(硬删除的 key 用 deleted-key 快照兜底)。key secret 永不读取。
- `computeTopCause` 返回嵌套后的 `主因` 字符串;独立的 `用户` 行对新事件退役;notifier 仍保留 `top_cause_users` reader,历史已存事件照常渲染。
- 删除两个旧的单维方法/结构体(TK #881 引入的);用户可控的 api-key 名称仍走 markdown 防注入(`sanitizeFeishuLabel`)。代码/测试中的示例名均为合成名。

## Markers

- `upstream-touch-trivial` —— 本 PR 唯一触达的 upstream-shaped 文件是 `ops_port.go`(`OpsRepository` 接口)。被替换的两个方法是 TK PR #881 新增的,upstream 没有这些符号,替换它们不存在 upstream 合并回退风险。
- `no-web-impact` —— 纯后端,无前端面变更。
- `sentinel-registry-reviewed` —— 本 PR 编辑了 `*_tk*.go` 热点文件并含删除(移除两个旧的单维方法/结构体/格式化函数)。已审查:被删符号(`TopRoutingCapacityRejectionCauses` / `…Users`、`OpsRoutingRejectionCause`、`formatRoutingRejectionCause` / `…Users`)在 `scripts/sentinels/*.json` 中**均未被 pin**(唯一提到这些文件的是 `pool_load_rate` sentinel 的 rationale 散文,其 `must_contain` 锚点是 ChannelType / poolLoadMinAccounts / 归一化比值,本 PR 未触及)。该 top-cause 是 best-effort 装饰(失败仅丢 `主因` 行、绝不阻断告警),非 sentinel 所保护的「静默删除致静默回归」型不变量,故无需新增锚点。

## 验证

- `go build ./...` ✓
- `go test -tags=unit ./...`(55 个包)✓
- `go test -tags=integration ./internal/repository/...` —— 真实 Postgres 跑通 window 查询、`api_keys` JOIN + deleted-key 快照兜底、NULL-user 处理,以及**同一用户跨两平台双 key**场景 ✓
- `go vet ./...`、`golangci-lint run ./...`(0 issues)✓
- `scripts/preflight.sh` PASS ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
