### PR TITLE
fix: restore kiro fallback for universal anthropic routing

### DIFF
--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -2495,7 +2495,18 @@ func (s *adminServiceImpl) grantExclusiveGroupMembership(ctx context.Context, gr
 }
 
 func (s *adminServiceImpl) UpdateGroupSortOrders(ctx context.Context, updates []GroupSortOrderUpdate) error {
-	return s.groupRepo.UpdateSortOrders(ctx, updates)
+	if err := s.groupRepo.UpdateSortOrders(ctx, updates); err != nil {
+		return err
+	}
+	if s.authCacheInvalidator != nil {
+		for _, u := range updates {
+			if u.ID <= 0 {
+				continue
+			}
+			s.authCacheInvalidator.InvalidateAuthCacheByGroupID(ctx, u.ID)
+		}
+	}
+	return nil
 }
 
 // AdminUpdateAPIKeyGroupID 管理员修改 API Key 分组绑定

--- a/backend/internal/service/admin_service_group_test.go
+++ b/backend/internal/service/admin_service_group_test.go
@@ -22,6 +22,8 @@ type groupRepoStubForAdmin struct {
 	getByID *Group // GetByID 返回值
 	getErr  error  // GetByID 返回的错误
 
+	sortUpdates []GroupSortOrderUpdate
+
 	listWithFiltersCalls       int
 	listWithFiltersParams      pagination.PaginationParams
 	listWithFiltersPlatform    string
@@ -121,7 +123,8 @@ func (s *groupRepoStubForAdmin) GetAccountIDsByGroupIDs(_ context.Context, _ []i
 	panic("unexpected GetAccountIDsByGroupIDs call")
 }
 
-func (s *groupRepoStubForAdmin) UpdateSortOrders(_ context.Context, _ []GroupSortOrderUpdate) error {
+func (s *groupRepoStubForAdmin) UpdateSortOrders(_ context.Context, updates []GroupSortOrderUpdate) error {
+	s.sortUpdates = append([]GroupSortOrderUpdate(nil), updates...)
 	return nil
 }
 
@@ -373,6 +376,26 @@ func TestAdminService_UpdateGroup_InvalidatesAuthCacheOnRPMLimitChange(t *testin
 	require.NotNil(t, group)
 	require.Equal(t, 60, repo.updated.RPMLimit)
 	require.Equal(t, []int64{1}, invalidator.groupIDs, "分组 RPMLimit 写入 auth snapshot，变更后必须失效 API Key 认证缓存")
+}
+
+func TestAdminService_UpdateGroupSortOrders_InvalidatesAuthCache(t *testing.T) {
+	repo := &groupRepoStubForAdmin{}
+	invalidator := &authCacheInvalidatorStub{}
+	svc := &adminServiceImpl{
+		groupRepo:            repo,
+		authCacheInvalidator: invalidator,
+	}
+
+	err := svc.UpdateGroupSortOrders(context.Background(), []GroupSortOrderUpdate{
+		{ID: 1, SortOrder: 10},
+		{ID: 15, SortOrder: 150},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []GroupSortOrderUpdate{
+		{ID: 1, SortOrder: 10},
+		{ID: 15, SortOrder: 150},
+	}, repo.sortUpdates)
+	require.Equal(t, []int64{1, 15}, invalidator.groupIDs, "分组排序影响 universal 选组，更新后必须失效相关 auth/universal 缓存")
 }
 
 func TestAdminService_CreateGroup_NormalizesMessagesDispatchModelConfig(t *testing.T) {

--- a/backend/internal/service/anthropic_config_reconciler.go
+++ b/backend/internal/service/anthropic_config_reconciler.go
@@ -74,6 +74,7 @@ type reconcilerAccountStore interface {
 	ListByPlatform(ctx context.Context, platform string) ([]Account, error)
 	SumConcurrencyAnthropic(ctx context.Context) (int64, error)
 	BulkUpdate(ctx context.Context, ids []int64, updates AccountBulkUpdate) (int64, error)
+	BindGroups(ctx context.Context, accountID int64, groupIDs []int64) error
 }
 
 // reconcilerUserStore is the narrow user dependency for the operator Σ sync and
@@ -290,6 +291,11 @@ func (r *AnthropicConfigReconciler) runOnce(ctx context.Context) {
 	// Step B: pool_mode self-heal on prod mirror stubs.
 	r.reconcileStubPoolMode(ctx, accounts)
 
+	// Step B-groups: keep kiro mirror stubs group-parity with their anthropic
+	// sibling stub on the same edge host, while retaining any kiro-local extra
+	// bindings already present on the kiro stub (e.g. kiro-edges).
+	r.reconcileKiroMirrorStubGroups(ctx, accounts)
+
 	// Step T: value-sync each tier-bound anthropic OAUTH account's concurrency
 	// column from its tier row (the reference-table write-source). Runs before
 	// Step A so the operator Σ reflects any concurrency it just re-asserted.
@@ -451,6 +457,70 @@ func (r *AnthropicConfigReconciler) reconcileStubPoolMode(ctx context.Context, a
 		slog.Info("anthropic config reconciler: stub pool_mode self-healed (local deployment only)",
 			"account_id", a.ID, "account_name", a.Name,
 			"pool_mode", wantPool, "pool_mode_retry_count", wantRetry)
+	}
+}
+
+// reconcileKiroMirrorStubGroups keeps every prod kiro mirror stub reachable from
+// the same anthropic groups as its sibling anthropic mirror stub on the same edge
+// host (same credentials.base_url), while preserving any kiro-local extra groups
+// the kiro stub already carries. This closes the prod routing gap where group-
+// scoped Claude Code traffic (for example cc-edges / paopi groups) could select
+// the anthropic sibling but never the kiro mirror because the kiro stub was only
+// bound to default + a kiro-local group.
+func (r *AnthropicConfigReconciler) reconcileKiroMirrorStubGroups(ctx context.Context, accounts []Account) {
+	doc, re, err := baseline.LoadStubPoolBaseline()
+	if err != nil {
+		slog.Warn("anthropic config reconciler: load stub-pool baseline failed (kiro groups)", "err", err)
+		return
+	}
+	_ = doc
+
+	sourceGroupsByBaseURL := make(map[string][]int64)
+	for i := range accounts {
+		a := &accounts[i]
+		if !r.isMirrorStub(a, re) {
+			continue
+		}
+		if mirrorCapacityPlatform(a.GetCredential("mirror_platform")) != PlatformAnthropic {
+			continue
+		}
+		baseURL := normalizeMirrorStubBaseURL(a.GetCredential("base_url"))
+		if baseURL == "" {
+			continue
+		}
+		sourceGroupsByBaseURL[baseURL] = appendUniquePositiveInt64s(sourceGroupsByBaseURL[baseURL], a.GroupIDs)
+	}
+
+	for i := range accounts {
+		a := &accounts[i]
+		if !r.isMirrorStub(a, re) {
+			continue
+		}
+		if mirrorCapacityPlatform(a.GetCredential("mirror_platform")) != PlatformKiro {
+			continue
+		}
+		baseURL := normalizeMirrorStubBaseURL(a.GetCredential("base_url"))
+		if baseURL == "" {
+			continue
+		}
+		siblingGroupIDs := sourceGroupsByBaseURL[baseURL]
+		if len(siblingGroupIDs) == 0 {
+			continue
+		}
+		desiredGroupIDs := append([]int64(nil), siblingGroupIDs...)
+		desiredGroupIDs = appendMissingPositiveInt64s(desiredGroupIDs, a.GroupIDs)
+		if int64SlicesEqual(a.GroupIDs, desiredGroupIDs) {
+			continue
+		}
+		if err := r.accounts.BindGroups(ctx, a.ID, desiredGroupIDs); err != nil {
+			slog.Warn("anthropic config reconciler: kiro mirror stub group self-heal write failed",
+				"account_id", a.ID, "account_name", a.Name, "base_url", baseURL,
+				"want_group_ids", desiredGroupIDs, "err", err)
+			continue
+		}
+		slog.Info("anthropic config reconciler: kiro mirror stub groups self-healed (local deployment only)",
+			"account_id", a.ID, "account_name", a.Name, "base_url", baseURL,
+			"group_ids", desiredGroupIDs)
 	}
 }
 
@@ -623,4 +693,48 @@ func (r *AnthropicConfigReconciler) isMirrorStub(a *Account, re interface{ Match
 	}
 	baseURL := strings.TrimSpace(a.GetCredential("base_url"))
 	return baseURL != "" && re.MatchString(baseURL)
+}
+
+func normalizeMirrorStubBaseURL(raw string) string {
+	baseURL := strings.ToLower(strings.TrimSpace(raw))
+	return strings.TrimRight(baseURL, "/")
+}
+
+func appendUniquePositiveInt64s(dst []int64, src []int64) []int64 {
+	if len(src) == 0 {
+		return dst
+	}
+	seen := make(map[int64]struct{}, len(dst)+len(src))
+	for _, id := range dst {
+		if id > 0 {
+			seen[id] = struct{}{}
+		}
+	}
+	for _, id := range src {
+		if id <= 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		dst = append(dst, id)
+	}
+	return dst
+}
+
+func appendMissingPositiveInt64s(dst []int64, src []int64) []int64 {
+	return appendUniquePositiveInt64s(dst, src)
+}
+
+func int64SlicesEqual(a []int64, b []int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/backend/internal/service/anthropic_config_reconciler_test.go
+++ b/backend/internal/service/anthropic_config_reconciler_test.go
@@ -22,14 +22,21 @@ type reconcilerAccountStub struct {
 	byPlatform map[string][]Account // optional per-platform override (runOnce now lists anthropic AND kiro)
 	sum        int64
 	bulkCalls  []bulkUpdateCall
+	bindCalls  []bindGroupsCall
 	listErr    error
 	sumErr     error
 	bulkErr    error
+	bindErr    error
 }
 
 type bulkUpdateCall struct {
 	ids     []int64
 	updates AccountBulkUpdate
+}
+
+type bindGroupsCall struct {
+	accountID int64
+	groupIDs  []int64
 }
 
 func (s *reconcilerAccountStub) ListByPlatform(ctx context.Context, platform string) ([]Account, error) {
@@ -69,6 +76,15 @@ func (s *reconcilerAccountStub) BulkUpdate(ctx context.Context, ids []int64, upd
 	}
 	s.bulkCalls = append(s.bulkCalls, bulkUpdateCall{ids: ids, updates: updates})
 	return int64(len(ids)), nil
+}
+
+func (s *reconcilerAccountStub) BindGroups(ctx context.Context, accountID int64, groupIDs []int64) error {
+	if s.bindErr != nil {
+		return s.bindErr
+	}
+	dup := append([]int64(nil), groupIDs...)
+	s.bindCalls = append(s.bindCalls, bindGroupsCall{accountID: accountID, groupIDs: dup})
+	return nil
 }
 
 type reconcilerUserStub struct {
@@ -437,6 +453,97 @@ func TestReconciler_SurfaceC_DefaultsToAnthropicWhenUnset(t *testing.T) {
 
 	require.Contains(t, doer.lastURL, "platform=anthropic")
 	require.NotContains(t, doer.lastURL, "platform=kiro")
+}
+
+func TestReconciler_KiroMirrorStubGroups_InheritsAnthropicSiblingGroups(t *testing.T) {
+	ccStub := Account{
+		ID:       55,
+		Name:     "cc-us6",
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		GroupIDs: []int64{1, 15},
+		Credentials: map[string]any{
+			"base_url": "https://api-us6.tokenkey.dev",
+			"api_key":  "sk-cc",
+		},
+	}
+	kiroStub := Account{
+		ID:       66,
+		Name:     "kiro-us6",
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		GroupIDs: []int64{1, 17},
+		Credentials: map[string]any{
+			"base_url":        "https://api-us6.tokenkey.dev",
+			"api_key":         "sk-kiro",
+			"mirror_platform": "kiro",
+		},
+	}
+	acc := &reconcilerAccountStub{accounts: []Account{ccStub, kiroStub}, sum: 0}
+	usr := &reconcilerUserStub{user: &User{ID: 1, Concurrency: 0}}
+	r := newTestReconciler(acc, usr, &reconcilerBalanceStub{}, mirrorEnabledCfg(false, false))
+
+	r.runOnce(context.Background())
+
+	require.Len(t, acc.bindCalls, 1, "kiro mirror stub missing sibling groups must be rebound once")
+	require.Equal(t, int64(66), acc.bindCalls[0].accountID)
+	require.Equal(t, []int64{1, 15, 17}, acc.bindCalls[0].groupIDs,
+		"kiro stub must inherit sibling anthropic groups first, while preserving its own kiro-local group")
+}
+
+func TestReconciler_KiroMirrorStubGroups_AlreadyAligned_NoWrite(t *testing.T) {
+	ccStub := Account{
+		ID:       55,
+		Name:     "cc-us6",
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		GroupIDs: []int64{1, 15},
+		Credentials: map[string]any{
+			"base_url": "https://api-us6.tokenkey.dev",
+			"api_key":  "sk-cc",
+		},
+	}
+	kiroStub := Account{
+		ID:       66,
+		Name:     "kiro-us6",
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		GroupIDs: []int64{1, 15, 17},
+		Credentials: map[string]any{
+			"base_url":        "https://api-us6.tokenkey.dev",
+			"api_key":         "sk-kiro",
+			"mirror_platform": "kiro",
+		},
+	}
+	acc := &reconcilerAccountStub{accounts: []Account{ccStub, kiroStub}, sum: 0}
+	usr := &reconcilerUserStub{user: &User{ID: 1, Concurrency: 0}}
+	r := newTestReconciler(acc, usr, &reconcilerBalanceStub{}, mirrorEnabledCfg(false, false))
+
+	r.runOnce(context.Background())
+
+	require.Empty(t, acc.bindCalls, "aligned kiro mirror stub groups must not be rebound")
+}
+
+func TestReconciler_KiroMirrorStubGroups_NoAnthropicSibling_NoWrite(t *testing.T) {
+	kiroStub := Account{
+		ID:       66,
+		Name:     "kiro-us6",
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		GroupIDs: []int64{1, 17},
+		Credentials: map[string]any{
+			"base_url":        "https://api-us6.tokenkey.dev",
+			"api_key":         "sk-kiro",
+			"mirror_platform": "kiro",
+		},
+	}
+	acc := &reconcilerAccountStub{accounts: []Account{kiroStub}, sum: 0}
+	usr := &reconcilerUserStub{user: &User{ID: 1, Concurrency: 0}}
+	r := newTestReconciler(acc, usr, &reconcilerBalanceStub{}, mirrorEnabledCfg(false, false))
+
+	r.runOnce(context.Background())
+
+	require.Empty(t, acc.bindCalls, "without an anthropic sibling source, kiro stub groups must be left unchanged")
 }
 
 func TestReconciler_SurfaceC_NeverWritesZeroOnFailure(t *testing.T) {

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -15,9 +15,12 @@
       "must_contain": [
         "func mirrorCapacityPlatform",
         "mirror_platform",
+        "r.reconcileKiroMirrorStubGroups(ctx, accounts)",
+        "func (r *AnthropicConfigReconciler) reconcileKiroMirrorStubGroups",
+        "r.accounts.BindGroups(ctx, a.ID, desiredGroupIDs)",
         "r.reconcileKiroPriorityBaseline(ctx)"
       ],
-      "rationale": "Prod side of surface-C: reads each mirror stub's credentials.mirror_platform (default anthropic) and queries the matching edge pool. Losing mirrorCapacityPlatform collapses the anthropic/kiro distinction so every mirror stub queries ?platform=anthropic again and a kiro stub silently mirrors the anthropic Σ. The r.reconcileKiroPriorityBaseline(ctx) call in runOnce is the wiring of the kiro priority self-heal step; losing the call leaves the step defined but never run."
+      "rationale": "Prod side of surface-C and group reachability: reads each mirror stub's credentials.mirror_platform (default anthropic) and queries the matching edge pool. Losing mirrorCapacityPlatform collapses the anthropic/kiro distinction so every mirror stub queries ?platform=anthropic again and a kiro stub silently mirrors the anthropic Σ. The reconcileKiroMirrorStubGroups call/function/BindGroups write keep a kiro mirror stub reachable from the same prod groups as its anthropic sibling on the same edge host; losing this regresses group-scoped universal routing to the 2026-06 failure mode where cc-us6 is visible in group 15 but kiro-us6 is not, so no failover target exists. The r.reconcileKiroPriorityBaseline(ctx) call in runOnce is the wiring of the kiro priority self-heal step; losing the call leaves the step defined but never run."
     },
     {
       "path": "backend/internal/repository/account_repo.go",
@@ -34,6 +37,15 @@
         "TestEdgeCapacityHandler_KiroUsesPlatformWideSum"
       ],
       "rationale": "Load-bearing QA evidence that the kiro capacity arm reads SumConcurrencyByPlatform(\"kiro\") and never the anthropic-group sum — the exact regression (kiro stub mirrors the anthropic number) this surface closes. Matches the *_tk_*_test.go hotspot-evidence rule."
+    },
+    {
+      "path": "backend/internal/service/anthropic_config_reconciler_test.go",
+      "must_contain": [
+        "TestReconciler_KiroMirrorStubGroups_InheritsAnthropicSiblingGroups",
+        "TestReconciler_KiroMirrorStubGroups_AlreadyAligned_NoWrite",
+        "TestReconciler_KiroMirrorStubGroups_NoAnthropicSibling_NoWrite"
+      ],
+      "rationale": "Load-bearing QA evidence for the prod-side kiro mirror group self-heal. These tests pin the three behaviors needed for group-scoped universal routing failover: kiro inherits sibling anthropic groups on the same edge, already-aligned stubs do not churn, and a kiro stub with no anthropic sibling is left untouched."
     },
     {
       "path": "backend/internal/domain/constants.go",


### PR DESCRIPTION
## 摘要
- 修复 universal anthropic 路由下 `kiro-us6` 无法接替 `cc-us6` 的问题
- 让同一 edge 的 kiro mirror stub 自动继承 anthropic sibling 的分组绑定，同时保留 kiro 自己的本地分组
- 修复 Admin UI 修改 `sort_order` 后 universal 选组仍使用旧结果的问题，补上按组失效 auth/universal cache
- 给 kiro mirror group self-heal 增加 `scripts/sentinels/kiro.json` 门禁，防止后续 upstream merge 静默覆盖
- sentinel-registry-reviewed

## 风险
- 影响范围集中在 anthropic mirror stub 分组自愈，以及 admin 分组排序写入后的缓存失效
- 改动不会改变 Admin UI 配置入口，也不改外部 API 契约
- 主要风险是自愈逻辑误改已有 kiro 本地分组；本次实现是“继承 sibling 分组 + 保留已有组”，不是覆盖写
- 新增 sentinel 只锚定既有实现和回归测试，不改变运行时行为

## 验证
- `python3 scripts/sentinels/check-kiro.py`
- `go test -tags unit ./internal/service -run 'TestAdminService_(UpdateGroupSortOrders_InvalidatesAuthCache|UpdateGroup_InvalidatesAuthCacheOnRPMLimitChange)|TestAnthropicConfigReconciler'`
- `scripts/preflight.sh`
- 结合历史日志复盘确认：故障时 `api_key_id=5 (tk)` 的 universal 路由命中 `group_id=15`，而 `kiro-us6` 当时不在该组；同时确认 sort_order 调整后仍继续命中旧组，是缓存未失效导致

## 提交
- b5978ce45 fix: restore kiro fallback for universal anthropic routing
- 3980f0b38 test: guard kiro mirror group self-heal
- 最新提交：3980f0b38
