### PR TITLE
chore(release): reduce multi-arch image push work

### DIFF
--- a/.goreleaser.full.yaml
+++ b/.goreleaser.full.yaml
@@ -31,12 +31,14 @@ builds:
 
 archives:
   - id: default
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - LICENSE*
       - README*
@@ -49,83 +51,31 @@ checksum:
 changelog:
   disable: true
 
-dockers:
-  - id: linux-amd64
-    goos: linux
-    goarch: amd64
+dockers_v2:
+  - id: multiarch
+    ids:
+      - sub2api
     dockerfile: Dockerfile.goreleaser
-    use: buildx
+    images:
+      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api"
+      - '{{ if ne .Env.DOCKERHUB_USERNAME "skip" }}{{ .Env.DOCKERHUB_USERNAME }}/sub2api{{ end }}'
+    tags:
+      - "{{ .Version }}"
+      - "latest"
+      - "{{ .Major }}.{{ .Minor }}"
+      - "{{ .Major }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
     extra_files:
       - deploy/docker-entrypoint.sh
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-      - '{{ if ne .Env.DOCKERHUB_USERNAME "skip" }}{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64{{ end }}'
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.revision={{ .Commit }}"
-      - "--label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPO_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}"
-
-  - id: linux-arm64
-    goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile.goreleaser
-    use: buildx
-    extra_files:
-      - deploy/docker-entrypoint.sh
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
-      - '{{ if ne .Env.DOCKERHUB_USERNAME "skip" }}{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64{{ end }}'
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.revision={{ .Commit }}"
-      - "--label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPO_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}"
-
-docker_manifests:
-  - name_template: "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}"
-    skip_push: '{{ if eq .Env.DOCKERHUB_USERNAME "skip" }}true{{ else }}false{{ end }}'
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:latest"
-    skip_push: '{{ if eq .Env.DOCKERHUB_USERNAME "skip" }}true{{ else }}false{{ end }}'
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Major }}.{{ .Minor }}"
-    skip_push: '{{ if eq .Env.DOCKERHUB_USERNAME "skip" }}true{{ else }}false{{ end }}'
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Major }}"
-    skip_push: '{{ if eq .Env.DOCKERHUB_USERNAME "skip" }}true{{ else }}false{{ end }}'
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:latest"
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Major }}.{{ .Minor }}"
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Major }}"
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
+    labels:
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.revision": "{{ .Commit }}"
+      "org.opencontainers.image.source": "https://github.com/{{ .Env.GITHUB_REPO_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}"
+    sbom: false
+    flags:
+      - "--provenance=false"
 
 release:
   github:

--- a/.goreleaser.simple.yaml
+++ b/.goreleaser.simple.yaml
@@ -33,26 +33,28 @@ changelog:
   disable: true
 
 # 仅 GHCR x86_64 镜像
-dockers:
+dockers_v2:
   - id: ghcr-amd64
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}"
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:latest"
+    ids:
+      - sub2api
+    images:
+      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api"
+    tags:
+      - "{{ .Version }}-amd64"
+      - "{{ .Version }}"
+      - "latest"
     dockerfile: Dockerfile.goreleaser
-    use: buildx
+    platforms:
+      - linux/amd64
     extra_files:
       - deploy/docker-entrypoint.sh
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.revision={{ .Commit }}"
-      - "--label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPO_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}"
-
-# 跳过 manifests（单架构不需要）
-docker_manifests: []
+    labels:
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.revision": "{{ .Commit }}"
+      "org.opencontainers.image.source": "https://github.com/{{ .Env.GITHUB_REPO_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}"
+    sbom: false
+    flags:
+      - "--provenance=false"
 
 release:
   github:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,8 @@ builds:
 
 archives:
   - id: default
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
     files:
@@ -40,88 +41,32 @@ changelog:
   # 禁用自动 changelog，完全使用 tag 消息
   disable: true
 
-# Docker images — one buildx build per linux/<arch> (GHCR + optional Docker Hub).
-# Docker Hub lines use an empty template when DOCKERHUB_USERNAME=skip (GoReleaser skips empty names).
-dockers:
-  - id: linux-amd64
-    goos: linux
-    goarch: amd64
+# Docker image — one buildx invocation publishes all shared multi-arch tags.
+dockers_v2:
+  - id: multiarch
+    ids:
+      - sub2api
     dockerfile: Dockerfile.goreleaser
