### PR TITLE
feat(modelops): display-coverage completeness — audit + CI gate + antigravity overlay backfill

### DIFF
--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1338,5 +1338,11 @@
     "mode": "image_generation",
     "output_cost_per_image": 0.0672,
     "source": "Gemini 3.1 Flash Image (preview) via antigravity (per-image, Vertex official). antigravity-served wire id; displays via overlay because prod reads the upstream remote mirror (which lacks it) and the bundled mirror is a shadowed fallback. Rate mirrors backend/resources/model-pricing/model_prices_and_context_window.json gemini-* (vertex_ai official). Surfaced by audit-display-coverage 2026-06-27 (#1029 allowlisted it without an overlay entry — same class as #1030)."
+  },
+  "gemini-3-pro-image": {
+    "litellm_provider": "antigravity",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.134,
+    "source": "Gemini 3 Pro Image via antigravity (per-image display /bin/zsh.134 = 1K/2K official Vertex rate, 1120 output tokens; = TK getDefaultImagePrice hardcoded fallback). Ref docs/accounts/google_vertex_pricing_20260619.md. Serves as itself (migration 049 identity mapping; -preview maps into it). Gemini-native image bills via the /v1/chat/completions token path, so this is the display figure. Surfaced by audit-display-coverage 2026-06-27."
   }
 }

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1299,5 +1299,44 @@
     "cache_read_input_token_cost": 0.0000005,
     "cache_creation_input_token_cost": 0.00000625,
     "source": "Bare gpt-5.6 alias bills as Sol (openai_codex_transform/openai_model_alias map gpt-5.6 -> gpt-5.6-sol). gpt-5.6 is absent from the upstream Wei-Shaw/litellm runtime mirror prod fetches, so the overlay carries it for /pricing display (billing already correct via billing_service fallbackPrices, PR #1030). Mirrors resources/model-pricing/model_prices_and_context_window.json. Captured 2026-06-27."
+  },
+  "gemini-3-flash": {
+    "litellm_provider": "antigravity",
+    "mode": "chat",
+    "input_cost_per_token": 0.0000005,
+    "output_cost_per_token": 0.000003,
+    "source": "Gemini 3 Flash via antigravity. antigravity-served wire id; displays via overlay because prod reads the upstream remote mirror (which lacks it) and the bundled mirror is a shadowed fallback. Rate mirrors backend/resources/model-pricing/model_prices_and_context_window.json gemini-* (vertex_ai official). Surfaced by audit-display-coverage 2026-06-27 (#1029 allowlisted it without an overlay entry — same class as #1030)."
+  },
+  "gemini-3.1-pro-low": {
+    "litellm_provider": "antigravity",
+    "mode": "chat",
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "source": "Gemini 3.1 Pro (low) via antigravity. antigravity-served wire id; displays via overlay because prod reads the upstream remote mirror (which lacks it) and the bundled mirror is a shadowed fallback. Rate mirrors backend/resources/model-pricing/model_prices_and_context_window.json gemini-* (vertex_ai official). Surfaced by audit-display-coverage 2026-06-27 (#1029 allowlisted it without an overlay entry — same class as #1030)."
+  },
+  "gemini-3.5-flash": {
+    "litellm_provider": "antigravity",
+    "mode": "chat",
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "source": "Gemini 3.5 Flash via antigravity. antigravity-served wire id; displays via overlay because prod reads the upstream remote mirror (which lacks it) and the bundled mirror is a shadowed fallback. Rate mirrors backend/resources/model-pricing/model_prices_and_context_window.json gemini-* (vertex_ai official). Surfaced by audit-display-coverage 2026-06-27 (#1029 allowlisted it without an overlay entry — same class as #1030)."
+  },
+  "gemini-2.5-flash-image": {
+    "litellm_provider": "antigravity",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.039,
+    "source": "Gemini 2.5 Flash Image via antigravity (per-image, Vertex official). antigravity-served wire id; displays via overlay because prod reads the upstream remote mirror (which lacks it) and the bundled mirror is a shadowed fallback. Rate mirrors backend/resources/model-pricing/model_prices_and_context_window.json gemini-* (vertex_ai official). Surfaced by audit-display-coverage 2026-06-27 (#1029 allowlisted it without an overlay entry — same class as #1030)."
+  },
+  "gemini-3.1-flash-image": {
+    "litellm_provider": "antigravity",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.0672,
+    "source": "Gemini 3.1 Flash Image via antigravity (per-image, Vertex official). antigravity-served wire id; displays via overlay because prod reads the upstream remote mirror (which lacks it) and the bundled mirror is a shadowed fallback. Rate mirrors backend/resources/model-pricing/model_prices_and_context_window.json gemini-* (vertex_ai official). Surfaced by audit-display-coverage 2026-06-27 (#1029 allowlisted it without an overlay entry — same class as #1030)."
+  },
+  "gemini-3.1-flash-image-preview": {
+    "litellm_provider": "antigravity",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.0672,
+    "source": "Gemini 3.1 Flash Image (preview) via antigravity (per-image, Vertex official). antigravity-served wire id; displays via overlay because prod reads the upstream remote mirror (which lacks it) and the bundled mirror is a shadowed fallback. Rate mirrors backend/resources/model-pricing/model_prices_and_context_window.json gemini-* (vertex_ai official). Surfaced by audit-display-coverage 2026-06-27 (#1029 allowlisted it without an overlay entry — same class as #1030)."
   }
 }

