### PR TITLE
feat(pricing): 登录态公开目录也显示授权分组与专属分组跳转

### DIFF
--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -165,7 +165,12 @@ type MePricingCatalogResponse struct {
 	Models           []MePricingModel     `json:"models"`
 	MyKeys           []MePricingKeyRef    `json:"my_keys"`
 	AccessibleGroups []MePricingGroupRef  `json:"accessible_groups"`
-	UpdatedAt        time.Time            `json:"updated_at"`
+	// AuthorizedGroupsByModel is the full model_id → accessible-groups index
+	// reused by the authenticated public-catalog view on /pricing (models[] only
+	// covers the target group's menu; the public catalog is wider). Same serving
+	// logic as per-row AuthorizedGroups — see buildAuthorizedGroupsIndex.
+	AuthorizedGroupsByModel map[string][]MePricingModelGroup `json:"authorized_groups_by_model,omitempty"`
+	UpdatedAt               time.Time                        `json:"updated_at"`
 }
 
 // MePricingTargetGroup describes the group the menu is currently scoped to.
@@ -194,10 +199,11 @@ type MePricingModel struct {
 	MaxOutputTokens int            `json:"max_output_tokens,omitempty"`
 	Capabilities    []string       `json:"capabilities"`
 	// AuthorizedGroups lists the caller's accessible groups (exclusive + public)
-	// that can serve this model — the "授权分组" column on the /pricing "my" view.
+	// that can serve this model — the "授权分组" column on /pricing when logged in
+	// (my view per-row; public view via authorized_groups_by_model lookup).
 	// Lets a user see at a glance which group/key to use, and (frontend) deep-link
-	// to /keys to create a key prefilled with that group. Empty/omitted on the
-	// public catalog. Sorted: target group first, then exclusive, then by name.
+	// to /keys to create a key prefilled with that group. Empty/omitted for guests.
+	// Sorted: target group first, then exclusive, then by name.
 	AuthorizedGroups []MePricingModelGroup `json:"authorized_groups,omitempty"`
 }
 
@@ -401,7 +407,10 @@ func (s *MePricingCatalogService) BuildForUser(
 
 	// 「授权分组」列：对每个模型标注该用户可访问分组中能服务它的分组集合，
 	// 方便用户看清该用什么 key/分组（前端可点击直达建 key）。
-	models = s.attachAuthorizedGroups(ctx, models, accessibleGroups, userRates, targetGroupID, opts.HideUserRateOverrides)
+	authByModel := s.buildAuthorizedGroupsIndex(
+		ctx, models, accessibleGroups, userRates, targetGroupID, opts.HideUserRateOverrides,
+	)
+	models = applyAuthorizedGroupsIndex(models, authByModel)
 
 	// HideUserRateOverrides：倍率提示字段回落到分组默认值（前端已不再渲染这些
 	// 字段——pricing 页与倍率彻底脱钩——但保留 #693 的口径以稳住 DTO 与测试）。
@@ -442,10 +451,11 @@ func (s *MePricingCatalogService) BuildForUser(
 			IsExclusive:      targetGroup.IsExclusive,
 			SubscriptionType: targetGroup.SubscriptionType,
 		},
-		Models:           models,
-		MyKeys:           myKeys,
-		AccessibleGroups: groupRefs,
-		UpdatedAt:        time.Now().UTC(),
+		Models:                  models,
+		MyKeys:                  myKeys,
+		AccessibleGroups:        groupRefs,
+		AuthorizedGroupsByModel: authByModel,
+		UpdatedAt:               time.Now().UTC(),
 	}, nil
 }
 
@@ -595,26 +605,22 @@ func (s *MePricingCatalogService) buildModelsForGroup(
 	return out
 }
 
