### PR TITLE
feat: harden kiro reauth skill workflow

### DIFF
--- a/.cursor/skills/tokenkey-kiro-reauth/SKILL.md
+++ b/.cursor/skills/tokenkey-kiro-reauth/SKILL.md
@@ -205,6 +205,9 @@ python3 .cursor/skills/tokenkey-kiro-reauth/scripts/apply_edge_kiro_oauth.py \
 Important:
 
 - Do not paste secrets into shell history, SSM command text, or chat.
+- `apply_edge_kiro_oauth.py` now does a read-before-write identity check via
+  `GET /api/v1/admin/accounts/:id`; keep `--expected-account-name` accurate and
+  treat a mismatch as a stop-the-line signal, not a warning.
 - Do not update a broad `WHERE platform='kiro'` set.
 - Do not overwrite full `extra` JSON with a credentials-only payload.
 - `apply-oauth-credentials` already invalidates token cache; do not add a blind

--- a/.cursor/skills/tokenkey-kiro-reauth/SKILL.md
+++ b/.cursor/skills/tokenkey-kiro-reauth/SKILL.md
@@ -5,132 +5,99 @@ description: TokenKey Kiro OAuth re-authorization and refresh troubleshooting wo
 
 # TokenKey: Kiro Re-OAuth Runbook
 
-This skill handles the Kiro OAuth lifecycle on TokenKey edges: diagnose whether
-Kiro is failing, extract fresh credentials from a locally re-authorized Kiro IDE,
-apply them to the correct edge account, clear runtime state, and verify traffic.
+This skill repairs a Kiro OAuth account on a TokenKey edge and proves the edge
+can still serve real Kiro traffic.
 
-Use `tokenkey-online-log-troubleshooting` and `tokenkey-online-traffic-profile`
-alongside this skill for live SSM probes. This skill adds the Kiro-specific
-decision tree and reauth steps.
+Use `tokenkey-online-log-troubleshooting` and
+`tokenkey-online-traffic-profile` for generic logs/traffic windows. This skill
+adds the Kiro-specific auth/apply/verify workflow plus bundled scripts for the
+mechanical steps:
+
+- `.cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py`
+- `.cursor/skills/tokenkey-kiro-reauth/scripts/local_kiro_credentials.py`
+- `.cursor/skills/tokenkey-kiro-reauth/scripts/apply_edge_kiro_oauth.py`
+- `.cursor/skills/tokenkey-kiro-reauth/scripts/compare_auth_summaries.py`
+- `.cursor/skills/tokenkey-kiro-reauth/scripts/probe_edge_auth_summary.sh`
+- `.cursor/skills/tokenkey-kiro-reauth/scripts/probe_real_kiro_request.sh`
 
 ## Ground Rules
 
-- Treat all Kiro credentials as secrets. Never print access_token,
-  refresh_token, client_secret, or full credentials JSON in chat or logs.
-- Prefer a read-only diagnosis first. Writing refreshed credentials to an edge is
-  a live operation and requires an explicit user request such as "update us6".
-- Use `ops/observability/run-probe.sh --target edge:<id>` for remote read-only
-  probes when possible. If a custom probe is needed, create a temporary file via
-  `apply_patch`, run it, then delete it before final response.
-- Every remote SELECT must output field-named JSON (`row_to_json` or
-  `jsonb_build_object`). Do not rely on column positions.
+- Treat all Kiro credentials as secrets. Never print `access_token`,
+  `refresh_token`, `client_secret`, or full credentials JSON in chat or logs.
+- Prefer read-only diagnosis first. Writing refreshed credentials to an edge is
+  a live operation and requires explicit user authorization.
 - Use exact account identity before writing: edge id, account id, account name,
-  platform=`kiro`, type=`oauth`, group, status, schedulable.
-- Do not use `probe-caps.sh PLATFORM=kiro` alone to attribute errors. Its error
-  filter also includes global "no available/rate_limit" keywords; those can be
-  Anthropic account errors on the same edge.
+  `platform=kiro`, `type=oauth`, group binding, status, schedulable.
+- Use `ops/observability/run-probe.sh --target edge:<id>` for remote probes.
+  If a custom temporary probe is required, create it via `apply_patch`, run it,
+  then delete it before the final response.
+- Every remote SQL query must emit field-named JSON (`row_to_json` or
+  `jsonb_build_object`). Never rely on column positions.
 
-## Decision Tree
+## False Signals: Do Not Treat These As Kiro Truth
 
-1. **Current traffic check**: If the user asks whether Kiro is failing now, run a
-   read-only edge probe for account roster, `usage_logs`, `ops_error_logs`, and
-   gateway completed logs scoped to Kiro.
-2. **Refresh capability check**: If the user asks why reauth repeats, inspect
-   Kiro token metadata and token_refresh logs before assuming refresh is broken.
-3. **Reauth apply**: If the user says local Kiro has been re-authorized and asks
-   to update an edge, extract fresh local credentials, apply them to the target
-   edge account, clear error/temp-unschedulable/token cache, then verify.
-4. **Postmortem**: Explain whether the event was:
-   - benign expiry/refresh race, which background refresh should recover;
-   - failed refresh due to invalid_grant/invalid_client, which needs reauth;
-   - 401 on still-valid access token, which indicates upstream grant revocation
-     and cannot be fixed by refreshing the same grant.
+- `probe-caps.sh PLATFORM=kiro` alone is not enough to attribute an incident. It
+  also catches global `no available` / rate-limit rows that may belong to
+  Anthropic on the same edge.
+- `POST /api/v1/admin/accounts/:id/refresh` is not Kiro-safe today. In
+  `backend/internal/handler/admin/account_handler.go`, Kiro falls through to the
+  Anthropic OAuth refresh branch. Use it only as code diagnosis, not as Kiro
+  remediation or proof.
+- `GET /api/v1/admin/accounts/:id/usage?source=active&force=true` is not Kiro
+  `/v1/messages` truth. `backend/internal/service/account_usage_service.go`
+  drives the Anthropic OAuth usage probe path there. A 401 on that endpoint does
+  **not** prove Kiro message routing is broken.
+- `POST /api/v1/admin/accounts/:id/apply-oauth-credentials` clears account error
+  and invalidates token cache, but does **not** guarantee `schedulable=true`.
+  Always verify `schedulable` after apply, and flip it explicitly if still
+  false.
+- On Stage0 edges, host `localhost:8080` is often not bound. Real Kiro probes
+  should run **inside** the `tokenkey` container against
+  `http://localhost:8080`, or hit the public domain via Caddy if container exec
+  is unavailable.
 
-## Local Credential Extraction
+## Deterministic Workflow
 
-Use this only after the user confirms Kiro was opened and re-authorized locally.
-Run locally on the operator machine; do not persist the output to a repo file.
+Default to the orchestrator unless you are debugging a specific phase:
 
 ```bash
-python3 - <<'PY'
-import glob, json, os, time
-from datetime import datetime
-
-def unix_seconds(value):
-    if value in (None, ""):
-        return None
-    if isinstance(value, str):
-        raw = value.strip()
-        normalized = raw.replace("UTC", "+00:00")
-        if normalized.endswith("Z"):
-            normalized = normalized[:-1] + "+00:00"
-        try:
-            return str(int(datetime.fromisoformat(normalized).timestamp()))
-        except ValueError:
-            value = raw
-    try:
-        n = int(float(value))
-    except (TypeError, ValueError):
-        return None
-    if n > 10_000_000_000:
-        n //= 1000
-    return str(n)
-
-cache = os.path.expanduser("~/.aws/sso/cache")
-tok_path = os.path.join(cache, "kiro-auth-token.json")
-t = json.load(open(tok_path, encoding="utf-8"))
-auth = "social" if str(t.get("authMethod", "")).lower() == "social" else "idc"
-out = {
-    "access_token": t["accessToken"],
-    "refresh_token": t["refreshToken"],
-    "region": t.get("region", "us-east-1"),
-    "auth_method": auth,
-}
-expires_at = unix_seconds(t.get("expiresAt") or t.get("expires_at"))
-if expires_at is None and t.get("expiresIn") not in (None, ""):
-    expires_at = str(int(time.time()) + int(float(t["expiresIn"])))
-if expires_at:
-    out["expires_at"] = expires_at
-if auth == "idc":
-    regs = []
-    for path in glob.glob(os.path.join(cache, "*.json")):
-        if path.endswith("kiro-auth-token.json"):
-            continue
-        try:
-            j = json.load(open(path, encoding="utf-8"))
-        except Exception:
-            continue
-        if "clientSecret" in j and "clientId" in j:
-            regs.append((os.path.getmtime(path), path, j))
-    if not regs:
-        raise SystemExit("missing Kiro IdC client registration in ~/.aws/sso/cache")
-    regs.sort(key=lambda item: (item[0], item[1]), reverse=True)
-    reg = regs[0][2]
-    out["client_id"] = reg["clientId"]
-    out["client_secret"] = reg["clientSecret"]
-print(json.dumps(out, ensure_ascii=False, indent=2))
-PY
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
+  --edge-id <edge> \
+  --account-id <id> \
+  --account-name <name> \
+  --apply \
+  --ensure-schedulable \
+  --verify-real-request \
+  --admin-password-file ~/Codes/keys/tokenkey-<edge>-admin-password.txt
 ```
 
-Important shape:
+Useful variants:
 
-- `auth_method=idc` requires `client_id` and `client_secret`.
-- `auth_method=social` uses only `refresh_token` for refresh.
-- `expires_at` must be Unix seconds when present. If local cache does not expose
-  it, derive it by refreshing once through the existing TokenKey Kiro refresh
-  path before apply. Do not keep a stale far-future `expires_at` from the
-  revoked grant with a newly re-authorized access token.
+```bash
+# read-only plan / target resolution only
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
+  --edge-id <edge> --account-id <id> --account-name <name> --plan-only
 
-## Edge Diagnosis Probe
+# local reauth already fresh, compare only, no writes
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
+  --edge-id <edge> --account-id <id> --account-name <name>
 
-Resolve and identify the target:
+# mint a fresh local access token first, then apply and verify
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
+  --edge-id <edge> --account-id <id> --account-name <name> \
+  --local-refresh --apply --ensure-schedulable --verify-real-request \
+  --admin-password-file ~/Codes/keys/tokenkey-<edge>-admin-password.txt
+```
+
+### 1. Resolve the Edge and Identify the Exact Account
+
+If you are not using the orchestrator, resolve target metadata first:
 
 ```bash
 python3 ops/stage0/edge_ssm_execution.py --repo-root . --edge-id <edge> --format json
 ```
 
-Then run a read-only probe. Scope by both platform and account id/name once
-known. Minimal SQL sections:
+Then find the exact Kiro OAuth account. Minimal roster SQL:
 
 ```sql
 SELECT row_to_json(t) FROM (
@@ -138,130 +105,213 @@ SELECT row_to_json(t) FROM (
          a.concurrency, a.temp_unschedulable_until,
          a.temp_unschedulable_reason,
          left(COALESCE(a.error_message,''),240) AS error_message,
-         ag.group_id, ag.priority AS group_priority
+         array_remove(array_agg(DISTINCT ag.group_id), NULL) AS group_ids
   FROM accounts a
-  LEFT JOIN account_groups ag ON ag.account_id=a.id
-  WHERE a.platform='kiro' AND a.deleted_at IS NULL
-  ORDER BY a.id, ag.group_id NULLS LAST
+  LEFT JOIN account_groups ag ON ag.account_id = a.id
+  WHERE a.platform = 'kiro' AND a.deleted_at IS NULL
+  GROUP BY a.id
+  ORDER BY a.id
 ) t;
 ```
 
