### PR TITLE
fix(ops): normalize 审计不再污染 recovered-200 与 prompt-surface-watch SSM

### DIFF
--- a/.cursor/skills/tokenkey-user-billing-watch/SKILL.md
+++ b/.cursor/skills/tokenkey-user-billing-watch/SKILL.md
@@ -64,6 +64,7 @@ bash ops/observability/run-probe.sh \
 |---|---|---|
 | `error_phase=routing` + `account_id=null` + `is_business_limited=true` | 空池 / 错组 key 误投（如 newapi 长尾模型用 anthropic 组 key 发 `/v1/messages`） | 客户端侧，**非系统**，不推送 |
 | `status_code=200` + `upstream_status_code∈{429,502,5xx}` | recovered-200：重试已成功，用户侧无感 | 不推送 |
+| `status_code=200` + `msg` 仅含 `cc_environment_stripped` / `cc_geo_stego_normalized`（或 `request_normalized` 审计类） | v1.8.64+ Anthropic CC prompt normalize 预期改写；`gateway.anthropic_request_normalized` 为 canonical 审计 | 不推送 |
 | `error_phase∈{request,upstream}` 的 4xx（`data_inspection_failed` 内容审核 / 退役模型 / prompt too long / 参数错） | 客户端输入或用法问题 | 不推送 |
 | `status_code≥500` 真失败（非 recovered） / 空池 429 绝对量**突升** / 流量归零 / 成本飙升 / 上述都不匹配的**新指纹** | 疑似系统异常 | **推送**并简述 |
 

--- a/.github/workflows/prompt-surface-watch.yml
+++ b/.github/workflows/prompt-surface-watch.yml
@@ -100,6 +100,7 @@ jobs:
             --target prod \
             --script ops/observability/probe-prompt-surface-fingerprints.sh \
             --env "SINCE=${SINCE}" \
+            --env "LIMIT=40" \
             --comment "prompt-surface-watch prod fingerprint aggregate" \
             --timeout-seconds 120 \
             > .cache/prompt-surface-watch/prod-fingerprints.json || true  # preflight-allow: swallow

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -577,6 +577,26 @@ func (w *opsCaptureWriter) WriteString(s string) (int, error) {
 	return w.ResponseWriter.WriteString(s)
 }
 
+// opsUpstreamEventsForRecoveredLogging drops normalize audit events from the
+// recovered-200 path. Those are intentional CC prompt-surface rewrites, not
+// upstream instability; they are audited via gateway.anthropic_request_normalized.
+func opsUpstreamEventsForRecoveredLogging(events []*service.OpsUpstreamErrorEvent) []*service.OpsUpstreamErrorEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]*service.OpsUpstreamErrorEvent, 0, len(events))
+	for _, ev := range events {
+		if ev == nil {
+			continue
+		}
+		if strings.TrimSpace(ev.Kind) == service.OpsUpstreamKindRequestNormalized {
+			continue
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
 // OpsErrorLoggerMiddleware records error responses (status >= 400) into ops_error_logs.
 //
 // Notes:
@@ -615,7 +635,7 @@ func OpsErrorLoggerMiddleware(ops *service.OpsService) gin.HandlerFunc {
 			var events []*service.OpsUpstreamErrorEvent
 			if v, ok := c.Get(service.OpsUpstreamErrorsKey); ok {
 				if arr, ok := v.([]*service.OpsUpstreamErrorEvent); ok && len(arr) > 0 {
-					events = arr
+					events = opsUpstreamEventsForRecoveredLogging(arr)
 				}
 			}
 			// Also accept single upstream fields set by gateway services (rare for successful requests).

--- a/backend/internal/handler/ops_error_logger_tk_request_normalized_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_request_normalized_test.go
@@ -1,0 +1,88 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+func TestOpsUpstreamEventsForRecoveredLogging_DropsNormalizeAudit(t *testing.T) {
+	in := []*service.OpsUpstreamErrorEvent{
+		{Kind: service.OpsUpstreamKindRequestNormalized, Message: "cc_environment_stripped"},
+		{UpstreamStatusCode: http.StatusUnauthorized, Message: "oauth expired"},
+	}
+	out := opsUpstreamEventsForRecoveredLogging(in)
+	require.Len(t, out, 1)
+	require.Equal(t, http.StatusUnauthorized, out[0].UpstreamStatusCode)
+}
+
+func TestOpsErrorLoggerMiddleware_SkipsRecoveredLogForNormalizeAuditOnly(t *testing.T) {
+	resetOpsErrorLoggerStateForTest(t)
+	opsErrorLogOnce.Do(func() {})
+	opsErrorLogMu.Lock()
+	opsErrorLogQueue = make(chan opsErrorLogJob, 4)
+	opsErrorLogMu.Unlock()
+
+	ops := service.NewOpsService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/v1/messages", OpsErrorLoggerMiddleware(ops), func(c *gin.Context) {
+		c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{{
+			Kind:    service.OpsUpstreamKindRequestNormalized,
+			Message: "cc_geo_stego_normalized,cc_environment_stripped",
+		}})
+		c.Status(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, int64(0), OpsErrorLogEnqueuedTotal())
+}
+
+func TestOpsErrorLoggerMiddleware_RecoveredLogKeepsRealUpstreamAfterNormalizeAudit(t *testing.T) {
+	resetOpsErrorLoggerStateForTest(t)
+	opsErrorLogOnce.Do(func() {})
+	opsErrorLogMu.Lock()
+	opsErrorLogQueue = make(chan opsErrorLogJob, 4)
+	opsErrorLogMu.Unlock()
+
+	ops := service.NewOpsService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/v1/messages", OpsErrorLoggerMiddleware(ops), func(c *gin.Context) {
+		c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{
+			{Kind: service.OpsUpstreamKindRequestNormalized, Message: "cc_environment_stripped"},
+			{UpstreamStatusCode: http.StatusUnauthorized, Message: "invalid bearer token"},
+		})
+		c.Status(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, int64(1), OpsErrorLogEnqueuedTotal())
+	require.Equal(t, int64(1), OpsErrorLogQueueLength())
+
+	select {
+	case job := <-opsErrorLogQueue:
+		require.NotNil(t, job.entry)
+		require.Equal(t, http.StatusOK, job.entry.StatusCode)
+		require.NotNil(t, job.entry.UpstreamStatusCode)
+		require.Equal(t, http.StatusUnauthorized, *job.entry.UpstreamStatusCode)
+		require.Contains(t, job.entry.ErrorMessage, "Recovered upstream error 401")
+	default:
+		t.Fatal("expected recovered upstream error log job")
+	}
+}

--- a/backend/internal/service/gateway_anthropic_request_normalize_tk.go
+++ b/backend/internal/service/gateway_anthropic_request_normalize_tk.go
@@ -212,11 +212,10 @@ func tkLogAnthropicNormalize(ctx context.Context, changes []tkAnthropicNormalize
 	)
 }
 
