### PR TITLE
fix(admin): edge panel 列与账号主表对齐

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 525,
-  "hash": "3591288f039239af737d59bb791aeb819cccfc300bbdd491b127fb29e6f72a7b",
+  "hash": "a8b0fa84beb6ac9a50a58bafd28534fe3359d966f5d7eb329ead5352760238d1",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/admin/account/EdgeAccountPanelTk.vue
+++ b/frontend/src/components/admin/account/EdgeAccountPanelTk.vue
@@ -92,15 +92,15 @@
       <table class="min-w-full divide-y divide-primary-100 text-sm dark:divide-dark-700">
         <thead class="bg-primary-50/60 text-xs uppercase tracking-wide text-gray-500 dark:bg-dark-900 dark:text-gray-400">
           <tr>
-            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.edgeAccounts.columns.name') }}</th>
-            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.edgeAccounts.columns.platformType') }}</th>
-            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.edgeAccounts.columns.capacity') }}</th>
-            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.edgeAccounts.columns.usageWindows') }}</th>
-            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.edgeAccounts.columns.state') }}</th>
+            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.accounts.columns.name') }}</th>
+            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.accounts.columns.platformType') }}</th>
+            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.accounts.columns.capacity') }}</th>
+            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.accounts.columns.status') }}</th>
             <th class="px-4 py-1.5 text-center font-medium">{{ t('admin.accounts.columns.schedulable') }}</th>
-            <th class="px-4 py-1.5 text-right font-medium">{{ t('admin.edgeAccounts.columns.priority') }}</th>
-            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.edgeAccounts.columns.groups') }}</th>
-            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.edgeAccounts.columns.lastUsed') }}</th>
+            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.accounts.columns.todayStats') }}</th>
+            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.accounts.columns.groups') }}</th>
+            <th class="px-4 py-1.5 text-left font-medium">{{ t('admin.accounts.columns.usageWindows') }}</th>
+            <th class="px-4 py-1.5 text-right font-medium">{{ t('admin.accounts.columns.priority') }}</th>
             <th class="px-4 py-1.5 text-right font-medium">{{ t('admin.accounts.edgePanel.actions') }}</th>
           </tr>
         </thead>
@@ -142,13 +142,6 @@
               <AccountCapacityCell :account="accountVm(acct).accountLike" />
             </td>
             <td class="px-4 py-1.5 align-top">
-              <AccountUsageCell
-                :account="accountVm(acct).accountLike"
-                :today-stats="accountVm(acct).windowStats"
-                :usage-override="usageOverrideFor(acct)"
-              />
-            </td>
-            <td class="px-4 py-1.5 align-top">
               <AccountStatusIndicator :account="accountVm(acct).accountLike" />
             </td>
             <td class="px-4 py-1.5 text-center align-top">
@@ -163,12 +156,20 @@
                 <span class="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out" :class="[acct.schedulable ? 'translate-x-4' : 'translate-x-0']" />
               </button>
             </td>
-            <td class="px-4 py-1.5 align-top text-right text-gray-700 dark:text-gray-200">{{ acct.priority }}</td>
+            <td class="px-4 py-1.5 align-top">
+              <AccountTodayStatsCell :stats="accountVm(acct).windowStats" />
+            </td>
             <td class="px-4 py-1.5 align-top text-gray-600 dark:text-gray-300">
               <span v-if="acct.groups && acct.groups.length">{{ acct.groups.join(', ') }}</span>
               <span v-else class="text-gray-300 dark:text-gray-600">—</span>
             </td>
-            <td class="px-4 py-1.5 align-top text-xs text-gray-500 dark:text-gray-400">{{ acct.last_used_at ? formatRelativeTime(acct.last_used_at) : '—' }}</td>
+            <td class="px-4 py-1.5 align-top">
+              <AccountUsageCell
+                :account="accountVm(acct).accountLike"
+                :usage-override="usageOverrideFor(acct)"
+              />
+            </td>
+            <td class="px-4 py-1.5 align-top text-right text-gray-700 dark:text-gray-200">{{ acct.priority }}</td>
             <td class="px-4 py-1.5 text-right align-top">
               <button
                 type="button"
@@ -219,11 +220,12 @@ import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@/components/icons'
 import AccountCapacityCell from '@/components/account/AccountCapacityCell.vue'
+import AccountTodayStatsCell from '@/components/account/AccountTodayStatsCell.vue'
 import AccountUsageCell from '@/components/account/AccountUsageCell.vue'
 import AccountStatusIndicator from '@/components/account/AccountStatusIndicator.vue'
 import EdgeAccountActionMenuTk from '@/components/admin/account/EdgeAccountActionMenuTk.vue'
 import PlatformTypeBadge from '@/components/common/PlatformTypeBadge.vue'
-import { formatRelativeTime, formatDateOnly } from '@/utils/format'
+import { formatDateOnly } from '@/utils/format'
 import { adminAPI } from '@/api/admin'
 import { useAppStore } from '@/stores/app'
 import type { Account, AccountUsageInfo, AccountPlatform, AccountType } from '@/types'

