### PR TITLE
chore(stage0): 剩余 edge rollout 默认 --parallel 1（中转池爆炸半径）

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -20,7 +20,7 @@ description: >-
 | 读取 deployable edge 矩阵 | 机械 | `python3 deploy/aws/stage0/resolve-edge-target.py --list-deployable` |
 | Edge dispatch 路由（edges 均为 Lightsail） | 机械 | `scripts/stage0/resolve-edge-deploy-route.py --edge-id <id> --json` |
 | Edge upgrade/smoke/rollback dispatch | 机械 | `bash scripts/stage0/dispatch-edge-deploy.sh --edge-id … --operation …` |
-| **其余 Edge rollout（bounded parallel fail-stop + smoke 标记验收）** | 机械 | `bash scripts/stage0/rollout-edges.sh --tag X.Y.Z --skip <canary>`（**默认且推荐 `--parallel 1` 顺序**；并发换容器会同窗口缩小 prod 的 anthropic/kiro failover 池——`--parallel N>1` 仅在 edges 已蓝绿/非中转 fleet 时作显式加速，见 §7 注） |
+| **其余 Edge rollout（bounded parallel fail-stop + smoke 标记验收）** | 机械 | `bash scripts/stage0/rollout-edges.sh --tag X.Y.Z --skip <canary>`（**默认 `--parallel 1` 顺序**，降低并发换容器对线上的影响；`N>1` 仅在可接受该影响时用） |
 | dispatch release.yml / deploy-stage0.yml + watch | 机械 | `gh workflow run` + `gh run watch --exit-status` |
 | prod 镜像预热（deploy 前，把 ~150s pull 移出关键路径） | 机械 | `gh workflow run warm-image-stage0.yml` + 自批 + watch（只读、非致命；命令形状见 §「部署目标矩阵 → prod」） |
 | prod Environment approval（canary 绿后） | 机械 | `gh api -X POST …/pending_deployments`（命令形状见 §「部署目标矩阵 → prod」；批不批、何时批是判断） |
@@ -249,7 +249,7 @@ python3 scripts/stage0/resolve-edge-deploy-route.py --edge-id "$EDGE_ID" --json
    # 每个 edge 输出 rollout-edges: edge=<id> run_id=<id> result=ok；全过输出 ALL_OK n=<k>
    ```
 
-   脚本按 batch dispatch upgrade → watch（自动重连抖动的 `gh run watch`）→ 验 `tk_edge_post_deploy_smoke: OK phase=infra`。**默认 `--parallel 1`（顺序），中转型 edge 保持顺序**：prod 的 `cc-/kiro-<edge>` 镜像账号把 anthropic/kiro 流量中转到各 edge，而 edge 是**原地换容器**（`deploy_via_ssm.sh`，有短暂 `/health=503` 窗口，非 prod 的蓝绿 `deploy_via_ssm_bluegreen.sh`），并发重启 N 个 edge 会在同一 ~80s 窗口从 prod failover 池摘掉 N 个目标（v1.8.48 实测：`--parallel 3` 升 us4/us5/us6 时只剩 canary 健康，并发切换瞬时出现一小簇 anthropic/kiro 502）。`--parallel N>1` 是显式的速度/爆炸半径取舍，**只有在 edges 已蓝绿或非中转型 fleet 时才用**。批内已 dispatch 的 edge 会全部验收；任一失败后不再启动下一批（未 dispatch 的 edge 留在旧 tag）。**不再**对每个 edge 跑 main-via-edge。
+   脚本按 batch dispatch upgrade → watch（自动重连抖动的 `gh run watch`）→ 验 `tk_edge_post_deploy_smoke: OK phase=infra`。**默认 `--parallel 1`（顺序）**，降低并发换容器对线上的影响（并发重启多个 edge 会缩小 prod 中转 failover 池、在换容器窗口冒 502）；`N>1` 仅在可接受该影响时用。批内已 dispatch 的 edge 会全部验收；任一失败后不再启动下一批（未 dispatch 的 edge 留在旧 tag）。**不再**对每个 edge 跑 main-via-edge。
    - **main-via-edge canary** 仍通常仅 **uk1 / us1**（需 `TK_SMOKE_API_KEY`）。
    - **us2 / us3 / us4** 等 Lightsail-only edge：rollout 以 infra smoke + 可选 `curl https://api-<id>.tokenkey.dev/health` 为准；勿因缺 canary secret 判失败。
 8. **发版后跟进（按 diff 档位，至多一次 tick）**：跑 `release-impact-files.sh` 读 `.followup.tier`：
