### PR TITLE
fix(modelops): surface antigravity gemini-* in public /pricing (vendor re-attribution)

### DIFF
--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -265,12 +265,43 @@ func FilterPublicCatalogToServable(resp *PublicCatalogResponse) *PublicCatalogRe
 	out := *resp // shallow copy: Object/UpdatedAt carried, Data replaced
 	filtered := make([]PublicCatalogModel, 0, len(resp.Data))
 	for _, m := range resp.Data {
+		// m is a by-value copy of the row — re-tagging its vendor here is
+		// presentation-only and never mutates the caller's cached BuildPublicCatalog.
+		m.Vendor = presentationVendorForServable(m.ModelID, m.Vendor)
 		if isPublicCatalogModelSupported(m.Vendor, m.ModelID) {
 			filtered = append(filtered, m)
 		}
 	}
 	out.Data = filtered
 	return &out
+}
+
+// presentationVendorForServable re-tags antigravity-served wire ids that the
+// upstream price mirror carries under a gemini/vertex vendor. The mirror routes
+// names like gemini-3.5-flash / gemini-3-pro-image / gemini-*-image to the
+// PlatformGemini gate, whose allowlist (the constrained Vertex 7-key set) lacks
+// them — so the public catalog silently drops them even though antigravity serves
+// them and the overlay/source prices them (#1029/#1030 follow-up: same class as
+// the gpt-5.6 display gap, on a different surface). A model that is in the
+// antigravity allowlist but NOT the gemini allowlist is antigravity-EXCLUSIVE:
+// re-attribute it to the antigravity vendor so it passes the antigravity gate and
+// displays under the correct (antigravity-served) vendor. Dual-listed ids (e.g.
+// gemini-2.5-flash, in BOTH sets) are genuinely Vertex-served too and keep the
+// gemini vendor. Presentation-only by construction (the caller copies rows by
+// value), so IsModelPriced / the Your-Menu metadata join are untouched.
+// ("public catalog" = the catalog behind GET /api/v1/public/pricing; the UI labels
+// that view 「所有分组 / All groups」 since #1037 — symbol names stay publicCatalog.)
+func presentationVendorForServable(modelID, vendor string) string {
+	if _, ag := supportedAntigravityCatalogModels[modelID]; !ag {
+		return vendor
+	}
+	if _, gem := supportedGeminiCatalogModels[modelID]; gem {
+		return vendor // dual-listed: genuinely Vertex-served, keep gemini vendor
+	}
+	if inferPlatformFromVendor(vendor) == PlatformGemini {
+		return PlatformAntigravity
+	}
+	return vendor
 }
 
 // supportedCatalogModelIDsForPlatform returns the empirically-servable model

--- a/backend/internal/service/pricing_catalog_tk_test.go
+++ b/backend/internal/service/pricing_catalog_tk_test.go
@@ -500,3 +500,47 @@ func TestPricingCatalogService_NilReceiverIsSafe(t *testing.T) {
 	assert.Equal(t, "list", resp.Object)
 	assert.Empty(t, resp.Data)
 }
+
+func TestFilterPublicCatalog_ReattributesAntigravityExclusiveVendor(t *testing.T) {
+	// The upstream price mirror carries antigravity-served wire ids under the
+	// vertex_ai vendor; without re-attribution the gemini gate (constrained Vertex
+	// allowlist) drops them from the public catalog (#1029/#1030 follow-up — same
+	// class as the gpt-5.6 display gap, on the antigravity surface).
+	in := &PublicCatalogResponse{Object: "list", Data: []PublicCatalogModel{
+		{ModelID: "gemini-3.5-flash", Vendor: "vertex_ai-language-models"},               // antigravity-exclusive, mirror-vendored
+		{ModelID: "gemini-3-pro-image", Vendor: "antigravity"},                           // antigravity-exclusive, overlay-injected
+		{ModelID: "gemini-2.5-flash", Vendor: "vertex_ai-language-models"},               // DUAL-listed (gemini + antigravity)
+		{ModelID: "imagen-4.0-generate-001", Vendor: "vertex_ai"},                        // gemini allowlist
+		{ModelID: "gemini-9-experimental-unlisted", Vendor: "vertex_ai-language-models"}, // in NO allowlist -> dropped
+	}}
+	out := FilterPublicCatalogToServable(in)
+	require.NotNil(t, out)
+	byID := map[string]PublicCatalogModel{}
+	for _, m := range out.Data {
+		byID[m.ModelID] = m
+	}
+
+	// antigravity-exclusive, mirror-vendored: survives + re-attributed to antigravity
+	m, ok := byID["gemini-3.5-flash"]
+	require.True(t, ok, "antigravity-exclusive gemini-* must survive the public filter")
+	assert.Equal(t, "antigravity", m.Vendor, "re-attributed to antigravity vendor")
+	// antigravity-exclusive, already overlay-injected as antigravity: survives unchanged
+	m, ok = byID["gemini-3-pro-image"]
+	require.True(t, ok)
+	assert.Equal(t, "antigravity", m.Vendor)
+	// dual-listed: survives, vendor NOT changed (genuinely Vertex-served too)
+	m, ok = byID["gemini-2.5-flash"]
+	require.True(t, ok, "dual-listed gemini survives")
+	assert.Equal(t, "vertex_ai-language-models", m.Vendor, "dual-listed keeps gemini vendor")
+	// plain gemini-allowlist model: survives, untouched
+	_, ok = byID["imagen-4.0-generate-001"]
+	assert.True(t, ok)
+	// vertex_ai model in NO allowlist: still dropped (the gemini gate stays strict)
+	_, ok = byID["gemini-9-experimental-unlisted"]
+	assert.False(t, ok, "vertex_ai model in no allowlist is still dropped")
+
+	// pure-function unit
+	assert.Equal(t, "antigravity", presentationVendorForServable("gemini-3.5-flash", "vertex_ai-language-models"))
+	assert.Equal(t, "vertex_ai-language-models", presentationVendorForServable("gemini-2.5-flash", "vertex_ai-language-models"))
+	assert.Equal(t, "openai", presentationVendorForServable("gpt-5.6-sol", "openai")) // non-antigravity untouched
+}


