### PR TITLE
chore(openai): align Codex client fingerprint to 0.142.2

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -110,7 +110,7 @@ const (
 	apiQueryMaxJitter       = 800 * time.Millisecond // 用量查询最大随机延迟
 	windowStatsCacheTTL     = 1 * time.Minute
 	openAIProbeCacheTTL     = 10 * time.Minute
-	openAICodexProbeVersion = "0.142.0"
+	openAICodexProbeVersion = "0.142.2"
 )
 
 // UsageCache 封装账户使用量相关的缓存

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -58,7 +58,7 @@ const (
 	openAIWSRetryBackoffMaxDefault     = 2 * time.Second
 	openAIWSRetryJitterRatioDefault    = 0.2
 	openAICompactSessionSeedKey        = "openai_compact_session_seed"
-	codexCLIVersion                    = "0.142.0"
+	codexCLIVersion                    = "0.142.2"
 	// Codex 限额快照仅用于后台展示/诊断，不需要每个成功请求都立即落库。
 	openAICodexSnapshotPersistMinInterval = 30 * time.Second
 	// 配额自动暂停时，超过该时长仍未刷新的 used% 快照视为陈旧，不再据此暂停账号。

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -147,7 +147,7 @@ const antigravityUserAgentVersionErrorTTL = 5 * time.Second
 const antigravityUserAgentVersionDBTimeout = 5 * time.Second
 
 // DefaultOpenAICodexUserAgent OpenAI Codex 默认 User-Agent。
-const DefaultOpenAICodexUserAgent = "codex-tui/0.142.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.142.0)"
+const DefaultOpenAICodexUserAgent = "codex-tui/0.142.2 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.142.2)"
 
 // cachedOpenAICodexUserAgent 缓存 OpenAI Codex UA（进程内缓存，60s TTL）
 type cachedOpenAICodexUserAgent struct {

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 512,
-  "hash": "5107df53ab1c914a115e8d12a86d5043cec8082188b5092cb75a4bae3005d24f",
+  "hash": "5dfe051e7c8a66ac663716371dadaabd2a3bc5844365adf29c1f169d4ab7c852",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -6392,7 +6392,7 @@ export default {
         antigravityUserAgentVersionPlaceholder: '1.23.2',
         antigravityUserAgentVersionHint: 'Leave empty to use ANTIGRAVITY_USER_AGENT_VERSION or the built-in default 1.23.2; when set, the admin setting takes precedence.',
         openaiCodexUserAgent: 'OpenAI Codex UA',
-        openaiCodexUserAgentPlaceholder: 'codex-tui/0.142.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.142.0)',
+        openaiCodexUserAgentPlaceholder: 'codex-tui/0.142.2 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.142.2)',
         openaiCodexUserAgentHint: 'Fallback Codex User-Agent for OpenAI OAuth upstream requests. Account-level custom UA wins, and real Codex client UA is preserved. Leave empty to use the built-in default.',
         openaiAllowClaudeCodeCodexPlugin: "Allow using the Codex plugin in Claude Code",
         openaiAllowClaudeCodeCodexPluginDesc:

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -6536,7 +6536,7 @@ export default {
         antigravityUserAgentVersionPlaceholder: '1.23.2',
         antigravityUserAgentVersionHint: '留空时使用 ANTIGRAVITY_USER_AGENT_VERSION 或内置默认值 1.23.2；填写后后台设置优先。',
         openaiCodexUserAgent: 'OpenAI Codex UA',
-        openaiCodexUserAgentPlaceholder: 'codex-tui/0.142.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.142.0)',
+        openaiCodexUserAgentPlaceholder: 'codex-tui/0.142.2 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.142.2)',
         openaiCodexUserAgentHint: 'OpenAI OAuth 上游请求的 Codex User-Agent 兜底值；账号自定义 UA 优先，真实 Codex 客户端 UA 原样保留。留空使用内置默认值。',
         openaiAllowClaudeCodeCodexPlugin: '允许在 Claude Code 中使用 Codex 插件',
         openaiAllowClaudeCodeCodexPluginDesc:


### PR DESCRIPTION
最新提交：45fdbfb0a

## 摘要

本机 Codex CLI 升级到 **0.142.2**（`codex-cli 0.142.2`），同步对齐 OpenAI 平台中 TokenKey 伪造/兜底的 Codex 客户端指纹。

在与上一次定版（PR #1007）相同的参考环境（**Mac OS 26.3.1；arm64；iTerm.app/3.6.11**）下重新抓取，确认 0.142.0 → 0.142.2 之间仅版本号变化：

- `originator = codex_cli_rs`：**未变**
- `OpenAI-Beta: responses=experimental`：**未变**（对照已安装的 0.142.2 二进制核实；新出现的 `responses_websockets=...` 属独立的 WS beta，已由 WS forwarder 单独处理）
- OS / arch / 终端段：**未变**（同一台机器）

改动（`0.142.0` → `0.142.2`）：

- `service.DefaultOpenAICodexUserAgent`——强制/兜底 UA + 后台设置默认值（`setting_service.go`）
- `service.codexCLIVersion`——网关 `version` 请求头（`openai_gateway_service.go`）
- `service.openAICodexProbeVersion`——用量探测 `Version` 请求头（`account_usage_service.go`）
- `openaiCodexUserAgentPlaceholder`（en/zh）——后台 OpenAI 账号 UA 输入框占位提示
- 重建内嵌 `backend/internal/web/dist/frontend-source.json`（i18n 源码哈希清单）

`request.go` / `request_test.go` 保留混合示例版本号——它们断言的是 `codex-tui/` 前缀匹配，与具体版本号无关，故不改。

## 风险

- 低。纯版本字面量 bump，三个被改的 service 文件均为 upstream-shaped，但改动只是已存在常量的取值变更：无回滚风险、未新增/删除任何 upstream 符号；三者均已在 `scripts/sentinels/gateway-tk.json` 有锚点。
- 若上游 0.142.2 实际还改了其它请求头（经核实未发现），最坏表现为指纹对齐略有偏差，不影响转发链路正确性。

## 验证

- `go build ./...`（跨仓库）——OK
- `go test -tags=unit ./internal/pkg/openai/...`——OK
- `go test -tags=unit ./internal/service -run 'Codex|OpenAICodex|UserAgent|Originator|OAuthPassthrough'`——OK
- `pnpm --dir frontend run build`（vue-tsc 类型检查 + vite + 清单）——OK
- `scripts/preflight.sh`——PASS

门禁标记：

- `upstream-touch-trivial`——upstream-shaped 文件，但仅版本字面量取值变更，无回滚风险、无符号增删。
- `sentinel-registry-reviewed`——已复核三处被改的 load-bearing surface，未引入新 surface，`gateway-tk.json` 既有锚点保持完整，无需新增锚点。

## 提交

- 45fdbfb0a chore(openai): align Codex client fingerprint to 0.142.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
