### PR TITLE
fix(studio): preserve generated video previews

### DIFF
--- a/backend/internal/handler/openai_gateway_tk_video_s3.go
+++ b/backend/internal/handler/openai_gateway_tk_video_s3.go
@@ -3,10 +3,14 @@ package handler
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"net/http"
+	"net/url"
+	"path"
 	"strings"
 	"time"
 
+	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -21,6 +25,14 @@ import (
 // is the EC2 instance role, whose session credentials cap the effective lifetime
 // anyway, and VideoFetch re-mints from the stored S3 key on demand (fast path).
 const mediaPresignTTL = time.Hour
+
+const (
+	videoURLDownloadMaxBytes = 128 << 20
+	videoURLDownloadTimeout  = 90 * time.Second
+	videoURLDeepScanMaxDepth = 4
+)
+
+var downloadPublicVideoURL = pkghttputil.DownloadPublicURL
 
 // SetMediaStore wires the media-offload store post-construction. Mirrors
 // SetVideoTaskCache (CLAUDE.md §5 — keep the upstream-shape constructor stable).
@@ -45,17 +57,17 @@ func (h *OpenAIGatewayHandler) tkVideoFastPathFromS3(c *gin.Context, rec *servic
 			zap.String("public_task_id", rec.PublicTaskID), zap.Error(err))
 		return false
 	}
-	writeVideoURLSuccess(c, url)
+	writeVideoURLSuccess(c, url, rec.MediaS3Key)
 	return true
 }
 
-// tkMaybeOffloadVideoToS3 transforms a TERMINAL-SUCCESS fetch response whose body
-// carries inline base64 video (Veo operation shape) into one carrying a presigned
-// S3 URL: decode → upload → store the key on the record → strip the base64 and set
-// top-level `video_url`. Returns the rewritten body and true when it offloaded;
+// tkMaybeOffloadVideoToS3 transforms a TERMINAL-SUCCESS fetch response carrying
+// generated video bytes (inline base64) or a short-lived upstream video URL into
+// one carrying a TokenKey-owned presigned S3 URL: download/decode → upload → store
+// the key on the record → set top-level `video_url`. Returns the rewritten body and true when it offloaded;
 // (nil, false) means "pass the upstream body through unchanged" — store disabled,
