### PR TITLE
feat(studio): 视频预览 SSOT（lightbox + copy-link + 过期播放守卫）

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 531,
-  "hash": "4ff554fe4f354f4a0a3ec74eb12616e37d1acfc0625e2c05f67f523b2b404aad",
+  "file_count": 532,
+  "hash": "698e17c1c5ef61d2bd235ec80010caf2518c222f805e61027244b1a4e56d302f",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 529,
-  "hash": "78c34998667c806db17e83bd5440ecdcae58d1899f224757292f87e0498d5bd3",
+  "file_count": 531,
+  "hash": "4ff554fe4f354f4a0a3ec74eb12616e37d1acfc0625e2c05f67f523b2b404aad",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/composables/__tests__/useStudioVideoCardActions.spec.ts
+++ b/frontend/src/composables/__tests__/useStudioVideoCardActions.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import * as studioDownload from '@/utils/studioDownload.tk'
+import { useStudioVideoCardActions } from '../useStudioVideoCardActions'
+
+describe('useStudioVideoCardActions', () => {
+  beforeEach(() => {
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText: vi.fn(async () => undefined) } })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('copyCardLink writes url to clipboard', async () => {
+    const writeText = vi.fn(async () => undefined)
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+    const { copyCardLink } = useStudioVideoCardActions()
+    await copyCardLink('https://cdn.example/a.mp4')
+    expect(writeText).toHaveBeenCalledWith('https://cdn.example/a.mp4')
+  })
+
+  it('downloadCardVideo warns instead of downloading when urlExpired', () => {
+    const onExpiredDownload = vi.fn()
+    const downloadSpy = vi.spyOn(studioDownload, 'downloadMedia')
+    const { downloadCardVideo } = useStudioVideoCardActions(onExpiredDownload)
+    downloadCardVideo('https://cdn.example/a.mp4', 'tokenkey-vt_1.mp4', true)
+    expect(onExpiredDownload).toHaveBeenCalled()
+    expect(downloadSpy).not.toHaveBeenCalled()
+    downloadSpy.mockRestore()
+  })
+})

--- a/frontend/src/composables/__tests__/useStudioVideoPreview.spec.ts
+++ b/frontend/src/composables/__tests__/useStudioVideoPreview.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import * as studioDownload from '@/utils/studioDownload.tk'
 import { useStudioVideoPreview } from '../useStudioVideoPreview'
 
 describe('useStudioVideoPreview', () => {
@@ -29,7 +30,7 @@ describe('useStudioVideoPreview', () => {
     expect(preview.previewState.value).toBe('ready')
   })
 
-  it('calls onUrlExpired with task id after preview error', () => {
+  it('calls onUrlExpired with task id after preview error and keeps lightbox open', () => {
     const onUrlExpired = vi.fn()
     const preview = useStudioVideoPreview({ onUrlExpired })
     preview.openPreview({
@@ -40,6 +41,40 @@ describe('useStudioVideoPreview', () => {
     })
     preview.onPreviewError()
     expect(onUrlExpired).toHaveBeenCalledWith('vt_err')
-    expect(preview.open.value).toBe(false)
+    expect(preview.open.value).toBe(true)
+    expect(preview.previewState.value).toBe('expired')
+    expect(preview.urlExpired.value).toBe(true)
+  })
+
+  it('copyPreviewLink writes raw upstream url even when playback uses blob', async () => {
+    const writeText = vi.fn(async () => undefined)
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+    const preview = useStudioVideoPreview()
+    preview.openPreview({
+      url: 'data:video/mp4;base64,QUFB',
+      label: 'Veo 3.1',
+      cost: 4.8,
+      taskId: 'vt_blob',
+    })
+    await preview.copyPreviewLink()
+    expect(writeText).toHaveBeenCalledWith('data:video/mp4;base64,QUFB')
+    vi.unstubAllGlobals()
+  })
+
+  it('downloadPreview invokes onExpiredDownload instead of downloading when url expired', () => {
+    const onExpiredDownload = vi.fn()
+    const downloadSpy = vi.spyOn(studioDownload, 'downloadMedia')
+    const preview = useStudioVideoPreview({ onExpiredDownload })
+    preview.openPreview({
+      url: 'https://cdn.example/clip.mp4',
+      label: 'Seedance',
+      cost: 1,
+      taskId: 'vt_err',
+      urlExpired: true,
+    })
+    preview.downloadPreview()
+    expect(onExpiredDownload).toHaveBeenCalled()
+    expect(downloadSpy).not.toHaveBeenCalled()
+    downloadSpy.mockRestore()
   })
 })

--- a/frontend/src/composables/__tests__/useStudioVideoPreview.spec.ts
+++ b/frontend/src/composables/__tests__/useStudioVideoPreview.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { useStudioVideoPreview } from '../useStudioVideoPreview'
+
+describe('useStudioVideoPreview', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'URL',
+      Object.assign({}, URL, {
+        createObjectURL: vi.fn(() => 'blob:preview'),
+        revokeObjectURL: vi.fn(),
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('converts inline data:video to blob playback url', () => {
+    const preview = useStudioVideoPreview()
+    preview.openPreview({
+      url: 'data:video/mp4;base64,QUFB',
+      label: 'Veo 3.1',
+      cost: 4.8,
+      taskId: 'vt_blob',
+    })
+    expect(URL.createObjectURL).toHaveBeenCalled()
+    expect(preview.previewUrl.value).toBe('blob:preview')
+    expect(preview.previewState.value).toBe('ready')
+  })
+
+  it('calls onUrlExpired with task id after preview error', () => {
+    const onUrlExpired = vi.fn()
+    const preview = useStudioVideoPreview({ onUrlExpired })
+    preview.openPreview({
+      url: 'https://cdn.example/clip.mp4',
+      label: 'Seedance',
+      cost: 1,
+      taskId: 'vt_err',
+    })
+    preview.onPreviewError()
+    expect(onUrlExpired).toHaveBeenCalledWith('vt_err')
+    expect(preview.open.value).toBe(false)
+  })
+})

--- a/frontend/src/composables/useStudioVideoCardActions.ts
+++ b/frontend/src/composables/useStudioVideoCardActions.ts
@@ -1,0 +1,28 @@
+import { ref } from 'vue'
+import { copyMediaLink, downloadMedia } from '@/utils/studioDownload.tk'
+
+/** Card-level copy-link + download actions shared by VideoStudio and BakeOff. */
+export function useStudioVideoCardActions(onExpiredDownload?: () => void) {
+  const copiedUrl = ref('')
+  let copiedTimer: ReturnType<typeof setTimeout> | undefined
+
+  async function copyCardLink(url: string): Promise<void> {
+    if (!url) return
+    if (await copyMediaLink(url)) {
+      copiedUrl.value = url
+      if (copiedTimer) clearTimeout(copiedTimer)
+      copiedTimer = setTimeout(() => (copiedUrl.value = ''), 1500)
+    }
+  }
+
+  function downloadCardVideo(url: string, filename: string, urlExpired?: boolean): void {
+    if (!url) return
+    if (urlExpired) {
+      onExpiredDownload?.()
+      return
+    }
+    downloadMedia(url, filename)
+  }
+
+  return { copiedUrl, copyCardLink, downloadCardVideo }
+}

--- a/frontend/src/composables/useStudioVideoPreview.ts
+++ b/frontend/src/composables/useStudioVideoPreview.ts
@@ -1,4 +1,5 @@
 import { computed, onBeforeUnmount, ref } from 'vue'
+import { copyMediaLink, downloadMedia } from '@/utils/studioDownload.tk'
 import { videoPlaybackUrl } from '@/utils/studioMedia.tk'
 
 export type StudioVideoPreviewState = 'loading' | 'ready' | 'expired'
@@ -8,6 +9,7 @@ export interface StudioVideoPreviewSource {
   label: string
   cost: number
   taskId?: string
+  urlExpired?: boolean
   /** Shown under the label in the lightbox footer (e.g. full prompt). */
   subtitle?: string
   downloadFilename?: string
@@ -15,6 +17,7 @@ export interface StudioVideoPreviewSource {
 
 export interface UseStudioVideoPreviewOptions {
   onUrlExpired?: (taskId: string) => void
+  onExpiredDownload?: () => void
 }
 
 /**
@@ -33,11 +36,13 @@ export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}
   const previewState = ref<StudioVideoPreviewState>('loading')
   const previewMediaReady = ref(false)
   const copiedLink = ref(false)
+  const urlExpired = ref(false)
 
   let previewRevoke: () => void = () => {}
   let copiedTimer: ReturnType<typeof setTimeout> | undefined
 
   const downloadUrl = computed(() => rawUrl.value || previewUrl.value)
+  const copyLinkUrl = computed(() => rawUrl.value || previewUrl.value)
 
   function openPreview(source: StudioVideoPreviewSource): void {
     if (!source.url) return
@@ -48,6 +53,7 @@ export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}
     cost.value = source.cost
     rawUrl.value = source.url
     taskId.value = source.taskId
+    urlExpired.value = source.urlExpired ?? false
     downloadFilename.value = source.downloadFilename ?? 'tokenkey-preview.mp4'
     previewUrl.value = ''
     previewState.value = 'loading'
@@ -69,6 +75,7 @@ export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}
     cost.value = null
     rawUrl.value = ''
     taskId.value = undefined
+    urlExpired.value = false
     previewUrl.value = ''
     previewState.value = 'loading'
     previewMediaReady.value = false
@@ -77,7 +84,12 @@ export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}
 
   function onPreviewError(): void {
     const id = taskId.value
-    closePreview()
+    previewRevoke()
+    previewRevoke = () => {}
+    previewUrl.value = ''
+    previewState.value = 'expired'
+    previewMediaReady.value = false
+    urlExpired.value = true
     if (id) options.onUrlExpired?.(id)
   }
 
@@ -88,6 +100,7 @@ export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}
       label: label.value,
       cost: cost.value ?? 0,
       taskId: taskId.value,
+      urlExpired: urlExpired.value,
       subtitle: subtitle.value,
       downloadFilename: downloadFilename.value,
     })
@@ -98,15 +111,23 @@ export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}
   }
 
   async function copyPreviewLink(): Promise<void> {
-    if (!previewUrl.value) return
-    try {
-      await navigator.clipboard?.writeText(previewUrl.value)
+    const url = copyLinkUrl.value
+    if (!url) return
+    if (await copyMediaLink(url)) {
       copiedLink.value = true
       if (copiedTimer) clearTimeout(copiedTimer)
       copiedTimer = setTimeout(() => (copiedLink.value = false), 1500)
-    } catch {
-      /* clipboard unavailable — Download still works */
     }
+  }
+
+  function downloadPreview(): void {
+    const url = downloadUrl.value
+    if (!url) return
+    if (urlExpired.value) {
+      options.onExpiredDownload?.()
+      return
+    }
+    downloadMedia(url, downloadFilename.value)
   }
 
   onBeforeUnmount(closePreview)
@@ -121,14 +142,17 @@ export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}
     cost,
     downloadFilename,
     downloadUrl,
+    copyLinkUrl,
     previewState,
     previewMediaReady,
     copiedLink,
+    urlExpired,
     openPreview,
     closePreview,
     onPreviewError,
     retryPreview,
     onPreviewMediaReady,
     copyPreviewLink,
+    downloadPreview,
   }
 }

--- a/frontend/src/composables/useStudioVideoPreview.ts
+++ b/frontend/src/composables/useStudioVideoPreview.ts
@@ -1,0 +1,134 @@
+import { computed, onBeforeUnmount, ref } from 'vue'
+import { videoPlaybackUrl } from '@/utils/studioMedia.tk'
+
+export type StudioVideoPreviewState = 'loading' | 'ready' | 'expired'
+
+export interface StudioVideoPreviewSource {
+  url: string
+  label: string
+  cost: number
+  taskId?: string
+  /** Shown under the label in the lightbox footer (e.g. full prompt). */
+  subtitle?: string
+  downloadFilename?: string
+}
+
+export interface UseStudioVideoPreviewOptions {
+  onUrlExpired?: (taskId: string) => void
+}
+
+/**
+ * Shared in-page video lightbox state for VideoStudio and BakeOff.
+ * http(s) URLs play directly; inline data:video becomes a tab-local Blob URL.
+ */
+export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}) {
+  const open = ref(false)
+  const previewUrl = ref('')
+  const rawUrl = ref('')
+  const taskId = ref<string | undefined>()
+  const label = ref('')
+  const subtitle = ref('')
+  const cost = ref<number | null>(null)
+  const downloadFilename = ref('tokenkey-preview.mp4')
+  const previewState = ref<StudioVideoPreviewState>('loading')
+  const previewMediaReady = ref(false)
+  const copiedLink = ref(false)
+
+  let previewRevoke: () => void = () => {}
+  let copiedTimer: ReturnType<typeof setTimeout> | undefined
+
+  const downloadUrl = computed(() => rawUrl.value || previewUrl.value)
+
+  function openPreview(source: StudioVideoPreviewSource): void {
+    if (!source.url) return
+    previewRevoke()
+    open.value = true
+    label.value = source.label
+    subtitle.value = source.subtitle ?? ''
+    cost.value = source.cost
+    rawUrl.value = source.url
+    taskId.value = source.taskId
+    downloadFilename.value = source.downloadFilename ?? 'tokenkey-preview.mp4'
+    previewUrl.value = ''
+    previewState.value = 'loading'
+    previewMediaReady.value = false
+    copiedLink.value = false
+
+    const playback = videoPlaybackUrl(source.url)
+    previewRevoke = playback.revoke
+    previewUrl.value = playback.url
+    previewState.value = playback.url ? 'ready' : 'expired'
+  }
+
+  function closePreview(): void {
+    previewRevoke()
+    previewRevoke = () => {}
+    open.value = false
+    label.value = ''
+    subtitle.value = ''
+    cost.value = null
+    rawUrl.value = ''
+    taskId.value = undefined
+    previewUrl.value = ''
+    previewState.value = 'loading'
+    previewMediaReady.value = false
+    copiedLink.value = false
+  }
+
+  function onPreviewError(): void {
+    const id = taskId.value
+    closePreview()
+    if (id) options.onUrlExpired?.(id)
+  }
+
+  function retryPreview(): void {
+    if (!rawUrl.value) return
+    openPreview({
+      url: rawUrl.value,
+      label: label.value,
+      cost: cost.value ?? 0,
+      taskId: taskId.value,
+      subtitle: subtitle.value,
+      downloadFilename: downloadFilename.value,
+    })
+  }
+
+  function onPreviewMediaReady(): void {
+    previewMediaReady.value = true
+  }
+
+  async function copyPreviewLink(): Promise<void> {
+    if (!previewUrl.value) return
+    try {
+      await navigator.clipboard?.writeText(previewUrl.value)
+      copiedLink.value = true
+      if (copiedTimer) clearTimeout(copiedTimer)
+      copiedTimer = setTimeout(() => (copiedLink.value = false), 1500)
+    } catch {
+      /* clipboard unavailable — Download still works */
+    }
+  }
+
+  onBeforeUnmount(closePreview)
+
+  return {
+    open,
+    previewUrl,
+    rawUrl,
+    taskId,
+    label,
+    subtitle,
+    cost,
+    downloadFilename,
+    downloadUrl,
+    previewState,
+    previewMediaReady,
+    copiedLink,
+    openPreview,
+    closePreview,
+    onPreviewError,
+    retryPreview,
+    onPreviewMediaReady,
+    copyPreviewLink,
+  }
+}

