### PR TITLE
feat(kiro): prod QA 导出 Anthropic 级明文 thinking

### DIFF
--- a/backend/internal/observability/qa/service.go
+++ b/backend/internal/observability/qa/service.go
@@ -1064,7 +1064,17 @@ func captureInternalThinkingBlocks(c *gin.Context) []string {
 	if c == nil {
 		return nil
 	}
-	value, ok := c.Get("ops_gemini_internal_thinking_blocks")
+	out := make([]string, 0, 4)
+	out = append(out, captureInternalThinkingBlocksFromKey(c, "ops_gemini_internal_thinking_blocks")...)
+	out = append(out, captureInternalThinkingBlocksFromKey(c, "ops_kiro_internal_thinking_blocks")...)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func captureInternalThinkingBlocksFromKey(c *gin.Context, key string) []string {
+	value, ok := c.Get(key)
 	if !ok {
 		return nil
 	}
@@ -1079,9 +1089,6 @@ func captureInternalThinkingBlocks(c *gin.Context) []string {
 			continue
 		}
 		out = append(out, logredact.RedactText(trimmed))
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }

--- a/backend/internal/observability/trajectory/projection.go
+++ b/backend/internal/observability/trajectory/projection.go
@@ -21,9 +21,10 @@ type EvidenceBlob struct {
 		UpstreamDivergent bool `json:"upstream_divergent,omitempty"`
 	} `json:"request"`
 	Response struct {
-		StatusCode int            `json:"status_code"`
-		Headers    map[string]any `json:"headers"`
-		Body       any            `json:"body"`
+		StatusCode             int            `json:"status_code"`
+		Headers                map[string]any `json:"headers"`
+		Body                   any            `json:"body"`
+		InternalThinkingBlocks []any          `json:"internal_thinking_blocks,omitempty"`
 	} `json:"response"`
 	Stream struct {
 		Chunks []map[string]any `json:"chunks"`

--- a/backend/internal/observability/trajectory/projection_v2.go
+++ b/backend/internal/observability/trajectory/projection_v2.go
@@ -608,7 +608,7 @@ func blocksFromStreamChunks(chunks []map[string]any) ([]any, map[string]any) {
 					a.name = cb.Get("name").String()
 				}
 				if a.typ == "redacted_thinking" {
-					a.thinking.WriteString(cb.Get("data").String())
+					_, _ = a.thinking.WriteString(cb.Get("data").String())
 				}
 			case "content_block_delta":
 				i := int(ev.Get("index").Int())

--- a/backend/internal/observability/trajectory/projection_v2.go
+++ b/backend/internal/observability/trajectory/projection_v2.go
@@ -431,8 +431,68 @@ func reconstructAssistantTurn(rec SourceRecord) ([]any, map[string]any) {
 	if _, ok := callMeta["stop_reason"]; !ok {
 		callMeta["stop_reason"] = ""
 	}
+	blocks = mergeInternalThinkingBlocks(blocks, rec.Blob.Response.InternalThinkingBlocks)
 	callMeta["thinking_source"] = thinkingSource(blocks)
 	return blocks, callMeta
+}
+
+// mergeInternalThinkingBlocks overlays gateway-stashed plaintext thinking (Kiro /
+// Gemini internal path) onto wire blocks. Client-facing captures may only carry
+// redacted_thinking or omit thinking entirely; internal blocks win for traj export.
+func mergeInternalThinkingBlocks(blocks []any, internal []any) []any {
+	thinking := parseInternalThinkingBlocks(internal)
+	if len(thinking) == 0 {
+		return blocks
+	}
+	rest := make([]any, 0, len(blocks))
+	for _, b := range blocks {
+		m, ok := b.(map[string]any)
+		if !ok {
+			rest = append(rest, b)
+			continue
+		}
+		typ, _ := m["type"].(string)
+		if typ == "redacted_thinking" {
+			continue
+		}
+		rest = append(rest, b)
+	}
+	out := make([]any, 0, len(thinking)+len(rest))
+	out = append(out, thinking...)
+	out = append(out, rest...)
+	return out
+}
+
+func parseInternalThinkingBlocks(raw []any) []any {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(raw))
+	for _, item := range raw {
+		switch v := item.(type) {
+		case string:
+			trimmed := strings.TrimSpace(v)
+			if trimmed == "" {
+				continue
+			}
+			var block map[string]any
+			if err := json.Unmarshal([]byte(trimmed), &block); err != nil {
+				continue
+			}
+			if block["type"] != "thinking" {
+				continue
+			}
+			out = append(out, block)
+		case map[string]any:
+			if v["type"] == "thinking" {
+				out = append(out, v)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func usageFromBody(respBody gjson.Result, record *ent.QARecord) map[string]any {
@@ -547,6 +607,9 @@ func blocksFromStreamChunks(chunks []map[string]any) ([]any, map[string]any) {
 					a.id = cb.Get("id").String()
 					a.name = cb.Get("name").String()
 				}
+				if a.typ == "redacted_thinking" {
+					a.thinking.WriteString(cb.Get("data").String())
+				}
 			case "content_block_delta":
 				i := int(ev.Get("index").Int())
 				a := ensure(i)
@@ -601,6 +664,8 @@ func blocksFromStreamChunks(chunks []map[string]any) ([]any, map[string]any) {
 				block["signature"] = a.signature
 			}
 			blocks = append(blocks, block)
+		case "redacted_thinking":
+			blocks = append(blocks, map[string]any{"type": "redacted_thinking", "data": a.thinking.String()})
 		case "text":
 			blocks = append(blocks, map[string]any{"type": "text", "text": a.text.String()})
 		case "tool_use":

--- a/backend/internal/observability/trajectory/projection_v2_test.go
+++ b/backend/internal/observability/trajectory/projection_v2_test.go
@@ -387,3 +387,64 @@ func TestBuildTrajSessionsV2_UpstreamDivergentFlag(t *testing.T) {
 		t.Errorf("non-divergent call must not carry the key: %+v", assistants[1].CallMeta)
 	}
 }
+
+func TestMergeInternalThinkingBlocks_ReplacesRedacted(t *testing.T) {
+	wire := []any{
+		map[string]any{"type": "redacted_thinking", "data": "opaque-hash"},
+		map[string]any{"type": "text", "text": "hello"},
+	}
+	internal := []any{`{"type":"thinking","thinking":"plain reasoning"}`}
+
+	got := mergeInternalThinkingBlocks(wire, internal)
+	if len(got) != 2 {
+		t.Fatalf("want 2 blocks, got %d: %+v", len(got), got)
+	}
+	tb, _ := got[0].(map[string]any)
+	if tb["type"] != "thinking" || tb["thinking"] != "plain reasoning" {
+		t.Errorf("thinking block wrong: %+v", tb)
+	}
+}
+
+func TestBuildTrajSessionsV2_KiroInternalThinkingFromBlob(t *testing.T) {
+	base := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	req := `{"model":"claude-sonnet-4-6","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"hi"}]}`
+	resp := `{"id":"msg_k","stop_reason":"end_turn","usage":{"output_tokens":3},"content":[{"type":"redacted_thinking","data":"hash"},{"type":"text","text":"ok"}]}`
+
+	blob := &EvidenceBlob{}
+	blob.Request.Body = mustBody(t, req)
+	blob.Response.Body = mustBody(t, resp)
+	blob.Response.InternalThinkingBlocks = []any{
+		`{"type":"thinking","thinking":"kiro plain chain"}`,
+	}
+
+	sources := []SourceRecord{{
+		Record: &ent.QARecord{
+			RequestID:      "req_kiro",
+			CreatedAt:      base,
+			Platform:       "anthropic",
+			RequestedModel: "claude-sonnet-4-6",
+			TrajectoryID:   strptr("traj-kiro"),
+			DialogSynth:    true,
+		},
+		Blob: blob,
+	}}
+
+	sessions, _, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("BuildTrajSessionsV2: %v", err)
+	}
+	if len(sessions) != 1 || len(sessions[0].Turns) != 2 {
+		t.Fatalf("unexpected session: %+v", sessions)
+	}
+	a := sessions[0].Turns[1]
+	if len(a.Blocks) != 2 {
+		t.Fatalf("blocks = %d: %+v", len(a.Blocks), a.Blocks)
+	}
+	tb, _ := a.Blocks[0].(map[string]any)
+	if tb["type"] != "thinking" || tb["thinking"] != "kiro plain chain" {
+		t.Errorf("thinking export wrong: %+v", tb)
+	}
+	if a.CallMeta["thinking_source"] != "present" {
+		t.Errorf("thinking_source = %v", a.CallMeta["thinking_source"])
+	}
+}

--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -1075,6 +1075,57 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_StreamingStillCollectsUsageAf
 	require.Equal(t, 5, result.usage.OutputTokens)
 }
 
+func TestGatewayService_AnthropicAPIKeyPassthrough_StripsKiroInternalThinkingSSEComment(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	svc := &GatewayService{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{
+				MaxLineSize: defaultMaxLineSize,
+			},
+		},
+		rateLimitService: &RateLimitService{},
+	}
+
+	thinking := "prod-only mirror hop reasoning"
+	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromPlaintext(thinking))
+	commentLine := kiroInternalThinkingSSECommentPfx + payload
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`data: {"type":"message_start","message":{"usage":{"input_tokens":3}}}`,
+			"",
+			commentLine,
+			"",
+			`data: {"type":"message_delta","usage":{"output_tokens":2}}`,
+			"",
+			"data: [DONE]",
+			"",
+		}, "\n"))),
+	}
+
+	result, err := svc.handleStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "claude-3-7-sonnet-20250219")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	out := rec.Body.String()
+	require.NotContains(t, out, kiroInternalThinkingSSECommentPfx)
+	require.NotContains(t, out, thinking)
+
+	raw, ok := c.Get(kiroInternalThinkingGinKey)
+	require.True(t, ok)
+	blocks, ok := raw.([]string)
+	require.True(t, ok)
+	require.Len(t, blocks, 1)
+	require.Contains(t, blocks[0], thinking)
+}
+
 func TestGatewayService_AnthropicAPIKeyPassthrough_MissingTerminalEventReturnsError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6354,6 +6354,9 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 		setHeaderRaw(req.Header, "anthropic-version", "2023-06-01")
 	}
 	tkEnsureClaudeCodeSessionHeader(req.Header, body, c)
