### PR TITLE
fix(kiro): chat 路径经 TLS doer 解析 profileArn 并在缺失时 fail-closed

### DIFF
--- a/backend/internal/integration/kiro/client.go
+++ b/backend/internal/integration/kiro/client.go
@@ -397,18 +397,20 @@ func CallKiroAPIWithDoer(doer HTTPDoer, account *Account, payload *KiroPayload, 
 	}
 
 	if payload != nil && strings.TrimSpace(payload.ProfileArn) == "" {
-		if err := ensureProfileArn(account); err != nil {
-			logWarnf("[ProfileArn] Failed to resolve profile ARN for %s: %v", accountEmail(account), err)
-		} else {
-			payload.ProfileArn = strings.TrimSpace(account.ProfileArn)
+		if err := ensureProfileArnWithDoer(account, doer); err != nil {
+			return fmt.Errorf("resolve profileArn: %w", err)
 		}
+		payload.ProfileArn = strings.TrimSpace(account.ProfileArn)
+	}
+	if payload != nil && strings.TrimSpace(payload.ProfileArn) == "" {
+		return fmt.Errorf("profileArn is required for Kiro requests")
 	}
 
 	endpoints := getSortedEndpoints(GetPreferredEndpoint())
 	err := callKiroAPIOnce(doer, account, payload, callback, endpoints)
 	if isInvalidProfileArnError(err) {
 		logWarnf("[KiroAPI] stale profileArn for %s, re-resolving: %v", accountEmail(account), err)
-		if resolveErr := reresolveProfileArnAfterStale(account); resolveErr == nil && payload != nil {
+		if resolveErr := reresolveProfileArnAfterStaleWithDoer(account, doer); resolveErr == nil && payload != nil {
 			payload.ProfileArn = strings.TrimSpace(account.ProfileArn)
 			return callKiroAPIOnce(doer, account, payload, callback, endpoints)
 		}

--- a/backend/internal/integration/kiro/client_profile_arn_test.go
+++ b/backend/internal/integration/kiro/client_profile_arn_test.go
@@ -29,11 +29,42 @@ func (d *staleProfileChatDoer) Do(req *http.Request) (*http.Response, error) {
 			Header:     http.Header{},
 		}, nil
 	}
+	if strings.TrimSpace(payload.ProfileArn) == "" {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       io.NopCloser(strings.NewReader(`{"message":"profileArn is required for this request."}`)),
+			Header:     http.Header{},
+		}, nil
+	}
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(bytes.NewReader(nil)),
 		Header:     http.Header{},
 	}, nil
+}
+
+// restProxyDoer forwards control-plane REST calls to srv while delegating chat
+// traffic to inner. Mirrors edge TLS doer usage where profileArn resolution and
+// chat share the same transport.
+type restProxyDoer struct {
+	restHost string
+	inner    HTTPDoer
+}
+
+func (d *restProxyDoer) Do(req *http.Request) (*http.Response, error) {
+	if req.URL != nil && (strings.Contains(req.URL.Path, "ListAvailableProfiles") ||
+		strings.Contains(req.URL.Path, "getUsageLimits") ||
+		strings.Contains(req.URL.Host, "management.") ||
+		strings.Contains(req.URL.Host, "codewhisperer.")) {
+		cloned := req.Clone(req.Context())
+		cloned.URL.Scheme = "http"
+		cloned.URL.Host = d.restHost
+		return http.DefaultClient.Do(cloned)
+	}
+	if d.inner != nil {
+		return d.inner.Do(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
 }
 
 func TestCallKiroAPI_RetriesAfterStaleProfileArn(t *testing.T) {
@@ -49,9 +80,9 @@ func TestCallKiroAPI_RetriesAfterStaleProfileArn(t *testing.T) {
 		})
 	}))
 	defer srv.Close()
-	installTestRestClient(t, srv)
 
