### PR TITLE
feat(pricing): catalog 刷新支持 24h 流量短路探测

### DIFF
--- a/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
+++ b/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
@@ -29,10 +29,11 @@ description: >-
 **已达基线**——可机械化的步骤全在脚本里，prompt 不重复它们：
 
 - **机械化（脚本承载）**：候选派生（按 litellm vendor + 是否有价，分 chat/responses/image
-  家族，Gemini 另走 discovered + seed）、SSM 投递与逐模型请求、HTTP→verdict 分类、留
+  家族，Gemini 另走 discovered + seed）、**24h 流量短路**（从 `usage_logs` 拉近窗成功流量、
+  与候选集求交、跳过 SSM 探测）、SSM 投递与逐模型请求、HTTP→verdict 分类、留
   `servable`、dated 去重、Go map splice、分批避开 SSM 等待窗口、自动开 PR——全在
-  `refresh-servable-allowlist.py` / `probe-servable-models.sh`，`selftest` 子命令覆盖，
-  preflight `servable-allowlist generator selftest` 门禁 + sentinel 守 splice 标记。
+  `refresh-servable-allowlist.py` / `probe-servable-models.sh` / `probe-traffic-proven-models.sh`，
+  `selftest` 子命令覆盖，preflight `servable-allowlist generator selftest` 门禁 + sentinel 守 splice 标记。
 - **真判断（留给人/agent）**：① `inconclusive`（429/502/503）的取舍——它常是「该探测组没有
   这类账号」而非模型本身不可用（如 image 经 GPT专线组、专用 codex 池）；要不要给别的组 key
   扩探测再加回，是判断。② 审 PR diff 是否合理（突然大幅增删要查是不是探测设置坏了，看
