### PR TITLE
fix(stage0): harden live-host assert region handling

### DIFF
--- a/ops/stage0/assert-live-host-state.sh
+++ b/ops/stage0/assert-live-host-state.sh
@@ -49,9 +49,15 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-ssm_region_args=()
 _region="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
-[[ -n "${_region}" ]] && ssm_region_args=(--region "${_region}")
+
+aws_ssm() {
+  if [[ -n "${_region}" ]]; then
+    aws --region "${_region}" ssm "$@"
+  else
+    aws ssm "$@"
+  fi
+}
 
 # Read-only remote probe: emit tagged, field-named JSON the verdict parses. Only
 # emits ENV lines for keys actually present, so a missing required key yields no
@@ -84,7 +90,7 @@ REMOTE_B64="$(printf '%s' "${REMOTE_PROBE}" | base64 | tr -d '\n')"
 
 # Guard send-command: an SSM transport failure must NOT make this advisory check
 # exit non-zero (the contract above) — surface it as a ::warning:: and stop.
-if ! cmd_id="$(aws ssm send-command "${ssm_region_args[@]}" \
+if ! cmd_id="$(aws_ssm send-command \
   --instance-ids "${INSTANCE_ID}" \
   --document-name AWS-RunShellScript \
   --comment "${COMMENT}" \
@@ -98,7 +104,7 @@ fi
 deadline=$(( $(date +%s) + SSM_TIMEOUT_SECONDS ))
 status="Pending"
 while :; do
-  status="$(aws ssm get-command-invocation "${ssm_region_args[@]}" \
+  status="$(aws_ssm get-command-invocation \
     --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
     --query 'Status' --output text 2>/dev/null || echo Pending)"
   case "${status}" in
@@ -108,7 +114,7 @@ while :; do
   sleep 2
 done
 
-probe_out="$(aws ssm get-command-invocation "${ssm_region_args[@]}" \
+probe_out="$(aws_ssm get-command-invocation \
   --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
   --query 'StandardOutputContent' --output text 2>/dev/null || true)"
 

--- a/ops/stage0/test_assert_live_host_state.py
+++ b/ops/stage0/test_assert_live_host_state.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for ops/stage0/assert-live-host-state.sh transport glue.
+
+The live-host verdict itself is tested in live_host_state_verdict.py. These tests
+stub the AWS CLI so the shell wrapper can be exercised without network access.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent / "assert-live-host-state.sh"
+
+
+class AssertLiveHostStateTransportTest(unittest.TestCase):
+    def _run_with_fake_aws(self, *, region: str | None = None) -> subprocess.CompletedProcess[str]:
+        tmp = pathlib.Path(tempfile.mkdtemp(prefix="assert-live-host-state-"))
+        calls = tmp / "aws-calls.txt"
+        fake_bin = tmp / "bin"
+        fake_bin.mkdir()
+        (fake_bin / "aws").write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                printf '%s\\n' "$*" >> {str(calls)!r}
+                if [[ "${{1:-}}" == "--region" ]]; then
+                  shift 2
+                fi
+                case "$*" in
+                  'ssm send-command '*)
+                    printf 'cmd-123\\n'
+                    ;;
+                  'ssm get-command-invocation --command-id cmd-123 --instance-id i-test --query Status --output text')
+                    printf 'Success\\n'
+                    ;;
+                  'ssm get-command-invocation --command-id cmd-123 --instance-id i-test --query StandardOutputContent --output text')
+                    cat <<'OUT'
+                APPCONTAINER {{"name":"tokenkey-blue"}}
+                RUNIMAGE {{"image":"ghcr.io/youxuanxue/sub2api:1.8.40"}}
+                ENV {{"key":"SERVER_FRONTEND_URL","value":"https://api.tokenkey.dev"}}
+                ENV {{"key":"QA_CAPTURE_EXPORT_STORAGE_DRIVER","value":"s3"}}
+                ENV {{"key":"QA_CAPTURE_EXPORT_STORAGE_REGION","value":"us-east-1"}}
+                ENV {{"key":"QA_CAPTURE_EXPORT_STORAGE_BUCKET","value":"tokenkey-prod-qa-exports-682751977094"}}
+                ENV {{"key":"QA_CAPTURE_EXPORT_STORAGE_PREFIX","value":"traj-exports"}}
+                RETENTION {{"value":"1.5"}}
+                OUT
+                    ;;
+                  *)
+                    printf 'unexpected aws call: %s\\n' "$*" >&2
+                    exit 9
+                    ;;
+                esac
+                """
+            ),
+            encoding="utf-8",
+        )
+        (fake_bin / "aws").chmod(0o755)
+        env = {
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "SSM_TIMEOUT_SECONDS": "5",
+        }
+        env.pop("AWS_REGION", None)
+        env.pop("AWS_DEFAULT_REGION", None)
+        if region is not None:
+            env["AWS_REGION"] = region
+        proc = subprocess.run(
+            ["bash", str(_SCRIPT), "i-test", "1.8.40"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        proc.calls = calls.read_text(encoding="utf-8").splitlines()  # type: ignore[attr-defined]
+        return proc
+
+    def test_no_region_uses_aws_default_chain_without_unbound_array(self) -> None:
+        proc = self._run_with_fake_aws()
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertIn("OK: live host matches intended state", proc.stdout)
+        self.assertTrue(proc.calls)  # type: ignore[attr-defined]
+        self.assertTrue(all(not call.startswith("--region ") for call in proc.calls))  # type: ignore[attr-defined]
+        self.assertNotIn("unbound variable", proc.stderr)
+
+    def test_region_is_passed_before_ssm_subcommand(self) -> None:
+        proc = self._run_with_fake_aws(region="us-east-1")
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertIn("OK: live host matches intended state", proc.stdout)
+        self.assertTrue(proc.calls)  # type: ignore[attr-defined]
+        self.assertTrue(all(call.startswith("--region us-east-1 ssm ") for call in proc.calls))  # type: ignore[attr-defined]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- 修复 `ops/stage0/assert-live-host-state.sh` 在未设置 `AWS_REGION` / `AWS_DEFAULT_REGION` 时，macOS Bash 3.2 + `set -u` 展开空数组导致的 `ssm_region_args[@]: unbound variable`。
- 将 SSM 调用收敛到 `aws_ssm()` helper：有 region 时显式传 `--region`，无 region 时走 AWS 默认凭证链。
- 新增 stdlib-only transport 测试，用 fake `aws` 覆盖无 region / 有 region 两条路径。

## 风险
- 低风险：只修只读运维检测脚本，不改线上配置、不重启服务、不影响 Web/API 行为。
- 脚本原有 drift verdict 逻辑未改，只修 AWS CLI 调用包装。

## 验证
- 复现旧问题：`bash ops/stage0/assert-live-host-state.sh i-0e43099f831b03160 1.8.40` 曾输出 `ssm_region_args[@]: unbound variable`。
- `python3 -m unittest ops.stage0.test_assert_live_host_state`
- `AWS_REGION=us-east-1 bash ops/stage0/assert-live-host-state.sh i-0e43099f831b03160 1.8.40` → `OK: live host matches intended state`
- `./scripts/preflight.sh`

## 提交
- `a509ce321 fix(stage0): harden live-host assert region handling no-web-impact`
- 最新提交：`a509ce321`
