### PR TITLE
refactor(studio): play Bake-Off videos on demand via the shared no-CDN lightbox

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 510,
-  "hash": "5dd0c52e3b861d9b27472e0243506bfd6304748fdb007e789aa08a11d26bda56",
+  "file_count": 511,
+  "hash": "7f2df407e260ea1185f8863fbd523aceb6021d971ea99be2c9fd2361d2bca915",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/utils/__tests__/studioMedia.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioMedia.tk.spec.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { videoPlaybackUrl } from '../studioMedia.tk'
+
+// jsdom does not implement URL.createObjectURL / revokeObjectURL, so we define them
+// per-test and restore after. (videoPlaybackUrl falls back to the original src when
+// they are absent — exercised implicitly by the non-mocked cases.)
+const urlStatic = URL as unknown as {
+  createObjectURL?: (b: Blob) => string
+  revokeObjectURL?: (u: string) => void
+}
+
+describe('videoPlaybackUrl', () => {
+  afterEach(() => {
+    delete urlStatic.createObjectURL
+    delete urlStatic.revokeObjectURL
+    vi.restoreAllMocks()
+  })
+
+  it('returns empty + noop for an empty src', () => {
+    const { url, revoke } = videoPlaybackUrl('')
+    expect(url).toBe('')
+    expect(() => revoke()).not.toThrow()
+  })
+
+  it('hands an http(s) URL straight to the browser (no Blob, noop revoke)', () => {
+    const revokeFn = vi.fn()
+    urlStatic.revokeObjectURL = revokeFn
+    const { url, revoke } = videoPlaybackUrl('https://cdn.example/v.mp4')
+    expect(url).toBe('https://cdn.example/v.mp4')
+    revoke()
+    expect(revokeFn).not.toHaveBeenCalled() // http URL has no Blob to free
+  })
+
+  it('converts inline data:video to a tab-local Blob URL and revokes it', () => {
+    const create = vi.fn(() => 'blob:mock-123')
+    const revokeFn = vi.fn()
+    urlStatic.createObjectURL = create
+    urlStatic.revokeObjectURL = revokeFn
+    const { url, revoke } = videoPlaybackUrl('data:video/mp4;base64,AAAA')
+    expect(url).toBe('blob:mock-123')
+    expect(create).toHaveBeenCalledOnce()
+    revoke()
+    expect(revokeFn).toHaveBeenCalledWith('blob:mock-123')
+  })
+
+  it('falls back to the original src for a non-base64 data: URI', () => {
+    const { url } = videoPlaybackUrl('data:video/mp4,notbase64')
+    expect(url).toBe('data:video/mp4,notbase64')
+  })
+})

--- a/frontend/src/utils/studioMedia.tk.ts
+++ b/frontend/src/utils/studioMedia.tk.ts
@@ -1,0 +1,50 @@
+/**
+ * TokenKey-only: resolve a generated-video src into a browser-playable URL WITHOUT
+ * making TokenKey host the media — the #944 "not a media CDN" rule, shared by every
+ * Studio surface that plays video on demand (VideoStudio lightbox, Bake-Off panels).
+ *
+ * http(s) upstream URLs are handed to the browser as-is. An inline `data:video`
+ * result (the one response already delivered to this tab) is converted to a
+ * tab-local Blob URL so it plays without re-fetching and without persisting. The
+ * returned `revoke()` frees the Blob when playback closes (a no-op for http URLs).
+ *
+ * Never throws: on any failure (non-base64 data URI, missing atob/createObjectURL,
+ * decode error) it falls back to the original src with a no-op revoke, so a caller
+ * always gets something usable to hand to a <video :src>.
+ */
+export interface VideoPlayback {
+  /** URL ready for a <video :src> — http(s) upstream URL or a tab-local blob: URL. */
+  url: string
+  /** Free the Blob URL (no-op for http(s) URLs); call when playback closes. */
+  revoke: () => void
+}
+
+const NOOP = (): void => {}
+
+export function videoPlaybackUrl(src: string): VideoPlayback {
+  if (!src) return { url: '', revoke: NOOP }
+  // http(s) (incl. presigned upstream/S3) — hand straight to the browser, no Blob.
+  if (!/^data:video/i.test(src)) return { url: src, revoke: NOOP }
+  try {
+    const match = /^data:(video\/[\w.+-]+);base64,([A-Za-z0-9+/=]+)$/i.exec(src)
+    if (!match || typeof atob !== 'function' || typeof URL?.createObjectURL !== 'function') {
+      return { url: src, revoke: NOOP }
+    }
+    const binary = atob(match[2])
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+    const objectUrl = URL.createObjectURL(new Blob([bytes], { type: match[1] }))
+    return {
+      url: objectUrl,
+      revoke: () => {
+        try {
+          URL.revokeObjectURL?.(objectUrl)
+        } catch {
+          /* ignore */
+        }
+      },
+    }
+  } catch {
+    return { url: src, revoke: NOOP }
+  }
+}

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -122,9 +122,24 @@
         </template>
         <!-- video -->
         <template v-else>
