### PR TITLE
fix(admin): optimize admin UI performance

### DIFF
--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -25,6 +25,11 @@ description: >-
 | live-host 运行态漂移（运行镜像 tag vs 部署 tag + deploy_via_ssm 注入的 env：SERVER_FRONTEND_URL / QA_CAPTURE_EXPORT_STORAGE_*）| 机械 | `ops/stage0/assert-live-host-state.sh <instance_id> [expected_tag]`（只读 SSM，advisory；verdict 逻辑+`--selftest` 在 `ops/stage0/live_host_state_verdict.py`，已进 preflight；deploy-stage0 部署后 + ops-daily-diagnostics 每日审计自动跑）|
 | Gateway "http request completed" 最近 N 行 tail（脱敏 → JSON array，轻量原始日志） | 机械 | `ops/observability/probe-tail-gateway-logs.sh`（经 run-probe 投递；`LIMIT` 默认 50、`SINCE` 默认 24h、`CONTAINER` 默认 tokenkey） |
 | Dashboard 预聚合覆盖度诊断（"使用趋势只显示 2 天"：usage_dashboard_daily/hourly vs raw usage_logs + aggregation watermark） | 机械 | `ops/observability/probe-dashboard-aggregate-coverage.sh`（经 run-probe 投递；只读 `row_to_json`） |
