### PR TITLE
refresh 工具补 gemini chat-image 探测族（Vertex 开通后续 Phase A）

### DIFF
--- a/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
+++ b/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
@@ -89,9 +89,11 @@ python3 ops/pricing/refresh-servable-allowlist.py probe --skip-proven-by-traffic
 ## Gemini / Vertex 三族（newapi 第五平台，探测目标 prod）
 
 gpt 经 prod 探测；claude **直探 edge 原生 OAuth 池**（见下文判断要点）；**gemini/Vertex 也经 prod 的 `google-vertex` 组探测**（live Vertex 账号
-ids 47/57/58/59 在 prod；旧 us6 `google` 组账号已软删、清空）。三族：
-`GEMINI_CHAT_MODELS`→`/v1/chat/completions`、`GEMINI_IMAGE_MODELS`→`/v1/images/generations`、
+ids 47/57/58/59 在 prod；旧 us6 `google` 组账号已软删、清空）。四族：
+`GEMINI_CHAT_MODELS`→`/v1/chat/completions`、`GEMINI_IMAGE_MODELS`→`/v1/images/generations`（**imagen-*** predict API）、
+`GEMINI_CHATIMAGE_MODELS`→`/v1/chat/completions`（**gemini-*-image / nano-banana** 经 chat/generateContent 出图，非 imagen predict 面）、
 `GEMINI_VIDEO_MODELS`→`/v1/video/generations`（异步 submit 200 即 servable，best-effort）。
+`split_gemini_families` 自动按名分流：`imagen-`→`gemini_image`、`image`/`nano-banana`→`gemini_chat_image`、其余 `gemini-`→`gemini_chat`、`veo-`→`gemini_video`；watchlist `probe_family` 可覆写。
 probe key 由 `__tk_probe_newapi_google_*` 自动 ensure（从 **google-vertex** 源组复制 schedulable 账号）。
 
 **走 prod 公网网关外部 curl**（与 openai/zhipu 同款），不再用 edge 内网 `docker exec wget`：Vertex 迁到

--- a/ops/pricing/probe-servable-models.sh
+++ b/ops/pricing/probe-servable-models.sh
@@ -10,7 +10,8 @@
 #   OPENAI_RESPONSES_MODELS  -> POST <prod>/v1/responses   (codex family)
 #   OPENAI_IMAGE_MODELS      -> POST <prod>/v1/images/generations (best-effort)
 #   GEMINI_CHAT_MODELS       -> POST app:8080/v1/chat/completions  (newapi/Vertex, edge-internal)
-#   GEMINI_IMAGE_MODELS      -> POST app:8080/v1/images/generations
+#   GEMINI_CHATIMAGE_MODELS  -> POST <prod>/v1/chat/completions  (gemini-*-image via chat/generateContent)
+#   GEMINI_IMAGE_MODELS      -> POST app:8080/v1/images/generations  (imagen-* predict API)
 #   GEMINI_VIDEO_MODELS      -> POST app:8080/v1/video/generations (async submit; 200-on-submit=servable, best-effort)
 #     NB gemini families run ON the edge host and hit the app container directly
 #     (the edge Caddy 403s host-local /v1/* — it only allows the prod gateway CIDR).
