### PR TITLE
fix(studio): 修复工作室生图 BakeOff / ImageStudio / newapi 分组

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -1928,6 +1928,37 @@ func TestAnthropicToResponsesResponse_NoCacheTokens(t *testing.T) {
 	assert.Nil(t, out.Usage.InputTokensDetails)
 }
 
+func TestAnthropicToResponsesResponse_AssistantImageBlockBecomesMarkdown(t *testing.T) {
+	resp := &AnthropicResponse{
+		ID:    "msg_img",
+		Model: "gemini-3.1-flash-image",
+		Content: []AnthropicContentBlock{
+			{
+				Type: "image",
+				Source: &AnthropicImageSource{
+					Type:      "base64",
+					MediaType: "image/png",
+					Data:      "QUJD",
+				},
+			},
+		},
+		StopReason: "end_turn",
+	}
+
+	out := AnthropicToResponsesResponse(resp)
+	require.Len(t, out.Output, 1)
+	require.Equal(t, "message", out.Output[0].Type)
+	require.Len(t, out.Output[0].Content, 1)
+	require.Equal(t, "output_text", out.Output[0].Content[0].Type)
+	require.Equal(t, "![image](data:image/png;base64,QUJD)", out.Output[0].Content[0].Text)
+
+	chat := ResponsesToChatCompletions(out, resp.Model)
+	require.Len(t, chat.Choices, 1)
+	var contentText string
+	require.NoError(t, json.Unmarshal(chat.Choices[0].Message.Content, &contentText))
+	require.Contains(t, contentText, "![image](data:image/png;base64,QUJD)")
+}
+
 func TestAnthropicEventToResponses_CacheTokensRoundTripFromMessageStart(t *testing.T) {
 	state := NewAnthropicEventToResponsesState()
 

--- a/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
@@ -50,6 +50,13 @@ func AnthropicToResponsesResponse(resp *AnthropicResponse) *ResponsesResponse {
 					Text: block.Text,
 				})
 			}
+		case "image":
+			if uri := anthropicImageToDataURI(block.Source); uri != "" {
+				msgParts = append(msgParts, ResponsesContentPart{
+					Type: "output_text",
+					Text: fmt.Sprintf("![image](%s)", uri),
+				})
+			}
 		case "tool_use":
 			args := "{}"
 			if len(block.Input) > 0 {

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -2801,6 +2801,21 @@ func convertGeminiToClaudeMessage(geminiResp map[string]any, originalModel strin
 								"text": text,
 							})
 						}
+						if inline, ok := pm["inlineData"].(map[string]any); ok {
+							if markdown := geminiInlineDataToImageMarkdown(inline); markdown != "" {
+								contentBlocks = append(contentBlocks, map[string]any{
+									"type": "text",
+									"text": markdown,
+								})
+							}
+						} else if inline, ok := pm["inline_data"].(map[string]any); ok {
+							if markdown := geminiInlineDataToImageMarkdown(inline); markdown != "" {
+								contentBlocks = append(contentBlocks, map[string]any{
+									"type": "text",
+									"text": markdown,
+								})
+							}
+						}
 						if fc, ok := pm["functionCall"].(map[string]any); ok {
 							name, _ := fc["name"].(string)
 							if strings.TrimSpace(name) == "" {
@@ -2841,6 +2856,31 @@ func convertGeminiToClaudeMessage(geminiResp map[string]any, originalModel strin
 	}
 
 	return resp, usage
+}
+
+// geminiInlineDataToImageMarkdown mirrors antigravity/new-api: gemini-native image
+// models return inline bytes in candidates[].content.parts[].inlineData; chat
+// completions clients (ImageStudio extractChatImageItems) expect markdown in
+// choices[].message.content.
+func geminiInlineDataToImageMarkdown(inline map[string]any) string {
+	if inline == nil {
+		return ""
+	}
+	data, _ := inline["data"].(string)
+	if data == "" {
+		return ""
+	}
+	mime, _ := inline["mimeType"].(string)
+	if mime == "" {
+		mime, _ = inline["mime_type"].(string)
+	}
+	if mime == "" {
+		mime = "image/png"
+	}
+	if !strings.HasPrefix(strings.ToLower(mime), "image/") {
+		return ""
+	}
+	return fmt.Sprintf("![image](data:%s;base64,%s)", mime, data)
 }
 
 func extractGeminiUsage(data []byte) *ClaudeUsage {

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -981,3 +981,40 @@ func parseAnthropicContentBlockEvents(t *testing.T, raw string) []anthropicConte
 	}
 	return events
 }
