### PR TITLE
feat(admin): 支持 Grok/Kiro relay stub 管理

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -556,7 +556,7 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 			dbaccount.PlatformEQ(service.PlatformAnthropic),
 			dbaccount.TypeEQ(service.AccountTypeAPIKey),
 			dbpredicate.Account(func(s *entsql.Selector) {
-				s.Where(sqljson.ValueEQ(dbaccount.FieldCredentials, "kiro", sqljson.Path("mirror_platform")))
+				s.Where(entsql.ExprP(fmt.Sprintf("LOWER(TRIM(%s->>'mirror_platform')) = 'kiro'", s.C(dbaccount.FieldCredentials))))
 				s.Where(entsql.ExprP(fmt.Sprintf("(%s->>'base_url') ~ '^https://api-[a-z0-9]+\\.tokenkey\\.dev/?$'", s.C(dbaccount.FieldCredentials))))
 			}),
 		)

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -551,7 +551,16 @@ func (r *accountRepository) List(ctx context.Context, params pagination.Paginati
 func (r *accountRepository) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]service.Account, *pagination.PaginationResult, error) {
 	q := r.client.Account.Query()
 
-	if platform != "" {
+	if platform == service.AccountListPlatformKiroStubFilter {
+		q = q.Where(
+			dbaccount.PlatformEQ(service.PlatformAnthropic),
+			dbaccount.TypeEQ(service.AccountTypeAPIKey),
+			dbpredicate.Account(func(s *entsql.Selector) {
+				s.Where(sqljson.ValueEQ(dbaccount.FieldCredentials, "kiro", sqljson.Path("mirror_platform")))
+				s.Where(entsql.ExprP(fmt.Sprintf("(%s->>'base_url') ~ '^https://api-[a-z0-9]+\\.tokenkey\\.dev/?$'", s.C(dbaccount.FieldCredentials))))
+			}),
+		)
+	} else if platform != "" {
 		q = q.Where(dbaccount.PlatformEQ(platform))
 	}
 	if accountType != "" {

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -262,6 +262,56 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 			},
 		},
 		{
+			name: "filter_by_kiro_stub_virtual_platform",
+			setup: func(client *dbent.Client) {
+				mustCreateAccount(s.T(), client, &service.Account{
+					Name:     "kiro-stub",
+					Platform: service.PlatformAnthropic,
+					Type:     service.AccountTypeAPIKey,
+					Credentials: map[string]any{
+						"api_key":         "tk-edge",
+						"base_url":        "https://api-us4.tokenkey.dev",
+						"mirror_platform": "kiro",
+					},
+				})
+				mustCreateAccount(s.T(), client, &service.Account{
+					Name:     "plain-anthropic-edge",
+					Platform: service.PlatformAnthropic,
+					Type:     service.AccountTypeAPIKey,
+					Credentials: map[string]any{
+						"api_key":         "tk-edge",
+						"base_url":        "https://api-us4.tokenkey.dev",
+						"mirror_platform": "anthropic",
+					},
+				})
+				mustCreateAccount(s.T(), client, &service.Account{
+					Name:     "kiro-oauth",
+					Platform: service.PlatformKiro,
+					Type:     service.AccountTypeOAuth,
+					Credentials: map[string]any{
+						"access_token": "access",
+					},
+				})
+				mustCreateAccount(s.T(), client, &service.Account{
+					Name:     "kiro-non-edge",
+					Platform: service.PlatformAnthropic,
+					Type:     service.AccountTypeAPIKey,
+					Credentials: map[string]any{
+						"api_key":         "key",
+						"base_url":        "https://api.anthropic.com",
+						"mirror_platform": "kiro",
+					},
+				})
+			},
+			platform:  service.AccountListPlatformKiroStubFilter,
+			wantCount: 1,
+			validate: func(accounts []service.Account) {
+				s.Require().Equal("kiro-stub", accounts[0].Name)
+				s.Require().Equal(service.PlatformAnthropic, accounts[0].Platform)
+				s.Require().Equal(service.AccountTypeAPIKey, accounts[0].Type)
+			},
+		},
+		{
 			name: "filter_by_type",
 			setup: func(client *dbent.Client) {
 				mustCreateAccount(s.T(), client, &service.Account{Name: "t1", Type: service.AccountTypeOAuth})

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -271,7 +271,7 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 					Credentials: map[string]any{
 						"api_key":         "tk-edge",
 						"base_url":        "https://api-us4.tokenkey.dev",
-						"mirror_platform": "kiro",
+						"mirror_platform": " Kiro ",
 					},
 				})
 				mustCreateAccount(s.T(), client, &service.Account{

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -17,6 +17,7 @@ var (
 
 const AccountListGroupUngrouped int64 = -1
 const AccountPrivacyModeUnsetFilter = "__unset__"
+const AccountListPlatformKiroStubFilter = "__kiro_stub__"
 
 type AccountRepository interface {
 	Create(ctx context.Context, account *Account) error

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 511,
-  "hash": "b54e49c6463061dcebd5c163e1511fdd2c912e212ae52724f21263b7580ac1b0",
+  "hash": "fe535d42f051d49a8f846e950d674c717318021be7e9a8de3802fa699df421ab",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 511,
-  "hash": "fe535d42f051d49a8f846e950d674c717318021be7e9a8de3802fa699df421ab",
+  "hash": "7e26ca88322b7dd75fb4cc83410c9f8e8a332b8aecfb9aff7652ae6b40497641",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -247,9 +247,73 @@
         />
       </div>
 
-      <!-- grok (7th platform): OAuth refresh_token paste directly under platform picker. -->
+      <!-- grok (7th platform): OAuth account or prod→edge first-class relay stub. -->
       <div v-if="form.platform === 'grok'" class="space-y-4">
+        <div>
+          <label class="input-label">{{ t('admin.accounts.accountType') }}</label>
+          <div class="mt-2 grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              @click="accountCategory = 'oauth-based'"
+              :class="[
+                'flex items-center gap-3 rounded-lg border-2 p-3 text-left transition-all',
+                accountCategory === 'oauth-based'
+                  ? 'border-slate-500 bg-slate-50 dark:bg-slate-900/20'
+                  : 'border-gray-200 hover:border-slate-300 dark:border-dark-600 dark:hover:border-slate-700'
+              ]"
+            >
+              <div
+                :class="[
+                  'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+                  accountCategory === 'oauth-based'
+                    ? 'bg-slate-700 text-white'
+                    : 'bg-gray-100 text-gray-500 dark:bg-dark-600 dark:text-gray-400'
+                ]"
+              >
+                <Icon name="sparkles" size="sm" />
+              </div>
+              <div>
+                <span class="block text-sm font-medium text-gray-900 dark:text-white">
+                  {{ t('admin.accounts.grokPlatform.oauthMode') }}
+                </span>
+                <span class="text-xs text-gray-500 dark:text-gray-400">
+                  {{ t('admin.accounts.grokPlatform.oauthModeHint') }}
+                </span>
+              </div>
+            </button>
+            <button
+              type="button"
+              @click="accountCategory = 'apikey'"
+              :class="[
+                'flex items-center gap-3 rounded-lg border-2 p-3 text-left transition-all',
+                accountCategory === 'apikey'
+                  ? 'border-slate-500 bg-slate-50 dark:bg-slate-900/20'
+                  : 'border-gray-200 hover:border-slate-300 dark:border-dark-600 dark:hover:border-slate-700'
+              ]"
+            >
+              <div
+                :class="[
+                  'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+                  accountCategory === 'apikey'
+                    ? 'bg-slate-700 text-white'
+                    : 'bg-gray-100 text-gray-500 dark:bg-dark-600 dark:text-gray-400'
+                ]"
+              >
+                <Icon name="key" size="sm" />
+              </div>
+              <div>
+                <span class="block text-sm font-medium text-gray-900 dark:text-white">
+                  {{ t('admin.accounts.grokPlatform.relayMode') }}
+                </span>
+                <span class="text-xs text-gray-500 dark:text-gray-400">
+                  {{ t('admin.accounts.grokPlatform.relayModeHint') }}
+                </span>
+              </div>
+            </button>
+          </div>
+        </div>
         <AccountGrokPlatformFields
+          v-if="accountCategory === 'oauth-based'"
           v-model:refreshToken="grokRefreshToken"
           v-model:baseUrl="grokBaseUrl"
           variant="create"
@@ -1133,7 +1197,9 @@
                 ? 'https://api.openai.com'
                 : form.platform === 'gemini'
                   ? 'https://generativelanguage.googleapis.com'
-                  : 'https://api.anthropic.com'
+                  : form.platform === 'grok'
+                    ? 'https://api-us4.tokenkey.dev'
+                    : 'https://api.anthropic.com'
             "
           />
           <p class="input-hint">{{ baseUrlHint }}</p>
@@ -1150,7 +1216,9 @@
                 ? 'sk-proj-...'
                 : form.platform === 'gemini'
                   ? 'AIza...'
-                  : 'sk-ant-...'
+                  : form.platform === 'grok'
+                    ? 'tk-edge-...'
+                    : 'sk-ant-...'
             "
           />
           <p class="input-hint">{{ apiKeyHint }}</p>
@@ -3450,12 +3518,14 @@ const oauthStepTitle = computed(() => {
 const baseUrlHint = computed(() => {
   if (form.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
   if (form.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
+  if (form.platform === 'grok' && form.type === 'apikey') return t('admin.accounts.grokPlatform.relayBaseUrlHint')
   return t('admin.accounts.baseUrlHint')
 })
 
 const apiKeyHint = computed(() => {
   if (form.platform === 'openai') return t('admin.accounts.openai.apiKeyHint')
   if (form.platform === 'gemini') return t('admin.accounts.gemini.apiKeyHint')
+  if (form.platform === 'grok' && form.type === 'apikey') return t('admin.accounts.grokPlatform.relayApiKeyHint')
   return t('admin.accounts.apiKeyHint')
 })
 
@@ -4076,9 +4146,9 @@ watch(
       form.type = 'oauth'
       return
     }
-    // grok (7th platform): always oauth type (refresh_token paste), regardless of addMethod.
+    // grok (7th platform): OAuth refresh_token or first-class API-key relay stub.
     if (form.platform === 'grok') {
-      form.type = 'oauth'
+      form.type = category === 'apikey' ? 'apikey' : 'oauth'
       return
     }
     if ((form.platform === 'gemini' || form.platform === 'anthropic') && category === 'service_account') {
@@ -4102,7 +4172,9 @@ watch(
         ? 'https://api.openai.com'
         : newPlatform === 'gemini'
           ? 'https://generativelanguage.googleapis.com'
-          : 'https://api.anthropic.com'
+          : newPlatform === 'grok'
+            ? ''
+            : 'https://api.anthropic.com'
     // Clear model-related settings
     allowedModels.value = []
     modelMappings.value = []
@@ -4138,8 +4210,8 @@ watch(
       antigravityModelMappings.value = []
       antigravityModelRestrictionMode.value = 'mapping'
     } else if (newPlatform === 'grok') {
-      // 第七平台 grok：oauth(refresh_token)直填，accountCategory='oauth-based' 让
-      // watcher A 把 form.type 同步成 'oauth'。字段重置由 composable.reset() 负责。
+      // 第七平台 grok 默认创建 OAuth 账号；需要 prod→edge relay stub 时可切到
+      // API Key，提交 platform=grok,type=apikey。
       accountCategory.value = 'oauth-based'
       allowOverages.value = false
       antigravityWhitelistModels.value = []
@@ -4986,11 +5058,30 @@ const handleSubmit = async () => {
     return
   }
 
-  // 第七平台 grok：粘 refresh_token，type=oauth；创建期后端 resolveGrokTokenOnSave
-  // 用 refresh_token 立刻换 access_token（绿勾 / 明确报错），无需手填 access_token。
+  // 第七平台 grok：OAuth 账号粘 refresh_token；prod→edge relay stub 走
+  // first-class platform=grok,type=apikey。
   if (form.platform === 'grok') {
     if (!form.name.trim()) {
       appStore.showError(t('admin.accounts.pleaseEnterAccountName'))
+      return
+    }
+    if (accountCategory.value === 'apikey') {
+      const baseURL = apiKeyBaseUrl.value.trim()
+      const apiKey = apiKeyValue.value.trim()
+      if (!baseURL) {
+        appStore.showError(t('admin.accounts.upstream.pleaseEnterBaseUrl'))
+        return
+      }
+      if (!apiKey) {
+        appStore.showError(t('admin.accounts.apiKeyIsRequired'))
+        return
+      }
+      const credentials: Record<string, unknown> = {
+        base_url: baseURL,
+        api_key: apiKey,
+        mirror_platform: 'grok',
+      }
+      await createAccountAndFinish('grok', 'apikey', credentials, buildAPIKeyOrBedrockExtra())
       return
     }
     const bundle = grokBuildSubmitBundle('create')

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -4079,6 +4079,10 @@ const handleSubmit = async () => {
         updatePayload.channel_type = bundle.channelType
       } else {
         const submittedBaseUrl = editBaseUrl.value.trim() || defaultBaseUrl.value
+        if (props.account.platform === 'grok' && !submittedBaseUrl) {
+          appStore.showError(t('admin.accounts.upstream.pleaseEnterBaseUrl'))
+          return
+        }
         newCredentials = { ...currentCredentials, base_url: submittedBaseUrl }
         if (editApiKey.value.trim()) {
           newCredentials.api_key = editApiKey.value.trim()

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -28,7 +28,7 @@
 
       <!-- grok (7th platform, OAuth): refresh_token rotation. Blank = keep current;
            a re-pasted token is re-validated + re-primed by the backend on save. -->
-      <div v-if="account.platform === 'grok'" class="space-y-4">
+      <div v-if="account.platform === 'grok' && account.type === 'oauth'" class="space-y-4">
         <AccountGrokPlatformFields
           v-model:refreshToken="grokRefreshToken"
           v-model:baseUrl="grokBaseUrl"
@@ -96,7 +96,9 @@
                     ? 'https://generativelanguage.googleapis.com'
                     : account.platform === 'antigravity'
                       ? 'https://cloudcode-pa.googleapis.com'
-                      : 'https://api.anthropic.com'
+                      : account.platform === 'grok'
+                        ? 'https://api-us4.tokenkey.dev'
+                        : 'https://api.anthropic.com'
               "
             />
             <p class="input-hint">{{ baseUrlHint }}</p>
@@ -118,7 +120,9 @@
                     ? 'AIza...'
                     : account.platform === 'antigravity'
                       ? 'sk-...'
-                      : 'sk-ant-...'
+                      : account.platform === 'grok'
+                        ? 'tk-edge-...'
+                        : 'sk-ant-...'
               "
             />
             <p class="input-hint">{{ t('admin.accounts.leaveEmptyToKeep') }}</p>
@@ -2597,6 +2601,7 @@ const baseUrlHint = computed(() => {
   if (!props.account) return t('admin.accounts.baseUrlHint')
   if (props.account.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
   if (props.account.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
+  if (props.account.platform === 'grok' && props.account.type === 'apikey') return t('admin.accounts.grokPlatform.relayBaseUrlHint')
   return t('admin.accounts.baseUrlHint')
 })
 
@@ -3050,6 +3055,7 @@ const tempUnschedPresets = computed(() => [
 const defaultBaseUrl = computed(() => {
   if (props.account?.platform === 'openai') return 'https://api.openai.com'
   if (props.account?.platform === 'gemini') return 'https://generativelanguage.googleapis.com'
+  if (props.account?.platform === 'grok') return ''
   return 'https://api.anthropic.com'
 })
 
@@ -3360,6 +3366,14 @@ const syncFormFromAccount = (newAccount: Account | null) => {
       credentials: (newAccount.credentials as Record<string, unknown> | undefined) || {},
     })
   }
+  // 第七平台 grok OAuth：refresh_token 是敏感字段，编辑时留空表示保留现有值
+  // （composable 不回填），base_url 回填。API-key relay stub 走下面的通用
+  // apikey 编辑字段，不应进入 OAuth composable。
+  if (newAccount.platform === 'grok' && newAccount.type === 'oauth') {
+    grokPopulateFromAccount({
+      credentials: (newAccount.credentials as Record<string, unknown> | undefined) || {},
+    })
+  }
 
   // Initialize API Key fields for apikey type
   if (newAccount.type === 'apikey' && newAccount.credentials) {
@@ -3369,7 +3383,9 @@ const syncFormFromAccount = (newAccount: Account | null) => {
         ? 'https://api.openai.com'
         : newAccount.platform === 'gemini'
           ? 'https://generativelanguage.googleapis.com'
-          : 'https://api.anthropic.com'
+          : newAccount.platform === 'grok'
+            ? ''
+            : 'https://api.anthropic.com'
     editBaseUrl.value = (credentials.base_url as string) || platformDefaultUrl
     // TK: edge mirror-stub pool (default anthropic for non-stub accounts).
     editMirrorPlatform.value = normalizeMirrorPlatform(credentials.mirror_platform)
@@ -3385,12 +3401,6 @@ const syncFormFromAccount = (newAccount: Account | null) => {
       if (!credentials.model_pricing_status) {
         void newapiRefreshStoredPricingStatus()
       }
-    }
-
-    // 第七平台 grok：refresh_token 是敏感字段，编辑时留空表示保留现有值（composable
-    // 不回填），base_url 回填。
-    if (newAccount.platform === 'grok') {
-      grokPopulateFromAccount({ credentials })
     }
 
     // Load model mappings and detect mode
@@ -3477,7 +3487,9 @@ const syncFormFromAccount = (newAccount: Account | null) => {
         ? 'https://api.openai.com'
         : newAccount.platform === 'gemini'
           ? 'https://generativelanguage.googleapis.com'
-          : 'https://api.anthropic.com'
+          : newAccount.platform === 'grok'
+            ? ''
+            : 'https://api.anthropic.com'
     editBaseUrl.value = platformDefaultUrl
 
     // Load model mappings for OpenAI OAuth accounts
@@ -4000,7 +4012,7 @@ const handleSubmit = async () => {
     // 第七平台 grok（oauth，非 apikey）：仅在重粘了 refresh_token 或改了 base_url 时
     // 才发 credentials。refresh_token 留空 = 保留现有（后端 MergePreservingSensitiveCreds
     // + 后台刷新器处理）；重粘则后端 resolveGrokTokenOnSave 活体校验 + 重新 prime。
-    if (props.account.platform === 'grok') {
+    if (props.account.platform === 'grok' && props.account.type === 'oauth') {
       const bundle = grokBuildSubmitBundle('edit')
       if (!bundle) return
       if (Object.keys(bundle.credentials).length > 0) {
@@ -4077,6 +4089,8 @@ const handleSubmit = async () => {
         // TK: edge mirror-stub pool selector (surface-C). anthropic apikey only.
         if (props.account.platform === 'anthropic') {
           newCredentials.mirror_platform = editMirrorPlatform.value
+        } else if (props.account.platform === 'grok') {
+          newCredentials.mirror_platform = 'grok'
         }
         if (shouldApplyModelMapping) {
           const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)

--- a/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
@@ -15,7 +15,7 @@
 
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 
 const { listChannelTypesMock, fetchUpstreamModelsMock, createAccountMock } = vi.hoisted(() => {
   return {
@@ -153,6 +153,14 @@ function mountModalWithRealNewApiChildren() {
   })
 }
 
+function clickPlatformByLabel(wrapper: ReturnType<typeof mountModal>, label: string) {
+  const btn = wrapper.findAll('button').find((b) => b.text().trim() === label)
+  if (!btn) {
+    throw new Error(`could not find platform button "${label}". buttons=${wrapper.findAll('button').map((b) => b.text()).join('|')}`)
+  }
+  return btn.trigger('click')
+}
+
 describe('CreateAccountModal — NewAPI (5th platform)', () => {
   beforeEach(() => {
     listChannelTypesMock.mockReset()
@@ -270,5 +278,79 @@ describe('CreateAccountModal — NewAPI (5th platform)', () => {
     // The NewAPI baseUrl label IS expected.
     const newapiBaseUrlOccurrences = (html.match(/admin\.accounts\.newApiPlatform\.baseUrl(?!Hint)/g) ?? []).length
     expect(newapiBaseUrlOccurrences).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('CreateAccountModal — Grok relay stub', () => {
+  beforeEach(() => {
+    listChannelTypesMock.mockReset()
+    fetchUpstreamModelsMock.mockReset()
+    createAccountMock.mockReset()
+    createAccountMock.mockResolvedValue({ id: 953 })
+  })
+
+  it('creates Grok relay stubs as first-class grok apikey accounts', async () => {
+    const wrapper = mountModal()
+    await nextTick()
+
+    await clickPlatformByLabel(wrapper, 'Grok')
+    await nextTick()
+    await nextTick()
+
+    const relayButton = wrapper.findAll('button').find((b) =>
+      b.text().includes('admin.accounts.grokPlatform.relayMode')
+    )
+    expect(relayButton).toBeTruthy()
+    await relayButton!.trigger('click')
+    await nextTick()
+    await nextTick()
+
+    await wrapper.find('input[data-tour="account-form-name"]').setValue('grok-us4')
+    const baseUrlInput = wrapper.find('input[placeholder="https://api-us4.tokenkey.dev"]')
+    const apiKeyInput = wrapper.find('input[placeholder="tk-edge-..."]')
+    expect(baseUrlInput.exists()).toBe(true)
+    expect(apiKeyInput.exists()).toBe(true)
+    await baseUrlInput.setValue('https://api-us4.tokenkey.dev')
+    await apiKeyInput.setValue('edge-tokenkey-key')
+
+    await wrapper.find('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock).toHaveBeenCalledTimes(1)
+    expect(createAccountMock).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'grok-us4',
+      platform: 'grok',
+      type: 'apikey',
+      credentials: {
+        base_url: 'https://api-us4.tokenkey.dev',
+        api_key: 'edge-tokenkey-key',
+        mirror_platform: 'grok'
+      }
+    }))
+  })
+
+  it('does not create a Grok relay stub without an edge base URL', async () => {
+    const wrapper = mountModal()
+    await nextTick()
+
+    await clickPlatformByLabel(wrapper, 'Grok')
+    await nextTick()
+    await nextTick()
+
+    const relayButton = wrapper.findAll('button').find((b) =>
+      b.text().includes('admin.accounts.grokPlatform.relayMode')
+    )
+    expect(relayButton).toBeTruthy()
+    await relayButton!.trigger('click')
+    await nextTick()
+    await nextTick()
+
+    await wrapper.find('input[data-tour="account-form-name"]').setValue('grok-us4')
+    await wrapper.find('input[placeholder="tk-edge-..."]').setValue('edge-tokenkey-key')
+
+    await wrapper.find('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/account/__tests__/EditAccountModal.grok-relay.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.grok-relay.spec.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+
+const { updateAccountMock, checkMixedChannelRiskMock, getWebSearchEmulationConfigMock, getSettingsMock, listTLSFingerprintProfilesMock } = vi.hoisted(() => ({
+  updateAccountMock: vi.fn(),
+  checkMixedChannelRiskMock: vi.fn(),
+  getWebSearchEmulationConfigMock: vi.fn(),
+  getSettingsMock: vi.fn(),
+  listTLSFingerprintProfilesMock: vi.fn()
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess: vi.fn(),
+    showInfo: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    isSimpleMode: true
+  })
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    accounts: {
+      update: updateAccountMock,
+      checkMixedChannelRisk: checkMixedChannelRiskMock
+    },
+    settings: {
+      getWebSearchEmulationConfig: getWebSearchEmulationConfigMock,
+      getSettings: getSettingsMock
+    },
+    tlsFingerprintProfiles: {
+      list: listTLSFingerprintProfilesMock
+    }
+  }
+}))
+
+vi.mock('@/api/admin/accounts', () => ({
+  getAntigravityDefaultModelMapping: vi.fn()
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+import EditAccountModal from '../EditAccountModal.vue'
+
+beforeEach(() => {
+  updateAccountMock.mockReset()
+  checkMixedChannelRiskMock.mockReset()
+  getWebSearchEmulationConfigMock.mockReset()
+  getSettingsMock.mockReset()
+  listTLSFingerprintProfilesMock.mockReset()
+
+  checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+  getWebSearchEmulationConfigMock.mockResolvedValue({ enabled: false, providers: [] })
+  getSettingsMock.mockResolvedValue({ account_quota_notify_enabled: false })
+  listTLSFingerprintProfilesMock.mockResolvedValue([])
+})
+
+const BaseDialogStub = defineComponent({
+  name: 'BaseDialog',
+  props: {
+    show: {
+      type: Boolean,
+      default: false
+    }
+  },
+  template: '<div v-if="show"><slot /><slot name="footer" /></div>'
+})
+
+const SelectStub = defineComponent({
+  name: 'SelectStub',
+  props: {
+    modelValue: {
+      type: [String, Number, Boolean, null],
+      default: ''
+    },
+    options: {
+      type: Array,
+      default: () => []
+    }
+  },
+  emits: ['update:modelValue'],
+  template: `
+    <select
+      v-bind="$attrs"
+      :value="modelValue"
+      @change="$emit('update:modelValue', $event.target.value)"
+    >
+      <option v-for="option in options" :key="option.value" :value="option.value">
+        {{ option.label }}
+      </option>
+    </select>
+  `
+})
+
+const ModelWhitelistSelectorStub = defineComponent({
+  name: 'ModelWhitelistSelector',
+  props: {
+    modelValue: {
+      type: Array,
+      default: () => []
+    }
+  },
+  emits: ['update:modelValue'],
+  template: '<div />'
+})
+
+function buildGrokRelayStubAccount() {
+  return {
+    id: 7,
+    name: 'Grok Relay',
+    notes: '',
+    platform: 'grok',
+    type: 'apikey',
+    credentials: {
+      base_url: 'https://api-us4.tokenkey.dev',
+      mirror_platform: 'grok'
+    },
+    credentials_status: { has_api_key: true },
+    extra: {},
+    proxy_id: null,
+    concurrency: 10,
+    priority: 1,
+    rate_multiplier: 1,
+    status: 'active',
+    group_ids: [],
+    expires_at: null,
+    auto_pause_on_expired: false
+  } as any
+}
+
+function mountModal() {
+  return mount(EditAccountModal, {
+    props: {
+      show: true,
+      account: buildGrokRelayStubAccount(),
+      proxies: [],
+      groups: []
+    },
+    global: {
+      stubs: {
+        BaseDialog: BaseDialogStub,
+        Select: SelectStub,
+        Icon: true,
+        ProxySelector: true,
+        GroupSelector: true,
+        ModelWhitelistSelector: ModelWhitelistSelectorStub
+      }
+    }
+  })
+}
+
+describe('EditAccountModal — Grok relay stub', () => {
+  it('blocks save when the edge base URL is cleared', async () => {
+    const wrapper = mountModal()
+
+    await wrapper.get('input[placeholder="https://api-us4.tokenkey.dev"]').setValue('')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/admin/account/AccountTableFilters.vue
+++ b/frontend/src/components/admin/account/AccountTableFilters.vue
@@ -32,7 +32,11 @@ const updateGroup = (value: string | number | boolean | null) => { emit('update:
 // "All" entry is rendered with the same label key as elsewhere in the admin UI.
 // The getter form keeps the i18n label reactive on locale switch.
 const { optionsWithAll } = usePlatformOptions()
-const pOpts = optionsWithAll(() => t('admin.accounts.allPlatforms'))
+const basePlatformOptions = optionsWithAll(() => t('admin.accounts.allPlatforms'))
+const pOpts = computed(() => [
+  ...basePlatformOptions.value,
+  { value: '__kiro_stub__', label: t('admin.accounts.kiroStubPlatform') },
+])
 const tOpts = computed(() => [{ value: '', label: t('admin.accounts.allTypes') }, { value: 'oauth', label: t('admin.accounts.oauthType') }, { value: 'setup-token', label: t('admin.accounts.setupToken') }, { value: 'apikey', label: t('admin.accounts.apiKey') }, { value: 'bedrock', label: 'AWS Bedrock' }])
 const sOpts = computed(() => [{ value: '', label: t('admin.accounts.allStatus') }, { value: 'active', label: t('admin.accounts.status.active') }, { value: 'inactive', label: t('admin.accounts.status.inactive') }, { value: 'error', label: t('admin.accounts.status.error') }, { value: 'rate_limited', label: t('admin.accounts.status.rateLimited') }, { value: 'temp_unschedulable', label: t('admin.accounts.status.tempUnschedulable') }, { value: 'unschedulable', label: t('admin.accounts.status.unschedulable') }])
 const privacyOpts = computed(() => [

--- a/frontend/src/components/admin/account/__tests__/AccountTableFilters.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountTableFilters.spec.ts
@@ -14,7 +14,7 @@ vi.mock('vue-i18n', async () => {
 })
 
 const SelectStub = defineComponent({
-  name: 'Select',
+  name: 'SelectStub',
   props: {
     modelValue: { type: [String, Number, Boolean], default: '' },
     options: { type: Array, default: () => [] }

--- a/frontend/src/components/admin/account/__tests__/AccountTableFilters.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountTableFilters.spec.ts
@@ -1,0 +1,84 @@
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import AccountTableFilters from '../AccountTableFilters.vue'
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+const SelectStub = defineComponent({
+  name: 'Select',
+  props: {
+    modelValue: { type: [String, Number, Boolean], default: '' },
+    options: { type: Array, default: () => [] }
+  },
+  emits: ['update:modelValue', 'change'],
+  template: `
+    <div data-testid="select">
+      <button
+        v-for="opt in options"
+        :key="String(opt.value)"
+        type="button"
+        :data-value="String(opt.value)"
+        @click="$emit('update:modelValue', opt.value); $emit('change')"
+      >
+        {{ opt.label }}
+      </button>
+    </div>
+  `
+})
+
+const SearchInputStub = defineComponent({
+  name: 'SearchInput',
+  props: {
+    modelValue: { type: String, default: '' }
+  },
+  emits: ['update:modelValue', 'search'],
+  template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" @change="$emit(\'search\')" />'
+})
+
+function mountFilters() {
+  return mount(AccountTableFilters, {
+    props: {
+      searchQuery: '',
+      filters: {
+        platform: '',
+        type: '',
+        status: '',
+        privacy_mode: '',
+        group: ''
+      },
+      groups: []
+    },
+    global: {
+      stubs: {
+        Select: SelectStub,
+        SearchInput: SearchInputStub
+      }
+    }
+  })
+}
+
+describe('AccountTableFilters', () => {
+  it('offers a virtual Kiro stub platform filter and emits the sentinel value', async () => {
+    const wrapper = mountFilters()
+
+    const kiroStubOption = wrapper.find('[data-value="__kiro_stub__"]')
+    expect(kiroStubOption.exists()).toBe(true)
+    expect(kiroStubOption.text()).toBe('admin.accounts.kiroStubPlatform')
+
+    await kiroStubOption.trigger('click')
+
+    expect(wrapper.emitted('update:filters')?.[0]?.[0]).toMatchObject({
+      platform: '__kiro_stub__'
+    })
+    expect(wrapper.emitted('change')).toBeTruthy()
+  })
+})

--- a/frontend/src/composables/usePlatformOptions.ts
+++ b/frontend/src/composables/usePlatformOptions.ts
@@ -1,6 +1,6 @@
 import { computed, toValue, type ComputedRef, type MaybeRefOrGetter } from 'vue'
 import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
-import type { AccountPlatform } from '@/types'
+import type { AccountPlatform, AccountPlatformFilterValue } from '@/types'
 
 export const PLATFORM_LABELS: Record<AccountPlatform, string> = {
   anthropic: 'Anthropic',
@@ -24,7 +24,7 @@ export interface PlatformOption {
 }
 
 export interface PlatformFilterOption {
-  value: '' | AccountPlatform
+  value: AccountPlatformFilterValue
   label: string
   [key: string]: unknown
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3517,6 +3517,7 @@ export default {
       notesPlaceholder: 'Enter notes',
       notesHint: 'Notes are optional',
       allPlatforms: 'All Platforms',
+      kiroStubPlatform: 'Kiro Stub',
       allTypes: 'All Types',
       allStatus: 'All Status',
       allGroups: 'All Groups',
@@ -4237,12 +4238,18 @@ export default {
         pleaseAcknowledgeTos: 'Please acknowledge the Kiro terms of service before creating the account'
       },
       grokPlatform: {
+        oauthMode: 'OAuth',
+        oauthModeHint: 'xAI refresh token',
+        relayMode: 'Relay Stub',
+        relayModeHint: 'Edge API key',
         refreshToken: 'Refresh Token',
         refreshTokenPlaceholder: 'xAI Grok OAuth refresh token',
         refreshTokenHint: 'On create, TokenKey immediately exchanges it for an access token — a failure here means the token is invalid or the account is not SuperGrok Heavy.',
         refreshTokenHowTo: 'Obtain the refresh_token by running the xAI Grok CLI login on your own machine (loopback OAuth), then paste it here. xAI\'s public client has no server-side redirect / device-code flow, so the token must be minted out-of-band.',
         baseUrl: 'Base URL (optional)',
         baseUrlHint: 'Defaults to https://api.x.ai/v1. Override only for a self-hosted reverse proxy.',
+        relayBaseUrlHint: 'Use the edge gateway URL, for example https://api-us4.tokenkey.dev.',
+        relayApiKeyHint: 'Use the TokenKey edge API key for this relay stub.',
         tokenEditHint: 'Leave empty to keep the current value',
         heavyNote: 'xAI gates the OAuth API surface to SuperGrok Heavy. A standard / expired subscription returns HTTP 403 at request time.',
         pleaseEnterRefreshToken: 'Please enter the Grok refresh token'

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3589,6 +3589,7 @@ export default {
       notesHint: '备注可选',
       // Filter options
       allPlatforms: '全部平台',
+      kiroStubPlatform: 'Kiro Stub',
       allTypes: '全部类型',
       allStatus: '全部状态',
       allGroups: '全部分组',
@@ -4379,12 +4380,18 @@ export default {
         pleaseAcknowledgeTos: '创建账号前请先勾选确认 Kiro 服务条款'
       },
       grokPlatform: {
+        oauthMode: 'OAuth',
+        oauthModeHint: 'xAI refresh token',
+        relayMode: 'Relay Stub',
+        relayModeHint: 'Edge API key',
         refreshToken: 'Refresh Token',
         refreshTokenPlaceholder: 'xAI Grok OAuth refresh token',
         refreshTokenHint: '创建时 TokenKey 会立刻用它换取 access token —— 这里若失败，说明 token 无效或该账号不是 SuperGrok Heavy。',
         refreshTokenHowTo: '在本机运行 xAI Grok CLI 登录（loopback OAuth）拿到 refresh_token 后粘贴到这里。xAI 公共 client 无服务端 redirect / device-code 流程，故 token 须在本机铸取。',
         baseUrl: 'Base URL（可选）',
         baseUrlHint: '默认 https://api.x.ai/v1，仅自建反代时覆盖。',
+        relayBaseUrlHint: '使用 edge 网关地址，例如 https://api-us4.tokenkey.dev。',
+        relayApiKeyHint: '填写该 relay stub 访问 edge 的 TokenKey API key。',
         tokenEditHint: '留空表示保留当前值',
         heavyNote: 'xAI 把 OAuth API 面限定给 SuperGrok Heavy；标准 / 过期订阅会在请求时返回 HTTP 403。',
         pleaseEnterRefreshToken: '请输入 Grok refresh token'

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -720,6 +720,7 @@ export interface UpdateGroupRequest {
 // ==================== Account & Proxy Types ====================
 
 export type AccountPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'newapi' | 'kiro' | 'grok'
+export type AccountPlatformFilterValue = '' | AccountPlatform | '__kiro_stub__'
 export type AccountType = 'oauth' | 'setup-token' | 'apikey' | 'upstream' | 'bedrock' | 'service_account'
 export type OAuthAddMethod = 'oauth' | 'setup-token'
 export type ProxyProtocol = 'http' | 'https' | 'socks5' | 'socks5h'

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1620,14 +1620,20 @@ const buildAccountQueryFilters = () => ({
   sort_by: sortState.sort_by,
   sort_order: sortState.sort_order
 })
+const ACCOUNT_EDGE_BASE_URL_PATTERN = /^https:\/\/api-[a-z0-9]+\.tokenkey\.dev\/?$/
 const accountMatchesPlatformFilter = (account: Account, platform: string) => {
   if (!platform) return true
   if (platform === ACCOUNT_KIRO_STUB_PLATFORM_FILTER) {
+    const baseUrl = typeof account.credentials?.base_url === 'string' ? account.credentials.base_url.trim() : ''
+    const mirrorPlatform =
+      typeof account.credentials?.mirror_platform === 'string'
+        ? account.credentials.mirror_platform.trim().toLowerCase()
+        : ''
     return (
       account.platform === 'anthropic' &&
       account.type === 'apikey' &&
-      Boolean(account.edge_id) &&
-      account.credentials?.mirror_platform === 'kiro'
+      mirrorPlatform === 'kiro' &&
+      ACCOUNT_EDGE_BASE_URL_PATTERN.test(baseUrl)
     )
   }
   return account.platform === platform

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1609,6 +1609,7 @@ const handleBulkUpdated = () => {
 const handleDataImported = () => { showImportData.value = false; reload() }
 const ACCOUNT_UNGROUPED_GROUP_QUERY_VALUE = 'ungrouped'
 const ACCOUNT_PRIVACY_MODE_UNSET_QUERY_VALUE = '__unset__'
+const ACCOUNT_KIRO_STUB_PLATFORM_FILTER = '__kiro_stub__'
 const buildAccountQueryFilters = () => ({
   platform: params.platform || '',
   type: params.type || '',
@@ -1619,9 +1620,21 @@ const buildAccountQueryFilters = () => ({
   sort_by: sortState.sort_by,
   sort_order: sortState.sort_order
 })
+const accountMatchesPlatformFilter = (account: Account, platform: string) => {
+  if (!platform) return true
+  if (platform === ACCOUNT_KIRO_STUB_PLATFORM_FILTER) {
+    return (
+      account.platform === 'anthropic' &&
+      account.type === 'apikey' &&
+      Boolean(account.edge_id) &&
+      account.credentials?.mirror_platform === 'kiro'
+    )
+  }
+  return account.platform === platform
+}
 const accountMatchesCurrentFilters = (account: Account) => {
   const filters = buildAccountQueryFilters()
-  if (filters.platform && account.platform !== filters.platform) return false
+  if (!accountMatchesPlatformFilter(account, filters.platform)) return false
   if (filters.type && account.type !== filters.type) return false
   if (filters.status) {
     const now = Date.now()

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -118,6 +118,16 @@
       "rationale": "The grok credential-rotation wiring in the account-edit modal (re-paste refresh_token, blank=keep). Losing it forces delete+recreate to rotate a dead grok refresh_token (invalid_grant). Paired with the UpdateAccount resolveGrokTokenOnSave gate (admin_service.go)."
     },
     {
+      "path": "frontend/src/components/account/EditAccountModal.vue",
+      "must_contain": ["!submittedBaseUrl", "admin.accounts.upstream.pleaseEnterBaseUrl", "newCredentials.mirror_platform = 'grok'"],
+      "rationale": "The first-class grok API-key relay stub edit guard. These accounts deliberately do not expose an api_key in admin, so clearing base_url would otherwise write an empty edge target and break relay forwarding. Losing this guard lets an innocuous edit silently disable a prod grok relay stub."
+    },
+    {
+      "path": "frontend/src/components/account/__tests__/EditAccountModal.grok-relay.spec.ts",
+      "must_contain": ["blocks save when the edge base URL is cleared", "expect(updateAccountMock).not.toHaveBeenCalled()"],
+      "rationale": "Focused regression evidence for the grok relay-stub edit guard. It pins the admin behavior that an existing grok+apikey relay stub cannot be saved after its edge base_url is cleared."
+    },
+    {
       "path": "frontend/src/i18n/locales/en.ts",
       "must_contain": ["grokPlatform"],
       "rationale": "English i18n strings for the grok account form. Losing them surfaces raw i18n keys in the UI."

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -275,6 +275,14 @@
       "rationale": "Two Kiro account-edit anchors. (1) Surface-C mirror-stub pool selector: the operator's only no-SQL way to set credentials.mirror_platform=kiro on an existing edge stub (e.g. kiro-edge-us1). Losing it strands the live fix: the kiro stub keeps mirroring the anthropic Σ. (2) Kiro OAuth credential edit wiring: AccountKiroPlatformFields + populate/submit bundle let operators rotate access_token/refresh_token, region/auth_method, IdC client_id/client_secret, Profile ARN, and ToS acknowledgement without delete+recreate. An upstream merge that rewrites EditAccountModal must preserve this branch or live Kiro accounts become unrepairable from the UI."
     },
     {
+      "path": "frontend/src/components/admin/account/AccountTableFilters.vue",
+      "must_contain": [
+        "__kiro_stub__",
+        "kiroStubPlatform"
+      ],
+      "rationale": "Admin account platform filtering must keep the first-class Kiro Stub virtual platform. Losing this option removes the no-SQL way to list prod anthropic API-key mirror stubs that target the edge Kiro pool (credentials.mirror_platform=kiro), making the live Kiro relay topology hard to audit after upstream-shaped account-filter UI rewrites."
+    },
+    {
       "path": "frontend/src/constants/mirrorPlatformOptions.tk.ts",
       "must_contain": [
         "MIRROR_PLATFORM_OPTIONS",


### PR DESCRIPTION
## 摘要
- 在新增账号弹窗中给 Grok 增加 OAuth / Relay Stub 两种模式，Relay Stub 直接创建 `platform=grok,type=apikey`，凭据写入 edge `base_url` / `api_key` / `mirror_platform=grok`。
- 修正编辑弹窗：`grok+oauth` 继续走 refresh_token 字段，`grok+apikey` 走普通 API Key 编辑并保持 relay stub 元数据；review 后补上 relay stub 清空 `base_url` 时禁止保存。
- 在账号平台筛选中增加 `Kiro Stub` 虚拟平台，后端和前端本地过滤都按 `anthropic+apikey + mirror_platform=kiro + api-*.tokenkey.dev` 识别，并对 `mirror_platform` 做 trim/lowercase 归一化。
- 补齐 Grok/Kiro sentinel 锚点和 focused 回归测试，防止上游形状改写静默抹掉 admin relay 管理入口。

## 风险
- 常规风险：影响 admin 账号创建/编辑/筛选路径，不涉及 schema 迁移。
- sentinel-registry-reviewed：已审阅 sentinel advisory；本 PR 已为新增/变更的 Grok relay guard 与 Kiro Stub filter 补充平台 sentinel，剩余 advisory surface 已确认由平台 sentinel / focused test 覆盖。
- upstream-touch-guarded：本 PR 触及的 revert-risk upstream-shaped 文件已通过 `scripts/checks/upstream-override-marker.py --base origin/main` 校验为 sentinel-pinned。
- 嵌入前端 dist 已通过 `pnpm --dir frontend run build` 刷新 `frontend-source.json`。

## 验证
- `make test-frontend`
- `pnpm exec eslint src/components/account/EditAccountModal.vue src/components/account/__tests__/EditAccountModal.grok-relay.spec.ts src/components/admin/account/__tests__/AccountTableFilters.spec.ts src/views/admin/AccountsView.vue`
- `pnpm test:run src/components/account/__tests__/CreateAccountModal.newapi.spec.ts src/components/admin/account/__tests__/AccountTableFilters.spec.ts src/components/account/__tests__/EditAccountModal.grok-relay.spec.ts`
- `HTTPS_PROXY= HTTP_PROXY= http_proxy= https_proxy= GOPROXY=https://goproxy.cn,direct go test -tags=integration ./internal/repository -run '^TestAccountRepoSuite$' -testify.m '^TestListWithFilters$' -count=1 -v`
- `python3 scripts/sentinels/check-grok.py && python3 scripts/sentinels/check-kiro.py && python3 scripts/checks/upstream-override-marker.py --base origin/main`
- `pnpm --dir frontend run build`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

## 提交
- `367c10013 feat(admin): expose Grok and Kiro relay stubs`
- `f37a9479c fix(admin): address Grok/Kiro relay review findings`
- 最新提交：`f37a9479c`
