### PR TITLE
fix(grok): admin 账号测试改走 /v1/responses

### DIFF
--- a/backend/internal/service/account_test_service_grok_test.go
+++ b/backend/internal/service/account_test_service_grok_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestAccountTestService_GrokAPIKeyRoutesToChatCompletions(t *testing.T) {
+func TestAccountTestService_GrokAPIKeyRoutesToResponses(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	resp := newJSONResponse(http.StatusOK, "")
 	resp.Header.Set("Content-Type", "text/event-stream")
-	resp.Body = ioNopCloserString("data: {\"choices\":[{\"delta\":{\"content\":\"hello from grok\"}}]}\n\ndata: [DONE]\n\n")
+	resp.Body = ioNopCloserString("data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello from grok\"}\n\ndata: {\"type\":\"response.completed\"}\n\n")
 	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
 
 	rec := httptest.NewRecorder()
@@ -47,7 +47,7 @@ func TestAccountTestService_GrokAPIKeyRoutesToChatCompletions(t *testing.T) {
 	require.Len(t, upstream.requests, 1)
 	req := upstream.requests[0]
 	require.Equal(t, http.MethodPost, req.Method)
-	require.Equal(t, "https://api-us4.tokenkey.dev/v1/chat/completions", req.URL.String())
+	require.Equal(t, "https://api-us4.tokenkey.dev/v1/responses", req.URL.String())
 	require.Equal(t, "Bearer edge-grok-key", req.Header.Get("Authorization"))
 	require.Equal(t, defaultGrokTestModelID, gjson.GetBytes(readRequestBodyForTest(t, req), "model").String())
 	body := rec.Body.String()
@@ -58,12 +58,12 @@ func TestAccountTestService_GrokAPIKeyRoutesToChatCompletions(t *testing.T) {
 	require.Contains(t, body, `"success":true`)
 }
 
-func TestAccountTestService_GrokOAuthRoutesToXAIChatCompletions(t *testing.T) {
+func TestAccountTestService_GrokOAuthRoutesToXAIResponses(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	resp := newJSONResponse(http.StatusOK, "")
-	resp.Header.Set("Content-Type", "text/event-stream")
-	resp.Body = ioNopCloserString("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n")
+	resp.Header.Set("Content-Type", "application/json")
+	resp.Body = ioNopCloserString(`{"status":"completed","model":"grok-code-fast-1","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}]}`)
 	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
 
 	rec := httptest.NewRecorder()
@@ -89,9 +89,10 @@ func TestAccountTestService_GrokOAuthRoutesToXAIChatCompletions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, upstream.requests, 1)
 	req := upstream.requests[0]
-	require.Equal(t, "https://api.x.ai/v1/chat/completions", req.URL.String())
+	require.Equal(t, "https://api.x.ai/v1/responses", req.URL.String())
 	require.Equal(t, "Bearer grok-oauth-token", req.Header.Get("Authorization"))
 	require.Contains(t, rec.Body.String(), `"model":"grok-code-fast-1"`)
+	require.Contains(t, rec.Body.String(), `"success":true`)
 }
 
 func TestAccountTestService_GrokRejectsDisallowedBaseURL(t *testing.T) {

--- a/backend/internal/service/account_test_service_tk_grok.go
+++ b/backend/internal/service/account_test_service_tk_grok.go
@@ -231,7 +231,7 @@ func extractGrokResponsesOutputText(body []byte) string {
 				continue
 			}
 			if text, ok := block["text"].(string); ok && strings.TrimSpace(text) != "" {
-				b.WriteString(text)
+				_, _ = b.WriteString(text)
 			}
 		}
 	}

--- a/backend/internal/service/account_test_service_tk_grok.go
+++ b/backend/internal/service/account_test_service_tk_grok.go
@@ -1,8 +1,14 @@
 package service
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	"github.com/gin-gonic/gin"
 )
 
@@ -12,32 +18,224 @@ func (s *AccountTestService) testGrokAccountConnection(c *gin.Context, account *
 	}
 
 	authToken := ""
-	baseURL := ""
+	normalizedBaseURL := ""
 	switch account.Type {
 	case AccountTypeAPIKey:
 		authToken = account.GetOpenAIApiKey()
-		baseURL = account.GetOpenAIBaseURL()
+		baseURL := account.GetOpenAIBaseURL()
+		if strings.TrimSpace(baseURL) == "" {
+			return s.sendErrorAndEnd(c, "No grok base URL available")
+		}
+		var err error
+		normalizedBaseURL, err = s.validateUpstreamBaseURL(baseURL)
+		if err != nil {
+			return s.sendErrorAndEnd(c, "Invalid base URL: "+err.Error())
+		}
 	case AccountTypeOAuth:
 		authToken = account.GetGrokAccessToken()
-		baseURL = account.GetGrokBaseURL()
+		baseURL := account.GetGrokBaseURL()
+		if strings.TrimSpace(baseURL) == "" {
+			return s.sendErrorAndEnd(c, "No grok base URL available")
+		}
+		var err error
+		normalizedBaseURL, err = s.validateUpstreamBaseURL(baseURL)
+		if err != nil {
+			return s.sendErrorAndEnd(c, "Invalid base URL: "+err.Error())
+		}
 	default:
 		return s.sendErrorAndEnd(c, "Unsupported grok account type: "+account.Type)
 	}
 	if strings.TrimSpace(authToken) == "" {
 		return s.sendErrorAndEnd(c, "No grok credential available")
 	}
-	if strings.TrimSpace(baseURL) == "" {
-		return s.sendErrorAndEnd(c, "No grok base URL available")
-	}
-	normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
-	if err != nil {
-		return s.sendErrorAndEnd(c, "Invalid base URL: "+err.Error())
-	}
 
 	testModelID := normalizeGrokAdminTestModel(modelID)
 	testModelID = account.GetMappedModel(testModelID)
 
-	return s.testOpenAIChatCompletionsConnection(c, account, testModelID, prompt, strings.TrimRight(normalizedBaseURL, "/"), authToken)
+	return s.testGrokResponsesConnection(c, account, testModelID, prompt, normalizedBaseURL, authToken)
+}
+
+func (s *AccountTestService) testGrokResponsesConnection(
+	c *gin.Context,
+	account *Account,
+	testModelID string,
+	prompt string,
+	normalizedBaseURL string,
+	authToken string,
+) error {
+	ctx := c.Request.Context()
+	apiURL, err := grokTestResponsesURL(account, normalizedBaseURL)
+	if err != nil {
+		return s.sendErrorAndEnd(c, err.Error())
+	}
+
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
+	c.Writer.Flush()
+
+	payloadBytes, _ := json.Marshal(createGrokResponsesTestPayload(testModelID, prompt))
+
+	s.sendEvent(c, TestEvent{Type: "test_start", Model: testModelID})
+	s.sendEvent(c, TestEvent{Type: "status", Text: "正在通过 /v1/responses 测试连接"})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(payloadBytes))
+	if err != nil {
+		return s.sendErrorAndEnd(c, "Failed to create Responses request")
+	}
+	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+authToken)
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+
+	resp, err := s.httpUpstream.DoWithTLS(req, proxyURL, account.ID, account.Concurrency, s.resolveAccountTestTLSProfile(account))
+	if err != nil {
+		return s.sendErrorAndEnd(c, fmt.Sprintf("Responses API (/v1/responses) request failed: %s", err.Error()))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			s.reconcileOpenAI429State(ctx, account, resp.Header, body)
+		}
+		if resp.StatusCode == http.StatusUnauthorized && s.accountRepo != nil {
+			errMsg := fmt.Sprintf("Responses authentication failed (401): %s", string(body))
+			_ = s.accountRepo.SetError(ctx, account.ID, errMsg)
+		}
+		return s.sendErrorAndEnd(c, fmt.Sprintf("Responses API (/v1/responses) returned %d: %s", resp.StatusCode, string(body)))
+	}
+
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	if strings.Contains(contentType, "text/event-stream") {
+		return s.processOpenAIStream(c, resp.Body)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return s.sendErrorAndEnd(c, fmt.Sprintf("Failed to read Responses body: %s", err.Error()))
+	}
+	return s.processGrokResponsesJSON(c, body)
+}
+
+func grokTestResponsesURL(account *Account, normalizedBaseURL string) (string, error) {
+	switch account.Type {
+	case AccountTypeOAuth:
+		return xai.BuildResponsesURL(strings.TrimSpace(account.GetGrokBaseURL()))
+	case AccountTypeAPIKey:
+		if strings.TrimSpace(normalizedBaseURL) == "" {
+			return "", fmt.Errorf("no grok base URL available")
+		}
+		return buildOpenAIResponsesURL(normalizedBaseURL), nil
+	default:
+		return "", fmt.Errorf("unsupported grok account type: %s", account.Type)
+	}
+}
+
+func createGrokResponsesTestPayload(modelID string, prompt string) map[string]any {
+	testPrompt := strings.TrimSpace(prompt)
+	if testPrompt == "" {
+		testPrompt = "hi"
+	}
+	return map[string]any{
+		"model": modelID,
+		"input": []map[string]any{
+			{
+				"type": "message",
+				"role": "user",
+				"content": []map[string]any{
+					{
+						"type": "input_text",
+						"text": testPrompt,
+					},
+				},
+			},
+		},
+		"stream":            true,
+		"max_output_tokens": 32,
+	}
+}
+
+func (s *AccountTestService) processGrokResponsesJSON(c *gin.Context, body []byte) error {
+	if !json.Valid(body) {
+		return s.sendErrorAndEnd(c, "Responses API returned invalid JSON")
+	}
+
+	status := strings.TrimSpace(jsonGetString(body, "status"))
+	if status == "failed" {
+		msg := jsonGetString(body, "error.message")
+		if msg == "" {
+			msg = "Grok response failed"
+		}
+		return s.sendErrorAndEnd(c, msg)
+	}
+
+	text := extractGrokResponsesOutputText(body)
+	if text != "" {
+		s.sendEvent(c, TestEvent{Type: "content", Text: text})
+	}
+
+	if status != "completed" && text == "" {
+		return s.sendErrorAndEnd(c, "Responses API returned no output text")
+	}
+
+	s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+	return nil
+}
+
+func jsonGetString(body []byte, path string) string {
+	parts := strings.Split(path, ".")
+	var current any
+	if err := json.Unmarshal(body, &current); err != nil {
+		return ""
+	}
+	for _, part := range parts {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = obj[part]
+	}
+	value, _ := current.(string)
+	return strings.TrimSpace(value)
+}
+
+func extractGrokResponsesOutputText(body []byte) string {
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return ""
+	}
+	output, ok := payload["output"].([]any)
+	if !ok {
+		return ""
+	}
+	var b strings.Builder
+	for _, item := range output {
+		msg, ok := item.(map[string]any)
+		if !ok || msg["type"] != "message" {
+			continue
+		}
+		content, ok := msg["content"].([]any)
+		if !ok {
+			continue
+		}
+		for _, part := range content {
+			block, ok := part.(map[string]any)
+			if !ok {
+				continue
+			}
+			if text, ok := block["text"].(string); ok && strings.TrimSpace(text) != "" {
+				b.WriteString(text)
+			}
+		}
+	}
+	return b.String()
 }
 
 func normalizeGrokAdminTestModel(modelID string) string {

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -147,16 +147,17 @@
         "if account.IsGrok() {",
         "return s.testGrokAccountConnection(c, account, modelID, prompt)"
       ],
