### PR TITLE
fix(openai): skip cooldown for client-induced capability 403 (embeddings) — gpt-5.5 capacity-rejection P0

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -1475,6 +1475,23 @@ func (s *RateLimitService) handleOpenAI403(ctx context.Context, account *Account
 		return true
 	}
 
+	// TK (prod P0 2026-06-25): a client-induced model/endpoint capability 403
+	// (e.g. /v1/embeddings with a chat-only model → "not allowed to generate
+	// embeddings from this model") is deterministic per-request and would 403 on
+	// every account. Skip the 403 counter AND the temp_unschedulable write so a
+	// single malformed request cannot cool a healthy shared OAuth account out of
+	// the pool for all other models. The request still fails over (return true).
+	// See ratelimit_service_tk_openai_client_induced_403.go.
+	if matched := tkIsOpenAIClientInducedCapability403(upstreamMsg, responseBody); matched != "" {
+		slog.Warn(
+			"openai_403_client_induced_capability_skip_cooldown",
+			"account_id", account.ID,
+			"matched_keyword", matched,
+			"upstream_msg", upstreamMsg,
+		)
+		return true
+	}
+
 	msg := buildForbiddenErrorMessage(
 		"Access forbidden (403):",
 		upstreamMsg,

--- a/backend/internal/service/ratelimit_service_tk_openai_client_induced_403.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_client_induced_403.go
@@ -1,0 +1,43 @@
+package service
+
+import "strings"
+
+// openAIClientInducedCapability403Keywords match OpenAI 403 bodies that are a
+// CLIENT-induced model/endpoint capability rejection, not an account-level
+// problem. The canonical trigger is a `POST /v1/embeddings` request carrying a
+// chat-only model (e.g. `gpt-5.5`): OpenAI replies 403 "You are not allowed to
+// generate embeddings from this model". The same request will 403 on EVERY
+// account in the pool, so it tells us nothing about this account's health.
+//
+// Match is case-insensitive; the haystack is upstreamMsg + responseBody.
+//
+// TK (prod P0 2026-06-25, routing_capacity_rejection spike on gpt-5.5): a single
+// malformed `/v1/embeddings` request with model=gpt-5.5 hit OAuth Codex accounts
+// 9 (GPT-pro1) and 73 (GPT-pro3) at 17:13:39Z. handleOpenAI403 treated the 403 as
+// account-level and wrote a 10-minute temp_unschedulable on both — the very
+// accounts that serve the bulk of gpt-5.5 CHAT traffic (~9.7k ok rows/24h
+// combined). With the two API-key mirror accounts (us3/us6) simultaneously
+// saturated and us4/GPT-pro2 already dead, the openai compat pool emptied for the
+// full 10-minute cooldown, producing 628 "no available accounts" 429s
+// (routing_capacity_rejection) until the cooldown lapsed at 17:23:3xZ and the
+// accounts auto-recovered. This is the OpenAI sibling of the Anthropic
+// client-induced-400 skip (Wei-Shaw/sub2api#2608, tkIsAnthropicClientInducedBadRequest):
+// a deterministic per-request rejection must fail the in-flight request back to
+// the caller WITHOUT cooling a shared, healthy account.
+var openAIClientInducedCapability403Keywords = []string{
+	"embeddings from this model",
+	"not allowed to generate embeddings",
+}
+
+// tkIsOpenAIClientInducedCapability403 reports whether an OpenAI 403 is a
+// client-induced model/endpoint capability rejection (see keyword doc above).
+// Such 403s must skip the openai_403 counter increment AND the
+// temp_unschedulable write, so a caller sending a wrong-endpoint request cannot
+// poison a shared OAuth account for all other models. The in-flight request
+// still fails over (handleOpenAI403 returns shouldDisable=true) because this
+// account cannot serve THIS request — but every other account would 403 it too,
+// so failover just surfaces the deterministic error to the caller.
+func tkIsOpenAIClientInducedCapability403(upstreamMsg string, responseBody []byte) string {
+	haystack := strings.ToLower(upstreamMsg + " " + string(responseBody))
+	return matchTempUnschedKeyword(haystack, openAIClientInducedCapability403Keywords)
+}

--- a/backend/internal/service/ratelimit_service_tk_openai_client_induced_403_test.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_client_induced_403_test.go
@@ -1,0 +1,115 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TK regression for prod P0 2026-06-25 (routing_capacity_rejection spike on
+// gpt-5.5). A client sent `POST /v1/embeddings` with model=gpt-5.5; OpenAI
+// replied 403 "You are not allowed to generate embeddings from this model".
+// Before this fix, handleOpenAI403 treated that client-induced capability 403 as
+// an account-level problem and wrote a 10-minute temp_unschedulable on the OAuth
+// Codex accounts that actually serve gpt-5.5 chat traffic, emptying the pool and
+// producing 628 "no available accounts" 429s until the cooldown lapsed.
+//
+// The 403 is deterministic per-request (every account 403s the same body), so it
+// must fail over WITHOUT incrementing the counter or cooling the account.
+func TestRateLimitService_HandleUpstreamError_OpenAI403EmbeddingsCapabilitySkipsCooldown(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "embeddings_from_this_model",
+			body: []byte(`{"error":{"message":"You are not allowed to generate embeddings from this model","type":"invalid_request_error","code":null}}`),
+		},
+		{
+			name: "not_allowed_to_generate_embeddings",
+			body: []byte(`{"error":{"message":"You are not allowed to generate embeddings.","type":"invalid_request_error"}}`),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &rateLimitAccountRepoStub{}
+			counter := &openAI403CounterCacheStub{counts: []int64{1}}
+			service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+			service.SetOpenAI403CounterCache(counter)
+
+			account := &Account{
+				ID:       73,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+			}
+
+			shouldDisable := service.HandleUpstreamError(
+				context.Background(),
+				account,
+				http.StatusForbidden,
+				http.Header{},
+				tc.body,
+			)
+
+			require.True(t, shouldDisable, "shouldDisable must stay true so the request fails over")
+			require.Equal(t, 0, repo.tempCalls, "client-induced embeddings 403 must not write temp_unschedulable")
+			require.Equal(t, 0, repo.setErrorCalls, "client-induced embeddings 403 must not SetError")
+			require.Empty(t, counter.incrementIDs, "client-induced embeddings 403 must not increment the 403 counter")
+		})
+	}
+}
+
+// Guard against over-matching: a genuine account-level permission 403 (no
+// embeddings-capability phrasing) must still go through the counter +
+// temp_unschedulable path, otherwise real account problems would be masked.
+func TestRateLimitService_HandleUpstreamError_OpenAI403GenericPermissionStillCoolsDown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &openAI403CounterCacheStub{counts: []int64{1}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetOpenAI403CounterCache(counter)
+
+	account := &Account{
+		ID:       902,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+	}
+
+	shouldDisable := service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusForbidden,
+		http.Header{},
+		[]byte(`{"error":{"message":"Your account is not allowed to access this resource.","type":"forbidden","code":"account_disabled"}}`),
+	)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.tempCalls, "real permission 403 must still write temp_unschedulable")
+	require.Equal(t, []int64{902}, counter.incrementIDs)
+}
+
+// Predicate-level coverage, kept separate so a regression localises to the
+// predicate vs. the handleOpenAI403 wiring.
+func TestTkIsOpenAIClientInducedCapability403(t *testing.T) {
+	match := []string{
+		"You are not allowed to generate embeddings from this model",
+		"not allowed to generate embeddings",
+		`{"error":{"message":"You are not allowed to generate EMBEDDINGS from this model"}}`,
+	}
+	for _, m := range match {
+		require.NotEmpty(t, tkIsOpenAIClientInducedCapability403(m, nil), "expected match for %q", m)
+	}
+	noMatch := []string{
+		"",
+		"Your account is suspended",
+		"rate limit exceeded",
+		"You do not have permission to access this endpoint",
+	}
+	for _, m := range noMatch {
+		require.Empty(t, tkIsOpenAIClientInducedCapability403(m, nil), "expected no match for %q", m)
+	}
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3,6 +3,16 @@
   "rationale": "Load-bearing TokenKey gateway/service injections that intentionally live in upstream-shaped hotspot files. These touches are small and compile-clean if dropped, so upstream merges can silently revert them unless preflight and upstream-merge PR shape check their literal hooks.",
   "sentinels": [
     {
+      "path": "backend/internal/service/ratelimit_service_tk_openai_client_induced_403.go",
+      "must_contain": [
+        "func tkIsOpenAIClientInducedCapability403(upstreamMsg string, responseBody []byte) string",
+        "openAIClientInducedCapability403Keywords",
+        "embeddings from this model",
+        "not allowed to generate embeddings"
+      ],
+      "rationale": "TK prod P0 2026-06-25 (routing_capacity_rejection spike on gpt-5.5): a single `POST /v1/embeddings` with model=gpt-5.5 returned OpenAI 403 'You are not allowed to generate embeddings from this model'. handleOpenAI403 treated that client-induced model/endpoint capability 403 as account-level and wrote a 10-min temp_unschedulable on OAuth Codex accounts #9/#73 — the very accounts serving the bulk of gpt-5.5 chat traffic — emptying the openai compat pool and producing 628 'no available accounts' 429s until the cooldown lapsed. This companion holds the keyword predicate that handleOpenAI403 consults (anchored via the ratelimit_service.go sentinel) to SKIP the 403 counter + cooldown for deterministic per-request capability 403s, the OpenAI sibling of the Anthropic client-induced-400 skip (#2608). Dropping this file or its keywords silently restores OAuth-pool poisoning where one wrong-endpoint request cools a healthy shared account for all other models."
+    },
+    {
       "path": "backend/internal/service/gateway_service_tk_sticky_saturation.go",
       "must_contain": [
         "func (s *GatewayService) tkShouldClearStickyForSaturation(",
@@ -181,6 +191,8 @@
         "openai_403_cf_challenge_skip_cooldown",
         "openAIIsHTMLBody",
         "openai_403_html_body_skip_cooldown",
+        "tkIsOpenAIClientInducedCapability403(upstreamMsg, responseBody)",
+        "openai_403_client_induced_capability_skip_cooldown",
         "handleAnthropicUpstreamError(",
         "handleAnthropicUpstreamErrorWithOptions",
         "IncrementAnthropicUpstreamErrorCount",


### PR DESCRIPTION
## 背景 / P0

prod P0 告警 `routing_capacity_rejection_count >= 50`（当前 398，overall），主因 openai ×397，模型 gpt-5.5 ×379，时间 `2026-06-25T17:17:13Z`。

## 根因（high）

一条畸形 embeddings 请求把 gpt-5.5 聊天主力账号冷却出池，触发整池"无可用账号"，持续约 10 分钟后自愈。

精确时间线（`ops_error_logs` + 账号快照）：

1. **17:13:39Z** — 客户端发 `POST /v1/embeddings`，`model=gpt-5.5`。gpt-5.5 是聊天模型不能做 embeddings，OpenAI 正确返回 **403 "You are not allowed to generate embeddings from this model"**。
2. 该 403 走进 `handleOpenAI403`，被当成账号级故障，给两个 OAuth Codex 账号各写 10 分钟 `temp_unschedulable`：
   - `#9 GPT-pro1` → 冷却至 17:23:39Z；`#73 GPT-pro3` → 17:23:37Z
   - 这俩近 24h 实际服务 9045 + 644 条 gpt-5.5 成功请求——gpt-5.5 聊天主力。
3. 同一时刻池里其余账号都不可用：`#48 GPT-pro2` token revoked（401，死）；`#68 openai-us4` 镜像 edge connection refused（06-23 起死）；仅剩 `#64/#63` 镜像自身在 429（其 edge 回 "no available accounts"）。
4. 17:13–17:23 → openai compat 池对 gpt-5.5 整池为空 → **628 条 routing-capacity 429**（峰值约 127/min）。
5. 17:23:3xZ 冷却到期，两个 OAuth 账号自动回池 → 恢复。

这是**跨请求类型的池中毒**：一个确定性、客户端诱发的 403（错误的 endpoint/model 组合，换任何账号都会同样 403）不应冷却共享的健康账号——既无用（重试照样 403），又有害（抽走其它模型/聊天容量）。

## 改动

- 新增 `ratelimit_service_tk_openai_client_induced_403.go`：关键字谓词 `tkIsOpenAIClientInducedCapability403`（匹配 `embeddings from this model` / `not allowed to generate embeddings`）。
- `handleOpenAI403`：在 HTML-body skip 之后、计数器自增之前，加 skip 分支——命中即 `return true`（请求照常 failover），但不自增 403 计数、不写 temp_unschedulable。打 `openai_403_client_induced_capability_skip_cooldown` 日志。
- 新增测试：embeddings-403 跳过冷却 + 真实权限 403 仍冷却（防过度匹配）+ 谓词单测。
- 新增 sentinel anchor（companion 文件 + ratelimit_service.go 注入点），防上游合并静默回退。

与既有 `openai_403_cf_challenge` / `html_403` skip 及 Anthropic client-induced-400 skip (#2608) 同一模式。

## 验证

- `go test -tags=unit ./internal/service/ -run 'OpenAI403|ClientInducedCapability403'` → ok
- `go build ./internal/service/`、`go vet -tags=unit` → 过
- `scripts/preflight.sh` → PASS（含 sentinel update gate / upstream override marker）

## 仍需 ops 跟进（非代码）

代码修复消除放大器，但池当时已很薄是被一击打空的前提：
- `#48 GPT-pro2`：OAuth token revoked → 需重新授权
- `#68 openai-us4`：镜像 edge `api-us4.tokenkey.dev` 06-23 起 connection refused → 修复或下线

## 合并方式

TK fix → **Squash and merge**。后端纯逻辑改动，UI/contract 无影响（no-web-impact）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)