### PR TITLE
fix(frontend): fix 4 pre-existing test reds (data-loss bug + feature gap)

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 519,
-  "hash": "c6dcdeb8e62cd83f4498f0f1bad7bd6e228bedf2ff41d1ab5bf45b1fde100c47",
+  "hash": "27c60fef0e3e3863d845e3596fce2e79aba6326ad1dcb61cde93f53d22e1f660",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1821,6 +1821,48 @@
         </div>
       </div>
 
+      <!-- OpenAI Codex image-generation bridge (account-level tri-state override) -->
+      <div
+        v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'apikey')"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div>
+          <label class="input-label mb-0">{{ t('admin.accounts.openai.codexImageGenerationBridge') }}</label>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {{ t('admin.accounts.openai.codexImageGenerationBridgeDesc') }}
+          </p>
+        </div>
+        <div class="mt-3 grid grid-cols-3 gap-2">
+          <button
+            v-for="option in codexImageGenerationBridgeOptions"
+            :key="option.value"
+            type="button"
+            :data-testid="`codex-image-bridge-${option.value}`"
+            @click="codexImageGenerationBridgeMode = option.value"
+            :class="[
+              'flex flex-col items-start rounded-lg border px-3 py-2 text-left transition-colors',
+              codexImageGenerationBridgeMode === option.value
+                ? 'border-primary-500 bg-primary-50 dark:border-primary-500 dark:bg-primary-900/20'
+                : 'border-gray-200 hover:border-gray-300 dark:border-dark-600 dark:hover:border-dark-500'
+            ]"
+          >
+            <span
+              :class="[
+                'text-sm font-medium',
+                codexImageGenerationBridgeMode === option.value
+                  ? 'text-primary-700 dark:text-primary-300'
+                  : 'text-gray-700 dark:text-gray-200'
+              ]"
+            >
+              {{ option.label }}
+            </span>
+            <span class="mt-0.5 text-[11px] leading-tight text-gray-500 dark:text-gray-400">
+              {{ option.desc }}
+            </span>
+          </button>
+        </div>
+      </div>
+
       <div
         v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'apikey')"
         class="border-t border-gray-200 pt-4 dark:border-dark-600 space-y-4"
