### PR TITLE
chore: refresh upstream issue cache

### DIFF
--- a/.cache/upstream/triage.json
+++ b/.cache/upstream/triage.json
@@ -4,12 +4,12 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 512,
-    "fixed": 42,
-    "medium": 144,
+    "needs_review": 888,
+    "medium": 213,
+    "fixed": 34,
     "not_applicable": 1,
-    "low": 134,
-    "unknown_low_signal": 523
+    "low": 194,
+    "unknown_low_signal": 761
   },
   "issues": [
     {
@@ -111,7 +111,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-04-12T15:17:35Z"
+      "updated_at": "2026-07-26T04:48:28Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1175",
@@ -161,7 +161,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-03-22T04:54:30Z"
+      "updated_at": "2026-07-17T08:35:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1219",
@@ -287,6 +287,19 @@
       "updated_at": "2026-06-10T09:56:47Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#1318",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1318",
+      "title": "[bug] openai_passthrough 命中临时不可调度规则后未触发 failover",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-26T06:47:06Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#1331",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1331",
       "title": "feat: 网关层协议自动转换，使分组与平台解耦",
@@ -297,7 +310,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-03-28T16:22:06Z"
+      "updated_at": "2026-07-01T03:23:53Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1339",
@@ -394,7 +407,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-05T03:04:31Z"
+      "updated_at": "2026-08-10T01:04:24Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1386",
@@ -659,20 +672,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-04-08T14:42:46Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1520",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1520",
-      "title": "分享: sub2api 在接入大语言模型接口时如何绕过风控的一些经验",
-      "impact": "needs_review",
-      "categories": [
-        "claude_mimicry",
-        "security"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-04-25T11:22:15Z"
+      "updated_at": "2026-08-17T09:13:42Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1525",
@@ -736,7 +736,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-12T13:41:15Z"
+      "updated_at": "2026-07-03T04:34:15Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1544",
@@ -1142,7 +1142,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-04-28T04:12:48Z"
+      "updated_at": "2026-08-01T03:51:31Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1805",
@@ -1195,6 +1195,18 @@
       "updated_at": "2026-04-23T06:14:50Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#1833",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1833",
+      "title": "不扣费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T08:46:58Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#1834",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1834",
       "title": "图生图接口有问题",
@@ -1228,7 +1240,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-04-23T08:15:11Z"
+      "updated_at": "2026-07-29T05:41:30Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1848",
@@ -1376,6 +1388,18 @@
       "updated_at": "2026-04-24T05:43:13Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#1882",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1882",
+      "title": "feat: 渠道监控，使用用户真实调用记录",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-02T20:21:48Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#1885",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1885",
       "title": "v0.1.117 版本使用 GPT 5.5 出现 No tool output found for tool search call fcjAsf03FedtKVWvFij7eSFSo7 导致 502 错误",
@@ -1437,7 +1461,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-17T02:18:08Z"
+      "updated_at": "2026-07-07T03:55:01Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1894",
@@ -1527,7 +1551,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-18T13:55:18Z"
+      "updated_at": "2026-08-09T03:14:13Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1928",
@@ -1540,6 +1564,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-04-25T00:54:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1934",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1934",
+      "title": "切组后旧 sticky session 没失效，导致一直调用已经被切出去的账号",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T03:35:59Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1941",
@@ -1565,7 +1601,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-04-30T07:31:25Z"
+      "updated_at": "2026-07-05T03:28:06Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1950",
@@ -1662,7 +1698,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-04-26T12:52:17Z"
+      "updated_at": "2026-08-02T12:00:04Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1982",
@@ -1725,7 +1761,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-04-26T14:03:22Z"
+      "updated_at": "2026-07-11T16:20:26Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1999",
@@ -1812,6 +1848,19 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-04-27T09:44:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2013",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2013",
+      "title": "claude top level cache control not working",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T01:47:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2014",
@@ -2083,7 +2132,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-03T17:28:05Z"
+      "updated_at": "2026-07-02T11:59:15Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2133",
@@ -2095,7 +2144,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-04-30T06:32:19Z"
+      "updated_at": "2026-07-26T08:08:12Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2135",
@@ -2570,6 +2619,18 @@
       "updated_at": "2026-06-15T14:22:57Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#2298",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2298",
+      "title": "Bug: Upstream empty SSE data: frames cause OpenAI SDK JSONDecodeError when using Responses API (/v1/responses)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-08T15:42:59Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#2315",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2315",
       "title": "This version of Antigravity is no longer supported. Please upgrade to receive the latest features.",
@@ -2902,7 +2963,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-09T05:11:57Z"
+      "updated_at": "2026-08-01T04:51:40Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2525",
@@ -2966,7 +3027,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-09T11:15:15Z"
+      "updated_at": "2026-08-17T12:29:24Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2560",
@@ -3038,7 +3099,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-16T08:42:27Z"
+      "updated_at": "2026-07-04T07:53:10Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2619",
@@ -3092,18 +3153,6 @@
       "updated_at": "2026-05-20T10:38:53Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2646",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2646",
-      "title": "【风控中心】-【内容审计】 可否 支持 【IP管理】-【代理服务器】",
-      "impact": "needs_review",
-      "categories": [
-        "claude_mimicry"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-26T03:15:58Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#268",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/268",
       "title": "我用的是antigratiy反代，现在莫名其妙出现429，尝试了几次之后六个号的额度瞬间满了",
@@ -3137,7 +3186,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-22T05:26:05Z"
+      "updated_at": "2026-07-28T15:28:06Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2689",
@@ -3162,7 +3211,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-19T06:06:54Z"
+      "updated_at": "2026-06-29T10:48:03Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2692",
@@ -3213,6 +3262,19 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-05-24T08:06:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2727",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2727",
+      "title": "请求反复打到同一个已经限流的账户上去",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-26T10:36:34Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2734",
@@ -3436,7 +3498,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-05T08:52:32Z"
+      "updated_at": "2026-07-28T03:48:46Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2806",
@@ -3448,7 +3510,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-11T04:47:05Z"
+      "updated_at": "2026-07-15T08:19:37Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2809",
@@ -3460,7 +3522,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-27T04:54:05Z"
+      "updated_at": "2026-07-14T03:01:56Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2810",
@@ -3496,7 +3558,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-27T07:42:06Z"
+      "updated_at": "2026-07-02T06:10:29Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2824",
@@ -3521,7 +3583,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-08T05:41:07Z"
+      "updated_at": "2026-07-08T02:37:24Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2828",
@@ -3669,7 +3731,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-24T02:38:21Z"
+      "updated_at": "2026-07-06T06:14:27Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2902",
@@ -3794,7 +3856,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-18T18:12:30Z"
+      "updated_at": "2026-07-17T09:52:01Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2959",
@@ -3891,7 +3953,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-01-19T10:03:26Z"
+      "updated_at": "2026-07-31T04:33:50Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2992",
@@ -3916,7 +3978,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T08:23:52Z"
+      "updated_at": "2026-07-14T09:29:07Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3004",
@@ -3929,6 +3991,20 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-03T08:18:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3014",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3014",
+      "title": "bug(openai): codex_cli_only 未拦截 /v1/chat/completions 兼容入口",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:47:42Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3015",
@@ -4067,19 +4143,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-05T17:16:17Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3074",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3074",
-      "title": "Codex App 请求普通文本时触发上游 image generation 权限错误并持续重连",
-      "impact": "needs_review",
-      "categories": [
-        "image_oauth"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-15T03:49:29Z"
+      "updated_at": "2026-07-03T01:18:11Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#308",
@@ -4091,7 +4155,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-01-16T15:17:20Z"
+      "updated_at": "2026-07-31T04:33:55Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3084",
@@ -4146,18 +4210,6 @@
       "updated_at": "2026-06-07T09:29:42Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#3101",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3101",
-      "title": "claude code缓存写一直累计问题",
-      "impact": "needs_review",
-      "categories": [
-        "claude_mimicry"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-07T09:48:39Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#3105",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/3105",
       "title": "Auto setup migration times out on Render with external PostgreSQL",
@@ -4191,7 +4243,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-08T02:53:27Z"
+      "updated_at": "2026-07-30T03:20:41Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3112",
@@ -4487,31 +4539,6 @@
       "updated_at": "2026-06-11T15:56:17Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#3227",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3227",
-      "title": "希望在 “风控中心”的日志记录中能增加 触发了哪个关键字的字段",
-      "impact": "needs_review",
-      "categories": [
-        "claude_mimicry"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-17T20:58:49Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3236",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3236",
-      "title": "OpenAI context-window overflow errors should not trigger account failover",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit_cooldown",
-        "image_oauth"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-12T04:07:22Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#3241",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/3241",
       "title": "功能请求：IP 代理失效自动切换开关",
@@ -4596,7 +4623,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-15T06:11:28Z"
+      "updated_at": "2026-07-01T03:48:53Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3292",
@@ -4632,7 +4659,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-15T18:10:57Z"
+      "updated_at": "2026-07-01T03:26:13Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3302",
@@ -4646,7 +4673,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-24T10:59:47Z"
+      "updated_at": "2026-07-17T09:09:49Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3303",
@@ -4695,7 +4722,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-24T03:31:03Z"
+      "updated_at": "2026-08-05T01:21:19Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#331",
@@ -4757,7 +4784,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-18T08:00:03Z"
+      "updated_at": "2026-07-08T00:23:51Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3332",
@@ -4843,7 +4870,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-18T07:56:09Z"
+      "updated_at": "2026-07-22T06:31:55Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3351",
@@ -4856,18 +4883,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-24T01:17:34Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3352",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3352",
-      "title": "支持基于 KEY 统计占用的并发",
-      "impact": "needs_review",
-      "categories": [
-        "billing_usage"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-18T08:56:25Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3362",
@@ -4929,7 +4944,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-21T11:46:41Z"
+      "updated_at": "2026-07-10T08:02:34Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3400",
@@ -4978,7 +4993,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-22T03:48:47Z"
+      "updated_at": "2026-07-01T02:21:41Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3410",
@@ -5004,7 +5019,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-22T09:02:54Z"
+      "updated_at": "2026-07-12T18:49:02Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3415",
@@ -5043,19 +5058,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-22T19:41:26Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3424",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3424",
-      "title": "Claude OAuth token exchange returns 400 Invalid request format when expires_in is sent",
-      "impact": "needs_review",
-      "categories": [
-        "image_oauth",
-        "security"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-23T03:37:41Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3427",
@@ -5145,18 +5147,6 @@
       "updated_at": "2026-06-26T02:58:05Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#347",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/347",
-      "title": "opencode 的使用示例有问题，无法读取图片和 cost",
-      "impact": "needs_review",
-      "categories": [
-        "image_oauth"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-03-17T06:11:22Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#3472",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/3472",
       "title": "添加账号的时候显示token exchange failed: status 403,",
@@ -5166,7 +5156,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-29T03:17:02Z"
+      "updated_at": "2026-07-06T07:51:34Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3475",
@@ -5203,19 +5193,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T16:14:48Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3504",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3504",
-      "title": "支付逻辑存在两个问题：退款 pending 被当成功，以及匿名查单暴露过多订单/退款信息",
-      "impact": "needs_review",
-      "categories": [
-        "security"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T18:19:09Z"
+      "updated_at": "2026-07-28T02:34:48Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3508",
@@ -5264,7 +5242,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T09:09:52Z"
+      "updated_at": "2026-07-01T03:48:55Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3522",
@@ -5277,7 +5255,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T09:48:59Z"
+      "updated_at": "2026-07-11T02:35:03Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3523",
@@ -5351,7 +5329,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-28T05:56:23Z"
+      "updated_at": "2026-07-01T03:26:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3539",
@@ -5364,19 +5342,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-28T08:51:35Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3540",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3540",
-      "title": "[Feature Request] 网关层增加控制字符清洗，兼容发送未转义控制字符的客户端",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit_cooldown",
-        "security"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-28T11:30:49Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3550",
@@ -5413,7 +5378,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-29T03:56:10Z"
+      "updated_at": "2026-06-30T18:27:34Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3555",
@@ -5425,20 +5390,56 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-29T08:43:26Z"
+      "updated_at": "2026-06-30T07:16:37Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#3556",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3556",
-      "title": "用户仪表盘的“模型分布”接口目前按 usage_logs.model 聚合，而不是按 requested_model 聚合。",
+      "upstream": "Wei-Shaw/sub2api#3562",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3562",
+      "title": "feat：增加自定义oauth2可接入第三方系统",
       "impact": "needs_review",
       "categories": [
-        "rate_limit_cooldown",
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-29T18:16:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3571",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3571",
+      "title": "能不能更新个同步上游key分组倍率 同步到“账号计费倍率”",
+      "impact": "needs_review",
+      "categories": [
         "billing_usage"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-29T08:55:51Z"
+      "updated_at": "2026-06-30T07:39:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3573",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3573",
+      "title": "Codex 生图是不是可以考虑用 Codex SDK 去合规实现，不会引发封号",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-30T08:18:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3595",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3595",
+      "title": "风控中心bug",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-01T02:53:30Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#360",
@@ -5453,6 +5454,19 @@
       "updated_at": "2026-01-22T08:43:50Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#3603",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3603",
+      "title": "Streaming `/responses` withholds `response.created` + the entire reasoning phase until output begins (pre-output hold) — reasoning clients see a frozen stream via OpenAI-compatible / apikey upstreams",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-01T07:12:34Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#362",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/362",
       "title": "配置了Claude的服务商为智谱，限额到达时账号没有限流",
@@ -5463,6 +5477,32 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-01-24T23:07:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3623",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3623",
+      "title": "多次设置Accept-Encoding",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-01T16:34:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3624",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3624",
+      "title": "openai oauth账号可否增加User-Agent和tlc指纹伪装",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T08:13:40Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#364",
@@ -5478,6 +5518,43 @@
       "updated_at": "2026-01-23T09:47:06Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#3644",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3644",
+      "title": "Codex 516的截断降智问题",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-08T02:45:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3646",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3646",
+      "title": "codex cli下伪装漏洞，originator与useragent不匹配",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-02T11:46:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3652",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3652",
+      "title": "143版本http_bridge模式下指纹信息构造不正确",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-02T13:37:56Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#367",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/367",
       "title": "请问这个429的时间，是本服务限制的吗？",
@@ -5488,6 +5565,141 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-01-22T22:25:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3678",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3678",
+      "title": "风控中心增加 AI 内容审核模块 — 支持自定义审核提示词、请求内容留存与 Group 级策略",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T10:25:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3682",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3682",
+      "title": "RFC: add asynchronous Gemini image batch generation with Gemini API key and Vertex providers",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-03T11:41:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3686",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3686",
+      "title": "Copilot integration support",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-16T10:02:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3700",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3700",
+      "title": "日志报错：ERROR service/scheduler_snapshot_service.go:244 [Scheduler] outbox watermark read failed: i/o timeout {\"service\": \"sub2api\", \"env\": \"production\", \"component\": \"service.scheduler_snapshot\", \"legacy_printf\": true}",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-04T02:15:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3701",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3701",
+      "title": "使用antigravity计费异常",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-04T03:20:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3705",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3705",
+      "title": "为什么明明搞了模型映射但是有时候就是没有映射呢，有时候又可以",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-04T06:27:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3706",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3706",
+      "title": "长会话过程中系统休眠十几个小时后回来openai必踢oauth号",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-04T07:22:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3711",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3711",
+      "title": "OIDC用户注册问题",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-04T14:47:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3720",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3720",
+      "title": "feat: support verified custom domains for user-owned API base URLs and endpoint isolation",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-05T02:42:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3725",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3725",
+      "title": "feat(payment): 支持微信支付 API v2 普通商户密钥模式",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-05T07:43:26Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#374",
@@ -5502,6 +5714,32 @@
       "updated_at": "2026-01-24T17:42:09Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#3741",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3741",
+      "title": "Claude用授权oauth 好 还是授权setup token好？",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-06T04:13:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3742",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3742",
+      "title": "总是偶尔出现503错误",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-08T01:37:20Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#375",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/375",
       "title": "【anti反代】 反代出来的cc貌似token一多就报错？",
@@ -5512,6 +5750,32 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-01-23T10:04:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3750",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3750",
+      "title": "request.go里面没有“Codex Desktop”",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-06T08:49:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3756",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3756",
+      "title": "feat：Claude、OpenAI的OAuth登录无法设置请求重试",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-06T11:18:59Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#376",
@@ -5526,6 +5790,30 @@
       "updated_at": "2026-01-24T00:38:20Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#3773",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3773",
+      "title": "能否自定义测试账号连接的提示词",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-07T03:35:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3779",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3779",
+      "title": "仪表盘 数据错误",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-07T06:16:34Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#378",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/378",
       "title": "反重力报错",
@@ -5536,6 +5824,31 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-02-09T08:59:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3782",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3782",
+      "title": "bug: /v1/responses 应本地拒绝非法 reasoning.effort",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-07T06:30:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3787",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3787",
+      "title": "别再交“学费”了，一步到位才是最省钱的",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-07T07:39:02Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#379",
@@ -5550,6 +5863,203 @@
       "updated_at": "2026-01-24T06:00:07Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#3797",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3797",
+      "title": "claude code 使用auto model on模式总是提示分类器不可用",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-08T11:06:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3814",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3814",
+      "title": "这个上游502错误是什么问题？是我的使用socks5的问题吗？",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-08T04:35:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3815",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3815",
+      "title": "[GeminiOAuth] Drive API scope not available (403)这个是什么问题？",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-08T02:07:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3817",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3817",
+      "title": "bug-一个账号用完，不会自动切换，codex直接502",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-08T02:44:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3821",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3821",
+      "title": "1个人使用claude时候也会频繁触发429，然后多个账号轮询一遍",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-01T03:50:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3825",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3825",
+      "title": "Claude Setup-Token不会自动刷新",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-15T03:23:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3826",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3826",
+      "title": "希望增加一个模型试用功能，即像new api的操练场",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-08T09:13:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3831",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3831",
+      "title": "微信公众号支付报错：payment resume tokens require a configured signing key",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-08T14:14:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3837",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3837",
+      "title": "oauth 回调",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-08T22:18:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3839",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3839",
+      "title": "多个安全问题：Token 泄露、Stored XSS、SSRF、安装接管、明文 API Key、依赖漏洞等",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T08:35:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3852",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3852",
+      "title": "账号测试是正常，但是一使用就报503",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-09T07:47:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3871",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3871",
+      "title": "Codex agent system prompt 这个能改成自己设置开启和自定义内容吗",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-09T10:34:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3872",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3872",
+      "title": "v0.1.147 版本bug",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-12T06:57:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3879",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3879",
+      "title": "添加账号时,授权url提交不全问题",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-09T13:23:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3890",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3890",
+      "title": "bug：gpt-5.6系列的fast模式在 apikey和oauth方式下模型单价不统一",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T10:12:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3894",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3894",
+      "title": "GPT-5.6 无法对缓存创建计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T03:16:28Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#390",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/390",
       "title": "配置了openAi调用api接口也是/v1/messages 接口访问 吗 为什么cli里是正常的我用/v1/messages方式访问提示`502 Bad Gateway` response:\\n{\\\"error\\\":{\\\"message\\\":\\\"Upstream service temporarily unavailable\\\",\\\"type\\\":\\\"upstream_error\\\"}",
@@ -5561,6 +6071,30 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-02-09T03:09:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3907",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3907",
+      "title": "是否限流与实际额度不符",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T14:39:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3919",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3919",
+      "title": "最新v0.1.149不计费gpt-5.6的缓存写入啊",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T03:37:49Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#392",
@@ -5577,6 +6111,104 @@
       "updated_at": "2026-03-06T10:05:03Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#3923",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3923",
+      "title": "这会对 本项目 集成号有影响吗",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T06:15:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3927",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3927",
+      "title": "希望下个版本适配 Codex Attestation generation（证明生成）",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T07:07:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3932",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3932",
+      "title": "Error running remote compact task:Stream disconnected before completion: stream closed before response.completed",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T16:46:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3936",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3936",
+      "title": "gpt-5.6的缓存写入没有计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-06T07:46:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3937",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3937",
+      "title": "[Feature] 支持 Anthropic Server-side Fallback 场景按响应模型计费",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T06:10:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3954",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3954",
+      "title": "API Error: 400 {\"detail\":\"Unsupported parameter: max_output_tokens\"}",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T07:22:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3955",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3955",
+      "title": "测试正常 可以对话 但是 codex调用直接 gpt-5.6-sol k12的账号",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T07:24:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3958",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3958",
+      "title": "bug：微信公众号支付报错payment resume tokens require a configured signing key，非微信支付官方报错，希望能修复。",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T07:35:15Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#396",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/396",
       "title": "错误: 反重力Token 刷新失败",
@@ -5589,6 +6221,206 @@
       "updated_at": "2026-01-26T04:06:21Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#3977",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3977",
+      "title": "antigravity有办法过403吗，买了很多高品质的号，绑定了住宅ip，oauth都是过了的，但一调用就403",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T12:24:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3978",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3978",
+      "title": "Feature: API Key TTL injection (system/group-level default expiry policy)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T10:04:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3995",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3995",
+      "title": "[Bug] v0.1.151: Codex /v1/models 在 OAuth/API Key 混合分组中随机 502",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-12T03:38:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3999",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3999",
+      "title": "fd文件打开异常",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T15:21:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4012",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4012",
+      "title": "Feature Request - MiniMax and GLM Coding Subscriptions",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-10T21:59:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4016",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4016",
+      "title": "gpt-5.6-sol计费叠加问题：上下文超出272K 与 fast 叠加后 输入达 20，输出达 90， 与官方计费规则违背。",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-07T11:51:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4017",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4017",
+      "title": "gpt-5.6-sol Compact 失败，需要切换回5.5",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-11T01:03:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4018",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4018",
+      "title": "关于生图失败自动降级为svg拼图的问题。",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-11T00:48:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4020",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4020",
+      "title": "codex 最新模型 gpt-5.6-sol 使用时 remote compact会报错导致 终端卡住",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-11T14:19:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4021",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4021",
+      "title": "使用api登录codex，对话显示404",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-11T02:20:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4024",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4024",
+      "title": "Support for Apple Container",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T04:50:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4029",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4029",
+      "title": "Codex/CC Switch key-usage templates hardcode model = \"gpt-5.5\", don't reflect available GPT-5.6 models",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-11T04:10:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4033",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4033",
+      "title": "5.6-sol，限流严重，但其他模型又没事",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T08:20:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4054",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4054",
+      "title": "Chat GPT 账号计费bug",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-11T10:35:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4070",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4070",
+      "title": "v0.1.151 codex models manifest request failed",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-11T18:04:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4078",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4078",
+      "title": "希望增加关闭计费记录仅记录Token数量的选项",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-12T01:25:20Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#408",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/408",
       "title": "调度问题",
@@ -5598,7 +6430,45 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-01-28T03:57:48Z"
+      "updated_at": "2026-07-03T07:10:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4080",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4080",
+      "title": "Error running remote compact task: unexpected status 502 Bad Gateway: error code: 502",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-12T13:40:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4090",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4090",
+      "title": "大量 502 错误 `account has no Codex backend access token` 寻求解决方案。",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T08:32:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4091",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4091",
+      "title": "建议：让 cyber_policy 遵循审计分组范围，支持部分分组不执行风控处置",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-12T07:39:41Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#410",
@@ -5610,7 +6480,175 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-02-26T05:52:37Z"
+      "updated_at": "2026-07-29T17:24:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4100",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4100",
+      "title": "[Feature Request] 用户标准并发与额外并发配额",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-12T12:53:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4102",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4102",
+      "title": "feat(payment): make recharge/subscription display currency configurable or method-aware",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-12T13:56:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4103",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4103",
+      "title": "bug: /v1/chat/completions incorrectly routes Antigravity accounts to Anthropic upstream",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-15T13:14:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4113",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4113",
+      "title": "/responses/compact upstream 503 triggers keepalive writer nil-pointer panic and disconnects Codex",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "account_pool_health",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T08:37:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4117",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4117",
+      "title": "feat: Antigravity groups support OpenAI /v1/chat/completions",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-15T13:21:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4127",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4127",
+      "title": "[Question] OAuth(ChatGPT)账号生图 /v1/images/generations 入参 传了 n> 1 则会报错 Unknown parameter: 'tools[0].n'",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T06:19:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4128",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4128",
+      "title": "Feature Request: CC Emultation for Upstream API",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T03:07:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4133",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4133",
+      "title": "unexpected status 502 Bad Gateway: Upstream request failed, url: https://xxx/v1/responses",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T11:27:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4136",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4136",
+      "title": "152版修复了接入上游第三方中转站API时gpt-5.6-sol在codex中不能调用工具的问题了吗？",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T06:53:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4137",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4137",
+      "title": "使用gpt-5.6后，多端同时请求非常容易出现超时：Invalid API response after 3 retries: slow response (110s) — likely upstream timeout",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T07:51:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4146",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4146",
+      "title": "codex 超过了272k被多收费问题",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T10:22:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4149",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4149",
+      "title": "建议 兼容 OpenAI Realtime",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T05:39:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4167",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4167",
+      "title": "Upstream 混用 /v1/chat/completions 与 /v1/responses，导致 Prompt Cache 错乱以及 Tools 间歇性丢失",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T08:04:45Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#417",
@@ -5625,6 +6663,266 @@
       "updated_at": "2026-02-04T14:21:04Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4172",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4172",
+      "title": "无法使用5.6系列模型 5.5 正常 账号管理内测试连接正常 codex中响应503",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T05:35:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4174",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4174",
+      "title": "在频繁触发stream disconnected before completion: error sending request，似乎会导致Go空指针崩溃",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T09:12:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4175",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4175",
+      "title": "OpenAI Responses 已输出后收到 response.failed 后不会记录错误日志以及切换账号重试",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T09:18:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4184",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4184",
+      "title": "[Bug] Antigravity OAuth 账号可正常请求但套餐标签显示“异常”",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T11:04:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4189",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4189",
+      "title": "Upstream request failed.Grok免费账号有几千个，但是请求经常会频发这个报错",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T11:34:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4191",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4191",
+      "title": "部署微软 openai apikey 在gpt-5.6上有不兼容冲突导致无法使用",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T02:05:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4192",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4192",
+      "title": "503 Service temporarily unavailable 错，该如何解决",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T12:10:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4196",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4196",
+      "title": "指纹采集网站不可用",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T13:29:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4198",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4198",
+      "title": "fix: OpenAI 号池调度问题，我号又很多个，但是很容易触发stream disconnected before completion: Concurrency limit exceeded for user, please retry later",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-08T08:36:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4199",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4199",
+      "title": "Grok 链接过程报502错误",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T13:51:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4200",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4200",
+      "title": "自定义菜单页面",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-13T13:56:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4223",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4223",
+      "title": "grok订阅在codex使用遇到Could not decode the compaction blob. Ensure it is unmodified from the compact response",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T02:06:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4236",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4236",
+      "title": "最新的版本v0.1.153更新后频繁报错：account has no Codex backend access token",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T04:12:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4246",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4246",
+      "title": "[Feature Request] usage_logs 增加请求时 proxy_id 快照",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T06:47:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4247",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4247",
+      "title": "grok 出来的api 能生图，有人生视频成功的么，有什么生成工具能自定义api 的么，",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T08:46:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4249",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4249",
+      "title": "最新的版本v0.1.153更新后出现了几个报错",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T09:39:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4251",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4251",
+      "title": "希望支持下grok的生图和生视频的测试",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T07:36:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4255",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4255",
+      "title": "Upstream service temporarily unavailable",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-15T02:47:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4260",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4260",
+      "title": "v0.1.155 图片生成异常！！没有内置image_gen工具！",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T09:31:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4268",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4268",
+      "title": "grok 一直 429",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T20:54:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4283",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4283",
+      "title": "支持第三方平台接入的接口",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-15T01:07:59Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#429",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/429",
       "title": "Antigravity OAuth 登录回调地址硬编码导致无法在非 localhost 环境下使用",
@@ -5637,6 +6935,167 @@
       "updated_at": "2026-02-08T06:47:53Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4292",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4292",
+      "title": "gpt-image-2 限流 ？？？ 这是什么？新出的 有佬可以解释一下吗？",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T02:52:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4308",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4308",
+      "title": "中转逻辑问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-14T21:43:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4320",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4320",
+      "title": "grok的账号429没有停止调度，且过一会429的标识会消失",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-16T00:14:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4321",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4321",
+      "title": "v0.1.155 仪表盘今天的 模型分布 Token 使用趋势 最近使用 (Top 12) 不显示",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-15T03:05:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4325",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4325",
+      "title": "Claude code 封号",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-18T08:52:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4332",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4332",
+      "title": "hermes 如果想用grok的图片生成或者视频生成，应该用什么skills",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-15T07:59:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4338",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4338",
+      "title": "只要是sub2api的中转站，接GPT 5.6模型到claude code cli ，使用Read工具offset参数总是过大，并且无限循环",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-03T12:38:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4345",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4345",
+      "title": "增强审计功能（风控中心），留存更多的上下文以得到更好的风控效果",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-15T07:13:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4347",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4347",
+      "title": "账号5小时限流一直是0%",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-15T08:16:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4350",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4350",
+      "title": "codex 如何调用image2 模型",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T04:17:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4365",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4365",
+      "title": "更新到156后，内存暴涨，重启不能解决问题",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-14T06:06:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4383",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4383",
+      "title": "功能增加建议",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-15T14:44:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4388",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4388",
+      "title": "Responses GPT-5.6 顶层 explicit_cache 应返回 400",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-15T15:40:56Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#439",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/439",
       "title": "opencode使用遇到问题",
@@ -5647,6 +7106,395 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-01-31T09:51:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4408",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4408",
+      "title": "Client disconnect before first token still bills full/near-full usage (bad for hedge losers)",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-16T02:36:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4410",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4410",
+      "title": "fix(billing): 渠道 token 定价下分组独立生图倍率不生效",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-16T13:16:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4411",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4411",
+      "title": "求助！！！微信公众号支付报错：payment resume tokens require a configured signing key",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-22T07:10:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4413",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4413",
+      "title": "Codex Personal Access Token授权方式 异常停止调度",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-16T09:44:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4415",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4415",
+      "title": "codex的image2,经常被sub2api限流 503",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-17T09:37:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4422",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4422",
+      "title": "Codex 与 Claude合并分组",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-16T07:33:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4426",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4426",
+      "title": "我的Claude code 接入Grok-4.5出现这个问题是为什么",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-16T23:17:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4436",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4436",
+      "title": "渠道定价token 计费下分组「独立生图倍率」不生效，且 usage_logs.rate_multiplier 落库为默认倍率（v0.1.157）",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-16T11:09:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4438",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4438",
+      "title": "生成不了图片是什么原因呢？sub2api中也没看到调用了gpt-image-2模型",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-18T13:07:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4465",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4465",
+      "title": "异步生图接入第三方",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-17T02:35:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4466",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4466",
+      "title": "OAuth 账号出现「账号级持续 400」（如 image_generation 工具能力丢失）时不停止调度，坏号被反复选中",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-17T03:04:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4472",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4472",
+      "title": "no available accounts，请求无法命中账户",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-17T04:06:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4491",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4491",
+      "title": "OpenAI OAuth 直连 /v1/responses/input_tokens 返回 HTML 403 并批量触发 10 分钟临时不可调度",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-17T14:51:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4493",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4493",
+      "title": "grok free账户请求偶尔会 API Error: API returned an empty or malformed response (HTTP 200) — check for a proxy or gateway intercepting the request",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-17T09:49:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4494",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4494",
+      "title": "[Bug] Grok 视频完成态透传受保护的上游 /content 地址，用户 Key 下载返回 401",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-18T13:25:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4495",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4495",
+      "title": "提示词审计：coding agent 正常流量被误判为 jailbreak 并硬阻断（over-defense，建议 Controversial 升级策略可配置）",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-17T10:23:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4500",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4500",
+      "title": "[Bug] usage_logs 外键 ON DELETE CASCADE 导致删除账号/API Key/用户时历史计费记录被物理删除",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-17T11:45:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4527",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4527",
+      "title": "希望出一个账号探活功能，自动探测账号是否触发临时不可调度",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T07:37:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4542",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4542",
+      "title": "异步图片能不能修改成在后台开启关闭。",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-19T04:35:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4546",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4546",
+      "title": "Grok 图生视频：省略 prompt 的 I2V 任务创建成功但轮询返回 xAI upstream 400",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-18T07:38:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4576",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4576",
+      "title": "v0.1.161 反向代理部署下 usage_logs 记录 IP 始终为 127.0.0.1",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-20T05:19:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4578",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4578",
+      "title": "Grok 媒体生成资格误判分析：bot_flag_source 风控标记导致生成能力降级",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-19T11:39:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4586",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4586",
+      "title": "如何修改 批量生图 中说明的 调用地址。 什么时候支持 gpt-image-2 批量生图",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-19T05:08:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4597",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4597",
+      "title": "502 codex models manifest upstream returned an invalid envelope: missing top-level models array 一直错误不停，但是不影响使用是怎么回事",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-20T08:37:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4599",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4599",
+      "title": "[BUG] OpenAI OAuth 账号通过 /v1/responses 请求任意模型均返回 503,no available accounts(excluded_account_count 一直为 0,v0.1.161)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-06T12:30:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4613",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4613",
+      "title": "stream disconnected before completion: [ObjectParam] [input[67Jencrypted_content] [missing_ required parameter] Missing required parameter: 'input[67].encrypted_content'.",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-19T13:35:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4621",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4621",
+      "title": "标题：渠道 token 定价下，分组「独立生图倍率」不生效",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-19T14:53:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4632",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4632",
+      "title": "bug(openai): Codex OAuth HTTP Responses 缓存命中不稳定，固定 prompt_cache_key/账号后仍跨轮 miss",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-17T08:19:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4636",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4636",
+      "title": "Claude code 遇到的：API Error: 424 No available accounts: no available accounts",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-20T06:23:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4639",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4639",
+      "title": "[billing] /responses + hosted image_generation 工具漏算图片计费 (image_output_cost=0, image_output_tokens=0)",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "account_pool_health",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-20T07:36:53Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#465",
@@ -5662,6 +7510,746 @@
       "updated_at": "2026-03-25T17:08:32Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4673",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4673",
+      "title": "GROK 生成的视频、图片只有灯塔这种不受提示词控制",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-22T02:01:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4686",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4686",
+      "title": "稳定访问 ChatGPT、Claude、Gemini 等 AI 工具的方法",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-21T08:27:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4690",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4690",
+      "title": "生图收费有bug",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-21T12:09:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4702",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4702",
+      "title": "有没有稳定的生图上游",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-21T13:50:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4706",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4706",
+      "title": "请求提供私密安全报告渠道",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-21T16:30:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4707",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4707",
+      "title": "Codex custom tools restored as name=namespace (execexec / waitwait) on Responses path (0.1.162)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-23T01:16:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4712",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4712",
+      "title": "gpt5.6模型缓存创建疑似没有正常计入",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-22T07:40:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4718",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4718",
+      "title": "Image2 image generation issues, Grok video-related problems",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-22T04:51:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4730",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4730",
+      "title": "能不能增加kimi-k3模型的账号计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-23T05:57:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4733",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4733",
+      "title": "设置模型每日使用额度",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-17T17:53:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4735",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4735",
+      "title": "v0.1.163 Codex Desktop image_generation billed but image not displayed or saved",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T13:35:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4740",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4740",
+      "title": "并发生成图片计费BUG",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-22T17:55:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4742",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4742",
+      "title": "stream disconnected before completion: Upstream request failed 上下文长了 对接上游会报错 然后对话一直报错",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T16:52:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4758",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4758",
+      "title": "Grok为什么是429，但是显示正常，调用的时候才会显示限流",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-23T01:16:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4761",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4761",
+      "title": "上游报错 400 Unknown parameter: input[894].namespace 导致用户端显示 502 报错",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-25T22:42:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4767",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4767",
+      "title": "Tool choice 'image_generation' not found in 'tools' parameter.",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-23T02:45:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4772",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4772",
+      "title": "[Bug] 多 Pod 部署下单个 Pod 间歇性返回 No available accounts，账号在其他 Pod 正常",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-10T07:18:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4784",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4784",
+      "title": "OpenAI OAuth workspace mismatch 409 repeatedly routes traffic to one account",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-23T12:18:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4785",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4785",
+      "title": "Grok账号permission-denied类型code会被误标记为账号失效",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-23T11:55:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4789",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4789",
+      "title": "求助 sub2api 应该怎么配置支持 codex-cli 0.145.0?",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-26T17:02:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4800",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4800",
+      "title": "This model is not supported when using X-OpenAI-Internal-Codex-Responses-Lite.",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-23T17:10:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4808",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4808",
+      "title": "feat(grok): 支持可配置 429 限流/停调度时长（含 24h 与手动恢复）",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-08T16:26:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4810",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4810",
+      "title": "建議在簡易模式支援聚合分組路由，且不啟用 SaaS 計費",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-24T02:44:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4812",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4812",
+      "title": "[Bug] Antigravity Gemini 3.1/3.6 native function calling returns MALFORMED_FUNCTION_CALL or empty STOP with minimal schema",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-24T07:08:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4813",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4813",
+      "title": "Composite 平台类型分组 没有达到想要的效果",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-16T23:42:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4817",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4817",
+      "title": "正价Pro被封后的一些建议以及功能请求，cyber policy",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-24T07:02:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4825",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4825",
+      "title": "设置关闭训练数据共享失败",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T12:49:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4826",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4826",
+      "title": "Adobe AI 啥时候支持一下呀 可以生图",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-24T09:42:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4829",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4829",
+      "title": "Claude 输入 Token 数貌似存在 Bug，全部都是 2",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-24T10:30:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4837",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4837",
+      "title": "Grok 视频生成失败依旧会计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-24T15:36:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4845",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4845",
+      "title": "Manual quota reset does not clear account scheduler rate-limit state, causing continued 503 \"no available accounts\"",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-25T01:52:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4857",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4857",
+      "title": "一直跳登录页",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-25T06:47:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4859",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4859",
+      "title": "[billing] Antigravity gemini-3.6-flash-* records tokens but costs remain $0",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-25T18:00:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4871",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4871",
+      "title": "大佬们解决一下 Grok free账号 使用手动授权 SSO导入 都失败了",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-30T03:32:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4880",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4880",
+      "title": "[Bug] v0.1.165 OpenAI WS passthrough 新连接首轮间歇性 1011 upstream websocket proxy failed",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "account_pool_health",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-26T01:46:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4883",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4883",
+      "title": "用量窗口点查询，数据没有变化",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-26T02:54:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4903",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4903",
+      "title": "语料库污染",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-26T09:01:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4914",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4914",
+      "title": "Feature Request: 订阅套餐支持 Stripe Billing 自动续费",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-26T13:21:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4915",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4915",
+      "title": "feat：OpenAI /v1/chat/completions 请求端点生图支持兼容",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T15:39:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4916",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4916",
+      "title": "v0.1.165 openai： unexpected status 503 Service Unavailable",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T02:07:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4918",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4918",
+      "title": "希望导入到ccs这里能加一个选择框",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-26T14:32:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4919",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4919",
+      "title": "claude sonnect5经常报错",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-26T15:10:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4921",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4921",
+      "title": "fix(openai): force_priority does not inject service_tier or update billing tier",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-26T16:23:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4940",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4940",
+      "title": "bug(gemini): OpenAI 兼容入口的 response_format 被静默丢弃（CC → Responses → Anthropic 中间态无承载位）",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-27T04:54:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4941",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4941",
+      "title": "高分辨率生图有时候会报错，容易经常524",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-27T06:03:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4949",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4949",
+      "title": "Codex API-key providers lose web search for Responses Lite GPT-5.6 models",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-01T09:34:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4955",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4955",
+      "title": "生图的这个代码改动后 会话会全部丢失，现在发现只在Windows系统上出现这个BUG。用下面这个模式对话任务栏是空的不显示。希望大佬重视下",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-27T12:05:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4961",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4961",
+      "title": "The gateway layer has no provider abstraction, and the repo already shows what one looks like",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-27T11:44:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4962",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4962",
+      "title": "HTTP handlers open database transactions, because there is no boundary that stops them",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-27T11:44:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4965",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4965",
+      "title": "Migration filenames stopped conveying order, and the runner now carries the scar tissue",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-27T11:44:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4966",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4966",
+      "title": "bug(grok): grok-4.5 prompt cache sometimes drops to 128/256 cached_tokens in large OAuth pool",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-27T11:50:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4967",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4967",
+      "title": "bug(grok): 大 Grok OAuth 账号池下 grok-4.5 提示词缓存偶尔只有 128/256 cached_tokens",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-27T11:53:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4974",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4974",
+      "title": "[RFC] 统一上游客户端身份，减少跨链路特征冲突与风控误判",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-31T04:33:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4977",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4977",
+      "title": "建议我的账号支持添加第三方openai兼容的服务提供商",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-27T19:42:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4982",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4982",
+      "title": "我搭建的平台没有对外开放却莫名被注册了一个账号，请检查一下是否是系统出现了漏洞",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-28T02:30:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4989",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4989",
+      "title": "只挂 pro 20x 账号似乎有内存泄露问题 166 版本",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-28T08:30:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4991",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4991",
+      "title": "异步生图失败",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-28T05:02:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4994",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4994",
+      "title": "gateway_forward：403 重试和 failover 可能导致高风险 Claude Code 请求扩散到整个账号分组",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-28T06:17:18Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#500",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/500",
       "title": "建议：希望能够支持 Antigravity OAuth token导入",
@@ -5673,6 +8261,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-02-06T10:13:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5000",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5000",
+      "title": "grok普通号限流问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-05T09:25:32Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#501",
@@ -5688,6 +8288,483 @@
       "updated_at": "2026-02-06T10:39:55Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#5010",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5010",
+      "title": "bug(openai): 共享 proxy_id 熔断会清空账号池，并在无候选时触发数据库查询风暴",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T02:13:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5012",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5012",
+      "title": "feat(admin): usage 记录增加独立 Token/s 列",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-28T11:37:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5017",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5017",
+      "title": "S3配置里面的Secret Access Key输入后无法保存怎么办呢",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T05:01:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5034",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5034",
+      "title": "Claude账号 OAuth模式下，看不到版本， 比如pro、max5、max20",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T03:03:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5036",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5036",
+      "title": "功能：运维预警支持企业微信群机器人通知",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T04:34:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5046",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5046",
+      "title": "【功能建议】Codex官方重置额度后希望能自动更新限流状态",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T08:45:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5047",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5047",
+      "title": "上游怎么支持阿里云的生图模型",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T08:50:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5061",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5061",
+      "title": "Codex 图片生成桥接已开启，但codex中仅返回文字、不显示生成图片",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T12:41:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5064",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5064",
+      "title": "模型广场有 BUG，分组显示不完整",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T15:46:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5067",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5067",
+      "title": "[Bug] Responses Lite HTTP forwarding strips namespace from continuation history",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-29T20:45:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5071",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5071",
+      "title": "[Feature Request] 支持按 API Key 设置请求并发上限，避免单个 Agent 占满用户并发",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-30T03:25:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5073",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5073",
+      "title": "image2生成图片全部失败",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-30T03:44:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5074",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5074",
+      "title": "[改进] 优化 CC-Switch 导入的用量查询脚本，完整展示订阅/配额/速率限制/余额四种模式",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-30T03:53:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5088",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5088",
+      "title": "ChatGPT、Claude Code都能稳定使用的梯子",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-30T08:04:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5090",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5090",
+      "title": "最近频繁遇到这个错误stream disconnected before completion: Transport error: network error: error decoding response body，有归因吗？",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-30T12:07:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5091",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5091",
+      "title": "[Feature] 支持出站 IP/代理运行时自动故障切换，并为 #4749 代理流熔断增加默认关闭开关",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-30T08:04:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5092",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5092",
+      "title": "Proposal: add a community-maintained Sealos deployment link",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-30T08:07:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5093",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5093",
+      "title": "context_length_exceeded-502",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-31T03:20:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5095",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5095",
+      "title": "压缩上下文时遇到502错误",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-30T09:47:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5097",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5097",
+      "title": "5.6模型 使用imagegen 生图就报错",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-12T11:01:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5098",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5098",
+      "title": "curl访问claude上游账号，sub2api的请求伪装没有问题吗？",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-30T08:59:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5106",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5106",
+      "title": "为什么LLM思考时间一久，就容易报错，openclaw是这个错误： Agent failed before reply: LLM request failed: provider rejected the request schema or tool payload. Logs: openclaw logs --follow",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T12:29:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5108",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5108",
+      "title": "codex 在一个对话中连续对话生图修改图，就会出现首token很长的情况，请问怎么解决那。",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T06:36:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5109",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5109",
+      "title": "SSO 导入多个，是同一个key3路并发吗？不应该是不同key并发吗",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T12:29:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5123",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5123",
+      "title": "bug: Azure API Key 后端下 Codex 上下文压缩请求存在两个 Responses API 兼容问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T12:29:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5132",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5132",
+      "title": "grok 状态码429后平台状态没变",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-07-31T22:04:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5140",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5140",
+      "title": "[bug][Responses] stream=true 时 response.completed 缺少 content[].annotations，严格客户端（Grok CLI）在流结束时报 serialization error",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-12T09:23:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5155",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5155",
+      "title": "[bug][Responses] Codex image_generation bridge: tool-call decision streamed, but image result never delivered — stream stops at message_stop",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage",
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-01T06:02:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5161",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5161",
+      "title": "支付有问题啊",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-01T09:21:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5165",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5165",
+      "title": "[Bug][Responses] HTTP 200 流内 response.failed 容量错误在已输出内容后缺少可重试语义和运维记录",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-01T11:35:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5170",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5170",
+      "title": "为什么会莫名奇妙限流，是被五小时限制了吗",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-03T15:45:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5173",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5173",
+      "title": "Cannot upgrade from free ChatGPT-PLUS group to paid plan on baaaai.com (baaaai.com)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-01T16:41:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5175",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5175",
+      "title": "feat: 能否支持账号插件功能",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T02:55:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5176",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5176",
+      "title": "[Feature] Compress OAuth Codex Backend `/responses` request bodies with zstd level 3",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T09:33:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5178",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5178",
+      "title": "Bug: Codex session resume fails with `Invalid 'input[x].content': array too long` due to incompatible reasoning items in rollout JSONL",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-07T02:41:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5184",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5184",
+      "title": "feat(admin): automatically retry and recover failed account models",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T08:38:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5195",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5195",
+      "title": "欢迎体验一下 Sub2API 开源 android app，希望可以帮忙宣传一下",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T12:58:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5196",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5196",
+      "title": "不同生图模型设定单独倍率",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T13:49:40Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#520",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/520",
       "title": "上游使用zenmux订阅作为源的时候，出现大量报错",
@@ -5701,6 +8778,72 @@
       "updated_at": "2026-02-09T16:25:41Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#5201",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5201",
+      "title": "Gemini为什么接上游遇到一个429就会有账号级限流",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-02T15:41:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5203",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5203",
+      "title": "ForwardAsChatCompletions path injects Anthropic ping events into OpenAI Chat Completions SSE stream",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-03T00:11:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5217",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5217",
+      "title": "bug(anthropic): Auto classifier still returns opaque 429 after #5153",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-03T04:50:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5221",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5221",
+      "title": "账号频繁临时不可调度导致下游503",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-04T11:53:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5237",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5237",
+      "title": "cc通过sub2api接gpt模型问题",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-03T15:29:29Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#524",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/524",
       "title": "官claude每天都要手动重置刷新，否则就会出现帐号错误",
@@ -5710,7 +8853,290 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-02-11T08:00:55Z"
+      "updated_at": "2026-07-08T03:08:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5249",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5249",
+      "title": "疑问：内容审核同一个cyber_policy账号被重复记录到不同用户上",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-04T03:50:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5251",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5251",
+      "title": "不知道为什么我的系统一直在报Warn：openai.ws_bind_response_account_failed acc=2 error=context canceled",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-17T09:48:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5252",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5252",
+      "title": "bug(openai): Codex /models 依赖随机上游，模型列表接口异常时向客户端返回 502",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-05T02:31:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5257",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5257",
+      "title": "OpenAI OAuth /responses 请求体持续增长至 38MB，未触发 compact 并导致代理产生数十 GB 流量",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-04T05:33:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5259",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5259",
+      "title": "OAuth 401: Your IP is not authorized to make this request.",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T04:35:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5260",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5260",
+      "title": "chatgpt账号用手动授权,当选择账号后,生成授权链接,过去之后全部报错2、用accesstoken添加账号也有问题",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-11T09:58:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5262",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5262",
+      "title": "Bug: 慢但成功的上游会保留粘性路由并拖累健康直连账号延迟",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "account_pool_health",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-07T10:07:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5263",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5263",
+      "title": "codex-auto-review价格依然没有更新，远端repo json文件计价覆盖了170版本pr",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-07T11:23:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5272",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5272",
+      "title": "feat(accounts): display official DeepSeek balance in upstream billing info",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-04T15:28:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5274",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5274",
+      "title": "报错",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-04T16:22:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5275",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5275",
+      "title": "[Bug] OpenAI APIKey 应按模型和协议探测能力，并支持周期复测",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-04T17:17:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5280",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5280",
+      "title": "只要403就冷却10分钟苦不堪言",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-10T02:57:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5281",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5281",
+      "title": "Bug: HTTP 200 response.failed 中的模型容量错误可能绕过 failover",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-05T03:27:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5282",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5282",
+      "title": "内容审核：cyber_policy 命中记录分析（7 天数据验证），附三个可优化点",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-05T06:31:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5290",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5290",
+      "title": "No first-token timeout: streaming request can hang for minutes when upstream stalls",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-05T07:02:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5292",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5292",
+      "title": "image-2 计费bug",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-05T07:21:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5299",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5299",
+      "title": "Claude Upstream service overloaded, please retry later",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-05T09:21:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5303",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5303",
+      "title": "v0.1.171 openai 容易出现：stream disconnected before completion: Upstream request failed",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-05T10:05:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5319",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5319",
+      "title": "grok free账号状态正常，但是永远不会被调用",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-06T01:34:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5322",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5322",
+      "title": "已经开启了异步生图，为啥调用gpt-image-2还是同步的，还需要去哪里设置吗",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-07T09:58:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5325",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5325",
+      "title": "feat: 支持模型名 effort 后缀映射思考等级（-none/-low/-medium/-high/-xhigh/-max）",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-06T06:14:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5343",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5343",
+      "title": "grok build (0.2.118) 通过 Grok 平台 API Key 账号调用 WebSearch 报 `serialization error: missing field action",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-06T16:57:11Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#535",
@@ -5725,6 +9151,626 @@
       "updated_at": "2026-02-24T16:54:00Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#5350",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5350",
+      "title": "OAuth Account Takeover via Pending Exchange Bypass in sub2api",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-07T15:23:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5360",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5360",
+      "title": "Nil pointer dereference when cloning an uninitialized query",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-07T04:26:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5370",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5370",
+      "title": "[agent-chore] opencode zen 上游 400 missing field id：OpenAI 直转路径补齐 message id",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-07T07:02:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5374",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5374",
+      "title": "[Bug] `/v1/images/generations` 无法透传自定义图片模型",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-13T05:11:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5378",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5378",
+      "title": "2026 TAG机场VPN怎么样？ChatGPT、Claude Code、Gemini和Cursor等AI工具都能用机场",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-07T13:24:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5379",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5379",
+      "title": "feat(openai-opencode): 提炼 OpenCodeProvider——zen 端点选择 + CreditsError 识别 + 模型能力元数据同步",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-07T14:11:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5402",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5402",
+      "title": "【社区提案流程建议】建议建立重要功能变更的说明和讨论流程",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-10T06:13:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5405",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5405",
+      "title": "希望支持大请求断点续传",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-07T18:56:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5407",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5407",
+      "title": "claude auto模式不可用报错",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-14T03:51:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5409",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5409",
+      "title": "我的中转站无法在codex里生成图片，但是另一家可以，大家可以帮忙看看吗？",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-10T01:32:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5414",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5414",
+      "title": "Add Agnes OpenAI-compatible image/video gateway support",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-09T02:55:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5418",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5418",
+      "title": "codex桌面端里 用生图技能生图之后不返回图片 是什么bug 之前可以的",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-10T01:30:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5420",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5420",
+      "title": "计费有问题吧，统计自己账号扣费的时候明明成本倍率低，但是扣费更高",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-15T05:33:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5426",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5426",
+      "title": "OpenAI free 账号额度窗口显示错误：显示 5h/7d 而非月度窗口",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-08T14:16:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5430",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5430",
+      "title": "[Bug] v0.1.172 将 Grok Video 1.5 文生视频请求静默降级为旧模型",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-08T16:52:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5438",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5438",
+      "title": "sub2api不支持/v1/responses/input_tokens",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-09T02:16:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5444",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5444",
+      "title": "bug: /v1/messages Anthropic 协议下 image 内容块被 modelSupportsImageInput 白名单误删（MiniMax 等非白名单模型无法识图）",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-09T05:48:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5451",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5451",
+      "title": "WS v2 passthrough 后续 turn 未重新占用账号并发槽，容量长期显示为 0",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-11T00:24:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5454",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5454",
+      "title": "No CAPTCHA on email verification-code endpoints: unlimited email bombing and SMTP quota exhaustion",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-09T12:40:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5456",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5456",
+      "title": "/v1/messages/count_tokens forwards full prompt to upstream without billing — free upstream token consumption",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-09T12:40:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5461",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5461",
+      "title": "[Bug] v0.1.172 更新后 Codex Responses 流频繁透传 server_is_overloaded",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T08:18:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5467",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5467",
+      "title": "bug(openai-ws): passthrough 模式绕过大首包 HTTP bridge，导致上游 1009 断连",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-09T16:50:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5473",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5473",
+      "title": "[Bug] OpenAI OAuth 账号“同步上游支持的模型”被后端错误拒绝",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-09T22:01:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5485",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5485",
+      "title": "/v1/chat/completions 会静默丢弃 PDF 附件（type:\"file\" 的 content part）",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-10T05:55:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5493",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5493",
+      "title": "grok账号限流问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-10T10:00:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5495",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5495",
+      "title": "上游是newapi的时候好像一般会亏钱？",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-11T04:24:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5507",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5507",
+      "title": "Gemini OAuth（Google One Pro）持续返回 429 RESOURCE_EXHAUSTED，即使订阅额度充足",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-11T16:26:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5518",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5518",
+      "title": "bug(openai compat): Codex json_schema is forwarded to DeepSeek and returned as generic 502",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-11T06:38:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5519",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5519",
+      "title": "bug(openai compat): Responses input_image is forwarded to text-only DeepSeek Chat and returned as generic 502",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-11T06:55:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5528",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5528",
+      "title": "[Bug] Anthropic→Chat Completions 直接桥接丢弃 assistant thinking 块，DeepSeek 等 reasoning 模型多轮对话报 400 (reasoning_content must be passed back)",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-13T12:10:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5530",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5530",
+      "title": "[Bug] Empty openai_capabilities silently excludes OpenAI OAuth accounts from text scheduling",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-11T12:07:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5533",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5533",
+      "title": "bug: Anthropic /v1/messages → OpenAI Codex /v1/responses 时 web_search 报 no function named 'web_search'",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-14T07:21:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5537",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5537",
+      "title": "Antigravity OAuth 账号持续 429 RESOURCE_EXHAUSTED（全新环境/回退版本/代理/UA 均无效）",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "account_pool_health",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-14T03:34:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5542",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5542",
+      "title": "[Bug] OpenAI OAuth上游返回401后未自动刷新Token，账号被临时停止调度",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "account_pool_health",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T05:28:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5547",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5547",
+      "title": "[Bug] OpenAI OAuth Responses forwards unsupported truncation field and returns 502",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-12T06:50:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5550",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5550",
+      "title": "同时接入gpt官方和deepseek模型官方,同一会话中切换模型会报502",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-13T04:43:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5555",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5555",
+      "title": "账号额度计费异常。是sub2的问题还是官方的问题 有没有大佬解释下",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-13T04:59:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5569",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5569",
+      "title": "bug: Grok subscription badge ignores persisted usage snapshot",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-12T19:03:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5578",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5578",
+      "title": "官方重置了周额度，但后台还是429要等到下周？",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-13T04:46:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5579",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5579",
+      "title": "0.1.176 池模式好像挂掉了，开了池模式还是会返回前台 429 没有自动重试",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-13T03:39:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5583",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5583",
+      "title": "feat(scheduling): Claude 与 OpenAI/Codex 按 5h/7d 配额重置时间统一调度",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-13T05:44:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5586",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5586",
+      "title": "bug(openai): native compaction v2 downgrades when its beta header is lost in a gateway chain",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-13T06:34:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5587",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5587",
+      "title": "gpt-image-2 无法在Codex中调用",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-14T08:08:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5593",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5593",
+      "title": "v0.1.176 Antigravity 账号限流问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-14T07:07:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5598",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5598",
+      "title": "3个pro账号突然变成无法压缩提示404 Not Found",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-14T01:26:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5608",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5608",
+      "title": "老是被吞记录",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-13T15:31:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5611",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5611",
+      "title": "Antigravity 账号持有 Google AI Pro（g1-pro-tier）时，网关转发到 prod 端点必定 429，官方客户端实际走 daily 端点",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T05:34:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5618",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5618",
+      "title": "管理员的使用记录这个菜单上的列表添加用户提示词功能",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-14T01:59:16Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#562",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/562",
       "title": "1.0.81版本升级后opus频繁报错",
@@ -5735,6 +9781,107 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-02-12T05:11:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5621",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5621",
+      "title": "【bug】176版本大bug，所有模型计费按照大上下文，也就是超过272k计算",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-15T02:50:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5628",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5628",
+      "title": "antigravity 账号429",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T16:22:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5631",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5631",
+      "title": "[bug][apicompat] 流式 chat/completions 参数增量重复输出 \"name\":\"\"，覆盖工具名导致工具调用失败",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-14T06:32:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5642",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5642",
+      "title": "期望增加高峰价格配置",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-17T02:26:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5645",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5645",
+      "title": "gpt账号被风控降额度。大佬们你们是怎么解决的。",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-18T15:03:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5648",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5648",
+      "title": "[bug][apicompat] force_chat_completions 下 Codex remote compaction v2 失效：compaction_trigger 被丢弃、响应无 compaction item",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-14T14:11:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5650",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5650",
+      "title": "Upstream gateway URL can leak to downstream clients (error messages / 3xx Location)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-14T14:49:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5652",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5652",
+      "title": "OpenAI Our servers are currently overloaded 未稳定触发 failover，无法像 model at capacity 一样正确切号",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T11:30:36Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#566",
@@ -5749,6 +9896,390 @@
       "updated_at": "2026-03-30T16:04:16Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#5677",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5677",
+      "title": "Update Antigravity model ID support for Gemini 3.7 Flash variants",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-15T13:33:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5678",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5678",
+      "title": "BUG(grok): 自定义上游返回同源非标准视频 URL 时下载失败",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-15T14:34:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5681",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5681",
+      "title": "[Feature Request] 新增自动探针触发上游账号周额度倒计时，避免额度刷新后闲置不进入冷却",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-16T02:35:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5686",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5686",
+      "title": "使用Antigravity.必须要用美国的原生家庭宽带吗？",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-16T11:30:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5692",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5692",
+      "title": "v0.1.177 后GPT PROX20 缩水额度问题还是存在",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T03:34:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5694",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5694",
+      "title": "bug: Token 区间计费未在 usage log 中保存命中档位",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-16T18:32:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5700",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5700",
+      "title": "bug: Claude缓存创建5m、1h无计费、且不可配置",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-16T11:37:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5702",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5702",
+      "title": "[BUG] API Key 类型账号的配额控制，测试实现有问题，它统计时使用的用户扣费，没使用账号计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-16T15:16:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5722",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5722",
+      "title": "重新授权后账号很快过期",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-17T06:24:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5727",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5727",
+      "title": "设计：让 Codex 指纹收敛在 HTTP、WebSocket 与 compact 上与源码一致",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T04:20:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5732",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5732",
+      "title": "[Bug] Prompt Guard 每 5 秒重复输出 prompt_guard.config_loaded",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-17T09:51:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5734",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5734",
+      "title": "Feature: batch scheduled account/model availability matrix with safe stale-model handling",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-17T10:15:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5735",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5735",
+      "title": "[Bug] v0.1.177：Responses WebSocket 长连接后续 turn 未重新校验订阅日限额",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "account_pool_health",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-17T10:36:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5745",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5745",
+      "title": "[Bug] 提示词审计：纯工具请求绕过审计（tool_use/tool_result/function_call_output/functionResponse 未解析）",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-17T15:27:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5746",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5746",
+      "title": "[Bug] 提示词审计：WebSocket 经 conversation.item.create 携带内容 + 空 response.create 绕过审计",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-17T15:48:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5757",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5757",
+      "title": "分组「逐模型定价」在网关计费路径上静默失效（v0.1.177）",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T07:34:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5763",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5763",
+      "title": "[Bug] Grok Business 版本账号不能正确获取用量窗口",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-18T07:02:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5768",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5768",
+      "title": "v0.1.177 使用 Codex Desktop 版本，經常性出現 \"重新連線 1/5\"",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-18T12:20:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5770",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5770",
+      "title": "创建渠道监控适配智谱",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-18T08:29:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5771",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5771",
+      "title": "fix(grok): Chat Completions 未将 reasoning_tokens 计入输出计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-18T08:43:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5786",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5786",
+      "title": "[调查/RFC] Codex Pro 账号额度缩水：installation identity 与 session 一致性问题",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T06:17:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5787",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5787",
+      "title": "178版本的pro额度新开账户还是仅有1400刀",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T05:55:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5789",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5789",
+      "title": "[Bug] 定时测试已勾 auto_recover，但滚动窗口恢复后账号不会被自动恢复",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-18T16:18:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5790",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5790",
+      "title": "[Bug] 定时测试已勾 auto_recover，但滚动窗口恢复后账号不会被自动恢复",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-18T16:18:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5802",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5802",
+      "title": "[Bug/RFC] Codex 指纹收敛仍缺部署隔离与跨路径一致性保护",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T15:52:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5806",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5806",
+      "title": "新开的 pro 账号并发只有 3 ，openai提示错误：Concurrency limit exceeded for account, please retry later",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T05:36:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5813",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5813",
+      "title": "高并发下 Postgres CPU 周期性打满 + settings 表被高频重复查询（1.12 亿次），建议增加应用层缓存 / 异步批量落库",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T09:08:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5820",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5820",
+      "title": "[Bug] automation_update 根级 oneOf 缺失 parameters.type 时 /v1/responses 仍返回 400",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T06:05:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5829",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5829",
+      "title": "This account only allows Codex official clients",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T08:41:21Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#583",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/583",
       "title": "【破坏性变更】将 ⁠PGDATA 直接设为卷根目录会导致升级初始化（initdb）失败",
@@ -5758,7 +10289,20 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-02-16T10:09:59Z"
+      "updated_at": "2026-07-22T07:53:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5830",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5830",
+      "title": "[Feature] 增加按平台配置的全局 User-Agent 兜底",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T01:33:39Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#584",
@@ -5773,6 +10317,32 @@
       "updated_at": "2026-02-15T16:41:12Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#5840",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5840",
+      "title": "Bug: ctx_pool WS ingress 未处理上游容量降载，导致 Codex 会话被硬终止（http_bridge 路径有处理）",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T14:07:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5843",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5843",
+      "title": "[Bug] v0.1.178 Antigravity: mixed tools (function + built-in) still triggers include_server_side_tool_invocations 400",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T10:17:45Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#585",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/585",
       "title": "JWT_EXPIRE_HOUR 被默认的 jwt.access_token_expire_minutes=360 覆盖，导致提前登出",
@@ -5785,6 +10355,79 @@
       "updated_at": "2026-02-22T09:16:54Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#5850",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5850",
+      "title": "Bug: http_bridge 上下文重建导致 custom tool call 重复注入，会话被永久毒化（v0.1.178 仍复现）",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T15:51:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5856",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5856",
+      "title": "[Bug] 渠道不稳定时上游扣费高于 Sub2API 下游计费，疑似部分请求记录或计费缺失",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T15:09:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5858",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5858",
+      "title": "ops 面板 trend 与 api-keys-usage 在大数据量下超时",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T16:19:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5863",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5863",
+      "title": "渠道监控 v2 不应当向普通用户展示全部分组",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-19T18:06:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5873",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5873",
+      "title": "pro20x 10并发以内 19 20这两天频繁报错429限流，然后限流后就接连触发服务暂时不可用",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T09:23:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5877",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5877",
+      "title": "[咨询]不同的chatgpt套餐，并发度限制会不同了？",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T05:35:05Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#588",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/588",
       "title": "最新的0.1.83版本无法自动刷新codex的用量",
@@ -5795,6 +10438,162 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-02-22T13:36:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5882",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5882",
+      "title": "设置高峰倍率一直会保存失败",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T04:43:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5883",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5883",
+      "title": "bug(openai compat): DeepSeek emits functions__exec for Codex custom exec; Chat bridge 200-forwards an unsupported call",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T04:53:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5884",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5884",
+      "title": "[Bug] Antigravity daily 端点下默认测试仍使用已下线的 claude-sonnet-4-5，返回 404",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T05:34:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5886",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5886",
+      "title": "[Bug] Composite groups cannot serve OpenAI targets via /v1/messages: 400 for custom model names, permanently-closed dispatch gate (403) for resolved openai targets",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T06:06:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5890",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5890",
+      "title": "【功能建议】增加上游账号级别异常统计",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T06:33:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5892",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5892",
+      "title": "glm coding plan无法使用",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T09:54:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5895",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5895",
+      "title": "{ \"error\": { \"message\": \"Upstream access forbidden, please contact administrator\", \"type\": \"upstream_error\" } }``",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T07:48:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5899",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5899",
+      "title": "[Bug] 经 Nginx HTTPS 反代登录后 Chrome 标签页 CPU 持续接近 100%",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T08:18:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5900",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5900",
+      "title": "[Bug] v0.1.178：已建立的上游 Responses WebSocket 因 keepalive ping timeout 以 1011 断开（非连接池耗尽）",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "account_pool_health",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T12:20:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5901",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5901",
+      "title": "推理强度限制bug",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T08:20:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5910",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5910",
+      "title": "[Feature] 增加 OpenAI 上游 HTTP 请求阶段诊断，便于排查请求长时间卡住问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T10:23:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5917",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5917",
+      "title": "fix: preserve Grok Imagine resolution and aspect_ratio when forwarding OpenAI size",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-08-20T11:36:22Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#593",
@@ -5973,7 +10772,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-27T14:25:51Z"
+      "updated_at": "2026-07-01T03:24:41Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#736",
@@ -6073,7 +10872,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-03-06T11:56:31Z"
+      "updated_at": "2026-07-21T18:10:23Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#822",
@@ -6201,7 +11000,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-12T14:34:57Z"
+      "updated_at": "2026-08-13T11:30:54Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#888",
@@ -6601,7 +11400,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-05-26T02:27:48Z"
+      "updated_at": "2026-07-01T03:26:01Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1496",
@@ -6726,18 +11525,6 @@
       "updated_at": "2026-01-05T06:26:56Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#1616",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1616",
-      "title": "feat 能否加一个数据统计列表：以账号为维度统计时间范围内的额度消耗",
-      "impact": "medium",
-      "categories": [
-        "admin_ui"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-04-15T04:07:41Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#1636",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1636",
       "title": "版本更新按钮无法点击 修复指南",
@@ -6760,7 +11547,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-05-21T06:32:43Z"
+      "updated_at": "2026-07-02T21:23:02Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1653",
@@ -6809,7 +11596,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-05-08T15:49:40Z"
+      "updated_at": "2026-07-01T03:48:50Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1696",
@@ -6821,7 +11608,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-06-15T14:17:53Z"
+      "updated_at": "2026-07-08T15:11:45Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1701",
@@ -6897,18 +11684,6 @@
       "updated_at": "2026-04-24T03:30:23Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#1882",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1882",
-      "title": "feat: 渠道监控，使用用户真实调用记录",
-      "impact": "medium",
-      "categories": [
-        "ops_observability"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-04-24T05:49:09Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#1890",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1890",
       "title": "BUG:运维监控中请求时长和TTFT明细展开后的数据都是请求时长",
@@ -6978,7 +11753,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-04-25T02:12:48Z"
+      "updated_at": "2026-07-01T03:48:54Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1954",
@@ -7099,7 +11874,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-04-29T01:23:40Z"
+      "updated_at": "2026-06-30T11:18:26Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2108",
@@ -7184,7 +11959,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-05-04T14:40:31Z"
+      "updated_at": "2026-08-04T07:18:26Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2193",
@@ -7408,7 +12183,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-06-08T04:48:30Z"
+      "updated_at": "2026-07-09T01:13:57Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2464",
@@ -7517,7 +12292,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-05-21T08:08:27Z"
+      "updated_at": "2026-07-29T05:40:53Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2676",
@@ -7637,7 +12412,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-06-05T15:37:41Z"
+      "updated_at": "2026-08-07T05:54:49Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3068",
@@ -7673,7 +12448,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-06-07T23:37:55Z"
+      "updated_at": "2026-07-08T07:46:46Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3117",
@@ -7734,7 +12509,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-06-09T13:10:08Z"
+      "updated_at": "2026-07-01T03:48:52Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3207",
@@ -7770,7 +12545,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-06-12T01:38:48Z"
+      "updated_at": "2026-07-01T03:25:04Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3263",
@@ -7782,19 +12557,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-06-16T11:37:36Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3300",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3300",
-      "title": "IP 白名单导致的不可访问时，支持在错误信息中展示当前请求的用户的 IP，方便排查问题",
-      "impact": "medium",
-      "categories": [
-        "admin_ui"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-06-16T08:40:48Z"
+      "updated_at": "2026-07-22T12:03:39Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3328",
@@ -7807,18 +12570,6 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
       "updated_at": "2026-06-17T06:13:36Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3355",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3355",
-      "title": "分组管理支持列管理",
-      "impact": "medium",
-      "categories": [
-        "admin_ui"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-06-18T09:35:40Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3373",
@@ -7842,7 +12593,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-06-22T10:12:40Z"
+      "updated_at": "2026-08-02T14:03:37Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3417",
@@ -7939,7 +12690,393 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-06-29T03:42:45Z"
+      "updated_at": "2026-06-30T06:10:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3567",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3567",
+      "title": "前端出问题了 没有任何输出 只输出了标题",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-06-30T07:13:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3610",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3610",
+      "title": "能否在Simple模式下给一个根据API Key来监控用量的分布图表？",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-01T10:30:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3667",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3667",
+      "title": "feat: 请求给注册登录页面的验证添加明确的占位框",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-03T02:59:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3668",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3668",
+      "title": "feat: API 密钥页面希望支持批量修改用户分组跟用量排序，分为按今天/30 天用量排序",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-03T03:59:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3679",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3679",
+      "title": "自定义菜单页面的重新打开窗口建议改为可拖动的",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-03T08:55:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3754",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3754",
+      "title": "建议增加 OpenAI 标准的 /v1/audio/speech（TTS）和 /v1/audio/transcriptions（STT/Whisper）端点",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-28T08:21:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3764",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3764",
+      "title": "做了个sub2api的移动端",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-06T14:44:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3770",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3770",
+      "title": "feat: 后台能适配下笔记本样式吗，在笔记本上呈现太大了",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-07T00:47:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3823",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3823",
+      "title": "拒绝非官方客户端请求的日志可否增加对方用的什么客户端",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-08T07:53:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3828",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3828",
+      "title": "渠道监控的能不能不要显示在使用记录里？",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-10T00:33:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3904",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3904",
+      "title": "提供 OpenTelemetry 用于日常监控和分析",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-10T01:57:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3910",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3910",
+      "title": "能否为可配置的自定义内容补充 i18n 支持",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-10T02:42:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3921",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3921",
+      "title": "远程压缩报错",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-10T06:43:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3928",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3928",
+      "title": "请问下各位我用sub2api反代的api，cc-switch开启保留官方登录，使用codex mac版就连不上呢",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-10T04:23:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3933",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3933",
+      "title": "升级后开启自动透传无法识别gpt-5.6系列模型",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-10T13:43:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4007",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4007",
+      "title": "Docker版本升级会造成随机用户“加载API密钥失败”",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-11T09:16:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4025",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4025",
+      "title": "v0.1.151版本，监控Claude一直报错challenge mismatch (expected *, got \"\")",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-11T03:04:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4038",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4038",
+      "title": "用户充值问题",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-11T05:31:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4046",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4046",
+      "title": "支持锁定访问域名",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-13T09:25:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4062",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4062",
+      "title": "建议开启openai的视频模型",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-12T04:59:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4064",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4064",
+      "title": "关于自定义菜单页面 - 新窗口打开 的优化建议",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-11T15:12:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4083",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4083",
+      "title": "151版本出现内核崩溃问题",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-12T23:36:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4119",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4119",
+      "title": "使用gpt5.6计算的延迟有误",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-13T10:24:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4124",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4124",
+      "title": "限额失效",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-20T05:46:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4126",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4126",
+      "title": "cache creation 一直为 0",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-13T03:07:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4151",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4151",
+      "title": "渠道监控错误判定 Anthropic thinking block 响应为失败",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-13T06:04:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4178",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4178",
+      "title": "gpt 订阅统计问题",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-13T09:37:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4186",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4186",
+      "title": "日志中有很多异常",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-13T12:04:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4210",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4210",
+      "title": "[Bug] 订阅续费商品弹窗无法滚动，第二个及后续续费卡片被截断",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-18T08:29:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4229",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4229",
+      "title": "fix: cc渠道监控报错",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-14T02:41:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4277",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4277",
+      "title": "grok free账号 Agent工具调用失败之后进入循环空转，大量错误产生，这个问题存在好几天。",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-14T11:16:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4330",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4330",
+      "title": "希望添加用户仪表盘的表格统计选项",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-15T04:28:48Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#438",
@@ -7954,6 +13091,223 @@
       "updated_at": "2026-02-08T13:55:41Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4405",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4405",
+      "title": "透传一下logprobs",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-16T01:49:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4454",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4454",
+      "title": "老是增加一些无关又无法关闭的功能限制例如敏感操作 step-up 2FA",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-17T08:52:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4492",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4492",
+      "title": "请求ip黑名单",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-25T16:20:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4557",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4557",
+      "title": "[Feature] “导入 CCS”的 Codex 默认模型（gpt-5.5）支持后台配置",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-20T09:11:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4592",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4592",
+      "title": "易支付里面配置了自定义类型USDT的支付方式，页面显示的￥符号",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-19T09:02:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4693",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4693",
+      "title": "希望可以支持自定义充值页面",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-21T10:09:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4703",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4703",
+      "title": "近24小时目前实际取值是今天和昨天",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-21T14:26:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4704",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4704",
+      "title": "能禁用ip或指定邮箱账号登录吗？",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-22T02:00:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4725",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4725",
+      "title": "无法探测配额",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-22T08:54:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4731",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4731",
+      "title": "希望新增记录 用户的原始输入；文字优先；这对企业审计相当好；统计一个人的使用偏好",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-22T12:21:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4732",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4732",
+      "title": "支持按模型配置不同的推理强度规则",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-19T01:53:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4736",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4736",
+      "title": "Bug: GPT 账户续费后账号管理页面无法更新到期时间",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-22T10:12:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4752",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4752",
+      "title": "自定义菜单栏 希望出个 仅快捷跳转，而不是一刀切全 iframe 页面",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-22T17:22:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4781",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4781",
+      "title": "分组管理",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-23T09:59:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4795",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4795",
+      "title": "希望支持为所有账号自动创建定时测试计划（全局开关）",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-23T15:11:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4797",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4797",
+      "title": "[Bug] 转发至 Gemini API 时，Tool/Function Calling Schema 包含不支持字段导致报错",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-23T15:28:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4870",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4870",
+      "title": "添加的grok账号如果上游是另一个sub实例，使用的时候会在上游报错",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-25T17:18:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4960",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4960",
+      "title": "WS ingress lease loss: the client sometimes gets a bare EOF instead of the 1013 close frame",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-27T11:44:00Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#498",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/498",
       "title": "gpt5.3xhigh模式会报错",
@@ -7966,6 +13320,79 @@
       "updated_at": "2026-02-24T17:16:11Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#5044",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5044",
+      "title": "[文档建议] 将默认 README 调整为中文，并保留多语言入口",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-29T08:00:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5102",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5102",
+      "title": "feat：关于 Selected model is at capacity. Please try a different model. 解决方案",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-04T06:29:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5142",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5142",
+      "title": "[Bug] v0.1.169 仍存在订阅月额度提前重置问题，可能重复发放整月额度",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-07-31T12:38:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5188",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5188",
+      "title": "[Bug] 退款状态机在并发/中断下存在重复退款、余额双扣、静默漏账与永久卡死（4 处）",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-02T10:27:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5255",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5255",
+      "title": "grok-4.5 free账号出现上下文只回答问题不写代码，而且老重复，/compact都不行，是不是sub2api的上下文出问题了?",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-04T05:22:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5256",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5256",
+      "title": "使用记录的费用统计没有按照渠道定价的价格进行计算",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-15T08:10:36Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#528",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/528",
       "title": "antigravity opus 4.6 反代出来在cc中无法正常展示思考",
@@ -7976,6 +13403,212 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
       "updated_at": "2026-02-09T13:41:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5431",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5431",
+      "title": "Add per-account fallback-only OpenAI session stickiness",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-08T16:55:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5478",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5478",
+      "title": "[bug] 远程压缩失败",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-13T03:39:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5523",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5523",
+      "title": "建议为账号统计新增 “最高并发数” 曲线图",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-11T08:37:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5529",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5529",
+      "title": "重装失败",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-11T11:13:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5544",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5544",
+      "title": "[Bug] 账号批量更新分组时会错误修改其他平台账号的分组",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-12T04:02:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5545",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5545",
+      "title": "建议运维监控页面增加 server 的网络带宽监控能力",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-12T04:42:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5617",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5617",
+      "title": "[bug] 首字显示异常，与上游不一致",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-15T08:12:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5637",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5637",
+      "title": "通过sub2api的api接入codex如何开启fast模式？",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-18T02:13:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5688",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5688",
+      "title": "[Bug] v0.1.177 使用记录“近24小时”仍查询昨天+今天，实际覆盖 24–48 小时",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-16T11:18:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5707",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5707",
+      "title": "Enhancement：完善 OpenAI 账号 Compact 能力识别与自动记录机制",
+      "impact": "medium",
+      "categories": [
+        "compatibility",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-17T02:21:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5739",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5739",
+      "title": "[Bug] Grok 4.6 的 reasoning_effort=xhigh 被强制降级为 high",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-18T11:50:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5743",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5743",
+      "title": "fix(openai): turn_started_at_unix_ms 时间戳 flaky —— map 版与 raw 版各取一次 time.Now() 导致断言偶发差 1ms",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-17T14:54:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5750",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5750",
+      "title": "建议添加一个单独的 openai 的兼容模式接入口，该模式不要请求太多的参数，只请求必要的就好。",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-18T01:07:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5783",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5783",
+      "title": "[Feature Request] 建议增加内置工单/Ticket 管理系统以优化用户反馈流程",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-18T12:58:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5818",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5818",
+      "title": "怎么没有测试模型的页面？单独的对话页面",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-19T19:53:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5891",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5891",
+      "title": "[bug] 初始化bug",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-20T06:56:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5909",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5909",
+      "title": "server_is_overloaded-Our servers are currently overloaded. Please try again later 类型错误，错误日志中没有记录",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-08-20T09:52:21Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#594",
@@ -8161,7 +13794,7 @@
         "security"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "OpenAI /v1/responses passthrough strips top-level `user` before forwarding. Symmetric coverage on (a) APIKey native path via OpenAIGatewayService.Forward's unsupportedFields list (the OAuth path already strips it through openAIChatGPTInternalUnsupportedFields in applyCodexOAuthTransform) and (b) the Cursor-shape short-circuit in ForwardAsChatCompletions via cursorResponsesUnsupportedFields. Native OpenAI Responses upstream rejects `user` with HTTP 400 \"Unsupported parameter: user\"; the Responses equivalent is `safety_identifier`, which we already filter.",
+      "rationale": "OpenAI /v1/responses passthrough strips top-level `user` before forwarding. The APIKey native path adds `user` to OpenAIGatewayService.Forward's unsupportedFields list (the OAuth path already filters it through applyCodexOAuthTransform); the Cursor-shape short-circuit in ForwardAsChatCompletions adds `user` to cursorResponsesUnsupportedFields. Without this, clients like LobeHub posting `user` to /v1/responses got upstream HTTP 400 'Unsupported parameter: user'.",
       "updated_at": "2026-03-24T13:52:59Z"
     },
     {
@@ -8180,19 +13813,6 @@
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "Non-stream buffered SSE->JSON handlers in both the OpenAI gateway (/v1/chat/completions, /v1/messages) and the Anthropic-backed gateway forward paths (Responses, Chat Completions) now explicitly set Content-Type: application/json after WriteFilteredHeaders. Without this, the upstream SSE Content-Type (text/event-stream) leaks onto JSON bodies because gin's render.writeContentType only writes when no Content-Type is set, breaking OpenAI-SDK consumers that branch on Content-Type.",
       "updated_at": "2026-06-06T13:33:05Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1318",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1318",
-      "title": "[bug] openai_passthrough 命中临时不可调度规则后未触发 failover",
-      "impact": "fixed",
-      "categories": [
-        "rate_limit_cooldown",
-        "image_oauth"
-      ],
-      "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "openai_passthrough now propagates HandleUpstreamError's shouldDisable signal: when a temp-unschedulable rule (or any policy that marks the account unschedulable — 402 deactivated_workspace, OAuth 401, organization disabled, etc.) fires, handleErrorResponsePassthrough returns UpstreamFailoverError and emits ops Kind=failover instead of writing the upstream error straight back to the client. This closes the half-applied state where the account got disabled but the in-flight request was still completed on it.",
-      "updated_at": "2026-03-26T06:47:06Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1322",
@@ -8218,20 +13838,8 @@
         "account_pool_health"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "OpenAI /v1/responses sendErrorEvent now prepends a blank line before the synthetic data: line, so any in-flight upstream SSE event whose terminating blank line was never sent is closed before the synthetic event is written. Without this, the unterminated `data:` line and the synthetic `data:` line merge into a single SSE event whose payload contains two concatenated JSON objects, which downstream OpenAI-compatible SDKs (Codex, OpenCode, etc.) reject with malformed JSON.",
-      "updated_at": "2026-04-06T00:12:29Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1723",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1723",
-      "title": "[Performance] UpdateLastUsed 写放大导致 Redis 大量不必要流量（单部署实测 1.85 TB / 6.5 天）",
-      "impact": "fixed",
-      "categories": [
-        "billing_usage"
-      ],
-      "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "schedulerCache.UpdateLastUsed 不再读改写完整账号键 sched:acc:<id>（3-12 KB JSON），只刷调度热路径 LRU 实际读取的 slim metadata 键 sched:meta:<id>，消除每次 LastUsedAt bump 的 Redis 读写放大（upstream 实测单部署 6.5 天 1.85 TB）。完整账号键的 LastUsedAt 由快照重建 / 账号变更刷新，不参与 LRU。 Fixed by youxuanxue/sub2api#525.",
-      "updated_at": "2026-05-27T03:33:48Z"
+      "rationale": "OpenAI /v1/responses sendErrorEvent prepends a blank line before the synthetic error event so an in-flight upstream SSE event (data: line without terminating blank line) does not merge with the injected error event into a single event carrying two JSON objects; downstream SDK JSON parsing no longer fails.",
+      "updated_at": "2026-07-30T03:42:06Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1824",
@@ -8250,18 +13858,6 @@
       "updated_at": "2026-04-23T06:46:12Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#1833",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1833",
-      "title": "不扣费",
-      "impact": "fixed",
-      "categories": [
-        "billing_usage"
-      ],
-      "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "calculateTokenCost no longer silently bills zero on ErrModelPricingUnavailable; it emits a structured gateway_usage.pricing_missing_record_zero_cost warning and marks BillingMode, at parity with the OpenAI record-usage path. Closes the free-usage leak for non-builtin models (GLM/qwen/deepseek over /v1/messages) with no configured pricing.",
-      "updated_at": "2026-04-24T08:46:58Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#1925",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1925",
       "title": "OpenAI 账号测试对 /responses 流式校验过宽，提前 EOF 也会判定成功，导致异常账号被误加入调度池",
@@ -8275,18 +13871,6 @@
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "OpenAI /responses account test requires response.completed/response.done; early EOF fails tests.",
       "updated_at": "2026-04-25T07:54:59Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1934",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1934",
-      "title": "切组后旧 sticky session 没失效，导致一直调用已经被切出去的账号",
-      "impact": "fixed",
-      "categories": [
-        "rate_limit_cooldown"
-      ],
-      "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "Sticky bindings are namespaced by (groupID, sessionHash) but resolved by global account ID; after an account is moved out of the group the stale binding kept routing the group's traffic at it. All three sticky fast paths now invalidate a binding whose bound account has known group membership excluding groupID (conservative: empty membership kept).",
-      "updated_at": "2026-04-25T03:35:59Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1946",
@@ -8311,20 +13895,7 @@
       ],
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "Opt-in (default OFF via tk_openai_max_rate_limit_cooldown_seconds) clamp of long OpenAI 429 resets (e.g. 7d window exhaustion) so released accounts re-enter the pool after the ceiling and are re-probed by live traffic instead of idling — 'traffic as the probe', no separate background prober.",
-      "updated_at": "2026-04-26T02:45:43Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#2013",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2013",
-      "title": "claude top level cache control not working",
-      "impact": "fixed",
-      "categories": [
-        "image_oauth",
-        "security"
-      ],
-      "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "enforceCacheControlLimit now counts a non-standard top-level cache_control toward the 4-block limit and trims it first, fixing Anthropic 400 'max 4 blocks, Found 5' when a client sends top-level cache_control plus 4 nested blocks.",
-      "updated_at": "2026-04-27T01:47:00Z"
+      "updated_at": "2026-08-10T01:51:18Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2055",
@@ -8443,18 +14014,6 @@
       "updated_at": "2026-05-07T16:54:09Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2298",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2298",
-      "title": "Bug: Upstream empty SSE data: frames cause OpenAI SDK JSONDecodeError when using Responses API (/v1/responses)",
-      "impact": "fixed",
-      "categories": [
-        "rate_limit_cooldown"
-      ],
-      "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "OpenAI gateway forward paths drop empty / whitespace-only `data:` SSE frames before they reach the client. Upstream gpt-5.5 on `/v1/responses` emits bare `data:\\n\\n` frames at roughly a 5-10% rate; the OpenAI Python SDK then crashes on json.loads(\"\") inside `openai/_streaming.py`. The TK fix introduces a single `openAISSEDataPayloadIsEmpty` predicate and consumes it in all three client-facing forward paths: handleStreamingResponse (main /v1/responses), handleStreamingResponsePassthrough (OAuth passthrough), and streamRawChatCompletions (third-party OpenAI-compat upstreams like DeepSeek / Kimi / GLM / Qwen). See router-for-me/CLIProxyAPI#2460 for the canonical analysis.",
-      "updated_at": "2026-05-08T15:42:59Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#2337",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2337",
       "title": "Bug: Anthropic→OpenAI 格式转换时 multi-turn tool_call ID 映射错误导致 400",
@@ -8492,7 +14051,7 @@
       ],
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "OpenAI usage recording has billing model candidates/source tracking and tests for mapped/unmapped models.",
-      "updated_at": "2026-06-17T02:38:11Z"
+      "updated_at": "2026-07-06T13:05:38Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2411",
@@ -8585,7 +14144,7 @@
         "enhancement"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "normalizeClaudeOAuthRequestBody now skips auto-injecting context_management for Haiku models, mirroring the existing Haiku exemption in the anthropic-beta header path; Anthropic /v1/messages would otherwise return HTTP 400 for claude-haiku-4-5-* when thinking.type is enabled.",
+      "rationale": "normalizeClaudeOAuthRequestBody skips context_management auto-injection for Haiku models (mirroring the existing Haiku exemption in FullClaudeCodeMimicryBetas), so claude-haiku-4-5-* + thinking.type=enabled no longer triggers Anthropic 400.",
       "updated_at": "2026-05-15T21:05:14Z"
     },
     {
@@ -8626,33 +14185,6 @@
       "updated_at": "2026-05-20T09:07:39Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2727",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2727",
-      "title": "请求反复打到同一个已经限流的账户上去",
-      "impact": "fixed",
-      "categories": [
-        "rate_limit_cooldown",
-        "image_oauth"
-      ],
-      "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "Opt-in (default OFF via tk_openai_implicit_throttle_cooldown_seconds) cross-request cooldown: an OpenAI-compat account that returns a failover-worthy 5xx (implicit throttle / header-timeout with no 429) is briefly benched so subsequent requests skip it. The deliberately-unbounded OpenAIResponseHeaderTimeout default is intentionally NOT changed.",
-      "updated_at": "2026-05-26T10:36:34Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3014",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3014",
-      "title": "bug(openai): codex_cli_only 未拦截 /v1/chat/completions 兼容入口",
-      "impact": "fixed",
-      "categories": [
-        "claude_mimicry",
-        "image_oauth",
-        "security"
-      ],
-      "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "codex_cli_only 访问控制绕过：限制此前只在 /v1/responses (Forward) 生效，普通非 Codex 客户端可经 /v1/chat/completions 兼容入口（内部转 Responses 后转发）继续使用受限 OAuth 账号。修复抽出共享 enforceCodexClientRestriction，在所有 OpenAI 网关转发入口统一执行：/responses、/v1/chat/completions、图片 OAuth 路径（forwardOpenAIImagesOAuth）；拒绝返回普通错误而非 *UpstreamFailoverError，确保不会 failover 到另一个账号而再次绕过策略。同时修掉既有脏 403：业务限流类拒绝已写完整响应时，handler 兜底 ensureForwardErrorResponse 不再追加错误帧污染 body。未开启 codex_cli_only 的账号为零成本 no-op。",
-      "updated_at": "2026-06-03T11:47:42Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#3158",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/3158",
       "title": "bug: WS v2 passthrough mode skips Codex image bridge",
@@ -8660,7 +14192,8 @@
       "categories": [
         "rate_limit_cooldown",
         "billing_usage",
-        "image_oauth"
+        "image_oauth",
+        "compatibility"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "WS v2 passthrough mode applies Codex image_generation bridge mutations on response.create frames before forwarding upstream, matching the regular WS ingress path.",
@@ -8676,7 +14209,10 @@
         "rate_limit_cooldown",
         "billing_usage",
         "image_oauth",
-        "security"
+        "security",
+        "ops_observability",
+        "compatibility",
+        "enhancement"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "Anthropic/Kiro API-key passthrough strips client timeout headers (x-stainless-timeout and related) by default so long non-stream requests no longer hit the ~125s upstream cancel boundary; opt in via anthropic_passthrough_allow_timeout_headers.",
@@ -8897,7 +14433,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-01-01T15:35:22Z"
+      "updated_at": "2026-07-03T07:10:06Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1232",
@@ -8912,18 +14448,6 @@
       "updated_at": "2026-03-24T07:50:32Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#1243",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1243",
-      "title": "很多账号报fail，一些封号的貌似也没检测出来，能优化吗？",
-      "impact": "low",
-      "categories": [
-        "enhancement"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-03-25T08:07:12Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#1244",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1244",
       "title": "希望可以新增类似newapi的模型广场的功能",
@@ -8933,7 +14457,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-05-27T13:56:51Z"
+      "updated_at": "2026-07-29T05:40:42Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1246",
@@ -9005,19 +14529,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-03-30T01:47:51Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1379",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1379",
-      "title": "建议增加功能： 账号复制",
-      "impact": "low",
-      "categories": [
-        "enhancement"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-03-30T03:49:43Z"
+      "updated_at": "2026-07-09T06:33:52Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1389",
@@ -9041,7 +14553,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-06-25T05:32:54Z"
+      "updated_at": "2026-07-13T04:53:19Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1425",
@@ -9113,7 +14625,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-04-05T21:26:18Z"
+      "updated_at": "2026-07-01T03:48:51Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1478",
@@ -9246,7 +14758,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-05-22T00:50:51Z"
+      "updated_at": "2026-07-27T02:30:02Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#188",
@@ -9306,7 +14818,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-05-26T03:25:10Z"
+      "updated_at": "2026-07-01T03:23:49Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1974",
@@ -9330,7 +14842,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-04-26T13:42:38Z"
+      "updated_at": "2026-07-20T11:52:38Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2002",
@@ -9462,7 +14974,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-05-10T15:21:10Z"
+      "updated_at": "2026-07-01T03:25:03Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2173",
@@ -9570,7 +15082,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-05-25T11:41:15Z"
+      "updated_at": "2026-08-07T12:39:11Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2382",
@@ -9594,7 +15106,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-05-12T12:18:52Z"
+      "updated_at": "2026-07-25T07:05:54Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2419",
@@ -9706,18 +15218,6 @@
       "updated_at": "2026-06-04T00:24:15Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2733",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2733",
-      "title": "Memory grows unbounded when Postgres is unreachable (RecordErrorBatch retry loop)",
-      "impact": "low",
-      "categories": [
-        "docs"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-05-24T03:30:57Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#2739",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2739",
       "title": "希望可以增加根据代理筛选账号的功能",
@@ -9728,18 +15228,6 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
       "updated_at": "2026-05-24T06:30:14Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#2765",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2765",
-      "title": "feat: 增加限制用户使用推理模式",
-      "impact": "low",
-      "categories": [
-        "enhancement"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-05-26T01:42:07Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2769",
@@ -9835,7 +15323,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-06-06T10:06:27Z"
+      "updated_at": "2026-07-02T05:32:34Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3085",
@@ -9848,18 +15336,6 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
       "updated_at": "2026-06-07T01:25:49Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3099",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3099",
-      "title": "json能不能直接导入分组啊",
-      "impact": "low",
-      "categories": [
-        "enhancement"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-06-10T05:30:30Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3110",
@@ -9883,7 +15359,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-06-08T03:35:43Z"
+      "updated_at": "2026-07-07T02:31:38Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3124",
@@ -9967,7 +15443,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-06-12T01:33:42Z"
+      "updated_at": "2026-07-01T03:25:03Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3240",
@@ -10039,7 +15515,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-06-21T03:49:12Z"
+      "updated_at": "2026-07-01T03:23:56Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3388",
@@ -10135,7 +15611,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-06-27T20:52:25Z"
+      "updated_at": "2026-07-03T04:33:55Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3547",
@@ -10162,6 +15638,42 @@
       "updated_at": "2026-06-29T08:12:28Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#3566",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3566",
+      "title": "希望支持OpenCode 订阅",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-04T18:19:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3590",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3590",
+      "title": "update",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-01T01:04:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3592",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3592",
+      "title": "能否记录存储所有的对话记录？",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-01T08:33:41Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#363",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/363",
       "title": "[BUG]Permission denied",
@@ -10174,6 +15686,54 @@
       "updated_at": "2026-01-23T09:27:19Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#3633",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3633",
+      "title": "是否可以增加一个按5小时重置时间越近的优先调度",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-02T03:32:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3660",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3660",
+      "title": "feat：账号管理表格里现在没有了点击显示所有分组，不方便查看启用的分组",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-02T20:14:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3666",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3666",
+      "title": "feat: 请求给系统添加自定义积分和签到功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-03T02:56:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3702",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3702",
+      "title": "希望能在批量导入是增加分组的功能和批量生成兑换码",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-04T03:50:21Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#372",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/372",
       "title": "feature: 支持优先使用快刷新的账号",
@@ -10183,7 +15743,79 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-01-23T10:11:46Z"
+      "updated_at": "2026-07-24T10:34:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3723",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3723",
+      "title": "用户端的首页登录头像旁边显示的余额和实际余额显示不一致",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-06T03:03:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3743",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3743",
+      "title": "网站是否可以重新开放注册",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-06T07:42:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3745",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3745",
+      "title": "cursor 使用sub2api的模型,无法控制thinking深度,是否可以sub2api中指定默认thinking程度",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-14T02:29:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3896",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3896",
+      "title": "CodeX 新增了设备证明的请求体",
+      "impact": "low",
+      "categories": [
+        "docs"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-10T14:57:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3897",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3897",
+      "title": "CodeX 新增了设备证明的请求体,请作者关注",
+      "impact": "low",
+      "categories": [
+        "docs"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-10T05:49:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3960",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3960",
+      "title": "支持配置数据库的 READONLY 节点，提供读写分离的性能优化",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-10T08:04:13Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#397",
@@ -10198,6 +15830,186 @@
       "updated_at": "2026-01-26T06:19:39Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4013",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4013",
+      "title": "Codex疑似新增指纹校验",
+      "impact": "low",
+      "categories": [
+        "docs"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-11T12:16:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4086",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4086",
+      "title": "关于易支付里面自定义支付方式问题",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-17T07:02:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4202",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4202",
+      "title": "后台管理筛选功能缺陷",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-13T14:35:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4267",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4267",
+      "title": "渠道定价没有生效",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-19T09:12:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4293",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4293",
+      "title": "是否可以添加一个 自动重置账号额度功能？",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-15T03:16:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4331",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4331",
+      "title": "账号希望支持上游sub2api或者new-api额度的查询和自定义账号查询，类似于cc-switch的用量查询",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-19T13:13:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4457",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4457",
+      "title": "去掉敏感操作2FA或提供关闭此功能的开关",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-17T10:12:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4469",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4469",
+      "title": "去掉只有开启2fa才能导出账号这个糟糕的限制",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-17T15:52:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4488",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4488",
+      "title": "codex与chatgpt工具合并后 使用chatgpt登录 按照文档配置config.toml后一直提示需要一次性权限才能用，有没有人解决了。",
+      "impact": "low",
+      "categories": [
+        "docs"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-21T00:49:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4512",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4512",
+      "title": "希望能支持Kimi官方客户端",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-17T15:07:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4513",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4513",
+      "title": "改进建议：根据首字优化上游供应商的选择",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-17T15:12:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4514",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4514",
+      "title": "[feat]: 希望支持国产Kimi账号反代",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-20T11:57:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4530",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4530",
+      "title": "有IP一直在尝试登陆，我如何屏蔽它？是否可以设置尝试多久失败后就ban IP1天之类",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-20T00:48:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4608",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4608",
+      "title": "这个币种标注如果只能按要求填，建议做成选择框",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-20T05:39:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4685",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4685",
+      "title": "bug(frontend): 账号并发数输入框无法先清空再输入新值",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-21T08:25:19Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#470",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/470",
       "title": "代理一键分配账号",
@@ -10210,6 +16022,90 @@
       "updated_at": "2026-02-03T10:36:48Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4708",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4708",
+      "title": "希望 支持【IP管理】-【失败回退】",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-21T17:26:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4727",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4727",
+      "title": "添加账号时，如果指定为API方式，Base URL设置为http协议的，测试报错Invalid base URL: invalid url scheme: http",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-22T09:13:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4729",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4729",
+      "title": "最近 API友商大战 DDOS 频出 建议出一个 请求错误/探测请求 过多 自动限制请求 或者暂时封禁的功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-22T09:32:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4745",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4745",
+      "title": "Agent Identity auth.json",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-22T15:09:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4747",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4747",
+      "title": "希望增加绑定的账号到期提醒，甚至邮箱提醒功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-22T15:14:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4753",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4753",
+      "title": "希望能够增加一个立柱式的模型调用分析表",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-22T17:51:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4763",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4763",
+      "title": "[建议] 建议大佬添加一个 【模型广场】的功能 清晰看到 每个模型的价格",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-29T06:12:40Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#483",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/483",
       "title": "希望一个key可以绑定多个模型使用（可以绑定多个分组）",
@@ -10219,7 +16115,367 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-03-20T07:22:23Z"
+      "updated_at": "2026-07-01T03:24:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4917",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4917",
+      "title": "请求贴（自设倍率与上游始终动态成比例）",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-29T09:25:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4938",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4938",
+      "title": "希望站点运营内容支持中英文独立配置与按语言显示",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-27T04:14:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4964",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4964",
+      "title": "SettingsView.vue: the nine tab panels are interleaved, and all of them mount on every visit",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-27T11:44:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5059",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5059",
+      "title": "建议添加用户自主注销账号",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-29T12:57:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5076",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5076",
+      "title": "希望能增加在线聊天功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-31T08:27:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5077",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5077",
+      "title": "建议标记稳定版",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-30T04:31:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5082",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5082",
+      "title": "修复了还是有Selected model is at capacity. Please try a different model.",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-30T11:20:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5122",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5122",
+      "title": "Batch API openai",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-02T12:29:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5126",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5126",
+      "title": "增强建议：提示词审计会被一直保留没有任何入口设置删除时间",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-07-31T05:25:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5204",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5204",
+      "title": "建议增加一个用户也可以自己增加账号和分组的",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-03T01:03:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5206",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5206",
+      "title": "增加一个用户角色或自定义权限角色",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-12T03:56:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5210",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5210",
+      "title": "Simple mode 希望也能支援 Composite 分組",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-03T03:29:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5235",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5235",
+      "title": "有个bug，接入上游时如果下游进站是chat/completions的协议，然后上游接受的是responses协议导致工具无法调用以及上下文增长一些，希望能够将这个统一，入站是什么协议，到上游就是什么协议",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-03T13:59:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5241",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5241",
+      "title": "账号调用缓存和粘性会话生失效不合理",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-03T16:22:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5278",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5278",
+      "title": "优化建议：能否在创建密钥时新增一个平台分类",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-05T02:04:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5296",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5296",
+      "title": "希望增加自动定时同步上游模型",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-05T08:31:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5333",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5333",
+      "title": "希望增加免费的国内人机验证适配",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-06T10:02:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5347",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5347",
+      "title": "希望上游申明倍率提供修正乘数",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-06T23:45:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5442",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5442",
+      "title": "功能建议：接入上游时可通过首字延迟自动切换上游",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-09T03:52:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5498",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5498",
+      "title": "功能请求：支持不同支付服务商独立配置支付规则",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-10T17:59:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5557",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5557",
+      "title": "希望可以更新下创建/编辑API密钥的时候可以选择备用分组",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-12T11:18:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5682",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5682",
+      "title": "无法支持ds模型",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-17T01:23:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5691",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5691",
+      "title": "希望可以查看某个号 某个日期段的用量情况",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-17T04:55:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5754",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5754",
+      "title": "为啥 首字偶尔会增高啊。",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-19T01:10:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5774",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5774",
+      "title": "希望增加一个功能，codex 20x账号发现额度异常（1分钟检测一次），自动暂停调度。",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-18T09:37:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5779",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5779",
+      "title": "deepseek 和 GLM 无法加入 gpt 或者 anthropic 类型组",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-18T13:21:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5857",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5857",
+      "title": "订阅日卡问题反馈",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-19T15:12:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5865",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5865",
+      "title": "[Feature] 余额充值支持阶梯定价",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-19T22:48:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5898",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5898",
+      "title": "Grok希望增加类似于GPT的重置功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-20T08:09:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5915",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5915",
+      "title": "支持多个分组混合使用",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-08-20T13:12:31Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#678",
@@ -10316,7 +16572,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-03-25T16:40:47Z"
+      "updated_at": "2026-07-08T12:13:28Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#979",
@@ -10460,7 +16716,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-19T08:33:42Z"
+      "updated_at": "2026-07-21T01:05:43Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1061",
@@ -10550,7 +16806,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-22T13:42:12Z"
+      "updated_at": "2026-07-03T07:08:32Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1091",
@@ -10693,16 +16949,6 @@
       "updated_at": "2026-03-19T14:58:54Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#1166",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1166",
-      "title": "账号管理应该加一个未绑定分组的账号筛选，方便绑定。。",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-03-19T15:25:10Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#1174",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1174",
       "title": "可以直接集成sub2apipay吗？",
@@ -10753,16 +16999,6 @@
       "updated_at": "2026-03-20T13:46:15Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#1187",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1187",
-      "title": "账号应该支持更细的检索，比如同是openai的账号，free和team和plus单独检索不了",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-03-20T14:40:26Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#1191",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1191",
       "title": "能不能直接使用一个apikey就使用不同的ai客户端，不通过cc switch",
@@ -10781,16 +17017,6 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-06-23T17:47:30Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1205",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1205",
-      "title": "English locale shows Chinese text \"倍率\" on Keys page",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-03-21T20:50:52Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1206",
@@ -10830,7 +17056,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-03-22T12:57:46Z"
+      "updated_at": "2026-08-01T03:39:41Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1221",
@@ -11080,7 +17306,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-03-30T17:21:51Z"
+      "updated_at": "2026-07-30T09:07:14Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1410",
@@ -11113,16 +17339,6 @@
       "updated_at": "2026-04-14T02:07:25Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#1446",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1446",
-      "title": "可以考虑加一个 Github Coplit 的反代功能么",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-04T03:00:47Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#1466",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1466",
       "title": "Unknown model: gpt-5.1",
@@ -11131,16 +17347,6 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-04-06T13:36:28Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1470",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1470",
-      "title": "Mailersend SMTP connection problem",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-06T08:37:08Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1472",
@@ -11240,7 +17446,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-15T22:30:55Z"
+      "updated_at": "2026-07-04T01:28:56Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1507",
@@ -11270,7 +17476,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-09T09:25:16Z"
+      "updated_at": "2026-07-24T04:03:52Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1515",
@@ -11420,7 +17626,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-09T09:05:55Z"
+      "updated_at": "2026-08-04T07:22:02Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1600",
@@ -11590,7 +17796,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-15T17:39:19Z"
+      "updated_at": "2026-07-29T06:14:49Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1699",
@@ -11810,7 +18016,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-13T11:03:22Z"
+      "updated_at": "2026-07-09T02:04:59Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1778",
@@ -11870,7 +18076,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-22T14:29:29Z"
+      "updated_at": "2026-07-20T09:06:09Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1808",
@@ -11890,7 +18096,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-12T05:28:56Z"
+      "updated_at": "2026-07-18T04:43:54Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1816",
@@ -11940,7 +18146,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-16T23:31:31Z"
+      "updated_at": "2026-07-27T17:31:31Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1839",
@@ -12090,7 +18296,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-03-31T03:05:18Z"
+      "updated_at": "2026-08-10T08:31:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1873",
@@ -12270,7 +18476,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-27T11:07:01Z"
+      "updated_at": "2026-07-17T07:00:03Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1993",
@@ -12310,7 +18516,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-11T09:51:27Z"
+      "updated_at": "2026-07-16T09:46:29Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2025",
@@ -12340,7 +18546,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-28T09:45:31Z"
+      "updated_at": "2026-07-26T23:53:55Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2046",
@@ -12490,7 +18696,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-07T09:02:39Z"
+      "updated_at": "2026-07-15T07:58:30Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2154",
@@ -12590,7 +18796,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-29T10:33:12Z"
+      "updated_at": "2026-07-30T09:07:20Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2240",
@@ -13000,7 +19206,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-23T11:04:18Z"
+      "updated_at": "2026-07-06T09:38:27Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2433",
@@ -13020,7 +19226,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-18T01:55:31Z"
+      "updated_at": "2026-08-14T19:36:46Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#244",
@@ -13050,7 +19256,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-31T13:48:06Z"
+      "updated_at": "2026-07-01T03:24:31Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2477",
@@ -13080,7 +19286,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-16T07:03:21Z"
+      "updated_at": "2026-07-11T03:41:33Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2517",
@@ -13130,7 +19336,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-20T00:14:46Z"
+      "updated_at": "2026-07-29T07:24:02Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2545",
@@ -13210,7 +19416,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-20T06:11:38Z"
+      "updated_at": "2026-07-29T05:40:09Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2617",
@@ -13220,7 +19426,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-13T07:38:51Z"
+      "updated_at": "2026-07-21T01:05:18Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#262",
@@ -13290,7 +19496,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-21T13:11:15Z"
+      "updated_at": "2026-08-11T05:45:59Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2675",
@@ -13311,16 +19517,6 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-05-22T05:53:55Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#2695",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2695",
-      "title": "没配置邮件一直报错 Send expiry reminder failed: subscription=33 user=113 err=error",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-22T13:11:58Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2696",
@@ -13450,7 +19646,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-28T11:36:23Z"
+      "updated_at": "2026-07-06T10:29:43Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2775",
@@ -13490,7 +19686,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-05T22:38:26Z"
+      "updated_at": "2026-08-20T06:29:01Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2793",
@@ -13550,7 +19746,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-05T01:42:33Z"
+      "updated_at": "2026-07-22T06:21:44Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2840",
@@ -13560,7 +19756,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-24T07:56:09Z"
+      "updated_at": "2026-07-27T09:44:39Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2842",
@@ -13620,7 +19816,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-17T03:33:54Z"
+      "updated_at": "2026-07-28T01:38:17Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2878",
@@ -13710,7 +19906,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-07T06:00:28Z"
+      "updated_at": "2026-07-08T05:48:08Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2941",
@@ -13770,7 +19966,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-02T01:52:37Z"
+      "updated_at": "2026-07-10T03:16:40Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2971",
@@ -13810,7 +20006,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-17T02:53:40Z"
+      "updated_at": "2026-07-24T09:08:21Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3013",
@@ -13900,7 +20096,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-06T07:25:35Z"
+      "updated_at": "2026-07-08T03:59:55Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3076",
@@ -14000,7 +20196,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-27T02:47:59Z"
+      "updated_at": "2026-08-07T12:52:11Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3159",
@@ -14030,17 +20226,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-09T14:13:09Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3190",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3190",
-      "title": "Anthropic模型支持",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-27T02:23:04Z"
+      "updated_at": "2026-08-18T07:00:27Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3205",
@@ -14050,7 +20236,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-10T09:39:14Z"
+      "updated_at": "2026-07-29T05:40:25Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3206",
@@ -14080,7 +20266,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-21T03:51:44Z"
+      "updated_at": "2026-07-24T09:07:11Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3253",
@@ -14101,16 +20287,6 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-06-12T07:39:07Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#3257",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3257",
-      "title": "AI says it is GPT-5.1 even though I selected GPT-5.5",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-15T02:38:13Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3279",
@@ -14190,7 +20366,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-18T03:32:11Z"
+      "updated_at": "2026-07-13T01:05:36Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3327",
@@ -14213,16 +20389,6 @@
       "updated_at": "2026-06-19T12:38:32Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#3348",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3348",
-      "title": "推理强度映射、速度映射",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-18T07:13:40Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#3353",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/3353",
       "title": "最新版本启动报错 0.1.137",
@@ -14230,7 +20396,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-18T09:33:32Z"
+      "updated_at": "2026-07-01T02:51:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3357",
@@ -14280,7 +20446,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-20T14:51:19Z"
+      "updated_at": "2026-07-11T09:51:24Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3385",
@@ -14410,7 +20576,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-26T00:37:18Z"
+      "updated_at": "2026-08-11T08:41:18Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3466",
@@ -14420,7 +20586,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-27T08:11:28Z"
+      "updated_at": "2026-08-19T09:09:42Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3479",
@@ -14440,7 +20606,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-27T03:12:55Z"
+      "updated_at": "2026-08-12T06:54:16Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3493",
@@ -14503,16 +20669,6 @@
       "updated_at": "2026-01-21T09:00:27Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#3511",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3511",
-      "title": "grok账号测试的时候没有grok的模型，串的是claude的模型",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-27T08:20:37Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#3516",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/3516",
       "title": "sub2api怎么接入seedance呢？",
@@ -14520,7 +20676,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-27T06:58:23Z"
+      "updated_at": "2026-06-30T07:14:29Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#3518",
@@ -14553,14 +20709,44 @@
       "updated_at": "2026-06-29T01:08:24Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#3557",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/3557",
-      "title": "linux.do注册时绑定邮箱internal error",
+      "upstream": "Wei-Shaw/sub2api#3561",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3561",
+      "title": "feat：增加可创建用户级别Open API密钥用来查询各种信息",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-29T09:25:46Z"
+      "updated_at": "2026-06-30T03:19:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3579",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3579",
+      "title": "138的新增订阅推广返利与\"优先最快重置账号\"调度策略",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-06-30T13:40:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3597",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3597",
+      "title": "可不可以实现 一个分组 能用两个 AI ？ 一个分组一个用量 能用 GPT + Claude",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-01T08:35:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3605",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3605",
+      "title": "修改用户的平台限额，无法保存。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-02T00:30:32Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#361",
@@ -14573,6 +20759,276 @@
       "updated_at": "2026-01-22T08:55:12Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#3613",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3613",
+      "title": "号池 支持批量探测",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-01T11:32:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3617",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3617",
+      "title": "能否增加一个嵌入客服的设置呀",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-01T14:29:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3621",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3621",
+      "title": "接入商汤日日新anthropic协议失败，报错401",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-01T15:40:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3625",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3625",
+      "title": "一个月的订阅用户 可以用两个月的用量",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-02T01:00:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3628",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3628",
+      "title": "走轉發後不出 fable",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-02T18:30:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3631",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3631",
+      "title": "是否考虑支持视频模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-05T04:39:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3634",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3634",
+      "title": "能不能单独给订阅调整 用量？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-02T03:36:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3636",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3636",
+      "title": "下面几个功能应该会增加sub2api的支持力度",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-02T04:05:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3637",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3637",
+      "title": "母账号切换代理ip后spark账号不会跟随",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-02T04:16:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3639",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3639",
+      "title": "男的找个男朋友（程序员）",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-02T05:42:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3640",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3640",
+      "title": "订阅管理分组能选到已删除的账号",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-02T06:52:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3648",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3648",
+      "title": "Codex session imagen tool not available （Codex 不能用来画图了）",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-11T06:50:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3651",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3651",
+      "title": "k12 同一空间导入多个账号里面只有一个账号，后面导入的会覆盖前面的。。。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-02T16:41:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3663",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3663",
+      "title": "open ai 订阅月额度刷新异常",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-03T00:55:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3664",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3664",
+      "title": "GLM请教",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-03T01:47:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3674",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3674",
+      "title": "火山coding plan无法同步模型和获取toekn计量",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-03T07:12:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3680",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3680",
+      "title": "api key可以新增根据用量排序吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-04T05:56:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3681",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3681",
+      "title": "高峰倍率能做到模型定价中吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-03T10:42:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3683",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3683",
+      "title": "你们的Codex 都能直接画图吗？ 能用 imagen 吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-17T10:26:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3687",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3687",
+      "title": "[Bug] Responses 端点请求 Responses 端点会触发固定 cache input",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-12T08:00:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3712",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3712",
+      "title": "OIDC使用邀请码注册用户缺少邮箱验证问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-04T14:56:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3727",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3727",
+      "title": "https://****/api/v1/payment/webhook/alipay 报404",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-06T06:33:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3746",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3746",
+      "title": "给gpt 添加一个 加入k12的功能啊",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-06T06:52:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3752",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3752",
+      "title": "倍率异常飙升，费用显示飙升，超过key限额 2.5倍",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T05:45:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3753",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3753",
+      "title": "能否代理加一下订阅功能",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-06T09:25:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3765",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3765",
+      "title": "admin/risk-control 這個頁面實際好像沒用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-06T14:52:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3791",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3791",
+      "title": "Tool choice 'image_generation' not found in 'tools' parameter.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-07T08:29:01Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#381",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/381",
       "title": "SMTP配置",
@@ -14581,6 +21037,96 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-01-24T10:56:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3810",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3810",
+      "title": "什么时候可以增加即梦国际版",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-03T15:21:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3818",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3818",
+      "title": "Invalid type for 'input[40].arguments 有些会话用久了好像会这样",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T06:29:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3819",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3819",
+      "title": "Antigravity-compatible accounts — strange behaviour",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-08T08:57:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3820",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3820",
+      "title": "claude 模型有的时候生成一个 api key，莫名其妙的就不能调用了，然后重新生成一个 key 就可以调用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-08T06:37:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3830",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3830",
+      "title": "新版本出现了很多内部错误",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-09T05:03:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3834",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3834",
+      "title": "经常没有模型和账号参数",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-08T16:29:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3844",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3844",
+      "title": "pincc有没有客服啊",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-09T03:37:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3856",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3856",
+      "title": "新出的voice模型是否有代理出来使用的场景呢",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T10:37:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3862",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3862",
+      "title": "能否加一个 webhook 报警的功能，比如可以配置飞书机器人进行报警，这样比单独的邮箱更方便多人查看",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-09T09:21:47Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#388",
@@ -14593,14 +21139,94 @@
       "updated_at": "2026-01-25T04:44:13Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#389",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/389",
-      "title": "BUG，现在5h用量都不清空了吗？",
+      "upstream": "Wei-Shaw/sub2api#3891",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3891",
+      "title": "{ \"error\": { \"message\": \"Failed to read request body\", \"type\": \"invalid_request_error\" } }",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-02-01T18:15:19Z"
+      "updated_at": "2026-07-13T06:18:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3902",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3902",
+      "title": "有大佬解释一下关于 渠道订阅 功能的情况吗？如何把自己的各方订阅接成个人中转？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T01:54:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3914",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3914",
+      "title": "gpt-5.6 模型测试失败",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T17:18:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3915",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3915",
+      "title": "为什么使用5.6会降级到5.4呀",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-04T09:12:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3918",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3918",
+      "title": "5.6模型 账号测试可用，在终端 api无法调用，提示没有这个模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T05:32:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3930",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3930",
+      "title": "更新失败",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-11T16:42:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3934",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3934",
+      "title": "5.6 压缩请求失败",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T07:10:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3946",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3946",
+      "title": "突然找不到5.6的映射了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T07:13:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3947",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3947",
+      "title": "gpt 5.6 Invalid type for 'input[40].arguments",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T07:15:01Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#395",
@@ -14613,6 +21239,36 @@
       "updated_at": "2026-01-26T03:57:41Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#3950",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3950",
+      "title": "hermes 使用有问题 HTTP 400: The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T10:39:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3962",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3962",
+      "title": "支持单独的 MIGRATION_DATABASE_URL 用于数据库迁移；从而让正常业务使用 PGBouncer 的 transaction 模式。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T08:13:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3979",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3979",
+      "title": "使用ultra级别推理，但是sub2api 0.1.150版本记录里面最高只会显示 Max",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-11T13:14:23Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#398",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/398",
       "title": "添加反重力家庭组会员问题",
@@ -14621,6 +21277,16 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-02-06T17:24:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3980",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/3980",
+      "title": "Grok账号",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T10:40:31Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#399",
@@ -14643,6 +21309,26 @@
       "updated_at": "2026-04-17T08:46:52Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4001",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4001",
+      "title": "bug：最新版本使用记录费用明细还是没有缓存写入价格和费用啊",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T23:19:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4008",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4008",
+      "title": "订阅可以扣费余额后，仅提交剩下的金额订单（用户可选）",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-10T17:04:41Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#402",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/402",
       "title": "反重力",
@@ -14650,7 +21336,57 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-01-27T04:08:38Z"
+      "updated_at": "2026-07-27T03:44:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4023",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4023",
+      "title": "Grok 4.5根本没办法正常调用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-11T06:11:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4031",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4031",
+      "title": "grok额度查询不正确",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-11T06:33:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4039",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4039",
+      "title": "151版本，发现 5.6 模型无法调用系统工具，如 shell，读写文件等。5.5 正常",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-12T05:38:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4042",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4042",
+      "title": "5.6缓存写入",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-11T09:06:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4047",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4047",
+      "title": "后续可以增加gpt_live语音的模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-24T04:54:54Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#405",
@@ -14663,6 +21399,56 @@
       "updated_at": "2026-01-27T11:14:47Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4056",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4056",
+      "title": "Failed to read request body",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T06:53:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4061",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4061",
+      "title": "调度优先级没有生效！！！",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-12T07:38:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4067",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4067",
+      "title": "151版本用不了GPT5.5，提示 Image generation is not enabled for this group",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-12T12:39:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4081",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4081",
+      "title": "配置强制注入，在codex里面调用image_gen出现问题。151版本",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-15T17:00:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4122",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4122",
+      "title": "gork用量窗口不准确",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-13T08:55:49Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#413",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/413",
       "title": "目前不支持 clawdbot",
@@ -14671,6 +21457,26 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-02-05T02:13:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4131",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4131",
+      "title": "0.1.152版本仍未修复websearch工具问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-16T02:31:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4132",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4132",
+      "title": "一个key没办法同时有gpt和grok的模型么",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-13T03:53:36Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#415",
@@ -14683,6 +21489,26 @@
       "updated_at": "2026-05-01T14:27:55Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4155",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4155",
+      "title": "Sub2api 不显示具体模型版本，订阅方式可以正常显示，有什么问题吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-13T07:10:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4166",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4166",
+      "title": "grok 模型反代出来支持多模态么？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-13T07:58:30Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#418",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/418",
       "title": "调度问题，同一个api请求出现No available account错误，实际有相同优先级的账号空闲",
@@ -14691,6 +21517,26 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-06-17T05:09:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4183",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4183",
+      "title": "Sepay support",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-13T11:02:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4185",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4185",
+      "title": "codex下游客户端经常会卡住",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-14T05:36:07Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#419",
@@ -14703,6 +21549,26 @@
       "updated_at": "2026-01-29T07:18:52Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4194",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4194",
+      "title": "订阅类的返利逻辑和充值类的返利逻辑不一样",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-13T12:55:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4201",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4201",
+      "title": "偶尔首字很长时间",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-15T01:28:02Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#421",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/421",
       "title": "openai的codex反代后能在claudecode里面使用吗",
@@ -14711,6 +21577,26 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-04-15T07:38:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4224",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4224",
+      "title": "grok自定义base url报错：Invalid Grok base URL: invalid base url: host is not allowed",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-14T02:13:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4226",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4226",
+      "title": "gpt账号bug号用量窗口里不显示30天重置，只能显示5h和7day",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-14T02:33:55Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#423",
@@ -14723,6 +21609,66 @@
       "updated_at": "2026-01-29T11:59:22Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4230",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4230",
+      "title": "导入grok账号能测活有返回，通过apikey调用出先服务不可用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-14T03:13:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4234",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4234",
+      "title": "Codex 调用 GPT5.6 系统全模型，均无法使用工具？有人遇到这个问题吗？怎么解决的？ 5.5 正常使用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-15T07:01:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4235",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4235",
+      "title": "首字严重超时，有时候几分钟的都会，严重的要30+分钟，有人知道是什么原因吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-14T08:46:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4243",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4243",
+      "title": "Codex 客户端执行完命令 经常卡住 卡死 有遇到过的吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-14T09:54:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4248",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4248",
+      "title": "首字 15 分钟, 真的受不了,不接中转站就好了, 是不是最近有 Bug?",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-19T09:37:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4270",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4270",
+      "title": "Failed to read request body",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T01:16:28Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#431",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/431",
       "title": "能不能指定某个用户或者某个分组，他们的会话粘性呢？",
@@ -14733,6 +21679,26 @@
       "updated_at": "2026-01-30T06:31:11Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4312",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4312",
+      "title": "为 单个密钥添加 并发限制",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-15T02:14:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4318",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4318",
+      "title": "远程压缩失败，Service temporarily unavailable",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-15T06:21:45Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#433",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/433",
       "title": "可否添加模型映射功能",
@@ -14741,6 +21707,86 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-01-30T08:57:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4343",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4343",
+      "title": "频繁状态异常520",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-15T10:15:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4351",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4351",
+      "title": "OpenAI ChatGPT bug team停止调度 错误码401",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-15T09:34:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4352",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4352",
+      "title": "v0.1.155 频繁：Selected model is at capacity. Please try a different model.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-15T17:35:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4354",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4354",
+      "title": "OpenAI WebSocket 首消息超时支持配置",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-16T01:13:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4366",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4366",
+      "title": "v0.1.156 Codex桌面版错误拉取模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-15T12:29:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4390",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4390",
+      "title": "claude gateway",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-15T15:46:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4397",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4397",
+      "title": "分页能不能支持自定义多少的,导入2000多,每次删50太难受了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-16T01:56:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4398",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4398",
+      "title": "对于批量测活,能不能加个功能,一件验证是否可用,一件移除配置",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-15T17:35:22Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#441",
@@ -14773,6 +21819,96 @@
       "updated_at": "2026-02-01T18:24:00Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4437",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4437",
+      "title": "Security contact for private vulnerability reports",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-16T11:41:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4446",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4446",
+      "title": "[嵌套] Sub2API → Sub2API 流式无结束帧 / empty stream（stream=true 有 delta 无 message_stop）",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-16T14:40:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4452",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4452",
+      "title": "我的sub2api 登不上了,一登录进后台就秒过期退出登录",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-18T04:57:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4455",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4455",
+      "title": "X-OpenAI-Internal-Codex-Responses-Lite only supports function tools, custom tools, and client-executed tool search.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-17T00:25:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4456",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4456",
+      "title": "user is not active",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-16T19:49:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4482",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4482",
+      "title": "Archive",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T06:46:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4499",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4499",
+      "title": "bug：S3备份的2FA提示依然在，修复个蛋",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-20T01:39:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4501",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4501",
+      "title": "定时测试如果失败，应当暂停调度账号，直到定时测试回报成功",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-17T11:50:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4502",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4502",
+      "title": "系统设置 数据备份 保存s3数据捅有bug",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-17T13:13:54Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#451",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/451",
       "title": "Web GUI 显示的错误记录缺乏实用信息",
@@ -14783,6 +21919,246 @@
       "updated_at": "2026-02-02T10:23:11Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4511",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4511",
+      "title": "删除了一个用户，之前的版本没这样的错误",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-17T15:04:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4516",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4516",
+      "title": "升级0.1.160后总是出Selected model is at capacity. Please try a different model.「已解决」",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-27T14:40:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4521",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4521",
+      "title": "add kimi account option",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-20T12:40:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4525",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4525",
+      "title": "grok账号授权授权forbidden",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-18T02:26:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4529",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4529",
+      "title": "登录成功后，又恢复未登录状态",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-25T07:23:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4531",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4531",
+      "title": "stripe付款出现延迟",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-18T03:47:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4550",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4550",
+      "title": "测试连接时经常出现请求失败",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-20T08:08:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4563",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4563",
+      "title": "grok批量更新base url问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-18T18:29:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4564",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4564",
+      "title": "This operation requires two-factor authentication; please enable TOTP first",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-19T03:26:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4579",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4579",
+      "title": "增加Claude kiro的登录和反代渠道",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-19T11:05:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4596",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4596",
+      "title": "ip地址监测错误",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-20T07:27:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4627",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4627",
+      "title": "升级161版本后 接入上游每个模型都有时间调用限制",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-20T04:21:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4628",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4628",
+      "title": "2FA丢失后如何关闭",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-21T06:59:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4631",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4631",
+      "title": "订阅bug 月额度刷新了 为啥用户开的30天有效期还没到期",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-24T08:50:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4646",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4646",
+      "title": "GROK我才导入五千多个账号，长时间占用网络什么原因 都跑了差不多是3T了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-20T08:41:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4663",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4663",
+      "title": "ws 好像不会主动切换。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-20T14:47:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4688",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4688",
+      "title": "订阅倍率异常，突然某次请求暴涨到25217倍",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T06:02:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4714",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4714",
+      "title": "大佬，什么时候更新 充值赠送、还有对接上国产模型呢",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-22T04:45:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4728",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4728",
+      "title": "什么时候能支持‌Seedance‌的接入啊 需求很大。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-22T09:16:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4738",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4738",
+      "title": "更新后Grok直接账号都不可用了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-22T12:57:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4741",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4741",
+      "title": "为什么现在注册不了？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-23T00:53:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4746",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4746",
+      "title": "Agent Identity auth.json增加多账号批量导入",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-22T15:09:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4759",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4759",
+      "title": "为什么刚刚注册的grok账号导入1，出现403？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-24T15:08:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4762",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4762",
+      "title": "v0.1.163版本，使用5.6luna 自动切换到了5.6 terra",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-23T03:12:17Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#477",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/477",
       "title": "是否支持配额达到80%后，使用其他账号进行调度？",
@@ -14791,6 +22167,26 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-02-07T23:40:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4770",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4770",
+      "title": "[bug]会话已过期，请重新登录。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-27T06:36:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4771",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4771",
+      "title": "This model is not supported when using X-OpenAI-Internal-Codex-Responses-Lite. v0.1.163",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-23T03:53:11Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#478",
@@ -14813,6 +22209,56 @@
       "updated_at": "2026-04-29T02:39:38Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4805",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4805",
+      "title": "Claude中，Fable的50%限额支持",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-25T16:01:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4822",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4822",
+      "title": "gemini个人账户pro现在还可以反代么？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-04T05:45:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4824",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4824",
+      "title": "Grok Free似乎取消了Grok Build的访问权限，来自官方Grok Build的登录都无效",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-27T12:13:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4827",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4827",
+      "title": "使用记录API 密钥 搜索列表不全",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-24T10:24:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4833",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4833",
+      "title": "1",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-24T13:15:44Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#484",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/484",
       "title": "用量窗口不能刷新",
@@ -14821,6 +22267,86 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-02-07T02:20:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4853",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4853",
+      "title": "Claude Opus 5 支持 适配",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-25T09:15:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4862",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4862",
+      "title": "自定义探测提示词",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-25T10:22:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4865",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4865",
+      "title": "模型列表今天拉不下来",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-27T00:14:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4866",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4866",
+      "title": "gpt账号的 5h窗口用量刷新不出来了？7d的点击查询没有问题，5h的不行",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-25T14:17:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4882",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4882",
+      "title": "需求，管理员APIKEY 可以控制用户的APIKEY建立删除等功能；",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-07T02:58:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4885",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4885",
+      "title": "[严重bug]关于163版本以后有相关脚本植入扫描账号问题是否存在",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-28T04:19:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4886",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4886",
+      "title": "严重bug+1，这个中转站有后门，会创建一个隐藏管理员账户，第二是会攻击服务器拿到root权限，一直攻击",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-28T04:08:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4902",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4902",
+      "title": "为什么claude导入SUb，明明复制了授权码，也还是认证失败",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-26T08:33:55Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#491",
@@ -14833,6 +22359,176 @@
       "updated_at": "2026-05-01T09:14:05Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#4937",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4937",
+      "title": "部署sub2api服务是否需要配置前置的nginx服务",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-27T08:48:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4939",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4939",
+      "title": "[需求]平台能否增加订阅会员优惠倍率功能，当用户订阅相关会员之后消耗的倍率不再是手动配置",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-27T04:37:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4943",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4943",
+      "title": "为什么我用claude 来用grok，提示用的模型是claude-opus-5",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-28T03:26:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4951",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4951",
+      "title": "为什么不支持向量化模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-27T09:47:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4952",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4952",
+      "title": "提示词审计功能不可用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-12T09:14:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4963",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4963",
+      "title": "One settings field costs ten declaration sites across two languages",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-27T11:44:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4976",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4976",
+      "title": "Qwen3Guard 配置了，用不了啊",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-30T11:40:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4987",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4987",
+      "title": "凌晨被人登录新建了两个key, 带ctf开头，我的密码是通过1password随机生成的，账号和密码也没有分享过给任何人",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-29T06:31:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#4996",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/4996",
+      "title": "Inline QR payment success leaves /purchase for standalone result page",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-28T06:41:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5043",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5043",
+      "title": "管理员应该加入一个 auth.login 防止撞库 ，ip频繁限制的",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-29T09:39:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5052",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5052",
+      "title": "后续是否考虑横向扩展?想要在k8s上进行部署设置多副本",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-29T10:28:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5055",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5055",
+      "title": "<thinking> Content </thinking> 思考内容进入了正文",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-02T12:39:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5057",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5057",
+      "title": "会上模型融合功能吗，就是将几个便宜模型聚合或者说融合成一个虚拟模型，就是fusion功能",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-29T13:12:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5069",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5069",
+      "title": "能不能统一成一个api啊？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-04T02:31:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5083",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5083",
+      "title": "代理部分能加入更多的格式支持吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-30T06:25:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5087",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5087",
+      "title": "Codex + Grok订阅 no available accounts",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-30T10:17:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5096",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5096",
+      "title": "最近一直 Selected model is at capacity. Please try a different model",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-04T11:54:43Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#51",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/51",
       "title": "好 好 好",
@@ -14841,6 +22537,56 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2025-12-27T06:39:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5103",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5103",
+      "title": "隐私状态显示错误",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-31T10:05:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5107",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5107",
+      "title": "个别用户首字一直都是几十秒，是什么原因那。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-31T02:10:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5121",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5121",
+      "title": "antigraviy不支持接入gemini-3-flash-preview吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-07-31T03:10:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5139",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5139",
+      "title": "codex-auto-review 计价应该与5.6 luna相同",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-07T11:01:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5150",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5150",
+      "title": "[bug] 版本：v0.1.169 Codex对话经常出现：No tool output found for custom tool call call_DwreR3KjTVoogdGltUqjurzy.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-12T02:49:58Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#516",
@@ -14853,6 +22599,36 @@
       "updated_at": "2026-02-11T12:34:36Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#5162",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5162",
+      "title": "codex接opencode第一次成功的，第二次失败报错是为什么？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-03T19:43:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5180",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5180",
+      "title": "sub2api的调度异常：会出现当优先级1-5正常可用的情况在 调度优先级6",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-02T04:35:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5207",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5207",
+      "title": "想请问一下为什么没有批量重新配额功能？官方重置后我在后台一个个账号点重置。人有点麻..还是说哪里有功能一键重置我没找到呢？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-03T04:49:16Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#521",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/521",
       "title": "docker部署改密码一直提示错误，登录不进去",
@@ -14860,7 +22636,127 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-06-13T05:06:45Z"
+      "updated_at": "2026-08-15T13:49:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5212",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5212",
+      "title": "v170 订阅重置出现问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-03T16:33:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5213",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5213",
+      "title": "腾讯云搭建的http代理服务器，测试报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-03T04:22:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5238",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5238",
+      "title": "CC switch 快捷导入 默认模型 应更新为 gpt-5.6",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-03T14:37:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5246",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5246",
+      "title": "bug 怎么修复 一直报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-04T01:12:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5276",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5276",
+      "title": "cursor工具的，什么时候可以支持呀",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-05T00:30:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5291",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5291",
+      "title": "腾讯云环境-无法更新",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-06T06:28:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5294",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5294",
+      "title": "gpt5.5 任务不能一次性执行完，每次只返回一行数据",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-05T08:26:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5305",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5305",
+      "title": "REFUND_GATEWAY_FAILED 2026/8/5 20:22:28 {\"detail\":\"easypay refund failed (HTTP 200): 退款成功！退款金额¥10.00\"} 操作人: admin",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-05T12:29:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5306",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5306",
+      "title": "同一个url下面能否配置多个key",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-05T12:34:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5323",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5323",
+      "title": "[Bug] v0.1.171 只要是「同步」(非流式) 请求,网关就返回 HTTP 200 空响应",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-06T06:01:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5328",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5328",
+      "title": "gemini账号请求除了2.5flash和2.5pro别的都是404，套餐买的是google one ultra",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-06T07:18:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5332",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5332",
+      "title": "openai平台的模型 无法同步上游",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-06T09:46:08Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#534",
@@ -14891,6 +22787,16 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-02-10T00:22:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5377",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5377",
+      "title": "【BUG】最新版171，每日额度重置失效，手动重置后，显示24小时后重置",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-07T16:41:21Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#538",
@@ -14933,6 +22839,56 @@
       "updated_at": "2026-05-10T11:24:22Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#5427",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5427",
+      "title": "几时能分组国内大模型，不要全套入openai的，logo啥的完全不能专门显示。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-09T13:11:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5428",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5428",
+      "title": "几时gemini可以用上游的api接入？而不是官方api",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-08T14:28:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5436",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5436",
+      "title": "These two IPs have been attempting to log in using the bug before 172. Blacklist functionality is required",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-08T20:52:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5445",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5445",
+      "title": "能不能像new-api一样订阅不绑定分组",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-09T05:44:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5452",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5452",
+      "title": "能否新增订阅管理重置时间跟随账号重置不要固定00:00刷新",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-09T11:23:53Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#546",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/546",
       "title": "分组有问题",
@@ -14941,6 +22897,226 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-02-10T12:10:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5484",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5484",
+      "title": "grok 重置的时间显示有问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-10T05:04:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5496",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5496",
+      "title": "异步生视频对象存储",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-10T16:25:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5505",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5505",
+      "title": "grok的重置时间、用量显示有问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-11T08:06:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5512",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5512",
+      "title": "SMTP增加认证机制",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-11T04:31:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5516",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5516",
+      "title": "最近这段时间号池几乎全在Selected model is at capacity. Please try a different model",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T06:39:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5524",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5524",
+      "title": "模型广场 在 /home 默认不显示",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-11T08:39:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5536",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5536",
+      "title": "sub2api 配置 openai 转 deepseek,出现异常内容",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-12T07:44:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5546",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5546",
+      "title": "是否有商业版？如何联系",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T08:57:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5554",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5554",
+      "title": "更新的grok 各种bug了呢？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-12T10:04:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5556",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5556",
+      "title": "为什么使用sub2api登录的账号额度会特别低，正确使用codex的账号额度是正确的",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-15T07:41:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5576",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5576",
+      "title": "Deepseek v4系列response api不支持Max推理强度",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T12:32:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5577",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5577",
+      "title": "docker部署服务就是重启不了呀",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T03:26:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5584",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5584",
+      "title": "网关设置-平台账号自动停调阈值 误伤大量账号",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T06:12:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5592",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5592",
+      "title": "v0.1.176：openai gpt-5.6-sol：Our servers are currently overloaded. Please try again later.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-18T07:22:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5594",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5594",
+      "title": "grok号问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T08:29:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5596",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5596",
+      "title": "api密钥列表，能否增加一个消耗日榜",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T09:55:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5601",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5601",
+      "title": "Grok build 使用grok会报错：Couldn't read the response- serialization error:missing field ‘created_at’， Try sending again.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T12:18:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5603",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5603",
+      "title": "多轮对话后出现 The `content[].thinking` in the thinking mode must be passed back to the API.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T15:13:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5604",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5604",
+      "title": "是否能增加 “重置跟随”功能？（适用于拼车而非开站）",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-13T12:48:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5615",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5615",
+      "title": "无法\"设置隐私\" , 总是提示 \"关闭训练数据共享失败\"",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-14T00:15:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5619",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5619",
+      "title": "接入到 Cursor 使用的 GPT-5.6 Sol , 推理强度 不显示, 是正常的吗?",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-15T15:13:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5626",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5626",
+      "title": "更新后，ccswitch测试延迟会变长老版本不会",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-15T07:37:48Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#563",
@@ -14953,6 +23129,26 @@
       "updated_at": "2026-02-25T08:57:29Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#5630",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5630",
+      "title": "用openai 的Pro 20x账号作为上游有封禁风险吗，有规避风险的办法吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-18T09:59:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5646",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5646",
+      "title": "grok多个账号用量与剩余额度不一致",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-14T13:23:58Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#565",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/565",
       "title": "能否像CRS1 一样能够查询缓存的创建和读取的具体数据",
@@ -14961,6 +23157,26 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-02-12T04:42:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5660",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5660",
+      "title": "【需求】模型映射支持正则表达式提取",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-15T02:09:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5663",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5663",
+      "title": "为什么两个PRO账号，额度到达100% 为什么差距这么大的？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-18T04:41:08Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#568",
@@ -14973,6 +23189,116 @@
       "updated_at": "2026-02-12T19:11:40Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#5680",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5680",
+      "title": "有roadmap吗 我发现我刚做的功能 你们这边就更新了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-15T14:50:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5689",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5689",
+      "title": "已经使用的兑换码不支持删除吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-16T05:46:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5704",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5704",
+      "title": "codex设置100万上下文之后没有生效，不确定是不是这个服务的问题？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-17T07:40:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5706",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5706",
+      "title": "gemini 这两天经常提示重新登录授权",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-17T02:08:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5713",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5713",
+      "title": "feat: 支持高峰低峰时段价格",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-17T16:48:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5723",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5723",
+      "title": "grok出现 Couldn't read the response — serialization error: missing field `created_at`. Try sending again.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-17T06:38:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5724",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5724",
+      "title": "上游响应,模型不一致,你们有遇到吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-17T08:29:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5731",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5731",
+      "title": "每天下午三点开始，首字就变得特别长",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-17T12:56:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5740",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5740",
+      "title": "cursor订阅可以分发吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-18T05:31:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5741",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5741",
+      "title": "模型广场找不到配置",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-17T19:57:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5747",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5747",
+      "title": "现在配额不稳定，按配额分配可以按实际额度分配吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-17T18:00:06Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#575",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/575",
       "title": "请问openai通道接入sub2api后如何接入newapi呀",
@@ -14980,7 +23306,127 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-03-04T19:32:22Z"
+      "updated_at": "2026-07-28T10:23:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5753",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5753",
+      "title": "有接近一半的概率模型没有缓存命中，导致请求消耗十倍以上额度。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-18T08:07:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5756",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5756",
+      "title": "大家20x 额度都正常了吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T08:18:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5766",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5766",
+      "title": "是否有峰谷计价功能",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-18T08:23:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5775",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5775",
+      "title": "版本太老是不是会导致封号？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T06:33:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5784",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5784",
+      "title": "生成key的时候能像newapi一样支持anthropic和openai协议吗。现在只要分组是openai协议、对应的key就只支持openai不支持anthropic协议，需要自己转换才行",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-18T14:19:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5788",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5788",
+      "title": "where people get cheap kimi and glm accounts ?",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-18T14:53:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5795",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5795",
+      "title": "zcode里使用sub2分发出来的key，能享受150%的配额吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T01:28:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5797",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5797",
+      "title": "需求请求：按照接口协议创建分组；",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T02:18:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5798",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5798",
+      "title": "178版本的pro 20额度新开账户仅有500刀额度",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T04:09:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5799",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5799",
+      "title": "订阅可不可以定 CNY 和HKD 或者USD 的价格，这样支付的时候不需要货币转换",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T02:21:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5804",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5804",
+      "title": "warp 不能使用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T03:00:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5805",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5805",
+      "title": "更新报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T03:08:33Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#581",
@@ -14991,6 +23437,196 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-02-14T12:31:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5812",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5812",
+      "title": "bug: thinking内容进入正文，并且工具调用出错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T05:44:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5814",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5814",
+      "title": "有考虑做http -> sub2api - ws -> openAI 这种桥接模式吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T08:29:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5821",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5821",
+      "title": "178 版本频繁遇到prompt_cache_retention is not supported on this model",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T09:33:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5825",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5825",
+      "title": "sub2api后如何接入newapi呀",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T08:29:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5827",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5827",
+      "title": "our servers are currently overloaded. Please try again later Selected model is at capacity. Please try a different model.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T11:31:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5828",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5828",
+      "title": "1.78版本频繁遇到重新连接和服务器过载的问题，有佬知道怎么解决吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T09:49:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5841",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5841",
+      "title": "opencode go能加进去不，我现在都是走的codex的api",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T09:50:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5852",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5852",
+      "title": "对于OpenAI上游的传输的服务过载和模型阻塞应该做些处理",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T11:32:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5853",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5853",
+      "title": "管理员密码是多少",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T14:55:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5854",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5854",
+      "title": "freebuff support",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T14:59:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5862",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5862",
+      "title": "bug(openai): group model_routing is accepted but ignored by OpenAI schedulers",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-19T17:34:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5869",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5869",
+      "title": "到期日期不同步不更新",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T00:21:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5870",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5870",
+      "title": "composite协议分组能否支持deepseek等国产模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T08:14:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5871",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5871",
+      "title": "不支持原生 mcp 格式的调用吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T01:40:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5879",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5879",
+      "title": "有没有可能加入 cursor to api 的功能，现在 Superhavey 带 cursor ultra 了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T03:40:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5887",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5887",
+      "title": "如何设置按7天重置窗口优先调度，现在没有5h限制，我只有两个账号，设置了好像也不好使 还是会来回调度",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T08:17:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5896",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5896",
+      "title": "依然存在DeepSeek（异常）：未返回 DeepSeek，返回了 Claude 系列",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T08:51:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5904",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5904",
+      "title": "DeepSeek用中转站的情况下，余额为0就会自动暂停调度，请各位大佬指点是我哪里设置问题吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T12:12:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#5916",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/5916",
+      "title": "请求添加 【上游为池时可关闭粘性调度】 功能",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-08-20T11:13:26Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#595",
@@ -15240,7 +23876,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-03-11T06:56:55Z"
+      "updated_at": "2026-07-30T09:07:36Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#722",
@@ -15360,7 +23996,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-17T02:46:12Z"
+      "updated_at": "2026-07-30T09:05:53Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#81",
@@ -15470,7 +24106,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-03-10T08:35:36Z"
+      "updated_at": "2026-06-30T08:15:04Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#914",


### PR DESCRIPTION
## Summary
- Refresh `.cache/upstream/triage.json` from the latest Wei-Shaw/sub2api issues.
- Update `.cache/upstream/fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Upstream Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/32374089906
- Repository SHA: `a915977bbba1903a361c1f5160bbc21796e1d932`
- Generated at: `2026-08-20T13:26:40Z`
- Upstream issues scanned: `3047`
- Fact checks: `39`
- Fixed facts verified: `24`
- High/critical unresolved: `0`

## Fixed facts verified

- Wei-Shaw/sub2api#641 via None
- Wei-Shaw/sub2api#2107 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2159 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2258 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2478 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2515 via None
- Wei-Shaw/sub2api#2500 via None
- Wei-Shaw/sub2api#1311 via None
- Wei-Shaw/sub2api#2363 via None
- Wei-Shaw/sub2api#2538 via None
- Wei-Shaw/sub2api#2539 via None
- Wei-Shaw/sub2api#2556 via None
- Wei-Shaw/sub2api#1170 via None
- Wei-Shaw/sub2api#1322 via None
- Wei-Shaw/sub2api#1824 via None
- Wei-Shaw/sub2api#1946 via None
- Wei-Shaw/sub2api#2608 via None
- Wei-Shaw/sub2api#1981 via None
- Wei-Shaw/sub2api#1326 via youxuanxue/sub2api (branch: fix/edge-real-client-ip)
- Wei-Shaw/sub2api#2245 via None
- Wei-Shaw/sub2api#2232 via None
- Wei-Shaw/sub2api#2413 via None
- Wei-Shaw/sub2api#3285 via None
- Wei-Shaw/sub2api#3158 via None

## Fact checks missing

- Wei-Shaw/sub2api#2332: backend/internal/service/gateway_service.go:if v := deltaUsage.Get("input_tokens").Int(); v > 0 {
- Wei-Shaw/sub2api#2506: backend/internal/service/gateway_service.go:See upstream Wei-Shaw/sub2api#2506, backend/internal/service/gateway_service.go:!strings.Contains(strings.ToLower(modelID), "haiku")
- Wei-Shaw/sub2api#2486: backend/internal/service/billing_service.go:Wei-Shaw/sub2api#2486
- Wei-Shaw/sub2api#2332: backend/internal/service/gateway_service.go:Wei-Shaw/sub2api#2332 hardening
- Wei-Shaw/sub2api#1471: backend/internal/service/openai_gateway_service.go:TK fix for upstream Wei-Shaw/sub2api#1471, backend/internal/service/openai_gateway_service.go:bufferedWriter.WriteString("\ndata: " + payload + "\n\n")
- Wei-Shaw/sub2api#2298: backend/internal/service/openai_gateway_service.go:TK fix for upstream Wei-Shaw/sub2api#2298
- Wei-Shaw/sub2api#1264: backend/internal/service/openai_gateway_service.go:Wei-Shaw/sub2api#1264, backend/internal/service/openai_gateway_service.go:"prompt_cache_retention", "safety_identifier", "user"
- Wei-Shaw/sub2api#1318: backend/internal/service/openai_gateway_service.go:upstream Wei-Shaw/sub2api#1318, backend/internal/service/openai_gateway_service.go:shouldDisable := s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, body
- Wei-Shaw/sub2api#1934: backend/internal/service/openai_gateway_service.go:openaiStickyAccountStillInGroup(account, *groupID), backend/internal/service/openai_account_scheduler.go:openaiStickyAccountStillInGroup(account, *req.GroupID)
- Wei-Shaw/sub2api#2013: backend/internal/service/gateway_service.go:topLevelCacheControl := gjson.GetBytes(out, "cache_control").Exists()
- Wei-Shaw/sub2api#1833: backend/internal/service/gateway_service.go:logTokenCostPricingMissing(billingModel, apiKey, result, err)
- Wei-Shaw/sub2api#2727: backend/internal/service/openai_gateway_service.go:s.tkApplyImplicitThrottleCooldown(ctx, account, resp.StatusCode)
- Wei-Shaw/sub2api#1723: backend/internal/repository/scheduler_cache.go:去掉了完整账号键的整段读 + 写放大, backend/internal/repository/scheduler_cache.go:schedulerAccountMetaKey(strconv.FormatInt(id, 10))
- Wei-Shaw/sub2api#3014: backend/internal/service/openai_gateway_service.go:func (s *OpenAIGatewayService) enforceCodexClientRestriction(ctx context.Context, c *gin.Context, account *Account, body []byte) error {, backend/internal/handler/openai_gateway_handler.go:if service.HasOpsClientBusinessLimited(c) {
- Wei-Shaw/sub2api#3025: backend/internal/service/openai_gateway_service.go:result.Used5hPercent = s.PrimaryUsedPercent, backend/internal/service/openai_gateway_service.go:result.Used5hPercent = s.SecondaryUsedPercent, backend/internal/service/openai_gateway_service.go:Do NOT reintroduce a 100-raw inversion


## Test plan
- [x] `python3 -m json.tool .cache/upstream/triage.json`
- [x] `python3 -m json.tool .cache/upstream/fixes.json`
- [x] `python3 -m json.tool .cache/upstream/fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream/issue-watchdog.py`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/agent-input.json`
