### PR TITLE
fix(studio): BakeOff 上游直链补复制链接与预览失败兜底

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 529,
-  "hash": "78c34998667c806db17e83bd5440ecdcae58d1899f224757292f87e0498d5bd3",
+  "hash": "7f4f38e20d7e782d3ae88c8a7db10c765861713253aa4637e7de3c5b6377751b",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/utils/__tests__/studioDownload.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioDownload.tk.spec.ts
@@ -56,3 +56,19 @@ describe('downloadMedia', () => {
     expect(openSpy).toHaveBeenCalledWith('https://cdn.example.com/v.mp4', '_blank')
   })
 })
+
+describe('copyMediaLink', () => {
+  it('returns false for empty url', async () => {
+    const { copyMediaLink } = await import('@/utils/studioDownload.tk')
+    await expect(copyMediaLink('')).resolves.toBe(false)
+  })
+
+  it('writes upstream url to clipboard', async () => {
+    const writeText = vi.fn(async () => undefined)
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+    const { copyMediaLink } = await import('@/utils/studioDownload.tk')
+    await expect(copyMediaLink('https://cdn.example/v.mp4')).resolves.toBe(true)
+    expect(writeText).toHaveBeenCalledWith('https://cdn.example/v.mp4')
+    vi.unstubAllGlobals()
+  })
+})

--- a/frontend/src/utils/studioDownload.tk.ts
+++ b/frontend/src/utils/studioDownload.tk.ts
@@ -26,3 +26,14 @@ export function downloadMedia(url: string, filename: string): void {
     window.open(url, '_blank')
   }
 }
