### PR TITLE
fix(billing,gateway): 对齐 watchdog #2486/#61348 fact-check 锚点

### DIFF
--- a/.cache/anthropic/cc-fact-checks.json
+++ b/.cache/anthropic/cc-fact-checks.json
@@ -6,9 +6,10 @@
       "upstream": "anthropics/claude-code#61348",
       "severity": "high",
       "tokenkey_pr": "youxuanxue/sub2api#514, youxuanxue/sub2api#518",
-      "summary": "Opus 4.7+ thinking.type=enabled 400 self-healed to thinking.type=adaptive on both the Forward and APIKey passthrough paths; model-aware RectifyThinkingBudget; hard-gated by isOpus47OrNewer.",
+      "summary": "Opus 4.7+ / Fable thinking.type=enabled 400 self-healed to thinking.type=adaptive on both the Forward and APIKey passthrough paths; model-aware RectifyThinkingBudget; hard-gated by requiresAdaptiveOnlyThinking (isOpus47OrNewer || isFableModel).",
       "fixed_by": [
         "backend/internal/service/gateway_request.go",
+        "backend/internal/service/gateway_request_tk_fable.go",
         "backend/internal/service/gateway_service.go",
         "backend/internal/service/gateway_request_thinking_adaptive_test.go"
       ],
@@ -16,7 +17,8 @@
         "backend/internal/service/gateway_request.go:func isThinkingTypeAdaptiveRequiredError",
         "backend/internal/service/gateway_request.go:func RectifyThinkingTypeAdaptive",
         "backend/internal/service/gateway_request.go:func isOpus47OrNewer",
-        "backend/internal/service/gateway_request.go:if isOpus47OrNewer(modelID) {",
+        "backend/internal/service/gateway_request_tk_fable.go:func requiresAdaptiveOnlyThinking",
+        "backend/internal/service/gateway_request.go:if requiresAdaptiveOnlyThinking(modelID) {",
         "backend/internal/service/gateway_service.go:Kind:               \"thinking_type_adaptive_error\",",
         "backend/internal/service/gateway_request_thinking_adaptive_test.go:func TestRectifyThinkingTypeAdaptive"
       ]

--- a/.cache/anthropic/cc-fixes.json
+++ b/.cache/anthropic/cc-fixes.json
@@ -19,10 +19,11 @@
       "status": "fixed_in_tokenkey",
       "fixed_by": [
         "backend/internal/service/gateway_request.go",
+        "backend/internal/service/gateway_request_tk_fable.go",
         "backend/internal/service/gateway_service.go",
         "backend/internal/service/gateway_request_thinking_adaptive_test.go"
       ],