### PR DESCRIPTION
# fix(modelops): surface antigravity gemini-* in public /pricing (vendor re-attribution)

## 摘要

> 术语:下文「公开目录 / 公开 /pricing」= `GET /api/v1/public/pricing` 那个目录,UI 自 #1037 起标为「**所有分组 / All groups**」视图(代码符号仍为 `publicCatalog`/`BuildPublicCatalog`,不随 UI 文案改)。

#1029/#1030 的 antigravity 面后续。上游价格 mirror 把 antigravity 实服的 wire id(`gemini-3.5-flash`、`gemini-3-pro-image`、`gemini-*-image`、`gemini-3-flash`、`gemini-3.1-pro-low`)挂在 **`vertex_ai` 厂商**下。公开目录**按厂商路由** → `vertex_ai`→`PlatformGemini` → 受限的 Vertex 7 键 allowlist(里面没有它们)→ **被静默丢弃**,尽管 antigravity 在服务、overlay/source 也有价。

这与 gpt-5.6 是**同一类展示 gap、不同面**:overlay 热推**修不了**它——`applyCatalogOverlayPricing` 只注入 source **缺失**的模型,无法给 source 已有的模型**改厂商**。

**修法**:`presentationVendorForServable` 在 `FilterPublicCatalogToServable` 内,把 **antigravity 专属**(在 antigravity allowlist、**不在** gemini allowlist)的 id 从 `vertex_ai` 重归到 `antigravity` 厂商 → 过 antigravity 闸 → 在 antigravity 厂商下展示。**纯展示层**(行按值拷贝),`IsModelPriced` / Your-Menu 元数据 join / 计费**全不受影响**——遵守该文件「此过滤器不得放进 `BuildPublicCatalog`」的既有契约。双挂 id(`gemini-2.5-flash`,两个 allowlist 都有)**保持 gemini 厂商**(它确实也经 Vertex 服务)。

修后公开 /pricing 在 antigravity 厂商下展示这 7 个模型;`audit-display-coverage --live` 对它们的 gap **真正闭合**(经 live 公开展示,而非仅 overlay 存在)。

## 风险

- **仅改 TK 自有 catalog 代码**(`pricing_catalog_supported_models_tk.go` + 对应 `*_test.go`):新增 `presentationVendorForServable` + 在 `FilterPublicCatalogToServable` 加一行重归调用。纯插入、无删除 → 非上游覆盖、无需 override/sentinel marker。
- **纯展示层**:重归只在 `FilterPublicCatalogToServable` 的按值拷贝行上发生,缓存的 `BuildPublicCatalog` 指针、`IsModelPriced`、my-pricing 的 metaByID join **均不受影响**(无计费/能力副作用)。
- **不误伤双挂模型**:`gemini-2.5-flash` 等(gemini + antigravity 都在)保持 gemini 厂商;只有 antigravity 专属(不在 gemini allowlist)才重归。测试覆盖该边界。
- gemini 闸仍严格:不在任何 allowlist 的 `vertex_ai` 模型照常被丢(测试覆盖)。

## 验证

- 新增 `TestFilterPublicCatalog_ReattributesAntigravityExclusiveVendor`:`gemini-3.5-flash`(mirror vertex_ai)→ 留存且重归 antigravity;`gemini-3-pro-image`(overlay antigravity)→ 留存;`gemini-2.5-flash`(双挂)→ 留存且**保持** vertex_ai;`imagen-4.0-generate-001`(gemini allowlist)→ 留存;无 allowlist 的 vertex_ai 模型 → 丢弃;`presentationVendorForServable` 纯函数单测。
- `go test -tags=unit ./internal/service/ -run 'Catalog|Pricing|Servable'` 通过(无回归)。
- 完整 `preflight` **PASS(exit 0)**。

## 提交

`git log --oneline origin/main..HEAD`:

- 1d1b34326 fix(modelops): surface antigravity gemini-* in public /pricing (vendor re-attribution)

最新提交：1d1b34326

## 上线

- 合并后**需发版**(catalog 是编译进镜像的 Go 代码,非 overlay 运行时热推面)才在 prod 生效;发版后公开 /pricing 即在 antigravity 厂商下展示这 7 个。

## 合并

- 合并方式:**Squash and merge**(TK fix PR,§5.y);合并等人授权。

---

no-web-impact — 仅后端 catalog 代码;无 `frontend/` 源改动。
