### PR TITLE
fix(dashboard): 今日消费统一按服务器/账单时区,管理后台与客户侧对齐

### DIFF
--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -41,6 +41,15 @@ func parseTimeRange(c *gin.Context) (time.Time, time.Time) {
 		return s, e
 	}
 
+	// TK: calendar presets (today/yesterday/this_month/last_month) are resolved
+	// in the SERVER/billing timezone so the admin dashboard's "今天" window is
+	// byte-identical to the customer dashboard (timezone.Today()) and the daily
+	// rollup buckets — regardless of the viewer's browser timezone. See
+	// dashboard_handler_tk_window.go.
+	if s, e, ok := parseNamedRange(c); ok {
+		return s, e
+	}
+
 	userTZ := c.Query("timezone") // Get user's timezone from request
 	now := timezone.NowInUserLocation(userTZ)
 	startDate := c.Query("start_date")

--- a/backend/internal/handler/admin/dashboard_handler_tk_window.go
+++ b/backend/internal/handler/admin/dashboard_handler_tk_window.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/gin-gonic/gin"
 )
 
-// TK: absolute-time window channel for the admin dashboard.
+// TK: absolute-time + canonical-calendar window channels for the admin dashboard.
 //
 // The default `start_date`/`end_date` channel is date-granular and re-expanded
 // by parseTimeRange into the *user's timezone* day boundaries. That makes a
@@ -20,9 +21,45 @@ import (
 // epoch-millisecond instants for them and we honor those verbatim, bypassing
 // the timezone-dependent date expansion entirely.
 //
-// Calendar presets (today / this month / custom date pick) keep using the
-// date-string + timezone path, where per-viewer local-calendar boundaries are
-// the intended behavior.
+// Calendar presets (today / yesterday / this month / last month) are a
+// *billing-day* concept in this system: quota resets, the customer-facing
+// dashboard ("今日消费", via timezone.Today()), and the rollup buckets
+// (usage_dashboard_user_platform_daily.bucket_date) are ALL anchored to the
+// server/reporting timezone. Resolving these presets against the *viewer's*
+// browser timezone instead (the legacy date-string + auto-attached `timezone`
+// path) made the admin per-user "今天" window refer to a different calendar day
+// than the customer's own dashboard whenever the operator's browser timezone
+// differed from the server — the two surfaces then reported different totals for
+// the same user/day. To keep a single canonical definition of "today", the
+// frontend now sends a named `range` for these presets and we resolve it here in
+// the SERVER timezone via the timezone package — byte-identical to what the
+// customer dashboard's timezone.Today() produces. Custom manual date picks (no
+// `range`) still flow through the legacy date-string path.
+
+// parseNamedRange resolves a calendar preset (`range` query param) into an
+// absolute [start, end) window anchored to the server/reporting timezone, so it
+// matches the customer dashboard and the daily rollup buckets exactly. It
+// returns ok=false for an absent/unknown value, leaving existing behavior
+// untouched. The viewer's `timezone` query param is intentionally ignored here:
+// "今天" must mean the same billing day for every viewer.
+func parseNamedRange(c *gin.Context) (start time.Time, end time.Time, ok bool) {
+	switch strings.TrimSpace(c.Query("range")) {
+	case "today":
+		s := timezone.Today()
+		return s, s.AddDate(0, 0, 1), true
+	case "yesterday":
+		e := timezone.Today()
+		return e.AddDate(0, 0, -1), e, true
+	case "this_month":
+		s := timezone.StartOfMonth(timezone.Now())
+		return s, s.AddDate(0, 1, 0), true
+	case "last_month":
+		thisMonth := timezone.StartOfMonth(timezone.Now())
+		return thisMonth.AddDate(0, -1, 0), thisMonth, true
+	default:
+		return time.Time{}, time.Time{}, false
+	}
+}
 
 // absoluteRangeFloor guards against absurd / malicious timestamps. Any data
 // predates this; anything before it is treated as "not an absolute range".

--- a/backend/internal/handler/admin/dashboard_handler_tk_window_test.go
+++ b/backend/internal/handler/admin/dashboard_handler_tk_window_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -68,11 +69,48 @@ func TestParseAbsoluteRange_RejectsAndFallsBack(t *testing.T) {
 }
 
 // TestParseTimeRange_FallbackUnchanged ensures the legacy date-string + timezone
-// path is untouched when no absolute ts is supplied.
+// path is untouched when no absolute ts / named range is supplied.
 func TestParseTimeRange_FallbackUnchanged(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	c := ctxWithURL("/?start_date=2024-01-01&end_date=2024-01-02&timezone=UTC")
 	start, end := parseTimeRange(c)
 	require.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), start)
 	require.Equal(t, time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC), end)
