### PR TITLE
fix: skip prod Kiro mirror 403

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -400,7 +400,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		// edge behind a stale error. Treat this as a transient downstream auth
 		// blip: fail over / let pool-mode retry absorb it, record a bounded
 		// saturation preference, and leave local stub health untouched.
-		if tkSkipDownstreamKiroOAuth401Penalty(account, statusCode, upstreamMsg, responseBody) {
+		if tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, statusCode, upstreamMsg, responseBody) {
 			slog.Info("anthropic_downstream_kiro_oauth_401_skip_penalty",
 				"account_id", account.ID,
 				"status_code", statusCode)
@@ -1100,6 +1100,18 @@ func (s *RateLimitService) handle403(ctx context.Context, account *Account, upst
 		return true
 	}
 	if account.Platform == PlatformAnthropic {
+		// TK (prod mirror boundary): a Kiro edge OAuth invalid-bearer 403 can be
+		// relayed to prod as an Anthropic API-key stub 403. Prod has no Kiro OAuth
+		// token to refresh; the edge owns #970-style force-refresh. Treat the relay
+		// stub as healthy and fail over without entering the generic Anthropic 403
+		// ladder / permanent-disable checks.
+		if tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, http.StatusForbidden, upstreamMsg, responseBody) {
+			slog.Info("anthropic_downstream_kiro_oauth_403_skip_penalty",
+				"account_id", account.ID,
+				"status_code", http.StatusForbidden)
+			s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, "kiro_oauth_403")
+			return true
+		}
 		// TK (PR #691 cc-only canary prep): a relayed canonical-ingress strict 403
 		// from a downstream strict-mode edge is the end client's identity problem,
 		// not stub health — fail over to the next stub without advancing the 3/3

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
@@ -115,10 +115,12 @@ func tkIsKiroMirrorStub(account *Account) bool {
 // permanently SetError'ing the prod stub would strand a healthy edge behind a
 // stale mirror error.
 //
-// Scope is intentionally narrow: only Kiro mirror stubs, only 401/403, and only
-// the TokenKey downstream wrapper / Kiro Invalid bearer shape. Real Anthropic
-// api-key 401s, generic Anthropic 403s, and other mirror platforms keep the
-// existing hard-disable / ladder behaviour.
+// Scope is intentionally narrow: only Kiro mirror stubs and only the TokenKey
+// downstream wrapper / Kiro Invalid bearer shape. 401 keeps the existing wrapper
+// compatibility; 403 mirrors the edge-local #970 force-refresh predicate and
+// requires the invalid-bearer signal. Real Anthropic api-key 401s, generic
+// Anthropic 403s, and other mirror platforms keep the existing hard-disable /
+// ladder behaviour.
 func tkSkipDownstreamKiroOAuthAuthRejectPenalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool {
 	if (statusCode != http.StatusUnauthorized && statusCode != http.StatusForbidden) || !tkIsKiroMirrorStub(account) {
 		return false
@@ -127,6 +129,9 @@ func tkSkipDownstreamKiroOAuthAuthRejectPenalty(account *Account, statusCode int
 	body := strings.ToLower(string(responseBody))
 	if strings.Contains(msg, "invalid bearer token") || strings.Contains(body, "invalid bearer token") {
 		return true
+	}
+	if statusCode == http.StatusForbidden {
+		return false
 	}
 	if strings.Contains(msg, "upstream request failed") || strings.Contains(body, "upstream request failed") {
 		return true

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
@@ -108,17 +108,19 @@ func tkIsKiroMirrorStub(account *Account) bool {
 	return strings.EqualFold(strings.TrimSpace(account.GetCredential("mirror_platform")), string(PlatformKiro))
 }
 
-// tkSkipDownstreamKiroOAuth401Penalty identifies a Kiro edge OAuth 401 that
-// crossed the prod mirror boundary as an Anthropic api-key error. The prod stub
-// is only a relay; it has no Kiro OAuth token to refresh. The edge owns recovery
-// via kiro_oauth_401_force_refresh_recovered, so permanently SetError'ing the
-// prod stub would strand a healthy edge behind a stale mirror error.
+// tkSkipDownstreamKiroOAuthAuthRejectPenalty identifies a Kiro edge OAuth auth
+// rejection that crossed the prod mirror boundary as an Anthropic api-key error.
+// The prod stub is only a relay; it has no Kiro OAuth token to refresh. The edge
+// owns recovery via kiro_oauth_auth_reject_force_refresh_recovered, so
+// permanently SetError'ing the prod stub would strand a healthy edge behind a
+// stale mirror error.
 //
-// Scope is intentionally narrow: only Kiro mirror stubs, only 401, and only the
-// TokenKey downstream wrapper / Kiro Invalid bearer shape. Real Anthropic api-key
-// 401s and other mirror platforms keep the existing hard-disable behaviour.
-func tkSkipDownstreamKiroOAuth401Penalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool {
-	if statusCode != http.StatusUnauthorized || !tkIsKiroMirrorStub(account) {
+// Scope is intentionally narrow: only Kiro mirror stubs, only 401/403, and only
+// the TokenKey downstream wrapper / Kiro Invalid bearer shape. Real Anthropic
+// api-key 401s, generic Anthropic 403s, and other mirror platforms keep the
+// existing hard-disable / ladder behaviour.
+func tkSkipDownstreamKiroOAuthAuthRejectPenalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool {
+	if (statusCode != http.StatusUnauthorized && statusCode != http.StatusForbidden) || !tkIsKiroMirrorStub(account) {
 		return false
 	}
 	msg := strings.ToLower(strings.TrimSpace(upstreamMsg))

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
@@ -44,7 +44,7 @@ func TestTkSkipDownstreamKiroOAuthAuthRejectPenalty(t *testing.T) {
 
 	require.True(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(stub, http.StatusUnauthorized, "", body))
 	require.True(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(stub, http.StatusUnauthorized, "Invalid bearer token", nil))
-	require.True(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(stub, http.StatusForbidden, "", body))
+	require.False(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(stub, http.StatusForbidden, "", body))
 	require.True(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(stub, http.StatusForbidden, "Invalid bearer token", nil))
 	require.False(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(stub, http.StatusBadRequest, "Invalid bearer token", nil))
 
@@ -215,6 +215,33 @@ func TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth403_DoesNotSetError
 	require.Equal(t, 0, repo.setRateLimitedCalls)
 	require.Empty(t, ladder.incrementIDs, "downstream Kiro OAuth 403 must not advance the 3/3 ladder")
 	require.Equal(t, []int64{66}, sat.incrementIDs, "transient downstream auth blip should feed bounded de-prioritization")
+}
+
+func TestRateLimitService_HandleUpstreamError_KiroMirrorGeneric403_StillCounts(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{3}, tierCounts: []int64{1}}
+	sat := &fakeSaturationCounterRL{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+	service.SetAnthropicSaturationCounter(sat)
+	account := &Account{
+		ID:       66,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": "kiro",
+			"pool_mode":       true,
+		},
+	}
+	body := []byte(`{"error":{"message":"Upstream request failed","type":"upstream_error"},"type":"error"}`)
+
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, http.StatusForbidden, http.Header{}, body)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 0, repo.setErrorCalls, "generic Kiro mirror 403 must not use the invalid-bearer skip")
+	require.Equal(t, 1, repo.tempCalls, "generic Kiro mirror 403 must still enter the upstream-error ladder")
+	require.Equal(t, []int64{66}, counter.incrementIDs)
+	require.Empty(t, sat.incrementIDs, "generic Kiro mirror 403 must not feed auth-reject saturation")
 }
 
 func TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsError(t *testing.T) {

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
@@ -31,7 +31,7 @@ func TestTkSkipDownstreamNoAvailableAccountsPenalty(t *testing.T) {
 	require.False(t, tkSkipDownstreamNoAvailableAccountsPenalty(http.StatusTooManyRequests, "", []byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`)))
 }
 
-func TestTkSkipDownstreamKiroOAuth401Penalty(t *testing.T) {
+func TestTkSkipDownstreamKiroOAuthAuthRejectPenalty(t *testing.T) {
 	stub := &Account{
 		ID:       66,
 		Platform: PlatformAnthropic,
@@ -42,12 +42,15 @@ func TestTkSkipDownstreamKiroOAuth401Penalty(t *testing.T) {
 	}
 	body := []byte(`{"error":{"message":"Upstream request failed","type":"upstream_error"},"type":"error"}`)
 
-	require.True(t, tkSkipDownstreamKiroOAuth401Penalty(stub, http.StatusUnauthorized, "", body))
-	require.True(t, tkSkipDownstreamKiroOAuth401Penalty(stub, http.StatusUnauthorized, "Invalid bearer token", nil))
-	require.False(t, tkSkipDownstreamKiroOAuth401Penalty(stub, http.StatusForbidden, "Invalid bearer token", nil))
+	require.True(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(stub, http.StatusUnauthorized, "", body))
+	require.True(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(stub, http.StatusUnauthorized, "Invalid bearer token", nil))
+	require.True(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(stub, http.StatusForbidden, "", body))
+	require.True(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(stub, http.StatusForbidden, "Invalid bearer token", nil))
+	require.False(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(stub, http.StatusBadRequest, "Invalid bearer token", nil))
 
 	plainAnthropic := &Account{ID: 67, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
-	require.False(t, tkSkipDownstreamKiroOAuth401Penalty(plainAnthropic, http.StatusUnauthorized, "Invalid bearer token", nil))
+	require.False(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(plainAnthropic, http.StatusUnauthorized, "Invalid bearer token", nil))
+	require.False(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(plainAnthropic, http.StatusForbidden, "Invalid bearer token", nil))
 
 	openaiMirror := &Account{
 		ID:       68,
@@ -57,7 +60,8 @@ func TestTkSkipDownstreamKiroOAuth401Penalty(t *testing.T) {
 			"mirror_platform": "openai",
 		},
 	}
-	require.False(t, tkSkipDownstreamKiroOAuth401Penalty(openaiMirror, http.StatusUnauthorized, "Invalid bearer token", nil))
+	require.False(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(openaiMirror, http.StatusUnauthorized, "Invalid bearer token", nil))
+	require.False(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(openaiMirror, http.StatusForbidden, "Invalid bearer token", nil))
 }
 
 // prod incident 2026-05-31: a downstream edge stub returning 503 "no available
@@ -185,6 +189,34 @@ func TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth401_DoesNotSetError
 	require.Equal(t, []int64{66}, sat.incrementIDs, "transient downstream auth blip should feed bounded de-prioritization")
 }
 
+func TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth403_DoesNotSetError(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	ladder := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1, 2, 3}}
+	sat := &fakeSaturationCounterRL{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(ladder)
+	service.SetAnthropicSaturationCounter(sat)
+	account := &Account{
+		ID:       66,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": "kiro",
+			"pool_mode":       true,
+		},
+	}
+	body := []byte(`{"error":{"message":"Invalid bearer token","type":"upstream_error"},"type":"error"}`)
+
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, http.StatusForbidden, http.Header{}, body)
+
+	require.True(t, shouldDisable, "in-flight request must fail over / let pool-mode retry, but stub health stays untouched")
+	require.Equal(t, 0, repo.setErrorCalls, "downstream Kiro OAuth 403 must not permanently disable the prod relay stub")
+	require.Equal(t, 0, repo.tempCalls, "downstream Kiro OAuth 403 must not ladder-cool the prod relay stub")
+	require.Equal(t, 0, repo.setRateLimitedCalls)
+	require.Empty(t, ladder.incrementIDs, "downstream Kiro OAuth 403 must not advance the 3/3 ladder")
+	require.Equal(t, []int64{66}, sat.incrementIDs, "transient downstream auth blip should feed bounded de-prioritization")
+}
+
 func TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsError(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
 	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
@@ -196,6 +228,22 @@ func TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsE
 	require.True(t, shouldDisable)
 	require.Equal(t, 1, repo.setErrorCalls, "real Anthropic api-key 401 must keep the permanent-disable guard")
 	require.Contains(t, repo.lastErrorMsg, "Authentication failed (401)")
+}
+
+func TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey403_StillCounts(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{3}, tierCounts: []int64{1}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+	account := &Account{ID: 67, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	body := []byte(`{"error":{"message":"Invalid bearer token","type":"permission_error"},"type":"error"}`)
+
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, http.StatusForbidden, http.Header{}, body)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 0, repo.setErrorCalls, "generic Anthropic API-key 403 must not use the Kiro mirror skip")
+	require.Equal(t, 1, repo.tempCalls, "generic Anthropic API-key 403 must still enter the upstream-error ladder")
+	require.Equal(t, []int64{67}, counter.incrementIDs)
 }
 
 // Regression: a genuine Anthropic upstream 503 (no "no available accounts" body)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -319,13 +319,14 @@
         "func tkIsKiroMirrorStub(account *Account) bool",
         "func tkSkipDownstreamKiroOAuthAuthRejectPenalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool",
         "statusCode != http.StatusUnauthorized && statusCode != http.StatusForbidden",
+        "if statusCode == http.StatusForbidden {",
         "all available accounts exhausted",
         "ErrNoAvailableAccounts.Error()",
         "mirror_platform",
         "invalid bearer token",
         "upstream request failed"
       ],
-      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and 'all available accounts exhausted' (G2 narrow, 429/5xx, downstream failover loop ran dry) are both TokenKey-generated downstream-capacity strings the real provider APIs never emit; a healthy forwarding stub must fail over without advancing the 3/3 ladder. Both skips match ONLY these TokenKey phrases, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. G5 Kiro mirror OAuth auth rejection: a prod Anthropic API-key mirror stub whose credentials.mirror_platform=kiro may receive the edge Kiro OAuth account's 401/403 invalid-bearer wrapper, but prod has no OAuth identity to refresh and must not SetError or ladder-cool the relay stub after edge self-heals. Dropping the Kiro mirror predicate or auth-reject helper silently reintroduces stale prod stub errors after a successful edge force-refresh. Widening the match beyond Kiro mirror stubs would weaken real Anthropic API-key 401 protection and generic Anthropic 403 route-away handling. Prod incidents 2026-05-31 / 2026-06 were both this misattribution class: downstream edge state punished as prod stub health."
+      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and 'all available accounts exhausted' (G2 narrow, 429/5xx, downstream failover loop ran dry) are both TokenKey-generated downstream-capacity strings the real provider APIs never emit; a healthy forwarding stub must fail over without advancing the 3/3 ladder. Both skips match ONLY these TokenKey phrases, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. G5 Kiro mirror OAuth auth rejection: a prod Anthropic API-key mirror stub whose credentials.mirror_platform=kiro may receive the edge Kiro OAuth account's 401/403 invalid-bearer wrapper, but prod has no OAuth identity to refresh and must not SetError or ladder-cool the relay stub after edge self-heals. 401 keeps the existing TokenKey wrapper compatibility; 403 must require the invalid-bearer signal to mirror #970 and must not skip a generic upstream_request_failed wrapper. Dropping the Kiro mirror predicate or auth-reject helper silently reintroduces stale prod stub errors after a successful edge force-refresh. Widening the match beyond Kiro mirror stubs would weaken real Anthropic API-key 401 protection and generic Anthropic 403 route-away handling. Prod incidents 2026-05-31 / 2026-06 were both this misattribution class: downstream edge state punished as prod stub health."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",
@@ -345,10 +346,11 @@
         "TestTkSkipDownstreamKiroOAuthAuthRejectPenalty",
         "TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth401_DoesNotSetError",
         "TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth403_DoesNotSetError",
+        "TestRateLimitService_HandleUpstreamError_KiroMirrorGeneric403_StillCounts",
         "TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsError",
         "TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey403_StillCounts"
       ],
-      "rationale": "Focused regressions proving the G5 boundary: Kiro mirror-stub 401/403 invalid-bearer wrappers are skipped without SetError or ladder cooldown, but a plain Anthropic API-key 401 still permanently disables and a plain Anthropic API-key 403 still enters the upstream-error ladder. Dropping these tests lets an upstream merge silently widen or remove the auth-reject carve-out."
+      "rationale": "Focused regressions proving the G5 boundary: Kiro mirror-stub 401/403 invalid-bearer wrappers are skipped without SetError or ladder cooldown, but a generic Kiro mirror 403 wrapper still enters the upstream-error ladder, a plain Anthropic API-key 401 still permanently disables, and a plain Anthropic API-key 403 still enters the ladder. Dropping these tests lets an upstream merge silently widen or remove the auth-reject carve-out."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_request_too_large_test.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -317,32 +317,38 @@
         "func tkIsDownstreamAllAccountsExhausted(upstreamMsg string, responseBody []byte) bool",
         "func tkSkipDownstreamFailoverExhaustedPenalty(statusCode int, upstreamMsg string, responseBody []byte) bool",
         "func tkIsKiroMirrorStub(account *Account) bool",
-        "func tkSkipDownstreamKiroOAuth401Penalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool",
+        "func tkSkipDownstreamKiroOAuthAuthRejectPenalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool",
+        "statusCode != http.StatusUnauthorized && statusCode != http.StatusForbidden",
         "all available accounts exhausted",
         "ErrNoAvailableAccounts.Error()",
         "mirror_platform",
         "invalid bearer token",
         "upstream request failed"
       ],
-      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and 'all available accounts exhausted' (G2 narrow, 429/5xx, downstream failover loop ran dry) are both TokenKey-generated downstream-capacity strings the real provider APIs never emit; a healthy forwarding stub must fail over without advancing the 3/3 ladder. Both skips match ONLY these TokenKey phrases, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. G5 Kiro mirror OAuth 401: a prod Anthropic API-key mirror stub whose credentials.mirror_platform=kiro may receive the edge Kiro OAuth account's 401 / invalid-bearer wrapper, but prod has no OAuth identity to refresh and must not SetError the relay stub after edge self-heals. Dropping the Kiro mirror predicate or 401 helper silently reintroduces stale prod stub errors after a successful edge force-refresh. Widening the match beyond Kiro mirror stubs would weaken real Anthropic API-key 401 protection. Prod incidents 2026-05-31 / 2026-06 were both this misattribution class: downstream edge state punished as prod stub health."
+      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and 'all available accounts exhausted' (G2 narrow, 429/5xx, downstream failover loop ran dry) are both TokenKey-generated downstream-capacity strings the real provider APIs never emit; a healthy forwarding stub must fail over without advancing the 3/3 ladder. Both skips match ONLY these TokenKey phrases, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. G5 Kiro mirror OAuth auth rejection: a prod Anthropic API-key mirror stub whose credentials.mirror_platform=kiro may receive the edge Kiro OAuth account's 401/403 invalid-bearer wrapper, but prod has no OAuth identity to refresh and must not SetError or ladder-cool the relay stub after edge self-heals. Dropping the Kiro mirror predicate or auth-reject helper silently reintroduces stale prod stub errors after a successful edge force-refresh. Widening the match beyond Kiro mirror stubs would weaken real Anthropic API-key 401 protection and generic Anthropic 403 route-away handling. Prod incidents 2026-05-31 / 2026-06 were both this misattribution class: downstream edge state punished as prod stub health."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
-        "tkSkipDownstreamKiroOAuth401Penalty(account, statusCode, upstreamMsg, responseBody)",
+        "tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, statusCode, upstreamMsg, responseBody)",
+        "tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, http.StatusForbidden, upstreamMsg, responseBody)",
         "anthropic_downstream_kiro_oauth_401_skip_penalty",
-        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"kiro_oauth_401\")"
+        "anthropic_downstream_kiro_oauth_403_skip_penalty",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"kiro_oauth_401\")",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, \"kiro_oauth_403\")"
       ],
-      "rationale": "G5 Kiro mirror OAuth 401 injection point in HandleUpstreamError case 401. This branch must run before the generic API-key SetError path so a relayed edge Kiro OAuth 401 fails over and feeds bounded mirror de-prioritization, while leaving prod mirror stub health untouched. If an upstream merge rewrites the 401 case and drops this call site, edge self-heal can clear the real OAuth account while prod keeps a stale API-key mirror SetError forever."
+      "rationale": "G5 Kiro mirror OAuth auth-reject injection points. The 401 branch must run before the generic API-key SetError path, and the 403 branch must run before handle403's generic Anthropic 403 ladder / permanent-disable checks, so relayed edge Kiro OAuth invalid-bearer errors fail over and feed bounded mirror de-prioritization while leaving prod mirror stub health untouched. If an upstream merge rewrites either call site, edge self-heal can clear the real OAuth account while prod keeps a stale API-key mirror SetError or ladder cooldown."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go",
       "must_contain": [
-        "TestTkSkipDownstreamKiroOAuth401Penalty",
+        "TestTkSkipDownstreamKiroOAuthAuthRejectPenalty",
         "TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth401_DoesNotSetError",
-        "TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsError"
+        "TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth403_DoesNotSetError",
+        "TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsError",
+        "TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey403_StillCounts"
       ],
-      "rationale": "Focused regressions proving the G5 boundary: Kiro mirror-stub 401 / invalid-bearer wrappers are skipped without SetError, but a plain Anthropic API-key 401 still permanently disables the account. Dropping these tests lets an upstream merge silently widen or remove the 401 carve-out."
+      "rationale": "Focused regressions proving the G5 boundary: Kiro mirror-stub 401/403 invalid-bearer wrappers are skipped without SetError or ladder cooldown, but a plain Anthropic API-key 401 still permanently disables and a plain Anthropic API-key 403 still enters the upstream-error ladder. Dropping these tests lets an upstream merge silently widen or remove the auth-reject carve-out."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_request_too_large_test.go",


### PR DESCRIPTION
## 摘要
- 将 prod Anthropic API-key Kiro mirror stub 的下游 Kiro OAuth auth rejection 识别从 401 扩展到 403。
- 403 仅在命中 Kiro mirror + Invalid bearer 时 failover 并记录 bounded saturation；generic upstream wrapper 仍走 Anthropic 403 ladder。
- 更新 gateway sentinel，防止后续 upstream merge 漏掉 401/403 注入点和 403 窄匹配边界。

## 风险
- 范围限定在 `credentials.mirror_platform=kiro` 的 prod Anthropic API-key mirror stub。
- 普通 Anthropic API-key 401 仍永久 SetError；普通/通用 wrapper Anthropic 403 仍进入 upstream-error ladder。
- Web impact: none。

## 验证
- `go test -tags unit ./internal/service -run 'TestTkSkipDownstreamKiroOAuthAuthRejectPenalty|TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth401_DoesNotSetError|TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth403_DoesNotSetError|TestRateLimitService_HandleUpstreamError_KiroMirrorGeneric403_StillCounts|TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsError|TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey403_StillCounts'`（在 `backend/` 下运行）
- `./scripts/preflight.sh`

## 提交
- `dae0b6e48 fix: skip prod Kiro mirror 403 no-web-impact`
- `a67adf447 fix: narrow prod Kiro mirror 403 no-web-impact`
- 最新提交：`a67adf447`
