### PR TITLE
fix(pricing): newapi 长尾 manifest SSOT 对齐服务与价目表展示

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -464,11 +464,6 @@ func (s *BillingService) initFallbackPricing() {
 		CacheReadPricePerToken: 0.22e-6,
 		SupportsCacheBreakdown: false,
 	}
-	s.fallbackPrices["glm-4-32b-0414-128k"] = &ModelPricing{
-		InputPricePerToken:     0.1e-6, // $0.10 per MTok
-		OutputPricePerToken:    0.1e-6,
-		SupportsCacheBreakdown: false,
-	}
 	// GLM-4.5-Flash / GLM-4.7-Flash 在 z.ai 上为 Free，保留 zero-cost entry 防止未知 alias 误计费。
 	s.fallbackPrices["glm-4.5-flash"] = &ModelPricing{
 		InputPricePerToken:     0,
@@ -701,9 +696,6 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	}
 	if strings.Contains(modelLower, "glm-4.5") {
 		return s.fallbackPrices["glm-4.5"]
-	}
-	if strings.Contains(modelLower, "glm-4-32b") {
-		return s.fallbackPrices["glm-4-32b-0414-128k"]
 	}
 
 	// 月之暗面 Kimi（kimi-k2.6 / kimi-for-coding / kimi-k2.5 / kimi-k2-thinking / kimi-k2）

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -571,12 +571,6 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 			expectedOutput:    floatPtr(0),
 			expectedCacheRead: floatPtr(0),
 		},
-		{
-			name:           "glm 4-32b legacy",
-			model:          "glm-4-32b-0414-128k",
-			expectedInput:  0.1e-6,
-			expectedOutput: floatPtr(0.1e-6),
-		},
 		// 关键：5.2 / 5.1 必须先于 5 匹配（避免被 glm-5 抢走）
 		{
 			name:              "glm 5.2 vs glm 5 ordering",

--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -754,6 +754,12 @@ func (s *MePricingCatalogService) fillAccountFallback(
 			}
 		}
 	}
