### PR TITLE
fix(admin): 80% zoom 下表格页 flex 填满视口底部

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 520,
-  "hash": "1b903a8a1e81996f0e1e228c27770d8d77bed9a96bdbe928e2574aeac99484fd",
+  "hash": "9318099435a29ac92afb0ee2022019e27d111c3cabc3622e9c827a1159eb2fad",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/styles/admin-ui-zoom.tk.css
+++ b/frontend/src/styles/admin-ui-zoom.tk.css
@@ -1,6 +1,8 @@
 /* TK: compensate viewport-based heights when AdminShellView applies document zoom.
    CSS zoom scales visual output but vh / min-h-screen stay in unzoomed viewport
-   units, leaving ~(1 - zoom) * 100vh blank space at the bottom of admin pages. */
+   units. Pass 1: scale shell wrappers. Pass 2: flex-fill admin table pages so
+   TablePageLayout consumes the space below filters/pagination instead of leaving
+   a dead band above main bottom padding. */
 
 html.tk-admin-ui-zoom,
 html.tk-admin-ui-zoom body {
@@ -11,6 +13,30 @@ html.tk-admin-ui-zoom .min-h-screen {
   min-height: calc(100vh / var(--tk-admin-ui-zoom));
 }
 
+/* AppLayout: header + main stack fills the compensated viewport. */
+html.tk-admin-ui-zoom .min-h-screen.bg-gray-50 > .relative.min-h-screen {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh / var(--tk-admin-ui-zoom));
+}
+
+html.tk-admin-ui-zoom main {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+@media (min-width: 1024px) {
+  html.tk-admin-ui-zoom main {
+    padding-bottom: 1rem;
+  }
+}
+
+/* Flex fill beats vh subtraction — chrome/padding drift under zoom caused the
+   post-#1047 gap below pagination on /admin/accounts. */
 html.tk-admin-ui-zoom .table-page-layout:not(.mobile-mode) {
-  height: calc((100vh - 64px - 4rem) / var(--tk-admin-ui-zoom));
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto !important;
 }

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -93,9 +93,11 @@
       "must_contain": [
         "html.tk-admin-ui-zoom .min-h-screen",
         "html.tk-admin-ui-zoom .table-page-layout:not(.mobile-mode)",
+        "flex: 1 1 auto",
+        "height: auto !important",
         "var(--tk-admin-ui-zoom)"
       ],
-      "rationale": "Viewport-height compensation for AdminShellView document zoom. Without these rules, min-h-screen / TablePageLayout 100vh calcs stay in unzoomed viewport units and admin pages show ~20% blank space at the bottom."
+      "rationale": "Viewport layout for AdminShellView document zoom. min-h-screen compensation removes page-level bottom whitespace; the AppLayout flex stack + TablePageLayout flex-fill removes the residual dead band below pagination on dense admin tables (/admin/accounts)."
     },
     {
       "path": "frontend/src/views/user/studio/BakeOff.vue",


### PR DESCRIPTION
## 摘要

- 跟进 1.8.53（#1047）：80% admin zoom 下 `/admin/accounts` 等表格页分页条下方仍有明显空白带。
- 根因是 `TablePageLayout` 用 `100vh - header - padding` 固定高度，在 zoom + 实际 chrome 偏差下算短了一截；表格区域无法吃掉剩余视口。
- 改为 AppLayout 内 `header + main` flex 纵向栈，`TablePageLayout` 用 `flex: 1; height: auto` 填满剩余空间；lg  breakpoint 下 `main` 底部 padding 从 2rem 收到 1rem，多挤出一点表格高度。

## 风险

- 低风险，纯 CSS，且仅在 `html.tk-admin-ui-zoom` 时生效；用户侧与 ops 全屏不受影响。
- 非表格 admin 页（Settings 等长页）仍可按内容自然增高滚动，未锁死 max-height。

## 验证

- `pnpm exec vitest run src/views/admin/__tests__/AdminShellView.spec.ts` — 4/4 通过
- `./scripts/preflight.sh` — PASS
- `make build-frontend` — 已更新 `frontend-source.json`

## 提交

- 9cccc4dc4 fix(admin): flex-fill table pages under 80% zoom

最新提交：9cccc4dc4