@@ -56,6 +57,34 @@ cd backend && go test -tags=unit ./internal/service/ -run PublicCatalog
 ```
 
 `run` 不带 `--open-pr` 只重写本地 Go 文件，便于先审 `git diff`。
+
+### 24h 流量短路（`--skip-proven-by-traffic`，加性优化、默认关、可灰度）
+
+全量探测约 162 模型 / 16 批 / 8–15 分钟。很多候选**近 24h 已被真实客流成功调用**，再探纯属浪费。
+`--skip-proven-by-traffic`（或 env `REFRESH_SKIP_PROVEN_BY_TRAFFIC=1`）在探测前先经 `run-probe.sh` 投递
+`probe-traffic-proven-models.sh`，只读聚合 `usage_logs` 近 `--traffic-hours`（默认 24）的成功流量，把
+**已被流量证明 servable 的候选直接判 servable 并移出探测批**，batch 数显著下降：
+
+```bash
+python3 ops/pricing/refresh-servable-allowlist.py run --skip-proven-by-traffic
+python3 ops/pricing/refresh-servable-allowlist.py run --skip-proven-by-traffic --traffic-hours 48
+# probe 子命令同样支持；被跳过的模型以 servable 行写进 TSV，apply 仍完整
+python3 ops/pricing/refresh-servable-allowlist.py probe --skip-proven-by-traffic | tee /tmp/servable.tsv
+```
+
+跳过项显式打到 stderr 供人审：`[refresh] skipping N models proven by 24h traffic: anthropic/claude-opus-4-8, …`。
+
+**正确性契约（改动前必读，全是为了不引入假阳/假阴）**：
+
+- **纯加性**：流量成功=确凿 servable 正证据；**没流量 ≠ 不可服务**（可能只是没人调）——未命中流量的候选
+  **仍正常进探测批**，短路只删探测、绝不判 unsupported。默认关，保守全探仍是基线，开关用于灰度。
+- **只能跳/加候选集内模型**：proven 集与派生候选集求交，流量无法把候选集外（无价/未知）模型塞进 allowlist。
+- **平台桶按候选集定，不按服务账号**：Vertex 经 `accounts.platform='newapi'` 服务，所以流量里的
+  `gemini-2.5-pro` 按其**候选平台** `gemini` 入桶；`usage_logs` 行只需 model id 命中候选即可。
+- **deadlist 不会因一条流量复活**：skiplist/deadlist 早已从候选集剔除，proven 再过一遍
+  `validate_results_against_reprobe_ledger` 兜底。
+- `usage_logs` 一行 = 一次**计费**请求（不耗 token 的错误不落行）；查询再要求真实产出（token/图/视频）
+  排除 `$0` 占位行，确保不把空请求当 servable 证据。
 
 ## Gemini / Vertex 三族（newapi 第五平台，探测目标 us6）
 

--- a/ops/pricing/README.md
+++ b/ops/pricing/README.md
@@ -23,7 +23,8 @@ hand-maintained empirical sets in the same file.
 | File | Role |
 | --- | --- |
 | `probe-servable-models.sh` | Runs on prod or an edge via `ops/observability/run-probe.sh`. Sends one minimal real request per candidate model and emits `platform⇥model⇥http⇥verdict` TSV. A model is **servable** iff it returns a real `200`. |
-| `refresh-servable-allowlist.py` | Refreshes the shared public-catalog/user-menu servable sets. It derives candidates, runs probes, keeps `verdict==servable`, de-duplicates dated snapshots, and splices the anthropic/openai/gemini Go blocks. `selftest` covers deterministic glue (no prod). |
+| `probe-traffic-proven-models.sh` | Runs on prod via `ops/observability/run-probe.sh`. Read-only over `usage_logs`: emits `platform⇥model⇥hits` for every model that served **real successful traffic** in the last `TRAFFIC_HOURS` (default 24). Feeds the `--skip-proven-by-traffic` short-circuit below. Positive evidence only — a model with no recent traffic is simply absent (never an unsupported signal). |
+| `refresh-servable-allowlist.py` | Refreshes the shared public-catalog/user-menu servable sets. It derives candidates, runs probes, keeps `verdict==servable`, de-duplicates dated snapshots, and splices the anthropic/openai/gemini Go blocks. `selftest` covers deterministic glue (no prod). Optional `--skip-proven-by-traffic` short-circuits candidates already proven by 24h traffic out of the probe batches. |
 | `modelops.py` | Read-only planner for model operations: compares upstream/admin discovery, probe TSV, pricing state, manifest intent, optional live `model_mapping` snapshots, and mirror policies such as `60 -> 72`. Prints probe commands and guarded apply dry-runs; never writes accounts or pricing. |
 | `reconcile-served-models.py` | Compatibility wrapper for `modelops.py`. New runbooks should call `modelops.py`. |
 | `apply-pricing-hotfix.py` | Companion runbook for the **"模型缺价（已记零成本）" Feishu alert** (PricingMissingNotifier). Hot-applies channel pricing via the prod admin API (immediate, no release) and stages the durable fill-only entry into `tk_pricing_overlay.json`. `selftest` covers all pure logic (no network). See "Pricing-missing hotfix" below. |
@@ -48,6 +49,49 @@ Split the steps when you want to inspect the raw verdicts first:
 python3 ops/pricing/refresh-servable-allowlist.py probe | tee /tmp/servable.tsv
 python3 ops/pricing/refresh-servable-allowlist.py apply --results /tmp/servable.tsv
 ```
+
+### 24h-traffic short-circuit (`--skip-proven-by-traffic`)
+
+A full probe is ~160 models in ~16 SSM batches (8–15 min). Many of those models
+already served **real successful traffic** in the last day — re-probing them is
+pure latency. `--skip-proven-by-traffic` (or env `REFRESH_SKIP_PROVEN_BY_TRAFFIC=1`)
+queries `usage_logs` once up front and skips the probe for any candidate already
+proven servable, cutting the batch count:
+
+```bash
+python3 ops/pricing/refresh-servable-allowlist.py run --skip-proven-by-traffic
+# tune the window (default 24h):
+python3 ops/pricing/refresh-servable-allowlist.py run --skip-proven-by-traffic --traffic-hours 48
+```
+
+It logs exactly what it skipped, for human review:
+
+```
+[refresh] skipping 37 models proven by 24h traffic: anthropic/claude-opus-4-8, openai/gpt-5.4, …
+[refresh] probing 41 models in 5 batch(es) of <= 12 …
+```
+
+**Why it is safe (purely additive — read the contract before changing it):**
+
+- **Traffic success = servable** is firm positive evidence; **no traffic ≠
+  unsupported**. A candidate that did not show up in the window is *still probed*
+  normally — the short-circuit only ever removes probes, never marks anything
+  unsupported. Default is **off** so the conservative full probe stays the baseline;
+  enable it as a graduated rollout.
+- **Only candidates can be skipped/added.** The proven set is intersected with the
+  derived candidate set, so traffic can never inject a model that is not already a
+  priced/known candidate.
+- **Platform bucket comes from the candidate set, not the serving account.** Vertex
+  is served under `accounts.platform='newapi'`, so a served `gemini-2.5-pro` is
+  bucketed as `gemini` because that is its *candidate* platform. The script's
+  `usage_logs` row only needs the model id to match.
+- **Blocked models cannot revive.** skiplist/deadlist entries are already absent
+  from the candidate set, and the proven set is additionally re-checked against the
+  reprobe ledger (`validate_results_against_reprobe_ledger`) — one successful
+  request cannot bring a deadlisted model back.
+- A `usage_logs` row is a **metered** request (errors that burn no tokens are not
+  logged); the query additionally requires real generation (tokens / image / video)
+  so a `$0` placeholder row never counts as proof.
 
 ## Modelops planner (read-only)
 

