### PR TITLE
feat(catalog): onboard qwen-turbo and official grok chat

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -147,20 +147,46 @@ var DefaultAntigravityModelMapping = map[string]string{
 	"tab_flash_lite_preview": "tab_flash_lite_preview",
 }
 
+var antigravityStructuralDeadModelMappingKeys = map[string]struct{}{
+	// PR #921 inventory + 2026-06-22 live snapshot: these are stale request aliases
+	// in persisted antigravity account mappings. Keep DefaultAntigravityModelMapping
+	// compatibility remaps, but do not write these aliases into canonical accounts.
+	"gemini-2.5-flash-image-preview": {},
+	"gemini-3-flash-preview":         {},
+	"gemini-3-pro-high":              {},
+	"gemini-3-pro-image-preview":     {},
+	"gemini-3-pro-low":               {},
+	"gemini-3-pro-preview":           {},
+	"gemini-3.1-pro-high":            {},
+	"gemini-3.1-pro-preview":         {},
+}
+
+// IsAntigravityStructuralDeadModelMappingKey reports whether k is a stale
+// Antigravity request alias that should not be persisted in canonical account
+// mappings. DefaultAntigravityModelMapping may still keep compatibility remaps.
+func IsAntigravityStructuralDeadModelMappingKey(k string) bool {
+	_, ok := antigravityStructuralDeadModelMappingKeys[k]
+	return ok
+}
+
 // GeminiOnlyAntigravityModelMapping 是 DefaultAntigravityModelMapping 去掉所有
-// claude-* 与 gpt-oss-* 键后的「gemini-only」服务映射——运营策略下 antigravity 只服务
-// gemini（claude 路由到 anthropic、gpt-oss 移出 antigravity）的规范账号映射，由
+// claude-*、gpt-oss-* 与 #921 confirmed structural-dead 兼容别名后的
+// 「gemini-only」服务映射——运营策略下 antigravity 只服务 gemini（claude 路由到
+// anthropic、gpt-oss 移出 antigravity）的规范账号映射，由
 // AntigravityConfigReconciler 自动写入每个 antigravity 账号。
 //
 // 在 DefaultAntigravityModelMapping 上方新增一个 gemini wire id 会自动流入此处（单一
