### PR TITLE
fix(studio): 全能 Key 模型发现、播放来源标注与浏览器缓存

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 520,
-  "hash": "9d2c2f2a0eed89c8f13a6f6d0b43c2d8db1076f240e6c58474f5a4714b1b879e",
+  "file_count": 523,
+  "hash": "5e6b60691ab82a7c60dfd39e96e9f279a490750fcfa1d1a75295ed65f9de1246",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/composables/__tests__/useMediaLibrary.spec.ts
+++ b/frontend/src/composables/__tests__/useMediaLibrary.spec.ts
@@ -1,6 +1,15 @@
 import { nextTick } from 'vue'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useMediaLibrary, type ImageHistoryItem, type VideoTaskItem } from '../useMediaLibrary'
+
+vi.mock('@/utils/studioBlobCache.tk', () => ({
+  cacheStudioBlobFromSrc: vi.fn(async () => true),
+  getStudioBlobObjectUrl: vi.fn(async (_u: string | number, kind: string, id: string) =>
+    kind === 'image' && id === 'img-reload' ? 'blob:cached-image' : ''
+  ),
+  deleteStudioBlob: vi.fn(async () => undefined),
+  pruneStudioBlobCache: vi.fn(async () => undefined),
+}))
 
 const USER_ID = 'media-lib-test'
 const KEY = `tk_media_lib_v1:${USER_ID}`
@@ -97,5 +106,19 @@ describe('useMediaLibrary image persistence', () => {
     const byId = Object.fromEntries(persisted.images.map((i: ImageHistoryItem) => [i.id, i.src]))
     expect(byId['img-http']).toBe('https://cdn.example/a.png')
     expect(byId['img-offloaded']).toBe('https://s3.example/presigned')
+  })
+
+  it('hydrates blank inline image src from the blob cache after reload', async () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        images: [{ ...imageItem('img-reload', ''), prompt: 'reload me' }],
+        videoTasks: [],
+      })
+    )
+    const lib = useMediaLibrary(USER_ID)
+    expect(lib.images.value[0].src).toBe('')
+    await lib.hydrateFromBlobCache()
+    expect(lib.images.value[0].src).toBe('blob:cached-image')
   })
 })

--- a/frontend/src/composables/useMediaLibrary.ts
+++ b/frontend/src/composables/useMediaLibrary.ts
@@ -11,13 +11,20 @@
  * key is resolved from the live key list at runtime (useVideoTaskPoll). A
  * deleted key simply means the task can no longer be polled.
  *
