### PR TITLE
fix(studio): 同台对比视频时长默认与模型选择顺序解耦

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 539,
-  "hash": "0ce7c77aa4f98088bb234a9effc8701b63a1e81cf9533801c002ababc03426a0",
+  "hash": "2738fb51d316a2228fdf2b68ed5f63c2e0e9d6d09c92a765c9fe9243bf9683d7",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/migrations/auth_identity_payment_migrations_regression_test.go
+++ b/backend/migrations/auth_identity_payment_migrations_regression_test.go
@@ -168,3 +168,15 @@ func TestMigration151AddsAccountAutoPauseExpiryPartialIndex(t *testing.T) {
 	require.Contains(t, sql, "auto_pause_on_expired = TRUE")
 	require.Contains(t, sql, "expires_at IS NOT NULL")
 }
+
+func TestMigrationTk041SkipsPartitionOverlapWhenLegacyStillCoversMonth(t *testing.T) {
+	content, err := FS.ReadFile("tk_041_provision_ops_monthly_partitions.sql")
+	require.NoError(t, err)
+
+	sql := string(content)
+	require.Contains(t, sql, "CREATE TABLE IF NOT EXISTS")
+	require.Contains(t, sql, "WHEN SQLSTATE '42P17' THEN")
+	require.Contains(t, sql, "'ops_system_logs', '202607'")
+	require.Contains(t, sql, "'ops_error_logs', '202610'")
+	require.Contains(t, sql, "rec.parent_table || '_' || rec.suffix")
+}

--- a/backend/migrations/tk_041_provision_ops_monthly_partitions.sql
+++ b/backend/migrations/tk_041_provision_ops_monthly_partitions.sql
@@ -2,31 +2,58 @@
 -- partitioned ops tables.
 --
 -- Context: ops_system_logs / ops_error_logs were converted to RANGE-partitioned
--- tables whose only child today is the wide legacy partition
--- `FOR VALUES FROM (MINVALUE) TO ('2026-07-01')`. That partition absorbs all
--- current writes, but there is NO partition for 2026-07-01 onward — so once the
--- calendar crosses 2026-07-01, an insert with created_at >= 2026-07-01 would have
--- no home and FAIL (there is no DEFAULT partition). The daily cleanup's
+-- tables whose legacy partition upper bound is computed at conversion time
+-- (tk_035/tk_037: [MINVALUE, next_month) where next_month rolls with UTC
+-- calendar). Going-forward monthly partitions must exist so inserts after the
+-- legacy bound have a home (no DEFAULT partition). The daily cleanup's
 -- EnsureMonthly is supposed to keep future months provisioned, but on prod none
 -- existed as of this change, so this migration guarantees the routing safety net
 -- independent of the background job.
 --
--- Names + bounds match pgpartition.EnsureMonthly exactly (table_YYYYMM, monthly
--- [first-of-month, first-of-next-month)), so this is idempotent with the job:
--- whichever runs first wins, the other is a no-op via IF NOT EXISTS. No overlap
--- with the legacy partition (legacy is exclusive at 2026-07-01). Empty partitions
--- cost nothing.
---
--- This also unblocks retention going forward: once writes land in dated monthly
--- partitions, DropExpired can drop whole past months instantly (and tk_040's
--- straddling chunked-DELETE bounds the legacy partition until it ages out).
+-- Static month targets below match the original 202607..202610 rollout. When the
+-- legacy partition still covers a target month (calendar rolled past the original
+-- tk_035 anchor), CREATE raises SQLSTATE 42P17 (overlap) — same benign case as
+-- pgpartition.EnsureMonthly and is skipped here. IF NOT EXISTS + overlap-skip
+-- keeps this idempotent with tk_035/tk_037 and the runtime job.
 
