### PR TITLE
fix(gateway): 出站 Messages 归一化 CC 地域隐写为 US 形态

### DIFF
--- a/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
+++ b/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tokenkey-cc-fingerprint-alignment
 description: >-
-  Capture real Claude Code TLS/HTTP fingerprints and diff/fix TokenKey constants. Use after cc version changes, ingress UA cohort drift, OAuth mimicry/beta/stainless drift, or refreshing tk_canonical_cc_oauth alignment.
+  Capture real Claude Code TLS/HTTP fingerprints and diff/fix TokenKey constants. Use after cc version changes, ingress UA cohort drift, OAuth mimicry/beta/stainless drift, CC geo-stego body drift (system/messages/system-reminder), or refreshing tk_canonical_cc_oauth alignment.
 ---
 
 # TokenKey：cc 指纹对齐（抓包 → diff → 修代码 → PR）
@@ -63,6 +63,8 @@ TOKENKEY_CC_DAILY_DRY_RUN=1 bash ops/anthropic/cc_fingerprint_open_tls_drift_pr.
 | TLS collector 采集 ClientHello | 机械 | `bash ops/anthropic/capture-cc-fingerprint.sh capture` |
 | HTTP mitm 采集 `/v1/messages` headers | 机械 | `bash ops/anthropic/capture-cc-fingerprint.sh capture --http` |
 | system prompt 锚点抓取 + diff（身份 banner + 计费前缀） | 机械 | mitm addon 记 `system_anchors` → `capture_cc_fingerprint.py check` 的 `system.*` 行 |
+| CC geo-stego wire body 矩阵（system / messages `<system-reminder>` / date_change） | 机械 | `bash ops/anthropic/probe_cc_geo_stego_direct.sh` → `probe_cc_geo_stego.py` |
+| geo-stego 归一化目标 vs 客户端实测 diff | 机械 | `probe_cc_geo_stego.py --check`（`needs_normalize=true` → 扩展 `gateway_request_tk_cc_geo_stego.go`） |
 | system prompt 副本单一源守卫（Go 3+ 处不漂） | 机械 | `python3 scripts/sentinels/check-cc-system-prompt.py`（preflight 内）|
 | 多请求 beta 一致性校验（haiku/sonnet/opus 各 N 次） | 机械 | `bash ops/anthropic/capture-http-comprehensive.sh` |
 | bundle 组装 + diff + `--check` 门禁 | 机械 | `capture_cc_fingerprint.py` / `check-tls` |
@@ -172,6 +174,65 @@ bash ops/anthropic/capture-http-comprehensive.sh
 
 任一 model 族出现 `WARN`（多种 beta）→ 在 PR / spec-delta 中记录分布，**禁止**在未抓包证据下改 beta 常量。
 
+### 2.6 Geo stego / wire body shape（**仅 claude CLI + mitm，无 cc0/gost**）
+
+CC ≥2.1.91 在**非** `api.anthropic.com` 的 `ANTHROPIC_BASE_URL` 下，把地域信号写进 **出站 JSON body**，不是 HTTP header。动态实测（2026-06）结论：
+
+| 表面 | 典型内容 | TokenKey 是否应改写 |
+|---|---|---|
+| `system[]` | Agent SDK 身份 banner；`-p` 模式通常**不含** `# currentDate` | 扫描但多数 no-op |
+| `messages[].content[].text` | `<system-reminder>` + `# currentDate` + `Today's date is …` | **是**（主战场） |
+| `messages[].content[].attachment` | `type=date_change` 的 `newDate` | **是** |
+| `# Environment` / billing block | 本机 TZ、proxy 字符串 | **否**（客户端环境自述，非隐写） |
+
+**触发器：** cc patch bump 后怀疑 geo 分支变化；Reddit/社区报新引号码点或日期格式；或 TokenKey 网关 normalize 回归。
+
+**环境（ deliberately 不用 cc0-here / gost）：**
+
+```bash
+~/.local/bin/claude --version          # ground truth cc patch
+# mitm CA 一次性：mitmproxy --version
+# OAuth + 默认 ANTHROPIC_BASE_URL 来自 ~/.claude/settings.json；矩阵内按场景覆盖
+```
+
+**一键矩阵采集 + 报告：**
+
+```bash
+cd "$REPO_ROOT"
+bash ops/anthropic/probe_cc_geo_stego_direct.sh
+# 输出：.tls_list/geo-stego-direct-*/capture.jsonl + report.txt + report.json
+```
+
+默认场景（可用 `TOKENKEY_CC_GEO_SCENARIOS="name|tz|base_url,..."` 覆盖）：
+
+| scenario | TZ | ANTHROPIC_BASE_URL | 预期客户端信号（2026-06 实测） |
+|---|---|---|---|
+| `shanghai_tokenkey` | Asia/Shanghai | `https://api.tokenkey.dev` | 日期 `/` + 通常 ASCII `'` |
+| `utc_tokenkey` | UTC | `https://api.tokenkey.dev` | 日期 `-` |
+| `shanghai_official` | Asia/Shanghai | `https://api.anthropic.com` | 无 geo 分支（对照组） |
+| `shanghai_mirror` | Asia/Shanghai | `https://api.aicodemirror.com` | 日期 `/` + U+2019 |
+
+CC 读 **`ANTHROPIC_BASE_URL` hostname** 选 geo 分支（不是 `http_proxy` 字符串）。probe 在 `/tmp` 下跑 `claude -p`，HTTPS 经 `mitmdump` 截获完整 body。
+
+**解读 `report.txt`：**
+
+- `surface=messages[…].content[…].text` + `needs_normalize=true` → 必须在 TokenKey 出站改写（见 `gateway_request_tk_cc_geo_stego.go`）。
+- `apostrophe=RIGHT_SINGLE_QUOTATION_U+2019` / `format=SLASH` → 应对齐为 ASCII `'` + `ISO_DASH`。
+- `surface=system[…]` 命中但 messages 也有 → **以 messages 为准** 开 PR；system-only 命中先记 evidence，勿单独改 banner 常量。
+- `--check` 非零 = 仍有场景需 normalize 规则覆盖。
+
+**修复清单（geo body，常规风险）：**
+
+1. 扩展 `gateway_request_tk_cc_geo_stego.go` 纯函数 + `gateway_request_tk_cc_geo_stego_test.go` table cases（先跑 probe 拿真实 line 作 fixture）。
+2. 确认三条出站路径均已挂接：`tkNormalizeAnthropicRequestBody`、API Key passthrough Forward、count_tokens API Key passthrough（见 `gateway_service.go`）。
+3. 更新 `scripts/sentinels/gateway-tk.json` rationale / `must_contain`（load-bearing）。
+4. `go test -tags=unit ./internal/service -run TestTkNormalizeCCGeo` + `python3 -m unittest ops/anthropic/test_probe_cc_geo_stego.py`。
+5. PR commit 带 `Web impact: none`；**不写** beta/UA spec-delta（与 §4.1–4.2 无关）。
+
+> **与 §2.4 的分工：** §2.4 `capture --http` 仍走 cc0+gost 链，抓 **HTTP headers + system 锚点**；§2.6 专抓 **body 地域隐写**，工具链独立，避免把 cc0 依赖混进 geo 判定。
+
+> **与 §4.3 的分工：** §4.3 对齐 **身份 banner** 锚点（防 403）；§2.6 对齐 **currentDate 行**（防 CN 客户端 + US edge 不一致）。勿用 system banner 规则去改 `<system-reminder>` 日期行。
+
 > **双峰（bimodal）beta 不再被当成硬 mismatch。** `bundle-from-artifacts` 现在把每个 model 族的**全量** beta 分布写进 bundle 的 `http_variants`（不再 last-wins 取一条样本）。`diff` / `check` 对一个族的判定规则：
 > - 单一 beta 集合 → 老逻辑 `OK` / `FAIL`。
 > - 出现 ≥2 种 beta 集合且 baseline 命中其中之一 → `INVESTIGATE`（`needs_investigation`，**不**计入 `has_actionable_mismatch`，`check` 退 0）。报告里给出 `[Nx] <beta>` 计数分布 + #429 提示。
