### PR TITLE
chore(tier): retune anthropic oauth baselines

### DIFF
--- a/backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json
+++ b/backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json
@@ -127,7 +127,7 @@
     "l1": {
       "baseline": {
         "account": {
-          "concurrency": 50,
+          "concurrency": 30,
           "priority": 1,
           "rate_multiplier": 1.0
         },
@@ -144,7 +144,7 @@
     "l2": {
       "baseline": {
         "account": {
-          "concurrency": 50,
+          "concurrency": 30,
           "priority": 1,
           "rate_multiplier": 1.0
         },
@@ -162,7 +162,7 @@
     "l3": {
       "baseline": {
         "account": {
-          "concurrency": 50,
+          "concurrency": 30,
           "priority": 1,
           "rate_multiplier": 1.0
         },
@@ -179,12 +179,12 @@
     "l4": {
       "baseline": {
         "account": {
-          "concurrency": 70,
+          "concurrency": 40,
           "priority": 1,
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 90,
+          "base_rpm": 80,
           "rpm_sticky_buffer": 20,
           "max_sessions": 450,
           "session_idle_timeout_minutes": 8,
@@ -196,12 +196,12 @@
     "l5": {
       "baseline": {
         "account": {
-          "concurrency": 90,
+          "concurrency": 50,
           "priority": 1,
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 120,
+          "base_rpm": 100,
           "rpm_sticky_buffer": 30,
           "max_sessions": 600,
           "session_idle_timeout_minutes": 8,

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -127,7 +127,7 @@
     "l1": {
       "baseline": {
         "account": {
-          "concurrency": 50,
+          "concurrency": 30,
           "priority": 1,
           "rate_multiplier": 1.0
         },
@@ -144,7 +144,7 @@
     "l2": {
       "baseline": {
         "account": {
-          "concurrency": 50,
+          "concurrency": 30,
           "priority": 1,
           "rate_multiplier": 1.0
         },
@@ -162,7 +162,7 @@
     "l3": {
       "baseline": {
         "account": {
-          "concurrency": 50,
+          "concurrency": 30,
           "priority": 1,
           "rate_multiplier": 1.0
         },
@@ -179,12 +179,12 @@
     "l4": {
       "baseline": {
         "account": {
-          "concurrency": 70,
+          "concurrency": 40,
           "priority": 1,
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 90,
+          "base_rpm": 80,
           "rpm_sticky_buffer": 20,
           "max_sessions": 450,
           "session_idle_timeout_minutes": 8,
@@ -196,12 +196,12 @@
     "l5": {
       "baseline": {
         "account": {
-          "concurrency": 90,
+          "concurrency": 50,
           "priority": 1,
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 120,
+          "base_rpm": 100,
           "rpm_sticky_buffer": 30,
           "max_sessions": 600,
           "session_idle_timeout_minutes": 8,


### PR DESCRIPTION
## 摘要

- 调整 Anthropic OAuth tier baseline：L1/L2/L3 降为 `30/60/15/300`，L4 调整为 `40/80/20/450`，L5 调整为 `50/100/30/600`。
- 同步更新 `deploy/aws/stage0` canonical JSON 与后端 `go:embed` 副本，保持运行时 seed 源一致。
- Web impact: none。本 PR 只调整后端/ops tier baseline JSON，不改变 Web 页面、API 契约或前端行为。

## 风险

- 常规风险：合并后下一次发版或显式 `apply-tiers-live` 会改变 Anthropic OAuth 账号 tier caps 与 concurrency。
- 不直接写 live 数据库；本 PR 只更新 git baseline。

## 验证

- `python3 scripts/sentinels/check-tier-baseline-embed.py`
- `go test ./internal/baseline`
- `python3 -m unittest ops.anthropic.test_manage_anthropic_config_tier_table_drift ops.anthropic.test_check_edge_oauth_stability_tier_managed`
- `python3 -m unittest ops.anthropic.test_manage_anthropic_config_plan`
- `git diff --check`
- `./scripts/preflight.sh`

## 提交

- `fce63c55b chore(tier): retune anthropic oauth baselines no-web-impact`

最新提交：`fce63c55b`
