### PR TITLE
fix(grok): prod 镜像账号 Grok 视频提交凭证修复

### DIFF
--- a/backend/internal/service/openai_gateway_grok_video_tk.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk.go
@@ -40,6 +40,39 @@ import (
 // account 403s on /videos exactly as on chat. We surface that as a clean
 // honesty-403 (no failover, no penalty), reusing tkIsGrokEntitlement403.
 
+// resolveGrokVideoCredential returns the Bearer token and base URL for the grok
+// native video arm. OAuth accounts use xAI access_token; API-key relay stubs
+// (prod→edge mirror accounts) use the edge TokenKey api_key + base_url — the
+// same split as openai_gateway_chat_completions_raw.go.
+func resolveGrokVideoCredential(account *Account) (token, baseURL string, err error) {
+	if account == nil {
+		return "", "", errors.New("grok video: account is nil")
+	}
+	switch {
+	case account.IsGrokOAuth():
+		token = account.GetGrokAccessToken()
+		baseURL = account.GetGrokBaseURL()
+	case account.IsGrokAPIKey():
+		token = account.GetOpenAIApiKey()
+		baseURL = account.GetGrokBaseURL()
+		if baseURL == "" {
+			baseURL = account.GetOpenAIBaseURL()
+		}
+	default:
+		return "", "", fmt.Errorf("grok account %d unsupported type for video", account.ID)
+	}
+	if token == "" {
+		if account.IsGrokAPIKey() {
+			return "", "", fmt.Errorf("grok relay account %d missing api_key", account.ID)
+		}
+		return "", "", fmt.Errorf("grok account %d missing access_token", account.ID)
+	}
+	if strings.TrimSpace(baseURL) == "" {
+		return "", "", fmt.Errorf("grok relay account %d missing base_url", account.ID)
+	}
+	return token, baseURL, nil
+}
+
 // grokNativeVideoSubmit POSTs the client's video request to xAI's OAuth video
 // endpoint and writes the OpenAI-Video submit acknowledgement (carrying TK's
 // public task id) to the gin response — mirroring the bridge contract that the
@@ -64,11 +97,11 @@ func (s *OpenAIGatewayService) grokNativeVideoSubmit(
 		upstreamBody = ReplaceModelInBody(body, upstreamModel)
 	}
 
-	token := account.GetGrokAccessToken()
-	if token == "" {
-		return nil, fmt.Errorf("grok account %d missing access_token", account.ID)
+	token, grokBase, cerr := resolveGrokVideoCredential(account)
+	if cerr != nil {
+		return nil, cerr
 	}
-	base, err := s.validateUpstreamBaseURL(account.GetGrokBaseURL())
+	base, err := s.validateUpstreamBaseURL(grokBase)
 	if err != nil {
 		return nil, fmt.Errorf("invalid grok base_url: %w", err)
 	}
@@ -129,16 +162,16 @@ func (s *OpenAIGatewayService) grokNativeVideoFetch(
 	if in.AccountID > 0 {
 		if acc, err := s.accountRepo.GetByID(ctx, in.AccountID); err == nil && acc != nil && acc.IsGrok() {
 			account = acc
-			if fresh := acc.GetGrokAccessToken(); fresh != "" {
-				token = fresh // re-resolve: the pinned record token may be a rotated/stale Bearer
-			}
-			if b, verr := s.validateUpstreamBaseURL(acc.GetGrokBaseURL()); verr == nil && b != "" {
-				base = strings.TrimRight(b, "/")
+			if freshToken, freshBase, rerr := resolveGrokVideoCredential(acc); rerr == nil {
+				token = freshToken // re-resolve: OAuth Bearer may rotate; relay api_key is stable
+				if b, verr := s.validateUpstreamBaseURL(freshBase); verr == nil && b != "" {
+					base = strings.TrimRight(b, "/")
+				}
 			}
 		}
 	}
 	if token == "" {
-		return nil, errors.New("grok video fetch: no usable access token")
+		return nil, errors.New("grok video fetch: no usable bearer credential")
 	}
 	url := base + "/videos/" + in.UpstreamTaskID
 

--- a/backend/internal/service/openai_gateway_grok_video_tk_test.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk_test.go
@@ -7,7 +7,88 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 )
+
+func TestResolveGrokVideoCredential(t *testing.T) {
+	t.Run("oauth uses access_token", func(t *testing.T) {
+		acct := &Account{
+			Platform: PlatformGrok,
+			Type:     AccountTypeOAuth,
+			Credentials: map[string]any{
+				"access_token": "oauth-bearer",
+				"base_url":     "https://api.x.ai/v1",
+			},
+		}
+		token, base, err := resolveGrokVideoCredential(acct)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if token != "oauth-bearer" || base != "https://api.x.ai/v1" {
+			t.Fatalf("got token=%q base=%q", token, base)
+		}
+	})
+
+	t.Run("apikey relay uses edge api_key", func(t *testing.T) {
+		acct := &Account{
+			ID:       65,
+			Platform: PlatformGrok,
+			Type:     AccountTypeAPIKey,
+			Credentials: map[string]any{
+				"api_key":  "edge-relay-key",
+				"base_url": "https://api-us4.tokenkey.dev",
+			},
+		}
+		token, base, err := resolveGrokVideoCredential(acct)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if token != "edge-relay-key" || base != "https://api-us4.tokenkey.dev" {
+			t.Fatalf("got token=%q base=%q", token, base)
+		}
+	})
+
+	t.Run("oauth missing access_token", func(t *testing.T) {
+		acct := &Account{Platform: PlatformGrok, Type: AccountTypeOAuth}
+		_, _, err := resolveGrokVideoCredential(acct)
+		if err == nil || !strings.Contains(err.Error(), "missing access_token") {
+			t.Fatalf("want missing access_token error, got %v", err)
+		}
+	})
+
+	t.Run("relay missing api_key", func(t *testing.T) {
+		acct := &Account{
+			ID:       65,
+			Platform: PlatformGrok,
+			Type:     AccountTypeAPIKey,
+			Credentials: map[string]any{
+				"base_url": "https://api-us4.tokenkey.dev",
+			},
+		}
+		_, _, err := resolveGrokVideoCredential(acct)
+		if err == nil || !strings.Contains(err.Error(), "missing api_key") {
+			t.Fatalf("want missing api_key error, got %v", err)
+		}
+	})
+
+	t.Run("oauth default base when unset", func(t *testing.T) {
+		acct := &Account{
+			Platform: PlatformGrok,
+			Type:     AccountTypeOAuth,
+			Credentials: map[string]any{
+				"access_token": "tok",
+			},
+		}
+		_, base, err := resolveGrokVideoCredential(acct)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if base != xai.DefaultBaseURL {
+			t.Fatalf("base = %q, want %q", base, xai.DefaultBaseURL)
+		}
+	})
+}
 
 // TestReadGrokVideoResponseLimited pins the bounded read that protects the grok
 // video arm from a hostile/runaway upstream: a body within the cap reads back

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -294,9 +294,10 @@
       "must_contain": [
         "func (s *OpenAIGatewayService) grokNativeVideoSubmit",
         "func (s *OpenAIGatewayService) grokNativeVideoFetch",
+        "resolveGrokVideoCredential",
         "/videos/generations"
       ],
-      "rationale": "The grok-native video arm: submit (POST api.x.ai/v1/videos/generations -> request_id) + poll (GET api.x.ai/v1/videos/{id}) over the grok OAuth Bearer, returning the same bridge.TaskSubmitOutcome/VideoFetchOutcome shapes the handler consumes so the vt_ public id, VideoTaskCache record, balance hold, per-second billing, terminal refund, direct video delivery and ownership-404 are all reused. Video has no new-api TaskAdaptor for xAI (GetTaskAdaptor has no xai entry), so this native arm is grok video's ONLY code path — losing it makes grok video fail outright."
+      "rationale": "The grok-native video arm: submit (POST api.x.ai/v1/videos/generations -> request_id) + poll (GET api.x.ai/v1/videos/{id}) over the grok OAuth Bearer OR prod→edge relay api_key (resolveGrokVideoCredential mirrors chat raw), returning the same bridge.TaskSubmitOutcome/VideoFetchOutcome shapes the handler consumes so the vt_ public id, VideoTaskCache record, balance hold, per-second billing, terminal refund, direct video delivery and ownership-404 are all reused. Video has no new-api TaskAdaptor for xAI (GetTaskAdaptor has no xai entry), so this native arm is grok video's ONLY code path — losing it makes grok video fail outright."
     },
     {
       "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go",
@@ -327,10 +328,11 @@
     {
       "path": "backend/internal/service/openai_gateway_grok_video_tk_test.go",
       "must_contain": [
+        "TestResolveGrokVideoCredential",
         "TestNormalizeGrokVideoStatus",
         "TestBuildGrokVideoSubmitResponse"
       ],
-      "rationale": "Load-bearing QA evidence for the grok-native video arm: the xAI status-enum -> videoTerminalOutcome mapping (drift would skip terminal-success retention or terminal-failure refund) and the submit acknowledgement shape (must carry TK's public task id, not the upstream request_id)."
+      "rationale": "Load-bearing QA evidence for the grok-native video arm: resolveGrokVideoCredential pins OAuth vs prod→edge relay api_key (revert to access_token-only silently re-breaks prod grok-us4 video submit), the xAI status-enum -> videoTerminalOutcome mapping (drift would skip terminal-success retention or terminal-failure refund), and the submit acknowledgement shape (must carry TK's public task id, not the upstream request_id)."
     },
     {
       "path": "backend/internal/server/routes/gateway_tk_openai_compat_handlers.go",


### PR DESCRIPTION
## 摘要

- 修复 Studio **Grok Imagine · Video** 在 prod 上报 **Video submit failed（502）** 的问题。
- 根因：`grokNativeVideoSubmit` 只读 OAuth `access_token`，而 prod 实际调度的是 **prod→edge 中继账号**（`grok-us4`，type=`apikey`，凭 `api_key` + `base_url` 转发到 `api-us4.tokenkey.dev`）。
- 与 chat raw 路径对齐：新增 `resolveGrokVideoCredential`，OAuth 用 `access_token`，relay 用 `api_key`；submit / poll 均复用。

sentinel-registry-reviewed：仅调整既有 grok video arm 凭证解析，无新公共路由/端点。

## 风险

- **常规风险**：仅影响 grok 平台 native video arm 的 Bearer 解析；OAuth 直连 xAI 路径行为不变。
- 发版后若 edge 侧 grok OAuth 账号不健康（us4 上 id=6 当前 status=error），仍可能 upstream 失败，但会返回具体 upstream 错误而非本地「缺 token」502。

## 验证

- `go test -tags=unit ./internal/service/ -run 'TestResolveGrokVideoCredential|TestNormalizeGrokVideo|TestBuildGrokVideo'` — 通过
- `./scripts/preflight.sh` — PASS
- Prod 端到端：合并发版后，用全能 Key 对 `POST /v1/video/generations`（model=`grok-imagine-video`）复测 submit 应返回 200 + `vt_` task id

## 提交

- `428d7169a` fix(grok): prod 镜像账号视频提交改用 edge api_key 凭证

最新提交：428d7169a
