### PR TITLE
fix(alerts): 加固飞书模型标签

### DIFF
--- a/backend/internal/service/ops_alert_evaluator_service_test.go
+++ b/backend/internal/service/ops_alert_evaluator_service_test.go
@@ -515,9 +515,10 @@ func TestIsEdgeNode(t *testing.T) {
 }
 
 // TestIsEdgeSuppressedAlertRule pins WHICH rules are silenced on a mirror-relay
-// edge. Only the routing-capacity-rejection P0 (client-invisible on an edge,
-// covered by account-incident / pool-exhausted P0s) qualifies; capacity/error
-// signals that ARE meaningful on an edge must still page.
+// edge. Only the routing-capacity-rejection P0 qualifies: edge-local events still
+// persist for diagnostics, while human paging for client-visible pool exhaustion
+// is centralized on prod. Capacity/error signals that ARE meaningful on an edge
+// must still page.
 func TestIsEdgeSuppressedAlertRule(t *testing.T) {
 	t.Parallel()
 	require.True(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "routing_capacity_rejection_count"}))

--- a/backend/internal/service/ops_alert_notifications_tk_feishu.go
+++ b/backend/internal/service/ops_alert_notifications_tk_feishu.go
@@ -39,13 +39,12 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertNotifications(ctx context.Conte
 	// Edge nodes are prod→edge mirror-relay targets, so a routing_capacity_rejection
 	// P0 there is just the prod relay being turned away — client-invisible (prod
 	// fails over to another edge), and the relay-探测 failover smears it across every
-	// thin edge it probes. A REAL edge outage is already paged by the account-incident
-	// P0 (账号失效) and the "平台池全不可调度 [edge-xxx]" pool-exhausted P0, both
-	// event-driven on the edge's own siteID and sharing this same feishu.enabled
-	// switch. So this rule is pure Feishu noise on an edge: suppress its
-	// notifications there. The event is still persisted (edge dashboard /
-	// scan-edge-health keep the trail); prod still pages — it is the relay terminus
-	// where the thin-pool-race blind spot actually matters.
+	// thin edge it probes. Edge-local diagnostics are still persisted for the edge
+	// dashboard / scan-edge-health trail, but human paging is centralized on prod:
+	// prod is the relay terminus where the thin-pool-race blind spot is
+	// client-visible and where platform-pool exhaustion Feishu cards are allowed to
+	// page. So this rule is pure Feishu noise on an edge: suppress its notifications
+	// there.
 	if s.isEdgeNode() && isEdgeSuppressedAlertRule(rule) {
 		return result
 	}

--- a/backend/internal/service/ops_alert_top_cause_tk.go
+++ b/backend/internal/service/ops_alert_top_cause_tk.go
@@ -75,10 +75,10 @@ func opsTopCauseApplies(metricType string) bool {
 // "" when the rule is not a rate metric, the query fails, or there is nothing to
 // show. `cause` is the primary line: the model/owner breakdown (error-rate
 // rules), the saturated pool(s) (pool_load_rate), or the empty platform pool(s)
-// (routing_capacity_rejection_count). `users` is the per-user (client)
-// concentration breakdown for routing_capacity_rejection_count, rendered on its
-// own line under 主因. Best-effort: a failure here must never block firing the
-// alert.
+// (routing_capacity_rejection_count). `models` is the failed-request top model
+// breakdown for routing_capacity_rejection_count, rendered on its own line under
+// 主因. `users` is retained for already-stored historical event dimensions.
+// Best-effort: a failure here must never block firing the alert.
 //
 // This function is node-agnostic. Edge nodes suppress the WHOLE
 // routing_capacity_rejection_count alert at the notification layer
@@ -159,10 +159,7 @@ func formatOpsTopCause(causes []*OpsTopErrorCause) string {
 		if c == nil {
 			continue
 		}
-		model := strings.TrimSpace(c.Model)
-		if model == "" {
-			model = "(unknown)"
-		}
+		model := sanitizeFeishuModelLabel(c.Model)
 		owner := strings.TrimSpace(c.ErrorOwner)
 		if owner == "" {
 			owner = "unknown"
@@ -255,16 +252,26 @@ func formatRoutingRejectionByModel(models []*OpsRoutingRejectionModel) string {
 		if m == nil || m.Count <= 0 {
 			continue
 		}
-		name := strings.TrimSpace(m.Model)
-		if name == "" {
-			name = "(unknown)"
-		}
+		name := sanitizeFeishuModelLabel(m.Model)
 		parts = append(parts, fmt.Sprintf("%s ×%d", name, m.Count))
 		if len(parts) >= 3 {
 			break
 		}
 	}
 	return strings.Join(parts, " · ")
+}
+
+func sanitizeFeishuModelLabel(model string) string {
+	raw := strings.TrimSpace(model)
+	if raw == "" || raw == "(unknown)" {
+		return "(unknown)"
+	}
+	name := sanitizeFeishuLabel(model)
+	if name == "" {
+		return "(unknown)"
+	}
+	name = strings.ReplaceAll(name, "://", ": / /")
+	return truncateRunes(name, 64)
 }
 
 // feishuLabelSanitizer defangs lark_md control characters in a user-controlled

--- a/backend/internal/service/ops_alert_top_cause_tk_test.go
+++ b/backend/internal/service/ops_alert_top_cause_tk_test.go
@@ -146,6 +146,17 @@ func TestFormatRoutingRejectionByModel(t *testing.T) {
 			{Model: "", Count: 5},
 		}))
 	})
+
+	t.Run("markdown in client-requested model is neutralized", func(t *testing.T) {
+		got := formatRoutingRejectionByModel([]*OpsRoutingRejectionModel{
+			{Model: "[claude-sonnet](http://evil)", Count: 12},
+		})
+		require.NotContains(t, got, "[")
+		require.NotContains(t, got, "](")
+		require.NotContains(t, got, "http://evil")
+		require.Contains(t, got, "claude-sonnet")
+		require.Contains(t, got, "×12")
+	})
 }
 
 func TestOpsTopCauseApplies(t *testing.T) {


### PR DESCRIPTION
## 摘要
- 对 Feishu 告警里的模型标签复用现有 markdown 防注入清洗，覆盖 error-rate 主因和 routing_capacity_rejection_count 的 `模型` top3 行。
- 将 edge routing-capacity 告警抑制注释更新为 #995 合并后的真实策略：edge 保留本地诊断，人工飞书 paging 集中在 prod。
- 补充客户端请求模型包含 markdown 链接时不会渲染成可点击链接的单测。

## 风险
- no-web-impact：仅后端告警文案渲染与注释/测试变更，不改 Web UI。
- 正常模型名保持原展示；只有 markdown 控制字符和裸 URL 协议会被打散，避免 Lark markdown 注入。
- sentinel-registry-reviewed：本 PR 只修正 #995 后续告警渲染/注释，不新增新的 load-bearing gateway surface；现有 sentinel 不需要新增 anchor。

## 验证
- `go test -tags unit ./internal/service -run 'TestFormatOpsTopCause|TestFormatRoutingRejectionByModel|TestBuildOpsFeishuAlertTextTopCauseLine|TestIsEdgeSuppressedAlertRule|TestMaybeSendAlertNotificationsEdgeSuppression|TestComputeTopCauseRoutingCapacityRejection' -count=1 -timeout=3m`
- `go test ./internal/service ./internal/repository ./cmd/server -count=1`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `git diff --check origin/main...HEAD`

## 关联
- Follow-up to #995

## 提交
- `9a28e2384 fix(alerts): harden Feishu model labels no-web-impact`
- 最新提交：`9a28e2384`