-          <div v-if="p.url" class="overflow-hidden rounded-lg bg-black">
-            <video :src="p.url" controls class="aspect-video w-full"></video>
-          </div>
+          <!-- On-demand playback only: no always-on <video> (it shows a poster-less
+               black box pre-play and would race up to MAX_PANELS competing loads).
+               Poster tile → in-page lightbox, mirroring VideoStudio and sharing
+               videoPlaybackUrl so inline data:video plays tab-local without rehosting. -->
+          <button
+            v-if="p.url"
+            type="button"
+            class="group relative block aspect-video w-full overflow-hidden rounded-lg bg-gradient-to-br from-gray-800 to-gray-950"
+            data-testid="bakeoff-video-play"
+            :title="t('studio.video.play')"
+            @click="openVideoPreview(p)"
+          >
+            <span class="pointer-events-none absolute inset-0 flex items-center justify-center">
+              <span class="flex h-12 w-12 items-center justify-center rounded-full bg-white/90 shadow-lg transition group-hover:scale-110 group-hover:bg-white">
+                <span aria-hidden="true" class="ml-1 text-xl text-gray-900">▶</span>
+              </span>
+            </span>
+          </button>
           <div v-else class="flex aspect-video items-center justify-center rounded-lg bg-gray-50 text-xs text-gray-500 dark:bg-dark-800 dark:text-dark-400">
             <span v-if="p.state === 'processing'" class="inline-flex items-center gap-1.5"><span class="h-2 w-2 animate-pulse rounded-full bg-primary-500"></span>{{ t('studio.video.statusProcessing') }} {{ formatElapsed(p.elapsedS || 0) }}</span>
             <span v-else-if="p.state === 'failed'" class="text-red-500">{{ t('studio.bakeoff.failed') }}</span>
@@ -137,11 +152,36 @@
         </div>
       </div>
     </div>
+
+    <!-- In-page video lightbox: plays one panel on demand (http URL direct, inline
+         data:video as a tab-local Blob via the shared videoPlaybackUrl) instead of
+         rendering MAX_PANELS always-on <video> elements. -->
+    <Teleport to="body">
+      <div
+        v-if="videoPreview"
+        class="fixed inset-0 z-[100] flex flex-col bg-black/85 backdrop-blur-sm"
+        data-testid="bakeoff-video-preview"
+        @click.self="closeVideoPreview"
+      >
+        <div class="flex items-center justify-end p-3">
+          <button type="button" class="rounded-lg bg-white/10 px-3 py-1.5 text-sm font-medium text-white hover:bg-white/20" data-testid="bakeoff-video-preview-close" @click="closeVideoPreview">
+            {{ t('studio.video.close') }} ✕
+          </button>
+        </div>
+        <div class="flex min-h-0 flex-1 items-center justify-center px-4" @click.self="closeVideoPreview">
+          <video v-if="videoPreviewUrl" :src="videoPreviewUrl" controls autoplay playsinline class="max-h-full max-w-full rounded-lg bg-black shadow-2xl"></video>
+        </div>
+        <div class="flex flex-wrap items-center justify-center gap-3 p-4">
+          <span class="max-w-[60vw] truncate text-xs text-white/80" :title="videoPreview.label">{{ videoPreview.label }}</span>
+          <span class="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[11px] font-semibold text-white">{{ formatUsd(videoPreview.cost) }}</span>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { gatewayImageGenerations, gatewayVideoSubmit } from '@/api/playground'
 import { extractImageItems, extractVideoTaskId, videoStateFromFetch, extractVideoUrl } from '@/constants/playgroundMedia.tk'
