### PR TITLE
chore(edge): retire decommissioned Lightsail edges

### DIFF
--- a/.github/workflows/deploy-edge-lightsail-stage0.yml
+++ b/.github/workflows/deploy-edge-lightsail-stage0.yml
@@ -18,14 +18,11 @@ on:
         required: true
         type: choice
         options:
-          - uk1
           - us1
-          - us2
           - us3
           - us4
           - us5
           - us6
-          - us7
       operation:
         description: "provision creates Lightsail instance; upgrade/rollback use SSM; smoke verifies."
         required: true
@@ -40,7 +37,7 @@ on:
         required: false
         type: string
       confirm_instance:
-        description: "Must match instance_name from matrix (e.g. tokenkey-edge-uk1-ls)."
+        description: "Must match instance_name from matrix (e.g. tokenkey-edge-us-oh1-ls)."
         required: true
         type: string
       recreate:

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -117,13 +117,13 @@ curl -sS -o /dev/null -w '%{http_code}\n' "https://${DOMAIN}/health"
 
 > **2026-06-07：edges 改为 Lightsail 唯一路径。** EC2/CFN 的 **Edge** 矩阵已退役（`deploy-edge-stage0.yml`、`stage0-edge-ec2.yaml`、EIP 轮换工具已删除，`edge-targets.json` 清空为 stub）。**prod 主网关仍是 EC2/CFN（`tokenkey-prod-stage0`），不受影响**——本节只讲 edge。
 
-Edge 子网关不是第二个用户入口。区域域名（如 `api-uk1.tokenkey.dev`、`api-us2.tokenkey.dev`）只作为 `api.tokenkey.dev` 背后的区域资源节点，默认 API 路径只允许主网关出口访问。
+Edge 子网关不是第二个用户入口。区域域名（如 `api-us3.tokenkey.dev`、`api-us4.tokenkey.dev`）只作为 `api.tokenkey.dev` 背后的区域资源节点，默认 API 路径只允许主网关出口访问。
 
 所有 edge 都在 Lightsail（矩阵 `deploy/aws/lightsail/edge-targets-lightsail.json`，workflow `deploy-edge-lightsail-stage0.yml`）。当前 edge 矩阵示例：
 
 ```text
-uk1 -> eu-west-2 -> api-uk1.tokenkey.dev -> tokenkey-edge-uk1-ls -> deploy-edge-lightsail-stage0.yml
-us2 -> us-east-1 -> api-us2.tokenkey.dev -> tokenkey-edge-us2-ls -> deploy-edge-lightsail-stage0.yml
+us3 -> us-east-2 -> api-us3.tokenkey.dev -> tokenkey-edge-us-oh1-ls -> deploy-edge-lightsail-stage0.yml
+us4 -> us-west-2 -> api-us4.tokenkey.dev -> tokenkey-edge-us-or1-ls -> deploy-edge-lightsail-stage0.yml
 ```
 
 新增 edge / 升级 / 回滚 / IP 轮换的端到端流程见
@@ -958,4 +958,3 @@ IAM 信任面：
 - **应用更新 / 滚动 / 回滚** → 主文档 §3.6
 - **Stage 1/2/3 升级触发条件** → 主文档 §二、§3.9
 - **CFN 全部 18 个参数详表** → 主文档 §3.5「全部参数总表」
-

--- a/deploy/aws/lightsail/README.md
+++ b/deploy/aws/lightsail/README.md
@@ -156,12 +156,15 @@ PREFLIGHT_BASE=origin/main bash scripts/preflight.sh
 - **常见假阴性（已修复）**：`DescribeInstanceInformation` 不允许把「标签过滤器」与其它过滤器混在一起；也不得依赖 `ComputerName` 默认等于 Lightsail `instance_name`（AL2023 常为 DHCP hostname）。provision 脚本现以 **`ActivationIds` = 本次 Hybrid activation** 作为主查询，并在 bootstrap 里 `hostnamectl set-hostname` 对齐实例名。
 - **仍超时**：Lightsail 浏览器 SSH 查看 `/var/log/tokenkey-lightsail-bootstrap.log`；失败行以 `BOOTSTRAP_FAIL:` 开头。Workflow 末尾会打印 `describe-activations` 帮助判断 activation / 配额是否用尽。
 
-## uk1：`api-uk1.tokenkey.dev` 权威平台（Lightsail）
+## 已退役 edge 记录
 
-矩阵基线：**EC2 `uk1.deployable=false`**（`deploy/aws/stage0/edge-targets.json`），**Lightsail `uk1.deployable=true`**（本目录 `edge-targets-lightsail.json`）。
-同名域名只能由一个平台对外服务；两边的 `deployable` 同时为 `true` 会被 **`scripts/checks/edge-platform-exclusivity.py`** 拦下。
+`uk1` / `us2` / `us7` 已于 2026-06-23 退役；对应 Lightsail instance、Static IP、
+SSM managed instance、SSM 参数、DNS A 记录、prod mirror account 均已删除。矩阵保留历史
+target 元数据，但必须保持 `deployable=false`；rollout、health、飞书配置同步和手动 edge
+deploy choice 都不应再指向这些 edge。
 
