### PR TITLE
fix(ci): client-release-watch sig label 超长导致 issue 创建失败

### DIFF
--- a/.github/workflows/client-release-watch.yml
+++ b/.github/workflows/client-release-watch.yml
@@ -134,9 +134,10 @@ jobs:
               ensure_label(platform_label, 'BFD4F2', f'Client release watch platform {platform_id}')
 
               upstream = item.get('upstream_latest') or 'unknown'
-              sig = f"client-release-{platform_id}-{upstream}"
-              sig_label = f"client-release-sig:{label_safe(sig)}"
-              ensure_label(sig_label, 'BFD4F2', 'Client release watch signature')
+              issue_signature = f"client-release-{platform_id}-{upstream}"
+              sig = f"{platform_id}-{upstream}"
+              sig_label = label_safe(f"cr-sig:{sig}")
+              ensure_label(sig_label, 'BFD4F2', f'Client release watch signature {sig}')
 
               title = f"[client-release] {item.get('name')} upstream {upstream} > pin {item.get('pinned') or 'n/a'}"[:250]
               body_lines = [
@@ -149,7 +150,7 @@ jobs:
                   f"- Pin path: `{item.get('pin_path')}`",
                   f"- Alignment skill: `{item.get('skill')}`",
                   f"- Watchdog run: {report.get('run_url') or 'n/a'}",
-                  f"- Signature: `{sig}`",
+                  f"- Signature: `{issue_signature}`",
                   '',
                   '## Upstream sources',
                   '',


### PR DESCRIPTION
## 摘要

- 修复 `Client Release Watch` workflow 在 **Open or update drift tracking issues** 步骤失败的问题。
- 根因：signature label `client-release-sig:client-release-…` 超过 GitHub label 名称 **50 字符**上限，`ensure_label` 静默失败导致 `gh issue create` 报 label not found。
- 改为 `cr-sig:{platform}-{version}` 并经 `label_safe()` 截断；issue body 仍保留可读 `client-release-{platform}-{version}` 签名。

## 风险

- 低风险：仅 workflow 内 inline Python 的 label 命名变更，不影响 scan 引擎与 pin 逻辑。
- merge 后首次全量 run 会创建约 6 个 drift tracking issue（此前验证 run 28353101308 在 cc-stainless 首条即失败）。

## 验证

- [x] `./scripts/preflight.sh` PASS
- [x] 本地复现：`gh issue create … --label client-release-sig:…` → HTTP 422 name too long
- [x] 修复后：`gh label create cr-sig:cc-stainless-0.106.0` 成功（27 字符）
- [ ] merge 后待跑：`gh workflow run "Client Release Watch" -f dry_run=false` 确认 issue + cache PR

## 提交

- `9da0297db` fix(ci): shorten client-release-watch sig labels to GitHub 50-char limit

最新提交：9da0297db
