### PR TITLE
fix(ci): prompt-surface-watch 补 new-api checkout

### DIFF
--- a/.github/workflows/prompt-surface-watch.yml
+++ b/.github/workflows/prompt-surface-watch.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: ./.github/actions/cache-and-checkout-new-api
+
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod


### PR DESCRIPTION
## 摘要

- `prompt-surface-watch` 的 registry-gate 跑 `go test` 时缺少 `../../new-api`，与 backend-ci 不一致导致 workflow_dispatch 失败。

Web impact: none

## 风险

- 低风险：仅补 `.github/actions/cache-and-checkout-new-api` 一步。

## 验证

- 本地 registry + fixture gateway + go test 全绿
- preflight PASS

## 提交

- cccdec95f fix(ci): prompt-surface-watch 补 new-api checkout 以跑 gateway 单测

最新提交：cccdec95f