@@ -154,6 +194,7 @@ import {
   type MediaPriceMap,
 } from '@/constants/mediaTiers.tk'
 import { estimateImageCost, estimateImageHoldCost, estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
+import { videoPlaybackUrl } from '@/utils/studioMedia.tk'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { useVideoTaskPoll } from '@/composables/useVideoTaskPoll'
 import type { VideoTaskItem } from '@/composables/useMediaLibrary'
@@ -226,6 +267,31 @@ const poll = useVideoTaskPoll({
   patch: patchVideoTask,
   onTerminal: () => emit('spent'),
 })
+
+// ---- In-page video lightbox (on-demand playback; no always-on <video>) ----------
+const videoPreview = ref<BakePanel | null>(null)
+const videoPreviewUrl = ref('')
+let videoPreviewRevoke: () => void = () => {}
+
+function openVideoPreview(panel: BakePanel): void {
+  if (!panel.url) return
+  videoPreviewRevoke()
+  // http(s) upstream URL plays directly; inline data:video becomes a tab-local Blob
+  // (shared with VideoStudio via videoPlaybackUrl — TokenKey never rehosts the clip).
+  const playback = videoPlaybackUrl(panel.url)
+  videoPreviewRevoke = playback.revoke
+  videoPreview.value = panel
+  videoPreviewUrl.value = playback.url
+}
+
+function closeVideoPreview(): void {
+  videoPreviewRevoke()
+  videoPreviewRevoke = () => {}
+  videoPreview.value = null
+  videoPreviewUrl.value = ''
+}
+
+onBeforeUnmount(closeVideoPreview)
 
 function selectedResolved() {
   return models.value.filter((r) => selectedModelIds.value.includes(r.model.modelId))

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -345,6 +345,7 @@ import {
 } from '@/constants/mediaTiers.tk'
 import { estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
 import { downloadMedia } from '@/utils/studioDownload.tk'
+import { videoPlaybackUrl } from '@/utils/studioMedia.tk'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { useMediaLibrary, type VideoTaskItem } from '@/composables/useMediaLibrary'
 import { useVideoTaskPoll, requestVideoNotifyPermission, maybeNotify } from '@/composables/useVideoTaskPoll'
@@ -495,49 +496,25 @@ const previewState = ref<'loading' | 'ready' | 'expired'>('loading')
 // Transient "copied" confirmation for the copy-link button (no toast/banner).
 const copied = ref(false)
 let copiedTimer: ReturnType<typeof setTimeout> | undefined
-let previewObjectUrl = ''
+let previewRevoke: () => void = () => {}
 
 async function openPreview(task: VideoTaskItem): Promise<void> {
   if (!task.url) return
-  revokePreviewObjectUrl()
+  previewRevoke()
   preview.value = task
   previewUrl.value = ''
   previewState.value = 'loading'
-  let url = task.url
-  // Video playback must not turn TokenKey into a media server. For http(s)
-  // upstream URLs, hand the URL directly to the browser. For inline data:video
-  // results, convert the one response already delivered to this tab into a
-  // temporary Blob URL and revoke it when the preview closes.
-  if (/^data:video/i.test(url)) {
-    url = dataVideoToObjectURL(url)
+  // Playback must not turn TokenKey into a media server: http(s) upstream URLs go
+  // straight to the browser; an inline data:video result becomes a tab-local Blob
+  // URL we revoke on close. Shared with Bake-Off via videoPlaybackUrl.
+  const playback = videoPlaybackUrl(task.url)
+  previewRevoke = playback.revoke
+  if (preview.value?.id !== task.id) {
+    playback.revoke()
+    return
   }
-  if (preview.value?.id !== task.id) return
-  previewUrl.value = url
-  previewState.value = url ? 'ready' : 'expired'
-}
-
-function dataVideoToObjectURL(dataUrl: string): string {
-  try {
-    const match = /^data:(video\/[\w.+-]+);base64,([A-Za-z0-9+/=]+)$/i.exec(dataUrl)
-    if (!match || typeof atob !== 'function' || typeof URL?.createObjectURL !== 'function') return dataUrl
-    const binary = atob(match[2])
-    const bytes = new Uint8Array(binary.length)
-    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
-    previewObjectUrl = URL.createObjectURL(new Blob([bytes], { type: match[1] }))
-    return previewObjectUrl
-  } catch {
-    return dataUrl
-  }
-}
-
-function revokePreviewObjectUrl(): void {
-  if (!previewObjectUrl) return
-  try {
-    URL.revokeObjectURL?.(previewObjectUrl)
-  } catch {
-    /* ignore */
-  }
-  previewObjectUrl = ''
+  previewUrl.value = playback.url
+  previewState.value = playback.url ? 'ready' : 'expired'
 }
 
 // The <video> failed to load. Degrade to a translated "expired" message + a
@@ -568,7 +545,8 @@ async function copyPreviewLink(): Promise<void> {
 }
 
 function closePreview(): void {
-  revokePreviewObjectUrl()
+  previewRevoke()
+  previewRevoke = () => {}
   preview.value = null
   previewUrl.value = ''
   copied.value = false
@@ -650,7 +628,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeydown)
   if (copiedTimer) clearTimeout(copiedTimer)
-  revokePreviewObjectUrl()
+  previewRevoke()
 })
 </script>
 

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -887,13 +887,22 @@
         "data-testid=\"studio-video-play\"",
         "data-testid=\"studio-video-preview\"",
         "data-testid=\"studio-video-copy-link\"",
-        "dataVideoToObjectURL",
-        "revokePreviewObjectUrl"
+        "videoPlaybackUrl"
       ],
       "must_not_contain": [
         "poll.refreshUrl"
       ],
-      "rationale": "TK-only Studio video-generation surface (mounted by MediaStudioView when mode==='video'). The model picker + generate button are the contract the studio e2e drives. studio-video-play (the succeeded-card poster tile) + studio-video-preview (the in-page lightbox) REPLACE the old always-on inline <video> and the open-in-new-tab link: the lightbox plays http(s) upstream URLs directly in the browser, while inline data:video results are converted into temporary Blob URLs for this tab and revoked on close/unmount. That keeps playback browser-local and prevents opening a succeeded card from refetching TokenKey as a video server. studio-video-copy-link remains the in-lightbox affordance for copying upstream/direct media URLs."
+      "rationale": "TK-only Studio video-generation surface (mounted by MediaStudioView when mode==='video'). The model picker + generate button are the contract the studio e2e drives. studio-video-play (the succeeded-card poster tile) + studio-video-preview (the in-page lightbox) REPLACE the old always-on inline <video> and the open-in-new-tab link: the lightbox plays http(s) upstream URLs directly in the browser, while inline data:video results are converted into temporary Blob URLs for this tab and revoked on close/unmount. That keeps playback browser-local and prevents opening a succeeded card from refetching TokenKey as a video server. The data:video->Blob conversion + revoke now lives in the shared videoPlaybackUrl helper (utils/studioMedia.tk.ts), used by both this lightbox and Bake-Off; this anchor pins that import/usage so the no-rehost playback can't be silently reverted to an always-on <video>. studio-video-copy-link remains the in-lightbox affordance for copying upstream/direct media URLs."
+    },
+    {
+      "path": "frontend/src/utils/studioMedia.tk.ts",
+      "must_contain": [
+        "export function videoPlaybackUrl",
+        "data:video",
+        "createObjectURL",
+        "revokeObjectURL"
+      ],
+      "rationale": "Shared Studio video-playback resolver enforcing the #944 'TokenKey is not a media CDN' rule for EVERY on-demand video surface (VideoStudio lightbox + Bake-Off panels). videoPlaybackUrl hands http(s) upstream URLs straight to the browser and converts an inline data:video result (the one response already delivered to this tab) into a tab-local Blob URL with a revoke() — never re-fetching or rehosting. Deleting/inlining this back into a single view risks one surface (e.g. Bake-Off) regressing to an always-on <video> that competes loads and black-boxes pre-play; the data:video + createObjectURL + revokeObjectURL anchors pin the conversion + cleanup."
     },
     {
       "path": "frontend/src/constants/mediaTiers.tk.ts",


### PR DESCRIPTION
## What & why

Final item of the media-pressure audit (#944 / #946). BakeOff rendered an **always-on** `<video :src="p.url" controls>` for every succeeded panel — up to `MAX_PANELS=4` whole clips inline-decoded at once, and for veo `p.url` is a full inline `data:video` base64 URI. This was the one place left that violated #944's no-always-on-`<video>` rule (VideoStudio already moved to a poster + on-demand lightbox).

## Change

- Extract the `data:video` → tab-local Blob conversion (+ `revoke`) into a shared **`videoPlaybackUrl`** util (`utils/studioMedia.tk.ts`).
- **VideoStudio**: refactored off its private `dataVideoToObjectURL`/`revokePreviewObjectUrl` onto the shared util — **behavior-preserving** (its spec still passes, including the lightbox copy-link case).
- **BakeOff**: replace the always-on `<video>` with a poster tile → in-page lightbox using the same util. http(s) upstream URLs play directly; inline `data:video` plays tab-local and is revoked on close/unmount, so TokenKey never rehosts the clip and panels no longer race competing loads.
- This is browser-CPU/consistency hygiene — **zero TK server cost** (BakeOff is ephemeral, ≤4 panels, never persisted).

## Sentinel

Moved the VideoStudio `data:video` anchor to `videoPlaybackUrl` and added a sentinel for the shared util, so the no-rehost playback stays guarded at its new home. The registry was updated in-PR (registry-update gate satisfied; no marker needed).

## Test plan

- `typecheck` + `lint:check` clean
- new `studioMedia.tk.spec.ts` (empty / http passthrough / data:video→Blob+revoke / non-base64 fallback) + existing VideoStudio + BakeOff specs — pass
- frontend TK sentinels 110/110; dist rebuilt; `scripts/preflight.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
