### PR TITLE
fix(anthropic): prod-side per-class 429 propagation + failover for mirror accounts

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -554,7 +554,13 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			// TK: feed the bounded saturation de-prioritization preference (not a
 			// cooldown; ladder/cooldown stay untouched). See
 			// ratelimit_service_tk_saturation.go.
-			s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "no_available_accounts")
+			satCount := s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "no_available_accounts")
+			// TK: when this edge's header-less empty-pool 429 is SUSTAINED, write a
+			// class-scoped cooldown on this MIRROR account so prod fails sonnet (the
+			// in-flight class) over to sonnet-healthy sibling mirrors and clears the
+			// stale sticky binding — opus/haiku stay schedulable. See
+			// ratelimit_service_tk_mirror_class_429.go.
+			s.tkTryAnthropicMirrorClassCooldownOnDownstreamEmpty(ctx, account, satCount, tkFirstRequestedModel(requestedModel))
 			return true
 		}
 		// TK (G2, narrow): the sibling downstream capacity signal — a forwarded
@@ -566,7 +572,10 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 				"account_id", account.ID,
 				"status_code", statusCode)
 			// TK: feed the bounded saturation de-prioritization preference.
-			s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "all_available_accounts_exhausted")
+			satCount := s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "all_available_accounts_exhausted")
+			// TK: sustained header-less downstream-exhaustion → class-scoped mirror
+			// cooldown + failover (see ratelimit_service_tk_mirror_class_429.go).
+			s.tkTryAnthropicMirrorClassCooldownOnDownstreamEmpty(ctx, account, satCount, tkFirstRequestedModel(requestedModel))
 			return true
 		}
 		// TK: a 429 with NO authoritative anthropic-ratelimit-* headers is not a
@@ -584,7 +593,12 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			// two sibling capacity-envelope skips above — a header-less envelope means
 			// the forwarded-to edge is transiently dry, so bias scheduling away from it
 			// (no cooldown; ladder untouched). See ratelimit_service_tk_saturation.go.
-			s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "non_authoritative_429")
+			satCount := s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "non_authoritative_429")
+			// TK: this is the cc-us7 header-less envelope from the ground-truth
+			// incident — when sustained, class-scope-cool this MIRROR account so the
+			// in-flight class fails over to sonnet-healthy siblings (opus/haiku stay
+			// schedulable). See ratelimit_service_tk_mirror_class_429.go.
+			s.tkTryAnthropicMirrorClassCooldownOnDownstreamEmpty(ctx, account, satCount, tkFirstRequestedModel(requestedModel))
 			return true
 		}
 		// handle429 returns true when SetRateLimited landed on an upstream-

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -573,8 +573,10 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 				"status_code", statusCode)
 			// TK: feed the bounded saturation de-prioritization preference.
 			satCount := s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "all_available_accounts_exhausted")
-			// TK: sustained header-less downstream-exhaustion → class-scoped mirror
+			// TK: sustained 429 failover-exhausted envelope → class-scoped mirror
 			// cooldown + failover (see ratelimit_service_tk_mirror_class_429.go).
+			// (A genuine HTTP 502 exhausted body routes through the default→legacy
+			// path, which is intentionally not wired — it lacks requestedModel.)
 			s.tkTryAnthropicMirrorClassCooldownOnDownstreamEmpty(ctx, account, satCount, tkFirstRequestedModel(requestedModel))
 			return true
 		}