--- a/ops/pricing/audit-display-coverage.py
+++ b/ops/pricing/audit-display-coverage.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""audit-display-coverage.py — servable ⇒ displayable completeness audit.
+
+The #1030 failure class: a model is in the Go servable allowlist
+(pricing_catalog_supported_models_tk.go) and bills correctly (fallbackPrices /
+family floor), but shows a BLANK price on /pricing because no DISPLAY source
+carries it. The display catalog is built from the upstream remote mirror
+(Wei-Shaw/model-price-repo, live-fetched) UNIONed with the TK overlay
+(tk_pricing_overlay.json, which INJECTS models the source lacks). The bundled
+backend/resources/model-pricing file is only a SHADOWED fallback prod does not
+read, and it is hand-maintained — so it is NOT a reliable "will it display"
+signal. The overlay is the only prod-reliable, repo-checkable display source.
+
+This tool asserts the invariant operators actually care about:
+
+    every model in the Go servable allowlist resolves to a NON-ZERO display
+    price, via the overlay (repo truth) OR the live prod /pricing (remote truth).
+
+"Display price" is media-aware: token models need input/output > 0; image
+models need output_cost_per_image > 0; video models need output_cost_per_second
+> 0.
+
+Coverage sources, in order:
+  - overlay  : tk_pricing_overlay.json carries the model with a non-zero price
+               (token OR media). Reliable in prod regardless of remote lag.
+  - live     : with --live, GET <base>/api/v1/public/pricing and treat a model
+               shown there with a non-zero token price as covered (this is how
+               standard upstream models — claude/gpt-5/… — are legitimately
+               sourced from the remote mirror, NOT the overlay).
+
+A model covered by NEITHER is a GAP (the #1030 shape). Antigravity/grok models
+are filtered out of the PUBLIC catalog by the vendor allowlist, so for those the
+overlay is the only coverage signal — exactly why #1029's antigravity image
+additions show as gaps until overlay-priced.
+
+Subcommands:
+  check        report gaps (exit 0 clean / 1 gaps / 2 error). --live to also
+               credit models displayed on prod. --platform to scope.
+  selftest     offline unit tests (no network, no repo reads).
+
+This is the LIVE CLOSE-OUT of model onboarding: run `check --live` after a
+catalog change is live and require 0 gaps. It is also a safe (read-only)
+periodic prod audit.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+GO_ALLOWLIST = REPO / "backend/internal/service/pricing_catalog_supported_models_tk.go"
+OVERLAY = REPO / "backend/internal/service/tk_pricing_overlay.json"
+DEFAULT_BASE = os.environ.get("TOKENKEY_BASE_URL", "https://api.tokenkey.dev")
+PLATFORMS = ("anthropic", "openai", "gemini", "antigravity", "grok")
+
+
+def parse_allowlist(go_text: str) -> dict[str, set[str]]:
+    """Extract {platform: {model_id, …}} from the splice-marked Go maps."""
+    out: dict[str, set[str]] = {}
+    for plat in PLATFORMS:
+        m = re.search(
+            r"servable-allowlist:begin %s(.*?)servable-allowlist:end %s" % (plat, plat),
+            go_text,
+            re.S,
+        )
+        out[plat] = set(re.findall(r'"([^"]+)":\s*\{\}', m.group(1))) if m else set()
+    return out
+
+
+def overlay_priced(entry: dict) -> bool:
+    """True iff the overlay entry carries a non-zero price (token OR media)."""
+    if not isinstance(entry, dict):
+        return False
+    return (
+        (entry.get("input_cost_per_token") or 0) > 0
+        or (entry.get("output_cost_per_token") or 0) > 0
+        or (entry.get("output_cost_per_image") or 0) > 0
+        or (entry.get("output_cost_per_second") or 0) > 0
+    )
+
+
+def overlay_covered(overlay: dict) -> set[str]:
+    return {k for k, v in overlay.items() if k != "_meta" and overlay_priced(v)}
+
+
+def _row_token_priced(row: dict) -> bool:
+    pr = row.get("pricing") or {}
+    tiers = pr.get("tiers") or []
+    base = tiers[0] if tiers else pr
+    return (base.get("input_per_1k_tokens") or 0) > 0 or (base.get("output_per_1k_tokens") or 0) > 0
+
+
+def live_token_priced(payload: dict) -> set[str]:
+    """Model ids that the live public catalog shows with a non-zero TOKEN price.
+    Media coverage is judged via the overlay (reliable), so the live signal only
+    needs to credit token models sourced from the remote mirror."""
+    out: set[str] = set()
+    for row in payload.get("data", []):
+        mid = row.get("model_id") or row.get("id")
+        if mid and _row_token_priced(row):
+            out.add(mid)
+    return out
+
+
+def fetch_live(base_url: str) -> dict:
+    url = base_url.rstrip("/") + "/api/v1/public/pricing"
+    with urllib.request.urlopen(url, timeout=25) as r:  # noqa: S310 (fixed prod URL)
+        return json.loads(r.read().decode())
+
+
+def audit(
+    allowlist: dict[str, set[str]],
+    covered_overlay: set[str],
+    covered_live: set[str],
+) -> dict[str, list[tuple[str, str]]]:
+    """Return {platform: [(model, reason), …]} for allowlisted-but-uncovered."""
+    gaps: dict[str, list[tuple[str, str]]] = {}
+    for plat, ids in allowlist.items():
+        miss = []
+        for mid in sorted(ids):
+            if mid in covered_overlay:
+                continue
+            if mid in covered_live:
+                continue
+            reason = "no overlay entry; not displayed on live /pricing" if covered_live else "no overlay entry"
+            miss.append((mid, reason))
+        if miss:
+            gaps[plat] = miss
+    return gaps
+
+
+def cmd_check(args) -> int:
+    try:
+        allowlist = parse_allowlist(GO_ALLOWLIST.read_text(encoding="utf-8"))
+        overlay = json.loads(OVERLAY.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001
+        print(f"ERROR: cannot read repo sources: {e}", file=sys.stderr)
+        return 2
+    covered_overlay = overlay_covered(overlay)
+    covered_live: set[str] = set()
+    if args.live:
+        try:
+            covered_live = live_token_priced(fetch_live(args.base_url))
+        except Exception as e:  # noqa: BLE001
+            print(f"ERROR: live /pricing fetch failed ({e}); rerun without --live for repo-only audit", file=sys.stderr)
+            return 2
+    if args.platform:
+        allowlist = {args.platform: allowlist.get(args.platform, set())}
+
+    gaps = audit(allowlist, covered_overlay, covered_live)
+    mode = "overlay ∪ live prod /pricing" if args.live else "overlay only (repo) — pass --live to credit remote-displayed models"
+    print(f"=== display-coverage audit (source: {mode}) ===")
+    total_models = sum(len(v) for v in allowlist.values())
+    total_gaps = sum(len(v) for v in gaps.values())
+    for plat, ids in allowlist.items():
+        plat_gaps = gaps.get(plat, [])
+        print(f"  {plat}: {len(plat_gaps)}/{len(ids)} uncovered")
+        for mid, why in plat_gaps:
+            print(f"      GAP {mid} — {why}")
+    print(f"TOTAL: {total_gaps} display gap(s) across {total_models} allowlisted model(s)")
+    if total_gaps:
+        print("\nfix: add a priced entry to tk_pricing_overlay.json (the prod-reliable display", file=sys.stderr)
+        print("source) for each GAP — use ops/pricing/apply-pricing-hotfix.py stage-overlay.", file=sys.stderr)
+    return 1 if total_gaps else 0
+
+
+def cmd_selftest(_args) -> int:
+    # parse_allowlist
+    go = (
+        "x\n// servable-allowlist:begin openai\n"
+        '\t"gpt-5": {},\n\t"gpt-5.6-sol": {},\n'
+        "// servable-allowlist:end openai\n"
+        "// servable-allowlist:begin gemini\n"
+        '\t"imagen-4.0-generate-001": {},\n\t"gemini-2.5-pro": {},\n'
+        "// servable-allowlist:end gemini\n"
+    )
+    al = parse_allowlist(go)
+    assert al["openai"] == {"gpt-5", "gpt-5.6-sol"}, al["openai"]
+    assert al["gemini"] == {"imagen-4.0-generate-001", "gemini-2.5-pro"}, al["gemini"]
+    assert al["anthropic"] == set() and al["grok"] == set(), al
+
+    # overlay_priced: token / image / video / zero / missing
+    assert overlay_priced({"input_cost_per_token": 5e-6})
+    assert overlay_priced({"output_cost_per_image": 0.04})
+    assert overlay_priced({"output_cost_per_second": 0.6})
+    assert not overlay_priced({"input_cost_per_token": 0, "output_cost_per_token": 0})
+    assert not overlay_priced({"litellm_provider": "openai"})  # no price fields
+    ov = {
+        "_meta": {"note": "x"},
+        "imagen-4.0-generate-001": {"output_cost_per_image": 0.04},  # media → covered
+        "veo-3.1-generate-001": {"output_cost_per_second": 0.6},     # media → covered
+        "zero-model": {"input_cost_per_token": 0},                   # zero → NOT covered
+    }
+    assert overlay_covered(ov) == {"imagen-4.0-generate-001", "veo-3.1-generate-001"}, overlay_covered(ov)
+
+    # live_token_priced: tiers + flat, media-zero excluded
+    live = {"data": [
+        {"model_id": "gpt-5", "pricing": {"tiers": [{"input_per_1k_tokens": 0.01, "output_per_1k_tokens": 0.03}]}},
+        {"model_id": "imagen-4.0-generate-001", "pricing": {"tiers": [{"input_per_1k_tokens": 0, "output_per_1k_tokens": 0}]}},
+        {"model_id": "gpt-flat", "pricing": {"input_per_1k_tokens": 0.002}},
+    ]}
+    lt = live_token_priced(live)
+    assert lt == {"gpt-5", "gpt-flat"}, lt  # imagen has zero token price → not credited here (overlay covers media)
+
+    # audit: the #1030 + #1029-antigravity shapes
+    allowlist = {
+        "openai": {"gpt-5", "gpt-5.6-sol"},          # gpt-5 via live; gpt-5.6-sol uncovered
+        "gemini": {"imagen-4.0-generate-001"},        # media via overlay
+        "antigravity": {"gemini-3.5-flash"},          # uncovered (no overlay, filtered from public)
+    }
+    covered_overlay = {"imagen-4.0-generate-001"}
+    covered_live = {"gpt-5"}
+    g = audit(allowlist, covered_overlay, covered_live)
+    assert g.get("openai") == [("gpt-5.6-sol", "no overlay entry; not displayed on live /pricing")], g
+    assert "gemini" not in g, g            # imagen covered by overlay (media)
+    assert g.get("antigravity") == [("gemini-3.5-flash", "no overlay entry; not displayed on live /pricing")], g
+
+    # repo-only mode (no live): gpt-5 also a gap (only overlay credited)
+    g2 = audit(allowlist, covered_overlay, set())
+    assert ("gpt-5", "no overlay entry") in g2["openai"], g2
+    print("audit-display-coverage selftest: PASS")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="servable ⇒ displayable completeness audit")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    ck = sub.add_parser("check", help="report allowlisted-but-undisplayable models")
+    ck.add_argument("--live", action="store_true", help="also credit models shown priced on prod /pricing")
+    ck.add_argument("--base-url", default=DEFAULT_BASE, help=f"prod base (default {DEFAULT_BASE})")
+    ck.add_argument("--platform", choices=PLATFORMS, help="scope to one platform")
+    ck.set_defaults(func=cmd_check)
+    st = sub.add_parser("selftest", help="offline unit tests")
+    st.set_defaults(func=cmd_selftest)
+    args = ap.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/checks/display-coverage-gate.py
+++ b/scripts/checks/display-coverage-gate.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""display-coverage-gate.py — forward guard against the #1030 / #1029 failure class.
+
+Both #1030 (gpt-5.6) and #1029 (antigravity gemini-* image/3.5-flash) added models
+to the Go servable allowlist (pricing_catalog_supported_models_tk.go) and to the
+BUNDLED litellm mirror (backend/resources/model-pricing/…), reasoning "it's priced
+in the mirror, so it displays." It does NOT: prod's /pricing catalog is built from
+the live UPSTREAM remote mirror (Wei-Shaw/model-price-repo) ∪ the TK overlay
+(tk_pricing_overlay.json). The bundled mirror is a hand-maintained, SHADOWED
+fallback prod never reads — so a model present only there shows a BLANK price.
+The overlay is the only prod-reliable, repo-checkable display source.
+
+This gate is DIFF-SCOPED: it only fires on models a PR ADDS to the allowlist
+(base..HEAD), so it passes on a clean main and never retroactively fails. For each
+newly-allowlisted model it requires display coverage in the overlay (non-zero,
+token OR media). The escape hatch is a falsifiable assertion, not a rubber stamp:
+a commit message carrying `display-via-remote-verified` declares the author
+confirmed the model already displays priced via the upstream remote (the only
+legitimate non-overlay source). The live backstop is
+ops/pricing/audit-display-coverage.py check --live (catches a wrong assertion).
+
+Exit: 0 clean / 1 gap (uncovered new allowlist entry, no marker) / 2 error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+GO_REL = "backend/internal/service/pricing_catalog_supported_models_tk.go"
+OVERLAY_REL = "backend/internal/service/tk_pricing_overlay.json"
+PLATFORMS = ("anthropic", "openai", "gemini", "antigravity", "grok")
+MARKER = "display-via-remote-verified"
+
+
+def parse_allowlist(go_text: str) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for plat in PLATFORMS:
+        m = re.search(
+            r"servable-allowlist:begin %s(.*?)servable-allowlist:end %s" % (plat, plat),
+            go_text,
+            re.S,
+        )
+        out[plat] = set(re.findall(r'"([^"]+)":\s*\{\}', m.group(1))) if m else set()
+    return out
+
+
+def overlay_priced(entry: object) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    return (
+        (entry.get("input_cost_per_token") or 0) > 0
+        or (entry.get("output_cost_per_token") or 0) > 0
+        or (entry.get("output_cost_per_image") or 0) > 0
+        or (entry.get("output_cost_per_second") or 0) > 0
+    )
+
+
+def covered_overlay_ids(overlay: dict) -> set[str]:
+    return {k for k, v in overlay.items() if k != "_meta" and overlay_priced(v)}
+
+
+def _git(*args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(REPO), *args], text=True)
+
+
+def added_allowlist_models(base: str) -> dict[str, set[str]]:
+    """Models present in HEAD's allowlist but not base's, per platform."""
+    try:
+        base_go = _git("show", f"{base}:{GO_REL}")
+    except subprocess.CalledProcessError:
+        base_go = ""  # file absent at base → everything is "added"
+    head_go = (REPO / GO_REL).read_text(encoding="utf-8")
+    base_al = parse_allowlist(base_go)
+    head_al = parse_allowlist(head_go)
+    return {p: head_al.get(p, set()) - base_al.get(p, set()) for p in PLATFORMS}
+
+
+def has_marker(base: str) -> bool:
+    try:
+        msgs = _git("log", "--format=%B", f"{base}..HEAD")
+    except subprocess.CalledProcessError:
+        return False
+    return MARKER in msgs
+
+
+def _base_resolves(base: str) -> bool:
+    try:
+        _git("rev-parse", "--verify", "--quiet", f"{base}^{{commit}}")
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def cmd_check(args) -> int:
+    if not _base_resolves(args.base):
+        # Offline / shallow clone without the base ref: skip rather than treat the
+        # whole allowlist as "added" (a false-fail). CI fetches origin/main, so the
+        # gate is enforced there.
+        print(f"display-coverage-gate: skip (base {args.base!r} not resolvable locally)")
+        return 0
+    try:
+        overlay = json.loads((REPO / OVERLAY_REL).read_text(encoding="utf-8"))
+        added = added_allowlist_models(args.base)
+    except Exception as e:  # noqa: BLE001
+        print(f"display-coverage-gate: error: {e}", file=sys.stderr)
+        return 2
+    covered = covered_overlay_ids(overlay)
+    uncovered: list[tuple[str, str]] = []
+    for plat, ids in added.items():
+        for mid in sorted(ids):
+            if mid not in covered:
+                uncovered.append((plat, mid))
+    if not uncovered:
+        print("display-coverage-gate: ok (no new allowlist entries lack overlay display coverage)")
+        return 0
+    if has_marker(args.base):
+        print(f"display-coverage-gate: ok ({MARKER} present; "
+              f"{len(uncovered)} new allowlist entr(ies) declared remote-displayed)")
+        for plat, mid in uncovered:
+            print(f"    (remote-verified) {plat}: {mid}")
+        return 0
+    print("display-coverage-gate: FAIL — new servable-allowlist entr(ies) with NO display "
+          "price source (overlay). The bundled mirror does NOT display in prod.", file=sys.stderr)
+    for plat, mid in uncovered:
+        print(f"    {plat}: {mid}", file=sys.stderr)
+    print(f"\nfix: add a priced tk_pricing_overlay.json entry for each (ops/pricing/"
+          f"apply-pricing-hotfix.py stage-overlay), OR if it genuinely displays via the\n"
+          f"upstream remote mirror, put `{MARKER}` in a commit message after confirming with\n"
+          f"ops/pricing/audit-display-coverage.py check --live.", file=sys.stderr)
+    return 1
+
+
+def cmd_selftest(_args) -> int:
+    base_go = (
+        "// servable-allowlist:begin openai\n"
+        '\t"gpt-5": {},\n'
+        "// servable-allowlist:end openai\n"
+    )
+    head_go = (
+        "// servable-allowlist:begin openai\n"
+        '\t"gpt-5": {},\n\t"gpt-5.6-sol": {},\n\t"gpt-6": {},\n'
+        "// servable-allowlist:end openai\n"
+    )
+    bal, hal = parse_allowlist(base_go), parse_allowlist(head_go)
+    added = {p: hal.get(p, set()) - bal.get(p, set()) for p in PLATFORMS}
+    assert added["openai"] == {"gpt-5.6-sol", "gpt-6"}, added["openai"]
+
+    overlay = {"_meta": {}, "gpt-6": {"input_cost_per_token": 1e-5, "output_cost_per_token": 3e-5}}
+    covered = covered_overlay_ids(overlay)
+    assert covered == {"gpt-6"}, covered
+    # gpt-5.6-sol uncovered (the #1030 shape) → would FAIL without marker; gpt-6 covered.
+    uncovered = [(p, m) for p, ids in added.items() for m in ids if m not in covered]
+    assert uncovered == [("openai", "gpt-5.6-sol")], uncovered
+
+    # media coverage counts
+    assert overlay_priced({"output_cost_per_image": 0.04})
+    assert overlay_priced({"output_cost_per_second": 0.6})
+    assert not overlay_priced({"input_cost_per_token": 0})
+    assert not overlay_priced({"litellm_provider": "openai"})
+    print("display-coverage-gate selftest: PASS")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="forward guard: new allowlist entry ⇒ overlay display coverage")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    ck = sub.add_parser("check")
+    ck.add_argument("--base", default="origin/main", help="diff base (default origin/main)")
+    ck.set_defaults(func=cmd_check)
+    st = sub.add_parser("selftest")
+    st.set_defaults(func=cmd_selftest)
+    args = ap.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1549,6 +1549,45 @@ else
     fi
 fi
 