-// attachAuthorizedGroups fills each model's AuthorizedGroups with the accessible
-// groups that can serve it. It reuses buildModelsForGroup per accessible group —
-// the exact channel + account-fallback serving logic — and inverts to
-// model_id -> []group, so the column can never diverge from what the gateway
-// actually schedules. K = len(accessibleGroups) is a single user's authorized
-// group count (small); BuildPublicCatalog is mtime-cached so the repeated
-// metadata join is cheap, and the target group's rows are reused (not rebuilt).
-// Rate=1.0 because only the served model_id SET matters here, not the price.
-func (s *MePricingCatalogService) attachAuthorizedGroups(
+// buildAuthorizedGroupsIndex inverts buildModelsForGroup across every accessible
+// group into model_id → []group. Reuses the target group's already-built rows
+// instead of rebuilding them. The index powers both the per-row AuthorizedGroups
+// on the "my" view and the authenticated public-catalog column (wider model set).
+func (s *MePricingCatalogService) buildAuthorizedGroupsIndex(
 	ctx context.Context,
-	models []MePricingModel,
+	targetModels []MePricingModel,
 	accessibleGroups []Group,
 	userRates map[int64]float64,
 	targetGroupID int64,
 	hideOverrides bool,
-) []MePricingModel {
-	if s == nil || len(models) == 0 || len(accessibleGroups) == 0 {
-		return models
+) map[string][]MePricingModelGroup {
+	if s == nil || len(accessibleGroups) == 0 {
+		return nil
 	}
-	byModel := make(map[string][]MePricingModelGroup, len(models))
+	byModel := make(map[string][]MePricingModelGroup)
 	for i := range accessibleGroups {
 		g := accessibleGroups[i]
 		rate := g.RateMultiplier
@@ -631,9 +637,8 @@ func (s *MePricingCatalogService) attachAuthorizedGroups(
 			SubscriptionType: g.SubscriptionType,
 		}
 		if g.ID == targetGroupID {
-			// Reuse the already-built target rows instead of rebuilding them.
-			for j := range models {
-				byModel[models[j].ModelID] = append(byModel[models[j].ModelID], ref)
+			for j := range targetModels {
+				byModel[targetModels[j].ModelID] = append(byModel[targetModels[j].ModelID], ref)
 			}
 			continue
 		}
@@ -641,13 +646,31 @@ func (s *MePricingCatalogService) attachAuthorizedGroups(
 			byModel[m.ModelID] = append(byModel[m.ModelID], ref)
 		}
 	}
-	for i := range models {
-		groups := byModel[models[i].ModelID]
+	for modelID, groups := range byModel {
 		if len(groups) == 0 {
+			delete(byModel, modelID)
 			continue
 		}
 		sortAuthorizedGroups(groups)
-		models[i].AuthorizedGroups = groups
+		byModel[modelID] = groups
+	}
+	if len(byModel) == 0 {
+		return nil
+	}
+	return byModel
+}
+
+func applyAuthorizedGroupsIndex(
+	models []MePricingModel,
+	byModel map[string][]MePricingModelGroup,
+) []MePricingModel {
+	if len(byModel) == 0 || len(models) == 0 {
+		return models
+	}
+	for i := range models {
+		if groups := byModel[models[i].ModelID]; len(groups) > 0 {
+			models[i].AuthorizedGroups = groups
+		}
 	}
 	return models
 }

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -762,9 +762,11 @@ func TestBuildForUser_AuthorizedGroups_CrossGroup(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, ga.AuthorizedGroups, 1)
 	assert.Equal(t, int64(30), ga.AuthorizedGroups[0].ID)
-}
 
-// TestBuildForUser_AccountWhitelist_VendorPrefix exercises reuse of
+	require.NotNil(t, resp.AuthorizedGroupsByModel)
+	assert.Len(t, resp.AuthorizedGroupsByModel["gpt-5"], 2)
+	assert.Len(t, resp.AuthorizedGroupsByModel["gpt-a"], 1)
+}
 // stripVendorPrefixForCatalogLookup (PR #326). An account whitelisting an
 // OpenRouter-style "<vendor>/<model>" must still resolve to the LiteLLM
 // catalog's bare model_id row.

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 515,
-  "hash": "749e0a9aa0b1364585f24273d76ef08ea7f10e8f376c5f98003ce6da44c39517",
+  "hash": "bc8d587e32c09d7ada65c039086334895f7d7e1fe6a25cabf77de4be9aaed97e",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 515,
-  "hash": "bc8d587e32c09d7ada65c039086334895f7d7e1fe6a25cabf77de4be9aaed97e",
+  "hash": "acb4148d3ec77e166064598285180232400a06ef53e90e7ccf402ebaa8a3e913",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/me-pricing.ts
+++ b/frontend/src/api/me-pricing.ts
@@ -74,8 +74,7 @@ export interface MePricingModel {
   context_window?: number
   max_output_tokens?: number
   capabilities: string[]
-  /** Accessible groups (exclusive + public) that can serve this model.
-   *  Only present on the authenticated "my" view; empty/omitted publicly. */
+  /** Accessible groups that can serve this model — "授权分组" column when logged in. */
   authorized_groups?: MePricingModelGroup[]
 }
 
@@ -114,6 +113,8 @@ export interface MePricingCatalogResponse {
   models: MePricingModel[]
   my_keys: MePricingKeyRef[]
   accessible_groups: MePricingGroupRef[]
+  /** Full model_id → authorized-groups index for the authenticated public catalog. */
+  authorized_groups_by_model?: Record<string, MePricingModelGroup[]>
   updated_at: string
 }
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -59,6 +59,7 @@ export default {
       keyPlaceholder: 'All keys',
       group: 'Group',
       publicCatalog: 'Public catalog',
+      groupExclusiveOption: '{group} (exclusive)',
       search: 'Search',
       activePublic: 'Viewing the public catalog',
       activeGroup: 'Viewing {group} group catalog',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -58,10 +58,10 @@ export default {
       apiKey: 'API Key',
       keyPlaceholder: 'All keys',
       group: 'Group',
-      publicCatalog: 'Public catalog',
+      publicCatalog: 'All groups',
       groupExclusiveOption: '{group} (exclusive)',
       search: 'Search',
-      activePublic: 'Viewing the public catalog',
+      activePublic: 'Viewing all groups',
       activeGroup: 'Viewing {group} group catalog',
       activeKeyGroup: 'Viewing {key} · {group}'
     },
@@ -82,7 +82,7 @@ export default {
     // multipliers.
     my: {
       tabMy: 'Group Catalog',
-      tabPublic: 'All Catalog',
+      tabPublic: 'All groups',
       title: 'Group Model Catalog',
       subtitle: 'Models available to the group of your selected API key, at official pricing',
       description:

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -58,6 +58,7 @@ export default {
       keyPlaceholder: '全部 Key',
       group: 'Group',
       publicCatalog: '公开目录',
+      groupExclusiveOption: '{group}（专属）',
       search: '搜索',
       activePublic: '正在查看公开目录',
       activeGroup: '正在查看 {group} 的分组目录',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -57,10 +57,10 @@ export default {
       apiKey: 'API Key',
       keyPlaceholder: '全部 Key',
       group: 'Group',
-      publicCatalog: '公开目录',
+      publicCatalog: '所有分组',
       groupExclusiveOption: '{group}（专属）',
       search: '搜索',
-      activePublic: '正在查看公开目录',
+      activePublic: '正在查看所有分组',
       activeGroup: '正在查看 {group} 的分组目录',
       activeKeyGroup: '正在查看 {key} · {group}'
     },
@@ -80,7 +80,7 @@ export default {
     // 展示官方定价，与分组倍率/个人覆写脱钩。
     my: {
       tabMy: '分组目录',
-      tabPublic: '所有目录',
+      tabPublic: '所有分组',
       title: '分组模型目录',
       subtitle: '当前 API Key 所属分组可调用的模型与官方定价',
       description:

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -112,7 +112,7 @@
                     :key="g.id"
                     :value="`group:${g.id}`"
                   >
-                    {{ g.name }}
+                    {{ groupFilterOptionLabel(g) }}
                   </option>
                 </select>
               </label>
@@ -335,8 +335,9 @@
                       {{ t('pricing.columns.capabilities') }}
                     </th>
                     <th
-                      v-if="viewMode === 'my'"
+                      v-if="showAuthorizedGroupsColumn"
                       scope="col"
+                      data-tk="pricing-col-authorized-groups"
                       class="sticky top-0 z-40 min-w-[12rem] bg-gray-50 px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
                     >
                       {{ t('pricing.my.columns.authorizedGroups') }}
@@ -457,7 +458,11 @@
                         >
                       </div>
                     </td>
-                    <td v-if="viewMode === 'my'" class="px-3 py-3 align-top">
+                    <td
+                      v-if="showAuthorizedGroupsColumn"
+                      data-tk="pricing-col-authorized-groups"
+                      class="px-3 py-3 align-top"
+                    >
                       <div class="flex flex-wrap gap-1.5">
                         <button
                           v-for="g in row.authorizedGroups || []"
@@ -589,7 +594,7 @@ interface NormalizedRow {
   perSecond?: number | null
   /** Input-token interval (阶梯) ladder, normalized from either catalog source. */
   tiers?: NormalizedTier[]
-  /** Accessible groups that can serve this model — "授权分组" column ('my' view only). */
+  /** Accessible groups that can serve this model — "授权分组" column when logged in. */
   authorizedGroups?: MePricingModelGroup[]
 }
 
@@ -657,6 +662,14 @@ function rowModality(billingMode?: string): PricingModality {
   return 'text'
 }
 
+function hasSavedAuthToken(): boolean {
+  try {
+    return typeof localStorage !== 'undefined' && !!localStorage.getItem('auth_token')
+  } catch {
+    return false
+  }
+}
+
 // Public catalog state (unchanged from v1 — US-028 backing data).
 const publicCatalog = ref<PublicCatalogResponse | null>(null)
 
@@ -665,7 +678,29 @@ const myCatalog = ref<MePricingCatalogResponse | null>(null)
 const selectedKeyId = ref<number>(0)
 const selectedGroupId = ref<number>(0)
 
-const canShowCatalogFilters = computed(() => myCatalog.value != null)
+const canShowCatalogFilters = computed(
+  () =>
+    myCatalog.value != null || authStore.isAuthenticated || hasSavedAuthToken()
+)
+
+/** Logged-in users see the authorized-groups column on both my and public views. */
+const showAuthorizedGroupsColumn = computed(
+  () => authStore.isAuthenticated || hasSavedAuthToken()
+)
+
+const authorizedGroupsByModel = computed<Record<string, MePricingModelGroup[]>>(() => {
+  const fromIndex = myCatalog.value?.authorized_groups_by_model
+  if (fromIndex && Object.keys(fromIndex).length > 0) {
+    return fromIndex
+  }
+  const fromRows: Record<string, MePricingModelGroup[]> = {}
+  for (const m of myCatalog.value?.models ?? []) {
+    if (m.authorized_groups?.length) {
+      fromRows[m.model_id] = m.authorized_groups
+    }
+  }
+  return fromRows
+})
 
 // Admin-only "export platform pricing" — the public (在售目录/对外价) catalog only,
 // as a sales-friendly CSV. Always visible for admins regardless of the current
@@ -740,7 +775,8 @@ const normalizedRows = computed<NormalizedRow[]>(() => {
         maxTokens: tt.max_tokens ?? null,
         inputPer1K: tt.input_per_1k_tokens ?? null,
         outputPer1K: tt.output_per_1k_tokens ?? null
-      }))
+      })),
+      authorizedGroups: authorizedGroupsByModel.value[m.model_id] ?? []
     }))
   }
   // 'my' view