+
+/** Best-effort clipboard copy of an upstream / inline media URL. */
+export async function copyMediaLink(url: string): Promise<boolean> {
+  if (!url) return false
+  try {
+    await navigator.clipboard?.writeText(url)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -174,9 +174,12 @@
         <div class="mt-2 flex flex-wrap items-center justify-between gap-2 text-sm">
           <div class="flex flex-wrap items-center gap-2">
             <span class="font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(p.cost) }}</span>
-            <StudioPlaybackBadge v-if="modality === 'video' && bakePanelVideoPlayable(p)" :task="panelPlaybackTask(p)!" />
+            <StudioPlaybackBadge
+              v-if="modality === 'video' && p.state === 'succeeded' && panelPlaybackTask(p)"
+              :task="panelPlaybackTask(p)!"
+            />
           </div>
-          <div class="flex items-center gap-2">
+          <div class="flex flex-wrap items-center gap-2">
             <button
               v-if="modality === 'image' && p.src"
               type="button"
@@ -185,15 +188,24 @@
             >
               {{ t('studio.image.download') }}
             </button>
-            <button
-              v-else-if="modality === 'video' && p.state === 'succeeded' && p.url"
-              type="button"
-              class="text-[11px] font-medium text-primary-600 dark:text-primary-300"
-              data-testid="bakeoff-video-download"
-              @click="downloadMedia(p.url!, `tokenkey-${p.taskId || p.modelId}.mp4`)"
-            >
-              {{ t('studio.video.download') }}
-            </button>
+            <template v-else-if="modality === 'video' && p.state === 'succeeded' && p.url">
+              <button
+                type="button"
+                class="text-[11px] font-medium text-primary-600 dark:text-primary-300"
+                data-testid="bakeoff-video-download"
+                @click="downloadPanelVideo(p)"
+              >
+                {{ t('studio.video.download') }}
+              </button>
+              <button
+                type="button"
+                class="text-[11px] font-medium text-gray-500 dark:text-dark-300"
+                data-testid="bakeoff-video-copy-card-link"
+                @click="copyPanelLink(p.url!)"
+              >
+                {{ copiedPanelUrl === p.url ? t('studio.video.copied') : t('studio.video.copyLink') }}
+              </button>
+            </template>
             <span v-if="p.elapsedS != null && p.state !== 'idle'" class="text-xs text-gray-500 dark:text-dark-400">⏱ {{ p.elapsedS }}s</span>
           </div>
         </div>
@@ -275,17 +287,27 @@
               </div>
               <StudioVideoUnavailable v-else :prompt="task.prompt" :task="task" />
               <div class="mt-1 flex items-center justify-between gap-2">
-                <StudioPlaybackBadge v-if="videoTaskPlaybackAvailable(task)" :task="task" />
+                <StudioPlaybackBadge v-if="task.state === 'succeeded'" :task="task" />
                 <span class="ml-auto text-xs font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(task.estCost) }}</span>
               </div>
-              <button
-                v-if="task.state === 'succeeded' && task.url"
-                type="button"
-                class="text-[10px] font-medium text-primary-600 dark:text-primary-300"
-                @click="downloadMedia(task.url, `tokenkey-${task.id}.mp4`)"
-              >
-                {{ t('studio.video.download') }}
-              </button>
+              <div v-if="task.state === 'succeeded' && task.url" class="mt-1 flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  class="text-[10px] font-medium text-primary-600 dark:text-primary-300"
+                  data-testid="bakeoff-history-video-download"
+                  @click="downloadHistoryVideo(task)"
+                >
+                  {{ t('studio.video.download') }}
+                </button>
+                <button
+                  type="button"
+                  class="text-[10px] font-medium text-gray-500 dark:text-dark-300"
+                  data-testid="bakeoff-history-video-copy-link"
+                  @click="copyPanelLink(task.url)"
+                >
+                  {{ copiedPanelUrl === task.url ? t('studio.video.copied') : t('studio.video.copyLink') }}
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -324,16 +346,40 @@
           <div v-else class="max-w-sm rounded-xl bg-white/10 p-6 text-center">
             <p class="text-sm font-semibold text-white">{{ t('studio.video.expiredTitle') }}</p>
             <p class="mt-1 text-xs text-white/70">{{ t('studio.video.expiredHint') }}</p>
-            <div class="mt-3 flex items-center justify-center gap-2">
+            <div class="mt-3 flex flex-wrap items-center justify-center gap-2">
               <button type="button" class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100" @click="retryVideoPreview">{{ t('studio.video.retry') }}</button>
+              <button
+                v-if="videoPreviewRawUrl"
+                type="button"
+                class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white"
+                data-testid="bakeoff-video-copy-link"
+                @click="copyVideoPreviewLink"
+              >
+                {{ copiedPreviewLink ? t('studio.video.copied') : t('studio.video.copyLink') }}
+              </button>
             </div>
           </div>
         </div>
         <div class="flex flex-wrap items-center justify-center gap-3 p-4">
           <span class="max-w-[60vw] truncate text-xs text-white/80" :title="videoPreviewLabel">{{ videoPreviewLabel }}</span>
           <span v-if="videoPreviewCost != null" class="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[11px] font-semibold text-white">{{ formatUsd(videoPreviewCost) }}</span>
-          <button v-if="videoPreviewDownloadUrl" type="button" class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100" @click="downloadMedia(videoPreviewDownloadUrl, `tokenkey-bakeoff-preview.mp4`)">{{ t('studio.video.download') }}</button>
-          <button v-if="videoPreviewState === 'ready' && videoPreviewUrl" type="button" class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white" data-testid="bakeoff-video-copy-link" @click="copyVideoPreviewLink">{{ copiedPreviewLink ? t('studio.video.copied') : t('studio.video.copyLink') }}</button>
+          <button
+            v-if="videoPreviewDownloadUrl"
+            type="button"
+            class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100"
+            @click="downloadPreviewVideo"
+          >
+            {{ t('studio.video.download') }}
+          </button>
+          <button
+            v-if="videoPreviewRawUrl"
+            type="button"
+            class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white"
+            data-testid="bakeoff-video-copy-link"
+            @click="copyVideoPreviewLink"
+          >
+            {{ copiedPreviewLink ? t('studio.video.copied') : t('studio.video.copyLink') }}
+          </button>
         </div>
       </div>
     </Teleport>
@@ -369,7 +415,7 @@ import {
   videoPlaybackUrl,
   videoTaskPlaybackAvailable,
 } from '@/utils/studioMedia.tk'
-import { downloadMedia } from '@/utils/studioDownload.tk'
+import { copyMediaLink, downloadMedia } from '@/utils/studioDownload.tk'
 import { resolveVideoPlaybackStorage } from '@/utils/studioPlaybackStorage.tk'
 import StudioLocalSaveBanner from '@/views/user/studio/components/StudioLocalSaveBanner.vue'
 import StudioImageExpired from '@/views/user/studio/components/StudioImageExpired.vue'
@@ -571,7 +617,11 @@ function openVideoHistoryPreview(task: VideoTaskItem): void {
 
 function onVideoPreviewError(): void {
   const taskId = videoPreviewTaskId.value
-  closeVideoPreview()
+  videoPreviewRevoke()
+  videoPreviewRevoke = () => {}
+  videoPreviewUrl.value = ''
+  videoPreviewState.value = 'expired'
+  videoPreviewMediaReady.value = false
   if (taskId) patchVideoTask(taskId, { urlExpired: true })
 }
 
@@ -586,15 +636,57 @@ function retryVideoPreview(): void {
 }
 
 async function copyVideoPreviewLink(): Promise<void> {
-  if (!videoPreviewUrl.value) return
-  try {
-    await navigator.clipboard?.writeText(videoPreviewUrl.value)
+  const url = videoPreviewRawUrl.value
+  if (!url) return
+  if (await copyMediaLink(url)) {
     copiedPreviewLink.value = true
     if (copiedPreviewTimer) clearTimeout(copiedPreviewTimer)
     copiedPreviewTimer = setTimeout(() => (copiedPreviewLink.value = false), 1500)
-  } catch {
-    /* clipboard unavailable — Download still works */
   }
+}
+
+const copiedPanelUrl = ref('')
+let copiedPanelTimer: ReturnType<typeof setTimeout> | undefined
+
+async function copyPanelLink(url: string): Promise<void> {
+  if (!url) return
+  if (await copyMediaLink(url)) {
+    copiedPanelUrl.value = url
+    if (copiedPanelTimer) clearTimeout(copiedPanelTimer)
+    copiedPanelTimer = setTimeout(() => (copiedPanelUrl.value = ''), 1500)
+  }
+}
+
+function downloadPanelVideo(panel: BakePanel): void {
+  if (!panel.url) return
+  if (panel.urlExpired) {
+    appStore.showWarning(t('studio.video.expiredHint'), 8000)
+    return
+  }
+  downloadMedia(panel.url, `tokenkey-${panel.taskId || panel.modelId}.mp4`)
+}
+
+function downloadHistoryVideo(task: VideoTaskItem): void {
+  if (!task.url) return
+  if (task.urlExpired) {
+    appStore.showWarning(t('studio.video.expiredHint'), 8000)
+    return
+  }
+  downloadMedia(task.url, `tokenkey-${task.id}.mp4`)
+}
+
+function downloadPreviewVideo(): void {
+  const url = videoPreviewDownloadUrl.value
+  if (!url) return
+  const panel = panels.value.find((p) => p.taskId === videoPreviewTaskId.value)
+  const task = videoPreviewTaskId.value
+    ? library.videoTasks.value.find((row) => row.id === videoPreviewTaskId.value)
+    : undefined
+  if (panel?.urlExpired || task?.urlExpired) {
+    appStore.showWarning(t('studio.video.expiredHint'), 8000)
+    return
+  }
+  downloadMedia(url, `tokenkey-${videoPreviewTaskId.value || 'bakeoff-preview'}.mp4`)
 }
 
 function closeVideoPreview(): void {

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -19,8 +19,12 @@ const libraryMock = vi.hoisted(() => ({
   cacheInlineMedia: vi.fn(async () => undefined),
 }))
 
+const appStoreMock = vi.hoisted(() => ({
+  showWarning: vi.fn(),
+}))
+
 vi.mock('@/stores/app', () => ({
-  useAppStore: () => ({ showWarning: vi.fn() }),
+  useAppStore: () => appStoreMock,
 }))
 
 vi.mock('@/api/playground', () => ({
@@ -279,7 +283,7 @@ describe('BakeOff image routing', () => {
     )
   })
 
-  it('closes the panel lightbox and marks the task expired when preview media fails', async () => {
+  it('keeps the lightbox open with copy-link fallback when preview media fails', async () => {
     vi.mocked(playground.gatewayVideoSubmit)
       .mockResolvedValueOnce({ id: 'vt_panel_a', status: 'succeeded', url: 'https://cdn.example/a.mp4' })
       .mockResolvedValueOnce({ id: 'vt_panel_b', status: 'succeeded', url: 'https://cdn.example/b.mp4' })
@@ -303,12 +307,70 @@ describe('BakeOff image routing', () => {
     await wrapper.find('[data-testid="bakeoff-video-preview"] video').trigger('error')
     await flushPromises()
 
-    expect(wrapper.find('[data-testid="bakeoff-video-preview"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="bakeoff-video-preview"]').exists()).toBe(true)
+    expect(wrapper.findAll('[data-testid="bakeoff-video-copy-link"]').length).toBeGreaterThan(0)
     expect(libraryMock.patchVideoTask).toHaveBeenCalledWith('vt_panel_a', { urlExpired: true })
     expect(panelEls[0].find('[data-testid="bakeoff-video-play"]').exists()).toBe(false)
     expect(panelEls[0].find('[data-testid="bakeoff-video-expired"]').exists()).toBe(true)
     expect(panelEls[0].find('[data-testid="bakeoff-video-download"]').exists()).toBe(true)
+    expect(panelEls[0].find('[data-testid="bakeoff-video-copy-card-link"]').exists()).toBe(true)
     expect(panelEls[1].find('[data-testid="bakeoff-video-play"]').exists()).toBe(true)
+  })
+
+  it('exposes card-level copy-link for succeeded video panels', async () => {
+    vi.mocked(playground.gatewayVideoSubmit)
+      .mockResolvedValueOnce({ id: 'vt_panel_a', status: 'succeeded', url: 'https://cdn.example/a.mp4' })
+      .mockResolvedValueOnce({ id: 'vt_panel_b', status: 'succeeded', url: 'https://cdn.example/b.mp4' })
+
+    const writeText = vi.fn(async () => undefined)
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+
+    const wrapper = mount(BakeOff, {
+      props: videoProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true, teleport: true } },
+    })
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    await tiers[0].trigger('click')
+    await tiers[1].trigger('click')
+    await wrapper.get('textarea').setValue('family in a garden')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    await wrapper.findAll('[data-testid="bakeoff-panel"]')[0].get('[data-testid="bakeoff-video-copy-card-link"]').trigger('click')
+    await flushPromises()
+    expect(writeText).toHaveBeenCalledWith('https://cdn.example/a.mp4')
+    vi.unstubAllGlobals()
+  })
+
+  it('warns instead of opening a new tab when downloading an expired panel url', async () => {
+    vi.mocked(playground.gatewayVideoSubmit)
+      .mockResolvedValueOnce({ id: 'vt_panel_a', status: 'succeeded', url: 'https://cdn.example/a.mp4' })
+      .mockResolvedValueOnce({ id: 'vt_panel_b', status: 'succeeded', url: 'https://cdn.example/b.mp4' })
+    const downloadSpy = vi.spyOn(await import('@/utils/studioDownload.tk'), 'downloadMedia')
+
+    const wrapper = mount(BakeOff, {
+      props: videoProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true, teleport: true } },
+    })
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    await tiers[0].trigger('click')
+    await tiers[1].trigger('click')
+    await wrapper.get('textarea').setValue('family in a garden')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    const panelEls = wrapper.findAll('[data-testid="bakeoff-panel"]')
+    await panelEls[0].get('[data-testid="bakeoff-video-play"]').trigger('click')
+    await flushPromises()
+    await wrapper.find('[data-testid="bakeoff-video-preview"] video').trigger('error')
+    await flushPromises()
+
+    appStoreMock.showWarning.mockClear()
+    downloadSpy.mockClear()
+    await panelEls[0].get('[data-testid="bakeoff-video-download"]').trigger('click')
+    expect(appStoreMock.showWarning).toHaveBeenCalled()
+    expect(downloadSpy).not.toHaveBeenCalled()
+    downloadSpy.mockRestore()
   })
 
   it('converts inline data:video panel urls to blob playback in the lightbox', async () => {

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -105,6 +105,8 @@
         "data-testid=\"bakeoff-tier\"",
         "data-testid=\"studio-bakeoff-run\"",
         "data-testid=\"bakeoff-panel\"",
+        "data-testid=\"bakeoff-video-copy-card-link\"",
+        "data-testid=\"bakeoff-video-copy-link\"",
         "useMediaLibrary",
         "StudioLocalSaveBanner",
         "test-id=\"studio-bakeoff-save-reminder\"",


### PR DESCRIPTION
## 摘要

- BakeOff 视频卡片/历史区补齐「复制链接」，与 VideoStudio 三件套（播放 / 下载 / 复制）对齐
- 预览 `@error` 时 lightbox 不再秒关，留在页内展示重试 + 复制上游直链
- `urlExpired` 时点击下载改为 warning，避免跨域直链打开空白 tab

## 风险

- 常规风险：纯前端 UX；不改变网关/API 契约
- 与 #1092 SSOT refactor 独立，合并后需在 composable 侧同步相同行为

## 验证

```bash
cd frontend && pnpm exec vitest run \
  src/views/user/studio/__tests__/BakeOff.spec.ts \
  src/utils/__tests__/studioDownload.tk.spec.ts
# 18 passed

pnpm run build
./scripts/preflight.sh
```

## 提交

- b06adce6f fix(studio): BakeOff 上游直链补卡片复制链接与预览失败兜底
- 最新提交：b06adce6f
