### PR TITLE
chore(kiro): shorten edge reauth workflow

### DIFF
--- a/.cursor/skills/tokenkey-kiro-reauth/SKILL.md
+++ b/.cursor/skills/tokenkey-kiro-reauth/SKILL.md
@@ -20,17 +20,43 @@ mechanical steps:
 - `.cursor/skills/tokenkey-kiro-reauth/scripts/probe_edge_auth_summary.sh`
 - `.cursor/skills/tokenkey-kiro-reauth/scripts/probe_real_kiro_request.sh`
 
+## Fast Path
+
+Use the orchestrator first. It normalizes `edge-<id>` / `edge:<id>` to the
+deployable edge id, resolves the exact Kiro OAuth account by name when
+`--account-id` is omitted, defaults the admin password file from the normalized
+edge id, and fails closed on zero or multiple matches.
+
+```bash
+# read-only: resolve edge + exact account, no local credential read, no writes
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
+  <account-name> <edge-id> --plan-only
+
+# read-only: compare local safe fingerprints with edge safe fingerprints
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
+  <account-name> <edge-id>
+
+# repair + verify: apply current local Kiro cache, restore schedulable, prove traffic
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
+  <account-name> <edge-id> \
+  --apply --ensure-schedulable --verify-real-request
+```
+
+Example: `kiro-us6-real edge-us6` resolves to edge `us6`, account id `2`, and
+`~/Codes/keys/tokenkey-us6-admin-password.txt` when present.
+
 ## Ground Rules
 
 - Treat all Kiro credentials as secrets. Never print `access_token`,
   `refresh_token`, `client_secret`, or full credentials JSON in chat or logs.
 - Prefer read-only diagnosis first. Writing refreshed credentials to an edge is
   a live operation and requires explicit user authorization.
-- Use exact account identity before writing: edge id, account id, account name,
+- Use exact account identity before writing: normalized edge id, account id,
+  account name,
   `platform=kiro`, `type=oauth`, group binding, status, schedulable.
 - Use `ops/observability/run-probe.sh --target edge:<id>` for remote probes.
-  If a custom temporary probe is required, create it via `apply_patch`, run it,
-  then delete it before the final response.
+  Prefer the bundled probes; create a custom temporary probe only when a bundled
+  probe cannot answer the question, then delete it before the final response.
 - Every remote SQL query must emit field-named JSON (`row_to_json` or
   `jsonb_build_object`). Never rely on column positions.
 
@@ -58,17 +84,24 @@ mechanical steps:
 
 ## Deterministic Workflow
 
-Default to the orchestrator unless you are debugging a specific phase:
+Default to the orchestrator unless you are debugging a specific phase. The
+preferred shorthand is:
+
+```bash
+python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
+  <account-name> <edge-id> \
+  --apply --ensure-schedulable --verify-real-request
+```
+
+The explicit form still works:
 
 ```bash
 python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
   --edge-id <edge> \
-  --account-id <id> \
   --account-name <name> \
   --apply \
   --ensure-schedulable \
-  --verify-real-request \
-  --admin-password-file ~/Codes/keys/tokenkey-<edge>-admin-password.txt
+  --verify-real-request
 ```
 
 Useful variants:
@@ -76,22 +109,22 @@ Useful variants:
 ```bash
 # read-only plan / target resolution only
 python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
-  --edge-id <edge> --account-id <id> --account-name <name> --plan-only
+  <account-name> <edge-id> --plan-only
 
 # local reauth already fresh, compare only, no writes
 python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
-  --edge-id <edge> --account-id <id> --account-name <name>
+  <account-name> <edge-id>
 
 # mint a fresh local access token first, then apply and verify
 python3 .cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py \
-  --edge-id <edge> --account-id <id> --account-name <name> \
-  --local-refresh --apply --ensure-schedulable --verify-real-request \
-  --admin-password-file ~/Codes/keys/tokenkey-<edge>-admin-password.txt
+  <account-name> <edge-id> \
+  --local-refresh --apply --ensure-schedulable --verify-real-request
 ```
 
 ### 1. Resolve the Edge and Identify the Exact Account
 
