### PR TITLE
fix(obs): add openai capacity and universal routing diagnostics

### DIFF
--- a/backend/internal/server/middleware/universal_routing_tk.go
+++ b/backend/internal/server/middleware/universal_routing_tk.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 )
 
 // 压缩请求体超过该大小时,跳过“解码取模型”以界定额外解码内存(取模型仅作平台偏好提示)。
@@ -58,14 +60,17 @@ func MaybeResolveUniversal(c *gin.Context, apiKey *service.APIKey, resolver *ser
 	}
 
 	model := peekUniversalModel(c, shape)
+	reqLog := universalRoutingLogger(c, apiKey, shape, model, forcedPlatform)
 
 	backing, err := resolver.Resolve(c.Request.Context(), apiKey, shape, model, forcedPlatform)
 	if err != nil {
 		// 区分“真没有被授权的组”(403,业务语义) 与跨度加载失败等内部错误(500,可重试):
 		// 后者不该被伪装成“该模型不在你的套餐内”。
 		if errors.Is(err, service.ErrUniversalNoEntitledGroup) {
+			reqLog.Warn("universal_routing.no_entitled_group")
 			writeUniversalRoutingError(c, shape, model)
 		} else {
+			reqLog.Error("universal_routing.resolve_failed", zap.Error(err))
 			writeUniversalRoutingInternalError(c, shape)
 		}
 		c.Abort()
@@ -75,7 +80,58 @@ func MaybeResolveUniversal(c *gin.Context, apiKey *service.APIKey, resolver *ser
 	// 伪装成绑定该后端组的普通 key。apiKey 是每请求新建的结构（snapshotToAPIKey），就地替换安全。
 	apiKey.Group = backing
 	apiKey.GroupID = &backing.ID
+	reqLog.Info("universal_routing.resolved",
+		zap.Int64("backing_group_id", backing.ID),
+		zap.String("backing_group_name", backing.Name),
+		zap.String("backing_platform", backing.Platform),
+	)
 	return false
+}
+
+func universalRoutingLogger(c *gin.Context, apiKey *service.APIKey, shape service.UniversalShape, model, forcedPlatform string) *zap.Logger {
+	base := logger.L()
+	if c != nil && c.Request != nil {
+		base = logger.FromContext(c.Request.Context())
+	}
+
+	fields := []zap.Field{
+		zap.String("component", "middleware.universal_routing"),
+		zap.String("universal_shape", universalShapeLabel(shape)),
+		zap.String("request_model", strings.TrimSpace(model)),
+		zap.String("forced_platform", strings.TrimSpace(forcedPlatform)),
+	}
+	if apiKey != nil {
+		fields = append(fields,
+			zap.Int64("api_key_id", apiKey.ID),
+			zap.Int64("user_id", apiKey.UserID),
+		)
+	}
+	return base.With(fields...)
+}
+
+func universalShapeLabel(shape service.UniversalShape) string {
+	switch shape {
+	case service.ShapeSkip:
+		return "skip"
+	case service.ShapeAnthropicMessages:
+		return "anthropic_messages"
+	case service.ShapeAnthropicCountTokens:
+		return "anthropic_count_tokens"
+	case service.ShapeOpenAIChat:
+		return "openai"
+	case service.ShapeOpenAIEmbeddings:
+		return "openai_embeddings"
+	case service.ShapeOpenAIImages:
+		return "openai_images"
+	case service.ShapeOpenAIImagesEdit:
+		return "openai_images_edit"
+	case service.ShapeOpenAIVideo:
+		return "openai_video"
+	case service.ShapeGemini:
+		return "gemini"
+	default:
+		return "unknown"
+	}
 }
 
 // peekUniversalModel 取请求模型名（仅作平台偏好提示）。body 类端点读 body 后“原样还原”

--- a/backend/internal/server/middleware/universal_routing_tk_test.go
+++ b/backend/internal/server/middleware/universal_routing_tk_test.go
@@ -7,17 +7,98 @@ import (
 	"compress/gzip"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
 )
+
+var middlewareStructuredLogCaptureMu sync.Mutex
+
+type middlewareInMemoryLogSink struct {
+	mu     sync.Mutex
+	events []*logger.LogEvent
+}
+
+func (s *middlewareInMemoryLogSink) WriteLogEvent(event *logger.LogEvent) {
+	if event == nil {
+		return
+	}
+	cloned := *event
+	if event.Fields != nil {
+		cloned.Fields = make(map[string]any, len(event.Fields))
+		for k, v := range event.Fields {
+			cloned.Fields[k] = v
+		}
+	}
+	s.mu.Lock()
+	s.events = append(s.events, &cloned)
+	s.mu.Unlock()
+}
+
+func (s *middlewareInMemoryLogSink) ContainsMessageAtLevel(substr, level string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	wantLevel := strings.ToLower(strings.TrimSpace(level))
+	for _, ev := range s.events {
+		if ev == nil {
+			continue
+		}
+		if strings.Contains(ev.Message, substr) && strings.ToLower(strings.TrimSpace(ev.Level)) == wantLevel {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *middlewareInMemoryLogSink) ContainsFieldValue(field, substr string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, ev := range s.events {
+		if ev == nil || ev.Fields == nil {
+			continue
+		}
+		if v, ok := ev.Fields[field]; ok && strings.Contains(fmt.Sprint(v), substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func captureMiddlewareStructuredLog(t *testing.T) (*middlewareInMemoryLogSink, func()) {
+	t.Helper()
+	middlewareStructuredLogCaptureMu.Lock()
+
+	err := logger.Init(logger.InitOptions{
+		Level:       "debug",
+		Format:      "json",
+		ServiceName: "sub2api",
+		Environment: "test",
+		Output: logger.OutputOptions{
+			ToStdout: true,
+			ToFile:   false,
+		},
+		Sampling: logger.SamplingOptions{Enabled: false},
+	})
+	require.NoError(t, err)
+
+	sink := &middlewareInMemoryLogSink{}
+	logger.SetSink(sink)
+	return sink, func() {
+		logger.SetSink(nil)
+		middlewareStructuredLogCaptureMu.Unlock()
+	}
+}
 
 type stubSpanLister struct {
 	groups []service.Group
@@ -259,6 +340,23 @@ func TestMaybeResolveUniversal_InternalErrorIs500Not403(t *testing.T) {
 	if strings.Contains(w.Body.String(), "universal_no_entitled_group") {
 		t.Fatalf("internal error must not be mislabeled as no-entitled-group: %s", w.Body.String())
 	}
+}
+
+func TestMaybeResolveUniversal_InternalErrorLogsStructuredContext(t *testing.T) {
+	logSink, restore := captureMiddlewareStructuredLog(t)
+	defer restore()
+
+	c, _ := newTestCtx(http.MethodPost, "/v1/chat/completions", `{"model":"gpt-5.5"}`)
+	resolver := service.NewUniversalRoutingResolver(&stubSpanLister{err: errors.New("database unavailable")})
+	apiKey := &service.APIKey{ID: 11, UserID: 22, RoutingMode: service.RoutingModeUniversal}
+
+	handled := MaybeResolveUniversal(c, apiKey, resolver)
+	require.True(t, handled)
+	require.True(t, logSink.ContainsMessageAtLevel("universal_routing.resolve_failed", "error"))
+	require.True(t, logSink.ContainsFieldValue("api_key_id", "11"))
+	require.True(t, logSink.ContainsFieldValue("user_id", "22"))
+	require.True(t, logSink.ContainsFieldValue("request_model", "gpt-5.5"))
+	require.True(t, logSink.ContainsFieldValue("universal_shape", "openai"))
 }
 
 // Regression for the "prod 视频全局宕" incident (fix/video-channel-type-selection):

--- a/backend/internal/server/middleware/universal_routing_tk_test.go
+++ b/backend/internal/server/middleware/universal_routing_tk_test.go
@@ -359,6 +359,47 @@ func TestMaybeResolveUniversal_InternalErrorLogsStructuredContext(t *testing.T) 
 	require.True(t, logSink.ContainsFieldValue("universal_shape", "openai"))
 }
 
+func TestMaybeResolveUniversal_NoEntitledGroupLogsStructuredContext(t *testing.T) {
+	logSink, restore := captureMiddlewareStructuredLog(t)
+	defer restore()
+
+	c, _ := newTestCtx(http.MethodPost, "/v1/chat/completions", `{"model":"gpt-5.5"}`)
+	resolver := service.NewUniversalRoutingResolver(&stubSpanLister{groups: []service.Group{activeGroup(10, service.PlatformAnthropic)}})
+	apiKey := &service.APIKey{ID: 11, UserID: 22, RoutingMode: service.RoutingModeUniversal}
+
+	handled := MaybeResolveUniversal(c, apiKey, resolver)
+	require.True(t, handled)
+	require.True(t, logSink.ContainsMessageAtLevel("universal_routing.no_entitled_group", "warn"))
+	require.True(t, logSink.ContainsFieldValue("api_key_id", "11"))
+	require.True(t, logSink.ContainsFieldValue("user_id", "22"))
+	require.True(t, logSink.ContainsFieldValue("request_model", "gpt-5.5"))
+	require.True(t, logSink.ContainsFieldValue("universal_shape", "openai"))
+}
+
+func TestMaybeResolveUniversal_ResolvedLogsStructuredContext(t *testing.T) {
+	logSink, restore := captureMiddlewareStructuredLog(t)
+	defer restore()
+
+	openaiGroup := activeGroup(20, service.PlatformOpenAI)
+	openaiGroup.Name = "uni-openai"
+	c, _ := newTestCtx(http.MethodPost, "/v1/chat/completions", `{"model":"gpt-5.5"}`)
+	resolver := service.NewUniversalRoutingResolver(&stubSpanLister{groups: []service.Group{
+		activeGroup(10, service.PlatformAnthropic),
+		openaiGroup,
+	}})
+	apiKey := &service.APIKey{ID: 11, UserID: 22, RoutingMode: service.RoutingModeUniversal}
+
+	handled := MaybeResolveUniversal(c, apiKey, resolver)
+	require.False(t, handled)
+	require.True(t, logSink.ContainsMessageAtLevel("universal_routing.resolved", "info"))
+	require.True(t, logSink.ContainsFieldValue("api_key_id", "11"))
+	require.True(t, logSink.ContainsFieldValue("user_id", "22"))
+	require.True(t, logSink.ContainsFieldValue("request_model", "gpt-5.5"))
+	require.True(t, logSink.ContainsFieldValue("backing_group_id", "20"))
+	require.True(t, logSink.ContainsFieldValue("backing_group_name", "uni-openai"))
+	require.True(t, logSink.ContainsFieldValue("backing_platform", service.PlatformOpenAI))
+}
+
 // Regression for the "prod 视频全局宕" incident (fix/video-channel-type-selection):
 // a universal key POSTing /v1/video/generations must peek the JSON body's model so the
 // resolver converges onto the video-capable backing group. Before the fix the video

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -4044,6 +4044,64 @@ func openAIStreamFailedEventShouldFailover(payload []byte, message string) bool 
 	return true
 }
 
+func openAIStreamFailedEventLooksTransient(payload []byte, message string) bool {
+	return isOpenAITransientProcessingError(http.StatusBadRequest, message, payload)
+}
+
+func logOpenAIStreamFailedEvent(ctx context.Context, c *gin.Context, account *Account, upstreamRequestID string, payload []byte, message string, clientOutputStarted bool, passthrough bool) {
+	log := logger.FromContext(ctx).With(
+		zap.String("component", "service.openai_gateway"),
+		zap.String("upstream_request_id", strings.TrimSpace(upstreamRequestID)),
+		zap.Bool("client_output_started", clientOutputStarted),
+		zap.Bool("failover_possible", !clientOutputStarted),
+		zap.Bool("passthrough_mode", passthrough),
+		zap.Bool("remote_compact", isOpenAIResponsesCompactPath(c)),
+	)
+	if account != nil {
+		log = log.With(
+			zap.Int64("account_id", account.ID),
+			zap.String("account_name", account.Name),
+			zap.String("account_type", account.Type),
+			zap.String("account_platform", account.Platform),
+		)
+	}
+	if c != nil {
+		if v, ok := c.Get(OpsModelKey); ok {
+			if model, ok := v.(string); ok && strings.TrimSpace(model) != "" {
+				log = log.With(zap.String("request_model", strings.TrimSpace(model)))
+			}
+		}
+	}
+	failoverEligible := openAIStreamFailedEventShouldFailover(payload, message)
+	transient := openAIStreamFailedEventLooksTransient(payload, message)
+	eventType := strings.TrimSpace(gjson.GetBytes(payload, "type").String())
+	errorCode := strings.TrimSpace(gjson.GetBytes(payload, "response.error.code").String())
+	if errorCode == "" {
+		errorCode = strings.TrimSpace(gjson.GetBytes(payload, "error.code").String())
+	}
+	errorType := strings.TrimSpace(gjson.GetBytes(payload, "response.error.type").String())
+	if errorType == "" {
+		errorType = strings.TrimSpace(gjson.GetBytes(payload, "error.type").String())
+	}
+	msg := "openai.stream_failed_event.forwarded_to_client"
+	if !clientOutputStarted && failoverEligible {
+		msg = "openai.stream_failed_event.failover_candidate"
+	}
+	fields := []zap.Field{
+		zap.String("event_type", eventType),
+		zap.String("error_code", errorCode),
+		zap.String("error_type", errorType),
+		zap.String("error_message", sanitizeUpstreamErrorMessage(strings.TrimSpace(message))),
+		zap.Bool("failover_eligible", failoverEligible),
+		zap.Bool("transient_processing_error", transient),
+	}
+	if clientOutputStarted && transient {
+		log.Warn(msg, fields...)
+		return
+	}
+	log.Info(msg, fields...)
+}
+
 func (s *OpenAIGatewayService) newOpenAIStreamFailoverError(
 	c *gin.Context,
 	account *Account,
@@ -4237,8 +4295,11 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 						UpstreamOutTok: usage.OutputTokens,
 					})
 				} else if !openAIStreamClientOutputStarted(c, clientOutputStarted) && openAIStreamFailedEventShouldFailover(dataBytes, failedMessage) {
+					logOpenAIStreamFailedEvent(ctx, c, account, upstreamRequestID, dataBytes, failedMessage, false, true)
 					return resultWithUsage(),
 						s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, dataBytes, failedMessage)
+				} else {
+					logOpenAIStreamFailedEvent(ctx, c, account, upstreamRequestID, dataBytes, failedMessage, openAIStreamClientOutputStarted(c, clientOutputStarted), true)
 				}
 				forceFlushFailedEvent = true
 				sawFailedEvent = true
@@ -5288,9 +5349,12 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 						UpstreamOutTok: usage.OutputTokens,
 					})
 				} else if !openAIStreamClientOutputStarted(c, clientOutputStarted) && openAIStreamFailedEventShouldFailover(dataBytes, failedMessage) {
+					logOpenAIStreamFailedEvent(ctx, c, account, upstreamRequestID, dataBytes, failedMessage, false, false)
 					sawFailedEvent = true
 					streamFailoverErr = s.newOpenAIStreamFailoverError(c, account, false, upstreamRequestID, dataBytes, failedMessage)
 					return
+				} else {
+					logOpenAIStreamFailedEvent(ctx, c, account, upstreamRequestID, dataBytes, failedMessage, openAIStreamClientOutputStarted(c, clientOutputStarted), false)
 				}
 				forceFlushFailedEvent = true
 				sawFailedEvent = true

