### PR TITLE
fix(studio): 预览失败后保留视频下载入口

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 529,
-  "hash": "63a3b05bf57c2dd0dc9028a0b4b2e28afb7cc7b8e42558926f1bc43a7ae1aede",
+  "hash": "7d274f71758e1bc881b2003ca71b4cc2c615a3a6fbf68b4f7fd18303841dd2fe",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 529,
-  "hash": "739816f0d8eeb0597ddb93d730714c8297cf99188f97ae23187f8027727906ac",
+  "hash": "63a3b05bf57c2dd0dc9028a0b4b2e28afb7cc7b8e42558926f1bc43a7ae1aede",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -301,7 +301,7 @@
           </button>
         </div>
         <div class="flex min-h-0 flex-1 items-center justify-center px-4" @click.self="closeVideoPreview">
-          <video v-if="videoPreviewUrl" :src="videoPreviewUrl" controls autoplay playsinline class="max-h-full max-w-full rounded-lg bg-black shadow-2xl"></video>
+          <video v-if="videoPreviewUrl" :src="videoPreviewUrl" controls autoplay playsinline class="h-full max-h-full w-full max-w-full rounded-lg bg-black object-contain shadow-2xl"></video>
         </div>
         <div class="flex flex-wrap items-center justify-center gap-3 p-4">
           <span class="max-w-[60vw] truncate text-xs text-white/80" :title="videoPreviewLabel">{{ videoPreviewLabel }}</span>

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -301,7 +301,7 @@
             autoplay
             playsinline
             preload="auto"
-            class="max-h-full max-w-full rounded-lg bg-black shadow-2xl"
+            class="h-full max-h-full w-full max-w-full rounded-lg bg-black object-contain shadow-2xl"
             @loadeddata="previewMediaReady = true"
             @error="onPreviewError"
           ></video>

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -258,6 +258,8 @@
           </div>
           <div class="flex gap-3 text-[11px] font-medium text-gray-500 dark:text-dark-400">
             <button v-if="videoTaskPlaybackAvailable(task)" type="button" class="text-primary-600 dark:text-primary-300" @click="openPreview(task)">{{ t('studio.video.play') }}</button>
+            <button v-if="task.url" type="button" class="text-primary-600 dark:text-primary-300" data-testid="studio-video-download" @click="downloadMedia(task.url, `tokenkey-${task.id}.mp4`)">{{ t('studio.video.download') }}</button>
+            <button v-if="task.url" type="button" class="text-gray-500 dark:text-dark-300" data-testid="studio-video-copy-card-link" @click="copyTaskLink(task.url)">{{ copiedTaskUrl === task.url ? t('studio.video.copied') : t('studio.video.copyLink') }}</button>
             <button type="button" @click="reuse(task)">{{ t('studio.image.usePrompt') }}</button>
             <button type="button" @click="removeTask(task.id)">{{ t('studio.clear') }}</button>
           </div>
@@ -527,7 +529,9 @@ const previewUrl = ref('')
 const previewState = ref<'loading' | 'ready' | 'expired'>('loading')
 // Transient "copied" confirmation for the copy-link button (no toast/banner).
 const copied = ref(false)
+const copiedTaskUrl = ref('')
 let copiedTimer: ReturnType<typeof setTimeout> | undefined
+let copiedTaskTimer: ReturnType<typeof setTimeout> | undefined
 let previewRevoke: () => void = () => {}
 
 async function openPreview(task: VideoTaskItem): Promise<void> {
@@ -552,10 +556,12 @@ async function openPreview(task: VideoTaskItem): Promise<void> {
 
 // The <video> failed to load — mark the card prompt-only and close the lightbox
 // instead of trapping the user in an "expired" modal they already saw on the list.
+// Keep the live-session URL so the card can still offer Download / Copy.
+// localStorage persistence continues to strip http(s) links on reload.
 function onPreviewError(): void {
   const task = preview.value
   closePreview()
-  if (task) library.patchVideoTask(task.id, { urlExpired: true, url: '' })
+  if (task) library.patchVideoTask(task.id, { urlExpired: true })
 }
 
 // Re-attempt playback — recovers from a transient media error without forcing
@@ -576,6 +582,18 @@ async function copyPreviewLink(): Promise<void> {
     copiedTimer = setTimeout(() => (copied.value = false), 1500)
   } catch {
     /* clipboard unavailable / blocked — silent, Download still works */
+  }
+}
+
+async function copyTaskLink(url: string): Promise<void> {
+  if (!url) return
+  try {
+    await navigator.clipboard?.writeText(url)
+    copiedTaskUrl.value = url
+    if (copiedTaskTimer) clearTimeout(copiedTaskTimer)
+    copiedTaskTimer = setTimeout(() => (copiedTaskUrl.value = ''), 1500)
+  } catch {
+    /* clipboard unavailable / blocked — Download still works */
   }
 }
 
@@ -666,6 +684,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeydown)
   if (copiedTimer) clearTimeout(copiedTimer)
