### PR TITLE
fix(account): allow editing Kiro credentials

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 510,
-  "hash": "ae67449507a57a0d05475d1ecd2e858059413ded734d5f612fb24cb0a5bd26f1",
+  "hash": "5dd0c52e3b861d9b27472e0243506bfd6304748fdb007e789aa08a11d26bda56",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -36,6 +36,22 @@
         />
       </div>
 
+      <!-- kiro (6th platform, OAuth): token refresh paste path. Blank secrets keep current values. -->
+      <div v-if="account.platform === 'kiro'" class="space-y-4">
+        <AccountKiroPlatformFields
+          v-model:accessToken="kiroAccessToken"
+          v-model:refreshToken="kiroRefreshToken"
+          v-model:region="kiroRegion"
+          v-model:authMethod="kiroAuthMethod"
+          v-model:machineId="kiroMachineId"
+          v-model:clientId="kiroClientId"
+          v-model:clientSecret="kiroClientSecret"
+          v-model:profileArn="kiroProfileArn"
+          v-model:tosAcknowledged="kiroTosAcknowledged"
+          variant="edit"
+        />
+      </div>
+
       <!-- API Key fields (only for apikey type) -->
       <div v-if="account.type === 'apikey'" class="space-y-4">
         <!--
@@ -2529,6 +2545,8 @@ import ModelWhitelistSelector from '@/components/account/ModelWhitelistSelector.
 import QuotaLimitCard from '@/components/account/QuotaLimitCard.vue'
 import AccountNewApiPlatformFields from './AccountNewApiPlatformFields.vue'
 import { useTkAccountNewApiPlatform } from '@/composables/useTkAccountNewApiPlatform'
+import AccountKiroPlatformFields from './AccountKiroPlatformFields.vue'
+import { useTkAccountKiroPlatform } from '@/composables/useTkAccountKiroPlatform'
 import AccountGrokPlatformFields from './AccountGrokPlatformFields.vue'
 import { useTkAccountGrokPlatform } from '@/composables/useTkAccountGrokPlatform'
 import { applyInterceptWarmup } from '@/components/account/credentialsBuilder'
@@ -2635,6 +2653,21 @@ const {
   isNewapi: () => props.account?.platform === 'newapi',
   storedAccount: () => (props.account ? { id: props.account.id, channel_type: props.account.channel_type } : null),
 })
