### PR TITLE
fix(gateway): 全能 key 未服务模型改 403，避免 routing 429 P0 风暴

### DIFF
--- a/backend/internal/service/universal_routing_tk_resolver.go
+++ b/backend/internal/service/universal_routing_tk_resolver.go
@@ -126,8 +126,14 @@ func (r *UniversalRoutingResolver) Resolve(ctx context.Context, apiKey *APIKey, 
 
 	// 模型服务真值收敛:把 eligible 收敛到“真正服务该模型”的组(见 universal_routing_tk_serving.go)。
 	// 仅当有模型名 + provider 已接线时执行;收敛后非空则用收敛集(deepseek/qwen/imagen/veo/
-	// seedance 等落到声明了该模型的对的组),否则退回原 eligible —— 安全兜底:provider 取数失败/
-	// 无组声明该模型时不比现状更严,继续按平台+hint 挑(gpt-image 这类无账号者仍会被下游诚实拒绝)。
+	// seedance 等落到声明了该模型的对的组)。
+	//
+	// 收敛为空且模型有平台 hint → ErrUniversalNoEntitledGroup(403),不再盲选错组后在下游
+	// 打成 routing-phase 429(P0 routing_capacity_rejection 风暴; prod 2026-07-01 user16
+	// universal key 245 压测 kimi-2.6 / deepseek-v3-2-251201 / claude@chat 等)。对齐
+	// docs/approved/universal-key-routing.md §4.3「模型不在任何被授权组 → 干脆报错」。
+	// hint 为空(未知 channel 模型)仍退回 eligible,由下游诚实拒绝 —— provider 未接线时整体
+	// 也保持旧平台级行为(见 TestResolve_NilProviderFallsBackToPlatformLevel)。
 	if model != "" {
 		if provider := r.providerSnapshot(); provider != nil {
 			served := make([]Group, 0, len(eligible))
@@ -138,6 +144,8 @@ func (r *UniversalRoutingResolver) Resolve(ctx context.Context, apiKey *APIKey, 
 			}
 			if len(served) > 0 {
 				eligible = served
+			} else if hint := universalModelPlatformHint(model); hint != "" {
+				return nil, ErrUniversalNoEntitledGroup
 			}
 		}
 	}

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -165,17 +165,31 @@ func TestResolve_NilProviderFallsBackToPlatformLevel(t *testing.T) {
 	}
 }
 
-// 安全兜底:无组声明该模型(served 全空)→ 不硬 403,退回 eligible 由下游裁决。
-func TestResolve_NoServingGroupFallsBackNotHard403(t *testing.T) {
+// 有平台 hint 但无组声明该模型 → 403(不盲选错组 → routing 429 P0 风暴)。
+func TestResolve_NoServingGroupWithHintReturnsNoEntitled(t *testing.T) {
 	ctx := context.Background()
 	span := []Group{grp(11, PlatformNewAPI, 10, false)}
 	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
 	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
-		11: {"deepseek-chat"}, // 不含 gpt-image
+		11: {"deepseek-chat"}, // 不含 kimi-2.6
+	}))
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIChat, "kimi-2.6", "")
+	if err != ErrUniversalNoEntitledGroup || g != nil {
+		t.Fatalf("kimi-2.6 无服务组应 ErrUniversalNoEntitledGroup, got=%v err=%v", g, err)
+	}
+}
+
+// hint 为空(未知 channel 模型)仍退回 eligible,由下游诚实拒绝。
+func TestResolve_NoServingGroupWithoutHintFallsBack(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{grp(11, PlatformNewAPI, 10, false)}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		11: {"deepseek-chat"},
 	}))
 	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIChat, "some-unmapped-model", "")
 	if err != nil || g == nil || g.ID != 11 {
-		t.Fatalf("无组声明该模型应退回 eligible(gid=11),由下游诚实拒绝;got=%v err=%v", g, err)
+		t.Fatalf("无 hint 的未知模型应退回 eligible(gid=11); got=%v err=%v", g, err)
 	}
 }
 
