### PR TITLE
fix(stage0): capture probe setup SQL failures

### DIFF
--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -24,7 +24,7 @@ LOG_WINDOW="${LOG_WINDOW:-3m}"
 REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-90}"
 PROBE_USER_ID=1
 
-PSQL=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
+PSQL=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -q -A -t -v ON_ERROR_STOP=1)
 
 sql_escape() {
   printf "%s" "$1" | sed "s/'/''/g"
@@ -37,6 +37,27 @@ import json, sys
 print(json.dumps({"verdict": "setup_error", "error": sys.argv[1]}, ensure_ascii=False))
 PY
   exit 0
+}
+
+psql_capture_numeric() {
+  local dest="$1"
+  local message="$2"
+  local query="$3"
+  local errfile out value excerpt
+  errfile="$(mktemp)"
+  if ! out="$("${PSQL[@]}" -c "$query" 2>"$errfile")"; then
+    local err
+    err="$(tr '\n' ' ' <"$errfile" | sed -E 's/[[:space:]]+/ /g; s/(password|token|secret|key)[^ ]*/\1=<redacted>/Ig' | cut -c1-240)"
+    rm -f "$errfile"
+    fail_json "${message}: ${err:-psql failed}"
+  fi
+  rm -f "$errfile"
+  value="$(printf '%s\n' "$out" | awk '/^[[:space:]]*[0-9]+[[:space:]]*$/ {gsub(/[[:space:]]/, ""); print; found=1; exit} END {exit found ? 0 : 1}' || true)"
+  if [[ -z "$value" ]]; then
+    excerpt="$(printf '%s' "$out" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g' | cut -c1-240)"
+    fail_json "${message}: no numeric id returned${excerpt:+ (stdout=${excerpt})}"
+  fi
+  printf -v "$dest" '%s' "$value"
 }
 
 if [[ ! "$ACCOUNT_ID" =~ ^[0-9]+$ ]]; then
@@ -169,7 +190,7 @@ SELECT COALESCE((
 ), '');
 " | tr -d '\n')"
   if [[ -n "$GROUP_ID" ]]; then
-    GROUP_ID="$("${PSQL[@]}" -c "
+    psql_capture_numeric GROUP_ID "failed to update probe group name=${GROUP_NAME} platform=${PLATFORM}" "
 UPDATE groups
 SET
   description = 'reserved reusable account/model probe group; direct probe key only; excluded from universal routing',
@@ -182,6 +203,9 @@ SET
   claude_code_only = false,
   model_routing_enabled = false,
   model_routing = '{}'::jsonb,
+  supported_model_scopes = '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,
+  messages_dispatch_model_config = '{}'::jsonb,
+  models_list_config = '{}'::jsonb,
   sort_order = 2147483000,
   rpm_limit = 0,
   updated_at = NOW()
@@ -189,39 +213,47 @@ WHERE id = ${GROUP_ID}
   AND name = '$(sql_escape "$GROUP_NAME")'
   AND deleted_at IS NULL
 RETURNING id;
-" | tr -d '[:space:]')"
+"
   else
-    GROUP_ID="$("${PSQL[@]}" -c "
+    psql_capture_numeric GROUP_ID "failed to insert probe group name=${GROUP_NAME} platform=${PLATFORM}" "
 INSERT INTO groups (
   name, description, platform, rate_multiplier, is_exclusive, status,
   subscription_type, default_validity_days, claude_code_only,
-  model_routing_enabled, model_routing, sort_order, rpm_limit, created_at, updated_at
+  model_routing_enabled, model_routing, supported_model_scopes,
+  messages_dispatch_model_config, models_list_config,
+  sort_order, rpm_limit, created_at, updated_at
 ) VALUES (
   '$(sql_escape "$GROUP_NAME")',
   'reserved reusable account/model probe group; direct probe key only; excluded from universal routing',
   '$(sql_escape "$PLATFORM")',
   1.0, true, 'active',
   'standard', 30, false,
-  false, '{}'::jsonb, 2147483000, 0, NOW(), NOW()
+  false, '{}'::jsonb, '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,
+  '{}'::jsonb, '{}'::jsonb,
+  2147483000, 0, NOW(), NOW()
 )
 RETURNING id;