+# ---- sub2api: display-coverage gate (servable ⇒ displayable) ----------------
+# Guards the #1030 / #1029 failure class: a model added to the Go servable
+# allowlist with NO display price source. Prod's /pricing reads the upstream
+# remote mirror ∪ tk_pricing_overlay.json; the bundled resources/model-pricing
+# mirror is a SHADOWED, hand-maintained fallback prod never reads — so a model
+# present only there renders a BLANK price (gpt-5.6 #1030; antigravity gemini-*
+# #1029). Diff-scoped: only NEW allowlist entries must be overlay-priced (or carry
+# `display-via-remote-verified`). Live backstop:
+# ops/pricing/audit-display-coverage.py check --live. CLAUDE.md §「升级原则」.
+echo ""
+echo "=== sub2api: display-coverage gate ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by display-coverage-gate)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/display-coverage-gate.py selftest >/dev/null 2>&1; then
+    echo "  FAIL: display-coverage-gate.py selftest (re-run: python3 scripts/checks/display-coverage-gate.py selftest)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/display-coverage-gate.py check --base "${PREFLIGHT_BASE:-origin/main}"; then
+    # gate already printed the actionable failure.
+    errors=$((errors + 1))
+fi
+
+# ---- sub2api: display-coverage audit selftest -------------------------------
+# ops/pricing/audit-display-coverage.py is the LIVE close-out of any catalog
+# change (run `check --live`, require 0 gaps) and a safe read-only periodic prod
+# audit. CI only runs its offline selftest; the --live audit is an operator /
+# scheduled action (no prod network in CI).
+echo ""
+echo "=== sub2api: display-coverage audit selftest ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by audit-display-coverage)"
+    errors=$((errors + 1))
+elif ! python3 ops/pricing/audit-display-coverage.py selftest >/dev/null 2>&1; then
+    echo "  FAIL: audit-display-coverage.py selftest (re-run: python3 ops/pricing/audit-display-coverage.py selftest)"
+    errors=$((errors + 1))
+else
+    echo "  ok: display-coverage audit selftest"
+fi
+
 # probe-servable-models.sh unconditionally sources its companion
 # probe_reserved_resources.sh (reserved-only; no direct-key fallback). run-probe.sh
 # only ships the companion to the remote host when the caller passes --with, so any


