### PR TITLE
chore(stage0): codify gp3 data volume performance

### DIFF
--- a/deploy/aws/cloudformation/stage0-single-ec2.yaml
+++ b/deploy/aws/cloudformation/stage0-single-ec2.yaml
@@ -84,6 +84,18 @@ Parameters:
       instance with all data intact, instead of being thrown away with the
       old root EBS. Sized for prod organic growth: live PostgreSQL + ~1.5 days
       of QA blobs + 6 hourly pgdump retained copies; 30 GiB proved too tight.
+  DataVolumeIops:
+    Type: Number
+    Default: 6000
+    MinValue: 3000
+    MaxValue: 16000
+    Description: Dedicated gp3 data volume provisioned IOPS.
+  DataVolumeThroughput:
+    Type: Number
+    Default: 250
+    MinValue: 125
+    MaxValue: 1000
+    Description: Dedicated gp3 data volume provisioned throughput in MiB/s.
   AmazonLinux2023Arm64Ami:
     Type: AWS::EC2::Image::Id
     Default: ami-0b183bb1259186479
@@ -495,6 +507,8 @@ Resources:
       AvailabilityZone: !Select [0, !GetAZs '']
       Size: !Ref DataVolumeSizeGiB
       VolumeType: gp3
+      Iops: !Ref DataVolumeIops
+      Throughput: !Ref DataVolumeThroughput
       Encrypted: true
       Tags:
         - {Key: Name, Value: !Sub '${ProjectName}-${Environment}-data'}


### PR DESCRIPTION
## 摘要
- 在 Stage0 单机 CFN 模板中增加 `DataVolumeIops` / `DataVolumeThroughput` 参数。
- 将 prod 当前真实数据盘性能 `6000 IOPS / 250 MiB/s` 写成模板默认值，并接入 `AWS::EC2::Volume` 的 gp3 属性。
- 仅 IaC 模板收敛，无 Web/API 行为变化。

## 风险
- 低风险代码改动：只修改 CFN 模板声明，不触发部署。
- 线上验证时发现当前 prod live template 仍含 `AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>` rolling AMI 参数；即使只改 `DataVolumeSizeGiB`，change set 也会显示 `Instance` / `EIPAssoc` replacement 风险。因此本 PR 不直接执行 prod stack update。
- 后续线上收敛必须继续以 change set 审核为门禁：只允许无 `Instance` / `EIPAssoc` / `DataVolume` replacement 的计划执行。

## 验证
- `aws cloudformation validate-template --region us-east-1 --template-body file://deploy/aws/cloudformation/stage0-single-ec2.yaml`
- `python3 -m unittest deploy.aws.stage0.test_build_cfn`
- `./scripts/preflight.sh`
- prod 只创建并删除 change set 探针，未执行：stack 保持 `UPDATE_COMPLETE`，`https://api.tokenkey.dev/health` 返回 `{"status":"ok"}`。

## 提交
- `1e53d5fc9 chore(stage0): codify gp3 data volume performance no-web-impact`
- 最新提交：`1e53d5fc9`

