### PR TITLE
fix(openai): 流式 capacity/overload 在首 token 前换号 failover

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1231,6 +1231,10 @@ func isOpenAITransientProcessingError(upstreamStatusCode int, upstreamMsg string
 		if strings.Contains(lower, "selected model is at capacity") {
 			return true
 		}
+		if strings.Contains(lower, "server_is_overloaded") ||
+			strings.Contains(lower, "servers are currently overloaded") {
+			return true
+		}
 		return strings.Contains(lower, "you can retry your request") &&
 			strings.Contains(lower, "help.openai.com") &&
 			strings.Contains(lower, "request id")
@@ -3230,6 +3234,10 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			}
 			return wsResult, nil
 		}
+		var wsFailoverErr *UpstreamFailoverError
+		if errors.As(wsErr, &wsFailoverErr) {
+			return nil, wsErr
+		}
 		s.writeOpenAIWSFallbackErrorResponse(c, account, wsErr)
 		return nil, wsErr
 	}
@@ -3984,8 +3992,12 @@ type openaiNonStreamingResultPassthrough struct {
 	imageOutputSizes []string
 }
 
-func openAIStreamClientOutputStarted(c *gin.Context, localStarted bool) bool {
-	if localStarted {
+func openAIStreamFailoverBlockedByClientOutput(firstTokenMs *int) bool {
+	return firstTokenMs != nil
+}
+
+func openAIStreamClientOutputStarted(c *gin.Context, clientOutputStarted bool, firstTokenMs *int) bool {
+	if clientOutputStarted || firstTokenMs != nil {
 		return true
 	}
 	return c != nil && c.Writer != nil && c.Writer.Written()
@@ -4009,6 +4021,21 @@ func openAIStreamDataStartsClientOutput(data, eventType string) bool {
 		return false
 	}
 	return !openAIStreamEventIsPreamble(eventType)
+}
+
+func openAIStreamDataCountsAsFirstToken(eventType string) bool {
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "" || openAIStreamEventIsPreamble(eventType) {
+		return false
+	}
+	switch eventType {
+	case "response.output_item.added", "response.output_item.done", "response.failed":
+		return false
+	}
+	if strings.Contains(eventType, ".delta") {
+		return true
+	}
+	return strings.HasPrefix(eventType, "response.output_text")
 }
 
 func openAIStreamFailedEventShouldFailover(payload []byte, message string) bool {
@@ -4294,12 +4321,12 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 						UpstreamInTok:  usage.InputTokens,
 						UpstreamOutTok: usage.OutputTokens,
 					})
-				} else if !openAIStreamClientOutputStarted(c, clientOutputStarted) && openAIStreamFailedEventShouldFailover(dataBytes, failedMessage) {
+				} else if !openAIStreamFailoverBlockedByClientOutput(firstTokenMs) && openAIStreamFailedEventShouldFailover(dataBytes, failedMessage) {
 					logOpenAIStreamFailedEvent(ctx, c, account, upstreamRequestID, dataBytes, failedMessage, false, true)
 					return resultWithUsage(),
 						s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, dataBytes, failedMessage)
 				} else {
-					logOpenAIStreamFailedEvent(ctx, c, account, upstreamRequestID, dataBytes, failedMessage, openAIStreamClientOutputStarted(c, clientOutputStarted), true)
+					logOpenAIStreamFailedEvent(ctx, c, account, upstreamRequestID, dataBytes, failedMessage, openAIStreamFailoverBlockedByClientOutput(firstTokenMs), true)
 				}
 				forceFlushFailedEvent = true
 				sawFailedEvent = true
@@ -4315,7 +4342,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 			}
 			imageCounter.AddSSEData(dataBytes)
 			lineStartsClientOutput = forceFlushFailedEvent || openAIStreamDataStartsClientOutput(trimmedData, eventType)