+  if (copiedTaskTimer) clearTimeout(copiedTaskTimer)
   previewRevoke()
 })
 </script>

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -4,11 +4,11 @@ import { createI18n } from 'vue-i18n'
 import en from '@/i18n/locales/en'
 import BakeOff from '../BakeOff.vue'
 import * as playground from '@/api/playground'
-import type { ImageHistoryItem } from '@/composables/useMediaLibrary'
+import type { ImageHistoryItem, VideoTaskItem } from '@/composables/useMediaLibrary'
 
 const libraryMock = vi.hoisted(() => ({
   images: { value: [] as ImageHistoryItem[] },
-  videoTasks: { value: [] },
+  videoTasks: { value: [] as VideoTaskItem[] },
   addImages: vi.fn(),
   clearImages: vi.fn(),
   upsertVideoTask: vi.fn(),
@@ -161,6 +161,51 @@ describe('BakeOff image routing', () => {
     expect(wrapper.findAll('[data-testid="bakeoff-panel"]').length).toBe(0)
     expect(wrapper.find('[data-testid="bakeoff-history"]').exists()).toBe(true)
     expect(wrapper.findAll('[data-testid="bakeoff-history-item"]').length).toBe(2)
+  })
+
+  it('opens history video previews at full lightbox size', async () => {
+    const batchMs = 1710000000000
+    libraryMock.videoTasks.value = [
+      {
+        id: 'vt_a',
+        prompt: 'a red apple',
+        model: 'veo-3.1-generate-001',
+        vendorLabel: 'Google Vertex',
+        seconds: 8,
+        estCost: 4.8,
+        keyId: 1,
+        state: 'succeeded',
+        url: 'https://cdn.example/a.mp4',
+        submittedAtMs: batchMs,
+        elapsedS: 8,
+      },
+      {
+        id: 'vt_b',
+        prompt: 'a red apple',
+        model: 'seedance-1-0-pro-250528',
+        vendorLabel: 'Doubao',
+        seconds: 10,
+        estCost: 1.09,
+        keyId: 1,
+        state: 'succeeded',
+        url: 'https://cdn.example/b.mp4',
+        submittedAtMs: batchMs,
+        elapsedS: 10,
+      },
+    ]
+    const wrapper = mount(BakeOff, {
+      props: baseProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true, teleport: true } },
+    })
+
+    await wrapper.get('[data-testid="bakeoff-history-item"] button').trigger('click')
+    await flushPromises()
+
+    const previewVideo = wrapper.get('[data-testid="bakeoff-video-preview"] video')
+    expect(previewVideo.attributes('src')).toBe('https://cdn.example/a.mp4')
+    expect(previewVideo.classes()).toEqual(
+      expect.arrayContaining(['h-full', 'w-full', 'object-contain', 'max-h-full', 'max-w-full'])
+    )
   })
 
   it('shows friendly panel error for codex unsupported gemini image', async () => {

--- a/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
@@ -164,9 +164,12 @@ describe('VideoStudio succeeded-task presentation', () => {
     await flushPromises()
 
     expect(w.find('[data-testid="studio-video-preview"]').exists()).toBe(false)
-    expect(libraryMock.patchVideoTaskSpy).toHaveBeenCalledWith('vt_abc', { urlExpired: true, url: '' })
+    expect(libraryMock.patchVideoTaskSpy).toHaveBeenCalledWith('vt_abc', { urlExpired: true })
     expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(false)
     expect(w.find('[data-testid="studio-video-expired"]').exists()).toBe(true)
+    expect(w.find('[data-testid="studio-video-download"]').exists()).toBe(true)
+    expect(w.find('[data-testid="studio-video-copy-card-link"]').exists()).toBe(true)
+    expect(libraryMock.videoTasks.value[0].url).toBe('https://cdn.example/upstream.mp4')
   })
 
   it('plays an http upstream clip directly without re-fetching through TokenKey', async () => {

--- a/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
@@ -179,8 +179,10 @@ describe('VideoStudio succeeded-task presentation', () => {
     await w.find('[data-testid="studio-video-play"]').trigger('click')
     await flushPromises()
     expect(gatewayVideoFetch).not.toHaveBeenCalled()
-    expect(w.find('[data-testid="studio-video-preview"] video').attributes('src')).toBe(
-      'https://cdn.example/upstream.mp4'
+    const previewVideo = w.find('[data-testid="studio-video-preview"] video')
+    expect(previewVideo.attributes('src')).toBe('https://cdn.example/upstream.mp4')
+    expect(previewVideo.classes()).toEqual(
+      expect.arrayContaining(['h-full', 'w-full', 'object-contain', 'max-h-full', 'max-w-full'])
     )
   })
 

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -961,6 +961,8 @@
         "data-testid=\"studio-video-play\"",
         "data-testid=\"studio-video-preview\"",
         "data-testid=\"studio-video-copy-link\"",
+        "data-testid=\"studio-video-download\"",
+        "data-testid=\"studio-video-copy-card-link\"",
         "StudioLocalSaveBanner",
         "test-id=\"studio-video-save-reminder\"",
         "StudioVideoUnavailable",
@@ -969,7 +971,7 @@
       "must_not_contain": [
         "poll.refreshUrl"
       ],
-      "rationale": "TK-only Studio video-generation surface (mounted by MediaStudioView when mode==='video'). The model picker + generate button are the contract the studio e2e drives. studio-video-play (the succeeded-card poster tile) + studio-video-preview (the in-page lightbox) REPLACE the old always-on inline <video> and the open-in-new-tab link: the lightbox plays http(s) upstream URLs directly in the browser, while inline data:video results are converted into temporary Blob URLs for this tab and revoked on close/unmount. That keeps playback browser-local and prevents opening a succeeded card from refetching TokenKey as a video server. The data:video->Blob conversion + revoke now lives in the shared videoPlaybackUrl helper (utils/studioMedia.tk.ts), used by both this lightbox and Bake-Off; this anchor pins that import/usage so the no-rehost playback can't be silently reverted to an always-on <video>. studio-video-copy-link remains the in-lightbox affordance for copying upstream/direct media URLs."
+      "rationale": "TK-only Studio video-generation surface (mounted by MediaStudioView when mode==='video'). The model picker + generate button are the contract the studio e2e drives. studio-video-play (the succeeded-card poster tile) + studio-video-preview (the in-page lightbox) REPLACE the old always-on inline <video> and the open-in-new-tab link: the lightbox plays http(s) upstream URLs directly in the browser, while inline data:video results are converted into temporary Blob URLs for this tab and revoked on close/unmount. That keeps playback browser-local and prevents opening a succeeded card from refetching TokenKey as a video server. The data:video->Blob conversion + revoke now lives in the shared videoPlaybackUrl helper (utils/studioMedia.tk.ts), used by both this lightbox and Bake-Off; this anchor pins that import/usage so the no-rehost playback can't be silently reverted to an always-on <video>. studio-video-copy-link remains the in-lightbox affordance for copying upstream/direct media URLs, while studio-video-download + studio-video-copy-card-link are the card-level escape hatches that must stay visible when cross-origin playback fails and the preview tile is marked unavailable."
     },
     {
       "path": "frontend/src/utils/studioMedia.tk.ts",


### PR DESCRIPTION
## 摘要
- 修复视频生成卡片在跨域/上游直链预览失败后只剩“不可预览”提示、没有下载入口的问题。
- 预览失败时只标记 `urlExpired`，不再清空当前会话里的上游 URL；成功卡片始终保留下载与复制链接按钮。
- 放大 VideoStudio 与 BakeOff 的视频 lightbox，使点击预览后视频占满可用预览区域并保持比例，不再停留在浏览器默认小播放器尺寸。
- 更新 VideoStudio / BakeOff 回归测试与 frontend TK sentinel，防止后续上游合并静默移除卡片级下载/复制兜底入口。

## 风险
- 低风险：局部前端 bugfix，只影响 Studio 视频成功卡片的预览失败兜底行为和视频 lightbox 展示尺寸。
- 不改变持久化策略：刷新后仍不会保留 http(s) 上游直链，只在当前会话内提供下载/复制。
- sentinel-registry-reviewed：已更新 `scripts/sentinels/frontend-tk.json`，把卡片级下载/复制按钮纳入机械锚点；本次 lightbox 尺寸调整由聚焦测试覆盖。

## 验证
- `pnpm exec vitest run src/views/user/studio/__tests__/VideoStudio.spec.ts src/views/user/studio/__tests__/BakeOff.spec.ts`
- `pnpm exec vue-tsc --noEmit`
- `pnpm --dir frontend run build`
- `python3 scripts/sentinels/check-frontend-tk.py --quiet`
- `python3 scripts/sentinels/check-registry-update-gate.py --base origin/main --head HEAD --pr-body /dev/null`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

## 提交
- `52e9fd569 fix(studio): keep video download available after preview failure`
- `b9bc6c4ab fix(studio): enlarge video preview lightbox`
- 最新提交：`b9bc6c4ab`