-For traffic and errors, query:
+Scope every later query by both `id` and `name`.
+
+### 2. Read-Only Diagnosis
+
+Use the normal Kiro windows:
 
 - `usage_logs WHERE account_id=<kiro_id> AND created_at >= now()-interval '<N> minutes'`
-- `ops_error_logs WHERE account_id=<kiro_id> OR platform='kiro' OR upstream_errors contains platform/account_id`
-- `docker logs tokenkey --since <N>m`, parse JSON lines containing
-  `http request completed`, then filter `account_id=<kiro_id>` or
-  `platform/billing_platform=kiro`.
+- `ops_error_logs WHERE account_id=<kiro_id> OR platform='kiro'`
+- `docker logs tokenkey --since <N>m`, filtered to
+  `path=/v1/messages` and `platform/billing_platform=kiro`
 
-Report windows in UTC and local time. Mention when unrelated Anthropic
-`claude-*` errors on the same edge are not Kiro.
+Always distinguish exact Kiro rows from unrelated Anthropic `claude-*` rows on
+the same edge.
 
-## Applying Re-Authorization
+### 3. Local Credential Extraction
 
-Only proceed after explicit user authorization to update the live edge.
+Use this only after the user confirms Kiro was opened and re-authorized locally.
+Run locally on the operator machine. Do not save the emitted JSON under a repo
+path.
+
+Commands:
+
+```bash
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/local_kiro_credentials.py --mode full
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/local_kiro_credentials.py --mode admin-payload
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/local_kiro_credentials.py --mode summary
+```
+
+If local cache lacks a parseable `expires_at`, or you intentionally want a newly
+minted token without reopening Kiro:
+
+```bash
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/local_kiro_credentials.py --refresh --mode admin-payload
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/local_kiro_credentials.py --refresh --mode summary
+```
+
+Rules:
+
+- Prefer applying the **exact local current cache** when the user says local
+  Kiro works right now.
+- Use `--refresh` only when you intentionally want fresh token material or need
+  a derived `expires_at`.
+- `auth_method=idc` requires `client_id` and `client_secret`.
+- `auth_method=social` uses only `refresh_token` for refresh.
+
+### 4. Edge Auth Summary Probe
+
+After you know the exact `ACCOUNT_ID` and `ACCOUNT_NAME`, read the edge summary:
+
+```bash
+bash ops/observability/run-probe.sh \
+  --target edge:<edge> \
+  --script .cursor/skills/tokenkey-kiro-reauth/scripts/probe_edge_auth_summary.sh \
+  --env ACCOUNT_ID=<id> \
+  --env ACCOUNT_NAME=<name>
+```
+
+This emits:
+
+- account state: `status`, `schedulable`, temp-unsched fields, error text
+- auth metadata: `auth_method`, `region`, `expires_at`, `_token_version`
+- credential fingerprints only: `access_md5_16`, `refresh_md5_16`,
+  `client_id_md5_16`, `client_secret_md5_16`
+
+Use it both before and after apply.
+
+### 5. Apply Re-Authorization
+
+Only proceed after explicit user approval.
 
 Preferred path:
 
-1. Read target account and assert exactly one Kiro OAuth account matches the
-   intended account id/name.
-2. Merge new Kiro credentials into existing credentials. Preserve unrelated
-   fields such as model_mapping, profile_arn if the new value is blank, and any
-   runtime metadata not being intentionally changed.
-3. Set:
-   - `credentials.access_token`
-   - `credentials.refresh_token`
-   - `credentials.region`
-   - `credentials.auth_method`
-   - `credentials.expires_at` from the new local token or derived refresh result
-   - `credentials.client_id` and `credentials.client_secret` for IdC
-   - `credentials._token_version` to a fresh millisecond timestamp
-4. Clear account error and temporary unschedulable state in the same remediation
-   flow:
-   - `status='active'`
-   - `schedulable=true`
-   - `error_message=''`
-   - clear `temp_unschedulable_until/reason` if present
-5. Invalidate runtime caches for the account if the service exposes them on that
-   edge. If using direct SQL, also restart only when cache invalidation is not
-   available and stale credentials persist.
+1. Generate the request body locally with
+   `local_kiro_credentials.py --mode admin-payload`.
+2. Apply it with the bundled helper:
 
-Safer application surfaces:
+```bash
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/apply_edge_kiro_oauth.py \
+  --base-url https://api-<edge>.tokenkey.dev \
+  --account-id <id> \
+  --expected-account-name <name> \
+  --payload-file /tmp/kiro-admin-payload.json \
+  --admin-password-file ~/Codes/keys/tokenkey-<edge>-admin-password.txt \
+  --ensure-schedulable
+```
 
-- Admin UI / API `POST /api/v1/admin/accounts/:id/apply-oauth-credentials` when
-  you have an admin session for the edge. This endpoint clears error and
-  invalidates token cache server-side.
-- Direct SSM + psql only when the admin UI/session path is unavailable. Use a
-  one-off script with JSON input supplied out-of-band; never echo the secret.
+3. Re-read the edge auth summary immediately afterward.
 
-Avoid these mistakes:
+Important:
 
-- Do not paste secrets into command text that will be stored in shell history,
-  SSM command details, or chat. If unavoidable for an emergency, rotate again
-  immediately afterward and note the exposure.
-- Do not update a broad `WHERE platform='kiro'` set. Use `id + name + platform +
-  type + deleted_at IS NULL`.
+- Do not paste secrets into shell history, SSM command text, or chat.
+- Do not update a broad `WHERE platform='kiro'` set.
 - Do not overwrite full `extra` JSON with a credentials-only payload.
+- `apply-oauth-credentials` already invalidates token cache; do not add a blind
+  restart unless cache invalidation is unavailable and you have evidence of
+  stale credentials persisting.
 
-## Verification
+### 6. Post-Apply Auth Match Check
 
-After apply, run the checks in this order:
+Do not stop at “apply returned 200”. Compare the local summary with the edge
+summary:
 
-1. Account row: active, schedulable, no error, has access_token/refresh_token,
-   and `expires_at` is parseable if present.
-2. Refresh state: look for `token_refresh.service_started`,
-   `token_refresh.account_refreshed`, `token_refresh.cycle_completed`, and
-   absence of `token_refresh.account_refresh_failed` for the Kiro account.
-3. Traffic: recent gateway completed logs for Kiro show `/v1/messages` status
-   200; `ops_error_logs` exact Kiro filter is empty or clearly old.
-4. If possible, run a small real Kiro-group request through the edge using the
-   direct Kiro key. Do not use a default Anthropic key; `claude-*` normally
-   routes to Anthropic unless the key/group is Kiro-scoped.
+- `refresh_md5_16` must match
+- `client_id_md5_16` and `client_secret_md5_16` must match for `auth_method=idc`
+- `auth_method` and `region` must match
+- `access_md5_16` must match when you applied the exact local current cache
 
-Verification summary must include:
+Mechanical compare:
 
-- edge id, region/instance/domain
-- account id/name
-- time window
-- request counts by status/model
+```bash
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/compare_auth_summaries.py \
+  --local /tmp/kiro-local-summary.json \
+  --edge /tmp/kiro-edge-summary.json
+```
+
+If you used `--refresh`, compare against the **refreshed** local summary, not
+against an older cached access token.
+
+### 7. Real Kiro Request Verification
+
+The authoritative success check is a real Kiro-group request through the edge,
+not admin usage and not speculative refresh output.
+
+```bash
+bash ops/observability/run-probe.sh \
+  --target edge:<edge> \
+  --script .cursor/skills/tokenkey-kiro-reauth/scripts/probe_real_kiro_request.sh \
+  --env GROUP_NAME=kiro \
+  --env MODEL=claude-opus-4-8
+```
+
+This probe:
+
+- fetches the direct Kiro group API key from the edge DB
+- sends a real `POST /v1/messages` **from inside the `tokenkey` container**
+- returns only safe response shape data and recent Kiro access-log rows
+
+Success criterion:
+
+- `request.http_status == 200`
+- response `type=message`
+- `role=assistant`
+
+The returned text does **not** need to match an exact marker string. A real 200
+message response is the truth signal. Recent Kiro access-log rows are secondary
+evidence; an empty recent window does not override a successful real 200
+response.
+
+### 8. Verification Summary
+
+Your final summary must include:
+
+- edge id, region, instance id, domain
+- account id and account name
+- whether local and edge auth fingerprints match
+- account state after apply: `active`, `schedulable`, no temp-unsched, no error
+- real `/v1/messages` verification result
 - exact Kiro error rows, if any
-- explicit distinction between Kiro errors and unrelated Anthropic errors
+- explicit distinction between Kiro failures and unrelated Anthropic failures
 
 ## Refresh Semantics
 
-TokenKey has Kiro refresh:
+TokenKey has a real Kiro refresher:
 
-- `backend/internal/service/kiro_token_refresher.go` implements
-  `KiroTokenRefresher`.
-- `backend/internal/integration/kiro/refresh.go` calls:
-  - social: `prod.us-east-1.auth.desktop.kiro.dev/refreshToken`
-  - IdC: `oidc.<region>.amazonaws.com/token`
-- `backend/internal/service/token_refresh_service.go` registers the refresher.
-- `backend/internal/repository/account_repo.go` includes Kiro in
-  `ListOAuthRefreshCandidates` via `engine.OAuthRefreshPlatforms()`.
+- `backend/internal/service/kiro_token_refresher.go`
+- `backend/internal/integration/kiro/refresh.go`
+- `backend/internal/service/token_refresh_service.go`
+- `backend/internal/repository/account_repo.go` via
+  `engine.OAuthRefreshPlatforms()`
+
+Kiro refresh endpoints:
+
+- social: `https://prod.us-east-1.auth.desktop.kiro.dev/refreshToken`
+- IdC: `https://oidc.<region>.amazonaws.com/token`
 
 Refresh can fix expired or near-expired access tokens. It cannot fix upstream
 grant revocation. In TokenKey, a 401 on a still-valid OAuth access token is
 treated as revoked grant and escalates to manual re-authorization:
 
-- `backend/internal/service/ratelimit_service_tk_oauth401.go`
+- code: `backend/internal/service/ratelimit_service_tk_oauth401.go`
 - marker: `oauth_401_valid_token_revoked`
 - user-facing text includes:
   `OAuth 401 on a still-valid access token — grant revoked upstream`
 
-For repeated reauth, check likely upstream causes:
+Repeated reauth usually points to one of:
 
 - same Kiro/AWS account re-logged on another host, invalidating the old grant
-- old edge/container still using an older refresh_token
-- IdC `client_id/client_secret` changed or mismatched with refresh_token
-- user/session revoked in AWS/Kiro account management
+- old edge/container still using an older `refresh_token`
+- `client_id/client_secret` changed or no longer matches the `refresh_token`
+- user/session revoked upstream
 - upstream risk/security policy revoking desktop grants
 
 ## Related References
 