-" | tr -d '[:space:]')"
+"
   fi
 else
-  GROUP_ID="$("${PSQL[@]}" -c "
+  psql_capture_numeric GROUP_ID "failed to insert one-off probe group name=${GROUP_NAME} platform=${PLATFORM}" "
 INSERT INTO groups (
   name, description, platform, rate_multiplier, is_exclusive, status,
   subscription_type, default_validity_days, claude_code_only,
-  model_routing_enabled, model_routing, sort_order, rpm_limit, created_at, updated_at
+  model_routing_enabled, model_routing, supported_model_scopes,
+  messages_dispatch_model_config, models_list_config,
+  sort_order, rpm_limit, created_at, updated_at
 ) VALUES (
 	  '$(sql_escape "$GROUP_NAME")',
 	  'exclusive temporary account/model probe; direct probe key only; excluded from universal routing',
 	  '$(sql_escape "$PLATFORM")',
 	  1.0, true, 'active',
 	  'standard', 30, false,
-	  false, '{}'::jsonb, 2147483000, 0, NOW(), NOW()
+	  false, '{}'::jsonb, '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,
+	  '{}'::jsonb, '{}'::jsonb,
+	  2147483000, 0, NOW(), NOW()
 	) RETURNING id;
-" | tr -d '[:space:]')"
+"
 fi
 
 if [[ ! "$GROUP_ID" =~ ^[0-9]+$ ]]; then
@@ -283,7 +315,7 @@ import secrets
 print(secrets.token_urlsafe(18).replace("-", "").replace("_", "")[:24])
 PY
 )"
