### PR TITLE
fix(qa-export): S3 instance-role auth for export store + per-key export panel state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ FRONTEND_CRITICAL_VITEST := \
 	src/views/user/__tests__/PaymentResultView.spec.ts \
 	src/components/user/profile/__tests__/ProfileInfoCard.spec.ts \
 	src/views/admin/__tests__/SettingsView.spec.ts \
-	src/views/user/__tests__/UsageView.spec.ts
+	src/views/user/__tests__/UsageView.spec.ts \
+	src/composables/__tests__/useTkExportPanel.spec.ts
 
 # 一键编译前后端
 build: build-frontend build-backend

--- a/backend/internal/observability/qa/blob_store.go
+++ b/backend/internal/observability/qa/blob_store.go
@@ -103,16 +103,7 @@ func newBlobStore(cfg config.QACaptureConfig) (BlobStore, error) {
 		return newLocalFSBlobStore(filepath.Join(dataDir, "qa_blobs")), nil
 	}
 
-	region := strings.TrimSpace(cfg.Storage.Region)
-	if region == "" {
-		region = "auto"
-	}
-	awsCfg, err := awsconfig.LoadDefaultConfig(context.Background(),
-		awsconfig.WithRegion(region),
-		awsconfig.WithCredentialsProvider(
-			credentials.NewStaticCredentialsProvider(cfg.Storage.AccessKeyID, cfg.Storage.SecretAccessKey, ""),
-		),
-	)
+	awsCfg, err := awsconfig.LoadDefaultConfig(context.Background(), qaS3LoadOptions(cfg.Storage)...)
 	if err != nil {
 		return nil, fmt.Errorf("load qa s3 config: %w", err)
 	}
@@ -133,6 +124,36 @@ func newBlobStore(cfg config.QACaptureConfig) (BlobStore, error) {
 		bucket: cfg.Storage.Bucket,
 		prefix: strings.Trim(strings.TrimSpace(cfg.Storage.Prefix), "/"),
 	}, nil