@@ -640,7 +640,7 @@ bash scripts/release-rollout-summary.sh --mode release
 - `scripts/release-decide-version.sh` — VERSION/tag 三态决策。
 - `scripts/release-tag.sh` — tag 门禁。
 - `.github/workflows/release.yml` — multi-arch image build 与 prod auto-dispatch。
-- `scripts/stage0/rollout-edges.sh` — 其余 Edge bounded-parallel rollout（fail-stop + smoke 标记验收；**默认且推荐 `--parallel 1` 顺序**；`N>1` 仅在 edges 已蓝绿/非中转 fleet 时作显式加速——并发换容器会缩小 prod 的 anthropic/kiro failover 池）。
+- `scripts/stage0/rollout-edges.sh` — 其余 Edge bounded-parallel rollout（fail-stop + smoke 标记验收；**默认 `--parallel 1` 顺序**，降低并发换容器对线上的影响；`N>1` 仅在可接受时用）。
 - `scripts/stage0/dispatch-edge-deploy.sh` — 单一 Edge deploy dispatch（edges 均为 Lightsail）。
 - `ops/observability/probe-release-control-plane.sh` — 发版后控制面探活（prod + deployable Edge，JSON lines + summary）。
 - `ops/observability/probe-post-release-tick.sh` — 发版后 tick 探针（blue/green active container auto + HOOK_PATTERNS 计数 + 流量/5xx/panic）。

--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -20,7 +20,7 @@ description: >-
 | 读取 deployable edge 矩阵 | 机械 | `python3 deploy/aws/stage0/resolve-edge-target.py --list-deployable` |
 | Edge dispatch 路由（edges 均为 Lightsail） | 机械 | `scripts/stage0/resolve-edge-deploy-route.py --edge-id <id> --json` |
 | Edge upgrade/smoke/rollback dispatch | 机械 | `bash scripts/stage0/dispatch-edge-deploy.sh --edge-id … --operation …` |
-| **其余 Edge rollout（bounded parallel fail-stop + smoke 标记验收）** | 机械 | `bash scripts/stage0/rollout-edges.sh --tag X.Y.Z --skip <canary> --parallel 3`（脚本默认 `--parallel 1`；`target=all` 在 prod/canary 都绿后用 3 加速） |
+| **其余 Edge rollout（bounded parallel fail-stop + smoke 标记验收）** | 机械 | `bash scripts/stage0/rollout-edges.sh --tag X.Y.Z --skip <canary>`（**默认且推荐 `--parallel 1` 顺序**；并发换容器会同窗口缩小 prod 的 anthropic/kiro failover 池——`--parallel N>1` 仅在 edges 已蓝绿/非中转 fleet 时作显式加速，见 §7 注） |
 | dispatch release.yml / deploy-stage0.yml + watch | 机械 | `gh workflow run` + `gh run watch --exit-status` |
 | prod 镜像预热（deploy 前，把 ~150s pull 移出关键路径） | 机械 | `gh workflow run warm-image-stage0.yml` + 自批 + watch（只读、非致命；命令形状见 §「部署目标矩阵 → prod」） |
 | prod Environment approval（canary 绿后） | 机械 | `gh api -X POST …/pending_deployments`（命令形状见 §「部署目标矩阵 → prod」；批不批、何时批是判断） |
@@ -245,11 +245,11 @@ python3 scripts/stage0/resolve-edge-deploy-route.py --edge-id "$EDGE_ID" --json
 7. **其余 deployable Edge（单命令，bounded-parallel fail-stop）**：
 
    ```bash
-   bash scripts/stage0/rollout-edges.sh --tag "$TARGET_TAG" --skip <canary_edge> --parallel 3
+   bash scripts/stage0/rollout-edges.sh --tag "$TARGET_TAG" --skip <canary_edge>   # 默认 --parallel 1（顺序）
    # 每个 edge 输出 rollout-edges: edge=<id> run_id=<id> result=ok；全过输出 ALL_OK n=<k>
    ```
 
