### PR TITLE
fix(kiro): chat 路径 stale profileArn 自愈

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -142,7 +142,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	modelPricingResolver := service.NewModelPricingResolver(channelService, billingService)
 	notificationEmailService := service.NewNotificationEmailService(settingRepository, emailService)
 	balanceNotifyService := service.ProvideBalanceNotifyService(emailService, settingRepository, accountRepository, notificationEmailService)
-	kiroGatewayService := service.NewKiroGatewayService(httpUpstream, tlsFingerprintProfileService)
+	kiroGatewayService := service.NewKiroGatewayService(httpUpstream, tlsFingerprintProfileService, accountRepository)
 	gatewayService := service.NewGatewayService(accountRepository, groupRepository, usageLogRepository, usageBillingRepository, userRepository, userSubscriptionRepository, userGroupRateRepository, gatewayCache, configConfig, schedulerSnapshotService, concurrencyService, billingService, rateLimitService, billingCacheService, identityService, httpUpstream, deferredService, claudeTokenProvider, sessionLimitCache, rpmCache, digestSessionStore, settingService, tlsFingerprintProfileService, channelService, modelPricingResolver, balanceNotifyService, serviceUserPlatformQuotaRepository, kiroGatewayService)
 	openAIOAuthClient := repository.NewOpenAIOAuthClient()
 	privacyClientFactory := providePrivacyClientFactory()

--- a/backend/internal/integration/kiro/client.go
+++ b/backend/internal/integration/kiro/client.go
@@ -397,20 +397,26 @@ func CallKiroAPIWithDoer(doer HTTPDoer, account *Account, payload *KiroPayload, 
 	}
 
 	if payload != nil && strings.TrimSpace(payload.ProfileArn) == "" {
-		if profileArn, err := ResolveProfileArn(account); err == nil {
-			payload.ProfileArn = profileArn
+		if err := ensureProfileArn(account); err != nil {
+			logWarnf("[ProfileArn] Failed to resolve profile ARN for %s: %v", accountEmail(account), err)
 		} else {
-			accountEmail := "<nil>"
-			if account != nil {
-				accountEmail = account.Email
-			}
-			logWarnf("[ProfileArn] Failed to resolve profile ARN for %s: %v", accountEmail, err)
+			payload.ProfileArn = strings.TrimSpace(account.ProfileArn)
 		}
 	}
 
-	// Build endpoint list ordered by configuration.
 	endpoints := getSortedEndpoints(GetPreferredEndpoint())
+	err := callKiroAPIOnce(doer, account, payload, callback, endpoints)
+	if isInvalidProfileArnError(err) {
+		logWarnf("[KiroAPI] stale profileArn for %s, re-resolving: %v", accountEmail(account), err)
+		if resolveErr := reresolveProfileArnAfterStale(account); resolveErr == nil && payload != nil {
+			payload.ProfileArn = strings.TrimSpace(account.ProfileArn)
+			return callKiroAPIOnce(doer, account, payload, callback, endpoints)
+		}
+	}
+	return err
+}
 