-**Porkbun（prod，`api-uk1.tokenkey.dev`）：** A 记录必须等于 Lightsail Static IP（`aws lightsail get-static-ip --static-ip-name vless-uk-fresh-1` 的 `ipAddress`）。当前矩阵记在 `edge-targets-lightsail.json` → **`targets.uk1.porkbun_a_ipv4`**（**`18.175.27.120`**），作为人工 DNS **唯一真值**。
+对仍在线的 edge，同名域名只能由一个平台对外服务；两边的 `deployable` 同时为 `true` 会被
+**`scripts/checks/edge-platform-exclusivity.py`** 拦下。
 
 **不能与 EC2 EIP 混用：** 旧 EC2 Edge 的 Elastic IP（例如历史 **`16.61.87.51` / `eipalloc-03b2653ddd57b9c93`**）**无法挂到 Lightsail 实例**。若 Porkbun 仍指向已游离的 EC2 EIP，公网会超时。迁到 Lightsail 后必须把 A 记录改到 **Lightsail Static IP**；不再需要的老 EIP 可通过 `release-address` 回收。
 

--- a/deploy/aws/lightsail/edge-targets-lightsail.json
+++ b/deploy/aws/lightsail/edge-targets-lightsail.json
@@ -10,7 +10,7 @@
   ],
   "targets": {
     "uk1": {
-      "deployable": true,
+      "deployable": false,
       "profile": "edge-lightsail-minimal",
       "swap_gib": 2,
       "lightsail_region": "eu-west-2",
@@ -24,7 +24,7 @@
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/uk1",
-      "purpose": "uk-egress-lightsail"
+      "purpose": "retired 2026-06-23: Lightsail instance, Static IP, SSM managed instance, SSM params, DNS, and prod mirror account removed"
     },
     "us1": {
       "deployable": false,
@@ -75,7 +75,7 @@
       "purpose": "sg-egress-planned"
     },
     "us2": {
-      "deployable": true,
+      "deployable": false,
       "profile": "edge-lightsail-minimal",
       "swap_gib": 2,
       "lightsail_region": "us-east-2",
@@ -89,7 +89,7 @@
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us2",
-      "purpose": "us-east-2-ohio-egress (adopted StaticIp-oh-2 after us-east-1 100.48.129.133 pollution)"
+      "purpose": "retired 2026-06-23: Lightsail instance, Static IP, SSM managed instance, SSM params, DNS, and prod mirror account removed; had adopted StaticIp-oh-2 after us-east-1 100.48.129.133 pollution"
     },
     "us3": {
       "deployable": true,
@@ -160,7 +160,7 @@
       "purpose": "us-east-2-ohio-egress (rehomed 2026-06-05 to adopted console-created edge-ls-us-oh-3 / StaticIp-oh-3; corrected 2026-06-08: A record was stale at ephemeral 52.15.35.197 which AWS re-adopted to *.coverahealth.com — StaticIp-oh-3 truth is 3.148.79.145)"
     },
     "us7": {
-      "deployable": true,
+      "deployable": false,
       "profile": "edge-lightsail-minimal",
       "swap_gib": 2,
       "lightsail_region": "us-east-2",
@@ -174,7 +174,7 @@
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us7",
-      "purpose": "us-east-2-ohio-egress (rehomed 2026-06-05 to adopted console-created edge-ls-us-oh-4; corrected 2026-06-08: live static IP is StaticIp-oh-4-b/18.188.207.95 not StaticIp-oh-4/3.139.183.116 — A record was stale at the dead 3.139.183.116)"
+      "purpose": "retired 2026-06-23: Lightsail instance, Static IP, SSM managed instance, SSM params, DNS, and prod mirror account removed; had been rehomed 2026-06-05 to adopted console-created edge-ls-us-oh-4"
     }
   }
 }

--- a/ops/stage0/test_edge_admin_resolve_target.py
+++ b/ops/stage0/test_edge_admin_resolve_target.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import pathlib
 import subprocess
 import unittest
+import json
 
 _SCRIPT = pathlib.Path(__file__).resolve().parent / "edge_admin_resolve_target.py"
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_LIGHTSAIL_MATRIX = _REPO_ROOT / "deploy/aws/lightsail/edge-targets-lightsail.json"
 
 
 def _resolve(*args: str) -> subprocess.CompletedProcess[str]:
