### PR TITLE
fix(kiro): prod 镜像 Forward 路径接入 thinking relay

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6354,9 +6354,7 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 		setHeaderRaw(req.Header, "anthropic-version", "2023-06-01")
 	}
 	tkEnsureClaudeCodeSessionHeader(req.Header, body, c)
-	if strings.TrimSpace(baseURL) != "" {
-		setKiroInternalThinkingMirrorHopHeader(req.Header)
-	}
+	setKiroInternalThinkingMirrorHopHeaderForAccount(req.Header, account)
 
 	return req, body, nil
 }
@@ -7367,6 +7365,7 @@ func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Contex
 	}
 
 	tkEnsureClaudeCodeSessionHeader(req.Header, body, c)
+	setKiroInternalThinkingMirrorHopHeaderForAccount(req.Header, account)
 
 	// === DEBUG: 打印上游转发请求（headers + body 摘要），与 CLIENT_ORIGINAL 对比 ===
 	s.debugLogGatewaySnapshot("UPSTREAM_FORWARD", req.Header, body, map[string]string{
@@ -8655,6 +8654,7 @@ type streamingResult struct {
 func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, startTime time.Time, originalModel, mappedModel string, mimicClaudeCode bool) (*streamingResult, error) {
 	// 更新5h窗口状态
 	s.rateLimitService.UpdateSessionWindow(ctx, account, resp.Header)
+	applyKiroInternalThinkingFromUpstream(c, resp.Header)
 
 	if s.responseHeaderFilter != nil {
 		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
@@ -8964,6 +8964,10 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 				return &streamingResult{usage: usage, firstTokenMs: firstTokenMs}, fmt.Errorf("stream read error: %w", ev.err)
 			}
 			line := ev.line
+			if blocks, ok := parseKiroInternalThinkingSSECommentLine(line); ok {
+				applyKiroInternalThinkingBlocks(c, blocks)
+				continue
+			}
 			trimmed := strings.TrimSpace(line)
 
 			if trimmed == "" {
@@ -9282,6 +9286,7 @@ func (s *GatewayService) resolveCacheTTLUsageOverrideTarget(ctx context.Context,
 func (s *GatewayService) handleNonStreamingResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, originalModel, mappedModel string) (*ClaudeUsage, error) {
 	// 更新5h窗口状态
 	s.rateLimitService.UpdateSessionWindow(ctx, account, resp.Header)
+	applyKiroInternalThinkingFromUpstream(c, resp.Header)
 
 	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, anthropicTooLargeError)
 	if err != nil {
@@ -11012,6 +11017,7 @@ func (s *GatewayService) buildCountTokensRequestAnthropicAPIKeyPassthrough(
 	if req.Header.Get("anthropic-version") == "" {
 		req.Header.Set("anthropic-version", "2023-06-01")
 	}
+	setKiroInternalThinkingMirrorHopHeaderForAccount(req.Header, account)
 
 	return req, nil
 }
@@ -11154,6 +11160,7 @@ func (s *GatewayService) buildCountTokensRequest(ctx context.Context, c *gin.Con
 	}
 
 	tkEnsureClaudeCodeSessionHeader(req.Header, body, c)
+	setKiroInternalThinkingMirrorHopHeaderForAccount(req.Header, account)
 
 	if c != nil && tokenType == "oauth" {
 		c.Set(claudeMimicDebugInfoKey, buildClaudeMimicDebugLine(req, body, account, tokenType, mimicClaudeCode))

--- a/backend/internal/service/gateway_service_tk_kiro_mirror_hop_test.go
+++ b/backend/internal/service/gateway_service_tk_kiro_mirror_hop_test.go
@@ -1,0 +1,125 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetKiroInternalThinkingMirrorHopHeaderForAccount_ExplicitEdgeBaseURL(t *testing.T) {
+	hdr := http.Header{}
+	account := &Account{
+		Type: AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api-us6.tokenkey.dev",
+		},
+	}
+	setKiroInternalThinkingMirrorHopHeaderForAccount(hdr, account)
+	require.Equal(t, "1", hdr.Get(kiroInternalThinkingMirrorHopRequestHeader))
+}
+
+func TestSetKiroInternalThinkingMirrorHopHeaderForAccount_DefaultAnthropicHostOmitsRelay(t *testing.T) {
+	hdr := http.Header{}
+	account := &Account{
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key": "sk-test",
+		},
+	}
+	setKiroInternalThinkingMirrorHopHeaderForAccount(hdr, account)
+	require.Empty(t, hdr.Get(kiroInternalThinkingMirrorHopRequestHeader))
+}
+
+func TestBuildUpstreamRequest_MirrorStubSetsRelayHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	svc := &GatewayService{
+		cfg: &config.Config{
+			Security: config.SecurityConfig{
+				URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+			},
+		},
+	}
+	account := &Account{
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "edge-relay-key",
+			"base_url": "https://api-us6.tokenkey.dev",
+		},
+	}
+
+	req, _, err := svc.buildUpstreamRequest(
+		context.Background(), c, account,
+		[]byte(`{"model":"claude-sonnet-4-20250514","messages":[]}`),
+		"edge-relay-key", "apikey", "claude-sonnet-4-20250514", true, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "1", getHeaderRaw(req.Header, kiroInternalThinkingMirrorHopRequestHeader))
+}
+
+func TestGatewayService_HandleStreamingResponse_StripsKiroInternalThinkingSSEComment(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	svc := &GatewayService{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize},
+		},
+		rateLimitService: &RateLimitService{},
+	}
+
+	thinking := "prod mirror stub reasoning"
+	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromPlaintext(thinking))
+	commentLine := kiroInternalThinkingSSECommentPfx + payload
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`data: {"type":"message_start","message":{"usage":{"input_tokens":3}}}`,
+			"",
+			commentLine,
+			"",
+			`data: {"type":"message_stop"}`,
+			"",
+			"data: [DONE]",
+			"",
+		}, "\n"))),
+	}
+
+	result, err := svc.handleStreamingResponse(
+		context.Background(), resp, c, &Account{ID: 55},
+		time.Now(), "claude-sonnet-4-20250514", "claude-sonnet-4-20250514", false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	out := rec.Body.String()
+	require.NotContains(t, out, kiroInternalThinkingSSECommentPfx)
+	require.NotContains(t, out, thinking)
+
+	raw, ok := c.Get(kiroInternalThinkingGinKey)
+	require.True(t, ok)
+	blocks, ok := raw.([]string)
+	require.True(t, ok)
+	require.Len(t, blocks, 1)
+	require.Contains(t, blocks[0], thinking)
+}