@@ -2890,6 +2932,29 @@ const openAICompactModeOptions = computed(() => [
   { value: 'auto', label: t('admin.accounts.openai.compactModeAuto') },
   { value: 'force_on', label: t('admin.accounts.openai.compactModeForceOn') },
   { value: 'force_off', label: t('admin.accounts.openai.compactModeForceOff') }
+])
+
+// Account-level tri-state override for the Codex image-generation bridge.
+// `inherit` writes no override (follow channel/global); `enabled`/`disabled`
+// pin the account policy. Submit logic lives in handleSubmit (codex_image_generation_bridge).
+const codexImageGenerationBridgeOptions = computed<
+  { value: CodexImageGenerationBridgeMode; label: string; desc: string }[]
+>(() => [
+  {
+    value: 'inherit',
+    label: t('admin.accounts.openai.codexImageGenerationBridgeInherit'),
+    desc: t('admin.accounts.openai.codexImageGenerationBridgeInheritDesc')
+  },
+  {
+    value: 'enabled',
+    label: t('admin.accounts.openai.codexImageGenerationBridgeEnabled'),
+    desc: t('admin.accounts.openai.codexImageGenerationBridgeEnabledDesc')
+  },
+  {
+    value: 'disabled',
+    label: t('admin.accounts.openai.codexImageGenerationBridgeDisabled'),
+    desc: t('admin.accounts.openai.codexImageGenerationBridgeDisabledDesc')
+  }
 ])
 
 const normalizeOpenAIMessagesCompactionThreshold = (): number | null => {
@@ -4121,7 +4186,12 @@ const handleSubmit = async () => {
           newCredentials.mirror_platform = 'grok'
         }
         if (shouldApplyModelMapping) {
-          const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)
+          // Persist BOTH whitelist passthrough entries and real remaps. The mode
+          // toggle is only a view switch; an account holding both (e.g. a gpt-5.2
+          // whitelist entry + a gpt-latest→gpt-5.2 remap) must not lose the hidden
+          // remaps when the whitelist is edited. Matches the oauth/anthropic submit
+          // paths, which all use the 'combined' helper.
+          const modelMapping = buildModelRestrictionMapping()
           if (modelMapping) {
             newCredentials.model_mapping = modelMapping
           } else {

--- a/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
@@ -25,6 +25,31 @@ vi.mock('@/api/admin/accounts', () => ({
   getAntigravityDefaultModelMapping: vi.fn()
 }))
 
+// Antigravity (like anthropic/openai/gemini) is API-backed after R-003: the model
+// whitelist selector derives its candidates from the self-healing
+// models-list-candidates endpoint, not a static list. Mock it with a realistic
+// antigravity candidate set (Gemini — including image models — plus Claude, and
+// NO GPT) so the platform-scoped whitelist renders deterministically.
+vi.mock('@/api/admin/groups', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/admin/groups')>()
+  return {
+    ...actual,
+    getModelsListCandidates: vi.fn(async (_id: number, platform?: string) => {
+      if (platform === 'antigravity') {
+        return [
+          'gemini-3.1-flash-image',
+          'gemini-2.5-flash-image',
+          'gemini-3-flash',
+          'gemini-2.5-pro',
+          'claude-sonnet-4-6',
+          'claude-opus-4-6'
+        ]
+      }
+      return []
+    })
+  }
+})
+
 vi.mock('vue-i18n', async () => {
   const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
   return {
@@ -90,10 +115,13 @@ describe('BulkEditAccountModal', () => {
 
   it('antigravity 白名单包含 Gemini 图片模型且过滤掉普通 GPT 模型', async () => {
     const wrapper = mountModal()
+    // Let the antigravity servable-models fetch resolve so the candidate list populates.
+    await flushPromises()
     const selector = wrapper.findComponent(ModelWhitelistSelector)
     expect(selector.exists()).toBe(true)
 
     await selector.find('div.cursor-pointer').trigger('click')
+    await flushPromises()
 
     expect(wrapper.text()).toContain('gemini-3.1-flash-image')
     expect(wrapper.text()).toContain('gemini-2.5-flash-image')

--- a/frontend/src/router/__tests__/guards.spec.ts
+++ b/frontend/src/router/__tests__/guards.spec.ts
@@ -78,6 +78,12 @@ function simulateGuard(
       authState.isAuthenticated &&
       (toPath === '/login' || toPath === '/register')
     ) {
+      // Mirror router/index.ts: in backend mode, non-admin users are NOT redirected
+      // away from login/register — they are blocked from every protected route, so a
+      // redirect to /dashboard would bounce back to /login (infinite loop).
+      if (authState.backendModeEnabled && !authState.isAdmin) {
+        return null
+      }
       return authState.isAdmin ? '/admin/dashboard' : '/dashboard'
     }
     if (authState.backendModeEnabled && !authState.isAuthenticated) {


### PR DESCRIPTION
## 概述
修复 `main` 上既有的 4 个前端红测试（在 `upstream-20260627` 融合审查时暴露，但与融合无关——它们在 `main` 上本就红，且不在 CI 的 `FRONTEND_CRITICAL_VITEST` 子集里，因此没有卡那次融合）。其中 **2 个是真实源码修复**，2 个是修正过期/不完整的测试脚手架，未弱化任何断言。

| # | 测试 | 类型 | 修复 |
|---|---|---|---|
| 1 | `EditAccountModal > preserves model mappings when editing the whitelist` | **源码·数据丢失 bug** | apikey 提交路径用了 `buildModelMappingObject('whitelist')`，当账号同时持有白名单透传项和真实 remap 时，会**静默丢掉隐藏的 remap**（如 `gpt-latest→gpt-5.2`）。改用 `buildModelRestrictionMapping()`（combined 模式），与 oauth/anthropic 提交路径一致。 |
| 2 | `EditAccountModal > submits account-level Codex image generation bridge override` | **源码·补全功能** | 补全 account 级 Codex 图片生成 bridge 三态开关（跟随渠道 / 强制开 / 强制关）。后端支持（`Account.CodexImageGenerationBridgeOverride`、`extra.codex_image_generation_bridge`）与 load/submit 接线本就存在，只缺 UI 控件。 |
| 3 | `guards > Backend Mode > /login is allowed (no redirect loop)` | 测试脚手架 | 生产 guard（`router/index.ts:525`）本就放行 backend-mode 非 admin 停留在 `/login`；测试手写的 `simulateGuard` 镜像过期，同步成真实逻辑。断言不变。 |
| 4 | `BulkEditAccountModal > antigravity 白名单包含 Gemini 图片模型且过滤掉普通 GPT 模型` | 测试脚手架 | antigravity 在 PR #752 后改为 API 驱动（`getModelsListCandidates`），spec 从未 mock 该端点，导致选择器渲染为空。补上忠实的 mock。断言不变。 |

## 验证
- `pnpm test:run` —— **1155/1155 全过**（原 1151/1155）
- `pnpm typecheck` + `pnpm lint:check` —— 绿
- 内嵌 `backend/internal/web/dist` 已重建
- `scripts/preflight.sh` —— PASS

## 上游覆盖标记
`EditAccountModal.vue` 属 upstream-shaped 文件，本次改动**非纯插入**（数据丢失修复替换了一行）。该改动是 bug 修复 + UI 功能补全，**不回退任何上游行为**，也未新增需要 sentinel 锚点的 load-bearing 面：
- `upstream-touch-trivial`
- `sentinel-registry-reviewed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
