### PR TITLE
fix(studio): Grok legacy relay 视频、Veo 大体积预览与价目表竞态

### DIFF
--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -174,7 +174,8 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 	// Platform-aware video gate: the newapi/openai path requires a channel_type
 	// whose value maps to a new-api TaskAdaptor; grok (channel_type=0 native
 	// OAuth) qualifies via its native arm. See engine.IsVideoSupportedForAccount.
-	if !engine.IsVideoSupportedForAccount(account.Platform, account.ChannelType) {
+	if !engine.IsVideoSupportedForAccount(account.Platform, account.ChannelType) &&
+		!service.UsesGrokNativeVideoArm(account) {
 		// channel_type=0 non-grok (incomplete account) and channel_type with no
 		// task adaptor (e.g. plain OpenAI account asked to do video) collapse into
 		// the same user-facing error: this group is not configured for video.
@@ -217,6 +218,10 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 	// usage_logs row by request_id in every resolution branch (ctx-derived
 	// or generated).
 	billingRequestID := service.TkResolveUsageBillingRequestID(c.Request.Context())
+	platform := account.Platform
+	if service.UsesGrokNativeVideoArm(account) {
+		platform = service.PlatformGrok
+	}
 	rec := &service.VideoTaskRecord{
 		PublicTaskID:   publicTaskID,
 		UpstreamTaskID: outcome.UpstreamTaskID,
@@ -225,7 +230,7 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 		GroupID:        groupID,
 		APIKeyID:       apiKey.ID,
 		ChannelType:    account.ChannelType,
-		Platform:       account.Platform,
+		Platform:       platform,
 		// BaseURL + APIKey snapshot the upstream routing the bridge used at
 		// submit time. We persist the bridge's resolved values (not a fresh
 		// account read) because credentials may rotate before the user polls,

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go
@@ -59,7 +59,7 @@ func (s *OpenAIGatewayService) ForwardAsVideoSubmitDispatched(
 	// (POST api.x.ai/v1/videos/generations), NOT the new-api task-adaptor bridge —
 	// it is channel_type=0 native OAuth with no TaskAdaptor. Branch before the
 	// bridge-eligibility / channel_type gates below, which are the newapi path.
-	if account != nil && account.IsGrok() {
+	if account != nil && UsesGrokNativeVideoArm(account) {
 		return s.grokNativeVideoSubmit(ctx, c, account, publicTaskID, body)
 	}
 	if !s.ShouldDispatchToNewAPIBridge(account, BridgeEndpointVideoSubmit) {

--- a/backend/internal/service/openai_gateway_grok_video_tk.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk.go
@@ -44,7 +44,8 @@ import (
 // through the edge gateway (credentials.api_key + api-<edge>.tokenkey.dev).
 // Includes platform=grok,type=apikey stubs AND legacy platform=newapi,ct=1
 // bridge stubs still migrating to platform=grok — both must NOT enter the
-// new-api task-adaptor video path.
+// new-api task-adaptor video path. Other edge mirrors (kiro/openai/…) share the
+// same host pattern but are excluded via transport/mirror_platform guards.
 func isGrokVideoEdgeRelayStub(account *Account) bool {
 	if account == nil || account.Type != AccountTypeAPIKey {
 		return false
@@ -52,9 +53,16 @@ func isGrokVideoEdgeRelayStub(account *Account) bool {
 	if account.IsGrokAPIKey() {
 		return true
 	}
-	baseURL := strings.TrimSpace(account.GetCredential("base_url"))
-	apiKey := strings.TrimSpace(account.GetCredential("api_key"))
-	return baseURL != "" && apiKey != "" && edgeIDPattern.MatchString(baseURL)
+	if !isEdgeMirrorStub(account, edgeIDPattern) {
+		return false
+	}
+	if strings.TrimSpace(account.GetCredential("api_key")) == "" {
+		return false
+	}
+	if account.Platform == PlatformNewAPI && account.ChannelType == 1 {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(account.GetCredential("mirror_platform")), PlatformGrok)
 }
 
 // UsesGrokNativeVideoArm reports whether video submit/fetch should use the grok

--- a/backend/internal/service/openai_gateway_grok_video_tk.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk.go
@@ -40,6 +40,29 @@ import (
 // account 403s on /videos exactly as on chat. We surface that as a clean
 // honesty-403 (no failover, no penalty), reusing tkIsGrokEntitlement403.
 
+// isGrokVideoEdgeRelayStub reports a prod→edge mirror stub that relays grok video
+// through the edge gateway (credentials.api_key + api-<edge>.tokenkey.dev).
+// Includes platform=grok,type=apikey stubs AND legacy platform=newapi,ct=1
+// bridge stubs still migrating to platform=grok — both must NOT enter the
+// new-api task-adaptor video path.
+func isGrokVideoEdgeRelayStub(account *Account) bool {
+	if account == nil || account.Type != AccountTypeAPIKey {
+		return false
+	}
+	if account.IsGrokAPIKey() {
+		return true
+	}
+	baseURL := strings.TrimSpace(account.GetCredential("base_url"))
+	apiKey := strings.TrimSpace(account.GetCredential("api_key"))
+	return baseURL != "" && apiKey != "" && edgeIDPattern.MatchString(baseURL)
+}
+
+// UsesGrokNativeVideoArm reports whether video submit/fetch should use the grok
+// native xAI OAuth arm instead of the new-api task adaptor.
+func UsesGrokNativeVideoArm(account *Account) bool {
+	return account != nil && (account.IsGrok() || isGrokVideoEdgeRelayStub(account))
+}
+
 // resolveGrokVideoCredential returns the Bearer token and base URL for the grok
 // native video arm. OAuth accounts use xAI access_token; API-key relay stubs
 // (prod→edge mirror accounts) use the edge TokenKey api_key + base_url — the
@@ -52,17 +75,23 @@ func resolveGrokVideoCredential(account *Account) (token, baseURL string, err er
 	case account.IsGrokOAuth():
 		token = account.GetGrokAccessToken()
 		baseURL = account.GetGrokBaseURL()
-	case account.IsGrokAPIKey():
+	case account.IsGrokAPIKey(), isGrokVideoEdgeRelayStub(account):
 		token = account.GetOpenAIApiKey()
+		if token == "" {
+			token = strings.TrimSpace(account.GetCredential("api_key"))
+		}
 		baseURL = account.GetGrokBaseURL()
 		if baseURL == "" {
 			baseURL = account.GetOpenAIBaseURL()
+		}
+		if baseURL == "" {
+			baseURL = strings.TrimSpace(account.GetCredential("base_url"))
 		}
 	default:
 		return "", "", fmt.Errorf("grok account %d unsupported type for video", account.ID)
 	}
 	if token == "" {
-		if account.IsGrokAPIKey() {
+		if account.IsGrokAPIKey() || isGrokVideoEdgeRelayStub(account) {
 			return "", "", fmt.Errorf("grok relay account %d missing api_key", account.ID)
 		}
 		return "", "", fmt.Errorf("grok account %d missing access_token", account.ID)

--- a/backend/internal/service/openai_gateway_grok_video_tk_test.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk_test.go
@@ -49,6 +49,29 @@ func TestResolveGrokVideoCredential(t *testing.T) {
 		}
 	})
 
+	t.Run("legacy newapi edge relay stub uses api_key", func(t *testing.T) {
+		acct := &Account{
+			ID:          65,
+			Platform:    PlatformNewAPI,
+			Type:        AccountTypeAPIKey,
+			ChannelType: 1,
+			Credentials: map[string]any{
+				"api_key":  "grok-bridge-key",
+				"base_url": "https://api-us4.tokenkey.dev",
+			},
+		}
+		if !UsesGrokNativeVideoArm(acct) {
+			t.Fatal("legacy grok bridge stub must use grok native video arm")
+		}
+		token, base, err := resolveGrokVideoCredential(acct)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if token != "grok-bridge-key" || base != "https://api-us4.tokenkey.dev" {
+			t.Fatalf("got token=%q base=%q", token, base)
+		}
+	})
+
 	t.Run("oauth missing access_token", func(t *testing.T) {
 		acct := &Account{Platform: PlatformGrok, Type: AccountTypeOAuth}
 		_, _, err := resolveGrokVideoCredential(acct)

--- a/backend/internal/service/openai_gateway_grok_video_tk_test.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk_test.go
@@ -72,6 +72,22 @@ func TestResolveGrokVideoCredential(t *testing.T) {
 		}
 	})
 
+	t.Run("kiro anthropic edge mirror is not grok video relay", func(t *testing.T) {
+		acct := &Account{
+			ID:       8,
+			Platform: PlatformAnthropic,
+			Type:     AccountTypeAPIKey,
+			Credentials: map[string]any{
+				"api_key":         "kiro-edge-key",
+				"base_url":        "https://api-us4.tokenkey.dev",
+				"mirror_platform": "kiro",
+			},
+		}
+		if UsesGrokNativeVideoArm(acct) {
+			t.Fatal("kiro mirror stub must not route to grok native video arm")
+		}
+	})
+
 	t.Run("oauth missing access_token", func(t *testing.T) {
 		acct := &Account{Platform: PlatformGrok, Type: AccountTypeOAuth}
 		_, _, err := resolveGrokVideoCredential(acct)

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 543,
-  "hash": "278e1a1556cc51035c39c5e28025c571abd60832c934a05793ba6839f41481a1",
+  "hash": "8124e8e125cdd3719700edc4398d17ad81126c340af75d69fa737b81b34dc019",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 543,
-  "hash": "19c0c39251b8d55e507513be57877eeb242173a47a87059650a20fcf10af1a6a",
+  "hash": "278e1a1556cc51035c39c5e28025c571abd60832c934a05793ba6839f41481a1",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/composables/__tests__/useStudioVideoPreview.spec.ts
+++ b/frontend/src/composables/__tests__/useStudioVideoPreview.spec.ts
@@ -17,7 +17,13 @@ describe('useStudioVideoPreview', () => {
     vi.unstubAllGlobals()
   })
 
-  it('converts inline data:video to blob playback url', () => {
+  it('converts inline data:video to blob playback url', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        blob: async () => new Blob([new Uint8Array([1, 2, 3])], { type: 'video/mp4' }),
+      }))
+    )
     const preview = useStudioVideoPreview()
     preview.openPreview({
       url: 'data:video/mp4;base64,QUFB',
@@ -25,9 +31,41 @@ describe('useStudioVideoPreview', () => {
       cost: 4.8,
       taskId: 'vt_blob',
     })
+    await vi.waitFor(() => {
+      expect(preview.previewState.value).toBe('ready')
+    })
     expect(URL.createObjectURL).toHaveBeenCalled()
     expect(preview.previewUrl.value).toBe('blob:preview')
-    expect(preview.previewState.value).toBe('ready')
+  })
+
+  it('discards async playback when preview closes before decode finishes', async () => {
+    let resolveBlob: (value: Blob) => void = () => {}
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolve({
+              blob: () =>
+                new Promise<Blob>((r) => {
+                  resolveBlob = r
+                }),
+            } as Response)
+          })
+      )
+    )
+    const preview = useStudioVideoPreview()
+    preview.openPreview({
+      url: 'data:video/mp4;base64,QUFB',
+      label: 'Veo 3.1',
+      cost: 4.8,
+      taskId: 'vt_slow',
+    })
+    preview.closePreview()
+    resolveBlob(new Blob([new Uint8Array([1])], { type: 'video/mp4' }))
+    await Promise.resolve()
+    expect(preview.open.value).toBe(false)
+    expect(preview.previewUrl.value).toBe('')
   })
 
   it('marks lightbox expired after preview error without mutating library tasks', () => {

--- a/frontend/src/composables/useMediaLibrary.ts
+++ b/frontend/src/composables/useMediaLibrary.ts
@@ -305,9 +305,15 @@ export function useMediaLibrary(userId: number | string): MediaLibrary {
     const nextVideos = [...videoTasks.value]
     for (let i = 0; i < nextVideos.length; i++) {
       const t = nextVideos[i]
-      if (t.url || t.state !== 'succeeded') continue
+      if (t.state !== 'succeeded') continue
       const blobUrl = await getStudioBlobObjectUrl(userId, 'video', t.id)
       if (!blobUrl) continue
+      const shouldSwap =
+        !t.url?.trim() ||
+        t.url.startsWith('blob:') ||
+        /^data:video/i.test(t.url) ||
+        /^https?:\/\//i.test(t.url)
+      if (!shouldSwap) continue
       nextVideos[i] = { ...t, url: blobUrl, blobCached: true, urlExpired: false }
       videosChanged = true
     }

--- a/frontend/src/composables/useStudioVideoPreview.ts
+++ b/frontend/src/composables/useStudioVideoPreview.ts
@@ -1,7 +1,7 @@
 import { computed, onBeforeUnmount, ref } from 'vue'
 import { copyStudioVideoLink, downloadMedia } from '@/utils/studioDownload.tk'
 import { isInlineStudioVideoUrl } from '@/utils/studioInlineVideo.tk'
-import { videoPlaybackUrl } from '@/utils/studioMedia.tk'
+import { videoPlaybackUrl, videoPlaybackUrlAsync } from '@/utils/studioMedia.tk'
 
 export type StudioVideoPreviewState = 'loading' | 'ready' | 'expired'
 
@@ -69,10 +69,18 @@ export function useStudioVideoPreview(options: UseStudioVideoPreviewOptions = {}
     previewMediaReady.value = false
     copiedLink.value = false
 
-    const playback = videoPlaybackUrl(source.url)
-    previewRevoke = playback.revoke
-    previewUrl.value = playback.url
-    previewState.value = playback.url ? 'ready' : 'expired'
+    void (async () => {
+      const playback = previewInline.value
+        ? await videoPlaybackUrlAsync(source.url)
+        : videoPlaybackUrl(source.url)
+      if (!open.value || rawUrl.value !== source.url) {
+        playback.revoke()
+        return
+      }
+      previewRevoke = playback.revoke
+      previewUrl.value = playback.url
+      previewState.value = playback.url ? 'ready' : 'expired'
+    })()
   }
 
   function closePreview(): void {

--- a/frontend/src/constants/__tests__/playgroundMedia.tk.spec.ts
+++ b/frontend/src/constants/__tests__/playgroundMedia.tk.spec.ts
@@ -177,6 +177,7 @@ describe('video task helpers', () => {
     expect(videoStateFromFetch({ status: 'succeeded' })).toBe('succeeded')
     expect(videoStateFromFetch({ status: 'SUCCESS' })).toBe('succeeded')
     expect(videoStateFromFetch({ status: 'completed' })).toBe('succeeded')
+    expect(videoStateFromFetch({ status: 'done' })).toBe('succeeded')
     expect(videoStateFromFetch({ status: 'failed' })).toBe('failed')
     expect(videoStateFromFetch({ status: 'failure' })).toBe('failed')
     expect(videoStateFromFetch({ status: 'error' })).toBe('failed')

--- a/frontend/src/constants/playgroundMedia.tk.ts
+++ b/frontend/src/constants/playgroundMedia.tk.ts
@@ -244,7 +244,9 @@ export function videoStateFromFetch(resp: unknown): PlaygroundVideoState {
   }
   // String-status shape (volcengine/doubao + OpenAI-video "completed").
   const status = typeof root.status === 'string' ? root.status.toLowerCase() : ''
-  if (status === 'success' || status === 'succeeded' || status === 'completed') return 'succeeded'
+  if (status === 'success' || status === 'succeeded' || status === 'completed' || status === 'done') {
+    return 'succeeded'
+  }
   if (status === 'failure' || status === 'failed' || status === 'error') return 'failed'
   return 'processing'
 }

--- a/frontend/src/utils/__tests__/studioMedia.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioMedia.tk.spec.ts
@@ -5,6 +5,7 @@ import {
   imageHistoryItemAvailable,
   shouldShowStudioSaveReminder,
   videoPlaybackUrl,
+  videoPlaybackUrlAsync,
   videoTaskCardPresentation,
   videoTaskPlaybackAvailable,
   videoCopyLinkAvailable,
@@ -243,5 +244,19 @@ describe('videoPlaybackUrl', () => {
   it('falls back to the original src for a non-base64 data: URI', () => {
     const { url } = videoPlaybackUrl('data:video/mp4,notbase64')
     expect(url).toBe('data:video/mp4,notbase64')
+  })
+
+  it('videoPlaybackUrlAsync uses fetch for inline data:video', async () => {
+    const create = vi.fn(() => 'blob:async-veo')
+    urlStatic.createObjectURL = create
+    urlStatic.revokeObjectURL = vi.fn()
+    const fetchMock = vi.fn(async () => ({
+      blob: async () => new Blob([new Uint8Array([1, 2, 3])], { type: 'video/mp4' }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { url, revoke } = await videoPlaybackUrlAsync('data:video/mp4;base64,AAAA')
+    expect(fetchMock).toHaveBeenCalled()
+    expect(url).toBe('blob:async-veo')
+    revoke()
   })
 })

--- a/frontend/src/utils/studioMedia.tk.ts
+++ b/frontend/src/utils/studioMedia.tk.ts
@@ -172,3 +172,31 @@ export function videoPlaybackUrl(src: string): VideoPlayback {
     return { url: src, revoke: NOOP }
   }
 }
+
+/** Async variant: fetch() decodes large data:video URIs without blocking the main thread. */
+export async function videoPlaybackUrlAsync(src: string): Promise<VideoPlayback> {
+  if (!src) return { url: '', revoke: NOOP }
+  if (!/^data:video/i.test(src)) return { url: src, revoke: NOOP }
+  if (typeof fetch === 'function' && typeof URL?.createObjectURL === 'function') {
+    try {
+      const res = await fetch(src)
+      const blob = await res.blob()
+      if (blob.size > 0) {
+        const objectUrl = URL.createObjectURL(blob)
+        return {
+          url: objectUrl,
+          revoke: () => {
+            try {
+              URL.revokeObjectURL?.(objectUrl)
+            } catch {
+              /* ignore */
+            }
+          },
+        }
+      }
+    } catch {
+      /* fall through to sync decode */
+    }
+  }
+  return videoPlaybackUrl(src)
+}

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -473,6 +473,7 @@ const props = defineProps<{
   keyId: number | null
   keys: ApiKey[]
   rateMultiplier: number
+  catalogLoading?: boolean
 }>()
 const emit = defineEmits<{ (e: 'spent'): void }>()
 

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -25,7 +25,11 @@
         <p class="text-sm text-gray-500 dark:text-dark-400">{{ t('studio.bakeoff.hint') }}</p>
       </div>
 
-      <div v-if="models.length < 2" class="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400">
+      <div v-if="catalogLoading && models.length === 0" class="rounded-lg border border-dashed border-gray-300 bg-white/60 p-4 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400" data-testid="studio-bakeoff-catalog-loading">
+        {{ t('studio.loadingModels') }}
+      </div>
+
+      <div v-else-if="models.length < 2" class="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400">
         {{ t('studio.bakeoff.needTwo') }}
       </div>
 

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -2,7 +2,10 @@
   <div class="grid grid-cols-1 gap-5 lg:grid-cols-[360px_1fr]">
     <!-- LEFT: orchestration -->
     <div class="space-y-4">
-      <div v-if="models.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400">
+      <div v-if="catalogLoading && models.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400" data-testid="studio-image-model-loading">
+        {{ t('studio.loadingModels') }}
+      </div>
+      <div v-else-if="models.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400">
         {{ t('studio.image.modelEmpty') }}
         <router-link class="mt-1 block font-medium text-primary-600 underline dark:text-primary-400" to="/pricing">
           {{ t('studio.viewPricing') }}
@@ -280,6 +283,7 @@ const props = defineProps<{
   balance: number
   userId: number | string
   rateMultiplier: number
+  catalogLoading?: boolean
 }>()
 const emit = defineEmits<{ (e: 'spent'): void }>()
 

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -118,6 +118,7 @@
         :balance="balance"
         :user-id="userId"
         :rate-multiplier="1"
+        :catalog-loading="mediaCatalogLoading"
         @spent="refreshBalance"
       />
       <VideoStudio
@@ -132,6 +133,7 @@
         :keys="keys"
         :rate-multiplier="1"
         :any-key-serves-video="anyKeyServesVideo"
+        :catalog-loading="mediaCatalogLoading"
         @spent="refreshBalance"
       />
       <BakeOff
@@ -145,6 +147,7 @@
         :key-id="selectedKeyId"
         :keys="keys"
         :rate-multiplier="1"
+        :catalog-loading="mediaCatalogLoading"
         @spent="refreshBalance"
       />
     </div>
@@ -218,8 +221,12 @@ const catalogBillingIndex = ref<CatalogBillingIndex>(new Map())
 // single source of media prices (no hardcoding, so prices can't drift).
 const priceMap = ref<Map<string, MediaPrice>>(new Map())
 const modelsLoading = ref(false)
+/** False until loadPriceMap finishes for the current selectedKeyId (avoids media empty-state races). */
+const priceCatalogReady = ref(false)
 const probed = ref(false)
 const loadError = ref('')
+
+const mediaCatalogLoading = computed(() => modelsLoading.value || !priceCatalogReady.value)
 
 const selectedKey = computed(() => keys.value.find((k) => k.id === selectedKeyId.value))
 const apiKey = computed(() => selectedKey.value?.key || '')
@@ -388,20 +395,36 @@ async function loadPriceMap(keyId: number): Promise<void> {
   }
 }
 
+let priceCatalogGen = 0
+
+/** Serialize price-catalog loads; media tabs must not show the empty state while this is in flight. */
+async function ensurePriceCatalog(keyId: number): Promise<void> {
+  const gen = ++priceCatalogGen
+  const k = keys.value.find((x) => x.id === keyId)
+  const syncUniversal = !!(k && isUniversalKey(k) && universalPriceMap.value.size > 0)
+  if (!syncUniversal) priceCatalogReady.value = false
+  await loadPriceMap(keyId)
+  if (gen === priceCatalogGen) priceCatalogReady.value = true
+}
+
 // Re-pick when the modality tab changes: if the current key already serves the
 // new modality it is kept, otherwise we move to one that does (the dropdown
 // still lets the user override). Bake-off (null modality) keeps the current key.
-watch(view, () => {
+watch(view, async (v) => {
   if (!probed.value) return
   const m = pickerModality.value
   if (!m) return
   selectedKeyId.value = pickModalityKey(modalityOptions(), m, selectedKeyId.value, catalogBillingIndex.value)
+  if (v === 'image' || v === 'video') {
+    const id = selectedKeyId.value
+    if (id != null) await ensurePriceCatalog(id)
+  }
 })
 
 // Refetch the price catalog whenever the selected key changes (prices are
-// per-group). Bootstrap awaits the first load before mounting the studios.
+// per-group). Bootstrap awaits the first load before mounting media studios.
 watch(selectedKeyId, (id) => {
-  if (probed.value && id != null) void loadPriceMap(id)
+  if (probed.value && id != null) void ensurePriceCatalog(id)
 })
 
 async function bootstrap(): Promise<void> {
@@ -446,7 +469,7 @@ async function bootstrap(): Promise<void> {
       }
       selectedKeyId.value = pickModalityKey(modalityOptions(), 'chat', seed, catalogBillingIndex.value)
       probed.value = true
-      if (selectedKeyId.value != null) void loadPriceMap(selectedKeyId.value)
+      if (selectedKeyId.value != null) void ensurePriceCatalog(selectedKeyId.value)
       void (async () => {
         if (!hasUniversal) await loadUserEntitlement()
         await finishBackgroundProbe(reps, new Set([seedGk]))
@@ -477,8 +500,8 @@ async function bootstrap(): Promise<void> {
       } else {
         modelsLoading.value = false
       }
+      await ensurePriceCatalog(seed)
       probed.value = true
-      await loadPriceMap(seed)
       return
     }
 
@@ -496,8 +519,8 @@ async function bootstrap(): Promise<void> {
       return
     }
     selectedKeyId.value = picked
+    if (selectedKeyId.value != null) await ensurePriceCatalog(selectedKeyId.value)
     probed.value = true
-    if (selectedKeyId.value != null) await loadPriceMap(selectedKeyId.value)
     modelsLoading.value = false
   } catch (e) {
     loadError.value = e instanceof Error ? e.message : t('studio.loadFailed')

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -2,7 +2,10 @@
   <div class="grid grid-cols-1 gap-5 lg:grid-cols-[360px_1fr]">
     <!-- LEFT: orchestration -->
     <div class="space-y-4">
-      <div v-if="models.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400" data-testid="studio-video-model-empty">
+      <div v-if="catalogLoading && models.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400" data-testid="studio-video-model-loading">
+        {{ t('studio.loadingModels') }}
+      </div>
+      <div v-else-if="models.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400" data-testid="studio-video-model-empty">
         <p>{{ t('studio.video.modelEmpty') }}</p>
         <p v-if="anyKeyServesVideo" class="mt-2 font-medium text-amber-800 dark:text-amber-200">{{ t('studio.video.modelEmptySwitchKey') }}</p>
         <p v-else class="mt-2 text-xs text-gray-400 dark:text-dark-500">{{ t('studio.video.modelEmptyAllKeys') }}</p>
@@ -398,6 +401,8 @@ const props = defineProps<{
   rateMultiplier: number
   /** True when another key in the dropdown serves video (empty-state hint). */
   anyKeyServesVideo?: boolean
+  /** Parent is still resolving priced ∩ servable — suppress the empty-state footgun. */
+  catalogLoading?: boolean
 }>()
 const emit = defineEmits<{ (e: 'spent'): void }>()
 

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -515,3 +515,14 @@ describe('BakeOff image routing', () => {
     expect(panelText).toMatch(/cannot serve that model|不支持该模型|studio\.errors\.unsupported_model/)
   })
 })
+
+describe('BakeOff model catalog loading', () => {
+  it('shows loading instead of needTwo while catalogLoading', () => {
+    const wrapper = mount(BakeOff, {
+      props: { ...videoProps, catalogLoading: true, availableIds: new Set<string>() },
+      global: { plugins: [i18n], stubs: { RouterLink: true } },
+    })
+    expect(wrapper.find('[data-testid="studio-bakeoff-catalog-loading"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('studio.bakeoff.needTwo')
+  })
+})

--- a/frontend/src/views/user/studio/__tests__/MediaStudioView.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/MediaStudioView.spec.ts
@@ -1,7 +1,6 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
-import { ref } from 'vue'
 import en from '@/i18n/locales/en'
 import MediaStudioView from '../MediaStudioView.vue'
 
@@ -44,7 +43,7 @@ vi.mock('vue-router', () => ({
 
 vi.mock('@/stores/auth', () => ({
   useAuthStore: () => ({
-    user: ref({ id: 1, balance: 100 }),
+    user: { id: 1, balance: 100 },
     refreshUser: vi.fn(),
   }),
 }))
@@ -62,7 +61,16 @@ vi.mock('../ChatStudio.vue', () => ({
 }))
 
 vi.mock('../ImageStudio.vue', () => ({ default: { template: '<div />' } }))
-vi.mock('../VideoStudio.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('../VideoStudio.vue', () => ({
+  default: {
+    name: 'VideoStudio',
+    props: ['catalogLoading', 'priceMap', 'availableIds'],
+    template: `<div>
+      <div v-if="catalogLoading" data-testid="studio-video-catalog-loading">loading</div>
+      <div v-else data-testid="studio-video-catalog-ready">ready</div>
+    </div>`,
+  },
+}))
 vi.mock('../BakeOff.vue', () => ({ default: { template: '<div />' } }))
 
 const i18n = createI18n({
@@ -172,5 +180,56 @@ describe('MediaStudioView bootstrap', () => {
     expect(getPublicPricing).toHaveBeenCalled()
     expect(wrapper.text()).toContain('studio.universalKeyBadge')
     expect(getMePricingCatalog).not.toHaveBeenCalledWith(expect.objectContaining({ apiKeyId: 9 }))
+  })
+
+  it('shows video catalog loading until per-key prices resolve after switching from chat', async () => {
+    listKeys.mockResolvedValue({
+      items: [{ id: 1, name: 'trial', key: 'sk-test', group: { id: 10, name: 'g1' } }],
+    })
+    gatewayListModels.mockResolvedValue({ data: [{ id: 'veo-3.1-generate-001' }] })
+    getPublicPricing.mockResolvedValue({
+      data: [
+        {
+          model_id: 'veo-3.1-generate-001',
+          billing_mode: 'video',
+          pricing: { output_cost_per_second: 0.5 },
+        },
+      ],
+    })
+    let resolvePerKey!: (value: { models: { model_id: string; billing_mode: string; your_price: { currency: string; per_second: number } }[] }) => void
+    const perKeyPending = new Promise<{ models: { model_id: string; billing_mode: string; your_price: { currency: string; per_second: number } }[] }>(
+      (resolve) => {
+        resolvePerKey = resolve
+      }
+    )
+    getMePricingCatalog.mockImplementation((opts?: { apiKeyId?: number }) => {
+      if (opts?.apiKeyId != null) return perKeyPending
+      return Promise.resolve({ authorized_groups_by_model: {}, models: [] })
+    })
+
+    const wrapper = mount(MediaStudioView, {
+      global: { plugins: [i18n], stubs: { 'router-link': true } },
+    })
+
+    await flushPromises()
+    expect(wrapper.find('[data-testid="studio-chat-panel"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="studio-mode-video"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    const videoStudio = wrapper.findComponent({ name: 'VideoStudio' })
+    expect(videoStudio.exists()).toBe(true)
+    expect(videoStudio.props('catalogLoading')).toBe(true)
+
+    resolvePerKey({
+      models: [
+        {
+          model_id: 'veo-3.1-generate-001',
+          billing_mode: 'video',
+          your_price: { currency: 'USD', per_second: 0.5 },
+        },
+      ],
+    })
+    await flushPromises()
+    expect(videoStudio.props('catalogLoading')).toBe(false)
   })
 })

--- a/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/VideoStudio.spec.ts
@@ -217,3 +217,20 @@ describe('VideoStudio succeeded-task presentation', () => {
     expect(w.find('[data-testid="studio-video-copy-link"]').exists()).toBe(true)
   })
 })
+
+describe('VideoStudio model catalog loading', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    libraryMock.usePersistedLibrary = true
+    libraryMock.videoTasks.value = []
+  })
+
+  it('shows loading instead of the empty-state footgun while catalogLoading', () => {
+    const w = mount(VideoStudio as never, {
+      props: { ...baseProps, catalogLoading: true },
+      global: { plugins: [i18n], stubs: { 'router-link': true, teleport: true } },
+    })
+    expect(w.find('[data-testid="studio-video-model-loading"]').exists()).toBe(true)
+    expect(w.find('[data-testid="studio-video-model-empty"]').exists()).toBe(false)
+  })
+})

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -295,6 +295,7 @@
         "func (s *OpenAIGatewayService) grokNativeVideoSubmit",
         "func (s *OpenAIGatewayService) grokNativeVideoFetch",
         "resolveGrokVideoCredential",
+        "UsesGrokNativeVideoArm",
         "/videos/generations"
       ],
       "rationale": "The grok-native video arm: submit (POST api.x.ai/v1/videos/generations -> request_id) + poll (GET api.x.ai/v1/videos/{id}) over the grok OAuth Bearer OR prod→edge relay api_key (resolveGrokVideoCredential mirrors chat raw), returning the same bridge.TaskSubmitOutcome/VideoFetchOutcome shapes the handler consumes so the vt_ public id, VideoTaskCache record, balance hold, per-second billing, terminal refund, direct video delivery and ownership-404 are all reused. Video has no new-api TaskAdaptor for xAI (GetTaskAdaptor has no xai entry), so this native arm is grok video's ONLY code path — losing it makes grok video fail outright."
@@ -302,7 +303,7 @@
     {
       "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go",
       "must_contain": [
-        "account.IsGrok()",
+        "UsesGrokNativeVideoArm",
         "grokNativeVideoSubmit",
         "in.Platform == PlatformGrok",
         "grokNativeVideoFetch"


### PR DESCRIPTION
## 摘要

- **Grok Imagine · Video**：legacy prod→edge 镜像账号（`platform=newapi, channel_type=1` + `api-<edge>.tokenkey.dev`）走 grok native video arm；task record 保存 `Platform=grok`；relay 判定收紧为 `isEdgeMirrorStub` + ct=1 / `mirror_platform=grok`，避免 kiro 等同 host stub 误路由。
- **Veo 3.1 · Cinematic 本机预览**：大体积 `data:video;base64,...` 用 `videoPlaybackUrlAsync`（fetch→Blob→object URL）；Grok poll 识别 `status: done`。
- **Studio 价目表竞态**：Video/Image/BakeOff tab 在 catalog 加载完成前显示 loading，不再误报空模型或 `needTwo`。

sentinel-registry-reviewed

## 风险

- 公共 Web 行为：Studio 视频 tab / BakeOff loading 态、预览 async 解码路径。
- Grok 视频 dispatch 扩到 `UsesGrokNativeVideoArm()`；发版后需在 BakeOff 复验 Grok submit+poll。
- Veo 大 data URI 在 fetch 失败时仍回退同步解码，极端体积下可能仍失败。

## 验证

- `./scripts/preflight.sh` — PASS（含 merge main 后）
- `go test -tags=unit ./internal/service/... -run TestResolveGrokVideoCredential` — PASS
- `pnpm build` — dist hash 已同步（冲突已 rebuild 解决）
- 已 merge `origin/main`（#1120 edge-health、#1124 antigravity admin test SSOT）

发版后人工复验：BakeOff Grok 提交不再 502；Veo 生成后立即播放；首次进 `/studio` 切 Video tab 无空模型闪屏。

## 提交

- `9cd594c02` fix(studio): Grok legacy relay 视频、Veo 大体积预览与价目表竞态
- `80917d5ec` fix(studio): address xj-review R-001..R-003 on PR #1121
- `9d7254bf7` merge: origin/main into fix/studio-video-grok-veo-catalog

最新提交：9d7254bf7