-If you are not using the orchestrator, resolve target metadata first:
+The orchestrator handles this. If you are debugging manually, resolve target
+metadata first:
 
 ```bash
 python3 ops/stage0/edge_ssm_execution.py --repo-root . --edge-id <edge> --format json
@@ -134,6 +167,15 @@ Use this only after the user confirms Kiro was opened and re-authorized locally.
 Run locally on the operator machine. Do not save the emitted JSON under a repo
 path.
 
+For the operator onboarding doc handoff, prefer the repo-level field exporter.
+It writes a human-readable admin-form field file with mode `0600`; the operator
+doc intentionally tells operators to receive fields from a technical owner
+instead of running skill scripts themselves:
+
+```bash
+bash ops/kiro/export-tokenkey-fields.sh /tmp/kiro-tokenkey-fields.txt
+```
+
 Commands:
 
 ```bash
@@ -161,13 +203,13 @@ Rules:
 
 ### 4. Edge Auth Summary Probe
 
-After you know the exact `ACCOUNT_ID` and `ACCOUNT_NAME`, read the edge summary:
+After you know the exact `ACCOUNT_NAME`, read the edge summary. `ACCOUNT_ID` is
+optional and should be passed when already known:
 
 ```bash
 bash ops/observability/run-probe.sh \
   --target edge:<edge> \
   --script .cursor/skills/tokenkey-kiro-reauth/scripts/probe_edge_auth_summary.sh \
-  --env ACCOUNT_ID=<id> \
   --env ACCOUNT_NAME=<name>
 ```
 