-    API_KEY_ID="$("${PSQL[@]}" -c "
+    psql_capture_numeric API_KEY_ID "failed to insert probe API key name=${KEY_NAME} group_id=${GROUP_ID}" "
 INSERT INTO api_keys (
   user_id, key, name, group_id, status, routing_mode,
   quota, quota_used, rate_limit_5h, rate_limit_1d, rate_limit_7d,
@@ -298,10 +330,10 @@ INSERT INTO api_keys (
   0, 0, 0, 0, 0,
   0, 0, 0, NOW(), NOW()
 ) RETURNING id;
-" | tr -d '[:space:]')"
+"
   fi
 else
-  API_KEY_ID="$("${PSQL[@]}" -c "
+  psql_capture_numeric API_KEY_ID "failed to insert one-off probe API key name=${KEY_NAME} group_id=${GROUP_ID}" "
 INSERT INTO api_keys (
   user_id, key, name, group_id, status, routing_mode,
   quota, quota_used, rate_limit_5h, rate_limit_1d, rate_limit_7d,
@@ -316,7 +348,7 @@ INSERT INTO api_keys (
   0, 0, 0, 0, 0,
   0, 0, 0, NOW(), NOW()
 ) RETURNING id;
-" | tr -d '[:space:]')"
+"
 fi
 
 if [[ ! "$API_KEY_ID" =~ ^[0-9]+$ ]]; then

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -11,7 +11,7 @@ TK_SMOKE_ANTHROPIC_REALISTIC="${TK_SMOKE_ANTHROPIC_REALISTIC:-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-}"
 MODEL="${MODEL:-}"
 ENDPOINT="${ENDPOINT:-messages}"
-APP_CONTAINER="${APP_CONTAINER:-tokenkey}"
+APP_CONTAINER="${APP_CONTAINER:-auto}"
 APP_URL="${APP_URL:-http://localhost:8080}"
 MAX_TOKENS="${MAX_TOKENS:-32}"
 PROMPT_TEXT="${PROMPT_TEXT:-hi}"
@@ -59,6 +59,36 @@ psql_capture_numeric() {
   fi
   printf -v "$dest" '%s' "$value"
 }
+
+resolve_app_container() {
+  if [[ "$APP_CONTAINER" != "auto" ]]; then
+    return 0
+  fi
+  if [[ -r /var/lib/tokenkey/active-color ]]; then
+    local color
+    color="$(sed -n '1p' /var/lib/tokenkey/active-color 2>/dev/null | tr -d '[:space:]')"
+    case "$color" in
+      blue|green)
+        if sudo docker inspect "tokenkey-$color" >/dev/null 2>&1; then
+          APP_CONTAINER="tokenkey-$color"
+          return 0
+        fi
+        ;;
+    esac
+  fi
+  for candidate in tokenkey tokenkey-blue tokenkey-green; do
+    if sudo docker inspect "$candidate" >/dev/null 2>&1; then
+      APP_CONTAINER="$candidate"
+      return 0
+    fi
+  done
+  APP_CONTAINER="tokenkey"
+}
+
+resolve_app_container
+if ! sudo docker inspect "$APP_CONTAINER" >/dev/null 2>&1; then
+  fail_json "app container not running: ${APP_CONTAINER}"
+fi
 
 if [[ ! "$ACCOUNT_ID" =~ ^[0-9]+$ ]]; then
   fail_json "ACCOUNT_ID must be numeric"

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -40,6 +40,14 @@ class ProbeAccountModelTest(unittest.TestCase):
         self.assertIn("fail_json \"${message}: ${err:-psql failed}\"", script)
         self.assertIn("no numeric id returned", script)
 
+    def test_app_container_auto_resolves_blue_green(self) -> None:
+        script = _SCRIPT.read_text()
+
+        self.assertIn('APP_CONTAINER="${APP_CONTAINER:-auto}"', script)
+        self.assertIn("resolve_app_container() {", script)
+        self.assertIn("/var/lib/tokenkey/active-color", script)
+        self.assertIn("app container not running", script)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -12,7 +12,7 @@ class ProbeAccountModelTest(unittest.TestCase):
     def test_reusable_group_ensure_uses_two_step_returning_id(self) -> None:
         script = _SCRIPT.read_text()
         start = script.index('if [[ "$PROBE_REUSE_MODE" == "1" ]]; then\n  GROUP_ID=')
-        end = script.index('else\n  GROUP_ID=', start)
+        end = script.index('else\n  psql_capture_numeric GROUP_ID "failed to insert one-off probe group', start)
         group_ensure = script[start:end]
 
         self.assertIn("SELECT id::text", group_ensure)
@@ -20,9 +20,25 @@ class ProbeAccountModelTest(unittest.TestCase):
         self.assertIn("UPDATE groups", group_ensure)
         self.assertIn("INSERT INTO groups", group_ensure)
         self.assertIn("RETURNING id;", group_ensure)
+        self.assertIn("psql_capture_numeric GROUP_ID", group_ensure)
+        self.assertIn("supported_model_scopes", group_ensure)
+        self.assertIn("messages_dispatch_model_config", group_ensure)
+        self.assertIn("models_list_config", group_ensure)
+        self.assertIn("claude", group_ensure)
+        self.assertIn("gemini_text", group_ensure)
+        self.assertIn("gemini_image", group_ensure)
         self.assertNotIn("ON CONFLICT", group_ensure)
         self.assertNotIn("WITH existing AS", group_ensure)
         self.assertNotIn("FROM picked", group_ensure)
+
+    def test_psql_id_capture_is_quiet_and_reports_sql_errors(self) -> None:
+        script = _SCRIPT.read_text()
+
+        self.assertIn("-X -q -A -t -v ON_ERROR_STOP=1", script)
+        self.assertIn("psql_capture_numeric() {", script)
+        self.assertIn("2>\"$errfile\"", script)
+        self.assertIn("fail_json \"${message}: ${err:-psql failed}\"", script)
+        self.assertIn("no numeric id returned", script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- quiet psql output for account-model probe setup ID reads
- capture sanitized SQL stderr when probe group/API key setup fails
- fill required group JSONB defaults for reusable and one-off probe groups

## Tests
- python3 -m unittest discover -s ops/stage0 -p 'test_*.py' -t ops/stage0 -v\n- bash -n ops/stage0/probe_account_model.sh\n- ./scripts/preflight.sh