### PR TITLE
fix(admin): 统一今日用量口径与服务器时区日界

### DIFF
--- a/backend/internal/handler/admin/admin_helpers_test.go
+++ b/backend/internal/handler/admin/admin_helpers_test.go
@@ -9,23 +9,28 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseTimeRange(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
+	t.Cleanup(func() { _ = timezone.Init("UTC") })
+
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	req := httptest.NewRequest(http.MethodGet, "/?start_date=2024-01-01&end_date=2024-01-02&timezone=UTC", nil)
+	req := httptest.NewRequest(http.MethodGet, "/?start_date=2024-01-01&end_date=2024-01-02&timezone=Asia/Shanghai", nil)
 	c.Request = req
 
+	loc := timezone.Location()
 	start, end := parseTimeRange(c)
-	require.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), start)
-	require.Equal(t, time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC), end)
+	require.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, loc), start)
+	require.Equal(t, time.Date(2024, 1, 3, 0, 0, 0, 0, loc), end)
 
-	req = httptest.NewRequest(http.MethodGet, "/?start_date=bad&timezone=UTC", nil)
+	req = httptest.NewRequest(http.MethodGet, "/?start_date=bad&timezone=Asia/Shanghai", nil)
 	c.Request = req
 	start, end = parseTimeRange(c)
 	require.False(t, start.IsZero())

--- a/backend/internal/handler/admin/dashboard_handler_tk_window_test.go
+++ b/backend/internal/handler/admin/dashboard_handler_tk_window_test.go
@@ -68,14 +68,18 @@ func TestParseAbsoluteRange_RejectsAndFallsBack(t *testing.T) {
 	}
 }
 
-// TestParseTimeRange_FallbackUnchanged ensures the legacy date-string + timezone
-// path is untouched when no absolute ts / named range is supplied.
-func TestParseTimeRange_FallbackUnchanged(t *testing.T) {
+// TestParseTimeRange_DateStringUsesServerTZ ensures manual start_date/end_date
+// parsing ignores the viewer timezone query param and uses server TZ instead.
+func TestParseTimeRange_DateStringUsesServerTZ(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
+	t.Cleanup(func() { _ = timezone.Init("UTC") })
+
 	gin.SetMode(gin.TestMode)
-	c := ctxWithURL("/?start_date=2024-01-01&end_date=2024-01-02&timezone=UTC")
+	c := ctxWithURL("/?start_date=2024-01-01&end_date=2024-01-02&timezone=Asia/Shanghai")
+	loc := timezone.Location()
 	start, end := parseTimeRange(c)
-	require.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), start)
-	require.Equal(t, time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC), end)
+	require.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, loc), start)
+	require.Equal(t, time.Date(2024, 1, 3, 0, 0, 0, 0, loc), end)
 }
 
 // TestParseNamedRange_ServerTZCanonical is the regression guard for the

--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -441,11 +441,10 @@ func (h *GroupHandler) GetStats(c *gin.Context) {
 }
 
 // GetUsageSummary returns today's and cumulative cost for all groups.
-// GET /api/v1/admin/groups/usage-summary?timezone=Asia/Shanghai
+// GET /api/v1/admin/groups/usage-summary
+// Day boundaries use the server-configured timezone (timezone query param is ignored).
 func (h *GroupHandler) GetUsageSummary(c *gin.Context) {
-	userTZ := c.Query("timezone")
-	now := timezone.NowInUserLocation(userTZ)
-	todayStart := timezone.StartOfDayInUserLocation(now, userTZ)
+	todayStart := timezone.Today()
 
 	// Cache by the local day boundary (the only input that affects the result).
 	cacheKey := todayStart.UTC().Format(time.RFC3339)

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -386,10 +386,10 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 	response.Success(c, stats)
 }
 