-      "rationale": "The admin account-test dispatcher must route grok accounts to the native OpenAI-compatible /v1/chat/completions probe before the generic Claude /v1/messages fallback. Losing this branch makes first-class grok relay stubs test through messages dispatch, which is intentionally disabled on grok groups and returns a misleading 403 even though native chat completions can serve."
+      "rationale": "The admin account-test dispatcher must route grok accounts to the grok-specific probe before the generic Claude /v1/messages fallback. Losing this branch makes grok relay stubs test through messages dispatch, which is intentionally disabled on grok groups."
     },
     {
       "path": "backend/internal/service/account_test_service_tk_grok.go",
       "must_contain": [
         "func (s *AccountTestService) testGrokAccountConnection",
-        "testOpenAIChatCompletionsConnection",
+        "testGrokResponsesConnection",
+        "buildOpenAIResponsesURL",
         "defaultGrokTestModelID"
       ],
-      "rationale": "Grok-specific admin test companion: API-key relay stubs use GetOpenAIApiKey/GetOpenAIBaseURL against the edge, OAuth grok uses GetGrokAccessToken/GetGrokBaseURL against api.x.ai, and the requested model is normalized to a chat-capable grok default. Losing this file or broadening it back into Claude messages reintroduces the group-dispatch 403 path for grok account tests."
+      "rationale": "Grok-specific admin test companion: API-key relay stubs use GetOpenAIApiKey/GetOpenAIBaseURL against the edge via /v1/responses (grok groups reject /v1/chat/completions), OAuth grok uses GetGrokAccessToken/GetGrokBaseURL against api.x.ai /responses, and the requested model is normalized to a chat-capable grok default. Losing this file or reverting to chat-completions reintroduces the 404 'Chat Completions API is not supported for Grok groups' admin test failure."
     },
     {
       "path": "frontend/src/constants/gatewayPlatforms.ts",


### PR DESCRIPTION
## 摘要

- Grok 账号在管理后台「测试连接」从 `/v1/chat/completions` 改为 **`/v1/responses`**，与 Grok 分组真实聊天入口一致。
- 支持 apikey 中继（`buildOpenAIResponsesURL`）与 OAuth（`xai.BuildResponsesURL`），SSE 与非流式 JSON 均可解析。
- 同步更新 grok sentinel 与单元测试，防止回退到 chat completions 路径。

## 风险

- 常规风险：仅影响 admin 账号测试 SSE 流，不改变网关转发或用户 API 契约。
- prod `grok-us4` apikey 中继在**用户网关层**仍可能 429/502（`forwardGrokResponses` OAuth-only），本 PR 不覆盖该路径。

## 验证

- `go test -tags=unit ./internal/service -run 'TestAccountTestService_Grok|TestNormalizeGrokAdminTestModel' -count=1` — PASS
- `./scripts/preflight.sh` — PASS
- `golangci-lint` errcheck（`WriteString`）— 已修复

## 提交

- 66f9dbfea fix(grok): admin 账号测试改走 /v1/responses 而非 chat completions
- 529cb1c34 fix(grok): address R-001 errcheck on WriteString in admin test helper

最新提交：529cb1c34