@@ -192,6 +253,8 @@ bash ops/anthropic/capture-http-comprehensive.sh
 | `system.identity_anchor` (`FAIL`) | 真实 CC system 块不命中任一 canonical 身份锚点 = banner 漂移（上游 403 风险，**actionable**）| 走 §4.3：改注册表 + Go 副本 + spec-delta |
 | `system.identity_anchor` (`SKIP`) | 本次未抓到 system 块（仅 TLS 跑）| 跑 `capture --http` 再看 |
 | `system.billing_prefix` (`INVESTIGATE`) | 未见 `x-anthropic-billing-header` 块 → 非硬错 | count_tokens / 子请求本就不带；仅当正常 `/v1/messages` 也缺才查 |
+| `geo.messages.currentDate` (`FAIL`) | messages `<system-reminder>` 日期行非 US 形态 | §2.6 probe + `gateway_request_tk_cc_geo_stego.go` |
+| `geo.date_change.newDate` (`FAIL`) | attachment 日期仍为 `/` | 同上 |
 
 ## 4) 代码修复清单（HTTP-only 型）
 
@@ -280,12 +343,15 @@ bash ops/anthropic/cc_fingerprint_apply_http_runtime.sh
 - ja3 变了却只改 HTTP 常量
 - 用 `cc0-here` 直接做 HTTP mitm（应走 `http_capture_invoke.sh`）
 - 跳过 comprehensive 直接开 PR（beta 分裂未验证）