-			if firstTokenMs == nil && lineStartsClientOutput && trimmedData != "[DONE]" {
+			if firstTokenMs == nil && openAIStreamDataCountsAsFirstToken(eventType) && trimmedData != "[DONE]" {
 				ms := int(time.Since(startTime).Milliseconds())
 				firstTokenMs = &ms
 			}
@@ -4366,7 +4393,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 			logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] SSE line too long: account=%d max_size=%d error=%v", account.ID, maxLineSize, err)
 			return resultWithUsage(), err
 		}
-		if !openAIStreamClientOutputStarted(c, clientOutputStarted) {
+		if !openAIStreamClientOutputStarted(c, clientOutputStarted, firstTokenMs) {
 			msg := "OpenAI stream disconnected before completion"
 			if errText := strings.TrimSpace(err.Error()); errText != "" {
 				msg += ": " + errText
@@ -4394,7 +4421,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 			zap.Int64("account_id", account.ID),
 			zap.String("upstream_request_id", upstreamRequestID),
 		).Info("OpenAI passthrough 上游流在未收到 [DONE] 时结束，疑似断流")
-		if !openAIStreamClientOutputStarted(c, clientOutputStarted) {
+		if !openAIStreamClientOutputStarted(c, clientOutputStarted, firstTokenMs) {
 			return resultWithUsage(),
 				s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, nil, "OpenAI stream ended before a terminal event")
 		}
@@ -5240,7 +5267,7 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 	}
 	finalizeStream := func() (*openaiStreamingResult, error) {
 		if !sawTerminalEvent {
-			if !openAIStreamClientOutputStarted(c, clientOutputStarted) {
+			if !openAIStreamClientOutputStarted(c, clientOutputStarted, firstTokenMs) {
 				return resultWithUsage(), s.newOpenAIStreamFailoverError(
 					c,
 					account,
@@ -5288,7 +5315,7 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 			sendErrorEvent("response_too_large")
 			return resultWithUsage(), scanErr, true
 		}
-		if !openAIStreamClientOutputStarted(c, clientOutputStarted) {
+		if !openAIStreamClientOutputStarted(c, clientOutputStarted, firstTokenMs) {
 			msg := "OpenAI stream disconnected before completion"
 			if errText := strings.TrimSpace(scanErr.Error()); errText != "" {
 				msg += ": " + errText
@@ -5348,13 +5375,13 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 						UpstreamInTok:  usage.InputTokens,
 						UpstreamOutTok: usage.OutputTokens,
 					})
-				} else if !openAIStreamClientOutputStarted(c, clientOutputStarted) && openAIStreamFailedEventShouldFailover(dataBytes, failedMessage) {
+				} else if !openAIStreamFailoverBlockedByClientOutput(firstTokenMs) && openAIStreamFailedEventShouldFailover(dataBytes, failedMessage) {
 					logOpenAIStreamFailedEvent(ctx, c, account, upstreamRequestID, dataBytes, failedMessage, false, false)
 					sawFailedEvent = true
 					streamFailoverErr = s.newOpenAIStreamFailoverError(c, account, false, upstreamRequestID, dataBytes, failedMessage)
 					return
 				} else {
-					logOpenAIStreamFailedEvent(ctx, c, account, upstreamRequestID, dataBytes, failedMessage, openAIStreamClientOutputStarted(c, clientOutputStarted), false)
+					logOpenAIStreamFailedEvent(ctx, c, account, upstreamRequestID, dataBytes, failedMessage, openAIStreamFailoverBlockedByClientOutput(firstTokenMs), false)
 				}
 				forceFlushFailedEvent = true
 				sawFailedEvent = true
@@ -5393,7 +5420,7 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 			// 写入客户端（客户端断开后继续 drain 上游）
 			if !clientDisconnected {
 				shouldFlush := queueDrained && (clientOutputStarted || startsClientOutput)
-				if firstTokenMs == nil && startsClientOutput {
+				if firstTokenMs == nil && openAIStreamDataCountsAsFirstToken(eventType) {
 					// 保证首个 token 事件尽快出站，避免影响 TTFT。
 					shouldFlush = true
 				}
@@ -5415,7 +5442,7 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 			}
 
 			// Record first token time
-			if firstTokenMs == nil && startsClientOutput {
+			if firstTokenMs == nil && openAIStreamDataCountsAsFirstToken(eventType) {
 				ms := int(time.Since(startTime).Milliseconds())
 				firstTokenMs = &ms
 			}

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1365,6 +1365,97 @@ func TestOpenAIStreamingResponseFailedBeforeOutputCapacityErrorReturnsFailover(t
 	require.Empty(t, rec.Body.String())
 }
 
+func TestOpenAIStreamingResponseFailedAfterKeepaliveStillFailovers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			StreamDataIntervalTimeout: 0,
+			StreamKeepaliveInterval:   1,
+			MaxLineSize:               defaultMaxLineSize,
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	pr, pw := io.Pipe()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       pr,
+		Header:     http.Header{"X-Request-Id": []string{"rid-capacity-after-keepalive"}},
+	}
+
+	go func() {
+		defer func() { _ = pw.Close() }()
+		_, _ = pw.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\n\n"))
+		time.Sleep(1200 * time.Millisecond)
+		_, _ = pw.Write([]byte(`data: {"type":"response.failed","response":{"error":{"type":"server_error","code":"model_capacity","message":"Selected model is at capacity. Please try a different model."}}}` + "\n\n"))
+	}()
+
+	_, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Name: "acc"}, time.Now(), "model", "model")
+	_ = pr.Close()
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Contains(t, string(failoverErr.ResponseBody), "Selected model is at capacity")
+	require.NotContains(t, rec.Body.String(), "Selected model is at capacity")
+}
+
+func TestOpenAIStreamingResponseFailedAfterOutputItemAddedStillFailovers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			StreamDataIntervalTimeout: 0,
+			StreamKeepaliveInterval:   0,
+			MaxLineSize:               defaultMaxLineSize,
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: response.created",
+			`data: {"type":"response.created","response":{"id":"resp_1"}}`,
+			"",
+			"event: response.output_item.added",
+			`data: {"type":"response.output_item.added","response":{"id":"resp_1"}}`,
+			"",
+			"event: response.failed",
+			`data: {"type":"response.failed","response":{"error":{"type":"server_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}}}`,
+			"",
+		}, "\n"))),
+		Header: http.Header{"X-Request-Id": []string{"rid-overload-after-structural"}},
+	}
+
+	_, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Name: "acc"}, time.Now(), "model", "model")
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Contains(t, string(failoverErr.ResponseBody), "servers are currently overloaded")
+	require.NotContains(t, rec.Body.String(), "servers are currently overloaded")
+}
+
+func TestOpenAIStreamFailoverBlockedByClientOutput_UsesFirstTokenOnly(t *testing.T) {
+	require.False(t, openAIStreamFailoverBlockedByClientOutput(nil))
+	ms := 1
+	require.True(t, openAIStreamFailoverBlockedByClientOutput(&ms))
+}
+
+func TestIsOpenAITransientProcessingError_ServerOverloaded(t *testing.T) {
+	require.True(t, isOpenAITransientProcessingError(
+		http.StatusBadRequest,
+		"Our servers are currently overloaded. Please try again later.",
+		[]byte(`{"error":{"type":"invalid_request_error","code":"server_is_overloaded"}}`),
+	))
+}
+
 func TestOpenAIStreamingPreambleOnlyMissingTerminalReturnsFailover(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1456,6 +1456,45 @@ func TestIsOpenAITransientProcessingError_ServerOverloaded(t *testing.T) {
 	))
 }
 
