### PR TITLE
chore(stage0): prod 持续 CPU CloudWatch 告警（>80% × 15min）

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -750,7 +750,7 @@ sudo systemctl list-timers tokenkey-pgdump.timer
 sudo systemctl list-timers tokenkey-disk-metrics.timer   # → CloudWatch tokenkey/EC2 DataVolumeUsedPercent
 sudo systemctl list-timers tokenkey-qa-stale-cleanup.timer
 ls -lh /var/lib/tokenkey/pgdump/ 2>/dev/null || echo '(no dumps yet — first dump runs on next scheduled timer tick)'
-# pg_dump 每小时一次，本地只滚动保留最近 6 份 tokenkey-*.sql.gz（S3 TOKENKEY_PGDUMP_S3_URI 才是归档源，本地仅供快速恢复）；清理在 dump 之前先跑以自愈满盘死锁。卷使用率告警：CFN DataVolumeDiskAlarm（探测）+ tokenkey-disk-metrics timer 的 on-box 飞书告警（通知，USED≥85%）/ 主文档 §3.8
+# pg_dump 每小时一次，本地只滚动保留最近 6 份 tokenkey-*.sql.gz（S3 TOKENKEY_PGDUMP_S3_URI 才是归档源，本地仅供快速恢复）；清理在 dump 之前先跑以自愈满盘死锁。卷使用率告警：CFN DataVolumeDiskAlarm（探测）+ tokenkey-disk-metrics timer 的 on-box 飞书告警（通知，USED≥85%）/ 主文档 §3.8。CPU 持续高负载：CloudWatch `tokenkey-prod-cpu-sustained-high`（AWS/EC2 CPUUtilization 5m Average >80% 连续 15min；`ops/stage0/sync-instance-cpu-alarm.sh` 可不经全栈 CFN 单独同步）。
 # 旧版手工/迁移快照 `pre-*.dump` 属存量文件；确认不需回滚后可删除，新模板的 pgdump timer 也会清理。
 # QA：`QaStaleRetentionDays`（默认 1.5 天）每日清理旧 qa_records + qa_blobs/qa_dlq；与 ops/prod/qa-export-and-purge.sh 范围对齐，0=关闭
 sudo cat /var/lib/tokenkey/.env                           # 含明文密码，慎查

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -370,6 +370,9 @@ aws cloudformation wait stack-update-complete --region "$REGION" --stack-name "$
 aws cloudformation describe-stacks --region "$REGION" --stack-name "$OIDC_STACK" \
   --query "Stacks[0].Parameters[?ParameterKey=='TargetInstanceId'].ParameterValue|[0]" --output text  # 期望 $NEW_ID
 
