### PR TITLE
fix(anthropic): Claude incident 只告警不豁免；OAuth 401 一律 SetError

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1585,6 +1585,12 @@ func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *se
 	if statusCode == http.StatusForbidden {
 		errMsg = service.TkEnrichForbiddenMessage(c, errMsg)
 	}
+	if platform == service.PlatformAnthropic {
+		if msg := service.ExtractUpstreamErrorMessage(responseBody); msg != "" {
+			errMsg = msg
+		}
+		errMsg = service.TkEnrichClaudeIncidentMessage(errMsg, statusCode)
+	}
 	h.handleStreamingAwareError(c, status, errType, errMsg, streamStarted)
 }
 

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -349,5 +349,6 @@ func (h *GatewayHandler) handleCCFailoverExhausted(c *gin.Context, lastErr *serv
 		h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "upstream_error", service.OpenAISilentRefusalClientMessage())
 		return
 	}
-	h.chatCompletionsErrorResponse(c, statusCode, "server_error", "All available accounts exhausted")
+	h.chatCompletionsErrorResponse(c, statusCode, "server_error",
+		service.TkEnrichClaudeIncidentMessage("All available accounts exhausted", statusCode))
 }

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -336,5 +336,6 @@ func (h *GatewayHandler) handleResponsesFailoverExhausted(c *gin.Context, lastEr
 		h.responsesErrorResponse(c, http.StatusBadGateway, "upstream_error", service.OpenAISilentRefusalClientMessage())
 		return
 	}
-	h.responsesErrorResponse(c, statusCode, "server_error", "All available accounts exhausted")
+	h.responsesErrorResponse(c, statusCode, "server_error",
+		service.TkEnrichClaudeIncidentMessage("All available accounts exhausted", statusCode))
 }

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1059,11 +1059,12 @@ func (h *OpenAIGatewayHandler) anthropicStreamingAwareError(c *gin.Context, stat
 // handleAnthropicFailoverExhausted maps upstream failover errors to Anthropic format.
 func (h *OpenAIGatewayHandler) handleAnthropicFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, streamStarted bool) {
 	status, errType, errMsg := h.mapUpstreamError(failoverErr.StatusCode)
+	if msg := service.ExtractUpstreamErrorMessage(failoverErr.ResponseBody); msg != "" {
+		errMsg = msg
+	}
 	if failoverErr.StatusCode == http.StatusForbidden {
 		errMsg = service.TkEnrichForbiddenMessage(c, errMsg)
 	}
-	// TK: during a Claude API incident, point the caller at the real upstream
-	// status page instead of letting the generic message implicate the pool.
 	errMsg = service.TkEnrichClaudeIncidentMessage(errMsg, failoverErr.StatusCode)
 	h.anthropicStreamingAwareError(c, status, errType, errMsg, streamStarted)
 }

--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -178,6 +178,7 @@ type TKAccountIncidentNotifier struct {
 	active            map[int64]map[string]*activeIncident   // accountID -> reasonClass -> 活跃事件(恢复台账)
 	recoverySentAt    map[int64]time.Time                    // 恢复绿卡去重: accountID -> 上次发送
 	poolExhaustSentAt map[string]time.Time                   // 平台池全不可调度 P0「待恢复」台账: platform -> 告警时刻(兼作 10min 去重)
+	claudeIncidentSentAt time.Time                           // Claude API 上游故障 P0 去重 + 恢复闭环台账
 
 	// poolSchedulableCounter 由 RateLimitService 注入(见 ProvideTKAccountIncidentNotifier),
 	// 返回某平台当前可调度账号数。池恢复轮询据此把空池火警闭环成「池已恢复」绿卡。

--- a/backend/internal/service/account_incident_notifier_tk_claude_status.go
+++ b/backend/internal/service/account_incident_notifier_tk_claude_status.go
@@ -1,0 +1,94 @@
+package service
+
+// TK: status.claude.com 上游 Claude API 故障 → 即时 P0 飞书卡片（及恢复绿卡）。
+//
+// 与 ratelimit 里「incident 期间不罚账号」的旧逻辑解耦：探测到 Anthropic 侧事件时只
+// 通知运营自行判断，账号级 401/429/403 等仍走常规 SetError / 冷却阶梯。
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+const claudeAPIIncidentAlertDedupeWindow = 10 * time.Minute
+
+// ClaudeAPIStatusNotifier 是 status.claude.com 轮询器的最小通知面。
+type ClaudeAPIStatusNotifier interface {
+	NotifyClaudeAPIIncidentStarted(status string)
+	NotifyClaudeAPIIncidentResolved(status string)
+}
+
+// NotifyClaudeAPIIncidentStarted 在 Claude API 从 operational 转为非 operational 时发 P0 红卡。
+func (n *TKAccountIncidentNotifier) NotifyClaudeAPIIncidentStarted(status string) {
+	if n == nil {
+		return
+	}
+	now := n.currentTime()
+	n.mu.Lock()
+	if !n.claudeIncidentSentAt.IsZero() && now.Sub(n.claudeIncidentSentAt) < claudeAPIIncidentAlertDedupeWindow {
+		n.mu.Unlock()
+		return
+	}
+	n.claudeIncidentSentAt = now
+	n.mu.Unlock()
+
+	title := fmt.Sprintf("TokenKey Claude API 上游故障 [%s]", n.siteID)
+	body := buildClaudeAPIIncidentStartedText(n.siteID, status, now)
+	n.send(title, "red", body, "claude_api_incident_started")
+}
+
+// NotifyClaudeAPIIncidentResolved 在 Claude API 恢复 operational 且此前发过故障卡时发绿卡闭环。
+func (n *TKAccountIncidentNotifier) NotifyClaudeAPIIncidentResolved(status string) {
+	if n == nil {
+		return
+	}
+	n.mu.Lock()
+	if n.claudeIncidentSentAt.IsZero() {
+		n.mu.Unlock()
+		return
+	}
+	n.claudeIncidentSentAt = time.Time{}
+	n.mu.Unlock()
+
+	title := fmt.Sprintf("TokenKey Claude API 上游已恢复 [%s]", n.siteID)
+	body := buildClaudeAPIIncidentResolvedText(n.siteID, status, n.currentTime())
+	n.send(title, "green", body, "claude_api_incident_resolved")
+}
+
+func buildClaudeAPIIncidentStartedText(site, status string, now time.Time) string {
+	return fmt.Sprintf("**节点**：%s\n**事件**：Anthropic Claude API 上游正在报告故障（status.claude.com: %s）\n**时间**：%s\n\n**建议**：这是 Anthropic 侧 provider 事件，不是 TokenKey 账号池问题。关注 %s 与 Anthropic 官方动态；若出现 anthropic 账号 401/403 等认证类错误，系统会照常 SetError 永久摘号——请运营判断是 refresh token、重新 OAuth 还是上游误报后再处置。",
+		escapeFeishuText(site),
+		escapeFeishuText(strings.TrimSpace(status)),
+		escapeFeishuText(formatAlertTime(now)),
+		escapeFeishuText(claudeStatusPageURL),
+	)
+}
+
+func buildClaudeAPIIncidentResolvedText(site, status string, now time.Time) string {
+	return fmt.Sprintf("**节点**：%s\n**事件**：Anthropic Claude API 已恢复 operational（当前状态: %s）\n**时间**：%s\n\n**说明**：此前 Claude API 上游故障 P0 已闭环；若仍有单账号 auth 错误，按账号永久失效卡片单独处理。",
+		escapeFeishuText(site),
+		escapeFeishuText(strings.TrimSpace(status)),
+		escapeFeishuText(formatAlertTime(now)),
+	)
+}
+
+var (
+	claudeAPIStatusNotifierMu sync.RWMutex
+	claudeAPIStatusNotifier   ClaudeAPIStatusNotifier
+)
+
+// SetClaudeAPIStatusNotifier registers the Feishu notifier for status.claude.com
+// transitions. Nil-safe; call before StartClaudeStatusPoller.
+func SetClaudeAPIStatusNotifier(n ClaudeAPIStatusNotifier) {
+	claudeAPIStatusNotifierMu.Lock()
+	claudeAPIStatusNotifier = n
+	claudeAPIStatusNotifierMu.Unlock()
+}
+
+func getClaudeAPIStatusNotifier() ClaudeAPIStatusNotifier {
+	claudeAPIStatusNotifierMu.RLock()
+	defer claudeAPIStatusNotifierMu.RUnlock()
+	return claudeAPIStatusNotifier
+}

--- a/backend/internal/service/account_incident_notifier_tk_claude_status_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_claude_status_test.go
@@ -1,0 +1,68 @@
+//go:build unit
+
+package service
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotifyClaudeAPIIncidentStarted_SendsP0Card(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 1)}
+	fixed := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, fixed)
+
+	n.NotifyClaudeAPIIncidentStarted("partial_outage")
+	<-doer.done
+
+	require.Equal(t, 1, doer.callCount())
+	body := doer.lastBody()
+	require.Contains(t, body, "partial_outage")
+	require.Contains(t, body, claudeStatusPageURL)
+	require.Contains(t, body, "SetError")
+}
+
+func TestNotifyClaudeAPIIncidentStarted_DedupesWithinWindow(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 2)}
+	fixed := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, fixed)
+
+	n.NotifyClaudeAPIIncidentStarted("partial_outage")
+	<-doer.done
+	n.NotifyClaudeAPIIncidentStarted("major_outage")
+
+	require.Equal(t, 1, doer.callCount())
+}
+
+func TestNotifyClaudeAPIIncidentResolved_OnlyAfterStarted(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 2)}
+	fixed := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, fixed)
+
+	n.NotifyClaudeAPIIncidentResolved("operational")
+	require.Equal(t, 0, doer.callCount())
+
+	n.NotifyClaudeAPIIncidentStarted("partial_outage")
+	<-doer.done
+	n.NotifyClaudeAPIIncidentResolved("operational")
+	<-doer.done
+
+	require.Equal(t, 2, doer.callCount())
+	require.True(t, strings.Contains(doer.lastBody(), "operational"))
+}
+
+func TestSetClaudeAPIStatusNotifier_WiresPollerTransition(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 1)}
+	fixed := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, fixed)
+	t.Cleanup(func() { SetClaudeAPIStatusNotifier(nil) })
+	SetClaudeAPIStatusNotifier(n)
+
+	claudeStatusAtom.Store(&ClaudeStatusSnapshot{IsIncident: false, Status: "operational", FetchedAt: fixed})
+	getClaudeAPIStatusNotifier().NotifyClaudeAPIIncidentStarted("major_outage")
+	<-doer.done
+	require.Equal(t, 1, doer.callCount())
+}

