### PR TITLE
fix(studio): 加速首屏加载、同台防误触与视频预览兜底

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 529,
-  "hash": "7d274f71758e1bc881b2003ca71b4cc2c615a3a6fbf68b4f7fd18303841dd2fe",
+  "hash": "ec904e2ee33dd778746d5bbfee1652b8b9eb2aa957ca3b2ed3bea9c4177cdd99",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 529,
-  "hash": "ec904e2ee33dd778746d5bbfee1652b8b9eb2aa957ca3b2ed3bea9c4177cdd99",
+  "hash": "78c34998667c806db17e83bd5440ecdcae58d1899f224757292f87e0498d5bd3",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -159,9 +159,12 @@
               </span>
             </span>
           </button>
-          <div v-else-if="p.state === 'succeeded'" class="flex aspect-video items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50 px-2 text-center text-[11px] text-gray-500 dark:border-dark-600 dark:bg-dark-800/60 dark:text-dark-400">
-            {{ t('studio.video.expiredReload') }}
-          </div>
+          <StudioVideoUnavailable
+            v-else-if="p.state === 'succeeded'"
+            :prompt="prompt"
+            :task="panelPlaybackTask(p)"
+            test-id="bakeoff-video-expired"
+          />
           <div v-else class="flex aspect-video items-center justify-center rounded-lg bg-gray-50 text-xs text-gray-500 dark:bg-dark-800 dark:text-dark-400">
             <span v-if="p.state === 'processing'" class="inline-flex items-center gap-1.5"><span class="h-2 w-2 animate-pulse rounded-full bg-primary-500"></span>{{ t('studio.video.statusProcessing') }} {{ formatElapsed(p.elapsedS || 0) }}</span>
             <span v-else-if="p.state === 'failed'" class="px-2 text-center text-red-500">{{ p.errorMessage || t('studio.bakeoff.failed') }}</span>
@@ -169,7 +172,10 @@
           </div>
         </template>
         <div class="mt-2 flex flex-wrap items-center justify-between gap-2 text-sm">
-          <span class="font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(p.cost) }}</span>
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(p.cost) }}</span>
+            <StudioPlaybackBadge v-if="modality === 'video' && bakePanelVideoPlayable(p)" :task="panelPlaybackTask(p)!" />
+          </div>
           <div class="flex items-center gap-2">
             <button
               v-if="modality === 'image' && p.src"
@@ -180,9 +186,10 @@
               {{ t('studio.image.download') }}
             </button>
             <button
-              v-else-if="modality === 'video' && bakePanelVideoPlayable(p) && p.url"
+              v-else-if="modality === 'video' && p.state === 'succeeded' && p.url"
               type="button"
               class="text-[11px] font-medium text-primary-600 dark:text-primary-300"
+              data-testid="bakeoff-video-download"
               @click="downloadMedia(p.url!, `tokenkey-${p.taskId || p.modelId}.mp4`)"
             >
               {{ t('studio.video.download') }}
@@ -272,7 +279,7 @@
                 <span class="ml-auto text-xs font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(task.estCost) }}</span>
               </div>
               <button
-                v-if="videoTaskPlaybackAvailable(task) && task.url"
+                v-if="task.state === 'succeeded' && task.url"
                 type="button"
                 class="text-[10px] font-medium text-primary-600 dark:text-primary-300"
                 @click="downloadMedia(task.url, `tokenkey-${task.id}.mp4`)"
@@ -290,7 +297,7 @@
          rendering MAX_PANELS always-on <video> elements. -->
     <Teleport to="body">
       <div
-        v-if="videoPreviewUrl"
+        v-if="videoPreviewOpen"
         class="fixed inset-0 z-[100] flex flex-col bg-black/85 backdrop-blur-sm"
         data-testid="bakeoff-video-preview"
         @click.self="closeVideoPreview"
@@ -300,13 +307,33 @@
             {{ t('studio.video.close') }} ✕
           </button>
         </div>