--- a/backend/internal/service/ratelimit_service_tk_mirror_class_429.go
+++ b/backend/internal/service/ratelimit_service_tk_mirror_class_429.go
@@ -1,0 +1,130 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// TK — prod-side per-class 429 propagation + failover for header-less edge
+// empty-pool 429s on Anthropic MIRROR (cc-<edge>) accounts.
+//
+// Topology (prod): client → prod gateway → a prod MIRROR account
+// (platform=anthropic, type=apikey, name cc-<edge>, credentials.base_url =
+// https://api-<edge>.tokenkey.dev) → an EDGE gateway (Lightsail) → the edge's
+// real OAuth account → Anthropic.
+//
+// Anthropic enforces a per-MODEL-CLASS 5h/7d "unified window". When a class
+// (e.g. sonnet) is exhausted on a single-account edge, the EDGE scheduler
+// filters that account out for sonnet (account.extra.model_rate_limits
+// ["anthropic:class:sonnet"] on the EDGE account) and returns prod a 429 "no
+// available accounts". opus/haiku on that same edge still serve 200.
+//
+// THE BUG this closes: the edge's per-class window is INVISIBLE to prod. The
+// prod MIRROR account shows model_rate_limits["anthropic:class:sonnet"]=null,
+// so prod (a) keeps sticky-binding sonnet to the mirror, (b) records NO
+// per-class cooldown on the mirror, and (c) does NOT fail over to sonnet-healthy
+// sibling mirrors (cc-us5/cc-us6). Net: a universal key is 0/N on sonnet while
+// healthy sonnet capacity sits idle next door, and shouldClearStickySession
+// never clears because the mirror looks schedulable.
+//
+// Resolution (prod-only inference): the edge's relayed 429 carries NO
+// anthropic-ratelimit-* headers and a class-agnostic body ("no available
+// accounts"), so prod cannot learn the edge's true per-class reset. Prod
+// therefore infers the class from the in-flight requested model (the class prod
+// just failed to serve on that mirror) and writes a BOUNDED, self-renewing floor
+// cooldown at the SAME class scope the read/filter/sticky-clear stack already
+// consumes (anthropic:class:<class>, via SetModelRateLimit). The read side is
+// already wired (model_rate_limit.go → tkAnthropicModelClassRateLimitActive;
+// gateway_service.go shouldClearStickySession), so this is a write-only change.
+//
+// Amplifier-safety (the same invariant the skip branch was built for): this
+// writes ONLY the class-scoped key — never SetRateLimited (whole-account), never
+// the 3/3 ladder. opus/haiku on the same mirror stay schedulable, so a sonnet
+// outage on one edge never collapses the whole mirror pool. It is gated on the
+// EXISTING sustained saturation threshold (4-in-90s) so a single transient blip
+// never cools a class.
+
+const (
+	// tkMirrorClassCooldownRewriteFloor caps scheduler-outbox churn: the
+	// per-class cooldown is only (re)written when the account's current remaining
+	// for that class has dropped below this floor. With a self-renewing ~90s
+	// floor this keeps writes to roughly once-per-floor instead of once-per-
+	// request while the edge stays dry.
+	tkMirrorClassCooldownRewriteFloor = 15 * time.Second
+)
+
+// tkTryAnthropicMirrorClassCooldownOnDownstreamEmpty writes a class-scoped
+// cooldown on a prod MIRROR account when an edge's header-less empty-pool 429 is
+// SUSTAINED for the in-flight model's class. Prod-only inference: the edge
+// cannot signal the class today, so we attribute the class prod just failed to
+// serve. Bounded self-renewing floor (no authoritative reset exists).
+//
+// Returns true iff a class cooldown was written. The caller still returns true
+// from the skip branch (the ladder / account-level path stays untouched)
+// regardless of this result — this is a strictly additive scheduling hint.
+//
+// It is a no-op (returns false) for: non-Anthropic accounts, a not-yet-sustained
+// count (count < threshold, incl. count==0 from an unwired/errored counter), an
+// unknown/absent model class (never guess), an already-actively-cooled class
+// with material remaining (outbox-churn guard), or a repo write failure.
+func (s *RateLimitService) tkTryAnthropicMirrorClassCooldownOnDownstreamEmpty(
+	ctx context.Context,
+	account *Account,
+	saturationCount int64,
+	requestedModel string,
+) bool {
+	if s == nil || s.accountRepo == nil || account == nil {
+		return false
+	}
+	if account.Platform != PlatformAnthropic {
+		return false
+	}
+	// Sustained-only: same gate as the saturation preference. count==0 means the
+	// counter is unwired or errored → cannot confirm sustained → do NOT cool.
+	if saturationCount < anthropicSaturationThreshold {
+		return false
+	}
+	scopeKey := tkAnthropicModelClassScopeKeyForModel(requestedModel)
+	if scopeKey == "" {
+		// Unknown/absent class → never guess which class the edge limited.
+		return false
+	}
+	// Outbox-churn guard: skip the rewrite when this class is already actively
+	// cooled with material remaining — keeps writes to ~once-per-floor.
+	if rem := account.tkAnthropicModelClassRateLimitRemaining(requestedModel); rem > tkMirrorClassCooldownRewriteFloor {
+		return false
+	}
+	resetAt := time.Now().Add(time.Duration(tkAnthropicMirrorClassCooldownSeconds) * time.Second)
+	// detail = 模型类，让飞书摘要直接显示被限流的是哪个模型类（上游窗口对 prod 不可见，
+	// 故不带窗口标签）。
+	s.notifyAccountSchedulingBlocked(account, resetAt, "429_mirror_class_downstream_empty",
+		tkAnthropicModelClass(requestedModel))
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, scopeKey, resetAt, tkAnthropicModelCooldownReason); err != nil {
+		slog.Warn("anthropic_mirror_class_cooldown_failed",
+			"account_id", account.ID,
+			"scope", scopeKey,
+			"error", err)
+		return false
+	}
+	slog.Info("anthropic_mirror_class_rate_limited",
+		"account_id", account.ID,
+		"scope", scopeKey,
+		"requested_model", requestedModel,
+		"reset_at", resetAt,
+		"reset_in", time.Until(resetAt).Truncate(time.Second),
+		"saturation_count", saturationCount)
+	return true
+}
+
+// tkFirstRequestedModel returns the first requested-model variadic arg, or "".
+// The HandleUpstreamError skip branches take requestedModel as a ...string, so
+// the in-flight model name may be absent (e.g. a WS fast-path with no model
+// context); an empty string then resolves to an unknown class and the mirror
+// per-class cooldown safely declines.
+func tkFirstRequestedModel(requestedModel []string) string {
+	if len(requestedModel) > 0 {
+		return requestedModel[0]
+	}
+	return ""
+}