- * Storage is best-effort. Inline data: payloads stay browser-local instead of
- * being written to localStorage: video tasks (data:video / blob:) and now images
- * (data: src with no s3Key — gemini-native, or imagen/gpt-image under the #944
- * pass-through default) are sanitized before persistence. A residual
- * QuotaExceededError still trims the oldest image entries and retries.
+ * Storage is best-effort. Inline data: payloads are NOT written to localStorage
+ * (gemini-native / pass-through #944 images, data:video clips) — they are mirrored
+ * into IndexedDB (`studioBlobCache.tk.ts`) keyed by item id so a reload can still
+ * show thumbnails / replay video without TokenKey hosting media. A residual
+ * QuotaExceededError on localStorage still trims the oldest metadata entries.
  */
 import { ref, watch, type Ref } from 'vue'
+import {
+  cacheStudioBlobFromSrc,
+  deleteStudioBlob,
+  getStudioBlobObjectUrl,
+  pruneStudioBlobCache,
+} from '@/utils/studioBlobCache.tk'
+import type { StudioPlaybackStorage } from '@/utils/studioPlaybackStorage.tk'
 
 export type VideoTaskState = 'processing' | 'succeeded' | 'failed'
 
@@ -30,9 +37,11 @@ export interface ImageHistoryItem {
    * one from this key (POST /v1/images/presign) so persisted thumbnails don't break.
    * Absent for inline data: URI images (gemini-native, or imagen/gpt-image under the
    * #944 pass-through default) — those carry the bytes inline and are NOT persisted
-   * (sanitizeImageForPersistence blanks src), so on reload they show a regenerate hint.
+   * (sanitizeImageForPersistence blanks src); bytes may still live in IndexedDB.
    */
   s3Key?: string
+  /** True when bytes were written to the browser blob cache (reload hydration). */
+  blobCached?: boolean
   prompt: string
   revisedPrompt?: string
   model: string
@@ -58,6 +67,10 @@ export interface VideoTaskItem {
   url: string
   /** Set when an upstream http(s) link expired or was stripped on reload — card shows prompt only. */
   urlExpired?: boolean
+  /** True when clip bytes were written to IndexedDB (reload playback). */
+  blobCached?: boolean
+  /** How replay / browser cache behaves for this clip (diagnostics). */
+  playbackStorage?: StudioPlaybackStorage
   submittedAtMs: number
   elapsedS: number
   errorMessage?: string
@@ -161,6 +174,10 @@ export interface MediaLibrary {
   patchVideoTask: (id: string, patch: Partial<VideoTaskItem>) => void
   removeVideoTask: (id: string) => void
   clearVideoTasks: () => void
+  /** Rehydrate empty src/url from IndexedDB after reload; call once on Studio mount. */
+  hydrateFromBlobCache: () => Promise<void>
+  /** Best-effort mirror of inline media into IndexedDB (generation / poll terminal). */
+  cacheInlineMedia: (kind: 'image' | 'video', itemId: string, src: string) => Promise<void>
 }
 
 export function useMediaLibrary(userId: number | string): MediaLibrary {
@@ -177,12 +194,39 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
     { deep: true }
   )
 
+  async function cacheInlineMedia(kind: 'image' | 'video', itemId: string, src: string): Promise<void> {
+    if (!src) return
+    const ok = await cacheStudioBlobFromSrc(userId, kind, itemId, src)
+    if (!ok) return
+    if (kind === 'image') {
+      const idx = images.value.findIndex((it) => it.id === itemId)
+      if (idx >= 0) {
+        const next = [...images.value]
+        next[idx] = { ...next[idx], blobCached: true }
+        images.value = next
+      }
+    } else {
+      const idx = videoTasks.value.findIndex((t) => t.id === itemId)
+      if (idx >= 0) {
+        const next = [...videoTasks.value]
+        next[idx] = { ...next[idx], blobCached: true, urlExpired: false }
+        videoTasks.value = next
+      }
+    }
+  }
+
   function addImages(items: ImageHistoryItem[]): void {
     if (!items.length) return
     images.value = [...items, ...images.value].slice(0, IMAGE_CAP)
+    for (const it of items) {
+      if (it.src && /^data:/i.test(it.src)) void cacheInlineMedia('image', it.id, it.src)
+    }
   }
 
   function clearImages(): void {
+    for (const it of images.value) {
+      if (it.blobCached) void deleteStudioBlob(userId, 'image', it.id)
+    }
     images.value = []
   }
 
@@ -195,6 +239,9 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
     } else {
       videoTasks.value = [task, ...videoTasks.value].slice(0, VIDEO_CAP)
     }
+    if (task.state === 'succeeded' && task.url && (/^data:video/i.test(task.url) || task.url.startsWith('blob:'))) {
+      void cacheInlineMedia('video', task.id, task.url)
+    }
   }
 
   function patchVideoTask(id: string, patch: Partial<VideoTaskItem>): void {
@@ -203,14 +250,50 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
     const next = [...videoTasks.value]
     next[idx] = { ...next[idx], ...patch }
     videoTasks.value = next
+    const merged = next[idx]
+    if (merged.state === 'succeeded' && merged.url && (/^data:video/i.test(merged.url) || merged.url.startsWith('blob:'))) {
+      void cacheInlineMedia('video', id, merged.url)
+    }
   }
 
   function removeVideoTask(id: string): void {
+    const task = videoTasks.value.find((t) => t.id === id)
+    if (task?.blobCached) void deleteStudioBlob(userId, 'video', id)
     videoTasks.value = videoTasks.value.filter((t) => t.id !== id)
   }
 
   function clearVideoTasks(): void {
+    for (const t of videoTasks.value) {
+      if (t.blobCached) void deleteStudioBlob(userId, 'video', t.id)
+    }
     videoTasks.value = []
+  }
+
+  async function hydrateFromBlobCache(): Promise<void> {
+    await pruneStudioBlobCache(userId)
+    let imagesChanged = false
+    const nextImages = [...images.value]
+    for (let i = 0; i < nextImages.length; i++) {
+      const it = nextImages[i]
+      if (it.src || it.s3Key) continue
+      const blobUrl = await getStudioBlobObjectUrl(userId, 'image', it.id)
+      if (!blobUrl) continue
+      nextImages[i] = { ...it, src: blobUrl, blobCached: true }
+      imagesChanged = true
+    }
+    if (imagesChanged) images.value = nextImages
+
+    let videosChanged = false
+    const nextVideos = [...videoTasks.value]
+    for (let i = 0; i < nextVideos.length; i++) {
+      const t = nextVideos[i]
+      if (t.url || t.state !== 'succeeded') continue
+      const blobUrl = await getStudioBlobObjectUrl(userId, 'video', t.id)
+      if (!blobUrl) continue
+      nextVideos[i] = { ...t, url: blobUrl, blobCached: true, urlExpired: false }
+      videosChanged = true
+    }
+    if (videosChanged) videoTasks.value = nextVideos
   }
 
   return {
@@ -222,5 +305,7 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
     patchVideoTask,
     removeVideoTask,
     clearVideoTasks,
+    hydrateFromBlobCache,
+    cacheInlineMedia,
   }
 }

--- a/frontend/src/composables/useMediaLibrary.ts
+++ b/frontend/src/composables/useMediaLibrary.ts
@@ -19,6 +19,7 @@
  */
 import { ref, watch, type Ref } from 'vue'
 import {
+  cacheStudioBlobFromHttpUrl,
   cacheStudioBlobFromSrc,
   deleteStudioBlob,
   getStudioBlobObjectUrl,
@@ -196,7 +197,9 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
 
   async function cacheInlineMedia(kind: 'image' | 'video', itemId: string, src: string): Promise<void> {
     if (!src) return
-    const ok = await cacheStudioBlobFromSrc(userId, kind, itemId, src)
+    const ok = /^https?:\/\//i.test(src)
+      ? await cacheStudioBlobFromHttpUrl(userId, kind, itemId, src)
+      : await cacheStudioBlobFromSrc(userId, kind, itemId, src)
     if (!ok) return
     if (kind === 'image') {
       const idx = images.value.findIndex((it) => it.id === itemId)

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -142,6 +142,16 @@ export default {
     viewPricing: 'See pricing',
     via: 'via {vendor}',
     keyNoModality: 'no models for this mode',
+    saveReminder: 'Results stay in this browser for about 7 days — download now; clearing cache or switching devices will lose them.',
+    universalKeyBadge: 'Universal key',
+    playback: {
+      inlineLocal: 'Local cache · preview survives reload (~7 days)',
+      upstreamCorsOk: 'Upstream URL · CORS fetch OK · download anyway',
+      upstreamCorsBlocked: 'Upstream URL · CORS blocks cache · no preview after reload · download now',
+      expired: 'Preview gone · prompt only kept',
+      unknown: 'Storage unknown · download now',
+      label: 'Preview source',
+    },
     needsApikeyAccount: 'Needs an API-key account',
     badge: {
       draft: 'Draft',
@@ -203,7 +213,7 @@ export default {
       usePrompt: 'Use prompt',
       useAsInput: 'Use as input',
       enlargeHint: 'Click to enlarge',
-      expiredReload: 'Preview not kept after reload — use the prompt to make it again.',
+      expiredReload: 'Local preview expired — download to keep, or reuse the prompt (billed again).',
       close: 'Close',
       inputImageLabel: 'Input image (image-to-image)',
       inputUpload: 'Upload image',
@@ -222,6 +232,8 @@ export default {
     video: {
       modelLabel: 'Model',
       modelEmpty: 'No video models are available for this group yet.',
+      modelEmptySwitchKey: 'Video models (Veo / Seedance) live on Vertex or VolcEngine groups. Switch to an API key that serves video above.',
+      modelEmptyAllKeys: 'None of your key groups expose video models yet. See pricing for supported groups or ask an admin.',
       samplePrompt: 'A neon Tokyo alley, slow push-in, rain, reflections, cinematic',
       perSecondUnit: ' /s',
       promptPlaceholder: 'Describe the video…',
@@ -263,7 +275,8 @@ export default {
       retry: 'Try again',
       copyLink: 'Copy link',
       copied: 'Copied',
-      retentionHint: 'Temporary upstream link · download soon'
+      retentionHint: 'Download now · short local preview; upstream links expire',
+      previewBuffering: 'Buffering video…',
     },
     chat: {
       model: 'Model',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -140,6 +140,16 @@ export default {
     viewPricing: '查看价格',
     via: '经 {vendor}',
     keyNoModality: '此模式无可用模型',
+    saveReminder: '生成结果保存在本机浏览器（约 7 天），仍请立即下载；清缓存或换设备后会丢失。',
+    universalKeyBadge: '全能 Key',
+    playback: {
+      inlineLocal: '本机缓存 · 刷新后仍可预览（约 7 天）',
+      upstreamCorsOk: '上游直链 · 已探测可缓存 · 仍请下载',
+      upstreamCorsBlocked: '上游直链 · 跨域不可缓存 · 刷新后不可预览 · 请立即下载',
+      expired: '预览已失效 · 仅保留提示词',
+      unknown: '存储方式未知 · 请立即下载',
+      label: '预览来源',
+    },
     needsApikeyAccount: '需要 apikey 类型账号',
     badge: {
       draft: '草稿',
@@ -201,7 +211,7 @@ export default {
       usePrompt: '用此 prompt',
       useAsInput: '用作输入',
       enlargeHint: '点击放大预览',
-      expiredReload: '预览不会在刷新后保留——用提示词重新生成。',
+      expiredReload: '本机预览已过期——可下载保存，或用提示词重新生成（需再次计费）。',
       close: '关闭',
       inputImageLabel: '输入图片（图生图）',
       inputUpload: '上传图片',
@@ -220,6 +230,8 @@ export default {
     video: {
       modelLabel: '模型',
       modelEmpty: '当前分组暂无可用的视频模型。',
+      modelEmptySwitchKey: '视频模型（Veo / Seedance）通常在 Vertex 或 VolcEngine 分组。请在上方切换到带「视频」能力的 API 密钥。',
+      modelEmptyAllKeys: '你的所有密钥分组均未开通视频模型。可在价格页查看支持的分组，或联系管理员开通。',
       samplePrompt: '霓虹东京小巷，慢推镜头，雨，反射光，电影感',
       perSecondUnit: ' /秒',
       promptPlaceholder: '描述你想要的视频…',
@@ -261,7 +273,8 @@ export default {
       retry: '重试',
       copyLink: '复制链接',
       copied: '已复制',
-      retentionHint: '上游临时链接 · 请及时下载'
+      retentionHint: '请立即下载保存 · 本机可短期预览，上游链接会过期',
+      previewBuffering: '正在缓冲视频…',
     },
     chat: {
       model: '模型',

--- a/frontend/src/utils/__tests__/studioPlaybackStorage.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioPlaybackStorage.tk.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { classifyVideoUrlStorage } from '../studioPlaybackStorage.tk'
+
+describe('classifyVideoUrlStorage', () => {
+  it('marks inline data:video as local-cacheable', () => {
+    expect(classifyVideoUrlStorage('data:video/mp4;base64,AAAA')).toBe('inline-local')
+  })
+
+  it('marks empty url as expired', () => {
+    expect(classifyVideoUrlStorage('')).toBe('expired')
+  })
+
+  it('marks http url as unknown until probed', () => {
+    expect(classifyVideoUrlStorage('https://cdn.example/v.mp4')).toBe('unknown')
+  })
+})

--- a/frontend/src/utils/__tests__/studioUniversalKey.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioUniversalKey.tk.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  entitledModelIds,
+  isUniversalKey,
+  priceMapFromPublicCatalog,
+} from '../studioUniversalKey.tk'
+import type { ApiKey } from '@/types'
+
+describe('studioUniversalKey', () => {
+  it('detects universal keys by routing_mode or missing group', () => {
+    expect(isUniversalKey({ id: 1, routing_mode: 'universal' } as ApiKey)).toBe(true)
+    expect(isUniversalKey({ id: 2, group_id: null, group: null } as ApiKey)).toBe(true)
+    expect(isUniversalKey({ id: 3, group: { id: 1, name: 'g' } } as ApiKey)).toBe(false)
+  })
+
+  it('builds entitled model ids from authorized_groups_by_model', () => {
+    const ids = entitledModelIds({
+      authorized_groups_by_model: {
+        'veo-3.1-generate-001': [{ group_id: 1, group_name: 'vertex' }],
+        'gemini-3.1-flash-image': [{ group_id: 2, group_name: 'gemini' }],
+      },
+    } as never)
+    expect(ids.has('veo-3.1-generate-001')).toBe(true)
+    expect(ids.has('gemini-3.1-flash-image')).toBe(true)
+  })
+
+  it('intersects public catalog prices with entitled ids', () => {
+    const map = priceMapFromPublicCatalog(
+      [
+        {
+          model_id: 'veo-3.1-generate-001',
+          pricing: { output_cost_per_second: 0.6 },
+        },
+        {
+          model_id: 'gpt-4o',
+          pricing: { output_cost_per_image: 0.01 },
+        },
+      ] as never,
+      new Set(['veo-3.1-generate-001'])
+    )
+    expect(map.get('veo-3.1-generate-001')?.perSecond).toBe(0.6)
+    expect(map.has('gpt-4o')).toBe(false)
+  })
+})

--- a/frontend/src/utils/studioBlobCache.tk.ts
+++ b/frontend/src/utils/studioBlobCache.tk.ts
@@ -107,8 +107,7 @@ async function enforceQuota(db: IDBDatabase, userId: string, incomingBytes: numb
 }
 
 /**
- * Persist media bytes from an in-tab src (data: URI or blob:). http(s) is skipped
- * here — callers may fetch+cache separately when CORS allows.
+ * Persist media bytes from an in-tab src (data: URI or blob:).
  */
 export async function cacheStudioBlobFromSrc(
   userId: string | number,
@@ -128,6 +127,34 @@ export async function cacheStudioBlobFromSrc(
     }
   }
   if (!blob || blob.size === 0) return false
+  return putBlobRecord(userId, kind, itemId, blob)
+}
+
+/** Fetch an upstream http(s) clip when CORS allows and mirror into IndexedDB. */
+export async function cacheStudioBlobFromHttpUrl(
+  userId: string | number,
+  kind: StudioBlobKind,
+  itemId: string,
+  url: string
+): Promise<boolean> {
+  if (!url || !/^https?:\/\//i.test(url) || typeof fetch !== 'function') return false
+  try {
+    const res = await fetch(url, { mode: 'cors' })
+    if (!res.ok) return false
+    const blob = await res.blob()
+    if (!blob.size) return false
+    return putBlobRecord(userId, kind, itemId, blob)
+  } catch {
+    return false
+  }
+}
+
+async function putBlobRecord(
+  userId: string | number,
+  kind: StudioBlobKind,
+  itemId: string,
+  blob: Blob
+): Promise<boolean> {
   try {
     const db = await openDb()
     await enforceQuota(db, String(userId), blob.size)

--- a/frontend/src/utils/studioBlobCache.tk.ts
+++ b/frontend/src/utils/studioBlobCache.tk.ts
@@ -1,0 +1,221 @@
+/**
+ * TokenKey-only: browser-local blob cache for Studio generated media.
+ *
+ * localStorage metadata (prompt, cost, model) stays small; inline data: / blob:
+ * payloads live in IndexedDB so a refresh can still show thumbnails and replay
+ * video without TokenKey hosting media (#944 pass-through). Best-effort: quota
+ * errors trim oldest entries; TTL evicts stale blobs.
+ */
+const DB_NAME = 'tk_studio_blob_v1'
+const STORE = 'blobs'
+/** Keep blobs ~7 days — enough for a work session + return visit, not a CDN. */
+const TTL_MS = 7 * 24 * 60 * 60 * 1000
+/** Per-user soft cap (decoded bytes). */
+const MAX_BYTES_PER_USER = 150 * 1024 * 1024
+
+export type StudioBlobKind = 'image' | 'video'
+
+interface BlobRecord {
+  /** `${userId}:${kind}:${itemId}` */
+  key: string
+  userId: string
+  kind: StudioBlobKind
+  itemId: string
+  mime: string
+  bytes: number
+  ts: number
+}
+
+function recordKey(userId: string | number, kind: StudioBlobKind, itemId: string): string {
+  return `${userId}:${kind}:${itemId}`
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('indexedDB_unavailable'))
+      return
+    }
+    const req = indexedDB.open(DB_NAME, 1)
+    req.onerror = () => reject(req.error ?? new Error('idb_open_failed'))
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(STORE)) {
+        const store = db.createObjectStore(STORE, { keyPath: 'key' })
+        store.createIndex('by_user', 'userId', { unique: false })
+      }
+    }
+    req.onsuccess = () => resolve(req.result)
+  })
+}
+
+function tx<T>(
+  db: IDBDatabase,
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest<T> | void
+): Promise<T | void> {
+  return new Promise((resolve, reject) => {
+    const t = db.transaction(STORE, mode)
+    const store = t.objectStore(STORE)
+    const req = fn(store)
+    t.oncomplete = () => resolve(req ? (req as IDBRequest<T>).result : undefined)
+    t.onerror = () => reject(t.error ?? new Error('idb_tx_failed'))
+  })
+}
+
+function dataUriToBlob(src: string): Blob | null {
+  const m = /^data:([\w.+-]+\/[\w.+-]+);base64,([A-Za-z0-9+/=]+)$/i.exec(src)
+  if (!m || typeof atob !== 'function') return null
+  try {
+    const binary = atob(m[2])
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+    return new Blob([bytes], { type: m[1] })
+  } catch {
+    return null
+  }
+}
+
+async function enforceQuota(db: IDBDatabase, userId: string, incomingBytes: number): Promise<void> {
+  const index = db.transaction(STORE, 'readonly').objectStore(STORE).index('by_user')
+  const rows: BlobRecord[] = await new Promise((resolve, reject) => {
+    const out: BlobRecord[] = []
+    const req = index.openCursor(IDBKeyRange.only(userId))
+    req.onerror = () => reject(req.error)
+    req.onsuccess = () => {
+      const cur = req.result
+      if (!cur) {
+        resolve(out)
+        return
+      }
+      out.push(cur.value as BlobRecord)
+      cur.continue()
+    }
+  })
+  rows.sort((a, b) => a.ts - b.ts)
+  let total = rows.reduce((s, r) => s + (r.bytes || 0), 0) + incomingBytes
+  const toDrop: string[] = []
+  for (const row of rows) {
+    if (total <= MAX_BYTES_PER_USER) break
+    toDrop.push(row.key)
+    total -= row.bytes || 0
+  }
+  if (!toDrop.length) return
+  await tx(db, 'readwrite', (store) => {
+    for (const k of toDrop) store.delete(k)
+  })
+}
+
+/**
+ * Persist media bytes from an in-tab src (data: URI or blob:). http(s) is skipped
+ * here — callers may fetch+cache separately when CORS allows.
+ */
+export async function cacheStudioBlobFromSrc(
+  userId: string | number,
+  kind: StudioBlobKind,
+  itemId: string,
+  src: string
+): Promise<boolean> {
+  if (!src || (!/^data:/i.test(src) && !src.startsWith('blob:'))) return false
+  let blob: Blob | null = null
+  if (/^data:/i.test(src)) blob = dataUriToBlob(src)
+  else if (src.startsWith('blob:') && typeof fetch === 'function') {
+    try {
+      const res = await fetch(src)
+      blob = await res.blob()
+    } catch {
+      return false
+    }
+  }
+  if (!blob || blob.size === 0) return false
+  try {
+    const db = await openDb()
+    await enforceQuota(db, String(userId), blob.size)
+    const rec: BlobRecord & { blob: Blob } = {
+      key: recordKey(userId, kind, itemId),
+      userId: String(userId),
+      kind,
+      itemId,
+      mime: blob.type || (kind === 'video' ? 'video/mp4' : 'image/png'),
+      bytes: blob.size,
+      ts: Date.now(),
+      blob,
+    }
+    await tx(db, 'readwrite', (store) => store.put(rec))
+    db.close()
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Mint a tab-local object URL for a cached blob, or '' when missing/expired. */
+export async function getStudioBlobObjectUrl(
+  userId: string | number,
+  kind: StudioBlobKind,
+  itemId: string
+): Promise<string> {
+  if (typeof URL?.createObjectURL !== 'function') return ''
+  try {
+    const db = await openDb()
+    const key = recordKey(userId, kind, itemId)
+    const row = (await tx(db, 'readonly', (store) => store.get(key))) as
+      | (BlobRecord & { blob?: Blob })
+      | undefined
+    db.close()
+    if (!row?.blob) return ''
+    if (Date.now() - row.ts > TTL_MS) {
+      void deleteStudioBlob(userId, kind, itemId)
+      return ''
+    }
+    return URL.createObjectURL(row.blob)
+  } catch {
+    return ''
+  }
+}
+
+export async function deleteStudioBlob(
+  userId: string | number,
+  kind: StudioBlobKind,
+  itemId: string
+): Promise<void> {
+  try {
+    const db = await openDb()
+    await tx(db, 'readwrite', (store) => store.delete(recordKey(userId, kind, itemId)))
+    db.close()
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Drop expired blobs for one user (call on Studio mount). */
+export async function pruneStudioBlobCache(userId: string | number): Promise<void> {
+  try {
+    const db = await openDb()
+    const uid = String(userId)
+    const index = db.transaction(STORE, 'readonly').objectStore(STORE).index('by_user')
+    const stale: string[] = await new Promise((resolve, reject) => {
+      const keys: string[] = []
+      const req = index.openCursor(IDBKeyRange.only(uid))
+      req.onerror = () => reject(req.error)
+      req.onsuccess = () => {
+        const cur = req.result
+        if (!cur) {
+          resolve(keys)
+          return
+        }
+        const row = cur.value as BlobRecord
+        if (Date.now() - row.ts > TTL_MS) keys.push(row.key)
+        cur.continue()
+      }
+    })
+    if (stale.length) {
+      await tx(db, 'readwrite', (store) => {
+        for (const k of stale) store.delete(k)
+      })
+    }
+    db.close()
+  } catch {
+    /* best-effort */
+  }
+}

--- a/frontend/src/utils/studioPlaybackStorage.tk.ts
+++ b/frontend/src/utils/studioPlaybackStorage.tk.ts
@@ -1,0 +1,63 @@
+/**
+ * TokenKey-only: classify how a generated video can be replayed / cached in-browser.
+ * Surfaces honest labels in Studio so ops/users can tell CORS-blocked upstream URLs
+ * from inline data: clips (#944 pass-through — TokenKey is not a media CDN).
+ */
+export type StudioPlaybackStorage =
+  /** data: / blob: — IndexedDB mirror possible in this browser. */
+  | 'inline-local'
+  /** http(s) and a CORS fetch succeeded — may mirror into IndexedDB. */
+  | 'upstream-cors-ok'
+  /** http(s) plays in-tab but fetch/cache blocked — refresh loses preview. */
+  | 'upstream-cors-blocked'
+  /** Stripped / expired / empty url after reload. */
+  | 'expired'
+  | 'unknown'
+
+export function classifyVideoUrlStorage(url: string): StudioPlaybackStorage {
+  if (!url) return 'expired'
+  if (/^data:video/i.test(url) || url.startsWith('blob:')) return 'inline-local'
+  if (/^https?:\/\//i.test(url)) return 'unknown' // resolved by probeUpstreamVideoCacheability
+  return 'unknown'
+}
+
+/** Best-effort CORS probe — does NOT download the whole clip (Range bytes=0-0). */
+export async function probeUpstreamVideoCacheability(
+  url: string
+): Promise<'upstream-cors-ok' | 'upstream-cors-blocked'> {
+  if (!/^https?:\/\//i.test(url)) return 'upstream-cors-blocked'
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      mode: 'cors',
+      headers: { Range: 'bytes=0-0' },
+    })
+    if (res.ok || res.status === 206) return 'upstream-cors-ok'
+    return 'upstream-cors-blocked'
+  } catch {
+    return 'upstream-cors-blocked'
+  }
+}
+
+export async function resolveVideoPlaybackStorage(url: string): Promise<StudioPlaybackStorage> {
+  const base = classifyVideoUrlStorage(url)
+  if (base === 'unknown' && /^https?:\/\//i.test(url)) {
+    return probeUpstreamVideoCacheability(url)
+  }
+  return base
+}
+
+export function studioPlaybackStorageI18nKey(storage: StudioPlaybackStorage | undefined): string {
+  switch (storage) {
+    case 'inline-local':
+      return 'studio.playback.inlineLocal'
+    case 'upstream-cors-ok':
+      return 'studio.playback.upstreamCorsOk'
+    case 'upstream-cors-blocked':
+      return 'studio.playback.upstreamCorsBlocked'
+    case 'expired':
+      return 'studio.playback.expired'
+    default:
+      return 'studio.playback.unknown'
+  }
+}

--- a/frontend/src/utils/studioUniversalKey.tk.ts
+++ b/frontend/src/utils/studioUniversalKey.tk.ts
@@ -39,23 +39,3 @@ export function priceMapFromPublicCatalog(
   }
   return map
 }
-
-/** Partial prices from the me-catalog target group only — prefer priceMapFromPublicCatalog for universal keys. */
-export function priceMapFromEntitledCatalog(
-  catalog: MePricingCatalogResponse | null,
-  entitled: ReadonlySet<string>
-): MediaPriceMap {
-  const map = new Map<string, MediaPrice>()
-  if (!catalog) return map
-  for (const m of catalog.models || []) {
-    if (!entitled.has(m.model_id)) continue
-    const perImage = m.your_price?.per_image
-    const perSecond = m.your_price?.per_second
-    if (perImage != null || perSecond != null) {
-      map.set(m.model_id, { perImage: perImage ?? undefined, perSecond: perSecond ?? undefined })
-    }
-  }
-  // Index keys may include models priced only on other groups — merge any row
-  // from the full public-facing catalog payload when present on sibling calls.
-  return map
-}

--- a/frontend/src/utils/studioUniversalKey.tk.ts
+++ b/frontend/src/utils/studioUniversalKey.tk.ts
@@ -1,0 +1,61 @@
+/**
+ * TokenKey-only: helpers for Universal (全能) API keys in the Studio.
+ *
+ * Per-request routing (video/image/chat) works on universal keys — the gap is
+ * Studio discovery: GET /v1/models skips universal resolution (metadata endpoint)
+ * and me/pricing-catalog rejects api_key_id when group_id IS NULL.
+ */
+import type { ApiKey } from '@/types'
+import type { MePricingCatalogResponse } from '@/api/me-pricing'
+import type { PublicCatalogModel } from '@/api/pricing'
+import type { MediaPrice, MediaPriceMap } from '@/constants/mediaTiers.tk'
+
+export function isUniversalKey(k: ApiKey | undefined | null): boolean {
+  if (!k) return false
+  if (k.routing_mode === 'universal') return true
+  return k.group_id == null && k.group == null
+}
+
+/** Model ids the user may reach across ALL accessible groups (pricing catalog index). */
+export function entitledModelIds(catalog: MePricingCatalogResponse | null): Set<string> {
+  const idx = catalog?.authorized_groups_by_model
+  if (!idx) return new Set()
+  return new Set(Object.keys(idx))
+}
+
+/** Official media prices for entitled models (public catalog ∩ authorized index). */
+export function priceMapFromPublicCatalog(
+  publicModels: readonly PublicCatalogModel[],
+  entitled: ReadonlySet<string>
+): MediaPriceMap {
+  const map = new Map<string, MediaPrice>()
+  for (const m of publicModels) {
+    if (!entitled.has(m.model_id)) continue
+    const perImage = m.pricing?.output_cost_per_image
+    const perSecond = m.pricing?.output_cost_per_second
+    if (perImage != null || perSecond != null) {
+      map.set(m.model_id, { perImage: perImage ?? undefined, perSecond: perSecond ?? undefined })
+    }
+  }
+  return map
+}
+
+/** Partial prices from the me-catalog target group only — prefer priceMapFromPublicCatalog for universal keys. */
+export function priceMapFromEntitledCatalog(
+  catalog: MePricingCatalogResponse | null,
+  entitled: ReadonlySet<string>
+): MediaPriceMap {
+  const map = new Map<string, MediaPrice>()
+  if (!catalog) return map
+  for (const m of catalog.models || []) {
+    if (!entitled.has(m.model_id)) continue
+    const perImage = m.your_price?.per_image
+    const perSecond = m.your_price?.per_second
+    if (perImage != null || perSecond != null) {
+      map.set(m.model_id, { perImage: perImage ?? undefined, perSecond: perSecond ?? undefined })
+    }
+  }
+  // Index keys may include models priced only on other groups — merge any row
+  // from the full public-facing catalog payload when present on sibling calls.
+  return map
+}

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -175,6 +175,10 @@
           </button>
         </div>
       </div>
+      <div v-if="library.images.value.length" class="mb-3 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100" data-testid="studio-image-save-reminder">
+        <span aria-hidden="true">⬇</span>
+        {{ t('studio.saveReminder') }}
+      </div>
       <div v-if="!library.images.value.length" class="py-16 text-center text-sm text-gray-500 dark:text-dark-400">
         {{ t('studio.image.emptyHint') }}
       </div>
@@ -504,7 +508,7 @@ async function refreshOffloadedImageUrls(): Promise<void> {
 
 onMounted(() => {
   window.addEventListener('keydown', onKeydown)
-  void refreshOffloadedImageUrls()
+  void library.hydrateFromBlobCache().then(() => refreshOffloadedImageUrls())
 })
 onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
 

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -131,6 +131,7 @@
         :key-id="selectedKeyId"
         :keys="keys"
         :rate-multiplier="1"
+        :any-key-serves-video="anyKeyServesVideo"
         @spent="refreshBalance"
       />
       <BakeOff
@@ -161,13 +162,20 @@ import BakeOff from '@/views/user/studio/BakeOff.vue'
 import { keysAPI } from '@/api/keys'
 import { gatewayListModels, resolveGatewayBaseUrl } from '@/api/playground'
 import { getMePricingCatalog } from '@/api/me-pricing'
+import { getPublicPricing } from '@/api/pricing'
 import { formatUsd } from '@/utils/mediaCostEstimate.tk'
+import {
+  entitledModelIds,
+  isUniversalKey,
+  priceMapFromPublicCatalog,
+} from '@/utils/studioUniversalKey.tk'
 import {
   groupServes,
   pickModalityKey,
   type ModalityKeyOption,
   type PickerModality,
   type MediaPrice,
+  type MediaPriceMap,
 } from '@/constants/mediaTiers.tk'
 import { useAppStore } from '@/stores/app'
 import { useAuthStore } from '@/stores/auth'
@@ -197,6 +205,9 @@ const gatewayBase = ref('')
 // group up front so the picker (and the dropdown annotations) can reason about
 // EVERY key's modality, not just the one currently selected.
 const groupModelSets = ref<Map<string, Set<string>>>(new Map())
+/** Cross-group entitlement index (me/pricing-catalog authorized_groups_by_model). */
+const userEntitledIds = ref<Set<string>>(new Set())
+const universalPriceMap = ref<MediaPriceMap>(new Map())
 // Live per-model price for the SELECTED key's group (getMePricingCatalog) — the
 // single source of media prices (no hardcoding, so prices can't drift).
 const priceMap = ref<Map<string, MediaPrice>>(new Map())
@@ -219,7 +230,12 @@ function groupKeyOf(k: ApiKey): string {
   return k.group?.id != null ? `g${k.group.id}` : `k${k.id}`
 }
 function availableIdsOf(k: ApiKey): Set<string> {
+  if (isUniversalKey(k)) return userEntitledIds.value
   return groupModelSets.value.get(groupKeyOf(k)) ?? new Set<string>()
+}
+
+function keyServesModality(k: ApiKey, modality: PickerModality): boolean {
+  return groupServes(modality, availableIdsOf(k))
 }
 
 // Model pool of the currently selected key — what the child studios resolve
@@ -227,6 +243,8 @@ function availableIdsOf(k: ApiKey): Set<string> {
 const availableIds = computed<Set<string>>(() =>
   selectedKey.value ? availableIdsOf(selectedKey.value) : new Set<string>()
 )
+
+const anyKeyServesVideo = computed(() => keys.value.some((k) => keyServesModality(k, 'video')))
 
 // The single modality the picker can optimize a key for. Bake-off has its OWN
 // internal image/video toggle, so no single key serves both of its sub-modes —
@@ -245,15 +263,25 @@ function modalityOptions(): ModalityKeyOption[] {
 }
 
 function keyLabel(k: ApiKey): string {
-  const group = k.group?.name || t('studio.defaultGroup')
+  const group = isUniversalKey(k) ? t('studio.universalKeyBadge') : k.group?.name || t('studio.defaultGroup')
   const base = `${k.name || k.id} · ${group}`
-  // Once probed, flag keys whose group can't serve the active modality so the
-  // user isn't left guessing which key to pick. Skipped on bake-off (dual modality).
   const m = pickerModality.value
-  if (probed.value && m && !groupServes(m, availableIdsOf(k))) {
+  if (probed.value && m && !keyServesModality(k, m)) {
     return `${base} · ${t('studio.keyNoModality')}`
   }
   return base
+}
+
+async function loadUserEntitlement(): Promise<void> {
+  try {
+    const [meCatalog, publicCatalog] = await Promise.all([getMePricingCatalog(), getPublicPricing()])
+    const entitled = entitledModelIds(meCatalog)
+    userEntitledIds.value = entitled
+    universalPriceMap.value = priceMapFromPublicCatalog(publicCatalog.data || [], entitled)
+  } catch {
+    userEntitledIds.value = new Set()
+    universalPriceMap.value = new Map()
+  }
 }
 
 async function refreshBalance(): Promise<void> {
@@ -304,6 +332,11 @@ async function probeAllGroups(): Promise<void> {
 // rateMultiplier=1. A model with no per_image/per_second price is simply omitted
 // (priced ∩ servable). Failure → empty map (models hide) rather than stale prices.
 async function loadPriceMap(keyId: number): Promise<void> {
+  const k = keys.value.find((x) => x.id === keyId)
+  if (k && isUniversalKey(k)) {
+    priceMap.value = new Map(universalPriceMap.value)
+    return
+  }
   try {
     const catalog = await getMePricingCatalog({ apiKeyId: keyId })
     const next = new Map<string, MediaPrice>()
@@ -349,7 +382,7 @@ async function bootstrap(): Promise<void> {
       loadError.value = t('studio.noApiKey')
       return
     }
-    await probeAllGroups()
+    await Promise.all([probeAllGroups(), loadUserEntitlement()])
     if (loadError.value) return
     // Seed with the historical default, then let the picker move to a key whose
     // group actually serves the landing modality (defaults to chat at mount).

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -2,9 +2,11 @@
   <div class="grid grid-cols-1 gap-5 lg:grid-cols-[360px_1fr]">
     <!-- LEFT: orchestration -->
     <div class="space-y-4">
-      <div v-if="models.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400">
-        {{ t('studio.video.modelEmpty') }}
-        <router-link class="mt-1 block font-medium text-primary-600 underline dark:text-primary-400" to="/pricing">
+      <div v-if="models.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400" data-testid="studio-video-model-empty">
+        <p>{{ t('studio.video.modelEmpty') }}</p>
+        <p v-if="anyKeyServesVideo" class="mt-2 font-medium text-amber-800 dark:text-amber-200">{{ t('studio.video.modelEmptySwitchKey') }}</p>
+        <p v-else class="mt-2 text-xs text-gray-400 dark:text-dark-500">{{ t('studio.video.modelEmptyAllKeys') }}</p>
+        <router-link class="mt-2 block font-medium text-primary-600 underline dark:text-primary-400" to="/pricing">
           {{ t('studio.viewPricing') }}
         </router-link>
       </div>
@@ -169,6 +171,10 @@
       <!-- Results header + bulk clear (matches the image surface). Shown only when
            there is history; the per-card status badge is the source of truth for
            each task's state — there is no global completion banner to go stale. -->
+      <div v-if="library.videoTasks.value.length" class="mb-2 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100" data-testid="studio-video-save-reminder">
+        <span aria-hidden="true">⬇</span>
+        {{ t('studio.saveReminder') }}
+      </div>
       <div v-if="library.videoTasks.value.length" class="flex items-center justify-between px-1">
         <span class="text-sm font-semibold text-gray-700 dark:text-dark-200">{{ t('studio.video.resultsTitle') }}</span>
         <button type="button" class="text-xs text-gray-400 hover:text-gray-700 dark:hover:text-dark-200" data-testid="studio-video-clear-all" @click="clearAll">{{ t('studio.clear') }}</button>
@@ -244,7 +250,17 @@
               </span>
               <span class="pointer-events-none absolute bottom-2 left-2 rounded bg-black/55 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-white/90">{{ task.seconds }}s{{ task.aspectRatio ? ' · ' + task.aspectRatio : '' }}</span>
             </button>
-            <p class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.video.retentionHint') }}</p>
+            <p
+              v-if="playbackStorageKind(task) !== 'unknown'"
+              class="inline-flex max-w-full items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium leading-snug"
+              :class="playbackBadgeClass(task)"
+              data-testid="studio-video-playback-badge"
+              :data-playback-storage="playbackStorageKind(task)"
+            >
+              <span class="shrink-0 opacity-80">{{ t('studio.playback.label') }}:</span>
+              <span>{{ playbackHint(task) }}</span>
+            </p>
+            <p v-else class="text-[10px] text-gray-400 dark:text-dark-500">{{ playbackHint(task) }}</p>
           </template>
           <div
             v-else
@@ -252,8 +268,18 @@
             data-testid="studio-video-expired"
           >
             <p class="whitespace-pre-wrap break-words text-sm text-gray-800 dark:text-dark-100">{{ task.prompt }}</p>
-            <p class="mt-2 text-[11px] text-gray-400 dark:text-dark-500">
-              {{ task.urlExpired || !task.url ? t('studio.video.expiredReload') : t('studio.video.noUrlHint') }}
+            <p
+              v-if="playbackStorageKind(task) !== 'unknown'"
+              class="mt-2 inline-flex max-w-full items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium leading-snug"
+              :class="playbackBadgeClass(task)"
+              data-testid="studio-video-playback-badge"
+              :data-playback-storage="playbackStorageKind(task)"
+            >
+              <span class="shrink-0 opacity-80">{{ t('studio.playback.label') }}:</span>
+              <span>{{ playbackHint(task) }}</span>
+            </p>
+            <p v-else class="mt-2 text-[11px] text-gray-400 dark:text-dark-500">
+              {{ playbackHint(task) }}
             </p>
           </div>
           <div class="flex items-center justify-between text-[11px] text-gray-500 dark:text-dark-400">
@@ -295,16 +321,19 @@
             {{ t('studio.video.close') }} ✕
           </button>
         </div>
-        <div class="flex min-h-0 flex-1 items-center justify-center px-4" @click.self="closePreview">
+        <div class="relative flex min-h-0 flex-1 items-center justify-center px-4" @click.self="closePreview">
           <video
             v-if="previewState === 'ready' && previewUrl"
             :src="previewUrl"
             controls
             autoplay
             playsinline
+            preload="auto"
             class="max-h-full max-w-full rounded-lg bg-black shadow-2xl"
+            @loadeddata="previewMediaReady = true"
             @error="onPreviewError"
           ></video>
+          <div v-if="previewState === 'ready' && previewUrl && !previewMediaReady" class="absolute text-sm text-white/80">{{ t('studio.video.previewBuffering') }}</div>
           <div v-else-if="previewState === 'loading'" class="text-sm text-white/80">{{ t('studio.video.loadingPreview') }}</div>
           <div v-else class="max-w-sm rounded-xl bg-white/10 p-6 text-center">
             <p class="text-sm font-semibold text-white">{{ t('studio.video.expiredTitle') }}</p>
@@ -350,9 +379,15 @@ import {
 import { estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
 import { downloadMedia } from '@/utils/studioDownload.tk'
 import { videoPlaybackUrl, videoTaskPlaybackAvailable } from '@/utils/studioMedia.tk'
+import {
+  resolveVideoPlaybackStorage,
+  studioPlaybackStorageI18nKey,
+  type StudioPlaybackStorage,
+} from '@/utils/studioPlaybackStorage.tk'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { useMediaLibrary, type VideoTaskItem } from '@/composables/useMediaLibrary'
 import { useVideoTaskPoll, requestVideoNotifyPermission, maybeNotify } from '@/composables/useVideoTaskPoll'
+import { useAppStore } from '@/stores/app'
 import type { ApiKey } from '@/types'
 
 const props = defineProps<{
@@ -365,10 +400,13 @@ const props = defineProps<{
   keyId: number | null
   keys: ApiKey[]
   rateMultiplier: number
+  /** True when another key in the dropdown serves video (empty-state hint). */
+  anyKeyServesVideo?: boolean
 }>()
 const emit = defineEmits<{ (e: 'spent'): void }>()
 
 const { t } = useI18n()
+const appStore = useAppStore()
 const library = useMediaLibrary(props.userId)
 
 const models = computed(() => resolveAvailableModels('video', props.availableIds, props.priceMap))
@@ -414,10 +452,51 @@ const formula = computed(() => {
   return t('studio.video.formula', { rate: formatUsd(selected.value.perSecond || 0), seconds: duration.value })
 })
 
+function playbackStorageKind(task: VideoTaskItem): StudioPlaybackStorage {
+  return task.playbackStorage ?? (task.urlExpired || !task.url ? 'expired' : 'unknown')
+}
+
+function playbackBadgeClass(task: VideoTaskItem): string {
+  switch (playbackStorageKind(task)) {
+    case 'inline-local':
+      return 'bg-green-50 text-green-800 dark:bg-green-950/40 dark:text-green-200'
+    case 'upstream-cors-ok':
+      return 'bg-blue-50 text-blue-800 dark:bg-blue-950/40 dark:text-blue-200'
+    case 'upstream-cors-blocked':
+      return 'bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-100'
+    case 'expired':
+      return 'bg-gray-100 text-gray-600 dark:bg-dark-800 dark:text-dark-300'
+    default:
+      return 'bg-gray-50 text-gray-500 dark:bg-dark-800 dark:text-dark-400'
+  }
+}
+
+function playbackHint(task: VideoTaskItem): string {
+  return t(studioPlaybackStorageI18nKey(playbackStorageKind(task)))
+}
+
+async function tagVideoPlayback(taskId: string, url: string): Promise<void> {
+  if (!url) {
+    library.patchVideoTask(taskId, { playbackStorage: 'expired' })
+    return
+  }
+  const storage = await resolveVideoPlaybackStorage(url)
+  library.patchVideoTask(taskId, { playbackStorage: storage })
+  if (storage === 'upstream-cors-blocked') {
+    appStore.showWarning(t('studio.playback.upstreamCorsBlocked'), 8000)
+  }
+  if (storage === 'inline-local' || storage === 'upstream-cors-ok') {
+    void library.cacheInlineMedia('video', taskId, url)
+  }
+}
+
 const poll = useVideoTaskPoll({
   gatewayBase: () => props.gatewayBase,
   resolveKey: (keyId) => props.keys.find((k) => k.id === keyId)?.key,
-  patch: library.patchVideoTask,
+  patch: (id, patch) => {
+    library.patchVideoTask(id, patch)
+    if (patch.url) void tagVideoPlayback(id, patch.url)
+  },
   onTerminal: (task, state) => {
     emit('spent')
     // The per-card status badge IS the in-page completion signal (no banner to go
@@ -495,6 +574,7 @@ async function enableNotify(): Promise<void> {
 
 // ---- In-page video lightbox ---------------------------------------------------
 const preview = ref<VideoTaskItem | null>(null)
+const previewMediaReady = ref(false)
 const previewUrl = ref('')
 const previewState = ref<'loading' | 'ready' | 'expired'>('loading')
 // Transient "copied" confirmation for the copy-link button (no toast/banner).
@@ -508,6 +588,7 @@ async function openPreview(task: VideoTaskItem): Promise<void> {
   preview.value = task
   previewUrl.value = ''
   previewState.value = 'loading'
+  previewMediaReady.value = false
   // Playback must not turn TokenKey into a media server: http(s) upstream URLs go
   // straight to the browser; an inline data:video result becomes a tab-local Blob
   // URL we revoke on close. Shared with Bake-Off via videoPlaybackUrl.
@@ -555,6 +636,7 @@ function closePreview(): void {
   previewRevoke = () => {}
   preview.value = null
   previewUrl.value = ''
+  previewMediaReady.value = false
   copied.value = false
 }
 
@@ -606,6 +688,7 @@ async function generate(): Promise<void> {
       elapsedS: 0,
     }
     library.upsertVideoTask(task)
+    if (task.url) void tagVideoPlayback(task.id, task.url)
     emit('spent') // balance reserved by the pre-flight hold
     if (state === 'processing') poll.resume(task)
   } catch (e) {
@@ -630,6 +713,7 @@ onMounted(() => {
   for (const task of library.videoTasks.value) {
     if (task.state === 'processing') poll.resume(task)
   }
+  void library.hydrateFromBlobCache()
 })
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeydown)

--- a/frontend/src/views/user/studio/__tests__/MediaStudioView.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/MediaStudioView.spec.ts
@@ -5,10 +5,11 @@ import { ref } from 'vue'
 import en from '@/i18n/locales/en'
 import MediaStudioView from '../MediaStudioView.vue'
 
-const { listKeys, gatewayListModels, getMePricingCatalog } = vi.hoisted(() => ({
+const { listKeys, gatewayListModels, getMePricingCatalog, getPublicPricing } = vi.hoisted(() => ({
   listKeys: vi.fn(),
   gatewayListModels: vi.fn(),
   getMePricingCatalog: vi.fn(),
+  getPublicPricing: vi.fn(),
 }))
 
 vi.mock('@/api/keys', () => ({
@@ -22,6 +23,10 @@ vi.mock('@/api/playground', () => ({
 
 vi.mock('@/api/me-pricing', () => ({
   getMePricingCatalog,
+}))
+
+vi.mock('@/api/pricing', () => ({
+  getPublicPricing,
 }))
 
 const fetchPublicSettings = vi.fn(async () => undefined)
@@ -73,21 +78,26 @@ describe('MediaStudioView bootstrap', () => {
     listKeys.mockReset()
     gatewayListModels.mockReset()
     getMePricingCatalog.mockReset()
+    getPublicPricing.mockReset()
     fetchPublicSettings.mockClear()
 
     listKeys.mockResolvedValue({
       items: [{ id: 1, name: 'trial', key: 'sk-test', group: { id: 10, name: 'default' } }],
     })
     gatewayListModels.mockResolvedValue({ data: [{ id: 'gpt-4o' }] })
+    getPublicPricing.mockResolvedValue({ data: [] })
   })
 
-  it('mounts ChatStudio after model probe without waiting for the price catalog', async () => {
+  it('mounts ChatStudio after model probe without waiting for the per-key price catalog', async () => {
     let resolveCatalog!: (value: { models: [] }) => void
-    getMePricingCatalog.mockReturnValue(
-      new Promise<{ models: [] }>((resolve) => {
-        resolveCatalog = resolve
-      })
-    )
+    getMePricingCatalog.mockImplementation((opts?: { apiKeyId?: number }) => {
+      if (opts?.apiKeyId != null) {
+        return new Promise<{ models: [] }>((resolve) => {
+          resolveCatalog = resolve
+        })
+      }
+      return Promise.resolve({ authorized_groups_by_model: {}, models: [] })
+    })
 
     const wrapper = mount(MediaStudioView, {
       global: {
@@ -102,5 +112,32 @@ describe('MediaStudioView bootstrap', () => {
 
     resolveCatalog({ models: [] })
     await flushPromises()
+  })
+
+  it('loads entitlement index for universal keys without per-key pricing catalog', async () => {
+    listKeys.mockResolvedValue({
+      items: [{ id: 9, name: 'universal', key: 'sk-uni', routing_mode: 'universal', group_id: null }],
+    })
+    getMePricingCatalog.mockResolvedValue({
+      authorized_groups_by_model: {
+        'veo-3.1-generate-001': [{ group_id: 3, group_name: 'vertex' }],
+      },
+      models: [],
+    })
+    getPublicPricing.mockResolvedValue({
+      data: [{ model_id: 'veo-3.1-generate-001', pricing: { output_cost_per_second: 0.5 } }],
+    })
+    gatewayListModels.mockResolvedValue({ data: [] })
+
+    const wrapper = mount(MediaStudioView, {
+      global: { plugins: [i18n], stubs: { 'router-link': true } },
+    })
+    await flushPromises()
+    await flushPromises()
+
+    expect(getMePricingCatalog).toHaveBeenCalled()
+    expect(getPublicPricing).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('studio.universalKeyBadge')
+    expect(getMePricingCatalog).not.toHaveBeenCalledWith(expect.objectContaining({ apiKeyId: 9 }))
   })
 })

--- a/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
@@ -29,6 +29,8 @@ vi.mock('@/composables/useMediaLibrary', async (importOriginal) => {
         patchVideoTask: libraryMock.patchVideoTaskSpy,
         removeVideoTask: vi.fn(),
         clearVideoTasks: vi.fn(),
+        hydrateFromBlobCache: vi.fn(async () => undefined),
+        cacheInlineMedia: vi.fn(async () => undefined),
       }
     },
   }
@@ -37,6 +39,15 @@ vi.mock('@/composables/useMediaLibrary', async (importOriginal) => {
 vi.mock('@/api/playground', () => ({
   gatewayVideoSubmit: vi.fn(),
   gatewayVideoFetch: vi.fn(async () => ({ done: true, video_url: 'https://s3.example/fresh.mp4' })),
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showWarning: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    showInfo: vi.fn(),
+  }),
 }))
 
 const i18n = createI18n({ legacy: false, locale: 'en', fallbackWarn: false, missingWarn: false, messages: { en } })
@@ -119,7 +130,7 @@ describe('VideoStudio succeeded-task presentation', () => {
     expect(w.text()).toContain('statusSucceeded')
   })
 
-  it('does not resurrect a persisted inline data: clip after reload', () => {
+  it('does not resurrect a persisted inline data: clip after reload when blob cache is empty', () => {
     seedPersisted([baseTask({ url: 'data:video/mp4;base64,AAAA' })])
     const w = mountStudio()
     expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(false)
@@ -139,7 +150,7 @@ describe('VideoStudio succeeded-task presentation', () => {
     expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(false)
     expect(w.find('[data-testid="studio-video-expired"]').exists()).toBe(true)
     expect(w.text()).toContain('neon Tokyo alley in rain')
-    expect(w.text()).toContain('expiredReload')
+    expect(w.text()).toContain('studio.playback.expired')
   })
 
   it('closes the lightbox and marks the card expired when preview media fails', async () => {


### PR DESCRIPTION
## 摘要

- **全能 Key 模型列表**：Studio 改用 `authorized_groups_by_model` + 公开定价并集，修复「能出 Gemini 图却显示无视频模型」的发现层缺口（生成 API 路由本身无差别）。
- **播放来源标注**：视频结果卡片显示彩色 badge（`data-playback-storage`），区分本机缓存 / 上游可缓存 / **CORS 不可缓存** / 已失效；琥珀色场景额外弹出 **warning toast**（8s）。
- **浏览器短时缓存**：`data:`/`blob:` 及 CORS 可 fetch 的上游链写入 IndexedDB（约 7 天），刷新后可恢复预览；琥珀色 saveReminder 条提醒立即下载。
- **Rebase**：已 rebase 到最新 `main`（含 #1063 fingerprint pins），解决 `frontend-source.json` 冲突并刷新 embedded dist hash。

sentinel-registry-reviewed
upstream-touch-trivial

## 风险

- 常规风险，仅前端 Studio；无后端/API 契约变更。
- CORS 探测为 best-effort（Range `bytes=0-0`）；`upstream-cors-ok` 会整段 fetch 入 IDB，大体积 clip 可能占满 150MB 软上限。
- IndexedDB 为单浏览器、非跨设备；清站点数据仍会丢失。

## 验证

```bash
cd frontend
pnpm exec vitest run \
  src/composables/__tests__/useMediaLibrary.spec.ts \
  src/views/user/studio/__tests__/VideoStudio.spec.ts \
  src/views/user/studio/__tests__/MediaStudioView.spec.ts \
  src/utils/__tests__/studioPlaybackStorage.tk.spec.ts \
  src/utils/__tests__/studioUniversalKey.tk.spec.ts
pnpm typecheck
./scripts/preflight.sh
```

- 20 项相关单测通过；rebase 后本地 preflight 全绿。

## 提交

- b1404a74e chore(studio): refresh embedded dist hash after rebase onto main
- 80f0068ea chore(studio): drop unused universal key price helper
- 47404cca3 fix(studio): mirror CORS-ok upstream video, add universal key tests
- c2f789bec fix(studio): universal key models, playback labels, blob cache

最新提交：b1404a74e