@@ -260,24 +274,39 @@ func TestResolve_MessagesDispatch_NewapiVendor_FilterIsLoadBearing(t *testing.T)
 	}
 }
 
-// count_tokens 候选恒为 [anthropic, antigravity],永不并入 openai-compat:即便模型是
-// deepseek(newapi)这类,count_tokens 也只在 anthropic/antigravity 组里挑,绝不落 newapi
-// 组(5/11/18)。在 user16 跨度里 → 唯一 count_tokens-eligible 组是 anthropic(1);服务真值
-// 过滤对它收敛为空,但安全兜底退回 eligible(不硬 403,由下游 anthropic count_tokens 处理器
-// 诚实拒绝 deepseek)。锁死「count_tokens 不被 dispatch 误导到 newapi」这条不变量。
+// count_tokens 候选恒为 [anthropic, antigravity],永不并入 openai-compat:deepseek 有 newapi
+// hint 且无组服务 → 403(不再盲落 anthropic 组后在下游打成 routing 429)。
 func TestResolve_CountTokensNeverDispatchesNewapi_User16(t *testing.T) {
 	ctx := context.Background()
 	r := NewUniversalRoutingResolver(&stubSpanLister{groups: user16Span()})
 	r.SetAvailableModelsProvider(user16ServingProvider())
 	g, err := r.Resolve(ctx, universalKey(16), ShapeAnthropicCountTokens, "deepseek-v4-flash", "")
-	if err != nil || g == nil {
-		t.Fatalf("count_tokens 应解析到 anthropic 组(安全兜底), got=%v err=%v", g, err)
+	if err != ErrUniversalNoEntitledGroup || g != nil {
+		t.Fatalf("count_tokens+deepseek 无 anthropic 服务组应 403, got=%v err=%v", g, err)
 	}
-	if g.Platform == PlatformNewAPI {
-		t.Fatalf("count_tokens 绝不应落 newapi 组(候选恒 [anthropic,antigravity]), got gid=%d platform=%s", g.ID, g.Platform)
+}
+
+// prod P0 2026-07-01:user16 universal key 245 压测未上架/未映射模型 → routing 429 风暴。
+func TestResolve_UniversalBenchmarkUnservedModels_User16(t *testing.T) {
+	ctx := context.Background()
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: user16Span()})
+	r.SetAvailableModelsProvider(user16ServingProvider())
+	key := universalKey(16)
+	cases := []struct {
+		shape UniversalShape
+		model string
+	}{
+		{ShapeOpenAIChat, "kimi-2.6"},
+		{ShapeOpenAIChat, "deepseek-v3-2-251201"},
+		{ShapeOpenAIChat, "glm-4-32b-0414-128k"},
+		{ShapeOpenAIChat, "claude-haiku-4-5"}, // anthropic hint, openai-compat 候选无 anthropic
+		{ShapeOpenAIChat, "gemini-pro-agent"},
 	}
-	if g.ID != 1 {
-		t.Fatalf("user16 跨度里 count_tokens 唯一 eligible 是 anthropic 组 gid=1, got gid=%d", g.ID)
+	for _, tc := range cases {
+		g, err := r.Resolve(ctx, key, tc.shape, tc.model, "")
+		if err != ErrUniversalNoEntitledGroup || g != nil {
+			t.Fatalf("model %q shape=%d should 403, got group=%v err=%v", tc.model, tc.shape, g, err)
+		}
 	}
 }
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3325,9 +3325,11 @@
         "var ErrUniversalNoEntitledGroup",
         "func pickUniversalBackingGroup(",
         "universalShapeRequiresImageGenerationEnabled",
-        "filterGroupsAllowImageGeneration"
+        "filterGroupsAllowImageGeneration",
+        "else if hint := universalModelPlatformHint(model); hint != \"\"",
+        "收敛为空且模型有平台 hint → ErrUniversalNoEntitledGroup(403)"
       ],