-    use: buildx
+    images:
+      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api"
+      - '{{ if ne .Env.DOCKERHUB_USERNAME "skip" }}{{ .Env.DOCKERHUB_USERNAME }}/sub2api{{ end }}'
+    tags:
+      - "{{ .Version }}"
+      - "latest"
+      - "{{ .Major }}.{{ .Minor }}"
+      - "{{ .Major }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
     extra_files:
       - deploy/docker-entrypoint.sh
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-      - '{{ if ne .Env.DOCKERHUB_USERNAME "skip" }}{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64{{ end }}'
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.revision={{ .Commit }}"
-      - "--label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPO_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}"
-
-  - id: linux-arm64
-    goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile.goreleaser
-    use: buildx
-    extra_files:
-      - deploy/docker-entrypoint.sh
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
-      - '{{ if ne .Env.DOCKERHUB_USERNAME "skip" }}{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64{{ end }}'
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.revision={{ .Commit }}"
-      - "--label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPO_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}"
-
-# Docker manifests for multi-arch support
-docker_manifests:
-  # DockerHub manifests (skipped if DOCKERHUB_USERNAME is 'skip')
-  - name_template: "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}"
-    skip_push: '{{ if eq .Env.DOCKERHUB_USERNAME "skip" }}true{{ else }}false{{ end }}'
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:latest"
-    skip_push: '{{ if eq .Env.DOCKERHUB_USERNAME "skip" }}true{{ else }}false{{ end }}'
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Major }}.{{ .Minor }}"
-    skip_push: '{{ if eq .Env.DOCKERHUB_USERNAME "skip" }}true{{ else }}false{{ end }}'
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Major }}"
-    skip_push: '{{ if eq .Env.DOCKERHUB_USERNAME "skip" }}true{{ else }}false{{ end }}'
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64"
-
-  # GHCR manifests (owner must be lowercase)
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:latest"
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Major }}.{{ .Minor }}"
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Major }}"
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
+    labels:
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.revision": "{{ .Commit }}"
+      "org.opencontainers.image.source": "https://github.com/{{ .Env.GITHUB_REPO_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}"
+    sbom: false
+    flags:
+      - "--provenance=false"
 
 release:
   github:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -11,6 +11,7 @@ ARG POSTGRES_IMAGE=postgres:18-alpine
 FROM ${POSTGRES_IMAGE} AS pg-client
 
 FROM ${ALPINE_IMAGE}
+ARG TARGETPLATFORM
 
 LABEL maintainer="Wei-Shaw <github.com/Wei-Shaw>"
 LABEL description="TokenKey - AI API Gateway Platform"
@@ -42,15 +43,14 @@ RUN addgroup -g 1000 sub2api && \
 
 WORKDIR /app
 
-# Copy pre-built binary from GoReleaser
-COPY sub2api /app/sub2api
+# Copy the pre-built binary selected by GoReleaser dockers_v2 for this target platform.
+COPY --chown=sub2api:sub2api --chmod=0755 ${TARGETPLATFORM}/sub2api /app/sub2api
 
 # Create data directory
-RUN mkdir -p /app/data && chown -R sub2api:sub2api /app
+RUN mkdir -p /app/data && chown sub2api:sub2api /app/data
 
 # Copy entrypoint script (fixes volume permissions then drops to sub2api)
-COPY deploy/docker-entrypoint.sh /app/docker-entrypoint.sh
-RUN chmod +x /app/docker-entrypoint.sh
+COPY --chmod=0755 deploy/docker-entrypoint.sh /app/docker-entrypoint.sh
 
 EXPOSE 8080
 