### PR DESCRIPTION
# feat(modelops): display-coverage completeness — audit + CI gate + antigravity overlay backfill

## 摘要

机制化消除 **#1030 / #1029 这一类「未完成形态」**：模型进了 Go servable allowlist、靠家族 floor / mirror 正常**计费**，但 `/pricing` 显示**空价**——因为没有任何**展示**源带它。

根因：prod 的 `/pricing` 展示目录读 **上游远端 mirror（`Wei-Shaw/model-price-repo`，运行期拉取）∪ `tk_pricing_overlay.json`**；仓库内 `backend/resources/model-pricing` mirror 只是**被 shadow 的手维 fallback，prod 从不读**。所以把模型加进 bundled mirror（#1030 的 gpt-5.6、#1029 的 antigravity gemini-*）**不会让它展示**。**overlay 是唯一 prod 可靠、仓库可校验的展示源。**

本 PR 三件：
1. **`ops/pricing/audit-display-coverage.py`** — **LIVE 收尾 / 周期巡检**。断言每个 allowlisted 模型经 overlay **或** live prod `/pricing` 解析出非零展示价（token + 媒体均覆盖）。`check --live` = 上架收尾闸（要求 0 gap）、只读安全。本轮 live 跑出全部 12 个真实 gap。
2. **`scripts/checks/display-coverage-gate.py`（+ preflight 接线）** — **diff-scoped CI 守卫**：PR 新增的 allowlist 条目必须 overlay 已定价（**bundled mirror 不算数**），否则需 commit 带 `display-via-remote-verified`。这条闸**本可拦下 #1030 与 #1029**。
3. **回填 7 个 antigravity overlay gap**（audit 发现，价**忠实取自源、禁臆造**）：`gemini-3-flash` / `-3.1-pro-low` / `-3.5-flash`（chat）+ `-2.5-flash-image` / `-3.1-flash-image` / `-3.1-flash-image-preview`（按张，bundled-mirror Vertex 官方率）+ **`gemini-3-pro-image`** = **$0.134/img**（`docs/accounts/google_vertex_pricing_20260619.md` Gemini 3 Pro Image 1K/2K 官方价 = TK `getDefaultImagePrice` fallback；它在 antigravity 经 migration 049 identity mapping **自服务**，非映射到他名）。均用既有 `provider=antigravity` overlay 模式。

