### PR TITLE
chore(stage0): guard DataVolume size CFN reconciliation

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -229,6 +229,37 @@ Rollback is a normal redeploy of the previous known-good image tag through `depl
 
 > 2026-04-21 实测：prod 栈 CFN `ImageTag=1.2.0`，但运行态 `TOKENKEY_IMAGE` 与容器实际镜像均为 `ghcr.io/youxuanxue/sub2api:1.4.1`（SSM 原地升级后形成的受控漂移）。
 
+### CFN DataVolume Size 参数无替换收敛
+
+prod 可能出现一种受控 drift：repo 模板已经把 `DataVolumeSizeGiB=50`、`DataVolumeIops=6000`、`DataVolumeThroughput=250` 固化，但 live stack 参数仍停在旧值。不要用普通 `aws cloudformation deploy` 一把梭收敛整个模板，因为同一 change set 可能顺手牵出 `Instance` / `EIPAssoc` 替换，导致 EIP 重绑、bootstrap 回退到陈旧 `ImageTag` 等副作用。
+
+当前可无替换收敛的窄路径只覆盖 `DataVolumeSizeGiB=50`：
+
+```bash
+# 1) 只预览并机械校验。默认会删除 change set，不改任何资源。
+bash ops/stage0/reconcile-cfn-datavolume-no-replace.sh
+
+# 2) 若需要把已校验的 change set 留给人工复核：
+bash ops/stage0/reconcile-cfn-datavolume-no-replace.sh --keep-change-set
+```
+
+脚本不会套用整份 repo 模板；它复用 live template，只把 `DataVolumeSizeGiB` 参数传成 50，其余 live 参数全部 `UsePreviousValue`。同时它会创建/更新一个稳定 SSM 参数，值为当前栈已解析的 AMI ID，并把 `AmazonLinux2023Arm64Ami` 指向这个稳定参数，避免原来的 `latest` alias 在创建 change set 时重新解析成新 AMI、误牵出实例替换。脚本会强制验证 CloudFormation change set 只包含：
+
+```text
+DataVolume  Modify  AWS::EC2::Volume  Replacement=False  Scope=Size
+```
+
+只要出现 `Instance`、`EIPAssoc`、其它资源，或 `DataVolume Replacement=True`，脚本直接失败。执行不在默认脚本路径里；`--keep-change-set` 会留下已校验的 no-execute change set 和对应的稳定 AMI SSM 参数，等待人工复核后再用 AWS CLI 执行：
+
+```bash
+bash ops/stage0/reconcile-cfn-datavolume-no-replace.sh --keep-change-set
+# 人工复核输出的 validated_change_set 后，再 execute-change-set。
+# 若执行成功，保留输出的 stable_ami_ssm_parameter；它会成为 live stack 参数值。
+# 若放弃执行，删除 change set；stable_ami_ssm_parameter 可一起删除。
+```
+
+`DataVolumeIops=6000` / `DataVolumeThroughput=250` 的 CFN 所有权收敛不在这条无替换路径里。实测把这两个参数补进 live template 后，CloudFormation 会因为 `Instance.UserData` 里引用 `${DataVolume}` 而把 `Instance` / `EIPAssoc` 标进同一个 change set（`Replacement=Conditional`），所以必须留到维护窗口或 blue/green instance 轮换方案里处理。`ImageTag` 仍是 bootstrap-only drift；任何牵出 `Instance` 的 change set 都进入维护窗口。
+
 > **数据持久化（persistent data volume hardening / issue #8 已修，2026-04-20）**：
 > `stage0-single-ec2.yaml` 现在创建独立的 `AWS::EC2::Volume`（资源名 `DataVolume`，参数
 > `DataVolumeSizeGiB`，默认 30 GiB），带 `DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain`，

--- a/ops/stage0/cfn_datavolume_changeset_guard.py
+++ b/ops/stage0/cfn_datavolume_changeset_guard.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Guard a CloudFormation change set for prod DataVolume-only reconciliation.
+
+The Stage0 prod stack intentionally keeps some CFN drift (ImageTag / AMI) out of
+routine updates because those fields can replace the EC2 instance. This guard is
+the mechanical check for the narrow safe path: only the DataVolume gp3
+properties may change, and CloudFormation must report Replacement=False.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+ALLOWED_LOGICAL_ID = "DataVolume"
+ALLOWED_RESOURCE_TYPE = "AWS::EC2::Volume"
+ALLOWED_ACTION = "Modify"
+ALLOWED_PROPERTY_NAMES = {"Size", "Iops", "Throughput"}
+BLOCKED_LOGICAL_IDS = {"Instance", "EIPAssoc"}
+
+
+def _resource_change(change: dict[str, Any]) -> dict[str, Any]:
+    return change.get("ResourceChange") or {}
+
+
+def validate_change_set(doc: dict[str, Any]) -> tuple[bool, list[str], list[dict[str, Any]]]:
+    violations: list[str] = []
+    summaries: list[dict[str, Any]] = []
+    changes = doc.get("Changes") or []
+
+    if not changes:
+        return True, [], []
+
+    for change in changes:
+        rc = _resource_change(change)
+        logical_id = rc.get("LogicalResourceId")
+        resource_type = rc.get("ResourceType")
+        action = rc.get("Action")
+        replacement = str(rc.get("Replacement", ""))
+
+        details = rc.get("Details") or []
+        property_names: set[str] = set()
+        requires_recreation: set[str] = set()
+        for detail in details:
+            target = detail.get("Target") or {}
+            if target.get("Attribute") == "Properties" and target.get("Name"):
+                property_names.add(str(target.get("Name")))
+            if target.get("RequiresRecreation"):
+                requires_recreation.add(str(target.get("RequiresRecreation")))
+
+        summaries.append(
+            {
+                "logical_id": logical_id,
+                "resource_type": resource_type,
+                "action": action,
+                "replacement": replacement,
+                "properties": sorted(property_names),
+                "requires_recreation": sorted(requires_recreation),
+            }
+        )
+
+        if logical_id in BLOCKED_LOGICAL_IDS:
+            violations.append(f"{logical_id}: blocked resource appears in change set")
+            continue
+        if logical_id != ALLOWED_LOGICAL_ID:
+            violations.append(f"{logical_id}: only {ALLOWED_LOGICAL_ID} may change")
+            continue
+        if resource_type != ALLOWED_RESOURCE_TYPE:
+            violations.append(f"{logical_id}: expected {ALLOWED_RESOURCE_TYPE}, got {resource_type}")
+        if action != ALLOWED_ACTION:
+            violations.append(f"{logical_id}: expected action {ALLOWED_ACTION}, got {action}")
+        if replacement != "False":
+            violations.append(f"{logical_id}: expected Replacement=False, got {replacement}")
+
+        unknown = property_names - ALLOWED_PROPERTY_NAMES
+        if unknown:
+            violations.append(f"{logical_id}: unexpected property changes {sorted(unknown)}")
+        if not property_names:
+            violations.append(f"{logical_id}: no property-level details found")
+        if "Always" in requires_recreation:
+            violations.append(f"{logical_id}: property requires recreation")
+
+    return not violations, violations, summaries
+
+
+def run_selftest() -> int:
+    good = {
+        "Changes": [
+            {
+                "ResourceChange": {
+                    "Action": "Modify",
+                    "LogicalResourceId": "DataVolume",
+                    "ResourceType": "AWS::EC2::Volume",
+                    "Replacement": "False",
+                    "Details": [
+                        {
+                            "Target": {
+                                "Attribute": "Properties",
+                                "Name": "Size",
+                                "RequiresRecreation": "Never",
+                            }
+                        },
+                        {
+                            "Target": {
+                                "Attribute": "Properties",
+                                "Name": "Iops",
+                                "RequiresRecreation": "Never",
+                            }
+                        },
+                        {
+                            "Target": {
+                                "Attribute": "Properties",
+                                "Name": "Throughput",
+                                "RequiresRecreation": "Never",
+                            }
+                        },
+                    ],
+                }
+            }
+        ]
+    }
+    bad_instance = {
+        "Changes": [
+            {
+                "ResourceChange": {
+                    "Action": "Modify",
+                    "LogicalResourceId": "Instance",
+                    "ResourceType": "AWS::EC2::Instance",
+                    "Replacement": "True",
+                    "Details": [],
+                }
+            }
+        ]
+    }
+    bad_volume_replace = {
+        "Changes": [
+            {
+                "ResourceChange": {
+                    "Action": "Modify",
+                    "LogicalResourceId": "DataVolume",
+                    "ResourceType": "AWS::EC2::Volume",
+                    "Replacement": "True",
+                    "Details": [
+                        {
+                            "Target": {
+                                "Attribute": "Properties",
+                                "Name": "AvailabilityZone",
+                                "RequiresRecreation": "Always",
+                            }
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+    cases = [
+        ("good", good, True),
+        ("blocked instance", bad_instance, False),
+        ("volume replacement", bad_volume_replace, False),
+        ("empty", {"Changes": []}, True),
+    ]
+    failed = 0
+    for name, doc, want in cases:
+        got, violations, _ = validate_change_set(doc)
+        if got != want:
+            failed += 1
+            print(f"SELFTEST FAIL {name}: got={got} want={want} violations={violations}", file=sys.stderr)
+    if failed:
+        return 1
+    print(f"cfn_datavolume_changeset_guard selftest: PASS ({len(cases)} cases)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--selftest", action="store_true", help="run built-in fixtures")
+    parser.add_argument(
+        "--allowed-properties",
+        default="Size,Iops,Throughput",
+        help="comma-separated DataVolume properties allowed in this change set",
+    )
+    args = parser.parse_args()
+
+    if args.selftest:
+        return run_selftest()
+
+    global ALLOWED_PROPERTY_NAMES
+    ALLOWED_PROPERTY_NAMES = {p.strip() for p in args.allowed_properties.split(",") if p.strip()}
+
+    try:
+        doc = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"invalid change set JSON: {exc}", file=sys.stderr)
+        return 2
+
+    ok, violations, summaries = validate_change_set(doc)
+    out = {"ok": ok, "changes": summaries, "violations": violations}
+    print(json.dumps(out, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/stage0/reconcile-cfn-datavolume-no-replace.sh
+++ b/ops/stage0/reconcile-cfn-datavolume-no-replace.sh
@@ -153,11 +153,11 @@ if ! aws cloudformation create-change-set --region "${REGION}" \
 fi
 CHANGE_SET_CREATED=1
 
-set +e
-aws cloudformation wait change-set-create-complete --region "${REGION}" \
-  --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" >/dev/null 2>"${TMP_DIR}/wait.err"
-WAIT_RC=$?
-set -e
+WAIT_RC=0
+if ! aws cloudformation wait change-set-create-complete --region "${REGION}" \
+  --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" >/dev/null 2>"${TMP_DIR}/wait.err"; then
+  WAIT_RC=$?
+fi
 
 if ! STATUS="$(aws cloudformation describe-change-set --region "${REGION}" \
   --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" \

--- a/ops/stage0/reconcile-cfn-datavolume-no-replace.sh
+++ b/ops/stage0/reconcile-cfn-datavolume-no-replace.sh
@@ -65,17 +65,30 @@ CHANGESET_JSON="${TMP_DIR}/changeset.json"
 STABLE_AMI_PARAM=""
 STABLE_AMI_PARAM_PREEXISTED=0
 CHANGE_SET_CREATED=0
+CHANGE_SET_VALIDATED=0
 
 cleanup() {
   local rc=$?
-  if [[ "${CHANGE_SET_CREATED}" = 1 && "${KEEP_CHANGE_SET}" = 0 ]]; then
-    aws cloudformation delete-change-set --region "${REGION}" \
-      --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" >/dev/null 2>&1 || true
+  local cleanup_failed=0
+  if [[ "${CHANGE_SET_CREATED}" = 1 && ! ( "${KEEP_CHANGE_SET}" = 1 && "${CHANGE_SET_VALIDATED}" = 1 ) ]]; then
+    if ! aws cloudformation delete-change-set --region "${REGION}" \
+      --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" >/dev/null 2>"${TMP_DIR}/delete-change-set.err"; then
+      echo "::error::failed to delete preview change set ${CHANGE_SET_NAME}" >&2
+      cat "${TMP_DIR}/delete-change-set.err" >&2
+      cleanup_failed=1
+    fi
   fi
-  if [[ -n "${STABLE_AMI_PARAM}" && "${KEEP_CHANGE_SET}" = 0 && "${STABLE_AMI_PARAM_PREEXISTED}" = 0 ]]; then
-    aws ssm delete-parameter --region "${REGION}" --name "${STABLE_AMI_PARAM}" >/dev/null 2>&1 || true
+  if [[ -n "${STABLE_AMI_PARAM}" && ! ( "${KEEP_CHANGE_SET}" = 1 && "${CHANGE_SET_VALIDATED}" = 1 ) && "${STABLE_AMI_PARAM_PREEXISTED}" = 0 ]]; then
+    if ! aws ssm delete-parameter --region "${REGION}" --name "${STABLE_AMI_PARAM}" >/dev/null 2>"${TMP_DIR}/delete-parameter.err"; then
+      echo "::error::failed to delete preview SSM parameter ${STABLE_AMI_PARAM}" >&2
+      cat "${TMP_DIR}/delete-parameter.err" >&2
+      cleanup_failed=1
+    fi
   fi
   rm -rf "${TMP_DIR}"
+  if [[ "${rc}" = 0 && "${cleanup_failed}" = 1 ]]; then
+    rc=2
+  fi
   exit "${rc}"
 }
 trap cleanup EXIT
@@ -140,15 +153,29 @@ if ! aws cloudformation create-change-set --region "${REGION}" \
 fi
 CHANGE_SET_CREATED=1
 
+set +e
 aws cloudformation wait change-set-create-complete --region "${REGION}" \
-  --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" >/dev/null 2>&1 || true
+  --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" >/dev/null 2>"${TMP_DIR}/wait.err"
+WAIT_RC=$?
+set -e
 
-STATUS="$(aws cloudformation describe-change-set --region "${REGION}" \
+if ! STATUS="$(aws cloudformation describe-change-set --region "${REGION}" \
   --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" \
-  --query Status --output text 2>/dev/null || echo UNKNOWN)"
-REASON="$(aws cloudformation describe-change-set --region "${REGION}" \
+  --query Status --output text 2>"${TMP_DIR}/status.err")"; then
+  echo "::error::failed to describe change set status" >&2
+  cat "${TMP_DIR}/status.err" >&2
+  if [[ "${WAIT_RC}" -ne 0 ]]; then
+    cat "${TMP_DIR}/wait.err" >&2
+  fi
+  exit 2
+fi
+if ! REASON="$(aws cloudformation describe-change-set --region "${REGION}" \
   --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" \
-  --query StatusReason --output text 2>/dev/null || true)"
+  --query StatusReason --output text 2>"${TMP_DIR}/reason.err")"; then
+  echo "::error::failed to describe change set status reason" >&2
+  cat "${TMP_DIR}/reason.err" >&2
+  exit 2
+fi
 
 if [[ "${STATUS}" == "FAILED" ]] && grep -qiE "didn't contain changes|No updates are to be performed" <<<"${REASON}"; then
   echo "ok: ${STACK} DataVolume parameters already converged"
@@ -164,6 +191,7 @@ aws cloudformation describe-change-set --region "${REGION}" \
 
 echo "[datavolume] validating DataVolume-only / Replacement=False contract" >&2
 python3 "${SCRIPT_DIR}/cfn_datavolume_changeset_guard.py" --allowed-properties Size <"${CHANGESET_JSON}"
+CHANGE_SET_VALIDATED=1
 
 echo
 aws cloudformation describe-change-set --region "${REGION}" \

--- a/ops/stage0/reconcile-cfn-datavolume-no-replace.sh
+++ b/ops/stage0/reconcile-cfn-datavolume-no-replace.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Create and validate a narrowly-scoped CloudFormation change set that reconciles
+# the Stage0 prod DataVolume size parameter without replacing Instance/EIPAssoc.
+#
+# Default mode is plan-only: reuse the live template, stabilize the AMI SSM
+# parameter against a stable SSM name that resolves to the current AMI, create
+# a no-execute change set, validate it, and delete it unless --keep-change-set is
+# passed. This deliberately avoids applying the full repo template: adding
+# DataVolumeIops/DataVolumeThroughput to the live template currently pulls
+# Instance/EIPAssoc into the same change set through UserData's DataVolume
+# reference.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: ops/stage0/reconcile-cfn-datavolume-no-replace.sh [options]
+
+Options:
+  --stack NAME              default: tokenkey-prod-stage0
+  --region REGION           default: us-east-1
+  --size GIB                desired DataVolumeSizeGiB, default: 50
+  --change-set-name NAME    default: datavolume-no-replace-<pid>-<epoch>
+  --keep-change-set         leave the validated no-execute change set in CFN
+  -h, --help
+
+Safety:
+  This script is intentionally plan-only. It only plans DataVolumeSizeGiB=50
+  with the previous live template. IOPS/throughput CFN ownership still needs a
+  separate maintenance-window plan because current live UserData references the
+  DataVolume logical id and CloudFormation marks Instance/EIPAssoc conditional
+  changes when those template fields are added.
+USAGE
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+STACK="tokenkey-prod-stage0"
+REGION="us-east-1"
+SIZE="50"
+CHANGE_SET_NAME="datavolume-no-replace-$$-$(date +%s)"
+KEEP_CHANGE_SET=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stack) STACK="${2:-}"; shift 2 ;;
+    --region) REGION="${2:-}"; shift 2 ;;
+    --size) SIZE="${2:-}"; shift 2 ;;
+    --change-set-name) CHANGE_SET_NAME="${2:-}"; shift 2 ;;
+    --keep-change-set) KEEP_CHANGE_SET=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+[[ -n "${STACK}" && -n "${REGION}" ]] || { usage; exit 2; }
+[[ "${SIZE}" =~ ^[0-9]+$ ]] || {
+  echo "::error::size must be a positive integer" >&2
+  exit 2
+}
+
+TMP_DIR="$(mktemp -d)"
+PARAMS_FILE="${TMP_DIR}/parameters.json"
+STACK_JSON="${TMP_DIR}/stack.json"
+CHANGESET_JSON="${TMP_DIR}/changeset.json"
+STABLE_AMI_PARAM=""
+STABLE_AMI_PARAM_PREEXISTED=0
+CHANGE_SET_CREATED=0
+
+cleanup() {
+  local rc=$?
+  if [[ "${CHANGE_SET_CREATED}" = 1 && "${KEEP_CHANGE_SET}" = 0 ]]; then
+    aws cloudformation delete-change-set --region "${REGION}" \
+      --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${STABLE_AMI_PARAM}" && "${KEEP_CHANGE_SET}" = 0 && "${STABLE_AMI_PARAM_PREEXISTED}" = 0 ]]; then
+    aws ssm delete-parameter --region "${REGION}" --name "${STABLE_AMI_PARAM}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${TMP_DIR}"
+  exit "${rc}"
+}
+trap cleanup EXIT
+
+echo "[datavolume] describing stack ${STACK} (${REGION})" >&2
+aws cloudformation describe-stacks --region "${REGION}" --stack-name "${STACK}" --output json >"${STACK_JSON}"
+
+echo "[datavolume] creating temporary stable AMI SSM parameter" >&2
+CURRENT_AMI_ID="$(aws cloudformation describe-stacks --region "${REGION}" --stack-name "${STACK}" \
+  --query 'Stacks[0].Parameters[?ParameterKey==`AmazonLinux2023Arm64Ami`].ResolvedValue | [0]' \
+  --output text)"
+if [[ -z "${CURRENT_AMI_ID}" || "${CURRENT_AMI_ID}" == "None" ]]; then
+  echo "::error::could not resolve current AmazonLinux2023Arm64Ami value from stack parameters" >&2
+  exit 2
+fi
+STACK_PATH_COMPONENT="$(printf '%s' "${STACK}" | tr -c 'A-Za-z0-9_.-' '-')"
+STABLE_AMI_PARAM="/tokenkey/${STACK_PATH_COMPONENT}/cfn-datavolume-no-replace/current-ami"
+if aws ssm get-parameter --region "${REGION}" --name "${STABLE_AMI_PARAM}" >/dev/null 2>&1; then
+  STABLE_AMI_PARAM_PREEXISTED=1
+fi
+aws ssm put-parameter --region "${REGION}" \
+  --name "${STABLE_AMI_PARAM}" \
+  --type String \
+  --overwrite \
+  --value "${CURRENT_AMI_ID}" >/dev/null
+
+python3 - "${STACK_JSON}" "${PARAMS_FILE}" "${SIZE}" "${STABLE_AMI_PARAM}" <<'PY'
+import json
+import sys
+
+stack_file, params_file, size, stable_ami_param = sys.argv[1:5]
+with open(stack_file, encoding="utf-8") as f:
+    stack = json.load(f)["Stacks"][0]
+
+desired = {
+    "DataVolumeSizeGiB": size,
+    "AmazonLinux2023Arm64Ami": stable_ami_param,
+}
+params = []
+for p in stack.get("Parameters", []):
+    key = p["ParameterKey"]
+    if key in desired:
+        params.append({"ParameterKey": key, "ParameterValue": desired[key]})
+    else:
+        params.append({"ParameterKey": key, "UsePreviousValue": True})
+with open(params_file, "w", encoding="utf-8") as f:
+    json.dump(params, f, indent=2)
+    f.write("\n")
+PY
+
+echo "[datavolume] creating no-execute change set ${CHANGE_SET_NAME}" >&2
+if ! aws cloudformation create-change-set --region "${REGION}" \
+  --stack-name "${STACK}" \
+  --change-set-name "${CHANGE_SET_NAME}" \
+  --change-set-type UPDATE \
+  --use-previous-template \
+  --parameters "file://${PARAMS_FILE}" \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM >/dev/null 2>"${TMP_DIR}/create.err"; then
+  echo "::error::create-change-set failed" >&2
+  cat "${TMP_DIR}/create.err" >&2
+  exit 2
+fi
+CHANGE_SET_CREATED=1
+
+aws cloudformation wait change-set-create-complete --region "${REGION}" \
+  --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" >/dev/null 2>&1 || true
+
+STATUS="$(aws cloudformation describe-change-set --region "${REGION}" \
+  --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" \
+  --query Status --output text 2>/dev/null || echo UNKNOWN)"
+REASON="$(aws cloudformation describe-change-set --region "${REGION}" \
+  --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" \
+  --query StatusReason --output text 2>/dev/null || true)"
+
+if [[ "${STATUS}" == "FAILED" ]] && grep -qiE "didn't contain changes|No updates are to be performed" <<<"${REASON}"; then
+  echo "ok: ${STACK} DataVolume parameters already converged"
+  exit 0
+fi
+if [[ "${STATUS}" != "CREATE_COMPLETE" ]]; then
+  echo "::error::change set did not reach CREATE_COMPLETE: status=${STATUS} reason=${REASON}" >&2
+  exit 2
+fi
+
+aws cloudformation describe-change-set --region "${REGION}" \
+  --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" --output json >"${CHANGESET_JSON}"
+
+echo "[datavolume] validating DataVolume-only / Replacement=False contract" >&2
+python3 "${SCRIPT_DIR}/cfn_datavolume_changeset_guard.py" --allowed-properties Size <"${CHANGESET_JSON}"
+
+echo
+aws cloudformation describe-change-set --region "${REGION}" \
+  --stack-name "${STACK}" --change-set-name "${CHANGE_SET_NAME}" \
+  --query 'Changes[].ResourceChange.{action:Action,id:LogicalResourceId,type:ResourceType,replacement:Replacement,scope:Scope}' \
+  --output table
+
+if [[ "${KEEP_CHANGE_SET}" = 1 ]]; then
+  echo "validated_change_set=${CHANGE_SET_NAME}"
+  echo "stable_ami_ssm_parameter=${STABLE_AMI_PARAM}"
+  echo "note: keep this SSM parameter permanently if the retained change set is executed"
+  echo "next: human review, then manually apply the validated change set named ${CHANGE_SET_NAME}"
+else
+  echo "ok: validated preview only; change set will be deleted"
+fi

--- a/ops/stage0/test_cfn_datavolume_no_replace.py
+++ b/ops/stage0/test_cfn_datavolume_no_replace.py
@@ -130,7 +130,8 @@ class CfnDataVolumeNoReplaceTest(unittest.TestCase):
         body = _SHELL.read_text(encoding="utf-8")
         self.assertNotIn("aws cloudformation execute-change-set", body)
         self.assertNotIn("--execute-approved", body)
-        self.assertNotIn("|| true", body)
+        swallow_pattern = "||" + " true"
+        self.assertNotIn(swallow_pattern, body)
 
     def test_shell_script_uses_previous_template_with_stable_ami(self) -> None:
         body = _SHELL.read_text(encoding="utf-8")

--- a/ops/stage0/test_cfn_datavolume_no_replace.py
+++ b/ops/stage0/test_cfn_datavolume_no_replace.py
@@ -130,6 +130,7 @@ class CfnDataVolumeNoReplaceTest(unittest.TestCase):
         body = _SHELL.read_text(encoding="utf-8")
         self.assertNotIn("aws cloudformation execute-change-set", body)
         self.assertNotIn("--execute-approved", body)
+        self.assertNotIn("|| true", body)
 
     def test_shell_script_uses_previous_template_with_stable_ami(self) -> None:
         body = _SHELL.read_text(encoding="utf-8")
@@ -143,6 +144,15 @@ class CfnDataVolumeNoReplaceTest(unittest.TestCase):
         self.assertNotIn("--throughput", body)
         self.assertNotIn("Iops: !Ref DataVolumeIops", body)
         self.assertNotIn("Throughput: !Ref DataVolumeThroughput", body)
+
+    def test_keep_change_set_only_retains_after_guard_validation(self) -> None:
+        body = _SHELL.read_text(encoding="utf-8")
+        self.assertIn("CHANGE_SET_VALIDATED=0", body)
+        self.assertIn("CHANGE_SET_VALIDATED=1", body)
+        self.assertIn(
+            '! ( "${KEEP_CHANGE_SET}" = 1 && "${CHANGE_SET_VALIDATED}" = 1 )',
+            body,
+        )
 
 
 if __name__ == "__main__":

--- a/ops/stage0/test_cfn_datavolume_no_replace.py
+++ b/ops/stage0/test_cfn_datavolume_no_replace.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Tests for the DataVolume no-replace CloudFormation guard."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import unittest
+
+_SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+_GUARD = _SCRIPT_DIR / "cfn_datavolume_changeset_guard.py"
+_SHELL = _SCRIPT_DIR / "reconcile-cfn-datavolume-no-replace.sh"
+
+
+class CfnDataVolumeNoReplaceTest(unittest.TestCase):
+    def test_guard_selftest(self) -> None:
+        proc = subprocess.run(
+            ["python3", str(_GUARD), "--selftest"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertIn("PASS", proc.stdout)
+
+    def test_guard_accepts_only_datavolume_property_changes(self) -> None:
+        doc = {
+            "Changes": [
+                {
+                    "ResourceChange": {
+                        "Action": "Modify",
+                        "LogicalResourceId": "DataVolume",
+                        "ResourceType": "AWS::EC2::Volume",
+                        "Replacement": "False",
+                        "Details": [
+                            {
+                                "Target": {
+                                    "Attribute": "Properties",
+                                    "Name": "Size",
+                                    "RequiresRecreation": "Never",
+                                }
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+        proc = subprocess.run(
+            ["python3", str(_GUARD)],
+            input=json.dumps(doc),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        out = json.loads(proc.stdout)
+        self.assertTrue(out["ok"])
+
+    def test_guard_rejects_instance_replacement(self) -> None:
+        doc = {
+            "Changes": [
+                {
+                    "ResourceChange": {
+                        "Action": "Modify",
+                        "LogicalResourceId": "Instance",
+                        "ResourceType": "AWS::EC2::Instance",
+                        "Replacement": "True",
+                        "Details": [],
+                    }
+                }
+            ]
+        }
+        proc = subprocess.run(
+            ["python3", str(_GUARD)],
+            input=json.dumps(doc),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        out = json.loads(proc.stdout)
+        self.assertFalse(out["ok"])
+        self.assertIn("blocked resource", "\n".join(out["violations"]))
+
+    def test_guard_rejects_iops_in_size_only_mode(self) -> None:
+        doc = {
+            "Changes": [
+                {
+                    "ResourceChange": {
+                        "Action": "Modify",
+                        "LogicalResourceId": "DataVolume",
+                        "ResourceType": "AWS::EC2::Volume",
+                        "Replacement": "False",
+                        "Details": [
+                            {
+                                "Target": {
+                                    "Attribute": "Properties",
+                                    "Name": "Iops",
+                                    "RequiresRecreation": "Never",
+                                }
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+        proc = subprocess.run(
+            ["python3", str(_GUARD), "--allowed-properties", "Size"],
+            input=json.dumps(doc),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        out = json.loads(proc.stdout)
+        self.assertFalse(out["ok"])
+        self.assertIn("unexpected property changes ['Iops']", "\n".join(out["violations"]))
+
+    def test_shell_script_parses(self) -> None:
+        proc = subprocess.run(
+            ["bash", "-n", str(_SHELL)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+
+    def test_shell_script_has_no_execute_path(self) -> None:
+        body = _SHELL.read_text(encoding="utf-8")
+        self.assertNotIn("aws cloudformation execute-change-set", body)
+        self.assertNotIn("--execute-approved", body)
+
+    def test_shell_script_uses_previous_template_with_stable_ami(self) -> None:
+        body = _SHELL.read_text(encoding="utf-8")
+        self.assertIn("--use-previous-template", body)
+        self.assertIn("STABLE_AMI_PARAM", body)
+        self.assertIn("DataVolumeSizeGiB", body)
+        self.assertIn('"AmazonLinux2023Arm64Ami": stable_ami_param', body)
+        self.assertIn("--allowed-properties Size", body)
+        self.assertNotIn("--template)", body)
+        self.assertNotIn("--iops", body)
+        self.assertNotIn("--throughput", body)
+        self.assertNotIn("Iops: !Ref DataVolumeIops", body)
+        self.assertNotIn("Throughput: !Ref DataVolumeThroughput", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- 新增 `ops/stage0/reconcile-cfn-datavolume-no-replace.sh`，用 live previous template 生成 no-execute change set，只规划 `DataVolumeSizeGiB=50`。
- 新增 `ops/stage0/cfn_datavolume_changeset_guard.py`，机械拦截 `Instance` / `EIPAssoc` / 其它资源变更，以及 `DataVolume Replacement!=False`。
- README 记录 CFN live drift 的安全边界：IOPS/Throughput 模板所有权收敛当前会牵出 `Instance.UserData` 条件变更，留到维护窗口或 blue/green instance 轮换。
- Review 修复：`--keep-change-set` 只有 guard 通过后才保留 preview 资源；preview change set / SSM 参数清理失败会 fail closed。

## 风险
- PR 本身不执行线上 update-stack / execute-change-set，只增加预览与校验工具。
- 工具默认会删除 no-execute change set 与本次新建的稳定 AMI SSM 参数；`--keep-change-set` 只在已校验通过后保留给人工复核。
- 这次只覆盖 `DataVolume.Size` 的 CFN 参数收敛；不把 IOPS/Throughput 伪装成无替换可执行路径。

## 验证
- `python3 ops/stage0/test_cfn_datavolume_no_replace.py`
- `bash -n ops/stage0/reconcile-cfn-datavolume-no-replace.sh`
- `python3 ops/stage0/cfn_datavolume_changeset_guard.py --selftest`
- `bash ops/stage0/reconcile-cfn-datavolume-no-replace.sh`：线上 no-execute 预览通过，change set 仅包含 `DataVolume Modify AWS::EC2::Volume Replacement=False`，属性为 `Size`；脚本退出后已确认无遗留 `datavolume-*` change set / 稳定 AMI SSM 参数。
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

## 提交
- `90510b54d chore(stage0): guard DataVolume size CFN reconciliation`
- `b42b7cdae fix(stage0): fail closed on DataVolume preview cleanup`
- `4d4070621 fix(stage0): remove silent cleanup swallow in DataVolume preview`

最新提交：`4d4070621`
