### PR TITLE
feat(admin): admin UI 默认 80% 缩放，免手动浏览器缩放

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 519,
-  "hash": "27c60fef0e3e3863d845e3596fce2e79aba6326ad1dcb61cde93f53d22e1f660",
+  "hash": "cc5057d634635b816d72ff77cc3c8c9c586f47e221df65d86048f9b390919879",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/constants/layout.ts
+++ b/frontend/src/constants/layout.ts
@@ -23,3 +23,10 @@ export const TK_SIDEBAR_WIDTH_CLASS = 'w-44'
  * literal rather than computed from the width token.
  */
 export const TK_SIDEBAR_MAIN_MARGIN_CLASS = 'lg:ml-44'
+
+/**
+ * Default visual scale for the admin shell. Ops feedback: dense admin tables
+ * (e.g. /admin/accounts) only fit at ~80% browser zoom on typical monitors;
+ * apply here so operators do not need manual Cmd/Ctrl+- on every session.
+ */
+export const TK_ADMIN_UI_ZOOM = 0.8

--- a/frontend/src/views/admin/AdminShellView.vue
+++ b/frontend/src/views/admin/AdminShellView.vue
@@ -5,9 +5,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted, onUnmounted, watch } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
 import AppLayout from '@/components/layout/AppLayout.vue'
+import { TK_ADMIN_UI_ZOOM } from '@/constants/layout'
 
 const route = useRoute()
 
@@ -15,4 +16,14 @@ const route = useRoute()
 const shellless = computed(
   () => route.name === 'AdminOps' && String(route.query.fullscreen ?? '') === '1'
 )
+
+function syncAdminUiZoom() {
+  document.documentElement.style.zoom = shellless.value ? '' : String(TK_ADMIN_UI_ZOOM)
+}
+
+watch(shellless, syncAdminUiZoom)
+onMounted(syncAdminUiZoom)
+onUnmounted(() => {
+  document.documentElement.style.zoom = ''
+})
 </script>

--- a/frontend/src/views/admin/__tests__/AdminShellView.spec.ts
+++ b/frontend/src/views/admin/__tests__/AdminShellView.spec.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, reactive } from 'vue'
+
+import { TK_ADMIN_UI_ZOOM } from '@/constants/layout'
+import AdminShellView from '../AdminShellView.vue'
+
+const route = reactive<{ name: string; query: Record<string, string> }>({
+  name: 'AdminAccounts',
+  query: {}
+})
+
+vi.mock('vue-router', () => ({
+  RouterView: defineComponent({ name: 'RouterView', template: '<div data-testid="router-view" />' }),
+  useRoute: () => route
+}))
+
+vi.mock('@/components/layout/AppLayout.vue', () => ({
+  default: defineComponent({
+    name: 'AppLayout',
+    template: '<div data-testid="app-layout"><slot /></div>'
+  })
+}))
+
+describe('AdminShellView', () => {
+  afterEach(() => {
+    document.documentElement.style.zoom = ''
+    route.name = 'AdminAccounts'
+    route.query = {}
+  })
+
+  it('applies the admin UI zoom on mount for normal admin routes', () => {
+    mount(AdminShellView)
+    expect(document.documentElement.style.zoom).toBe(String(TK_ADMIN_UI_ZOOM))
+  })
+
+  it('clears zoom for ops fullscreen shellless mode', () => {
+    route.name = 'AdminOps'
+    route.query = { fullscreen: '1' }
+    mount(AdminShellView)
+    expect(document.documentElement.style.zoom).toBe('')
+  })
+
+  it('restores zoom when leaving ops fullscreen', async () => {
+    route.name = 'AdminOps'
+    route.query = { fullscreen: '1' }
+    const wrapper = mount(AdminShellView)
+    expect(document.documentElement.style.zoom).toBe('')
+
+    route.query = {}
+    await wrapper.vm.$nextTick()
+    expect(document.documentElement.style.zoom).toBe(String(TK_ADMIN_UI_ZOOM))
+  })
+
+  it('clears zoom on unmount so user routes stay at 100%', () => {
+    const wrapper = mount(AdminShellView)
+    expect(document.documentElement.style.zoom).toBe(String(TK_ADMIN_UI_ZOOM))
+    wrapper.unmount()
+    expect(document.documentElement.style.zoom).toBe('')
+  })
+})

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -6,9 +6,10 @@
       "path": "frontend/src/constants/layout.ts",
       "must_contain": [
         "TK_SIDEBAR_WIDTH_CLASS",
-        "TK_SIDEBAR_MAIN_MARGIN_CLASS"
+        "TK_SIDEBAR_MAIN_MARGIN_CLASS",
+        "TK_ADMIN_UI_ZOOM"
       ],
