### PR TITLE
fix: avoid stale prod Kiro mirror 401 errors

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -393,6 +393,20 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		}
 		// 其他 400 错误（如参数问题）不处理，不禁用账号
 	case 401:
+		// TK (prod incident 2026-06-24): Kiro mirror stubs ride the Anthropic
+		// api-key transport, but the 401 is owned by the downstream edge Kiro
+		// OAuth account. The edge can force-refresh and clear its own OAuth
+		// state; permanently disabling the prod relay stub strands that recovered
+		// edge behind a stale error. Treat this as a transient downstream auth
+		// blip: fail over / let pool-mode retry absorb it, record a bounded
+		// saturation preference, and leave local stub health untouched.
+		if tkSkipDownstreamKiroOAuth401Penalty(account, statusCode, upstreamMsg, responseBody) {
+			slog.Info("anthropic_downstream_kiro_oauth_401_skip_penalty",
+				"account_id", account.ID,
+				"status_code", statusCode)
+			s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "kiro_oauth_401")
+			return true
+		}
 		// TK (prod P0 2026-06-13, GPT专线): a capability/scope-level 401 (the
 		// upstream rejects a specific capability — e.g. image generation — because
 		// the serving OAuth token lacks that capability's scope) must NOT cool or

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
@@ -98,3 +98,36 @@ func tkSkipDownstreamFailoverExhaustedPenalty(statusCode int, upstreamMsg string
 	}
 	return tkIsDownstreamAllAccountsExhausted(upstreamMsg, responseBody)
 }
