### PR TITLE
fix(accounts): 仅对 anthropic OAuth/setup-token 账号展示「设置 Tier」

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 514,
-  "hash": "b373093058cceb1fa85e4e2fd1c654ece02dbcc49b3e4d9a40388912b32b8f9d",
+  "hash": "b3029d128905394866b96ef5930e8bc2c6d02f97959901dcad25b86367823a85",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/admin/account/AccountActionMenu.vue
+++ b/frontend/src/components/admin/account/AccountActionMenu.vue
@@ -36,7 +36,7 @@
               <Icon name="shield" size="sm" />
               {{ t('admin.accounts.setPrivacy') }}
             </button>
-            <button v-if="isAnthropic" @click="$emit('set-tier', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-amber-600 hover:bg-gray-100 dark:hover:bg-dark-700">
+            <button v-if="canSetTier" @click="$emit('set-tier', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-amber-600 hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="chart" size="sm" />
               {{ t('admin.accounts.setTierDialog.menuItem') }}
             </button>
@@ -86,7 +86,16 @@ const hasRecoverableState = computed(() => {
 const isAntigravityOAuth = computed(() => props.account?.platform === 'antigravity' && props.account?.type === 'oauth')
 const isOpenAIOAuth = computed(() => props.account?.platform === 'openai' && props.account?.type === 'oauth')
 const supportsPrivacy = computed(() => isAntigravityOAuth.value || isOpenAIOAuth.value)
-const isAnthropic = computed(() => props.account?.platform === 'anthropic')
+// Tier (5h window / session control) only applies to anthropic OAUTH and
+// setup-token accounts — mirrors backend AccountTierService.applyTier, which
+// rejects api-key / mirror-stub accounts (e.g. prod cc-<edge> stubs whose
+// concurrency is reconciler-mirrored, not tier-driven). Without this the menu
+// offered "设置 Tier" on stubs where the apply call always errors out.
+const canSetTier = computed(
+  () =>
+    props.account?.platform === 'anthropic' &&
+    (props.account?.type === 'oauth' || props.account?.type === 'setup-token')
+)
 const hasQuotaLimit = computed(() => {
   return (props.account?.type === 'apikey' || props.account?.type === 'bedrock') && (
     (props.account?.quota_limit ?? 0) > 0 ||

--- a/frontend/src/components/admin/account/__tests__/AccountActionMenu.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountActionMenu.spec.ts
@@ -1,0 +1,60 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import AccountActionMenu from '../AccountActionMenu.vue'
+import type { Account } from '@/types'
+
+// t() returns the key verbatim so we can locate the "设置 Tier" item by its key.
+const TIER_ITEM_KEY = 'admin.accounts.setTierDialog.menuItem'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key })
+}))
+
+function makeAccount(partial: Partial<Account>): Account {
+  return {
+    id: 1,
+    name: 'acc',
+    platform: 'anthropic',
+    type: 'oauth',
+    ...partial
+  } as Account
+}
+
+function mountMenu(account: Account) {
+  return mount(AccountActionMenu, {
+    props: {
+      show: true,
+      account,
+      position: { top: 0, left: 0 }
+    },
+    global: {
+      // Render Teleport content inline so find() can see it; stub Icon.
+      stubs: { Teleport: true, Icon: true }
+    }
+  })
+}
+
+function hasTierItem(account: Account): boolean {
+  const wrapper = mountMenu(account)
+  return wrapper.findAll('button').some(b => b.text().includes(TIER_ITEM_KEY))
+}
+
+describe('AccountActionMenu — 设置 Tier gating', () => {
+  it('shows tier action for anthropic oauth accounts', () => {
+    expect(hasTierItem(makeAccount({ platform: 'anthropic', type: 'oauth' }))).toBe(true)
+  })
+
+  it('shows tier action for anthropic setup-token accounts', () => {
+    expect(hasTierItem(makeAccount({ platform: 'anthropic', type: 'setup-token' }))).toBe(true)
+  })
+
+  it('hides tier action for anthropic api-key mirror stubs (e.g. prod cc-<edge>)', () => {
+    // Backend AccountTierService.applyTier rejects api-key accounts; the menu
+    // must not offer an action that always errors out.
+    expect(hasTierItem(makeAccount({ platform: 'anthropic', type: 'apikey' }))).toBe(false)
+  })
+
+  it('hides tier action for non-anthropic accounts', () => {
+    expect(hasTierItem(makeAccount({ platform: 'openai', type: 'oauth' }))).toBe(false)
+  })
+})

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -459,6 +459,14 @@
       "rationale": "TK-only modal for the admin 'Set Tier' action. Thin template that renders the tier options and the local-deployment-only scope warning (applying a tier writes ONLY this deployment's DB; fleet fan-out still needs the ops/anthropic pipeline). Guards against silent upstream-merge deletion."
     },
     {
+      "path": "frontend/src/components/admin/account/AccountActionMenu.vue",
+      "must_contain": [
+        "canSetTier",
+        "props.account?.type === 'oauth' || props.account?.type === 'setup-token'"
+      ],
+      "rationale": "TK-only '设置 Tier' menu entry point lives in this upstream-shaped action menu. The canSetTier gate restricts the action to platform=anthropic AND type in {oauth, setup-token}, mirroring backend AccountTierService.applyTier — which rejects api-key / mirror-stub accounts (e.g. prod cc-<edge> stubs whose concurrency is reconciler-mirrored, not tier-driven). Without this anchor an upstream merge could silently revert the gate to a broader condition (e.g. any anthropic account), re-exposing a tier action that always errors out on stubs. The type-restriction substring is the load-bearing semantic; pinning it makes the regression a hard CI failure instead of a silent clobber. Companion regression test: AccountActionMenu.spec.ts."
+    },
+    {
       "path": "frontend/src/api/admin/tier.ts",
       "must_contain": [
         "/admin/tiers",


### PR DESCRIPTION
## 摘要

prod 上的 anthropic 镜像 stub（`platform=anthropic, type=apikey`，例如 `cc-us4` / `cc-<edge>`）在 admin 账号卡操作菜单里**仍能看到并点开「设置 Tier」**，但这类 stub 不该走 tier——它们的 `concurrency` 由后端 surface-C reconciler 从对应 edge 的 Σ schedulable 并发**自动镜像**写入（`reconcileConcurrencyMirror`），tier（5h window / session 控制）只对真正的 OAuth 容量账号有意义。

后端其实**已正确拒绝**：`AccountTierService.applyTier` 校验 `platform=anthropic` 且 `type ∈ {oauth, setup-token}`，否则返回 `tier does not apply to api-key / mirror-stub accounts`。但前端 `AccountActionMenu.vue` 的按钮仅以 `isAnthropic`（任意 anthropic 账号）作门禁，导致 stub 卡上仍渲染该入口，点击后 apply 必然报错——一个**永远会失败的操作**暴露在 UI。

本 PR 把门禁从 `isAnthropic` 收紧为 `canSetTier`：`platform=anthropic` 且 `type ∈ {oauth, setup-token}`，与后端 `IsAnthropicOAuthOrSetupToken` 语义对齐；并为该门禁补 frontend-tk sentinel 锚点防上游 merge 静默回退。

## 风险

低。纯前端门禁收紧，**无后端行为改动**，不删除任何 upstream 符号。仅隐藏一个本就会报错的菜单项；OAuth / setup-token 账号的 tier 入口不受影响。`AccountActionMenu.vue` 是 upstream-shaped 文件，本 PR 通过新增 sentinel 锚点（`canSetTier` + type 限制语义）满足 upstream-override-marker 的 verified sentinel coverage，无需 PR-body marker，且把「门禁被上游回退」从 silent clobber 升级为 CI 硬失败。已重建嵌入 dist 并刷新 `frontend-source.json` freshness manifest。

## 验证

- `pnpm lint:check` / `pnpm typecheck` 通过
- `vitest run AccountActionMenu.spec.ts` 4/4 通过（oauth/setup-token 展示，apikey/非 anthropic 隐藏）
- `pnpm build` 重建嵌入 dist + 写 `frontend-source.json`
- `check-frontend-tk.py` 113/113 intact（含新增锚点）
- `upstream-override-marker.py --base origin/main`：verified coverage
- `scripts/preflight.sh` 全绿

## 提交

```
5fdf8cb61 chore(sentinels): pin AccountActionMenu 设置 Tier 门禁防上游覆盖
8d6533674 fix(accounts): 仅对 anthropic OAuth/setup-token 账号展示「设置 Tier」
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

最新提交：5fdf8cb61
