### PR TITLE
fix(admin): 根治 /accounts 偶发持续闪烁 — 虚拟化 getItemKey + 整页 overscan

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 497,
-  "hash": "97b57a9a67b32d202a4f300f21e3511247a2bd40730ea3f9430467b17a5e1a2f",
+  "hash": "019562f1ff8b3d8c0c916f1a8e780dbc6e07c37e368b6d3e70c3b829da3e0d76",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/common/DataTable.vue
+++ b/frontend/src/components/common/DataTable.vue
@@ -692,6 +692,10 @@ const rowVirtualizer = useVirtualizer(computed(() => ({
   getScrollElement: () => tableWrapperRef.value,
   estimateSize: () => props.estimateRowHeight ?? 56,
   overscan: props.overscan ?? 5,
+  // 关键:用稳定的逻辑 key(flatItemKey,行/明细行各自唯一)作为测量缓存键,而非默认的 flat index。
+  // 否则展开/折叠或 flatItems 重排会使某 index 的缓存高度落到「另一条逻辑行」上,measure 时读到错位
+  // 旧值 → 反复产生非零 delta → 校正→重排→再测量,在变高明细行(edge 面板)场景下永不收敛,表现为页面持续闪烁。
+  getItemKey: (index: number) => flatItemKey(index),
   // 兜底高度:首个有效高度读数到来前,先按一屏渲染,避免空白帧
   initialRect: { width: 0, height: estimatedViewportHeight() },
   // 关键:过滤 0 高度读数,杜绝 scrollRect 被钉成 0 → calculateRange 返回 null → 整表空白

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -174,6 +174,11 @@
           @toggle-schedulable="handleBulkToggleSchedulable"
         />
         <div ref="accountTableRef" class="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <!-- TK(防闪烁): overscan = 当前 page_size,使账号页(行数天然受 page_size 上界约束)始终渲染
+             整页行,等价于不开窗。fluid 模式走 table-auto——列宽由「当前已渲染的行」内容决定,虚拟化下
+             可见行集随滚动/测量变化会让换行单元格的高度抖动,打破 @tanstack/vue-virtual 的测量自收敛
+             假设,在变高 edge 明细行场景下出现「偶发的页面持续闪烁」。整页渲染后列宽对每帧恒定(与非虚拟化
+             的 /edge-accounts 页同样稳定),根除该抖动;edge 明细行仍按需展开,DOM 量受 page_size 约束。 -->
         <DataTable
           ref="dataTableRef"
           fluid
@@ -188,7 +193,7 @@
           default-sort-order="asc"
           :sort-storage-key="ACCOUNT_SORT_STORAGE_KEY"
           :estimate-row-height="76"
-          :overscan="5"
+          :overscan="pagination.page_size"
           :expandable="isEdgeExpandable"
           :expanded-keys="edgeExpandedKeys"
         >


### PR DESCRIPTION
## 问题

`https://api.tokenkey.dev/admin/accounts` **偶发**进入「页面一直闪烁」状态,edge 明细面板展开时尤甚(见用户截图:kiro stub「该 edge 暂未被发现」状态下的持续闪烁)。

## 根因(两个叠加的虚拟化缺陷)

经对抗式排查(多路独立侦察 + 对抗验证)确认,闪烁来自 `DataTable` 虚拟化与 fluid 表格布局的相互作用:

1. **缺少 `getItemKey`** — `@tanstack/vue-virtual` 默认按 *flat index* 索引测量缓存。穿插了变高的 edge 明细行后,展开/折叠或 `flatItems` 重排会让某 index 的缓存高度落到「另一条逻辑行」上,`measure` 读到错位旧值 → 反复产生非零 delta。
2. **`table-layout: auto` + 虚拟化** — fluid 模式下列宽由「**当前已渲染的可见行**」内容决定。虚拟化下可见行集随滚动/测量变化 → 边界换行单元格高度抖动 → 打破 vue-virtual「同一节点 `offsetHeight` 稳定」的自收敛前提 → 在特定滚动位置/数据下进入**双稳态 range 翻转,永不收敛**。

这唯一地解释了:
- **「偶发」** — 只有某些行集 / 滚动位置进入双稳态;
- **「一直闪烁」** — 一旦进入就不收敛;
- 为何**非虚拟化**的 `/edge-accounts` 页(同一 edge 数据引擎)**从不闪烁**。

### 排除的假线索

`checkActionsColumnWidth` 在 `ResizeObserver` 里 toggle `actionsExpanded`,看似一个经典 RO 反馈环。但 `actions-expanded` **无任何 CSS 规则**、AccountsView 的 `#cell-actions` **忽略 `:expanded` 槽属性**、`actionsColumnNeedsExpanding` **无人读取** → 该 toggle 在本视图完全无布局副作用,环闭合不了。

默认开启的 30s edge 自动刷新真实存在但**良性**(只是 30s 一次文案刷新,非持续闪烁;其「就地改字段」式修法有 `accountVm` WeakMap 缓存陈旧暗雷,已避开)。

## 修复(最小、低风险、限定影响)

| 文件 | 改动 | 说明 |
|---|---|---|
| `DataTable.vue` | 补 `getItemKey: (index) => flatItemKey(index)` | 测量缓存改按**稳定逻辑 key** 索引。纯新增;对所有消费方都是改进——服务端排序时 index-keyed 缓存本就会错位。**不碰**「整表空白」兜底守卫(`observeElementRectNonZero` / `initialRect`)。 |
| `AccountsView.vue` | `:overscan="pagination.page_size"` | 让受 `page_size` 上界约束的账号页**始终整页渲染** → 列宽对每帧恒定(等价于非虚拟化的 `/edge-accounts` 稳定行为),根除 table-auto 抖动。**仅限 AccountsView**,其它 DataTable 消费方零影响。 |

`backend/internal/web/dist/frontend-source.json` 为前端构建产物清单的常规重生成。

## 验证

- ✅ `pnpm typecheck`
- ✅ `pnpm lint:check`
- ✅ `pnpm exec vitest run`(28 文件 / 103 测试全过,含 `DataTableExpandable` 与 admin 视图)
- ✅ `pnpm build`(已重生成 `frontend-source.json`)
- ✅ 本地 `scripts/preflight.sh` 全过;上游覆写门禁:无需 marker(两个 Vue 视图不在上游受管路径集内)

## 说明 / 局限

闪烁是状态依赖的偶发现象,需 prod edge 数据 + 特定双稳态布局才能现场复现,jsdom 无真实布局也无法在单测里触发该测量环——故本修复为**强对抗 RCA + 静态校验**确认,而非现场复现修复。`getItemKey` 这条连「试图反驳它是主因」的验证也认可为安全且正确的硬化。若部署后仍偶见闪烁,下一手是给 `DataTable` 的 fluid 路径上 `table-layout: fixed`(需统一列宽,视觉面较大,故本 PR 暂不动)或线上插桩。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 门禁标记

`sentinel-registry-reviewed`

— 本 PR 编辑了 sentinel 受管的 TK 面 `frontend/src/views/admin/AccountsView.vue`,且含一处删除行(`:overscan="5"` → `:overscan="pagination.page_size"`),故触发 sentinel registry update gate。已逐条复核 `scripts/sentinels/frontend-tk.json` 中该文件的全部锚点(`<TablePageLayout fluid>`、`:sticky-edge-hints="false"`、`Wrap-first column policy`、`const wrap`、`wrap('max-w-[15rem]')`、`current.current_rpm !== next.current_rpm`、`v-if="row.notes"`、`EdgeAccountPanelTk`、`useTkAccountsEdgePanels`、`:expanded-keys="edgeExpandedKeys"`、ID hint、`useTkAccountUsageBatch` / `accountUsageOverrideFor` / `refreshUsageBatch` 等)——**全部保留、未改动**。被删除的 `:overscan="5"` 并非任何受管锚点,无需新增/更新 sentinel 锚点。

(upstream-override 子门已通过:无上游受管路径变更;本 PR 非 upstream-merge,故不使用 `upstream-merge` 标记。)