-// parseUserTimeRange parses start_date, end_date query parameters for user dashboard
-// Uses user's timezone if provided, otherwise falls back to server timezone
+// parseUserTimeRange parses start_date, end_date query parameters for user dashboard.
+// Day boundaries use the server-configured timezone (timezone query param is ignored).
 func parseUserTimeRange(c *gin.Context) (time.Time, time.Time) {
-	userTZ := c.Query("timezone") // Get user's timezone from request
+	userTZ := c.Query("timezone")
 	now := timezone.NowInUserLocation(userTZ)
 	startDate := c.Query("start_date")
 	endDate := c.Query("end_date")

--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -123,39 +123,23 @@ func ParseInLocation(layout, value string) (time.Time, error) {
 	return time.ParseInLocation(layout, value, Location())
 }
 
-// ParseInUserLocation parses a time string in the user's timezone.
-// If userTZ is empty or invalid, falls back to the configured server timezone.
+// ParseInUserLocation parses a time string in the configured server timezone.
+// userTZ is ignored (kept for query/API compatibility).
 func ParseInUserLocation(layout, value, userTZ string) (time.Time, error) {
-	loc := Location() // default to server timezone
-	if userTZ != "" {
-		if userLoc, err := time.LoadLocation(userTZ); err == nil {
-			loc = userLoc
-		}
-	}
-	return time.ParseInLocation(layout, value, loc)
+	_ = userTZ
+	return ParseInLocation(layout, value)
 }
 
-// NowInUserLocation returns the current time in the user's timezone.
-// If userTZ is empty or invalid, falls back to the configured server timezone.
+// NowInUserLocation returns the current time in the configured server timezone.
+// userTZ is ignored (kept for query/API compatibility).
 func NowInUserLocation(userTZ string) time.Time {
-	if userTZ == "" {
-		return Now()
-	}
-	if userLoc, err := time.LoadLocation(userTZ); err == nil {
-		return time.Now().In(userLoc)
-	}
+	_ = userTZ
 	return Now()
 }
 
-// StartOfDayInUserLocation returns the start of the given day in the user's timezone.
-// If userTZ is empty or invalid, falls back to the configured server timezone.
+// StartOfDayInUserLocation returns the start of the given day in the configured server timezone.
+// userTZ is ignored (kept for query/API compatibility).
 func StartOfDayInUserLocation(t time.Time, userTZ string) time.Time {
-	loc := Location()
-	if userTZ != "" {
-		if userLoc, err := time.LoadLocation(userTZ); err == nil {
-			loc = userLoc
-		}
-	}
-	t = t.In(loc)
-	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
+	_ = userTZ
+	return StartOfDay(t)
 }

--- a/backend/internal/pkg/timezone/timezone_test.go
+++ b/backend/internal/pkg/timezone/timezone_test.go
@@ -136,6 +136,34 @@ func TestDSTAwareness(t *testing.T) {
 	_ = StartOfDay(Now())
 }
 
+func TestInUserLocationHelpersIgnoreClientTimezone(t *testing.T) {
+	if err := Init("Asia/Shanghai"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = Init("UTC") })
+
+	// A US browser zone must not shift billing-day boundaries.
+	parsed, err := ParseInUserLocation("2006-01-02", "2026-06-28", "America/New_York")
+	if err != nil {
+		t.Fatalf("ParseInUserLocation: %v", err)
+	}
+	want := time.Date(2026, 6, 28, 0, 0, 0, 0, Location())
+	if !parsed.Equal(want) {
+		t.Fatalf("ParseInUserLocation = %v, want %v", parsed, want)
+	}
+
+	now := NowInUserLocation("America/Los_Angeles")
+	if now.Location().String() != Location().String() {
+		t.Fatalf("NowInUserLocation location = %s, want %s", now.Location(), Location())
+	}
+
+	midday := time.Date(2026, 6, 28, 15, 30, 0, 0, Location())
+	start := StartOfDayInUserLocation(midday, "Europe/London")
+	if start.Hour() != 0 || start.Day() != 28 {
+		t.Fatalf("StartOfDayInUserLocation = %v, want start of server day", start)
+	}
+}
+
 func TestStartOfWeek_Boundaries(t *testing.T) {
 	if err := Init("Asia/Shanghai"); err != nil {
 		t.Fatalf("Init: %v", err)

--- a/backend/internal/repository/usage_log_repo.go
+++ b/backend/internal/repository/usage_log_repo.go
@@ -3327,7 +3327,7 @@ func (r *usageLogRepository) GetUserBreakdownStats(ctx context.Context, startTim
 }
 
 // GetAllGroupUsageSummary returns today's and cumulative actual_cost for every group.
-// todayStart is the start-of-day in the caller's timezone (UTC-based).
+// todayStart is the start-of-day in the server-configured timezone.
 //
 // TK perf: the legacy query below SUMs total_cost over the ENTIRE usage_logs table
 // on every GroupsView load. It is now served from the per-(group, day) rollup

--- a/backend/internal/repository/usage_log_repo_tk_group_rollup.go
+++ b/backend/internal/repository/usage_log_repo_tk_group_rollup.go
@@ -23,13 +23,10 @@ import (
 //
 //	total_cost[g] = SUM(rollup.actual_cost WHERE bucket_date < serverToday)   -- completed server-TZ days
 //	              + SUM(raw.actual_cost    WHERE created_at  >= serverToday)   -- the remainder not yet rolled up
-//	today_cost[g] = SUM(raw.actual_cost    WHERE created_at  >= userTodayStart)
+//	today_cost[g] = SUM(raw.actual_cost    WHERE created_at  >= serverTodayStart)
 //
-// The rollup buckets by SERVER-TZ day, so the rollup/raw split for total_cost
-// uses the server-TZ start-of-today; a row is in exactly one side (rollup if its
-// server-TZ date < today, raw otherwise). today_cost uses the caller's user-TZ
-// todayStart, which may differ from the server TZ — both are narrow, index-bounded
-// reads of recent usage_logs (createdAt index), unlike the legacy full-table scan.
+// The rollup buckets by SERVER-TZ day; today_cost uses the same server-TZ
+// day boundary as accounts today-stats and admin list surfaces.
 func (r *usageLogRepository) groupUsageSummaryFromRollup(ctx context.Context, todayStart time.Time) ([]usagestats.GroupUsageSummary, bool, error) {
 	var done bool
 	if err := scanSingleRow(ctx, r.sql,
@@ -49,7 +46,7 @@ func (r *usageLogRepository) groupUsageSummaryFromRollup(ctx context.Context, to
 
 	// $1 = server-TZ today date (rollup completed-day boundary)
 	// $2 = server-TZ start-of-today instant (raw remainder boundary for total_cost)
-	// $3 = caller's user-TZ start-of-today instant (raw boundary for today_cost)
+	// $3 = server-TZ start-of-today instant (today_cost boundary; same as accounts today-stats)
 	query := `
 		SELECT
 			g.id,

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 519,
-  "hash": "27c60fef0e3e3863d845e3596fce2e79aba6326ad1dcb61cde93f53d22e1f660",
+  "hash": "95d94b26c59fd271e8ea3ef6e5f17a814190c650679236246cf4c99099df1284",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/__tests__/client.spec.ts
+++ b/frontend/src/api/__tests__/client.spec.ts
@@ -60,7 +60,7 @@ describe('API Client', () => {
       expect(config.headers.get('Authorization')).toBeFalsy()
     })
 
-    it('GET 请求自动附加 timezone 参数', async () => {
+    it('GET 请求不附加 timezone 参数（日界由服务器时区统一解析）', async () => {
       const adapter = vi.fn().mockResolvedValue({
         status: 200,
         data: { code: 0, data: {} },
@@ -73,7 +73,7 @@ describe('API Client', () => {
       await apiClient.get('/test')
 
       const config = adapter.mock.calls[0][0]
-      expect(config.params).toHaveProperty('timezone')
+      expect(config.params?.timezone).toBeUndefined()
     })
 
     it('POST 请求不附加 timezone 参数', async () => {

--- a/frontend/src/api/admin/groups.ts
+++ b/frontend/src/api/admin/groups.ts
@@ -302,18 +302,13 @@ export async function clearGroupRPMOverrides(id: number): Promise<{ message: str
 }
 
 /**
- * Get usage summary (today + cumulative cost) for all groups
- * @param timezone - IANA timezone string (e.g. "Asia/Shanghai")
- * @returns Array of group usage summaries
+ * Get usage summary (today + cumulative user-billed cost) for all groups.
+ * Day boundaries use the server-configured timezone.
  */
-export async function getUsageSummary(
-  timezone?: string
-): Promise<{ group_id: number; today_cost: number; total_cost: number }[]> {
+export async function getUsageSummary(): Promise<{ group_id: number; today_cost: number; total_cost: number }[]> {
   const { data } = await apiClient.get<
     { group_id: number; today_cost: number; total_cost: number }[]
-  >('/admin/groups/usage-summary', {
-    params: timezone ? { timezone } : undefined
-  })
+  >('/admin/groups/usage-summary')
   return data
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -45,15 +45,6 @@ function onTokenRefreshed(token: string, error?: unknown): void {
 
 // ==================== Request Interceptor ====================
 
-// Get user's timezone
-const getUserTimezone = (): string => {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone
-  } catch {
-    return 'UTC'
-  }
-}
-
 apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     // Attach token from localStorage
@@ -65,14 +56,6 @@ apiClient.interceptors.request.use(
     // Attach locale for backend translations
     if (config.headers) {
       config.headers['Accept-Language'] = getLocale()
-    }
-
-    // Attach timezone for all GET requests (backend may use it for default date ranges)
-    if (config.method === 'get') {
-      if (!config.params) {
-        config.params = {}
-      }
-      config.params.timezone = getUserTimezone()
     }
 
     return config

--- a/frontend/src/components/account/AccountCapacityCell.vue
+++ b/frontend/src/components/account/AccountCapacityCell.vue
@@ -32,35 +32,18 @@
     <QuotaBadge v-if="showDailyQuota" :used="account.quota_daily_used ?? 0" :limit="account.quota_daily_limit!" label="D" />
     <QuotaBadge v-if="showWeeklyQuota" :used="account.quota_weekly_used ?? 0" :limit="account.quota_weekly_limit!" label="W" />
     <QuotaBadge v-if="showTotalQuota" :used="account.quota_used ?? 0" :limit="account.quota_limit!" />
-
-    <!-- 今日用量（tokens + 计费），全账号类型；数据由父组件注入 -->
-    <span
-      v-if="todayStats"
-      :class="['inline-flex items-center gap-1 rounded-md px-1.5 py-px text-[10px] font-medium leading-tight', todayUsageClass]"
-      :title="todayTooltip"
-    >
-      <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
-      </svg>
-      <span class="font-mono">{{ formatTokensK(todayStats.tokens) }}</span>
-      <span class="text-gray-400 dark:text-gray-500">·</span>
-      <span class="font-mono">{{ formatCurrency(todayStats.cost) }}</span>
-    </span>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { Account, WindowStats } from '@/types'
-import { formatCurrency, formatTokensK } from '@/utils/format'
+import type { Account } from '@/types'
 import CapacityBadge from '@/components/account/CapacityBadge.vue'
 import QuotaBadge from '@/components/account/QuotaBadge.vue'
 
 const props = defineProps<{
   account: Account
-  // 今日用量（tokens + 计费），由父组件按账号 ID 注入；全账号类型通用。
-  todayStats?: WindowStats | null
 }>()
 
 const { t } = useI18n()
@@ -153,8 +136,6 @@ const rpmBuffer = computed(() => {
   return props.account.rpm_sticky_buffer ?? (base > 0 ? Math.max(1, Math.floor(base / 5)) : 0)
 })
 
-// sticky_exempt has no finite sticky buffer (unlimited sticky headroom), so it
-// keeps the bare [S] tag; tiered surfaces the actual buffer count as (+N sticky).
 const rpmSuffix = computed(() =>
   rpmStrategy.value === 'sticky_exempt'
     ? '[S]'
@@ -193,32 +174,10 @@ const rpmTooltip = computed(() => {
   }
 })
 
-// 格式化费用显示
 const formatCost = (value: number | null | undefined) => {
   if (value === null || value === undefined) return '0'
   return value.toFixed(2)
 }
-
-// ====== 今日用量（全账号类型；0 值灰显以暴露异常，如 kiro 当前 0 计费） ======
-const hasTodayUsage = computed(() => {
-  const s = props.todayStats
-  return !!s && ((s.tokens ?? 0) > 0 || (s.cost ?? 0) > 0)
-})
-
-const todayUsageClass = computed(() =>
-  hasTodayUsage.value
-    ? 'bg-indigo-50 text-indigo-600 dark:bg-indigo-900/20 dark:text-indigo-300'
-    : 'bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-500'
-)
-
-const todayTooltip = computed(() => {
-  const s = props.todayStats
-  if (!s) return ''
-  return t('admin.accounts.capacity.today.tooltip', {
-    requests: s.requests ?? 0,
-    cost: formatCurrency(s.cost)
-  })
-})
 
 // ====== 配额 ======
 const isQuotaEligible = computed(() => props.account.type === 'apikey' || props.account.type === 'bedrock')

--- a/frontend/src/components/account/__tests__/AccountCapacityCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountCapacityCell.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AccountCapacityCell from '../AccountCapacityCell.vue'
+import type { Account } from '@/types'
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: 9,
+    name: 'GPT-pro1',
+    platform: 'openai',
+    type: 'oauth',
+    proxy_id: null,
+    concurrency: 42,
+    priority: 1,
+    status: 'active',
+    error_message: null,
+    last_used_at: null,
+    expires_at: null,
+    auto_pause_on_expired: true,
+    created_at: '2026-03-15T00:00:00Z',
+    updated_at: '2026-03-15T00:00:00Z',
+    schedulable: true,
+    rate_limited_at: null,
+    rate_limit_reset_at: null,
+    overload_until: null,
+    temp_unschedulable_until: null,
+    temp_unschedulable_reason: null,
+    session_window_start: null,
+    session_window_end: null,
+    session_window_status: null,
+    current_concurrency: 0,
+    ...overrides
+  }
+}
+
+describe('AccountCapacityCell', () => {
+  it('不展示今日统计 badge（由今日统计列单独承载）', () => {
+    const wrapper = mount(AccountCapacityCell, {
+      props: {
+        account: makeAccount()
+      },
+      global: {
+        stubs: {
+          CapacityBadge: {
+            props: ['current', 'max'],
+            template: '<div class="capacity-badge">{{ current }} / {{ max }}</div>'
+          },
+          QuotaBadge: true
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('0 / 42')
+    expect(wrapper.text()).not.toMatch(/\$/)
+    expect(wrapper.find('svg path[d*="M6.75 3v2.25"]').exists()).toBe(false)
+  })
+
+  it('仍展示并发与配额类容量指标', () => {
+    const wrapper = mount(AccountCapacityCell, {
+      props: {
+        account: makeAccount({
+          type: 'apikey',
+          quota_daily_limit: 10,
+          quota_daily_used: 3
+        })
+      },
+      global: {
+        stubs: {
+          CapacityBadge: { template: '<div class="capacity-badge"><slot /></div>' },
+          QuotaBadge: { template: '<div class="quota-badge" />' }
+        }
+      }
+    })
+
+    expect(wrapper.find('.capacity-badge').exists()).toBe(true)
+    expect(wrapper.find('.quota-badge').exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/admin/account/EdgeAccountPanelTk.vue
+++ b/frontend/src/components/admin/account/EdgeAccountPanelTk.vue
@@ -139,7 +139,7 @@
               </div>
             </td>
             <td class="px-4 py-1.5 align-top">
-              <AccountCapacityCell :account="accountVm(acct).accountLike" :today-stats="accountVm(acct).windowStats" />
+              <AccountCapacityCell :account="accountVm(acct).accountLike" />
             </td>
             <td class="px-4 py-1.5 align-top">
               <AccountUsageCell

--- a/frontend/src/components/admin/usage/UsageCleanupDialog.vue
+++ b/frontend/src/components/admin/usage/UsageCleanupDialog.vue
@@ -227,14 +227,6 @@ const formatRange = (task: UsageCleanupTask) => {
   return `${start} ~ ${end}`
 }
 
-const getUserTimezone = () => {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone
-  } catch {
-    return 'UTC'
-  }
-}
-
 const loadTasks = async () => {
   if (!props.show) return
   tasksLoading.value = true
@@ -293,7 +285,6 @@ const buildPayload = (): CreateUsageCleanupTaskRequest | null => {
   const payload: CreateUsageCleanupTaskRequest = {
     start_date: localStartDate.value,
     end_date: localEndDate.value,
-    timezone: getUserTimezone()
   }
 
   if (localFilters.value.user_id && localFilters.value.user_id > 0) {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3690,9 +3690,6 @@ export default {
           exceeded: 'Quota exceeded, account paused',
           normal: 'Quota normal'
         },
-        today: {
-          tooltip: "Today's usage: {requests} requests · billed {cost}"
-        },
       },
       tempUnschedulable: {
         title: 'Temp Unschedulable',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3713,9 +3713,6 @@ export default {
           exceeded: '配额已用完，账号暂停调度',
           normal: '配额正常'
         },
-        today: {
-          tooltip: '今日用量：{requests} 次请求 · 计费 {cost}'
-        },
       },
       clearRateLimit: '清除速率限制',
       resetQuota: '重置配额',

--- a/frontend/src/utils/dashboardWindow.tk.ts
+++ b/frontend/src/utils/dashboardWindow.tk.ts
@@ -17,8 +17,11 @@
  * window refer to a different calendar day than the customer's own dashboard
  * whenever the operator's browser timezone differed from the server, so the two
  * surfaces reported different totals for the same user/day. We therefore send a
- * A manual custom date pick (preset === null) still flows through the
- * start_date/end_date path, parsed in the server-configured timezone on the backend.
+ * named `range` for these presets and let the backend resolve it in the server
+ * timezone (see backend dashboard_handler_tk_window.go) — one canonical "today"
+ * for every viewer. A manual custom date pick (preset === null) still flows
+ * through the start_date/end_date path, parsed in the server-configured timezone
+ * on the backend.
  */
 
 const HOUR_MS = 60 * 60 * 1000

--- a/frontend/src/utils/dashboardWindow.tk.ts
+++ b/frontend/src/utils/dashboardWindow.tk.ts
@@ -17,10 +17,8 @@
  * window refer to a different calendar day than the customer's own dashboard
  * whenever the operator's browser timezone differed from the server, so the two
  * surfaces reported different totals for the same user/day. We therefore send a
- * named `range` for these presets and let the backend resolve it in the server
- * timezone (see backend dashboard_handler_tk_window.go) — one canonical "today"
- * for every viewer. A manual custom date pick (preset === null) still flows
- * through the date-string path.
+ * A manual custom date pick (preset === null) still flows through the
+ * start_date/end_date path, parsed in the server-configured timezone on the backend.
  */
 
 const HOUR_MS = 60 * 60 * 1000

--- a/frontend/src/views/KeyUsageView.vue
+++ b/frontend/src/views/KeyUsageView.vue
@@ -502,7 +502,6 @@ function getDateParams(): string {
     params.set('end_date', end)
   }
   params.set('days', String(dailyUsageDays.value))
-  params.set('timezone', getBrowserTimezone())
   return params.toString()
 }
 
@@ -835,14 +834,6 @@ function formatDate(iso: string | null | undefined): string {
   const d = new Date(iso)
   const loc = locale.value === 'zh' ? 'zh-CN' : 'en-US'
   return d.toLocaleDateString(loc, { year: 'numeric', month: 'long', day: 'numeric' })
-}
-
-function getBrowserTimezone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
-  } catch {
-    return 'UTC'
-  }
 }
 
 // ==================== API Query ====================

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -294,7 +294,7 @@
             </div>
           </template>
           <template #cell-capacity="{ row }">
-            <AccountCapacityCell :account="row" :today-stats="todayStatsByAccountId[String(row.id)] ?? null" />
+            <AccountCapacityCell :account="row" />
           </template>
           <template #cell-status="{ row }">
             <div class="flex items-center gap-1.5">
@@ -736,12 +736,8 @@ const buildDefaultTodayStats = (): WindowStats => ({
 })
 
 const refreshTodayStatsBatch = async () => {
-  // Why this checks these columns:
-  // - today_stats column shows dedicated today's metrics.
-  // - usage column also embeds today's stats for Key/Bedrock rows.
-  // - capacity column now embeds a today usage badge for ALL account types.
-  // So we only skip fetching when ALL three columns are hidden.
-  if (hiddenColumns.has('today_stats') && hiddenColumns.has('usage') && hiddenColumns.has('capacity')) {
+  // today_stats column and usage column embed today's metrics; capacity does not.
+  if (hiddenColumns.has('today_stats') && hiddenColumns.has('usage')) {
     todayStatsLoading.value = false
     todayStatsError.value = null
     return

--- a/frontend/src/views/admin/EdgeAccountsView.vue
+++ b/frontend/src/views/admin/EdgeAccountsView.vue
@@ -314,7 +314,7 @@
                     <span v-if="acct.channel_type" class="text-gray-400 dark:text-gray-500"> · ch{{ acct.channel_type }}</span>
                   </td>
                   <td class="px-4 py-2 align-top">
-                    <AccountCapacityCell :account="accountVm(acct).accountLike" :today-stats="accountVm(acct).windowStats" />
+                    <AccountCapacityCell :account="accountVm(acct).accountLike" />
                   </td>
                   <td class="px-4 py-2 align-top">
                     <AccountUsageCell

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -3975,8 +3975,8 @@ const formatCost = (cost: number): string => {
 const loadUsageSummary = async () => {
   usageLoading.value = true;
   try {
-    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const data = await adminAPI.groups.getUsageSummary(tz);
+    // Admin list views share the server-configured day boundary (same as accounts today-stats).
+    const data = await adminAPI.groups.getUsageSummary();
     const map = new Map<number, { today_cost: number; total_cost: number }>();
     for (const item of data) {
       map.set(item.group_id, {

--- a/frontend/src/views/admin/affiliates/AdminAffiliateRecordsTable.vue
+++ b/frontend/src/views/admin/affiliates/AdminAffiliateRecordsTable.vue
@@ -228,14 +228,6 @@ function loadInitialSortState(): { sort_by: string; sort_order: 'asc' | 'desc' }
 
 const sortState = reactive(loadInitialSortState())
 
-function userTimezone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone
-  } catch {
-    return 'UTC'
-  }
-}
-
 function buildParams(): ListAffiliateRecordsParams {
   return {
     page: pagination.page,
@@ -245,7 +237,6 @@ function buildParams(): ListAffiliateRecordsParams {
     end_at: filters.end_at || undefined,
     sort_by: sortState.sort_by,
     sort_order: sortState.sort_order,
-    timezone: userTimezone(),
   }
 }
 

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -643,10 +643,13 @@
     {
       "path": "frontend/src/components/account/AccountCapacityCell.vue",
       "must_contain": [
+        "CapacityBadge :color-class=\"concurrencyClass\""
+      ],
+      "must_not_contain": [
         "todayStats",
         "capacity.today.tooltip"
       ],
-      "rationale": "TK adds a today-usage badge (tokens·$cost) for ALL account types in the capacity column (admin accounts page + edge accounts page). The `todayStats` prop and the `admin.accounts.capacity.today.tooltip` i18n key are the TK-only contract; an upstream merge that rewrites this capacity cell could silently drop the today-usage badge — it would compile fine, just lose the feature (and the deliberate 0-value grey-out that surfaces anomalies like kiro's current 0-billing). Sentinel guards that the badge survives upstream convergence."
+      "rationale": "TK removed the today-usage badge from the capacity column — today metrics (tokens, account billing, user billing) live only in the dedicated 今日统计 column to avoid duplicating the same numbers. must_not_contain blocks an upstream merge from re-embedding tokens·$cost in capacity; must_contain keeps the concurrency capacity badge wired."
     },
     {
       "path": "frontend/src/views/admin/GroupsView.vue",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3489,6 +3489,16 @@
         "if s, e, ok := parseNamedRange(c); ok {"
       ],
       "rationale": "parseTimeRange MUST consult parseNamedRange (server-TZ calendar presets) after parseAbsoluteRange and before the viewer-timezone date-string fallback. If this injection line is dropped on an upstream merge, the resolver in dashboard_handler_tk_window.go is orphaned and admin calendar presets silently revert to browser-timezone windows — the cross-surface 今日消费 mismatch returns with no compile error."
+    },
+    {
+      "path": "backend/internal/pkg/timezone/timezone.go",
+      "must_contain": [
+        "userTZ is ignored",
+        "_ = userTZ",
+        "return ParseInLocation(layout, value)",
+        "return StartOfDay(t)"
+      ],
+      "rationale": "Billing-day boundaries MUST use the server-configured timezone only. ParseInUserLocation / NowInUserLocation / StartOfDayInUserLocation keep the userTZ parameter for API compatibility but ignore it — an upstream merge that restores client-timezone parsing would silently desync admin groups today_cost, account today-stats, dashboard calendar windows, and usage date filters while still compiling. Pins the ignore-and-delegate implementation in this upstream-shaped file."
     }
   ]
 }

--- a/scripts/sentinels/perf-query-shape.json
+++ b/scripts/sentinels/perf-query-shape.json
@@ -39,7 +39,7 @@
         "WHERE gd.bucket_date > DATE '",
         "func (r *usageLogRepository) groupDailyMetricsBackfilled("
       ],
-      "rationale": "groupUsageSummaryFromRollup's exact rollup/raw decomposition: total_cost = SUM(rollup completed days, bucket_date < server-today) + SUM(raw remainder, created_at >= server-today); today_cost = SUM(raw, created_at >= user-today). getGroupStatsFromRollup is the Dashboard/Usage group-distribution twin: it uses completed-day usage_dashboard_group_daily metrics plus raw head/tail spans, gated by groupDailyMetricsBackfilled so old cost-only rows are never trusted for requests/tokens. A refactor that drops the bounds, raw split, or metrics-backfill gate would double-count/miss rows or silently return zero historical tokens."
+      "rationale": "groupUsageSummaryFromRollup's exact rollup/raw decomposition: total_cost = SUM(rollup completed days, bucket_date < server-today) + SUM(raw remainder, created_at >= server-today); today_cost = SUM(raw, created_at >= server-today start) using the same server-TZ day boundary as accounts today-stats. getGroupStatsFromRollup is the Dashboard/Usage group-distribution twin: it uses completed-day usage_dashboard_group_daily metrics plus raw head/tail spans, gated by groupDailyMetricsBackfilled so old cost-only rows are never trusted for requests/tokens. A refactor that drops the bounds, raw split, or metrics-backfill gate would double-count/miss rows or silently return zero historical tokens."
     },
     {
       "path": "backend/internal/repository/dashboard_aggregation_repo_tk_group.go",


### PR DESCRIPTION
## 摘要

- 移除账号列表「容量」列中的今日用量 badge（tokens + 美金），避免与「今日统计」列重复；账号计费 / 用户扣费仅在今日统计列展示。
- 全产品「今日」日界统一为服务器配置时区（`timezone.Today()`）：后端 `*InUserLocation` 忽略客户端 `timezone` 参数；前端不再自动附加浏览器时区。
- 分组用量、账号 today-stats、Dashboard 日历 preset、用量报表等共用同一日界。
- 已 rebase/merge `main`（#1045 admin UI 80% 缩放），并同步更新嵌入 dist。
- 新增 `gateway-tk.json` sentinel 锚定 `timezone.go` 忽略客户端时区，防止 upstream merge 静默恢复浏览器日界。

sentinel-registry-reviewed

## 风险

- 浏览器时区与服务器时区不一致的管理员，分组/账号「今日」数字相对旧版可能变化（旧版分组页曾用浏览器 TZ）。
- 已嵌入 `backend/internal/web/dist` 前端产物，需随 PR 合并。

## 验证

- `go test -tags=unit ./internal/pkg/timezone/...`（含 `TestInUserLocationHelpersIgnoreClientTimezone`）
- `go test -tags=unit ./internal/handler/admin/... -run TestParseTimeRange`
- `pnpm test:run src/components/account/__tests__/AccountCapacityCell.spec.ts src/api/__tests__/client.spec.ts`
- `pnpm build` + `python3 scripts/checks/frontend-dist-freshness.py --check ./backend/internal/web/dist`
- `./scripts/preflight.sh` PASS（含 gateway/perf sentinel registry）

## 提交

- 59b62c899 chore(sentinel): anchor server-TZ billing day in timezone.go
- 61009a472 fix(admin): align parseTimeRange tests with server-TZ day boundary
- 78e7b2e84 merge: sync main (#1045 admin UI zoom) into usage-audit branch
- 0e15bb398 fix(admin): unify billing day on server TZ and drop capacity today badge

最新提交：59b62c899