+
+// tkIsKiroMirrorStub reports whether this local account is a prod Anthropic
+// api-key relay stub that represents the downstream edge Kiro pool.
+func tkIsKiroMirrorStub(account *Account) bool {
+	if account == nil || account.Platform != PlatformAnthropic || account.Type != AccountTypeAPIKey {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(account.GetCredential("mirror_platform")), string(PlatformKiro))
+}
+
+// tkSkipDownstreamKiroOAuth401Penalty identifies a Kiro edge OAuth 401 that
+// crossed the prod mirror boundary as an Anthropic api-key error. The prod stub
+// is only a relay; it has no Kiro OAuth token to refresh. The edge owns recovery
+// via kiro_oauth_401_force_refresh_recovered, so permanently SetError'ing the
+// prod stub would strand a healthy edge behind a stale mirror error.
+//
+// Scope is intentionally narrow: only Kiro mirror stubs, only 401, and only the
+// TokenKey downstream wrapper / Kiro Invalid bearer shape. Real Anthropic api-key
+// 401s and other mirror platforms keep the existing hard-disable behaviour.
+func tkSkipDownstreamKiroOAuth401Penalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool {
+	if statusCode != http.StatusUnauthorized || !tkIsKiroMirrorStub(account) {
+		return false
+	}
+	msg := strings.ToLower(strings.TrimSpace(upstreamMsg))
+	body := strings.ToLower(string(responseBody))
+	if strings.Contains(msg, "invalid bearer token") || strings.Contains(body, "invalid bearer token") {
+		return true
+	}
+	if strings.Contains(msg, "upstream request failed") || strings.Contains(body, "upstream request failed") {
+		return true
+	}
+	return false
+}

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
@@ -31,6 +31,35 @@ func TestTkSkipDownstreamNoAvailableAccountsPenalty(t *testing.T) {
 	require.False(t, tkSkipDownstreamNoAvailableAccountsPenalty(http.StatusTooManyRequests, "", []byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`)))
 }
 
+func TestTkSkipDownstreamKiroOAuth401Penalty(t *testing.T) {
+	stub := &Account{
+		ID:       66,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": "kiro",
+		},
+	}
+	body := []byte(`{"error":{"message":"Upstream request failed","type":"upstream_error"},"type":"error"}`)
+
+	require.True(t, tkSkipDownstreamKiroOAuth401Penalty(stub, http.StatusUnauthorized, "", body))
+	require.True(t, tkSkipDownstreamKiroOAuth401Penalty(stub, http.StatusUnauthorized, "Invalid bearer token", nil))
+	require.False(t, tkSkipDownstreamKiroOAuth401Penalty(stub, http.StatusForbidden, "Invalid bearer token", nil))
+
+	plainAnthropic := &Account{ID: 67, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	require.False(t, tkSkipDownstreamKiroOAuth401Penalty(plainAnthropic, http.StatusUnauthorized, "Invalid bearer token", nil))
+
+	openaiMirror := &Account{
+		ID:       68,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": "openai",
+		},
+	}
+	require.False(t, tkSkipDownstreamKiroOAuth401Penalty(openaiMirror, http.StatusUnauthorized, "Invalid bearer token", nil))
+}
+
 // prod incident 2026-05-31: a downstream edge stub returning 503 "no available
 // accounts" (a transient edge pool-capacity blip) must fail the request over to
 // the next stub WITHOUT advancing the per-account cooldown counter or cooling the
@@ -129,6 +158,44 @@ func TestRateLimitService_DownstreamNoAvailable_NilSaturationCounterIsInert(t *t
 	noAvail := []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)
 	require.True(t, service.HandleUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, noAvail))
 	require.Equal(t, 0, repo.tempCalls)
+}
+
+func TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth401_DoesNotSetError(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	sat := &fakeSaturationCounterRL{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicSaturationCounter(sat)
+	account := &Account{
+		ID:       66,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": "kiro",
+			"pool_mode":       true,
+		},
+	}
+	body := []byte(`{"error":{"message":"Upstream request failed","type":"upstream_error"},"type":"error"}`)
+
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, http.StatusUnauthorized, http.Header{}, body)
+
+	require.True(t, shouldDisable, "in-flight request must fail over / let pool-mode retry, but stub health stays untouched")
+	require.Equal(t, 0, repo.setErrorCalls, "downstream Kiro OAuth 401 must not permanently disable the prod relay stub")
+	require.Equal(t, 0, repo.tempCalls, "downstream Kiro OAuth 401 must not ladder-cool the prod relay stub")
+	require.Equal(t, 0, repo.setRateLimitedCalls)
+	require.Equal(t, []int64{66}, sat.incrementIDs, "transient downstream auth blip should feed bounded de-prioritization")
+}
+
+func TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsError(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{ID: 67, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	body := []byte(`{"error":{"message":"invalid x-api-key","type":"authentication_error"},"type":"error"}`)
+
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, http.StatusUnauthorized, http.Header{}, body)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.setErrorCalls, "real Anthropic api-key 401 must keep the permanent-disable guard")
+	require.Contains(t, repo.lastErrorMsg, "Authentication failed (401)")
 }
 
 // Regression: a genuine Anthropic upstream 503 (no "no available accounts" body)


### PR DESCRIPTION
## 摘要
- 将 `anthropic/apikey + mirror_platform=kiro` 的下游 Kiro OAuth 401 识别为 transient relay failure，不再永久 `SetError` prod mirror stub。
- 命中该路径时仍返回 failover / pool-mode retry 语义，并写入 bounded saturation counter，让持续抖动的 edge 短窗口降优先级，恢复后自动消退。
- 保留普通 Anthropic API key 401 的永久禁用保护不变。

## 风险
- 风险集中在 Anthropic transport 的 Kiro mirror stub 401 分类，scope 限定为 `mirror_platform=kiro` 且 401 body/message 包含下游 wrapper 或 `Invalid bearer token`。
- 对真实 Anthropic API key 401、非 Kiro mirror、OAuth 账号 401 的既有路径不放宽。
- Web impact: none。

## 验证
- `go test -tags unit ./internal/service -run 'TestTkSkipDownstreamKiroOAuth401Penalty|TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth401_DoesNotSetError|TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsError'`（在 `backend/`）
- `go test -tags unit ./internal/service`（在 `backend/`，rebase 前全量通过）
- `scripts/preflight.sh`

## 提交
- `169f879c5 fix: avoid stale prod Kiro mirror 401 errors`

最新提交：`169f879c5`
