### PR TITLE
fix(ops): make overlay sync-runtime actually push (gzip + base64-decode-in-PG + file-exec)

### DIFF
--- a/ops/pricing/manage-overlay-runtime.py
+++ b/ops/pricing/manage-overlay-runtime.py
@@ -30,10 +30,12 @@ from __future__ import annotations
 
 import argparse
 import base64
+import gzip
 import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import NoReturn
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 OVERLAY_PATH = REPO_ROOT / "backend" / "internal" / "service" / "tk_pricing_overlay.json"
@@ -47,7 +49,7 @@ PSQL = "sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A
 REDISCLI = "env -u REDISCLI_AUTH sudo docker exec tokenkey-redis redis-cli"
 
 
-def fail(msg: str) -> "NoReturn":  # type: ignore[name-defined]
+def fail(msg: str) -> NoReturn:
     print(f"ERROR: {msg}", file=sys.stderr)
     sys.exit(2)
 
@@ -99,8 +101,22 @@ def resolve_prod_instance() -> str:
 
 
 def ssm_run_shell(instance_id: str, shell_b64: str, comment: str) -> str:
-    """Run a base64-encoded shell script on prod via SSM; return stdout."""
-    command = f"set -euo pipefail\necho {shell_b64} | base64 -d | bash"
+    """Run a base64-encoded shell script on prod via SSM; return stdout.
+
+    The decoded script is written to a FILE and bash'd from that file rather than piped
+    to `bash` via stdin. If the script contains a `docker exec -i ... psql` call (it does),
+    that child shares the shell's stdin; when stdin is the decode pipe it SLURPS the rest
+    of the script, silently truncating everything after the first psql call while still
+    reporting Success (rc=0). File-backed exec gives the child an empty stdin instead.
+    `set -uo pipefail` (no -e) so a non-zero inner script still lets us capture rc, clean
+    up, and propagate the exit code."""
+    command = (
+        "set -uo pipefail\n"
+        f"echo {shell_b64} | base64 -d > /tmp/.ovr_runtime_$$.sh\n"
+        "bash /tmp/.ovr_runtime_$$.sh; rc=$?\n"
+        "rm -f /tmp/.ovr_runtime_$$.sh\n"
+        "exit $rc"
+    )
     params = json.dumps({"commands": [command]}, ensure_ascii=False)
     try:
         cid = subprocess.check_output(
@@ -178,30 +194,43 @@ def cmd_sync_runtime(args) -> int:
         return 0
 
     inst = resolve_prod_instance()
-    value_b64 = base64.b64encode(overlay_bytes).decode()
-    # Pass the JSON value through a psql variable with :'v' quoting — psql escapes
-    # embedded single quotes (source strings may contain apostrophes), so no manual
-    # quoting hazard. base64 carries the multi-line JSON intact to the host.
+    # Transport: GZIP then base64 so the SSM SendCommand parameter stays well under AWS's
+    # 97KB limit. The raw overlay is ~100KB+ (long per-entry `source` strings); base64 of
+    # that alone exceeds 97KB -> MaxDocumentSizeExceeded. gzip shrinks the repetitive JSON
+    # ~6x. On the host we gunzip and re-base64 (host-side command length is NOT SSM-limited)
+    # and decode it INSIDE Postgres via convert_from(decode(...,'base64'),'UTF8'): base64 is
+    # pure ASCII so it is safe inside the single-quoted SQL literal, and this avoids the
+    # psql :'v' variable interpolation which silently fails in -c mode (syntax error at ":").
+    gz_b64 = base64.b64encode(gzip.compress(overlay_bytes)).decode()
+    if gzip.decompress(base64.b64decode(gz_b64)) != overlay_bytes:
+        fail("gzip roundtrip mismatch; refusing to push")  # never touch prod on a bad encode
+    # Decode on the host, re-base64 the plain JSON, decode that inside Postgres. The stored
+    # `value` is the exact overlay JSON (byte-identical to the old :'v' path); `check` reads
+    # it back unchanged.
     upsert = (
-        f"INSERT INTO settings (key, value, updated_at) VALUES ('{SETTING_KEY}', :'v', NOW()) "
+        f"INSERT INTO settings (key, value, updated_at) VALUES "
+        f"('{SETTING_KEY}', convert_from(decode('$JSON_B64','base64'),'UTF8'), NOW()) "
         "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW();"
     )
     shell = (
-        "set -euo pipefail\n"
+        "set -uo pipefail\n"
         f"PSQL='{PSQL}'\n"
         f"RC='{REDISCLI}'\n"
-        f"VAL=\"$(echo {value_b64} | base64 -d)\"\n"
+        f"JSON_B64=\"$(echo {gz_b64} | base64 -d | gunzip | base64 | tr -d '\\n')\"\n"
         "echo '=== upsert tk_pricing_overlay_runtime ==='\n"
-        f"$PSQL -v v=\"$VAL\" -c \"{upsert}\"\n"
+        f"$PSQL -c \"{upsert}\" </dev/null && echo UPSERT_OK\n"
         "echo '=== publish settings_updated (fan-out reload) ==='\n"
-        # Best-effort: the UPSERT above is the durable truth; PUBLISH only makes the
-        # reload immediate. Surface a failure (don't swallow it) so the operator knows
-        # replicas will lag to the poll interval instead of reloading now.
-        "$RC PUBLISH settings_updated refresh || echo 'WARN: redis PUBLISH failed; replicas reload within the pricing poll interval, not immediately'\n"
+        # Best-effort: the UPSERT above is the durable truth; PUBLISH only makes the reload
+        # immediate. Surface (don't swallow) a failure so the operator knows replicas will
+        # lag to the poll interval instead of reloading now.
+        "$RC PUBLISH settings_updated refresh </dev/null || echo 'WARN: redis PUBLISH failed; replicas reload within the pricing poll interval, not immediately'\n"
         "echo '=== settings_after ==='\n"
-        f"$PSQL -c \"SELECT key, length(value) AS bytes FROM settings WHERE key='{SETTING_KEY}';\"\n"
+        f"$PSQL -c \"SELECT key, length(value) AS bytes FROM settings WHERE key='{SETTING_KEY}';\" </dev/null\n"
     )
     b64 = base64.b64encode(shell.encode()).decode()
+    if len(b64) > 90_000:  # headroom under the 97KB SSM SendCommand parameter ceiling
+        fail(f"encoded sync payload is {len(b64)}B (>90KB) even gzipped; overlay too large "
+             f"for SSM SendCommand — stage via S3 instead")
     out = ssm_run_shell(inst, b64, "overlay sync-runtime: upsert + publish")
     print(out)
     print("synced. Verify with: manage-overlay-runtime.py check")


### PR DESCRIPTION
## Problem

`ops/pricing/manage-overlay-runtime.py sync-runtime` — the documented zero-deploy price hot-push path (`tokenkey-onboard-model` skill §4) — **never actually worked at the current overlay size**. Discovered while hot-pushing `qwen3.6-27b`'s price to prod (#920): prod's `tk_pricing_overlay_runtime` setting was **empty (0 entries)**, so every model has been pricing off the embedded image floor only.

Three independent blockers:

1. **SSM 97KB limit** — raw overlay (~64KB) base64'd in the SSM shell, then base64'd *again* by `ssm_run_shell`, exceeded the 97KB `SendCommand` parameter ceiling → `MaxDocumentSizeExceeded`.
2. **psql `:'v'` fails in `-c` mode** — `syntax error at or near ":"`; the UPSERT never ran even when small enough.
3. **`docker exec -i` stdin slurp** — the decoded script was piped to `bash` via stdin; the first `docker exec -i psql` slurps the rest of the script (silent truncation, still `rc=0`), eating the `PUBLISH` + verify.

## Fix

| blocker | fix |
|---|---|
| 97KB | `gzip(overlay)+base64` (~11KB) to host → gunzip + re-base64 host-side → decode in Postgres. Local roundtrip + payload-size guards refuse to touch prod on a bad encode. |
| `:'v'` | `convert_from(decode('<b64>','base64'),'UTF8')` — pure-ASCII base64, safe in the SQL literal, no interpolation. |
| stdin slurp | `ssm_run_shell` writes the decoded script to a file and `bash`es the file (fixes every caller). |

Plus a pre-existing F821 (`fail()` annotated `-> "NoReturn"` with no import).

## Validation

- `--selftest` 5/5, `sync-runtime --dry-run` green, ruff clean, preflight PASS.
- gzip transport: **64629 B raw → 11380 B gz+base64**, est SSM payload ~16KB (≪ 97KB).
- The `convert_from` + file-exec transport is byte-for-byte the one used this session to successfully hot-push `qwen3.6-27b`'s runtime price to prod (verified read-back).

## Not in this PR (follow-up menu from the toolchain audit)

Idempotency skip (don't UPSERT if already in sync), Python-side post-sync drift recheck, instance-id regex validation, `get-command-invocation` malformed-JSON guard, and `probe-servable-models.sh` group-not-found explicit error (vs generic `000 auth_error`). Listed for a focused follow-up.

`no-web-impact` (ops tooling, no frontend). Merge awaits authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
