### PR TITLE
/pricing「授权分组」列 + 点击建 key 深链

### DIFF
--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -193,6 +193,25 @@ type MePricingModel struct {
 	ContextWindow   int            `json:"context_window,omitempty"`
 	MaxOutputTokens int            `json:"max_output_tokens,omitempty"`
 	Capabilities    []string       `json:"capabilities"`
+	// AuthorizedGroups lists the caller's accessible groups (exclusive + public)
+	// that can serve this model — the "授权分组" column on the /pricing "my" view.
+	// Lets a user see at a glance which group/key to use, and (frontend) deep-link
+	// to /keys to create a key prefilled with that group. Empty/omitted on the
+	// public catalog. Sorted: target group first, then exclusive, then by name.
+	AuthorizedGroups []MePricingModelGroup `json:"authorized_groups,omitempty"`
+}
+
+// MePricingModelGroup is a per-model reference to one accessible group that can
+// serve the model. A trimmed MePricingGroupRef (no per-key flags) — just what the
+// "授权分组" column + create-key deep-link need.
+type MePricingModelGroup struct {
+	ID               int64   `json:"id"`
+	Name             string  `json:"name"`
+	Platform         string  `json:"platform"`
+	IsExclusive      bool    `json:"is_exclusive"`
+	IsCurrentForKey  bool    `json:"is_current_for_key"`
+	RateMultiplier   float64 `json:"rate_multiplier"`
+	SubscriptionType string  `json:"subscription_type,omitempty"`
 }
 
 // MePricingPrice mirrors the "your price" view in USD per 1k tokens (or