+func TestOpenAIStreamingResponseFailedAfterRealTokenDoesNotFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			StreamDataIntervalTimeout: 0,
+			StreamKeepaliveInterval:   0,
+			MaxLineSize:               defaultMaxLineSize,
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: response.created",
+			`data: {"type":"response.created","response":{"id":"resp_1"}}`,
+			"",
+			"event: response.output_text.delta",
+			`data: {"type":"response.output_text.delta","delta":"hi"}`,
+			"",
+			"event: response.failed",
+			`data: {"type":"response.failed","response":{"error":{"type":"server_error","code":"model_capacity","message":"Selected model is at capacity. Please try a different model."}}}`,
+			"",
+		}, "\n"))),
+		Header: http.Header{"X-Request-Id": []string{"rid-capacity-after-token"}},
+	}
+
+	_, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Name: "acc"}, time.Now(), "model", "model")
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.Contains(t, err.Error(), "upstream response failed")
+	require.Contains(t, rec.Body.String(), "Selected model is at capacity")
+}
+
 func TestOpenAIStreamingPreambleOnlyMissingTerminalReturnsFailover(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -2238,6 +2238,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		imageCounter.AddSSEData(message)
 
 		if eventType == "response.failed" {
+			failedMessage := extractOpenAISSEErrorMessage(message)
 			if hit, code, msg := detectOpenAICyberPolicy(message); hit {
 				MarkOpsCyberPolicy(c, CyberPolicyMark{
 					Code:           code,
@@ -2247,6 +2248,18 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 					UpstreamInTok:  usage.InputTokens,
 					UpstreamOutTok: usage.OutputTokens,
 				})
+			} else if firstTokenMs == nil && openAIStreamFailedEventShouldFailover(message, failedMessage) {
+				lease.MarkBroken()
+				parseOpenAIWSResponseUsageFromCompletedEvent(message, usage)
+				logOpenAIStreamFailedEvent(ctx, c, account, strings.TrimSpace(lease.HandshakeHeaders().Get("x-request-id")), message, failedMessage, false, false)
+				return nil, s.newOpenAIStreamFailoverError(
+					c,
+					account,
+					false,
+					strings.TrimSpace(lease.HandshakeHeaders().Get("x-request-id")),
+					message,
+					failedMessage,
+				)
 			}
 		}
 
@@ -3225,6 +3238,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			imageCounter.AddSSEData(upstreamMessage)
 
 			if eventType == "response.failed" {
+				failedMessage := extractOpenAISSEErrorMessage(upstreamMessage)
 				if hit, code, msg := detectOpenAICyberPolicy(upstreamMessage); hit {
 					MarkOpsCyberPolicy(c, CyberPolicyMark{
 						Code:           code,
@@ -3234,6 +3248,17 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 						UpstreamInTok:  usage.InputTokens,
 						UpstreamOutTok: usage.OutputTokens,
 					})
+				} else if firstTokenMs == nil && openAIStreamFailedEventShouldFailover(upstreamMessage, failedMessage) {
+					lease.MarkBroken()
+					logOpenAIStreamFailedEvent(ctx, c, account, strings.TrimSpace(lease.HandshakeHeaders().Get("x-request-id")), upstreamMessage, failedMessage, false, false)
+					return nil, s.newOpenAIStreamFailoverError(
+						c,
+						account,
+						false,
+						strings.TrimSpace(lease.HandshakeHeaders().Get("x-request-id")),
+						upstreamMessage,
+						failedMessage,
+					)
 				}
 			}
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3340,6 +3340,31 @@
         "if !s.isAccountSchedulableForOpenAIWindow(ctx, account, true) {"
       ],
       "rationale": "PR #902 coverage parity: the window-sched tri-state guard now gates the previous_response_id chain (SelectAccountByPreviousResponseID) too, replacing the retired auto-pause that used to gate this path. isSticky=true keeps a StickyOnly account's chain, only a NotSchedulable account yields. If an upstream merge drops this line the prev-response path loses window coverage silently. Anchor pins the injection."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "openAIStreamFailoverBlockedByClientOutput(firstTokenMs)",
