### PR TITLE
fix(studio): BakeOff 本地历史、下载提醒与全能 Key gemini 图片路由

### DIFF
--- a/backend/internal/service/universal_routing_tk_endpoint_map.go
+++ b/backend/internal/service/universal_routing_tk_endpoint_map.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Wei-Shaw/sub2api/internal/engine"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
 )
 
 // Universal Key（全能 Key）端点形状映射。
@@ -76,7 +77,7 @@ func UniversalShapeForRequest(fullPath, method string) UniversalShape {
 //     从 engine.capability 派生；anthropic/gemini 原生形状用原生平台常量。
 //   - hasMessagesDispatch：跨度内存在开了 messages-dispatch 的组时，/v1/messages
 //     才把 openai-compat 平台并入候选（用 Claude 名映射到 GPT 的场景）。
-func universalCandidatePlatforms(shape UniversalShape, forcedPlatform string, hasMessagesDispatch bool) []string {
+func universalCandidatePlatforms(shape UniversalShape, forcedPlatform string, hasMessagesDispatch bool, model string) []string {
 	if forcedPlatform != "" {
 		return []string{forcedPlatform}
 	}
@@ -90,7 +91,16 @@ func universalCandidatePlatforms(shape UniversalShape, forcedPlatform string, ha
 	case ShapeAnthropicCountTokens:
 		return []string{PlatformAnthropic, PlatformAntigravity}
 	case ShapeOpenAIChat:
-		return OpenAICompatPlatforms()
+		out := OpenAICompatPlatforms()
+		// Gemini-native image models (gemini-*-image, nano-banana) ride
+		// /v1/chat/completions but are served by the antigravity pool — not
+		// openai-compat. Without antigravity in candidates, universal keys
+		// land on openai/Codex and upstream rejects with "not supported when
+		// using Codex with a ChatGPT account".
+		if antigravity.IsImageModel(model) {
+			out = append(out, PlatformAntigravity)
+		}
+		return out
 	case ShapeOpenAIEmbeddings:
 		return capabilityPlatforms(engine.BridgeEndpointEmbeddings)
 	case ShapeOpenAIImages:
@@ -129,6 +139,9 @@ func universalModelPlatformHint(model string) string {
 		return PlatformAnthropic
 	case strings.HasPrefix(m, "grok"):
 		return PlatformGrok
+	case antigravity.IsImageModel(m):
+		// Served via antigravity generateContent, not gemini-platform / openai-compat.
+		return PlatformAntigravity
 	case strings.HasPrefix(m, "gemini"), strings.HasPrefix(m, "imagen"), strings.HasPrefix(m, "veo"):
 		return PlatformGemini
 	case strings.HasPrefix(m, "gpt"), strings.HasPrefix(m, "o1"), strings.HasPrefix(m, "o3"),

--- a/backend/internal/service/universal_routing_tk_resolver.go
+++ b/backend/internal/service/universal_routing_tk_resolver.go
@@ -98,7 +98,7 @@ func (r *UniversalRoutingResolver) Resolve(ctx context.Context, apiKey *APIKey, 
 		return nil, err
 	}
 
-	candidates := universalCandidatePlatforms(shape, forcedPlatform, spanHasMessagesDispatch(span))
+	candidates := universalCandidatePlatforms(shape, forcedPlatform, spanHasMessagesDispatch(span), model)
 	if len(candidates) == 0 {
 		return nil, ErrUniversalNoEntitledGroup
 	}

--- a/backend/internal/service/universal_routing_tk_resolver_test.go
+++ b/backend/internal/service/universal_routing_tk_resolver_test.go
@@ -91,34 +91,39 @@ func TestUniversalCandidatePlatforms(t *testing.T) {
 	}
 
 	// forced platform wins regardless of shape.
-	if got := universalCandidatePlatforms(ShapeOpenAIChat, PlatformAntigravity, false); len(got) != 1 || got[0] != PlatformAntigravity {
+	if got := universalCandidatePlatforms(ShapeOpenAIChat, PlatformAntigravity, false, ""); len(got) != 1 || got[0] != PlatformAntigravity {
 		t.Errorf("forced platform should win: %v", got)
 	}
 
 	// anthropic messages: native pair, no openai-compat unless a dispatch group exists.
-	base := universalCandidatePlatforms(ShapeAnthropicMessages, "", false)
+	base := universalCandidatePlatforms(ShapeAnthropicMessages, "", false, "")
 	if !contains(base, PlatformAnthropic) || !contains(base, PlatformAntigravity) || contains(base, PlatformOpenAI) {
 		t.Errorf("messages base candidates wrong: %v", base)
 	}
-	withDispatch := universalCandidatePlatforms(ShapeAnthropicMessages, "", true)
+	withDispatch := universalCandidatePlatforms(ShapeAnthropicMessages, "", true, "")
 	if !contains(withDispatch, PlatformOpenAI) {
 		t.Errorf("messages with dispatch should include openai-compat: %v", withDispatch)
 	}
 
 	// count_tokens never includes openai-compat.
-	ct := universalCandidatePlatforms(ShapeAnthropicCountTokens, "", true)
+	ct := universalCandidatePlatforms(ShapeAnthropicCountTokens, "", true, "")
 	if contains(ct, PlatformOpenAI) || contains(ct, PlatformNewAPI) {
 		t.Errorf("count_tokens must stay anthropic/antigravity: %v", ct)
 	}
 
 	// chat = OpenAI-compat pool (includes grok).
-	chat := universalCandidatePlatforms(ShapeOpenAIChat, "", false)
+	chat := universalCandidatePlatforms(ShapeOpenAIChat, "", false, "")
 	if !contains(chat, PlatformOpenAI) || !contains(chat, PlatformNewAPI) || !contains(chat, PlatformGrok) {
 		t.Errorf("chat candidates should be openai-compat pool: %v", chat)
 	}
+	// gemini-native image on chat completions also includes antigravity.
+	chatImage := universalCandidatePlatforms(ShapeOpenAIChat, "", false, "gemini-3.1-flash-image")
+	if !contains(chatImage, PlatformAntigravity) {
+		t.Errorf("gemini-native image chat should include antigravity: %v", chatImage)
+	}
 
 	// gemini native pair.
-	gem := universalCandidatePlatforms(ShapeGemini, "", false)
+	gem := universalCandidatePlatforms(ShapeGemini, "", false, "")
 	if !contains(gem, PlatformGemini) || !contains(gem, PlatformAntigravity) {
 		t.Errorf("gemini candidates wrong: %v", gem)
 	}
@@ -131,6 +136,7 @@ func TestUniversalModelPlatformHint(t *testing.T) {
 		"gpt-5":                  PlatformOpenAI,
 		"o3-mini":                PlatformOpenAI,
 		"gemini-3-pro":           PlatformGemini,
+		"gemini-3.1-flash-image": PlatformAntigravity,
 		"doubao-seedream-4":      PlatformNewAPI,
 		"deepseek-chat":          PlatformNewAPI,
 		"some-unknown-model-xyz": "",

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -69,6 +69,23 @@ func TestResolve_NativeEmptyMappingDoesNotMatchOtherVendor(t *testing.T) {
 	}
 }
 
+// gemini-native image on /v1/chat/completions 必须落 antigravity 组,不能撞 openai/Codex。
+func TestResolve_GeminiNativeImageChatPicksAntigravity(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(2, PlatformOpenAI, 5, false),
+		grp(9, PlatformAntigravity, 10, false),
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		9: {"gemini-3.1-flash-image", "claude-sonnet-4-6"},
+	}))
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIChat, "gemini-3.1-flash-image", "")
+	if err != nil || g == nil || g.ID != 9 {
+		t.Fatalf("gemini-native image chat 应落 antigravity gid=9, got=%v err=%v", g, err)
+	}
+}
+
 // imagen 走 newapi google-vertex 组(显式声明),不落 openai 组。
 func TestResolve_ImagenPicksVertexNewapiGroup(t *testing.T) {
 	ctx := context.Background()

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 525,
-  "hash": "a8b0fa84beb6ac9a50a58bafd28534fe3359d966f5d7eb329ead5352760238d1",
+  "file_count": 529,
+  "hash": "739816f0d8eeb0597ddb93d730714c8297cf99188f97ae23187f8027727906ac",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -142,7 +142,8 @@ export default {
     viewPricing: 'See pricing',
     via: 'via {vendor}',
     keyNoModality: 'no models for this mode',
-    saveReminder: 'Results stay in this browser for about 7 days — download now; clearing cache or switching devices will lose them.',
+    saveReminderTitle: 'Download your results now',
+    saveReminder: 'Stored only in this browser (~7 days). Clearing cache, private mode, or switching devices removes previews — download files to keep them.',
     universalKeyBadge: 'Universal key',
     playback: {
       inlineLocal: 'Local cache · preview survives reload (~7 days)',
@@ -176,10 +177,16 @@ export default {
       pickModels: 'Compare:',
       run: 'Generate across {count}',
       running: 'Generating…',
+      regenerate: 'Regenerate',
+      regenerateChanged: 'Generate with new prompt',
+      clearResults: 'Clear current view',
+      historyTitle: 'Past comparisons',
+      maxModelsHint: 'Compare up to {max} models at once — deselect one to add another.',
       totalCost: 'Total ≈ {cost}',
       cannotAfford: 'Balance too low for this run.',
       generating: 'Generating…',
-      failed: 'Failed'
+      failed: 'Failed',
+      panelError: 'Generation failed'
     },
     cost: {
       thisGeneration: 'This generation',
@@ -194,6 +201,7 @@ export default {
       unpriced: 'This model is not available for generation right now.',
       rate_limited: 'Too many requests — slow down and try again shortly.',
       unauthorized: 'Your API key is invalid or expired.',
+      unsupported_model: 'This key/group cannot serve that model — switch keys or deselect it.',
       generic: 'Generation failed. Please try again.'
     },
     image: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -140,7 +140,8 @@ export default {
     viewPricing: '查看价格',
     via: '经 {vendor}',
     keyNoModality: '此模式无可用模型',
-    saveReminder: '生成结果保存在本机浏览器（约 7 天），仍请立即下载；清缓存或换设备后会丢失。',
+    saveReminderTitle: '请立即下载保存',
+    saveReminder: '生成结果只存在本机浏览器（约 7 天）。清缓存、无痕模式或换设备后预览会丢失——请下载到本地留存。',
     universalKeyBadge: '全能 Key',
     playback: {
       inlineLocal: '本机缓存 · 刷新后仍可预览（约 7 天）',
@@ -174,10 +175,16 @@ export default {
       pickModels: '对比：',
       run: '同台生成 {count} 个',
       running: '生成中…',
+      regenerate: '重新生成',
+      regenerateChanged: '用新 prompt 生成',
+      clearResults: '清空当前展示',
+      historyTitle: '历史对比',
+      maxModelsHint: '最多同时对比 {max} 个模型，取消一个后可再选。',
       totalCost: '合计 ≈ {cost}',
       cannotAfford: '余额不足以跑这次对比。',
       generating: '生成中…',
-      failed: '失败'
+      failed: '失败',
+      panelError: '生成失败'
     },
     cost: {
       thisGeneration: '本次生成',
@@ -192,6 +199,7 @@ export default {
       unpriced: '该模型当前不可用于生成。',
       rate_limited: '请求过于频繁，请稍后再试。',
       unauthorized: 'API 密钥无效或已过期。',
+      unsupported_model: '当前密钥/分组不支持该模型，请换分组密钥或取消勾选该模型。',
       generic: '生成失败，请重试。'
     },
     image: {

--- a/frontend/src/utils/__tests__/studioGatewayError.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioGatewayError.tk.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { classifyGatewayError, parseGatewayErrorMessage } from '@/utils/studioGatewayError.tk'
+
+describe('studioGatewayError', () => {
+  it('parses JSON gateway error bodies', () => {
+    const raw =
+      '{"message":"The \'gemini-3.1-flash-image\' model is not supported when using Codex with a ChatGPT account.","type":"invalid_request_error"}'
+    expect(parseGatewayErrorMessage(raw)).toBe(
+      "The 'gemini-3.1-flash-image' model is not supported when using Codex with a ChatGPT account."
+    )
+    expect(classifyGatewayError(parseGatewayErrorMessage(raw))).toBe('unsupported_model')
+  })
+})

--- a/frontend/src/utils/__tests__/studioMedia.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioMedia.tk.spec.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { videoPlaybackUrl, videoTaskPlaybackAvailable } from '../studioMedia.tk'
+import {
+  groupImageHistoryByTs,
+  groupVideoHistoryByBatch,
+  imageHistoryItemAvailable,
+  shouldShowStudioSaveReminder,
+  videoPlaybackUrl,
+  videoTaskPlaybackAvailable,
+} from '../studioMedia.tk'
+import type { ImageHistoryItem, VideoTaskItem } from '@/composables/useMediaLibrary'
 
 // jsdom does not implement URL.createObjectURL / revokeObjectURL, so we define them
 // per-test and restore after. (videoPlaybackUrl falls back to the original src when
@@ -28,6 +36,64 @@ describe('videoTaskPlaybackAvailable', () => {
         urlExpired: false,
       })
     ).toBe(true)
+  })
+})
+
+describe('groupImageHistoryByTs', () => {
+  it('groups multi-model batches and skips single-image rows', () => {
+    const img = (ts: number, model: string): ImageHistoryItem => ({
+      id: `${ts}-${model}`,
+      src: 'https://cdn.example/x.png',
+      prompt: 'p',
+      model,
+      vendorLabel: 'V',
+      size: '1:1',
+      cost: 0.1,
+      ts,
+    })
+    const runs = groupImageHistoryByTs([img(1, 'a'), img(1, 'b'), img(2, 'solo')])
+    expect(runs).toHaveLength(1)
+    expect(runs[0].items).toHaveLength(2)
+  })
+})
+
+describe('groupVideoHistoryByBatch', () => {
+  it('groups tasks with the same submittedAtMs', () => {
+    const task = (ms: number, model: string): VideoTaskItem => ({
+      id: `${ms}-${model}`,
+      prompt: 'clip',
+      model,
+      vendorLabel: 'V',
+      seconds: 8,
+      estCost: 1,
+      keyId: 1,
+      state: 'succeeded',
+      url: '',
+      submittedAtMs: ms,
+      elapsedS: 0,
+    })
+    const runs = groupVideoHistoryByBatch([task(100, 'veo-a'), task(100, 'veo-b'), task(200, 'solo')])
+    expect(runs).toHaveLength(1)
+    expect(runs[0].items).toHaveLength(2)
+  })
+})
+
+describe('imageHistoryItemAvailable', () => {
+  it('is false when src is empty after reload', () => {
+    expect(imageHistoryItemAvailable({ src: '' })).toBe(false)
+    expect(imageHistoryItemAvailable({ src: '   ' })).toBe(false)
+  })
+
+  it('is true when src is present', () => {
+    expect(imageHistoryItemAvailable({ src: 'https://cdn.example/x.png' })).toBe(true)
+  })
+})
+
+describe('shouldShowStudioSaveReminder', () => {
+  it('shows when library or active panels have content', () => {
+    expect(shouldShowStudioSaveReminder({ imageCount: 0, videoTaskCount: 0, activeResultCount: 0 })).toBe(false)
+    expect(shouldShowStudioSaveReminder({ imageCount: 1, videoTaskCount: 0 })).toBe(true)
+    expect(shouldShowStudioSaveReminder({ imageCount: 0, videoTaskCount: 0, activeResultCount: 2 })).toBe(true)
   })
 })
 

--- a/frontend/src/utils/__tests__/studioPlaybackStorage.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioPlaybackStorage.tk.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { classifyVideoUrlStorage } from '../studioPlaybackStorage.tk'
+import { classifyVideoUrlStorage, videoTaskPlaybackStorageKind } from '../studioPlaybackStorage.tk'
 
 describe('classifyVideoUrlStorage', () => {
   it('marks inline data:video as local-cacheable', () => {
@@ -12,5 +12,15 @@ describe('classifyVideoUrlStorage', () => {
 
   it('marks http url as unknown until probed', () => {
     expect(classifyVideoUrlStorage('https://cdn.example/v.mp4')).toBe('unknown')
+  })
+})
+
+describe('videoTaskPlaybackStorageKind', () => {
+  it('derives expired when url is stripped', () => {
+    expect(videoTaskPlaybackStorageKind({ url: '', urlExpired: true })).toBe('expired')
+  })
+
+  it('prefers persisted playbackStorage', () => {
+    expect(videoTaskPlaybackStorageKind({ url: 'https://x/v.mp4', playbackStorage: 'inline-local' })).toBe('inline-local')
   })
 })

--- a/frontend/src/utils/studioGatewayError.tk.ts
+++ b/frontend/src/utils/studioGatewayError.tk.ts
@@ -18,7 +18,23 @@ export type StudioErrorCode =
   | 'unpriced'
   | 'rate_limited'
   | 'unauthorized'
+  | 'unsupported_model'
   | 'generic'
+
+/** Pull a human-readable message from gatewayRequestJSON's stringified error. */
+export function parseGatewayErrorMessage(raw: string | undefined | null): string {
+  const text = (raw || '').trim()
+  if (!text) return ''
+  try {
+    const parsed = JSON.parse(text) as { message?: unknown }
+    if (typeof parsed.message === 'string' && parsed.message.trim()) {
+      return parsed.message.trim()
+    }
+  } catch {
+    /* not JSON — use raw text */
+  }
+  return text
+}
 
 export function classifyGatewayError(message: string | undefined | null): StudioErrorCode {
   const m = (message || '').toLowerCase()
@@ -28,6 +44,13 @@ export function classifyGatewayError(message: string | undefined | null): Studio
   if (m.includes('permission') || m.includes('not allowed') || m.includes('forbidden')) return 'permission'
   if (m.includes('not yet priced') || m.includes('unpriced') || m.includes('not priced')) return 'unpriced'
   if (m.includes('429') || m.includes('rate limit') || m.includes('too many requests')) return 'rate_limited'
+  if (
+    m.includes('not supported when using codex') ||
+    m.includes('not supported with a chatgpt account') ||
+    (m.includes('invalid_request_error') && m.includes('not supported'))
+  ) {
+    return 'unsupported_model'
+  }
   return 'generic'
 }
 

--- a/frontend/src/utils/studioMedia.tk.ts
+++ b/frontend/src/utils/studioMedia.tk.ts
@@ -12,11 +12,69 @@
  * decode error) it falls back to the original src with a no-op revoke, so a caller
  * always gets something usable to hand to a <video :src>.
  */
-import type { VideoTaskItem } from '@/composables/useMediaLibrary'
+import type { ImageHistoryItem, VideoTaskItem } from '@/composables/useMediaLibrary'
+
+/** i18n key for image thumbnails that lost their in-browser bytes after reload. */
+export const STUDIO_IMAGE_EXPIRED_I18N_KEY = 'studio.image.expiredReload' as const
+
+/** True when an image history row still has a renderable thumbnail in this tab. */
+export function imageHistoryItemAvailable(img: Pick<ImageHistoryItem, 'src'>): boolean {
+  return !!img.src?.trim()
+}
 
 /** True when the task card may offer in-page playback (same session, non-expired url). */
 export function videoTaskPlaybackAvailable(task: Pick<VideoTaskItem, 'state' | 'url' | 'urlExpired'>): boolean {
   return task.state === 'succeeded' && !!task.url && !task.urlExpired
+}
+
+/** When any Studio surface should show the local-save download banner. */
+export function shouldShowStudioSaveReminder(opts: {
+  imageCount: number
+  videoTaskCount: number
+  /** In-tab panels or in-flight jobs not yet counted in library rows. */
+  activeResultCount?: number
+}): boolean {
+  return opts.imageCount > 0 || opts.videoTaskCount > 0 || (opts.activeResultCount ?? 0) > 0
+}
+
+export interface ImageHistoryRun {
+  ts: number
+  prompt: string
+  items: ImageHistoryItem[]
+}
+
+/** Group image history rows that share a generation batch (`ts`). Bake-Off and multi-`n` Image runs use the same field. */
+export function groupImageHistoryByTs(images: readonly ImageHistoryItem[], minItems = 2): ImageHistoryRun[] {
+  const byTs = new Map<number, ImageHistoryItem[]>()
+  for (const img of images) {
+    const list = byTs.get(img.ts) ?? []
+    list.push(img)
+    byTs.set(img.ts, list)
+  }
+  return [...byTs.entries()]
+    .filter(([, items]) => items.length >= minItems)
+    .sort((a, b) => b[0] - a[0])
+    .map(([ts, items]) => ({ ts, prompt: items[0]?.prompt ?? '', items }))
+}
+
+export interface VideoHistoryRun {
+  batchMs: number
+  prompt: string
+  items: VideoTaskItem[]
+}
+
+/** Group video tasks submitted in the same Bake-Off batch (`submittedAtMs`). */
+export function groupVideoHistoryByBatch(tasks: readonly VideoTaskItem[], minItems = 2): VideoHistoryRun[] {
+  const byBatch = new Map<number, VideoTaskItem[]>()
+  for (const task of tasks) {
+    const list = byBatch.get(task.submittedAtMs) ?? []
+    list.push(task)
+    byBatch.set(task.submittedAtMs, list)
+  }
+  return [...byBatch.entries()]
+    .filter(([, items]) => items.length >= minItems)
+    .sort((a, b) => b[0] - a[0])
+    .map(([batchMs, items]) => ({ batchMs, prompt: items[0]?.prompt ?? '', items }))
 }
 
 export interface VideoPlayback {

--- a/frontend/src/utils/studioPlaybackStorage.tk.ts
+++ b/frontend/src/utils/studioPlaybackStorage.tk.ts
@@ -1,3 +1,5 @@
+import type { VideoTaskItem } from '@/composables/useMediaLibrary'
+
 /**
  * TokenKey-only: classify how a generated video can be replayed / cached in-browser.
  * Surfaces honest labels in Studio so ops/users can tell CORS-blocked upstream URLs
@@ -59,5 +61,28 @@ export function studioPlaybackStorageI18nKey(storage: StudioPlaybackStorage | un
       return 'studio.playback.expired'
     default:
       return 'studio.playback.unknown'
+  }
+}
+
+/** Resolve persisted or derived playback-storage kind for a video task row. */
+export function videoTaskPlaybackStorageKind(
+  task: Pick<VideoTaskItem, 'playbackStorage' | 'urlExpired' | 'url'>
+): StudioPlaybackStorage {
+  return task.playbackStorage ?? (task.urlExpired || !task.url ? 'expired' : 'unknown')
+}
+
+/** Tailwind classes for the honest playback-source badge (Image / Video / Bake-Off). */
+export function studioPlaybackBadgeClass(storage: StudioPlaybackStorage): string {
+  switch (storage) {
+    case 'inline-local':
+      return 'bg-green-50 text-green-800 dark:bg-green-950/40 dark:text-green-200'
+    case 'upstream-cors-ok':
+      return 'bg-blue-50 text-blue-800 dark:bg-blue-950/40 dark:text-blue-200'
+    case 'upstream-cors-blocked':
+      return 'bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-100'
+    case 'expired':
+      return 'bg-gray-100 text-gray-600 dark:bg-dark-800 dark:text-dark-300'
+    default:
+      return 'bg-gray-50 text-gray-500 dark:bg-dark-800 dark:text-dark-400'
   }
 }

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -55,6 +55,13 @@
             {{ r.model.displayName }}
             <span class="opacity-70">{{ modality === 'image' ? formatUsd(r.baseImagePrice || 0) + t('studio.image.perImageUnit') : formatUsd(r.perSecond || 0) + t('studio.video.perSecondUnit') }}</span>
           </button>
+          <p
+            v-if="selectedModelIds.length >= MAX_PANELS && models.length > MAX_PANELS"
+            class="w-full text-[11px] text-amber-700 dark:text-amber-300"
+            data-testid="bakeoff-max-models-hint"
+          >
+            {{ t('studio.bakeoff.maxModelsHint', { max: MAX_PANELS }) }}
+          </p>
         </div>
 
         <!-- Shared duration is a TARGET across the compared models; chips are the
@@ -84,7 +91,16 @@
             data-testid="studio-bakeoff-run"
             @click="run"
           >
-            {{ running ? t('studio.bakeoff.running') : t('studio.bakeoff.run', { count: selectedModelIds.length }) }}
+            {{ runButtonLabel }}
+          </button>
+          <button
+            v-if="panels.length && !running"
+            type="button"
+            class="rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-600 transition hover:border-gray-300 dark:border-dark-600 dark:text-dark-300"
+            data-testid="studio-bakeoff-clear-results"
+            @click="clearResults"
+          >
+            {{ t('studio.bakeoff.clearResults') }}
           </button>
           <span class="rounded-lg bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-700 ring-1 ring-amber-200 dark:bg-amber-950/30 dark:text-amber-300 dark:ring-amber-900/50">
             {{ t('studio.bakeoff.totalCost', { cost: formatUsd(totalCost) }) }}
@@ -102,8 +118,10 @@
       </template>
     </div>
 
+    <StudioLocalSaveBanner v-if="showSaveReminder" test-id="studio-bakeoff-save-reminder" />
+
     <!-- side-by-side panels -->
-    <div v-if="panels.length" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+    <div v-if="panels.length" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-[repeat(auto-fit,minmax(220px,1fr))]">
       <div v-for="p in panels" :key="p.modelId" data-testid="bakeoff-panel" class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm dark:border-dark-700 dark:bg-dark-900">
         <div class="mb-2 flex items-center justify-between">
           <span class="text-sm font-semibold text-gray-900 dark:text-white">{{ p.label }}</span>
@@ -114,9 +132,10 @@
           <div v-if="p.src" class="overflow-hidden rounded-lg border border-gray-200 dark:border-dark-700">
             <img :src="p.src" :alt="prompt" class="aspect-square w-full object-cover" loading="lazy" />
           </div>
+          <StudioImageExpired v-else-if="p.state === 'succeeded'" compact />
           <div v-else class="flex aspect-square items-center justify-center rounded-lg bg-gray-50 text-xs text-gray-400 dark:bg-dark-800 dark:text-dark-500">
             <span v-if="p.state === 'processing'">{{ t('studio.bakeoff.generating') }}</span>
-            <span v-else-if="p.state === 'failed'" class="text-red-500">{{ t('studio.bakeoff.failed') }}</span>
+            <span v-else-if="p.state === 'failed'" class="px-2 text-center text-red-500">{{ p.errorMessage || t('studio.bakeoff.failed') }}</span>
             <span v-else>—</span>
           </div>
         </template>
@@ -127,7 +146,7 @@
                Poster tile → in-page lightbox, mirroring VideoStudio and sharing
                videoPlaybackUrl so inline data:video plays tab-local without rehosting. -->
           <button
-            v-if="p.url"
+            v-if="bakePanelVideoPlayable(p)"
             type="button"
             class="group relative block aspect-video w-full overflow-hidden rounded-lg bg-gradient-to-br from-gray-800 to-gray-950"
             data-testid="bakeoff-video-play"
@@ -140,17 +159,130 @@
               </span>
             </span>
           </button>
+          <div v-else-if="p.state === 'succeeded'" class="flex aspect-video items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50 px-2 text-center text-[11px] text-gray-500 dark:border-dark-600 dark:bg-dark-800/60 dark:text-dark-400">
+            {{ t('studio.video.expiredReload') }}
+          </div>
           <div v-else class="flex aspect-video items-center justify-center rounded-lg bg-gray-50 text-xs text-gray-500 dark:bg-dark-800 dark:text-dark-400">
             <span v-if="p.state === 'processing'" class="inline-flex items-center gap-1.5"><span class="h-2 w-2 animate-pulse rounded-full bg-primary-500"></span>{{ t('studio.video.statusProcessing') }} {{ formatElapsed(p.elapsedS || 0) }}</span>
-            <span v-else-if="p.state === 'failed'" class="text-red-500">{{ t('studio.bakeoff.failed') }}</span>
+            <span v-else-if="p.state === 'failed'" class="px-2 text-center text-red-500">{{ p.errorMessage || t('studio.bakeoff.failed') }}</span>
             <span v-else>—</span>
           </div>
         </template>
-        <div class="mt-2 flex items-center justify-between text-sm">
+        <div class="mt-2 flex flex-wrap items-center justify-between gap-2 text-sm">
           <span class="font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(p.cost) }}</span>
-          <span v-if="p.elapsedS != null && p.state !== 'idle'" class="text-xs text-gray-500 dark:text-dark-400">⏱ {{ p.elapsedS }}s</span>
+          <div class="flex items-center gap-2">
+            <button
+              v-if="modality === 'image' && p.src"
+              type="button"
+              class="text-[11px] font-medium text-primary-600 dark:text-primary-300"
+              @click="downloadImage(p.src, p.modelId)"
+            >
+              {{ t('studio.image.download') }}
+            </button>
+            <button
+              v-else-if="modality === 'video' && bakePanelVideoPlayable(p) && p.url"
+              type="button"
+              class="text-[11px] font-medium text-primary-600 dark:text-primary-300"
+              @click="downloadMedia(p.url!, `tokenkey-${p.taskId || p.modelId}.mp4`)"
+            >
+              {{ t('studio.video.download') }}
+            </button>
+            <span v-if="p.elapsedS != null && p.state !== 'idle'" class="text-xs text-gray-500 dark:text-dark-400">⏱ {{ p.elapsedS }}s</span>
+          </div>
         </div>
       </div>
+    </div>
+
+    <div
+      v-if="modality === 'image' ? imageHistoryRuns.length : videoHistoryRuns.length"
+      class="space-y-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-dark-700 dark:bg-dark-900"
+      data-testid="bakeoff-history"
+    >
+      <div class="flex items-center justify-between">
+        <span class="text-sm font-semibold text-gray-700 dark:text-dark-200">{{ t('studio.bakeoff.historyTitle') }}</span>
+      </div>
+      <template v-if="modality === 'image'">
+        <div v-for="run in imageHistoryRuns" :key="run.key" class="space-y-2 border-t border-gray-100 pt-4 first:border-t-0 first:pt-0 dark:border-dark-800">
+          <p class="truncate text-xs text-gray-500 dark:text-dark-400" :title="run.prompt">{{ run.prompt }}</p>
+          <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-[repeat(auto-fit,minmax(220px,1fr))]">
+            <div
+              v-for="img in run.items"
+              :key="img.id"
+              class="rounded-xl border border-gray-200 p-2 dark:border-dark-700"
+              data-testid="bakeoff-history-item"
+            >
+              <div class="mb-1 flex items-center justify-between gap-2">
+                <span class="truncate text-xs font-semibold text-gray-800 dark:text-dark-200">{{ modelLabel(img.model) }}</span>
+                <span class="shrink-0 text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: img.vendorLabel }) }}</span>
+              </div>
+              <div v-if="imageHistoryItemAvailable(img)" class="overflow-hidden rounded-lg">
+                <img :src="img.src" :alt="img.prompt" class="aspect-square w-full object-cover" loading="lazy" />
+              </div>
+              <StudioImageExpired v-else compact />
+              <div class="mt-1 flex items-center justify-between gap-2">
+                <span class="text-xs font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(img.cost) }}</span>
+                <button
+                  v-if="imageHistoryItemAvailable(img)"
+                  type="button"
+                  class="text-[10px] font-medium text-primary-600 dark:text-primary-300"
+                  @click="downloadImage(img.src, img.id)"
+                >
+                  {{ t('studio.image.download') }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+      <template v-else>
+        <div v-for="run in videoHistoryRuns" :key="run.key" class="space-y-2 border-t border-gray-100 pt-4 first:border-t-0 first:pt-0 dark:border-dark-800">
+          <p class="truncate text-xs text-gray-500 dark:text-dark-400" :title="run.prompt">{{ run.prompt }}</p>
+          <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-[repeat(auto-fit,minmax(220px,1fr))]">
+            <div
+              v-for="task in run.items"
+              :key="task.id"
+              class="rounded-xl border border-gray-200 p-2 dark:border-dark-700"
+              data-testid="bakeoff-history-item"
+            >
+              <div class="mb-1 flex items-center justify-between gap-2">
+                <span class="truncate text-xs font-semibold text-gray-800 dark:text-dark-200">{{ modelLabel(task.model) }}</span>
+                <span class="shrink-0 text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: task.vendorLabel }) }}</span>
+              </div>
+              <button
+                v-if="videoTaskPlaybackAvailable(task)"
+                type="button"
+                class="group relative block aspect-video w-full overflow-hidden rounded-lg bg-gradient-to-br from-gray-800 to-gray-950"
+                @click="openVideoHistoryPreview(task)"
+              >
+                <span class="pointer-events-none absolute inset-0 flex items-center justify-center">
+                  <span class="flex h-10 w-10 items-center justify-center rounded-full bg-white/90 shadow-lg transition group-hover:scale-110">
+                    <span aria-hidden="true" class="ml-0.5 text-lg text-gray-900">▶</span>
+                  </span>
+                </span>
+              </button>
+              <div v-else-if="task.state === 'processing'" class="flex aspect-video items-center justify-center rounded-lg bg-gray-50 text-[11px] text-gray-500 dark:bg-dark-800 dark:text-dark-400">
+                <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 animate-pulse rounded-full bg-primary-500"></span>{{ t('studio.video.statusProcessing') }}</span>
+              </div>
+              <div v-else-if="task.state === 'failed'" class="flex aspect-video items-center justify-center rounded-lg bg-gray-50 text-[11px] text-red-500 dark:bg-dark-800">
+                {{ t('studio.bakeoff.failed') }}
+              </div>
+              <StudioVideoUnavailable v-else :prompt="task.prompt" :task="task" />
+              <div class="mt-1 flex items-center justify-between gap-2">
+                <StudioPlaybackBadge v-if="videoTaskPlaybackAvailable(task)" :task="task" />
+                <span class="ml-auto text-xs font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(task.estCost) }}</span>
+              </div>
+              <button
+                v-if="videoTaskPlaybackAvailable(task) && task.url"
+                type="button"
+                class="text-[10px] font-medium text-primary-600 dark:text-primary-300"
+                @click="downloadMedia(task.url, `tokenkey-${task.id}.mp4`)"
+              >
+                {{ t('studio.video.download') }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </template>
     </div>
 
     <!-- In-page video lightbox: plays one panel on demand (http URL direct, inline
@@ -158,7 +290,7 @@
          rendering MAX_PANELS always-on <video> elements. -->
     <Teleport to="body">
       <div
-        v-if="videoPreview"
+        v-if="videoPreviewUrl"
         class="fixed inset-0 z-[100] flex flex-col bg-black/85 backdrop-blur-sm"
         data-testid="bakeoff-video-preview"
         @click.self="closeVideoPreview"
@@ -172,8 +304,9 @@
           <video v-if="videoPreviewUrl" :src="videoPreviewUrl" controls autoplay playsinline class="max-h-full max-w-full rounded-lg bg-black shadow-2xl"></video>
         </div>
         <div class="flex flex-wrap items-center justify-center gap-3 p-4">
-          <span class="max-w-[60vw] truncate text-xs text-white/80" :title="videoPreview.label">{{ videoPreview.label }}</span>
-          <span class="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[11px] font-semibold text-white">{{ formatUsd(videoPreview.cost) }}</span>
+          <span class="max-w-[60vw] truncate text-xs text-white/80" :title="videoPreviewLabel">{{ videoPreviewLabel }}</span>
+          <span v-if="videoPreviewCost != null" class="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[11px] font-semibold text-white">{{ formatUsd(videoPreviewCost) }}</span>
+          <button v-if="videoPreviewUrl" type="button" class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100" @click="downloadMedia(videoPreviewUrl, `tokenkey-bakeoff-preview.mp4`)">{{ t('studio.video.download') }}</button>
         </div>
       </div>
     </Teleport>
@@ -181,9 +314,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { gatewayGeminiImageViaChat, gatewayImageGenerations, gatewayVideoSubmit } from '@/api/playground'
+import { gatewayGeminiImageViaChat, gatewayImageGenerations, gatewayVideoSubmit, gatewayImagePresign } from '@/api/playground'
 import {
   extractChatImageItems,
   extractImageItems,
@@ -201,10 +334,24 @@ import {
   type MediaPriceMap,
 } from '@/constants/mediaTiers.tk'
 import { estimateImageCost, estimateImageHoldCost, estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
-import { videoPlaybackUrl } from '@/utils/studioMedia.tk'
-import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
+import {
+  groupImageHistoryByTs,
+  groupVideoHistoryByBatch,
+  imageHistoryItemAvailable,
+  shouldShowStudioSaveReminder,
+  videoPlaybackUrl,
+  videoTaskPlaybackAvailable,
+} from '@/utils/studioMedia.tk'
+import { downloadMedia } from '@/utils/studioDownload.tk'
+import { resolveVideoPlaybackStorage } from '@/utils/studioPlaybackStorage.tk'
+import StudioLocalSaveBanner from '@/views/user/studio/components/StudioLocalSaveBanner.vue'
+import StudioImageExpired from '@/views/user/studio/components/StudioImageExpired.vue'
+import StudioPlaybackBadge from '@/views/user/studio/components/StudioPlaybackBadge.vue'
+import StudioVideoUnavailable from '@/views/user/studio/components/StudioVideoUnavailable.vue'
+import { useAppStore } from '@/stores/app'
+import { classifyGatewayError, parseGatewayErrorMessage, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { useVideoTaskPoll } from '@/composables/useVideoTaskPoll'
-import type { VideoTaskItem } from '@/composables/useMediaLibrary'
+import { useMediaLibrary, type ImageHistoryItem, type VideoTaskItem } from '@/composables/useMediaLibrary'
 import type { ApiKey } from '@/types'
 
 const props = defineProps<{
@@ -213,6 +360,7 @@ const props = defineProps<{
   availableIds: Set<string>
   priceMap: MediaPriceMap
   balance: number
+  userId: number | string
   keyId: number | null
   keys: ApiKey[]
   rateMultiplier: number
@@ -220,8 +368,9 @@ const props = defineProps<{
 const emit = defineEmits<{ (e: 'spent'): void }>()
 
 const { t } = useI18n()
+const appStore = useAppStore()
 
-const MAX_PANELS = 4
+const MAX_PANELS = 6
 /** Imagen / seedream: ratio code on /v1/images/generations (see ImageStudio sentSize). */
 const DEFAULT_IMAGEN_SIZE = '1:1'
 /** Gemini-native image: aspect_ratio via /v1/chat/completions extra_body.google.image_config. */
@@ -231,6 +380,7 @@ const modality = ref<StudioModality>('video')
 const models = computed(() => resolveAvailableModels(modality.value, props.availableIds, props.priceMap))
 const selectedModelIds = ref<string[]>([])
 const prompt = ref('')
+const lastRunPrompt = ref('')
 const duration = ref(VIDEO_DURATION_DEFAULT)
 const running = ref(false)
 const errorMessage = ref('')
@@ -250,26 +400,37 @@ interface BakePanel {
   taskId?: string
   url?: string
   elapsedS?: number
+  errorMessage?: string
 }
 const panels = ref<BakePanel[]>([])
+const activeRunTs = ref<number | null>(null)
 
-// Local VideoTaskItem store for the poll engine (ephemeral — Bake-Off is a
-// comparison surface, not persistent history).
-const videoTasks = ref<VideoTaskItem[]>([])
-function patchVideoTask(id: string, patch: Partial<VideoTaskItem>): void {
-  const idx = videoTasks.value.findIndex((tk) => tk.id === id)
-  if (idx >= 0) {
-    const next = [...videoTasks.value]
-    next[idx] = { ...next[idx], ...patch }
-    videoTasks.value = next
+const library = useMediaLibrary(props.userId)
+
+async function tagVideoPlayback(taskId: string, url: string): Promise<void> {
+  if (!url) {
+    library.patchVideoTask(taskId, { playbackStorage: 'expired' })
+    return
   }
-  // Mirror onto the panel by taskId.
+  const storage = await resolveVideoPlaybackStorage(url)
+  library.patchVideoTask(taskId, { playbackStorage: storage })
+  if (storage === 'upstream-cors-blocked') {
+    appStore.showWarning(t('studio.playback.upstreamCorsBlocked'), 8000)
+  }
+  if (storage === 'inline-local' || storage === 'upstream-cors-ok') {
+    void library.cacheInlineMedia('video', taskId, url)
+  }
+}
+
+function patchVideoTask(id: string, patch: Partial<VideoTaskItem>): void {
+  library.patchVideoTask(id, patch)
   const panel = panels.value.find((p) => p.taskId === id)
   if (panel) {
     if (patch.state) panel.state = patch.state
     if (patch.url != null) panel.url = patch.url
     if (patch.elapsedS != null) panel.elapsedS = patch.elapsedS
   }
+  if (patch.url) void tagVideoPlayback(id, patch.url)
 }
 const poll = useVideoTaskPoll({
   gatewayBase: () => props.gatewayBase,
@@ -278,26 +439,75 @@ const poll = useVideoTaskPoll({
   onTerminal: () => emit('spent'),
 })
 
+type ImageHistoryRunView = { key: string; prompt: string; items: ImageHistoryItem[] }
+type VideoHistoryRunView = { key: string; prompt: string; items: VideoTaskItem[] }
+
+const imageHistoryRuns = computed<ImageHistoryRunView[]>(() => {
+  const hideTs = panels.value.length ? activeRunTs.value : null
+  return groupImageHistoryByTs(library.images.value)
+    .filter((run) => run.ts !== hideTs)
+    .map((run) => ({ key: `img-${run.ts}`, prompt: run.prompt, items: run.items }))
+})
+
+const videoHistoryRuns = computed<VideoHistoryRunView[]>(() => {
+  const hideTs = panels.value.length ? activeRunTs.value : null
+  return groupVideoHistoryByBatch(library.videoTasks.value)
+    .filter((run) => run.batchMs !== hideTs)
+    .map((run) => ({ key: `vid-${run.batchMs}`, prompt: run.prompt, items: run.items }))
+})
+
+const showSaveReminder = computed(() =>
+  shouldShowStudioSaveReminder({
+    imageCount: library.images.value.length,
+    videoTaskCount: library.videoTasks.value.length,
+    activeResultCount: panels.value.length,
+  })
+)
+
+function bakePanelVideoPlayable(p: BakePanel): boolean {
+  return p.state === 'succeeded' && !!p.url
+}
+
+function downloadImage(src: string, id: string): void {
+  downloadMedia(src, `tokenkey-${id}.png`)
+}
+
+function modelLabel(modelId: string): string {
+  const hit = models.value.find((r) => r.model.modelId === modelId || r.servedId === modelId)
+  return hit?.model.displayName ?? modelId
+}
+
 // ---- In-page video lightbox (on-demand playback; no always-on <video>) ----------
-const videoPreview = ref<BakePanel | null>(null)
 const videoPreviewUrl = ref('')
+const videoPreviewLabel = ref('')
+const videoPreviewCost = ref<number | null>(null)
 let videoPreviewRevoke: () => void = () => {}
+
+function openVideoPreviewFromUrl(label: string, cost: number, url: string): void {
+  if (!url) return
+  videoPreviewRevoke()
+  const playback = videoPlaybackUrl(url)
+  videoPreviewRevoke = playback.revoke
+  videoPreviewLabel.value = label
+  videoPreviewCost.value = cost
+  videoPreviewUrl.value = playback.url
+}
 
 function openVideoPreview(panel: BakePanel): void {
   if (!panel.url) return
-  videoPreviewRevoke()
-  // http(s) upstream URL plays directly; inline data:video becomes a tab-local Blob
-  // (shared with VideoStudio via videoPlaybackUrl — TokenKey never rehosts the clip).
-  const playback = videoPlaybackUrl(panel.url)
-  videoPreviewRevoke = playback.revoke
-  videoPreview.value = panel
-  videoPreviewUrl.value = playback.url
+  openVideoPreviewFromUrl(panel.label, panel.cost, panel.url)
+}
+
+function openVideoHistoryPreview(task: VideoTaskItem): void {
+  if (!videoTaskPlaybackAvailable(task) || !task.url) return
+  openVideoPreviewFromUrl(modelLabel(task.model), task.estCost, task.url)
 }
 
 function closeVideoPreview(): void {
   videoPreviewRevoke()
   videoPreviewRevoke = () => {}
-  videoPreview.value = null
+  videoPreviewLabel.value = ''
+  videoPreviewCost.value = null
   videoPreviewUrl.value = ''
 }
 
@@ -350,13 +560,32 @@ const canAfford = computed(() => totalHold.value <= props.balance)
 const canRun = computed(
   () => !running.value && !!props.apiKey && !!prompt.value.trim() && selectedModelIds.value.length >= 2 && canAfford.value && props.keyId != null
 )
+const promptChangedSinceRun = computed(
+  () => panels.value.length > 0 && prompt.value.trim() !== lastRunPrompt.value
+)
+const runButtonLabel = computed(() => {
+  if (running.value) return t('studio.bakeoff.running')
+  if (panels.value.length && !promptChangedSinceRun.value) return t('studio.bakeoff.regenerate')
+  if (panels.value.length && promptChangedSinceRun.value) return t('studio.bakeoff.regenerateChanged')
+  return t('studio.bakeoff.run', { count: selectedModelIds.value.length })
+})
 
 function setModality(m: StudioModality): void {
   if (running.value) return
   modality.value = m
   selectedModelIds.value = []
   panels.value = []
-  videoTasks.value = []
+  lastRunPrompt.value = ''
+  activeRunTs.value = null
+}
+
+function clearResults(): void {
+  if (running.value) return
+  panels.value = []
+  lastRunPrompt.value = ''
+  activeRunTs.value = null
+  errorMessage.value = ''
+  errorCode.value = ''
 }
 
 function toggleModel(id: string): void {
@@ -378,8 +607,10 @@ async function run(): Promise<void> {
   errorMessage.value = ''
   errorCode.value = ''
   running.value = true
+  lastRunPrompt.value = text
+  const runTs = Date.now()
+  activeRunTs.value = runTs
   poll.stopAll()
-  videoTasks.value = []
   // Seed panels.
   panels.value = chosen.map((r) => ({
     modelId: r.model.modelId,
@@ -396,19 +627,35 @@ async function run(): Promise<void> {
 
   try {
     if (modality.value === 'image') {
+      const historyBatch: ImageHistoryItem[] = []
       await Promise.all(
-        panels.value.map(async (panel) => {
+        panels.value.map(async (panel, index) => {
           try {
             const items = await generateBakeoffImage(panel.servedId, text)
             if (!items.length) throw new Error('no_image')
-            panel.src = items[0].src
+            const it = items[0]
+            panel.src = it.src
             panel.state = 'succeeded'
+            historyBatch.push({
+              id: `${runTs}-${panel.modelId}-${index}`,
+              src: it.src,
+              s3Key: it.s3Key,
+              prompt: text,
+              revisedPrompt: it.revisedPrompt,
+              model: panel.servedId,
+              vendorLabel: panel.vendorLabel,
+              size: DEFAULT_IMAGEN_SIZE,
+              cost: panel.cost,
+              ts: runTs,
+            })
           } catch (e) {
             panel.state = 'failed'
+            panel.errorMessage = panelErrorText(e)
             mapError(e)
           }
         })
       )
+      if (historyBatch.length) library.addImages(historyBatch)
       emit('spent')
     } else {
       // Submit all videos, then poll each.
@@ -432,13 +679,15 @@ async function run(): Promise<void> {
               keyId: props.keyId as number,
               state,
               url: panel.url || '',
-              submittedAtMs: Date.now(),
+              submittedAtMs: runTs,
               elapsedS: 0,
             }
-            videoTasks.value = [...videoTasks.value, task]
+            library.upsertVideoTask(task)
             if (state === 'processing') poll.resume(task)
+            else if (panel.url) void tagVideoPlayback(taskId, panel.url)
           } catch (e) {
             panel.state = 'failed'
+            panel.errorMessage = panelErrorText(e)
             mapError(e)
           }
         })
@@ -469,8 +718,16 @@ async function generateBakeoffImage(modelId: string, prompt: string) {
   return extractImageItems(raw)
 }
 
+function panelErrorText(e: unknown): string {
+  const msg = parseGatewayErrorMessage(e instanceof Error ? e.message : '')
+  const code = classifyGatewayError(msg)
+  if (code !== 'generic') return t(studioErrorI18nKey(code))
+  if (msg && msg !== 'no_image' && msg !== 'no_task') return msg
+  return t('studio.bakeoff.panelError')
+}
+
 function mapError(e: unknown): void {
-  const msg = e instanceof Error ? e.message : ''
+  const msg = parseGatewayErrorMessage(e instanceof Error ? e.message : '')
   const code = classifyGatewayError(msg)
   if (code !== 'generic') {
     errorCode.value = code
@@ -479,4 +736,27 @@ function mapError(e: unknown): void {
     errorMessage.value = msg
   }
 }
+
+async function refreshOffloadedImageUrls(): Promise<void> {
+  if (!props.apiKey) return
+  const stale = library.images.value.filter((it) => it.s3Key)
+  if (!stale.length) return
+  await Promise.all(
+    stale.map(async (it) => {
+      try {
+        const url = await gatewayImagePresign(props.apiKey, props.gatewayBase, it.s3Key as string)
+        if (url) it.src = url
+      } catch {
+        /* history is best-effort */
+      }
+    })
+  )
+}
+
+onMounted(() => {
+  for (const task of library.videoTasks.value) {
+    if (task.state === 'processing') poll.resume(task)
+  }
+  void library.hydrateFromBlobCache().then(() => refreshOffloadedImageUrls())
+})
 </script>

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -175,10 +175,7 @@
           </button>
         </div>
       </div>
-      <div v-if="library.images.value.length" class="mb-3 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100" data-testid="studio-image-save-reminder">
-        <span aria-hidden="true">⬇</span>
-        {{ t('studio.saveReminder') }}
-      </div>
+      <StudioLocalSaveBanner v-if="library.images.value.length" test-id="studio-image-save-reminder" class="mb-3" />
       <div v-if="!library.images.value.length" class="py-16 text-center text-sm text-gray-500 dark:text-dark-400">
         {{ t('studio.image.emptyHint') }}
       </div>
@@ -194,7 +191,7 @@
                  browsers block top-level navigation to data: URLs (→ about:blank,
                  the "click shows nothing" report). A lightbox previews every src
                  (data: or http) without leaving the page. -->
-            <template v-if="img.src">
+            <template v-if="imageHistoryItemAvailable(img)">
               <button type="button" class="block w-full cursor-zoom-in" :title="t('studio.image.enlargeHint')" data-testid="studio-image-thumb" @click="openPreview(img)">
                 <img :src="img.src" :alt="img.prompt" class="aspect-square w-full object-cover" loading="lazy" />
               </button>
@@ -208,11 +205,9 @@
                  not persisted to localStorage (#944 pass-through default — the gateway
                  does not rehost generated images), so after a reload there is no
                  thumbnail to show. Offer a regenerate path instead of a broken <img>. -->
-            <div v-else class="flex aspect-square w-full flex-col items-center justify-center gap-1 bg-gray-50 px-2 text-center dark:bg-dark-800" data-testid="studio-image-expired">
-              <span aria-hidden="true" class="text-2xl text-gray-300 dark:text-dark-600">🖼</span>
-              <span class="text-[10px] leading-tight text-gray-400 dark:text-dark-500">{{ t('studio.image.expiredReload') }}</span>
+            <StudioImageExpired v-else>
               <button type="button" class="mt-1 rounded-md bg-white/90 px-2 py-0.5 text-[10px] font-medium text-gray-700 ring-1 ring-gray-200 hover:bg-white dark:bg-dark-700 dark:text-dark-200 dark:ring-dark-600" @click="reuse(img)">{{ t('studio.image.usePrompt') }}</button>
-            </div>
+            </StudioImageExpired>
           </div>
           <figcaption class="flex items-center justify-between gap-2 px-2.5 py-1.5 text-[11px] text-gray-500 dark:text-dark-400">
             <span class="truncate" :title="img.prompt">{{ img.prompt }}</span>
@@ -272,6 +267,9 @@ import {
 } from '@/utils/mediaCostEstimate.tk'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { downloadMedia } from '@/utils/studioDownload.tk'
+import { imageHistoryItemAvailable } from '@/utils/studioMedia.tk'
+import StudioLocalSaveBanner from '@/views/user/studio/components/StudioLocalSaveBanner.vue'
+import StudioImageExpired from '@/views/user/studio/components/StudioImageExpired.vue'
 import { useMediaLibrary, type ImageHistoryItem } from '@/composables/useMediaLibrary'
 
 const props = defineProps<{

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -141,6 +141,7 @@
         :available-ids="availableIds"
         :price-map="priceMap"
         :balance="balance"
+        :user-id="userId"
         :key-id="selectedKeyId"
         :keys="keys"
         :rate-multiplier="1"

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -171,10 +171,7 @@
       <!-- Results header + bulk clear (matches the image surface). Shown only when
            there is history; the per-card status badge is the source of truth for
            each task's state — there is no global completion banner to go stale. -->
-      <div v-if="library.videoTasks.value.length" class="mb-2 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100" data-testid="studio-video-save-reminder">
-        <span aria-hidden="true">⬇</span>
-        {{ t('studio.saveReminder') }}
-      </div>
+      <StudioLocalSaveBanner v-if="library.videoTasks.value.length" test-id="studio-video-save-reminder" class="mb-2" />
       <div v-if="library.videoTasks.value.length" class="flex items-center justify-between px-1">
         <span class="text-sm font-semibold text-gray-700 dark:text-dark-200">{{ t('studio.video.resultsTitle') }}</span>
         <button type="button" class="text-xs text-gray-400 hover:text-gray-700 dark:hover:text-dark-200" data-testid="studio-video-clear-all" @click="clearAll">{{ t('studio.clear') }}</button>
@@ -250,38 +247,11 @@
               </span>
               <span class="pointer-events-none absolute bottom-2 left-2 rounded bg-black/55 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-white/90">{{ task.seconds }}s{{ task.aspectRatio ? ' · ' + task.aspectRatio : '' }}</span>
             </button>
-            <p
-              v-if="playbackStorageKind(task) !== 'unknown'"
-              class="inline-flex max-w-full items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium leading-snug"
-              :class="playbackBadgeClass(task)"
-              data-testid="studio-video-playback-badge"
-              :data-playback-storage="playbackStorageKind(task)"
-            >
-              <span class="shrink-0 opacity-80">{{ t('studio.playback.label') }}:</span>
-              <span>{{ playbackHint(task) }}</span>
-            </p>
-            <p v-else class="text-[10px] text-gray-400 dark:text-dark-500">{{ playbackHint(task) }}</p>
+            <div class="mt-2">
+              <StudioPlaybackBadge :task="task" />
+            </div>
           </template>
-          <div
-            v-else
-            class="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-3 py-4 dark:border-dark-600 dark:bg-dark-800/60"
-            data-testid="studio-video-expired"
-          >
-            <p class="whitespace-pre-wrap break-words text-sm text-gray-800 dark:text-dark-100">{{ task.prompt }}</p>
-            <p
-              v-if="playbackStorageKind(task) !== 'unknown'"
-              class="mt-2 inline-flex max-w-full items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium leading-snug"
-              :class="playbackBadgeClass(task)"
-              data-testid="studio-video-playback-badge"
-              :data-playback-storage="playbackStorageKind(task)"
-            >
-              <span class="shrink-0 opacity-80">{{ t('studio.playback.label') }}:</span>
-              <span>{{ playbackHint(task) }}</span>
-            </p>
-            <p v-else class="mt-2 text-[11px] text-gray-400 dark:text-dark-500">
-              {{ playbackHint(task) }}
-            </p>
-          </div>
+          <StudioVideoUnavailable v-else :prompt="task.prompt" :task="task" />
           <div class="flex items-center justify-between text-[11px] text-gray-500 dark:text-dark-400">
             <span v-if="videoTaskPlaybackAvailable(task)" class="truncate" :title="task.prompt">{{ task.prompt }}</span>
             <span class="shrink-0 rounded bg-primary-50 px-1.5 py-0.5 font-semibold text-primary-700 dark:bg-primary-950/50 dark:text-primary-300">{{ formatUsd(task.estCost) }}</span>
@@ -381,9 +351,10 @@ import { downloadMedia } from '@/utils/studioDownload.tk'
 import { videoPlaybackUrl, videoTaskPlaybackAvailable } from '@/utils/studioMedia.tk'
 import {
   resolveVideoPlaybackStorage,
-  studioPlaybackStorageI18nKey,
-  type StudioPlaybackStorage,
 } from '@/utils/studioPlaybackStorage.tk'
+import StudioLocalSaveBanner from '@/views/user/studio/components/StudioLocalSaveBanner.vue'
+import StudioPlaybackBadge from '@/views/user/studio/components/StudioPlaybackBadge.vue'
+import StudioVideoUnavailable from '@/views/user/studio/components/StudioVideoUnavailable.vue'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { useMediaLibrary, type VideoTaskItem } from '@/composables/useMediaLibrary'
 import { useVideoTaskPoll, requestVideoNotifyPermission, maybeNotify } from '@/composables/useVideoTaskPoll'
@@ -451,29 +422,6 @@ const formula = computed(() => {
   if (!selected.value) return ''
   return t('studio.video.formula', { rate: formatUsd(selected.value.perSecond || 0), seconds: duration.value })
 })
-
-function playbackStorageKind(task: VideoTaskItem): StudioPlaybackStorage {
-  return task.playbackStorage ?? (task.urlExpired || !task.url ? 'expired' : 'unknown')
-}
-
-function playbackBadgeClass(task: VideoTaskItem): string {
-  switch (playbackStorageKind(task)) {
-    case 'inline-local':
-      return 'bg-green-50 text-green-800 dark:bg-green-950/40 dark:text-green-200'
-    case 'upstream-cors-ok':
-      return 'bg-blue-50 text-blue-800 dark:bg-blue-950/40 dark:text-blue-200'
-    case 'upstream-cors-blocked':
-      return 'bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-100'
-    case 'expired':
-      return 'bg-gray-100 text-gray-600 dark:bg-dark-800 dark:text-dark-300'
-    default:
-      return 'bg-gray-50 text-gray-500 dark:bg-dark-800 dark:text-dark-400'
-  }
-}
-
-function playbackHint(task: VideoTaskItem): string {
-  return t(studioPlaybackStorageI18nKey(playbackStorageKind(task)))
-}
 
 async function tagVideoPlayback(taskId: string, url: string): Promise<void> {
   if (!url) {

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -4,11 +4,34 @@ import { createI18n } from 'vue-i18n'
 import en from '@/i18n/locales/en'
 import BakeOff from '../BakeOff.vue'
 import * as playground from '@/api/playground'
+import type { ImageHistoryItem } from '@/composables/useMediaLibrary'
+
+const libraryMock = vi.hoisted(() => ({
+  images: { value: [] as ImageHistoryItem[] },
+  videoTasks: { value: [] },
+  addImages: vi.fn(),
+  clearImages: vi.fn(),
+  upsertVideoTask: vi.fn(),
+  patchVideoTask: vi.fn(),
+  removeVideoTask: vi.fn(),
+  clearVideoTasks: vi.fn(),
+  hydrateFromBlobCache: vi.fn(async () => undefined),
+  cacheInlineMedia: vi.fn(async () => undefined),
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({ showWarning: vi.fn() }),
+}))
 
 vi.mock('@/api/playground', () => ({
   gatewayImageGenerations: vi.fn(),
   gatewayGeminiImageViaChat: vi.fn(),
   gatewayVideoSubmit: vi.fn(),
+  gatewayImagePresign: vi.fn(),
+}))
+
+vi.mock('@/composables/useMediaLibrary', () => ({
+  useMediaLibrary: () => libraryMock,
 }))
 
 vi.mock('@/composables/useVideoTaskPoll', () => ({
@@ -30,15 +53,20 @@ const i18n = createI18n({
 const baseProps = {
   apiKey: 'sk-test',
   gatewayBase: 'https://api.example.com',
+  userId: 42,
   availableIds: new Set([
     'imagen-4.0-fast-generate-001',
     'imagen-4.0-generate-001',
+    'imagen-4.0-ultra-generate-001',
     'gemini-3.1-flash-image',
+    'seedream-4-0-250828',
   ]),
   priceMap: new Map([
     ['imagen-4.0-fast-generate-001', { perImage: 0.02 }],
     ['imagen-4.0-generate-001', { perImage: 0.04 }],
+    ['imagen-4.0-ultra-generate-001', { perImage: 0.06 }],
     ['gemini-3.1-flash-image', { perImage: 0.0672 }],
+    ['seedream-4-0-250828', { perImage: 0.0299 }],
   ]),
   balance: 100,
   keyId: 1,
@@ -48,6 +76,12 @@ const baseProps = {
 
 describe('BakeOff image routing', () => {
   beforeEach(() => {
+    libraryMock.images.value = []
+    libraryMock.videoTasks.value = []
+    libraryMock.addImages.mockReset()
+    libraryMock.addImages.mockImplementation((items: ImageHistoryItem[]) => {
+      libraryMock.images.value = [...items, ...libraryMock.images.value]
+    })
     vi.mocked(playground.gatewayImageGenerations).mockReset()
     vi.mocked(playground.gatewayGeminiImageViaChat).mockReset()
     vi.mocked(playground.gatewayImageGenerations).mockResolvedValue({
@@ -65,9 +99,10 @@ describe('BakeOff image routing', () => {
     })
     await wrapper.get('[data-testid="bakeoff-mode-image"]').trigger('click')
     const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    // sorted cheap→premium: fast, seedream, standard, ultra, gemini
     await tiers[0].trigger('click')
     await tiers[1].trigger('click')
-    await tiers[2].trigger('click')
+    await tiers[4].trigger('click')
     await wrapper.get('textarea').setValue('a red apple')
     await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
     await flushPromises()
@@ -85,7 +120,70 @@ describe('BakeOff image routing', () => {
     expect(playground.gatewayImageGenerations).toHaveBeenCalledWith(
       'sk-test',
       'https://api.example.com',
-      expect.objectContaining({ model: 'imagen-4.0-generate-001', size: '1:1' })
+      expect.objectContaining({ model: 'seedream-4-0-250828', size: '1:1' })
     )
+    expect(libraryMock.addImages).toHaveBeenCalled()
+  })
+
+  it('allows selecting five image models for bake-off', async () => {
+    const wrapper = mount(BakeOff, {
+      props: baseProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true } },
+    })
+    await wrapper.get('[data-testid="bakeoff-mode-image"]').trigger('click')
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    expect(tiers.length).toBe(5)
+    for (const tier of tiers) {
+      await tier.trigger('click')
+    }
+    expect(tiers.filter((t) => t.classes().some((c) => c.includes('bg-primary-600'))).length).toBe(5)
+  })
+
+  it('persists to shared library and keeps history after clearing the current view', async () => {
+    const wrapper = mount(BakeOff, {
+      props: baseProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true } },
+    })
+    await wrapper.get('[data-testid="bakeoff-mode-image"]').trigger('click')
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    await tiers[0].trigger('click')
+    await tiers[1].trigger('click')
+    await wrapper.get('textarea').setValue('a red apple')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    expect(libraryMock.addImages).toHaveBeenCalledTimes(1)
+    expect(libraryMock.addImages.mock.calls[0][0]).toHaveLength(2)
+    expect(wrapper.findAll('[data-testid="bakeoff-panel"]').length).toBe(2)
+    expect(wrapper.find('[data-testid="studio-bakeoff-save-reminder"]').exists()).toBe(true)
+
+    await wrapper.get('[data-testid="studio-bakeoff-clear-results"]').trigger('click')
+    expect(wrapper.findAll('[data-testid="bakeoff-panel"]').length).toBe(0)
+    expect(wrapper.find('[data-testid="bakeoff-history"]').exists()).toBe(true)
+    expect(wrapper.findAll('[data-testid="bakeoff-history-item"]').length).toBe(2)
+  })
+
+  it('shows friendly panel error for codex unsupported gemini image', async () => {
+    vi.mocked(playground.gatewayGeminiImageViaChat).mockRejectedValueOnce(
+      new Error(
+        '{"message":"The \'gemini-3.1-flash-image\' model is not supported when using Codex with a ChatGPT account.","type":"invalid_request_error"}'
+      )
+    )
+    const wrapper = mount(BakeOff, {
+      props: baseProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true } },
+    })
+    await wrapper.get('[data-testid="bakeoff-mode-image"]').trigger('click')
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    await tiers[0].trigger('click')
+    await tiers[4].trigger('click')
+    await wrapper.get('textarea').setValue('a red apple')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    const panelText = wrapper.findAll('[data-testid="bakeoff-panel"]').map((p) => p.text()).join('\n')
+    expect(panelText).not.toContain('invalid_request_error')
+    expect(panelText).not.toContain('ChatGPT account')
+    expect(panelText).toMatch(/cannot serve that model|不支持该模型|studio\.errors\.unsupported_model/)
   })
 })

--- a/frontend/src/views/user/studio/components/StudioImageExpired.vue
+++ b/frontend/src/views/user/studio/components/StudioImageExpired.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { STUDIO_IMAGE_EXPIRED_I18N_KEY } from '@/utils/studioMedia.tk'
+
+withDefaults(
+  defineProps<{
+    testId?: string
+    compact?: boolean
+  }>(),
+  { testId: 'studio-image-expired', compact: false }
+)
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div
+    class="flex w-full flex-col items-center justify-center gap-1 bg-gray-50 px-2 text-center dark:bg-dark-800"
+    :class="compact ? 'aspect-square text-[11px]' : 'aspect-square text-[10px]'"
+    :data-testid="testId"
+  >
+    <span aria-hidden="true" class="text-2xl text-gray-300 dark:text-dark-600">🖼</span>
+    <span class="leading-tight text-gray-400 dark:text-dark-500">{{ t(STUDIO_IMAGE_EXPIRED_I18N_KEY) }}</span>
+    <slot />
+  </div>
+</template>

--- a/frontend/src/views/user/studio/components/StudioLocalSaveBanner.vue
+++ b/frontend/src/views/user/studio/components/StudioLocalSaveBanner.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+withDefaults(
+  defineProps<{
+    /** Override default `studio-local-save-banner` test id (e.g. per-surface). */
+    testId?: string
+    class?: string
+  }>(),
+  { testId: 'studio-local-save-banner' }
+)
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div
+    class="flex items-start gap-2.5 rounded-lg border-2 border-amber-300 bg-amber-50 px-3 py-2.5 text-xs text-amber-950 shadow-sm dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-50"
+    :class="$props.class"
+    :data-testid="testId"
+    role="alert"
+  >
+    <span aria-hidden="true" class="mt-0.5 shrink-0 text-base leading-none">⬇</span>
+    <div class="min-w-0">
+      <p class="font-semibold leading-snug">{{ t('studio.saveReminderTitle') }}</p>
+      <p class="mt-1 font-medium leading-snug opacity-90">{{ t('studio.saveReminder') }}</p>
+    </div>
+  </div>
+</template>

--- a/frontend/src/views/user/studio/components/StudioPlaybackBadge.vue
+++ b/frontend/src/views/user/studio/components/StudioPlaybackBadge.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { VideoTaskItem } from '@/composables/useMediaLibrary'
+import {
+  studioPlaybackBadgeClass,
+  studioPlaybackStorageI18nKey,
+  videoTaskPlaybackStorageKind,
+} from '@/utils/studioPlaybackStorage.tk'
+
+const props = withDefaults(
+  defineProps<{
+    task: Pick<VideoTaskItem, 'playbackStorage' | 'urlExpired' | 'url'>
+    testId?: string
+  }>(),
+  { testId: 'studio-playback-badge' }
+)
+
+const { t } = useI18n()
+const kind = computed(() => videoTaskPlaybackStorageKind(props.task))
+</script>
+
+<template>
+  <p
+    v-if="kind !== 'unknown'"
+    class="inline-flex max-w-full items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium leading-snug"
+    :class="studioPlaybackBadgeClass(kind)"
+    :data-testid="testId"
+    :data-playback-storage="kind"
+  >
+    <span class="shrink-0 opacity-80">{{ t('studio.playback.label') }}:</span>
+    <span>{{ t(studioPlaybackStorageI18nKey(kind)) }}</span>
+  </p>
+  <p v-else class="text-[10px] text-gray-400 dark:text-dark-500">
+    {{ t(studioPlaybackStorageI18nKey(kind)) }}
+  </p>
+</template>

--- a/frontend/src/views/user/studio/components/StudioVideoUnavailable.vue
+++ b/frontend/src/views/user/studio/components/StudioVideoUnavailable.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import type { VideoTaskItem } from '@/composables/useMediaLibrary'
+import StudioPlaybackBadge from '@/views/user/studio/components/StudioPlaybackBadge.vue'
+
+defineProps<{
+  prompt: string
+  task?: Pick<VideoTaskItem, 'playbackStorage' | 'urlExpired' | 'url'>
+  testId?: string
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div
+    class="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-3 py-4 dark:border-dark-600 dark:bg-dark-800/60"
+    :data-testid="testId ?? 'studio-video-expired'"
+  >
+    <p class="whitespace-pre-wrap break-words text-sm text-gray-800 dark:text-dark-100">{{ prompt }}</p>
+    <StudioPlaybackBadge v-if="task" class="mt-2" :task="task" />
+    <p v-else class="mt-2 text-[11px] text-gray-400 dark:text-dark-500">{{ t('studio.video.expiredReload') }}</p>
+    <slot />
+  </div>
+</template>

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -105,6 +105,10 @@
         "data-testid=\"bakeoff-tier\"",
         "data-testid=\"studio-bakeoff-run\"",
         "data-testid=\"bakeoff-panel\"",
+        "useMediaLibrary",
+        "StudioLocalSaveBanner",
+        "test-id=\"studio-bakeoff-save-reminder\"",
+        "data-testid=\"bakeoff-history\"",
         "gatewayGeminiImageViaChat",
         "isGeminiNativeImageModel"
       ],
@@ -941,6 +945,9 @@
         "data-testid=\"studio-image-model\"",
         "data-testid=\"studio-image-aspect\"",
         "data-testid=\"studio-image-generate\"",
+        "StudioLocalSaveBanner",
+        "test-id=\"studio-image-save-reminder\"",
+        "StudioImageExpired",
         "refreshOffloadedImageUrls",
         "pricesFlat"
       ],
@@ -954,6 +961,9 @@
         "data-testid=\"studio-video-play\"",
         "data-testid=\"studio-video-preview\"",
         "data-testid=\"studio-video-copy-link\"",
+        "StudioLocalSaveBanner",
+        "test-id=\"studio-video-save-reminder\"",
+        "StudioVideoUnavailable",
         "videoPlaybackUrl"
       ],
       "must_not_contain": [
@@ -965,6 +975,9 @@
       "path": "frontend/src/utils/studioMedia.tk.ts",
       "must_contain": [
         "export function videoPlaybackUrl",
+        "export function imageHistoryItemAvailable",
+        "export function shouldShowStudioSaveReminder",
+        "export function groupImageHistoryByTs",
         "data:video",
         "createObjectURL",
         "revokeObjectURL"

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3273,7 +3273,8 @@
       "must_contain": [
         "func UniversalShapeForRequest(",
         "func universalCandidatePlatforms(",
-        "return OpenAICompatPlatforms()",
+        "out := OpenAICompatPlatforms()",
+        "antigravity.IsImageModel(model)",
         "engine.CapabilityForEndpoint(bridgeEndpoint)",
         "func universalModelPlatformHint("
       ],


### PR DESCRIPTION
## 摘要

- BakeOff 接入 `useMediaLibrary`，与图片/视频单页共用同一 localStorage 历史；支持最多 6 模型同台对比、重新生成与「清空当前展示」（不删 library）。
- 三页统一 `StudioLocalSaveBanner` 强提示下载保存，图片/视频过期标记抽成共享组件与 helper（诚实说明预览失效原因）。
- 全能 Key 下 `gemini-*-image` 经 `/v1/chat/completions` 时候选平台纳入 antigravity，避免误路由到 Codex 并报 ChatGPT account 错误。

## 风险

- 常规风险：Studio 前端 + universal routing 行为变更；BakeOff 生成会写入与图片/视频 tab 相同的 library（设计如此）。
- 后端 universal 路由仅扩展 openai-chat 形状下 gemini-native 图片的候选平台，不影响其它形状。

## 验证

- `./scripts/preflight.sh` 本地 PASS（含 frontend dist freshness、gateway/frontend sentinels）
- `go test -tags=unit ./internal/service/... -run 'Universal|GeminiNativeImage'`（universal routing 回归）
- `pnpm exec vitest run src/views/user/studio/__tests__/BakeOff.spec.ts src/views/user/studio/__tests__/VideoStudio.spec.ts src/utils/__tests__/studioMedia.tk.spec.ts src/utils/__tests__/studioPlaybackStorage.tk.spec.ts src/utils/__tests__/studioGatewayError.tk.spec.ts`
- `pnpm typecheck`
- `pnpm --dir frontend run build`（embedded dist + frontend-source.json）

## 提交

- 6561630e6 fix(studio): 对齐 BakeOff 本地历史与下载提醒，修复全能 Key 的 gemini 图片路由

最新提交：6561630e6