-- `docs/operator/kiro-account-onboarding.md` for the operator-facing local Kiro
-  credential extraction flow.
-- `backend/internal/service/kiro_token_refresher.go` for refresh behavior.
-- `backend/internal/integration/kiro/refresh.go` for Kiro refresh endpoints.
-- `backend/internal/repository/account_repo.go` for refresh candidate selection.
-- `ops/observability/run-probe.sh` for SSM read-only probe transport.
+- `docs/operator/kiro-account-onboarding.md`
+- `backend/internal/handler/admin/account_handler.go`
+- `backend/internal/service/account_usage_service.go`
+- `backend/internal/service/kiro_token_refresher.go`
+- `backend/internal/integration/kiro/refresh.go`
+- `backend/internal/repository/account_repo.go`
+- `ops/observability/run-probe.sh`

--- a/.cursor/skills/tokenkey-kiro-reauth/SKILL.md
+++ b/.cursor/skills/tokenkey-kiro-reauth/SKILL.md
@@ -241,26 +241,32 @@ not admin usage and not speculative refresh output.
 bash ops/observability/run-probe.sh \
   --target edge:<edge> \
   --script .cursor/skills/tokenkey-kiro-reauth/scripts/probe_real_kiro_request.sh \
+  --env ACCOUNT_ID=<id> \
   --env GROUP_NAME=kiro \
   --env MODEL=claude-opus-4-8
 ```
 
 This probe:
 
-- fetches the direct Kiro group API key from the edge DB
+- resolves the exact target account inside the named group, then fetches that
+  group's direct API key from the edge DB
 - sends a real `POST /v1/messages` **from inside the `tokenkey` container**
-- returns only safe response shape data and recent Kiro access-log rows
+- correlates the resulting request by exact `X-Client-Request-ID` /
+  `usage_logs.request_id=client:<id>` and reports whether the target account
+  actually served it
+- returns only safe response shape data, exact request correlation, and recent
+  Kiro access-log rows
 
 Success criterion:
 
+- `verification.verdict == "exact_target_verified"`
 - `request.http_status == 200`
 - response `type=message`
 - `role=assistant`
 
 The returned text does **not** need to match an exact marker string. A real 200
-message response is the truth signal. Recent Kiro access-log rows are secondary
-evidence; an empty recent window does not override a successful real 200
-response.
+that routed to a **different** Kiro sibling account is **not** success for the
+reauth target; the probe reports that as `wrong_account_served`, not as a pass.
 
 ### 8. Verification Summary
 

--- a/.cursor/skills/tokenkey-kiro-reauth/agents/openai.yaml
+++ b/.cursor/skills/tokenkey-kiro-reauth/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "TokenKey Kiro Reauth"
-  short_description: "Run Kiro OAuth repair on TokenKey edges."
-  default_prompt: "Use $tokenkey-kiro-reauth to repair a Kiro OAuth account on an edge and verify traffic."
+  short_description: "Repair Kiro OAuth on an edge and verify a real Kiro request."
+  default_prompt: "Use $tokenkey-kiro-reauth to compare local Kiro auth with edge state, re-apply credentials, and validate a real /v1/messages request on the edge."

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/apply_edge_kiro_oauth.py
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/apply_edge_kiro_oauth.py
@@ -163,6 +163,56 @@ def validate_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return credentials
 
 
+def require_live_target_confirmation(args: argparse.Namespace) -> None:
+    if args.dry_run:
+        return
+    if not args.expected_account_name:
+        raise SystemExit("--expected-account-name is required unless --dry-run is set")
+
+
+def fetch_account(
+    *,
+    base_url: str,
+    account_id: int,
+    auth_headers: dict[str, str],
+    timeout: int,
+) -> dict[str, Any]:
+    response_obj = request_json(
+        "GET",
+        f"{base_url}/api/v1/admin/accounts/{account_id}",
+        headers=auth_headers,
+        timeout=timeout,
+    )
+    account = unwrap_api_data(response_obj)
+    if not isinstance(account, dict):
+        raise SystemExit("account lookup returned no account object")
+    return account
+
+
+def validate_target_account(
+    account: dict[str, Any],
+    *,
+    account_id: int,
+    expected_account_name: str,
+) -> None:
+    response_id = account.get("id")
+    if response_id != account_id:
+        raise SystemExit(
+            f"account lookup id mismatch: expected {account_id!r}, got {response_id!r}"
+        )
+    response_name = str(account.get("name") or "")
+    if response_name != expected_account_name:
+        raise SystemExit(
+            f"account lookup name mismatch: expected {expected_account_name!r}, got {response_name!r}"
+        )
+    platform = str(account.get("platform") or "")
+    if platform.lower() != "kiro":
+        raise SystemExit(
+            f"refusing to apply Kiro oauth credentials to non-Kiro account: "
+            f"id={account_id}, name={response_name!r}, platform={platform!r}"
+        )
+
+
 def summarize_account(
     account: dict[str, Any],
     *,
@@ -207,6 +257,7 @@ def main() -> int:
     base_url = strip_trailing_slash(args.base_url)
     payload = read_json(args.payload_file)
     credentials = validate_payload(payload)
+    require_live_target_confirmation(args)
 
     # Auth resolution is intentionally early so dry-run can verify auth source shape.
     auth_headers, auth_mode, auth_email = resolve_auth_headers(args, base_url)
@@ -227,6 +278,18 @@ def main() -> int:
         sys.stdout.write("\n")
         return 0
 
+    target_account = fetch_account(
+        base_url=base_url,
+        account_id=args.account_id,
+        auth_headers=auth_headers,
+        timeout=args.timeout,
+    )
+    validate_target_account(
+        target_account,
+        account_id=args.account_id,
+        expected_account_name=args.expected_account_name,
+    )
+
     apply_response = request_json(
         "POST",
         f"{base_url}/api/v1/admin/accounts/{args.account_id}/apply-oauth-credentials",
@@ -238,12 +301,11 @@ def main() -> int:
     if not isinstance(account, dict):
         raise SystemExit("apply response contained no account object")
 
-    if args.expected_account_name:
-        response_name = str(account.get("name") or "")
-        if response_name != args.expected_account_name:
-            raise SystemExit(
-                f"apply response name mismatch: expected {args.expected_account_name!r}, got {response_name!r}"
-            )
+    validate_target_account(
+        account,
+        account_id=args.account_id,
+        expected_account_name=args.expected_account_name,
+    )
 
     ensured_schedulable = False
     if args.ensure_schedulable and account.get("schedulable") is False:

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/apply_edge_kiro_oauth.py
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/apply_edge_kiro_oauth.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Apply Kiro OAuth credentials to a TokenKey edge account safely.
+
+The script supports either:
+  - admin API key auth via x-api-key
+  - admin email/password login via /api/v1/auth/login
+
+Payload input should usually come from:
+  python3 local_kiro_credentials.py --mode admin-payload
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+def read_text(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def read_json(path: str) -> dict[str, Any]:
+    try:
+        data = json.loads(read_text(path))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid JSON in {path}: {exc}")
+    if not isinstance(data, dict):
+        raise SystemExit(f"expected JSON object in {path}")
+    return data
+
+
+def strip_trailing_slash(value: str) -> str:
+    return value[:-1] if value.endswith("/") else value
+
+
+def request_json(
+    method: str,
+    url: str,
+    *,
+    body: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    payload = None
+    req_headers = dict(headers or {})
+    if body is not None:
+        payload = json.dumps(body).encode("utf-8")
+        req_headers["Content-Type"] = "application/json"
+    req_headers.setdefault("Accept", "application/json")
+    request = urllib.request.Request(url, data=payload, headers=req_headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"{method} {url} failed: status {exc.code}, body: {detail[:500]}")
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"{method} {url} failed: {exc}")
+
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{method} {url} returned invalid JSON: {exc}")
+    if not isinstance(parsed, dict):
+        raise SystemExit(f"{method} {url} returned non-object JSON")
+    return parsed
+
+
+def unwrap_api_data(response_obj: dict[str, Any]) -> dict[str, Any]:
+    if "data" in response_obj and isinstance(response_obj["data"], dict):
+        return response_obj["data"]
+    return response_obj
+
+
+def extract_login_token(response_obj: dict[str, Any]) -> str:
+    data = unwrap_api_data(response_obj)
+    candidates = []
+    if isinstance(data, dict):
+        candidates.extend([
+            data.get("access_token"),
+            data.get("token"),
+            data.get("jwt"),
+        ])
+    candidates.extend([
+        response_obj.get("access_token"),
+        response_obj.get("token"),
+        response_obj.get("jwt"),
+    ])
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate
+    raise SystemExit("login succeeded but response contained no bearer token")
+
+
+def parse_password_file(path: str) -> tuple[str | None, str]:
+    raw = Path(path).read_text(encoding="utf-8").strip()
+    email = None
+    password = None
+    lines = [line.strip() for line in raw.splitlines() if line.strip()]
+    for line in lines:
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip().lower()
+        value = value.strip()
+        if key == "email":
+            email = value
+        elif key == "password":
+            password = value
+    if password:
+        return email, password
+    if not raw:
+        raise SystemExit(f"admin password file is empty: {path}")
+    return None, raw
+
+
+def resolve_auth_headers(args: argparse.Namespace, base_url: str) -> tuple[dict[str, str], str, str]:
+    api_key = args.admin_api_key
+    if api_key:
+        return {"x-api-key": api_key}, "api_key", ""
+
+    email = args.admin_email
+    password = args.admin_password
+    if args.admin_password_file:
+        file_email, file_password = parse_password_file(args.admin_password_file)
+        password = password or file_password
+        email = email or file_email
+
+    if not email or not password:
+        raise SystemExit("need either --admin-api-key or (--admin-email and password source)")
+
+    response_obj = request_json(
+        "POST",
+        f"{base_url}/api/v1/auth/login",
+        body={"email": email, "password": password},
+        timeout=args.timeout,
+    )
+    token = extract_login_token(response_obj)
+    return {"Authorization": f"Bearer {token}"}, "login_token", email
+
+
+def validate_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("type") != "oauth":
+        raise SystemExit("payload.type must be oauth")
+    credentials = payload.get("credentials")
+    if not isinstance(credentials, dict) or not credentials:
+        raise SystemExit("payload.credentials must be a non-empty object")
+    required = ["access_token", "refresh_token", "region", "auth_method"]
+    missing = [key for key in required if not str(credentials.get(key) or "").strip()]
+    if missing:
+        raise SystemExit(f"payload.credentials missing required keys: {', '.join(missing)}")
+    if str(credentials.get("auth_method", "")).lower() == "idc":
+        for key in ("client_id", "client_secret"):
+            if not str(credentials.get(key) or "").strip():
+                raise SystemExit(f"payload.credentials missing required key for idc: {key}")
+    return credentials
+
+
+def summarize_account(
+    account: dict[str, Any],
+    *,
+    base_url: str,
+    auth_mode: str,
+    auth_email: str,
+    ensured_schedulable: bool,
+) -> dict[str, Any]:
+    return {
+        "base_url": base_url,
+        "auth_mode": auth_mode,
+        "auth_email": auth_email,
+        "account_id": account.get("id"),
+        "name": account.get("name"),
+        "platform": account.get("platform"),
+        "type": account.get("type"),
+        "status": account.get("status"),
+        "schedulable": account.get("schedulable"),
+        "ensured_schedulable": ensured_schedulable,
+        "temp_unschedulable_until": account.get("temp_unschedulable_until"),
+        "error_message_prefix": str(account.get("error_message") or "")[:240],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", required=True, help="edge base URL, e.g. https://api-us6.tokenkey.dev")
+    parser.add_argument("--account-id", required=True, type=int)
+    parser.add_argument("--expected-account-name", default="", help="fail if response name differs")
+    parser.add_argument("--payload-file", default="-", help="JSON payload file path or - for stdin")
+    parser.add_argument("--ensure-schedulable", action="store_true", help="force schedulable=true if apply leaves it false")
+    parser.add_argument("--dry-run", action="store_true", help="validate inputs and auth plan without live writes")
+    parser.add_argument("--timeout", type=int, default=30)
+
+    parser.add_argument("--admin-api-key", default="")
+    parser.add_argument("--admin-email", default="")
+    parser.add_argument("--admin-password", default="")
+    parser.add_argument("--admin-password-file", default="")
+
+    args = parser.parse_args()
+
+    base_url = strip_trailing_slash(args.base_url)
+    payload = read_json(args.payload_file)
+    credentials = validate_payload(payload)
+
+    # Auth resolution is intentionally early so dry-run can verify auth source shape.
+    auth_headers, auth_mode, auth_email = resolve_auth_headers(args, base_url)
+
+    if args.dry_run:
+        output = {
+            "dry_run": True,
+            "base_url": base_url,
+            "account_id": args.account_id,
+            "expected_account_name": args.expected_account_name,
+            "auth_mode": auth_mode,
+            "auth_email": auth_email,
+            "payload_keys": sorted(payload.keys()),
+            "credential_keys": sorted(credentials.keys()),
+            "ensure_schedulable": args.ensure_schedulable,
+        }
+        json.dump(output, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    apply_response = request_json(
+        "POST",
+        f"{base_url}/api/v1/admin/accounts/{args.account_id}/apply-oauth-credentials",
+        body=payload,
+        headers=auth_headers,
+        timeout=args.timeout,
+    )
+    account = unwrap_api_data(apply_response)
+    if not isinstance(account, dict):
+        raise SystemExit("apply response contained no account object")
+
+    if args.expected_account_name:
+        response_name = str(account.get("name") or "")
+        if response_name != args.expected_account_name:
+            raise SystemExit(
+                f"apply response name mismatch: expected {args.expected_account_name!r}, got {response_name!r}"
+            )
+
+    ensured_schedulable = False
+    if args.ensure_schedulable and account.get("schedulable") is False:
+        sched_response = request_json(
+            "POST",
+            f"{base_url}/api/v1/admin/accounts/{args.account_id}/schedulable",
+            body={"schedulable": True},
+            headers=auth_headers,
+            timeout=args.timeout,
+        )
+        account = unwrap_api_data(sched_response)
+        if not isinstance(account, dict):
+            raise SystemExit("schedulable response contained no account object")
+        ensured_schedulable = True
+
+    output = summarize_account(
+        account,
+        base_url=base_url,
+        auth_mode=auth_mode,
+        auth_email=auth_email,
+        ensured_schedulable=ensured_schedulable,
+    )
+    json.dump(output, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/compare_auth_summaries.py
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/compare_auth_summaries.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Compare a local Kiro auth summary with an edge auth summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def read_json(path: str) -> dict[str, Any]:
+    raw = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid JSON in {path}: {exc}")
+    if not isinstance(data, dict):
+        raise SystemExit(f"expected JSON object in {path}")
+    return data
+
+
+def compare_pair(left: dict[str, Any], right: dict[str, Any], key: str) -> dict[str, Any]:
+    a = left.get(key)
+    b = right.get(key)
+    return {"match": a == b, "local": a, "edge": b}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--local", required=True, help="local summary JSON path or -")
+    parser.add_argument("--edge", required=True, help="edge summary JSON path or -")
+    parser.add_argument(
+        "--allow-access-mismatch",
+        action="store_true",
+        help="treat access token mismatch as non-fatal when other control-plane fields match",
+    )
+    args = parser.parse_args()
+
+    local = read_json(args.local)
+    edge = read_json(args.edge)
+
+    checks: dict[str, Any] = {
+        "auth_method": compare_pair(local, edge, "auth_method"),
+        "region": compare_pair(local, edge, "region"),
+        "refresh_token": compare_pair(local, edge, "refresh_md5_16"),
+        "access_token": compare_pair(local, edge, "access_md5_16"),
+    }
+
+    auth_method = str(local.get("auth_method") or edge.get("auth_method") or "").lower()
+    if auth_method == "idc":
+        checks["client_id"] = compare_pair(local, edge, "client_id_md5_16")
+        checks["client_secret"] = compare_pair(local, edge, "client_secret_md5_16")
+
+    edge_ready = {
+        "active": edge.get("status") == "active",
+        "schedulable": edge.get("schedulable") is True,
+        "no_error_message": not str(edge.get("error_message") or "").strip(),
+        "has_access_token": bool(edge.get("has_access_token", True)),
+        "has_refresh_token": bool(edge.get("has_refresh_token", True)),
+    }
+    if auth_method == "idc":
+        edge_ready["has_client_id"] = bool(edge.get("has_client_id", True))
+        edge_ready["has_client_secret"] = bool(edge.get("has_client_secret", True))
+
+    required_check_names = [name for name in checks if name != "access_token"]
+    control_plane_match = all(bool(checks[name]["match"]) for name in required_check_names)
+    access_match = bool(checks["access_token"]["match"])
+    edge_ready_ok = all(edge_ready.values())
+
+    if control_plane_match and access_match and edge_ready_ok:
+        verdict = "exact_match_ready"
+    elif control_plane_match and access_match and not edge_ready_ok:
+        verdict = "exact_match_edge_not_ready"
+    elif control_plane_match and not access_match and args.allow_access_mismatch:
+        verdict = "control_plane_match_access_diff_allowed"
+    elif control_plane_match and not access_match:
+        verdict = "control_plane_match_access_diff_only"
+    else:
+        verdict = "mismatch"
+
+    output = {
+        "verdict": verdict,
+        "control_plane_match": control_plane_match,
+        "access_match": access_match,
+        "edge_ready": edge_ready_ok,
+        "checks": checks,
+        "edge_state": edge_ready,
+        "local_identity": {
+            "auth_method": local.get("auth_method"),
+            "region": local.get("region"),
+            "token_source": local.get("token_source"),
+            "refreshed_at_utc": local.get("refreshed_at_utc", ""),
+        },
+        "edge_identity": {
+            "account_id": edge.get("id"),
+            "account_name": edge.get("name"),
+            "status": edge.get("status"),
+            "schedulable": edge.get("schedulable"),
+            "token_version": edge.get("token_version", ""),
+        },
+    }
+    json.dump(output, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/local_kiro_credentials.py
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/local_kiro_credentials.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Extract or locally refresh Kiro OAuth credentials from ~/.aws/sso/cache.
+
+This script never writes back to the local cache. It only emits one of:
+  - full credentials JSON
+  - admin apply payload JSON
+  - hash-only summary JSON
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import hashlib
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def unix_seconds(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, str):
+        raw = value.strip()
+        normalized = raw.replace("UTC", "+00:00")
+        if normalized.endswith("Z"):
+            normalized = normalized[:-1] + "+00:00"
+        try:
+            return str(int(datetime.fromisoformat(normalized).timestamp()))
+        except ValueError:
+            value = raw
+    try:
+        number = int(float(value))
+    except (TypeError, ValueError):
+        return None
+    if number > 10_000_000_000:
+        number //= 1000
+    return str(number)
+
+
+def md5_16(value: str) -> str:
+    if not value:
+        return ""
+    return hashlib.md5(value.encode("utf-8")).hexdigest()[:16]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def latest_idc_registration(cache_dir: Path) -> tuple[Path, dict[str, Any]] | None:
+    matches: list[tuple[float, str, Path, dict[str, Any]]] = []
+    for raw in glob.glob(str(cache_dir / "*.json")):
+        path = Path(raw)
+        if path.name == "kiro-auth-token.json":
+            continue
+        try:
+            payload = read_json(path)
+        except Exception:
+            continue
+        if "clientId" not in payload or "clientSecret" not in payload:
+            continue
+        matches.append((path.stat().st_mtime, str(path), path, payload))
+    if not matches:
+        return None
+    matches.sort(reverse=True)
+    _, _, path, payload = matches[0]
+    return path, payload
+
+
+def load_local_credentials() -> tuple[dict[str, Any], dict[str, Any]]:
+    cache_dir = Path.home() / ".aws" / "sso" / "cache"
+    token_path = cache_dir / "kiro-auth-token.json"
+    if not token_path.exists():
+        raise SystemExit(f"missing local Kiro token cache: {token_path}")
+
+    token = read_json(token_path)
+    auth_method = "social" if str(token.get("authMethod", "")).lower() == "social" else "idc"
+    credentials: dict[str, Any] = {
+        "access_token": token["accessToken"],
+        "refresh_token": token["refreshToken"],
+        "region": token.get("region", "us-east-1"),
+        "auth_method": auth_method,
+    }
+
+    expires_at = unix_seconds(token.get("expiresAt") or token.get("expires_at"))
+    if expires_at is None and token.get("expiresIn") not in (None, ""):
+        expires_at = str(int(time.time()) + int(float(token["expiresIn"])))
+    if expires_at:
+        credentials["expires_at"] = expires_at
+
+    meta: dict[str, Any] = {
+        "token_path": str(token_path),
+        "token_mtime_local": int(token_path.stat().st_mtime),
+        "token_source": "cache",
+        "raw_expires_at": token.get("expiresAt") or token.get("expires_at") or "",
+    }
+
+    if auth_method == "idc":
+        latest = latest_idc_registration(cache_dir)
+        if latest is None:
+            raise SystemExit("missing Kiro IdC client registration in ~/.aws/sso/cache")
+        reg_path, reg = latest
+        credentials["client_id"] = reg["clientId"]
+        credentials["client_secret"] = reg["clientSecret"]
+        meta["registration_path"] = str(reg_path)
+        meta["registration_mtime_local"] = int(reg_path.stat().st_mtime)
+
+    return credentials, meta
+
+
+def refresh_locally(credentials: dict[str, Any], timeout: int) -> tuple[dict[str, Any], dict[str, Any]]:
+    auth_method = str(credentials.get("auth_method", "")).lower()
+    region = str(credentials.get("region") or "us-east-1")
+
+    if auth_method == "social":
+        url = "https://prod.us-east-1.auth.desktop.kiro.dev/refreshToken"
+        payload = {"refreshToken": credentials["refresh_token"]}
+    else:
+        client_id = str(credentials.get("client_id") or "")
+        client_secret = str(credentials.get("client_secret") or "")
+        if not client_id or not client_secret:
+            raise SystemExit("OIDC refresh requires client_id and client_secret")
+        url = f"https://oidc.{region}.amazonaws.com/token"
+        payload = {
+            "clientId": client_id,
+            "clientSecret": client_secret,
+            "refreshToken": credentials["refresh_token"],
+            "grantType": "refresh_token",
+        }
+
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read()
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"refresh failed: status {exc.code}, body: {body[:400]}")
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"refresh failed: {exc}")
+
+    try:
+        result = json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"refresh returned invalid JSON: {exc}")
+
+    refreshed = dict(credentials)
+    refreshed["access_token"] = result["accessToken"]
+    refreshed["refresh_token"] = result.get("refreshToken") or credentials["refresh_token"]
+
+    expires_in = result.get("expiresIn")
+    if expires_in not in (None, ""):
+        refreshed["expires_at"] = str(int(time.time()) + int(expires_in))
+    if result.get("profileArn"):
+        refreshed["profile_arn"] = result["profileArn"]
+
+    meta = {
+        "token_source": "refreshed",
+        "refreshed_at_utc": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+        "refresh_endpoint": url,
+    }
+    return refreshed, meta
+
+
+def render_summary(credentials: dict[str, Any], meta: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "token_source": meta.get("token_source", "cache"),
+        "token_path": meta.get("token_path", ""),
+        "token_mtime_local": meta.get("token_mtime_local"),
+        "registration_path": meta.get("registration_path", ""),
+        "registration_mtime_local": meta.get("registration_mtime_local"),
+        "auth_method": credentials.get("auth_method", ""),
+        "region": credentials.get("region", ""),
+        "expires_at": credentials.get("expires_at", ""),
+        "raw_expires_at": meta.get("raw_expires_at", ""),
+        "profile_arn_present": bool(credentials.get("profile_arn")),
+        "access_md5_16": md5_16(str(credentials.get("access_token", ""))),
+        "refresh_md5_16": md5_16(str(credentials.get("refresh_token", ""))),
+        "client_id_md5_16": md5_16(str(credentials.get("client_id", ""))),
+        "client_secret_md5_16": md5_16(str(credentials.get("client_secret", ""))),
+        "refreshed_at_utc": meta.get("refreshed_at_utc", ""),
+        "refresh_endpoint": meta.get("refresh_endpoint", ""),
+    }
+
+
+def render_admin_payload(credentials: dict[str, Any], token_version_ms: int | None) -> dict[str, Any]:
+    payload_credentials = dict(credentials)
+    payload_credentials["_token_version"] = str(token_version_ms or int(time.time() * 1000))
+    payload_credentials["tos_acknowledged"] = True
+    return {
+        "type": "oauth",
+        "credentials": payload_credentials,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=("full", "summary", "admin-payload"),
+        default="full",
+        help="output format",
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="mint a fresh access token locally using the current refresh token",
+    )
+    parser.add_argument(
+        "--token-version-ms",
+        type=int,
+        default=None,
+        help="override _token_version when --mode admin-payload",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="HTTP timeout in seconds for --refresh",
+    )
+    args = parser.parse_args()
+
+    credentials, meta = load_local_credentials()
+    if args.refresh:
+        credentials, refresh_meta = refresh_locally(credentials, timeout=args.timeout)
+        meta.update(refresh_meta)
+
+    if args.mode == "full":
+        output: dict[str, Any] = dict(credentials)
+    elif args.mode == "summary":
+        output = render_summary(credentials, meta)
+    else:
+        output = render_admin_payload(credentials, token_version_ms=args.token_version_ms)
+
+    json.dump(output, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/probe_edge_auth_summary.sh
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/probe_edge_auth_summary.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACCOUNT_ID="${ACCOUNT_ID:-}"
+ACCOUNT_NAME="${ACCOUNT_NAME:-}"
+
+if [[ ! "${ACCOUNT_ID}" =~ ^[0-9]+$ ]]; then
+  echo '{"error":"ACCOUNT_ID must be a numeric account id"}'
+  exit 0
+fi
+
+if [[ -z "${ACCOUNT_NAME}" ]]; then
+  echo '{"error":"ACCOUNT_NAME is required"}'
+  exit 0
+fi
+
+name_sql="${ACCOUNT_NAME//\'/\'\'}"
+PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+
+result="$($PSQL -c "
+SELECT row_to_json(t)
+FROM (
+  SELECT
+    a.id,
+    a.name,
+    a.platform,
+    a.type,
+    a.status,
+    a.schedulable,
+    a.concurrency,
+    a.temp_unschedulable_until AT TIME ZONE 'UTC' AS temp_unschedulable_until_utc,
+    left(COALESCE(a.temp_unschedulable_reason,''),240) AS temp_unschedulable_reason,
+    left(COALESCE(a.error_message,''),240) AS error_message,
+    array_remove(array_agg(DISTINCT ag.group_id), NULL) AS group_ids,
+    COALESCE(a.credentials->>'auth_method','') AS auth_method,
+    COALESCE(a.credentials->>'region','') AS region,
+    COALESCE(a.credentials->>'expires_at','') AS expires_at,
+    COALESCE(a.credentials->>'_token_version','') AS token_version,
+    (COALESCE(a.credentials->>'access_token','') <> '') AS has_access_token,
+    (COALESCE(a.credentials->>'refresh_token','') <> '') AS has_refresh_token,
+    (COALESCE(a.credentials->>'client_id','') <> '') AS has_client_id,
+    (COALESCE(a.credentials->>'client_secret','') <> '') AS has_client_secret,
+    CASE
+      WHEN COALESCE(a.credentials->>'access_token','') = '' THEN ''
+      ELSE substring(md5(a.credentials->>'access_token') from 1 for 16)
+    END AS access_md5_16,
+    CASE
+      WHEN COALESCE(a.credentials->>'refresh_token','') = '' THEN ''
+      ELSE substring(md5(a.credentials->>'refresh_token') from 1 for 16)
+    END AS refresh_md5_16,
+    CASE
+      WHEN COALESCE(a.credentials->>'client_id','') = '' THEN ''
+      ELSE substring(md5(a.credentials->>'client_id') from 1 for 16)
+    END AS client_id_md5_16,
+    CASE
+      WHEN COALESCE(a.credentials->>'client_secret','') = '' THEN ''
+      ELSE substring(md5(a.credentials->>'client_secret') from 1 for 16)
+    END AS client_secret_md5_16
+  FROM accounts a
+  LEFT JOIN account_groups ag ON ag.account_id = a.id
+  WHERE a.id = ${ACCOUNT_ID}
+    AND a.name = '${name_sql}'
+    AND a.platform = 'kiro'
+    AND a.type = 'oauth'
+    AND a.deleted_at IS NULL
+  GROUP BY a.id
+) t;
+")"
+
+result="$(printf '%s' "${result}" | tr -d '\n')"
+
+if [[ -z "${result}" ]]; then
+  python3 - "${ACCOUNT_ID}" "${ACCOUNT_NAME}" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "error": "account_not_found",
+    "account_id": int(sys.argv[1]),
+    "account_name": sys.argv[2],
+}, ensure_ascii=False))
+PY
+  exit 0
+fi
+
+printf '%s\n' "${result}"

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/probe_edge_auth_summary.sh
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/probe_edge_auth_summary.sh
@@ -14,10 +14,19 @@ if [[ -z "${ACCOUNT_NAME}" ]]; then
   exit 0
 fi
 
-name_sql="${ACCOUNT_NAME//\'/\'\'}"
-PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+sql_b64() {
+  python3 - "$1" <<'PY'
+import base64
+import sys
 
-result="$($PSQL -c "
+print(base64.b64encode(sys.argv[1].encode("utf-8")).decode("ascii"), end="")
+PY
+}
+
+ACCOUNT_NAME_B64="$(sql_b64 "${ACCOUNT_NAME}")"
+PSQL=(docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
+
+result="$("${PSQL[@]}" -c "
 SELECT row_to_json(t)
 FROM (
   SELECT
@@ -59,7 +68,7 @@ FROM (
   FROM accounts a
   LEFT JOIN account_groups ag ON ag.account_id = a.id
   WHERE a.id = ${ACCOUNT_ID}
-    AND a.name = '${name_sql}'
+    AND a.name = convert_from(decode('${ACCOUNT_NAME_B64}','base64'),'utf8')
     AND a.platform = 'kiro'
     AND a.type = 'oauth'
     AND a.deleted_at IS NULL

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/probe_real_kiro_request.sh
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/probe_real_kiro_request.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GROUP_NAME="${GROUP_NAME:-kiro}"
+MODEL="${MODEL:-claude-opus-4-8}"
+APP_CONTAINER="${APP_CONTAINER:-tokenkey}"
+APP_URL="${APP_URL:-http://localhost:8080}"
+MAX_TOKENS="${MAX_TOKENS:-48}"
+PROMPT_TEXT="${PROMPT_TEXT:-Say hello in one short sentence.}"
+LOG_WINDOW="${LOG_WINDOW:-3m}"
+
+PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+
+key="$($PSQL -c "SELECT ak.key
+FROM api_keys ak
+JOIN groups g ON g.id = ak.group_id
+WHERE g.name = '${GROUP_NAME//\'/\'\'}'
+  AND g.deleted_at IS NULL
+  AND ak.deleted_at IS NULL
+ORDER BY ak.id
+LIMIT 1" | tr -d '[:space:]')"
+
+if [[ -z "${key}" ]]; then
+  echo '{"error":"missing_group_api_key"}'
+  exit 0
+fi
+
+payload="$(python3 - "${MODEL}" "${MAX_TOKENS}" "${PROMPT_TEXT}" <<'PY'
+import json
+import sys
+
+model = sys.argv[1]
+max_tokens = int(sys.argv[2])
+prompt_text = sys.argv[3]
+
+user_id = json.dumps({
+    "device_id": "0000000000000000000000000000000000000000000000000000000000000001",
+    "account_uuid": "",
+    "session_id": "00000000-0000-0000-0000-000000000001",
+}, ensure_ascii=False, separators=(",", ":"))
+
+print(json.dumps({
+    "model": model,
+    "max_tokens": max_tokens,
+    "messages": [{"role": "user", "content": prompt_text}],
+    "metadata": {"user_id": user_id},
+}, ensure_ascii=False, separators=(",", ":")))
+PY
+)"
+
+tmp_body="$(mktemp)"
+tmp_payload="$(mktemp)"
+tmp_log="$(mktemp)"
+tmp_err="$(mktemp)"
+cleanup() {
+  rm -f "${tmp_body}" "${tmp_payload}" "${tmp_log}" "${tmp_err}"
+  docker exec "${APP_CONTAINER}" rm -f /tmp/kiro-real-request.json /tmp/kiro-real-response.json >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+printf '%s' "${payload}" >"${tmp_payload}"
+
+http_code=""
+if ! http_code="$(docker exec -i "${APP_CONTAINER}" sh -lc '
+  cat > /tmp/kiro-real-request.json
+  curl -sS -o /tmp/kiro-real-response.json -w "%{http_code}" \
+    -H "x-api-key: '"${key}"'" \
+    -H "anthropic-version: 2023-06-01" \
+    -H "anthropic-beta: claude-code-20250219" \
+    -H "X-App: cli" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: Claude-Code/1.0.33 (macOS; arm64)" \
+    --data-binary @/tmp/kiro-real-request.json \
+    "'"${APP_URL}"'/v1/messages"
+' <"${tmp_payload}" 2>"${tmp_err}")"; then
+  http_code=""
+fi
+
+if docker exec "${APP_CONTAINER}" test -f /tmp/kiro-real-response.json >/dev/null 2>&1; then
+  docker exec "${APP_CONTAINER}" cat /tmp/kiro-real-response.json >"${tmp_body}"
+else
+  : >"${tmp_body}"
+fi
+
+docker logs "${APP_CONTAINER}" --since "${LOG_WINDOW}" >"${tmp_log}" 2>&1 || true
+
+python3 - "${tmp_body}" "${tmp_log}" "${tmp_err}" "${http_code}" "${GROUP_NAME}" "${MODEL}" "${LOG_WINDOW}" "${PROMPT_TEXT}" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+
+body_path, log_path, err_path, http_code, group_name, model, log_window, prompt_text = sys.argv[1:9]
+
+raw_body = open(body_path, encoding="utf-8", errors="replace").read()
+curl_error = open(err_path, encoding="utf-8", errors="replace").read().strip()
+
+request_summary = {
+    "requested_at_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    "group_name": group_name,
+    "model": model,
+    "prompt_text": prompt_text,
+    "http_status": int(http_code) if http_code.isdigit() else None,
+}
+if curl_error:
+    request_summary["curl_error"] = curl_error[:400]
+
+try:
+    parsed = json.loads(raw_body) if raw_body else None
+except Exception:
+    parsed = None
+
+if isinstance(parsed, dict):
+    request_summary["type"] = parsed.get("type")
+    request_summary["role"] = parsed.get("role")
+    if isinstance(parsed.get("content"), list):
+        texts = [item.get("text", "") for item in parsed["content"] if isinstance(item, dict) and item.get("type") == "text"]
+        request_summary["text_prefix"] = ("".join(texts))[:240]
+    request_summary["stop_reason"] = parsed.get("stop_reason")
+    if isinstance(parsed.get("usage"), dict):
+        request_summary["usage_keys"] = sorted(parsed["usage"].keys())
+    if isinstance(parsed.get("error"), dict):
+        request_summary["error_type"] = parsed["error"].get("type")
+        request_summary["error_message"] = parsed["error"].get("message")
+else:
+    request_summary["raw_prefix"] = raw_body[:240]
+
+recent_rows = []
+with open(log_path, encoding="utf-8", errors="replace") as handle:
+    for raw in handle:
+        raw = raw.strip()
+        if not raw.startswith("{"):
+            continue
+        try:
+            obj = json.loads(raw)
+        except Exception:
+            continue
+        if (obj.get("msg") or obj.get("message")) != "http request completed":
+            continue
+        if obj.get("path") != "/v1/messages":
+            continue
+        if obj.get("platform") != "kiro" and obj.get("billing_platform") != "kiro":
+            continue
+        recent_rows.append({
+            "account_id": obj.get("account_id"),
+            "platform": obj.get("platform"),
+            "billing_platform": obj.get("billing_platform"),
+            "status_code": obj.get("status_code"),
+            "model": obj.get("model"),
+            "completed_at": obj.get("completed_at"),
+            "latency_ms": obj.get("latency_ms"),
+        })
+
+print(json.dumps({
+    "request": request_summary,
+    "recent_kiro_access": {
+        "window": log_window,
+        "count": len(recent_rows),
+        "rows": recent_rows[-10:],
+    },
+}, ensure_ascii=False, indent=2))
+PY

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/probe_real_kiro_request.sh
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/probe_real_kiro_request.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ACCOUNT_ID="${ACCOUNT_ID:-}"
 GROUP_NAME="${GROUP_NAME:-kiro}"
 MODEL="${MODEL:-claude-opus-4-8}"
 APP_CONTAINER="${APP_CONTAINER:-tokenkey}"
@@ -8,20 +9,135 @@ APP_URL="${APP_URL:-http://localhost:8080}"
 MAX_TOKENS="${MAX_TOKENS:-48}"
 PROMPT_TEXT="${PROMPT_TEXT:-Say hello in one short sentence.}"
 LOG_WINDOW="${LOG_WINDOW:-3m}"
+USAGE_POLL_ATTEMPTS="${USAGE_POLL_ATTEMPTS:-10}"
+USAGE_POLL_INTERVAL_SECONDS="${USAGE_POLL_INTERVAL_SECONDS:-1}"
 
-PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+if [[ ! "${ACCOUNT_ID}" =~ ^[0-9]+$ ]]; then
+  echo '{"error":"ACCOUNT_ID must be a numeric account id"}'
+  exit 0
+fi
 
-key="$($PSQL -c "SELECT ak.key
-FROM api_keys ak
-JOIN groups g ON g.id = ak.group_id
-WHERE g.name = '${GROUP_NAME//\'/\'\'}'
-  AND g.deleted_at IS NULL
-  AND ak.deleted_at IS NULL
+sql_b64() {
+  python3 - "$1" <<'PY'
+import base64
+import sys
+
+print(base64.b64encode(sys.argv[1].encode("utf-8")).decode("ascii"), end="")
+PY
+}
+
+GROUP_NAME_B64="$(sql_b64 "${GROUP_NAME}")"
+PSQL=(docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
+
+context_json="$("${PSQL[@]}" -c "
+WITH target AS (
+  SELECT a.id, a.name, a.status, a.schedulable, ag.group_id
+  FROM accounts a
+  JOIN account_groups ag ON ag.account_id = a.id
+  JOIN groups g ON g.id = ag.group_id
+  WHERE a.id = ${ACCOUNT_ID}
+    AND g.name = convert_from(decode('${GROUP_NAME_B64}','base64'),'utf8')
+    AND a.platform = 'kiro'
+    AND a.type = 'oauth'
+    AND a.deleted_at IS NULL
+    AND g.deleted_at IS NULL
+  ORDER BY g.id
+  LIMIT 1
+)
+SELECT json_build_object(
+  'group_id', t.group_id,
+  'group_name', convert_from(decode('${GROUP_NAME_B64}','base64'),'utf8'),
+  'target_account', json_build_object(
+    'account_id', t.id,
+    'account_name', t.name,
+    'status', t.status,
+    'schedulable', t.schedulable
+  ),
+  'group_api_key', (
+    SELECT row_to_json(ak_row)
+    FROM (
+      SELECT ak.id AS api_key_id, ak.name AS api_key_name
+      FROM api_keys ak
+      WHERE ak.group_id = t.group_id
+        AND ak.deleted_at IS NULL
+        AND ak.status = 'active'
+      ORDER BY ak.id
+      LIMIT 1
+    ) ak_row
+  ),
+  'group_accounts', COALESCE((
+    SELECT json_agg(json_build_object(
+      'account_id', a2.id,
+      'account_name', a2.name,
+      'status', a2.status,
+      'schedulable', a2.schedulable,
+      'priority', ag2.priority,
+      'temp_unschedulable_until_utc', a2.temp_unschedulable_until AT TIME ZONE 'UTC',
+      'temp_unschedulable_reason', left(COALESCE(a2.temp_unschedulable_reason,''),240),
+      'error_message', left(COALESCE(a2.error_message,''),240)
+    ) ORDER BY ag2.priority DESC, a2.id)
+    FROM account_groups ag2
+    JOIN accounts a2 ON a2.id = ag2.account_id
+    WHERE ag2.group_id = t.group_id
+      AND a2.platform = 'kiro'
+      AND a2.type = 'oauth'
+      AND a2.deleted_at IS NULL
+  ), '[]'::json)
+)
+FROM target t;
+")"
+context_json="$(printf '%s' "${context_json}" | tr -d '\n')"
+
+if [[ -z "${context_json}" ]]; then
+  python3 - "${ACCOUNT_ID}" "${GROUP_NAME}" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "error": "target_group_context_not_found",
+    "account_id": int(sys.argv[1]),
+    "group_name": sys.argv[2],
+}, ensure_ascii=False))
+PY
+  exit 0
+fi
+
+key="$("${PSQL[@]}" -c "
+WITH target AS (
+  SELECT ag.group_id
+  FROM accounts a
+  JOIN account_groups ag ON ag.account_id = a.id
+  JOIN groups g ON g.id = ag.group_id
+  WHERE a.id = ${ACCOUNT_ID}
+    AND g.name = convert_from(decode('${GROUP_NAME_B64}','base64'),'utf8')
+    AND a.platform = 'kiro'
+    AND a.type = 'oauth'
+    AND a.deleted_at IS NULL
+    AND g.deleted_at IS NULL
+  ORDER BY g.id
+  LIMIT 1
+)
+SELECT ak.key
+FROM target t
+JOIN api_keys ak ON ak.group_id = t.group_id
+WHERE ak.deleted_at IS NULL
+  AND ak.status = 'active'
 ORDER BY ak.id
-LIMIT 1" | tr -d '[:space:]')"
+LIMIT 1;
+")"
+key="$(printf '%s' "${key}" | tr -d '\n')"
 
 if [[ -z "${key}" ]]; then
-  echo '{"error":"missing_group_api_key"}'
+  python3 - "${ACCOUNT_ID}" "${GROUP_NAME}" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "error": "missing_group_api_key",
+    "account_id": int(sys.argv[1]),
+    "group_name": sys.argv[2],
+}, ensure_ascii=False))
+PY
   exit 0
 fi
 
@@ -52,26 +168,37 @@ tmp_body="$(mktemp)"
 tmp_payload="$(mktemp)"
 tmp_log="$(mktemp)"
 tmp_err="$(mktemp)"
+tmp_headers="$(mktemp)"
+tmp_context="$(mktemp)"
+tmp_usage="$(mktemp)"
 cleanup() {
-  rm -f "${tmp_body}" "${tmp_payload}" "${tmp_log}" "${tmp_err}"
-  docker exec "${APP_CONTAINER}" rm -f /tmp/kiro-real-request.json /tmp/kiro-real-response.json >/dev/null 2>&1 || true
+  rm -f "${tmp_body}" "${tmp_payload}" "${tmp_log}" "${tmp_err}" "${tmp_headers}" "${tmp_context}" "${tmp_usage}"
+  docker exec "${APP_CONTAINER}" rm -f /tmp/kiro-real-request.json /tmp/kiro-real-response.json /tmp/kiro-real-response-headers.txt >/dev/null 2>&1 || true # preflight-allow: swallow
 }
 trap cleanup EXIT
 
 printf '%s' "${payload}" >"${tmp_payload}"
+printf '%s' "${context_json}" >"${tmp_context}"
+
+probe_request_id="kiro-probe-${ACCOUNT_ID}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 
 http_code=""
-if ! http_code="$(docker exec -i "${APP_CONTAINER}" sh -lc '
+if ! http_code="$(docker exec -i \
+  -e KIRO_GROUP_API_KEY="${key}" \
+  -e KIRO_APP_URL="${APP_URL}" \
+  -e KIRO_PROBE_REQUEST_ID="${probe_request_id}" \
+  "${APP_CONTAINER}" sh -lc '
   cat > /tmp/kiro-real-request.json
-  curl -sS -o /tmp/kiro-real-response.json -w "%{http_code}" \
-    -H "x-api-key: '"${key}"'" \
+  curl -sS -D /tmp/kiro-real-response-headers.txt -o /tmp/kiro-real-response.json -w "%{http_code}" \
+    -H "x-api-key: $KIRO_GROUP_API_KEY" \
     -H "anthropic-version: 2023-06-01" \
     -H "anthropic-beta: claude-code-20250219" \
     -H "X-App: cli" \
+    -H "X-Request-ID: $KIRO_PROBE_REQUEST_ID" \
     -H "Content-Type: application/json" \
     -H "User-Agent: Claude-Code/1.0.33 (macOS; arm64)" \
     --data-binary @/tmp/kiro-real-request.json \
-    "'"${APP_URL}"'/v1/messages"
+    "$KIRO_APP_URL/v1/messages"
 ' <"${tmp_payload}" 2>"${tmp_err}")"; then
   http_code=""
 fi
@@ -82,17 +209,126 @@ else
   : >"${tmp_body}"
 fi
 
-docker logs "${APP_CONTAINER}" --since "${LOG_WINDOW}" >"${tmp_log}" 2>&1 || true
+if docker exec "${APP_CONTAINER}" test -f /tmp/kiro-real-response-headers.txt >/dev/null 2>&1; then
+  docker exec "${APP_CONTAINER}" cat /tmp/kiro-real-response-headers.txt >"${tmp_headers}"
+else
+  : >"${tmp_headers}"
+fi
 
-python3 - "${tmp_body}" "${tmp_log}" "${tmp_err}" "${http_code}" "${GROUP_NAME}" "${MODEL}" "${LOG_WINDOW}" "${PROMPT_TEXT}" <<'PY'
+mapfile -t response_ids < <(python3 - "${tmp_headers}" "${probe_request_id}" <<'PY'
+import sys
+from pathlib import Path
+
+path, fallback_request_id = sys.argv[1:3]
+request_id = fallback_request_id
+client_request_id = ""
+
+text = Path(path).read_text(encoding="utf-8", errors="replace") if Path(path).exists() else ""
+for raw in text.splitlines():
+    line = raw.rstrip("\r")
+    if ":" not in line:
+        continue
+    name, value = line.split(":", 1)
+    lname = name.strip().lower()
+    if lname == "x-request-id":
+        request_id = value.strip() or request_id
+    elif lname == "x-client-request-id":
+        client_request_id = value.strip()
+
+print(request_id)
+print(client_request_id)
+PY
+)
+response_request_id="${response_ids[0]:-${probe_request_id}}"
+response_client_request_id="${response_ids[1]:-}"
+usage_lookup_request_id=""
+if [[ -n "${response_client_request_id}" ]]; then
+  usage_lookup_request_id="client:${response_client_request_id}"
+fi
+
+fetch_usage_row() {
+  local lookup_request_id="$1"
+  local lookup_request_id_b64
+  lookup_request_id_b64="$(sql_b64 "${lookup_request_id}")"
+  "${PSQL[@]}" -c "
+SELECT row_to_json(t)
+FROM (
+  SELECT
+    ul.id,
+    ul.account_id,
+    ul.request_id,
+    ul.model,
+    ul.stream,
+    ul.duration_ms,
+    ul.created_at AT TIME ZONE 'UTC' AS created_at_utc
+  FROM usage_logs ul
+  WHERE ul.request_id = convert_from(decode('${lookup_request_id_b64}','base64'),'utf8')
+  ORDER BY ul.id DESC
+  LIMIT 1
+) t;
+"
+}
+
+usage_row_json=""
+if [[ -n "${usage_lookup_request_id}" ]]; then
+  for ((attempt = 1; attempt <= USAGE_POLL_ATTEMPTS; attempt++)); do
+    usage_row_json="$(fetch_usage_row "${usage_lookup_request_id}")"
+    usage_row_json="$(printf '%s' "${usage_row_json}" | tr -d '\n')"
+    if [[ -n "${usage_row_json}" ]]; then
+      break
+    fi
+    sleep "${USAGE_POLL_INTERVAL_SECONDS}"
+  done
+fi
+
+if [[ -n "${usage_row_json}" ]]; then
+  printf '%s' "${usage_row_json}" >"${tmp_usage}"
+else
+  printf 'null' >"${tmp_usage}"
+fi
+
+docker logs "${APP_CONTAINER}" --since "${LOG_WINDOW}" >"${tmp_log}" 2>&1 || true # preflight-allow: swallow
+
+python3 - "${tmp_body}" "${tmp_headers}" "${tmp_log}" "${tmp_err}" "${http_code}" "${GROUP_NAME}" "${MODEL}" "${LOG_WINDOW}" "${PROMPT_TEXT}" "${ACCOUNT_ID}" "${tmp_context}" "${tmp_usage}" "${probe_request_id}" <<'PY'
 import json
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
-body_path, log_path, err_path, http_code, group_name, model, log_window, prompt_text = sys.argv[1:9]
+(
+    body_path,
+    headers_path,
+    log_path,
+    err_path,
+    http_code,
+    group_name,
+    model,
+    log_window,
+    prompt_text,
+    target_account_id_raw,
+    context_path,
+    usage_path,
+    probe_request_id,
+) = sys.argv[1:14]
+
+target_account_id = int(target_account_id_raw)
 
 raw_body = open(body_path, encoding="utf-8", errors="replace").read()
 curl_error = open(err_path, encoding="utf-8", errors="replace").read().strip()
+context = json.loads(Path(context_path).read_text(encoding="utf-8"))
+usage_row = json.loads(Path(usage_path).read_text(encoding="utf-8"))
+
+response_headers: dict[str, str] = {}
+for raw in Path(headers_path).read_text(encoding="utf-8", errors="replace").splitlines():
+    line = raw.rstrip("\r")
+    if ":" not in line:
+        continue
+    name, value = line.split(":", 1)
+    response_headers[name.strip().lower()] = value.strip()
+
+response_request_id = response_headers.get("x-request-id") or probe_request_id
+response_client_request_id = response_headers.get("x-client-request-id", "")
+usage_lookup_request_id = f"client:{response_client_request_id}" if response_client_request_id else ""
 
 request_summary = {
     "requested_at_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
@@ -100,6 +336,9 @@ request_summary = {
     "model": model,
     "prompt_text": prompt_text,
     "http_status": int(http_code) if http_code.isdigit() else None,
+    "request_id": response_request_id,
+    "client_request_id": response_client_request_id,
+    "usage_lookup_request_id": usage_lookup_request_id,
 }
 if curl_error:
     request_summary["curl_error"] = curl_error[:400]
@@ -125,6 +364,7 @@ else:
     request_summary["raw_prefix"] = raw_body[:240]
 
 recent_rows = []
+matching_access_row = None
 with open(log_path, encoding="utf-8", errors="replace") as handle:
     for raw in handle:
         raw = raw.strip()
@@ -140,7 +380,7 @@ with open(log_path, encoding="utf-8", errors="replace") as handle:
             continue
         if obj.get("platform") != "kiro" and obj.get("billing_platform") != "kiro":
             continue
-        recent_rows.append({
+        row = {
             "account_id": obj.get("account_id"),
             "platform": obj.get("platform"),
             "billing_platform": obj.get("billing_platform"),
@@ -148,10 +388,73 @@ with open(log_path, encoding="utf-8", errors="replace") as handle:
             "model": obj.get("model"),
             "completed_at": obj.get("completed_at"),
             "latency_ms": obj.get("latency_ms"),
-        })
+            "request_id": obj.get("request_id"),
+            "client_request_id": obj.get("client_request_id"),
+        }
+        recent_rows.append(row)
+        request_id_match = response_request_id and row.get("request_id") == response_request_id
+        client_request_id_match = response_client_request_id and row.get("client_request_id") == response_client_request_id
+        if request_id_match or client_request_id_match:
+            matching_access_row = row
+
+group_accounts = context.get("group_accounts") or []
+eligible_accounts = [
+    row for row in group_accounts
+    if row.get("status") == "active" and row.get("schedulable") is True
+]
+
+target_account = context.get("target_account") or {
+    "account_id": target_account_id,
+}
+usage_account_id = usage_row.get("account_id") if isinstance(usage_row, dict) else None
+access_account_id = matching_access_row.get("account_id") if matching_access_row else None
+usage_matches_target = usage_account_id == target_account_id
+access_matches_target = access_account_id == target_account_id if access_account_id is not None else None
+
+if (
+    usage_account_id is not None
+    and access_account_id is not None
+    and usage_account_id != access_account_id
+):
+    verdict = "observability_conflict"
+elif request_summary.get("http_status") != 200:
+    verdict = "request_failed"
+elif request_summary.get("type") != "message" or request_summary.get("role") != "assistant":
+    verdict = "unexpected_response_shape"
+elif not isinstance(usage_row, dict):
+    verdict = "usage_row_missing"
+elif usage_matches_target:
+    verdict = "exact_target_verified"
+else:
+    verdict = "wrong_account_served"
 
 print(json.dumps({
     "request": request_summary,
+    "target": target_account,
+    "routing_pool": {
+        "group_id": context.get("group_id"),
+        "group_name": context.get("group_name"),
+        "eligible_account_count": len(eligible_accounts),
+        "accounts": group_accounts,
+    },
+    "usage_correlation": {
+        "matched": isinstance(usage_row, dict),
+        "row": usage_row,
+        "account_matches_target": usage_matches_target if isinstance(usage_row, dict) else False,
+    },
+    "access_log_correlation": {
+        "matched": matching_access_row is not None,
+        "row": matching_access_row,
+        "account_matches_target": access_matches_target,
+    },
+    "verification": {
+        "verdict": verdict,
+        "target_account_id": target_account_id,
+        "target_account_matched": usage_matches_target,
+        "response_ok": request_summary.get("http_status") == 200
+        and request_summary.get("type") == "message"
+        and request_summary.get("role") == "assistant",
+    },
     "recent_kiro_access": {
         "window": log_window,
         "count": len(recent_rows),

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Orchestrate the full Kiro reauth flow with deterministic sub-steps.
+
+This wrapper composes the bundled scripts instead of re-implementing their logic:
+  1. local summary / admin payload
+  2. pre-apply edge auth summary
+  3. optional apply
+  4. post-apply edge auth summary
+  5. summary compare
+  6. optional real Kiro request probe
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[3]
+
+LOCAL_CREDS = HERE / "local_kiro_credentials.py"
+APPLY_EDGE = HERE / "apply_edge_kiro_oauth.py"
+COMPARE = HERE / "compare_auth_summaries.py"
+EDGE_SUMMARY = HERE / "probe_edge_auth_summary.sh"
+REAL_PROBE = HERE / "probe_real_kiro_request.sh"
+RUN_PROBE = REPO_ROOT / "ops" / "observability" / "run-probe.sh"
+EDGE_RESOLVE = REPO_ROOT / "ops" / "stage0" / "edge_ssm_execution.py"
+
+
+def run_command(
+    argv: list[str],
+    *,
+    stdin_text: str | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[int, str, str]:
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    proc = subprocess.run(
+        argv,
+        input=stdin_text,
+        text=True,
+        capture_output=True,
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def must_json(stdout: str, label: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{label} returned invalid JSON: {exc}\nstdout:\n{stdout[:1000]}")
+    if not isinstance(parsed, dict):
+        raise SystemExit(f"{label} returned non-object JSON")
+    return parsed
+
+
+def run_json(argv: list[str], *, stdin_text: str | None = None, label: str, extra_env: dict[str, str] | None = None) -> dict[str, Any]:
+    code, stdout, stderr = run_command(argv, stdin_text=stdin_text, extra_env=extra_env)
+    if code != 0:
+        raise SystemExit(f"{label} failed with exit {code}\nstderr:\n{stderr}\nstdout:\n{stdout}")
+    return must_json(stdout, label)
+
+
+def resolve_edge(edge_id: str) -> dict[str, Any]:
+    return run_json(
+        [sys.executable, str(EDGE_RESOLVE), "--repo-root", ".", "--edge-id", edge_id, "--format", "json"],
+        label="edge_resolve",
+    )
+
+
+def local_summary(refresh: bool) -> dict[str, Any]:
+    argv = [sys.executable, str(LOCAL_CREDS), "--mode", "summary"]
+    if refresh:
+        argv.append("--refresh")
+    return run_json(argv, label="local_summary")
+
+
+def local_admin_payload(refresh: bool) -> dict[str, Any]:
+    argv = [sys.executable, str(LOCAL_CREDS), "--mode", "admin-payload"]
+    if refresh:
+        argv.append("--refresh")
+    return run_json(argv, label="local_admin_payload")
+
+
+def edge_summary(edge_id: str, account_id: int, account_name: str) -> dict[str, Any]:
+    argv = [
+        "bash",
+        str(RUN_PROBE),
+        "--target",
+        f"edge:{edge_id}",
+        "--script",
+        str(EDGE_SUMMARY),
+        "--env",
+        f"ACCOUNT_ID={account_id}",
+        "--env",
+        f"ACCOUNT_NAME={account_name}",
+    ]
+    return run_json(argv, label="edge_summary")
+
+
+def apply_edge(
+    *,
+    base_url: str,
+    account_id: int,
+    account_name: str,
+    payload: dict[str, Any],
+    admin_api_key: str,
+    admin_email: str,
+    admin_password: str,
+    admin_password_file: str,
+    ensure_schedulable: bool,
+    dry_run: bool,
+) -> dict[str, Any]:
+    argv = [
+        sys.executable,
+        str(APPLY_EDGE),
+        "--base-url",
+        base_url,
+        "--account-id",
+        str(account_id),
+        "--expected-account-name",
+        account_name,
+        "--payload-file",
+        "-",
+    ]
+    if ensure_schedulable:
+        argv.append("--ensure-schedulable")
+    if dry_run:
+        argv.append("--dry-run")
+    if admin_api_key:
+        argv.extend(["--admin-api-key", admin_api_key])
+    if admin_email:
+        argv.extend(["--admin-email", admin_email])
+    if admin_password:
+        argv.extend(["--admin-password", admin_password])
+    if admin_password_file:
+        argv.extend(["--admin-password-file", admin_password_file])
+    return run_json(argv, stdin_text=json.dumps(payload), label="apply_edge")
+
+
+def compare_summaries(local_obj: dict[str, Any], edge_obj: dict[str, Any]) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="kiro-compare-") as tmpdir:
+        local_path = Path(tmpdir) / "local.json"
+        edge_path = Path(tmpdir) / "edge.json"
+        local_path.write_text(json.dumps(local_obj, ensure_ascii=False), encoding="utf-8")
+        edge_path.write_text(json.dumps(edge_obj, ensure_ascii=False), encoding="utf-8")
+        return run_json(
+            [
+                sys.executable,
+                str(COMPARE),
+                "--local",
+                str(local_path),
+                "--edge",
+                str(edge_path),
+            ],
+            label="compare_summaries",
+        )
+
+
+def real_probe(edge_id: str, group_name: str, model: str, prompt_text: str, log_window: str) -> dict[str, Any]:
+    argv = [
+        "bash",
+        str(RUN_PROBE),
+        "--target",
+        f"edge:{edge_id}",
+        "--script",
+        str(REAL_PROBE),
+        "--env",
+        f"GROUP_NAME={group_name}",
+        "--env",
+        f"MODEL={model}",
+        "--env",
+        f"PROMPT_TEXT={prompt_text}",
+        "--env",
+        f"LOG_WINDOW={log_window}",
+    ]
+    return run_json(argv, label="real_probe")
+
+
+def render_plan(args: argparse.Namespace, edge_info: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "edge_id": args.edge_id,
+        "base_url": args.base_url or f"https://{edge_info['domain']}",
+        "account_id": args.account_id,
+        "account_name": args.account_name,
+        "local_refresh": args.local_refresh,
+        "do_apply": args.apply,
+        "do_real_probe": args.verify_real_request,
+        "ensure_schedulable": args.ensure_schedulable,
+        "group_name": args.group_name,
+        "model": args.model,
+        "log_window": args.log_window,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--edge-id", required=True)
+    parser.add_argument("--account-id", required=True, type=int)
+    parser.add_argument("--account-name", required=True)
+    parser.add_argument("--base-url", default="", help="override base URL; defaults to https://<resolved-domain>")
+
+    parser.add_argument("--local-refresh", action="store_true", help="mint a fresh local Kiro access token first")
+    parser.add_argument("--apply", action="store_true", help="apply local credentials to the edge")
+    parser.add_argument("--verify-real-request", action="store_true", help="run a real Kiro /v1/messages request after compare")
+    parser.add_argument("--ensure-schedulable", action="store_true", help="force schedulable=true after apply if needed")
+    parser.add_argument("--plan-only", action="store_true", help="resolve targets and print the intended plan only")
+
+    parser.add_argument("--group-name", default="kiro")
+    parser.add_argument("--model", default="claude-opus-4-8")
+    parser.add_argument("--prompt-text", default="Say hello in one short sentence.")
+    parser.add_argument("--log-window", default="3m")
+
+    parser.add_argument("--admin-api-key", default="")
+    parser.add_argument("--admin-email", default="")
+    parser.add_argument("--admin-password", default="")
+    parser.add_argument("--admin-password-file", default="")
+    args = parser.parse_args()
+
+    edge_info = resolve_edge(args.edge_id)
+    base_url = args.base_url or f"https://{edge_info['domain']}"
+
+    output: dict[str, Any] = {
+        "edge": edge_info,
+        "plan": render_plan(args, edge_info),
+    }
+
+    if args.plan_only:
+        json.dump(output, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    local_summary_obj = local_summary(args.local_refresh)
+    output["local_summary"] = local_summary_obj
+
+    pre_edge = edge_summary(args.edge_id, args.account_id, args.account_name)
+    output["pre_apply_edge_summary"] = pre_edge
+
+    if args.apply:
+        payload = local_admin_payload(args.local_refresh)
+        apply_result = apply_edge(
+            base_url=base_url,
+            account_id=args.account_id,
+            account_name=args.account_name,
+            payload=payload,
+            admin_api_key=args.admin_api_key,
+            admin_email=args.admin_email,
+            admin_password=args.admin_password,
+            admin_password_file=args.admin_password_file,
+            ensure_schedulable=args.ensure_schedulable,
+            dry_run=False,
+        )
+        output["apply_result"] = apply_result
+
+    post_edge = edge_summary(args.edge_id, args.account_id, args.account_name)
+    output["post_apply_edge_summary"] = post_edge
+    output["compare"] = compare_summaries(local_summary_obj, post_edge)
+
+    if args.verify_real_request:
+        output["real_request_probe"] = real_probe(
+            args.edge_id,
+            args.group_name,
+            args.model,
+            args.prompt_text,
+            args.log_window,
+        )
+
+    json.dump(output, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py
@@ -168,7 +168,7 @@ def compare_summaries(local_obj: dict[str, Any], edge_obj: dict[str, Any]) -> di
         )
 
 
-def real_probe(edge_id: str, group_name: str, model: str, prompt_text: str, log_window: str) -> dict[str, Any]:
+def real_probe(edge_id: str, account_id: int, group_name: str, model: str, prompt_text: str, log_window: str) -> dict[str, Any]:
     argv = [
         "bash",
         str(RUN_PROBE),
@@ -176,6 +176,8 @@ def real_probe(edge_id: str, group_name: str, model: str, prompt_text: str, log_
         f"edge:{edge_id}",
         "--script",
         str(REAL_PROBE),
+        "--env",
+        f"ACCOUNT_ID={account_id}",
         "--env",
         f"GROUP_NAME={group_name}",
         "--env",
@@ -263,13 +265,19 @@ def main() -> int:
         )
         output["apply_result"] = apply_result
 
-    post_edge = edge_summary(args.edge_id, args.account_id, args.account_name)
-    output["post_apply_edge_summary"] = post_edge
-    output["compare"] = compare_summaries(local_summary_obj, post_edge)
+    compare_edge = pre_edge
+    output["compare_edge_source"] = "pre_apply_edge_summary"
+    if args.apply:
+        post_edge = edge_summary(args.edge_id, args.account_id, args.account_name)
+        output["post_apply_edge_summary"] = post_edge
+        compare_edge = post_edge
+        output["compare_edge_source"] = "post_apply_edge_summary"
+    output["compare"] = compare_summaries(local_summary_obj, compare_edge)
 
     if args.verify_real_request:
         output["real_request_probe"] = real_probe(
             args.edge_id,
+            args.account_id,
             args.group_name,
             args.model,
             args.prompt_text,


### PR DESCRIPTION
## Summary
- harden `tokenkey-kiro-reauth` from a prose-heavy runbook into a script-backed workflow
- add deterministic helpers for local credential extraction, edge apply, auth-summary comparison, and real Kiro request verification
- codify the false-signal pitfalls from the recent us6 investigation directly in the skill guidance

## What Changed
- rewrote `.cursor/skills/tokenkey-kiro-reauth/SKILL.md` to prefer a single orchestrated flow and to explicitly ban misleading signals like admin `/refresh` and admin active `usage` as Kiro truth
- added bundled scripts for:
  - local Kiro credential extraction and optional local refresh
  - safe edge apply via admin login/API key with optional `schedulable=true` recovery
  - local-vs-edge auth summary comparison
  - edge auth summary probing over `run-probe.sh`
  - real `/v1/messages` verification from inside the `tokenkey` container
  - one-shot orchestration of the full reauth flow
- updated `agents/openai.yaml` to reflect the new real-request verification workflow

## Validation
- `bash scripts/preflight.sh`
- `python3 -m py_compile .cursor/skills/tokenkey-kiro-reauth/scripts/*.py`
- `bash -n .cursor/skills/tokenkey-kiro-reauth/scripts/probe_edge_auth_summary.sh .cursor/skills/tokenkey-kiro-reauth/scripts/probe_real_kiro_request.sh`
- `python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py --edge-id us6 --account-id 2 --account-name kiro-us6-real --plan-only`
- `python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py --edge-id us6 --account-id 2 --account-name kiro-us6-real`