+        "openAIStreamDataCountsAsFirstToken(eventType)",
+        "server_is_overloaded"
+      ],
+      "rationale": "PR #1001: OpenAI Responses stream failover on response.failed must gate only on real first-token timing (firstTokenMs), not structural SSE events like response.output_item.added. server_is_overloaded must stay in the transient/capacity classifier so pre-token capacity failures fail over instead of forwarding to the client. Upstream merges of openai_gateway_service.go can silently restore clientOutputStarted gating and drop the overload markers while older happy-path tests still pass."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service_test.go",
+      "must_contain": [
+        "TestOpenAIStreamingResponseFailedAfterOutputItemAddedStillFailovers",
+        "TestOpenAIStreamingResponseFailedAfterRealTokenDoesNotFailover",
+        "TestOpenAIStreamFailoverBlockedByClientOutput_UsesFirstTokenOnly"
+      ],
+      "rationale": "PR #1001 regression anchors: structural output_item.added before response.failed must still fail over; real output_text.delta before response.failed must not; helper openAIStreamFailoverBlockedByClientOutput must remain firstTokenMs-only. Without pinning these tests, an upstream merge conflict can drop the focused cases and reintroduce the prod 1.8.42 failover_eligible-without-failover_candidate pattern."
+    },
+    {
+      "path": "backend/internal/service/openai_ws_forwarder.go",
+      "must_contain": [
+        "firstTokenMs == nil && openAIStreamFailedEventShouldFailover"
+      ],
+      "rationale": "PR #1001: WS Responses paths (forwardOpenAIWSV2 + ProxyResponsesWebSocketFromClient) must surface UpstreamFailoverError on pre-token response.failed transient/capacity errors instead of forwarding to the client. Losing this branch reverts WS to the HTTP/SSE bug class fixed in #1001."
     }
   ]
 }