-// 真值源）。保留全部 gemini-* 以及 Google 原生 tab_flash_lite_preview（二者都不是
-// claude/gpt-oss）——「gemini-only」按 PR #767 明确点名的两类排除（claude + gpt-oss）。
+// 真值源），除非它是 structural-dead 兼容别名。保留 Google 原生
+// tab_flash_lite_preview（不是 claude/gpt-oss；定价缺口由 pricing 层单独处理）。
 var GeminiOnlyAntigravityModelMapping = buildGeminiOnlyAntigravityModelMapping()
 
 func buildGeminiOnlyAntigravityModelMapping() map[string]string {
 	out := make(map[string]string, len(DefaultAntigravityModelMapping))
 	for k, v := range DefaultAntigravityModelMapping {
 		if strings.HasPrefix(k, "claude-") || strings.HasPrefix(k, "gpt-oss-") {
+			continue
+		}
+		if IsAntigravityStructuralDeadModelMappingKey(k) {
 			continue
 		}
 		out[k] = v

--- a/backend/internal/domain/constants_test.go
+++ b/backend/internal/domain/constants_test.go
@@ -106,7 +106,8 @@ func TestDefaultAntigravityModelMapping_ContainsEmpiricalGeminiWireIDs(t *testin
 // credentials.model_mapping 排除，而非删默认）。与 claude keep-guard 对称，防止
 // 未来 merge 静默删掉它而无测试翻红。
 // GeminiOnlyAntigravityModelMapping 必须是 DefaultAntigravityModelMapping 去掉
-// claude-* / gpt-oss-* 后的严格子集，且保留全部 gemini + tab_flash_lite_preview。
+// claude-* / gpt-oss-* 与 structural-dead 兼容别名后的严格子集，且保留可服务
+// gemini wire id + tab_flash_lite_preview。
 // 这是 AntigravityConfigReconciler 写入账号的规范 gemini-only 映射的单一真值源。
 func TestGeminiOnlyAntigravityModelMapping(t *testing.T) {
 	t.Parallel()
@@ -118,6 +119,9 @@ func TestGeminiOnlyAntigravityModelMapping(t *testing.T) {
 	for k, v := range m {
 		if strings.HasPrefix(k, "claude-") || strings.HasPrefix(k, "gpt-oss-") {
 			t.Fatalf("excluded key leaked into gemini-only map: %q", k)
+		}
+		if _, dead := antigravityStructuralDeadModelMappingKeys[k]; dead {
+			t.Fatalf("structural-dead antigravity alias leaked into gemini-only map: %q", k)
 		}
 		// strict subset of the default (same key→value)
 		if got, ok := DefaultAntigravityModelMapping[k]; !ok || got != v {
@@ -142,6 +146,39 @@ func TestGeminiOnlyAntigravityModelMapping(t *testing.T) {
 	}
 	if _, ok := m["gpt-oss-120b-medium"]; ok {
 		t.Fatal("gpt-oss-120b-medium must be excluded from gemini-only map")
+	}
+}
+
+func TestGeminiOnlyAntigravityModelMapping_DropsStructuralDeadAliases(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []string{
+		"gemini-2.5-flash-image-preview",
+		"gemini-3-flash-preview",
+		"gemini-3-pro-high",
+		"gemini-3-pro-image-preview",
+		"gemini-3-pro-low",
+		"gemini-3-pro-preview",
+		"gemini-3.1-pro-high",
+		"gemini-3.1-pro-preview",
+	} {
+		if _, ok := DefaultAntigravityModelMapping[key]; !ok {
+			t.Fatalf("default compatibility mapping must retain %q", key)
+		}
+		if _, ok := GeminiOnlyAntigravityModelMapping[key]; ok {
+			t.Fatalf("canonical gemini-only account mapping must drop structural-dead alias %q", key)
+		}
+	}
+	for _, want := range []string{
+		"gemini-2.5-flash-image",
+		"gemini-3-flash",
+		"gemini-3.1-flash-image",
+		"gemini-3.1-pro-low",
+		"gemini-pro-agent",
+	} {
+		if _, ok := GeminiOnlyAntigravityModelMapping[want]; !ok {
+			t.Fatalf("canonical gemini-only account mapping must keep servable target %q", want)
+		}
 	}
 }
 

--- a/backend/internal/service/antigravity_config_reconciler.go
+++ b/backend/internal/service/antigravity_config_reconciler.go
@@ -216,14 +216,15 @@ func (r *AntigravityConfigReconciler) tryAcquireLock() (func(), bool) {
 	}, true
 }
 
-// antigravityCanServeExcluded reports whether an antigravity account can still
-// serve a claude-* or gpt-oss-* model and therefore violates the gemini-only
-// policy. Two complementary checks (mirroring the post-rollout
-// check-antigravity-account-config.py invariant so the reconciler heals exactly
-// what the check flags):
-//   - scan the resolved mapping keys for a claude-* / gpt-oss-* prefix — catches
-//     ANY excluded id (e.g. claude-opus-4-8), not just the probe ids, and catches
-//     the empty-map case (which resolves to DefaultAntigravityModelMapping);
+// antigravityCanServeExcluded reports whether an antigravity account carries any
+// mapping drift the canonical gemini-only account map must heal: excluded
+// claude/gpt-oss families or PR #921 structural-dead Antigravity aliases. Two
+// complementary checks (mirroring the post-rollout check-antigravity-account-config.py
+// invariant so the reconciler heals exactly what the check flags):
+//   - scan the resolved mapping keys for a claude-* / gpt-oss-* prefix or
+//     structural-dead alias — catches ANY excluded id (e.g. claude-opus-4-8) and
+//     stale Antigravity aliases, not just the probe ids, and catches the empty-map
+//     case (which resolves to DefaultAntigravityModelMapping);
 //   - probe the representative ids — catches a catch-all wildcard (e.g. "*") that
 //     would match claude/gpt-oss without carrying a literal claude-* key.
 func antigravityCanServeExcluded(a *Account) bool {
@@ -231,17 +232,21 @@ func antigravityCanServeExcluded(a *Account) bool {
 		if strings.HasPrefix(k, "claude-") || strings.HasPrefix(k, "gpt-oss-") {
 			return true
 		}
+		if domain.IsAntigravityStructuralDeadModelMappingKey(k) {
+			return true
+		}
 	}
 	return a.IsModelSupported(antigravityClaudeProbeModel) || a.IsModelSupported(antigravityGptOssProbeModel)
 }
 
 // runOnce enforces gemini-only model_mapping on every antigravity account in the
-// LOCAL DB. An account that can still serve claude/gpt-oss (an empty mapping
-// falls back to DefaultAntigravityModelMapping, which includes both) has its
+// LOCAL DB. An account that can still serve claude/gpt-oss or carries stale
+// structural-dead aliases (an empty mapping falls back to DefaultAntigravityModelMapping,
+// which includes both excluded families and compatibility aliases) has its
 // credentials.model_mapping rewritten to GeminiOnlyAntigravityModelMapping via
-// BulkUpdate (whose JSONB shallow-merge replaces the whole model_mapping
-// sub-object — dropping claude/gpt-oss keys — and enqueues a scheduler_outbox
-// event so the change takes effect). Tests call it directly.
+// BulkUpdate (whose JSONB shallow-merge replaces the whole model_mapping sub-object
+// — dropping excluded/stale keys — and enqueues a scheduler_outbox event so the
+// change takes effect). Tests call it directly.
 func (r *AntigravityConfigReconciler) runOnce(ctx context.Context) {
 	if r == nil {
 		return

--- a/backend/internal/service/antigravity_config_reconciler_test.go
+++ b/backend/internal/service/antigravity_config_reconciler_test.go
@@ -121,6 +121,33 @@ func TestAntigravityReconciler_NonProbeClaudeId_StillReconciled(t *testing.T) {
 	require.NotContains(t, mm, "claude-opus-4-8")
 }
 
+func TestAntigravityReconciler_StructuralDeadAlias_StillReconciled(t *testing.T) {
+	acc := &reconcilerAccountStub{
+		byPlatform: map[string][]Account{
+			PlatformAntigravity: {
+				{
+					ID:       10,
+					Platform: PlatformAntigravity,
+					Credentials: map[string]any{
+						"model_mapping": map[string]any{
+							"gemini-3-pro-preview": "gemini-pro-agent",
+							"gemini-pro-agent":     "gemini-pro-agent",
+						},
+					},
+				},
+			},
+		},
+	}
+	r := NewAntigravityConfigReconciler(acc, nil, nil, nil)
+	r.runOnce(context.Background())
+
+	require.Len(t, acc.bulkCalls, 1, "custom map with structural-dead alias must be reconciled")
+	require.Equal(t, []int64{10}, acc.bulkCalls[0].ids)
+	mm := acc.bulkCalls[0].updates.Credentials["model_mapping"].(map[string]any)
+	require.NotContains(t, mm, "gemini-3-pro-preview")
+	require.Contains(t, mm, "gemini-pro-agent")
+}
+
 // Nil store / nil reconciler must be safe (mirrors the wire minimal-deps smoke).
 func TestAntigravityReconciler_NilSafe(t *testing.T) {
 	var nilRec *AntigravityConfigReconciler

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -966,8 +966,8 @@ func TestBuildForUser_GrokUnrestricted_ListsServableModels(t *testing.T) {
 		"a channel_type=0 grok account must be in scope for a grok group")
 	catalog := &PublicCatalogResponse{
 		Data: []PublicCatalogModel{
-			// grok-code-fast-1 is the one token-priced grok chat model.
-			mkPublicCatalogModel("grok-code-fast-1", "xai", 0.0002, 0.0015, 0),
+			mkPublicCatalogModel("grok-4.3", "xai", 0.00125, 0.0025, 0),
+			mkPublicCatalogModel("grok-code-fast-1", "xai", 0.001, 0.002, 0),
 		},
 	}
 	svc := newServiceWithAccounts(
@@ -990,9 +990,12 @@ func TestBuildForUser_GrokUnrestricted_ListsServableModels(t *testing.T) {
 		byID[m.ModelID] = m
 	}
 	// Catalog-priced model gets its price joined.
+	require.Contains(t, byID, "grok-4.3")
+	require.NotNil(t, byID["grok-4.3"].YourPrice.InputPer1K)
+	assert.InDelta(t, 0.00125, *byID["grok-4.3"].YourPrice.InputPer1K, 1e-9)
 	require.Contains(t, byID, "grok-code-fast-1")
 	require.NotNil(t, byID["grok-code-fast-1"].YourPrice.InputPer1K)
-	assert.InDelta(t, 0.0002, *byID["grok-code-fast-1"].YourPrice.InputPer1K, 1e-9)
+	assert.InDelta(t, 0.001, *byID["grok-code-fast-1"].YourPrice.InputPer1K, 1e-9)
 	// The grok-imagine media models surface even without a catalog row joined.
 	require.Contains(t, byID, "grok-imagine-image")
 	require.Contains(t, byID, "grok-imagine-video")

--- a/backend/internal/service/pricing_catalog_availability_tk.go
+++ b/backend/internal/service/pricing_catalog_availability_tk.go
@@ -75,10 +75,10 @@ func inferPlatformFromVendor(vendor string) string {
 	case "antigravity":
 		return PlatformAntigravity
 	case "xai", "x-ai":
-		// xAI / Grok (seventh platform). The overlay rows for the grok-imagine
-		// media family + grok-code-fast-1 carry litellm_provider="xai"; mapping
-		// it here lets the public-catalog servable gate and the availability
-		// self-heal treat grok like the other native platforms.
+		// xAI / Grok (seventh platform). TK-owned overlay rows for grok chat
+		// and grok-imagine media carry litellm_provider="xai"; mapping it here
+		// lets the public-catalog servable gate and the availability self-heal
+		// treat grok like the other native platforms.
 		return PlatformGrok
 	}
 	return ""

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -143,22 +143,23 @@ var supportedAntigravityCatalogModels = map[string]struct{}{
 // channel, so before this set both the channel stage and the whitelist stage
 // of the per-user menu produced nothing and a grok group showed an EMPTY
 // "分组目录" (incident 2026-06-20). The set is the SAME grok IDs the public
-// /pricing catalog surfaces — exactly the four priced entries in
-// tk_pricing_overlay.json (litellm_provider="xai"): the grok-imagine media
-// family (image/video) plus grok-code-fast-1 chat.
+// /pricing catalog surfaces: the priced grok-imagine media family plus grok
+// chat ids whose official xAI price is in tk_pricing_overlay.json and whose
+// edge-us4 native-grok live probe returned 200 on 2026-06-22.
 //
 // Hand-maintained like the antigravity arm (the refresh tool's probe tuple is
-// anthropic/openai/gemini and does not cover grok yet). The grok-4.x CHAT
-// models (grok-4 / grok-4.3 — the SuperGrok Heavy OAuth default) are
-// DELIBERATELY EXCLUDED: tk_pricing_overlay.json intentionally leaves them
-// unpriced (their 2026 list price is unconfirmed; they bill $0 and raise
-// served_zero_cost P0s) per the overlay's "a wrong price has no probe"
-// discipline — advertising an unpriced model at "—" would invite exactly that
-// free-usage leak. Add them here only once a verified price lands in the
-// overlay. While EMPTY the catalog/menu gates fall through to passthrough
-// (no regression), matching the gemini/antigravity arms.
+// anthropic/openai/gemini and does not cover grok yet). Back-compat aliases
+// such as grok-4.3-latest / grok-latest / grok-code-fast-1-0825 are priced in
+// the overlay so explicit requests do not bill $0, but are not public-listed:
+// the visible catalog prefers stable bare ids and current official SKUs. While
+// EMPTY the catalog/menu gates fall through to passthrough (no regression),
+// matching the gemini/antigravity arms.
 var supportedGrokCatalogModels = map[string]struct{}{
 	// servable-allowlist:begin grok
+	"grok-4.20-0309-non-reasoning": {},
+	"grok-4.20-0309-reasoning":     {},
+	"grok-4.3":                     {},
+	"grok-build-0.1":               {},
 	"grok-code-fast-1":           {},
 	"grok-imagine-image":         {},
 	"grok-imagine-image-quality": {},

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -160,10 +160,10 @@ var supportedGrokCatalogModels = map[string]struct{}{
 	"grok-4.20-0309-reasoning":     {},
 	"grok-4.3":                     {},
 	"grok-build-0.1":               {},
-	"grok-code-fast-1":           {},
-	"grok-imagine-image":         {},
-	"grok-imagine-image-quality": {},
-	"grok-imagine-video":         {},
+	"grok-code-fast-1":             {},
+	"grok-imagine-image":           {},
+	"grok-imagine-image-quality":   {},
+	"grok-imagine-video":           {},
 	// servable-allowlist:end grok
 }
 

--- a/backend/internal/service/pricing_catalog_tk_test.go
+++ b/backend/internal/service/pricing_catalog_tk_test.go
@@ -264,7 +264,7 @@ func TestIsPublicCatalogModelSupported(t *testing.T) {
 		{"x-ai", "grok-imagine-image", true}, // openrouter-style x-ai alias maps too
 		{"xai", "grok-4", false},             // third-party-priced / unverified legacy slug
 		{"xai", "grok-latest", false},        // priced alias, not public-listed
-		{"", "anything", true},                  // unknown vendor: pass-through
+		{"", "anything", true},               // unknown vendor: pass-through
 	}
 	for _, c := range cases {
 		assert.Equalf(t, c.want, isPublicCatalogModelSupported(c.vendor, c.model),

--- a/backend/internal/service/pricing_catalog_tk_test.go
+++ b/backend/internal/service/pricing_catalog_tk_test.go
@@ -256,10 +256,14 @@ func TestIsPublicCatalogModelSupported(t *testing.T) {
 		{"antigravity", "claude-sonnet-4-6", false},   // claude routed to anthropic
 		{"antigravity", "gemini-2.5-pro", false},      // 503 at probe, not in antigravity set
 		// grok (xai vendor → grok platform): gated to the priced overlay set.
+		{"xai", "grok-4.3", true},
+		{"xai", "grok-4.20-0309-reasoning", true},
+		{"xai", "grok-build-0.1", true},
 		{"xai", "grok-code-fast-1", true},
 		{"xai", "grok-imagine-video", true},
-		{"x-ai", "grok-imagine-image", true},    // openrouter-style x-ai alias maps too
-		{"xai", "grok-4", false},                // chat models intentionally unpriced → not served
+		{"x-ai", "grok-imagine-image", true}, // openrouter-style x-ai alias maps too
+		{"xai", "grok-4", false},             // third-party-priced / unverified legacy slug
+		{"xai", "grok-latest", false},        // priced alias, not public-listed
 		{"", "anything", true},                  // unknown vendor: pass-through
 	}
 	for _, c := range cases {
@@ -291,9 +295,9 @@ func TestSupportedCatalogModelIDsForPlatform_Antigravity(t *testing.T) {
 
 // TestSupportedCatalogModelIDsForPlatform_Grok pins the grok served set used by
 // the per-user menu fallback (platformDefaultModelIDs) AND the admin
-// model-whitelist selector (tkServableCandidateIDs): the four priced grok
-// overlay models, with the grok-4.x chat family deliberately excluded
-// (intentionally unpriced). Regression for the 2026-06-20 empty-grok-group bug.
+// model-whitelist selector (tkServableCandidateIDs): priced grok overlay models
+// whose native-grok live probe returned 200. Regression for the 2026-06-20
+// empty-grok-group bug.
 func TestSupportedCatalogModelIDsForPlatform_Grok(t *testing.T) {
 	ids := supportedCatalogModelIDsForPlatform(PlatformGrok)
 	require.NotEmpty(t, ids)
@@ -301,11 +305,20 @@ func TestSupportedCatalogModelIDsForPlatform_Grok(t *testing.T) {
 	for _, id := range ids {
 		set[id] = struct{}{}
 	}
-	for _, want := range []string{"grok-code-fast-1", "grok-imagine-image", "grok-imagine-image-quality", "grok-imagine-video"} {
+	for _, want := range []string{
+		"grok-4.3",
+		"grok-4.20-0309-reasoning",
+		"grok-4.20-0309-non-reasoning",
+		"grok-build-0.1",
+		"grok-code-fast-1",
+		"grok-imagine-image",
+		"grok-imagine-image-quality",
+		"grok-imagine-video",
+	} {
 		_, ok := set[want]
 		assert.Truef(t, ok, "expected grok menu to advertise %q", want)
 	}
-	for _, deny := range []string{"grok-4", "grok-4.3", "claude-opus-4-8"} {
+	for _, deny := range []string{"grok-4", "grok-latest", "grok-code-fast-1-0825", "claude-opus-4-8"} {
 		_, ok := set[deny]
 		assert.Falsef(t, ok, "grok menu must not advertise %q (unpriced/off-platform)", deny)
 	}

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -924,6 +924,14 @@
     "cache_read_input_token_cost": 3.582089552238806e-07,
     "source": "Alibaba DashScope qwen-max (legacy stable alias, 当前能力等同 qwen-max snapshot) official China-mainland (Beijing) RMB list ÷ 6.7 (无阶梯计价 in ¥2.4/M out ¥9.6/M); docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Added 2026-06-13: client-facing legacy alias served via account 60 (dashscope.aliyuncs.com) that the qwen3.7-* mapping did not cover (empty-pool 429 incident). List price only — Batch (half-price)/context-cache discounts not modeled (bill at list). International deployment is ~5x higher (¥11.743/¥46.971) and intentionally NOT modeled; the prod account uses the China-mainland endpoint."
   },
+  "qwen-turbo": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 4.477611940298507e-08,
+    "output_cost_per_token": 8.955223880597015e-08,
+    "cache_read_input_token_cost": 4.477611940298507e-08,
+    "source": "Alibaba DashScope qwen-turbo (commercial qwen3 alias) official China-mainland (Beijing) RMB list ÷ 6.7 (无阶梯 in ¥0.3/M, out 非思考 ¥0.6/M); docs/accounts/aliyun_pricing_20260612.md line 394 captured 2026-06-12. Added 2026-06-22 (Goal 2 fleet servable-expansion): client-facing model served via account 60 (dashscope.aliyuncs.com), mapped by tk_042. Output priced at NON-thinking list; enable_thinking defaults FALSE for commercial qwen (same treatment as qwen-plus), thinking-mode output (¥3/M) intentionally NOT modeled (bill at non-thinking list). List price only — Batch (half-price)/context-cache discounts not modeled (cache_read billed at full input rate). International deployment higher and intentionally NOT modeled; the prod account uses the China-mainland endpoint."
+  },
   "qwen-plus": {
     "litellm_provider": "dashscope",
     "mode": "chat",

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -23,12 +23,85 @@
     "source": "xAI official video pricing (docs.x.ai/developers/models/grok-imagine-video, captured 2026-06-19): output $0.05/s base (480p text-to-video), 720p output $0.07/s, +$0.01/s when image is used as input. TK bills a single flat per-OUTPUT-second rate (no resolution/input granularity), set to the MAX reachable tier 720p+image-input = $0.07+$0.01 = $0.08/s so cheaper combos over- not under-charge (same MAX-tier convention as veo/doubao). Cross-checked live 2026-06-19 against api.x.ai/v1/videos via a grok OAuth Heavy account: a 5s text-to-video reported usage.cost_in_usd_ticks=2500000000 = $0.25 ($0.05/s), confirming 1 tick = 1e-10 USD (grok-imagine-image 2e8 ticks = its known $0.02). video_url (continuation) input is rejected at submit (unpriced under per-output-second); only first-frame image_url input is allowed. failure_billing=success_only: xAI bills generated output seconds, and TokenKey's terminal-failure refund reverses the submit-time charge.",
     "failure_billing": "success_only"
   },
+  "grok-4.3": {
+    "litellm_provider": "xai",
+    "mode": "chat",
+    "input_cost_per_token": 1.25e-06,
+    "cache_read_input_token_cost": 2e-07,
+    "output_cost_per_token": 2.5e-06,
+    "source": "xAI official pricing (docs.x.ai/developers/pricing, captured 2026-06-22; page last updated 2026-06-12): grok-4.3 input $1.25/Mtok, cached input $0.20/Mtok, output $2.50/Mtok. Live probe 2026-06-22 via edge-us4 native grok group returned 200 for grok-4.3, grok-4.3-latest and grok-latest; only the stable bare id is public-listed."
+  },
+  "grok-4.3-latest": {
+    "litellm_provider": "xai",
+    "mode": "chat",
+    "input_cost_per_token": 1.25e-06,
+    "cache_read_input_token_cost": 2e-07,
+    "output_cost_per_token": 2.5e-06,
+    "source": "Alias priced to grok-4.3 per xAI official pricing (docs.x.ai/developers/pricing, captured 2026-06-22): input $1.25/Mtok, cached input $0.20/Mtok, output $2.50/Mtok. Live probe 2026-06-22 returned 200; kept priced so explicit alias requests do not bill $0, but not public-listed."
+  },
+  "grok-latest": {
+    "litellm_provider": "xai",
+    "mode": "chat",
+    "input_cost_per_token": 1.25e-06,
+    "cache_read_input_token_cost": 2e-07,
+    "output_cost_per_token": 2.5e-06,
+    "source": "Alias priced to grok-4.3 per xAI official pricing (docs.x.ai/developers/pricing, captured 2026-06-22): input $1.25/Mtok, cached input $0.20/Mtok, output $2.50/Mtok. Live probe 2026-06-22 returned 200; kept priced so explicit alias requests do not bill $0, but not public-listed."
+  },
+  "grok-4-fast-reasoning": {
+    "litellm_provider": "xai",
+    "mode": "chat",
+    "input_cost_per_token": 1.25e-06,
+    "cache_read_input_token_cost": 2e-07,
+    "output_cost_per_token": 2.5e-06,
+    "source": "xAI official model-retirement page (docs.x.ai/developers/migration/may-15-retirement, captured 2026-06-22) says retired grok-4-fast-reasoning redirects to grok-4.3 and is charged as grok-4.3: input $1.25/Mtok, cached input $0.20/Mtok, output $2.50/Mtok from docs.x.ai/developers/pricing. Live probe 2026-06-22 returned 200; priced for backward compatibility, not public-listed."
+  },
+  "grok-4.20-0309-reasoning": {
+    "litellm_provider": "xai",
+    "mode": "chat",
+    "input_cost_per_token": 1.25e-06,
+    "cache_read_input_token_cost": 2e-07,
+    "output_cost_per_token": 2.5e-06,
+    "source": "xAI official pricing (docs.x.ai/developers/pricing, captured 2026-06-22; page last updated 2026-06-12): grok-4.20-0309-reasoning input $1.25/Mtok, cached input $0.20/Mtok, output $2.50/Mtok. Live probe 2026-06-22 via edge-us4 native grok group returned 200."
+  },
+  "grok-4.20-0309-non-reasoning": {
+    "litellm_provider": "xai",
+    "mode": "chat",
+    "input_cost_per_token": 1.25e-06,
+    "cache_read_input_token_cost": 2e-07,
+    "output_cost_per_token": 2.5e-06,
+    "source": "xAI official pricing (docs.x.ai/developers/pricing, captured 2026-06-22; page last updated 2026-06-12): grok-4.20-0309-non-reasoning input $1.25/Mtok, cached input $0.20/Mtok, output $2.50/Mtok. Live probe 2026-06-22 via edge-us4 native grok group returned 200."
+  },
+  "grok-build-0.1": {
+    "litellm_provider": "xai",
+    "mode": "chat",
+    "input_cost_per_token": 1e-06,
+    "cache_read_input_token_cost": 2e-07,
+    "output_cost_per_token": 2e-06,
+    "source": "xAI official pricing (docs.x.ai/developers/pricing, captured 2026-06-22; page last updated 2026-06-12): grok-build-0.1 input $1/Mtok, cached input $0.20/Mtok, output $2/Mtok. Live probe 2026-06-22 via edge-us4 native grok group returned 200."
+  },
+  "grok-code-fast": {
+    "litellm_provider": "xai",
+    "mode": "chat",
+    "input_cost_per_token": 1e-06,
+    "cache_read_input_token_cost": 2e-07,
+    "output_cost_per_token": 2e-06,
+    "source": "xAI official grok-build-0.1 model page (docs.x.ai/developers/models/grok-code-fast-1, captured 2026-06-22) lists grok-code-fast as an alias of grok-build-0.1. Official pricing page lists grok-build-0.1 at input $1/Mtok, cached input $0.20/Mtok, output $2/Mtok. Live probe 2026-06-22 returned 200."
+  },
+  "grok-code-fast-1-0825": {
+    "litellm_provider": "xai",
+    "mode": "chat",
+    "input_cost_per_token": 1e-06,
+    "cache_read_input_token_cost": 2e-07,
+    "output_cost_per_token": 2e-06,
+    "source": "xAI official grok-build-0.1 model page (docs.x.ai/developers/models/grok-code-fast-1, captured 2026-06-22) lists grok-code-fast-1-0825 as an alias of grok-build-0.1. Official pricing page lists grok-build-0.1 at input $1/Mtok, cached input $0.20/Mtok, output $2/Mtok. Live probe 2026-06-22 returned 200; kept priced for backward compatibility, not public-listed."
+  },
   "grok-code-fast-1": {
     "litellm_provider": "xai",
     "mode": "chat",
-    "input_cost_per_token": 2e-07,
-    "output_cost_per_token": 1.5e-06,
-    "source": "xAI official (x.ai/news/grok-code-fast-1) post-promo list $0.20/Mtok in, $1.50/Mtok out, captured 2026-06. NOTE: grok-4.x chat models (incl. grok-4.3 — the SuperGrok Heavy OAuth default) are intentionally NOT priced here — their 2026 list price was unconfirmed at authoring time; they bill $0 (served_zero_cost P0 alerts) until the operator adds verified rows from console.x.ai. Per the overlay's 'a wrong price has no probe' discipline, a missing-but-alarmed price is safer than a guessed one."
+    "input_cost_per_token": 1e-06,
+    "cache_read_input_token_cost": 2e-07,
+    "output_cost_per_token": 2e-06,
+    "source": "xAI official grok-build-0.1 model page (docs.x.ai/developers/models/grok-code-fast-1, captured 2026-06-22) lists grok-code-fast-1 as an alias of grok-build-0.1. Official pricing page lists grok-build-0.1 at input $1/Mtok, cached input $0.20/Mtok, output $2/Mtok. This replaces the older x.ai/news/grok-code-fast-1 promo/post-promo row, which would under-bill the current routed model."
   },
   "claude-fable-5": {
     "litellm_provider": "anthropic",

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -123,6 +123,18 @@
       "display": false,
       "notes": "Qwen account 60. Legacy stable alias mapped by tk_027. Flat-priced in overlay."
     },
+    "newapi/qwen-turbo": {
+      "platform": "newapi",
+      "model_id": "qwen-turbo",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen-turbo",
+      "display": false,
+      "notes": "Qwen account 60. Mapped by tk_042 (Goal 2 fleet servable-expansion). Flat non-thinking list price in overlay (commercial qwen, enable_thinking default false — thinking tier intentionally not modeled, see overlay source note)."
+    },
     "newapi/qwen-plus": {
       "platform": "newapi",
       "model_id": "qwen-plus",

--- a/backend/migrations/tk_042_qwen_turbo_model_mapping.sql
+++ b/backend/migrations/tk_042_qwen_turbo_model_mapping.sql
@@ -1,0 +1,46 @@
+-- Migration: tk_042_qwen_turbo_model_mapping
+--
+-- Advertise qwen-turbo on the Qwen account (id=60) so the Qwen group can access it.
+--
+-- Why (Goal 2 fleet servable-expansion, 2026-06-22): qwen-turbo is in the ct=17
+-- Ali/DashScope adaptor catalog and DashScope serves it with account 60's key, but
+-- TK returned 429 (empty pool / not_allowlisted) because account 60's
+-- credentials.model_mapping is an identity WHITELIST that did not list qwen-turbo.
+-- Merging it makes the newapi bridge advertise + route it. Reachability confirmed by
+-- post-apply livefire (the gateway empty-pool gate makes a pre-map probe impossible).
+--
+-- Pricing ships in the SAME release via backend/internal/service/tk_pricing_overlay.json
+-- (qwen-turbo, flat non-thinking China-mainland list; compile-embedded), so the
+-- whitelist add and the price go live together — no $0 billing window.
+--
+-- Merge (jsonb ||) preserves the existing qwen3.7-max/qwen-plus/etc. entries; only the
+-- qwen-turbo identity key is added. Raw-SQL account mutation bypasses the Ent
+-- snapshot-refresh hooks, so enqueue a scheduler_outbox account_changed event
+-- (pattern: tk_024/tk_022).
+--
+-- Idempotent + cross-deployment safe: guarded by (id, name, platform='newapi',
+-- channel_type=17) so re-running merges the same key (no-op) and a bare id colliding
+-- with an unrelated account in another DB cannot match.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH upd AS (
+    UPDATE accounts
+    SET credentials = jsonb_set(
+            credentials,
+            '{model_mapping}',
+            COALESCE(credentials -> 'model_mapping', '{}'::jsonb) || '{
+                "qwen-turbo": "qwen-turbo"
+            }'::jsonb
+        ),
+        updated_at = NOW()
+    WHERE id = 60
+      AND name = 'Qwen'
+      AND platform = 'newapi'
+      AND channel_type = 17
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;

--- a/backend/migrations/tk_043_prune_antigravity_structural_dead_mapping.sql
+++ b/backend/migrations/tk_043_prune_antigravity_structural_dead_mapping.sql
@@ -1,0 +1,46 @@
+-- Migration: tk_043_prune_antigravity_structural_dead_mapping
+--
+-- Remove PR #921-confirmed structural-dead Antigravity request aliases from
+-- persisted account credentials.model_mapping. These aliases either remap away
+-- from retired/deprecated Antigravity IDs or are stale preview spellings; keeping
+-- them in the DB widens the visible/schedulable surface without adding a real
+-- servable model. DefaultAntigravityModelMapping keeps compatibility remaps for
+-- legacy clients; canonical persisted accounts should carry only live target ids.
+--
+-- Raw SQL account mutations bypass Ent hooks, so enqueue account_changed events
+-- for the scheduler snapshot refresh (same pattern as tk_020/tk_024/tk_037).
+-- Idempotent: after the first run, no row contains any key in remove_keys.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH params(remove_keys) AS (
+    VALUES (ARRAY[
+        'gemini-2.5-flash-image-preview',
+        'gemini-3-flash-preview',
+        'gemini-3-pro-high',
+        'gemini-3-pro-image-preview',
+        'gemini-3-pro-low',
+        'gemini-3-pro-preview',
+        'gemini-3.1-pro-high',
+        'gemini-3.1-pro-preview'
+    ]::text[])
+),
+upd AS (
+    UPDATE accounts AS a
+    SET credentials = jsonb_set(
+            COALESCE(a.credentials, '{}'::jsonb),
+            '{model_mapping}',
+            (a.credentials -> 'model_mapping') - p.remove_keys,
+            true
+        ),
+        updated_at = NOW()
+    FROM params AS p
+    WHERE a.platform = 'antigravity'
+      AND a.deleted_at IS NULL
+      AND jsonb_typeof(a.credentials -> 'model_mapping') = 'object'
+      AND (a.credentials -> 'model_mapping') ?| p.remove_keys
+    RETURNING a.id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;

--- a/ops/antigravity/check-antigravity-account-config.py
+++ b/ops/antigravity/check-antigravity-account-config.py
@@ -6,8 +6,9 @@ routed to anthropic, gpt-oss off antigravity) across all deployable edges + prod
 on BOTH surfaces the backend ``AntigravityConfigReconciler`` self-heals:
 
   1. **accounts** — every ``platform=antigravity`` account carries a gemini-only
-     ``credentials.model_mapping`` (no ``claude-*`` / ``gpt-oss-*`` keys), AND any
-     active+schedulable account is bound to an antigravity group (account_groups).
+     ``credentials.model_mapping`` (no ``claude-*`` / ``gpt-oss-*`` keys, no
+     PR #921 structural-dead Antigravity aliases), AND any active+schedulable
+     account is bound to an antigravity group (account_groups).
   2. **groups** — every active ``platform=antigravity`` group carries gemini-only
      ``supported_model_scopes`` (exactly ``[gemini_text, gemini_image]``), so
      ``/antigravity/v1/models`` + the API key usage guide hide claude.
@@ -18,11 +19,12 @@ tool is the only safety net for it. This tool is the post-rollout *verification*
 
 A **violation** is any antigravity account whose ``model_mapping`` is null/empty
 (an empty map falls back to ``DefaultAntigravityModelMapping``, which still
-includes claude + gpt-oss) or contains any ``claude-`` / ``gpt-oss-`` key, OR an
-active+schedulable account with no antigravity-group binding (account_groups missing
-→ scheduler "No available accounts" 429: looks ready but silently never serves); OR
-any active antigravity group whose ``supported_model_scopes`` is empty (unrestricted
-→ advertises claude) or not exactly the gemini-only set.
+includes claude + gpt-oss) or contains any ``claude-`` / ``gpt-oss-`` key or
+PR #921 structural-dead alias, OR an active+schedulable account with no
+antigravity-group binding (account_groups missing → scheduler "No available
+accounts" 429: looks ready but silently never serves); OR any active antigravity
+group whose ``supported_model_scopes`` is empty (unrestricted → advertises claude)
+or not exactly the gemini-only set.
 
 Exit codes (mirrors the anthropic post-release check): ``0`` = all gemini-only
 (green); ``1`` = violations found (yellow, non-blocking at rollout); ``2`` = could
@@ -69,6 +71,17 @@ ANTIGRAVITY_GROUPS_SQL = (
 # Canonical gemini-only group scopes — mirrors domain.GeminiOnlyAntigravityModelScopes
 # and the reconciler's antigravityGroupScopesNeedGeminiOnly predicate.
 GEMINI_ONLY_SCOPES = {"gemini_text", "gemini_image"}
+
+ANTIGRAVITY_STRUCTURAL_DEAD_MODEL_MAPPING_KEYS = {
+    "gemini-2.5-flash-image-preview",
+    "gemini-3-flash-preview",
+    "gemini-3-pro-high",
+    "gemini-3-pro-image-preview",
+    "gemini-3-pro-low",
+    "gemini-3-pro-preview",
+    "gemini-3.1-pro-high",
+    "gemini-3.1-pro-preview",
+}
 
 # ops-sql-coverage gate: ssm_run_sql ships SQL over SSM, it does not build it.
 SELF_CHECK_EXEMPT: dict[str, str] = {
@@ -166,6 +179,9 @@ def _account_violation(row: dict) -> str | None:
         leaked = sorted(k for k in mm if k.startswith("claude-") or k.startswith("gpt-oss-"))
         if leaked:
             reasons.append("serves excluded models: " + ", ".join(leaked))
+        stale = sorted(k for k in mm if k in ANTIGRAVITY_STRUCTURAL_DEAD_MODEL_MAPPING_KEYS)
+        if stale:
+            reasons.append("contains structural-dead aliases: " + ", ".join(stale))
 
     if row.get("status") == "active" and row.get("schedulable") and not row.get("bound"):
         reasons.append("active+schedulable but NOT bound to any antigravity group "

--- a/ops/antigravity/test_check_antigravity_account_config.py
+++ b/ops/antigravity/test_check_antigravity_account_config.py
@@ -43,6 +43,13 @@ class AccountViolationTest(unittest.TestCase):
         self.assertIn("claude-opus-4-8", r)
         self.assertIsNotNone(CHK._account_violation({"model_mapping": {"gpt-oss-120b-medium": "x"}}))
 
+    def test_structural_dead_alias_is_violation(self):
+        for key in CHK.ANTIGRAVITY_STRUCTURAL_DEAD_MODEL_MAPPING_KEYS:
+            with self.subTest(key=key):
+                r = CHK._account_violation({"model_mapping": {key: "x", "gemini-pro-agent": "gemini-pro-agent"}})
+                self.assertIsNotNone(r)
+                self.assertIn(key, r)
+
     def _gemini_only_mm(self):
         return {"gemini-3-flash": "gemini-3-flash"}
 

--- a/ops/pricing/probe-servable-models.sh
+++ b/ops/pricing/probe-servable-models.sh
@@ -14,6 +14,11 @@
 #   GEMINI_VIDEO_MODELS      -> POST app:8080/v1/video/generations (async submit; 200-on-submit=servable, best-effort)
 #     NB gemini families run ON the edge host and hit the app container directly
 #     (the edge Caddy 403s host-local /v1/* — it only allows the prod gateway CIDR).
+#   GROK_CHAT_MODELS         -> POST app:8080/v1/chat/completions  (native grok, edge-internal)
+#     NB grok lives on its native edge pool (currently edge-us4). Like gemini,
+#     the edge-local probe hits the app container directly instead of the public
+#     Caddy path. Use run-probe with --target edge:us4 and a key bound to the
+#     edge-side grok group.
 #   DASHSCOPE_CHAT_MODELS    -> POST <prod>/v1/chat/completions  (newapi channel_type=17, qwen3 dense)
 #     The newapi fifth-platform pool IS served at prod (unlike gemini, which is
 #     edge-internal), so this family routes through the normal prod TK gateway
@@ -53,6 +58,9 @@
 #   GEMINI_GROUP_NAME        default google-vertex  (verified prod newapi Vertex group; CASE-SENSITIVE)
 #   GEMINI_APP_CONTAINER     default tokenkey-caddy (a container on the compose net with busybox wget)
 #   GEMINI_APP_URL           default http://tokenkey:8080 (the app, reached internally)
+#   GROK_GROUP_NAME          default grok  (verified edge native grok group; CASE-SENSITIVE)
+#   GROK_APP_CONTAINER       default tokenkey-caddy
+#   GROK_APP_URL             default http://tokenkey:8080
 #   DASHSCOPE_GROUP_NAME     default Qwen  (verified prod group, capital Q; CASE-SENSITIVE; never printed)
 #   REQ_SLEEP                default 2  (seconds between requests; avoids pool exhaustion)
 #
@@ -89,6 +97,9 @@ GEMINI_GROUP_NAME="${GEMINI_GROUP_NAME:-google-vertex}"
 # carries busybox wget and resolves the app service name on the compose network.
 GEMINI_APP_CONTAINER="${GEMINI_APP_CONTAINER:-tokenkey-caddy}"
 GEMINI_APP_URL="${GEMINI_APP_URL:-http://tokenkey:8080}"
+GROK_GROUP_NAME="${GROK_GROUP_NAME:-grok}"
+GROK_APP_CONTAINER="${GROK_APP_CONTAINER:-tokenkey-caddy}"
+GROK_APP_URL="${GROK_APP_URL:-http://tokenkey:8080}"
 DASHSCOPE_GROUP_NAME="${DASHSCOPE_GROUP_NAME:-Qwen}"
 REQ_SLEEP="${REQ_SLEEP:-2}"
 UA='claude-cli/2.1.165 (external, sdk-cli)'
@@ -189,6 +200,21 @@ probe_gemini_internal() { # $1=key $2=endpoint $3=models $4=jsonbody-template-fn
 	done
 }
 
+probe_grok_internal() { # $1=key $2=endpoint $3=models $4=jsonbody-template-fn
+	local key="$1" path="$2" models="$3" buildfn="$4" m hf bf code body
+	for m in $models; do
+		hf="$(mktemp)"; bf="$(mktemp)"; body="$($buildfn "$m")"
+		sudo docker exec "$GROK_APP_CONTAINER" wget -S -q -O - --timeout=90 \
+			--header="Authorization: Bearer $key" --header='content-type: application/json' \
+			--post-data="$body" "$GROK_APP_URL$path" >"$bf" 2>"$hf" || true
+		code="$(grep -oE 'HTTP/[0-9.]+ [0-9]{3}' "$hf" | tail -1 | grep -oE '[0-9]{3}$')"
+		[ -z "$code" ] && code=000
+		emit grok "$m" "$code" "$(verdict "$code" "$bf")"
+		rm -f "$hf" "$bf"
+		sleep "$REQ_SLEEP"
+	done
+}
+
 body_chat() { printf '{"model":"%s","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}' "$1"; }
 body_resp() { printf '{"model":"%s","instructions":"You are a helpful assistant.","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"Say OK"}]}],"stream":false}' "$1"; }
 body_img() { printf '{"model":"%s","prompt":"a small red circle on white","n":1,"size":"1024x1024"}' "$1"; }
@@ -228,7 +254,7 @@ probe_dashscope() { # $1=key  (models from $DASHSCOPE_CHAT_MODELS)
 }
 
 main() {
-	local akey okey gkey dkey arkacct arkkey arkbase
+	local akey okey gkey grkey dkey arkacct arkkey arkbase
 	if [ -n "${ANTHROPIC_MODELS:-}" ]; then
 		akey="$($PSQL -c "SELECT credentials->>'api_key' FROM accounts WHERE id=$AACCT AND deleted_at IS NULL" | tr -d '[:space:]')"
 		if [ -z "$akey" ]; then
@@ -276,6 +302,17 @@ main() {
 			cfgerr newapi "no api_key bound to group '$DASHSCOPE_GROUP_NAME' (DASHSCOPE_GROUP_NAME) — check name/case + that a key is bound"
 		else
 			probe_dashscope "$dkey"
+		fi
+	fi
+	# Grok family: native xAI OAuth pool on the edge (currently us4). Probe key is
+	# a TK api_key BOUND TO the edge-side grok group; never printed. The probe runs
+	# on the edge host and hits the app container directly, bypassing edge Caddy.
+	if [ -n "${GROK_CHAT_MODELS:-}" ]; then
+		grkey="$($PSQL -c "SELECT ak.key FROM api_keys ak JOIN groups g ON g.id=ak.group_id WHERE g.name='$GROK_GROUP_NAME' AND g.platform='grok' AND ak.deleted_at IS NULL AND g.deleted_at IS NULL ORDER BY ak.id LIMIT 1" | tr -d '[:space:]')"
+		if [ -z "$grkey" ]; then
+			cfgerr grok "no api_key bound to group '$GROK_GROUP_NAME' (GROK_GROUP_NAME) — check name/case + that a key is bound"
+		else
+			probe_grok_internal "$grkey" /v1/chat/completions "$GROK_CHAT_MODELS" body_chat
 		fi
 	fi
 	# Gemini family: newapi/Vertex models served through the google group on GEMINI_BASE.

--- a/ops/pricing/refresh-servable-allowlist.py
+++ b/ops/pricing/refresh-servable-allowlist.py
@@ -173,7 +173,7 @@ def dedup(servable: set[str]) -> list[str]:
 # ----- results TSV parsing -----
 def parse_results(text: str) -> dict[str, set[str]]:
     """platform -> set of servable model ids. Lines: platform\\tmodel\\tcode\\tverdict."""
-    out: dict[str, set[str]] = {"anthropic": set(), "openai": set(), "gemini": set()}
+    out: dict[str, set[str]] = {"anthropic": set(), "openai": set(), "gemini": set(), "grok": set()}
     for line in text.splitlines():
         parts = line.rstrip("\n").split("\t")
         if len(parts) != 4:
@@ -365,14 +365,22 @@ def selftest() -> int:
     cks = chunk(big, BATCH_SIZE)
     assert all(len(c) <= BATCH_SIZE for c in cks) and sum(cks, []) == big
 
-    # parse: gemini rows land in the gemini bucket; non-servable/auth dropped
+    # parse: gemini/grok rows land in their buckets; non-servable/auth dropped.
+    # Grok remains hand-maintained in pricing_catalog_supported_models_tk.go, so
+    # write_allowlists still rewrites only anthropic/openai/gemini.
     tsv = (
         "anthropic\tclaude-opus-4-8\t200\tservable\n"
         "openai\tgpt-4o\t400\tunsupported\nopenai\t*\t000\tauth_error\n"
-        "gemini\tgemini-2.5-pro\t200\tservable\ngemini\tgemma-4-31b-it\t400\tunsupported"
+        "gemini\tgemini-2.5-pro\t200\tservable\ngemini\tgemma-4-31b-it\t400\tunsupported\n"
+        "grok\tgrok-4.3\t200\tservable\ngrok\tgrok-4-0709\t429\tinconclusive"
     )
     p = parse_results(tsv)
-    assert p == {"anthropic": {"claude-opus-4-8"}, "openai": set(), "gemini": {"gemini-2.5-pro"}}, p
+    assert p == {
+        "anthropic": {"claude-opus-4-8"},
+        "openai": set(),
+        "gemini": {"gemini-2.5-pro"},
+        "grok": {"grok-4.3"},
+    }, p
 
     # splice round-trips between markers and is idempotent (anthropic + gemini)
     sample = (

--- a/scripts/checks/pricing-overlay.py
+++ b/scripts/checks/pricing-overlay.py
@@ -18,6 +18,8 @@ a soft rule that bit us once becomes a mechanical gate). It asserts:
        deepseek-v4-flash              -> input_cost_per_token > 0
        doubao-seedream-4-0-250828     -> output_cost_per_image > 0
        doubao-seedance-1-0-pro-250528 -> output_cost_per_second > 0
+       grok-4.3                       -> input_cost_per_token > 0
+       grok-build-0.1                 -> input_cost_per_token > 0
   3. EVERY entry has a recognized mode and a > 0 price in the matching field(s)
      (no silently-shipped $0 entry, which would deduct nothing):
        image_generation -> output_cost_per_image
@@ -50,6 +52,8 @@ ANCHORS = {
     "deepseek-v4-flash": "input_cost_per_token",
     "doubao-seedream-4-0-250828": "output_cost_per_image",
     "doubao-seedance-1-0-pro-250528": "output_cost_per_second",
+    "grok-4.3": "input_cost_per_token",
+    "grok-build-0.1": "input_cost_per_token",
 }
 
 # Models that MUST carry a thinking-mode output price. For Qwen3 open-source dense

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1002,6 +1002,15 @@
       "rationale": "Per-user pricing-catalog service. Five load-bearing invariants pinned: (1) BuildForUser is the only entry point; renaming it silently breaks the handler. (2) ErrMePricingGroupForbidden is part of the documented error contract (403 mapping in handler) — losing the sentinel would let a refactor collapse it into a generic error and the handler would surface 500 instead. (3) The cross-platform leak guard (`m.Platform != targetGroup.Platform`) prevents an anthropic-platform model from bleeding into a newapi group's menu when a channel sits on groups across platforms; the same discipline is enforced in available_channel_handler.go and dropping it here would re-introduce the leak. (4) The unrestricted-account fallback for anthropic/openai uses supportedCatalogModelIDsForPlatform — the SAME empirically-servable allowlist the public /pricing catalog filters by (pricing_catalog_supported_models_tk.go) — so a native OAuth group whose accounts carry no channel and no model_mapping whitelist lists exactly the models that passed a live prod probe, not the canonical advertised set that includes upstream-rejected models (user_id=16 incident + 实测通过 directive). Dropping this reverts the menu to empty or re-introduces unservable models. (5) The platformDefaultModelIDs `case PlatformGrok:` arm gives the seventh platform (native OAuth, unrestricted accounts, no channel) its curated served set; losing it re-empties a grok group's 分组目录 (2026-06-20 incident)."
     },
     {
+      "path": "backend/internal/service/me_pricing_catalog_tk_test.go",
+      "must_contain": [
+        "TestBuildForUser_GrokUnrestricted_ListsServableModels",
+        "grok-4.3",
+        "grok-code-fast-1"
+      ],
+      "rationale": "Regression test for the grok per-user menu fallback: a native grok OAuth account has no channel and no model_mapping whitelist, so BuildForUser must populate the menu from supportedCatalogModelIDsForPlatform(PlatformGrok) and join catalog token prices for both current grok chat (grok-4.3) and the grok-build alias family (grok-code-fast-1). Dropping this test re-opens the 2026-06-20 empty-grok-group class and the newer official-priced grok chat visibility regression."
+    },
+    {
       "path": "backend/internal/handler/me_pricing_catalog_handler_tk.go",
       "must_contain": [
         "middleware.GetAuthSubjectFromContext(c)",
@@ -1627,20 +1636,32 @@
       "must_contain": [
         "func (r *AntigravityConfigReconciler) runOnce(",
         "func antigravityCanServeExcluded(",
+        "domain.IsAntigravityStructuralDeadModelMappingKey",
         "domain.GeminiOnlyAntigravityModelMapping",
         "func (r *AntigravityConfigReconciler) reconcileGroups(",
         "func antigravityGroupScopesNeedGeminiOnly(",
         "domain.GeminiOnlyAntigravityModelScopes"
       ],
-      "rationale": "Per-node in-process self-healer that enforces the operator policy 'Antigravity serves gemini only' on TWO surfaces: (1) accounts — rewrites every antigravity account's credentials.model_mapping to domain.GeminiOnlyAntigravityModelMapping (antigravityCanServeExcluded drift predicate); (2) groups — rewrites every active antigravity group's supported_model_scopes to domain.GeminiOnlyAntigravityModelScopes (antigravityGroupScopesNeedGeminiOnly drift predicate, reconcileGroups), so /antigravity/v1/models + the API key usage guide hide claude for newly-created / drifted groups too. It is a plain-named (non-_tk_) service file that is compile-clean if dropped, so an upstream merge or refactor could silently delete either half and the gemini-only auto-sync would stop with no test failure. Both drift predicates must stay aligned with the post-rollout check ops/antigravity/check-antigravity-account-config.py (accounts + groups same口径); weakening antigravityCanServeExcluded back to a two-id probe re-opens the claude-leak the reconciler exists to close (xj-review R-001); dropping reconcileGroups re-opens claude in /models + usage guide for new groups."
+      "rationale": "Per-node in-process self-healer that enforces the operator policy 'Antigravity serves gemini only' on TWO surfaces: (1) accounts — rewrites every antigravity account's credentials.model_mapping to domain.GeminiOnlyAntigravityModelMapping (antigravityCanServeExcluded drift predicate, including PR #921 structural-dead aliases via domain.IsAntigravityStructuralDeadModelMappingKey); (2) groups — rewrites every active antigravity group's supported_model_scopes to domain.GeminiOnlyAntigravityModelScopes (antigravityGroupScopesNeedGeminiOnly drift predicate, reconcileGroups), so /antigravity/v1/models + the API key usage guide hide claude for newly-created / drifted groups too. It is a plain-named (non-_tk_) service file that is compile-clean if dropped, so an upstream merge or refactor could silently delete either half and the gemini-only auto-sync would stop with no test failure. Both drift predicates must stay aligned with the post-rollout check ops/antigravity/check-antigravity-account-config.py (accounts + groups same口径); weakening antigravityCanServeExcluded back to a two-id probe re-opens the claude/stale-alias leak the reconciler exists to close; dropping reconcileGroups re-opens claude in /models + usage guide for new groups."
     },
     {
       "path": "backend/internal/domain/constants.go",
       "must_contain": [
         "func buildGeminiOnlyAntigravityModelMapping(",
-        "strings.HasPrefix(k, \"claude-\") || strings.HasPrefix(k, \"gpt-oss-\")"
+        "strings.HasPrefix(k, \"claude-\") || strings.HasPrefix(k, \"gpt-oss-\")",
+        "antigravityStructuralDeadModelMappingKeys",
+        "func IsAntigravityStructuralDeadModelMappingKey("
       ],
-      "rationale": "GeminiOnlyAntigravityModelMapping — the canonical map the AntigravityConfigReconciler writes onto every antigravity account — is derived once at package init from DefaultAntigravityModelMapping by dropping claude-* / gpt-oss-* keys. A silent upstream-merge change to (or removal of) the builder's prefix filter would let claude/gpt-oss back into the map the reconciler writes, i.e. silently serve claude on antigravity — the exact backward-drift this guards. Locked by TestGeminiOnlyAntigravityModelMapping too; this sentinel additionally catches a source revert that lands without the test running."
+      "rationale": "GeminiOnlyAntigravityModelMapping — the canonical map the AntigravityConfigReconciler writes onto every antigravity account — is derived once at package init from DefaultAntigravityModelMapping by dropping claude-* / gpt-oss-* keys and PR #921-confirmed structural-dead antigravity aliases. A silent upstream-merge change to (or removal of) either filter would let excluded families or stale request aliases back into the map the reconciler writes, i.e. silently serve claude on antigravity or re-widen the DB mapping surface. Locked by TestGeminiOnlyAntigravityModelMapping too; this sentinel additionally catches a source revert that lands without the test running."
+    },
+    {
+      "path": "backend/migrations/tk_043_prune_antigravity_structural_dead_mapping.sql",
+      "must_contain": [
+        "gemini-3-pro-high",
+        "gemini-3.1-pro-preview",
+        "INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)"
+      ],
+      "rationale": "DB hygiene migration for the #921-confirmed antigravity structural-dead aliases found on the four live persisted mappings (edge us3/us4 plus prod 61/62). The migration must keep the exact stale-key removal and enqueue scheduler account_changed events; otherwise running replicas keep stale mapping snapshots until a full rebuild, and future releases can re-advertise dead aliases even though the canonical reconciler map excludes them."
     },
     {
       "path": "backend/internal/domain/constants.go",

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -69,8 +69,8 @@
     },
     {
       "path": "backend/internal/service/tk_pricing_overlay.json",
-      "must_contain": ["grok-imagine-image", "grok-imagine-video"],
-      "rationale": "Grok image AND video pricing rows. Image models with no usable static price are REJECTED with a pre-spend 400 by TkImageModelUnpriced, and video models likewise by TkVideoModelUnpriced — so losing these rows makes grok image/video generation fail outright (not just bill $0). grok-imagine-video is priced per output second at the MAX reachable tier ($0.08/s, 720p+input) per the overlay's never-under-charge convention."
+      "must_contain": ["grok-4.3", "grok-build-0.1", "grok-imagine-image", "grok-imagine-video"],
+      "rationale": "Grok pricing rows. Chat models with no usable token price still serve and alert, so losing grok-4.3 / grok-build-0.1 would re-open the served-zero-cost grok chat hole; image models with no usable static price are REJECTED with a pre-spend 400 by TkImageModelUnpriced, and video models likewise by TkVideoModelUnpriced — so losing media rows makes grok image/video generation fail outright. grok-imagine-video is priced per output second at the MAX reachable tier ($0.08/s, 720p+input) per the overlay's never-under-charge convention."
     },
     {
       "path": "backend/migrations/tk_028_allow_grok_model_availability_platform.sql",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -80,7 +80,7 @@
         "servable-allowlist:begin antigravity",
         "servable-allowlist:begin grok"
       ],
-      "rationale": "Single source for the empirically-servable claude + gpt sets, shared by the public /pricing presentation filter (FilterPublicCatalogToServable) and the Your-Menu unrestricted-account fallback (supportedCatalogModelIDsForPlatform). Losing the allowlist vars would silently widen both surfaces back to the full unservable set; losing the funcs breaks both call sites. The `servable-allowlist:begin/end` splice markers are load-bearing for ops/pricing/refresh-servable-allowlist.py (it rewrites the maps between them); an upstream merge that drops the markers would break the re-runnable refresh. The antigravity allowlist (supportedAntigravityCatalogModels, gemini-only per operator policy — claude routed to anthropic, gpt-oss off antigravity) is hand-maintained from the 2026-06-13 empirical probe (the refresh tool has no antigravity family, so it never rewrites the antigravity anchors); losing it silently reverts antigravity to passthrough. The grok allowlist (supportedGrokCatalogModels, the four priced grok-imagine/grok-code-fast-1 overlay rows) is likewise hand-maintained (the refresh tool has no grok family); losing it silently empties a grok group's 分组目录 again (2026-06-20 incident). Other vendors (deepseek, …) intentionally pass through — claude + gpt + antigravity-gemini + grok are curated."
+      "rationale": "Single source for the empirically-servable claude + gpt sets, shared by the public /pricing presentation filter (FilterPublicCatalogToServable) and the Your-Menu unrestricted-account fallback (supportedCatalogModelIDsForPlatform). Losing the allowlist vars would silently widen both surfaces back to the full unservable set; losing the funcs breaks both call sites. The `servable-allowlist:begin/end` splice markers are load-bearing for ops/pricing/refresh-servable-allowlist.py (it rewrites the maps between them); an upstream merge that drops the markers would break the re-runnable refresh. The antigravity allowlist (supportedAntigravityCatalogModels, gemini-only per operator policy — claude routed to anthropic, gpt-oss off antigravity) is hand-maintained from the 2026-06-13 empirical probe (the refresh tool has no antigravity family, so it never rewrites the antigravity anchors); losing it silently reverts antigravity to passthrough. The grok allowlist (supportedGrokCatalogModels: priced grok-imagine media + official-priced grok chat ids that returned 200 on the native grok edge probe) is likewise hand-maintained; losing it silently empties a grok group's 分组目录 again (2026-06-20 incident). Other vendors (deepseek, …) intentionally pass through — claude + gpt + antigravity-gemini + grok are curated."
     },
     {
       "path": "backend/internal/service/pricing_catalog_candidates_tk.go",
@@ -140,9 +140,11 @@
     {
       "path": "scripts/checks/pricing-overlay.py",
       "must_contain": [
-        "failure_billing"
+        "failure_billing",
+        "grok-4.3",
+        "grok-build-0.1"
       ],
-      "rationale": "The failure_billing declaration check is the human-judgment anchor of the video pricing workflow: TokenKey refunds users in full on terminal-failed video tasks, which is only loss-free when the provider does not charge for failures — whoever prices a video model must verify and declare that. Dropping this block from the check silently removes the forced verification while overlay entries keep parsing fine."
+      "rationale": "The failure_billing declaration check is the human-judgment anchor of the video pricing workflow: TokenKey refunds users in full on terminal-failed video tasks, which is only loss-free when the provider does not charge for failures — whoever prices a video model must verify and declare that. Dropping this block from the check silently removes the forced verification while overlay entries keep parsing fine. The grok-4.3 / grok-build-0.1 anchors keep xAI's two current chat price roots pinned in the same overlay gate, so a future edit cannot re-create the served-zero-cost grok chat hole while leaving media anchors intact."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_media_unpriced_guard_contract_test.go",


### PR DESCRIPTION
## 做了什么

本 PR 将 #933 和 #938 合并成一个 catalog/pricing PR：一次性补齐 `qwen-turbo`、官方价 Grok chat 目录，以及 antigravity 结构性死映射清理。

### Qwen：新增可服务且可定价的 `qwen-turbo`

`qwen-turbo` 已接入 Qwen newapi 账号 60：

- 新增 `tk_042_qwen_turbo_model_mapping.sql`，把 `qwen-turbo` identity-merge 到 account 60 的 `credentials.model_mapping`，并写入 `scheduler_outbox account_changed` 让调度快照刷新。
- 在 `tk_served_models.json` 记录 `newapi/qwen-turbo`：served on account 60、channel_type 17、`display=false`。
- 在 `tk_pricing_overlay.json` 按 Alibaba DashScope 中国内地官方价定价：input ¥0.3/M、非思考 output ¥0.6/M，按 6.7 折算 USD。
- 商用 qwen 默认 `enable_thinking=false`，因此只建模非思考价；思考 output tier 刻意不建模，和 `qwen-plus` 保持同一口径。

说明：newapi net-new 模型在映射前会被网关 empty-pool / not_allowlisted gate 拦在转发前，因此 pre-map probe 会返回 429，不能证明上游不可达。此项按“映射 + 定价同发版，合并部署后 livefire 坐实”的路径处理。

### Grok：新增官方价且实测可达的可见模型

公开目录和用户菜单新增官方 xAI 定价、edge-us4 实测 200 的 Grok chat 模型：

- `grok-4.3`
- `grok-4.20-0309-reasoning`
- `grok-4.20-0309-non-reasoning`
- `grok-build-0.1`
- 保留已有可见项 `grok-code-fast-1`，并重定价为当前官方 `grok-build-0.1` alias 价

以下兼容 alias 只定价、不公开展示，避免目录出现重复 alias / dated SKU，但显式请求不会 $0 计费：

- `grok-4.3-latest`
- `grok-latest`
- `grok-4-fast-reasoning`
- `grok-code-fast`
- `grok-code-fast-1-0825`

价格来源只使用官方 xAI 文档：`docs.x.ai/developers/pricing`、`docs.x.ai/developers/models/grok-code-fast-1`，以及 xAI May 15 retirement 页面中 `grok-4-fast-reasoning` redirect 到 `grok-4.3` 并按 `grok-4.3` 计价的说明。未使用第三方博客或聚合源价格。

### Grok：补 probe 支持

扩展 `ops/pricing/probe-servable-models.sh` / `refresh-servable-allowlist.py`，支持通过 edge 内部 app container 探测 native grok family（`GROK_CHAT_MODELS`）。

2026-06-22 edge-us4 live probe 结果：

- `grok-4.3`、`grok-4.3-latest`、`grok-latest` -> 200
- `grok-4-fast-reasoning` -> 200
- `grok-4.20-0309-reasoning`、`grok-4.20-0309-non-reasoning` -> 200
- `grok-build-0.1`、`grok-code-fast`、`grok-code-fast-1`、`grok-code-fast-1-0825` -> 200
- 未纳入公开目录：429 rate/empty-pool 的 inconclusive 候选，以及 `grok-4.20-multi-agent-0309` 400

### Antigravity：清理结构性死映射

新增 `tk_043_prune_antigravity_structural_dead_mapping.sql`，从 antigravity 持久化账号的 `credentials.model_mapping` 删除 8 个 #921-confirmed structural-dead alias，并写入 `scheduler_outbox account_changed`。

只读 SSM 快照确认清理范围为 4 个账号：edge `us3` account 3、edge `us4` account 5、prod accounts 61/62，均携带同一组 8 个 stale keys。

默认兼容映射仍保留 legacy request id 的 remap；但 `GeminiOnlyAntigravityModelMapping` 和 reconciler 不再把这些 stale alias 写回 canonical account mapping。

## Review

已做两路只读 review，均未发现阻塞问题：

- pricing/catalog 切面：`qwen-turbo` 的 manifest / price / migration 意图一致；Grok 可见 ID 均已定价，兼容 alias 只定价不公开展示。
- migration/ops/reconciler 切面：`tk_042` / `tk_043` 幂等且有 outbox refresh；antigravity structural-dead alias 口径一致；Grok probe 的 `|| true` 只会产生 `000/inconclusive`，不会误判为 `servable`，也不会被 refresh apply 写回 Grok allowlist。

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `go test -tags=unit ./internal/domain ./internal/service -run 'Test(GeminiOnlyAntigravityModelMapping|DefaultAntigravityModelMapping|AntigravityReconciler|AntigravityGatewayService_GetMappedModel|AccountGetModelMapping_Antigravity|GatewayService_isModelSupportedByAccount_Antigravity|IsPublicCatalogModelSupported|SupportedCatalogModelIDsForPlatform_(Antigravity|Grok)|BuildForUser_GrokUnrestricted_ListsServableModels|ServableClientFacingIDs)'`
- `go test -tags=integration ./internal/repository -run 'TestMigrationsRunner_IsIdempotent_AndSchemaIsUpToDate' -count=1`
- `python3 scripts/checks/pricing-overlay.py`
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`
- `python3 scripts/sentinels/check-grok.py --quiet`
- `python3 scripts/sentinels/check-antigravity.py --quiet`
- `python3 scripts/sentinels/check-pricing-availability.py --quiet`
- `python3 scripts/checks/catalog-serving-drift.py --quiet`
- `python3 ops/pricing/refresh-servable-allowlist.py selftest`
- `python3 -m unittest ops/antigravity/test_check_antigravity_account_config.py`
- `git diff --check`

CI 状态：#938 当前全部非 skipped checks 通过，merge state 为 `CLEAN`。

no-web-impact: 仅修改后端 catalog/pricing 数据、probe/检查脚本和 antigravity account-mapping hygiene；现有 pricing/menu UI 继续消费同一组通用 API 字段，无 Web surface 变更。

## Supersedes

Supersedes #933。本 PR 已包含 #933 的 `qwen-turbo` onboarding，以及 #938 原本的官方 Grok catalog 和 antigravity cleanup。

## 不在范围

- 不做 Veo livefire / onboarding。
- 不做 GLM onboarding；仍阻塞于 operator 账号、真实 key、channel setup 和官方价抓取。
