### PR TITLE
test: guard Kiro OAuth refresh wiring

### DIFF
--- a/backend/internal/service/wire_tk_kiro_test.go
+++ b/backend/internal/service/wire_tk_kiro_test.go
@@ -1,0 +1,29 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvideRateLimitService_KiroOAuth401RefreshAPIWired(t *testing.T) {
+	refreshAPI := NewOAuthRefreshAPI(nil, nil)
+
+	svc := ProvideRateLimitService(
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		refreshAPI,
+	)
+
+	require.Same(t, refreshAPI, svc.oauthRefreshAPI)
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -265,9 +265,19 @@
       "path": "backend/internal/service/wire.go",
       "must_contain": [
         "anthropicUpstreamErrorCounterCache AnthropicUpstreamErrorCounterCache,",
-        "svc.SetAnthropicUpstreamErrorCounterCache(anthropicUpstreamErrorCounterCache)"
+        "svc.SetAnthropicUpstreamErrorCounterCache(anthropicUpstreamErrorCounterCache)",
+        "refreshAPI *OAuthRefreshAPI",
+        "svc.SetOAuthRefreshAPI(refreshAPI)"
       ],
-      "rationale": "ProvideRateLimitService MUST keep the Anthropic upstream-error counter parameter and the SetAnthropicUpstreamErrorCounterCache wire call. If an upstream merge drops either line, handleAnthropicUpstreamError silently falls through (nil counter → returns false → no temp_unschedulable) and the burst protection becomes a NOOP that compiles cleanly and passes all current unit tests. The literal parameter declaration is what wire.go regen sees; the Set call is what hands the dependency to the runtime service. (The former OAuth401AfterRefreshCounterCache parameter + SetOAuth401AfterRefreshCounter call were removed when the revoked-OAuth-401 escalation was replaced by the token-validity check in ratelimit_service_tk_oauth401.go, which needs no injected counter.)"
+      "rationale": "ProvideRateLimitService MUST keep the Anthropic upstream-error counter parameter and the SetAnthropicUpstreamErrorCounterCache wire call. If an upstream merge drops either line, handleAnthropicUpstreamError silently falls through (nil counter → returns false → no temp_unschedulable) and the burst protection becomes a NOOP that compiles cleanly and passes all current unit tests. The Kiro valid-token 401 force-refresh path also depends on OAuthRefreshAPI being injected here; dropping the refreshAPI parameter or svc.SetOAuthRefreshAPI(refreshAPI) compiles but leaves s.oauthRefreshAPI nil, silently reverting Kiro still-valid access-token 401 back to manual re-OAuth. The literal parameter declarations are what wire.go regen sees; the Set calls are what hand the dependencies to the runtime service. (The former OAuth401AfterRefreshCounterCache parameter + SetOAuth401AfterRefreshCounter call were removed when the revoked-OAuth-401 escalation was replaced by the token-validity check in ratelimit_service_tk_oauth401.go, which needs no injected counter.)"
+    },
+    {
+      "path": "backend/internal/service/wire_tk_kiro_test.go",
+      "must_contain": [
+        "TestProvideRateLimitService_KiroOAuth401RefreshAPIWired",
+        "require.Same(t, refreshAPI, svc.oauthRefreshAPI)"
+      ],
+      "rationale": "Focused regression proving ProvideRateLimitService wires OAuthRefreshAPI into RateLimitService. This is the guard for the Kiro valid-token 401 force-refresh production seam: if an upstream merge rewrites service/wire.go and omits svc.SetOAuthRefreshAPI(refreshAPI), the app still builds but Kiro falls back to grant-revoked/manual re-OAuth instead of refreshing the edge's current refresh_token/client credentials."
     },
     {
       "path": "backend/internal/repository/wire.go",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -219,6 +219,14 @@
       "rationale": "Wire provider registration for the kiro forwarder (NewKiroGatewayService). Dropping it de-wires the gateway's kiro branch dependency. (The KiroTokenRefresher is constructed inside NewTokenRefreshService, not via wire — its registration is guarded by the token_refresh_service.go sentinel entry instead.)"
     },
     {
+      "path": "backend/internal/service/wire.go",
+      "must_contain": [
+        "refreshAPI *OAuthRefreshAPI",
+        "svc.SetOAuthRefreshAPI(refreshAPI)"
+      ],
+      "rationale": "Production wiring for the Kiro valid-token 401 force-refresh path. RateLimitService.tkHandleKiroOAuth401OnValidToken needs OAuthRefreshAPI to refresh Kiro using the edge's existing refresh_token/client credentials before falling back to grant-revoked SetError. An upstream merge that drops this parameter or setter still compiles but leaves s.oauthRefreshAPI nil, silently reverting Kiro valid-token 401 to manual re-OAuth."
+    },
+    {
       "path": "backend/internal/handler/admin/account_handler_tk_kiro_validate_test.go",
       "must_contain": [
         "tkValidateKiroAccountCreate"


### PR DESCRIPTION
## 摘要
- 给 Kiro valid-token 401 强制刷新链路补一个 production wiring 单测，断言 `ProvideRateLimitService` 会把 `OAuthRefreshAPI` 注入到 `RateLimitService`。
- 在 `scripts/sentinels/kiro.json` 锚住 `wire.go` 的 `refreshAPI *OAuthRefreshAPI` 参数和 `svc.SetOAuthRefreshAPI(refreshAPI)` 注入点，防止 upstream merge 静默删掉 Kiro 刷新依赖。
- 在 `scripts/sentinels/gateway-tk.json` 同步锚住新增 TK companion 测试文件和注入线，满足新增 `*_tk_*` load-bearing surface 的 registry update gate。

## 风险
- no-web-impact：只新增后端 unit test 和 sentinel registry，不改业务运行代码、前端、路由或静态资源。
- sentinel-registry-reviewed：本 PR 专门补 upstream 覆盖写门禁；Kiro registry 与 gateway-tk registry 均已更新，不依赖 PR marker 逃逸。
- upstream-touch-trivial：触及 sentinel registry 文案与测试文件；不改变运行时行为。

## 验证
- `go test -tags unit ./internal/service -run 'TestProvideRateLimitService_KiroOAuth401RefreshAPIWired|TestRateLimitService_OAuth401_Kiro'`
- `python3 scripts/sentinels/check-registry-update-gate.py --base origin/main --head HEAD`
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`
- `python3 scripts/sentinels/check-kiro.py --quiet`
- `git diff --check origin/main..HEAD`
- `scripts/preflight.sh`

## 提交
- `958192937 test: guard Kiro OAuth refresh wiring no-web-impact`
- 基于：`origin/main` after merged #966