-      "rationale": "Universal Key (全能 Key) per-request resolver: maps a routing_mode=universal key to a concrete backing group from the owner's live entitlement span (GetAvailableGroups, short-TTL cached), filtered by endpoint-shape candidate platforms, with deterministic pick (subscription-held -> sort_order -> id). docs/approved/universal-key-routing.md. Dropping this file disables universal-key routing entirely (every universal key would fall through with a nil group). Pins the constructor, Resolve entrypoint, the no-entitled-group sentinel error, and the deterministic picker."
+      "rationale": "Universal Key (全能 Key) per-request resolver: maps a routing_mode=universal key to a concrete backing group from the owner's live entitlement span (GetAvailableGroups, short-TTL cached), filtered by endpoint-shape candidate platforms, with deterministic pick (subscription-held -> sort_order -> id). docs/approved/universal-key-routing.md §4.3. Dropping this file disables universal-key routing entirely (every universal key would fall through with a nil group). Pins the constructor, Resolve entrypoint, the no-entitled-group sentinel error, and the deterministic picker. Load-bearing P0 gate (prod 2026-07-01 user16 universal key #245): when groupServesModel filters eligible to empty AND the model has a platform hint, Resolve must return ErrUniversalNoEntitledGroup (middleware 403) — NOT fall back to a wrong openai-compat group and surface routing-phase 429 No available accounts (routing_capacity_rejection storm). An upstream merge that restores the old served-empty fallback silently re-opens the amplifier; the else-if hint branch is the mechanical anchor."
     },
     {
       "path": "backend/internal/service/universal_routing_tk_endpoint_map.go",


### PR DESCRIPTION
## 摘要

- prod P0 `routing_capacity_rejection_count`（2026-07-01 19:16 CST）根因：user #16 的 universal key #245（`benchmark组-赵欣宇`）压测 **当前授权组不服务的模型**（`kimi-2.6`、`deepseek-v3-2-251201`、`glm-*`、cross-vendor chat 上的 `claude-*`/`gemini-*`/`grok-*`）。
- 旧逻辑在「服务真值过滤」找不到组时仍 **盲选错组**，下游打成 `error_phase=routing` 429，1h 内单 key 刷出 7618 条 routing 拒绝。
- 修复：provider 已接线且模型有平台 hint、但无 eligible 组声明服务该模型时，直接 `ErrUniversalNoEntitledGroup` → middleware **403**，对齐 `docs/approved/universal-key-routing.md` §4.3。
- 补 `gateway-tk.json` sentinel 锚点，防止 upstream merge 静默回退 served-empty → blind-group fallback。

sentinel-registry-reviewed

no-web-impact

## 风险

- 常规风险 / Web 行为：仅改变 universal key 在「无组服务该模型」时的失败形态（429 routing → 403 invalid_request_error），direct key 路径不变。
- 行为变更：`claude-*` + `/v1/chat/completions` + 全能 Key 将 upfront 403（不再盲落 GPT 专线碰运气）；Claude 请走 `/v1/messages`。
- 发版前 benchmark 仍可能因 `gpt-5.6` 等 openai native 透传模型产生少量 downstream routing 429（本次 P0 主因已覆盖）。

## 验证

- `./scripts/preflight.sh` PASS
- `python3 scripts/sentinels/check-gateway-tk.py` PASS
- `go test -tags=unit ./internal/service/ -run 'TestResolve_|TestUniversal'`
- `go test -tags=unit ./internal/server/middleware/ -run 'Universal'`
- prod 只读探针：routing 拒绝 100% 归因 api_key_id=245；group 19 newapi 无 kimi/deepseek-v3-2/glm mapping

## 提交

- d8821d0bc fix(gateway): 全能 key 未服务模型改 403，避免 routing 429 P0 风暴
- d03d6c4a6 chore: Web impact: none — universal routing 403 gate only
- 878bb2df8 chore(sentinel): anchor universal served-empty hint 403 gate

最新提交：878bb2df8
