### PR TITLE
fix(stage0): harden prod blue-green deploy follow-up

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -44,7 +44,7 @@ CFN 模板已把 `docker-compose.yml`、`Caddyfile`、`deploy/aws/stage0/tokenke
 
 ### 把 Caddyfile 改动落到「已经在跑」的主机（热同步）
 
-`deploy-stage0.yml` / `deploy_via_ssm.sh` **只换镜像，不刷新 Caddyfile**——Caddyfile 是开机时由 UserData 从 SSM Parameter 渲染一次的。所以改了 `lb_try_duration` 这类指令后，现有 prod/edge 主机要等下次重建才生效。两条生效路径：
+`deploy_via_ssm.sh`（Lightsail edge / legacy single-app path）**只换镜像，不刷新 Caddyfile**——Caddyfile 是开机时由 UserData 从 SSM Parameter 渲染一次的。所以改了 `lb_try_duration` 这类指令后，现有主机要等下次重建才生效。两条生效路径：
 
 - **下次重建生效（reboot durability）**：`build-cfn.sh` 已把新 Caddyfile 嵌进 CFN 模板的 SSM 段；一次普通 `update-stack`（或重新 provision / EIP 轮换）就把新 blob 推进 Parameter Store，下次开机渲染即新值。更新 SSM Parameter 资源**不会**替换实例（UserData 只在启动时跑）。
 - **立刻生效（live host）**：跑热同步脚本，在运行中的主机上按开机同样的方式重渲染 Caddyfile 并 `caddy reload`（零断连）：
@@ -57,11 +57,11 @@ bash ops/stage0/sync_caddyfile_via_ssm.sh prod <instance-id>
 EDGE_ID=<edge> bash ops/stage0/sync_caddyfile_via_ssm.sh edge <mi-id>
 ```
 
-脚本复刻开机渲染：`API_DOMAIN`/`ACME_EMAIL` 取自主机 `.env`；edge 的 `MAIN_GATEWAY_ALLOWED_CIDR`（不在 `.env`）从当前 Caddyfile 的 `remote_ip` 行反读以原样保留 allowlist。先在一次性 caddy 容器里 `caddy validate`，通过才**就地**写回（`cat > Caddyfile` 保 inode，避免 bind-mount 单文件换 inode 后容器看不到），再 `caddy reload`；任一步失败自动回滚到备份并 reload。
+脚本复刻开机渲染：`API_DOMAIN`/`ACME_EMAIL` 取自主机 `.env`；edge 的 `MAIN_GATEWAY_ALLOWED_CIDR`（不在 `.env`）从当前 Caddyfile 的 `remote_ip` 行反读以原样保留 allowlist。prod 主机如果已迁移到 blue/green，会在渲染 canonical Caddyfile 后保留当前 `active-color` 对应的 `tokenkey-blue|green:8080` upstream，避免热同步把流量指回 legacy `tokenkey:8080`。先在一次性 caddy 容器里 `caddy validate`，通过才**就地**写回（`cat > Caddyfile` 保 inode，避免 bind-mount 单文件换 inode 后容器看不到），再 `caddy reload`；任一步失败自动回滚到备份并 reload。
 
 ### 把 #811 的 swap + 内存压力告警落到「已经在跑」的 prod（不重建实例）
 
-同一道理：`deploy-stage0.yml` 只换镜像、**不跑 bootstrap**，所以 #811 给 `stage0-ec2-bootstrap.sh` 加的 `/swapfile` 释放阀 + `vm.swappiness`/`vfs_cache_pressure` sysctl，以及 `tokenkey-disk-metrics.sh` 里的内存压力告警，都只在**实例 bootstrap**时落地——#811 之前 provision 的 prod 实例不会有。两条生效路径：
+同一道理：`deploy-stage0.yml` 虽然会更新 app 镜像和 blue/green runtime state，但**不跑 EC2 bootstrap / CloudFormation UserData**，所以 #811 给 `stage0-ec2-bootstrap.sh` 加的 `/swapfile` 释放阀 + `vm.swappiness`/`vfs_cache_pressure` sysctl，以及 `tokenkey-disk-metrics.sh` 里的内存压力告警，都只在**实例 bootstrap**时落地——#811 之前 provision 的 prod 实例不会有。两条生效路径：
 
 - **下次重建生效**：换机 / CFN 更新时 bootstrap 自动装上（#804 已 pin AMI，换机不退版）。
 - **立刻生效（live host，prod-only）**：dispatch `ops-stage0-host-mem-guard.yml -f target=prod`（或本地 `bash ops/stage0/sync-host-mem-guard-via-ssm.sh <instance-id>`）。原语在运行中的实例上 fallocate swap + 写 sysctl + 刷新 `tokenkey-disk-metrics.sh`，**两段 payload 都从 `stage0-ec2-bootstrap.sh` 运行时抽取**（单一源、无副本漂移）；幂等（swap 已在则跳过、disk-metrics 原地覆盖由 5min timer 复跑）。edge 是 Lightsail 中继、另一套 bootstrap、无此 timer，故不覆盖。
@@ -224,7 +224,7 @@ Runtime state on the prod host:
 - active app containers: `tokenkey-blue` or `tokenkey-green`
 - systemd restart policy: `tokenkey.service` starts Postgres/Redis, the active app color, and Caddy; it does not restart the legacy `tokenkey` app.
 
-Rollback is a normal redeploy of the previous known-good image tag through `deploy-stage0.yml`; the script pulls it into the inactive color, switches Caddy after health is green, and drains the current color. Destructive DB migrations remain the main semantic risk: any new/changed SQL migration with `DROP`, `RENAME`, `SET NOT NULL`, or `ALTER ... TYPE` must pass `scripts/checks/bluegreen-migration-safety.py` via `scripts/preflight.sh` before merge, or carry an explicit `bluegreen-safe-destructive-ok` comment after manual expand-contract review.
+Rollback is a normal redeploy of the previous known-good image tag through `deploy-stage0.yml`; the script pulls it into the inactive color, switches Caddy after health is green, and drains the current color. Destructive DB migrations remain the main semantic risk: any new/changed SQL migration with `DROP`, `RENAME`, `SET NOT NULL`, `ADD COLUMN ... NOT NULL`, or `ALTER ... TYPE` must pass `scripts/checks/bluegreen-migration-safety.py` via `scripts/preflight.sh` before merge, or carry an explicit `bluegreen-safe-destructive-ok` comment after manual expand-contract review.
 
 
 > 2026-04-21 实测：prod 栈 CFN `ImageTag=1.2.0`，但运行态 `TOKENKEY_IMAGE` 与容器实际镜像均为 `ghcr.io/youxuanxue/sub2api:1.4.1`（SSM 原地升级后形成的受控漂移）。

