### PR TITLE
fix(openai): 非流式缓冲 missing-terminal 改 failover 而非 502

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -426,12 +426,14 @@ func (s *OpenAIGatewayService) handleChatBufferedStreamingResponse(
 
 	finalResponse, usage, acc, err := s.readOpenAICompatBufferedTerminal(resp, "openai chat_completions buffered", requestID)
 	if err != nil {
+		if result, failoverErr := s.openAICompatBufferedReadErrResult(c, account, requestID, acc, openAICompatBufferedRouteChat, err); failoverErr != nil {
+			return result, failoverErr
+		}
 		return nil, err
 	}
 
 	if finalResponse == nil {
-		writeChatCompletionsError(c, http.StatusBadGateway, "api_error", "Upstream stream ended without a terminal response event")
-		return nil, fmt.Errorf("upstream stream ended without terminal event")
+		return s.openAICompatBufferedMissingTerminalResult(c, account, requestID, acc, openAICompatBufferedRouteChat)
 	}
 	if strings.TrimSpace(finalResponse.Status) == "failed" {
 		payload, _ := json.Marshal(gin.H{"type": "response.failed", "response": finalResponse})

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -426,9 +426,6 @@ func (s *OpenAIGatewayService) handleChatBufferedStreamingResponse(
 
 	finalResponse, usage, acc, err := s.readOpenAICompatBufferedTerminal(resp, "openai chat_completions buffered", requestID)
 	if err != nil {
-		if result, failoverErr := s.openAICompatBufferedReadErrResult(c, account, requestID, acc, openAICompatBufferedRouteChat, err); failoverErr != nil {
-			return result, failoverErr
-		}
 		return nil, err
 	}
 

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -545,9 +545,6 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 
 	finalResponse, usage, acc, err := s.readOpenAICompatBufferedTerminal(resp, "openai messages buffered", requestID)
 	if err != nil {
-		if result, failoverErr := s.openAICompatBufferedReadErrResult(c, account, requestID, acc, openAICompatBufferedRouteMessages, err); failoverErr != nil {
-			return result, failoverErr
-		}
 		return nil, err
 	}
 

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -410,7 +410,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		result, handleErr = s.handleAnthropicStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime)
 	} else {
 		// Client wants JSON: buffer the streaming response and assemble a JSON reply.
-		result, handleErr = s.handleAnthropicBufferedStreamingResponse(resp, c, originalModel, billingModel, upstreamModel, startTime)
+		result, handleErr = s.handleAnthropicBufferedStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime)
 	}
 	if result != nil {
 		result.CompactCandidate = compactCandidate
@@ -535,6 +535,7 @@ func (s *OpenAIGatewayService) handleAnthropicErrorResponse(
 func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	billingModel string,
 	upstreamModel string,
@@ -544,16 +545,16 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 
 	finalResponse, usage, acc, err := s.readOpenAICompatBufferedTerminal(resp, "openai messages buffered", requestID)
 	if err != nil {
+		if result, failoverErr := s.openAICompatBufferedReadErrResult(c, account, requestID, acc, openAICompatBufferedRouteMessages, err); failoverErr != nil {
+			return result, failoverErr
+		}
 		return nil, err
 	}
 
 	if finalResponse == nil {
-		writeAnthropicError(c, http.StatusBadGateway, "api_error", "Upstream stream ended without a terminal response event")
-		return nil, fmt.Errorf("upstream stream ended without terminal event")
+		return s.openAICompatBufferedMissingTerminalResult(c, account, requestID, acc, openAICompatBufferedRouteMessages)
 	}
 
-	// cyber_policy：上游硬阻断（response.failed）。anthropic buffered 原对 failed 无特殊分支，
-	// 此处仅为 cyber 增加：以 Anthropic 错误格式回写，标记供 handler 事后写风控/邮件/tokens=0 用量行。
 	if strings.TrimSpace(finalResponse.Status) == "failed" {
 		payload, _ := json.Marshal(gin.H{"type": "response.failed", "response": finalResponse})
 		if hit, code, msg := detectOpenAICyberPolicy(payload); hit {
@@ -572,6 +573,7 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", clientMsg)
 			return nil, fmt.Errorf("openai cyber_policy: %s", msg)
 		}
+		return s.openAICompatBufferedFailedResponseFailover(c, account, requestID, finalResponse)
 	}
 
 	// When the terminal event has an empty output array, reconstruct from

--- a/backend/internal/service/openai_gateway_service_tk_buffered_failover.go
+++ b/backend/internal/service/openai_gateway_service_tk_buffered_failover.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+)
+
+type openAICompatBufferedRouteKind int
+
+const (
+	openAICompatBufferedRouteChat openAICompatBufferedRouteKind = iota
+	openAICompatBufferedRouteMessages
+)
+
+// openAICompatBufferedMissingTerminalResult mirrors the streaming missing-terminal
+// policy: no accumulated content → safe failover; partial content → client error
+// without failover (client-visible output must not be replayed on another account).
+func (s *OpenAIGatewayService) openAICompatBufferedMissingTerminalResult(
+	c *gin.Context,
+	account *Account,
+	requestID string,
+	acc *apicompat.BufferedResponseAccumulator,
+	route openAICompatBufferedRouteKind,
+) (*OpenAIForwardResult, error) {
+	const clientMsg = "Upstream stream ended without a terminal response event"
+	if acc != nil && acc.HasContent() {
+		if route == openAICompatBufferedRouteMessages {
+			s.recordOpenAIMessagesStreamUpstreamError(c, account, requestID, "buffered_missing_terminal", clientMsg)
+			writeAnthropicError(c, http.StatusBadGateway, "api_error", clientMsg)
+		} else {
+			writeChatCompletionsError(c, http.StatusBadGateway, "api_error", clientMsg)
+		}
+		return nil, fmt.Errorf("upstream stream ended without terminal event")
+	}
+
+	failoverMsg := "OpenAI stream ended before a terminal event"
+	if route == openAICompatBufferedRouteMessages {
+		failoverMsg = "OpenAI messages stream ended before a terminal event"
+	}
+	return nil, s.newOpenAIStreamFailoverError(c, account, false, requestID, nil, failoverMsg)
+}
+
+func (s *OpenAIGatewayService) openAICompatBufferedReadErrResult(
+	c *gin.Context,
+	account *Account,
+	requestID string,
+	acc *apicompat.BufferedResponseAccumulator,
+	route openAICompatBufferedRouteKind,
+	readErr error,
+) (*OpenAIForwardResult, error) {
+	if readErr == nil {
+		return nil, nil
+	}
+	if acc == nil || !acc.HasContent() {
+		failoverMsg := "OpenAI stream ended before a terminal event"
+		if route == openAICompatBufferedRouteMessages {
+			failoverMsg = "OpenAI messages stream ended before a terminal event"
+		}
+		return nil, s.newOpenAIStreamFailoverError(c, account, false, requestID, nil, failoverMsg)
+	}
+	return nil, readErr
+}
+
+func (s *OpenAIGatewayService) openAICompatBufferedFailedResponseFailover(
+	c *gin.Context,
+	account *Account,
+	requestID string,
+	finalResponse *apicompat.ResponsesResponse,
+) (*OpenAIForwardResult, error) {
+	if finalResponse == nil {
+		return nil, fmt.Errorf("openai buffered response.failed: nil response")
+	}
+	payload, _ := json.Marshal(gin.H{"type": "response.failed", "response": finalResponse})
+	return nil, s.newOpenAIStreamFailoverError(
+		c,
+		account,
+		false,
+		requestID,
+		payload,
+		openAICompatFailedResponseMessage(finalResponse),
+	)
+}

--- a/backend/internal/service/openai_gateway_service_tk_buffered_failover.go
+++ b/backend/internal/service/openai_gateway_service_tk_buffered_failover.go
@@ -45,27 +45,6 @@ func (s *OpenAIGatewayService) openAICompatBufferedMissingTerminalResult(
 	return nil, s.newOpenAIStreamFailoverError(c, account, false, requestID, nil, failoverMsg)
 }
 
-func (s *OpenAIGatewayService) openAICompatBufferedReadErrResult(
-	c *gin.Context,
-	account *Account,
-	requestID string,
-	acc *apicompat.BufferedResponseAccumulator,
-	route openAICompatBufferedRouteKind,
-	readErr error,
-) (*OpenAIForwardResult, error) {
-	if readErr == nil {
-		return nil, nil
-	}
-	if acc == nil || !acc.HasContent() {
-		failoverMsg := "OpenAI stream ended before a terminal event"
-		if route == openAICompatBufferedRouteMessages {
-			failoverMsg = "OpenAI messages stream ended before a terminal event"
-		}
-		return nil, s.newOpenAIStreamFailoverError(c, account, false, requestID, nil, failoverMsg)
-	}
-	return nil, readErr
-}
-
 func (s *OpenAIGatewayService) openAICompatBufferedFailedResponseFailover(
 	c *gin.Context,
 	account *Account,

--- a/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
@@ -163,6 +163,39 @@ func TestForwardAsAnthropic_BufferedMissingTerminalAfterOutputReturns502WithoutF
 	require.Equal(t, "buffered_missing_terminal", events[0].Kind)
 }
 
+func TestForwardAsAnthropic_BufferedResponseFailedTriggersFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","max_tokens":16,"messages":[{"role":"user","content":"large prompt"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`event: response.failed`,
+		`data: {"type":"response.failed","response":{"id":"resp_failed","object":"response","model":"gpt-5.5","status":"failed","output":[],"error":{"code":"upstream_error","message":"input exceeds the context window"}}}`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid_messages_failed_buffered"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := openAICompatTestOAuthAccount(1, "openai-oauth")
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.5")
+	require.Error(t, err)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Contains(t, string(failoverErr.ResponseBody), "input exceeds the context window")
+	require.False(t, c.Writer.Written())
+}
+
 func openAICompatTestOAuthAccount(id int64, name string) *Account {
 	return &Account{
 		ID:          id,

--- a/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
@@ -1,0 +1,178 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForwardAsChatCompletions_BufferedMissingTerminalBeforeOutputReturnsFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := "data: [DONE]\n\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid_chat_buffered_missing_terminal"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := openAICompatTestOAuthAccount(64, "openai-us3")
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "gpt-5.1")
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr), "buffered missing terminal before output must failover")
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Contains(t, string(failoverErr.ResponseBody), "terminal event")
+	require.Nil(t, result)
+	require.False(t, c.Writer.Written(), "failover must not commit client body before retry")
+	require.Empty(t, rec.Body.String())
+
+	events := openAICompatOpsEvents(t, c)
+	require.Len(t, events, 1)
+	require.Equal(t, "failover", events[0].Kind)
+	require.Equal(t, int64(64), events[0].AccountID)
+	require.Equal(t, "rid_chat_buffered_missing_terminal", events[0].UpstreamRequestID)
+}
+
+func TestForwardAsChatCompletions_BufferedMissingTerminalAfterOutputReturns502WithoutFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"partial"}`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid_chat_buffered_partial"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := openAICompatTestOAuthAccount(1, "openai-oauth")
+
+	type forwardResult struct {
+		result *OpenAIForwardResult
+		err    error
+	}
+	resultCh := make(chan forwardResult, 1)
+	go func() {
+		result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "gpt-5.1")
+		resultCh <- forwardResult{result: result, err: err}
+	}()
+
+	select {
+	case got := <-resultCh:
+		require.Error(t, got.err)
+		require.Contains(t, got.err.Error(), "without terminal event")
+		var failoverErr *UpstreamFailoverError
+		require.False(t, errors.As(got.err, &failoverErr), "partial buffered content must not failover")
+		require.Nil(t, got.result)
+		require.True(t, c.Writer.Written())
+		require.Equal(t, http.StatusBadGateway, rec.Code)
+		require.Contains(t, rec.Body.String(), "terminal response event")
+	case <-time.After(time.Second):
+		require.Fail(t, "ForwardAsChatCompletions buffered partial missing terminal should return quickly")
+	}
+}
+
+func TestForwardAsAnthropic_BufferedMissingTerminalBeforeOutputReturnsFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := "data: [DONE]\n\n"
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid_messages_buffered_missing_terminal"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := openAICompatTestOAuthAccount(64, "openai-us3")
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.1")
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.Contains(t, string(failoverErr.ResponseBody), "terminal event")
+	require.Nil(t, result)
+	require.False(t, c.Writer.Written())
+	require.Empty(t, rec.Body.String())
+}
+
+func TestForwardAsAnthropic_BufferedMissingTerminalAfterOutputReturns502WithoutFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"partial"}`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid_messages_buffered_partial"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := openAICompatTestOAuthAccount(1, "openai-oauth")
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "without terminal event")
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.Nil(t, result)
+	require.True(t, c.Writer.Written())
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+
+	events := openAICompatOpsEvents(t, c)
+	require.Len(t, events, 1)
+	require.Equal(t, "buffered_missing_terminal", events[0].Kind)
+}
+
+func openAICompatTestOAuthAccount(id int64, name string) *Account {
+	return &Account{
+		ID:          id,
+		Name:        name,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+		},
+	}
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3365,6 +3365,24 @@
         "firstTokenMs == nil && openAIStreamFailedEventShouldFailover"
       ],
       "rationale": "PR #1001: WS Responses paths (forwardOpenAIWSV2 + ProxyResponsesWebSocketFromClient) must surface UpstreamFailoverError on pre-token response.failed transient/capacity errors instead of forwarding to the client. Losing this branch reverts WS to the HTTP/SSE bug class fixed in #1001."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service_tk_buffered_failover.go",