--- a/scripts/checks/release-goreleaser-docker.py
+++ b/scripts/checks/release-goreleaser-docker.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Verify the release GoReleaser Docker config stays multi-arch and v2-based.
+
+Release speed depends on GoReleaser's dockers_v2 path: one buildx invocation
+publishes the shared multi-arch tags directly. Reintroducing the legacy
+`dockers` + `docker_manifests` split silently adds extra registry pushes and
+manifest operations back into every release. Dropping arm64 is worse: prod and
+Edge Stage0 hosts are Graviton.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print(
+        "  err: PyYAML not installed (required to parse GoReleaser configs).\n"
+        "       fix: python3 -m pip install --user pyyaml",
+        flush=True,
+    )
+    sys.exit(2)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+MULTIARCH_CONFIGS = [
+    REPO_ROOT / ".goreleaser.yaml",
+    REPO_ROOT / ".goreleaser.full.yaml",
+]
+SIMPLE_CONFIG = REPO_ROOT / ".goreleaser.simple.yaml"
+DOCKERFILE = REPO_ROOT / "Dockerfile.goreleaser"
+
+
+def _rel(path: pathlib.Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def _load(path: pathlib.Path) -> dict:
+    if not path.is_file():
+        raise ValueError(f"{_rel(path)} not found")
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{_rel(path)} is not valid YAML: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise ValueError(f"{_rel(path)} must be a YAML mapping")
+    return doc
+
+
+def _check_no_legacy(path: pathlib.Path, doc: dict) -> list[str]:
+    errors: list[str] = []
+    if "dockers" in doc:
+        errors.append(
+            f"{_rel(path)} defines legacy `dockers`; use `dockers_v2` so release "
+            "does not return to per-arch image pushes."
+        )
+    if "docker_manifests" in doc:
+        errors.append(
+            f"{_rel(path)} defines legacy `docker_manifests`; `dockers_v2` should "
+            "publish shared tags directly."
+        )
+    return errors
+
+
+def _single_docker_config(path: pathlib.Path, doc: dict) -> dict:
+    dockers = doc.get("dockers_v2")
+    if not isinstance(dockers, list) or not dockers:
+        raise ValueError(f"{_rel(path)} must define at least one `dockers_v2` entry")
+    if len(dockers) != 1:
+        raise ValueError(
+            f"{_rel(path)} must keep one `dockers_v2` entry; multiple entries add "
+            "extra buildx/push work to every release"
+        )
+    cfg = dockers[0]
+    if not isinstance(cfg, dict):
+        raise ValueError(f"{_rel(path)} dockers_v2[0] must be a mapping")
+    return cfg
+
+
+def _check_multiarch(path: pathlib.Path, doc: dict) -> list[str]:
+    errors = _check_no_legacy(path, doc)
+    try:
+        cfg = _single_docker_config(path, doc)
+    except ValueError as exc:
+        return errors + [str(exc)]
+
+    platforms = cfg.get("platforms")
+    if platforms != ["linux/amd64", "linux/arm64"]:
+        errors.append(
+            f"{_rel(path)} dockers_v2[0].platforms = {platforms!r}; expected "
+            "['linux/amd64', 'linux/arm64'] for Graviton-safe release tags."
+        )
+
+    tags = cfg.get("tags")
+    required_tags = {"{{ .Version }}", "latest", "{{ .Major }}.{{ .Minor }}", "{{ .Major }}"}
+    if not isinstance(tags, list) or not required_tags.issubset(set(tags)):
+        errors.append(
+            f"{_rel(path)} dockers_v2[0].tags must include version/latest/major.minor/major "
+            "shared tags."
+        )
+
+    if cfg.get("dockerfile") != "Dockerfile.goreleaser":
+        errors.append(f"{_rel(path)} dockers_v2[0].dockerfile must be Dockerfile.goreleaser")
+
+    if "deploy/docker-entrypoint.sh" not in (cfg.get("extra_files") or []):
+        errors.append(f"{_rel(path)} must pass deploy/docker-entrypoint.sh via extra_files")
+
+    if cfg.get("ids") != ["sub2api"]:
+        errors.append(f"{_rel(path)} dockers_v2[0].ids must be ['sub2api']")
+
+    return errors
+
+
+def _check_simple(path: pathlib.Path, doc: dict) -> list[str]:
+    errors = _check_no_legacy(path, doc)
+    try:
+        cfg = _single_docker_config(path, doc)
+    except ValueError as exc:
+        return errors + [str(exc)]
+
+    if cfg.get("platforms") != ["linux/amd64"]:
+        errors.append(f"{_rel(path)} must stay explicit linux/amd64-only")
+    if cfg.get("ids") != ["sub2api"]:
+        errors.append(f"{_rel(path)} dockers_v2[0].ids must be ['sub2api']")
+    if cfg.get("dockerfile") != "Dockerfile.goreleaser":
+        errors.append(f"{_rel(path)} dockers_v2[0].dockerfile must be Dockerfile.goreleaser")
+    if "deploy/docker-entrypoint.sh" not in (cfg.get("extra_files") or []):
+        errors.append(f"{_rel(path)} must pass deploy/docker-entrypoint.sh via extra_files")
+    return errors
+
+
+def _check_dockerfile() -> list[str]:
+    if not DOCKERFILE.is_file():
+        return [f"{_rel(DOCKERFILE)} not found"]
+    text = DOCKERFILE.read_text()
+    errors: list[str] = []
+    if "ARG TARGETPLATFORM" not in text:
+        errors.append("Dockerfile.goreleaser must declare ARG TARGETPLATFORM for dockers_v2")
+    if (
+        "COPY --chown=sub2api:sub2api --chmod=0755 ${TARGETPLATFORM}/sub2api /app/sub2api"
+        not in text
+    ):
+        errors.append(
+            "Dockerfile.goreleaser must copy ${TARGETPLATFORM}/sub2api from the "
+            "dockers_v2 build context with final owner/mode"
+        )
+    if "COPY sub2api /app/sub2api" in text:
+        errors.append("Dockerfile.goreleaser still copies legacy root-level sub2api")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quiet", action="store_true", help="suppress success output")
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    for path in MULTIARCH_CONFIGS:
+        try:
+            errors.extend(_check_multiarch(path, _load(path)))
+        except ValueError as exc:
+            errors.append(str(exc))
+    try:
+        errors.extend(_check_simple(SIMPLE_CONFIG, _load(SIMPLE_CONFIG)))
+    except ValueError as exc:
+        errors.append(str(exc))
+    errors.extend(_check_dockerfile())
+
+    if errors:
+        for error in errors:
+            print(f"  err: {error}", flush=True)
+        return 1
+
+    if not args.quiet:
+        print("  ok: GoReleaser Docker config uses dockers_v2 with safe platforms")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1247,6 +1247,23 @@ else
     echo "  ok: release.yml simple_release default = false (Graviton-safe)"
 fi
 
+# ---- sub2api: GoReleaser Docker config is Graviton-safe + v2 ---------------
+# Keeps release.yml on the faster dockers_v2 path. The legacy `dockers` +
+# `docker_manifests` split pushes per-arch intermediate tags and then creates
+# shared manifests afterward; it is extra registry work on the slowest release
+# path. Default/full releases must also keep linux/arm64 because prod + Edge
+# Stage0 hosts are Graviton.
+echo ""
+echo "=== sub2api: GoReleaser Docker config ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required to parse GoReleaser configs)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/release-goreleaser-docker.py --quiet; then
+    errors=$((errors + 1))
+else
+    echo "  ok: GoReleaser Docker config uses dockers_v2 with safe platforms"
+fi
+
 # ---- sub2api: main ancestry anchor ------------------------------------------
 # Mechanizes CLAUDE.md §5.y / §5.y.1 ("`main` is immutable history once
 # pushed"). The previous enforcement stack worked on diff content; none of


### PR DESCRIPTION
## 摘要
- 将默认/full/simple GoReleaser Docker 配置迁到 `dockers_v2`，默认/full release 直接发布共享 multi-arch tags，减少旧 `dockers` + `docker_manifests` 的 per-arch 中间 tag 与后置 manifest 工作。
- 优化 `Dockerfile.goreleaser` 的应用层：用 `COPY --chown/--chmod` 设置二进制和 entrypoint 权限，避免 `chown -R /app` 把大二进制复制进第二层。
- 新增 `release-goreleaser-docker.py` 并接入 preflight，机械守住 release 配置必须走 `dockers_v2` 且默认/full 包含 `linux/arm64`。

## 风险
- 中等：release 镜像构建路径变化，但部署仍消费相同的 `ghcr.io/<owner>/sub2api:<tag>` multi-arch tags，未改 prod/Edge deploy workflow。
- `sentinel-registry-reviewed`：本 PR 修改 `Dockerfile.goreleaser` 是构建层与 GoReleaser build context 优化；已确认 `LABEL description="TokenKey - AI API Gateway Platform"` 品牌锚点未变，无需更新 brand sentinel registry。

## 验证
- `goreleaser check --config .goreleaser.yaml` / `.goreleaser.full.yaml` / `.goreleaser.simple.yaml`：通过。
- `docker buildx build --platform=linux/amd64 -f Dockerfile.goreleaser <mock dockers_v2 context> --load`：通过。
- `docker buildx build --platform=linux/arm64 -f Dockerfile.goreleaser <mock dockers_v2 context> --load`：通过。
- `python3 scripts/checks/release-goreleaser-docker.py`：通过。
- `./scripts/preflight.sh`：通过。

## 提交
- `16f8f12af` chore(release): reduce multi-arch image push work

最新提交：`16f8f12af`
