### PR TITLE
fix(ops): prompt-surface-watch 始终跑 prod-aggregate 并同步 Issue

### DIFF
--- a/.github/workflows/prompt-surface-watch.yml
+++ b/.github/workflows/prompt-surface-watch.yml
@@ -10,12 +10,6 @@ on:
     - cron: "3 23 * * *"
   workflow_dispatch:
     inputs:
-      with_prod:
-        description: "Also aggregate prod gateway fingerprint logs via SSM (always true on schedule)"
-        required: false
-        default: "false"
-        type: choice
-        options: ["false", "true"]
       since:
         description: "docker logs --since for prod fingerprint probe"
         required: false
@@ -105,7 +99,7 @@ jobs:
 
   prod-aggregate:
     needs: registry-gate
-    if: always() && needs.registry-gate.result == 'success' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.with_prod == 'true'))
+    if: always() && needs.registry-gate.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:


### PR DESCRIPTION
## 摘要

- 去掉 `with_prod` 手动开关；`registry-gate` 成功后，cron 与 `workflow_dispatch` 均自动跑 `prod-aggregate`。
- prod 聚合完成后继续走既有 `prod-sync`：有 actionable drift 开/更新 GitHub Issue，无 drift 自动关闭。
- 仅 `dry_run=true` 时跳过 Issue 写入。

## 风险

- 常规风险，仅 workflow 调度形状变更；手动 dispatch 默认也会触发 SSM prod 探测（与 cron 对齐）。
- 依赖 `AWS_OIDC_ROLE_ARN` 与 `UPSTREAM_MERGE_GH_TOKEN`；缺失时 prod 跳过或 Issue 步骤 fail（行为与现网一致）。

## 验证

- `./scripts/preflight.sh` 全绿（含 `test_open_prompt_surface_watch_issues`）。
- 合并后可在 Actions 手动 Run workflow（不设 `dry_run`）确认 `prod-aggregate` 与 `Sync prod drift tracking issue` 步骤执行。

## 提交

- e5899ae44 fix(ops): prompt-surface-watch 始终跑 prod-aggregate 并同步 Issue

最新提交：e5899ae44