--- a/ops/pricing/probe-traffic-proven-models.sh
+++ b/ops/pricing/probe-traffic-proven-models.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# probe-traffic-proven-models.sh — runs ON the prod host (delivered via
+# ops/observability/run-probe.sh) and emits the (platform, model) pairs that
+# served REAL traffic successfully in the last TRAFFIC_HOURS hours, read-only
+# from usage_logs.
+#
+# Why this exists: refresh-servable-allowlist.py probes ~160 candidate models
+# through prod SSM in ~16 batches (8–15 min). A candidate that real users already
+# got a successful response for in the last day is provably servable — there is no
+# value in re-probing it. This script supplies that positive evidence so the
+# refresh tool can SHORT-CIRCUIT those candidates out of the probe batches.
+#
+# Correctness contract (the caller depends on these properties):
+#   * usage_logs is append-only and holds ONE row per METERED (served) request.
+#     A row existing for a model means that request completed and was billed —
+#     errors that consume no tokens are never metered, so they leave no row. The
+#     extra "real generation" filter (tokens / image / video > 0) drops any $0
+#     placeholder row so a recorded-but-empty request can never read as proof.
+#     => a row passing the filter is POSITIVE evidence of servability, never the
+#        reverse: a model with no recent traffic is simply absent here (the caller
+#        still probes it; absence is NOT an unsupported signal).
+#   * Platform attribution is intentionally NOT decided here. accounts.platform is
+#     emitted only as human context; the caller buckets each model by the
+#     CANDIDATE platform set and intersects against it, so a model that is not a
+#     known candidate is dropped (never injected into the allowlist) regardless of
+#     which platform/account happened to serve it. This is robust to Vertex/gemini
+#     being served under accounts.platform='newapi' as the fifth platform.
+#
+# Both the billed `model` and the client-facing `requested_model` are reported so
+# a menu-facing requested id whose upstream was mapped is still counted.
+#
+# Env:
+#   TRAFFIC_HOURS  default 24   (look-back window, integer hours)
+#
+# Output: one TSV line per (platform, model):  <platform>\t<model>\t<hits>
+# Keys/credentials are never touched; this is a pure read of usage_logs+accounts.
+set -uo pipefail
+
+HOURS="${TRAFFIC_HOURS:-24}"
+if ! [[ "$HOURS" =~ ^[0-9]+$ ]] || [ "$HOURS" -lt 1 ]; then
+	echo "probe-traffic-proven [config]: TRAFFIC_HOURS must be a positive integer, got: $HOURS" >&2
+	exit 1
+fi
+
+PSQL='sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1'
+
+# One text column per row, tab-joined inside the SELECT (so -A -t needs no -F).
+# UNION ALL folds the billed model id and the client-requested id into the same
+# served-model universe; GROUP BY collapses to distinct (platform, model) + hits.
+$PSQL <<SQL
+SELECT a.platform || E'\t' || u.mdl || E'\t' || count(*)::text
+FROM (
+  SELECT account_id, model AS mdl
+  FROM usage_logs
+  WHERE created_at >= now() - interval '${HOURS} hours'
+    AND (input_tokens > 0 OR output_tokens > 0 OR image_count > 0
+         OR COALESCE(video_duration_seconds, 0) > 0)
+  UNION ALL
+  SELECT account_id, requested_model AS mdl
+  FROM usage_logs
+  WHERE created_at >= now() - interval '${HOURS} hours'
+    AND requested_model IS NOT NULL AND requested_model <> ''
+    AND (input_tokens > 0 OR output_tokens > 0 OR image_count > 0
+         OR COALESCE(video_duration_seconds, 0) > 0)
+) u
+JOIN accounts a ON a.id = u.account_id AND a.deleted_at IS NULL
+WHERE u.mdl IS NOT NULL AND u.mdl <> ''
+GROUP BY a.platform, u.mdl
+ORDER BY a.platform, u.mdl;
+SQL

