### PR TITLE
fix(accounts): 对齐 #1031 订阅/用量在 edge 面板与本机列表

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -317,6 +317,10 @@ func (s *AccountUsageService) GetUsage(ctx context.Context, accountID int64, for
 		return usage, err
 	}
 
+	if account.IsGrok() {
+		return s.buildLocalWindowUsage(ctx, account), nil
+	}
+
 	if account.Platform == PlatformGemini {
 		usage, err := s.getGeminiUsage(ctx, account)
 		if err == nil {
@@ -505,6 +509,13 @@ func (s *AccountUsageService) GetPassiveUsage(ctx context.Context, accountID int
 		return s.buildPassiveKiroUsage(account), nil
 	}
 
+	// Grok/xAI does not expose the Codex-style upstream quota snapshot that OpenAI
+	// OAuth has, and it must not fall through to the Anthropic OAuth usage API.
+	// Surface local account billing windows so operators still see activity.
+	if account.IsGrok() {
+		return s.buildLocalWindowUsage(ctx, account), nil
+	}
+
 	if !account.IsAnthropicOAuthOrSetupToken() {
 		return nil, fmt.Errorf("passive usage only supported for Anthropic OAuth/SetupToken accounts")
 	}
@@ -550,6 +561,31 @@ func (s *AccountUsageService) buildPassiveOpenAIUsage(account *Account) *UsageIn
 		usage.SevenDay = progress
 	}
 
+	return usage
+}
+
+func (s *AccountUsageService) buildLocalWindowUsage(ctx context.Context, account *Account) *UsageInfo {
+	now := time.Now()
+	usage := &UsageInfo{
+		Source:    "passive",
+		UpdatedAt: &now,
+	}
+	if account == nil || s.usageLogRepo == nil {
+		return usage
+	}
+
+	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, now.Add(-5*time.Hour)); err == nil {
+		usage.FiveHour = &UsageProgress{
+			Utilization: 0,
+			WindowStats: windowStatsFromAccountStats(stats),
+		}
+	}
+	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, now.Add(-7*24*time.Hour)); err == nil {
+		usage.SevenDay = &UsageProgress{
+			Utilization: 0,
+			WindowStats: windowStatsFromAccountStats(stats),
+		}
+	}
 	return usage
 }
 

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -192,6 +192,37 @@ func TestAccountUsageService_GetPassiveUsage_OpenAIOAuthRebuildsCodexWindows(t *
 	}
 }
 
+func TestAccountUsageService_GetUsage_GrokUsesLocalWindowStats(t *testing.T) {
+	t.Parallel()
+
+	acct := Account{ID: 77, Platform: PlatformGrok, Type: AccountTypeOAuth}
+	logRepo := &passiveBatchUsageLogRepo{cost: map[int64]float64{77: 12.5}}
+	svc := &AccountUsageService{
+		accountRepo:  stubOpenAIAccountRepo{accounts: []Account{acct}},
+		usageLogRepo: logRepo,
+	}
+
+	usage, err := svc.GetUsage(context.Background(), 77)
+	if err != nil {
+		t.Fatalf("GetUsage() error = %v", err)
+	}
+	if usage.Source != "passive" {
+		t.Fatalf("Source = %q, want passive", usage.Source)
+	}
+	if usage.FiveHour == nil || usage.FiveHour.WindowStats == nil {
+		t.Fatalf("FiveHour local stats missing: %#v", usage.FiveHour)
+	}
+	if usage.SevenDay == nil || usage.SevenDay.WindowStats == nil {
+		t.Fatalf("SevenDay local stats missing: %#v", usage.SevenDay)
+	}
+	if usage.FiveHour.WindowStats.Cost != 12.5 {
+		t.Fatalf("FiveHour cost = %v, want 12.5", usage.FiveHour.WindowStats.Cost)
+	}
+	if logRepo.singleCalls.Load() != 2 {
+		t.Fatalf("GetAccountWindowStats calls = %d, want 2", logRepo.singleCalls.Load())
+	}
+}
+
 func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -192,37 +192,6 @@ func TestAccountUsageService_GetPassiveUsage_OpenAIOAuthRebuildsCodexWindows(t *
 	}
 }
 
-func TestAccountUsageService_GetUsage_GrokUsesLocalWindowStats(t *testing.T) {
-	t.Parallel()
-
-	acct := Account{ID: 77, Platform: PlatformGrok, Type: AccountTypeOAuth}
-	logRepo := &passiveBatchUsageLogRepo{cost: map[int64]float64{77: 12.5}}
-	svc := &AccountUsageService{
-		accountRepo:  stubOpenAIAccountRepo{accounts: []Account{acct}},
-		usageLogRepo: logRepo,
-	}
-
-	usage, err := svc.GetUsage(context.Background(), 77)
-	if err != nil {
-		t.Fatalf("GetUsage() error = %v", err)
-	}
-	if usage.Source != "passive" {
-		t.Fatalf("Source = %q, want passive", usage.Source)
-	}
-	if usage.FiveHour == nil || usage.FiveHour.WindowStats == nil {
-		t.Fatalf("FiveHour local stats missing: %#v", usage.FiveHour)
-	}
-	if usage.SevenDay == nil || usage.SevenDay.WindowStats == nil {
-		t.Fatalf("SevenDay local stats missing: %#v", usage.SevenDay)
-	}
-	if usage.FiveHour.WindowStats.Cost != 12.5 {
-		t.Fatalf("FiveHour cost = %v, want 12.5", usage.FiveHour.WindowStats.Cost)
-	}
-	if logRepo.singleCalls.Load() != 2 {
-		t.Fatalf("GetAccountWindowStats calls = %d, want 2", logRepo.singleCalls.Load())
-	}
-}
-
 func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/backend/internal/service/account_usage_service_tk_passive_batch.go
+++ b/backend/internal/service/account_usage_service_tk_passive_batch.go
@@ -57,8 +57,8 @@ func (s *AccountUsageService) GetPassiveUsageBatch(ctx context.Context, accountI
 			continue
 		}
 		// 仅被动用量可服务的账号才纳入（与单查 gate 一致）：Anthropic OAuth/SetupToken、
