### PR TITLE
fix(security): add HSTS header + sanitize validator binding errors

### DIFF
--- a/backend/internal/handler/admin/account_codex_import.go
+++ b/backend/internal/handler/admin/account_codex_import.go
@@ -112,7 +112,7 @@ type codexAccountIndex struct {
 func (h *AccountHandler) ImportCodexSession(c *gin.Context) {
 	var req CodexSessionImportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if req.Concurrency != nil && *req.Concurrency < 0 {

--- a/backend/internal/handler/admin/account_codex_import.go
+++ b/backend/internal/handler/admin/account_codex_import.go
@@ -112,7 +112,7 @@ type codexAccountIndex struct {
 func (h *AccountHandler) ImportCodexSession(c *gin.Context) {
 	var req CodexSessionImportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if req.Concurrency != nil && *req.Concurrency < 0 {

--- a/backend/internal/handler/admin/account_data.go
+++ b/backend/internal/handler/admin/account_data.go
@@ -213,7 +213,7 @@ func (h *AccountHandler) ExportData(c *gin.Context) {
 func (h *AccountHandler) ImportData(c *gin.Context) {
 	var req DataImportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/account_data.go
+++ b/backend/internal/handler/admin/account_data.go
@@ -213,7 +213,7 @@ func (h *AccountHandler) ExportData(c *gin.Context) {
 func (h *AccountHandler) ImportData(c *gin.Context) {
 	var req DataImportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -478,7 +478,7 @@ func (h *AccountHandler) GetByID(c *gin.Context) {
 func (h *AccountHandler) CheckMixedChannel(c *gin.Context) {
 	var req CheckMixedChannelRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -522,7 +522,7 @@ func (h *AccountHandler) CheckMixedChannel(c *gin.Context) {
 func (h *AccountHandler) Create(c *gin.Context) {
 	var req CreateAccountRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if req.RateMultiplier != nil && *req.RateMultiplier < 0 {
@@ -615,7 +615,7 @@ func (h *AccountHandler) Update(c *gin.Context) {
 
 	var req UpdateAccountRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if req.RateMultiplier != nil && *req.RateMultiplier < 0 {
@@ -799,7 +799,7 @@ func (h *AccountHandler) RecoverState(c *gin.Context) {
 func (h *AccountHandler) SyncFromCRS(c *gin.Context) {
 	var req SyncFromCRSRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -830,7 +830,7 @@ func (h *AccountHandler) SyncFromCRS(c *gin.Context) {
 func (h *AccountHandler) PreviewFromCRS(c *gin.Context) {
 	var req PreviewFromCRSRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1031,7 +1031,7 @@ func (h *AccountHandler) ApplyOAuthCredentials(c *gin.Context) {
 
 	var req ApplyOAuthCredentialsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1175,7 +1175,7 @@ func (h *AccountHandler) BatchClearError(c *gin.Context) {
 		AccountIDs []int64 `json:"account_ids"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if len(req.AccountIDs) == 0 {
@@ -1243,7 +1243,7 @@ func (h *AccountHandler) BatchRefresh(c *gin.Context) {
 		AccountIDs []int64 `json:"account_ids"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if len(req.AccountIDs) == 0 {
@@ -1337,7 +1337,7 @@ func (h *AccountHandler) BatchCreate(c *gin.Context) {
 		Accounts []CreateAccountRequest `json:"accounts" binding:"required,min=1"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1475,7 +1475,7 @@ type BatchUpdateCredentialsRequest struct {
 func (h *AccountHandler) BatchUpdateCredentials(c *gin.Context) {
 	var req BatchUpdateCredentialsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1557,7 +1557,7 @@ func (h *AccountHandler) BatchUpdateCredentials(c *gin.Context) {
 func (h *AccountHandler) BulkUpdate(c *gin.Context) {
 	var req BulkUpdateAccountsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if req.RateMultiplier != nil && *req.RateMultiplier < 0 {
@@ -1698,7 +1698,7 @@ type ExchangeCodeRequest struct {
 func (h *OAuthHandler) ExchangeCode(c *gin.Context) {
 	var req ExchangeCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1720,7 +1720,7 @@ func (h *OAuthHandler) ExchangeCode(c *gin.Context) {
 func (h *OAuthHandler) ExchangeSetupTokenCode(c *gin.Context) {
 	var req ExchangeCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1748,7 +1748,7 @@ type CookieAuthRequest struct {
 func (h *OAuthHandler) CookieAuth(c *gin.Context) {
 	var req CookieAuthRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1770,7 +1770,7 @@ func (h *OAuthHandler) CookieAuth(c *gin.Context) {
 func (h *OAuthHandler) SetupTokenCookieAuth(c *gin.Context) {
 	var req CookieAuthRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1931,7 +1931,7 @@ type BatchTodayStatsRequest struct {
 func (h *AccountHandler) GetBatchTodayStats(c *gin.Context) {
 	var req BatchTodayStatsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1988,7 +1988,7 @@ func (h *AccountHandler) SetSchedulable(c *gin.Context) {
 
 	var req SetSchedulableRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -2275,7 +2275,7 @@ func (h *AccountHandler) SyncUpstreamModelsPreview(c *gin.Context) {
 		APIKey   string `json:"api_key" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -478,7 +478,7 @@ func (h *AccountHandler) GetByID(c *gin.Context) {
 func (h *AccountHandler) CheckMixedChannel(c *gin.Context) {
 	var req CheckMixedChannelRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -522,7 +522,7 @@ func (h *AccountHandler) CheckMixedChannel(c *gin.Context) {
 func (h *AccountHandler) Create(c *gin.Context) {
 	var req CreateAccountRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if req.RateMultiplier != nil && *req.RateMultiplier < 0 {
@@ -615,7 +615,7 @@ func (h *AccountHandler) Update(c *gin.Context) {
 
 	var req UpdateAccountRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if req.RateMultiplier != nil && *req.RateMultiplier < 0 {
@@ -799,7 +799,7 @@ func (h *AccountHandler) RecoverState(c *gin.Context) {
 func (h *AccountHandler) SyncFromCRS(c *gin.Context) {
 	var req SyncFromCRSRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -830,7 +830,7 @@ func (h *AccountHandler) SyncFromCRS(c *gin.Context) {
 func (h *AccountHandler) PreviewFromCRS(c *gin.Context) {
 	var req PreviewFromCRSRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1031,7 +1031,7 @@ func (h *AccountHandler) ApplyOAuthCredentials(c *gin.Context) {
 
 	var req ApplyOAuthCredentialsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1175,7 +1175,7 @@ func (h *AccountHandler) BatchClearError(c *gin.Context) {
 		AccountIDs []int64 `json:"account_ids"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if len(req.AccountIDs) == 0 {
@@ -1243,7 +1243,7 @@ func (h *AccountHandler) BatchRefresh(c *gin.Context) {
 		AccountIDs []int64 `json:"account_ids"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if len(req.AccountIDs) == 0 {
@@ -1337,7 +1337,7 @@ func (h *AccountHandler) BatchCreate(c *gin.Context) {
 		Accounts []CreateAccountRequest `json:"accounts" binding:"required,min=1"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1475,7 +1475,7 @@ type BatchUpdateCredentialsRequest struct {
 func (h *AccountHandler) BatchUpdateCredentials(c *gin.Context) {
 	var req BatchUpdateCredentialsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1557,7 +1557,7 @@ func (h *AccountHandler) BatchUpdateCredentials(c *gin.Context) {
 func (h *AccountHandler) BulkUpdate(c *gin.Context) {
 	var req BulkUpdateAccountsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if req.RateMultiplier != nil && *req.RateMultiplier < 0 {
@@ -1698,7 +1698,7 @@ type ExchangeCodeRequest struct {
 func (h *OAuthHandler) ExchangeCode(c *gin.Context) {
 	var req ExchangeCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1720,7 +1720,7 @@ func (h *OAuthHandler) ExchangeCode(c *gin.Context) {
 func (h *OAuthHandler) ExchangeSetupTokenCode(c *gin.Context) {
 	var req ExchangeCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1748,7 +1748,7 @@ type CookieAuthRequest struct {
 func (h *OAuthHandler) CookieAuth(c *gin.Context) {
 	var req CookieAuthRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1770,7 +1770,7 @@ func (h *OAuthHandler) CookieAuth(c *gin.Context) {
 func (h *OAuthHandler) SetupTokenCookieAuth(c *gin.Context) {
 	var req CookieAuthRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1931,7 +1931,7 @@ type BatchTodayStatsRequest struct {
 func (h *AccountHandler) GetBatchTodayStats(c *gin.Context) {
 	var req BatchTodayStatsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1988,7 +1988,7 @@ func (h *AccountHandler) SetSchedulable(c *gin.Context) {
 
 	var req SetSchedulableRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -2275,7 +2275,7 @@ func (h *AccountHandler) SyncUpstreamModelsPreview(c *gin.Context) {
 		APIKey   string `json:"api_key" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/account_handler_tk_passive_usage_batch.go
+++ b/backend/internal/handler/admin/account_handler_tk_passive_usage_batch.go
@@ -25,7 +25,7 @@ type BatchPassiveUsageRequest struct {
 func (h *AccountHandler) GetBatchPassiveUsage(c *gin.Context) {
 	var req BatchPassiveUsageRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/account_handler_tk_passive_usage_batch.go
+++ b/backend/internal/handler/admin/account_handler_tk_passive_usage_batch.go
@@ -25,7 +25,7 @@ type BatchPassiveUsageRequest struct {
 func (h *AccountHandler) GetBatchPassiveUsage(c *gin.Context) {
 	var req BatchPassiveUsageRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/affiliate_handler.go
+++ b/backend/internal/handler/admin/affiliate_handler.go
@@ -67,7 +67,7 @@ func (h *AffiliateHandler) UpdateUserSettings(c *gin.Context) {
 
 	var req UpdateAffiliateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -135,7 +135,7 @@ type BatchSetRateRequest struct {
 func (h *AffiliateHandler) BatchSetRate(c *gin.Context) {
 	var req BatchSetRateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if len(req.UserIDs) == 0 {

--- a/backend/internal/handler/admin/affiliate_handler.go
+++ b/backend/internal/handler/admin/affiliate_handler.go
@@ -67,7 +67,7 @@ func (h *AffiliateHandler) UpdateUserSettings(c *gin.Context) {
 
 	var req UpdateAffiliateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -135,7 +135,7 @@ type BatchSetRateRequest struct {
 func (h *AffiliateHandler) BatchSetRate(c *gin.Context) {
 	var req BatchSetRateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if len(req.UserIDs) == 0 {

--- a/backend/internal/handler/admin/announcement_handler.go
+++ b/backend/internal/handler/admin/announcement_handler.go
@@ -105,7 +105,7 @@ func (h *AnnouncementHandler) GetByID(c *gin.Context) {
 func (h *AnnouncementHandler) Create(c *gin.Context) {
 	var req CreateAnnouncementRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -153,7 +153,7 @@ func (h *AnnouncementHandler) Update(c *gin.Context) {
 
 	var req UpdateAnnouncementRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/announcement_handler.go
+++ b/backend/internal/handler/admin/announcement_handler.go
@@ -105,7 +105,7 @@ func (h *AnnouncementHandler) GetByID(c *gin.Context) {
 func (h *AnnouncementHandler) Create(c *gin.Context) {
 	var req CreateAnnouncementRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -153,7 +153,7 @@ func (h *AnnouncementHandler) Update(c *gin.Context) {
 
 	var req UpdateAnnouncementRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/apikey_handler.go
+++ b/backend/internal/handler/admin/apikey_handler.go
@@ -39,7 +39,7 @@ func (h *AdminAPIKeyHandler) UpdateGroup(c *gin.Context) {
 
 	var req AdminUpdateAPIKeyGroupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/apikey_handler.go
+++ b/backend/internal/handler/admin/apikey_handler.go
@@ -39,7 +39,7 @@ func (h *AdminAPIKeyHandler) UpdateGroup(c *gin.Context) {
 
 	var req AdminUpdateAPIKeyGroupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/apikey_handler_test.go
+++ b/backend/internal/handler/admin/apikey_handler_test.go
@@ -47,7 +47,12 @@ func TestAdminAPIKeyHandler_UpdateGroup_InvalidJSON(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	// 安全审计 P2-1：绑定失败统一返回通用 "invalid request"，不透出 validator 字段/框架细节。
-	require.Contains(t, rec.Body.String(), "invalid request")
+	// 这条经真实端点（bind 失败）兜住调用点，防上游合并把 "Invalid request: "+err.Error() 改回来。
+	body := rec.Body.String()
+	require.Contains(t, body, "invalid request")
+	for _, leak := range []string{"Field validation", "Error:Field", "tag", "Request.", "Key:"} {
+		require.NotContains(t, body, leak, "绑定失败响应不得泄露 validator/框架内部细节")
+	}
 }
 
 func TestAdminAPIKeyHandler_UpdateGroup_KeyNotFound(t *testing.T) {

--- a/backend/internal/handler/admin/apikey_handler_test.go
+++ b/backend/internal/handler/admin/apikey_handler_test.go
@@ -46,7 +46,8 @@ func TestAdminAPIKeyHandler_UpdateGroup_InvalidJSON(t *testing.T) {
 	router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
-	require.Contains(t, rec.Body.String(), "Invalid request")
+	// 安全审计 P2-1：绑定失败统一返回通用 "invalid request"，不透出 validator 字段/框架细节。
+	require.Contains(t, rec.Body.String(), "invalid request")
 }
 
 func TestAdminAPIKeyHandler_UpdateGroup_KeyNotFound(t *testing.T) {

--- a/backend/internal/handler/admin/backup_handler.go
+++ b/backend/internal/handler/admin/backup_handler.go
@@ -33,7 +33,7 @@ func (h *BackupHandler) GetS3Config(c *gin.Context) {
 func (h *BackupHandler) UpdateS3Config(c *gin.Context) {
 	var req service.BackupS3Config
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	cfg, err := h.backupService.UpdateS3Config(c.Request.Context(), req)
@@ -47,7 +47,7 @@ func (h *BackupHandler) UpdateS3Config(c *gin.Context) {
 func (h *BackupHandler) TestS3Connection(c *gin.Context) {
 	var req service.BackupS3Config
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	err := h.backupService.TestS3Connection(c.Request.Context(), req)
@@ -72,7 +72,7 @@ func (h *BackupHandler) GetSchedule(c *gin.Context) {
 func (h *BackupHandler) UpdateSchedule(c *gin.Context) {
 	var req service.BackupScheduleConfig
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	cfg, err := h.backupService.UpdateSchedule(c.Request.Context(), req)

--- a/backend/internal/handler/admin/backup_handler.go
+++ b/backend/internal/handler/admin/backup_handler.go
@@ -33,7 +33,7 @@ func (h *BackupHandler) GetS3Config(c *gin.Context) {
 func (h *BackupHandler) UpdateS3Config(c *gin.Context) {
 	var req service.BackupS3Config
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	cfg, err := h.backupService.UpdateS3Config(c.Request.Context(), req)
@@ -47,7 +47,7 @@ func (h *BackupHandler) UpdateS3Config(c *gin.Context) {
 func (h *BackupHandler) TestS3Connection(c *gin.Context) {
 	var req service.BackupS3Config
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	err := h.backupService.TestS3Connection(c.Request.Context(), req)
@@ -72,7 +72,7 @@ func (h *BackupHandler) GetSchedule(c *gin.Context) {
 func (h *BackupHandler) UpdateSchedule(c *gin.Context) {
 	var req service.BackupScheduleConfig
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	cfg, err := h.backupService.UpdateSchedule(c.Request.Context(), req)

--- a/backend/internal/handler/admin/compliance_handler.go
+++ b/backend/internal/handler/admin/compliance_handler.go
@@ -42,7 +42,7 @@ func (h *ComplianceHandler) GetStatus(c *gin.Context) {
 func (h *ComplianceHandler) Accept(c *gin.Context) {
 	var req AcceptAdminComplianceRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/compliance_handler.go
+++ b/backend/internal/handler/admin/compliance_handler.go
@@ -42,7 +42,7 @@ func (h *ComplianceHandler) GetStatus(c *gin.Context) {
 func (h *ComplianceHandler) Accept(c *gin.Context) {
 	var req AcceptAdminComplianceRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/content_moderation_handler.go
+++ b/backend/internal/handler/admin/content_moderation_handler.go
@@ -80,7 +80,7 @@ func (h *ContentModerationHandler) GetConfig(c *gin.Context) {
 func (h *ContentModerationHandler) UpdateConfig(c *gin.Context) {
 	var req contentModerationConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	cfg, err := h.service.UpdateConfig(c.Request.Context(), service.UpdateContentModerationConfigInput{
@@ -126,7 +126,7 @@ func (h *ContentModerationHandler) UpdateConfig(c *gin.Context) {
 func (h *ContentModerationHandler) TestAPIKeys(c *gin.Context) {
 	var req contentModerationAPIKeyTestRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	result, err := h.service.TestAPIKeys(c.Request.Context(), service.TestContentModerationAPIKeysInput{
@@ -217,7 +217,7 @@ func (h *ContentModerationHandler) UnbanUser(c *gin.Context) {
 func (h *ContentModerationHandler) DeleteFlaggedHash(c *gin.Context) {
 	var req contentModerationHashRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	result, err := h.service.DeleteFlaggedInputHash(c.Request.Context(), req.InputHash)

--- a/backend/internal/handler/admin/content_moderation_handler.go
+++ b/backend/internal/handler/admin/content_moderation_handler.go
@@ -80,7 +80,7 @@ func (h *ContentModerationHandler) GetConfig(c *gin.Context) {
 func (h *ContentModerationHandler) UpdateConfig(c *gin.Context) {
 	var req contentModerationConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	cfg, err := h.service.UpdateConfig(c.Request.Context(), service.UpdateContentModerationConfigInput{
@@ -126,7 +126,7 @@ func (h *ContentModerationHandler) UpdateConfig(c *gin.Context) {
 func (h *ContentModerationHandler) TestAPIKeys(c *gin.Context) {
 	var req contentModerationAPIKeyTestRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	result, err := h.service.TestAPIKeys(c.Request.Context(), service.TestContentModerationAPIKeysInput{
@@ -217,7 +217,7 @@ func (h *ContentModerationHandler) UnbanUser(c *gin.Context) {
 func (h *ContentModerationHandler) DeleteFlaggedHash(c *gin.Context) {
 	var req contentModerationHashRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	result, err := h.service.DeleteFlaggedInputHash(c.Request.Context(), req.InputHash)

--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -543,7 +543,7 @@ func (h *DashboardHandler) GetUserSpendingRanking(c *gin.Context) {
 func (h *DashboardHandler) GetBatchUsersUsage(c *gin.Context) {
 	var req BatchUsersUsageRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -592,7 +592,7 @@ type BatchAPIKeysUsageRequest struct {
 func (h *DashboardHandler) GetBatchAPIKeysUsage(c *gin.Context) {
 	var req BatchAPIKeysUsageRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -543,7 +543,7 @@ func (h *DashboardHandler) GetUserSpendingRanking(c *gin.Context) {
 func (h *DashboardHandler) GetBatchUsersUsage(c *gin.Context) {
 	var req BatchUsersUsageRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -592,7 +592,7 @@ type BatchAPIKeysUsageRequest struct {
 func (h *DashboardHandler) GetBatchAPIKeysUsage(c *gin.Context) {
 	var req BatchAPIKeysUsageRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/data_management_handler.go
+++ b/backend/internal/handler/admin/data_management_handler.go
@@ -134,7 +134,7 @@ func (h *DataManagementHandler) GetConfig(c *gin.Context) {
 func (h *DataManagementHandler) UpdateConfig(c *gin.Context) {
 	var req service.DataManagementConfig
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -152,7 +152,7 @@ func (h *DataManagementHandler) UpdateConfig(c *gin.Context) {
 func (h *DataManagementHandler) TestS3(c *gin.Context) {
 	var req TestS3ConnectionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -180,7 +180,7 @@ func (h *DataManagementHandler) TestS3(c *gin.Context) {
 func (h *DataManagementHandler) CreateBackupJob(c *gin.Context) {
 	var req CreateBackupJobRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -240,7 +240,7 @@ func (h *DataManagementHandler) CreateSourceProfile(c *gin.Context) {
 
 	var req CreateSourceProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -275,7 +275,7 @@ func (h *DataManagementHandler) UpdateSourceProfile(c *gin.Context) {
 
 	var req UpdateSourceProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -356,7 +356,7 @@ func (h *DataManagementHandler) ListS3Profiles(c *gin.Context) {
 func (h *DataManagementHandler) CreateS3Profile(c *gin.Context) {
 	var req CreateS3ProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -390,7 +390,7 @@ func (h *DataManagementHandler) CreateS3Profile(c *gin.Context) {
 func (h *DataManagementHandler) UpdateS3Profile(c *gin.Context) {
 	var req UpdateS3ProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/data_management_handler.go
+++ b/backend/internal/handler/admin/data_management_handler.go
@@ -134,7 +134,7 @@ func (h *DataManagementHandler) GetConfig(c *gin.Context) {
 func (h *DataManagementHandler) UpdateConfig(c *gin.Context) {
 	var req service.DataManagementConfig
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -152,7 +152,7 @@ func (h *DataManagementHandler) UpdateConfig(c *gin.Context) {
 func (h *DataManagementHandler) TestS3(c *gin.Context) {
 	var req TestS3ConnectionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -180,7 +180,7 @@ func (h *DataManagementHandler) TestS3(c *gin.Context) {
 func (h *DataManagementHandler) CreateBackupJob(c *gin.Context) {
 	var req CreateBackupJobRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -240,7 +240,7 @@ func (h *DataManagementHandler) CreateSourceProfile(c *gin.Context) {
 
 	var req CreateSourceProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -275,7 +275,7 @@ func (h *DataManagementHandler) UpdateSourceProfile(c *gin.Context) {
 
 	var req UpdateSourceProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -356,7 +356,7 @@ func (h *DataManagementHandler) ListS3Profiles(c *gin.Context) {
 func (h *DataManagementHandler) CreateS3Profile(c *gin.Context) {
 	var req CreateS3ProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -390,7 +390,7 @@ func (h *DataManagementHandler) CreateS3Profile(c *gin.Context) {
 func (h *DataManagementHandler) UpdateS3Profile(c *gin.Context) {
 	var req UpdateS3ProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/error_passthrough_handler.go
+++ b/backend/internal/handler/admin/error_passthrough_handler.go
@@ -91,7 +91,7 @@ func (h *ErrorPassthroughHandler) GetByID(c *gin.Context) {
 func (h *ErrorPassthroughHandler) Create(c *gin.Context) {
 	var req CreateErrorPassthroughRuleRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -166,7 +166,7 @@ func (h *ErrorPassthroughHandler) Update(c *gin.Context) {
 
 	var req UpdateErrorPassthroughRuleRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/error_passthrough_handler.go
+++ b/backend/internal/handler/admin/error_passthrough_handler.go
@@ -91,7 +91,7 @@ func (h *ErrorPassthroughHandler) GetByID(c *gin.Context) {
 func (h *ErrorPassthroughHandler) Create(c *gin.Context) {
 	var req CreateErrorPassthroughRuleRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -166,7 +166,7 @@ func (h *ErrorPassthroughHandler) Update(c *gin.Context) {
 
 	var req UpdateErrorPassthroughRuleRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/gemini_oauth_handler.go
+++ b/backend/internal/handler/admin/gemini_oauth_handler.go
@@ -40,7 +40,7 @@ type GeminiGenerateAuthURLRequest struct {
 func (h *GeminiOAuthHandler) GenerateAuthURL(c *gin.Context) {
 	var req GeminiGenerateAuthURLRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -93,7 +93,7 @@ type GeminiExchangeCodeRequest struct {
 func (h *GeminiOAuthHandler) ExchangeCode(c *gin.Context) {
 	var req GeminiExchangeCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/gemini_oauth_handler.go
+++ b/backend/internal/handler/admin/gemini_oauth_handler.go
@@ -40,7 +40,7 @@ type GeminiGenerateAuthURLRequest struct {
 func (h *GeminiOAuthHandler) GenerateAuthURL(c *gin.Context) {
 	var req GeminiGenerateAuthURLRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -93,7 +93,7 @@ type GeminiExchangeCodeRequest struct {
 func (h *GeminiOAuthHandler) ExchangeCode(c *gin.Context) {
 	var req GeminiExchangeCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -297,7 +297,7 @@ func (h *GroupHandler) GetModelsListCandidates(c *gin.Context) {
 func (h *GroupHandler) Create(c *gin.Context) {
 	var req CreateGroupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -355,7 +355,7 @@ func (h *GroupHandler) Update(c *gin.Context) {
 
 	var req UpdateGroupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -576,7 +576,7 @@ func (h *GroupHandler) BatchSetGroupRateMultipliers(c *gin.Context) {
 
 	var req BatchSetGroupRateMultipliersRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -604,7 +604,7 @@ func (h *GroupHandler) BatchSetGroupRPMOverrides(c *gin.Context) {
 
 	var req BatchSetGroupRPMOverridesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -646,7 +646,7 @@ type UpdateSortOrderRequest struct {
 func (h *GroupHandler) UpdateSortOrder(c *gin.Context) {
 	var req UpdateSortOrderRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -297,7 +297,7 @@ func (h *GroupHandler) GetModelsListCandidates(c *gin.Context) {
 func (h *GroupHandler) Create(c *gin.Context) {
 	var req CreateGroupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -355,7 +355,7 @@ func (h *GroupHandler) Update(c *gin.Context) {
 
 	var req UpdateGroupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -576,7 +576,7 @@ func (h *GroupHandler) BatchSetGroupRateMultipliers(c *gin.Context) {
 
 	var req BatchSetGroupRateMultipliersRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -604,7 +604,7 @@ func (h *GroupHandler) BatchSetGroupRPMOverrides(c *gin.Context) {
 
 	var req BatchSetGroupRPMOverridesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -646,7 +646,7 @@ type UpdateSortOrderRequest struct {
 func (h *GroupHandler) UpdateSortOrder(c *gin.Context) {
 	var req UpdateSortOrderRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/openai_oauth_handler.go
+++ b/backend/internal/handler/admin/openai_oauth_handler.go
@@ -79,7 +79,7 @@ type OpenAIExchangeCodeRequest struct {
 func (h *OpenAIOAuthHandler) ExchangeCode(c *gin.Context) {
 	var req OpenAIExchangeCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -111,7 +111,7 @@ type OpenAIRefreshTokenRequest struct {
 func (h *OpenAIOAuthHandler) RefreshToken(c *gin.Context) {
 	var req OpenAIRefreshTokenRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	refreshToken := strings.TrimSpace(req.RefreshToken)
@@ -218,7 +218,7 @@ func (h *OpenAIOAuthHandler) CreateAccountFromOAuth(c *gin.Context) {
 		GroupIDs    []int64 `json:"group_ids"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/openai_oauth_handler.go
+++ b/backend/internal/handler/admin/openai_oauth_handler.go
@@ -79,7 +79,7 @@ type OpenAIExchangeCodeRequest struct {
 func (h *OpenAIOAuthHandler) ExchangeCode(c *gin.Context) {
 	var req OpenAIExchangeCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -111,7 +111,7 @@ type OpenAIRefreshTokenRequest struct {
 func (h *OpenAIOAuthHandler) RefreshToken(c *gin.Context) {
 	var req OpenAIRefreshTokenRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	refreshToken := strings.TrimSpace(req.RefreshToken)
@@ -218,7 +218,7 @@ func (h *OpenAIOAuthHandler) CreateAccountFromOAuth(c *gin.Context) {
 		GroupIDs    []int64 `json:"group_ids"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/ops_handler.go
+++ b/backend/internal/handler/admin/ops_handler.go
@@ -651,7 +651,7 @@ func (h *OpsHandler) UpdateErrorResolution(c *gin.Context) {
 
 	var req opsResolveRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	uid := subject.UserID

--- a/backend/internal/handler/admin/ops_handler.go
+++ b/backend/internal/handler/admin/ops_handler.go
@@ -651,7 +651,7 @@ func (h *OpsHandler) UpdateErrorResolution(c *gin.Context) {
 
 	var req opsResolveRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	uid := subject.UserID

--- a/backend/internal/handler/admin/payment_handler.go
+++ b/backend/internal/handler/admin/payment_handler.go
@@ -153,7 +153,7 @@ func (h *PaymentHandler) ProcessRefund(c *gin.Context) {
 
 	var req AdminProcessRefundRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -193,7 +193,7 @@ func (h *PaymentHandler) ListPlans(c *gin.Context) {
 func (h *PaymentHandler) CreatePlan(c *gin.Context) {
 	var req service.CreatePlanRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	plan, err := h.configService.CreatePlan(c.Request.Context(), req)
@@ -213,7 +213,7 @@ func (h *PaymentHandler) UpdatePlan(c *gin.Context) {
 	}
 	var req service.UpdatePlanRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	plan, err := h.configService.UpdatePlan(c.Request.Context(), id, req)
@@ -256,7 +256,7 @@ func (h *PaymentHandler) ListProviders(c *gin.Context) {
 func (h *PaymentHandler) CreateProvider(c *gin.Context) {
 	var req service.CreateProviderInstanceRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	inst, err := h.configService.CreateProviderInstance(c.Request.Context(), req)
@@ -277,7 +277,7 @@ func (h *PaymentHandler) UpdateProvider(c *gin.Context) {
 	}
 	var req service.UpdateProviderInstanceRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	inst, err := h.configService.UpdateProviderInstance(c.Request.Context(), id, req)
@@ -333,7 +333,7 @@ func (h *PaymentHandler) GetConfig(c *gin.Context) {
 func (h *PaymentHandler) UpdateConfig(c *gin.Context) {
 	var req service.UpdatePaymentConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if err := h.configService.UpdatePaymentConfig(c.Request.Context(), req); err != nil {

--- a/backend/internal/handler/admin/payment_handler.go
+++ b/backend/internal/handler/admin/payment_handler.go
@@ -153,7 +153,7 @@ func (h *PaymentHandler) ProcessRefund(c *gin.Context) {
 
 	var req AdminProcessRefundRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -193,7 +193,7 @@ func (h *PaymentHandler) ListPlans(c *gin.Context) {
 func (h *PaymentHandler) CreatePlan(c *gin.Context) {
 	var req service.CreatePlanRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	plan, err := h.configService.CreatePlan(c.Request.Context(), req)
@@ -213,7 +213,7 @@ func (h *PaymentHandler) UpdatePlan(c *gin.Context) {
 	}
 	var req service.UpdatePlanRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	plan, err := h.configService.UpdatePlan(c.Request.Context(), id, req)
@@ -256,7 +256,7 @@ func (h *PaymentHandler) ListProviders(c *gin.Context) {
 func (h *PaymentHandler) CreateProvider(c *gin.Context) {
 	var req service.CreateProviderInstanceRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	inst, err := h.configService.CreateProviderInstance(c.Request.Context(), req)
@@ -277,7 +277,7 @@ func (h *PaymentHandler) UpdateProvider(c *gin.Context) {
 	}
 	var req service.UpdateProviderInstanceRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	inst, err := h.configService.UpdateProviderInstance(c.Request.Context(), id, req)
@@ -333,7 +333,7 @@ func (h *PaymentHandler) GetConfig(c *gin.Context) {
 func (h *PaymentHandler) UpdateConfig(c *gin.Context) {
 	var req service.UpdatePaymentConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if err := h.configService.UpdatePaymentConfig(c.Request.Context(), req); err != nil {

--- a/backend/internal/handler/admin/promo_handler.go
+++ b/backend/internal/handler/admin/promo_handler.go
@@ -97,7 +97,7 @@ func (h *PromoHandler) GetByID(c *gin.Context) {
 func (h *PromoHandler) Create(c *gin.Context) {
 	var req CreatePromoCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -133,7 +133,7 @@ func (h *PromoHandler) Update(c *gin.Context) {
 
 	var req UpdatePromoCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/promo_handler.go
+++ b/backend/internal/handler/admin/promo_handler.go
@@ -97,7 +97,7 @@ func (h *PromoHandler) GetByID(c *gin.Context) {
 func (h *PromoHandler) Create(c *gin.Context) {
 	var req CreatePromoCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -133,7 +133,7 @@ func (h *PromoHandler) Update(c *gin.Context) {
 
 	var req UpdatePromoCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/proxy_data.go
+++ b/backend/internal/handler/admin/proxy_data.go
@@ -99,7 +99,7 @@ func (h *ProxyHandler) ImportData(c *gin.Context) {
 
 	var req ProxyImportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/proxy_data.go
+++ b/backend/internal/handler/admin/proxy_data.go
@@ -99,7 +99,7 @@ func (h *ProxyHandler) ImportData(c *gin.Context) {
 
 	var req ProxyImportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/proxy_handler.go
+++ b/backend/internal/handler/admin/proxy_handler.go
@@ -138,7 +138,7 @@ func (h *ProxyHandler) GetByID(c *gin.Context) {
 func (h *ProxyHandler) Create(c *gin.Context) {
 	var req CreateProxyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -178,7 +178,7 @@ func (h *ProxyHandler) Update(c *gin.Context) {
 
 	var req UpdateProxyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -235,7 +235,7 @@ func (h *ProxyHandler) BatchDelete(c *gin.Context) {
 
 	var req BatchDeleteRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -345,7 +345,7 @@ type BatchCreateRequest struct {
 func (h *ProxyHandler) BatchCreate(c *gin.Context) {
 	var req BatchCreateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/proxy_handler.go
+++ b/backend/internal/handler/admin/proxy_handler.go
@@ -138,7 +138,7 @@ func (h *ProxyHandler) GetByID(c *gin.Context) {
 func (h *ProxyHandler) Create(c *gin.Context) {
 	var req CreateProxyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -178,7 +178,7 @@ func (h *ProxyHandler) Update(c *gin.Context) {
 
 	var req UpdateProxyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -235,7 +235,7 @@ func (h *ProxyHandler) BatchDelete(c *gin.Context) {
 
 	var req BatchDeleteRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -345,7 +345,7 @@ type BatchCreateRequest struct {
 func (h *ProxyHandler) BatchCreate(c *gin.Context) {
 	var req BatchCreateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/redeem_handler.go
+++ b/backend/internal/handler/admin/redeem_handler.go
@@ -132,7 +132,7 @@ func (h *RedeemHandler) GetByID(c *gin.Context) {
 func (h *RedeemHandler) Generate(c *gin.Context) {
 	var req GenerateRedeemCodesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -173,7 +173,7 @@ func (h *RedeemHandler) CreateAndRedeem(c *gin.Context) {
 
 	var req CreateAndRedeemCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	req.Code = strings.TrimSpace(req.Code)
@@ -291,7 +291,7 @@ func (h *RedeemHandler) BatchDelete(c *gin.Context) {
 		IDs []int64 `json:"ids" binding:"required,min=1"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -317,7 +317,7 @@ func (h *RedeemHandler) BatchUpdate(c *gin.Context) {
 
 	var req dto.BatchUpdateRedeemCodesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/redeem_handler.go
+++ b/backend/internal/handler/admin/redeem_handler.go
@@ -132,7 +132,7 @@ func (h *RedeemHandler) GetByID(c *gin.Context) {
 func (h *RedeemHandler) Generate(c *gin.Context) {
 	var req GenerateRedeemCodesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -173,7 +173,7 @@ func (h *RedeemHandler) CreateAndRedeem(c *gin.Context) {
 
 	var req CreateAndRedeemCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	req.Code = strings.TrimSpace(req.Code)
@@ -291,7 +291,7 @@ func (h *RedeemHandler) BatchDelete(c *gin.Context) {
 		IDs []int64 `json:"ids" binding:"required,min=1"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -317,7 +317,7 @@ func (h *RedeemHandler) BatchUpdate(c *gin.Context) {
 
 	var req dto.BatchUpdateRedeemCodesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -705,7 +705,7 @@ type UpdateSettingsRequest struct {
 func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 	var req UpdateSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -2975,7 +2975,7 @@ type TestSMTPRequest struct {
 func (h *SettingHandler) TestSMTPConnection(c *gin.Context) {
 	var req TestSMTPRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -3043,7 +3043,7 @@ type SendTestEmailRequest struct {
 func (h *SettingHandler) SendTestEmail(c *gin.Context) {
 	var req SendTestEmailRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -3203,7 +3203,7 @@ type UpdateOverloadCooldownSettingsRequest struct {
 func (h *SettingHandler) UpdateOverloadCooldownSettings(c *gin.Context) {
 	var req UpdateOverloadCooldownSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -3255,7 +3255,7 @@ type UpdateRateLimit429CooldownSettingsRequest struct {
 func (h *SettingHandler) UpdateRateLimit429CooldownSettings(c *gin.Context) {
 	var req UpdateRateLimit429CooldownSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -3335,7 +3335,7 @@ type UpdateRectifierSettingsRequest struct {
 func (h *SettingHandler) UpdateRectifierSettings(c *gin.Context) {
 	var req UpdateRectifierSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -3418,7 +3418,7 @@ type UpdateBetaPolicySettingsRequest struct {
 func (h *SettingHandler) UpdateBetaPolicySettings(c *gin.Context) {
 	var req UpdateBetaPolicySettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -3461,7 +3461,7 @@ type UpdateStreamTimeoutSettingsRequest struct {
 func (h *SettingHandler) UpdateStreamTimeoutSettings(c *gin.Context) {
 	var req UpdateStreamTimeoutSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -3510,7 +3510,7 @@ func (h *SettingHandler) GetWebSearchEmulationConfig(c *gin.Context) {
 func (h *SettingHandler) UpdateWebSearchEmulationConfig(c *gin.Context) {
 	var cfg service.WebSearchEmulationConfig
 	if err := c.ShouldBindJSON(&cfg); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -3535,7 +3535,7 @@ func (h *SettingHandler) ResetWebSearchUsage(c *gin.Context) {
 		ProviderType string `json:"provider_type"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if req.ProviderType == "" {
@@ -3556,7 +3556,7 @@ func (h *SettingHandler) TestWebSearchEmulation(c *gin.Context) {
 		Query string `json:"query"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if strings.TrimSpace(req.Query) == "" {
@@ -3669,7 +3669,7 @@ func (h *SettingHandler) UpdateEmailTemplate(c *gin.Context) {
 	}
 	var req dto.UpdateEmailTemplateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	tmpl, err := h.notificationEmailService.UpdateTemplate(c.Request.Context(), c.Param("event"), c.Param("locale"), req.Subject, req.HTML)
@@ -3704,7 +3704,7 @@ func (h *SettingHandler) PreviewEmailTemplate(c *gin.Context) {
 	}
 	var req dto.PreviewEmailTemplateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	preview, err := h.notificationEmailService.PreviewTemplate(c.Request.Context(), service.NotificationEmailPreviewInput{

--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -705,7 +705,7 @@ type UpdateSettingsRequest struct {
 func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 	var req UpdateSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -2975,7 +2975,7 @@ type TestSMTPRequest struct {
 func (h *SettingHandler) TestSMTPConnection(c *gin.Context) {
 	var req TestSMTPRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -3043,7 +3043,7 @@ type SendTestEmailRequest struct {
 func (h *SettingHandler) SendTestEmail(c *gin.Context) {
 	var req SendTestEmailRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -3203,7 +3203,7 @@ type UpdateOverloadCooldownSettingsRequest struct {
 func (h *SettingHandler) UpdateOverloadCooldownSettings(c *gin.Context) {
 	var req UpdateOverloadCooldownSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -3255,7 +3255,7 @@ type UpdateRateLimit429CooldownSettingsRequest struct {
 func (h *SettingHandler) UpdateRateLimit429CooldownSettings(c *gin.Context) {
 	var req UpdateRateLimit429CooldownSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -3335,7 +3335,7 @@ type UpdateRectifierSettingsRequest struct {
 func (h *SettingHandler) UpdateRectifierSettings(c *gin.Context) {
 	var req UpdateRectifierSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -3418,7 +3418,7 @@ type UpdateBetaPolicySettingsRequest struct {
 func (h *SettingHandler) UpdateBetaPolicySettings(c *gin.Context) {
 	var req UpdateBetaPolicySettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -3461,7 +3461,7 @@ type UpdateStreamTimeoutSettingsRequest struct {
 func (h *SettingHandler) UpdateStreamTimeoutSettings(c *gin.Context) {
 	var req UpdateStreamTimeoutSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -3510,7 +3510,7 @@ func (h *SettingHandler) GetWebSearchEmulationConfig(c *gin.Context) {
 func (h *SettingHandler) UpdateWebSearchEmulationConfig(c *gin.Context) {
 	var cfg service.WebSearchEmulationConfig
 	if err := c.ShouldBindJSON(&cfg); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -3535,7 +3535,7 @@ func (h *SettingHandler) ResetWebSearchUsage(c *gin.Context) {
 		ProviderType string `json:"provider_type"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if req.ProviderType == "" {
@@ -3556,7 +3556,7 @@ func (h *SettingHandler) TestWebSearchEmulation(c *gin.Context) {
 		Query string `json:"query"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if strings.TrimSpace(req.Query) == "" {
@@ -3669,7 +3669,7 @@ func (h *SettingHandler) UpdateEmailTemplate(c *gin.Context) {
 	}
 	var req dto.UpdateEmailTemplateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	tmpl, err := h.notificationEmailService.UpdateTemplate(c.Request.Context(), c.Param("event"), c.Param("locale"), req.Subject, req.HTML)
@@ -3704,7 +3704,7 @@ func (h *SettingHandler) PreviewEmailTemplate(c *gin.Context) {
 	}
 	var req dto.PreviewEmailTemplateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	preview, err := h.notificationEmailService.PreviewTemplate(c.Request.Context(), service.NotificationEmailPreviewInput{

--- a/backend/internal/handler/admin/subscription_handler.go
+++ b/backend/internal/handler/admin/subscription_handler.go
@@ -137,7 +137,7 @@ func (h *SubscriptionHandler) GetProgress(c *gin.Context) {
 func (h *SubscriptionHandler) Assign(c *gin.Context) {
 	var req AssignSubscriptionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -164,7 +164,7 @@ func (h *SubscriptionHandler) Assign(c *gin.Context) {
 func (h *SubscriptionHandler) BulkAssign(c *gin.Context) {
 	var req BulkAssignSubscriptionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -197,7 +197,7 @@ func (h *SubscriptionHandler) Extend(c *gin.Context) {
 
 	var req AdjustSubscriptionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -234,7 +234,7 @@ func (h *SubscriptionHandler) ResetQuota(c *gin.Context) {
 	}
 	var req ResetSubscriptionQuotaRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if !req.Daily && !req.Weekly && !req.Monthly {

--- a/backend/internal/handler/admin/subscription_handler.go
+++ b/backend/internal/handler/admin/subscription_handler.go
@@ -137,7 +137,7 @@ func (h *SubscriptionHandler) GetProgress(c *gin.Context) {
 func (h *SubscriptionHandler) Assign(c *gin.Context) {
 	var req AssignSubscriptionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -164,7 +164,7 @@ func (h *SubscriptionHandler) Assign(c *gin.Context) {
 func (h *SubscriptionHandler) BulkAssign(c *gin.Context) {
 	var req BulkAssignSubscriptionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -197,7 +197,7 @@ func (h *SubscriptionHandler) Extend(c *gin.Context) {
 
 	var req AdjustSubscriptionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -234,7 +234,7 @@ func (h *SubscriptionHandler) ResetQuota(c *gin.Context) {
 	}
 	var req ResetSubscriptionQuotaRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if !req.Daily && !req.Weekly && !req.Monthly {

--- a/backend/internal/handler/admin/tls_fingerprint_profile_handler.go
+++ b/backend/internal/handler/admin/tls_fingerprint_profile_handler.go
@@ -89,7 +89,7 @@ func (h *TLSFingerprintProfileHandler) GetByID(c *gin.Context) {
 func (h *TLSFingerprintProfileHandler) Create(c *gin.Context) {
 	var req CreateTLSFingerprintProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -135,7 +135,7 @@ func (h *TLSFingerprintProfileHandler) Update(c *gin.Context) {
 
 	var req UpdateTLSFingerprintProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/tls_fingerprint_profile_handler.go
+++ b/backend/internal/handler/admin/tls_fingerprint_profile_handler.go
@@ -89,7 +89,7 @@ func (h *TLSFingerprintProfileHandler) GetByID(c *gin.Context) {
 func (h *TLSFingerprintProfileHandler) Create(c *gin.Context) {
 	var req CreateTLSFingerprintProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -135,7 +135,7 @@ func (h *TLSFingerprintProfileHandler) Update(c *gin.Context) {
 
 	var req UpdateTLSFingerprintProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -476,7 +476,7 @@ func (h *UsageHandler) CreateCleanupTask(c *gin.Context) {
 
 	var req CreateUsageCleanupTaskRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	req.StartDate = strings.TrimSpace(req.StartDate)

--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -476,7 +476,7 @@ func (h *UsageHandler) CreateCleanupTask(c *gin.Context) {
 
 	var req CreateUsageCleanupTaskRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	req.StartDate = strings.TrimSpace(req.StartDate)

--- a/backend/internal/handler/admin/user_attribute_handler.go
+++ b/backend/internal/handler/admin/user_attribute_handler.go
@@ -155,7 +155,7 @@ func (h *UserAttributeHandler) ListDefinitions(c *gin.Context) {
 func (h *UserAttributeHandler) CreateDefinition(c *gin.Context) {
 	var req CreateAttributeDefinitionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -189,7 +189,7 @@ func (h *UserAttributeHandler) UpdateDefinition(c *gin.Context) {
 
 	var req UpdateAttributeDefinitionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -238,7 +238,7 @@ func (h *UserAttributeHandler) DeleteDefinition(c *gin.Context) {
 func (h *UserAttributeHandler) ReorderDefinitions(c *gin.Context) {
 	var req ReorderRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -290,7 +290,7 @@ func (h *UserAttributeHandler) UpdateUserAttributes(c *gin.Context) {
 
 	var req UpdateUserAttributesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -327,7 +327,7 @@ func (h *UserAttributeHandler) UpdateUserAttributes(c *gin.Context) {
 func (h *UserAttributeHandler) GetBatchUserAttributes(c *gin.Context) {
 	var req BatchGetUserAttributesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/user_attribute_handler.go
+++ b/backend/internal/handler/admin/user_attribute_handler.go
@@ -155,7 +155,7 @@ func (h *UserAttributeHandler) ListDefinitions(c *gin.Context) {
 func (h *UserAttributeHandler) CreateDefinition(c *gin.Context) {
 	var req CreateAttributeDefinitionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -189,7 +189,7 @@ func (h *UserAttributeHandler) UpdateDefinition(c *gin.Context) {
 
 	var req UpdateAttributeDefinitionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -238,7 +238,7 @@ func (h *UserAttributeHandler) DeleteDefinition(c *gin.Context) {
 func (h *UserAttributeHandler) ReorderDefinitions(c *gin.Context) {
 	var req ReorderRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -290,7 +290,7 @@ func (h *UserAttributeHandler) UpdateUserAttributes(c *gin.Context) {
 
 	var req UpdateUserAttributesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -327,7 +327,7 @@ func (h *UserAttributeHandler) UpdateUserAttributes(c *gin.Context) {
 func (h *UserAttributeHandler) GetBatchUserAttributes(c *gin.Context) {
 	var req BatchGetUserAttributesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/admin/user_handler.go
+++ b/backend/internal/handler/admin/user_handler.go
@@ -228,7 +228,7 @@ func (h *UserHandler) BindAuthIdentity(c *gin.Context) {
 
 	var req BindUserAuthIdentityRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -261,7 +261,7 @@ func (h *UserHandler) BindAuthIdentity(c *gin.Context) {
 func (h *UserHandler) Create(c *gin.Context) {
 	var req CreateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -294,7 +294,7 @@ func (h *UserHandler) Update(c *gin.Context) {
 
 	var req UpdateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -349,7 +349,7 @@ func (h *UserHandler) UpdateBalance(c *gin.Context) {
 
 	var req UpdateBalanceRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -473,7 +473,7 @@ func (h *UserHandler) ReplaceGroup(c *gin.Context) {
 
 	var req ReplaceGroupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -518,7 +518,7 @@ type BatchUpdateConcurrencyRequest struct {
 func (h *UserHandler) BatchUpdateConcurrency(c *gin.Context) {
 	var req BatchUpdateConcurrencyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if !req.All && len(req.UserIDs) == 0 {
@@ -628,7 +628,7 @@ func (h *UserHandler) UpdateUserPlatformQuotas(c *gin.Context) {
 
 	var req UpdateUserPlatformQuotasRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -804,7 +804,7 @@ func (h *UserHandler) ResetUserPlatformQuotaWindow(c *gin.Context) {
 
 	var req ResetUserPlatformQuotaWindowRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/admin/user_handler.go
+++ b/backend/internal/handler/admin/user_handler.go
@@ -228,7 +228,7 @@ func (h *UserHandler) BindAuthIdentity(c *gin.Context) {
 
 	var req BindUserAuthIdentityRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -261,7 +261,7 @@ func (h *UserHandler) BindAuthIdentity(c *gin.Context) {
 func (h *UserHandler) Create(c *gin.Context) {
 	var req CreateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -294,7 +294,7 @@ func (h *UserHandler) Update(c *gin.Context) {
 
 	var req UpdateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -349,7 +349,7 @@ func (h *UserHandler) UpdateBalance(c *gin.Context) {
 
 	var req UpdateBalanceRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -473,7 +473,7 @@ func (h *UserHandler) ReplaceGroup(c *gin.Context) {
 
 	var req ReplaceGroupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -518,7 +518,7 @@ type BatchUpdateConcurrencyRequest struct {
 func (h *UserHandler) BatchUpdateConcurrency(c *gin.Context) {
 	var req BatchUpdateConcurrencyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if !req.All && len(req.UserIDs) == 0 {
@@ -628,7 +628,7 @@ func (h *UserHandler) UpdateUserPlatformQuotas(c *gin.Context) {
 
 	var req UpdateUserPlatformQuotasRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -804,7 +804,7 @@ func (h *UserHandler) ResetUserPlatformQuotaWindow(c *gin.Context) {
 
 	var req ResetUserPlatformQuotaWindowRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/api_key_handler.go
+++ b/backend/internal/handler/api_key_handler.go
@@ -151,7 +151,7 @@ func (h *APIKeyHandler) Create(c *gin.Context) {
 
 	var req CreateAPIKeyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -203,7 +203,7 @@ func (h *APIKeyHandler) Update(c *gin.Context) {
 
 	var req UpdateAPIKeyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/api_key_handler.go
+++ b/backend/internal/handler/api_key_handler.go
@@ -151,7 +151,7 @@ func (h *APIKeyHandler) Create(c *gin.Context) {
 
 	var req CreateAPIKeyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -203,7 +203,7 @@ func (h *APIKeyHandler) Update(c *gin.Context) {
 
 	var req UpdateAPIKeyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/auth_email_oauth.go
+++ b/backend/internal/handler/auth_email_oauth.go
@@ -342,7 +342,7 @@ type completeEmailOAuthRequest struct {
 func (h *AuthHandler) completeEmailOAuthRegistration(c *gin.Context, provider string) {
 	var req completeEmailOAuthRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/auth_email_oauth.go
+++ b/backend/internal/handler/auth_email_oauth.go
@@ -342,7 +342,7 @@ type completeEmailOAuthRequest struct {
 func (h *AuthHandler) completeEmailOAuthRegistration(c *gin.Context, provider string) {
 	var req completeEmailOAuthRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -161,7 +161,7 @@ func (h *AuthHandler) isBackendModeEnabled(ctx context.Context) bool {
 func (h *AuthHandler) Register(c *gin.Context) {
 	var req RegisterRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -193,7 +193,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 func (h *AuthHandler) SendVerifyCode(c *gin.Context) {
 	var req SendVerifyCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -220,7 +220,7 @@ func (h *AuthHandler) SendVerifyCode(c *gin.Context) {
 func (h *AuthHandler) Login(c *gin.Context) {
 	var req LoginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -278,7 +278,7 @@ type Login2FARequest struct {
 func (h *AuthHandler) Login2FA(c *gin.Context) {
 	var req Login2FARequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -467,7 +467,7 @@ func (h *AuthHandler) ValidatePromoCode(c *gin.Context) {
 
 	var req ValidatePromoCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -534,7 +534,7 @@ func (h *AuthHandler) ValidateInvitationCode(c *gin.Context) {
 
 	var req ValidateInvitationCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -586,7 +586,7 @@ type ForgotPasswordResponse struct {
 func (h *AuthHandler) ForgotPassword(c *gin.Context) {
 	var req ForgotPasswordRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -632,7 +632,7 @@ type ResetPasswordResponse struct {
 func (h *AuthHandler) ResetPassword(c *gin.Context) {
 	var req ResetPasswordRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -667,7 +667,7 @@ type RefreshTokenResponse struct {
 func (h *AuthHandler) RefreshToken(c *gin.Context) {
 	var req RefreshTokenRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -161,7 +161,7 @@ func (h *AuthHandler) isBackendModeEnabled(ctx context.Context) bool {
 func (h *AuthHandler) Register(c *gin.Context) {
 	var req RegisterRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -193,7 +193,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 func (h *AuthHandler) SendVerifyCode(c *gin.Context) {
 	var req SendVerifyCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -220,7 +220,7 @@ func (h *AuthHandler) SendVerifyCode(c *gin.Context) {
 func (h *AuthHandler) Login(c *gin.Context) {
 	var req LoginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -278,7 +278,7 @@ type Login2FARequest struct {
 func (h *AuthHandler) Login2FA(c *gin.Context) {
 	var req Login2FARequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -467,7 +467,7 @@ func (h *AuthHandler) ValidatePromoCode(c *gin.Context) {
 
 	var req ValidatePromoCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -534,7 +534,7 @@ func (h *AuthHandler) ValidateInvitationCode(c *gin.Context) {
 
 	var req ValidateInvitationCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -586,7 +586,7 @@ type ForgotPasswordResponse struct {
 func (h *AuthHandler) ForgotPassword(c *gin.Context) {
 	var req ForgotPasswordRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -632,7 +632,7 @@ type ResetPasswordResponse struct {
 func (h *AuthHandler) ResetPassword(c *gin.Context) {
 	var req ResetPasswordRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -667,7 +667,7 @@ type RefreshTokenResponse struct {
 func (h *AuthHandler) RefreshToken(c *gin.Context) {
 	var req RefreshTokenRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/auth_oauth_pending_flow.go
+++ b/backend/internal/handler/auth_oauth_pending_flow.go
@@ -560,7 +560,7 @@ func (h *AuthHandler) CreatePendingOAuthAccount(c *gin.Context) {
 func (h *AuthHandler) SendPendingOAuthVerifyCode(c *gin.Context) {
 	var req sendPendingOAuthVerifyCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1617,7 +1617,7 @@ func writeOAuthTokenPairResponse(c *gin.Context, tokenPair *service.TokenPair) {
 func (h *AuthHandler) bindPendingOAuthLogin(c *gin.Context, provider string) {
 	var req bindPendingOAuthLoginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1703,7 +1703,7 @@ func respondPendingOAuthBindingApplyError(c *gin.Context, err error) {
 func (h *AuthHandler) createPendingOAuthAccount(c *gin.Context, provider string) {
 	var req createPendingOAuthAccountRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -1892,7 +1892,7 @@ func (h *AuthHandler) ExchangePendingOAuthCompletion(c *gin.Context) {
 	}
 	adoptionDecision, err := bindOptionalOAuthAdoptionDecision(c)
 	if err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/auth_oauth_pending_flow.go
+++ b/backend/internal/handler/auth_oauth_pending_flow.go
@@ -560,7 +560,7 @@ func (h *AuthHandler) CreatePendingOAuthAccount(c *gin.Context) {
 func (h *AuthHandler) SendPendingOAuthVerifyCode(c *gin.Context) {
 	var req sendPendingOAuthVerifyCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1617,7 +1617,7 @@ func writeOAuthTokenPairResponse(c *gin.Context, tokenPair *service.TokenPair) {
 func (h *AuthHandler) bindPendingOAuthLogin(c *gin.Context, provider string) {
 	var req bindPendingOAuthLoginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1703,7 +1703,7 @@ func respondPendingOAuthBindingApplyError(c *gin.Context, err error) {
 func (h *AuthHandler) createPendingOAuthAccount(c *gin.Context, provider string) {
 	var req createPendingOAuthAccountRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -1892,7 +1892,7 @@ func (h *AuthHandler) ExchangePendingOAuthCompletion(c *gin.Context) {
 	}
 	adoptionDecision, err := bindOptionalOAuthAdoptionDecision(c)
 	if err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/payment_handler.go
+++ b/backend/internal/handler/payment_handler.go
@@ -233,7 +233,7 @@ func (h *PaymentHandler) CreateOrder(c *gin.Context) {
 
 	var req CreateOrderRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 	if strings.TrimSpace(req.WechatResumeToken) != "" {
@@ -401,7 +401,7 @@ func (h *PaymentHandler) RequestRefund(c *gin.Context) {
 
 	var req RefundRequestBody
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -442,7 +442,7 @@ func (h *PaymentHandler) VerifyOrder(c *gin.Context) {
 
 	var req VerifyOrderRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -508,7 +508,7 @@ func buildPublicOrderResult(order *dbent.PaymentOrder) PublicOrderResult {
 func (h *PaymentHandler) VerifyOrderPublic(c *gin.Context) {
 	var req VerifyOrderRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -525,7 +525,7 @@ func (h *PaymentHandler) VerifyOrderPublic(c *gin.Context) {
 func (h *PaymentHandler) ResolveOrderPublicByResumeToken(c *gin.Context) {
 	var req ResolveOrderByResumeTokenRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/payment_handler.go
+++ b/backend/internal/handler/payment_handler.go
@@ -233,7 +233,7 @@ func (h *PaymentHandler) CreateOrder(c *gin.Context) {
 
 	var req CreateOrderRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 	if strings.TrimSpace(req.WechatResumeToken) != "" {
@@ -401,7 +401,7 @@ func (h *PaymentHandler) RequestRefund(c *gin.Context) {
 
 	var req RefundRequestBody
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -442,7 +442,7 @@ func (h *PaymentHandler) VerifyOrder(c *gin.Context) {
 
 	var req VerifyOrderRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -508,7 +508,7 @@ func buildPublicOrderResult(order *dbent.PaymentOrder) PublicOrderResult {
 func (h *PaymentHandler) VerifyOrderPublic(c *gin.Context) {
 	var req VerifyOrderRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -525,7 +525,7 @@ func (h *PaymentHandler) VerifyOrderPublic(c *gin.Context) {
 func (h *PaymentHandler) ResolveOrderPublicByResumeToken(c *gin.Context) {
 	var req ResolveOrderByResumeTokenRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/qa_handler.go
+++ b/backend/internal/handler/qa_handler.go
@@ -91,7 +91,7 @@ func (h *QAHandler) ExportSelf(c *gin.Context) {
 	req := ExportSelfRequest{}
 	if c.Request != nil && c.Request.ContentLength != 0 {
 		if err := c.ShouldBindJSON(&req); err != nil {
-			response.InvalidRequest(c, err)
+			response.InvalidRequest(c)
 			return
 		}
 	}

--- a/backend/internal/handler/qa_handler.go
+++ b/backend/internal/handler/qa_handler.go
@@ -91,7 +91,7 @@ func (h *QAHandler) ExportSelf(c *gin.Context) {
 	req := ExportSelfRequest{}
 	if c.Request != nil && c.Request.ContentLength != 0 {
 		if err := c.ShouldBindJSON(&req); err != nil {
-			response.BadRequest(c, "Invalid request: "+err.Error())
+			response.InvalidRequest(c, err)
 			return
 		}
 	}

--- a/backend/internal/handler/qa_handler_traj.go
+++ b/backend/internal/handler/qa_handler_traj.go
@@ -45,7 +45,7 @@ func (h *QAHandler) ExportSelfTrajectory(c *gin.Context) {
 	req := ExportSelfRequest{}
 	if c.Request != nil && c.Request.ContentLength != 0 {
 		if err := c.ShouldBindJSON(&req); err != nil {
-			response.InvalidRequest(c, err)
+			response.InvalidRequest(c)
 			return
 		}
 	}

--- a/backend/internal/handler/qa_handler_traj.go
+++ b/backend/internal/handler/qa_handler_traj.go
@@ -45,7 +45,7 @@ func (h *QAHandler) ExportSelfTrajectory(c *gin.Context) {
 	req := ExportSelfRequest{}
 	if c.Request != nil && c.Request.ContentLength != 0 {
 		if err := c.ShouldBindJSON(&req); err != nil {
-			response.BadRequest(c, "Invalid request: "+err.Error())
+			response.InvalidRequest(c, err)
 			return
 		}
 	}

--- a/backend/internal/handler/redeem_handler.go
+++ b/backend/internal/handler/redeem_handler.go
@@ -46,7 +46,7 @@ func (h *RedeemHandler) Redeem(c *gin.Context) {
 
 	var req RedeemRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/redeem_handler.go
+++ b/backend/internal/handler/redeem_handler.go
@@ -46,7 +46,7 @@ func (h *RedeemHandler) Redeem(c *gin.Context) {
 
 	var req RedeemRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/totp_handler.go
+++ b/backend/internal/handler/totp_handler.go
@@ -115,7 +115,7 @@ func (h *TotpHandler) Enable(c *gin.Context) {
 
 	var req TotpEnableRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -144,7 +144,7 @@ func (h *TotpHandler) Disable(c *gin.Context) {
 
 	var req TotpDisableRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/totp_handler.go
+++ b/backend/internal/handler/totp_handler.go
@@ -115,7 +115,7 @@ func (h *TotpHandler) Enable(c *gin.Context) {
 
 	var req TotpEnableRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -144,7 +144,7 @@ func (h *TotpHandler) Disable(c *gin.Context) {
 
 	var req TotpDisableRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -526,7 +526,7 @@ func (h *UsageHandler) DashboardAPIKeysUsage(c *gin.Context) {
 
 	var req BatchAPIKeysUsageRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -526,7 +526,7 @@ func (h *UsageHandler) DashboardAPIKeysUsage(c *gin.Context) {
 
 	var req BatchAPIKeysUsageRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/handler/user_handler.go
+++ b/backend/internal/handler/user_handler.go
@@ -141,7 +141,7 @@ func (h *UserHandler) ChangePassword(c *gin.Context) {
 
 	var req ChangePasswordRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -169,7 +169,7 @@ func (h *UserHandler) UpdateProfile(c *gin.Context) {
 
 	var req UpdateProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -257,7 +257,7 @@ func (h *UserHandler) StartIdentityBinding(c *gin.Context) {
 
 	var req StartIdentityBindingRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -288,7 +288,7 @@ func (h *UserHandler) BindEmailIdentity(c *gin.Context) {
 
 	var req BindEmailIdentityRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -362,7 +362,7 @@ func (h *UserHandler) SendEmailBindingCode(c *gin.Context) {
 
 	var req SendEmailBindingCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -390,7 +390,7 @@ func (h *UserHandler) SendNotifyEmailCode(c *gin.Context) {
 
 	var req SendNotifyEmailCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -420,7 +420,7 @@ func (h *UserHandler) VerifyNotifyEmail(c *gin.Context) {
 
 	var req VerifyNotifyEmailRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -462,7 +462,7 @@ func (h *UserHandler) RemoveNotifyEmail(c *gin.Context) {
 
 	var req RemoveNotifyEmailRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 
@@ -505,7 +505,7 @@ func (h *UserHandler) ToggleNotifyEmail(c *gin.Context) {
 
 	var req ToggleNotifyEmailRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.BadRequest(c, "Invalid request: "+err.Error())
+		response.InvalidRequest(c, err)
 		return
 	}
 

--- a/backend/internal/handler/user_handler.go
+++ b/backend/internal/handler/user_handler.go
@@ -141,7 +141,7 @@ func (h *UserHandler) ChangePassword(c *gin.Context) {
 
 	var req ChangePasswordRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -169,7 +169,7 @@ func (h *UserHandler) UpdateProfile(c *gin.Context) {
 
 	var req UpdateProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -257,7 +257,7 @@ func (h *UserHandler) StartIdentityBinding(c *gin.Context) {
 
 	var req StartIdentityBindingRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -288,7 +288,7 @@ func (h *UserHandler) BindEmailIdentity(c *gin.Context) {
 
 	var req BindEmailIdentityRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -362,7 +362,7 @@ func (h *UserHandler) SendEmailBindingCode(c *gin.Context) {
 
 	var req SendEmailBindingCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -390,7 +390,7 @@ func (h *UserHandler) SendNotifyEmailCode(c *gin.Context) {
 
 	var req SendNotifyEmailCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -420,7 +420,7 @@ func (h *UserHandler) VerifyNotifyEmail(c *gin.Context) {
 
 	var req VerifyNotifyEmailRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -462,7 +462,7 @@ func (h *UserHandler) RemoveNotifyEmail(c *gin.Context) {
 
 	var req RemoveNotifyEmailRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 
@@ -505,7 +505,7 @@ func (h *UserHandler) ToggleNotifyEmail(c *gin.Context) {
 
 	var req ToggleNotifyEmailRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.InvalidRequest(c, err)
+		response.InvalidRequest(c)
 		return
 	}
 

--- a/backend/internal/pkg/response/response.go
+++ b/backend/internal/pkg/response/response.go
@@ -106,9 +106,9 @@ func BadRequest(c *gin.Context, message string) {
 // 会把 go-playground/validator 的原始报错（如 "Key: 'LoginRequest.Email' Error:Field
 // validation for 'Email' failed on the 'required' tag"）透传给客户端，泄露 Go struct 名、
 // 字段名与框架/tag 细节，降低逆向门槛。绑定/校验失败对客户端只需告知"请求非法"，无需也不应
-// 暴露内部结构。err 参数保留以便调用点形态统一并供将来按需做服务端日志，不写入响应体。
-func InvalidRequest(c *gin.Context, err error) {
-	_ = err
+// 暴露内部结构。调用点的 err 仍用于 `if err != nil` 判定，故此处不收 err 参数（与其它
+// 响应 helper 保持一致，避免无意义的入参）。
+func InvalidRequest(c *gin.Context) {
 	Error(c, http.StatusBadRequest, "invalid request")
 }
 

--- a/backend/internal/pkg/response/response.go
+++ b/backend/internal/pkg/response/response.go
@@ -100,6 +100,18 @@ func BadRequest(c *gin.Context, message string) {
 	Error(c, http.StatusBadRequest, message)
 }
 
+// InvalidRequest 处理请求体绑定/校验失败，统一返回通用 400。
+//
+// 安全审计 P2-1：此前各 handler 一律 BadRequest("Invalid request: "+err.Error())，
+// 会把 go-playground/validator 的原始报错（如 "Key: 'LoginRequest.Email' Error:Field
+// validation for 'Email' failed on the 'required' tag"）透传给客户端，泄露 Go struct 名、
+// 字段名与框架/tag 细节，降低逆向门槛。绑定/校验失败对客户端只需告知"请求非法"，无需也不应
+// 暴露内部结构。err 参数保留以便调用点形态统一并供将来按需做服务端日志，不写入响应体。
+func InvalidRequest(c *gin.Context, err error) {
+	_ = err
+	Error(c, http.StatusBadRequest, "invalid request")
+}
+
 // Unauthorized 返回401错误
 func Unauthorized(c *gin.Context, message string) {
 	Error(c, http.StatusUnauthorized, message)

--- a/backend/internal/pkg/response/response_test.go
+++ b/backend/internal/pkg/response/response_test.go
@@ -356,6 +356,28 @@ func TestBadRequest(t *testing.T) {
 	require.Equal(t, "参数无效", got.Message)
 }
 
+// TestInvalidRequest 锁死安全审计 P2-1：绑定/校验失败统一返回通用 400，响应体里
+// 绝不能出现 go-playground/validator 原始报错的 struct 名 / 字段名 / tag 细节。
+func TestInvalidRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	InvalidRequest(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	got := parseResponseBody(t, w)
+	require.Equal(t, http.StatusBadRequest, got.Code)
+	require.Equal(t, "invalid request", got.Message)
+
+	// 负向断言：模拟此前会被透传的 validator 内部细节绝不出现在响应里。
+	body := w.Body.String()
+	for _, leak := range []string{"Field validation", "Error:Field", "'required' tag", "Request.", "Key:"} {
+		require.NotContains(t, body, leak, "InvalidRequest 不得泄露 validator/框架内部细节")
+	}
+}
+
 func TestUnauthorized(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/server/middleware/security_headers.go
+++ b/backend/internal/server/middleware/security_headers.go
@@ -94,6 +94,11 @@ func SecurityHeaders(cfg config.CSPConfig, getFrameSrcOrigins func() []string) g
 		c.Header("X-Content-Type-Options", "nosniff")
 		c.Header("X-Frame-Options", "DENY")
 		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+		// HSTS：强制后续访问走 HTTPS，防 SSL Stripping 中间人窃取 JWT/API Key（安全审计 P0-1）。
+		// 必须无条件下发：应用位于 Caddy 反代之后，c.Request.TLS 恒为 nil（TLS 在 Caddy 终止），
+		// 浏览器本就只在 HTTPS 连接上认 HSTS、明文连接收到即忽略，故无需也不能按 TLS 探测来 gate。
+		// 不带 preload：preload 是需手动提交且近乎不可逆的运维承诺，留给运营按需开启。
+		c.Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		if isAPIRoutePath(c) {
 			c.Next()
 			return

--- a/backend/internal/server/middleware/security_headers_test.go
+++ b/backend/internal/server/middleware/security_headers_test.go
@@ -95,6 +95,8 @@ func TestSecurityHeaders(t *testing.T) {
 		assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
 		assert.Equal(t, "DENY", w.Header().Get("X-Frame-Options"))
 		assert.Equal(t, "strict-origin-when-cross-origin", w.Header().Get("Referrer-Policy"))
+		// 安全审计 P0-1：HSTS 必须随基础安全头一并下发，锁死防 SSL Stripping 不被静默移除。
+		assert.Equal(t, "max-age=31536000; includeSubDomains", w.Header().Get("Strict-Transport-Security"))
 	})
 
 	t.Run("csp_disabled_no_csp_header", func(t *testing.T) {


### PR DESCRIPTION
## 背景

针对 `api.tokenkey.dev` 安全审计报告（2026-06-25 复验）逐条核实后，修复其中两个**确属代码层**的问题。Live 端 curl 与代码根因均已双重确认。

## 修复

### 🔴 P0-1 HSTS 头缺失
- live 实证：响应头无 `Strict-Transport-Security`（CSP/XFO/XCTO/Referrer-Policy 均在）。
- 修复：在 `SecurityHeaders` 中间件统一下发 `Strict-Transport-Security: max-age=31536000; includeSubDomains`，置于 API 早返回之前 → 首页 HTML 与 API 路由全覆盖；单一 chokepoint，不依赖逐个 Caddyfile、也避免重复头。
- 关键点：应用位于 Caddy 反代之后，`c.Request.TLS` 恒为 nil，故**无条件下发**（浏览器只在 HTTPS 连接认 HSTS、明文收到即忽略）。未带 `preload`（不可逆运维承诺，留给运维按需开启）。

### 🟡 P2-1 validator 报错泄露后端框架/结构
- live 实证：`{"email":""}` 登录返回 `Key: 'LoginRequest.Email' Error:Field validation ... 'required' tag`，泄露 Go struct 名、字段名、go-playground/validator tag。
- 修复：新增 `response.InvalidRequest(c, err)` 统一返回 `{"code":400,"message":"invalid request"}`，机械替换**全部 141 处** `BadRequest(c, "Invalid request: "+err.Error())`（38 个 handler 文件）。整类一次收口（CLAUDE.md §5「重复模式收敛成 helper」），非只修登录。
- 同步修正一处断言旧大写 `"Invalid request"` 的测试。

## 未在本 PR 处理（已与授权人确认）
- **P1-1 风控未开启**：运行时 admin/DB 配置项，不在代码仓库。且审计自身指出仅在「重开注册」时有意义，当前 `registration_enabled:false`，不紧急。
- **P2-2 前端配置注入**：`featureFlags.ts` 注册表 + drift 测试支撑的**有意 SPA 设计**（这些 flag 驱动菜单/路由可见性、不授予任何能力，属 security-through-obscurity）。授权人确认维持现状。

## 验证
- `go build ./...` ✅
- `go test -tags=unit ./internal/pkg/response/... ./internal/server/middleware/... ./internal/handler/...` ✅
- `golangci-lint run`（response / middleware / handler）→ 0 issues ✅
- 本地 preflight（含 sub2api 专项检查）PASS ✅

## 合并/纪律
- TK 自有 fix → 用 **Squash and merge**（§5.y）。
- upstream-override marker：`upstream-touch-trivial`（仅调用点形态替换 + 新增一个安全响应头，未删除任何 upstream 符号、无回退风险）。
- 纯后端：`no-web-impact`（未增删路由、未改响应 schema）。
- **out-of-order 说明**：当前 TK 落后 upstream/main 3 个 commit（`git log --oneline upstream/main..HEAD` 反向为 GPT-5.5 codex / codex spark image-tool strip，均属 gateway-openai），与本 PR 改动文件（`security_headers.go` / `response.go` / handler 调用点）**零重叠**，故安全地先行合入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## sentinel-registry-reviewed

本 PR 对若干 sentinel-pinned handler（account_handler.go / api_key_handler.go / dashboard_handler.go / group_handler.go / account_handler_tk_passive_usage_batch.go 等）的改动**仅是把绑定错误响应行 `BadRequest(c, "Invalid request: "+err.Error())` 替换为 `InvalidRequest(c)`**（行替换含删除，故非纯插入而触发本门禁）。该改动与 sentinel 锚定的 gateway / affinity / grok-routing / newapi 语义**完全正交**，未触达任何 `must_contain` 锚点——`check-newapi.py` 全绿（52/52 intact）、preflight newapi sentinel PASS 可证。已逐文件复核确认无需新增 / 变更 sentinel 锚点。