-        <div class="flex min-h-0 flex-1 items-center justify-center px-4" @click.self="closeVideoPreview">
-          <video v-if="videoPreviewUrl" :src="videoPreviewUrl" controls autoplay playsinline class="h-full max-h-full w-full max-w-full rounded-lg bg-black object-contain shadow-2xl"></video>
+        <div class="relative flex min-h-0 flex-1 items-center justify-center px-4" @click.self="closeVideoPreview">
+          <video
+            v-if="videoPreviewState === 'ready' && videoPreviewUrl"
+            :src="videoPreviewUrl"
+            controls
+            autoplay
+            playsinline
+            preload="auto"
+            class="h-full max-h-full w-full max-w-full rounded-lg bg-black object-contain shadow-2xl"
+            @loadeddata="videoPreviewMediaReady = true"
+            @error="onVideoPreviewError"
+          ></video>
+          <div v-if="videoPreviewState === 'ready' && videoPreviewUrl && !videoPreviewMediaReady" class="absolute text-sm text-white/80">{{ t('studio.video.previewBuffering') }}</div>
+          <div v-else-if="videoPreviewState === 'loading'" class="text-sm text-white/80">{{ t('studio.video.loadingPreview') }}</div>
+          <div v-else class="max-w-sm rounded-xl bg-white/10 p-6 text-center">
+            <p class="text-sm font-semibold text-white">{{ t('studio.video.expiredTitle') }}</p>
+            <p class="mt-1 text-xs text-white/70">{{ t('studio.video.expiredHint') }}</p>
+            <div class="mt-3 flex items-center justify-center gap-2">
+              <button type="button" class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100" @click="retryVideoPreview">{{ t('studio.video.retry') }}</button>
+            </div>
+          </div>
         </div>
         <div class="flex flex-wrap items-center justify-center gap-3 p-4">
           <span class="max-w-[60vw] truncate text-xs text-white/80" :title="videoPreviewLabel">{{ videoPreviewLabel }}</span>
           <span v-if="videoPreviewCost != null" class="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[11px] font-semibold text-white">{{ formatUsd(videoPreviewCost) }}</span>
-          <button v-if="videoPreviewUrl" type="button" class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100" @click="downloadMedia(videoPreviewUrl, `tokenkey-bakeoff-preview.mp4`)">{{ t('studio.video.download') }}</button>
+          <button v-if="videoPreviewDownloadUrl" type="button" class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100" @click="downloadMedia(videoPreviewDownloadUrl, `tokenkey-bakeoff-preview.mp4`)">{{ t('studio.video.download') }}</button>
+          <button v-if="videoPreviewState === 'ready' && videoPreviewUrl" type="button" class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white" data-testid="bakeoff-video-copy-link" @click="copyVideoPreviewLink">{{ copiedPreviewLink ? t('studio.video.copied') : t('studio.video.copyLink') }}</button>
         </div>
       </div>
     </Teleport>
@@ -399,6 +426,7 @@ interface BakePanel {
   src?: string
   taskId?: string
   url?: string
+  urlExpired?: boolean
   elapsedS?: number
   errorMessage?: string
 }
@@ -431,8 +459,12 @@ function patchVideoTask(id: string, patch: Partial<VideoTaskItem>): void {
   const panel = panels.value.find((p) => p.taskId === id)
   if (panel) {
     if (patch.state) panel.state = patch.state
-    if (patch.url != null) panel.url = patch.url
+    if (typeof patch.url === 'string' && (patch.url !== '' || patch.state !== 'processing')) {
+      panel.url = patch.url
+    }
+    if (patch.urlExpired != null) panel.urlExpired = patch.urlExpired
     if (patch.elapsedS != null) panel.elapsedS = patch.elapsedS
+    if (patch.errorMessage != null) panel.errorMessage = patch.errorMessage
   }
   if (patch.url) void tagVideoPlayback(id, patch.url)
 }
