### PR TITLE
fix(kiro): 402 reached-the-limit 专用 P0 飞书告警

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -189,7 +189,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	antigravityQuotaFetcher := service.NewAntigravityQuotaFetcher(proxyRepository)
 	usageCache := service.NewUsageCache()
 	accountUsageService := service.NewAccountUsageService(accountRepository, usageLogRepository, claudeUsageFetcher, geminiQuotaService, antigravityQuotaFetcher, usageCache, identityCache, tlsFingerprintProfileService)
-	accountTestService := service.NewAccountTestService(accountRepository, geminiTokenProvider, claudeTokenProvider, antigravityGatewayService, kiroGatewayService, httpUpstream, configConfig, tlsFingerprintProfileService)
+	accountTestService := service.NewAccountTestService(accountRepository, geminiTokenProvider, claudeTokenProvider, antigravityGatewayService, kiroGatewayService, rateLimitService, httpUpstream, configConfig, tlsFingerprintProfileService)
 	crsSyncService := service.NewCRSSyncService(accountRepository, proxyRepository, oAuthService, openAIOAuthService, geminiOAuthService, configConfig)
 	accountTierService := service.NewAccountTierService(adminService, tierService, tlsFingerprintProfileService)
 	accountHandler := admin.NewAccountHandler(adminService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, rateLimitService, accountUsageService, accountTestService, concurrencyService, crsSyncService, sessionLimitCache, rpmCache, compositeTokenCacheInvalidator, accountTierService)

--- a/backend/internal/handler/admin/account_handler_available_models_test.go
+++ b/backend/internal/handler/admin/account_handler_available_models_test.go
@@ -75,6 +75,7 @@ func setupSyncUpstreamModelsRouter(adminSvc service.AdminService, upstream servi
 		upstream,
 		&config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
 		nil,
+		nil,
 	)
 	handler := NewAccountHandler(adminSvc, nil, nil, nil, nil, nil, nil, accountTestSvc, nil, nil, nil, nil, nil, nil)
 	router.POST("/api/v1/admin/accounts/:id/models/sync-upstream", handler.SyncUpstreamModels)

--- a/backend/internal/handler/admin/account_handler_available_models_test.go
+++ b/backend/internal/handler/admin/account_handler_available_models_test.go
@@ -72,9 +72,9 @@ func setupSyncUpstreamModelsRouter(adminSvc service.AdminService, upstream servi
 		nil,
 		nil,
 		nil,
+		nil, // rateLimitService
 		upstream,
 		&config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
-		nil,
 		nil,
 	)
 	handler := NewAccountHandler(adminSvc, nil, nil, nil, nil, nil, nil, accountTestSvc, nil, nil, nil, nil, nil, nil)

--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -114,6 +114,11 @@ func classifyIncident(reason string, until time.Time, kind AccountIncidentKind) 
 		// 1h per-account dedupe so a persistently-arrears account fires at most
 		// once per window instead of one card per request.
 		return incidentClass{true, IncidentKindPermanentDisable, "newapi_arrears", "上游账号欠费", "DashScope 等上游账号欠费(Arrearage),需在对应控制台(如阿里云百炼)充值/还款;账号已临时摘出轮换,充值后冷却到期自动恢复"}
+	case "kiro_quota_limit":
+		// TK (prod 2026-06-25, edge-us4 account 9): Kiro OAuth subscription quota
+		// exhaustion is HTTP 402 + "You have reached the limit." — not an auth
+		// failure. Route through the immediate P0 card with quota-specific advice.
+		return incidentClass{true, IncidentKindPermanentDisable, "kiro_quota_limit", "Kiro 订阅用量额度耗尽", "AWS Kiro/CodeWhisperer 订阅额度已用尽(402 reached the limit);等待额度重置或升级 Kiro 订阅;账号已停调度,恢复后需手动清除 error 并重测"}
 	case "429_model_class":
 		// G4(#600)模型维度 cooldown：单模型类(如 opus)打穿 5h/7d 用量窗口,只冷却该模型类,
 		// 账号其它模型仍可调度。不能复用兜底的"账号临时冷却"——那会误报成整账号下线。