+}
+
+// TestParseNamedRange_ServerTZCanonical is the regression guard for the
+// "admin per-user 今日消费 ≠ customer 今日消费" bug: a calendar `range` preset must
+// resolve to the SERVER/billing timezone (matching the customer dashboard's
+// timezone.Today()), ignoring both the viewer `timezone` param and any
+// browser-local start_date/end_date that rides along.
+func TestParseNamedRange_ServerTZCanonical(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	today := timezone.Today()
+	thisMonth := timezone.StartOfMonth(timezone.Now())
+
+	cases := []struct {
+		name      string
+		rng       string
+		wantStart time.Time
+		wantEnd   time.Time
+	}{
+		{"today", "today", today, today.AddDate(0, 0, 1)},
+		{"yesterday", "yesterday", today.AddDate(0, 0, -1), today},
+		{"this_month", "this_month", thisMonth, thisMonth.AddDate(0, 1, 0)},
+		{"last_month", "last_month", thisMonth.AddDate(0, -1, 0), thisMonth},
+	}
+
+	// Every viewer timezone (and a bogus browser-local date) must yield the same
+	// canonical server-TZ window.
+	for _, tz := range []string{"Asia/Shanghai", "America/Los_Angeles", "UTC"} {
+		for _, tc := range cases {
+			t.Run(tc.name+"/"+tz, func(t *testing.T) {
+				url := fmt.Sprintf("/?range=%s&start_date=1999-01-01&end_date=1999-01-01&timezone=%s", tc.rng, tz)
+				start, end := parseTimeRange(ctxWithURL(url))
+				require.Equal(t, tc.wantStart, start)
+				require.Equal(t, tc.wantEnd, end)
+			})
+		}
+	}
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 513,
-  "hash": "314ba4a4b413671d50a49b80c1538b0cec4ed9d9d1a1b11bcc98de4cff845134",
+  "hash": "095bdab27bde93471f30e9ce911a92c6d2257c9b9d4a647d6a80d3d3bd5edd3d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/utils/__tests__/dashboardWindow.tk.spec.ts
+++ b/frontend/src/utils/__tests__/dashboardWindow.tk.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import {
+  rollingWindowTs,
+  dashboardWindowParams,
+  CALENDAR_PRESET_RANGE
+} from '@/utils/dashboardWindow.tk'
+
+describe('dashboardWindowParams', () => {
+  it('returns absolute epoch-ms window for rolling presets', () => {
+    const out = dashboardWindowParams('last24Hours') as {
+      start_ts: number
+      end_ts: number
+    }
+    expect(typeof out.start_ts).toBe('number')
+    expect(typeof out.end_ts).toBe('number')
+    expect(out.end_ts - out.start_ts).toBe(24 * 60 * 60 * 1000)
+    // mirrors rollingWindowTs for rolling presets
+    expect(rollingWindowTs('last24Hours')).not.toBeNull()
+  })
+
+  it('returns a canonical server-TZ range token for calendar presets', () => {
+    expect(dashboardWindowParams('today')).toEqual({ range: 'today' })
+    expect(dashboardWindowParams('yesterday')).toEqual({ range: 'yesterday' })
+    expect(dashboardWindowParams('thisMonth')).toEqual({ range: 'this_month' })
+    expect(dashboardWindowParams('lastMonth')).toEqual({ range: 'last_month' })
+  })
+
+  it('never emits start_ts/end_ts for calendar presets (those stay server-TZ)', () => {
+    for (const preset of Object.keys(CALENDAR_PRESET_RANGE)) {
+      const out = dashboardWindowParams(preset) as Record<string, unknown>
+      expect(out).not.toHaveProperty('start_ts')
+      expect(out).toHaveProperty('range')
+    }
+  })
+
+  it('returns empty params for custom picks / unknown presets', () => {
+    expect(dashboardWindowParams(null)).toEqual({})
+    expect(dashboardWindowParams(undefined)).toEqual({})
+    expect(dashboardWindowParams('custom')).toEqual({})
+  })
+})

--- a/frontend/src/utils/dashboardWindow.tk.ts
+++ b/frontend/src/utils/dashboardWindow.tk.ts
@@ -10,9 +10,17 @@
  * different numbers. To make the window timezone-independent, we send precise
  * epoch-millisecond instants (`start_ts`/`end_ts`) computed from `Date.now()`.
  *
- * Calendar presets (today / yesterday / this month / last month / custom date
- * pick) intentionally keep the date-string + timezone path: a "today" report is
- * a local-calendar concept and should follow the viewer's timezone.
+ * Calendar presets (today / yesterday / this month / last month) are a
+ * billing-day concept: the customer-facing dashboard ("今日消费"), quota resets,
+ * and the daily rollup buckets are all anchored to the server/reporting
+ * timezone. Following the *viewer's* browser timezone here made the admin "今天"
+ * window refer to a different calendar day than the customer's own dashboard
+ * whenever the operator's browser timezone differed from the server, so the two
+ * surfaces reported different totals for the same user/day. We therefore send a
+ * named `range` for these presets and let the backend resolve it in the server
+ * timezone (see backend dashboard_handler_tk_window.go) — one canonical "today"
+ * for every viewer. A manual custom date pick (preset === null) still flows
+ * through the date-string path.
  */
 
 const HOUR_MS = 60 * 60 * 1000
@@ -53,4 +61,37 @@ export function rollingWindowTs(
 
   const end = floorToMinute(Date.now())
   return { start_ts: end - duration, end_ts: end }
+}
+
+/**
+ * Maps a DateRangePicker calendar preset to the backend's canonical `range`
+ * token. The backend resolves these in the server/billing timezone so the window
+ * is identical for every viewer (and matches the customer dashboard). Rolling
+ * presets and manual custom picks are absent here — they keep their own paths.
+ */
+export const CALENDAR_PRESET_RANGE: Record<string, string> = {
+  today: 'today',
+  yesterday: 'yesterday',
+  thisMonth: 'this_month',
+  lastMonth: 'last_month'
+}
+
+/**
+ * Returns the window params to spread into a dashboard request for the active
+ * preset:
+ *   - rolling preset  → { start_ts, end_ts }  (absolute, timezone-independent)
+ *   - calendar preset → { range }             (server-TZ canonical, set on the
+ *                                               backend)
+ *   - custom pick / unknown → {}              (caller still sends start_date /
+ *                                               end_date)
+ */
+export function dashboardWindowParams(
+  preset: string | null | undefined
+): { start_ts: number; end_ts: number } | { range: string } | Record<string, never> {
+  const rolling = rollingWindowTs(preset)
+  if (rolling) return rolling
+  if (preset && CALENDAR_PRESET_RANGE[preset]) {
+    return { range: CALENDAR_PRESET_RANGE[preset] }
+  }
+  return {}
 }

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -370,7 +370,7 @@ import DateRangePicker from '@/components/common/DateRangePicker.vue'
 import Select from '@/components/common/Select.vue'
 import ModelDistributionChart from '@/components/charts/ModelDistributionChart.vue'
 import TokenUsageTrend from '@/components/charts/TokenUsageTrend.vue'
-import { rollingWindowTs } from '@/utils/dashboardWindow.tk'
+import { dashboardWindowParams, rollingWindowTs } from '@/utils/dashboardWindow.tk'
 
 import {
   Chart as ChartJS,
@@ -664,6 +664,10 @@ const goToUserUsage = (item: UserSpendingRankingItem) => {
       user_id: String(item.user_id),
       start_date: startDate.value,
       end_date: endDate.value,
+      // The /admin/usage list parser only consumes absolute start_ts/end_ts (+
+      // date strings); it does NOT understand the server-TZ `range` token, so we
+      // forward only the rolling absolute window here. Server-TZ alignment of the
+      // usage-list drilldown itself is a separate change to parseUsageListTimeRange.
       ...(rollingWindowTs(activePreset.value) ?? {})
     }
   })
