### PR TITLE
fix(pricing): gpt-5.6 系列补 overlay 展示价（#1030 漏项）

### DIFF
--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1254,5 +1254,50 @@
     "input_cost_per_token": 1e-07,
     "output_cost_per_token": 1e-07,
     "source": "Z.AI official pricing (https://docs.z.ai/guides/overview/pricing, captured 2026-06-22; page last modified 2026-06-16): GLM-4-32B-0414-128K input $0.10/Mtok, output $0.10/Mtok. The official table has no cached-input price for this row. Served through TokenKey newapi account 67 after tk_044 switches GLM from channel_type=16 to ZhipuV4 channel_type=26."
+  },
+  "gpt-5.6-sol": {
+    "litellm_provider": "openai",
+    "mode": "chat",
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 0.0000005,
+    "cache_creation_input_token_cost": 0.00000625,
+    "source": "GPT-5.6 Sol official OpenAI tier. gpt-5.6 is absent from the upstream Wei-Shaw/litellm runtime mirror prod fetches, so the overlay carries it for /pricing display (billing already correct via billing_service fallbackPrices, PR #1030). Mirrors resources/model-pricing/model_prices_and_context_window.json. Captured 2026-06-27."
+  },
+  "gpt-5.6-terra": {
+    "litellm_provider": "openai",
+    "mode": "chat",
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 0.00000025,
+    "cache_creation_input_token_cost": 0.000003125,
+    "source": "GPT-5.6 Terra official OpenAI tier. gpt-5.6 is absent from the upstream Wei-Shaw/litellm runtime mirror prod fetches, so the overlay carries it for /pricing display (billing already correct via billing_service fallbackPrices, PR #1030). Mirrors resources/model-pricing/model_prices_and_context_window.json. Captured 2026-06-27."
+  },
+  "gpt-5.6-luna": {
+    "litellm_provider": "openai",
+    "mode": "chat",
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 0.0000001,
+    "cache_creation_input_token_cost": 0.00000125,
+    "source": "GPT-5.6 Luna official OpenAI tier. gpt-5.6 is absent from the upstream Wei-Shaw/litellm runtime mirror prod fetches, so the overlay carries it for /pricing display (billing already correct via billing_service fallbackPrices, PR #1030). Mirrors resources/model-pricing/model_prices_and_context_window.json. Captured 2026-06-27."
+  },
+  "gpt-5.6-chat-latest": {
+    "litellm_provider": "openai",
+    "mode": "chat",
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 0.0000005,
+    "cache_creation_input_token_cost": 0.00000625,
+    "source": "GPT-5.6 chat-latest bills as Sol (billing_service collapses it). gpt-5.6 is absent from the upstream Wei-Shaw/litellm runtime mirror prod fetches, so the overlay carries it for /pricing display (billing already correct via billing_service fallbackPrices, PR #1030). Mirrors resources/model-pricing/model_prices_and_context_window.json. Captured 2026-06-27."
+  },
+  "gpt-5.6": {
+    "litellm_provider": "openai",
+    "mode": "chat",
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 0.0000005,
+    "cache_creation_input_token_cost": 0.00000625,
+    "source": "Bare gpt-5.6 alias bills as Sol (openai_codex_transform/openai_model_alias map gpt-5.6 -> gpt-5.6-sol). gpt-5.6 is absent from the upstream Wei-Shaw/litellm runtime mirror prod fetches, so the overlay carries it for /pricing display (billing already correct via billing_service fallbackPrices, PR #1030). Mirrors resources/model-pricing/model_prices_and_context_window.json. Captured 2026-06-27."
   }
 }


### PR DESCRIPTION
# fix(pricing): gpt-5.6 系列补 overlay 展示价（#1030 漏项）

## 摘要

#1030 上架 GPT-5.6 Sol/Terra/Luna 时把价加到了 ①`billing_service` fallbackPrices（计费）②`resources/model-pricing` bundled mirror ③servable allowlist，**漏了 `tk_pricing_overlay.json`**，导致 `/pricing` 显示空价（厂商/价/上下文全是 `—`），但**计费一直正确**。

根因：prod 的展示目录从**上游 `Wei-Shaw/model-price-repo` 拉取**（运行期源 `/app/data/model_pricing.json`，prod 无 `PRICING_*` env 覆盖 → 用默认上游 URL），该源没有 TK 自有的 gpt-5.6；bundled mirror 只是被 shadow 的 fallback（运行期路径里都不存在）。**overlay 是 TK 给「上游目录没有的自有模型」补展示价的唯一机制**——`applyCatalogOverlayPricing` 会把不在源里的 overlay 模型**注入**公开目录，gpt-5.6 已在 allowlist 故注入后过 servable 过滤 → public `/pricing` + my-pricing 双面显示。

本 PR 给 overlay 补 5 条（价取自 #1030 官方 tier，与 mirror/fallbackPrices 一致，禁臆造）：

| model | input | output | 说明 |
|---|---|---|---|
| gpt-5.6 / gpt-5.6-sol / gpt-5.6-chat-latest | $5/M | $30/M | bare/chat-latest 计费折叠为 sol（codex_transform/model_alias） |
| gpt-5.6-terra | $2.5/M | $15/M | |
| gpt-5.6-luna | $1/M | $6/M | |

（cache_read / cache_creation 同步 mirror。）

## 风险

- **仅改 TK 自有数据文件 `tk_pricing_overlay.json`**（+5 条，纯插入）——无 service 逻辑 / 计费代码 / migration / 上游文件改动。计费此前已正确，本 PR 只补展示。
- overlay 注入条目**不带 context window**（注入路径不设 max tokens，既有限制）→ gpt-5.6 上下文列暂空，价/厂商正常显示。属可接受的小缺口，非本 PR 范围。
- 价为 fill-only：若日后上游源补上 gpt-5.6 真价，源值自动让位（`tkIsEffectivelyUnpriced` 语义），overlay 不覆盖真实非零源价。
- 发现的 **hot-push 工具缺陷**（`manage-overlay-runtime.py` 读回路径走 SSM stdout 24KiB 上限，overlay 已 81KB → `check`/`sync-runtime` 读回截断报错）**不在本 PR**，单独处置（见 PR 讨论）；本 PR 走常规发版即可让嵌入式 floor 带上 gpt-5.6。

## 验证

- `scripts/checks/pricing-overlay.py`：**99 条 overlay 全 valid（anchors present, no $0）**。
- 完整 `preflight`（pre-commit）**PASS（exit 0）**——pricing overlay / pricing-availability sentinel / overlay-runtime hot-push tool selftest / catalog serving drift 全绿。
- 价值逐条核对 `resources/model-pricing/model_prices_and_context_window.json` gpt-5.6-*（#1030 加的镜像）与 `billing_service.go` fallbackPrices 一致。
- 注入链路代码确认：`applyCatalogOverlayPricing` 对源缺失模型走 append 注入 → `FilterPublicCatalogToServable` 按 allowlist 保留 → my-pricing `buildModelsForGroup` Stage 3 经 `metaByID` 拿到价/厂商。

## 提交

`git log --oneline origin/main..HEAD`：

- 7e506f247 fix(pricing): gpt-5.6 系列补 overlay 展示价（#1030 漏项，/pricing 显示空价）

最新提交：7e506f247

## 合并

- 合并方式：**Squash and merge**（TK fix PR，§5.y）；合并等人授权。

---

no-web-impact — 仅改后端 TK 数据文件 `tk_pricing_overlay.json`（pricing overlay 内容），无 `frontend/` 源改动；/pricing 展示内容变化经后端目录注入，非前端构件变更。
