### PR TITLE
docs(migration): tk_054 注释对齐智谱官网 overlay 定价

### DIFF
--- a/backend/migrations/tk_054_qwen_glm_dashscope_model_mapping.sql
+++ b/backend/migrations/tk_054_qwen_glm_dashscope_model_mapping.sql
@@ -9,8 +9,8 @@
 --   account 72 model_mapping == account 60 model_mapping
 --
 -- DashScope model ids match the Alibaba百炼 GLM section (华北2北京 mainland).
--- Pricing lands in tk_pricing_overlay.json from docs/accounts/aliyun_pricing_20260701.md
--- (CNY ÷ 6.7). Account 67 still serves the ZhipuV4 direct SKUs via tk_044.
+-- User-facing overlay pricing follows Zhipu official list (https://open.bigmodel.cn/pricing).
+-- Account 67 still serves the ZhipuV4 direct SKUs via tk_044.
 --
 -- Merge (jsonb ||) preserves existing whitelist entries. Raw-SQL account mutation
 -- bypasses Ent snapshot hooks — enqueue scheduler_outbox account_changed per account.


### PR DESCRIPTION
## 摘要

- #1125 合并后 GLM overlay 已改回智谱官网价（https://open.bigmodel.cn/pricing），但 `tk_054` 迁移头注释仍写「百炼 CNY÷6.7」。
- 本 PR **仅**修正 `backend/migrations/tk_054_qwen_glm_dashscope_model_mapping.sql` 头注释两行，消除 SSOT 漂移；**无 schema / 运行时行为变更**。
- 已重建分支 commit（修复此前 Git API 误用整树 SHA 导致的多文件回滚 diff）。

## 风险

- 低风险：纯注释变更，不影响已执行迁移或 prod 状态。

## 验证

- PR diff 仅 1 个 migration 文件（+2/-2 行注释）
- `./scripts/preflight.sh` PASS（含 high-risk-anchor）
- 无新增测试需求（注释-only）

## 提交

- `b2086ad3e` docs(migration): tk_054 注释对齐智谱官网 overlay 定价

最新提交：b2086ad
