### PR TITLE
fix(admin): 80% 缩放下消除 admin 页面底部空白

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 519,
-  "hash": "d4b82ef74fdadc13d98b8587cd2b2630aae54c336849f65d7dd6c3ba32e72983",
+  "file_count": 520,
+  "hash": "1b903a8a1e81996f0e1e228c27770d8d77bed9a96bdbe928e2574aeac99484fd",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/styles/admin-ui-zoom.tk.css
+++ b/frontend/src/styles/admin-ui-zoom.tk.css
@@ -1,0 +1,16 @@
+/* TK: compensate viewport-based heights when AdminShellView applies document zoom.
+   CSS zoom scales visual output but vh / min-h-screen stay in unzoomed viewport
+   units, leaving ~(1 - zoom) * 100vh blank space at the bottom of admin pages. */
+
+html.tk-admin-ui-zoom,
+html.tk-admin-ui-zoom body {
+  min-height: calc(100vh / var(--tk-admin-ui-zoom));
+}
+
+html.tk-admin-ui-zoom .min-h-screen {
+  min-height: calc(100vh / var(--tk-admin-ui-zoom));
+}
+
+html.tk-admin-ui-zoom .table-page-layout:not(.mobile-mode) {
+  height: calc((100vh - 64px - 4rem) / var(--tk-admin-ui-zoom));
+}

--- a/frontend/src/views/admin/AdminShellView.vue
+++ b/frontend/src/views/admin/AdminShellView.vue
@@ -9,21 +9,35 @@ import { computed, onMounted, onUnmounted, watch } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import { TK_ADMIN_UI_ZOOM } from '@/constants/layout'
+import '@/styles/admin-ui-zoom.tk.css'
 
 const route = useRoute()
+const TK_ADMIN_UI_ZOOM_CLASS = 'tk-admin-ui-zoom'
 
 /** Ops fullscreen mode renders edge-to-edge without sidebar/header. */
 const shellless = computed(
   () => route.name === 'AdminOps' && String(route.query.fullscreen ?? '') === '1'
 )
 
+function clearAdminUiZoom() {
+  document.documentElement.style.zoom = ''
+  document.documentElement.classList.remove(TK_ADMIN_UI_ZOOM_CLASS)
+  document.documentElement.style.removeProperty('--tk-admin-ui-zoom')
+}
+
 function syncAdminUiZoom() {
-  document.documentElement.style.zoom = shellless.value ? '' : String(TK_ADMIN_UI_ZOOM)
+  if (shellless.value) {
+    clearAdminUiZoom()
+    return
+  }
+
+  const root = document.documentElement
+  document.documentElement.style.zoom = String(TK_ADMIN_UI_ZOOM)
+  root.classList.add(TK_ADMIN_UI_ZOOM_CLASS)
+  root.style.setProperty('--tk-admin-ui-zoom', String(TK_ADMIN_UI_ZOOM))
 }
 
 watch(shellless, syncAdminUiZoom)
 onMounted(syncAdminUiZoom)
-onUnmounted(() => {
-  document.documentElement.style.zoom = ''
-})
+onUnmounted(clearAdminUiZoom)
 </script>

