### PR TITLE
docs: 压缩 CLAUDE.md 至 Claude Code 40k 内存上限内

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,54 +41,7 @@ pnpm lint:check && pnpm typecheck # Lint + type check
 
 ## Architecture
 
-```
-sub2api/                                  # This repo (.git)
-├── CLAUDE.md
-├── docs/                                 # Planning & operational docs
-├── backend/
-│   ├── cmd/server/                       # Entry point, Wire DI, VERSION
-│   ├── ent/schema/                       # DB schema definitions (source of truth)
-│   ├── ent/                              # Generated Ent ORM code
-│   ├── internal/
-│   │   ├── handler/                      # HTTP handlers (Gin)
-│   │   ├── service/                      # Business logic, gateway forwarding
-│   │   ├── repository/                   # Data access (Ent queries)
-│   │   ├── middleware/                   # Auth, rate-limit, concurrency
-│   │   ├── integration/newapi/           # New API bridge (affinity, payment SDKs)
-│   │   ├── pkg/                          # Platform adapters (claude, openai, gemini, etc.)
-│   │   ├── domain/                       # Constants & types
-│   │   ├── model/                        # Business models
-│   │   ├── config/                       # App configuration + Wire
-│   │   ├── server/                       # Server bootstrap + routes
-│   │   ├── setup/                        # First-run initialization
-│   │   ├── web/                          # Embedded frontend dist
-│   │   ├── testutil/                     # Test fixtures & stubs
-│   │   └── util/                         # Shared utilities
-│   ├── migrations/                       # SQL migrations (numbered NNN_* + TK-only tk_NNN_*)
-│   └── resources/model-pricing/          # Model pricing data
-├── frontend/src/
-│   ├── api/                              # API client
-│   ├── views/ components/                # Pages & components
-│   ├── stores/ router/                   # Pinia stores, Vue Router
-│   ├── composables/ utils/ styles/       # Hooks, helpers, CSS
-│   ├── i18n/ types/                      # i18n (en/zh), TS types
-│   └── __tests__/                        # Frontend tests
-├── deploy/                               # Docker Compose variants
-│   ├── docker-compose.yml                #   Production
-│   ├── docker-compose.dev.yml            #   Development (with build)
-│   ├── docker-compose.local.yml          #   Local (pre-built image)
-│   └── docker-compose.standalone.yml     #   Standalone (all-in-one)
-├── assets/                               # Logos, partner assets
-└── tools/                                # check_pnpm_audit_exceptions.py
-```
-
-Sibling dependency (same parent directory):
-
-```
-tk/                         # Parent directory (NOT a git repo)
-├── sub2api/                # This repo
-└── new-api/                # QuantumNous/new-api clone (own .git)
-```
+Backend `backend/` (Go: `handler` → `service` → `repository` → `ent`), frontend `frontend/` (Vue 3 + pnpm), deploy `deploy/`. Sibling `new-api/` clone required at `../../new-api` (see §4). Key paths: `backend/internal/{handler,service,integration/newapi,relay/bridge}`, `frontend/src/{views,composables,api}`, `deploy/docker-compose*.yml`.
 
 ## Hard Rules
 
