### PR TITLE
chore: refresh claude-code issue cache

### DIFF
--- a/.cache/anthropic/cc-triage.json
+++ b/.cache/anthropic/cc-triage.json
@@ -4,23 +4,23 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded; gateway-relevance filtered",
   "rationale": "TokenKey-local triage cache for anthropics/claude-code issues, filtered for gateway/relay relevance. Most claude-code issues are client-side (IDE/terminal/MCP) and are marked not_applicable. Only human-pinned MANUAL_TRIAGE high/critical entries become fix candidates.",
   "counts": {
-    "needs_review": 372,
-    "medium": 8,
-    "not_applicable": 771,
-    "unknown_low_signal": 307
+    "needs_review": 355,
+    "medium": 13,
+    "not_applicable": 831,
+    "unknown_low_signal": 304
   },
   "issues": [
     {
-      "upstream": "anthropics/claude-code#10199",
-      "url": "https://github.com/anthropics/claude-code/issues/10199",
-      "title": "[BUG] API Error 400 - Thinking Block Modification Error",
+      "upstream": "anthropics/claude-code#16294",
+      "url": "https://github.com/anthropics/claude-code/issues/16294",
+      "title": "[BUG] API Error 400 \"no low surrogate in string\" when Bash output contains invalid Unicode",
       "impact": "needs_review",
       "categories": [
         "request_shape_400"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T18:01:18Z"
+      "updated_at": "2026-06-29T08:18:11Z"
     },
     {
       "upstream": "anthropics/claude-code#18028",
@@ -33,6 +33,31 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-27T22:25:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#20131",
+      "url": "https://github.com/anthropics/claude-code/issues/20131",
+      "title": "Feature Request: Multi-Account Profile Support",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T17:46:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#23030",
+      "url": "https://github.com/anthropics/claude-code/issues/23030",
+      "title": "[Bug] Rate limit triggered before reaching session usage limit (71%)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-30T00:13:42Z"
     },
     {
       "upstream": "anthropics/claude-code#26166",
@@ -144,6 +169,18 @@
       "updated_at": "2026-06-27T21:18:52Z"
     },
     {
+      "upstream": "anthropics/claude-code#3433",
+      "url": "https://github.com/anthropics/claude-code/issues/3433",
+      "title": "Claude Code cannot connect to GitHub's remote MCP server using OAuth authentication",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T22:40:08Z"
+    },
+    {
       "upstream": "anthropics/claude-code#35744",
       "url": "https://github.com/anthropics/claude-code/issues/35744",
       "title": "[FEATURE] Auto-continue after subscription rate limit resets",
@@ -190,18 +227,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-27T21:17:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#40175",
-      "url": "https://github.com/anthropics/claude-code/issues/40175",
-      "title": "[BUG] Cowork: Global instructions silently revert to older version after saving",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T19:43:15Z"
     },
     {
       "upstream": "anthropics/claude-code#40495",
@@ -314,19 +339,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T05:11:14Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#47930",
-      "url": "https://github.com/anthropics/claude-code/issues/47930",
-      "title": "[BUG] Agent Teams: lead session loops on idle notifications and duplicate task_assignment echoes, burns ~13–22% of input tokens on no-op acks",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:29:13Z"
+      "updated_at": "2026-06-29T13:35:51Z"
     },
     {
       "upstream": "anthropics/claude-code#48164",
@@ -583,18 +596,6 @@
       "updated_at": "2026-06-27T10:41:55Z"
     },
     {
-      "upstream": "anthropics/claude-code#53442",
-      "url": "https://github.com/anthropics/claude-code/issues/53442",
-      "title": "[BUG] Cowork Google Drive MCP cannot see content in any Workspace Shared Drive",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T14:57:58Z"
-    },
-    {
       "upstream": "anthropics/claude-code#54171",
       "url": "https://github.com/anthropics/claude-code/issues/54171",
       "title": "[DOCS] Agent SDK MCP docs omit `mcp_authenticate` `redirectUri` usage for custom schemes and Claude.ai connectors",
@@ -669,6 +670,30 @@
       "updated_at": "2026-06-27T20:57:26Z"
     },
     {
+      "upstream": "anthropics/claude-code#55788",
+      "url": "https://github.com/anthropics/claude-code/issues/55788",
+      "title": "[BUG] Live Artifacts (CoworkArtifacts.callMcpTool) reject local stdio MCP servers on cold start — claude.ai relay rejects server name as non-UUID",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:52:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56978",
+      "url": "https://github.com/anthropics/claude-code/issues/56978",
+      "title": "Graceful handling when hitting usage limits mid-session",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T13:14:57Z"
+    },
+    {
       "upstream": "anthropics/claude-code#57200",
       "url": "https://github.com/anthropics/claude-code/issues/57200",
       "title": "[BUG] Claude ignores instructions and violates rules consistently",
@@ -681,19 +706,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-27T22:38:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#57660",
-      "url": "https://github.com/anthropics/claude-code/issues/57660",
-      "title": "[BUG] /loop dynamic-mode termination doesn't cancel pending ScheduleWakeup fires; loop reactivates after declared stop",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:29:15Z"
     },
     {
       "upstream": "anthropics/claude-code#58212",
@@ -769,16 +781,16 @@
       "updated_at": "2026-06-27T10:41:55Z"
     },
     {
-      "upstream": "anthropics/claude-code#60095",
-      "url": "https://github.com/anthropics/claude-code/issues/60095",
-      "title": "Background task chips persist as 'Running' after subagent exits; Stop button no-ops",
+      "upstream": "anthropics/claude-code#60669",
+      "url": "https://github.com/anthropics/claude-code/issues/60669",
+      "title": "[BUG]",
       "impact": "needs_review",
       "categories": [
         "model_lifecycle"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T17:35:57Z"
+      "updated_at": "2026-06-29T16:39:18Z"
     },
     {
       "upstream": "anthropics/claude-code#60943",
@@ -804,6 +816,30 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-27T22:25:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61724",
+      "url": "https://github.com/anthropics/claude-code/issues/61724",
+      "title": "[BUG] vscode extension crashes when trying to resume any conversation. exit code 4294967295,",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:42:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61874",
+      "url": "https://github.com/anthropics/claude-code/issues/61874",
+      "title": "[FEATURE] Safety-Critical Process Mode — opt-in, standards-anchored rigor (IEC 62304 / DO-178C / ISO 26262)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T22:26:06Z"
     },
     {
       "upstream": "anthropics/claude-code#61889",
@@ -867,19 +903,6 @@
       "updated_at": "2026-06-27T22:25:24Z"
     },
     {
-      "upstream": "anthropics/claude-code#62314",
-      "url": "https://github.com/anthropics/claude-code/issues/62314",
-      "title": "Sonnet 4.6 routes every request to long-context tier on Claude Desktop 2.1.149 (429 'Usage credits required')",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T13:02:00Z"
-    },
-    {
       "upstream": "anthropics/claude-code#62503",
       "url": "https://github.com/anthropics/claude-code/issues/62503",
       "title": "[BUG] Appeal Form Redirect Loop After Account Restriction",
@@ -889,7 +912,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-28T14:45:27Z"
+      "updated_at": "2026-06-29T17:13:30Z"
     },
     {
       "upstream": "anthropics/claude-code#62556",
@@ -901,7 +924,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T10:42:10Z"
+      "updated_at": "2026-06-29T14:13:44Z"
     },
     {
       "upstream": "anthropics/claude-code#62802",
@@ -927,18 +950,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-28T22:24:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63055",
-      "url": "https://github.com/anthropics/claude-code/issues/63055",
-      "title": "[BUG] RemoteTrigger create/update returns HTTP 400 with circular error: \"event_type is required\" / \"unknown field event_type\"",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T23:08:46Z"
     },
     {
       "upstream": "anthropics/claude-code#63171",
@@ -967,31 +978,6 @@
       "updated_at": "2026-06-28T22:25:05Z"
     },
     {
-      "upstream": "anthropics/claude-code#63470",
-      "url": "https://github.com/anthropics/claude-code/issues/63470",
-      "title": "Remote Control silently fails when HTTPS-scanning AV (e.g. Norton 360) intercepts TLS - Node rejects MITM cert chain",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T20:14:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63546",
-      "url": "https://github.com/anthropics/claude-code/issues/63546",
-      "title": "[Bug] Opus 4.8 on Bedrock: \"thinking.type.enabled\" not supported — regression from #51439",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T12:21:02Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63604",
       "url": "https://github.com/anthropics/claude-code/issues/63604",
       "title": "[BUG] Opus 4.8 repeatedly emits malformed tool_use blocks, entire response discarded (4.7 works fine)",
@@ -1003,19 +989,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-27T10:17:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63754",
-      "url": "https://github.com/anthropics/claude-code/issues/63754",
-      "title": "[BUG] Cowork — account enrolled in two A/B variants (`testfoo` + `0526`) causing skill misfires + connector failure; `ENABLE_TOOL_SEARCH` mismatch",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:29:42Z"
     },
     {
       "upstream": "anthropics/claude-code#63792",
@@ -1053,18 +1026,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-29T02:56:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63879",
-      "url": "https://github.com/anthropics/claude-code/issues/63879",
-      "title": "[Bug] Tool-use block markup intermittently corrupted with stray token prefix",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T00:20:40Z"
     },
     {
       "upstream": "anthropics/claude-code#64129",
@@ -1118,18 +1079,6 @@
       "updated_at": "2026-06-28T22:24:39Z"
     },
     {
-      "upstream": "anthropics/claude-code#64397",
-      "url": "https://github.com/anthropics/claude-code/issues/64397",
-      "title": "[Bug] CCR routines: 3 structural observability gaps — RemoteTrigger.run HTTP 400 + unmerged claude/* fire artifacts + MCP-permission-prompt deadlocks",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T18:49:06Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64578",
       "url": "https://github.com/anthropics/claude-code/issues/64578",
       "title": "[BUG] Managed MCP server tools permanently stuck in \"Needs Approval\" — users cannot approve unlisted tools, contradicting docs and UI",
@@ -1154,6 +1103,18 @@
       "updated_at": "2026-06-28T13:19:58Z"
     },
     {
+      "upstream": "anthropics/claude-code#64684",
+      "url": "https://github.com/anthropics/claude-code/issues/64684",
+      "title": "Tool call intermittently emitted as literal \"count\" (antml: prefix dropped, \"could not be parsed\") in long Opus 4.8 1M-context sessions",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:42:25Z"
+    },
+    {
       "upstream": "anthropics/claude-code#64797",
       "url": "https://github.com/anthropics/claude-code/issues/64797",
       "title": "Remote Control: Android approval signal silently dropped — server never receives it (Linux/tmux, pure remote session)",
@@ -1164,19 +1125,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-27T22:25:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64900",
-      "url": "https://github.com/anthropics/claude-code/issues/64900",
-      "title": "[BUG] Intermittent mid-stream SSE stall — Opus 4.7/4.8, Sonnet 4.6, pause token emission 40–600s mid-response, latency increasing (VS Code extension)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:29:09Z"
     },
     {
       "upstream": "anthropics/claude-code#64970",
@@ -1213,7 +1161,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T16:49:14Z"
+      "updated_at": "2026-06-29T12:59:56Z"
     },
     {
       "upstream": "anthropics/claude-code#65241",
@@ -1241,18 +1189,6 @@
       "updated_at": "2026-06-27T13:40:05Z"
     },
     {
-      "upstream": "anthropics/claude-code#65464",
-      "url": "https://github.com/anthropics/claude-code/issues/65464",
-      "title": "[BUG] CC + Opus 4.8: `ScheduleWakeup` constantly re-injects workflow slash command as an apparent user invocation, causing an unrequested re-run of entire workflow",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T11:03:19Z"
-    },
-    {
       "upstream": "anthropics/claude-code#65506",
       "url": "https://github.com/anthropics/claude-code/issues/65506",
       "title": "[BUG]Cannot authenticate Claude Code on headless remote server (VPS)",
@@ -1265,18 +1201,6 @@
       "updated_at": "2026-06-27T10:42:12Z"
     },
     {
-      "upstream": "anthropics/claude-code#65551",
-      "url": "https://github.com/anthropics/claude-code/issues/65551",
-      "title": "[Bug] Anthropic API Error: Rate limiting despite normal usage patterns",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:29:04Z"
-    },
-    {
       "upstream": "anthropics/claude-code#65559",
       "url": "https://github.com/anthropics/claude-code/issues/65559",
       "title": "[Bug] Anthropic API Error: Server Rate Limited - Requests Being Temporarily Throttled",
@@ -1287,42 +1211,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-28T22:24:57Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65574",
-      "url": "https://github.com/anthropics/claude-code/issues/65574",
-      "title": "[Bug] False positive cyber safeguard blocks agentic workflow, causing token loss without recovery path",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:29:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65581",
-      "url": "https://github.com/anthropics/claude-code/issues/65581",
-      "title": "Opus 4.8 in Claude Code: deflects bugs to external systems, band-aids instead of root-causing, over-steers the user, ignores stored rules",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:29:14Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65591",
-      "url": "https://github.com/anthropics/claude-code/issues/65591",
-      "title": "[BUG]",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:29:18Z"
     },
     {
       "upstream": "anthropics/claude-code#65601",
@@ -1460,19 +1348,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-27T10:42:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65697",
-      "url": "https://github.com/anthropics/claude-code/issues/65697",
-      "title": "[FEATURE] Official Claude Desktop build for Linux (Ubuntu LTS / Debian)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T20:56:32Z"
     },
     {
       "upstream": "anthropics/claude-code#65699",
@@ -1632,6 +1507,19 @@
       "updated_at": "2026-06-27T22:25:33Z"
     },
     {
+      "upstream": "anthropics/claude-code#65805",
+      "url": "https://github.com/anthropics/claude-code/issues/65805",
+      "title": "[BUG] `--resume` drops the Opus `[1m]` modifier, invalidating the prompt cache",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:42:36Z"
+    },
+    {
       "upstream": "anthropics/claude-code#65807",
       "url": "https://github.com/anthropics/claude-code/issues/65807",
       "title": "[Feature Request] Usage credit adjustment for Anthropic API errors and rate limiting issues",
@@ -1666,6 +1554,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-28T10:47:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65841",
+      "url": "https://github.com/anthropics/claude-code/issues/65841",
+      "title": "[BUG] CLI TUI: AskUserQuestion and permission prompts intermittently never render — session shows activity spinner indefinitely, queued messages never processed (2.1.167, Linux)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T22:25:47Z"
     },
     {
       "upstream": "anthropics/claude-code#65845",
@@ -1728,6 +1628,18 @@
       "updated_at": "2026-06-28T22:24:59Z"
     },
     {
+      "upstream": "anthropics/claude-code#65870",
+      "url": "https://github.com/anthropics/claude-code/issues/65870",
+      "title": "[BUG] Regression: long sessions no longer auto-compact before the context limit, silently crossing into the 200k–1M billing tier (desktop app)",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:42:33Z"
+    },
+    {
       "upstream": "anthropics/claude-code#65881",
       "url": "https://github.com/anthropics/claude-code/issues/65881",
       "title": "Cowork desktop client silently mutates MCP tool-call string args containing long repeated-character runs",
@@ -1738,6 +1650,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-29T08:25:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65889",
+      "url": "https://github.com/anthropics/claude-code/issues/65889",
+      "title": "[Bug] Silent model routing ignoring pinned claude-opus-4-7 setting in settings.json",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:42:42Z"
     },
     {
       "upstream": "anthropics/claude-code#65894",
@@ -1800,6 +1724,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-28T22:24:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65918",
+      "url": "https://github.com/anthropics/claude-code/issues/65918",
+      "title": "[Bug] Experimental CreateTeam: peer agents not inheriting workspace auto-approval for sandbox bash and repo filesystem operations",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T22:25:58Z"
     },
     {
       "upstream": "anthropics/claude-code#65923",
@@ -1900,18 +1836,6 @@
       "updated_at": "2026-06-28T22:25:12Z"
     },
     {
-      "upstream": "anthropics/claude-code#65967",
-      "url": "https://github.com/anthropics/claude-code/issues/65967",
-      "title": "[Bug] AskUserQuestion silently auto-rejected when user messages queued",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T10:22:50Z"
-    },
-    {
       "upstream": "anthropics/claude-code#65972",
       "url": "https://github.com/anthropics/claude-code/issues/65972",
       "title": "[FEATURE] Make the mobile Code tab a native client for agent-view background sessions",
@@ -1924,16 +1848,124 @@
       "updated_at": "2026-06-28T22:25:14Z"
     },
     {
-      "upstream": "anthropics/claude-code#66400",
-      "url": "https://github.com/anthropics/claude-code/issues/66400",
-      "title": "Tool calls intermittently fail with \"malformed and could not be parsed\"; markup rendered as chat text",
+      "upstream": "anthropics/claude-code#65974",
+      "url": "https://github.com/anthropics/claude-code/issues/65974",
+      "title": "[BUG] [PowerShell] Reporting $LASTEXITCODE causes unnecessary permission checks",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:42:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65975",
+      "url": "https://github.com/anthropics/claude-code/issues/65975",
+      "title": "Claude Opus 4.7 + ultracode: 50min/37% budget burned, total failure on Chrome Native Messaging integration on Win11",
       "impact": "needs_review",
       "categories": [
         "model_lifecycle"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T20:25:10Z"
+      "updated_at": "2026-06-29T11:42:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65977",
+      "url": "https://github.com/anthropics/claude-code/issues/65977",
+      "title": "[Bug] Anthropic API Error: Server Rate Limiting",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:42:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65985",
+      "url": "https://github.com/anthropics/claude-code/issues/65985",
+      "title": "[BUG] Claude generates tight gh run view polling loops that exhaust GitHub API rate limits",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:42:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66023",
+      "url": "https://github.com/anthropics/claude-code/issues/66023",
+      "title": "Workflow tool: one invocation spawned 46 Opus subagents (~3M tokens) with no cost confirmation",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:42:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66034",
+      "url": "https://github.com/anthropics/claude-code/issues/66034",
+      "title": "[BUG] Repeated incorrect bug diagnosis led to ~$94 wasted over 2 days on the same root cause",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:42:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66083",
+      "url": "https://github.com/anthropics/claude-code/issues/66083",
+      "title": "Desktop app: effort picker silently drops 'max', shows 'extra effort' while ultracode is active, and /effort is unavailable in app sessions",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T22:25:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66111",
+      "url": "https://github.com/anthropics/claude-code/issues/66111",
+      "title": "[BUG] Desktop Read-aloud play button enters playing state, then reverts to idle after ~3 seconds (no audio, no error shown)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T22:26:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66139",
+      "url": "https://github.com/anthropics/claude-code/issues/66139",
+      "title": "Feature request: AZ5 emergency stop — immediately kill all running tasks and commands",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T22:26:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66149",
+      "url": "https://github.com/anthropics/claude-code/issues/66149",
+      "title": "[Bug] Anthropic API Error: Server rate limiting on requests",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T22:26:13Z"
     },
     {
       "upstream": "anthropics/claude-code#66601",
@@ -1998,18 +2030,6 @@
       "updated_at": "2026-06-28T14:55:27Z"
     },
     {
-      "upstream": "anthropics/claude-code#67490",
-      "url": "https://github.com/anthropics/claude-code/issues/67490",
-      "title": "[BUG] Desktop (Epitaxy) copy-link on a model-authored file link yields a dead https://claude.ai/epitaxy/local_<uuid> URL instead of the file path",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T01:11:53Z"
-    },
-    {
       "upstream": "anthropics/claude-code#67529",
       "url": "https://github.com/anthropics/claude-code/issues/67529",
       "title": "[BUG] \"Please run /login · API Error: 401 ... token expired\" has no recovery path when using Claude Platform for AWS (awsAuthRefresh configured)",
@@ -2032,19 +2052,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-28T08:27:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#67849",
-      "url": "https://github.com/anthropics/claude-code/issues/67849",
-      "title": "Windows: path-scoped Write/Edit permission rules never match — Write tool absolutizes file_path pre-check and absolute Windows paths match no documented pattern form",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T21:44:41Z"
     },
     {
       "upstream": "anthropics/claude-code#68005",
@@ -2097,6 +2104,18 @@
       "updated_at": "2026-06-29T01:41:19Z"
     },
     {
+      "upstream": "anthropics/claude-code#69015",
+      "url": "https://github.com/anthropics/claude-code/issues/69015",
+      "title": "[BUG] Claude Code long-running session invents tool results, fake user turns, and follow-up actions without user input",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T15:36:14Z"
+    },
+    {
       "upstream": "anthropics/claude-code#69179",
       "url": "https://github.com/anthropics/claude-code/issues/69179",
       "title": "False \"Context limit reached\" at 21% context after loading claude-api skill",
@@ -2107,18 +2126,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-28T12:44:22Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#69444",
-      "url": "https://github.com/anthropics/claude-code/issues/69444",
-      "title": "[BUG] Claude Code *Desktop* app lost the ability to select 1M Context variants of models for 3p inference",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T00:30:06Z"
     },
     {
       "upstream": "anthropics/claude-code#69528",
@@ -2205,6 +2212,18 @@
       "updated_at": "2026-06-27T12:49:12Z"
     },
     {
+      "upstream": "anthropics/claude-code#70128",
+      "url": "https://github.com/anthropics/claude-code/issues/70128",
+      "title": "[Bug] Anthropic API Error: Request Timed Out",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T13:39:00Z"
+    },
+    {
       "upstream": "anthropics/claude-code#70148",
       "url": "https://github.com/anthropics/claude-code/issues/70148",
       "title": "[BUG] Model fabricates entire conversation turns (fake user messages + fake tool results) after an interrupted tool call under transmission latency",
@@ -2217,16 +2236,18 @@
       "updated_at": "2026-06-28T16:07:02Z"
     },
     {
-      "upstream": "anthropics/claude-code#70420",
-      "url": "https://github.com/anthropics/claude-code/issues/70420",
-      "title": "CLAUDE.md rules aren't reliably followed; PreToolUse hooks are a partial, hand-rolled stopgap",
+      "upstream": "anthropics/claude-code#70315",
+      "url": "https://github.com/anthropics/claude-code/issues/70315",
+      "title": "[Bug] Still reproducing on 2.1.186: assistant hallucinates fake user/system turns with stop_reason=null (re-report of #64791, wrongly auto-closed)",
       "impact": "needs_review",
       "categories": [
-        "model_lifecycle"
+        "request_shape_400",
+        "model_lifecycle",
+        "prompt_caching"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:14:03Z"
+      "updated_at": "2026-06-29T19:58:09Z"
     },
     {
       "upstream": "anthropics/claude-code#70459",
@@ -2241,6 +2262,30 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-29T01:37:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#70475",
+      "url": "https://github.com/anthropics/claude-code/issues/70475",
+      "title": "[Bug] Multi-agent workflows terminate on transient server errors instead of retrying with backoff",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T17:03:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#70756",
+      "url": "https://github.com/anthropics/claude-code/issues/70756",
+      "title": "[BUG] \"Failed to save changes\" error when enabling unrestricted git push permission",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T15:12:24Z"
     },
     {
       "upstream": "anthropics/claude-code#70810",
@@ -2519,19 +2564,6 @@
       "updated_at": "2026-06-28T05:45:48Z"
     },
     {
-      "upstream": "anthropics/claude-code#71114",
-      "url": "https://github.com/anthropics/claude-code/issues/71114",
-      "title": "opus 4.8 xhigh acting very dumb on toy reinforcement learning",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T14:04:06Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71124",
       "url": "https://github.com/anthropics/claude-code/issues/71124",
       "title": "[Bug][aup] Cyber safeguard blocked continuing authorized network-device hardening and config work (req_011Cc474wkKrNpjskQSGvsJv)",
@@ -2578,18 +2610,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-28T05:45:35Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71297",
-      "url": "https://github.com/anthropics/claude-code/issues/71297",
-      "title": "Ubersuggest MCP: OAuth token not forwarded — all API calls return \"Not connected\" despite connector showing active",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T14:09:49Z"
     },
     {
       "upstream": "anthropics/claude-code#71336",
@@ -2653,18 +2673,6 @@
       "updated_at": "2026-06-28T12:12:40Z"
     },
     {
-      "upstream": "anthropics/claude-code#71481",
-      "url": "https://github.com/anthropics/claude-code/issues/71481",
-      "title": "[BUG] Silent default model upgrade to Opus 4.7 caused $506 in unexpected charges over 6 days",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:32:27Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71518",
       "url": "https://github.com/anthropics/claude-code/issues/71518",
       "title": "claude remote-control --permission-mode bypassPermissions is silently ignored on mobile (native Windows)",
@@ -2675,337 +2683,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-27T10:06:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71566",
-      "url": "https://github.com/anthropics/claude-code/issues/71566",
-      "title": "IDE selection from a closed, never-saved file leaks into model context (transmitted a secret)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T11:29:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71572",
-      "url": "https://github.com/anthropics/claude-code/issues/71572",
-      "title": "I have been Using Claude with GUI and I had several named...",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T10:35:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71574",
-      "url": "https://github.com/anthropics/claude-code/issues/71574",
-      "title": "[BUG]",
-      "impact": "needs_review",
-      "categories": [
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T10:44:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71578",
-      "url": "https://github.com/anthropics/claude-code/issues/71578",
-      "title": "Bug: currentDate in system prompt shows previous day's date after context compression — causes incorrect date-sensitive operations",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T11:07:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71583",
-      "url": "https://github.com/anthropics/claude-code/issues/71583",
-      "title": "[FEATURE] Claude Code mobile/web: show model, context (K), effort level & usage limit",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T11:19:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71585",
-      "url": "https://github.com/anthropics/claude-code/issues/71585",
-      "title": "[BUG] The external-file-change system note asserts an unverifiable cause (\"by the user or by a linter\") and the user's awareness — the model relays it as fact",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T11:30:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71588",
-      "url": "https://github.com/anthropics/claude-code/issues/71588",
-      "title": "Claude Code repeatedly fabricates technical explanations without verifying source data",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T13:51:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71591",
-      "url": "https://github.com/anthropics/claude-code/issues/71591",
-      "title": "[BUG] Bash tool broken on Windows: /usr/bin/bash: -c: line 26: unexpected EOF while looking for matching backtick",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T12:48:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71599",
-      "url": "https://github.com/anthropics/claude-code/issues/71599",
-      "title": "Vertex/Bedrock: `thinking.display:\"summarized\"` stripped from request body → empty thinking on Opus 4.8/4.7 (regression 2.1.150→2.1.177, still in 2.1.193)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T13:12:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71602",
-      "url": "https://github.com/anthropics/claude-code/issues/71602",
-      "title": "Forged `<system-reminder>` markup in subagent output is relayed unsanitized to the parent agent, impersonating a genuine system-reminder",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T15:57:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71612",
-      "url": "https://github.com/anthropics/claude-code/issues/71612",
-      "title": "Completed Explore sub-agent re-fires with hallucinated content, fabricates a 'security classifier' urging permission escalation",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T14:53:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71620",
-      "url": "https://github.com/anthropics/claude-code/issues/71620",
-      "title": "[BUG] claudeCode.environmentVariables workspace scope regression in v2.1.193 — setting greyed out with scope warning",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T15:29:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71624",
-      "url": "https://github.com/anthropics/claude-code/issues/71624",
-      "title": "collaborative multi-session Claude",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T15:55:45Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71629",
-      "url": "https://github.com/anthropics/claude-code/issues/71629",
-      "title": "[BUG] Code on the web: Trusted egress allowlist is systematically out of sync with where tooling connects",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T16:22:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71631",
-      "url": "https://github.com/anthropics/claude-code/issues/71631",
-      "title": "Voice input transcribes in English when speaking Portuguese (Brazil)",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T16:43:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71633",
-      "url": "https://github.com/anthropics/claude-code/issues/71633",
-      "title": "[Bug] skill-creator run_loop.py burns ~50% of a usage window in minutes: full claude -p agent per query x run x iteration, no cost preview or cap",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T19:46:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71634",
-      "url": "https://github.com/anthropics/claude-code/issues/71634",
-      "title": "[Bug] Anthropic API Error: Server rate limit exceeded (temporary)",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T16:52:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71635",
-      "url": "https://github.com/anthropics/claude-code/issues/71635",
-      "title": "[Bug] Anthropic API Error: Server rate limiting on valid requests",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T16:54:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71636",
-      "url": "https://github.com/anthropics/claude-code/issues/71636",
-      "title": "[Bug] Anthropic API Error: Server rate limiting during requests",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T16:52:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71649",
-      "url": "https://github.com/anthropics/claude-code/issues/71649",
-      "title": "claude.ai managed connector (claudeai-proxy) can't be re-attached from CLI — claudeAiOauth never re-minted, no recovery path",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T23:04:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71659",
-      "url": "https://github.com/anthropics/claude-code/issues/71659",
-      "title": "[BUG] --resume causes massive silent token drain on session restore (Pro, v2.1.193)",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "model_lifecycle",
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T19:42:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71665",
-      "url": "https://github.com/anthropics/claude-code/issues/71665",
-      "title": "[Bug] Anthropic API Error: Server rate limit exceeded",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T19:49:09Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71666",
-      "url": "https://github.com/anthropics/claude-code/issues/71666",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting During Normal Usage",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T19:51:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71667",
-      "url": "https://github.com/anthropics/claude-code/issues/71667",
-      "title": "[Bug] Anthropic API Error: Server rate limiting on requests",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T19:50:15Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71668",
-      "url": "https://github.com/anthropics/claude-code/issues/71668",
-      "title": "[Bug] Anthropic API Error: Server temporarily limiting requests (rate limit)",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T20:02:22Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71669",
-      "url": "https://github.com/anthropics/claude-code/issues/71669",
-      "title": "[Bug] Anthropic API Error: Server rate limiting requests",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T20:04:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71670",
-      "url": "https://github.com/anthropics/claude-code/issues/71670",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting on Valid Requests",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T20:02:44Z"
     },
     {
       "upstream": "anthropics/claude-code#71671",
@@ -3020,32 +2697,6 @@
       "updated_at": "2026-06-28T07:07:55Z"
     },
     {
-      "upstream": "anthropics/claude-code#71672",
-      "url": "https://github.com/anthropics/claude-code/issues/71672",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting During Normal Usage",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T20:05:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71673",
-      "url": "https://github.com/anthropics/claude-code/issues/71673",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting on Valid Requests",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T20:08:52Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71681",
       "url": "https://github.com/anthropics/claude-code/issues/71681",
       "title": "[BUG] [BUG] Long-session context bleed: assistant fabricated a user-reported bug that was never reported",
@@ -3056,78 +2707,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-27T07:04:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71683",
-      "url": "https://github.com/anthropics/claude-code/issues/71683",
-      "title": "[BUG] VS Code integrated terminal: every request fails with 503 'pre-upstream queue is saturated'; native Terminal.app works (macOS)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T01:12:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71702",
-      "url": "https://github.com/anthropics/claude-code/issues/71702",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting on Requests",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:31:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71703",
-      "url": "https://github.com/anthropics/claude-code/issues/71703",
-      "title": "[Bug] Anthropic API Error: Server rate limiting (temporary request throttling)",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:31:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71704",
-      "url": "https://github.com/anthropics/claude-code/issues/71704",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting on Valid Requests",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:32:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71705",
-      "url": "https://github.com/anthropics/claude-code/issues/71705",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting During Normal Usage",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:32:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71706",
-      "url": "https://github.com/anthropics/claude-code/issues/71706",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting (Request Throttling)",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T22:32:14Z"
     },
     {
       "upstream": "anthropics/claude-code#71708",
@@ -3155,19 +2734,6 @@
       "updated_at": "2026-06-27T07:05:06Z"
     },
     {
-      "upstream": "anthropics/claude-code#71717",
-      "url": "https://github.com/anthropics/claude-code/issues/71717",
-      "title": "[BUG] [BUG] OAuth login succeeds but .credentials.json never written on Windows, causing permanent 401 loop",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T00:02:26Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71727",
       "url": "https://github.com/anthropics/claude-code/issues/71727",
       "title": "[BUG] 2.1.19x native CLI: OAuth login fails CERT_HAS_EXPIRED on claude.com / platform.claude.com (no proxy) — bundled Bun 1.4.0 regression vs 1.3.14",
@@ -3178,114 +2744,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-27T08:04:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71740",
-      "url": "https://github.com/anthropics/claude-code/issues/71740",
-      "title": "[Bug] Anthropic API Error: Server rate limiting during normal usage",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T03:13:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71741",
-      "url": "https://github.com/anthropics/claude-code/issues/71741",
-      "title": "[Bug] Anthropic API Error: Server rate limiting during normal usage",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T03:15:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71742",
-      "url": "https://github.com/anthropics/claude-code/issues/71742",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting During Normal Usage",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T03:14:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71743",
-      "url": "https://github.com/anthropics/claude-code/issues/71743",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting During Normal Usage",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T03:18:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71744",
-      "url": "https://github.com/anthropics/claude-code/issues/71744",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting on Requests",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T03:19:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71745",
-      "url": "https://github.com/anthropics/claude-code/issues/71745",
-      "title": "[Bug] Anthropic API Error: Server rate limiting during requests",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T03:15:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71746",
-      "url": "https://github.com/anthropics/claude-code/issues/71746",
-      "title": "[Bug] Anthropic API Error: Server Rate Limiting During Normal Usage",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T03:15:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71747",
-      "url": "https://github.com/anthropics/claude-code/issues/71747",
-      "title": "[Bug] Anthropic API Error: Server rate limiting on requests",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T03:16:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71748",
-      "url": "https://github.com/anthropics/claude-code/issues/71748",
-      "title": "[Bug] Anthropic API Error: Server rate limiting (temporary request throttling)",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T03:17:19Z"
     },
     {
       "upstream": "anthropics/claude-code#71757",
@@ -4159,7 +3617,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-28T17:02:05Z"
+      "updated_at": "2026-06-29T23:02:21Z"
     },
     {
       "upstream": "anthropics/claude-code#72042",
@@ -4531,7 +3989,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-29T09:37:27Z"
+      "updated_at": "2026-06-29T14:45:33Z"
     },
     {
       "upstream": "anthropics/claude-code#72231",
@@ -4545,6 +4003,331 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-29T10:12:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72240",
+      "url": "https://github.com/anthropics/claude-code/issues/72240",
+      "title": "Tool-call markup occasionally emitted as plain text instead of executed (commands silently not run)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:09:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72241",
+      "url": "https://github.com/anthropics/claude-code/issues/72241",
+      "title": "Claude Desktop: Atlassian connector 'Install' button grayed out, OAuth flow never triggered",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T14:07:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72242",
+      "url": "https://github.com/anthropics/claude-code/issues/72242",
+      "title": "[BUG] Windows: incomplete Claude Code update leaves two versioned runtime folders under `%APPDATA%\\Claude\\claude-code\\`, causing a deterministic Bun segfault at Code startup (every session)",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T11:37:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72248",
+      "url": "https://github.com/anthropics/claude-code/issues/72248",
+      "title": "[Bug] Workflow tool delivers JSON args as string instead of parsed object",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T12:11:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72249",
+      "url": "https://github.com/anthropics/claude-code/issues/72249",
+      "title": "Claude Code lowers the reasoning effort level mid-session without consent",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T12:20:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72256",
+      "url": "https://github.com/anthropics/claude-code/issues/72256",
+      "title": "False positive: API safeguards block legitimate security code reviews via custom subagents [skip-publish-guard]",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-30T00:34:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72259",
+      "url": "https://github.com/anthropics/claude-code/issues/72259",
+      "title": "[BUG] Unauthorized Max 5x→20x upgrade + €491 auto-recharge charges in one day",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T13:19:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72274",
+      "url": "https://github.com/anthropics/claude-code/issues/72274",
+      "title": "[Bug] Cross-session credential leakage: production database modified on unauthorized host",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T17:28:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72277",
+      "url": "https://github.com/anthropics/claude-code/issues/72277",
+      "title": "headersHelper in plugin .mcp.json still ignores ${CLAUDE_PLUGIN_ROOT} (repro on 2.1.181/2.1.187; root cause + fingerprint)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T14:52:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72278",
+      "url": "https://github.com/anthropics/claude-code/issues/72278",
+      "title": "[Bug] /ultrareview charges for failed runs despite incomplete execution",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T20:07:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72291",
+      "url": "https://github.com/anthropics/claude-code/issues/72291",
+      "title": "[BUG] Claude Code shows \"out of credits\" on overage accounts; requires full system reboot to recover",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T15:52:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72293",
+      "url": "https://github.com/anthropics/claude-code/issues/72293",
+      "title": "[Bug] Anthropic API Error: Server Rate Limiting During Normal Usage",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T16:01:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72294",
+      "url": "https://github.com/anthropics/claude-code/issues/72294",
+      "title": "[Bug] Anthropic API Error: Server Rate Limiting (Temporary Request Throttling)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T16:07:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72298",
+      "url": "https://github.com/anthropics/claude-code/issues/72298",
+      "title": "[Bug] Claude Code LLM functions perform below expected capability level despite adequate context provided",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T16:37:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72318",
+      "url": "https://github.com/anthropics/claude-code/issues/72318",
+      "title": "[Bug][cyber] Safety block halted reverse-engineering USB AOA accessory framing for a drone controller app (req_011CcXzbthv6diNEz89koBkH)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T18:17:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72322",
+      "url": "https://github.com/anthropics/claude-code/issues/72322",
+      "title": "[Bug] Claude Code auto-update mechanism not triggering",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T18:27:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72330",
+      "url": "https://github.com/anthropics/claude-code/issues/72330",
+      "title": "Agent acts on bundled multi-part approvals; presents decisions as bare issue-IDs; confident stale knowledge",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T19:02:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72333",
+      "url": "https://github.com/anthropics/claude-code/issues/72333",
+      "title": "MCP collision check suppresses claude.ai connectors that point to a different workspace than the same-named plugin — no scriptable workaround",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T19:14:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72336",
+      "url": "https://github.com/anthropics/claude-code/issues/72336",
+      "title": "[Billing Bug] Unauthorized Pro→Max 20x upgrade, charged twice, refund denied — Slovakia/EEA",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T19:53:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72344",
+      "url": "https://github.com/anthropics/claude-code/issues/72344",
+      "title": "[BUG] OAuth login fails on Linux VPS: \"Redirect URI platform.claude.com/oauth/callback is not supported by client\"",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T20:59:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72349",
+      "url": "https://github.com/anthropics/claude-code/issues/72349",
+      "title": "Named background subagents persist in FleetView after completion; no dismiss affordance + inconsistent shutdown_request reaping",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T21:54:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72350",
+      "url": "https://github.com/anthropics/claude-code/issues/72350",
+      "title": "[Bug][cyber] Safety block halted routine GUI work on a drone telemetry/video ground-station HUD (req_011CcYJUCfHYwm1Zzc8uwssh)",
+      "impact": "needs_review",
+      "categories": [
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T22:32:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72352",
+      "url": "https://github.com/anthropics/claude-code/issues/72352",
+      "title": "Malformed tool-call generation: stray `court` token + non-namespaced <invoke> rejected by parser",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T22:09:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72353",
+      "url": "https://github.com/anthropics/claude-code/issues/72353",
+      "title": "[Bug][cyber] ClAudit false-positive in android — req_011CcYJd2P9uUiFo9rWWG8VM",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T22:12:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72358",
+      "url": "https://github.com/anthropics/claude-code/issues/72358",
+      "title": "[Bug][cyber] False cyber block while building drone flight UI with live video, telemetry, and connection-statu (req_011CcYLSQEyq2CeAsBAgK4Pz)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T23:32:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72375",
+      "url": "https://github.com/anthropics/claude-code/issues/72375",
+      "title": "[BUG] Gmail + Google Calendar connectors show \"Connected\" in UI but never trigger OAuth, no Google account linked",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T23:47:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72384",
+      "url": "https://github.com/anthropics/claude-code/issues/72384",
+      "title": "[DOCS] MCP OAuth docs do not clarify that unset `oauth.scopes` should avoid requesting the full `scopes_supported` catalog",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T23:56:08Z"
     },
     {
       "upstream": "anthropics/claude-code#22264",
@@ -4571,6 +4354,18 @@
       "updated_at": "2026-06-27T21:19:14Z"
     },
     {
+      "upstream": "anthropics/claude-code#34773",
+      "url": "https://github.com/anthropics/claude-code/issues/34773",
+      "title": "Sonnet 4.6 1M context unavailable on Max 20x plan - only Opus 1M appears in /model",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-29T18:26:05Z"
+    },
+    {
       "upstream": "anthropics/claude-code#41265",
       "url": "https://github.com/anthropics/claude-code/issues/41265",
       "title": "[DOCS] Headless and Agent SDK docs do not explain error result payloads beyond subtype names",
@@ -4583,16 +4378,30 @@
       "updated_at": "2026-06-27T21:16:29Z"
     },
     {
-      "upstream": "anthropics/claude-code#64445",
-      "url": "https://github.com/anthropics/claude-code/issues/64445",
-      "title": "1M context credits consumed without user selecting 1M mode",
+      "upstream": "anthropics/claude-code#59529",
+      "url": "https://github.com/anthropics/claude-code/issues/59529",
+      "title": "Memory directives are loaded but not consistently honoured",
       "impact": "medium",
       "categories": [
-        "token_limits"
+        "token_limits",
+        "effort_structured"
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-26T11:03:32Z"
+      "updated_at": "2026-06-29T22:26:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60733",
+      "url": "https://github.com/anthropics/claude-code/issues/60733",
+      "title": "Model uses N sequential Edit calls for bulk renumbering instead of single sed/Write",
+      "impact": "medium",
+      "categories": [
+        "token_limits",
+        "effort_structured"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-29T11:42:49Z"
     },
     {
       "upstream": "anthropics/claude-code#65414",
@@ -4607,6 +4416,18 @@
       "updated_at": "2026-06-27T10:41:43Z"
     },
     {
+      "upstream": "anthropics/claude-code#65515",
+      "url": "https://github.com/anthropics/claude-code/issues/65515",
+      "title": "Enhancement: Hybrid Memory Architecture to Replace Full Conversation History in Context Window",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-29T11:42:34Z"
+    },
+    {
       "upstream": "anthropics/claude-code#65785",
       "url": "https://github.com/anthropics/claude-code/issues/65785",
       "title": "[DOCS] Thinking docs omit `--thinking disabled` and per-model disable behavior for default-thinking models",
@@ -4617,6 +4438,18 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
       "updated_at": "2026-06-27T22:25:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#68110",
+      "url": "https://github.com/anthropics/claude-code/issues/68110",
+      "title": "General-purpose sub-agents recursively spawn unbounded child agents, causing exponential fan-out and massive token burn",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-29T18:15:20Z"
     },
     {
       "upstream": "anthropics/claude-code#70222",
@@ -4643,16 +4476,16 @@
       "updated_at": "2026-06-27T18:46:54Z"
     },
     {
-      "upstream": "anthropics/claude-code#10071",
-      "url": "https://github.com/anthropics/claude-code/issues/10071",
-      "title": "[FEATURE] Claude can reconnect to a broken MCP in a manner similar to how it performs other actions",
-      "impact": "not_applicable",
+      "upstream": "anthropics/claude-code#72385",
+      "url": "https://github.com/anthropics/claude-code/issues/72385",
+      "title": "[DOCS] Agent view docs omit bypass-mode disclaimer and per-spawn bypass behavior for `claude agents --dangerously-skip-permissions`",
+      "impact": "medium",
       "categories": [
-        "mcp"
+        "effort_structured"
       ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T16:08:23Z"
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-29T23:59:24Z"
     },
     {
       "upstream": "anthropics/claude-code#10258",
@@ -4666,7 +4499,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:40:02Z"
+      "updated_at": "2026-06-29T22:05:37Z"
     },
     {
       "upstream": "anthropics/claude-code#10375",
@@ -4679,6 +4512,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T12:10:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#10621",
+      "url": "https://github.com/anthropics/claude-code/issues/10621",
+      "title": "[Feature Request] Require double ESC in Vim mode to clear message in Plan Mode Q&A",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T18:43:14Z"
     },
     {
       "upstream": "anthropics/claude-code#11002",
@@ -4721,18 +4567,16 @@
       "updated_at": "2026-06-28T03:57:14Z"
     },
     {
-      "upstream": "anthropics/claude-code#12808",
-      "url": "https://github.com/anthropics/claude-code/issues/12808",
-      "title": "[BUG] In vscode workspace, Claude Code always starts in first project",
+      "upstream": "anthropics/claude-code#12748",
+      "url": "https://github.com/anthropics/claude-code/issues/12748",
+      "title": "[FEATURE] Add cwd parameter to Task tool for setting subagent working directory (to support Git worktrees)",
       "impact": "not_applicable",
       "categories": [
-        "ide",
-        "terminal",
         "plugin"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T13:37:24Z"
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T12:55:34Z"
     },
     {
       "upstream": "anthropics/claude-code#12872",
@@ -4757,7 +4601,22 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T15:12:25Z"
+      "updated_at": "2026-06-29T20:49:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#14023",
+      "url": "https://github.com/anthropics/claude-code/issues/14023",
+      "title": "[BUG] I am not able to login through VSCode extension",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:11:15Z"
     },
     {
       "upstream": "anthropics/claude-code#14828",
@@ -4770,7 +4629,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T16:01:47Z"
+      "updated_at": "2026-06-29T15:42:36Z"
     },
     {
       "upstream": "anthropics/claude-code#14836",
@@ -4820,6 +4679,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T22:25:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#16837",
+      "url": "https://github.com/anthropics/claude-code/issues/16837",
+      "title": "[BUG] Claude code does not obey values of MCP_TIMEOUT longer than 60 seconds",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T18:28:19Z"
     },
     {
       "upstream": "anthropics/claude-code#16849",
@@ -4883,7 +4755,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T10:09:32Z"
+      "updated_at": "2026-06-29T17:13:16Z"
     },
     {
       "upstream": "anthropics/claude-code#18435",
@@ -4897,7 +4769,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-29T09:59:03Z"
+      "updated_at": "2026-06-29T23:29:49Z"
     },
     {
       "upstream": "anthropics/claude-code#18467",
@@ -4951,6 +4823,31 @@
       "updated_at": "2026-06-28T13:53:36Z"
     },
     {
+      "upstream": "anthropics/claude-code#22931",
+      "url": "https://github.com/anthropics/claude-code/issues/22931",
+      "title": "[BUG] I archived my Claude Cowork chats and they are nowhere to be found.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:46:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#23134",
+      "url": "https://github.com/anthropics/claude-code/issues/23134",
+      "title": "Feature Request: Option to disable paste text collapse in input field",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:04:07Z"
+    },
+    {
       "upstream": "anthropics/claude-code#24285",
       "url": "https://github.com/anthropics/claude-code/issues/24285",
       "title": "[BUG] Can't see Claude's thinking anymore",
@@ -4973,21 +4870,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T19:33:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#25087",
-      "url": "https://github.com/anthropics/claude-code/issues/25087",
-      "title": "[BUG] keybindings.json ignored in Claude desktop app — Enter/Shift+Enter always submit",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T19:57:46Z"
+      "updated_at": "2026-06-29T16:58:14Z"
     },
     {
       "upstream": "anthropics/claude-code#25434",
@@ -5053,19 +4936,6 @@
       "updated_at": "2026-06-28T16:16:56Z"
     },
     {
-      "upstream": "anthropics/claude-code#26679",
-      "url": "https://github.com/anthropics/claude-code/issues/26679",
-      "title": "[FEATURE] Paste images from clipboard directly into Claude Code (Windows)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T16:29:44Z"
-    },
-    {
       "upstream": "anthropics/claude-code#26954",
       "url": "https://github.com/anthropics/claude-code/issues/26954",
       "title": "Bash output truncated: ctrl+o/ctrl+e don't fully expand output",
@@ -5091,6 +4961,45 @@
       "updated_at": "2026-06-27T21:22:36Z"
     },
     {
+      "upstream": "anthropics/claude-code#28077",
+      "url": "https://github.com/anthropics/claude-code/issues/28077",
+      "title": "Allow scrolling back to view full conversation history in CLI TUI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:23:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#28125",
+      "url": "https://github.com/anthropics/claude-code/issues/28125",
+      "title": "[BUG] Cowork Can't add private GitHub marketplace",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:25:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#28300",
+      "url": "https://github.com/anthropics/claude-code/issues/28300",
+      "title": "[FEATURE] Multi-agent collaboration across machines (Agent-to-Agent protocol)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T19:30:50Z"
+    },
+    {
       "upstream": "anthropics/claude-code#28372",
       "url": "https://github.com/anthropics/claude-code/issues/28372",
       "title": "[DOCS] Hooks: add stability warning for many parallel hooks on the same matcher",
@@ -5101,6 +5010,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T21:22:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#28508",
+      "url": "https://github.com/anthropics/claude-code/issues/28508",
+      "title": "[BUG] Remote Control: AskUserQuestion selections made on mobile not received by CLI — causes infinite wait",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T12:53:51Z"
     },
     {
       "upstream": "anthropics/claude-code#28575",
@@ -5127,6 +5050,18 @@
       "updated_at": "2026-06-27T21:27:39Z"
     },
     {
+      "upstream": "anthropics/claude-code#29580",
+      "url": "https://github.com/anthropics/claude-code/issues/29580",
+      "title": "[BUG] DISABLE_TELEMETRY=1 breaks remote-control with misleading \"not yet enabled\" error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:20:44Z"
+    },
+    {
       "upstream": "anthropics/claude-code#30232",
       "url": "https://github.com/anthropics/claude-code/issues/30232",
       "title": "Show status line during permission prompts and user questions",
@@ -5139,32 +5074,16 @@
       "updated_at": "2026-06-28T10:47:02Z"
     },
     {
-      "upstream": "anthropics/claude-code#30407",
-      "url": "https://github.com/anthropics/claude-code/issues/30407",
-      "title": "[workflow issue] all issues get auto-closed without review??",
+      "upstream": "anthropics/claude-code#30699",
+      "url": "https://github.com/anthropics/claude-code/issues/30699",
+      "title": "[BUG] Contextual prompt suggestions during conversations stopped working (regression ~March 1-2)",
       "impact": "not_applicable",
       "categories": [
-        "ide",
         "terminal"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T02:46:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#30492",
-      "url": "https://github.com/anthropics/claude-code/issues/30492",
-      "title": "[Feature Request] Real-time steering: priority message channel for redirecting Claude mid-execution",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T17:31:37Z"
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:16:52Z"
     },
     {
       "upstream": "anthropics/claude-code#31352",
@@ -5178,22 +5097,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T21:21:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#31388",
-      "url": "https://github.com/anthropics/claude-code/issues/31388",
-      "title": "[BUG] Plugin paths hardcoded with absolute paths fail across environments",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "plugin",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T01:46:49Z"
     },
     {
       "upstream": "anthropics/claude-code#31678",
@@ -5248,32 +5151,6 @@
       "updated_at": "2026-06-27T21:24:11Z"
     },
     {
-      "upstream": "anthropics/claude-code#32726",
-      "url": "https://github.com/anthropics/claude-code/issues/32726",
-      "title": "VSCode extension: add option to prevent panel from stealing focus",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T02:52:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#32733",
-      "url": "https://github.com/anthropics/claude-code/issues/32733",
-      "title": "[FEATURE] Secure secrets injection for Claude Code on the web",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T10:22:27Z"
-    },
-    {
       "upstream": "anthropics/claude-code#3301",
       "url": "https://github.com/anthropics/claude-code/issues/3301",
       "title": "[BUG] Environment Contributions warning continuously reappears",
@@ -5311,6 +5188,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-29T07:56:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#3412",
+      "url": "https://github.com/anthropics/claude-code/issues/3412",
+      "title": "Allow viewing and editing content of “pasted text” blocks before submission",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T19:12:35Z"
     },
     {
       "upstream": "anthropics/claude-code#34275",
@@ -5402,20 +5292,6 @@
       "updated_at": "2026-06-28T10:47:09Z"
     },
     {
-      "upstream": "anthropics/claude-code#36351",
-      "url": "https://github.com/anthropics/claude-code/issues/36351",
-      "title": "[BUG] 1M context window removed from Desktop Code tab model picker after v1.1.7714 update on Max plan",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T00:31:55Z"
-    },
-    {
       "upstream": "anthropics/claude-code#36477",
       "url": "https://github.com/anthropics/claude-code/issues/36477",
       "title": "[BUG] --channels mode stops processing incoming messages after first response",
@@ -5452,7 +5328,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T20:39:50Z"
+      "updated_at": "2026-06-29T20:46:50Z"
     },
     {
       "upstream": "anthropics/claude-code#36857",
@@ -5479,7 +5355,21 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T16:13:58Z"
+      "updated_at": "2026-06-29T20:39:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38098",
+      "url": "https://github.com/anthropics/claude-code/issues/38098",
+      "title": "[BUG] Telegram plugin auto-loads in all Claude Code sessions, not just --channels sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:32:48Z"
     },
     {
       "upstream": "anthropics/claude-code#38562",
@@ -5518,7 +5408,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T16:55:30Z"
+      "updated_at": "2026-06-29T22:48:13Z"
     },
     {
       "upstream": "anthropics/claude-code#39429",
@@ -5613,31 +5503,6 @@
       "updated_at": "2026-06-27T21:16:56Z"
     },
     {
-      "upstream": "anthropics/claude-code#40173",
-      "url": "https://github.com/anthropics/claude-code/issues/40173",
-      "title": "Claude-in-Chrome: Server-side domain blocking breaks legitimate business automation",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T00:17:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#40574",
-      "url": "https://github.com/anthropics/claude-code/issues/40574",
-      "title": "[Bug] Garbled characters (mojibake) in CLI output since v2.1.86",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:09Z"
-    },
-    {
       "upstream": "anthropics/claude-code#40766",
       "url": "https://github.com/anthropics/claude-code/issues/40766",
       "title": "[BUG] mcp__ide__getDiagnostics available in CLI (integrated terminal) but missing from VSCode extension panel",
@@ -5652,22 +5517,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T10:42:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#41242",
-      "url": "https://github.com/anthropics/claude-code/issues/41242",
-      "title": "[BUG] Claude Code sustained ~80% ECONNRESET failure rate — March 30, 2026 specifically from Boston Area",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "mcp",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:05Z"
     },
     {
       "upstream": "anthropics/claude-code#41264",
@@ -5732,19 +5581,6 @@
       "updated_at": "2026-06-27T21:14:58Z"
     },
     {
-      "upstream": "anthropics/claude-code#41914",
-      "url": "https://github.com/anthropics/claude-code/issues/41914",
-      "title": "bypassPermissions mode still prompts for Edit/Write on UNC paths (Windows)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:07Z"
-    },
-    {
       "upstream": "anthropics/claude-code#42142",
       "url": "https://github.com/anthropics/claude-code/issues/42142",
       "title": "[BUG] Claude Code Desktop Doesn't Have /plugin Command and cannot add plugin marketplaces, Claude hallucinates about this a lot",
@@ -5758,6 +5594,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-29T00:31:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42264",
+      "url": "https://github.com/anthropics/claude-code/issues/42264",
+      "title": "[Bug] \"Unchanged since last read\" error when reading file previously accessed in reverted conversation state",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T21:02:46Z"
     },
     {
       "upstream": "anthropics/claude-code#42317",
@@ -5785,33 +5633,6 @@
       "updated_at": "2026-06-27T21:14:16Z"
     },
     {
-      "upstream": "anthropics/claude-code#4276",
-      "url": "https://github.com/anthropics/claude-code/issues/4276",
-      "title": "Feature Request: Extend Environment Variable Expansion to `settings.json` files",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:00:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#42776",
-      "url": "https://github.com/anthropics/claude-code/issues/42776",
-      "title": "[BUG] Claude Code Desktop fails to Relaunch on Windows due to orphaned process file lock",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T13:46:16Z"
-    },
-    {
       "upstream": "anthropics/claude-code#4297",
       "url": "https://github.com/anthropics/claude-code/issues/4297",
       "title": "[BUG] API Error (Connection error.)",
@@ -5822,7 +5643,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T10:21:59Z"
+      "updated_at": "2026-06-29T13:55:34Z"
     },
     {
       "upstream": "anthropics/claude-code#43364",
@@ -5889,20 +5710,6 @@
       "updated_at": "2026-06-27T10:42:00Z"
     },
     {
-      "upstream": "anthropics/claude-code#44456",
-      "url": "https://github.com/anthropics/claude-code/issues/44456",
-      "title": "CLI discards logical symlink path, uses realpath — degrades usability in deep directory trees",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:03:52Z"
-    },
-    {
       "upstream": "anthropics/claude-code#45361",
       "url": "https://github.com/anthropics/claude-code/issues/45361",
       "title": "[BUG] Cannot purchase API credits - card approved by bank (3DS passed) but Stripe declines",
@@ -5951,18 +5758,28 @@
       "updated_at": "2026-06-28T12:04:04Z"
     },
     {
-      "upstream": "anthropics/claude-code#45841",
-      "url": "https://github.com/anthropics/claude-code/issues/45841",
-      "title": "VSCODE Extension: Chat panel inline code and code blocks have no background, ignore VSCode theme tokens",
+      "upstream": "anthropics/claude-code#46083",
+      "url": "https://github.com/anthropics/claude-code/issues/46083",
+      "title": "[BUG] [workflow] No email warning when \"stale\" label is applied",
       "impact": "not_applicable",
       "categories": [
-        "ide",
-        "terminal",
-        "install"
+        "terminal"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:14:18Z"
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:14:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46621",
+      "url": "https://github.com/anthropics/claude-code/issues/46621",
+      "title": "Critical: Claude Code silently deletes conversation history without user consent",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T16:27:15Z"
     },
     {
       "upstream": "anthropics/claude-code#47083",
@@ -5980,17 +5797,18 @@
       "updated_at": "2026-06-28T07:56:19Z"
     },
     {
-      "upstream": "anthropics/claude-code#47305",
-      "url": "https://github.com/anthropics/claude-code/issues/47305",
-      "title": "inimize/Collapse button for AskUserQuestion popup",
+      "upstream": "anthropics/claude-code#47166",
+      "url": "https://github.com/anthropics/claude-code/issues/47166",
+      "title": "[FEATURE] JetBrains need some love - a real Claude AI Assist interface plugin",
       "impact": "not_applicable",
       "categories": [
+        "ide",
         "terminal",
-        "slash_hook"
+        "plugin"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:03:56Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:35:21Z"
     },
     {
       "upstream": "anthropics/claude-code#47327",
@@ -6004,7 +5822,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T05:18:55Z"
+      "updated_at": "2026-06-29T15:40:56Z"
     },
     {
       "upstream": "anthropics/claude-code#48275",
@@ -6243,6 +6061,18 @@
       "updated_at": "2026-06-28T12:12:05Z"
     },
     {
+      "upstream": "anthropics/claude-code#50321",
+      "url": "https://github.com/anthropics/claude-code/issues/50321",
+      "title": "[BUG] Usage limit reached - while still having 93% weekly limit and 100% 5-hour limit",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:29Z"
+    },
+    {
       "upstream": "anthropics/claude-code#50674",
       "url": "https://github.com/anthropics/claude-code/issues/50674",
       "title": "Cowork fails on ARM64 (Snapdragon X) despite passing readiness check",
@@ -6266,6 +6096,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T10:47:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50901",
+      "url": "https://github.com/anthropics/claude-code/issues/50901",
+      "title": "[BUG] Claude Desktop App Goes Blank on Latest version",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:24Z"
     },
     {
       "upstream": "anthropics/claude-code#51366",
@@ -6333,31 +6175,16 @@
       "updated_at": "2026-06-27T21:07:29Z"
     },
     {
-      "upstream": "anthropics/claude-code#51464",
-      "url": "https://github.com/anthropics/claude-code/issues/51464",
-      "title": "[BUG] Segmentation fault at address",
+      "upstream": "anthropics/claude-code#51742",
+      "url": "https://github.com/anthropics/claude-code/issues/51742",
+      "title": "VS Code extension: text input types backwards (RTL direction bug) — frequent occurrence",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
-        "install",
-        "platform"
+        "ide"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#51701",
-      "url": "https://github.com/anthropics/claude-code/issues/51701",
-      "title": "[BUG] The Claude desktop app is sending `x-apple.systempreferences://...` — a **macOS-only URI** — on your Windows machine",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T17:30:24Z"
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:32Z"
     },
     {
       "upstream": "anthropics/claude-code#51773",
@@ -6447,6 +6274,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T21:05:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52465",
+      "url": "https://github.com/anthropics/claude-code/issues/52465",
+      "title": "[BUG] Custom theme overrides silently ignored for markdown-rendered slots (codespan, text, error, warning, success, ...)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:32Z"
     },
     {
       "upstream": "anthropics/claude-code#52603",
@@ -6820,6 +6660,19 @@
       "updated_at": "2026-06-27T20:58:32Z"
     },
     {
+      "upstream": "anthropics/claude-code#55254",
+      "url": "https://github.com/anthropics/claude-code/issues/55254",
+      "title": "[BUG] Something went wrong Try sending your message again. If it keeps happening, share feedback so we can investigate. The session stopped responding. Send your message again to resume with a fresh process.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:37Z"
+    },
+    {
       "upstream": "anthropics/claude-code#55500",
       "url": "https://github.com/anthropics/claude-code/issues/55500",
       "title": "[BUG] Branch selector missing in iOS Code UI",
@@ -6845,30 +6698,52 @@
       "updated_at": "2026-06-27T20:39:34Z"
     },
     {
-      "upstream": "anthropics/claude-code#56144",
-      "url": "https://github.com/anthropics/claude-code/issues/56144",
-      "title": "Unexpected message injection — text from WhatsApp appeared in Claude Code session",
+      "upstream": "anthropics/claude-code#55854",
+      "url": "https://github.com/anthropics/claude-code/issues/55854",
+      "title": "[FEATURE] Permission prompts: never use a number for \"No\"; treat stray digits as \"Yes\" fallback",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
-        "platform"
+        "terminal"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:10Z"
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:14:53Z"
     },
     {
-      "upstream": "anthropics/claude-code#56281",
-      "url": "https://github.com/anthropics/claude-code/issues/56281",
-      "title": "[BUG] Can't upgrade Max 5x → Max 20x: payment fails on every attempt, support unresponsive",
+      "upstream": "anthropics/claude-code#55915",
+      "url": "https://github.com/anthropics/claude-code/issues/55915",
+      "title": "Add option to configure week start day (Monday) for welcome page heatmap",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
-        "platform"
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:47:38Z"
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:14:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55945",
+      "url": "https://github.com/anthropics/claude-code/issues/55945",
+      "title": "[FEATURE] Hook which fires when you run out of tokens; expose time when they will be available again",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:14:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55951",
+      "url": "https://github.com/anthropics/claude-code/issues/55951",
+      "title": "Desktop sidebar ignores UserPromptSubmit hook `sessionTitle` output",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:22:55Z"
     },
     {
       "upstream": "anthropics/claude-code#56693",
@@ -6913,20 +6788,6 @@
       "updated_at": "2026-06-28T02:28:00Z"
     },
     {
-      "upstream": "anthropics/claude-code#57161",
-      "url": "https://github.com/anthropics/claude-code/issues/57161",
-      "title": "[BUG] Personal GitHub repos not showing in Claude Code web repo picker despite app installed and connector connected",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T12:19:42Z"
-    },
-    {
       "upstream": "anthropics/claude-code#57230",
       "url": "https://github.com/anthropics/claude-code/issues/57230",
       "title": "[VSCode Extension] Add native system/toast notifications when Claude needs attention",
@@ -6938,7 +6799,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T03:20:21Z"
+      "updated_at": "2026-06-29T14:24:38Z"
     },
     {
       "upstream": "anthropics/claude-code#57286",
@@ -7100,34 +6961,6 @@
       "updated_at": "2026-06-28T22:25:11Z"
     },
     {
-      "upstream": "anthropics/claude-code#58923",
-      "url": "https://github.com/anthropics/claude-code/issues/58923",
-      "title": "[BUG] Claude code CLI cannot paste Image",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59112",
-      "url": "https://github.com/anthropics/claude-code/issues/59112",
-      "title": "Background sessions (claude agents / fleet) don't honor permissions.defaultMode: bypassPermissions",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T13:40:24Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59314",
       "url": "https://github.com/anthropics/claude-code/issues/59314",
       "title": "Plan-scoped permission manifest — approve once per plan, not per tool call",
@@ -7154,19 +6987,16 @@
       "updated_at": "2026-06-28T22:24:44Z"
     },
     {
-      "upstream": "anthropics/claude-code#59750",
-      "url": "https://github.com/anthropics/claude-code/issues/59750",
-      "title": "[BUG] claude agents TUI fully unresponsive on Windows Terminal — broken rendering + dead input loop (2.1.143)",
+      "upstream": "anthropics/claude-code#59726",
+      "url": "https://github.com/anthropics/claude-code/issues/59726",
+      "title": "[BUG] ENAMETOOLONG creating ~/.claude/projects/ when cwd is long (eCryptfs NAME_MAX=143); reproduces via Claude Desktop cowork bootstrap",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
-        "slash_hook",
-        "install",
-        "platform"
+        "install"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:03:49Z"
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:55Z"
     },
     {
       "upstream": "anthropics/claude-code#59833",
@@ -7196,6 +7026,18 @@
       "updated_at": "2026-06-28T22:25:09Z"
     },
     {
+      "upstream": "anthropics/claude-code#60020",
+      "url": "https://github.com/anthropics/claude-code/issues/60020",
+      "title": "[FEATURE] VS Code extension panel should display current model name passively",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:50Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60097",
       "url": "https://github.com/anthropics/claude-code/issues/60097",
       "title": "[Desktop] Display current worktree/cwd name in app UI (statusLine equivalent)",
@@ -7207,6 +7049,21 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-29T09:57:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60341",
+      "url": "https://github.com/anthropics/claude-code/issues/60341",
+      "title": "[BUG] CCD desktop silently drops sessions on relaunch and has no in-app recovery; CLI --resume produces sessions invisible to the sidebar",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:59:18Z"
     },
     {
       "upstream": "anthropics/claude-code#60400",
@@ -7335,6 +7192,20 @@
       "updated_at": "2026-06-29T09:44:50Z"
     },
     {
+      "upstream": "anthropics/claude-code#60776",
+      "url": "https://github.com/anthropics/claude-code/issues/60776",
+      "title": "2.1.144/145: CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 in settings.json + --chrome freezes input for ~3.5 min at startup (macOS)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:44Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60829",
       "url": "https://github.com/anthropics/claude-code/issues/60829",
       "title": "[Bug] Claude outputs duplicate instructions and repeats text on terminal resize/scroll",
@@ -7373,6 +7244,43 @@
       "updated_at": "2026-06-28T01:27:58Z"
     },
     {
+      "upstream": "anthropics/claude-code#61172",
+      "url": "https://github.com/anthropics/claude-code/issues/61172",
+      "title": "[BUG] /clear inherits previous session name instead of resetting it, causing duplicate-named sessions in /resume",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:26:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61343",
+      "url": "https://github.com/anthropics/claude-code/issues/61343",
+      "title": "[BUG] Cowork sandbox: unlink(2) returns EPERM on owned files, breaks .git lock cleanup",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T16:29:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61388",
+      "url": "https://github.com/anthropics/claude-code/issues/61388",
+      "title": "Prior-turn agent commitments are silently dropped on operator task-shift unless explicitly re-anchored",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:09Z"
+    },
+    {
       "upstream": "anthropics/claude-code#61484",
       "url": "https://github.com/anthropics/claude-code/issues/61484",
       "title": "Feature request: add \"Copy selection\" to right-click menu",
@@ -7383,6 +7291,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T08:03:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61586",
+      "url": "https://github.com/anthropics/claude-code/issues/61586",
+      "title": "[FEATURE] Voice mode in VS Code on WSL",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:41Z"
     },
     {
       "upstream": "anthropics/claude-code#61682",
@@ -7437,32 +7359,42 @@
       "updated_at": "2026-06-28T09:29:03Z"
     },
     {
-      "upstream": "anthropics/claude-code#62119",
-      "url": "https://github.com/anthropics/claude-code/issues/62119",
-      "title": "[BUG] Personal repository not appearing in Claude Code repo picker",
+      "upstream": "anthropics/claude-code#62113",
+      "url": "https://github.com/anthropics/claude-code/issues/62113",
+      "title": "[BUG] Desktop SSH (Mac → Windows): shell mis-detected as 'posix' after update, breaks 'server --install' on PowerShell default shell",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
         "install",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T16:03:43Z"
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:17Z"
     },
     {
-      "upstream": "anthropics/claude-code#62141",
-      "url": "https://github.com/anthropics/claude-code/issues/62141",
-      "title": "Claude in Chrome: Browser extension not connected after Claude Code auto-update (Windows)",
+      "upstream": "anthropics/claude-code#62319",
+      "url": "https://github.com/anthropics/claude-code/issues/62319",
+      "title": "[BUG] form-mode MCP elicitation auto-declines in interactive TUI — server-initiated form is treated as \"print mode\"",
       "impact": "not_applicable",
       "categories": [
-        "ide",
-        "mcp",
-        "platform"
+        "terminal",
+        "mcp"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:22Z"
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:51:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62320",
+      "url": "https://github.com/anthropics/claude-code/issues/62320",
+      "title": "[BUG] Weird hieroglyphics showing up in terminal",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:54Z"
     },
     {
       "upstream": "anthropics/claude-code#62334",
@@ -7476,18 +7408,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T10:47:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#62423",
-      "url": "https://github.com/anthropics/claude-code/issues/62423",
-      "title": "[BUG] Claude Code uses legacy XTMODKEYS even when terminal advertises the kitty keyboard protocol",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:01:01Z"
     },
     {
       "upstream": "anthropics/claude-code#62458",
@@ -7578,6 +7498,22 @@
       "updated_at": "2026-06-27T22:25:17Z"
     },
     {
+      "upstream": "anthropics/claude-code#62718",
+      "url": "https://github.com/anthropics/claude-code/issues/62718",
+      "title": "[BUG] Multi-root workspace: agent-emitted file links unclickable outside primary folder",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:08:49Z"
+    },
+    {
       "upstream": "anthropics/claude-code#62743",
       "url": "https://github.com/anthropics/claude-code/issues/62743",
       "title": "[BUG] Network Sandbox in WSL intermittent failures",
@@ -7605,20 +7541,6 @@
       "updated_at": "2026-06-27T10:42:02Z"
     },
     {
-      "upstream": "anthropics/claude-code#62844",
-      "url": "https://github.com/anthropics/claude-code/issues/62844",
-      "title": "MCP tools/list_changed notifications not honored in headless --print --output-format stream-json mode",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T16:16:21Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63092",
       "url": "https://github.com/anthropics/claude-code/issues/63092",
       "title": "[BUG] Pressing 'Escape' doesn't close the /BTW conversation when the main conversation is asking for approval",
@@ -7631,6 +7553,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T22:25:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63100",
+      "url": "https://github.com/anthropics/claude-code/issues/63100",
+      "title": "[BUG] Claude Code's Bash execution waits forever with no processes running",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:38Z"
     },
     {
       "upstream": "anthropics/claude-code#63308",
@@ -7657,18 +7593,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, slash_hook, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T22:24:45Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63433",
-      "url": "https://github.com/anthropics/claude-code/issues/63433",
-      "title": "[Feature Request] Auto theme mode should dynamically follow system appearance changes",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:12Z"
     },
     {
       "upstream": "anthropics/claude-code#63458",
@@ -7742,7 +7666,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T10:58:12Z"
+      "updated_at": "2026-06-29T13:08:21Z"
     },
     {
       "upstream": "anthropics/claude-code#63925",
@@ -7755,7 +7679,20 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T10:47:18Z"
+      "updated_at": "2026-06-29T18:34:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63974",
+      "url": "https://github.com/anthropics/claude-code/issues/63974",
+      "title": "[Feature Request] Add `disabledSlashCommands` setting to selectively suppress built-in slash commands",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:50:32Z"
     },
     {
       "upstream": "anthropics/claude-code#64001",
@@ -7771,6 +7708,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T10:46:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64061",
+      "url": "https://github.com/anthropics/claude-code/issues/64061",
+      "title": "VS Code extension ignores sandbox settings.json / /sandbox unavailable (approval-fatigue fix unreachable in IDE)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-30T00:00:23Z"
     },
     {
       "upstream": "anthropics/claude-code#64108",
@@ -7807,6 +7758,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T17:16:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64239",
+      "url": "https://github.com/anthropics/claude-code/issues/64239",
+      "title": "[BUG] typescript-lsp pushes stale diagnostics on 2.1.158 (post-#17979) in TS project-references/composite workspaces",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T16:51:00Z"
     },
     {
       "upstream": "anthropics/claude-code#64248",
@@ -7846,6 +7810,34 @@
       "updated_at": "2026-06-27T22:25:02Z"
     },
     {
+      "upstream": "anthropics/claude-code#64271",
+      "url": "https://github.com/anthropics/claude-code/issues/64271",
+      "title": "`claude --bg` code-writing sessions stall on permission prompts with no non-interactive way to reply (acceptEdits insufficient)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64272",
+      "url": "https://github.com/anthropics/claude-code/issues/64272",
+      "title": "Docs: clarify that `claude --bg` / background dispatch sessions do not carry `agent_id` in hook payloads",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:46Z"
+    },
+    {
       "upstream": "anthropics/claude-code#64301",
       "url": "https://github.com/anthropics/claude-code/issues/64301",
       "title": "Bash sandbox (bubblewrap) corrupts `!` to `\\!` in commands, making the sandbox unusable for agentic workflows",
@@ -7857,19 +7849,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-29T03:34:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64334",
-      "url": "https://github.com/anthropics/claude-code/issues/64334",
-      "title": "Bash command with 2>&1 causes ~12min spinner hang with token usage climbing during the stall",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:13Z"
     },
     {
       "upstream": "anthropics/claude-code#64365",
@@ -7923,17 +7902,17 @@
       "updated_at": "2026-06-28T10:46:59Z"
     },
     {
-      "upstream": "anthropics/claude-code#64779",
-      "url": "https://github.com/anthropics/claude-code/issues/64779",
-      "title": "Connect claude.ai Projects to Claude Code (VS Code / CLI)",
+      "upstream": "anthropics/claude-code#64799",
+      "url": "https://github.com/anthropics/claude-code/issues/64799",
+      "title": "[BUG] bwrap sandbox broken on merged-usr systems (Arch): \"Can't mount tmpfs on /newroot/lib64\" — enableWeakerNestedSandbox does not fix it, MCP servers fail to start",
       "impact": "not_applicable",
       "categories": [
-        "ide",
-        "terminal"
+        "terminal",
+        "mcp"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T23:12:59Z"
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T12:33:05Z"
     },
     {
       "upstream": "anthropics/claude-code#64817",
@@ -7946,6 +7925,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T22:25:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64883",
+      "url": "https://github.com/anthropics/claude-code/issues/64883",
+      "title": "[BUG][Desktop][macOS 26] Code tab kills entire app — rootfs.img redownload loop (disk-write jetsam); crashes even with all connectors disabled",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:38Z"
     },
     {
       "upstream": "anthropics/claude-code#64889",
@@ -7973,30 +7965,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T16:47:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64948",
-      "url": "https://github.com/anthropics/claude-code/issues/64948",
-      "title": "[Feature Request] Disable automatic branch creation for Claude Code operations",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64975",
-      "url": "https://github.com/anthropics/claude-code/issues/64975",
-      "title": "Confirm-exit or Ctrl+C debounce to prevent accidental session loss",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T17:55:30Z"
     },
     {
       "upstream": "anthropics/claude-code#64990",
@@ -8036,6 +8004,18 @@
       "updated_at": "2026-06-28T10:47:18Z"
     },
     {
+      "upstream": "anthropics/claude-code#65080",
+      "url": "https://github.com/anthropics/claude-code/issues/65080",
+      "title": "You've hit your session limit · resets 12pm (America/Los_Angeles)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:52Z"
+    },
+    {
       "upstream": "anthropics/claude-code#65114",
       "url": "https://github.com/anthropics/claude-code/issues/65114",
       "title": "[FEATURE] Cowork: give users a manual /compact (user-initiated compaction)",
@@ -8048,21 +8028,30 @@
       "updated_at": "2026-06-28T01:06:18Z"
     },
     {
-      "upstream": "anthropics/claude-code#65355",
-      "url": "https://github.com/anthropics/claude-code/issues/65355",
-      "title": "[BUG] Claude for Windows (desktop): built-in /create-pr (GitHub) runs instead of project custom command; terminal & VS Code work correctly",
+      "upstream": "anthropics/claude-code#65150",
+      "url": "https://github.com/anthropics/claude-code/issues/65150",
+      "title": "Claude Code requires 1M context credits for standard agentic tasks on Pro plan",
       "impact": "not_applicable",
       "categories": [
-        "ide",
         "terminal",
-        "plugin",
-        "slash_hook",
-        "install",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T12:26:00Z"
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65229",
+      "url": "https://github.com/anthropics/claude-code/issues/65229",
+      "title": "[BUG] Edit tool silently destroys some files in OneDrive-synced folders via non-deterministic delete-then-rename race (Windows)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:08Z"
     },
     {
       "upstream": "anthropics/claude-code#65367",
@@ -8077,29 +8066,18 @@
       "updated_at": "2026-06-27T22:25:06Z"
     },
     {
-      "upstream": "anthropics/claude-code#65383",
-      "url": "https://github.com/anthropics/claude-code/issues/65383",
-      "title": "[BUG] Claude is blocked from executing sleep commands",
+      "upstream": "anthropics/claude-code#65396",
+      "url": "https://github.com/anthropics/claude-code/issues/65396",
+      "title": "Add a setting to hide the usage-limit warning banner in the chat UI",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
+        "ide",
+        "slash_hook",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65399",
-      "url": "https://github.com/anthropics/claude-code/issues/65399",
-      "title": "Cannot remove/change primary working directory, and stale folder paths are unrecoverable",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T10:28:30Z"
+      "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T21:13:51Z"
     },
     {
       "upstream": "anthropics/claude-code#65437",
@@ -8154,134 +8132,6 @@
       "updated_at": "2026-06-27T22:25:21Z"
     },
     {
-      "upstream": "anthropics/claude-code#65519",
-      "url": "https://github.com/anthropics/claude-code/issues/65519",
-      "title": "[BUG][Windows] Korean Hangul jamo do not compose while typing in CLI input (raw-mode TUI bypasses IME)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:03:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65530",
-      "url": "https://github.com/anthropics/claude-code/issues/65530",
-      "title": "[Bug] Code block highlighting renders as per-line ribbons instead of continuous rectangle on macOS",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:03:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65538",
-      "url": "https://github.com/anthropics/claude-code/issues/65538",
-      "title": "[Bug] Custom skills not recognized in .claude/skills directory",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:03:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65539",
-      "url": "https://github.com/anthropics/claude-code/issues/65539",
-      "title": "Auto-save session summary when context limit is reached",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:04:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65541",
-      "url": "https://github.com/anthropics/claude-code/issues/65541",
-      "title": "[Bug] Anthropic API Error: Request blocked by cyber-related safeguards policy",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:03:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65542",
-      "url": "https://github.com/anthropics/claude-code/issues/65542",
-      "title": "[VS Code] open?session= URI does not focus an already-open session - opens a fresh conversation (busy) or a duplicate view (idle)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:03:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65544",
-      "url": "https://github.com/anthropics/claude-code/issues/65544",
-      "title": "[BUG] [Windows] Cowork crashes: HostLoop forces CLAUDE_CODE_GIT_BASH_PATH=%COMSPEC% (cmd.exe), overriding env/PATH/settings",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:03:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65547",
-      "url": "https://github.com/anthropics/claude-code/issues/65547",
-      "title": "[Bug] Claude Code CLI performance degradation - slow response times",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:28:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65548",
-      "url": "https://github.com/anthropics/claude-code/issues/65548",
-      "title": "[VSCode Extension] Markdown links to files with non-ASCII (e.g. Japanese) filenames fail silently to open",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:28:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65549",
-      "url": "https://github.com/anthropics/claude-code/issues/65549",
-      "title": "[Feature Request] Allow read-only access to Code tab conversation history after subscription expires",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:28:49Z"
-    },
-    {
       "upstream": "anthropics/claude-code#65554",
       "url": "https://github.com/anthropics/claude-code/issues/65554",
       "title": "`/desktop` session transfer drops the EnterWorktree working directory — Desktop resumes in the main checkout (wrong branch), no mismatch warning",
@@ -8294,84 +8144,6 @@
       "updated_at": "2026-06-28T10:46:52Z"
     },
     {
-      "upstream": "anthropics/claude-code#65567",
-      "url": "https://github.com/anthropics/claude-code/issues/65567",
-      "title": "[BUG] Built-in Workflow tool description (~4k tokens) is injected as conversation content every turn, with no way to disable it",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65568",
-      "url": "https://github.com/anthropics/claude-code/issues/65568",
-      "title": "Official marketplace fails schema validation on CLI 2.1.163 (git-subdir source type)",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65575",
-      "url": "https://github.com/anthropics/claude-code/issues/65575",
-      "title": "[BUG] Edit staleness check fires after own git commit when pre-commit formatter touches unrelated lines",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65576",
-      "url": "https://github.com/anthropics/claude-code/issues/65576",
-      "title": "[BUG] CronCreate: recurring ticks queue during busy REPL turns, then flush as duplicates on idle",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65583",
-      "url": "https://github.com/anthropics/claude-code/issues/65583",
-      "title": "[Bug] Task auto-completion displays unexpected output tokens in message",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:14Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65585",
-      "url": "https://github.com/anthropics/claude-code/issues/65585",
-      "title": "Auto-compact stopped working for third-party API providers since v2.1.161",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T03:06:08Z"
-    },
-    {
       "upstream": "anthropics/claude-code#65590",
       "url": "https://github.com/anthropics/claude-code/issues/65590",
       "title": "[FEATURE] Session Teams (Make structured sessions and sessions can comunicate each others interactively)",
@@ -8382,30 +8154,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T22:25:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65598",
-      "url": "https://github.com/anthropics/claude-code/issues/65598",
-      "title": "feat: support effort level in agent definition frontmatter",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65599",
-      "url": "https://github.com/anthropics/claude-code/issues/65599",
-      "title": "[FEATURE] Setting to change claude code header design (unreadable)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:20Z"
     },
     {
       "upstream": "anthropics/claude-code#65602",
@@ -8421,48 +8169,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T10:46:57Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65604",
-      "url": "https://github.com/anthropics/claude-code/issues/65604",
-      "title": "[BUG] The unminimizable update/install popup is user-hostile garbage — fix it or give us a workaround",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65605",
-      "url": "https://github.com/anthropics/claude-code/issues/65605",
-      "title": "[BUG] Cowork tab shows \"Virtualization not enabled\" false positive warning — Cowork works fully despite the error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65608",
-      "url": "https://github.com/anthropics/claude-code/issues/65608",
-      "title": "\"Allow once\" on the Workflow usage warning persists skipWorkflowUsageWarning, silently disabling it",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:29:21Z"
     },
     {
       "upstream": "anthropics/claude-code#65613",
@@ -8886,6 +8592,18 @@
       "updated_at": "2026-06-27T22:25:15Z"
     },
     {
+      "upstream": "anthropics/claude-code#65725",
+      "url": "https://github.com/anthropics/claude-code/issues/65725",
+      "title": "[BUG] \"claude auth status\" says logged in but \"claude\" wants to login again",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:15Z"
+    },
+    {
       "upstream": "anthropics/claude-code#65727",
       "url": "https://github.com/anthropics/claude-code/issues/65727",
       "title": "[Bug] Anthropic API Error: Usage Policy Violation Without Clear Cause",
@@ -8921,6 +8639,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T22:25:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65736",
+      "url": "https://github.com/anthropics/claude-code/issues/65736",
+      "title": "[Bug] Rating prompt triggers in fork subagents and deadlocks them",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:58Z"
     },
     {
       "upstream": "anthropics/claude-code#65739",
@@ -9115,6 +8846,19 @@
       "updated_at": "2026-06-27T22:25:31Z"
     },
     {
+      "upstream": "anthropics/claude-code#65792",
+      "url": "https://github.com/anthropics/claude-code/issues/65792",
+      "title": "Show context-window usage (%) per agent in the background agents list / FleetView",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:54Z"
+    },
+    {
       "upstream": "anthropics/claude-code#65797",
       "url": "https://github.com/anthropics/claude-code/issues/65797",
       "title": "[BUG] Allow partial globs in permissions.allow for MCP tools (regression 2.1.166+)",
@@ -9138,6 +8882,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T22:25:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65799",
+      "url": "https://github.com/anthropics/claude-code/issues/65799",
+      "title": "[BUG] NVDA review cursor forcibly moved to edit box",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:53Z"
     },
     {
       "upstream": "anthropics/claude-code#65803",
@@ -9207,6 +8965,19 @@
       "updated_at": "2026-06-28T10:46:55Z"
     },
     {
+      "upstream": "anthropics/claude-code#65820",
+      "url": "https://github.com/anthropics/claude-code/issues/65820",
+      "title": "Desktop app (macOS): turn timer + pulsing logo keep counting after response completes (still occurring on 2.1.160; ref #48170)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:51Z"
+    },
+    {
       "upstream": "anthropics/claude-code#65822",
       "url": "https://github.com/anthropics/claude-code/issues/65822",
       "title": "[BUG] limit reached",
@@ -9269,7 +9040,19 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-29T09:54:40Z"
+      "updated_at": "2026-06-29T20:03:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65835",
+      "url": "https://github.com/anthropics/claude-code/issues/65835",
+      "title": "[Bug] False trust/safety flagging triggered across multiple sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:35Z"
     },
     {
       "upstream": "anthropics/claude-code#65836",
@@ -9442,6 +9225,18 @@
       "updated_at": "2026-06-28T10:47:15Z"
     },
     {
+      "upstream": "anthropics/claude-code#65864",
+      "url": "https://github.com/anthropics/claude-code/issues/65864",
+      "title": "Trust dialog reappears every session — `hasTrustDialogAccepted` not persisted on `/exit`",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:43Z"
+    },
+    {
       "upstream": "anthropics/claude-code#65874",
       "url": "https://github.com/anthropics/claude-code/issues/65874",
       "title": "[BUG] Version: 2.1.14 Stop hook fires →",
@@ -9467,6 +9262,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T10:47:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65887",
+      "url": "https://github.com/anthropics/claude-code/issues/65887",
+      "title": "[BUG] CoworkVMService stops between sessions and cannot be restarted by the app",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:17Z"
     },
     {
       "upstream": "anthropics/claude-code#65888",
@@ -9517,6 +9326,19 @@
       "updated_at": "2026-06-28T10:47:24Z"
     },
     {
+      "upstream": "anthropics/claude-code#65901",
+      "url": "https://github.com/anthropics/claude-code/issues/65901",
+      "title": "[BUG] Predictive text/ghost text jumbles input in Claude Code",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:48Z"
+    },
+    {
       "upstream": "anthropics/claude-code#65904",
       "url": "https://github.com/anthropics/claude-code/issues/65904",
       "title": "[FEATURE] ESC while scrolling history should return to prompt, not interrupt processing",
@@ -9553,6 +9375,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T22:24:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65925",
+      "url": "https://github.com/anthropics/claude-code/issues/65925",
+      "title": "[BUG] Background Agent tasks persist as \"running\" in /workflows after full process restart on both dispatch and viewing hosts",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:54Z"
     },
     {
       "upstream": "anthropics/claude-code#65927",
@@ -9594,6 +9430,18 @@
       "updated_at": "2026-06-28T22:24:51Z"
     },
     {
+      "upstream": "anthropics/claude-code#65933",
+      "url": "https://github.com/anthropics/claude-code/issues/65933",
+      "title": "[BUG] 2.1.167 hides trailing whitespaces",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:34Z"
+    },
+    {
       "upstream": "anthropics/claude-code#65941",
       "url": "https://github.com/anthropics/claude-code/issues/65941",
       "title": "[Bug] Tool call parsing failed - unable to parse model response",
@@ -9616,6 +9464,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T22:24:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65946",
+      "url": "https://github.com/anthropics/claude-code/issues/65946",
+      "title": "[Bug] iOS companion app hangs after context compaction due to missing re-sync event",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:31Z"
     },
     {
       "upstream": "anthropics/claude-code#65947",
@@ -9735,6 +9595,266 @@
       "updated_at": "2026-06-28T22:25:10Z"
     },
     {
+      "upstream": "anthropics/claude-code#65976",
+      "url": "https://github.com/anthropics/claude-code/issues/65976",
+      "title": "[Bug] Auto mode still prompts for confirmation on git operations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65979",
+      "url": "https://github.com/anthropics/claude-code/issues/65979",
+      "title": "[FEATURE] PreUserMessage hook — intercept prompt before context is loaded into model",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65981",
+      "url": "https://github.com/anthropics/claude-code/issues/65981",
+      "title": "VS Code extension ignores settings.json allow list and bypassPermissions for UNC network path file edits",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65986",
+      "url": "https://github.com/anthropics/claude-code/issues/65986",
+      "title": "Usage stats show token consumption during period when laptop was fully powered off",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65988",
+      "url": "https://github.com/anthropics/claude-code/issues/65988",
+      "title": "[Bug] Cursor focus lost in text input field",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65991",
+      "url": "https://github.com/anthropics/claude-code/issues/65991",
+      "title": "[BUG] Unable to continue after Claude Code acknowledge desired interrupt",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65993",
+      "url": "https://github.com/anthropics/claude-code/issues/65993",
+      "title": "[FEATURE] claude agents dispatch input: @ should also autocomplete file paths, not only repos/subagents",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65994",
+      "url": "https://github.com/anthropics/claude-code/issues/65994",
+      "title": "[BUG] Claude Cowork - Surfacing 1M context Bug and forcing to charge money",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65996",
+      "url": "https://github.com/anthropics/claude-code/issues/65996",
+      "title": "/desktop fails on Windows: deep-link URL split on ampersand by cmd.exe",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66012",
+      "url": "https://github.com/anthropics/claude-code/issues/66012",
+      "title": "[FEATURE] Themeable selected-row highlight for /config & interactive option-list menus (low-vision a11y)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66013",
+      "url": "https://github.com/anthropics/claude-code/issues/66013",
+      "title": "DECSTBM scroll-region experiment (tengu_marlin_porch) corrupts inline TUI on wide panes / multi-line statuslines",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66017",
+      "url": "https://github.com/anthropics/claude-code/issues/66017",
+      "title": "[BUG] Windows: MSIX updates leave orphaned package versions; Deleted-folder cleanup fails with ERROR_OPLOCK_NOT_GRANTED (0x12C), blocking all installs with 0x80073CF6",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66024",
+      "url": "https://github.com/anthropics/claude-code/issues/66024",
+      "title": "[BUG] Claude Code app does not send image only upload over to Cloud Code local session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66028",
+      "url": "https://github.com/anthropics/claude-code/issues/66028",
+      "title": "[Bug] API Safety Filters Blocking Legitimate Biology Requests on Paid Plan",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66032",
+      "url": "https://github.com/anthropics/claude-code/issues/66032",
+      "title": "[FEATURE] Make Workflow scripts (.claude/workflows/*.js) a distributable plugin component",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66035",
+      "url": "https://github.com/anthropics/claude-code/issues/66035",
+      "title": "IDE 세션 초기화 시 불필요한 컨텍스트 재로드로 토큰 낭비",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66038",
+      "url": "https://github.com/anthropics/claude-code/issues/66038",
+      "title": "[Bug] Excessive token consumption during code review phase",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66047",
+      "url": "https://github.com/anthropics/claude-code/issues/66047",
+      "title": "[FEATURE] Use a unique color code for the 'Auto Mode' feature",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66048",
+      "url": "https://github.com/anthropics/claude-code/issues/66048",
+      "title": "[Feature Request] Add cost limit configuration to prevent unattended runs from exceeding budget",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66054",
+      "url": "https://github.com/anthropics/claude-code/issues/66054",
+      "title": "Claude Code repeatedly claims work is done without verifying, wastes hours on broken WebGL",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:56Z"
+    },
+    {
       "upstream": "anthropics/claude-code#66056",
       "url": "https://github.com/anthropics/claude-code/issues/66056",
       "title": "Right-click paste broken since ~2.1.167: mouse reporting captures right-click, requires Shift+right-click workaround",
@@ -9745,6 +9865,285 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T18:03:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66058",
+      "url": "https://github.com/anthropics/claude-code/issues/66058",
+      "title": "[BUG] Edit tool corrupts literal escape sequences",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66060",
+      "url": "https://github.com/anthropics/claude-code/issues/66060",
+      "title": "Feature Request: Option to disable auto-stash on session crash/teleport",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66061",
+      "url": "https://github.com/anthropics/claude-code/issues/66061",
+      "title": "[FEATURE] Custom groups in the CLI agents view, like the desktop app",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66062",
+      "url": "https://github.com/anthropics/claude-code/issues/66062",
+      "title": "[Bug] AUP false positive blocking transcription of historical fiction text",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66065",
+      "url": "https://github.com/anthropics/claude-code/issues/66065",
+      "title": "[BUG] Corruption happens to Unicode English during `/copy` resulting in mojibake (yet, `/export` works fine)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66066",
+      "url": "https://github.com/anthropics/claude-code/issues/66066",
+      "title": "[BUG] Persistent massive token drain on Max 20x Plan (Weekly limit exhausting in 1 day)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:42:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66068",
+      "url": "https://github.com/anthropics/claude-code/issues/66068",
+      "title": "UI: Toolbar icons overlap/crowd in top-left of welcome/stats screen",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66069",
+      "url": "https://github.com/anthropics/claude-code/issues/66069",
+      "title": "git commit bypasses commit-msg hook (likely --no-verify)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66070",
+      "url": "https://github.com/anthropics/claude-code/issues/66070",
+      "title": "[BUG] .NET runtime error when creating scheduled task",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66072",
+      "url": "https://github.com/anthropics/claude-code/issues/66072",
+      "title": "[Bug] Database seed fails mid-execution, leaving development database in incomplete state",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66078",
+      "url": "https://github.com/anthropics/claude-code/issues/66078",
+      "title": "BUG] Desktop app loses access to past sessions and local project directories after updates",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66081",
+      "url": "https://github.com/anthropics/claude-code/issues/66081",
+      "title": "[BUG] RADIO non working",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66084",
+      "url": "https://github.com/anthropics/claude-code/issues/66084",
+      "title": "[BUG] tools/list_changed doesn't refresh the deferred-tool / ToolSearch index in interactive sessions (still repros on 2.1.165; carve-out from #4118 / #60626)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66085",
+      "url": "https://github.com/anthropics/claude-code/issues/66085",
+      "title": "[BUG] Failed auto-update download leaks multiple GB per process → concurrent native sessions OOM the host (macOS arm64, 2.1.165 fetching 2.1.168)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66086",
+      "url": "https://github.com/anthropics/claude-code/issues/66086",
+      "title": "AskUserQuestion silently auto-answers (picks option 1) in acceptEdits mode — still broken in v2.1.167 after #29618 closed NOT_PLANNED",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66087",
+      "url": "https://github.com/anthropics/claude-code/issues/66087",
+      "title": "[BUG] VS Code extension: \"The user modified your proposed changes\" notification never appears",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66088",
+      "url": "https://github.com/anthropics/claude-code/issues/66088",
+      "title": "Workflow tool: structured return value not retrievable after completion notification truncates it",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66090",
+      "url": "https://github.com/anthropics/claude-code/issues/66090",
+      "title": "[Bug] ECONNRESET errors with VPN connections to Anthropic API",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66091",
+      "url": "https://github.com/anthropics/claude-code/issues/66091",
+      "title": "WebSocket reconnect corrupts readline input buffer in iTerm2",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66092",
+      "url": "https://github.com/anthropics/claude-code/issues/66092",
+      "title": "Auto-stash on branch switch uses --include-untracked, silently sweeping untracked files (appear deleted)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66097",
+      "url": "https://github.com/anthropics/claude-code/issues/66097",
+      "title": "[FEATURE] Monitor CI: keep auto-fix but make auto-replying to / resolving review threads opt-out",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66100",
+      "url": "https://github.com/anthropics/claude-code/issues/66100",
+      "title": "[BUG] VS Code extension /model does not change the active model when ANTHROPIC_MODEL is set (v2.1.168)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:25:59Z"
     },
     {
       "upstream": "anthropics/claude-code#66101",
@@ -9760,6 +10159,44 @@
       "updated_at": "2026-06-27T11:10:41Z"
     },
     {
+      "upstream": "anthropics/claude-code#66102",
+      "url": "https://github.com/anthropics/claude-code/issues/66102",
+      "title": "[Bug] Auto-update failed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66107",
+      "url": "https://github.com/anthropics/claude-code/issues/66107",
+      "title": "[BUG] LE BIG BAZAR DEPUIS UN IPHONE",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66116",
+      "url": "https://github.com/anthropics/claude-code/issues/66116",
+      "title": "[BUG] Bun bus error (0xBAD4007) on clipboard image paste — macOS arm64, Claude Code 2.1.168",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:02Z"
+    },
+    {
       "upstream": "anthropics/claude-code#66117",
       "url": "https://github.com/anthropics/claude-code/issues/66117",
       "title": "Add option to disable prompt suggestions in Claude.ai web/app interface",
@@ -9770,6 +10207,200 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T16:04:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66118",
+      "url": "https://github.com/anthropics/claude-code/issues/66118",
+      "title": "[Bug] Socket connection closed unexpectedly during API request",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66121",
+      "url": "https://github.com/anthropics/claude-code/issues/66121",
+      "title": "[BUG] `codex_sandbox` firewall rules cause intermittent ECONNRESET in VS Code extension (Windows)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66133",
+      "url": "https://github.com/anthropics/claude-code/issues/66133",
+      "title": "[BUG] VSCode plan-review: comment panel overflows viewport with no internal scroll, hiding Submit/prompt (zoom-out is the only workaround)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66135",
+      "url": "https://github.com/anthropics/claude-code/issues/66135",
+      "title": "[BUG] Fix github action bot incorrectly closing feature and support request",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66137",
+      "url": "https://github.com/anthropics/claude-code/issues/66137",
+      "title": "/model command does not persist: Claude Code reverts to Sonnet 1M context (paid credits) despite selecting default Sonnet 4.6",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66138",
+      "url": "https://github.com/anthropics/claude-code/issues/66138",
+      "title": "[META] Cowork cluster — 2026-06 active sub-issues (extends closed #54891 / #54847)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66141",
+      "url": "https://github.com/anthropics/claude-code/issues/66141",
+      "title": "Oversized image (>2000px) poisons all later image processing in a session — misleading error + token waste",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66145",
+      "url": "https://github.com/anthropics/claude-code/issues/66145",
+      "title": "[BUG] SECURITY RISK FORCING USERS FOLDER FOR .CLAUDE",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66146",
+      "url": "https://github.com/anthropics/claude-code/issues/66146",
+      "title": "This appears to be positive feedback rather than a bug report or feature request. Since you're expressing satisfaction with Claude Code rather than reporting an issue, no GitHub issue title is needed. If you have specific feature suggestions or bugs to re",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66151",
+      "url": "https://github.com/anthropics/claude-code/issues/66151",
+      "title": "[BUG] Stop hook bash commands leave orphan child processes on Windows when parent dies abnormally",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66152",
+      "url": "https://github.com/anthropics/claude-code/issues/66152",
+      "title": "[Bug] Claude Code generates invalid Python 3.14 PEP 758 exception syntax and fails validation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66155",
+      "url": "https://github.com/anthropics/claude-code/issues/66155",
+      "title": "[BUG] claude code desktop app - \"no repos match\" error even when selecting default, and github is connected",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66156",
+      "url": "https://github.com/anthropics/claude-code/issues/66156",
+      "title": "[Bug] Auto-update failed - npm installation error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66157",
+      "url": "https://github.com/anthropics/claude-code/issues/66157",
+      "title": "[BUG] ⏺ The model's tool call could not be parsed (retry also failed).",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:26:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66192",
+      "url": "https://github.com/anthropics/claude-code/issues/66192",
+      "title": "[BUG] Copy-paste does not work",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T12:14:48Z"
     },
     {
       "upstream": "anthropics/claude-code#66402",
@@ -9784,18 +10415,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T07:17:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#66504",
-      "url": "https://github.com/anthropics/claude-code/issues/66504",
-      "title": "[FEATURE] Session URL appended to commit messages and PR descriptions by default — should be opt-in",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:35:01Z"
     },
     {
       "upstream": "anthropics/claude-code#66534",
@@ -9821,7 +10440,20 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T20:05:29Z"
+      "updated_at": "2026-06-29T15:36:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#67141",
+      "url": "https://github.com/anthropics/claude-code/issues/67141",
+      "title": "[BUG] cmd+delete and option+delete no longer work in chat input (regression)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T16:34:13Z"
     },
     {
       "upstream": "anthropics/claude-code#67220",
@@ -9851,16 +10483,29 @@
       "updated_at": "2026-06-28T02:30:34Z"
     },
     {
-      "upstream": "anthropics/claude-code#67540",
-      "url": "https://github.com/anthropics/claude-code/issues/67540",
-      "title": "Code Review: claude[bot] reacts with 👀 but no check run is created (managed integration)",
+      "upstream": "anthropics/claude-code#67522",
+      "url": "https://github.com/anthropics/claude-code/issues/67522",
+      "title": "[BUG] Desktop app (macOS): Cmd+V starts a new session instead of pasting with German Neo 2 keyboard layout",
       "impact": "not_applicable",
       "categories": [
-        "install"
+        "terminal",
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:27:54Z"
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:26:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#67567",
+      "url": "https://github.com/anthropics/claude-code/issues/67567",
+      "title": "[BUG] \"Type something\" accepts only a very short piece of text before I can't see what I'm typing",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:15:00Z"
     },
     {
       "upstream": "anthropics/claude-code#67938",
@@ -9889,18 +10534,6 @@
       "updated_at": "2026-06-28T16:07:42Z"
     },
     {
-      "upstream": "anthropics/claude-code#68077",
-      "url": "https://github.com/anthropics/claude-code/issues/68077",
-      "title": "[BUG] The GitHub Actions integration on this repo closes threads as \"stale\" without warning",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T16:18:35Z"
-    },
-    {
       "upstream": "anthropics/claude-code#68089",
       "url": "https://github.com/anthropics/claude-code/issues/68089",
       "title": "[Bug] `/status` command Config output does not match documentation regarding configuration layers and settings display (re-opening)",
@@ -9912,30 +10545,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T18:56:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#68102",
-      "url": "https://github.com/anthropics/claude-code/issues/68102",
-      "title": "Remote Control: built-in slash commands (/clear, /context) not intercepted — delivered to the model as plain text",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:25:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#68287",
-      "url": "https://github.com/anthropics/claude-code/issues/68287",
-      "title": "[BUG] Max plan: Opus 4.8 only shows 256k context, 1M option missing in model picker",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T00:31:30Z"
     },
     {
       "upstream": "anthropics/claude-code#68364",
@@ -9953,58 +10562,17 @@
       "updated_at": "2026-06-28T19:57:41Z"
     },
     {
-      "upstream": "anthropics/claude-code#68367",
-      "url": "https://github.com/anthropics/claude-code/issues/68367",
-      "title": "[BUG] Model fabricates subsequent user/system turns inside one assistant message, then acts on its own fabrication",
+      "upstream": "anthropics/claude-code#68587",
+      "url": "https://github.com/anthropics/claude-code/issues/68587",
+      "title": "sandbox.enabled: true triggers a synchronous full-tree directory walk on startup → multi-minute hang in large workspaces",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T14:48:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#68395",
-      "url": "https://github.com/anthropics/claude-code/issues/68395",
-      "title": "Add setting to disable auto-opening file/diff tabs in VS Code extension",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T02:52:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#68522",
-      "url": "https://github.com/anthropics/claude-code/issues/68522",
-      "title": "Custom model via ANTHROPIC_BASE_URL: no way to declare a context window >200k (status line & auto-compaction assume 200k)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T14:29:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#68545",
-      "url": "https://github.com/anthropics/claude-code/issues/68545",
-      "title": "Subagent returns prompt-injection-shaped output with 0 tool uses (general-purpose, model: opus), localized to one long-running session",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
         "plugin",
-        "slash_hook"
+        "install"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T17:56:11Z"
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:37:04Z"
     },
     {
       "upstream": "anthropics/claude-code#68625",
@@ -10029,7 +10597,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T20:22:33Z"
+      "updated_at": "2026-06-29T11:59:05Z"
     },
     {
       "upstream": "anthropics/claude-code#68809",
@@ -10045,43 +10613,31 @@
       "updated_at": "2026-06-27T10:04:02Z"
     },
     {
-      "upstream": "anthropics/claude-code#69109",
-      "url": "https://github.com/anthropics/claude-code/issues/69109",
-      "title": "[FEATURE] Opus 4.8 (1M context) model option disappeared from the model picker",
-      "impact": "not_applicable",
-      "categories": [
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T00:31:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#69111",
-      "url": "https://github.com/anthropics/claude-code/issues/69111",
-      "title": "[BUG] mouse wheel scroll in IntelliJ on mac does not scroll conversation",
+      "upstream": "anthropics/claude-code#69272",
+      "url": "https://github.com/anthropics/claude-code/issues/69272",
+      "title": "[FEATURE] Add /fork (conversation branching) support to VS Code extension",
       "impact": "not_applicable",
       "categories": [
         "ide",
-        "terminal"
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T13:59:25Z"
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:50:46Z"
     },
     {
-      "upstream": "anthropics/claude-code#69276",
-      "url": "https://github.com/anthropics/claude-code/issues/69276",
-      "title": "[BUG] Installer fails due to claude.ai not providing proper setup data",
+      "upstream": "anthropics/claude-code#69411",
+      "url": "https://github.com/anthropics/claude-code/issues/69411",
+      "title": "[FEATURE] Expose the auto-generated session title to hooks/templates so it can be wrapped with a prefix and suffix",
       "impact": "not_applicable",
       "categories": [
         "terminal",
-        "install"
+        "slash_hook",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T13:09:13Z"
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:22:53Z"
     },
     {
       "upstream": "anthropics/claude-code#69415",
@@ -10095,7 +10651,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T10:12:00Z"
+      "updated_at": "2026-06-29T20:54:22Z"
     },
     {
       "upstream": "anthropics/claude-code#69428",
@@ -10108,20 +10664,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T21:49:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#69430",
-      "url": "https://github.com/anthropics/claude-code/issues/69430",
-      "title": "[BUG] Weekly Limit Jumped From ~50% to 100% in less than an hour of usage on Max20x Plan",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T14:58:46Z"
     },
     {
       "upstream": "anthropics/claude-code#69542",
@@ -10151,17 +10693,18 @@
       "updated_at": "2026-06-28T10:05:23Z"
     },
     {
-      "upstream": "anthropics/claude-code#69750",
-      "url": "https://github.com/anthropics/claude-code/issues/69750",
-      "title": "Session lifecycle hooks: proactive Claude response on start + pre-exit turns",
+      "upstream": "anthropics/claude-code#69641",
+      "url": "https://github.com/anthropics/claude-code/issues/69641",
+      "title": "[BUG] Desktop SSH remote BinaryDeployment deploys linux-x64-musl to a glibc WSL2 host; fails \"not runnable\" / statx: symbol not found",
       "impact": "not_applicable",
       "categories": [
         "terminal",
-        "slash_hook"
+        "install",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T20:24:31Z"
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:48:58Z"
     },
     {
       "upstream": "anthropics/claude-code#69792",
@@ -10173,7 +10716,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T23:25:41Z"
+      "updated_at": "2026-06-29T12:23:34Z"
     },
     {
       "upstream": "anthropics/claude-code#69829",
@@ -10186,7 +10729,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T18:30:36Z"
+      "updated_at": "2026-06-29T21:50:00Z"
     },
     {
       "upstream": "anthropics/claude-code#69836",
@@ -10250,35 +10793,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-29T07:25:45Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#70463",
-      "url": "https://github.com/anthropics/claude-code/issues/70463",
-      "title": "[BUG] 5 hour usage limit reached - but I have not used Claude in over a day",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:09:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#70497",
-      "url": "https://github.com/anthropics/claude-code/issues/70497",
-      "title": "VS Code extension runs statusLine (never rendered in IDE) -> focus/panel-reveal war across multiple chat sessions in one window (Windows)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T02:52:43Z"
+      "updated_at": "2026-06-29T22:16:29Z"
     },
     {
       "upstream": "anthropics/claude-code#70539",
@@ -10291,6 +10806,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-29T09:26:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#70558",
+      "url": "https://github.com/anthropics/claude-code/issues/70558",
+      "title": "connect issue",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:24:43Z"
     },
     {
       "upstream": "anthropics/claude-code#70591",
@@ -10307,20 +10834,6 @@
       "updated_at": "2026-06-28T03:28:33Z"
     },
     {
-      "upstream": "anthropics/claude-code#70620",
-      "url": "https://github.com/anthropics/claude-code/issues/70620",
-      "title": "[BUG] Desktop app remote SSH install fails on Ubuntu 24.04 — \"installed cli ... is not runnable\"",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T16:37:39Z"
-    },
-    {
       "upstream": "anthropics/claude-code#70622",
       "url": "https://github.com/anthropics/claude-code/issues/70622",
       "title": "[Feature Request] Add option to disable clickable Yes/No prompts in terminal",
@@ -10331,7 +10844,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T02:40:42Z"
+      "updated_at": "2026-06-29T16:30:09Z"
     },
     {
       "upstream": "anthropics/claude-code#70650",
@@ -10357,18 +10870,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T23:14:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#70684",
-      "url": "https://github.com/anthropics/claude-code/issues/70684",
-      "title": "[BUG] sandbox: SOCKS5 proxy requires authentication that BSD nc cannot negotiate, breaking SSH git operations",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T23:30:15Z"
     },
     {
       "upstream": "anthropics/claude-code#70733",
@@ -10398,16 +10899,16 @@
       "updated_at": "2026-06-27T12:24:48Z"
     },
     {
-      "upstream": "anthropics/claude-code#70784",
-      "url": "https://github.com/anthropics/claude-code/issues/70784",
-      "title": "[Bug] Persistent API Response Timeout: Retry Loop Since June 22",
+      "upstream": "anthropics/claude-code#70857",
+      "url": "https://github.com/anthropics/claude-code/issues/70857",
+      "title": "Fullscreen (alternate-screen) mode breaks terminal copy — can't select/copy login URL",
       "impact": "not_applicable",
       "categories": [
         "terminal"
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T19:52:30Z"
+      "updated_at": "2026-06-29T21:37:28Z"
     },
     {
       "upstream": "anthropics/claude-code#70881",
@@ -10510,18 +11011,6 @@
       "updated_at": "2026-06-28T15:46:30Z"
     },
     {
-      "upstream": "anthropics/claude-code#71446",
-      "url": "https://github.com/anthropics/claude-code/issues/71446",
-      "title": "[BUG] Recently Opus feels like old sonnet, Sonnet is even worse",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T15:49:08Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71455",
       "url": "https://github.com/anthropics/claude-code/issues/71455",
       "title": "[BUG] [platform::intellij] Regression of #10813: 'Slow operations are prohibited on EDT' in DiagnosticTools.openVirtualFileFromPath (macOS, plugin 0.1.14-beta)",
@@ -10561,7 +11050,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:12:18Z"
+      "updated_at": "2026-06-29T21:38:36Z"
     },
     {
       "upstream": "anthropics/claude-code#71467",
@@ -10622,18 +11111,6 @@
       "updated_at": "2026-06-29T03:46:23Z"
     },
     {
-      "upstream": "anthropics/claude-code#71510",
-      "url": "https://github.com/anthropics/claude-code/issues/71510",
-      "title": "[Bug] Image references removed during JIRA description edits cause permanent screenshot loss",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:30:42Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71517",
       "url": "https://github.com/anthropics/claude-code/issues/71517",
       "title": "[BUG] out of credits in 3 days, as a hobbyist.",
@@ -10646,18 +11123,6 @@
       "updated_at": "2026-06-27T06:32:15Z"
     },
     {
-      "upstream": "anthropics/claude-code#71539",
-      "url": "https://github.com/anthropics/claude-code/issues/71539",
-      "title": "[BUG] Mouse click to refocus terminal triggers permission prompt unintentionally",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:22:33Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71542",
       "url": "https://github.com/anthropics/claude-code/issues/71542",
       "title": "GitHub connector links repositories successfully but Claude cannot access content for ANY repository (account-wide, public and private alike) — recent regression",
@@ -10668,7 +11133,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T18:52:37Z"
+      "updated_at": "2026-06-29T14:25:38Z"
     },
     {
       "upstream": "anthropics/claude-code#71551",
@@ -10685,30 +11150,6 @@
       "updated_at": "2026-06-28T16:06:51Z"
     },
     {
-      "upstream": "anthropics/claude-code#71555",
-      "url": "https://github.com/anthropics/claude-code/issues/71555",
-      "title": "[Bug] Overly broad cybersecurity content filter flags legitimate debugging tasks",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T14:24:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71557",
-      "url": "https://github.com/anthropics/claude-code/issues/71557",
-      "title": "vm_bundles grows to 9.3GB+ on initial download after v1.15962.0 update (June 25 2026) — freezes Intel Mac on Cowork open",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:59:50Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71562",
       "url": "https://github.com/anthropics/claude-code/issues/71562",
       "title": "[BUG] hasTrustDialogAccepted never persisted to ~/.claude.json despite repeated interactive sessions",
@@ -10719,32 +11160,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T03:42:25Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71564",
-      "url": "https://github.com/anthropics/claude-code/issues/71564",
-      "title": "[BUG][SECURITY] Tool results appear to be modified after execution with injected pseudo-\"system instructions\" repeatedly urging destructive `git push --force` (Cowork research preview, Windows)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T10:09:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71569",
-      "url": "https://github.com/anthropics/claude-code/issues/71569",
-      "title": "[Bug] Claude Code ignores user instructions and generates unintended code modifications",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T10:26:02Z"
     },
     {
       "upstream": "anthropics/claude-code#71570",
@@ -10759,179 +11174,6 @@
       "updated_at": "2026-06-28T15:48:21Z"
     },
     {
-      "upstream": "anthropics/claude-code#71571",
-      "url": "https://github.com/anthropics/claude-code/issues/71571",
-      "title": "[Bug] Anthropic API Error: Image in conversation could not be processed",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T10:36:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71573",
-      "url": "https://github.com/anthropics/claude-code/issues/71573",
-      "title": "[Bug] Enterprise login success message requires inconsistent key press to complete authentication",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T10:36:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71575",
-      "url": "https://github.com/anthropics/claude-code/issues/71575",
-      "title": "[Bug] Tool fails to apply API after multiple requests",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T10:46:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71576",
-      "url": "https://github.com/anthropics/claude-code/issues/71576",
-      "title": "[Bug] Claude Code ignoring explicit user instructions and autonomously executing actions without approval",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:27:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71579",
-      "url": "https://github.com/anthropics/claude-code/issues/71579",
-      "title": "[Bug] High error rate in task execution: 59 violations and 17 wrong deliveries 1 TASK",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:10:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71580",
-      "url": "https://github.com/anthropics/claude-code/issues/71580",
-      "title": "[BUG] Claude Code started calling me bro",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:11:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71582",
-      "url": "https://github.com/anthropics/claude-code/issues/71582",
-      "title": "[FEATURE] Claude Code Desktop: persistent status line (configurable), or at minimum always-visible context size",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:18:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71584",
-      "url": "https://github.com/anthropics/claude-code/issues/71584",
-      "title": "[BUG] Mobile app: slash commands & skills execute but don't autocomplete (works on Desktop)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:19:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71586",
-      "url": "https://github.com/anthropics/claude-code/issues/71586",
-      "title": "[Bug] Claude Code generates incorrect content instead of performing language corrections",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:29:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71587",
-      "url": "https://github.com/anthropics/claude-code/issues/71587",
-      "title": "[FEATURE] Desktop: session status should reflect background task activity, plus more/customizable statuses & colors",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T11:39:45Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71589",
-      "url": "https://github.com/anthropics/claude-code/issues/71589",
-      "title": "[Bug] Excessive token consumption in session - 42% usage in 40 minutes for standard PR review workflow",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:12:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71590",
-      "url": "https://github.com/anthropics/claude-code/issues/71590",
-      "title": "[Bug] Claude Code fails to follow explicit prompts and context for language tasks",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:25:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71592",
-      "url": "https://github.com/anthropics/claude-code/issues/71592",
-      "title": "[Bug] Claude Code fails to apply language corrections despite multiple iterations",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T19:06:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71593",
-      "url": "https://github.com/anthropics/claude-code/issues/71593",
-      "title": "[Bug] High task failure rate (82 failures) with basic operations",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T12:33:03Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71594",
       "url": "https://github.com/anthropics/claude-code/issues/71594",
       "title": "[BUG] Got a session limit issue without actually using it, hit the limit exactly at the start of the reset",
@@ -10944,91 +11186,6 @@
       "updated_at": "2026-06-28T15:36:46Z"
     },
     {
-      "upstream": "anthropics/claude-code#71595",
-      "url": "https://github.com/anthropics/claude-code/issues/71595",
-      "title": "[FEATURE] Desktop app: option to dock the terminal panel to the bottom",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T12:36:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71596",
-      "url": "https://github.com/anthropics/claude-code/issues/71596",
-      "title": "[Feature Request] Auto-populate package details from user account/session context",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T12:40:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71597",
-      "url": "https://github.com/anthropics/claude-code/issues/71597",
-      "title": "[BUG] Background sessions (Agent View) do not load MCP servers from ~/.claude/mcp.json",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T14:09:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71598",
-      "url": "https://github.com/anthropics/claude-code/issues/71598",
-      "title": "[BUG] Session shows as working (running timer + busy spinner + active work-tracker) while idle awaiting user input",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T13:14:25Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71601",
-      "url": "https://github.com/anthropics/claude-code/issues/71601",
-      "title": "[Bug] Documents not persisting on Finsetup server after signout",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T13:37:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71603",
-      "url": "https://github.com/anthropics/claude-code/issues/71603",
-      "title": "[BUG] Mobile (Pixel 8 Pro): input typed while the agent is busy stays as an unconfirmed draft and is silently discarded when the app is backgrounded",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T13:48:39Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71604",
-      "url": "https://github.com/anthropics/claude-code/issues/71604",
-      "title": "[BUG] Claude Desktop Preview For Static HTML Pages Opens file:// Instead of Live Server — CSS Styles Not Loading",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T14:02:13Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71605",
       "url": "https://github.com/anthropics/claude-code/issues/71605",
       "title": "[Mobile app – Remote Claude Code] Text box draft is lost + keyboard covers the Send button",
@@ -11038,31 +11195,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T14:00:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71606",
-      "url": "https://github.com/anthropics/claude-code/issues/71606",
-      "title": "[Feature Request] Improve API key provisioning workflow for enterprise security teams",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T14:09:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71607",
-      "url": "https://github.com/anthropics/claude-code/issues/71607",
-      "title": "[FEATURE] Add shortcut to Anthropic Console from Claude Code interface\"",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T14:09:31Z"
+      "updated_at": "2026-06-29T11:00:41Z"
     },
     {
       "upstream": "anthropics/claude-code#71609",
@@ -11079,44 +11212,6 @@
       "updated_at": "2026-06-28T21:49:33Z"
     },
     {
-      "upstream": "anthropics/claude-code#71611",
-      "url": "https://github.com/anthropics/claude-code/issues/71611",
-      "title": "[FEATURE] Global session search across all projects in --resume picker",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T14:42:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71613",
-      "url": "https://github.com/anthropics/claude-code/issues/71613",
-      "title": "[FEATURE] Config setting to disable ultra plan",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T14:51:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71615",
-      "url": "https://github.com/anthropics/claude-code/issues/71615",
-      "title": "Title: [Bug Report] Cascading regressions on gen-math-complexe.js across 2-day session",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T15:11:43Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71616",
       "url": "https://github.com/anthropics/claude-code/issues/71616",
       "title": "[BUG] All newly-created Code sessions auto-archive on iOS and become inaccessible from mobile app",
@@ -11127,81 +11222,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T19:48:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71617",
-      "url": "https://github.com/anthropics/claude-code/issues/71617",
-      "title": "[FEATURE] hovering or showing a tooltip with the word's definition would make the spinner words both fun and educational.",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T15:23:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71618",
-      "url": "https://github.com/anthropics/claude-code/issues/71618",
-      "title": "[BUG] Claude Code wastes paid sessions fixing self-created bugs — no accountability, no forward progress",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T16:26:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71619",
-      "url": "https://github.com/anthropics/claude-code/issues/71619",
-      "title": "[BUG] extended usage",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T15:26:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71621",
-      "url": "https://github.com/anthropics/claude-code/issues/71621",
-      "title": "[FEATURE] Plan Mode: Actually show the the plan while discussing it",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T15:35:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71622",
-      "url": "https://github.com/anthropics/claude-code/issues/71622",
-      "title": "[BUG] [Billing] Max account inaccessible — wrong account routing, Fin refuses to escalate",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T15:39:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71623",
-      "url": "https://github.com/anthropics/claude-code/issues/71623",
-      "title": "[Bug] ESC key in primary REPL window terminates all background agents when team lead is idle",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T15:43:18Z"
     },
     {
       "upstream": "anthropics/claude-code#71625",
@@ -11216,45 +11236,6 @@
       "updated_at": "2026-06-27T07:05:19Z"
     },
     {
-      "upstream": "anthropics/claude-code#71626",
-      "url": "https://github.com/anthropics/claude-code/issues/71626",
-      "title": "[BUG] Add a setting to disable the changes-view git diff on large repos",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T16:06:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71628",
-      "url": "https://github.com/anthropics/claude-code/issues/71628",
-      "title": "Feature request: expose @file mention (and slash-command) highlighting as customizable theme tokens",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T16:17:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71630",
-      "url": "https://github.com/anthropics/claude-code/issues/71630",
-      "title": "Feature request: portable conversation context across Claude Code, claude.ai, and Cowork",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T16:39:24Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71632",
       "url": "https://github.com/anthropics/claude-code/issues/71632",
       "title": "[BUG] Claude Routine permission bug",
@@ -11266,89 +11247,12 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T16:49:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71637",
-      "url": "https://github.com/anthropics/claude-code/issues/71637",
-      "title": "[Bug] Hyperlinks not clickable in Claude CLI output",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T17:07:39Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71638",
-      "url": "https://github.com/anthropics/claude-code/issues/71638",
-      "title": "[BUG] Escape interrupt contaminates Claude's reasoning on all subsequent turns",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:16:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71639",
-      "url": "https://github.com/anthropics/claude-code/issues/71639",
-      "title": "[FEATURE] skill.name tag in claude_code.cost.usage should reflect actual skill name for marketplace plugin skills",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T17:23:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71640",
-      "url": "https://github.com/anthropics/claude-code/issues/71640",
-      "title": "[Bug] Agent Teams conversation blocks navigation back to agents view",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:31:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71641",
-      "url": "https://github.com/anthropics/claude-code/issues/71641",
-      "title": "[Bug] Voice dictation fails with microphone error instead of authentication error when logged out",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T17:33:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71642",
-      "url": "https://github.com/anthropics/claude-code/issues/71642",
-      "title": "Subagent cards no longer show context size / token / cost next to runtime",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T17:29:28Z"
+      "updated_at": "2026-06-29T15:13:01Z"
     },
     {
       "upstream": "anthropics/claude-code#71644",
       "url": "https://github.com/anthropics/claude-code/issues/71644",
-      "title": "[BUG] Subagents going idle (new fullscreen mode only)",
+      "title": "[BUG] Subagents going idle",
       "impact": "not_applicable",
       "categories": [
         "terminal",
@@ -11356,173 +11260,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T13:53:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71645",
-      "url": "https://github.com/anthropics/claude-code/issues/71645",
-      "title": "Setting to show permission prompt explanations by default (without pressing Ctrl+E)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:14:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71646",
-      "url": "https://github.com/anthropics/claude-code/issues/71646",
-      "title": "VS Code extension: webview CSS uses --vscode-* theme tokens without fallbacks → invisible table borders, colorless charts, missing code-block backgrounds",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:15:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71647",
-      "url": "https://github.com/anthropics/claude-code/issues/71647",
-      "title": "[BUG] VSCode sidebar \"Past conversations\" empty - extension filters out its own sessions via includeProgrammaticSessions=false (regression in 2.1.191)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:29:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71648",
-      "url": "https://github.com/anthropics/claude-code/issues/71648",
-      "title": "[BUG] Plugin-namespaced agent body not injected for teammates (frontmatter IS applied; markdown body dropped)",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:23:39Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71650",
-      "url": "https://github.com/anthropics/claude-code/issues/71650",
-      "title": "[BUG] Cowork fails with HYPERVISOR_VIRT_DISABLED on Windows 11 Pro ARM64 in Parallels 26 on M3 Pro",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:29:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71651",
-      "url": "https://github.com/anthropics/claude-code/issues/71651",
-      "title": "[Bug] Claude incorrectly believes it has exited plan mode while still active",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T19:51:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71652",
-      "url": "https://github.com/anthropics/claude-code/issues/71652",
-      "title": "Feature request: hook event on user interrupt (Esc)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:35:51Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71653",
-      "url": "https://github.com/anthropics/claude-code/issues/71653",
-      "title": "VS Code extension triggers Windows Firewall \"allow public/private networks\" prompt on every extension-host load (managed machine)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "mcp",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T18:45:15Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71654",
-      "url": "https://github.com/anthropics/claude-code/issues/71654",
-      "title": "[Bug] Session transcripts leak secrets (GitHub PAT, API tokens) to persisted logs",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T19:15:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71655",
-      "url": "https://github.com/anthropics/claude-code/issues/71655",
-      "title": "EPERM error after update to 2.1.193",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:27:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71656",
-      "url": "https://github.com/anthropics/claude-code/issues/71656",
-      "title": "[Bug] Ctrl-L triggers /clear command instead of screen repaint",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T19:11:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71657",
-      "url": "https://github.com/anthropics/claude-code/issues/71657",
-      "title": "[FEATURE] Per-worktree Python venv isolation",
-      "impact": "not_applicable",
-      "categories": [
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T19:23:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71658",
-      "url": "https://github.com/anthropics/claude-code/issues/71658",
-      "title": "[Bug] OSC 8 hyperlinks to local HTML files open Finder instead of web browser",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T19:26:18Z"
+      "updated_at": "2026-06-29T23:10:54Z"
     },
     {
       "upstream": "anthropics/claude-code#71663",
@@ -11536,19 +11274,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T22:56:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71674",
-      "url": "https://github.com/anthropics/claude-code/issues/71674",
-      "title": "I don't have enough information to generate a GitHub issue title from \"Ignorance.\" Could you please provide the actual bug report or feature request details? I need information such as: - What problem occurred or what feature is being requested? - What e",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T20:11:13Z"
+      "updated_at": "2026-06-29T14:26:12Z"
     },
     {
       "upstream": "anthropics/claude-code#71675",
@@ -11564,146 +11290,6 @@
       "updated_at": "2026-06-28T20:48:33Z"
     },
     {
-      "upstream": "anthropics/claude-code#71676",
-      "url": "https://github.com/anthropics/claude-code/issues/71676",
-      "title": "[Bug] False positive detection occurring repeatedly",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T20:16:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71677",
-      "url": "https://github.com/anthropics/claude-code/issues/71677",
-      "title": "[BUG] Desktop SSH remote: CLI provisioning transfers far slower than the link allows, times out at 180s \"Configuring machine\"",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T20:27:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71682",
-      "url": "https://github.com/anthropics/claude-code/issues/71682",
-      "title": "/insights output leaks literal <message> tags into rendered response",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:16:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71684",
-      "url": "https://github.com/anthropics/claude-code/issues/71684",
-      "title": "[FEATURE] Allow naming/labeling sessions so they're identifiable in /resume",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:25:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71685",
-      "url": "https://github.com/anthropics/claude-code/issues/71685",
-      "title": "Remote Control (iOS): closing a fullscreen code block exits the whole conversation instead of just the code view",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:34:22Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71687",
-      "url": "https://github.com/anthropics/claude-code/issues/71687",
-      "title": "[DOCS] Environment variables reference missing `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` added in v2.1.195",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:45:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71688",
-      "url": "https://github.com/anthropics/claude-code/issues/71688",
-      "title": "[DOCS] Hooks reference does not document that hyphenated MCP server names exact-match in v2.1.195",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:45:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71689",
-      "url": "https://github.com/anthropics/claude-code/issues/71689",
-      "title": "[DOCS] Voice dictation troubleshooting omits macOS default input device change in long sessions",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:45:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71691",
-      "url": "https://github.com/anthropics/claude-code/issues/71691",
-      "title": "[DOCS] Plugin install consent docs do not explain project-settings-only plugins no longer re-prompt consent on every loader (v2.1.195)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin",
-        "slash_hook",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:45:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71694",
-      "url": "https://github.com/anthropics/claude-code/issues/71694",
-      "title": "[DOCS] Voice dictation Linux troubleshooting does not distinguish \"no microphone\" from \"SoX not installed\" (added in v2.1.195)",
-      "impact": "not_applicable",
-      "categories": [
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:45:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71696",
-      "url": "https://github.com/anthropics/claude-code/issues/71696",
-      "title": "[DOCS] `/plugin` enable/disable docs do not address name mismatch between `plugin.json` and marketplace entry (fixed in v2.1.195)",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:46:30Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71697",
       "url": "https://github.com/anthropics/claude-code/issues/71697",
       "title": "[BUG] Auto session recap no longer fires on idle return (macOS Apple Terminal CLI, 2.1.193)",
@@ -11715,60 +11301,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:51:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71698",
-      "url": "https://github.com/anthropics/claude-code/issues/71698",
-      "title": "[BUG] /usage text unselectable after Edit tool diff block; prior diff component breaks mouse selection",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T21:53:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71699",
-      "url": "https://github.com/anthropics/claude-code/issues/71699",
-      "title": "claude update fails with \"getaddrinfo EREFUSED\" on split-DNS VPN — updater resolves via c-ares, not the system resolver",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:12:35Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71700",
-      "url": "https://github.com/anthropics/claude-code/issues/71700",
-      "title": "[BUG] Kitty keyboard protocol gated on terminal-name allow-list instead of CSI ? u capability — capable terminals (Alacritty) denied",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:07:09Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71707",
-      "url": "https://github.com/anthropics/claude-code/issues/71707",
-      "title": "[Feature Request] Display exact allowlist command format when requesting tool permission",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T22:32:38Z"
+      "updated_at": "2026-06-29T16:00:30Z"
     },
     {
       "upstream": "anthropics/claude-code#71709",
@@ -11805,126 +11338,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T00:11:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71712",
-      "url": "https://github.com/anthropics/claude-code/issues/71712",
-      "title": "Pasting Thai/multibyte UTF-8 into prompt input strips bytes 0x80–0x9F (mojibake, unrecoverable)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T23:44:57Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71713",
-      "url": "https://github.com/anthropics/claude-code/issues/71713",
-      "title": "[Bug] Full Screen Mode: Auto-scroll behavior prevents manual scrolling",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T23:18:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71714",
-      "url": "https://github.com/anthropics/claude-code/issues/71714",
-      "title": "[Bug] Claude ignores user instructions and over-complicates responses",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T23:21:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71716",
-      "url": "https://github.com/anthropics/claude-code/issues/71716",
-      "title": "[Bug] Claude ignoring user instructions in favor of default behavior",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T23:29:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71718",
-      "url": "https://github.com/anthropics/claude-code/issues/71718",
-      "title": "[BUG] Cannot copy text correctly from Code tab (Remote Control session) on mobile app",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-26T23:51:45Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71719",
-      "url": "https://github.com/anthropics/claude-code/issues/71719",
-      "title": "[BUG] SPB_DATA installation failure due to Cadence HOME environment variable",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T00:09:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71720",
-      "url": "https://github.com/anthropics/claude-code/issues/71720",
-      "title": "Feature request: show per-message timestamps in the terminal conversation UI",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T00:14:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71721",
-      "url": "https://github.com/anthropics/claude-code/issues/71721",
-      "title": "[Feature Request] Custom vocabulary support for voice dictation to improve technical acronym and accent handling",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T01:39:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71722",
-      "url": "https://github.com/anthropics/claude-code/issues/71722",
-      "title": "[BUG] \"Open in desktop app\" (code-session teleport) opens a blank window and hangs the whole app",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T00:18:13Z"
+      "updated_at": "2026-06-29T20:25:43Z"
     },
     {
       "upstream": "anthropics/claude-code#71723",
@@ -11937,20 +11351,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-28T18:10:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71726",
-      "url": "https://github.com/anthropics/claude-code/issues/71726",
-      "title": "[FEATURE] Desktop app: inject queued messages mid-task between tool calls (CLI steering parity)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T01:03:36Z"
     },
     {
       "upstream": "anthropics/claude-code#71729",
@@ -11979,55 +11379,6 @@
       "updated_at": "2026-06-27T20:42:24Z"
     },
     {
-      "upstream": "anthropics/claude-code#71731",
-      "url": "https://github.com/anthropics/claude-code/issues/71731",
-      "title": "Remote sessions require local access to enable - no way to take control purely remotely",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T03:11:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71732",
-      "url": "https://github.com/anthropics/claude-code/issues/71732",
-      "title": "[BUG] 動かない",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T02:37:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71733",
-      "url": "https://github.com/anthropics/claude-code/issues/71733",
-      "title": "[BUG] Option to log issue in GitHub from Claude Code can fail silently",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T02:34:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71734",
-      "url": "https://github.com/anthropics/claude-code/issues/71734",
-      "title": "[Bug] Claude Code prioritizes built-in code-review skill over repository-specific reviews skill",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T02:26:27Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71736",
       "url": "https://github.com/anthropics/claude-code/issues/71736",
       "title": "VSCode extension does not surface claude.ai account connectors (MCP) that the CLI exposes — same version 2.1.156",
@@ -12054,31 +11405,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T15:05:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71739",
-      "url": "https://github.com/anthropics/claude-code/issues/71739",
-      "title": "[BUG] First-time Dispatch never connects on Windows 11 — messages send but no response renders, mobile \"failed to load sessions",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T03:10:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71749",
-      "url": "https://github.com/anthropics/claude-code/issues/71749",
-      "title": "Transcript view (Ctrl+O) keyboard scroll keys dead in forced-fullscreen renderer (attached background/child sessions)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T03:39:07Z"
     },
     {
       "upstream": "anthropics/claude-code#71750",
@@ -12147,19 +11473,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T06:38:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71758",
-      "url": "https://github.com/anthropics/claude-code/issues/71758",
-      "title": "[BUG] Zoom step is too large in desktop app on Windows",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T08:58:40Z"
     },
     {
       "upstream": "anthropics/claude-code#71759",
@@ -12235,7 +11548,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T08:50:52Z"
+      "updated_at": "2026-06-29T11:23:54Z"
     },
     {
       "upstream": "anthropics/claude-code#71772",
@@ -12337,7 +11650,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-27T12:29:14Z"
+      "updated_at": "2026-06-29T14:58:02Z"
     },
     {
       "upstream": "anthropics/claude-code#71784",
@@ -13088,7 +12401,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-29T01:35:35Z"
+      "updated_at": "2026-06-29T19:43:29Z"
     },
     {
       "upstream": "anthropics/claude-code#72013",
@@ -13525,7 +12838,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T18:10:14Z"
+      "updated_at": "2026-06-29T13:43:36Z"
     },
     {
       "upstream": "anthropics/claude-code#72089",
@@ -13628,7 +12941,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-28T19:15:59Z"
+      "updated_at": "2026-06-29T14:26:29Z"
     },
     {
       "upstream": "anthropics/claude-code#72123",
@@ -14092,7 +13405,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-29T02:50:04Z"
+      "updated_at": "2026-06-29T20:15:29Z"
     },
     {
       "upstream": "anthropics/claude-code#72190",
@@ -14132,19 +13445,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-29T03:11:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#72195",
-      "url": "https://github.com/anthropics/claude-code/issues/72195",
-      "title": "[BUG] Scheduled task fires (lastRunAt updates) but no session is spawned",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-29T03:17:20Z"
     },
     {
       "upstream": "anthropics/claude-code#72196",
@@ -14238,7 +13538,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-29T06:10:57Z"
+      "updated_at": "2026-06-29T12:33:53Z"
     },
     {
       "upstream": "anthropics/claude-code#72207",
@@ -14391,7 +13691,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-29T08:00:48Z"
+      "updated_at": "2026-06-29T12:34:09Z"
     },
     {
       "upstream": "anthropics/claude-code#72222",
@@ -14443,7 +13743,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-29T10:08:04Z"
+      "updated_at": "2026-06-29T14:00:38Z"
     },
     {
       "upstream": "anthropics/claude-code#72232",
@@ -14511,6 +13811,1281 @@
       "updated_at": "2026-06-29T10:30:57Z"
     },
     {
+      "upstream": "anthropics/claude-code#72237",
+      "url": "https://github.com/anthropics/claude-code/issues/72237",
+      "title": "Drive MCP: create_file creates duplicates, no update_file available",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T10:41:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72239",
+      "url": "https://github.com/anthropics/claude-code/issues/72239",
+      "title": "[FEATURE] Honour MCP Annotations.Audience on tool-result content blocks",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:05:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72245",
+      "url": "https://github.com/anthropics/claude-code/issues/72245",
+      "title": "Add RTL (right-to-left) layout support for Hebrew/Arabic users",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T11:54:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72246",
+      "url": "https://github.com/anthropics/claude-code/issues/72246",
+      "title": "French sessions: activity status line produces French/English hybrid words (e.g. \"Inventaired\")",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T12:11:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72247",
+      "url": "https://github.com/anthropics/claude-code/issues/72247",
+      "title": "Claude Desktop: expose a spellchecker language setting (stuck on en-US)",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T12:05:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72250",
+      "url": "https://github.com/anthropics/claude-code/issues/72250",
+      "title": "[BUG] bun install fails with 503 on private GitHub Packages (sandbox proxy rejects redirect with Authorization header)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T12:35:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72251",
+      "url": "https://github.com/anthropics/claude-code/issues/72251",
+      "title": "[BUG] Session history button in Claude Code VSCode extension wipes current active chat",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:24:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72252",
+      "url": "https://github.com/anthropics/claude-code/issues/72252",
+      "title": "[Bug] Claude making assumptions without grounding in facts or requesting clarification",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T12:38:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72253",
+      "url": "https://github.com/anthropics/claude-code/issues/72253",
+      "title": "Clickable prompt-summary header → jump to any prior input in scrollback",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T12:50:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72254",
+      "url": "https://github.com/anthropics/claude-code/issues/72254",
+      "title": "[BUG] Write tool still corrupts CJK UTF-8 to U+FFFD on v2.1.195 (Windows)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:08:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72255",
+      "url": "https://github.com/anthropics/claude-code/issues/72255",
+      "title": "[BUG] Claude Desktop never creates ant-did directory on fresh install — auth fails silently, no sign-in screen (macOS Sonoma 14.5, arm64)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:07:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72257",
+      "url": "https://github.com/anthropics/claude-code/issues/72257",
+      "title": "Feature Request: Internationalization (i18n) support for Claude Code UI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:07:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72260",
+      "url": "https://github.com/anthropics/claude-code/issues/72260",
+      "title": "[Bug] Anthropic API: 50% timeout errors causing token waste",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:24:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72261",
+      "url": "https://github.com/anthropics/claude-code/issues/72261",
+      "title": "[BUG] VSCode extension ignores claude environment settings",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T19:16:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72262",
+      "url": "https://github.com/anthropics/claude-code/issues/72262",
+      "title": "Docs: PreToolUse hook tool_input (Bash) omits run_in_background / description / tool_use_id",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:35:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72263",
+      "url": "https://github.com/anthropics/claude-code/issues/72263",
+      "title": "[Feature] Configurable Shift+Tab permission-mode cycle (order + subset)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:35:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72265",
+      "url": "https://github.com/anthropics/claude-code/issues/72265",
+      "title": "[Bug] Linux UI copy functionality is flaky and unreliable",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:47:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72266",
+      "url": "https://github.com/anthropics/claude-code/issues/72266",
+      "title": "[FEATURE] Expose a way to set the session/tab title in the VSCode extension (ungate /rename or add a command)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:51:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72267",
+      "url": "https://github.com/anthropics/claude-code/issues/72267",
+      "title": "Built-in deep-research workflow: Scope phase exhausts StructuredOutput retry cap on long briefs",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:57:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72268",
+      "url": "https://github.com/anthropics/claude-code/issues/72268",
+      "title": "[BUG] Mouse/focus escape sequences dump into input on window resize (WSL2, v2.1.195)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:09:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72269",
+      "url": "https://github.com/anthropics/claude-code/issues/72269",
+      "title": "[Bug] Terminal mouse/focus escape sequences leak into input on WSL2 resize",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:10:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72271",
+      "url": "https://github.com/anthropics/claude-code/issues/72271",
+      "title": "[FEATURE] Forward MCP EmbeddedResource blob to Anthropic API content blocks",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:13:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72272",
+      "url": "https://github.com/anthropics/claude-code/issues/72272",
+      "title": "spawn ENAMETOOLONG in Cowork on all chats (new, existing, empty) - Windows 10 Build 26100",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:08:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72273",
+      "url": "https://github.com/anthropics/claude-code/issues/72273",
+      "title": "TUI: click-to-select fires even when the TUI window lacks focus — should require focus-first",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:19:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72276",
+      "url": "https://github.com/anthropics/claude-code/issues/72276",
+      "title": "statusLine command never invoked on macOS (2.1.195, Homebrew native binary) — config valid, command works manually, zero spawns",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:45:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72279",
+      "url": "https://github.com/anthropics/claude-code/issues/72279",
+      "title": "[FEATURE] esc key to exit code edition preview window - vscode addin",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T14:59:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72280",
+      "url": "https://github.com/anthropics/claude-code/issues/72280",
+      "title": "[BUG] Recent VSC extension update seems to have Claude hanging up occasionally.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T20:50:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72281",
+      "url": "https://github.com/anthropics/claude-code/issues/72281",
+      "title": "[VSCode] Cannot fork a conversation after the latest assistant reply — fork only anchors on user messages",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:07:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72282",
+      "url": "https://github.com/anthropics/claude-code/issues/72282",
+      "title": "[Bug] Text unexpectedly converted to Korean without user action",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:35:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72283",
+      "url": "https://github.com/anthropics/claude-code/issues/72283",
+      "title": "Ultraplan web handoff fails to push PR when container has read-only GitHub access",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:32:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72284",
+      "url": "https://github.com/anthropics/claude-code/issues/72284",
+      "title": "[BUG] Cowork microphone input cuts off after ~2 seconds on x64 — works fine on ARM64",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T16:55:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72285",
+      "url": "https://github.com/anthropics/claude-code/issues/72285",
+      "title": "[BUG] spawn ENAMETOOLONG",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:33:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72286",
+      "url": "https://github.com/anthropics/claude-code/issues/72286",
+      "title": "Ultraplan web handoff is delta-blind to local uncommitted edits",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:34:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72287",
+      "url": "https://github.com/anthropics/claude-code/issues/72287",
+      "title": "[Feature Request] Add per-subagent observability (model, effort) to /agents Running tab and agent JSON output",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-30T00:34:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72288",
+      "url": "https://github.com/anthropics/claude-code/issues/72288",
+      "title": "[Feature Request] Add command to close active fork session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:36:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72289",
+      "url": "https://github.com/anthropics/claude-code/issues/72289",
+      "title": "Background job writes completion output into the wrong thread — job spawned in Thread A bleeds into Thread B if B is active when the job finishes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:43:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72290",
+      "url": "https://github.com/anthropics/claude-code/issues/72290",
+      "title": "[BUG] GitHub \"Issue opened\" trigger does not fire when the issue is created by a Claude routine (self-trigger)",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:45:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72292",
+      "url": "https://github.com/anthropics/claude-code/issues/72292",
+      "title": "/workflows slash command not recognized in VS Code extension",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T15:59:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72296",
+      "url": "https://github.com/anthropics/claude-code/issues/72296",
+      "title": "[BUG] Sonnet 4.6 1m missing from Max plan",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T16:28:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72297",
+      "url": "https://github.com/anthropics/claude-code/issues/72297",
+      "title": "[BUG] claude desktop blows away it's own settings on startup",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T16:42:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72299",
+      "url": "https://github.com/anthropics/claude-code/issues/72299",
+      "title": "Shift+Enter acts like Enter (submits) in KDE Konsole — multi-line input not triggered",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T16:41:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72300",
+      "url": "https://github.com/anthropics/claude-code/issues/72300",
+      "title": "[FEATURE] Preserve file-change system-reminders across context summarization",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T16:47:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72301",
+      "url": "https://github.com/anthropics/claude-code/issues/72301",
+      "title": "[FEATURE] VS Code extension: select assistant response text as context for follow-up (like Codex)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T16:49:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72302",
+      "url": "https://github.com/anthropics/claude-code/issues/72302",
+      "title": "TOOL ARGUES ABOUT ERRORS INSTEAD OF CORRECTING",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:01:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72303",
+      "url": "https://github.com/anthropics/claude-code/issues/72303",
+      "title": "When using cmd+option and arrows to navigate between tabs it doesn't follow the normal order, and jumps between them with no real reason that I can identify.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:11:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72304",
+      "url": "https://github.com/anthropics/claude-code/issues/72304",
+      "title": "[Bug] Claude makes unfounded claims without analyzing context or user constraints",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:10:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72305",
+      "url": "https://github.com/anthropics/claude-code/issues/72305",
+      "title": "Desktop Code mode creates an orphan empty-context session instead of resuming; UI keeps showing full scrollback",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:16:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72306",
+      "url": "https://github.com/anthropics/claude-code/issues/72306",
+      "title": "[BUG] Claude Code Plugin Directory Submission Link Redirects to Documentation URL and Returns 403 Forbidden",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:19:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72308",
+      "url": "https://github.com/anthropics/claude-code/issues/72308",
+      "title": "Claude Desktop: scheduled-task/background `claude` CLI sessions never exit → memory exhaustion over 1–2 days",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:35:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72309",
+      "url": "https://github.com/anthropics/claude-code/issues/72309",
+      "title": "[Feature Request] Auto-update capability for Claude Code CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:38:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72311",
+      "url": "https://github.com/anthropics/claude-code/issues/72311",
+      "title": "Make it easier to expand repo access in a Claude code session",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:46:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72315",
+      "url": "https://github.com/anthropics/claude-code/issues/72315",
+      "title": "[BUG] Error: Subprocess initialization did not complete within 60000ms — check authentication and network connectivity View output logs · Troubleshooting resources",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:46:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72316",
+      "url": "https://github.com/anthropics/claude-code/issues/72316",
+      "title": "LSP tool: goToDefinition/findReferences/workspaceSymbol always return empty while hover/documentSymbol work",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:47:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72317",
+      "url": "https://github.com/anthropics/claude-code/issues/72317",
+      "title": "[BUG] claude plugin update is silent on no-op/failure and has no bulk mode — outcomes are indistinguishable to the caller",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T18:12:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72319",
+      "url": "https://github.com/anthropics/claude-code/issues/72319",
+      "title": "[BUG] In-session /add-dir accepts only one path; launch --add-dir is variadic — inconsistent arity for the same command",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T18:22:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72320",
+      "url": "https://github.com/anthropics/claude-code/issues/72320",
+      "title": "[Feature Request] Plan mode should not auto-dismiss explanation while user is reading | Zed on Mac",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T19:25:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72321",
+      "url": "https://github.com/anthropics/claude-code/issues/72321",
+      "title": "[BUG] - Sidebar/ruler not visible after latest update , - Unable to scroll up in session, - OS: Windows WSL2",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T18:26:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72327",
+      "url": "https://github.com/anthropics/claude-code/issues/72327",
+      "title": "UserPromptSubmit: add a 'handled' decision (show output, skip agent, no 'blocked' framing)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T18:29:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72329",
+      "url": "https://github.com/anthropics/claude-code/issues/72329",
+      "title": "Python file I/O snippets should always include encoding='utf-8' to prevent silent data corruption on Windows (follow-up to #62828)",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T18:58:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72332",
+      "url": "https://github.com/anthropics/claude-code/issues/72332",
+      "title": "[Bug] Prompt Injection in Sub-agent Output: Attempted Manipulation to Write Fabricated Security Findings",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T19:13:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72334",
+      "url": "https://github.com/anthropics/claude-code/issues/72334",
+      "title": "[BUG] Daemon supervisor (transient) hard-exits on EADDRINUSE during control-socket bind race — regression in 2.1.195",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T19:18:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72335",
+      "url": "https://github.com/anthropics/claude-code/issues/72335",
+      "title": "SSH sessions: history blank and fork fails due to tail connecting via raw IP instead of SSH config alias",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T19:28:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72337",
+      "url": "https://github.com/anthropics/claude-code/issues/72337",
+      "title": "[Bug][cyber] Debugging an H.264 video capture/extraction pipeline against known-good decoder output blocked (req_011CcY9KbFHf4xez9uNGQyAH)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:07:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72338",
+      "url": "https://github.com/anthropics/claude-code/issues/72338",
+      "title": "[BUG] Unexpected permission prompt appears without Cancel/Deny button and triggers unwanted commit on click",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T20:18:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72339",
+      "url": "https://github.com/anthropics/claude-code/issues/72339",
+      "title": "[BUG] Working directory resets between tool calls",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T20:15:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72341",
+      "url": "https://github.com/anthropics/claude-code/issues/72341",
+      "title": "GUI app: \"thinking\" indicator (✳) animation can freeze while the session is still actively working",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T20:26:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72342",
+      "url": "https://github.com/anthropics/claude-code/issues/72342",
+      "title": "[BUG] Claude Code VS Code extension — main-thread saturation, UI freezes, and memory growth during extended thinking",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T20:50:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72343",
+      "url": "https://github.com/anthropics/claude-code/issues/72343",
+      "title": "[BUG] Agent Teams: tmux/auto teammates crash on spawn — non-TTY stdin triggers --print with no prompt (2.1.195)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-30T00:34:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72346",
+      "url": "https://github.com/anthropics/claude-code/issues/72346",
+      "title": "[Bug] Live ↓ tokens counter absent during thinking phase",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:04:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72347",
+      "url": "https://github.com/anthropics/claude-code/issues/72347",
+      "title": "Interactive sessions that inherit CLAUDE_CODE_CHILD_SESSION silently skip local transcript persistence",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T21:20:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72348",
+      "url": "https://github.com/anthropics/claude-code/issues/72348",
+      "title": "[FEATURE] Mobile push notifications when Claude Code finishes a task or requires input",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T21:29:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72351",
+      "url": "https://github.com/anthropics/claude-code/issues/72351",
+      "title": "[Bug][cyber] Cyber filter blocked building a drone flight UI with live video feed and telemetry HUD (req_011CcYJWT9EjGMeSaqybt7TC)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:12:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72354",
+      "url": "https://github.com/anthropics/claude-code/issues/72354",
+      "title": "[Bug][cyber] Building drone flight UI with live video + telemetry connection-status HUD blocked (req_011CcYJgUdojjgA9CLvAaxrz)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:16:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72355",
+      "url": "https://github.com/anthropics/claude-code/issues/72355",
+      "title": "[Bug][cyber] Tweaking ffmpeg params to fix too-wide on-screen video aspect ratio wrongly blocked (req_011CcYJyW46wcHoLHF5AJVmu)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:20:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72356",
+      "url": "https://github.com/anthropics/claude-code/issues/72356",
+      "title": "[Bug] Agent execution loop causes corrupted state",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:30:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72357",
+      "url": "https://github.com/anthropics/claude-code/issues/72357",
+      "title": "[Bug][cyber] Correcting a too-wide on-screen video aspect ratio via ffmpeg parameter tweaks (req_011CcYKHENYHwr9vFJzc6eDX)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:56:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72360",
+      "url": "https://github.com/anthropics/claude-code/issues/72360",
+      "title": "[Bug] Fullscreen TUI prevents scrollback in iTerm2",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:39:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72362",
+      "url": "https://github.com/anthropics/claude-code/issues/72362",
+      "title": "[Feature Request] One-shot model override for single prompts without session switching",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:47:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72364",
+      "url": "https://github.com/anthropics/claude-code/issues/72364",
+      "title": "[FEATURE] Claude agents to show time since finished / stopped instead of when state transitioned",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:53:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72365",
+      "url": "https://github.com/anthropics/claude-code/issues/72365",
+      "title": "[Bug][cyber] Block halted debugging of a captured H.264 video stream decode/extraction pipeline (req_011CcYNMVAVYbm5pwJSrZdpJ)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T22:57:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72366",
+      "url": "https://github.com/anthropics/claude-code/issues/72366",
+      "title": "[FEATURE] UI/UX: Left sidebar with Pinned, Current Works, and Recents for better session management",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:05:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72368",
+      "url": "https://github.com/anthropics/claude-code/issues/72368",
+      "title": "[BUG] Claude Agents has buggy behaviour with agent invocation via CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:09:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72369",
+      "url": "https://github.com/anthropics/claude-code/issues/72369",
+      "title": "[BUG] --plugin-dir does not take precedence over marketplace-installed plugin with same name",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:35:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72370",
+      "url": "https://github.com/anthropics/claude-code/issues/72370",
+      "title": "[Bug] Auto-update failed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:28:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72371",
+      "url": "https://github.com/anthropics/claude-code/issues/72371",
+      "title": "[Bug] Text truncation at right edge in tmux + iTerm2 terminal",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:31:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72374",
+      "url": "https://github.com/anthropics/claude-code/issues/72374",
+      "title": "[Bug] Auto-compact fails to trigger at high token usage after context reduction",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:35:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72376",
+      "url": "https://github.com/anthropics/claude-code/issues/72376",
+      "title": "[BUG] Claude steals focus on startup in vscode",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:44:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72377",
+      "url": "https://github.com/anthropics/claude-code/issues/72377",
+      "title": "[BUG] Cowork regression: KERNEL_MODE_HEAP_CORRUPTION (0x13A) in storvsp!VspVsmbFileCreate — started with build 1.15962.0, not fixed in 1.15962.1.0",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:53:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72379",
+      "url": "https://github.com/anthropics/claude-code/issues/72379",
+      "title": "[DOCS] Interactive mode docs omit Cmd/Ctrl-click reveal-in-finder behavior for chat file attachments",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:55:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72380",
+      "url": "https://github.com/anthropics/claude-code/issues/72380",
+      "title": "[DOCS] PowerShell docs omit no-match exit 1 behavior for `git diff`, `git grep`, `egrep`, and `fgrep`",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:55:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72381",
+      "url": "https://github.com/anthropics/claude-code/issues/72381",
+      "title": "[DOCS] Claude Code on the web docs omit mid-turn Remote session auto-resume after server restart",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:56:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72386",
+      "url": "https://github.com/anthropics/claude-code/issues/72386",
+      "title": "[DOCS] Background session docs are outdated for long-running command survival across process restarts and Windows handoff",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T23:56:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72388",
+      "url": "https://github.com/anthropics/claude-code/issues/72388",
+      "title": "[BUG] Desktop app: input draft loses markdown formatting after switching session tabs",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-30T00:27:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72389",
+      "url": "https://github.com/anthropics/claude-code/issues/72389",
+      "title": "[BUG] Windows Desktop app: `!` interactive shell forces PowerShell, ignoring defaultShell:\"bash\" (CLI works with identical settings)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-30T00:17:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72391",
+      "url": "https://github.com/anthropics/claude-code/issues/72391",
+      "title": "Windows: non-ASCII file paths corrupted (surrogate-escaped) when passed to PreToolUse Python hooks",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-30T00:16:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72392",
+      "url": "https://github.com/anthropics/claude-code/issues/72392",
+      "title": "[Bug] Flicker-free rendering breaks Shift+Enter on iTerm2",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-30T00:30:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72394",
+      "url": "https://github.com/anthropics/claude-code/issues/72394",
+      "title": "[BUG] Extremely slow startup and shutdown",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-30T00:47:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72395",
+      "url": "https://github.com/anthropics/claude-code/issues/72395",
+      "title": "[Bug] Prompt injection-like instructions in tool results/session context with destructive commands",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-30T00:47:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#7387",
+      "url": "https://github.com/anthropics/claude-code/issues/7387",
+      "title": "[BUG] Shell script occasionally fails due to crazy escaping",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T13:14:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#7618",
+      "url": "https://github.com/anthropics/claude-code/issues/7618",
+      "title": "[BUG] VS Code terminal steals focus even when running Claude Code externally with /ide (terminal not open)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T12:32:10Z"
+    },
+    {
       "upstream": "anthropics/claude-code#8473",
       "url": "https://github.com/anthropics/claude-code/issues/8473",
       "title": "[BUG] Error: Failed to load usage data",
@@ -14522,6 +15097,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-27T21:28:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#8477",
+      "url": "https://github.com/anthropics/claude-code/issues/8477",
+      "title": "[FEATURE] Add Option to Always Show Claude's Thinking",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T21:09:45Z"
     },
     {
       "upstream": "anthropics/claude-code#9716",
@@ -14536,6 +15123,18 @@
       "updated_at": "2026-06-28T11:41:16Z"
     },
     {
+      "upstream": "anthropics/claude-code#9796",
+      "url": "https://github.com/anthropics/claude-code/issues/9796",
+      "title": "[BUG] Context compaction erases .claude/project-context.md instructions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-29T17:35:18Z"
+    },
+    {
       "upstream": "anthropics/claude-code#13689",
       "url": "https://github.com/anthropics/claude-code/issues/13689",
       "title": "[FEATURE] Improve the model's ability to follow instructions",
@@ -14543,7 +15142,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T21:56:08Z"
+      "updated_at": "2026-06-29T19:44:59Z"
     },
     {
       "upstream": "anthropics/claude-code#1757",
@@ -14563,17 +15162,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-28T17:19:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#21867",
-      "url": "https://github.com/anthropics/claude-code/issues/21867",
-      "title": "[FEATURE] Add settings to hide token counter and version display in status line",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T22:56:33Z"
+      "updated_at": "2026-06-29T19:31:06Z"
     },
     {
       "upstream": "anthropics/claude-code#21894",
@@ -14634,16 +15223,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-27T21:22:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#3138",
-      "url": "https://github.com/anthropics/claude-code/issues/3138",
-      "title": "[BUG] resume flag fails to maintain conversation context after hitting usage/context limits",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T10:46:19Z"
     },
     {
       "upstream": "anthropics/claude-code#31677",
@@ -14716,16 +15295,6 @@
       "updated_at": "2026-06-27T21:16:48Z"
     },
     {
-      "upstream": "anthropics/claude-code#42700",
-      "url": "https://github.com/anthropics/claude-code/issues/42700",
-      "title": "TTS readback of responses + voice mode for Remote Control sessions",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T15:10:22Z"
-    },
-    {
       "upstream": "anthropics/claude-code#43356",
       "url": "https://github.com/anthropics/claude-code/issues/43356",
       "title": "[DOCS] Bedrock onboarding docs omit login-screen setup wizard",
@@ -14743,7 +15312,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-28T21:32:26Z"
+      "updated_at": "2026-06-29T18:29:07Z"
     },
     {
       "upstream": "anthropics/claude-code#48858",
@@ -14764,6 +15333,16 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-27T21:14:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49084",
+      "url": "https://github.com/anthropics/claude-code/issues/49084",
+      "title": "Feature request: expose timestamps to Claude as structured data for time-aware reasoning",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T19:04:58Z"
     },
     {
       "upstream": "anthropics/claude-code#49295",
@@ -14793,7 +15372,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-28T14:54:38Z"
+      "updated_at": "2026-06-29T16:01:33Z"
     },
     {
       "upstream": "anthropics/claude-code#50137",
@@ -14813,7 +15392,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-27T11:43:48Z"
+      "updated_at": "2026-06-29T19:43:48Z"
     },
     {
       "upstream": "anthropics/claude-code#51373",
@@ -14834,16 +15413,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-27T21:07:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#52051",
-      "url": "https://github.com/anthropics/claude-code/issues/52051",
-      "title": "Seamless local multi-branching: parallel sessions currently conflict on the working tree",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T11:03:48Z"
     },
     {
       "upstream": "anthropics/claude-code#52204",
@@ -14903,7 +15472,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-28T16:03:52Z"
+      "updated_at": "2026-06-29T19:40:13Z"
     },
     {
       "upstream": "anthropics/claude-code#55615",
@@ -14924,16 +15493,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-27T20:56:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60644",
-      "url": "https://github.com/anthropics/claude-code/issues/60644",
-      "title": "[BUG] Approval prompt hidden when tool detail view (Ctrl+O) is expanded",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T22:29:10Z"
     },
     {
       "upstream": "anthropics/claude-code#60848",
@@ -14973,7 +15532,17 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-28T17:30:58Z"
+      "updated_at": "2026-06-29T12:42:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63602",
+      "url": "https://github.com/anthropics/claude-code/issues/63602",
+      "title": "Opus 4.8 asserted a false answer on a trivial lookup without verifying first",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T11:42:40Z"
     },
     {
       "upstream": "anthropics/claude-code#64171",
@@ -15006,16 +15575,6 @@
       "updated_at": "2026-06-28T10:47:10Z"
     },
     {
-      "upstream": "anthropics/claude-code#65457",
-      "url": "https://github.com/anthropics/claude-code/issues/65457",
-      "title": "[MODEL] Claude raised my stress levels, causing me stomach aches",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T11:03:50Z"
-    },
-    {
       "upstream": "anthropics/claude-code#65498",
       "url": "https://github.com/anthropics/claude-code/issues/65498",
       "title": "[DOCS] Headless docs omit `claude -p` background-shell cleanup after final result",
@@ -15034,36 +15593,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-28T10:47:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65524",
-      "url": "https://github.com/anthropics/claude-code/issues/65524",
-      "title": "Expose current usage / limit state to the model (self-pacing for long autonomous runs)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T11:03:51Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65560",
-      "url": "https://github.com/anthropics/claude-code/issues/65560",
-      "title": "ALLOW ACCESS TO FOLDER WITH ADDITIONAL INFO/COMMENTS",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T22:29:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65563",
-      "url": "https://github.com/anthropics/claude-code/issues/65563",
-      "title": "Claude deleted production database record without user permission",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T22:29:16Z"
     },
     {
       "upstream": "anthropics/claude-code#65592",
@@ -15256,6 +15785,76 @@
       "updated_at": "2026-06-28T22:25:10Z"
     },
     {
+      "upstream": "anthropics/claude-code#65999",
+      "url": "https://github.com/anthropics/claude-code/issues/65999",
+      "title": "Add shareable achievement badges for exceptional Claude Code usage (LinkedIn-ready)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T11:42:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66049",
+      "url": "https://github.com/anthropics/claude-code/issues/66049",
+      "title": "Opus repeatedly refuses to use available tools when explicitly instructed",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T11:42:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66050",
+      "url": "https://github.com/anthropics/claude-code/issues/66050",
+      "title": "Paying customer fed up: Claude wastes time by refusing to follow explicit instructions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T11:42:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66120",
+      "url": "https://github.com/anthropics/claude-code/issues/66120",
+      "title": "Grep tool returns silent \"no matches\" for files containing a NUL byte (swallows ripgrep's \"binary file matches\" notice)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T22:26:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66128",
+      "url": "https://github.com/anthropics/claude-code/issues/66128",
+      "title": "[FEATURE] When Claude Code offers a User-Writeable 'Other' choice, accept Enter as a submit command.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T22:26:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66129",
+      "url": "https://github.com/anthropics/claude-code/issues/66129",
+      "title": "[Bug] Auto-update failure with latest version installed",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T22:26:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#66140",
+      "url": "https://github.com/anthropics/claude-code/issues/66140",
+      "title": "Feature request: AZ5 emergency stop button in mobile app — no Ctrl+C available on mobile",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T22:26:11Z"
+    },
+    {
       "upstream": "anthropics/claude-code#67069",
       "url": "https://github.com/anthropics/claude-code/issues/67069",
       "title": "Account disabled on June 7 — \"This organization has been disabled\" — requesting manual review (Max 5x, China user)",
@@ -15264,26 +15863,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-28T06:49:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#67616",
-      "url": "https://github.com/anthropics/claude-code/issues/67616",
-      "title": "...",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T18:22:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#68773",
-      "url": "https://github.com/anthropics/claude-code/issues/68773",
-      "title": "[Billing][Bug] Auto-recharge loop charged consumer plan 29x ($661) in error; Fin support admits malfunction but cannot escalate to a human",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T19:00:04Z"
     },
     {
       "upstream": "anthropics/claude-code#69026",
@@ -15303,17 +15882,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-29T08:57:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#69691",
-      "url": "https://github.com/anthropics/claude-code/issues/69691",
-      "title": "Sub-agent sync-vs-async is session-host-dependent (not version/flag); run_in_background:false not reliably honored — no documented way to force synchronous execution",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-27T00:29:59Z"
+      "updated_at": "2026-06-29T20:26:47Z"
     },
     {
       "upstream": "anthropics/claude-code#69752",
@@ -15344,26 +15913,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-28T06:20:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#70536",
-      "url": "https://github.com/anthropics/claude-code/issues/70536",
-      "title": "[MODEL] Model repeatedly submits incorrect heredoc despite acknowledging the error",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T10:27:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#70702",
-      "url": "https://github.com/anthropics/claude-code/issues/70702",
-      "title": "[DOCS] Sandboxing docs do not explain that hosts allowed via the network prompt are remembered only for the rest of the session",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T16:03:37Z"
     },
     {
       "upstream": "anthropics/claude-code#70741",
@@ -15916,16 +16465,6 @@
       "updated_at": "2026-06-28T05:45:12Z"
     },
     {
-      "upstream": "anthropics/claude-code#71567",
-      "url": "https://github.com/anthropics/claude-code/issues/71567",
-      "title": "[FEATURE] Agent SDK: Add option to skip historical messages when resuming sessions with streaming",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T10:18:22Z"
-    },
-    {
       "upstream": "anthropics/claude-code#71568",
       "url": "https://github.com/anthropics/claude-code/issues/71568",
       "title": "Relocating a project dir (symlink / new mount) orphans all session history, memory & context — project keyed by raw cwd path",
@@ -15934,136 +16473,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-27T08:20:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71577",
-      "url": "https://github.com/anthropics/claude-code/issues/71577",
-      "title": "Claude ignores CLAUDE.md instruction to never git commit/push without explicit user approval",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T16:23:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71608",
-      "url": "https://github.com/anthropics/claude-code/issues/71608",
-      "title": "[Feature Request] Reduce prompts for user feedback on agent performance",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T14:13:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71614",
-      "url": "https://github.com/anthropics/claude-code/issues/71614",
-      "title": "Plan mode: add a \"clear context & implement plan\" action",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T15:08:25Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71643",
-      "url": "https://github.com/anthropics/claude-code/issues/71643",
-      "title": "Attached/pasted images are visible to the model but not written to disk — blocks image-processing tools (sips/ImageMagick)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T18:08:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71661",
-      "url": "https://github.com/anthropics/claude-code/issues/71661",
-      "title": "Status bar shows stale working directory and branch info",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T19:38:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71678",
-      "url": "https://github.com/anthropics/claude-code/issues/71678",
-      "title": "Claude Code binary silently disables transparent huge pages (THP)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T21:17:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71679",
-      "url": "https://github.com/anthropics/claude-code/issues/71679",
-      "title": "[FEATURE] Allow editing proposed diffs in the approval prompt before accepting",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T20:47:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71686",
-      "url": "https://github.com/anthropics/claude-code/issues/71686",
-      "title": "Path-scoped rules (.claude/rules/*.md) silently dropped when matching set exceeds an undocumented size budget",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T21:40:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71690",
-      "url": "https://github.com/anthropics/claude-code/issues/71690",
-      "title": "[DOCS] Voice dictation auto-submit does not document behavior for languages without word spaces (added fix in v2.1.195)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T21:45:51Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71692",
-      "url": "https://github.com/anthropics/claude-code/issues/71692",
-      "title": "[DOCS] `claude agents` background-session docs do not cover data loss when read by an older Claude Code version (v2.1.195 fix)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T21:45:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71693",
-      "url": "https://github.com/anthropics/claude-code/issues/71693",
-      "title": "[DOCS] Agent view docs do not describe control-socket startup failure keeping the supervisor unreachable (fixed in v2.1.195)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T21:46:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71695",
-      "url": "https://github.com/anthropics/claude-code/issues/71695",
-      "title": "[DOCS] Claude Code on the web docs do not document the in-progress provisioning checklist shown while a cloud session container starts (v2.1.195)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-26T21:46:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#71724",
-      "url": "https://github.com/anthropics/claude-code/issues/71724",
-      "title": "Add \"Dismiss\" option to the Create PR branch status widget",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-27T00:41:45Z"
     },
     {
       "upstream": "anthropics/claude-code#71756",
@@ -17386,16 +17795,6 @@
       "updated_at": "2026-06-29T00:31:36Z"
     },
     {
-      "upstream": "anthropics/claude-code#72122",
-      "url": "https://github.com/anthropics/claude-code/issues/72122",
-      "title": "Stale 'running task' indicator after response completes",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-28T19:28:04Z"
-    },
-    {
       "upstream": "anthropics/claude-code#72127",
       "url": "https://github.com/anthropics/claude-code/issues/72127",
       "title": "Workflow tool burned entire 5x plan in ~5 minutes with no warning or authorization prompt",
@@ -17563,7 +17962,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-29T05:31:30Z"
+      "updated_at": "2026-06-29T17:31:08Z"
     },
     {
       "upstream": "anthropics/claude-code#72202",
@@ -17594,6 +17993,176 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-29T09:33:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72238",
+      "url": "https://github.com/anthropics/claude-code/issues/72238",
+      "title": "CronCreate { durable: true } is silently session-only — does not persist (contradicts the tool description)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T12:34:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72243",
+      "url": "https://github.com/anthropics/claude-code/issues/72243",
+      "title": "[FEATURE] Alphabetical sorting of SSH remote hosts in the host picker",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T11:40:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72307",
+      "url": "https://github.com/anthropics/claude-code/issues/72307",
+      "title": "[Bug][cyber] Refactoring stdlib Python modules into a FOSS SDK package and wiring container PYTHONPATH wrongly (req_011CcXwXRJge32P93SCFJfau)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T17:40:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72310",
+      "url": "https://github.com/anthropics/claude-code/issues/72310",
+      "title": "[FEATURE] Add `cache.ruby-lang.org` to allowlist",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T17:39:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72312",
+      "url": "https://github.com/anthropics/claude-code/issues/72312",
+      "title": "[Bug][cyber] ClAudit false-positive in DJI — req_011CcXx519mXa7HjqfZPJPLS",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T17:44:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72313",
+      "url": "https://github.com/anthropics/claude-code/issues/72313",
+      "title": "[Bug][cyber] Wrongly blocked moving stdlib core modules into a FOSS Python SDK package and wiring container im (req_011CcXx4QDZwTyZLrwPi4jSz)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T18:13:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72323",
+      "url": "https://github.com/anthropics/claude-code/issues/72323",
+      "title": "[Bug][cyber] ClAudit false-positive in DJI — req_011CcY1Y8jnEBVLdJRRcdaFA",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T22:08:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72324",
+      "url": "https://github.com/anthropics/claude-code/issues/72324",
+      "title": "[Bug][cyber] False-positive safeguard block stops legitimate cybersecurity assistance mid-session (req_011CcY1kC1p5G4SvH8vm5s6P)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T18:30:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72326",
+      "url": "https://github.com/anthropics/claude-code/issues/72326",
+      "title": "[Bug][cyber] Safety filter blocks legitimate cybersecurity topic assistance in Claude Code session (req_011CcY1kqamR8G6sW1fDj6zF)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T18:30:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72328",
+      "url": "https://github.com/anthropics/claude-code/issues/72328",
+      "title": "[Bug][cyber] Safety block interrupts legitimate security vulnerability analysis workflow (req_011CcY1o5TFLzNFaV7gPUFGo)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T20:06:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72359",
+      "url": "https://github.com/anthropics/claude-code/issues/72359",
+      "title": "Project memory & session context orphaned silently when a repo directory is renamed/moved",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T22:38:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72373",
+      "url": "https://github.com/anthropics/claude-code/issues/72373",
+      "title": "[Bug][cyber] Safety block prevents writing or reviewing code that reads drone telemetry sensor data (req_011CcYR3zvFDq6wKPwZEMFur)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T23:41:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72378",
+      "url": "https://github.com/anthropics/claude-code/issues/72378",
+      "title": "[DOCS] Model config docs omit \"Org default\" and \"Role default\" labels in `/model` picker",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T23:55:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72382",
+      "url": "https://github.com/anthropics/claude-code/issues/72382",
+      "title": "[DOCS] Remote Control docs omit disabling behavior when `ANTHROPIC_BASE_URL` points at a non-Anthropic host",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T23:55:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72383",
+      "url": "https://github.com/anthropics/claude-code/issues/72383",
+      "title": "[DOCS] Workflow docs omit `/deep-research` `unverified` result when verifier failures occur",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T23:57:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72387",
+      "url": "https://github.com/anthropics/claude-code/issues/72387",
+      "title": "[DOCS] Sessions docs omit `/cd` reappearing in old-directory resume list after non-graceful exit with special characters in path",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-29T23:56:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#72393",
+      "url": "https://github.com/anthropics/claude-code/issues/72393",
+      "title": "[FEATURE] opt-in, user-curated, PII-sanitized training data contribution",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-30T00:46:10Z"
     },
     {
       "upstream": "anthropics/claude-code#895",


### PR DESCRIPTION
## Summary
- Refresh `.cache/anthropic/cc-triage.json` from the latest anthropics/claude-code issues.
- Update `.cache/anthropic/cc-fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Anthropic Claude-Code Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/28412610328
- Repository SHA: `9b51fdf53f6ad3527563a8571131679b8dad2455`
- Generated at: `2026-06-30T00:50:21Z`
- Upstream issues scanned: `2990`
- Fact checks: `3`
- Fixed facts verified: `3`
- High/critical unresolved: `0`

## Fixed facts verified

- anthropics/claude-code#61348 via youxuanxue/sub2api#514, youxuanxue/sub2api#518
- anthropics/claude-code#60168, anthropics/claude-code#63885, anthropics/claude-code#64777 via youxuanxue/sub2api (UTF-8/surrogate self-heal)
- anthropics/claude-code#60913 via youxuanxue/sub2api ([1m] context-window model-alias strip)


## Test plan
- [x] `python3 -m json.tool .cache/anthropic/cc-triage.json`
- [x] `python3 -m json.tool .cache/anthropic/cc-fixes.json`
- [x] `python3 -m json.tool .cache/anthropic/cc-fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream/issue-watchdog.py`
- [x] `python3 -m json.tool .cache/anthropic-cc-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/anthropic-cc-issue-watchdog/agent-input.json`
