### PR TITLE
fix: normalize OpenAI OAuth Codex headers

### DIFF
--- a/backend/internal/pkg/openai/request.go
+++ b/backend/internal/pkg/openai/request.go
@@ -3,8 +3,9 @@ package openai
 import "strings"
 
 // CodexCLIUserAgentPrefixes matches Codex CLI User-Agent patterns
-// Examples: "codex_vscode/1.0.0", "codex_cli_rs/0.1.2"
+// Examples: "codex-tui/0.142.0", "codex_vscode/1.0.0", "codex_cli_rs/0.1.2"
 var CodexCLIUserAgentPrefixes = []string{
+	"codex-tui/",
 	"codex_vscode/",
 	"codex_cli_rs/",
 }
@@ -12,6 +13,7 @@ var CodexCLIUserAgentPrefixes = []string{
 // CodexOfficialClientUserAgentPrefixes matches Codex 官方客户端家族 User-Agent 前缀。
 // 该列表仅用于 OpenAI OAuth `codex_cli_only` 访问限制判定。
 var CodexOfficialClientUserAgentPrefixes = []string{
+	"codex-tui/",
 	"codex_cli_rs/",
 	"codex_vscode/",
 	"codex_app/",

--- a/backend/internal/pkg/openai/request_test.go
+++ b/backend/internal/pkg/openai/request_test.go
@@ -8,6 +8,7 @@ func TestIsCodexCLIRequest(t *testing.T) {
 		ua   string
 		want bool
 	}{
+		{name: "codex-tui 前缀", ua: "codex-tui/0.142.0", want: true},
 		{name: "codex_cli_rs 前缀", ua: "codex_cli_rs/0.1.0", want: true},
 		{name: "codex_vscode 前缀", ua: "codex_vscode/1.2.3", want: true},
 		{name: "大小写混合", ua: "Codex_CLI_Rs/0.1.0", want: true},
@@ -33,6 +34,7 @@ func TestIsCodexOfficialClientRequest(t *testing.T) {
 		ua   string
 		want bool
 	}{
+		{name: "codex-tui 前缀", ua: "codex-tui/0.142.0", want: true},
 		{name: "codex_cli_rs 前缀", ua: "codex_cli_rs/0.98.0", want: true},
 		{name: "codex_vscode 前缀", ua: "codex_vscode/1.0.0", want: true},
 		{name: "codex_app 前缀", ua: "codex_app/0.1.0", want: true},

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -110,7 +110,7 @@ const (
 	apiQueryMaxJitter       = 800 * time.Millisecond // 用量查询最大随机延迟
 	windowStatsCacheTTL     = 1 * time.Minute
 	openAIProbeCacheTTL     = 10 * time.Minute
-	openAICodexProbeVersion = "0.125.0"
+	openAICodexProbeVersion = "0.142.0"
 )
 
 // UsageCache 封装账户使用量相关的缓存

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -970,7 +970,7 @@ func TestForwardAsAnthropic_ReusesOAuthCodexTurnState(t *testing.T) {
 	require.NotNil(t, firstResult)
 	require.Empty(t, upstream.requests[0].Header.Get("x-codex-turn-state"))
 	require.Empty(t, upstream.requests[0].Header.Get("OpenAI-Beta"))
-	require.Empty(t, upstream.requests[0].Header.Get("originator"))
+	require.Equal(t, "codex_cli_rs", upstream.requests[0].Header.Get("originator"))
 
 	secondBody := []byte(`{"model":"claude-sonnet-4-5","max_tokens":16,"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"ok"},{"role":"user","content":"second"}],"stream":false}`)
 	secondRec := httptest.NewRecorder()
@@ -985,7 +985,7 @@ func TestForwardAsAnthropic_ReusesOAuthCodexTurnState(t *testing.T) {
 	require.Equal(t, generateSessionUUID(isolateOpenAISessionID(0, "stable-cache-key")), upstream.requests[1].Header.Get("session_id"))
 	require.Empty(t, upstream.requests[1].Header.Get("conversation_id"))
 	require.Empty(t, upstream.requests[1].Header.Get("OpenAI-Beta"))
-	require.Empty(t, upstream.requests[1].Header.Get("originator"))
+	require.Equal(t, "codex_cli_rs", upstream.requests[1].Header.Get("originator"))
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "prompt_cache_key").Exists())
 	// OAuth continuation is now enabled: previous_response_id from turn 1 is attached on turn 2.
 	require.Equal(t, "resp_oauth_first", gjson.GetBytes(upstream.bodies[1], "previous_response_id").String())
@@ -1201,7 +1201,7 @@ func TestForwardAsAnthropic_OAuthKeepsSystemAsDeveloperInput(t *testing.T) {
 	require.True(t, instructions.Exists())
 	require.Empty(t, instructions.String())
 	require.Empty(t, upstream.requests[0].Header.Get("OpenAI-Beta"))
-	require.Empty(t, upstream.requests[0].Header.Get("originator"))
+	require.Equal(t, "codex_cli_rs", upstream.requests[0].Header.Get("originator"))
 }
 
 func TestForwardAsAnthropic_OAuthAddsClaudeCodeTodoGuardForCompatModel(t *testing.T) {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -281,10 +281,10 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	if account.IsOpenAIOAuth() {
 		// Anthropic Messages compatibility uses the ChatGPT Codex SSE endpoint.
 		// Match airgate-openai's request shape: the SSE endpoint does not need
-		// the Responses experimental beta header, and forcing originator can make
-		// ChatGPT select a different internal continuation path.
+		// the Responses experimental beta header. Keep originator so ChatGPT
+		// classifies the request under the official Codex surface instead of
+		// Uncategorized.
 		upstreamReq.Header.Del("OpenAI-Beta")
-		upstreamReq.Header.Del("originator")
 	}
 	if account.IsOpenAIOAuth() && promptCacheKey != "" && strings.TrimSpace(c.GetHeader("conversation_id")) == "" {
 		upstreamReq.Header.Del("conversation_id")

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -42,10 +42,8 @@ const (
 	// OpenAI Platform API for API Key accounts (fallback)
 	openaiPlatformAPIURL   = "https://api.openai.com/v1/responses"
 	openaiStickySessionTTL = time.Hour // 粘性会话TTL
-	// 与真实 Codex CLI 的 User-Agent 结构对齐：
-	// {originator}/{version} ({OS} {OS_version}; {arch}) {terminal}
-	// 旧值 "codex_cli_rs/0.125.0" 缺少 OS/架构/终端后缀，易被上游指纹识别为非官方客户端。
-	codexCLIUserAgent = "codex_cli_rs/0.125.0 (Ubuntu 22.4.0; x86_64) xterm-256color"
+	// 与真实本机 Codex CLI 0.142.0 / chatgpt.com backend capture 对齐。
+	codexCLIUserAgent = "codex-tui/0.142.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.142.0)"
 	// codex_cli_only 拒绝时单个请求头日志长度上限（字符）
 	codexCLIOnlyHeaderValueMaxBytes = 256
 
@@ -59,7 +57,7 @@ const (
 	openAIWSRetryBackoffMaxDefault     = 2 * time.Second
 	openAIWSRetryJitterRatioDefault    = 0.2
 	openAICompactSessionSeedKey        = "openai_compact_session_seed"
-	codexCLIVersion                    = "0.125.0"
+	codexCLIVersion                    = "0.142.0"
 	// Codex 限额快照仅用于后台展示/诊断，不需要每个成功请求都立即落库。
 	openAICodexSnapshotPersistMinInterval = 30 * time.Second
 	// 配额自动暂停时，超过该时长仍未刷新的 used% 快照视为陈旧，不再据此暂停账号。
@@ -1340,13 +1338,42 @@ func (s *OpenAIGatewayService) GenerateSessionHashWithFallback(c *gin.Context, b
 func resolveOpenAIUpstreamOriginator(c *gin.Context, isOfficialClient bool) string {
 	if c != nil {
 		if originator := strings.TrimSpace(c.GetHeader("originator")); originator != "" {
-			return originator
+			if openai.IsCodexOfficialClientOriginator(originator) {
+				return originator
+			}
 		}
 	}
 	if isOfficialClient {
 		return "codex_cli_rs"
 	}
-	return "opencode"
+	return "codex_cli_rs"
+}
+
+func resolveOpenAICodexUserAgent(ctx context.Context, s *OpenAIGatewayService, account *Account, inboundUserAgent string) string {
+	if s != nil && s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
+		return codexCLIUserAgent
+	}
+	if account != nil {
+		if customUA := strings.TrimSpace(account.GetOpenAIUserAgent()); customUA != "" {
+			return customUA
+		}
+	}
+	if ua := strings.TrimSpace(inboundUserAgent); openai.IsCodexOfficialClientRequest(ua) {
+		return ua
+	}
+	if s != nil && s.settingService != nil {
+		if ua := strings.TrimSpace(s.settingService.GetOpenAICodexUserAgent(ctx)); ua != "" {
+			return ua
+		}
+	}
+	return codexCLIUserAgent
+}
+
+func (s *OpenAIGatewayService) applyOpenAICodexUserAgent(ctx context.Context, req *http.Request, account *Account, inboundUserAgent string) {
+	if req == nil || account == nil || !account.IsOpenAIOAuth() {
+		return
+	}
+	req.Header.Set("user-agent", resolveOpenAICodexUserAgent(ctx, s, account, inboundUserAgent))
 }
 
 // BindStickySession sets session -> account binding with standard TTL.
@@ -3769,17 +3796,17 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 		}
 	}
 
-	// 透传模式也支持账户自定义 User-Agent 与 ForceCodexCLI 兜底。
-	customUA := account.GetOpenAIUserAgent()
-	if customUA != "" {
-		req.Header.Set("user-agent", customUA)
-	}
-	if s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
-		req.Header.Set("user-agent", codexCLIUserAgent)
-	}
-	// OAuth 安全透传：对非 Codex UA 统一兜底，降低被上游风控拦截概率。
-	if account.IsOpenAIOAuth() && !openai.IsCodexCLIRequest(req.Header.Get("user-agent")) {
-		req.Header.Set("user-agent", codexCLIUserAgent)
+	if account.IsOpenAIOAuth() {
+		inboundUA := ""
+		if c != nil {
+			inboundUA = c.GetHeader("User-Agent")
+		}
+		s.applyOpenAICodexUserAgent(ctx, req, account, inboundUA)
+	} else {
+		customUA := account.GetOpenAIUserAgent()
+		if customUA != "" {
+			req.Header.Set("user-agent", customUA)
+		}
 	}
 
 	// 浏览器型 UA 兜底：仅 OAuth（ChatGPT 内部接口）账号生效，若最终 user-agent 仍为浏览器
@@ -4665,13 +4692,12 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 		clientConversationID := strings.TrimSpace(req.Header.Get("conversation_id"))
 		req.Header.Del("conversation_id")
 		req.Header.Del("session_id")
+		req.Header.Set("originator", resolveOpenAIUpstreamOriginator(c, isCodexCLI))
 
 		if compatMessagesBridge {
 			req.Header.Del("OpenAI-Beta")
-			req.Header.Del("originator")
 		} else {
 			req.Header.Set("OpenAI-Beta", "responses=experimental")
-			req.Header.Set("originator", resolveOpenAIUpstreamOriginator(c, isCodexCLI))
 		}
 		apiKeyID := getAPIKeyIDFromContext(c)
 		if isOpenAIResponsesCompactPath(c) {
@@ -4693,16 +4719,17 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 		}
 	}
 
-	// Apply custom User-Agent if configured
-	customUA := account.GetOpenAIUserAgent()
-	if customUA != "" {
-		req.Header.Set("user-agent", customUA)
-	}
-
-	// 若开启 ForceCodexCLI，则强制将上游 User-Agent 伪装为 Codex CLI。
-	// 用于网关未透传/改写 User-Agent 时，仍能命中 Codex 侧识别逻辑。
-	if s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
-		req.Header.Set("user-agent", codexCLIUserAgent)
+	if account.IsOpenAIOAuth() {
+		inboundUA := ""
+		if c != nil {
+			inboundUA = c.GetHeader("User-Agent")
+		}
+		s.applyOpenAICodexUserAgent(ctx, req, account, inboundUA)
+	} else {
+		customUA := account.GetOpenAIUserAgent()
+		if customUA != "" {
+			req.Header.Set("user-agent", customUA)
+		}
 	}
 
 	// 浏览器型 UA 兜底：仅 OAuth（ChatGPT 内部接口）账号生效，若最终 user-agent 仍为浏览器

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -42,8 +42,9 @@ const (
 	// OpenAI Platform API for API Key accounts (fallback)
 	openaiPlatformAPIURL   = "https://api.openai.com/v1/responses"
 	openaiStickySessionTTL = time.Hour // 粘性会话TTL
-	// 与真实本机 Codex CLI 0.142.0 / chatgpt.com backend capture 对齐。
-	codexCLIUserAgent = "codex-tui/0.142.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.142.0)"
+	// ForceCodexCLI 硬覆盖与 settingService 缺省时的兜底 UA，与后台默认值共用同一份字面量，
+	// 避免 Codex 版本升级时两处手工同步漂移（见 DefaultOpenAICodexUserAgent）。
+	codexCLIUserAgent = DefaultOpenAICodexUserAgent
 	// codex_cli_only 拒绝时单个请求头日志长度上限（字符）
 	codexCLIOnlyHeaderValueMaxBytes = 256
 

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -2304,7 +2304,7 @@ func TestOpenAIBuildUpstreamRequestOAuthMessagesBridgeUsesSessionOnly(t *testing
 	require.NotEmpty(t, req.Header.Get("Session_Id"))
 	require.Empty(t, req.Header.Get("Conversation_Id"))
 	require.Empty(t, req.Header.Get("OpenAI-Beta"))
-	require.Empty(t, req.Header.Get("originator"))
+	require.Equal(t, "codex_cli_rs", req.Header.Get("originator"))
 }
 
 func TestOpenAIBuildUpstreamRequestPreservesCompactPathForAPIKeyBaseURL(t *testing.T) {
@@ -2389,6 +2389,17 @@ func TestOpenAIBuildUpstreamRequestOAuthOfficialClientOriginatorCompatibility(t 
 			require.Equal(t, tt.wantOriginator, req.Header.Get("originator"))
 		})
 	}
+}
+
+func TestResolveOpenAIUpstreamOriginatorRejectsNonCodexOriginator(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("originator", "opencode")
+
+	require.Equal(t, "codex_cli_rs", resolveOpenAIUpstreamOriginator(c, false))
 }
 
 // ==================== P1-08 修复：model 替换性能优化测试 ====================

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -194,7 +194,81 @@ func TestOpenAIGatewayService_OAuthMessagesBridgeDoesNotInjectDefaultInstruction
 	require.NotEmpty(t, upstream.lastReq.Header.Get("Session_Id"))
 	require.Empty(t, upstream.lastReq.Header.Get("Conversation_Id"))
 	require.Empty(t, upstream.lastReq.Header.Get("OpenAI-Beta"))
-	require.Empty(t, upstream.lastReq.Header.Get("originator"))
+	require.Equal(t, "codex_cli_rs", upstream.lastReq.Header.Get("originator"))
+}
+
+func TestOpenAIGatewayService_OAuthUpstreamHeadersNormalizeNonCodexIngress(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		path           string
+		body           []byte
+		userAgent      string
+		wantOriginator string
+	}{
+		{
+			name:           "responses python requests",
+			path:           "/v1/responses",
+			body:           []byte(`{"model":"gpt-5.5","stream":true,"instructions":"local-test-instructions","input":[{"type":"input_text","text":"hi"}]}`),
+			userAgent:      "python-requests/2.33.1",
+			wantOriginator: "codex_cli_rs",
+		},
+		{
+			name:           "chat completions python urllib",
+			path:           "/v1/chat/completions",
+			body:           []byte(`{"model":"gpt-5.5","stream":true,"messages":[{"role":"user","content":"hi"}]}`),
+			userAgent:      "Python-urllib/3.13",
+			wantOriginator: "codex_cli_rs",
+		},
+		{
+			name:           "messages claude cli",
+			path:           "/v1/messages",
+			body:           []byte(`{"model":"claude-opus-4-7","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"hi"}]}`),
+			userAgent:      "claude-cli/2.1.179 (external, sdk-cli)",
+			wantOriginator: "codex_cli_rs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, tt.path, bytes.NewReader(tt.body))
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Request.Header.Set("User-Agent", tt.userAgent)
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid-normalize"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"stop after capture"}}`)),
+			}}
+			svc := &OpenAIGatewayService{
+				cfg:          &config.Config{},
+				httpUpstream: upstream,
+			}
+			account := &Account{
+				ID:          123,
+				Name:        "acc",
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeOAuth,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"access_token":       "oauth-token",
+					"chatgpt_account_id": "chatgpt-acc",
+				},
+				Status:      StatusActive,
+				Schedulable: true,
+			}
+
+			_, err := svc.Forward(context.Background(), c, account, tt.body)
+			require.Error(t, err)
+			require.NotNil(t, upstream.lastReq)
+			require.Equal(t, DefaultOpenAICodexUserAgent, upstream.lastReq.Header.Get("User-Agent"))
+			require.Equal(t, tt.wantOriginator, upstream.lastReq.Header.Get("originator"))
+			require.NotEqual(t, tt.userAgent, upstream.lastReq.Header.Get("User-Agent"))
+		})
+	}
 }
 
 type openAIPassthroughFailoverRepo struct {

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -1164,22 +1164,24 @@ func (s *OpenAIGatewayService) buildOpenAIWSHeaders(
 	}
 	headers.Set("OpenAI-Beta", betaValue)
 
-	customUA := ""
-	if account != nil {
-		customUA = account.GetOpenAIUserAgent()
-	}
-	if strings.TrimSpace(customUA) != "" {
-		headers.Set("user-agent", customUA)
-	} else if c != nil {
-		if ua := strings.TrimSpace(c.GetHeader("User-Agent")); ua != "" {
-			headers.Set("user-agent", ua)
+	if account != nil && account.Type == AccountTypeOAuth {
+		inboundUA := ""
+		if c != nil {
+			inboundUA = c.GetHeader("User-Agent")
 		}
-	}
-	if s != nil && s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
-		headers.Set("user-agent", codexCLIUserAgent)
-	}
-	if account != nil && account.Type == AccountTypeOAuth && !openai.IsCodexCLIRequest(headers.Get("user-agent")) {
-		headers.Set("user-agent", codexCLIUserAgent)
+		headers.Set("user-agent", resolveOpenAICodexUserAgent(context.Background(), s, account, inboundUA))
+	} else {
+		customUA := ""
+		if account != nil {
+			customUA = account.GetOpenAIUserAgent()
+		}
+		if strings.TrimSpace(customUA) != "" {
+			headers.Set("user-agent", customUA)
+		} else if c != nil {
+			if ua := strings.TrimSpace(c.GetHeader("User-Agent")); ua != "" {
+				headers.Set("user-agent", ua)
+			}
+		}
 	}
 
 	return headers, sessionResolution

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -146,8 +146,8 @@ const antigravityUserAgentVersionCacheTTL = 60 * time.Second
 const antigravityUserAgentVersionErrorTTL = 5 * time.Second
 const antigravityUserAgentVersionDBTimeout = 5 * time.Second
 
-// DefaultOpenAICodexUserAgent OpenAI Codex 默认 User-Agent（用于规避 Cloudflare 对浏览器 UA 的质询）
-const DefaultOpenAICodexUserAgent = "codex-tui/0.125.0 (Ubuntu 22.4.0; x86_64) xterm-256color (codex-tui; 0.125.0)"
+// DefaultOpenAICodexUserAgent OpenAI Codex 默认 User-Agent。
+const DefaultOpenAICodexUserAgent = "codex-tui/0.142.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.142.0)"
 
 // cachedOpenAICodexUserAgent 缓存 OpenAI Codex UA（进程内缓存，60s TTL）
 type cachedOpenAICodexUserAgent struct {

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 512,
-  "hash": "d24468c4e9d2c2feaabb26cf57237f3d2c1684ef7b9a1509c82a73a851bc9788",
+  "hash": "5107df53ab1c914a115e8d12a86d5043cec8082188b5092cb75a4bae3005d24f",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -6392,8 +6392,8 @@ export default {
         antigravityUserAgentVersionPlaceholder: '1.23.2',
         antigravityUserAgentVersionHint: 'Leave empty to use ANTIGRAVITY_USER_AGENT_VERSION or the built-in default 1.23.2; when set, the admin setting takes precedence.',
         openaiCodexUserAgent: 'OpenAI Codex UA',
-        openaiCodexUserAgentPlaceholder: 'codex-tui/0.125.0 (Ubuntu 22.4.0; x86_64) xterm-256color (codex-tui; 0.125.0)',
-        openaiCodexUserAgentHint: 'Used to bypass Cloudflare browser-UA challenges on the OpenAI upstream. Only applies when the client User-Agent is detected as a browser (Mozilla/...). Leave empty to use the built-in default.',
+        openaiCodexUserAgentPlaceholder: 'codex-tui/0.142.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.142.0)',
+        openaiCodexUserAgentHint: 'Fallback Codex User-Agent for OpenAI OAuth upstream requests. Account-level custom UA wins, and real Codex client UA is preserved. Leave empty to use the built-in default.',
         openaiAllowClaudeCodeCodexPlugin: "Allow using the Codex plugin in Claude Code",
         openaiAllowClaudeCodeCodexPluginDesc:
           "Global switch; only affects OpenAI OAuth accounts that have 'Codex official clients only' enabled. When on, all such accounts additionally allow requests from the Claude Code Codex plugin (exact match on originator=Claude Code) without per-account config; upstream requests remain pass-through.",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -6536,8 +6536,8 @@ export default {
         antigravityUserAgentVersionPlaceholder: '1.23.2',
         antigravityUserAgentVersionHint: '留空时使用 ANTIGRAVITY_USER_AGENT_VERSION 或内置默认值 1.23.2；填写后后台设置优先。',
         openaiCodexUserAgent: 'OpenAI Codex UA',
-        openaiCodexUserAgentPlaceholder: 'codex-tui/0.125.0 (Ubuntu 22.4.0; x86_64) xterm-256color (codex-tui; 0.125.0)',
-        openaiCodexUserAgentHint: '用于规避 OpenAI 上游 Cloudflare 对浏览器 UA 的访问质询。仅在检测到客户端 User-Agent 为浏览器（Mozilla/...）时生效，其他客户端原样透传。留空使用内置默认值。',
+        openaiCodexUserAgentPlaceholder: 'codex-tui/0.142.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.142.0)',
+        openaiCodexUserAgentHint: 'OpenAI OAuth 上游请求的 Codex User-Agent 兜底值；账号自定义 UA 优先，真实 Codex 客户端 UA 原样保留。留空使用内置默认值。',
         openaiAllowClaudeCodeCodexPlugin: '允许在 Claude Code 中使用 Codex 插件',
         openaiAllowClaudeCodeCodexPluginDesc:
           '全局开关，仅对已开启「仅允许 Codex 官方客户端」的 OpenAI OAuth 账号生效。开启后，所有此类账号都额外放行通过 Claude Code 的 Codex 插件发起的请求（精确匹配 originator=Claude Code），无需逐账号配置；上游请求仍保持透传。',

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3385,6 +3385,36 @@
         "TestForwardAsAnthropic_BufferedResponseFailedTriggersFailover"
       ],
       "rationale": "Regression anchors for buffered missing-terminal failover: [DONE]/EOF with no content must UpstreamFailoverError without committing client body; partial delta without terminal must stay 502 and must not failover."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "func resolveOpenAICodexUserAgent(",
+        "func (s *OpenAIGatewayService) applyOpenAICodexUserAgent(",
+        "openai.IsCodexOfficialClientOriginator(originator)"
+      ],
+      "rationale": "OpenAI OAuth upstream Codex fingerprint normalization (prod GPT-pro1 id=9, 2026-06-25). Non-Codex OAuth ingress (python-requests/urllib/SDK) must be re-presented upstream as official Codex: applyOpenAICodexUserAgent sets a Codex UA (precedence ForceCodexCLI > account custom UA > preserve-real-Codex-ingress > admin setting > built-in default) and resolveOpenAIUpstreamOriginator only preserves an inbound originator when IsCodexOfficialClientOriginator() accepts it, otherwise forces codex_cli_rs. Dropping these helpers/wiring silently reverts to forwarding arbitrary client identity, which OpenAI categorizes as Uncategorized and which degrades account health/risk-control — and unit tests on unrelated paths can still stay green. NOTE: anchors structural behavior only, never the codex-tui UA version literal (that is a fingerprint value governed by tokenkey-cc/openai fingerprint-alignment and is meant to drift)."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages.go",
+      "must_contain": [
+        "classifies the request under the official Codex surface"
+      ],
+      "rationale": "Anthropic Messages -> Codex SSE bridge must KEEP the originator header (set to codex_cli_rs upstream) so ChatGPT classifies the request under the official Codex surface, NOT delete it. This reverses the earlier req.Header.Del(\"originator\") that the prior code carried; that exact spot has proven TK<->upstream churn, so an upstream merge re-adding the Del would silently re-introduce Uncategorized classification. Anchoring the rationale comment forces any revert to also drop the comment, surfacing the change in preflight + the upstream-merge PR shape check. Paired regression tests live in openai_compat_model_test.go (TestForwardAsAnthropic_* assert originator==codex_cli_rs)."
+    },
+    {
+      "path": "backend/internal/pkg/openai/request.go",
+      "must_contain": [
+        "\"codex-tui/\","
+      ],
+      "rationale": "codex-tui/ is the real local Codex CLI UA family token (capture 0.142.0). It must stay in both CodexCLIUserAgentPrefixes and CodexOfficialClientUserAgentPrefixes so (a) real codex-tui ingress is recognized as Codex and preserved, and (b) codex_cli_only access restriction accepts it. Dropping it makes legitimate Codex clients fall through to forced-UA rewrite and breaks the codex_cli_only allowlist for the dominant client. Anchors the prefix token (not a version), so upstream merges to the prefix lists are caught."
+    },
+    {
+      "path": "backend/internal/service/openai_oauth_passthrough_test.go",
+      "must_contain": [
+        "TestOpenAIGatewayService_OAuthUpstreamHeadersNormalizeNonCodexIngress"
+      ],
+      "rationale": "Regression anchor for the Codex fingerprint normalization: non-Codex OAuth ingress (python-requests / Python-urllib / claude-cli) across /v1/responses, /v1/chat/completions, /v1/messages must reach upstream with a Codex UA and originator==codex_cli_rs, never the inbound client identity. Pins the test so an upstream refactor cannot silently drop the only end-to-end guard for the mimicry behavior."
     }
   ]
 }