-	doer := &staleProfileChatDoer{}
+	chat := &staleProfileChatDoer{}
+	doer := &restProxyDoer{restHost: srv.Listener.Addr().String(), inner: chat}
 	account := &Account{
 		AccessToken:  "tok",
 		RefreshToken: "rt",
@@ -60,10 +91,49 @@ func TestCallKiroAPI_RetriesAfterStaleProfileArn(t *testing.T) {
 	if err := CallKiroAPIWithDoer(doer, account, &KiroPayload{}, nil); err != nil {
 		t.Fatalf("CallKiroAPIWithDoer() error = %v", err)
 	}
-	if doer.calls.Load() < 2 {
-		t.Fatalf("chat doer calls = %d, want at least 2 (stale pass then fresh retry)", doer.calls.Load())
+	if chat.calls.Load() < 2 {
+		t.Fatalf("chat doer calls = %d, want at least 2 (stale pass then fresh retry)", chat.calls.Load())
 	}
 	if got := account.ProfileArn; got != "arn:aws:codewhisperer:us-east-1:123456789012:profile/fresh" {
 		t.Fatalf("account.ProfileArn = %q, want fresh ARN", got)
+	}
+}
+
+func TestCallKiroAPI_ResolvesMissingProfileArnViaInjectedDoer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "ListAvailableProfiles") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []map[string]string{
+				{"arn": "arn:aws:codewhisperer:us-east-1:123456789012:profile/fresh"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	chat := &staleProfileChatDoer{}
+	doer := &restProxyDoer{restHost: srv.Listener.Addr().String(), inner: chat}
+	account := &Account{AccessToken: "tok", RefreshToken: "rt"}
+	if err := CallKiroAPIWithDoer(doer, account, &KiroPayload{}, nil); err != nil {
+		t.Fatalf("CallKiroAPIWithDoer() error = %v", err)
+	}
+	if chat.calls.Load() != 1 {
+		t.Fatalf("chat doer calls = %d, want 1", chat.calls.Load())
+	}
+	if got := account.ProfileArn; got != "arn:aws:codewhisperer:us-east-1:123456789012:profile/fresh" {
+		t.Fatalf("account.ProfileArn = %q, want resolved ARN", got)
+	}
+}
+
+func TestCallKiroAPI_FailsWhenProfileArnUnresolved(t *testing.T) {
+	account := &Account{AccessToken: "tok"}
+	err := CallKiroAPIWithDoer(&staleProfileChatDoer{}, account, &KiroPayload{}, nil)
+	if err == nil {
+		t.Fatal("CallKiroAPIWithDoer() expected error when profileArn cannot be resolved")
+	}
+	if !strings.Contains(err.Error(), "resolve profileArn") && !strings.Contains(err.Error(), "no available Kiro profile") {
+		t.Fatalf("error = %q, want profileArn resolution failure", err)
 	}
 }

--- a/backend/internal/integration/kiro/rest.go
+++ b/backend/internal/integration/kiro/rest.go
@@ -38,22 +38,26 @@ func kiroRestBases() []string { return []string{kiroManagementAPIBase, kiroRestA
 // instead folded into getUsageLimits (userInfo{email,userId} + subscriptionInfo),
 // which TK already parses. kiro.GetUserInfo has no caller in TK anyway.
 func kiroRestFetch(account *Account, method, path, body string, withParn bool) ([]byte, error) {
+	return kiroRestFetchWithDoer(account, method, path, body, withParn, nil)
+}
+
+func kiroRestFetchWithDoer(account *Account, method, path, body string, withParn bool, doer HTTPDoer) ([]byte, error) {
 	if withParn {
-		if err := ensureProfileArn(account); err != nil {
+		if err := ensureProfileArnWithDoer(account, doer); err != nil {
 			return nil, err
 		}
 	}
-	data, err := kiroRestFetchBases(account, method, path, body, withParn)
+	data, err := kiroRestFetchBases(account, method, path, body, withParn, doer)
 	if withParn && isInvalidProfileArnError(err) {
 		logWarnf("[KiroREST] stale profileArn for %s, re-resolving: %v", accountEmail(account), err)
-		if resolveErr := reresolveProfileArnAfterStale(account); resolveErr == nil {
-			return kiroRestFetchBases(account, method, path, body, withParn)
+		if resolveErr := reresolveProfileArnAfterStaleWithDoer(account, doer); resolveErr == nil {
+			return kiroRestFetchBases(account, method, path, body, withParn, doer)
 		}
 	}
 	return data, err
 }
 
-func kiroRestFetchBases(account *Account, method, path, body string, withParn bool) ([]byte, error) {
+func kiroRestFetchBases(account *Account, method, path, body string, withParn bool, doer HTTPDoer) ([]byte, error) {
 	var lastErr error
 	for _, base := range kiroRestBases() {
 		u := base + path
@@ -73,7 +77,7 @@ func kiroRestFetchBases(account *Account, method, path, body string, withParn bo
 		if body != "" {
 			req.Header.Set("Content-Type", "application/json")
 		}
-		resp, err := GetRestClientForProxy(ResolveAccountProxyURL(account)).Do(req)
+		resp, err := restHTTPDo(req, account, doer)
 		if err != nil {
 			lastErr = err
 			logWarnf("[KiroREST] %s %s failed: %v", method, base, err)
@@ -92,28 +96,45 @@ func kiroRestFetchBases(account *Account, method, path, body string, withParn bo
 }
 
 func ensureProfileArn(account *Account) error {
+	return ensureProfileArnWithDoer(account, nil)
+}
+
+func ensureProfileArnWithDoer(account *Account, doer HTTPDoer) error {
 	if account == nil {
 		return fmt.Errorf("account is nil")
 	}
-	_, err := ResolveProfileArn(account)
+	_, err := ResolveProfileArnWithDoer(account, doer)
 	return err
 }
 
 // reresolveProfileArnAfterStale clears a cached profileArn and fetches a fresh one.
 // Used when upstream returns HTTP 400 Invalid profileArn for REST and chat paths.
 func reresolveProfileArnAfterStale(account *Account) error {
+	return reresolveProfileArnAfterStaleWithDoer(account, nil)
+}
+
+func reresolveProfileArnAfterStaleWithDoer(account *Account, doer HTTPDoer) error {
 	if account == nil {
 		return fmt.Errorf("account is nil")
 	}
 	account.ProfileArn = ""
-	return ensureProfileArn(account)
+	return ensureProfileArnWithDoer(account, doer)
+}
+
+func restHTTPDo(req *http.Request, account *Account, doer HTTPDoer) (*http.Response, error) {
+	if doer != nil {
+		return doer.Do(req)
+	}
+	return GetRestClientForProxy(ResolveAccountProxyURL(account)).Do(req)
 }
 
 func isInvalidProfileArnError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(strings.ToLower(err.Error()), "invalid profilearn")
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "invalid profilearn") ||
+		strings.Contains(msg, "profilearn is required")
 }
 
 func accountEmail(account *Account) string {
@@ -191,6 +212,10 @@ func ListAvailableModels(account *Account) ([]ModelInfo, error) {
 // when it is missing. First tries ListAvailableProfiles; if that returns empty,
 // falls back to refreshing the token (which returns profileArn in the response).
 func ResolveProfileArn(account *Account) (string, error) {
+	return ResolveProfileArnWithDoer(account, nil)
+}
+
+func ResolveProfileArnWithDoer(account *Account, doer HTTPDoer) (string, error) {
 	if account == nil {
 		return "", fmt.Errorf("account is nil")
 	}
@@ -202,7 +227,7 @@ func ResolveProfileArn(account *Account) (string, error) {
 	// NOTE: persistence removed (vendor package does not write a DB). The
 	// resolved ARN is cached only on the in-memory account; the TokenKey layer
 	// is responsible for persisting account.ProfileArn after this returns.
-	profileArn, err := listAvailableProfilesWithRetry(account)
+	profileArn, err := listAvailableProfilesWithRetryWithDoer(account, doer)
 	if err == nil && profileArn != "" {
 		account.ProfileArn = profileArn
 		return profileArn, nil
@@ -221,6 +246,10 @@ func ResolveProfileArn(account *Account) (string, error) {
 }
 
 func listAvailableProfilesWithRetry(account *Account) (string, error) {
+	return listAvailableProfilesWithRetryWithDoer(account, nil)
+}
+
+func listAvailableProfilesWithRetryWithDoer(account *Account, doer HTTPDoer) (string, error) {
 	// Retry transient failures (network errors, 5xx, 429) with short backoff.
 	// An empty profile list or 4xx (other than 429) is treated as authoritative
 	// and not retried — they reflect account state, not upstream flakiness.
@@ -229,7 +258,7 @@ func listAvailableProfilesWithRetry(account *Account) (string, error) {
 
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		profileArn, err := listAvailableProfiles(account)
+		profileArn, err := listAvailableProfilesWithDoer(account, doer)
 		if err == nil {
 			return profileArn, nil
 		}
@@ -264,7 +293,11 @@ func isTransientProfileFetchError(err error) bool {
 }
 
 func listAvailableProfiles(account *Account) (string, error) {
-	data, err := kiroRestFetch(account, "POST", "/ListAvailableProfiles", `{"maxResults":10}`, false)
+	return listAvailableProfilesWithDoer(account, nil)
+}
+
+func listAvailableProfilesWithDoer(account *Account, doer HTTPDoer) (string, error) {
+	data, err := kiroRestFetchWithDoer(account, "POST", "/ListAvailableProfiles", `{"maxResults":10}`, false, doer)
 	if err != nil {
 		return "", err
 	}

--- a/backend/internal/integration/kiro/rest_test.go
+++ b/backend/internal/integration/kiro/rest_test.go
@@ -143,6 +143,9 @@ func TestIsInvalidProfileArnError(t *testing.T) {
 	if !isInvalidProfileArnError(fmt.Errorf(`HTTP 400 from https://codewhisperer.us-east-1.amazonaws.com: {"message":"Invalid profileArn."}`)) {
 		t.Fatal("expected invalid profileArn detection")
 	}
+	if !isInvalidProfileArnError(fmt.Errorf(`HTTP 400 from https://runtime.us-east-1.kiro.dev: {"message":"profileArn is required for this request."}`)) {
+		t.Fatal("expected missing profileArn detection")
+	}
 	if isInvalidProfileArnError(fmt.Errorf("HTTP 401: unauthorized")) {
 		t.Fatal("401 should not match invalid profileArn")
 	}

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -129,6 +129,7 @@ func newKiroAccountForTest() *Account {
 		Credentials: map[string]any{
 			"access_token":  "at",
 			"refresh_token": "rt",
+			"profile_arn":   "arn:aws:codewhisperer:us-east-1:123456789012:profile/test",
 			"region":        "us-east-1",
 			"auth_method":   "social",
 		},

--- a/backend/internal/service/ratelimit_service_tk_kiro_quota402_test.go
+++ b/backend/internal/service/ratelimit_service_tk_kiro_quota402_test.go
@@ -18,6 +18,11 @@ func newEdgeUS4KiroAccount() *Account {
 		Name:     "kiro-us4-real",
 		Platform: PlatformKiro,
 		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token":  "at",
+			"refresh_token": "rt",
+			"profile_arn":   "arn:aws:codewhisperer:us-east-1:123456789012:profile/test",
+		},
 	}
 }
 

--- a/backend/internal/service/ratelimit_service_tk_oauth401_test.go
+++ b/backend/internal/service/ratelimit_service_tk_oauth401_test.go
@@ -359,6 +359,7 @@ func newKiroOAuth401Account(id int64, expiresAt time.Time) *Account {
 			"client_id":     "cid",
 			"client_secret": "secret",
 			"region":        "us-east-1",
+			"profile_arn":   "arn:aws:codewhisperer:us-east-1:123456789012:profile/test",
 		},
 	}
 }


### PR DESCRIPTION
## 摘要

- `runtime.us-east-1.kiro.dev` 要求 chat 请求体带 `profileArn`；edge-us5 `kiro-us5` 测试连接曾返回 `400: profileArn is required for this request`。
- 修复：`ListAvailableProfiles` / profileArn 解析与 chat 共用注入的 TLS doer；解析失败 fail-closed，不再发无 ARN 请求；`profileArn is required` 与 `Invalid profileArn` 一样触发重解析重试。
- CI 修复：OAuth401 相关测试 fixture 补上 `profile_arn`，避免在到达上游 mock 前被 fail-closed 拦截。

## 风险

- 常规风险：仅影响 Kiro OAuth 账号在缺/过期 `profile_arn` 时的控制面解析与 chat 前置校验。
- 解析仍失败时错误从模糊 400 变为明确的 `resolve profileArn: ...`，便于运维判断是否要重刷 OAuth。

## 验证

```bash
cd backend && go test -tags=unit ./internal/integration/kiro/... ./internal/service/... -run 'ProfileArn|KiroOAuth|Kiro402|KiroGateway' -count=1
cd backend && go test -tags=unit ./internal/service/... -count=1
./scripts/preflight.sh
```

- preflight：PASS
- kiro 相关单元测试 + 全量 service unit：PASS

## 提交

- `fd1b89ccf` fix(kiro): chat 路径经 TLS doer 解析 profileArn 并在缺失时 fail-closed
- `d60e7b880` test(kiro): OAuth401 测试 fixture 补上 profile_arn

最新提交：d60e7b880

sentinel-registry-reviewed