+
+// 第六平台 kiro：编辑时可轮换 access_token / refresh_token 与 IdC 字段。
+const {
+  accessToken: kiroAccessToken,
+  refreshToken: kiroRefreshToken,
+  region: kiroRegion,
+  authMethod: kiroAuthMethod,
+  machineId: kiroMachineId,
+  clientId: kiroClientId,
+  clientSecret: kiroClientSecret,
+  profileArn: kiroProfileArn,
+  tosAcknowledged: kiroTosAcknowledged,
+  populateFromAccount: kiroPopulateFromAccount,
+  buildSubmitBundle: kiroBuildSubmitBundle,
+} = useTkAccountKiroPlatform()
 
 // 第七平台 grok：编辑时的 refresh_token 轮换 + base_url。
 const {
@@ -3322,6 +3355,12 @@ const syncFormFromAccount = (newAccount: Account | null) => {
 
   loadTempUnschedRules(credentials)
 
+  if (newAccount.platform === 'kiro') {
+    kiroPopulateFromAccount({
+      credentials: (newAccount.credentials as Record<string, unknown> | undefined) || {},
+    })
+  }
+
   // Initialize API Key fields for apikey type
   if (newAccount.type === 'apikey' && newAccount.credentials) {
     const credentials = newAccount.credentials as Record<string, unknown>
@@ -3969,6 +4008,22 @@ const handleSubmit = async () => {
       }
     }
 
+    if (props.account.platform === 'kiro') {
+      const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
+      const bundle = kiroBuildSubmitBundle('edit')
+      if (!bundle) return
+      const newCredentials: Record<string, unknown> = { ...currentCredentials }
+
+      delete newCredentials.machine_id
+      delete newCredentials.profile_arn
+      if (bundle.credentials.auth_method !== 'idc') {
+        delete newCredentials.client_id
+        delete newCredentials.client_secret
+      }
+
+      updatePayload.credentials = { ...newCredentials, ...bundle.credentials }
+    }
+
     // For apikey type, handle credentials update
     if (props.account.type === 'apikey') {
       const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
@@ -4310,8 +4365,8 @@ const handleSubmit = async () => {
 
       updatePayload.credentials = newCredentials
     } else {
-      // For oauth/setup-token types, only update intercept_warmup_requests if changed
-      const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
+      const currentCredentials = (updatePayload.credentials as Record<string, unknown>) ||
+        ((props.account.credentials as Record<string, unknown>) || {})
       const newCredentials: Record<string, unknown> = { ...currentCredentials }
 
       applyInterceptWarmup(newCredentials, interceptWarmupRequests.value, 'edit')

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { mount } from '@vue/test-utils'
 
@@ -55,6 +55,19 @@ vi.mock('vue-i18n', async () => {
 })
 
 import EditAccountModal from '../EditAccountModal.vue'
+
+beforeEach(() => {
+  updateAccountMock.mockReset()
+  checkMixedChannelRiskMock.mockReset()
+  getWebSearchEmulationConfigMock.mockReset()
+  getSettingsMock.mockReset()
+  listTLSFingerprintProfilesMock.mockReset()
+
+  checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+  getWebSearchEmulationConfigMock.mockResolvedValue({ enabled: false, providers: [] })
+  getSettingsMock.mockResolvedValue({ account_quota_notify_enabled: false })
+  listTLSFingerprintProfilesMock.mockResolvedValue([])
+})
 
 const BaseDialogStub = defineComponent({
   name: 'BaseDialog',
@@ -167,6 +180,32 @@ function buildVertexAccount() {
     group_ids: [],
     expires_at: null,
     auto_pause_on_expired: false
+  } as any
+}
+
+function buildKiroAccount() {
+  return {
+    id: 6,
+    name: 'Kiro Real',
+    notes: '',
+    platform: 'kiro',
+    type: 'oauth',
+    credentials: {
+      region: 'us-east-1',
+      auth_method: 'social',
+      machine_id: 'old-machine',
+      profile_arn: '',
+      tos_acknowledged: true
+    },
+    extra: {},
+    proxy_id: null,
+    concurrency: 30,
+    priority: 10,
+    rate_multiplier: 1,
+    status: 'active',
+    group_ids: [],
+    expires_at: null,
+    auto_pause_on_expired: true
   } as any
 }
 
@@ -549,5 +588,58 @@ describe('EditAccountModal', () => {
 
     expect(updateAccountMock).not.toHaveBeenCalled()
   })
-})
 
+  it('renders and submits Kiro credential fields in edit mode', async () => {
+    const account = buildKiroAccount()
+    updateAccountMock.mockReset()
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+
+    const accessTokenInput = wrapper.get<HTMLTextAreaElement>(
+      'textarea[placeholder="admin.accounts.kiroPlatform.accessTokenPlaceholder"]'
+    )
+    const refreshTokenInput = wrapper.get<HTMLTextAreaElement>(
+      'textarea[placeholder="admin.accounts.kiroPlatform.refreshTokenPlaceholder"]'
+    )
+    const authMethodSelect = wrapper
+      .findAll<HTMLSelectElement>('select')
+      .find((select) => select.find('option[value="idc"]').exists())
+    expect(authMethodSelect).toBeTruthy()
+    const tosCheckbox = wrapper.get<HTMLInputElement>('input[type="checkbox"]')
+
+    expect(tosCheckbox.element.checked).toBe(true)
+
+    await accessTokenInput.setValue('new-access-token')
+    await refreshTokenInput.setValue('new-refresh-token')
+    await wrapper.get<HTMLInputElement>('input[placeholder="us-east-1"]').setValue('us-west-2')
+    await authMethodSelect!.setValue('idc')
+    await wrapper
+      .get<HTMLInputElement>('input[placeholder="admin.accounts.kiroPlatform.clientIdPlaceholder"]')
+      .setValue('new-client-id')
+    await wrapper
+      .get<HTMLInputElement>('input[placeholder="admin.accounts.kiroPlatform.clientSecretPlaceholder"]')
+      .setValue('new-client-secret')
+    await wrapper
+      .get<HTMLInputElement>('input[placeholder="admin.accounts.kiroPlatform.machineIdPlaceholder"]')
+      .setValue('new-machine-id')
+    await wrapper
+      .get<HTMLInputElement>('input[placeholder="admin.accounts.kiroPlatform.profileArnPlaceholder"]')
+      .setValue('arn:aws:codewhisperer:us-west-2:123456789012:profile/example')
+
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.credentials).toMatchObject({
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token',
+      region: 'us-west-2',
+      auth_method: 'idc',
+      client_id: 'new-client-id',
+      client_secret: 'new-client-secret',
+      machine_id: 'new-machine-id',
+      profile_arn: 'arn:aws:codewhisperer:us-west-2:123456789012:profile/example',
+      tos_acknowledged: true
+    })
+  })
+})

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -246,9 +246,13 @@
     {
       "path": "frontend/src/components/account/EditAccountModal.vue",
       "must_contain": [
-        "editMirrorPlatform"
+        "editMirrorPlatform",
+        "AccountKiroPlatformFields",
+        "kiroPopulateFromAccount",
+        "kiroBuildSubmitBundle",
+        "props.account.platform === 'kiro'"
       ],
-      "rationale": "Surface-C mirror-stub pool selector in the account-edit modal — the operator's only no-SQL way to set credentials.mirror_platform=kiro on an existing edge stub (e.g. kiro-edge-us1). Losing it strands the live fix: the kiro stub keeps mirroring the anthropic Σ."
+      "rationale": "Two Kiro account-edit anchors. (1) Surface-C mirror-stub pool selector: the operator's only no-SQL way to set credentials.mirror_platform=kiro on an existing edge stub (e.g. kiro-edge-us1). Losing it strands the live fix: the kiro stub keeps mirroring the anthropic Σ. (2) Kiro OAuth credential edit wiring: AccountKiroPlatformFields + populate/submit bundle let operators rotate access_token/refresh_token, region/auth_method, IdC client_id/client_secret, Profile ARN, and ToS acknowledgement without delete+recreate. An upstream merge that rewrites EditAccountModal must preserve this branch or live Kiro accounts become unrepairable from the UI."
     },
     {
       "path": "frontend/src/constants/mirrorPlatformOptions.tk.ts",


### PR DESCRIPTION
## Summary
- 在账号编辑弹窗中补上 Kiro 专用凭证字段，支持粘贴 `access_token`、`refresh_token`、`region`、`auth_method`、IdC 的 `client_id` / `client_secret`、Profile ARN，并可勾选 ToS。
- 编辑时敏感字段留空不会覆盖现有值；可选字段如 `profile_arn` 清空后可以从 credentials 中移除。
- 增加 Kiro 编辑提交 payload 的回归测试，并刷新嵌入式前端 source manifest。
- 补充 `scripts/sentinels/kiro.json` 对 Kiro 编辑凭证接线的 anchor，防止未来 upstream merge 覆盖掉 `EditAccountModal.vue` 中的新入口。

## Risk
- 低风险。改动只作用于后台账号编辑弹窗中的 `platform === "kiro"` 路径；非 Kiro 账号沿用原有 credentials 合并逻辑。
- upstream 覆盖写面已处理：`EditAccountModal.vue` 是 upstream-shaped 热点文件，本 PR 对新增 Kiro edit wiring 增加了 `kiro.json` sentinel anchor；`upstream-override-marker` 对该文件返回 verified coverage。
- sentinel-registry-reviewed：已复核该热点面，本 PR 已新增对应 Kiro sentinel anchor。

## Validation
- `pnpm --dir frontend test:run src/components/account/__tests__/EditAccountModal.spec.ts -t "renders and submits Kiro credential fields in edit mode"`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend run build`
- `python3 scripts/sentinels/check-kiro.py`
- `python3 scripts/checks/upstream-override-marker.py --base origin/main`
- `git diff --check`
- `./scripts/preflight.sh`

备注：完整运行 `EditAccountModal.spec.ts` 时仍有两条既有 OpenAI 相关失败，分别是 model mapping 保留行为和 Codex image bridge 旧 selector 漂移；与本次 Kiro 修复无关。新增的 Kiro 定向回归测试已通过。