### PR DESCRIPTION
## 摘要

1.8.42 生产日志显示：`POST /responses` 流式 `response.failed` 大量出现 `failover_eligible=true` 但 `failover_possible=false`（近 12h `forwarded_to_client=21`、`failover_candidate=0`），错误被直接转发给客户端而非换号。

- HTTP/SSE：`response.failed` 的换号门槛改为 **仅当已有真实首 token（firstTokenMs）** 才禁止 failover；结构性事件（如 `output_item.added`）不再误占首 token。
- 将 `server_is_overloaded` / overload 文案纳入 transient 识别，与 capacity 同类处理。
- WS：在无 token 的 `response.failed` 上返回 `UpstreamFailoverError`；Forward 路径直接上抛该错误以触发 handler 换号。
- 补 `gateway-tk.json` sentinel 锚点 + 首 token 后禁止 failover 的负向回归测试。
- rebase 到当前 `main`，修复 Main Ancestry Guard。

sentinel-registry-reviewed：新增 gateway-tk 语义锚点（firstTokenMs failover gate + WS response.failed + 回归测试名）。

## 风险

- 常规风险：行为变更限于 OpenAI `/responses` 流式与 WS 的早期失败路径；真实 token 已输出后仍不换号（与原先「中途不可 failover」一致）。
- 若池内所有账号同时 overload，用户仍可能看到上游错误，但应减少「单账号满了却直透客户端」的情况。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service -run 'TestOpenAIStreamingResponseFailed|TestOpenAIStreamFailover|TestIsOpenAITransientProcessingError_ServerOverloaded|TestOpenAIStreamingResponseFailedAfterRealToken' -count=1
PREFLIGHT_BASE=origin/main bash scripts/preflight.sh
```

- 上述单测与 preflight 均已本地通过。
- 生产 before 证据（1.8.42）：`tokenkey-green` 近 12h `openai.stream_failed_event.forwarded_to_client` 样本含 `client_output_started=true`、`failover_eligible=true`、`error_code=server_is_overloaded`。
- after 需发版后观察：`failover_candidate` 计数、用户侧 capacity/overload 弹窗是否下降。

## 提交

- 11b539d72 fix(openai): failover on pre-token response.failed capacity/overload
- 841c4f796 fix(openai): pin pre-token failover sentinels and post-token regression

最新提交：841c4f796
