### PR TITLE
feat(pricing): tiered (阶梯) pricing on public + Your-Menu, single source of truth + admin CSV export

### DIFF
--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -211,6 +211,46 @@ type MePricingPrice struct {
 	// the public catalog meta (which now surfaces media — pricing_catalog_tk.go).
 	PerImage  *float64 `json:"per_image,omitempty"`
 	PerSecond *float64 `json:"per_second,omitempty"`
+	// Tiers, when non-empty, is the input-token interval (阶梯) ladder for models
+	// whose unit price varies by request input length. Single source of truth: it
+	// is copied verbatim from the public catalog (PublicCatalogModel.Pricing.Tiers,
+	// built once in attachCatalogOverlayTiers) — me-pricing shows the OFFICIAL list
+	// price (officialRate = 1.0, no group/override scaling), so its ladder is the
+	// same one the public /pricing endpoint serves. The flat Input/OutputPer1K
+	// fields carry the first (lowest) tier. Per 1k tokens, USD.
+	Tiers []MePricingTier `json:"tiers,omitempty"`
+}
+
+// MePricingTier mirrors PublicCatalogTier (the single source) in the me-pricing
+// DTO's per-1k naming. MinTokens inclusive, MaxTokens exclusive (nil = open-ended
+// top tier). Pointer prices keep the "nil = no data" convention of MePricingPrice.
+type MePricingTier struct {
+	MinTokens      int      `json:"min_tokens"`
+	MaxTokens      *int     `json:"max_tokens,omitempty"`
+	InputPer1K     *float64 `json:"input_per_1k,omitempty"`
+	OutputPer1K    *float64 `json:"output_per_1k,omitempty"`
+	CacheReadPer1K *float64 `json:"cache_read_per_1k,omitempty"`
+}
+
+// mePricingTiersFromCatalog converts the public catalog's tier ladder into the
+// me-pricing DTO shape verbatim (no rate scaling — me-pricing is the official
+// list price). Returns nil for a flat-priced model so the field stays omitted.
+func mePricingTiersFromCatalog(tiers []PublicCatalogTier) []MePricingTier {
+	if len(tiers) == 0 {
+		return nil
+	}
+	out := make([]MePricingTier, 0, len(tiers))
+	for i := range tiers {
+		t := tiers[i]
+		in, outp := t.InputPer1KTokens, t.OutputPer1KTokens
+		mt := MePricingTier{MinTokens: t.MinTokens, MaxTokens: t.MaxTokens, InputPer1K: &in, OutputPer1K: &outp}
+		if t.CacheReadPer1K > 0 {
+			cr := t.CacheReadPer1K
+			mt.CacheReadPer1K = &cr
+		}
+		out = append(out, mt)
+	}
+	return out
 }
 
 // MePricingKeyRef populates the key-picker dropdown. Only active keys