+
+func TestConvertGeminiToClaudeMessage_EmbedsInlineImageMarkdown(t *testing.T) {
+	t.Parallel()
+
+	geminiResp := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"parts": []any{
+						map[string]any{
+							"inlineData": map[string]any{
+								"mimeType": "image/jpeg",
+								"data":     "aGVsbG8=",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	claudeMap, _ := convertGeminiToClaudeMessage(geminiResp, "gemini-3.1-flash-image", nil)
+	content, ok := claudeMap["content"].([]any)
+	require.True(t, ok)
+	require.Len(t, content, 1)
+	block, ok := content[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "text", block["type"])
+	require.Equal(t, "![image](data:image/jpeg;base64,aGVsbG8=)", block["text"])
+
+	chatResp, _, err := geminiResponseToChatCompletions(geminiResp, "gemini-3.1-flash-image", nil, nil)
+	require.NoError(t, err)
+	require.Len(t, chatResp.Choices, 1)
+	var contentText string
+	require.NoError(t, json.Unmarshal(chatResp.Choices[0].Message.Content, &contentText))
+	require.Contains(t, contentText, "![image](data:image/jpeg;base64,aGVsbG8=)")
+}

--- a/backend/internal/service/universal_routing_tk_resolver.go
+++ b/backend/internal/service/universal_routing_tk_resolver.go
@@ -157,7 +157,41 @@ func (r *UniversalRoutingResolver) Resolve(ctx context.Context, apiKey *APIKey, 
 		}
 	}
 
+	// Image-generation endpoints enforce groups.allow_image_generation after routing.
+	// Without this gate the resolver can land on a newapi vendor group that serves
+	// imagen/seedream but still has the column at default false (migration 134 only
+	// backfilled openai/gemini/antigravity), yielding a confusing permission_error.
+	if universalShapeRequiresImageGenerationEnabled(shape) {
+		imageEligible := filterGroupsAllowImageGeneration(eligible)
+		if len(imageEligible) == 0 {
+			return nil, ErrUniversalNoEntitledGroup
+		}
+		eligible = imageEligible
+	}
+
 	return pickUniversalBackingGroup(eligible), nil
+}
+
+func universalShapeRequiresImageGenerationEnabled(shape UniversalShape) bool {
+	switch shape {
+	case ShapeOpenAIImages, ShapeOpenAIImagesEdit:
+		return true
+	default:
+		return false
+	}
+}
+
+func filterGroupsAllowImageGeneration(groups []Group) []Group {
+	if len(groups) == 0 {
+		return nil
+	}
+	out := make([]Group, 0, len(groups))
+	for _, g := range groups {
+		if g.AllowImageGeneration {
+			out = append(out, g)
+		}
+	}
+	return out
 }
 
 // span 取（带缓存的）用户权限跨度。命中且未过期 → 0 次 DB；未命中走 singleflight 合并重算。

--- a/backend/internal/service/universal_routing_tk_resolver_test.go
+++ b/backend/internal/service/universal_routing_tk_resolver_test.go
@@ -27,7 +27,13 @@ func grp(id int64, platform string, sortOrder int, sub bool) Group {
 	if sub {
 		st = SubscriptionTypeSubscription
 	}
-	return Group{ID: id, Platform: platform, Status: StatusActive, SortOrder: sortOrder, SubscriptionType: st}
+	return Group{ID: id, Platform: platform, Status: StatusActive, SortOrder: sortOrder, SubscriptionType: st, AllowImageGeneration: true}
+}
+
+func grpNoImage(id int64, platform string, sortOrder int, sub bool) Group {
+	g := grp(id, platform, sortOrder, sub)
+	g.AllowImageGeneration = false
+	return g
 }
 
 func universalKey(userID int64) *APIKey {

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -86,6 +86,38 @@ func TestResolve_ImagenPicksVertexNewapiGroup(t *testing.T) {
 	}
 }
 
+// imagen 不得落到 allow_image_generation=false 的 newapi 组; 应优先/仅选已开生图的组。
+func TestResolve_ImagenSkipsGroupWithoutImageGenerationPermission(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grpNoImage(16, PlatformNewAPI, 10, false),
+		grp(17, PlatformNewAPI, 20, false),
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		16: {"imagen-4.0-fast-generate-001"},
+		17: {"imagen-4.0-fast-generate-001"},
+	}))
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIImages, "imagen-4.0-fast-generate-001", "")
+	if err != nil || g == nil || g.ID != 17 {
+		t.Fatalf("imagen 应跳过未开生图的 gid=16 并落 gid=17, got=%v err=%v", g, err)
+	}
+}
+
+// 若所有可服务 imagen 的组都未开生图,解析失败(403 套餐语义),而非事后 permission_error。
+func TestResolve_ImagenNoImageEnabledGroupReturnsNoEntitled(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{grpNoImage(16, PlatformNewAPI, 10, false)}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		16: {"imagen-4.0-fast-generate-001"},
+	}))
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIImages, "imagen-4.0-fast-generate-001", "")
+	if err != ErrUniversalNoEntitledGroup || g != nil {
+		t.Fatalf("无 allow_image_generation 组应 ErrUniversalNoEntitledGroup, got=%v err=%v", g, err)
+	}
+}
+
 // 回归:原生 anthropic 组(nil served)claude-* 仍正常解析(按 tiebreaker)。
 func TestResolve_NativeAnthropicRegression(t *testing.T) {
 	ctx := context.Background()

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 524,
-  "hash": "f9d255b875a7635eb69395b8a63a09dfa38484ec539078b9eb25ab5a046336ec",
+  "file_count": 525,
+  "hash": "3591288f039239af737d59bb791aeb819cccfc300bbdd491b127fb29e6f72a7b",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/migrations/tk_049_newapi_media_allow_image_generation.sql
+++ b/backend/migrations/tk_049_newapi_media_allow_image_generation.sql
@@ -1,0 +1,17 @@
+-- Migration 134 backfilled allow_image_generation for openai/gemini/antigravity only.
+-- newapi vendor groups carrying Vertex (imagen/veo) or VolcEngine Seedream accounts
+-- were left at default false. Admin UI now exposes the same toggle for platform=newapi
+-- (GroupsView → 图片生成计费); this one-time UPDATE backfills existing prod rows.
+
+UPDATE groups g
+SET allow_image_generation = true
+WHERE g.platform = 'newapi'
+  AND NOT g.allow_image_generation
+  AND EXISTS (
+    SELECT 1
+    FROM account_groups ag
+    JOIN accounts a ON a.id = ag.account_id
+    WHERE ag.group_id = g.id
+      AND a.deleted_at IS NULL
+      AND a.channel_type IN (41, 45)
+  );

--- a/docs/approved/newapi-allow-image-generation-ops.md
+++ b/docs/approved/newapi-allow-image-generation-ops.md
@@ -1,0 +1,37 @@
+---
+title: newapi 分组图片生成开关与 tk_049 存量回填
+status: pending
+approved_by: pending
+authors: [agent]
+created: 2026-06-29
+related_prs: []
+related_commits: []
+parent_design: docs/approved/admin-ui-newapi-platform-end-to-end.md
+---
+
+# newapi 分组图片生成开关与 tk_049 存量回填
+
+## 背景
+
+Migration 134 只为 `openai` / `gemini` / `antigravity` 回填了 `groups.allow_image_generation`。
+含 Vertex Imagen（channel_type 41）或 VolcEngine Seedream（45）的 `newapi` 分组在 prod 仍为
+默认 `false`，导致 `/v1/images/generations` 与全能 Key imagen 路由报「该分组未开通此类生成」。
+
+Admin 后端字段与 API 已支持 `allow_image_generation`，但 `GroupsView` 的「图片生成计费」区块
+原先未包含 `platform=newapi`。
+
+## 变更
+
+1. **Admin UI**：`supportsGroupImagePricing()` 将 `newapi` 纳入图片生成计费开关（与 openai/gemini/antigravity 一致）。
+2. **一次性迁移 `tk_049`**：为已有 Vertex/Seedream 账号绑定的 `newapi` 分组 `UPDATE allow_image_generation=true`。
+3. **全能 Key 路由**：`/v1/images/generations` 形状在 pick 前过滤 `allow_image_generation=false` 的分组。
+
+## 不在范围
+
+- gemini-native 经 `/v1/chat/completions` 的生图不走 `allow_image_generation` 列（沿用 chat 计费路径）。
+- 不新增独立图片协议入口。
+
+## 验证
+
+- 单元/前端测试覆盖 resolver 过滤、inlineData→markdown、BakeOff 路由分流、Admin 平台 gate。
+- prod BakeOff / ImageStudio 实机复现：PR 验证节标注为待人工确认。

--- a/frontend/src/constants/__tests__/groupImagePricing.tk.spec.ts
+++ b/frontend/src/constants/__tests__/groupImagePricing.tk.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { GROUP_IMAGE_PRICING_PLATFORMS, supportsGroupImagePricing } from '../groupImagePricing.tk'
+
+describe('groupImagePricing.tk', () => {
+  it('includes newapi alongside legacy image platforms', () => {
+    expect(GROUP_IMAGE_PRICING_PLATFORMS).toContain('newapi')
+    expect(GROUP_IMAGE_PRICING_PLATFORMS).toEqual(
+      expect.arrayContaining(['openai', 'gemini', 'antigravity', 'newapi'])
+    )
+  })
+
+  it('supportsGroupImagePricing is case-insensitive', () => {
+    expect(supportsGroupImagePricing('newapi')).toBe(true)
+    expect(supportsGroupImagePricing('NEWAPI')).toBe(true)
+    expect(supportsGroupImagePricing('anthropic')).toBe(false)
+    expect(supportsGroupImagePricing('')).toBe(false)
+  })
+})

--- a/frontend/src/constants/__tests__/playgroundMedia.tk.spec.ts
+++ b/frontend/src/constants/__tests__/playgroundMedia.tk.spec.ts
@@ -131,6 +131,27 @@ describe('extractChatImageItems (gemini image via /v1/chat/completions)', () => 
     ])
   })
 
