### PR TITLE
fix(ops): format account incident notifier

### DIFF
--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -171,14 +171,14 @@ type TKAccountIncidentNotifier struct {
 	siteID      string
 	now         func() time.Time
 
-	mu                sync.Mutex
-	permSentAt        map[string]time.Time                   // 永久失效去重: key -> 上次发送
-	permLimiter       *slidingWindowLimiter                  // 永久失效防爆量
-	digest            map[string]*accountIncidentDigestEntry // reasonClass -> 聚合条目
-	active            map[int64]map[string]*activeIncident   // accountID -> reasonClass -> 活跃事件(恢复台账)
-	recoverySentAt    map[int64]time.Time                    // 恢复绿卡去重: accountID -> 上次发送
-	poolExhaustSentAt map[string]time.Time                   // 平台池全不可调度 P0「待恢复」台账: platform -> 告警时刻(兼作 10min 去重)
-	claudeIncidentSentAt time.Time                           // Claude API 上游故障 P0 去重 + 恢复闭环台账
+	mu                   sync.Mutex
+	permSentAt           map[string]time.Time                   // 永久失效去重: key -> 上次发送
+	permLimiter          *slidingWindowLimiter                  // 永久失效防爆量
+	digest               map[string]*accountIncidentDigestEntry // reasonClass -> 聚合条目
+	active               map[int64]map[string]*activeIncident   // accountID -> reasonClass -> 活跃事件(恢复台账)
+	recoverySentAt       map[int64]time.Time                    // 恢复绿卡去重: accountID -> 上次发送
+	poolExhaustSentAt    map[string]time.Time                   // 平台池全不可调度 P0「待恢复」台账: platform -> 告警时刻(兼作 10min 去重)
+	claudeIncidentSentAt time.Time                              // Claude API 上游故障 P0 去重 + 恢复闭环台账
 
 	// poolSchedulableCounter 由 RateLimitService 注入(见 ProvideTKAccountIncidentNotifier),
 	// 返回某平台当前可调度账号数。池恢复轮询据此把空池火警闭环成「池已恢复」绿卡。


### PR DESCRIPTION
## 背景
- PR #957 合并后，main 分支 CI 的 golangci-lint job 在 `backend/internal/service/account_incident_notifier_tk.go` 报 `File is not properly formatted (gofmt)`。
- 失败点不在 #957 diff 内，本 PR 仅修复主干上已有的格式漂移。

## 变更
- 对 `TKAccountIncidentNotifier` 字段声明运行 `gofmt`，无业务逻辑变化。

## 风险
- 仅格式化 Go 结构体字段对齐，运行时行为不变。
- Web impact: none
- sentinel-registry-reviewed：本 PR 只有 gofmt 造成的删除/插入行，无 TK/NewAPI 哨兵锚点变化。

## 验证
- `golangci-lint run --path-mode=abs --concurrency=4 --timeout=30m`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`