+# 4b) CPU 告警若经 sync 脚本落地（非全栈 CFN），实例 ID 变更后必须重指：
+bash ops/stage0/sync-instance-cpu-alarm.sh --stack "$STACK"
+
 # 回退：把 TARGET 改回 t4g.small 重跑步骤 0→4（同样 1–3 min replace，数据同样保留，
 #       同样要 pin $RUNNING_TAG + 重指 OIDC）。
 ```

--- a/deploy/aws/cloudformation/stage0-single-ec2.yaml
+++ b/deploy/aws/cloudformation/stage0-single-ec2.yaml
@@ -154,8 +154,8 @@ Parameters:
     Type: String
     Default: ''
     Description: >-
-      Optional SNS topic ARN subscribed to DataVolumeDiskAlarm (email/Slack).
-      Leave empty to create the alarm without notifications.
+      Optional SNS topic ARN subscribed to DataVolumeDiskAlarm and InstanceCpuAlarm
+      (email/Slack). Leave empty to create alarms without SNS notifications.
 
   QaStaleRetentionDays:
     Type: Number
@@ -581,6 +581,27 @@ Resources:
           Value: !Ref Instance
       AlarmActions: !If [AlarmTopicProvided, [!Ref AlarmSnsTopicArn], !Ref AWS::NoValue]
 
+  InstanceCpuAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub '${ProjectName}-${Environment}-cpu-sustained-high'
+      AlarmDescription: >-
+        tokenkey EC2 CPU > 80% (5m Average) for 15 consecutive minutes — deploy
+        burst or traffic spike; check load, active-color container, and consider resize.
+      Namespace: AWS/EC2
+      MetricName: CPUUtilization
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
+      Threshold: 80
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref Instance
+      AlarmActions: !If [AlarmTopicProvided, [!Ref AlarmSnsTopicArn], !Ref AWS::NoValue]
+
 Outputs:
   PublicIP:
     Description: Elastic IP - set this as the A record for ApiDomain
@@ -609,3 +630,6 @@ Outputs:
   DataVolumeDiskAlarmName:
     Description: CloudWatch alarm for DataVolume utilization (tokenkey/EC2 DataVolumeUsedPercent)
     Value: !Ref DataVolumeDiskAlarm
+  InstanceCpuAlarmName:
+    Description: CloudWatch alarm for sustained EC2 CPU (AWS/EC2 CPUUtilization > 80% for 15m)
+    Value: !Ref InstanceCpuAlarm

--- a/deploy/aws/stage0/test_stage0_cfn_alarms.py
+++ b/deploy/aws/stage0/test_stage0_cfn_alarms.py
@@ -28,6 +28,20 @@ class Stage0CfnAlarmsTest(unittest.TestCase):
         self.assertIn("ComparisonOperator: GreaterThanThreshold", body)
         self.assertIn("TreatMissingData: notBreaching", body)
 
+    def test_sync_script_alarm_contract_matches_cfn(self) -> None:
+        script_path = pathlib.Path(__file__).resolve().parents[3] / "ops/stage0/sync-instance-cpu-alarm.sh"
+        script = script_path.read_text(encoding="utf-8")
+        for needle in (
+            "--period 300",
+            "--evaluation-periods 3",
+            "--datapoints-to-alarm 3",
+            "--threshold 80",
+            "GreaterThanThreshold",
+            "notBreaching",
+            "CPUUtilization",
+        ):
+            self.assertIn(needle, script, f"sync script missing {needle!r}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/deploy/aws/stage0/test_stage0_cfn_alarms.py
+++ b/deploy/aws/stage0/test_stage0_cfn_alarms.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""CFN alarm contract checks for stage0-single-ec2.yaml (stdlib-only)."""
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+CFN = pathlib.Path(__file__).resolve().parents[1] / "cloudformation/stage0-single-ec2.yaml"
+
+
+class Stage0CfnAlarmsTest(unittest.TestCase):
+    def test_instance_cpu_alarm_sustained_80_for_15m(self) -> None:
+        text = CFN.read_text(encoding="utf-8")
+        block = re.search(
+            r"InstanceCpuAlarm:\s*\n\s*Type: AWS::CloudWatch::Alarm\s*\n\s*Properties:(.*?)(?:\n  [A-Z][A-Za-z0-9]+:|\nOutputs:)",
+            text,
+            re.S,
+        )
+        self.assertIsNotNone(block, "InstanceCpuAlarm resource missing")
+        body = block.group(1)
+        self.assertIn("MetricName: CPUUtilization", body)
+        self.assertIn("Statistic: Average", body)
+        self.assertIn("Period: 300", body)
+        self.assertIn("EvaluationPeriods: 3", body)
+        self.assertIn("DatapointsToAlarm: 3", body)
+        self.assertIn("Threshold: 80", body)
+        self.assertIn("ComparisonOperator: GreaterThanThreshold", body)
+        self.assertIn("TreatMissingData: notBreaching", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/stage0/sync-instance-cpu-alarm.sh
+++ b/ops/stage0/sync-instance-cpu-alarm.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# sync-instance-cpu-alarm.sh — apply tokenkey Stage0 InstanceCpuAlarm without a full
+# CFN stack update (prod stack template drift can otherwise trigger instance replace).
+#
+# Contract matches deploy/aws/cloudformation/stage0-single-ec2.yaml InstanceCpuAlarm:
+#   AWS/EC2 CPUUtilization Average > 80 for 3×5m (15 minutes sustained).
+#
+# Usage:
+#   bash ops/stage0/sync-instance-cpu-alarm.sh --stack tokenkey-prod-stage0
+#   bash ops/stage0/sync-instance-cpu-alarm.sh --instance-id i-0123456789abcdef0
+# Env:
+#   AWS_REGION / AWS_DEFAULT_REGION (default us-east-1)
+#   ALARM_SNS_TOPIC_ARN — optional; when set, alarm notifies SNS on breach
+set -euo pipefail
+
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+STACK=""
+INSTANCE_ID=""
+SNS_ARN="${ALARM_SNS_TOPIC_ARN:-}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --stack) STACK="$2"; shift 2 ;;
+    --instance-id) INSTANCE_ID="$2"; shift 2 ;;
+    --sns-topic-arn) SNS_ARN="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "sync-instance-cpu-alarm: unknown arg $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$INSTANCE_ID" ] && [ -n "$STACK" ]; then
+  INSTANCE_ID="$(aws cloudformation describe-stacks --region "$REGION" --stack-name "$STACK" \
+    --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' --output text)"
+fi
+if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "None" ]; then
+  echo "sync-instance-cpu-alarm: provide --instance-id or --stack with InstanceId output" >&2
+  exit 1
+fi
+
+if [ -n "$STACK" ]; then
+  ALARM_NAME="$(printf '%s' "$STACK" | sed -E 's/-stage0$/-cpu-sustained-high/')"
+else
+  ALARM_NAME="tokenkey-prod-cpu-sustained-high"
+fi
+
+args=(
+  --region "$REGION"
+  --alarm-name "$ALARM_NAME"
+  --alarm-description "tokenkey EC2 CPU > 80% (5m Average) for 15 consecutive minutes — deploy burst or traffic spike; check load, active-color container, and consider resize."
+  --namespace AWS/EC2
+  --metric-name CPUUtilization
+  --dimensions "Name=InstanceId,Value=${INSTANCE_ID}"
+  --statistic Average
+  --period 300
+  --evaluation-periods 3
+  --datapoints-to-alarm 3
+  --threshold 80
+  --comparison-operator GreaterThanThreshold
+  --treat-missing-data notBreaching
+)
+if [ -n "$SNS_ARN" ]; then
+  args+=(--alarm-actions "$SNS_ARN")
+fi
+
+aws cloudwatch put-metric-alarm "${args[@]}"
+echo "sync-instance-cpu-alarm: ok alarm=${ALARM_NAME} instance=${INSTANCE_ID} region=${REGION}"


### PR DESCRIPTION
## 摘要

- 在 `stage0-single-ec2.yaml` 增加 `InstanceCpuAlarm`：AWS/EC2 `CPUUtilization` 5 分钟 Average **>80%** 且连续 **3 个周期**（15 分钟）。
- 新增 `ops/stage0/sync-instance-cpu-alarm.sh`：不经全栈 CFN update 单独同步告警（避免 prod 栈模板漂移触发 instance replace）。
- prod 已手工落地告警 `tokenkey-prod-cpu-sustained-high`（`i-0e43099f831b03160`）；本 PR 将 IaC 与运维脚本入库对齐。
- resize SOP 补充 step 4b：实例 replace 后需重跑 sync 脚本重指 CPU 告警。

## 风险

- 低风险：仅 CloudWatch 告警定义 + 同步脚本 + 契约测试；不触发生产容器/路由变更。
- 全栈 CFN deploy **仍不可直接做**（预览 changeset 会夹带 Instance Replacement）；合并后新栈/安全窗口内再对齐 CFN 资源即可。
- 当前 `AlarmSnsTopicArn` 为空，告警只在 CloudWatch 控制台可见（与磁盘告警一致）；接 SNS 后可重跑 sync 脚本。

## 验证

- `python3 deploy/aws/stage0/test_stage0_cfn_alarms.py -v` — PASS（含 sync 脚本 parity）
- `./scripts/preflight.sh` — PASS
- prod 已存在：`aws cloudwatch describe-alarms --alarm-names tokenkey-prod-cpu-sustained-high`
- `bash ops/stage0/sync-instance-cpu-alarm.sh --stack tokenkey-prod-stage0` — idempotent ok

## 提交

- `3d36a86b2` chore(stage0): add prod sustained CPU CloudWatch alarm
- `ae9529353` fix(stage0): rebase CPU alarm PR and tighten alarm contract tests

最新提交：ae9529353
