### PR TITLE
chore(skill): Codex 可加载 release-rollout skill frontmatter

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: tokenkey-stage0-release-rollout
-description: >-
-  Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, rollback, and release-risk checks. Use for release tagging, deploy-stage0, Lightsail edge rollout, structured smoke results, or post-release OAuth checks.
+description: Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, rollback, and release-risk checks. Use for release tagging, deploy-stage0, Lightsail edge rollout, structured smoke results, or post-release OAuth checks.
 ---
 
 # TokenKey：Stage0 release → prod/Edge rollout → 真实测试


### PR DESCRIPTION
## 摘要

- 将 `tokenkey-stage0-release-rollout/SKILL.md` 的 `description: >-` 改为 agentskills 规范的单行 `description:`，避免 Codex 报 `missing YAML frontmatter delimited by ---`。
- 升级 `dev-rules` 子模块：`check_codex_skill_limits.py` 新增 UTF-8 BOM、frontmatter 缺失、`name` 与目录名不一致的 preflight 拦截。

## 风险

- 低风险：仅 skill 元数据与 dev-rules 机械门禁；无运行时/API/契约行为变化。

## 验证

- `python3 dev-rules/scripts/check_codex_skill_limits.py --self-test` — PASS
- `python3 dev-rules/scripts/check_codex_skill_limits.py --root .` — 25 skills frontmatter OK
- `./scripts/preflight.sh` — PASS（commit hook）

## 提交

- `1f28a518d` chore(skill): normalize release-rollout frontmatter for Codex load

最新提交：1f28a518d