@@ -379,6 +398,10 @@ func (s *MePricingCatalogService) BuildForUser(
 	// pricing 页是官方定价目录；真实计费在网关按 effective 倍率执行，不受此影响。
 	const officialRate = 1.0
 	models := s.buildModelsForGroup(ctx, targetGroup, officialRate)
+
+	// 「授权分组」列：对每个模型标注该用户可访问分组中能服务它的分组集合，
+	// 方便用户看清该用什么 key/分组（前端可点击直达建 key）。
+	models = s.attachAuthorizedGroups(ctx, models, accessibleGroups, userRates, targetGroupID, opts.HideUserRateOverrides)
 
 	// HideUserRateOverrides：倍率提示字段回落到分组默认值（前端已不再渲染这些
 	// 字段——pricing 页与倍率彻底脱钩——但保留 #693 的口径以稳住 DTO 与测试）。
@@ -570,6 +593,77 @@ func (s *MePricingCatalogService) buildModelsForGroup(
 
 	sort.Slice(out, func(i, j int) bool { return out[i].ModelID < out[j].ModelID })
 	return out
+}
+
+// attachAuthorizedGroups fills each model's AuthorizedGroups with the accessible
+// groups that can serve it. It reuses buildModelsForGroup per accessible group —
+// the exact channel + account-fallback serving logic — and inverts to
+// model_id -> []group, so the column can never diverge from what the gateway
+// actually schedules. K = len(accessibleGroups) is a single user's authorized
+// group count (small); BuildPublicCatalog is mtime-cached so the repeated
+// metadata join is cheap, and the target group's rows are reused (not rebuilt).
+// Rate=1.0 because only the served model_id SET matters here, not the price.
+func (s *MePricingCatalogService) attachAuthorizedGroups(
+	ctx context.Context,
+	models []MePricingModel,
+	accessibleGroups []Group,
+	userRates map[int64]float64,
+	targetGroupID int64,
+	hideOverrides bool,
+) []MePricingModel {
+	if s == nil || len(models) == 0 || len(accessibleGroups) == 0 {
+		return models
+	}
+	byModel := make(map[string][]MePricingModelGroup, len(models))
+	for i := range accessibleGroups {
+		g := accessibleGroups[i]
+		rate := g.RateMultiplier
+		if r, ok := userRates[g.ID]; ok && !hideOverrides {
+			rate = r
+		}
+		ref := MePricingModelGroup{
+			ID:               g.ID,
+			Name:             g.Name,
+			Platform:         g.Platform,
+			IsExclusive:      g.IsExclusive,
+			IsCurrentForKey:  g.ID == targetGroupID,
+			RateMultiplier:   rate,
+			SubscriptionType: g.SubscriptionType,
+		}
+		if g.ID == targetGroupID {
+			// Reuse the already-built target rows instead of rebuilding them.
+			for j := range models {
+				byModel[models[j].ModelID] = append(byModel[models[j].ModelID], ref)
+			}
+			continue
+		}
+		for _, m := range s.buildModelsForGroup(ctx, g, 1.0) {
+			byModel[m.ModelID] = append(byModel[m.ModelID], ref)
+		}
+	}
+	for i := range models {
+		groups := byModel[models[i].ModelID]
+		if len(groups) == 0 {
+			continue
+		}
+		sortAuthorizedGroups(groups)
+		models[i].AuthorizedGroups = groups
+	}
+	return models
+}
+
+// sortAuthorizedGroups orders the per-model group badges deterministically:
+// the current/target group first, then exclusive groups, then by name.
+func sortAuthorizedGroups(g []MePricingModelGroup) {
+	sort.SliceStable(g, func(i, j int) bool {
+		if g[i].IsCurrentForKey != g[j].IsCurrentForKey {
+			return g[i].IsCurrentForKey
+		}
+		if g[i].IsExclusive != g[j].IsExclusive {
+			return g[i].IsExclusive
+		}
+		return g[i].Name < g[j].Name
+	})
 }
 
 // fillAccountFallback inserts account-derived menu rows for each

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -711,6 +711,59 @@ func TestBuildForUser_ChannelAndAccount_ChannelWins(t *testing.T) {
 	assert.InDelta(t, 0.0025, *byID["gpt-4o"].YourPrice.InputPer1K, 1e-9, "gpt-4o is account-only — catalog 0.0025 × 1.0 rate")
 }
 
+// TestBuildForUser_AuthorizedGroups_CrossGroup pins the "授权分组" column: each
+// model's AuthorizedGroups lists every accessible group that can serve it (not
+// just the target group), so the user can see which key/group to use. Ordering:
+// current/target group first, then exclusive, then by name.
+func TestBuildForUser_AuthorizedGroups_CrossGroup(t *testing.T) {
+	gTarget := mkGroupForMe(30, "GPT专属", "openai", 1.0)
+	gTarget.IsExclusive = true
+	gOther := mkGroupForMe(31, "GPT公开", "openai", 1.0) // public
+	k1 := mkKeyForMe(1, 7, "gpt-key", ptrI(30))
+	// gpt-5 served by BOTH groups; gpt-a only by the target group.
+	chShared := mkChannelWithModel(100, "shared-ch",
+		[]AvailableGroupRef{{ID: 30, Platform: "openai"}, {ID: 31, Platform: "openai"}},
+		[]SupportedModel{mkSupportedModel("gpt-5", "openai", mkPricing(0.001, 0.002, 0))},
+	)
+	chTargetOnly := mkChannelWithModel(101, "target-ch",
+		[]AvailableGroupRef{{ID: 30, Platform: "openai"}},
+		[]SupportedModel{mkSupportedModel("gpt-a", "openai", mkPricing(0.001, 0.002, 0))},
+	)
+	catalog := &PublicCatalogResponse{Data: []PublicCatalogModel{
+		mkPublicCatalogModel("gpt-5", "OpenAI", 0.001, 0.002, 0),
+		mkPublicCatalogModel("gpt-a", "OpenAI", 0.001, 0.002, 0),
+	}}
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gTarget, gOther}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{chShared, chTargetOnly}},
+		&fakeCatalogProvider{resp: catalog},
+		&fakeAccountSource{},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	byID := map[string]MePricingModel{}
+	for _, m := range resp.Models {
+		byID[m.ModelID] = m
+	}
+
+	// gpt-5 is served by the target group AND the other group → both listed,
+	// current/exclusive target first.
+	g5, ok := byID["gpt-5"]
+	require.True(t, ok)
+	require.Len(t, g5.AuthorizedGroups, 2, "gpt-5 served by both accessible groups")
+	assert.Equal(t, int64(30), g5.AuthorizedGroups[0].ID, "current/target group sorts first")
+	assert.True(t, g5.AuthorizedGroups[0].IsCurrentForKey)
+	assert.True(t, g5.AuthorizedGroups[0].IsExclusive, "target group is exclusive")
+	assert.Equal(t, int64(31), g5.AuthorizedGroups[1].ID)
+	assert.False(t, g5.AuthorizedGroups[1].IsCurrentForKey)
+
+	// gpt-a is only on the target group → single-group column.
+	ga, ok := byID["gpt-a"]
+	require.True(t, ok)
+	require.Len(t, ga.AuthorizedGroups, 1)
+	assert.Equal(t, int64(30), ga.AuthorizedGroups[0].ID)
+}
+
 // TestBuildForUser_AccountWhitelist_VendorPrefix exercises reuse of
 // stripVendorPrefixForCatalogLookup (PR #326). An account whitelisting an
 // OpenRouter-style "<vendor>/<model>" must still resolve to the LiteLLM

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 515,
-  "hash": "7528e80444c19f90c10afc022ce618e97cb374df344d3531634765f90ac41f5e",
+  "hash": "749e0a9aa0b1364585f24273d76ef08ea7f10e8f376c5f98003ce6da44c39517",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/me-pricing.ts
+++ b/frontend/src/api/me-pricing.ts
@@ -53,6 +53,19 @@ export interface MePricingTier {
   cache_read_per_1k?: number
 }
 