--- a/backend/internal/service/kiro_internal_thinking_tk.go
+++ b/backend/internal/service/kiro_internal_thinking_tk.go
@@ -34,6 +34,19 @@ func setKiroInternalThinkingMirrorHopHeader(hdr http.Header) {
 	hdr.Set(kiroInternalThinkingMirrorHopRequestHeader, "1")
 }
 
+// setKiroInternalThinkingMirrorHopHeaderForAccount marks prod→edge mirror hops.
+// Only accounts with an explicit credentials.base_url (TokenKey edge relay stubs)
+// emit the header; default api.anthropic.com api-key accounts must not.
+func setKiroInternalThinkingMirrorHopHeaderForAccount(hdr http.Header, account *Account) {
+	if hdr == nil || account == nil || account.Type != AccountTypeAPIKey {
+		return
+	}
+	if strings.TrimSpace(account.GetCredential("base_url")) == "" {
+		return
+	}
+	setKiroInternalThinkingMirrorHopHeader(hdr)
+}
+
 // publishKiroInternalThinkingSideChannel stashes plaintext thinking for QA and,
 // only on prod→edge mirror hops, emits the wire side channel (SSE comment or
 // response header) that prod passthrough reads and strips before the end client.

--- a/backend/internal/service/kiro_internal_thinking_tk_test.go
+++ b/backend/internal/service/kiro_internal_thinking_tk_test.go
@@ -91,3 +91,15 @@ func TestPublishKiroInternalThinkingSideChannel_MirrorHopEmitsWire(t *testing.T)
 	require.Contains(t, rec.Body.String(), kiroInternalThinkingSSECommentPfx)
 	require.NotEmpty(t, rec.Header().Get(kiroInternalThinkingResponseHeader))
 }
+
+func TestSetKiroInternalThinkingMirrorHopHeaderForAccount_OAuthIgnored(t *testing.T) {
+	hdr := http.Header{}
+	account := &Account{
+		Type: AccountTypeOAuth,
+		Credentials: map[string]any{
+			"base_url": "https://api-us6.tokenkey.dev",
+		},
+	}
+	setKiroInternalThinkingMirrorHopHeaderForAccount(hdr, account)
+	require.Empty(t, hdr.Get(kiroInternalThinkingMirrorHopRequestHeader))
+}


### PR DESCRIPTION
## 摘要

- 修复 v1.8.64 / #1113 发版后 prod 镜像 QA 仍缺 `internal_thinking_blocks` 的问题。
- 根因：prod edge mirror stub（如 `cc-us6`）走常规 `buildUpstreamRequest` + `handleStreamingResponse`，未设置 `X-Tk-Internal-Thinking-Relay`，也未解析 Edge 回传的 SSE side channel；#1113 仅覆盖了 API-key passthrough 路径。
- 变更：镜像 stub（`credentials.base_url` 非空）出站补 relay header；标准 Forward 流式/非流式响应路径对称解析并 stash 明文 thinking 供 QA/traj export。

no-web-impact
sentinel-registry-reviewed

## 风险

- 仅影响带显式 `base_url` 的 api-key 镜像账号；直连 `api.anthropic.com` 账号不受影响。
- 客户端 wire 仍只见 `redacted_thinking`；side channel 在 prod passthrough 层剥离，不暴露给终端。

## 验证

- `go test -tags=unit ./internal/service -run 'KiroInternal|MirrorHop|MirrorStub|StripsKiro' -count=1` — 通过
- `./scripts/preflight.sh` — 通过（含 pre-commit / pre-push）
- 发版后 prod QA 手验：待合并部署后再跑 `ops/observability/probe-kiro-internal-thinking-qa.sh`

## 提交

- `8c1a53f82` fix(kiro): wire thinking relay on prod mirror Forward path

最新提交：8c1a53f82
