### PR TITLE
fix(ci): prompt-surface-watch 在 backend/ 跑 go test

### DIFF
--- a/.github/workflows/prompt-surface-watch.yml
+++ b/.github/workflows/prompt-surface-watch.yml
@@ -52,9 +52,12 @@ jobs:
           set -euo pipefail
           python3 ops/anthropic/probe_prompt_surfaces.py --check-registry
           python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway
-          go test -tags=unit ./backend/internal/service \
-            -run 'TestTkExtractAnthropicPromptFingerprint|TestTkProbePromptSurfaceGatewayCoverageJSONL|TestTkNormalizeCCGeo' \
-            -count=1
+          (
+            cd backend
+            go test -tags=unit ./internal/service \
+              -run 'TestTkExtractAnthropicPromptFingerprint|TestTkProbePromptSurfaceGatewayCoverageJSONL|TestTkNormalizeCCGeo' \
+              -count=1
+          )
           python3 -m unittest ops.anthropic.test_probe_prompt_surfaces -v
           python3 -m unittest ops.anthropic.test_probe_cc_geo_stego -v
           python3 -m unittest ops.observability.test_probe_prompt_surface_fingerprints -v


### PR DESCRIPTION
## 摘要

- registry-gate 在仓库根目录执行 `go test ./backend/...` 会报 `cannot find main module`（go.mod 在 `backend/`）。

Web impact: none

## 风险

- 低风险：仅改 workflow 工作目录，与 probe 脚本一致。

## 验证

- 本地 registry + fixture gateway + `cd backend && go test` + python unittest 全绿

## 提交

- 497563b8e fix(ci): prompt-surface-watch 在 backend/ 目录跑 go test

最新提交：497563b8e