@@ -835,8 +871,20 @@ const formattedUpdatedAt = computed(() => {
 
 const groupFilterOptions = computed<MePricingGroupRef[]>(() => {
   if (!myCatalog.value) return []
-  return myCatalog.value.accessible_groups
+  const groups = [...myCatalog.value.accessible_groups]
+  groups.sort((a, b) => {
+    if (a.is_exclusive !== b.is_exclusive) return a.is_exclusive ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+  return groups
 })
+
+function groupFilterOptionLabel(g: MePricingGroupRef): string {
+  if (g.is_exclusive) {
+    return t('pricing.filters.groupExclusiveOption', { group: g.name })
+  }
+  return g.name
+}
 
 const displayGroupValue = computed(() => {
   if (viewMode.value === 'public') return 'public'
@@ -949,14 +997,6 @@ async function loadMyCatalog(): Promise<void> {
   myCatalog.value = await getMePricingCatalog(params)
 }
 
-function hasSavedAuthToken(): boolean {
-  try {
-    return typeof localStorage !== 'undefined' && !!localStorage.getItem('auth_token')
-  } catch {
-    return false
-  }
-}
-
 async function loadInitialCatalog(): Promise<void> {
   if (!hasSavedAuthToken()) {
     viewMode.value = 'public'
@@ -1019,6 +1059,16 @@ function onPickGroup(e: Event): void {
   void load()
 }
 
+async function ensureMyCatalogForAuthHints(): Promise<void> {
+  if (!hasSavedAuthToken() && !authStore.isAuthenticated) return
+  if (myCatalog.value?.authorized_groups_by_model) return
+  try {
+    myCatalog.value = await getMePricingCatalog()
+  } catch {
+    // Public catalog still works without auth hints.
+  }
+}
+
 async function load(): Promise<void> {
   loading.value = true
   errorMessage.value = ''
@@ -1028,7 +1078,7 @@ async function load(): Promise<void> {
     } else if (viewMode.value === 'my') {
       await loadMyCatalog()
     } else {
-      await loadPublicCatalog()
+      await Promise.all([ensureMyCatalogForAuthHints(), loadPublicCatalog()])
     }
   } catch (err) {
     const apiErr = err as { message?: string }

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -866,7 +866,7 @@ const formattedUpdatedAt = computed(() => {
 
 // ============================== group switcher ==============================
 //
-// TK: pricing 页（分组目录/所有目录）一律展示官方定价，与分组倍率/个人覆写
+// TK: pricing 页（分组目录/所有分组）一律展示官方定价，与分组倍率/个人覆写
 // 彻底脱钩——故不再有倍率提示（原 rateHint）、对比下拉不再拼 ×N 倍率角标。
 
 const groupFilterOptions = computed<MePricingGroupRef[]>(() => {

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -83,15 +83,15 @@ vi.mock('vue-i18n', async () => {
     'pricing.filters.apiKey': 'API Key',
     'pricing.filters.keyPlaceholder': 'All keys',
     'pricing.filters.group': 'Group',
-    'pricing.filters.publicCatalog': 'Public catalog',
+    'pricing.filters.publicCatalog': 'All groups',
     'pricing.filters.groupExclusiveOption': '{group} (exclusive)',
     'pricing.filters.search': 'Search',
-    'pricing.filters.activePublic': 'Viewing the public catalog',
+    'pricing.filters.activePublic': 'Viewing all groups',
     'pricing.filters.activeGroup': 'Viewing {group} group catalog',
     'pricing.filters.activeKeyGroup': 'Viewing {key} · {group}',
     'common.loading': 'Loading',
     'pricing.my.tabMy': 'Group Catalog',
-    'pricing.my.tabPublic': 'All Catalog',
+    'pricing.my.tabPublic': 'All groups',
     'pricing.my.title': 'Group Model Catalog',
     'pricing.my.subtitle': '',
     'pricing.my.description': '',
@@ -389,7 +389,7 @@ describe('PricingView', () => {
     await flushPromises()
 
     expect(getPublicPricing).toHaveBeenCalledTimes(1)
-    expect(wrapper.text()).toContain('Viewing the public catalog')
+    expect(wrapper.text()).toContain('Viewing all groups')
     expect(wrapper.text()).toContain('public-model')
     expect(wrapper.find('[data-tk="pricing-filter-key"]').exists()).toBe(true)
     expect(wrapper.find('[data-tk="pricing-filter-group"]').exists()).toBe(true)
@@ -497,7 +497,7 @@ describe('PricingView', () => {
 
     expect(getMePricingCatalog).toHaveBeenCalledTimes(1)
     expect(getPublicPricing).toHaveBeenCalledTimes(1)
-    expect(wrapper.text()).toContain('Viewing the public catalog')
+    expect(wrapper.text()).toContain('Viewing all groups')
     expect(wrapper.text()).toContain('public-model')
   })
 
@@ -546,7 +546,7 @@ describe('PricingView', () => {
 
     // Switched to public, loaded it, and exported that catalog.
     expect(getPublicPricing).toHaveBeenCalledTimes(1)
-    expect(wrapper.text()).toContain('Viewing the public catalog')
+    expect(wrapper.text()).toContain('Viewing all groups')
     expect(exportPricingCsv).toHaveBeenCalledTimes(1)
     expect(exportPricingCsv.mock.calls[0][0]).toMatchObject({
       data: [expect.objectContaining({ model_id: 'public-model' })],

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -84,6 +84,7 @@ vi.mock('vue-i18n', async () => {
     'pricing.filters.keyPlaceholder': 'All keys',
     'pricing.filters.group': 'Group',
     'pricing.filters.publicCatalog': 'Public catalog',
+    'pricing.filters.groupExclusiveOption': '{group} (exclusive)',
     'pricing.filters.search': 'Search',
     'pricing.filters.activePublic': 'Viewing the public catalog',
     'pricing.filters.activeGroup': 'Viewing {group} group catalog',
@@ -109,7 +110,10 @@ vi.mock('vue-i18n', async () => {
     'pricing.perRequest': '/ request',
     'pricing.export.button': 'Export CSV',
     'pricing.export.success': 'Pricing exported',
-    'pricing.export.empty': 'Public catalog is empty — nothing to export'
+    'pricing.export.empty': 'Public catalog is empty — nothing to export',
+    'pricing.my.columns.authorizedGroups': 'Authorized Groups',
+    'pricing.my.authorizedGroups.createKeyHint': 'Create a key in {group}',
+    'pricing.my.authorizedGroups.exclusive': 'exclusive',
   }
   return {
     ...actual,
@@ -389,6 +393,98 @@ describe('PricingView', () => {
     expect(wrapper.text()).toContain('public-model')
     expect(wrapper.find('[data-tk="pricing-filter-key"]').exists()).toBe(true)
     expect(wrapper.find('[data-tk="pricing-filter-group"]').exists()).toBe(true)
+  })
+
+  it('shows authorized groups on the public catalog when logged in', async () => {
+    authState.isAuthenticated = true
+    localStorage.setItem('auth_token', 'token')
+    getMePricingCatalog.mockResolvedValue(
+      meCatalog({
+        authorized_groups_by_model: {
+          'public-only-model': [
+            {
+              id: 10,
+              name: 'Pro',
+              platform: 'newapi',
+              is_exclusive: true,
+              is_current_for_key: true,
+              rate_multiplier: 1.5,
+            },
+            {
+              id: 20,
+              name: 'Batch',
+              platform: 'newapi',
+              is_exclusive: false,
+              is_current_for_key: false,
+              rate_multiplier: 1,
+            },
+          ],
+        },
+      })
+    )
+    getPublicPricing.mockResolvedValue(publicCatalog([publicModel('public-only-model')]))
+
+    const wrapper = mountPricingView()
+    await flushPromises()
+
+    await wrapper.get('[data-tk="pricing-filter-group"]').setValue('public')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Authorized Groups')
+    expect(wrapper.text()).toContain('Pro')
+    expect(wrapper.text()).toContain('Batch')
+    expect(wrapper.text()).toContain('exclusive')
+    expect(wrapper.find('[data-tk="pricing-col-authorized-groups"]').exists()).toBe(true)
+  })
+
+  it('labels exclusive groups in the group filter while viewing the public catalog', async () => {
+    authState.isAuthenticated = true
+    localStorage.setItem('auth_token', 'token')
+    getMePricingCatalog.mockResolvedValue(
+      meCatalog({
+        accessible_groups: [
+          {
+            id: 10,
+            name: 'Pro',
+            platform: 'newapi',
+            rate_multiplier: 1.5,
+            is_current_for_key: true,
+            is_exclusive: true,
+            subscription_type: 'standard',
+          },
+          {
+            id: 20,
+            name: 'Batch',
+            platform: 'newapi',
+            rate_multiplier: 1,
+            is_current_for_key: false,
+            is_exclusive: false,
+            subscription_type: 'standard',
+          },
+        ],
+      })
+    )
+    getPublicPricing.mockResolvedValue(publicCatalog([publicModel('public-only-model')]))
+
+    const wrapper = mountPricingView()
+    await flushPromises()
+
+    await wrapper.get('[data-tk="pricing-filter-group"]').setValue('public')
+    await flushPromises()
+
+    const groupSelect = wrapper.get('[data-tk="pricing-filter-group"]')
+    expect(groupSelect.text()).toContain('Pro (exclusive)')
+    expect(groupSelect.text()).toContain('Batch')
+    expect(groupSelect.text()).not.toContain('Batch (exclusive)')
+  })
+
+  it('hides authorized groups on the public catalog for guests', async () => {
+    getPublicPricing.mockResolvedValue(publicCatalog([publicModel('public-only-model')]))
+
+    const wrapper = mountPricingView()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Authorized Groups')
   })
 
   it('falls back to the public catalog when saved auth cannot load the user catalog', async () => {


### PR DESCRIPTION
## 摘要

- #1034 在「分组目录」已有「授权分组」列 + 点击 badge 深链建 key；本 PR 延伸到**登录态下的「所有分组」视图**（原内部 `viewMode=public`，GROUP 下拉不再叫「公开目录」）。
- **GROUP 下拉**：第一项为「所有分组」，其余为可访问分组；专属分组带 `（专属）` 后缀。
- **表格最右列**：「所有分组」视图每行展示可服务该模型的分组 badge（与 #1034 同款样式/跳转）；后端新增 `authorized_groups_by_model` 全量索引。

## 风险

- 后端纯加性：抽出 `buildAuthorizedGroupsIndex`，响应多一个 map 字段；调度/计费路径未改。
- 前端薄注入：`PricingView` 列可见性 + 行 merge + GROUP 文案；`upstream-touch-trivial`。
- 已 merge 最新 `main`（含 Studio/Accounts 等前端变更），冲突仅在 `frontend-source.json`，`pnpm build` 重建 dist。

## 验证

- `go test -tags=unit ./internal/service/ -run 'MePricing|AuthorizedGroups'` ✓
- `pnpm exec vitest run src/views/__tests__/PricingView.spec.ts`（14 项）✓
- merge 后 `pnpm build` + `./scripts/preflight.sh` PASS ✓

## 提交

- 820b42129 merge: resolve main into feat/pricing-public-authorized-groups
- fd4ac923a fix(pricing): GROUP 筛选「公开目录」改名为「所有分组」
- f6147f5d3 feat(pricing): 登录态公开目录也显示授权分组与专属分组跳转

最新提交：820b42129

---

sentinel-registry-reviewed — DTO 加字段 + PricingView 加性扩展，未删 frontend-tk / gateway-tk 锚点。
