### PR TITLE
feat(studio): back off video polling + downscale input images

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 510,
-  "hash": "5dd0c52e3b861d9b27472e0243506bfd6304748fdb007e789aa08a11d26bda56",
+  "hash": "1d39c10f00897a5452327403d48d08f0744397e791fed969d1bac76a6d62abec",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/common/ImageUpload.vue
+++ b/frontend/src/components/common/ImageUpload.vue
@@ -81,6 +81,11 @@ const props = withDefaults(defineProps<{
   removeLabel?: string
   hint?: string
   maxSize?: number // bytes
+  // Opt-in (image mode only): downscale the uploaded image to this max edge (px)
+  // and re-encode before emitting the data: URI, so a multi-MB input doesn't flow
+  // inline through the gateway. 0/undefined = emit the original (admin logo uploads
+  // want full fidelity; only the Studio input-image flows pass this).
+  downscaleMaxEdge?: number
 }>(), {
   mode: 'image',
   size: 'md',
@@ -88,6 +93,7 @@ const props = withDefaults(defineProps<{
   removeLabel: 'Remove',
   hint: '',
   maxSize: 300 * 1024,
+  downscaleMaxEdge: 0,
 })
 
 const emit = defineEmits<{
@@ -132,8 +138,14 @@ function handleUpload(event: Event) {
       input.value = ''
       return
     }
-    reader.onload = (e) => {
-      emit('update:modelValue', e.target?.result as string)
+    reader.onload = async (e) => {
+      const dataUrl = e.target?.result as string
+      if (!dataUrl) return
+      if (props.downscaleMaxEdge && props.downscaleMaxEdge > 0) {
+        emit('update:modelValue', await downscaleDataUrl(dataUrl, props.downscaleMaxEdge))
+      } else {
+        emit('update:modelValue', dataUrl)
+      }
     }
     reader.readAsDataURL(file)
   }
@@ -142,5 +154,41 @@ function handleUpload(event: Event) {
     error.value = 'Failed to read file'
   }
   input.value = ''
+}
+
+// Downscale a data: image URL to maxEdge (longest side) and re-encode lossily so a
+// large input image doesn't travel inline through the gateway. Best-effort: any
+// failure (no canvas/2d ctx, decode error, already-small image) resolves to the
+// ORIGINAL so an upload never silently fails over compression. Prefers WebP (alpha +
+// smaller); falls back to JPEG when the browser can't encode WebP.
+function downscaleDataUrl(dataUrl: string, maxEdge: number): Promise<string> {
+  return new Promise((resolve) => {
+    try {
+      const img = new Image()
+      img.onload = () => {
+        const longest = Math.max(img.width, img.height)
+        if (!longest || longest <= maxEdge) {
+          resolve(dataUrl)
+          return
+        }
+        const scale = maxEdge / longest
+        const canvas = document.createElement('canvas')
+        canvas.width = Math.round(img.width * scale)
+        canvas.height = Math.round(img.height * scale)
+        const ctx = canvas.getContext('2d')
+        if (!ctx) {
+          resolve(dataUrl)
+          return
+        }
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+        const webp = canvas.toDataURL('image/webp', 0.85)
+        resolve(webp.startsWith('data:image/webp') ? webp : canvas.toDataURL('image/jpeg', 0.85))
+      }
+      img.onerror = () => resolve(dataUrl)
+      img.src = dataUrl
+    } catch {
+      resolve(dataUrl)
+    }
+  })
 }
 </script>

--- a/frontend/src/composables/__tests__/useVideoTaskPoll.spec.ts
+++ b/frontend/src/composables/__tests__/useVideoTaskPoll.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { pollIntervalMs } from '../useVideoTaskPoll'
+
+describe('pollIntervalMs stepped backoff', () => {
+  it('polls fast (5s) for the first minute', () => {
+    expect(pollIntervalMs(0)).toBe(5_000)
+    expect(pollIntervalMs(59_999)).toBe(5_000)
+  })
+
+  it('backs off to 10s after one minute', () => {
+    expect(pollIntervalMs(60_000)).toBe(10_000)
+    expect(pollIntervalMs(179_999)).toBe(10_000)
+  })
+
+  it('backs off to 15s after three minutes (and stays there — no hard cap)', () => {
+    expect(pollIntervalMs(180_000)).toBe(15_000)
+    expect(pollIntervalMs(60 * 60_000)).toBe(15_000) // an hour-old reattached task still polls
+  })
+})

--- a/frontend/src/composables/useVideoTaskPoll.ts
+++ b/frontend/src/composables/useVideoTaskPoll.ts
@@ -19,8 +19,33 @@ import { gatewayVideoFetch } from '@/api/playground'
 import { videoStateFromFetch, extractVideoUrl, type PlaygroundVideoState } from '@/constants/playgroundMedia.tk'
 import type { VideoTaskItem } from '@/composables/useMediaLibrary'
 
-const POLL_INTERVAL_MS = 5_000
+// Stepped poll backoff: each poll is a real gateway request that REPLAYS the task
+// fetch upstream (VideoFetch → ForwardAsVideoFetchDispatched), so a fixed 5s cadence
+// on a multi-minute render is pure fan-out — and reattaching a full VIDEO_CAP of
+// persisted tasks on a Studio reload bursts it. Poll fast early (when completion is
+// plausible), then back off. There is DELIBERATELY no absolute duration cap: the
+// terminal-failure refund only fires when the client polls a terminal task
+// (openai_gateway_tk_video.go), so stopping early would orphan a real refund. The
+// server-side 24h TTL + terminal auto-delete + the 3-consecutive-error stop already
+// bound a genuinely stuck task.
+const POLL_INTERVAL_FAST_MS = 5_000
+const POLL_INTERVAL_MID_MS = 10_000
+const POLL_INTERVAL_SLOW_MS = 15_000
+const POLL_BACKOFF_MID_AFTER_MS = 60_000
+const POLL_BACKOFF_SLOW_AFTER_MS = 180_000
 const MAX_CONSECUTIVE_ERRORS = 3
+
+/**
+ * Poll interval for a task given its age (now - submittedAtMs): 5s for the first
+ * minute, 10s up to three minutes, 15s after. Pure + exported so the backoff schedule
+ * is unit-testable without driving setTimeout. A reattached task whose submit time is
+ * already old correctly starts at the slow cadence.
+ */
+export function pollIntervalMs(ageMs: number): number {
+  if (ageMs >= POLL_BACKOFF_SLOW_AFTER_MS) return POLL_INTERVAL_SLOW_MS
+  if (ageMs >= POLL_BACKOFF_MID_AFTER_MS) return POLL_INTERVAL_MID_MS
+  return POLL_INTERVAL_FAST_MS
+}
 
 export interface VideoTaskPollOptions {
   gatewayBase: () => string
@@ -90,7 +115,7 @@ export function useVideoTaskPoll(opts: VideoTaskPollOptions): VideoTaskPoller {
     if (!p) return
     p.timer = setTimeout(() => {
       void pollOnce(task)
-    }, POLL_INTERVAL_MS)
+    }, pollIntervalMs(Date.now() - task.submittedAtMs))
   }
 
   async function pollOnce(task: VideoTaskItem): Promise<void> {

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -61,6 +61,7 @@
             :remove-label="t('studio.image.inputRemove')"
             :hint="t('studio.image.inputHint')"
             :max-size="INPUT_IMAGE_MAX_BYTES"
+            :downscale-max-edge="INPUT_IMAGE_DOWNSCALE_EDGE"
             @update:model-value="inputImage = $event"
           />
           <button
@@ -318,6 +319,11 @@ const errorCode = ref<StudioErrorCode | ''>('')
 // seedream take no input image on /v1/images/generations). The input image is a
 // data: URI (fresh upload) or a library image's src (reuse).
 const INPUT_IMAGE_MAX_BYTES = 4 * 1024 * 1024 // 4 MB — well within gemini inline-image limits
+// Downscale the input image to this max edge (px) before it travels inline through the
+// gateway: image-to-image / reverse-prompt / first-frame inputs don't need full res
+// (gemini inline-image guidance is well under 4 MB), so this cuts request-body bytes
+// by an order of magnitude. The 4 MB cap above still guards the original upload.
+const INPUT_IMAGE_DOWNSCALE_EDGE = 1536
 const inputImage = ref('')
 const reversing = ref(false)
 const supportsImageInput = computed(() => isFlatImage.value)


### PR DESCRIPTION
## What & why

Part of the media-pressure audit (#944 / #946). Two independent reductions of what the Studio pushes through the gateway.

**Video poll backoff** — each poll is a real gateway request that **replays the task fetch upstream** (`VideoFetch → ForwardAsVideoFetchDispatched`). The fixed 5s cadence was pure fan-out on multi-minute renders, and reattaching a full `VIDEO_CAP` of persisted tasks on a Studio reload bursts it. Step the interval **5s → 10s (after 60s) → 15s (after 180s)**, keyed off the task's submit time (`pollIntervalMs`, pure + unit-tested).
- **No absolute duration cap, by design:** the terminal-failure **refund** only fires when the client polls a terminal task (`openai_gateway_tk_video.go`), so stopping early would orphan a real refund (money loss). A genuinely stuck task is already bounded by the server 24h TTL + terminal auto-delete + the 3-consecutive-error stop.

**Input-image downscale** — image-to-image / reverse-prompt / first-frame inputs were `readAsDataURL`'d and sent inline through the gateway at up to **~5.3 MB base64, uncompressed**. Add an **opt-in** `downscaleMaxEdge` prop to the shared `ImageUpload` (default `0` = unchanged, so admin logo uploads in RiskControl/Settings keep full fidelity); `ImageStudio` passes **1536px**. A canvas downscale + WebP/JPEG re-encode cuts the request body to ~100–300 KB. Best-effort: any failure (no canvas, decode error, already-small) resolves to the original.

## Test plan

- `typecheck` + `lint:check` clean
- `useVideoTaskPoll.spec.ts` — new `pollIntervalMs` stepped-backoff cases (fast/mid/slow, no cap) pass
- existing studio/media vitest green; dist manifest rebuilt
- `scripts/preflight.sh` PASS (ImageStudio edit kept insertion-only → registry gate clean, no marker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