--- a/frontend/src/views/admin/__tests__/AdminShellView.spec.ts
+++ b/frontend/src/views/admin/__tests__/AdminShellView.spec.ts
@@ -25,6 +25,8 @@ vi.mock('@/components/layout/AppLayout.vue', () => ({
 describe('AdminShellView', () => {
   afterEach(() => {
     document.documentElement.style.zoom = ''
+    document.documentElement.classList.remove('tk-admin-ui-zoom')
+    document.documentElement.style.removeProperty('--tk-admin-ui-zoom')
     route.name = 'AdminAccounts'
     route.query = {}
   })
@@ -32,6 +34,10 @@ describe('AdminShellView', () => {
   it('applies the admin UI zoom on mount for normal admin routes', () => {
     mount(AdminShellView)
     expect(document.documentElement.style.zoom).toBe(String(TK_ADMIN_UI_ZOOM))
+    expect(document.documentElement.classList.contains('tk-admin-ui-zoom')).toBe(true)
+    expect(document.documentElement.style.getPropertyValue('--tk-admin-ui-zoom')).toBe(
+      String(TK_ADMIN_UI_ZOOM)
+    )
   })
 
   it('clears zoom for ops fullscreen shellless mode', () => {
@@ -39,6 +45,8 @@ describe('AdminShellView', () => {
     route.query = { fullscreen: '1' }
     mount(AdminShellView)
     expect(document.documentElement.style.zoom).toBe('')
+    expect(document.documentElement.classList.contains('tk-admin-ui-zoom')).toBe(false)
+    expect(document.documentElement.style.getPropertyValue('--tk-admin-ui-zoom')).toBe('')
   })
 
   it('restores zoom when leaving ops fullscreen', async () => {
@@ -50,6 +58,7 @@ describe('AdminShellView', () => {
     route.query = {}
     await wrapper.vm.$nextTick()
     expect(document.documentElement.style.zoom).toBe(String(TK_ADMIN_UI_ZOOM))
+    expect(document.documentElement.classList.contains('tk-admin-ui-zoom')).toBe(true)
   })
 
   it('clears zoom on unmount so user routes stay at 100%', () => {
@@ -57,5 +66,7 @@ describe('AdminShellView', () => {
     expect(document.documentElement.style.zoom).toBe(String(TK_ADMIN_UI_ZOOM))
     wrapper.unmount()
     expect(document.documentElement.style.zoom).toBe('')
+    expect(document.documentElement.classList.contains('tk-admin-ui-zoom')).toBe(false)
+    expect(document.documentElement.style.getPropertyValue('--tk-admin-ui-zoom')).toBe('')
   })
 })

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -82,9 +82,20 @@
       "must_contain": [
         "syncAdminUiZoom",
         "TK_ADMIN_UI_ZOOM",
-        "document.documentElement.style.zoom"
+        "document.documentElement.style.zoom",
+        "tk-admin-ui-zoom",
+        "admin-ui-zoom.tk.css"
       ],
-      "rationale": "Persistent admin shell (PR #935) owns AppLayout once for all /admin/* routes. TK applies documentElement zoom here so dense admin tables fit without per-session browser scaling; an upstream merge that rewrites the shell file could silently drop the zoom hook while admin-shell-layout still passes."
+      "rationale": "Persistent admin shell (PR #935) owns AppLayout once for all /admin/* routes. TK applies documentElement zoom here so dense admin tables fit without per-session browser scaling; the tk-admin-ui-zoom class + admin-ui-zoom.tk.css compensate vh-based heights that would otherwise leave bottom whitespace at 80% zoom. An upstream merge that rewrites the shell file could silently drop the zoom hook while admin-shell-layout still passes."
+    },
+    {
+      "path": "frontend/src/styles/admin-ui-zoom.tk.css",
+      "must_contain": [
+        "html.tk-admin-ui-zoom .min-h-screen",
+        "html.tk-admin-ui-zoom .table-page-layout:not(.mobile-mode)",
+        "var(--tk-admin-ui-zoom)"
+      ],
+      "rationale": "Viewport-height compensation for AdminShellView document zoom. Without these rules, min-h-screen / TablePageLayout 100vh calcs stay in unzoomed viewport units and admin pages show ~20% blank space at the bottom."
     },
     {
       "path": "frontend/src/views/user/studio/BakeOff.vue",


### PR DESCRIPTION
## 摘要

- 修复 #1045 引入的 admin 默认 `zoom: 0.8` 与 `min-h-screen` / `100vh` 未联动导致的页面底部约 20% 空白、空间利用率差的问题。
- `AdminShellView` 挂载时为 `<html>` 增加 `tk-admin-ui-zoom` class 与 `--tk-admin-ui-zoom` CSS 变量；新增 `admin-ui-zoom.tk.css`，将 `min-h-screen` 与 `TablePageLayout` 高度按缩放比例补偿（`calc(... / var(--tk-admin-ui-zoom))`）。
- Ops 全屏模式与离开 admin 时仍清除 zoom / class / 变量；sentinel 锚定补偿 CSS 与 shell hook。

## 风险

- 低风险，纯前端布局补偿；用户侧 `/user/*` 不受影响。
- 补偿规则仅在有 `html.tk-admin-ui-zoom` 时生效；若未来 admin 页新增其他 `100vh` 硬编码布局，可能需补同类规则（当前主要命中 AppLayout + TablePageLayout）。

## 验证

- `pnpm exec vitest run src/views/admin/__tests__/AdminShellView.spec.ts` — 4/4 通过
- `./scripts/preflight.sh` — PASS（含 embedded dist freshness、frontend TK sentinels）
- `make build-frontend` — 已更新 `frontend-source.json`

## 提交

- 4dd106324 fix(admin): compensate viewport heights under 80% admin zoom

最新提交：4dd106324
