### PR TITLE
chore: guard Kiro mirror 401 sentinel

### DIFF
--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -316,10 +316,33 @@
         "func tkSkipDownstreamNoAvailableAccountsPenalty(statusCode int, upstreamMsg string, responseBody []byte) bool",
         "func tkIsDownstreamAllAccountsExhausted(upstreamMsg string, responseBody []byte) bool",
         "func tkSkipDownstreamFailoverExhaustedPenalty(statusCode int, upstreamMsg string, responseBody []byte) bool",
+        "func tkIsKiroMirrorStub(account *Account) bool",
+        "func tkSkipDownstreamKiroOAuth401Penalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool",
         "all available accounts exhausted",
-        "ErrNoAvailableAccounts.Error()"
+        "ErrNoAvailableAccounts.Error()",
+        "mirror_platform",
+        "invalid bearer token",
+        "upstream request failed"
       ],
-      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and 'all available accounts exhausted' (G2 narrow, 429/5xx, downstream failover loop ran dry) are both TokenKey-generated downstream-capacity strings the real provider APIs never emit; a healthy forwarding stub must fail over without advancing the 3/3 ladder. Both skips match ONLY these TokenKey phrases, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. Dropping any function silently re-arms the corresponding downstream-error amplifier; widening the match beyond the TokenKey phrases would break route-away on genuinely-broken edges. Prod incidents 2026-05-31 / 2026-06 were both this misattribution: empty-pool downstream 503/429 punished as account health."
+      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and 'all available accounts exhausted' (G2 narrow, 429/5xx, downstream failover loop ran dry) are both TokenKey-generated downstream-capacity strings the real provider APIs never emit; a healthy forwarding stub must fail over without advancing the 3/3 ladder. Both skips match ONLY these TokenKey phrases, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. G5 Kiro mirror OAuth 401: a prod Anthropic API-key mirror stub whose credentials.mirror_platform=kiro may receive the edge Kiro OAuth account's 401 / invalid-bearer wrapper, but prod has no OAuth identity to refresh and must not SetError the relay stub after edge self-heals. Dropping the Kiro mirror predicate or 401 helper silently reintroduces stale prod stub errors after a successful edge force-refresh. Widening the match beyond Kiro mirror stubs would weaken real Anthropic API-key 401 protection. Prod incidents 2026-05-31 / 2026-06 were both this misattribution class: downstream edge state punished as prod stub health."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "tkSkipDownstreamKiroOAuth401Penalty(account, statusCode, upstreamMsg, responseBody)",
+        "anthropic_downstream_kiro_oauth_401_skip_penalty",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"kiro_oauth_401\")"
+      ],
+      "rationale": "G5 Kiro mirror OAuth 401 injection point in HandleUpstreamError case 401. This branch must run before the generic API-key SetError path so a relayed edge Kiro OAuth 401 fails over and feeds bounded mirror de-prioritization, while leaving prod mirror stub health untouched. If an upstream merge rewrites the 401 case and drops this call site, edge self-heal can clear the real OAuth account while prod keeps a stale API-key mirror SetError forever."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go",
+      "must_contain": [
+        "TestTkSkipDownstreamKiroOAuth401Penalty",
+        "TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth401_DoesNotSetError",
+        "TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsError"
+      ],
+      "rationale": "Focused regressions proving the G5 boundary: Kiro mirror-stub 401 / invalid-bearer wrappers are skipped without SetError, but a plain Anthropic API-key 401 still permanently disables the account. Dropping these tests lets an upstream merge silently widen or remove the 401 carve-out."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_request_too_large_test.go",


### PR DESCRIPTION
## 摘要
- 在 `scripts/sentinels/gateway-tk.json` 补 G5 Kiro mirror OAuth 401 门禁。
- 钉住 prod Anthropic API-key mirror stub 的 Kiro 401 skip helper、`ratelimit_service.go` 401 分支调用点、日志 marker、saturation reason 和边界回归测试。
- 防止后续 upstream merge 覆盖 #972 后，edge OAuth 已自愈但 prod mirror stub 仍被 stale `SetError` 卡住。

## 风险
- 只改 sentinel registry，不改运行时代码。
- 预期影响：后续 preflight / upstream-merge PR shape 会在相关实现或测试被覆盖删除时失败。

## 验证
- `python3 scripts/sentinels/check-gateway-tk.py`
- `scripts/preflight.sh`

## Web Impact
- none: sentinel registry only; no frontend/backend runtime behavior change.