@@ -201,6 +243,10 @@ python3 .cursor/skills/tokenkey-kiro-reauth/scripts/apply_edge_kiro_oauth.py \
 ```
 
 3. Re-read the edge auth summary immediately afterward.
+
+Do not use the helper directly for normal runs; the orchestrator already wraps
+payload generation, identity check, apply, post-summary, compare, and real
+request verification.
 
 Important:
 

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/probe_edge_auth_summary.sh
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/probe_edge_auth_summary.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ACCOUNT_ID="${ACCOUNT_ID:-}"
 ACCOUNT_NAME="${ACCOUNT_NAME:-}"
+ACCOUNT_ID="${ACCOUNT_ID:-}"
 
-if [[ ! "${ACCOUNT_ID}" =~ ^[0-9]+$ ]]; then
-  echo '{"error":"ACCOUNT_ID must be a numeric account id"}'
+if [[ -n "${ACCOUNT_ID}" && ! "${ACCOUNT_ID}" =~ ^[0-9]+$ ]]; then
+  echo '{"error":"ACCOUNT_ID must be blank or a numeric account id"}'
   exit 0
 fi
 
@@ -27,8 +27,7 @@ ACCOUNT_NAME_B64="$(sql_b64 "${ACCOUNT_NAME}")"
 PSQL=(docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
 
 result="$("${PSQL[@]}" -c "
-SELECT row_to_json(t)
-FROM (
+WITH matches AS (
   SELECT
     a.id,
     a.name,
@@ -67,13 +66,31 @@ FROM (
     END AS client_secret_md5_16
   FROM accounts a
   LEFT JOIN account_groups ag ON ag.account_id = a.id
-  WHERE a.id = ${ACCOUNT_ID}
-    AND a.name = convert_from(decode('${ACCOUNT_NAME_B64}','base64'),'utf8')
+  WHERE a.name = convert_from(decode('${ACCOUNT_NAME_B64}','base64'),'utf8')
+    AND (${ACCOUNT_ID:-0} = 0 OR a.id = ${ACCOUNT_ID:-0})
     AND a.platform = 'kiro'
     AND a.type = 'oauth'
     AND a.deleted_at IS NULL
   GROUP BY a.id
-) t;
+),
+match_count AS (
+  SELECT count(*) AS n FROM matches
+)
+SELECT CASE
+  WHEN (SELECT n FROM match_count) = 1 THEN (
+    SELECT row_to_json(matches)::jsonb FROM matches
+  )
+  WHEN (SELECT n FROM match_count) = 0 THEN jsonb_build_object(
+    'error', 'account_not_found',
+    'account_id', NULLIF('${ACCOUNT_ID}', '')::bigint,
+    'account_name', convert_from(decode('${ACCOUNT_NAME_B64}','base64'),'utf8')
+  )
+  ELSE jsonb_build_object(
+    'error', 'ambiguous_account_name',
+    'account_name', convert_from(decode('${ACCOUNT_NAME_B64}','base64'),'utf8'),
+    'matching_ids', (SELECT jsonb_agg(id ORDER BY id) FROM matches)
+  )
+END;
 ")"
 
 result="$(printf '%s' "${result}" | tr -d '\n')"
@@ -85,7 +102,7 @@ import sys
 
 print(json.dumps({
     "error": "account_not_found",
-    "account_id": int(sys.argv[1]),
+    "account_id": int(sys.argv[1]) if sys.argv[1] else None,
     "account_name": sys.argv[2],
 }, ensure_ascii=False))
 PY

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/run_kiro_reauth_flow.py
@@ -72,6 +72,32 @@ def run_json(argv: list[str], *, stdin_text: str | None = None, label: str, extr
     return must_json(stdout, label)
 
 
+def normalize_edge_id(value: str) -> str:
+    edge_id = value.strip()
+    if edge_id.startswith("edge:"):
+        edge_id = edge_id.removeprefix("edge:")
+    if edge_id.startswith("edge-"):
+        edge_id = edge_id.removeprefix("edge-")
+    return edge_id
+
+
+def default_admin_password_file(edge_id: str, explicit_path: str) -> str:
+    if explicit_path:
+        return explicit_path
+    for candidate in (
+        Path.home() / "Codes" / "keys" / f"tokenkey-{edge_id}-admin-password.txt",
+        Path.home() / "Codes" / "keys" / f"tokenkey-edge-{edge_id}-admin-password.txt",
+    ):
+        if candidate.exists():
+            return str(candidate)
+    return ""
+
+
+def require_probe_success(obj: dict[str, Any], label: str) -> None:
+    if obj.get("error"):
+        raise SystemExit(f"{label} returned error: {json.dumps(obj, ensure_ascii=False)}")
+
+
 def resolve_edge(edge_id: str) -> dict[str, Any]:
     return run_json(
         [sys.executable, str(EDGE_RESOLVE), "--repo-root", ".", "--edge-id", edge_id, "--format", "json"],
@@ -93,7 +119,7 @@ def local_admin_payload(refresh: bool) -> dict[str, Any]:
     return run_json(argv, label="local_admin_payload")
 
 
-def edge_summary(edge_id: str, account_id: int, account_name: str) -> dict[str, Any]:
+def edge_summary(edge_id: str, account_id: int | None, account_name: str) -> dict[str, Any]:
     argv = [
         "bash",
         str(RUN_PROBE),
@@ -102,10 +128,10 @@ def edge_summary(edge_id: str, account_id: int, account_name: str) -> dict[str, 
         "--script",
         str(EDGE_SUMMARY),
         "--env",
-        f"ACCOUNT_ID={account_id}",
-        "--env",
         f"ACCOUNT_NAME={account_name}",
     ]
+    if account_id is not None:
+        argv.extend(["--env", f"ACCOUNT_ID={account_id}"])
     return run_json(argv, label="edge_summary")
 
 
@@ -190,16 +216,28 @@ def real_probe(edge_id: str, account_id: int, group_name: str, model: str, promp
     return run_json(argv, label="real_probe")
 
 
-def render_plan(args: argparse.Namespace, edge_info: dict[str, Any]) -> dict[str, Any]:
+def render_plan(
+    args: argparse.Namespace,
+    edge_info: dict[str, Any],
+    *,
+    input_edge_id: str,
+    account_id: int,
+    account_name: str,
+    admin_password_file: str,
+) -> dict[str, Any]:
     return {
+        "input_edge_id": input_edge_id,
         "edge_id": args.edge_id,
         "base_url": args.base_url or f"https://{edge_info['domain']}",
         "account_id": args.account_id,
+        "resolved_account_id": account_id,
         "account_name": args.account_name,
+        "resolved_account_name": account_name,
         "local_refresh": args.local_refresh,
         "do_apply": args.apply,
         "do_real_probe": args.verify_real_request,
         "ensure_schedulable": args.ensure_schedulable,
+        "admin_password_file": admin_password_file,
         "group_name": args.group_name,
         "model": args.model,
         "log_window": args.log_window,
@@ -208,9 +246,9 @@ def render_plan(args: argparse.Namespace, edge_info: dict[str, Any]) -> dict[str
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--edge-id", required=True)
-    parser.add_argument("--account-id", required=True, type=int)
-    parser.add_argument("--account-name", required=True)
+    parser.add_argument("--edge-id", default="")
+    parser.add_argument("--account-id", type=int, default=None, help="optional when --account-name uniquely identifies a Kiro OAuth account")
+    parser.add_argument("--account-name", default="")
     parser.add_argument("--base-url", default="", help="override base URL; defaults to https://<resolved-domain>")
 
     parser.add_argument("--local-refresh", action="store_true", help="mint a fresh local Kiro access token first")
@@ -228,17 +266,46 @@ def main() -> int:
     parser.add_argument("--admin-email", default="")
     parser.add_argument("--admin-password", default="")
     parser.add_argument("--admin-password-file", default="")
+    parser.add_argument("shorthand", nargs="*", help="optional shorthand: <account-name> <edge-id>")
     args = parser.parse_args()
+
+    if args.shorthand:
+        if len(args.shorthand) != 2:
+            raise SystemExit("shorthand usage is: <account-name> <edge-id>")
+        args.account_name = args.account_name or args.shorthand[0]
+        args.edge_id = args.edge_id or args.shorthand[1]
+
+    if not args.edge_id:
+        raise SystemExit("--edge-id is required, or use shorthand: <account-name> <edge-id>")
+    if not args.account_name:
+        raise SystemExit("--account-name is required, or use shorthand: <account-name> <edge-id>")
+
+    input_edge_id = args.edge_id
+    args.edge_id = normalize_edge_id(args.edge_id)
+    args.admin_password_file = default_admin_password_file(args.edge_id, args.admin_password_file)
 
     edge_info = resolve_edge(args.edge_id)
     base_url = args.base_url or f"https://{edge_info['domain']}"
 
+    pre_edge = edge_summary(args.edge_id, args.account_id, args.account_name)
+    require_probe_success(pre_edge, "edge_summary")
+    resolved_account_id = int(pre_edge["id"])
+    resolved_account_name = str(pre_edge["name"])
+
     output: dict[str, Any] = {
         "edge": edge_info,
-        "plan": render_plan(args, edge_info),
+        "plan": render_plan(
+            args,
+            edge_info,
+            input_edge_id=input_edge_id,
+            account_id=resolved_account_id,
+            account_name=resolved_account_name,
+            admin_password_file=args.admin_password_file,
+        ),
     }
 
     if args.plan_only:
+        output["resolved_edge_summary"] = pre_edge
         json.dump(output, sys.stdout, ensure_ascii=False, indent=2)
         sys.stdout.write("\n")
         return 0
@@ -246,15 +313,14 @@ def main() -> int:
     local_summary_obj = local_summary(args.local_refresh)
     output["local_summary"] = local_summary_obj
 
-    pre_edge = edge_summary(args.edge_id, args.account_id, args.account_name)
     output["pre_apply_edge_summary"] = pre_edge
 
     if args.apply:
         payload = local_admin_payload(args.local_refresh)
         apply_result = apply_edge(
             base_url=base_url,
-            account_id=args.account_id,
-            account_name=args.account_name,
+            account_id=resolved_account_id,
+            account_name=resolved_account_name,
             payload=payload,
             admin_api_key=args.admin_api_key,
             admin_email=args.admin_email,
@@ -268,7 +334,8 @@ def main() -> int:
     compare_edge = pre_edge
     output["compare_edge_source"] = "pre_apply_edge_summary"
     if args.apply:
-        post_edge = edge_summary(args.edge_id, args.account_id, args.account_name)
+        post_edge = edge_summary(args.edge_id, resolved_account_id, resolved_account_name)
+        require_probe_success(post_edge, "post_apply_edge_summary")
         output["post_apply_edge_summary"] = post_edge
         compare_edge = post_edge
         output["compare_edge_source"] = "post_apply_edge_summary"
@@ -277,7 +344,7 @@ def main() -> int:
     if args.verify_real_request:
         output["real_request_probe"] = real_probe(
             args.edge_id,
-            args.account_id,
+            resolved_account_id,
             args.group_name,
             args.model,
             args.prompt_text,

--- a/.cursor/skills/tokenkey-kiro-reauth/scripts/test_run_kiro_reauth_flow.py
+++ b/.cursor/skills/tokenkey-kiro-reauth/scripts/test_run_kiro_reauth_flow.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("run_kiro_reauth_flow.py")
+SPEC = importlib.util.spec_from_file_location("run_kiro_reauth_flow", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+mod = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mod)
+
+
+class RunKiroReauthFlowTest(unittest.TestCase):
+    def test_normalize_edge_id_accepts_operator_labels(self) -> None:
+        self.assertEqual(mod.normalize_edge_id("us6"), "us6")
+        self.assertEqual(mod.normalize_edge_id("edge-us6"), "us6")
+        self.assertEqual(mod.normalize_edge_id("edge:us6"), "us6")
+
+    def test_default_admin_password_file_prefers_normalized_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            key_dir = home / "Codes" / "keys"
+            key_dir.mkdir(parents=True)
+            normalized = key_dir / "tokenkey-us6-admin-password.txt"
+            legacy = key_dir / "tokenkey-edge-us6-admin-password.txt"
+            normalized.write_text("password", encoding="utf-8")
+            legacy.write_text("password", encoding="utf-8")
+
+            with mock.patch.object(mod.Path, "home", return_value=home):
+                self.assertEqual(mod.default_admin_password_file("us6", ""), str(normalized))
+
+    def test_default_admin_password_file_keeps_explicit_path(self) -> None:
+        self.assertEqual(
+            mod.default_admin_password_file("us6", "/tmp/custom-password.txt"),
+            "/tmp/custom-password.txt",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/operator/kiro-account-onboarding.md
+++ b/docs/operator/kiro-account-onboarding.md
@@ -1,60 +1,160 @@
-# Kiro 账号配置 · 极简操作指南
+# Kiro 账号配置 · 运营操作指南
 
-> 给运营：拿到一个 Kiro / AWS CodeWhisperer 授权，在 TokenKey 后台配成可用账号。
-> 全程在你自己的 Mac 上操作。
+> 给运营：把一个已经完成授权的 Kiro 账号配置到 TokenKey 指定 edge 后台。运营只做页面操作。
 
-## 4 步搞定
+## 分工
 
-**1. 装 Kiro 并登录**
-- 装：`brew install --cask kiro`（或官网 <https://kiro.dev> 下载）
-- 开：`open -a Kiro`
-- 登录选 **组织 / 公司 SSO**，填起始地址（例 `https://d-906671b2ce.awsapps.com/start`），浏览器点 **批准**。
+运营负责：
 