--- a/backend/internal/service/openai_stream_failed_event_log_test.go
+++ b/backend/internal/service/openai_stream_failed_event_log_test.go
@@ -1,0 +1,55 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogOpenAIStreamFailedEvent_FailoverCandidate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logSink, restore := captureStructuredLog(t)
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Set(OpsModelKey, "gpt-5.5")
+	account := &Account{ID: 73, Name: "GPT-pro3", Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	payload := []byte(`{"type":"response.failed","response":{"error":{"type":"server_error","code":"model_capacity","message":"Selected model is at capacity. Please try a different model."}}}`)
+
+	logOpenAIStreamFailedEvent(context.Background(), c, account, "rid-cap-1", payload, "Selected model is at capacity. Please try a different model.", false, false)
+
+	require.True(t, logSink.ContainsMessageAtLevel("openai.stream_failed_event.failover_candidate", "info"))
+	require.True(t, logSink.ContainsFieldValue("failover_eligible", "true"))
+	require.True(t, logSink.ContainsFieldValue("client_output_started", "false"))
+	require.True(t, logSink.ContainsFieldValue("error_code", "model_capacity"))
+	require.True(t, logSink.ContainsFieldValue("request_model", "gpt-5.5"))
+}
+
+func TestLogOpenAIStreamFailedEvent_PostOutputCapacityWarnsAndMarksCompact(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logSink, restore := captureStructuredLog(t)
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", nil)
+	c.Set(OpsModelKey, "gpt-5.5")
+	account := &Account{ID: 73, Name: "GPT-pro3", Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	payload := []byte(`{"type":"response.failed","response":{"error":{"type":"server_error","code":"model_capacity","message":"Selected model is at capacity. Please try a different model."}}}`)
+
+	logOpenAIStreamFailedEvent(context.Background(), c, account, "rid-cap-2", payload, "Selected model is at capacity. Please try a different model.", true, true)
+
+	require.True(t, logSink.ContainsMessageAtLevel("openai.stream_failed_event.forwarded_to_client", "warn"))
+	require.True(t, logSink.ContainsFieldValue("failover_possible", "false"))
+	require.True(t, logSink.ContainsFieldValue("remote_compact", "true"))
+	require.True(t, logSink.ContainsFieldValue("passthrough_mode", "true"))
+	require.True(t, logSink.ContainsFieldValue("error_code", "model_capacity"))
+}


### PR DESCRIPTION
## 摘要
- 为 universal routing 解析成功/失败补结构化日志，便于把 universal-routing 500 关联到 user/api-key/model/shape
- 为 OpenAI stream `response.failed` 事件补结构化诊断，区分可 failover 的 capacity 事件与已输出后转发给客户端的失败
- 补 middleware/service 可观测性路径的 focused 单元测试

## 风险
- 常规风险：仅增加日志与测试，不改变网关路由/计费/鉴权行为
- `universal_routing.resolved` 在每次成功解析时打 Info，短期可能增加日志量；用于 capacity 排查，可后续按采样或级别调整

## 验证
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `go test -tags=unit ./internal/server/middleware -run 'TestMaybeResolveUniversal_(InternalErrorLogsStructuredContext|NoEntitledGroupLogsStructuredContext|ResolvedLogsStructuredContext)'`
- `go test -tags=unit ./internal/service -run 'TestLogOpenAIStreamFailedEvent_'`

no-web-impact

## 提交
- `4b20ae9cc` fix(obs): add openai capacity and universal routing diagnostics
- `2d43291a6` chore: mark no-web-impact for observability-only diagnostics
- `c71adc1ab` test(obs): cover universal routing resolve and no-entitled logs

最新提交：c71adc1ab