@@ -421,10 +422,13 @@ main() {
 	# newapi families (zhipu/dashscope), NOT the edge-internal wget hop (that was only
 	# needed to bypass an edge Caddy /v1/* CIDR restriction; prod's gateway is public).
 	# emit tag stays `gemini` so parse_results maps results to the gemini allowlist.
-	if [ -n "${GEMINI_CHAT_MODELS:-}${GEMINI_IMAGE_MODELS:-}${GEMINI_VIDEO_MODELS:-}" ]; then
+	if [ -n "${GEMINI_CHAT_MODELS:-}${GEMINI_CHATIMAGE_MODELS:-}${GEMINI_IMAGE_MODELS:-}${GEMINI_VIDEO_MODELS:-}" ]; then
 		if tk_probe_catalog_key newapi_google newapi source_group "$PROBE_GEMINI_SOURCE_GROUP"; then
 			gkey="$REPLY_KEY"
 			[ -n "${GEMINI_CHAT_MODELS:-}" ] && probe_compat_endpoint gemini "$PROD" "$gkey" /v1/chat/completions "$GEMINI_CHAT_MODELS" body_chat
+			# gemini-*-image generate via the chat/generateContent surface, NOT the
+			# images predict API — probe through /v1/chat/completions (emit `gemini`).
+			[ -n "${GEMINI_CHATIMAGE_MODELS:-}" ] && probe_compat_endpoint gemini "$PROD" "$gkey" /v1/chat/completions "$GEMINI_CHATIMAGE_MODELS" body_chat
 			[ -n "${GEMINI_IMAGE_MODELS:-}" ] && probe_compat_endpoint gemini "$PROD" "$gkey" /v1/images/generations "$GEMINI_IMAGE_MODELS" body_img
 			[ -n "${GEMINI_VIDEO_MODELS:-}" ] && probe_compat_endpoint gemini "$PROD" "$gkey" /v1/video/generations "$GEMINI_VIDEO_MODELS" body_video
 		else

--- a/ops/pricing/refresh-servable-allowlist.py
+++ b/ops/pricing/refresh-servable-allowlist.py
@@ -88,7 +88,11 @@ GEMINI_EXCLUDE_RE = re.compile(r"gemma-|lyria-|deep-research|robotics|antigravit
 PROBE_FAMILIES_BY_PLATFORM = {
     "anthropic": ("anthropic",),
     "openai": ("openai_chat", "openai_responses", "openai_image"),
-    "gemini": ("gemini_chat", "gemini_image", "gemini_video"),
+    # gemini_chat_image: the generateContent image models (gemini-*-image,
+    # nano-banana) ride the /v1/chat/completions surface, NOT the imagen
+    # /v1/images/generations predict API — a distinct family so they probe the
+    # right endpoint. imagen-* stays in gemini_image.
+    "gemini": ("gemini_chat", "gemini_chat_image", "gemini_image", "gemini_video"),
 }
 # Inverse of PROBE_FAMILIES_BY_PLATFORM: probe-family -> allowlist platform.
 FAMILY_PLATFORM = {
@@ -141,7 +145,7 @@ def split_gemini_families(discovered: list[str]) -> dict[str, list[str]]:
     image -> /v1/images/generations, video -> /v1/video/generations. Exotic
     families (see GEMINI_EXCLUDE_RE) are dropped so the catch-all never $0-serves
     an unpriced niche model."""
-    fams: dict[str, list[str]] = {"gemini_chat": [], "gemini_image": [], "gemini_video": []}
+    fams: dict[str, list[str]] = {"gemini_chat": [], "gemini_chat_image": [], "gemini_image": [], "gemini_video": []}
     seen: set[str] = set()
     for mid in list(discovered) + list(GEMINI_PREDICT_MODELS):
         mid = mid.strip()
@@ -152,8 +156,13 @@ def split_gemini_families(discovered: list[str]) -> dict[str, list[str]]:
             continue
         if mid.startswith("veo-"):
             fams["gemini_video"].append(mid)
-        elif mid.startswith("imagen-") or "image" in mid or "nano-banana" in mid:
+        elif mid.startswith("imagen-"):
+            # imagen-* uses the /v1/images/generations predict API.
             fams["gemini_image"].append(mid)
+        elif "image" in mid or "nano-banana" in mid:
+            # gemini-*-image / nano-banana generate via the chat/generateContent
+            # surface, not the images predict API → probe through /v1/chat/completions.
+            fams["gemini_chat_image"].append(mid)
         elif mid.startswith("gemini-"):
             fams["gemini_chat"].append(mid)
         # other-vendor ids are ignored (not part of the google catch-all scope)
@@ -202,8 +211,10 @@ def _probe_family_for(platform: str, model: str, probe_family: str | None = None
     if platform == "gemini":
         if model.startswith("veo-"):
             return "gemini_video"
-        if model.startswith("imagen-") or "image" in model or "nano-banana" in model:
+        if model.startswith("imagen-"):
             return "gemini_image"
+        if "image" in model or "nano-banana" in model:
+            return "gemini_chat_image"
         return "gemini_chat"
     raise ValueError(f"{platform}/{model}: refresh tool cannot probe this platform")
 
@@ -344,6 +355,7 @@ def augment_candidates_with_watchlist(candidates: dict[str, list[str]], ledger: 
         ("openai_responses", ("openai",)),
         ("openai_image", ("openai",)),
         ("gemini_chat", ("gemini",)),
+        ("gemini_chat_image", ("gemini",)),
         ("gemini_image", ("gemini",)),
         ("gemini_video", ("gemini",)),
     ):
@@ -584,6 +596,7 @@ ENV_BY_FAMILY = (
     ("OPENAI_RESPONSES_MODELS", "openai_responses", "prod"),
     ("OPENAI_IMAGE_MODELS", "openai_image", "prod"),
     ("GEMINI_CHAT_MODELS", "gemini_chat", GEMINI_TARGET),
+    ("GEMINI_CHATIMAGE_MODELS", "gemini_chat_image", GEMINI_TARGET),
     ("GEMINI_IMAGE_MODELS", "gemini_image", GEMINI_TARGET),
     ("GEMINI_VIDEO_MODELS", "gemini_video", GEMINI_TARGET),
 )
@@ -805,8 +818,12 @@ def selftest() -> int:
     }
     aug = augment_candidates_with_watchlist(build_candidates(cat, ["gemini-3-pro-image-preview"]), ledger)
     assert "gpt-5.2" in aug["openai_chat"], aug["openai_chat"]
+    # watchlist probe_family override moves it from the base family (now
+    # gemini_chat_image for *-image ids) to the overridden gemini_chat, and out of
+    # all peers — proves the override wins over the systematic family routing.
     assert "gemini-3-pro-image-preview" in aug["gemini_chat"], aug["gemini_chat"]
     assert "gemini-3-pro-image-preview" not in aug["gemini_image"], aug["gemini_image"]
+    assert "gemini-3-pro-image-preview" not in aug["gemini_chat_image"], aug["gemini_chat_image"]
     assert "gpt-image-dead" not in aug["openai_image"], aug["openai_image"]
     validate_reprobe_ledger(
         ledger,
@@ -855,9 +872,11 @@ def selftest() -> int:
         "gemini-2.5-computer-use-preview-10-2025",
     ])
     assert g["gemini_chat"] == ["gemini-2.5-pro", "gemini-3-pro-preview"], g["gemini_chat"]
-    # discovered image models classified into the image family (alongside imagen seed)
+    # generateContent image models go to gemini_chat_image (chat surface), NOT the
+    # imagen predict family; imagen-* stays in gemini_image.
     for img in ("gemini-2.5-flash-image", "gemini-3-pro-image", "nano-banana-pro-preview"):
-        assert img in g["gemini_image"], (img, g["gemini_image"])
+        assert img in g["gemini_chat_image"], (img, g["gemini_chat_image"])
+        assert img not in g["gemini_image"], (img, g["gemini_image"])
     # predict seed always merged into video/image even with empty discovery
     assert "veo-3.1-generate-001" in g["gemini_video"], g["gemini_video"]
     assert "imagen-4.0-generate-001" in g["gemini_image"], g["gemini_image"]
@@ -941,8 +960,11 @@ def selftest() -> int:
     assert ("openai", "gpt-5.2") in real_members, "watchlist gpt-5.2 must be probed"
     assert ("openai", "codex-auto-review") in real_members, "watchlist codex-auto-review must be probed"
     assert ("gemini", "gemini-3-pro-preview") not in real_members, "skiplist gemini chat must be excluded"
-    assert "gemini-3-pro-image-preview" in real_cands["gemini_chat"], real_cands["gemini_chat"]
+    # gemini-*-image route to the gemini_chat_image family (chat/generateContent
+    # surface), not gemini_chat (text) or gemini_image (imagen predict API).
+    assert "gemini-3-pro-image-preview" in real_cands["gemini_chat_image"], real_cands["gemini_chat_image"]
     assert "gemini-3-pro-image-preview" not in real_cands["gemini_image"], real_cands["gemini_image"]
+    assert "gemini-3-pro-image-preview" not in real_cands["gemini_chat"], real_cands["gemini_chat"]
 
     probe_lib = REPO / "ops/pricing/probe_reserved_resources.sh"
     probe_test = REPO / "ops/pricing/test_probe_reserved_resources.sh"

--- a/ops/pricing/servable-reprobe-ledger.json
+++ b/ops/pricing/servable-reprobe-ledger.json
@@ -95,11 +95,11 @@
     {
       "platform": "gemini",
       "model": "gemini-2.5-flash-image",
-      "reason": "2026-06-23 edge-us6 /v1/chat/completions reprobe returned 429 inconclusive; baseline gemini-2.5-flash also returned 429, so current Vertex path is pool/quota limited.",
+      "reason": "2026-06-23 edge-us6 /v1/chat/completions reprobe returned 429 inconclusive; baseline gemini-2.5-flash also returned 429, so current Vertex path is pool/quota limited. gemini-*-image now ride the systematic gemini_chat_image family (chat/generateContent surface).",
       "last_probe": "2026-06-23",
       "freshness_days": 30,
       "auto_probe": true,
-      "probe_family": "gemini_chat"
+      "probe_family": "gemini_chat_image"
     },
     {
       "platform": "gemini",
@@ -108,7 +108,7 @@
       "last_probe": "2026-06-23",
       "freshness_days": 30,
       "auto_probe": true,
-      "probe_family": "gemini_chat"
+      "probe_family": "gemini_chat_image"
     },
     {
       "platform": "gemini",
@@ -117,7 +117,7 @@
       "last_probe": "2026-06-23",
       "freshness_days": 30,
       "auto_probe": true,
-      "probe_family": "gemini_chat"
+      "probe_family": "gemini_chat_image"
     },
     {
       "platform": "gemini",
@@ -126,7 +126,7 @@
       "last_probe": "2026-06-23",
       "freshness_days": 30,
       "auto_probe": true,
-      "probe_family": "gemini_chat"
+      "probe_family": "gemini_chat_image"
     },
     {
       "platform": "gemini",


### PR DESCRIPTION
# refresh 工具补 gemini chat-image 探测族（Vertex 开通后续 Phase A）

## 摘要

`gemini-*-image` / `nano-banana` 这类**生成图**模型经 **chat/generateContent** 出图，不走 `imagen-*` 的 `/v1/images/generations` predict 面。原先靠 watchlist per-id `probe_family` 覆写绕到 `gemini_chat`；本 PR 把它**系统化**为独立的 `gemini_chat_image` 探测族 —— 这是「Vertex 开通图像模型」后续的 **Phase A（仅工具、零 prod 写）**。

## 改动

- **`refresh-servable-allowlist.py`**：
  - `PROBE_FAMILIES_BY_PLATFORM` gemini 加 `gemini_chat_image`。
  - `split_gemini_families` / `_probe_family_for` 按名分流：`imagen-`→`gemini_image`、`image`/`nano-banana`→`gemini_chat_image`、其余 `gemini-`→`gemini_chat`、`veo-`→`gemini_video`。
  - `ENV_BY_FAMILY` 加 `GEMINI_CHATIMAGE_MODELS`→`/v1/chat/completions`（emit `gemini`，结果入 gemini allowlist）。
  - selftest 覆盖新族分流 + watchlist `probe_family` 覆写仍生效。
- **`probe-servable-models.sh`**：加 `GEMINI_CHATIMAGE_MODELS` 分支（chat 端点、gemini 组 key、`body_chat`）。
- **`servable-reprobe-ledger.json`**：4 个 `gemini-*-image` watchlist 项 `probe_family` `gemini_chat`→`gemini_chat_image`（`imagen-*` 保持 `gemini_image`），与系统化分流对齐。
- **skill**：Gemini 节由「三族」更新为「四族」+ 分流规则。

## 风险

- **仅 ops 探测工具 + skill + ledger 数据**，零 backend / 计费 / prod 改动；非 upstream-shaped 路径 → 无需 override marker。
- `gemini_chat_image` 与 `gemini_chat` 都打 `/v1/chat/completions`，故即便分流变化，探测端点不变；watchlist 覆写机制保留（selftest 证明覆写仍能把模型移到指定族）。
- ledger 迁移最小 diff（仅 5 行 probe_family/reason），未重排 JSON。

## 验证

- `refresh-servable-allowlist.py selftest` PASS（含新族分流 + 覆写用例 + 真实 ledger 用例）。
- 完整 `preflight` PASS（pre-commit）—— servable-allowlist generator selftest / probe `--with` companion guard / determinism-baseline 全绿。
- `candidates` 实测：`gemini-2.5-flash-image` / `gemini-3-pro-image` / `gemini-3.1-flash-image` / `nano-banana-pro-preview` → `gemini_chat_image`；`imagen-*` → `gemini_image`。

## 后续（不在本 PR）

**Phase B（所有 PR review 合并后、再单独确认）**：临时给 Vertex 账号(47/57/58/59) `model_mapping` 加这些 image id → 用本族经 prod chat 端点探一窗确认 Vertex 真能服务 → 永久写 mapping + `refresh` 重生成 gemini allowlist + 发版。**prod 写全部押后。**

## 提交

`git log --oneline origin/main..HEAD`：

- 8114caa80 feat(modelops): refresh 工具补 gemini chat-image 探测族（Vertex 开通后续 Phase A）

最新提交：8114caa80

## 合并

- 合并方式：**Squash and merge**（TK feature PR，§5.y）；合并等人授权，本 PR 不自合。