-   脚本按 batch dispatch upgrade → watch（自动重连抖动的 `gh run watch`）→ 验 `tk_edge_post_deploy_smoke: OK phase=infra`。`--parallel 3` 只用于 prod/canary 都绿后的剩余 Edge infra 阶段：批内已 dispatch 的 edge 会全部验收；任一失败后不再启动下一批（未 dispatch 的 edge 留在旧 tag）。**不再**对每个 edge 跑 main-via-edge。
+   脚本按 batch dispatch upgrade → watch（自动重连抖动的 `gh run watch`）→ 验 `tk_edge_post_deploy_smoke: OK phase=infra`。**默认 `--parallel 1`（顺序），中转型 edge 保持顺序**：prod 的 `cc-/kiro-<edge>` 镜像账号把 anthropic/kiro 流量中转到各 edge，而 edge 是**原地换容器**（`deploy_via_ssm.sh`，有短暂 `/health=503` 窗口，非 prod 的蓝绿 `deploy_via_ssm_bluegreen.sh`），并发重启 N 个 edge 会在同一 ~80s 窗口从 prod failover 池摘掉 N 个目标（v1.8.48 实测：`--parallel 3` 升 us4/us5/us6 时只剩 canary 健康，并发切换瞬时出现一小簇 anthropic/kiro 502）。`--parallel N>1` 是显式的速度/爆炸半径取舍，**只有在 edges 已蓝绿或非中转型 fleet 时才用**。批内已 dispatch 的 edge 会全部验收；任一失败后不再启动下一批（未 dispatch 的 edge 留在旧 tag）。**不再**对每个 edge 跑 main-via-edge。
    - **main-via-edge canary** 仍通常仅 **uk1 / us1**（需 `TK_SMOKE_API_KEY`）。
    - **us2 / us3 / us4** 等 Lightsail-only edge：rollout 以 infra smoke + 可选 `curl https://api-<id>.tokenkey.dev/health` 为准；勿因缺 canary secret 判失败。
 8. **发版后跟进（按 diff 档位，至多一次 tick）**：跑 `release-impact-files.sh` 读 `.followup.tier`：
@@ -640,7 +640,7 @@ bash scripts/release-rollout-summary.sh --mode release
 - `scripts/release-decide-version.sh` — VERSION/tag 三态决策。
 - `scripts/release-tag.sh` — tag 门禁。
 - `.github/workflows/release.yml` — multi-arch image build 与 prod auto-dispatch。
-- `scripts/stage0/rollout-edges.sh` — 其余 Edge bounded-parallel rollout（fail-stop + smoke 标记验收；`target=all` 推荐 `--parallel 3`）。
+- `scripts/stage0/rollout-edges.sh` — 其余 Edge bounded-parallel rollout（fail-stop + smoke 标记验收；**默认且推荐 `--parallel 1` 顺序**；`N>1` 仅在 edges 已蓝绿/非中转 fleet 时作显式加速——并发换容器会缩小 prod 的 anthropic/kiro failover 池）。
 - `scripts/stage0/dispatch-edge-deploy.sh` — 单一 Edge deploy dispatch（edges 均为 Lightsail）。
 - `ops/observability/probe-release-control-plane.sh` — 发版后控制面探活（prod + deployable Edge，JSON lines + summary）。
 - `ops/observability/probe-post-release-tick.sh` — 发版后 tick 探针（blue/green active container auto + HOOK_PATTERNS 计数 + 流量/5xx/panic）。

--- a/scripts/stage0/rollout-edges.sh
+++ b/scripts/stage0/rollout-edges.sh
@@ -7,11 +7,23 @@
 # watch the run to completion, and verify the canonical acceptance marker
 # `tk_edge_post_deploy_smoke: OK phase=infra` in the run log.
 #
-# Default is sequential. --parallel N dispatches bounded batches after the
-# canary/prod gates have already passed, reducing all-rollout wall clock while
-# preserving fail-stop between batches. If any edge in a batch fails, the script
-# finishes verifying that already-dispatched batch, prints the failed edge(s),
-# and does not dispatch the next batch.
+# Default is sequential (--parallel 1) and SHOULD stay that way for the relay-
+# bearing edge fleet. WHY this default is load-bearing, not just conservative:
+# prod holds cc-/kiro-<edge> mirror accounts that relay anthropic/kiro traffic to
+# api-<edge>.tokenkey.dev, and edges swap containers IN-PLACE (deploy_via_ssm.sh,
+# brief /health=503 window) rather than blue/green like prod (deploy_via_ssm_
+# bluegreen.sh). Restarting N edges concurrently removes N relay targets from
+# prod's failover pool in the SAME ~80s swap window. Observed v1.8.48 (2026-06-26):
+# a --parallel 3 rollout of us4/us5/us6 left only the canary healthy and produced a
+# small anthropic/kiro 502 cluster at the concurrent-swap instant. So --parallel
+# N>1 is an explicit speed/blast-radius tradeoff, safe only once edges are
+# blue/green (or for non-relay-bearing fleets) — do not raise the default.
+#
+# --parallel N dispatches bounded batches after the canary/prod gates have already
+# passed, reducing all-rollout wall clock while preserving fail-stop between
+# batches. If any edge in a batch fails, the script finishes verifying that
+# already-dispatched batch, prints the failed edge(s), and does not dispatch the
+# next batch.
 #
 # Usage:
 #   bash scripts/stage0/rollout-edges.sh --tag 1.7.88 --skip uk1

