### PR TITLE
feat(catalog): onboard qwen-turbo on Qwen account 60 (servable + priced)

### DIFF
--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -851,6 +851,14 @@
     "cache_read_input_token_cost": 3.582089552238806e-07,
     "source": "Alibaba DashScope qwen-max (legacy stable alias, 当前能力等同 qwen-max snapshot) official China-mainland (Beijing) RMB list ÷ 6.7 (无阶梯计价 in ¥2.4/M out ¥9.6/M); docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Added 2026-06-13: client-facing legacy alias served via account 60 (dashscope.aliyuncs.com) that the qwen3.7-* mapping did not cover (empty-pool 429 incident). List price only — Batch (half-price)/context-cache discounts not modeled (bill at list). International deployment is ~5x higher (¥11.743/¥46.971) and intentionally NOT modeled; the prod account uses the China-mainland endpoint."
   },
+  "qwen-turbo": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 4.477611940298507e-08,
+    "output_cost_per_token": 8.955223880597015e-08,
+    "cache_read_input_token_cost": 4.477611940298507e-08,
+    "source": "Alibaba DashScope qwen-turbo (commercial qwen3 alias) official China-mainland (Beijing) RMB list ÷ 6.7 (无阶梯 in ¥0.3/M, out 非思考 ¥0.6/M); docs/accounts/aliyun_pricing_20260612.md line 394 captured 2026-06-12. Added 2026-06-22 (Goal 2 fleet servable-expansion): client-facing model served via account 60 (dashscope.aliyuncs.com), mapped by tk_042. Output priced at NON-thinking list; enable_thinking defaults FALSE for commercial qwen (same treatment as qwen-plus), thinking-mode output (¥3/M) intentionally NOT modeled (bill at non-thinking list). List price only — Batch (half-price)/context-cache discounts not modeled (cache_read billed at full input rate). International deployment higher and intentionally NOT modeled; the prod account uses the China-mainland endpoint."
+  },
   "qwen-plus": {
     "litellm_provider": "dashscope",
     "mode": "chat",

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -123,6 +123,18 @@
       "display": false,
       "notes": "Qwen account 60. Legacy stable alias mapped by tk_027. Flat-priced in overlay."
     },
+    "newapi/qwen-turbo": {
+      "platform": "newapi",
+      "model_id": "qwen-turbo",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen-turbo",
+      "display": false,
+      "notes": "Qwen account 60. Mapped by tk_042 (Goal 2 fleet servable-expansion). Flat non-thinking list price in overlay (commercial qwen, enable_thinking default false — thinking tier intentionally not modeled, see overlay source note)."
+    },
     "newapi/qwen-plus": {
       "platform": "newapi",
       "model_id": "qwen-plus",

--- a/backend/migrations/tk_042_qwen_turbo_model_mapping.sql
+++ b/backend/migrations/tk_042_qwen_turbo_model_mapping.sql
@@ -1,0 +1,46 @@
+-- Migration: tk_042_qwen_turbo_model_mapping
+--
+-- Advertise qwen-turbo on the Qwen account (id=60) so the Qwen group can access it.
+--
+-- Why (Goal 2 fleet servable-expansion, 2026-06-22): qwen-turbo is in the ct=17
+-- Ali/DashScope adaptor catalog and DashScope serves it with account 60's key, but
+-- TK returned 429 (empty pool / not_allowlisted) because account 60's
+-- credentials.model_mapping is an identity WHITELIST that did not list qwen-turbo.
+-- Merging it makes the newapi bridge advertise + route it. Reachability confirmed by
+-- post-apply livefire (the gateway empty-pool gate makes a pre-map probe impossible).
+--
+-- Pricing ships in the SAME release via backend/internal/service/tk_pricing_overlay.json
+-- (qwen-turbo, flat non-thinking China-mainland list; compile-embedded), so the
+-- whitelist add and the price go live together — no $0 billing window.
+--
+-- Merge (jsonb ||) preserves the existing qwen3.7-max/qwen-plus/etc. entries; only the
+-- qwen-turbo identity key is added. Raw-SQL account mutation bypasses the Ent
+-- snapshot-refresh hooks, so enqueue a scheduler_outbox account_changed event
+-- (pattern: tk_024/tk_022).
+--
+-- Idempotent + cross-deployment safe: guarded by (id, name, platform='newapi',
+-- channel_type=17) so re-running merges the same key (no-op) and a bare id colliding
+-- with an unrelated account in another DB cannot match.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH upd AS (
+    UPDATE accounts
+    SET credentials = jsonb_set(
+            credentials,
+            '{model_mapping}',
+            COALESCE(credentials -> 'model_mapping', '{}'::jsonb) || '{
+                "qwen-turbo": "qwen-turbo"
+            }'::jsonb
+        ),
+        updated_at = NOW()
+    WHERE id = 60
+      AND name = 'Qwen'
+      AND platform = 'newapi'
+      AND channel_type = 17
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;


### PR DESCRIPTION
## Goal 2 — 现有 fleet servable 扩展（第 1 个净增）

`qwen-turbo` 在 ct=17 Ali/DashScope 适配器目录内、DashScope 用账号 60 的 key 确定可服务，但 TK 之前返 **429 not_allowlisted**（空池）——因为账号 60 的 `credentials.model_mapping` identity 白名单没列它。onboard 它：**映射 + 定价同发**，让它成为可见+可达+可定价（#932 不变量）。

### 改动
- `backend/migrations/tk_042_qwen_turbo_model_mapping.sql` — `jsonb ||` 把 qwen-turbo identity-merge 进账号 60 model_mapping + `scheduler_outbox account_changed`（模板 tk_024；按 id/name/platform/channel_type 守卫；幂等）。
- `tk_pricing_overlay.json` — qwen-turbo 平价非思考价（中国内地 ¥0.3/¥0.6 每 M ÷6.7；`docs/accounts/aliyun_pricing_20260612.md` L394）。**商用 qwen → enable_thinking 默认 false → 按非思考价计**，思考档（¥3/M）刻意不建模（同 qwen-plus 处理；`pricing-overlay.py` THINKING_ANCHORS 不覆盖商用 qwen）。
- `tk_served_models.json` — `newapi/qwen-turbo` 清单条目（served_on 60, ct17, overlay, display=false）。

### 验证
- `catalog-serving-drift` 三方一致（manifest↔tk_042↔overlay）✓；`pricing-overlay` guard ✓（72 entries）；本地 + pre-commit 全量 preflight 全绿。
- **可达性**：网关空池闸使 pre-map 探测必返 429（这正是触发本 onboard 的信号），可达性由 **apply-live 后 livefire** 确认（迁移 + 编译内嵌 overlay 同发，无 $0 窗口）。

### 影响
纯后端（迁移 + overlay/manifest JSON），无 frontend：`no-web-impact`。apply-live（prod 路由热更 + overlay 价热推，零发版）+ livefire 为合并后的 gated 步骤。

合并方式按 §5.y：TK feat → **Squash and merge**。