--- a/docs/approved/deploy-stage0-workflow.md
+++ b/docs/approved/deploy-stage0-workflow.md
@@ -6,7 +6,7 @@ approved_at: 2026-04-24
 created: 2026-04-23
 shipped_at: 2026-04-24
 owners: [tk-platform]
-related_prs: ["#53", "#976"]
+related_prs: ["#53", "#976", "#978"]
 # First successful prod deploy via the new workflow:
 #   GHA run https://github.com/youxuanxue/sub2api/actions/runs/24872412714
 #   (env=prod, tag=1.6.0, no-op image hash, external /health 200).
@@ -260,9 +260,9 @@ Step 6.
       (env=prod, tag=1.6.0, external `/health` HTTP 200)
 - [x] Status flipped to `shipped` (this PR)
 - [x] 2026-06-24 revision: prod deploy primitive changed from single-container
-      restart to same-host blue/green, single data layer. Approved by
-      youxuanxue in the PR #976 review path; merge of #976 makes this section
-      the new conformance baseline.
+      restart to same-host blue/green, single data layer. PR #976 shipped the
+      runtime change; PR #978 hardened the approved baseline, Caddy active
+      upstream handling, SSM timeout, and migration-safety guard.
 
 ### Adversarial gate verified
 

--- a/docs/approved/deploy-stage0-workflow.md
+++ b/docs/approved/deploy-stage0-workflow.md
@@ -6,52 +6,53 @@ approved_at: 2026-04-24
 created: 2026-04-23
 shipped_at: 2026-04-24
 owners: [tk-platform]
-related_prs: ["#53"]
+related_prs: ["#53", "#976"]
 # First successful prod deploy via the new workflow:
 #   GHA run https://github.com/youxuanxue/sub2api/actions/runs/24872412714
 #   (env=prod, tag=1.6.0, no-op image hash, external /health 200).
 # Adversarial fail-closed gate also verified:
 #   GHA run https://github.com/youxuanxue/sub2api/actions/runs/24872388875
 #   (tag=99.99.99 → exited at GHCR manifest precheck before any AWS call).
-scope: ".github/workflows/deploy-stage0.yml (prod-only) + ops/stage0/post_deploy_smoke.sh + IAM in deploy/aws/cloudformation/cicd-oidc.yaml"
+scope: ".github/workflows/deploy-stage0.yml (prod-only) + ops/stage0/deploy_via_ssm_bluegreen.sh + ops/stage0/post_deploy_smoke.sh + scripts/checks/bluegreen-migration-safety.py + IAM in deploy/aws/cloudformation/cicd-oidc.yaml"
 ---
 
 # Cloud-Agent-Driven Tag-and-Deploy Workflow
 
 ## 1. Why this exists
 
-The release loop "tag → `release.yml` builds image → operator runs SSM SOP
-from a workstation → verify health" today requires an operator-side step
-that no cloud agent can take: the existing `AWS_OIDC_ROLE_ARN` trust
-policy only accepts the GitHub Actions OIDC issuer, not a cloud-agent VM.
-Every release is therefore gated on a human pasting the multi-line
-`aws ssm send-command` block from `deploy/aws/README.md` § 生产升级 SOP,
-even though the command is mechanical and identical between releases.
+The release loop is now: tag → `release.yml` builds a multi-arch image →
+operator dispatches one prod Environment-gated workflow → the workflow performs
+the same-host blue/green SSM deploy, external health check, and gateway smoke.
 
-This proposal adds **one** workflow `.github/workflows/deploy-stage0.yml`
-that wraps that SOP. The cloud-agent loop becomes:
+This document originally approved the cloud-agent wrapper around the old manual
+SSM SOP. The 2026-06-24 revision keeps the same GitHub Environment/OIDC control
+plane, but changes the prod host mutation from single-container restart to
+same-host blue/green, single data layer. The operator loop remains:
 
 ```
 bash scripts/release-tag.sh vX.Y.Z                                 # existing
 gh workflow run deploy-stage0.yml -f tag=X.Y.Z                     # NEW (gated by prod Environment reviewer)
 ```
 
-The workflow only **automates the keystrokes** the operator already runs
-by hand. No new AWS infrastructure, no behavior change to `release.yml`
-or the stage0 stack, no new SSM Documents.
+No new AWS infrastructure or SSM Document is introduced. The behavior change is
+limited to runtime state on the existing prod EC2 host: two app colors,
+`active-color`, generated blue/green compose, blue/green `tokenkey.service`, and
+Caddy active-upstream rewrites.
 
 ## 2. Why this is high-risk
 
 Per `product-dev.mdc` §高风险 — prod-touching automation that:
 
-- **Mutates durable host state**: rewrites `/var/lib/tokenkey/.env` and
-  restarts the prod `tokenkey` container.
+- **Mutates durable host state**: rewrites `/var/lib/tokenkey/.env`, writes
+  blue/green compose and `active-color`, installs a blue/green
+  `tokenkey.service`, rewrites the live Caddy upstream, and starts/stops app
+  color containers.
 - **Expands a security boundary** (Section 3): adds the `environment:prod`
   OIDC subject to the existing role (prod Stage0 deploy only).
 - **Has high blast radius**: a wrong tag, an arch-mismatched image
-  (`simple_release=true` amd64-only on Graviton), or an unhealthy
-  container after restart all surface as immediate API outage on
-  `api.tokenkey.dev`.
+  (`simple_release=true` amd64-only on Graviton), incompatible DB migration,
+  bad Caddy upstream rewrite, or an unhealthy target color after cutover can
+  surface as API errors on `api.tokenkey.dev`.
 
 What stops these risks from materialising lives in Section 4 (workflow
 shape) and Section 5 (operator setup); each item is a hard mechanical
@@ -95,22 +96,54 @@ Steps:
    containing both `linux/amd64` and `linux/arm64` descriptors. Fail-closed
    unless `simple_release_override=true`. This is the §9.1 trap rebuilt as
    a hard gate at deploy time.
-3. **Configure AWS credentials via OIDC** — `aws-actions/configure-aws-credentials@v4`,
+3. **Configure AWS credentials via OIDC** — `aws-actions/configure-aws-credentials@v6`,
    role from `vars.AWS_OIDC_ROLE_ARN`. The job-level **`environment: prod`**
    binding (a) adds the subject the IAM trust requires, (b) pauses for any
    reviewer rule configured on the prod Environment (Section 5).
