### PR TITLE
chore(dev-rules): 同步 PR body 中文规则

### DIFF
--- a/.cursor/rules/product-dev.mdc
+++ b/.cursor/rules/product-dev.mdc
@@ -173,7 +173,10 @@ spec delta 是意图载体，不是审批基线；若命中高风险条件，必
 - 提交消息聚焦"为什么"而非"改了什么"，一行说清单个原子变化的原因
 - 每个 PR 只解决一个问题，不混合无关变更
 - 不默认拆出 docs/prototype/dev/release 多个 PR；只有真实决策边界或风险隔离需求，才拆 PR
-- PR 描述默认只保留 `Summary`、`Risk`、`Validation`；只有高风险变更才展开 `Design` / `Contract` / `Migration`
+- PR body 必须用中文撰写；技术名词、命令、错误码、commit subject 可保留英文
+- PR 描述默认只保留中文小节：`摘要`、`风险`、`验证`、`提交`；只有高风险变更才展开 `设计` / `契约` / `迁移`
+- `提交` 小节必须从当前 PR commit 集合生成，至少包含相对 base 的所有 commit short SHA + subject，并包含 `最新提交：<HEAD short SHA>` freshness anchor
+- 每产生新的 commit 后，必须在 push 或继续 review 前用当前 `git log --oneline <base>..HEAD` 重写整个 PR body；禁止沿用旧 body 或只追加零散备注
 - review comment 默认只报阻塞问题、真实风险、缺失验证；不输出大而全的审计散文
 - 公共契约删除必须在 commit subject/body 显式声明删除说明锚点（如 `contract-deletion-notice`），禁止静默删约。
 - 有 Web surface 的仓库中，后端服务/业务逻辑改动必须同 PR 对齐对应 Web 页面、配置、契约或 Story；确无影响时必须在 commit message 中写明 `no-web-impact` / `Web impact: none`，让 preflight 可机械验证。
@@ -193,7 +196,7 @@ spec delta 是意图载体，不是审批基线；若命中高风险条件，必
 当作为 Background Agent 或 Long-running Agent 执行时：
 - 每完成一个可验证的里程碑，立即提交并推送
 - 如果连续 3 次尝试同一问题未成功，暂停并记录分析，等待人工介入
-- 产出 PR 时默认附带精简的 `Summary`、`Risk`、`Validation`；只有高风险变更才附设计/迁移等展开内容
+- 产出 PR 时默认附带精简中文 `摘要`、`风险`、`验证`、`提交`；每次新增 commit 后先重写 PR body 再 push / review
 - 高风险原型阶段完成后必须暂停等待审批，不得自行进入功能实现阶段
 
 ## 完成自检（提交前必做）


### PR DESCRIPTION
## 摘要
同步 dev-rules 已合并的 PR body 规则到 sub2api，并把 `dev-rules` submodule 指针前移到最新合并点位 `bc8d007`。
规则要求 PR body 使用中文，并在新增 commit 后按当前提交列表重写。

## 风险
低风险。变更只影响 agent 工作规则和 dev-rules submodule 指针，不改运行时代码；主要风险是旧流程未及时按中文 PR body 和最新提交锚点更新。

## 验证
已运行 `./scripts/preflight.sh`，通过 dev-rules template 和 sub2api 项目门禁。
已运行 `/Users/xuejiao/Codes/dev-rules/sync.sh --all`，确认规则同步到本地项目。

## 提交
536118020 chore(dev-rules): sync PR body rules

最新提交：536118020