-		// OpenAI OAuth 或 Kiro。其余（apikey 等）单查会报错，此处跳过让 cell 显示「-」。
-		if !account.IsAnthropicOAuthOrSetupToken() && !account.IsOpenAIOAuth() && !account.IsKiro() {
+		// OpenAI OAuth、Kiro 或 Grok。其余（apikey 等）单查会报错，此处跳过让 cell 显示「-」。
+		if !account.IsAnthropicOAuthOrSetupToken() && !account.IsOpenAIOAuth() && !account.IsKiro() && !account.IsGrok() {
 			continue
 		}
 		// TK perf: the account is already fully loaded (GetByIDs above), so build
@@ -101,6 +101,12 @@ func (s *AccountUsageService) getPassiveUsageForAccount(ctx context.Context, acc
 	// upstream — mirrors GetPassiveUsage's kiro branch.
 	if account.IsKiro() {
 		return s.buildPassiveKiroUsage(account), nil
+	}
+
+	// Grok/xAI has no upstream percentage quota API; expose local 5h/7d billing
+	// windows through the same passive batch path the account list already owns.
+	if account.IsGrok() {
+		return s.buildLocalWindowUsage(ctx, account), nil
 	}
 
 	if !account.IsAnthropicOAuthOrSetupToken() {

--- a/backend/internal/service/account_usage_service_tk_passive_batch_test.go
+++ b/backend/internal/service/account_usage_service_tk_passive_batch_test.go
@@ -66,14 +66,14 @@ func (r *passiveBatchUsageLogRepo) GetAccountWindowStatsBatch(_ context.Context,
 	r.batchCalls.Add(1)
 	out := make(map[int64]*usagestats.AccountStats, len(accountIDs))
 	for _, id := range accountIDs {
-		out[id] = &usagestats.AccountStats{StandardCost: r.cost[id], Requests: 1}
+		out[id] = &usagestats.AccountStats{Cost: r.cost[id], StandardCost: r.cost[id], Requests: 1}
 	}
 	return out, nil
 }
 
 func (r *passiveBatchUsageLogRepo) GetAccountWindowStats(_ context.Context, accountID int64, _ time.Time) (*usagestats.AccountStats, error) {
 	r.singleCalls.Add(1)
-	return &usagestats.AccountStats{StandardCost: r.cost[accountID], Requests: 1}, nil
+	return &usagestats.AccountStats{Cost: r.cost[accountID], StandardCost: r.cost[accountID], Requests: 1}, nil
 }
 
 func passiveAnthropicAccount(id int64, windowStart time.Time) Account {
@@ -137,6 +137,23 @@ func TestGetPassiveUsageBatch_EqualsSinglePerAccount(t *testing.T) {
 	// addWindowStats 命中缓存，零单查。
 	require.Equal(t, int64(2), logRepo.batchCalls.Load(), "one window-stats batch query per distinct window start")
 	require.Zero(t, logRepo.singleCalls.Load(), "prefetched cache must spare per-account window-stats single queries")
+}
+
+func TestGetPassiveUsageBatch_IncludesGrokLocalWindows(t *testing.T) {
+	accounts := []Account{
+		{ID: 9, Platform: PlatformGrok, Type: AccountTypeAPIKey, Status: StatusActive},
+	}
+	repo := &passiveBatchAccountRepo{accounts: accounts}
+	logRepo := &passiveBatchUsageLogRepo{cost: map[int64]float64{9: 1.25}}
+	svc := &AccountUsageService{accountRepo: repo, usageLogRepo: logRepo, cache: NewUsageCache()}
+
+	got := svc.GetPassiveUsageBatch(context.Background(), []int64{9})
+
+	require.Len(t, got, 1)
+	require.NotNil(t, got[9].FiveHour)
+	require.NotNil(t, got[9].SevenDay)
+	require.Equal(t, 1.25, got[9].FiveHour.WindowStats.Cost)
+	require.Equal(t, int64(2), logRepo.singleCalls.Load(), "grok local 5h/7d windows come from usage logs")
 }
 
 func TestGetPassiveUsageBatch_EmptyAndNilSafe(t *testing.T) {

--- a/backend/internal/service/account_usage_service_tk_passive_batch_test.go
+++ b/backend/internal/service/account_usage_service_tk_passive_batch_test.go
@@ -156,6 +156,26 @@ func TestGetPassiveUsageBatch_IncludesGrokLocalWindows(t *testing.T) {
 	require.Equal(t, int64(2), logRepo.singleCalls.Load(), "grok local 5h/7d windows come from usage logs")
 }
 
+func TestAccountUsageService_GetUsage_GrokUsesLocalWindowStats(t *testing.T) {
+	acct := Account{ID: 77, Platform: PlatformGrok, Type: AccountTypeOAuth}
+	logRepo := &passiveBatchUsageLogRepo{cost: map[int64]float64{77: 12.5}}
+	svc := &AccountUsageService{
+		accountRepo:  &passiveBatchAccountRepo{accounts: []Account{acct}},
+		usageLogRepo: logRepo,
+	}
+
+	usage, err := svc.GetUsage(context.Background(), 77)
+
+	require.NoError(t, err)
+	require.Equal(t, "passive", usage.Source)
+	require.NotNil(t, usage.FiveHour)
+	require.NotNil(t, usage.FiveHour.WindowStats)
+	require.NotNil(t, usage.SevenDay)
+	require.NotNil(t, usage.SevenDay.WindowStats)
+	require.Equal(t, 12.5, usage.FiveHour.WindowStats.Cost)
+	require.Equal(t, int64(2), logRepo.singleCalls.Load())
+}
+
 func TestGetPassiveUsageBatch_EmptyAndNilSafe(t *testing.T) {
 	svc := &AccountUsageService{
 		accountRepo:  &passiveBatchAccountRepo{},

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 514,
-  "hash": "b373093058cceb1fa85e4e2fd1c654ece02dbcc49b3e4d9a40388912b32b8f9d",
+  "file_count": 515,
+  "hash": "c14a501a9a301948f8b26601027b4642018c2107f8833ec7509979d15654501e",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 515,
-  "hash": "c14a501a9a301948f8b26601027b4642018c2107f8833ec7509979d15654501e",
+  "hash": "ba67d8ee24d04506d0a1b9e933d44ff1dfb74785865fe3bdb0bdb5664c80afef",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -33,7 +33,10 @@ const activeCell = computed(() => {
     return AnthropicUsageCell
   }
 
-  if (account.platform === 'openai' && account.type === 'oauth') {
+  if (
+    (account.platform === 'openai' && account.type === 'oauth') ||
+    account.platform === 'grok'
+  ) {
     return OpenAIUsageCell
   }
 

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -206,7 +206,7 @@ describe('AccountUsageCell', () => {
 
     await flushPromises()
 
-    expect(getUsage).toHaveBeenCalledWith(2000, undefined)
+    expect(getUsage).toHaveBeenCalledWith(2000, 'passive')
     expect(wrapper.text()).toContain('5h|15|300')
     expect(wrapper.text()).toContain('7d|77|300')
   })
@@ -267,8 +267,8 @@ describe('AccountUsageCell', () => {
 
     await flushPromises()
 
-    expect(getUsage).toHaveBeenCalledWith(2001, undefined)
-    // 单一数据源：始终使用 /usage API 返回值，忽略 codex 快照
+    expect(getUsage).toHaveBeenCalledWith(2001, 'passive')
+    // 单一数据源：始终使用被动 /usage API 返回值，忽略行内 codex 快照
     expect(wrapper.text()).toContain('5h|18|900')
     expect(wrapper.text()).toContain('7d|36|900')
   })
@@ -338,12 +338,12 @@ describe('AccountUsageCell', () => {
 
     // 手动刷新再拉一次
     expect(getUsage).toHaveBeenCalledTimes(2)
-    expect(getUsage).toHaveBeenCalledWith(2010, undefined)
-    // 单一数据源：始终使用 /usage API 值
+    expect(getUsage).toHaveBeenCalledWith(2010, 'passive')
+    // 单一数据源：始终使用被动 /usage API 值
     expect(wrapper.text()).toContain('5h|18|900')
   })
 
-  it('OpenAI OAuth 有列表 override 时不自动拉取但手动刷新会拉取', async () => {
+  it('OpenAI OAuth 有列表 override 时不自动拉取，手动刷新也交给 batch', async () => {
     getUsage.mockResolvedValue({
       five_hour: {
         utilization: 21,
@@ -388,9 +388,51 @@ describe('AccountUsageCell', () => {
     await wrapper.setProps({ manualRefreshToken: 1 })
     await flushPromises()
 
+    expect(getUsage).not.toHaveBeenCalled()
+  })
+
+  it('Kiro 有列表 override 时不自动拉取，但手动刷新会拉 active usage', async () => {
+    getUsage.mockResolvedValue({
+      kiro_usage: {
+        current: 12,
+        limit: 100,
+        percent: 12,
+        next_reset_date: '2099-03-07T12:00:00Z',
+        subscription_title: 'Kiro Pro'
+      }
+    })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2013,
+          platform: 'kiro',
+          type: 'oauth',
+          extra: {}
+        }),
+        usageOverride: null,
+        manualRefreshToken: 0
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'resetsAt', 'color'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ resetsAt }}</div>'
+          },
+          AccountQuotaInfo: true
+        }
+      }
+    })
+
+    await flushPromises()
+    expect(getUsage).not.toHaveBeenCalled()
+
+    await wrapper.setProps({ manualRefreshToken: 1 })
+    await flushPromises()
+
     expect(getUsage).toHaveBeenCalledTimes(1)
-    expect(getUsage).toHaveBeenCalledWith(2011, undefined)
-    expect(wrapper.text()).toContain('5h|21|300')
+    expect(getUsage).toHaveBeenCalledWith(2013, 'active', true)
+    expect(wrapper.text()).toContain('admin.accounts.usageWindow.kiroCredits|12|2099-03-07T12:00:00Z')
   })
 
   it('Anthropic OAuth 有列表 override 时手动刷新不回退为逐行 usage 请求', async () => {
@@ -486,7 +528,7 @@ describe('AccountUsageCell', () => {
 
 	await flushPromises()
 
-	expect(getUsage).toHaveBeenCalledWith(2002, undefined)
+	expect(getUsage).toHaveBeenCalledWith(2002, 'passive')
 	expect(wrapper.text()).toContain('5h|0|27700')
 	expect(wrapper.text()).toContain('7d|0|27700')
   })
@@ -618,7 +660,7 @@ describe('AccountUsageCell', () => {
 
 	await flushPromises()
 
-  expect(getUsage).toHaveBeenCalledWith(2004, undefined)
+  expect(getUsage).toHaveBeenCalledWith(2004, 'passive')
   expect(wrapper.text()).toContain('5h|100|106540000')
   expect(wrapper.text()).toContain('7d|100|106540000')
   })

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -435,6 +435,63 @@ describe('AccountUsageCell', () => {
     expect(wrapper.text()).toContain('admin.accounts.usageWindow.kiroCredits|12|2099-03-07T12:00:00Z')
   })
 
+  it('Grok 平台复用 5h/7d usage 窗口展示本地统计', async () => {
+    getUsage.mockResolvedValue({
+      source: 'passive',
+      five_hour: {
+        utilization: 0,
+        resets_at: null,
+        remaining_seconds: 0,
+        window_stats: {
+          requests: 4,
+          tokens: 4096,
+          cost: 0.12,
+          standard_cost: 0.12,
+          user_cost: 0.10
+        }
+      },
+      seven_day: {
+        utilization: 0,
+        resets_at: null,
+        remaining_seconds: 0,
+        window_stats: {
+          requests: 9,
+          tokens: 8192,
+          cost: 0.24,
+          standard_cost: 0.24,
+          user_cost: 0.20
+        }
+      }
+    })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2014,
+          platform: 'grok',
+          type: 'apikey',
+          extra: {}
+        })
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'windowStats'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ windowStats?.tokens }}</div>'
+          },
+          AccountQuotaInfo: true,
+          OpenAIQuotaResetCell: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(getUsage).toHaveBeenCalledWith(2014, 'passive')
+    expect(wrapper.text()).toContain('5h|0|4096')
+    expect(wrapper.text()).toContain('7d|0|8192')
+  })
+
   it('Anthropic OAuth 有列表 override 时手动刷新不回退为逐行 usage 请求', async () => {
     getUsage.mockResolvedValue({
       five_hour: {

--- a/frontend/src/components/account/usage-cells/KiroUsageCell.vue
+++ b/frontend/src/components/account/usage-cells/KiroUsageCell.vue
@@ -95,7 +95,31 @@
       </div>
     </div>
 
-    <div v-else class="text-xs text-gray-400">-</div>
+    <div v-else class="space-y-1">
+      <div class="text-xs text-gray-400">-</div>
+      <button
+        type="button"
+        class="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[9px] font-medium text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/30 transition-colors"
+        :disabled="activeQueryLoading"
+        @click="loadActiveUsage"
+      >
+        <svg
+          class="h-2.5 w-2.5"
+          :class="{ 'animate-spin': activeQueryLoading }"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+          />
+        </svg>
+        {{ t('admin.accounts.usageWindow.activeQuery') }}
+      </button>
+    </div>
   </div>
 </template>
 

--- a/frontend/src/components/account/usage-cells/useAccountUsageFetch.ts
+++ b/frontend/src/components/account/usage-cells/useAccountUsageFetch.ts
@@ -296,6 +296,6 @@ export function useAccountUsageFetch(
 }
 
 export function showUsageWindowsForAccount(account: Account): boolean {
-  if (account.platform === 'gemini' || account.platform === 'kiro') return true
+  if (account.platform === 'gemini' || account.platform === 'kiro' || account.platform === 'grok') return true
   return account.type === 'oauth' || account.type === 'setup-token'
 }

--- a/frontend/src/components/account/usage-cells/useAccountUsageFetch.ts
+++ b/frontend/src/components/account/usage-cells/useAccountUsageFetch.ts
@@ -13,6 +13,11 @@ import type { Account, AccountUsageInfo } from '@/types'
 import { buildOpenAIUsageRefreshKey } from '@/utils/accountUsageRefresh'
 import { enqueueUsageRequest } from '@/utils/usageLoadQueue'
 import type { AccountUsageCellProps } from '../accountUsageCellProps'
+import {
+  canSelfFetchUsage as accountCanSelfFetchUsage,
+  isBatchPassiveCapable,
+  usesPassiveUsageOnMount as accountUsesPassiveUsageOnMount
+} from '@/utils/accountUsageBatch.tk'
 
 // Module-level cache shared across all usage cell instances
 const _usageCache = new Map<number, { data: AccountUsageInfo; ts: number }>()
@@ -29,19 +34,7 @@ export function clearAccountUsageCache(accountId?: number) {
 const desktopViewportQuery = '(min-width: 768px)'
 
 function canFetchUsageForAccount(props: AccountUsageCellProps): boolean {
-  if (props.account.platform === 'anthropic') {
-    return props.account.type === 'oauth' || props.account.type === 'setup-token'
-  }
-  if (props.account.platform === 'gemini') {
-    return true
-  }
-  if (props.account.platform === 'antigravity') {
-    return props.account.type === 'oauth'
-  }
-  if (props.account.platform === 'openai') {
-    return props.account.type === 'oauth'
-  }
-  return false
+  return accountCanSelfFetchUsage(props.account)
 }
 
 function shouldAutoFetchUsageForAccount(props: AccountUsageCellProps): boolean {
@@ -95,13 +88,6 @@ export function useAccountUsageFetch(
 
   const shouldLazyLoadOnMobile = computed(() => {
     return shouldFetchUsage.value && !isDesktopViewport.value
-  })
-
-  const isAnthropicOAuthOrSetupToken = computed(() => {
-    return (
-      props.account.platform === 'anthropic' &&
-      (props.account.type === 'oauth' || props.account.type === 'setup-token')
-    )
   })
 
   const openAIUsageRefreshKey = computed(() => buildOpenAIUsageRefreshKey(props.account))
@@ -220,7 +206,7 @@ export function useAccountUsageFetch(
     }
 
     if (!shouldAutoLoadUsageOnMount.value) return
-    const source = isAnthropicOAuthOrSetupToken.value ? 'passive' : undefined
+    const source = accountUsesPassiveUsageOnMount(props.account) ? 'passive' : undefined
     requestAutoLoad(source)
   })
 
@@ -239,11 +225,22 @@ export function useAccountUsageFetch(
     (nextToken, prevToken) => {
       if (nextToken === prevToken) return
       if (!canFetchUsage.value) return
-      // AccountsView already refreshes Anthropic passive usage through the batch
-      // endpoint before bumping this token; do not reintroduce per-row fan-out.
-      if (props.usageOverride !== undefined && isAnthropicOAuthOrSetupToken.value) return
 
-      const source = isAnthropicOAuthOrSetupToken.value ? 'passive' : undefined
+      // Kiro: explicit 刷新 pulls live credits once (#1031). Must run before the
+      // batch-passive early return (kiro is batch-capable but not batch-only on refresh).
+      if (props.account.platform === 'kiro') {
+        _usageCache.delete(props.account.id)
+        loadActiveUsage().catch((e) => {
+          console.error('Failed to refresh kiro usage after manual refresh:', e)
+        })
+        return
+      }
+
+      // AccountsView already refreshes Anthropic/OpenAI/Kiro passive usage through the
+      // batch endpoint before bumping this token; do not reintroduce per-row fan-out.
+      if (props.usageOverride !== undefined && isBatchPassiveCapable(props.account)) return
+
+      const source = accountUsesPassiveUsageOnMount(props.account) ? 'passive' : undefined
       _usageCache.delete(props.account.id)
       loadUsage({ source, bypassCache: true }).catch((e) => {
         console.error('Failed to refresh usage after manual refresh:', e)
@@ -299,6 +296,6 @@ export function useAccountUsageFetch(
 }
 
 export function showUsageWindowsForAccount(account: Account): boolean {
-  if (account.platform === 'gemini') return true
+  if (account.platform === 'gemini' || account.platform === 'kiro') return true
   return account.type === 'oauth' || account.type === 'setup-token'
 }

--- a/frontend/src/components/admin/account/EdgeAccountPanelTk.vue
+++ b/frontend/src/components/admin/account/EdgeAccountPanelTk.vue
@@ -125,14 +125,17 @@
               <PlatformTypeBadge
                 :platform="(acct.platform as AccountPlatform)"
                 :type="(acct.type as AccountType)"
-                :plan-type="acct.subscription?.plan_type"
-                :subscription-expires-at="acct.subscription?.expires_at"
+                :plan-type="(accountVm(acct).accountLike.credentials?.plan_type as string | undefined)"
+                :subscription-expires-at="(accountVm(acct).accountLike.credentials?.subscription_expires_at as string | undefined)"
               />
               <div v-if="acct.channel_type" class="mt-0.5 text-xs text-gray-400 dark:text-gray-500">ch{{ acct.channel_type }}</div>
-              <!-- Operator-set account 到期 (the only expiry anthropic has; openai's
-                   subscription 到期 already shows in the badge above). -->
-              <div v-if="acct.expires_at" class="mt-0.5 text-[10px] leading-tight text-gray-400 dark:text-gray-500">
-                {{ t('admin.accounts.columns.expiresAt') }} {{ formatDateOnly(acct.expires_at) }}
+              <!-- Operator-set account 到期 (same field as prod list expires_at column). -->
+              <div
+                v-if="accountVm(acct).accountLike.expires_at"
+                class="mt-0.5 text-[10px] leading-tight text-gray-400 dark:text-gray-500"
+              >
+                {{ t('admin.accounts.columns.expiresAt') }}
+                {{ formatDateOnly(new Date(accountVm(acct).accountLike.expires_at! * 1000)) }}
               </div>
             </td>
             <td class="px-4 py-1.5 align-top">

--- a/frontend/src/composables/__tests__/useTkAccountUsageBatch.spec.ts
+++ b/frontend/src/composables/__tests__/useTkAccountUsageBatch.spec.ts
@@ -24,7 +24,7 @@ describe('useTkAccountUsageBatch', () => {
     getBatchPassiveUsage.mockReset()
   })
 
-  it('only sends Anthropic passive rows to the batch endpoint and suppresses active self-fetch rows', async () => {
+  it('sends passive batch rows (Anthropic, OpenAI OAuth, Kiro) and suppresses active self-fetch rows', async () => {
     getBatchPassiveUsage.mockResolvedValue({ usage: { '1': usageA } })
     const { refreshUsageBatch, usageOverrideFor } = useTkAccountUsageBatch()
 
@@ -33,29 +33,24 @@ describe('useTkAccountUsageBatch', () => {
       acct(2, 'anthropic', 'setup-token'),
       acct(3, 'anthropic', 'apikey'), // never self-fetches
       acct(4, 'gemini', 'oauth'), // active-only on manual refresh
-      acct(5, 'openai', 'oauth'), // active-only on manual refresh
-      acct(6, 'antigravity', 'oauth') // active-only on manual refresh
+      acct(5, 'openai', 'oauth'), // passive batch (codex windows from Extra)
+      acct(6, 'antigravity', 'oauth'), // active-only on manual refresh
+      acct(7, 'kiro', 'oauth') // passive batch like Anthropic
     ]
 
     await refreshUsageBatch(accounts)
 
-    // Only the two batch-capable IDs are sent upstream.
     expect(getBatchPassiveUsage).toHaveBeenCalledTimes(1)
-    expect(getBatchPassiveUsage).toHaveBeenCalledWith([1, 2])
+    expect(getBatchPassiveUsage).toHaveBeenCalledWith([1, 2, 5, 7])
 
-    // Capable rows: override defined (suppresses self-fetch). id 1 has data,
-    // id 2 omitted by server => null (still suppresses, shows "-").
     expect(usageOverrideFor(accounts[0])).toEqual(usageA)
     expect(usageOverrideFor(accounts[1])).toBeNull()
+    expect(usageOverrideFor(accounts[4])).toBeNull()
+    expect(usageOverrideFor(accounts[6])).toBeNull()
 
-    // Rows that never self-fetch usage are left alone.
     expect(usageOverrideFor(accounts[2])).toBeUndefined()
 
-    // Active-only platforms get a null override on list load, so mounting the
-    // table no longer fans out to per-row active usage probes.
     expect(usageOverrideFor(accounts[3])).toBeNull()
-    expect(usageOverrideFor(accounts[4])).toBeNull()
-    expect(usageOverrideFor(accounts[5])).toBeNull()
   })
 
   it('returns null override for a capable row before the batch resolves', () => {
@@ -67,7 +62,7 @@ describe('useTkAccountUsageBatch', () => {
 
   it('does not call the API when there are no passive batch-capable rows', async () => {
     const { refreshUsageBatch, usageOverrideFor } = useTkAccountUsageBatch()
-    const accounts = [acct(1, 'gemini', 'oauth'), acct(2, 'openai', 'oauth')]
+    const accounts = [acct(1, 'gemini', 'oauth'), acct(2, 'antigravity', 'oauth')]
     await refreshUsageBatch(accounts)
     expect(getBatchPassiveUsage).not.toHaveBeenCalled()
     expect(usageOverrideFor(accounts[0])).toBeNull()

--- a/frontend/src/composables/__tests__/useTkAccountUsageBatch.spec.ts
+++ b/frontend/src/composables/__tests__/useTkAccountUsageBatch.spec.ts
@@ -24,7 +24,7 @@ describe('useTkAccountUsageBatch', () => {
     getBatchPassiveUsage.mockReset()
   })
 
-  it('sends passive batch rows (Anthropic, OpenAI OAuth, Kiro) and suppresses active self-fetch rows', async () => {
+  it('sends passive batch rows (Anthropic, OpenAI OAuth, Kiro, Grok) and suppresses active self-fetch rows', async () => {
     getBatchPassiveUsage.mockResolvedValue({ usage: { '1': usageA } })
     const { refreshUsageBatch, usageOverrideFor } = useTkAccountUsageBatch()
 
@@ -35,18 +35,20 @@ describe('useTkAccountUsageBatch', () => {
       acct(4, 'gemini', 'oauth'), // active-only on manual refresh
       acct(5, 'openai', 'oauth'), // passive batch (codex windows from Extra)
       acct(6, 'antigravity', 'oauth'), // active-only on manual refresh
-      acct(7, 'kiro', 'oauth') // passive batch like Anthropic
+      acct(7, 'kiro', 'oauth'), // passive batch like Anthropic
+      acct(8, 'grok', 'apikey') // local 5h/7d windows from usage logs
     ]
 
     await refreshUsageBatch(accounts)
 
     expect(getBatchPassiveUsage).toHaveBeenCalledTimes(1)
-    expect(getBatchPassiveUsage).toHaveBeenCalledWith([1, 2, 5, 7])
+    expect(getBatchPassiveUsage).toHaveBeenCalledWith([1, 2, 5, 7, 8])
 
     expect(usageOverrideFor(accounts[0])).toEqual(usageA)
     expect(usageOverrideFor(accounts[1])).toBeNull()
     expect(usageOverrideFor(accounts[4])).toBeNull()
     expect(usageOverrideFor(accounts[6])).toBeNull()
+    expect(usageOverrideFor(accounts[7])).toBeNull()
 
     expect(usageOverrideFor(accounts[2])).toBeUndefined()
 

--- a/frontend/src/composables/useTkAccountUsageBatch.ts
+++ b/frontend/src/composables/useTkAccountUsageBatch.ts
@@ -5,7 +5,7 @@
  * AccountUsageCell self-fetched GET /admin/accounts/:id/usage on mount, so a
  * page of N Anthropic OAuth/SetupToken rows fired N parallel XHRs (the client
  * usageLoadQueue is a no-op pass-through). This composable fetches all visible
- * Anthropic OAuth/SetupToken rows' passive usage in ONE POST
+ * Anthropic / OpenAI OAuth / Kiro passive rows in ONE POST
  * /admin/accounts/usage/batch call, and exposes a per-row override the cell
  * renders verbatim (usageOverride !== undefined => the cell never self-fetches).
  *
@@ -18,23 +18,10 @@
 import { ref } from 'vue'
 import { adminAPI } from '@/api'
 import type { Account, AccountUsageInfo } from '@/types'
-
-// Mirrors AccountUsageCell's source='passive' mount condition: only Anthropic
-// OAuth/SetupToken rows are served by the batch passive endpoint.
-function isBatchPassiveCapable(account: Account): boolean {
-  return (
-    account.platform === 'anthropic' &&
-    (account.type === 'oauth' || account.type === 'setup-token')
-  )
-}
-
-function canSelfFetchUsage(account: Account): boolean {
-  if (isBatchPassiveCapable(account)) return true
-  if (account.platform === 'gemini') return true
-  if (account.platform === 'antigravity') return account.type === 'oauth'
-  if (account.platform === 'openai') return account.type === 'oauth'
-  return false
-}
+import {
+  canSelfFetchUsage,
+  isBatchPassiveCapable
+} from '@/utils/accountUsageBatch.tk'
 
 export function useTkAccountUsageBatch() {
   // accountID(string) -> usage. Present-with-null is a deliberate signal to the

--- a/frontend/src/utils/__tests__/edgeAccountsTk.spec.ts
+++ b/frontend/src/utils/__tests__/edgeAccountsTk.spec.ts
@@ -14,6 +14,8 @@ import {
   shouldShowEdgeAccountError,
   accountVm,
   toAccountLike,
+  parseEdgeOperatorExpiresAt,
+  edgeSubscriptionToCredentials,
   stripClassPrefix
 } from '@/utils/edgeAccounts.tk'
 import type { EdgeAccountSummary, EdgeAccountsResult } from '@/api/admin/edgeAccounts'
@@ -405,6 +407,33 @@ describe('stripClassPrefix', () => {
     })
     expect(out.opus.rate_limited_at).toBe(reset)
     expect(out.AICredits.rate_limit_reset_at).toBe(reset)
+  })
+})
+
+describe('toAccountLike subscription + operator expiry', () => {
+  it('maps edge subscription snapshot into credentials for PlatformTypeBadge parity', () => {
+    const result = toAccountLike(
+      acct({
+        subscription: { plan_type: 'plus', expires_at: '2026-12-01T00:00:00Z' }
+      })
+    )
+    expect(result.credentials).toEqual({
+      plan_type: 'plus',
+      subscription_expires_at: '2026-12-01T00:00:00Z'
+    })
+  })
+
+  it('parses operator expires_at ISO into unix seconds', () => {
+    const iso = '2026-06-01T12:00:00.000Z'
+    expect(parseEdgeOperatorExpiresAt(iso)).toBe(Math.floor(Date.parse(iso) / 1000))
+    expect(toAccountLike(acct({ expires_at: iso })).expires_at).toBe(
+      parseEdgeOperatorExpiresAt(iso)
+    )
+  })
+
+  it('leaves credentials undefined when subscription is absent', () => {
+    expect(edgeSubscriptionToCredentials(undefined)).toBeUndefined()
+    expect(toAccountLike(acct({ subscription: undefined })).credentials).toBeUndefined()
   })
 })
 

--- a/frontend/src/utils/accountUsageBatch.tk.ts
+++ b/frontend/src/utils/accountUsageBatch.tk.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared passive-usage batch eligibility (#1031 / useTkAccountUsageBatch).
+ *
+ * Single source of truth for which admin list rows are served by
+ * POST /admin/accounts/usage/batch (mirrors backend GetPassiveUsageBatch gates).
+ */
+import type { Account } from '@/types'
+
+/** Rows whose list load is satisfied by the batch passive endpoint (no mount fan-out). */
+export function isBatchPassiveCapable(account: Account): boolean {
+  if (account.platform === 'kiro') return true
+  if (account.platform === 'openai' && account.type === 'oauth') return true
+  return (
+    account.platform === 'anthropic' &&
+    (account.type === 'oauth' || account.type === 'setup-token')
+  )
+}
+
+/** Passive source on mount when the cell self-fetches (non-batch / no override path). */
+export function usesPassiveUsageOnMount(account: Account): boolean {
+  return isBatchPassiveCapable(account)
+}
+
+/** Whether AccountUsageCell may ever load usage for this account. */
+export function canSelfFetchUsage(account: Account): boolean {
+  if (isBatchPassiveCapable(account)) return true
+  if (account.platform === 'gemini') return true
+  return account.platform === 'antigravity' && account.type === 'oauth'
+}

--- a/frontend/src/utils/accountUsageBatch.tk.ts
+++ b/frontend/src/utils/accountUsageBatch.tk.ts
@@ -10,6 +10,7 @@ import type { Account } from '@/types'
 export function isBatchPassiveCapable(account: Account): boolean {
   if (account.platform === 'kiro') return true
   if (account.platform === 'openai' && account.type === 'oauth') return true
+  if (account.platform === 'grok') return true
   return (
     account.platform === 'anthropic' &&
     (account.type === 'oauth' || account.type === 'setup-token')

--- a/frontend/src/utils/edgeAccounts.tk.ts
+++ b/frontend/src/utils/edgeAccounts.tk.ts
@@ -57,6 +57,25 @@ export function shouldShowEdgeAccountError(s: EdgeAccountSummary): boolean {
  */
 const ANTHROPIC_CLASS_PREFIX = 'anthropic:class:'
 
+/** Edge DTO RFC3339 → Account unix seconds (operator-set expires_at column). */
+export function parseEdgeOperatorExpiresAt(iso?: string | null): number | null {
+  if (!iso) return null
+  const ms = Date.parse(iso)
+  if (Number.isNaN(ms)) return null
+  return Math.floor(ms / 1000)
+}
+
+/** Credential-free edge subscription → admin Account credentials projection. */
+export function edgeSubscriptionToCredentials(
+  subscription?: EdgeAccountSummary['subscription']
+): Record<string, unknown> | undefined {
+  if (!subscription) return undefined
+  const creds: Record<string, unknown> = {}
+  if (subscription.plan_type) creds.plan_type = subscription.plan_type
+  if (subscription.expires_at) creds.subscription_expires_at = subscription.expires_at
+  return Object.keys(creds).length > 0 ? creds : undefined
+}
+
 export function stripClassPrefix(
   m: Record<string, { rate_limited_at?: string; rate_limit_reset_at?: string; reason?: string }>
 ): Record<string, { rate_limited_at: string; rate_limit_reset_at: string }> {
@@ -78,9 +97,9 @@ export function stripClassPrefix(
  * Adapts a credential-free EdgeAccountSummary into the admin `Account` shape so
  * the read-only Edge Accounts page can reuse AccountCapacityCell verbatim (the
  * cell only reads capacity/gauge fields). Missing-but-required Account fields are
- * filled with inert defaults; `expires_at` is dropped (the edge DTO carries it as
- * an RFC3339 string while Account types it as a unix number, and the cell doesn't
- * read it). No side effects — pure mapping.
+ * filled with inert defaults. Maps edge subscription snapshot + operator expiry into
+ * the same credentials / expires_at fields the prod account list uses
+ * (PlatformTypeBadge + expires_at column). No side effects — pure mapping.
  */
 export function toAccountLike(s: EdgeAccountSummary): Account {
   return {
@@ -89,6 +108,7 @@ export function toAccountLike(s: EdgeAccountSummary): Account {
     platform: s.platform as Account['platform'],
     type: s.type as Account['type'],
     channel_type: s.channel_type,
+    credentials: edgeSubscriptionToCredentials(s.subscription),
     proxy_id: null,
     concurrency: s.concurrency,
     current_concurrency: s.current_concurrency,
@@ -97,7 +117,7 @@ export function toAccountLike(s: EdgeAccountSummary): Account {
     status: s.status as Account['status'],
     error_message: s.error_message ?? null,
     last_used_at: s.last_used_at ?? null,
-    expires_at: null,
+    expires_at: parseEdgeOperatorExpiresAt(s.expires_at),
     auto_pause_on_expired: false,
     created_at: s.created_at,
     updated_at: s.created_at,

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -713,7 +713,7 @@ const usageManualRefreshToken = ref(0)
 const kiroRefreshToken = ref(0)
 
 // TK: batch passive-usage for the list, replacing the per-row /usage fan-out for
-// Anthropic OAuth/SetupToken rows. The cell renders usageOverrideFor(row) and
+// Anthropic / OpenAI OAuth / Kiro rows. The cell renders usageOverrideFor(row) and
 // never self-fetches when an override is present (see useTkAccountUsageBatch).
 const { usageOverrideFor: accountUsageOverrideFor, refreshUsageBatch } = useTkAccountUsageBatch()
 
@@ -1173,9 +1173,9 @@ const refreshAccountsIncrementally = async () => {
 const handleManualRefresh = async () => {
   await load()
   await refreshEdges({ force: true })
-  // load() already starts the batch passive-usage refresh for Anthropic rows
-  // (override path). Bump the token so the residual self-fetch platforms
-  // (gemini/antigravity/openai cells) also refresh on explicit user refresh.
+  // load() already starts the batch passive-usage refresh for Anthropic/OpenAI/Kiro
+  // rows (override path). Bump the token so the residual self-fetch platforms
+  // (gemini/antigravity cells) also refresh on explicit user refresh.
   usageManualRefreshToken.value += 1
   // Edge kiro accounts have no organic passive refresh (credits come only from an
   // explicit CodeWhisperer call), so an explicit user refresh also pulls live kiro

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -976,9 +976,10 @@
         "export function usesPassiveUsageOnMount(account: Account): boolean",
         "export function canSelfFetchUsage(account: Account): boolean",
         "account.platform === 'kiro'",
-        "account.platform === 'openai' && account.type === 'oauth'"
+        "account.platform === 'openai' && account.type === 'oauth'",
+        "account.platform === 'grok'"
       ],
-      "rationale": "Single source of truth for which admin list rows are served by POST /admin/accounts/usage/batch (Anthropic OAuth/SetupToken, OpenAI OAuth, Kiro). Shared by useTkAccountUsageBatch and useAccountUsageFetch so batch eligibility and cell self-fetch gates cannot drift. Dropping or narrowing this module reintroduces per-row /usage fan-out or blanks passive kiro/openai rows on edge/prod account lists."
+      "rationale": "Single source of truth for which admin list rows are served by POST /admin/accounts/usage/batch (Anthropic OAuth/SetupToken, OpenAI OAuth, Kiro, Grok). Shared by useTkAccountUsageBatch and useAccountUsageFetch so batch eligibility and cell self-fetch gates cannot drift. Dropping or narrowing this module reintroduces per-row /usage fan-out or blanks passive kiro/openai/grok rows on edge/prod account lists."
     },
     {
       "path": "frontend/src/composables/useTkAccountUsageBatch.ts",
@@ -990,7 +991,7 @@
         "function usageOverrideFor(account: Account): AccountUsageInfo | null | undefined",
         "return key in usageByAccountId.value ? usageByAccountId.value[key] : null"
       ],
-      "rationale": "TK composable that batches Anthropic / OpenAI OAuth / Kiro passive usage for the admin accounts list and exposes a per-row usageOverride (defined => the cell never self-fetches). Owns the batch API call + race guard; platform scoping lives in accountUsageBatch.tk.ts. If deleted or narrowed back to passive-only rows, the accounts list regresses to per-row /usage XHRs. Pins the composable, the batch API call, the shared scoping import, the list-owned override function, and the present-with-null sentinel."
+      "rationale": "TK composable that batches Anthropic / OpenAI OAuth / Kiro / Grok passive usage for the admin accounts list and exposes a per-row usageOverride (defined => the cell never self-fetches). Owns the batch API call + race guard; platform scoping lives in accountUsageBatch.tk.ts. If deleted or narrowed back to passive-only rows, the accounts list regresses to per-row /usage XHRs. Pins the composable, the batch API call, the shared scoping import, the list-owned override function, and the present-with-null sentinel."
     },
     {
       "path": "frontend/src/views/admin/AccountsView.vue",

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -530,6 +530,8 @@
       "path": "frontend/src/utils/edgeAccounts.tk.ts",
       "must_contain": [
         "export function toAccountLike",
+        "export function edgeSubscriptionToCredentials",
+        "parseEdgeOperatorExpiresAt(s.expires_at)",
         "export function stripClassPrefix",
         "export function toUsageInfo",
         "export function accountVm",
@@ -602,7 +604,7 @@
         "function canFetchUsageForAccount(props: AccountUsageCellProps): boolean",
         "function shouldAutoFetchUsageForAccount(props: AccountUsageCellProps): boolean",
         "if (props.usageOverride !== undefined) return false",
-        "if (props.usageOverride !== undefined && isAnthropicOAuthOrSetupToken.value) return"
+        "if (props.usageOverride !== undefined && isBatchPassiveCapable(props.account)) return"
       ],
       "rationale": "TK injection point (fetch short-circuit): when usageOverride is provided (even null), skip mount/lazy self-fetch and render injected usage verbatim. The explicit manual-refresh guard prevents Anthropic OAuth/SetupToken rows owned by the list batch loader from falling back to per-row /usage after a refresh token bump. Split from AccountUsageCell.vue (B6 perf) — dropping these guards would re-enable per-row /usage fetches on Edge Accounts overview or the admin accounts list and hammer prod."
     },
@@ -968,16 +970,27 @@
       "rationale": "PR #803: the upstream-shaped axios response interceptor must reject with createApiError(...) (a real Error), NOT a plain object. This is the load-bearing injection point — an upstream merge that restores the original `Promise.reject({ status, code, message })` plain-object shape would compile fine and silently reintroduce the app-wide [object Object] rendering bug at every `e instanceof Error ? e.message : String(e)` call site. Anchoring the createApiError( call makes that revert fail the merge gate instead of shipping silently."
     },
     {
+      "path": "frontend/src/utils/accountUsageBatch.tk.ts",
+      "must_contain": [
+        "export function isBatchPassiveCapable(account: Account): boolean",
+        "export function usesPassiveUsageOnMount(account: Account): boolean",
+        "export function canSelfFetchUsage(account: Account): boolean",
+        "account.platform === 'kiro'",
+        "account.platform === 'openai' && account.type === 'oauth'"
+      ],
+      "rationale": "Single source of truth for which admin list rows are served by POST /admin/accounts/usage/batch (Anthropic OAuth/SetupToken, OpenAI OAuth, Kiro). Shared by useTkAccountUsageBatch and useAccountUsageFetch so batch eligibility and cell self-fetch gates cannot drift. Dropping or narrowing this module reintroduces per-row /usage fan-out or blanks passive kiro/openai rows on edge/prod account lists."
+    },
+    {
       "path": "frontend/src/composables/useTkAccountUsageBatch.ts",
       "must_contain": [
         "export function useTkAccountUsageBatch(",
         "getBatchPassiveUsage(",
         "isBatchPassiveCapable",
-        "function canSelfFetchUsage(account: Account): boolean",
+        "from '@/utils/accountUsageBatch.tk'",
         "function usageOverrideFor(account: Account): AccountUsageInfo | null | undefined",
         "return key in usageByAccountId.value ? usageByAccountId.value[key] : null"
       ],
-      "rationale": "TK composable that batches Anthropic OAuth/SetupToken passive usage for the admin accounts list and exposes a per-row usageOverride (defined => the cell never self-fetches). Owns the batch API call + race guard + platform scoping; canSelfFetchUsage deliberately returns null overrides for active-only fetchable platforms until explicit user refresh, suppressing the historical mount-time N parallel /usage XHRs. If deleted or narrowed back to passive-only rows, the accounts list regresses to per-row /usage XHRs. Pins the composable, the batch API call, the scoping predicate, the list-owned override function, and the present-with-null sentinel."
+      "rationale": "TK composable that batches Anthropic / OpenAI OAuth / Kiro passive usage for the admin accounts list and exposes a per-row usageOverride (defined => the cell never self-fetches). Owns the batch API call + race guard; platform scoping lives in accountUsageBatch.tk.ts. If deleted or narrowed back to passive-only rows, the accounts list regresses to per-row /usage XHRs. Pins the composable, the batch API call, the shared scoping import, the list-owned override function, and the present-with-null sentinel."
     },
     {
       "path": "frontend/src/views/admin/AccountsView.vue",
@@ -1034,7 +1047,7 @@
         "adminAPI.edgeAccounts.clearRateLimit",
         "shouldShowEdgeAccountError(acct)",
         "PlatformTypeBadge",
-        ":subscription-expires-at=\"acct.subscription?.expires_at\"",
+        ":subscription-expires-at=\"(accountVm(acct).accountLike.credentials?.subscription_expires_at",
         "refreshKiroToken",
         "fetchActiveUsageInto"
       ],

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -108,6 +108,16 @@
       "rationale": "grok's membership in GATEWAY_PLATFORMS + OPENAI_COMPAT_PLATFORMS + GROUP_DISPATCH_CONFIG_PLATFORMS + the exhaustive Record<AccountPlatform> color maps. OPENAI_COMPAT_PLATFORMS must mirror the backend engine.OpenAICompatPlatforms() (preflight newapi compat-pool drift guard watches the lockstep); removing 'grok' drops it from the admin platform pickers/badges and breaks the pool mirror."
     },
     {
+      "path": "backend/internal/service/account_usage_service.go",
+      "must_contain": ["if account.IsGrok() {", "return s.buildLocalWindowUsage(ctx, account), nil", "func (s *AccountUsageService) buildLocalWindowUsage"],
+      "rationale": "Grok usage-window support must not fall through to the Anthropic OAuth usage API. The admin usage endpoint returns local 5h/7d billing windows for grok so the accounts table can show operator-visible activity without inventing an upstream xAI quota percentage."
+    },
+    {
+      "path": "frontend/src/components/account/AccountUsageCell.vue",
+      "must_contain": ["account.platform === 'grok'", "return OpenAIUsageCell"],
+      "rationale": "Grok reuses the OpenAI-style 5h/7d UsageProgressBar rendering because the backend returns the same AccountUsageInfo five_hour/seven_day shape. Dropping this branch hides grok usage windows even though the backend provides them."
+    },
+    {
       "path": "frontend/src/composables/usePlatformOptions.ts",
       "must_contain": ["grok:"],
       "rationale": "grok's brand label (PLATFORM_LABELS, exhaustive Record<AccountPlatform>). Without it typecheck fails and the platform renders an untranslated value."


### PR DESCRIPTION
## 摘要

- 补全 #1031 前端遗漏：`useTkAccountUsageBatch` 与后端 `GetPassiveUsageBatch` 对齐，纳入 **Kiro + OpenAI OAuth + Grok** passive 用量；edge 本机 `/admin/accounts` 不再长期显示 `-`。
- 新增 `accountUsageBatch.tk.ts` 作为 batch/self-fetch 单一规则源；`toAccountLike` 映射 edge 订阅快照与运维到期，**EdgeAccountPanelTk** 与 **AccountsView** 展示同源。
- 修复 Kiro 手动刷新被 batch 早退挡住的问题；Kiro 空态增加「查询」按钮；Grok 展示本地 5h/7d usage log 窗口。
- 已 merge `main`（含 #1033 tier 菜单 gate），解决 `frontend-source.json` 冲突并重建 embedded dist。

## 风险

- 常规风险，账号用量展示路径扩展；无 API/Schema 变更。
- OpenAI OAuth 列表加载改为 batch passive；Grok 仅显示本地 billing window stats，不调用上游 quota API。
- sentinel-registry-reviewed：已更新 `scripts/sentinels/grok.json` 与 `scripts/sentinels/frontend-tk.json`。

## 验证

- `./scripts/preflight.sh` PASS（merge 后本地已跑）
- CI 待 merge commit 重跑后验收
- `pnpm exec vitest run src/components/account/__tests__/AccountUsageCell.spec.ts src/composables/__tests__/useTkAccountUsageBatch.spec.ts`
- `go test -tags=unit ./internal/service -run 'TestGetPassiveUsageBatch_IncludesGrokLocalWindows|TestAccountUsageService_GetUsage_GrokUsesLocalWindowStats'`

## 提交

- fef413c88 fix(accounts): 对齐 #1031 订阅/用量在 edge 面板与本机列表的双路径展示
- 7c4992810 test(accounts): lock passive batch usage refresh semantics
- f367b2b95 feat(accounts): surface grok usage windows
- 74ac3b35e test(accounts): keep grok usage tests in unit build
- 9547c3e8e merge: resolve main into fix/1031-account-usage-ui-parity

最新提交：9547c3e8e
