### PR TITLE
fix(gateway): ToolSearch 历史 signed thinking 预过滤 (#63792/#10199)

### DIFF
--- a/.cache/anthropic/cc-fact-checks.json
+++ b/.cache/anthropic/cc-fact-checks.json
@@ -57,6 +57,25 @@
         "backend/internal/service/gateway_service.go:if bare, aliased := tkStripContextWindowModelAlias(input.RequestModel); aliased {",
         "backend/internal/service/gateway_anthropic_context_window_alias_tk_test.go:func TestTkStripContextWindowModelAlias"
       ]
+    },
+    {
+      "upstream": "anthropics/claude-code#63792, anthropics/claude-code#10199",
+      "severity": "high",
+      "tokenkey_pr": "youxuanxue/sub2api (ToolSearch historical thinking pre-filter)",
+      "summary": "When Claude Code dynamic tool loading (ToolSearch) re-serializes prior assistant turns, signed thinking blocks in historical messages are perturbed and Anthropic returns 400 'cannot be modified', forcing a client strip-and-retry storm every turn. TokenKey proactively downgrades historical assistant thinking blocks to text before the first upstream call when ToolSearch tools are present, preserving assistant-prefill thinking and tool_use blocks. Wired on OAuth Forward and API-Key passthrough paths after FilterThinkingBlocks.",
+      "fixed_by": [
+        "backend/internal/service/gateway_request_tk_toolsearch_thinking.go",
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/gateway_request_tk_toolsearch_thinking_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/gateway_request_tk_toolsearch_thinking.go:func TkPrefilterToolSearchHistoricalThinking",
+        "backend/internal/service/gateway_request_tk_toolsearch_thinking.go:func tkBodyHasToolSearchTools",
+        "backend/internal/service/gateway_request_tk_toolsearch_thinking.go:func tkStripHistoricalAssistantThinking",
+        "backend/internal/service/gateway_service.go:TkPrefilterToolSearchHistoricalThinking(body, reqModel)",
+        "backend/internal/service/gateway_service.go:TkPrefilterToolSearchHistoricalThinking(input.Body, input.RequestModel)",
+        "backend/internal/service/gateway_request_tk_toolsearch_thinking_test.go:func TestTkPrefilterToolSearchHistoricalThinking_StripsHistoricalToolCoupledThinking"
+      ]
     }
   ]
 }

