### PR TITLE
fix(studio): 统一 Image/Video 预览与重载 SSOT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,24 @@ section only records sub2api-specific choices.
   The "submodule first" order is enforced by preflight § 2 (warns on offline,
   fails if SHA missing locally) and by `dev-rules/rules/dev-rules-convention.mdc`.
 
+## Studio SSOT（`/studio` Image / Video / BakeOff）
+
+`/studio` 三页（`ImageStudio` / `VideoStudio` / `BakeOff`）共享的历史、预览、下载、重载行为**禁止**在页面内各写一套。Owner 如下（#1092 视频 SSOT + 图片 SSOT 扩展）：
+
+| 意图 | Owner | 消费方 |
+| --- | --- | --- |
+| 媒体历史持久化（localStorage 元数据 + IndexedDB 镜像） | `composables/useMediaLibrary.ts` + `utils/studioBlobCache.tk.ts` | Image / Video / BakeOff |
+| 图片历史 mount（IDB hydrate → s3Key presign → thumb error 回退） | `composables/useStudioImageLibrary.ts` | ImageStudio, BakeOff |
+| 视频历史 mount（IDB hydrate → replay error 回退） | `composables/useStudioVideoLibrary.ts` | VideoStudio, BakeOff |
+| 图片 lightbox 状态 | `composables/useStudioImagePreview.ts` + `components/StudioImagePreviewLightbox.vue` | ImageStudio |
+| 图片 history id / ephemeral src / revised_prompt tooltip | `utils/studioImageHistory.tk.ts` | useMediaLibrary, ImageStudio, BakeOff |
+| 视频 lightbox 状态 + 过期播放守卫 | `composables/useStudioVideoPreview.ts` + `components/StudioVideoPreviewLightbox.vue` | VideoStudio, BakeOff |
+| 视频卡片 copy-link / 下载 | `composables/useStudioVideoCardActions.ts` + `utils/studioDownload.tk.ts` | VideoStudio, BakeOff |
+| 视频 playback 分类 + IDB 镜像 | `utils/studioPlaybackStorage.tk.ts` (`tagStudioVideoPlayback`) | VideoStudio, BakeOff |
+| 视频 tab-local Blob 播放 | `utils/studioMedia.tk.ts` (`videoPlaybackUrl`) | lightbox + BakeOff 面板 |
+
+新增 Studio 行为时：先查上表能否扩展 owner；若 Image **与** Video **与** BakeOff 任两者都需要，必须进共享 composable/组件并在 `scripts/sentinels/frontend-tk.json` 加锚点。宪法原则见 `dev-rules/global/CLAUDE.md` §5.1。
+
 ## Agent skills（Cursor / Claude Code）
 
 技能正文只在 [.cursor/skills/](.cursor/skills/) 下各目录的 `SKILL.md`。仓库根的 `.claude/skills` **仅为**指向 `.cursor/skills` 的 symlink（不要在 `.claude/skills/` 下创建真实文件或副本）。全局禁令见 **`dev-rules/global/CLAUDE.md`** §4「Agent Skills」。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,7 +344,7 @@ section only records sub2api-specific choices.
 | --- | --- | --- |
 | 媒体历史持久化（localStorage 元数据 + IndexedDB 镜像） | `composables/useMediaLibrary.ts` + `utils/studioBlobCache.tk.ts` | Image / Video / BakeOff |
 | 图片历史 mount（IDB hydrate → s3Key presign → thumb error 回退） | `composables/useStudioImageLibrary.ts` | ImageStudio, BakeOff |
-| 视频历史 mount（IDB hydrate → replay error 回退） | `composables/useStudioVideoLibrary.ts` | VideoStudio, BakeOff |
+| 视频历史 mount（IDB hydrate） | `composables/useStudioVideoLibrary.ts` | VideoStudio, BakeOff |
 | 图片 lightbox 状态 | `composables/useStudioImagePreview.ts` + `components/StudioImagePreviewLightbox.vue` | ImageStudio |
 | 图片 history id / ephemeral src / revised_prompt tooltip | `utils/studioImageHistory.tk.ts` | useMediaLibrary, ImageStudio, BakeOff |
 | 视频 lightbox 状态 + 过期播放守卫 | `composables/useStudioVideoPreview.ts` + `components/StudioVideoPreviewLightbox.vue` | VideoStudio, BakeOff |

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 537,
-  "hash": "e7646136fae4d986bb2ca177b14c297d2a21eea9aafe3054ea4c1bbbe1b91a16",
+  "file_count": 539,
+  "hash": "9c7cf411194aed85812d753e78f5cdf7b0c08ad1bc6355a9a33efee6329b0955",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 539,
-  "hash": "9c7cf411194aed85812d753e78f5cdf7b0c08ad1bc6355a9a33efee6329b0955",
+  "hash": "0ce7c77aa4f98088bb234a9effc8701b63a1e81cf9533801c002ababc03426a0",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 532,
-  "hash": "698e17c1c5ef61d2bd235ec80010caf2518c222f805e61027244b1a4e56d302f",
+  "file_count": 537,
+  "hash": "e7646136fae4d986bb2ca177b14c297d2a21eea9aafe3054ea4c1bbbe1b91a16",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/composables/__tests__/useMediaLibrary.spec.ts
+++ b/frontend/src/composables/__tests__/useMediaLibrary.spec.ts
@@ -4,9 +4,12 @@ import { useMediaLibrary, type ImageHistoryItem, type VideoTaskItem } from '../u
 
 vi.mock('@/utils/studioBlobCache.tk', () => ({
   cacheStudioBlobFromSrc: vi.fn(async () => true),
-  getStudioBlobObjectUrl: vi.fn(async (_u: string | number, kind: string, id: string) =>
-    kind === 'image' && id === 'img-reload' ? 'blob:cached-image' : ''
-  ),
+  cacheStudioBlobFromHttpUrl: vi.fn(async () => true),
+  getStudioBlobObjectUrl: vi.fn(async (_u: string | number, kind: string, id: string) => {
+    if (kind === 'image' && id === 'img-reload') return 'blob:cached-image'
+    if (kind === 'video' && id === 'vt-reload') return 'blob:cached-video'
+    return ''
+  }),
   deleteStudioBlob: vi.fn(async () => undefined),
   pruneStudioBlobCache: vi.fn(async () => undefined),
 }))
@@ -76,6 +79,38 @@ describe('useMediaLibrary video persistence', () => {
     expect(lib.videoTasks.value[0].urlExpired).toBe(true)
     expect(lib.videoTasks.value[0].prompt).toBe('neon alley rain')
   })
+
+  it('hydrates blank video url from IndexedDB after reload', async () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        images: [],
+        videoTasks: [
+          {
+            ...videoTask(''),
+            id: 'vt-reload',
+            url: '',
+            urlExpired: true,
+            blobCached: true,
+          },
+        ],
+      })
+    )
+    const lib = useMediaLibrary(USER_ID)
+    expect(lib.videoTasks.value[0].url).toBe('')
+    await lib.hydrateFromBlobCache()
+    expect(lib.videoTasks.value[0].url).toBe('blob:cached-video')
+    expect(lib.videoTasks.value[0].urlExpired).toBe(false)
+  })
+
+  it('rehydrateVideoFromBlob restores playback url from IndexedDB', async () => {
+    const lib = useMediaLibrary(USER_ID)
+    lib.upsertVideoTask({ ...videoTask(''), id: 'vt-reload', url: '', urlExpired: true })
+    const ok = await lib.rehydrateVideoFromBlob('vt-reload')
+    expect(ok).toBe(true)
+    expect(lib.videoTasks.value[0].url).toBe('blob:cached-video')
+    expect(lib.videoTasks.value[0].urlExpired).toBe(false)
+  })
 })
 
 describe('useMediaLibrary image persistence', () => {
@@ -94,7 +129,7 @@ describe('useMediaLibrary image persistence', () => {
     expect(persisted.images[0].prompt).toBe('a cat')
   })
 
-  it('preserves offloaded (s3Key) and http image URLs in localStorage', async () => {
+  it('strips http and s3Key presigned src from localStorage (reload via IDB/presign)', async () => {
     const lib = useMediaLibrary(USER_ID)
     lib.addImages([
       imageItem('img-http', 'https://cdn.example/a.png'),
@@ -103,9 +138,42 @@ describe('useMediaLibrary image persistence', () => {
 
     await nextTick()
     const persisted = JSON.parse(window.localStorage.getItem(KEY) || '{}')
-    const byId = Object.fromEntries(persisted.images.map((i: ImageHistoryItem) => [i.id, i.src]))
-    expect(byId['img-http']).toBe('https://cdn.example/a.png')
-    expect(byId['img-offloaded']).toBe('https://s3.example/presigned')
+    const byId = Object.fromEntries(persisted.images.map((i: ImageHistoryItem) => [i.id, i]))
+    expect(byId['img-http'].src).toBe('')
+    expect(byId['img-offloaded'].src).toBe('')
+    expect(byId['img-offloaded'].s3Key).toBe('media/images/abc.png')
+  })
+
+  it('does not persist blob: src after IndexedDB hydration (second reload safe)', async () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        images: [{ ...imageItem('img-reload', 'blob:http://localhost/dead'), blobCached: true }],
+        videoTasks: [],
+      })
+    )
+    const lib = useMediaLibrary(USER_ID)
+    expect(lib.images.value[0].src).toBe('')
+    await lib.hydrateFromBlobCache()
+    expect(lib.images.value[0].src).toBe('blob:cached-image')
+
+    await nextTick()
+    const persisted = JSON.parse(window.localStorage.getItem(KEY) || '{}')
+    expect(persisted.images[0].src).toBe('')
+  })
+
+  it('hydrates legacy persisted http image src from the blob cache after reload', async () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        images: [{ ...imageItem('img-reload', 'https://cdn.example/stale.png'), prompt: 'reload me' }],
+        videoTasks: [],
+      })
+    )
+    const lib = useMediaLibrary(USER_ID)
+    expect(lib.images.value[0].src).toBe('')
+    await lib.hydrateFromBlobCache()
+    expect(lib.images.value[0].src).toBe('blob:cached-image')
   })
 
   it('hydrates blank inline image src from the blob cache after reload', async () => {

--- a/frontend/src/composables/__tests__/useMediaLibrary.spec.ts
+++ b/frontend/src/composables/__tests__/useMediaLibrary.spec.ts
@@ -103,14 +103,6 @@ describe('useMediaLibrary video persistence', () => {
     expect(lib.videoTasks.value[0].urlExpired).toBe(false)
   })
 
-  it('rehydrateVideoFromBlob restores playback url from IndexedDB', async () => {
-    const lib = useMediaLibrary(USER_ID)
-    lib.upsertVideoTask({ ...videoTask(''), id: 'vt-reload', url: '', urlExpired: true })
-    const ok = await lib.rehydrateVideoFromBlob('vt-reload')
-    expect(ok).toBe(true)
-    expect(lib.videoTasks.value[0].url).toBe('blob:cached-video')
-    expect(lib.videoTasks.value[0].urlExpired).toBe(false)
-  })
 })
 
 describe('useMediaLibrary image persistence', () => {

--- a/frontend/src/composables/__tests__/useStudioImageLibrary.spec.ts
+++ b/frontend/src/composables/__tests__/useStudioImageLibrary.spec.ts
@@ -1,0 +1,62 @@
+import { ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  mountStudioImageLibrary,
+  onStudioImageThumbError,
+  refreshStudioOffloadedImageUrls,
+} from '../useStudioImageLibrary'
+import type { ImageHistoryItem } from '../useMediaLibrary'
+
+vi.mock('@/api/playground', () => ({
+  gatewayImagePresign: vi.fn(async (_key: string, _base: string, s3Key: string) =>
+    s3Key ? `https://fresh.example/${s3Key}` : ''
+  ),
+}))
+
+function imageRow(id: string, s3Key?: string): ImageHistoryItem {
+  return {
+    id,
+    src: '',
+    s3Key,
+    prompt: 'cat',
+    model: 'imagen-4',
+    vendorLabel: 'Vertex',
+    size: '1:1',
+    cost: 0.04,
+    ts: 1,
+  }
+}
+
+describe('useStudioImageLibrary', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('refreshStudioOffloadedImageUrls re-presigns s3Key rows', async () => {
+    const rows = ref([imageRow('a', 'media/a.png')])
+    await refreshStudioOffloadedImageUrls('key', 'https://gw', rows)
+    expect(rows.value[0].src).toBe('https://fresh.example/media/a.png')
+  })
+
+  it('mountStudioImageLibrary hydrates then presigns', async () => {
+    const images = ref([imageRow('b', 'media/b.png')])
+    const hydrate = vi.fn(async () => {
+      images.value[0].src = 'blob:cached'
+    })
+    const library = {
+      images,
+      hydrateFromBlobCache: hydrate,
+      rehydrateImageFromBlob: vi.fn(async () => true),
+    }
+    await mountStudioImageLibrary('key', 'https://gw', library)
+    expect(hydrate).toHaveBeenCalled()
+    expect(images.value[0].src).toBe('https://fresh.example/media/b.png')
+  })
+
+  it('onStudioImageThumbError delegates to rehydrateImageFromBlob', async () => {
+    const rehydrate = vi.fn(async () => true)
+    await onStudioImageThumbError(
+      { images: ref([]), hydrateFromBlobCache: vi.fn(), rehydrateImageFromBlob: rehydrate },
+      'id-1'
+    )
+    expect(rehydrate).toHaveBeenCalledWith('id-1')
+  })
+})

--- a/frontend/src/composables/__tests__/useStudioImagePreview.spec.ts
+++ b/frontend/src/composables/__tests__/useStudioImagePreview.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { useStudioImagePreview } from '../useStudioImagePreview'
+import type { ImageHistoryItem } from '../useMediaLibrary'
+
+function row(src: string): ImageHistoryItem {
+  return {
+    id: '1',
+    src,
+    prompt: 'p',
+    model: 'imagen-4',
+    vendorLabel: 'Vertex',
+    size: '1:1',
+    cost: 0.04,
+    ts: 1,
+  }
+}
+
+describe('useStudioImagePreview', () => {
+  it('opens only when src is available', () => {
+    const { preview, openPreview, closePreview } = useStudioImagePreview()
+    openPreview(row(''))
+    expect(preview.value).toBeNull()
+    openPreview(row('data:image/png;base64,AA=='))
+    expect(preview.value?.src).toContain('data:image')
+    closePreview()
+    expect(preview.value).toBeNull()
+  })
+})

--- a/frontend/src/composables/__tests__/useStudioVideoLibrary.spec.ts
+++ b/frontend/src/composables/__tests__/useStudioVideoLibrary.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { mountStudioVideoLibrary, onStudioVideoReplayError } from '../useStudioVideoLibrary'
+import { mountStudioVideoLibrary } from '../useStudioVideoLibrary'
 
 describe('useStudioVideoLibrary', () => {
   beforeEach(() => vi.clearAllMocks())
@@ -8,17 +8,7 @@ describe('useStudioVideoLibrary', () => {
     const hydrate = vi.fn(async () => undefined)
     await mountStudioVideoLibrary({
       hydrateFromBlobCache: hydrate,
-      rehydrateVideoFromBlob: vi.fn(async () => true),
     })
     expect(hydrate).toHaveBeenCalled()
-  })
-
-  it('onStudioVideoReplayError delegates to rehydrateVideoFromBlob', async () => {
-    const rehydrate = vi.fn(async () => true)
-    await onStudioVideoReplayError(
-      { hydrateFromBlobCache: vi.fn(), rehydrateVideoFromBlob: rehydrate },
-      'vt-1'
-    )
-    expect(rehydrate).toHaveBeenCalledWith('vt-1')
   })
 })

--- a/frontend/src/composables/__tests__/useStudioVideoLibrary.spec.ts
+++ b/frontend/src/composables/__tests__/useStudioVideoLibrary.spec.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mountStudioVideoLibrary, onStudioVideoReplayError } from '../useStudioVideoLibrary'
+
+describe('useStudioVideoLibrary', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('mountStudioVideoLibrary hydrates mirrored clips from IndexedDB', async () => {
+    const hydrate = vi.fn(async () => undefined)
+    await mountStudioVideoLibrary({
+      hydrateFromBlobCache: hydrate,
+      rehydrateVideoFromBlob: vi.fn(async () => true),
+    })
+    expect(hydrate).toHaveBeenCalled()
+  })
+
+  it('onStudioVideoReplayError delegates to rehydrateVideoFromBlob', async () => {
+    const rehydrate = vi.fn(async () => true)
+    await onStudioVideoReplayError(
+      { hydrateFromBlobCache: vi.fn(), rehydrateVideoFromBlob: rehydrate },
+      'vt-1'
+    )
+    expect(rehydrate).toHaveBeenCalledWith('vt-1')
+  })
+})

