### PR TITLE
fix(stage0): include kiro pool in edge native smoke

### DIFF
--- a/ops/stage0/edge_native_anthropic_smoke.sh
+++ b/ops/stage0/edge_native_anthropic_smoke.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-# edge_native_anthropic_smoke.sh — realistic per-account Anthropic OAuth smoke on an edge host.
+# edge_native_anthropic_smoke.sh — realistic per-account Anthropic/Kiro native smoke on an edge host.
 #
-# Runs ON the edge machine (SSM / run-probe). For each schedulable native OAuth account
-# in the default group, binds a reserved __tk_probe_* key and sends one in-container
-# /v1/messages request with Claude Code-shaped payload (smoke_anthropic_realistic.py).
+# Runs ON the edge machine (SSM / run-probe). For each schedulable native /v1/messages
+# account (Anthropic OAuth in the default group, plus Kiro's platform-wide pool), binds
+# a reserved __tk_probe_* key and sends one in-container request with Claude Code-shaped
+# payload (smoke_anthropic_realistic.py).
 #
 # Env:
 #   ANTHROPIC_MODELS          space/comma separated model ids (default: claude-sonnet-4-6)
-#   ANTHROPIC_SOURCE_GROUP    edge OAuth pool group name (default: default)
+#   ANTHROPIC_SOURCE_GROUP    edge Anthropic OAuth pool group name (default: default)
 #   PROBE_ACCOUNT_MODEL_SH    path to probe_account_model.sh (default: same dir)
 #   SMOKE_ANTHROPIC_REALISTIC_PY  path to payload builder (default: same dir)
 set -euo pipefail
@@ -45,35 +46,42 @@ fi
 
 PSQL=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
 
-account_ids="$("${PSQL[@]}" -c "
+account_rows="$("${PSQL[@]}" -c "
 SELECT a.id
+     , a.platform
 FROM accounts a
-JOIN account_groups ag ON ag.account_id = a.id
-JOIN groups g ON g.id = ag.group_id
-WHERE a.platform = 'anthropic'
+LEFT JOIN account_groups ag ON ag.account_id = a.id
+LEFT JOIN groups g ON g.id = ag.group_id
+  AND g.name = '${ANTHROPIC_SOURCE_GROUP//\'/''}'
+  AND g.deleted_at IS NULL
+WHERE a.platform IN ('anthropic', 'kiro')
   AND a.deleted_at IS NULL
   AND a.schedulable = true
   AND a.status = 'active'
   AND a.type IN ('oauth', 'setup_token')
-  AND g.name = '${ANTHROPIC_SOURCE_GROUP//\'/''}'
-  AND g.deleted_at IS NULL
+  AND (
+    (a.platform = 'anthropic' AND g.id IS NOT NULL)
+    OR a.platform = 'kiro'
+  )
+GROUP BY a.id, a.platform
 ORDER BY a.id;
-" | tr -d '[:space:]' | sed 's/|/ /g')"
+" | awk 'NF {print}')"
 
-if [[ -z "${account_ids// }" ]]; then
-  echo "tk_edge_native_anthropic_smoke: no schedulable anthropic OAuth accounts in group=${ANTHROPIC_SOURCE_GROUP}" >&2
+if [[ -z "${account_rows// }" ]]; then
+  echo "tk_edge_native_anthropic_smoke: no schedulable anthropic OAuth accounts in group=${ANTHROPIC_SOURCE_GROUP} and no schedulable kiro accounts" >&2
   exit 1
 fi
 
-echo "tk_edge_native_anthropic_smoke: group=${ANTHROPIC_SOURCE_GROUP} models=${models[*]} accounts=${account_ids}"
+echo "tk_edge_native_anthropic_smoke: group=${ANTHROPIC_SOURCE_GROUP} models=${models[*]} accounts=${account_rows//$'\n'/ }"
 
 hard_fail=0
 soft_only=0
 served=0
 