+| Admin UI access-log 性能画像（/admin 前端资源 + /api/v1/admin/* latency p50/p90/p95 + slow samples） | 机械 | `ops/observability/probe-admin-ui-perf.sh`（经 run-probe 投递；只读 Docker logs 聚合） |
+| Admin UI API timing（逐页接口 curl TTFB/total/size/非 2xx，含 dashboard/usage/accounts/ops/payment 等页面形状） | 机械 | `ops/observability/probe-admin-ui-api-timing.sh`（经 run-probe 投递；只读 admin API key + curl，无 mutating endpoints） |
+| Admin aggregation runtime config（dashboard aggregation env/config + hourly/daily/model/group marker 覆盖度） | 机械 | `ops/observability/probe-admin-aggregation-config.sh`（经 run-probe 投递；只读 env + SELECT） |
+| Admin model rollup timing（dashboard/models 冷态慢：raw 7d group-by vs usage_dashboard_model_daily + raw today 耗时/一致性） | 机械 | `ops/observability/probe-admin-model-rollup-timing.sh`（经 run-probe 投递；只读 SELECT + EXPLAIN ANALYZE） |
+| Admin group rollup timing（usage/dashboard group distribution 冷态慢：raw 7d group-by vs usage_dashboard_group_daily + raw today 耗时/一致性） | 机械 | `ops/observability/probe-admin-group-rollup-timing.sh`（经 run-probe 投递；只读 SELECT + EXPLAIN ANALYZE） |
 | 图片/视频盯盘（成功计量计费 + 错误分面 + 计费异常 + last-seen；区分 image vs video、空池 429 vs 真上游错误 vs 缺权限 401） | 机械 | `ops/observability/probe-image-video-billing.sh`（窗口盯盘，`WINDOW_MIN`/`CTX_HOURS`）+ `ops/observability/probe-image-video-deepctx.sh`（openai 账号池/报错归属/流量出处一次性深挖），均经 run-probe 投递；只读 `row_to_json` |
 | 用户级盯盘（一组 user_id 的请求 + 错误 + 计量计费 + 图片/视频 breakout + last-seen，单次 SSM 往返，对齐 30min 汇报节奏） | 机械 | `ops/observability/probe-user-billing-watch.sh`（经 run-probe 投递；`USER_IDS` 逗号分隔整数默认 `1,16`、`WINDOW_MINUTES` 默认 30；只读 `row_to_json`，复用 probe-image-video-billing.sh 的 image/video 判别谓词） |
 | Gateway UA/TLS / usage_logs / ops / docker 指纹交叉对比（窄时间窗） | 机械 | `ops/observability/probe-gateway-ua-tls-compare.sh`（通过 run-probe.sh 投递；`WINDOW_MINUTES` 收窄 DB 窗） |
@@ -304,6 +309,60 @@ CLI 契约：
 **前置条件**：目标实例上 debug  env 已开启且文件存在；否则 SSM 会在 `docker exec tokenkey test -f …` 失败。未开启时先用 §5 / §5.1 聚合，或经 deploy/ops 流程临时开启（超出本 skill 只读边界，需显式确认）。
 
 **与 run-probe 的分工**：`run-probe.sh` 只回传远端 stdout 字节；本脚本需要本机 boto3 presign + S3 下载，因此是**开发者机器上运行的 orchestrator**，不要塞进 run-probe。
+
+## 5.3) Admin UI 性能探测（机械化）
+
+Admin 页面慢、首屏资源异常、或发版后需要复测 `/admin/*` 运营体验时，用两个只读 probe 组合：access-log 聚合看真实访问路径和慢样本，API timing 主动测每个页面依赖的接口形状。都通过 §2 `run-probe.sh` 投递；脚本只读 Docker logs、settings 表里的 `admin_api_key`，并只调用 `GET` 与只读 batch `POST`，不跑 test/run/export/sync/reset 类 mutating endpoint。
+
+```bash
+# 真实访问日志聚合：/api/v1/admin/* endpoint latency + /admin 前端资源 preload/慢资源样本
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/observability/probe-admin-ui-perf.sh \
+  --env SINCE=24h \
+  --timeout-seconds 180
+
+# 主动接口 timing：Dashboard / Usage / Accounts / Groups / Ops / Payment / Risk 等页面形状
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/observability/probe-admin-ui-api-timing.sh \
+  --timeout-seconds 240
+
+# 聚合运行态：确认 dashboard aggregation env/config、watermark、model/group backfill marker
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/observability/probe-admin-aggregation-config.sh \
+  --timeout-seconds 120
+
+# 针对 dashboard/models 冷态慢：验证 model daily rollup 是否生效、raw today group-by 耗时
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/observability/probe-admin-model-rollup-timing.sh \
+  --timeout-seconds 240
+
+# 针对 usage/dashboard group distribution 冷态慢：验证 group daily rollup 是否生效
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/observability/probe-admin-group-rollup-timing.sh \
+  --timeout-seconds 240
+```
+
+输出解读：
+
+| probe | 主要字段 | 用途 |
+|---|---|---|
+| `probe-admin-ui-perf.sh` | `admin_by_endpoint_top`、`frontend_by_path_top`、`slow_admin_samples`、`slow_frontend_samples` | 找出真实用户访问中的慢 endpoint、旧资源是否仍被 preload、慢资源样本 |
+| `probe-admin-ui-api-timing.sh` | `top_slow`、`non_2xx`、`results[].label`、`curl.ttfb`、`curl.total`、`curl.size` | 主动复现各 admin 页面依赖接口的 TTFB/total，定位 stats/model/group/users-trend 等慢段 |
+| `probe-admin-aggregation-config.sh` | `env_dashboard_aggregation`、`aggregation_watermark`、`hourly_min/max`、`group_daily_backfilled`、`group_daily_metrics_backfilled`、`model_daily_backfilled` | 部署前后确认聚合运行态、历史 backfill marker 是否已启用对应快路径 |
+| `probe-admin-model-rollup-timing.sh` | `model_daily_backfilled`、`raw_7d_model_group_explain`、`rollup_completed_days_explain`、`raw_today_model_group_explain`、`raw_vs_rollup_plus_today_delta` | 验证 dashboard model distribution 的 7d raw group-by 耗时、completed-day rollup 耗时、today raw tail 耗时、历史 backfill marker 与快路径一致性 |
+| `probe-admin-group-rollup-timing.sh` | `raw_7d_group_explain`、`rollup_completed_days_explain`、`raw_today_group_explain`、`raw_vs_rollup_completed_days_delta` | 验证 Dashboard/Usage group distribution 的 7d raw group-by 耗时、completed-day rollup 耗时、today raw tail 耗时和历史一致性 |
+
+`probe-admin-model-rollup-timing.sh` / `probe-admin-group-rollup-timing.sh` 默认只输出 meta、窗口计数与一致性 delta，避免 SSM stdout 被 `EXPLAIN FORMAT JSON` 截断；需要执行计划时追加 `--env INCLUDE_EXPLAIN=1`，或用 `--env INCLUDE_EXPLAIN=1 --env EXPLAIN_SECTION=raw_7d|rollup_completed_days|raw_today` 单段拉取。
+
+解读纪律：
+- Dashboard/Usage 的 combined snapshot 可能被前一个 split 请求预热；需要冷态判断时，把 split 测点排在 combined 前，或比较 `trend-only` / `models-only` / `groups-only` 的首个耗时。
+- `http_code=500` 先看具体 label，不要把整个 admin UI 判死；例如 `dashboard.snapshot.*users-trend*` 失败通常只影响 users-trend 区块。
+- API timing 的公网网络耗时很小，`ttfb≈total` 时基本就是服务端/DB/缓存路径耗时；DNS/connect 异常才看网络。
 
 ## 6) 配置与限额核对
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1950,7 +1950,7 @@ func setDefaults() {
 	viper.SetDefault("dashboard_cache.enabled", true)
 	viper.SetDefault("dashboard_cache.key_prefix", "sub2api:")
 	viper.SetDefault("dashboard_cache.stats_fresh_ttl_seconds", 15)
-	viper.SetDefault("dashboard_cache.stats_ttl_seconds", 30)
+	viper.SetDefault("dashboard_cache.stats_ttl_seconds", 300)
 	viper.SetDefault("dashboard_cache.stats_refresh_timeout_seconds", 30)
 
 	// Dashboard aggregation

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -591,8 +591,8 @@ func TestLoadDefaultDashboardCacheConfig(t *testing.T) {
 	if cfg.Dashboard.StatsFreshTTLSeconds != 15 {
 		t.Fatalf("Dashboard.StatsFreshTTLSeconds = %d, want 15", cfg.Dashboard.StatsFreshTTLSeconds)
 	}
-	if cfg.Dashboard.StatsTTLSeconds != 30 {
-		t.Fatalf("Dashboard.StatsTTLSeconds = %d, want 30", cfg.Dashboard.StatsTTLSeconds)
+	if cfg.Dashboard.StatsTTLSeconds != 300 {
+		t.Fatalf("Dashboard.StatsTTLSeconds = %d, want 300", cfg.Dashboard.StatsTTLSeconds)
 	}
 	if cfg.Dashboard.StatsRefreshTimeoutSeconds != 30 {
 		t.Fatalf("Dashboard.StatsRefreshTimeoutSeconds = %d, want 30", cfg.Dashboard.StatsRefreshTimeoutSeconds)

--- a/backend/internal/handler/admin/dashboard_handler_cache_test.go
+++ b/backend/internal/handler/admin/dashboard_handler_cache_test.go
@@ -62,9 +62,19 @@ func resetDashboardReadCachesForTest() {
 	dashboardTrendCache = newSnapshotCache(30 * time.Second)
 	dashboardUsersTrendCache = newSnapshotCache(30 * time.Second)
 	dashboardAPIKeysTrendCache = newSnapshotCache(30 * time.Second)
-	dashboardModelStatsCache = newSnapshotCache(30 * time.Second)
-	dashboardGroupStatsCache = newSnapshotCache(30 * time.Second)
+	dashboardModelStatsCache = newSnapshotCache(dashboardDistributionCacheTTL)
+	dashboardGroupStatsCache = newSnapshotCache(dashboardDistributionCacheTTL)
 	dashboardSnapshotV2Cache = newSnapshotCache(30 * time.Second)
+}
+
+func TestDashboardHandler_DistributionCachesUseLongerTTL(t *testing.T) {
+	t.Cleanup(resetDashboardReadCachesForTest)
+	resetDashboardReadCachesForTest()
+
+	require.Equal(t, 30*time.Second, dashboardTrendCache.ttl)
+	require.Equal(t, dashboardDistributionCacheTTL, dashboardModelStatsCache.ttl)
+	require.Equal(t, dashboardDistributionCacheTTL, dashboardGroupStatsCache.ttl)
+	require.Equal(t, 30*time.Second, dashboardUsersTrendCache.ttl)
 }
 
 func TestDashboardHandler_GetUsageTrend_UsesCache(t *testing.T) {

--- a/backend/internal/handler/admin/dashboard_query_cache.go
+++ b/backend/internal/handler/admin/dashboard_query_cache.go
@@ -11,11 +11,13 @@ import (
 
 var (
 	dashboardTrendCache        = newSnapshotCache(30 * time.Second)
-	dashboardModelStatsCache   = newSnapshotCache(30 * time.Second)
-	dashboardGroupStatsCache   = newSnapshotCache(30 * time.Second)
+	dashboardModelStatsCache   = newSnapshotCache(dashboardDistributionCacheTTL)
+	dashboardGroupStatsCache   = newSnapshotCache(dashboardDistributionCacheTTL)
 	dashboardUsersTrendCache   = newSnapshotCache(30 * time.Second)
 	dashboardAPIKeysTrendCache = newSnapshotCache(30 * time.Second)
 )
+
+const dashboardDistributionCacheTTL = 5 * time.Minute
 
 type dashboardTrendCacheKey struct {
 	StartTime   string `json:"start_time"`

--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -312,17 +312,19 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 
 	// Build filters and call GetStatsWithFilters
 	filters := usagestats.UsageLogFilters{
-		UserID:      userID,
-		APIKeyID:    apiKeyID,
-		AccountID:   accountID,
-		GroupID:     groupID,
-		Model:       model,
-		RequestType: requestType,
-		Stream:      stream,
-		BillingType: billingType,
-		BillingMode: billingMode,
-		StartTime:   &startTime,
-		EndTime:     &endTime,
+		UserID:            userID,
+		APIKeyID:          apiKeyID,
+		AccountID:         accountID,
+		GroupID:           groupID,
+		Model:             model,
+		RequestType:       requestType,
+		Stream:            stream,
+		BillingType:       billingType,
+		BillingMode:       billingMode,
+		StartTime:         &startTime,
+		EndTime:           &endTime,
+		SkipSummary:       !parseBoolQueryWithDefault(c.Query("include_summary"), true),
+		SkipEndpointStats: !parseBoolQueryWithDefault(c.Query("include_endpoints"), true),
 	}
 
 	var stats *usagestats.UsageStats

--- a/backend/internal/handler/admin/usage_handler_request_type_test.go
+++ b/backend/internal/handler/admin/usage_handler_request_type_test.go
@@ -140,3 +140,16 @@ func TestAdminUsageStatsInvalidStream(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+func TestAdminUsageStatsIncludeToggles(t *testing.T) {
+	repo := &adminUsageRepoCapture{}
+	router := newAdminUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/usage/stats?include_summary=0&include_endpoints=false", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, repo.statsFilters.SkipSummary)
+	require.True(t, repo.statsFilters.SkipEndpointStats)
+}

--- a/backend/internal/handler/admin/usage_query_cache.go
+++ b/backend/internal/handler/admin/usage_query_cache.go
@@ -11,17 +11,19 @@ import (
 var usageStatsCache = newSnapshotCache(30 * time.Second)
 
 type usageStatsCacheKeyData struct {
-	StartTime   string `json:"start_time"`
-	EndTime     string `json:"end_time"`
-	UserID      int64  `json:"user_id"`
-	APIKeyID    int64  `json:"api_key_id"`
-	AccountID   int64  `json:"account_id"`
-	GroupID     int64  `json:"group_id"`
-	Model       string `json:"model"`
-	BillingMode string `json:"billing_mode"`
-	RequestType *int16 `json:"request_type"`
-	Stream      *bool  `json:"stream"`
-	BillingType *int8  `json:"billing_type"`
+	StartTime         string `json:"start_time"`
+	EndTime           string `json:"end_time"`
+	UserID            int64  `json:"user_id"`
+	APIKeyID          int64  `json:"api_key_id"`
+	AccountID         int64  `json:"account_id"`
+	GroupID           int64  `json:"group_id"`
+	Model             string `json:"model"`
+	BillingMode       string `json:"billing_mode"`
+	RequestType       *int16 `json:"request_type"`
+	Stream            *bool  `json:"stream"`
+	BillingType       *int8  `json:"billing_type"`
+	SkipSummary       bool   `json:"skip_summary"`
+	SkipEndpointStats bool   `json:"skip_endpoint_stats"`
 }
 
 func usageStatsCacheKey(filters usagestats.UsageLogFilters) string {
@@ -34,17 +36,19 @@ func usageStatsCacheKey(filters usagestats.UsageLogFilters) string {
 		end = filters.EndTime.UTC().Format(time.RFC3339)
 	}
 	return mustMarshalDashboardCacheKey(usageStatsCacheKeyData{
-		StartTime:   start,
-		EndTime:     end,
-		UserID:      filters.UserID,
-		APIKeyID:    filters.APIKeyID,
-		AccountID:   filters.AccountID,
-		GroupID:     filters.GroupID,
-		Model:       filters.Model,
-		BillingMode: filters.BillingMode,
-		RequestType: filters.RequestType,
-		Stream:      filters.Stream,
-		BillingType: filters.BillingType,
+		StartTime:         start,
+		EndTime:           end,
+		UserID:            filters.UserID,
+		APIKeyID:          filters.APIKeyID,
+		AccountID:         filters.AccountID,
+		GroupID:           filters.GroupID,
+		Model:             filters.Model,
+		BillingMode:       filters.BillingMode,
+		RequestType:       filters.RequestType,
+		Stream:            filters.Stream,
+		BillingType:       filters.BillingType,
+		SkipSummary:       filters.SkipSummary,
+		SkipEndpointStats: filters.SkipEndpointStats,
 	})
 }
 

--- a/backend/internal/handler/admin/usage_query_cache_test.go
+++ b/backend/internal/handler/admin/usage_query_cache_test.go
@@ -25,4 +25,12 @@ func TestUsageStatsCacheKey_StableAndDistinct(t *testing.T) {
 	withUser := base
 	withUser.UserID = 7
 	require.NotEqual(t, k1, usageStatsCacheKey(withUser), "different user must change key")
+
+	withoutEndpointStats := base
+	withoutEndpointStats.SkipEndpointStats = true
+	require.NotEqual(t, k1, usageStatsCacheKey(withoutEndpointStats), "endpoint stats toggle must change key")
+
+	withoutSummary := base
+	withoutSummary.SkipSummary = true
+	require.NotEqual(t, k1, usageStatsCacheKey(withoutSummary), "summary toggle must change key")
 }

--- a/backend/internal/pkg/usagestats/usage_log_types.go
+++ b/backend/internal/pkg/usagestats/usage_log_types.go
@@ -274,6 +274,10 @@ type UsageLogFilters struct {
 	EndTime     *time.Time
 	// ExactTotal requests exact COUNT(*) for pagination. Default false for fast large-table paging.
 	ExactTotal bool
+	// SkipSummary and SkipEndpointStats let admin stats callers split expensive
+	// aggregate and endpoint-distribution queries without changing legacy defaults.
+	SkipSummary       bool
+	SkipEndpointStats bool
 }
 
 // UsageStats represents usage statistics

--- a/backend/internal/repository/dashboard_aggregation_repo.go
+++ b/backend/internal/repository/dashboard_aggregation_repo.go
@@ -19,6 +19,7 @@ type dashboardAggregationRepository struct {
 
 const usageLogsCleanupBatchSize = 10000
 const usageBillingDedupCleanupBatchSize = 10000
+const dashboardHistoricalBackfillMinRemaining = 5 * time.Minute
 
 // NewDashboardAggregationRepository 创建仪表盘预聚合仓储。
 func NewDashboardAggregationRepository(sqlDB *sql.DB) service.DashboardAggregationRepository {
@@ -34,6 +35,11 @@ func NewDashboardAggregationRepository(sqlDB *sql.DB) service.DashboardAggregati
 
 func newDashboardAggregationRepositoryWithSQL(sqlq sqlExecutor) *dashboardAggregationRepository {
 	return &dashboardAggregationRepository{sql: sqlq}
+}
+
+func hasDashboardHistoricalBackfillBudget(ctx context.Context) bool {
+	deadline, ok := ctx.Deadline()
+	return !ok || time.Until(deadline) >= dashboardHistoricalBackfillMinRemaining
 }
 
 func isPostgresDriver(db *sql.DB) bool {
@@ -55,6 +61,12 @@ func (r *dashboardAggregationRepository) AggregateRange(ctx context.Context, sta
 	// the raw scan and the next cycle retries, so it never blocks aggregation.
 	if err := r.backfillGroupDailyAllOnce(ctx); err != nil {
 		log.Printf("[DashboardAggregation] group daily rollup backfill failed (read path falls back to raw scan): %v", err)
+	}
+	if err := r.backfillGroupDailyMetricsAllOnce(ctx); err != nil {
+		log.Printf("[DashboardAggregation] group daily metrics backfill failed (group distribution falls back to raw scan): %v", err)
+	}
+	if err := r.backfillModelDailyAllOnce(ctx); err != nil {
+		log.Printf("[DashboardAggregation] model daily rollup backfill failed (model distribution falls back to raw scan): %v", err)
 	}
 	loc := timezone.Location()
 	startLocal := start.In(loc)

--- a/backend/internal/repository/dashboard_aggregation_repo_tk_group.go
+++ b/backend/internal/repository/dashboard_aggregation_repo_tk_group.go
@@ -2,42 +2,71 @@ package repository
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 )
 
-// TK: per-(group, day) cost rollup feeder. Backs the admin Groups page
-// usage-summary widget (GET /api/v1/admin/groups/usage-summary), whose legacy
-// query SUMs actual_cost over the ENTIRE usage_logs table on every load. The
-// live read path (usage_log_repo_tk_group_rollup.go) sums completed days from
-// this rollup and reads only today's partial day from raw usage_logs, so the
-// all-time total is served without the full-table scan.
+// TK: per-(group, day) rollup feeder. Backs the admin Groups page usage-summary
+// widget (GET /api/v1/admin/groups/usage-summary), whose legacy query SUMs
+// actual_cost over the ENTIRE usage_logs table on every load, and the admin
+// Dashboard/Usage group-distribution chart. The live read paths sum completed
+// days from this rollup and read only partial/today slices from raw usage_logs,
+// so wide windows are served without a full raw scan.
 //
 // bucket_date is computed in the configured server timezone (timezone.Name()) so
 // the rollup/today split in the read path lines up exactly with the rollup grain.
 
-// upsertGroupDailyAggregates rebuilds the per-(group, day) cost rows for the given
+// upsertGroupDailyAggregates rebuilds the per-(group, day) rows for the given
 // server-TZ day window directly from raw usage_logs. Mirrors
 // upsertUserPlatformDailyAggregates: the window is day-aligned so each day's SUM
 // is complete, and ON CONFLICT replaces (not adds) so re-running a day is
-// idempotent. Rows with NULL group_id are excluded (the legacy query's
-// groups-LEFT-JOIN-usage_logs only sees rows whose group_id matches a group).
+// idempotent. Rows with NULL group_id are stored under group_id=0 so the
+// Dashboard/Usage group-distribution chart preserves the legacy
+// COALESCE(ul.group_id, 0) bucket. The Groups usage-summary read path filters
+// back down to real group ids.
 func (r *dashboardAggregationRepository) upsertGroupDailyAggregates(ctx context.Context, dayStart, dayEnd time.Time) error {
 	tzName := timezone.Name()
 	query := `
-		INSERT INTO usage_dashboard_group_daily (bucket_date, group_id, actual_cost, computed_at)
+		INSERT INTO usage_dashboard_group_daily (
+			bucket_date,
+			group_id,
+			total_requests,
+			input_tokens,
+			output_tokens,
+			cache_creation_tokens,
+			cache_read_tokens,
+			total_cost,
+			actual_cost,
+			account_cost,
+			computed_at
+		)
 		SELECT
 			(ul.created_at AT TIME ZONE $3)::date AS bucket_date,
-			ul.group_id,
+			COALESCE(ul.group_id, 0) AS group_id,
+			COUNT(*) AS total_requests,
+			COALESCE(SUM(ul.input_tokens), 0) AS input_tokens,
+			COALESCE(SUM(ul.output_tokens), 0) AS output_tokens,
+			COALESCE(SUM(ul.cache_creation_tokens), 0) AS cache_creation_tokens,
+			COALESCE(SUM(ul.cache_read_tokens), 0) AS cache_read_tokens,
+			COALESCE(SUM(ul.total_cost), 0) AS total_cost,
 			COALESCE(SUM(ul.actual_cost), 0) AS actual_cost,
+			COALESCE(SUM(COALESCE(ul.account_stats_cost, ul.total_cost) * COALESCE(ul.account_rate_multiplier, 1)), 0) AS account_cost,
 			NOW()
 		FROM usage_logs ul
-		WHERE ul.created_at >= $1 AND ul.created_at < $2 AND ul.group_id IS NOT NULL
-		GROUP BY 1, ul.group_id
+		WHERE ul.created_at >= $1 AND ul.created_at < $2
+		GROUP BY 1, COALESCE(ul.group_id, 0)
 		ON CONFLICT (bucket_date, group_id)
 		DO UPDATE SET
+			total_requests = EXCLUDED.total_requests,
+			input_tokens = EXCLUDED.input_tokens,
+			output_tokens = EXCLUDED.output_tokens,
+			cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+			cache_read_tokens = EXCLUDED.cache_read_tokens,
+			total_cost = EXCLUDED.total_cost,
 			actual_cost = EXCLUDED.actual_cost,
+			account_cost = EXCLUDED.account_cost,
 			computed_at = EXCLUDED.computed_at
 	`
 	_, err := r.sql.ExecContext(ctx, query, dayStart, dayEnd, tzName)
@@ -56,10 +85,11 @@ func (r *dashboardAggregationRepository) deleteGroupDailyRange(ctx context.Conte
 }
 
 // groupDailyBackfillMarkerDate is the reserved bucket_date of the sentinel row
-// (group_id = 0, a value no real group uses) that records "the one-time
-// historical backfill has run". The read path filters group_id > 0, so the
-// marker never affects any group's total.
+// (group_id = 0) that records "the one-time historical backfill has run".
+// group_id=0 is also used for real ungrouped usage on normal dates, so rollup
+// read paths exclude these reserved marker dates explicitly.
 const groupDailyBackfillMarkerDate = "1970-01-01"
+const groupDailyMetricsBackfillMarkerDate = "1970-01-02"
 
 // backfillGroupDailyAllOnce does a ONE-TIME full-history aggregation of the
 // per-(group, day) rollup, in the runtime server timezone. This is required
@@ -84,26 +114,128 @@ func (r *dashboardAggregationRepository) backfillGroupDailyAllOnce(ctx context.C
 	if done {
 		return nil
 	}
+	if !hasDashboardHistoricalBackfillBudget(ctx) {
+		log.Printf("[DashboardAggregation] group daily rollup backfill deferred: context deadline too close")
+		return nil
+	}
 	tzName := timezone.Name()
 	if _, err := r.sql.ExecContext(ctx, `
-		INSERT INTO usage_dashboard_group_daily (bucket_date, group_id, actual_cost, computed_at)
+		INSERT INTO usage_dashboard_group_daily (
+			bucket_date,
+			group_id,
+			total_requests,
+			input_tokens,
+			output_tokens,
+			cache_creation_tokens,
+			cache_read_tokens,
+			total_cost,
+			actual_cost,
+			account_cost,
+			computed_at
+		)
 		SELECT
 			(ul.created_at AT TIME ZONE $1)::date AS bucket_date,
-			ul.group_id,
+			COALESCE(ul.group_id, 0) AS group_id,
+			COUNT(*) AS total_requests,
+			COALESCE(SUM(ul.input_tokens), 0) AS input_tokens,
+			COALESCE(SUM(ul.output_tokens), 0) AS output_tokens,
+			COALESCE(SUM(ul.cache_creation_tokens), 0) AS cache_creation_tokens,
+			COALESCE(SUM(ul.cache_read_tokens), 0) AS cache_read_tokens,
+			COALESCE(SUM(ul.total_cost), 0) AS total_cost,
 			COALESCE(SUM(ul.actual_cost), 0) AS actual_cost,
+			COALESCE(SUM(COALESCE(ul.account_stats_cost, ul.total_cost) * COALESCE(ul.account_rate_multiplier, 1)), 0) AS account_cost,
 			NOW()
 		FROM usage_logs ul
-		WHERE ul.group_id IS NOT NULL
-		GROUP BY 1, ul.group_id
+		GROUP BY 1, COALESCE(ul.group_id, 0)
 		ON CONFLICT (bucket_date, group_id)
 		DO UPDATE SET
+			total_requests = EXCLUDED.total_requests,
+			input_tokens = EXCLUDED.input_tokens,
+			output_tokens = EXCLUDED.output_tokens,
+			cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+			cache_read_tokens = EXCLUDED.cache_read_tokens,
+			total_cost = EXCLUDED.total_cost,
 			actual_cost = EXCLUDED.actual_cost,
+			account_cost = EXCLUDED.account_cost,
 			computed_at = EXCLUDED.computed_at
 	`, tzName); err != nil {
 		return err
 	}
-	// Set the backfill-done marker so the full-table scan above never runs again.
+	// Set both markers: this backfill now writes the full metric set, so a fresh
+	// deployment must not immediately run the metrics-only backfill again.
+	_, err := r.sql.ExecContext(ctx, `
+		INSERT INTO usage_dashboard_group_daily (bucket_date, group_id, actual_cost, computed_at)
+		VALUES
+			(DATE '`+groupDailyBackfillMarkerDate+`', 0, 0, NOW()),
+			(DATE '`+groupDailyMetricsBackfillMarkerDate+`', 0, 0, NOW())
+		ON CONFLICT (bucket_date, group_id) DO NOTHING
+	`)
+	return err
+}
+
+// backfillGroupDailyMetricsAllOnce exists for deployments that already ran
+// tk_038 when usage_dashboard_group_daily contained only actual_cost. tk_046 adds
+// metric columns with default zero, so the group-distribution read path must not
+// trust historical rows until this one-time rewrite has populated requests,
+// tokens, total_cost, and account_cost.
+func (r *dashboardAggregationRepository) backfillGroupDailyMetricsAllOnce(ctx context.Context) error {
+	var done bool
+	if err := scanSingleRow(ctx, r.sql,
+		"SELECT EXISTS(SELECT 1 FROM usage_dashboard_group_daily WHERE group_id = 0 AND bucket_date = DATE '"+groupDailyMetricsBackfillMarkerDate+"')",
+		nil, &done); err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+	if !hasDashboardHistoricalBackfillBudget(ctx) {
+		log.Printf("[DashboardAggregation] group daily metrics backfill deferred: context deadline too close")
+		return nil
+	}
+	tzName := timezone.Name()
+	if _, err := r.sql.ExecContext(ctx, `
+		INSERT INTO usage_dashboard_group_daily (
+			bucket_date,
+			group_id,
+			total_requests,
+			input_tokens,
+			output_tokens,
+			cache_creation_tokens,
+			cache_read_tokens,
+			total_cost,
+			actual_cost,
+			account_cost,
+			computed_at
+		)
+		SELECT
+			(ul.created_at AT TIME ZONE $1)::date AS bucket_date,
+			COALESCE(ul.group_id, 0) AS group_id,
+			COUNT(*) AS total_requests,
+			COALESCE(SUM(ul.input_tokens), 0) AS input_tokens,
+			COALESCE(SUM(ul.output_tokens), 0) AS output_tokens,
+			COALESCE(SUM(ul.cache_creation_tokens), 0) AS cache_creation_tokens,
+			COALESCE(SUM(ul.cache_read_tokens), 0) AS cache_read_tokens,
+			COALESCE(SUM(ul.total_cost), 0) AS total_cost,
+			COALESCE(SUM(ul.actual_cost), 0) AS actual_cost,
+			COALESCE(SUM(COALESCE(ul.account_stats_cost, ul.total_cost) * COALESCE(ul.account_rate_multiplier, 1)), 0) AS account_cost,
+			NOW()
+		FROM usage_logs ul
+		GROUP BY 1, COALESCE(ul.group_id, 0)
+		ON CONFLICT (bucket_date, group_id)
+		DO UPDATE SET
+			total_requests = EXCLUDED.total_requests,
+			input_tokens = EXCLUDED.input_tokens,
+			output_tokens = EXCLUDED.output_tokens,
+			cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+			cache_read_tokens = EXCLUDED.cache_read_tokens,
+			total_cost = EXCLUDED.total_cost,
+			actual_cost = EXCLUDED.actual_cost,
+			account_cost = EXCLUDED.account_cost,
+			computed_at = EXCLUDED.computed_at
+	`, tzName); err != nil {
+		return err
+	}
 	_, err := r.sql.ExecContext(ctx,
-		"INSERT INTO usage_dashboard_group_daily (bucket_date, group_id, actual_cost, computed_at) VALUES (DATE '"+groupDailyBackfillMarkerDate+"', 0, 0, NOW()) ON CONFLICT (bucket_date, group_id) DO NOTHING")
+		"INSERT INTO usage_dashboard_group_daily (bucket_date, group_id, actual_cost, computed_at) VALUES (DATE '"+groupDailyMetricsBackfillMarkerDate+"', 0, 0, NOW()) ON CONFLICT (bucket_date, group_id) DO NOTHING")
 	return err
 }

--- a/backend/internal/repository/dashboard_aggregation_repo_tk_model.go
+++ b/backend/internal/repository/dashboard_aggregation_repo_tk_model.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
@@ -9,6 +10,14 @@ import (
 
 // TK: per-(requested-model, day) rollup feeder for the admin dashboard model-stats
 // widget. Mirrors dashboard_aggregation_repo_tk_user_platform.go.
+//
+// modelDailyBackfillMarkerDate/modelDailyBackfillMarkerModel identify the
+// sentinel row that records "the one-time full-history model rollup rebuild has
+// run". Read paths ignore the rollup until this marker is present because
+// production may already have partial rows from the forward-only aggregation
+// watermark.
+const modelDailyBackfillMarkerDate = "1970-01-01"
+const modelDailyBackfillMarkerModel = "__tk_model_daily_backfill_marker__"
 
 func (r *dashboardAggregationRepository) deleteModelDailyRange(ctx context.Context, dayStart, dayEnd time.Time) error {
 	_, err := r.sql.ExecContext(ctx,
@@ -89,5 +98,87 @@ func (r *dashboardAggregationRepository) upsertModelDailyAggregates(ctx context.
 			computed_at = EXCLUDED.computed_at
 	`
 	_, err := r.sql.ExecContext(ctx, query, dayStart, dayEnd, tzName)
+	return err
+}
+
+// backfillModelDailyAllOnce rewrites the historical per-(requested-model, day)
+// rollup before the admin Dashboard model-distribution fast path is allowed to
+// use it. The existing aggregation watermark is shared with older rollup tables,
+// so a deployment can otherwise have recent/partial usage_dashboard_model_daily
+// rows while older completed days are permanently missing or stale.
+func (r *dashboardAggregationRepository) backfillModelDailyAllOnce(ctx context.Context) error {
+	var done bool
+	if err := scanSingleRow(ctx, r.sql,
+		"SELECT EXISTS(SELECT 1 FROM usage_dashboard_model_daily WHERE bucket_date = DATE '"+modelDailyBackfillMarkerDate+"' AND model = $1)",
+		[]any{modelDailyBackfillMarkerModel}, &done); err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+	if !hasDashboardHistoricalBackfillBudget(ctx) {
+		log.Printf("[DashboardAggregation] model daily rollup backfill deferred: context deadline too close")
+		return nil
+	}
+	tzName := timezone.Name()
+	if _, err := r.sql.ExecContext(ctx, `
+		INSERT INTO usage_dashboard_model_daily (
+			bucket_date,
+			model,
+			total_requests,
+			input_tokens,
+			output_tokens,
+			cache_creation_tokens,
+			cache_read_tokens,
+			total_cost,
+			actual_cost,
+			account_cost,
+			computed_at
+		)
+		SELECT
+			(ul.created_at AT TIME ZONE $1)::date AS bucket_date,
+			COALESCE(NULLIF(TRIM(ul.requested_model), ''), ul.model) AS model,
+			COUNT(*) AS total_requests,
+			COALESCE(SUM(ul.input_tokens), 0) AS input_tokens,
+			COALESCE(SUM(ul.output_tokens), 0) AS output_tokens,
+			COALESCE(SUM(ul.cache_creation_tokens), 0) AS cache_creation_tokens,
+			COALESCE(SUM(ul.cache_read_tokens), 0) AS cache_read_tokens,
+			COALESCE(SUM(ul.total_cost), 0) AS total_cost,
+			COALESCE(SUM(ul.actual_cost), 0) AS actual_cost,
+			COALESCE(SUM(COALESCE(ul.account_stats_cost, ul.total_cost) * COALESCE(ul.account_rate_multiplier, 1)), 0) AS account_cost,
+			NOW()
+		FROM usage_logs ul
+		GROUP BY 1, COALESCE(NULLIF(TRIM(ul.requested_model), ''), ul.model)
+		ON CONFLICT (bucket_date, model)
+		DO UPDATE SET
+			total_requests = EXCLUDED.total_requests,
+			input_tokens = EXCLUDED.input_tokens,
+			output_tokens = EXCLUDED.output_tokens,
+			cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+			cache_read_tokens = EXCLUDED.cache_read_tokens,
+			total_cost = EXCLUDED.total_cost,
+			actual_cost = EXCLUDED.actual_cost,
+			account_cost = EXCLUDED.account_cost,
+			computed_at = EXCLUDED.computed_at
+	`, tzName); err != nil {
+		return err
+	}
+	_, err := r.sql.ExecContext(ctx, `
+		INSERT INTO usage_dashboard_model_daily (
+			bucket_date,
+			model,
+			total_requests,
+			input_tokens,
+			output_tokens,
+			cache_creation_tokens,
+			cache_read_tokens,
+			total_cost,
+			actual_cost,
+			account_cost,
+			computed_at
+		)
+		VALUES (DATE '`+modelDailyBackfillMarkerDate+`', $1, 0, 0, 0, 0, 0, 0, 0, 0, NOW())
+		ON CONFLICT (bucket_date, model) DO NOTHING
+	`, modelDailyBackfillMarkerModel)
 	return err
 }

--- a/backend/internal/repository/migrations_schema_integration_test.go
+++ b/backend/internal/repository/migrations_schema_integration_test.go
@@ -49,6 +49,14 @@ func TestMigrationsRunner_IsIdempotent_AndSchemaIsUpToDate(t *testing.T) {
 	requireColumn(t, tx, "usage_logs", "image_output_size", "character varying", 32, true)
 	requireColumn(t, tx, "usage_logs", "image_size_source", "character varying", 16, true)
 	requireColumn(t, tx, "usage_logs", "image_size_breakdown", "jsonb", 0, true)
+	requireColumn(t, tx, "usage_dashboard_group_daily", "total_requests", "bigint", 0, false)
+	requireColumn(t, tx, "usage_dashboard_group_daily", "input_tokens", "bigint", 0, false)
+	requireColumn(t, tx, "usage_dashboard_group_daily", "output_tokens", "bigint", 0, false)
+	requireColumn(t, tx, "usage_dashboard_group_daily", "cache_creation_tokens", "bigint", 0, false)
+	requireColumn(t, tx, "usage_dashboard_group_daily", "cache_read_tokens", "bigint", 0, false)
+	requireColumn(t, tx, "usage_dashboard_group_daily", "total_cost", "numeric", 0, false)
+	requireColumn(t, tx, "usage_dashboard_group_daily", "actual_cost", "numeric", 0, false)
+	requireColumn(t, tx, "usage_dashboard_group_daily", "account_cost", "numeric", 0, false)
 	requireConstraintDefinitionContains(
 		t,
 		tx,

--- a/backend/internal/repository/usage_log_repo.go
+++ b/backend/internal/repository/usage_log_repo.go
@@ -3077,8 +3077,10 @@ func (r *usageLogRepository) GetModelStatsWithFiltersBySource(ctx context.Contex
 
 func (r *usageLogRepository) getModelStatsWithFiltersBySource(ctx context.Context, startTime, endTime time.Time, userID, apiKeyID, accountID, groupID int64, requestType *int16, stream *bool, billingType *int8, source string) (results []ModelStat, err error) {
 	if shouldUseModelDailyRollup(userID, apiKeyID, accountID, groupID, requestType, stream, billingType, source) {
-		aggregated, aggregatedErr := r.getModelStatsFromRollup(ctx, startTime, endTime)
-		if aggregatedErr == nil && len(aggregated) > 0 {
+		aggregated, ok, aggregatedErr := r.getModelStatsFromRollup(ctx, startTime, endTime)
+		if aggregatedErr != nil {
+			logger.LegacyPrintf("repository.usage_log", "getModelStatsFromRollup failed, falling back to usage_logs: %v", aggregatedErr)
+		} else if ok {
 			return aggregated, nil
 		}
 	}
@@ -3152,6 +3154,14 @@ func (r *usageLogRepository) getModelStatsWithFiltersBySource(ctx context.Contex
 
 // GetGroupStatsWithFilters returns group usage statistics with optional filters
 func (r *usageLogRepository) GetGroupStatsWithFilters(ctx context.Context, startTime, endTime time.Time, userID, apiKeyID, accountID, groupID int64, requestType *int16, stream *bool, billingType *int8) (results []usagestats.GroupStat, err error) {
+	if shouldUseGroupDailyStatsRollup(userID, apiKeyID, accountID, requestType, stream, billingType) {
+		if fast, ok, err := r.getGroupStatsFromRollup(ctx, startTime, endTime, groupID); err != nil {
+			logger.LegacyPrintf("repository.usage_log", "getGroupStatsFromRollup failed, falling back to usage_logs: %v", err)
+		} else if ok {
+			return fast, nil
+		}
+	}
+
 	query := `
 		SELECT
 			COALESCE(ul.group_id, 0) as group_id,
@@ -3487,6 +3497,22 @@ func (r *usageLogRepository) GetStatsWithFilters(ctx context.Context, filters Us
 
 	// 汇总查询:失败即致命。
 	runSummary := func(c context.Context) error {
+		if filters.SkipSummary {
+			return nil
+		}
+		if fast, ok, err := r.getStatsWithFiltersFromHourlyRollup(c, filters, start, end); err != nil {
+			logger.LegacyPrintf("repository.usage_log", "getStatsWithFiltersFromHourlyRollup failed, falling back to usage_logs: %v", err)
+		} else if ok {
+			stats.TotalRequests = fast.TotalRequests
+			stats.TotalInputTokens = fast.TotalInputTokens
+			stats.TotalOutputTokens = fast.TotalOutputTokens
+			stats.TotalCacheTokens = fast.TotalCacheTokens
+			stats.TotalCost = fast.TotalCost
+			stats.TotalActualCost = fast.TotalActualCost
+			totalAccountCost = fast.totalAccountCost
+			stats.AverageDurationMs = fast.AverageDurationMs
+			return nil
+		}
 		return scanSingleRow(
 			c, r.sql, query, args,
 			&stats.TotalRequests,
@@ -3501,6 +3527,10 @@ func (r *usageLogRepository) GetStatsWithFilters(ctx context.Context, filters Us
 	}
 	// endpoint 明细:best-effort(失败 log + 返空),不致命。
 	runEndpoints := func(c context.Context) {
+		if filters.SkipEndpointStats {
+			endpoints = []EndpointStat{}
+			return
+		}
 		res, err := r.GetEndpointStatsWithFilters(c, start, end, filters.UserID, filters.APIKeyID, filters.AccountID, filters.GroupID, filters.Model, filters.RequestType, filters.Stream, filters.BillingType)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
@@ -3511,6 +3541,10 @@ func (r *usageLogRepository) GetStatsWithFilters(ctx context.Context, filters Us
 		endpoints = res
 	}
 	runUpstream := func(c context.Context) {
+		if filters.SkipEndpointStats {
+			upstreamEndpoints = []EndpointStat{}
+			return
+		}
 		res, err := r.GetUpstreamEndpointStatsWithFilters(c, start, end, filters.UserID, filters.APIKeyID, filters.AccountID, filters.GroupID, filters.Model, filters.RequestType, filters.Stream, filters.BillingType)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
@@ -3521,6 +3555,10 @@ func (r *usageLogRepository) GetStatsWithFilters(ctx context.Context, filters Us
 		upstreamEndpoints = res
 	}
 	runPaths := func(c context.Context) {
+		if filters.SkipEndpointStats {
+			endpointPaths = []EndpointStat{}
+			return
+		}
 		res, err := r.getEndpointPathStatsWithFilters(c, start, end, filters.UserID, filters.APIKeyID, filters.AccountID, filters.GroupID, filters.Model, filters.RequestType, filters.Stream, filters.BillingType)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -453,6 +453,100 @@ func TestUsageLogRepositoryGetModelStatsAccountCostColumn(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestUsageLogRepositoryGetModelStatsRollupRawTailGroupsByExpression(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
+
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db}
+
+	today := timezone.Today()
+	start := today.Add(-2 * 24 * time.Hour)
+	end := today.Add(2 * time.Hour)
+
+	mock.ExpectQuery("SELECT EXISTS\\(SELECT 1 FROM usage_dashboard_model_daily").
+		WithArgs(modelDailyBackfillMarkerModel).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	mock.ExpectQuery("SELECT to_char\\(MIN\\(bucket_date\\), 'YYYY-MM-DD'\\) FROM usage_dashboard_model_daily").
+		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(start.Format("2006-01-02")))
+
+	mock.ExpectQuery("FROM usage_dashboard_model_daily").
+		WithArgs(start, today).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"model", "requests", "input_tokens", "output_tokens",
+			"cache_creation_tokens", "cache_read_tokens", "total_tokens",
+			"cost", "actual_cost", "account_cost",
+		}).AddRow("claude-sonnet-4-6", int64(20), int64(200), int64(400), int64(10), int64(5), int64(615), 4.0, 3.2, 2.8))
+
+	mock.ExpectQuery("FROM usage_logs\\s+WHERE created_at >= \\$1 AND created_at < \\$2\\s+GROUP BY 1").
+		WithArgs(today, end).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"model", "requests", "input_tokens", "output_tokens",
+			"cache_creation_tokens", "cache_read_tokens", "total_tokens",
+			"cost", "actual_cost", "account_cost",
+		}).
+			AddRow("claude-sonnet-4-6", int64(3), int64(30), int64(40), int64(2), int64(1), int64(73), 0.7, 0.6, 0.5).
+			AddRow("claude-opus-4-6", int64(1), int64(10), int64(20), int64(0), int64(0), int64(30), 0.4, 0.3, 0.2))
+
+	results, err := repo.GetModelStatsWithFilters(context.Background(), start, end, 0, 0, 0, 0, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	require.Equal(t, "claude-sonnet-4-6", results[0].Model)
+	require.Equal(t, int64(23), results[0].Requests)
+	require.Equal(t, int64(688), results[0].TotalTokens)
+	require.InDelta(t, 4.7, results[0].Cost, 1e-9)
+	require.InDelta(t, 3.8, results[0].ActualCost, 1e-9)
+	require.InDelta(t, 3.3, results[0].AccountCost, 1e-9)
+	require.Equal(t, "claude-opus-4-6", results[1].Model)
+	require.Equal(t, int64(30), results[1].TotalTokens)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUsageLogRepositoryGetModelStatsRollupReturnsEmptyWithoutRawFallback(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
+
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db}
+
+	start := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+
+	mock.ExpectQuery("SELECT EXISTS\\(SELECT 1 FROM usage_dashboard_model_daily").
+		WithArgs(modelDailyBackfillMarkerModel).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	mock.ExpectQuery("SELECT to_char\\(MIN\\(bucket_date\\), 'YYYY-MM-DD'\\) FROM usage_dashboard_model_daily").
+		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow("2025-01-01"))
+
+	mock.ExpectQuery("FROM usage_dashboard_model_daily").
+		WithArgs(start, end).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"model", "requests", "input_tokens", "output_tokens",
+			"cache_creation_tokens", "cache_read_tokens", "total_tokens",
+			"cost", "actual_cost", "account_cost",
+		}))
+
+	results, err := repo.GetModelStatsWithFilters(context.Background(), start, end, 0, 0, 0, 0, nil, nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, results)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDashboardAggregationModelBackfillDefersWhenDeadlineTooShort(t *testing.T) {
+	db, mock := newSQLMock(t)
+	repo := newDashboardAggregationRepositoryWithSQL(db)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute))
+	defer cancel()
+
+	mock.ExpectQuery("SELECT EXISTS\\(SELECT 1 FROM usage_dashboard_model_daily").
+		WithArgs(modelDailyBackfillMarkerModel).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	require.NoError(t, repo.backfillModelDailyAllOnce(ctx))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestUsageLogRepositoryGetGroupStatsAccountCostColumn(t *testing.T) {
 	db, mock := newSQLMock(t)
 	repo := &usageLogRepository{sql: db}
@@ -482,6 +576,86 @@ func TestUsageLogRepositoryGetGroupStatsAccountCostColumn(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestUsageLogRepositoryGetGroupStatsRollupFallbackUntilMetricsBackfill(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
+
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db, db: db}
+
+	start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+
+	mock.ExpectQuery("SELECT EXISTS\\(SELECT 1 FROM usage_dashboard_group_daily WHERE group_id = 0 AND bucket_date = DATE '1970-01-02'\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	mock.ExpectQuery("FROM usage_logs").
+		WithArgs(start, end).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"group_id", "group_name", "requests", "total_tokens",
+			"cost", "actual_cost", "account_cost",
+		}).AddRow(int64(1), "azure-cc", int64(100), int64(5000), 10.0, 8.5, 7.2))
+
+	results, err := repo.GetGroupStatsWithFilters(context.Background(), start, end, 0, 0, 0, 0, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, int64(5000), results[0].TotalTokens)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUsageLogRepositoryGetGroupStatsRollupMergesCompletedDaysAndRawTail(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
+
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db, db: db}
+
+	today := timezone.Today()
+	start := today.Add(-2 * 24 * time.Hour)
+	end := today.Add(2 * time.Hour)
+
+	mock.ExpectQuery("SELECT EXISTS\\(SELECT 1 FROM usage_dashboard_group_daily WHERE group_id = 0 AND bucket_date = DATE '1970-01-02'\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery("SELECT to_char\\(MIN\\(bucket_date\\), 'YYYY-MM-DD'\\) FROM usage_dashboard_group_daily WHERE bucket_date > DATE '1970-01-02'").
+		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(start.Format("2006-01-02")))
+
+	mock.ExpectQuery("FROM usage_dashboard_group_daily gd").
+		WithArgs(start, today).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"group_id", "group_name", "requests", "input_tokens", "output_tokens",
+			"cache_creation_tokens", "cache_read_tokens", "cost", "actual_cost", "account_cost",
+		}).
+			AddRow(int64(1), "azure-cc", int64(10), int64(100), int64(200), int64(5), int64(3), 2.0, 1.5, 1.2).
+			AddRow(int64(0), "", int64(4), int64(8), int64(12), int64(1), int64(1), 0.3, 0.2, 0.2).
+			AddRow(int64(2), "max", int64(2), int64(20), int64(30), int64(0), int64(0), 0.5, 0.4, 0.3))
+
+	mock.ExpectQuery("FROM usage_logs ul").
+		WithArgs(today, end).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"group_id", "group_name", "requests", "input_tokens", "output_tokens",
+			"cache_creation_tokens", "cache_read_tokens", "cost", "actual_cost", "account_cost",
+		}).
+			AddRow(int64(1), "azure-cc", int64(3), int64(30), int64(40), int64(2), int64(1), 0.7, 0.6, 0.5).
+			AddRow(int64(3), "other", int64(1), int64(5), int64(7), int64(0), int64(0), 0.2, 0.1, 0.1))
+
+	results, err := repo.GetGroupStatsWithFilters(context.Background(), start, end, 0, 0, 0, 0, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 4)
+	require.Equal(t, int64(1), results[0].GroupID)
+	require.Equal(t, "azure-cc", results[0].GroupName)
+	require.Equal(t, int64(13), results[0].Requests)
+	require.Equal(t, int64(381), results[0].TotalTokens)
+	require.InDelta(t, 2.7, results[0].Cost, 1e-9)
+	require.InDelta(t, 2.1, results[0].ActualCost, 1e-9)
+	require.InDelta(t, 1.7, results[0].AccountCost, 1e-9)
+	require.Equal(t, int64(2), results[1].GroupID)
+	require.Equal(t, int64(50), results[1].TotalTokens)
+	require.Equal(t, int64(0), results[2].GroupID)
+	require.Equal(t, "", results[2].GroupName)
+	require.Equal(t, int64(22), results[2].TotalTokens)
+	require.Equal(t, int64(3), results[3].GroupID)
+	require.Equal(t, int64(12), results[3].TotalTokens)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestUsageLogRepositoryGetStatsWithFiltersAlwaysReturnsAccountCost(t *testing.T) {
 	db, mock := newSQLMock(t)
 	repo := &usageLogRepository{sql: db}
@@ -506,6 +680,178 @@ func TestUsageLogRepositoryGetStatsWithFiltersAlwaysReturnsAccountCost(t *testin
 	require.NoError(t, err)
 	require.NotNil(t, stats.TotalAccountCost, "TotalAccountCost must always be returned, even without AccountID filter")
 	require.Equal(t, 11.0, *stats.TotalAccountCost)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUsageLogRepositoryGetStatsWithFiltersCanSkipEndpointStats(t *testing.T) {
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db}
+
+	filters := usagestats.UsageLogFilters{SkipEndpointStats: true}
+
+	mock.ExpectQuery("FROM usage_logs").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total_requests", "total_input_tokens", "total_output_tokens",
+			"total_cache_tokens", "total_cost", "total_actual_cost",
+			"total_account_cost", "avg_duration_ms",
+		}).AddRow(int64(50), int64(1000), int64(2000), int64(100), 15.0, 12.5, 11.0, 100.0))
+
+	stats, err := repo.GetStatsWithFilters(context.Background(), filters)
+	require.NoError(t, err)
+	require.Equal(t, int64(50), stats.TotalRequests)
+	require.Empty(t, stats.Endpoints)
+	require.Empty(t, stats.UpstreamEndpoints)
+	require.Empty(t, stats.EndpointPaths)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUsageLogRepositoryGetStatsWithFiltersCanSkipSummary(t *testing.T) {
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db}
+
+	filters := usagestats.UsageLogFilters{SkipSummary: true}
+
+	mock.ExpectQuery("SELECT COALESCE\\(NULLIF\\(TRIM\\(inbound_endpoint\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"endpoint", "requests", "total_tokens", "cost", "actual_cost"}).
+			AddRow("/v1/messages", int64(2), int64(30), 0.2, 0.1))
+	mock.ExpectQuery("SELECT COALESCE\\(NULLIF\\(TRIM\\(upstream_endpoint\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"endpoint", "requests", "total_tokens", "cost", "actual_cost"}))
+	mock.ExpectQuery("SELECT CONCAT\\(").
+		WillReturnRows(sqlmock.NewRows([]string{"endpoint", "requests", "total_tokens", "cost", "actual_cost"}))
+
+	stats, err := repo.GetStatsWithFilters(context.Background(), filters)
+	require.NoError(t, err)
+	require.Zero(t, stats.TotalRequests)
+	require.Len(t, stats.Endpoints, 1)
+	require.Equal(t, "/v1/messages", stats.Endpoints[0].Endpoint)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUsageLogRepositoryGetStatsWithFiltersUsesHourlyRollupForUnfilteredSummary(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
+
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db, db: db}
+
+	start := time.Date(2026, 6, 22, 0, 30, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 23, 8, 15, 0, 0, time.UTC)
+	filters := usagestats.UsageLogFilters{StartTime: &start, EndTime: &end, SkipEndpointStats: true}
+
+	mock.ExpectQuery("SELECT MIN\\(bucket_start\\) FROM usage_dashboard_hourly").
+		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)))
+	mock.ExpectQuery("SELECT last_aggregated_at FROM usage_dashboard_aggregation_watermark").
+		WillReturnRows(sqlmock.NewRows([]string{"last_aggregated_at"}).AddRow(time.Date(2026, 6, 23, 8, 5, 0, 0, time.UTC)))
+
+	mock.ExpectQuery("FROM usage_dashboard_hourly").
+		WithArgs(time.Date(2026, 6, 22, 1, 0, 0, 0, time.UTC), time.Date(2026, 6, 23, 8, 0, 0, 0, time.UTC)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total_requests", "total_input_tokens", "total_output_tokens", "total_cache_tokens",
+			"total_cost", "total_actual_cost", "total_account_cost", "total_duration_ms",
+		}).AddRow(int64(100), int64(1000), int64(2000), int64(300), 10.0, 8.0, 7.0, int64(50000)))
+
+	mock.ExpectQuery("FROM usage_logs\\s+WHERE created_at >= \\$1 AND created_at < \\$2").
+		WithArgs(start, time.Date(2026, 6, 22, 1, 0, 0, 0, time.UTC)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total_requests", "total_input_tokens", "total_output_tokens", "total_cache_tokens",
+			"total_cost", "total_actual_cost", "total_account_cost", "total_duration_ms",
+		}).AddRow(int64(2), int64(10), int64(20), int64(3), 0.2, 0.15, 0.1, int64(1000)))
+
+	mock.ExpectQuery("FROM usage_logs\\s+WHERE created_at >= \\$1 AND created_at < \\$2").
+		WithArgs(time.Date(2026, 6, 23, 8, 0, 0, 0, time.UTC), end).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total_requests", "total_input_tokens", "total_output_tokens", "total_cache_tokens",
+			"total_cost", "total_actual_cost", "total_account_cost", "total_duration_ms",
+		}).AddRow(int64(3), int64(30), int64(40), int64(7), 0.3, 0.25, 0.2, int64(1500)))
+
+	stats, err := repo.GetStatsWithFilters(context.Background(), filters)
+	require.NoError(t, err)
+	require.Equal(t, int64(105), stats.TotalRequests)
+	require.Equal(t, int64(1040), stats.TotalInputTokens)
+	require.Equal(t, int64(2060), stats.TotalOutputTokens)
+	require.Equal(t, int64(310), stats.TotalCacheTokens)
+	require.InDelta(t, 10.5, stats.TotalCost, 1e-9)
+	require.InDelta(t, 8.4, stats.TotalActualCost, 1e-9)
+	require.NotNil(t, stats.TotalAccountCost)
+	require.InDelta(t, 7.3, *stats.TotalAccountCost, 1e-9)
+	require.InDelta(t, float64(52500)/105, stats.AverageDurationMs, 1e-9)
+	require.Empty(t, stats.Endpoints)
+	require.Empty(t, stats.UpstreamEndpoints)
+	require.Empty(t, stats.EndpointPaths)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUsageLogRepositoryGetStatsWithFiltersHourlyRollupFloorKeepsPreFloorRaw(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
+
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db, db: db}
+
+	start := time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 22, 6, 30, 0, 0, time.UTC)
+	filters := usagestats.UsageLogFilters{StartTime: &start, EndTime: &end, SkipEndpointStats: true}
+
+	mock.ExpectQuery("SELECT MIN\\(bucket_start\\) FROM usage_dashboard_hourly").
+		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(time.Date(2026, 6, 22, 3, 0, 0, 0, time.UTC)))
+	mock.ExpectQuery("SELECT last_aggregated_at FROM usage_dashboard_aggregation_watermark").
+		WillReturnRows(sqlmock.NewRows([]string{"last_aggregated_at"}).AddRow(time.Date(2026, 6, 22, 6, 5, 0, 0, time.UTC)))
+
+	mock.ExpectQuery("FROM usage_dashboard_hourly").
+		WithArgs(time.Date(2026, 6, 22, 3, 0, 0, 0, time.UTC), time.Date(2026, 6, 22, 6, 0, 0, 0, time.UTC)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total_requests", "total_input_tokens", "total_output_tokens", "total_cache_tokens",
+			"total_cost", "total_actual_cost", "total_account_cost", "total_duration_ms",
+		}).AddRow(int64(30), int64(300), int64(400), int64(50), 3.0, 2.0, 1.5, int64(15000)))
+
+	mock.ExpectQuery("FROM usage_logs\\s+WHERE created_at >= \\$1 AND created_at < \\$2").
+		WithArgs(start, time.Date(2026, 6, 22, 3, 0, 0, 0, time.UTC)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total_requests", "total_input_tokens", "total_output_tokens", "total_cache_tokens",
+			"total_cost", "total_actual_cost", "total_account_cost", "total_duration_ms",
+		}).AddRow(int64(7), int64(70), int64(80), int64(9), 0.7, 0.6, 0.5, int64(3500)))
+
+	mock.ExpectQuery("FROM usage_logs\\s+WHERE created_at >= \\$1 AND created_at < \\$2").
+		WithArgs(time.Date(2026, 6, 22, 6, 0, 0, 0, time.UTC), end).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total_requests", "total_input_tokens", "total_output_tokens", "total_cache_tokens",
+			"total_cost", "total_actual_cost", "total_account_cost", "total_duration_ms",
+		}).AddRow(int64(2), int64(20), int64(30), int64(4), 0.2, 0.1, 0.05, int64(1000)))
+
+	stats, err := repo.GetStatsWithFilters(context.Background(), filters)
+	require.NoError(t, err)
+	require.Equal(t, int64(39), stats.TotalRequests)
+	require.Equal(t, int64(390), stats.TotalInputTokens)
+	require.Equal(t, int64(510), stats.TotalOutputTokens)
+	require.Equal(t, int64(63), stats.TotalCacheTokens)
+	require.InDelta(t, 3.9, stats.TotalCost, 1e-9)
+	require.InDelta(t, 2.7, stats.TotalActualCost, 1e-9)
+	require.NotNil(t, stats.TotalAccountCost)
+	require.InDelta(t, 2.05, *stats.TotalAccountCost, 1e-9)
+	require.InDelta(t, float64(19500)/39, stats.AverageDurationMs, 1e-9)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUsageLogRepositoryGetStatsWithFiltersFilteredSummaryFallsBackToRaw(t *testing.T) {
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db, db: db}
+
+	start := time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC)
+	filters := usagestats.UsageLogFilters{UserID: 42, StartTime: &start, EndTime: &end, SkipEndpointStats: true}
+
+	mock.ExpectQuery("FROM usage_logs").
+		WithArgs(int64(42), start, end).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total_requests", "total_input_tokens", "total_output_tokens",
+			"total_cache_tokens", "total_cost", "total_actual_cost",
+			"total_account_cost", "avg_duration_ms",
+		}).AddRow(int64(4), int64(40), int64(50), int64(6), 0.4, 0.3, 0.2, 123.0))
+
+	stats, err := repo.GetStatsWithFilters(context.Background(), filters)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), stats.TotalRequests)
+	require.Equal(t, int64(96), stats.TotalTokens)
+	require.NotNil(t, stats.TotalAccountCost)
+	require.InDelta(t, 0.2, *stats.TotalAccountCost, 1e-9)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -588,7 +934,7 @@ func TestUsageLogRepositoryGetUserUsageTrendRollupSelectsTopUsersByTokens(t *tes
 			AddRow(int64(2), 2.0, int64(9), int64(900)))
 
 	mock.ExpectQuery("FROM usage_dashboard_user_platform_daily").
-		WillReturnRows(sqlmock.NewRows([]string{"date", "user_id", "total_cost", "actual_cost", "requests", "tokens"}).
+		WillReturnRows(sqlmock.NewRows([]string{"date", "user_id", "cost", "actual_cost", "requests", "tokens"}).
 			AddRow("2025-01-01", int64(1), 1.0, 1.0, int64(10), int64(1000)).
 			AddRow("2025-01-01", int64(2), 2.0, 2.0, int64(9), int64(900)))
 

--- a/backend/internal/repository/usage_log_repo_tk_group_rollup.go
+++ b/backend/internal/repository/usage_log_repo_tk_group_rollup.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"context"
+	"database/sql"
+	"sort"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
@@ -88,4 +90,216 @@ func (r *usageLogRepository) groupUsageSummaryFromRollup(ctx context.Context, to
 		return nil, false, err
 	}
 	return results, true, nil
+}
+
+type groupStatAgg struct {
+	groupName           string
+	requests            int64
+	inputTokens         int64
+	outputTokens        int64
+	cacheCreationTokens int64
+	cacheReadTokens     int64
+	cost                float64
+	actualCost          float64
+	accountCost         float64
+}
+
+func shouldUseGroupDailyStatsRollup(userID, apiKeyID, accountID int64, requestType *int16, stream *bool, billingType *int8) bool {
+	return userID == 0 &&
+		apiKeyID == 0 &&
+		accountID == 0 &&
+		requestType == nil &&
+		stream == nil &&
+		billingType == nil
+}
+
+func (r *usageLogRepository) groupDailyMetricsBackfilled(ctx context.Context) (bool, error) {
+	var done bool
+	if err := scanSingleRow(ctx, r.sql,
+		"SELECT EXISTS(SELECT 1 FROM usage_dashboard_group_daily WHERE group_id = 0 AND bucket_date = DATE '"+groupDailyMetricsBackfillMarkerDate+"')",
+		nil, &done); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+	return done, nil
+}
+
+func (r *usageLogRepository) getGroupStatsFromRollup(
+	ctx context.Context,
+	startTime,
+	endTime time.Time,
+	groupID int64,
+) ([]usagestats.GroupStat, bool, error) {
+	if r.db == nil || !endTime.After(startTime) {
+		return nil, false, nil
+	}
+	metricsReady, err := r.groupDailyMetricsBackfilled(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	if !metricsReady {
+		return nil, false, nil
+	}
+
+	floorDay, hasRollupData, err := r.groupDailyRollupFloorDay(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	win := planUsageRollupWindow(startTime, endTime, floorDay, hasRollupData)
+	byGroupID := make(map[int64]*groupStatAgg)
+
+	addRow := func(groupID int64, groupName string, reqs, inTok, outTok, cacheCreate, cacheRead int64, cost, actualCost, accountCost float64) {
+		a, ok := byGroupID[groupID]
+		if !ok {
+			a = &groupStatAgg{}
+			byGroupID[groupID] = a
+		}
+		if groupName != "" {
+			a.groupName = groupName
+		}
+		a.requests += reqs
+		a.inputTokens += inTok
+		a.outputTokens += outTok
+		a.cacheCreationTokens += cacheCreate
+		a.cacheReadTokens += cacheRead
+		a.cost += cost
+		a.actualCost += actualCost
+		a.accountCost += accountCost
+	}
+
+	if win.hasRollup {
+		query := `
+			SELECT
+				gd.group_id,
+				COALESCE(g.name, '') AS group_name,
+				COALESCE(SUM(gd.total_requests), 0),
+				COALESCE(SUM(gd.input_tokens), 0),
+				COALESCE(SUM(gd.output_tokens), 0),
+				COALESCE(SUM(gd.cache_creation_tokens), 0),
+				COALESCE(SUM(gd.cache_read_tokens), 0),
+				COALESCE(SUM(gd.total_cost), 0),
+				COALESCE(SUM(gd.actual_cost), 0),
+				COALESCE(SUM(gd.account_cost), 0)
+			FROM usage_dashboard_group_daily gd
+			LEFT JOIN groups g ON g.id = gd.group_id
+			WHERE gd.bucket_date > DATE '` + groupDailyMetricsBackfillMarkerDate + `'
+			  AND gd.bucket_date >= $1::date AND gd.bucket_date < $2::date
+		`
+		args := []any{win.rollupStartDay, win.rollupEndDay}
+		if groupID > 0 {
+			query += " AND gd.group_id = $3"
+			args = append(args, groupID)
+		}
+		query += " GROUP BY gd.group_id, g.name"
+
+		rows, err := r.sql.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, false, err
+		}
+		for rows.Next() {
+			var id int64
+			var name string
+			var reqs, inTok, outTok, cacheCreate, cacheRead int64
+			var cost, actualCost, accountCost float64
+			if err := rows.Scan(&id, &name, &reqs, &inTok, &outTok, &cacheCreate, &cacheRead, &cost, &actualCost, &accountCost); err != nil {
+				_ = rows.Close()
+				return nil, false, err
+			}
+			addRow(id, name, reqs, inTok, outTok, cacheCreate, cacheRead, cost, actualCost, accountCost)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, false, err
+		}
+		if err := rows.Err(); err != nil {
+			return nil, false, err
+		}
+	}
+
+	for _, span := range win.rawSpans {
+		from, to := span[0], span[1]
+		query := `
+			SELECT
+				COALESCE(ul.group_id, 0) AS group_id,
+				COALESCE(g.name, '') AS group_name,
+				COUNT(*) AS requests,
+				COALESCE(SUM(ul.input_tokens), 0),
+				COALESCE(SUM(ul.output_tokens), 0),
+				COALESCE(SUM(ul.cache_creation_tokens), 0),
+				COALESCE(SUM(ul.cache_read_tokens), 0),
+				COALESCE(SUM(ul.total_cost), 0),
+				COALESCE(SUM(ul.actual_cost), 0),
+				COALESCE(SUM(COALESCE(ul.account_stats_cost, ul.total_cost) * COALESCE(ul.account_rate_multiplier, 1)), 0)
+			FROM usage_logs ul
+			LEFT JOIN groups g ON g.id = ul.group_id
+			WHERE ul.created_at >= $1 AND ul.created_at < $2
+		`
+		args := []any{from, to}
+		if groupID > 0 {
+			query += " AND ul.group_id = $3"
+			args = append(args, groupID)
+		}
+		query += " GROUP BY ul.group_id, g.name"
+
+		rows, err := r.sql.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, false, err
+		}
+		for rows.Next() {
+			var id int64
+			var name string
+			var reqs, inTok, outTok, cacheCreate, cacheRead int64
+			var cost, actualCost, accountCost float64
+			if err := rows.Scan(&id, &name, &reqs, &inTok, &outTok, &cacheCreate, &cacheRead, &cost, &actualCost, &accountCost); err != nil {
+				_ = rows.Close()
+				return nil, false, err
+			}
+			addRow(id, name, reqs, inTok, outTok, cacheCreate, cacheRead, cost, actualCost, accountCost)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, false, err
+		}
+		if err := rows.Err(); err != nil {
+			return nil, false, err
+		}
+	}
+
+	results := make([]usagestats.GroupStat, 0, len(byGroupID))
+	for id, a := range byGroupID {
+		results = append(results, usagestats.GroupStat{
+			GroupID:     id,
+			GroupName:   a.groupName,
+			Requests:    a.requests,
+			TotalTokens: a.inputTokens + a.outputTokens + a.cacheCreationTokens + a.cacheReadTokens,
+			Cost:        a.cost,
+			ActualCost:  a.actualCost,
+			AccountCost: a.accountCost,
+		})
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].TotalTokens == results[j].TotalTokens {
+			return results[i].GroupID < results[j].GroupID
+		}
+		return results[i].TotalTokens > results[j].TotalTokens
+	})
+	return results, true, nil
+}
+
+func (r *usageLogRepository) groupDailyRollupFloorDay(ctx context.Context) (time.Time, bool, error) {
+	var s sql.NullString
+	if err := scanSingleRow(ctx, r.sql,
+		`SELECT to_char(MIN(bucket_date), 'YYYY-MM-DD') FROM usage_dashboard_group_daily WHERE bucket_date > DATE '`+groupDailyMetricsBackfillMarkerDate+`'`,
+		nil, &s); err != nil {
+		return time.Time{}, false, err
+	}
+	if !s.Valid || s.String == "" {
+		return time.Time{}, false, nil
+	}
+	loc := timezone.Today().Location()
+	day, err := time.ParseInLocation("2006-01-02", s.String, loc)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	return day, true, nil
 }

--- a/backend/internal/repository/usage_log_repo_tk_group_rollup_integration_test.go
+++ b/backend/internal/repository/usage_log_repo_tk_group_rollup_integration_test.go
@@ -18,6 +18,32 @@ func indexByGroup(rows []usagestats.GroupUsageSummary) map[int64]usagestats.Grou
 	return out
 }
 
+func indexGroupStats(rows []usagestats.GroupStat) map[int64]usagestats.GroupStat {
+	out := make(map[int64]usagestats.GroupStat, len(rows))
+	for _, r := range rows {
+		out[r.GroupID] = r
+	}
+	return out
+}
+
+func (s *UsageLogRepoSuite) rollupParityCreateUngroupedLog(user *service.User, apiKey *service.APIKey, account *service.Account, in, out, cacheCreate, cacheRead int, cost float64, createdAt time.Time) {
+	log := &service.UsageLog{
+		UserID:              user.ID,
+		APIKeyID:            apiKey.ID,
+		AccountID:           account.ID,
+		Model:               "claude-3",
+		InputTokens:         in,
+		OutputTokens:        out,
+		CacheCreationTokens: cacheCreate,
+		CacheReadTokens:     cacheRead,
+		TotalCost:           cost,
+		ActualCost:          cost,
+		CreatedAt:           createdAt,
+	}
+	_, err := s.repo.Create(s.ctx, log)
+	s.Require().NoError(err)
+}
+
 // TestGroupRollupParity_EqualsLegacyRawScan is the load-bearing equality test for
 // the per-(group, day) rollup that backs GetAllGroupUsageSummary. It builds a
 // fixture spanning two groups over completed past days + today, then asserts:
@@ -80,4 +106,152 @@ func (s *UsageLogRepoSuite) TestGroupRollupParity_EqualsLegacyRawScan() {
 	s.InDelta(preIdx[grpA.ID].TodayCost, postIdx[grpA.ID].TodayCost, 1e-9)
 	s.InDelta(preIdx[grpB.ID].TotalCost, postIdx[grpB.ID].TotalCost, 1e-9)
 	s.InDelta(preIdx[grpB.ID].TodayCost, postIdx[grpB.ID].TodayCost, 1e-9)
+}
+
+// TestGroupStatsRollupParity_EqualsLegacyRawScanWithUngrouped is the equality
+// test for Dashboard/Usage group distribution. It locks the legacy
+// COALESCE(group_id, 0) bucket for ungrouped usage while proving completed days
+// served from usage_dashboard_group_daily plus raw today equals the legacy raw
+// query.
+func (s *UsageLogRepoSuite) TestGroupStatsRollupParity_EqualsLegacyRawScanWithUngrouped() {
+	now := time.Now()
+	today := timezone.Today()
+	start := today.Add(-6 * 24 * time.Hour)
+	day5 := today.Add(-5 * 24 * time.Hour).Add(9 * time.Hour)
+	day2 := today.Add(-2 * 24 * time.Hour).Add(14 * time.Hour)
+	todayPoint := today.Add(3 * time.Hour)
+	if todayPoint.After(now) {
+		todayPoint = now.Add(-time.Minute)
+	}
+	end := todayPoint.Add(time.Minute)
+
+	user := mustCreateUser(s.T(), s.client, &service.User{Email: "grp-stats-rollup@test.com"})
+	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-grp-stats-rollup", Name: "k"})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "grp-stats-rollup-acc", Platform: service.PlatformAnthropic})
+	grpA := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-stats-rollup-A", Platform: service.PlatformAnthropic})
+	grpB := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-stats-rollup-B", Platform: service.PlatformOpenAI})
+
+	// Real groups across completed days + today's raw tail.
+	s.rollupParityCreateLog(user, key, acc, grpA.ID, 10, 20, 0, 0, 0.50, day5)
+	s.rollupParityCreateLog(user, key, acc, grpA.ID, 5, 7, 1, 2, 0.10, todayPoint)
+	s.rollupParityCreateLog(user, key, acc, grpB.ID, 2, 3, 0, 0, 0.20, day2)
+	// Ungrouped usage must stay visible as group_id=0 in group distribution.
+	s.rollupParityCreateUngroupedLog(user, key, acc, 3, 4, 5, 6, 0.20, day2)
+	s.rollupParityCreateUngroupedLog(user, key, acc, 7, 8, 0, 1, 0.05, todayPoint)
+
+	// Before aggregation the metrics marker is absent, so this is the legacy raw
+	// path. It is the ground-truth reference for the rollup path below.
+	pre, err := s.repo.GetGroupStatsWithFilters(s.ctx, start, end, 0, 0, 0, 0, nil, nil, nil)
+	s.Require().NoError(err)
+	preIdx := indexGroupStats(pre)
+	s.Require().Contains(preIdx, int64(0), "legacy raw path must expose ungrouped usage as group_id=0")
+	s.Equal(int64(2), preIdx[0].Requests)
+	s.Equal(int64(34), preIdx[0].TotalTokens)
+	s.InDelta(0.25, preIdx[0].ActualCost, 1e-9)
+
+	// Populate the group daily rollup and set both backfill markers. The read path
+	// now uses completed days from usage_dashboard_group_daily plus raw today.
+	aggRepo := newDashboardAggregationRepositoryWithSQL(s.tx)
+	s.Require().NoError(aggRepo.AggregateRange(s.ctx, start, today), "AggregateRange")
+
+	post, err := s.repo.GetGroupStatsWithFilters(s.ctx, start, end, 0, 0, 0, 0, nil, nil, nil)
+	s.Require().NoError(err)
+	postIdx := indexGroupStats(post)
+	s.Require().Len(postIdx, len(preIdx))
+	for groupID, want := range preIdx {
+		got, ok := postIdx[groupID]
+		s.Require().True(ok, "rollup path missing group_id=%d", groupID)
+		s.Equal(want.GroupName, got.GroupName, "group_name group_id=%d", groupID)
+		s.Equal(want.Requests, got.Requests, "requests group_id=%d", groupID)
+		s.Equal(want.TotalTokens, got.TotalTokens, "tokens group_id=%d", groupID)
+		s.InDelta(want.Cost, got.Cost, 1e-9, "cost group_id=%d", groupID)
+		s.InDelta(want.ActualCost, got.ActualCost, 1e-9, "actual_cost group_id=%d", groupID)
+		s.InDelta(want.AccountCost, got.AccountCost, 1e-9, "account_cost group_id=%d", groupID)
+	}
+
+	filtered, err := s.repo.GetGroupStatsWithFilters(s.ctx, start, end, 0, 0, 0, grpA.ID, nil, nil, nil)
+	s.Require().NoError(err)
+	s.Require().Len(filtered, 1)
+	s.Equal(grpA.ID, filtered[0].GroupID)
+	s.Equal(preIdx[grpA.ID].Requests, filtered[0].Requests)
+	s.Equal(preIdx[grpA.ID].TotalTokens, filtered[0].TotalTokens)
+	s.InDelta(preIdx[grpA.ID].ActualCost, filtered[0].ActualCost, 1e-9)
+}
+
+// TestGroupStatsRollupWaitsForMetricsBackfill covers the deploy path for
+// databases that already ran tk_038 before tk_046 added the metric columns. The
+// old all-time cost marker may exist while historical metric columns are still
+// zero, so the group-distribution read path must ignore the rollup until the
+// metrics marker is present and backfillGroupDailyMetricsAllOnce has rewritten
+// historical rows.
+func (s *UsageLogRepoSuite) TestGroupStatsRollupWaitsForMetricsBackfill() {
+	today := timezone.Today()
+	start := today.Add(-6 * 24 * time.Hour)
+	day5 := today.Add(-5 * 24 * time.Hour).Add(9 * time.Hour)
+	end := today
+
+	user := mustCreateUser(s.T(), s.client, &service.User{Email: "grp-stats-metrics-backfill@test.com"})
+	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-grp-stats-metrics-backfill", Name: "k"})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "grp-stats-metrics-backfill-acc", Platform: service.PlatformAnthropic})
+	grp := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-stats-metrics-backfill", Platform: service.PlatformAnthropic})
+	s.rollupParityCreateLog(user, key, acc, grp.ID, 11, 13, 2, 3, 0.42, day5)
+
+	// Simulate an old deployment: tk_038's historical cost backfill marker exists
+	// and there is a completed-day row with actual_cost, but tk_046's metric
+	// marker is missing and the new metric columns still have their zero defaults.
+	_, err := s.tx.ExecContext(s.ctx, `
+		INSERT INTO usage_dashboard_group_daily (bucket_date, group_id, actual_cost, computed_at)
+		VALUES
+			($1::date, $2, 0.42, NOW()),
+			(DATE '`+groupDailyBackfillMarkerDate+`', 0, 0, NOW())
+		ON CONFLICT (bucket_date, group_id) DO UPDATE SET
+			actual_cost = EXCLUDED.actual_cost,
+			computed_at = EXCLUDED.computed_at
+	`, day5.Format("2006-01-02"), grp.ID)
+	s.Require().NoError(err)
+
+	metricsReady, err := s.repo.groupDailyMetricsBackfilled(s.ctx)
+	s.Require().NoError(err)
+	s.False(metricsReady, "metric marker is absent, so production fast path must not trust zero-filled metric columns")
+
+	rawBefore, err := s.repo.GetGroupStatsWithFilters(s.ctx, start, end, 0, 0, 0, 0, nil, nil, nil)
+	s.Require().NoError(err)
+	rawIdx := indexGroupStats(rawBefore)
+	s.Equal(int64(29), rawIdx[grp.ID].TotalTokens)
+	s.InDelta(0.42, rawIdx[grp.ID].ActualCost, 1e-9)
+
+	aggRepo := newDashboardAggregationRepositoryWithSQL(s.tx)
+	s.Require().NoError(aggRepo.backfillGroupDailyMetricsAllOnce(s.ctx))
+
+	metricsReady, err = s.repo.groupDailyMetricsBackfilled(s.ctx)
+	s.Require().NoError(err)
+	s.True(metricsReady, "metric marker should enable the production group stats rollup after rewrite")
+
+	var row struct {
+		Requests    int64
+		InputTokens int64
+		OutputToken int64
+		CacheCreate int64
+		CacheRead   int64
+		ActualCost  float64
+	}
+	err = scanSingleRow(s.ctx, s.tx, `
+		SELECT total_requests, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, actual_cost
+		FROM usage_dashboard_group_daily
+		WHERE bucket_date = $1::date AND group_id = $2
+	`, []any{day5.Format("2006-01-02"), grp.ID},
+		&row.Requests,
+		&row.InputTokens,
+		&row.OutputToken,
+		&row.CacheCreate,
+		&row.CacheRead,
+		&row.ActualCost,
+	)
+	s.Require().NoError(err)
+	s.Equal(int64(1), row.Requests)
+	s.Equal(int64(11), row.InputTokens)
+	s.Equal(int64(13), row.OutputToken)
+	s.Equal(int64(2), row.CacheCreate)
+	s.Equal(int64(3), row.CacheRead)
+	s.InDelta(rawIdx[grp.ID].ActualCost, row.ActualCost, 1e-9)
 }

--- a/backend/internal/repository/usage_log_repo_tk_model_rollup.go
+++ b/backend/internal/repository/usage_log_repo_tk_model_rollup.go
@@ -43,7 +43,7 @@ func shouldUseModelDailyRollup(
 
 func (r *usageLogRepository) modelDailyRollupFloorDay(ctx context.Context) (time.Time, bool, error) {
 	rows, err := r.sql.QueryContext(ctx,
-		`SELECT to_char(MIN(bucket_date), 'YYYY-MM-DD') FROM usage_dashboard_model_daily`)
+		`SELECT to_char(MIN(bucket_date), 'YYYY-MM-DD') FROM usage_dashboard_model_daily WHERE bucket_date > DATE '`+modelDailyBackfillMarkerDate+`'`)
 	if err != nil {
 		return time.Time{}, false, err
 	}
@@ -71,13 +71,34 @@ func (r *usageLogRepository) modelDailyRollupFloorDay(ctx context.Context) (time
 	return day, true, nil
 }
 
+func (r *usageLogRepository) modelDailyBackfilled(ctx context.Context) (bool, error) {
+	var done bool
+	if err := scanSingleRow(ctx, r.sql,
+		"SELECT EXISTS(SELECT 1 FROM usage_dashboard_model_daily WHERE bucket_date = DATE '"+modelDailyBackfillMarkerDate+"' AND model = $1)",
+		[]any{modelDailyBackfillMarkerModel}, &done); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+	return done, nil
+}
+
 func (r *usageLogRepository) getModelStatsFromRollup(
 	ctx context.Context,
 	startTime, endTime time.Time,
-) ([]ModelStat, error) {
+) ([]ModelStat, bool, error) {
+	ready, err := r.modelDailyBackfilled(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ready {
+		return nil, false, nil
+	}
+
 	floorDay, hasRollupData, err := r.modelDailyRollupFloorDay(ctx)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	win := planUsageRollupWindow(startTime, endTime, floorDay, hasRollupData)
 	byModel := make(map[string]*modelStatAgg)
@@ -113,12 +134,13 @@ func (r *usageLogRepository) getModelStatsFromRollup(
 				COALESCE(SUM(actual_cost), 0),
 				COALESCE(SUM(account_cost), 0)
 			FROM usage_dashboard_model_daily
-			WHERE bucket_date >= $1::date AND bucket_date < $2::date
+			WHERE bucket_date > DATE '` + modelDailyBackfillMarkerDate + `'
+			  AND bucket_date >= $1::date AND bucket_date < $2::date
 			GROUP BY model
 		`
 		rows, err := r.sql.QueryContext(ctx, q, win.rollupStartDay, win.rollupEndDay)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		for rows.Next() {
 			var model string
@@ -126,15 +148,15 @@ func (r *usageLogRepository) getModelStatsFromRollup(
 			var cost, actualCost, accountCost float64
 			if err := rows.Scan(&model, &reqs, &inTok, &outTok, &cacheCreate, &cacheRead, &totalTok, &cost, &actualCost, &accountCost); err != nil {
 				_ = rows.Close()
-				return nil, err
+				return nil, false, err
 			}
 			addRow(model, reqs, inTok, outTok, cacheCreate, cacheRead, totalTok, cost, actualCost, accountCost)
 		}
 		if err := rows.Close(); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if err := rows.Err(); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
@@ -154,11 +176,11 @@ func (r *usageLogRepository) getModelStatsFromRollup(
 				COALESCE(SUM(COALESCE(account_stats_cost, total_cost) * COALESCE(account_rate_multiplier, 1)), 0)
 			FROM usage_logs
 			WHERE created_at >= $1 AND created_at < $2
-			GROUP BY model
+			GROUP BY 1
 		`
 		rows, err := r.sql.QueryContext(ctx, q, from, to)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		for rows.Next() {
 			var model string
@@ -166,15 +188,15 @@ func (r *usageLogRepository) getModelStatsFromRollup(
 			var cost, actualCost, accountCost float64
 			if err := rows.Scan(&model, &reqs, &inTok, &outTok, &cacheCreate, &cacheRead, &totalTok, &cost, &actualCost, &accountCost); err != nil {
 				_ = rows.Close()
-				return nil, err
+				return nil, false, err
 			}
 			addRow(model, reqs, inTok, outTok, cacheCreate, cacheRead, totalTok, cost, actualCost, accountCost)
 		}
 		if err := rows.Close(); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if err := rows.Err(); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
@@ -199,5 +221,5 @@ func (r *usageLogRepository) getModelStatsFromRollup(
 		}
 		return results[i].Model < results[j].Model
 	})
-	return results, nil
+	return results, true, nil
 }

--- a/backend/internal/repository/usage_log_repo_tk_model_rollup_integration_test.go
+++ b/backend/internal/repository/usage_log_repo_tk_model_rollup_integration_test.go
@@ -1,0 +1,131 @@
+//go:build integration
+
+package repository
+
+import (
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+func indexModelStats(rows []ModelStat) map[string]ModelStat {
+	out := make(map[string]ModelStat, len(rows))
+	for _, r := range rows {
+		out[r.Model] = r
+	}
+	return out
+}
+
+func (s *UsageLogRepoSuite) modelRollupParityCreateLog(user *service.User, apiKey *service.APIKey, account *service.Account, requestedModel, storedModel string, in, out, cacheCreate, cacheRead int, cost float64, createdAt time.Time) {
+	log := &service.UsageLog{
+		UserID:              user.ID,
+		APIKeyID:            apiKey.ID,
+		AccountID:           account.ID,
+		Model:               storedModel,
+		RequestedModel:      requestedModel,
+		InputTokens:         in,
+		OutputTokens:        out,
+		CacheCreationTokens: cacheCreate,
+		CacheReadTokens:     cacheRead,
+		TotalCost:           cost,
+		ActualCost:          cost,
+		CreatedAt:           createdAt,
+	}
+	_, err := s.repo.Create(s.ctx, log)
+	s.Require().NoError(err)
+}
+
+// TestModelStatsRollupWaitsForBackfillMarkerAndMatchesRaw locks the prod deploy
+// safety property for usage_dashboard_model_daily: partial/stale rows from the
+// forward-only aggregation watermark must not be trusted until the one-time
+// historical rebuild has set the model backfill marker. Once the marker exists,
+// completed days from the rollup plus today's raw tail must equal the legacy raw
+// model distribution.
+func (s *UsageLogRepoSuite) TestModelStatsRollupWaitsForBackfillMarkerAndMatchesRaw() {
+	now := timezone.Now()
+	today := timezone.Today()
+	start := today.Add(-6 * 24 * time.Hour)
+	day5 := today.Add(-5 * 24 * time.Hour).Add(9 * time.Hour)
+	day2 := today.Add(-2 * 24 * time.Hour).Add(14 * time.Hour)
+	todayPoint := today.Add(3 * time.Hour)
+	if todayPoint.After(now) {
+		todayPoint = now.Add(-time.Minute)
+	}
+	if todayPoint.Before(today) {
+		todayPoint = today.Add(time.Second)
+	}
+	end := todayPoint.Add(time.Minute)
+
+	user := mustCreateUser(s.T(), s.client, &service.User{Email: "model-rollup@test.com"})
+	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-model-rollup", Name: "k"})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "model-rollup-acc", Platform: service.PlatformAnthropic})
+
+	s.modelRollupParityCreateLog(user, key, acc, "claude-sonnet-4-6", "upstream-sonnet", 10, 20, 1, 2, 0.50, day5)
+	s.modelRollupParityCreateLog(user, key, acc, "claude-opus-4-6", "upstream-opus", 2, 3, 0, 1, 0.20, day2)
+	s.modelRollupParityCreateLog(user, key, acc, "claude-sonnet-4-6", "upstream-sonnet", 5, 7, 0, 0, 0.10, todayPoint)
+
+	// Simulate current prod before this fix: the rollup table has data, but there
+	// is no marker proving that historical days were rebuilt from raw usage_logs.
+	_, err := s.tx.ExecContext(s.ctx, `
+		INSERT INTO usage_dashboard_model_daily (
+			bucket_date,
+			model,
+			total_requests,
+			input_tokens,
+			output_tokens,
+			cache_creation_tokens,
+			cache_read_tokens,
+			total_cost,
+			actual_cost,
+			account_cost,
+			computed_at
+		)
+		VALUES ($1::date, $2, 999, 999, 999, 0, 0, 99, 88, 77, NOW())
+		ON CONFLICT (bucket_date, model) DO UPDATE SET
+			total_requests = EXCLUDED.total_requests,
+			input_tokens = EXCLUDED.input_tokens,
+			output_tokens = EXCLUDED.output_tokens,
+			actual_cost = EXCLUDED.actual_cost,
+			computed_at = EXCLUDED.computed_at
+	`, day5.Format("2006-01-02"), "claude-sonnet-4-6")
+	s.Require().NoError(err)
+
+	ready, err := s.repo.modelDailyBackfilled(s.ctx)
+	s.Require().NoError(err)
+	s.False(ready, "model rollup fast path must wait for the full-history backfill marker")
+
+	pre, err := s.repo.GetModelStatsWithFilters(s.ctx, start, end, 0, 0, 0, 0, nil, nil, nil)
+	s.Require().NoError(err)
+	preIdx := indexModelStats(pre)
+	s.Equal(int64(2), preIdx["claude-sonnet-4-6"].Requests)
+	s.Equal(int64(45), preIdx["claude-sonnet-4-6"].TotalTokens)
+	s.InDelta(0.60, preIdx["claude-sonnet-4-6"].ActualCost, 1e-9)
+	s.Equal(int64(1), preIdx["claude-opus-4-6"].Requests)
+	s.Equal(int64(6), preIdx["claude-opus-4-6"].TotalTokens)
+
+	aggRepo := newDashboardAggregationRepositoryWithSQL(s.tx)
+	s.Require().NoError(aggRepo.backfillModelDailyAllOnce(s.ctx))
+
+	ready, err = s.repo.modelDailyBackfilled(s.ctx)
+	s.Require().NoError(err)
+	s.True(ready, "the marker should enable the production model stats rollup after rewrite")
+
+	post, err := s.repo.GetModelStatsWithFilters(s.ctx, start, end, 0, 0, 0, 0, nil, nil, nil)
+	s.Require().NoError(err)
+	postIdx := indexModelStats(post)
+	s.Require().Len(postIdx, len(preIdx))
+	for model, want := range preIdx {
+		got, ok := postIdx[model]
+		s.Require().True(ok, "rollup path missing model=%s", model)
+		s.Equal(want.Requests, got.Requests, "requests model=%s", model)
+		s.Equal(want.InputTokens, got.InputTokens, "input_tokens model=%s", model)
+		s.Equal(want.OutputTokens, got.OutputTokens, "output_tokens model=%s", model)
+		s.Equal(want.CacheCreationTokens, got.CacheCreationTokens, "cache_creation_tokens model=%s", model)
+		s.Equal(want.CacheReadTokens, got.CacheReadTokens, "cache_read_tokens model=%s", model)
+		s.Equal(want.TotalTokens, got.TotalTokens, "total_tokens model=%s", model)
+		s.InDelta(want.Cost, got.Cost, 1e-9, "cost model=%s", model)
+		s.InDelta(want.ActualCost, got.ActualCost, 1e-9, "actual_cost model=%s", model)
+		s.InDelta(want.AccountCost, got.AccountCost, 1e-9, "account_cost model=%s", model)
+	}
+}

--- a/backend/internal/repository/usage_log_repo_tk_stats_rollup.go
+++ b/backend/internal/repository/usage_log_repo_tk_stats_rollup.go
@@ -1,0 +1,208 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
+)
+
+type usageStatsRollupAgg struct {
+	TotalRequests       int64
+	TotalInputTokens    int64
+	TotalOutputTokens   int64
+	TotalCacheTokens    int64
+	TotalCost           float64
+	TotalActualCost     float64
+	totalAccountCost    float64
+	AverageDurationMs   float64
+	totalDurationMillis int64
+}
+
+func shouldUseUsageStatsHourlyRollup(filters usagestats.UsageLogFilters) bool {
+	return filters.UserID == 0 &&
+		filters.APIKeyID == 0 &&
+		filters.AccountID == 0 &&
+		filters.GroupID == 0 &&
+		filters.Model == "" &&
+		filters.RequestType == nil &&
+		filters.Stream == nil &&
+		filters.BillingType == nil &&
+		filters.BillingMode == ""
+}
+
+func floorHourServerTZ(t time.Time) time.Time {
+	loc := timezone.Location()
+	local := t.In(loc)
+	return time.Date(local.Year(), local.Month(), local.Day(), local.Hour(), 0, 0, 0, loc)
+}
+
+func ceilHourServerTZ(t time.Time) time.Time {
+	floor := floorHourServerTZ(t)
+	if floor.Equal(t.In(floor.Location())) {
+		return floor
+	}
+	return floor.Add(time.Hour)
+}
+
+func (r *usageLogRepository) getStatsWithFiltersFromHourlyRollup(
+	ctx context.Context,
+	filters usagestats.UsageLogFilters,
+	start,
+	end time.Time,
+) (*usageStatsRollupAgg, bool, error) {
+	if r.db == nil || !shouldUseUsageStatsHourlyRollup(filters) || !end.After(start) {
+		return nil, false, nil
+	}
+
+	rollupStart := ceilHourServerTZ(start)
+	rollupEnd := floorHourServerTZ(end)
+	if !rollupEnd.After(rollupStart) {
+		return nil, false, nil
+	}
+
+	floor, hasRollupData, err := r.usageStatsHourlyRollupFloor(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	if !hasRollupData {
+		return nil, false, nil
+	}
+	if floor.After(rollupStart) {
+		rollupStart = floor
+	}
+	if !rollupEnd.After(rollupStart) {
+		return nil, false, nil
+	}
+
+	var watermark time.Time
+	if err := scanSingleRow(ctx, r.sql, "SELECT last_aggregated_at FROM usage_dashboard_aggregation_watermark WHERE id = 1", nil, &watermark); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	watermarkHour := floorHourServerTZ(watermark)
+	if watermarkHour.Before(rollupEnd) {
+		rollupEnd = watermarkHour
+	}
+	if !rollupEnd.After(rollupStart) {
+		return nil, false, nil
+	}
+
+	agg := &usageStatsRollupAgg{}
+	if err := r.addUsageStatsHourlyRollup(ctx, agg, rollupStart, rollupEnd); err != nil {
+		return nil, false, err
+	}
+	if rollupStart.After(start) {
+		if err := r.addUsageStatsRawSpan(ctx, agg, start, rollupStart); err != nil {
+			return nil, false, err
+		}
+	}
+	if end.After(rollupEnd) {
+		if err := r.addUsageStatsRawSpan(ctx, agg, rollupEnd, end); err != nil {
+			return nil, false, err
+		}
+	}
+	if agg.TotalRequests > 0 {
+		agg.AverageDurationMs = float64(agg.totalDurationMillis) / float64(agg.TotalRequests)
+	}
+	return agg, true, nil
+}
+
+func (r *usageLogRepository) usageStatsHourlyRollupFloor(ctx context.Context) (time.Time, bool, error) {
+	var floor sql.NullTime
+	if err := scanSingleRow(ctx, r.sql, `SELECT MIN(bucket_start) FROM usage_dashboard_hourly`, nil, &floor); err != nil {
+		return time.Time{}, false, err
+	}
+	if !floor.Valid {
+		return time.Time{}, false, nil
+	}
+	return floorHourServerTZ(floor.Time), true, nil
+}
+
+func (r *usageLogRepository) addUsageStatsHourlyRollup(ctx context.Context, agg *usageStatsRollupAgg, start, end time.Time) error {
+	const q = `
+		SELECT
+			COALESCE(SUM(total_requests), 0),
+			COALESCE(SUM(input_tokens), 0),
+			COALESCE(SUM(output_tokens), 0),
+			COALESCE(SUM(cache_creation_tokens + cache_read_tokens), 0),
+			COALESCE(SUM(total_cost), 0),
+			COALESCE(SUM(actual_cost), 0),
+			COALESCE(SUM(account_cost), 0),
+			COALESCE(SUM(total_duration_ms), 0)
+		FROM usage_dashboard_hourly
+		WHERE bucket_start >= $1 AND bucket_start < $2
+	`
+	var row usageStatsRollupAgg
+	if err := scanSingleRow(
+		ctx,
+		r.sql,
+		q,
+		[]any{start, end},
+		&row.TotalRequests,
+		&row.TotalInputTokens,
+		&row.TotalOutputTokens,
+		&row.TotalCacheTokens,
+		&row.TotalCost,
+		&row.TotalActualCost,
+		&row.totalAccountCost,
+		&row.totalDurationMillis,
+	); err != nil {
+		return err
+	}
+	mergeUsageStatsAgg(agg, &row)
+	return nil
+}
+
+func (r *usageLogRepository) addUsageStatsRawSpan(ctx context.Context, agg *usageStatsRollupAgg, start, end time.Time) error {
+	if !end.After(start) {
+		return nil
+	}
+	const q = `
+		SELECT
+			COUNT(*),
+			COALESCE(SUM(input_tokens), 0),
+			COALESCE(SUM(output_tokens), 0),
+			COALESCE(SUM(cache_creation_tokens + cache_read_tokens), 0),
+			COALESCE(SUM(total_cost), 0),
+			COALESCE(SUM(actual_cost), 0),
+			COALESCE(SUM(COALESCE(account_stats_cost, total_cost) * COALESCE(account_rate_multiplier, 1)), 0),
+			COALESCE(SUM(COALESCE(duration_ms, 0)), 0)
+		FROM usage_logs
+		WHERE created_at >= $1 AND created_at < $2
+	`
+	var row usageStatsRollupAgg
+	if err := scanSingleRow(
+		ctx,
+		r.sql,
+		q,
+		[]any{start, end},
+		&row.TotalRequests,
+		&row.TotalInputTokens,
+		&row.TotalOutputTokens,
+		&row.TotalCacheTokens,
+		&row.TotalCost,
+		&row.TotalActualCost,
+		&row.totalAccountCost,
+		&row.totalDurationMillis,
+	); err != nil {
+		return err
+	}
+	mergeUsageStatsAgg(agg, &row)
+	return nil
+}
+
+func mergeUsageStatsAgg(dst, src *usageStatsRollupAgg) {
+	dst.TotalRequests += src.TotalRequests
+	dst.TotalInputTokens += src.TotalInputTokens
+	dst.TotalOutputTokens += src.TotalOutputTokens
+	dst.TotalCacheTokens += src.TotalCacheTokens
+	dst.TotalCost += src.TotalCost
+	dst.TotalActualCost += src.TotalActualCost
+	dst.totalAccountCost += src.totalAccountCost
+	dst.totalDurationMillis += src.totalDurationMillis
+}

--- a/backend/internal/repository/usage_log_repo_tk_user_platform_rollup.go
+++ b/backend/internal/repository/usage_log_repo_tk_user_platform_rollup.go
@@ -682,7 +682,7 @@ func (r *usageLogRepository) getUserUsageTrendRollup(
 			SELECT
 				TO_CHAR(bucket_date::timestamp, '%s') AS date,
 				user_id,
-				COALESCE(SUM(total_cost), 0),
+				COALESCE(SUM(actual_cost), 0),
 				COALESCE(SUM(actual_cost), 0),
 				COALESCE(SUM(total_requests), 0),
 				COALESCE(SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens), 0)

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 511,
-  "hash": "903017e5923664d2a4ec89d6a71e20b994635e48d4c7e51f12fbc09f996a4f9d",
+  "hash": "b54e49c6463061dcebd5c163e1511fdd2c912e212ae52724f21263b7580ac1b0",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/migrations/tk_038_usage_dashboard_group_daily.sql
+++ b/backend/migrations/tk_038_usage_dashboard_group_daily.sql
@@ -13,9 +13,8 @@
 -- usage_log_repo_tk_group_rollup.go (read) and dashboard_aggregation_repo_tk_group.go
 -- (feeder + one-time backfill).
 --
--- Grain: one row per (group_id, bucket_date). Metric: actual_cost only — that is
--- the single column the usage-summary reads. "platform"/token columns are
--- deliberately omitted (YAGNI); add later if a consumer needs them.
+-- Grain: one row per (group_id, bucket_date). Metrics cover both the Groups page
+-- cost summary and the Dashboard/Usage group distribution chart.
 --
 -- Retention: UNLIKE the windowed usage_dashboard_* rollups, this table is NOT
 -- pruned by CleanupAggregates — the Groups summary is an ALL-TIME cumulative, so
@@ -31,10 +30,17 @@
 -- grain matches the read path exactly.
 
 CREATE TABLE IF NOT EXISTS usage_dashboard_group_daily (
-    bucket_date  DATE NOT NULL,
-    group_id     BIGINT NOT NULL,
-    actual_cost  DECIMAL(20, 10) NOT NULL DEFAULT 0,
-    computed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    bucket_date           DATE NOT NULL,
+    group_id              BIGINT NOT NULL,
+    total_requests        BIGINT NOT NULL DEFAULT 0,
+    input_tokens          BIGINT NOT NULL DEFAULT 0,
+    output_tokens         BIGINT NOT NULL DEFAULT 0,
+    cache_creation_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_read_tokens     BIGINT NOT NULL DEFAULT 0,
+    total_cost            DECIMAL(20, 10) NOT NULL DEFAULT 0,
+    actual_cost           DECIMAL(20, 10) NOT NULL DEFAULT 0,
+    account_cost          DECIMAL(20, 10) NOT NULL DEFAULT 0,
+    computed_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (bucket_date, group_id)
 );
 

--- a/backend/migrations/tk_046_usage_dashboard_group_daily_metrics.sql
+++ b/backend/migrations/tk_046_usage_dashboard_group_daily_metrics.sql
@@ -1,0 +1,16 @@
+-- Extend the TK per-(group, day) rollup beyond the Groups page cost summary so
+-- it can also serve the admin Dashboard/Usage group distribution chart.
+--
+-- Existing deployments may already have usage_dashboard_group_daily with only
+-- actual_cost. The Go feeder writes these metrics for new/recomputed days, and
+-- backfillGroupDailyMetricsAllOnce fills historical rows before the read path
+-- uses them.
+
+ALTER TABLE usage_dashboard_group_daily
+    ADD COLUMN IF NOT EXISTS total_requests BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS input_tokens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS output_tokens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS cache_creation_tokens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS cache_read_tokens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS total_cost DECIMAL(20, 10) NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS account_cost DECIMAL(20, 10) NOT NULL DEFAULT 0;

--- a/backend/migrations/tk_046_usage_dashboard_group_daily_metrics.sql
+++ b/backend/migrations/tk_046_usage_dashboard_group_daily_metrics.sql
@@ -5,6 +5,7 @@
 -- actual_cost. The Go feeder writes these metrics for new/recomputed days, and
 -- backfillGroupDailyMetricsAllOnce fills historical rows before the read path
 -- uses them.
+-- bluegreen-safe-destructive-ok: expand-only DEFAULT 0 columns keep old writers/readers compatible during color overlap.
 
 ALTER TABLE usage_dashboard_group_daily
     ADD COLUMN IF NOT EXISTS total_requests BIGINT NOT NULL DEFAULT 0,

--- a/docs/approved/admin-ui-performance-rollups.md
+++ b/docs/approved/admin-ui-performance-rollups.md
@@ -65,6 +65,38 @@ page supplies per-row overrides from `/admin/accounts/usage/batch`.
 - If backfill is deferred by a short request deadline, the next aggregation
   cycle retries and the read path remains on raw data.
 
+## Pre-deploy Prod Baseline
+
+Read-only probes were run against prod via
+`ops/observability/run-probe.sh --target prod` on 2026-06-23
+12:57-12:59 UTC. This is the comparison baseline for post-deploy validation;
+it does not prove the change has shipped.
+
+- Rollup coverage: aggregation watermark was fresh at
+  2026-06-23T12:58:35Z, but `model_daily_backfilled=false` and
+  `group_daily_metrics_backfilled=false`.
+- Group rollup schema: prod `usage_dashboard_group_daily` did not yet have the
+  `tk_046` metric columns, so group rollup consistency diff was skipped until
+  the migration is deployed.
+- Dashboard users trend: `dashboard.snapshot.7d.users-trend-only` and
+  `dashboard.snapshot.7d.full` returned HTTP 500.
+- Slow direct timings:
+  - `usage.stats.summary-only.ui-default-range`: 3.93s.
+  - `usage.stats.summary-only`: 2.31s.
+  - `dashboard.snapshot.7d.models-only`: 2.31s.
+  - `usage.chart.groups-only.7d`: 1.89s.
+  - `usage.stats.endpoints-only`: 1.33s.
+  - `usage.stats.default`: 1.24s.
+- Access-log profile over the prior 24h:
+  - `/api/v1/admin/usage/stats`: p50 962ms, p90 2993ms, p95 3668ms,
+    max 4206ms.
+  - `/api/v1/admin/dashboard/snapshot-v2`: p50 119ms, p90 1439ms,
+    p95 3189ms, max 4324ms, including 22 HTTP 500 responses.
+  - `/api/v1/admin/accounts/:id/usage`: 496 requests, p50 352ms,
+    p95 719ms, max 1546ms.
+  - `/api/v1/admin/accounts/usage/batch`: 11 requests, p50 5ms,
+    p95 30ms, max 30ms.
+
 ## Validation
 
 - `pnpm build`
@@ -78,3 +110,9 @@ page supplies per-row overrides from `/admin/accounts/usage/batch`.
   - `ops/observability/probe-admin-aggregation-config.sh`
   - `ops/observability/probe-admin-ui-api-timing.sh`
   - `ops/observability/probe-admin-ui-perf.sh`
+
+Post-deploy acceptance requires stronger evidence than green CI: the prod
+deployment must show `tk_046` applied, model/group backfill markers ready or a
+safe raw fallback while markers converge, dashboard users-trend no longer
+returning 500, and materially lower latency for `usage.stats`, dashboard
+model/group chart reads, and account passive usage loading.

--- a/docs/approved/admin-ui-performance-rollups.md
+++ b/docs/approved/admin-ui-performance-rollups.md
@@ -1,11 +1,11 @@
 ---
 title: Admin UI Performance Rollups
-status: pending
-approved_by: pending
+status: approved
+approved_by: "xuejiao (design approval, 2026-06-23)"
 created: 2026-06-23
 owners: [tk-platform]
-related_prs: []
-related_commits: []
+related_prs: [963]
+related_commits: ["511ef944504de4387dec865f4ba11114e7cea0a5"]
 ---
 
 # Admin UI Performance Rollups
@@ -64,6 +64,25 @@ page supplies per-row overrides from `/admin/accounts/usage/batch`.
   read path starts using the new metric columns.
 - If backfill is deferred by a short request deadline, the next aggregation
   cycle retries and the read path remains on raw data.
+
+## Approval Guidance
+
+Approved with a Jobs-style product bar: this is one product promise, not a bag
+of unrelated optimizations. Admin first paint must stay responsive; slow
+aggregations must not block operators from using the dashboard, usage page, or
+accounts page.
+
+- Keep the success surface focused on `/admin/dashboard`, `/admin/usage`, and
+  `/admin/accounts`; implementation details only matter insofar as they improve
+  those paths.
+- Correctness is non-negotiable. Marker and coverage gates must prefer a safe
+  raw fallback over fast but incomplete rollup reads.
+- The additive `tk_046` migration is approved, provided production validation
+  confirms it is applied before group metric rollups are trusted.
+- Deployment is not complete until prod probes show dashboard users-trend no
+  longer returns 500 and the key latency paths materially improve against the
+  pre-deploy baseline. Safe fallback during marker convergence is acceptable,
+  but fallback alone is not a completed performance win.
 
 ## Pre-deploy Prod Baseline
 

--- a/docs/approved/admin-ui-performance-rollups.md
+++ b/docs/approved/admin-ui-performance-rollups.md
@@ -5,7 +5,7 @@ approved_by: "xuejiao (design approval, 2026-06-23)"
 created: 2026-06-23
 owners: [tk-platform]
 related_prs: [963]
-related_commits: ["511ef944504de4387dec865f4ba11114e7cea0a5"]
+related_commits: ["e2e5055a878cd9aaff4c1e4016071f903cfc693d"]
 ---
 
 # Admin UI Performance Rollups

--- a/docs/approved/admin-ui-performance-rollups.md
+++ b/docs/approved/admin-ui-performance-rollups.md
@@ -1,0 +1,80 @@
+---
+title: Admin UI Performance Rollups
+status: pending
+approved_by: pending
+created: 2026-06-23
+owners: [tk-platform]
+related_prs: []
+related_commits: []
+---
+
+# Admin UI Performance Rollups
+
+## Intent
+
+Reduce latency across the production admin UI without changing public response
+shapes. Live evidence shows the slow paths are concentrated in dashboard
+widgets, usage statistics, and account usage cells. The implementation moves
+wide, repeated admin reads onto existing or new rollup-backed paths and leaves
+mutable partial ranges on raw `usage_logs`.
+
+## Scope
+
+- `/admin/dashboard`: split stats, trend, model, group, user-trend, and ranking
+  loads so the first paint is not blocked by the slowest aggregation.
+- `/admin/usage`: split summary and endpoint statistics; lazy-load endpoint
+  distribution after the chart enters view.
+- `/admin/accounts`: replace per-row passive usage fan-out with one batch call
+  for the visible account rows.
+- Frontend build output: avoid preloading large admin page chunks and chart
+  chunks before the user navigates to those views.
+- Observability: add read-only probes for admin API timing, access-log latency
+  profiles, and rollup coverage.
+
+## Schema
+
+`backend/migrations/tk_046_usage_dashboard_group_daily_metrics.sql` adds
+metrics columns to `usage_dashboard_group_daily` for existing deployments:
+request count, token components, total cost, and account cost. The migration is
+additive only; it does not drop, rename, or rewrite existing columns.
+
+`backend/migrations/tk_038_usage_dashboard_group_daily.sql` is updated so fresh
+databases receive the same shape as already-deployed databases after `tk_046`.
+
+## Read/Write Path
+
+The dashboard aggregation job fills model and group daily rollups. Read paths
+use rollups only when their backfill marker proves historical coverage. Until
+then they keep the existing raw-scan path, which preserves correctness at the
+cost of current latency.
+
+Usage summary reads use `usage_dashboard_hourly` for complete server-timezone
+hours and raw `usage_logs` for the head/tail partial spans and data after the
+aggregation watermark. Filtered stats continue to use raw logs.
+
+Account passive usage no longer self-fetches once per row during page load; the
+page supplies per-row overrides from `/admin/accounts/usage/batch`.
+
+## Risk Controls
+
+- Rollup-backed reads are gated by marker rows or coverage floors, so partial
+  rollups do not silently undercount.
+- Today/current-hour slices stay raw, preserving live operational numbers.
+- The group-daily schema change is additive and is safe to deploy before the
+  read path starts using the new metric columns.
+- If backfill is deferred by a short request deadline, the next aggregation
+  cycle retries and the read path remains on raw data.
+
+## Validation
+
+- `pnpm build`
+- `python3 scripts/checks/frontend-release-assets.py --dist backend/internal/web/dist`
+- Focused frontend vitest suite for dashboard, usage, and account usage cells.
+- Focused backend unit tests for usage stats, dashboard caches, model/group
+  rollup gates, and users-trend.
+- Integration tests for model and group rollup parity against raw scans.
+- `scripts/preflight.sh`
+- Post-deploy read-only probes:
+  - `ops/observability/probe-admin-aggregation-config.sh`
+  - `ops/observability/probe-admin-ui-api-timing.sh`
+  - `ops/observability/probe-admin-ui-perf.sh`

--- a/frontend/src/api/admin/usage.ts
+++ b/frontend/src/api/admin/usage.ts
@@ -124,6 +124,8 @@ export async function getStats(params: {
   end_date?: string
   timezone?: string
   nocache?: number
+  include_summary?: number | boolean
+  include_endpoints?: number | boolean
 }): Promise<AdminUsageStatsResponse> {
   const { data } = await apiClient.get<AdminUsageStatsResponse>('/admin/usage/stats', {
     params

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -343,6 +343,99 @@ describe('AccountUsageCell', () => {
     expect(wrapper.text()).toContain('5h|18|900')
   })
 
+  it('OpenAI OAuth 有列表 override 时不自动拉取但手动刷新会拉取', async () => {
+    getUsage.mockResolvedValue({
+      five_hour: {
+        utilization: 21,
+        resets_at: '2099-03-07T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 3,
+          tokens: 300,
+          cost: 0.03,
+          standard_cost: 0.03,
+          user_cost: 0.03
+        }
+      },
+      seven_day: null
+    })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2011,
+          platform: 'openai',
+          type: 'oauth',
+          extra: {}
+        }),
+        usageOverride: null,
+        manualRefreshToken: 0
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'windowStats'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ windowStats?.tokens }}</div>'
+          },
+          AccountQuotaInfo: true
+        }
+      }
+    })
+
+    await flushPromises()
+    expect(getUsage).not.toHaveBeenCalled()
+
+    await wrapper.setProps({ manualRefreshToken: 1 })
+    await flushPromises()
+
+    expect(getUsage).toHaveBeenCalledTimes(1)
+    expect(getUsage).toHaveBeenCalledWith(2011, undefined)
+    expect(wrapper.text()).toContain('5h|21|300')
+  })
+
+  it('Anthropic OAuth 有列表 override 时手动刷新不回退为逐行 usage 请求', async () => {
+    getUsage.mockResolvedValue({
+      five_hour: {
+        utilization: 50,
+        resets_at: '2099-03-07T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 5,
+          tokens: 500,
+          cost: 0.05,
+          standard_cost: 0.05,
+          user_cost: 0.05
+        }
+      },
+      seven_day: null
+    })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2012,
+          platform: 'anthropic',
+          type: 'oauth',
+          extra: {}
+        }),
+        usageOverride: null,
+        manualRefreshToken: 0
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: true,
+          AccountQuotaInfo: true
+        }
+      }
+    })
+
+    await flushPromises()
+    await wrapper.setProps({ manualRefreshToken: 1 })
+    await flushPromises()
+
+    expect(getUsage).not.toHaveBeenCalled()
+  })
+
   it('OpenAI OAuth 在无 codex 快照时会回退显示 usage 接口窗口', async () => {
 	getUsage.mockResolvedValue({
 	  five_hour: {

--- a/frontend/src/components/account/usage-cells/useAccountUsageFetch.ts
+++ b/frontend/src/components/account/usage-cells/useAccountUsageFetch.ts
@@ -28,8 +28,7 @@ export function clearAccountUsageCache(accountId?: number) {
 
 const desktopViewportQuery = '(min-width: 768px)'
 
-function shouldFetchUsageForAccount(props: AccountUsageCellProps): boolean {
-  if (props.usageOverride !== undefined) return false
+function canFetchUsageForAccount(props: AccountUsageCellProps): boolean {
   if (props.account.platform === 'anthropic') {
     return props.account.type === 'oauth' || props.account.type === 'setup-token'
   }
@@ -43,6 +42,11 @@ function shouldFetchUsageForAccount(props: AccountUsageCellProps): boolean {
     return props.account.type === 'oauth'
   }
   return false
+}
+
+function shouldAutoFetchUsageForAccount(props: AccountUsageCellProps): boolean {
+  if (props.usageOverride !== undefined) return false
+  return canFetchUsageForAccount(props)
 }
 
 export function useAccountUsageFetch(
@@ -84,7 +88,8 @@ export function useAccountUsageFetch(
   let desktopViewportListener: ((event: MediaQueryListEvent) => void) | null = null
   let visibilityObserver: IntersectionObserver | null = null
 
-  const shouldFetchUsage = computed(() => shouldFetchUsageForAccount(props))
+  const shouldFetchUsage = computed(() => shouldAutoFetchUsageForAccount(props))
+  const canFetchUsage = computed(() => canFetchUsageForAccount(props))
 
   const shouldAutoLoadUsageOnMount = computed(() => shouldFetchUsage.value)
 
@@ -105,7 +110,7 @@ export function useAccountUsageFetch(
     source?: 'passive' | 'active'
     bypassCache?: boolean
   }) => {
-    if (!shouldFetchUsage.value) return
+    if (!canFetchUsage.value) return
 
     if (!loadOptions?.bypassCache) {
       const cached = _usageCache.get(props.account.id)
@@ -233,7 +238,10 @@ export function useAccountUsageFetch(
     () => props.manualRefreshToken,
     (nextToken, prevToken) => {
       if (nextToken === prevToken) return
-      if (!shouldFetchUsage.value) return
+      if (!canFetchUsage.value) return
+      // AccountsView already refreshes Anthropic passive usage through the batch
+      // endpoint before bumping this token; do not reintroduce per-row fan-out.
+      if (props.usageOverride !== undefined && isAnthropicOAuthOrSetupToken.value) return
 
       const source = isAnthropicOAuthOrSetupToken.value ? 'passive' : undefined
       _usageCache.delete(props.account.id)

--- a/frontend/src/composables/__tests__/useTkAccountUsageBatch.spec.ts
+++ b/frontend/src/composables/__tests__/useTkAccountUsageBatch.spec.ts
@@ -24,17 +24,17 @@ describe('useTkAccountUsageBatch', () => {
     getBatchPassiveUsage.mockReset()
   })
 
-  it('only batches Anthropic OAuth/SetupToken rows; others get undefined override', async () => {
+  it('only sends Anthropic passive rows to the batch endpoint and suppresses active self-fetch rows', async () => {
     getBatchPassiveUsage.mockResolvedValue({ usage: { '1': usageA } })
     const { refreshUsageBatch, usageOverrideFor } = useTkAccountUsageBatch()
 
     const accounts = [
       acct(1, 'anthropic', 'oauth'),
       acct(2, 'anthropic', 'setup-token'),
-      acct(3, 'anthropic', 'apikey'), // not passive-capable
-      acct(4, 'gemini', 'oauth'), // self-fetches, no override
-      acct(5, 'openai', 'oauth'), // active path, no override
-      acct(6, 'antigravity', 'oauth') // active path, no override
+      acct(3, 'anthropic', 'apikey'), // never self-fetches
+      acct(4, 'gemini', 'oauth'), // active-only on manual refresh
+      acct(5, 'openai', 'oauth'), // active-only on manual refresh
+      acct(6, 'antigravity', 'oauth') // active-only on manual refresh
     ]
 
     await refreshUsageBatch(accounts)
@@ -48,11 +48,14 @@ describe('useTkAccountUsageBatch', () => {
     expect(usageOverrideFor(accounts[0])).toEqual(usageA)
     expect(usageOverrideFor(accounts[1])).toBeNull()
 
-    // Non-capable rows: undefined => cell self-fetches as before.
+    // Rows that never self-fetch usage are left alone.
     expect(usageOverrideFor(accounts[2])).toBeUndefined()
-    expect(usageOverrideFor(accounts[3])).toBeUndefined()
-    expect(usageOverrideFor(accounts[4])).toBeUndefined()
-    expect(usageOverrideFor(accounts[5])).toBeUndefined()
+
+    // Active-only platforms get a null override on list load, so mounting the
+    // table no longer fans out to per-row active usage probes.
+    expect(usageOverrideFor(accounts[3])).toBeNull()
+    expect(usageOverrideFor(accounts[4])).toBeNull()
+    expect(usageOverrideFor(accounts[5])).toBeNull()
   })
 
   it('returns null override for a capable row before the batch resolves', () => {
@@ -62,10 +65,13 @@ describe('useTkAccountUsageBatch', () => {
     expect(usageOverrideFor(acct(9, 'anthropic', 'oauth'))).toBeNull()
   })
 
-  it('does not call the API when there are no capable rows', async () => {
-    const { refreshUsageBatch } = useTkAccountUsageBatch()
-    await refreshUsageBatch([acct(1, 'gemini', 'oauth'), acct(2, 'openai', 'oauth')])
+  it('does not call the API when there are no passive batch-capable rows', async () => {
+    const { refreshUsageBatch, usageOverrideFor } = useTkAccountUsageBatch()
+    const accounts = [acct(1, 'gemini', 'oauth'), acct(2, 'openai', 'oauth')]
+    await refreshUsageBatch(accounts)
     expect(getBatchPassiveUsage).not.toHaveBeenCalled()
+    expect(usageOverrideFor(accounts[0])).toBeNull()
+    expect(usageOverrideFor(accounts[1])).toBeNull()
   })
 
   it('ignores a stale response when a newer refresh has started (race guard)', async () => {

--- a/frontend/src/composables/useTkAccountUsageBatch.ts
+++ b/frontend/src/composables/useTkAccountUsageBatch.ts
@@ -9,13 +9,11 @@
  * /admin/accounts/usage/batch call, and exposes a per-row override the cell
  * renders verbatim (usageOverride !== undefined => the cell never self-fetches).
  *
- * Scope is deliberately Anthropic OAuth/SetupToken only — exactly the rows the
- * cell loads with source='passive' on mount, so the override is a byte-identical
- * passive→passive replacement. gemini/antigravity/openai rows keep their own
- * fetch (gemini computes from local logs; openai/antigravity use the active
- * path on mount), so no behavior changes for them. The residual per-cell
- * fetches for those minority platforms are bounded by the p-limit in
- * utils/usageLoadQueue.
+ * The server endpoint remains passive-only. Rows it can serve receive that
+ * passive payload; rows that would otherwise self-fetch active usage receive a
+ * null override on table load, so mounting the account list no longer fans out
+ * to upstream usage probes. Explicit user refresh still flows through the
+ * cell's manual-refresh token.
  */
 import { ref } from 'vue'
 import { adminAPI } from '@/api'
