### PR TITLE
fix(grok-video): bound the native video poll response read

### DIFF
--- a/backend/internal/service/openai_gateway_grok_video_tk.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk.go
@@ -174,6 +174,35 @@ func (s *OpenAIGatewayService) grokNativeVideoFetch(
 // shared upstream HTTP client (proxy + per-account concurrency honored). Bodies
 // are small JSON (request_id on submit; status+url on poll), so reading fully is
 // fine. account may be nil on the fetch path (used only for proxy/concurrency).
+// grokVideoResponseMaxBytes bounds the grok-native video submit/poll response we
+// read into memory. xAI returns small URL-JSON (the clip is hosted upstream, never
+// inline base64), so a few-MB ceiling is honest headroom while bounding a hostile or
+// runaway upstream. This is the grok-arm counterpart to the new-api bridge's
+// videoFetchResponseMaxBytes (80MB); we keep a SEPARATE service-local const rather
+// than importing the bridge's package-private value — grok never carries inline
+// bytes, so a smaller cap is more honest, and widening the bridge surface buys nothing.
+const grokVideoResponseMaxBytes int64 = 16 << 20
+
+var errGrokVideoResponseTooLarge = errors.New("grok video upstream response too large")
+
+// readGrokVideoResponseLimited reads at most maxBytes (+1 sentinel byte) from r and
+// errors if the body exceeds the cap — the same bounded-read shape the bridge uses in
+// readVideoFetchResponseBodyLimited. Extracted so the bound is unit-testable without a
+// live upstream.
+func readGrokVideoResponseLimited(r io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		maxBytes = grokVideoResponseMaxBytes
+	}
+	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, errGrokVideoResponseTooLarge
+	}
+	return body, nil
+}
+
 func (s *OpenAIGatewayService) grokVideoHTTP(
 	ctx context.Context,
 	account *Account,
@@ -212,7 +241,7 @@ func (s *OpenAIGatewayService) grokVideoHTTP(
 		return nil, 0, fmt.Errorf("grok video upstream request failed: %s", sanitizeUpstreamErrorMessage(err.Error()))
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, rerr := io.ReadAll(resp.Body)
+	respBody, rerr := readGrokVideoResponseLimited(resp.Body, grokVideoResponseMaxBytes)
 	if rerr != nil {
 		return nil, resp.StatusCode, fmt.Errorf("read grok video response: %w", rerr)
 	}

--- a/backend/internal/service/openai_gateway_grok_video_tk_test.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk_test.go
@@ -4,8 +4,41 @@ package service
 
 import (
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 )
+
+// TestReadGrokVideoResponseLimited pins the bounded read that protects the grok
+// video arm from a hostile/runaway upstream: a body within the cap reads back
+// verbatim, and one over the cap returns errGrokVideoResponseTooLarge instead of
+// buffering unbounded media into gateway memory (parity with the new-api bridge's
+// readVideoFetchResponseBodyLimited).
+func TestReadGrokVideoResponseLimited(t *testing.T) {
+	t.Run("within cap reads verbatim", func(t *testing.T) {
+		body := `{"video_url":"https://x.ai/v.mp4"}`
+		got, err := readGrokVideoResponseLimited(strings.NewReader(body), 1024)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(got) != body {
+			t.Fatalf("body mismatch: got %q want %q", got, body)
+		}
+	})
+	t.Run("over cap errors", func(t *testing.T) {
+		_, err := readGrokVideoResponseLimited(strings.NewReader(strings.Repeat("a", 100)), 16)
+		if !errors.Is(err, errGrokVideoResponseTooLarge) {
+			t.Fatalf("expected errGrokVideoResponseTooLarge, got %v", err)
+		}
+	})
+	t.Run("exactly at cap is allowed", func(t *testing.T) {
+		body := strings.Repeat("a", 16)
+		got, err := readGrokVideoResponseLimited(strings.NewReader(body), 16)
+		if err != nil || len(got) != 16 {
+			t.Fatalf("at-cap read should succeed: got len=%d err=%v", len(got), err)
+		}
+	})
+}
 
 // TestNormalizeGrokVideoStatus pins the mapping from xAI's video status enum
 // (queued/processing/done/failed/expired) onto the handler's videoTerminalOutcome


### PR DESCRIPTION
## What & why

Part of the media-pressure audit (follow-up to #944 / #946). `grokVideoHTTP` read the xAI submit/poll response with an **unbounded** `io.ReadAll` — the only unbounded media-buffering read left on the entire video path. The new-api bridge already caps task-poll bodies at `videoFetchResponseMaxBytes` (80MB); the grok native arm had no such guard. xAI returns small URL-JSON (the clip is hosted upstream, never inline), so a hostile or runaway upstream could otherwise stream unbounded bytes into gateway memory.

## Change

- Add a service-local `grokVideoResponseMaxBytes` (16MB — honest headroom for URL-JSON) + a testable `readGrokVideoResponseLimited` helper (`LimitReader(max+1)` + size check), mirroring the bridge's `readVideoFetchResponseBodyLimited`.
- `grokVideoHTTP` now uses the bounded read. No behavior change for real grok responses (sub-KB); this only bounds the worst case.
- Deliberately a **separate** const, not the bridge's package-private `videoFetchResponseMaxBytes` — grok never carries inline bytes, so a smaller cap is more honest and the bridge surface stays unwidened.

## Test plan

- `go build ./...`, `go test -tags=unit ./internal/service/ -run GrokVideo` — pass (new `readGrokVideoResponseLimited` within-cap / over-cap / at-cap cases)
- `golangci-lint` clean; `scripts/preflight.sh` PASS

## Markers

`sentinel-registry-reviewed` — the grok.json anchors for this file (`grokNativeVideoSubmit`, `grokNativeVideoFetch`, `/videos/generations`) are all still present; the deletion-bearing edit is only the one-line `io.ReadAll` swap, no anchor removed. `no-web-impact` (backend-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
