### PR TITLE
fix(ops): overlay hot-push read-back — gzip the SELECT so >24KiB overlays parse

### DIFF
--- a/ops/pricing/manage-overlay-runtime.py
+++ b/ops/pricing/manage-overlay-runtime.py
@@ -93,16 +93,37 @@ def drift_is_clean(drift: dict) -> bool:
 # --- AWS / SSM I/O: resolve_prod_instance + run_shell_b64 live in ops/stage0/ssm_execution.py
 
 
-def read_runtime_blob(instance_id: str) -> dict:
-    shell = f"{PSQL} -c \"SELECT value FROM settings WHERE key='{SETTING_KEY}';\""
-    b64 = base64.b64encode(shell.encode()).decode()
-    out = _SSM.run_shell_b64(instance_id, b64, "overlay check: read runtime settings").strip()
+def _decode_runtime_value(out: str) -> dict:
+    """Decode the host-side `SELECT value … | gzip | base64` output back to the
+    overlay dict. Empty output (no settings row, or an empty value) -> {}. Raises
+    on a corrupt gzip/base64/JSON payload (read_runtime_blob wraps it with fail())."""
+    out = out.strip()
     if not out:
         return {}
+    raw = gzip.decompress(base64.b64decode(out)).decode("utf-8").strip()
+    if not raw:
+        return {}
+    return json.loads(raw)
+
+
+def read_runtime_blob(instance_id: str) -> dict:
+    # The runtime overlay blob is ~80KB+ JSON; piping the raw SELECT to SSM stdout
+    # truncates at AWS GetCommandInvocation's ~24KiB cap (surfaces as an
+    # "Unterminated string" JSON error once the overlay outgrows ~24KiB — which it
+    # has). gzip|base64 the value ON THE HOST first: ~80KB -> ~13KB compressed,
+    # well under the cap; decode + gunzip client-side. Mirrors the sync-runtime
+    # WRITE path, which already gzips for exactly this reason. (json.JSONDecodeError
+    # is a ValueError subclass, so it is covered by the except below.)
+    shell = (
+        f"{PSQL} -c \"SELECT value FROM settings WHERE key='{SETTING_KEY}';\""
+        " | gzip -c | base64 | tr -d '\\n'"
+    )
+    b64 = base64.b64encode(shell.encode()).decode()
+    out = _SSM.run_shell_b64(instance_id, b64, "overlay check: read runtime settings (gzip)")
     try:
-        return json.loads(out)
-    except json.JSONDecodeError as e:
-        fail(f"runtime settings blob is not valid JSON: {e}")
+        return _decode_runtime_value(out)
+    except (OSError, ValueError) as e:
+        fail(f"runtime settings blob decode failed (host gzip|base64 read-back): {e}")
 
 
 def load_repo_overlay() -> dict:
@@ -239,6 +260,18 @@ def cmd_selftest(_args) -> int:
             print(f"  FAIL {name}: got {got} want {want}")
         else:
             print(f"  PASS {name}")
+    # _decode_runtime_value: the >24KiB gzip read-back round-trip (the fix). The
+    # host pipes `SELECT value | gzip | base64`; this must reconstruct the dict.
+    try:
+        blob = {"_meta": {"n": "x"}, "m": {"input_cost_per_token": 1e-6}}
+        enc = base64.b64encode(gzip.compress((json.dumps(blob) + "\n").encode())).decode()
+        assert _decode_runtime_value(enc) == blob
+        assert _decode_runtime_value("") == {}                                              # no command output
+        assert _decode_runtime_value(base64.b64encode(gzip.compress(b"")).decode()) == {}   # settings row absent
+        print("  PASS decode-runtime-value gzip read-back round-trip")
+    except AssertionError:
+        ok = False
+        print("  FAIL decode-runtime-value gzip read-back round-trip")
     print("selftest ok" if ok else "selftest FAILED")
     return 0 if ok else 1
 


### PR DESCRIPTION
# fix(ops): overlay hot-push read-back — gzip the SELECT so >24KiB overlays parse

## 摘要

`manage-overlay-runtime.py` 的 `check` 与 `sync-runtime` 把 prod 运行期 overlay blob 经 `psql SELECT value` → SSM stdout 读回，但 AWS `GetCommandInvocation` 的 stdout **上限 ~24KiB**。overlay 现已 **~81KiB**，读回在中途被截断（`Unterminated string` JSON 报错）：`check` 直接失败、`sync-runtime` 在写之前的幂等预读处就 `fail()` 退出——即**全平台展示价的 overlay 热推在当前规模下是坏的**。写路径早已 gzip，唯独读回从未压缩，随 overlay 增长静默越限；离线 selftest 只测纯 drift 逻辑，从未覆盖真实 SSM 读尺寸。

修复：读回也在 **host 侧先 `gzip|base64`**（对称于写路径）——~81KiB → ~13KiB，远低于上限——客户端再 gunzip。抽出 `_decode_runtime_value`（空/无行 → `{}`）并加 round-trip selftest。

## 风险

- **仅改一个 ops 工具**（`ops/pricing/manage-overlay-runtime.py`），无 service / 计费 / migration / 前端 / 上游文件改动。
- 行为对称于既有写路径（同样 gzip），语义不变：`check` 的 drift 判定、`sync-runtime` 的幂等 + 写后校验逻辑均不变，只是读回不再截断。
- 边界：无 settings 行 / 空值 → `SELECT` 空 → gzip(空) → 解码为空 → `{}`（selftest 覆盖）。

## 验证

- `--selftest` PASS（含新 `decode-runtime-value gzip read-back round-trip`）。
- **只读对 prod 实测**：`check` 现成功返回（`prod runtime 93 / git 94，1 pending: gemini-2.5-flash-thinking`），不再报截断错；**未做任何写**。同时证明 prod 运行期 blob 本就完好（93 条），先前的「损坏」纯属读侧截断假象。
- 完整 `preflight` **PASS（exit 0）**——`overlay-runtime hot-push tool selftest` 闸跑的就是本工具的更新 selftest。

## 提交

`git log --oneline origin/main..HEAD`：

- 31b8f5fe4 fix(ops): overlay hot-push read-back — gzip the SELECT so >24KiB overlays parse

最新提交：31b8f5fe4

## 合并

- 合并方式：**Squash and merge**（TK fix PR，§5.y）；合并等人授权。

---

no-web-impact — 仅 ops 工具脚本；无 `frontend/` 源、无运行期服务代码改动。