@@ -518,6 +558,9 @@ func (s *MePricingCatalogService) buildModelsForGroup(
 			if m.Vendor == "" {
 				m.Vendor = meta.Vendor
 			}
+			// Single source of truth: the阶梯 ladder is the public catalog's,
+			// copied verbatim (me-pricing is the official list price, rate 1.0).
+			m.YourPrice.Tiers = mePricingTiersFromCatalog(meta.Pricing.Tiers)
 		}
 		if m.Capabilities == nil {
 			m.Capabilities = []string{}

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -184,6 +184,62 @@ func mkPublicCatalogModel(modelID, vendor string, in, out, cacheR float64) Publi
 
 // ----- tests -----
 
+// TestMePricingCatalog_TiersFromPublicCatalog pins the single-source-of-truth
+// contract: Your-Menu surfaces the input-token interval (阶梯) ladder copied
+// verbatim from the public catalog (no rate scaling — me-pricing is the official
+// list price), so /pricing and me/pricing-catalog never diverge on tiers.
+func TestMePricingCatalog_TiersFromPublicCatalog(t *testing.T) {
+	g := mkGroupForMe(10, "Pro", "newapi", 1.5)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+
+	maxTok := func(v int) *int { return &v }
+	catalogModel := PublicCatalogModel{
+		ModelID:      "qwen-plus",
+		Vendor:       "dashscope",
+		Capabilities: []string{},
+		Pricing: PublicCatalogPricing{
+			Currency:          "USD",
+			InputPer1KTokens:  0.0001194,
+			OutputPer1KTokens: 0.0002985,
+			Tiers: []PublicCatalogTier{
+				{MinTokens: 0, MaxTokens: maxTok(128000), InputPer1KTokens: 0.0001194, OutputPer1KTokens: 0.0002985, CacheReadPer1K: 0.0001194},
+				{MinTokens: 128000, MaxTokens: nil, InputPer1KTokens: 0.0007164, OutputPer1KTokens: 0.0071642},
+			},
+		},
+	}
+
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{g}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{
+			mkChannelWithModel(100, "ch1",
+				[]AvailableGroupRef{{ID: 10, Name: "Pro", Platform: "newapi", RateMultiplier: 1.5}},
+				[]SupportedModel{mkSupportedModel("qwen-plus", "newapi", mkPricing(0.0000001194, 0.0000002985, 0))},
+			),
+		}},
+		&fakeCatalogProvider{resp: &PublicCatalogResponse{Object: "list", Data: []PublicCatalogModel{catalogModel}}},
+	)
+
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1)
+	tiers := resp.Models[0].YourPrice.Tiers
+	require.Len(t, tiers, 2, "ladder copied from the public catalog")
+
+	// tier 1: bounded, verbatim (no ×1.5 scaling — official list price).
+	assert.Equal(t, 0, tiers[0].MinTokens)
+	require.NotNil(t, tiers[0].MaxTokens)
+	assert.Equal(t, 128000, *tiers[0].MaxTokens)
+	require.NotNil(t, tiers[0].InputPer1K)
+	assert.InDelta(t, 0.0001194, *tiers[0].InputPer1K, 1e-12, "verbatim from catalog, not scaled by 1.5")
+	require.NotNil(t, tiers[0].CacheReadPer1K)
+	assert.InDelta(t, 0.0001194, *tiers[0].CacheReadPer1K, 1e-12)
+
+	// top tier: open-ended, costlier; no cache-read → pointer stays nil.
+	assert.Nil(t, tiers[1].MaxTokens)
+	assert.InDelta(t, 0.0007164, *tiers[1].InputPer1K, 1e-12)
+	assert.Nil(t, tiers[1].CacheReadPer1K)
+}
+
 // TK: 价格一律官方基价（倍率 1.0），TargetGroup 的 RateMultiplier 字段仍反映
 // 真实生效倍率（1.5），但不再作用于 YourPrice。
 func TestMePricingCatalog_DefaultToFirstKeyGroup_OfficialPrice(t *testing.T) {

--- a/backend/internal/service/pricing_catalog_tk.go
+++ b/backend/internal/service/pricing_catalog_tk.go
@@ -102,6 +102,28 @@ type PublicCatalogPricing struct {
 	BillingMode         string  `json:"billing_mode,omitempty"`
 	OutputCostPerImage  float64 `json:"output_cost_per_image,omitempty"`
 	OutputCostPerSecond float64 `json:"output_cost_per_second,omitempty"`
+	// Tiers, when non-empty, is the input-token interval (阶梯) pricing for models
+	// whose unit price varies by request input length (overlay `intervals` —
+	// VolcEngine doubao-seed-*, DeepSeek, Qwen-plus/coder, GLM-4.7 tiered SKUs).
+	// The flat Input/OutputPer1KTokens fields above carry the FIRST (lowest) tier
+	// so pre-tier clients still render a sane base price; tier-aware clients (and
+	// the admin CSV export) render the full ladder. Per 1k tokens, USD. Until this
+	// field shipped the public /pricing endpoint silently flattened these models to
+	// their first-tier price only — the ladder lived only in the compiled-in
+	// tk_pricing_overlay.json. Omitted for flat-priced models.
+	Tiers []PublicCatalogTier `json:"tiers,omitempty"`
+}
+
+// PublicCatalogTier is one input-token bracket of a tiered (阶梯) price. MinTokens
+// is inclusive, MaxTokens exclusive; MaxTokens == nil is the open-ended top tier.
+// Prices are USD per 1k tokens (overlay intervals are stored per-token → ×1000 to
+// match the rest of the catalog).
+type PublicCatalogTier struct {
+	MinTokens         int     `json:"min_tokens"`
+	MaxTokens         *int    `json:"max_tokens,omitempty"`
+	InputPer1KTokens  float64 `json:"input_per_1k_tokens"`
+	OutputPer1KTokens float64 `json:"output_per_1k_tokens"`
+	CacheReadPer1K    float64 `json:"cache_read_per_1k,omitempty"`
 }
 
 // catalogRichEntry mirrors the litellm-shape JSON fields needed for the public
@@ -221,6 +243,7 @@ func (s *PricingCatalogService) BuildPublicCatalog(ctx context.Context) *PublicC
 	// contract) rather than surfacing a partial overlay-only catalog.
 	if len(resp.Data) > 0 {
 		applyCatalogOverlayPricing(resp)
+		attachCatalogOverlayTiers(resp)
 	}
 
 	s.mu.Lock()
@@ -390,6 +413,45 @@ func applyCatalogOverlayPricing(resp *PublicCatalogResponse) {
 		sort.Slice(resp.Data, func(i, j int) bool {
 			return resp.Data[i].ModelID < resp.Data[j].ModelID
 		})
+	}
+}
+
+// attachCatalogOverlayTiers surfaces overlay-defined input-token interval (阶梯)
+// pricing on the public catalog. Runs AFTER applyCatalogOverlayPricing so it sees
+// every model (file-sourced and overlay-filled). The flat Input/OutputPer1KTokens
+// fields stay the base (first) tier for pre-tier clients; this fills the full
+// ladder on Pricing.Tiers for tier-aware clients and the admin CSV export. Overlay
+// interval prices are per-token → ×1000 to match the catalog's per-1k unit.
+// Purely additive (never mutates flat prices), idempotent, nil-safe.
+func attachCatalogOverlayTiers(resp *PublicCatalogResponse) {
+	if resp == nil || len(resp.Data) == 0 {
+		return
+	}
+	overlay := loadTKPricingOverlay()
+	if len(overlay) == 0 {
+		return
+	}
+	for i := range resp.Data {
+		p := overlay[resp.Data[i].ModelID]
+		if p == nil || len(p.Intervals) == 0 {
+			continue
+		}
+		tiers := make([]PublicCatalogTier, 0, len(p.Intervals))
+		for j := range p.Intervals {
+			iv := p.Intervals[j]
+			tier := PublicCatalogTier{MinTokens: iv.MinTokens, MaxTokens: iv.MaxTokens}
+			if iv.InputPrice != nil {
+				tier.InputPer1KTokens = *iv.InputPrice * 1000
+			}
+			if iv.OutputPrice != nil {
+				tier.OutputPer1KTokens = *iv.OutputPrice * 1000
+			}
+			if iv.CacheReadPrice != nil {
+				tier.CacheReadPer1K = *iv.CacheReadPrice * 1000
+			}
+			tiers = append(tiers, tier)
+		}
+		resp.Data[i].Pricing.Tiers = tiers
 	}
 }
 