+- 未跑 §2.6 probe 就扩展 geo normalize 规则（须用真实 `capture.jsonl` line 作测试 fixture）
+- 把 `# Environment` 段 TZ/proxy 字符串当作 TokenKey 应改写的隐写
 
 ## 7) 流程图
 
 ```text
 check env → capture --http → comprehensive (beta consistency)
     → check / check-tls
+    → [geo body?] probe_cc_geo_stego_direct.sh → probe_cc_geo_stego.py --check
     → [ja3变?] manage-anthropic-config apply + TLS drift PR
     → [仅UA/版本?] 编辑 baselines.json cc_version → check-cc-version-sync --write（自动改全部副本）→ changelog 追加一行（不写独立 spec-delta）
     → [beta集合变?] baselines 数组 + constants betas + tests + 主题命名 spec-delta 决策记录 + changelog 一行（§4.2，需抓包证据）

--- a/backend/internal/service/gateway_anthropic_request_normalize_tk.go
+++ b/backend/internal/service/gateway_anthropic_request_normalize_tk.go
@@ -27,6 +27,11 @@ import (
 //     report (strategy A), we strip the thinking field — the client's
 //     forced-tool-use intent wins.
 //
+//  3. Claude Code geo steganography in system / system-reminder text (date
+//     separator + Unicode apostrophe variants when BASE_URL is not
+//     api.anthropic.com). Rewritten to first-party US shape before US edge
+//     egress. See gateway_request_tk_cc_geo_stego.go.
+//
 // Scope: only the standard forward path (gateway_service.Forward — i.e. all
 // Anthropic-platform requests EXCEPT IsAnthropicAPIKeyPassthroughEnabled and
 // Bedrock, both of which early-return before this hook). The hook runs once
@@ -84,6 +89,11 @@ func (s *GatewayService) tkNormalizeAnthropicRequestBody(ctx context.Context, c 
 	if patched, applied := tkNormalizeAnthropicThinkingForcesToolUse(next); applied {
 		next = patched
 		changes = append(changes, tkNormalizeChangeThinkingForcesToolUse)
+	}
+
+	if patched, applied := tkNormalizeAnthropicCCGeoStego(next); applied {
+		next = patched
+		changes = append(changes, tkNormalizeChangeCCGeoStego)
 	}
 
 	if len(changes) == 0 {

--- a/backend/internal/service/gateway_request_tk_cc_geo_stego.go
+++ b/backend/internal/service/gateway_request_tk_cc_geo_stego.go
@@ -1,0 +1,182 @@
+package service
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// TokenKey: normalize Claude Code client geo steganography in outbound
+// /v1/messages bodies before they reach US OAuth edges.
+//
+// CC ≥2.1.91 embeds region signals in user-visible prompt text when
+// ANTHROPIC_BASE_URL is not api.anthropic.com:
+//   - TZ Asia/Shanghai | Asia/Urumqi → date uses YYYY/MM/DD instead of YYYY-MM-DD
+//   - known mirror BASE_URL host → Unicode apostrophe in "Today's date is ..."
+//   - lab keyword in host → other apostrophe codepoints
+//
+// TokenKey cannot control the user's machine, but we can rewrite the wire body
+// to the first-party shape (ASCII apostrophe + dashed ISO date) so upstream
+// does not see "client says CN, egress says US". Observed in Agent SDK -p
+// traffic under messages[].content[].text <system-reminder> (#currentDate),
+// not in system[] billing blocks.
+//
+// Pure functions only — wired from gateway_anthropic_request_normalize_tk.go
+// and the Anthropic API-key passthrough path.
+
+const tkNormalizeChangeCCGeoStego tkAnthropicNormalizeChange = "cc_geo_stego_normalized"
+
+var (
+	tkCCGeoStegoTodayDateRE    = regexp.MustCompile("Today[''\u2019\u02bc\u02b9]s date is (\\d{4})[/-](\\d{2})[/-](\\d{2})\\.")
+	tkCCGeoStegoTodayDateNowRE = regexp.MustCompile("Today[''\u2019\u02bc\u02b9]s date is now (\\d{4})[/-](\\d{2})[/-](\\d{2})\\.")
+	tkCCGeoStegoDateTokenRE    = regexp.MustCompile(`^(\d{4})[/-](\d{2})[/-](\d{2})$`)
+)
+
+func tkNormalizeCCGeoStegoText(text string) (string, bool) {
+	if text == "" || (!strings.Contains(text, "Today") && !strings.Contains(text, "date is now")) {
+		return text, false
+	}
+	out := tkCCGeoStegoTodayDateNowRE.ReplaceAllString(text, "Today's date is now $1-$2-$3.")
+	out = tkCCGeoStegoTodayDateRE.ReplaceAllString(out, "Today's date is $1-$2-$3.")
+	return out, out != text
+}
+
+func tkNormalizeCCGeoDateToken(date string) (string, bool) {
+	trimmed := strings.TrimSpace(date)
+	m := tkCCGeoStegoDateTokenRE.FindStringSubmatch(trimmed)
+	if len(m) != 4 {
+		return date, false
+	}
+	canon := m[1] + "-" + m[2] + "-" + m[3]
+	if canon == trimmed {
+		return date, false
+	}
+	return canon, true
+}
+
+func tkNormalizeAnthropicCCGeoStego(body []byte) ([]byte, bool) {
+	if len(body) == 0 {
+		return body, false
+	}
+
+	out := body
+	changed := false
+
+	if patched, applied := tkNormalizeAnthropicCCGeoStegoSystem(out); applied {
+		out = patched
+		changed = true
+	}
+	if patched, applied := tkNormalizeAnthropicCCGeoStegoMessages(out); applied {
+		out = patched
+		changed = true
+	}
+	return out, changed
+}
+
+func tkNormalizeAnthropicCCGeoStegoSystem(body []byte) ([]byte, bool) {
+	system := gjson.GetBytes(body, "system")
+	if !system.Exists() {
+		return body, false
+	}
+
+	switch system.Type {
+	case gjson.String:
+		newText, ok := tkNormalizeCCGeoStegoText(system.String())
+		if !ok {
+			return body, false
+		}
+		out, err := sjson.SetBytes(body, "system", newText)
+		if err != nil {
+			return body, false
+		}
+		return out, true
+	case gjson.JSON:
+		if !system.IsArray() {
+			return body, false
+		}
+		out := body
+		changed := false
+		for i, item := range system.Array() {
+			if item.Get("type").String() != "text" {
+				continue
+			}
+			text := item.Get("text").String()
+			newText, ok := tkNormalizeCCGeoStegoText(text)
+			if !ok {
+				continue
+			}
+			path := fmt.Sprintf("system.%d.text", i)
+			next, err := sjson.SetBytes(out, path, newText)
+			if err != nil {
+				continue
+			}
+			out = next
+			changed = true
+		}
+		return out, changed
+	default:
+		return body, false
+	}
+}
+
+func tkNormalizeAnthropicCCGeoStegoMessages(body []byte) ([]byte, bool) {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return body, false
+	}
+
+	out := body
+	changed := false
+	for mi, msg := range messages.Array() {
+		content := msg.Get("content")
+		switch content.Type {
+		case gjson.String:
+			newText, ok := tkNormalizeCCGeoStegoText(content.String())
+			if !ok {
+				continue
+			}
+			path := fmt.Sprintf("messages.%d.content", mi)
+			next, err := sjson.SetBytes(out, path, newText)
+			if err != nil {
+				continue
+			}
+			out = next
+			changed = true
+		case gjson.JSON:
+			if !content.IsArray() {
+				continue
+			}
+			for ci, block := range content.Array() {
+				blockType := block.Get("type").String()
+				if blockType == "text" {
+					text := block.Get("text").String()
+					newText, ok := tkNormalizeCCGeoStegoText(text)
+					if ok {
+						path := fmt.Sprintf("messages.%d.content.%d.text", mi, ci)
+						next, err := sjson.SetBytes(out, path, newText)
+						if err == nil {
+							out = next
+							changed = true
+						}
+					}
+				}
+				if block.Get("attachment.type").String() == "date_change" {
+					date := block.Get("attachment.newDate").String()
+					newDate, ok := tkNormalizeCCGeoDateToken(date)
+					if ok {
+						path := fmt.Sprintf("messages.%d.content.%d.attachment.newDate", mi, ci)
+						next, err := sjson.SetBytes(out, path, newDate)
+						if err == nil {
+							out = next
+							changed = true
+						}
+					}
+				}
+			}
+		}
+	}
+	return out, changed
+}

--- a/backend/internal/service/gateway_request_tk_cc_geo_stego_test.go
+++ b/backend/internal/service/gateway_request_tk_cc_geo_stego_test.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestTkNormalizeCCGeoStegoText(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		changed bool
+	}{
+		{
+			name:    "shanghai slash date ascii apostrophe",
+			in:      "# currentDate\nToday's date is 2026/06/30.\n\nIMPORTANT",
+			want:    "# currentDate\nToday's date is 2026-06-30.\n\nIMPORTANT",
+			changed: true,
+		},
+		{
+			name:    "known mirror unicode apostrophe",
+			in:      "Today\u2019s date is 2026/06/30.",
+			want:    "Today's date is 2026-06-30.",
+			changed: true,
+		},
+		{
+			name:    "lab keyword apostrophe",
+			in:      "Today\u02BCs date is 2026/06/30.",
+			want:    "Today's date is 2026-06-30.",
+			changed: true,
+		},
+		{
+			name:    "both signals apostrophe",
+			in:      "Today\u02B9s date is 2026/06/30.",
+			want:    "Today's date is 2026-06-30.",
+			changed: true,
+		},
+		{
+			name:    "date change meta line",
+			in:      "The date has changed. Today\u2019s date is now 2026/06/30.",
+			want:    "The date has changed. Today's date is now 2026-06-30.",
+			changed: true,
+		},
+		{
+			name:    "already canonical",
+			in:      "Today's date is 2026-06-30.",
+			want:    "Today's date is 2026-06-30.",
+			changed: false,
+		},
+		{
+			name:    "unrelated text",
+			in:      "hello world",
+			want:    "hello world",
+			changed: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, changed := tkNormalizeCCGeoStegoText(tc.in)
+			require.Equal(t, tc.changed, changed)
+			require.Equal(t, tc.want, out)
+		})
+	}
+}
+
+func TestTkNormalizeAnthropicCCGeoStegoMessagesSystemReminder(t *testing.T) {
+	in := []byte(`{
+		"model":"claude-sonnet-4-6",
+		"system":[{"type":"text","text":"You are a Claude agent, built on Anthropic's Claude Agent SDK."}],
+		"messages":[{"role":"user","content":[
+			{"type":"text","text":"<system-reminder>\n# currentDate\nToday\u2019s date is 2026/06/30.\n</system-reminder>"}
+		]}]
+	}`)
+	out, changed := tkNormalizeAnthropicCCGeoStego(in)
+	require.True(t, changed)
+	got := gjson.GetBytes(out, "messages.0.content.0.text").String()
+	require.Contains(t, got, "Today's date is 2026-06-30.")
+	require.NotContains(t, got, "\u2019")
+	require.NotContains(t, got, "/06/")
+}
+
+func TestTkNormalizeAnthropicCCGeoStegoDateChangeAttachment(t *testing.T) {
+	in := []byte(`{"messages":[{"role":"user","content":[
+		{"type":"text","text":"hi","attachment":{"type":"date_change","newDate":"2026/06/30"}}
+	]}]}`)
+	out, changed := tkNormalizeAnthropicCCGeoStego(in)
+	require.True(t, changed)
+	require.Equal(t, "2026-06-30", gjson.GetBytes(out, "messages.0.content.0.attachment.newDate").String())
+}
+
+func TestTkNormalizeAnthropicCCGeoStegoNoOpWhenClean(t *testing.T) {
+	in := []byte(`{"messages":[{"role":"user","content":"Today's date is 2026-06-30."}]}`)
+	out, changed := tkNormalizeAnthropicCCGeoStego(in)
+	require.False(t, changed)
+	require.Equal(t, string(in), string(out))
+}
+
+func TestTkNormalizeAnthropicRequestBodyAppliesCCGeoStego(t *testing.T) {
+	svc := newNormalizeTestService(t, "true")
+	in := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"Today\u2019s date is 2026/06/30."}]}]}`)
+	out := svc.tkNormalizeAnthropicRequestBody(context.Background(), nil, in)
+	require.Contains(t, string(out), "Today's date is 2026-06-30.")
+}