+/** One accessible group that can serve a given model — the "授权分组" column.
+ *  Trimmed group ref (no per-key flags) for the per-model badge + create-key
+ *  deep-link. Absent on the public catalog. */
+export interface MePricingModelGroup {
+  id: number
+  name: string
+  platform: string
+  is_exclusive: boolean
+  is_current_for_key: boolean
+  rate_multiplier: number
+  subscription_type?: string
+}
+
 export interface MePricingModel {
   model_id: string
   vendor?: string
@@ -61,6 +74,9 @@ export interface MePricingModel {
   context_window?: number
   max_output_tokens?: number
   capabilities: string[]
+  /** Accessible groups (exclusive + public) that can serve this model.
+   *  Only present on the authenticated "my" view; empty/omitted publicly. */
+  authorized_groups?: MePricingModelGroup[]
 }
 
 export interface MePricingTargetGroup {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -92,7 +92,12 @@ export default {
       noKeyHint: 'You have no active API keys yet — create one in the console first.',
       columns: {
         input: 'Input (official price)',
-        output: 'Output (official price)'
+        output: 'Output (official price)',
+        authorizedGroups: 'Authorized Groups'
+      },
+      authorizedGroups: {
+        createKeyHint: 'Create an API key in {group}',
+        exclusive: 'exclusive'
       },
       empty: {
         noAccess: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -90,7 +90,12 @@ export default {
       noKeyHint: '你还没有可用的 API Key，先去控制台创建一个。',
       columns: {
         input: '输入（官方单价）',
-        output: '输出（官方单价）'
+        output: '输出（官方单价）',
+        authorizedGroups: '授权分组'
+      },
+      authorizedGroups: {
+        createKeyHint: '在 {group} 创建 API Key',
+        exclusive: '专属'
       },
       empty: {
         noAccess: {

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -334,6 +334,13 @@
                     >
                       {{ t('pricing.columns.capabilities') }}
                     </th>
+                    <th
+                      v-if="viewMode === 'my'"
+                      scope="col"
+                      class="sticky top-0 z-40 min-w-[12rem] bg-gray-50 px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
+                    >
+                      {{ t('pricing.my.columns.authorizedGroups') }}
+                    </th>
                   </tr>
                 </thead>
                 <tbody
@@ -450,6 +457,34 @@
                         >
                       </div>
                     </td>
+                    <td v-if="viewMode === 'my'" class="px-3 py-3 align-top">
+                      <div class="flex flex-wrap gap-1.5">
+                        <button
+                          v-for="g in row.authorizedGroups || []"
+                          :key="g.id"
+                          type="button"
+                          :title="t('pricing.my.authorizedGroups.createKeyHint', { group: g.name })"
+                          class="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium transition-colors"
+                          :class="[
+                            g.is_exclusive
+                              ? 'border-primary-200 bg-primary-50 text-primary-700 hover:bg-primary-100 dark:border-primary-700/50 dark:bg-primary-900/30 dark:text-primary-200 dark:hover:bg-primary-900/50'
+                              : 'border-gray-200 bg-gray-50 text-gray-600 hover:bg-gray-100 dark:border-dark-700 dark:bg-dark-800/60 dark:text-dark-300 dark:hover:bg-dark-700',
+                            g.is_current_for_key ? 'ring-1 ring-primary-400/60' : ''
+                          ]"
+                          @click="onCreateKeyForGroup(g)"
+                        >
+                          <span>{{ g.name }}</span>
+                          <span v-if="g.is_exclusive" class="text-[10px] opacity-70">{{
+                            t('pricing.my.authorizedGroups.exclusive')
+                          }}</span>
+                        </button>
+                        <span
+                          v-if="!row.authorizedGroups || row.authorizedGroups.length === 0"
+                          class="text-xs text-gray-400"
+                          >—</span
+                        >
+                      </div>
+                    </td>
                   </tr>
                 </tbody>
               </table>
@@ -497,11 +532,13 @@
  */
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import { getPublicPricing, type PublicCatalogResponse } from '@/api/pricing'
 import {
   getMePricingCatalog,
   type MePricingCatalogResponse,
-  type MePricingGroupRef
+  type MePricingGroupRef,
+  type MePricingModelGroup
 } from '@/api/me-pricing'
 import Icon from '@/components/icons/Icon.vue'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
@@ -515,6 +552,13 @@ import {
 import { exportPricingCsv } from '@/composables/useTkPricingExport'
 
 const { t } = useI18n()
+const router = useRouter()
+
+// 「授权分组」badge 点击：跳到 Keys 页并自动打开「创建密钥」面板、预置该分组。
+// 用路由 name（'Keys'）而非硬编码路径，避免 path 漂移。
+function onCreateKeyForGroup(g: MePricingModelGroup): void {
+  void router.push({ name: 'Keys', query: { create: '1', group_id: String(g.id) } })
+}
 const authStore = useAuthStore()
 const appStore = useAppStore()
 
@@ -545,6 +589,8 @@ interface NormalizedRow {
   perSecond?: number | null
   /** Input-token interval (阶梯) ladder, normalized from either catalog source. */
   tiers?: NormalizedTier[]
+  /** Accessible groups that can serve this model — "授权分组" column ('my' view only). */
+  authorizedGroups?: MePricingModelGroup[]
 }
 
 /** Normalized阶梯 bracket shared by public + my views (per-1k). */
@@ -719,7 +765,8 @@ const normalizedRows = computed<NormalizedRow[]>(() => {
       maxTokens: tt.max_tokens ?? null,
       inputPer1K: tt.input_per_1k ?? null,
       outputPer1K: tt.output_per_1k ?? null
-    }))
+    })),
+    authorizedGroups: m.authorized_groups ?? []
   }))
 })
 

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -1107,12 +1107,15 @@
 <script setup lang="ts">
 	import { ref, computed, onMounted, onUnmounted, type ComponentPublicInstance } from 'vue'
 	import { useI18n } from 'vue-i18n'