### PR DESCRIPTION
## 概述
- 对非 Codex 入站流量，归一化 OpenAI OAuth 上游的 `User-Agent` / `originator`，使 GPT-pro1 流量统一以 Codex CLI 身份呈现，而非任意 SDK/urllib 客户端。
- 当入站本身已是 Codex 时，保留真实官方 Codex 客户端请求头；账号自定义 UA 与 `ForceCodexCLI` 的优先级保持不变。
- 新增 `codex-tui/` 识别，内置 Codex 兜底 UA/版本更新为 `codex-tui/0.142.0`；同步刷新后台文案与嵌入前端的新鲜度哈希。

## 排查记录
- 线上 GPT-pro1 账号 id=9 健康，能正常返回 Codex 用量窗口。
- 近期 id=9 的用量中，`/v1/chat/completions -> /v1/responses` 大量来自 `python-requests`、`Python-urllib` 及 OpenAI SDK 的 User-Agent；少量合法 Codex 客户端流量本身已携带 `codex-tui`、`Codex Desktop` 或扩展风格请求头。
- 本 PR 解决的根因：OpenAI OAuth 上游转发会保留非 Codex 入站身份，被上游归类为 Uncategorized。

## Sentinel 评审
本 PR 改动既有 OpenAI OAuth 网关/请求头行为及对应测试。经 xj-review「上游覆盖门禁自问」复核：UA/originator 归一化是 load-bearing fingerprint/mimicry 行为，且活在上游高频编辑的 `openai_gateway_service.go` / `openai_gateway_messages.go` / `request.go`（bridge originator 是对旧代码 `Del("originator")` 的反转）。`gateway-tk.json` 此前无锚点覆盖该语义，故本 PR **新增 4 条 sentinel**（纯结构行为，不 pin codex-tui UA 版本字面量）：
- `openai_gateway_service.go`：`resolveOpenAICodexUserAgent` / `applyOpenAICodexUserAgent` / `IsCodexOfficialClientOriginator(originator)` 入口与 originator 门禁
- `openai_gateway_messages.go`：bridge「保留 originator」rationale 注释
- `request.go`：`codex-tui/` 前缀 token
- `openai_oauth_passthrough_test.go`：端到端归一化回归测试


## xj-review 收口
- 经 `/xj-review #1007` 审查，决策 `merge-ready`（零 medium+ finding）。
- R-001（low，重复维护）已修复：`codexCLIUserAgent` 与 `DefaultOpenAICodexUserAgent` 此前各存一份逐字节相同的 codex-tui UA 字面量，每次 Codex 版本升级需手工同步两处；现改为前者直接引用后者，单一来源，消除指纹漂移隐患。仅常量收敛，无行为变化。
- R-002（low，验证缺口）：messages-bridge 路径的 originator 行为由"删除"反转为保留 `codex_cli_rs`，stub 测试已覆盖请求头与续接逻辑，但真实 ChatGPT 续接路径无法在单测中验证。建议合并后对真实上游确认 bridge 续接（turn-state / previous_response_id 复用）未退化，作为 prod 烟测一项。

## 测试
- `go test ./internal/pkg/openai ./internal/service -run 'OpenAI|Codex|ForwardAsAnthropic' -count=1`
- `pnpm --dir frontend run build`
- `git diff --check`
- `./scripts/preflight.sh`（含全部 sub2api sentinel 门禁，PASS）