+}
+
+// qaS3LoadOptions builds the AWS SDK config load options for the QA S3 store.
+//
+// It injects a static credentials provider ONLY when an access key is explicitly
+// configured (non-AWS / local S3-compatible stores like R2 / MinIO). When the
+// access key is empty it adds NO credentials provider, so LoadDefaultConfig uses
+// the default AWS credential chain — i.e. the EC2 instance role on prod. That is
+// exactly how the deploy is wired: ops/stage0/deploy_via_ssm.sh injects only
+// DRIVER/REGION/BUCKET/PREFIX (never a long-lived key), and the QaExports bucket
+// policy grants the app instance role Put/Get/Delete
+// (deploy/aws/cloudformation/stage0-backups.yaml).
+//
+// Previously newBlobStore unconditionally passed an empty static provider, so
+// every prod export died with "operation error S3: PutObject ... static
+// credentials are empty". This mirrors S3MediaStore
+// (internal/repository/media_s3_store.go), which is why media offload works on
+// the same instance role while export did not.
+func qaS3LoadOptions(storage config.QACaptureStorageConfig) []func(*awsconfig.LoadOptions) error {
+	region := strings.TrimSpace(storage.Region)
+	if region == "" {
+		region = "auto" // Cloudflare R2 default
+	}
+	opts := []func(*awsconfig.LoadOptions) error{awsconfig.WithRegion(region)}
+	if strings.TrimSpace(storage.AccessKeyID) != "" {
+		opts = append(opts, awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(storage.AccessKeyID, storage.SecretAccessKey, ""),
+		))
+	}
+	return opts
 }
 
 func (s *s3BlobStore) fullKey(key string) string {

--- a/backend/internal/observability/qa/blob_store_creds_test.go
+++ b/backend/internal/observability/qa/blob_store_creds_test.go
@@ -1,0 +1,78 @@
+//go:build unit
+
+package qa
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+// On prod the QA export S3 store authenticates via the EC2 instance role: the
+// deploy injects only DRIVER/REGION/BUCKET/PREFIX and the QaExports bucket
+// policy grants the instance role Put/Get/Delete. Forcing an empty static
+// credentials provider broke every export with "static credentials are empty"
+// (PutObject). This locks the fix: a static provider is added ONLY when an
+// access key is configured; otherwise we fall through to the default chain.
+func TestQAS3LoadOptions_StaticCredsOnlyWhenConfigured(t *testing.T) {
+	ctx := context.Background()
+
+	// No access key (the prod / instance-role path): exactly one option (region),
+	// no static credentials provider injected.
+	noCreds := qaS3LoadOptions(config.QACaptureStorageConfig{
+		Driver: "s3", Region: "us-east-1", Bucket: "tokenkey-prod-qa-exports",
+	})
+	if len(noCreds) != 1 {
+		t.Fatalf("empty access key must add only the region option (no static provider); got %d options", len(noCreds))
+	}
+
+	// Explicit access key (R2 / MinIO / local S3): region + static provider, and
+	// the resolved credentials are exactly the configured static pair.
+	withCreds := qaS3LoadOptions(config.QACaptureStorageConfig{
+		Driver: "s3", Region: "auto", Bucket: "b",
+		AccessKeyID: "AKIDTEST", SecretAccessKey: "SECRETTEST",
+	})
+	if len(withCreds) != 2 {
+		t.Fatalf("configured access key must add a static credentials provider; got %d options", len(withCreds))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, withCreds...)
+	if err != nil {
+		t.Fatalf("LoadDefaultConfig with static creds: %v", err)
+	}
+	creds, err := cfg.Credentials.Retrieve(ctx)
+	if err != nil {
+		t.Fatalf("retrieve static creds: %v", err)
+	}
+	if creds.AccessKeyID != "AKIDTEST" || creds.SecretAccessKey != "SECRETTEST" {
+		t.Fatalf("static creds not honored: got %q/%q", creds.AccessKeyID, "<redacted>")
+	}
+}
+
+// The regression guard, stated as the actual symptom: building the config the
+// empty-access-key way and resolving credentials must NOT yield the
+// "static credentials are empty" error that the empty static provider produced.
+// (It may fail with a default-chain error in a credential-less CI sandbox, or
+// succeed if ambient creds exist — either is fine; only the empty-static error
+// is the regression.)
+func TestQAS3LoadOptions_EmptyKeyDoesNotForceEmptyStatic(t *testing.T) {
+	// Keep the default chain from probing IMDS so the test never hangs/network-calls.
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	ctx := context.Background()
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, qaS3LoadOptions(config.QACaptureStorageConfig{
+		Driver: "s3", Region: "us-east-1", Bucket: "b",
+	})...)
+	if err != nil {
+		t.Fatalf("LoadDefaultConfig (no creds): %v", err)
+	}
+	if _, err := cfg.Credentials.Retrieve(ctx); err != nil {
+		if strings.Contains(err.Error(), "static credentials are empty") {
+			t.Fatalf("regression: empty static provider forced — export would fail on prod: %v", err)
+		}
+		// Any other error (no creds available in sandbox) is acceptable here.
+	}
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 497,
-  "hash": "243a9980593e4dbf991fe2a6305c17e82dbdb2bc6631e04013cd79937a2ccd96",
+  "hash": "97b57a9a67b32d202a4f300f21e3511247a2bd40730ea3f9430467b17a5e1a2f",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/composables/__tests__/useTkExportPanel.spec.ts
+++ b/frontend/src/composables/__tests__/useTkExportPanel.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+
+const showError = vi.fn()
+const showSuccess = vi.fn()
+const showInfo = vi.fn()
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({ showError, showSuccess, showInfo })
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string, args?: Record<string, unknown>) => (args ? `${key}:${JSON.stringify(args)}` : key) })
+}))
+
+vi.mock('@/api/qaTraj', () => ({
+  qaTrajAPI: {
+    exportKey: vi.fn(),
+    getJob: vi.fn(),
+    listExports: vi.fn(),
+    download: vi.fn()
+  }
+}))
+
+import { useTkExportPanel } from '@/composables/useTkExportPanel'
+import { qaTrajAPI } from '@/api/qaTraj'
+
+const mockExport = vi.mocked(qaTrajAPI.exportKey)
+const mockGetJob = vi.mocked(qaTrajAPI.getJob)
+const mockList = vi.mocked(qaTrajAPI.listExports)
+
+describe('useTkExportPanel — per-key export independence', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    showError.mockReset()
+    showSuccess.mockReset()
+    showInfo.mockReset()
+    mockExport.mockReset()
+    mockGetJob.mockReset()
+    mockList.mockReset()
+    mockList.mockResolvedValue([])
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // The panel is one reused instance whose api-key-id swaps as the user opens it
+  // for different keys. "running" must be scoped to the key actually exporting,
+  // not a shared boolean — otherwise exporting grok disables yace's button.
+  it('running is true only for the key whose export is in flight', async () => {
+    const apiKeyId = ref<number | null>(1) // grok
+    const apiKeyName = ref<string | undefined>('grok')
+    const tk = useTkExportPanel({ apiKeyId, apiKeyName })
+
+    mockExport.mockResolvedValue({ job_id: 'j1', status: 'pending', record_count: 0 })
+    let status = 'running'
+    mockGetJob.mockImplementation(async () => ({ job_id: 'j1', status, record_count: status === 'done' ? 5 : 0 }) as any)
+
+    const p = tk.exportNow() // in flight (setRunning runs synchronously before first await)
+
+    expect(tk.running.value).toBe(true) // grok exporting
+
+    // Switch the panel to a different key with no export of its own.
+    apiKeyId.value = 2 // yace
+    apiKeyName.value = 'yace'
+    expect(tk.running.value).toBe(false) // yace's button is enabled — the bug fix
+
+    // Switch back to grok while it is still polling.
+    apiKeyId.value = 1
+    apiKeyName.value = 'grok'
+    expect(tk.running.value).toBe(true)
+
+    // Finish grok's export.
+    status = 'done'
+    await vi.advanceTimersByTimeAsync(2100)
+    await p
+    expect(tk.running.value).toBe(false)
+  })
+
+  // A backgrounded export (user closed the dialog or switched keys) must NOT fire
+  // a toast — it would appear to belong to whatever key is on screen now. The
+  // panel's job list (refreshed on open) carries the result instead.
+  it('does not toast when the user switched away before the export finished', async () => {
+    const apiKeyId = ref<number | null>(1)
+    const apiKeyName = ref<string | undefined>('grok')
+    const tk = useTkExportPanel({ apiKeyId, apiKeyName })
+
+    mockExport.mockResolvedValue({ job_id: 'j1', status: 'pending', record_count: 0 })
+    let status = 'running'
+    mockGetJob.mockImplementation(async () => ({ job_id: 'j1', status, record_count: status === 'done' ? 7 : 0 }) as any)
+
+    const p = tk.exportNow()
+    apiKeyId.value = 2 // user moved to another key
+    status = 'done'
+    await vi.advanceTimersByTimeAsync(2100)
+    await p
+
+    expect(showSuccess).not.toHaveBeenCalled()
+    expect(showInfo).not.toHaveBeenCalled()
+    // the in-flight key was cleared even though we are no longer viewing it
+    apiKeyId.value = 1
+    expect(tk.running.value).toBe(false)
+  })
+
+  it('toasts success when the user is still viewing the exported key', async () => {
+    const apiKeyId = ref<number | null>(1)
+    const apiKeyName = ref<string | undefined>('grok')
+    const tk = useTkExportPanel({ apiKeyId, apiKeyName })
+
+    mockExport.mockResolvedValue({ job_id: 'j1', status: 'pending', record_count: 0 })
+    let status = 'running'
+    mockGetJob.mockImplementation(async () => ({ job_id: 'j1', status, record_count: status === 'done' ? 9 : 0 }) as any)
+
+    const p = tk.exportNow()
+    status = 'done'
+    await vi.advanceTimersByTimeAsync(2100)
+    await p
+
+    expect(showSuccess).toHaveBeenCalledTimes(1)
+    expect(showSuccess).toHaveBeenCalledWith('keys.exportSuccess:{"count":9}')
+  })
+})