-      "rationale": "Single source of truth for TK sidebar geometry. AppSidebar.vue / AppLayout.vue import these so upstream-shaped layout files stay close to upstream; if either constant disappears, the import sites fail to compile (loud). The sentinel adds a second layer in case an upstream merge replaces the entire constants file."
+      "rationale": "Single source of truth for TK sidebar geometry and admin-shell default zoom. AppSidebar.vue / AppLayout.vue import the sidebar constants so upstream-shaped layout files stay close to upstream; AdminShellView imports TK_ADMIN_UI_ZOOM for the ops default 80% scale. If either constant disappears, the import sites fail to compile (loud). The sentinel adds a second layer in case an upstream merge replaces the entire constants file."
     },
     {
       "path": "frontend/src/composables/useTkExportPanel.ts",
@@ -75,6 +76,15 @@
         "@/views/admin/AdminShellView.vue"
       ],
       "rationale": "TK-isolated admin route subtree (extracted from router/index.ts to minimize upstream-merge conflicts, see CLAUDE.md §5). The `adminRoutes` export is the contract index.ts spreads; the AdminShellView import is the persistent-shell nesting (PR #935) that the admin-shell-layout guard depends on. Anchor both so a refactor or merge that flattens the shell or breaks the export is caught at preflight time rather than in prod."
+    },
+    {
+      "path": "frontend/src/views/admin/AdminShellView.vue",
+      "must_contain": [
+        "syncAdminUiZoom",
+        "TK_ADMIN_UI_ZOOM",
+        "document.documentElement.style.zoom"
+      ],
+      "rationale": "Persistent admin shell (PR #935) owns AppLayout once for all /admin/* routes. TK applies documentElement zoom here so dense admin tables fit without per-session browser scaling; an upstream merge that rewrites the shell file could silently drop the zoom hook while admin-shell-layout still passes."
     },
     {
       "path": "frontend/src/views/user/studio/BakeOff.vue",


### PR DESCRIPTION
## 摘要

- 在 `AdminShellView` 挂载时对 `document.documentElement` 应用 `zoom: 0.8`，覆盖全部 `/admin/*` 页面（含 Teleport 弹窗），解决运营反馈的 accounts 等宽表在 100% 浏览器缩放下看不全、需反复 Cmd/Ctrl+- 的问题。
- 缩放比例抽成 `TK_ADMIN_UI_ZOOM` 常量（`frontend/src/constants/layout.ts`），便于后续统一调整。
- Ops 全屏模式（`/admin/ops?fullscreen=1`）保持 100%；离开 admin 或卸载 shell 时自动恢复。
- sentinel：`frontend-tk.json` 已锚定 `AdminShellView` zoom hook 与 `TK_ADMIN_UI_ZOOM` 常量，防止 upstream merge 静默冲掉。

## 风险

- 低风险，纯前端视觉缩放；用户侧 `/user/*` 不受影响。
- `zoom` 在 Chromium/Safari/Firefox 现代版本可用；与浏览器自带缩放叠加时可能略小于 80%（运营当前即手动 80%）。
- Edge handoff（`/admin/edge-handoff`）不在 AdminShell 内，保持原样。

## 验证

- `pnpm exec vitest run src/views/admin/__tests__/AdminShellView.spec.ts` — 4/4 通过
- `./scripts/preflight.sh` — PASS（含 embedded dist freshness）
- `python3 scripts/checks/admin-shell-layout.py` — PASS
- `python3 scripts/checks/upstream-override-marker.py --base origin/main` — verified coverage（AdminShellView sentinel）
- `python3 scripts/sentinels/check-registry-update-gate.py --base origin/main` — ok

## 提交

- b79d30457 feat(admin): default admin shell to 80% zoom so dense tables fit without manual browser scaling
- f9468f688 fix(admin): pin admin UI zoom in frontend TK sentinel registry

最新提交：f9468f688