--- a/ops/pricing/refresh-servable-allowlist.py
+++ b/ops/pricing/refresh-servable-allowlist.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import os
 import re
 import subprocess
 import sys
@@ -40,8 +41,16 @@ REPO = Path(__file__).resolve().parents[2]
 CATALOG = REPO / "backend/resources/model-pricing/model_prices_and_context_window.json"
 GO_FILE = REPO / "backend/internal/service/pricing_catalog_supported_models_tk.go"
 PROBE = REPO / "ops/pricing/probe-servable-models.sh"
+TRAFFIC_PROBE = REPO / "ops/pricing/probe-traffic-proven-models.sh"
 RUN_PROBE = REPO / "ops/observability/run-probe.sh"
 REPROBE_LEDGER = REPO / "ops/pricing/servable-reprobe-ledger.json"
+
+# 24h-traffic short-circuit (additive optimization, gated by a flag/env so the
+# default stays the conservative full probe). A candidate model that already
+# served real successful traffic in this window is proven servable and skips the
+# SSM probe batch entirely. Absence of traffic is NOT a negative signal — those
+# candidates are still probed normally.
+DEFAULT_TRAFFIC_HOURS = 24
 
 # Dated snapshot suffix, both fleet conventions: anthropic "-YYYYMMDD"
 # (claude-opus-4-5-20251101) and openai "-YYYY-MM-DD" (gpt-5.5-2026-04-23).
@@ -75,6 +84,12 @@ PROBE_FAMILIES_BY_PLATFORM = {
     "anthropic": ("anthropic",),
     "openai": ("openai_chat", "openai_responses", "openai_image"),
     "gemini": ("gemini_chat", "gemini_image", "gemini_video"),
+}
+# Inverse of PROBE_FAMILIES_BY_PLATFORM: probe-family -> allowlist platform.
+FAMILY_PLATFORM = {
+    family: platform
+    for platform, families in PROBE_FAMILIES_BY_PLATFORM.items()
+    for family in families
 }
 GO_ALLOWLIST_PLATFORMS = ("anthropic", "openai", "gemini", "antigravity", "grok")
 REPROBE_LISTS = ("watchlist", "skiplist", "deadlist")
@@ -215,17 +230,8 @@ def _known_allowlist_members(text: str) -> set[tuple[str, str]]:
 
 
 def _candidate_members(candidates: dict[str, list[str]]) -> set[tuple[str, str]]:
-    family_platform = {
-        "anthropic": "anthropic",
-        "openai_chat": "openai",
-        "openai_responses": "openai",
-        "openai_image": "openai",
-        "gemini_chat": "gemini",
-        "gemini_image": "gemini",
-        "gemini_video": "gemini",
-    }
     out: set[tuple[str, str]] = set()
-    for family, platform in family_platform.items():
+    for family, platform in FAMILY_PLATFORM.items():
         out.update((platform, model) for model in candidates.get(family, []))
     return out
 