--- a/backend/internal/service/gateway_service_tk_upstream_error_msg.go
+++ b/backend/internal/service/gateway_service_tk_upstream_error_msg.go
@@ -80,26 +80,19 @@ func tkForbiddenAdvice(bodyLen int) string {
 	return "This is an upstream access/policy rejection unrelated to request size; retry the request, and contact administrator if it persists."
 }
 
-// TkEnrichClaudeIncidentMessage rewrites a failover-exhausted client message
-// into an incident-aware notice when status.claude.com reports a non-operational
-// Claude API. The goal is to redirect the caller's attention to the real
-// upstream (Anthropic) instead of the generic "all accounts exhausted" wording,
-// which wrongly implicates the TokenKey account pool or the user's own key.
-//
-// Returns defaultMsg verbatim when there is no active incident (including the
-// staleness fail-safe in IsClaudeAPIIncident), so non-incident behaviour is
-// unchanged. upstreamStatusCode carries the upstream HTTP status into the
-// message so the caller can see what Anthropic actually returned.
+// TkEnrichClaudeIncidentMessage rewrites a client-facing error during a Claude API
+// incident to include status.claude.com context and the upstream HTTP status.
+// Account-level penalties are NOT suppressed during incidents — this is UX only.
+// Returns defaultMsg verbatim when there is no active incident.
 func TkEnrichClaudeIncidentMessage(defaultMsg string, upstreamStatusCode int) string {
 	if !IsClaudeAPIIncident() {
 		return defaultMsg
 	}
 	snap := GetClaudeStatusSnapshot()
 	return fmt.Sprintf(
-		"Anthropic upstream is currently reporting an incident (Claude API status: %s, upstream returned %d). "+
-			"This is an Anthropic-side outage, not a problem with your account or API key. "+
-			"Check live status at %s — requests recover automatically once Anthropic returns to operational.",
-		snap.Status, upstreamStatusCode, claudeStatusPageURL,
+		"%s (Anthropic upstream incident: Claude API status %s, upstream HTTP %d). "+
+			"Check live status at %s — this is an Anthropic-side event; re-OAuth the account if auth errors persist.",
+		defaultMsg, snap.Status, upstreamStatusCode, claudeStatusPageURL,
 	)
 }
 

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -415,19 +415,21 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			shouldDisable = true
 			break
 		}