--- a/scripts/stage0/rollout-edges.sh
+++ b/scripts/stage0/rollout-edges.sh
@@ -7,23 +7,15 @@
 # watch the run to completion, and verify the canonical acceptance marker
 # `tk_edge_post_deploy_smoke: OK phase=infra` in the run log.
 #
-# Default is sequential (--parallel 1) and SHOULD stay that way for the relay-
-# bearing edge fleet. WHY this default is load-bearing, not just conservative:
-# prod holds cc-/kiro-<edge> mirror accounts that relay anthropic/kiro traffic to
-# api-<edge>.tokenkey.dev, and edges swap containers IN-PLACE (deploy_via_ssm.sh,
-# brief /health=503 window) rather than blue/green like prod (deploy_via_ssm_
-# bluegreen.sh). Restarting N edges concurrently removes N relay targets from
-# prod's failover pool in the SAME ~80s swap window. Observed v1.8.48 (2026-06-26):
-# a --parallel 3 rollout of us4/us5/us6 left only the canary healthy and produced a
-# small anthropic/kiro 502 cluster at the concurrent-swap instant. So --parallel
-# N>1 is an explicit speed/blast-radius tradeoff, safe only once edges are
-# blue/green (or for non-relay-bearing fleets) — do not raise the default.
+# Default is sequential (--parallel 1) to reduce the online impact of edge
+# container swaps: restarting several edges at once shrinks prod's relay failover
+# pool and can surface 502s during the swap window. Raise --parallel only when
+# that impact is acceptable.
 #
 # --parallel N dispatches bounded batches after the canary/prod gates have already
-# passed, reducing all-rollout wall clock while preserving fail-stop between
-# batches. If any edge in a batch fails, the script finishes verifying that
-# already-dispatched batch, prints the failed edge(s), and does not dispatch the
-# next batch.
+# passed, preserving fail-stop between batches. If any edge in a batch fails, the
+# script finishes verifying that already-dispatched batch, prints the failed
+# edge(s), and does not dispatch the next batch.
 #
 # Usage:
 #   bash scripts/stage0/rollout-edges.sh --tag 1.7.88 --skip uk1


### PR DESCRIPTION
## 背景

v1.8.48 发版（2026-06-26）跟踪时发现:剩余 edge rollout 用 `--parallel 3` 升 us4/us5/us6,在并发换容器的 ~80s 窗口里出现了一小簇 anthropic/kiro 502。复盘后确认这是**结构性的爆炸半径放大**,不是偶发。

## 根因

- prod 的 `cc-/kiro-<edge>` 镜像账号把 anthropic/kiro 流量**中转到各 edge**(`api-<edge>.tokenkey.dev`)。
- edge 是**原地换容器**(`deploy_via_ssm.sh`,有短暂 `/health=503` 窗口),**不像 prod 的蓝绿**(`deploy_via_ssm_bluegreen.sh`,新容器 green 后才摘旧)。
- 并发重启 N 个 edge → 同一窗口从 prod failover 池摘掉 N 个目标。`--parallel 3` 升 us4/us5/us6 时只剩 canary(us3)健康,少数请求来不及 failover 就 502。

（那次 17 个 502 里大头其实是 grok 上游 502/503/429,与发版无关;真正发版相关的只有 ~5 笔,全聚在并发切换那一刻。）

## 改动

- **`scripts/stage0/rollout-edges.sh`**:脚本默认本就是 `--parallel 1`,本 PR 在 header 记录**为什么这个默认是 load-bearing**(中转池 + 原地换容器),提醒不要上调。
- **`tokenkey-stage0-release-rollout` skill**:`target=all` 剩余 edge 阶段的指引从「推荐 `--parallel 3` 加速」改为**默认/推荐 `--parallel 1` 顺序**;`N>1` 重新定义为「**仅在 edges 已蓝绿或非中转 fleet 时**」的显式速度/爆炸半径取舍。

## 行为影响

- **运行时行为不变**:脚本默认已是 1;本 PR 是把口头决策**硬化进 skill + 脚本文档**,消除 skill 指引与脚本默认之间的漂移。
- 代价:剩余 edge 阶段墙钟 ~3×(顺序),但该阶段是 infra-only、不在用户关键路径。
- 后续(不在本 PR):评估把蓝绿原语移植到 Lightsail edges(确认实例内存可短时容纳两容器),则 `N>1` 可重新安全使用——把这类错误从「靠降并发规避」升级成「结构上不存在」。

## 验证

- `bash scripts/preflight.sh` PASS(含 `Stage0 deployment primitive sharing`、skill description 长度、agent contract drift 等门禁)。

## No web impact

纯 ops 脚本注释 + release skill 文本,无前端/网关用户面改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)