合本 PR + #1038（gpt-5.6）后，`audit-display-coverage check --live` **antigravity 0/14、全平台 0 gap**。

## 风险

- **仅改 TK 自有数据 + ops/scripts 工具**：`tk_pricing_overlay.json`（+6 条 antigravity，纯插入）、`scripts/preflight.sh`（+2 检查）、2 个新工具。无 service 逻辑 / 计费代码 / migration / 上游文件改动。计费此前已正确，本 PR 只补展示 + 加守卫。
- 6 条 antigravity overlay 价 = bundled-mirror 既有 curated 值（非臆造），且复用既有 `provider=antigravity` 模式 → 行为与既有 antigravity overlay 条目一致（consistent-by-precedent）。
- CI gate **diff-scoped**：只对「本 PR 新增的 allowlist 条目」生效，clean main 必过、不回溯失败；base 不可解析时 skip（避免离线误报）。本 PR 不新增 allowlist 条目 → gate 自然过。
- audit `--live` 只读 prod `/pricing`（公开端点 curl），无任何写。

## 验证

- `audit-display-coverage.py selftest` PASS；`display-coverage-gate.py selftest` PASS。
- **live 审计**：`check --live` 跑通，定位 12 真实 gap（媒体/公开-vs-my-pricing 假阳已正确排除）；本 PR 回填全部 7 个 antigravity gap → `antigravity 0/14`，仅剩 gpt-5.6（在 #1038）。
- `scripts/checks/pricing-overlay.py`：100 条 overlay 全 valid（no $0）。
- 完整 `preflight` **PASS（exit 0）**——含新 `display-coverage gate` / `display-coverage audit selftest` / `ops tool orphan（0 orphans，新工具已接线）` / overlay validator 全绿。

