### PR TITLE
fix(studio): 修复对话区空白、过期视频卡片与 Admin 用量窗口

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 515,
-  "hash": "749e0a9aa0b1364585f24273d76ef08ea7f10e8f376c5f98003ce6da44c39517",
+  "hash": "193d146dde1ade21f11171c3de9969ac15021d48ed0ff43ebd73e4eec8edbbad",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -435,6 +435,56 @@ describe('AccountUsageCell', () => {
     expect(wrapper.text()).toContain('admin.accounts.usageWindow.kiroCredits|12|2099-03-07T12:00:00Z')
   })
 
+  it('OpenAI 列表 batch override 从 null 更新为数据时会渲染 5h/7d 窗口', async () => {
+    const passiveUsage = {
+      source: 'passive',
+      five_hour: {
+        utilization: 42,
+        resets_at: '2099-03-07T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 3,
+          tokens: 300,
+          cost: 0.03,
+          standard_cost: 0.03,
+          user_cost: 0.03
+        }
+      },
+      seven_day: null
+    }
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2014,
+          platform: 'openai',
+          type: 'oauth',
+          extra: {}
+        }),
+        usageOverride: null,
+        manualRefreshToken: 0
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'windowStats'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ windowStats?.tokens }}</div>'
+          },
+          AccountQuotaInfo: true
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('-')
+    expect(getUsage).not.toHaveBeenCalled()
+
+    await wrapper.setProps({ usageOverride: passiveUsage })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('5h|42|300')
+    expect(getUsage).not.toHaveBeenCalled()
+  })
+
   it('Grok 平台复用 5h/7d usage 窗口展示本地统计', async () => {
     getUsage.mockResolvedValue({
       source: 'passive',

--- a/frontend/src/components/account/usage-cells/useAccountUsageFetch.ts
+++ b/frontend/src/components/account/usage-cells/useAccountUsageFetch.ts
@@ -67,7 +67,8 @@ export function useAccountUsageFetch(
     () => props.usageOverride,
     (v) => {
       if (v !== undefined) usageInfo.value = v
-    }
+    },
+    { immediate: true }
   )
 
   const isDesktopViewport = ref(

--- a/frontend/src/composables/__tests__/useMediaLibrary.spec.ts
+++ b/frontend/src/composables/__tests__/useMediaLibrary.spec.ts
@@ -38,13 +38,34 @@ describe('useMediaLibrary video persistence', () => {
     expect(persisted.videoTasks[0].url).toBe('')
   })
 
-  it('preserves http upstream video URLs in localStorage', async () => {
+  it('strips http upstream video URLs from localStorage and marks urlExpired', async () => {
     const lib = useMediaLibrary(USER_ID)
     lib.upsertVideoTask(videoTask('https://cdn.example/video.mp4'))
+    expect(lib.videoTasks.value[0].url).toBe('https://cdn.example/video.mp4')
 
     await nextTick()
     const persisted = JSON.parse(window.localStorage.getItem(KEY) || '{}')
-    expect(persisted.videoTasks[0].url).toBe('https://cdn.example/video.mp4')
+    expect(persisted.videoTasks[0].url).toBe('')
+    expect(persisted.videoTasks[0].urlExpired).toBe(true)
+  })
+
+  it('reloads legacy persisted http video tasks as prompt-only (urlExpired)', () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        images: [],
+        videoTasks: [
+          {
+            ...videoTask('https://cdn.example/stale.mp4'),
+            prompt: 'neon alley rain',
+          },
+        ],
+      })
+    )
+    const lib = useMediaLibrary(USER_ID)
+    expect(lib.videoTasks.value[0].url).toBe('')
+    expect(lib.videoTasks.value[0].urlExpired).toBe(true)
+    expect(lib.videoTasks.value[0].prompt).toBe('neon alley rain')
   })
 })
 