--- a/.cache/anthropic/cc-fixes.json
+++ b/.cache/anthropic/cc-fixes.json
@@ -3,6 +3,17 @@
   "rationale": "TokenKey-local registry of anthropics/claude-code issues this gateway has already addressed. Use this file before re-triaging a claude-code issue; the anthropic-cc-issue-watchdog reads it to mark issues fixed_in_tokenkey when the paired fact-check needles are present on main.",
   "issues": [
     {
+      "upstream": "anthropics/claude-code#63792, anthropics/claude-code#10199",
+      "tokenkey_pr": "youxuanxue/sub2api (ToolSearch historical thinking pre-filter)",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_request_tk_toolsearch_thinking.go",
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/gateway_request_tk_toolsearch_thinking_test.go"
+      ],
+      "summary": "When Claude Code dynamic tool loading (ToolSearch) re-serializes prior assistant turns, signed thinking blocks in historical messages are perturbed and Anthropic returns 400 'cannot be modified', forcing a client strip-and-retry storm every turn. TokenKey proactively downgrades historical assistant thinking blocks to text before the first upstream call when ToolSearch tools are present, preserving assistant-prefill thinking and tool_use blocks. Wired on OAuth Forward and API-Key passthrough paths after FilterThinkingBlocks."
+    },
+    {
       "upstream": "anthropics/claude-code#60913",
       "tokenkey_pr": "youxuanxue/sub2api ([1m] context-window model-alias strip)",
       "status": "fixed_in_tokenkey",

--- a/.cache/anthropic/cc-triage.json
+++ b/.cache/anthropic/cc-triage.json
@@ -4,24 +4,13 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded; gateway-relevance filtered",
   "rationale": "TokenKey-local triage cache for anthropics/claude-code issues, filtered for gateway/relay relevance. Most claude-code issues are client-side (IDE/terminal/MCP) and are marked not_applicable. Only human-pinned MANUAL_TRIAGE high/critical entries become fix candidates.",
   "counts": {
-    "needs_review": 372,
+    "fixed": 2,
+    "needs_review": 370,
     "medium": 8,
     "not_applicable": 771,
     "unknown_low_signal": 307
   },
   "issues": [
-    {
-      "upstream": "anthropics/claude-code#10199",
-      "url": "https://github.com/anthropics/claude-code/issues/10199",
-      "title": "[BUG] API Error 400 - Thinking Block Modification Error",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-26T18:01:18Z"
-    },
     {
       "upstream": "anthropics/claude-code#18028",
       "url": "https://github.com/anthropics/claude-code/issues/18028",
@@ -1016,19 +1005,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-26T22:29:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63792",
-      "url": "https://github.com/anthropics/claude-code/issues/63792",
-      "title": "Opus 4.8 + dynamic tool loading (ToolSearch) re-modifies signed thinking blocks → \"messages.N.content.M ... cannot be modified\" 400 storm → strip-and-retry every turn",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-28T10:47:10Z"
     },
     {
       "upstream": "anthropics/claude-code#63817",
@@ -4641,6 +4617,31 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
       "updated_at": "2026-06-27T18:46:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#10199",
+      "url": "https://github.com/anthropics/claude-code/issues/10199",
+      "title": "[BUG] API Error 400 - Thinking Block Modification Error",
+      "impact": "fixed",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "When Claude Code dynamic tool loading (ToolSearch) re-serializes prior assistant turns, signed thinking blocks in historical messages are perturbed and Anthropic returns 400 'cannot be modified', forcing a client strip-and-retry storm every turn. TokenKey proactively downgrades historical assistant thinking blocks to text before the first upstream call when ToolSearch tools are present, preserving assistant-prefill thinking and tool_use blocks. Wired on OAuth Forward and API-Key passthrough paths after FilterThinkingBlocks. Fixed by youxuanxue/sub2api (ToolSearch historical thinking pre-filter).",
+      "updated_at": "2026-06-26T18:01:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63792",
+      "url": "https://github.com/anthropics/claude-code/issues/63792",
+      "title": "Opus 4.8 + dynamic tool loading (ToolSearch) re-modifies signed thinking blocks → \"messages.N.content.M ... cannot be modified\" 400 storm → strip-and-retry every turn",
+      "impact": "fixed",
+      "categories": [
+        "request_shape_400",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "When Claude Code dynamic tool loading (ToolSearch) re-serializes prior assistant turns, signed thinking blocks in historical messages are perturbed and Anthropic returns 400 'cannot be modified', forcing a client strip-and-retry storm every turn. TokenKey proactively downgrades historical assistant thinking blocks to text before the first upstream call when ToolSearch tools are present, preserving assistant-prefill thinking and tool_use blocks. Wired on OAuth Forward and API-Key passthrough paths after FilterThinkingBlocks. Fixed by youxuanxue/sub2api (ToolSearch historical thinking pre-filter).",
+      "updated_at": "2026-06-28T10:47:10Z"
     },
     {
       "upstream": "anthropics/claude-code#10071",

--- a/backend/internal/service/gateway_request_tk_toolsearch_thinking.go
+++ b/backend/internal/service/gateway_request_tk_toolsearch_thinking.go
@@ -1,0 +1,228 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// TokenKey: proactive pre-filter for Claude Code ToolSearch + signed thinking storms.
+//
+// anthropics/claude-code#63792 (and the generic #10199 "Thinking Block Modification
+// Error"): when dynamic/on-demand tool loading (ToolSearch) is active, Claude Code
+// re-serializes prior assistant turns after the tool set changes. That perturbs
+// signed thinking/redacted_thinking blocks in historical messages; Anthropic rejects
+// the request with 400 "... cannot be modified". The client then strips the blocks
+// and retries — an extra full round-trip on every poisoned turn.
+//
+// TokenKey repairs PRE-FLIGHT (same net body shape as the client's post-400 retry,
+// without the wasted upstream call). Only historical assistant turns are touched;
+// an assistant-prefill final message is left intact for the interleaved-thinking
+// structural constraint.
+
+func tkBodyHasToolSearchTools(body []byte) bool {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() || len(tools.Array()) == 0 {
+		return false
+	}
+	if !bytes.Contains(body, []byte("tool_search")) {
+		return false
+	}
+	for _, t := range tools.Array() {
+		typ := strings.ToLower(t.Get("type").String())
+		if strings.Contains(typ, "tool_search") {
+			return true
+		}
+	}
+	return false
+}
+
+func tkBodyHasSignedThinkingHistory(body []byte) bool {
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return false
+	}
+	arr := msgs.Array()
+	if len(arr) == 0 {
+		return false
+	}
+	// Historical = any assistant turn before the last message, or all assistant
+	// turns when the last message is not an assistant prefill.
+	lastIsAssistantPrefill := arr[len(arr)-1].Get("role").String() == "assistant"
+	end := len(arr)
+	if lastIsAssistantPrefill {
+		end--
+	}
+	for i := 0; i < end; i++ {
+		if arr[i].Get("role").String() != "assistant" {
+			continue
+		}
+		content := arr[i].Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		for _, block := range content.Array() {
+			typ := block.Get("type").String()
+			if typ != "thinking" && typ != "redacted_thinking" {
+				continue
+			}
+			if typ == "thinking" {
+				if sig := block.Get("signature").String(); sig != "" {
+					return true
+				}
+				continue
+			}
+			if data := block.Get("data").String(); data != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TkPrefilterToolSearchHistoricalThinking downgrades signed thinking blocks in
+// historical assistant turns when ToolSearch tools are present. Returns the input
+// unchanged when the gate does not apply or when no modification is needed.
+func TkPrefilterToolSearchHistoricalThinking(body []byte, mappedModel string) []byte {
+	if !ShouldApplyRetryFilters(mappedModel) {
+		return body
+	}
+	if !tkBodyHasToolSearchTools(body) || !tkBodyHasSignedThinkingHistory(body) {
+		return body
+	}
+	return tkStripHistoricalAssistantThinking(body)
+}
+
+func tkStripHistoricalAssistantThinking(body []byte) []byte {
+	jsonStr := string(body)
+	msgsRes := gjson.Get(jsonStr, "messages")
+	if !msgsRes.Exists() || !msgsRes.IsArray() {
+		return body
+	}
+
+	var messages []any
+	if err := json.Unmarshal(sliceRawFromBody(body, msgsRes), &messages); err != nil {
+		return body
+	}
+	if len(messages) == 0 {
+		return body
+	}
+
+	prefillIdx := -1
+	if lastMap, ok := messages[len(messages)-1].(map[string]any); ok {
+		if role, _ := lastMap["role"].(string); role == "assistant" {
+			prefillIdx = len(messages) - 1
+		}
+	}
+
+	topLevelThinkingExists := gjson.Get(jsonStr, "thinking").Exists()
+	anyThinkingPreserved := false
+	modified := false
+
+	for i := 0; i < len(messages); i++ {
+		if i == prefillIdx {
+			continue
+		}
+		msgMap, ok := messages[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		role, _ := msgMap["role"].(string)
+		if role != "assistant" {
+			continue
+		}
+		content, ok := msgMap["content"].([]any)
+		if !ok {
+			continue
+		}
+
+		var newContent []any
+		modifiedThisMsg := false
+		for bi, block := range content {
+			blockMap, ok := block.(map[string]any)
+			if !ok {
+				if newContent != nil {
+					newContent = append(newContent, block)
+				}
+				continue
+			}
+			blockType, _ := blockMap["type"].(string)
+			switch blockType {
+			case "thinking", "redacted_thinking":
+				modifiedThisMsg = true
+				if newContent == nil {
+					newContent = make([]any, 0, len(content))
+					newContent = append(newContent, content[:bi]...)
+				}
+				if blockType == "thinking" {
+					if thinkingText, _ := blockMap["thinking"].(string); thinkingText != "" {
+						newContent = append(newContent, map[string]any{"type": "text", "text": thinkingText})
+					}
+				}
+				continue
+			}
+			if newContent != nil {
+				newContent = append(newContent, block)
+			}
+		}
+
+		if !modifiedThisMsg {
+			continue
+		}
+		modified = true
+		if newContent == nil || len(newContent) == 0 {
+			msgMap["content"] = []any{map[string]any{"type": "text", "text": "(assistant content removed)"}}
+			continue
+		}
+		msgMap["content"] = newContent
+	}
+
+	if prefillIdx >= 0 {
+		if msgMap, ok := messages[prefillIdx].(map[string]any); ok {
+			if content, ok := msgMap["content"].([]any); ok {
+				for _, block := range content {
+					if bm, ok := block.(map[string]any); ok {
+						if t, _ := bm["type"].(string); t == "thinking" || t == "redacted_thinking" {
+							anyThinkingPreserved = true
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	deleteTopLevelThinking := topLevelThinkingExists && !anyThinkingPreserved
+	if !modified && !deleteTopLevelThinking {
+		return body
+	}
+
+	out := body
+	if deleteTopLevelThinking {
+		if b, err := sjson.DeleteBytes(out, "thinking"); err == nil {
+			out = removeThinkingDependentContextStrategies(b)
+		} else {
+			return body
+		}
+	}
+	if modified {
+		msgsBytes, err := json.Marshal(messages)
+		if err != nil {
+			return body
+		}
+		var setErr error
+		out, setErr = sjson.SetRawBytes(out, "messages", msgsBytes)
+		if setErr != nil {
+			return body
+		}
+	}
+
+	logger.LegacyPrintf("service.gateway",
+		"[ToolSearchThinkingPrefilter] stripped historical signed thinking blocks before upstream forward (claude-code #63792)")
+	return out
+}

--- a/backend/internal/service/gateway_request_tk_toolsearch_thinking.go
+++ b/backend/internal/service/gateway_request_tk_toolsearch_thinking.go
@@ -175,7 +175,7 @@ func tkStripHistoricalAssistantThinking(body []byte) []byte {
 			continue
 		}
 		modified = true
-		if newContent == nil || len(newContent) == 0 {
+		if len(newContent) == 0 {
 			msgMap["content"] = []any{map[string]any{"type": "text", "text": "(assistant content removed)"}}
 			continue
 		}

--- a/backend/internal/service/gateway_request_tk_toolsearch_thinking_test.go
+++ b/backend/internal/service/gateway_request_tk_toolsearch_thinking_test.go
@@ -1,0 +1,120 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkBodyHasToolSearchTools(t *testing.T) {
+	require.True(t, tkBodyHasToolSearchTools([]byte(`{"tools":[{"type":"tool_search_tool_regex_20251119","name":"search"}],"messages":[]}`)))
+	require.True(t, tkBodyHasToolSearchTools([]byte(`{"tools":[{"type":"tool_search_tool_bm25_20251119","name":"search"}],"messages":[]}`)))
+	require.False(t, tkBodyHasToolSearchTools([]byte(`{"tools":[{"name":"Bash"}],"messages":[]}`)))
+	require.False(t, tkBodyHasToolSearchTools([]byte(`{"messages":[]}`)))
+}
+
+func TestTkBodyHasSignedThinkingHistory(t *testing.T) {
+	history := []byte(`{
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"hi"}]},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"plan","signature":"sig_hist"},
+				{"type":"tool_use","id":"toolu_1","name":"Bash","input":{}}
+			]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}
+		]
+	}`)
+	require.True(t, tkBodyHasSignedThinkingHistory(history))
+
+	prefillOnly := []byte(`{
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"hi"}]},
+			{"role":"assistant","content":[{"type":"thinking","thinking":"prefill","signature":"sig_pf"}]}
+		]
+	}`)
+	require.False(t, tkBodyHasSignedThinkingHistory(prefillOnly))
+}
+
+func TestTkPrefilterToolSearchHistoricalThinking_StripsHistoricalToolCoupledThinking(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-8",
+		"thinking":{"type":"adaptive"},
+		"tools":[{"type":"tool_search_tool_regex_20251119","name":"search"},{"name":"Bash"}],
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"task"}]},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"historical reasoning","signature":"EuAGCmMIDh_stale"},
+				{"type":"tool_use","id":"toolu_hist","name":"Bash","input":{"command":"ls"}}
+			]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_hist","content":"a.txt"}]},
+			{"role":"user","content":[{"type":"text","text":"continue"}]}
+		]
+	}`)
+
+	out := TkPrefilterToolSearchHistoricalThinking(input, "claude-opus-4-8")
+	require.NotEqual(t, string(input), string(out))
+
+	req := parseReq(t, out)
+	content := assistantContent(t, req, 1)
+	require.Equal(t, 0, countBlockType(content, "thinking"), "historical thinking must be stripped even in tool_use turns under ToolSearch")
+	require.Equal(t, 1, countBlockType(content, "tool_use"), "tool_use must remain")
+	require.Equal(t, 1, countBlockType(content, "text"), "thinking content should be preserved as text")
+}
+
+func TestTkPrefilterToolSearchHistoricalThinking_PreservesAssistantPrefill(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-8",
+		"thinking":{"type":"adaptive"},
+		"tools":[{"type":"tool_search_tool_regex_20251119","name":"search"}],
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"q"}]},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"old","signature":"sig_old"},
+				{"type":"text","text":"prior answer"}
+			]},
+			{"role":"assistant","content":[{"type":"thinking","thinking":"prefill","signature":"sig_pf"}]}
+		]
+	}`)
+
+	out := TkPrefilterToolSearchHistoricalThinking(input, "claude-opus-4-8")
+	req := parseReq(t, out)
+
+	earlier := assistantContent(t, req, 1)
+	require.Equal(t, 0, countBlockType(earlier, "thinking"))
+
+	prefill := assistantContent(t, req, 2)
+	require.Equal(t, 1, countBlockType(prefill, "thinking"), "assistant prefill thinking must be preserved")
+	_, hasThinking := req["thinking"]
+	require.True(t, hasThinking, "top-level thinking stays when prefill thinking survives")
+}
+
+func TestTkPrefilterToolSearchHistoricalThinking_NoOpWithoutToolSearch(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-8",
+		"tools":[{"name":"Bash"}],
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"keep","signature":"sig"},
+				{"type":"tool_use","id":"toolu_1","name":"Bash","input":{}}
+			]}
+		]
+	}`)
+	out := TkPrefilterToolSearchHistoricalThinking(input, "claude-opus-4-8")
+	require.Equal(t, input, out)
+}
+
+func TestTkPrefilterToolSearchHistoricalThinking_SkipsPassbackRequiredUpstream(t *testing.T) {
+	input := []byte(`{
+		"model":"deepseek-v4-pro",
+		"tools":[{"type":"tool_search_tool_regex_20251119","name":"search"}],
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"keep","signature":"sig"}
+			]}
+		]
+	}`)
+	out := TkPrefilterToolSearchHistoricalThinking(input, "deepseek-v4-pro")
+	require.Equal(t, input, out)
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -5375,6 +5375,13 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	if err := replaceBody(FilterThinkingBlocks(body, reqModel)); err != nil {
 		return nil, err
 	}
+	// TK: ToolSearch dynamic tool loading re-serializes historical signed thinking
+	// blocks (claude-code #63792 / #10199) → upstream 400 "cannot be modified" +
+	// client strip-and-retry storm. Pre-filter historical assistant thinking before
+	// the first upstream call when ToolSearch tools are present.
+	if err := replaceBody(TkPrefilterToolSearchHistoricalThinking(body, reqModel)); err != nil {
+		return nil, err
+	}
 	// Chinese LLM thinking.type 协议差异补正（如 MiniMax 只接受 adaptive；Anthropic-SDK
 	// 客户端默认发 enabled）。仅对 passback-required 上游生效（claude-* 不会进来）。
 	if ResolveThinkingProtocol(reqModel) == ThinkingProtocolPassbackRequired {
@@ -6107,6 +6114,8 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 			return nil, err
 		}
 	}
+	// TK: ToolSearch + stale signed thinking pre-filter (claude-code #63792 / #10199).
+	input.Body = TkPrefilterToolSearchHistoricalThinking(input.Body, input.RequestModel)
 
 	// Sticky routing: for non-Claude-Code clients hitting Anthropic API Key,
 	// derive + inject metadata.user_id so upstream prompt cache can bucket

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2067,6 +2067,23 @@
       "rationale": "Pure, fork-only UTF-8 / lone-surrogate sanitizer core (claude-code #60168 / #63885 / #64777), kept in a *_tk_*.go companion out of upstream-owned gateway_request.go (rule §5). TkSanitizeRequestBodyUTF8 rewrites lone JSON surrogate escapes and invalid raw UTF-8 to U+FFFD while preserving valid pairs / escaped backslashes and returning clean bodies byte-identical (changed=false, zero alloc). Anchor the two pure functions + the logging wrapper so an upstream refactor that consolidates body rewrites cannot delete this surface and silently re-expose the 'str is not valid UTF-8: surrogate' 400. Exhaustively covered by gateway_request_tk_utf8_test.go."
     },
     {
+      "path": "backend/internal/service/gateway_request_tk_toolsearch_thinking.go",
+      "must_contain": [
+        "func TkPrefilterToolSearchHistoricalThinking(body []byte, mappedModel string) []byte {",
+        "func tkBodyHasToolSearchTools(body []byte) bool {",
+        "func tkStripHistoricalAssistantThinking(body []byte) []byte {"
+      ],
+      "rationale": "Pure, fork-only ToolSearch historical signed-thinking pre-filter (claude-code #63792 / #10199), kept in a *_tk_*.go companion out of upstream-owned gateway_request.go (rule §5). When dynamic tool loading re-serializes prior assistant turns, stale signed thinking blocks trigger upstream 400 'cannot be modified' and a client strip-and-retry storm every turn. TkPrefilterToolSearchHistoricalThinking downgrades historical assistant thinking to text before the first upstream call when ToolSearch tools are present, preserving assistant-prefill thinking. Anchor the gate + stripper so an upstream merge cannot delete this surface and silently re-expose the per-turn double round-trip. Exhaustively covered by gateway_request_tk_toolsearch_thinking_test.go."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "TkPrefilterToolSearchHistoricalThinking(body, reqModel)",
+        "TkPrefilterToolSearchHistoricalThinking(input.Body, input.RequestModel)"
+      ],
+      "rationale": "Wiring of the ToolSearch historical thinking pre-filter (claude-code #63792 / #10199) into OAuth Forward and API-Key passthrough paths after FilterThinkingBlocks / UTF-8 sanitize. One-line hooks in an upstream-shaped file compile clean if dropped, silently re-exposing the per-turn 400 + strip-and-retry storm. Anchor both call shapes; the pure filter is guarded by gateway_request_tk_toolsearch_thinking.go."
+    },
+    {
       "path": "backend/internal/server/http.go",
       "must_contain": [
         "tkResolveTrustedProxies(cfg.Server.TrustedProxies)"

--- a/scripts/upstream/issue-watchdog.py
+++ b/scripts/upstream/issue-watchdog.py
@@ -71,6 +71,27 @@ def issue_url(upstream: str) -> str:
     return f"https://github.com/{repo}/issues/{number}"
 
 
+def issue_numbers_in_upstream(upstream: str) -> set[int]:
+    """All `#NNNN` issue numbers referenced in an upstream field.
+
+    Handles multi-issue fact-check rows such as
+    `anthropics/claude-code#60168, #63885, anthropics/claude-code#64777`.
+    """
+    nums = [int(m) for m in re.findall(r"#([0-9]+)", upstream or "")]
+    return set(nums)
+
+
+def upstream_check_covers_entry(check_upstream: str, entry_upstream: str) -> bool:
+    """True when a fact-check/fix `upstream` field covers a triage row."""
+    if check_upstream == entry_upstream:
+        return True
+    try:
+        entry_num = issue_number(entry_upstream)
+    except ValueError:
+        return False
+    return entry_num in issue_numbers_in_upstream(check_upstream)
+
+
 def sh(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, text=True, capture_output=True, check=check)
 
@@ -127,7 +148,7 @@ def update_triage_fixed(triage: dict[str, Any], check: dict[str, Any]) -> bool:
     upstream = check["upstream"]
     changed = False
     for entry in triage.get("issues", []):
-        if entry.get("upstream") != upstream:
+        if not upstream_check_covers_entry(upstream, entry.get("upstream", "")):
             continue
         if entry.get("impact") != "fixed":
             entry["impact"] = "fixed"


### PR DESCRIPTION
## 摘要

- 针对 Claude Code ToolSearch 动态工具加载导致历史 assistant signed thinking 被污染、每轮触发 400「cannot be modified」+ strip-and-retry 风暴的问题，在 OAuth Forward 与 API-Key passthrough 路径增加 **pre-flight 预过滤**：检测到 ToolSearch 工具时，将历史 assistant 的 thinking/redacted_thinking 降级为 text，保留 tool_use 与 assistant prefill thinking。
- 修复 `issue-watchdog.py` 的 `update_triage_fixed`：支持 fact-check 中逗号分隔的多 issue `upstream`，使 #63792 在 `cc-triage.json` 中正确标记为 `fixed_in_tokenkey`。
- 同步更新 `cc-fact-checks.json`、`cc-fixes.json`、`gateway-tk.json` sentinel 锚点。
- 已 merge `origin/main`（#1069 cache refresh + #1086），解决 `cc-triage.json` 冲突。

## 风险

- 常规风险：仅影响含 ToolSearch 工具且带历史 signed thinking 的 Anthropic 请求；无 ToolSearch 或 passback-required 上游为 no-op。
- 历史 tool_use 回合中的 thinking 会被降级为 text（与 Claude Code 客户端 post-400 retry 行为一致），可能轻微影响 prompt cache 断点，但优于每轮额外往返。

## 验证

- `go test -tags=unit ./internal/service -run 'TestTkPrefilterToolSearch|TestFilterThinkingBlocksForRetry' -count=1` — PASS
- `./scripts/preflight.sh` — PASS（含 fix-ledger consistency、gateway TK sentinel）
- `python3 scripts/upstream/apply-fix-ledger.py --ledger anthropic --apply` — #63792 triage 已标 `fixed_in_tokenkey`

## 提交

- `0d730c104` fix(gateway): pre-filter ToolSearch stale signed thinking before forward
- `ddf165031` merge: sync origin/main into fix/anthropic-toolsearch-thinking-prefilter
- `5eebc3b1a` fix(gateway): satisfy staticcheck S1009 in ToolSearch prefilter

最新提交：5eebc3b1a
