### PR TITLE
chore(observability): support bluegreen log tail

### DIFF
--- a/ops/observability/probe-tail-gateway-logs.sh
+++ b/ops/observability/probe-tail-gateway-logs.sh
@@ -5,14 +5,20 @@
 # Env:
 #   LIMIT       max rows (default 50)
 #   SINCE       docker logs --since (default 24h)
-#   CONTAINER   gateway container (default auto: active blue/green or legacy tokenkey)
+#   CONTAINER   gateway container (default auto). auto resolves
+#               /var/lib/tokenkey/active-color to tokenkey-blue/green and
+#               falls back to the legacy tokenkey container.
+#   ACTIVE_COLOR_FILE
+#               active-color file path for CONTAINER=auto
+#               (default /var/lib/tokenkey/active-color; test seam).
 set -u
 
 LIMIT="${LIMIT:-50}"
 SINCE="${SINCE:-24h}"
 CONTAINER="${CONTAINER:-auto}"
+ACTIVE_COLOR_FILE="${ACTIVE_COLOR_FILE:-/var/lib/tokenkey/active-color}"
 
-python3 - "$LIMIT" "$SINCE" "$CONTAINER" <<'PY'
+python3 - "$LIMIT" "$SINCE" "$CONTAINER" "$ACTIVE_COLOR_FILE" <<'PY'
 import json
 import pathlib
 import re
@@ -21,26 +27,30 @@ import sys
 
 limit = int(sys.argv[1])
 since = sys.argv[2]
-container = sys.argv[3]
+container_arg = sys.argv[3]
+active_color_file = sys.argv[4]
 
 marker = "http request completed"
 json_re = re.compile(r"\{.*\}\s*$")
 
 def docker_inspect_exists(name):
-    return subprocess.run(
+    proc = subprocess.run(
         ["docker", "inspect", name, "--format", "{{.Name}}"],
         capture_output=True,
         text=True,
         check=False,
-    ).returncode == 0
+    )
+    return proc.returncode == 0
 
-def resolve_container(container_arg):
+
+def resolve_container(container):
     notes = []
-    if container_arg != "auto":
-        return container_arg, ["explicit"]
-    active = pathlib.Path("/var/lib/tokenkey/active-color")
-    if active.is_file():
-        color = active.read_text(encoding="utf-8", errors="ignore").strip()
+    if container != "auto":
+        return container, ["explicit"]
+
+    path = pathlib.Path(active_color_file)
+    if path.is_file():
+        color = path.read_text(encoding="utf-8", errors="ignore").strip()
         notes.append(f"active-color={color or '<empty>'}")
         if color in ("blue", "green"):
             candidate = f"tokenkey-{color}"
@@ -49,13 +59,14 @@ def resolve_container(container_arg):
             notes.append(f"{candidate} missing")
     else:
         notes.append("active-color missing")
+
     for candidate in ("tokenkey", "tokenkey-blue", "tokenkey-green"):
         if docker_inspect_exists(candidate):
             return candidate, notes + [f"fallback={candidate}"]
     return "tokenkey", notes + ["fallback=tokenkey-unverified"]
 