@@ -700,7 +704,7 @@ const loadDashboardStatsSnapshot = async () => {
     const response = await adminAPI.dashboard.getSnapshotV2({
       start_date: startDate.value,
       end_date: endDate.value,
-      ...(rollingWindowTs(activePreset.value) ?? {}),
+      ...(dashboardWindowParams(activePreset.value)),
       granularity: granularity.value,
       include_stats: true,
       include_trend: false,
@@ -725,7 +729,7 @@ const loadDashboardTrendSnapshot = async (currentSeq: number) => {
     const response = await adminAPI.dashboard.getSnapshotV2({
       start_date: startDate.value,
       end_date: endDate.value,
-      ...(rollingWindowTs(activePreset.value) ?? {}),
+      ...(dashboardWindowParams(activePreset.value)),
       granularity: granularity.value,
       include_stats: false,
       include_trend: true,
@@ -750,7 +754,7 @@ const loadDashboardModelStatsSnapshot = async (currentSeq: number) => {
     const response = await adminAPI.dashboard.getSnapshotV2({
       start_date: startDate.value,
       end_date: endDate.value,
-      ...(rollingWindowTs(activePreset.value) ?? {}),
+      ...(dashboardWindowParams(activePreset.value)),
       granularity: granularity.value,
       include_stats: false,
       include_trend: false,
@@ -784,7 +788,7 @@ const loadUserUsageTrend = async () => {
     const response = await adminAPI.dashboard.getSnapshotV2({
       start_date: startDate.value,
       end_date: endDate.value,
-      ...(rollingWindowTs(activePreset.value) ?? {}),
+      ...(dashboardWindowParams(activePreset.value)),
       granularity: granularity.value,
       include_stats: false,
       include_trend: false,
@@ -812,7 +816,7 @@ const loadUserSpendingRanking = async () => {
     const response = await adminAPI.dashboard.getUserSpendingRanking({
       start_date: startDate.value,
       end_date: endDate.value,
-      ...(rollingWindowTs(activePreset.value) ?? {}),
+      ...(dashboardWindowParams(activePreset.value)),
       limit: rankingLimit
     })
     if (currentSeq !== rankingLoadSeq) return

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1055,11 +1055,12 @@
     {
       "path": "frontend/src/views/admin/DashboardView.vue",
       "must_contain": [
-        "import { rollingWindowTs } from '@/utils/dashboardWindow.tk'",
+        "import { dashboardWindowParams, rollingWindowTs } from '@/utils/dashboardWindow.tk'",
         "const goToUserUsage = (item: UserSpendingRankingItem) => {",
+        "...(dashboardWindowParams(activePreset.value))",
         "...(rollingWindowTs(activePreset.value) ?? {})"
       ],
-      "rationale": "Admin Dashboard rolling presets and user-ranking drilldown must carry the same absolute epoch-ms window to /admin/usage. If an upstream-shaped DashboardView rewrite drops rollingWindowTs propagation, dashboard numbers and usage drilldowns desynchronize and the usage page widens queries back to full date boundaries while still compiling."
+      "rationale": "The admin Dashboard's own requests (snapshot-v2 / user-ranking) carry the TK window via dashboardWindowParams(): rolling presets → absolute epoch-ms (timezone-independent), calendar presets ('今天'/昨天/本月/上月) → a server-TZ `range` token resolved by the backend (parseNamedRange). The `range` path is load-bearing — without it the admin per-user '今日消费' window follows the operator's browser timezone and silently disagrees with the customer dashboard (timezone.Today()) and the daily rollup buckets for the same user/day. The goToUserUsage drilldown deliberately keeps rollingWindowTs() instead, because /admin/usage's parser consumes only absolute start_ts/end_ts (+ date strings) and would silently drop a `range` token. If an upstream-shaped DashboardView rewrite collapses these two helpers, either the dashboard calendar windows fall back to browser-local date strings (mismatch returns) or the drilldown emits a dead param — both while still compiling."
     },
     {
       "path": "frontend/src/views/admin/UsageView.vue",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3472,6 +3472,23 @@
         "TestOpenAIGatewayService_OAuthUpstreamHeadersNormalizeNonCodexIngress"
       ],
       "rationale": "Regression anchor for the Codex fingerprint normalization: non-Codex OAuth ingress (python-requests / Python-urllib / claude-cli) across /v1/responses, /v1/chat/completions, /v1/messages must reach upstream with a Codex UA and originator==codex_cli_rs, never the inbound client identity. Pins the test so an upstream refactor cannot silently drop the only end-to-end guard for the mimicry behavior."
+    },
+    {
+      "path": "backend/internal/handler/admin/dashboard_handler_tk_window.go",
+      "must_contain": [
+        "func parseNamedRange(c *gin.Context) (start time.Time, end time.Time, ok bool)",
+        "case \"today\":",
+        "s := timezone.Today()",
+        "timezone.StartOfMonth(timezone.Now())"
+      ],
+      "rationale": "Admin dashboard calendar presets (today/yesterday/this_month/last_month) MUST resolve to the server/billing timezone here (timezone.Today()/StartOfMonth), byte-identical to the customer dashboard and the daily rollup buckets. Without this resolver the admin per-user '今日消费' window follows the operator's browser timezone and silently disagrees with the customer's own dashboard for the same user/day (TK 2026-06-26: admin $1360 vs customer $1024 for user_id=16). An upstream-shaped refactor of the admin dashboard handlers could drop this companion and the window would fall back to browser-local date strings while still compiling."
+    },
+    {
+      "path": "backend/internal/handler/admin/dashboard_handler.go",
+      "must_contain": [
+        "if s, e, ok := parseNamedRange(c); ok {"
+      ],
+      "rationale": "parseTimeRange MUST consult parseNamedRange (server-TZ calendar presets) after parseAbsoluteRange and before the viewer-timezone date-string fallback. If this injection line is dropped on an upstream merge, the resolver in dashboard_handler_tk_window.go is orphaned and admin calendar presets silently revert to browser-timezone windows — the cross-surface 今日消费 mismatch returns with no compile error."
     }
   ]
 }


### PR DESCRIPTION
## 摘要

修复运营反馈的「今日消费」口径不一致:prod 管理后台「用户消费榜」与客户侧仪表盘「今日消费」对同一用户(user_id=16, compute@tk.com)显示的今日数据对不上 —— 管理后台 ≈ \$1.36K / 152,143 请求 / 1.57B Token,客户侧 \$1024.3798 / 93,618 请求 / 1112.9M Token,三个指标全部偏大且比例各异。

**根因:今日的时区边界不一致。** 两侧查的是同一张表 `usage_logs`、同一字段 `SUM(actual_cost)`、同一用户,唯一差别是"今天"窗口的时区口径:

| 界面 | "今天"起点 | 时区 |
|------|-----------|------|
| 客户侧「今日消费」 | `timezone.Today()`,写死服务器时区,忽略浏览器 | 服务器 TZ(Asia/Shanghai) |
| 管理后台「用户消费榜」(今天预设) | 浏览器本地日期串 + axios 拦截器自动附带的 `timezone=Intl....timeZone` | 运营者浏览器 TZ |

当运营者浏览器时区 ≠ 服务器时区时,管理后台的"今天"指向另一个日历日(部分重叠/错位),三指标因而全部偏大且比例各异。客户侧 \$1024.38 才是与配额重置、滚动桶 `usage_dashboard_user_platform_daily.bucket_date` 一致的账单日数值。

**修复(经运营确认:全站统一服务器/账单时区)。** 让后端用与客户侧相同的 `timezone` 包权威解析日历预设,前端只声明意图,"今天"全站只有一个定义:

- 后端 `dashboard_handler_tk_window.go` 新增 `parseNamedRange`:`range=today|yesterday|this_month|last_month` 在服务器时区解析(`today` 即 `timezone.Today()`,与客户侧字节级一致),刻意忽略浏览器 `timezone`;接入 `parseTimeRange`(`parseAbsoluteRange` 之后、日期字符串回退之前)。缺省 `range` 行为完全不变,所有 admin dashboard 端点(snapshot-v2 / users-ranking 等)共用此函数一处生效。
- 前端 `dashboardWindow.tk.ts` 新增 `dashboardWindowParams()`:滚动预设→`{start_ts,end_ts}`(绝对值,不变)、日历预设→`{range}`(服务器 TZ)、自定义→`{}`;`DashboardView.vue` 5 个 dashboard 请求调用点统一改用(保持 upstream-shaped .vue 薄壳)。
- Sentinel:`frontend-tk` DashboardView 锚点更新为 `dashboardWindowParams` + `rollingWindowTs` 双调用;新增 `gateway-tk` 两条锚点钉住 `parseNamedRange` 解析器与其在 `parseTimeRange` 的注入调用,防止上游合并静默丢弃后口径回退。

## 风险

- 低。后端为纯插入式注入(`dashboard_handler.go` 仅新增 9 行调用,0 删除),缺省 `range` 时旧的 `start_ts/end_ts`(滚动)与日期字符串(viewer-TZ)路径行为完全不变,既有回归测试 `TestParseAbsoluteRange_*` / `TestParseTimeRange_FallbackUnchanged` 均保持。
- 行为变化点:管理后台日历预设(今天/昨天/本月/上月)现按服务器时区计算 —— 这正是修复目标,使其与客户侧、配额重置、滚动桶一致。身处其他时区的运营者将看到上海账单日(符合计费语义)。
- `goToUserUsage` 下钻:刻意只转发滚动绝对窗口(`rollingWindowTs`),不向 `/admin/usage`(其解析器 `parseUsageListTimeRange` 不认 `range`)发送死参数,drill-down 行为与 main 字节一致;明细页自身的服务器 TZ 对齐属另一界面/独立 PR(见下)。
- 无删除上游符号(`git diff --diff-filter=D` 为空);`dashboard_handler.go` 为纯插入,coverage-first 自动通过,无需 override marker。

## 验证

- `go build ./...` ✓;`golangci-lint run ./internal/handler/admin/` 0 issues ✓
- `go test -tags=unit ./internal/handler/admin/` ✓,含新增 `TestParseNamedRange_ServerTZCanonical`(4 预设 × 3 浏览器时区,证明结果只取决于服务器时区,忽略浏览器 `timezone` 与 browser-local 日期串)
- 前端 `pnpm typecheck` / `pnpm lint:check` 干净;新增 `dashboardWindow.tk.spec.ts`(4 用例)✓
- `pnpm build` 重新生成嵌入 `backend/internal/web/dist`;`bash scripts/preflight.sh` 全绿(含 frontend-tk / gateway-tk sentinel、dist freshness、sentinel update gate)
- 已过 `/xj-review`:发现并修掉 R-001(`goToUserUsage` 误用 `dashboardWindowParams` 会向 range-unaware 的 `/admin/usage` 发死参数),改回 `rollingWindowTs`;复审零 medium+ finding。
- 诊断基于代码路径推导(两条查询除时区边界外完全等价),未直连 prod DB 取数;修复后两侧对同一用户/同一服务器账单日必然返回同一窗口、同一数值。

## 范围外(未改,待决策)

点击消费榜某行跳转 `/admin/usage` 明细列表走另一解析器 `parseUsageListTimeRange`,尚不认 `range`,日历预设下仍按浏览器 TZ 日期串。让该 drill-down 也对齐服务器 TZ 需给 `parseUsageListTimeRange` 加 `range` 支持(另一界面/独立 PR,本 PR 未含)。

合并方式:本 PR 为 TK fix,使用 **Squash and merge**。

## 提交

最新提交:42fd7882e

- 42fd7882e fix(dashboard): 今日消费统一按服务器/账单时区,管理后台与客户侧对齐

🤖 Generated with [Claude Code](https://claude.com/claude-code)
