### PR TITLE
fix(antigravity): admin 账号测试模型列表对齐 gemini-only SSOT

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -2068,10 +2068,9 @@ func (h *AccountHandler) GetAvailableModels(c *gin.Context) {
 		return
 	}
 
-	// Handle Antigravity accounts: return Claude + Gemini models
+	// Handle Antigravity accounts: gemini-only servable set (same SSOT as /antigravity/models).
 	if account.Platform == service.PlatformAntigravity {
-		// 直接复用 antigravity.DefaultModels()，与 /v1/models 端点保持同步
-		response.Success(c, antigravity.DefaultModels())
+		response.Success(c, tkAntigravityAdminDefaultModels(c.Request.Context(), account))
 		return
 	}
 
@@ -2209,6 +2208,39 @@ func tkGrokAdminDefaultModels(ctx context.Context) []openai.Model {
 
 func tkGeminiAdminDefaultModels(ctx context.Context) []geminicli.Model {
 	return geminicli.ModelsForIDs(service.ServableClientFacingIDs(ctx, service.PlatformGemini, nil, nil))
+}
+
+// tkAntigravityAdminDefaultModels returns admin account-test models from the unified
+// antigravity servable set, intersected with the account whitelist (mapAntigravityModel).
+// Matches gateway tkAntigravityDefaultModels — not antigravity.DefaultModels() (legacy claude rows).
+func tkAntigravityAdminDefaultModels(ctx context.Context, account *service.Account) []antigravity.ClaudeModel {
+	defaults := antigravity.DefaultModels()
+	byID := make(map[string]antigravity.ClaudeModel, len(defaults))
+	for _, m := range defaults {
+		byID[m.ID] = m
+	}
+	ids := service.ServableClientFacingIDs(ctx, service.PlatformAntigravity, nil, nil)
+	sort.SliceStable(ids, func(i, j int) bool {
+		if ids[i] == service.AntigravityDefaultTestModelID {
+			return true
+		}
+		if ids[j] == service.AntigravityDefaultTestModelID {
+			return false
+		}
+		return ids[i] < ids[j]
+	})
+	out := make([]antigravity.ClaudeModel, 0, len(ids))
+	for _, id := range ids {
+		if account != nil && service.MapAntigravityModel(account, id) == "" {
+			continue
+		}
+		if m, ok := byID[id]; ok {
+			out = append(out, m)
+			continue
+		}
+		out = append(out, antigravity.ClaudeModel{ID: id, Type: "model", DisplayName: id})
+	}
+	return out
 }
 
 func tkClaudeAdminDefaultModels(ctx context.Context) []claude.Model {

--- a/backend/internal/handler/admin/account_handler_available_models_test.go
+++ b/backend/internal/handler/admin/account_handler_available_models_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
@@ -371,6 +372,47 @@ func TestAccountHandlerGetAvailableModels_GrokUsesGrokCatalog(t *testing.T) {
 	ids := modelIDSet(resp.Data)
 	require.True(t, ids["grok-4.3"], "grok account test must default from the grok catalog")
 	require.False(t, ids["claude-sonnet-4-6"], "grok must not fall through to Claude catalog")
+}
+
+func TestAccountHandlerGetAvailableModels_AntigravityUsesGeminiOnlyCatalog(t *testing.T) {
+	geminiOnly := make(map[string]any, len(domain.GeminiOnlyAntigravityModelMapping))
+	for k, v := range domain.GeminiOnlyAntigravityModelMapping {
+		geminiOnly[k] = v
+	}
+	svc := &availableModelsAdminService{
+		stubAdminService: newStubAdminService(),
+		account: service.Account{
+			ID:       701,
+			Name:     "antigravity-or1-ls-b",
+			Platform: service.PlatformAntigravity,
+			Type:     service.AccountTypeOAuth,
+			Status:   service.StatusActive,
+			Credentials: map[string]any{
+				"model_mapping": geminiOnly,
+			},
+		},
+	}
+	router := setupAvailableModelsRouter(svc)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/accounts/701/models", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.Data)
+	require.Equal(t, service.AntigravityDefaultTestModelID, resp.Data[0].ID,
+		"antigravity chat probe default must be first")
+	ids := modelIDSet(resp.Data)
+	require.True(t, ids["gemini-3-flash"])
+	require.True(t, ids["gemini-pro-agent"])
+	require.False(t, ids["claude-sonnet-4-5"], "antigravity admin test must not offer claude models")
 }
 
 func TestAccountHandlerGetAvailableModels_KiroMirrorStubUsesKiroCatalog(t *testing.T) {

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -37,6 +37,10 @@ const (
 	chatgptCodexAPIURL     = "https://chatgpt.com/backend-api/codex/responses"
 	defaultGrokTestModelID = "grok-4.3"
 	GrokDefaultTestModelID = defaultGrokTestModelID
+	// Antigravity serves gemini only (AntigravityConfigReconciler); claude-* probes
+	// fail mapAntigravityModel whitelist on reconciled accounts.
+	defaultAntigravityTestModelID = "gemini-3-flash"
+	AntigravityDefaultTestModelID = defaultAntigravityTestModelID
 )
 
 // TestEvent represents a SSE event for account testing
@@ -1069,10 +1073,9 @@ func (s *AccountTestService) routeAntigravityTest(c *gin.Context, account *Accou
 func (s *AccountTestService) testAntigravityAccountConnection(c *gin.Context, account *Account, modelID string) error {
 	ctx := c.Request.Context()
 
-	// 默认模型：Claude 使用 claude-sonnet-4-5，Gemini 使用 gemini-3-pro-preview
 	testModelID := modelID
 	if testModelID == "" {
-		testModelID = "claude-sonnet-4-5"
+		testModelID = AntigravityDefaultTestModelID
 	}
 
 	if s.antigravityGatewayService == nil {

--- a/backend/internal/service/account_test_service_antigravity_test.go
+++ b/backend/internal/service/account_test_service_antigravity_test.go
@@ -1,0 +1,31 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapAntigravityModel_GeminiOnlyAccountRejectsClaudeProbe(t *testing.T) {
+	geminiOnly := make(map[string]any, len(domain.GeminiOnlyAntigravityModelMapping))
+	for k, v := range domain.GeminiOnlyAntigravityModelMapping {
+		geminiOnly[k] = v
+	}
+	account := &Account{
+		Platform: PlatformAntigravity,
+		Credentials: map[string]any{
+			"model_mapping": geminiOnly,
+		},
+	}
+
+	require.NotEmpty(t, MapAntigravityModel(account, AntigravityDefaultTestModelID))
+	require.Empty(t, MapAntigravityModel(account, "claude-sonnet-4-5"))
+}
+
+func TestAntigravityDefaultTestModelID_IsGeminiWire(t *testing.T) {
+	require.True(t, len(AntigravityDefaultTestModelID) > len("gemini-"))
+	require.Contains(t, AntigravityDefaultTestModelID, "gemini-")
+}

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -1027,6 +1027,12 @@ func mapAntigravityModel(account *Account, requestedModel string) string {
 	return ""
 }
 
+// MapAntigravityModel reports the upstream wire id after account mapping.
+// Empty string means the requested model is not whitelisted for this account.
+func MapAntigravityModel(account *Account, requestedModel string) string {
+	return mapAntigravityModel(account, requestedModel)
+}
+
 // getMappedModel 获取映射后的模型名
 // 完全依赖映射配置：账户映射（通配符）→ 默认映射兜底
 func (s *AntigravityGatewayService) getMappedModel(account *Account, requestedModel string) string {

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 543,
-  "hash": "19c0c39251b8d55e507513be57877eeb242173a47a87059650a20fcf10af1a6a",
+  "hash": "5daf38fafd6661cf5c2cf46aaa3c897e0b9a0bd813a5c9b01933b88beec56a87",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/AccountTestModal.vue
+++ b/frontend/src/components/account/AccountTestModal.vue
@@ -353,7 +353,7 @@ const loadAvailableModels = async () => {
       : models
     // Default selection by platform
     if (availableModels.value.length > 0) {
-      if (props.account.platform === 'gemini') {
+      if (props.account.platform === 'gemini' || props.account.platform === 'antigravity') {
         selectedModelId.value = availableModels.value[0].id
       } else {
         // Try to select Sonnet as default, otherwise use first model

--- a/frontend/src/components/admin/account/AccountTestModal.vue
+++ b/frontend/src/components/admin/account/AccountTestModal.vue
@@ -379,6 +379,9 @@ const loadAvailableModels = async () => {
     if (availableModels.value.length > 0) {
       if (props.account.platform === 'gemini') {
         selectedModelId.value = availableModels.value[0].id
+      } else if (props.account.platform === 'antigravity') {
+        // Backend pins AntigravityDefaultTestModelID first; gemini-only policy — no sonnet default.
+        selectedModelId.value = availableModels.value[0].id
       } else if (isKiroTestAccount.value) {
         selectedModelId.value =
           availableModels.value.find((m) => m.id === 'claude-sonnet-4-5')?.id ||

--- a/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
@@ -231,6 +231,33 @@ describe('AccountTestModal', () => {
     })
   })
 
+  it('defaults antigravity account test to first gemini model from admin catalog', async () => {
+    getAvailableModels.mockResolvedValueOnce([
+      { id: 'gemini-3-flash', display_name: 'Gemini 3 Flash' },
+      { id: 'gemini-pro-agent', display_name: 'Gemini 3.1 Pro (High)' }
+    ])
+    const wrapper = mountWith({
+      id: 701,
+      name: 'antigravity-or1-ls-b',
+      platform: 'antigravity',
+      type: 'oauth',
+      status: 'active'
+    })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const startButton = wrapper.findAll('button').find((button) => button.text().includes('admin.accounts.startTest'))
+    expect(startButton).toBeTruthy()
+    await startButton!.trigger('click')
+    await flushPromises()
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    const [, request] = (global.fetch as any).mock.calls[0]
+    expect(JSON.parse(request.body)).toMatchObject({
+      model_id: 'gemini-3-flash'
+    })
+  })
+
   // Regression (#900 lazyMount): AccountsView lazy-mounts this modal, so on first
   // open it is CREATED with show already true. A non-immediate show-watch never
   // fires for that mount → models never loaded → empty picker. onMounted must load


### PR DESCRIPTION
## 摘要

- Admin 账号测试「可用模型」不再返回 `antigravity.DefaultModels()` 中的 Claude 条目，改为 `ServableClientFacingIDs(antigravity)` 与 `MapAntigravityModel` 交集（gemini-only SSOT）。
- OAuth 默认探针模型从 `claude-sonnet-4-5` 改为 `gemini-3-flash`；前端测试弹窗对 antigravity/gemini 默认选中列表首项。
- 新增后端/前端回归测试，覆盖 admin 模型列表与默认选中行为。

## 风险

- 常规风险：仅影响 admin 账号测试 UI 与默认探针模型，不改变网关运行时路由或 mapping 规则。
- Antigravity 账号若 mapping 为空，可用模型列表可能为空（与网关行为一致）。

## 验证

- `./scripts/preflight.sh` PASS（含 frontend dist hash 同步）
- `go test -tags=unit ./internal/handler/admin/... -run AntigravityUsesGeminiOnly`
- `go test -tags=unit ./internal/service/... -run MapAntigravityModel_GeminiOnly`
- `go test -tags=unit ./internal/service/... -run 'MapAntigravityModel_GeminiOnly|AntigravityDefaultTestModelID'`
- `pnpm --dir frontend exec vitest run src/components/admin/account/__tests__/AccountTestModal.spec.ts`

sentinel-registry-reviewed
upstream-touch-trivial

## 提交

- b7150518c fix(antigravity): admin 账号测试模型列表对齐 gemini-only SSOT

最新提交：b7150518c