--- a/frontend/src/composables/useTkExportPanel.ts
+++ b/frontend/src/composables/useTkExportPanel.ts
@@ -11,7 +11,7 @@
  * (TokenKey upstream-isolation pattern, CLAUDE.md §5).
  */
 
-import { ref, type Ref } from 'vue'
+import { computed, ref, type Ref } from 'vue'
 import { qaTrajAPI, type TrajExportJob } from '@/api/qaTraj'
 import { useAppStore } from '@/stores/app'
 import { useI18n } from 'vue-i18n'
@@ -35,8 +35,30 @@ export function useTkExportPanel(args: UseTkExportPanelArgs) {
 
   const exports = ref<TrajExportJob[]>([])
   const loading = ref(false)
-  const running = ref(false)
   const error = ref(false)
+
+  // Set of api-key ids with an in-flight manual export. The panel is a SINGLE
+  // persistent instance reused for every key (KeysView toggles :show + swaps
+  // :api-key-id), and exportNow() polls for up to 10 min off the request path —
+  // so "is an export running" MUST be scoped per key, not a shared boolean.
+  // Otherwise exporting key A and switching to key B (or reopening the panel for
+  // B) would show B as "exporting" and disable its button until A's poll loop
+  // ends. Keyed independence also lets A and B export concurrently (the backend
+  // already serializes them on its single export worker).
+  const runningKeyIds = ref<Set<number>>(new Set())
+
+  /** Whether the key currently shown in the panel has an in-flight export. */
+  const running = computed(() => {
+    const id = args.apiKeyId.value
+    return id != null && runningKeyIds.value.has(id)
+  })
+
+  function setRunning(id: number, on: boolean): void {
+    const next = new Set(runningKeyIds.value)
+    if (on) next.add(id)
+    else next.delete(id)
+    runningKeyIds.value = next
+  }
 
   /** (Re)load the key's recent export jobs, newest first. */
   async function refresh(): Promise<void> {
@@ -64,8 +86,16 @@ export function useTkExportPanel(args: UseTkExportPanelArgs) {
    */
   async function exportNow(): Promise<void> {
     const id = args.apiKeyId.value
-    if (id == null || running.value) return
-    running.value = true
+    // Re-entry guard is per-key: block a second export of THIS key, but never
+    // block a different key whose own export isn't running.
+    if (id == null || runningKeyIds.value.has(id)) return
+    // `viewing` answers "is the user still on the key this export belongs to?".
+    // Toasts and the list refresh are gated on it so a backgrounded export
+    // (panel closed, or switched to another key) never fires feedback that
+    // appears to belong to whatever key is on screen now — the panel's job list
+    // (refreshed on open) is the durable record for those cases.
+    const viewing = () => args.apiKeyId.value === id
+    setRunning(id, true)
     try {
       let job = await qaTrajAPI.exportKey(id)
       const deadline = Date.now() + POLL_DEADLINE_MS
@@ -74,18 +104,20 @@ export function useTkExportPanel(args: UseTkExportPanelArgs) {
         await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
         job = await qaTrajAPI.getJob(job.job_id)
       }
-      if (job.status === 'failed') {
-        appStore.showInfo(job.error === 'no_records' ? t('keys.exportEmpty') : t('keys.exportFailed'))
-      } else if (!job.record_count) {
-        appStore.showInfo(t('keys.exportEmpty'))
-      } else {
-        appStore.showSuccess(t('keys.exportSuccess', { count: job.record_count }))
+      if (viewing()) {
+        if (job.status === 'failed') {
+          appStore.showInfo(job.error === 'no_records' ? t('keys.exportEmpty') : t('keys.exportFailed'))
+        } else if (!job.record_count) {
+          appStore.showInfo(t('keys.exportEmpty'))
+        } else {
+          appStore.showSuccess(t('keys.exportSuccess', { count: job.record_count }))
+        }
       }
     } catch {
-      appStore.showError(t('keys.exportFailed'))
+      if (viewing()) appStore.showError(t('keys.exportFailed'))
     } finally {
-      running.value = false
-      await refresh()
+      setRunning(id, false)
+      if (viewing()) await refresh()
     }
   }
 


### PR DESCRIPTION
## 改了什么

修复 per-API-key 对话(traj)导出的两个 bug,均在 **prod** 复现。

### 1. 导出全部失败 —— 「0 条 · 失败 · 导出失败,请重试」(见截图)

**根因(在 prod 实测坐实,非推测):** 异步导出 worker 日志报:

```
qa/service_traj_export_job.go:194  traj export job failed
  error: "operation error S3: PutObject, get identity: get credentials:
          failed to refresh cached credentials, static credentials are empty"
```

`newBlobStore`(`internal/observability/qa/blob_store.go`)**无条件**注入了空的
`credentials.NewStaticCredentialsProvider(AccessKeyID, SecretAccessKey, "")`。
但 prod 的导出 S3 是走 **EC2 实例角色** 认证的,不是静态密钥:
`ops/stage0/deploy_via_ssm.sh` 只注入 `QA_CAPTURE_EXPORT_STORAGE_{DRIVER,REGION,BUCKET,PREFIX}`,而
`QaExportsBucketPolicy`(`deploy/aws/cloudformation/stage0-backups.yaml`)直接把
`s3:PutObject/GetObject/DeleteObject` 授权给了应用实例角色。当没有配置静态密钥时,这个空的
static provider **盖住了默认凭据链**,于是 zip 已经构建完成、到 `PutObject` 一步必炸 ——
所以 **每个 key、每个平台** 都是 `status=failed, error=export_failed, record_count=0`
(record_count 只在成功路径写,失败恒为 0,所以「0 条」并不代表没数据)。

这也解释了为什么同一台 host 上 `MEDIA_STORAGE`(图片/视频 offload)能用、导出却不能用:
`S3MediaStore`(`internal/repository/media_s3_store.go`)早就做对了 —— **仅当配置了 access key 时**
才注入 static provider,否则回落到实例角色。

**修复:** 让 `newBlobStore` 照搬 `S3MediaStore` 的写法 —— 抽出 `qaS3LoadOptions`,
只有 `AccessKeyID != ""` 时才注入 static provider,否则让 `LoadDefaultConfig` 走默认凭据链(实例角色)。

**已在 prod 实例角色上端到端验证**(确保修完不会变成 AccessDenied):用实例角色对
`tokenkey-prod-qa-exports-…/traj-exports/` 实跑 `PutObject` / `GetObject` / presign / `DeleteObject`,
全部成功。**无需改任何 prod 配置** —— 下次镜像部署即可生效。

### 2. 导出「正在导出」状态没有按 key 隔离

用户反馈:导出 `grok`,关掉弹窗等它后台跑,再打开另一个 key(`yace`)想导出 ——
它的按钮显示「正在导出」且不可点,非要等 grok 的导出结束才解锁。

**根因:** `ExportPanel` 是单例复用(KeysView 只切 `:show` 和 `:api-key-id`);
`useTkExportPanel` 用了一个共享的 `running` 布尔,而 `exportNow()` 会轮询最多 10 分钟,
于是 grok 那个在跑的轮询把其它每个 key 的按钮都锁住了。

**修复:** 把运行态按 `api-key-id` 隔离(用 `Set`),`running` 改成只看当前 key 的 computed;
并把「完成提示 + 列表刷新」限制在「仍在看该 key」时,这样后台导出永远不会对错的 key 弹提示。
各 key 现在互相独立导出(后端本来就用单 worker 串行排队)。

## 测试

- `backend/internal/observability/qa/blob_store_creds_test.go` —— 锁定凭据 provider 选择
  (key 为空时不注入 static provider;配置了就尊重静态凭据;空路径永远不会再报 "static credentials are empty")。
- `frontend/src/composables/__tests__/useTkExportPanel.spec.ts` —— 锁定按 key 隔离 + 提示归属;
  已加入 CI critical vitest 集(Makefile)。
- `make` 后端 unit 全量(`go test -tags=unit ./...`)绿;`go build ./...` 绿;golangci-lint 干净;
  前端 lint + typecheck + critical vitest 绿;`scripts/preflight.sh` PASS。

## Markers

`sentinel-registry-reviewed` —— registry-update gate 标记了我对 `Makefile`
(在 `FRONTEND_CRITICAL_VITEST` 里增量加了一行)和既有文件
`frontend/src/composables/useTkExportPanel.ts`(非纯插入式编辑)的改动。二者都是对既有文件的编辑、
不是新增的 load-bearing companion,无需新增 sentinel 锚点;已审阅确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