+      "must_contain": [
+        "openAICompatBufferedMissingTerminalResult",
+        "acc.HasContent()",
+        "newOpenAIStreamFailoverError"
+      ],
+      "rationale": "Non-stream /v1/chat/completions and /v1/messages buffer upstream Responses SSE; when the stream ends without a terminal event and no accumulated output, prod account 64 was returning gateway-generated 502 instead of failing over to a sibling. This companion mirrors the streaming missing-terminal policy (failover before output, client error after partial output). Upstream merges that revert the buffered handlers to direct writeChatCompletionsError/writeAnthropicError silently restore the 502 storm."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go",
+      "must_contain": [
+        "TestForwardAsChatCompletions_BufferedMissingTerminalBeforeOutputReturnsFailover",
+        "TestForwardAsChatCompletions_BufferedMissingTerminalAfterOutputReturns502WithoutFailover",
+        "TestForwardAsAnthropic_BufferedMissingTerminalBeforeOutputReturnsFailover"
+      ],
+      "rationale": "Regression anchors for buffered missing-terminal failover: [DONE]/EOF with no content must UpstreamFailoverError without committing client body; partial delta without terminal must stay 502 and must not failover."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3370,6 +3370,7 @@
       "path": "backend/internal/service/openai_gateway_service_tk_buffered_failover.go",
       "must_contain": [
         "openAICompatBufferedMissingTerminalResult",
+        "openAICompatBufferedFailedResponseFailover",
         "acc.HasContent()",
         "newOpenAIStreamFailoverError"
       ],