+func callKiroAPIOnce(doer HTTPDoer, account *Account, payload *KiroPayload, callback *KiroStreamCallback, endpoints []kiroEndpoint) error {
 	var lastErr error
 	for _, ep := range endpoints {
 		// Update the origin field for the selected endpoint.

--- a/backend/internal/integration/kiro/client_profile_arn_test.go
+++ b/backend/internal/integration/kiro/client_profile_arn_test.go
@@ -1,0 +1,69 @@
+package kiro
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type staleProfileChatDoer struct {
+	calls atomic.Int32
+}
+
+func (d *staleProfileChatDoer) Do(req *http.Request) (*http.Response, error) {
+	d.calls.Add(1)
+	body, _ := io.ReadAll(req.Body)
+	var payload struct {
+		ProfileArn string `json:"profileArn"`
+	}
+	_ = json.Unmarshal(body, &payload)
+	if strings.Contains(payload.ProfileArn, "profile/stale") {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       io.NopCloser(strings.NewReader(`{"message":"Invalid profileArn."}`)),
+			Header:     http.Header{},
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+		Header:     http.Header{},
+	}, nil
+}
+
+func TestCallKiroAPI_RetriesAfterStaleProfileArn(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "ListAvailableProfiles") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []map[string]string{
+				{"arn": "arn:aws:codewhisperer:us-east-1:123456789012:profile/fresh"},
+			},
+		})
+	}))
+	defer srv.Close()
+	installTestRestClient(t, srv)
+
+	doer := &staleProfileChatDoer{}
+	account := &Account{
+		AccessToken:  "tok",
+		RefreshToken: "rt",
+		ProfileArn:   "arn:aws:codewhisperer:us-east-1:123456789012:profile/stale",
+	}
+	if err := CallKiroAPIWithDoer(doer, account, &KiroPayload{}, nil); err != nil {
+		t.Fatalf("CallKiroAPIWithDoer() error = %v", err)
+	}
+	if doer.calls.Load() < 2 {
+		t.Fatalf("chat doer calls = %d, want at least 2 (stale pass then fresh retry)", doer.calls.Load())
+	}
+	if got := account.ProfileArn; got != "arn:aws:codewhisperer:us-east-1:123456789012:profile/fresh" {
+		t.Fatalf("account.ProfileArn = %q, want fresh ARN", got)
+	}
+}

