### PR TITLE
fix(alerts): 收敛飞书告警到 prod

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -173,7 +173,9 @@ func runMainServer() {
 
 	pollCtx, pollCancel := context.WithCancel(context.Background())
 	defer pollCancel()
-	service.StartClaudeStatusPoller(pollCtx)
+	if !service.IsEdgeFrontendURL(cfg.Server.FrontendURL) {
+		service.StartClaudeStatusPoller(pollCtx)
+	}
 
 	// 启动服务器
 	go func() {

--- a/backend/internal/repository/ops_repo_routing_capacity_rejection_integration_test.go
+++ b/backend/internal/repository/ops_repo_routing_capacity_rejection_integration_test.go
@@ -32,29 +32,29 @@ func TestRoutingCapacityRejectionCountIsolatesRoutingPhase(t *testing.T) {
 	windowEnd := windowStart.Add(time.Hour)
 	at := windowStart.Add(5 * time.Minute)
 
-	insert := func(phase, owner, platform string, statusCode int, businessLimited bool) {
+	insert := func(phase, owner, platform, requestedModel, model string, statusCode int, businessLimited bool) {
 		_, err := integrationDB.ExecContext(ctx, `
 			INSERT INTO ops_error_logs (
 				error_phase, error_type, severity, status_code,
-				error_owner, platform, is_business_limited, created_at
-			) VALUES ($1, 'api_error', 'error', $2, $3, $4, $5, $6)`,
-			phase, statusCode, owner, platform, businessLimited, at,
+				error_owner, platform, requested_model, model, is_business_limited, created_at
+			) VALUES ($1, 'api_error', 'error', $2, $3, $4, $5, $6, $7, $8)`,
+			phase, statusCode, owner, platform, requestedModel, model, businessLimited, at,
 		)
 		require.NoError(t, err)
 	}
 
 	// Routing-phase capacity rejections — MUST be counted. Split across platforms
 	// so the top-cause breakdown is exercised (anthropic 2 : openai 1).
-	insert("routing", "platform", "anthropic", 429, true) // local empty pool fast-fail (#575)
-	insert("routing", "platform", "anthropic", 503, true) // relayed downstream-capacity (rare 503 terminal)
-	insert("routing", "platform", "openai", 429, true)    // a second platform's empty-pool rejection
+	insert("routing", "platform", "anthropic", "claude-sonnet-4-5", "mapped-a", 429, true) // local empty pool fast-fail (#575)
+	insert("routing", "platform", "anthropic", "claude-sonnet-4-5", "mapped-b", 503, true) // relayed downstream-capacity (rare 503 terminal)
+	insert("routing", "platform", "openai", "", "gpt-5.1", 429, true)                      // a second platform's empty-pool rejection
 
 	// NOT routing — must NOT be counted, even though some are 429 + business-limited:
-	insert("auth", "client", "anthropic", 429, true)      // user-level rate limit (their own quota)
-	insert("upstream", "provider", "anthropic", 429, false) // real provider rate_limit_error
-	insert("request", "client", "openai", 429, true)        // concurrency/queue business limit
-	insert("internal", "platform", "gemini", 500, false)    // non-capacity platform error
-	insert("upstream", "provider", "openai", 502, false)    // ordinary provider failure
+	insert("auth", "client", "anthropic", "claude-sonnet-4-5", "", 429, true)      // user-level rate limit (their own quota)
+	insert("upstream", "provider", "anthropic", "claude-opus-4-8", "", 429, false) // real provider rate_limit_error
+	insert("request", "client", "openai", "gpt-5.1", "", 429, true)                // concurrency/queue business limit
+	insert("internal", "platform", "gemini", "gemini-2.5-pro", "", 500, false)     // non-capacity platform error
+	insert("upstream", "provider", "openai", "gpt-5.1", "", 502, false)            // ordinary provider failure
 
 	filter := &service.OpsDashboardFilter{
 		StartTime: windowStart,
@@ -82,6 +82,14 @@ func TestRoutingCapacityRejectionCountIsolatesRoutingPhase(t *testing.T) {
 	require.Equal(t, "openai", platforms[1].Platform)
 	require.EqualValues(t, 1, platforms[1].Count)
 	require.Empty(t, platforms[1].Users)
+
+	models, err := repo.TopRoutingCapacityRejectionByModel(ctx, filter, 3)
+	require.NoError(t, err)
+	require.Len(t, models, 2)
+	require.Equal(t, "claude-sonnet-4-5", models[0].Model, "requested_model wins over mapped model")
+	require.EqualValues(t, 2, models[0].Count)
+	require.Equal(t, "gpt-5.1", models[1].Model, "legacy rows fall back to model when requested_model is blank")
+	require.EqualValues(t, 1, models[1].Count)
 
 	// Cross-check the blind spot: the three routing rows are business-limited →
 	// excluded from the ratio metrics' numerator AND denominator, which is exactly

--- a/backend/internal/repository/ops_repo_routing_capacity_tk.go
+++ b/backend/internal/repository/ops_repo_routing_capacity_tk.go
@@ -187,3 +187,51 @@ ORDER BY platform ASC, cnt DESC, user_id ASC, key_name ASC`
 	}
 	return out, nil
 }
+
+// TopRoutingCapacityRejectionByModel returns the top requested-model buckets over
+// the routing-capacity rejection rows in the same window/scope as the alert
+// metric. requested_model is preferred because it is the client-visible demand
+// signal; model is a legacy fallback for older rows.
+func (r *opsRepository) TopRoutingCapacityRejectionByModel(ctx context.Context, filter *service.OpsDashboardFilter, limit int) ([]*service.OpsRoutingRejectionModel, error) {
+	if r == nil || r.db == nil {
+		return nil, fmt.Errorf("nil ops repository")
+	}
+	if filter == nil {
+		return nil, fmt.Errorf("nil filter")
+	}
+	if filter.StartTime.IsZero() || filter.EndTime.IsZero() {
+		return nil, fmt.Errorf("start_time/end_time required")
+	}
+	if limit <= 0 {
+		limit = 3
+	}
+
+	where, args, next := buildErrorWhere(filter, filter.StartTime.UTC(), filter.EndTime.UTC(), 1)
+	q := `SELECT COALESCE(NULLIF(TRIM(requested_model), ''), NULLIF(TRIM(model), ''), '(unknown)') AS model, COUNT(*) AS cnt
+FROM ops_error_logs
+` + where + `
+  AND error_phase = 'routing'
+GROUP BY 1
+ORDER BY cnt DESC, model ASC
+LIMIT $` + strconv.Itoa(next)
+	args = append(args, limit)
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]*service.OpsRoutingRejectionModel, 0, limit)
+	for rows.Next() {
+		var m service.OpsRoutingRejectionModel
+		if err := rows.Scan(&m.Model, &m.Count); err != nil {
+			return nil, err
+		}
+		out = append(out, &m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -612,6 +612,21 @@ func accountIncidentDedupeKey(site string, accountID int64, reasonClass string) 
 	return fmt.Sprintf("%s|%d|%s", site, accountID, reasonClass)
 }
 
+func isEdgeSiteID(site string) bool {
+	return strings.HasPrefix(strings.TrimSpace(site), "edge-")
+}
+
+// IsEdgeFrontendURL reports whether server.frontend_url identifies a TokenKey
+// mirror-relay edge. Empty/unparseable/custom hosts are treated as non-edge so
+// prod does not silently lose global checks when config is incomplete.
+func IsEdgeFrontendURL(frontendURL string) bool {
+	return isEdgeSiteID(siteFromFrontendURL(frontendURL))
+}
+
+func (n *TKAccountIncidentNotifier) isEdgeSite() bool {
+	return n != nil && isEdgeSiteID(n.siteID)
+}
+
 // siteFromFrontendURL 从 server.frontend_url 域名提取节点名:
 //
 //	api.tokenkey.dev      -> prod

--- a/backend/internal/service/account_incident_notifier_tk_claude_status.go
+++ b/backend/internal/service/account_incident_notifier_tk_claude_status.go
@@ -22,7 +22,7 @@ type ClaudeAPIStatusNotifier interface {
 
 // NotifyClaudeAPIIncidentStarted 在 Claude API 从 operational 转为非 operational 时发 P0 红卡。
 func (n *TKAccountIncidentNotifier) NotifyClaudeAPIIncidentStarted(status string) {
-	if n == nil {
+	if n == nil || n.isEdgeSite() {
 		return
 	}
 	now := n.currentTime()
@@ -41,7 +41,7 @@ func (n *TKAccountIncidentNotifier) NotifyClaudeAPIIncidentStarted(status string
 
 // NotifyClaudeAPIIncidentResolved 在 Claude API 恢复 operational 且此前发过故障卡时发绿卡闭环。
 func (n *TKAccountIncidentNotifier) NotifyClaudeAPIIncidentResolved(status string) {
-	if n == nil {
+	if n == nil || n.isEdgeSite() {
 		return
 	}
 	n.mu.Lock()

--- a/backend/internal/service/account_incident_notifier_tk_claude_status_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_claude_status_test.go
@@ -54,6 +54,18 @@ func TestNotifyClaudeAPIIncidentResolved_OnlyAfterStarted(t *testing.T) {
 	require.True(t, strings.Contains(doer.lastBody(), "operational"))
 }
 
+func TestNotifyClaudeAPIIncident_EdgeSiteIsSuppressed(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 2)}
+	fixed := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, fixed)
+	n.siteID = "edge-us3"
+
+	n.NotifyClaudeAPIIncidentStarted("partial_outage")
+	n.NotifyClaudeAPIIncidentResolved("operational")
+
+	require.Equal(t, 0, doer.callCount())
+}
+
 func TestSetClaudeAPIStatusNotifier_WiresPollerTransition(t *testing.T) {
 	doer := &blockingFeishuDoer{done: make(chan struct{}, 1)}
 	fixed := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)

--- a/backend/internal/service/account_incident_notifier_tk_pool.go
+++ b/backend/internal/service/account_incident_notifier_tk_pool.go
@@ -43,7 +43,7 @@ func (n *TKAccountIncidentNotifier) SetPoolSchedulableCounter(fn func(ctx contex
 // NotifyPlatformPoolExhausted 发送平台池全不可调度 P0 卡片。按 platform 去重
 // （冷却风暴里每个后续账号封锁都会再触发一次池级检查,只发第一张）。
 func (n *TKAccountIncidentNotifier) NotifyPlatformPoolExhausted(platform string, trigger *Account, until time.Time, reason string) {
-	if n == nil || strings.TrimSpace(platform) == "" {
+	if n == nil || n.isEdgeSite() || strings.TrimSpace(platform) == "" {
 		return
 	}
 	now := n.currentTime()
@@ -123,6 +123,9 @@ func (n *TKAccountIncidentNotifier) poolRecoveryLoop() {
 // 保证每个平台一次恢复事件只发一张绿卡。
 func (n *TKAccountIncidentNotifier) checkPoolRecovery() {
 	if n == nil {
+		return
+	}
+	if n.isEdgeSite() {
 		return
 	}
 	n.mu.Lock()

--- a/backend/internal/service/account_incident_notifier_tk_pool_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_pool_test.go
@@ -108,6 +108,28 @@ func TestCheckPoolRecovery_SendsGreenCardPairedWithExhaust(t *testing.T) {
 	require.Equal(t, 2, doer.callCount(), "recovery must not re-fire for an already-recovered platform")
 }
 
+func TestNotifyPlatformPoolExhausted_EdgeSiteIsSuppressed(t *testing.T) {
+	provider := &fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 2)}
+	fixedNow := time.Date(2026, 6, 11, 6, 49, 0, 0, time.UTC)
+	n := newTestNotifier(provider, doer, fixedNow)
+	n.siteID = "edge-us3"
+
+	var counterCalls int64
+	n.SetPoolSchedulableCounter(func(_ context.Context, _ string) (int, error) {
+		atomic.AddInt64(&counterCalls, 1)
+		return 1, nil
+	})
+
+	trigger := &Account{ID: 7, Name: "cc-us3", Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	n.NotifyPlatformPoolExhausted(PlatformAnthropic, trigger, fixedNow.Add(10*time.Minute), "529")
+	n.checkPoolRecovery()
+	time.Sleep(100 * time.Millisecond)
+
+	require.Equal(t, 0, doer.callCount())
+	require.EqualValues(t, 0, atomic.LoadInt64(&counterCalls), "edge pool recovery must not compute after suppressed exhaust")
+}
+
 func TestCheckPoolRecovery_NoCounterIsNoop(t *testing.T) {
 	provider := &fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}
 	doer := &blockingFeishuDoer{done: make(chan struct{}, 4)}

--- a/backend/internal/service/account_incident_notifier_tk_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_test.go
@@ -92,7 +92,7 @@ func (d *blockingFeishuDoer) lastBody() string {
 }
 
 func newTestNotifier(provider opsFeishuConfigProvider, doer opsFeishuHTTPDoer, fixedNow time.Time) *TKAccountIncidentNotifier {
-	n := newTKAccountIncidentNotifier(provider, "edge-test")
+	n := newTKAccountIncidentNotifier(provider, "prod")
 	n.httpClient = doer
 	n.now = func() time.Time { return fixedNow }
 	return n
@@ -159,6 +159,14 @@ func TestSiteFromFrontendURL(t *testing.T) {
 	for in, want := range cases {
 		require.Equal(t, want, siteFromFrontendURL(in), "input=%q", in)
 	}
+}
+
+func TestIsEdgeFrontendURL(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsEdgeFrontendURL("https://api-us3.tokenkey.dev"))
+	require.False(t, IsEdgeFrontendURL("https://api.tokenkey.dev"))
+	require.False(t, IsEdgeFrontendURL(""))
+	require.False(t, IsEdgeFrontendURL("https://gateway.example.com"))
 }
 
 func TestNotifyPermanentSendsImmediately(t *testing.T) {

--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -295,7 +295,7 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 			// TK (us7 P0 2026-06-13): attach the top offending model/reason so the
 			// notification card is self-diagnosing (real fire vs client noise)
 			// without an SSH/dashboard drill. Best-effort — never blocks firing.
-			if cause, users := s.computeTopCause(ctx, rule, windowStart, windowEnd, scopePlatform, scopeGroupID); cause != "" || users != "" {
+			if cause, users, models := s.computeTopCause(ctx, rule, windowStart, windowEnd, scopePlatform, scopeGroupID); cause != "" || users != "" || models != "" {
 				if dimensions == nil {
 					dimensions = map[string]any{}
 				}
@@ -304,6 +304,9 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 				}
 				if users != "" {
 					dimensions["top_cause_users"] = users
+				}
+				if models != "" {
+					dimensions["top_cause_models"] = models
 				}
 			}
 

--- a/backend/internal/service/ops_alert_evaluator_service_test.go
+++ b/backend/internal/service/ops_alert_evaluator_service_test.go
@@ -22,6 +22,8 @@ type stubOpsRepo struct {
 	routingRejectionsErr error
 	routingByPlatform    []*OpsRoutingRejectionPlatform
 	routingByPlatformErr error
+	routingByModel       []*OpsRoutingRejectionModel
+	routingByModelErr    error
 }
 
 func (s *stubOpsRepo) GetDashboardOverview(ctx context.Context, filter *OpsDashboardFilter) (*OpsDashboardOverview, error) {
@@ -46,6 +48,13 @@ func (s *stubOpsRepo) TopRoutingCapacityRejectionByPlatform(ctx context.Context,
 		return nil, s.routingByPlatformErr
 	}
 	return s.routingByPlatform, nil
+}
+
+func (s *stubOpsRepo) TopRoutingCapacityRejectionByModel(ctx context.Context, filter *OpsDashboardFilter, limit int) ([]*OpsRoutingRejectionModel, error) {
+	if s.routingByModelErr != nil {
+		return nil, s.routingByModelErr
+	}
+	return s.routingByModel, nil
 }
 
 // GetTopErrorCause is overridden (the embedded OpsRepository is nil) so the
@@ -394,9 +403,9 @@ func TestComputeRuleMetricRoutingCapacityRejectionCount(t *testing.T) {
 // TestComputeTopCauseRoutingCapacityRejection pins the self-diagnosing 主因 line
 // for the empty-pool P0: a single JOINT breakdown naming WHICH platform pool(s)
 // are out of capacity AND WHO inside each pool is driving it (user id + api-key
-// name + count), instead of two un-cross-referenceable marginal lines. `users` is
-// always empty now — the standalone 用户 line is retired. Example names here are
-// synthetic.
+// name + count), plus the top requested models by failed request volume. `users`
+// is always empty now — the standalone 用户 line is retired. Example names here
+// are synthetic.
 func TestComputeTopCauseRoutingCapacityRejection(t *testing.T) {
 	t.Parallel()
 
@@ -407,18 +416,26 @@ func TestComputeTopCauseRoutingCapacityRejection(t *testing.T) {
 
 	t.Run("joint per-platform breakdown with nested users", func(t *testing.T) {
 		t.Parallel()
-		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{routingByPlatform: []*OpsRoutingRejectionPlatform{
-			{Platform: "anthropic", Count: 40, Users: []*OpsRoutingRejectionUser{
-				{UserID: 1, APIKeyName: "eval-harness", Count: 30},
-				{UserID: 16, APIKeyName: "mobile-app", Count: 10},
-			}},
-			{Platform: "newapi", Count: 8, Users: []*OpsRoutingRejectionUser{
-				{UserID: 16, APIKeyName: "ci-runner", Count: 8},
-			}},
-		}}}
-		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
+		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{
+			routingByPlatform: []*OpsRoutingRejectionPlatform{
+				{Platform: "anthropic", Count: 40, Users: []*OpsRoutingRejectionUser{
+					{UserID: 1, APIKeyName: "eval-harness", Count: 30},
+					{UserID: 16, APIKeyName: "mobile-app", Count: 10},
+				}},
+				{Platform: "newapi", Count: 8, Users: []*OpsRoutingRejectionUser{
+					{UserID: 16, APIKeyName: "ci-runner", Count: 8},
+				}},
+			},
+			routingByModel: []*OpsRoutingRejectionModel{
+				{Model: "claude-sonnet-4-5", Count: 31},
+				{Model: "claude-opus-4-8", Count: 12},
+				{Model: "qwen3-coder-plus", Count: 5},
+			},
+		}}
+		cause, users, models := svc.computeTopCause(ctx, rule, start, end, "", nil)
 		require.Equal(t, `anthropic ×40（#1 "eval-harness" ×30 · #16 "mobile-app" ×10） · newapi ×8（#16 "ci-runner" ×8）`, cause)
 		require.Empty(t, users, "standalone 用户 line is retired for new events")
+		require.Equal(t, "claude-sonnet-4-5 ×31 · claude-opus-4-8 ×12 · qwen3-coder-plus ×5", models)
 	})
 
 	t.Run("platform with no attributable users renders bare", func(t *testing.T) {
@@ -426,25 +443,43 @@ func TestComputeTopCauseRoutingCapacityRejection(t *testing.T) {
 		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{routingByPlatform: []*OpsRoutingRejectionPlatform{
 			{Platform: "anthropic", Count: 40},
 		}}}
-		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
+		cause, users, models := svc.computeTopCause(ctx, rule, start, end, "", nil)
 		require.Equal(t, "anthropic ×40", cause)
 		require.Empty(t, users)
+		require.Empty(t, models)
 	})
 
 	t.Run("no rows => no 主因 line", func(t *testing.T) {
 		t.Parallel()
 		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{}}
-		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
+		cause, users, models := svc.computeTopCause(ctx, rule, start, end, "", nil)
 		require.Empty(t, cause)
 		require.Empty(t, users)
+		require.Empty(t, models)
 	})
 
-	t.Run("query error => no 主因 line (best-effort, never blocks firing)", func(t *testing.T) {
+	t.Run("platform query error still keeps model line (best-effort, never blocks firing)", func(t *testing.T) {
 		t.Parallel()
-		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{routingByPlatformErr: context.DeadlineExceeded}}
-		cause, users := svc.computeTopCause(ctx, rule, start, end, "", nil)
+		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{
+			routingByPlatformErr: context.DeadlineExceeded,
+			routingByModel:       []*OpsRoutingRejectionModel{{Model: "claude-sonnet-4-5", Count: 9}},
+		}}
+		cause, users, models := svc.computeTopCause(ctx, rule, start, end, "", nil)
 		require.Empty(t, cause)
 		require.Empty(t, users)
+		require.Equal(t, "claude-sonnet-4-5 ×9", models)
+	})
+
+	t.Run("model query error still keeps platform line (best-effort, never blocks firing)", func(t *testing.T) {
+		t.Parallel()
+		svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{
+			routingByPlatform: []*OpsRoutingRejectionPlatform{{Platform: "anthropic", Count: 40}},
+			routingByModelErr: context.DeadlineExceeded,
+		}}
+		cause, users, models := svc.computeTopCause(ctx, rule, start, end, "", nil)
+		require.Equal(t, "anthropic ×40", cause)
+		require.Empty(t, users)
+		require.Empty(t, models)
 	})
 }
 

--- a/backend/internal/service/ops_alert_top_cause_tk.go
+++ b/backend/internal/service/ops_alert_top_cause_tk.go
@@ -50,6 +50,14 @@ type OpsRoutingRejectionUser struct {
 	Count      int64
 }
 
+// OpsRoutingRejectionModel is one requested-model bucket for routing-phase
+// capacity rejections. It answers the operator question "which requested models
+// make up the failed request volume?" on the no-available-accounts P0 card.
+type OpsRoutingRejectionModel struct {
+	Model string
+	Count int64
+}
+
 // opsTopCauseMetricTypes are the rule metric types for which a top-cause
 // breakdown is meaningful (rate metrics over ops_error_logs). Other rule types
 // (system gauges, group-availability counts) get no breakdown — keeping the
@@ -76,25 +84,25 @@ func opsTopCauseApplies(metricType string) bool {
 // routing_capacity_rejection_count alert at the notification layer
 // (maybeSendAlertNotifications → isEdgeNode), so there is no per-field edge
 // branching here.
-func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *OpsAlertRule, start, end time.Time, platform string, groupID *int64) (cause string, users string) {
+func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *OpsAlertRule, start, end time.Time, platform string, groupID *int64) (cause string, users string, models string) {
 	if s == nil || rule == nil {
-		return "", ""
+		return "", "", ""
 	}
 	metricType := strings.TrimSpace(rule.MetricType)
 	// pool_load_rate 的主因来自实时池负载快照（哪几个调度池在饱和），而非
 	// ops_error_logs，所以单独取一支；详见 ops_pool_load_rate_tk.go。
 	if metricType == "pool_load_rate" {
 		if s.opsService == nil {
-			return "", ""
+			return "", "", ""
 		}
 		pools, err := s.opsService.ComputePoolLoadRates(ctx)
 		if err != nil {
-			return "", ""
+			return "", "", ""
 		}
-		return formatPoolLoadCause(pools, rule, platform, groupID), ""
+		return formatPoolLoadCause(pools, rule, platform, groupID), "", ""
 	}
 	if s.opsRepo == nil {
-		return "", ""
+		return "", "", ""
 	}
 	// routing_capacity_rejection_count's cause is a single JOINT breakdown over the
 	// routing-phase rows themselves (not the model/owner/upstream_status breakdown
@@ -117,10 +125,11 @@ func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *Op
 			QueryMode: OpsQueryModeRaw,
 		}
 		platforms, _ := s.opsRepo.TopRoutingCapacityRejectionByPlatform(ctx, filter, 2, 3)
-		return formatRoutingRejectionByPlatform(platforms), ""
+		modelBuckets, _ := s.opsRepo.TopRoutingCapacityRejectionByModel(ctx, filter, 3)
+		return formatRoutingRejectionByPlatform(platforms), "", formatRoutingRejectionByModel(modelBuckets)
 	}
 	if !opsTopCauseApplies(metricType) {
-		return "", ""
+		return "", "", ""
 	}
 	// upstream_error_rate counts only provider-owned, non-429/529 final failures
 	// (the upstream_excl set); error_rate counts all SLA errors. Mirror that so
@@ -134,9 +143,9 @@ func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *Op
 		QueryMode: OpsQueryModeRaw,
 	}, upstreamOnly, 2)
 	if err != nil || len(causes) == 0 {
-		return "", ""
+		return "", "", ""
 	}
-	return formatOpsTopCause(causes), ""
+	return formatOpsTopCause(causes), "", ""
 }
 
 // formatOpsTopCause renders up to two causes as a compact one-line string, e.g.
@@ -234,6 +243,28 @@ func formatRejectionUserSegment(u *OpsRoutingRejectionUser) string {
 	}
 	seg += fmt.Sprintf(" ×%d", u.Count)
 	return seg
+}
+
+// formatRoutingRejectionByModel renders up to 3 requested-model buckets as a
+// compact line for routing-capacity P0 cards, e.g.
+//
+//	claude-sonnet-4-5 ×120 · claude-opus-4-8 ×32 · (unknown) ×4
+func formatRoutingRejectionByModel(models []*OpsRoutingRejectionModel) string {
+	parts := make([]string, 0, 3)
+	for _, m := range models {
+		if m == nil || m.Count <= 0 {
+			continue
+		}
+		name := strings.TrimSpace(m.Model)
+		if name == "" {
+			name = "(unknown)"
+		}
+		parts = append(parts, fmt.Sprintf("%s ×%d", name, m.Count))
+		if len(parts) >= 3 {
+			break
+		}
+	}
+	return strings.Join(parts, " · ")
 }
 
 // feishuLabelSanitizer defangs lark_md control characters in a user-controlled

--- a/backend/internal/service/ops_alert_top_cause_tk_test.go
+++ b/backend/internal/service/ops_alert_top_cause_tk_test.go
@@ -86,6 +86,20 @@ func TestBuildOpsFeishuAlertTextTopCauseLine(t *testing.T) {
 		require.Contains(t, out, "anthropic ×339 · newapi ×4\n**用户**：")
 	})
 
+	t.Run("renders 模型 on its own line when top_cause_models present", func(t *testing.T) {
+		ev := &OpsAlertEvent{
+			MetricValue: &mv,
+			Dimensions: map[string]any{
+				"top_cause":        "anthropic ×339",
+				"top_cause_models": "claude-sonnet-4-5 ×180 · claude-opus-4-8 ×49 · qwen3-coder-plus ×12",
+			},
+		}
+		out := buildOpsFeishuAlertText(rule, ev, "prod", "")
+		require.Contains(t, out, "**主因**：anthropic ×339")
+		require.Contains(t, out, "**模型**：claude-sonnet-4-5 ×180 · claude-opus-4-8 ×49 · qwen3-coder-plus ×12")
+		require.Contains(t, out, "anthropic ×339\n**模型**：")
+	})
+
 	// No top_cause_users dimension (non-rejection rules, or a degraded user query)
 	// => no 用户 line. (Edge nodes never reach this renderer at all — the whole
 	// routing-rejection alert is suppressed upstream in maybeSendAlertNotifications.)
@@ -111,6 +125,26 @@ func TestBuildOpsFeishuAlertTextTopCauseLine(t *testing.T) {
 		out := buildOpsFeishuAlertText(rule, ev, "prod", "")
 		require.Contains(t, out, `**用户**：#1 "eval-harness" ×275`)
 		require.NotContains(t, out, "**主因**")
+	})
+}
+
+func TestFormatRoutingRejectionByModel(t *testing.T) {
+	t.Run("top three requested models", func(t *testing.T) {
+		require.Equal(t,
+			"claude-sonnet-4-5 ×120 · claude-opus-4-8 ×32 · qwen3-coder-plus ×4",
+			formatRoutingRejectionByModel([]*OpsRoutingRejectionModel{
+				{Model: "claude-sonnet-4-5", Count: 120},
+				{Model: "claude-opus-4-8", Count: 32},
+				{Model: "qwen3-coder-plus", Count: 4},
+				{Model: "gpt-5.1", Count: 1},
+			}))
+	})
+
+	t.Run("blank model defaults safely and non-positive counts skipped", func(t *testing.T) {
+		require.Equal(t, "(unknown) ×5", formatRoutingRejectionByModel([]*OpsRoutingRejectionModel{
+			{Model: "skip", Count: 0},
+			{Model: "", Count: 5},
+		}))
 	})
 }
 

--- a/backend/internal/service/ops_feishu_notifier_tk.go
+++ b/backend/internal/service/ops_feishu_notifier_tk.go
@@ -236,6 +236,9 @@ func buildOpsFeishuAlertText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLabel
 	if users := opsFeishuTopCauseUsers(event.Dimensions); users != "" {
 		topCauseLine += fmt.Sprintf("\n**用户**：%s", escapeFeishuText(users))
 	}
+	if models := opsFeishuTopCauseModels(event.Dimensions); models != "" {
+		topCauseLine += fmt.Sprintf("\n**模型**：%s", escapeFeishuText(models))
+	}
 	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**当前值**：%s\n**范围**：%s%s\n**时间**：%s\n\n**建议**：%s",
 		escapeFeishuText(nodeLabel),
 		escapeFeishuText(strings.TrimSpace(rule.Name)),
@@ -275,6 +278,21 @@ func opsFeishuTopCauseUsers(dimensions map[string]any) string {
 		return ""
 	}
 	if v, ok := dimensions["top_cause_users"]; ok {
+		if s, ok := v.(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+// opsFeishuTopCauseModels extracts the top requested-model breakdown for
+// routing-capacity P0s. It is separate from 主因 so platform/user attribution and
+// model demand stay independently readable.
+func opsFeishuTopCauseModels(dimensions map[string]any) string {
+	if len(dimensions) == 0 {
+		return ""
+	}
+	if v, ok := dimensions["top_cause_models"]; ok {
 		if s, ok := v.(string); ok {
 			return strings.TrimSpace(s)
 		}

--- a/backend/internal/service/ops_port.go
+++ b/backend/internal/service/ops_port.go
@@ -40,6 +40,10 @@ type OpsRepository interface {
 	// out of capacity AND WHO inside each pool is driving it — the platform→user
 	// attribution the old two separate marginal queries could not express.
 	TopRoutingCapacityRejectionByPlatform(ctx context.Context, filter *OpsDashboardFilter, platformLimit, usersPerPlatform int) ([]*OpsRoutingRejectionPlatform, error)
+	// TopRoutingCapacityRejectionByModel returns the top requested-model buckets
+	// over the same routing-capacity rejection window/scope. It powers the
+	// no-available-accounts P0 card's "模型" line.
+	TopRoutingCapacityRejectionByModel(ctx context.Context, filter *OpsDashboardFilter, limit int) ([]*OpsRoutingRejectionModel, error)
 	GetThroughputTrend(ctx context.Context, filter *OpsDashboardFilter, bucketSeconds int) (*OpsThroughputTrendResponse, error)
 	GetLatencyHistogram(ctx context.Context, filter *OpsDashboardFilter) (*OpsLatencyHistogramResponse, error)
 	GetErrorTrend(ctx context.Context, filter *OpsDashboardFilter, bucketSeconds int) (*OpsErrorTrendResponse, error)

--- a/backend/internal/service/ops_repo_mock_test.go
+++ b/backend/internal/service/ops_repo_mock_test.go
@@ -94,6 +94,10 @@ func (m *opsRepoMock) TopRoutingCapacityRejectionByPlatform(ctx context.Context,
 	return nil, nil
 }
 
+func (m *opsRepoMock) TopRoutingCapacityRejectionByModel(ctx context.Context, filter *OpsDashboardFilter, limit int) ([]*OpsRoutingRejectionModel, error) {
+	return nil, nil
+}
+
 func (m *opsRepoMock) GetThroughputTrend(ctx context.Context, filter *OpsDashboardFilter, bucketSeconds int) (*OpsThroughputTrendResponse, error) {
 	return &OpsThroughputTrendResponse{}, nil
 }

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -1000,7 +1000,11 @@ func ProvideTKAccountIncidentNotifier(
 	if rl != nil {
 		rl.SetAccountIncidentNotifier(n)
 	}
-	SetClaudeAPIStatusNotifier(n)
+	if isEdgeSiteID(site) {
+		SetClaudeAPIStatusNotifier(nil)
+	} else {
+		SetClaudeAPIStatusNotifier(n)
+	}
 	return n
 }
 


### PR DESCRIPTION
## 摘要
- Claude API 上游故障/恢复飞书告警只在 prod 节点检测和推送，edge 节点不再启动 status.claude.com 轮询，也不会注册全局 Claude status notifier。
- 平台池全不可调度飞书红卡/恢复绿卡只保留 prod 侧推送；edge 本地账号事件仍保留日志/诊断，不进飞书群。
- `routing_capacity_rejection_count` P0 卡新增请求模型 top3（`模型` 行），与原平台/用户主因使用同一告警窗口和 scope。

## 风险
- 主要风险是 prod/edge 识别依赖 `server.frontend_url`；沿用现有 `siteFromFrontendURL` 口径，无法解析时按非 edge 处理，避免 prod 因配置缺失静默丢告警。
- sentinel-registry-reviewed：本 PR 修改的是既有告警行为边界和卡片维度，不新增新的 load-bearing gateway surface；现有 sentinel 已覆盖相关伴生文件/注入面，未追加 registry anchor。

## 验证
- `go test -tags unit ./internal/service -run 'TestNotifyClaudeAPIIncident|TestSetClaudeAPIStatusNotifier|TestNotifyPlatformPoolExhausted|TestCheckPoolRecovery|TestTemporaryDigestDisabled|TestSiteFromFrontendURL|TestIsEdgeFrontendURL|TestComputeTopCauseRoutingCapacityRejection|TestBuildOpsFeishuAlertTextTopCauseLine|TestFormatRoutingRejectionByModel|TestFormatRoutingRejectionByPlatform' -count=1 -timeout=3m`
- `go test ./internal/service ./internal/repository ./cmd/server -count=1`
- `./scripts/preflight.sh`
- `git diff --check`

## 提交
- `bea203ad0 fix(alerts): scope Feishu alerts to prod no-web-impact`
- 最新提交：`bea203ad0`