--- a/backend/internal/service/gateway_request_tk_cc_geo_stego_test.go
+++ b/backend/internal/service/gateway_request_tk_cc_geo_stego_test.go
@@ -2,8 +2,14 @@ package service
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -104,4 +110,32 @@ func TestTkNormalizeAnthropicRequestBodyAppliesCCGeoStego(t *testing.T) {
 	in := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"Today\u2019s date is 2026/06/30."}]}]}`)
 	out := svc.tkNormalizeAnthropicRequestBody(context.Background(), nil, in)
 	require.Contains(t, string(out), "Today's date is 2026-06-30.")
+}
+
+func TestForwardCountTokensAnthropicAPIKeyPassthrough_NormalizesCCGeoStego(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", nil)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":[{"type":"text","text":"Today\u2019s date is 2026/06/30."}]}]}`)
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-sonnet-4-6"}
+
+	upstream := &anthropicHTTPUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"input_tokens":10}`)),
+		},
+	}
+
+	svc := newNormalizeTestService(t, "true")
+	svc.cfg = &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}
+	svc.httpUpstream = upstream
+
+	err := svc.ForwardCountTokens(context.Background(), c, newAnthropicAPIKeyAccountForTest(), parsed)
+	require.NoError(t, err)
+	require.Contains(t, string(upstream.lastBody), "Today's date is 2026-06-30.")
+	require.NotContains(t, string(upstream.lastBody), "\u2019")
+	require.NotContains(t, string(upstream.lastBody), "/06/")
 }

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6113,6 +6113,19 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 			return nil, err
 		}
 	}
+	// TK: CC geo stego normalize only (passthrough skips the full normalize hook).
+	if s != nil && s.settingService != nil && s.settingService.IsAnthropicRequestNormalizeEnabled(ctx) {
+		if patched, applied := tkNormalizeAnthropicCCGeoStego(input.Body); applied {
+			input.Body = patched
+			tkLogAnthropicNormalize(ctx, []tkAnthropicNormalizeChange{tkNormalizeChangeCCGeoStego})
+			tkRecordAnthropicNormalizeOpsEvent(c, []tkAnthropicNormalizeChange{tkNormalizeChangeCCGeoStego})
+			if input.Parsed != nil {
+				if err := input.Parsed.ReplaceBody(input.Body); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
 	// TK: ToolSearch + stale signed thinking pre-filter (claude-code #63792 / #10199).
 	input.Body = TkPrefilterToolSearchHistoricalThinking(input.Body, input.RequestModel)
 

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -10993,6 +10993,14 @@ func (s *GatewayService) forwardCountTokensAnthropicAPIKeyPassthrough(ctx contex
 			"fields", stripped,
 		)
 	}
+	// TK: CC geo stego normalize only (passthrough skips the full normalize hook).
+	if s != nil && s.settingService != nil && s.settingService.IsAnthropicRequestNormalizeEnabled(ctx) {
+		if patched, applied := tkNormalizeAnthropicCCGeoStego(body); applied {
+			body = patched
+			tkLogAnthropicNormalize(ctx, []tkAnthropicNormalizeChange{tkNormalizeChangeCCGeoStego})
+			tkRecordAnthropicNormalizeOpsEvent(c, []tkAnthropicNormalizeChange{tkNormalizeChangeCCGeoStego})
+		}
+	}
 
 	upstreamReq, err := s.buildCountTokensRequestAnthropicAPIKeyPassthrough(ctx, c, account, body, token)
 	if err != nil {

--- a/ops/anthropic/probe_cc_geo_stego.py
+++ b/ops/anthropic/probe_cc_geo_stego.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Analyze CC /v1/messages wire body for geo-steganography signals.
+
+Reads mitm JSONL from probe_cc_geo_stego_mitm.py. Surfaces live in:
+  - system[] text blocks (Agent SDK / billing banner — usually NOT #currentDate)
+  - messages[].content[].text <system-reminder> # currentDate (primary CC ≥2.1.91)
+  - messages[].content[].attachment.type=date_change newDate
+
+TokenKey egress canonical shape (gateway_request_tk_cc_geo_stego.go):
+  ASCII apostrophe U+0027 + ISO date YYYY-MM-DD.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DATE_LINE = re.compile(
+    r"(Today.?s date is(?: now)?|The current date is|Current date:?)\s*(.+)",
+    re.IGNORECASE,
+)
+APOSTROPHE_NAMES = {
+    "\u0027": "ASCII_APOSTROPHE_U+0027",
+    "\u2019": "RIGHT_SINGLE_QUOTATION_U+2019",
+    "\u02bc": "MODIFIER_LETTER_APOSTROPHE_U+02BC",
+    "\u02b9": "MODIFIER_LETTER_PRIME_U+02B9",
+}
+CANONICAL_APOSTROPHE = "ASCII_APOSTROPHE_U+0027"
+CANONICAL_DATE_FORMAT = "ISO_DASH"
+
+
+def classify_apostrophe_in_date_line(line: str) -> str | None:
+    m = DATE_LINE.search(line)
+    if not m:
+        return None
+    prefix = m.group(0)[: m.start(2) - m.start(0)]
+    for ch, name in APOSTROPHE_NAMES.items():
+        if ch in prefix:
+            return name
+    return "NO_SPECIAL_APOSTROPHE"
+
+
+def classify_date_value(raw: str) -> dict:
+    raw = raw.strip().rstrip(".")
+    out = {"raw": raw[:80]}
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", raw):
+        out["format"] = "ISO_DASH"
+    elif re.fullmatch(r"\d{4}/\d{2}/\d{2}", raw):
+        out["format"] = "SLASH"
+    else:
+        out["format"] = "OTHER"
+    return out
+
+
+def extract_system_texts(system) -> list[str]:
+    texts: list[str] = []
+    if isinstance(system, str):
+        if system.strip():
+            texts.append(system.strip())
+        return texts
+    if isinstance(system, list):
+        for entry in system:
+            if isinstance(entry, dict):
+                t = str(entry.get("text") or "").strip()
+                if t:
+                    texts.append(t)
+            elif isinstance(entry, str) and entry.strip():
+                texts.append(entry.strip())
+    return texts
+
+
+def _date_line_records(texts: list[str], surface: str) -> list[dict]:
+    rows: list[dict] = []
+    for i, text in enumerate(texts):
+        for line in text.splitlines():
+            m = DATE_LINE.search(line)
+            if not m:
+                continue
+            apostrophe = classify_apostrophe_in_date_line(line)
+            date = classify_date_value(m.group(2))
+            rows.append(
+                {
+                    "surface": surface,
+                    "block_index": i,
+                    "line": line.strip()[:200],
+                    "apostrophe": apostrophe,
+                    "date": date,
+                    "needs_normalize": (
+                        apostrophe not in (None, CANONICAL_APOSTROPHE, "NO_SPECIAL_APOSTROPHE")
+                        or date.get("format") != CANONICAL_DATE_FORMAT
+                    ),
+                }
+            )
+    return rows
+
+
+def _message_date_lines(messages) -> list[dict]:
+    rows: list[dict] = []
+    if not isinstance(messages, list):
+        return rows
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role") or "")
+        mi = msg.get("index")
+        for block in msg.get("text_blocks") or []:
+            for line in block.get("date_lines") or []:
+                m = DATE_LINE.search(line)
+                if not m:
+                    continue
+                apostrophe = classify_apostrophe_in_date_line(line)
+                date = classify_date_value(m.group(2))
+                rows.append(
+                    {
+                        "surface": f"messages[{mi}].content[{block.get('index')}].text",
+                        "role": role,
+                        "has_system_reminder": block.get("has_system_reminder"),
+                        "line": line.strip()[:200],
+                        "apostrophe": apostrophe,
+                        "date": date,
+                        "needs_normalize": (
+                            apostrophe not in (None, CANONICAL_APOSTROPHE, "NO_SPECIAL_APOSTROPHE")
+                            or date.get("format") != CANONICAL_DATE_FORMAT
+                        ),
+                    }
+                )
+        for att in msg.get("date_change_attachments") or []:
+            raw = str(att.get("newDate") or "")
+            date = classify_date_value(raw)
+            rows.append(
+                {
+                    "surface": f"messages[{mi}].content[{att.get('content_index')}].attachment.newDate",
+                    "line": raw[:80],
+                    "apostrophe": None,
+                    "date": date,
+                    "needs_normalize": date.get("format") != CANONICAL_DATE_FORMAT,
+                }
+            )
+    return rows
+
+
+def analyze_record(rec: dict) -> dict:
+    body = rec.get("body") or {}
+    system = body.get("system")
+    system_texts = extract_system_texts(system)
+    date_lines = _date_line_records(system_texts, "system")
+    date_lines.extend(_message_date_lines(body.get("messages")))
+    needs_normalize = any(dl.get("needs_normalize") for dl in date_lines)
+    return {
+        "scenario": rec.get("scenario"),
+        "tz": rec.get("tz"),
+        "proxy": rec.get("proxy"),
+        "base_url": rec.get("base_url"),
+        "host": rec.get("host"),
+        "system_block_count": len(system_texts),
+        "system_heads": [t[:120].replace("\n", "\\n") for t in system_texts[:6]],
+        "message_summaries": body.get("messages") or [],
+        "date_lines": date_lines,
+        "needs_normalize": needs_normalize,
+        "billing_blocks": [
+            t[:160]
+            for t in system_texts
+            if t.startswith("x-anthropic-billing-header")
+        ],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("jsonl", type=Path)
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if any captured scenario still needs TokenKey normalize",
+    )
+    args = ap.parse_args()
+
+    rows = []
+    for line in args.jsonl.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rows.append(analyze_record(json.loads(line)))
+
+    if args.json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2))
+    else:
+        for row in rows:
+            print(
+                f"=== scenario={row['scenario']} tz={row['tz']} "
+                f"host={row.get('host')} needs_normalize={row['needs_normalize']} ==="
+            )
+            print(f"system_blocks={row['system_block_count']}")
+            for dl in row["date_lines"]:
+                surf = dl.get("surface", "?")
+                print(
+                    f"  [{surf}] apostrophe={dl.get('apostrophe')} "
+                    f"format={dl['date']['format']} raw={dl['date']['raw']}"
+                )
+                print(f"    {dl.get('line')}")
+            if not row["date_lines"]:
+                print("  date_line: <none matched>")
+            print()
+
+    if args.check and any(r.get("needs_normalize") for r in rows):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/anthropic/probe_cc_geo_stego_direct.sh
+++ b/ops/anthropic/probe_cc_geo_stego_direct.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Dynamic CC geo-stego probe: plain `claude` CLI + mitmdump (no cc0, no gost).
+#
+# Captures system[], messages[] <system-reminder>, and date_change attachments
+# under a scenario matrix (TZ × ANTHROPIC_BASE_URL host). Use findings to extend
+# gateway_request_tk_cc_geo_stego.go and tokenkey-cc-fingerprint-alignment skill §2.6.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MITM_ADDON="$SCRIPT_DIR/probe_cc_geo_stego_mitm.py"
+ANALYZE="$SCRIPT_DIR/probe_cc_geo_stego.py"
+CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
+CA="${HOME}/.mitmproxy/mitmproxy-ca-cert.pem"
+
+MODEL="${TOKENKEY_CC_GEO_MODEL:-claude-haiku-4-5-20251001}"
+MITM_PORT="${TOKENKEY_CC_GEO_MITM_PORT:-11804}"
+OUT_DIR="${TOKENKEY_CC_GEO_PROBE_OUT:-$REPO_ROOT/.tls_list/geo-stego-direct-$(date -u +%Y%m%dT%H%M%SZ)}"
+PROMPT="${TOKENKEY_CC_HTTP_CAPTURE_PROMPT:-Say only the word PONG}"
+
+require_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "need $1" >&2; exit 1; }; }
+require_cmd mitmdump
+require_cmd python3
+[[ -x "$CLAUDE_BIN" ]] || { echo "need CLAUDE_BIN=$CLAUDE_BIN" >&2; exit 1; }
+[[ -f "$CA" ]] || { echo "need mitm CA at $CA (mitmproxy --version once)" >&2; exit 1; }
+
+mkdir -p "$OUT_DIR"
+LOG="$OUT_DIR/capture.jsonl"
+: >"$LOG"
+
+invoke_claude() {
+  local tz="$1" base_url="$2"
+  local out err
+  out="$(mktemp "${TMPDIR:-/tmp}/geo-claude.out.XXXXXX")"
+  err="$(mktemp "${TMPDIR:-/tmp}/geo-claude.err.XXXXXX")"
+  (
+    cd /tmp || exit 1
+    # Neutral cwd: avoid sub2api SessionStart short-circuit.
+    # HTTPS via mitm; ANTHROPIC_BASE_URL hostname drives CC geo-stego branch.
+    env -i \
+      HOME="$HOME" USER="${USER:-$(id -un)}" LOGNAME="${LOGNAME:-$(id -un)}" \
+      PATH="$PATH" SHELL="${SHELL:-/bin/sh}" TERM="${TERM:-xterm-256color}" \
+      LANG="${LANG:-en_US.UTF-8}" TZ="$tz" \
+      HTTP_PROXY="http://127.0.0.1:${MITM_PORT}" \
+      HTTPS_PROXY="http://127.0.0.1:${MITM_PORT}" \
+      http_proxy="http://127.0.0.1:${MITM_PORT}" \
+      https_proxy="http://127.0.0.1:${MITM_PORT}" \
+      NO_PROXY="" no_proxy="" \
+      ANTHROPIC_BASE_URL="$base_url" \
+      NODE_EXTRA_CA_CERTS="$CA" \
+      NODE_TLS_REJECT_UNAUTHORIZED=0 \
+      CLAUDE_CODE_REMOTE_SEND_KEEPALIVES=true \
+      "$CLAUDE_BIN" \
+      -p "$PROMPT" \
+      --model "$MODEL" \
+      --max-budget-usd 0.15 \
+      --output-format text \
+      </dev/null >"$out" 2>"$err"
+  ) || true
+  echo "--- tz=$tz base_url=$base_url ---" >&2
+  sed -n '1,12p' "$err" >&2 || true
+  sed -n '1,3p' "$out" >&2 || true
+  rm -f "$out" "$err"
+}
+
+run_scenario() {
+  local name="$1" tz="$2" base_url="$3"
+  local mitm_pid=""
+
+  echo "[probe-direct] scenario=$name tz=$tz base_url=$base_url" >&2
+  pkill -f "mitmdump.*${MITM_PORT}" 2>/dev/null || true
+  sleep 1
+
+  CC_GEO_PROBE_LOG="$LOG" \
+  CC_GEO_PROBE_SCENARIO="$name" \
+  CC_GEO_PROBE_TZ="$tz" \
+  CC_GEO_PROBE_PROXY="mitm" \
+  CC_GEO_PROBE_BASE_URL="$base_url" \
+  CC_GEO_PROBE_HOSTS="tokenkey.dev,anthropic.com,aicodemirror.com" \
+    mitmdump --listen-port "$MITM_PORT" \
+      -s "$MITM_ADDON" \
+      >"$OUT_DIR/mitm-${name}.out" 2>"$OUT_DIR/mitm-${name}.err" &
+  mitm_pid=$!
+  sleep 2
+
+  invoke_claude "$tz" "$base_url"
+  sleep 2
+  kill "$mitm_pid" 2>/dev/null || true
+  wait "$mitm_pid" 2>/dev/null || true
+}
+
+echo "claude=$("$CLAUDE_BIN" --version 2>/dev/null || true)" >&2
+echo "model=$MODEL out_dir=$OUT_DIR" >&2
+
+# Default matrix — override with TOKENKEY_CC_GEO_SCENARIOS="name|tz|base_url,..."
+if [[ -n "${TOKENKEY_CC_GEO_SCENARIOS:-}" ]]; then
+  IFS=',' read -r -a _scenarios <<<"$TOKENKEY_CC_GEO_SCENARIOS"
+  for spec in "${_scenarios[@]}"; do
+    IFS='|' read -r name tz base_url <<<"$spec"
+    run_scenario "$name" "$tz" "$base_url"
+  done
+else
+  run_scenario "shanghai_tokenkey" "Asia/Shanghai" "https://api.tokenkey.dev"
+  run_scenario "utc_tokenkey" "UTC" "https://api.tokenkey.dev"
+  run_scenario "shanghai_official" "Asia/Shanghai" "https://api.anthropic.com"
+  run_scenario "shanghai_mirror" "Asia/Shanghai" "https://api.aicodemirror.com"
+fi
+
+python3 "$ANALYZE" "$LOG" | tee "$OUT_DIR/report.txt"
+python3 "$ANALYZE" "$LOG" --json >"$OUT_DIR/report.json"
+
+echo "out_dir=$OUT_DIR"
+echo "TokenKey normalize target: ASCII U+0027 + YYYY-MM-DD in gateway_request_tk_cc_geo_stego.go" >&2

--- a/ops/anthropic/probe_cc_geo_stego_mitm.py
+++ b/ops/anthropic/probe_cc_geo_stego_mitm.py
@@ -1,0 +1,122 @@
+"""mitmproxy addon: capture /v1/messages body shape for CC geo-stego probe.
+
+Records system[], messages[] text blocks (incl. <system-reminder>), and
+date_change attachments — the surfaces TokenKey gateway_request_tk_cc_geo_stego.go
+must normalize before US edge egress.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+
+from mitmproxy import http
+
+LOG_PATH = os.environ.get("CC_GEO_PROBE_LOG", "").strip()
+SCENARIO = os.environ.get("CC_GEO_PROBE_SCENARIO", "unknown")
+TZ = os.environ.get("CC_GEO_PROBE_TZ", "")
+PROXY = os.environ.get("CC_GEO_PROBE_PROXY", "")
+BASE_URL = os.environ.get("CC_GEO_PROBE_BASE_URL", "")
+
+SYSTEM_REMINDER = re.compile(r"<system-reminder>", re.I)
+CURRENT_DATE = re.compile(r"#\s*currentDate", re.I)
+DATE_LINE = re.compile(
+    r"(Today.?s date is(?: now)?|The current date is|Current date:?)\s*",
+    re.IGNORECASE,
+)
+
+
+def _capture_hosts() -> tuple[str, ...]:
+    raw = os.environ.get("CC_GEO_PROBE_HOSTS", "anthropic.com,tokenkey.dev,aicodemirror.com").strip()
+    return tuple(h.strip() for h in raw.split(",") if h.strip())
+
+
+def _host_matches(host: str) -> bool:
+    host = host or ""
+    return any(marker in host for marker in _capture_hosts())
+
+
+def _text_blocks(content) -> list[str]:
+    texts: list[str] = []
+    if isinstance(content, str):
+        if content.strip():
+            texts.append(content)
+        return texts
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    t = str(block.get("text") or "")
+                    if t.strip():
+                        texts.append(t)
+    return texts
+
+
+def _summarize_messages(messages) -> list[dict]:
+    out: list[dict] = []
+    if not isinstance(messages, list):
+        return out
+    for mi, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role") or "")
+        content = msg.get("content")
+        entry: dict = {"index": mi, "role": role, "text_blocks": []}
+        for ti, text in enumerate(_text_blocks(content)):
+            block = {
+                "index": ti,
+                "has_system_reminder": bool(SYSTEM_REMINDER.search(text)),
+                "has_current_date": bool(CURRENT_DATE.search(text)),
+                "date_lines": [
+                    ln.strip()[:240]
+                    for ln in text.splitlines()
+                    if DATE_LINE.search(ln)
+                ],
+                "head": text[:160].replace("\n", "\\n"),
+            }
+            entry["text_blocks"].append(block)
+        if isinstance(content, list):
+            for ci, block in enumerate(content):
+                if not isinstance(block, dict):
+                    continue
+                att = block.get("attachment")
+                if isinstance(att, dict) and att.get("type") == "date_change":
+                    entry.setdefault("date_change_attachments", []).append(
+                        {
+                            "content_index": ci,
+                            "newDate": att.get("newDate"),
+                        }
+                    )
+        if entry["text_blocks"] or entry.get("date_change_attachments"):
+            out.append(entry)
+    return out
+
+
+def request(flow: http.HTTPFlow) -> None:
+    if not LOG_PATH:
+        return
+    if not _host_matches(flow.request.host or ""):
+        return
+    path = flow.request.path.split("?", 1)[0]
+    if path != "/v1/messages" and not path.startswith("/v1/messages"):
+        return
+    body_text = flow.request.get_text(strict=False) or ""
+    try:
+        body = json.loads(body_text) if body_text.strip().startswith("{") else {}
+    except Exception:
+        body = {}
+    record = {
+        "scenario": SCENARIO,
+        "tz": TZ,
+        "proxy": PROXY,
+        "base_url": BASE_URL,
+        "host": flow.request.host,
+        "path": path,
+        "model": body.get("model"),
+        "body": {
+            "system": body.get("system"),
+            "messages": _summarize_messages(body.get("messages")),
+        },
+    }
+    with open(LOG_PATH, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")

--- a/ops/anthropic/test_probe_cc_geo_stego.py
+++ b/ops/anthropic/test_probe_cc_geo_stego.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Unit tests for probe_cc_geo_stego.py analyzer."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+OPS = Path(__file__).resolve().parent
+PROBE = OPS / "probe_cc_geo_stego.py"
+
+
+class TestProbeCCGeoStego(unittest.TestCase):
+    def _run(self, records: list[dict], extra_args: list[str] | None = None) -> subprocess.CompletedProcess:
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+            for rec in records:
+                f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            path = f.name
+        args = [sys.executable, str(PROBE), path, "--json"]
+        if extra_args:
+            args.extend(extra_args)
+        return subprocess.run(args, capture_output=True, text=True, check=False)
+
+    def test_system_reminder_in_messages_needs_normalize(self) -> None:
+        rec = {
+            "scenario": "shanghai_tokenkey",
+            "tz": "Asia/Shanghai",
+            "host": "api.tokenkey.dev",
+            "body": {
+                "system": [{"type": "text", "text": "You are a Claude agent."}],
+                "messages": [
+                    {
+                        "index": 0,
+                        "role": "user",
+                        "text_blocks": [
+                            {
+                                "index": 0,
+                                "has_system_reminder": True,
+                                "has_current_date": True,
+                                "date_lines": ["Today\u2019s date is 2026/06/30."],
+                                "head": "<system-reminder>",
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+        cp = self._run([rec])
+        self.assertEqual(cp.returncode, 0, cp.stderr)
+        rows = json.loads(cp.stdout)
+        self.assertTrue(rows[0]["needs_normalize"])
+        self.assertEqual(rows[0]["date_lines"][0]["surface"], "messages[0].content[0].text")
+
+    def test_canonical_shape_no_normalize(self) -> None:
+        rec = {
+            "scenario": "utc_tokenkey",
+            "tz": "UTC",
+            "host": "api.tokenkey.dev",
+            "body": {
+                "messages": [
+                    {
+                        "index": 0,
+                        "role": "user",
+                        "text_blocks": [
+                            {
+                                "index": 0,
+                                "date_lines": ["Today's date is 2026-06-30."],
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+        cp = self._run([rec], ["--check"])
+        rows = json.loads(cp.stdout)
+        self.assertFalse(rows[0]["needs_normalize"])
+        self.assertEqual(cp.returncode, 0)
+
+    def test_date_change_attachment_slash_needs_normalize(self) -> None:
+        rec = {
+            "scenario": "shanghai_tokenkey",
+            "body": {
+                "messages": [
+                    {
+                        "index": 0,
+                        "role": "user",
+                        "text_blocks": [],
+                        "date_change_attachments": [{"content_index": 0, "newDate": "2026/06/30"}],
+                    }
+                ],
+            },
+        }
+        cp = self._run([rec])
+        rows = json.loads(cp.stdout)
+        self.assertTrue(rows[0]["needs_normalize"])
+        surfaces = [dl["surface"] for dl in rows[0]["date_lines"]]
+        self.assertIn("messages[0].content[0].attachment.newDate", surfaces)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1192,6 +1192,7 @@
         "func tkNormalizeAnthropicThinkingForcesToolUse",
         "tkNormalizeChangeToolChoiceStringToObject",
         "tkNormalizeChangeThinkingForcesToolUse",
+        "tkNormalizeChangeCCGeoStego",
         "Kind:     \"request_normalized\"",
         "gateway.anthropic_request_normalized"
       ],
@@ -2076,10 +2077,21 @@
       "rationale": "Pure, fork-only ToolSearch historical signed-thinking pre-filter (claude-code #63792 / #10199), kept in a *_tk_*.go companion out of upstream-owned gateway_request.go (rule §5). When dynamic tool loading re-serializes prior assistant turns, stale signed thinking blocks trigger upstream 400 'cannot be modified' and a client strip-and-retry storm every turn. TkPrefilterToolSearchHistoricalThinking downgrades historical assistant thinking to text before the first upstream call when ToolSearch tools are present, preserving assistant-prefill thinking. Anchor the gate + stripper so an upstream merge cannot delete this surface and silently re-expose the per-turn double round-trip. Exhaustively covered by gateway_request_tk_toolsearch_thinking_test.go."
     },
     {
+      "path": "backend/internal/service/gateway_request_tk_cc_geo_stego.go",
+      "must_contain": [
+        "func tkNormalizeAnthropicCCGeoStego",
+        "func tkNormalizeCCGeoStegoText",
+        "tkNormalizeChangeCCGeoStego",
+        "Today's date is $1-$2-$3."
+      ],
+      "rationale": "Pure CC geo-stego normalizer: rewrite Today's date lines in system / system-reminder text to first-party US shape (ASCII apostrophe + YYYY-MM-DD) before US edge OAuth egress. Wired from gateway_anthropic_request_normalize_tk.go and API-key passthrough. Exhaustively covered by gateway_request_tk_cc_geo_stego_test.go."
+    },
+    {
       "path": "backend/internal/service/gateway_service.go",
       "must_contain": [
         "TkPrefilterToolSearchHistoricalThinking(body, reqModel)",
-        "TkPrefilterToolSearchHistoricalThinking(input.Body, input.RequestModel)"
+        "TkPrefilterToolSearchHistoricalThinking(input.Body, input.RequestModel)",
+        "tkNormalizeAnthropicCCGeoStego(input.Body)"
       ],
       "rationale": "Wiring of the ToolSearch historical thinking pre-filter (claude-code #63792 / #10199) into OAuth Forward and API-Key passthrough paths after FilterThinkingBlocks / UTF-8 sanitize. One-line hooks in an upstream-shaped file compile clean if dropped, silently re-exposing the per-turn 400 + strip-and-retry storm. Anchor both call shapes; the pure filter is guarded by gateway_request_tk_toolsearch_thinking.go."
     },

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2084,7 +2084,7 @@
         "tkNormalizeChangeCCGeoStego",
         "Today's date is $1-$2-$3."
       ],
-      "rationale": "Pure CC geo-stego normalizer: rewrite Today's date lines in system / system-reminder text to first-party US shape (ASCII apostrophe + YYYY-MM-DD) before US edge OAuth egress. Wired from gateway_anthropic_request_normalize_tk.go and API-key passthrough. Exhaustively covered by gateway_request_tk_cc_geo_stego_test.go."
+      "rationale": "Pure CC geo-stego normalizer: rewrite Today's date lines in system / system-reminder text to first-party US shape (ASCII apostrophe + YYYY-MM-DD) before US edge OAuth egress. Wired from gateway_anthropic_request_normalize_tk.go, Forward API-key passthrough, and count_tokens API-key passthrough. Exhaustively covered by gateway_request_tk_cc_geo_stego_test.go."
     },
     {
       "path": "backend/internal/service/gateway_service.go",


### PR DESCRIPTION
## 摘要

- 在 Anthropic `/v1/messages` 出站前，将 Claude Code 写入 `system` / `<system-reminder>` / `date_change` attachment 的地域隐写（日期 `/` vs `-`、Unicode 引号变体）改写为与官方 `api.anthropic.com` 一致的美区形态（ASCII `'` + `YYYY-MM-DD`）。
- 挂接现有 `tk_anthropic_request_normalize_enabled` 开关；OAuth Forward、API Key passthrough Forward、以及 count_tokens API Key passthrough 三条出站路径均覆盖。
- 新增 `ops/anthropic/probe_cc_geo_stego_*` + skill §2.6：用**纯 claude CLI + mitm**（无 cc0/gost）矩阵采集 `system[]` / `messages[]` / `<system-reminder>`，驱动后续 normalize 规则扩展。

## 风险

- 常规风险：仅改写已识别的 `Today's date is …` / `date_change.newDate` 模式；已是 US 形态则 no-op。
- 关闭 `tk_anthropic_request_normalize_enabled` 可立即回退为透传客户端原文。
- Web impact: none（纯网关 body 改写 + ops 探针/skill，无 Admin/UI 变更）。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service \
  -run 'TestTkNormalizeCCGeoStego|TestTkNormalizeAnthropicCCGeoStego|TestForwardCountTokensAnthropicAPIKeyPassthrough_NormalizesCCGeoStego|TestTkNormalizeAnthropicRequestBody_' -count=1
python3 -m unittest ops/anthropic/test_probe_cc_geo_stego.py -v
./scripts/preflight.sh
```

- 动态实测（本机 `claude` 2.1.196 + mitm）：Shanghai `2026/06/30` → 归一化后 `2026-06-30`；已知镜像域 U+2019 → ASCII `'`.

## 提交

- cfb6cb625 fix(gateway): normalize CC geo stego in outbound Messages bodies
- 3bb5c9773 fix(gateway): cc geo normalize on count_tokens passthrough path
- 4418f0615 docs(ops): add CC geo-stego probe workflow to cc fingerprint skill

最新提交：4418f0615
