### PR TITLE
fix(kiro): 修复 GetUsageLimits Invalid profileArn 400

### DIFF
--- a/backend/internal/integration/kiro/rest.go
+++ b/backend/internal/integration/kiro/rest.go
@@ -38,6 +38,23 @@ func kiroRestBases() []string { return []string{kiroManagementAPIBase, kiroRestA
 // instead folded into getUsageLimits (userInfo{email,userId} + subscriptionInfo),
 // which TK already parses. kiro.GetUserInfo has no caller in TK anyway.
 func kiroRestFetch(account *Account, method, path, body string, withParn bool) ([]byte, error) {
+	if withParn {
+		if err := ensureProfileArn(account); err != nil {
+			return nil, err
+		}
+	}
+	data, err := kiroRestFetchBases(account, method, path, body, withParn)
+	if withParn && isInvalidProfileArnError(err) {
+		logWarnf("[KiroREST] stale profileArn for %s, re-resolving: %v", accountEmail(account), err)
+		account.ProfileArn = ""
+		if resolveErr := ensureProfileArn(account); resolveErr == nil {
+			return kiroRestFetchBases(account, method, path, body, withParn)
+		}
+	}
+	return data, err
+}
+
+func kiroRestFetchBases(account *Account, method, path, body string, withParn bool) ([]byte, error) {
 	var lastErr error
 	for _, base := range kiroRestBases() {
 		u := base + path
@@ -73,6 +90,28 @@ func kiroRestFetch(account *Account, method, path, body string, withParn bool) (
 		return data, nil
 	}
 	return nil, lastErr
+}
+
+func ensureProfileArn(account *Account) error {
+	if account == nil {
+		return fmt.Errorf("account is nil")
+	}
+	_, err := ResolveProfileArn(account)
+	return err
+}
+
+func isInvalidProfileArnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "invalid profilearn")
+}
+
+func accountEmail(account *Account) string {
+	if account == nil {
+		return ""
+	}
+	return account.Email
 }
 
 // GetUsageLimits 获取账户使用量和订阅信息

--- a/backend/internal/integration/kiro/rest_test.go
+++ b/backend/internal/integration/kiro/rest_test.go
@@ -1,0 +1,149 @@
+package kiro
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type rewriteHostTransport struct {
+	target string
+	base   http.RoundTripper
+}
+
+func (t *rewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.URL.Scheme = "http"
+	cloned.URL.Host = t.target
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(cloned)
+}
+
+func installTestRestClient(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	prev := kiroRestHttpStore.Load()
+	kiroRestHttpStore.Store(&http.Client{
+		Transport: &rewriteHostTransport{target: srv.Listener.Addr().String()},
+	})
+	t.Cleanup(func() { kiroRestHttpStore.Store(prev) })
+}
+
+func TestGetUsageLimits_AutoResolvesMissingProfileArn(t *testing.T) {
+	var listCalls atomic.Int32
+	var usageCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "ListAvailableProfiles"):
+			listCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"profiles": []map[string]string{
+					{"arn": "arn:aws:codewhisperer:us-east-1:123456789012:profile/good"},
+				},
+			})
+		case strings.Contains(r.URL.Path, "getUsageLimits"):
+			usageCalls.Add(1)
+			if !strings.Contains(r.URL.RawQuery, "profileArn=") {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"message":"Invalid profileArn."}`)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"usageBreakdownList": []any{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	installTestRestClient(t, srv)
+
+	account := &Account{AccessToken: "tok", RefreshToken: "rt"}
+	resp, err := GetUsageLimits(account)
+	if err != nil {
+		t.Fatalf("GetUsageLimits() error = %v", err)
+	}
+	if resp == nil {
+		t.Fatal("GetUsageLimits() returned nil response")
+	}
+	if listCalls.Load() != 1 {
+		t.Fatalf("ListAvailableProfiles calls = %d, want 1", listCalls.Load())
+	}
+	if usageCalls.Load() == 0 {
+		t.Fatal("expected getUsageLimits to be called")
+	}
+	if got := account.ProfileArn; got != "arn:aws:codewhisperer:us-east-1:123456789012:profile/good" {
+		t.Fatalf("account.ProfileArn = %q, want resolved ARN", got)
+	}
+}
+
+func TestGetUsageLimits_RetriesAfterStaleProfileArn(t *testing.T) {
+	var listCalls atomic.Int32
+	var usageCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "ListAvailableProfiles"):
+			listCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"profiles": []map[string]string{
+					{"arn": "arn:aws:codewhisperer:us-east-1:123456789012:profile/fresh"},
+				},
+			})
+		case strings.Contains(r.URL.Path, "getUsageLimits"):
+			usageCalls.Add(1)
+			if strings.Contains(r.URL.RawQuery, "profile%2Fstale") || strings.Contains(r.URL.RawQuery, "profile/stale") {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"message":"Invalid profileArn."}`)
+				return
+			}
+			if !strings.Contains(r.URL.RawQuery, "profile%2Ffresh") && !strings.Contains(r.URL.RawQuery, "profile/fresh") {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"message":"Invalid profileArn."}`)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"usageBreakdownList": []any{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	installTestRestClient(t, srv)
+
+	account := &Account{
+		AccessToken:  "tok",
+		RefreshToken: "rt",
+		ProfileArn:   "arn:aws:codewhisperer:us-east-1:123456789012:profile/stale",
+	}
+	resp, err := GetUsageLimits(account)
+	if err != nil {
+		t.Fatalf("GetUsageLimits() error = %v", err)
+	}
+	if resp == nil {
+		t.Fatal("GetUsageLimits() returned nil response")
+	}
+	if listCalls.Load() != 1 {
+		t.Fatalf("ListAvailableProfiles calls = %d, want 1 after stale retry", listCalls.Load())
+	}
+	if usageCalls.Load() < 2 {
+		t.Fatalf("getUsageLimits calls = %d, want at least 2 (stale then fresh)", usageCalls.Load())
+	}
+	if got := account.ProfileArn; got != "arn:aws:codewhisperer:us-east-1:123456789012:profile/fresh" {
+		t.Fatalf("account.ProfileArn = %q, want fresh ARN", got)
+	}
+}
+
+func TestIsInvalidProfileArnError(t *testing.T) {
+	if !isInvalidProfileArnError(fmt.Errorf(`HTTP 400 from https://codewhisperer.us-east-1.amazonaws.com: {"message":"Invalid profileArn."}`)) {
+		t.Fatal("expected invalid profileArn detection")
+	}
+	if isInvalidProfileArnError(fmt.Errorf("HTTP 401: unauthorized")) {
+		t.Fatal("401 should not match invalid profileArn")
+	}
+}