--- a/frontend/src/components/admin/account/__tests__/EdgeAccountPanelTk.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/EdgeAccountPanelTk.spec.ts
@@ -1,0 +1,139 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import EdgeAccountPanelTk from '../EdgeAccountPanelTk.vue'
+import type { Account } from '@/types'
+import type { EdgeAccountSummary, EdgeAccountsResult } from '@/api/admin/edgeAccounts'
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showSuccess: vi.fn(),
+    showError: vi.fn()
+  })
+}))
+
+function acct(over: Partial<EdgeAccountSummary> = {}): EdgeAccountSummary {
+  return {
+    id: 8,
+    name: 'oh-1-f',
+    platform: 'anthropic',
+    type: 'oauth',
+    status: 'active',
+    schedulable: true,
+    is_schedulable: true,
+    concurrency: 0,
+    priority: 1,
+    rate_multiplier: 1,
+    created_at: '2026-06-09T00:00:00Z',
+    groups: ['default'],
+    today_stats: {
+      requests: 42,
+      tokens: 1_000_000,
+      cost: 12.34,
+      user_cost: 3.21
+    },
+    usage: {
+      source: 'passive',
+      five_hour: { utilization: 0.1, resets_at: null },
+      seven_day: { utilization: 0.5, resets_at: null }
+    },
+    ...over
+  }
+}
+
+function edge(over: Partial<EdgeAccountsResult> = {}): EdgeAccountsResult {
+  return {
+    edge_id: 'us3',
+    base_url: 'https://api-us3.tokenkey.dev',
+    ok: true,
+    stub_schedulable: true,
+    stub_groups: [],
+    edge_group: 'default',
+    accounts: [acct()],
+    ...over
+  }
+}
+
+const stub: Account = {
+  id: 52,
+  name: 'cc-us3',
+  platform: 'anthropic',
+  type: 'apikey',
+  status: 'active',
+  schedulable: true,
+  edge_id: 'us3',
+  concurrency: 0,
+  priority: 1,
+  rate_multiplier: 1,
+  created_at: '2026-06-09T00:00:00Z'
+} as Account
+
+describe('EdgeAccountPanelTk', () => {
+  it('renders edge sub-table columns aligned with the main accounts list', () => {
+    const wrapper = mount(EdgeAccountPanelTk, {
+      props: {
+        stub,
+        edge: edge()
+      },
+      global: {
+        stubs: {
+          Icon: true,
+          PlatformTypeBadge: true,
+          AccountCapacityCell: true,
+          AccountTodayStatsCell: true,
+          AccountUsageCell: true,
+          AccountStatusIndicator: true,
+          EdgeAccountActionMenuTk: true
+        }
+      }
+    })
+
+    const headers = wrapper.findAll('thead th').map((th) => th.text())
+    expect(headers).toEqual([
+      'admin.accounts.columns.name',
+      'admin.accounts.columns.platformType',
+      'admin.accounts.columns.capacity',
+      'admin.accounts.columns.status',
+      'admin.accounts.columns.schedulable',
+      'admin.accounts.columns.todayStats',
+      'admin.accounts.columns.groups',
+      'admin.accounts.columns.usageWindows',
+      'admin.accounts.columns.priority',
+      'admin.accounts.edgePanel.actions'
+    ])
+  })
+
+  it('does not render a last-used column in the edge sub-table', () => {
+    const wrapper = mount(EdgeAccountPanelTk, {
+      props: {
+        stub,
+        edge: edge({
+          accounts: [acct({ last_used_at: '2026-06-29T10:00:00Z' })]
+        })
+      },
+      global: {
+        stubs: {
+          Icon: true,
+          PlatformTypeBadge: true,
+          AccountCapacityCell: true,
+          AccountTodayStatsCell: true,
+          AccountUsageCell: true,
+          AccountStatusIndicator: true,
+          EdgeAccountActionMenuTk: true
+        }
+      }
+    })
+
+    expect(wrapper.text()).not.toContain('admin.edgeAccounts.columns.lastUsed')
+    expect(wrapper.findComponent({ name: 'AccountTodayStatsCell' }).exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## 摘要

- `/admin/accounts` 展开 cc-edge stub 后的 edge 子表列顺序与主表一致：名称 → 平台/类型 → 容量 → 状态 → 调度 → 今日统计 → 分组 → 用量窗口 → 优先级 → 操作
- 新增独立「今日统计」列（`AccountTodayStatsCell`，数据来自 edge DTO `today_stats`）
- 移除「最近使用」列；用量窗口不再混入 today stats

sentinel-registry-reviewed

## 风险

- 低风险，纯 Admin UI 列布局调整，无 API/后端行为变更
- edge 账号若缺少 `today_stats` 字段，今日统计列显示 `-`（与 prod 主表无数据时一致）

## 验证

- `pnpm exec vitest run src/components/admin/account/__tests__/EdgeAccountPanelTk.spec.ts` — 2 passed
- `./scripts/preflight.sh` — PASS（含 frontend release asset contract）
- rebase 到最新 `origin/main` 后 Main Ancestry Guard 应恢复通过

## 提交

- 392f281a7 fix(admin): align edge panel columns with accounts table

最新提交：392f281a7