+	if strings.TrimSpace(baseURL) != "" {
+		setKiroInternalThinkingMirrorHopHeader(req.Header)
+	}
 
 	return req, body, nil
 }
@@ -6476,9 +6479,6 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 				if !clientDisconnected {
 					// 兜底补刷，确保最后一个未以空行结尾的事件也能及时送达客户端。
 					flusher.Flush()
-				}
-				if trailerBlocks := kiroInternalThinkingBlocksFromUpstream(resp.Trailer); len(trailerBlocks) > 0 {
-					applyKiroInternalThinkingBlocks(c, trailerBlocks)
 				}
 				if !sawTerminalEvent {
 					if clientDisconnected && streamInterval > 0 {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6369,6 +6369,7 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 	if s.rateLimitService != nil {
 		s.rateLimitService.UpdateSessionWindow(ctx, account, resp.Header)
 	}
+	applyKiroInternalThinkingFromUpstream(c, resp.Header)
 
 	writeAnthropicPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 
@@ -6476,6 +6477,9 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 					// 兜底补刷，确保最后一个未以空行结尾的事件也能及时送达客户端。
 					flusher.Flush()
 				}
+				if trailerBlocks := kiroInternalThinkingBlocksFromUpstream(resp.Trailer); len(trailerBlocks) > 0 {
+					applyKiroInternalThinkingBlocks(c, trailerBlocks)
+				}
 				if !sawTerminalEvent {
 					if clientDisconnected && streamInterval > 0 {
 						lastRead := time.Unix(0, atomic.LoadInt64(&lastReadAt))
@@ -6505,6 +6509,10 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 			}
 
 			line := ev.line
+			if blocks, ok := parseKiroInternalThinkingSSECommentLine(line); ok {
+				applyKiroInternalThinkingBlocks(c, blocks)
+				continue
+			}
 			if data, ok := extractAnthropicSSEDataLine(line); ok {
 				trimmed := strings.TrimSpace(data)
 				if anthropicStreamEventIsTerminal("", trimmed) {
@@ -6745,6 +6753,7 @@ func (s *GatewayService) handleNonStreamingResponseAnthropicAPIKeyPassthrough(
 	if s.rateLimitService != nil {
 		s.rateLimitService.UpdateSessionWindow(ctx, account, resp.Header)
 	}
+	applyKiroInternalThinkingFromUpstream(c, resp.Header)
 
 	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, anthropicTooLargeError)
 	if err != nil {

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -189,8 +189,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 
 	if c != nil {
 		c.Header("x-request-id", requestID)
-		stashKiroInternalThinkingBlocks(c, thinkingBuf)
-		writeKiroInternalThinkingResponseHeader(c.Writer.Header(), thinkingBuf)
+		publishKiroInternalThinkingSideChannel(c, nil, c.Writer.Header(), thinkingBuf)
 		c.JSON(http.StatusOK, resp)
 	}
 
@@ -345,8 +344,7 @@ func (s *KiroGatewayService) forwardStreaming(
 	enc.closeOpenBlock()
 	enc.writeMessageDelta(outputToks)
 	enc.writeMessageStop()
-	_ = writeKiroInternalThinkingSSEComment(w, thinkingBuf)
-	stashKiroInternalThinkingBlocks(c, thinkingBuf)
+	publishKiroInternalThinkingSideChannel(c, w, nil, thinkingBuf)
 	flusher.Flush()
 
 	if callbackErr != nil {

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -189,6 +189,8 @@ func (s *KiroGatewayService) forwardNonStreaming(
 
 	if c != nil {
 		c.Header("x-request-id", requestID)
+		stashKiroInternalThinkingBlocks(c, thinkingBuf)
+		writeKiroInternalThinkingResponseHeader(c.Writer.Header(), thinkingBuf)
 		c.JSON(http.StatusOK, resp)
 	}
 
@@ -343,6 +345,8 @@ func (s *KiroGatewayService) forwardStreaming(
 	enc.closeOpenBlock()
 	enc.writeMessageDelta(outputToks)
 	enc.writeMessageStop()
+	_ = writeKiroInternalThinkingSSEComment(w, thinkingBuf)
+	stashKiroInternalThinkingBlocks(c, thinkingBuf)
 	flusher.Flush()
 
 	if callbackErr != nil {

--- a/backend/internal/service/kiro_internal_thinking_tk.go
+++ b/backend/internal/service/kiro_internal_thinking_tk.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	kiroInternalThinkingGinKey              = "ops_kiro_internal_thinking_blocks"
-	kiroInternalThinkingResponseHeader      = "X-Tk-Internal-Thinking-Blocks"
-	kiroInternalThinkingSSECommentPfx       = ": x-tk-internal-thinking "
+	kiroInternalThinkingGinKey         = "ops_kiro_internal_thinking_blocks"
+	kiroInternalThinkingResponseHeader = "X-Tk-Internal-Thinking-Blocks"
+	kiroInternalThinkingSSECommentPfx  = ": x-tk-internal-thinking "
 	// kiroInternalThinkingMirrorHopRequestHeader is set by prod mirror passthrough
 	// on outbound edge hops so Edge emits the side channel on the wire. Edge
 	// direct clients must not receive plaintext thinking on the response body.

--- a/backend/internal/service/kiro_internal_thinking_tk.go
+++ b/backend/internal/service/kiro_internal_thinking_tk.go
@@ -11,10 +11,44 @@ import (
 )
 
 const (
-	kiroInternalThinkingGinKey         = "ops_kiro_internal_thinking_blocks"
-	kiroInternalThinkingResponseHeader = "X-Tk-Internal-Thinking-Blocks"
-	kiroInternalThinkingSSECommentPfx  = ": x-tk-internal-thinking "
+	kiroInternalThinkingGinKey              = "ops_kiro_internal_thinking_blocks"
+	kiroInternalThinkingResponseHeader      = "X-Tk-Internal-Thinking-Blocks"
+	kiroInternalThinkingSSECommentPfx       = ": x-tk-internal-thinking "
+	// kiroInternalThinkingMirrorHopRequestHeader is set by prod mirror passthrough
+	// on outbound edge hops so Edge emits the side channel on the wire. Edge
+	// direct clients must not receive plaintext thinking on the response body.
+	kiroInternalThinkingMirrorHopRequestHeader = "X-Tk-Internal-Thinking-Relay"
 )
+
+func kiroInternalThinkingMirrorHopRequested(c *gin.Context) bool {
+	if c == nil || c.Request == nil {
+		return false
+	}
+	return strings.TrimSpace(c.GetHeader(kiroInternalThinkingMirrorHopRequestHeader)) != ""
+}
+
+func setKiroInternalThinkingMirrorHopHeader(hdr http.Header) {
+	if hdr == nil {
+		return
+	}
+	hdr.Set(kiroInternalThinkingMirrorHopRequestHeader, "1")
+}
+
+// publishKiroInternalThinkingSideChannel stashes plaintext thinking for QA and,
+// only on prod→edge mirror hops, emits the wire side channel (SSE comment or
+// response header) that prod passthrough reads and strips before the end client.
+func publishKiroInternalThinkingSideChannel(c *gin.Context, w io.Writer, hdr http.Header, thinking string) {
+	stashKiroInternalThinkingBlocks(c, thinking)
+	if !kiroInternalThinkingMirrorHopRequested(c) {
+		return
+	}
+	if w != nil {
+		_ = writeKiroInternalThinkingSSEComment(w, thinking)
+	}
+	if hdr != nil {
+		writeKiroInternalThinkingResponseHeader(hdr, thinking)
+	}
+}
 
 // kiroInternalThinkingBlockJSON returns one Anthropic-shaped thinking block JSON
 // string for QA/traj export. Kiro upstream has no signature token; only plaintext

--- a/backend/internal/service/kiro_internal_thinking_tk.go
+++ b/backend/internal/service/kiro_internal_thinking_tk.go
@@ -1,0 +1,150 @@
+package service
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	kiroInternalThinkingGinKey         = "ops_kiro_internal_thinking_blocks"
+	kiroInternalThinkingResponseHeader = "X-Tk-Internal-Thinking-Blocks"
+	kiroInternalThinkingSSECommentPfx  = ": x-tk-internal-thinking "
+)
+
+// kiroInternalThinkingBlockJSON returns one Anthropic-shaped thinking block JSON
+// string for QA/traj export. Kiro upstream has no signature token; only plaintext
+// thinking is stashed (client-facing wire stays redacted_thinking).
+func kiroInternalThinkingBlockJSON(thinking string) string {
+	thinking = strings.TrimSpace(thinking)
+	if thinking == "" {
+		return ""
+	}
+	b, err := json.Marshal(map[string]any{
+		"type":     "thinking",
+		"thinking": thinking,
+	})
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func kiroInternalThinkingBlocksFromPlaintext(thinking string) []string {
+	block := kiroInternalThinkingBlockJSON(thinking)
+	if block == "" {
+		return nil
+	}
+	return []string{block}
+}
+
+func encodeKiroInternalThinkingPayload(blocks []string) string {
+	if len(blocks) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(blocks)
+	if err != nil {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+func decodeKiroInternalThinkingPayload(encoded string) []string {
+	encoded = strings.TrimSpace(encoded)
+	if encoded == "" {
+		return nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil
+	}
+	var blocks []string
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		trimmed := strings.TrimSpace(block)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func stashKiroInternalThinkingBlocks(c *gin.Context, thinking string) {
+	if c == nil {
+		return
+	}
+	blocks := kiroInternalThinkingBlocksFromPlaintext(thinking)
+	if len(blocks) == 0 {
+		return
+	}
+	applyKiroInternalThinkingBlocks(c, blocks)
+}
+
+func applyKiroInternalThinkingBlocks(c *gin.Context, blocks []string) {
+	if c == nil || len(blocks) == 0 {
+		return
+	}
+	existing, _ := c.Get(kiroInternalThinkingGinKey)
+	if prior, ok := existing.([]string); ok && len(prior) > 0 {
+		blocks = append(append([]string{}, prior...), blocks...)
+	}
+	c.Set(kiroInternalThinkingGinKey, blocks)
+}
+
+func writeKiroInternalThinkingResponseHeader(hdr http.Header, thinking string) {
+	if hdr == nil {
+		return
+	}
+	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromPlaintext(thinking))
+	if payload == "" {
+		return
+	}
+	hdr.Set(kiroInternalThinkingResponseHeader, payload)
+}
+
+func writeKiroInternalThinkingSSEComment(w io.Writer, thinking string) error {
+	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromPlaintext(thinking))
+	if payload == "" || w == nil {
+		return nil
+	}
+	_, err := io.WriteString(w, kiroInternalThinkingSSECommentPfx+payload+"\n\n")
+	return err
+}
+
+func kiroInternalThinkingBlocksFromUpstream(hdr http.Header) []string {
+	if hdr == nil {
+		return nil
+	}
+	return decodeKiroInternalThinkingPayload(hdr.Get(kiroInternalThinkingResponseHeader))
+}
+
+func parseKiroInternalThinkingSSECommentLine(line string) ([]string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, strings.TrimSpace(kiroInternalThinkingSSECommentPfx)) {
+		return nil, false
+	}
+	payload := strings.TrimSpace(strings.TrimPrefix(trimmed, strings.TrimSpace(kiroInternalThinkingSSECommentPfx)))
+	blocks := decodeKiroInternalThinkingPayload(payload)
+	if len(blocks) == 0 {
+		return nil, false
+	}
+	return blocks, true
+}
+
+func applyKiroInternalThinkingFromUpstream(c *gin.Context, hdr http.Header) {
+	blocks := kiroInternalThinkingBlocksFromUpstream(hdr)
+	if len(blocks) == 0 {
+		return
+	}
+	applyKiroInternalThinkingBlocks(c, blocks)
+}

--- a/backend/internal/service/kiro_internal_thinking_tk_test.go
+++ b/backend/internal/service/kiro_internal_thinking_tk_test.go
@@ -1,0 +1,60 @@
+//go:build unit
+
+package service
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKiroInternalThinking_EncodeDecodeRoundTrip(t *testing.T) {
+	blocks := kiroInternalThinkingBlocksFromPlaintext("reason step one")
+	require.Len(t, blocks, 1)
+	require.Contains(t, blocks[0], `"type":"thinking"`)
+	require.Contains(t, blocks[0], "reason step one")
+
+	payload := encodeKiroInternalThinkingPayload(blocks)
+	got := decodeKiroInternalThinkingPayload(payload)
+	require.Equal(t, blocks, got)
+}
+
+func TestParseKiroInternalThinkingSSECommentLine(t *testing.T) {
+	thinking := "streamed reasoning"
+	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromPlaintext(thinking))
+	line := kiroInternalThinkingSSECommentPfx + payload
+
+	blocks, ok := parseKiroInternalThinkingSSECommentLine(line)
+	require.True(t, ok)
+	require.Len(t, blocks, 1)
+	require.Contains(t, blocks[0], thinking)
+
+	_, bad := parseKiroInternalThinkingSSECommentLine(": unrelated comment")
+	require.False(t, bad)
+}
+
+func TestStashKiroInternalThinkingBlocks_GinContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	stashKiroInternalThinkingBlocks(c, "first")
+	stashKiroInternalThinkingBlocks(c, "second")
+
+	raw, ok := c.Get(kiroInternalThinkingGinKey)
+	require.True(t, ok)
+	blocks, ok := raw.([]string)
+	require.True(t, ok)
+	require.Len(t, blocks, 2)
+}
+
+func TestWriteKiroInternalThinkingResponseHeader(t *testing.T) {
+	hdr := httptest.NewRecorder().Header()
+	writeKiroInternalThinkingResponseHeader(hdr, "non-stream reasoning")
+	require.NotEmpty(t, hdr.Get(kiroInternalThinkingResponseHeader))
+
+	got := kiroInternalThinkingBlocksFromUpstream(hdr)
+	require.Len(t, got, 1)
+	require.Contains(t, got[0], "non-stream reasoning")
+}

--- a/backend/internal/service/kiro_internal_thinking_tk_test.go
+++ b/backend/internal/service/kiro_internal_thinking_tk_test.go
@@ -3,6 +3,7 @@
 package service
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -57,4 +58,36 @@ func TestWriteKiroInternalThinkingResponseHeader(t *testing.T) {
 	got := kiroInternalThinkingBlocksFromUpstream(hdr)
 	require.Len(t, got, 1)
 	require.Contains(t, got[0], "non-stream reasoning")
+}
+
+func TestPublishKiroInternalThinkingSideChannel_DirectEdgeOmitsWire(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	publishKiroInternalThinkingSideChannel(c, rec, rec.Header(), "edge-only reasoning")
+
+	require.NotContains(t, rec.Body.String(), kiroInternalThinkingSSECommentPfx)
+	require.Empty(t, rec.Header().Get(kiroInternalThinkingResponseHeader))
+
+	raw, ok := c.Get(kiroInternalThinkingGinKey)
+	require.True(t, ok)
+	blocks, ok := raw.([]string)
+	require.True(t, ok)
+	require.Len(t, blocks, 1)
+	require.Contains(t, blocks[0], "edge-only reasoning")
+}
+
+func TestPublishKiroInternalThinkingSideChannel_MirrorHopEmitsWire(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	c.Request.Header.Set(kiroInternalThinkingMirrorHopRequestHeader, "1")
+
+	publishKiroInternalThinkingSideChannel(c, rec, rec.Header(), "mirror hop reasoning")
+
+	require.Contains(t, rec.Body.String(), kiroInternalThinkingSSECommentPfx)
+	require.NotEmpty(t, rec.Header().Get(kiroInternalThinkingResponseHeader))
 }

--- a/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
+++ b/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
@@ -149,9 +150,42 @@ func TestKiroGatewayService_Forward_Streaming_RedactsSplitInlineThinkingTags(t *
 	out := rec.Body.String()
 	require.Contains(t, out, `"type":"redacted_thinking"`)
 	require.Contains(t, out, "I am Claude.")
-	require.Contains(t, out, kiroInternalThinkingSSECommentPfx)
+	require.NotContains(t, out, kiroInternalThinkingSSECommentPfx)
 	require.NotContains(t, out, "<thinking>")
 	require.NotContains(t, out, "</thinking>")
 	require.NotContains(t, out, "The user asks who I am.")
 	require.NotContains(t, out, "thinking_delta")
+}
+
+func TestKiroGatewayService_Forward_Streaming_MirrorHopEmitsInternalThinkingSideChannel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	c.Request.Header.Set(kiroInternalThinkingMirrorHopRequestHeader, "1")
+
+	body := []byte{}
+	for _, content := range []string{
+		"<thinking>hidden plan</thinking>visible answer",
+	} {
+		body = append(body, buildKiroEventStreamMessage("assistantResponseEvent",
+			[]byte(`{"content":`+strconv.Quote(content)+`}`))...)
+	}
+	upstream := &kiroFakeUpstream{body: body}
+
+	svc := NewKiroGatewayService(upstream, nil, nil)
+	reqBody, _ := json.Marshal(map[string]any{
+		"model":      "claude-sonnet-4-6",
+		"messages":   []map[string]any{{"role": "user", "content": "hi"}},
+		"max_tokens": 32,
+		"stream":     true,
+	})
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(reqBody), Model: "claude-sonnet-4-6", Stream: true}
+
+	_, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), parsed, time.Now())
+	require.NoError(t, err)
+
+	out := rec.Body.String()
+	require.Contains(t, out, kiroInternalThinkingSSECommentPfx)
+	require.NotContains(t, out, "hidden plan")
 }

--- a/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
+++ b/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
@@ -149,6 +149,7 @@ func TestKiroGatewayService_Forward_Streaming_RedactsSplitInlineThinkingTags(t *
 	out := rec.Body.String()
 	require.Contains(t, out, `"type":"redacted_thinking"`)
 	require.Contains(t, out, "I am Claude.")
+	require.Contains(t, out, kiroInternalThinkingSSECommentPfx)
 	require.NotContains(t, out, "<thinking>")
 	require.NotContains(t, out, "</thinking>")
 	require.NotContains(t, out, "The user asks who I am.")

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -163,7 +163,8 @@
         "kiroproto.EstimateOutputTokens",
         "BillingTier:   kiroproto.KiroEstimatedBillingTier",
         "callErr != nil && !enc.started",
-        "classifyKiroForwardError"
+        "classifyKiroForwardError",
+        "publishKiroInternalThinkingSideChannel"
       ],
       "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream. It estimates token usage locally (EstimateInputTokens/EstimateOutputTokens) and stamps ForwardResult.BillingTier=\"kiro-estimated\", because the Kiro upstream reports credits only — without these calls both forward paths return Usage{0,0} and kiro bills as 100% free. The `callErr != nil && !enc.started` guard + classifyKiroForwardError are equally load-bearing: message_start is emitted lazily (see kiro_sse_encoder ensureBlock/writeToolUse), so an upstream failure before any content arrives surfaces a typed error instead of the old empty-but-200 SSE stream (the 'pre-content 400 returns a clean 200 lie' bug). An upstream merge that drops the estimate/BillingTier wiring (regresses kiro to free billing), reintroduces an eager enc.writeMessageStart() before the upstream call, or drops the classifier, regresses one of these."
     },
@@ -182,9 +183,36 @@
       "must_contain": [
         "account.IsKiro()",
         "kiroGateway",
-        "BillingTier:           optionalTrimmedStringPtr(result.BillingTier)"
+        "BillingTier:           optionalTrimmedStringPtr(result.BillingTier)",
+        "setKiroInternalThinkingMirrorHopHeader",
+        "parseKiroInternalThinkingSSECommentLine"
       ],
-      "rationale": "The Forward() dispatch injection point (next to IsBedrock) + the GatewayService.kiroGateway field, plus the ForwardResult.BillingTier -> UsageLog.BillingTier passthrough in buildRecordUsageLog that persists the kiro \"kiro-estimated\" provenance label. An upstream merge that rewrites Forward()/NewGatewayService() must preserve the dispatch branch (or kiro accounts fall through to the Anthropic path and fail); an upstream merge that rewrites buildRecordUsageLog must preserve the BillingTier line (or kiro usage logs lose the estimated-billing label even though estimation still runs)."
+      "rationale": "The Forward() dispatch injection point (next to IsBedrock) + the GatewayService.kiroGateway field, plus the ForwardResult.BillingTier -> UsageLog.BillingTier passthrough in buildRecordUsageLog that persists the kiro \"kiro-estimated\" provenance label. The setKiroInternalThinkingMirrorHopHeader + parseKiroInternalThinkingSSECommentLine anchors wire the prod mirror passthrough that strips Kiro plaintext-thinking side channels before the end client while stashing blocks for QA/traj export. An upstream merge that rewrites Forward()/NewGatewayService() must preserve the dispatch branch (or kiro accounts fall through to the Anthropic path and fail); an upstream merge that rewrites buildRecordUsageLog must preserve the BillingTier line (or kiro usage logs lose the estimated-billing label even though estimation still runs)."
+    },
+    {
+      "path": "backend/internal/service/kiro_internal_thinking_tk.go",
+      "must_contain": [
+        "func publishKiroInternalThinkingSideChannel",
+        "kiroInternalThinkingMirrorHopRequestHeader",
+        "func setKiroInternalThinkingMirrorHopHeader",
+        "func parseKiroInternalThinkingSSECommentLine"
+      ],
+      "rationale": "Kiro plaintext-thinking side channel for prod mirror QA/traj export. Edge emits the wire side channel only when the prod mirror hop header is present; direct edge clients get gin-context stash only. Losing publishKiroInternalThinkingSideChannel or the mirror-hop gate regresses to leaking plaintext thinking on edge direct SSE/headers or drops prod passthrough stash."
+    },
+    {
+      "path": "backend/internal/service/kiro_internal_thinking_tk_test.go",
+      "must_contain": [
+        "TestPublishKiroInternalThinkingSideChannel_DirectEdgeOmitsWire",
+        "TestPublishKiroInternalThinkingSideChannel_MirrorHopEmitsWire"
+      ],
+      "rationale": "Regression guard for the mirror-hop gate: edge direct must not emit wire side channel; prod mirror hop must."
+    },
+    {
+      "path": "backend/internal/service/gateway_anthropic_apikey_passthrough_test.go",
+      "must_contain": [
+        "TestGatewayService_AnthropicAPIKeyPassthrough_StripsKiroInternalThinkingSSEComment"
+      ],
+      "rationale": "Regression guard for prod passthrough stripping Kiro internal-thinking SSE comments while stashing blocks for QA/traj export."
     },
     {
       "path": "backend/internal/handler/admin/account_handler_tk_kiro_validate.go",


### PR DESCRIPTION
## 摘要

- Kiro 客户端仍只看到 `redacted_thinking`；明文 reasoning 经 **prod→edge mirror hop 侧信道** 进入 prod QA blob（`internal_thinking_blocks`），traj v2 导出时用 Anthropic 形 `thinking` 块替换 wire 上的 `redacted_thinking`。
- **Edge 直连**只写 gin context（本地 QA），**不在 SSE/响应头**暴露明文；Prod passthrough 发 `X-Tk-Internal-Thinking-Relay`、解析并剥离 Edge 侧信道后 stash，再写入 prod QA。
- QA 记录继续 `platform=anthropic`，无需单独 kiro 平台筛选。

## 风险

- **部署顺序**：Prod 镜像流量依赖 Edge 发侧信道 + Prod 解析；需 **Edge 与 Prod 同步发版**，否则 prod 导出仍只有 hash。
- **signature**：Kiro 上游无 Anthropic `signature`，导出块仅含 `type:thinking` + `thinking` 明文。
- **隐私**：review R-001/R-002 已修——Edge 直连默认不在 wire 上携带可解码明文；明文仅 prod mirror 路径 + traj opt-in blob。

## 验证

- `go test -tags=unit ./internal/service/ -run 'KiroInternal|PublishKiroInternal|AnthropicAPIKeyPassthrough_StripsKiro|KiroGatewayService_Forward_Streaming'`
- `go test -tags=unit ./internal/observability/trajectory/ -run 'KiroInternal|MergeInternal'`
- `./scripts/preflight.sh` PASS（含 kiro sentinel）
- 发版后：prod traj opt-in key 走 kiro 镜像打流式请求 → 手动 traj export v2 → assistant turn 含明文 `thinking` 块（**未验证**）

Web impact: none

sentinel-registry-reviewed

## 提交

- f3cdb0663 feat(kiro): stash plaintext thinking for prod QA traj export
- e177de2b3 fix(kiro): gate thinking side channel to prod mirror hops only
- 608b4c263 fix(kiro): satisfy golangci-lint on thinking side-channel paths

最新提交：608b4c263