-		// TK: Claude API 故障期间，上游可能对全队仍有效的 token 误发 401。此窗口内任何
-		// anthropic 账号都不得被一次 401 永久禁用（first-strike 会把全池一起打死）——统一
-		// 回退 temp_unschedulable 冷却，覆盖下面所有子路径（OAuth 有效-token / 缺 refresh_token
-		// / setup-token / apikey）。与 403/429 路径同口径（IsClaudeAPIIncident）；非 anthropic
-		// 账号不受影响（该探测器只反映 Anthropic 状态）。故障结束后仍 401 才按各自路径处置。
-		if account.Platform == PlatformAnthropic && IsClaudeAPIIncident() {
-			msg := "OAuth 401 deferred during Claude API incident (not permanently disabled)"
-			if upstreamMsg != "" {
-				msg = "OAuth 401 (incident-deferred): " + upstreamMsg
+		// TK: Anthropic OAuth 任意 401 → 立即 SetError + P0 飞书（auth_error），不再区分
+		// token 是否过期、不再走 temp_unschedulable 冷却，由运营人工 re-OAuth。
+		if account.Platform == PlatformAnthropic && account.Type == AccountTypeOAuth {
+			if s.tokenCacheInvalidator != nil {
+				if err := s.tokenCacheInvalidator.InvalidateToken(ctx, account); err != nil {
+					slog.Warn("oauth_401_invalidate_cache_failed", "account_id", account.ID, "error", err)
+				}
 			}
-			slog.Warn("oauth_401_disable_deferred_during_incident",
+			msg := "OAuth 401 — manual re-authorization required (re-login via account management)"
+			if upstreamMsg != "" {
+				msg = "OAuth 401: " + upstreamMsg
+			}
+			slog.Warn("oauth_401_immediate_disable",
 				"account_id", account.ID, "platform", account.Platform)
-			s.tkApplyOAuth401Cooldown(ctx, account, msg)
+			s.handleAuthError(ctx, account, msg)
 			shouldDisable = true
 			break
 		}
@@ -1212,27 +1214,7 @@ func (s *RateLimitService) handleAnthropicUpstreamError(ctx context.Context, acc
 		return true
 	}
 
-	// TK: when status.claude.com reports a non-operational Claude API, the error is
-	// Anthropic's fault, not the account's. Skip writing temp_unschedulable_until so
-	// account health scores are not penalised during upstream incidents.
-	// Counters still advance for observability (handled inside WithOptions).
-	//
-	// Scope note: this only protects account *health* (the account stays in the
-	// pool and is immediately usable the moment Anthropic recovers — no cooldown
-	// tail). It does NOT rescue the in-flight request: shouldDisable=true still
-	// fails this request over, and once the failover loop exhausts the pool the
-	// caller receives Anthropic's real upstream error. handleAnthropicFailoverExhausted
-	// then enriches that client message via TkEnrichClaudeIncidentMessage so the
-	// user is pointed at status.claude.com instead of blaming the TokenKey pool.
-	skipCooldown := IsClaudeAPIIncident()
-	if skipCooldown {
-		snap := GetClaudeStatusSnapshot()
-		slog.Info("anthropic_upstream_error_incident_skip_cooldown",
-			"account_id", account.ID,
-			"status_code", statusCode,
-			"upstream_status", snap.Status)
-	}
-	return s.handleAnthropicUpstreamErrorWithOptions(ctx, account, statusCode, upstreamMsg, responseBody, skipCooldown)
+	return s.handleAnthropicUpstreamErrorWithOptions(ctx, account, statusCode, upstreamMsg, responseBody, false)
 }
 
 // handleAnthropicUpstreamErrorWithOptions is the implementation seam for

--- a/backend/internal/service/ratelimit_service_tk_anthropic_bodyless_403.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_bodyless_403.go
@@ -28,8 +28,6 @@ import (
 //     里警告的「一个坏 model 请求误禁健康账号」。
 //   - **独立计数器**（IncrementAnthropicBodyless403Count，独立 Redis key），不与 429/5xx
 //     混——避免误把限流/过载账号永久禁用。
-//   - **尊重 IsClaudeAPIIncident()**：provider 级事件期间不批量禁用全池（与
-//     handleAnthropicUpstreamError 的 skipCooldown 同款封套）。
 //   - **fail-open**：计数器未注入 / 出错 / 未达阈值 → 返回 false，落回既有阶梯，行为不变。
 
 const (
@@ -78,11 +76,6 @@ func (s *RateLimitService) tkTryEscalatePersistentBodyless403(ctx context.Contex
 	// 只处理空 body / 非结构化 403。结构化 body（含 model-level 拒绝、以及已被 #810 捕获的
 	// org-ban 短语）一律不计入、不升级。
 	if !tkIsUnstructuredAnthropicErrorBody(responseBody) {
-		return false
-	}
-	// Provider 级事件期间（status.claude.com 报 Claude API 非运营）不升级，避免把全池因
-	// 上游短时故障批量永久禁用——与 handleAnthropicUpstreamError 的 skipCooldown 同款。
-	if IsClaudeAPIIncident() {
 		return false
 	}
 

--- a/backend/internal/service/ratelimit_service_tk_anthropic_bodyless_403_test.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_bodyless_403_test.go
@@ -79,10 +79,8 @@ func TestRateLimitService_BodylessBan403_StructuredBodyNeverCounts(t *testing.T)
 	require.Empty(t, counter.bodyless403IncrementIDs, "structured body must not advance the bodyless counter")
 }
 
-// During a live Claude API incident, a bodyless 403 must NOT escalate to a
-// permanent disable — we must not mass-disable the pool for a provider-wide
-// outage. The counter is not even advanced (we return before incrementing).
-func TestRateLimitService_BodylessBan403_IncidentSkipsEscalation(t *testing.T) {
+// During a live Claude API incident, bodyless 403 at threshold still permanently disables.
+func TestRateLimitService_BodylessBan403_IncidentStillEscalates(t *testing.T) {
 	setClaudeStatusForTest(t, ClaudeStatusSnapshot{IsIncident: true, Status: "partial_outage", FetchedAt: time.Now()})
 
 	repo := &rateLimitAccountRepoStub{}
@@ -95,8 +93,8 @@ func TestRateLimitService_BodylessBan403_IncidentSkipsEscalation(t *testing.T) {
 
 	service.HandleUpstreamError(context.Background(), account, http.StatusForbidden, http.Header{}, []byte(""))
 
-	require.Equal(t, 0, repo.setErrorCalls, "incident must not permanently disable on a bodyless 403")
-	require.Empty(t, counter.bodyless403IncrementIDs, "incident path returns before advancing the counter")
+	require.Equal(t, 1, repo.setErrorCalls, "incident must not skip bodyless 403 permanent disable")
+	require.Equal(t, []int64{904}, counter.bodyless403IncrementIDs)
 }
 
 // A counter backend error must fail OPEN — never permanently disable on a

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
@@ -269,8 +269,9 @@ func TestG4_OAuth401_StaysAccountLevel(t *testing.T) {
 	)
 
 	require.Empty(t, repo.modelRateLimitCalls,
-		"401 auth failure is account-level (temp-unschedulable for token refresh), never model-scoped")
-	require.Greater(t, repo.tempCalls, 0, "OAuth 401 → SetTempUnschedulable (account-level)")
+		"401 auth failure is account-level, never model-scoped")
+	require.Equal(t, 1, repo.setErrorCalls, "Anthropic OAuth 401 → SetError (account-level)")
+	require.Equal(t, 0, repo.tempCalls, "must not temp_unschedulable hold")
 }
 
 func TestG4_529Overloaded_StaysAccountLevel(t *testing.T) {

--- a/backend/internal/service/ratelimit_service_tk_oauth401.go
+++ b/backend/internal/service/ratelimit_service_tk_oauth401.go
@@ -7,22 +7,10 @@ import (
 	"time"
 )
 
-// TK：OAuth 账号 401 的「grant 被上游吊销」判定——单一信号，第一次即禁。
+// TK：非 Anthropic OAuth 账号 401 的「grant 被上游吊销」判定。
 //
-// 判据只有一个布尔：401 发生时 access_token 是否仍然有效（离过期还有足够余量）。
-//   - 仍有效 → 一个没过期的 token 被上游 401，正常不该发生，除非 grant 已被吊销：
-//     第一次即 SetError 永久停调度 + 告警（提示人工重授权），不再走 temp_unschedulable 冷却。
-//   - 已过期 / 在刷新窗口内 → 过期抢跑（请求拿旧 token 抢在后台刷新前打上游）的良性 401：
-//     不禁用，回退调用方的 temp_unschedulable 冷却 + 后台刷新自愈。
-//
-// 取代旧的双触发计数器（version-bump + same-version + 窗口 + debounce）。依据 2026-06 prod
-// 7 天全队取证：真实吊销 401 的 access_token 全部仍有效（旧 same-version 特征），过期抢跑型
-// 良性 401 = 0。token 有效性这一个布尔同时覆盖两件事：① edge-uk1 2026-06-08 那类「有效但被
-// 吊销、版本冻结、永不刷新」的无限 flap（旧逻辑要跨冷却周期才升级，这里第一次即禁，更快）；
-// ② 不把过期抢跑 401 误判为永久吊销（旧『naive 401 计数器』的反面教材）。
-//
-// fail-safe：expires_at 缺失/不可解析（无法确认有效性）→ 返回 false 回退冷却，绝不在
-// 「不确定」时永久禁用账号。
+// Anthropic OAuth 已在 HandleUpstreamError case 401 顶层统一 SetError（不区分 token
+// 是否过期）。本文件仅服务 OpenAI / Gemini 等其它 OAuth 平台。
 
 // oauth401ValidTokenMarginFloor：判定 access_token「仍然有效」所需剩余有效期的下限兜底。
 // 实际余量 = max(本下限, 刷新窗口)；下限防 refresh_before_expiry_hours 误配成 0 时退化成
@@ -63,8 +51,6 @@ func (s *RateLimitService) tkDisableIfOAuth401OnValidToken(ctx context.Context, 
 		return false
 	}
 	// token 仍 solidly valid 却被上游 401 → grant 吊销 → 第一次即禁用，人工重授权。
-	// （Claude API 故障期间对全队的统一豁免在 HandleUpstreamError 的 case 401 顶部、
-	// 进入本函数之前就拦截了，见 ratelimit_service.go oauth_401_disable_deferred_during_incident。）
 	msg := "OAuth 401 on a still-valid access token — grant revoked upstream, manual re-authorization required (re-login via account management)"
 	if strings.TrimSpace(upstreamMsg) != "" {
 		msg = msg + ": " + upstreamMsg
@@ -79,12 +65,8 @@ func (s *RateLimitService) tkDisableIfOAuth401OnValidToken(ctx context.Context, 
 	return true
 }
 
-// tkApplyOAuth401Cooldown 把一次 OAuth 401 落成 temp_unschedulable 冷却（替代永久禁用）+
-// 发调度阻塞通知。供两处复用，确保冷却时长/通知口径一致：
-//   - HandleUpstreamError case 401 的「普通 401 回退」分支；
-//   - 同处「Claude API 故障期间统一豁免」的顶层 gate。
-//
-// reasonMsg 写入 temp_unschedulable_reason。
+// tkApplyOAuth401Cooldown 把一次非-Anthropic OAuth 401 落成 temp_unschedulable 冷却 +
+// 发调度阻塞通知。
 func (s *RateLimitService) tkApplyOAuth401Cooldown(ctx context.Context, account *Account, reasonMsg string) {
 	cooldownMinutes := s.cfg.RateLimit.OAuth401CooldownMinutes
 	if cooldownMinutes <= 0 {

--- a/backend/internal/service/ratelimit_service_tk_oauth401_test.go
+++ b/backend/internal/service/ratelimit_service_tk_oauth401_test.go
@@ -25,56 +25,31 @@ func newOAuth401AnthropicAccount(id int64, expiresAt time.Time) *Account {
 	}
 }
 
-// 仍然有效的 access_token 上吃 401 = grant 被吊销 → 第一次即 SetError 永久停调度 + 告警，
-// 不走 temp_unschedulable 冷却，错误信息提示需人工重授权。
-func TestRateLimitService_OAuth401_ValidTokenDisablesFirstStrike(t *testing.T) {
-	repo := &rateLimitAccountRepoStub{}
-	blocker := &runtimeBlockRecorder{}
-	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
-	service.SetAccountRuntimeBlocker(blocker)
-	account := newOAuth401AnthropicAccount(701, time.Now().Add(2*time.Hour))
+func TestRateLimitService_OAuth401_AnthropicAny401SetErrorsImmediately(t *testing.T) {
+	cases := []struct {
+		name      string
+		expiresAt time.Time
+	}{
+		{"valid_token", time.Now().Add(2 * time.Hour)},
+		{"expired_token", time.Now().Add(-1 * time.Hour)},
+		{"near_expiry", time.Now().Add(1 * time.Minute)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &rateLimitAccountRepoStub{}
+			service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+			account := newOAuth401AnthropicAccount(700, tc.expiresAt)
 
-	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
+			shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
 
-	require.True(t, shouldDisable)
-	require.Equal(t, 1, repo.setErrorCalls, "valid-token 401 must SetError on first strike")
-	require.Equal(t, 0, repo.tempCalls, "must NOT fall through to temp_unschedulable cooldown")
-	require.Contains(t, repo.lastErrorMsg, "still-valid access token")
-	require.Contains(t, repo.lastErrorMsg, "grant revoked upstream")
-	require.Contains(t, repo.lastErrorMsg, "manual re-authorization")
-	require.Len(t, blocker.accounts, 1, "disable must notify scheduling-blocked for alerting")
-	require.Equal(t, account.ID, blocker.accounts[0].ID)
-	require.Equal(t, "auth_error", blocker.reasons[0])
+			require.True(t, shouldDisable)
+			require.Equal(t, 1, repo.setErrorCalls, "anthropic OAuth 401 must SetError immediately")
+			require.Equal(t, 0, repo.tempCalls, "must not temp_unschedulable / hold")
+		})
+	}
 }
 
-// access_token 已过期 → 过期抢跑良性 401 → 回退冷却，不永久禁用。
-func TestRateLimitService_OAuth401_ExpiredTokenFallsThroughToCooldown(t *testing.T) {
-	repo := &rateLimitAccountRepoStub{}
-	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
-	account := newOAuth401AnthropicAccount(702, time.Now().Add(-1*time.Hour))
-
-	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
-
-	require.True(t, shouldDisable)
-	require.Equal(t, 0, repo.setErrorCalls, "expired-token 401 must not permanently disable")
-	require.Equal(t, 1, repo.tempCalls, "expired-token 401 falls through to temp_unschedulable cooldown")
-}
-
-// access_token 在刷新窗口内（近过期，剩余 < margin floor 5min）→ 视为良性抢跑 → 回退冷却。
-func TestRateLimitService_OAuth401_NearExpiryFallsThroughToCooldown(t *testing.T) {
-	repo := &rateLimitAccountRepoStub{}
-	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
-	account := newOAuth401AnthropicAccount(703, time.Now().Add(1*time.Minute))
-
-	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
-
-	require.True(t, shouldDisable)
-	require.Equal(t, 0, repo.setErrorCalls, "near-expiry 401 must fall through to cooldown")
-	require.Equal(t, 1, repo.tempCalls)
-}
-
-// expires_at 缺失（无法判断有效性）→ fail-safe 回退冷却，绝不永久禁用。
-func TestRateLimitService_OAuth401_MissingExpiryFallsThroughToCooldown(t *testing.T) {
+func TestRateLimitService_OAuth401_AnthropicMissingExpiryStillSetErrors(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
 	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
 	account := &Account{
@@ -82,50 +57,7 @@ func TestRateLimitService_OAuth401_MissingExpiryFallsThroughToCooldown(t *testin
 		Platform: PlatformAnthropic,
 		Type:     AccountTypeOAuth,
 		Credentials: map[string]any{
-			"refresh_token": "rt", // 无 expires_at
-		},
-	}
-
-	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
-
-	require.True(t, shouldDisable)
-	require.Equal(t, 0, repo.setErrorCalls, "unknown expiry must fail-safe to cooldown, not disable")
-	require.Equal(t, 1, repo.tempCalls)
-}
-
-// 余量取刷新窗口：RefreshBeforeExpiryHours=1 → 窗口 1h。45min 剩余 < 1h 视为近过期回退冷却；
-// 90min 剩余 ≥ 1h 视为 solidly valid → 第一次即禁。
-func TestRateLimitService_OAuth401_MarginUsesRefreshWindow(t *testing.T) {
-	cfg := &config.Config{}
-	cfg.TokenRefresh.RefreshBeforeExpiryHours = 1
-
-	repo1 := &rateLimitAccountRepoStub{}
-	svc1 := NewRateLimitService(repo1, nil, cfg, nil, nil)
-	within := newOAuth401AnthropicAccount(705, time.Now().Add(45*time.Minute))
-	require.True(t, svc1.HandleUpstreamError(context.Background(), within, 401, http.Header{}, []byte("unauthorized")))
-	require.Equal(t, 0, repo1.setErrorCalls, "45min < 1h refresh window → near-expiry → cooldown")
-	require.Equal(t, 1, repo1.tempCalls)
-
-	repo2 := &rateLimitAccountRepoStub{}
-	svc2 := NewRateLimitService(repo2, nil, cfg, nil, nil)
-	beyond := newOAuth401AnthropicAccount(706, time.Now().Add(90*time.Minute))
-	require.True(t, svc2.HandleUpstreamError(context.Background(), beyond, 401, http.Header{}, []byte("unauthorized")))
-	require.Equal(t, 1, repo2.setErrorCalls, "90min ≥ 1h refresh window → solidly valid → disable")
-	require.Equal(t, 0, repo2.tempCalls)
-}
-
-// 缺 refresh_token 的 OAuth 账号：任意 401 立即 SetError（结构性不可自愈，既有行为，
-// 在 valid-token 判定之前短路）。
-func TestRateLimitService_OAuth401_MissingRefreshTokenImmediateDisable(t *testing.T) {
-	repo := &rateLimitAccountRepoStub{}
-	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
-	account := &Account{
-		ID:       707,
-		Platform: PlatformAnthropic,
-		Type:     AccountTypeOAuth,
-		Credentials: map[string]any{
-			// 有效但无 refresh_token：缺 refresh_token 分支先于 valid-token 判定。
-			"expires_at": time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339),
+			"refresh_token": "rt",
 		},
 	}
 
@@ -134,27 +66,41 @@ func TestRateLimitService_OAuth401_MissingRefreshTokenImmediateDisable(t *testin
 	require.True(t, shouldDisable)
 	require.Equal(t, 1, repo.setErrorCalls)
 	require.Equal(t, 0, repo.tempCalls)
-	require.Contains(t, repo.lastErrorMsg, "refresh_token missing")
 }
 
-// Claude API 故障期间：有效-token 401 不永久禁用（防上游对全队有效 token 误发 401 时批量
-// 禁全池），改回退 temp_unschedulable 冷却；故障结束后仍 401 才禁。与 403/429 路径同口径。
-func TestRateLimitService_OAuth401_ValidTokenDeferredDuringClaudeIncident(t *testing.T) {
-	setClaudeStatusForTest(t, ClaudeStatusSnapshot{IsIncident: true, Status: "major_outage", FetchedAt: time.Now()})
+func TestRateLimitService_OAuth401_AnthropicMissingRefreshTokenSetErrors(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
 	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
-	account := newOAuth401AnthropicAccount(708, time.Now().Add(2*time.Hour)) // solidly valid
+	account := &Account{
+		ID:       707,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"expires_at": time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
 
 	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
 
 	require.True(t, shouldDisable)
-	require.Equal(t, 0, repo.setErrorCalls, "incident 期间 valid-token 401 不得永久禁用")
-	require.Equal(t, 1, repo.tempCalls, "incident 期间回退 temp_unschedulable 冷却")
+	require.Equal(t, 1, repo.setErrorCalls)
+	require.Contains(t, repo.lastErrorMsg, "OAuth 401")
 }
 
-// Claude API 故障期间：setup-token 账号的 401 也走统一豁免（顶层 anthropic gate 覆盖
-// 非-OAuth/缺-refresh 等所有子路径），不永久禁用、改回退冷却。
-func TestRateLimitService_OAuth401_SetupTokenDeferredDuringClaudeIncident(t *testing.T) {
+func TestRateLimitService_OAuth401_AnthropicStillSetErrorsDuringClaudeIncident(t *testing.T) {
+	setClaudeStatusForTest(t, ClaudeStatusSnapshot{IsIncident: true, Status: "major_outage", FetchedAt: time.Now()})
+	repo := &rateLimitAccountRepoStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := newOAuth401AnthropicAccount(708, time.Now().Add(-1*time.Hour))
+
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.setErrorCalls)
+	require.Equal(t, 0, repo.tempCalls)
+}
+
+func TestRateLimitService_OAuth401_SetupTokenStillSetErrorsDuringClaudeIncident(t *testing.T) {
 	setClaudeStatusForTest(t, ClaudeStatusSnapshot{IsIncident: true, Status: "partial_outage", FetchedAt: time.Now()})
 	repo := &rateLimitAccountRepoStub{}
 	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
@@ -170,14 +116,12 @@ func TestRateLimitService_OAuth401_SetupTokenDeferredDuringClaudeIncident(t *tes
 	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
 
 	require.True(t, shouldDisable)
-	require.Equal(t, 0, repo.setErrorCalls, "incident 期间 setup-token 401 不得永久禁用")
-	require.Equal(t, 1, repo.tempCalls, "incident 期间回退 temp_unschedulable 冷却")
+	require.Equal(t, 1, repo.setErrorCalls)
+	require.Equal(t, 0, repo.tempCalls)
 }
 
-// 反向校准：incident gate 只对 anthropic 生效。Claude API 故障期间，一个 OpenAI OAuth
-// 账号的有效-token 401 仍照常永久禁用（Anthropic 状态与它无关，不得被误延后）。
-func TestRateLimitService_OAuth401_NonAnthropicNotDeferredDuringClaudeIncident(t *testing.T) {
-	setClaudeStatusForTest(t, ClaudeStatusSnapshot{IsIncident: true, Status: "major_outage", FetchedAt: time.Now()})
+// OpenAI OAuth 仍保留「有效 token 永久禁用 / 过期 token 冷却」分支（非 Anthropic）。
+func TestRateLimitService_OAuth401_OpenAIValidTokenDisablesFirstStrike(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
 	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
 	account := &Account{
@@ -186,13 +130,33 @@ func TestRateLimitService_OAuth401_NonAnthropicNotDeferredDuringClaudeIncident(t
 		Type:     AccountTypeOAuth,
 		Credentials: map[string]any{
 			"refresh_token": "rt",
-			"expires_at":    time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339), // solidly valid
+			"expires_at":    time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339),
 		},
 	}
 
 	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
 
 	require.True(t, shouldDisable)
-	require.Equal(t, 1, repo.setErrorCalls, "non-anthropic valid-token 401 不受 Claude incident gate 影响，照常永久禁用")
+	require.Equal(t, 1, repo.setErrorCalls)
 	require.Equal(t, 0, repo.tempCalls)
+}
+
+func TestRateLimitService_OAuth401_OpenAIExpiredTokenStillCools(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{
+		ID:       711,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"refresh_token": "rt",
+			"expires_at":    time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Equal(t, 1, repo.tempCalls)
 }

--- a/backend/internal/service/upstream_status_tk.go
+++ b/backend/internal/service/upstream_status_tk.go
@@ -67,6 +67,11 @@ func StartClaudeStatusPoller(ctx context.Context) {
 	// Prime the snapshot synchronously so the very first requests benefit too.
 	if snap, err := fetchClaudeAPIStatus(ctx, client, claudeStatusAPIURL); err == nil {
 		claudeStatusAtom.Store(snap)
+		if snap.IsIncident {
+			if n := getClaudeAPIStatusNotifier(); n != nil {
+				n.NotifyClaudeAPIIncidentStarted(snap.Status)
+			}
+		}
 	}
 
 	go func() {
@@ -85,11 +90,15 @@ func StartClaudeStatusPoller(ctx context.Context) {
 				prev := GetClaudeStatusSnapshot()
 				claudeStatusAtom.Store(snap)
 				if snap.IsIncident && !prev.IsIncident {
-					slog.Warn("claude_api_incident_detected",
-						"status", snap.Status,
-						"effect", "anthropic_account_cooldown_writes_suppressed")
+					slog.Warn("claude_api_incident_detected", "status", snap.Status)
+					if n := getClaudeAPIStatusNotifier(); n != nil {
+						n.NotifyClaudeAPIIncidentStarted(snap.Status)
+					}
 				} else if !snap.IsIncident && prev.IsIncident {
 					slog.Info("claude_api_incident_resolved", "status", snap.Status)
+					if n := getClaudeAPIStatusNotifier(); n != nil {
+						n.NotifyClaudeAPIIncidentResolved(snap.Status)
+					}
 				}
 			}
 		}
@@ -130,9 +139,8 @@ func fetchClaudeAPIStatus(ctx context.Context, client *http.Client, url string) 
 			snap.Status = c.Status
 			// Anything other than "operational" (degraded_performance /
 			// partial_outage / major_outage / under_maintenance) counts as an
-			// incident. This is intentionally conservative: a false positive
-			// only ever *avoids* penalising an account's health, never the
-			// reverse.
+			// incident. Ops are notified via Feishu P0; account-level penalties
+			// are NOT suppressed during incidents.
 			snap.IsIncident = c.Status != "operational"
 			break
 		}

--- a/backend/internal/service/upstream_status_tk_test.go
+++ b/backend/internal/service/upstream_status_tk_test.go
@@ -24,10 +24,9 @@ func setClaudeStatusForTest(t *testing.T, snap ClaudeStatusSnapshot) {
 	})
 }
 
-// During a live Claude API incident the 3/3 counter still advances (so ops
-// retains the failure signal) but the ladder MUST NOT write
-// SetTempUnschedulable — the error is Anthropic's fault, not the account's.
-func TestRateLimitService_AnthropicUpstreamError_IncidentSkipsCooldownWrite(t *testing.T) {
+// During a live Claude API incident the 3/3 ladder still writes cooldown — incident
+// no longer suppresses account penalties (ops get a Feishu P0 instead).
+func TestRateLimitService_AnthropicUpstreamError_IncidentStillLadders(t *testing.T) {
 	setClaudeStatusForTest(t, ClaudeStatusSnapshot{
 		IsIncident: true,
 		Status:     "partial_outage",
@@ -59,8 +58,8 @@ func TestRateLimitService_AnthropicUpstreamError_IncidentSkipsCooldownWrite(t *t
 		}
 	}
 
-	require.Equal(t, 0, repo.tempCalls,
-		"incident in progress: ladder MUST suppress SetTempUnschedulable so account health is not penalised")
+	require.Equal(t, 1, repo.tempCalls,
+		"incident in progress: ladder still writes SetTempUnschedulable")
 	require.Equal(t, []int64{801, 801, 801}, counter.incrementIDs,
 		"3/3 counter advances on every hit even during an incident (ops signal preserved)")
 }
@@ -183,40 +182,22 @@ func TestFetchClaudeAPIStatus(t *testing.T) {
 	}
 }
 
-// The client-facing failover-exhausted message must be rewritten to point at
-// the upstream status page during an incident, and left untouched otherwise.
 func TestTkEnrichClaudeIncidentMessage(t *testing.T) {
-	const def = "All available accounts exhausted"
-
-	t.Run("incident rewrites message with status + link", func(t *testing.T) {
+	const def = "upstream overloaded"
+	t.Run("incident appends status and link", func(t *testing.T) {
 		setClaudeStatusForTest(t, ClaudeStatusSnapshot{
 			IsIncident: true,
 			Status:     "partial_outage",
 			FetchedAt:  time.Now(),
 		})
 		got := TkEnrichClaudeIncidentMessage(def, http.StatusInternalServerError)
-		require.NotEqual(t, def, got)
+		require.Contains(t, got, def)
 		require.Contains(t, got, "partial_outage")
-		require.Contains(t, got, "500")
 		require.Contains(t, got, claudeStatusPageURL)
 	})
-
-	t.Run("operational leaves message unchanged", func(t *testing.T) {
-		setClaudeStatusForTest(t, ClaudeStatusSnapshot{
-			IsIncident: false,
-			Status:     "operational",
-			FetchedAt:  time.Now(),
-		})
-		require.Equal(t, def, TkEnrichClaudeIncidentMessage(def, http.StatusInternalServerError))
-	})
-
-	t.Run("stale incident is treated as resolved (unchanged)", func(t *testing.T) {
-		setClaudeStatusForTest(t, ClaudeStatusSnapshot{
-			IsIncident: true,
-			Status:     "partial_outage",
-			FetchedAt:  time.Now().Add(-claudeStatusMaxStaleness - time.Minute),
-		})
-		require.Equal(t, def, TkEnrichClaudeIncidentMessage(def, http.StatusInternalServerError))
+	t.Run("operational unchanged", func(t *testing.T) {
+		setClaudeStatusForTest(t, ClaudeStatusSnapshot{IsIncident: false, Status: "operational", FetchedAt: time.Now()})
+		require.Equal(t, def, TkEnrichClaudeIncidentMessage(def, 500))
 	})
 }
 

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -998,6 +998,7 @@ func ProvideTKAccountIncidentNotifier(
 	if rl != nil {
 		rl.SetAccountIncidentNotifier(n)
 	}
+	SetClaudeAPIStatusNotifier(n)
 	return n
 }
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -196,10 +196,8 @@
         "if account.IsPoolMode() && !customErrorCodesEnabled && account.Platform != PlatformAnthropic {",
         "if !account.ShouldHandleErrorCode(statusCode) && account.Platform != PlatformAnthropic {",
         "s.ResetAnthropicUpstreamErrorCounter(ctx, accountID)",
-        "IsClaudeAPIIncident()",
-        "anthropic_upstream_error_incident_skip_cooldown",
         "s.tkDisableIfOAuth401OnValidToken(ctx, account, upstreamMsg)",
-        "oauth_401_disable_deferred_during_incident",
+        "oauth_401_immediate_disable",
         "case 413:",
         "anthropic_request_too_large_skip_penalty",
         "tkSkipDownstreamFailoverExhaustedPenalty",
@@ -208,7 +206,7 @@
         "tkLogAnthropicNonAuthoritative429Skip(account, statusCode)",
         "s.notifyAccountRecovered(accountID)"
       ],
-      "rationale": "Anthropic model-not-found 404s are CLIENT errors (a model name no account serves — Anthropic's catalog is global, not per-account) and must SKIP the account penalty (slog `anthropic_model_not_found_skip_penalty`, return false → shouldDisable=false, no UpstreamFailoverError wrap) so one bad-model client cannot cool accounts and drain a thin edge pool into 'No available accounts' 429s; the gateway then surfaces a 400 'Unsupported model' to the client (path B, prod P0 2026-06-06 edge us5). An upstream merge that re-adds SetModelRateLimit on this 404 path reintroduces the amplifier. Anthropic 429s without reset metadata must use the configurable short cooldown unless the body is the known third-party/extra-usage rejection, otherwise production can repeatedly hit the same account with no local backoff. Anthropic upstream errors must feed the TK short-window counter (anchored by `anthropicUpstreamErrorWindowMinutes` — intentionally short at 1 minute so transient bursts clear quickly) and mark the account temporarily unschedulable after three hits so a single bad Edge/OAuth account cannot produce repeated upstream 400/403/5xx responses before the scheduler removes it. **Pool-mode policy (2026-05-21 revision of PR #333, anchored by `anthropicCooldownTierLadder`)**: the prior PR #333 carve-out (which let pool_mode accounts early-return before the counter via `anthropic_upstream_error_pool_mode_skipped`) is removed. PR #333's blanket immunity left ops with no mechanical signal that a stub was failing, leaving cc-edges (single-member exclusive group) vulnerable to silently routing all traffic to a dead upstream pool. The replacement is **tiered exponential cooldown**: first cooldown in a 30-min window is 30s (transient jitter shrugged off without the 10-min outage that motivated PR #248's reversal), second is 2 min, third+ is 10 min. The two carve-outs on `HandleUpstreamError` entry (`account.Platform != PlatformAnthropic` on both the pool-mode early-return AND the custom-error-codes allowlist guard) MUST stay so Anthropic 4xx/5xx still enter the dispatch — without them an upstream merge that 'simplifies' the early-returns would silently restore PR #333's broken immunity. `IncrementAnthropicCooldownTier` and `ResetAnthropicCooldownTier` are anchored separately because they are the load-bearing seams for tier escalation; a Redis client refactor that drops them would silently collapse the ladder back to a fixed 30s cooldown. The `ResetAnthropicUpstreamErrorCounter` call MUST be invoked from recovery hotpaths (ClearRateLimit, RecoverAccountState, ClearTempUnschedulable, UpdateSessionWindow allowed status) so a healed account does not carry stale strikes OR stale tier escalation. OpenAI burst 429s (Codex headers present but neither 5h nor 7d window at 100% used+with-reset) must call the TK companion TkRecordOpenAI429BurstFallthrough and return nil so handle429 falls back to the short cooldown, otherwise transient throttle surges turn into multi-day 503 windows (upstream #2258). Upstream merges in this large service file can compile cleanly while dropping any of these protections, so the sentinel anchors all policies in the hotspot file. Upstream-incident guard: when status.claude.com reports Claude API non-operational, `handleAnthropicUpstreamError` calls `IsClaudeAPIIncident()` and delegates to the existing `skipCooldownWrite=true` seam — account health scores are not penalised during Anthropic-caused incidents. The slog key `anthropic_upstream_error_incident_skip_cooldown` is the observability anchor. **G1 (413 / request_too_large)**: `case 413:` short-circuits an upstream request_too_large for Anthropic (slog `anthropic_request_too_large_skip_penalty`) so an oversized request that cleared TokenKey's local body-limit but exceeded Anthropic's own cap fails back to the client without advancing the 3/3 ladder — a client looping 300KB+ sessions must not be able to cool a shared OAuth account. Dropping the case lets request_too_large fall into the default 4xx-5xx branch and silently re-arm the amplifier. **G2 (narrow — downstream failover-exhausted)**: `tkSkipDownstreamFailoverExhaustedPenalty` (slog `anthropic_downstream_failover_exhausted_skip_penalty`) extends the no-available skip to TokenKey's own 'all available accounts exhausted' downstream capacity envelope; it matches ONLY that TokenKey-generated phrase, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. Removing either hook silently regresses the corresponding non-account amplification exemption. **Recovery notify**: `notifyAccountSchedulingBlockCleared`(ClearRateLimit/RecoverAccountState 的账号真实清除汇聚点)末尾调 `s.notifyAccountRecovered(accountID)` 发飞书恢复绿卡(事件驱动)。删掉该行 → 账号恢复无任何飞书通知,恢复链路断裂。 **G3 (non-authoritative 429)**: 无 anthropic-ratelimit-* 头的 429 是 edge 的 header-less capacity/failover 信封('Upstream rate limit exceeded, please retry later' 等),不是真窗口限流(真窗口限流一定带头);case-429 调 `tkIsAnthropicNonAuthoritative429`(无条件,无开关)不冷却不喂阶梯(slog `anthropic_non_authoritative_429_skip_penalty`),泛化 no-available / failover-exhausted 两个 needle 跳过 —— 删掉它会重新点燃把健康镜像(cc-us7,2026-06-13 23:11 tier-0 30s)冷却的放大器。详见 ratelimit_service_tk_nonauthoritative_429.go。"
+      "rationale": "Anthropic model-not-found 404s are CLIENT errors (a model name no account serves — Anthropic's catalog is global, not per-account) and must SKIP the account penalty (slog `anthropic_model_not_found_skip_penalty`, return false → shouldDisable=false, no UpstreamFailoverError wrap) so one bad-model client cannot cool accounts and drain a thin edge pool into 'No available accounts' 429s; the gateway then surfaces a 400 'Unsupported model' to the client (path B, prod P0 2026-06-06 edge us5). An upstream merge that re-adds SetModelRateLimit on this 404 path reintroduces the amplifier. Anthropic 429s without reset metadata must use the configurable short cooldown unless the body is the known third-party/extra-usage rejection, otherwise production can repeatedly hit the same account with no local backoff. Anthropic upstream errors must feed the TK short-window counter (anchored by `anthropicUpstreamErrorWindowMinutes` — intentionally short at 1 minute so transient bursts clear quickly) and mark the account temporarily unschedulable after three hits so a single bad Edge/OAuth account cannot produce repeated upstream 400/403/5xx responses before the scheduler removes it. **Pool-mode policy (2026-05-21 revision of PR #333, anchored by `anthropicCooldownTierLadder`)**: the prior PR #333 carve-out (which let pool_mode accounts early-return before the counter via `anthropic_upstream_error_pool_mode_skipped`) is removed. PR #333's blanket immunity left ops with no mechanical signal that a stub was failing, leaving cc-edges (single-member exclusive group) vulnerable to silently routing all traffic to a dead upstream pool. The replacement is **tiered exponential cooldown**: first cooldown in a 30-min window is 30s (transient jitter shrugged off without the 10-min outage that motivated PR #248's reversal), second is 2 min, third+ is 10 min. The two carve-outs on `HandleUpstreamError` entry (`account.Platform != PlatformAnthropic` on both the pool-mode early-return AND the custom-error-codes allowlist guard) MUST stay so Anthropic 4xx/5xx still enter the dispatch — without them an upstream merge that 'simplifies' the early-returns would silently restore PR #333's broken immunity. `IncrementAnthropicCooldownTier` and `ResetAnthropicCooldownTier` are anchored separately because they are the load-bearing seams for tier escalation; a Redis client refactor that drops them would silently collapse the ladder back to a fixed 30s cooldown. The `ResetAnthropicUpstreamErrorCounter` call MUST be invoked from recovery hotpaths (ClearRateLimit, RecoverAccountState, ClearTempUnschedulable, UpdateSessionWindow allowed status) so a healed account does not carry stale strikes OR stale tier escalation. OpenAI burst 429s (Codex headers present but neither 5h nor 7d window at 100% used+with-reset) must call the TK companion TkRecordOpenAI429BurstFallthrough and return nil so handle429 falls back to the short cooldown, otherwise transient throttle surges turn into multi-day 503 windows (upstream #2258). Upstream merges in this large service file can compile cleanly while dropping any of these protections, so the sentinel anchors all policies in the hotspot file. **G1 (413 / request_too_large)**: `case 413:` short-circuits an upstream request_too_large for Anthropic (slog `anthropic_request_too_large_skip_penalty`) so an oversized request that cleared TokenKey's local body-limit but exceeded Anthropic's own cap fails back to the client without advancing the 3/3 ladder — a client looping 300KB+ sessions must not be able to cool a shared OAuth account. Dropping the case lets request_too_large fall into the default 4xx-5xx branch and silently re-arm the amplifier. **G2 (narrow — downstream failover-exhausted)**: `tkSkipDownstreamFailoverExhaustedPenalty` (slog `anthropic_downstream_failover_exhausted_skip_penalty`) extends the no-available skip to TokenKey's own 'all available accounts exhausted' downstream capacity envelope; it matches ONLY that TokenKey-generated phrase, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. Removing either hook silently regresses the corresponding non-account amplification exemption. **Recovery notify**: `notifyAccountSchedulingBlockCleared`(ClearRateLimit/RecoverAccountState 的账号真实清除汇聚点)末尾调 `s.notifyAccountRecovered(accountID)` 发飞书恢复绿卡(事件驱动)。删掉该行 → 账号恢复无任何飞书通知,恢复链路断裂。 **G3 (non-authoritative 429)**: 无 anthropic-ratelimit-* 头的 429 是 edge 的 header-less capacity/failover 信封('Upstream rate limit exceeded, please retry later' 等),不是真窗口限流(真窗口限流一定带头);case-429 调 `tkIsAnthropicNonAuthoritative429`(无条件,无开关)不冷却不喂阶梯(slog `anthropic_non_authoritative_429_skip_penalty`),泛化 no-available / failover-exhausted 两个 needle 跳过 —— 删掉它会重新点燃把健康镜像(cc-us7,2026-06-13 23:11 tier-0 30s)冷却的放大器。详见 ratelimit_service_tk_nonauthoritative_429.go。"
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_nonauthoritative_429.go",
@@ -378,17 +376,12 @@
     {
       "path": "backend/internal/service/ratelimit_service_tk_oauth401_test.go",
       "must_contain": [
-        "TestRateLimitService_OAuth401_ValidTokenDisablesFirstStrike",
-        "TestRateLimitService_OAuth401_ExpiredTokenFallsThroughToCooldown",
-        "TestRateLimitService_OAuth401_NearExpiryFallsThroughToCooldown",
-        "TestRateLimitService_OAuth401_MissingExpiryFallsThroughToCooldown",
-        "TestRateLimitService_OAuth401_MarginUsesRefreshWindow",
-        "TestRateLimitService_OAuth401_MissingRefreshTokenImmediateDisable",
-        "TestRateLimitService_OAuth401_ValidTokenDeferredDuringClaudeIncident",
-        "TestRateLimitService_OAuth401_SetupTokenDeferredDuringClaudeIncident",
-        "TestRateLimitService_OAuth401_NonAnthropicNotDeferredDuringClaudeIncident"
+        "TestRateLimitService_OAuth401_AnthropicAny401SetErrorsImmediately",
+        "TestRateLimitService_OAuth401_AnthropicStillSetErrorsDuringClaudeIncident",
+        "TestRateLimitService_OAuth401_OpenAIValidTokenDisablesFirstStrike",
+        "TestRateLimitService_OAuth401_OpenAIExpiredTokenStillCools"
       ],
-      "rationale": "Focused regressions proving the token-validity disable: a 401 on a still-valid access token SetErrors on the FIRST strike with a manual-re-authorization message + scheduling-blocked alert; an expired token, a near-expiry token (inside the refresh-window margin), and a missing/unparseable expires_at all fall through to the existing temp_unschedulable cooldown (no false permanent disable); the margin tracks token_refresh.refresh_before_expiry_hours; and a refresh_token-less OAuth account still disables immediately via the pre-existing branch. Dropping these lets an upstream merge silently revert the disable to the infinite flap, or — worse — regress into permanently disabling healthy accounts on transient/expiry 401s, without any unit signal."
+      "rationale": "Anthropic OAuth 401 → immediate SetError + P0 (no token-expiry branch, no temp cooldown). Other OAuth platforms keep valid-token first-strike disable + expired-token cooldown via tkDisableIfOAuth401OnValidToken."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_openai_burst.go",
@@ -1134,9 +1127,11 @@
         "claudeStatusAPIURL",
         "claudeStatusPageURL",
         "claudeStatusMaxStaleness",
-        "claude_api_incident_detected"
+        "claude_api_incident_detected",
+        "NotifyClaudeAPIIncidentStarted",
+        "getClaudeAPIStatusNotifier"
       ],
-      "rationale": "TK companion that polls status.claude.com/api/v2/components.json every 30s and exposes IsClaudeAPIIncident() for the incident-aware cooldown guard in ratelimit_service.go. If this file is silently dropped by an upstream merge (unlikely since it is a *_tk_*.go companion, but the hotspot-pattern gate covers it), account cooldown writes resume during upstream incidents and health scores are incorrectly penalised. claudeAPIComponentID must remain 'k8w3r06qmzrp' (the Claude API component ID on status.claude.com); if Anthropic changes their status-page IDs, this sentinel will fail and force a deliberate update. claudeStatusMaxStaleness anchors the fail-safe that treats a too-old incident reading as resolved (so a status-page outage cannot suppress cooldowns forever). claudeStatusPageURL is the human-facing link surfaced to clients by TkEnrichClaudeIncidentMessage."
+      "rationale": "TK companion that polls status.claude.com/api/v2/components.json every 30s. On transition to non-operational it fires a P0 Feishu card via SetClaudeAPIStatusNotifier (account_incident_notifier_tk_claude_status.go); account-level penalties are NOT suppressed during incidents. claudeAPIComponentID must remain 'k8w3r06qmzrp'. claudeStatusMaxStaleness is the fail-safe that treats a too-old incident reading as resolved."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_upstream_error_msg.go",
@@ -1144,7 +1139,7 @@
         "func TkEnrichForbiddenMessage(",
         "func TkEnrichClaudeIncidentMessage("
       ],
-      "rationale": "Service-layer client-message enrichers. TkEnrichForbiddenMessage keeps body-size context on upstream 403s. TkEnrichClaudeIncidentMessage rewrites the failover-exhausted client message during a Claude API incident so the caller is pointed at status.claude.com (the real upstream) instead of the generic 'all accounts exhausted' wording that wrongly implicates the TokenKey pool / the user's key. Dropping the incident enricher silently regresses the incident UX back to a misleading message."
+      "rationale": "Service-layer client-message enrichers. TkEnrichForbiddenMessage for upstream 403s. TkEnrichClaudeIncidentMessage adds status.claude.com context during upstream incidents (UX only; account penalties not suppressed)."
     },
     {
       "path": "backend/internal/handler/openai_gateway_handler.go",
@@ -1152,7 +1147,7 @@
         "service.TkEnrichClaudeIncidentMessage(",
         "service.TkStripEncryptedReasoningForFailover("
       ],
-      "rationale": "Locks two TK hooks in the OpenAI gateway handler. (1) TkEnrichClaudeIncidentMessage in handleAnthropicFailoverExhausted — the native /v1/messages (Claude Code / claude-cli) exhausted path; without it a Claude API incident surfaces to the caller as a generic upstream error with no pointer to status.claude.com. (2) TkStripEncryptedReasoningForFailover at the Responses failover boundary — strips a previous account's reasoning encrypted_content before re-dispatching to a freshly-selected account, so the new account's first hop does not draw a 400 invalid_encrypted_content. An upstream merge that rewrites the failover loop would silently drop either hook."
+      "rationale": "TkEnrichClaudeIncidentMessage in handleAnthropicFailoverExhausted surfaces upstream incident context to clients. TkStripEncryptedReasoningForFailover strips encrypted reasoning at Responses failover boundary."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_canonical_http.go",
@@ -2458,6 +2453,16 @@
       "rationale": "Platform-pool-exhausted P0 Feishu card (closes the #516 blind spot where 7 simultaneous per-account cooldowns produced no pool-level signal and the 06:49-06:58 outage went unalerted). Dedupe-per-platform is required: every subsequent account block during a cooldown storm re-triggers the pool check."
     },
     {
+      "path": "backend/internal/service/account_incident_notifier_tk_claude_status.go",
+      "must_contain": [
+        "NotifyClaudeAPIIncidentStarted",
+        "NotifyClaudeAPIIncidentResolved",
+        "SetClaudeAPIStatusNotifier",
+        "claudeAPIIncidentAlertDedupeWindow"
+      ],
+      "rationale": "P0 Feishu card when status.claude.com reports Claude API non-operational (replaces the old incident-aware account-penalty suppression). Wired from upstream_status_tk.go via SetClaudeAPIStatusNotifier in ProvideTKAccountIncidentNotifier."
+    },
+    {
       "path": "backend/internal/handler/gateway_handler_tk_cc_only_fallback.go",
       "must_contain": [
         "func tkCCOnlyFallbackGroupValid(fallback *service.Group) bool",
@@ -2793,12 +2798,11 @@
       "must_contain": [
         "func (s *RateLimitService) tkTryEscalatePersistentBodyless403(",
         "func tkIsUnstructuredAnthropicErrorBody(",
-        "IsClaudeAPIIncident()",
         "IncrementAnthropicBodyless403Count(",
         "anthropic_persistent_bodyless_403_disable",
         "s.handleAuthError(ctx, account, msg)"
       ],
-      "rationale": "Persistent bodyless/unstructured Anthropic 403 terminal disable (handle403 gap after #810, 2026-06-16 edge us6). #810 only catches a STRUCTURED-body org-ban phrase; the same org ban also arrives with an EMPTY body (id=1 historically emitted bodyless 403s — see failover_loop.go), which cannot match the phrase and falls into the auto-recovering 3/3 ladder, flapping forever. This file accumulates ONLY empty/unstructured 403s on a SEPARATE counter (IncrementAnthropicBodyless403Count) and, at threshold, permanently disables (handleAuthError → SetError, stops scheduling AND background refresh). tkIsUnstructuredAnthropicErrorBody is the structured-body gate (a model-level 403 carries a structured body → never counts → no false disable, per #810's precision bar). The IsClaudeAPIIncident() guard prevents mass-disabling the pool during a provider-wide outage. The slog marker anthropic_persistent_bodyless_403_disable is the ops observability anchor. Deleting any of these silently reopens the bodyless-ban eternal-flap."
+      "rationale": "Persistent bodyless/unstructured Anthropic 403 terminal disable (handle403 gap after #810, 2026-06-16 edge us6). tkIsUnstructuredAnthropicErrorBody is the structured-body gate. The slog marker anthropic_persistent_bodyless_403_disable is the ops observability anchor."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_oauth_fatal_403_skip.go",

--- a/scripts/sentinels/relay-invariants.json
+++ b/scripts/sentinels/relay-invariants.json
@@ -45,10 +45,10 @@
     {
       "path": "backend/internal/service/ratelimit_service_tk_oauth401_test.go",
       "must_contain": [
-        "func TestRateLimitService_OAuth401_ValidTokenDisablesFirstStrike(",
-        "func TestRateLimitService_OAuth401_ValidTokenDeferredDuringClaudeIncident("
+        "func TestRateLimitService_OAuth401_AnthropicAny401SetErrorsImmediately(",
+        "func TestRateLimitService_OAuth401_OpenAIValidTokenDisablesFirstStrike("
       ],
-      "rationale": "OAuth 401 on a still-valid token → first-strike disable (#831), DEFERRED during a Claude-wide incident (#834). A 401 returned while the local access_token is provably fresh means the grant was revoked upstream, so TK disables on the first strike — EXCEPT during a declared Claude API incident, when a 401 storm is upstream-wide and disabling would drain the pool. Both the disable and the incident-defer are deliberate TK choices a merge could silently undo."
+      "rationale": "Anthropic OAuth 401 → immediate SetError (any token state). OpenAI OAuth keeps valid-token first-strike disable."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_beta_selfheal_test.go",


### PR DESCRIPTION
## Summary

- **Claude API incident**：`status.claude.com` 非 operational 时发 P0 飞书红卡（恢复 operational 发绿卡闭环）；**不再**在 incident 期间豁免账号惩罚（401 冷却跳过 / 429·5xx 跳过冷却 / 空 body 403 不升级）。
- **客户端 UX 保留**：incident 期间 failover/上游错误仍通过 `TkEnrichClaudeIncidentMessage` 附带上游 message + `status.claude.com` 链接（仅文案，不罚账号）。
- **Anthropic OAuth 401**：任意 401（不区分 token 是否过期）→ 立即 `SetError` + `auth_error` P0 飞书，由运营人工 re-OAuth；不再走 `temp_unschedulable` hold。OpenAI/Gemini OAuth 仍保留原有 valid-token 首次禁用 / expired-token 冷却逻辑。

## Risk

- incident 期间 Anthropic 上游抖动可能更快摘号（有意为之）；401 不再给 refresh 自愈窗口。
- OpenAI OAuth 行为未改。

## Validation

- `go test -tags=unit ./internal/service/` 全绿
- `./scripts/preflight.sh` PASS

Web impact: none


Made with [Cursor](https://cursor.com)