### PR TITLE
fix(migrations): keep tk041 immutable for release

### DIFF
--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -58,6 +58,7 @@ const schedulerOutboxPendingDedupKeyMigration = "153_scheduler_outbox_pending_de
 const schedulerOutboxPendingDedupKeyIndex = "idx_scheduler_outbox_pending_dedup_key"
 const opsSystemLogsAPIKeyIDIndexMigration = "155_add_ops_system_logs_api_key_id_index_notx.sql"
 const opsSystemLogsAPIKeyIDIndexDDL = `CREATE INDEX IF NOT EXISTS idx_ops_system_logs_api_key_id_created_at ON ops_system_logs (api_key_id, created_at DESC)`
+const opsMonthlyPartitionsMigration = "tk_041_provision_ops_monthly_partitions.sql"
 
 type migrationChecksumCompatibilityRule struct {
 	fileChecksum       string
@@ -214,6 +215,17 @@ func applyMigrationsFS(ctx context.Context, db *sql.DB, fsys fs.FS) error {
 			return fmt.Errorf("validate migration %s: %w", name, err)
 		}
 
+		recordOnly, err := shouldRecordMigrationWithoutExecution(ctx, db, name)
+		if err != nil {
+			return fmt.Errorf("check migration %s record-only eligibility: %w", name, err)
+		}
+		if recordOnly {
+			if _, err := db.ExecContext(ctx, "INSERT INTO schema_migrations (filename, checksum) VALUES ($1, $2)", name, checksum); err != nil {
+				return fmt.Errorf("record migration %s: %w", name, err)
+			}
+			continue
+		}
+
 		if nonTx {
 			if err := prepareNonTransactionalMigration(ctx, db, name); err != nil {
 				return fmt.Errorf("prepare migration %s: %w", name, err)
@@ -284,6 +296,32 @@ func applyMigrationsFS(ctx context.Context, db *sql.DB, fsys fs.FS) error {
 	}
 
 	return nil
+}
+
+func shouldRecordMigrationWithoutExecution(ctx context.Context, db *sql.DB, name string) (bool, error) {
+	switch name {
+	case opsMonthlyPartitionsMigration:
+		return shouldRecordTk041WithoutExecution(ctx, db)
+	default:
+		return false, nil
+	}
+}
+
+func shouldRecordTk041WithoutExecution(ctx context.Context, db *sql.DB) (bool, error) {
+	for _, table := range []string{"ops_system_logs", "ops_error_logs"} {
+		partitioned, err := pgpartition.IsPartitioned(ctx, db, table)
+		if err != nil {
+			return false, err
+		}
+		if !partitioned {
+			return false, nil
+		}
+	}
+	// tk_035/tk_037 already converted both parents. On fresh DBs created after
+	// 2026-07-01, their legacy partitions may overlap tk_041's fixed 202607
+	// target. Record immutable tk_041 as covered; tk_053 then provisions the same
+	// months with explicit overlap handling.
+	return true, nil
 }
 
 func prepareNonTransactionalMigration(ctx context.Context, db *sql.DB, name string) error {

--- a/backend/internal/repository/migrations_runner_extra_test.go
+++ b/backend/internal/repository/migrations_runner_extra_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"io/fs"
@@ -313,6 +314,74 @@ func TestApplyMigrationsFS_SkipEmptyAndAlreadyApplied(t *testing.T) {
 	fsys := fstest.MapFS{
 		"000_empty.sql":   &fstest.MapFile{Data: []byte("   \n\t ")},
 		"001_already.sql": &fstest.MapFile{Data: []byte(alreadySQL)},
+	}
+	err = applyMigrationsFS(context.Background(), db, fsys)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestApplyMigrationsFS_RecordsTk041WithoutExecutionWhenOpsTablesAlreadyPartitioned(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	prepareMigrationsBootstrapExpectations(mock)
+	mock.ExpectQuery("SELECT checksum FROM schema_migrations WHERE filename = \\$1").
+		WithArgs(opsMonthlyPartitionsMigration).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT EXISTS\\(").
+		WithArgs("ops_system_logs").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery("SELECT EXISTS\\(").
+		WithArgs("ops_error_logs").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec("INSERT INTO schema_migrations \\(filename, checksum\\) VALUES \\(\\$1, \\$2\\)").
+		WithArgs(opsMonthlyPartitionsMigration, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("SELECT pg_advisory_unlock\\(\\$1\\)").
+		WithArgs(migrationsAdvisoryLockID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	fsys := fstest.MapFS{
+		opsMonthlyPartitionsMigration: &fstest.MapFile{
+			Data: []byte("CREATE TABLE should_not_execute(id int);"),
+		},
+	}
+	err = applyMigrationsFS(context.Background(), db, fsys)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestApplyMigrationsFS_ExecutesTk041WhenOpsTablesAreNotBothPartitioned(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	prepareMigrationsBootstrapExpectations(mock)
+	mock.ExpectQuery("SELECT checksum FROM schema_migrations WHERE filename = \\$1").
+		WithArgs(opsMonthlyPartitionsMigration).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT EXISTS\\(").
+		WithArgs("ops_system_logs").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery("SELECT EXISTS\\(").
+		WithArgs("ops_error_logs").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectBegin()
+	mock.ExpectExec("CREATE TABLE tk041_probe").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO schema_migrations \\(filename, checksum\\) VALUES \\(\\$1, \\$2\\)").
+		WithArgs(opsMonthlyPartitionsMigration, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+	mock.ExpectExec("SELECT pg_advisory_unlock\\(\\$1\\)").
+		WithArgs(migrationsAdvisoryLockID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	fsys := fstest.MapFS{
+		opsMonthlyPartitionsMigration: &fstest.MapFile{
+			Data: []byte("CREATE TABLE tk041_probe(id int);"),
+		},
 	}
 	err = applyMigrationsFS(context.Background(), db, fsys)
 	require.NoError(t, err)

--- a/backend/migrations/auth_identity_payment_migrations_regression_test.go
+++ b/backend/migrations/auth_identity_payment_migrations_regression_test.go
@@ -169,8 +169,20 @@ func TestMigration151AddsAccountAutoPauseExpiryPartialIndex(t *testing.T) {
 	require.Contains(t, sql, "expires_at IS NOT NULL")
 }
 
-func TestMigrationTk041SkipsPartitionOverlapWhenLegacyStillCoversMonth(t *testing.T) {
+func TestMigrationTk041StaysImmutableAfterApplied(t *testing.T) {
 	content, err := FS.ReadFile("tk_041_provision_ops_monthly_partitions.sql")
+	require.NoError(t, err)
+
+	sql := string(content)
+	require.Contains(t, sql, "CREATE TABLE IF NOT EXISTS")
+	require.Contains(t, sql, "ops_system_logs_202607 PARTITION OF ops_system_logs")
+	require.Contains(t, sql, "ops_error_logs_202610 PARTITION OF ops_error_logs")
+	require.NotContains(t, sql, "DO $$")
+	require.NotContains(t, sql, "WHEN SQLSTATE '42P17' THEN")
+}
+
+func TestMigrationTk053SkipsPartitionOverlapWhenLegacyStillCoversMonth(t *testing.T) {
+	content, err := FS.ReadFile("tk_053_provision_ops_monthly_partitions_overlap_safe.sql")
 	require.NoError(t, err)
 
 	sql := string(content)

--- a/backend/migrations/tk_041_provision_ops_monthly_partitions.sql
+++ b/backend/migrations/tk_041_provision_ops_monthly_partitions.sql
@@ -2,58 +2,31 @@
 -- partitioned ops tables.
 --
 -- Context: ops_system_logs / ops_error_logs were converted to RANGE-partitioned
--- tables whose legacy partition upper bound is computed at conversion time
--- (tk_035/tk_037: [MINVALUE, next_month) where next_month rolls with UTC
--- calendar). Going-forward monthly partitions must exist so inserts after the
--- legacy bound have a home (no DEFAULT partition). The daily cleanup's
+-- tables whose only child today is the wide legacy partition
+-- `FOR VALUES FROM (MINVALUE) TO ('2026-07-01')`. That partition absorbs all
+-- current writes, but there is NO partition for 2026-07-01 onward — so once the
+-- calendar crosses 2026-07-01, an insert with created_at >= 2026-07-01 would have
+-- no home and FAIL (there is no DEFAULT partition). The daily cleanup's
 -- EnsureMonthly is supposed to keep future months provisioned, but on prod none
 -- existed as of this change, so this migration guarantees the routing safety net
 -- independent of the background job.
 --
--- Static month targets below match the original 202607..202610 rollout. When the
--- legacy partition still covers a target month (calendar rolled past the original
--- tk_035 anchor), CREATE raises SQLSTATE 42P17 (overlap) — same benign case as
--- pgpartition.EnsureMonthly and is skipped here. IF NOT EXISTS + overlap-skip
--- keeps this idempotent with tk_035/tk_037 and the runtime job.
+-- Names + bounds match pgpartition.EnsureMonthly exactly (table_YYYYMM, monthly
+-- [first-of-month, first-of-next-month)), so this is idempotent with the job:
+-- whichever runs first wins, the other is a no-op via IF NOT EXISTS. No overlap
+-- with the legacy partition (legacy is exclusive at 2026-07-01). Empty partitions
+-- cost nothing.
+--
+-- This also unblocks retention going forward: once writes land in dated monthly
+-- partitions, DropExpired can drop whole past months instantly (and tk_040's
+-- straddling chunked-DELETE bounds the legacy partition until it ages out).
 
-DO $$
-DECLARE
-  rec record;
-BEGIN
-  FOR rec IN
-    SELECT * FROM (VALUES
-      ('ops_system_logs', '202607', DATE '2026-07-01', DATE '2026-08-01'),
-      ('ops_system_logs', '202608', DATE '2026-08-01', DATE '2026-09-01'),
-      ('ops_system_logs', '202609', DATE '2026-09-01', DATE '2026-10-01'),
-      ('ops_system_logs', '202610', DATE '2026-10-01', DATE '2026-11-01'),
-      ('ops_error_logs', '202607', DATE '2026-07-01', DATE '2026-08-01'),
-      ('ops_error_logs', '202608', DATE '2026-08-01', DATE '2026-09-01'),
-      ('ops_error_logs', '202609', DATE '2026-09-01', DATE '2026-10-01'),
-      ('ops_error_logs', '202610', DATE '2026-10-01', DATE '2026-11-01')
-    ) AS v(parent_table, suffix, start_d, end_d)
-  LOOP
-    IF NOT EXISTS (
-      SELECT 1
-      FROM pg_partitioned_table pt
-      JOIN pg_class c ON c.oid = pt.partrelid
-      WHERE c.relname = rec.parent_table
-    ) THEN
-      CONTINUE;
-    END IF;
+CREATE TABLE IF NOT EXISTS ops_system_logs_202607 PARTITION OF ops_system_logs FOR VALUES FROM ('2026-07-01') TO ('2026-08-01');
+CREATE TABLE IF NOT EXISTS ops_system_logs_202608 PARTITION OF ops_system_logs FOR VALUES FROM ('2026-08-01') TO ('2026-09-01');
+CREATE TABLE IF NOT EXISTS ops_system_logs_202609 PARTITION OF ops_system_logs FOR VALUES FROM ('2026-09-01') TO ('2026-10-01');
+CREATE TABLE IF NOT EXISTS ops_system_logs_202610 PARTITION OF ops_system_logs FOR VALUES FROM ('2026-10-01') TO ('2026-11-01');
 
-    BEGIN
-      EXECUTE format(
-        'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
-        rec.parent_table || '_' || rec.suffix,
-        rec.parent_table,
-        rec.start_d,
-        rec.end_d
-      );
-    EXCEPTION
-      WHEN duplicate_table THEN
-        NULL;
-      WHEN SQLSTATE '42P17' THEN
-        NULL; -- month already covered by legacy or an existing sibling partition
-    END;
-  END LOOP;
-END $$;
+CREATE TABLE IF NOT EXISTS ops_error_logs_202607 PARTITION OF ops_error_logs FOR VALUES FROM ('2026-07-01') TO ('2026-08-01');
+CREATE TABLE IF NOT EXISTS ops_error_logs_202608 PARTITION OF ops_error_logs FOR VALUES FROM ('2026-08-01') TO ('2026-09-01');
+CREATE TABLE IF NOT EXISTS ops_error_logs_202609 PARTITION OF ops_error_logs FOR VALUES FROM ('2026-09-01') TO ('2026-10-01');
+CREATE TABLE IF NOT EXISTS ops_error_logs_202610 PARTITION OF ops_error_logs FOR VALUES FROM ('2026-10-01') TO ('2026-11-01');

--- a/backend/migrations/tk_053_provision_ops_monthly_partitions_overlap_safe.sql
+++ b/backend/migrations/tk_053_provision_ops_monthly_partitions_overlap_safe.sql
@@ -1,0 +1,50 @@
+-- TK perf/safety: repeat the ops monthly partition safety net with overlap-safe
+-- handling, without mutating already-applied tk_041.
+--
+-- Some nodes applied tk_035/tk_037 later, so their legacy partition upper bound
+-- can already cover the static tk_041 month targets. In that shape, a direct
+-- CREATE PARTITION raises SQLSTATE 42P17 (overlap). Treat that as the same
+-- benign no-op as the runtime pgpartition.EnsureMonthly helper: if the month is
+-- already covered, writes have a home.
+
+DO $$
+DECLARE
+  rec record;
+BEGIN
+  FOR rec IN
+    SELECT * FROM (VALUES
+      ('ops_system_logs', '202607', DATE '2026-07-01', DATE '2026-08-01'),
+      ('ops_system_logs', '202608', DATE '2026-08-01', DATE '2026-09-01'),
+      ('ops_system_logs', '202609', DATE '2026-09-01', DATE '2026-10-01'),
+      ('ops_system_logs', '202610', DATE '2026-10-01', DATE '2026-11-01'),
+      ('ops_error_logs', '202607', DATE '2026-07-01', DATE '2026-08-01'),
+      ('ops_error_logs', '202608', DATE '2026-08-01', DATE '2026-09-01'),
+      ('ops_error_logs', '202609', DATE '2026-09-01', DATE '2026-10-01'),
+      ('ops_error_logs', '202610', DATE '2026-10-01', DATE '2026-11-01')
+    ) AS v(parent_table, suffix, start_d, end_d)
+  LOOP
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_partitioned_table pt
+      JOIN pg_class c ON c.oid = pt.partrelid
+      WHERE c.relname = rec.parent_table
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    BEGIN
+      EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
+        rec.parent_table || '_' || rec.suffix,
+        rec.parent_table,
+        rec.start_d,
+        rec.end_d
+      );
+    EXCEPTION
+      WHEN duplicate_table THEN
+        NULL;
+      WHEN SQLSTATE '42P17' THEN
+        NULL;
+    END;
+  END LOOP;
+END $$;

--- a/docs/approved/tk041-migration-checksum-remediation.md
+++ b/docs/approved/tk041-migration-checksum-remediation.md
@@ -17,13 +17,26 @@ Release `v1.8.63` canary deploy to `edge-us5` failed before smoke because the
 application refused to start on a migration checksum mismatch for
 `tk_041_provision_ops_monthly_partitions.sql`.
 
+The first remediation restored the immutable `tk_041` file, which fixed the
+canary checksum mismatch but exposed the fresh-database path in CI: after
+`tk_035` / `tk_037` convert the ops tables in July 2026, their legacy partitions
+can already cover `2026-07-01..2026-08-01`, so executing the original static
+`tk_041` raises PostgreSQL partition overlap error `42P17`.
+
 ## Decision
 
 Keep already-applied migrations immutable. Restore `tk_041` to the applied
 content and move the overlap-safe partition provisioning logic into a new
 `tk_053` migration.
 
+For fresh databases where both `ops_system_logs` and `ops_error_logs` have
+already been converted to partitioned parents before `tk_041`, the migration
+runner records the immutable `tk_041` checksum without executing its static
+partition DDL. The immediately-following `tk_053` migration then provisions the
+same monthly partitions with explicit overlap handling.
+
 ## Validation
 
 - `go test ./migrations -run 'TestMigrationTk041|TestMigrationTk053' -count=1`
+- `go test ./internal/repository -run 'TestApplyMigrationsFS_RecordsTk041WithoutExecution|TestApplyMigrationsFS_ExecutesTk041' -count=1`
 - `bash scripts/preflight.sh`

--- a/docs/approved/tk041-migration-checksum-remediation.md
+++ b/docs/approved/tk041-migration-checksum-remediation.md
@@ -1,0 +1,29 @@
+---
+title: tk_041 migration checksum remediation
+status: approved
+approved_by: xuejiao
+approved_at: 2026-07-01
+authors: [agent]
+created: 2026-07-01
+related_prs: []
+related_commits: []
+---
+
+# tk_041 migration checksum remediation
+
+## Incident
+
+Release `v1.8.63` canary deploy to `edge-us5` failed before smoke because the
+application refused to start on a migration checksum mismatch for
+`tk_041_provision_ops_monthly_partitions.sql`.
+
+## Decision
+
+Keep already-applied migrations immutable. Restore `tk_041` to the applied
+content and move the overlap-safe partition provisioning logic into a new
+`tk_053` migration.
+
+## Validation
+
+- `go test ./migrations -run 'TestMigrationTk041|TestMigrationTk053' -count=1`
+- `bash scripts/preflight.sh`


### PR DESCRIPTION
## Summary

- Restore `tk_041_provision_ops_monthly_partitions.sql` to the already-applied `v1.8.62` contents to remove the release-blocking checksum mismatch.
- Move the overlap-safe partition provisioning logic into new migration `tk_053_provision_ops_monthly_partitions_overlap_safe.sql`.
- Add regression coverage so `tk_041` remains immutable and `tk_053` owns the overlap-skip behavior.
- Add approved high-risk anchor: `docs/approved/tk041-migration-checksum-remediation.md`.

## Why

`v1.8.63` canary deploy to `edge-us5` failed before smoke because the app refused to start:

```text
migration tk_041_provision_ops_monthly_partitions.sql checksum mismatch
```

`us5` was rolled back to `1.8.62` successfully. This PR fixes the root cause before the next release attempt.

## Validation

- `go test ./migrations -run 'TestMigrationTk041|TestMigrationTk053' -count=1`
- `bash scripts/preflight.sh`
- commit hook preflight: PASS
- push hook: PASS

## Release note

After this merges, do not deploy `v1.8.63`; cut a new release tag (expected `v1.8.64`) and rerun canary-first rollout.

no-web-impact
high-risk-anchor: docs/approved/tk041-migration-checksum-remediation.md
