### PR TITLE
feat(studio): Studio 媒体模型从 pricing catalog 派生，自动展示 Grok 视频

### DIFF
--- a/backend/internal/service/universal_routing_tk_endpoint_map.go
+++ b/backend/internal/service/universal_routing_tk_endpoint_map.go
@@ -108,7 +108,14 @@ func universalCandidatePlatforms(shape UniversalShape, forcedPlatform string, ha
 	case ShapeOpenAIImagesEdit:
 		return []string{PlatformOpenAI} // /v1/images/edits 仅 openai（handler 层硬门）
 	case ShapeOpenAIVideo:
-		return capabilityPlatforms(engine.BridgeEndpointVideoSubmit)
+		out := capabilityPlatforms(engine.BridgeEndpointVideoSubmit)
+		// grok-imagine-video rides the native xAI OAuth video API (channel_type=0),
+		// not the new-api task-adaptor bridge. Without grok in candidates, universal
+		// keys land on openai/newapi and fail at submit.
+		if universalModelPlatformHint(model) == PlatformGrok {
+			out = append(out, PlatformGrok)
+		}
+		return out
 	case ShapeGemini:
 		return []string{PlatformGemini, PlatformAntigravity}
 	default:

--- a/backend/internal/service/universal_routing_tk_resolver_test.go
+++ b/backend/internal/service/universal_routing_tk_resolver_test.go
@@ -122,6 +122,16 @@ func TestUniversalCandidatePlatforms(t *testing.T) {
 		t.Errorf("gemini-native image chat should include antigravity: %v", chatImage)
 	}
 
+	// grok-native video on /v1/video/generations also includes grok (not task-adaptor).
+	videoGrok := universalCandidatePlatforms(ShapeOpenAIVideo, "", false, "grok-imagine-video")
+	if !contains(videoGrok, PlatformOpenAI) || !contains(videoGrok, PlatformNewAPI) || !contains(videoGrok, PlatformGrok) {
+		t.Errorf("grok video should extend bridge candidates with grok platform: %v", videoGrok)
+	}
+	videoVeo := universalCandidatePlatforms(ShapeOpenAIVideo, "", false, "veo-3.1-generate-001")
+	if contains(videoVeo, PlatformGrok) {
+		t.Errorf("veo video should not pull grok into candidates: %v", videoVeo)
+	}
+
 	// gemini native pair.
 	gem := universalCandidatePlatforms(ShapeGemini, "", false, "")
 	if !contains(gem, PlatformGemini) || !contains(gem, PlatformAntigravity) {
@@ -179,6 +189,11 @@ func TestResolve_PicksByPlatformAndHint(t *testing.T) {
 	g, err = r.Resolve(ctx, key, ShapeGemini, "gemini-3-pro", "")
 	if err != nil || g == nil || g.Platform != PlatformGemini {
 		t.Fatalf("gemini resolve got %v err %v", g, err)
+	}
+	// video shape + grok-imagine-video → grok group (native xAI video arm, not newapi task adaptor).
+	g, err = r.Resolve(ctx, key, ShapeOpenAIVideo, "grok-imagine-video", "")
+	if err != nil || g == nil || g.Platform != PlatformGrok {
+		t.Fatalf("grok video resolve got %v err %v", g, err)
 	}
 }
 

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 542,
-  "hash": "3d0080af85b2a504d0915dc7cd1db642efa328afa935927b48ab3b315d17c081",
+  "file_count": 543,
+  "hash": "a8d044992e89cfe1ed761471deb7056786badbfff74c6ea4179ccde8c2dceffd",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
+++ b/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
@@ -170,7 +170,7 @@ describe('resolveAvailableModels (transparent model picker)', () => {
     expect(out[0].baseImagePrice).toBe(0.03)
   })
 
-  it('surfaces catalog-only models (e.g. grok-imagine-video) without a presentation gate', () => {
+  it('surfaces grok-imagine-video when priced and in the group pool', () => {
     const out = resolveAvailableModels(
       'video',
       GROK_VIDEO,
@@ -180,6 +180,22 @@ describe('resolveAvailableModels (transparent model picker)', () => {
     expect(out[0].model.modelId).toBe('grok-imagine-video')
     expect(out[0].model.displayName).toBe('Grok Imagine · Video')
     expect(out[0].perSecond).toBe(0.08)
+  })
+
+  it('builds conservative defaults when catalog lists a model not in MEDIA_MODELS', () => {
+    const unknownId = 'future-video-model-xyz'
+    const out = resolveAvailableModels(
+      'video',
+      new Set([unknownId]),
+      new Map([[unknownId, { perSecond: 0.12, billingMode: 'video', vendor: 'xai' }]])
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0].model.modelId).toBe(unknownId)
+    expect(out[0].model.displayName).toBe('Future Video Model Xyz')
+    expect(out[0].model.vendorLabel).toBe('xAI')
+    expect(out[0].model.supportedParams).toEqual([])
+    expect(out[0].model.videoDurations).toEqual([8])
+    expect(out[0].perSecond).toBe(0.12)
   })
 
   it('excludes models not in the group pool', () => {

--- a/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
+++ b/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
@@ -13,53 +13,75 @@ import {
   GEMINI_IMAGE_SIZES,
   type ModalityKeyOption,
   type StudioParam,
+  type MediaPriceMap,
 } from '@/constants/mediaTiers.tk'
+import { buildCatalogBillingIndex } from '@/utils/studioMediaCatalog.tk'
+
+function catalogFromIds(entries: Array<[string, 'image' | 'video']>) {
+  return buildCatalogBillingIndex(
+    entries.map(([model_id, billing_mode]) => ({
+      model_id,
+      pricing: {
+        billing_mode,
+        output_cost_per_image: billing_mode === 'image' ? 0.01 : undefined,
+        output_cost_per_second: billing_mode === 'video' ? 0.01 : undefined,
+      },
+    }))
+  )
+}
+
+const IMAGEN_CATALOG = catalogFromIds([
+  ['imagen-4.0-fast-generate-001', 'image'],
+  ['imagen-4.0-generate-001', 'image'],
+])
+const VEO_CATALOG = catalogFromIds([['veo-3.1-generate-001', 'video']])
+const GROK_VIDEO_CATALOG = catalogFromIds([['grok-imagine-video', 'video']])
+const EMPTY_CATALOG = buildCatalogBillingIndex([])
 
 // A Vertex group serves the imagen image tiers + the veo cinematic video tier.
 const IMAGEN = new Set(['imagen-4.0-fast-generate-001', 'imagen-4.0-generate-001'])
 const VEO = new Set(['veo-3.1-generate-001'])
+const GROK_VIDEO = new Set(['grok-imagine-video'])
 // An antigravity/gemini-text group serves none of the studio media tiers.
 const ANTIGRAVITY = new Set(['claude-sonnet-4-5', 'gemini-3-flash'])
 
 describe('modalityHasTiers', () => {
-  it('is true when the pool backs at least one tier', () => {
-    expect(modalityHasTiers('image', IMAGEN)).toBe(true)
-    expect(modalityHasTiers('video', VEO)).toBe(true)
+  it('is true when the pool backs at least one catalog media model', () => {
+    expect(modalityHasTiers('image', IMAGEN, IMAGEN_CATALOG)).toBe(true)
+    expect(modalityHasTiers('video', VEO, VEO_CATALOG)).toBe(true)
+    expect(modalityHasTiers('video', GROK_VIDEO, GROK_VIDEO_CATALOG)).toBe(true)
   })
 
-  it('is false for a pool with no backing model', () => {
-    expect(modalityHasTiers('image', ANTIGRAVITY)).toBe(false)
-    expect(modalityHasTiers('video', ANTIGRAVITY)).toBe(false)
-    expect(modalityHasTiers('image', VEO)).toBe(false) // veo backs video only
-    expect(modalityHasTiers('video', IMAGEN)).toBe(false)
-    expect(modalityHasTiers('image', new Set())).toBe(false)
+  it('is false for a pool with no catalog media model', () => {
+    expect(modalityHasTiers('image', ANTIGRAVITY, IMAGEN_CATALOG)).toBe(false)
+    expect(modalityHasTiers('video', ANTIGRAVITY, VEO_CATALOG)).toBe(false)
+    expect(modalityHasTiers('image', VEO, IMAGEN_CATALOG)).toBe(false)
+    expect(modalityHasTiers('video', IMAGEN, VEO_CATALOG)).toBe(false)
+    expect(modalityHasTiers('image', new Set(), EMPTY_CATALOG)).toBe(false)
   })
 
   it('is price-agnostic (the picker must not need a per-group price fetch)', () => {
-    // True on a servable group even before prices load — unlike the priced card
-    // resolver, which (deliberately) returns [] without a price map.
-    expect(modalityHasTiers('image', IMAGEN)).toBe(true)
+    expect(modalityHasTiers('image', IMAGEN, IMAGEN_CATALOG)).toBe(true)
     expect(resolveAvailableModels('image', IMAGEN, new Map())).toEqual([])
   })
 })
 
 describe('groupServes (chat as a peer picker modality)', () => {
   it('serves chat when the pool exposes any chat-classified id', () => {
-    // modalityForModel classifies non image/video ids as chat.
-    expect(groupServes('chat', ANTIGRAVITY)).toBe(true) // claude/gemini text models
-    expect(groupServes('chat', new Set(['gpt-5']))).toBe(true)
+    expect(groupServes('chat', ANTIGRAVITY, EMPTY_CATALOG)).toBe(true)
+    expect(groupServes('chat', new Set(['gpt-5']), EMPTY_CATALOG)).toBe(true)
   })
 
   it('does NOT serve chat for an image/video-only pool', () => {
-    expect(groupServes('chat', IMAGEN)).toBe(false)
-    expect(groupServes('chat', VEO)).toBe(false)
-    expect(groupServes('chat', new Set())).toBe(false)
+    expect(groupServes('chat', IMAGEN, IMAGEN_CATALOG)).toBe(false)
+    expect(groupServes('chat', VEO, VEO_CATALOG)).toBe(false)
+    expect(groupServes('chat', new Set(), EMPTY_CATALOG)).toBe(false)
   })
 
-  it('delegates to media tiers for image/video', () => {
-    expect(groupServes('image', IMAGEN)).toBe(true)
-    expect(groupServes('video', VEO)).toBe(true)
-    expect(groupServes('image', ANTIGRAVITY)).toBe(false)
+  it('delegates to catalog billing for image/video', () => {
+    expect(groupServes('image', IMAGEN, IMAGEN_CATALOG)).toBe(true)
+    expect(groupServes('video', VEO, VEO_CATALOG)).toBe(true)
+    expect(groupServes('image', ANTIGRAVITY, IMAGEN_CATALOG)).toBe(false)
   })
 })
 
@@ -69,48 +91,41 @@ function opt(id: number, isTrial: boolean, availableIds: Set<string>): ModalityK
 
 describe('pickModalityKey', () => {
   it('returns currentId unchanged when no options', () => {
-    expect(pickModalityKey([], 'image', 7)).toBe(7)
-    expect(pickModalityKey([], 'image', null)).toBe(null)
+    expect(pickModalityKey([], 'image', 7, EMPTY_CATALOG)).toBe(7)
+    expect(pickModalityKey([], 'image', null, EMPTY_CATALOG)).toBe(null)
   })
 
   it('keeps the current key when it already serves the modality', () => {
     const opts = [opt(1, false, ANTIGRAVITY), opt(2, false, IMAGEN)]
-    expect(pickModalityKey(opts, 'image', 2)).toBe(2)
+    expect(pickModalityKey(opts, 'image', 2, IMAGEN_CATALOG)).toBe(2)
   })
 
   it('moves off a non-serving current key to a serving one', () => {
-    // The prod regression: bootstrap seeded the antigravity key (1); image needs
-    // the imagen group (2).
     const opts = [opt(1, true, ANTIGRAVITY), opt(2, false, IMAGEN)]
-    expect(pickModalityKey(opts, 'image', 1)).toBe(2)
+    expect(pickModalityKey(opts, 'image', 1, IMAGEN_CATALOG)).toBe(2)
   })
 
   it('prefers a trial-named serving key over the first serving key', () => {
     const opts = [opt(1, false, IMAGEN), opt(2, true, IMAGEN)]
-    expect(pickModalityKey(opts, 'image', null)).toBe(2)
+    expect(pickModalityKey(opts, 'image', null, IMAGEN_CATALOG)).toBe(2)
   })
 
   it('re-targets per modality (image vs video live on different groups)', () => {
     const opts = [opt(1, false, IMAGEN), opt(2, false, VEO)]
-    expect(pickModalityKey(opts, 'image', null)).toBe(1)
-    expect(pickModalityKey(opts, 'video', null)).toBe(2)
+    expect(pickModalityKey(opts, 'image', null, IMAGEN_CATALOG)).toBe(1)
+    expect(pickModalityKey(opts, 'video', null, VEO_CATALOG)).toBe(2)
   })
 
   it('lands a chat key on a chat-serving group, off a media-only current key', () => {
-    // Studio now defaults to the chat tab: a media-only key must yield to a
-    // chat-serving one (the inverse of the imagen regression above).
     const opts = [opt(1, false, IMAGEN), opt(2, true, ANTIGRAVITY)]
-    expect(pickModalityKey(opts, 'chat', 1)).toBe(2)
-    // keep a chat-serving current key untouched
-    expect(pickModalityKey(opts, 'chat', 2)).toBe(2)
+    expect(pickModalityKey(opts, 'chat', 1, IMAGEN_CATALOG)).toBe(2)
+    expect(pickModalityKey(opts, 'chat', 2, EMPTY_CATALOG)).toBe(2)
   })
 
   it('falls back to the seed/global default when nothing serves the modality', () => {
     const opts = [opt(1, false, ANTIGRAVITY), opt(2, true, ANTIGRAVITY)]
-    // current seed kept so the UI still shows an honest empty state
-    expect(pickModalityKey(opts, 'image', 1)).toBe(1)
-    // no seed → trial-named key, else first
-    expect(pickModalityKey(opts, 'image', null)).toBe(2)
+    expect(pickModalityKey(opts, 'image', 1, IMAGEN_CATALOG)).toBe(1)
+    expect(pickModalityKey(opts, 'image', null, IMAGEN_CATALOG)).toBe(2)
   })
 })
 
@@ -121,10 +136,10 @@ describe('resolveAvailableModels (transparent model picker)', () => {
     'imagen-4.0-ultra-generate-001',
   ])
   // Live prices come from the per-user catalog (getMePricingCatalog), not hardcoded.
-  const IMAGEN_PRICES = new Map([
-    ['imagen-4.0-fast-generate-001', { perImage: 0.02 }],
-    ['imagen-4.0-generate-001', { perImage: 0.04 }],
-    ['imagen-4.0-ultra-generate-001', { perImage: 0.06 }],
+  const IMAGEN_PRICES: MediaPriceMap = new Map([
+    ['imagen-4.0-fast-generate-001', { perImage: 0.02, billingMode: 'image' }],
+    ['imagen-4.0-generate-001', { perImage: 0.04, billingMode: 'image' }],
+    ['imagen-4.0-ultra-generate-001', { perImage: 0.06, billingMode: 'image' }],
   ])
 
   it('lists only priced+servable image models, sorted cheap → premium, with live price', () => {
@@ -147,12 +162,24 @@ describe('resolveAvailableModels (transparent model picker)', () => {
     const out = resolveAvailableModels(
       'image',
       new Set(['doubao-seedream-4-0-250828']),
-      new Map([['doubao-seedream-4-0-250828', { perImage: 0.03 }]])
+      new Map([['doubao-seedream-4-0-250828', { perImage: 0.03, billingMode: 'image' }]])
     )
     expect(out).toHaveLength(1)
     expect(out[0].model.modelId).toBe('seedream-4-0-250828')
-    expect(out[0].servedId).toBe('doubao-seedream-4-0-250828') // billing key = the served id
+    expect(out[0].servedId).toBe('doubao-seedream-4-0-250828')
     expect(out[0].baseImagePrice).toBe(0.03)
+  })
+
+  it('surfaces catalog-only models (e.g. grok-imagine-video) without a presentation gate', () => {
+    const out = resolveAvailableModels(
+      'video',
+      GROK_VIDEO,
+      new Map([['grok-imagine-video', { perSecond: 0.08, billingMode: 'video', vendor: 'xai' }]])
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0].model.modelId).toBe('grok-imagine-video')
+    expect(out[0].model.displayName).toBe('Grok Imagine · Video')
+    expect(out[0].perSecond).toBe(0.08)
   })
 
   it('excludes models not in the group pool', () => {
@@ -166,17 +193,27 @@ describe('resolveAvailableModels (transparent model picker)', () => {
     const out = resolveAvailableModels(
       'video',
       new Set(['veo-3.1-generate-001']),
-      new Map([['veo-3.1-generate-001', { perSecond: 0.4 }]])
+      new Map([['veo-3.1-generate-001', { perSecond: 0.4, billingMode: 'video' }]])
     )
     expect(out.map((r) => r.model.modelId)).toEqual(['veo-3.1-generate-001'])
     expect(out[0].perSecond).toBe(0.4)
   })
+
+  it('skips ids whose billing_mode does not match the requested modality', () => {
+    expect(
+      resolveAvailableModels(
+        'video',
+        new Set(['imagen-4.0-ultra-generate-001']),
+        new Map([['imagen-4.0-ultra-generate-001', { perImage: 0.06, billingMode: 'image' }]])
+      )
+    ).toEqual([])
+  })
 })
 
 describe('defaultModelId', () => {
-  const PRICES = new Map([
-    ['imagen-4.0-fast-generate-001', { perImage: 0.02 }],
-    ['imagen-4.0-generate-001', { perImage: 0.04 }],
+  const PRICES: MediaPriceMap = new Map([
+    ['imagen-4.0-fast-generate-001', { perImage: 0.02, billingMode: 'image' }],
+    ['imagen-4.0-generate-001', { perImage: 0.04, billingMode: 'image' }],
   ])
   it('picks the cheapest non-footgun model', () => {
     const out = resolveAvailableModels(
@@ -263,10 +300,11 @@ describe('video durations (per-model discrete, never a footgun)', () => {
     expect(videoDurationDefault([])).toBe(VIDEO_DURATION_DEFAULT)
   })
 
-  it('Veo 3.1 accepts exactly 4/6/8s (Vertex official); Seedance 1.0 exactly 5/10s', () => {
+  it('Veo 3.1 accepts exactly 4/6/8s; Seedance 1.0 exactly 5/10s; Grok Imagine 5s', () => {
     expect(byId('veo-3.1-generate-001').videoDurations).toEqual([4, 6, 8])
     expect(byId('veo-3.1-fast-generate-001').videoDurations).toEqual([4, 6, 8])
     expect(byId('seedance-1-0-pro-250528').videoDurations).toEqual([5, 10])
+    expect(byId('grok-imagine-video').videoDurations).toEqual([5])
   })
 })
 
@@ -277,12 +315,17 @@ describe('image aspect options (per-model, upstream-valid wire values)', () => {
   // and Imagen must send the ratio code verbatim.
   const IMAGEN_VALID = new Set(['1:1', '3:4', '4:3', '9:16', '16:9'])
 
-  it('all image models carry imageSizes (gemini too, post-canary); video carry none', () => {
+  it('image models with flatPricePerImage may omit imageSizes (grok-imagine)', () => {
+    const flatNoSizes = MEDIA_MODELS.filter((m) => m.modality === 'image' && m.flatPricePerImage && !m.imageSizes)
+    expect(flatNoSizes.some((m) => m.modelId.startsWith('grok-imagine-'))).toBe(true)
+  })
+
+  it('other image models carry imageSizes; video carry none', () => {
     // Gemini-native image regained its aspect picker: a prod canary (2026-06-17) confirmed
     // cloudcode-pa honors imageConfig.aspectRatio for all 10 documented ratios, lifting the
     // #807 R-001 "no picker" deferral. So every image model now carries imageSizes; only
     // video models (passthrough hint, separate VIDEO_ASPECT_PRESETS) carry none.
-    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image')) {
+    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image' && !m.flatPricePerImage)) {
       expect(m.imageSizes && m.imageSizes.length).toBeTruthy()
     }
     for (const m of MEDIA_MODELS.filter((m) => m.modality === 'video')) {

--- a/frontend/src/constants/mediaTiers.tk.ts
+++ b/frontend/src/constants/mediaTiers.tk.ts
@@ -1,22 +1,17 @@
 /**
- * TokenKey-only: media (image/video) quality-tier catalog for the Studio.
+ * TokenKey-only: Studio media presentation + resolver helpers.
  *
- * The Studio picks MODELS by a human "quality tier × price" card, never by a
- * bare model id — the vendor (Vertex / VolcEngine / …) is a footnote, not a
- * choice (design: docs/playground-media-redesign.md §3.2/§4.1).
+ * **Membership SSOT** (which image/video models exist for a key) lives in the
+ * pricing catalogs (`GET /api/v1/public/pricing`, `GET /api/v1/me/pricing-catalog`)
+ * via `billing_mode: image | video` — see `utils/studioMediaCatalog.tk.ts`.
  *
- * Each tier carries ORDERED candidate models. resolveTier() picks the first
- * candidate that is BOTH (a) priced+servable here and (b) present in the user's
- * key-group model pool (GET /v1/models). So a tier lights up only when a real,
- * priced model backs it — never a 400-on-submit footgun.
- *
- * Prices are verified against backend/internal/service/tk_pricing_overlay.json
- * (output_cost_per_image / output_cost_per_second). They drive the client cost
- * MIRROR (utils/mediaCostEstimate.tk.ts); the backend pre-flight hold remains
- * the source of truth and corrects any drift.
+ * **This file** holds presentation-only metadata (display names, aspect ratios,
+ * discrete video durations, verified adaptor params). A model appears in Studio
+ * only when catalog membership ∩ key entitlement ∩ live price all agree.
  */
 
 import { modalityForModel } from '@/constants/playgroundMedia.tk'
+import type { CatalogBillingIndex } from '@/utils/studioMediaCatalog.tk'
 
 export type StudioModality = 'image' | 'video'
 
@@ -32,43 +27,65 @@ export type PickerModality = StudioModality | 'chat'
 const VERTEX = 'Google Vertex'
 const VOLC = 'VolcEngine'
 const GEMINI = 'Google Gemini'
+const XAI = 'xAI'
+
+const VENDOR_LABELS: Record<string, string> = {
+  xai: XAI,
+  vertex_ai: VERTEX,
+  volcengine: VOLC,
+  google: GEMINI,
+  gemini: GEMINI,
+}
+
+function formatVendorLabel(vendor?: string): string {
+  if (!vendor) return ''
+  const key = vendor.trim().toLowerCase()
+  return VENDOR_LABELS[key] ?? vendor
+}
+
+function defaultDisplayName(modelId: string): string {
+  return modelId
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
 
 /**
- * True when this group's pool backs at least one media model of the modality —
- * i.e. the Studio tab is usable for a key whose group exposes `availableIds`.
- * Drives the modality-aware key picker (pickModalityKey), which runs across ALL
- * the user's groups, so it is PRICE-AGNOSTIC by design: it must not require a
- * per-group price-catalog fetch. /v1/models is already filtered to priced models
- * upstream, so servable here implies priced for the per-key card resolver.
+ * True when this key's pool backs at least one catalog-listed media model of
+ * `modality`. Uses the public pricing catalog's billing_mode index (loaded once
+ * at Studio bootstrap) — not the presentation table below.
  */
 export function modalityHasTiers(
   modality: StudioModality,
-  availableIds: ReadonlySet<string>
+  availableIds: ReadonlySet<string>,
+  catalogBilling: CatalogBillingIndex
 ): boolean {
-  return MEDIA_MODELS.some(
-    (m) =>
-      m.modality === modality &&
-      [m.modelId, ...(m.aliasIds ?? [])].some((id) => availableIds.has(id))
-  )
+  for (const id of availableIds) {
+    if (catalogBilling.get(id) === modality) return true
+  }
+  return false
 }
 
 /**
  * Whether this group's pool serves `modality` for the SHELL's key picker.
- * Dispatches chat (any chat-classified id in the pool) vs media (tier catalog),
- * so the modality-aware landing/annotation logic treats chat as a first-class
- * peer of image/video without a media tier entry.
+ * Dispatches chat (any chat-classified id in the pool) vs media (catalog
+ * billing_mode). Bake-off passes no picker modality (dual sub-modality → user
+ * owns the key).
  */
 export function groupServes(
   modality: PickerModality,
-  availableIds: ReadonlySet<string>
+  availableIds: ReadonlySet<string>,
+  catalogBilling: CatalogBillingIndex
 ): boolean {
   if (modality === 'chat') {
     for (const id of availableIds) {
+      if (catalogBilling.has(id)) continue
       if (modalityForModel(id) === 'chat') return true
     }
     return false
   }
-  return modalityHasTiers(modality, availableIds)
+  return modalityHasTiers(modality, availableIds, catalogBilling)
 }
 
 /** One selectable key, reduced to what the modality-aware picker needs. */
@@ -99,10 +116,11 @@ export interface ModalityKeyOption {
 export function pickModalityKey(
   options: readonly ModalityKeyOption[],
   modality: PickerModality,
-  currentId: number | null
+  currentId: number | null,
+  catalogBilling: CatalogBillingIndex
 ): number | null {
   if (options.length === 0) return currentId
-  const serving = options.filter((o) => groupServes(modality, o.availableIds))
+  const serving = options.filter((o) => groupServes(modality, o.availableIds, catalogBilling))
   if (currentId != null && serving.some((o) => o.id === currentId)) return currentId
   const pickServing = serving.find((o) => o.isTrial) ?? serving[0]
   if (pickServing) return pickServing.id
@@ -210,18 +228,11 @@ export const IMAGE_N_MIN = 1
 export const IMAGE_N_MAX = 4
 
 /* ────────────────────────────────────────────────────────────────────────────
- * Model catalog (transparent model picker)
+ * Presentation overlay (NOT membership SSOT — catalog billing_mode is).
  *
- * The Studio now lets the user pick the ACTUAL model — shown humanely (friendly
- * name + price + vendor footnote + raw id subtext), not a bare quality tier.
- * This completes the originally-planned "Advanced model picker" (design §3.2)
- * that #769 left unshipped. The quality label becomes a card BADGE, not the
- * selection axis.
- *
- * Same hard rule as resolveTier: only models BOTH (a) priced+servable here and
- * (b) present in the user's key-group pool (GET /v1/models) are shown — never a
- * 400-on-submit footgun. The raw modelId stays the billing key; displayName is
- * cosmetic only.
+ * Friendly names, badges, aspect ratios, discrete video durations, and verified
+ * adaptor params. Models without an entry still appear when the catalog lists
+ * them; they get conservative defaults until presentation is curated here.
  * ──────────────────────────────────────────────────────────────────────────── */
 
 /**
@@ -295,15 +306,7 @@ export interface MediaModel {
   videoDurations?: number[]
 }
 
-/**
- * Static catalog of media models = display metadata + the verified capability
- * map ONLY. Prices are NOT hardcoded here — they come live from the per-user
- * pricing catalog (getMePricingCatalog, the same source #788 established), so a
- * price change in the overlay can't drift. A model is shown only when it is BOTH
- * in the key-group's GET /v1/models pool AND carries a live catalog price
- * (priced ∩ servable — never a 400-on-submit footgun). modelId stays the billing
- * key; displayName is cosmetic.
- */
+/** Presentation-only entries keyed by canonical model_id. */
 export const MEDIA_MODELS: MediaModel[] = [
   // ── image (imagen/seedream honor NO advanced params per adaptor) ──
   {
@@ -388,6 +391,26 @@ export const MEDIA_MODELS: MediaModel[] = [
     flatImageBilling: true,
     imageSizes: GEMINI_IMAGE_SIZES,
   },
+  {
+    modelId: 'grok-imagine-image',
+    displayName: 'Grok Imagine · Standard',
+    qualityBadge: 'standard',
+    qualityBadgeKey: 'studio.badge.standard',
+    vendorLabel: XAI,
+    modality: 'image',
+    supportedParams: [],
+    flatPricePerImage: true,
+  },
+  {
+    modelId: 'grok-imagine-image-quality',
+    displayName: 'Grok Imagine · Quality',
+    qualityBadge: 'ultra',
+    qualityBadgeKey: 'studio.badge.ultra',
+    vendorLabel: XAI,
+    modality: 'image',
+    supportedParams: [],
+    flatPricePerImage: true,
+  },
   // gpt-image-* is deliberately ABSENT: it needs a type=apikey OpenAI account
   // (OAuth subscriptions 502). If a future probe adds an apikey-backed group,
   // add it here with needsApikeyAccount: true.
@@ -443,7 +466,44 @@ export const MEDIA_MODELS: MediaModel[] = [
     // Veo 3.1: discrete 4/6/8s (Vertex AI official, high confidence).
     videoDurations: [4, 6, 8],
   },
+  {
+    modelId: 'grok-imagine-video',
+    displayName: 'Grok Imagine · Video',
+    qualityBadge: 'standard',
+    qualityBadgeKey: 'studio.badge.standard',
+    vendorLabel: XAI,
+    modality: 'video',
+    // Native xAI arm: first-frame image_url only (no negativePrompt / generateAudio).
+    supportedParams: ['firstFrameImage'],
+    // Live probe 2026-06-19: 5s text-to-video succeeded; expand when xAI docs capture full set.
+    videoDurations: [5],
+  },
 ]
+
+function lookupPresentation(modelId: string): MediaModel | undefined {
+  const direct = MEDIA_MODELS.find((m) => m.modelId === modelId)
+  if (direct) return direct
+  return MEDIA_MODELS.find((m) => m.aliasIds?.includes(modelId))
+}
+
+function buildMediaModelForCatalogRow(
+  servedId: string,
+  modality: StudioModality,
+  presentation: MediaModel | undefined,
+  vendor?: string
+): MediaModel {
+  if (presentation) return presentation
+  return {
+    modelId: servedId,
+    displayName: defaultDisplayName(servedId),
+    qualityBadge: 'standard',
+    qualityBadgeKey: 'studio.badge.standard',
+    vendorLabel: formatVendorLabel(vendor),
+    modality,
+    supportedParams: [],
+    videoDurations: modality === 'video' ? [VIDEO_DURATION_DEFAULT] : undefined,
+  }
+}
 
 /** Live per-model price from the user's pricing catalog (getMePricingCatalog). */
 export interface MediaPrice {
@@ -451,6 +511,10 @@ export interface MediaPrice {
   perImage?: number
   /** USD per second (video models). */
   perSecond?: number
+  /** From catalog billing_mode — membership SSOT for Studio. */
+  billingMode?: StudioModality
+  /** Raw vendor slug from the catalog row (e.g. xai, vertex_ai). */
+  vendor?: string
 }
 export type MediaPriceMap = ReadonlyMap<string, MediaPrice>
 
@@ -475,17 +539,29 @@ export function resolveAvailableModels(
   priceMap: MediaPriceMap
 ): ResolvedModel[] {
   const out: ResolvedModel[] = []
-  for (const model of MEDIA_MODELS) {
-    if (model.modality !== modality) continue
-    const ids = [model.modelId, ...(model.aliasIds ?? [])]
-    const servedId = ids.find((id) => availableIds.has(id))
-    if (!servedId) continue
-    const price = ids.map((id) => priceMap.get(id)).find((p) => p != null)
-    const baseImagePrice = modality === 'image' ? price?.perImage : undefined
-    const perSecond = modality === 'video' ? price?.perSecond : undefined
-    if (baseImagePrice == null && perSecond == null) continue // no live price → hide
+  const seenCanonical = new Set<string>()
+
+  for (const servedId of availableIds) {
+    const price = priceMap.get(servedId)
+    if (!price) continue
+    const rowModality =
+      price.billingMode ??
+      (price.perSecond != null ? 'video' : price.perImage != null ? 'image' : undefined)
+    if (rowModality !== modality) continue
+
+    const baseImagePrice = modality === 'image' ? price.perImage : undefined
+    const perSecond = modality === 'video' ? price.perSecond : undefined
+    if (baseImagePrice == null && perSecond == null) continue
+
+    const presentation = lookupPresentation(servedId)
+    const canonicalId = presentation?.modelId ?? servedId
+    if (seenCanonical.has(canonicalId)) continue
+    seenCanonical.add(canonicalId)
+
+    const model = buildMediaModelForCatalogRow(servedId, modality, presentation, price.vendor)
     out.push({ model, servedId, baseImagePrice, perSecond })
   }
+
   out.sort((a, b) => (a.baseImagePrice ?? a.perSecond ?? 0) - (b.baseImagePrice ?? b.perSecond ?? 0))
   return out
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -241,7 +241,7 @@ export default {
     video: {
       modelLabel: 'Model',
       modelEmpty: 'No video models are available for this group yet.',
-      modelEmptySwitchKey: 'Video models (Veo / Seedance) live on Vertex or VolcEngine groups. Switch to an API key that serves video above.',
+      modelEmptySwitchKey: 'Video models (Veo, Seedance, Grok, etc.) live on platform-specific groups. Switch to an API key that serves video above.',
       modelEmptyAllKeys: 'None of your key groups expose video models yet. See pricing for supported groups or ask an admin.',
       samplePrompt: 'A neon Tokyo alley, slow push-in, rain, reflections, cinematic',
       perSecondUnit: ' /s',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -239,7 +239,7 @@ export default {
     video: {
       modelLabel: '模型',
       modelEmpty: '当前分组暂无可用的视频模型。',
-      modelEmptySwitchKey: '视频模型（Veo / Seedance）通常在 Vertex 或 VolcEngine 分组。请在上方切换到带「视频」能力的 API 密钥。',
+      modelEmptySwitchKey: '部分 API 密钥分组提供视频模型（如 Vertex、VolcEngine、Grok）。请在上方切换到带「视频」能力的密钥。',
       modelEmptyAllKeys: '你的所有密钥分组均未开通视频模型。可在价格页查看支持的分组，或联系管理员开通。',
       samplePrompt: '霓虹东京小巷，慢推镜头，雨，反射光，电影感',
       perSecondUnit: ' /秒',

--- a/frontend/src/utils/__tests__/studioMediaCatalog.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioMediaCatalog.tk.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCatalogBillingIndex,
+  priceMapFromMeCatalog,
+  priceMapFromPublicCatalog,
+} from '@/utils/studioMediaCatalog.tk'
+
+describe('studioMediaCatalog', () => {
+  it('buildCatalogBillingIndex maps billing_mode image and video only', () => {
+    const idx = buildCatalogBillingIndex([
+      { model_id: 'imagen-4.0-generate-001', pricing: { billing_mode: 'image' } },
+      { model_id: 'grok-imagine-video', pricing: { billing_mode: 'video' } },
+      { model_id: 'grok-4.3', pricing: { billing_mode: 'token' } },
+    ])
+    expect(idx.get('imagen-4.0-generate-001')).toBe('image')
+    expect(idx.get('grok-imagine-video')).toBe('video')
+    expect(idx.has('grok-4.3')).toBe(false)
+  })
+
+  it('priceMapFromPublicCatalog carries billingMode and vendor', () => {
+    const map = priceMapFromPublicCatalog(
+      [
+        {
+          model_id: 'grok-imagine-video',
+          vendor: 'xai',
+          pricing: { billing_mode: 'video', output_cost_per_second: 0.08 },
+        },
+      ] as never,
+      new Set(['grok-imagine-video'])
+    )
+    expect(map.get('grok-imagine-video')).toEqual({
+      perSecond: 0.08,
+      billingMode: 'video',
+      vendor: 'xai',
+    })
+  })
+
+  it('priceMapFromMeCatalog mirrors me pricing rows', () => {
+    const map = priceMapFromMeCatalog([
+      {
+        model_id: 'grok-imagine-image',
+        vendor: 'xai',
+        billing_mode: 'image',
+        your_price: { currency: 'USD', per_image: 0.02 },
+        capabilities: [],
+      },
+    ] as never)
+    expect(map.get('grok-imagine-image')).toEqual({
+      perImage: 0.02,
+      billingMode: 'image',
+      vendor: 'xai',
+    })
+  })
+})

--- a/frontend/src/utils/__tests__/studioUniversalKey.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioUniversalKey.tk.spec.ts
@@ -29,7 +29,7 @@ describe('studioUniversalKey', () => {
       [
         {
           model_id: 'veo-3.1-generate-001',
-          pricing: { output_cost_per_second: 0.6 },
+          pricing: { billing_mode: 'video', output_cost_per_second: 0.6 },
         },
         {
           model_id: 'gpt-4o',
@@ -39,6 +39,7 @@ describe('studioUniversalKey', () => {
       new Set(['veo-3.1-generate-001'])
     )
     expect(map.get('veo-3.1-generate-001')?.perSecond).toBe(0.6)
+    expect(map.get('veo-3.1-generate-001')?.billingMode).toBe('video')
     expect(map.has('gpt-4o')).toBe(false)
   })
 })

--- a/frontend/src/utils/studioMediaCatalog.tk.ts
+++ b/frontend/src/utils/studioMediaCatalog.tk.ts
@@ -1,0 +1,80 @@
+/**
+ * TokenKey-only: Studio media membership + prices from the public / me pricing
+ * catalogs (billing_mode image | video). Presentation metadata stays in
+ * mediaTiers.tk.ts — this module must NOT invent model inventories.
+ */
+import type { MePricingModel } from '@/api/me-pricing'
+import type { PublicCatalogModel } from '@/api/pricing'
+import type { MediaPrice, MediaPriceMap, StudioModality } from '@/constants/mediaTiers.tk'
+
+export type CatalogBillingIndex = ReadonlyMap<string, StudioModality>
+
+function normalizeBillingMode(raw: string | undefined): StudioModality | undefined {
+  if (raw === 'image' || raw === 'video') return raw
+  return undefined
+}
+
+/** model_id → image | video, derived from GET /api/v1/public/pricing. */
+export function buildCatalogBillingIndex(
+  publicModels: readonly Pick<PublicCatalogModel, 'model_id' | 'pricing'>[]
+): CatalogBillingIndex {
+  const map = new Map<string, StudioModality>()
+  for (const m of publicModels) {
+    const mode = normalizeBillingMode(m.pricing?.billing_mode)
+    if (mode) map.set(m.model_id, mode)
+  }
+  return map
+}
+
+export function catalogModalityForModel(
+  modelId: string,
+  catalogBilling: CatalogBillingIndex
+): StudioModality | undefined {
+  return catalogBilling.get(modelId)
+}
+
+/** Official media prices for entitled models (public catalog ∩ authorized index). */
+export function priceMapFromPublicCatalog(
+  publicModels: readonly PublicCatalogModel[],
+  entitled: ReadonlySet<string>
+): MediaPriceMap {
+  const map = new Map<string, MediaPrice>()
+  for (const m of publicModels) {
+    if (!entitled.has(m.model_id)) continue
+    const entry = mediaPriceFromCatalogRow(m.pricing?.billing_mode, m.pricing?.output_cost_per_image, m.pricing?.output_cost_per_second, m.vendor)
+    if (entry) map.set(m.model_id, entry)
+  }
+  return map
+}
+
+export function priceMapFromMeCatalog(models: readonly MePricingModel[]): MediaPriceMap {
+  const map = new Map<string, MediaPrice>()
+  for (const m of models) {
+    const entry = mediaPriceFromCatalogRow(
+      m.billing_mode,
+      m.your_price?.per_image,
+      m.your_price?.per_second,
+      m.vendor
+    )
+    if (entry) map.set(m.model_id, entry)
+  }
+  return map
+}
+
+function mediaPriceFromCatalogRow(
+  billingModeRaw: string | undefined,
+  perImage: number | undefined | null,
+  perSecond: number | undefined | null,
+  vendor: string | undefined
+): MediaPrice | undefined {
+  const billingMode = normalizeBillingMode(billingModeRaw)
+  const hasImage = perImage != null && perImage > 0
+  const hasVideo = perSecond != null && perSecond > 0
+  if (!hasImage && !hasVideo) return undefined
+  return {
+    perImage: hasImage ? perImage : undefined,
+    perSecond: hasVideo ? perSecond : undefined,
+    billingMode: billingMode ?? (hasVideo ? 'video' : hasImage ? 'image' : undefined),
+    vendor,
+  }
+}

--- a/frontend/src/utils/studioUniversalKey.tk.ts
+++ b/frontend/src/utils/studioUniversalKey.tk.ts
@@ -7,8 +7,13 @@
  */
 import type { ApiKey } from '@/types'
 import type { MePricingCatalogResponse } from '@/api/me-pricing'
-import type { PublicCatalogModel } from '@/api/pricing'
-import type { MediaPrice, MediaPriceMap } from '@/constants/mediaTiers.tk'
+
+export {
+  buildCatalogBillingIndex,
+  priceMapFromMeCatalog,
+  priceMapFromPublicCatalog,
+  type CatalogBillingIndex,
+} from '@/utils/studioMediaCatalog.tk'
 
 export function isUniversalKey(k: ApiKey | undefined | null): boolean {
   if (!k) return false
@@ -21,21 +26,4 @@ export function entitledModelIds(catalog: MePricingCatalogResponse | null): Set<
   const idx = catalog?.authorized_groups_by_model
   if (!idx) return new Set()
   return new Set(Object.keys(idx))
-}
-
-/** Official media prices for entitled models (public catalog ∩ authorized index). */
-export function priceMapFromPublicCatalog(
-  publicModels: readonly PublicCatalogModel[],
-  entitled: ReadonlySet<string>
-): MediaPriceMap {
-  const map = new Map<string, MediaPrice>()
-  for (const m of publicModels) {
-    if (!entitled.has(m.model_id)) continue
-    const perImage = m.pricing?.output_cost_per_image
-    const perSecond = m.pricing?.output_cost_per_second
-    if (perImage != null || perSecond != null) {
-      map.set(m.model_id, { perImage: perImage ?? undefined, perSecond: perSecond ?? undefined })
-    }
-  }
-  return map
 }

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -168,7 +168,10 @@ import { formatUsd } from '@/utils/mediaCostEstimate.tk'
 import {
   entitledModelIds,
   isUniversalKey,
+  buildCatalogBillingIndex,
   priceMapFromPublicCatalog,
+  priceMapFromMeCatalog,
+  type CatalogBillingIndex,
 } from '@/utils/studioUniversalKey.tk'
 import {
   groupServes,
@@ -209,6 +212,8 @@ const groupModelSets = ref<Map<string, Set<string>>>(new Map())
 /** Cross-group entitlement index (me/pricing-catalog authorized_groups_by_model). */
 const userEntitledIds = ref<Set<string>>(new Set())
 const universalPriceMap = ref<MediaPriceMap>(new Map())
+/** Public catalog billing_mode index — Studio media membership SSOT. */
+const catalogBillingIndex = ref<CatalogBillingIndex>(new Map())
 // Live per-model price for the SELECTED key's group (getMePricingCatalog) — the
 // single source of media prices (no hardcoding, so prices can't drift).
 const priceMap = ref<Map<string, MediaPrice>>(new Map())
@@ -236,7 +241,7 @@ function availableIdsOf(k: ApiKey): Set<string> {
 }
 
 function keyServesModality(k: ApiKey, modality: PickerModality): boolean {
-  return groupServes(modality, availableIdsOf(k))
+  return groupServes(modality, availableIdsOf(k), catalogBillingIndex.value)
 }
 
 // Model pool of the currently selected key — what the child studios resolve
@@ -278,9 +283,11 @@ async function loadUserEntitlement(): Promise<void> {
     const [meCatalog, publicCatalog] = await Promise.all([getMePricingCatalog(), getPublicPricing()])
     const entitled = entitledModelIds(meCatalog)
     userEntitledIds.value = entitled
+    catalogBillingIndex.value = buildCatalogBillingIndex(publicCatalog.data || [])
     universalPriceMap.value = priceMapFromPublicCatalog(publicCatalog.data || [], entitled)
   } catch {
     userEntitledIds.value = new Set()
+    catalogBillingIndex.value = new Map()
     universalPriceMap.value = new Map()
   }
 }
@@ -341,7 +348,7 @@ let backgroundProbeGen = 0
 function repickKeyForCurrentModality(): void {
   const m = pickerModality.value
   if (!m) return
-  selectedKeyId.value = pickModalityKey(modalityOptions(), m, selectedKeyId.value)
+  selectedKeyId.value = pickModalityKey(modalityOptions(), m, selectedKeyId.value, catalogBillingIndex.value)
 }
 
 /** Finish probing groups the fast path skipped; refresh key annotations when done. */
@@ -375,15 +382,7 @@ async function loadPriceMap(keyId: number): Promise<void> {
   }
   try {
     const catalog = await getMePricingCatalog({ apiKeyId: keyId })
-    const next = new Map<string, MediaPrice>()
-    for (const m of catalog.models || []) {
-      const perImage = m.your_price?.per_image
-      const perSecond = m.your_price?.per_second
-      if (perImage != null || perSecond != null) {
-        next.set(m.model_id, { perImage: perImage ?? undefined, perSecond: perSecond ?? undefined })
-      }
-    }
-    priceMap.value = next
+    priceMap.value = new Map(priceMapFromMeCatalog(catalog.models || []))
   } catch {
     priceMap.value = new Map()
   }
@@ -396,7 +395,7 @@ watch(view, () => {
   if (!probed.value) return
   const m = pickerModality.value
   if (!m) return
-  selectedKeyId.value = pickModalityKey(modalityOptions(), m, selectedKeyId.value)
+  selectedKeyId.value = pickModalityKey(modalityOptions(), m, selectedKeyId.value, catalogBillingIndex.value)
 })
 
 // Refetch the price catalog whenever the selected key changes (prices are
@@ -445,7 +444,7 @@ async function bootstrap(): Promise<void> {
         modelsLoading.value = false
         return
       }
-      selectedKeyId.value = pickModalityKey(modalityOptions(), 'chat', seed)
+      selectedKeyId.value = pickModalityKey(modalityOptions(), 'chat', seed, catalogBillingIndex.value)
       probed.value = true
       if (selectedKeyId.value != null) void loadPriceMap(selectedKeyId.value)
       void (async () => {
@@ -483,13 +482,13 @@ async function bootstrap(): Promise<void> {
       return
     }
 
-    let picked = pickModalityKey(modalityOptions(), landingView, seed)
+    let picked = pickModalityKey(modalityOptions(), landingView, seed, catalogBillingIndex.value)
     const currentServes =
       picked != null &&
       keys.value.some((k) => k.id === picked && keyServesModality(k, landingView))
     if (!currentServes && ordered.length > 1) {
       await probeGroupEntries(ordered.slice(1))
-      picked = pickModalityKey(modalityOptions(), landingView, seed)
+      picked = pickModalityKey(modalityOptions(), landingView, seed, catalogBillingIndex.value)
     }
     if (!anyOk) {
       loadError.value = t('studio.loadFailed')


### PR DESCRIPTION
## 摘要

- Studio 图片/视频页的**可见模型 membership** 改从 `GET /api/v1/public/pricing` 与 `me/pricing-catalog` 的 `billing_mode` + Key entitlement 派生，不再由 `MEDIA_MODELS` 硬编码 gate。
- `MEDIA_MODELS` 降级为**展示 overlay**；catalog 有、presentation 无的模型仍会出现并带保守默认值。
- 新增 `studioMediaCatalog.tk.ts`；验证阶段发现全能 Key 提交 `grok-imagine-video` 会误落 openai 组，已补 `universalCandidatePlatforms(ShapeOpenAIVideo)` 在 grok model hint 时纳入 `PlatformGrok`。

sentinel-registry-reviewed

## 风险

- 常规风险：Studio 媒体列表 + 全能 Key grok 视频路由小修；无 DB schema 变更。
- 分组 Key 仍依赖该组 `/v1/models` 探针；全能 Key 依赖 `authorized_groups_by_model` 索引。
- catalog 下架但 overlay 仍存在的模型不会显示（membership 以 catalog 为准）。

## 验证

- `./scripts/preflight.sh` PASS
- `pnpm exec vitest run src/constants/__tests__/mediaTiers.tk.spec.ts src/utils/__tests__/studioMediaCatalog.tk.spec.ts src/utils/__tests__/studioUniversalKey.tk.spec.ts src/views/user/studio/__tests__/` — 70 passed
- `go test -tags=unit ./internal/service/ -run 'TestUniversalCandidatePlatforms|TestResolve_PicksByPlatformAndHint'` — PASS（grok-imagine-video → PlatformGrok）
- `go test -tags=unit ./internal/engine/ -run GrokVideo` — PASS（grok 原生视频 capability + submit ack 形状）

## 提交

- 41496e695 feat(studio): 媒体模型列表改从 pricing catalog 派生
- f252d81ea fix(studio): 全能 Key 的 grok 视频路由 + 补 catalog fallback 测试

最新提交：f252d81ea