-CREATE TABLE IF NOT EXISTS ops_system_logs_202607 PARTITION OF ops_system_logs FOR VALUES FROM ('2026-07-01') TO ('2026-08-01');
-CREATE TABLE IF NOT EXISTS ops_system_logs_202608 PARTITION OF ops_system_logs FOR VALUES FROM ('2026-08-01') TO ('2026-09-01');
-CREATE TABLE IF NOT EXISTS ops_system_logs_202609 PARTITION OF ops_system_logs FOR VALUES FROM ('2026-09-01') TO ('2026-10-01');
-CREATE TABLE IF NOT EXISTS ops_system_logs_202610 PARTITION OF ops_system_logs FOR VALUES FROM ('2026-10-01') TO ('2026-11-01');
+DO $$
+DECLARE
+  rec record;
+BEGIN
+  FOR rec IN
+    SELECT * FROM (VALUES
+      ('ops_system_logs', '202607', DATE '2026-07-01', DATE '2026-08-01'),
+      ('ops_system_logs', '202608', DATE '2026-08-01', DATE '2026-09-01'),
+      ('ops_system_logs', '202609', DATE '2026-09-01', DATE '2026-10-01'),
+      ('ops_system_logs', '202610', DATE '2026-10-01', DATE '2026-11-01'),
+      ('ops_error_logs', '202607', DATE '2026-07-01', DATE '2026-08-01'),
+      ('ops_error_logs', '202608', DATE '2026-08-01', DATE '2026-09-01'),
+      ('ops_error_logs', '202609', DATE '2026-09-01', DATE '2026-10-01'),
+      ('ops_error_logs', '202610', DATE '2026-10-01', DATE '2026-11-01')
+    ) AS v(parent_table, suffix, start_d, end_d)
+  LOOP
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_partitioned_table pt
+      JOIN pg_class c ON c.oid = pt.partrelid
+      WHERE c.relname = rec.parent_table
+    ) THEN
+      CONTINUE;
+    END IF;
 
-CREATE TABLE IF NOT EXISTS ops_error_logs_202607 PARTITION OF ops_error_logs FOR VALUES FROM ('2026-07-01') TO ('2026-08-01');
-CREATE TABLE IF NOT EXISTS ops_error_logs_202608 PARTITION OF ops_error_logs FOR VALUES FROM ('2026-08-01') TO ('2026-09-01');
-CREATE TABLE IF NOT EXISTS ops_error_logs_202609 PARTITION OF ops_error_logs FOR VALUES FROM ('2026-09-01') TO ('2026-10-01');
-CREATE TABLE IF NOT EXISTS ops_error_logs_202610 PARTITION OF ops_error_logs FOR VALUES FROM ('2026-10-01') TO ('2026-11-01');
+    BEGIN
+      EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
+        rec.parent_table || '_' || rec.suffix,
+        rec.parent_table,
+        rec.start_d,
+        rec.end_d
+      );
+    EXCEPTION
+      WHEN duplicate_table THEN
+        NULL;
+      WHEN SQLSTATE '42P17' THEN
+        NULL; -- month already covered by legacy or an existing sibling partition
+    END;
+  END LOOP;
+END $$;

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -76,6 +76,7 @@
             type="button"
             class="rounded-lg border px-3 py-1.5 text-sm font-medium tabular-nums transition disabled:cursor-not-allowed disabled:opacity-50"
             :class="duration === d ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 text-gray-600 hover:border-primary-300 dark:border-dark-600 dark:text-dark-300'"
+            :data-testid="`bakeoff-duration-${d}`"
             :disabled="isBusy"
             @click="duration = d"
           >
@@ -639,11 +640,10 @@ const durationOptions = computed<number[]>(() => {
   return [...set].sort((a, b) => a - b)
 })
 
-// Keep the shared target inside the union; default to its MAX (user directive).
+// Re-sync whenever the selected-model union changes so the default does not
+// depend on click order (Veo-first kept 8s while Seedance-first jumped to 10s).
 watch(durationOptions, (opts) => {
-  if (opts.length && !opts.includes(duration.value)) {
-    duration.value = videoDurationDefault(opts)
-  }
+  if (opts.length) duration.value = videoDurationDefault(opts)
 })
 
 /** Per-panel duration: the shared target snapped to THIS model's accepted set. */
