### PR TITLE
feat(kiro): 迁移数据面+控制面到 *.kiro.dev(legacy fallback,edge-first)

### DIFF
--- a/backend/internal/integration/kiro/client.go
+++ b/backend/internal/integration/kiro/client.go
@@ -65,9 +65,25 @@ type kiroEndpoint struct {
 // gateways have begun migrating (e.g. 9router -> runtime.us-east-1.kiro.dev, with
 // auto-resolved profileArn to avoid IDC-login 403 — a case TK's ResolveProfileArn
 // already covers). No firm cutoff date is published, so this stays a scheduled
-// migration, not an emergency — but it is a committed upstream deprecation, not a
-// guess: plan the host flip rather than waiting for the legacy hosts to go dark.
+// migration, not an emergency — but it is a committed upstream deprecation.
+//
+// MIGRATION (this list, rolled out edge-first): the runtime.us-east-1.kiro.dev
+// endpoint is now PREFERRED (index 0, selected by the "auto"/"runtime" preference),
+// with the legacy q/codewhisperer hosts RETAINED below as automatic fallback — the
+// request loop falls through to them on any failure, so a runtime hiccup self-heals
+// to legacy with no behavior regression. The control plane is migrated alongside
+// it in rest.go (kiroRestFetch, management.us-east-1.kiro.dev first, codewhisperer
+// fallback) for the calls edge-us6 smoke-validated equivalent on management —
+// ListAvailableProfiles, ListAvailableModels, getUsageLimits. GetUserInfo stays on
+// codewhisperer: management returns UnknownOperationException for it.
 var kiroEndpoints = []kiroEndpoint{
+	{
+		// Kiro Runtime — the go-forward *.kiro.dev data-plane host (preferred).
+		URL:       "https://runtime.us-east-1.kiro.dev/generateAssistantResponse",
+		Origin:    "AI_EDITOR",
+		AmzTarget: "AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
+		Name:      "Kiro Runtime",
+	},
 	{
 		URL:       "https://q.us-east-1.amazonaws.com/generateAssistantResponse",
 		Origin:    "AI_EDITOR",
@@ -300,15 +316,17 @@ func getSortedEndpoints(preferred string) []kiroEndpoint {
 
 	var primary int
 	switch preferred {
-	case "kiro":
+	case "runtime":
 		primary = 0
-	case "codewhisperer":
+	case "kiro":
 		primary = 1
-	case "amazonq":
+	case "codewhisperer":
 		primary = 2
+	case "amazonq":
+		primary = 3
 	default:
-		// "auto": Kiro first, then fallback to others
-		return []kiroEndpoint{kiroEndpoints[0], kiroEndpoints[1], kiroEndpoints[2]}
+		// "auto": runtime.kiro.dev first, then legacy hosts as fallback.
+		return []kiroEndpoint{kiroEndpoints[0], kiroEndpoints[1], kiroEndpoints[2], kiroEndpoints[3]}
 	}
 
 	if !fallback {

--- a/backend/internal/integration/kiro/client.go
+++ b/backend/internal/integration/kiro/client.go
@@ -75,7 +75,8 @@ type kiroEndpoint struct {
 // it in rest.go (kiroRestFetch, management.us-east-1.kiro.dev first, codewhisperer
 // fallback) for the calls edge-us6 smoke-validated equivalent on management —
 // ListAvailableProfiles, ListAvailableModels, getUsageLimits. GetUserInfo stays on
-// codewhisperer: management returns UnknownOperationException for it.
+// codewhisperer: the new protocol has no standalone user-info op (identity is folded
+// into getUsageLimits.userInfo, which TK already reads) and TK has no caller for it.
 var kiroEndpoints = []kiroEndpoint{
 	{
 		// Kiro Runtime — the go-forward *.kiro.dev data-plane host (preferred).

--- a/backend/internal/integration/kiro/client.go
+++ b/backend/internal/integration/kiro/client.go
@@ -462,9 +462,18 @@ func CallKiroAPIWithDoer(doer HTTPDoer, account *Account, payload *KiroPayload, 
 			errBody, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			lastErr = fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, ep.Name, string(errBody))
-			// Authentication errors and payment errors are not retried across endpoints.
+			// Auth/payment errors normally aren't retried across endpoints (the same
+			// token would be rejected everywhere). EXCEPTION: runtime.kiro.dev is a
+			// different gateway/entitlement domain than the legacy amazonaws hosts, so
+			// a 401/403/402 there does NOT imply legacy will reject the same token —
+			// it must still fall through to legacy (the migration's self-heal). Only
+			// a legacy-host auth/payment error short-circuits.
 			if resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 402 {
-				return lastErr
+				if !strings.Contains(ep.URL, ".kiro.dev") {
+					return lastErr
+				}
+				logWarnf("[KiroAPI] Endpoint %s auth/payment error %d; falling through to legacy: %v", ep.Name, resp.StatusCode, lastErr)
+				continue
 			}
 			logWarnf("[KiroAPI] Endpoint %s error: %v", ep.Name, lastErr)
 			continue

--- a/backend/internal/integration/kiro/client_endpoints_test.go
+++ b/backend/internal/integration/kiro/client_endpoints_test.go
@@ -1,0 +1,62 @@
+package kiro
+
+import (
+	"strings"
+	"testing"
+)
+
+// runtime.us-east-1.kiro.dev is the go-forward data-plane host and must be the
+// preferred (first) endpoint, with the legacy q/codewhisperer hosts retained as
+// automatic fallback. Guards the edge-first migration against an accidental
+// re-ordering that would silently route serving traffic back to the deprecated
+// amazonaws hosts.
+func TestKiroEndpoints_RuntimeIsPreferredWithLegacyFallback(t *testing.T) {
+	if len(kiroEndpoints) != 4 {
+		t.Fatalf("expected 4 endpoints (runtime + 3 legacy), got %d", len(kiroEndpoints))
+	}
+	if got := kiroEndpoints[0].URL; got != "https://runtime.us-east-1.kiro.dev/generateAssistantResponse" {
+		t.Fatalf("endpoint[0] must be the runtime.kiro.dev host, got %q", got)
+	}
+	if kiroEndpoints[0].AmzTarget != "AmazonCodeWhispererStreamingService.GenerateAssistantResponse" {
+		t.Fatalf("runtime endpoint must carry the CodeWhisperer streaming X-Amz-Target, got %q", kiroEndpoints[0].AmzTarget)
+	}
+
+	// "auto" (the default selector) → runtime first, then all legacy hosts as fallback.
+	auto := getSortedEndpoints("auto")
+	if len(auto) != 4 {
+		t.Fatalf("auto must keep the full fallback chain, got %d", len(auto))
+	}
+	if !strings.Contains(auto[0].URL, "runtime.us-east-1.kiro.dev") {
+		t.Fatalf("auto[0] must be runtime.kiro.dev, got %q", auto[0].URL)
+	}
+	// Legacy hosts remain reachable as fallback so a runtime failure self-heals.
+	var hasQ, hasCW bool
+	for _, ep := range auto[1:] {
+		if strings.Contains(ep.URL, "q.us-east-1.amazonaws.com") {
+			hasQ = true
+		}
+		if strings.Contains(ep.URL, "codewhisperer.us-east-1.amazonaws.com") {
+			hasCW = true
+		}
+	}
+	if !hasQ || !hasCW {
+		t.Fatalf("legacy q + codewhisperer must remain as fallback (q=%v cw=%v)", hasQ, hasCW)
+	}
+}
+
+func TestGetSortedEndpoints_PreferenceMapping(t *testing.T) {
+	cases := map[string]string{
+		"runtime":       "runtime.us-east-1.kiro.dev",
+		"kiro":          "q.us-east-1.amazonaws.com",
+		"codewhisperer": "codewhisperer.us-east-1.amazonaws.com",
+	}
+	for pref, wantHost := range cases {
+		eps := getSortedEndpoints(pref)
+		if len(eps) == 0 {
+			t.Fatalf("preference %q returned no endpoints", pref)
+		}
+		if !strings.Contains(eps[0].URL, wantHost) {
+			t.Fatalf("preference %q: want primary host %q, got %q", pref, wantHost, eps[0].URL)
+		}
+	}
+}

--- a/backend/internal/integration/kiro/client_fallback_test.go
+++ b/backend/internal/integration/kiro/client_fallback_test.go
@@ -1,0 +1,87 @@
+package kiro
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// recordingDoer returns 403 for the runtime.kiro.dev gateway and 200 (empty event
+// stream) for any legacy amazonaws host, recording every host it is asked to hit.
+type recordingDoer struct{ seen []string }
+
+func (d *recordingDoer) Do(req *http.Request) (*http.Response, error) {
+	d.seen = append(d.seen, req.URL.Host)
+	if strings.Contains(req.URL.Host, "kiro.dev") {
+		return &http.Response{
+			StatusCode: 403,
+			Body:       io.NopCloser(strings.NewReader(`{"__type":"AccessDeniedException"}`)),
+			Header:     http.Header{},
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     http.Header{},
+	}, nil
+}
+
+// A 403 from the runtime.kiro.dev gateway must NOT fail the request — it must fall
+// through to the legacy amazonaws hosts (the migration's self-heal guarantee). This
+// is the regression test for the auth-error short-circuit that, before the fix,
+// returned immediately and would have surfaced a runtime-only 403 to the customer.
+func TestCallKiroAPI_Runtime403FallsThroughToLegacy(t *testing.T) {
+	doer := &recordingDoer{}
+	account := &Account{AccessToken: "tok", ProfileArn: "arn:aws:codewhisperer:us-east-1:1:profile/x"}
+	if err := CallKiroAPIWithDoer(doer, account, &KiroPayload{}, nil); err != nil {
+		t.Fatalf("runtime 403 should fall through to a legacy 200, got error: %v", err)
+	}
+	if len(doer.seen) < 2 {
+		t.Fatalf("expected fall-through to legacy, doer only saw: %v", doer.seen)
+	}
+	if !strings.Contains(doer.seen[0], "kiro.dev") {
+		t.Fatalf("runtime.kiro.dev must be tried first, saw: %v", doer.seen)
+	}
+	var hitLegacy bool
+	for _, h := range doer.seen[1:] {
+		if strings.Contains(h, "amazonaws.com") {
+			hitLegacy = true
+		}
+	}
+	if !hitLegacy {
+		t.Fatalf("a runtime 403 must fall through to a legacy amazonaws host, saw: %v", doer.seen)
+	}
+}
+
+// A 403 from a legacy amazonaws host still short-circuits (same token would be
+// rejected on the sibling amazonaws hosts) — i.e. the fall-through is scoped to the
+// cross-gateway runtime.kiro.dev case, not a blanket retry of auth errors.
+func TestCallKiroAPI_LegacyAuthErrorStillShortCircuits(t *testing.T) {
+	doer := &legacy403Doer{}
+	account := &Account{AccessToken: "tok", ProfileArn: "arn:aws:codewhisperer:us-east-1:1:profile/x"}
+	err := CallKiroAPIWithDoer(doer, account, &KiroPayload{}, nil)
+	if err == nil {
+		t.Fatal("a legacy-host 403 should short-circuit and return an error")
+	}
+	// runtime (kiro.dev) tried first then exactly one legacy host before returning.
+	if len(doer.seen) != 2 {
+		t.Fatalf("expected runtime + one legacy host then short-circuit, saw: %v", doer.seen)
+	}
+}
+
+type legacy403Doer struct{ seen []string }
+
+func (d *legacy403Doer) Do(req *http.Request) (*http.Response, error) {
+	d.seen = append(d.seen, req.URL.Host)
+	// runtime falls through; the first legacy host 403s and must short-circuit.
+	code := 200
+	if strings.Contains(req.URL.Host, "kiro.dev") || strings.Contains(req.URL.Host, "amazonaws.com") {
+		code = 403
+	}
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader(`{"__type":"AccessDeniedException"}`)),
+		Header:     http.Header{},
+	}, nil
+}

--- a/backend/internal/integration/kiro/rest.go
+++ b/backend/internal/integration/kiro/rest.go
@@ -12,39 +12,82 @@ import (
 
 const (
 	kiroRestAPIBase = "https://codewhisperer.us-east-1.amazonaws.com"
+	// kiroManagementAPIBase is the go-forward *.kiro.dev control-plane host
+	// (configuration / lifecycle / access management). It replaces the legacy
+	// codewhisperer.* base, which Kiro's docs no longer list at all. Used (via
+	// kiroRestFetch, management-first with codewhisperer fallback) by the calls
+	// edge-us6 smoke-validated equivalent on management: ListAvailableProfiles
+	// (same profileArn), ListAvailableModels (same model set), getUsageLimits (all
+	// fields UsageLimitsResponse reads). GetUserInfo stays on codewhisperer —
+	// management returns UnknownOperationException for it.
+	kiroManagementAPIBase = "https://management.us-east-1.kiro.dev"
 )
+
+// kiroRestBases lists the control-plane hosts in preference order: the go-forward
+// management.us-east-1.kiro.dev first, the legacy codewhisperer.* as fallback.
+func kiroRestBases() []string { return []string{kiroManagementAPIBase, kiroRestAPIBase} }
+
+// kiroRestFetch issues method+path against each control-plane base in turn
+// (profileArn appended when withParn), returning the first HTTP-200 body. Used by
+// the calls edge-us6 smoke-validated equivalent on management — ListAvailableProfiles
+// (same profileArn), ListAvailableModels (same model set), getUsageLimits (every
+// field UsageLimitsResponse reads is present). GetUserInfo is deliberately NOT routed
+// here: management returns UnknownOperationException (HTTP 400) for it, so it stays on
+// the legacy host until the management operation name is identified.
+func kiroRestFetch(account *Account, method, path, body string, withParn bool) ([]byte, error) {
+	var lastErr error
+	for _, base := range kiroRestBases() {
+		u := base + path
+		if withParn {
+			u = withProfileArnQuery(u, account)
+		}
+		var rdr io.Reader
+		if body != "" {
+			rdr = strings.NewReader(body)
+		}
+		req, err := http.NewRequest(method, u, rdr)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		setKiroHeaders(req, account)
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, err := GetRestClientForProxy(ResolveAccountProxyURL(account)).Do(req)
+		if err != nil {
+			lastErr = err
+			logWarnf("[KiroREST] %s %s failed: %v", method, base, err)
+			continue
+		}
+		data, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != 200 {
+			lastErr = fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, base, string(data))
+			logWarnf("[KiroREST] %s %s -> HTTP %d", method, base, resp.StatusCode)
+			continue
+		}
+		return data, nil
+	}
+	return nil, lastErr
+}
 
 // GetUsageLimits 获取账户使用量和订阅信息
 func GetUsageLimits(account *Account) (*UsageLimitsResponse, error) {
-	url := fmt.Sprintf("%s/getUsageLimits?origin=AI_EDITOR&resourceType=AGENTIC_REQUEST&isEmailRequired=true", kiroRestAPIBase)
-	url = withProfileArnQuery(url, account)
-
-	req, err := http.NewRequest("GET", url, nil)
+	data, err := kiroRestFetch(account, "GET", "/getUsageLimits?origin=AI_EDITOR&resourceType=AGENTIC_REQUEST&isEmailRequired=true", "", true)
 	if err != nil {
 		return nil, err
 	}
-
-	setKiroHeaders(req, account)
-
-	resp, err := GetRestClientForProxy(ResolveAccountProxyURL(account)).Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
-	}
-
 	var result UsageLimitsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(data, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
 }
 
-// GetUserInfo 获取用户信息
+// GetUserInfo 获取用户信息. Stays on the legacy codewhisperer.* host: management.kiro.dev
+// returns UnknownOperationException (HTTP 400) for GetUserInfo (edge-us6 probe, 2026-06-26),
+// so it is NOT routed through kiroRestFetch until the management equivalent is identified.
 func GetUserInfo(account *Account) (*UserInfoResponse, error) {
 	url := fmt.Sprintf("%s/GetUserInfo", kiroRestAPIBase)
 
@@ -77,31 +120,14 @@ func GetUserInfo(account *Account) (*UserInfoResponse, error) {
 
 // ListAvailableModels 获取可用模型列表
 func ListAvailableModels(account *Account) ([]ModelInfo, error) {
-	url := fmt.Sprintf("%s/ListAvailableModels?origin=AI_EDITOR&maxResults=50", kiroRestAPIBase)
-	url = withProfileArnQuery(url, account)
-
-	req, err := http.NewRequest("GET", url, nil)
+	data, err := kiroRestFetch(account, "GET", "/ListAvailableModels?origin=AI_EDITOR&maxResults=50", "", true)
 	if err != nil {
 		return nil, err
 	}
-
-	setKiroHeaders(req, account)
-
-	resp, err := GetRestClientForProxy(ResolveAccountProxyURL(account)).Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
-	}
-
 	var result struct {
 		Models []ModelInfo `json:"models"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(data, &result); err != nil {
 		return nil, err
 	}
 	return result.Models, nil
@@ -184,30 +210,16 @@ func isTransientProfileFetchError(err error) bool {
 }
 
 func listAvailableProfiles(account *Account) (string, error) {
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/ListAvailableProfiles", kiroRestAPIBase), strings.NewReader(`{"maxResults":10}`))
+	data, err := kiroRestFetch(account, "POST", "/ListAvailableProfiles", `{"maxResults":10}`, false)
 	if err != nil {
 		return "", err
 	}
-	setKiroHeaders(req, account)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := GetRestClientForProxy(ResolveAccountProxyURL(account)).Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
-	}
-
 	var result struct {
 		Profiles []struct {
 			Arn string `json:"arn"`
 		} `json:"profiles"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(data, &result); err != nil {
 		return "", err
 	}
 	for _, profile := range result.Profiles {

--- a/backend/internal/integration/kiro/rest.go
+++ b/backend/internal/integration/kiro/rest.go
@@ -18,8 +18,9 @@ const (
 	// kiroRestFetch, management-first with codewhisperer fallback) by the calls
 	// edge-us6 smoke-validated equivalent on management: ListAvailableProfiles
 	// (same profileArn), ListAvailableModels (same model set), getUsageLimits (all
-	// fields UsageLimitsResponse reads). GetUserInfo stays on codewhisperer —
-	// management returns UnknownOperationException for it.
+	// fields UsageLimitsResponse reads). GetUserInfo stays on codewhisperer: the new
+	// protocol has no standalone user-info op — identity is folded into getUsageLimits
+	// (userInfo{email,userId}); and kiro.GetUserInfo has no TK caller anyway.
 	kiroManagementAPIBase = "https://management.us-east-1.kiro.dev"
 )
 
@@ -31,9 +32,11 @@ func kiroRestBases() []string { return []string{kiroManagementAPIBase, kiroRestA
 // (profileArn appended when withParn), returning the first HTTP-200 body. Used by
 // the calls edge-us6 smoke-validated equivalent on management — ListAvailableProfiles
 // (same profileArn), ListAvailableModels (same model set), getUsageLimits (every
-// field UsageLimitsResponse reads is present). GetUserInfo is deliberately NOT routed
-// here: management returns UnknownOperationException (HTTP 400) for it, so it stays on
-// the legacy host until the management operation name is identified.
+// field UsageLimitsResponse reads is present). GetUserInfo is NOT routed here: the
+// new *.kiro.dev protocol has no standalone user-info operation (management 400s
+// every GetUserInfo/getUserInfo/GetUser variant, edge-us6-probed); user identity is
+// instead folded into getUsageLimits (userInfo{email,userId} + subscriptionInfo),
+// which TK already parses. kiro.GetUserInfo has no caller in TK anyway.
 func kiroRestFetch(account *Account, method, path, body string, withParn bool) ([]byte, error) {
 	var lastErr error
 	for _, base := range kiroRestBases() {
@@ -85,9 +88,12 @@ func GetUsageLimits(account *Account) (*UsageLimitsResponse, error) {
 	return &result, nil
 }
 
-// GetUserInfo 获取用户信息. Stays on the legacy codewhisperer.* host: management.kiro.dev
-// returns UnknownOperationException (HTTP 400) for GetUserInfo (edge-us6 probe, 2026-06-26),
-// so it is NOT routed through kiroRestFetch until the management equivalent is identified.
+// GetUserInfo 获取用户信息. Legacy codewhisperer.* only — the new *.kiro.dev protocol
+// has NO standalone user-info operation (management 400s every variant; edge-us6 probe
+// 2026-06-26). On the new protocol user identity is returned inside getUsageLimits
+// (userInfo{email,userId} + subscriptionInfo), already parsed via the migrated
+// GetUsageLimits. This function additionally has no caller in TK, so it needs no
+// migration; kept as vendored API surface.
 func GetUserInfo(account *Account) (*UserInfoResponse, error) {
 	url := fmt.Sprintf("%s/GetUserInfo", kiroRestAPIBase)
 

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -109,9 +109,19 @@
       "must_contain": [
         "func CallKiroAPIWithDoer",
         "func parseEventStream",
-        "HTTPDoer"
+        "HTTPDoer",
+        "runtime.us-east-1.kiro.dev"
       ],
-      "rationale": "Streaming call entry + hand-rolled AWS EventStream binary decoder + the HTTPDoer injection seam that lets the TK gateway supply a TLS/proxy-aware doer. Losing parseEventStream breaks all streaming responses; losing the HTTPDoer seam breaks fingerprint/proxy egress."
+      "rationale": "Streaming call entry + hand-rolled AWS EventStream binary decoder + the HTTPDoer injection seam that lets the TK gateway supply a TLS/proxy-aware doer. Losing parseEventStream breaks all streaming responses; losing the HTTPDoer seam breaks fingerprint/proxy egress. The runtime.us-east-1.kiro.dev anchor pins the go-forward *.kiro.dev data-plane host as the preferred endpoint (edge-first migration); an upstream merge that drops it would silently route serving traffic back to the deprecated amazonaws hosts."
+    },
+    {
+      "path": "backend/internal/integration/kiro/rest.go",
+      "must_contain": [
+        "kiroManagementAPIBase",
+        "management.us-east-1.kiro.dev",
+        "func kiroRestFetch"
+      ],
+      "rationale": "Control-plane calls (ListAvailableProfiles / ListAvailableModels / getUsageLimits) routed through management.us-east-1.kiro.dev first with a codewhisperer.* fallback via kiroRestFetch (edge-us6 smoke-validated equivalent). A missing profileArn is the classic Kiro IDC-login 403 cause, so losing the management base or its fallback silently reintroduces 403s once codewhisperer.* is deprecated."
     },
     {
       "path": "backend/internal/service/account_tk_kiro.go",


### PR DESCRIPTION
## 核心变更

把 Kiro 上游从 legacy `*.amazonaws.com` 迁到 go-forward `*.kiro.dev` 网关,**edge-first**,legacy 全程保留为自动 fallback。范围**严格等于** edge-us6 真账号 `kiro-us6-real` 逐条实测验证过的,无一盲迁。

- **数据面**:`runtime.us-east-1.kiro.dev/generateAssistantResponse` 设为**首选**(`kiroEndpoints[0]` / "auto"),legacy `q`/`codewhisperer`/`amazonq` 仍在链中。请求循环失败即下沉。
- **控制面**(`rest.go` `kiroRestFetch` — management 优先、codewhisperer fallback):`ListAvailableProfiles`(相同 profileArn)、`ListAvailableModels`(相同 14 模型)、`getUsageLimits`(`UsageLimitsResponse` 读的字段全等价)。
- **`GetUserInfo` 留 legacy**:新协议无独立 user-info op(management 对所有变体返 `UnknownOperationException`);身份折叠进 `getUsageLimits.userInfo{email,userId}`,TK 已解析;且 `kiro.GetUserInfo` 在 TK 无调用方。
- **R-001(自审修复)**:auth/payment 短路只限 legacy host —— `runtime.kiro.dev` 的 401/403/402 会**下沉到 legacy**(否则新网关 entitlement/profileArn 的 403 会被直接抛给客户、不回退)。

## 对线上 TokenKey 服务的影响

> Kiro 是 **edge-served** 平台(OAuth 账号在各 edge,prod 不直接服务 kiro)。故本 PR 影响的是 **edge 侧 kiro serving**,部署粒度天然 edge-by-edge。

### 正面
1. **跟上 AWS/Kiro 官方弃用方向(主要价值)**:官方已声明 `q.*.amazonaws.com` legacy/will-be-deprecated、`codewhisperer.*` 文档已下架。本 PR 让 TK 提前站到 `*.kiro.dev`,AWS 真停 legacy 时**不掉线**(否则就是一次紧急逆向 + outage)。
2. **指纹/mimicry 更贴真机**:真实 Kiro IDE 现在就走 `runtime.kiro.dev`;TK 转发到同一 host 比继续打真机已弃用的 amazonaws host 更不易被上游判为异常流量。
3. **控制面更稳**:profileArn 经 `management.kiro.dev` 解析(+ codewhisperer fallback),为 `codewhisperer.*`(已无文档)被切做了准备。

### 负面 / 风险
1. **这是 live 路由改动**(非零行为):每个 edge kiro 请求的首跳上游 host 改变。
2. **fallback 只兜硬失败,兜不住"200 但内容退化"**:runtime 返 4xx/5xx/连接失败 → 自动落 legacy(已修 R-001、已测);但若 runtime 返 **200 却行为有差异**(tool-use / 多轮 / 个别模型 / 流式细节),fallback 不触发。实测只覆盖 minimal ping,非穷举 —— **这是最大残余风险,靠 edge-us6 观察兜底**。
3. **fallback 会掩盖 runtime 故障**:若 runtime 静默全挂,流量会悄悄全落 legacy、表面无感 —— 需主动观测"是否真经 runtime 服务",否则迁移等于没生效却以为生效。
4. **首跳延迟**:多一次到 `runtime.kiro.dev` 的 DNS/连接;runtime 慢或抖动时首跳延迟上升(硬失败由 fallback 覆盖)。影响小。
5. **控制面账号信息漂移**:`getUsageLimits`/`ListAvailableModels` 改走 management,若 management 返回与 legacy 有细微差异会影响用量/订阅展示(非 serving 关键;`getUsageLimits` 已验证 TK 读的字段等价)。

### 净评估
- **直接 serving 风险:低-中,且已多重缓释** —— legacy 全链 fallback + R-001 修复 + edge-first 灰度 + 一条 `git revert` 可彻底回退。
- **战略价值:高** —— 对冲官方已宣布的弃用 + 指纹对齐。
- 残余风险集中在"runtime 200 内容退化"这一 fallback 盲区,由 edge-us6 灰度观察拦截。

## 灰度 / rollout(部署侧,非本 PR 代码)
合并 + 发版后**只部署 edge-us6**(已验证那台),观察一个窗口:`scan-edge-health.sh` 的 `served_200 : no_available_429`、`ops_error_logs` 的 kiro 403/5xx、**访问日志确认流量确实命中 `runtime.kiro.dev`**(防"全落 legacy 假成功")。无新增 403/5xx 且确经 runtime 服务后,再扩其它 edge。出问题 fallback 自愈到 legacy,不掉线。

## 验证
- `go build ./...`、kiro + service 单测、**full preflight + kiro sentinels** 全绿。
- 单测:`client_endpoints_test.go`(runtime 首选 + fallback 链 + 偏好映射)、`client_fallback_test.go`(runtime 403→落 legacy 200;legacy 403→仍短路)。
- `scripts/sentinels/kiro.json` 加锚点(`runtime.kiro.dev` / `kiroRestFetch` + management base),防上游 merge 静默改回旧 host。

## no-web-impact
后端 Kiro 上游路由改动;无前端 / API 契约变更。