-4. **Resolve target instance + api domain** from the stack's
+4. **Blue/green migration safety gate** — compare the target release tag to
+   the previous release tag (fallback `origin/main..HEAD` only when the target
+   tag cannot be resolved locally) and scan changed SQL migrations for
+   old-code-incompatible patterns. `DROP`, `RENAME`, `SET NOT NULL`,
+   `ADD COLUMN ... NOT NULL`, and `ALTER ... TYPE` require an explicit
+   `bluegreen-safe-destructive-ok` acknowledgement after expand/contract
+   review. This is fail-closed before AWS credentials are configured.
+5. **Resolve target instance + api domain** from the stack's
    `InstanceId` / `ApiUrl` outputs.
-5. **Deploy via SSM Run-Command** — same commands as
-   `deploy/aws/README.md` § 生产升级 SOP, transported via
-   `aws ssm send-command --parameters file://…`:
-   `.env` snapshot → `sed` image tag → `docker compose pull tokenkey` →
-   `up -d --no-deps tokenkey` → 12 × 5 s health-poll → `compose ps` →
-   `docker logs --since 2m | tail -20`. Job fails if the container does
-   not reach `healthy`.
-6. **External health-check** — `curl ${ApiUrl}/health`, three attempts
+6. **Deploy via SSM Run-Command** — call
+   `ops/stage0/deploy_via_ssm_bluegreen.sh` against the prod EC2 `i-*`
+   instance. The primitive is prod-only; Lightsail Edge keeps the single-app
+   `deploy_via_ssm.sh` path.
+
+   First run self-migrates the legacy app:
+   `.env` backup → derive current `tokenkey` image → write
+   `/var/lib/tokenkey/docker-compose.bluegreen.yml` → start
+   `tokenkey-blue` with the current image → wait Docker health and `/health`
+   readiness → rewrite only the live Caddy `reverse_proxy` upstream to
+   `tokenkey-blue:8080` and hot reload → write
+   `/var/lib/tokenkey/active-color=blue` → install the blue/green
+   `tokenkey.service` → drain and remove legacy `tokenkey`.
+
+   Every subsequent deploy alternates colors:
+   `.env` backup → pull target tag into the inactive color
+   (`tokenkey-blue` or `tokenkey-green`) → start/recreate only that color →
+   wait Docker health and `/health` readiness → rewrite only the live Caddy
+   upstream to the target color and hot reload → atomically write
+   `active-color` → install/update the blue/green systemd unit → SIGUSR1/drain
+   and stop the previous color.
+
+   PostgreSQL, Redis, Caddy, `/var/lib/tokenkey/app`, and the Docker network
+   remain the single shared data layer. The generated blue/green compose only
+   contains the two app services and points them at `tokenkey-postgres` /
+   `tokenkey-redis`.
+7. **External health-check** — `curl ${ApiUrl}/health`, three attempts
    spaced 10 s apart, require HTTP 200 within 5 s.
-7. **Post-deploy gateway smoke** — `ops/stage0/post_deploy_smoke.sh` against
+8. **Post-deploy live-host advisory checks** — the workflow reads the active
+   app container and drift-sensitive env on the host, and also runs the
+   exclusive-group orphan check. These checks warn but do not roll back a
+   successfully switched color.
+9. **Sync Feishu alert config** — fail the deploy if prod cannot persist and
+   verify the shared Feishu alert webhook/secret.
+10. **Post-deploy gateway smoke** — `ops/stage0/post_deploy_smoke.sh` against
    `${ApiUrl}`: public settings, authenticated `/v1/models`,
    `/v1/chat/completions`, and `/v1/messages` (Claude Code-style `x-api-key`).
    Requires **`prod` Environment secret** `TK_SMOKE_API_KEY` (one all-capability
@@ -121,7 +154,7 @@ Steps:
    `claude-sonnet-4-6`), `TK_SMOKE_GEMINI_MODELS` (default
    `gemini-3.1-pro-preview`), `TK_SMOKE_OPENAI_OAUTH_MODELS` (default
    `gpt-5.4`).
-8. **Job summary** — write the deployed tag, the SSM command id, and a
+11. **Job summary** — write the deployed tag, the SSM command id, and a
    one-liner re-dispatch command for rollback. No auto-rollback (would
    mask transient failures).
 
@@ -166,14 +199,18 @@ After this PR merges, before the first dispatch:
 
 ## 6. Explicitly out of scope
 
-To stay on "automate the existing manual SOP" and nothing else:
+To stay focused on prod deploy automation and nothing else:
 
-- **No DB migrations / schema bumps** — only restarts the `tokenkey`
-  container; PostgreSQL / Redis / Caddy are untouched.
+- **No general-purpose DB migration framework** — app startup may apply
+  normal migrations, but the workflow only adds a static blue/green
+  compatibility gate for changed SQL. Destructive/contract migrations still
+  require manual expand/contract review and explicit acknowledgement.
 - **No multi-region** — role scoped to one `AWS::Region`.
 - **No separate staging promotion gate inside Actions** — `deploy-stage0.yml`
   upgrades **`prod` only**; smoke probes target that stack's `ApiUrl`.
-- **No auto-rollback** — re-dispatch the workflow with the previous tag.
+- **No post-cutover auto-rollback** — before Caddy reload, failures leave the
+  old color untouched and serving; after Caddy reload, re-dispatch the workflow
+  with the previous tag so the rollback goes through the same health/smoke path.
 - **No CFN `ImageTag` parameter mutation** — drift between the CFN
   parameter and runtime `TOKENKEY_IMAGE` remains the accepted trade-off
   documented in `deploy/aws/README.md` §升级 / 发版.
@@ -183,12 +220,18 @@ To stay on "automate the existing manual SOP" and nothing else:
 If the workflow misbehaves after merge:
 
 - **Disable**: Settings → Actions → "Stage0 Deploy" → Disable. Operators
-  fall back to the manual SOP in `deploy/aws/README.md` §生产升级 SOP
-  (kept intact for this case).
+  fall back only after explicitly choosing a recovery path for the live host
+  layout: either keep blue/green and run `deploy_via_ssm_bluegreen.sh` manually,
+  or restore the legacy single-app compose/service and then use the manual SOP
+  in `deploy/aws/README.md` §生产升级 SOP.
 - **Revert IAM**: re-deploy `cicd-oidc.yaml` from this repo revision or tighten
   `AllowedSubjects="repo:youxuanxue/sub2api:ref:refs/heads/main"` if needed.
   Role ARN does not change, so `ops-daily-diagnostics.yml` diagnostics are unaffected.