--- a/frontend/src/composables/__tests__/useStudioVideoPreview.spec.ts
+++ b/frontend/src/composables/__tests__/useStudioVideoPreview.spec.ts
@@ -30,9 +30,8 @@ describe('useStudioVideoPreview', () => {
     expect(preview.previewState.value).toBe('ready')
   })
 
-  it('calls onUrlExpired with task id after preview error and keeps lightbox open', () => {
-    const onUrlExpired = vi.fn()
-    const preview = useStudioVideoPreview({ onUrlExpired })
+  it('marks lightbox expired after preview error without mutating library tasks', () => {
+    const preview = useStudioVideoPreview()
     preview.openPreview({
       url: 'https://cdn.example/clip.mp4',
       label: 'Seedance',
@@ -40,10 +39,10 @@ describe('useStudioVideoPreview', () => {
       taskId: 'vt_err',
     })
     preview.onPreviewError()
-    expect(onUrlExpired).toHaveBeenCalledWith('vt_err')
     expect(preview.open.value).toBe(true)
     expect(preview.previewState.value).toBe('expired')
     expect(preview.urlExpired.value).toBe(true)
+    expect(preview.rawUrl.value).toBe('https://cdn.example/clip.mp4')
   })
 
   it('copyPreviewLink writes raw upstream url even when playback uses blob', async () => {
@@ -61,7 +60,7 @@ describe('useStudioVideoPreview', () => {
     vi.unstubAllGlobals()
   })
 
-  it('downloadPreview invokes onExpiredDownload instead of downloading when url expired', () => {
+  it('downloadPreview still uses raw upstream url after lightbox playback fails', () => {
     const onExpiredDownload = vi.fn()
     const downloadSpy = vi.spyOn(studioDownload, 'downloadMedia')
     const preview = useStudioVideoPreview({ onExpiredDownload })
@@ -70,8 +69,18 @@ describe('useStudioVideoPreview', () => {
       label: 'Seedance',
       cost: 1,
       taskId: 'vt_err',
-      urlExpired: true,
     })
+    preview.onPreviewError()
+    preview.downloadPreview()
+    expect(downloadSpy).toHaveBeenCalledWith('https://cdn.example/clip.mp4', 'tokenkey-preview.mp4')
+    expect(onExpiredDownload).not.toHaveBeenCalled()
+    downloadSpy.mockRestore()
+  })
+
+  it('downloadPreview invokes onExpiredDownload when no raw url is available', () => {
+    const onExpiredDownload = vi.fn()
+    const downloadSpy = vi.spyOn(studioDownload, 'downloadMedia')
+    const preview = useStudioVideoPreview({ onExpiredDownload })
     preview.downloadPreview()
     expect(onExpiredDownload).toHaveBeenCalled()
     expect(downloadSpy).not.toHaveBeenCalled()

--- a/frontend/src/composables/useMediaLibrary.ts
+++ b/frontend/src/composables/useMediaLibrary.ts
@@ -189,8 +189,6 @@ export interface MediaLibrary {
   cacheInlineMedia: (kind: 'image' | 'video', itemId: string, src: string) => Promise<void>
   /** On <img> error: try IndexedDB mirror, else mark thumbnail unavailable. */
   rehydrateImageFromBlob: (id: string) => Promise<boolean>
-  /** On stale/empty video url: try IndexedDB mirror, else mark clip unavailable. */
-  rehydrateVideoFromBlob: (id: string) => Promise<boolean>
 }
 
 export function useMediaLibrary(userId: number | string): MediaLibrary {
@@ -333,21 +331,6 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
     return true
   }
 
-  async function rehydrateVideoFromBlob(id: string): Promise<boolean> {
-    const idx = videoTasks.value.findIndex((t) => t.id === id)
-    if (idx < 0) return false
-    const blobUrl = await getStudioBlobObjectUrl(userId, 'video', id)
-    const next = [...videoTasks.value]
-    if (!blobUrl) {
-      next[idx] = { ...next[idx], url: '', urlExpired: true }
-      videoTasks.value = next
-      return false
-    }
-    next[idx] = { ...next[idx], url: blobUrl, blobCached: true, urlExpired: false }
-    videoTasks.value = next
-    return true
-  }
-
   return {
     images,
     videoTasks,
@@ -360,6 +343,5 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
     hydrateFromBlobCache,
     cacheInlineMedia,
     rehydrateImageFromBlob,
-    rehydrateVideoFromBlob,
   }
 }

--- a/frontend/src/composables/useMediaLibrary.ts
+++ b/frontend/src/composables/useMediaLibrary.ts
@@ -26,6 +26,7 @@ import {
   pruneStudioBlobCache,
 } from '@/utils/studioBlobCache.tk'
 import type { StudioPlaybackStorage } from '@/utils/studioPlaybackStorage.tk'
+import { isEphemeralImageSrc } from '@/utils/studioImageHistory.tk'
 
 export type VideoTaskState = 'processing' | 'succeeded' | 'failed'
 
@@ -96,7 +97,9 @@ function loadPersisted(key: string): PersistShape {
     if (!raw) return { images: [], videoTasks: [] }
     const parsed = JSON.parse(raw) as Partial<PersistShape> | null
     return {
-      images: Array.isArray(parsed?.images) ? (parsed!.images as ImageHistoryItem[]) : [],
+      images: Array.isArray(parsed?.images)
+        ? (parsed!.images as ImageHistoryItem[]).map(normalizeLoadedImage)
+        : [],
       videoTasks: Array.isArray(parsed?.videoTasks)
         ? (parsed!.videoTasks as VideoTaskItem[]).map(sanitizeVideoTaskForPersistence)
         : [],
@@ -126,17 +129,22 @@ function sanitizeVideoTasksForPersistence(tasks: VideoTaskItem[]): VideoTaskItem
 }
 
 /**
- * Inline data: image bytes (gemini-native, or imagen/gpt-image once image S3
- * offload is off — the #944 pass-through default) must NOT be persisted: a multi-MB
- * base64 string per image blows the ~5-10MB localStorage budget and silently evicts
- * real history through the degradation loop below. Mirror the data:video sanitizer:
- * blank the src on the PERSISTED copy only — the in-memory images.value keeps the
- * full data: src so the current session's grid + lightbox still render browser-local.
- * Offloaded (s3Key) and http(s) images are tiny + re-mintable, so they persist as-is.
+ * Inline / blob / upstream http(s) thumbnails must NOT be persisted in localStorage:
+ * data: blows the quota; blob: URLs die on reload; presigned http links expire.
+ * Bytes (or s3Key for gateway offload) are the reload path — IndexedDB mirror and/or
+ * POST /v1/images/presign on Studio mount.
  */
 function sanitizeImageForPersistence(item: ImageHistoryItem): ImageHistoryItem {
-  if (item.s3Key || !/^data:/i.test(item.src)) return item
-  return { ...item, src: '' }
+  if (item.s3Key) return { ...item, src: '' }
+  if (isEphemeralImageSrc(item.src)) return { ...item, src: '' }
+  return item
+}
+
+/** Strip legacy persisted blob:/http src so reload always rehydrates from IDB / presign. */
+function normalizeLoadedImage(item: ImageHistoryItem): ImageHistoryItem {
+  if (item.s3Key) return { ...item, src: '' }
+  if (isEphemeralImageSrc(item.src)) return { ...item, src: '' }
+  return item
 }
 
 /**
@@ -179,6 +187,10 @@ export interface MediaLibrary {
   hydrateFromBlobCache: () => Promise<void>
   /** Best-effort mirror of inline media into IndexedDB (generation / poll terminal). */
   cacheInlineMedia: (kind: 'image' | 'video', itemId: string, src: string) => Promise<void>
+  /** On <img> error: try IndexedDB mirror, else mark thumbnail unavailable. */
+  rehydrateImageFromBlob: (id: string) => Promise<boolean>
+  /** On stale/empty video url: try IndexedDB mirror, else mark clip unavailable. */
+  rehydrateVideoFromBlob: (id: string) => Promise<boolean>
 }
 
 export function useMediaLibrary(userId: number | string): MediaLibrary {
@@ -222,7 +234,9 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
     if (!items.length) return
     images.value = [...items, ...images.value].slice(0, IMAGE_CAP)
     for (const it of items) {
-      if (it.src && /^data:/i.test(it.src)) void cacheInlineMedia('image', it.id, it.src)
+      if (it.src && (/^data:/i.test(it.src) || /^https?:\/\//i.test(it.src))) {
+        void cacheInlineMedia('image', it.id, it.src)
+      }
     }
   }
 
@@ -278,7 +292,10 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
     const nextImages = [...images.value]
     for (let i = 0; i < nextImages.length; i++) {
       const it = nextImages[i]
-      if (it.src || it.s3Key) continue
+      if (it.s3Key) continue
+      const needsBlob =
+        !it.src?.trim() || it.src.startsWith('blob:') || /^https?:\/\//i.test(it.src)
+      if (!needsBlob) continue
       const blobUrl = await getStudioBlobObjectUrl(userId, 'image', it.id)
       if (!blobUrl) continue
       nextImages[i] = { ...it, src: blobUrl, blobCached: true }
@@ -299,6 +316,38 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
     if (videosChanged) videoTasks.value = nextVideos
   }
 
+  async function rehydrateImageFromBlob(id: string): Promise<boolean> {
+    const idx = images.value.findIndex((it) => it.id === id)
+    if (idx < 0) return false
+    const it = images.value[idx]
+    if (it.s3Key) return false
+    const blobUrl = await getStudioBlobObjectUrl(userId, 'image', id)
+    const next = [...images.value]
+    if (!blobUrl) {
+      next[idx] = { ...next[idx], src: '' }
+      images.value = next
+      return false
+    }
+    next[idx] = { ...next[idx], src: blobUrl, blobCached: true }
+    images.value = next
+    return true
+  }
+
+  async function rehydrateVideoFromBlob(id: string): Promise<boolean> {
+    const idx = videoTasks.value.findIndex((t) => t.id === id)
+    if (idx < 0) return false
+    const blobUrl = await getStudioBlobObjectUrl(userId, 'video', id)
+    const next = [...videoTasks.value]
+    if (!blobUrl) {
+      next[idx] = { ...next[idx], url: '', urlExpired: true }
+      videoTasks.value = next
+      return false
+    }
+    next[idx] = { ...next[idx], url: blobUrl, blobCached: true, urlExpired: false }
+    videoTasks.value = next
+    return true
+  }
+
   return {
     images,
     videoTasks,
@@ -310,5 +359,7 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
     clearVideoTasks,
     hydrateFromBlobCache,
     cacheInlineMedia,
+    rehydrateImageFromBlob,
+    rehydrateVideoFromBlob,
   }
 }

--- a/frontend/src/composables/useStudioImageLibrary.ts
+++ b/frontend/src/composables/useStudioImageLibrary.ts
@@ -1,0 +1,51 @@
+import type { Ref } from 'vue'
+import { gatewayImagePresign } from '@/api/playground'
+import type { ImageHistoryItem, MediaLibrary } from '@/composables/useMediaLibrary'
+
+export type StudioImageLibrary = Pick<
+  MediaLibrary,
+  'images' | 'hydrateFromBlobCache' | 'rehydrateImageFromBlob'
+>
+
+/**
+ * Re-mint presigned URLs for gateway-offloaded images (s3Key rows).
+ * Shared by ImageStudio and BakeOff — single reload path after hydrateFromBlobCache.
+ */
+export async function refreshStudioOffloadedImageUrls(
+  apiKey: string,
+  gatewayBase: string,
+  images: Ref<ImageHistoryItem[]> | ImageHistoryItem[]
+): Promise<void> {
+  if (!apiKey) return
+  const rows = 'value' in images ? images.value : images
+  const stale = rows.filter((it) => it.s3Key)
+  if (!stale.length) return
+  await Promise.all(
+    stale.map(async (it) => {
+      try {
+        const url = await gatewayImagePresign(apiKey, gatewayBase, it.s3Key as string)
+        if (url) it.src = url
+      } catch {
+        /* history is best-effort */
+      }
+    })
+  )
+}
+
+/** Mount hook: IndexedDB hydrate, then presign refresh for offloaded rows. */
+export async function mountStudioImageLibrary(
+  apiKey: string,
+  gatewayBase: string,
+  library: StudioImageLibrary
+): Promise<void> {
+  await library.hydrateFromBlobCache()
+  await refreshStudioOffloadedImageUrls(apiKey, gatewayBase, library.images)
+}
+
+/** Thumbnail load failure: try IndexedDB mirror before showing expired placeholder. */
+export async function onStudioImageThumbError(
+  library: StudioImageLibrary,
+  itemId: string
+): Promise<void> {
+  await library.rehydrateImageFromBlob(itemId)
+}

--- a/frontend/src/composables/useStudioImagePreview.ts
+++ b/frontend/src/composables/useStudioImagePreview.ts
@@ -1,0 +1,29 @@
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import type { ImageHistoryItem } from '@/composables/useMediaLibrary'
+import { imageHistoryItemAvailable } from '@/utils/studioMedia.tk'
+
+/**
+ * Shared in-page image lightbox for ImageStudio (mirrors useStudioVideoPreview from #1092).
+ * data: URIs cannot open in a new tab; preview stays in-page.
+ */
+export function useStudioImagePreview() {
+  const preview = ref<ImageHistoryItem | null>(null)
+
+  function openPreview(img: ImageHistoryItem): void {
+    if (!imageHistoryItemAvailable(img)) return
+    preview.value = img
+  }
+
+  function closePreview(): void {
+    preview.value = null
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape' && preview.value) closePreview()
+  }
+
+  onMounted(() => window.addEventListener('keydown', onKeydown))
+  onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
+
+  return { preview, openPreview, closePreview }
+}

--- a/frontend/src/composables/useStudioVideoLibrary.ts
+++ b/frontend/src/composables/useStudioVideoLibrary.ts
@@ -1,0 +1,20 @@
+import type { MediaLibrary } from '@/composables/useMediaLibrary'
+
+export type StudioVideoLibrary = Pick<MediaLibrary, 'hydrateFromBlobCache' | 'rehydrateVideoFromBlob'>
+
+/**
+ * Rehydrate IndexedDB-mirrored video clips after reload.
+ * Shared by VideoStudio and BakeOff — single reload path (mirrors mountStudioImageLibrary
+ * without s3Key presign; video passthrough keeps http urls out of localStorage).
+ */
+export async function mountStudioVideoLibrary(library: StudioVideoLibrary): Promise<void> {
+  await library.hydrateFromBlobCache()
+}
+
+/** Play / card replay: try IndexedDB mirror before showing expired placeholder. */
+export async function onStudioVideoReplayError(
+  library: StudioVideoLibrary,
+  taskId: string
+): Promise<boolean> {
+  return library.rehydrateVideoFromBlob(taskId)
+}

--- a/frontend/src/composables/useStudioVideoLibrary.ts
+++ b/frontend/src/composables/useStudioVideoLibrary.ts
@@ -1,6 +1,6 @@
 import type { MediaLibrary } from '@/composables/useMediaLibrary'
 
-export type StudioVideoLibrary = Pick<MediaLibrary, 'hydrateFromBlobCache' | 'rehydrateVideoFromBlob'>
+export type StudioVideoLibrary = Pick<MediaLibrary, 'hydrateFromBlobCache'>
 
 /**
  * Rehydrate IndexedDB-mirrored video clips after reload.
@@ -9,12 +9,4 @@ export type StudioVideoLibrary = Pick<MediaLibrary, 'hydrateFromBlobCache' | 're
  */
 export async function mountStudioVideoLibrary(library: StudioVideoLibrary): Promise<void> {
   await library.hydrateFromBlobCache()
-}
-
-/** Play / card replay: try IndexedDB mirror before showing expired placeholder. */
-export async function onStudioVideoReplayError(
-  library: StudioVideoLibrary,
-  taskId: string
-): Promise<boolean> {
-  return library.rehydrateVideoFromBlob(taskId)
 }

--- a/frontend/src/composables/useStudioVideoPreview.ts
+++ b/frontend/src/composables/useStudioVideoPreview.ts
@@ -16,13 +16,16 @@ export interface StudioVideoPreviewSource {
 }
 
 export interface UseStudioVideoPreviewOptions {
-  onUrlExpired?: (taskId: string) => void
+  /** Toast when lightbox download is blocked (playback failed or persisted url stripped). */
   onExpiredDownload?: () => void
 }
 
 /**
  * Shared in-page video lightbox state for VideoStudio and BakeOff.
  * http(s) URLs play directly; inline data:video becomes a tab-local Blob URL.
+ *
+ * Lightbox playback failure is session-local (`previewState === 'expired'`) and must
+ * not mutate library/panel task cards — card poster SSOT stays on the raw upstream url.
  */
 export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}) {
   const open = ref(false)
@@ -83,14 +86,12 @@ export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}
   }
 
   function onPreviewError(): void {
-    const id = taskId.value
     previewRevoke()
     previewRevoke = () => {}
     previewUrl.value = ''
     previewState.value = 'expired'
     previewMediaReady.value = false
     urlExpired.value = true
-    if (id) options.onUrlExpired?.(id)
   }
 
   function retryPreview(): void {
@@ -121,9 +122,8 @@ export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}
   }
 
   function downloadPreview(): void {
-    const url = downloadUrl.value
-    if (!url) return
-    if (urlExpired.value) {
+    const url = rawUrl.value
+    if (!url) {
       options.onExpiredDownload?.()
       return
     }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -230,6 +230,7 @@ export default {
       reversePrompt: 'Generate prompt from image',
       reversing: 'Reading image…',
       reverseEmpty: 'Could not derive a prompt from the image.',
+      revisedPromptHint: 'Prompt the model actually used: {text}',
       generate: 'Generate · {cost}',
       generateTopUp: 'Generate · {cost} — top up',
       generating: 'Generating…',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -286,6 +286,9 @@ export default {
       copied: 'Copied',
       retentionHint: 'Download now · short local preview; upstream links expire',
       previewBuffering: 'Buffering video…',
+      checkingPreview: 'Checking whether in-page preview is available…',
+      downloadOnlyTitle: 'Video ready',
+      downloadOnlyHint: 'This source cannot be previewed in the browser. Download to watch locally.',
     },
     chat: {
       model: 'Model',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -228,6 +228,7 @@ export default {
       reversePrompt: '从图片生成提示词',
       reversing: '识别中…',
       reverseEmpty: '未能从图片生成提示词。',
+      revisedPromptHint: '模型实际使用的提示词：{text}',
       generate: '生成 · {cost}',
       generateTopUp: '生成 · {cost} — 去充值',
       generating: '生成中…',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -284,6 +284,9 @@ export default {
       copied: '已复制',
       retentionHint: '请立即下载保存 · 本机可短期预览，上游链接会过期',
       previewBuffering: '正在缓冲视频…',
+      checkingPreview: '正在检查能否在页面内预览…',
+      downloadOnlyTitle: '视频已生成',
+      downloadOnlyHint: '此来源不支持在页面内播放，请下载到本地观看。',
     },
     chat: {
       model: '模型',

--- a/frontend/src/utils/__tests__/studioImageHistory.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioImageHistory.tk.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  imageHistoryPromptTitle,
+  isEphemeralImageSrc,
+  matchImageHistoryModel,
+  studioImageHistoryId,
+} from '../studioImageHistory.tk'
+
+describe('studioImageHistory.tk', () => {
+  it('mints unique ids', () => {
+    const a = studioImageHistoryId()
+    const b = studioImageHistoryId()
+    expect(a).toBeTruthy()
+    expect(b).toBeTruthy()
+    expect(a).not.toBe(b)
+  })
+
+  it('classifies ephemeral image src schemes', () => {
+    expect(isEphemeralImageSrc('')).toBe(true)
+    expect(isEphemeralImageSrc('data:image/png;base64,AA==')).toBe(true)
+    expect(isEphemeralImageSrc('blob:http://localhost/x')).toBe(true)
+    expect(isEphemeralImageSrc('https://cdn.example/a.png')).toBe(true)
+    expect(isEphemeralImageSrc('file:///tmp/x.png')).toBe(false)
+  })
+
+  it('builds prompt tooltip with revised prompt when different', () => {
+    const title = imageHistoryPromptTitle(
+      { prompt: 'rabbit', revisedPrompt: 'a white rabbit in grass', model: 'imagen-4' },
+      (text) => `revised: ${text}`
+    )
+    expect(title).toContain('rabbit')
+    expect(title).toContain('revised: a white rabbit')
+    expect(title).toContain('imagen-4')
+  })
+
+  it('matchImageHistoryModel resolves served or catalog id', () => {
+    const models = [{ servedId: 'imagen-4.0-generate-001', model: { modelId: 'imagen-4-fast' } }]
+    expect(matchImageHistoryModel(models, 'imagen-4.0-generate-001')?.model.modelId).toBe('imagen-4-fast')
+    expect(matchImageHistoryModel(models, 'imagen-4-fast')?.servedId).toBe('imagen-4.0-generate-001')
+  })
+})

--- a/frontend/src/utils/__tests__/studioMedia.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioMedia.tk.spec.ts
@@ -5,6 +5,7 @@ import {
   imageHistoryItemAvailable,
   shouldShowStudioSaveReminder,
   videoPlaybackUrl,
+  videoTaskCardPresentation,
   videoTaskPlaybackAvailable,
 } from '../studioMedia.tk'
 import type { ImageHistoryItem, VideoTaskItem } from '@/composables/useMediaLibrary'
@@ -17,6 +18,60 @@ const urlStatic = URL as unknown as {
   revokeObjectURL?: (u: string) => void
 }
 
+describe('videoTaskCardPresentation', () => {
+  it('is expired when reload stripped the upstream url', () => {
+    expect(
+      videoTaskCardPresentation({
+        state: 'succeeded',
+        url: '',
+        urlExpired: true,
+      })
+    ).toBe('expired')
+  })
+
+  it('is loading for http upstream until CORS classification finishes', () => {
+    expect(
+      videoTaskCardPresentation({
+        state: 'succeeded',
+        url: 'https://cdn.example/fresh.mp4',
+        urlExpired: false,
+      })
+    ).toBe('loading')
+  })
+
+  it('is download-only when upstream CORS blocks inline preview/cache', () => {
+    expect(
+      videoTaskCardPresentation({
+        state: 'succeeded',
+        url: 'https://cdn.example/seedance.mp4',
+        urlExpired: false,
+        playbackStorage: 'upstream-cors-blocked',
+      })
+    ).toBe('download-only')
+  })
+
+  it('is inline-play when upstream CORS probe succeeds', () => {
+    expect(
+      videoTaskCardPresentation({
+        state: 'succeeded',
+        url: 'https://cdn.example/fresh.mp4',
+        urlExpired: false,
+        playbackStorage: 'upstream-cors-ok',
+      })
+    ).toBe('inline-play')
+  })
+
+  it('is inline-play for tab-local blob urls regardless of storage kind', () => {
+    expect(
+      videoTaskCardPresentation({
+        state: 'succeeded',
+        url: 'blob:cached-video',
+        playbackStorage: 'upstream-cors-blocked',
+      })
+    ).toBe('inline-play')
+  })
+})
+
 describe('videoTaskPlaybackAvailable', () => {
   it('is false for succeeded tasks whose upstream link was stripped on reload', () => {
     expect(
@@ -28,14 +83,23 @@ describe('videoTaskPlaybackAvailable', () => {
     ).toBe(false)
   })
 
-  it('is true for succeeded tasks with a live in-tab url', () => {
+  it('is true only when inline-play presentation applies', () => {
     expect(
       videoTaskPlaybackAvailable({
         state: 'succeeded',
         url: 'https://cdn.example/fresh.mp4',
         urlExpired: false,
+        playbackStorage: 'upstream-cors-ok',
       })
     ).toBe(true)
+    expect(
+      videoTaskPlaybackAvailable({
+        state: 'succeeded',
+        url: 'https://cdn.example/seedance.mp4',
+        urlExpired: false,
+        playbackStorage: 'upstream-cors-blocked',
+      })
+    ).toBe(false)
   })
 })
 

--- a/frontend/src/utils/__tests__/studioPlaybackStorage.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioPlaybackStorage.tk.spec.ts
@@ -20,8 +20,18 @@ describe('videoTaskPlaybackStorageKind', () => {
     expect(videoTaskPlaybackStorageKind({ url: '', urlExpired: true })).toBe('expired')
   })
 
-  it('prefers persisted playbackStorage', () => {
+  it('prefers persisted playbackStorage when url is still present', () => {
     expect(videoTaskPlaybackStorageKind({ url: 'https://x/v.mp4', playbackStorage: 'inline-local' })).toBe('inline-local')
+  })
+
+  it('ignores stale playbackStorage after reload stripped the url', () => {
+    expect(
+      videoTaskPlaybackStorageKind({
+        url: '',
+        urlExpired: true,
+        playbackStorage: 'upstream-cors-ok',
+      })
+    ).toBe('expired')
   })
 })
 

--- a/frontend/src/utils/studioImageHistory.tk.ts
+++ b/frontend/src/utils/studioImageHistory.tk.ts
@@ -1,0 +1,37 @@
+import type { ImageHistoryItem } from '@/composables/useMediaLibrary'
+
+/** Mint a stable, unique id for a Studio image history row (Vue :key + IndexedDB). */
+export function studioImageHistoryId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
+}
+
+/** True when src bytes are mirrored in IndexedDB or re-minted on mount — not safe to persist. */
+export function isEphemeralImageSrc(src: string | undefined): boolean {
+  const s = (src ?? '').trim()
+  if (!s) return true
+  return /^data:/i.test(s) || s.startsWith('blob:') || /^https?:\/\//i.test(s)
+}
+
+/** Tooltip: user prompt, optional upstream revised_prompt, and served model id. */
+export function imageHistoryPromptTitle(
+  img: Pick<ImageHistoryItem, 'prompt' | 'revisedPrompt' | 'model'>,
+  revisedPromptHint: (text: string) => string
+): string {
+  const lines = [img.prompt]
+  if (img.revisedPrompt && img.revisedPrompt.trim() !== img.prompt.trim()) {
+    lines.push(revisedPromptHint(img.revisedPrompt))
+  }
+  lines.push(img.model)
+  return lines.join('\n')
+}
+
+/** Resolve a priced model row from a history item's served id (ImageStudio reuse). */
+export function matchImageHistoryModel<T extends { servedId: string; model: { modelId: string } }>(
+  models: readonly T[],
+  servedOrModelId: string
+): T | undefined {
+  return models.find((r) => r.servedId === servedOrModelId || r.model.modelId === servedOrModelId)
+}

--- a/frontend/src/utils/studioMedia.tk.ts
+++ b/frontend/src/utils/studioMedia.tk.ts
@@ -22,7 +22,9 @@ export function imageHistoryItemAvailable(img: Pick<ImageHistoryItem, 'src'>): b
   return !!img.src?.trim()
 }
 
-/** True when the task card may offer in-page playback (same session, non-expired url). */
+/** True when the task card may offer in-page playback (same session, non-expired url).
+ *  `urlExpired` is set only when a reload stripped the http url from storage — not when
+ *  the lightbox fails to play an upstream CORS-blocked clip in the current tab. */
 export function videoTaskPlaybackAvailable(task: Pick<VideoTaskItem, 'state' | 'url' | 'urlExpired'>): boolean {
   return task.state === 'succeeded' && !!task.url && !task.urlExpired
 }

--- a/frontend/src/utils/studioMedia.tk.ts
+++ b/frontend/src/utils/studioMedia.tk.ts
@@ -13,6 +13,7 @@
  * always gets something usable to hand to a <video :src>.
  */
 import type { ImageHistoryItem, VideoTaskItem } from '@/composables/useMediaLibrary'
+import { videoTaskPlaybackStorageKind } from '@/utils/studioPlaybackStorage.tk'
 
 /** i18n key for image thumbnails that lost their in-browser bytes after reload. */
 export const STUDIO_IMAGE_EXPIRED_I18N_KEY = 'studio.image.expiredReload' as const
@@ -22,11 +23,44 @@ export function imageHistoryItemAvailable(img: Pick<ImageHistoryItem, 'src'>): b
   return !!img.src?.trim()
 }
 
-/** True when the task card may offer in-page playback (same session, non-expired url).
- *  `urlExpired` is set only when a reload stripped the http url from storage — not when
- *  the lightbox fails to play an upstream CORS-blocked clip in the current tab. */
-export function videoTaskPlaybackAvailable(task: Pick<VideoTaskItem, 'state' | 'url' | 'urlExpired'>): boolean {
-  return task.state === 'succeeded' && !!task.url && !task.urlExpired
+/** Card surface for a succeeded video task after CORS/storage classification. */
+export type VideoTaskCardPresentation = 'loading' | 'inline-play' | 'download-only' | 'expired'
+
+/**
+ * Decide which video card UI to show. Upstream http(s) URLs stay in `loading` until
+ * tagStudioVideoPlayback resolves; CORS-blocked upstream clips skip the play tile
+ * and surface download-first (honest UX — no fake ▶).
+ */
+export function videoTaskCardPresentation(
+  task: Pick<VideoTaskItem, 'state' | 'url' | 'urlExpired' | 'playbackStorage'>
+): VideoTaskCardPresentation {
+  if (task.state !== 'succeeded') return 'expired'
+  if (task.urlExpired || !task.url?.trim()) return 'expired'
+
+  const url = task.url.trim()
+  if (/^data:video/i.test(url) || url.startsWith('blob:')) return 'inline-play'
+
+  const kind = videoTaskPlaybackStorageKind(task)
+  switch (kind) {
+    case 'upstream-cors-blocked':
+      return 'download-only'
+    case 'unknown':
+      return 'loading'
+    case 'expired':
+      return 'expired'
+    case 'inline-local':
+    case 'upstream-cors-ok':
+      return 'inline-play'
+    default:
+      return 'loading'
+  }
+}
+
+/** True when the card may show the in-page play tile / open the lightbox. */
+export function videoTaskPlaybackAvailable(
+  task: Pick<VideoTaskItem, 'state' | 'url' | 'urlExpired' | 'playbackStorage'>
+): boolean {
+  return videoTaskCardPresentation(task) === 'inline-play'
 }
 
 /** When any Studio surface should show the local-save download banner. */

--- a/frontend/src/utils/studioPlaybackStorage.tk.ts
+++ b/frontend/src/utils/studioPlaybackStorage.tk.ts
@@ -68,7 +68,8 @@ export function studioPlaybackStorageI18nKey(storage: StudioPlaybackStorage | un
 export function videoTaskPlaybackStorageKind(
   task: Pick<VideoTaskItem, 'playbackStorage' | 'urlExpired' | 'url'>
 ): StudioPlaybackStorage {
-  return task.playbackStorage ?? (task.urlExpired || !task.url ? 'expired' : 'unknown')
+  if (task.urlExpired || !task.url?.trim()) return 'expired'
+  return task.playbackStorage ?? 'unknown'
 }
 
 export interface TagStudioVideoPlaybackDeps {

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -146,7 +146,7 @@
                Poster tile → in-page lightbox, mirroring VideoStudio and sharing
                videoPlaybackUrl so inline data:video plays tab-local without rehosting. -->
           <button
-            v-if="bakePanelVideoPlayable(p)"
+            v-if="bakePanelPresentation(p) === 'inline-play'"
             type="button"
             class="group relative block aspect-video w-full overflow-hidden rounded-lg bg-gradient-to-br from-gray-800 to-gray-950"
             data-testid="bakeoff-video-play"
@@ -159,6 +159,22 @@
               </span>
             </span>
           </button>
+          <StudioVideoPreviewChecking
+            v-else-if="bakePanelPresentation(p) === 'loading'"
+            aspect-ratio="16 / 9"
+            test-id="bakeoff-video-checking"
+          />
+          <StudioVideoDownloadCard
+            v-else-if="bakePanelPresentation(p) === 'download-only' && panelPlaybackTask(p)"
+            :prompt="prompt"
+            :task="panelPlaybackTask(p)!"
+            :copied="copiedUrl === p.url"
+            test-id="bakeoff-video-download-only"
+            download-test-id="bakeoff-video-download-primary"
+            copy-test-id="bakeoff-video-copy-primary"
+            @download="downloadCardVideo(p.url!, `tokenkey-${p.taskId || p.modelId}.mp4`, p.urlExpired)"
+            @copy-link="copyCardLink(p.url!)"
+          />
           <StudioVideoUnavailable
             v-else-if="p.state === 'succeeded'"
             :prompt="prompt"
@@ -175,7 +191,7 @@
           <div class="flex flex-wrap items-center gap-2">
             <span class="font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(p.cost) }}</span>
             <StudioPlaybackBadge
-              v-if="modality === 'video' && p.state === 'succeeded' && panelPlaybackTask(p)"
+              v-if="modality === 'video' && p.state === 'succeeded' && panelPlaybackTask(p) && bakePanelPresentation(p) === 'loading'"
               :task="panelPlaybackTask(p)!"
             />
           </div>
@@ -188,7 +204,7 @@
             >
               {{ t('studio.image.download') }}
             </button>
-            <template v-else-if="modality === 'video' && p.state === 'succeeded' && p.url">
+            <template v-else-if="modality === 'video' && p.state === 'succeeded' && p.url && bakePanelPresentation(p) !== 'download-only'">
               <button
                 type="button"
                 class="text-[11px] font-medium text-primary-600 dark:text-primary-300"
@@ -274,9 +290,10 @@
                 <span class="shrink-0 text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: task.vendorLabel }) }}</span>
               </div>
               <button
-                v-if="videoTaskPlaybackAvailable(task)"
+                v-if="videoTaskCardPresentation(task) === 'inline-play'"
                 type="button"
                 class="group relative block aspect-video w-full overflow-hidden rounded-lg bg-gradient-to-br from-gray-800 to-gray-950"
+                data-testid="bakeoff-history-video-play"
                 @click="openVideoHistoryPreview(task)"
               >
                 <span class="pointer-events-none absolute inset-0 flex items-center justify-center">
@@ -285,6 +302,22 @@
                   </span>
                 </span>
               </button>
+              <StudioVideoPreviewChecking
+                v-else-if="videoTaskCardPresentation(task) === 'loading'"
+                aspect-ratio="16 / 9"
+                test-id="bakeoff-history-video-checking"
+              />
+              <StudioVideoDownloadCard
+                v-else-if="videoTaskCardPresentation(task) === 'download-only'"
+                :prompt="task.prompt"
+                :task="task"
+                :copied="copiedUrl === task.url"
+                test-id="bakeoff-history-video-download-only"
+                download-test-id="bakeoff-history-video-download-primary"
+                copy-test-id="bakeoff-history-video-copy-primary"
+                @download="downloadCardVideo(task.url, `tokenkey-${task.id}.mp4`, task.urlExpired)"
+                @copy-link="copyCardLink(task.url)"
+              />
               <div v-else-if="task.state === 'processing'" class="flex aspect-video items-center justify-center rounded-lg bg-gray-50 text-[11px] text-gray-500 dark:bg-dark-800 dark:text-dark-400">
                 <span class="inline-flex items-center gap-1.5"><span class="h-2 w-2 animate-pulse rounded-full bg-primary-500"></span>{{ t('studio.video.statusProcessing') }}</span>
               </div>
@@ -293,10 +326,16 @@
               </div>
               <StudioVideoUnavailable v-else :prompt="task.prompt" :task="task" />
               <div class="mt-1 flex items-center justify-between gap-2">
-                <StudioPlaybackBadge v-if="task.state === 'succeeded'" :task="task" />
+                <StudioPlaybackBadge
+                  v-if="task.state === 'succeeded' && videoTaskCardPresentation(task) === 'loading'"
+                  :task="task"
+                />
                 <span class="ml-auto text-xs font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(task.estCost) }}</span>
               </div>
-              <div v-if="task.state === 'succeeded' && task.url" class="mt-1 flex flex-wrap items-center gap-2">
+              <div
+                v-if="task.state === 'succeeded' && task.url && videoTaskCardPresentation(task) !== 'download-only'"
+                class="mt-1 flex flex-wrap items-center gap-2"
+              >
                 <button
                   type="button"
                   class="text-[10px] font-medium text-primary-600 dark:text-primary-300"
@@ -369,6 +408,7 @@ import {
   groupVideoHistoryByBatch,
   imageHistoryItemAvailable,
   shouldShowStudioSaveReminder,
+  videoTaskCardPresentation,
   videoTaskPlaybackAvailable,
 } from '@/utils/studioMedia.tk'
 import { downloadMedia } from '@/utils/studioDownload.tk'
@@ -376,6 +416,8 @@ import { tagStudioVideoPlayback } from '@/utils/studioPlaybackStorage.tk'
 import StudioLocalSaveBanner from '@/views/user/studio/components/StudioLocalSaveBanner.vue'
 import StudioImageExpired from '@/views/user/studio/components/StudioImageExpired.vue'
 import StudioPlaybackBadge from '@/views/user/studio/components/StudioPlaybackBadge.vue'
+import StudioVideoDownloadCard from '@/views/user/studio/components/StudioVideoDownloadCard.vue'
+import StudioVideoPreviewChecking from '@/views/user/studio/components/StudioVideoPreviewChecking.vue'
 import StudioVideoPreviewLightbox from '@/views/user/studio/components/StudioVideoPreviewLightbox.vue'
 import StudioVideoUnavailable from '@/views/user/studio/components/StudioVideoUnavailable.vue'
 import { useAppStore } from '@/stores/app'
@@ -437,6 +479,7 @@ interface BakePanel {
   taskId?: string
   url?: string
   urlExpired?: boolean
+  playbackStorage?: import('@/utils/studioPlaybackStorage.tk').StudioPlaybackStorage
   elapsedS?: number
   errorMessage?: string
 }
@@ -448,12 +491,6 @@ const isBusy = computed(
 const activeRunTs = ref<number | null>(null)
 
 const library = useMediaLibrary(props.userId)
-
-const playbackDeps = {
-  patchVideoTask: (id: string, patch: Partial<VideoTaskItem>) => library.patchVideoTask(id, patch),
-  cacheInlineMedia: library.cacheInlineMedia.bind(library),
-  onUpstreamCorsBlocked: () => appStore.showWarning(t('studio.playback.upstreamCorsBlocked'), 8000),
-}
 
 function tagVideoPlayback(taskId: string, url: string): void {
   void tagStudioVideoPlayback(playbackDeps, taskId, url)
@@ -468,11 +505,19 @@ function patchVideoTask(id: string, patch: Partial<VideoTaskItem>): void {
       panel.url = patch.url
     }
     if (patch.urlExpired != null) panel.urlExpired = patch.urlExpired
+    if (patch.playbackStorage != null) panel.playbackStorage = patch.playbackStorage
     if (patch.elapsedS != null) panel.elapsedS = patch.elapsedS
     if (patch.errorMessage != null) panel.errorMessage = patch.errorMessage
   }
   if (patch.url) void tagVideoPlayback(id, patch.url)
 }
+
+const playbackDeps = {
+  patchVideoTask,
+  cacheInlineMedia: library.cacheInlineMedia.bind(library),
+  onUpstreamCorsBlocked: () => appStore.showWarning(t('studio.playback.upstreamCorsBlocked'), 8000),
+}
+
 const poll = useVideoTaskPoll({
   gatewayBase: () => props.gatewayBase,
   resolveKey: (keyId) => props.keys.find((k) => k.id === keyId)?.key,
@@ -505,9 +550,15 @@ const showSaveReminder = computed(() =>
   })
 )
 
-function bakePanelVideoPlayable(p: BakePanel): boolean {
-  if (p.state !== 'succeeded') return false
-  return videoTaskPlaybackAvailable({ state: p.state, url: p.url ?? '', urlExpired: p.urlExpired })
+function bakePanelPresentation(p: BakePanel) {
+  if (p.state !== 'succeeded') return 'expired' as const
+  const stored = p.taskId ? library.videoTasks.value.find((t) => t.id === p.taskId) : undefined
+  return videoTaskCardPresentation({
+    state: p.state,
+    url: p.url ?? stored?.url ?? '',
+    urlExpired: p.urlExpired ?? stored?.urlExpired,
+    playbackStorage: p.playbackStorage ?? stored?.playbackStorage,
+  })
 }
 
 function panelPlaybackTask(p: BakePanel): Pick<VideoTaskItem, 'playbackStorage' | 'urlExpired' | 'url'> | undefined {
@@ -557,7 +608,7 @@ function openVideoPreviewFromUrl(label: string, cost: number, url: string, taskI
 
 function openVideoPreview(panel: BakePanel): void {
   if (panel.state !== 'succeeded' || !panel.url) return
-  if (!videoTaskPlaybackAvailable({ state: panel.state, url: panel.url ?? '', urlExpired: panel.urlExpired })) return
+  if (!videoTaskPlaybackAvailable({ state: panel.state, url: panel.url ?? '', urlExpired: panel.urlExpired, playbackStorage: panel.playbackStorage })) return
   openVideoPreviewFromUrl(panel.label, panel.cost, panel.url, panel.taskId, panel.urlExpired)
 }
 

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -235,7 +235,13 @@
                 <span class="shrink-0 text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: img.vendorLabel }) }}</span>
               </div>
               <div v-if="imageHistoryItemAvailable(img)" class="overflow-hidden rounded-lg">
-                <img :src="img.src" :alt="img.prompt" class="aspect-square w-full object-cover" loading="lazy" />
+                <img
+                  :src="img.src"
+                  :alt="img.prompt"
+                  class="aspect-square w-full object-cover"
+                  loading="lazy"
+                  @error="onImageHistoryThumbError(img.id)"
+                />
               </div>
               <StudioImageExpired v-else compact />
               <div class="mt-1 flex items-center justify-between gap-2">
@@ -340,7 +346,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { gatewayGeminiImageViaChat, gatewayImageGenerations, gatewayVideoSubmit, gatewayImagePresign } from '@/api/playground'
+import { gatewayGeminiImageViaChat, gatewayImageGenerations, gatewayVideoSubmit } from '@/api/playground'
 import {
   extractChatImageItems,
   extractImageItems,
@@ -378,6 +384,9 @@ import { useStudioVideoCardActions } from '@/composables/useStudioVideoCardActio
 import { useStudioVideoPreview } from '@/composables/useStudioVideoPreview'
 import { useVideoTaskPoll } from '@/composables/useVideoTaskPoll'
 import { useMediaLibrary, type ImageHistoryItem, type VideoTaskItem } from '@/composables/useMediaLibrary'
+import { studioImageHistoryId } from '@/utils/studioImageHistory.tk'
+import { mountStudioImageLibrary, onStudioImageThumbError } from '@/composables/useStudioImageLibrary'
+import { mountStudioVideoLibrary } from '@/composables/useStudioVideoLibrary'
 import type { ApiKey } from '@/types'
 
 const props = defineProps<{
@@ -532,7 +541,6 @@ const {
   copyPreviewLink,
   downloadPreview,
 } = useStudioVideoPreview({
-  onUrlExpired: (id) => patchVideoTask(id, { urlExpired: true }),
   onExpiredDownload: warnExpiredDownload,
 })
 
@@ -683,7 +691,7 @@ async function run(): Promise<void> {
     if (modality.value === 'image') {
       const historyBatch: ImageHistoryItem[] = []
       await Promise.all(
-        panels.value.map(async (panel, index) => {
+        panels.value.map(async (panel) => {
           try {
             const items = await generateBakeoffImage(panel.servedId, text)
             if (!items.length) throw new Error('no_image')
@@ -691,7 +699,7 @@ async function run(): Promise<void> {
             panel.src = it.src
             panel.state = 'succeeded'
             historyBatch.push({
-              id: `${runTs}-${panel.modelId}-${index}`,
+              id: studioImageHistoryId(),
               src: it.src,
               s3Key: it.s3Key,
               prompt: text,
@@ -791,26 +799,15 @@ function mapError(e: unknown): void {
   }
 }
 
-async function refreshOffloadedImageUrls(): Promise<void> {
-  if (!props.apiKey) return
-  const stale = library.images.value.filter((it) => it.s3Key)
-  if (!stale.length) return
-  await Promise.all(
-    stale.map(async (it) => {
-      try {
-        const url = await gatewayImagePresign(props.apiKey, props.gatewayBase, it.s3Key as string)
-        if (url) it.src = url
-      } catch {
-        /* history is best-effort */
-      }
-    })
-  )
+function onImageHistoryThumbError(itemId: string): void {
+  void onStudioImageThumbError(library, itemId)
 }
 
 onMounted(() => {
   for (const task of library.videoTasks.value) {
     if (task.state === 'processing') poll.resume(task)
   }
-  void library.hydrateFromBlobCache().then(() => refreshOffloadedImageUrls())
+  void mountStudioImageLibrary(props.apiKey, props.gatewayBase, library)
+  void mountStudioVideoLibrary(library)
 })
 </script>

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -193,7 +193,13 @@
                  (data: or http) without leaving the page. -->
             <template v-if="imageHistoryItemAvailable(img)">
               <button type="button" class="block w-full cursor-zoom-in" :title="t('studio.image.enlargeHint')" data-testid="studio-image-thumb" @click="openPreview(img)">
-                <img :src="img.src" :alt="img.prompt" class="aspect-square w-full object-cover" loading="lazy" />
+                <img
+                  :src="img.src"
+                  :alt="img.prompt"
+                  class="aspect-square w-full object-cover"
+                  loading="lazy"
+                  @error="onThumbError(img)"
+                />
               </button>
               <div class="pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-center gap-1.5 bg-black/40 p-1.5 opacity-0 transition group-hover:pointer-events-auto group-hover:opacity-100">
                 <button type="button" class="rounded-md bg-white/90 px-2 py-1 text-[11px] font-medium text-gray-800 hover:bg-white" @click="download(img)">{{ t('studio.image.download') }}</button>
@@ -210,45 +216,31 @@
             </StudioImageExpired>
           </div>
           <figcaption class="flex items-center justify-between gap-2 px-2.5 py-1.5 text-[11px] text-gray-500 dark:text-dark-400">
-            <span class="truncate" :title="img.prompt">{{ img.prompt }}</span>
+            <div class="min-w-0 flex-1">
+              <span class="block truncate" :title="imagePromptTitle(img)">{{ img.prompt }}</span>
+              <span class="block truncate font-mono text-[10px] text-gray-400 dark:text-dark-500" :title="img.model">{{ img.model }}</span>
+            </div>
             <span class="shrink-0 rounded bg-primary-50 px-1.5 py-0.5 font-semibold text-primary-700 dark:bg-primary-950/50 dark:text-primary-300">{{ formatUsd(img.cost) }}</span>
           </figcaption>
         </figure>
       </div>
     </div>
 
-    <!-- Lightbox: full-resolution in-page preview (replaces the broken open-in-new-tab). -->
-    <Teleport to="body">
-      <div
-        v-if="preview"
-        class="fixed inset-0 z-[100] flex flex-col bg-black/85 backdrop-blur-sm"
-        data-testid="studio-image-preview"
-        @click.self="closePreview"
-      >
-        <div class="flex items-center justify-end p-3">
-          <button type="button" class="rounded-lg bg-white/10 px-3 py-1.5 text-sm font-medium text-white hover:bg-white/20" data-testid="studio-image-preview-close" @click="closePreview">
-            {{ t('studio.image.close') }} ✕
-          </button>
-        </div>
-        <div class="flex min-h-0 flex-1 items-center justify-center px-4" @click.self="closePreview">
-          <img :src="preview.src" :alt="preview.prompt" class="max-h-full max-w-full rounded-lg object-contain shadow-2xl" />
-        </div>
-        <div class="flex flex-wrap items-center justify-center gap-3 p-4">
-          <span class="max-w-[60vw] truncate text-xs text-white/80" :title="preview.prompt">{{ preview.prompt }}</span>
-          <span class="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[11px] font-semibold text-white">{{ formatUsd(preview.cost) }}</span>
-          <button type="button" class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100" @click="download(preview)">{{ t('studio.image.download') }}</button>
-          <button type="button" class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white" @click="reuseAndClose(preview)">{{ t('studio.image.usePrompt') }}</button>
-          <button v-if="supportsImageInput" type="button" class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white" @click="useAsInputAndClose(preview)">{{ t('studio.image.useAsInput') }}</button>
-        </div>
-      </div>
-    </Teleport>
+    <StudioImagePreviewLightbox
+      :preview="preview"
+      :show-use-as-input="supportsImageInput"
+      @close="closePreview"
+      @download="download"
+      @reuse="reuseAndClose"
+      @use-as-input="useAsInputAndClose"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { gatewayImageGenerations, gatewayGeminiImageViaChat, gatewayImageToPrompt, gatewayImagePresign } from '@/api/playground'
+import { gatewayImageGenerations, gatewayGeminiImageViaChat, gatewayImageToPrompt } from '@/api/playground'
 import { extractImageItems, extractChatImageItems, pickVisionChatModel } from '@/constants/playgroundMedia.tk'
 import ImageUpload from '@/components/common/ImageUpload.vue'
 import {
@@ -268,8 +260,16 @@ import {
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { downloadMedia } from '@/utils/studioDownload.tk'
 import { imageHistoryItemAvailable } from '@/utils/studioMedia.tk'
+import {
+  imageHistoryPromptTitle,
+  matchImageHistoryModel,
+  studioImageHistoryId,
+} from '@/utils/studioImageHistory.tk'
+import { mountStudioImageLibrary, onStudioImageThumbError } from '@/composables/useStudioImageLibrary'
+import { useStudioImagePreview } from '@/composables/useStudioImagePreview'
 import StudioLocalSaveBanner from '@/views/user/studio/components/StudioLocalSaveBanner.vue'
 import StudioImageExpired from '@/views/user/studio/components/StudioImageExpired.vue'
+import StudioImagePreviewLightbox from '@/views/user/studio/components/StudioImagePreviewLightbox.vue'
 import { useMediaLibrary, type ImageHistoryItem } from '@/composables/useMediaLibrary'
 
 const props = defineProps<{
@@ -285,6 +285,7 @@ const emit = defineEmits<{ (e: 'spent'): void }>()
 
 const { t } = useI18n()
 const library = useMediaLibrary(props.userId)
+const { preview, openPreview, closePreview } = useStudioImagePreview()
 
 const models = computed(() => resolveAvailableModels('image', props.availableIds, props.priceMap))
 const selectedModelId = ref<string>('')
@@ -417,6 +418,16 @@ watch(
 function reuse(img: ImageHistoryItem): void {
   prompt.value = img.prompt
   userEditedPrompt.value = true
+  const match = matchImageHistoryModel(models.value, img.model)
+  if (match) selectedModelId.value = match.model.modelId
+}
+
+function imagePromptTitle(img: ImageHistoryItem): string {
+  return imageHistoryPromptTitle(img, (text) => t('studio.image.revisedPromptHint', { text }))
+}
+
+function onThumbError(img: ImageHistoryItem): void {
+  void onStudioImageThumbError(library, img.id)
 }
 
 // Drop a staged input image when switching to a model that can't consume it,
@@ -461,54 +472,14 @@ function download(img: ImageHistoryItem): void {
   downloadMedia(img.src, `tokenkey-${img.id}.png`)
 }
 
-// In-page lightbox: clicking a thumbnail opens the full image here instead of a
-// new tab (data: URIs can't be navigated to top-level — they 404 to about:blank).
-const preview = ref<ImageHistoryItem | null>(null)
-function openPreview(img: ImageHistoryItem): void {
-  // A reloaded inline image has an empty src (its bytes were not persisted); there
-  // is nothing to enlarge, so don't open an empty lightbox.
-  if (!img.src) return
-  preview.value = img
-}
-function closePreview(): void {
-  preview.value = null
-}
 function reuseAndClose(img: ImageHistoryItem): void {
   reuse(img)
   closePreview()
 }
-function onKeydown(e: KeyboardEvent): void {
-  if (e.key === 'Escape' && preview.value) closePreview()
-}
-/**
- * Re-mint fresh presigned URLs for persisted offloaded images. Studio history is
- * localStorage-backed, but a presigned URL is intentionally short-lived, so on a
- * reload the stored `src` for an offloaded image may have expired (broken <img>).
- * For every persisted image carrying an s3Key, re-presign from the key (no
- * re-generation, no re-bill) and patch `src`.
- * Best-effort — a failure keeps the cached URL, at worst a stale thumbnail.
- */
-async function refreshOffloadedImageUrls(): Promise<void> {
-  if (!props.apiKey) return
-  const stale = library.images.value.filter((it) => it.s3Key)
-  if (!stale.length) return
-  await Promise.all(
-    stale.map(async (it) => {
-      try {
-        const url = await gatewayImagePresign(props.apiKey, props.gatewayBase, it.s3Key as string)
-        if (url) it.src = url // deep watch in useMediaLibrary persists the refresh
-      } catch {
-        /* keep the cached URL — history is a convenience, not correctness */
-      }
-    })
-  )
-}
 
 onMounted(() => {
-  window.addEventListener('keydown', onKeydown)
-  void library.hydrateFromBlobCache().then(() => refreshOffloadedImageUrls())
+  void mountStudioImageLibrary(props.apiKey, props.gatewayBase, library)
 })
-onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
 
 // Batch export: browsers throttle a burst of synchronous downloads, so stagger
 // each save. Order matches the on-screen grid (newest first).
@@ -556,8 +527,8 @@ async function generate(): Promise<void> {
       rateMultiplier: props.rateMultiplier,
     })
     const ts = Date.now()
-    const history: ImageHistoryItem[] = items.map((it, i) => ({
-      id: `${ts}-${i}-${Math.round(perImage * 1e6)}`,
+    const history: ImageHistoryItem[] = items.map((it) => ({
+      id: studioImageHistoryId(),
       src: it.src,
       s3Key: it.s3Key,
       prompt: text,

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -326,6 +326,7 @@ import StudioVideoUnavailable from '@/views/user/studio/components/StudioVideoUn
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { useMediaLibrary, type VideoTaskItem } from '@/composables/useMediaLibrary'
 import { useStudioVideoCardActions } from '@/composables/useStudioVideoCardActions'
+import { mountStudioVideoLibrary } from '@/composables/useStudioVideoLibrary'
 import { useStudioVideoPreview } from '@/composables/useStudioVideoPreview'
 import { useVideoTaskPoll, requestVideoNotifyPermission, maybeNotify } from '@/composables/useVideoTaskPoll'
 import { useAppStore } from '@/stores/app'
@@ -505,7 +506,6 @@ const {
   copyPreviewLink,
   downloadPreview,
 } = useStudioVideoPreview({
-  onUrlExpired: (id) => library.patchVideoTask(id, { urlExpired: true }),
   onExpiredDownload: warnExpiredDownload,
 })
 
@@ -597,7 +597,7 @@ onMounted(() => {
   for (const task of library.videoTasks.value) {
     if (task.state === 'processing') poll.resume(task)
   }
-  void library.hydrateFromBlobCache()
+  void mountStudioVideoLibrary(library)
 })
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeydown)

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -227,10 +227,9 @@
           <p v-if="task.errorMessage" class="rounded-lg bg-amber-50 px-2.5 py-1.5 text-[11px] font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">{{ t('studio.video.stalled') }}</p>
         </div>
 
-        <!-- succeeded: poster tile when playback is still available in this tab;
-             otherwise prompt-only (upstream http links are not replayed after reload). -->
+        <!-- succeeded: play tile only when inline preview is eligible; CORS-blocked upstream → download-first. -->
         <div v-else-if="task.state === 'succeeded'" class="space-y-2">
-          <template v-if="videoTaskPlaybackAvailable(task)">
+          <template v-if="videoTaskCardPresentation(task) === 'inline-play'">
             <button
               type="button"
               class="group relative block w-full overflow-hidden rounded-lg bg-gradient-to-br from-gray-800 to-gray-950"
@@ -251,15 +250,44 @@
               <StudioPlaybackBadge :task="task" />
             </div>
           </template>
+          <StudioVideoPreviewChecking
+            v-else-if="videoTaskCardPresentation(task) === 'loading'"
+            :aspect-ratio="posterAspect(task)"
+            :seconds="task.seconds"
+            :aspect-label="task.aspectRatio"
+          />
+          <StudioVideoDownloadCard
+            v-else-if="videoTaskCardPresentation(task) === 'download-only'"
+            :prompt="task.prompt"
+            :task="task"
+            :seconds="task.seconds"
+            :aspect-label="task.aspectRatio"
+            :copied="copiedUrl === task.url"
+            @download="downloadCardVideo(task.url, `tokenkey-${task.id}.mp4`, task.urlExpired)"
+            @copy-link="copyCardLink(task.url)"
+          />
           <StudioVideoUnavailable v-else :prompt="task.prompt" :task="task" />
           <div class="flex items-center justify-between text-[11px] text-gray-500 dark:text-dark-400">
-            <span v-if="videoTaskPlaybackAvailable(task)" class="truncate" :title="task.prompt">{{ task.prompt }}</span>
+            <span v-if="videoTaskCardPresentation(task) === 'inline-play'" class="truncate" :title="task.prompt">{{ task.prompt }}</span>
+            <span v-else-if="videoTaskCardPresentation(task) === 'loading'" class="truncate" :title="task.prompt">{{ task.prompt }}</span>
             <span class="shrink-0 rounded bg-primary-50 px-1.5 py-0.5 font-semibold text-primary-700 dark:bg-primary-950/50 dark:text-primary-300">{{ formatUsd(task.estCost) }}</span>
           </div>
           <div class="flex gap-3 text-[11px] font-medium text-gray-500 dark:text-dark-400">
-            <button v-if="videoTaskPlaybackAvailable(task)" type="button" class="text-primary-600 dark:text-primary-300" @click="openPreview(task)">{{ t('studio.video.play') }}</button>
-            <button v-if="task.url" type="button" class="text-primary-600 dark:text-primary-300" data-testid="studio-video-download" @click="downloadCardVideo(task.url, `tokenkey-${task.id}.mp4`, task.urlExpired)">{{ t('studio.video.download') }}</button>
-            <button v-if="task.url" type="button" class="text-gray-500 dark:text-dark-300" data-testid="studio-video-copy-card-link" @click="copyCardLink(task.url)">{{ copiedUrl === task.url ? t('studio.video.copied') : t('studio.video.copyLink') }}</button>
+            <button v-if="videoTaskCardPresentation(task) === 'inline-play'" type="button" class="text-primary-600 dark:text-primary-300" @click="openPreview(task)">{{ t('studio.video.play') }}</button>
+            <button
+              v-if="task.url && videoTaskCardPresentation(task) !== 'download-only'"
+              type="button"
+              class="text-primary-600 dark:text-primary-300"
+              data-testid="studio-video-download"
+              @click="downloadCardVideo(task.url, `tokenkey-${task.id}.mp4`, task.urlExpired)"
+            >{{ t('studio.video.download') }}</button>
+            <button
+              v-if="task.url && videoTaskCardPresentation(task) !== 'download-only'"
+              type="button"
+              class="text-gray-500 dark:text-dark-300"
+              data-testid="studio-video-copy-card-link"
+              @click="copyCardLink(task.url)"
+            >{{ copiedUrl === task.url ? t('studio.video.copied') : t('studio.video.copyLink') }}</button>
             <button type="button" @click="reuse(task)">{{ t('studio.image.usePrompt') }}</button>
             <button type="button" @click="removeTask(task.id)">{{ t('studio.clear') }}</button>
           </div>
@@ -317,10 +345,12 @@ import {
   type MediaPriceMap,
 } from '@/constants/mediaTiers.tk'
 import { estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
-import { videoTaskPlaybackAvailable } from '@/utils/studioMedia.tk'
+import { videoTaskCardPresentation, videoTaskPlaybackAvailable } from '@/utils/studioMedia.tk'
 import { tagStudioVideoPlayback } from '@/utils/studioPlaybackStorage.tk'
 import StudioLocalSaveBanner from '@/views/user/studio/components/StudioLocalSaveBanner.vue'
 import StudioPlaybackBadge from '@/views/user/studio/components/StudioPlaybackBadge.vue'
+import StudioVideoDownloadCard from '@/views/user/studio/components/StudioVideoDownloadCard.vue'
+import StudioVideoPreviewChecking from '@/views/user/studio/components/StudioVideoPreviewChecking.vue'
 import StudioVideoPreviewLightbox from '@/views/user/studio/components/StudioVideoPreviewLightbox.vue'
 import StudioVideoUnavailable from '@/views/user/studio/components/StudioVideoUnavailable.vue'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -27,7 +27,6 @@ const libraryMock = vi.hoisted(() => ({
   hydrateFromBlobCache: vi.fn(async () => undefined),
   cacheInlineMedia: vi.fn(async () => undefined),
   rehydrateImageFromBlob: vi.fn(async () => false),
-  rehydrateVideoFromBlob: vi.fn(async () => false),
 }))
 
 const appStoreMock = vi.hoisted(() => ({

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -11,12 +11,23 @@ const libraryMock = vi.hoisted(() => ({
   videoTasks: { value: [] as VideoTaskItem[] },
   addImages: vi.fn(),
   clearImages: vi.fn(),
-  upsertVideoTask: vi.fn(),
-  patchVideoTask: vi.fn(),
+  upsertVideoTask: vi.fn((task: VideoTaskItem) => {
+    const idx = libraryMock.videoTasks.value.findIndex((t) => t.id === task.id)
+    if (idx >= 0) libraryMock.videoTasks.value[idx] = task
+    else libraryMock.videoTasks.value.push(task)
+  }),
+  patchVideoTask: vi.fn((id: string, patch: Partial<VideoTaskItem>) => {
+    const idx = libraryMock.videoTasks.value.findIndex((t) => t.id === id)
+    if (idx >= 0) {
+      libraryMock.videoTasks.value[idx] = { ...libraryMock.videoTasks.value[idx], ...patch }
+    }
+  }),
   removeVideoTask: vi.fn(),
   clearVideoTasks: vi.fn(),
   hydrateFromBlobCache: vi.fn(async () => undefined),
   cacheInlineMedia: vi.fn(async () => undefined),
+  rehydrateImageFromBlob: vi.fn(async () => false),
+  rehydrateVideoFromBlob: vi.fn(async () => false),
 }))
 
 const appStoreMock = vi.hoisted(() => ({
@@ -33,6 +44,28 @@ vi.mock('@/api/playground', () => ({
   gatewayVideoSubmit: vi.fn(),
   gatewayImagePresign: vi.fn(),
 }))
+
+vi.mock('@/utils/studioPlaybackStorage.tk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/studioPlaybackStorage.tk')>()
+  return {
+    ...actual,
+    tagStudioVideoPlayback: vi.fn(async (deps, taskId, url) => {
+      if (!url) {
+        deps.patchVideoTask(taskId, { playbackStorage: 'expired' })
+        return
+      }
+      if (/^data:video/i.test(url) || url.startsWith('blob:')) {
+        deps.patchVideoTask(taskId, { playbackStorage: 'inline-local' })
+        return
+      }
+      if (/^https?:\/\//i.test(url)) {
+        deps.patchVideoTask(taskId, { playbackStorage: 'upstream-cors-ok' })
+        return
+      }
+      deps.patchVideoTask(taskId, { playbackStorage: 'unknown' })
+    }),
+  }
+})
 
 vi.mock('@/composables/useMediaLibrary', () => ({
   useMediaLibrary: () => libraryMock,
@@ -251,6 +284,7 @@ describe('BakeOff image routing', () => {
         keyId: 1,
         state: 'succeeded',
         url: 'https://cdn.example/a.mp4',
+        playbackStorage: 'upstream-cors-ok',
         submittedAtMs: batchMs,
         elapsedS: 8,
       },
@@ -264,6 +298,7 @@ describe('BakeOff image routing', () => {
         keyId: 1,
         state: 'succeeded',
         url: 'https://cdn.example/b.mp4',
+        playbackStorage: 'upstream-cors-ok',
         submittedAtMs: batchMs,
         elapsedS: 10,
       },
@@ -273,7 +308,7 @@ describe('BakeOff image routing', () => {
       global: { plugins: [i18n], stubs: { RouterLink: true, teleport: true } },
     })
 
-    await wrapper.get('[data-testid="bakeoff-history-item"] button').trigger('click')
+    await wrapper.get('[data-testid="bakeoff-history-video-play"]').trigger('click')
     await flushPromises()
 
     const previewVideo = wrapper.get('[data-testid="bakeoff-video-preview"] video')

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -309,9 +309,9 @@ describe('BakeOff image routing', () => {
 
     expect(wrapper.find('[data-testid="bakeoff-video-preview"]').exists()).toBe(true)
     expect(wrapper.findAll('[data-testid="bakeoff-video-copy-link"]').length).toBeGreaterThan(0)
-    expect(libraryMock.patchVideoTask).toHaveBeenCalledWith('vt_panel_a', { urlExpired: true })
-    expect(panelEls[0].find('[data-testid="bakeoff-video-play"]').exists()).toBe(false)
-    expect(panelEls[0].find('[data-testid="bakeoff-video-expired"]').exists()).toBe(true)
+    expect(libraryMock.patchVideoTask).not.toHaveBeenCalledWith('vt_panel_a', { urlExpired: true })
+    expect(panelEls[0].find('[data-testid="bakeoff-video-play"]').exists()).toBe(true)
+    expect(panelEls[0].find('[data-testid="bakeoff-video-expired"]').exists()).toBe(false)
     expect(panelEls[0].find('[data-testid="bakeoff-video-download"]').exists()).toBe(true)
     expect(panelEls[0].find('[data-testid="bakeoff-video-copy-card-link"]').exists()).toBe(true)
     expect(panelEls[1].find('[data-testid="bakeoff-video-play"]').exists()).toBe(true)
@@ -342,7 +342,7 @@ describe('BakeOff image routing', () => {
     vi.unstubAllGlobals()
   })
 
-  it('warns instead of opening a new tab when downloading an expired panel url', async () => {
+  it('panel download still uses upstream url after lightbox playback fails', async () => {
     vi.mocked(playground.gatewayVideoSubmit)
       .mockResolvedValueOnce({ id: 'vt_panel_a', status: 'succeeded', url: 'https://cdn.example/a.mp4' })
       .mockResolvedValueOnce({ id: 'vt_panel_b', status: 'succeeded', url: 'https://cdn.example/b.mp4' })
@@ -368,8 +368,8 @@ describe('BakeOff image routing', () => {
     appStoreMock.showWarning.mockClear()
     downloadSpy.mockClear()
     await panelEls[0].get('[data-testid="bakeoff-video-download"]').trigger('click')
-    expect(appStoreMock.showWarning).toHaveBeenCalled()
-    expect(downloadSpy).not.toHaveBeenCalled()
+    expect(downloadSpy).toHaveBeenCalledWith('https://cdn.example/a.mp4', 'tokenkey-vt_panel_a.mp4')
+    expect(appStoreMock.showWarning).not.toHaveBeenCalled()
     downloadSpy.mockRestore()
   })
 

--- a/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
@@ -78,6 +78,7 @@ function baseTask(overrides: Partial<VideoTaskItem> = {}): VideoTaskItem {
     keyId: 1,
     state: 'succeeded',
     url: 'https://cdn.example/upstream.mp4',
+    playbackStorage: 'upstream-cors-ok',
     submittedAtMs: Date.now(),
     elapsedS: 8,
     ...overrides,
@@ -123,7 +124,7 @@ describe('VideoStudio succeeded-task presentation', () => {
   })
 
   it('renders a poster tile, NOT an always-on inline <video>, for a fresh in-session task', () => {
-    seedInSession(baseTask({ url: 'https://s3.example/clip.mp4' }))
+    seedInSession(baseTask({ url: 'https://s3.example/clip.mp4', playbackStorage: 'upstream-cors-ok' }))
     const w = mountStudio()
     expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(true)
     expect(w.find('video').exists()).toBe(false)
@@ -185,6 +186,27 @@ describe('VideoStudio succeeded-task presentation', () => {
     expect(previewVideo.classes()).toEqual(
       expect.arrayContaining(['h-full', 'w-full', 'object-contain', 'max-h-full', 'max-w-full'])
     )
+  })
+
+  it('shows download-first card for upstream CORS-blocked clips (no play tile)', () => {
+    seedInSession(
+      baseTask({
+        url: 'https://cdn.volcengine.example/seedance.mp4',
+        playbackStorage: 'upstream-cors-blocked',
+      })
+    )
+    const w = mountStudio()
+    expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(false)
+    expect(w.find('[data-testid="studio-video-download-only"]').exists()).toBe(true)
+    expect(w.find('[data-testid="studio-video-download-primary"]').exists()).toBe(true)
+    expect(w.find('[data-testid="studio-video-download"]').exists()).toBe(false)
+  })
+
+  it('shows checking state before upstream CORS classification completes', () => {
+    seedInSession(baseTask({ url: 'https://cdn.example/pending.mp4', playbackStorage: undefined }))
+    const w = mountStudio()
+    expect(w.find('[data-testid="studio-video-checking"]').exists()).toBe(true)
+    expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(false)
   })
 
   it('exposes a copy-link affordance in the lightbox ready state', async () => {

--- a/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
@@ -153,7 +153,7 @@ describe('VideoStudio succeeded-task presentation', () => {
     expect(w.text()).toContain('studio.playback.expired')
   })
 
-  it('keeps the lightbox open and marks the card expired when preview media fails', async () => {
+  it('keeps the card play tile when preview media fails in the lightbox', async () => {
     seedInSession(baseTask())
     const w = mountStudio()
     await w.find('[data-testid="studio-video-play"]').trigger('click')
@@ -165,9 +165,9 @@ describe('VideoStudio succeeded-task presentation', () => {
 
     expect(w.find('[data-testid="studio-video-preview"]').exists()).toBe(true)
     expect(w.findAll('[data-testid="studio-video-copy-link"]').length).toBeGreaterThan(0)
-    expect(libraryMock.patchVideoTaskSpy).toHaveBeenCalledWith('vt_abc', { urlExpired: true })
-    expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(false)
-    expect(w.find('[data-testid="studio-video-expired"]').exists()).toBe(true)
+    expect(libraryMock.patchVideoTaskSpy).not.toHaveBeenCalledWith('vt_abc', { urlExpired: true })
+    expect(w.find('[data-testid="studio-video-play"]').exists()).toBe(true)
+    expect(w.find('[data-testid="studio-video-expired"]').exists()).toBe(false)
     expect(w.find('[data-testid="studio-video-download"]').exists()).toBe(true)
     expect(w.find('[data-testid="studio-video-copy-card-link"]').exists()).toBe(true)
     expect(libraryMock.videoTasks.value[0].url).toBe('https://cdn.example/upstream.mp4')

--- a/frontend/src/views/user/studio/components/StudioImagePreviewLightbox.vue
+++ b/frontend/src/views/user/studio/components/StudioImagePreviewLightbox.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { formatUsd } from '@/utils/mediaCostEstimate.tk'
+import type { ImageHistoryItem } from '@/composables/useMediaLibrary'
+import { imageHistoryPromptTitle } from '@/utils/studioImageHistory.tk'
+
+defineProps<{
+  preview: ImageHistoryItem | null
+  showUseAsInput?: boolean
+  testId?: string
+  closeTestId?: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  download: [item: ImageHistoryItem]
+  reuse: [item: ImageHistoryItem]
+  'use-as-input': [item: ImageHistoryItem]
+}>()
+
+const { t } = useI18n()
+
+function promptTitle(img: ImageHistoryItem): string {
+  return imageHistoryPromptTitle(img, (text) => t('studio.image.revisedPromptHint', { text }))
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="preview"
+      class="fixed inset-0 z-[100] flex flex-col bg-black/85 backdrop-blur-sm"
+      :data-testid="testId ?? 'studio-image-preview'"
+      @click.self="emit('close')"
+    >
+      <div class="flex items-center justify-end p-3">
+        <button
+          type="button"
+          class="rounded-lg bg-white/10 px-3 py-1.5 text-sm font-medium text-white hover:bg-white/20"
+          :data-testid="closeTestId ?? 'studio-image-preview-close'"
+          @click="emit('close')"
+        >
+          {{ t('studio.image.close') }} ✕
+        </button>
+      </div>
+      <div class="flex min-h-0 flex-1 items-center justify-center px-4" @click.self="emit('close')">
+        <img
+          :src="preview.src"
+          :alt="preview.prompt"
+          class="max-h-full max-w-full rounded-lg object-contain shadow-2xl"
+        />
+      </div>
+      <div class="flex flex-wrap items-center justify-center gap-3 p-4">
+        <span class="max-w-[60vw] truncate text-xs text-white/80" :title="promptTitle(preview)">{{ preview.prompt }}</span>
+        <span class="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[11px] font-semibold text-white">{{ formatUsd(preview.cost) }}</span>
+        <button
+          type="button"
+          class="rounded-md bg-white px-3 py-1.5 text-[12px] font-medium text-gray-900 hover:bg-gray-100"
+          @click="emit('download', preview)"
+        >
+          {{ t('studio.image.download') }}
+        </button>
+        <button
+          type="button"
+          class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white"
+          @click="emit('reuse', preview)"
+        >
+          {{ t('studio.image.usePrompt') }}
+        </button>
+        <button
+          v-if="showUseAsInput"
+          type="button"
+          class="rounded-md bg-white/90 px-3 py-1.5 text-[12px] font-medium text-gray-800 hover:bg-white"
+          @click="emit('use-as-input', preview)"
+        >
+          {{ t('studio.image.useAsInput') }}
+        </button>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/frontend/src/views/user/studio/components/StudioVideoDownloadCard.vue
+++ b/frontend/src/views/user/studio/components/StudioVideoDownloadCard.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import type { VideoTaskItem } from '@/composables/useMediaLibrary'
+import StudioPlaybackBadge from '@/views/user/studio/components/StudioPlaybackBadge.vue'
+
+defineProps<{
+  prompt: string
+  task: Pick<VideoTaskItem, 'playbackStorage' | 'urlExpired' | 'url'>
+  seconds?: number
+  aspectLabel?: string
+  copied?: boolean
+  testId?: string
+  downloadTestId?: string
+  copyTestId?: string
+}>()
+
+defineEmits<{
+  download: []
+  copyLink: []
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div
+    class="rounded-lg border border-amber-200/80 bg-amber-50/60 px-3 py-4 dark:border-amber-900/50 dark:bg-amber-950/20"
+    :data-testid="testId ?? 'studio-video-download-only'"
+  >
+    <p class="text-xs font-semibold uppercase tracking-wide text-amber-900 dark:text-amber-100">
+      {{ t('studio.video.downloadOnlyTitle') }}
+    </p>
+    <p class="mt-2 whitespace-pre-wrap break-words text-sm text-gray-800 dark:text-dark-100">{{ prompt }}</p>
+    <StudioPlaybackBadge class="mt-2" :task="task" />
+    <p class="mt-2 text-[11px] leading-snug text-amber-900/90 dark:text-amber-100/90">
+      {{ t('studio.video.downloadOnlyHint') }}
+    </p>
+    <p
+      v-if="seconds"
+      class="mt-2 font-mono text-[10px] tabular-nums text-gray-500 dark:text-dark-400"
+    >
+      {{ seconds }}s<span v-if="aspectLabel"> · {{ aspectLabel }}</span>
+    </p>
+    <div class="mt-3 flex flex-wrap gap-2">
+      <button
+        type="button"
+        class="inline-flex items-center justify-center rounded-lg bg-primary-600 px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-400"
+        :data-testid="downloadTestId ?? 'studio-video-download-primary'"
+        @click="$emit('download')"
+      >
+        {{ t('studio.video.download') }}
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center justify-center rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs font-medium text-gray-700 transition hover:bg-gray-50 dark:border-dark-600 dark:bg-dark-900 dark:text-dark-100 dark:hover:bg-dark-800"
+        :data-testid="copyTestId ?? 'studio-video-copy-primary'"
+        @click="$emit('copyLink')"
+      >
+        {{ copied ? t('studio.video.copied') : t('studio.video.copyLink') }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/frontend/src/views/user/studio/components/StudioVideoPreviewChecking.vue
+++ b/frontend/src/views/user/studio/components/StudioVideoPreviewChecking.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+withDefaults(
+  defineProps<{
+    aspectRatio?: string
+    seconds?: number
+    aspectLabel?: string
+    testId?: string
+  }>(),
+  { aspectRatio: '16 / 9', testId: 'studio-video-checking' }
+)
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div
+    class="relative flex w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-gray-200 bg-gray-50 px-3 py-6 text-center dark:border-dark-600 dark:bg-dark-800/60"
+    :style="{ aspectRatio }"
+    :data-testid="testId"
+  >
+    <span class="inline-flex items-center gap-2 text-xs text-gray-500 dark:text-dark-400">
+      <span class="h-2 w-2 animate-pulse rounded-full bg-primary-500" aria-hidden="true" />
+      {{ t('studio.video.checkingPreview') }}
+    </span>
+    <span
+      v-if="seconds"
+      class="pointer-events-none absolute bottom-2 left-2 rounded bg-black/55 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-white/90"
+    >
+      {{ seconds }}s<span v-if="aspectLabel"> · {{ aspectLabel }}</span>
+    </span>
+  </div>
+</template>

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -114,6 +114,9 @@
         "StudioVideoPreviewLightbox",
         "useStudioVideoPreview",
         "useStudioVideoCardActions",
+        "mountStudioImageLibrary",
+        "mountStudioVideoLibrary",
+        "onStudioImageThumbError",
         "data-testid=\"bakeoff-video-copy-card-link\"",
         "test-id=\"bakeoff-video-preview\""
       ],
@@ -953,10 +956,12 @@
         "StudioLocalSaveBanner",
         "test-id=\"studio-image-save-reminder\"",
         "StudioImageExpired",
-        "refreshOffloadedImageUrls",
+        "mountStudioImageLibrary",
+        "useStudioImagePreview",
+        "StudioImagePreviewLightbox",
         "pricesFlat"
       ],
-      "rationale": "TK-only Studio image-generation surface (mounted by MediaStudioView when mode==='image'). The model card picker, the per-model aspect-ratio chips, and the generate button are the contract the studio e2e drives. The aspect chips are MODEL-SPECIFIC by design: each model's imageSizes (mediaTiers.tk.ts) decides the exact `size` string sent — Imagen ratio codes, Seedream pixels — so an upstream merge that drops the aspect picker or reverts it to a fixed pixel preset reintroduces the Imagen 'Invalid aspect ratio, 3:2' hard-400 on landscape/portrait. refreshOffloadedImageUrls anchors the onMounted re-presign of persisted offloaded images: offloaded image src is a short-lived presigned S3 link, so a reloaded session must re-mint from the stored s3Key (POST /v1/images/presign) — dropping this call leaves a reopened Studio with dead (expired) image thumbnails. pricesFlat is the FE mirror of the backend Imagen flat-billing exemption (billing_service_tk_flat_image.go): it ORs flatImageBilling (gemini-native) with the model's flatPricePerImage (imagen) and drives the estimate/hold/formula/billed note to drop the 1K/2K/4K size multiplier for imagen WITHOUT touching imagen's /v1/images routing, multi-image n, or no-image-input behaviors — dropping it desyncs the quoted price from settlement (UI over-quotes imagen ×1.5 while the gateway now bills flat). Anchoring the test-ids keeps the surface from compiling green with the feature silently gone."
+      "rationale": "TK-only Studio image-generation surface (mounted by MediaStudioView when mode==='image'). The model card picker, the per-model aspect-ratio chips, and the generate button are the contract the studio e2e drives. The aspect chips are MODEL-SPECIFIC by design: each model's imageSizes (mediaTiers.tk.ts) decides the exact `size` string sent — Imagen ratio codes, Seedream pixels — so an upstream merge that drops the aspect picker or reverts it to a fixed pixel preset reintroduces the Imagen 'Invalid aspect ratio, 3:2' hard-400 on landscape/portrait. mountStudioImageLibrary (SSOT with BakeOff) anchors onMounted IndexedDB hydrate + s3Key re-presign (POST /v1/images/presign) so reloaded sessions don't show dead thumbnails; useStudioImagePreview + StudioImagePreviewLightbox mirror the video SSOT lightbox (#1092). pricesFlat is the FE mirror of the backend Imagen flat-billing exemption (billing_service_tk_flat_image.go): it ORs flatImageBilling (gemini-native) with the model's flatPricePerImage (imagen) and drives the estimate/hold/formula/billed note to drop the 1K/2K/4K size multiplier for imagen WITHOUT touching imagen's /v1/images routing, multi-image n, or no-image-input behaviors — dropping it desyncs the quoted price from settlement (UI over-quotes imagen ×1.5 while the gateway now bills flat). Anchoring the test-ids keeps the surface from compiling green with the feature silently gone."
     },
     {
       "path": "frontend/src/views/user/studio/VideoStudio.vue",
@@ -971,7 +976,8 @@
         "StudioVideoUnavailable",
         "StudioVideoPreviewLightbox",
         "useStudioVideoPreview",
-        "useStudioVideoCardActions"
+        "useStudioVideoCardActions",
+        "mountStudioVideoLibrary"
       ],
       "must_not_contain": [
         "poll.refreshUrl"
@@ -999,10 +1005,10 @@
         "copyMediaLink",
         "onPreviewError",
         "downloadPreview",
-        "onUrlExpired",
-        "urlExpired"
+        "previewState",
+        "rawUrl"
       ],
-      "rationale": "Single lightbox state machine for Studio video preview (VideoStudio + BakeOff). Centralizes open/close, Blob URL revoke, preview error -> urlExpired (lightbox stays open), retry, copy-link (raw upstream url), and expired download guard so surfaces cannot drift after playback fixes."
+      "rationale": "Single lightbox state machine for Studio video preview (VideoStudio + BakeOff). Centralizes open/close, Blob URL revoke, session-local preview error (lightbox stays open; card poster SSOT unchanged), retry, copy-link (raw upstream url), and download via rawUrl so surfaces cannot drift after playback fixes."
     },
     {
       "path": "frontend/src/composables/useStudioVideoCardActions.ts",
@@ -1026,6 +1032,54 @@
         "emit('download')"
       ],
       "rationale": "Shared Teleport lightbox UI for Studio video playback. VideoStudio and BakeOff mount this instead of duplicating inline video + error/retry/download affordances."
+    },
+    {
+      "path": "frontend/src/composables/useStudioImageLibrary.ts",
+      "must_contain": [
+        "export async function mountStudioImageLibrary",
+        "export async function refreshStudioOffloadedImageUrls",
+        "export async function onStudioImageThumbError",
+        "gatewayImagePresign"
+      ],
+      "rationale": "Single reload path for Studio image history (ImageStudio + BakeOff): IndexedDB hydrate, s3Key re-presign, and thumbnail error -> IDB rehydrate. Prevents duplicate mount logic and the blob:/http localStorage persistence bug that broke previews on second refresh."
+    },
+    {
+      "path": "frontend/src/composables/useStudioVideoLibrary.ts",
+      "must_contain": [
+        "export async function mountStudioVideoLibrary",
+        "export async function onStudioVideoReplayError",
+        "hydrateFromBlobCache",
+        "rehydrateVideoFromBlob"
+      ],
+      "rationale": "Single reload path for Studio video history (VideoStudio + BakeOff): IndexedDB hydrate after reload and on-demand IDB rehydrate before showing expired placeholders. Mirrors useStudioImageLibrary without s3Key presign — video passthrough keeps http urls out of localStorage (#944)."
+    },
+    {
+      "path": "frontend/src/composables/useStudioImagePreview.ts",
+      "must_contain": [
+        "export function useStudioImagePreview",
+        "imageHistoryItemAvailable",
+        "closePreview"
+      ],
+      "rationale": "Shared in-page image lightbox state for ImageStudio (mirrors useStudioVideoPreview from #1092). data: URIs cannot open in a new tab; preview stays in-page with Escape-to-close."
+    },
+    {
+      "path": "frontend/src/views/user/studio/components/StudioImagePreviewLightbox.vue",
+      "must_contain": [
+        "'studio-image-preview'",
+        "'studio-image-preview-close'",
+        "emit('download', preview)",
+        "emit('reuse', preview)"
+      ],
+      "rationale": "Shared Teleport lightbox UI for Studio image playback. ImageStudio mounts this instead of duplicating inline preview + footer actions."
+    },
+    {
+      "path": "frontend/src/utils/studioImageHistory.tk.ts",
+      "must_contain": [
+        "export function studioImageHistoryId",
+        "export function isEphemeralImageSrc",
+        "export function imageHistoryPromptTitle"
+      ],
+      "rationale": "Shared image-history helpers: unique row ids (Vue :key), ephemeral-src persistence guard, and revised_prompt tooltip text. Used by useMediaLibrary sanitizers and ImageStudio/BakeOff history cards."
     },
     {
       "path": "frontend/src/utils/studioPlaybackStorage.tk.ts",

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1052,11 +1052,9 @@
       "path": "frontend/src/composables/useStudioVideoLibrary.ts",
       "must_contain": [
         "export async function mountStudioVideoLibrary",
-        "export async function onStudioVideoReplayError",
-        "hydrateFromBlobCache",
-        "rehydrateVideoFromBlob"
+        "hydrateFromBlobCache"
       ],
-      "rationale": "Single reload path for Studio video history (VideoStudio + BakeOff): IndexedDB hydrate after reload and on-demand IDB rehydrate before showing expired placeholders. Mirrors useStudioImageLibrary without s3Key presign — video passthrough keeps http urls out of localStorage (#944)."
+      "rationale": "Single reload path for Studio video history (VideoStudio + BakeOff): IndexedDB hydrate after reload. Mirrors useStudioImageLibrary without s3Key presign — video passthrough keeps http urls out of localStorage (#944)."
     },
     {
       "path": "frontend/src/composables/useStudioImagePreview.ts",

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -977,7 +977,10 @@
         "StudioVideoPreviewLightbox",
         "useStudioVideoPreview",
         "useStudioVideoCardActions",
-        "mountStudioVideoLibrary"
+        "mountStudioVideoLibrary",
+        "StudioVideoPreviewChecking",
+        "StudioVideoDownloadCard",
+        "videoTaskCardPresentation"
       ],
       "must_not_contain": [
         "poll.refreshUrl"
@@ -987,6 +990,8 @@
     {
       "path": "frontend/src/utils/studioMedia.tk.ts",
       "must_contain": [
+        "export function videoTaskCardPresentation",
+        "export function videoTaskPlaybackAvailable",
         "export function videoPlaybackUrl",
         "export function imageHistoryItemAvailable",
         "export function shouldShowStudioSaveReminder",
@@ -1061,6 +1066,24 @@
         "closePreview"
       ],
       "rationale": "Shared in-page image lightbox state for ImageStudio (mirrors useStudioVideoPreview from #1092). data: URIs cannot open in a new tab; preview stays in-page with Escape-to-close."
+    },
+    {
+      "path": "frontend/src/views/user/studio/components/StudioVideoDownloadCard.vue",
+      "must_contain": [
+        "studio-video-download-only",
+        "studio-video-download-primary",
+        "StudioPlaybackBadge",
+        "downloadOnlyHint"
+      ],
+      "rationale": "Download-first succeeded card when upstream http(s) URLs fail CORS inline preview (Seedance/VolcEngine). Replaces misleading play tile with primary download + copy-link — honest UX per #944 pass-through."
+    },
+    {
+      "path": "frontend/src/views/user/studio/components/StudioVideoPreviewChecking.vue",
+      "must_contain": [
+        "studio-video-checking",
+        "checkingPreview"
+      ],
+      "rationale": "Transient card while tagStudioVideoPlayback probes upstream CORS — no fake play tile before classification completes."
     },
     {
       "path": "frontend/src/views/user/studio/components/StudioImagePreviewLightbox.vue",


### PR DESCRIPTION
## 摘要

- 统一 `/studio` Image / Video / BakeOff 的预览、下载、copy-link、历史重载与过期态 owner：共享行为进入 composable / `*.tk.ts`，重复 UI 进入共享组件。
- Video 预览改为真实上游可用性语义：CORS 阻挡时显示不可内嵌/可下载/可复制的 honest 状态，不伪造可播放 tile。
- 移除未接线的 video replay-error helper 与对应 false contract，避免 sentinel / tests 保护不存在的运行时路径。
- dev-rules submodule 指向已合并的 `origin/main` commit `ae1788177`：全局 §5.1 只保留跨项目通用 SSOT 原则，TokenKey 具体 Studio owner 表留在本仓库 `CLAUDE.md` 与 `scripts/sentinels/frontend-tk.json`。

## 风险

- 前端行为变更集中在 Studio 媒体预览与历史恢复。
- CORS-gated video 不再表现为可内嵌播放；用户仍可下载或复制链接。
- `CLAUDE.md` / sentinel 增加的是 TokenKey 项目级 owner 锚点；dev-rules 只承载通用规则。

## 验证

- `pnpm --dir frontend exec vitest run src/composables/__tests__/useMediaLibrary.spec.ts src/composables/__tests__/useStudioImageLibrary.spec.ts src/composables/__tests__/useStudioImagePreview.spec.ts src/composables/__tests__/useStudioVideoLibrary.spec.ts src/composables/__tests__/useStudioVideoPreview.spec.ts src/utils/__tests__/studioImageHistory.tk.spec.ts src/utils/__tests__/studioMedia.tk.spec.ts src/utils/__tests__/studioPlaybackStorage.tk.spec.ts src/views/user/studio/__tests__/VideoStudio.spec.ts src/views/user/studio/__tests__/BakeOff.spec.ts`（65/65 pass）
- `pnpm --dir frontend run build`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`（PASS；dev-rules submodule SHA reachable on `origin/main`）

## 提交

- `33c0ff689` fix(studio): 统一 Image/Video 预览与重载 SSOT
- `c1b88f1da` fix(studio): honest CORS-gated video card (no fake play tile for upstream-cors-blocked)
- `366da6421` chore: bump dev-rules for Studio UI SSOT constitution §5.1
- `b557e84d0` fix(studio): align video library SSOT contract
- `31f90ab43` chore: update dev-rules Studio SSOT wording
- `8a9298ec1` chore: bump dev-rules to merged SSOT rule
- 最新提交：`8a9298ec1`