@@ -20,6 +22,16 @@ def _resolve(*args: str) -> subprocess.CompletedProcess[str]:
         ["python3", str(_SCRIPT), str(_REPO_ROOT), *args],
         capture_output=True, text=True, check=False,
     )
+
+
+def _deployable_lightsail_edge() -> str | None:
+    matrix = json.loads(_LIGHTSAIL_MATRIX.read_text(encoding="utf-8"))
+    targets = matrix.get("targets") or {}
+    deployable = sorted(
+        edge_id for edge_id, target in targets.items()
+        if isinstance(target, dict) and target.get("deployable") is True
+    )
+    return deployable[0] if deployable else None
 
 
 class EdgeAdminResolveTargetTest(unittest.TestCase):
@@ -39,7 +51,10 @@ class EdgeAdminResolveTargetTest(unittest.TestCase):
     def test_edge_resolution_still_works(self) -> None:
         # Sanity: a real deployable Lightsail edge still routes via the matrices,
         # proving the prod short-circuit did not shadow the edge path.
-        proc = _resolve("uk1")
+        edge_id = _deployable_lightsail_edge()
+        if edge_id is None:
+            self.skipTest("no deployable Lightsail edge in matrix")
+        proc = _resolve(edge_id)
         self.assertEqual(proc.returncode, 0, msg=proc.stderr)
         mode, region, _stack = proc.stdout.rstrip("\n").split("\t")
         self.assertEqual(mode, "lightsail")

--- a/scripts/checks/workflow-edge-coverage.json
+++ b/scripts/checks/workflow-edge-coverage.json
@@ -12,13 +12,10 @@
       "option_prefix": "edge-",
       "required_set": "all-deployable",
       "opt_out_edges": [
-        {"id": "uk1", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},
-        {"id": "us2", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},
         {"id": "us3", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},
         {"id": "us4", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},
         {"id": "us5", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},
-        {"id": "us6", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"},
-        {"id": "us7", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"}
+        {"id": "us6", "reason": "pg_dump SSM refresh targets the prod EC2 instance only; Lightsail edges are out of scope for this cadence by design"}
       ]
     }
   }

--- a/scripts/test_resolve_edge_deploy_route.py
+++ b/scripts/test_resolve_edge_deploy_route.py
@@ -10,6 +10,17 @@ import unittest
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts/stage0/resolve-edge-deploy-route.py"
+LIGHTSAIL_MATRIX = REPO_ROOT / "deploy/aws/lightsail/edge-targets-lightsail.json"
+
+
+def _deployable_lightsail_edge() -> str | None:
+    matrix = json.loads(LIGHTSAIL_MATRIX.read_text(encoding="utf-8"))
+    targets = matrix.get("targets") or {}
+    deployable = sorted(
+        edge_id for edge_id, target in targets.items()
+        if isinstance(target, dict) and target.get("deployable") is True
+    )
+    return deployable[0] if deployable else None
 
 
 class ResolveEdgeDeployRouteTest(unittest.TestCase):
@@ -23,8 +34,11 @@ class ResolveEdgeDeployRouteTest(unittest.TestCase):
         )
         return json.loads(proc.stdout)
 
-    def test_uk1_routes_to_lightsail(self) -> None:
-        route = self._route("uk1")
+    def test_deployable_edge_routes_to_lightsail(self) -> None:
+        edge_id = _deployable_lightsail_edge()
+        if edge_id is None:
+            self.skipTest("no deployable Lightsail edge in matrix")
+        route = self._route(edge_id)
         self.assertEqual(route["platform"], "lightsail")
         self.assertEqual(route["workflow_file"], "deploy-edge-lightsail-stage0.yml")
         self.assertEqual(route["confirm_flag"], "confirm_instance")


### PR DESCRIPTION
## Summary
- mark uk1/us2/us7 Lightsail matrix entries as deployable=false after live decommission
- remove those retired edges from manual Lightsail deploy workflow choices and stale pg_dump coverage opt-outs
- update edge routing tests to use the live deployable Lightsail fixture instead of hard-coding uk1

## Risk
- Low/ops cleanup: live Lightsail instances, Static IPs, SSM managed instances, SSM params, DNS A records, and prod mirror accounts were already removed before this PR.
- Remaining deployable edge set is us3/us4/us5/us6.

## Validation
- python3 deploy/aws/stage0/resolve-edge-target.py --list-deployable -> us3/us4/us5/us6
- python3 scripts/checks/workflow-edge-coverage.py
- env -u GIT_DIR -u GIT_INDEX_FILE -u GIT_WORK_TREE python3 -m unittest discover -s ops/stage0 -p 'test_*.py' -t ops/stage0 -v\n- env -u GIT_DIR -u GIT_INDEX_FILE -u GIT_WORK_TREE python3 -m unittest discover -s scripts -p 'test_*.py' -t scripts -v\n- bash scripts/preflight.sh\n