### PR TITLE
fix(migrations): 还原 tk_038 checksum 解除 v1.8.39 deploy 阻塞

### DIFF
--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -79,6 +79,13 @@ var migrationChecksumCompatibilityRules = map[string]migrationChecksumCompatibil
 	"123_fix_legacy_auth_source_grant_on_signup_defaults.sql": newMigrationChecksumCompatibilityRule("2ce43c2cd89e9f9e1febd34a407ed9e84d177386c5544b6f02c1f58a21129f57", "6cd33422f215dcd1f486ab6f35c0ea5805d9ca69bb25906d94bc649156657145"),
 	// tk_006: prod recorded checksum from v1.7.14 file; merge #112 changed comments only → new trim-hash.
 	"tk_006_add_qa_records_synth_fields.sql": newMigrationChecksumCompatibilityRule("06fed3407eaa878b73f7fd0d5bd00be5c9852eb58a0c7682b49a03d36be3391e", "913563b6ed60214ea05e3d2ee2f50aeddfb015b2ade7669a62d602630b0c1a50"),
+	// tk_038: #963 mistakenly expanded CREATE TABLE in-place (v1.8.39); prod/edge DBs
+	// already recorded the v1.8.38 checksum. Metric columns belong in tk_046 only.
+	"tk_038_usage_dashboard_group_daily.sql": newMigrationChecksumCompatibilityRule(
+		"55d565b2820aa360f3efdeb4186c78548c715bce44b93bc32da3d9946a370793",
+		"55d565b2820aa360f3efdeb4186c78548c715bce44b93bc32da3d9946a370793",
+		"03b5b2d5a2ab4c714f547ee03eb08076d8ce8ff948e403d0a09dfc5e20cdd913",
+	),
 }
 
 // ApplyMigrations 将嵌入的 SQL 迁移文件应用到指定的数据库。

--- a/backend/internal/repository/migrations_runner_extra_test.go
+++ b/backend/internal/repository/migrations_runner_extra_test.go
@@ -68,6 +68,18 @@ func TestLatestMigrationBaseline(t *testing.T) {
 	})
 }
 
+func TestIsMigrationChecksumCompatible_Tk038UsageDashboardGroupDaily(t *testing.T) {
+	const (
+		appliedV138 = "55d565b2820aa360f3efdeb4186c78548c715bce44b93bc32da3d9946a370793"
+		mistakeV139 = "03b5b2d5a2ab4c714f547ee03eb08076d8ce8ff948e403d0a09dfc5e20cdd913"
+	)
+	name := "tk_038_usage_dashboard_group_daily.sql"
+
+	require.True(t, isMigrationChecksumCompatible(name, appliedV138, appliedV138))
+	require.True(t, isMigrationChecksumCompatible(name, appliedV138, mistakeV139))
+	require.False(t, isMigrationChecksumCompatible(name, "unknown-db-checksum", appliedV138))
+}
+
 func TestIsMigrationChecksumCompatible_AdditionalCases(t *testing.T) {
 	require.False(t, isMigrationChecksumCompatible("unknown.sql", "db", "file"))
 
@@ -104,6 +116,7 @@ func TestMigrationChecksumCompatibilityRules_CoverEditedUpgradeCompatibilityMigr
 		"118_wechat_dual_mode_and_auth_source_defaults.sql",
 		"120_enforce_payment_orders_out_trade_no_unique_notx.sql",
 		"123_fix_legacy_auth_source_grant_on_signup_defaults.sql",
+		"tk_038_usage_dashboard_group_daily.sql",
 	} {
 		rule, ok := migrationChecksumCompatibilityRules[name]
 		require.Truef(t, ok, "missing compatibility rule for %s", name)

--- a/backend/migrations/tk_038_usage_dashboard_group_daily.sql
+++ b/backend/migrations/tk_038_usage_dashboard_group_daily.sql
@@ -13,8 +13,9 @@
 -- usage_log_repo_tk_group_rollup.go (read) and dashboard_aggregation_repo_tk_group.go
 -- (feeder + one-time backfill).
 --
--- Grain: one row per (group_id, bucket_date). Metrics cover both the Groups page
--- cost summary and the Dashboard/Usage group distribution chart.
+-- Grain: one row per (group_id, bucket_date). Metric: actual_cost only — that is
+-- the single column the usage-summary reads. "platform"/token columns are
+-- deliberately omitted (YAGNI); add later if a consumer needs them.
 --
 -- Retention: UNLIKE the windowed usage_dashboard_* rollups, this table is NOT
 -- pruned by CleanupAggregates — the Groups summary is an ALL-TIME cumulative, so
@@ -30,17 +31,10 @@
 -- grain matches the read path exactly.
 
 CREATE TABLE IF NOT EXISTS usage_dashboard_group_daily (
-    bucket_date           DATE NOT NULL,
-    group_id              BIGINT NOT NULL,
-    total_requests        BIGINT NOT NULL DEFAULT 0,
-    input_tokens          BIGINT NOT NULL DEFAULT 0,
-    output_tokens         BIGINT NOT NULL DEFAULT 0,
-    cache_creation_tokens BIGINT NOT NULL DEFAULT 0,
-    cache_read_tokens     BIGINT NOT NULL DEFAULT 0,
-    total_cost            DECIMAL(20, 10) NOT NULL DEFAULT 0,
-    actual_cost           DECIMAL(20, 10) NOT NULL DEFAULT 0,
-    account_cost          DECIMAL(20, 10) NOT NULL DEFAULT 0,
-    computed_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    bucket_date  DATE NOT NULL,
+    group_id     BIGINT NOT NULL,
+    actual_cost  DECIMAL(20, 10) NOT NULL DEFAULT 0,
+    computed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (bucket_date, group_id)
 );
 


### PR DESCRIPTION
## 摘要

- 将 `tk_038_usage_dashboard_group_daily.sql` 还原为 v1.8.38 已应用版本（checksum `55d565b2…`），扩展列仍由 `tk_046` 的 `ADD COLUMN IF NOT EXISTS` 负责。
- 在 `migrations_runner.go` 增加 `tk_038` compatibility rule，兼容 v1.8.39 误改 file checksum（`03b5b2d5…`）。
- 补充回归测试 `TestIsMigrationChecksumCompatible_Tk038UsageDashboardGroupDaily`。

**背景：** v1.8.39 canary（us3）升级失败，应用启动报 `tk_038 checksum mismatch`；us3 已回滚至 1.8.38，prod 未部署。

## 风险

- 低风险 hotfix：仅迁移校验与已应用文件还原，无网关行为变更。
- 合并后需发 **v1.8.40** 再 rollout（**勿** deploy `1.8.39` 镜像）。

## 验证

- `./scripts/preflight.sh` PASS（含 blue/green migration safety）
- `go build -tags=unit ./internal/repository/` PASS
- tk_038 还原后 trimmed checksum 与线上 DB 一致（`55d565b2…`）

## 提交

- 01bccf8aa fix(migrations): 还原 tk_038 checksum 以解除 v1.8.39 deploy 阻塞

最新提交：01bccf8aa