-// not a success, no inline base64 (upstream already returned a URL), or any
-// best-effort failure (we never fail a generated+billed video over offload).
+// not a success, no media URL/bytes, or any best-effort failure (we never fail a
+// generated+billed video over offload).
 func (h *OpenAIGatewayHandler) tkMaybeOffloadVideoToS3(ctx context.Context, rec *service.VideoTaskRecord, out *bridge.VideoFetchOutcome) ([]byte, bool) {
 	if h.mediaStore == nil || rec == nil || out == nil || len(out.RawResponse) == 0 {
 		return nil, false
@@ -64,17 +76,39 @@ func (h *OpenAIGatewayHandler) tkMaybeOffloadVideoToS3(ctx context.Context, rec 
 		return nil, false
 	}
 	b64, mime := extractInlineVideoBase64(out.RawResponse)
-	if b64 == "" {
-		return nil, false // upstream already returns a URL (doubao/volc) → passthrough
+	if b64 != "" {
+		data, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil || len(data) == 0 {
+			logger.L().Warn("openai_video_fetch.s3_b64_decode_failed",
+				zap.String("public_task_id", rec.PublicTaskID), zap.Error(err))
+			return nil, false
+		}
+		return h.tkStoreVideoMedia(ctx, rec, out.RawResponse, data, mediaContentType(mime))
 	}
-	data, err := base64.StdEncoding.DecodeString(b64)
-	if err != nil || len(data) == 0 {
-		logger.L().Warn("openai_video_fetch.s3_b64_decode_failed",
+
+	// Some upstreams return a short-lived hosted video_url instead of inline
+	// bytes. If we pass that URL through, the Studio can persist only an upstream
+	// preview link that later opens to "preview expired". Re-host it immediately
+	// while the URL is fresh, then future opens re-presign from our MediaStore.
+	videoURL := extractVideoURLFromBody(out.RawResponse)
+	if videoURL == "" {
+		return nil, false
+	}
+	download, err := downloadPublicVideoURL(ctx, videoURL, videoURLDownloadMaxBytes, videoURLDownloadTimeout)
+	if err != nil {
+		logger.L().Warn("openai_video_fetch.s3_url_download_failed",
 			zap.String("public_task_id", rec.PublicTaskID), zap.Error(err))
 		return nil, false
 	}
-	key := "media/videos/" + rec.PublicTaskID + videoExtForMime(mime)
-	if err := h.mediaStore.Upload(ctx, key, data, mediaContentType(mime)); err != nil {
+	return h.tkStoreVideoMedia(ctx, rec, out.RawResponse, download.Body, mediaContentTypeForVideoURL(videoURL, download.ContentType))
+}
+
+func (h *OpenAIGatewayHandler) tkStoreVideoMedia(ctx context.Context, rec *service.VideoTaskRecord, rawBody []byte, data []byte, contentType string) ([]byte, bool) {
+	if len(data) == 0 {
+		return nil, false
+	}
+	key := "media/videos/" + rec.PublicTaskID + videoExtForMime(contentType)
+	if err := h.mediaStore.Upload(ctx, key, data, mediaContentType(contentType)); err != nil {
 		logger.L().Warn("openai_video_fetch.s3_upload_failed",
 			zap.String("public_task_id", rec.PublicTaskID), zap.Int("bytes", len(data)), zap.Error(err))
 		return nil, false
@@ -96,7 +130,7 @@ func (h *OpenAIGatewayHandler) tkMaybeOffloadVideoToS3(ctx context.Context, rec 
 	}
 	logger.L().Info("openai_video_fetch.s3_offloaded",
 		zap.String("public_task_id", rec.PublicTaskID), zap.String("key", key), zap.Int("bytes", len(data)))
-	return rewriteVideoBodyWithURL(out.RawResponse, url), true
+	return rewriteVideoBodyWithURL(rawBody, url, key), true
 }
 
 // extractInlineVideoBase64 pulls the inline base64 clip + its mime out of a Veo
@@ -120,7 +154,7 @@ func extractInlineVideoBase64(body []byte) (b64, mime string) {
 // presigned URL — which is exactly the field extractVideoUrl's URL branch reads.
 // All other upstream fields (done/status/error) are preserved so videoStateFromFetch
 // still classifies the task as succeeded.
-func rewriteVideoBodyWithURL(body []byte, url string) []byte {
+func rewriteVideoBodyWithURL(body []byte, url string, s3Key string) []byte {
 	out := body
 	for _, p := range []string{"response.videos", "response.bytesBase64Encoded", "response.video"} {
 		if b, err := sjson.DeleteBytes(out, p); err == nil {
@@ -130,16 +164,90 @@ func rewriteVideoBodyWithURL(body []byte, url string) []byte {
 	if b, err := sjson.SetBytes(out, "video_url", url); err == nil {
 		out = b
 	}
+	if s3Key != "" {
+		if b, err := sjson.SetBytes(out, "s3_key", s3Key); err == nil {
+			out = b
+		}
+	}
 	return out
 }
 
 // writeVideoURLSuccess writes the minimal success body the frontend needs: done=true
 // (videoStateFromFetch ⇒ succeeded) + video_url (extractVideoUrl ⇒ the URL).
-func writeVideoURLSuccess(c *gin.Context, url string) {
+func writeVideoURLSuccess(c *gin.Context, url string, s3Key string) {
 	c.Header("Content-Type", "application/json")
 	c.Status(http.StatusOK)
 	body, _ := sjson.SetBytes([]byte(`{"done":true}`), "video_url", url)
+	if s3Key != "" {
+		body, _ = sjson.SetBytes(body, "s3_key", s3Key)
+	}
 	_, _ = c.Writer.Write(body)
+}
+
+func extractVideoURLFromBody(body []byte) string {
+	for _, p := range []string{"content.video_url", "data.video_url", "video_url", "data.url"} {
+		if v := gjson.GetBytes(body, p).String(); isHTTPVideoURLCandidate(v) {
+			return v
+		}
+	}
+	var decoded any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return ""
+	}
+	return deepScanVideoURL(decoded, 0)
+}
+
+func deepScanVideoURL(node any, depth int) string {
+	if depth > videoURLDeepScanMaxDepth {
+		return ""
+	}
+	switch v := node.(type) {
+	case []any:
+		for _, item := range v {
+			if hit := deepScanVideoURL(item, depth+1); hit != "" {
+				return hit
+			}
+		}
+	case map[string]any:
+		for key, value := range v {
+			s, ok := value.(string)
+			if !ok || !isHTTPVideoURLCandidate(s) {
+				continue
+			}
+			k := strings.ToLower(key)
+			if strings.Contains(k, "video") || hasVideoFileExt(s) {
+				return s
+			}
+		}
+		for _, value := range v {
+			if hit := deepScanVideoURL(value, depth+1); hit != "" {
+				return hit
+			}
+		}
+	}
+	return ""
+}
+
+func isHTTPVideoURLCandidate(v string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(v))
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	return scheme == "https" || scheme == "http"
+}
+
+func hasVideoFileExt(v string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(v))
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(path.Ext(parsed.Path)) {
+	case ".mp4", ".webm", ".mov", ".m4v":
+		return true
+	default:
+		return false
+	}
 }
 
 func videoExtForMime(mime string) string {
@@ -156,6 +264,24 @@ func videoExtForMime(mime string) string {
 func mediaContentType(mime string) string {
 	if m := strings.ToLower(strings.TrimSpace(mime)); strings.HasPrefix(m, "video/") {
 		return m
+	}
+	return "video/mp4"
+}
+
+func mediaContentTypeForVideoURL(videoURL string, contentType string) string {
+	if semi := strings.IndexByte(contentType, ';'); semi >= 0 {
+		contentType = contentType[:semi]
+	}
+	if m := mediaContentType(contentType); m != "video/mp4" || strings.HasPrefix(strings.ToLower(strings.TrimSpace(contentType)), "video/") {
+		return m
+	}
+	if parsed, err := url.Parse(strings.TrimSpace(videoURL)); err == nil {
+		switch strings.ToLower(path.Ext(parsed.Path)) {
+		case ".webm":
+			return "video/webm"
+		case ".mov":
+			return "video/quicktime"
+		}
 	}
 	return "video/mp4"
 }

--- a/backend/internal/handler/openai_gateway_tk_video_s3.go
+++ b/backend/internal/handler/openai_gateway_tk_video_s3.go
@@ -150,10 +150,10 @@ func extractInlineVideoBase64(body []byte) (b64, mime string) {
 }
 
 // rewriteVideoBodyWithURL strips every inline-base64 path extractVideoUrl checks
-// (so it can't return a now-empty data: URI) and sets top-level `video_url` to the
-// presigned URL — which is exactly the field extractVideoUrl's URL branch reads.
-// All other upstream fields (done/status/error) are preserved so videoStateFromFetch
-// still classifies the task as succeeded.
+// (so it can't return a now-empty data: URI) and replaces every known URL path
+// extractVideoUrl prefers with the presigned URL. All other upstream fields
+// (done/status/error) are preserved so videoStateFromFetch still classifies the
+// task as succeeded.
 func rewriteVideoBodyWithURL(body []byte, url string, s3Key string) []byte {
 	out := body
 	for _, p := range []string{"response.videos", "response.bytesBase64Encoded", "response.video"} {
@@ -161,8 +161,13 @@ func rewriteVideoBodyWithURL(body []byte, url string, s3Key string) []byte {
 			out = b
 		}
 	}
-	if b, err := sjson.SetBytes(out, "video_url", url); err == nil {
-		out = b
+	for _, p := range []string{"content.video_url", "data.video_url", "video_url", "data.url"} {
+		if p != "video_url" && !gjson.GetBytes(out, p).Exists() {
+			continue
+		}
+		if b, err := sjson.SetBytes(out, p, url); err == nil {
+			out = b
+		}
 	}
 	if s3Key != "" {
 		if b, err := sjson.SetBytes(out, "s3_key", s3Key); err == nil {

--- a/backend/internal/handler/openai_gateway_tk_video_s3_test.go
+++ b/backend/internal/handler/openai_gateway_tk_video_s3_test.go
@@ -69,20 +69,35 @@ func TestExtractInlineVideoBase64(t *testing.T) {
 func TestRewriteVideoBodyWithURL(t *testing.T) {
 	b64 := base64.StdEncoding.EncodeToString([]byte("FAKEMP4"))
 	url := "https://s3.example.test/media/videos/vt_x.mp4"
-	r := gjson.ParseBytes(rewriteVideoBodyWithURL(veoSuccessBody(b64, "video/mp4"), url, "media/videos/vt_x.mp4"))
-	// base64 must be GONE (else extractVideoUrl returns a now-empty data: URI).
-	if r.Get("response.videos").Exists() {
-		t.Fatalf("response.videos not stripped: %s", r.Raw)
-	}
-	if r.Get("video_url").String() != url {
-		t.Fatalf("video_url not set: %s", r.Raw)
-	}
-	if !r.Get("done").Bool() {
-		t.Fatalf("done flag lost (videoStateFromFetch would misclassify): %s", r.Raw)
-	}
-	if r.Get("s3_key").String() != "media/videos/vt_x.mp4" {
-		t.Fatalf("s3_key not set: %s", r.Raw)
-	}
+	t.Run("inline base64 is stripped and top-level URL is set", func(t *testing.T) {
+		r := gjson.ParseBytes(rewriteVideoBodyWithURL(veoSuccessBody(b64, "video/mp4"), url, "media/videos/vt_x.mp4"))
+		// base64 must be GONE (else extractVideoUrl returns a now-empty data: URI).
+		if r.Get("response.videos").Exists() {
+			t.Fatalf("response.videos not stripped: %s", r.Raw)
+		}
+		if r.Get("video_url").String() != url {
+			t.Fatalf("video_url not set: %s", r.Raw)
+		}
+		if !r.Get("done").Bool() {
+			t.Fatalf("done flag lost (videoStateFromFetch would misclassify): %s", r.Raw)
+		}
+		if r.Get("s3_key").String() != "media/videos/vt_x.mp4" {
+			t.Fatalf("s3_key not set: %s", r.Raw)
+		}
+	})
+
+	t.Run("known nested URL fields are replaced", func(t *testing.T) {
+		body := rewriteVideoBodyWithURL([]byte(`{"done":true,"content":{"video_url":"https://provider.example/a.mp4"},"data":{"video_url":"https://provider.example/b.mp4","url":"https://provider.example/c.mp4"}}`), url, "media/videos/vt_x.mp4")
+		r := gjson.ParseBytes(body)
+		for _, p := range []string{"content.video_url", "data.video_url", "data.url", "video_url"} {
+			if r.Get(p).String() != url {
+				t.Fatalf("%s not rewritten to TokenKey URL: %s", p, r.Raw)
+			}
+		}
+		if r.Get("s3_key").String() != "media/videos/vt_x.mp4" {
+			t.Fatalf("s3_key not set: %s", r.Raw)
+		}
+	})
 }
 
 func TestVideoExtAndContentType(t *testing.T) {
@@ -183,8 +198,8 @@ func TestMaybeOffloadVideoToS3(t *testing.T) {
 		if string(fs.uploads[wantKey]) != "URLMP4" {
 			t.Fatalf("uploaded bytes=%q want URLMP4", fs.uploads[wantKey])
 		}
-		if gjson.GetBytes(body, "content.video_url").String() != "https://x/y.mp4" {
-			t.Fatalf("original vendor body should be preserved: %s", body)
+		if gjson.GetBytes(body, "content.video_url").String() != "https://s3.example.test/"+wantKey {
+			t.Fatalf("nested provider URL should be replaced with TokenKey URL: %s", body)
 		}
 		if gjson.GetBytes(body, "video_url").String() != "https://s3.example.test/"+wantKey {
 			t.Fatalf("rewritten body missing TokenKey URL: %s", body)

--- a/backend/internal/handler/openai_gateway_tk_video_s3_test.go
+++ b/backend/internal/handler/openai_gateway_tk_video_s3_test.go
@@ -5,11 +5,13 @@ package handler
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
 	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
 	"github.com/Wei-Shaw/sub2api/internal/repository"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -67,7 +69,7 @@ func TestExtractInlineVideoBase64(t *testing.T) {
 func TestRewriteVideoBodyWithURL(t *testing.T) {
 	b64 := base64.StdEncoding.EncodeToString([]byte("FAKEMP4"))
 	url := "https://s3.example.test/media/videos/vt_x.mp4"
-	r := gjson.ParseBytes(rewriteVideoBodyWithURL(veoSuccessBody(b64, "video/mp4"), url))
+	r := gjson.ParseBytes(rewriteVideoBodyWithURL(veoSuccessBody(b64, "video/mp4"), url, "media/videos/vt_x.mp4"))
 	// base64 must be GONE (else extractVideoUrl returns a now-empty data: URI).
 	if r.Get("response.videos").Exists() {
 		t.Fatalf("response.videos not stripped: %s", r.Raw)
@@ -77,6 +79,9 @@ func TestRewriteVideoBodyWithURL(t *testing.T) {
 	}
 	if !r.Get("done").Bool() {
 		t.Fatalf("done flag lost (videoStateFromFetch would misclassify): %s", r.Raw)
+	}
+	if r.Get("s3_key").String() != "media/videos/vt_x.mp4" {
+		t.Fatalf("s3_key not set: %s", r.Raw)
 	}
 }
 
@@ -155,10 +160,53 @@ func TestMaybeOffloadVideoToS3(t *testing.T) {
 		}
 	})
 
-	t.Run("upstream-url body (no base64) passes through", func(t *testing.T) {
+	t.Run("upstream-url body downloads and offloads", func(t *testing.T) {
+		prev := downloadPublicVideoURL
+		downloadPublicVideoURL = func(_ context.Context, raw string, _ int64, _ time.Duration) (*pkghttputil.PublicURLDownload, error) {
+			if raw != "https://x/y.mp4" {
+				t.Fatalf("download url=%q want https://x/y.mp4", raw)
+			}
+			return &pkghttputil.PublicURLDownload{Body: []byte("URLMP4"), ContentType: "video/mp4"}, nil
+		}
+		defer func() { downloadPublicVideoURL = prev }()
+
 		fs := newFakeMediaStore()
-		if _, ok := mk(fs).tkMaybeOffloadVideoToS3(context.Background(), newRecord("vt_e", ""), out("success", []byte(`{"status":"succeeded","content":{"video_url":"https://x/y.mp4"}}`))); ok {
-			t.Fatal("url-shaped body must not offload")
+		rec := newRecord("vt_e", "")
+		body, ok := mk(fs).tkMaybeOffloadVideoToS3(context.Background(), rec, out("success", []byte(`{"status":"succeeded","content":{"video_url":"https://x/y.mp4"}}`)))
+		if !ok {
+			t.Fatal("url-shaped body should offload while upstream URL is fresh")
+		}
+		wantKey := "media/videos/vt_e.mp4"
+		if rec.MediaS3Key != wantKey {
+			t.Fatalf("rec.MediaS3Key=%q want %q", rec.MediaS3Key, wantKey)
+		}
+		if string(fs.uploads[wantKey]) != "URLMP4" {
+			t.Fatalf("uploaded bytes=%q want URLMP4", fs.uploads[wantKey])
+		}
+		if gjson.GetBytes(body, "content.video_url").String() != "https://x/y.mp4" {
+			t.Fatalf("original vendor body should be preserved: %s", body)
+		}
+		if gjson.GetBytes(body, "video_url").String() != "https://s3.example.test/"+wantKey {
+			t.Fatalf("rewritten body missing TokenKey URL: %s", body)
+		}
+		if gjson.GetBytes(body, "s3_key").String() != wantKey {
+			t.Fatalf("rewritten body missing s3_key: %s", body)
+		}
+	})
+
+	t.Run("upstream-url download failure degrades to passthrough", func(t *testing.T) {
+		prev := downloadPublicVideoURL
+		downloadPublicVideoURL = func(context.Context, string, int64, time.Duration) (*pkghttputil.PublicURLDownload, error) {
+			return nil, errors.New("expired")
+		}
+		defer func() { downloadPublicVideoURL = prev }()
+
+		fs := newFakeMediaStore()
+		if _, ok := mk(fs).tkMaybeOffloadVideoToS3(context.Background(), newRecord("vt_url_fail", ""), out("success", []byte(`{"status":"succeeded","content":{"video_url":"https://x/y.mp4"}}`))); ok {
+			t.Fatal("download error must degrade to passthrough (ok=false)")
+		}
+		if len(fs.uploads) != 0 {
+			t.Fatalf("no upload expected, got %d", len(fs.uploads))
 		}
 	})
 
@@ -188,7 +236,7 @@ func TestVideoFastPathFromS3(t *testing.T) {
 			t.Fatal("expected fast path to handle")
 		}
 		r := gjson.ParseBytes(w.Body.Bytes())
-		if !r.Get("done").Bool() || r.Get("video_url").String() != "https://s3.example.test/media/videos/vt_x.mp4" {
+		if !r.Get("done").Bool() || r.Get("video_url").String() != "https://s3.example.test/media/videos/vt_x.mp4" || r.Get("s3_key").String() != "media/videos/vt_x.mp4" {
 			t.Fatalf("fast-path body wrong: %s", w.Body.String())
 		}
 	})

--- a/backend/internal/pkg/httputil/public_download.go
+++ b/backend/internal/pkg/httputil/public_download.go
@@ -1,0 +1,232 @@
+package httputil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var publicDownloadBlockedHostnames = map[string]struct{}{
+	"localhost":                  {},
+	"localhost.localdomain":      {},
+	"metadata":                   {},
+	"metadata.google.internal":   {},
+	"metadata.goog":              {},
+	"instance-data":              {},
+	"instance-data.ec2.internal": {},
+}
+
+var publicDownloadBlockedCIDRs = mustParsePublicDownloadCIDRs([]string{
+	"127.0.0.0/8",
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"169.254.0.0/16",
+	"100.64.0.0/10",
+	"0.0.0.0/8",
+	"::1/128",
+	"fc00::/7",
+	"fe80::/10",
+	"::/128",
+})
+
+type PublicURLDownload struct {
+	Body        []byte
+	ContentType string
+}
+
+// DownloadPublicURL fetches a public HTTP(S) object with SSRF and size guards.
+// It is for server-side re-hosting of URLs returned by trusted upstream APIs:
+// private/link-local targets are rejected both before the request and at dial
+// time, redirects are re-validated, and the response body is hard-capped.
+func DownloadPublicURL(ctx context.Context, raw string, maxBytes int64, timeout time.Duration) (*PublicURLDownload, error) {
+	if maxBytes <= 0 {
+		return nil, errors.New("maxBytes must be positive")
+	}
+	parsed, err := validatePublicDownloadURL(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	reqCtx := ctx
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		reqCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "video/*,application/octet-stream;q=0.9,*/*;q=0.1")
+
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			Proxy:                 nil,
+			DialContext:           publicDownloadDialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          4,
+			IdleConnTimeout:       30 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 15 * time.Second,
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return errors.New("too many redirects")
+			}
+			_, err := validatePublicDownloadURL(req.URL.String())
+			return err
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return readPublicDownloadResponse(resp, maxBytes)
+}
+
+func readPublicDownloadResponse(resp *http.Response, maxBytes int64) (*PublicURLDownload, error) {
+	if resp == nil {
+		return nil, errors.New("empty response")
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("download HTTP %d", resp.StatusCode)
+	}
+	if resp.ContentLength > maxBytes {
+		return nil, fmt.Errorf("download too large: content-length %d > %d", resp.ContentLength, maxBytes)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("download too large: body exceeds %d bytes", maxBytes)
+	}
+	if len(body) == 0 {
+		return nil, errors.New("download body is empty")
+	}
+	return &PublicURLDownload{Body: body, ContentType: resp.Header.Get("Content-Type")}, nil
+}
+
+func validatePublicDownloadURL(raw string) (*url.URL, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, errors.New("url is required")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid url: %s", trimmed)
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "https" && scheme != "http" {
+		return nil, fmt.Errorf("invalid url scheme: %s", parsed.Scheme)
+	}
+	if parsed.User != nil {
+		return nil, errors.New("url userinfo is not allowed")
+	}
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	if host == "" || isPublicDownloadBlockedHostname(host) {
+		return nil, fmt.Errorf("host is not allowed: %s", host)
+	}
+	if ip := net.ParseIP(host); ip != nil && isPublicDownloadPrivateIP(ip) {
+		return nil, fmt.Errorf("host is not allowed: %s", host)
+	}
+	if port := parsed.Port(); port != "" {
+		num, err := strconv.Atoi(port)
+		if err != nil || num <= 0 || num > 65535 {
+			return nil, fmt.Errorf("invalid port: %s", port)
+		}
+	}
+	return parsed, nil
+}
+
+func publicDownloadDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if isPublicDownloadPrivateIP(ip) {
+			return nil, &net.AddrError{Err: "blocked by SSRF policy", Addr: address}
+		}
+		return (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext(ctx, network, address)
+	}
+	if isPublicDownloadBlockedHostname(host) {
+		return nil, &net.AddrError{Err: "blocked by SSRF policy", Addr: address}
+	}
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if len(addrs) == 0 {
+		return nil, &net.AddrError{Err: "no addresses for host", Addr: host}
+	}
+	dialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	var lastErr error
+	for _, addr := range addrs {
+		if isPublicDownloadPrivateIP(addr.IP) {
+			lastErr = &net.AddrError{Err: "blocked by SSRF policy", Addr: addr.IP.String()}
+			continue
+		}
+		conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(addr.IP.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = &net.AddrError{Err: "no usable addresses", Addr: host}
+	}
+	return nil, lastErr
+}
+
+func isPublicDownloadBlockedHostname(hostname string) bool {
+	if hostname == "" {
+		return true
+	}
+	host := strings.ToLower(hostname)
+	if strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	_, blocked := publicDownloadBlockedHostnames[host]
+	return blocked
+}
+
+func isPublicDownloadPrivateIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsUnspecified() || ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsInterfaceLocalMulticast() {
+		return true
+	}
+	for _, n := range publicDownloadBlockedCIDRs {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func mustParsePublicDownloadCIDRs(cidrs []string) []*net.IPNet {
+	out := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			panic("public_download: invalid CIDR " + c + ": " + err.Error())
+		}
+		out = append(out, n)
+	}
+	return out
+}

--- a/backend/internal/pkg/httputil/public_download_test.go
+++ b/backend/internal/pkg/httputil/public_download_test.go
@@ -1,0 +1,86 @@
+package httputil
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidatePublicDownloadURL(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		ok   bool
+	}{
+		{"https public", "https://cdn.example.com/video.mp4?sig=1", true},
+		{"http public allowed", "http://cdn.example.com/video.mp4", true},
+		{"javascript rejected", "javascript:alert(1)", false},
+		{"userinfo rejected", "https://user:pass@cdn.example.com/video.mp4", false},
+		{"localhost rejected", "https://localhost/video.mp4", false},
+		{"localhost suffix rejected", "https://foo.localhost/video.mp4", false},
+		{"loopback rejected", "https://127.0.0.1/video.mp4", false},
+		{"private rejected", "https://10.0.0.1/video.mp4", false},
+		{"metadata rejected", "http://169.254.169.254/latest/meta-data", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validatePublicDownloadURL(tc.raw)
+			if tc.ok && err != nil {
+				t.Fatalf("expected valid URL, got %v", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatal("expected URL validation error")
+			}
+		})
+	}
+}
+
+func TestDownloadPublicURLRejectsLocalhostBeforeRequest(t *testing.T) {
+	_, err := DownloadPublicURL(context.Background(), "http://127.0.0.1/video.mp4", 4, time.Second)
+	if err == nil || !strings.Contains(err.Error(), "host is not allowed") {
+		t.Fatalf("expected host rejection, got %v", err)
+	}
+}
+
+func TestReadPublicDownloadResponseRejectsOversizedContentLength(t *testing.T) {
+	resp := &http.Response{
+		StatusCode:    http.StatusOK,
+		ContentLength: 10,
+		Body:          io.NopCloser(strings.NewReader("0123456789")),
+	}
+	_, err := readPublicDownloadResponse(resp, 4)
+	if err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("expected too-large error, got %v", err)
+	}
+}
+
+func TestReadPublicDownloadResponseRejectsOversizedChunkedBody(t *testing.T) {
+	resp := &http.Response{
+		StatusCode:    http.StatusOK,
+		ContentLength: -1,
+		Body:          io.NopCloser(strings.NewReader("0123456789")),
+	}
+	_, err := readPublicDownloadResponse(resp, 4)
+	if err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("expected too-large error, got %v", err)
+	}
+}
+
+func TestReadPublicDownloadResponseReturnsBodyAndContentType(t *testing.T) {
+	resp := &http.Response{
+		StatusCode:    http.StatusOK,
+		ContentLength: 3,
+		Header:        http.Header{"Content-Type": []string{"video/webm"}},
+		Body:          io.NopCloser(strings.NewReader("abc")),
+	}
+	got, err := readPublicDownloadResponse(resp, 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got.Body) != "abc" || got.ContentType != "video/webm" {
+		t.Fatalf("unexpected download: body=%q contentType=%q", got.Body, got.ContentType)
+	}
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 509,
-  "hash": "9684860bfebdef664ad8f3851197eddc5b08229a496381fafb372c52feaffbc5",
+  "hash": "5636d6697c3ba2a4c2ca54b3e234282a5b752030839dc12cb221a578a100fc27",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/composables/useMediaLibrary.ts
+++ b/frontend/src/composables/useMediaLibrary.ts
@@ -52,6 +52,8 @@ export interface VideoTaskItem {
   keyId: number
   state: VideoTaskState
   url: string
+  /** S3 key for backend-offloaded videos; enables future explicit re-presign paths. */
+  s3Key?: string
   submittedAtMs: number
   elapsedS: number
   errorMessage?: string

--- a/frontend/src/composables/useVideoTaskPoll.ts
+++ b/frontend/src/composables/useVideoTaskPoll.ts
@@ -16,7 +16,7 @@
  */
 import { onUnmounted } from 'vue'
 import { gatewayVideoFetch } from '@/api/playground'
-import { videoStateFromFetch, extractVideoUrl, type PlaygroundVideoState } from '@/constants/playgroundMedia.tk'
+import { videoStateFromFetch, extractVideoUrl, extractVideoS3Key, type PlaygroundVideoState } from '@/constants/playgroundMedia.tk'
 import type { VideoTaskItem } from '@/composables/useMediaLibrary'
 
 const POLL_INTERVAL_MS = 5_000
@@ -120,15 +120,16 @@ export function useVideoTaskPoll(opts: VideoTaskPollOptions): VideoTaskPoller {
       p.errors = 0
       const state = videoStateFromFetch(raw)
       const url = state === 'succeeded' ? extractVideoUrl(raw) : ''
+      const s3Key = state === 'succeeded' ? extractVideoS3Key(raw) || undefined : undefined
       // Clear any stale `errorMessage` (e.g. a prior 'key_unavailable' stall): a
       // successful fetch means the loop is making progress again, so the card must
       // not keep showing the "stalled" warning.
-      opts.patch(task.id, { state, url, errorMessage: undefined })
+      opts.patch(task.id, { state, url, s3Key, errorMessage: undefined })
       if (state === 'processing') {
         schedule(task)
       } else {
         stop(task.id)
-        opts.onTerminal?.({ ...task, state, url }, state)
+        opts.onTerminal?.({ ...task, state, url, s3Key }, state)
       }
     } catch (e) {
       if (ctrl.signal.aborted || !pollers.has(task.id)) return
@@ -165,7 +166,8 @@ export function useVideoTaskPoll(opts: VideoTaskPollOptions): VideoTaskPoller {
       const state = videoStateFromFetch(raw)
       if (state === 'succeeded') {
         const url = extractVideoUrl(raw)
-        if (url) opts.patch(task.id, { url })
+        const s3Key = extractVideoS3Key(raw) || undefined
+        if (url) opts.patch(task.id, { url, s3Key })
       }
       // Non-succeeded (e.g. record expired past TTL) → keep the cached URL; the
       // self-contained data: URL fallback still plays, and we never downgrade a

--- a/frontend/src/constants/__tests__/playgroundMedia.tk.spec.ts
+++ b/frontend/src/constants/__tests__/playgroundMedia.tk.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   extractChatImageItems,
   extractImageItems,
+  extractVideoS3Key,
   extractVideoTaskId,
   extractVideoUrl,
   isGeminiNativeImageModel,
@@ -226,8 +227,19 @@ describe('video task helpers', () => {
     // Cross-layer contract with the backend transform (rewriteVideoBodyWithURL):
     // the Veo success body has its inline base64 removed and a presigned URL set
     // at top-level video_url. Both helpers must still resolve it as a ready video.
-    const rewritten = { done: true, response: {}, video_url: 'https://s3.example.test/media/videos/vt_x.mp4' }
+    const rewritten = {
+      done: true,
+      response: {},
+      video_url: 'https://s3.example.test/media/videos/vt_x.mp4',
+      s3_key: 'media/videos/vt_x.mp4'
+    }
     expect(videoStateFromFetch(rewritten)).toBe('succeeded')
     expect(extractVideoUrl(rewritten)).toBe('https://s3.example.test/media/videos/vt_x.mp4')
+    expect(extractVideoS3Key(rewritten)).toBe('media/videos/vt_x.mp4')
+  })
+
+  it('rejects non-video s3_key values on video responses', () => {
+    expect(extractVideoS3Key({ s3_key: 'media/images/x.png' })).toBe('')
+    expect(extractVideoS3Key({ s3_key: 'https://s3.example/media/videos/x.mp4' })).toBe('')
   })
 })

--- a/frontend/src/constants/playgroundMedia.tk.ts
+++ b/frontend/src/constants/playgroundMedia.tk.ts
@@ -280,6 +280,14 @@ export function extractVideoUrl(resp: unknown): string {
   return deepScanVideoUrl(root, 0)
 }
 
+/** Backend media-offload marker for generated videos. */
+export function extractVideoS3Key(resp: unknown): string {
+  const root = asRecord(resp)
+  if (!root) return ''
+  const key = typeof root.s3_key === 'string' ? root.s3_key.trim() : ''
+  return key.startsWith('media/videos/') ? key : ''
+}
+
 const DEEP_SCAN_MAX_DEPTH = 4
 
 function deepScanVideoUrl(node: unknown, depth: number): string {

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -332,7 +332,7 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { gatewayVideoSubmit } from '@/api/playground'
-import { extractVideoTaskId, videoStateFromFetch, extractVideoUrl } from '@/constants/playgroundMedia.tk'
+import { extractVideoTaskId, videoStateFromFetch, extractVideoUrl, extractVideoS3Key } from '@/constants/playgroundMedia.tk'
 import {
   VIDEO_ASPECT_PRESETS,
   VIDEO_DURATION_DEFAULT,
@@ -595,6 +595,7 @@ async function generate(): Promise<void> {
       keyId: props.keyId,
       state,
       url: state === 'succeeded' ? extractVideoUrl(raw) : '',
+      s3Key: state === 'succeeded' ? extractVideoS3Key(raw) || undefined : undefined,
       submittedAtMs: Date.now(),
       elapsedS: 0,
     }

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -871,6 +871,16 @@
       "rationale": "TK-only Studio image-generation surface (mounted by MediaStudioView when mode==='image'). The model card picker, the per-model aspect-ratio chips, and the generate button are the contract the studio e2e drives. The aspect chips are MODEL-SPECIFIC by design: each model's imageSizes (mediaTiers.tk.ts) decides the exact `size` string sent — Imagen ratio codes, Seedream pixels — so an upstream merge that drops the aspect picker or reverts it to a fixed pixel preset reintroduces the Imagen 'Invalid aspect ratio, 3:2' hard-400 on landscape/portrait. refreshOffloadedImageUrls anchors the onMounted re-presign of persisted offloaded images: offloaded image src is a short-lived presigned S3 link, so a reloaded session must re-mint from the stored s3Key (POST /v1/images/presign) — dropping this call leaves a reopened Studio with dead (expired) image thumbnails. pricesFlat is the FE mirror of the backend Imagen flat-billing exemption (billing_service_tk_flat_image.go): it ORs flatImageBilling (gemini-native) with the model's flatPricePerImage (imagen) and drives the estimate/hold/formula/billed note to drop the 1K/2K/4K size multiplier for imagen WITHOUT touching imagen's /v1/images routing, multi-image n, or no-image-input behaviors — dropping it desyncs the quoted price from settlement (UI over-quotes imagen ×1.5 while the gateway now bills flat). Anchoring the test-ids keeps the surface from compiling green with the feature silently gone."
     },
     {
+      "path": "frontend/src/composables/useVideoTaskPoll.ts",
+      "must_contain": [
+        "extractVideoS3Key",
+        "opts.patch(task.id, { state, url, s3Key, errorMessage: undefined })",
+        "opts.onTerminal?.({ ...task, state, url, s3Key }, state)",
+        "opts.patch(task.id, { url, s3Key })"
+      ],
+      "rationale": "TK-only Studio video polling must persist the backend media-offload marker (`s3_key`) whenever a task first succeeds and whenever an already-succeeded task refreshes its playback URL. The backend now converts short-lived upstream video URLs into TokenKey-owned S3 media, and the frontend needs s3Key in the task record so reopened sessions can keep moving through the durable offload path instead of falling back to an expired upstream preview URL. useVideoTaskPoll.ts is upstream-shaped; an upstream merge that removes these small patch/onTerminal fields would compile cleanly but silently reintroduce the customer-facing 'preview expired after generation' failure. These anchors pin the import, terminal-state persistence, terminal callback payload, and lazy refresh path."
+    },
+    {
       "path": "frontend/src/views/user/studio/VideoStudio.vue",
       "must_contain": [
         "data-testid=\"studio-video-model\"",


### PR DESCRIPTION
## 这次修什么

客户反馈的问题是：视频生成已经完成，但点开预览时看到“预览已过期”，结果等于看不到。

原因是有些上游视频模型返回的不是视频文件本身，而是一个很短命的上游视频链接。我们之前把这个短命链接保存到了 Studio 任务里，等客户晚一点再点开时，上游链接已经过期，所以页面只能显示过期提示。

## 核心改动

这次把“生成完成后的视频结果”改成我们自己接管：

- 如果上游返回的是视频链接，后端会立刻趁链接还有效，把视频下载下来。
- 下载后上传到 TokenKey 自己的媒体存储里。
- 返回给前端的是 TokenKey 自己签出来的播放链接，并同时返回 `s3_key`。
- 前端保存任务时也会保存这个 `s3_key`。
- 以后客户再打开同一个已完成任务时，不再依赖原来的上游短命链接，而是用 `s3_key` 重新签一个新的播放链接。

用大白话说：以前是“把别人给的临时门票存起来，过期就进不去”；现在是“视频先搬到我们自己的仓库，以后每次打开都重新发一张我们的临时门票”。

## 安全边界

后端下载上游视频链接时加了保护：只允许 http/https 公网地址，拦截内网、localhost、metadata 地址、异常端口、跳转后的危险地址，并限制超时和最大体积。下载失败时不会影响已生成结果，会退回原始上游响应。

## 测试

- `go test ./internal/pkg/httputil`
- `go test -tags unit ./internal/handler -run 'Test(MaybeOffloadVideoToS3|VideoFastPathFromS3|RewriteVideoBodyWithURL|ExtractInlineVideoBase64|VideoExtAndContentType)'`
- `pnpm --dir frontend test:run src/constants/__tests__/playgroundMedia.tk.spec.ts src/views/user/studio/__tests__/VideoStudio.spec.ts`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend run build`
- `./scripts/preflight.sh`

## 门禁确认

- upstream-touch-guarded：本 PR 修改了上游形状的 Studio 相关前端文件，已在 `scripts/sentinels/frontend-tk.json` 增加 `useVideoTaskPoll.ts` 的 `s3_key` 透传保护；既有 `VideoStudio.vue` sentinel 继续保护播放入口。
- sentinel-registry-reviewed：已检查并更新 sentinel，确保后续上游合并不会静默删掉这次视频预览修复链路。