--- a/frontend/src/utils/__tests__/studioDownload.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioDownload.tk.spec.ts
@@ -56,3 +56,19 @@ describe('downloadMedia', () => {
     expect(openSpy).toHaveBeenCalledWith('https://cdn.example.com/v.mp4', '_blank')
   })
 })
+
+describe('copyMediaLink', () => {
+  it('returns false on empty url', async () => {
+    const { copyMediaLink } = await import('@/utils/studioDownload.tk')
+    expect(await copyMediaLink('')).toBe(false)
+  })
+
+  it('writes url to clipboard', async () => {
+    const writeText = vi.fn(async () => undefined)
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+    const { copyMediaLink } = await import('@/utils/studioDownload.tk')
+    expect(await copyMediaLink('https://cdn.example/v.mp4')).toBe(true)
+    expect(writeText).toHaveBeenCalledWith('https://cdn.example/v.mp4')
+    vi.unstubAllGlobals()
+  })
+})

--- a/frontend/src/utils/__tests__/studioPlaybackStorage.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioPlaybackStorage.tk.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { classifyVideoUrlStorage, videoTaskPlaybackStorageKind } from '../studioPlaybackStorage.tk'
+import { describe, expect, it, vi } from 'vitest'
+import { classifyVideoUrlStorage, tagStudioVideoPlayback, videoTaskPlaybackStorageKind } from '../studioPlaybackStorage.tk'
 
 describe('classifyVideoUrlStorage', () => {
   it('marks inline data:video as local-cacheable', () => {
@@ -22,5 +22,17 @@ describe('videoTaskPlaybackStorageKind', () => {
 
   it('prefers persisted playbackStorage', () => {
     expect(videoTaskPlaybackStorageKind({ url: 'https://x/v.mp4', playbackStorage: 'inline-local' })).toBe('inline-local')
+  })
+})
+
+describe('tagStudioVideoPlayback', () => {
+  it('marks empty url as expired storage', async () => {
+    const patchVideoTask = vi.fn()
+    await tagStudioVideoPlayback(
+      { patchVideoTask, cacheInlineMedia: vi.fn(async () => undefined) },
+      'vt_empty',
+      ''
+    )
+    expect(patchVideoTask).toHaveBeenCalledWith('vt_empty', { playbackStorage: 'expired' })
   })
 })

--- a/frontend/src/utils/studioDownload.tk.ts
+++ b/frontend/src/utils/studioDownload.tk.ts
@@ -26,3 +26,14 @@ export function downloadMedia(url: string, filename: string): void {
     window.open(url, '_blank')
   }
 }
+
+/** Best-effort clipboard copy of an upstream / inline media URL. */
+export async function copyMediaLink(url: string): Promise<boolean> {
+  if (!url) return false
+  try {
+    await navigator.clipboard?.writeText(url)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/frontend/src/utils/studioPlaybackStorage.tk.ts
+++ b/frontend/src/utils/studioPlaybackStorage.tk.ts
@@ -71,6 +71,30 @@ export function videoTaskPlaybackStorageKind(
   return task.playbackStorage ?? (task.urlExpired || !task.url ? 'expired' : 'unknown')
 }
 
+export interface TagStudioVideoPlaybackDeps {
+  patchVideoTask: (id: string, patch: Partial<VideoTaskItem>) => void
+  cacheInlineMedia: (kind: 'video', itemId: string, src: string) => Promise<void>
+  onUpstreamCorsBlocked?: () => void
+}
+
+/** Classify upstream playback storage and mirror inline clips into IndexedDB when safe. */
+export async function tagStudioVideoPlayback(
+  deps: TagStudioVideoPlaybackDeps,
+  taskId: string,
+  url: string
+): Promise<void> {
+  if (!url) {
+    deps.patchVideoTask(taskId, { playbackStorage: 'expired' })
+    return
+  }
+  const storage = await resolveVideoPlaybackStorage(url)
+  deps.patchVideoTask(taskId, { playbackStorage: storage })
+  if (storage === 'upstream-cors-blocked') deps.onUpstreamCorsBlocked?.()
+  if (storage === 'inline-local' || storage === 'upstream-cors-ok') {
+    void deps.cacheInlineMedia('video', taskId, url)
+  }
+}
+
 /** Tailwind classes for the honest playback-source badge (Image / Video / Bake-Off). */
 export function studioPlaybackBadgeClass(storage: StudioPlaybackStorage): string {
   switch (storage) {

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -174,9 +174,12 @@
         <div class="mt-2 flex flex-wrap items-center justify-between gap-2 text-sm">
           <div class="flex flex-wrap items-center gap-2">
             <span class="font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(p.cost) }}</span>
-            <StudioPlaybackBadge v-if="modality === 'video' && bakePanelVideoPlayable(p)" :task="panelPlaybackTask(p)!" />
+            <StudioPlaybackBadge
+              v-if="modality === 'video' && p.state === 'succeeded' && panelPlaybackTask(p)"
+              :task="panelPlaybackTask(p)!"
+            />
           </div>
-          <div class="flex items-center gap-2">
+          <div class="flex flex-wrap items-center gap-2">
             <button
               v-if="modality === 'image' && p.src"
               type="button"
@@ -185,15 +188,24 @@
             >
               {{ t('studio.image.download') }}
             </button>
-            <button
-              v-else-if="modality === 'video' && p.state === 'succeeded' && p.url"
-              type="button"
-              class="text-[11px] font-medium text-primary-600 dark:text-primary-300"
-              data-testid="bakeoff-video-download"
-              @click="downloadMedia(p.url!, `tokenkey-${p.taskId || p.modelId}.mp4`)"
-            >
-              {{ t('studio.video.download') }}
-            </button>
+            <template v-else-if="modality === 'video' && p.state === 'succeeded' && p.url">
+              <button
+                type="button"
+                class="text-[11px] font-medium text-primary-600 dark:text-primary-300"
+                data-testid="bakeoff-video-download"
+                @click="downloadCardVideo(p.url, `tokenkey-${p.taskId || p.modelId}.mp4`, p.urlExpired)"
+              >
+                {{ t('studio.video.download') }}
+              </button>
+              <button
+                type="button"
+                class="text-[11px] font-medium text-gray-500 dark:text-dark-300"
+                data-testid="bakeoff-video-copy-card-link"
+                @click="copyCardLink(p.url)"
+              >
+                {{ copiedUrl === p.url ? t('studio.video.copied') : t('studio.video.copyLink') }}
+              </button>
+            </template>
             <span v-if="p.elapsedS != null && p.state !== 'idle'" class="text-xs text-gray-500 dark:text-dark-400">⏱ {{ p.elapsedS }}s</span>
           </div>
         </div>
@@ -275,17 +287,27 @@
               </div>
               <StudioVideoUnavailable v-else :prompt="task.prompt" :task="task" />
               <div class="mt-1 flex items-center justify-between gap-2">
-                <StudioPlaybackBadge v-if="videoTaskPlaybackAvailable(task)" :task="task" />
+                <StudioPlaybackBadge v-if="task.state === 'succeeded'" :task="task" />
                 <span class="ml-auto text-xs font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(task.estCost) }}</span>
               </div>
-              <button
-                v-if="task.state === 'succeeded' && task.url"
-                type="button"
-                class="text-[10px] font-medium text-primary-600 dark:text-primary-300"
-                @click="downloadMedia(task.url, `tokenkey-${task.id}.mp4`)"
-              >
-                {{ t('studio.video.download') }}
-              </button>
+              <div v-if="task.state === 'succeeded' && task.url" class="mt-1 flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  class="text-[10px] font-medium text-primary-600 dark:text-primary-300"
+                  data-testid="bakeoff-history-video-download"
+                  @click="downloadCardVideo(task.url, `tokenkey-${task.id}.mp4`, task.urlExpired)"
+                >
+                  {{ t('studio.video.download') }}
+                </button>
+                <button
+                  type="button"
+                  class="text-[10px] font-medium text-gray-500 dark:text-dark-300"
+                  data-testid="bakeoff-history-video-copy-link"
+                  @click="copyCardLink(task.url)"
+                >
+                  {{ copiedUrl === task.url ? t('studio.video.copied') : t('studio.video.copyLink') }}
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -309,6 +331,7 @@
       @error="onPreviewError"
       @retry="retryPreviewLightbox"
       @copy-link="copyPreviewLink"
+      @download="downloadPreview"
       @media-ready="onPreviewMediaReady"
     />
   </div>
@@ -351,6 +374,7 @@ import StudioVideoPreviewLightbox from '@/views/user/studio/components/StudioVid
 import StudioVideoUnavailable from '@/views/user/studio/components/StudioVideoUnavailable.vue'
 import { useAppStore } from '@/stores/app'
 import { classifyGatewayError, parseGatewayErrorMessage, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
+import { useStudioVideoCardActions } from '@/composables/useStudioVideoCardActions'
 import { useStudioVideoPreview } from '@/composables/useStudioVideoPreview'
 import { useVideoTaskPoll } from '@/composables/useVideoTaskPoll'
 import { useMediaLibrary, type ImageHistoryItem, type VideoTaskItem } from '@/composables/useMediaLibrary'
@@ -371,6 +395,8 @@ const emit = defineEmits<{ (e: 'spent'): void }>()
 
 const { t } = useI18n()
 const appStore = useAppStore()
+const warnExpiredDownload = () => appStore.showWarning(t('studio.video.expiredHint'), 8000)
+const { copiedUrl, copyCardLink, downloadCardVideo } = useStudioVideoCardActions(warnExpiredDownload)
 
 const MAX_PANELS = 6
 /** Imagen / seedream: ratio code on /v1/images/generations (see ImageStudio sentSize). */
@@ -504,16 +530,19 @@ const {
   retryPreview: retryPreviewLightbox,
   onPreviewMediaReady,
   copyPreviewLink,
+  downloadPreview,
 } = useStudioVideoPreview({
   onUrlExpired: (id) => patchVideoTask(id, { urlExpired: true }),
+  onExpiredDownload: warnExpiredDownload,
 })
 
-function openVideoPreviewFromUrl(label: string, cost: number, url: string, taskId?: string): void {
+function openVideoPreviewFromUrl(label: string, cost: number, url: string, taskId?: string, urlExpired?: boolean): void {
   openPreviewLightbox({
     url,
     label,
     cost,
     taskId,
+    urlExpired,
     downloadFilename: taskId ? `tokenkey-${taskId}.mp4` : 'tokenkey-bakeoff-preview.mp4',
   })
 }
@@ -521,12 +550,12 @@ function openVideoPreviewFromUrl(label: string, cost: number, url: string, taskI
 function openVideoPreview(panel: BakePanel): void {
   if (panel.state !== 'succeeded' || !panel.url) return
   if (!videoTaskPlaybackAvailable({ state: panel.state, url: panel.url ?? '', urlExpired: panel.urlExpired })) return
-  openVideoPreviewFromUrl(panel.label, panel.cost, panel.url, panel.taskId)
+  openVideoPreviewFromUrl(panel.label, panel.cost, panel.url, panel.taskId, panel.urlExpired)
 }
 
 function openVideoHistoryPreview(task: VideoTaskItem): void {
   if (!videoTaskPlaybackAvailable(task) || !task.url) return
-  openVideoPreviewFromUrl(modelLabel(task.model), task.estCost, task.url, task.id)
+  openVideoPreviewFromUrl(modelLabel(task.model), task.estCost, task.url, task.id, task.urlExpired)
 }
 
 function downloadImage(src: string, id: string): void {

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -292,56 +292,30 @@
       </template>
     </div>
 
-    <!-- In-page video lightbox: plays one panel on demand (http URL direct, inline
-         data:video as a tab-local Blob via the shared videoPlaybackUrl) instead of
-         rendering MAX_PANELS always-on <video> elements. -->
-    <Teleport to="body">
-      <div
-        v-if="videoPreviewOpen"
-        class="fixed inset-0 z-[100] flex flex-col bg-black/85 backdrop-blur-sm"
-        data-testid="bakeoff-video-preview"
-        @click.self="closeVideoPreview"
-      >
-        <div class="flex items-center justify-end p-3">
-          <button type="button" class="rounded-lg bg-white/10 px-3 py-1.5 text-sm font-medium text-white hover:bg-white/20" data-testid="bakeoff-video-preview-close" @click="closeVideoPreview">
-            {{ t('studio.video.close') }} ✕
-          </button>
-        </div>
-        <div class="relative flex min-h-0 flex-1 items-center justify-center px-4" @click.self="closeVideoPreview">
-          <video
-            v-if="videoPreviewState === 'ready' && videoPreviewUrl"
-            :src="videoPreviewUrl"
-            controls
-            autoplay
-            playsinline
-            preload="auto"
-            class="h-full max-h-full w-full max-w-full rounded-lg bg-black object-contain shadow-2xl"
-            @loadeddata="videoPreviewMediaReady = true"
-            @error="onVideoPreviewError"
-          ></video>
-          <div v-if="videoPreviewState === 'ready' && videoPreviewUrl && !videoPreviewMediaReady" class="absolute text-sm text-white/80">{{ t('studio.video.previewBuffering') }}</div>
-          <div v-else-if="videoPreviewState === 'loading'" class="text-sm text-white/80">{{ t('studio.video.loadingPreview') }}</div>
-          <div v-else class="max-w-sm rounded-xl bg-white/10 p-6 text-center">
-            <p class="text-sm font-semibold text-white">{{ t('studio.video.expiredTitle') }}</p>
-            <p class="mt-1 text-xs text-white/70">{{ t('studio.video.expiredHint') }}</p>
-            <div class="mt-3 flex items-center justify-center gap-2">
-              <button type="button" class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100" @click="retryVideoPreview">{{ t('studio.video.retry') }}</button>
-            </div>
-          </div>
-        </div>
-        <div class="flex flex-wrap items-center justify-center gap-3 p-4">
-          <span class="max-w-[60vw] truncate text-xs text-white/80" :title="videoPreviewLabel">{{ videoPreviewLabel }}</span>
-          <span v-if="videoPreviewCost != null" class="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[11px] font-semibold text-white">{{ formatUsd(videoPreviewCost) }}</span>
-          <button v-if="videoPreviewDownloadUrl" type="button" class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100" @click="downloadMedia(videoPreviewDownloadUrl, `tokenkey-bakeoff-preview.mp4`)">{{ t('studio.video.download') }}</button>
-          <button v-if="videoPreviewState === 'ready' && videoPreviewUrl" type="button" class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white" data-testid="bakeoff-video-copy-link" @click="copyVideoPreviewLink">{{ copiedPreviewLink ? t('studio.video.copied') : t('studio.video.copyLink') }}</button>
-        </div>
-      </div>
-    </Teleport>
+    <StudioVideoPreviewLightbox
+      :open="previewOpen"
+      :preview-state="previewState"
+      :preview-url="previewUrl"
+      :download-url="previewDownloadUrl"
+      :download-filename="previewDownloadFilename"
+      :label="previewLabel"
+      :cost="previewCost"
+      :preview-media-ready="previewMediaReady"
+      :copied-link="previewCopiedLink"
+      test-id="bakeoff-video-preview"
+      close-test-id="bakeoff-video-preview-close"
+      copy-link-test-id="bakeoff-video-copy-link"
+      @close="closePreviewLightbox"
+      @error="onPreviewError"
+      @retry="retryPreviewLightbox"
+      @copy-link="copyPreviewLink"
+      @media-ready="onPreviewMediaReady"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { gatewayGeminiImageViaChat, gatewayImageGenerations, gatewayVideoSubmit, gatewayImagePresign } from '@/api/playground'
 import {
@@ -366,17 +340,18 @@ import {
   groupVideoHistoryByBatch,
   imageHistoryItemAvailable,
   shouldShowStudioSaveReminder,
-  videoPlaybackUrl,
   videoTaskPlaybackAvailable,
 } from '@/utils/studioMedia.tk'
 import { downloadMedia } from '@/utils/studioDownload.tk'
-import { resolveVideoPlaybackStorage } from '@/utils/studioPlaybackStorage.tk'
+import { tagStudioVideoPlayback } from '@/utils/studioPlaybackStorage.tk'
 import StudioLocalSaveBanner from '@/views/user/studio/components/StudioLocalSaveBanner.vue'
 import StudioImageExpired from '@/views/user/studio/components/StudioImageExpired.vue'
 import StudioPlaybackBadge from '@/views/user/studio/components/StudioPlaybackBadge.vue'
+import StudioVideoPreviewLightbox from '@/views/user/studio/components/StudioVideoPreviewLightbox.vue'
 import StudioVideoUnavailable from '@/views/user/studio/components/StudioVideoUnavailable.vue'
 import { useAppStore } from '@/stores/app'
 import { classifyGatewayError, parseGatewayErrorMessage, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
+import { useStudioVideoPreview } from '@/composables/useStudioVideoPreview'
 import { useVideoTaskPoll } from '@/composables/useVideoTaskPoll'
 import { useMediaLibrary, type ImageHistoryItem, type VideoTaskItem } from '@/composables/useMediaLibrary'
 import type { ApiKey } from '@/types'
@@ -439,19 +414,14 @@ const activeRunTs = ref<number | null>(null)
 
 const library = useMediaLibrary(props.userId)
 
-async function tagVideoPlayback(taskId: string, url: string): Promise<void> {
-  if (!url) {
-    library.patchVideoTask(taskId, { playbackStorage: 'expired' })
-    return
-  }
-  const storage = await resolveVideoPlaybackStorage(url)
-  library.patchVideoTask(taskId, { playbackStorage: storage })
-  if (storage === 'upstream-cors-blocked') {
-    appStore.showWarning(t('studio.playback.upstreamCorsBlocked'), 8000)
-  }
-  if (storage === 'inline-local' || storage === 'upstream-cors-ok') {
-    void library.cacheInlineMedia('video', taskId, url)
-  }
+const playbackDeps = {
+  patchVideoTask: (id: string, patch: Partial<VideoTaskItem>) => library.patchVideoTask(id, patch),
+  cacheInlineMedia: library.cacheInlineMedia.bind(library),
+  onUpstreamCorsBlocked: () => appStore.showWarning(t('studio.playback.upstreamCorsBlocked'), 8000),
+}
+
+function tagVideoPlayback(taskId: string, url: string): void {
+  void tagStudioVideoPlayback(playbackDeps, taskId, url)
 }
 
 function patchVideoTask(id: string, patch: Partial<VideoTaskItem>): void {
@@ -517,50 +487,40 @@ function panelPlaybackTask(p: BakePanel): Pick<VideoTaskItem, 'playbackStorage' 
   }
 }
 
-function downloadImage(src: string, id: string): void {
-  downloadMedia(src, `tokenkey-${id}.png`)
-}
-
-function modelLabel(modelId: string): string {
-  const hit = models.value.find((r) => r.model.modelId === modelId || r.servedId === modelId)
-  return hit?.model.displayName ?? modelId
-}
-
-// ---- In-page video lightbox (on-demand playback; no always-on <video>) ----------
-const videoPreviewOpen = ref(false)
-const videoPreviewUrl = ref('')
-const videoPreviewRawUrl = ref('')
-const videoPreviewTaskId = ref<string | undefined>()
-const videoPreviewLabel = ref('')
-const videoPreviewCost = ref<number | null>(null)
-const videoPreviewState = ref<'loading' | 'ready' | 'expired'>('loading')
-const videoPreviewMediaReady = ref(false)
-const copiedPreviewLink = ref(false)
-let videoPreviewRevoke: () => void = () => {}
-let copiedPreviewTimer: ReturnType<typeof setTimeout> | undefined
-
-const videoPreviewDownloadUrl = computed(() => videoPreviewRawUrl.value || videoPreviewUrl.value)
+// ---- In-page video lightbox (shared with VideoStudio) -------------------------
+const {
+  open: previewOpen,
+  previewUrl,
+  downloadUrl: previewDownloadUrl,
+  downloadFilename: previewDownloadFilename,
+  label: previewLabel,
+  cost: previewCost,
+  previewState,
+  previewMediaReady,
+  copiedLink: previewCopiedLink,
+  openPreview: openPreviewLightbox,
+  closePreview: closePreviewLightbox,
+  onPreviewError,
+  retryPreview: retryPreviewLightbox,
+  onPreviewMediaReady,
+  copyPreviewLink,
+} = useStudioVideoPreview({
+  onUrlExpired: (id) => patchVideoTask(id, { urlExpired: true }),
+})
 
 function openVideoPreviewFromUrl(label: string, cost: number, url: string, taskId?: string): void {
-  if (!url) return
-  videoPreviewRevoke()
-  videoPreviewOpen.value = true
-  videoPreviewLabel.value = label
-  videoPreviewCost.value = cost
-  videoPreviewRawUrl.value = url
-  videoPreviewTaskId.value = taskId
-  videoPreviewUrl.value = ''
-  videoPreviewState.value = 'loading'
-  videoPreviewMediaReady.value = false
-  const playback = videoPlaybackUrl(url)
-  videoPreviewRevoke = playback.revoke
-  videoPreviewUrl.value = playback.url
-  videoPreviewState.value = playback.url ? 'ready' : 'expired'
+  openPreviewLightbox({
+    url,
+    label,
+    cost,
+    taskId,
+    downloadFilename: taskId ? `tokenkey-${taskId}.mp4` : 'tokenkey-bakeoff-preview.mp4',
+  })
 }
 
 function openVideoPreview(panel: BakePanel): void {
   if (panel.state !== 'succeeded' || !panel.url) return
-  if (!videoTaskPlaybackAvailable({ state: panel.state, url: panel.url, urlExpired: panel.urlExpired })) return
+  if (!videoTaskPlaybackAvailable({ state: panel.state, url: panel.url ?? '', urlExpired: panel.urlExpired })) return
   openVideoPreviewFromUrl(panel.label, panel.cost, panel.url, panel.taskId)
 }
 
@@ -569,48 +529,14 @@ function openVideoHistoryPreview(task: VideoTaskItem): void {
   openVideoPreviewFromUrl(modelLabel(task.model), task.estCost, task.url, task.id)
 }
 
-function onVideoPreviewError(): void {
-  const taskId = videoPreviewTaskId.value
-  closeVideoPreview()
-  if (taskId) patchVideoTask(taskId, { urlExpired: true })
+function downloadImage(src: string, id: string): void {
+  downloadMedia(src, `tokenkey-${id}.png`)
 }
 
-function retryVideoPreview(): void {
-  if (!videoPreviewRawUrl.value) return
-  openVideoPreviewFromUrl(
-    videoPreviewLabel.value,
-    videoPreviewCost.value ?? 0,
-    videoPreviewRawUrl.value,
-    videoPreviewTaskId.value
-  )
+function modelLabel(modelId: string): string {
+  const hit = models.value.find((r) => r.model.modelId === modelId || r.servedId === modelId)
+  return hit?.model.displayName ?? modelId
 }
-
-async function copyVideoPreviewLink(): Promise<void> {
-  if (!videoPreviewUrl.value) return
-  try {
-    await navigator.clipboard?.writeText(videoPreviewUrl.value)
-    copiedPreviewLink.value = true
-    if (copiedPreviewTimer) clearTimeout(copiedPreviewTimer)
-    copiedPreviewTimer = setTimeout(() => (copiedPreviewLink.value = false), 1500)
-  } catch {
-    /* clipboard unavailable — Download still works */
-  }
-}
-
-function closeVideoPreview(): void {
-  videoPreviewRevoke()
-  videoPreviewRevoke = () => {}
-  videoPreviewOpen.value = false
-  videoPreviewLabel.value = ''
-  videoPreviewCost.value = null
-  videoPreviewRawUrl.value = ''
-  videoPreviewTaskId.value = undefined
-  videoPreviewUrl.value = ''
-  videoPreviewState.value = 'loading'
-  videoPreviewMediaReady.value = false
-}
-
-onBeforeUnmount(closeVideoPreview)
 
 function selectedResolved() {
   return models.value.filter((r) => selectedModelIds.value.includes(r.model.modelId))

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -258,8 +258,8 @@
           </div>
           <div class="flex gap-3 text-[11px] font-medium text-gray-500 dark:text-dark-400">
             <button v-if="videoTaskPlaybackAvailable(task)" type="button" class="text-primary-600 dark:text-primary-300" @click="openPreview(task)">{{ t('studio.video.play') }}</button>
-            <button v-if="task.url" type="button" class="text-primary-600 dark:text-primary-300" data-testid="studio-video-download" @click="downloadMedia(task.url, `tokenkey-${task.id}.mp4`)">{{ t('studio.video.download') }}</button>
-            <button v-if="task.url" type="button" class="text-gray-500 dark:text-dark-300" data-testid="studio-video-copy-card-link" @click="copyTaskLink(task.url)">{{ copiedTaskUrl === task.url ? t('studio.video.copied') : t('studio.video.copyLink') }}</button>
+            <button v-if="task.url" type="button" class="text-primary-600 dark:text-primary-300" data-testid="studio-video-download" @click="downloadCardVideo(task.url, `tokenkey-${task.id}.mp4`, task.urlExpired)">{{ t('studio.video.download') }}</button>
+            <button v-if="task.url" type="button" class="text-gray-500 dark:text-dark-300" data-testid="studio-video-copy-card-link" @click="copyCardLink(task.url)">{{ copiedUrl === task.url ? t('studio.video.copied') : t('studio.video.copyLink') }}</button>
             <button type="button" @click="reuse(task)">{{ t('studio.image.usePrompt') }}</button>
             <button type="button" @click="removeTask(task.id)">{{ t('studio.clear') }}</button>
           </div>
@@ -294,6 +294,7 @@
       @retry="retryPreviewLightbox"
       @reuse="reuseAndClosePreview"
       @copy-link="copyPreviewLink"
+      @download="downloadPreview"
       @media-ready="onPreviewMediaReady"
     />
   </div>
@@ -316,7 +317,6 @@ import {
   type MediaPriceMap,
 } from '@/constants/mediaTiers.tk'
 import { estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
-import { downloadMedia } from '@/utils/studioDownload.tk'
 import { videoTaskPlaybackAvailable } from '@/utils/studioMedia.tk'
 import { tagStudioVideoPlayback } from '@/utils/studioPlaybackStorage.tk'
 import StudioLocalSaveBanner from '@/views/user/studio/components/StudioLocalSaveBanner.vue'
@@ -325,6 +325,7 @@ import StudioVideoPreviewLightbox from '@/views/user/studio/components/StudioVid
 import StudioVideoUnavailable from '@/views/user/studio/components/StudioVideoUnavailable.vue'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { useMediaLibrary, type VideoTaskItem } from '@/composables/useMediaLibrary'
+import { useStudioVideoCardActions } from '@/composables/useStudioVideoCardActions'
 import { useStudioVideoPreview } from '@/composables/useStudioVideoPreview'
 import { useVideoTaskPoll, requestVideoNotifyPermission, maybeNotify } from '@/composables/useVideoTaskPoll'
 import { useAppStore } from '@/stores/app'
@@ -347,6 +348,8 @@ const emit = defineEmits<{ (e: 'spent'): void }>()
 
 const { t } = useI18n()
 const appStore = useAppStore()
+const warnExpiredDownload = () => appStore.showWarning(t('studio.video.expiredHint'), 8000)
+const { copiedUrl, copyCardLink, downloadCardVideo } = useStudioVideoCardActions(warnExpiredDownload)
 const library = useMediaLibrary(props.userId)
 
 const models = computed(() => resolveAvailableModels('video', props.availableIds, props.priceMap))
@@ -500,8 +503,10 @@ const {
   retryPreview: retryPreviewLightbox,
   onPreviewMediaReady,
   copyPreviewLink,
+  downloadPreview,
 } = useStudioVideoPreview({
   onUrlExpired: (id) => library.patchVideoTask(id, { urlExpired: true }),
+  onExpiredDownload: warnExpiredDownload,
 })
 
 function openPreview(task: VideoTaskItem): void {
@@ -513,6 +518,7 @@ function openPreview(task: VideoTaskItem): void {
     subtitle: task.prompt,
     cost: task.estCost,
     taskId: task.id,
+    urlExpired: task.urlExpired,
     downloadFilename: `tokenkey-${task.id}.mp4`,
   })
 }
@@ -521,22 +527,6 @@ function reuseAndClosePreview(): void {
   if (previewTask.value) reuse(previewTask.value)
   closePreviewLightbox()
   previewTask.value = null
-}
-
-// Transient "copied" confirmation for the card copy-link button (no toast/banner).
-const copiedTaskUrl = ref('')
-let copiedTaskTimer: ReturnType<typeof setTimeout> | undefined
-
-async function copyTaskLink(url: string): Promise<void> {
-  if (!url) return
-  try {
-    await navigator.clipboard?.writeText(url)
-    copiedTaskUrl.value = url
-    if (copiedTaskTimer) clearTimeout(copiedTaskTimer)
-    copiedTaskTimer = setTimeout(() => (copiedTaskUrl.value = ''), 1500)
-  } catch {
-    /* clipboard unavailable / blocked — Download still works */
-  }
 }
 
 function onKeydown(e: KeyboardEvent): void {
@@ -611,7 +601,6 @@ onMounted(() => {
 })
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeydown)
-  if (copiedTaskTimer) clearTimeout(copiedTaskTimer)
 })
 </script>
 

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -277,58 +277,25 @@
       </div>
     </div>
 
-    <!-- Lightbox: in-page playback (replaces the always-on black inline player and
-         the open-in-new-tab dead-end that 404'd for data: veo clips). HTTP video
-         URLs go straight to the browser; inline data:video results become a
-         temporary Blob URL for this tab only. -->
-    <Teleport to="body">
-      <div
-        v-if="preview"
-        class="fixed inset-0 z-[100] flex flex-col bg-black/85 backdrop-blur-sm"
-        data-testid="studio-video-preview"
-        @click.self="closePreview"
-      >
-        <div class="flex items-center justify-end p-3">
-          <button type="button" class="rounded-lg bg-white/10 px-3 py-1.5 text-sm font-medium text-white hover:bg-white/20" data-testid="studio-video-preview-close" :aria-label="t('studio.video.close')" @click="closePreview">
-            {{ t('studio.video.close') }} ✕
-          </button>
-        </div>
-        <div class="relative flex min-h-0 flex-1 items-center justify-center px-4" @click.self="closePreview">
-          <video
-            v-if="previewState === 'ready' && previewUrl"
-            :src="previewUrl"
-            controls
-            autoplay
-            playsinline
-            preload="auto"
-            class="h-full max-h-full w-full max-w-full rounded-lg bg-black object-contain shadow-2xl"
-            @loadeddata="previewMediaReady = true"
-            @error="onPreviewError"
-          ></video>
-          <div v-if="previewState === 'ready' && previewUrl && !previewMediaReady" class="absolute text-sm text-white/80">{{ t('studio.video.previewBuffering') }}</div>
-          <div v-else-if="previewState === 'loading'" class="text-sm text-white/80">{{ t('studio.video.loadingPreview') }}</div>
-          <div v-else class="max-w-sm rounded-xl bg-white/10 p-6 text-center">
-            <p class="text-sm font-semibold text-white">{{ t('studio.video.expiredTitle') }}</p>
-            <p class="mt-1 text-xs text-white/70">{{ t('studio.video.expiredHint') }}</p>
-            <div class="mt-3 flex items-center justify-center gap-2">
-              <!-- A media error can be transient (one-off network blip), so offer a
-                   retry before pushing the user to (re-)pay to regenerate. -->
-              <button type="button" class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100" @click="retryPreview">{{ t('studio.video.retry') }}</button>
-              <button type="button" class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white" @click="reuseAndClose(preview)">{{ t('studio.image.usePrompt') }}</button>
-            </div>
-          </div>
-        </div>
-        <div class="flex flex-wrap items-center justify-center gap-3 p-4">
-          <span class="max-w-[60vw] truncate text-xs text-white/80" :title="preview.prompt">{{ preview.prompt }}</span>
-          <span class="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[11px] font-semibold text-white">{{ formatUsd(preview.estCost) }}</span>
-          <button v-if="previewState === 'ready' && previewUrl" type="button" class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100" @click="downloadMedia(previewUrl, `tokenkey-${preview.id}.mp4`)">{{ t('studio.video.download') }}</button>
-          <!-- Restore a way to grab the link itself (the #860 rework dropped the
-               open-in-new-tab anchor → the "看不到链接" report). -->
-          <button v-if="previewState === 'ready' && previewUrl" type="button" class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white" data-testid="studio-video-copy-link" @click="copyPreviewLink">{{ copied ? t('studio.video.copied') : t('studio.video.copyLink') }}</button>
-          <button type="button" class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white" @click="reuseAndClose(preview)">{{ t('studio.image.usePrompt') }}</button>
-        </div>
-      </div>
-    </Teleport>
+    <StudioVideoPreviewLightbox
+      :open="previewOpen"
+      :preview-state="previewState"
+      :preview-url="previewUrl"
+      :download-url="previewDownloadUrl"
+      :download-filename="previewDownloadFilename"
+      :label="previewLabel"
+      :subtitle="previewSubtitle"
+      :cost="previewCost"
+      :preview-media-ready="previewMediaReady"
+      :copied-link="previewCopiedLink"
+      show-reuse-prompt
+      @close="closePreviewLightbox"
+      @error="onPreviewError"
+      @retry="retryPreviewLightbox"
+      @reuse="reuseAndClosePreview"
+      @copy-link="copyPreviewLink"
+      @media-ready="onPreviewMediaReady"
+    />
   </div>
 </template>
 
@@ -350,15 +317,15 @@ import {
 } from '@/constants/mediaTiers.tk'
 import { estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
 import { downloadMedia } from '@/utils/studioDownload.tk'
-import { videoPlaybackUrl, videoTaskPlaybackAvailable } from '@/utils/studioMedia.tk'
-import {
-  resolveVideoPlaybackStorage,
-} from '@/utils/studioPlaybackStorage.tk'
+import { videoTaskPlaybackAvailable } from '@/utils/studioMedia.tk'
+import { tagStudioVideoPlayback } from '@/utils/studioPlaybackStorage.tk'
 import StudioLocalSaveBanner from '@/views/user/studio/components/StudioLocalSaveBanner.vue'
 import StudioPlaybackBadge from '@/views/user/studio/components/StudioPlaybackBadge.vue'
+import StudioVideoPreviewLightbox from '@/views/user/studio/components/StudioVideoPreviewLightbox.vue'
 import StudioVideoUnavailable from '@/views/user/studio/components/StudioVideoUnavailable.vue'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { useMediaLibrary, type VideoTaskItem } from '@/composables/useMediaLibrary'
+import { useStudioVideoPreview } from '@/composables/useStudioVideoPreview'
 import { useVideoTaskPoll, requestVideoNotifyPermission, maybeNotify } from '@/composables/useVideoTaskPoll'
 import { useAppStore } from '@/stores/app'
 import type { ApiKey } from '@/types'
@@ -425,19 +392,14 @@ const formula = computed(() => {
   return t('studio.video.formula', { rate: formatUsd(selected.value.perSecond || 0), seconds: duration.value })
 })
 
-async function tagVideoPlayback(taskId: string, url: string): Promise<void> {
-  if (!url) {
-    library.patchVideoTask(taskId, { playbackStorage: 'expired' })
-    return
-  }
-  const storage = await resolveVideoPlaybackStorage(url)
-  library.patchVideoTask(taskId, { playbackStorage: storage })
-  if (storage === 'upstream-cors-blocked') {
-    appStore.showWarning(t('studio.playback.upstreamCorsBlocked'), 8000)
-  }
-  if (storage === 'inline-local' || storage === 'upstream-cors-ok') {
-    void library.cacheInlineMedia('video', taskId, url)
-  }
+const playbackDeps = {
+  patchVideoTask: (id: string, patch: Partial<VideoTaskItem>) => library.patchVideoTask(id, patch),
+  cacheInlineMedia: library.cacheInlineMedia.bind(library),
+  onUpstreamCorsBlocked: () => appStore.showWarning(t('studio.playback.upstreamCorsBlocked'), 8000),
+}
+
+function tagVideoPlayback(taskId: string, url: string): void {
+  void tagStudioVideoPlayback(playbackDeps, taskId, url)
 }
 
 const poll = useVideoTaskPoll({
@@ -504,17 +466,14 @@ function reuse(task: VideoTaskItem): void {
 }
 
 function removeTask(id: string): void {
-  // Stop the poll loop BEFORE dropping the task, otherwise clearing an in-flight
-  // task leaves a phantom poller (setTimeout + AbortController) running until the
-  // component unmounts — it would keep patching a task that no longer exists.
   poll.stop(id)
-  if (preview.value?.id === id) closePreview()
+  if (previewTaskId.value === id) closePreviewLightbox()
   library.removeVideoTask(id)
 }
 
 function clearAll(): void {
-  closePreview()
-  poll.stopAll() // drop any in-flight pollers so cleared tasks leave no phantoms
+  closePreviewLightbox()
+  poll.stopAll()
   library.clearVideoTasks()
 }
 
@@ -522,68 +481,51 @@ async function enableNotify(): Promise<void> {
   notifyState.value = (await requestVideoNotifyPermission()) ? 'granted' : 'denied'
 }
 
-// ---- In-page video lightbox ---------------------------------------------------
-const preview = ref<VideoTaskItem | null>(null)
-const previewMediaReady = ref(false)
-const previewUrl = ref('')
-const previewState = ref<'loading' | 'ready' | 'expired'>('loading')
-// Transient "copied" confirmation for the copy-link button (no toast/banner).
-const copied = ref(false)
-const copiedTaskUrl = ref('')
-let copiedTimer: ReturnType<typeof setTimeout> | undefined
-let copiedTaskTimer: ReturnType<typeof setTimeout> | undefined
-let previewRevoke: () => void = () => {}
+const previewTask = ref<VideoTaskItem | null>(null)
+const {
+  open: previewOpen,
+  previewUrl,
+  downloadUrl: previewDownloadUrl,
+  downloadFilename: previewDownloadFilename,
+  label: previewLabel,
+  subtitle: previewSubtitle,
+  cost: previewCost,
+  previewState,
+  previewMediaReady,
+  copiedLink: previewCopiedLink,
+  taskId: previewTaskId,
+  openPreview: openPreviewLightbox,
+  closePreview: closePreviewLightbox,
+  onPreviewError,
+  retryPreview: retryPreviewLightbox,
+  onPreviewMediaReady,
+  copyPreviewLink,
+} = useStudioVideoPreview({
+  onUrlExpired: (id) => library.patchVideoTask(id, { urlExpired: true }),
+})
 
-async function openPreview(task: VideoTaskItem): Promise<void> {
+function openPreview(task: VideoTaskItem): void {
   if (!videoTaskPlaybackAvailable(task)) return
-  previewRevoke()
-  preview.value = task
-  previewUrl.value = ''
-  previewState.value = 'loading'
-  previewMediaReady.value = false
-  // Playback must not turn TokenKey into a media server: http(s) upstream URLs go
-  // straight to the browser; an inline data:video result becomes a tab-local Blob
-  // URL we revoke on close. Shared with Bake-Off via videoPlaybackUrl.
-  const playback = videoPlaybackUrl(task.url)
-  previewRevoke = playback.revoke
-  if (preview.value?.id !== task.id) {
-    playback.revoke()
-    return
-  }
-  previewUrl.value = playback.url
-  previewState.value = playback.url ? 'ready' : 'expired'
+  previewTask.value = task
+  openPreviewLightbox({
+    url: task.url,
+    label: task.model,
+    subtitle: task.prompt,
+    cost: task.estCost,
+    taskId: task.id,
+    downloadFilename: `tokenkey-${task.id}.mp4`,
+  })
 }
 
-// The <video> failed to load — mark the card prompt-only and close the lightbox
-// instead of trapping the user in an "expired" modal they already saw on the list.
-// Keep the live-session URL so the card can still offer Download / Copy.
-// localStorage persistence continues to strip http(s) links on reload.
-function onPreviewError(): void {
-  const task = preview.value
-  closePreview()
-  if (task) library.patchVideoTask(task.id, { urlExpired: true })
+function reuseAndClosePreview(): void {
+  if (previewTask.value) reuse(previewTask.value)
+  closePreviewLightbox()
+  previewTask.value = null
 }
 
-// Re-attempt playback — recovers from a transient media error without forcing
-// the user to close, re-click, or pay to regenerate.
-function retryPreview(): void {
-  if (preview.value) void openPreview(preview.value)
-}
-
-// Copy the active preview URL to the clipboard. Best-effort: an insecure context
-// or a denied permission is a no-op (Download remains the fallback), so the copy
-// affordance never throws into the UI.
-async function copyPreviewLink(): Promise<void> {
-  if (!previewUrl.value) return
-  try {
-    await navigator.clipboard?.writeText(previewUrl.value)
-    copied.value = true
-    if (copiedTimer) clearTimeout(copiedTimer)
-    copiedTimer = setTimeout(() => (copied.value = false), 1500)
-  } catch {
-    /* clipboard unavailable / blocked — silent, Download still works */
-  }
-}
+// Transient "copied" confirmation for the card copy-link button (no toast/banner).
+const copiedTaskUrl = ref('')
+let copiedTaskTimer: ReturnType<typeof setTimeout> | undefined
 
 async function copyTaskLink(url: string): Promise<void> {
   if (!url) return
@@ -597,22 +539,8 @@ async function copyTaskLink(url: string): Promise<void> {
   }
 }
 
-function closePreview(): void {
-  previewRevoke()
-  previewRevoke = () => {}
-  preview.value = null
-  previewUrl.value = ''
-  previewMediaReady.value = false
-  copied.value = false
-}
-
-function reuseAndClose(task: VideoTaskItem | null): void {
-  if (task) reuse(task)
-  closePreview()
-}
-
 function onKeydown(e: KeyboardEvent): void {
-  if (e.key === 'Escape' && preview.value) closePreview()
+  if (e.key === 'Escape' && previewOpen.value) closePreviewLightbox()
 }
 
 async function generate(): Promise<void> {
@@ -683,9 +611,7 @@ onMounted(() => {
 })
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeydown)
-  if (copiedTimer) clearTimeout(copiedTimer)
   if (copiedTaskTimer) clearTimeout(copiedTaskTimer)
-  previewRevoke()
 })
 </script>
 

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -19,8 +19,12 @@ const libraryMock = vi.hoisted(() => ({
   cacheInlineMedia: vi.fn(async () => undefined),
 }))
 
+const appStoreMock = vi.hoisted(() => ({
+  showWarning: vi.fn(),
+}))
+
 vi.mock('@/stores/app', () => ({
-  useAppStore: () => ({ showWarning: vi.fn() }),
+  useAppStore: () => appStoreMock,
 }))
 
 vi.mock('@/api/playground', () => ({
@@ -279,7 +283,7 @@ describe('BakeOff image routing', () => {
     )
   })
 
-  it('closes the panel lightbox and marks the task expired when preview media fails', async () => {
+  it('keeps the lightbox open with copy-link fallback when preview media fails', async () => {
     vi.mocked(playground.gatewayVideoSubmit)
       .mockResolvedValueOnce({ id: 'vt_panel_a', status: 'succeeded', url: 'https://cdn.example/a.mp4' })
       .mockResolvedValueOnce({ id: 'vt_panel_b', status: 'succeeded', url: 'https://cdn.example/b.mp4' })
@@ -303,12 +307,70 @@ describe('BakeOff image routing', () => {
     await wrapper.find('[data-testid="bakeoff-video-preview"] video').trigger('error')
     await flushPromises()
 
-    expect(wrapper.find('[data-testid="bakeoff-video-preview"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="bakeoff-video-preview"]').exists()).toBe(true)
+    expect(wrapper.findAll('[data-testid="bakeoff-video-copy-link"]').length).toBeGreaterThan(0)
     expect(libraryMock.patchVideoTask).toHaveBeenCalledWith('vt_panel_a', { urlExpired: true })
     expect(panelEls[0].find('[data-testid="bakeoff-video-play"]').exists()).toBe(false)
     expect(panelEls[0].find('[data-testid="bakeoff-video-expired"]').exists()).toBe(true)
     expect(panelEls[0].find('[data-testid="bakeoff-video-download"]').exists()).toBe(true)
+    expect(panelEls[0].find('[data-testid="bakeoff-video-copy-card-link"]').exists()).toBe(true)
     expect(panelEls[1].find('[data-testid="bakeoff-video-play"]').exists()).toBe(true)
+  })
+
+  it('exposes card-level copy-link for succeeded video panels', async () => {
+    vi.mocked(playground.gatewayVideoSubmit)
+      .mockResolvedValueOnce({ id: 'vt_panel_a', status: 'succeeded', url: 'https://cdn.example/a.mp4' })
+      .mockResolvedValueOnce({ id: 'vt_panel_b', status: 'succeeded', url: 'https://cdn.example/b.mp4' })
+
+    const writeText = vi.fn(async () => undefined)
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+
+    const wrapper = mount(BakeOff, {
+      props: videoProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true, teleport: true } },
+    })
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    await tiers[0].trigger('click')
+    await tiers[1].trigger('click')
+    await wrapper.get('textarea').setValue('family in a garden')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    await wrapper.findAll('[data-testid="bakeoff-panel"]')[0].get('[data-testid="bakeoff-video-copy-card-link"]').trigger('click')
+    await flushPromises()
+    expect(writeText).toHaveBeenCalledWith('https://cdn.example/a.mp4')
+    vi.unstubAllGlobals()
+  })
+
+  it('warns instead of opening a new tab when downloading an expired panel url', async () => {
+    vi.mocked(playground.gatewayVideoSubmit)
+      .mockResolvedValueOnce({ id: 'vt_panel_a', status: 'succeeded', url: 'https://cdn.example/a.mp4' })
+      .mockResolvedValueOnce({ id: 'vt_panel_b', status: 'succeeded', url: 'https://cdn.example/b.mp4' })
+    const downloadSpy = vi.spyOn(await import('@/utils/studioDownload.tk'), 'downloadMedia')
+
+    const wrapper = mount(BakeOff, {
+      props: videoProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true, teleport: true } },
+    })
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    await tiers[0].trigger('click')
+    await tiers[1].trigger('click')
+    await wrapper.get('textarea').setValue('family in a garden')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    const panelEls = wrapper.findAll('[data-testid="bakeoff-panel"]')
+    await panelEls[0].get('[data-testid="bakeoff-video-play"]').trigger('click')
+    await flushPromises()
+    await wrapper.find('[data-testid="bakeoff-video-preview"] video').trigger('error')
+    await flushPromises()
+
+    appStoreMock.showWarning.mockClear()
+    downloadSpy.mockClear()
+    await panelEls[0].get('[data-testid="bakeoff-video-download"]').trigger('click')
+    expect(appStoreMock.showWarning).toHaveBeenCalled()
+    expect(downloadSpy).not.toHaveBeenCalled()
+    downloadSpy.mockRestore()
   })
 
   it('converts inline data:video panel urls to blob playback in the lightbox', async () => {

--- a/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
@@ -153,7 +153,7 @@ describe('VideoStudio succeeded-task presentation', () => {
     expect(w.text()).toContain('studio.playback.expired')
   })
 
-  it('closes the lightbox and marks the card expired when preview media fails', async () => {
+  it('keeps the lightbox open and marks the card expired when preview media fails', async () => {
     seedInSession(baseTask())
     const w = mountStudio()
     await w.find('[data-testid="studio-video-play"]').trigger('click')
@@ -163,7 +163,8 @@ describe('VideoStudio succeeded-task presentation', () => {
     await w.find('[data-testid="studio-video-preview"] video').trigger('error')
     await flushPromises()
 
-    expect(w.find('[data-testid="studio-video-preview"]').exists()).toBe(false)
+    expect(w.find('[data-testid="studio-video-preview"]').exists()).toBe(true)
+    expect(w.findAll('[data-testid="studio-video-copy-link"]').length).toBeGreaterThan(0)
     expect(libraryMock.patchVideoTaskSpy).toHaveBeenCalledWith('vt_abc', { urlExpired: true })
     expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(false)
     expect(w.find('[data-testid="studio-video-expired"]').exists()).toBe(true)

--- a/frontend/src/views/user/studio/components/StudioVideoPreviewLightbox.vue
+++ b/frontend/src/views/user/studio/components/StudioVideoPreviewLightbox.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { formatUsd } from '@/utils/mediaCostEstimate.tk'
-import { downloadMedia } from '@/utils/studioDownload.tk'
 import type { StudioVideoPreviewState } from '@/composables/useStudioVideoPreview'
 
-const props = defineProps<{
+defineProps<{
   open: boolean
   previewState: StudioVideoPreviewState
   previewUrl: string
@@ -27,15 +26,11 @@ const emit = defineEmits<{
   retry: []
   reuse: []
   'copy-link': []
+  download: []
   'media-ready': []
 }>()
 
 const { t } = useI18n()
-
-function onDownload(): void {
-  if (!props.downloadUrl) return
-  downloadMedia(props.downloadUrl, props.downloadFilename)
-}
 </script>
 
 <template>
@@ -81,13 +76,22 @@ function onDownload(): void {
         <div v-else class="max-w-sm rounded-xl bg-white/10 p-6 text-center">
           <p class="text-sm font-semibold text-white">{{ t('studio.video.expiredTitle') }}</p>
           <p class="mt-1 text-xs text-white/70">{{ t('studio.video.expiredHint') }}</p>
-          <div class="mt-3 flex items-center justify-center gap-2">
+          <div class="mt-3 flex flex-wrap items-center justify-center gap-2">
             <button
               type="button"
               class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100"
               @click="emit('retry')"
             >
               {{ t('studio.video.retry') }}
+            </button>
+            <button
+              v-if="downloadUrl"
+              type="button"
+              class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white"
+              :data-testid="copyLinkTestId ?? 'studio-video-copy-link'"
+              @click="emit('copy-link')"
+            >
+              {{ copiedLink ? t('studio.video.copied') : t('studio.video.copyLink') }}
             </button>
             <button
               v-if="showReusePrompt"
@@ -109,12 +113,12 @@ function onDownload(): void {
           v-if="downloadUrl"
           type="button"
           class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100"
-          @click="onDownload"
+          @click="emit('download')"
         >
           {{ t('studio.video.download') }}
         </button>
         <button
-          v-if="previewState === 'ready' && previewUrl"
+          v-if="downloadUrl"
           type="button"
           class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white"
           :data-testid="copyLinkTestId ?? 'studio-video-copy-link'"

--- a/frontend/src/views/user/studio/components/StudioVideoPreviewLightbox.vue
+++ b/frontend/src/views/user/studio/components/StudioVideoPreviewLightbox.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { formatUsd } from '@/utils/mediaCostEstimate.tk'
+import { downloadMedia } from '@/utils/studioDownload.tk'
+import type { StudioVideoPreviewState } from '@/composables/useStudioVideoPreview'
+
+const props = defineProps<{
+  open: boolean
+  previewState: StudioVideoPreviewState
+  previewUrl: string
+  downloadUrl: string
+  downloadFilename: string
+  label: string
+  subtitle?: string
+  cost: number | null
+  previewMediaReady: boolean
+  copiedLink: boolean
+  testId?: string
+  closeTestId?: string
+  copyLinkTestId?: string
+  showReusePrompt?: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+  error: []
+  retry: []
+  reuse: []
+  'copy-link': []
+  'media-ready': []
+}>()
+
+const { t } = useI18n()
+
+function onDownload(): void {
+  if (!props.downloadUrl) return
+  downloadMedia(props.downloadUrl, props.downloadFilename)
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="fixed inset-0 z-[100] flex flex-col bg-black/85 backdrop-blur-sm"
+      :data-testid="testId ?? 'studio-video-preview'"
+      @click.self="emit('close')"
+    >
+      <div class="flex items-center justify-end p-3">
+        <button
+          type="button"
+          class="rounded-lg bg-white/10 px-3 py-1.5 text-sm font-medium text-white hover:bg-white/20"
+          :data-testid="closeTestId ?? 'studio-video-preview-close'"
+          :aria-label="t('studio.video.close')"
+          @click="emit('close')"
+        >
+          {{ t('studio.video.close') }} ✕
+        </button>
+      </div>
+      <div class="relative flex min-h-0 flex-1 items-center justify-center px-4" @click.self="emit('close')">
+        <video
+          v-if="previewState === 'ready' && previewUrl"
+          :src="previewUrl"
+          controls
+          autoplay
+          playsinline
+          preload="auto"
+          class="h-full max-h-full w-full max-w-full rounded-lg bg-black object-contain shadow-2xl"
+          @loadeddata="$emit('media-ready')"
+          @error="$emit('error')"
+        ></video>
+        <div
+          v-if="previewState === 'ready' && previewUrl && !previewMediaReady"
+          class="absolute text-sm text-white/80"
+        >
+          {{ t('studio.video.previewBuffering') }}
+        </div>
+        <div v-else-if="previewState === 'loading'" class="text-sm text-white/80">
+          {{ t('studio.video.loadingPreview') }}
+        </div>
+        <div v-else class="max-w-sm rounded-xl bg-white/10 p-6 text-center">
+          <p class="text-sm font-semibold text-white">{{ t('studio.video.expiredTitle') }}</p>
+          <p class="mt-1 text-xs text-white/70">{{ t('studio.video.expiredHint') }}</p>
+          <div class="mt-3 flex items-center justify-center gap-2">
+            <button
+              type="button"
+              class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100"
+              @click="emit('retry')"
+            >
+              {{ t('studio.video.retry') }}
+            </button>
+            <button
+              v-if="showReusePrompt"
+              type="button"
+              class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white"
+              @click="emit('reuse')"
+            >
+              {{ t('studio.image.usePrompt') }}
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="flex flex-wrap items-center justify-center gap-3 p-4">
+        <span class="max-w-[60vw] truncate text-xs text-white/80" :title="subtitle || label">{{ subtitle || label }}</span>
+        <span v-if="cost != null" class="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[11px] font-semibold text-white">
+          {{ formatUsd(cost) }}
+        </span>
+        <button
+          v-if="downloadUrl"
+          type="button"
+          class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100"
+          @click="onDownload"
+        >
+          {{ t('studio.video.download') }}
+        </button>
+        <button
+          v-if="previewState === 'ready' && previewUrl"
+          type="button"
+          class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white"
+          :data-testid="copyLinkTestId ?? 'studio-video-copy-link'"
+          @click="emit('copy-link')"
+        >
+          {{ copiedLink ? t('studio.video.copied') : t('studio.video.copyLink') }}
+        </button>
+        <button
+          v-if="showReusePrompt"
+          type="button"
+          class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white"
+          @click="emit('reuse')"
+        >
+          {{ t('studio.image.usePrompt') }}
+        </button>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/frontend/src/views/user/studio/components/__tests__/StudioVideoPreviewLightbox.spec.ts
+++ b/frontend/src/views/user/studio/components/__tests__/StudioVideoPreviewLightbox.spec.ts
@@ -65,4 +65,20 @@ describe('StudioVideoPreviewLightbox', () => {
     const wrapper = mountLightbox({ previewState: 'expired', previewUrl: '' })
     expect(wrapper.text()).toContain('studio.video.retry')
   })
+
+  it('emits download when footer download is clicked', async () => {
+    const wrapper = mountLightbox()
+    const buttons = wrapper.findAll('button').filter((b) => b.text().includes('studio.video.download'))
+    await buttons[0].trigger('click')
+    expect(wrapper.emitted('download')).toHaveLength(1)
+  })
+
+  it('shows copy-link in expired state when downloadUrl is set', () => {
+    const wrapper = mountLightbox({
+      previewState: 'expired',
+      previewUrl: '',
+      downloadUrl: 'https://cdn.example/clip.mp4',
+    })
+    expect(wrapper.find('[data-testid="studio-video-copy-link"]').exists()).toBe(true)
+  })
 })

--- a/frontend/src/views/user/studio/components/__tests__/StudioVideoPreviewLightbox.spec.ts
+++ b/frontend/src/views/user/studio/components/__tests__/StudioVideoPreviewLightbox.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en'
+import StudioVideoPreviewLightbox from '../StudioVideoPreviewLightbox.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackWarn: false,
+  missingWarn: false,
+  messages: { en },
+})
+
+function mountLightbox(overrides: Record<string, unknown> = {}) {
+  return mount(StudioVideoPreviewLightbox, {
+    props: {
+      open: true,
+      previewState: 'ready',
+      previewUrl: 'https://cdn.example/clip.mp4',
+      downloadUrl: 'https://cdn.example/clip.mp4',
+      downloadFilename: 'tokenkey-test.mp4',
+      label: 'Seedance 1.0',
+      cost: 1.09,
+      previewMediaReady: true,
+      copiedLink: false,
+      testId: 'studio-video-preview',
+      ...overrides,
+    },
+    global: { plugins: [i18n], stubs: { teleport: true } },
+  })
+}
+
+describe('StudioVideoPreviewLightbox', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'URL',
+      Object.assign({}, URL, {
+        createObjectURL: vi.fn(() => 'blob:preview'),
+        revokeObjectURL: vi.fn(),
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders a full-size video element for ready state', () => {
+    const wrapper = mountLightbox()
+    const video = wrapper.get('[data-testid="studio-video-preview"] video')
+    expect(video.attributes('src')).toBe('https://cdn.example/clip.mp4')
+    expect(video.classes()).toEqual(
+      expect.arrayContaining(['h-full', 'w-full', 'object-contain', 'max-h-full', 'max-w-full'])
+    )
+  })
+
+  it('emits error when the video element fails to load', async () => {
+    const wrapper = mountLightbox()
+    await wrapper.get('[data-testid="studio-video-preview"] video').trigger('error')
+    expect(wrapper.emitted('error')).toHaveLength(1)
+  })
+
+  it('shows retry affordance in expired state', () => {
+    const wrapper = mountLightbox({ previewState: 'expired', previewUrl: '' })
+    expect(wrapper.text()).toContain('studio.video.retry')
+  })
+})

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -113,6 +113,8 @@
         "isGeminiNativeImageModel",
         "StudioVideoPreviewLightbox",
         "useStudioVideoPreview",
+        "useStudioVideoCardActions",
+        "data-testid=\"bakeoff-video-copy-card-link\"",
         "test-id=\"bakeoff-video-preview\""
       ],
       "rationale": "BakeOff.vue is the TK-only Studio 'bake-off' compare surface — one prompt rendered across 2-4 priced image/video models side by side, each panel showing its own real price + latency. It is mounted by MediaStudioView.vue (view==='bakeoff') and is the only multi-model compare flow; the test-ids are the contract the studio e2e (frontend/e2e/studio.e2e.ts) drives and the anchors that keep an upstream merge from silently dropping the view (compiles green, feature gone). Note: the bakeoff image/video sub-mode toggle reuses data-testid=\"bakeoff-mode-image\"/\"bakeoff-mode-video\"; the run button + tier chips + result panels are anchored here."
@@ -968,7 +970,8 @@
         "test-id=\"studio-video-save-reminder\"",
         "StudioVideoUnavailable",
         "StudioVideoPreviewLightbox",
-        "useStudioVideoPreview"
+        "useStudioVideoPreview",
+        "useStudioVideoCardActions"
       ],
       "must_not_contain": [
         "poll.refreshUrl"
@@ -993,10 +996,24 @@
       "must_contain": [
         "export function useStudioVideoPreview",
         "videoPlaybackUrl",
+        "copyMediaLink",
         "onPreviewError",
-        "onUrlExpired"
+        "downloadPreview",
+        "onUrlExpired",
+        "urlExpired"
       ],
-      "rationale": "Single lightbox state machine for Studio video preview (VideoStudio + BakeOff). Centralizes open/close, Blob URL revoke, preview error -> urlExpired, retry, and copy-link so surfaces cannot drift after playback fixes."
+      "rationale": "Single lightbox state machine for Studio video preview (VideoStudio + BakeOff). Centralizes open/close, Blob URL revoke, preview error -> urlExpired (lightbox stays open), retry, copy-link (raw upstream url), and expired download guard so surfaces cannot drift after playback fixes."
+    },
+    {
+      "path": "frontend/src/composables/useStudioVideoCardActions.ts",
+      "must_contain": [
+        "export function useStudioVideoCardActions",
+        "copyMediaLink",
+        "downloadMedia",
+        "copyCardLink",
+        "downloadCardVideo"
+      ],
+      "rationale": "Shared card-level copy-link + download actions for VideoStudio and BakeOff succeeded panels. urlExpired download path warns instead of opening a dead upstream tab."
     },
     {
       "path": "frontend/src/views/user/studio/components/StudioVideoPreviewLightbox.vue",
@@ -1005,7 +1022,8 @@
         "'studio-video-preview-close'",
         "'studio-video-copy-link'",
         "@error",
-        "studio.video.retry"
+        "studio.video.retry",
+        "emit('download')"
       ],
       "rationale": "Shared Teleport lightbox UI for Studio video playback. VideoStudio and BakeOff mount this instead of duplicating inline video + error/retry/download affordances."
     },

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -110,7 +110,10 @@
         "test-id=\"studio-bakeoff-save-reminder\"",
         "data-testid=\"bakeoff-history\"",
         "gatewayGeminiImageViaChat",
-        "isGeminiNativeImageModel"
+        "isGeminiNativeImageModel",
+        "StudioVideoPreviewLightbox",
+        "useStudioVideoPreview",
+        "test-id=\"bakeoff-video-preview\""
       ],
       "rationale": "BakeOff.vue is the TK-only Studio 'bake-off' compare surface — one prompt rendered across 2-4 priced image/video models side by side, each panel showing its own real price + latency. It is mounted by MediaStudioView.vue (view==='bakeoff') and is the only multi-model compare flow; the test-ids are the contract the studio e2e (frontend/e2e/studio.e2e.ts) drives and the anchors that keep an upstream merge from silently dropping the view (compiles green, feature gone). Note: the bakeoff image/video sub-mode toggle reuses data-testid=\"bakeoff-mode-image\"/\"bakeoff-mode-video\"; the run button + tier chips + result panels are anchored here."
     },
@@ -959,14 +962,13 @@
         "data-testid=\"studio-video-model\"",
         "data-testid=\"studio-video-generate\"",
         "data-testid=\"studio-video-play\"",
-        "data-testid=\"studio-video-preview\"",
-        "data-testid=\"studio-video-copy-link\"",
         "data-testid=\"studio-video-download\"",
         "data-testid=\"studio-video-copy-card-link\"",
         "StudioLocalSaveBanner",
         "test-id=\"studio-video-save-reminder\"",
         "StudioVideoUnavailable",
-        "videoPlaybackUrl"
+        "StudioVideoPreviewLightbox",
+        "useStudioVideoPreview"
       ],
       "must_not_contain": [
         "poll.refreshUrl"
@@ -985,6 +987,34 @@
         "revokeObjectURL"
       ],
       "rationale": "Shared Studio video-playback resolver enforcing the #944 'TokenKey is not a media CDN' rule for EVERY on-demand video surface (VideoStudio lightbox + Bake-Off panels). videoPlaybackUrl hands http(s) upstream URLs straight to the browser and converts an inline data:video result (the one response already delivered to this tab) into a tab-local Blob URL with a revoke() — never re-fetching or rehosting. Deleting/inlining this back into a single view risks one surface (e.g. Bake-Off) regressing to an always-on <video> that competes loads and black-boxes pre-play; the data:video + createObjectURL + revokeObjectURL anchors pin the conversion + cleanup."
+    },
+    {
+      "path": "frontend/src/composables/useStudioVideoPreview.ts",
+      "must_contain": [
+        "export function useStudioVideoPreview",
+        "videoPlaybackUrl",
+        "onPreviewError",
+        "onUrlExpired"
+      ],
+      "rationale": "Single lightbox state machine for Studio video preview (VideoStudio + BakeOff). Centralizes open/close, Blob URL revoke, preview error -> urlExpired, retry, and copy-link so surfaces cannot drift after playback fixes."
+    },
+    {
+      "path": "frontend/src/views/user/studio/components/StudioVideoPreviewLightbox.vue",
+      "must_contain": [
+        "'studio-video-preview'",
+        "'studio-video-preview-close'",
+        "'studio-video-copy-link'",
+        "@error",
+        "studio.video.retry"
+      ],
+      "rationale": "Shared Teleport lightbox UI for Studio video playback. VideoStudio and BakeOff mount this instead of duplicating inline video + error/retry/download affordances."
+    },
+    {
+      "path": "frontend/src/utils/studioPlaybackStorage.tk.ts",
+      "must_contain": [
+        "export async function tagStudioVideoPlayback"
+      ],
+      "rationale": "Shared playback-storage tagging after video task url arrives — used by VideoStudio and BakeOff instead of duplicating CORS probe + IndexedDB mirror wiring."
     },
     {
       "path": "frontend/src/constants/mediaTiers.tk.ts",


### PR DESCRIPTION
## 摘要

- 新增 `useStudioVideoPreview` + `StudioVideoPreviewLightbox`，VideoStudio / BakeOff 共用 lightbox 状态机（打开/关闭、Blob 回收、播放失败→urlExpired 且 lightbox 保持打开、重试、复制 rawUrl、过期下载拦截）
- 新增 `useStudioVideoCardActions` + `copyMediaLink()`，卡片级「复制链接 / 下载」两页共用，替代 BakeOff / VideoStudio 内联实现
- 新增 `tagStudioVideoPlayback()` 统一 CORS 探测 + IndexedDB 镜像；吸收 #1093 的 BakeOff 上游直链 copy-link / 过期下载 toast 行为，**#1093 关闭**
- 更新 `frontend-tk.json` sentinel（含 `useStudioVideoCardActions`、`bakeoff-video-copy-card-link`）

## 风险

- 常规风险：纯前端 refactor + 行为对齐；不改变网关/API 契约
- 播放失败时 lightbox 不再自动关闭（改为 expired 态 + copy-link 兜底），与 #1093 意图一致
- sentinel + vitest 覆盖 copy-link、过期下载、error 路径

## 验证

```bash
cd frontend && pnpm exec vitest run \
  src/composables/__tests__/useStudioVideoPreview.spec.ts \
  src/composables/__tests__/useStudioVideoCardActions.spec.ts \
  src/views/user/studio/components/__tests__/StudioVideoPreviewLightbox.spec.ts \
  src/views/user/studio/__tests__/VideoStudio.spec.ts \
  src/views/user/studio/__tests__/BakeOff.spec.ts \
  src/utils/__tests__/studioDownload.tk.spec.ts \
  src/utils/__tests__/studioPlaybackStorage.tk.spec.ts

pnpm run build
./scripts/preflight.sh
```

## 提交

- bdb856155 refactor(studio): 抽取共享视频预览 lightbox 与 playback 标记
- abd78bb3d feat(studio): SSOT video preview copy-link and expired playback guard
- 最新提交：abd78bb3d