-- **No data migration** — nothing in this PR writes durable state.
+- **Durable host state** — after the blue/green revision, prod deploys can leave
+  `/var/lib/tokenkey/docker-compose.bluegreen.yml`,
+  `/var/lib/tokenkey/active-color`, per-color image env keys, and a blue/green
+  `tokenkey.service`. To disable the workflow without rolling the host layout
+  back, re-dispatch the previous known-good tag through the same workflow.
 
 ## 8. Acceptance criteria
 
@@ -216,6 +259,10 @@ Step 6.
       [run 24872412714](https://github.com/youxuanxue/sub2api/actions/runs/24872412714)
       (env=prod, tag=1.6.0, external `/health` HTTP 200)
 - [x] Status flipped to `shipped` (this PR)
+- [x] 2026-06-24 revision: prod deploy primitive changed from single-container
+      restart to same-host blue/green, single data layer. Approved by
+      youxuanxue in the PR #976 review path; merge of #976 makes this section
+      the new conformance baseline.
 
 ### Adversarial gate verified
 

--- a/docs/deploy/blue-green-zero-downtime-backlog.md
+++ b/docs/deploy/blue-green-zero-downtime-backlog.md
@@ -60,12 +60,13 @@
 2. 给 target 设新镜像 tag，`compose up -d <target>`，等 Docker health `/health/live` 和 readiness `/health` 都通过；
 3. `caddy validate` 新配置后 reload 到 target upstream，新请求开始进入 target；
 4. SIGUSR1 drain 旧色，等 `in_flight=0` 或 plateau；
-5. 停旧色容器；写 `active-color=target` 并持久化 blue/green 版 `tokenkey.service`。
+5. 写 `active-color=target` 并持久化 blue/green 版 `tokenkey.service`；
+6. 停旧色容器。
    **失败时**（target 没 healthy）：旧色从未被 drain/切走，零影响，停掉失败 target 即可。
 
 ### 已验证的技术结论
 
-- **Caddy 切色原子性**：第一阶段用 `caddy validate` + `cat > Caddyfile` 保 inode + `caddy reload`。reload 失败会写回旧 Caddyfile 并 reload 回旧配置；Caddy reload 成功后脚本不再自动删除 target，避免误删已开始服务的新 upstream。
+- **Caddy 切色原子性**：第一阶段只改 live Caddyfile 的唯一 `reverse_proxy` upstream，保留其余 canonical / hot-sync 指令；再用 `caddy validate` + `cat > Caddyfile` 保 inode + `caddy reload`。reload 失败会写回旧 Caddyfile 并 reload 回旧配置；Caddy reload 成功后脚本不再自动删除 target，避免误删已开始服务的新 upstream。
 - **drain 是进程级、无同名容器假设**：`drainFlag` 是每进程独立的 `atomic.Bool`；`docker kill -s USR1 tokenkey-blue` 只 drain blue 进程。`/health`（drain-aware→503）/ `/health/live`（恒 200，docker healthcheck 用）/ `/health/inflight`（loopback-only，脚本须 `docker exec <color> wget localhost:8080/...`）。无 `SetDrain(false)` 调用点 → 新色必须是全新 `up`（drain=false 初始），换色天然清 drain，**不需要单色模式那条 `--force-recreate` load-bearing 逻辑**。
 - **内存**：当前 prod `t4g.large` 足够短暂双 app 重叠。后续若把蓝绿布局固化进 CFN，可再加 app `mem_limit` / `GOMEMLIMIT` 钉峰值。
 - **edge 不上蓝绿**：edge 是 t4g.micro（1GB），双色即便有 swap 也重度换页；edge 是薄 relay 节点、发版影响面小，维持现状单色 drain-recreate。**方案按节点 opt-in：prod 蓝绿，edge 现状。**
@@ -81,7 +82,7 @@
 |---|---|---|
 | `deploy/aws/stage0/docker-compose.yml` | 引入 `x-tokenkey-app` YAML anchor，`tokenkey` 拆成 `tokenkey-blue` + `tokenkey-green`（各自 `container_name` + `TOKENKEY_IMAGE_{BLUE,GREEN}`）；加 `mem_limit`/`GOMEMLIMIT`；caddy `depends_on` 收敛到只依赖 postgres/redis | **此文件被 prod+edge 共享 embed，必须先拆 edge** |
 | `deploy/aws/stage0/docker-compose.edge.yml`（新增） | edge 保留单色 `container_name: tokenkey`（=现状），与 prod 解耦 | 解决共享耦合 |
-| `deploy/aws/stage0/Caddyfile` | `reverse_proxy tokenkey:8080` → `reverse_proxy tokenkey-blue:8080 tokenkey-green:8080`，其余不变 | 双 upstream + active health 自动路由 |
+| `deploy/aws/stage0/Caddyfile` | 第一阶段**不改** canonical 文件，仍保留 `reverse_proxy tokenkey:8080`；live host 由 `deploy_via_ssm_bluegreen.sh` / `sync_caddyfile_via_ssm.sh` 只重写 upstream host 为 active 色 | 单 active upstream，避免 cutover 前 target 提前接流量 |
 | `deploy/aws/stage0/Caddyfile.edge` | **不改**（edge 单色 `tokenkey:8080`） | edge opt-out |
 | `deploy/aws/stage0/build-cfn.sh` | 拆 `COMPOSE_SRC` 为 prod / edge 两个 blob，分别 embed 进 single-ec2 / edge-ec2（仿 Caddyfile 已有的 prod/edge 分流），新增 `EDGE_COMPOSE_GZB64_SSM` marker | prod/edge compose 解耦 |
 | `deploy/aws/cloudformation/stage0-single-ec2.yaml` | 加 `SwapSizeGiB`（抄 edge swapfile UserData）；`COMPOSE_GZB64_SSM` 指向蓝绿 compose；UserData 首启写 `active-color=blue` 并只 `up` active 色 | prod 加 swap + 蓝绿首启 |
@@ -89,14 +90,14 @@
 | `sync_compose_via_ssm.sh`（新增） | 热同步 compose 到 live host（类比 `ops/stage0/sync_caddyfile_via_ssm.sh`，但无 envsubst、可直接 `gunzip >` 覆盖，只落盘 + `compose config -q` 校验、不 `up`） | 现存实例落地 |
 | `ops/stage0/deploy_via_ssm_bluegreen.sh` | **已实施**。蓝绿切换原语，含单色 `tokenkey` → `tokenkey-blue` 自迁移、Caddy 切色、systemd 持久化 | prod 发版 |
 | `cutover_to_bluegreen_via_ssm.sh`（新增） | **不再需要第一阶段**：自迁移已合入 `deploy_via_ssm_bluegreen.sh` | 仅后续拆分时考虑 |
-| `scripts/checks/bluegreen-migration-safety.py` | **已实施**。对本次新增/修改迁移静态扫 `DROP COLUMN`/`DROP TABLE`/`SET NOT NULL`/`RENAME`/`ALTER...TYPE`，命中需迁移头注释显式标记才放行 | expand-contract 门禁 |
+| `scripts/checks/bluegreen-migration-safety.py` | **已实施**。对本次新增/修改迁移静态扫 `DROP COLUMN`/`DROP TABLE`/`SET NOT NULL`/`ADD COLUMN ... NOT NULL`/`RENAME`/`ALTER...TYPE`，命中需迁移头注释显式标记才放行 | expand-contract 门禁 |
 | `backend/migrations/README.md` | 加「蓝绿 expand-contract 规则」：破坏性变更拆两次发布（先 expand 双写、下版 contract 删旧），即「N 版代码必须能在 N+1 schema 上正常跑」 | 文档约束 |
 | `.github/workflows/deploy-stage0.yml` | **已实施**：Deploy via SSM 改调 `deploy_via_ssm_bluegreen.sh`；后续可选加 `operation=rollback`（秒级换回旧色） | prod workflow |
 | `.github/workflows/deploy-edge-*.yml` | **不改** | edge opt-out |
 
 ### DB 迁移 expand-contract（最大语义风险）
 
-蓝绿重叠窗口内新旧 schema 代码同连一个库。Advisory Lock（ID `694208311321144027`）已串行化并发迁移、checksum 跳过已应用——**并发安全已具备**。危险在**语义**：若新版带破坏性迁移（DROP/RENAME/NOT NULL），旧色（N 版代码）在「新色 healthy 但还没 drain 旧色」窗口里业务请求会 500，破坏「零影响」承诺。现有迁移以 `ADD COLUMN`/`CREATE TABLE`/`CREATE INDEX CONCURRENTLY`/seed 为主（expand 友好），但存在 `DROP` 类。门禁 `scripts/checks/bluegreen-migration-safety.py` 把「记得 expand-contract」变成机械检查，不可省。
+蓝绿重叠窗口内新旧 schema 代码同连一个库。Advisory Lock（ID `694208311321144027`）已串行化并发迁移、checksum 跳过已应用——**并发安全已具备**。危险在**语义**：若新版带破坏性迁移（DROP/RENAME/NOT NULL/ADD COLUMN NOT NULL），旧色（N 版代码）在「新色 healthy 但还没 drain 旧色」窗口里业务请求会 500，破坏「零影响」承诺。现有迁移以 `ADD COLUMN`/`CREATE TABLE`/`CREATE INDEX CONCURRENTLY`/seed 为主（expand 友好），但存在 `DROP` 类。门禁 `scripts/checks/bluegreen-migration-safety.py` 把「记得 expand-contract」变成机械检查，不可省。
 
 ---
 
@@ -136,7 +137,7 @@
 | **Caddy 探测时延**（`sleep 12` 经验值，≥2×health_interval） | 与 health_interval 同步调；§5 步骤 4 覆盖此风险 |
 | **cutover 一次性窗口顺序敏感** | 封装专用脚本，先本地演练 §5 再上 prod |
 
-**回滚（分层）**：① 蓝绿发版失败 → 脚本 drain 前 `exit 1`，旧色零影响；② 上线后发现问题（已切色）→ `operation=rollback` 重新拉起上一色（仍持上版镜像）、drain 当前色、翻 `active-color`，秒级；③ 蓝绿方案本身出问题 → `sync_compose_via_ssm.sh` 同步回单色版（含 `.before-<ts>` 备份 + ERR trap），回到 `deploy_via_ssm.sh` 单色发版，整能力一键回退到现状。
+**回滚（分层）**：① 蓝绿发版失败 → Caddy reload 前 `exit 1`，旧色零影响；② 上线后发现问题（已切色）→ 重新 dispatch 上一版 tag，脚本拉起 inactive 色、健康后切回并 drain 当前色；③ 蓝绿方案本身出问题 → 手工恢复 legacy `tokenkey` compose/service 后，workflow 可临时改回 `deploy_via_ssm.sh` 单色发版。
 
 ---
 

--- a/ops/stage0/deploy_via_ssm_bluegreen.sh
+++ b/ops/stage0/deploy_via_ssm_bluegreen.sh
@@ -28,7 +28,8 @@ set -euo pipefail
 TAG="${1:-${INPUT_TAG:-}}"
 INSTANCE_ID="${2:-${INSTANCE_ID:-}}"
 COMMENT="${3:-${SSM_COMMENT:-deploy-stage0-bluegreen}}"
-TIMEOUT_SECONDS="${STAGE0_SSM_TIMEOUT_SECONDS:-600}"
+TIMEOUT_SECONDS="${STAGE0_SSM_TIMEOUT_SECONDS:-1200}"
+EXECUTION_TIMEOUT_SECONDS="${STAGE0_SSM_EXECUTION_TIMEOUT_SECONDS:-$TIMEOUT_SECONDS}"
 OUTPUT_DIR="${STAGE0_SSM_OUTPUT_DIR:-.}"
 
 if [[ -z "${TAG}" ]]; then
@@ -41,6 +42,11 @@ if [[ -z "${INSTANCE_ID}" ]]; then
 fi
 if [[ "${INSTANCE_ID}" != i-* ]]; then
   echo "stage0_deploy_via_ssm_bluegreen: prod-only primitive requires EC2 instance id (i-*), got ${INSTANCE_ID}" >&2
+  exit 1
+fi
+if [[ ! "${TIMEOUT_SECONDS}" =~ ^[0-9]+$ || ! "${EXECUTION_TIMEOUT_SECONDS}" =~ ^[0-9]+$ ]] \
+  || (( TIMEOUT_SECONDS <= 0 || EXECUTION_TIMEOUT_SECONDS <= 0 )); then
+  echo "stage0_deploy_via_ssm_bluegreen: timeout values must be positive integers" >&2
   exit 1
 fi
 
@@ -447,75 +453,38 @@ UNIT
   log "installed blue/green tokenkey.service restart policy"
 }
 