--- a/backend/internal/service/account_usage_service_tk_kiro.go
+++ b/backend/internal/service/account_usage_service_tk_kiro.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	kiroproto "github.com/Wei-Shaw/sub2api/internal/integration/kiro"
@@ -66,13 +67,16 @@ func (s *AccountUsageService) getKiroUsage(ctx context.Context, account *Account
 
 	flightKey := fmt.Sprintf("kiro-usage:%d", account.ID)
 	result, flightErr, _ := s.cache.kiroFlight.Do(flightKey, func() (any, error) {
-		info, err := kiroproto.RefreshAccountInfo(account.toKiroProtoAccount())
+		kiroAcct := account.toKiroProtoAccount()
+		info, err := kiroproto.RefreshAccountInfo(kiroAcct)
 		if err != nil {
 			slog.Warn("kiro usage fetch failed, returning degraded response", "account_id", account.ID, "error", err)
 			passive.Error = fmt.Sprintf("usage API error: %v", err)
 			enrichUsageWithAccountError(passive, account)
 			return passive, nil
 		}
+
+		s.persistKiroProfileArnIfChanged(ctx, account, kiroAcct)
 
 		usage := buildKiroUsageFromInfo(info)
 		s.syncKiroActiveToPassive(ctx, account.ID, usage)
@@ -87,6 +91,23 @@ func (s *AccountUsageService) getKiroUsage(ctx context.Context, account *Account
 		return passive, nil
 	}
 	return usage, nil
+}
+
+// persistKiroProfileArnIfChanged writes a freshly resolved profile_arn back to account
+// credentials so subsequent usage/gateway calls do not repeat ListAvailableProfiles or
+// keep sending a stale ARN that triggers HTTP 400 Invalid profileArn.
+func (s *AccountUsageService) persistKiroProfileArnIfChanged(ctx context.Context, account *Account, kiroAcct *kiroproto.Account) {
+	if s == nil || account == nil || kiroAcct == nil {
+		return
+	}
+	resolved := strings.TrimSpace(kiroAcct.ProfileArn)
+	if resolved == "" || resolved == account.GetKiroProfileArn() {
+		return
+	}
+	merged := MergeCredentials(account.Credentials, map[string]any{"profile_arn": resolved})
+	if err := persistAccountCredentials(ctx, s.accountRepo, account, merged); err != nil {
+		slog.Warn("persist_kiro_profile_arn_failed", "account_id", account.ID, "error", err)
+	}
 }
 
 // buildKiroUsageFromInfo maps the vendored kiro.AccountInfo (GetUsageLimits result)

--- a/backend/internal/service/account_usage_service_tk_kiro_test.go
+++ b/backend/internal/service/account_usage_service_tk_kiro_test.go
@@ -11,7 +11,8 @@ import (
 
 type kiroPassiveSyncRepo struct {
 	AccountRepository
-	updates map[string]any
+	updates     map[string]any
+	credentials map[string]any
 }
 
 func (r *kiroPassiveSyncRepo) UpdateExtra(_ context.Context, _ int64, updates map[string]any) error {
@@ -19,6 +20,11 @@ func (r *kiroPassiveSyncRepo) UpdateExtra(_ context.Context, _ int64, updates ma
 	for k, v := range updates {
 		r.updates[k] = v
 	}
+	return nil
+}
+
+func (r *kiroPassiveSyncRepo) UpdateCredentials(_ context.Context, _ int64, credentials map[string]any) error {
+	r.credentials = cloneCredentials(credentials)
 	return nil
 }
 
@@ -187,5 +193,49 @@ func TestSyncKiroActiveToPassive_ClearsStaleTrialAndSubscriptionKeys(t *testing.
 		if got, ok := repo.updates[key]; !ok || got != nil {
 			t.Fatalf("%s = %v (present=%v), want explicit nil clear", key, got, ok)
 		}
+	}
+}
+
+func TestPersistKiroProfileArnIfChanged_WritesResolvedArn(t *testing.T) {
+	repo := &kiroPassiveSyncRepo{}
+	svc := &AccountUsageService{accountRepo: repo}
+	account := &Account{
+		ID:          7,
+		Platform:    PlatformKiro,
+		Type:        AccountTypeOAuth,
+		Credentials: map[string]any{"access_token": "tok"},
+	}
+	kiroAcct := &kiroproto.Account{ProfileArn: "arn:aws:codewhisperer:us-east-1:1:profile/fresh"}
+
+	svc.persistKiroProfileArnIfChanged(context.Background(), account, kiroAcct)
+
+	if repo.credentials == nil {
+		t.Fatal("expected UpdateCredentials")
+	}
+	if got := repo.credentials["profile_arn"]; got != "arn:aws:codewhisperer:us-east-1:1:profile/fresh" {
+		t.Fatalf("profile_arn = %v, want fresh ARN", got)
+	}
+	if got := account.GetKiroProfileArn(); got != "arn:aws:codewhisperer:us-east-1:1:profile/fresh" {
+		t.Fatalf("in-memory profile_arn = %q", got)
+	}
+}
+
+func TestPersistKiroProfileArnIfChanged_SkipsWhenUnchanged(t *testing.T) {
+	repo := &kiroPassiveSyncRepo{}
+	svc := &AccountUsageService{accountRepo: repo}
+	account := &Account{
+		ID:       7,
+		Platform: PlatformKiro,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"profile_arn": "arn:aws:codewhisperer:us-east-1:1:profile/same",
+		},
+	}
+	kiroAcct := &kiroproto.Account{ProfileArn: "arn:aws:codewhisperer:us-east-1:1:profile/same"}
+
+	svc.persistKiroProfileArnIfChanged(context.Background(), account, kiroAcct)
+
+	if repo.credentials != nil {
+		t.Fatalf("unexpected credential write: %+v", repo.credentials)
 	}
 }

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -119,6 +119,7 @@
       "must_contain": [
         "kiroManagementAPIBase",
         "management.us-east-1.kiro.dev",
+        "func ensureProfileArn",
         "func kiroRestFetch"
       ],
       "rationale": "Control-plane calls (ListAvailableProfiles / ListAvailableModels / getUsageLimits) routed through management.us-east-1.kiro.dev first with a codewhisperer.* fallback via kiroRestFetch (edge-us6 smoke-validated equivalent). A missing profileArn is the classic Kiro IDC-login 403 cause, so losing the management base or its fallback silently reintroduces 403s once codewhisperer.* is deprecated."
@@ -361,7 +362,8 @@
       "path": "backend/internal/service/account_usage_service_tk_kiro.go",
       "must_contain": [
         "func (s *AccountUsageService) getKiroUsage",
-        "kiroproto.RefreshAccountInfo(account.toKiroProtoAccount())",
+        "kiroproto.RefreshAccountInfo(kiroAcct)",
+        "persistKiroProfileArnIfChanged",
         "func (s *AccountUsageService) buildPassiveKiroUsage",
         "func buildKiroUsageFromInfo",
         "func (s *AccountUsageService) syncKiroActiveToPassive"


### PR DESCRIPTION
## 摘要

- Kiro usage 查询（`GetUsageLimits`）在发控制面请求前未解析 `profileArn`，与 chat 路径行为不一致，导致 `HTTP 400 Invalid profileArn`
- 现于 `kiroRestFetch(withParn=true)` 自动调用 `ResolveProfileArn`；若返回 stale ARN 错误则清空并重试一次
- usage 查询成功后，将新解析的 `profile_arn` 写回 credentials，避免重复解析

## 风险

- 常规风险：仅影响 Kiro 第六平台 usage 控制面调用，不改变 gateway 路由或公共 API 契约
- 首次「查询」可能多一次 `ListAvailableProfiles`（仅缺失/过期 ARN 时）

## 验证

```bash
cd backend
go test -tags=unit ./internal/integration/kiro/ -run 'TestGetUsageLimits|TestIsInvalidProfileArn' -v
go test -tags=unit ./internal/service/ -run 'TestPersistKiroProfileArn|TestBuildKiroUsage' -v
./scripts/preflight.sh
```

- 本地 preflight 全绿
- 新增单元测试覆盖：缺失 ARN 自动解析、stale ARN 重试、credentials 持久化

## 提交

- 75dd863b0 fix(kiro): 修复 GetUsageLimits 因缺失或过期 profileArn 返回 400

最新提交：75dd863b0