@@ -3380,7 +3381,8 @@
       "must_contain": [
         "TestForwardAsChatCompletions_BufferedMissingTerminalBeforeOutputReturnsFailover",
         "TestForwardAsChatCompletions_BufferedMissingTerminalAfterOutputReturns502WithoutFailover",
-        "TestForwardAsAnthropic_BufferedMissingTerminalBeforeOutputReturnsFailover"
+        "TestForwardAsAnthropic_BufferedMissingTerminalBeforeOutputReturnsFailover",
+        "TestForwardAsAnthropic_BufferedResponseFailedTriggersFailover"
       ],
       "rationale": "Regression anchors for buffered missing-terminal failover: [DONE]/EOF with no content must UpstreamFailoverError without committing client body; partial delta without terminal must stay 502 and must not failover."
     }


### PR DESCRIPTION
## 摘要

- 非流式 `/v1/chat/completions` 与 `/v1/messages` 在上游 Responses SSE **无 terminal 事件**结束且 **未累积任何输出** 时，改为返回 `UpstreamFailoverError` 触发账号 failover，不再直写网关 502。
- 新增 TK companion `openai_gateway_service_tk_buffered_failover.go`；有 partial delta 仍写 502、不 failover。
- messages 缓冲路径补齐 `response.failed`（非 cyber_policy）failover，与 chat 对齐。
- review 收敛：移除 read-error 无条件 failover（与流式 cancel 语义不一致）；补 messages `response.failed` 回归测试。

## 风险

- **常规风险**：仅影响 OpenAI compat 非流式缓冲路径。
- 与 PR #1001（流式 pre-token failover）互补。
- Web impact: none

## 验证

```bash
go test -tags=unit ./internal/service -run 'BufferedMissingTerminal|BufferedResponseFailed' -count=1 -v
./scripts/preflight.sh
```

上述命令本地均已 PASS。

## 提交

- `8fb8b51da` fix(openai): failover buffered missing-terminal instead of 502
- `3500196b0` fix(openai): tighten buffered failover scope from review

最新提交：3500196b0