## 提交

`git log --oneline origin/main..HEAD`：

- 88d51efd0 fix(modelops): price gemini-3-pro-image overlay ($0.134/img, doc-sourced)
- 86ee524cb feat(modelops): display-coverage completeness — audit + CI gate + antigravity overlay backfill

最新提交：88d51efd0

> rebased onto origin/main `e4271d31e`（含已合并的 #1038 gpt-5.6 + #1040 hot-push 修复）；overlay 冲突按 union 解（保留 #1038 的 gpt-5.6 + 本 PR 7 个 antigravity，无丢条目）。合本 PR 后 `audit-display-coverage check --live` = **全平台 0 gap**。

## 合并

- 合并方式：**Squash and merge**（TK feat PR，§5.y）；合并等人授权。

---

no-web-impact — 仅后端数据（`tk_pricing_overlay.json`）+ `ops/`、`scripts/` 工具；无 `frontend/` 源改动。

sentinel-registry-reviewed — 已复核 registry 影响：新增文件为 `ops/pricing/audit-display-coverage.py`（ops 审计工具，preflight selftest 接线）与 `scripts/checks/display-coverage-gate.py`（CI 检查脚本），**均非运行期 TK 服务面 / 非 `*_tk_*.go` companion / 非前端模块**，无需新增 sentinel 锚点；`tk_pricing_overlay.json` 为既有数据文件内容改动。