-for account_id in ${account_ids}; do
+while IFS='|' read -r account_id account_platform; do
+  [[ -n "${account_id}" ]] || continue
   for model in "${models[@]}"; do
-    echo "tk_edge_native_anthropic_smoke: probe account_id=${account_id} model=${model}"
+    echo "tk_edge_native_anthropic_smoke: probe account_id=${account_id} platform=${account_platform} model=${model}"
   probe_json="$(
     SMOKE_ANTHROPIC_REALISTIC_PY="$REALISTIC_PY" \
     TK_SMOKE_ANTHROPIC_REALISTIC=1 \
@@ -86,7 +94,7 @@ for account_id in ${account_ids}; do
   )"
     verdict="$(jq -r '.verdict // empty' <<<"$probe_json")"
     http_code="$(jq -r '.http_code // empty' <<<"$probe_json")"
-    echo "tk_edge_native_anthropic_smoke: account_id=${account_id} model=${model} verdict=${verdict} http=${http_code}"
+    echo "tk_edge_native_anthropic_smoke: account_id=${account_id} platform=${account_platform} model=${model} verdict=${verdict} http=${http_code}"
 
     case "$verdict" in
       servable|uncorrelated_success)
@@ -94,35 +102,35 @@ for account_id in ${account_ids}; do
         ;;
       upstream_rejected)
         if [[ "$http_code" == "401" || "$http_code" == "403" ]]; then
-          echo "::error::tk_edge_native_anthropic_smoke: account_id=${account_id} model=${model} auth rejected (HTTP ${http_code}) — re-OAuth or fix credentials" >&2
+          echo "::error::tk_edge_native_anthropic_smoke: account_id=${account_id} platform=${account_platform} model=${model} auth rejected (HTTP ${http_code}) — re-OAuth or fix credentials" >&2
           jq -c '{verdict,http_code,target_account:{id,name,error_message},response:{body_excerpt}}' <<<"$probe_json" >&2 || true
           hard_fail=1
         else
-          echo "::warning::tk_edge_native_anthropic_smoke: account_id=${account_id} model=${model} upstream HTTP ${http_code} (not deploy-blocking)" >&2
+          echo "::warning::tk_edge_native_anthropic_smoke: account_id=${account_id} platform=${account_platform} model=${model} upstream HTTP ${http_code} (not deploy-blocking)" >&2
           soft_only=1
         fi
         ;;
       gateway_rejected)
         if [[ "$http_code" == "429" ]]; then
-          echo "::warning::tk_edge_native_anthropic_smoke: account_id=${account_id} model=${model} rate-limited / pool exhausted (HTTP 429) — not a deploy regression" >&2
+          echo "::warning::tk_edge_native_anthropic_smoke: account_id=${account_id} platform=${account_platform} model=${model} rate-limited / pool exhausted (HTTP 429) — not a deploy regression" >&2
           soft_only=1
         else
-          echo "::error::tk_edge_native_anthropic_smoke: account_id=${account_id} model=${model} gateway rejected HTTP ${http_code}" >&2
+          echo "::error::tk_edge_native_anthropic_smoke: account_id=${account_id} platform=${account_platform} model=${model} gateway rejected HTTP ${http_code}" >&2
           hard_fail=1
         fi
         ;;
       wrong_account|setup_error)
-        echo "::error::tk_edge_native_anthropic_smoke: account_id=${account_id} model=${model} probe ${verdict}" >&2
+        echo "::error::tk_edge_native_anthropic_smoke: account_id=${account_id} platform=${account_platform} model=${model} probe ${verdict}" >&2
         jq -c '{verdict,error,probe}' <<<"$probe_json" >&2 || true
         hard_fail=1
         ;;
       *)
-        echo "::error::tk_edge_native_anthropic_smoke: account_id=${account_id} model=${model} unknown verdict=${verdict}" >&2
+        echo "::error::tk_edge_native_anthropic_smoke: account_id=${account_id} platform=${account_platform} model=${model} unknown verdict=${verdict}" >&2
         hard_fail=1
         ;;
     esac
   done
