### PR TITLE
fix(openai): 缓冲 response.failed failover 改由 shouldFailover 门禁

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -452,7 +452,7 @@ func (s *OpenAIGatewayService) handleChatBufferedStreamingResponse(
 			writeChatCompletionsError(c, http.StatusBadRequest, "invalid_request_error", clientMsg)
 			return nil, fmt.Errorf("openai cyber_policy: %s", msg)
 		}
-		return nil, s.newOpenAIStreamFailoverError(c, account, false, requestID, payload, openAICompatFailedResponseMessage(finalResponse))
+		return s.openAICompatBufferedFailedResponseResult(c, account, requestID, finalResponse, openAICompatBufferedRouteChat)
 	}
 
 	// When the terminal event has an empty output array, reconstruct from

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -570,7 +570,7 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", clientMsg)
 			return nil, fmt.Errorf("openai cyber_policy: %s", msg)
 		}
-		return s.openAICompatBufferedFailedResponseFailover(c, account, requestID, finalResponse)
+		return s.openAICompatBufferedFailedResponseResult(c, account, requestID, finalResponse, openAICompatBufferedRouteMessages)
 	}
 
 	// When the terminal event has an empty output array, reconstruct from

--- a/backend/internal/service/openai_gateway_service_tk_buffered_failover.go
+++ b/backend/internal/service/openai_gateway_service_tk_buffered_failover.go
@@ -45,22 +45,42 @@ func (s *OpenAIGatewayService) openAICompatBufferedMissingTerminalResult(
 	return nil, s.newOpenAIStreamFailoverError(c, account, false, requestID, nil, failoverMsg)
 }
 
-func (s *OpenAIGatewayService) openAICompatBufferedFailedResponseFailover(
+// openAICompatBufferedFailedResponseResult mirrors the streaming response.failed
+// policy. The streaming path only fails over when openAIStreamFailedEventShouldFailover
+// agrees (transient / capacity errors); a non-retryable failure (content_policy,
+// safety, invalid_request, …) is forwarded to the client instead of replayed on a
+// sibling account. The buffered path applies the same gate: retryable → failover,
+// non-retryable → surface the upstream message as a client error with no failover.
+// cyber_policy is handled by the caller before reaching here.
+func (s *OpenAIGatewayService) openAICompatBufferedFailedResponseResult(
 	c *gin.Context,
 	account *Account,
 	requestID string,
 	finalResponse *apicompat.ResponsesResponse,
+	route openAICompatBufferedRouteKind,
 ) (*OpenAIForwardResult, error) {
 	if finalResponse == nil {
 		return nil, fmt.Errorf("openai buffered response.failed: nil response")
 	}
 	payload, _ := json.Marshal(gin.H{"type": "response.failed", "response": finalResponse})
-	return nil, s.newOpenAIStreamFailoverError(
-		c,
-		account,
-		false,
-		requestID,
-		payload,
-		openAICompatFailedResponseMessage(finalResponse),
-	)
+	message := openAICompatFailedResponseMessage(finalResponse)
+	if openAIStreamFailedEventShouldFailover(payload, message) {
+		return nil, s.newOpenAIStreamFailoverError(c, account, false, requestID, payload, message)
+	}
+
+	// Non-retryable upstream failure: do not failover (replaying a policy/invalid
+	// rejection on another account is pointless and pollutes sibling cooldown
+	// attribution). Surface the upstream message to the client, as the streaming
+	// path forwards the response.failed event verbatim.
+	clientMsg := message
+	if clientMsg == "" {
+		clientMsg = "Upstream returned a failed response"
+	}
+	if route == openAICompatBufferedRouteMessages {
+		s.recordOpenAIMessagesStreamUpstreamError(c, account, requestID, "buffered_response_failed", clientMsg)
+		writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", clientMsg)
+	} else {
+		writeChatCompletionsError(c, http.StatusBadRequest, "invalid_request_error", clientMsg)
+	}
+	return nil, fmt.Errorf("openai buffered response.failed (non-retryable): %s", message)
 }

--- a/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
@@ -196,6 +196,76 @@ func TestForwardAsAnthropic_BufferedResponseFailedTriggersFailover(t *testing.T)
 	require.False(t, c.Writer.Written())
 }
 
