### PR TITLE
fix(stage0): upsert reusable probe groups

### DIFF
--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -159,38 +159,20 @@ trap cleanup EXIT
 
 if [[ "$PROBE_REUSE_MODE" == "1" ]]; then
   GROUP_ID="$("${PSQL[@]}" -c "
-WITH existing AS (
-  SELECT id
-  FROM groups
-  WHERE name = '$(sql_escape "$GROUP_NAME")'
-    AND deleted_at IS NULL
-  ORDER BY id
-  LIMIT 1
-),
-inserted AS (
-  INSERT INTO groups (
-    name, description, platform, rate_multiplier, is_exclusive, status,
-    subscription_type, default_validity_days, claude_code_only,
-    model_routing_enabled, model_routing, sort_order, rpm_limit, created_at, updated_at
-  )
-  SELECT
-    '$(sql_escape "$GROUP_NAME")',
-    'reserved reusable account/model probe group; direct probe key only; excluded from universal routing',
-    '$(sql_escape "$PLATFORM")',
-    1.0, true, 'active',
-    'standard', 30, false,
-    false, '{}'::jsonb, 2147483000, 0, NOW(), NOW()
-  WHERE NOT EXISTS (SELECT 1 FROM existing)
-  RETURNING id
-),
-picked AS (
-  SELECT id FROM inserted
-  UNION ALL
-  SELECT id FROM existing
-  LIMIT 1
+INSERT INTO groups (
+  name, description, platform, rate_multiplier, is_exclusive, status,
+  subscription_type, default_validity_days, claude_code_only,
+  model_routing_enabled, model_routing, sort_order, rpm_limit, created_at, updated_at
+) VALUES (
+  '$(sql_escape "$GROUP_NAME")',
+  'reserved reusable account/model probe group; direct probe key only; excluded from universal routing',
+  '$(sql_escape "$PLATFORM")',
+  1.0, true, 'active',
+  'standard', 30, false,
+  false, '{}'::jsonb, 2147483000, 0, NOW(), NOW()
 )
-UPDATE groups g
-SET
+ON CONFLICT (name) WHERE (deleted_at IS NULL)
+DO UPDATE SET
   description = 'reserved reusable account/model probe group; direct probe key only; excluded from universal routing',
   platform = '$(sql_escape "$PLATFORM")',
   rate_multiplier = 1.0,
@@ -204,9 +186,7 @@ SET
   sort_order = 2147483000,
   rpm_limit = 0,
   updated_at = NOW()
-FROM picked
-WHERE g.id = picked.id
-RETURNING g.id;
+RETURNING id;
 " | tr -d '[:space:]')"
 else
   GROUP_ID="$("${PSQL[@]}" -c "

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Static regression tests for probe_account_model.sh."""
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent / "probe_account_model.sh"
+
+
+class ProbeAccountModelTest(unittest.TestCase):
+    def test_reusable_group_ensure_uses_upsert_returning_id(self) -> None:
+        script = _SCRIPT.read_text()
+        start = script.index('if [[ "$PROBE_REUSE_MODE" == "1" ]]; then\n  GROUP_ID=')
+        end = script.index('else\n  GROUP_ID=', start)
+        group_ensure = script[start:end]
+
+        self.assertIn("ON CONFLICT (name) WHERE (deleted_at IS NULL)", group_ensure)
+        self.assertIn("DO UPDATE SET", group_ensure)
+        self.assertIn("RETURNING id;", group_ensure)
+        self.assertNotIn("WITH existing AS", group_ensure)
+        self.assertNotIn("FROM picked", group_ensure)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace the reusable account-model probe group CTE/update path with INSERT ... ON CONFLICT ... RETURNING id
- Add a regression test for the group ensure SQL shape

## Verification
- python3 -m unittest ops.stage0.test_probe_account_model -v
- python3 -m unittest discover -s ops/stage0 -p 'test_*.py' -t ops/stage0 -v\n- ./scripts/preflight.sh\n\n## Checklist\n- [x] sentinel-registry-reviewed\n- [x] Web impact: none