### PR TITLE
feat(gateway): OpenAI/Anthropic 429 冷却 clamp 默认上限改为 5h

### DIFF
--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -480,8 +480,11 @@ grep -Fc 'gateway_usage.cost_calculation_failed_record_zero_cost' /tmp/tk.log   
 grep -Fc 'openai_implicit_throttle_cooldown_applied' /tmp/tk.log
 grep -Fc 'openai_implicit_throttle_cooldown_failed'  /tmp/tk.log    # SetTempUnschedulable 失败，应为 0
 
-# #1981 限流 reset 钳制（opt-in；默认关 → 应为 0）。命中时确认被钳的原始 reset 确是超长窗口。
+# #1981 限流 reset 钳制（DEFAULT-ON；未显式设 0 即生效，默认 ceiling 18000s/5h）。
+#        marker 仅在超长 upstream reset 被截断时出现；不能用 marker=0 推断「仍关闭」。
 grep -F 'openai_rate_limit_reset_clamped' /tmp/tk.log \
+  | grep -oE '"original_reset":"[^"]*"' | head
+grep -F 'anthropic_rate_limit_reset_clamped' /tmp/tk.log \
   | grep -oE '"original_reset":"[^"]*"' | head
 ```
 
@@ -492,9 +495,10 @@ grep -F 'openai_rate_limit_reset_clamped' /tmp/tk.log \
 | **#1934** sticky 切组 | 复用既有 sticky 删除路径，无新行 | OpenAI/newapi sticky failover 率 / `decision.Layer` 分布有无异常上升（§5 parse-access-log by-minute）；预期几乎无变化（仅平台 openai/newapi，不碰 Anthropic） |
 | **#1946** 监控 thinking-block | 提取层改动，无新行 | Anthropic 渠道监控「测试失败」误报是否下降（渠道监控结果 / ops_error_logs 里 challenge mismatch 计数应降） |
 
-opt-in 开关确认（这批默认关，部署后未显式配置则应保持关）：
+opt-in 开关确认（仅 #2727 默认关；#1981 clamp 为 DEFAULT-ON，见上节 grep）：
 
-- `#2727` `tk_openai_implicit_throttle_cooldown_seconds`、`#1981` `tk_openai_max_rate_limit_cooldown_seconds`：上面两组 marker 计数为 0 即证明仍默认关；要启用先设对应 SettingKey 再复查 marker 出现。
+- `#2727` `tk_openai_implicit_throttle_cooldown_seconds`：上面 marker 计数为 0 即证明仍默认关；要启用先设 SettingKey 再复查 marker 出现。
+- `#1981` `tk_openai_max_rate_limit_cooldown_seconds` / `tk_anthropic_max_rate_limit_cooldown_seconds`：未写入 settings 或非法值时走代码默认 18000s；显式 `"0"` 关闭 clamp。DB 显式值（如 `"3600"`）优先于代码默认。
 
 > 按 §0「配置收敛≠线上稳定」：marker 计数只证明代码路径被走到，真实稳定仍需对照 final `status_code`、503 率、账号可调度数（§4 / §5 / §6）。本节 marker 串以 `backend/internal/service/*` 的 `slog`/`zap` 调用为 ground truth；改了日志文案需同步本节。
 

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -171,9 +171,9 @@ const (
 
 	// SettingKeyOpenAIMaxRateLimitCooldownSeconds caps how long an OpenAI-compat
 	// (OpenAI + NewAPI) account may stay rate-limited from a single upstream
-	// window-exhaustion 429 reset. DEFAULT-ON (ceiling 3600s), in lockstep with
+	// window-exhaustion 429 reset. DEFAULT-ON (ceiling 18000s / 5h), in lockstep with
 	// SettingKeyAnthropicMaxRateLimitCooldownSeconds: unset / blank / non-numeric
-	// / negative → 3600; an explicit "0" disables it (trust the upstream reset
+	// / negative → 18000; an explicit "0" disables it (trust the upstream reset
 	// verbatim). An upstream reset farther out than the ceiling (e.g. a 7-day
 	// window-exhaustion reset) is clamped to now+ceiling so the account re-enters
 	// the pool and is re-probed by natural request traffic instead of sitting idle
@@ -186,7 +186,7 @@ const (
 	// account may stay rate-limited from a single upstream unified-window (5h/7d)
 	// 429 reset. Unlike its OpenAI twin this is DEFAULT-ON: when unset / blank /
 	// non-numeric / negative it falls back to defaultAnthropicMaxRateLimitCooldownSeconds
-	// (3600s). An explicit "0" disables it (trust the upstream reset verbatim).
+	// (18000s / 5h). An explicit "0" disables it (trust the upstream reset verbatim).
 	//
 	// Rationale (prod 2026-06, edge-us6 account oh-3-a): Anthropic's unified 7d
 	// window is rolling — utilization that was >=1.0 at the moment of the 429

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -1645,8 +1645,9 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 		persistOpenAI429PlanType(ctx, s.accountRepo, account, responseBody)
 		s.persistOpenAICodexSnapshot(ctx, account, headers)
 		if resetAt := s.calculateOpenAI429ResetTime(headers); resetAt != nil {
-			// TK (upstream#1981): opt-in clamp of long upstream resets (e.g. 7d
-			// window exhaustion) so released accounts are not idled. Default OFF.
+			// TK (upstream#1981): DEFAULT-ON clamp of long upstream resets (e.g. 7d
+			// window exhaustion); ceiling from SettingKeyOpenAIMaxRateLimitCooldownSeconds
+			// (default 18000s / 5h). Explicit "0" disables and trusts upstream reset.
 			clamped := s.tkClampOpenAIRateLimitReset(ctx, account.ID, *resetAt)
 			s.notifyAccountSchedulingBlocked(account, clamped, "429")
 			if err := s.accountRepo.SetRateLimited(ctx, account.ID, clamped); err != nil {
@@ -1715,7 +1716,7 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 				if len(requestedModel) > 0 && s.tkTryOpenAICodexModelScopedCooldown(ctx, account, requestedModel[0], resetTime) {
 					return true
 				}
-				// TK (upstream#1981): opt-in clamp (default OFF) — see header path above.
+				// TK (upstream#1981): DEFAULT-ON clamp — see header path above.
 				resetTime = s.tkClampOpenAIRateLimitReset(ctx, account.ID, resetTime)
 				s.notifyAccountSchedulingBlocked(account, resetTime, "429")
 				if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetTime); err != nil {

--- a/backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp.go
@@ -18,10 +18,10 @@ const defaultAnthropicMaxRateLimitCooldownSeconds = 18000
 // an Anthropic account may stay rate-limited from a single upstream unified-window
 // 429 reset.
 //
-// Unlike its OpenAI twin (OpenAIMaxRateLimitCooldownSeconds, default-off), this is
-// DEFAULT-ON: an unset / blank / non-numeric / negative value falls back to
-// defaultAnthropicMaxRateLimitCooldownSeconds. Only an explicit, non-negative
-// integer overrides it; "0" disables clamping.
+// Unlike its OpenAI twin (OpenAIMaxRateLimitCooldownSeconds), this is DEFAULT-ON
+// with the same default ceiling (18000s / 5h): an unset / blank / non-numeric /
+// negative value falls back to defaultAnthropicMaxRateLimitCooldownSeconds. Only
+// an explicit, non-negative integer overrides it; "0" disables clamping.
 //
 // TK (sibling of upstream Wei-Shaw/sub2api#1981; see
 // ratelimit_service_tk_anthropic_reset_clamp.go package doc).

--- a/backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp.go
@@ -8,11 +8,11 @@ import (
 	"time"
 )
 
-// defaultAnthropicMaxRateLimitCooldownSeconds is the DEFAULT-ON ceiling (1h)
+// defaultAnthropicMaxRateLimitCooldownSeconds is the DEFAULT-ON ceiling (5h)
 // applied to Anthropic unified-window (5h/7d) 429 cooldowns when the operator
 // has not configured SettingKeyAnthropicMaxRateLimitCooldownSeconds. An explicit
 // "0" disables clamping (trust the upstream reset verbatim).
-const defaultAnthropicMaxRateLimitCooldownSeconds = 3600
+const defaultAnthropicMaxRateLimitCooldownSeconds = 18000
 
 // AnthropicMaxRateLimitCooldownSeconds returns the ceiling (seconds) for how long
 // an Anthropic account may stay rate-limited from a single upstream unified-window

--- a/backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp_test.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp_test.go
@@ -22,24 +22,24 @@ func settingServiceWithAnthropicMaxCooldown(val string) *SettingService {
 }
 
 // Unlike the OpenAI twin this is DEFAULT-ON: unset/blank/malformed/negative all
-// fall back to 3600 (the safety default), and only an explicit "0" disables it.
+// fall back to 18000 (the safety default), and only an explicit "0" disables it.
 func TestAnthropicMaxRateLimitCooldownSeconds(t *testing.T) {
 	ctx := context.Background()
-	require.Equal(t, 3600, settingServiceWithAnthropicMaxCooldown("").AnthropicMaxRateLimitCooldownSeconds(ctx), "unset => default ON 3600")
-	require.Equal(t, 3600, settingServiceWithAnthropicMaxCooldown("-1").AnthropicMaxRateLimitCooldownSeconds(ctx), "negative => default, never silently disable")
-	require.Equal(t, 3600, settingServiceWithAnthropicMaxCooldown("nope").AnthropicMaxRateLimitCooldownSeconds(ctx), "malformed => default, never silently disable")
+	require.Equal(t, 18000, settingServiceWithAnthropicMaxCooldown("").AnthropicMaxRateLimitCooldownSeconds(ctx), "unset => default ON 18000")
+	require.Equal(t, 18000, settingServiceWithAnthropicMaxCooldown("-1").AnthropicMaxRateLimitCooldownSeconds(ctx), "negative => default, never silently disable")
+	require.Equal(t, 18000, settingServiceWithAnthropicMaxCooldown("nope").AnthropicMaxRateLimitCooldownSeconds(ctx), "malformed => default, never silently disable")
 	require.Equal(t, 0, settingServiceWithAnthropicMaxCooldown("0").AnthropicMaxRateLimitCooldownSeconds(ctx), "explicit 0 => disabled")
-	require.Equal(t, 1800, settingServiceWithAnthropicMaxCooldown("1800").AnthropicMaxRateLimitCooldownSeconds(ctx), "explicit positive override")
+	require.Equal(t, 3600, settingServiceWithAnthropicMaxCooldown("3600").AnthropicMaxRateLimitCooldownSeconds(ctx), "explicit positive override")
 }
 
 func TestTkClampAnthropicWindowReset(t *testing.T) {
 	ctx := context.Background()
 	sevenDays := time.Now().Add(7 * 24 * time.Hour)
 
-	t.Run("default-on clamps a far-future reset to now+1h", func(t *testing.T) {
+	t.Run("default-on clamps a far-future reset to now+5h", func(t *testing.T) {
 		svc := &RateLimitService{settingService: settingServiceWithAnthropicMaxCooldown("")}
 		got := svc.tkClampAnthropicWindowReset(ctx, 1, sevenDays)
-		require.WithinDuration(t, time.Now().Add(time.Hour), got, 2*time.Second, "default-on must clamp a 7d reset to now+1h")
+		require.WithinDuration(t, time.Now().Add(5*time.Hour), got, 2*time.Second, "default-on must clamp a 7d reset to now+5h")
 	})
 
 	t.Run("explicit 0 disables, returns reset verbatim", func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestTkClampAnthropicWindowReset(t *testing.T) {
 	})
 
 	t.Run("near reset within ceiling is preserved", func(t *testing.T) {
-		svc := &RateLimitService{settingService: settingServiceWithAnthropicMaxCooldown("3600")}
+		svc := &RateLimitService{settingService: settingServiceWithAnthropicMaxCooldown("18000")}
 		near := time.Now().Add(5 * time.Minute)
 		got := svc.tkClampAnthropicWindowReset(ctx, 1, near)
 		require.WithinDuration(t, near, got, time.Second, "a reset within the ceiling must be preserved")
@@ -99,7 +99,7 @@ func (r *anthropicClampRepoStub) UpdateSessionWindow(_ context.Context, _ int64,
 func TestPersistAnthropicExhaustedWindowLimit_ClampsSchedulingNotGauge(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("7d window: scheduling reset clamped to now+1h", func(t *testing.T) {
+	t.Run("7d window: scheduling reset clamped to now+5h", func(t *testing.T) {
 		repo := &anthropicClampRepoStub{}
 		svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
 		svc.SetSettingService(settingServiceWithAnthropicMaxCooldown("")) // default-on
@@ -113,8 +113,8 @@ func TestPersistAnthropicExhaustedWindowLimit_ClampsSchedulingNotGauge(t *testin
 		require.True(t, svc.persistAnthropicExhaustedWindowLimit(ctx, account, headers))
 
 		require.Equal(t, 1, repo.rateLimitCalls)
-		require.WithinDuration(t, time.Now().Add(time.Hour), repo.rateLimitReset, 2*time.Second, "scheduling cooldown must be clamped to now+1h, not the 3d upstream reset")
-		require.True(t, repo.rateLimitReset.Before(original.Add(-time.Hour)), "clamped reset must be well before the upstream 3d reset")
+		require.WithinDuration(t, time.Now().Add(5*time.Hour), repo.rateLimitReset, 2*time.Second, "scheduling cooldown must be clamped to now+5h, not the 3d upstream reset")
+		require.True(t, repo.rateLimitReset.Before(original.Add(-5*time.Hour)), "clamped reset must be well before the upstream 3d reset")
 		require.Zero(t, repo.sessionCalls, "7d window does not touch the 5h session gauge")
 	})
 
@@ -123,7 +123,7 @@ func TestPersistAnthropicExhaustedWindowLimit_ClampsSchedulingNotGauge(t *testin
 		svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
 		svc.SetSettingService(settingServiceWithAnthropicMaxCooldown("")) // default-on
 
-		originalEnd := time.Now().Add(4 * time.Hour) // > 1h ceiling, within 6h max-age
+		originalEnd := time.Now().Add(6 * time.Hour) // > 5h ceiling, within 6h max-age
 		headers := http.Header{}
 		headers.Set("anthropic-ratelimit-unified-5h-status", "rejected")
 		headers.Set("anthropic-ratelimit-unified-5h-reset", strconv.FormatInt(originalEnd.Unix(), 10))
@@ -132,7 +132,7 @@ func TestPersistAnthropicExhaustedWindowLimit_ClampsSchedulingNotGauge(t *testin
 		require.True(t, svc.persistAnthropicExhaustedWindowLimit(ctx, account, headers))
 
 		require.Equal(t, 1, repo.rateLimitCalls)
-		require.WithinDuration(t, time.Now().Add(time.Hour), repo.rateLimitReset, 2*time.Second, "scheduling cooldown clamped to now+1h")
+		require.WithinDuration(t, time.Now().Add(5*time.Hour), repo.rateLimitReset, 2*time.Second, "scheduling cooldown clamped to now+5h")
 		require.Equal(t, 1, repo.sessionCalls)
 		require.WithinDuration(t, originalEnd, repo.sessionWindowEnd, 2*time.Second, "usage gauge window-end must stay at the ORIGINAL upstream 5h reset, not the clamp")
 	})

--- a/backend/internal/service/ratelimit_service_tk_openai_reset_clamp.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_reset_clamp.go
@@ -8,12 +8,12 @@ import (
 	"time"
 )
 
-// defaultOpenAIMaxRateLimitCooldownSeconds is the DEFAULT-ON ceiling (1h) applied
+// defaultOpenAIMaxRateLimitCooldownSeconds is the DEFAULT-ON ceiling (5h) applied
 // to OpenAI-compat (OpenAI + NewAPI) window-exhaustion 429 cooldowns when the
 // operator has not configured SettingKeyOpenAIMaxRateLimitCooldownSeconds. An
 // explicit "0" disables clamping (trust the upstream reset verbatim). Kept in
 // lockstep with defaultAnthropicMaxRateLimitCooldownSeconds.
-const defaultOpenAIMaxRateLimitCooldownSeconds = 3600
+const defaultOpenAIMaxRateLimitCooldownSeconds = 18000
 
 // OpenAIMaxRateLimitCooldownSeconds returns the ceiling (seconds) for how long an
 // OpenAI-compat account may stay rate-limited from a single upstream window 429
@@ -56,7 +56,7 @@ func (s *SettingService) OpenAIMaxRateLimitCooldownSeconds(ctx context.Context) 
 // accounts" / 503 despite spare capacity. Clamping lets the account re-enter the
 // pool after the ceiling so live traffic re-probes it (a fresh 429 re-cools it).
 // This is "traffic as the probe" — no separate background prober, no extra
-// upstream cost. Default-on (ceiling 1h) for parity with the Anthropic clamp;
+// upstream cost. Default-on (ceiling 5h) for parity with the Anthropic clamp;
 // set the ceiling to 0 to disable and trust the upstream reset verbatim.
 func (s *RateLimitService) tkClampOpenAIRateLimitReset(ctx context.Context, accountID int64, resetAt time.Time) time.Time {
 	if s == nil || s.settingService == nil {

--- a/backend/internal/service/ratelimit_service_tk_openai_reset_clamp_test.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_reset_clamp_test.go
@@ -20,14 +20,14 @@ func settingServiceWithMaxCooldown(val string) *SettingService {
 }
 
 // DEFAULT-ON (flipped for parity with the Anthropic clamp): unset/blank/malformed/
-// negative fall back to 3600; only an explicit "0" disables it.
+// negative fall back to 18000; only an explicit "0" disables it.
 func TestOpenAIMaxRateLimitCooldownSeconds(t *testing.T) {
 	ctx := context.Background()
-	require.Equal(t, 3600, settingServiceWithMaxCooldown("").OpenAIMaxRateLimitCooldownSeconds(ctx), "unset => default ON 3600")
-	require.Equal(t, 3600, settingServiceWithMaxCooldown("-1").OpenAIMaxRateLimitCooldownSeconds(ctx), "negative => default, never silently disable")
-	require.Equal(t, 3600, settingServiceWithMaxCooldown("nope").OpenAIMaxRateLimitCooldownSeconds(ctx), "malformed => default, never silently disable")
+	require.Equal(t, 18000, settingServiceWithMaxCooldown("").OpenAIMaxRateLimitCooldownSeconds(ctx), "unset => default ON 18000")
+	require.Equal(t, 18000, settingServiceWithMaxCooldown("-1").OpenAIMaxRateLimitCooldownSeconds(ctx), "negative => default, never silently disable")
+	require.Equal(t, 18000, settingServiceWithMaxCooldown("nope").OpenAIMaxRateLimitCooldownSeconds(ctx), "malformed => default, never silently disable")
 	require.Equal(t, 0, settingServiceWithMaxCooldown("0").OpenAIMaxRateLimitCooldownSeconds(ctx), "explicit 0 => disabled")
-	require.Equal(t, 1800, settingServiceWithMaxCooldown("1800").OpenAIMaxRateLimitCooldownSeconds(ctx), "explicit positive override")
+	require.Equal(t, 3600, settingServiceWithMaxCooldown("3600").OpenAIMaxRateLimitCooldownSeconds(ctx), "explicit positive override")
 }
 
 // upstream Wei-Shaw/sub2api#1981: opt-in clamp of long upstream resets.
@@ -41,14 +41,14 @@ func TestTkClampOpenAIRateLimitReset(t *testing.T) {
 		require.WithinDuration(t, sevenDays, got, time.Second, "explicit 0 must trust the upstream reset verbatim")
 	})
 
-	t.Run("default-on clamps a far-future reset to now+1h", func(t *testing.T) {
+	t.Run("default-on clamps a far-future reset to now+5h", func(t *testing.T) {
 		svc := &RateLimitService{settingService: settingServiceWithMaxCooldown("")}
 		got := svc.tkClampOpenAIRateLimitReset(ctx, 1, sevenDays)
-		require.WithinDuration(t, time.Now().Add(time.Hour), got, 2*time.Second, "default-on must clamp a 7d reset to now+1h")
+		require.WithinDuration(t, time.Now().Add(5*time.Hour), got, 2*time.Second, "default-on must clamp a 7d reset to now+5h")
 	})
 
 	t.Run("enabled leaves a near reset untouched", func(t *testing.T) {
-		svc := &RateLimitService{settingService: settingServiceWithMaxCooldown("3600")}
+		svc := &RateLimitService{settingService: settingServiceWithMaxCooldown("18000")}
 		near := time.Now().Add(5 * time.Minute)
 		got := svc.tkClampOpenAIRateLimitReset(ctx, 1, near)
 		require.WithinDuration(t, near, got, time.Second, "a reset within the ceiling must be preserved")

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1443,18 +1443,18 @@
       "must_contain": [
         "func (s *RateLimitService) tkClampOpenAIRateLimitReset",
         "SettingKeyOpenAIMaxRateLimitCooldownSeconds",
-        "defaultOpenAIMaxRateLimitCooldownSeconds = 3600"
+        "defaultOpenAIMaxRateLimitCooldownSeconds = 18000"
       ],
-      "rationale": "TK#1981: default-ON (ceiling 1h, flipped for parity with the Anthropic clamp) clamp of long OpenAI/NewAPI window-exhaustion 429 reset windows. Guards the capability — and its default-on ceiling — against silent upstream-merge deletion or a default flip back to OFF."
+      "rationale": "TK#1981: default-ON (ceiling 5h, flipped for parity with the Anthropic clamp) clamp of long OpenAI/NewAPI window-exhaustion 429 reset windows. Guards the capability — and its default-on ceiling — against silent upstream-merge deletion or a default flip back to OFF."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_anthropic_reset_clamp.go",
       "must_contain": [
         "func (s *RateLimitService) tkClampAnthropicWindowReset",
         "SettingKeyAnthropicMaxRateLimitCooldownSeconds",
-        "defaultAnthropicMaxRateLimitCooldownSeconds = 3600"
+        "defaultAnthropicMaxRateLimitCooldownSeconds = 18000"
       ],
-      "rationale": "TK (sibling of #1981, default-ON ceiling 1h): clamp of long Anthropic unified 5h/7d 429 reset windows. Anthropic's 7d window is rolling, so the upstream reset (a conservative weekly boundary) far outlives the account's actual recovery; without the clamp a recovered account is benched for days (prod 2026-06 edge-us6 oh-3-a). Guards the capability — and its default-on ceiling — against silent upstream-merge deletion or a default flip back to OFF."
+      "rationale": "TK (sibling of #1981, default-ON ceiling 5h): clamp of long Anthropic unified 5h/7d 429 reset windows. Anthropic's 7d window is rolling, so the upstream reset (a conservative weekly boundary) far outlives the account's actual recovery; without the clamp a recovered account is benched for days (prod 2026-06 edge-us6 oh-3-a). Guards the capability — and its default-on ceiling — against silent upstream-merge deletion or a default flip back to OFF."
     },
     {
       "path": "backend/internal/service/openai_gateway_tk_failover_encrypted_reasoning.go",


### PR DESCRIPTION
## 摘要

- 将 `tk_openai_max_rate_limit_cooldown_seconds` 与 `tk_anthropic_max_rate_limit_cooldown_seconds` 的**代码默认上限**从 3600s（1h）改为 18000s（5h）。
- 上游 5h/7d 窗口打满后，调度冷却仍会被 clamp；未显式写入 settings 的部署自动生效，显式 `"0"` 仍可关闭 clamp。
- 同步更新单元测试、`gateway-tk.json` sentinel，以及 review 指出的 clamp 文档/skill 漂移。

## 风险

- 用量打满后账号回到调度池的时间从约 1h 延长到约 5h，窗口未恢复前仍可能 429，但减少过早复探带来的无效 failover。
- 若某环境已在 `settings` 表显式写入 `3600`，该值继续优先于新默认；仅 unset/blank/非法值走 18000。
- 无 Web/API 契约变更（`Web impact: none`）。

## 验证

- `go test -tags=unit ./internal/service -run 'TestOpenAIMaxRateLimitCooldownSeconds|TestTkClampOpenAIRateLimitReset|TestAnthropicMaxRateLimitCooldownSeconds|TestTkClampAnthropicWindowReset|TestPersistAnthropicExhaustedWindowLimit_ClampsSchedulingNotGauge' -count=1` — PASS
- `./scripts/preflight.sh` — PASS（含 doc-fix commit）

## 提交

- e5b00c348 feat(gateway): 将 OpenAI/Anthropic 429 冷却 clamp 默认上限改为 5h
- c5c416b3e fix(gateway): 对齐 429 clamp DEFAULT-ON 文档与运维 skill

最新提交：c5c416b3e