--- a/backend/internal/service/ratelimit_service_tk_mirror_class_429_test.go
+++ b/backend/internal/service/ratelimit_service_tk_mirror_class_429_test.go
@@ -159,6 +159,56 @@ func TestMirrorClass429_NonAuthoritative429Branch_WritesCooldown(t *testing.T) {
 	require.Equal(t, 0, repo.tempCalls)
 }
 
+// 7) The all_available_accounts_exhausted branch (failover-exhausted sibling
+// capacity envelope) also writes the class cooldown when sustained — covering
+// the second of the three new injection points. NOTE: this injection point lives
+// in HandleUpstreamError's `case 429:` block, so it fires for the
+// failover-exhausted body relayed with a 429 status (e.g. empty-pool fast-fail).
+// A genuine HTTP 502 routes through the `default:` → legacy
+// handleAnthropicUpstreamError path, which is intentionally NOT wired (it lacks
+// requestedModel) and is documented as out-of-scope — see TestMirrorClass429_
+// Genuine502_LegacyPath_NoMirrorClassCooldown for that boundary.
+func TestMirrorClass429_FailoverExhaustedBody429_WritesCooldown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc, _ := newMirrorClass429Service(repo)
+	account := &Account{ID: 54, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	// 429 whose body is TokenKey's own failover-exhausted capacity phrase.
+	body := []byte(`{"type":"error","error":{"type":"server_error","message":"all available accounts exhausted"}}`)
+	for i := 0; i < 5; i++ {
+		require.True(t, svc.HandleUpstreamError(context.Background(), account,
+			http.StatusTooManyRequests, http.Header{}, body, "claude-sonnet-4-5"))
+	}
+	require.NotEmpty(t, repo.modelRateLimitCalls,
+		"sustained failover-exhausted 429 must class-cool the mirror account")
+	require.Equal(t, "anthropic:class:sonnet", repo.modelRateLimitCalls[0].scope)
+	require.Equal(t, "anthropic_unified_window_exceeded", repo.modelRateLimitCalls[0].reason)
+	require.Equal(t, 0, repo.setRateLimitedCalls)
+	require.Equal(t, 0, repo.tempCalls)
+}
+
+// 8) Boundary: a genuine HTTP 502 for an Anthropic mirror account routes through
+// the legacy handleAnthropicUpstreamError path, which is intentionally NOT wired
+// for the mirror per-class cooldown (it lacks requestedModel). Asserts no
+// mirror-class cooldown is written there — documenting the deliberate scope
+// boundary so a future reader does not assume 502 is covered.
+func TestMirrorClass429_Genuine502_LegacyPath_NoMirrorClassCooldown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc, _ := newMirrorClass429Service(repo)
+	account := &Account{ID: 54, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	body := []byte(`{"type":"error","error":{"type":"server_error","message":"all available accounts exhausted"}}`)
+	for i := 0; i < 5; i++ {
+		// 502 → default: → legacy handleAnthropicUpstreamError (no requestedModel).
+		require.True(t, svc.HandleUpstreamError(context.Background(), account,
+			http.StatusBadGateway, http.Header{}, body, "claude-sonnet-4-5"))
+	}
+	require.Empty(t, repo.modelRateLimitCalls,
+		"the legacy 502 path is intentionally NOT wired for the mirror per-class cooldown")
+	require.Equal(t, 0, repo.setRateLimitedCalls)
+	require.Equal(t, 0, repo.tempCalls)
+}
+
 // accountWithClassCooldown builds an Account whose Extra carries an active
 // model-class cooldown at the given scope/resetAt, matching the JSON shape
 // modelRateLimitResetAt reads.