--- a/backend/internal/service/pricing_catalog_tk_test.go
+++ b/backend/internal/service/pricing_catalog_tk_test.go
@@ -163,6 +163,52 @@ func TestPricingCatalogService_AppliesTKOverlayPricing(t *testing.T) {
 		"source price wins over overlay (fill-only); overlay must NOT override")
 }
 
+// TestPricingCatalogService_AttachesOverlayTiers pins that input-token interval
+// (阶梯) pricing from tk_pricing_overlay.json is surfaced on Pricing.Tiers of the
+// public catalog (the fix for "公开接口拍平丢掉阶梯价"), and that the flat price is
+// left untouched as the first-tier base. doubao-seed-2-0-pro-260215 carries a 3-tier
+// ladder in the compiled-in overlay.
+func TestPricingCatalogService_AttachesOverlayTiers(t *testing.T) {
+	const fixture = `{
+	  "gpt-5.4": {"input_cost_per_token":0.0000005,"output_cost_per_token":0.000002,"litellm_provider":"openai"}
+	}`
+	s := &PricingCatalogService{}
+	s.SetSourceForTesting(func() ([]byte, time.Time, bool) {
+		return []byte(fixture), time.Date(2026, 6, 26, 0, 0, 0, 0, time.UTC), true
+	})
+
+	resp := s.BuildPublicCatalog(context.Background())
+	require.NotNil(t, resp)
+	byID := make(map[string]PublicCatalogModel, len(resp.Data))
+	for _, m := range resp.Data {
+		byID[m.ModelID] = m
+	}
+
+	pro, ok := byID["doubao-seed-2-0-pro-260215"]
+	require.True(t, ok, "tiered overlay model must surface")
+	require.Len(t, pro.Pricing.Tiers, 3, "doubao-seed-2-0-pro carries a 3-tier ladder")
+
+	// tier 1: [0, 32000), per-token ×1000 = per-1k.
+	assert.Equal(t, 0, pro.Pricing.Tiers[0].MinTokens)
+	require.NotNil(t, pro.Pricing.Tiers[0].MaxTokens)
+	assert.Equal(t, 32000, *pro.Pricing.Tiers[0].MaxTokens)
+	assert.InDelta(t, 0.000477612, pro.Pricing.Tiers[0].InputPer1KTokens, 1e-9)
+	assert.InDelta(t, 0.002388060, pro.Pricing.Tiers[0].OutputPer1KTokens, 1e-9)
+
+	// top tier is open-ended (MaxTokens nil) and costs more than tier 1.
+	assert.Nil(t, pro.Pricing.Tiers[2].MaxTokens, "top tier must be unbounded")
+	assert.Greater(t, pro.Pricing.Tiers[2].InputPer1KTokens, pro.Pricing.Tiers[0].InputPer1KTokens)
+
+	// flat price is left as the first-tier base (purely additive — display unchanged).
+	assert.InDelta(t, pro.Pricing.Tiers[0].InputPer1KTokens, pro.Pricing.InputPer1KTokens, 1e-9,
+		"flat input price must equal first tier (additive change, not a mutation)")
+
+	// flat-priced model has no tiers.
+	flat, ok := byID["gpt-5.4"]
+	require.True(t, ok)
+	assert.Empty(t, flat.Pricing.Tiers, "flat-priced model must not carry tiers")
+}
+
 func TestPricingCatalogService_AntigravityThinkingOverlaySurfaces(t *testing.T) {
 	const fixture = `{
 	  "gemini-2.5-flash": {"input_cost_per_token":0.0000003,"output_cost_per_token":0.0000025,"cache_read_input_token_cost":0.00000003,"litellm_provider":"vertex_ai-language-models"}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 512,
-  "hash": "7968a024f843e1e3cfdc7b8e0272b6bd92cc818ce6b26d6dd064ce9161d995de",
+  "file_count": 513,
+  "hash": "314ba4a4b413671d50a49b80c1538b0cec4ed9d9d1a1b11bcc98de4cff845134",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/me-pricing.ts
+++ b/frontend/src/api/me-pricing.ts
@@ -37,6 +37,20 @@ export interface MePricingPrice {
   per_image?: number
   /** USD per second of generated video (video billing_mode), scaled by the user's rate. */
   per_second?: number
+  /** Input-token interval (阶梯) ladder, copied verbatim from the public catalog
+   *  (single source of truth — me-pricing is the official list price). The flat
+   *  input/output fields carry the first tier. Absent for flat-priced models. */
+  tiers?: MePricingTier[]
+}
+
+/** One input-token bracket of a tiered (阶梯) price. `min_tokens` inclusive,
+ *  `max_tokens` exclusive; `max_tokens` absent = open-ended top tier. Per 1k tokens. */
+export interface MePricingTier {
+  min_tokens: number
+  max_tokens?: number
+  input_per_1k?: number
+  output_per_1k?: number
+  cache_read_per_1k?: number
 }
 
 export interface MePricingModel {

--- a/frontend/src/api/pricing.ts
+++ b/frontend/src/api/pricing.ts
@@ -26,6 +26,21 @@ export interface PublicPricing {
   output_cost_per_image?: number
   /** USD per second of generated video (video billing_mode). */
   output_cost_per_second?: number
+  /** Input-token interval (阶梯) pricing for models whose unit price varies by
+   *  request input length (VolcEngine doubao-seed-*, DeepSeek, Qwen-plus/coder,
+   *  GLM-4.7). The flat input/output fields carry the first (lowest) tier; this
+   *  array carries the full ladder. Absent for flat-priced models. Per 1k tokens. */
+  tiers?: PublicPricingTier[]
+}
+
+/** One input-token bracket of a tiered (阶梯) price. `min_tokens` inclusive,
+ *  `max_tokens` exclusive; `max_tokens` absent = open-ended top tier. Per 1k tokens. */
+export interface PublicPricingTier {
+  min_tokens: number
+  max_tokens?: number
+  input_per_1k_tokens: number
+  output_per_1k_tokens: number
+  cache_read_per_1k?: number
 }
 
 export interface PublicCatalogModel {

--- a/frontend/src/composables/__tests__/useTkPricingExport.spec.ts
+++ b/frontend/src/composables/__tests__/useTkPricingExport.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { buildPricingCsv, formatTiers, pricingCsvFilename } from '../useTkPricingExport'
+import type { PublicCatalogResponse } from '@/api/pricing'
+
+const catalog = (data: PublicCatalogResponse['data']): PublicCatalogResponse => ({
+  object: 'list',
+  data,
+  updated_at: '2026-06-26T00:00:00Z'
+})
+
+describe('useTkPricingExport.buildPricingCsv', () => {
+  it('emits header + one row per model, prices converted to per-1M', () => {
+    const csv = buildPricingCsv(
+      catalog([
+        {
+          model_id: 'claude-haiku-4-5',
+          vendor: 'anthropic',
+          pricing: { currency: 'USD', input_per_1k_tokens: 0.001, output_per_1k_tokens: 0.005 },
+          context_window: 200000,
+          max_output_tokens: 64000,
+          capabilities: ['vision', 'tool_use']
+        }
+      ])
+    )
+    const [header, row] = csv.split('\r\n')
+    expect(header.split(',')).toContain('input_per_1M')
+    expect(header.split(',')).toContain('tiers')
+    // 0.001/1k → 1.0/1M, 0.005/1k → 5.0/1M
+    expect(row).toContain('1,5,') // input_per_1M, output_per_1M
+    // capabilities joined with ';' so the cell stays one CSV column
+    expect(row).toContain('vision;tool_use')
+  })
+
+  it('renders the 阶梯 ladder into a single readable tiers cell (quoted, per-1M)', () => {
+    const csv = buildPricingCsv(
+      catalog([
+        {
+          model_id: 'qwen-plus',
+          vendor: 'dashscope',
+          pricing: {
+            currency: 'USD',
+            input_per_1k_tokens: 0.0001194,
+            output_per_1k_tokens: 0.0002985,
+            tiers: [
+              { min_tokens: 0, max_tokens: 128000, input_per_1k_tokens: 0.0001194, output_per_1k_tokens: 0.0002985 },
+              { min_tokens: 128000, input_per_1k_tokens: 0.0007164, output_per_1k_tokens: 0.0071642 }
+            ]
+          },
+          capabilities: []
+        }
+      ])
+    )
+    // the ladder is one cell, segments joined by ' | ' (no comma → no quoting)
+    expect(csv).toContain('0-128k: in 0.1194 / out 0.2985 | 128k-∞: in 0.7164 / out 7.1642')
+  })
+
+  it('sorts by (vendor, model_id) and leaves flat models with an empty tiers cell', () => {
+    const csv = buildPricingCsv(
+      catalog([
+        { model_id: 'z-model', vendor: 'zhipu', pricing: { currency: 'USD', input_per_1k_tokens: 0.001, output_per_1k_tokens: 0.002 }, capabilities: [] },
+        { model_id: 'a-model', vendor: 'anthropic', pricing: { currency: 'USD', input_per_1k_tokens: 0.001, output_per_1k_tokens: 0.002 }, capabilities: [] }
+      ])
+    )
+    const rows = csv.split('\r\n')
+    expect(rows[1]).toContain('a-model')
+    expect(rows[2]).toContain('z-model')
+  })
+
+  it('returns just the header for an empty/null catalog', () => {
+    expect(buildPricingCsv(null).split('\r\n')).toHaveLength(1)
+    expect(buildPricingCsv(catalog([])).split('\r\n')).toHaveLength(1)
+  })
+})
+
+describe('useTkPricingExport.formatTiers', () => {
+  it('is empty for missing tiers', () => {
+    expect(formatTiers(undefined)).toBe('')
+    expect(formatTiers([])).toBe('')
+  })
+})
+
+describe('useTkPricingExport.pricingCsvFilename', () => {
+  it('embeds the date', () => {
+    expect(pricingCsvFilename(new Date('2026-06-26T10:00:00Z'))).toBe('tokenkey-pricing-2026-06-26.csv')
+  })
+})

--- a/frontend/src/composables/useTkPricingExport.ts
+++ b/frontend/src/composables/useTkPricingExport.ts
@@ -1,0 +1,132 @@
+/**
+ * TokenKey: admin-only "export platform pricing" for the public /pricing page.
+ *
+ * Builds a sales-friendly CSV from the public catalog (在售目录 / 对外价) the page
+ * already fetched — no extra backend call. Prices are emitted per 1,000,000 tokens
+ * (the sales口径) and the input-token interval (阶梯) ladder is rendered into a
+ * single readable `tiers` column so a tiered model stays one row.
+ *
+ * This composable owns the CSV + download logic; PricingView.vue stays template +
+ * a single admin-gated button (TokenKey upstream-isolation pattern, CLAUDE.md §5).
+ */
+
+import type { PublicCatalogModel, PublicCatalogResponse, PublicPricingTier } from '@/api/pricing'
+
+const CSV_COLUMNS = [
+  'model_id',
+  'vendor',
+  'billing_mode',
+  'currency',
+  'input_per_1M',
+  'output_per_1M',
+  'thinking_output_per_1M',
+  'cache_read_per_1M',
+  'cache_write_per_1M',
+  'price_per_image_USD',
+  'price_per_second_USD',
+  'tiers',
+  'context_window',
+  'max_output_tokens',
+  'capabilities'
+] as const
+
+/** per-1k → per-1M, rounded to kill float noise; '' for missing/zero. */
+function per1M(per1k: number | undefined | null): string {
+  if (per1k === undefined || per1k === null || per1k === 0) return ''
+  return String(Number((per1k * 1000).toFixed(4)))
+}
+
+/** USD per unit (image/second), rounded; '' for missing/zero. */
+function unitUsd(v: number | undefined | null): string {
+  if (v === undefined || v === null || v === 0) return ''
+  return String(Number(v.toFixed(6)))
+}
+
+/** "32000" → "32k", "256000" → "256k", 0 → "0", non-round → raw. nil = "∞". */
+function tokenBound(n: number | undefined): string {
+  if (n === undefined) return '∞'
+  if (n === 0) return '0'
+  return n % 1000 === 0 ? `${n / 1000}k` : String(n)
+}
+
+/** Render the阶梯 ladder into one readable cell (prices per 1M USD). */
+export function formatTiers(tiers: PublicPricingTier[] | undefined): string {
+  if (!tiers || tiers.length === 0) return ''
+  return tiers
+    .map((t) => {
+      const lo = tokenBound(t.min_tokens)
+      const hi = tokenBound(t.max_tokens)
+      const inp = per1M(t.input_per_1k_tokens)
+      const out = per1M(t.output_per_1k_tokens)
+      return `${lo}-${hi}: in ${inp} / out ${out}`
+    })
+    .join(' | ')
+}
+
+/** RFC-4180 escaping: quote when the cell holds a comma, quote, or newline. */
+function csvEscape(value: string): string {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+function rowFor(m: PublicCatalogModel): string[] {
+  const p = m.pricing
+  return [
+    m.model_id ?? '',
+    m.vendor ?? '',
+    p.billing_mode || 'token',
+    p.currency ?? 'USD',
+    per1M(p.input_per_1k_tokens),
+    per1M(p.output_per_1k_tokens),
+    per1M(p.thinking_output_per_1k_tokens),
+    per1M(p.cache_read_per_1k),
+    per1M(p.cache_write_per_1k),
+    unitUsd(p.output_cost_per_image),
+    unitUsd(p.output_cost_per_second),
+    formatTiers(p.tiers),
+    m.context_window ? String(m.context_window) : '',
+    m.max_output_tokens ? String(m.max_output_tokens) : '',
+    (m.capabilities ?? []).join(';')
+  ]
+}
+
+/**
+ * Build the full CSV text (incl. header). Exported for unit testing. Models are
+ * sorted by (vendor, model_id) for a stable, scannable sheet.
+ */
+export function buildPricingCsv(catalog: PublicCatalogResponse | null): string {
+  const models = [...(catalog?.data ?? [])].sort((a, b) => {
+    const va = a.vendor ?? ''
+    const vb = b.vendor ?? ''
+    return va === vb ? a.model_id.localeCompare(b.model_id) : va.localeCompare(vb)
+  })
+  const lines = [CSV_COLUMNS.join(',')]
+  for (const m of models) {
+    lines.push(rowFor(m).map(csvEscape).join(','))
+  }
+  return lines.join('\r\n')
+}
+
+/** Build the dated download filename, e.g. tokenkey-pricing-2026-06-26.csv. */
+export function pricingCsvFilename(now: Date = new Date()): string {
+  return `tokenkey-pricing-${now.toISOString().split('T')[0]}.csv`
+}
+
+/**
+ * Trigger a browser download of the public pricing catalog as CSV. A leading
+ * UTF-8 BOM keeps Excel from garbling the中文 capability/vendor cells.
+ */
+export function exportPricingCsv(catalog: PublicCatalogResponse | null): void {
+  const csv = '﻿' + buildPricingCsv(catalog)
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+  const url = window.URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = pricingCsvFilename()
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  window.URL.revokeObjectURL(url)
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -25,6 +25,11 @@ export default {
     },
     tableHint:
       'Swipe horizontally or scroll below to see all columns. Model names wrap in the left column.',
+    export: {
+      button: 'Export CSV',
+      success: 'Pricing exported'
+    },
+    tieredBadge: 'Tiered ×{n}',
     footer: {
       total: '{count} models listed',
       filtered: 'Showing {shown} of {total} models'

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -24,6 +24,11 @@ export default {
       capabilities: '能力'
     },
     tableHint: '可左右滑动或横向滚动查看全部列；左侧模型名称支持换行显示。',
+    export: {
+      button: '导出 CSV',
+      success: '定价已导出'
+    },
+    tieredBadge: '阶梯 ×{n}',
     footer: {
       total: '共 {count} 个模型',
       filtered: '显示 {shown} / {total} 个模型'

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -244,6 +244,16 @@
             class="flex shrink-0 flex-col gap-3 border-b border-gray-100 bg-gray-50/80 px-4 py-3 dark:border-dark-800 dark:bg-dark-800/40 sm:flex-row sm:items-center sm:justify-between"
           >
             <p class="text-xs text-gray-500 dark:text-dark-400" data-tk="pricing-active-catalog">{{ activeCatalogLabel }}</p>
+            <button
+              v-if="canExportPricing"
+              type="button"
+              class="inline-flex items-center gap-1.5 self-start rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-50 dark:border-dark-700 dark:bg-dark-800 dark:text-dark-100 dark:hover:bg-dark-700 sm:self-auto"
+              data-tk="pricing-export-csv"
+              @click="onExportPricing"
+            >
+              <Icon name="download" size="sm" :stroke-width="2" />
+              {{ t('pricing.export.button') }}
+            </button>
           </div>
           <p
             class="shrink-0 border-b border-gray-100 bg-gray-50/50 px-4 py-2 text-xs text-gray-500 dark:border-dark-800 dark:bg-dark-800/30 dark:text-dark-400 lg:hidden"
@@ -367,6 +377,14 @@
                         <span class="ml-0.5 text-xs text-gray-400">{{
                           t('pricing.perThousandTokens')
                         }}</span>
+                        <div v-if="row.tiers && row.tiers.length" class="mt-0.5">
+                          <span
+                            class="inline-flex cursor-help items-center rounded bg-amber-50 px-1 py-px text-[10px] font-medium text-amber-700 dark:bg-amber-500/10 dark:text-amber-300"
+                            :title="tierTooltip(row)"
+                            data-tk="pricing-tier-badge"
+                            >{{ t('pricing.tieredBadge', { n: row.tiers.length }) }}</span
+                          >
+                        </div>
                       </template>
                       <template v-else>—</template>
                     </td>
@@ -493,6 +511,7 @@ import {
   filterPricingCatalogByModel,
   type PricingCatalogSearchMode
 } from '@/utils/pricingCatalogSearch'
+import { exportPricingCsv } from '@/composables/useTkPricingExport'
 
 const { t } = useI18n()
 const authStore = useAuthStore()
@@ -523,6 +542,16 @@ interface NormalizedRow {
   perRequest?: number | null
   perImage?: number | null
   perSecond?: number | null
+  /** Input-token interval (阶梯) ladder, normalized from either catalog source. */
+  tiers?: NormalizedTier[]
+}
+
+/** Normalized阶梯 bracket shared by public + my views (per-1k). */
+interface NormalizedTier {
+  minTokens: number
+  maxTokens: number | null
+  inputPer1K: number | null
+  outputPer1K: number | null
 }
 
 const signupBonusFormatted = computed(() =>
@@ -591,6 +620,17 @@ const selectedGroupId = ref<number>(0)
 
 const canShowCatalogFilters = computed(() => myCatalog.value != null)
 
+// Admin-only "export platform pricing" — the public (在售目录/对外价) catalog only,
+// as a sales-friendly CSV. Hidden for non-admins and when there is nothing to export.
+const canExportPricing = computed(
+  () => authStore.isAdmin && viewMode.value === 'public' && (publicCatalog.value?.data.length ?? 0) > 0
+)
+
+const onExportPricing = () => {
+  exportPricingCsv(publicCatalog.value)
+  appStore.showSuccess(t('pricing.export.success'))
+}
+
 // ============================== hero copy ==============================
 
 const heroTitle = computed(() => t('pricing.title'))
@@ -623,7 +663,13 @@ const normalizedRows = computed<NormalizedRow[]>(() => {
       billingMode: m.pricing.billing_mode || 'token',
       perRequest: null,
       perImage: m.pricing.output_cost_per_image ?? null,
-      perSecond: m.pricing.output_cost_per_second ?? null
+      perSecond: m.pricing.output_cost_per_second ?? null,
+      tiers: m.pricing.tiers?.map((tt) => ({
+        minTokens: tt.min_tokens,
+        maxTokens: tt.max_tokens ?? null,
+        inputPer1K: tt.input_per_1k_tokens ?? null,
+        outputPer1K: tt.output_per_1k_tokens ?? null
+      }))
     }))
   }
   // 'my' view
@@ -642,7 +688,13 @@ const normalizedRows = computed<NormalizedRow[]>(() => {
     billingMode: m.billing_mode,
     perRequest: m.your_price.per_request ?? null,
     perImage: m.your_price.per_image ?? null,
-    perSecond: m.your_price.per_second ?? null
+    perSecond: m.your_price.per_second ?? null,
+    tiers: m.your_price.tiers?.map((tt) => ({
+      minTokens: tt.min_tokens,
+      maxTokens: tt.max_tokens ?? null,
+      inputPer1K: tt.input_per_1k ?? null,
+      outputPer1K: tt.output_per_1k ?? null
+    }))
   }))
 })
 
@@ -766,6 +818,27 @@ function formatPrice(value: number): string {
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat().format(value)
+}
+
+/** "0" / "32000"→"32k" / null→"∞" — compact token-bound label for the阶梯 tooltip. */
+function tierTokenLabel(n: number | null): string {
+  if (n === null) return '∞'
+  if (n === 0) return '0'
+  return n % 1000 === 0 ? `${n / 1000}k` : String(n)
+}
+
+/** Multi-line ladder for the row's tier badge `title` (per-1k, both views). */
+function tierTooltip(row: NormalizedRow): string {
+  if (!row.tiers || row.tiers.length === 0) return ''
+  const unit = t('pricing.perThousandTokens')
+  return row.tiers
+    .map((tier) => {
+      const range = `${tierTokenLabel(tier.minTokens)}–${tierTokenLabel(tier.maxTokens)}`
+      const inp = tier.inputPer1K != null ? formatPrice(tier.inputPer1K) : '—'
+      const out = tier.outputPer1K != null ? formatPrice(tier.outputPer1K) : '—'
+      return `${range}: ${t('pricing.columns.input')} ${inp} / ${t('pricing.columns.output')} ${out} ${unit}`
+    })
+    .join('\n')
 }
 
 function formatBillingMode(mode: string): string {


### PR DESCRIPTION
## 背景

公开 `/api/v1/public/pricing` 此前**静默把阶梯模型拍平成首档价**——VolcEngine doubao-seed-*、DeepSeek、Qwen-plus/coder、GLM-4.7 的输入 token 区间阶梯只活在编进二进制的 `tk_pricing_overlay.json` 里,接口和前端都看不到。本 PR 把它显式吐出来,并保证**同一份阶梯被所有消费端复用**。

## 单一事实来源

overlay intervals 只在一处转成 `PublicCatalogModel.Pricing.Tiers`(`attachCatalogOverlayTiers`):

```
overlay (tk_pricing_overlay.json)
   └─ attachCatalogOverlayTiers() 建一次 ──► PublicCatalogModel.Pricing.Tiers
                                              ├─ /api/v1/public/pricing 直接吐
                                              └─ me/pricing-catalog Stage-3 metaByID join 原样复制
```

- me-pricing 是**官方列表价**(`officialRate = 1.0`,不乘 group/override 倍率),所以阶梯**逐字复制、不缩放** → `/pricing` 与 Your-Menu 永不漂移。
- 扁平 input/output 字段仍是首档,**纯增量**(pre-tier 客户端无感),**无删除任何 upstream 符号**。

## 改动

**后端**
- `pricing_catalog_tk.go`:`PublicCatalogPricing.Tiers` + `attachCatalogOverlayTiers`(per-token ×1000 → per-1k)。
- `me_pricing_catalog_tk.go`:`MePricingPrice.Tiers`,在已有 Stage-3 统一 join 里复制 `meta.Pricing.Tiers`(一个注入点,覆盖 channel-priced + fallback 行)。
- 测试:阶梯存在 + 逐字未缩放 + 扁平=首档 + 平价模型无 tiers。

**前端**
- `api/pricing.ts` / `api/me-pricing.ts`:tier 类型。
- `composables/useTkPricingExport.ts`(+spec):**admin-only Export CSV**——纯前端从已拉取目录生成销售友好 CSV(每 1M token、阶梯渲染成单列、媒体按张/秒、UTF-8 BOM)。
- `views/PricingView.vue`:`/pricing` 页 admin-only 导出按钮(`v-if isAdmin`);公开页与 Your-Menu **共用同一表格**渲染 `阶梯 ×N` 徽章 + 悬浮完整阶梯。
- i18n en/zh:`pricing.export.*`、`pricing.tieredBadge`。

## 最小侵入(§5)

后端全在 `*_tk_*.go`;前端全为纯插入或 `useTk*` composable + 薄 view 接线。无 upstream 符号删除。

## 验证

- `go build ./...`、service 单测(Pricing/Catalog/Overlay/MePricing)、`golangci-lint` 0 issues
- `pnpm typecheck` / `lint:check`、vitest(PricingView 7 + 导出 composable 6)
- `pnpm build` 重建嵌入 dist、`scripts/preflight.sh` PASS

## 门禁说明

`sentinel-registry-reviewed`:新增的 `useTkPricingExport.ts` 与 `PricingView.vue` 改动均为只读展示/客户端导出,非反删除关键面,已 review 确认无需新增 sentinel 锚点。

合并方式:**Squash and merge**(TK feature)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)