### PR TITLE
fix(pricing): admin 导出 CSV 按钮始终可见,点击自动切对外价视图再导出

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 513,
-  "hash": "095bdab27bde93471f30e9ce911a92c6d2257c9b9d4a647d6a80d3d3bd5edd3d",
+  "hash": "ea42f90f3e37fd2a9dde616c9c0d07c7edbb88d6ac7d7696b88ee16646572862",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -27,7 +27,8 @@ export default {
       'Swipe horizontally or scroll below to see all columns. Model names wrap in the left column.',
     export: {
       button: 'Export CSV',
-      success: 'Pricing exported'
+      success: 'Pricing exported',
+      empty: 'Public catalog is empty — nothing to export'
     },
     tieredBadge: 'Tiered ×{n}',
     footer: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -26,7 +26,8 @@ export default {
     tableHint: '可左右滑动或横向滚动查看全部列；左侧模型名称支持换行显示。',
     export: {
       button: '导出 CSV',
-      success: '定价已导出'
+      success: '定价已导出',
+      empty: '对外价目录为空，无可导出内容'
     },
     tieredBadge: '阶梯 ×{n}',
     footer: {

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -247,7 +247,8 @@
             <button
               v-if="canExportPricing"
               type="button"
-              class="inline-flex items-center gap-1.5 self-start rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-50 dark:border-dark-700 dark:bg-dark-800 dark:text-dark-100 dark:hover:bg-dark-700 sm:self-auto"
+              :disabled="exporting"
+              class="inline-flex items-center gap-1.5 self-start rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-dark-700 dark:bg-dark-800 dark:text-dark-100 dark:hover:bg-dark-700 sm:self-auto"
               data-tk="pricing-export-csv"
               @click="onExportPricing"
             >
@@ -621,14 +622,38 @@ const selectedGroupId = ref<number>(0)
 const canShowCatalogFilters = computed(() => myCatalog.value != null)
 
 // Admin-only "export platform pricing" — the public (在售目录/对外价) catalog only,
-// as a sales-friendly CSV. Hidden for non-admins and when there is nothing to export.
-const canExportPricing = computed(
-  () => authStore.isAdmin && viewMode.value === 'public' && (publicCatalog.value?.data.length ?? 0) > 0
-)
+// as a sales-friendly CSV. Always visible for admins regardless of the current
+// view; clicking switches to the public catalog first (and loads it if needed)
+// so the export always reflects 对外价, never a per-key/group Your-Menu view.
+const canExportPricing = computed(() => authStore.isAdmin)
 
-const onExportPricing = () => {
-  exportPricingCsv(publicCatalog.value)
-  appStore.showSuccess(t('pricing.export.success'))
+const exporting = ref(false)
+
+const onExportPricing = async (): Promise<void> => {
+  if (exporting.value) return
+  exporting.value = true
+  try {
+    // The CSV is always the public 对外价 catalog. If the admin is currently on
+    // a Your-Menu (my) view, switch to public and (re)load it before exporting.
+    if (viewMode.value !== 'public') {
+      viewMode.value = 'public'
+      selectedKeyId.value = 0
+      selectedGroupId.value = 0
+    }
+    if ((publicCatalog.value?.data.length ?? 0) === 0) {
+      await loadPublicCatalog()
+    }
+    if ((publicCatalog.value?.data.length ?? 0) === 0) {
+      appStore.showError(t('pricing.export.empty'))
+      return
+    }
+    exportPricingCsv(publicCatalog.value)
+    appStore.showSuccess(t('pricing.export.success'))
+  } catch {
+    appStore.showError(t('pricing.export.empty'))
+  } finally {
+    exporting.value = false
+  }
 }
 
 // ============================== hero copy ==============================

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -5,11 +5,15 @@ import PricingView from '../PricingView.vue'
 import type { PublicCatalogResponse } from '@/api/pricing'
 import type { MePricingCatalogResponse } from '@/api/me-pricing'
 
-const { getPublicPricing, getMePricingCatalog, authState } = vi.hoisted(() => ({
-  getPublicPricing: vi.fn(),
-  getMePricingCatalog: vi.fn(),
-  authState: { isAuthenticated: false, isAdmin: false },
-}))
+const { getPublicPricing, getMePricingCatalog, authState, exportPricingCsv, showSuccess, showError } =
+  vi.hoisted(() => ({
+    getPublicPricing: vi.fn(),
+    getMePricingCatalog: vi.fn(),
+    authState: { isAuthenticated: false, isAdmin: false },
+    exportPricingCsv: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+  }))
 
 vi.mock('@/api/pricing', () => ({
   getPublicPricing,
@@ -17,6 +21,10 @@ vi.mock('@/api/pricing', () => ({
 
 vi.mock('@/api/me-pricing', () => ({
   getMePricingCatalog,
+}))
+
+vi.mock('@/composables/useTkPricingExport', () => ({
+  exportPricingCsv,
 }))
 
 vi.mock('@/stores/auth', () => ({
@@ -33,6 +41,8 @@ vi.mock('@/stores/app', () => ({
       backend_mode_enabled: false,
     },
     fetchPublicSettings: vi.fn(),
+    showSuccess,
+    showError,
   }),
 }))
 
@@ -96,7 +106,10 @@ vi.mock('vue-i18n', async () => {
     'pricing.my.exploreBanner.message': 'Viewing {group} catalog',
     'pricing.my.exploreBanner.cta': 'Create key in {group}',
     'pricing.my.noKeyHint': '',
-    'pricing.perRequest': '/ request'
+    'pricing.perRequest': '/ request',
+    'pricing.export.button': 'Export CSV',
+    'pricing.export.success': 'Pricing exported',
+    'pricing.export.empty': 'Public catalog is empty — nothing to export'
   }
   return {
     ...actual,
@@ -211,6 +224,9 @@ describe('PricingView', () => {
   beforeEach(() => {
     getPublicPricing.mockReset()
     getMePricingCatalog.mockReset()
+    exportPricingCsv.mockReset()
+    showSuccess.mockReset()
+    showError.mockReset()
     localStorage.clear()
     authState.isAuthenticated = false
     authState.isAdmin = false
@@ -387,5 +403,77 @@ describe('PricingView', () => {
     expect(getPublicPricing).toHaveBeenCalledTimes(1)
     expect(wrapper.text()).toContain('Viewing the public catalog')
     expect(wrapper.text()).toContain('public-model')
+  })
+
+  it('shows the export button to admins even on a Your-Menu (my) view', async () => {
+    authState.isAuthenticated = true
+    authState.isAdmin = true
+    localStorage.setItem('auth_token', 'token')
+    getMePricingCatalog.mockResolvedValue(meCatalog())
+
+    const wrapper = mountPricingView()
+    await flushPromises()
+
+    // Landed on the my-view (Your-Menu), yet the admin export button is visible.
+    expect(wrapper.text()).toContain('Viewing default · Pro')
+    expect(wrapper.find('[data-tk="pricing-export-csv"]').exists()).toBe(true)
+  })
+
+  it('hides the export button from non-admins', async () => {
+    authState.isAuthenticated = true
+    authState.isAdmin = false
+    localStorage.setItem('auth_token', 'token')
+    getMePricingCatalog.mockResolvedValue(meCatalog())
+
+    const wrapper = mountPricingView()
+    await flushPromises()
+
+    expect(wrapper.find('[data-tk="pricing-export-csv"]').exists()).toBe(false)
+  })
+
+  it('export from a my-view auto-switches to the public catalog then exports', async () => {
+    authState.isAuthenticated = true
+    authState.isAdmin = true
+    localStorage.setItem('auth_token', 'token')
+    getMePricingCatalog.mockResolvedValue(meCatalog())
+    getPublicPricing.mockResolvedValue(publicCatalog([publicModel('public-model')]))
+
+    const wrapper = mountPricingView()
+    await flushPromises()
+
+    // Sanity: started on the my-view and the public catalog was NOT fetched yet.
+    expect(wrapper.text()).toContain('Viewing default · Pro')
+    expect(getPublicPricing).not.toHaveBeenCalled()
+
+    await wrapper.get('[data-tk="pricing-export-csv"]').trigger('click')
+    await flushPromises()
+
+    // Switched to public, loaded it, and exported that catalog.
+    expect(getPublicPricing).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).toContain('Viewing the public catalog')
+    expect(exportPricingCsv).toHaveBeenCalledTimes(1)
+    expect(exportPricingCsv.mock.calls[0][0]).toMatchObject({
+      data: [expect.objectContaining({ model_id: 'public-model' })],
+    })
+    expect(showSuccess).toHaveBeenCalledTimes(1)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('export surfaces an error when the public catalog is empty', async () => {
+    authState.isAuthenticated = true
+    authState.isAdmin = true
+    localStorage.setItem('auth_token', 'token')
+    getMePricingCatalog.mockResolvedValue(meCatalog())
+    getPublicPricing.mockResolvedValue(publicCatalog([]))
+
+    const wrapper = mountPricingView()
+    await flushPromises()
+
+    await wrapper.get('[data-tk="pricing-export-csv"]').trigger('click')
+    await flushPromises()
+
+    expect(getPublicPricing).toHaveBeenCalledTimes(1)
+    expect(exportPricingCsv).not.toHaveBeenCalled()
+    expect(showError).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## 背景

PR #1020(v1.8.48 已发版)给 `/pricing` 加了 admin-only 的「导出 CSV(对外价)」按钮,但门控写成三条件 AND:

```js
canExportPricing = authStore.isAdmin && viewMode.value === 'public' && publicCatalog 非空
```

而 `loadInitialCatalog()` 对**任何持有 `auth_token` 的登录用户(含 admin)默认落在「我的目录(my)」视图**,所以登录 admin 进 `/pricing` 时 `viewMode !== 'public'` → 按钮**始终不渲染**。运营反馈「看不到下载定价报价的按钮」即此。

## 改动

放宽为「admin 始终可见,点击时自动切到 public 视图再导出」:

**`frontend/src/views/PricingView.vue`**
- `canExportPricing` → **仅 `authStore.isAdmin`**(admin 在任意视图都能看到按钮)。
- `onExportPricing` 重写为 async:点击时若不在 public 视图,**自动切到公开目录**(清掉 key/group 选择)并按需 `loadPublicCatalog()`,再导出。导出口径**恒为对外价**,绝不会导出 per-key/group 的 Your-Menu 视图。空目录走 `showError` 友好提示;新增 `exporting` 标志防重复点击 + 按钮 disabled 态。

**i18n** `en/zh`:新增 `pricing.export.empty`(纯增量)。

**测试** `PricingView.spec.ts`:新增 4 例 —— admin 跨视图可见 / 非 admin 隐藏 / my 视图点击自动切 public 并导出 / 空目录报错。共 **17 例通过**。

## 最小侵入(§5)

全为前端纯插入 / 薄 view 接线 + 既有 `useTkPricingExport` composable(未改动其导出逻辑)。无 upstream 符号删除。

## 门禁说明

`sentinel-registry-reviewed`:`PricingView.vue` 改动为只读展示 + admin 门控放宽,非反删除关键面(与 #1020 同性质),已 review 确认无需新增 sentinel 锚点。

## 验证

- `pnpm typecheck` / `lint:check` 干净
- vitest(PricingView 17 例通过,含新增 4 例)
- `pnpm build` 重建嵌入 dist(`backend/internal/web/dist/frontend-source.json`)
- `scripts/preflight.sh` PASS

合并方式:**Squash and merge**(TK feature)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