+	var newapiManifestAllow map[string]struct{}
+	if targetGroup.Platform == PlatformNewAPI {
+		if ids := loadTkServedModelsManifestIDs(); len(ids) > 0 {
+			newapiManifestAllow = ids
+		}
+	}
 	for i := range accounts {
 		a := &accounts[i]
 		if !accountInGroupScope(a, targetGroup.Platform) {
@@ -763,6 +769,11 @@ func (s *MePricingCatalogService) fillAccountFallback(
 			for _, modelID := range parseWhitelistFromCredentials(a.Credentials) {
 				if restrictedDisplayAllow != nil {
 					if _, ok := restrictedDisplayAllow[modelID]; !ok {
+						continue
+					}
+				}
+				if newapiManifestAllow != nil {
+					if _, ok := newapiManifestAllow[modelID]; !ok {
 						continue
 					}
 				}

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -910,10 +910,11 @@ func TestBuildForUser_AccountWhitelist_NewapiRequiresChannelType(t *testing.T) {
 	gNewapi := mkGroupForMe(50, "newapi-pro", "newapi", 1.0)
 	k1 := mkKeyForMe(1, 7, "newapi-key", ptrI(50))
 	bad := mkAccountWithWhitelist(11, "incomplete-newapi", "newapi", 0, []string{"gemini-2.5-pro"})
-	good := mkAccountWithWhitelist(12, "configured-newapi", "newapi", 31, []string{"qwen-3-max"})
+	good := mkAccountWithWhitelist(12, "configured-newapi", "newapi", 31, []string{"qwen-plus"})
 	catalog := &PublicCatalogResponse{
 		Data: []PublicCatalogModel{
 			mkPublicCatalogModel("gemini-2.5-pro", "Google", 0.00125, 0.005, 0),
+			mkPublicCatalogModel("qwen-plus", "Alibaba", 0.0012, 0.0024, 0),
 			mkPublicCatalogModel("qwen-3-max", "Alibaba", 0.0012, 0.0024, 0),
 		},
 	}
@@ -926,8 +927,8 @@ func TestBuildForUser_AccountWhitelist_NewapiRequiresChannelType(t *testing.T) {
 	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
 	require.NoError(t, err)
 	require.Len(t, resp.Models, 1, "channel_type=0 newapi account must be filtered out (no adaptor target)")
-	assert.Equal(t, "qwen-3-max", resp.Models[0].ModelID,
-		"only the channel_type>0 newapi account surfaces — matches scheduler IsOpenAICompatPoolMember")
+	assert.Equal(t, "qwen-plus", resp.Models[0].ModelID,
+		"only manifest-listed newapi whitelist models surface in Group Catalog")
 }
 
 // ----- platform-default fallback (unrestricted native OAuth accounts) -----

--- a/backend/internal/service/pricing_catalog_membership_tk.go
+++ b/backend/internal/service/pricing_catalog_membership_tk.go
@@ -70,9 +70,13 @@ func (s *PricingCatalogService) findCatalogModel(modelID string) (*PublicCatalog
 		return nil, false
 	}
 	for i := range resp.Data {
-		if resp.Data[i].ModelID == id {
-			return &resp.Data[i], true
+		if resp.Data[i].ModelID != id {
+			continue
 		}
+		if !isTkCuratedNewAPICatalogRowListed(resp.Data[i].Vendor, id) {
+			return nil, false
+		}
+		return &resp.Data[i], true
 	}
 	if tail, ok := stripVendorPrefixForCatalogLookup(id); ok {
 		allowPrefix := strings.Contains(tail, "-")
@@ -80,9 +84,15 @@ func (s *PricingCatalogService) findCatalogModel(modelID string) (*PublicCatalog
 		for i := range resp.Data {
 			mid := resp.Data[i].ModelID
 			if mid == tail {
+				if !isTkCuratedNewAPICatalogRowListed(resp.Data[i].Vendor, mid) {
+					continue
+				}
 				return &resp.Data[i], true
 			}
 			if allowPrefix && strings.HasPrefix(mid, prefix) {
+				if !isTkCuratedNewAPICatalogRowListed(resp.Data[i].Vendor, mid) {
+					continue
+				}
 				return &resp.Data[i], true
 			}
 		}

--- a/backend/internal/service/pricing_catalog_membership_tk_test.go
+++ b/backend/internal/service/pricing_catalog_membership_tk_test.go
@@ -149,3 +149,21 @@ func TestIsModelPriced_VendorPrefixDoesNotLeakAcrossFamilies(t *testing.T) {
 	require.False(t, svc.IsModelPriced("/gpt-4o-mini", "newapi"),
 		"empty vendor must not enable the fallback")
 }
+
+func TestIsModelPriced_RejectsUnlistedNewAPILongTail(t *testing.T) {
+	const fixture = `{
+	  "deepseek-v4-pro": {"input_cost_per_token":0.000000435,"output_cost_per_token":0.00000087,"litellm_provider":"deepseek"},
+	  "deepseek-v3-2-251201": {"input_cost_per_token":0.0,"output_cost_per_token":0.0,"litellm_provider":"volcengine"},
+	  "glm-4-32b-0414-128k": {"input_cost_per_token":0.0000001,"output_cost_per_token":0.0000001,"litellm_provider":"zhipu"}
+	}`
+	svc := &PricingCatalogService{}
+	svc.SetSourceForTesting(func() ([]byte, time.Time, bool) {
+		return []byte(fixture), time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), true
+	})
+
+	require.True(t, svc.IsModelPriced("deepseek-v4-pro", "newapi"))
+	require.False(t, svc.IsModelPriced("deepseek-v3-2-251201", "newapi"),
+		"litellm residue must not count as priced without manifest listing")
+	require.False(t, svc.IsModelPriced("glm-4-32b-0414-128k", "newapi"),
+		"withdrawn GLM SKU must not count as priced without manifest listing")
+}

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -206,6 +206,13 @@ var supportedGrokCatalogModels = map[string]struct{}{
 // vertex_ai-style provider strings map consistently with the availability
 // decoration path.
 func isPublicCatalogModelSupported(vendor, modelID string) bool {
+	// Fifth-platform newapi long-tail: only manifest-listed models may appear on
+	// /pricing. Unlisted newapi long-tail residue is excluded from BuildPublicCatalog
+	// overlay fill and from IsModelPriced membership; native platforms use their
+	// empirical allowlists below.
+	if isNewAPILongTailCatalogVendor(vendor) {
+		return isTkCuratedNewAPICatalogRowListed(vendor, modelID)
+	}
 	switch inferPlatformFromVendor(vendor) {
 	case PlatformAnthropic:
 		_, ok := supportedAnthropicCatalogModels[modelID]
@@ -246,8 +253,9 @@ func isPublicCatalogModelSupported(vendor, modelID string) bool {
 }
 
 // FilterPublicCatalogToServable returns a shallow copy of resp with the
-// claude + gpt rows narrowed to the empirically-servable allowlists; every
-// other vendor's rows pass through unchanged.
+// claude + gpt rows narrowed to the empirically-servable allowlists, the
+// newapi long-tail rows narrowed to tk_served_models.json, and every other
+// vendor's rows pass through unchanged.
 //
 // This is the PRESENTATION-layer filter for GET /api/v1/public/pricing ONLY.
 // It deliberately does NOT live inside BuildPublicCatalog / buildCatalogFromBytes,

--- a/backend/internal/service/pricing_catalog_tk.go
+++ b/backend/internal/service/pricing_catalog_tk.go
@@ -357,6 +357,9 @@ func applyCatalogOverlayPricing(resp *PublicCatalogResponse) {
 		if p == nil {
 			continue
 		}
+		if isNewAPILongTailCatalogVendor(p.LiteLLMProvider) && !isTkCuratedNewAPIModelListed(name) {
+			continue
+		}
 		isMedia := p.OutputCostPerImage > 0 || p.OutputCostPerSecond > 0
 		if p.InputCostPerToken == 0 && p.OutputCostPerToken == 0 && !isMedia {
 			continue

--- a/backend/internal/service/pricing_catalog_tk_test.go
+++ b/backend/internal/service/pricing_catalog_tk_test.go
@@ -236,14 +236,12 @@ func TestPricingCatalogService_AntigravityThinkingOverlaySurfaces(t *testing.T) 
 
 // TestPricingCatalogService_ZeroPlaceholderRowGetsOverlayPrice verifies the
 // display side of the absent-or-zero fill: a source row whose every price field
-// is 0.0 (litellm "cost unknown" — the prod shape of deepseek-v3-2-251201 under
-// volcengine) must show the overlay price in the public catalog, matching what
-// billing actually charges. Row metadata (context window) stays from the file
-// source.
+// is 0.0 (litellm "cost unknown") must show the overlay price for a manifest-
+// listed model, matching what billing actually charges.
 func TestPricingCatalogService_ZeroPlaceholderRowGetsOverlayPrice(t *testing.T) {
 	const fixture = `{
 	  "gpt-5.4": {"input_cost_per_token":0.0000005,"output_cost_per_token":0.000002,"litellm_provider":"openai"},
-	  "deepseek-v3-2-251201": {"input_cost_per_token":0.0,"output_cost_per_token":0.0,"litellm_provider":"volcengine","max_input_tokens":98304,"max_output_tokens":32768}
+	  "deepseek-v4-pro": {"input_cost_per_token":0.0,"output_cost_per_token":0.0,"litellm_provider":"deepseek","max_input_tokens":65536,"max_output_tokens":8192}
 	}`
 	s := &PricingCatalogService{}
 	s.SetSourceForTesting(func() ([]byte, time.Time, bool) {
@@ -257,20 +255,29 @@ func TestPricingCatalogService_ZeroPlaceholderRowGetsOverlayPrice(t *testing.T) 
 		byID[m.ModelID] = m
 	}
 
-	v32, ok := byID["deepseek-v3-2-251201"]
+	pro, ok := byID["deepseek-v4-pro"]
 	require.True(t, ok)
-	assert.InDelta(t, 2.0/6.7e3, v32.Pricing.InputPer1KTokens, 1e-12,
-		"zero placeholder row must display the overlay Ark price (¥2/M ÷ 6.7 × 1K)")
-	assert.InDelta(t, 3.0/6.7e3, v32.Pricing.OutputPer1KTokens, 1e-12)
-	assert.InDelta(t, 0.4/6.7e3, v32.Pricing.CacheReadPer1K, 1e-12)
-	assert.Equal(t, 98304, v32.ContextWindow, "file-source row metadata must be preserved")
-	assert.Equal(t, 32768, v32.MaxOutputTokens)
+	assert.InDelta(t, 0.000435, pro.Pricing.InputPer1KTokens, 1e-9,
+		"zero placeholder row must display the overlay deepseek-v4-pro price")
+	assert.InDelta(t, 0.00087, pro.Pricing.OutputPer1KTokens, 1e-9)
+	assert.InDelta(t, 0.000003625, pro.Pricing.CacheReadPer1K, 1e-12)
+	assert.Equal(t, 65536, pro.ContextWindow, "file-source row metadata must be preserved")
+	assert.Equal(t, 8192, pro.MaxOutputTokens)
+
+	filtered := FilterPublicCatalogToServable(resp)
+	require.NotNil(t, filtered)
+	for _, m := range filtered.Data {
+		if m.ModelID == "deepseek-v4-pro" {
+			return
+		}
+	}
+	t.Fatal("manifest-listed deepseek-v4-pro must remain on the public /pricing storefront")
 }
 
 // TestPublicCatalog_FiltersUnservableClaudeAndGpt covers the support filter
 // (pricing_catalog_supported_models_tk.go): retired/unservable claude + gpt
-// rows are pruned, servable ones kept, and every non-claude/gpt vendor passes
-// through untouched.
+// rows are pruned, servable ones kept, newapi long-tail rows require a
+// tk_served_models.json entry, and other vendors pass through unchanged.
 func TestPublicCatalog_FiltersUnservableClaudeAndGpt(t *testing.T) {
 	const fixture = `{
 	  "claude-opus-4-8":           {"input_cost_per_token":0.000005,"output_cost_per_token":0.000025,"litellm_provider":"anthropic"},
@@ -280,7 +287,9 @@ func TestPublicCatalog_FiltersUnservableClaudeAndGpt(t *testing.T) {
 	  "gpt-4o":                    {"input_cost_per_token":0.0000025,"output_cost_per_token":0.00001,"litellm_provider":"openai"},
 	  "gpt-3.5-turbo":             {"input_cost_per_token":0.0000005,"output_cost_per_token":0.0000015,"litellm_provider":"openai"},
 	  "gemini-2.5-pro":            {"input_cost_per_token":0.00000125,"output_cost_per_token":0.00001,"litellm_provider":"vertex_ai-language-models"},
-	  "deepseek-chat":             {"input_cost_per_token":0.0000003,"output_cost_per_token":0.0000011,"litellm_provider":"deepseek"}
+	  "deepseek-chat":             {"input_cost_per_token":0.0000003,"output_cost_per_token":0.0000011,"litellm_provider":"deepseek"},
+	  "deepseek-v3-2-251201":      {"input_cost_per_token":0.0000002,"output_cost_per_token":0.0000004,"litellm_provider":"volcengine"},
+	  "glm-4-32b-0414-128k":       {"input_cost_per_token":0.0000001,"output_cost_per_token":0.0000001,"litellm_provider":"zhipu"}
 	}`
 	s := &PricingCatalogService{}
 	s.SetSourceForTesting(func() ([]byte, time.Time, bool) {
@@ -308,7 +317,9 @@ func TestPublicCatalog_FiltersUnservableClaudeAndGpt(t *testing.T) {
 	assert.False(t, got["gpt-3.5-turbo"], "legacy gpt pruned")
 	// Other vendors untouched (filter only curates claude + gpt families).
 	assert.True(t, got["gemini-2.5-pro"], "gemini vendor passes through")
-	assert.True(t, got["deepseek-chat"], "non-curated vendor passes through")
+	assert.True(t, got["deepseek-chat"], "manifest-listed deepseek kept")
+	assert.False(t, got["deepseek-v3-2-251201"], "priced-but-unlisted volcengine residue pruned")
+	assert.False(t, got["glm-4-32b-0414-128k"], "withdrawn GLM SKU pruned from storefront")
 }
 
 func TestIsPublicCatalogModelSupported(t *testing.T) {
@@ -332,6 +343,9 @@ func TestIsPublicCatalogModelSupported(t *testing.T) {
 		{"azure_openai", "gpt-4", false},                      // azure_openai → openai platform, gated
 		{"vertex_ai-language-models", "gemini-2.5-pro", true}, // other vendor: pass-through
 		{"deepseek", "deepseek-chat", true},
+		{"volcengine", "deepseek-v3-2-251201", false},
+		{"zhipu", "glm-4-32b-0414-128k", false},
+		{"zhipu", "glm-5.2", true},
 		// antigravity (2026-06-13 empirical probe, refreshed 2026-06-23): gated to the gemini-only set.
 		{"antigravity", "gemini-2.5-flash", true},
 		{"antigravity", "gemini-2.5-flash-lite", true},

--- a/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
@@ -175,8 +175,11 @@ func TestCatalogInvalidateCache_PicksUpHotOverlay(t *testing.T) {
 	if has(cat.BuildPublicCatalog(context.Background())) {
 		t.Fatalf("setup: %s should not exist before hot-push", hot)
 	}
-	// Hot-push: add the model to the runtime union.
-	rebuildTKOverlayUnion([]byte(`{"` + hot + `":{"input_cost_per_token":3e-06,"output_cost_per_token":6e-06,"litellm_provider":"dashscope","mode":"chat"}}`))
+	// Hot-push: add the model to the runtime union. Use openai vendor so the
+	// newapi long-tail manifest gate (dashscope/alibaba/etc.) does not block this
+	// overlay-runtime regression — this test is about mtime cache + InvalidateCache,
+	// not manifest membership.
+	rebuildTKOverlayUnion([]byte(`{"` + hot + `":{"input_cost_per_token":3e-06,"output_cost_per_token":6e-06,"litellm_provider":"openai","mode":"chat"}}`))
 
 	// Same mtime → still cached, the trap: new model NOT visible.
 	if has(cat.BuildPublicCatalog(context.Background())) {

--- a/backend/internal/service/pricing_service_tk_overlay_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_test.go
@@ -122,16 +122,15 @@ func TestTKPricingOverlay_FillsGeminiProAgent(t *testing.T) {
 }
 
 // TestTKPricingOverlay_ZeroPlaceholderIsReplaced verifies the absent-or-zero fill:
-// a source entry whose every cost field is 0.0 (litellm's "cost unknown" shape —
-// the exact prod state of deepseek-v3-2-251201 under volcengine, which billed 683
-// requests at $0 through 2026-06-10) must NOT shadow the curated overlay price.
+// a source entry whose every cost field is 0.0 (litellm's "cost unknown" shape)
+// must NOT shadow a curated overlay price for a manifest-listed model.
 func TestTKPricingOverlay_ZeroPlaceholderIsReplaced(t *testing.T) {
 	svc := &PricingService{}
 	body := []byte(`{
-		"deepseek-v3-2-251201": {
+		"deepseek-v4-pro": {
 			"input_cost_per_token": 0.0,
 			"output_cost_per_token": 0.0,
-			"litellm_provider": "volcengine",
+			"litellm_provider": "deepseek",
 			"mode": "chat"
 		}
 	}`)
@@ -139,13 +138,12 @@ func TestTKPricingOverlay_ZeroPlaceholderIsReplaced(t *testing.T) {
 	data, err := svc.parsePricingData(body)
 	require.NoError(t, err)
 
-	v32 := data["deepseek-v3-2-251201"]
-	require.NotNil(t, v32)
-	// Ark official ¥/M ÷ CNY-USD 6.7 (in ¥2/M, out ¥3/M, cache-hit ¥0.4/M).
-	require.InDelta(t, 2.0/6.7e6, v32.InputCostPerToken, 1e-15,
-		"zero placeholder must be replaced by the overlay Ark price")
-	require.InDelta(t, 3.0/6.7e6, v32.OutputCostPerToken, 1e-15)
-	require.InDelta(t, 0.4/6.7e6, v32.CacheReadInputTokenCost, 1e-15)
+	pro := data["deepseek-v4-pro"]
+	require.NotNil(t, pro)
+	require.InDelta(t, 4.35e-7, pro.InputCostPerToken, 1e-15,
+		"zero placeholder must be replaced by the overlay deepseek-v4-pro price")
+	require.InDelta(t, 8.7e-7, pro.OutputCostPerToken, 1e-15)
+	require.InDelta(t, 3.625e-9, pro.CacheReadInputTokenCost, 1e-15)
 }
 
 // TestTKIsEffectivelyUnpriced pins the predicate: zero-everything (and nil) are

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -206,30 +206,6 @@
     "supports_prompt_caching": true,
     "source": "https://api-docs.deepseek.com/quick_start/pricing (2026-06-04: in $0.435/M cache-miss, $0.003625/M cache-hit, out $0.87/M)"
   },
-  "deepseek-v3-2-251201": {
-    "litellm_provider": "volcengine",
-    "mode": "chat",
-    "input_cost_per_token": 2.9850746268656716e-07,
-    "output_cost_per_token": 4.4776119402985074e-07,
-    "cache_read_input_token_cost": 5.970149253731344e-08,
-    "intervals": [
-      {
-        "min_tokens": 0,
-        "max_tokens": 32000,
-        "input_cost_per_token": 2.9850746268656716e-07,
-        "output_cost_per_token": 4.4776119402985074e-07,
-        "cache_read_input_token_cost": 5.970149253731344e-08
-      },
-      {
-        "min_tokens": 32000,
-        "max_tokens": null,
-        "input_cost_per_token": 5.970149253731343e-07,
-        "output_cost_per_token": 8.955223880597015e-07,
-        "cache_read_input_token_cost": 5.970149253731344e-08
-      }
-    ],
-    "source": "VolcEngine Ark official 在线推理(常规) (model-pricing page, captured 2026-06-11; CNY/USD=6.7; tiered by input tokens, USD=¥/M÷6.7). Whole-request input-tier via overlay intervals; per-tier cache-hit price."
-  },
   "imagen-3.0-capability-001": {
     "litellm_provider": "vertex_ai",
     "mode": "image_generation",
@@ -1247,13 +1223,6 @@
     "output_cost_per_token": 4.5e-06,
     "cache_read_input_token_cost": 2.2e-07,
     "source": "Z.AI official pricing (https://docs.z.ai/guides/overview/pricing, captured 2026-06-22; page last modified 2026-06-16): GLM-4.5-AirX input $1.10/Mtok, cached input $0.22/Mtok, output $4.50/Mtok. Cache storage is listed as limited-time free; no separate cache-write/storage price is modeled. Served through TokenKey newapi account 67 after tk_044 switches GLM from channel_type=16 to ZhipuV4 channel_type=26."
-  },
-  "glm-4-32b-0414-128k": {
-    "litellm_provider": "zhipu",
-    "mode": "chat",
-    "input_cost_per_token": 1e-07,
-    "output_cost_per_token": 1e-07,
-    "source": "Z.AI official pricing (https://docs.z.ai/guides/overview/pricing, captured 2026-06-22; page last modified 2026-06-16): GLM-4-32B-0414-128K input $0.10/Mtok, output $0.10/Mtok. The official table has no cached-input price for this row. Served through TokenKey newapi account 67 after tk_044 switches GLM from channel_type=16 to ZhipuV4 channel_type=26."
   },
   "gpt-5.6-sol": {
     "litellm_provider": "openai",

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "TokenKey served-models MANIFEST — the single declarative source of intent for 'TK serves model M on platform P via an account credentials.model_mapping whitelist, at price π, display=yes/no'. This is a THIN INTENT layer ABOVE the two existing mechanisms it must agree with: (1) per-account credentials.model_mapping (the runtime servable WHITELIST, set by tk_NNN_*_model_mapping*.sql migrations and admin-UI edits), and (2) tk_pricing_overlay.json + the runtime litellm mirror (the PRICE). It is NOT a replacement for either — its projections must AGREE with them, and scripts/checks/catalog-serving-drift.py asserts that agreement (drift guard). SCOPE: ONLY the TK-curated, account-model_mapping-served newapi long-tail — the qwen/deepseek chat families on their dedicated single-account groups, the GLM direct account 67 ZhipuV4 chat family, plus the volcengine account 7 Ark family (channel_type 45: doubao chat, seedream image, seedance video) that is explicitly mapped and priced. NOT the litellm catalog, NOT the four native-platform first-class catalogs (anthropic/openai/gemini/antigravity — those have Go servable-allowlist maps in pricing_catalog_supported_models_tk.go), NOT grok (native seventh platform served by platform routing + ch48, not by this manifest's newapi model_mapping intent). Consumers: drift guard (now), tokenkey-onboard-model skill (now), future newapi reconciler (//go:embed of THIS file). Co-located with tk_pricing_overlay.json so the same Go package can embed both and the same preflight can parse both.",
+  "_doc": "TokenKey served-models MANIFEST — the single declarative source of intent for 'TK serves model M on platform P via an account credentials.model_mapping whitelist, at price π, display=yes/no'. This is a THIN INTENT layer ABOVE the two existing mechanisms it must agree with: (1) per-account credentials.model_mapping (the runtime servable WHITELIST, set by tk_NNN_*_model_mapping*.sql migrations and admin-UI edits), and (2) tk_pricing_overlay.json + the runtime litellm mirror (the PRICE). It is NOT a replacement for either — its projections must AGREE with them, and scripts/checks/catalog-serving-drift.py asserts that agreement (drift guard). SCOPE: ONLY the TK-curated, account-model_mapping-served newapi long-tail — the qwen/deepseek chat families on their dedicated single-account groups, the GLM direct account 67 ZhipuV4 chat family, plus the volcengine account 7 Ark family (channel_type 45: doubao chat, seedream image, seedance video) that is explicitly mapped and priced. NOT the litellm catalog, NOT the four native-platform first-class catalogs (anthropic/openai/gemini/antigravity — those have Go servable-allowlist maps in pricing_catalog_supported_models_tk.go), NOT grok (native seventh platform served by platform routing + ch48, not by this manifest's newapi model_mapping intent). Consumers: drift guard (now), tokenkey-onboard-model skill (now), public /pricing + Group Catalog presentation filter (tk_served_models_manifest_tk.go), future newapi reconciler (//go:embed of THIS file). Co-located with tk_pricing_overlay.json so the same Go package can embed both and the same preflight can parse both.",
   "_schema": {
     "version": 1,
     "entry_key": "<platform>/<model_id>",
@@ -672,18 +672,6 @@
       "channel_type": 26,
       "price_source": "overlay",
       "price_key": "glm-4.5-airx",
-      "display": false,
-      "notes": "GLM account 67. Direct Z.AI / open.bigmodel.cn ZhipuV4 chat SKU, mapped by tk_044. Official paid price in overlay from docs.z.ai captured 2026-06-22."
-    },
-    "newapi/glm-4-32b-0414-128k": {
-      "platform": "newapi",
-      "model_id": "glm-4-32b-0414-128k",
-      "served_on": [
-        "67"
-      ],
-      "channel_type": 26,
-      "price_source": "overlay",
-      "price_key": "glm-4-32b-0414-128k",
       "display": false,
       "notes": "GLM account 67. Direct Z.AI / open.bigmodel.cn ZhipuV4 chat SKU, mapped by tk_044. Official paid price in overlay from docs.z.ai captured 2026-06-22."
     }

--- a/backend/internal/service/tk_served_models_manifest_tk.go
+++ b/backend/internal/service/tk_served_models_manifest_tk.go
@@ -1,0 +1,84 @@
+package service
+
+import (
+	_ "embed"
+	"encoding/json"
+	"sync"
+)
+
+// TokenKey: runtime loader for tk_served_models.json — the curated newapi
+// long-tail manifest. The drift guard (scripts/checks/catalog-serving-drift.py)
+// asserts this file agrees with overlay price + account model_mapping; the
+// public /pricing presentation filter and the per-user newapi Group Catalog
+// whitelist fallback consume the same embedded source so priced-but-unwired
+// models (deepseek-v3-2-251201) and withdrawn SKUs (glm-4-32b upstream 400)
+// cannot mislead the storefront.
+
+//go:embed tk_served_models.json
+var tkServedModelsManifestRaw []byte
+
+type tkServedModelsManifestFile struct {
+	Entries map[string]tkServedModelsManifestEntry `json:"entries"`
+}
+
+type tkServedModelsManifestEntry struct {
+	ModelID string `json:"model_id"`
+}
+
+var (
+	tkServedModelsManifestOnce sync.Once
+	tkServedModelsManifestIDs  map[string]struct{}
+)
+
+func loadTkServedModelsManifestIDs() map[string]struct{} {
+	tkServedModelsManifestOnce.Do(func() {
+		var doc tkServedModelsManifestFile
+		if err := json.Unmarshal(tkServedModelsManifestRaw, &doc); err != nil {
+			tkServedModelsManifestIDs = map[string]struct{}{}
+			return
+		}
+		out := make(map[string]struct{}, len(doc.Entries))
+		for _, e := range doc.Entries {
+			if e.ModelID == "" {
+				continue
+			}
+			out[e.ModelID] = struct{}{}
+		}
+		tkServedModelsManifestIDs = out
+	})
+	return tkServedModelsManifestIDs
+}
+
+// isTkCuratedNewAPIModelListed reports whether modelID is declared in the
+// served-models manifest (newapi long-tail only). Used by the /pricing
+// presentation filter and the newapi account whitelist menu fallback.
+func isTkCuratedNewAPIModelListed(modelID string) bool {
+	if modelID == "" {
+		return false
+	}
+	_, ok := loadTkServedModelsManifestIDs()[modelID]
+	return ok
+}
+
+// isTkCuratedNewAPICatalogRowListed is the shared SSOT gate for newapi long-tail
+// rows across /pricing display, IsModelPriced membership, and overlay fill.
+// Native platforms and unrelated vendors pass through unchanged.
+func isTkCuratedNewAPICatalogRowListed(vendor, modelID string) bool {
+	if !isNewAPILongTailCatalogVendor(vendor) {
+		return true
+	}
+	return isTkCuratedNewAPIModelListed(modelID)
+}
+
+// isNewAPILongTailCatalogVendor reports whether a catalog row's vendor string
+// belongs to the fifth-platform newapi curated long-tail (qwen/deepseek/GLM/
+// VolcEngine Ark), as opposed to the four native platforms + grok which carry
+// their own servable allowlists.
+func isNewAPILongTailCatalogVendor(vendor string) bool {
+	switch vendor {
+	case "newapi", "volcengine", "deepseek", "dashscope", "alibaba", "zhipu", "bigmodel", "zai":
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/service/tk_served_models_manifest_tk_test.go
+++ b/backend/internal/service/tk_served_models_manifest_tk_test.go
@@ -1,0 +1,26 @@
+package service
+
+import "testing"
+
+func TestIsTkCuratedNewAPIModelListed(t *testing.T) {
+	if !isTkCuratedNewAPIModelListed("deepseek-chat") {
+		t.Fatal("deepseek-chat must be manifest-listed")
+	}
+	if isTkCuratedNewAPIModelListed("deepseek-v3-2-251201") {
+		t.Fatal("deepseek-v3-2-251201 must not be manifest-listed")
+	}
+	if isTkCuratedNewAPIModelListed("glm-4-32b-0414-128k") {
+		t.Fatal("glm-4-32b-0414-128k must not be manifest-listed after upstream 400 withdrawal")
+	}
+}
+
+func TestIsNewAPILongTailCatalogVendor(t *testing.T) {
+	for _, v := range []string{"volcengine", "deepseek", "dashscope", "zhipu", "newapi"} {
+		if !isNewAPILongTailCatalogVendor(v) {
+			t.Fatalf("vendor %q must be newapi long-tail", v)
+		}
+	}
+	if isNewAPILongTailCatalogVendor("anthropic") {
+		t.Fatal("anthropic must not be newapi long-tail")
+	}
+}

--- a/backend/migrations/tk_044_glm_direct_zhipuv4_model_mapping.sql
+++ b/backend/migrations/tk_044_glm_direct_zhipuv4_model_mapping.sql
@@ -26,8 +26,7 @@ WITH upd AS (
                 "glm-4.5": "glm-4.5",
                 "glm-4.5-x": "glm-4.5-x",
                 "glm-4.5-air": "glm-4.5-air",
-                "glm-4.5-airx": "glm-4.5-airx",
-                "glm-4-32b-0414-128k": "glm-4-32b-0414-128k"
+                "glm-4.5-airx": "glm-4.5-airx"
             }'::jsonb,
             true
         ),

--- a/backend/migrations/tk_054_prune_unservable_newapi_skus.sql
+++ b/backend/migrations/tk_054_prune_unservable_newapi_skus.sql
@@ -1,0 +1,30 @@
+-- TokenKey: align account model_mapping with tk_served_models.json SSOT.
+--
+-- glm-4-32b-0414-128k was removed from the served-models manifest after prod
+-- livefire returned upstream 400 model_not_found on account 67 (ZhipuV4).
+-- Keeping the id in credentials.model_mapping advertised a model the gateway
+-- could route but not serve — the same class of drift catalog-serving-drift.py
+-- guards against (#812).
+--
+-- Idempotent: re-running is a no-op when the key is already absent.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH upd AS (
+    UPDATE accounts
+    SET credentials = jsonb_set(
+            credentials,
+            '{model_mapping}',
+            COALESCE(credentials -> 'model_mapping', '{}'::jsonb) - 'glm-4-32b-0414-128k',
+            true
+        ),
+        updated_at = NOW()
+    WHERE id = 67
+      AND platform = 'newapi'
+      AND deleted_at IS NULL
+      AND credentials -> 'model_mapping' ? 'glm-4-32b-0414-128k'
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;

--- a/docs/all-platform-model-inventory.md
+++ b/docs/all-platform-model-inventory.md
@@ -49,7 +49,7 @@ ADVERTISED（在某平台 DefaultModels → 喂 /v1/models 与「我的菜单」
 | 2 | `openai` | OpenAI / Codex OAuth | 原生；GPT 专线 key | Go `supportedOpenAICatalogModels`（硬闸）|
 | 3 | `gemini` | Google Vertex AI | 原生；media 经 Vertex ch41 | Go `supportedGeminiCatalogModels`（空则透传）|
 | 4 | `antigravity` | Google cloudcode-pa OAuth | 原生中继；**仅服务 gemini**（claude 路由到 anthropic，gpt-oss 排除）| Go `supportedAntigravityCatalogModels`（空则透传）|
-| 5 | `newapi` | 各 channel 上游（Ali/DeepSeek/VolcEngine/…）| OpenAI 兼容网关 + new-api 适配器（`channel_type>0`）| 账号 `credentials.model_mapping` 白名单 + `tk_served_models.json` 清单（**无 Go map**，靠价格存在透传）|
+| 5 | `newapi` | 各 channel 上游（Ali/DeepSeek/VolcEngine/…）| OpenAI 兼容网关 + new-api 适配器（`channel_type>0`）| 账号 `credentials.model_mapping` 白名单 + `tk_served_models.json` 清单（**展示/IsModelPriced 均 manifest 硬闸**）|
 | 6 | `kiro` | AWS CodeWhisperer | prod→edge anthropic apikey 中继；镜像进 claude 组 | 中继 claude id（无自有目录）|
 | 7 | `grok` | xAI（SuperGrok Heavy OAuth）| 原生 OAuth 中继；chat/image/video 全臂 | Go `supportedGrokCatalogModels`（空则透传）|
 
@@ -57,7 +57,7 @@ ADVERTISED（在某平台 DefaultModels → 喂 /v1/models 与「我的菜单」
 
 - **SERVABLE**：网关能真拿到 200。判定方式按平台不同：原生显示平台是 Go 硬 allowlist；newapi 是 per-account `model_mapping` identity 白名单（空 mapping = 该账号 catch-all 放行全渠道）；kiro 与 grok 原生臂是纯透传中继。
 - **PRICED**：在 litellm 运行时镜像或 `tk_pricing_overlay.json` 有非零价。`price_source ∈ {overlay, mirror, channel, none}`。`none` = 计 `$0`（chat 会 P0 告警；media 会被 400 守卫拦下）。
-- **DISPLAYED**：是否进 `GET /api/v1/public/pricing`，由 `isPublicCatalogModelSupported` 决定（`pricing_catalog_supported_models_tk.go`）。
+- **DISPLAYED**：是否进 `GET /api/v1/public/pricing` 与 `IsModelPriced` 会员资格，由 `isPublicCatalogModelSupported` / `isTkCuratedNewAPICatalogRowListed` 决定（native 平台用 Go allowlist；newapi 用 manifest）。
 - **ADVERTISED**：是否在某平台 `DefaultModels`（喂网关 `/v1/models` 与「我的菜单」）。**与可服务正交**——可服务未必广告（如 `claude-opus-4-1`），广告未必可服务（`advertised_dead`）。
 
 ### 1.3 公开目录闸门逻辑（`isPublicCatalogModelSupported`）
@@ -65,7 +65,7 @@ ADVERTISED（在某平台 DefaultModels → 喂 /v1/models 与「我的菜单」
 ```
 anthropic / openai → 硬闸：只放 allowlist 内的 id（map 永不为空）
 gemini / antigravity / grok → 软闸：map 为空时透传（不收窄，零回归）；非空则像 claude/gpt 一样收窄
-newapi（dashscope/deepseek/volcengine vendor）→ inferPlatformFromVendor 不识别 → default-true 透传，靠「价格存在」隐式收窄
+newapi long-tail（dashscope / deepseek / volcengine / zhipu vendor）→ **manifest 硬闸**：只放 `tk_served_models.json` 内的 id；runtime servable 白名单 = 账号 `model_mapping`（必须与 manifest 一致，`catalog-serving-drift.py` A3）
 ```
 
 > 推论：**`DefaultModels`（/v1/models 来源）与 /pricing storefront 用的是两套闸**——前者按 `IsModelPriced`（全镜像），后者按 servable-allowlist。两者不一致正是 `advertised_dead` 类缺口的根因。
@@ -189,7 +189,7 @@ overlay `litellm_provider="volcengine"` 共 28 条；`tk_served_models.json` 当
 | image | `doubao-seedream-4-0-250828`（no-prefix `seedream-4-0-250828` 只是 parity 计费键，不进 manifest）|
 | video | `doubao-seedance-1-0-pro-250528`、`doubao-seedance-1-5-pro-251215`、`doubao-seedance-2-0-260128`、`doubao-seedance-2-0-fast-260128`（no-prefix `seedance-1-0-pro-*` 只是 parity 计费键）；`failure_billing=success_only` |
 
-> `deepseek-v3-2-251201` 在 overlay 标 volcengine 但 **tk_020 故意不在账号 7 服务**（VolcEngine 自报价 ~4× 官方 DeepSeek 价）；其 servable 家在 DeepSeek 直连（账号 39）。volcengine 标签价是无害残留。`doubao-seed-translation-250915` 虽在 tk_020 mapping 与 overlay 中，但 2026-06-23 两次 direct Ark `/api/v3/chat/completions` 复测均为 400 inconclusive，本轮不进 manifest/正面清单。
+> `deepseek-v3-2-251201` 曾出现在 litellm mirror / overlay，但 **tk_020 故意不在账号 7 服务**（VolcEngine 自报价 ~4× 官方 DeepSeek 价），也 **不在 manifest**；2026-07-01 已从 overlay 移除以对齐 SSOT（定价=服务=展示均以 manifest 为准）。其 servable 家应在 DeepSeek 直连（账号 39），待正式 onboarding 后再进 manifest。
 
 - 媒体类的 `servable_unpriced` 风险全被 **media 400 守卫**收口为干净报错，无资损。
 - 故意排除的上游媒体变体（`seedream-4.5/5.0(-lite)`、`seedance-1.0-pro-fast`、`seedance-1.0-lite`）见 §4/§5。
@@ -202,10 +202,11 @@ tk_044 把 GLM 从 legacy ct16 Zhipu v3 迁到 ct26 ZhipuV4/OpenAI-compatible，
 glm-5.2  glm-5.1  glm-5  glm-5-turbo
 glm-4.7  glm-4.7-flashx  glm-4.6
 glm-4.5  glm-4.5-x  glm-4.5-air  glm-4.5-airx
-glm-4-32b-0414-128k
 ```
 
-free SKU `glm-4.7-flash` / `glm-4.5-flash` 刻意不进 `model_mapping` / overlay 公开目录，避免可见 `$0` 模型。prod canary 已于 2026-06-22 完成：runtime overlay 热推后，account 67 切到 ct26、`base_url=https://open.bigmodel.cn`、12 个 paid mapping；`ZHIPU_CHAT_MODELS=glm-4.7` 经 prod 网关返回 `200 servable`，`usage_logs` 落 account 67 / group 26 且 `total_cost=0.0004964000` 非零。
+`glm-4-32b-0414-128k` 已于 2026-07-01 从 manifest / overlay / account 67 mapping 移除：prod 上游 400 model_not_found，不再服务也不再展示。
+
+free SKU `glm-4.7-flash` / `glm-4.5-flash` 刻意不进 `model_mapping` / overlay 公开目录，避免可见 `$0` 模型。prod canary 已于 2026-06-22 完成：runtime overlay 热推后，account 67 切到 ct26、`base_url=https://open.bigmodel.cn`、11 个 paid mapping；`ZHIPU_CHAT_MODELS=glm-4.7` 经 prod 网关返回 `200 servable`，`usage_logs` 落 account 67 / group 26 且 `total_cost=0.0004964000` 非零。
 
 ### 2.7 kiro（第六平台，CodeWhisperer 中继）
 
@@ -227,7 +228,7 @@ free SKU `glm-4.7-flash` / `glm-4.5-flash` 刻意不进 `model_mapping` / overla
 | `advertised_dead` | openai | `gpt-5.2` `gpt-5.3-codex` `gpt-image-{1,1.5,2}` | 已收敛 | `codex-auto-review` 实测 200 后加入；其余死项不再进默认可见面 |
 | `advertised_dead` | gemini | `gemini-2.0-flash`（含 admin 测试默认）`gemini-3.x` chat | 中 | 复测；用 servable-allowlist 闸 DefaultModels |
 | `channel_not_onboarded` | openai/gemini/newapi | ct1/57、ct24/41、Moonshot/MiniMax/Zhipu… | 中 | 见 §5 backlog |
-| `priced_not_displayed` | gemini/antigravity/volcengine | imagen-3.0/veo 变体、gemini-3.1-pro-low、deepseek-v3-2 | 低 | Gemini media 2026-06-23 复测 429，留 watchlist；deepseek-v3-2 是 VolcEngine 价残留，账号 7 不服务 |
+| `priced_not_displayed` | gemini/antigravity/volcengine | imagen-3.0/veo 变体、gemini-3.1-pro-low | 低 | Gemini media 2026-06-23 复测 429，留 watchlist |
 | `priced_mapped_not_proven_served` | newapi(volcengine) | `doubao-seed-translation-250915` | 中 | tk_020 mapping + overlay 已有，但 2026-06-23 direct Ark 两次 400 inconclusive；不进 manifest，留 watchlist |
 | `priced_not_served` | newapi(qwen) | qwen2.5-coder-* | 中 | 抑制 parity 行的展示，或在账号 60 真 mapping；qwen3.7-max preview/dated 已由 2026-06-23 prod mapping + livefire 证实可服务 |
 | `dated_dup` | anthropic/grok/volcengine | claude bare↔dated、grok-imagine-image-pro、no-prefix seedream/seedance | 低 | anthropic 已由 override 机制处理；其余被 media 守卫/上游 404 收口 |

--- a/scripts/checks/catalog-serving-drift.py
+++ b/scripts/checks/catalog-serving-drift.py
@@ -66,7 +66,7 @@ MODE_FIELDS = {
 ALLOWLIST_PLATFORMS = ("anthropic", "openai", "gemini", "antigravity")
 
 # A4 advisory: overlay vendors whose chat models are the manifest's curated long-tail.
-ENUMERATION_PROVIDERS = {"dashscope", "deepseek"}
+ENUMERATION_PROVIDERS = {"dashscope", "deepseek", "volcengine", "zhipu", "bigmodel", "zai"}
 
 # Recognized literal escape hatch in an entry's notes (A3 migration-scan opt-out).
 ADMIN_UI_OPT_OUT = "served-via-admin-ui"

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -263,6 +263,7 @@
       "must_contain": [
         "MePricingAccountSource",
         "fillAccountFallback",
+        "newapiManifestAllow",
         "parseWhitelistFromCredentials",
         "buildAccountFallbackEntry"
       ],

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -68,6 +68,7 @@
       "must_contain": [
         "func isPublicCatalogModelSupported(",
         "func FilterPublicCatalogToServable(",
+        "isNewAPILongTailCatalogVendor(",
         "func supportedCatalogModelIDsForPlatform(",
         "supportedAnthropicCatalogModels",
         "supportedOpenAICatalogModels",
@@ -80,7 +81,16 @@
         "servable-allowlist:begin antigravity",
         "servable-allowlist:begin grok"
       ],
-      "rationale": "Single source for the empirically-servable claude + gpt sets, shared by the public /pricing presentation filter (FilterPublicCatalogToServable) and the Your-Menu unrestricted-account fallback (supportedCatalogModelIDsForPlatform). Losing the allowlist vars would silently widen both surfaces back to the full unservable set; losing the funcs breaks both call sites. The `servable-allowlist:begin/end` splice markers are load-bearing for ops/pricing/refresh-servable-allowlist.py (it rewrites the maps between them); an upstream merge that drops the markers would break the re-runnable refresh. The antigravity allowlist (supportedAntigravityCatalogModels, gemini-only per operator policy — claude routed to anthropic, gpt-oss off antigravity) is hand-maintained from the 2026-06-13 empirical probe (the refresh tool has no antigravity family, so it never rewrites the antigravity anchors); losing it silently reverts antigravity to passthrough. The grok allowlist (supportedGrokCatalogModels: priced grok-imagine media + official-priced grok chat ids that returned 200 on the native grok edge probe) is likewise hand-maintained; losing it silently empties a grok group's 分组目录 again (2026-06-20 incident). Other vendors (deepseek, …) intentionally pass through — claude + gpt + antigravity-gemini + grok are curated."
+      "rationale": "Single source for the empirically-servable claude + gpt sets, shared by the public /pricing presentation filter (FilterPublicCatalogToServable) and the Your-Menu unrestricted-account fallback (supportedCatalogModelIDsForPlatform). Losing the allowlist vars would silently widen both surfaces back to the full unservable set; losing the funcs breaks both call sites. The `servable-allowlist:begin/end` splice markers are load-bearing for ops/pricing/refresh-servable-allowlist.py (it rewrites the maps between them); an upstream merge that drops the markers would break the re-runnable refresh. The antigravity allowlist (supportedAntigravityCatalogModels, gemini-only per operator policy — claude routed to anthropic, gpt-oss off antigravity) is hand-maintained from the 2026-06-13 empirical probe (the refresh tool has no antigravity family, so it never rewrites the antigravity anchors); losing it silently reverts antigravity to passthrough. The grok allowlist (supportedGrokCatalogModels: priced grok-imagine media + official-priced grok chat ids that returned 200 on the native grok edge probe) is likewise hand-maintained; losing it silently empties a grok group's 分组目录 again (2026-06-20 incident). Fifth-platform newapi long-tail vendors are gated separately via tk_served_models_manifest_tk.go."
+    },
+    {
+      "path": "backend/internal/service/tk_served_models_manifest_tk.go",
+      "must_contain": [
+        "//go:embed tk_served_models.json",
+        "func isTkCuratedNewAPIModelListed(",
+        "func isNewAPILongTailCatalogVendor("
+      ],
+      "rationale": "Runtime embed of tk_served_models.json — gates public /pricing and newapi Group Catalog whitelist rows to manifest-listed models only. Without it, priced overlay residue (deepseek-v3-2-251201) and withdrawn SKUs reappear on the storefront and mislead users into 400/429 requests."
     },
     {
       "path": "backend/internal/service/pricing_catalog_candidates_tk.go",


### PR DESCRIPTION
## 摘要

- 以 `tk_served_models.json` 为 newapi 长尾单一事实来源：新增 manifest 闸，统一 `/pricing`、分组目录与 `IsModelPriced` 展示逻辑。
- 移除 prod 不可服务 SKU：`glm-4-32b-0414-128k`（账号 67 上游 400）、`deepseek-v3-2-251201`（从未 onboarding）；同步清理 overlay、billing fallback、tk_044 seed。
- 新增 `tk_054` 迁移：prod 账号 67 删除 `glm-4-32b-0414-128k` mapping key。

Web impact: none
high-risk-anchor: tk_054/044 为 mapping prune 与 seed 修正，非不可逆 schema 变更
sentinel-registry-reviewed

## 风险

- 合并后发版 + 跑迁移前，prod 价目表仍可能短暂展示已移除模型（仅展示层；路由层 PR #1122 另管 universal key 403）。
- `tk_054` 仅影响账号 67 的 mapping JSON，幂等；误删 mapping 可通过 modelops 恢复（需人工）。
- overlay 删行后依赖 manifest 闸，若 manifest 与 mapping 再漂移，`catalog-serving-drift.py` 应拦截。

## 验证

- `go test -tags=unit ./internal/service/... -run 'TkServedModelsManifest|PricingCatalog|IsModelPriced|TestCatalogInvalidateCache'`
- `python3 scripts/checks/catalog-serving-drift.py --quiet`
- `python3 scripts/export_agent_contract.py --check`
- `./scripts/preflight.sh`（本地 pre-commit + pre-push 全绿）

## 提交

- 9e46bfc99 fix(pricing): newapi 长尾按 tk_served_models manifest 对齐服务与展示
- 114346f11 fix(pricing): overlay hot-push 回归测试避开 manifest 闸

最新提交：114346f11