@@ -187,52 +140,11 @@ This repo is a fork of `Wei-Shaw/sub2api`, tracked via the `upstream` remote (`u
 
 #### 5.y Forward-looking history & merge discipline
 
-The `main` branch is **immutable history** once pushed. The TK-ahead commits include both linear and merge commits and several `vX.Y.Z` tags pointing into them — rewriting history would orphan tags and break PR audit trails. Going forward:
-
-- **No history rewrites on `main`.** No `git rebase -i` of pushed commits, no `git push --force` to `main`/`master`, no squash-merge of already-merged feature branches.
-- **Every TK feature lands via PR** with a clear scope (new file or one upstream-file injection point), reviewed against rule §5 above. Small + frequent beats one giant rebase.
-- **PR merge mode is content-typed, not personal preference:**
-  - **TK feature / fix / chore PRs** (anything originating from this fork) → GitHub **"Squash and merge"**. The PR becomes **one** commit on `main` whose title = PR title and whose body aggregates the development commits. Rationale: the feature branch's work-in-progress commits (`fix lint`, `typo`, `rebase main`, sync-VERSION housekeeping) carry no long-term audit value once the PR is approved as a unit; collapsing them keeps `git log --oneline --first-parent main` readable and keeps the per-PR diff trivially `git revert`-able.
-  - **Upstream merge PRs** (`merge/upstream-YYYYMMDD`) → GitHub **"Create a merge commit"** invoked locally as `git merge --no-ff upstream/main`. Never `--squash`, never `--ff-only`. Rationale: each upstream commit is an external contract reference; squashing them severs the `git log upstream/main..HEAD` audit chain that §5.y depends on.
-  - This is **not** a contradiction with "no squash-merge of already-merged feature branches" above: that rule forbids rewriting commits **already on `main`**; the squash here happens **at PR-merge time**, before anything reaches `main`.
-- **`git merge-tree upstream/main HEAD` is the pre-merge dry-run.** Run it before any upstream merge to surface conflicts; resolve in a dedicated `merge/upstream-YYYYMMDD` branch, not on `main`.
-- **Tag = consolidation point, not a rewrite cue.** When you tag `vX.Y.Z`, all earlier commits become permanent history. If a tag points at a commit with `[skip ci]` (see §9.2), do NOT delete and re-tag — dispatch the workflow manually.
-- **Audit cadence:** every merge PR description includes `git log --oneline upstream/main..HEAD | wc -l` (TK ahead count) + `git diff --stat upstream/main..HEAD -- backend/` (top changed files). Use these numbers to decide whether the next batch of TK work should be split into smaller PRs.
+`main` history is immutable once pushed. TK PRs → **Squash and merge**; upstream merges (`merge/upstream-YYYYMMDD`) → **`git merge --no-ff upstream/main`** then **Create a merge commit** on GitHub (never squash/ff). Pre-merge dry-run: `git merge-tree upstream/main HEAD`. Merge PR body must include `upstream/main..HEAD` audit cadence. Full rules: [`docs/global/upstream-merge-discipline.md`](docs/global/upstream-merge-discipline.md).
 
 #### 5.y.1 Mechanical enforcement (no soft rule without a check)
 
-Per dev-rules §"Hard Constraint Wiring" — every soft rule above MUST have an automated gate. The §5.y enforcement stack:
-
-| Mechanism | Trigger | What it does |
-|---|---|---|
-| `scripts/upstream/check-drift.sh` | local, on demand | Prints TK ahead/behind vs `upstream/main` + the §5.y procedure when behind. Exit: `0` synced, `1` behind, `2` failure; `--json` / `--quiet`. |
-| `.github/workflows/upstream-merge-agent-daily.yml` | daily 04:00 Asia/Shanghai + manual dispatch | Single periodic upstream-sync path: drift → headless merge automation when needed → final preflight + PR-body cadence audit; actionable blockers tracked via the `upstream-merge-agent` issue channel. |
-| `.github/workflows/upstream-merge-pr-shape.yml` | PRs from `merge/upstream-*` | Hard gates: (a) PR must contain a merge commit whose second parent is reachable from `upstream/main` (squash/ff fail), (b) PR body must include the literal substring `upstream/main..HEAD` (§5.y audit cadence), (c) no first-parent commit introduced by the PR may carry the bracketed skip-ci marker (see §9.2; imported upstream history exempt), (d) the newapi sentinel registry (`scripts/sentinels/newapi.json`) is intact — `scripts/preflight.sh` runs the same script locally. |
-| `scripts/checks/upstream-override-marker.py` (via `scripts/preflight.sh`) | every PR (CI preflight + local pre-commit) | When the PR diff touches any upstream-shaped path (handlers/services/views/… excluding `*_tk_*.go` / `*.tk.ts` / `*_test.go` / TK-only subpackages), the gate is **coverage-first**: a pure-insertion diff or **verified sentinel coverage** of every deletion-bearing upstream file (its `path` is pinned in some `scripts/sentinels/*.json`, pre-existing or added this PR) auto-passes with **no marker**. Only an *uncovered* revert-risk edit needs a marker. `upstream-touch-guarded` is **mechanically verified, not trusted**: it asserts the touched files are already pinned, so if they are NOT the claim is false and the gate **fails** (it can no longer be a free bypass — covered edits already passed without it). The other three markers assert protection is *not needed* and remain honest, reviewer-visible opt-outs: `upstream-touch-trivial` (no revert risk) / `upstream-merge` (the merge PR) / `no-upstream-touch` (misclassified path). Forced confrontation before merge, like `no-web-impact`. |
-| `.github/workflows/main-ancestry-guard.yml` | any PR with `base.ref == 'main'` | **Check 1:** PR base must be an ancestor of PR head (catches the PR #307 orphan-reset mode). **Check 2:** `.main-ancestry-anchor` may only change with the `main-ancestry-anchor-advance` marker AND a new SHA descending from the old (see below). **Check 3:** PR title/body/commit messages must not contain the bracketed forms `[skip ci]` / `[ci skip]` (see §9.2). |
-| `scripts/checks/main-ancestry-anchor.py` (via `scripts/preflight.sh`) | every PR (CI preflight + local pre-commit) | Verifies the SHA in repo-root `.main-ancestry-anchor` is an ancestor of HEAD — catches orphan-resets on paths the PR-level guard can't see (direct push, force push, propagated reset). |
-
-**Anchor advancement.** `.main-ancestry-anchor` is a one-way ratchet: a known-good SHA every future HEAD must descend from (baseline `62482fa9bc30ac292ecca92341ef055a024d8a26`, locked after the PR #307 orphan-reset incident). To advance it: open a PR that updates the file AND carries the literal marker `main-ancestry-anchor-advance` + a one-line justification in a commit message. Guard Check 2 also requires the new SHA to be a descendant of the old one — the descendant check is the real ratchet, the marker is the human-attention gate.
-
-**Branch protection on `main`** SHOULD list `Upstream Merge PR Shape / validate` and `Main Ancestry Guard / validate` as required status checks (Settings → Branches → main). Known limit: GitHub doesn't expose merge-method choice, so these gates can't stop a manual "Squash and merge" click on a merge PR — they only make the wrong shape fail CI.
-
-#### Convergence & minimal invasion (especially large upstream files)
-
-**Goal:** TK behavior should **converge** into dedicated modules so the fork stays **merge-friendly**; upstream files should read almost unchanged except for **thin injection points** (imports + a few lines, not new pages of logic).
-
-**When the file is upstream-shaped and large** (e.g. `gateway_handler*.go`, `openai_*_handler.go`, `setting_handler.go`, `endpoint.go`, `ChannelsView.vue`, account modals):
-
-1. **Do not** paste multi-screen TK branches, repeated error handling, or catalog/API glue into the upstream file.
-2. **Do** implement behavior in a companion and call it from upstream:
-   - **Go (same package):** `*_tk_*.go` — selection/affinity, relay error JSON, endpoint aliases, settings merge fields, passkey routes, admin route registration helpers (`registerTK*`), etc.
-   - **Go (shared across handlers):** small neutral helpers in the `handler` package (e.g. `TkTryWriteNewAPIRelayErrorJSON`, `TkAPIKeyGroupName`) to dedupe without inflating each upstream handler.
-   - **Routes:** move new paths and predicates into `*_tk_*.go` in `internal/server/routes/`; keep `admin.go` / `gateway.go` to a single `registerTK…()` call where possible.
-   - **Vue / TS:** `frontend/src/composables/useTk*.ts` (and `constants/` or `*.tk.ts` for pure maps). Views and modals stay **template + wiring**; composables own API calls, watchers, and state for TK-only flows.
-3. **Upstream file edits** should trend toward: **one import block delta + one-line hooks** (or replacing a repeated 10–20 line pattern with **one** helper call), not reformatting or reordering unrelated upstream code.
-4. **DTO / struct fields** that belong to the upstream request/response shape may still live in the primary handler file; **validation, merge rules, and audit diffs** belong in `*_tk_*.go` helpers.
-5. **Out of scope for this pattern:** Ent schema + generated `ent/`, `wire_gen.go`, and migration SQL — follow schema-first rules; generated churn is expected.
-
-**Anti-patterns:** Duplicating the same `errors.As` + JSON response blocks across handlers; duplicating aggregated-admin API logic across large `.vue` files; registering many new routes inline in `admin.go` instead of a `registerTK…` helper.
+Gates: `scripts/upstream/check-drift.sh`, `scripts/checks/upstream-override-marker.py`, `scripts/checks/main-ancestry-anchor.py`; workflows `upstream-merge-pr-shape.yml`, `main-ancestry-guard.yml`. `.main-ancestry-anchor` is a one-way ratchet — advance only via PR with `main-ancestry-anchor-advance` marker. Full mechanism table + minimal-invasion patterns: [`docs/global/upstream-merge-discipline.md`](docs/global/upstream-merge-discipline.md).
 
 ### 6. Interface Method Completeness
 
@@ -292,131 +204,22 @@ a git submodule at `dev-rules/`. The full convention is in
 `dev-rules/rules/dev-rules-convention.mdc` (synced to `.cursor/rules/`); this
 section only records sub2api-specific choices.
 
-- **`scripts/preflight.sh` is a thin wrapper, not a re-implementation.**
-  All generic checks (branch naming, submodule pointer, `.cursor/rules`
-  drift, agent contract drift, story/test alignment, `docs/approved`
-  discipline, approved-doc invariants R1-R5, doc-stat drift, cloud-agent
-  env consistency) are **delegated** to `dev-rules/templates/preflight.sh`
-  — the wrapper just invokes it. The wrapper exists ONLY to host
-  **sub2api-specific checks**:
-  - **newapi compat-pool drift** — guards the **forward-drift** failure
-    mode that triggered `docs/approved/newapi-as-fifth-platform.md`. Any
-    new scheduler/gateway caller must use `IsOpenAICompatPoolMember` /
-    `OpenAICompatPlatforms` instead of bare `PlatformOpenAI` / `IsOpenAI`.
-  - **newapi sentinel registry** — guards the **backward-drift** failure
-    mode (a load-bearing fifth-platform file/symbol gets silently deleted
-    by an upstream merge or refactor). Source of truth is
-    `scripts/sentinels/newapi.json` (declarative `path` + `must_contain`
-    list with rationale per entry). `scripts/sentinels/check-newapi.py`
-    reads the registry; the same script is invoked by
-    `.github/workflows/upstream-merge-pr-shape.yml`, so a green local
-    preflight implies a green merge-PR check. Adding a new load-bearing
-    surface for newapi MUST add a sentinel entry in the same commit. See
-    `docs/approved/newapi-as-fifth-platform.md` § 12 for the registry
-    doctrine (categories, double-trigger, evolution discipline).
-    Mechanized for ALL platforms by
-    `scripts/sentinels/check-registry-update-gate.py`: a newly ADDED
-    hotspot file (new `*_tk_*.go` companion, bridge file, TK frontend
-    module) fails the marker-acknowledgement CI gate unless the PR adds
-    sentinel anchor(s) for it or carries `sentinel-registry-reviewed`
-    in the PR description — pure-insertion no longer exempts new files.
-  When adding a new sub2api-only check, append it to `scripts/preflight.sh`
-  (NEVER edit the dev-rules template — it is shared across all consumer
-  projects). If the check turns out to be useful for more than just
-  sub2api, lift it into dev-rules and remove the local copy. The git
-  pre-commit hook installed by `dev-rules/templates/install-hooks.sh`
-  prefers `scripts/preflight.sh` when present and falls back to the
-  dev-rules template otherwise.
-- **CI must check out submodules.** All workflow jobs that run
-  `dev-rules/...` (preflight, contract drift, etc.) must use
-  `actions/checkout@v6` with `submodules: recursive`.
-- **Editing rules:** edit `dev-rules/rules/*.mdc` (or `commands/`,
-  `global/`), then `dev-rules/sync.sh --local`, commit submodule first, push
-  submodule, then commit parent (`dev-rules` pointer + `.cursor/rules/`).
-  The "submodule first" order is enforced by preflight § 2 (warns on offline,
-  fails if SHA missing locally) and by `dev-rules/rules/dev-rules-convention.mdc`.
+- **`scripts/preflight.sh` is a thin wrapper** delegating generic checks to `dev-rules/templates/preflight.sh`. Sub2api-specific checks only: **newapi compat-pool drift** (`IsOpenAICompatPoolMember` / `OpenAICompatPlatforms`) and **sentinel registry** (`scripts/sentinels/newapi.json` + `check-newapi.py`; new hotspot files need anchors or `sentinel-registry-reviewed` — see `docs/approved/newapi-as-fifth-platform.md` §12). Append new checks to `scripts/preflight.sh`, never the dev-rules template.
+- **CI must check out submodules** (`actions/checkout@v6` with `submodules: recursive`).
+- **Editing rules:** edit `dev-rules/rules/*.mdc`, `dev-rules/sync.sh --local`, commit submodule first + push, then parent (`dev-rules` pointer + `.cursor/rules/`).
 
 ## Studio SSOT（`/studio` Image / Video / BakeOff）
 
-`/studio` 三页（`ImageStudio` / `VideoStudio` / `BakeOff`）共享的历史、预览、下载、重载行为**禁止**在页面内各写一套。Owner 如下（#1092 视频 SSOT + 图片 SSOT 扩展）：
-
-| 意图 | Owner | 消费方 |
-| --- | --- | --- |
-| 媒体历史持久化（localStorage 元数据 + IndexedDB 镜像） | `composables/useMediaLibrary.ts` + `utils/studioBlobCache.tk.ts` | Image / Video / BakeOff |
-| 图片历史 mount（IDB hydrate → s3Key presign → thumb error 回退） | `composables/useStudioImageLibrary.ts` | ImageStudio, BakeOff |
-| 视频历史 mount（IDB hydrate） | `composables/useStudioVideoLibrary.ts` | VideoStudio, BakeOff |
-| 图片 lightbox 状态 | `composables/useStudioImagePreview.ts` + `components/StudioImagePreviewLightbox.vue` | ImageStudio |
-| 图片 history id / ephemeral src / revised_prompt tooltip | `utils/studioImageHistory.tk.ts` | useMediaLibrary, ImageStudio, BakeOff |
-| 视频 lightbox 状态 + 过期播放守卫 | `composables/useStudioVideoPreview.ts` + `components/StudioVideoPreviewLightbox.vue` | VideoStudio, BakeOff |
-| 视频卡片 copy-link / 下载 | `composables/useStudioVideoCardActions.ts` + `utils/studioDownload.tk.ts` | VideoStudio, BakeOff |
-| 视频 playback 分类 + IDB 镜像 | `utils/studioPlaybackStorage.tk.ts` (`tagStudioVideoPlayback`) | VideoStudio, BakeOff |
-| 视频 tab-local Blob 播放 | `utils/studioMedia.tk.ts` (`videoPlaybackUrl`) | lightbox + BakeOff 面板 |
-
-新增 Studio 行为时：先查上表能否扩展 owner；若 Image **与** Video **与** BakeOff 任两者都需要，必须进共享 composable/组件并在 `scripts/sentinels/frontend-tk.json` 加锚点。宪法原则见 `dev-rules/global/CLAUDE.md` §5.1。
+Owner table + extension rules: [`docs/global/agent-reference.md`](docs/global/agent-reference.md#studio-ssot-studio-image--video--bakeoff). 宪法原则见 `dev-rules/global/CLAUDE.md` §5.1。
 
 ## Agent skills（Cursor / Claude Code）
 
-技能正文只在 [.cursor/skills/](.cursor/skills/) 下各目录的 `SKILL.md`。仓库根的 `.claude/skills` **仅为**指向 `.cursor/skills` 的 symlink（不要在 `.claude/skills/` 下创建真实文件或副本）。全局禁令见 **`dev-rules/global/CLAUDE.md`** §4「Agent Skills」。
-
-- **Modelops 运营 hub（唯一入口）：** [.cursor/skills/tokenkey-modelops-planner/SKILL.md](.cursor/skills/tokenkey-modelops-planner/SKILL.md) — 路由 catalog/menu 刷新（分支 B → servable-model-refresh）、mapping 对账（分支 A）、上架（分支 C → onboard-model）。
-- **Stage0 发布与 rollout：** [.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md](.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md) — `main` → VERSION/tag → `release.yml` → `deploy-stage0` prod 与 `deploy-edge-lightsail-stage0` Edge rollout（edges 为 Lightsail-only）→ 烟测。
-- **本机 Stage0 Docker：** [.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md](.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md) — 与 `deploy/aws/stage0` 对齐的 compose、`AUTO_SETUP`、默认 `REPO_ROOT` / sibling `new-api` / `.cache` 路径见该 skill。
-- **cc 指纹对齐（抓包 → diff → PR）：** [.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md](.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md) — `capture-cc-fingerprint.sh` + `capture_cc_fingerprint.py`；cc0-here 实机 TLS/HTTP 对照 TokenKey 常量。
-- **Codex 指纹对齐（读本机 codex → diff → PR）：** [.cursor/skills/tokenkey-codex-fingerprint-alignment/SKILL.md](.cursor/skills/tokenkey-codex-fingerprint-alignment/SKILL.md) — `ops/openai/capture-codex-fingerprint.sh` + `capture_codex_fingerprint.py`；codex CLI 升级后 bump UA / `version` / 探测版本 / en-zh 占位符（5 pin），`preflight` 的 `codex fingerprint pin consistency` 兜「半截 bump」。
+技能正文在 `.cursor/skills/<name>/SKILL.md`；`.claude/skills` 仅为 symlink。完整索引见 [`AGENTS.md`](AGENTS.md)。常用入口：modelops → `tokenkey-modelops-planner`；Stage0 发版 → `tokenkey-stage0-release-rollout`；cc/codex 指纹 → `tokenkey-cc-fingerprint-alignment` / `tokenkey-codex-fingerprint-alignment`。
 
 ## Key Reference
 
-### Disaster recovery / 数据重建从哪找
+Gateway flow, prod↔edge topology, disaster recovery, full PR checklist: [`docs/global/agent-reference.md`](docs/global/agent-reference.md).
 
-prod 数据层要恢复/重建时，**先看 `deploy/aws/RUNBOOK-disaster-recovery.md` 顶部的「恢复资产地图」**——一张表说清每份备份（PG 账本、`.env` 密钥、CFN 模板、S3 离机 dump）存在哪、用哪节恢复。最常见 §3（实例死卷在→换机零丢失）；离机最后一手是 §4.4（S3 `s3://tokenkey-prod-pgdump-<acct>/prod/pgdump/`，hourly，RPO ≤1h）。
+Treat `internal/integration/newapi/` and `internal/relay/bridge/` as implementation source of truth; external planning docs may lag the code.
 
-### Current Gateway Flow
-
-```
-HTTP Request → Auth (JWT/APIKey) → Account Scheduling (sticky/load-aware)
- → Platform-specific forwarding (Claude / OpenAI / Gemini / Antigravity / New API fifth platform `newapi`)
- → Usage recording + quota deduction
-```
-
-The fifth platform **`newapi`** is a first-class account/group platform (not an add-on card on the other four): it uses OpenAI-compatible gateway routes and the New API **adaptor** layer in `internal/relay/bridge` when `channel_type > 0`. The `internal/integration/newapi/` package provides the channel-type catalog, affinity helpers, upstream model metadata helpers, and other `newapi`-specific bridge support required by TokenKey's fifth-platform flow.
-
-**Image and video generation surfaces** ride on the same `newapi` (and `openai`) compat-pool routing:
-
-- **Sync image** — `POST /v1/images/generations` (and `POST /images/generations` alias) via `bridge.RunImageRelay` and `bridge.DispatchImageGenerations`. Volcengine `channel_type=45` (Doubao Seedream) is supported through the upstream `volcengine` adapter.
-- **Async video** — `POST /v1/video/generations` + `GET /v1/video/generations/:task_id` (and the OpenAI-compat aliases `POST /v1/videos` + `GET /v1/videos/:task_id`, plus their no-prefix variants). Submit returns a TokenKey-issued `task_id` (prefix `vt_`); subsequent polls hit the upstream task adapter pinned at submit time. Supported channel types are auto-derived from `relay.GetTaskAdaptor` — i.e. whatever new-api's task-adaptor registry maps (as of 2026-06 that includes VolcEngine `45` / DoubaoVideo `54` → Doubao Seedance, Vertex AI `41` → Veo, plus Ali, Kling, Jimeng, Vidu, Sora/OpenAI, Gemini, MiniMax); never hard-code a channel list in TK code or docs — the predicate below is the single source of truth. Routing metadata lives in `service.VideoTaskCache` (Redis primary, in-memory fallback for single-replica dev). Default record TTL is 24h; terminal status (`succeeded`/`failed`) deletes the record. Adding a new task adapter upstream requires no TK code changes — the `IsVideoSupportedChannelType` predicate sees the new channel type as soon as the upstream adapter map registers it.
-
-**Scheduling-pool semantics (per `docs/approved/newapi-as-fifth-platform.md`, shipped):** the OpenAI-compatible pool now partitions strictly by `group.platform`. `openai` groups schedule only `openai` accounts; `newapi` groups schedule only `newapi` accounts (with `channel_type > 0`). The canonical predicate is `account.IsOpenAICompatPoolMember(groupPlatform)` in `backend/internal/service/account_tk_compat_pool.go`, used by load-balance, sticky-session, and recheck paths in `openai_account_scheduler.go` / `openai_gateway_service.go`. Cross-platform fallback is forbidden — an empty pool surfaces an error. Sticky-session bindings whose bound account drifted to the wrong platform (or whose `channel_type` was reset to 0) are invalidated and the request fails over to load-balance. `messages_dispatch_model_config` is preserved for `openai` and `newapi` groups, cleared for `anthropic` / `gemini` / `antigravity` (predicate: `isOpenAICompatPlatformGroup`). Sticky routing (per `docs/approved/sticky-routing.md`, shipped) layers above this pool to optimize prompt-cache hit rates within each platform's bucket.
-
-### prod ↔ Edge mirror relay topology
-
-Production (`api.tokenkey.dev`) is **not** where the upstream Anthropic OAuth capacity lives. prod holds `cc-<edge>` mirror accounts (`platform=anthropic, type=apikey`) whose `credentials.base_url = https://api-<edge>.tokenkey.dev`; they relay prod traffic to the **Edge Stage0 stacks** (Lightsail-only since 2026-06-07; the EC2/CFN edge matrix was retired — fleet source of truth: `deploy/aws/lightsail/edge-targets-lightsail.json`), which hold the real OAuth/setup-token accounts and forward to Anthropic. (prod itself remains EC2/CFN; only the edge fleet is Lightsail.) So the prod anthropic pool failing over across `cc-us3 / cc-us6 / …` is failing over across *edges*, not local accounts.
-
-**Attribution discipline:** a prod `cc-<edge>` cooldown (`temp_unschedulable_reason.matched_keyword='anthropic_upstream_error'`) is almost never prod-local — the real cause is on that edge. prod's `upstream-429 by account` / `recovered-200` are polluted by client-cancel tagging + failover smear and **cannot tell a dead edge from a healthy one** (a dead single-account edge and a healthy multi-account edge can both read ~1300 upstream-429). The reliable signal is each edge's OWN access-log `served_200 : no_available_429` ratio + schedulable-account count — run `ops/observability/scan-edge-health.sh`. See skills `tokenkey-online-log-troubleshooting` (§0 trap 9, §6.1 D) and `tokenkey-online-traffic-profile` (§4.1).
-
-### Fusion / Bridge Plans
-
-Treat `internal/integration/newapi/` and `internal/relay/bridge/` as the implementation source of truth; any external planning docs may lag the code.
-
-### PR Checklist
-
-- `go test -tags=unit ./...` passes
-- `go test -tags=integration ./...` passes
-- `golangci-lint run ./...` — no new issues
-- `pnpm-lock.yaml` in sync (if `package.json` changed)
-- Test stubs complete (if interfaces changed)
-- Ent generated code committed (if schema changed)
-- `go build ./...` succeeds (cross-repo dependency compiles)
-- If bumping `backend/cmd/server/VERSION` for a release: commit message contains **no** literal `[skip ci]` / `[ci skip]` anywhere (rule 9.2 — discussion of the marker counts as carrying it). Use `bash scripts/release-tag.sh vX.Y.Z` to push the tag — it enforces this mechanically.
-- If touching `.github/workflows/release.yml`: `simple_release` default stays `false`; warning banner step is intact (rule 9.1)
-- If the PR deletes any upstream-owned file/method/route: PR description contains the (a)/(b)/(c) justification block from rule §5.x; otherwise change to "override default" or "disable via setting" instead
-- After upstream merge: PR body includes `git log --oneline upstream/main..HEAD | wc -l` and the top-5 lines of `git diff --stat upstream/main..HEAD -- backend/` (rule §5.y audit cadence). The `Upstream Merge PR Shape` workflow (§5.y.1) enforces this automatically — fix any failures it reports rather than ignoring them.
-- Drift check: before opening any non-trivial PR, run `bash scripts/upstream/check-drift.sh`. If TK is behind upstream/main, pause and either land the upstream merge first or document why this PR ships out of order.
-- Upstream override marker (rule §5.y.1): if the PR diff touches any upstream-shaped path (handlers / services / repositories / middleware / relay / server / views / components / api / migrations / ent schema, excluding `*_tk_*.go` / `*.tk.ts` / `*_test.go` / TK-only subpackages), the gate is **coverage-first** — a pure-insertion diff or **verified sentinel coverage** of every deletion-bearing upstream file (its `path` pinned in some `scripts/sentinels/*.json`, pre-existing or added this PR) auto-passes with no marker. Only an *uncovered* revert-risk edit needs a marker. `upstream-touch-guarded` is **mechanically verified**: it claims the touched files are already pinned, so a false claim (no covering sentinel `path`) **fails** the gate — prefer adding the real anchor. The other three (`upstream-touch-trivial` / `upstream-merge` / `no-upstream-touch`) are honest opt-outs asserting protection is not needed. `scripts/preflight.sh` enforces this mechanically via `scripts/checks/upstream-override-marker.py`.
-- Reviewer picks the GitHub merge button per rule §5.y: **Squash and merge** for TK-originated PRs (feature / fix / chore / docs), **Create a merge commit** for `merge/upstream-*` PRs. Never use **Rebase and merge** on `main`.
-- **Root docs / deploy boundary:** keep root user-facing files (`README*.md`, root compose examples, generic upstream deployment snippets) aligned with upstream by default. TokenKey-specific local Stage0 validation, AWS prod deployment, smoke-test, image/tag, domain, and operator runbook changes belong under `deploy/*` (or the matching skill text), not in root README files. Only change root files when the build/release contract truly requires it, and prefer a short pointer to `deploy/*` over duplicating deployment steps.
-- If the PR touches `dev-rules/` (submodule pointer bump or `.cursor/rules/` resync): per rule §10, the dev-rules submodule MUST be pushed first; this PR's CI `preflight` job will fail otherwise (the dev-rules SHA in `.gitmodules` won't be reachable on `origin/main`).
-- **If the PR fixes an upstream / claude-code issue, record it in the fix ledger from inside the PR** (so the issue-watchdog triage doesn't re-select an already-fixed issue, and you never need a separate固化 PR):
-  1. Add a fact-check entry to `.cache/upstream/fact-checks.json` (for Wei-Shaw/sub2api) or `.cache/anthropic/cc-fact-checks.json` (for anthropics/claude-code). The `fixed_if_all_present` anchors (`path:needle`) are the irreducible human judgment — pick stable lines that prove the fix is present on `main`.
-  2. Run `python3 scripts/upstream/apply-fix-ledger.py --ledger <upstream|anthropic> --apply` to propagate it into `fixes.json` + `triage.json` (byte-identical to the daily `*-issue-watchdog.yml`, so no dual-writer churn).
-  3. Declare the issue in a commit message trailer: `Upstream-Fixes: Wei-Shaw/sub2api#NNNN` or `Anthropic-Fixes: anthropics/claude-code#NNNN` (comma-separated for multi-issue fixes).
-  `scripts/preflight.sh` gates this mechanically (`sub2api: fix-ledger consistency`): a commit that declares a fix via the trailer must carry a matching fact-check whose anchors resolve and whose propagation is already applied — otherwise preflight fails with the exact `--apply` command to run. The gate is trailer-scoped, so PRs that don't declare a fix are unaffected.
+**Before push:** run `./scripts/preflight.sh` + `make test`. PR checklist detail in agent-reference doc above.

--- a/docs/global/agent-reference.md
+++ b/docs/global/agent-reference.md
@@ -1,0 +1,72 @@
+# Agent reference (CLAUDE.md overflow)
+
+Long-form operational reference moved out of root `CLAUDE.md` to stay under the Claude Code memory limit. Hard rules remain in `CLAUDE.md`; load this file when you need gateway topology, Studio SSOT, or the full PR checklist.
+
+## Studio SSOT (`/studio` Image / Video / BakeOff)
+
+`/studio` 三页（`ImageStudio` / `VideoStudio` / `BakeOff`）共享的历史、预览、下载、重载行为**禁止**在页面内各写一套。Owner 如下（#1092 视频 SSOT + 图片 SSOT 扩展）：
+
+| 意图 | Owner | 消费方 |
+| --- | --- | --- |
+| 媒体历史持久化（localStorage 元数据 + IndexedDB 镜像） | `composables/useMediaLibrary.ts` + `utils/studioBlobCache.tk.ts` | Image / Video / BakeOff |
+| 图片历史 mount（IDB hydrate → s3Key presign → thumb error 回退） | `composables/useStudioImageLibrary.ts` | ImageStudio, BakeOff |
+| 视频历史 mount（IDB hydrate） | `composables/useStudioVideoLibrary.ts` | VideoStudio, BakeOff |
+| 图片 lightbox 状态 | `composables/useStudioImagePreview.ts` + `components/StudioImagePreviewLightbox.vue` | ImageStudio |
+| 图片 history id / ephemeral src / revised_prompt tooltip | `utils/studioImageHistory.tk.ts` | useMediaLibrary, ImageStudio, BakeOff |
+| 视频 lightbox 状态 + 过期播放守卫 | `composables/useStudioVideoPreview.ts` + `components/StudioVideoPreviewLightbox.vue` | VideoStudio, BakeOff |
+| 视频卡片 copy-link / 下载 | `composables/useStudioVideoCardActions.ts` + `utils/studioDownload.tk.ts` | VideoStudio, BakeOff |
+| 视频 playback 分类 + IDB 镜像 | `utils/studioPlaybackStorage.tk.ts` (`tagStudioVideoPlayback`) | VideoStudio, BakeOff |
+| 视频 tab-local Blob 播放 | `utils/studioMedia.tk.ts` (`videoPlaybackUrl`) | lightbox + BakeOff 面板 |
+
+新增 Studio 行为时：先查上表能否扩展 owner；若 Image **与** Video **与** BakeOff 任两者都需要，必须进共享 composable/组件并在 `scripts/sentinels/frontend-tk.json` 加锚点。宪法原则见 `dev-rules/global/CLAUDE.md` §5.1。
+
+## Disaster recovery / 数据重建从哪找
+
+prod 数据层要恢复/重建时，**先看 `deploy/aws/RUNBOOK-disaster-recovery.md` 顶部的「恢复资产地图」**——一张表说清每份备份（PG 账本、`.env` 密钥、CFN 模板、S3 离机 dump）存在哪、用哪节恢复。最常见 §3（实例死卷在→换机零丢失）；离机最后一手是 §4.4（S3 `s3://tokenkey-prod-pgdump-<acct>/prod/pgdump/`，hourly，RPO ≤1h）。
+
+## Current Gateway Flow
+
+```
+HTTP Request → Auth (JWT/APIKey) → Account Scheduling (sticky/load-aware)
+ → Platform-specific forwarding (Claude / OpenAI / Gemini / Antigravity / New API fifth platform `newapi`)
+ → Usage recording + quota deduction
+```
+
+The fifth platform **`newapi`** is a first-class account/group platform (not an add-on card on the other four): it uses OpenAI-compatible gateway routes and the New API **adaptor** layer in `internal/relay/bridge` when `channel_type > 0`. The `internal/integration/newapi/` package provides the channel-type catalog, affinity helpers, upstream model metadata helpers, and other `newapi`-specific bridge support required by TokenKey's fifth-platform flow.
+
+**Image and video generation surfaces** ride on the same `newapi` (and `openai`) compat-pool routing:
+
+- **Sync image** — `POST /v1/images/generations` (and `POST /images/generations` alias) via `bridge.RunImageRelay` and `bridge.DispatchImageGenerations`. Volcengine `channel_type=45` (Doubao Seedream) is supported through the upstream `volcengine` adapter.
+- **Async video** — `POST /v1/video/generations` + `GET /v1/video/generations/:task_id` (and the OpenAI-compat aliases `POST /v1/videos` + `GET /v1/videos/:task_id`, plus their no-prefix variants). Submit returns a TokenKey-issued `task_id` (prefix `vt_`); subsequent polls hit the upstream task adapter pinned at submit time. Supported channel types are auto-derived from `relay.GetTaskAdaptor` — i.e. whatever new-api's task-adaptor registry maps (as of 2026-06 that includes VolcEngine `45` / DoubaoVideo `54` → Doubao Seedance, Vertex AI `41` → Veo, plus Ali, Kling, Jimeng, Vidu, Sora/OpenAI, Gemini, MiniMax); never hard-code a channel list in TK code or docs — the predicate below is the single source of truth. Routing metadata lives in `service.VideoTaskCache` (Redis primary, in-memory fallback for single-replica dev). Default record TTL is 24h; terminal status (`succeeded`/`failed`) deletes the record. Adding a new task adapter upstream requires no TK code changes — the `IsVideoSupportedChannelType` predicate sees the new channel type as soon as the upstream adapter map registers it.
+
+**Scheduling-pool semantics (per `docs/approved/newapi-as-fifth-platform.md`, shipped):** the OpenAI-compatible pool now partitions strictly by `group.platform`. `openai` groups schedule only `openai` accounts; `newapi` groups schedule only `newapi` accounts (with `channel_type > 0`). The canonical predicate is `account.IsOpenAICompatPoolMember(groupPlatform)` in `backend/internal/service/account_tk_compat_pool.go`, used by load-balance, sticky-session, and recheck paths in `openai_account_scheduler.go` / `openai_gateway_service.go`. Cross-platform fallback is forbidden — an empty pool surfaces an error. Sticky-session bindings whose bound account drifted to the wrong platform (or whose `channel_type` was reset to 0) are invalidated and the request fails over to load-balance. `messages_dispatch_model_config` is preserved for `openai` and `newapi` groups, cleared for `anthropic` / `gemini` / `antigravity` (predicate: `isOpenAICompatPlatformGroup`). Sticky routing (per `docs/approved/sticky-routing.md`, shipped) layers above this pool to optimize prompt-cache hit rates within each platform's bucket.
+
+## prod ↔ Edge mirror relay topology
+
+Production (`api.tokenkey.dev`) is **not** where the upstream Anthropic OAuth capacity lives. prod holds `cc-<edge>` mirror accounts (`platform=anthropic, type=apikey`) whose `credentials.base_url = https://api-<edge>.tokenkey.dev`; they relay prod traffic to the **Edge Stage0 stacks** (Lightsail-only since 2026-06-07; the EC2/CFN edge matrix was retired — fleet source of truth: `deploy/aws/lightsail/edge-targets-lightsail.json`), which hold the real OAuth/setup-token accounts and forward to Anthropic. (prod itself remains EC2/CFN; only the edge fleet is Lightsail.) So the prod anthropic pool failing over across `cc-us3 / cc-us6 / …` is failing over across *edges*, not local accounts.
+
+**Attribution discipline:** a prod `cc-<edge>` cooldown (`temp_unschedulable_reason.matched_keyword='anthropic_upstream_error'`) is almost never prod-local — the real cause is on that edge. prod's `upstream-429 by account` / `recovered-200` are polluted by client-cancel tagging + failover smear and **cannot tell a dead edge from a healthy one** (a dead single-account edge and a healthy multi-account edge can both read ~1300 upstream-429). The reliable signal is each edge's OWN access-log `served_200 : no_available_429` ratio + schedulable-account count — run `ops/observability/scan-edge-health.sh`. See skills `tokenkey-online-log-troubleshooting` (§0 trap 9, §6.1 D) and `tokenkey-online-traffic-profile` (§4.1).
+
+## PR Checklist
+
+- `go test -tags=unit ./...` passes
+- `go test -tags=integration ./...` passes
+- `golangci-lint run ./...` — no new issues
+- `pnpm-lock.yaml` in sync (if `package.json` changed)
+- Test stubs complete (if interfaces changed)
+- Ent generated code committed (if schema changed)
+- `go build ./...` succeeds (cross-repo dependency compiles)
+- If bumping `backend/cmd/server/VERSION` for a release: commit message contains **no** literal `[skip ci]` / `[ci skip]` anywhere (rule 9.2 — discussion of the marker counts as carrying it). Use `bash scripts/release-tag.sh vX.Y.Z` to push the tag — it enforces this mechanically.
+- If touching `.github/workflows/release.yml`: `simple_release` default stays `false`; warning banner step is intact (rule 9.1)
+- If the PR deletes any upstream-owned file/method/route: PR description contains the (a)/(b)/(c) justification block from rule §5.x; otherwise change to "override default" or "disable via setting" instead
+- After upstream merge: PR body includes `git log --oneline upstream/main..HEAD | wc -l` and the top-5 lines of `git diff --stat upstream/main..HEAD -- backend/` (rule §5.y audit cadence). The `Upstream Merge PR Shape` workflow (§5.y.1) enforces this automatically — fix any failures it reports rather than ignoring them.
+- Drift check: before opening any non-trivial PR, run `bash scripts/upstream/check-drift.sh`. If TK is behind upstream/main, pause and either land the upstream merge first or document why this PR ships out of order.
+- Upstream override marker (rule §5.y.1): if the PR diff touches any upstream-shaped path (handlers / services / repositories / middleware / relay / server / views / components / api / migrations / ent schema, excluding `*_tk_*.go` / `*.tk.ts` / `*_test.go` / TK-only subpackages), the gate is **coverage-first** — a pure-insertion diff or **verified sentinel coverage** of every deletion-bearing upstream file (its `path` pinned in some `scripts/sentinels/*.json`, pre-existing or added this PR) auto-passes with no marker. Only an *uncovered* revert-risk edit needs a marker. `upstream-touch-guarded` is **mechanically verified**: it claims the touched files are already pinned, so a false claim (no covering sentinel `path`) **fails** the gate — prefer adding the real anchor. The other three (`upstream-touch-trivial` / `upstream-merge` / `no-upstream-touch`) are honest opt-outs asserting protection is not needed. `scripts/preflight.sh` enforces this mechanically via `scripts/checks/upstream-override-marker.py`.
+- Reviewer picks the GitHub merge button per rule §5.y: **Squash and merge** for TK-originated PRs (feature / fix / chore / docs), **Create a merge commit** for `merge/upstream-*` PRs. Never use **Rebase and merge** on `main`.
+- **Root docs / deploy boundary:** keep root user-facing files (`README*.md`, root compose examples, generic upstream deployment snippets) aligned with upstream by default. TokenKey-specific local Stage0 validation, AWS prod deployment, smoke-test, image/tag, domain, and operator runbook changes belong under `deploy/*` (or the matching skill text), not in root README files. Only change root files when the build/release contract truly requires it, and prefer a short pointer to `deploy/*` over duplicating deployment steps.
+- If the PR touches `dev-rules/` (submodule pointer bump or `.cursor/rules/` resync): per rule §10, the dev-rules submodule MUST be pushed first; this PR's CI `preflight` job will fail otherwise (the dev-rules SHA in `.gitmodules` won't be reachable on `origin/main`).
+- **If the PR fixes an upstream / claude-code issue, record it in the fix ledger from inside the PR** (so the issue-watchdog triage doesn't re-select an already-fixed issue, and you never need a separate固化 PR):
+  1. Add a fact-check entry to `.cache/upstream/fact-checks.json` (for Wei-Shaw/sub2api) or `.cache/anthropic/cc-fact-checks.json` (for anthropics/claude-code). The `fixed_if_all_present` anchors (`path:needle`) are the irreducible human judgment — pick stable lines that prove the fix is present on `main`.
+  2. Run `python3 scripts/upstream/apply-fix-ledger.py --ledger <upstream|anthropic> --apply` to propagate it into `fixes.json` + `triage.json` (byte-identical to the daily `*-issue-watchdog.yml`, so no dual-writer churn).
+  3. Declare the issue in a commit message trailer: `Upstream-Fixes: Wei-Shaw/sub2api#NNNN` or `Anthropic-Fixes: anthropics/claude-code#NNNN` (comma-separated for multi-issue fixes).
+  `scripts/preflight.sh` gates this mechanically (`sub2api: fix-ledger consistency`): a commit that declares a fix via the trailer must carry a matching fact-check whose anchors resolve and whose propagation is already applied — otherwise preflight fails with the exact `--apply` command to run. The gate is trailer-scoped, so PRs that don't declare a fix are unaffected.

--- a/docs/global/upstream-merge-discipline.md
+++ b/docs/global/upstream-merge-discipline.md
@@ -1,0 +1,52 @@
+# Upstream merge discipline (CLAUDE.md §5 overflow)
+
+Canonical hard rules stay in root `CLAUDE.md` §5; this file holds the long-form reference for merge history, mechanical gates, and minimal-invasion patterns.
+
+## 5.y Forward-looking history & merge discipline
+
+The `main` branch is **immutable history** once pushed. The TK-ahead commits include both linear and merge commits and several `vX.Y.Z` tags pointing into them — rewriting history would orphan tags and break PR audit trails. Going forward:
+
+- **No history rewrites on `main`.** No `git rebase -i` of pushed commits, no `git push --force` to `main`/`master`, no squash-merge of already-merged feature branches.
+- **Every TK feature lands via PR** with a clear scope (new file or one upstream-file injection point), reviewed against rule §5 above. Small + frequent beats one giant rebase.
+- **PR merge mode is content-typed, not personal preference:**
+  - **TK feature / fix / chore PRs** (anything originating from this fork) → GitHub **"Squash and merge"**. The PR becomes **one** commit on `main` whose title = PR title and whose body aggregates the development commits. Rationale: the feature branch's work-in-progress commits (`fix lint`, `typo`, `rebase main`, sync-VERSION housekeeping) carry no long-term audit value once the PR is approved as a unit; collapsing them keeps `git log --oneline --first-parent main` readable and keeps the per-PR diff trivially `git revert`-able.
+  - **Upstream merge PRs** (`merge/upstream-YYYYMMDD`) → GitHub **"Create a merge commit"** invoked locally as `git merge --no-ff upstream/main`. Never `--squash`, never `--ff-only`. Rationale: each upstream commit is an external contract reference; squashing them severs the `git log upstream/main..HEAD` audit chain that §5.y depends on.
+  - This is **not** a contradiction with "no squash-merge of already-merged feature branches" above: that rule forbids rewriting commits **already on `main`**; the squash here happens **at PR-merge time**, before anything reaches `main`.
+- **`git merge-tree upstream/main HEAD` is the pre-merge dry-run.** Run it before any upstream merge to surface conflicts; resolve in a dedicated `merge/upstream-YYYYMMDD` branch, not on `main`.
+- **Tag = consolidation point, not a rewrite cue.** When you tag `vX.Y.Z`, all earlier commits become permanent history. If a tag points at a commit with `[skip ci]` (see CLAUDE.md §9.2), do NOT delete and re-tag — dispatch the workflow manually.
+- **Audit cadence:** every merge PR description includes `git log --oneline upstream/main..HEAD | wc -l` (TK ahead count) + `git diff --stat upstream/main..HEAD -- backend/` (top changed files). Use these numbers to decide whether the next batch of TK work should be split into smaller PRs.
+
+## 5.y.1 Mechanical enforcement stack
+
+Per dev-rules §"Hard Constraint Wiring" — every soft rule above MUST have an automated gate.
+
+| Mechanism | Trigger | What it does |
+|---|---|---|
+| `scripts/upstream/check-drift.sh` | local, on demand | Prints TK ahead/behind vs `upstream/main` + the §5.y procedure when behind. Exit: `0` synced, `1` behind, `2` failure; `--json` / `--quiet`. |
+| `.github/workflows/upstream-merge-agent-daily.yml` | daily 04:00 Asia/Shanghai + manual dispatch | Single periodic upstream-sync path: drift → headless merge automation when needed → final preflight + PR-body cadence audit; actionable blockers tracked via the `upstream-merge-agent` issue channel. |
+| `.github/workflows/upstream-merge-pr-shape.yml` | PRs from `merge/upstream-*` | Hard gates: (a) PR must contain a merge commit whose second parent is reachable from `upstream/main` (squash/ff fail), (b) PR body must include the literal substring `upstream/main..HEAD` (§5.y audit cadence), (c) no first-parent commit introduced by the PR may carry the bracketed skip-ci marker (see CLAUDE.md §9.2; imported upstream history exempt), (d) the newapi sentinel registry (`scripts/sentinels/newapi.json`) is intact — `scripts/preflight.sh` runs the same script locally. |
+| `scripts/checks/upstream-override-marker.py` (via `scripts/preflight.sh`) | every PR (CI preflight + local pre-commit) | When the PR diff touches any upstream-shaped path (handlers/services/views/… excluding `*_tk_*.go` / `*.tk.ts` / `*_test.go` / TK-only subpackages), the gate is **coverage-first**: a pure-insertion diff or **verified sentinel coverage** of every deletion-bearing upstream file (its `path` is pinned in some `scripts/sentinels/*.json`, pre-existing or added this PR) auto-passes with **no marker**. Only an *uncovered* revert-risk edit needs a marker. `upstream-touch-guarded` is **mechanically verified, not trusted**: it asserts the touched files are already pinned, so if they are NOT the claim is false and the gate **fails** (it can no longer be a free bypass — covered edits already passed without it). The other three markers assert protection is *not needed* and remain honest, reviewer-visible opt-outs: `upstream-touch-trivial` (no revert risk) / `upstream-merge` (the merge PR) / `no-upstream-touch` (misclassified path). Forced confrontation before merge, like `no-web-impact`. |
+| `.github/workflows/main-ancestry-guard.yml` | any PR with `base.ref == 'main'` | **Check 1:** PR base must be an ancestor of PR head (catches the PR #307 orphan-reset mode). **Check 2:** `.main-ancestry-anchor` may only change with the `main-ancestry-anchor-advance` marker AND a new SHA descending from the old (see below). **Check 3:** PR title/body/commit messages must not contain the bracketed forms `[skip ci]` / `[ci skip]` (see CLAUDE.md §9.2). |
+| `scripts/checks/main-ancestry-anchor.py` (via `scripts/preflight.sh`) | every PR (CI preflight + local pre-commit) | Verifies the SHA in repo-root `.main-ancestry-anchor` is an ancestor of HEAD — catches orphan-resets on paths the PR-level guard can't see (direct push, force push, propagated reset). |
+
+**Anchor advancement.** `.main-ancestry-anchor` is a one-way ratchet: a known-good SHA every future HEAD must descend from (baseline `62482fa9bc30ac292ecca92341ef055a024d8a26`, locked after the PR #307 orphan-reset incident). To advance it: open a PR that updates the file AND carries the literal marker `main-ancestry-anchor-advance` + a one-line justification in a commit message. Guard Check 2 also requires the new SHA to be a descendant of the old one — the descendant check is the real ratchet, the marker is the human-attention gate.
+
+**Branch protection on `main`** SHOULD list `Upstream Merge PR Shape / validate` and `Main Ancestry Guard / validate` as required status checks (Settings → Branches → main). Known limit: GitHub doesn't expose merge-method choice, so these gates can't stop a manual "Squash and merge" click on a merge PR — they only make the wrong shape fail CI.
+
+## Convergence & minimal invasion (especially large upstream files)
+
+**Goal:** TK behavior should **converge** into dedicated modules so the fork stays **merge-friendly**; upstream files should read almost unchanged except for **thin injection points** (imports + a few lines, not new pages of logic).
+
+**When the file is upstream-shaped and large** (e.g. `gateway_handler*.go`, `openai_*_handler.go`, `setting_handler.go`, `endpoint.go`, `ChannelsView.vue`, account modals):
+
+1. **Do not** paste multi-screen TK branches, repeated error handling, or catalog/API glue into the upstream file.
+2. **Do** implement behavior in a companion and call it from upstream:
+   - **Go (same package):** `*_tk_*.go` — selection/affinity, relay error JSON, endpoint aliases, settings merge fields, passkey routes, admin route registration helpers (`registerTK*`), etc.
+   - **Go (shared across handlers):** small neutral helpers in the `handler` package (e.g. `TkTryWriteNewAPIRelayErrorJSON`, `TkAPIKeyGroupName`) to dedupe without inflating each upstream handler.
+   - **Routes:** move new paths and predicates into `*_tk_*.go` in `internal/server/routes/`; keep `admin.go` / `gateway.go` to a single `registerTK…()` call where possible.
+   - **Vue / TS:** `frontend/src/composables/useTk*.ts` (and `constants/` or `*.tk.ts` for pure maps). Views and modals stay **template + wiring**; composables own API calls, watchers, and state for TK-only flows.
+3. **Upstream file edits** should trend toward: **one import block delta + one-line hooks** (or replacing a repeated 10–20 line pattern with **one** helper call), not reformatting or reordering unrelated upstream code.
+4. **DTO / struct fields** that belong to the upstream request/response shape may still live in the primary handler file; **validation, merge rules, and audit diffs** belong in `*_tk_*.go` helpers.
+5. **Out of scope for this pattern:** Ent schema + generated `ent/`, `wire_gen.go`, and migration SQL — follow schema-first rules; generated churn is expected.
+
+**Anti-patterns:** Duplicating the same `errors.As` + JSON response blocks across handlers; duplicating aggregated-admin API logic across large `.vue` files; registering many new routes inline in `admin.go` instead of a `registerTK…` helper.


### PR DESCRIPTION
## 摘要

- 根目录 `CLAUDE.md` 从约 42k 字符压缩至约 16k，消除 Claude Code `/memory` 40k 超限告警。
- 长文参考外移至 `docs/global/upstream-merge-discipline.md`（§5.y 合并纪律、机械门禁、最小侵入）与 `docs/global/agent-reference.md`（网关拓扑、Studio SSOT、PR checklist）。
- 根文件保留全部 Hard Rules（§1–§10）及 CI/preflight 引用的节锚点（§5.y、§5.y.1 等）。

## 风险

- 低风险：纯文档重组，无代码/契约行为变更。
- Agent 需通过链接读取外移细节；硬规则与节标题仍在 `CLAUDE.md`。

## 验证

- `wc -c CLAUDE.md` → 16300 字符（< 40k）
- pre-commit `preflight` 全绿（含 commit 时机械检查）

## 提交

- c6d16c608 docs: trim CLAUDE.md under Claude Code 40k memory limit

最新提交：c6d16c608