@@ -687,6 +687,7 @@ function setModality(m: StudioModality): void {
   if (isBusy.value) return
   modality.value = m
   selectedModelIds.value = []
+  duration.value = VIDEO_DURATION_DEFAULT
   panels.value = []
   lastRunPrompt.value = ''
   activeRunTs.value = null

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -124,6 +124,53 @@ const videoProps = {
   ]),
 }
 
+describe('BakeOff video duration default', () => {
+  async function selectModels(wrapper: ReturnType<typeof mount>, indices: number[]): Promise<void> {
+    const tiers = wrapper.findAll('[data-testid="bakeoff-tier"]')
+    for (const i of indices) {
+      await tiers[i].trigger('click')
+    }
+  }
+
+  function selectedDurationChip(wrapper: ReturnType<typeof mount>) {
+    return wrapper.find('[data-testid^="bakeoff-duration-"].border-primary-600')
+  }
+
+  it('defaults to the union MAX regardless of model selection order', async () => {
+    const orders = [
+      [0, 1, 2],
+      [2, 1, 0],
+      [1, 0, 2],
+    ]
+    for (const order of orders) {
+      const wrapper = mount(BakeOff, {
+        props: videoProps,
+        global: { plugins: [i18n], stubs: { RouterLink: true } },
+      })
+      await selectModels(wrapper, order)
+      expect(selectedDurationChip(wrapper).attributes('data-testid')).toBe('bakeoff-duration-12')
+      wrapper.unmount()
+    }
+  })
+
+  it('keeps a manually picked duration until the selected model set changes', async () => {
+    const wrapper = mount(BakeOff, {
+      props: videoProps,
+      global: { plugins: [i18n], stubs: { RouterLink: true } },
+    })
+
+    await selectModels(wrapper, [0, 1, 2])
+    await wrapper.get('[data-testid="bakeoff-duration-8"]').trigger('click')
+    expect(selectedDurationChip(wrapper).attributes('data-testid')).toBe('bakeoff-duration-8')
+
+    await wrapper.get('[data-testid="bakeoff-duration-6"]').trigger('click')
+    expect(selectedDurationChip(wrapper).attributes('data-testid')).toBe('bakeoff-duration-6')
+
+    await selectModels(wrapper, [2])
+    expect(selectedDurationChip(wrapper).attributes('data-testid')).toBe('bakeoff-duration-12')
+  })
+})
+
 describe('BakeOff run gate', () => {
   beforeEach(() => {
     libraryMock.videoTasks.value = []


### PR DESCRIPTION
## 摘要

- 修复 Studio「同台对比」视频模式下，选中 Seedance 1.0 / Seedance 2.0 / Veo 3.1 时，默认时长随点击顺序在 8s 与 10s 间漂移的问题。
- `durationOptions` 变化时始终重置为 union 的 MAX，与选择顺序无关；各模型提交仍经 `snapVideoDuration` 落到自身合法时长。
- 修复 `tk_041` 静态分区迁移在 UTC 进入 202607 后与 `tk_035` 动态 legacy 上界重叠，导致 `test-integration` CI 失败的问题（捕获 SQLSTATE 42P17 并跳过，与 `EnsureMonthly` 一致）。

## 风险

- 常规风险：Studio 同台对比默认时长逻辑变更；手动点选 chip 后保留，直到已选模型集合再次变化。
- 迁移：`tk_041` 对已部署环境为幂等（已成功的 CREATE 不会重跑；fresh DB 在 legacy 仍覆盖目标月时跳过重叠）。

## 验证

- `./scripts/preflight.sh` PASS
- `pnpm --dir frontend exec vitest run src/views/user/studio/__tests__/BakeOff.spec.ts` — 13 passed
- `go test -tags=unit ./migrations/ -run TestMigrationTk041` PASS
- CI `test-integration` PASS（修复后）

sentinel-registry-reviewed

## 提交

- b39fd3b84 fix(studio): 同台对比时长默认与模型选择顺序解耦
- e65633229 fix(migrations): tk_041 跳过分区重叠以适配 legacy 边界漂移 high-risk-anchor

最新提交：e65633229