@@ -362,6 +368,141 @@ def build_probe_candidates(catalog: dict, discovered: list[str]) -> tuple[dict[s
     cands = augment_candidates_with_watchlist(build_candidates(catalog, discovered), ledger)
     validate_reprobe_ledger(ledger, allowlist_members=_known_allowlist_members(GO_FILE.read_text(encoding="utf-8")), candidates=cands)
     return cands, ledger
+
+
+# ----- 24h-traffic short-circuit (deterministic glue; transport is run-probe) -----
+def parse_traffic_rows(text: str) -> dict[str, set[str]]:
+    """probe-traffic-proven-models.sh TSV -> accounts.platform -> set of served
+    model ids. Lines: platform\\tmodel\\thits. The platform column here is the
+    SERVING account's platform (human context only); buckets are re-decided from
+    the candidate set in proven_servable_from_traffic, so unknown platforms are
+    harmless. Malformed lines are ignored."""
+    out: dict[str, set[str]] = {}
+    for line in text.splitlines():
+        parts = line.rstrip("\n").split("\t")
+        if len(parts) != 3:
+            continue
+        plat, model, _hits = (p.strip() for p in parts)
+        if not plat or not model:
+            continue
+        out.setdefault(plat, set()).add(model)
+    return out
+
+
+def candidate_model_platforms(candidates: dict[str, list[str]]) -> dict[str, set[str]]:
+    """model id -> set of allowlist platforms it is a candidate for."""
+    out: dict[str, set[str]] = {}
+    for platform, model in _candidate_members(candidates):
+        out.setdefault(model, set()).add(platform)
+    return out
+
+
+def proven_servable_from_traffic(
+    traffic: dict[str, set[str]], candidates: dict[str, list[str]]
+) -> dict[str, set[str]]:
+    """Intersect the 24h-traffic-served models with the candidate set, bucketing
+    each by the CANDIDATE platform (NOT the serving-account platform — Vertex is
+    served under accounts.platform='newapi', so account platform is unreliable).
+
+    Properties enforced here (the correctness contract):
+      * PURELY ADDITIVE — only models that BOTH appear in traffic AND are known
+        candidates survive. A candidate absent from traffic is simply not returned
+        (it stays in the probe set). A served model that is not a candidate is
+        dropped (never injected into the allowlist).
+      * Blocked models (skiplist/deadlist) are already absent from `candidates`
+        (augment_candidates_with_watchlist removed them), so they can never appear
+        here even with a real traffic hit — a deadlist model cannot revive on one
+        successful request. validate_results_against_reprobe_ledger is still run on
+        the result by callers as defense-in-depth.
+    Returns platform -> set of proven-servable model ids."""
+    model_platforms = candidate_model_platforms(candidates)
+    served = {model for models in traffic.values() for model in models}
+    out: dict[str, set[str]] = {}
+    for model in served:
+        for platform in model_platforms.get(model, ()):
+            out.setdefault(platform, set()).add(model)
+    return out
+
+
+def remove_proven_from_candidates(
+    candidates: dict[str, list[str]], proven: dict[str, set[str]]
+) -> dict[str, list[str]]:
+    """Drop proven (platform, model) pairs from the probe families so the SSM
+    probe never re-tests a model the traffic already proved. Returns a new dict;
+    the input is untouched."""
+    proven_pairs = {(platform, model) for platform, models in proven.items() for model in models}
+    out: dict[str, list[str]] = {}
+    for family, models in candidates.items():
+        platform = FAMILY_PLATFORM.get(family)
+        out[family] = [model for model in models if (platform, model) not in proven_pairs]
+    return out
+
+
+def proven_as_tsv(proven: dict[str, set[str]]) -> str:
+    """Render the traffic-proven set as servable probe rows (platform\\tmodel\\t200
+    \\tservable) so the `probe` subcommand's TSV stays complete for a later
+    `apply --results`."""
+    return "\n".join(
+        f"{platform}\t{model}\t200\tservable"
+        for platform in sorted(proven)
+        for model in sorted(proven[platform])
+    )
+
+
+def _log_proven_skip(proven: dict[str, set[str]], hours: int) -> None:
+    total = sum(len(models) for models in proven.values())
+    if total == 0:
+        print(
+            f"[refresh] no candidate model matched the last {hours}h of successful "
+            "traffic — probing the full candidate set",
+            file=sys.stderr,
+        )
+        return
+    rendered = ", ".join(
+        f"{platform}/{model}"
+        for platform in sorted(proven)
+        for model in sorted(proven[platform])
+    )
+    print(
+        f"[refresh] skipping {total} models proven by {hours}h traffic: {rendered}",
+        file=sys.stderr,
+    )
+
+
+def fetch_traffic_proven(hours: int = DEFAULT_TRAFFIC_HOURS, target: str = "prod") -> dict[str, set[str]]:
+    """Pull the (platform, model) pairs that served successful traffic in the last
+    `hours` hours from prod, via the same run-probe SSM transport the probe uses."""
+    if not RUN_PROBE.exists() or not TRAFFIC_PROBE.exists():
+        raise SystemExit("FATAL: run-probe.sh or probe-traffic-proven-models.sh missing")
+    cmd = [
+        "bash", str(RUN_PROBE), "--target", target, "--script", str(TRAFFIC_PROBE),
+        "--timeout-seconds", "120", "--env", f"TRAFFIC_HOURS={hours}",
+    ]
+    proc = subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sys.stderr.write(proc.stderr)
+    if proc.returncode != 0:
+        raise SystemExit(f"FATAL: traffic-proven query failed (exit {proc.returncode}) — see stderr above")
+    return parse_traffic_rows(proc.stdout)
+
+
+def short_circuit_by_traffic(
+    candidates: dict[str, list[str]],
+    ledger: dict,
+    *,
+    hours: int = DEFAULT_TRAFFIC_HOURS,
+    target: str = "prod",
+) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
+    """Fetch 24h traffic, derive the proven-servable candidates, validate them
+    against the reprobe ledger, log the skips, and return (reduced_candidates,
+    proven). reduced_candidates has the proven models removed so they are not
+    re-probed; proven is merged into the servable results by the caller."""
+    traffic = fetch_traffic_proven(hours=hours, target=target)
+    proven = proven_servable_from_traffic(traffic, candidates)
+    # Defense-in-depth: proven ⊆ candidates (which already exclude skiplist/deadlist),
+    # so this never fires — but it guards against any future candidate-derivation drift.
+    validate_results_against_reprobe_ledger(proven, ledger)
+    _log_proven_skip(proven, hours)
+    return remove_proven_from_candidates(candidates, proven), proven
 
 
 # ----- de-duplication (operator rule) -----
@@ -703,6 +844,59 @@ def selftest() -> int:
     assert "gemini-3-pro-image-preview" in real_cands["gemini_chat"], real_cands["gemini_chat"]
     assert "gemini-3-pro-image-preview" not in real_cands["gemini_image"], real_cands["gemini_image"]
 
+    # 24h-traffic short-circuit: proven-by-traffic candidates skip the probe batch
+    # but still land in the servable set, while non-candidates / blocked / untrafficked
+    # models are handled correctly (no injection, no revival, no false negative).
+    traffic_cands = augment_candidates_with_watchlist(build_candidates(cat, ["gemini-2.5-pro"]), ledger)
+    assert "gpt-image-dead" not in traffic_cands["openai_image"], "skiplist must pre-exclude"
+    assert candidate_model_platforms(traffic_cands)["gemini-2.5-pro"] == {"gemini"}
+    mock_tsv = (
+        "anthropic\tclaude-opus-4-8\t42\n"      # candidate -> proven (anthropic)
+        "openai\tgpt-5.4\t10\n"                 # candidate -> proven (openai)
+        "newapi\tgemini-2.5-pro\t7\n"           # served as newapi, but candidate=gemini -> bucket by CANDIDATE platform
+        "openai\tgpt-image-dead\t3\n"           # skiplisted -> not a candidate -> dropped, no revival
+        "openai\tgpt-4o\t99\n"                  # unpriced -> not a candidate -> dropped, no injection
+        "\n bad line with no tabs \n"            # malformed -> ignored
+    )
+    traffic = parse_traffic_rows(mock_tsv)
+    assert traffic["newapi"] == {"gemini-2.5-pro"}, traffic
+    proven = proven_servable_from_traffic(traffic, traffic_cands)
+    assert proven == {
+        "anthropic": {"claude-opus-4-8"},
+        "openai": {"gpt-5.4"},
+        "gemini": {"gemini-2.5-pro"},  # bucketed by candidate platform, NOT the serving 'newapi'
+    }, proven
+    flat_proven = {m for s in proven.values() for m in s}
+    assert "gpt-image-dead" not in flat_proven, "blocked model must never revive via traffic"
+    assert "gpt-4o" not in flat_proven, "non-candidate must never be injected via traffic"
+    # proven ⊆ candidates (which exclude skiplist/deadlist) -> ledger validation passes.
+    validate_results_against_reprobe_ledger(proven, ledger)
+    # reduced candidates: proven removed (not re-probed), untrafficked candidates kept (still probed).
+    reduced = remove_proven_from_candidates(traffic_cands, proven)
+    assert "claude-opus-4-8" not in reduced["anthropic"], reduced["anthropic"]
+    assert "claude-3-haiku-20240307" in reduced["anthropic"], "untrafficked candidate must still be probed"
+    assert "gpt-5.4" not in reduced["openai_chat"], reduced["openai_chat"]
+    assert "gpt-5.2" in reduced["openai_chat"], "untrafficked watchlist candidate must still be probed"
+    assert "gemini-2.5-pro" not in reduced["gemini_chat"], reduced["gemini_chat"]
+    assert "gemini-3-pro-image-preview" in reduced["gemini_chat"], "untrafficked candidate must still be probed"
+    orig_count = sum(len(v) for v in traffic_cands.values())
+    reduced_count = sum(len(v) for v in reduced.values())
+    assert reduced_count == orig_count - 3, (orig_count, reduced_count)
+    # empty traffic -> no short-circuit, candidates untouched (pure additive, never subtractive)
+    assert proven_servable_from_traffic({}, traffic_cands) == {}
+    assert remove_proven_from_candidates(traffic_cands, {}) == traffic_cands
+    # a blocked model that somehow reached the proven set IS still caught by the ledger guard
+    try:
+        validate_results_against_reprobe_ledger({"openai": {"gpt-image-dead"}}, ledger)
+        raise AssertionError("blocked proven model must fail ledger validation")
+    except SystemExit as e:
+        assert "skiplist/deadlist" in str(e), e
+    # proven_as_tsv round-trips into servable probe rows the apply path understands
+    tsv = proven_as_tsv({"anthropic": {"claude-opus-4-8"}, "openai": {"gpt-5.4"}})
+    assert parse_results(tsv) == {
+        "anthropic": {"claude-opus-4-8"}, "openai": {"gpt-5.4"}, "gemini": set(), "grok": set()
+    }, tsv
+
     print("refresh-servable-allowlist selftest: PASS")
     return 0
 
@@ -714,17 +908,35 @@ def main() -> int:
         "gemini discovered-models source: JSON object (account.model_pricing_status "
         "— keys), JSON list, or newline list. Omit to probe only the imagen/veo seed."
     )
+    SKIP_HELP = (
+        "short-circuit: skip the SSM probe for any candidate already proven servable "
+        "by the last --traffic-hours of successful prod traffic (additive; unmatched "
+        "candidates are still probed). Default off (env REFRESH_SKIP_PROVEN_BY_TRAFFIC=1 "
+        "also enables it) so the conservative full probe stays the default."
+    )
+    HOURS_HELP = f"traffic short-circuit look-back window in hours (default {DEFAULT_TRAFFIC_HOURS})"
+
+    def add_traffic_flags(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--skip-proven-by-traffic", action="store_true", help=SKIP_HELP)
+        p.add_argument("--traffic-hours", type=int, default=DEFAULT_TRAFFIC_HOURS, help=HOURS_HELP)
+
     ap_cand = sub.add_parser("candidates")
     ap_cand.add_argument("--discovered", help=DISC_HELP)
     ap_probe = sub.add_parser("probe")
     ap_probe.add_argument("--discovered", help=DISC_HELP)
+    add_traffic_flags(ap_probe)
     ap_apply = sub.add_parser("apply")
     ap_apply.add_argument("--results", required=True, help="TSV results file (- for stdin)")
     ap_run = sub.add_parser("run")
     ap_run.add_argument("--open-pr", action="store_true")
     ap_run.add_argument("--discovered", help=DISC_HELP)
+    add_traffic_flags(ap_run)
     sub.add_parser("selftest")
     args = ap.parse_args()
+
+    def skip_proven_enabled() -> bool:
+        return bool(getattr(args, "skip_proven_by_traffic", False)) or \
+            os.environ.get("REFRESH_SKIP_PROVEN_BY_TRAFFIC", "") not in ("", "0", "false", "False")
 
     def _report(final: dict[str, list[str]]) -> None:
         print(
@@ -742,8 +954,15 @@ def main() -> int:
         return 0
 
     if args.cmd == "probe":
-        cands, _ledger = build_probe_candidates(json.loads(CATALOG.read_text(encoding="utf-8")), load_discovered(args.discovered))
-        print(live_probe(cands))
+        cands, ledger = build_probe_candidates(json.loads(CATALOG.read_text(encoding="utf-8")), load_discovered(args.discovered))
+        proven: dict[str, set[str]] = {}
+        if skip_proven_enabled():
+            cands, proven = short_circuit_by_traffic(cands, ledger, hours=args.traffic_hours)
+        probe_tsv = live_probe(cands)
+        if proven:
+            tsv = proven_as_tsv(proven)
+            probe_tsv = f"{tsv}\n{probe_tsv}".strip() if probe_tsv else tsv
+        print(probe_tsv)
         return 0
 
     if args.cmd == "apply":
@@ -755,7 +974,13 @@ def main() -> int:
 
     if args.cmd == "run":
         cands, ledger = build_probe_candidates(json.loads(CATALOG.read_text(encoding="utf-8")), load_discovered(args.discovered))
-        final = write_allowlists(parse_results(live_probe(cands)), ledger)
+        proven: dict[str, set[str]] = {}
+        if skip_proven_enabled():
+            cands, proven = short_circuit_by_traffic(cands, ledger, hours=args.traffic_hours)
+        servable = parse_results(live_probe(cands))
+        for platform, models in proven.items():
+            servable.setdefault(platform, set()).update(models)
+        final = write_allowlists(servable, ledger)
         _report(final)
         if args.open_pr:
             open_pr(final)


### PR DESCRIPTION
## 背景

分支 B 的 catalog/menu allowlist 刷新工具(`ops/pricing/refresh-servable-allowlist.py`)目前把所有候选(约 162 模型)全量经 prod SSM 探测,16 批、8-15 分钟。很多候选近 24h 已被真实客流成功调用,再探纯属浪费。

## 改动

在 SSM 探测前先从 `usage_logs` 拉近 24h 成功流量,把**已被真实流量证明 servable 的候选直接判定并移出探测批**,显著降低 batch 数。

- 新增 `ops/pricing/probe-traffic-proven-models.sh`:只读聚合 `usage_logs`(经现有 `run-probe.sh` SSM 通道),emit `platform⇥model⇥hits`。`usage_logs` 一行 = 一次计费请求,查询再要求真实产出(token/图/视频)排除 `$0` 占位行。
- `refresh-servable-allowlist.py` 加 `--skip-proven-by-traffic`(+ `--traffic-hours`,+ env `REFRESH_SKIP_PROVEN_BY_TRAFFIC=1`),`probe` / `run` 子命令生效。
- selftest 加 mock 流量覆盖;更新 README + `tokenkey-servable-model-refresh` SKILL。

## 纯加性正确性契约

- **流量成功=确凿 servable 正证据**;**没流量 ≠ 不可服务** —— 未命中流量的候选仍正常进探测批,短路只删探测、绝不判 unsupported。
- **只能跳/加候选集内模型**:proven 与派生候选集求交,流量无法把候选集外模型塞进 allowlist。
- **平台桶按候选集定,不按服务账号**:Vertex 经 `accounts.platform='newapi'` 服务,`gemini-2.5-pro` 仍按候选平台入 `gemini` 桶。
- **deadlist 不复活**:复用 `validate_results_against_reprobe_ledger` 兜底。
- **默认关、可灰度**;不改 verdict 语义 / Go splice / sentinel。

## 与 #1002 的关系

与 #1002(catalog reserved-probe)改的是同一工具但不同维度,可独立合入或 cherry-pick 本分支的单 commit 过去(两边对 `refresh-servable-allowlist.py` / README / SKILL 均为加性改动,冲突仅在插入边界,易解)。

## 验证

- `python3 ops/pricing/refresh-servable-allowlist.py selftest` PASS
- `bash scripts/preflight.sh` PASS

no-web-impact
no-upstream-touch