+render_caddy_with_upstream() {
+  local upstream="$1" tmp="$2"
+  sudo awk -v upstream="${upstream}" '
+    /^[[:space:]]*reverse_proxy[[:space:]]+/ && $0 ~ /\{[[:space:]]*$/ {
+      count += 1
+      if (count == 1) {
+        match($0, /[^[:space:]]/)
+        indent = RSTART > 1 ? substr($0, 1, RSTART - 1) : ""
+        print indent "reverse_proxy " upstream " {"
+      } else {
+        print
+      }
+      next
+    }
+    { print }
+    END { if (count != 1) exit 7 }
+  ' "${LIVE_CADDY}" | sudo tee "${tmp}" >/dev/null
+}
+
 write_caddy_for_color() {
-  local color="$1" upstream tmp backup api_domain acme_email ts
+  local color="$1" upstream tmp backup ts
   upstream="$(color_container "${color}"):8080"
-  api_domain="$(env_get API_DOMAIN)"
-  acme_email="$(env_get ACME_EMAIL)"
-  [[ -n "${api_domain}" ]] || die "API_DOMAIN empty in ${ENV_FILE}"
-  [[ -n "${acme_email}" ]] || die "ACME_EMAIL empty in ${ENV_FILE}"
   [[ -f "${LIVE_CADDY}" ]] || die "missing live Caddyfile at ${LIVE_CADDY}"
 
   tmp="${CADDY_DIR}/Caddyfile.bluegreen-${color}.new"
   ts="$(date +%Y%m%d-%H%M%S)"
   backup="${CADDY_DIR}/Caddyfile.before-bluegreen-${color}-${ts}"
 
-  sudo tee "${tmp}" >/dev/null <<CADDY
-{
-	email ${acme_email}
-}
-
-${api_domain} {
-	encode zstd gzip
-
-	@static {
-		path /assets/*
-		path /logo.png
-		path /favicon.ico
-	}
-	header @static ?Cache-Control "public, max-age=31536000, immutable"
-
-	tls {
-		protocols tls1.2 tls1.3
-		issuer acme {
-			email ${acme_email}
-			disable_http_challenge
-		}
-	}
-
-	reverse_proxy ${upstream} {
-		flush_interval -1
-		health_uri /health
-		health_interval 5s
-		health_timeout 3s
-		fail_duration 5s
-		max_fails 1
-		unhealthy_status 502 504
-		lb_try_duration 30s
-		lb_try_interval 1s
-		header_up X-Real-IP {remote_host}
-		header_up X-Forwarded-For {remote_host}
-		header_up X-Forwarded-Proto {scheme}
-		header_up X-Forwarded-Host {host}
-		transport http {
-			dial_timeout 5s
-			keepalive 120s
-			keepalive_idle_conns 64
-			compression off
-		}
-	}
-
-	request_body {
-		max_size 100MB
-	}
-
-	log {
-		output stdout
-		format json
-		level INFO
-	}
-}
-CADDY
+  if ! render_caddy_with_upstream "${upstream}" "${tmp}"; then
+    sudo rm -f "${tmp}" >/dev/null 2>&1 || true
+    die "could not rewrite exactly one reverse_proxy upstream in ${LIVE_CADDY}"
+  fi
 
   sudo docker run --rm -v "${tmp}:/tmp/Caddyfile:ro" caddy:2-alpine caddy validate --config /tmp/Caddyfile --adapter caddyfile
   sudo cp -a "${LIVE_CADDY}" "${backup}"
@@ -661,6 +630,7 @@ chunks_json="$(printf '%s' "${REMOTE_B64}" | fold -w 1000 | jq -R -s 'split("\n"
 
 jq -n \
   --arg tag "${TAG}" \
+  --arg execution_timeout "${EXECUTION_TIMEOUT_SECONDS}" \
   --arg qa_driver "${QA_CAPTURE_EXPORT_STORAGE_DRIVER:-s3}" \
   --arg qa_region "${QA_CAPTURE_EXPORT_STORAGE_REGION:-us-east-1}" \
   --arg qa_bucket "${QA_CAPTURE_EXPORT_STORAGE_BUCKET:-tokenkey-prod-qa-exports-682751977094}" \
@@ -692,7 +662,8 @@ jq -n \
       + " GATEWAY_IMAGE_CONCURRENCY_OVERFLOW_MODE=" + ($image_overflow|@sh)
       + " /tmp/tokenkey-bluegreen-deploy.sh"
     )
-  ])
+  ]),
+  executionTimeout: [$execution_timeout]
 }' > "${params_file}"
 
 if [[ -n "${STAGE0_RENDER_ONLY:-}" ]]; then

--- a/ops/stage0/sync_caddyfile_via_ssm.sh
+++ b/ops/stage0/sync_caddyfile_via_ssm.sh
@@ -17,7 +17,7 @@
 #      means the sync does not depend on a CFN stack update having already
 #      propagated the new blob to Parameter Store.
 #   2. On the host: write it to caddy/Caddyfile.template, derive the render vars
-#      (same set as boot UserData), then `envsubst` — IDENTICAL to the UserData
+#      (same set as boot UserData), then `envsubst` — matching the UserData
 #      "envsubst < caddy/Caddyfile.template > caddy/Caddyfile" line:
 #        - API_DOMAIN / ACME_EMAIL: sourced from /var/lib/tokenkey/.env (the
 #          boot UserData persists both there).
@@ -25,6 +25,9 @@
 #          holds it only transiently. Recovered from the live Caddyfile's
 #          `remote_ip` line so the relay allowlist is preserved verbatim. For
 #          prod the template has no such token, so the var stays empty/no-op.
+#      For prod hosts already migrated to blue/green, rewrite the rendered
+#      canonical prod upstream from tokenkey:8080 to tokenkey-${active}:8080 so
+#      directive hot-sync never disables the active color.
 #   3. Validate the rendered config in a throwaway caddy:2-alpine container.
 #   4. Apply IN PLACE (`cat new > Caddyfile`, NOT mv): the compose mount binds
 #      the single FILE, so replacing the inode via mv would leave the running
@@ -127,6 +130,7 @@ jq -n --arg b64 "${CADDY_B64}" --arg kind "${KIND}" '{
     "echo \"render vars: API_DOMAIN=$API_DOMAIN ACME_EMAIL=${ACME_EMAIL:-} MAIN_GATEWAY_ALLOWED_CIDR=${MAIN_GATEWAY_ALLOWED_CIDR:-<none>}\"",
     ("printf '\''%s'\'' \"" + $b64 + "\" | base64 -d | sudo tee \"$CADDY_DIR/Caddyfile.template\" >/dev/null"),
     "sudo sh -c \"API_DOMAIN='\''$API_DOMAIN'\'' ACME_EMAIL='\''${ACME_EMAIL:-}'\'' MAIN_GATEWAY_ALLOWED_CIDR='\''${MAIN_GATEWAY_ALLOWED_CIDR:-}'\'' envsubst '\''\\$API_DOMAIN \\$ACME_EMAIL \\$MAIN_GATEWAY_ALLOWED_CIDR'\'' < '\''$CADDY_DIR/Caddyfile.template'\'' > '\''$CADDY_DIR/Caddyfile.new'\''\"",
+    "if [ \"$KIND\" = prod ] && [ -r /var/lib/tokenkey/active-color ]; then ACTIVE_COLOR=\"$(sed -n '\''1p'\'' /var/lib/tokenkey/active-color | tr -d '\''[:space:]'\'')\"; case \"$ACTIVE_COLOR\" in blue|green) UPSTREAM=\"tokenkey-$ACTIVE_COLOR:8080\"; sudo awk -v upstream=\"$UPSTREAM\" '\''/^[[:space:]]*reverse_proxy[[:space:]]+/ && $0 ~ /\\{[[:space:]]*$/ { count += 1; if (count == 1) { match($0, /[^[:space:]]/); indent = RSTART > 1 ? substr($0, 1, RSTART - 1) : \"\"; print indent \"reverse_proxy \" upstream \" {\" } else { print }; next } { print } END { if (count != 1) exit 7 }'\'' \"$CADDY_DIR/Caddyfile.new\" | sudo tee \"$CADDY_DIR/Caddyfile.rewritten\" >/dev/null; sudo mv \"$CADDY_DIR/Caddyfile.rewritten\" \"$CADDY_DIR/Caddyfile.new\"; echo \"prod blue/green active upstream preserved: $UPSTREAM\" ;; *) echo \"::error::invalid active-color for prod blue/green Caddy sync: ${ACTIVE_COLOR:-<empty>}\"; exit 1 ;; esac; fi",
     "echo === validate rendered config in throwaway caddy container ===",
     "sudo docker run --rm -v \"$CADDY_DIR/Caddyfile.new\":/tmp/Caddyfile:ro caddy:2-alpine caddy validate --config /tmp/Caddyfile --adapter caddyfile",
     "echo \"=== apply IN PLACE (cat-truncate keeps inode the bind-mount maps) ===\"",

--- a/ops/stage0/test_deploy_via_ssm_bluegreen.py
+++ b/ops/stage0/test_deploy_via_ssm_bluegreen.py
@@ -76,6 +76,7 @@ class BlueGreenRenderTest(unittest.TestCase):
         commands = params["commands"]
         joined = "\n".join(commands)
 
+        self.assertEqual(params.get("executionTimeout"), ["1200"])
         self.assertIn("/tmp/tokenkey-bluegreen-deploy.sh", joined)
         self.assertIn("TAG='1.8.99'", joined)
         self.assertIn("QA_CAPTURE_EXPORT_STORAGE_BUCKET='tokenkey-prod-qa-exports-682751977094'", joined)
@@ -89,7 +90,8 @@ class BlueGreenRenderTest(unittest.TestCase):
         self.assertIn("TOKENKEY_IMAGE_BLUE", remote)
         self.assertIn("TOKENKEY_IMAGE_GREEN", remote)
         self.assertIn("write_caddy_for_color", remote)
-        self.assertIn("reverse_proxy ${upstream}", remote)
+        self.assertIn("render_caddy_with_upstream", remote)
+        self.assertIn("could not rewrite exactly one reverse_proxy upstream", remote)
         self.assertIn("wait_ready", remote)
         self.assertIn("http://localhost:8080/health", remote)
         self.assertIn("drain_container \"${active_container}\"", remote)

--- a/ops/stage0/test_sync_caddyfile_via_ssm.py
+++ b/ops/stage0/test_sync_caddyfile_via_ssm.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Render tests for ops/stage0/sync_caddyfile_via_ssm.sh."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent / "sync_caddyfile_via_ssm.sh"
+
+
+def _run_sync(kind: str = "prod"):
+    out_dir = pathlib.Path(tempfile.mkdtemp(prefix="sync-caddy-render-"))
+    bin_dir = out_dir / "bin"
+    bin_dir.mkdir()
+    aws_stub = bin_dir / "aws"
+    aws_stub.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            case "$*" in
+              *send-command*)                         echo "cmd-stub" ;;
+              *get-command-invocation*Status*)        echo "Success" ;;
+              *get-command-invocation*StandardOutput*) echo "stdout" ;;
+              *get-command-invocation*StandardError*) echo "" ;;
+              *)                                      echo "stub" ;;
+            esac
+            """
+        )
+    )
+    aws_stub.chmod(aws_stub.stat().st_mode | stat.S_IXUSR)
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "AWS_REGION": "us-east-1",
+        "STAGE0_SSM_OUTPUT_DIR": str(out_dir),
+    }
+    proc = subprocess.run(
+        ["bash", str(_SCRIPT), kind, "i-0stub", "probe"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    params = None
+    params_path = out_dir / "ssm-params.json"
+    if params_path.exists():
+        params = json.loads(params_path.read_text())
+    return proc, params
+
+
+class SyncCaddyfileRenderTest(unittest.TestCase):
+    def test_prod_preserves_bluegreen_active_upstream(self) -> None:
+        proc, params = _run_sync("prod")
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        assert params is not None
+        joined = "\n".join(params["commands"])
+
+        parsed = subprocess.run(
+            ["bash", "-n"],
+            input=joined,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(parsed.returncode, 0, msg=parsed.stderr)
+        self.assertIn("/var/lib/tokenkey/active-color", joined)
+        self.assertIn("tokenkey-$ACTIVE_COLOR:8080", joined)
+        self.assertIn("Caddyfile.rewritten", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/checks/bluegreen-migration-safety.py
+++ b/scripts/checks/bluegreen-migration-safety.py
@@ -28,6 +28,7 @@ DANGEROUS = [
     ("DROP TABLE", re.compile(r"\bDROP\s+TABLE\b", re.I)),
     ("DROP COLUMN", re.compile(r"\bDROP\s+COLUMN\b", re.I)),
     ("ALTER TABLE RENAME", re.compile(r"\bALTER\s+TABLE\b[^;]*\bRENAME\b", re.I | re.S)),
+    ("ADD COLUMN NOT NULL", re.compile(r"\bADD\s+COLUMN\b[^;]*\bNOT\s+NULL\b", re.I | re.S)),
     ("RENAME COLUMN", re.compile(r"\bRENAME\s+COLUMN\b", re.I)),
     ("RENAME TO", re.compile(r"\bRENAME\s+TO\b", re.I)),
     ("SET NOT NULL", re.compile(r"\bSET\s+NOT\s+NULL\b", re.I)),
@@ -84,8 +85,7 @@ def strip_comments(sql: str) -> str:
     return sql
 
 
-def scan_file(path: Path) -> list[str]:
-    text = path.read_text(errors="replace")
+def scan_sql(text: str) -> list[str]:
     if ACK in text:
         return []
     body = strip_comments(text)
@@ -93,12 +93,62 @@ def scan_file(path: Path) -> list[str]:
     return hits
 
 
+def scan_file(path: Path) -> list[str]:
+    return scan_sql(path.read_text(errors="replace"))
+
+
+def selftest() -> int:
+    cases = [
+        (
+            "drop-column",
+            "ALTER TABLE accounts DROP COLUMN old_token;",
+            ["DROP COLUMN"],
+        ),
+        (
+            "add-column-not-null",
+            "ALTER TABLE users ADD COLUMN tier_id integer NOT NULL;",
+            ["ADD COLUMN NOT NULL"],
+        ),
+        (
+            "nullable-add-column",
+            "ALTER TABLE users ADD COLUMN tier_id integer;",
+            [],
+        ),
+        (
+            "comment-stripped",
+            "-- ALTER TABLE users ADD COLUMN tier_id integer NOT NULL;\nSELECT 1;",
+            [],
+        ),
+        (
+            "ack-bypasses-after-human-expand-contract-review",
+            f"-- {ACK}: expand column first, contract in later deploy\nALTER TABLE users ADD COLUMN tier_id integer NOT NULL;",
+            [],
+        ),
+    ]
+    failures: list[str] = []
+    for name, sql, expected in cases:
+        got = scan_sql(sql)
+        if got != expected:
+            failures.append(f"{name}: expected {expected}, got {got}")
+    if failures:
+        print("FAIL: bluegreen-migration-safety selftest")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    print("ok: bluegreen-migration-safety selftest")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--base", default=os.environ.get("PREFLIGHT_BASE"))
     ap.add_argument("--head", default="HEAD")
     ap.add_argument("--quiet", action="store_true")
+    ap.add_argument("--selftest", action="store_true")
     args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
 
     base, head = resolve_range(args.base, args.head)
     if not base:

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1330,7 +1330,7 @@ elif ! grep -q 'ops/stage0/deploy_via_ssm.sh' .github/workflows/deploy-edge-ligh
     echo "  FAIL: deploy-edge-lightsail-stage0.yml must use ops/stage0/deploy_via_ssm.sh"
     errors=$((errors + 1))
 elif grep -q 'docker compose --env-file .* up -d --no-deps tokenkey' .github/workflows/deploy-stage0.yml .github/workflows/deploy-edge-lightsail-stage0.yml; then
-    echo "  FAIL: Stage0 workflows must not inline tokenkey SSM deploy commands; use ops/stage0/deploy_via_ssm.sh"
+    echo "  FAIL: Stage0 workflows must not inline tokenkey SSM deploy commands; use the matching ops/stage0 deploy primitive"
     errors=$((errors + 1))
 else
     echo "  ok: prod uses blue/green SSM primitive; Lightsail edge stays on single-app SSM primitive"
@@ -1340,6 +1340,10 @@ echo ""
 echo "=== sub2api: blue/green migration safety ==="
 if ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required for blue/green migration safety)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/bluegreen-migration-safety.py --selftest >/dev/null; then
+    echo "  FAIL: blue/green migration safety selftest failed"
+    echo "        — run: python3 scripts/checks/bluegreen-migration-safety.py --selftest"
     errors=$((errors + 1))
 else
     _bgm_base="${PREFLIGHT_BASE:-origin/main}"


### PR DESCRIPTION
## 摘要
- 补上 #976 合并后的 blue/green deploy 审核修复，目标是降低 prod 发版期间用户可感知 5xx，同时避免后续 deploy/sync 覆盖 live Caddy 配置。
- `deploy_via_ssm_bluegreen.sh` 不再写入完整 inline Caddyfile，只在 live Caddyfile 中重写唯一 `reverse_proxy` upstream，保留 canonical/hot-synced directives。
- `sync_caddyfile_via_ssm.sh prod` 在已迁移 blue/green 主机上保留 active `tokenkey-blue|green:8080` upstream，避免 Caddy sync 回写到 legacy `tokenkey:8080`。
- 将 SSM local poll / remote execution timeout 默认提升到 `1200s`，覆盖首次 self-migration + image pull + target deploy 的正常耗时。
- 扩展 blue/green SQL migration safety：新增 `ADD COLUMN ... NOT NULL` 阻断，并加入 selftest 到 preflight。
- 更新 approved deploy 基线和部署文档，让 agent/reviewer 后续按 #976/#978 之后的真实蓝绿契约审查。

## 背景
#976 已经把 prod deploy-stage0 切到同机 blue/green：`tokenkey-blue` / `tokenkey-green` 双 app，共用 Postgres / Redis / Caddy / 数据卷。本 PR 是对 #976 的 follow-up hardening，不重复改 Lightsail edge 的单 app deploy 路径。

## 风险
- 修改 `docs/approved/deploy-stage0-workflow.md` 是有意的 approval baseline 更新，反映 #976 合并后的实际 prod deploy primitive，并用 #978 记录本次 baseline/Caddy/timeout/migration-safety hardening。
- Blue/green 仍不能消除 DB 语义风险；破坏性或 contract migration 仍需 expand-contract review，并显式写入 `bluegreen-safe-destructive-ok`。
- Caddy reload 后的线上回滚路径仍是用同一 workflow 部署 previous known-good tag，本 PR 不引入自动 rollback。
- 本 PR 不执行线上发版；prod deploy 仍需要 Environment approval 和发布后 smoke。

## 验证
- `python3 -m unittest ops/stage0/test_sync_caddyfile_via_ssm.py ops/stage0/test_deploy_via_ssm_bluegreen.py`
- `python3 scripts/checks/bluegreen-migration-safety.py --selftest`
- `python3 scripts/checks/bluegreen-migration-safety.py --base origin/main --head HEAD`
- `python3 dev-rules/scripts/check_approved_docs.py`
- `git diff --check origin/main...HEAD`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy -u ALL_PROXY -u all_proxy GOPROXY=https://goproxy.cn,direct PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- commit hook `scripts/preflight.sh` PASS after `b446c57c9`

## 提交
- `e2dea05db` fix(stage0): harden blue-green deploy review gaps
- `b446c57c9` docs(stage0): clarify blue-green review baseline provenance

最新提交：`b446c57c9`