-container_input = container
-container, resolution = resolve_container(container_input)
+
+container, resolution = resolve_container(container_arg)
 
 proc = subprocess.run(
     ["docker", "logs", container, "--since", since],
@@ -64,7 +75,12 @@ proc = subprocess.run(
     check=False,
 )
 if proc.returncode != 0:
-    print(json.dumps({"error": proc.stderr.strip() or "docker logs failed"}))
+    print(json.dumps({
+        "error": proc.stderr.strip() or "docker logs failed",
+        "container_input": container_arg,
+        "container": container,
+        "container_resolution": resolution,
+    }))
     sys.exit(1)
 
 rows = []
@@ -105,8 +121,8 @@ for line in proc.stdout.splitlines():
 tail = rows[-limit:] if len(rows) > limit else rows
 out = {
     "meta": {
+        "container_input": container_arg,
         "container": container,
-        "container_input": container_input,
         "container_resolution": resolution,
         "since": since,
         "limit": limit,

--- a/ops/observability/test_probe_tail_gateway_logs.py
+++ b/ops/observability/test_probe_tail_gateway_logs.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Validation tests for probe-tail-gateway-logs.sh."""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent / "probe-tail-gateway-logs.sh"
+
+
+class ProbeTailGatewayLogsTest(unittest.TestCase):
+    def test_syntax_clean(self) -> None:
+        proc = subprocess.run(
+            ["bash", "-n", str(_SCRIPT)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+
+    def test_auto_container_resolves_active_color(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            active = tmp / "active-color"
+            active.write_text("green\n")
+            fakebin = tmp / "bin"
+            fakebin.mkdir()
+            (fakebin / "docker").write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    if [ "$1" = inspect ]; then
+                      [ "$2" = tokenkey-green ] && exit 0
+                      exit 1
+                    fi
+                    if [ "$1" = logs ]; then
+                      cat <<'LOGS'
+                    2026-06-24T05:00:00Z INFO http request completed {"request_id":"r1","path":"/v1/messages","status_code":200,"latency_ms":123}
+                    LOGS
+                      exit 0
+                    fi
+                    exit 2
+                    """
+                ),
+            )
+            (fakebin / "docker").chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{fakebin}:{os.environ.get('PATH', '')}",
+                "ACTIVE_COLOR_FILE": str(active),
+            }
+            proc = subprocess.run(
+                ["bash", str(_SCRIPT)],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stderr + proc.stdout)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["meta"]["container"], "tokenkey-green")
+            self.assertIn("active-color=green", payload["meta"]["container_resolution"])
+            self.assertIn("active-color container exists", payload["meta"]["container_resolution"])
+            self.assertEqual(payload["requests"][0]["request_id"], "r1")
+
+    def test_auto_container_falls_back_to_legacy(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            fakebin = tmp / "bin"
+            fakebin.mkdir()
+            (fakebin / "docker").write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    if [ "$1" = inspect ]; then
+                      [ "$2" = tokenkey ] && exit 0
+                      exit 1
+                    fi
+                    if [ "$1" = logs ]; then
+                      echo 'INFO http request completed {"request_id":"r2","path":"/health/live","status_code":200}'
+                      exit 0
+                    fi
+                    exit 2
+                    """
+                ),
+            )
+            (fakebin / "docker").chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{fakebin}:{os.environ.get('PATH', '')}",
+                "ACTIVE_COLOR_FILE": str(tmp / "missing-active-color"),
+            }
+            proc = subprocess.run(
+                ["bash", str(_SCRIPT)],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stderr + proc.stdout)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["meta"]["container"], "tokenkey")
+            self.assertIn("fallback=tokenkey", payload["meta"]["container_resolution"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- 在 `probe-tail-gateway-logs.sh` 的现有 `CONTAINER=auto` 基础上补齐 `ACTIVE_COLOR_FILE` 测试 seam，便于离线覆盖 prod blue/green active-color 解析。
- 在 docker logs 失败时输出 `container_input`、实际解析出的 `container` 与 `container_resolution`，方便线上只读排障定位容器解析问题。
- 新增离线单测覆盖 active-color 命中与 legacy fallback。

## 风险
- 低风险；只改只读观测脚本和测试，不改线上业务路径、部署原语、CFN、数据库或 Web surface。
- no-web-impact：未改 backend/business logic 或 frontend。

## 验证
- `python3 ops/observability/test_probe_tail_gateway_logs.py`
- `python3 ops/observability/test_probe_post_release_tick.py`
- `bash -n ops/observability/probe-tail-gateway-logs.sh`
- `bash scripts/preflight.sh`
- 线上只读采样：`run-probe.sh --target prod --script ops/observability/probe-tail-gateway-logs.sh --env LIMIT=12 --env SINCE=10m --timeout-seconds 120` 成功解析 `container=tokenkey-blue`，10 分钟窗口 `matched_total=675`。

## 提交
- `99b86e7a1` chore(observability): support bluegreen log tail no-web-impact
- 最新提交：`99b86e7a1`