@@ -469,7 +501,20 @@ const showSaveReminder = computed(() =>
 )
 
 function bakePanelVideoPlayable(p: BakePanel): boolean {
-  return p.state === 'succeeded' && !!p.url
+  if (p.state !== 'succeeded') return false
+  return videoTaskPlaybackAvailable({ state: p.state, url: p.url ?? '', urlExpired: p.urlExpired })
+}
+
+function panelPlaybackTask(p: BakePanel): Pick<VideoTaskItem, 'playbackStorage' | 'urlExpired' | 'url'> | undefined {
+  if (!p.url && !p.urlExpired) return undefined
+  const stored = p.taskId ? library.videoTasks.value.find((t) => t.id === p.taskId) : undefined
+  const url = p.url ?? stored?.url ?? ''
+  if (!url && !p.urlExpired && !stored?.urlExpired) return undefined
+  return {
+    url,
+    urlExpired: p.urlExpired ?? stored?.urlExpired,
+    playbackStorage: stored?.playbackStorage,
+  }
 }
 
 function downloadImage(src: string, id: string): void {
@@ -482,37 +527,87 @@ function modelLabel(modelId: string): string {
 }
 
 // ---- In-page video lightbox (on-demand playback; no always-on <video>) ----------
+const videoPreviewOpen = ref(false)
 const videoPreviewUrl = ref('')
+const videoPreviewRawUrl = ref('')
+const videoPreviewTaskId = ref<string | undefined>()
 const videoPreviewLabel = ref('')
 const videoPreviewCost = ref<number | null>(null)
+const videoPreviewState = ref<'loading' | 'ready' | 'expired'>('loading')
+const videoPreviewMediaReady = ref(false)
+const copiedPreviewLink = ref(false)
 let videoPreviewRevoke: () => void = () => {}
+let copiedPreviewTimer: ReturnType<typeof setTimeout> | undefined
 
-function openVideoPreviewFromUrl(label: string, cost: number, url: string): void {
+const videoPreviewDownloadUrl = computed(() => videoPreviewRawUrl.value || videoPreviewUrl.value)
+
+function openVideoPreviewFromUrl(label: string, cost: number, url: string, taskId?: string): void {
   if (!url) return
   videoPreviewRevoke()
-  const playback = videoPlaybackUrl(url)
-  videoPreviewRevoke = playback.revoke
+  videoPreviewOpen.value = true
   videoPreviewLabel.value = label
   videoPreviewCost.value = cost
+  videoPreviewRawUrl.value = url
+  videoPreviewTaskId.value = taskId
+  videoPreviewUrl.value = ''
+  videoPreviewState.value = 'loading'
+  videoPreviewMediaReady.value = false
+  const playback = videoPlaybackUrl(url)
+  videoPreviewRevoke = playback.revoke
   videoPreviewUrl.value = playback.url
+  videoPreviewState.value = playback.url ? 'ready' : 'expired'
 }
 
 function openVideoPreview(panel: BakePanel): void {
-  if (!panel.url) return
-  openVideoPreviewFromUrl(panel.label, panel.cost, panel.url)
+  if (panel.state !== 'succeeded' || !panel.url) return
+  if (!videoTaskPlaybackAvailable({ state: panel.state, url: panel.url, urlExpired: panel.urlExpired })) return
+  openVideoPreviewFromUrl(panel.label, panel.cost, panel.url, panel.taskId)
 }
 
 function openVideoHistoryPreview(task: VideoTaskItem): void {
   if (!videoTaskPlaybackAvailable(task) || !task.url) return
-  openVideoPreviewFromUrl(modelLabel(task.model), task.estCost, task.url)
+  openVideoPreviewFromUrl(modelLabel(task.model), task.estCost, task.url, task.id)
+}
+
+function onVideoPreviewError(): void {
+  const taskId = videoPreviewTaskId.value
+  closeVideoPreview()
+  if (taskId) patchVideoTask(taskId, { urlExpired: true })
+}
+
+function retryVideoPreview(): void {
+  if (!videoPreviewRawUrl.value) return
+  openVideoPreviewFromUrl(
+    videoPreviewLabel.value,
+    videoPreviewCost.value ?? 0,
+    videoPreviewRawUrl.value,
+    videoPreviewTaskId.value
+  )
+}
+
+async function copyVideoPreviewLink(): Promise<void> {
+  if (!videoPreviewUrl.value) return
+  try {
+    await navigator.clipboard?.writeText(videoPreviewUrl.value)
+    copiedPreviewLink.value = true
+    if (copiedPreviewTimer) clearTimeout(copiedPreviewTimer)
+    copiedPreviewTimer = setTimeout(() => (copiedPreviewLink.value = false), 1500)
+  } catch {
+    /* clipboard unavailable — Download still works */
+  }
 }
 
 function closeVideoPreview(): void {
   videoPreviewRevoke()
   videoPreviewRevoke = () => {}
+  videoPreviewOpen.value = false
   videoPreviewLabel.value = ''
   videoPreviewCost.value = null
+  videoPreviewRawUrl.value = ''
+  videoPreviewTaskId.value = undefined
   videoPreviewUrl.value = ''
+  videoPreviewState.value = 'loading'
+  videoPreviewMediaReady.value = false
 }
 
 onBeforeUnmount(closeVideoPreview)

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -35,7 +35,7 @@
           rows="2"
           class="w-full resize-none rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20 dark:border-dark-600 dark:bg-dark-950 dark:text-white"
           :placeholder="t('studio.bakeoff.promptPlaceholder')"
-          :disabled="running"
+          :disabled="isBusy"
         />
 
         <div class="mt-3 flex flex-wrap items-center gap-2">
@@ -48,7 +48,7 @@
             :class="selectedModelIds.includes(r.model.modelId)
               ? 'border-primary-600 bg-primary-600 text-white'
               : 'border-gray-200 text-gray-600 hover:border-primary-300 dark:border-dark-600 dark:text-dark-300'"
-            :disabled="running || (!selectedModelIds.includes(r.model.modelId) && selectedModelIds.length >= MAX_PANELS)"
+            :disabled="isBusy || (!selectedModelIds.includes(r.model.modelId) && selectedModelIds.length >= MAX_PANELS)"
             data-testid="bakeoff-tier"
             @click="toggleModel(r.model.modelId)"
           >
@@ -76,7 +76,7 @@
             type="button"
             class="rounded-lg border px-3 py-1.5 text-sm font-medium tabular-nums transition disabled:cursor-not-allowed disabled:opacity-50"
             :class="duration === d ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 text-gray-600 hover:border-primary-300 dark:border-dark-600 dark:text-dark-300'"
-            :disabled="running"
+            :disabled="isBusy"
             @click="duration = d"
           >
             {{ d }} s
@@ -94,7 +94,7 @@
             {{ runButtonLabel }}
           </button>
           <button
-            v-if="panels.length && !running"
+            v-if="panels.length && !isBusy"
             type="button"
             class="rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-600 transition hover:border-gray-300 dark:border-dark-600 dark:text-dark-300"
             data-testid="studio-bakeoff-clear-results"
@@ -403,6 +403,10 @@ interface BakePanel {
   errorMessage?: string
 }
 const panels = ref<BakePanel[]>([])
+/** Submit phase OR any panel still polling upstream — one gate for the whole run. */
+const isBusy = computed(
+  () => running.value || panels.value.some((p) => p.state === 'processing')
+)
 const activeRunTs = ref<number | null>(null)
 
 const library = useMediaLibrary(props.userId)
@@ -558,20 +562,20 @@ const totalHold = computed(() =>
 )
 const canAfford = computed(() => totalHold.value <= props.balance)
 const canRun = computed(
-  () => !running.value && !!props.apiKey && !!prompt.value.trim() && selectedModelIds.value.length >= 2 && canAfford.value && props.keyId != null
+  () => !isBusy.value && !!props.apiKey && !!prompt.value.trim() && selectedModelIds.value.length >= 2 && canAfford.value && props.keyId != null
 )
 const promptChangedSinceRun = computed(
   () => panels.value.length > 0 && prompt.value.trim() !== lastRunPrompt.value
 )
 const runButtonLabel = computed(() => {
-  if (running.value) return t('studio.bakeoff.running')
+  if (isBusy.value) return t('studio.bakeoff.running')
   if (panels.value.length && !promptChangedSinceRun.value) return t('studio.bakeoff.regenerate')
   if (panels.value.length && promptChangedSinceRun.value) return t('studio.bakeoff.regenerateChanged')
   return t('studio.bakeoff.run', { count: selectedModelIds.value.length })
 })
 
 function setModality(m: StudioModality): void {
-  if (running.value) return
+  if (isBusy.value) return
   modality.value = m
   selectedModelIds.value = []
   panels.value = []
@@ -580,7 +584,7 @@ function setModality(m: StudioModality): void {
 }
 
 function clearResults(): void {
-  if (running.value) return
+  if (isBusy.value) return
   panels.value = []
   lastRunPrompt.value = ''
   activeRunTs.value = null
@@ -589,7 +593,7 @@ function clearResults(): void {
 }
 
 function toggleModel(id: string): void {
-  if (running.value) return
+  if (isBusy.value) return
   const i = selectedModelIds.value.indexOf(id)
   if (i >= 0) selectedModelIds.value.splice(i, 1)
   else if (selectedModelIds.value.length < MAX_PANELS) selectedModelIds.value.push(id)
@@ -603,7 +607,7 @@ function formatElapsed(s: number): string {
 async function run(): Promise<void> {
   const text = prompt.value.trim()
   const chosen = selectedResolved()
-  if (!text || chosen.length < 2 || running.value || !canAfford.value || props.keyId == null) return
+  if (!text || chosen.length < 2 || isBusy.value || !canAfford.value || props.keyId == null) return
   errorMessage.value = ''
   errorCode.value = ''
   running.value = true

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -293,37 +293,72 @@ async function refreshBalance(): Promise<void> {
   }
 }
 
-// Probe /v1/models for every distinct group, in parallel. A failed probe maps to
-// an empty pool (so that group's tiers stay hidden); only an all-failed result
-// is surfaced as a hard load error.
-async function probeAllGroups(): Promise<void> {
+/** One representative key per distinct group — shared by staged / full probes. */
+function groupRepresentatives(keyList: ApiKey[]): Map<string, ApiKey> {
   const reps = new Map<string, ApiKey>()
-  for (const k of keys.value) {
+  for (const k of keyList) {
     const gk = groupKeyOf(k)
     if (!reps.has(gk)) reps.set(gk, k)
   }
+  return reps
+}
+
+function mergeGroupProbe(gk: string, ids: Iterable<string>): void {
+  const next = new Map(groupModelSets.value)
+  next.set(gk, new Set(ids))
+  groupModelSets.value = next
+}
+
+/** Probe the listed groups in parallel; returns true when at least one fetch succeeded. */
+async function probeGroupEntries(entries: readonly [string, ApiKey][]): Promise<boolean> {
+  if (entries.length === 0) return false
+  const results = await Promise.allSettled(
+    entries.map(([, k]) => gatewayListModels(k.key, gatewayBase.value))
+  )
+  let anyOk = false
+  results.forEach((r, i) => {
+    const gk = entries[i][0]
+    if (r.status === 'fulfilled') {
+      anyOk = true
+      mergeGroupProbe(gk, (r.value.data || []).map((m) => m.id))
+    } else {
+      mergeGroupProbe(gk, [])
+    }
+  })
+  return anyOk
+}
+
+function orderedGroupEntries(reps: Map<string, ApiKey>, priorityGk: string): [string, ApiKey][] {
   const entries = [...reps.entries()]
-  if (entries.length === 0) return
-  modelsLoading.value = true
+  const idx = entries.findIndex(([gk]) => gk === priorityGk)
+  if (idx <= 0) return entries
+  const [prio] = entries.splice(idx, 1)
+  return [prio, ...entries]
+}
+
+let backgroundProbeGen = 0
+
+function repickKeyForCurrentModality(): void {
+  const m = pickerModality.value
+  if (!m) return
+  selectedKeyId.value = pickModalityKey(modalityOptions(), m, selectedKeyId.value)
+}
+
+/** Finish probing groups the fast path skipped; refresh key annotations when done. */
+async function finishBackgroundProbe(
+  reps: Map<string, ApiKey>,
+  alreadyProbed: ReadonlySet<string>
+): Promise<void> {
+  const gen = ++backgroundProbeGen
+  const remaining = [...reps.entries()].filter(([gk]) => !alreadyProbed.has(gk))
   try {
-    const results = await Promise.allSettled(
-      entries.map(([, k]) => gatewayListModels(k.key, gatewayBase.value))
-    )
-    const next = new Map<string, Set<string>>()
-    let anyOk = false
-    results.forEach((r, i) => {
-      const gk = entries[i][0]
-      if (r.status === 'fulfilled') {
-        anyOk = true
-        next.set(gk, new Set((r.value.data || []).map((m) => m.id)))
-      } else {
-        next.set(gk, new Set())
-      }
-    })
-    groupModelSets.value = next
-    if (!anyOk) loadError.value = t('studio.loadFailed')
+    if (remaining.length > 0) {
+      await probeGroupEntries(remaining)
+      if (gen !== backgroundProbeGen) return
+      repickKeyForCurrentModality()
+    }
   } finally {
-    modelsLoading.value = false
+    if (gen === backgroundProbeGen) modelsLoading.value = false
   }
 }
 
@@ -383,17 +418,91 @@ async function bootstrap(): Promise<void> {
       loadError.value = t('studio.noApiKey')
       return
     }
-    await Promise.all([probeAllGroups(), loadUserEntitlement()])
-    if (loadError.value) return
-    // Seed with the historical default, then let the picker move to a key whose
-    // group actually serves the landing modality (defaults to chat at mount).
-    selectedKeyId.value = pickModalityKey(modalityOptions(), pickerModality.value ?? 'chat', seed)
-    // Mount studios as soon as /v1/models is probed. Price catalog is only needed
-    // for image/video/bake-off; awaiting it blocked Chat on slow catalog fetches.
+    const seedKey = keys.value.find((k) => k.id === seed)
+    if (!seedKey) {
+      loadError.value = t('studio.loadFailed')
+      return
+    }
+
+    const reps = groupRepresentatives(keys.value)
+    const seedGk = groupKeyOf(seedKey)
+    const hasUniversal = keys.value.some(isUniversalKey)
+    const landingView = view.value
+    modelsLoading.value = true
+
+    // Chat is the default landing tab. Probing every distinct group up front made
+    // first paint wait on N gateway round-trips (painful for admins with many
+    // groups). Probe the seed group first, mount Chat, then finish the rest in
+    // the background for key-picker annotations and tab switches.
+    if (landingView === 'chat') {
+      const entitlementNow = hasUniversal ? loadUserEntitlement() : Promise.resolve()
+      const probeSeed = isUniversalKey(seedKey)
+        ? Promise.resolve(true)
+        : probeGroupEntries([[seedGk, seedKey]])
+      const [, anyOk] = await Promise.all([entitlementNow, probeSeed])
+      if (!anyOk && reps.size === 1) {
+        loadError.value = t('studio.loadFailed')
+        modelsLoading.value = false
+        return
+      }
+      selectedKeyId.value = pickModalityKey(modalityOptions(), 'chat', seed)
+      probed.value = true
+      if (selectedKeyId.value != null) void loadPriceMap(selectedKeyId.value)
+      void (async () => {
+        if (!hasUniversal) await loadUserEntitlement()
+        await finishBackgroundProbe(reps, new Set([seedGk]))
+        if (!anyOk && reps.size > 1 && ![...groupModelSets.value.values()].some((s) => s.size > 0)) {
+          loadError.value = t('studio.loadFailed')
+        }
+      })()
+      return
+    }
+
+    // Image / video / bake-off deep-links need a price catalog before the child
+    // studio mounts. Probe the seed group first, then batch the rest if needed.
+    const ordered = orderedGroupEntries(reps, seedGk)
+    const [, anyOk] = await Promise.all([
+      loadUserEntitlement(),
+      probeGroupEntries(ordered.length ? [ordered[0]] : []),
+    ])
+
+    if (landingView === 'bakeoff') {
+      if (!anyOk) {
+        loadError.value = t('studio.loadFailed')
+        modelsLoading.value = false
+        return
+      }
+      selectedKeyId.value = seed
+      if (ordered.length > 1) {
+        void finishBackgroundProbe(reps, new Set([seedGk]))
+      } else {
+        modelsLoading.value = false
+      }
+      probed.value = true
+      await loadPriceMap(seed)
+      return
+    }
+
+    let picked = pickModalityKey(modalityOptions(), landingView, seed)
+    const currentServes =
+      picked != null &&
+      keys.value.some((k) => k.id === picked && keyServesModality(k, landingView))
+    if (!currentServes && ordered.length > 1) {
+      await probeGroupEntries(ordered.slice(1))
+      picked = pickModalityKey(modalityOptions(), landingView, seed)
+    }
+    if (!anyOk) {
+      loadError.value = t('studio.loadFailed')
+      modelsLoading.value = false
+      return
+    }
+    selectedKeyId.value = picked
     probed.value = true
-    if (selectedKeyId.value != null) void loadPriceMap(selectedKeyId.value)
+    if (selectedKeyId.value != null) await loadPriceMap(selectedKeyId.value)
+    modelsLoading.value = false
   } catch (e) {
     loadError.value = e instanceof Error ? e.message : t('studio.loadFailed')
+    modelsLoading.value = false
   }
 }
 

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -74,6 +74,77 @@ const baseProps = {
   rateMultiplier: 1,
 }
 
+const videoProps = {
+  ...baseProps,
+  availableIds: new Set([
+    'seedance-1-0-pro-250528',
+    'doubao-seedance-2-0-fast-260128',
+    'veo-3.1-generate-001',
+  ]),
+  priceMap: new Map([
+    ['seedance-1-0-pro-250528', { perSecond: 0.1088 }],
+    ['doubao-seedance-2-0-fast-260128', { perSecond: 0.1194 }],
+    ['veo-3.1-generate-001', { perSecond: 0.6 }],
+  ]),
+}
+
+describe('BakeOff run gate', () => {
+  beforeEach(() => {
+    libraryMock.videoTasks.value = []
+    vi.mocked(playground.gatewayVideoSubmit).mockReset()
+    vi.mocked(playground.gatewayVideoSubmit).mockResolvedValue({ id: 'vt_busy', status: 'processing' })
+  })
+
+  it('blocks a second video run while panels are still processing', async () => {
+    const wrapper = mount(BakeOff, {
+      props: videoProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true } },
+    })
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    await tiers[0].trigger('click')
+    await tiers[1].trigger('click')
+    await wrapper.get('textarea').setValue('family in a garden')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    expect(playground.gatewayVideoSubmit).toHaveBeenCalledTimes(2)
+    const runBtn = wrapper.get('[data-testid="studio-bakeoff-run"]')
+    expect(runBtn.attributes('disabled')).toBeDefined()
+    expect(runBtn.text()).toContain('studio.bakeoff.running')
+
+    await runBtn.trigger('click')
+    await flushPromises()
+    expect(playground.gatewayVideoSubmit).toHaveBeenCalledTimes(2)
+  })
+
+  it('allows regenerate after every panel reaches a terminal state', async () => {
+    vi.mocked(playground.gatewayVideoSubmit)
+      .mockResolvedValueOnce({ id: 'vt_a', status: 'succeeded', url: 'https://cdn/a.mp4' })
+      .mockResolvedValueOnce({ id: 'vt_b', status: 'succeeded', url: 'https://cdn/b.mp4' })
+
+    const wrapper = mount(BakeOff, {
+      props: videoProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true } },
+    })
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    await tiers[0].trigger('click')
+    await tiers[1].trigger('click')
+    await wrapper.get('textarea').setValue('family in a garden')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    expect(playground.gatewayVideoSubmit).toHaveBeenCalledTimes(2)
+    const runBtn = wrapper.get('[data-testid="studio-bakeoff-run"]')
+    expect(runBtn.attributes('disabled')).toBeUndefined()
+    expect(runBtn.text()).toContain('studio.bakeoff.regenerate')
+
+    vi.mocked(playground.gatewayVideoSubmit).mockResolvedValue({ id: 'vt_redo', status: 'processing' })
+    await runBtn.trigger('click')
+    await flushPromises()
+    expect(playground.gatewayVideoSubmit).toHaveBeenCalledTimes(4)
+  })
+})
+
 describe('BakeOff image routing', () => {
   beforeEach(() => {
     libraryMock.images.value = []

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -279,6 +279,75 @@ describe('BakeOff image routing', () => {
     )
   })
 
+  it('closes the panel lightbox and marks the task expired when preview media fails', async () => {
+    vi.mocked(playground.gatewayVideoSubmit)
+      .mockResolvedValueOnce({ id: 'vt_panel_a', status: 'succeeded', url: 'https://cdn.example/a.mp4' })
+      .mockResolvedValueOnce({ id: 'vt_panel_b', status: 'succeeded', url: 'https://cdn.example/b.mp4' })
+
+    const wrapper = mount(BakeOff, {
+      props: videoProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true, teleport: true } },
+    })
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    await tiers[0].trigger('click')
+    await tiers[1].trigger('click')
+    await wrapper.get('textarea').setValue('family in a garden')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    const panelEls = wrapper.findAll('[data-testid="bakeoff-panel"]')
+    await panelEls[0].get('[data-testid="bakeoff-video-play"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="bakeoff-video-preview"] video').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="bakeoff-video-preview"] video').trigger('error')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="bakeoff-video-preview"]').exists()).toBe(false)
+    expect(libraryMock.patchVideoTask).toHaveBeenCalledWith('vt_panel_a', { urlExpired: true })
+    expect(panelEls[0].find('[data-testid="bakeoff-video-play"]').exists()).toBe(false)
+    expect(panelEls[0].find('[data-testid="bakeoff-video-expired"]').exists()).toBe(true)
+    expect(panelEls[0].find('[data-testid="bakeoff-video-download"]').exists()).toBe(true)
+    expect(panelEls[1].find('[data-testid="bakeoff-video-play"]').exists()).toBe(true)
+  })
+
+  it('converts inline data:video panel urls to blob playback in the lightbox', async () => {
+    const createObjectURL = vi.fn(() => 'blob:preview')
+    vi.stubGlobal(
+      'URL',
+      Object.assign({}, URL, {
+        createObjectURL,
+        revokeObjectURL: vi.fn(),
+      })
+    )
+    vi.mocked(playground.gatewayVideoSubmit)
+      .mockResolvedValueOnce({
+        id: 'vt_data',
+        done: true,
+        response: { videos: [{ bytesBase64Encoded: 'QUFB', mimeType: 'video/mp4' }] },
+      })
+      .mockResolvedValueOnce({ id: 'vt_http', status: 'succeeded', url: 'https://cdn.example/b.mp4' })
+
+    const wrapper = mount(BakeOff, {
+      props: videoProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true, teleport: true } },
+    })
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    await tiers[0].trigger('click')
+    await tiers[1].trigger('click')
+    await wrapper.get('textarea').setValue('family in a garden')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    const panelEls = wrapper.findAll('[data-testid="bakeoff-panel"]')
+    await panelEls[0].get('[data-testid="bakeoff-video-play"]').trigger('click')
+    await flushPromises()
+
+    expect(createObjectURL).toHaveBeenCalled()
+    expect(wrapper.get('[data-testid="bakeoff-video-preview"] video').attributes('src')).toBe('blob:preview')
+    vi.unstubAllGlobals()
+  })
+
   it('shows friendly panel error for codex unsupported gemini image', async () => {
     vi.mocked(playground.gatewayGeminiImageViaChat).mockRejectedValueOnce(
       new Error(

--- a/frontend/src/views/user/studio/__tests__/MediaStudioView.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/MediaStudioView.spec.ts
@@ -88,6 +88,39 @@ describe('MediaStudioView bootstrap', () => {
     getPublicPricing.mockResolvedValue({ data: [] })
   })
 
+  it('mounts ChatStudio after probing only the seed group, not every distinct group', async () => {
+    listKeys.mockResolvedValue({
+      items: [
+        { id: 1, name: 'trial', key: 'sk-a', group: { id: 10, name: 'g1' } },
+        { id: 2, name: 'other', key: 'sk-b', group: { id: 20, name: 'g2' } },
+      ],
+    })
+    let resolveSecond!: (value: { data: { id: string }[] }) => void
+    gatewayListModels.mockImplementation((key: string) => {
+      if (key === 'sk-a') return Promise.resolve({ data: [{ id: 'gpt-4o' }] })
+      return new Promise((resolve) => {
+        resolveSecond = resolve
+      })
+    })
+    getMePricingCatalog.mockResolvedValue({ authorized_groups_by_model: {}, models: [] })
+
+    const wrapper = mount(MediaStudioView, {
+      global: {
+        plugins: [i18n],
+        stubs: { 'router-link': true },
+      },
+    })
+
+    await flushPromises()
+    expect(wrapper.find('[data-testid="studio-chat-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="studio-bootstrap-loading"]').exists()).toBe(false)
+    expect(gatewayListModels).toHaveBeenCalledWith('sk-a', 'https://api.example')
+
+    resolveSecond({ data: [{ id: 'claude-3-opus' }] })
+    await flushPromises()
+    expect(gatewayListModels).toHaveBeenCalledWith('sk-b', 'https://api.example')
+  })
+
   it('mounts ChatStudio after model probe without waiting for the per-key price catalog', async () => {
     let resolveCatalog!: (value: { models: [] }) => void
     getMePricingCatalog.mockImplementation((opts?: { apiKeyId?: number }) => {


### PR DESCRIPTION
## 摘要

- **首屏加速**：`/studio` 对话模式（默认）只探针 seed 分组即可挂载 ChatStudio，其余分组与 entitlement 索引后台补齐，避免 admin 多分组时首屏卡在「正在加载模型…」。
- **同台防误触**：视频同台对比引入 `isBusy`（提交中 ∪ 任意 panel 仍在 `processing`），轮询未完成时主按钮 disabled 且显示「生成中…」，防止 `poll.stopAll()` + 二次 hold/扣费。
- **同台视频播放**：BakeOff lightbox 对齐 VideoStudio——`urlExpired` 同步、`@error` 失败兜底、重试/复制链接、预览失败仍保留下载；Veo 内联 `data:video` 转 Blob 播放。

sentinel-registry-reviewed

## 风险

- 常规风险：纯前端 Studio 行为变更；对话首屏可能短暂使用 seed 分组模型池，后台探针完成后 key 选择器会自动 re-pick。
- 图片/视频/同台深链仍走 seed 优先 + 按需补探，并在挂载子组件前等待 price catalog。
- 浏览器仍可能因 upstream 编解码器/CORS/链接过期导致 `<video>` 加载失败；修复后卡片会标记不可用并保留下载，不再静默黑屏。

## 验证

- `pnpm exec vitest run src/views/user/studio/__tests__/MediaStudioView.spec.ts src/views/user/studio/__tests__/BakeOff.spec.ts` — 12 passed
- `./scripts/preflight.sh` — PASS（含 embedded dist freshness）

## 提交

- a7a4b272e fix(studio): 加速首屏加载并防止同台对比轮询期二次提交
- e0d2c9597 fix(studio): 同台对比视频预览对齐 VideoStudio 播放与失败兜底
- 最新提交：e0d2c9597
