### PR TITLE
fix(oauth): guard-drift apply 账号匹配与 sync-runtime TLS 缓存失效

### DIFF
--- a/ops/anthropic/manage-anthropic-config.py
+++ b/ops/anthropic/manage-anthropic-config.py
@@ -590,6 +590,10 @@ def render_runtime_sync_shell(ua_version: str, mimicry_manifest_json: str | None
         "  for id in $ids; do fk=\"fingerprint:${id}\"; out=\"$($RC DEL \"$fk\" 2>&1 || true)\"; "
         "echo \"DEL ${fk} => ${out}\"; done\n"
         "fi\n"
+        "echo '=== redis_tls_fingerprint_profiles_invalidate ==='\n"
+        "out=\"$($RC DEL tls_fingerprint_profiles 2>&1 || true)\"; echo \"DEL tls_fingerprint_profiles => ${out}\"\n"
+        "out=\"$($RC PUBLISH tls_fingerprint_profiles_updated sync-runtime 2>&1 || true)\"; "
+        "echo \"PUBLISH tls_fingerprint_profiles_updated => ${out}\"\n"
         "echo '=== settings_after ==='\n"
         f"$PSQL -c \"SELECT row_to_json(t) FROM (SELECT key, value FROM settings "
         f"WHERE key IN ('{ua_key}', '{mimicry_key}')) t;\"\n"
@@ -2066,9 +2070,10 @@ def cmd_plan_guard_drift_fix(args: argparse.Namespace) -> int:
             fail(f"guard drift account {account_name!r} on {edge_id} has unknown tier {tier_key!r}")
         edge = _find_edge(snap, edge_id)
         account = _find_edge_account(edge, account_name)
+        actual_name = str(account.get("name") or account_name)
         baseline = tiers[tier_key]
         step = len(actions) + 1
-        actions.append(_build_tier_action(edge_id, account_name, baseline, tier_key, step))
+        actions.append(_build_tier_action(edge_id, actual_name, baseline, tier_key, step))
         befores.append({"edge_id": edge_id, "drift": drift, **_account_before(account)})
 
     plan = {
@@ -2329,8 +2334,10 @@ def _find_edge(snap: dict, edge_id: str) -> dict:
 
 
 def _find_edge_account(edge: dict, account_name: str) -> dict:
+    want = account_name.strip()
     for a in edge.get("oauth_accounts", []):
-        if a.get("name") == account_name:
+        live = str(a.get("name") or "").strip()
+        if live == want or a.get("name") == account_name:
             return a
     fail(f"account {account_name!r} not found in edge oauth_accounts")
     return {}  # unreachable

--- a/ops/anthropic/test_manage_anthropic_config_runtime_sync.py
+++ b/ops/anthropic/test_manage_anthropic_config_runtime_sync.py
@@ -22,6 +22,8 @@ class RuntimeSyncShellTest(unittest.TestCase):
         self.assertIn("claude_code_user_agent_version", shell)
         self.assertIn("claude_code_http_mimicry_manifest", shell)
         self.assertIn("fingerprint:${id}", shell)
+        self.assertIn("DEL tls_fingerprint_profiles", shell)
+        self.assertIn("PUBLISH tls_fingerprint_profiles_updated", shell)
 
     def test_render_runtime_sync_shell_persists_valid_json_manifest(self) -> None:
         # Regression: the manifest UPSERT must be delivered as base64 SQL piped to
@@ -161,6 +163,54 @@ class GuardDriftPlanTest(unittest.TestCase):
             self.assertFalse(plan["noop"])
             self.assertEqual(len(plan["actions"]), 1)
             self.assertTrue(plan["intent"]["force_template_rewrite"])
+
+    def test_plan_guard_drift_fix_matches_account_name_with_leading_space(self) -> None:
+        baseline = mgr._load_tier_baselines()["l3"]
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            snap = {
+                "version": mgr.SNAPSHOT_VERSION,
+                "captured_at": "2026-05-27T00:00:00Z",
+                "edges": {
+                    "us4": {
+                        "deployable": True,
+                        "oauth_accounts": [{
+                            "id": 9,
+                            "name": " or-1-f",
+                            "stability_tier": "l3",
+                            **{k: baseline[k] for k in mgr._TIER_BASELINE_FIELDS},
+                        }],
+                    },
+                },
+            }
+            snap_path = tmp_path / "snap.json"
+            snap_path.write_text(json.dumps(snap))
+            check_path = tmp_path / "check.json"
+            check_path.write_text(json.dumps({
+                "guards": [{
+                    "report": {
+                        "selector": {"edge_id": "us4"},
+                        "items": [{
+                            "status": "drift",
+                            "account_name": "or-1-f",
+                            "baseline_tier": "l3",
+                            "diffs": [{"path": "/tls_profile/description"}],
+                        }],
+                    },
+                }],
+            }))
+            plan_path = tmp_path / "plan.json"
+            rc = mgr.cmd_plan_guard_drift_fix(
+                __import__("argparse").Namespace(
+                    snapshot=str(snap_path),
+                    check_report=str(check_path),
+                    allow_planned=False,
+                    out=str(plan_path),
+                )
+            )
+            self.assertEqual(rc, 0)
+            plan = json.loads(plan_path.read_text())
+            self.assertEqual(" or-1-f", plan["actions"][0]["variables"]["account_name"])
 
 
 class HttpUaDriftTest(unittest.TestCase):


### PR DESCRIPTION
## 摘要

v1.8.55 发版后 `remediate-guard-drift` 在 prod/Edge 上 apply 时暴露两个 orchestrator 缺口：

1. **guard plan 账号匹配**：us4 live 账号名带前导空格（`' or-1-f'`），guard 报告为 `or-1-f`，`plan-guard-drift-fix` 直接 fail。
2. **sync-runtime Redis 缓存**：TLS template force-rewrite 后 DB 已更新，但 `sync-runtime` 只 `DEL fingerprint:{id}`，未失效 `tls_fingerprint_profiles` blob，导致 `check` 持续报 `redis_cache_drift` STALE。

本 PR 修复 `_find_edge_account` strip 匹配 + plan 使用 DB 真实名；`sync-runtime` 增加 `DEL tls_fingerprint_profiles` + `PUBLISH tls_fingerprint_profiles_updated`。

## 风险

- **低**：仅 `ops/anthropic/manage-anthropic-config.py` orchestrator 行为；无 gateway/API/Web 契约变更。
- sync-runtime 多删一个 Redis key，与 backend `tls_fingerprint_profile_cache.go` 约定一致，属于 check 已推荐的修复路径。

## 验证

```bash
python3 -m unittest ops/anthropic/test_manage_anthropic_config_runtime_sync.py -v
bash scripts/preflight.sh
```

- 单元测试 31/31 通过（含 leading-space 账号 plan + TLS cache invalidation shell 断言）
- preflight PASS
- 发版现场已手工验证：`remediate-guard-drift` + `sync-runtime` 后 fleet `check` → `any_violation=False`（us3–us6）

## 提交

- 12b759cd4 fix(oauth): unblock guard-drift apply after v26.3.0 TLS bump

最新提交：12b759cd4
