### PR TITLE
fix(kiro): preserve Claude identity and redact split thinking

### DIFF
--- a/backend/internal/integration/kiro/prompt_filter_test.go
+++ b/backend/internal/integration/kiro/prompt_filter_test.go
@@ -40,3 +40,23 @@ func TestApplyPromptFilters_ClaudeCodeStripsEnvNoise(t *testing.T) {
 	require.NotContains(t, got, "gitStatus")
 	require.NotContains(t, got, "# Environment")
 }
+
+func TestBuildClaudeSystemPrompt_AddsKiroIdentityOverrideWithoutSystemPrompt(t *testing.T) {
+	got := buildClaudeSystemPrompt(nil, false)
+	require.Contains(t, got, "You are Claude, Anthropic's assistant")
+	require.Contains(t, got, "Do not identify as Kiro")
+}
+
+func TestBuildClaudeSystemPrompt_ClaudeCodePreservesPromptWithKiroIdentityOverride(t *testing.T) {
+	ccPrompt := strings.Join([]string{
+		"You are Claude Code, Anthropic's official CLI for Claude.",
+		"You are an interactive agent that helps users with software engineering tasks.",
+		"# doing tasks",
+		"# using your tools",
+	}, "\n")
+
+	got := buildClaudeSystemPrompt([]interface{}{map[string]interface{}{"type": "text", "text": ccPrompt}}, false)
+	require.Contains(t, got, "You are Claude, Anthropic's assistant")
+	require.Contains(t, got, "Do not identify as Kiro")
+	require.Contains(t, got, "You are Claude Code, Anthropic's official CLI for Claude.")
+}