-**2. 提取凭证**（终端粘贴运行，会打印一段 JSON）
+- 登录 Kiro，确认账号可用。
+- 在 TokenKey 后台新建或编辑 Kiro OAuth 账号。
+- 把账号挂到 `kiro` group，并确认账号可调度。
+- 保存配置结果和异常现象。
 
-```bash
-python3 - <<'PY'
-import json, glob, os
-c = os.path.expanduser("~/.aws/sso/cache")
-t = json.load(open(os.path.join(c, "kiro-auth-token.json")))
-auth = "social" if str(t.get("authMethod","")).lower()=="social" else "idc"
-out = {"access_token": t["accessToken"], "refresh_token": t["refreshToken"],
-       "region": t.get("region","us-east-1"), "auth_method": auth}
-if auth == "idc":
-    reg = next(json.load(open(f)) for f in glob.glob(c+"/*.json")
-               if not f.endswith("kiro-auth-token.json") and "clientSecret" in json.load(open(f)))
-    out["client_id"], out["client_secret"] = reg["clientId"], reg["clientSecret"]
-print(json.dumps(out, ensure_ascii=False, indent=2))
-PY
+技术负责人负责：
+
+- 安全提取 Kiro OAuth 字段。
+- 把字段通过受控方式交给运营，或现场协助粘贴到后台。
+- 完成真实 Kiro 请求验证。
+
+## 安全红线
+
+- 不把 Access Token、Refresh Token、Client Secret 发到群里、工单、PR 或普通聊天窗口。
+- 不截图、不长期保存任何包含 token 的页面或文件。
+- 如果需要他人协助，只让技术负责人通过受控方式处理敏感字段。
+- 配置完成后，清空剪贴板里残留的 token 内容。
+
+## 1. 下载并登录 Kiro
+
+1. 打开 Kiro 官网下载安装：<https://kiro.dev>
+2. 打开 Kiro。
+3. 在登录页选择组织/公司 SSO。
+4. 起始地址填写：
+
+```text
+https://d-906671b2ce.awsapps.com/start
 ```
 
-> 这几段是敏感凭证（等于账号密码）：只在后台输入框粘贴，不发群、不存文件、不截图。
+5. 浏览器打开授权页后点击批准。
+6. 回到 Kiro，确认能进入会话页。
 
-**3. 后台新建账号**
-账号管理 → 新建 → 平台选 **Kiro**，把上面 JSON 填进对应框：
+如果已经登录过，但这次是修复 401、Invalid bearer token 或授权失效问题，请先退出 Kiro 后重新登录授权。
 
-| 后台字段 | 填 |
+## 2. 准备后台填写字段
+
+运营不要自行提取 token。请技术负责人提供以下字段：
+
+| 字段 | 说明 |
 | --- | --- |
-| Access Token | `access_token` |
-| Refresh Token | `refresh_token` |
-| Region | `us-east-1` |
-| 认证方式 | IdC（组织 SSO）/ Social（社交登录） |
-| Client ID / Client Secret | `client_id` / `client_secret`（仅 IdC） |
-| Profile ARN | 留空 |
-| ☑ 接受 Kiro 服务条款 | **必须勾** |
+| Access Token | 必填，敏感字段 |
+| Refresh Token | 必填，敏感字段 |
+| Region | 通常是 `us-east-1` |
+| 认证方式 | 通常是 `idc`；如果是社交登录则为 `social` |
+| Client ID | `idc` 必填 |
+| Client Secret | `idc` 必填，敏感字段 |
+| Profile ARN | 有值就填，没有就留空 |
 
-保存。
+收到字段后，只用于 TokenKey 后台填写，不转发、不截图、不保存副本。
 
-**4. 挂分组**
-把账号挂到对应 group，按常规设 RPM / 并发即可（和其它平台一样）。账号挂进 group 且可调度后，Kiro 即开始服务——和其它平台一样「有可调度账号就在线」，无需任何额外开关。
+## 3. 进入目标 edge 后台
+
+目标 edge 后台地址由负责人提供，通常格式是：
+
+```text
+https://api-<edge>.tokenkey.dev/admin
+```
+
+进入后台后打开“账号管理”。
+
+## 4. 新建或编辑 Kiro 账号
+
+如果是新账号：
+
+1. 点击“新建账号”。
+2. 平台选择 `Kiro`。
+3. 类型选择 `OAuth`。
+
+如果是修复已有账号：
+
+1. 在账号管理里找到目标 Kiro OAuth 账号。
+2. 核对账号名称，避免改错 edge 或改错账号。
+3. 点击编辑。
+
+按下面字段填写：
+
+| 后台字段 | 填写 |
+| --- | --- |
+| 平台 | Kiro |
+| 类型 | OAuth |
+| Access Token | 技术负责人提供的 Access Token |
+| Refresh Token | 技术负责人提供的 Refresh Token |
+| Region | 技术负责人提供的 Region，通常是 `us-east-1` |
+| 认证方式 | 技术负责人提供的认证方式，通常是 `idc` |
+| Client ID | 技术负责人提供的 Client ID；`idc` 必填 |
+| Client Secret | 技术负责人提供的 Client Secret；`idc` 必填 |
+| Profile ARN | 有值就填，没有就留空 |
+| 接受 Kiro 服务条款 | 必须勾选 |
+
+保存后记录：
+
+- edge 名称
+- 账号 ID
+- 账号名称
+- 配置时间
+
+## 5. 挂到 Kiro Group
+
+在后台把账号挂到 `kiro` group。
+
+保存后确认：
+
+- 账号状态是 `active`。
+- 可调度已开启。
+- 没有错误信息。
+- 账号已在 `kiro` group 下。
+
+如果后台有 RPM、并发、优先级等配置，按负责人给出的值填写；没有特别要求时，沿用同 edge 上其他 Kiro 账号的配置。
+
+## 6. 验证
+
+运营侧检查：
+
+- 账号保存成功。
+- 账号在 `kiro` group 中。
+- 账号状态为 active。
+- 可调度开启。
+- 页面没有错误信息。
+
+技术侧验证：
+
+- 请技术负责人发起一次真实 Kiro 请求验证。
+- 验证通过后，记录“已完成真实请求验证”。
+
+不要用“后台刷新账号”或“后台 usage 强制刷新”判断 Kiro 是否可用；Kiro 是否真正可用，以技术负责人真实请求验证结果为准。
 
 ## 常见问题
 
 | 现象 | 处理 |
 | --- | --- |
-| 调用报 `No available accounts`（429） | 账号没挂进对应 group，或账号不可调度（见第 3–4 步） |
-| 创建提示要确认 ToS | 勾「接受 Kiro 服务条款」 |
-| 创建提示缺 client_id/secret | IdC 必须填这两个 |
-| 持续 401 / 刷新失败 | 回第 1 步重登 Kiro，重跑第 2 步，**编辑**账号粘新 token |
+| 后台提示缺 Access Token / Refresh Token | 找技术负责人重新提供完整字段 |
+| 后台提示缺 Client ID / Client Secret | 认证方式是 `idc` 时这两个字段必填，找技术负责人补齐 |
+| 后台提示缺 ToS | 勾选“接受 Kiro 服务条款” |
+| 请求返回 No available accounts | 检查账号是否挂到 `kiro` group，且可调度已开启 |
+| 后续出现 401 / Invalid bearer token | 重新登录 Kiro 后，请技术负责人重新提取字段并更新后台 |
+| 不确定该新建还是编辑 | 修复已有账号时优先编辑原账号；新增账号必须先确认不会造成重复账号混淆 |
 
-> Access Token 过期不用管，系统会用 refresh token 自动续。
+## 汇报模板
+
+配置完成后，只汇报安全摘要，不附 token：
+
+```text
+edge:
+账号 ID:
+账号名称:
+操作类型: 新建 / 编辑
+状态: active / 非 active
+可调度: 是 / 否
+Group: kiro 已挂 / 未挂
+页面错误: 无 / 有（摘要）
+真实请求验证: 已通过 / 待技术验证 / 未通过
+```

--- a/ops/kiro/export-tokenkey-fields.sh
+++ b/ops/kiro/export-tokenkey-fields.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT="${1:-/tmp/kiro-tokenkey-fields.txt}"
+
+python3 - "${OUT}" <<'PY'
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+out_path = Path(sys.argv[1])
+cache_dir = Path.home() / ".aws" / "sso" / "cache"
+token_path = cache_dir / "kiro-auth-token.json"
+
+if not token_path.exists():
+    raise SystemExit(
+        "找不到 Kiro token cache。请先打开 Kiro 并完成登录，再重新执行导出命令。"
+    )
+
+with token_path.open(encoding="utf-8") as handle:
+    token = json.load(handle)
+
+auth_method = "social" if str(token.get("authMethod", "")).lower() == "social" else "idc"
+credentials = {
+    "access_token": token.get("accessToken", ""),
+    "refresh_token": token.get("refreshToken", ""),
+    "region": token.get("region", "us-east-1"),
+    "auth_method": auth_method,
+    "profile_arn": token.get("profileArn", ""),
+}
+
+if auth_method == "idc":
+    registrations = []
+    for raw_path in glob.glob(str(cache_dir / "*.json")):
+        path = Path(raw_path)
+        if path.name == "kiro-auth-token.json":
+            continue
+        try:
+            with path.open(encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except Exception:
+            continue
+        if not payload.get("clientId") or not payload.get("clientSecret"):
+            continue
+        registrations.append((path.stat().st_mtime, path, payload))
+
+    if not registrations:
+        raise SystemExit(
+            "找不到 Kiro IdC Client ID / Client Secret。请重新走一遍 Kiro 组织 SSO 登录。"
+        )
+
+    registrations.sort(key=lambda item: item[0], reverse=True)
+    registration = registrations[0][2]
+    credentials["client_id"] = registration.get("clientId", "")
+    credentials["client_secret"] = registration.get("clientSecret", "")
+else:
+    credentials["client_id"] = ""
+    credentials["client_secret"] = ""
+
+required = ("access_token", "refresh_token", "region", "auth_method")
+missing = [key for key in required if not str(credentials.get(key) or "").strip()]
+if missing:
+    raise SystemExit("Kiro credentials 缺少字段：" + ", ".join(missing))
+
+if auth_method == "idc":
+    missing_idc = [
+        key for key in ("client_id", "client_secret")
+        if not str(credentials.get(key) or "").strip()
+    ]
+    if missing_idc:
+        raise SystemExit("Kiro IdC credentials 缺少字段：" + ", ".join(missing_idc))
+
+lines = [
+    "TokenKey Kiro OAuth 新建账号填写字段",
+    "",
+    "请只把下面字段填写到 TokenKey 后台。不要转发、截图或提交本文件。",
+    "",
+    "平台: Kiro",
+    "类型: OAuth",
+    "",
+    f"Access Token: {credentials.get('access_token', '')}",
+    f"Refresh Token: {credentials.get('refresh_token', '')}",
+    f"Region: {credentials.get('region', '')}",
+    f"认证方式: {credentials.get('auth_method', '')}",
+    f"Client ID: {credentials.get('client_id', '')}",
+    f"Client Secret: {credentials.get('client_secret', '')}",
+    f"Profile ARN: {credentials.get('profile_arn', '')}",
+    "",
+    "接受 Kiro 服务条款: 勾选",
+    "",
+    "后台保存成功后，请删除本文件。",
+]
+
+out_path.parent.mkdir(parents=True, exist_ok=True)
+out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+os.chmod(out_path, 0o600)
+print(str(out_path))
+PY
+
+echo
+echo "已生成 TokenKey 后台填写字段：${OUT}"
+echo "打开查看：open ${OUT}"
+echo "后台保存后删除：rm -f ${OUT}"

--- a/ops/kiro/test_export_tokenkey_fields.py
+++ b/ops/kiro/test_export_tokenkey_fields.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("export-tokenkey-fields.sh")
+
+
+class ExportTokenKeyFieldsTest(unittest.TestCase):
+    def test_script_is_operator_facing_and_self_contained(self) -> None:
+        text = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("kiro-auth-token.json", text)
+        self.assertIn("clientId", text)
+        self.assertIn("clientSecret", text)
+        self.assertIn("chmod(out_path, 0o600)", text)
+        self.assertNotIn(".cursor/skills", text)
+
+    def test_script_syntax(self) -> None:
+        proc = subprocess.run(
+            ["bash", "-n", str(SCRIPT)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_output_template_contains_operator_fields(self) -> None:
+        text = SCRIPT.read_text(encoding="utf-8")
+        for label in (
+            "Access Token:",
+            "Refresh Token:",
+            "Region:",
+            "认证方式:",
+            "Client ID:",
+            "Client Secret:",
+            "接受 Kiro 服务条款: 勾选",
+        ):
+            self.assertIn(label, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- 优化 `tokenkey-kiro-reauth` skill 的默认路径：支持 `<account-name> <edge-id>` 快捷调用，自动归一化 `edge-us6` / `edge:us6`，并自动解析唯一 Kiro OAuth 账号。
- 新增技术负责人入口 `ops/kiro/export-tokenkey-fields.sh`：从本机 Kiro 登录缓存导出 TokenKey 后台需要填写的字段，输出文件权限为 `0600`，用于受控交接或现场协助粘贴。
- 重写 `docs/operator/kiro-account-onboarding.md`：运营只做页面操作，重点是下载并登录 Kiro、拿到负责人提供的字段、后台新建/编辑账号、挂到 `kiro` group、运营侧检查和汇报模板，不要求运营写代码或运行 skill 脚本。

## 风险
- 低风险：仅调整运维 skill、脚本和操作文档，不改运行时服务逻辑。
- 文档明确运营不自行提取 token；敏感字段由技术负责人受控处理，不进入群聊、工单、PR 或普通聊天窗口。
- 写 edge 仍需显式 `--apply`，读-only / plan-only 不写生产状态。

## 验证
- `python3 ops/kiro/test_export_tokenkey_fields.py -v`
- `python3 .cursor/skills/tokenkey-kiro-reauth/scripts/test_run_kiro_reauth_flow.py -v`
- `python3 /Users/xuejiao/.codex/skills/.system/skill-creator/scripts/quick_validate.py .cursor/skills/tokenkey-kiro-reauth`
- `rg -n "skill|\.cursor/skills|probe_|run_kiro_reauth_flow|local_kiro_credentials|bash ops/kiro|re-oauth" docs/operator/kiro-account-onboarding.md || true && git diff --check && python3 scripts/checks/script-ref-existence.py`
- `bash scripts/preflight.sh`

## 提交
- `3892b8cd1 chore(kiro): shorten edge reauth workflow`
- 最新提交：`3892b8cd1`
