### PR TITLE
feat(qwen): onboard qwen3.6-27b on the Qwen group (account 60)

### DIFF
--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -980,6 +980,15 @@
     "cache_read_input_token_cost": 2.9850746268656716e-07,
     "source": "Alibaba DashScope qwen3-235b-a22b (开源版 MoE, 235B total / 22B active, hybrid 非思考和思考模式) official China-mainland (Beijing) RMB list ÷ 6.7; docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (qwen3-235b-a22b 中国内地 row). Added 2026-06-18 per customer request to surface the flagship Qwen3 model on the Qwen group (account 60), which previously listed only the smaller Qwen3 models. Mirrors Alibaba's two-rate table for the SAME model id (in ¥2/M; out 非思考 ¥8/M / 思考 ¥20/M) — coincidentally identical per-token rates to qwen3-32b — switched by the request's enable_thinking param: output_cost_per_token = non-thinking, thinking_output_cost_per_token = thinking. enable_thinking DEFAULTS to true for the open-source Qwen3 hybrid base alias, so billing defaults to the thinking rate when the param is absent (matches upstream). List price only — Batch (half-price)/context-cache discounts not modeled (cache_read billed at full input rate). International deployment is higher and intentionally NOT modeled; the prod account uses the China-mainland endpoint."
   },
+  "qwen3.6-27b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 4.477611940298508e-07,
+    "output_cost_per_token": 2.6865671641791044e-06,
+    "thinking_output_cost_per_token": 2.6865671641791044e-06,
+    "cache_read_input_token_cost": 4.477611940298508e-07,
+    "source": "Alibaba DashScope qwen3.6-27b (开源版 dense, Qwen3.6 family, released 2026-04-22) official China-mainland (华北2北京) RMB list ÷ 6.7; docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (Qwen3.6 华北2北京 row, single tier 0<Token≤256K). Mirrors Alibaba's two-rate table for the SAME model id (in ¥3/M; out 非思考 ¥18/M / 思考 ¥18/M — i.e. 非思考和思考同价, unlike the older dense qwen3-8b/14b/32b whose thinking rate is higher), switched by the request's enable_thinking param: output_cost_per_token = non-thinking, thinking_output_cost_per_token = thinking (equal here). enable_thinking DEFAULTS to true for open-source dense Qwen3, so billing defaults to the thinking rate when the param is absent (matches upstream). Added 2026-06-21 per customer request to serve the dense 27B Qwen3.6 model on the Qwen group (account 60). List price only — Batch (half-price)/context-cache discounts not modeled (cache_read billed at full input rate). International deployment is higher and intentionally NOT modeled; the prod account uses the China-mainland endpoint."
+  },
   "qwen2.5-coder-32b": {
     "litellm_provider": "dashscope",
     "mode": "chat",

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -183,6 +183,18 @@
       "display": false,
       "notes": "Qwen account 60. Flagship open-source Qwen3 MoE (235B total / 22B active). Mapped by tk_032 (identity whitelist merge). Priced in overlay (added 2026-06-18, same per-token rates as qwen3-32b). Added per customer request: the Qwen group previously listed only the smaller Qwen3 models."
     },
+    "newapi/qwen3.6-27b": {
+      "platform": "newapi",
+      "model_id": "qwen3.6-27b",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3.6-27b",
+      "display": false,
+      "notes": "Qwen account 60. Dense 27B Qwen3.6 model (released 2026-04-22, DashScope model id qwen3.6-27b). Mapped by tk_039 (identity whitelist merge). Priced in overlay (中国内地/华北2北京 in ¥3/M out ¥18/M, 非思考和思考同价, ÷6.7; thinking-rate default because open-source dense Qwen3 defaults enable_thinking=true). Added 2026-06-21 per customer request (client wrote 'qwen3.6-27B'; served under DashScope's canonical lowercase id)."
+    },
     "newapi/doubao-seedance-1-0-pro-250528": {
       "platform": "newapi",
       "model_id": "doubao-seedance-1-0-pro-250528",

--- a/backend/migrations/tk_039_qwen3_6_27b_model_mapping.sql
+++ b/backend/migrations/tk_039_qwen3_6_27b_model_mapping.sql
@@ -1,0 +1,56 @@
+-- Migration: tk_039_qwen3_6_27b_model_mapping
+--
+-- Advertise the dense open-source Qwen3.6 27B model on the Qwen account (id=60),
+-- so the Qwen group can serve it:
+--   - account 60 "Qwen" (Ali, channel_type=17): qwen3.6-27b
+--
+-- Why (prod 2026-06-21, per customer request): a client asked for the dense 27B
+-- Qwen3.6 model (released 2026-04-22; DashScope model id "qwen3.6-27b"). account
+-- 60's credentials.model_mapping is an identity WHITELIST that listed the qwen3.7-max
+-- family + qwen-max/qwen-plus (tk_027), qwen3.7-plus / qwen3.6-flash /
+-- qwen3-coder-plus (tk_024), the dense qwen3-8b/14b/32b (tk_029) and the flagship
+-- qwen3-235b-a22b (tk_032), but NOT qwen3.6-27b. The scheduler found no account
+-- advertising this name for the group -> empty pool -> fast-fail 429. DashScope
+-- serves qwen3.6-27b directly with account 60's key (China-mainland/Beijing
+-- endpoint), so merging it into the whitelist makes the bridge advertise + route it.
+--
+-- Pricing shipped alongside this migration (added 2026-06-21) via
+-- backend/internal/service/tk_pricing_overlay.json (qwen3.6-27b: in ¥3/M, out
+-- 非思考 ¥18/M / 思考 ¥18/M — 非思考和思考同价; all ÷6.7; thinking-rate default because
+-- open-source dense Qwen3 defaults enable_thinking=true). The overlay is
+-- compile-embedded, so the whitelist add lands on an image that already prices this
+-- name -- no $0 window.
+--
+-- Merge (jsonb ||) preserves the existing identity-whitelist entries; only the one
+-- new identity key is added. Raw-SQL account mutation bypasses the Ent
+-- snapshot-refresh hooks, so enqueue a scheduler_outbox account_changed event
+-- (pattern: tk_022 / tk_024 / tk_027 / tk_029 / tk_032) so the running scheduler
+-- sees the change without a restart.
+--
+-- Idempotent + cross-deployment safe: guarded by (id, name, platform='newapi',
+-- channel_type=17) so re-running merges the same key (no-op) and a bare id
+-- colliding with an unrelated account in another DB cannot match.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+-- Qwen account 60: add qwen3.6-27b (dense, open-source, hybrid thinking).
+WITH upd_qwen AS (
+    UPDATE accounts
+    SET credentials = jsonb_set(
+            credentials,
+            '{model_mapping}',
+            COALESCE(credentials -> 'model_mapping', '{}'::jsonb) || '{
+                "qwen3.6-27b": "qwen3.6-27b"
+            }'::jsonb
+        ),
+        updated_at = NOW()
+    WHERE id = 60
+      AND name = 'Qwen'
+      AND platform = 'newapi'
+      AND channel_type = 17
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd_qwen;


