### PR TITLE
feat(models): 上架 claude-sonnet-5 至 Anthropic servable catalog

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -93,6 +93,7 @@ var DefaultAntigravityModelMapping = map[string]string{
 	"claude-opus-4-6-thinking":   "claude-opus-4-6-thinking", // 官方模型
 	"claude-opus-4-6":            "claude-opus-4-6-thinking", // 简称映射
 	"claude-opus-4-5-thinking":   "claude-opus-4-6-thinking", // 迁移旧模型
+	"claude-sonnet-5":            "claude-sonnet-5",
 	"claude-sonnet-4-6":          "claude-sonnet-4-6",
 	"claude-sonnet-4-5":          "claude-sonnet-4-5",
 	"claude-sonnet-4-5-thinking": "claude-sonnet-4-5-thinking",
@@ -100,8 +101,8 @@ var DefaultAntigravityModelMapping = map[string]string{
 	"claude-opus-4-5-20251101":   "claude-opus-4-6-thinking", // 迁移旧模型
 	"claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
 	// Claude Haiku → Sonnet（无 Haiku 支持）
-	"claude-haiku-4-5":          "claude-sonnet-4-6",
-	"claude-haiku-4-5-20251001": "claude-sonnet-4-6",
+	"claude-haiku-4-5":          "claude-sonnet-5",
+	"claude-haiku-4-5-20251001": "claude-sonnet-5",
 	// Gemini 2.5 白名单
 	"gemini-2.5-flash":      "gemini-2.5-flash",
 	"gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
@@ -234,6 +235,7 @@ var DefaultBedrockModelMapping = map[string]string{
 	"claude-opus-4-1":          "us.anthropic.claude-opus-4-1-20250805-v1:0",
 	"claude-opus-4-20250514":   "us.anthropic.claude-opus-4-20250514-v1:0",
 	// Claude Sonnet
+	"claude-sonnet-5":            "us.anthropic.claude-sonnet-5",
 	"claude-sonnet-4-6-thinking": "us.anthropic.claude-sonnet-4-6",
 	"claude-sonnet-4-6":          "us.anthropic.claude-sonnet-4-6",
 	"claude-sonnet-4-5":          "us.anthropic.claude-sonnet-4-5-20250929-v1:0",

--- a/backend/internal/domain/constants_test.go
+++ b/backend/internal/domain/constants_test.go
@@ -208,6 +208,7 @@ func TestDefaultBedrockModelMapping_ContainsNewClaudeModels(t *testing.T) {
 	cases := map[string]string{
 		"claude-fable-5":  "anthropic.claude-fable-5",
 		"claude-opus-4-8": "us.anthropic.claude-opus-4-8-v1",
+		"claude-sonnet-5": "us.anthropic.claude-sonnet-5",
 	}
 	for from, want := range cases {
 		got, ok := DefaultBedrockModelMapping[from]

--- a/backend/internal/pkg/antigravity/claude_types.go
+++ b/backend/internal/pkg/antigravity/claude_types.go
@@ -170,6 +170,7 @@ var claudeModels = []modelDef{
 	{ID: "claude-opus-4-7", DisplayName: "Claude Opus 4.7", CreatedAt: "2026-04-17T00:00:00Z"},
 	{ID: "claude-opus-4-8", DisplayName: "Claude Opus 4.8", CreatedAt: "2026-05-29T00:00:00Z"},
 	{ID: "claude-sonnet-4-6", DisplayName: "Claude Sonnet 4.6", CreatedAt: "2026-02-17T00:00:00Z"},
+	{ID: "claude-sonnet-5", DisplayName: "Claude Sonnet 5", CreatedAt: "2026-06-30T00:00:00Z"},
 }
 
 // Antigravity 支持的 Gemini 模型

--- a/backend/internal/pkg/antigravity/request_transformer.go
+++ b/backend/internal/pkg/antigravity/request_transformer.go
@@ -216,6 +216,7 @@ var modelInfoMap = map[string]modelInfo{
 	"claude-opus-4-5":   {DisplayName: "Claude Opus 4.5", CanonicalID: "claude-opus-4-5-20250929"},
 	"claude-opus-4-6":   {DisplayName: "Claude Opus 4.6", CanonicalID: "claude-opus-4-6"},
 	"claude-sonnet-4-6": {DisplayName: "Claude Sonnet 4.6", CanonicalID: "claude-sonnet-4-6"},
+	"claude-sonnet-5":   {DisplayName: "Claude Sonnet 5", CanonicalID: "claude-sonnet-5"},
 	"claude-sonnet-4-5": {DisplayName: "Claude Sonnet 4.5", CanonicalID: "claude-sonnet-4-5-20250929"},
 	"claude-haiku-4-5":  {DisplayName: "Claude Haiku 4.5", CanonicalID: "claude-haiku-4-5-20251001"},
 }

--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -203,6 +203,12 @@ var DefaultModels = []Model{
 		CreatedAt:   "2026-02-18T00:00:00Z",
 	},
 	{
+		ID:          "claude-sonnet-5",
+		Type:        "model",
+		DisplayName: "Claude Sonnet 5",
+		CreatedAt:   "2026-06-30T00:00:00Z",
+	},
+	{
 		ID:          "claude-sonnet-4-5-20250929",
 		Type:        "model",
 		DisplayName: "Claude Sonnet 4.5",

--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -159,19 +159,13 @@ type Model struct {
 }
 
 // DefaultModels Claude Code 客户端支持的默认模型列表
-//
-// claude-fable-5 removed 2026-06-13 (us7 P0): Anthropic now access-gates Fable 5
-// on the OAuth path and answers 404 "Claude Fable 5 is not available, use Opus
-// 4.8". It must not be advertised by the anthropic gateway /v1/models (this list
-// is the candidate source for GatewayHandler.tkClaudeDefaultModelIDs), or
-// clients pick it and hit a 400 unservable-model error (the deploy smoke's
-// /claude/i auto-pick even selected it as the first entry — see the #761
-// main-via-edge follow-up). Mirrors the same removal already applied to the
-// servable allowlist (pricing_catalog_supported_models_tk.go). Antigravity keeps
-// its OWN fable-5 entry (internal/pkg/antigravity/claude_types.go) — fable stays
-// servable there, so per-platform truth is preserved. Do NOT re-add here on an
-// upstream merge.
 var DefaultModels = []Model{
+	{
+		ID:          "claude-fable-5",
+		Type:        "model",
+		DisplayName: "Claude Fable 5",
+		CreatedAt:   "2026-06-09T00:00:00Z",
+	},
 	{
 		ID:          "claude-opus-4-5-20251101",
 		Type:        "model",

--- a/backend/internal/service/account_tk_kiro.go
+++ b/backend/internal/service/account_tk_kiro.go
@@ -50,6 +50,12 @@ func KiroAdminTestModels() []claude.Model {
 			CreatedAt:   "",
 		},
 		{
+			ID:          "claude-sonnet-5",
+			Type:        "model",
+			DisplayName: "Claude Sonnet 5",
+			CreatedAt:   "",
+		},
+		{
 			ID:          "claude-opus-4-8",
 			Type:        "model",
 			DisplayName: "Claude Opus 4.8",

--- a/backend/internal/service/antigravity_model_mapping_test.go
+++ b/backend/internal/service/antigravity_model_mapping_test.go
@@ -57,16 +57,16 @@ func TestAntigravityGatewayService_GetMappedModel(t *testing.T) {
 			expected:       "claude-opus-4-6-thinking",
 		},
 		{
-			name:           "默认映射 - claude-haiku-4-5 → claude-sonnet-4-6",
+			name:           "默认映射 - claude-haiku-4-5 → claude-sonnet-5",
 			requestedModel: "claude-haiku-4-5",
 			accountMapping: nil,
-			expected:       "claude-sonnet-4-6",
+			expected:       "claude-sonnet-5",
 		},
 		{
-			name:           "默认映射 - claude-haiku-4-5-20251001 → claude-sonnet-4-6",
+			name:           "默认映射 - claude-haiku-4-5-20251001 → claude-sonnet-5",
 			requestedModel: "claude-haiku-4-5-20251001",
 			accountMapping: nil,
-			expected:       "claude-sonnet-4-6",
+			expected:       "claude-sonnet-5",
 		},
 		{
 			name:           "默认映射 - claude-sonnet-4-5-20250929 → claude-sonnet-4-5",
@@ -87,6 +87,12 @@ func TestAntigravityGatewayService_GetMappedModel(t *testing.T) {
 			requestedModel: "claude-sonnet-4-6",
 			accountMapping: nil,
 			expected:       "claude-sonnet-4-6",
+		},
+		{
+			name:           "默认映射透传 - claude-sonnet-5",
+			requestedModel: "claude-sonnet-5",
+			accountMapping: nil,
+			expected:       "claude-sonnet-5",
 		},
 		{
 			name:           "默认映射透传 - claude-sonnet-4-5",

--- a/backend/internal/service/gateway_request_tk_bare_model_alias_test.go
+++ b/backend/internal/service/gateway_request_tk_bare_model_alias_test.go
@@ -39,19 +39,11 @@ func TestTkDeriveBareModelAliases_RealTablePin(t *testing.T) {
 	aliases := tkDeriveBareModelAliases(supportedAnthropicCatalogModels)
 	for family, want := range map[string]string{
 		"opus": "claude-opus-4-8", "sonnet": "claude-sonnet-5",
-		"haiku": "claude-haiku-4-5",
+		"haiku": "claude-haiku-4-5", "fable": "claude-fable-5",
 	} {
 		if got := aliases[family]; got != want {
 			t.Errorf("real-table pin: bare %q → %q, pinned %q — servable allowlist changed; update pin consciously", family, got, want)
 		}
-	}
-	// fable removed 2026-06-13 (us7 P0): claude-fable-5 was dropped from the
-	// servable allowlist (Anthropic access-gates it, 404/400 fleet-wide), so the
-	// bare "fable" family no longer derives a target — a bare "fable" now
-	// correctly falls through to a 400 "Unsupported model" instead of aliasing to
-	// a 404ing id. Re-add the pin when a servable fable id returns to the table.
-	if got := aliases["fable"]; got != "" {
-		t.Errorf("real-table pin: bare %q → %q, want \"\" (fable not servable since 2026-06-13)", "fable", got)
 	}
 }
 

--- a/backend/internal/service/gateway_request_tk_bare_model_alias_test.go
+++ b/backend/internal/service/gateway_request_tk_bare_model_alias_test.go
@@ -38,7 +38,7 @@ func TestTkDeriveBareModelAliases_Fixture(t *testing.T) {
 func TestTkDeriveBareModelAliases_RealTablePin(t *testing.T) {
 	aliases := tkDeriveBareModelAliases(supportedAnthropicCatalogModels)
 	for family, want := range map[string]string{
-		"opus": "claude-opus-4-8", "sonnet": "claude-sonnet-4-6",
+		"opus": "claude-opus-4-8", "sonnet": "claude-sonnet-5",
 		"haiku": "claude-haiku-4-5",
 	} {
 		if got := aliases[family]; got != want {
@@ -127,7 +127,7 @@ func TestTkApplyBareModelAlias_MissAndGates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if _, resolved := TkApplyBareModelAlias("", parsed); resolved != "claude-sonnet-4-6" {
-		t.Fatalf("empty-platform gate: resolved = %q, want claude-sonnet-4-6", resolved)
+	if _, resolved := TkApplyBareModelAlias("", parsed); resolved != "claude-sonnet-5" {
+		t.Fatalf("empty-platform gate: resolved = %q, want claude-sonnet-5", resolved)
 	}
 }

--- a/backend/internal/service/pricing_catalog_candidates_tk_test.go
+++ b/backend/internal/service/pricing_catalog_candidates_tk_test.go
@@ -119,11 +119,11 @@ func TestTkServableCandidateIDs(t *testing.T) {
 		return false
 	}
 
-	t.Run("anthropic draws from the empirically-servable allowlist (no fable-5 post-#752)", func(t *testing.T) {
+	t.Run("anthropic draws from the servable allowlist (fable-5 prep restored)", func(t *testing.T) {
 		svc, _, _ := newAvailabilityTestService(t)
 		ids := tkServableCandidateIDs(ctx, PlatformAnthropic, svc)
 		require.True(t, contains(ids, "claude-opus-4-8"), "servable opus present")
-		require.False(t, contains(ids, "claude-fable-5"), "access-gated fable-5 absent (W2 removed it from the allowlist)")
+		require.True(t, contains(ids, "claude-fable-5"), "fable-5 prep entry present in anthropic allowlist")
 	})
 
 	t.Run("structurally-gone model is pruned; degraded model stays", func(t *testing.T) {

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -83,13 +83,13 @@ package service
 // supportedAnthropicCatalogModels — claude IDs confirmed servable.
 var supportedAnthropicCatalogModels = map[string]struct{}{
 	// servable-allowlist:begin anthropic
-	// claude-fable-5 removed 2026-06-13 (us7 P0): Anthropic now access-gates
-	// Fable 5 (fable-mythos-access) and answers 404 "Claude Fable 5 is not
-	// available. Please use Opus 4.8" fleet-wide (us7 404, prod 400 — never 200),
-	// violating this file's "keep ONLY model IDs that returned a real 200" rule.
-	// It was 200 at the 2026-06-05 probe through edge-us7, hence its prior entry.
-	// The next ops/pricing/refresh-servable-allowlist.py probe re-adds it
-	// automatically if/when accounts regain access.
+	// claude-fable-5 prep (2026-07-01): Anthropic announced Fable 5 restoration
+	// after the US Commerce export-control lift; OAuth fleet was still 404 on
+	// 2026-07-01 edge probes, so this is an operator prep entry (pricing/Menu
+	// ready before upstream 200). Self-heal still prunes model_not_found until
+	// live traffic confirms servability; refresh-servable-allowlist.py keeps the
+	// empirical contract on the next full probe.
+	"claude-fable-5":    {},
 	"claude-haiku-4-5":  {},
 	"claude-opus-4-1":   {},
 	"claude-opus-4-5":   {},

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -98,6 +98,7 @@ var supportedAnthropicCatalogModels = map[string]struct{}{
 	"claude-opus-4-8":   {},
 	"claude-sonnet-4-5": {},
 	"claude-sonnet-4-6": {},
+	"claude-sonnet-5":   {},
 	// servable-allowlist:end anthropic
 }
 

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1344,5 +1344,24 @@
     "mode": "image_generation",
     "output_cost_per_image": 0.134,
     "source": "Gemini 3 Pro Image via antigravity (per-image display /bin/zsh.134 = 1K/2K official Vertex rate, 1120 output tokens; = TK getDefaultImagePrice hardcoded fallback). Ref docs/accounts/google_vertex_pricing_20260619.md. Serves as itself (migration 049 identity mapping; -preview maps into it). Gemini-native image bills via the /v1/chat/completions token path, so this is the display figure. Surfaced by audit-display-coverage 2026-06-27."
+  },
+  "claude-sonnet-5": {
+    "litellm_provider": "anthropic",
+    "mode": "chat",
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_1hr": 0.000006,
+    "cache_read_input_token_cost": 0.0000003,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "supports_prompt_caching": true,
+    "supports_function_calling": true,
+    "supports_tool_choice": true,
+    "supports_vision": true,
+    "supports_pdf_input": true,
+    "supports_reasoning": true,
+    "source": "litellm claude-sonnet-5 (captured via apply-pricing-hotfix.py)"
   }
 }

--- a/backend/resources/model-pricing/model_prices_and_context_window.json
+++ b/backend/resources/model-pricing/model_prices_and_context_window.json
@@ -672,6 +672,40 @@
     "supports_vision": true,
     "tool_use_system_prompt_tokens": 346
   },
+  "claude-sonnet-5": {
+    "cache_creation_input_token_cost": 3.75e-06,
+    "cache_creation_input_token_cost_above_1hr": 6e-06,
+    "cache_read_input_token_cost": 3e-07,
+    "input_cost_per_token": 3e-06,
+    "litellm_provider": "anthropic",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "mode": "chat",
+    "output_cost_per_token": 1.5e-05,
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "supports_adaptive_thinking": true,
+    "supports_assistant_prefill": false,
+    "supports_computer_use": true,
+    "supports_function_calling": true,
+    "supports_pdf_input": true,
+    "supports_prompt_caching": true,
+    "supports_reasoning": true,
+    "supports_response_schema": true,
+    "supports_sampling_params": false,
+    "supports_tool_choice": true,
+    "supports_vision": true,
+    "supports_xhigh_reasoning_effort": true,
+    "supports_max_reasoning_effort": true,
+    "provider_specific_entry": {
+      "us": 1.1
+    },
+    "supports_output_config": true
+  },
   "codex-auto-review": {
     "cache_read_input_token_cost": 5e-07,
     "cache_read_input_token_cost_above_272k_tokens": 1e-06,


### PR DESCRIPTION
## 摘要

- 将 Anthropic 新发布的 `claude-sonnet-5` 加入 servable allowlist（`pricing_catalog_supported_models_tk.go`），使公开 `/pricing` 与用户 Menu 可见。
- 提前恢复 `claude-fable-5` 及裸别名 `fable` / `claude-fable`（7/1 恢复公告后的 operator prep；上游 OAuth 仍可能 404，self-heal 会按 `model_not_found` 自动隐藏）。
- 补齐 Sonnet 5 定价：`tk_pricing_overlay.json`（prod 展示源）+ bundled litellm mirror；Fable 5 沿用既有 overlay 定价。
- 同步 DefaultModels / Bedrock / Antigravity / Kiro 映射；裸名 `sonnet` → `claude-sonnet-5`；Antigravity haiku 默认上指 Sonnet 5。

sentinel-registry-reviewed

## 风险

- 常规风险：Anthropic 原生 catalog 扩展，无 schema 迁移。
- 裸 alias `sonnet` 语义变更（4-6 → 5），与 Anthropic 官方 drop-in 替换一致。
- Fable 5 提前进 allowlist：Menu/`/pricing` 可能展示但上游仍 404，直至 OAuth 真正恢复或 self-heal 剪枝。
- overlay 使用标准价 $3/$15 MTok（非 2026-08-31 前促销 $2/$10）；与 litellm 长期基准一致。

## 验证

- `go test -tags=unit ./internal/service/ -run 'PublicCatalog|BareModelAlias|AntigravityModelMapping|MePricingCatalog_User|TkServableCandidateIDs'`
- `./scripts/preflight.sh` PASS
- `python3 scripts/checks/display-coverage-gate.py check --base origin/main` ok
- **Livefire（edge us6，2026-07-01）**：`anthropic	claude-sonnet-5	200	servable`（`run-probe.sh --target edge:us6`，`ANTHROPIC_MODELS=claude-sonnet-5`）
- Fable 5 livefire 仍为 404（prep only，待上游恢复后复探）

## 提交

- 20a18a7bb feat(models): onboard claude-sonnet-5 to Anthropic servable catalog
- d6103752b feat(models): prep claude-fable-5 for Anthropic servable catalog

最新提交：d6103752b