--- a/backend/internal/integration/kiro/thinking_redact.go
+++ b/backend/internal/integration/kiro/thinking_redact.go
@@ -20,22 +20,105 @@ func RedactedThinkingData(thinking string) string {
 // ExtractThinkingFromContent splits inline <thinking>...</thinking> tags that some
 // Kiro models embed in assistantResponseEvent text from the visible answer text.
 func ExtractThinkingFromContent(content string) (visible string, thinking string) {
-	result := content
+	var redactor InlineThinkingRedactor
+	visible, thinking = redactor.Push(content)
+	tailVisible, tailThinking := redactor.Flush()
+	if tailVisible != "" {
+		if visible == "" {
+			visible = tailVisible
+		} else {
+			visible += tailVisible
+		}
+	}
+	if tailThinking != "" {
+		if thinking == "" {
+			thinking = tailThinking
+		} else {
+			thinking += tailThinking
+		}
+	}
+	return strings.TrimSpace(visible), strings.TrimSpace(thinking)
+}
+
+// InlineThinkingRedactor removes inline <thinking>...</thinking> spans from a
+// stream of assistant text chunks. Kiro may split the tags across chunks, so a
+// stateless string replace leaks partial tags and reasoning text.
+type InlineThinkingRedactor struct {
+	pending    string
+	inThinking bool
+}
+
+// Push consumes one upstream assistant text chunk and returns visible text plus
+// extracted reasoning. It may hold a short suffix in pending when that suffix
+// could be the start of a split thinking tag.
+func (r *InlineThinkingRedactor) Push(content string) (visible string, thinking string) {
+	r.pending += content
+	var out strings.Builder
 	var reasoning strings.Builder
 
-	for {
-		start := strings.Index(result, "<thinking>")
+	for r.pending != "" {
+		if r.inThinking {
+			end := strings.Index(r.pending, "</thinking>")
+			if end == -1 {
+				keep := longestTagPrefixSuffix(r.pending, "</thinking>")
+				if len(r.pending) > keep {
+					_, _ = reasoning.WriteString(r.pending[:len(r.pending)-keep])
+					r.pending = r.pending[len(r.pending)-keep:]
+				}
+				break
+			}
+			_, _ = reasoning.WriteString(r.pending[:end])
+			r.pending = r.pending[end+len("</thinking>"):]
+			r.inThinking = false
+			continue
+		}
+
+		start := strings.Index(r.pending, "<thinking>")
 		if start == -1 {
+			keep := longestTagPrefixSuffix(r.pending, "<thinking>")
+			if len(r.pending) > keep {
+				_, _ = out.WriteString(r.pending[:len(r.pending)-keep])
+				r.pending = r.pending[len(r.pending)-keep:]
+			}
 			break
 		}
-		end := strings.Index(result[start:], "</thinking>")
-		if end == -1 {
-			break
-		}
-		end += start
-		_, _ = reasoning.WriteString(result[start+len("<thinking>") : end])
-		result = result[:start] + result[end+len("</thinking>"):]
+		_, _ = out.WriteString(r.pending[:start])
+		r.pending = r.pending[start+len("<thinking>"):]
+		r.inThinking = true
 	}
 
-	return strings.TrimSpace(result), strings.TrimSpace(reasoning.String())
+	return out.String(), reasoning.String()
+}
+
+// Flush releases any text held for split-tag detection. If upstream ends while a
+// thinking block is still open, the buffered tail is treated as reasoning so it
+// remains redacted rather than leaking into visible text.
+func (r *InlineThinkingRedactor) Flush() (visible string, thinking string) {
+	if r.pending == "" {
+		return "", ""
+	}
+	if r.inThinking {
+		thinking = r.pending
+	} else if longestTagPrefixSuffix(r.pending, "<thinking>") == len(r.pending) ||
+		longestTagPrefixSuffix(r.pending, "</thinking>") == len(r.pending) {
+		thinking = r.pending
+	} else {
+		visible = r.pending
+	}
+	r.pending = ""
+	r.inThinking = false
+	return visible, thinking
+}
+
+func longestTagPrefixSuffix(s, tag string) int {
+	max := len(tag) - 1
+	if len(s) < max {
+		max = len(s)
+	}
+	for n := max; n > 0; n-- {
+		if strings.HasSuffix(s, tag[:n]) {
+			return n
+		}
+	}
+	return 0
 }

--- a/backend/internal/integration/kiro/thinking_redact_test.go
+++ b/backend/internal/integration/kiro/thinking_redact_test.go
@@ -16,6 +16,54 @@ func TestExtractThinkingFromContent(t *testing.T) {
 	require.Equal(t, "internal", thinking)
 }
 
+func TestInlineThinkingRedactor_SplitTagsAcrossChunks(t *testing.T) {
+	var redactor InlineThinkingRedactor
+
+	visible, thinking := redactor.Push("<thin")
+	require.Empty(t, visible)
+	require.Empty(t, thinking)
+
+	visible, thinking = redactor.Push("king>secret")
+	require.Empty(t, visible)
+	require.Equal(t, "secret", thinking)
+
+	visible, thinking = redactor.Push(" plan</thin")
+	require.Empty(t, visible)
+	require.Equal(t, " plan", thinking)
+
+	visible, thinking = redactor.Push("king>Visible")
+	require.Equal(t, "Visible", visible)
+	require.Empty(t, thinking)
+
+	visible, thinking = redactor.Flush()
+	require.Empty(t, visible)
+	require.Empty(t, thinking)
+}
+
+func TestInlineThinkingRedactor_UnclosedThinkingFlushesAsThinking(t *testing.T) {
+	var redactor InlineThinkingRedactor
+
+	visible, thinking := redactor.Push("prefix <thinking>secret")
+	require.Equal(t, "prefix ", visible)
+	require.Equal(t, "secret", thinking)
+
+	visible, thinking = redactor.Flush()
+	require.Empty(t, visible)
+	require.Empty(t, thinking)
+}
+
+func TestInlineThinkingRedactor_FlushRedactsTrailingTagFragment(t *testing.T) {
+	var redactor InlineThinkingRedactor
+
+	visible, thinking := redactor.Push("visible <thin")
+	require.Equal(t, "visible ", visible)
+	require.Empty(t, thinking)
+
+	visible, thinking = redactor.Flush()
+	require.Empty(t, visible)
+	require.Equal(t, "<thin", thinking)
+}
+
 func TestRedactedThinkingData_DeterministicOpaque(t *testing.T) {
 	a := RedactedThinkingData("reasoning text")
 	b := RedactedThinkingData("reasoning text")

--- a/backend/internal/integration/kiro/translator.go
+++ b/backend/internal/integration/kiro/translator.go
@@ -196,6 +196,11 @@ type ClaudeUsage struct {
 
 const maxToolDescLen = 10237
 
+const kiroClaudeIdentityOverride = `Kiro mirror identity override:
+- You are Claude, Anthropic's assistant.
+- If asked who you are, answer as Claude/Anthropic. Do not identify as Kiro or as an AI development environment.
+- Treat Kiro as a transport layer only, not as your assistant identity.`
+
 func ClaudeToKiro(req *ClaudeRequest, thinking bool) *KiroPayload {
 	modelID := MapModel(req.Model)
 	origin := "AI_EDITOR"
@@ -345,8 +350,13 @@ func ClaudeToKiro(req *ClaudeRequest, thinking bool) *KiroPayload {
 }
 
 func buildClaudeSystemPrompt(system interface{}, thinking bool) string {
-	systemPrompt := extractSystemPrompt(system)
-	systemPrompt = applyPromptFilters(systemPrompt)
+	rawSystemPrompt := extractSystemPrompt(system)
+	systemPrompt := applyPromptFilters(rawSystemPrompt)
+	if systemPrompt == "" {
+		systemPrompt = kiroClaudeIdentityOverride
+	} else {
+		systemPrompt = kiroClaudeIdentityOverride + "\n\n" + systemPrompt
+	}
 	if !thinking {
 		return systemPrompt
 	}

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -128,6 +128,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		thinkingBuf string
 		toolUses    []kiroproto.KiroToolUse
 		callbackErr error
+		redactor    kiroproto.InlineThinkingRedactor
 	)
 
 	callback := &kiroproto.KiroStreamCallback{
@@ -135,7 +136,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 			if isThinking {
 				thinkingBuf += text
 			} else {
-				visible, inlineThinking := kiroproto.ExtractThinkingFromContent(text)
+				visible, inlineThinking := redactor.Push(text)
 				if inlineThinking != "" {
 					thinkingBuf += inlineThinking
 				}
@@ -160,6 +161,10 @@ func (s *KiroGatewayService) forwardNonStreaming(
 	}
 	if callbackErr != nil {
 		return nil, fmt.Errorf("kiro stream error: %w", callbackErr)
+	}
+	if visible, inlineThinking := redactor.Flush(); visible != "" || inlineThinking != "" {
+		textBuf += visible
+		thinkingBuf += inlineThinking
 	}
 
 	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
@@ -235,6 +240,7 @@ func (s *KiroGatewayService) forwardStreaming(
 		toolUses    []kiroproto.KiroToolUse
 		callbackErr error
 		firstTokMs  *int
+		redactor    kiroproto.InlineThinkingRedactor
 	)
 
 	markFirstToken := func() {
@@ -259,7 +265,7 @@ func (s *KiroGatewayService) forwardStreaming(
 				thinkingBuf += text
 				enc.writeThinkingDelta(text)
 			} else {
-				visible, inlineThinking := kiroproto.ExtractThinkingFromContent(text)
+				visible, inlineThinking := redactor.Push(text)
 				if inlineThinking != "" {
 					thinkingBuf += inlineThinking
 					enc.writeThinkingDelta(inlineThinking)
@@ -307,6 +313,16 @@ func (s *KiroGatewayService) forwardStreaming(
 	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
 	// inputTokens was already computed for the encoder (message_start.usage); reuse
 	// it for the ForwardResult so the two never drift.
+	if visible, inlineThinking := redactor.Flush(); visible != "" || inlineThinking != "" {
+		if inlineThinking != "" {
+			thinkingBuf += inlineThinking
+			enc.writeThinkingDelta(inlineThinking)
+		}
+		if visible != "" {
+			textBuf += visible
+			enc.writeTextDelta(visible)
+		}
+	}
 	inputTokens := enc.inputTokens
 	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, toolUses)
 

--- a/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
+++ b/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -114,4 +115,42 @@ func TestKiroGatewayService_Forward_Streaming_WithReasoningEvent(t *testing.T) {
 	require.Contains(t, out, "final answer")
 	require.NotContains(t, out, "thinking_delta")
 	require.NotContains(t, out, "plan step one")
+}
+
+func TestKiroGatewayService_Forward_Streaming_RedactsSplitInlineThinkingTags(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	body := []byte{}
+	for _, content := range []string{
+		"<thin",
+		"king>\nThe user asks who I am.",
+		" I must not expose this.</thin",
+		"king>I am Claude.",
+	} {
+		body = append(body, buildKiroEventStreamMessage("assistantResponseEvent",
+			[]byte(`{"content":`+strconv.Quote(content)+`}`))...)
+	}
+	upstream := &kiroFakeUpstream{body: body}
+
+	svc := NewKiroGatewayService(upstream, nil)
+	reqBody, _ := json.Marshal(map[string]any{
+		"model":      "claude-sonnet-4-6",
+		"messages":   []map[string]any{{"role": "user", "content": "who are you"}},
+		"max_tokens": 32,
+		"stream":     true,
+	})
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(reqBody), Model: "claude-sonnet-4-6", Stream: true}
+
+	_, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), parsed, time.Now())
+	require.NoError(t, err)
+
+	out := rec.Body.String()
+	require.Contains(t, out, `"type":"redacted_thinking"`)
+	require.Contains(t, out, "I am Claude.")
+	require.NotContains(t, out, "<thinking>")
+	require.NotContains(t, out, "</thinking>")
+	require.NotContains(t, out, "The user asks who I am.")
+	require.NotContains(t, out, "thinking_delta")
 }


### PR DESCRIPTION
## 摘要
- 修复 Kiro upstream 将 `<thinking>` 跨 chunk 混在 `assistantResponseEvent.content` 时泄漏到 `text_delta` 的问题，stream / non-stream 都复用状态机抽取 reasoning。
- Kiro 的 Claude 转换默认注入 Claude/Anthropic 身份约束，避免 `claude-sonnet-4-6` 通过 Kiro 链路回答成 Kiro。
- sentinel-registry-reviewed：本次修改落在既有 Kiro translator/gateway sentinel 覆盖面内，未新增需要锚定的新入口。

## 风险
- 行为影响限定在 Kiro Claude 协议转换链路；非 Kiro 账号和 Web UI 无影响。
- reasoning 仍计入本地估算输出 token，但客户端只看到 `redacted_thinking`，不看到明文 reasoning。
- Web impact: none。

## 验证
- `go test -tags=unit ./internal/integration/kiro/... ./internal/service/ -count=1`
- `./scripts/preflight.sh`
- 已在修复前用 prod → account 66 → api-us6 复现：stream 明文泄漏 `<thinking>`，identity 回答为 Kiro；合并部署后会用同一 reserved probe 复测。

## 提交
- bea872d22 fix(kiro): preserve Claude identity and redact split thinking
- 最新提交：bea872d22