-// tkRecordAnthropicNormalizeOpsEvent records one ops upstream-errors event
-// per request so an operator can SQL the rows that were normalized but still
-// failed. The event only persists if the request ultimately errors (ops
-// logger only writes rows for non-2xx final outcomes), so this measures
-// "normalize did not save the request" not "normalize ran".
+// tkRecordAnthropicNormalizeOpsEvent attaches normalize change kinds to the
+// request's upstream-errors event list so failed (>=400) rows retain them in
+// upstream_errors JSON. Recovered-200 ops logging intentionally skips this kind;
+// gateway.anthropic_request_normalized slog is the success-path audit trail.
 func tkRecordAnthropicNormalizeOpsEvent(c *gin.Context, changes []tkAnthropicNormalizeChange) {
 	if c == nil || len(changes) == 0 {
 		return

--- a/backend/internal/service/ops_upstream_context.go
+++ b/backend/internal/service/ops_upstream_context.go
@@ -27,6 +27,11 @@ const (
 	OpsUpstreamErrorDetailKey  = "ops_upstream_error_detail"
 	OpsUpstreamErrorsKey       = "ops_upstream_errors"
 
+	// OpsUpstreamKindRequestNormalized marks Anthropic request-body normalize audit
+	// events (change-kind list in Message). Recovered-200 ops logging must ignore
+	// these; gateway.anthropic_request_normalized slog is the canonical audit path.
+	OpsUpstreamKindRequestNormalized = "request_normalized"
+
 	// OpsInternalErrorDetailKey carries a sanitized, truncated detail string for
 	// internal-phase errors (cache/redis/db/context failures) that bubble up as
 	// 5xx from middleware. Distinct from upstream-* keys so dashboards don't

--- a/ops/observability/prompt_surface_aggregate.py
+++ b/ops/observability/prompt_surface_aggregate.py
@@ -83,7 +83,14 @@ def main() -> int:
     args = ap.parse_args()
 
     if args.input:
-        payload = json.loads(args.input.read_text(encoding="utf-8"))
+        raw = args.input.read_text(encoding="utf-8")
+        if "--output truncated--" in raw:
+            print(
+                "error: probe output truncated (SSM ~24KB limit); lower LIMIT in workflow",
+                file=sys.stderr,
+            )
+            return 1
+        payload = json.loads(raw)
     else:
         payload = json.load(sys.stdin)
 


### PR DESCRIPTION
## 摘要

- recovered-200 路径过滤 `request_normalized` 审计事件，避免 `cc_environment_stripped` / `cc_geo_stego_normalized` 写入 `ops_error_logs` 触发盯盘误报；真实上游 401 等仍会保留。
- `prompt-surface-watch` prod 探针 `LIMIT=40`，避开 SSM ~24KB 截断；aggregate 对截断输出给出明确错误。
- `tokenkey-user-billing-watch` §4 补充 normalize 噪声判别（不推送）。
- 已 rebase 到含 #1114 / #1118 的 `main`，与 CC prompt-surface 收窄改动无冲突。

## 风险

- 常规风险：仅影响 ops 观测落库与 workflow 探针上限，不改变网关 normalize 行为。
- 失败请求（>=400）的 `upstream_errors` JSON 仍保留 `request_normalized` 事件供排障。

## 验证

- `go test -tags=unit ./internal/handler -run 'TestOpsUpstreamEventsForRecoveredLogging|TestOpsErrorLoggerMiddleware_' -count=1` 通过（rebase 后）
- `./scripts/preflight.sh` 通过

## 提交

- f0797bdae fix(ops): stop normalize audit from polluting recovered-200 error logs

最新提交：f0797bdae

sentinel-registry-reviewed