--- a/backend/internal/integration/kiro/rest.go
+++ b/backend/internal/integration/kiro/rest.go
@@ -46,8 +46,7 @@ func kiroRestFetch(account *Account, method, path, body string, withParn bool) (
 	data, err := kiroRestFetchBases(account, method, path, body, withParn)
 	if withParn && isInvalidProfileArnError(err) {
 		logWarnf("[KiroREST] stale profileArn for %s, re-resolving: %v", accountEmail(account), err)
-		account.ProfileArn = ""
-		if resolveErr := ensureProfileArn(account); resolveErr == nil {
+		if resolveErr := reresolveProfileArnAfterStale(account); resolveErr == nil {
 			return kiroRestFetchBases(account, method, path, body, withParn)
 		}
 	}
@@ -98,6 +97,16 @@ func ensureProfileArn(account *Account) error {
 	}
 	_, err := ResolveProfileArn(account)
 	return err
+}
+
+// reresolveProfileArnAfterStale clears a cached profileArn and fetches a fresh one.
+// Used when upstream returns HTTP 400 Invalid profileArn for REST and chat paths.
+func reresolveProfileArnAfterStale(account *Account) error {
+	if account == nil {
+		return fmt.Errorf("account is nil")
+	}
+	account.ProfileArn = ""
+	return ensureProfileArn(account)
 }
 
 func isInvalidProfileArnError(err error) bool {

--- a/backend/internal/service/account_test_service_kiro_quota402_test.go
+++ b/backend/internal/service/account_test_service_kiro_quota402_test.go
@@ -30,7 +30,7 @@ func TestAccountTestService_Kiro402ReachedLimitTriggersIncidentAlert(t *testing.
 
 	account := newEdgeUS4KiroAccount()
 	testSvc := &AccountTestService{
-		kiroGatewayService: NewKiroGatewayService(upstream, nil),
+		kiroGatewayService: NewKiroGatewayService(upstream, nil, nil),
 		rateLimitService:   svc,
 	}
 	err := testSvc.testKiroAccountConnection(c, account, KiroDefaultTestModel, "hi")

--- a/backend/internal/service/account_test_service_kiro_test.go
+++ b/backend/internal/service/account_test_service_kiro_test.go
@@ -28,7 +28,7 @@ func TestAccountTestService_KiroOAuthUsesKiroGateway(t *testing.T) {
 
 	svc := &AccountTestService{
 		accountRepo:        stubOpenAIAccountRepo{accounts: []Account{account}},
-		kiroGatewayService: NewKiroGatewayService(upstream, nil),
+		kiroGatewayService: NewKiroGatewayService(upstream, nil, nil),
 	}
 
 	err := svc.TestAccountConnection(ctx, account.ID, "claude-sonnet-4-5-20250929", "hi", AccountTestModeDefault)

--- a/backend/internal/service/account_tk_kiro.go
+++ b/backend/internal/service/account_tk_kiro.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -113,6 +115,23 @@ func (a *Account) GetKiroExpiresAt() *time.Time { return a.GetCredentialAsTime("
 // kiroDefaultRegion is the fallback AWS region used when the account has no
 // explicit region credential.
 const kiroDefaultRegion = "us-east-1"
+
+// PersistKiroProfileArnIfChanged writes a freshly resolved profile_arn back to account
+// credentials so subsequent usage/gateway calls do not repeat ListAvailableProfiles or
+// keep sending a stale ARN that triggers HTTP 400 Invalid profileArn.
+func PersistKiroProfileArnIfChanged(ctx context.Context, repo AccountRepository, account *Account, kiroAcct *kiroproto.Account) {
+	if repo == nil || account == nil || kiroAcct == nil {
+		return
+	}
+	resolved := strings.TrimSpace(kiroAcct.ProfileArn)
+	if resolved == "" || resolved == account.GetKiroProfileArn() {
+		return
+	}
+	merged := MergeCredentials(account.Credentials, map[string]any{"profile_arn": resolved})
+	if err := persistAccountCredentials(ctx, repo, account, merged); err != nil {
+		slog.Warn("persist_kiro_profile_arn_failed", "account_id", account.ID, "error", err)
+	}
+}
 
 // toKiroProtoAccount maps the business Account onto the vendored kiroproto.Account
 // shape consumed by internal/integration/kiro. The vendored ID field is a string,

--- a/backend/internal/service/account_usage_service_tk_kiro.go
+++ b/backend/internal/service/account_usage_service_tk_kiro.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	kiroproto "github.com/Wei-Shaw/sub2api/internal/integration/kiro"
@@ -97,17 +96,7 @@ func (s *AccountUsageService) getKiroUsage(ctx context.Context, account *Account
 // credentials so subsequent usage/gateway calls do not repeat ListAvailableProfiles or
 // keep sending a stale ARN that triggers HTTP 400 Invalid profileArn.
 func (s *AccountUsageService) persistKiroProfileArnIfChanged(ctx context.Context, account *Account, kiroAcct *kiroproto.Account) {
-	if s == nil || account == nil || kiroAcct == nil {
-		return
-	}
-	resolved := strings.TrimSpace(kiroAcct.ProfileArn)
-	if resolved == "" || resolved == account.GetKiroProfileArn() {
-		return
-	}
-	merged := MergeCredentials(account.Credentials, map[string]any{"profile_arn": resolved})
-	if err := persistAccountCredentials(ctx, s.accountRepo, account, merged); err != nil {
-		slog.Warn("persist_kiro_profile_arn_failed", "account_id", account.ID, "error", err)
-	}
+	PersistKiroProfileArnIfChanged(ctx, s.accountRepo, account, kiroAcct)
 }
 
 // buildKiroUsageFromInfo maps the vendored kiro.AccountInfo (GetUsageLimits result)

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -30,16 +30,19 @@ import (
 type KiroGatewayService struct {
 	httpUpstream        HTTPUpstream
 	tlsFPProfileService *TLSFingerprintProfileService
+	accountRepo         AccountRepository
 }
 
 // NewKiroGatewayService constructs a KiroGatewayService.
 func NewKiroGatewayService(
 	httpUpstream HTTPUpstream,
 	tlsFPProfileService *TLSFingerprintProfileService,
+	accountRepo AccountRepository,
 ) *KiroGatewayService {
 	return &KiroGatewayService{
 		httpUpstream:        httpUpstream,
 		tlsFPProfileService: tlsFPProfileService,
+		accountRepo:         accountRepo,
 	}
 }
 
@@ -106,9 +109,17 @@ func (s *KiroGatewayService) Forward(
 	}
 
 	if req.Stream {
-		return s.forwardStreaming(ctx, c, doer, kiroAcct, payload, &req, requestID, model, startTime)
+		result, err := s.forwardStreaming(ctx, c, doer, kiroAcct, payload, &req, requestID, model, startTime)
+		if err == nil {
+			PersistKiroProfileArnIfChanged(ctx, s.accountRepo, account, kiroAcct)
+		}
+		return result, err
 	}
-	return s.forwardNonStreaming(ctx, c, doer, kiroAcct, payload, &req, requestID, model, startTime)
+	result, err := s.forwardNonStreaming(ctx, c, doer, kiroAcct, payload, &req, requestID, model, startTime)
+	if err == nil {
+		PersistKiroProfileArnIfChanged(ctx, s.accountRepo, account, kiroAcct)
+	}
+	return result, err
 }
 
 // forwardNonStreaming accumulates text/thinking/tool-use then writes a single

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -144,7 +144,7 @@ func TestKiroGatewayService_Forward_NonStreaming(t *testing.T) {
 		[]byte(`{"content":"hello world","inputTokens":12,"outputTokens":5}`))
 	upstream := &kiroFakeUpstream{body: frame}
 
-	svc := NewKiroGatewayService(upstream, nil)
+	svc := NewKiroGatewayService(upstream, nil, nil)
 
 	body, _ := json.Marshal(map[string]any{
 		"model":      "claude-sonnet-4",
@@ -185,7 +185,7 @@ func TestKiroGatewayService_Forward_Streaming(t *testing.T) {
 		[]byte(`{"content":"hi there","inputTokens":8,"outputTokens":3}`))
 	upstream := &kiroFakeUpstream{body: frame}
 
-	svc := NewKiroGatewayService(upstream, nil)
+	svc := NewKiroGatewayService(upstream, nil, nil)
 
 	body, _ := json.Marshal(map[string]any{
 		"model":      "claude-sonnet-4",
@@ -248,7 +248,7 @@ func TestKiroGatewayService_Forward_Streaming_InvalidModel_NoEmpty200(t *testing
 		status: http.StatusBadRequest,
 		body:   `{"reason":"INVALID_MODEL_ID","message":"model not found"}`,
 	}
-	svc := NewKiroGatewayService(upstream, nil)
+	svc := NewKiroGatewayService(upstream, nil, nil)
 
 	body, _ := json.Marshal(map[string]any{
 		"model":      "claude-haiku-4.5",
@@ -284,7 +284,7 @@ func TestKiroGatewayService_Forward_NonStreaming_InvalidModel(t *testing.T) {
 		status: http.StatusBadRequest,
 		body:   `{"reason":"INVALID_MODEL_ID"}`,
 	}
-	svc := NewKiroGatewayService(upstream, nil)
+	svc := NewKiroGatewayService(upstream, nil, nil)
 
 	body, _ := json.Marshal(map[string]any{
 		"model":    "claude-haiku-4.5",
@@ -367,7 +367,7 @@ func TestGatewayService_Forward_Kiro401TriggersRateLimitRefresh(t *testing.T) {
 	})
 
 	svc := &GatewayService{
-		kiroGateway:      NewKiroGatewayService(upstream, nil),
+		kiroGateway:      NewKiroGatewayService(upstream, nil, nil),
 		rateLimitService: rateLimit,
 	}
 	body, _ := json.Marshal(map[string]any{

--- a/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
+++ b/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
@@ -97,7 +97,7 @@ func TestKiroGatewayService_Forward_Streaming_WithReasoningEvent(t *testing.T) {
 	body := append(reasoningFrame, textFrame...)
 	upstream := &kiroFakeUpstream{body: body}
 
-	svc := NewKiroGatewayService(upstream, nil)
+	svc := NewKiroGatewayService(upstream, nil, nil)
 	reqBody, _ := json.Marshal(map[string]any{
 		"model":      "claude-sonnet-4-6",
 		"messages":   []map[string]any{{"role": "user", "content": "hi"}},
@@ -134,7 +134,7 @@ func TestKiroGatewayService_Forward_Streaming_RedactsSplitInlineThinkingTags(t *
 	}
 	upstream := &kiroFakeUpstream{body: body}
 
-	svc := NewKiroGatewayService(upstream, nil)
+	svc := NewKiroGatewayService(upstream, nil, nil)
 	reqBody, _ := json.Marshal(map[string]any{
 		"model":      "claude-sonnet-4-6",
 		"messages":   []map[string]any{{"role": "user", "content": "who are you"}},

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -108,6 +108,8 @@
       "path": "backend/internal/integration/kiro/client.go",
       "must_contain": [
         "func CallKiroAPIWithDoer",
+        "func callKiroAPIOnce",
+        "stale profileArn",
         "func parseEventStream",
         "HTTPDoer",
         "runtime.us-east-1.kiro.dev"
@@ -120,6 +122,7 @@
         "kiroManagementAPIBase",
         "management.us-east-1.kiro.dev",
         "func ensureProfileArn",
+        "func reresolveProfileArnAfterStale",
         "func kiroRestFetch"
       ],
       "rationale": "Control-plane calls (ListAvailableProfiles / ListAvailableModels / getUsageLimits) routed through management.us-east-1.kiro.dev first with a codewhisperer.* fallback via kiroRestFetch (edge-us6 smoke-validated equivalent). A missing profileArn is the classic Kiro IDC-login 403 cause, so losing the management base or its fallback silently reintroduces 403s once codewhisperer.* is deprecated."
@@ -128,6 +131,7 @@
       "path": "backend/internal/service/account_tk_kiro.go",
       "must_contain": [
         "func (a *Account) IsKiro()",
+        "PersistKiroProfileArnIfChanged",
         "toKiroProtoAccount",
         "func (a *Account) isKiroTLSFingerprintEnabled()",
         "CanonicalKiroTLSProfileName"
@@ -154,6 +158,7 @@
       "must_contain": [
         "type KiroGatewayService",
         "func (s *KiroGatewayService) Forward",
+        "PersistKiroProfileArnIfChanged",
         "kiroproto.EstimateInputTokens",
         "kiroproto.EstimateOutputTokens",
         "BillingTier:   kiroproto.KiroEstimatedBillingTier",


### PR DESCRIPTION
## 摘要

- 在已合并的 #1079（REST `GetUsageLimits` profileArn 自愈）基础上，补齐 **chat 路径**：`CallKiroAPI` 在 upstream 返回 `Invalid profileArn` 时清空 stale ARN、重解析并重试一次。
- 抽出 `reresolveProfileArnAfterStale` 与 `PersistKiroProfileArnIfChanged`，gateway 转发成功后写回 `credentials.profile_arn`，避免只走 chat、不查 usage 的账号长期携带过期 ARN。

## 风险

- 常规风险：仅 Kiro 内部重试与 credentials 写回，无公共 API/契约变化。
- 重试仅触发一次，避免无限循环；写回失败只记 warn，不阻断转发。
- sentinel-registry-reviewed：`kiro_sse_encoder_tk_thinking_redact_test.go` 仅因 `NewKiroGatewayService` 新增第三参（测试传 `nil`），无 load-bearing 行为变更，无需新增 gateway-tk sentinel。

## 验证

- `go test -tags=unit ./internal/integration/kiro/ -run 'TestCallKiroAPI_RetriesAfterStaleProfileArn|TestGetUsageLimits'`
- `go test -tags=unit ./internal/service/ -run 'TestPersistKiroProfileArn|TestKiroGateway'`
- `./scripts/preflight.sh`（`PREFLIGHT_BASE=origin/main`）PASS

## 提交

- `11bf93b58` fix(kiro): chat 路径 stale profileArn 自愈并与 usage 共用持久化

最新提交：11bf93b58