--- a/backend/internal/service/ratelimit_service_tk_mirror_class_429_test.go
+++ b/backend/internal/service/ratelimit_service_tk_mirror_class_429_test.go
@@ -1,0 +1,177 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// newMirrorClass429Service wires a fresh RateLimitService with the given repo
+// stub and a saturation counter whose IncrementSaturation returns a monotonic
+// 1,2,3,… so the Nth HandleUpstreamError call sees count==N. This mirrors the
+// prod MIRROR-account path (Anthropic apikey) where each forwarded edge 429
+// re-increments the saturation counter.
+func newMirrorClass429Service(repo *rateLimitAccountRepoStub) (*RateLimitService, *fakeSaturationCounterRL) {
+	sat := &fakeSaturationCounterRL{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAnthropicSaturationCounter(sat)
+	return svc, sat
+}
+
+func headerlessEmptyPoolBody() []byte {
+	return []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)
+}
+
+// 1) Sustained sonnet header-less 429 on a prod MIRROR account writes EXACTLY a
+// class-scoped cooldown (anthropic:class:sonnet), reason
+// anthropic_unified_window_exceeded, resetAt within [now, now+90s] — and NEVER
+// an account-level SetRateLimited or the 3/3 ladder.
+func TestMirrorClass429_SustainedSonnet_WritesClassScopedCooldown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc, _ := newMirrorClass429Service(repo)
+	account := &Account{ID: 54, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	body := headerlessEmptyPoolBody()
+	before := time.Now()
+	// Drive past the sustained threshold (4-in-window): 5 hits.
+	for i := 0; i < 5; i++ {
+		require.True(t, svc.HandleUpstreamError(context.Background(), account,
+			http.StatusTooManyRequests, http.Header{}, body, "claude-sonnet-4-5"))
+	}
+	after := time.Now()
+
+	require.NotEmpty(t, repo.modelRateLimitCalls, "sustained sonnet 429 must write a class cooldown")
+	// First write lands on the threshold-crossing hit (count==4); subsequent hits
+	// are suppressed by the rewrite guard while remaining stays high.
+	first := repo.modelRateLimitCalls[0]
+	require.Equal(t, int64(54), first.accountID)
+	require.Equal(t, "anthropic:class:sonnet", first.scope)
+	require.Equal(t, "anthropic_unified_window_exceeded", first.reason)
+	require.False(t, first.resetAt.Before(before), "resetAt must be >= now")
+	require.False(t, first.resetAt.After(after.Add(time.Duration(tkAnthropicMirrorClassCooldownSeconds)*time.Second)),
+		"resetAt must be within the bounded ~90s floor")
+
+	require.Equal(t, 0, repo.setRateLimitedCalls, "must NEVER write account-level SetRateLimited")
+	require.Equal(t, 0, repo.tempCalls, "must NEVER advance the ladder / temp_unschedulable")
+	require.Equal(t, 0, repo.setErrorCalls)
+}
+
+// 2) A single blip (count below the sustained threshold) writes NO class cooldown.
+func TestMirrorClass429_BelowThreshold_NoCooldown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc, _ := newMirrorClass429Service(repo)
+	account := &Account{ID: 54, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	body := headerlessEmptyPoolBody()
+	// Only 3 hits → count never reaches the threshold (4).
+	for i := 0; i < 3; i++ {
+		require.True(t, svc.HandleUpstreamError(context.Background(), account,
+			http.StatusTooManyRequests, http.Header{}, body, "claude-sonnet-4-5"))
+	}
+	require.Empty(t, repo.modelRateLimitCalls, "a transient blip must not cool the class")
+	require.Equal(t, 0, repo.setRateLimitedCalls)
+	require.Equal(t, 0, repo.tempCalls)
+}
+
+// 3) Unknown / absent class (empty model name) → no write even when sustained.
+func TestMirrorClass429_UnknownClass_NoWrite(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc, _ := newMirrorClass429Service(repo)
+	account := &Account{ID: 54, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	body := headerlessEmptyPoolBody()
+	for i := 0; i < 5; i++ {
+		// No requestedModel arg → tkFirstRequestedModel == "" → unknown class.
+		require.True(t, svc.HandleUpstreamError(context.Background(), account,
+			http.StatusTooManyRequests, http.Header{}, body))
+	}
+	require.Empty(t, repo.modelRateLimitCalls, "unknown class must never be guessed into a cooldown")
+}
+
+// 4) Amplifier-safety: cooling sonnet on the mirror MUST leave opus schedulable.
+func TestMirrorClass429_Opus_OnlyCoolsOpus_SonnetSiblingStaysSchedulable(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc, _ := newMirrorClass429Service(repo)
+	account := &Account{ID: 54, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	body := headerlessEmptyPoolBody()
+	for i := 0; i < 5; i++ {
+		require.True(t, svc.HandleUpstreamError(context.Background(), account,
+			http.StatusTooManyRequests, http.Header{}, body, "claude-opus-4-8[1m]"))
+	}
+	require.NotEmpty(t, repo.modelRateLimitCalls)
+	require.Equal(t, "anthropic:class:opus", repo.modelRateLimitCalls[0].scope)
+
+	// Apply the written cooldown to a fresh account snapshot and assert sonnet is
+	// NOT considered model-rate-limited (sibling class unaffected).
+	cooled := accountWithClassCooldown(54, "anthropic:class:opus", repo.modelRateLimitCalls[0].resetAt)
+	require.True(t, cooled.tkAnthropicModelClassRateLimitActive("claude-opus-4-8[1m]"),
+		"opus must be cooled")
+	require.False(t, cooled.tkAnthropicModelClassRateLimitActive("claude-sonnet-4-5"),
+		"sonnet sibling must stay schedulable (amplifier-safety)")
+}
+
+// 5) Outbox-churn guard: a class already actively cooled with material remaining
+// is NOT rewritten on the next sustained hit.
+func TestMirrorClass429_AlreadyCooled_NoRewrite(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc, _ := newMirrorClass429Service(repo)
+	// Pre-seed an active sonnet cooldown with plenty of remaining (> rewrite floor).
+	account := accountWithClassCooldown(54, "anthropic:class:sonnet", time.Now().Add(80*time.Second))
+	account.Type = AccountTypeAPIKey
+
+	body := headerlessEmptyPoolBody()
+	for i := 0; i < 5; i++ {
+		require.True(t, svc.HandleUpstreamError(context.Background(), account,
+			http.StatusTooManyRequests, http.Header{}, body, "claude-sonnet-4-5"))
+	}
+	require.Empty(t, repo.modelRateLimitCalls,
+		"an already-actively-cooled class must not be rewritten (outbox-churn guard)")
+}
+
+// 6) The non_authoritative_429 branch (cc-us7 header-less envelope from the
+// ground-truth incident) also writes the class cooldown when sustained. This
+// body matches NO needle but IS header-less, so it lands on the
+// tkIsAnthropicNonAuthoritative429 skip branch.
+func TestMirrorClass429_NonAuthoritative429Branch_WritesCooldown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc, _ := newMirrorClass429Service(repo)
+	account := &Account{ID: 54, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	// Header-less 429 whose body is NOT a TK capacity needle ("no available
+	// accounts" / "all available accounts exhausted") — the cc-us7 relayed
+	// "Upstream rate limit exceeded" envelope.
+	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Upstream rate limit exceeded, please retry later"}}`)
+	for i := 0; i < 5; i++ {
+		require.True(t, svc.HandleUpstreamError(context.Background(), account,
+			http.StatusTooManyRequests, http.Header{}, body, "claude-sonnet-4-5"))
+	}
+	require.NotEmpty(t, repo.modelRateLimitCalls,
+		"header-less non-authoritative 429 must class-cool when sustained")
+	require.Equal(t, "anthropic:class:sonnet", repo.modelRateLimitCalls[0].scope)
+	require.Equal(t, 0, repo.setRateLimitedCalls)
+	require.Equal(t, 0, repo.tempCalls)
+}
+
+// accountWithClassCooldown builds an Account whose Extra carries an active
+// model-class cooldown at the given scope/resetAt, matching the JSON shape
+// modelRateLimitResetAt reads.
+func accountWithClassCooldown(id int64, scope string, resetAt time.Time) *Account {
+	return &Account{
+		ID:       id,
+		Platform: PlatformAnthropic,
+		Extra: map[string]any{
+			modelRateLimitsKey: map[string]any{
+				scope: map[string]any{
+					"rate_limit_reset_at": resetAt.Format(time.RFC3339),
+				},
+			},
+		},
+	}
+}

--- a/backend/internal/service/ratelimit_service_tk_saturation.go
+++ b/backend/internal/service/ratelimit_service_tk_saturation.go
@@ -37,6 +37,15 @@ const (
 	// no-available hits (e.g. one momentary edge burst) never trip it; only a
 	// SUSTAINED pattern does.
 	anthropicSaturationThreshold int64 = 4
+
+	// tkAnthropicMirrorClassCooldownSeconds is the bounded, self-renewing floor
+	// (in seconds) written on a prod MIRROR account's per-class cooldown when an
+	// edge's header-less empty-pool 429 is SUSTAINED for the in-flight model's
+	// class (see ratelimit_service_tk_mirror_class_429.go). Reuses the saturation
+	// window so there is a single knob: the edge 429 carries no authoritative
+	// reset, so the floor self-renews on each subsequent class-429 and
+	// self-expires on read.
+	tkAnthropicMirrorClassCooldownSeconds = anthropicSaturationWindowSeconds
 )
 
 // SetAnthropicSaturationCounter wires the Redis-backed saturation counter into
@@ -53,9 +62,14 @@ func (s *RateLimitService) SetAnthropicSaturationCounter(cache AnthropicSaturati
 // logged and swallowed — selection must never fail because the preference
 // counter is unavailable. Logs at threshold crossing only (low-volume), so ops
 // can see a stub entering the de-prioritized state.
-func (s *RateLimitService) recordAnthropicStubSaturation(ctx context.Context, accountID int64, statusCode int, reason string) {
+//
+// Returns the new in-window count so callers can gate a sustained-only side
+// effect (e.g. the prod mirror per-class cooldown) on the SAME threshold
+// without a second Redis read. Returns 0 when the counter is unwired or Redis
+// errored — callers MUST treat 0 as "cannot confirm sustained" (do NOT cool).
+func (s *RateLimitService) recordAnthropicStubSaturation(ctx context.Context, accountID int64, statusCode int, reason string) int64 {
 	if s == nil || s.anthropicSaturationCounter == nil {
-		return
+		return 0
 	}
 	count, err := s.anthropicSaturationCounter.IncrementSaturation(ctx, accountID, anthropicSaturationWindowSeconds)
 	if err != nil {
@@ -63,7 +77,7 @@ func (s *RateLimitService) recordAnthropicStubSaturation(ctx context.Context, ac
 			"account_id", accountID,
 			"reason", reason,
 			"error", err)
-		return
+		return 0
 	}
 	// Log exactly on the threshold-crossing increment (count == threshold), not
 	// per hit — one line marks the transition into the de-prioritized state.
@@ -76,4 +90,5 @@ func (s *RateLimitService) recordAnthropicStubSaturation(ctx context.Context, ac
 			"status_code", statusCode,
 			"reason", reason)
 	}
+	return count
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2539,9 +2539,10 @@
         "TestMirrorClass429_SustainedSonnet_WritesClassScopedCooldown",
         "TestMirrorClass429_BelowThreshold_NoCooldown",
         "TestMirrorClass429_Opus_OnlyCoolsOpus_SonnetSiblingStaysSchedulable",
-        "TestMirrorClass429_NonAuthoritative429Branch_WritesCooldown"
+        "TestMirrorClass429_NonAuthoritative429Branch_WritesCooldown",
+        "TestMirrorClass429_Genuine502_LegacyPath_NoMirrorClassCooldown"
       ],
-      "rationale": "Unit coverage for the prod-side per-class 429 propagation + failover helper (ratelimit_service_tk_mirror_class_429.go). Pins the amplifier-safety regression guards: sustained sonnet 429 writes ONLY anthropic:class:sonnet (never account-level SetRateLimited / ladder), a single blip writes nothing, an opus cooldown leaves sonnet schedulable, and the header-less non-authoritative-429 branch (the cc-us7 envelope) class-cools when sustained. An upstream merge that drops these tests removes the only mechanical proof the prod mirror failover stays class-scoped."
+      "rationale": "Unit coverage for the prod-side per-class 429 propagation + failover helper (ratelimit_service_tk_mirror_class_429.go). Pins the amplifier-safety regression guards: sustained sonnet 429 writes ONLY anthropic:class:sonnet (never account-level SetRateLimited / ladder), a single blip writes nothing, an opus cooldown leaves sonnet schedulable, and the header-less non-authoritative-429 branch (the cc-us7 envelope) class-cools when sustained. An upstream merge that drops these tests removes the only mechanical proof the prod mirror failover stays class-scoped. Includes the 502-legacy boundary test: a genuine HTTP 502 routes through the legacy handleAnthropicUpstreamError path which is intentionally NOT wired for the mirror per-class cooldown — pins that deliberate scope boundary against an accidental future widening."
     },
     {
       "path": "backend/internal/repository/anthropic_saturation_counter_cache.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2516,9 +2516,32 @@
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
         "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"no_available_accounts\")",
-        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"all_available_accounts_exhausted\")"
+        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"all_available_accounts_exhausted\")",
+        "s.tkTryAnthropicMirrorClassCooldownOnDownstreamEmpty(ctx, account, satCount, tkFirstRequestedModel(requestedModel))"
       ],
-      "rationale": "Thin injection of the saturation counter increments at the two HandleUpstreamError skip-penalty branches (429 empty-pool + legacy 503 no-available, and the failover-exhausted 502 sibling). These sit AFTER the skip decision (the function still returns true to fail over) so they never change the cooldown/ladder behaviour — they only feed the de-prioritization preference. An upstream merge that rewrites the skip branches would silently drop the feed; these literal call anchors catch it."
+      "rationale": "Thin injection of the saturation counter increments at the two HandleUpstreamError skip-penalty branches (429 empty-pool + legacy 503 no-available, and the failover-exhausted 502 sibling). These sit AFTER the skip decision (the function still returns true to fail over) so they never change the cooldown/ladder behaviour — they only feed the de-prioritization preference. An upstream merge that rewrites the skip branches would silently drop the feed; these literal call anchors catch it. TK prod per-class 429 propagation: the same two skip branches (plus the non-authoritative-429 branch) now also call tkTryAnthropicMirrorClassCooldownOnDownstreamEmpty with the saturation count + in-flight model, so a SUSTAINED header-less edge empty-pool 429 writes a class-scoped cooldown on the prod MIRROR account and prod fails the in-flight class over to sonnet-healthy sibling mirrors (amplifier-safe: class-scope only, never account-level/ladder). An upstream merge rewriting the skip branches would drop this feed; this literal anchor catches it. See ratelimit_service_tk_mirror_class_429.go."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_mirror_class_429.go",
+      "must_contain": [
+        "func (s *RateLimitService) tkTryAnthropicMirrorClassCooldownOnDownstreamEmpty(",
+        "if saturationCount < anthropicSaturationThreshold {",
+        "scopeKey := tkAnthropicModelClassScopeKeyForModel(requestedModel)",
+        "s.accountRepo.SetModelRateLimit(ctx, account.ID, scopeKey, resetAt, tkAnthropicModelCooldownReason)",
+        "anthropic_mirror_class_rate_limited",
+        "func tkFirstRequestedModel(requestedModel []string) string"
+      ],
+      "rationale": "Prod-side per-class 429 propagation + failover (prod incident: cc-us7 / account 54 0/N on sonnet while sibling mirrors had sonnet headroom). The edge's relayed empty-pool 429 is header-less and class-agnostic, so the edge's per-class window is invisible to prod and the prod MIRROR account never recorded model_rate_limits[\"anthropic:class:sonnet\"] — prod kept sticky-binding sonnet to the dead mirror and never failed over to sonnet-healthy siblings. This helper infers the class from the in-flight requested model and writes a BOUNDED, self-renewing floor cooldown at anthropic:class:<class> scope (via SetModelRateLimit, reusing tkAnthropicModelCooldownReason) ONLY when the saturation hit is SUSTAINED (saturationCount >= anthropicSaturationThreshold). Amplifier-safe: writes ONLY the class-scoped key, never account-level SetRateLimited or the 3/3 ladder, so opus/haiku on the same mirror stay schedulable. The read/filter/sticky-clear side is already wired (model_rate_limit.go tkAnthropicModelClassRateLimitActive; gateway_service shouldClearStickySession). An upstream merge or refactor dropping this helper or its sustained-gate silently regresses the failover and re-strands sonnet on the dead mirror — these anchors pin the load-bearing decision lines."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_mirror_class_429_test.go",
+      "must_contain": [
+        "TestMirrorClass429_SustainedSonnet_WritesClassScopedCooldown",
+        "TestMirrorClass429_BelowThreshold_NoCooldown",
+        "TestMirrorClass429_Opus_OnlyCoolsOpus_SonnetSiblingStaysSchedulable",
+        "TestMirrorClass429_NonAuthoritative429Branch_WritesCooldown"
+      ],
+      "rationale": "Unit coverage for the prod-side per-class 429 propagation + failover helper (ratelimit_service_tk_mirror_class_429.go). Pins the amplifier-safety regression guards: sustained sonnet 429 writes ONLY anthropic:class:sonnet (never account-level SetRateLimited / ladder), a single blip writes nothing, an opus cooldown leaves sonnet schedulable, and the header-less non-authoritative-429 branch (the cc-us7 envelope) class-cools when sustained. An upstream merge that drops these tests removes the only mechanical proof the prod mirror failover stays class-scoped."
     },
     {
       "path": "backend/internal/repository/anthropic_saturation_counter_cache.go",


### PR DESCRIPTION
## Root cause (prod incident: cc-us7 / account 54, 0/N on sonnet)

Prod reaches Anthropic only through per-edge **MIRROR** accounts (`cc-<edge>`, `platform=anthropic type=apikey`, `credentials.base_url=https://api-<edge>.tokenkey.dev`) that relay to an **edge** gateway holding the real OAuth account. Anthropic enforces a **per-MODEL-CLASS 5h/7d unified window**: when sonnet is exhausted on a single-account edge, the edge scheduler filters that OAuth account out for sonnet (records `account.extra.model_rate_limits["anthropic:class:sonnet"]` on the **edge** account) and returns prod a header-less `429 "no available accounts"` — while opus/haiku on that edge still serve 200.

The bug is on the **prod side**: the edge's per-class window is **invisible to prod**. The prod MIRROR account's `model_rate_limits["anthropic:class:sonnet"]` stays null, so prod:

1. keeps **sticky-binding** sonnet to the dead mirror (`shouldClearStickySession` never clears — the mirror still looks schedulable),
2. records **no** per-class cooldown on the edge 429,
3. never **fails over** to sonnet-healthy sibling mirrors (`cc-us5`/`cc-us6` whose edges have sonnet headroom).

Net: a universal/any key reads **0/N on sonnet** while healthy sonnet capacity sits idle next door.

## Fix (prod-only, write-only, edge-rollout-independent)

The edge's relayed 429 carries **no** `anthropic-ratelimit-*` headers and a class-agnostic body, so prod cannot learn the edge's true per-class reset. Prod therefore **infers the class from the in-flight requested model** (the class it just failed to serve on that mirror) and, when the hit is **SUSTAINED** (`saturationCount >= anthropicSaturationThreshold`, the existing 4-in-90s gate), writes a **bounded, self-renewing ~90s floor cooldown** at `anthropic:class:<class>` scope via the existing `SetModelRateLimit` store (reason `anthropic_unified_window_exceeded`).

Wired at the three **`case 429:`** skip branches in `HandleUpstreamError`:
- `no_available_accounts` (429 empty-pool fast-fail; legacy 503 stays on the legacy path),
- `all_available_accounts_exhausted` (the failover-exhausted body **relayed with a 429** status),
- `non_authoritative_429` (the **cc-us7 header-less envelope** from this incident).

**The read/filter/sticky-clear stack is already wired** for `anthropic:class:<class>` (`model_rate_limit.go` → `tkAnthropicModelClassRateLimitActive`; `gateway_service` `shouldClearStickySession`) — **zero read-side change**. So writing the class cooldown immediately makes prod fail the in-flight class over to a sonnet-healthy sibling and clear the stale sticky binding.

### Deliberate scope boundary (corrected during self-review)
The injection points live in `case 429:`. A **genuine HTTP 502** failover-exhausted body routes through `default:` → the **legacy** `handleAnthropicUpstreamError`, which is **intentionally NOT wired** for the mirror per-class cooldown because it lacks `requestedModel` (threading it would be a non-thin edit to an upstream-shaped function). The reported incident is 429-driven, so this is sufficient; the 502 legacy path is documented as out-of-scope and guarded by a boundary test. (Optional future work: an edge-side `X-TK-Model-Scope-Limited` header, or threading `requestedModel` into the legacy path.)

### Amplifier-safe (preserves the 2026-05-31 503-amplifier invariant)
- Writes **only** the class-scoped key — never account-level `SetRateLimited`, never the 3/3 ladder. opus/haiku on the same mirror **stay schedulable**.
- Gated on the **existing sustained threshold** — a single transient blip never cools a class.
- `recordAnthropicStubSaturation` now **returns the in-window count** so the sustained gate reuses the existing Redis counter with **no second read**; a nil/errored counter returns `0` → "cannot confirm sustained" → no write.
- Outbox-churn guard: skips rewrite while the class still has material remaining (best-effort, idempotent `SetModelRateLimit` overwrite).

## Tests
`ratelimit_service_tk_mirror_class_429_test.go` (8 cases):
1. Sustained sonnet 429 → exactly `anthropic:class:sonnet`, reason `anthropic_unified_window_exceeded`, `resetAt ∈ [now, now+90s]`; **no** `SetRateLimited` / `temp_unschedulable`.
2. Below threshold → no cooldown.
3. Unknown/absent class → no write (never guess).
4. Opus cools `anthropic:class:opus` only; sonnet sibling stays schedulable (amplifier-safety guard).
5. Already-actively-cooled class with material remaining → no rewrite (churn guard).
6. Non-authoritative-429 branch (cc-us7 header-less envelope) → class cooldown when sustained.
7. Failover-exhausted body **at 429** → class cooldown when sustained (covers injection point 2).
8. Genuine **502** → **no** mirror-class cooldown (legacy-path boundary guard).

Existing regressions (`ratelimit_service_tk_downstream_no_available_test.go` etc.) pass unchanged — the `recordAnthropicStubSaturation` return-value change is additive.

## Validation
- `go test -tags=unit ./...` — green (full `./...`)
- `go build ./...` + `go build -tags=integration ./...` — green
- `golangci-lint run ./internal/service/...` — 0 issues
- `scripts/preflight.sh` — **PASS** (gateway-tk sentinels intact; registry-update gate green — new files + injection lines anchored)

## Gate notes
- **Backend-only** → commits carry `no-web-impact`. No frontend/dist change.
- **Upstream override marker:** `ratelimit_service.go` is touched but the diff is **pure-insertion** and the file is sentinel-covered → coverage-first gate auto-passes with no marker.
- **Sentinel registry:** new file + test file + injection lines added to `scripts/sentinels/gateway-tk.json` — real anchors added (no `sentinel-registry-reviewed` marker needed).