+  it('handles text parts and anthropic image blocks in structured content arrays', () => {
+    expect(
+      extractChatImageItems(
+        chat([{ type: 'text', text: '![image](data:image/jpeg;base64,aGVsbG8=)' }])
+      )
+    ).toEqual([{ src: 'data:image/jpeg;base64,aGVsbG8=' }])
+    expect(
+      extractChatImageItems(
+        chat([
+          {
+            type: 'image',
+            source: { type: 'base64', media_type: 'image/png', data: 'QQ==' }
+          }
+        ])
+      )
+    ).toEqual([{ src: 'data:image/png;base64,QQ==' }])
+    expect(
+      extractChatImageItems(chat('see ![img](https://cdn.example/gen.png)'))
+    ).toEqual([{ src: 'https://cdn.example/gen.png' }])
+  })
+
   it('returns empty for text-only / malformed responses', () => {
     expect(extractChatImageItems(chat('just text, no image'))).toEqual([])
     expect(extractChatImageItems(null)).toEqual([])

--- a/frontend/src/constants/groupImagePricing.tk.ts
+++ b/frontend/src/constants/groupImagePricing.tk.ts
@@ -1,0 +1,19 @@
+// TokenKey-only: admin group form surfaces image-generation billing controls for
+// platforms that can actually serve /v1/images/generations or gemini-native chat
+// image. newapi was omitted from the original UI gate even though migration 134
+// only backfilled openai/gemini/antigravity — Vertex (41) / Seedream (45) media
+// groups need the same allow_image_generation toggle.
+
+export const GROUP_IMAGE_PRICING_PLATFORMS = [
+  'openai',
+  'gemini',
+  'antigravity',
+  'newapi',
+] as const
+
+export type GroupImagePricingPlatform = (typeof GROUP_IMAGE_PRICING_PLATFORMS)[number]
+
+export function supportsGroupImagePricing(platform: string | undefined | null): boolean {
+  const p = (platform || '').trim().toLowerCase()
+  return (GROUP_IMAGE_PRICING_PLATFORMS as readonly string[]).includes(p)
+}

--- a/frontend/src/constants/playgroundMedia.tk.ts
+++ b/frontend/src/constants/playgroundMedia.tk.ts
@@ -155,20 +155,40 @@ export function extractChatImageItems(resp: unknown): PlaygroundImageItem[] {
     if (/^https?:\/\//i.test(url)) items.push({ src: url })
     else pushDataUri(url)
   }
+  const pushMarkdownImagesFromText = (text: string): void => {
+    const dataRe = /\(\s*(data:image\/[\w.+-]+;base64,[A-Za-z0-9+/=]+)\s*\)/gi
+    let mm: RegExpExecArray | null
+    while ((mm = dataRe.exec(text)) !== null) pushDataUri(mm[1])
+    const httpRe = /!\[[^\]]*\]\(\s*(https?:\/\/[^\s)]+)\s*\)/gi
+    while ((mm = httpRe.exec(text)) !== null) pushUrl(mm[1])
+  }
+  const pushAnthropicImagePart = (part: Record<string, unknown>): void => {
+    const source = asRecord(part.source)
+    if (!source || source.type !== 'base64') return
+    const data = typeof source.data === 'string' ? source.data : ''
+    if (!withinInlineB64Cap(data)) return
+    const mime =
+      typeof source.media_type === 'string' && source.media_type.startsWith('image')
+        ? source.media_type
+        : 'image/png'
+    items.push({ src: `data:${mime};base64,${data}` })
+  }
   for (const choice of choices) {
     const message = asRecord(asRecord(choice)?.message)
     if (!message) continue
     const content = message.content
     if (typeof content === 'string') {
-      // markdown ![…](data:image/…;base64,…) — pull every data: image URI out.
-      const re = /\(\s*(data:image\/[\w.+-]+;base64,[A-Za-z0-9+/=]+)\s*\)/gi
-      let mm: RegExpExecArray | null
-      while ((mm = re.exec(content)) !== null) pushDataUri(mm[1])
+      pushMarkdownImagesFromText(content)
     } else if (Array.isArray(content)) {
-      // structured parts: {type:'image_url', image_url:{url}} or {inline_data:{data,mime_type}}.
       for (const part of content) {
         const p = asRecord(part)
         if (!p) continue
+        if (typeof p.text === 'string') {
+          pushMarkdownImagesFromText(p.text)
+        }
+        if (p.type === 'image') {
+          pushAnthropicImagePart(p)
+        }
         const imageUrl = asRecord(p.image_url)
         if (typeof imageUrl?.url === 'string') pushUrl(imageUrl.url)
         else if (typeof p.image_url === 'string') pushUrl(p.image_url)

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -752,11 +752,7 @@
 
         <!-- 图片生成计费配置 -->
         <div
-          v-if="
-            createForm.platform === 'antigravity' ||
-            createForm.platform === 'gemini' ||
-            createForm.platform === 'openai'
-          "
+          v-if="supportsGroupImagePricing(createForm.platform)"
           class="border-t pt-4"
         >
           <label
@@ -2110,11 +2106,7 @@
 
         <!-- 图片生成计费配置 -->
         <div
-          v-if="
-            editForm.platform === 'antigravity' ||
-            editForm.platform === 'gemini' ||
-            editForm.platform === 'openai'
-          "
+          v-if="supportsGroupImagePricing(editForm.platform)"
           class="border-t pt-4"
         >
           <label
@@ -3204,6 +3196,7 @@ import { useKeyedDebouncedSearch } from "@/composables/useKeyedDebouncedSearch";
 import { getPersistedPageSize } from "@/composables/usePersistedPageSize";
 import { usePlatformOptions } from "@/composables/usePlatformOptions";
 import { isOpenAICompatPlatform, hasMessagesDispatchConfig } from "@/constants/gatewayPlatforms";
+import { supportsGroupImagePricing } from "@/constants/groupImagePricing.tk";
 import {
   createDefaultMessagesDispatchFormState,
   messagesDispatchConfigToFormState,

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -183,8 +183,15 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { gatewayImageGenerations, gatewayVideoSubmit } from '@/api/playground'
-import { extractImageItems, extractVideoTaskId, videoStateFromFetch, extractVideoUrl } from '@/constants/playgroundMedia.tk'
+import { gatewayGeminiImageViaChat, gatewayImageGenerations, gatewayVideoSubmit } from '@/api/playground'
+import {
+  extractChatImageItems,
+  extractImageItems,
+  extractVideoTaskId,
+  isGeminiNativeImageModel,
+  videoStateFromFetch,
+  extractVideoUrl,
+} from '@/constants/playgroundMedia.tk'
 import {
   VIDEO_DURATION_DEFAULT,
   videoDurationDefault,
@@ -215,7 +222,10 @@ const emit = defineEmits<{ (e: 'spent'): void }>()
 const { t } = useI18n()
 
 const MAX_PANELS = 4
-const DEFAULT_IMAGE_SIZE = '1024x1024'
+/** Imagen / seedream: ratio code on /v1/images/generations (see ImageStudio sentSize). */
+const DEFAULT_IMAGEN_SIZE = '1:1'
+/** Gemini-native image: aspect_ratio via /v1/chat/completions extra_body.google.image_config. */
+const DEFAULT_GEMINI_ASPECT = '1:1'
 
 const modality = ref<StudioModality>('video')
 const models = computed(() => resolveAvailableModels(modality.value, props.availableIds, props.priceMap))
@@ -321,7 +331,7 @@ function panelSeconds(r: { model: { videoDurations?: number[] } }): number {
 const totalCost = computed(() =>
   selectedResolved().reduce((sum, r) => {
     if (modality.value === 'image') {
-      return sum + estimateImageCost({ baseImagePrice: r.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
+      return sum + estimateImageCost({ baseImagePrice: r.baseImagePrice || 0, size: DEFAULT_IMAGEN_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
     }
     return sum + estimateVideoCost({ perSecond: r.perSecond || 0, seconds: panelSeconds(r), rateMultiplier: props.rateMultiplier })
   }, 0)
@@ -378,7 +388,7 @@ async function run(): Promise<void> {
     vendorLabel: r.model.vendorLabel,
     cost:
       modality.value === 'image'
-        ? estimateImageCost({ baseImagePrice: r.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
+        ? estimateImageCost({ baseImagePrice: r.baseImagePrice || 0, size: DEFAULT_IMAGEN_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
         : estimateVideoCost({ perSecond: r.perSecond || 0, seconds: panelSeconds(r), rateMultiplier: props.rateMultiplier }),
     seconds: modality.value === 'video' ? panelSeconds(r) : undefined,
     state: 'processing',
@@ -389,8 +399,7 @@ async function run(): Promise<void> {
       await Promise.all(
         panels.value.map(async (panel) => {
           try {
-            const raw = await gatewayImageGenerations(props.apiKey, props.gatewayBase, { model: panel.servedId, prompt: text, size: DEFAULT_IMAGE_SIZE, n: 1 })
-            const items = extractImageItems(raw)
+            const items = await generateBakeoffImage(panel.servedId, text)
             if (!items.length) throw new Error('no_image')
             panel.src = items[0].src
             panel.state = 'succeeded'
@@ -439,6 +448,25 @@ async function run(): Promise<void> {
   } finally {
     running.value = false
   }
+}
+
+/** Route like ImageStudio: gemini-native via chat; imagen/seedream via /v1/images/generations. */
+async function generateBakeoffImage(modelId: string, prompt: string) {
+  if (isGeminiNativeImageModel(modelId)) {
+    const raw = await gatewayGeminiImageViaChat(props.apiKey, props.gatewayBase, {
+      model: modelId,
+      prompt,
+      aspectRatio: DEFAULT_GEMINI_ASPECT,
+    })
+    return extractChatImageItems(raw)
+  }
+  const raw = await gatewayImageGenerations(props.apiKey, props.gatewayBase, {
+    model: modelId,
+    prompt,
+    size: DEFAULT_IMAGEN_SIZE,
+    n: 1,
+  })
+  return extractImageItems(raw)
 }
 
 function mapError(e: unknown): void {

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en'
+import BakeOff from '../BakeOff.vue'
+import * as playground from '@/api/playground'
+
+vi.mock('@/api/playground', () => ({
+  gatewayImageGenerations: vi.fn(),
+  gatewayGeminiImageViaChat: vi.fn(),
+  gatewayVideoSubmit: vi.fn(),
+}))
+
+vi.mock('@/composables/useVideoTaskPoll', () => ({
+  useVideoTaskPoll: () => ({ stopAll: vi.fn(), resume: vi.fn() }),
+}))
+
+vi.mock('vue-router', () => ({
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackWarn: false,
+  missingWarn: false,
+  messages: { en },
+})
+
+const baseProps = {
+  apiKey: 'sk-test',
+  gatewayBase: 'https://api.example.com',
+  availableIds: new Set([
+    'imagen-4.0-fast-generate-001',
+    'imagen-4.0-generate-001',
+    'gemini-3.1-flash-image',
+  ]),
+  priceMap: new Map([
+    ['imagen-4.0-fast-generate-001', { perImage: 0.02 }],
+    ['imagen-4.0-generate-001', { perImage: 0.04 }],
+    ['gemini-3.1-flash-image', { perImage: 0.0672 }],
+  ]),
+  balance: 100,
+  keyId: 1,
+  keys: [{ id: 1, key: 'sk-test' }],
+  rateMultiplier: 1,
+}
+
+describe('BakeOff image routing', () => {
+  beforeEach(() => {
+    vi.mocked(playground.gatewayImageGenerations).mockReset()
+    vi.mocked(playground.gatewayGeminiImageViaChat).mockReset()
+    vi.mocked(playground.gatewayImageGenerations).mockResolvedValue({
+      data: [{ url: 'https://cdn.example/imagen.png' }],
+    })
+    vi.mocked(playground.gatewayGeminiImageViaChat).mockResolvedValue({
+      choices: [{ message: { content: '![image](data:image/png;base64,abc)' } }],
+    })
+  })
+
+  it('routes gemini-native image models via chat completions', async () => {
+    const wrapper = mount(BakeOff, {
+      props: baseProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true } },
+    })
+    await wrapper.get('[data-testid="bakeoff-mode-image"]').trigger('click')
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    await tiers[0].trigger('click')
+    await tiers[1].trigger('click')
+    await tiers[2].trigger('click')
+    await wrapper.get('textarea').setValue('a red apple')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    expect(playground.gatewayGeminiImageViaChat).toHaveBeenCalledWith(
+      'sk-test',
+      'https://api.example.com',
+      expect.objectContaining({ model: 'gemini-3.1-flash-image', aspectRatio: '1:1' })
+    )
+    expect(playground.gatewayImageGenerations).toHaveBeenCalledWith(
+      'sk-test',
+      'https://api.example.com',
+      expect.objectContaining({ model: 'imagen-4.0-fast-generate-001', size: '1:1' })
+    )
+    expect(playground.gatewayImageGenerations).toHaveBeenCalledWith(
+      'sk-test',
+      'https://api.example.com',
+      expect.objectContaining({ model: 'imagen-4.0-generate-001', size: '1:1' })
+    )
+  })
+})

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -104,7 +104,9 @@
       "must_contain": [
         "data-testid=\"bakeoff-tier\"",
         "data-testid=\"studio-bakeoff-run\"",
-        "data-testid=\"bakeoff-panel\""
+        "data-testid=\"bakeoff-panel\"",
+        "gatewayGeminiImageViaChat",
+        "isGeminiNativeImageModel"
       ],
       "rationale": "BakeOff.vue is the TK-only Studio 'bake-off' compare surface — one prompt rendered across 2-4 priced image/video models side by side, each panel showing its own real price + latency. It is mounted by MediaStudioView.vue (view==='bakeoff') and is the only multi-model compare flow; the test-ids are the contract the studio e2e (frontend/e2e/studio.e2e.ts) drives and the anchors that keep an upstream merge from silently dropping the view (compiles green, feature gone). Note: the bakeoff image/video sub-mode toggle reuses data-testid=\"bakeoff-mode-image\"/\"bakeoff-mode-video\"; the run button + tier chips + result panels are anchored here."
     },
@@ -817,6 +819,15 @@
         "extractChatImageItems"
       ],
       "rationale": "Playground media modality table + tolerant response parsing. /v1/models returns bare ids and the public catalog has no image/video capability tag, so this frontend table is the only thing routing gpt-image-*/imagen-*/seedream prompts to /v1/images/generations and veo-*/seedance prompts to the vt_ video task flow. The gpt-image- prefix mirrors the backend's own intent predicate (openai_images.go isOpenAIImageGenerationModel) — if either side changes family patterns the other must follow. isGeminiNativeImageModel classifies gemini-*-image / nano-banana ids as 'image' (mirrors backend isImageGenerationModel) — they are served via /v1/chat/completions (verified prod: the image returns as ![image](data:…) markdown for antigravity + newapi groups), so extractChatImageItems is the ONLY parser pulling that inline image out of the chat response; dropping either silently regresses gemini-native image in the Studio."
+    },
+    {
+      "path": "frontend/src/constants/groupImagePricing.tk.ts",
+      "must_contain": [
+        "GROUP_IMAGE_PRICING_PLATFORMS",
+        "'newapi'",
+        "supportsGroupImagePricing"
+      ],
+      "rationale": "Admin GroupsView gates the 图片生成计费 section (allow_image_generation + image price tiers) through supportsGroupImagePricing. newapi media groups (Vertex imagen/veo, Seedream) need the same toggle migration 134 gave openai/gemini/antigravity; omitting newapi here hides the only operator-facing control and forces SQL backfills for every new media group."
     },
     {
       "path": "frontend/src/views/user/studio/ChatStudio.vue",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3262,7 +3262,9 @@
         "func NewUniversalRoutingResolver(",
         "func (r *UniversalRoutingResolver) Resolve(",
         "var ErrUniversalNoEntitledGroup",
-        "func pickUniversalBackingGroup("
+        "func pickUniversalBackingGroup(",
+        "universalShapeRequiresImageGenerationEnabled",
+        "filterGroupsAllowImageGeneration"
       ],
       "rationale": "Universal Key (全能 Key) per-request resolver: maps a routing_mode=universal key to a concrete backing group from the owner's live entitlement span (GetAvailableGroups, short-TTL cached), filtered by endpoint-shape candidate platforms, with deterministic pick (subscription-held -> sort_order -> id). docs/approved/universal-key-routing.md. Dropping this file disables universal-key routing entirely (every universal key would fall through with a nil group). Pins the constructor, Resolve entrypoint, the no-entitled-group sentinel error, and the deterministic picker."
     },


### PR DESCRIPTION
## 摘要

- **BakeOff 同台对比（图片）**：gemini-native 模型改走 `/v1/chat/completions`（与 ImageStudio 一致），imagen 仍走 `/v1/images/generations`；全能 Key 路由 imagen 时跳过 `allow_image_generation=false` 的 newapi 分组。
- **ImageStudio「网关未返回图片数据」**：修复 gemini 平台路径上 `convertGeminiToClaudeMessage` 丢弃 `inlineData` 的问题；补强 `extractChatImageItems` 对结构化 content 的解析；assistant `type:image` 块在 Responses→Chat 链路中转为 markdown。
- **Admin newapi 生图开关**：「图片生成计费 → 允许当前分组生图」已对 `platform=newapi` 展示（原先 UI 仅 openai/gemini/antigravity）；`tk_049` 迁移一次性回填含 Vertex(41)/Seedream(45) 账号的存量 newapi 分组；审批锚点见 `docs/approved/newapi-allow-image-generation-ops.md`。

## 风险

- 常规风险：影响工作室生图与全能 Key imagen 路由，不涉及 schema 破坏性变更。
- 迁移 `tk_049` 仅对已有 41/45 账号的 newapi 分组将 `allow_image_generation` 置 true，不回写已手动关闭的分组（`NOT allow_image_generation` 条件）。
- 未在 prod 实机复现生图；依赖单元测试 + preflight。

## 验证

- `./scripts/preflight.sh` — PASS（含 high-risk approval anchor）
- `go test -tags=unit ./internal/service/ -run 'TestResolve_Imagen|TestConvertGeminiToClaudeMessage_EmbedsInlineImageMarkdown'`
- `go test -tags=unit ./internal/pkg/apicompat/ -run 'TestAnthropicToResponsesResponse_AssistantImageBlockBecomesMarkdown'`
- `pnpm vitest run src/views/user/studio/__tests__/BakeOff.spec.ts src/constants/__tests__/playgroundMedia.tk.spec.ts src/constants/__tests__/groupImagePricing.tk.spec.ts`

## 提交

7257c0e8e docs: add approval anchor for newapi allow_image_generation ops
81464a942 fix(studio): restore image generation for BakeOff, ImageStudio, and newapi groups

最新提交：7257c0e8e