@@ -30,6 +28,14 @@ function isBatchPassiveCapable(account: Account): boolean {
   )
 }
 
+function canSelfFetchUsage(account: Account): boolean {
+  if (isBatchPassiveCapable(account)) return true
+  if (account.platform === 'gemini') return true
+  if (account.platform === 'antigravity') return account.type === 'oauth'
+  if (account.platform === 'openai') return account.type === 'oauth'
+  return false
+}
+
 export function useTkAccountUsageBatch() {
   // accountID(string) -> usage. Present-with-null is a deliberate signal to the
   // cell: "the list owns your usage, do not self-fetch" (override !== undefined).
@@ -38,14 +44,15 @@ export function useTkAccountUsageBatch() {
 
   /**
    * usageOverrideFor returns the prop value for a given row:
-   *  - AccountUsageInfo | null  for batch-capable rows (suppresses self-fetch);
-   *  - undefined                for all other rows (cell self-fetches as before).
+   *  - AccountUsageInfo | null  for rows whose list view owns usage loading;
+   *  - undefined                for rows that never self-fetch usage.
    */
   function usageOverrideFor(account: Account): AccountUsageInfo | null | undefined {
-    if (!isBatchPassiveCapable(account)) return undefined
+    if (!canSelfFetchUsage(account)) return undefined
     const key = String(account.id)
     // Until the batch resolves, return null (still suppresses the per-row XHR;
-    // the cell shows "-" briefly, then the override watcher fills it in).
+    // batch-capable cells show "-" briefly, then the override watcher fills it in.
+    // Active-only platforms stay null until an explicit refresh.
     return key in usageByAccountId.value ? usageByAccountId.value[key] : null
   }
 
@@ -68,8 +75,13 @@ export function useTkAccountUsageBatch() {
       if (reqSeq !== usageReqSeq.value) return
       const server = result.usage ?? {}
       const next: Record<string, AccountUsageInfo | null> = {}
-      for (const id of ids) {
-        const key = String(id)
+      for (const account of accounts) {
+        if (!canSelfFetchUsage(account)) continue
+        const key = String(account.id)
+        if (!isBatchPassiveCapable(account)) {
+          next[key] = null
+          continue
+        }
         // Omitted by the server (cannot serve passive) => null => cell shows "-".
         next[key] = server[key] ?? null
       }

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -711,6 +711,16 @@ const usageManualRefreshToken = ref(0)
 // never self-fetches when an override is present (see useTkAccountUsageBatch).
 const { usageOverrideFor: accountUsageOverrideFor, refreshUsageBatch } = useTkAccountUsageBatch()
 
+const refreshAccountRowMetrics = () => {
+  const rows = accounts.value.slice()
+  refreshTodayStatsBatch().catch((error) => {
+    console.error('Failed to load account today stats:', error)
+  })
+  refreshUsageBatch(rows).catch((error) => {
+    console.error('Failed to load account usage:', error)
+  })
+}
+
 const buildDefaultTodayStats = (): WindowStats => ({
   requests: 0,
   tokens: 0,
@@ -979,8 +989,7 @@ const load = async () => {
   requestParams.lite = '1'
   isFirstLoad.value = false
   await baseLoad()
-  await refreshTodayStatsBatch()
-  refreshUsageBatch(accounts.value)
+  refreshAccountRowMetrics()
 }
 
 const reload = async () => {
@@ -988,8 +997,7 @@ const reload = async () => {
   resetAutoRefreshCache()
   pendingTodayStatsRefresh.value = false
   await baseReload()
-  await refreshTodayStatsBatch()
-  refreshUsageBatch(accounts.value)
+  refreshAccountRowMetrics()
 }
 
 const debouncedReload = () => {
@@ -1148,8 +1156,7 @@ const refreshAccountsIncrementally = async () => {
       hasPendingListSync.value = false
     }
 
-    await refreshTodayStatsBatch()
-    refreshUsageBatch(accounts.value)
+    refreshAccountRowMetrics()
   } catch (error) {
     console.error('Auto refresh failed:', error)
   } finally {
@@ -1160,7 +1167,7 @@ const refreshAccountsIncrementally = async () => {
 const handleManualRefresh = async () => {
   await load()
   await refreshEdges({ force: true })
-  // load() already refreshed the batch passive-usage for Anthropic rows
+  // load() already starts the batch passive-usage refresh for Anthropic rows
   // (override path). Bump the token so the residual self-fetch platforms
   // (gemini/antigravity/openai cells) also refresh on explicit user refresh.
   usageManualRefreshToken.value += 1

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -289,7 +289,7 @@
                   @change="onDateRangeChange"
                 />
               </div>
-              <button @click="loadDashboardStats" :disabled="chartsLoading" class="btn btn-secondary">
+              <button @click="loadDashboardStats" :disabled="dashboardChartsLoading" class="btn btn-secondary">
                 {{ t('common.refresh') }}
               </button>
               <div class="ml-auto flex items-center gap-2">
@@ -316,7 +316,7 @@
               :ranking-total-actual-cost="rankingTotalActualCost"
               :ranking-total-requests="rankingTotalRequests"
               :ranking-total-tokens="rankingTotalTokens"
-              :loading="chartsLoading"
+              :loading="modelStatsLoading"
               :ranking-loading="rankingLoading"
               :ranking-error="rankingError"
               :start-date="startDate"
@@ -350,7 +350,7 @@
   </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { useAppStore } from '@/stores/app'
@@ -400,9 +400,11 @@ const router = useRouter()
 const stats = ref<DashboardStats | null>(null)
 const loading = ref(false)
 const chartsLoading = ref(false)
+const modelStatsLoading = ref(false)
 const userTrendLoading = ref(false)
 const rankingLoading = ref(false)
 const rankingError = ref(false)
+const dashboardChartsLoading = computed(() => chartsLoading.value || modelStatsLoading.value)
 
 // Chart data
 const trendData = ref<TrendDataPoint[]>([])
@@ -412,9 +414,12 @@ const rankingItems = ref<UserSpendingRankingItem[]>([])
 const rankingTotalActualCost = ref(0)
 const rankingTotalRequests = ref(0)
 const rankingTotalTokens = ref(0)
+let statsLoadSeq = 0
 let chartLoadSeq = 0
+let userTrendLoadSeq = 0
 let rankingLoadSeq = 0
 const rankingLimit = 12
+let initialChartTimer: number | null = null
 
 // Helper function to format date in local timezone
 const formatLocalDate = (date: Date): string => {
@@ -687,12 +692,92 @@ const onDateRangeChange = (range: {
 }
 
 // Load data
-const loadDashboardSnapshot = async (includeStats: boolean) => {
-  const currentSeq = ++chartLoadSeq
-  if (includeStats && !stats.value) {
-    loading.value = true
+const loadDashboardStatsSnapshot = async () => {
+  const currentSeq = ++statsLoadSeq
+  if (!stats.value) loading.value = true
+  try {
+    const response = await adminAPI.dashboard.getSnapshotV2({
+      start_date: startDate.value,
+      end_date: endDate.value,
+      ...rollingWindowTs(activePreset.value),
+      granularity: granularity.value,
+      include_stats: true,
+      include_trend: false,
+      include_model_stats: false,
+      include_group_stats: false,
+      include_users_trend: false
+    })
+    if (currentSeq !== statsLoadSeq) return
+    if (response.stats) stats.value = response.stats
+  } catch (error) {
+    if (currentSeq !== statsLoadSeq) return
+    appStore.showError(t('admin.dashboard.failedToLoad'))
+    console.error('Error loading dashboard stats snapshot:', error)
+  } finally {
+    if (currentSeq === statsLoadSeq) loading.value = false
   }
+}
+
+const loadDashboardTrendSnapshot = async (currentSeq: number) => {
   chartsLoading.value = true
+  try {
+    const response = await adminAPI.dashboard.getSnapshotV2({
+      start_date: startDate.value,
+      end_date: endDate.value,
+      ...rollingWindowTs(activePreset.value),
+      granularity: granularity.value,
+      include_stats: false,
+      include_trend: true,
+      include_model_stats: false,
+      include_group_stats: false,
+      include_users_trend: false
+    })
+    if (currentSeq !== chartLoadSeq) return
+    trendData.value = response.trend || []
+  } catch (error) {
+    if (currentSeq !== chartLoadSeq) return
+    trendData.value = []
+    console.error('Error loading dashboard trend snapshot:', error)
+  } finally {
+    if (currentSeq === chartLoadSeq) chartsLoading.value = false
+  }
+}
+
+const loadDashboardModelStatsSnapshot = async (currentSeq: number) => {
+  modelStatsLoading.value = true
+  try {
+    const response = await adminAPI.dashboard.getSnapshotV2({
+      start_date: startDate.value,
+      end_date: endDate.value,
+      ...rollingWindowTs(activePreset.value),
+      granularity: granularity.value,
+      include_stats: false,
+      include_trend: false,
+      include_model_stats: true,
+      include_group_stats: false,
+      include_users_trend: false
+    })
+    if (currentSeq !== chartLoadSeq) return
+    modelStats.value = response.models || []
+  } catch (error) {
+    if (currentSeq !== chartLoadSeq) return
+    modelStats.value = []
+    console.error('Error loading dashboard model snapshot:', error)
+  } finally {
+    if (currentSeq === chartLoadSeq) modelStatsLoading.value = false
+  }
+}
+
+const loadDashboardChartsSnapshot = async () => {
+  const currentSeq = ++chartLoadSeq
+  await Promise.allSettled([
+    loadDashboardTrendSnapshot(currentSeq),
+    loadDashboardModelStatsSnapshot(currentSeq),
+  ])
+}
+
+const loadUserUsageTrend = async () => {
+  const currentSeq = ++userTrendLoadSeq
   userTrendLoading.value = true
   try {
     const response = await adminAPI.dashboard.getSnapshotV2({
@@ -700,35 +785,21 @@ const loadDashboardSnapshot = async (includeStats: boolean) => {
       end_date: endDate.value,
       ...rollingWindowTs(activePreset.value),
       granularity: granularity.value,
-      include_stats: includeStats,
-      include_trend: true,
-      include_model_stats: true,
+      include_stats: false,
+      include_trend: false,
+      include_model_stats: false,
       include_group_stats: false,
-      // Fold the users-trend chart into this single snapshot request instead of a
-      // second parallel /users-trend call. The snapshot handler computes its
-      // sections concurrently, so this saves one round-trip without serializing
-      // the heavy users-trend aggregation behind stats/trend/models.
       include_users_trend: true,
       users_trend_limit: 12
     })
-    if (currentSeq !== chartLoadSeq) return
-    if (includeStats && response.stats) {
-      stats.value = response.stats
-    }
-    trendData.value = response.trend || []
-    modelStats.value = response.models || []
+    if (currentSeq !== userTrendLoadSeq) return
     userTrend.value = response.users_trend || []
   } catch (error) {
-    if (currentSeq !== chartLoadSeq) return
+    if (currentSeq !== userTrendLoadSeq) return
     userTrend.value = []
-    appStore.showError(t('admin.dashboard.failedToLoad'))
-    console.error('Error loading dashboard snapshot:', error)
+    console.error('Error loading user usage trend:', error)
   } finally {
-    if (currentSeq === chartLoadSeq) {
-      loading.value = false
-      chartsLoading.value = false
-      userTrendLoading.value = false
-    }
+    if (currentSeq === userTrendLoadSeq) userTrendLoading.value = false
   }
 }
 
@@ -764,22 +835,35 @@ const loadUserSpendingRanking = async () => {
 }
 
 const loadDashboardStats = async () => {
-  // users-trend is now folded into loadDashboardSnapshot (one snapshot request).
-  await Promise.all([
-    loadDashboardSnapshot(true),
-    loadUserSpendingRanking()
-  ])
+  await loadDashboardStatsSnapshot()
+  void loadChartData()
 }
 
 const loadChartData = async () => {
   await Promise.all([
-    loadDashboardSnapshot(false),
+    loadDashboardChartsSnapshot(),
+    loadUserUsageTrend(),
     loadUserSpendingRanking()
   ])
 }
 
 onMounted(() => {
-  loadDashboardStats()
+  chartsLoading.value = true
+  modelStatsLoading.value = true
+  userTrendLoading.value = true
+  rankingLoading.value = true
+  void loadDashboardStatsSnapshot()
+  initialChartTimer = window.setTimeout(() => {
+    void loadChartData()
+    initialChartTimer = null
+  }, 120)
+})
+
+onUnmounted(() => {
+  if (initialChartTimer !== null) {
+    window.clearTimeout(initialChartTimer)
+    initialChartTimer = null
+  }
 })
 </script>
 

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -38,7 +38,7 @@
           <GroupDistributionChart
             v-model:metric="groupDistributionMetric"
             :group-stats="groupStats"
-            :loading="chartsLoading"
+            :loading="groupStatsLoading"
             :show-metric-toggle="true"
             :start-date="startDate"
             :end-date="endDate"
@@ -46,20 +46,22 @@
           />
         </div>
         <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
-          <EndpointDistributionChart
-            v-model:source="endpointDistributionSource"
-            v-model:metric="endpointDistributionMetric"
-            :endpoint-stats="inboundEndpointStats"
-            :upstream-endpoint-stats="upstreamEndpointStats"
-            :endpoint-path-stats="endpointPathStats"
-            :loading="endpointStatsLoading"
-            :show-source-toggle="true"
-            :show-metric-toggle="true"
-            :title="t('usage.endpointDistribution')"
-            :start-date="startDate"
-            :end-date="endDate"
-            :filters="breakdownFilters"
-          />
+          <div ref="endpointChartRef" class="min-h-[360px]">
+            <EndpointDistributionChart
+              v-model:source="endpointDistributionSource"
+              v-model:metric="endpointDistributionMetric"
+              :endpoint-stats="inboundEndpointStats"
+              :upstream-endpoint-stats="upstreamEndpointStats"
+              :endpoint-path-stats="endpointPathStats"
+              :loading="endpointStatsLoading"
+              :show-source-toggle="true"
+              :show-metric-toggle="true"
+              :title="t('usage.endpointDistribution')"
+              :start-date="startDate"
+              :end-date="endDate"
+              :filters="breakdownFilters"
+            />
+          </div>
           <TokenUsageTrend :trend-data="trendData" :loading="chartsLoading" />
         </div>
       </div>
@@ -177,7 +179,7 @@ type EndpointSource = 'inbound' | 'upstream' | 'path'
 type ModelDistributionSource = 'requested' | 'upstream' | 'mapping'
 const route = useRoute()
 const usageStats = ref<AdminUsageStatsResponse | null>(null); const usageLogs = ref<AdminUsageLog[]>([]); const loading = ref(false); const exporting = ref(false)
-const trendData = ref<TrendDataPoint[]>([]); const requestedModelStats = ref<ModelStat[]>([]); const upstreamModelStats = ref<ModelStat[]>([]); const mappingModelStats = ref<ModelStat[]>([]); const groupStats = ref<GroupStat[]>([]); const chartsLoading = ref(false); const modelStatsLoading = ref(false); const granularity = ref<'day' | 'hour'>('hour')
+const trendData = ref<TrendDataPoint[]>([]); const requestedModelStats = ref<ModelStat[]>([]); const upstreamModelStats = ref<ModelStat[]>([]); const mappingModelStats = ref<ModelStat[]>([]); const groupStats = ref<GroupStat[]>([]); const chartsLoading = ref(false); const groupStatsLoading = ref(false); const modelStatsLoading = ref(false); const granularity = ref<'day' | 'hour'>('hour')
 const modelDistributionMetric = ref<DistributionMetric>('tokens')
 const modelDistributionSource = ref<ModelDistributionSource>('requested')
 const loadedModelSources = reactive<Record<ModelDistributionSource, boolean>>({
@@ -192,10 +194,15 @@ const inboundEndpointStats = ref<EndpointStat[]>([])
 const upstreamEndpointStats = ref<EndpointStat[]>([])
 const endpointPathStats = ref<EndpointStat[]>([])
 const endpointStatsLoading = ref(false)
+const endpointChartRef = ref<HTMLElement | null>(null)
+const endpointStatsActivated = ref(false)
 let abortController: AbortController | null = null; let exportAbortController: AbortController | null = null
+let endpointObserver: IntersectionObserver | null = null
 let chartReqSeq = 0
 let statsReqSeq = 0
+let endpointStatsReqSeq = 0
 let modelStatsReqSeq = 0
+let initialChartTimer: number | null = null
 const exportProgress = reactive({ show: false, progress: 0, current: 0, total: 0, estimatedTime: '' })
 const cleanupDialogVisible = ref(false)
 // Balance history modal state
@@ -333,6 +340,28 @@ const loadLogs = async () => {
 }
 const loadStats = async (force = false) => {
   const seq = ++statsReqSeq
+  try {
+    const requestType = filters.value.request_type
+    const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
+    const s = await adminAPI.usage.getStats({
+      ...filters.value,
+      stream: legacyStream === null ? undefined : legacyStream,
+      include_endpoints: 0,
+      ...(force ? { nocache: 1 } : {}),
+    })
+    if (seq !== statsReqSeq) return
+    usageStats.value = s
+  } catch (error) {
+    if (seq !== statsReqSeq) return
+    console.error('Failed to load usage stats:', error)
+  }
+}
+
+const loadEndpointStats = async (force = false) => {
+  if (!force && !endpointStatsActivated.value) {
+    return
+  }
+  const seq = ++endpointStatsReqSeq
   endpointStatsLoading.value = true
   try {
     const requestType = filters.value.request_type
@@ -340,22 +369,31 @@ const loadStats = async (force = false) => {
     const s = await adminAPI.usage.getStats({
       ...filters.value,
       stream: legacyStream === null ? undefined : legacyStream,
+      include_summary: 0,
+      include_endpoints: 1,
       ...(force ? { nocache: 1 } : {}),
     })
-    if (seq !== statsReqSeq) return
-    usageStats.value = s
+    if (seq !== endpointStatsReqSeq) return
     inboundEndpointStats.value = s.endpoints || []
     upstreamEndpointStats.value = s.upstream_endpoints || []
     endpointPathStats.value = s.endpoint_paths || []
   } catch (error) {
-    if (seq !== statsReqSeq) return
-    console.error('Failed to load usage stats:', error)
+    if (seq !== endpointStatsReqSeq) return
+    console.error('Failed to load endpoint stats:', error)
     inboundEndpointStats.value = []
     upstreamEndpointStats.value = []
     endpointPathStats.value = []
   } finally {
-    if (seq === statsReqSeq) endpointStatsLoading.value = false
+    if (seq === endpointStatsReqSeq) endpointStatsLoading.value = false
   }
+}
+
+const activateEndpointStats = () => {
+  if (endpointStatsActivated.value) return
+  endpointStatsActivated.value = true
+  void loadEndpointStats(true)
+  endpointObserver?.disconnect()
+  endpointObserver = null
 }
 
 // 失效模型统计缓存:仅标记需要重取,保留旧数据直到新数据到达(避免刷新时图表闪空)。
@@ -417,40 +455,69 @@ const loadModelStats = async (source: ModelDistributionSource, force = false) =>
   }
 }
 
-const loadChartData = async () => {
-  const seq = ++chartReqSeq
+const buildChartSnapshotParams = () => {
+  const requestType = filters.value.request_type
+  const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
+  return {
+    start_date: filters.value.start_date || startDate.value,
+    end_date: filters.value.end_date || endDate.value,
+    granularity: granularity.value,
+    user_id: filters.value.user_id,
+    model: filters.value.model,
+    api_key_id: filters.value.api_key_id,
+    account_id: filters.value.account_id,
+    group_id: filters.value.group_id,
+    request_type: requestType,
+    stream: legacyStream === null ? undefined : legacyStream,
+    billing_type: filters.value.billing_type,
+  }
+}
+
+const loadTrendData = async (seq: number) => {
   chartsLoading.value = true
   try {
-    const requestType = filters.value.request_type
-    const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
     const snapshot = await adminAPI.dashboard.getSnapshotV2({
-      start_date: filters.value.start_date || startDate.value,
-      end_date: filters.value.end_date || endDate.value,
-      granularity: granularity.value,
-      user_id: filters.value.user_id,
-      model: filters.value.model,
-      api_key_id: filters.value.api_key_id,
-      account_id: filters.value.account_id,
-      group_id: filters.value.group_id,
-      request_type: requestType,
-      stream: legacyStream === null ? undefined : legacyStream,
-      billing_type: filters.value.billing_type,
+      ...buildChartSnapshotParams(),
       include_stats: false,
       include_trend: true,
+      include_model_stats: false,
+      include_group_stats: false,
+      include_users_trend: false
+    })
+    if (seq !== chartReqSeq) return
+    trendData.value = snapshot.trend || []
+  } catch (error) { console.error('Failed to load usage trend data:', error) } finally { if (seq === chartReqSeq) chartsLoading.value = false }
+}
+
+const loadGroupStats = async (seq: number) => {
+  groupStatsLoading.value = true
+  try {
+    const snapshot = await adminAPI.dashboard.getSnapshotV2({
+      ...buildChartSnapshotParams(),
+      include_stats: false,
+      include_trend: false,
       include_model_stats: false,
       include_group_stats: true,
       include_users_trend: false
     })
     if (seq !== chartReqSeq) return
-    trendData.value = snapshot.trend || []
     groupStats.value = snapshot.groups || []
-  } catch (error) { console.error('Failed to load chart data:', error) } finally { if (seq === chartReqSeq) chartsLoading.value = false }
+  } catch (error) { console.error('Failed to load group distribution data:', error) } finally { if (seq === chartReqSeq) groupStatsLoading.value = false }
+}
+
+const loadChartData = async () => {
+  const seq = ++chartReqSeq
+  await Promise.allSettled([
+    loadTrendData(seq),
+    loadGroupStats(seq),
+  ])
 }
 const applyFilters = () => {
   pagination.page = 1
   invalidateModelStatsCache()
   loadLogs()
   loadStats()
+  if (endpointStatsActivated.value) loadEndpointStats()
   loadModelStats(modelDistributionSource.value, true)
   loadChartData()
   errPage.value = 1
@@ -464,6 +531,7 @@ const refreshData = () => {
   invalidateModelStatsCache()
   loadLogs()
   loadStats(true)
+  if (endpointStatsActivated.value) loadEndpointStats(true)
   loadModelStats(modelDistributionSource.value, true)
   loadChartData()
   if (activeTab.value === 'errors') loadAdminErrors()
@@ -678,18 +746,31 @@ onMounted(() => {
   applyRouteQueryFilters()
   loadLogs()
   loadStats()
-  loadModelStats(modelDistributionSource.value, true)
-  window.setTimeout(() => {
+  initialChartTimer = window.setTimeout(() => {
+    void loadModelStats(modelDistributionSource.value, true)
     void loadChartData()
+    initialChartTimer = null
   }, 120)
+  if ('IntersectionObserver' in window) {
+    endpointObserver = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        activateEndpointStats()
+      }
+    }, { rootMargin: '200px 0px' })
+    if (endpointChartRef.value) {
+      endpointObserver.observe(endpointChartRef.value)
+    }
+  } else {
+    activateEndpointStats()
+  }
   loadSavedColumns()
   document.addEventListener('click', handleColumnClickOutside)
 })
-onUnmounted(() => { abortController?.abort(); exportAbortController?.abort(); document.removeEventListener('click', handleColumnClickOutside) })
+onUnmounted(() => { if (initialChartTimer !== null) window.clearTimeout(initialChartTimer); endpointObserver?.disconnect(); abortController?.abort(); exportAbortController?.abort(); document.removeEventListener('click', handleColumnClickOutside) })
 
 watch(modelDistributionSource, (source) => {
   void loadModelStats(source)
 })
 
-defineExpose({ requestedModelStats, refreshData })
+defineExpose({ requestedModelStats, refreshData, activateEndpointStats })
 </script>

--- a/frontend/src/views/admin/__tests__/AccountsView.usageWindowsHint.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.usageWindowsHint.spec.ts
@@ -171,4 +171,36 @@ describe('admin AccountsView usage windows hint', () => {
     expect(hint.exists()).toBe(true)
     expect(hint.text()).toBe('admin.accounts.usageWindowsHint')
   })
+
+  it('does not wait for today stats before loading batch usage metrics', async () => {
+    let resolveTodayStats!: (value: { stats: Record<string, unknown> }) => void
+    getBatchTodayStats.mockReturnValue(new Promise(resolve => {
+      resolveTodayStats = resolve
+    }))
+    listAccounts.mockResolvedValue({
+      items: [{
+        id: 42,
+        name: 'anthropic-oauth',
+        platform: 'anthropic',
+        type: 'oauth',
+        status: 'active',
+        schedulable: true,
+        created_at: '2026-03-07T10:00:00Z',
+        updated_at: '2026-03-07T10:00:00Z'
+      }],
+      total: 1,
+      page: 1,
+      page_size: 20,
+      pages: 1
+    })
+
+    mountView()
+    await flushPromises()
+
+    expect(getBatchTodayStats).toHaveBeenCalledWith([42])
+    expect(getBatchPassiveUsage).toHaveBeenCalledWith([42])
+
+    resolveTodayStats({ stats: {} })
+    await flushPromises()
+  })
 })

--- a/frontend/src/views/admin/__tests__/DashboardView.daterange-repro.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.daterange-repro.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DashboardView from '../DashboardView.vue'
@@ -68,10 +68,11 @@ const mountDashboard = () =>
     }
   })
 
-const lastSnapshotCall = () =>
-  getSnapshotV2.mock.calls.at(-1)?.[0] as
-    | { start_date: string; end_date: string; granularity: string }
-    | undefined
+const lastChartSnapshotCall = () =>
+  getSnapshotV2.mock.calls
+    .map((call) => call[0])
+    .filter((params) => params?.include_trend === true)
+    .at(-1) as { start_date: string; end_date: string; granularity: string } | undefined
 
 // open the date picker and click a preset by its (mocked) label key
 const clickPreset = async (wrapper: ReturnType<typeof mountDashboard>, labelKey: string) => {
@@ -101,6 +102,7 @@ const selectGranularity = async (wrapper: ReturnType<typeof mountDashboard>, lab
 
 describe('admin DashboardView — date-range / granularity request params', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     getSnapshotV2.mockReset()
     getUserUsageTrend.mockReset()
     getUserSpendingRanking.mockReset()
@@ -118,6 +120,10 @@ describe('admin DashboardView — date-range / granularity request params', () =
     })
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   // Regression guard for the screenshot bug: selecting 近14天 used to only flip
   // the trigger label without applying, so a subsequent granularity change still
   // requested the default last-24h window (2 daily buckets) while the label read
@@ -125,15 +131,17 @@ describe('admin DashboardView — date-range / granularity request params', () =
   it('picking 近14天 preset applies immediately and a later 粒度→按天 keeps the 14-day window', async () => {
     const wrapper = mountDashboard()
     await flushPromises()
+    vi.advanceTimersByTime(120)
+    await flushPromises()
 
     // baseline: default last-24h + hour
-    expect(lastSnapshotCall()).toMatchObject({ granularity: 'hour' })
+    expect(lastChartSnapshotCall()).toMatchObject({ granularity: 'hour' })
 
     await clickPreset(wrapper, 'dates.last14Days')
     await selectGranularity(wrapper, 'admin.dashboard.day')
     await flushPromises()
 
-    const call = lastSnapshotCall()!
+    const call = lastChartSnapshotCall()!
     const span =
       (new Date(call.end_date).getTime() - new Date(call.start_date).getTime()) / 86400000
 
@@ -144,11 +152,13 @@ describe('admin DashboardView — date-range / granularity request params', () =
   it('picking 近14天 preset alone sends a real 14-day window', async () => {
     const wrapper = mountDashboard()
     await flushPromises()
+    vi.advanceTimersByTime(120)
+    await flushPromises()
 
     await clickPreset(wrapper, 'dates.last14Days')
     await flushPromises()
 
-    const call = lastSnapshotCall()!
+    const call = lastChartSnapshotCall()!
     const span =
       (new Date(call.end_date).getTime() - new Date(call.start_date).getTime()) / 86400000
 

--- a/frontend/src/views/admin/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import type { DashboardStats } from '@/types'
@@ -89,6 +89,7 @@ const createDashboardStats = (): DashboardStats => ({
 
 describe('admin DashboardView', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     getSnapshotV2.mockReset()
     getUserUsageTrend.mockReset()
     getUserSpendingRanking.mockReset()
@@ -112,6 +113,10 @@ describe('admin DashboardView', () => {
       start_date: '',
       end_date: ''
     })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('uses last 24 hours as default dashboard range', async () => {
@@ -139,7 +144,35 @@ describe('admin DashboardView', () => {
     expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
       start_date: formatLocalDate(yesterday),
       end_date: formatLocalDate(now),
-      granularity: 'hour'
+      granularity: 'hour',
+      include_stats: true,
+      include_trend: false,
+      include_model_stats: false,
+      include_users_trend: false
     }))
+
+    vi.advanceTimersByTime(120)
+    await flushPromises()
+
+    expect(getSnapshotV2).toHaveBeenCalledTimes(4)
+    expect(getSnapshotV2).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      include_stats: false,
+      include_trend: true,
+      include_model_stats: false,
+      include_users_trend: false
+    }))
+    expect(getSnapshotV2).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      include_stats: false,
+      include_trend: false,
+      include_model_stats: true,
+      include_users_trend: false
+    }))
+    expect(getSnapshotV2).toHaveBeenNthCalledWith(4, expect.objectContaining({
+      include_stats: false,
+      include_trend: false,
+      include_model_stats: false,
+      include_users_trend: true
+    }))
+    expect(getUserSpendingRanking).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -34,6 +34,31 @@ const formatLocalDate = (date: Date): string => {
   return `${year}-${month}-${day}`
 }
 
+let endpointIntersectionCallback: IntersectionObserverCallback | null = null
+
+class MockIntersectionObserver {
+  constructor(callback: IntersectionObserverCallback) {
+    endpointIntersectionCallback = callback
+  }
+
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+  takeRecords = vi.fn(() => [])
+}
+
+const installIntersectionObserver = () => {
+  endpointIntersectionCallback = null
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+}
+
+const triggerEndpointIntersection = (isIntersecting = true) => {
+  endpointIntersectionCallback?.(
+    [{ isIntersecting } as IntersectionObserverEntry],
+    {} as IntersectionObserver,
+  )
+}
+
 vi.mock('@/api/admin', () => ({
   adminAPI: {
     usage: {
@@ -119,6 +144,7 @@ const GroupDistributionChartStub = {
 describe('admin UsageView distribution metric toggles', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    installIntersectionObserver()
     list.mockReset()
     getStats.mockReset()
     getSnapshotV2.mockReset()
@@ -150,6 +176,43 @@ describe('admin UsageView distribution metric toggles', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('loads summary first and endpoint distribution only after the chart enters view', async () => {
+    mount(UsageView, {
+      global: { stubs: {
+        AppLayout: AppLayoutStub, UsageStatsCards: true, UsageFilters: UsageFiltersStub,
+        UsageTable: true, UsageExportProgress: true, UsageCleanupDialog: true,
+        UserBalanceHistoryModal: true, AuditLogModal: true, Pagination: true, Select: true,
+        DateRangePicker: true, Icon: true, TokenUsageTrend: true,
+        ModelDistributionChart: true, GroupDistributionChart: true, EndpointDistributionChart: true,
+      } },
+    })
+
+    await flushPromises()
+    expect(getStats).toHaveBeenCalledTimes(1)
+    expect(getStats).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      include_endpoints: 0,
+    }))
+    expect(getStats).not.toHaveBeenNthCalledWith(1, expect.objectContaining({
+      include_summary: 0,
+    }))
+
+    vi.advanceTimersByTime(120)
+    await flushPromises()
+    expect(getStats).toHaveBeenCalledTimes(1)
+    expect(getStats).not.toHaveBeenCalledWith(expect.objectContaining({
+      include_summary: 0,
+      include_endpoints: 1,
+    }))
+
+    triggerEndpointIntersection()
+    await flushPromises()
+    expect(getStats).toHaveBeenCalledTimes(2)
+    expect(getStats).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      include_summary: 0,
+      include_endpoints: 1,
+    }))
   })
 
   it('keeps previous model stats visible during refresh until new data arrives', async () => {
@@ -208,13 +271,22 @@ describe('admin UsageView distribution metric toggles', () => {
     vi.advanceTimersByTime(120)
     await flushPromises()
 
-    expect(getSnapshotV2).toHaveBeenCalledTimes(1)
+    expect(getSnapshotV2).toHaveBeenCalledTimes(2)
     const now = new Date()
     const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
     expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
       start_date: formatLocalDate(yesterday),
       end_date: formatLocalDate(now),
-      granularity: 'hour'
+      granularity: 'hour',
+      include_trend: true,
+      include_group_stats: false,
+    }))
+    expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
+      start_date: formatLocalDate(yesterday),
+      end_date: formatLocalDate(now),
+      granularity: 'hour',
+      include_trend: false,
+      include_group_stats: true,
     }))
 
     const modelChart = wrapper.find('[data-test="model-chart"]')
@@ -228,20 +300,21 @@ describe('admin UsageView distribution metric toggles', () => {
 
     expect(modelChart.find('.metric').text()).toBe('actual_cost')
     expect(groupChart.find('.metric').text()).toBe('tokens')
-    expect(getSnapshotV2).toHaveBeenCalledTimes(1)
+    expect(getSnapshotV2).toHaveBeenCalledTimes(2)
 
     await groupChart.find('.switch-metric').trigger('click')
     await flushPromises()
 
     expect(modelChart.find('.metric').text()).toBe('actual_cost')
     expect(groupChart.find('.metric').text()).toBe('actual_cost')
-    expect(getSnapshotV2).toHaveBeenCalledTimes(1)
+    expect(getSnapshotV2).toHaveBeenCalledTimes(2)
   })
 })
 
 describe('admin UsageView handleUserClick', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    installIntersectionObserver()
     list.mockReset()
     getStats.mockReset()
     getSnapshotV2.mockReset()
@@ -298,6 +371,7 @@ describe('admin UsageView handleUserClick', () => {
 describe('admin UsageView errors tab filter forwarding', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    installIntersectionObserver()
     list.mockReset()
     getStats.mockReset()
     getSnapshotV2.mockReset()

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -34,6 +34,19 @@ function injectPublicSettings(backendUrl: string): Plugin {
   }
 }
 
+const ENTRY_HTML_PRELOAD_BLOCKLIST = [
+  '/AccountsView-',
+  '/AccountUsageCell-',
+  '/CreateAccountModal-',
+  '/EditAccountModal-',
+  '/BulkEditAccountModal-',
+  '/ModelWhitelistSelector',
+  '/OAuthAuthorizationFlow',
+  '/DashboardView-',
+  '/admin-dashboard-view-',
+  '/vendor-chart-'
+]
+
 export default defineConfig(({ mode }) => {
   // 加载环境变量
   const env = loadEnv(mode, process.cwd(), '')
@@ -61,6 +74,17 @@ export default defineConfig(({ mode }) => {
     __INTLIFY_JIT_COMPILATION__: true
   },
   build: {
+    modulePreload: {
+      resolveDependencies(filename, deps, context) {
+        if (context.hostType !== 'html') return deps
+
+        // TK admin perf: the SPA shell is shared by all routes. Keep route-level
+        // dynamic-import preloads intact; only trim the index.html eager set.
+        if (!filename.startsWith('assets/index-')) return deps
+
+        return deps.filter(dep => !ENTRY_HTML_PRELOAD_BLOCKLIST.some(token => dep.includes(token)))
+      }
+    },
     outDir: '../backend/internal/web/dist',
     emptyOutDir: true,
     rollupOptions: {
@@ -112,22 +136,6 @@ export default defineConfig(({ mode }) => {
             return 'vendor-misc'
           }
 
-          // TK admin perf: isolate heavy account page surfaces from the entry chunk.
-          if (id.includes('/components/account/CreateAccountModal') ||
-              id.includes('/components/account/EditAccountModal') ||
-              id.includes('/components/account/BulkEditAccountModal')) {
-            return 'admin-account-modals'
-          }
-          if (id.includes('/components/account/usage-cells/')) {
-            return 'admin-account-usage-cells'
-          }
-          if (id.includes('/views/admin/AccountsView.vue')) {
-            return 'admin-accounts-view'
-          }
-          if (id.includes('/views/admin/DashboardView.vue') ||
-              id.includes('/components/charts/')) {
-            return 'admin-dashboard-view'
-          }
           if (id.includes('/views/admin/AdminShellView.vue') ||
               id.includes('/components/layout/AppLayout.vue') ||
               id.includes('/components/layout/AppSidebar.vue') ||

--- a/ops/observability/probe-admin-aggregation-config.sh
+++ b/ops/observability/probe-admin-aggregation-config.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# probe-admin-aggregation-config.sh — read-only runtime config/env snapshot for
+# admin dashboard aggregation jobs.
+set -euo pipefail
+
+echo "=== env_dashboard_aggregation ==="
+docker exec tokenkey sh -c 'printenv | grep -E "^(DASHBOARD_AGGREGATION_|DASHBOARD_CACHE_)" | sort || true' |
+  sed -E 's/(PASSWORD|TOKEN|SECRET|KEY)=.*/\1=<redacted>/'
+
+echo "=== config_files ==="
+docker exec tokenkey sh -c '
+for f in /app/config.yaml /app/config.yml /app/config/config.yaml /app/config/config.yml; do
+  [ -f "$f" ] && printf "%s\n" "$f"
+done
+' || true
+
+echo "=== aggregation_tables ==="
+PSQL="${PSQL:-docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t}"
+$PSQL -c "SELECT row_to_json(t) FROM (
+  SELECT
+    now() AT TIME ZONE 'UTC' AS now_utc,
+    (SELECT last_aggregated_at FROM usage_dashboard_aggregation_watermark WHERE id = 1) AS aggregation_watermark,
+    (SELECT COUNT(*) FROM usage_dashboard_hourly) AS hourly_rows,
+    (SELECT MIN(bucket_start) FROM usage_dashboard_hourly) AS hourly_min,
+    (SELECT MAX(bucket_start) FROM usage_dashboard_hourly) AS hourly_max,
+    (SELECT COUNT(*) FROM usage_dashboard_daily) AS daily_rows,
+    (SELECT MIN(bucket_date) FROM usage_dashboard_daily) AS daily_min,
+    (SELECT MAX(bucket_date) FROM usage_dashboard_daily) AS daily_max,
+    (SELECT COUNT(*) FROM usage_dashboard_group_daily) AS group_daily_rows,
+    EXISTS(SELECT 1 FROM usage_dashboard_group_daily WHERE group_id = 0 AND bucket_date = DATE '1970-01-01') AS group_daily_backfilled,
+    EXISTS(SELECT 1 FROM usage_dashboard_group_daily WHERE group_id = 0 AND bucket_date = DATE '1970-01-02') AS group_daily_metrics_backfilled,
+    EXISTS(SELECT 1 FROM usage_dashboard_model_daily WHERE bucket_date = DATE '1970-01-01' AND model = '__tk_model_daily_backfill_marker__') AS model_daily_backfilled
+) t;"

--- a/ops/observability/probe-admin-group-rollup-timing.sh
+++ b/ops/observability/probe-admin-group-rollup-timing.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# probe-admin-group-rollup-timing.sh — read-only timing/coverage probe for
+# admin Dashboard/Usage group-distribution rollup candidates.
+set -euo pipefail
+
+PSQL="${PSQL:-docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t}"
+INCLUDE_EXPLAIN="${INCLUDE_EXPLAIN:-0}"
+EXPLAIN_SECTION="${EXPLAIN_SECTION:-all}"
+REQUIRED_GROUP_DAILY_COLUMNS="total_requests,input_tokens,output_tokens,cache_creation_tokens,cache_read_tokens,total_cost,actual_cost,account_cost"
+
+should_explain() {
+  [ "$INCLUDE_EXPLAIN" = "1" ] && { [ "$EXPLAIN_SECTION" = "all" ] || [ "$EXPLAIN_SECTION" = "$1" ]; }
+}
+
+echo "=== meta ==="
+HAS_GROUP_DAILY_METRICS="$($PSQL -c "
+SELECT CASE WHEN COUNT(*) = 8 THEN 'true' ELSE 'false' END
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'usage_dashboard_group_daily'
+  AND column_name = ANY (string_to_array('$REQUIRED_GROUP_DAILY_COLUMNS', ','));
+")"
+
+$PSQL -c "
+SELECT row_to_json(t)
+FROM (
+  SELECT
+    now() AT TIME ZONE 'UTC' AS now_utc,
+    (SELECT MIN(bucket_date) FROM usage_dashboard_group_daily WHERE bucket_date > DATE '1970-01-02') AS group_daily_min_date,
+    (SELECT MAX(bucket_date) FROM usage_dashboard_group_daily WHERE bucket_date > DATE '1970-01-02') AS group_daily_max_date,
+    (SELECT COUNT(*) FROM usage_dashboard_group_daily) AS group_daily_rows,
+    ${HAS_GROUP_DAILY_METRICS}::boolean AS has_group_daily_metrics,
+    EXISTS(
+      SELECT 1
+      FROM usage_dashboard_group_daily
+      WHERE group_id = 0 AND bucket_date = DATE '1970-01-01'
+    ) AS group_daily_backfilled,
+    EXISTS(
+      SELECT 1
+      FROM usage_dashboard_group_daily
+      WHERE group_id = 0 AND bucket_date = DATE '1970-01-02'
+    ) AS metrics_backfilled,
+    (SELECT last_aggregated_at FROM usage_dashboard_aggregation_watermark WHERE id = 1) AS aggregation_watermark
+) t;
+"
+
+if should_explain raw_7d; then
+  echo "=== raw_7d_group_explain ==="
+  $PSQL -c "
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+SELECT
+  COALESCE(ul.group_id, 0) AS group_id,
+  COUNT(*) AS requests,
+  COALESCE(SUM(ul.input_tokens + ul.output_tokens + ul.cache_creation_tokens + ul.cache_read_tokens), 0) AS total_tokens,
+  COALESCE(SUM(ul.total_cost), 0) AS cost,
+  COALESCE(SUM(ul.actual_cost), 0) AS actual_cost,
+  COALESCE(SUM(COALESCE(ul.account_stats_cost, ul.total_cost) * COALESCE(ul.account_rate_multiplier, 1)), 0) AS account_cost
+FROM usage_logs ul
+WHERE ul.created_at >= (((now() AT TIME ZONE 'Asia/Shanghai')::date - interval '6 days')::date)::timestamp AT TIME ZONE 'Asia/Shanghai'
+  AND ul.created_at < now()
+GROUP BY ul.group_id
+ORDER BY total_tokens DESC
+LIMIT 20;
+"
+fi
+
+if should_explain rollup_completed_days; then
+  echo "=== rollup_completed_days_explain ==="
+  if [[ "$HAS_GROUP_DAILY_METRICS" != "true" ]]; then
+    echo '{"skipped":true,"reason":"usage_dashboard_group_daily lacks metric columns; run tk_046 migration before rollup timing"}'
+  else
+    $PSQL -c "
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+SELECT
+  gd.group_id,
+  COALESCE(SUM(gd.total_requests), 0) AS requests,
+  COALESCE(SUM(gd.input_tokens + gd.output_tokens + gd.cache_creation_tokens + gd.cache_read_tokens), 0) AS total_tokens,
+  COALESCE(SUM(gd.total_cost), 0) AS cost,
+  COALESCE(SUM(gd.actual_cost), 0) AS actual_cost,
+  COALESCE(SUM(gd.account_cost), 0) AS account_cost
+FROM usage_dashboard_group_daily gd
+WHERE gd.bucket_date > DATE '1970-01-02'
+  AND gd.bucket_date >= ((now() AT TIME ZONE 'Asia/Shanghai')::date - interval '6 days')::date
+  AND gd.bucket_date < (now() AT TIME ZONE 'Asia/Shanghai')::date
+GROUP BY gd.group_id
+ORDER BY total_tokens DESC
+LIMIT 20;
+"
+  fi
+fi
+
+if should_explain raw_today; then
+  echo "=== raw_today_group_explain ==="
+  $PSQL -c "
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+SELECT
+  COALESCE(ul.group_id, 0) AS group_id,
+  COUNT(*) AS requests,
+  COALESCE(SUM(ul.input_tokens + ul.output_tokens + ul.cache_creation_tokens + ul.cache_read_tokens), 0) AS total_tokens,
+  COALESCE(SUM(ul.total_cost), 0) AS cost,
+  COALESCE(SUM(ul.actual_cost), 0) AS actual_cost,
+  COALESCE(SUM(COALESCE(ul.account_stats_cost, ul.total_cost) * COALESCE(ul.account_rate_multiplier, 1)), 0) AS account_cost
+FROM usage_logs ul
+WHERE ul.created_at >= date_trunc('day', now() AT TIME ZONE 'Asia/Shanghai') AT TIME ZONE 'Asia/Shanghai'
+  AND ul.created_at < now()
+GROUP BY ul.group_id
+ORDER BY total_tokens DESC
+LIMIT 20;
+"
+fi
+
+echo "=== raw_vs_rollup_completed_days_delta ==="
+if [[ "$HAS_GROUP_DAILY_METRICS" != "true" ]]; then
+  echo '{"skipped":true,"reason":"usage_dashboard_group_daily lacks metric columns; run tk_046 migration before consistency diff"}'
+else
+  $PSQL -c "
+WITH bounds AS (
+  SELECT
+    ((now() AT TIME ZONE 'Asia/Shanghai')::date - interval '6 days')::date AS start_day,
+    (now() AT TIME ZONE 'Asia/Shanghai')::date AS today_day,
+    (((now() AT TIME ZONE 'Asia/Shanghai')::date - interval '6 days')::date)::timestamp AT TIME ZONE 'Asia/Shanghai' AS start_ts,
+    ((now() AT TIME ZONE 'Asia/Shanghai')::date)::timestamp AT TIME ZONE 'Asia/Shanghai' AS today_ts
+),
+raw AS (
+  SELECT
+    COALESCE(group_id, 0) AS group_id,
+    COUNT(*)::bigint AS requests,
+    COALESCE(SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens), 0)::bigint AS tokens,
+    COALESCE(SUM(actual_cost), 0)::numeric AS actual_cost
+  FROM usage_logs, bounds
+  WHERE created_at >= bounds.start_ts AND created_at < bounds.today_ts
+  GROUP BY COALESCE(group_id, 0)
+),
+rollup AS (
+  SELECT
+    group_id,
+    COALESCE(SUM(total_requests), 0)::bigint AS requests,
+    COALESCE(SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens), 0)::bigint AS tokens,
+    COALESCE(SUM(actual_cost), 0)::numeric AS actual_cost
+  FROM usage_dashboard_group_daily, bounds
+  WHERE bucket_date > DATE '1970-01-02'
+    AND bucket_date >= bounds.start_day
+    AND bucket_date < bounds.today_day
+  GROUP BY group_id
+),
+joined AS (
+  SELECT
+    COALESCE(raw.group_id, rollup.group_id) AS group_id,
+    COALESCE(raw.requests, 0) - COALESCE(rollup.requests, 0) AS request_delta,
+    COALESCE(raw.tokens, 0) - COALESCE(rollup.tokens, 0) AS token_delta,
+    COALESCE(raw.actual_cost, 0) - COALESCE(rollup.actual_cost, 0) AS actual_cost_delta
+  FROM raw
+  FULL OUTER JOIN rollup USING (group_id)
+)
+SELECT row_to_json(t)
+FROM (
+  SELECT
+    COUNT(*) FILTER (
+      WHERE request_delta <> 0
+        OR token_delta <> 0
+        OR ABS(actual_cost_delta) > 0.0000001
+    ) AS changed_groups,
+    COALESCE(SUM(ABS(request_delta)), 0) AS request_delta_sum,
+    COALESCE(SUM(ABS(token_delta)), 0) AS token_delta_sum,
+    COALESCE(SUM(ABS(actual_cost_delta)), 0) AS actual_cost_delta_sum,
+    COALESCE(MAX(ABS(request_delta)), 0) AS max_abs_request_delta,
+    COALESCE(MAX(ABS(token_delta)), 0) AS max_abs_token_delta
+  FROM joined
+) t;
+"
+fi

--- a/ops/observability/probe-admin-model-rollup-timing.sh
+++ b/ops/observability/probe-admin-model-rollup-timing.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# probe-admin-model-rollup-timing.sh — read-only timing/consistency probe for
+# admin dashboard model distribution rollup candidates.
+set -euo pipefail
+
+PSQL="${PSQL:-docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t}"
+INCLUDE_EXPLAIN="${INCLUDE_EXPLAIN:-0}"
+EXPLAIN_SECTION="${EXPLAIN_SECTION:-all}"
+
+should_explain() {
+  [ "$INCLUDE_EXPLAIN" = "1" ] && { [ "$EXPLAIN_SECTION" = "all" ] || [ "$EXPLAIN_SECTION" = "$1" ]; }
+}
+
+echo "=== meta ==="
+$PSQL -c "SELECT row_to_json(t) FROM (
+  SELECT
+    now() AT TIME ZONE 'UTC' AS now_utc,
+    EXISTS(SELECT 1 FROM usage_dashboard_model_daily WHERE bucket_date = DATE '1970-01-01' AND model = '__tk_model_daily_backfill_marker__') AS model_daily_backfilled,
+    (SELECT min(bucket_date) FROM usage_dashboard_model_daily WHERE bucket_date > DATE '1970-01-01') AS model_daily_min_date,
+    (SELECT max(bucket_date) FROM usage_dashboard_model_daily WHERE bucket_date > DATE '1970-01-01') AS model_daily_max_date,
+    (SELECT count(*) FROM usage_dashboard_model_daily) AS model_daily_rows_total,
+    (SELECT count(*) FROM usage_dashboard_model_daily WHERE bucket_date > DATE '1970-01-01') AS model_daily_rows_data,
+    (SELECT last_aggregated_at FROM usage_dashboard_aggregation_watermark WHERE id = 1) AS aggregation_watermark
+) t;"
+
+echo "=== window_row_counts ==="
+$PSQL -c "SELECT row_to_json(t) FROM (
+  WITH bounds AS (
+    SELECT
+      ((now() AT TIME ZONE 'Asia/Shanghai')::date - interval '6 days')::date AS start_day,
+      (now() AT TIME ZONE 'Asia/Shanghai')::date AS today_day,
+      now() AS now_ts,
+      (SELECT last_aggregated_at FROM usage_dashboard_aggregation_watermark WHERE id = 1) AS watermark
+  ),
+  planned AS (
+    SELECT
+      bounds.*,
+      bounds.start_day::timestamp AT TIME ZONE 'Asia/Shanghai' AS window_start,
+      bounds.today_day::timestamp AT TIME ZONE 'Asia/Shanghai' AS today_start,
+      GREATEST(
+        bounds.start_day,
+        COALESCE((SELECT min(bucket_date) FROM usage_dashboard_model_daily WHERE bucket_date > DATE '1970-01-01'), bounds.today_day)
+      ) AS rollup_start_day
+    FROM bounds
+  )
+  SELECT
+    (SELECT window_start FROM planned) AS window_start,
+    (SELECT today_start FROM planned) AS today_start,
+    (SELECT rollup_start_day FROM planned) AS rollup_start_day,
+    (SELECT watermark FROM planned) AS watermark,
+    (SELECT count(*) FROM usage_logs ul, planned p WHERE ul.created_at >= p.window_start AND ul.created_at < p.now_ts) AS raw_7d_rows_to_now,
+    (SELECT count(*) FROM usage_logs ul, planned p WHERE ul.created_at >= p.window_start AND ul.created_at < p.today_start) AS raw_completed_day_rows,
+    (SELECT count(*) FROM usage_logs ul, planned p WHERE ul.created_at >= p.window_start AND ul.created_at < (p.rollup_start_day::timestamp AT TIME ZONE 'Asia/Shanghai')) AS raw_prefloor_rows,
+    (SELECT count(*) FROM usage_logs ul, planned p WHERE ul.created_at >= p.today_start AND ul.created_at < p.now_ts) AS raw_today_rows_to_now,
+    (SELECT coalesce(sum(total_requests), 0) FROM usage_dashboard_model_daily d, planned p WHERE d.bucket_date > DATE '1970-01-01' AND d.bucket_date >= p.rollup_start_day AND d.bucket_date < p.today_day) AS model_daily_rollup_day_requests
+) t;"
+
+if should_explain raw_7d; then
+  echo "=== raw_7d_model_group_explain ==="
+  $PSQL -c "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+WITH bounds AS (
+  SELECT (((now() AT TIME ZONE 'Asia/Shanghai')::date - interval '6 days')::date)::timestamp AT TIME ZONE 'Asia/Shanghai' AS start_at,
+         now() AS end_at
+)
+SELECT
+  COALESCE(NULLIF(TRIM(ul.requested_model), ''), ul.model) AS model,
+  COUNT(*) AS requests,
+  COALESCE(SUM(ul.input_tokens), 0) AS input_tokens,
+  COALESCE(SUM(ul.output_tokens), 0) AS output_tokens,
+  COALESCE(SUM(ul.cache_creation_tokens), 0) AS cache_creation_tokens,
+  COALESCE(SUM(ul.cache_read_tokens), 0) AS cache_read_tokens,
+  COALESCE(SUM(ul.input_tokens + ul.output_tokens + ul.cache_creation_tokens + ul.cache_read_tokens), 0) AS total_tokens,
+  COALESCE(SUM(ul.total_cost), 0) AS total_cost,
+  COALESCE(SUM(ul.actual_cost), 0) AS actual_cost,
+  COALESCE(SUM(COALESCE(ul.account_stats_cost, ul.total_cost) * COALESCE(ul.account_rate_multiplier, 1)), 0) AS account_cost
+FROM usage_logs ul, bounds b
+WHERE ul.created_at >= b.start_at AND ul.created_at < b.end_at
+GROUP BY 1
+ORDER BY total_tokens DESC
+LIMIT 20;"
+fi
+
+if should_explain rollup_completed_days; then
+  echo "=== rollup_completed_days_explain ==="
+  $PSQL -c "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+  WITH bounds AS (
+    SELECT
+      ((now() AT TIME ZONE 'Asia/Shanghai')::date - interval '6 days')::date AS start_day,
+      (now() AT TIME ZONE 'Asia/Shanghai')::date AS today_day
+  ),
+  planned AS (
+    SELECT
+      bounds.*,
+      GREATEST(
+        bounds.start_day,
+        COALESCE((SELECT min(bucket_date) FROM usage_dashboard_model_daily WHERE bucket_date > DATE '1970-01-01'), bounds.today_day)
+      ) AS rollup_start_day
+    FROM bounds
+)
+SELECT
+  model,
+  COALESCE(SUM(total_requests), 0) AS requests,
+  COALESCE(SUM(input_tokens), 0) AS input_tokens,
+  COALESCE(SUM(output_tokens), 0) AS output_tokens,
+  COALESCE(SUM(cache_creation_tokens), 0) AS cache_creation_tokens,
+  COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+  COALESCE(SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens), 0) AS total_tokens,
+  COALESCE(SUM(total_cost), 0) AS total_cost,
+  COALESCE(SUM(actual_cost), 0) AS actual_cost,
+  COALESCE(SUM(account_cost), 0) AS account_cost
+FROM usage_dashboard_model_daily, planned
+WHERE bucket_date > DATE '1970-01-01'
+  AND bucket_date >= planned.rollup_start_day AND bucket_date < planned.today_day
+GROUP BY model
+ORDER BY total_tokens DESC
+LIMIT 20;"
+fi
+
+if should_explain raw_today; then
+  echo "=== raw_today_model_group_explain ==="
+  $PSQL -c "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+WITH bounds AS (
+  SELECT date_trunc('day', now() AT TIME ZONE 'Asia/Shanghai') AT TIME ZONE 'Asia/Shanghai' AS start_at,
+         now() AS end_at
+)
+SELECT
+  COALESCE(NULLIF(TRIM(ul.requested_model), ''), ul.model) AS model,
+  COUNT(*) AS requests,
+  COALESCE(SUM(ul.input_tokens), 0) AS input_tokens,
+  COALESCE(SUM(ul.output_tokens), 0) AS output_tokens,
+  COALESCE(SUM(ul.cache_creation_tokens), 0) AS cache_creation_tokens,
+  COALESCE(SUM(ul.cache_read_tokens), 0) AS cache_read_tokens,
+  COALESCE(SUM(ul.input_tokens + ul.output_tokens + ul.cache_creation_tokens + ul.cache_read_tokens), 0) AS total_tokens,
+  COALESCE(SUM(ul.total_cost), 0) AS total_cost,
+  COALESCE(SUM(ul.actual_cost), 0) AS actual_cost,
+  COALESCE(SUM(COALESCE(ul.account_stats_cost, ul.total_cost) * COALESCE(ul.account_rate_multiplier, 1)), 0) AS account_cost
+FROM usage_logs ul, bounds b
+WHERE ul.created_at >= b.start_at AND ul.created_at < b.end_at
+GROUP BY 1
+ORDER BY total_tokens DESC
+LIMIT 20;"
+fi
+
+echo "=== raw_vs_rollup_plus_today_delta ==="
+$PSQL -c "SELECT row_to_json(t) FROM (
+  WITH bounds AS (
+    SELECT
+      ((now() AT TIME ZONE 'Asia/Shanghai')::date - interval '6 days')::date AS start_day,
+      (now() AT TIME ZONE 'Asia/Shanghai')::date AS today_day,
+      (((now() AT TIME ZONE 'Asia/Shanghai')::date - interval '6 days')::date)::timestamp AT TIME ZONE 'Asia/Shanghai' AS start_ts,
+      ((now() AT TIME ZONE 'Asia/Shanghai')::date)::timestamp AT TIME ZONE 'Asia/Shanghai' AS today_ts,
+      now() AS now_ts
+  ),
+  planned AS (
+    SELECT
+      bounds.*,
+      GREATEST(
+        bounds.start_day,
+        COALESCE((SELECT min(bucket_date) FROM usage_dashboard_model_daily WHERE bucket_date > DATE '1970-01-01'), bounds.today_day)
+      ) AS rollup_start_day
+    FROM bounds
+  ),
+  raw AS (
+    SELECT
+      COALESCE(NULLIF(TRIM(ul.requested_model), ''), ul.model) AS model,
+      COUNT(*)::bigint AS requests,
+      COALESCE(SUM(ul.input_tokens + ul.output_tokens + ul.cache_creation_tokens + ul.cache_read_tokens), 0)::bigint AS total_tokens,
+      COALESCE(SUM(ul.actual_cost), 0)::numeric AS actual_cost
+    FROM usage_logs ul, planned b
+    WHERE ul.created_at >= b.start_ts AND ul.created_at < b.now_ts
+    GROUP BY 1
+  ),
+  raw_head AS (
+    SELECT
+      COALESCE(NULLIF(TRIM(ul.requested_model), ''), ul.model) AS model,
+      COUNT(*)::bigint AS requests,
+      COALESCE(SUM(ul.input_tokens + ul.output_tokens + ul.cache_creation_tokens + ul.cache_read_tokens), 0)::bigint AS total_tokens,
+      COALESCE(SUM(ul.actual_cost), 0)::numeric AS actual_cost
+    FROM usage_logs ul, planned b
+    WHERE ul.created_at >= b.start_ts AND ul.created_at < (b.rollup_start_day::timestamp AT TIME ZONE 'Asia/Shanghai')
+    GROUP BY 1
+  ),
+  rollup AS (
+    SELECT
+      d.model,
+      COALESCE(SUM(d.total_requests), 0)::bigint AS requests,
+      COALESCE(SUM(d.input_tokens + d.output_tokens + d.cache_creation_tokens + d.cache_read_tokens), 0)::bigint AS total_tokens,
+      COALESCE(SUM(d.actual_cost), 0)::numeric AS actual_cost
+    FROM usage_dashboard_model_daily d, planned b
+    WHERE d.bucket_date > DATE '1970-01-01'
+      AND d.bucket_date >= b.rollup_start_day AND d.bucket_date < b.today_day
+    GROUP BY d.model
+  ),
+  today AS (
+    SELECT
+      COALESCE(NULLIF(TRIM(ul.requested_model), ''), ul.model) AS model,
+      COUNT(*)::bigint AS requests,
+      COALESCE(SUM(ul.input_tokens + ul.output_tokens + ul.cache_creation_tokens + ul.cache_read_tokens), 0)::bigint AS total_tokens,
+      COALESCE(SUM(ul.actual_cost), 0)::numeric AS actual_cost
+    FROM usage_logs ul, planned b
+    WHERE ul.created_at >= b.today_ts AND ul.created_at < b.now_ts
+    GROUP BY 1
+  ),
+  fast_path AS (
+    SELECT
+      COALESCE(raw_head.model, rollup.model, today.model) AS model,
+      COALESCE(raw_head.requests, 0) + COALESCE(rollup.requests, 0) + COALESCE(today.requests, 0) AS requests,
+      COALESCE(raw_head.total_tokens, 0) + COALESCE(rollup.total_tokens, 0) + COALESCE(today.total_tokens, 0) AS total_tokens,
+      COALESCE(raw_head.actual_cost, 0) + COALESCE(rollup.actual_cost, 0) + COALESCE(today.actual_cost, 0) AS actual_cost
+    FROM raw_head
+    FULL OUTER JOIN rollup ON rollup.model = raw_head.model
+    FULL OUTER JOIN today ON today.model = COALESCE(raw_head.model, rollup.model)
+  ),
+  deltas AS (
+    SELECT
+      COALESCE(raw.model, fast_path.model) AS model,
+      COALESCE(raw.requests, 0) - COALESCE(fast_path.requests, 0) AS request_delta,
+      COALESCE(raw.total_tokens, 0) - COALESCE(fast_path.total_tokens, 0) AS token_delta,
+      COALESCE(raw.actual_cost, 0) - COALESCE(fast_path.actual_cost, 0) AS actual_cost_delta
+    FROM raw
+    FULL OUTER JOIN fast_path ON fast_path.model = raw.model
+  )
+  SELECT
+    COUNT(*) FILTER (
+      WHERE request_delta <> 0
+        OR token_delta <> 0
+        OR ABS(actual_cost_delta) > 0.0000001
+    ) AS changed_models,
+    COALESCE(SUM(ABS(request_delta)), 0) AS request_delta_sum,
+    COALESCE(SUM(ABS(token_delta)), 0) AS token_delta_sum,
+    COALESCE(SUM(ABS(actual_cost_delta)), 0) AS actual_cost_delta_sum,
+    COALESCE(MAX(abs(request_delta)), 0) AS max_abs_request_delta,
+    COALESCE(MAX(abs(token_delta)), 0) AS max_abs_token_delta
+  FROM deltas
+) t;"

--- a/ops/observability/probe-admin-ui-api-timing.sh
+++ b/ops/observability/probe-admin-ui-api-timing.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# probe-admin-ui-api-timing.sh — read-only local timing for selected admin APIs.
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-https://api.tokenkey.dev/api/v1}"
+HOST_HEADER="${HOST_HEADER:-}"
+PSQL="${PSQL:-docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t}"
+TIMEOUT="${TIMEOUT:-20}"
+
+ADMIN_KEY="$($PSQL -c "SELECT value FROM settings WHERE key='admin_api_key' LIMIT 1" 2>/dev/null | head -n1 || true)"
+if [ -z "$ADMIN_KEY" ]; then
+  echo '{"error":"admin_api_key_not_found"}'
+  exit 0
+fi
+
+python3 - "$BASE_URL" "$ADMIN_KEY" "$TIMEOUT" "$HOST_HEADER" <<'PY'
+import datetime as dt
+import json
+import subprocess
+import sys
+import time
+import urllib.parse
+from zoneinfo import ZoneInfo
+
+base, key, timeout_s, host_header = sys.argv[1:5]
+timeout = int(timeout_s)
+today = dt.datetime.now(ZoneInfo("Asia/Shanghai")).date()
+week_start = today - dt.timedelta(days=6)
+ui_default_start = today - dt.timedelta(days=1)
+
+def day(d):
+    return d.isoformat()
+
+def call(label, method, path, body=None):
+    url = base.rstrip("/") + path
+    cmd = [
+        "curl", "-sS", "-o", "/dev/null",
+        "-w", "http_code=%{http_code} namelookup=%{time_namelookup} connect=%{time_connect} ttfb=%{time_starttransfer} total=%{time_total} size=%{size_download}",
+        "--max-time", str(timeout),
+        "-k",
+        "-H", f"x-api-key: {key}",
+        "-H", "Content-Type: application/json",
+    ]
+    if host_header:
+        cmd += ["-H", f"Host: {host_header}"]
+    if method != "GET":
+        cmd += ["-X", method]
+    if body is not None:
+        cmd += ["--data", json.dumps(body, separators=(",", ":"))]
+    cmd.append(url)
+    start = time.time()
+    try:
+        cp = subprocess.run(cmd, text=True, capture_output=True, timeout=timeout + 2)
+        elapsed = time.time() - start
+        out = cp.stdout.strip()
+        parsed = {}
+        for part in out.split():
+            if "=" in part:
+                k, v = part.split("=", 1)
+                parsed[k] = v
+        return {
+            "label": label,
+            "method": method,
+            "path": path,
+            "exit_code": cp.returncode,
+            "elapsed_ms": round(elapsed * 1000),
+            "curl": parsed,
+            "stderr": cp.stderr.strip()[:300],
+        }
+    except subprocess.TimeoutExpired:
+        return {"label": label, "method": method, "path": path, "timeout": True}
+
+def q(params):
+    return "?" + urllib.parse.urlencode(params, doseq=True)
+
+# Keep this small: one probe per endpoint shape, no mutating calls.
+requests = [
+    ("dashboard.snapshot.7d.stats-only", "GET", "/admin/dashboard/snapshot-v2" + q({
+        "start_date": day(week_start),
+        "end_date": day(today),
+        "granularity": "day",
+        "include_stats": "true",
+        "include_trend": "false",
+        "include_model_stats": "false",
+        "include_group_stats": "false",
+        "include_users_trend": "false",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("dashboard.snapshot.7d.trend-only", "GET", "/admin/dashboard/snapshot-v2" + q({
+        "start_date": day(week_start),
+        "end_date": day(today),
+        "granularity": "day",
+        "include_stats": "false",
+        "include_trend": "true",
+        "include_model_stats": "false",
+        "include_group_stats": "false",
+        "include_users_trend": "false",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("dashboard.snapshot.7d.models-only", "GET", "/admin/dashboard/snapshot-v2" + q({
+        "start_date": day(week_start),
+        "end_date": day(today),
+        "granularity": "day",
+        "include_stats": "false",
+        "include_trend": "false",
+        "include_model_stats": "true",
+        "include_group_stats": "false",
+        "include_users_trend": "false",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("dashboard.snapshot.7d.charts-no-users", "GET", "/admin/dashboard/snapshot-v2" + q({
+        "start_date": day(week_start),
+        "end_date": day(today),
+        "granularity": "day",
+        "include_stats": "false",
+        "include_trend": "true",
+        "include_model_stats": "true",
+        "include_group_stats": "false",
+        "include_users_trend": "false",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("dashboard.snapshot.7d.full", "GET", "/admin/dashboard/snapshot-v2" + q({
+        "start_date": day(week_start),
+        "end_date": day(today),
+        "granularity": "day",
+        "include_stats": "true",
+        "include_trend": "true",
+        "include_model_stats": "true",
+        "include_group_stats": "false",
+        "include_users_trend": "true",
+        "users_trend_limit": "12",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("dashboard.snapshot.7d.users-trend-only", "GET", "/admin/dashboard/snapshot-v2" + q({
+        "start_date": day(week_start),
+        "end_date": day(today),
+        "granularity": "day",
+        "include_stats": "false",
+        "include_trend": "false",
+        "include_model_stats": "false",
+        "include_group_stats": "false",
+        "include_users_trend": "true",
+        "users_trend_limit": "12",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("dashboard.users-ranking.7d", "GET", "/admin/dashboard/users-ranking" + q({
+        "start_date": day(week_start),
+        "end_date": day(today),
+        "limit": "10",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("dashboard.models.7d", "GET", "/admin/dashboard/models" + q({
+        "start_date": day(week_start),
+        "end_date": day(today),
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("usage.list.default", "GET", "/admin/usage" + q({
+        "page": "1",
+        "page_size": "20",
+        "exact_total": "false",
+        "sort_by": "created_at",
+        "sort_order": "desc",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("usage.stats.default", "GET", "/admin/usage/stats" + q({
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("usage.stats.summary-only", "GET", "/admin/usage/stats" + q({
+        "include_endpoints": "0",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("usage.stats.summary-only.ui-default-range", "GET", "/admin/usage/stats" + q({
+        "start_date": day(ui_default_start),
+        "end_date": day(today),
+        "include_endpoints": "0",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("usage.stats.endpoints-only", "GET", "/admin/usage/stats" + q({
+        "include_summary": "0",
+        "include_endpoints": "1",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("usage.stats.endpoints-only.ui-default-range", "GET", "/admin/usage/stats" + q({
+        "start_date": day(ui_default_start),
+        "end_date": day(today),
+        "include_summary": "0",
+        "include_endpoints": "1",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("usage.chart.trend-only.7d", "GET", "/admin/dashboard/snapshot-v2" + q({
+        "start_date": day(week_start),
+        "end_date": day(today),
+        "granularity": "day",
+        "include_stats": "false",
+        "include_trend": "true",
+        "include_model_stats": "false",
+        "include_group_stats": "false",
+        "include_users_trend": "false",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("usage.chart.groups-only.7d", "GET", "/admin/dashboard/snapshot-v2" + q({
+        "start_date": day(week_start),
+        "end_date": day(today),
+        "granularity": "day",
+        "include_stats": "false",
+        "include_trend": "false",
+        "include_model_stats": "false",
+        "include_group_stats": "true",
+        "include_users_trend": "false",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("usage.chart.snapshot.7d", "GET", "/admin/dashboard/snapshot-v2" + q({
+        "start_date": day(week_start),
+        "end_date": day(today),
+        "granularity": "day",
+        "include_stats": "false",
+        "include_trend": "true",
+        "include_model_stats": "false",
+        "include_group_stats": "true",
+        "include_users_trend": "false",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("accounts.list.lite", "GET", "/admin/accounts" + q({
+        "page": "1",
+        "page_size": "20",
+        "lite": "1",
+        "sort_by": "id",
+        "sort_order": "desc",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("accounts.today-stats.batch.small", "POST", "/admin/accounts/today-stats/batch", {"account_ids":[1,2,3,4,5,6,7,8,9,10]}),
+    ("accounts.passive-usage.batch.small", "POST", "/admin/accounts/usage/batch", {"account_ids":[1,2,3,4,5,6,7,8,9,10]}),
+    ("groups.list", "GET", "/admin/groups" + q({
+        "page": "1",
+        "page_size": "20",
+        "sort_by": "sort_order",
+        "sort_order": "asc",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("groups.usage-summary", "GET", "/admin/groups/usage-summary" + q({
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("groups.capacity-summary", "GET", "/admin/groups/capacity-summary" + q({
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("edge-accounts", "GET", "/admin/edge-accounts" + q({
+        "platform": "all",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("users.list", "GET", "/admin/users" + q({
+        "page": "1",
+        "page_size": "20",
+        "sort_by": "id",
+        "sort_order": "desc",
+    }), None),
+    ("user-attributes.list", "GET", "/admin/user-attributes", None),
+    ("subscriptions.list", "GET", "/admin/subscriptions" + q({
+        "page": "1",
+        "page_size": "20",
+        "sort_by": "id",
+        "sort_order": "desc",
+    }), None),
+    ("channels.list", "GET", "/admin/channels" + q({
+        "page": "1",
+        "page_size": "20",
+        "sort_by": "id",
+        "sort_order": "desc",
+    }), None),
+    ("channel-types", "GET", "/admin/channel-types", None),
+    ("channel-monitors.list", "GET", "/admin/channel-monitors" + q({
+        "page": "1",
+        "page_size": "20",
+    }), None),
+    ("channel-monitor-templates.list", "GET", "/admin/channel-monitor-templates" + q({
+        "page": "1",
+        "page_size": "20",
+    }), None),
+    ("announcements.list", "GET", "/admin/announcements" + q({
+        "page": "1",
+        "page_size": "20",
+        "sort_by": "created_at",
+        "sort_order": "desc",
+    }), None),
+    ("proxies.list", "GET", "/admin/proxies" + q({
+        "page": "1",
+        "page_size": "20",
+        "sort_by": "id",
+        "sort_order": "desc",
+    }), None),
+    ("proxies.all", "GET", "/admin/proxies/all", None),
+    ("redeem-codes.list", "GET", "/admin/redeem-codes" + q({
+        "page": "1",
+        "page_size": "20",
+        "sort_by": "id",
+        "sort_order": "desc",
+    }), None),
+    ("redeem-codes.stats", "GET", "/admin/redeem-codes/stats", None),
+    ("promo-codes.list", "GET", "/admin/promo-codes" + q({
+        "page": "1",
+        "page_size": "20",
+        "sort_by": "id",
+        "sort_order": "desc",
+    }), None),
+    ("settings", "GET", "/admin/settings", None),
+    ("payment.config", "GET", "/admin/payment/config", None),
+    ("payment.dashboard.7d", "GET", "/admin/payment/dashboard" + q({
+        "days": "7",
+    }), None),
+    ("payment.orders.list", "GET", "/admin/payment/orders" + q({
+        "page": "1",
+        "page_size": "20",
+    }), None),
+    ("payment.plans", "GET", "/admin/payment/plans", None),
+    ("payment.providers", "GET", "/admin/payment/providers", None),
+    ("risk-control.config", "GET", "/admin/risk-control/config", None),
+    ("risk-control.status", "GET", "/admin/risk-control/status", None),
+    ("risk-control.logs", "GET", "/admin/risk-control/logs" + q({
+        "page": "1",
+        "page_size": "20",
+    }), None),
+    ("affiliates.users", "GET", "/admin/affiliates/users" + q({
+        "page": "1",
+        "page_size": "20",
+    }), None),
+    ("affiliates.invites", "GET", "/admin/affiliates/invites" + q({
+        "page": "1",
+        "page_size": "20",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("affiliates.rebates", "GET", "/admin/affiliates/rebates" + q({
+        "page": "1",
+        "page_size": "20",
+        "timezone": "Asia/Shanghai",
+    }), None),
+    ("ops.dashboard.snapshot.1h", "GET", "/admin/ops/dashboard/snapshot-v2" + q({
+        "time_range": "1h",
+        "mode": "auto",
+    }), None),
+    ("ops.concurrency", "GET", "/admin/ops/concurrency", None),
+    ("ops.account-availability", "GET", "/admin/ops/account-availability", None),
+    ("ops.realtime-traffic.5m", "GET", "/admin/ops/realtime-traffic" + q({
+        "window": "5m",
+    }), None),
+    ("ops.errors.list", "GET", "/admin/ops/errors" + q({
+        "page": "1",
+        "page_size": "20",
+        "time_range": "1h",
+    }), None),
+    ("ops.requests.list", "GET", "/admin/ops/requests" + q({
+        "page": "1",
+        "page_size": "20",
+        "time_range": "1h",
+    }), None),
+    ("ops.alert-rules", "GET", "/admin/ops/alert-rules", None),
+    ("ops.alert-events", "GET", "/admin/ops/alert-events" + q({
+        "page": "1",
+        "page_size": "20",
+    }), None),
+    ("ops.system-logs.health", "GET", "/admin/ops/system-logs/health", None),
+]
+
+results = [call(*req) for req in requests]
+
+def total_seconds(row):
+    try:
+        return float(row.get("curl", {}).get("total", "0") or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+top_slow = [
+    {
+        "label": row.get("label"),
+        "http_code": row.get("curl", {}).get("http_code"),
+        "ttfb": row.get("curl", {}).get("ttfb"),
+        "total": row.get("curl", {}).get("total"),
+        "size": row.get("curl", {}).get("size"),
+        "elapsed_ms": row.get("elapsed_ms"),
+    }
+    for row in sorted(results, key=total_seconds, reverse=True)[:12]
+]
+non_2xx = [
+    {
+        "label": row.get("label"),
+        "http_code": row.get("curl", {}).get("http_code"),
+        "total": row.get("curl", {}).get("total"),
+        "elapsed_ms": row.get("elapsed_ms"),
+        "stderr": row.get("stderr"),
+    }
+    for row in results
+    if not str(row.get("curl", {}).get("http_code", "")).startswith("2")
+]
+
+print(json.dumps({"top_slow": top_slow, "non_2xx": non_2xx, "results": results}, ensure_ascii=False, sort_keys=True))
+PY

--- a/ops/observability/probe-admin-ui-perf.sh
+++ b/ops/observability/probe-admin-ui-perf.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# probe-admin-ui-perf.sh — read-only admin UI/access latency aggregation.
+set -euo pipefail
+
+SINCE="${SINCE:-24h}"
+CONTAINER="${CONTAINER:-tokenkey}"
+TOP_LIMIT="${TOP_LIMIT:-80}"
+SLOW_LIMIT="${SLOW_LIMIT:-30}"
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+docker logs "$CONTAINER" --since "$SINCE" >"$tmp" 2>&1 || true
+
+python3 - "$tmp" "$SINCE" "$TOP_LIMIT" "$SLOW_LIMIT" "$CONTAINER" <<'PY'
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from urllib.parse import urlsplit
+
+log_path, since, top_limit_s, slow_limit_s, container = sys.argv[1:6]
+top_limit = int(top_limit_s)
+slow_limit = int(slow_limit_s)
+
+json_re = re.compile(r"\{.*\}")
+rows = []
+asset_rows = []
+
+def norm_path(path: str) -> str:
+    if not path:
+        return ""
+    path = urlsplit(path).path
+    if path.startswith("/api/v1/admin/edge-accounts/"):
+        parts = path.split("/")
+        if len(parts) >= 7:
+            parts[5] = ":edge"
+            if len(parts) >= 8 and parts[6] == "accounts":
+                parts[7] = ":account"
+            return "/".join(parts)
+    patterns = [
+        (r"/api/v1/admin/users/\d+/api-keys$", "/api/v1/admin/users/:id/api-keys"),
+        (r"/api/v1/admin/users/\d+/usage$", "/api/v1/admin/users/:id/usage"),
+        (r"/api/v1/admin/users/\d+/platform-quotas$", "/api/v1/admin/users/:id/platform-quotas"),
+        (r"/api/v1/admin/users/\d+/balance-history$", "/api/v1/admin/users/:id/balance-history"),
+        (r"/api/v1/admin/users/\d+$", "/api/v1/admin/users/:id"),
+        (r"/api/v1/admin/accounts/\d+/usage$", "/api/v1/admin/accounts/:id/usage"),
+        (r"/api/v1/admin/accounts/\d+/stats$", "/api/v1/admin/accounts/:id/stats"),
+        (r"/api/v1/admin/accounts/\d+/quota$", "/api/v1/admin/accounts/:id/quota"),
+        (r"/api/v1/admin/accounts/\d+$", "/api/v1/admin/accounts/:id"),
+        (r"/api/v1/admin/groups/\d+/api-keys$", "/api/v1/admin/groups/:id/api-keys"),
+        (r"/api/v1/admin/groups/\d+/stats$", "/api/v1/admin/groups/:id/stats"),
+        (r"/api/v1/admin/groups/\d+/models-list-candidates$", "/api/v1/admin/groups/:id/models-list-candidates"),
+        (r"/api/v1/admin/groups/\d+$", "/api/v1/admin/groups/:id"),
+        (r"/api/v1/admin/proxies/\d+/accounts$", "/api/v1/admin/proxies/:id/accounts"),
+        (r"/api/v1/admin/proxies/\d+/stats$", "/api/v1/admin/proxies/:id/stats"),
+        (r"/api/v1/admin/proxies/\d+$", "/api/v1/admin/proxies/:id"),
+        (r"/api/v1/admin/redeem-codes/\d+/stats$", "/api/v1/admin/redeem-codes/:id/stats"),
+        (r"/api/v1/admin/redeem-codes/\d+$", "/api/v1/admin/redeem-codes/:id"),
+        (r"/api/v1/admin/subscriptions/\d+/progress$", "/api/v1/admin/subscriptions/:id/progress"),
+        (r"/api/v1/admin/subscriptions/\d+$", "/api/v1/admin/subscriptions/:id"),
+        (r"/api/v1/admin/channels/\d+$", "/api/v1/admin/channels/:id"),
+        (r"/api/v1/admin/channel-monitors/\d+/history$", "/api/v1/admin/channel-monitors/:id/history"),
+        (r"/api/v1/admin/channel-monitors/\d+$", "/api/v1/admin/channel-monitors/:id"),
+        (r"/api/v1/admin/channel-monitor-templates/\d+/monitors$", "/api/v1/admin/channel-monitor-templates/:id/monitors"),
+        (r"/api/v1/admin/channel-monitor-templates/\d+$", "/api/v1/admin/channel-monitor-templates/:id"),
+        (r"/api/v1/admin/payment/orders/\d+$", "/api/v1/admin/payment/orders/:id"),
+    ]
+    for pat, repl in patterns:
+        if re.fullmatch(pat, path):
+            return repl
+    return path
+
+def percentile(vals, pct):
+    if not vals:
+        return None
+    vals = sorted(vals)
+    idx = int(round((pct / 100) * (len(vals) - 1)))
+    return vals[idx]
+
+with open(log_path, "r", errors="replace") as f:
+    for line in f:
+        if "http request completed" not in line:
+            continue
+        m = json_re.search(line)
+        if not m:
+            continue
+        try:
+            obj = json.loads(m.group(0))
+        except Exception:
+            continue
+        path = obj.get("path") or ""
+        if not isinstance(path, str):
+            continue
+        lat = obj.get("latency_ms")
+        status = obj.get("status_code")
+        if not isinstance(lat, (int, float)) or not isinstance(status, int):
+            continue
+        rec = {
+            "completed_at": obj.get("completed_at"),
+            "request_id": obj.get("request_id"),
+            "method": obj.get("method"),
+            "path": path,
+            "endpoint": norm_path(path),
+            "status_code": status,
+            "latency_ms": int(lat),
+        }
+        if path.startswith("/api/v1/admin"):
+            rows.append(rec)
+        elif path.startswith("/admin") or path.startswith("/assets/") or path in ("/", "/favicon.ico"):
+            asset_rows.append(rec)
+
+def aggregate(items):
+    by_ep = defaultdict(list)
+    by_status = Counter()
+    for r in items:
+        by_ep[(r["method"], r["endpoint"])].append(r)
+        by_status[str(r["status_code"])] += 1
+    out = []
+    for (method, endpoint), rs in by_ep.items():
+        vals = [r["latency_ms"] for r in rs]
+        statuses = Counter(str(r["status_code"]) for r in rs)
+        out.append({
+            "method": method,
+            "endpoint": endpoint,
+            "count": len(rs),
+            "status_counts": dict(sorted(statuses.items())),
+            "p50_ms": percentile(vals, 50),
+            "p90_ms": percentile(vals, 90),
+            "p95_ms": percentile(vals, 95),
+            "p99_ms": percentile(vals, 99),
+            "max_ms": max(vals),
+        })
+    out.sort(key=lambda x: (x["p95_ms"] or 0, x["max_ms"] or 0, x["count"]), reverse=True)
+    return out, dict(sorted(by_status.items()))
+
+admin_agg, admin_status = aggregate(rows)
+asset_agg, asset_status = aggregate(asset_rows)
+slow = sorted(rows, key=lambda r: r["latency_ms"], reverse=True)[:slow_limit]
+slow_assets = sorted(asset_rows, key=lambda r: r["latency_ms"], reverse=True)[:slow_limit]
+
+print(json.dumps({
+    "meta": {
+        "container": container,
+        "since": since,
+        "admin_rows": len(rows),
+        "frontend_rows": len(asset_rows),
+        "top_limit": top_limit,
+        "slow_limit": slow_limit,
+    },
+    "admin_status_counts": admin_status,
+    "frontend_status_counts": asset_status,
+    "admin_by_endpoint_top": admin_agg[:top_limit],
+    "frontend_by_path_top": asset_agg[:40],
+    "slow_admin_samples": slow,
+    "slow_frontend_samples": slow_assets,
+}, ensure_ascii=False, sort_keys=True))
+PY

--- a/scripts/checks/frontend-release-assets.py
+++ b/scripts/checks/frontend-release-assets.py
@@ -62,6 +62,18 @@ def account_assets_from_vite_entry(entry_js: str) -> list[str]:
     return seen
 
 
+def js_asset_paths_from_vite_asset(asset: str) -> list[str]:
+    """Resolve JS chunk paths embedded in a Vite chunk's dependency map/imports."""
+    names = re.findall(r'assets/([^"\'\\]+\.js)', asset)
+    names.extend(re.findall(r'from"\./([^"\'\\]+\.js)"', asset))
+    seen: list[str] = []
+    for name in names:
+        path = "/assets/" + name
+        if path not in seen:
+            seen.append(path)
+    return seen
+
+
 def asset_has_account_create_mount(asset: str) -> bool:
     """Content fingerprint of the chunk that carries the account create-mode NewAPI
     field mount, independent of the chunk's filename (rename-proof)."""
@@ -103,20 +115,6 @@ def check_account_asset(asset: str, source: str) -> list[str]:
     if missing:
         errors.append(f"{source}: create-mode Extension Engine field mount is missing props: {', '.join(missing)}")
 
-    required_labels = [
-        "newApiPlatform.channelType",
-        "newApiPlatform.baseUrl",
-        "newApiPlatform.apiKey",
-    ]
-    label_positions = {label: asset.find(label) for label in required_labels}
-    missing_labels = [label for label, idx in label_positions.items() if idx < 0]
-    if missing_labels:
-        errors.append(f"{source}: shared NewAPI field component is missing labels: {', '.join(missing_labels)}")
-
-    ordered_labels = [label_positions[label] for label in required_labels]
-    if all(idx >= 0 for idx in ordered_labels) and ordered_labels != sorted(ordered_labels):
-        errors.append(f"{source}: shared NewAPI channel/base-url/api-key labels are out of order")
-
     account_type_idx = asset.find("admin.accounts.accountType", platform_idx)
     if account_type_idx >= 0 and account_type_idx < create_mount_idx:
         errors.append(f"{source}: account-type block appears before create-mode Extension Engine field mount")
@@ -133,6 +131,24 @@ def check_account_asset(asset: str, source: str) -> list[str]:
     return errors
 
 
+REQUIRED_NEWAPI_LABELS = [
+    "newApiPlatform.channelType",
+    "newApiPlatform.baseUrl",
+    "newApiPlatform.apiKey",
+]
+
+
+def check_newapi_labels(asset: str, source: str) -> list[str]:
+    label_positions = {label: asset.find(label) for label in REQUIRED_NEWAPI_LABELS}
+    if not all(idx >= 0 for idx in label_positions.values()):
+        return []
+
+    ordered_labels = [label_positions[label] for label in REQUIRED_NEWAPI_LABELS]
+    if ordered_labels != sorted(ordered_labels):
+        return [f"{source}: shared NewAPI channel/base-url/api-key labels are out of order"]
+    return []
+
+
 def check_dist(dist: Path) -> list[str]:
     # Rename-proof: scan every JS chunk and validate the one(s) that carry the
     # account create-mode NewAPI field mount, identified by content rather than by
@@ -140,18 +156,29 @@ def check_dist(dist: Path) -> list[str]:
     # breaking again the next time frontend/vite.config.ts reshuffles manualChunks.
     errors: list[str] = []
     checked = 0
-    for path in sorted((dist / "assets").glob("*.js")):
-        asset = read_file(path)
+    labels_checked = 0
+    all_js_assets = [(path, read_file(path)) for path in sorted((dist / "assets").glob("*.js"))]
+    for path, asset in all_js_assets:
         if not asset_has_account_create_mount(asset):
             continue
         checked += 1
         errors.extend(check_account_asset(asset, str(path)))
 
+    for path, asset in all_js_assets:
+        if not all(label in asset for label in REQUIRED_NEWAPI_LABELS):
+            continue
+        labels_checked += 1
+        errors.extend(check_newapi_labels(asset, str(path)))
+
     if checked == 0:
-        return [
+        errors.extend([
             f"{dist}: no JS chunk carries the admin account create-mode Extension Engine "
             f"field mount (variant:\"create\" + channel-type-options)"
-        ]
+        ])
+    if labels_checked == 0:
+        errors.append(
+            f"{dist}: no JS chunk carries the shared NewAPI field labels: {', '.join(REQUIRED_NEWAPI_LABELS)}"
+        )
     return errors
 
 
@@ -173,15 +200,35 @@ def check_url(base_url: str) -> list[str]:
             return [f"{base}: Vite entry {entry_rel} does not reference an AccountsView chunk"]
 
     errors: list[str] = []
+    account_asset = ""
+    account_asset_path = ""
     for asset_path in assets:
         asset_url = urljoin(base, asset_path.lstrip("/"))
         asset = read_url(asset_url)
         if not asset_has_account_create_mount(asset):
             continue
+        account_asset = asset
+        account_asset_path = asset_path
         errors.extend(check_account_asset(asset, asset_url))
+        break
+
+    if not account_asset:
+        errors.append(f"{base}: referenced account-modal assets do not contain the Extension Engine/newapi create-mode field mount")
         return errors
 
-    errors.append(f"{base}: referenced account-modal assets do not contain the Extension Engine/newapi create-mode field mount")
+    label_errors = check_newapi_labels(account_asset, urljoin(base, account_asset_path.lstrip("/")))
+    if not label_errors and all(label in account_asset for label in REQUIRED_NEWAPI_LABELS):
+        return errors
+
+    for dep_path in js_asset_paths_from_vite_asset(account_asset):
+        dep_url = urljoin(base, dep_path.lstrip("/"))
+        dep_asset = read_url(dep_url)
+        if not all(label in dep_asset for label in REQUIRED_NEWAPI_LABELS):
+            continue
+        errors.extend(check_newapi_labels(dep_asset, dep_url))
+        return errors
+
+    errors.append(f"{base}: no account-modal dependency carries the shared NewAPI field labels: {', '.join(REQUIRED_NEWAPI_LABELS)}")
     return errors
 
 

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -598,9 +598,12 @@
     {
       "path": "frontend/src/components/account/usage-cells/useAccountUsageFetch.ts",
       "must_contain": [
-        "if (props.usageOverride !== undefined) return false"
+        "function canFetchUsageForAccount(props: AccountUsageCellProps): boolean",
+        "function shouldAutoFetchUsageForAccount(props: AccountUsageCellProps): boolean",
+        "if (props.usageOverride !== undefined) return false",
+        "if (props.usageOverride !== undefined && isAnthropicOAuthOrSetupToken.value) return"
       ],
-      "rationale": "TK injection point (fetch short-circuit): when usageOverride is provided (even null), skip self-fetch and render injected usage verbatim. Split from AccountUsageCell.vue (B6 perf) — dropping this guard would re-enable per-row /usage fetches on Edge Accounts overview and hammer prod for non-existent ids."
+      "rationale": "TK injection point (fetch short-circuit): when usageOverride is provided (even null), skip mount/lazy self-fetch and render injected usage verbatim. The explicit manual-refresh guard prevents Anthropic OAuth/SetupToken rows owned by the list batch loader from falling back to per-row /usage after a refresh token bump. Split from AccountUsageCell.vue (B6 perf) — dropping these guards would re-enable per-row /usage fetches on Edge Accounts overview or the admin accounts list and hammer prod."
     },
     {
       "path": "frontend/src/components/layout/AppSidebar.vue",
@@ -968,18 +971,24 @@
       "must_contain": [
         "export function useTkAccountUsageBatch(",
         "getBatchPassiveUsage(",
-        "isBatchPassiveCapable"
+        "isBatchPassiveCapable",
+        "function canSelfFetchUsage(account: Account): boolean",
+        "function usageOverrideFor(account: Account): AccountUsageInfo | null | undefined",
+        "return key in usageByAccountId.value ? usageByAccountId.value[key] : null"
       ],
-      "rationale": "TK composable that batches Anthropic OAuth/SetupToken passive usage for the admin accounts list and exposes a per-row usageOverride (defined => the cell never self-fetches). Owns the batch API call + race guard + the platform scoping (only anthropic oauth/setup-token). If deleted, the accounts list regresses to per-row /usage XHRs. Pins the composable, the batch API call, and the scoping predicate."
+      "rationale": "TK composable that batches Anthropic OAuth/SetupToken passive usage for the admin accounts list and exposes a per-row usageOverride (defined => the cell never self-fetches). Owns the batch API call + race guard + platform scoping; canSelfFetchUsage deliberately returns null overrides for active-only fetchable platforms until explicit user refresh, suppressing the historical mount-time N parallel /usage XHRs. If deleted or narrowed back to passive-only rows, the accounts list regresses to per-row /usage XHRs. Pins the composable, the batch API call, the scoping predicate, the list-owned override function, and the present-with-null sentinel."
     },
     {
       "path": "frontend/src/views/admin/AccountsView.vue",
       "must_contain": [
         "useTkAccountUsageBatch",
         ":usage-override=\"accountUsageOverrideFor(row)\"",
-        "refreshUsageBatch(accounts.value)"
+        "const refreshAccountRowMetrics = () => {",
+        "refreshTodayStatsBatch().catch(",
+        "refreshUsageBatch(rows).catch(",
+        "refreshAccountRowMetrics()"
       ],
-      "rationale": "Injection points where the upstream-shaped accounts list wires the batch passive-usage composable: the cell usage-override binding (suppresses per-row self-fetch) and the refreshUsageBatch calls after each list load. An upstream merge re-resolving AccountsView could drop the override binding (cells fall back to N self-fetches) or the refresh calls (overrides never populate). Pins the import, the cell binding, and the refresh call."
+      "rationale": "Injection points where the upstream-shaped accounts list wires the batch passive-usage composable: the cell usage-override binding (suppresses per-row self-fetch) and the refreshAccountRowMetrics helper that kicks today-stats and usage-batch loading after list load/reload/auto-refresh without serializing those background requests on the main list response. An upstream merge re-resolving AccountsView could drop the override binding (cells fall back to N self-fetches), restore serialized row metrics, or stop refreshing overrides after list changes. Pins the import, the cell binding, and the concurrent row-metric refresh helper/calls."
     },
     {
       "path": "frontend/src/api/admin/accounts.ts",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3123,24 +3123,76 @@
       "rationale": "TK feeder that populates the per-(user, platform, day) rollup table (tk_034) backing the admin Users page + dashboard spending-ranking widget. This is the write half of the perf fix that replaced the full 30-day usage_logs scan (845K buffers / 2.7s on prod) with pre-aggregated reads. The effective-platform projection reuses the live queries' usageLogEffectivePlatformExpr (same package) so the rollup partitions by exactly the platform the page shows; this sentinel pins the upsert, the target table, and that the platform projection reuses the shared expression so an upstream merge / refactor cannot silently drop the feeder or drift the platform grain."
     },
     {
+      "path": "backend/internal/repository/dashboard_aggregation_repo_tk_group.go",
+      "must_contain": [
+        "func (r *dashboardAggregationRepository) upsertGroupDailyAggregates(",
+        "INSERT INTO usage_dashboard_group_daily",
+        "COALESCE(ul.group_id, 0) AS group_id",
+        "COALESCE(SUM(ul.input_tokens), 0) AS input_tokens",
+        "COALESCE(SUM(COALESCE(ul.account_stats_cost, ul.total_cost) * COALESCE(ul.account_rate_multiplier, 1)), 0) AS account_cost",
+        "func (r *dashboardAggregationRepository) backfillGroupDailyMetricsAllOnce"
+      ],
+      "rationale": "TK feeder for the per-(group, day) rollup now backing both Groups usage-summary and Dashboard/Usage group distribution. It must write full requests/token/cost metrics, not just actual_cost, and must run a metrics backfill marker for deployments whose old tk_038 table was cost-only. Dropping this silently leaves group distribution on the slow raw usage_logs scan or, worse, historical requests/tokens at zero."
+    },
+    {
+      "path": "backend/internal/repository/usage_log_repo_tk_group_rollup.go",
+      "must_contain": [
+        "func (r *usageLogRepository) getGroupStatsFromRollup(",
+        "func (r *usageLogRepository) groupDailyMetricsBackfilled(",
+        "FROM usage_dashboard_group_daily gd",
+        "WHERE gd.bucket_date > DATE '",
+        "win.rawSpans"
+      ],
+      "rationale": "TK read path for Dashboard/Usage group distribution: completed server-TZ days come from usage_dashboard_group_daily metrics, raw head/tail spans come from usage_logs, and the metrics-backfill marker prevents old cost-only rows from being trusted. Anchors the fast path and correctness gate so group distribution cannot silently regress to the 0.9s raw scan or zero historical tokens."
+    },
+    {
       "path": "backend/internal/repository/dashboard_aggregation_repo.go",
       "must_contain": [
         "if err := r.upsertUserPlatformDailyAggregates(ctx, dayStart, dayEnd); err != nil {",
+        "if err := r.backfillGroupDailyMetricsAllOnce(ctx); err != nil {",
+        "if err := r.upsertGroupDailyAggregates(ctx, dayStart, dayEnd); err != nil {",
         "if err := r.deleteUserPlatformDailyRange(ctx, dayStart, dayEnd); err != nil {",
+        "if err := r.deleteGroupDailyRange(ctx, dayStart, dayEnd); err != nil {",
         "if err := r.cleanupUserPlatformDaily(ctx, dailyCutoffUTC); err != nil {"
       ],
-      "rationale": "Thin injection of the per-(user, platform, day) rollup feeder into the upstream-shaped aggregation repo: the upsert call lives in both aggregateRangeInTx and recomputeRangeInTx, the range delete in recomputeRangeInTx (so a zeroed day does not linger after a usage_logs rollback), and the retention prune in CleanupAggregates. These are single-line hooks into upstream-shaped functions; an upstream merge resolving DashboardAggregationService could silently drop them, leaving the rollup unpopulated and the admin pages reading stale/empty history. Pins all three call sites."
+      "rationale": "Thin injection of TK rollup feeders into the upstream-shaped aggregation repo: user-platform and group daily upsert calls live in both aggregateRangeInTx and recomputeRangeInTx, range deletes prevent stale rows after recompute, user-platform retention prune follows the daily cutoff, and group metrics backfill runs before group distribution trusts the extended table. These are single-line hooks into upstream-shaped functions; an upstream merge resolving DashboardAggregationService could silently drop them, leaving rollups unpopulated and admin pages reading stale/empty history or raw-scanning again."
     },
     {
       "path": "backend/internal/repository/usage_log_repo_tk_user_platform_rollup.go",
       "must_contain": [
         "func (r *usageLogRepository) getBatchUserUsageStatsRollup(",
         "func (r *usageLogRepository) getUserSpendingRankingRollup(",
+        "func (r *usageLogRepository) getUserUsageTrendRollup(",
         "func planUsageRollupWindow(",
         "func (r *usageLogRepository) userPlatformRollupFloorDay(",
-        "FROM usage_dashboard_user_platform_daily"
+        "FROM usage_dashboard_user_platform_daily",
+        "COALESCE(SUM(actual_cost), 0)"
       ],
-      "rationale": "TK read half of the rollup perf fix: GetBatchUserUsageStats and GetUserSpendingRanking are served from usage_dashboard_user_platform_daily for completed days plus raw usage_logs for the partial/today slices. planUsageRollupWindow is the exact-semantics window decomposition (full completed server-TZ days from the rollup, partial head/tail + today from raw) that keeps output byte-identical to the legacy raw-scan queries. userPlatformRollupFloorDay is the coverage floor that routes completed days the rollup does not yet cover (post-migration cold start, where the shared aggregation watermark won't backfill old days) back to raw usage_logs, so the page never silently undercounts history. Pins both read entry points, the decomposition function (loose prefix — signature evolves), the coverage-floor helper, and the rollup table read so a merge cannot silently revert the pages to the slow full-window scan or drop the cold-start fallback."
+      "rationale": "TK read half of the rollup perf fix: GetBatchUserUsageStats, GetUserSpendingRanking, and dashboard user-usage trend are served from usage_dashboard_user_platform_daily for completed days plus raw usage_logs for the partial/today slices. planUsageRollupWindow is the exact-semantics window decomposition (full completed server-TZ days from the rollup, partial head/tail + today from raw) that keeps output byte-identical to the legacy raw-scan queries. userPlatformRollupFloorDay is the coverage floor that routes completed days the rollup does not yet cover (post-migration cold start, where the shared aggregation watermark won't backfill old days) back to raw usage_logs, so the page never silently undercounts history. The table column is actual_cost, not total_cost; pinning actual_cost catches the prod 500 class where a drifted trend query references the wrong rollup column. Pins the read entry points, the decomposition function (loose prefix), the coverage-floor helper, and the rollup table read so a merge cannot silently revert the pages to the slow full-window scan or drop the cold-start fallback."
+    },
+    {
+      "path": "backend/internal/repository/usage_log_repo_tk_model_rollup.go",
+      "must_contain": [
+        "func shouldUseModelDailyRollup(",
+        "func (r *usageLogRepository) modelDailyBackfilled(",
+        "func (r *usageLogRepository) getModelStatsFromRollup(",
+        "FROM usage_dashboard_model_daily",
+        "modelDailyBackfillMarkerDate",
+        "COALESCE(NULLIF(TRIM(requested_model), ''), model) AS model",
+        "GROUP BY 1"
+      ],
+      "rationale": "Dashboard model distribution uses completed-day usage_dashboard_model_daily plus raw head/tail spans only after a one-time historical backfill marker is present; without that marker prod can have partial/stale rows from the forward-only aggregation watermark and the read path must fall back to raw logs. The raw tail intentionally groups by SELECT ordinal (GROUP BY 1) because the expression is aliased to model while usage_logs also has a model column; GROUP BY model resolves to the input column and breaks the requested_model fallback expression on Postgres, causing the rollup path to error and fall back to a slow full raw scan. Pins the rollup entry point, the marker gate, the daily table, the requested_model fallback expression, and the GROUP BY 1 fix."
+    },
+    {
+      "path": "backend/internal/repository/usage_log_repo_tk_stats_rollup.go",
+      "must_contain": [
+        "func shouldUseUsageStatsHourlyRollup(",
+        "func (r *usageLogRepository) getStatsWithFiltersFromHourlyRollup(",
+        "SELECT last_aggregated_at FROM usage_dashboard_aggregation_watermark WHERE id = 1",
+        "FROM usage_dashboard_hourly",
+        "addUsageStatsRawSpan(ctx, agg, rollupEnd, end)"
+      ],
+      "rationale": "Admin Usage summary default stats are served from usage_dashboard_hourly for complete hours, capped by the shared aggregation watermark, with raw head/tail spans for partial hours. This avoids the first-screen /admin/usage/stats raw full-window scan while preserving exact semantics for the unfiltered summary path. Pins the eligibility gate, the read entry point, the watermark cap, the hourly table read, and the raw-tail merge."
     },
     {
       "path": "backend/internal/repository/usage_log_repo.go",

--- a/scripts/sentinels/perf-query-shape.json
+++ b/scripts/sentinels/perf-query-shape.json
@@ -13,25 +13,40 @@
     {
       "path": "backend/internal/repository/usage_log_repo.go",
       "must_contain": [
-        "groupUsageSummaryFromRollup"
+        "groupUsageSummaryFromRollup",
+        "getGroupStatsFromRollup"
       ],
-      "rationale": "GetAllGroupUsageSummary feeds the admin Groups page usage-summary on every load. It MUST route through groupUsageSummaryFromRollup (the per-(group,day) rollup, completed days from usage_dashboard_group_daily + today from raw) before falling back to the legacy `groups g LEFT JOIN usage_logs ul ... SUM(actual_cost)` un-time-bounded full-table scan. An upstream merge or a 'simplify' refactor that drops the rollup call silently restores the full 2.4M-row scan on every GroupsView load with all tests green (the fallback returns identical numbers). This sentinel is the only mechanical guard. See usage_log_repo_tk_group_rollup.go."
+      "rationale": "GetAllGroupUsageSummary feeds the admin Groups page usage-summary on every load, and GetGroupStatsWithFilters feeds Dashboard/Usage group distribution. They MUST route through usage_dashboard_group_daily rollup helpers before falling back to raw usage_logs scans: groupUsageSummaryFromRollup for all-time cost summary, getGroupStatsFromRollup for completed-day requests/tokens/cost distribution plus raw head/tail. Dropping either call silently restores a 2.4M-row or wide-window scan with byte-identical results and green tests, so this sentinel is the mechanical guard."
     },
     {
       "path": "backend/internal/repository/usage_log_repo_tk_group_rollup.go",
       "must_contain": [
         "WHERE group_id > 0 AND bucket_date < $1::date",
-        "FILTER (WHERE created_at >= $2)"
+        "FILTER (WHERE created_at >= $2)",
+        "func (r *usageLogRepository) getGroupStatsFromRollup(",
+        "FROM usage_dashboard_group_daily gd",
+        "WHERE gd.bucket_date > DATE '",
+        "func (r *usageLogRepository) groupDailyMetricsBackfilled("
       ],
-      "rationale": "groupUsageSummaryFromRollup's exact rollup/raw decomposition: total_cost = SUM(rollup completed days, bucket_date < server-today) + SUM(raw remainder, created_at >= server-today); today_cost = SUM(raw, created_at >= user-today). Each usage_logs row is counted exactly once toward total_cost. A refactor that drops the `bucket_date < today` rollup bound or the `created_at >= $2` raw-remainder split would double-count or miss the today/history boundary — a SILENT correctness regression on a financial figure that a small test fixture may not surface. These anchors pin the load-bearing shape."
+      "rationale": "groupUsageSummaryFromRollup's exact rollup/raw decomposition: total_cost = SUM(rollup completed days, bucket_date < server-today) + SUM(raw remainder, created_at >= server-today); today_cost = SUM(raw, created_at >= user-today). getGroupStatsFromRollup is the Dashboard/Usage group-distribution twin: it uses completed-day usage_dashboard_group_daily metrics plus raw head/tail spans, gated by groupDailyMetricsBackfilled so old cost-only rows are never trusted for requests/tokens. A refactor that drops the bounds, raw split, or metrics-backfill gate would double-count/miss rows or silently return zero historical tokens."
     },
     {
       "path": "backend/internal/repository/dashboard_aggregation_repo_tk_group.go",
       "must_contain": [
         "backfillGroupDailyAllOnce",
+        "backfillGroupDailyMetricsAllOnce",
         "usage_dashboard_group_daily"
       ],
-      "rationale": "The per-(group,day) rollup feeder + one-time historical backfill. backfillGroupDailyAllOnce is REQUIRED: the watermark-driven incremental feeder only moves forward and never backfills pre-deploy days, so without the guarded one-time backfill the all-time Groups total would permanently exclude historical cost (or force the read path to keep raw-scanning the whole table). A refactor that removes the backfill or the upsertGroupDailyAggregates feeder breaks the rollup silently — the read path then falls back to the slow full scan with identical numbers."
+      "rationale": "The per-(group,day) rollup feeder + one-time historical backfills. backfillGroupDailyAllOnce is REQUIRED for the all-time Groups cost summary; backfillGroupDailyMetricsAllOnce is REQUIRED for deployments that already had the old cost-only table before requests/tokens/account-cost columns were added. The watermark-driven incremental feeder only moves forward and never backfills pre-deploy days, so removing either backfill permanently undercounts or forces slow raw scans. A refactor that removes the backfill or the upsertGroupDailyAggregates feeder breaks the rollup silently."
+    },
+    {
+      "path": "backend/migrations/tk_046_usage_dashboard_group_daily_metrics.sql",
+      "must_contain": [
+        "ALTER TABLE usage_dashboard_group_daily",
+        "ADD COLUMN IF NOT EXISTS total_requests",
+        "ADD COLUMN IF NOT EXISTS account_cost"
+      ],
+      "rationale": "Schema bridge for old deployments that already ran tk_038 with actual_cost only. Dashboard/Usage group distribution needs requests, tokens, total_cost and account_cost; without tk_046 the Go feeder/read path cannot use usage_dashboard_group_daily safely after rollout. Pins the additive migration so the performance fix is deployable on prod, not just fresh databases."
     },
     {
       "path": "backend/internal/service/ops_cleanup_executor.go",


### PR DESCRIPTION
## 摘要

优化 prod admin UI 的主要慢路径：dashboard、usage、accounts。

- Dashboard 首屏先加载 stats，再延迟并拆分 trend/model/group/users-trend/ranking，避免最慢聚合阻塞首屏。
- Usage 页面拆分 summary 与 endpoint stats，endpoint 分布图进入视口后再拉取。
- Accounts 页面用 `/admin/accounts/usage/batch` 替代可见行逐个自取 passive usage，降低 N+1 请求。
- 后端增加 usage hourly summary、model daily、group daily metrics 等 rollup-backed read path，并用 marker/coverage floor 防止部分回填导致低估。
- Vite preload 策略避免 admin 大页面和 chart chunk 被首屏提前预加载。
- 新增只读 prod 探针，覆盖 admin API timing、access-log latency profile、rollup coverage。
- 审批锚点补充了 2026-06-23 12:57-12:59 UTC prod pre-deploy 基线，便于 post-deploy 对比。

## 风险

这是高风险变更：包含 additive migration，并影响 admin dashboard/usage/accounts 的读路径。审批锚点为 `docs/approved/admin-ui-performance-rollups.md`，当前 `status: pending`，需要人工确认后再进入 prod 发布。

迁移是 additive：`tk_046_usage_dashboard_group_daily_metrics.sql` 只给既有 `usage_dashboard_group_daily` 增加 metrics 列；`tk_038` 同步 fresh DB schema。读路径在 marker 未就绪时保留 raw fallback。

## 验证

已通过：

- `pnpm build`
- `python3 scripts/checks/frontend-release-assets.py --dist backend/internal/web/dist`
- focused frontend vitest：AccountUsageCell、useTkAccountUsageBatch、AccountsView、DashboardView、UsageView
- focused backend unit tests：usage stats、dashboard cache、model/group rollup、users-trend
- repository integration subset：migration idempotency、model/group rollup parity
- `bash -n` for new probes
- `scripts/preflight.sh` via commit hook，PASS

线上只读探针确认 prod 当前慢点集中在 `usage.stats`、dashboard model/group/users-trend、accounts usage N+1；本 PR 覆盖这些路径。pre-deploy 基线已写入审批锚点：

- dashboard users-trend/full 当前返回 500
- `usage.stats.summary-only.ui-default-range` 约 3.93s
- dashboard models-only 约 2.31s，groups-only chart 约 1.89s
- 24h 内 `/admin/accounts/:id/usage` 496 次，p50 352ms，p95 719ms
- model/group rollup marker 当前未就绪，group daily metrics migration 尚未部署

prod 尚未部署，部署后需要跑：

- `ops/observability/probe-admin-aggregation-config.sh`
- `ops/observability/probe-admin-ui-api-timing.sh`
- `ops/observability/probe-admin-ui-perf.sh`

## 提交

- `afe73d621 docs(admin): add admin UI performance approval anchor`
- `50ab8f813 fix(admin): optimize admin UI performance`
- `ed2e16f95 docs(admin): record prod performance baseline`

最新提交：`ed2e16f95`