+	import { useRoute, useRouter } from 'vue-router'
 	import { useAppStore } from '@/stores/app'
 	import { useOnboardingStore } from '@/stores/onboarding'
 	import { useClipboard } from '@/composables/useClipboard'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 
 const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
 import { keysAPI, authAPI, usageAPI, userGroupsAPI } from '@/api'
 import { useAuthStore } from '@/stores/auth'
 import AppLayout from '@/components/layout/AppLayout.vue'
@@ -1872,9 +1875,27 @@ function formatResetTime(resetAt: string | null): string {
   return `${mins}m`
 }
 
+// Deep-link from the /pricing「授权分组」column: ?create=1&group_id=N opens the
+// create-key dialog with that group preselected. Runs after groups load so the
+// group_id is validated against the user's accessible set before binding.
+function applyCreateKeyFromQuery(): void {
+  if (route.query.create !== '1') return
+  const gid = Number(route.query.group_id)
+  if (Number.isFinite(gid) && gid > 0 && groups.value.some((g) => g.id === gid)) {
+    formData.value.universal = false
+    formData.value.group_id = gid
+  }
+  showCreateModal.value = true
+  // Strip the one-shot params so a refresh/back-nav doesn't reopen the dialog.
+  const q = { ...route.query }
+  delete q.create
+  delete q.group_id
+  void router.replace({ query: q })
+}
+
 onMounted(() => {
   loadApiKeys()
-  loadGroups()
+  void loadGroups().then(() => applyCreateKeyFromQuery())
   loadUserGroupRates()
   loadPublicSettings()
   document.addEventListener('click', closeGroupSelector)


### PR DESCRIPTION
# /pricing「授权分组」列 + 点击建 key 深链

## 摘要

登录态「我的目录」(my pricing) 每个模型新增**「授权分组」列**：列出该用户可访问分组中、**实测能服务该模型**的分组（专属 / 公开）。公开目录视图不显示该列。点击分组 badge → 跳 Keys 页**自动打开「创建密钥」面板并预选该分组**，让用户照着列就能配好对应 key。

## 实现

**后端（`me_pricing`）：**
- `MePricingModel` 加 `authorized_groups`（`MePricingModelGroup`: id/name/platform/is_exclusive/is_current_for_key/rate_multiplier/subscription_type）。
- `attachAuthorizedGroups`：**复用 `buildModelsForGroup` 逐可访问分组算可服务集，再倒排到 model→groups** —— 与网关实际调度同源、不另造谓词。target 组复用已构建的行（不重算），rate=1.0（只关心 served 集，不重算价）。排序：当前组优先 → 专属 → 按名。
- 单测 `TestBuildForUser_AuthorizedGroups_CrossGroup`（一个模型被两组服务 → 都列出、当前/专属优先；单组模型 → 只列该组）。

**前端：**
- `me-pricing.ts` 加 `MePricingModelGroup` + `authorized_groups`。
- `PricingView` 加列（仅 `my` 视图）+ 可点 badge（专属 primary / 公开 gray、当前组 ring 高亮）→ `router.push({ name:'Keys', query:{ create:'1', group_id } })`（用路由 **name** 避免 path 漂移）。
- `KeysView` 读 `?create=1&group_id=N`（分组加载后校验 ∈ 可访问集）→ 自动开「建 key」弹窗、预选分组、`universal=false`，并清理一次性 query（防刷新/返回重开）。
- i18n en/zh：`pricing.my.columns.authorizedGroups` + `pricing.my.authorizedGroups.{createKeyHint,exclusive}`。

## 风险

- **改动是上游视图的薄注入**：`PricingView.vue` 加一列 + 一个 handler；`KeysView.vue` 加 deep-link（imports + 一个函数 + onMounted 一行）；未重写/回退任何上游逻辑 → `upstream-touch-trivial`。
- **后端纯加性**：新增 DTO 字段 + 一个 helper，未动既有计费/调度路径；`authorized_groups` 与网关调度同源（复用 `buildModelsForGroup`），不会与实际可服务性漂移。
- **性能**：每模型授权分组 = 逐可访问分组复用 `buildModelsForGroup`（K=用户授权分组数，通常很小；catalog mtime 缓存、target 组复用已构建行）。非热路径（pricing 页）。
- **公开目录无影响**：该列 `v-if="viewMode==='my'"`，未登录视图不渲染。

## 验证

- 后端 `go test -tags=unit ./internal/service/ -run MePricing` ✓（含新增 cross-group 用例）。
- 前端 `pnpm typecheck` ✓ / `pnpm lint:check` ✓ / i18n en-zh parity ✓ / `PricingView.spec.ts` ✓。
- 重建嵌入 dist（`pnpm --dir frontend run build` → `frontend-source.json` 刷新），过 frontend release asset contract；完整 `preflight` PASS（pre-commit）。
- 注：本地 6 个失败用例（EditAccountModal / BulkEditAccountModal / guards / EmailVerifyView / usePersistedPageSize）经 `git stash` 复核在 origin/main **同样失败**，与本 PR 无关（账号弹窗/路由守卫/OAuth/分页，零代码重叠）。

## 提交

`git log --oneline origin/main..HEAD`：

- 597c69928 feat(pricing): /pricing「授权分组」列 + 点击建 key 深链

最新提交：597c69928

## 合并

- 合并方式：**Squash and merge**（TK feature PR，§5.y）；合并等人授权，本 PR 不自合。

---

sentinel-registry-reviewed — 本 PR 改动的 frontend TK 面（`PricingView.vue` 加列 + `me-pricing.ts` 加 DTO 字段）均为**纯加性内容扩展**，未删除/改动 frontend-tk sentinel 钉住的载荷锚点；后端 `me_pricing_catalog_tk.go` 加 DTO 字段 + helper，非新载荷符号。无需新增 sentinel 锚点。