-done
+done <<<"$account_rows"
 
 if [[ "$hard_fail" -ne 0 ]]; then
   exit 1

--- a/ops/stage0/test_edge_native_anthropic_smoke.py
+++ b/ops/stage0/test_edge_native_anthropic_smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for edge_native_anthropic_smoke.sh model parsing."""
+"""Tests for edge_native_anthropic_smoke.sh model/account parsing."""
 from __future__ import annotations
 
 import os
@@ -13,7 +13,11 @@ _SCRIPT = pathlib.Path(__file__).resolve().parent / "edge_native_anthropic_smoke
 
 
 class EdgeNativeAnthropicSmokeTest(unittest.TestCase):
-    def _run_smoke(self, models: str) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    def _run_smoke(
+        self,
+        models: str,
+        account_rows: str = "66|kiro",
+    ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
         with tempfile.TemporaryDirectory(prefix="edge-native-smoke-test-") as td:
             tmpdir = pathlib.Path(td)
             bin_dir = tmpdir / "bin"
@@ -25,7 +29,7 @@ class EdgeNativeAnthropicSmokeTest(unittest.TestCase):
                 textwrap.dedent(
                     """\
                     #!/usr/bin/env bash
-                    printf '%s\n' "${FAKE_ACCOUNT_IDS:-66}"
+                    printf '%s\n' "${FAKE_ACCOUNT_ROWS:-66|kiro}"
                     """
                 )
             )
@@ -67,6 +71,7 @@ class EdgeNativeAnthropicSmokeTest(unittest.TestCase):
                 "PROBE_ACCOUNT_MODEL_SH": str(probe),
                 "SMOKE_ANTHROPIC_REALISTIC_PY": str(realistic),
                 "PROBE_MODEL_LOG": str(model_log),
+                "FAKE_ACCOUNT_ROWS": account_rows,
             }
             proc = subprocess.run(
                 ["bash", str(_SCRIPT)],
@@ -83,6 +88,7 @@ class EdgeNativeAnthropicSmokeTest(unittest.TestCase):
 
         self.assertEqual(proc.returncode, 0, msg=proc.stderr)
         self.assertEqual(logged_models, ["claude-sonnet-4-6"])
+        self.assertIn("probe account_id=66 platform=kiro model=claude-sonnet-4-6", proc.stdout)
         self.assertIn("OK served=1", proc.stdout)
         self.assertNotIn("no models configured", proc.stderr)
 
@@ -91,6 +97,15 @@ class EdgeNativeAnthropicSmokeTest(unittest.TestCase):
 
         self.assertEqual(proc.returncode, 0, msg=proc.stderr)
         self.assertEqual(logged_models, ["claude-a", "claude-b"])
+        self.assertIn("OK served=2", proc.stdout)
+
+    def test_multiple_native_account_rows_are_probed_with_platforms(self) -> None:
+        proc, logged_models = self._run_smoke("claude-sonnet-4-6", "11|anthropic\n66|kiro")
+
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(logged_models, ["claude-sonnet-4-6", "claude-sonnet-4-6"])
+        self.assertIn("probe account_id=11 platform=anthropic model=claude-sonnet-4-6", proc.stdout)
+        self.assertIn("probe account_id=66 platform=kiro model=claude-sonnet-4-6", proc.stdout)
         self.assertIn("OK served=2", proc.stdout)
 
 


### PR DESCRIPTION
## Summary
- Treat Kiro as a native /v1/messages edge pool in edge-native smoke
- Keep Anthropic OAuth scoped to the configured source group while probing Kiro platform-wide accounts
- Extend deterministic smoke tests to cover account row platform parsing

## Verification
- python3 -m unittest ops.stage0.test_edge_native_anthropic_smoke -v
- python3 -m unittest discover -s ops/stage0 -p 'test_*.py' -t ops/stage0 -v\n- ./scripts/preflight.sh\n\n## Checklist\n- [x] sentinel-registry-reviewed\n- [x] Web impact: none