-      "summary": "Opus 4.7+ thinking.type=enabled 400 self-healed to thinking.type=adaptive on both the Forward and APIKey passthrough paths; model-aware RectifyThinkingBudget; hard-gated by isOpus47OrNewer."
+      "summary": "Opus 4.7+ / Fable thinking.type=enabled 400 self-healed to thinking.type=adaptive on both the Forward and APIKey passthrough paths; model-aware RectifyThinkingBudget; hard-gated by requiresAdaptiveOnlyThinking (isOpus47OrNewer || isFableModel)."
     },
     {
       "upstream": "anthropics/claude-code#60168, anthropics/claude-code#63885, anthropics/claude-code#64777",

--- a/.cache/upstream/fact-checks.json
+++ b/.cache/upstream/fact-checks.json
@@ -166,15 +166,19 @@
     {
       "upstream": "Wei-Shaw/sub2api#2486",
       "severity": "high",
-      "summary": "Unknown gemini-* models (including gemini-pro-agent) fall back to gemini-3.1-pro pricing instead of returning nil (which caused calculateTokenCost to silently record ActualCost=0 with no quota deduction).",
+      "summary": "Unknown gemini-* models (including gemini-pro-agent) fall back to a non-nil pro/flash family floor instead of returning nil (which caused calculateTokenCost to silently record ActualCost=0 with no quota deduction). Production also carries an explicit tk_pricing_overlay entry for gemini-pro-agent.",
       "fixed_by": [
         "backend/internal/service/billing_service.go",
-        "backend/internal/service/billing_service_test.go"
+        "backend/internal/service/billing_service_test.go",
+        "backend/internal/service/pricing_service_tk_overlay_test.go",
+        "backend/internal/service/tk_pricing_overlay.json"
       ],
       "fixed_if_all_present": [
         "backend/internal/service/billing_service.go:Wei-Shaw/sub2api#2486",
         "backend/internal/service/billing_service.go:if strings.Contains(modelLower, \"gemini\")",
-        "backend/internal/service/billing_service_test.go:gemini-pro-agent falls back to 3.1-pro"
+        "backend/internal/service/billing_service_test.go:gemini-pro-agent falls back to pro family floor",
+        "backend/internal/service/pricing_service_tk_overlay_test.go:TestTKPricingOverlay_FillsGeminiProAgent",
+        "backend/internal/service/tk_pricing_overlay.json:\"gemini-pro-agent\""
       ]
     },
     {

--- a/.cache/upstream/fixes.json
+++ b/.cache/upstream/fixes.json
@@ -485,9 +485,11 @@
       "status": "fixed_in_tokenkey",
       "fixed_by": [
         "backend/internal/service/billing_service.go",
-        "backend/internal/service/billing_service_test.go"
+        "backend/internal/service/billing_service_test.go",
+        "backend/internal/service/pricing_service_tk_overlay_test.go",
+        "backend/internal/service/tk_pricing_overlay.json"
       ],
-      "summary": "Unknown gemini-* models (including gemini-pro-agent) fall back to gemini-3.1-pro pricing instead of returning nil (which caused calculateTokenCost to silently record ActualCost=0 with no quota deduction)."
+      "summary": "Unknown gemini-* models (including gemini-pro-agent) fall back to a non-nil pro/flash family floor instead of returning nil (which caused calculateTokenCost to silently record ActualCost=0 with no quota deduction). Production also carries an explicit tk_pricing_overlay entry for gemini-pro-agent."
     },
     {
       "upstream": "Wei-Shaw/sub2api#2487",

--- a/.cache/upstream/triage.json
+++ b/.cache/upstream/triage.json
@@ -6,8 +6,8 @@
   "counts": {
     "needs_review": 480,
     "needs_prod_validation": 1,
-    "fixed": 39,
     "medium": 139,
+    "fixed": 39,
     "not_applicable": 1,
     "low": 125,
     "unknown_low_signal": 502
@@ -8081,7 +8081,7 @@
         "billing_usage"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "Unknown gemini-* models (including gemini-pro-agent) fall back to gemini-3.1-pro pricing instead of returning nil (which caused calculateTokenCost to silently record ActualCost=0 with no quota deduction).",
+      "rationale": "Unknown gemini-* models (including gemini-pro-agent) fall back to a non-nil pro/flash family floor instead of returning nil (which caused calculateTokenCost to silently record ActualCost=0 with no quota deduction). Production also carries an explicit tk_pricing_overlay entry for gemini-pro-agent.",
       "updated_at": "2026-05-15T03:55:24Z"
     },
     {

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -627,6 +627,8 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	// served_at_fallback alert then drives a real-price fill. "pro" → pro floor; flash / flash-lite /
 	// unknown gemini → flash-tier median. (Family granularity + median tier bound the mischarge that a
 	// single flat rate would cause — that was the C-era objection, addressed here, not avoided.)
+	// TK: See upstream Wei-Shaw/sub2api#2486 — gemini-pro-agent and other unknown gemini-* ids must
+	// never return nil here; nil caused calculateTokenCost to record ActualCost=0 with no quota deduction.
 	if strings.Contains(modelLower, "gemini") {
 		if strings.Contains(modelLower, "pro") {
 			return s.fallbackPrices["gemini-2.5-pro"]

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -34,6 +34,13 @@ func TestCalculateCost_BasicComputation(t *testing.T) {
 	require.InDelta(t, expectedInput+expectedOutput, cost.ActualCost, 1e-10)
 }
 
+func TestCalculateCost_GeminiProAgent_FallbackFloorNonZero(t *testing.T) {
+	svc := newTestBillingService()
+	cost, err := svc.CalculateCost("gemini-pro-agent", UsageTokens{InputTokens: 1000, OutputTokens: 500}, 1.0)
+	require.NoError(t, err)
+	require.Greater(t, cost.ActualCost, 0.0, "Wei-Shaw/sub2api#2486: gemini-pro-agent must never bill $0 via nil pricing")
+}
+
 func TestCalculateCost_WithCacheTokens(t *testing.T) {
 	svc := newTestBillingService()
 
@@ -360,7 +367,8 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 		// floor (never $0, never rejected) and fires served_at_fallback → fill. Real-priced gemini
 		// models resolve in GetModelPricing before this fallback.
 		{name: "gemini-*-pro unknown → pro family floor", model: "gemini-2.0-pro", expectedInput: 1.25e-6},
-		{name: "gemini-pro-agent → pro family floor", model: "gemini-pro-agent", expectedInput: 1.25e-6},
+		// Wei-Shaw/sub2api#2486: gemini-pro-agent falls back to pro family floor (never $0).
+		{name: "gemini-pro-agent falls back to pro family floor", model: "gemini-pro-agent", expectedInput: 1.25e-6},
 		{name: "gemini-*-flash unknown → flash family floor", model: "gemini-9-flash-preview", expectedInput: 3e-7},
 		{name: "gemini-*-flash-lite unknown → flash-lite floor (S3: no 6x overcharge)", model: "gemini-9-flash-lite-x", expectedInput: 1e-7},
 		{name: "gemini unknown no tier → flash-tier median floor", model: "gemini-9-ultra", expectedInput: 3e-7},

--- a/backend/internal/service/pricing_service_tk_overlay_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_test.go
@@ -94,6 +94,33 @@ func TestTKPricingOverlay_FillsAntigravityGeminiThinking(t *testing.T) {
 	require.True(t, thinking.SupportsPromptCaching)
 }
 
+// TestTKPricingOverlay_FillsGeminiProAgent verifies the Antigravity Gemini 3.1 Pro
+// High wire id (gemini-pro-agent) has a concrete price. Without this overlay entry the
+// model was servable but billed $0 (upstream Wei-Shaw/sub2api#2486).
+func TestTKPricingOverlay_FillsGeminiProAgent(t *testing.T) {
+	svc := &PricingService{}
+	body := []byte(`{
+		"gemini-2.5-pro": {
+			"input_cost_per_token": 0.00000125,
+			"output_cost_per_token": 0.00001,
+			"cache_read_input_token_cost": 0.000000125,
+			"litellm_provider": "vertex_ai-language-models",
+			"mode": "chat"
+		}
+	}`)
+
+	data, err := svc.parsePricingData(body)
+	require.NoError(t, err)
+
+	proAgent := data["gemini-pro-agent"]
+	require.NotNil(t, proAgent, "overlay must inject gemini-pro-agent")
+	require.Equal(t, "antigravity", proAgent.LiteLLMProvider)
+	require.Equal(t, "chat", proAgent.Mode)
+	require.InDelta(t, 2e-6, proAgent.InputCostPerToken, 1e-15)
+	require.InDelta(t, 1.2e-5, proAgent.OutputCostPerToken, 1e-15)
+	require.InDelta(t, 2e-7, proAgent.CacheReadInputTokenCost, 1e-15)
+}
+
 // TestTKPricingOverlay_ZeroPlaceholderIsReplaced verifies the absent-or-zero fill:
 // a source entry whose every cost field is 0.0 (litellm's "cost unknown" shape —
 // the exact prod state of deepseek-v3-2-251201 under volcengine, which billed 683


### PR DESCRIPTION
## 摘要

- 来自 watchdog PR #894 / #875 的两条高优 issue：`Wei-Shaw/sub2api#2486`（`gemini-pro-agent` 可能 $0 计费）与 `anthropics/claude-code#61348`（Opus 4.7+ `thinking.type=enabled` 400）。
- 运行时逻辑已在 main，但 fact-check 锚点过期（仍找 `3.1-pro` / `if isOpus47OrNewer`），导致 daily watchdog 无法 verified。
- 补齐 `gemini-pro-agent` 计费回归测试，刷新 upstream / anthropic fix-ledger 锚点，使 triage 可机械标记 `fixed_in_tokenkey`。

## 风险

- 常规风险：仅补测试 + ledger 锚点同步，无公共 API 行为变更。
- `#61348` 路径仍由既有 `requiresAdaptiveOnlyThinking` + `RectifyThinkingTypeAdaptive` 承担，未改 gateway 转发语义。

## 验证

- `./scripts/preflight.sh` — PASS（含 fix-ledger consistency）
- `go test -tags=unit ./internal/service -run 'TestCalculateCost_GeminiProAgent|TestTKPricingOverlay_FillsGeminiProAgent|TestRectifyThinkingTypeAdaptive|TestRequiresAdaptiveOnlyThinking'` — PASS
- fact-check 锚点手工 grep — `#2486` / `#61348` 全部 OK

## 提交

- f8d1e3d2a fix(billing,gateway): 对齐 watchdog 高优 issue 的 fact-check 锚点

最新提交：f8d1e3d2a