### PR DESCRIPTION
## What

Onboard **`qwen3.6-27b`** (dense open-source Qwen3.6 27B, released 2026-04-22) on the **Qwen group** (account 60, `newapi` platform / `channel_type=17` / DashScope) — served **and** priced.

Client requested `qwen3.6-27B`; served under DashScope's canonical lowercase id `qwen3.6-27b` (the `model_mapping` whitelist key must match the upstream id exactly).

## Changes (three-way consistent, gated by `scripts/checks/catalog-serving-drift.py`)

- **`tk_served_models.json`** — manifest entry `newapi/qwen3.6-27b` (`served_on=["60"]`, `price_source=overlay`, `channel_type=17`, `display=false`).
- **`tk_pricing_overlay.json`** — price for `qwen3.6-27b`. `thinking_output_cost_per_token` carried (= output) because open-source dense Qwen3 defaults `enable_thinking=true`. Source: `docs/accounts/aliyun_pricing_20260612.md` line 967 (captured 2026-06-12).
- **`tk_039_qwen3_6_27b_model_mapping.sql`** — merge identity whitelist key onto account 60 (`jsonb ||`, guarded by `id/name/platform/channel_type/deleted_at`) + `scheduler_outbox account_changed` for hot pickup (pattern `tk_032`).

## Pricing provenance (sourced, not fabricated)

| model | region | input | output 非思考 | output 思考 | tier |
|---|---|---|---|---|---|
| `qwen3.6-27b` | 中国内地 (华北2北京) | ¥3/M | ¥18/M | ¥18/M | 0<Token≤256K |

非思考和思考同价. ÷ 6.7 (canonical CNY/USD) → input `3/6.7/1e6` = `4.477611940298508e-07`; output/thinking `18/6.7/1e6` = `2.6865671641791044e-06`; `cache_read = input` (full input rate, no cache discount modeled). List price only; International deployment intentionally not modeled (prod uses the China-mainland endpoint).

## Validation

- `catalog-serving-drift.py` `--selftest` + live: **ok (20 entries)** — A1 price + A3 migration-mapping both pass for the new row.
- `pricing-overlay.py`: **ok (71 entries)**.
- `scripts/preflight.sh` (pre-commit hook): **PASS**.
- Marker gates (real CI mode): `upstream-override-marker` → *no upstream-shaped paths changed* (no marker); `check-registry-update-gate` → *no changed registries* (no anchor needed).
- `no-web-impact`: backend data only (overlay / manifest / migration); no frontend source or dist change. The public `/pricing` catalog renders `newapi` models via runtime price-presence passthrough.

## Out of scope / operator follow-ups (NOT in this PR, prod-only, authorized)

1. Migration applies on deploy → `scheduler_outbox account_changed` hot-picks the new whitelist key (no restart).
2. Overlay price hot-push without waiting for a release: `python3 ops/pricing/manage-overlay-runtime.py sync-runtime` (prod SSM).
3. Livefire 200 probe (thinking + non-thinking) per the `tokenkey-onboard-model` skill §5, then a two-tier billing spot-check on a real `usage_log`.

Reviewer: **Squash and merge** (TK-originated PR). Merge awaits authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