+func TestForwardAsChatCompletions_BufferedResponseFailedNonRetryableNoFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`event: response.failed`,
+		`data: {"type":"response.failed","response":{"id":"resp_failed","object":"response","model":"gpt-5.5","status":"failed","output":[],"error":{"code":"invalid_request_error","message":"messages is not allowed for this model"}}}`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid_chat_failed_nonretryable"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := openAICompatTestOAuthAccount(1, "openai-oauth")
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "gpt-5.5")
+	require.Error(t, err)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "non-retryable response.failed must not failover")
+	require.True(t, c.Writer.Written())
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "not allowed")
+}
+
+func TestForwardAsAnthropic_BufferedResponseFailedNonRetryableNoFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`event: response.failed`,
+		`data: {"type":"response.failed","response":{"id":"resp_failed","object":"response","model":"gpt-5.5","status":"failed","output":[],"error":{"code":"invalid_request_error","message":"messages is not allowed for this model"}}}`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid_messages_failed_nonretryable"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := openAICompatTestOAuthAccount(1, "openai-oauth")
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.5")
+	require.Error(t, err)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "non-retryable response.failed must not failover")
+	require.True(t, c.Writer.Written())
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "not allowed")
+
+	events := openAICompatOpsEvents(t, c)
+	require.Len(t, events, 1)
+	require.Equal(t, "buffered_response_failed", events[0].Kind)
+}
+
 func openAICompatTestOAuthAccount(id int64, name string) *Account {
 	return &Account{
 		ID:          id,

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3370,11 +3370,12 @@
       "path": "backend/internal/service/openai_gateway_service_tk_buffered_failover.go",
       "must_contain": [
         "openAICompatBufferedMissingTerminalResult",
-        "openAICompatBufferedFailedResponseFailover",
+        "openAICompatBufferedFailedResponseResult",
         "acc.HasContent()",
+        "openAIStreamFailedEventShouldFailover",
         "newOpenAIStreamFailoverError"
       ],
-      "rationale": "Non-stream /v1/chat/completions and /v1/messages buffer upstream Responses SSE; when the stream ends without a terminal event and no accumulated output, prod account 64 was returning gateway-generated 502 instead of failing over to a sibling. This companion mirrors the streaming missing-terminal policy (failover before output, client error after partial output). Upstream merges that revert the buffered handlers to direct writeChatCompletionsError/writeAnthropicError silently restore the 502 storm."
+      "rationale": "Non-stream /v1/chat/completions and /v1/messages buffer upstream Responses SSE; when the stream ends without a terminal event and no accumulated output, prod account 64 was returning gateway-generated 502 instead of failing over to a sibling. This companion mirrors the streaming missing-terminal policy (failover before output, client error after partial output) AND the streaming response.failed policy (failover only when openAIStreamFailedEventShouldFailover agrees; non-retryable content_policy/safety/invalid_request failures surface to the client instead of replaying on a sibling). Upstream merges that revert the buffered handlers to direct writeChatCompletionsError/writeAnthropicError silently restore the 502 storm; dropping the shouldFailover gate silently restores pointless sibling failover on non-retryable rejections."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go",
@@ -3382,9 +3383,11 @@
         "TestForwardAsChatCompletions_BufferedMissingTerminalBeforeOutputReturnsFailover",
         "TestForwardAsChatCompletions_BufferedMissingTerminalAfterOutputReturns502WithoutFailover",
         "TestForwardAsAnthropic_BufferedMissingTerminalBeforeOutputReturnsFailover",
-        "TestForwardAsAnthropic_BufferedResponseFailedTriggersFailover"
+        "TestForwardAsAnthropic_BufferedResponseFailedTriggersFailover",
+        "TestForwardAsChatCompletions_BufferedResponseFailedNonRetryableNoFailover",
+        "TestForwardAsAnthropic_BufferedResponseFailedNonRetryableNoFailover"
       ],
-      "rationale": "Regression anchors for buffered missing-terminal failover: [DONE]/EOF with no content must UpstreamFailoverError without committing client body; partial delta without terminal must stay 502 and must not failover."
+      "rationale": "Regression anchors for buffered missing-terminal failover: [DONE]/EOF with no content must UpstreamFailoverError without committing client body; partial delta without terminal must stay 502 and must not failover. The NonRetryable anchors pin the shouldFailover gate: a content_policy/safety/invalid_request response.failed must surface to the client as an error and must NOT failover to a sibling account."
     }
   ]
 }


### PR DESCRIPTION
## 摘要

承接 PR #1004 的 review finding R-001(low / design-quality):非流式缓冲 `response.failed` 的 failover 之前是**无条件**的(仅 cyber_policy 短路),与流式路径不一致。流式路径在 failover 前还要过 `openAIStreamFailedEventShouldFailover()` 门禁——非 cyber 的不可重试错误(`invalid_request` / `content_policy` / `safety` / `violat` 等)会**透传给客户端**而非跨账号重试。

本 PR 让两条缓冲 `response.failed` 分支(chat + messages)都经过同一门禁:

- **可重试**(transient / capacity)→ `UpstreamFailoverError`,与之前行为一致。
- **不可重试**(命中 non-retryable marker)→ 写客户端错误(chat 走 `writeChatCompletionsError`、messages 走 `writeAnthropicError`,均 `400 invalid_request_error`),**不 failover**——镜像流式 else 分支把 `response.failed` 事件透传给客户端的语义。

顺带把 chat 内联的 failed-failover 调用点(`openai_gateway_chat_completions.go`)也收敛进 companion `openAICompatBufferedFailedResponseResult`,与 messages 统一,upstream 文件回归一行 hook。

## 风险

- **常规风险**:仅影响 OpenAI compat 非流式缓冲路径的 `response.failed` 分支。
- cyber_policy 行为不变(在到达 companion 前已由 caller 处理)。
- missing-terminal 行为不变(本 PR 不动)。
- Web impact: none

## 验证

```bash
go test -tags=unit ./internal/service -run 'Buffered(MissingTerminal|ResponseFailed)' -count=1 -v
go test -tags=integration ./internal/service -count=1
./scripts/preflight.sh
```

新增两条回归测试 pin 住门禁语义:

- `TestForwardAsChatCompletions_BufferedResponseFailedNonRetryableNoFailover`
- `TestForwardAsAnthropic_BufferedResponseFailedNonRetryableNoFailover`

非可重试 `response.failed` 必须写客户端 `400` 且 `errors.As(*UpstreamFailoverError)` 为 false。已有 4 条 #1004 回归测试(message="input exceeds the context window" 命中可重试)继续 failover,未受影响。sentinel `gateway-tk.json` 锚点已同步更新(新增 `openAIStreamFailedEventShouldFailover` + 两条新测试名)。

上述命令本地均已 PASS。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