--- a/backend/internal/service/account_incident_notifier_tk_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_test.go
@@ -123,6 +123,7 @@ func TestClassifyIncident(t *testing.T) {
 		{"openai_403_temp", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "403"},
 		{"temp_unschedulable", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "temp"},
 		{"stream_timeout_temp_unschedulable", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "temp"},
+		{"kiro_quota_limit", time.Time{}, IncidentKindUnknown, IncidentKindPermanentDisable, "kiro_quota_limit"},
 		// unknown reason → fall back to until/kind
 		{"mystery", time.Time{}, IncidentKindUnknown, IncidentKindPermanentDisable, "other"},
 		{"mystery", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "other"},

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -71,6 +71,7 @@ type AccountTestService struct {
 	claudeTokenProvider       *ClaudeTokenProvider
 	antigravityGatewayService *AntigravityGatewayService
 	kiroGatewayService        *KiroGatewayService
+	rateLimitService          *RateLimitService
 	httpUpstream              HTTPUpstream
 	cfg                       *config.Config
 	tlsFPProfileService       *TLSFingerprintProfileService
@@ -83,6 +84,7 @@ func NewAccountTestService(
 	claudeTokenProvider *ClaudeTokenProvider,
 	antigravityGatewayService *AntigravityGatewayService,
 	kiroGatewayService *KiroGatewayService,
+	rateLimitService *RateLimitService,
 	httpUpstream HTTPUpstream,
 	cfg *config.Config,
 	tlsFPProfileService *TLSFingerprintProfileService,
@@ -93,6 +95,7 @@ func NewAccountTestService(
 		claudeTokenProvider:       claudeTokenProvider,
 		antigravityGatewayService: antigravityGatewayService,
 		kiroGatewayService:        kiroGatewayService,
+		rateLimitService:          rateLimitService,
 		httpUpstream:              httpUpstream,
 		cfg:                       cfg,
 		tlsFPProfileService:       tlsFPProfileService,
@@ -301,6 +304,9 @@ func (s *AccountTestService) testKiroAccountConnection(c *gin.Context, account *
 		}
 		var failoverErr *UpstreamFailoverError
 		if errors.As(err, &failoverErr) {
+			if s.rateLimitService != nil {
+				s.rateLimitService.HandleUpstreamError(ctx, account, failoverErr.StatusCode, failoverErr.ResponseHeaders, failoverErr.ResponseBody, parsed.Model)
+			}
 			body := strings.TrimSpace(string(failoverErr.ResponseBody))
 			if body == "" {
 				body = failoverErr.Error()

--- a/backend/internal/service/account_test_service_kiro_quota402_test.go
+++ b/backend/internal/service/account_test_service_kiro_quota402_test.go
@@ -1,0 +1,41 @@
+//go:build unit
+
+package service
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountTestService_Kiro402ReachedLimitTriggersIncidentAlert(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/test", nil)
+
+	upstream := &kiroStatusUpstream{
+		status: http.StatusPaymentRequired,
+		body:   "You have reached the limit.",
+	}
+	repo := &rateLimitAccountRepoStub{}
+	incidents := &tkBridgePenaltyIncidentRecorder{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAccountRuntimeBlocker(&runtimeBlockRecorder{})
+	svc.SetAccountIncidentNotifier(incidents)
+
+	account := newEdgeUS4KiroAccount()
+	testSvc := &AccountTestService{
+		kiroGatewayService: NewKiroGatewayService(upstream, nil),
+		rateLimitService:   svc,
+	}
+	err := testSvc.testKiroAccountConnection(c, account, KiroDefaultTestModel, "hi")
+	require.Error(t, err)
+	require.Equal(t, 1, repo.setErrorCalls)
+	require.Equal(t, []string{tkKiroQuotaLimitIncidentReason}, incidents.reasons)
+	require.Contains(t, incidents.details[0], "402")
+}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -521,6 +521,10 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			shouldDisable = s.handleAnthropicUpstreamError(ctx, account, statusCode, upstreamMsg, responseBody)
 			break
 		}
+		if s.tkHandleKiroQuotaLimit402(ctx, account, upstreamMsg, responseBody) {
+			shouldDisable = true
+			break
+		}
 		// 支付要求：余额不足或计费问题，停止调度
 		msg := "Payment required (402): insufficient balance or billing issue"
 		if upstreamMsg != "" {

--- a/backend/internal/service/ratelimit_service_tk_kiro_quota402.go
+++ b/backend/internal/service/ratelimit_service_tk_kiro_quota402.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// TK: Kiro (sixth platform) upstream HTTP 402 "You have reached the limit."
+//
+// Prod incident 2026-06-25 (edge-us4, account id=9): Kiro OAuth subscription
+// quota exhaustion arrives as 402 + plain-text "You have reached the limit."
+// Generic case 402 already SetError + notifyAccountSchedulingBlocked, but it
+// used reason "auth_error" ("账号永久失效（认证失败）") — misleading for a quota
+// cap, and admin account-test bypassed HandleUpstreamError entirely (same class
+// of gap as newapi bridge #617 / #628). This companion narrows on the Kiro
+// quota marker and routes through reason "kiro_quota_limit" for an immediate,
+// actionable P0 Feishu card while keeping the same stop-scheduling semantics.
+
+const tkKiroQuotaLimitIncidentReason = "kiro_quota_limit"
+
+const tkKiroQuotaLimitMarker = "reached the limit"
+
+func tkIsKiroQuotaLimit402(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool {
+	if account == nil || account.Platform != PlatformKiro || statusCode != http.StatusPaymentRequired {
+		return false
+	}
+	haystack := strings.ToLower(strings.TrimSpace(upstreamMsg))
+	if haystack == "" {
+		haystack = strings.ToLower(strings.TrimSpace(string(responseBody)))
+	}
+	return strings.Contains(haystack, tkKiroQuotaLimitMarker)
+}
+
+func (s *RateLimitService) tkHandleKiroQuotaLimit402(ctx context.Context, account *Account, upstreamMsg string, responseBody []byte) bool {
+	if s == nil || account == nil {
+		return false
+	}
+	if !tkIsKiroQuotaLimit402(account, http.StatusPaymentRequired, upstreamMsg, responseBody) {
+		return false
+	}
+	msg := "Payment required (402): insufficient balance or billing issue"
+	if trimmed := strings.TrimSpace(upstreamMsg); trimmed != "" {
+		msg = "Payment required (402): " + trimmed
+	} else if body := strings.TrimSpace(string(responseBody)); body != "" {
+		msg = "Payment required (402): " + body
+	}
+	s.notifyAccountSchedulingBlocked(account, time.Time{}, tkKiroQuotaLimitIncidentReason, msg)
+	if err := s.accountRepo.SetError(ctx, account.ID, msg); err != nil {
+		slog.Warn("kiro_quota_limit_set_error_failed", "account_id", account.ID, "error", err)
+		return true
+	}
+	slog.Warn("account_disabled_kiro_quota_limit", "account_id", account.ID, "error", msg)
+	return true
+}

--- a/backend/internal/service/ratelimit_service_tk_kiro_quota402_test.go
+++ b/backend/internal/service/ratelimit_service_tk_kiro_quota402_test.go
@@ -1,0 +1,85 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func newEdgeUS4KiroAccount() *Account {
+	return &Account{
+		ID:       9,
+		Name:     "kiro-us4-real",
+		Platform: PlatformKiro,
+		Type:     AccountTypeOAuth,
+	}
+}
+
+func TestTkIsKiroQuotaLimit402_MatchesReachedTheLimit(t *testing.T) {
+	account := newEdgeUS4KiroAccount()
+	require.True(t, tkIsKiroQuotaLimit402(account, http.StatusPaymentRequired, "You have reached the limit.", nil))
+	require.True(t, tkIsKiroQuotaLimit402(account, http.StatusPaymentRequired, "", []byte("You have reached the limit.")))
+}
+
+func TestTkIsKiroQuotaLimit402_NonKiroOrOther402NeverMatch(t *testing.T) {
+	account := newEdgeUS4KiroAccount()
+	for _, tc := range []struct {
+		name       string
+		account    *Account
+		statusCode int
+		msg        string
+	}{
+		{"openai 402", &Account{Platform: PlatformOpenAI}, http.StatusPaymentRequired, "You have reached the limit."},
+		{"kiro 401", account, http.StatusUnauthorized, "You have reached the limit."},
+		{"kiro 402 other message", account, http.StatusPaymentRequired, "Insufficient Balance"},
+		{"nil account", nil, http.StatusPaymentRequired, "You have reached the limit."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.False(t, tkIsKiroQuotaLimit402(tc.account, tc.statusCode, tc.msg, nil))
+		})
+	}
+}
+
+func TestTkHandleKiroQuotaLimit402_DisablesAccountAndAlerts(t *testing.T) {
+	svc, repo, blocker, incidents := newBridgePenaltyTestService()
+	account := newEdgeUS4KiroAccount()
+
+	handled := svc.tkHandleKiroQuotaLimit402(context.Background(), account, "You have reached the limit.", nil)
+	require.True(t, handled)
+	require.Equal(t, 1, repo.setErrorCalls)
+	require.Contains(t, repo.lastErrorMsg, "Payment required (402): You have reached the limit.")
+	require.Len(t, blocker.reasons, 1)
+	require.Equal(t, tkKiroQuotaLimitIncidentReason, blocker.reasons[0])
+	require.Equal(t, []string{tkKiroQuotaLimitIncidentReason}, incidents.reasons)
+	require.Contains(t, incidents.details[0], "402")
+}
+
+func TestHandleUpstreamError_Kiro402ReachedLimitUsesDedicatedReason(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	blocker := &runtimeBlockRecorder{}
+	incidents := &tkBridgePenaltyIncidentRecorder{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAccountRuntimeBlocker(blocker)
+	svc.SetAccountIncidentNotifier(incidents)
+
+	account := newEdgeUS4KiroAccount()
+	shouldDisable := svc.HandleUpstreamError(context.Background(), account, http.StatusPaymentRequired, nil, []byte("You have reached the limit."))
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.setErrorCalls)
+	require.Equal(t, []string{tkKiroQuotaLimitIncidentReason}, incidents.reasons)
+	require.NotContains(t, incidents.reasons, "auth_error")
+}
+
+func TestClassifyIncident_KiroQuotaLimit_IsImmediateP0(t *testing.T) {
+	cls := classifyIncident(tkKiroQuotaLimitIncidentReason, time.Time{}, IncidentKindUnknown)
+	require.True(t, cls.alert)
+	require.Equal(t, IncidentKindPermanentDisable, cls.kind)
+	require.Equal(t, "kiro_quota_limit", cls.reasonClass)
+	require.Contains(t, cls.kindZh, "Kiro")
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -421,6 +421,48 @@
       "rationale": "TK companion holding OAuth auth-rejection handling. For non-Anthropic OAuth 401, tkDisableIfOAuth401OnValidToken keeps the original safety gate: only a STILL-VALID access_token (remaining lifetime >= tkOAuth401ValidTokenMargin = max(refresh window, 5min floor)) is treated as grant revocation and SetError on the first strike; expired/near-expiry/missing expires_at falls through to temp_unschedulable cooldown + background refresh. Kiro is the narrow exception: valid-token 401 and Kiro upstream 403 bodies/messages containing invalid bearer token both call the shared tkHandleKiroOAuthAuthReject path, which uses OAuthRefreshAPI.RefreshNow under the distributed lock and clears error/schedulability/temp cooldown after a successful refresh. The 403_invalid_bearer path deliberately does NOT require expires_at because live edge-us4 Kiro credentials lacked expires_at while returning HTTP 403 \"The bearer token included in the request is invalid.\" Nonretryable refresh errors still fall back to handleAuthError/manual re-auth, so revoked grants are not hidden. Anchors here prevent an upstream merge from turning the 403 fix into a broad 403 retry, dropping RefreshNow, or removing the 401 validity gate."
     },
     {
+      "path": "backend/internal/service/ratelimit_service_tk_kiro_quota402.go",
+      "must_contain": [
+        "tkIsKiroQuotaLimit402",
+        "tkHandleKiroQuotaLimit402",
+        "tkKiroQuotaLimitIncidentReason",
+        "reached the limit"
+      ],
+      "rationale": "Kiro subscription quota exhaustion (prod 2026-06-25 edge-us4 account 9: HTTP 402 + plain-text 'You have reached the limit.') must route through a dedicated incident reason for an immediate actionable P0 Feishu card, not the misleading auth_error '认证失败' bucket. tkHandleKiroQuotaLimit402 stops scheduling (SetError) and funnels notifyAccountSchedulingBlocked with reason kiro_quota_limit. Dropping this companion silently regresses operators back to either no alert (admin account-test bypass) or a mislabeled auth card."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_kiro_quota402_test.go",
+      "must_contain": [
+        "TestTkHandleKiroQuotaLimit402_DisablesAccountAndAlerts",
+        "TestHandleUpstreamError_Kiro402ReachedLimitUsesDedicatedReason",
+        "TestClassifyIncident_KiroQuotaLimit_IsImmediateP0"
+      ],
+      "rationale": "Focused regressions for the Kiro 402 reached-the-limit P0 path: matcher boundary, HandleUpstreamError integration, classifyIncident permanent P0 mapping, and admin account-test penalty wiring."
+    },
+    {
+      "path": "backend/internal/service/account_test_service.go",
+      "must_contain": [
+        "rateLimitService          *RateLimitService",
+        "s.rateLimitService.HandleUpstreamError(ctx, account, failoverErr.StatusCode"
+      ],
+      "rationale": "Admin Kiro account-test must mirror gateway Forward's HandleUpstreamError side effect. Without it, an operator reproducing edge-us4 account 9's 402 via /admin/accounts/:id/test disables nothing in the incident funnel and sends no Feishu P0 — the same silent-alert class as pre-bridge newapi."
+    },
+    {
+      "path": "backend/internal/service/account_incident_notifier_tk.go",
+      "must_contain": [
+        "case \"kiro_quota_limit\":",
+        "IncidentKindPermanentDisable, \"kiro_quota_limit\", \"Kiro 订阅用量额度耗尽\""
+      ],
+      "rationale": "classifyIncident MUST map reason kiro_quota_limit to the IMMEDIATE P0 card path (IncidentKindPermanentDisable), NOT auth_error's misleading 认证失败 copy and NOT the default-OFF temporary digest. Quota exhaustion needs human action (wait for reset / upgrade subscription)."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "s.tkHandleKiroQuotaLimit402(ctx, account, upstreamMsg, responseBody)"
+      ],
+      "rationale": "HandleUpstreamError case 402 must invoke the Kiro quota-limit companion before the generic Payment required → auth_error path so Kiro 402 reached-the-limit gets the dedicated P0 reason. An upstream merge that drops this call site re-buries the alert under auth_error or skips the matcher entirely."
+    },
+    {
       "path": "backend/internal/service/ratelimit_service_tk_oauth401_test.go",
       "must_contain": [
         "TestRateLimitService_OAuth401_AnthropicAny401SetErrorsImmediately",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -298,6 +298,40 @@
       "rationale": "English i18n strings for the kiro account form (labels, ToS copy, validation messages). Losing them surfaces raw i18n keys in the UI."
     },
     {
+      "path": "backend/internal/service/ratelimit_service_tk_kiro_quota402.go",
+      "must_contain": [
+        "tkIsKiroQuotaLimit402",
+        "tkHandleKiroQuotaLimit402",
+        "tkKiroQuotaLimitIncidentReason",
+        "reached the limit"
+      ],
+      "rationale": "Kiro OAuth subscription quota exhaustion surfaces as HTTP 402 + 'You have reached the limit.' (prod 2026-06-25 edge-us4 account 9). This companion maps that verdict to reason kiro_quota_limit + SetError stop-scheduling + immediate Feishu P0. Without it, operators either get a mislabeled auth_error card or no alert when reproducing via admin account-test."
+    },
+    {
+      "path": "backend/internal/service/account_test_service.go",
+      "must_contain": [
+        "rateLimitService          *RateLimitService",
+        "s.rateLimitService.HandleUpstreamError(ctx, account, failoverErr.StatusCode"
+      ],
+      "rationale": "Admin Kiro account-test must call HandleUpstreamError on UpstreamFailoverError, matching gateway_service.go's kiro Forward branch. Otherwise a 402 quota hit visible in the test UI never reaches the Feishu incident funnel."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_kiro_quota402_test.go",
+      "must_contain": [
+        "TestTkHandleKiroQuotaLimit402_DisablesAccountAndAlerts",
+        "TestHandleUpstreamError_Kiro402ReachedLimitUsesDedicatedReason",
+        "TestClassifyIncident_KiroQuotaLimit_IsImmediateP0"
+      ],
+      "rationale": "Regression guard for the Kiro 402 reached-the-limit matcher, HandleUpstreamError integration, and classifyIncident permanent P0 mapping."
+    },
+    {
+      "path": "backend/internal/service/account_test_service_kiro_quota402_test.go",
+      "must_contain": [
+        "TestAccountTestService_Kiro402ReachedLimitTriggersIncidentAlert"
+      ],
+      "rationale": "Regression guard that admin Kiro account-test forwards UpstreamFailoverError into HandleUpstreamError so a reproduced 402 quota hit triggers the Feishu incident funnel."
+    },
+    {
       "path": "frontend/src/i18n/locales/zh.ts",
       "must_contain": [
         "kiroPlatform"


### PR DESCRIPTION
## 摘要

- edge-us4 Kiro 账号 402 `You have reached the limit.` 不再走误导性的 `auth_error`（「认证失败」），改为 `kiro_quota_limit` 即时 P0 红卡，事件文案为「Kiro 订阅用量额度耗尽」。
- Admin 账号测试路径补齐 `HandleUpstreamError`，与 gateway Kiro Forward 行为对齐，避免只在 UI 看到 402 却收不到飞书。
- 新增 sentinel + 单元测试覆盖 matcher、HandleUpstreamError、classifyIncident 与 account-test 三条链路。
- 修复 `NewAccountTestService` 构造函数参数顺序，消除 CI typecheck 失败。

## 风险

- **常规风险**：仅影响 Kiro 平台且上游 body/message 含 `reached the limit` 的 402；其它 402 仍走原有通用路径。
- Web impact: none

## 验证

```bash
go test -tags=unit ./internal/service -run 'KiroQuota|Kiro402|TkHandleKiroQuota|TkIsKiroQuota' -count=1 -v
go test -tags=unit ./internal/handler/admin/... -count=1
./scripts/preflight.sh
```

本地均已 PASS。

## 提交

- `ec1391a01` fix(test): address R-001 — NewAccountTestService 参数顺序
- `30cc892ff` fix(kiro): 402 reached-the-limit 走专用 P0 飞书告警

最新提交：ec1391a01