--- a/frontend/src/composables/useMediaLibrary.ts
+++ b/frontend/src/composables/useMediaLibrary.ts
@@ -56,6 +56,8 @@ export interface VideoTaskItem {
   keyId: number
   state: VideoTaskState
   url: string
+  /** Set when an upstream http(s) link expired or was stripped on reload — card shows prompt only. */
+  urlExpired?: boolean
   submittedAtMs: number
   elapsedS: number
   errorMessage?: string
@@ -91,8 +93,18 @@ function loadPersisted(key: string): PersistShape {
 }
 
 function sanitizeVideoTaskForPersistence(task: VideoTaskItem): VideoTaskItem {
-  if (!/^data:video/i.test(task.url) && !task.url.startsWith('blob:')) return task
-  return { ...task, url: '' }
+  if (task.urlExpired && task.url) {
+    return { ...task, url: '' }
+  }
+  if (/^data:video/i.test(task.url) || task.url.startsWith('blob:')) {
+    return { ...task, url: '' }
+  }
+  // Upstream presigned http(s) links are short-lived (#944 — TokenKey is not a media CDN).
+  // Persist prompt/history only so a reload never offers a stale play tile.
+  if (/^https?:\/\//i.test(task.url)) {
+    return { ...task, url: '', urlExpired: true }
+  }
+  return task
 }
 
 function sanitizeVideoTasksForPersistence(tasks: VideoTaskItem[]): VideoTaskItem[] {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -238,6 +238,7 @@ export default {
       notifyMe: 'Notify me when done',
       usuallyTakes: 'Usually 30–90s',
       noUrlHint: 'Task succeeded. Video results are not retained long-term, so it cannot be played here — generate again to view it.',
+      expiredReload: 'Link expired — only the prompt is kept. Reuse it to generate again.',
       download: 'Download',
       failedRefunded: 'Generation failed — {cost} refunded. Try a shorter clip or another tier.',
       techDetails: 'Technical details',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -236,6 +236,7 @@ export default {
       notifyMe: '完成通知我',
       usuallyTakes: '通常 30–90 秒',
       noUrlHint: '任务已成功。视频结果不会长期保留，此处无法播放——如需查看请重新生成。',
+      expiredReload: '链接已过期，仅保留提示词——可复用提示词重新生成。',
       download: '下载',
       failedRefunded: '生成失败 — 已退你 {cost}。试试更短的片子或别的档位。',
       techDetails: '技术详情',

--- a/frontend/src/utils/__tests__/studioMedia.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioMedia.tk.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { videoPlaybackUrl } from '../studioMedia.tk'
+import { videoPlaybackUrl, videoTaskPlaybackAvailable } from '../studioMedia.tk'
 
 // jsdom does not implement URL.createObjectURL / revokeObjectURL, so we define them
 // per-test and restore after. (videoPlaybackUrl falls back to the original src when
@@ -8,6 +8,28 @@ const urlStatic = URL as unknown as {
   createObjectURL?: (b: Blob) => string
   revokeObjectURL?: (u: string) => void
 }
+
+describe('videoTaskPlaybackAvailable', () => {
+  it('is false for succeeded tasks whose upstream link was stripped on reload', () => {
+    expect(
+      videoTaskPlaybackAvailable({
+        state: 'succeeded',
+        url: '',
+        urlExpired: true,
+      })
+    ).toBe(false)
+  })
+
+  it('is true for succeeded tasks with a live in-tab url', () => {
+    expect(
+      videoTaskPlaybackAvailable({
+        state: 'succeeded',
+        url: 'https://cdn.example/fresh.mp4',
+        urlExpired: false,
+      })
+    ).toBe(true)
+  })
+})
 
 describe('videoPlaybackUrl', () => {
   afterEach(() => {

--- a/frontend/src/utils/studioMedia.tk.ts
+++ b/frontend/src/utils/studioMedia.tk.ts
@@ -12,6 +12,13 @@
  * decode error) it falls back to the original src with a no-op revoke, so a caller
  * always gets something usable to hand to a <video :src>.
  */
+import type { VideoTaskItem } from '@/composables/useMediaLibrary'
+
+/** True when the task card may offer in-page playback (same session, non-expired url). */
+export function videoTaskPlaybackAvailable(task: Pick<VideoTaskItem, 'state' | 'url' | 'urlExpired'>): boolean {
+  return task.state === 'succeeded' && !!task.url && !task.urlExpired
+}
+
 export interface VideoPlayback {
   /** URL ready for a <video :src> — http(s) upstream URL or a tab-local blob: URL. */
   url: string

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1010,7 +1010,14 @@ const debouncedReload = () => {
   hasPendingListSync.value = false
   resetAutoRefreshCache()
   pendingTodayStatsRefresh.value = true
-  baseDebouncedReload()
+  // Always refresh row metrics after the debounced table reload completes.
+  // Relying only on watch(loading) races with the initial onMounted load(): that
+  // load can finish while pendingTodayStatsRefresh is already true (user filtered
+  // early), consume the flag, and leave the debounced reload with no batch refresh.
+  void baseDebouncedReload().then(() => {
+    pendingTodayStatsRefresh.value = false
+    refreshAccountRowMetrics()
+  })
 }
 
 const handlePageChange = (page: number) => {

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -95,8 +95,16 @@
         <p v-if="modelsLoading" class="text-xs text-gray-400 dark:text-dark-500">{{ t('studio.loadingModels') }}</p>
       </div>
 
+      <div
+        v-if="!loadError && !probed"
+        class="flex min-h-[420px] items-center justify-center rounded-xl border border-dashed border-gray-200 bg-white text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900 dark:text-dark-400"
+        data-testid="studio-bootstrap-loading"
+      >
+        {{ t('studio.loadingModels') }}
+      </div>
+
       <ChatStudio
-        v-if="userReady && !loadError && probed && view === 'chat'"
+        v-if="!loadError && probed && view === 'chat'"
         :api-key="apiKey"
         :gateway-base="gatewayBase"
         :available-ids="availableIds"
@@ -344,12 +352,12 @@ async function bootstrap(): Promise<void> {
     await probeAllGroups()
     if (loadError.value) return
     // Seed with the historical default, then let the picker move to a key whose
-    // group actually serves the landing modality (view is 'image' at mount).
-    selectedKeyId.value = pickModalityKey(modalityOptions(), pickerModality.value ?? 'image', seed)
-    // Load the first key's live prices before mounting, so the model cards never
-    // flash an empty "no models" state while the catalog is in flight.
-    if (selectedKeyId.value != null) await loadPriceMap(selectedKeyId.value)
+    // group actually serves the landing modality (defaults to chat at mount).
+    selectedKeyId.value = pickModalityKey(modalityOptions(), pickerModality.value ?? 'chat', seed)
+    // Mount studios as soon as /v1/models is probed. Price catalog is only needed
+    // for image/video/bake-off; awaiting it blocked Chat on slow catalog fetches.
     probed.value = true
+    if (selectedKeyId.value != null) void loadPriceMap(selectedKeyId.value)
   } catch (e) {
     loadError.value = e instanceof Error ? e.message : t('studio.loadFailed')
   }

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -224,43 +224,47 @@
           <p v-if="task.errorMessage" class="rounded-lg bg-amber-50 px-2.5 py-1.5 text-[11px] font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">{{ t('studio.video.stalled') }}</p>
         </div>
 
-        <!-- succeeded: poster tile → in-page lightbox playback. We deliberately do
-             NOT render an always-on <video> (it shows a black, poster-less 0:00 box
-             before play, and multiple cards could start competing video loads).
-             The clip plays only on demand in the lightbox, using the upstream URL
-             directly or a tab-local Blob URL for inline bytes. -->
+        <!-- succeeded: poster tile when playback is still available in this tab;
+             otherwise prompt-only (upstream http links are not replayed after reload). -->
         <div v-else-if="task.state === 'succeeded'" class="space-y-2">
-          <button
-            v-if="task.url"
-            type="button"
-            class="group relative block w-full overflow-hidden rounded-lg bg-gradient-to-br from-gray-800 to-gray-950"
-            :style="{ aspectRatio: posterAspect(task) }"
-            :title="t('studio.video.playHint')"
-            :aria-label="t('studio.video.play')"
-            data-testid="studio-video-play"
-            @click="openPreview(task)"
-          >
-            <span class="pointer-events-none absolute inset-0 flex items-center justify-center">
-              <span class="flex h-14 w-14 items-center justify-center rounded-full bg-white/90 shadow-lg transition group-hover:scale-110 group-hover:bg-white">
-                <span aria-hidden="true" class="ml-1 text-2xl text-gray-900">▶</span>
+          <template v-if="videoTaskPlaybackAvailable(task)">
+            <button
+              type="button"
+              class="group relative block w-full overflow-hidden rounded-lg bg-gradient-to-br from-gray-800 to-gray-950"
+              :style="{ aspectRatio: posterAspect(task) }"
+              :title="t('studio.video.playHint')"
+              :aria-label="t('studio.video.play')"
+              data-testid="studio-video-play"
+              @click="openPreview(task)"
+            >
+              <span class="pointer-events-none absolute inset-0 flex items-center justify-center">
+                <span class="flex h-14 w-14 items-center justify-center rounded-full bg-white/90 shadow-lg transition group-hover:scale-110 group-hover:bg-white">
+                  <span aria-hidden="true" class="ml-1 text-2xl text-gray-900">▶</span>
+                </span>
               </span>
-            </span>
-            <span class="pointer-events-none absolute bottom-2 left-2 rounded bg-black/55 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-white/90">{{ task.seconds }}s{{ task.aspectRatio ? ' · ' + task.aspectRatio : '' }}</span>
-          </button>
-          <p v-else class="rounded-lg bg-amber-50 px-2.5 py-2 text-xs text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">{{ t('studio.video.noUrlHint') }}</p>
+              <span class="pointer-events-none absolute bottom-2 left-2 rounded bg-black/55 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-white/90">{{ task.seconds }}s{{ task.aspectRatio ? ' · ' + task.aspectRatio : '' }}</span>
+            </button>
+            <p class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.video.retentionHint') }}</p>
+          </template>
+          <div
+            v-else
+            class="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-3 py-4 dark:border-dark-600 dark:bg-dark-800/60"
+            data-testid="studio-video-expired"
+          >
+            <p class="whitespace-pre-wrap break-words text-sm text-gray-800 dark:text-dark-100">{{ task.prompt }}</p>
+            <p class="mt-2 text-[11px] text-gray-400 dark:text-dark-500">
+              {{ task.urlExpired || !task.url ? t('studio.video.expiredReload') : t('studio.video.noUrlHint') }}
+            </p>
+          </div>
           <div class="flex items-center justify-between text-[11px] text-gray-500 dark:text-dark-400">
-            <span class="truncate" :title="task.prompt">{{ task.prompt }}</span>
+            <span v-if="videoTaskPlaybackAvailable(task)" class="truncate" :title="task.prompt">{{ task.prompt }}</span>
             <span class="shrink-0 rounded bg-primary-50 px-1.5 py-0.5 font-semibold text-primary-700 dark:bg-primary-950/50 dark:text-primary-300">{{ formatUsd(task.estCost) }}</span>
           </div>
           <div class="flex gap-3 text-[11px] font-medium text-gray-500 dark:text-dark-400">
-            <button v-if="task.url" type="button" class="text-primary-600 dark:text-primary-300" @click="openPreview(task)">{{ t('studio.video.play') }}</button>
+            <button v-if="videoTaskPlaybackAvailable(task)" type="button" class="text-primary-600 dark:text-primary-300" @click="openPreview(task)">{{ t('studio.video.play') }}</button>
             <button type="button" @click="reuse(task)">{{ t('studio.image.usePrompt') }}</button>
             <button type="button" @click="removeTask(task.id)">{{ t('studio.clear') }}</button>
           </div>
-          <!-- The clip plays from a short-lived upstream link (TokenKey no longer
-               rehosts video results), so nudge the user to grab it now rather than
-               discover it expired. -->
-          <p v-if="task.url" class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.video.retentionHint') }}</p>
         </div>
 
         <!-- failed: refund -->
@@ -345,7 +349,7 @@ import {
 } from '@/constants/mediaTiers.tk'
 import { estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
 import { downloadMedia } from '@/utils/studioDownload.tk'
-import { videoPlaybackUrl } from '@/utils/studioMedia.tk'
+import { videoPlaybackUrl, videoTaskPlaybackAvailable } from '@/utils/studioMedia.tk'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { useMediaLibrary, type VideoTaskItem } from '@/composables/useMediaLibrary'
 import { useVideoTaskPoll, requestVideoNotifyPermission, maybeNotify } from '@/composables/useVideoTaskPoll'
@@ -499,7 +503,7 @@ let copiedTimer: ReturnType<typeof setTimeout> | undefined
 let previewRevoke: () => void = () => {}
 
 async function openPreview(task: VideoTaskItem): Promise<void> {
-  if (!task.url) return
+  if (!videoTaskPlaybackAvailable(task)) return
   previewRevoke()
   preview.value = task
   previewUrl.value = ''
@@ -517,10 +521,12 @@ async function openPreview(task: VideoTaskItem): Promise<void> {
   previewState.value = playback.url ? 'ready' : 'expired'
 }
 
-// The <video> failed to load. Degrade to a translated "expired" message + a
-// retry / reuse-the-prompt path, instead of leaving a silent black box.
+// The <video> failed to load — mark the card prompt-only and close the lightbox
+// instead of trapping the user in an "expired" modal they already saw on the list.
 function onPreviewError(): void {
-  previewState.value = 'expired'
+  const task = preview.value
+  closePreview()
+  if (task) library.patchVideoTask(task.id, { urlExpired: true, url: '' })
 }
 
 // Re-attempt playback — recovers from a transient media error without forcing

--- a/frontend/src/views/user/studio/__tests__/MediaStudioView.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/MediaStudioView.spec.ts
@@ -1,0 +1,106 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { ref } from 'vue'
+import en from '@/i18n/locales/en'
+import MediaStudioView from '../MediaStudioView.vue'
+
+const { listKeys, gatewayListModels, getMePricingCatalog } = vi.hoisted(() => ({
+  listKeys: vi.fn(),
+  gatewayListModels: vi.fn(),
+  getMePricingCatalog: vi.fn(),
+}))
+
+vi.mock('@/api/keys', () => ({
+  keysAPI: { list: listKeys },
+}))
+
+vi.mock('@/api/playground', () => ({
+  gatewayListModels,
+  resolveGatewayBaseUrl: vi.fn((base?: string) => base || 'https://gw.example'),
+}))
+
+vi.mock('@/api/me-pricing', () => ({
+  getMePricingCatalog,
+}))
+
+const fetchPublicSettings = vi.fn(async () => undefined)
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    fetchPublicSettings,
+    apiBaseUrl: 'https://api.example',
+    cachedPublicSettings: { api_base_url: 'https://api.example' },
+  }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} }),
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    user: ref({ id: 1, balance: 100 }),
+    refreshUser: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/layout/AppLayout.vue', () => ({
+  default: { template: '<div><slot /></div>' },
+}))
+
+vi.mock('../ChatStudio.vue', () => ({
+  default: {
+    name: 'ChatStudio',
+    props: ['apiKey', 'gatewayBase', 'availableIds'],
+    template: '<div data-testid="studio-chat-panel">chat</div>',
+  },
+}))
+
+vi.mock('../ImageStudio.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('../VideoStudio.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('../BakeOff.vue', () => ({ default: { template: '<div />' } }))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackWarn: false,
+  missingWarn: false,
+  messages: { en },
+})
+
+describe('MediaStudioView bootstrap', () => {
+  beforeEach(() => {
+    listKeys.mockReset()
+    gatewayListModels.mockReset()
+    getMePricingCatalog.mockReset()
+    fetchPublicSettings.mockClear()
+
+    listKeys.mockResolvedValue({
+      items: [{ id: 1, name: 'trial', key: 'sk-test', group: { id: 10, name: 'default' } }],
+    })
+    gatewayListModels.mockResolvedValue({ data: [{ id: 'gpt-4o' }] })
+  })
+
+  it('mounts ChatStudio after model probe without waiting for the price catalog', async () => {
+    let resolveCatalog!: (value: { models: [] }) => void
+    getMePricingCatalog.mockReturnValue(
+      new Promise<{ models: [] }>((resolve) => {
+        resolveCatalog = resolve
+      })
+    )
+
+    const wrapper = mount(MediaStudioView, {
+      global: {
+        plugins: [i18n],
+        stubs: { 'router-link': true },
+      },
+    })
+
+    await flushPromises()
+    expect(wrapper.find('[data-testid="studio-chat-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="studio-bootstrap-loading"]').exists()).toBe(false)
+
+    resolveCatalog({ models: [] })
+    await flushPromises()
+  })
+})

--- a/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
@@ -1,11 +1,39 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 import en from '@/i18n/locales/en'
+import type { VideoTaskItem } from '@/composables/useMediaLibrary'
 import VideoStudio from '../VideoStudio.vue'
 
-// The component imports the gateway media client; never hit the network in a unit
-// test. gatewayVideoFetch is only reached via the lazy on-open URL refresh.
+const libraryMock = vi.hoisted(() => ({
+  usePersistedLibrary: true,
+  videoTasks: { value: [] as Array<Record<string, unknown>> },
+  patchVideoTaskSpy: vi.fn(),
+}))
+
+vi.mock('@/composables/useMediaLibrary', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/composables/useMediaLibrary')>()
+  return {
+    ...actual,
+    useMediaLibrary: (userId: number | string) => {
+      if (libraryMock.usePersistedLibrary) {
+        return actual.useMediaLibrary(userId)
+      }
+      return {
+        images: ref([]),
+        videoTasks: libraryMock.videoTasks,
+        addImages: vi.fn(),
+        clearImages: vi.fn(),
+        upsertVideoTask: vi.fn(),
+        patchVideoTask: libraryMock.patchVideoTaskSpy,
+        removeVideoTask: vi.fn(),
+        clearVideoTasks: vi.fn(),
+      }
+    },
+  }
+})
+
 vi.mock('@/api/playground', () => ({
   gatewayVideoSubmit: vi.fn(),
   gatewayVideoFetch: vi.fn(async () => ({ done: true, video_url: 'https://s3.example/fresh.mp4' })),
@@ -27,8 +55,8 @@ const baseProps = {
   rateMultiplier: 1,
 }
 
-function seedSucceeded(url: string): void {
-  const task = {
+function baseTask(overrides: Partial<VideoTaskItem> = {}): VideoTaskItem {
+  return {
     id: 'vt_abc',
     prompt: 'a calm mountain lake at dawn',
     model: 'veo-3.1-generate-001',
@@ -38,11 +66,21 @@ function seedSucceeded(url: string): void {
     estCost: 4.8,
     keyId: 1,
     state: 'succeeded',
-    url,
+    url: 'https://cdn.example/upstream.mp4',
     submittedAtMs: Date.now(),
     elapsedS: 8,
+    ...overrides,
   }
-  window.localStorage.setItem(`tk_media_lib_v1:${USER_ID}`, JSON.stringify({ images: [], videoTasks: [task] }))
+}
+
+function seedPersisted(tasks: VideoTaskItem[]): void {
+  libraryMock.usePersistedLibrary = true
+  window.localStorage.setItem(`tk_media_lib_v1:${USER_ID}`, JSON.stringify({ images: [], videoTasks: tasks }))
+}
+
+function seedInSession(task: VideoTaskItem): void {
+  libraryMock.usePersistedLibrary = false
+  libraryMock.videoTasks.value = [task as unknown as Record<string, unknown>]
 }
 
 const mountStudio = () =>
@@ -55,6 +93,14 @@ const mountStudio = () =>
 describe('VideoStudio succeeded-task presentation', () => {
   beforeEach(() => {
     window.localStorage.clear()
+    libraryMock.usePersistedLibrary = true
+    libraryMock.videoTasks.value = []
+    libraryMock.patchVideoTaskSpy.mockReset()
+    libraryMock.patchVideoTaskSpy.mockImplementation((id: string, patch: Partial<VideoTaskItem>) => {
+      libraryMock.videoTasks.value = libraryMock.videoTasks.value.map((task) =>
+        task.id === id ? { ...task, ...patch } : task
+      )
+    })
     Object.defineProperty(URL, 'createObjectURL', {
       value: vi.fn(() => 'blob:https://studio.test/video-preview'),
       configurable: true,
@@ -65,29 +111,56 @@ describe('VideoStudio succeeded-task presentation', () => {
     })
   })
 
-  it('renders a poster tile, NOT an always-on inline <video>, for a succeeded task', () => {
-    // Bug 2: the old always-on <video> showed a black, poster-less 0:00 box.
-    seedSucceeded('https://s3.example/clip.mp4')
+  it('renders a poster tile, NOT an always-on inline <video>, for a fresh in-session task', () => {
+    seedInSession(baseTask({ url: 'https://s3.example/clip.mp4' }))
     const w = mountStudio()
     expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(true)
     expect(w.find('video').exists()).toBe(false)
-    // The per-card status badge is the in-page completion signal that replaced the
-    // stale global toast (Bug 1). The runtime-only i18n build returns the key path
-    // rather than the translation, so assert on the rendered key.
     expect(w.text()).toContain('statusSucceeded')
   })
 
   it('does not resurrect a persisted inline data: clip after reload', () => {
-    seedSucceeded('data:video/mp4;base64,AAAA')
+    seedPersisted([baseTask({ url: 'data:video/mp4;base64,AAAA' })])
     const w = mountStudio()
     expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(false)
-    expect(w.text()).toContain('noUrlHint')
+    expect(w.find('[data-testid="studio-video-expired"]').exists()).toBe(true)
     expect(URL.createObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('shows prompt-only card for reloaded http upstream clips (no play tile)', () => {
+    seedPersisted([
+      baseTask({
+        id: 'vt_stale',
+        prompt: 'neon Tokyo alley in rain',
+        url: 'https://cdn.example/stale.mp4',
+      }),
+    ])
+    const w = mountStudio()
+    expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(false)
+    expect(w.find('[data-testid="studio-video-expired"]').exists()).toBe(true)
+    expect(w.text()).toContain('neon Tokyo alley in rain')
+    expect(w.text()).toContain('expiredReload')
+  })
+
+  it('closes the lightbox and marks the card expired when preview media fails', async () => {
+    seedInSession(baseTask())
+    const w = mountStudio()
+    await w.find('[data-testid="studio-video-play"]').trigger('click')
+    await flushPromises()
+    expect(w.find('[data-testid="studio-video-preview"] video').exists()).toBe(true)
+
+    await w.find('[data-testid="studio-video-preview"] video').trigger('error')
+    await flushPromises()
+
+    expect(w.find('[data-testid="studio-video-preview"]').exists()).toBe(false)
+    expect(libraryMock.patchVideoTaskSpy).toHaveBeenCalledWith('vt_abc', { urlExpired: true, url: '' })
+    expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(false)
+    expect(w.find('[data-testid="studio-video-expired"]').exists()).toBe(true)
   })
 
   it('plays an http upstream clip directly without re-fetching through TokenKey', async () => {
     const { gatewayVideoFetch } = await import('@/api/playground')
-    seedSucceeded('https://cdn.example/upstream.mp4')
+    seedInSession(baseTask())
     const w = mountStudio()
     await w.find('[data-testid="studio-video-play"]').trigger('click')
     await flushPromises()
@@ -98,10 +171,7 @@ describe('VideoStudio succeeded-task presentation', () => {
   })
 
   it('exposes a copy-link affordance in the lightbox ready state', async () => {
-    // The "看不到 S3 链接" regression: #860 dropped the open-in-new-tab anchor, so an
-    // URL-only card dead-ended. Once the URL is ready, the user must be able to
-    // grab the link itself — not only Download.
-    seedSucceeded('https://cdn.example/upstream.mp4')
+    seedInSession(baseTask())
     const w = mountStudio()
     await w.find('[data-testid="studio-video-play"]').trigger('click')
     await flushPromises()


### PR DESCRIPTION
## 摘要

- **Studio 对话区空白**：`MediaStudioView` 不再等待价格 catalog 完成才挂载 `ChatStudio`；bootstrap 期间显示 loading 占位；默认 modality 改为 chat。
- **过期视频 UX**：刷新后上游 http 临时链接不再持久化；历史卡片只展示 prompt + 过期说明，去掉播放入口；同会话播放失败时静默标记过期，不再弹出「预览已过期」lightbox。
- **Admin OpenAI 用量窗口**：平台筛选触发 debounced reload 后补拉 batch 用量；`usageOverride` watch 加 `immediate: true`，首次筛选即可显示 GPT-pro 窗口。

sentinel-registry-reviewed（均为既有 Studio/Accounts 面的 bugfix，无新增 load-bearing 契约面）

upstream-touch-trivial（TK bugfix：无 upstream merge 回滚风险；`useMediaLibrary` 为 TK Studio 持久化语义，非上游同步面）

## 风险

- 常规风险，纯前端 + embedded dist manifest 同步，无后端/API/Schema 变更。
- 过期视频：同会话内刚生成的视频仍可播放；仅 reload 后或播放失败时切 prompt-only。

## 验证

- `./scripts/preflight.sh` PASS（含 pre-commit）
- `pnpm exec vitest run src/views/user/studio/__tests__/MediaStudioView.spec.ts src/views/user/studio/__tests__/VideoStudio.spec.ts src/composables/__tests__/useMediaLibrary.spec.ts src/utils/__tests__/studioMedia.tk.spec.ts src/components/account/__tests__/AccountUsageCell.spec.ts` — 35 passed
- `pnpm --dir frontend run build` — dist / frontend-source.json 已更新

## 提交

- 30ca11bf6 fix(studio): 修复对话区空白、过期视频卡片与账号用量窗口

最新提交：30ca11bf6
