### PR TITLE
fix(stage0): prepare reusable probe groups in two steps

### DIFF
--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -159,20 +159,19 @@ trap cleanup EXIT
 
 if [[ "$PROBE_REUSE_MODE" == "1" ]]; then
   GROUP_ID="$("${PSQL[@]}" -c "
-INSERT INTO groups (
-  name, description, platform, rate_multiplier, is_exclusive, status,
-  subscription_type, default_validity_days, claude_code_only,
-  model_routing_enabled, model_routing, sort_order, rpm_limit, created_at, updated_at
-) VALUES (
-  '$(sql_escape "$GROUP_NAME")',
-  'reserved reusable account/model probe group; direct probe key only; excluded from universal routing',
-  '$(sql_escape "$PLATFORM")',
-  1.0, true, 'active',
-  'standard', 30, false,
-  false, '{}'::jsonb, 2147483000, 0, NOW(), NOW()
-)
-ON CONFLICT (name) WHERE (deleted_at IS NULL)
-DO UPDATE SET
+SELECT COALESCE((
+  SELECT id::text
+  FROM groups
+  WHERE name = '$(sql_escape "$GROUP_NAME")'
+    AND deleted_at IS NULL
+  ORDER BY id
+  LIMIT 1
+), '');
+" | tr -d '\n')"
+  if [[ -n "$GROUP_ID" ]]; then
+    GROUP_ID="$("${PSQL[@]}" -c "
+UPDATE groups
+SET
   description = 'reserved reusable account/model probe group; direct probe key only; excluded from universal routing',
   platform = '$(sql_escape "$PLATFORM")',
   rate_multiplier = 1.0,
@@ -186,8 +185,28 @@ DO UPDATE SET
   sort_order = 2147483000,
   rpm_limit = 0,
   updated_at = NOW()
+WHERE id = ${GROUP_ID}
+  AND name = '$(sql_escape "$GROUP_NAME")'
+  AND deleted_at IS NULL
 RETURNING id;
 " | tr -d '[:space:]')"
+  else
+    GROUP_ID="$("${PSQL[@]}" -c "
+INSERT INTO groups (
+  name, description, platform, rate_multiplier, is_exclusive, status,
+  subscription_type, default_validity_days, claude_code_only,
+  model_routing_enabled, model_routing, sort_order, rpm_limit, created_at, updated_at
+) VALUES (
+  '$(sql_escape "$GROUP_NAME")',
+  'reserved reusable account/model probe group; direct probe key only; excluded from universal routing',
+  '$(sql_escape "$PLATFORM")',
+  1.0, true, 'active',
+  'standard', 30, false,
+  false, '{}'::jsonb, 2147483000, 0, NOW(), NOW()
+)
+RETURNING id;
+" | tr -d '[:space:]')"
+  fi
 else
   GROUP_ID="$("${PSQL[@]}" -c "
 INSERT INTO groups (
@@ -206,7 +225,7 @@ INSERT INTO groups (
 fi
 
 if [[ ! "$GROUP_ID" =~ ^[0-9]+$ ]]; then
-  fail_json "failed to prepare probe group"
+  fail_json "failed to prepare probe group name=${GROUP_NAME} platform=${PLATFORM}"
 fi
 
 "${PSQL[@]}" -c "

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -9,15 +9,18 @@ _SCRIPT = pathlib.Path(__file__).resolve().parent / "probe_account_model.sh"
 
 
 class ProbeAccountModelTest(unittest.TestCase):
-    def test_reusable_group_ensure_uses_upsert_returning_id(self) -> None:
+    def test_reusable_group_ensure_uses_two_step_returning_id(self) -> None:
         script = _SCRIPT.read_text()
         start = script.index('if [[ "$PROBE_REUSE_MODE" == "1" ]]; then\n  GROUP_ID=')
         end = script.index('else\n  GROUP_ID=', start)
         group_ensure = script[start:end]
 
-        self.assertIn("ON CONFLICT (name) WHERE (deleted_at IS NULL)", group_ensure)
-        self.assertIn("DO UPDATE SET", group_ensure)
+        self.assertIn("SELECT id::text", group_ensure)
+        self.assertIn("if [[ -n \"$GROUP_ID\" ]]; then", group_ensure)
+        self.assertIn("UPDATE groups", group_ensure)
+        self.assertIn("INSERT INTO groups", group_ensure)
         self.assertIn("RETURNING id;", group_ensure)
+        self.assertNotIn("ON CONFLICT", group_ensure)
         self.assertNotIn("WITH existing AS", group_ensure)
         self.assertNotIn("FROM picked", group_ensure)
 


### PR DESCRIPTION
## Summary
- Prepare reusable account-model probe groups with explicit select/update-or-insert steps under the probe lock
- Avoid relying on ON CONFLICT / CTE semantics for first-time group creation
- Keep regression coverage for the group ensure SQL shape

## Verification
- python3 -m unittest ops.stage0.test_probe_account_model -v
- python3 -m unittest discover -s ops/stage0 -p 'test_*.py' -t ops/stage0 -v\n- ./scripts/preflight.sh\n\n## Checklist\n- [x] sentinel-registry-reviewed\n- [x] Web impact: none