### PR TITLE
fix(kiro): 全 endpoint 429 配额耗尽走 10s 短时冷却

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -794,6 +794,13 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					return
 				}
 
+				var kiroQuotaErr *service.KiroEndpointQuotaExhaustedError
+				if errors.As(err, &kiroQuotaErr) {
+					c.Header("Retry-After", "10")
+					h.errorResponse(c, http.StatusTooManyRequests, "rate_limit_error", kiroQuotaErr.ClientMessage())
+					return
+				}
+
 				// TK canonical-OAuth ingress UA reject: 403 immediately, no failover.
 				// Local policy denial, not account/provider health — mark it
 				// business-limited so strict-mode canary reject volume stays out of

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -796,7 +796,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 
 				var kiroQuotaErr *service.KiroEndpointQuotaExhaustedError
 				if errors.As(err, &kiroQuotaErr) {
-					c.Header("Retry-After", "10")
+					c.Header("Retry-After", strconv.Itoa(service.KiroEndpointQuotaExhaustedRetryAfterSeconds()))
 					h.errorResponse(c, http.StatusTooManyRequests, "rate_limit_error", kiroQuotaErr.ClientMessage())
 					return
 				}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4879,9 +4879,18 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 
 	if account != nil && account.IsKiro() {
 		result, err := s.kiroGateway.Forward(ctx, c, account, parsed, startTime)
-		var failoverErr *UpstreamFailoverError
-		if err != nil && s.rateLimitService != nil && errors.As(err, &failoverErr) {
-			s.rateLimitService.HandleUpstreamError(ctx, account, failoverErr.StatusCode, failoverErr.ResponseHeaders, failoverErr.ResponseBody, parsed.Model)
+		if err != nil && s.rateLimitService != nil {
+			var quotaErr *KiroEndpointQuotaExhaustedError
+			if errors.As(err, &quotaErr) {
+				s.rateLimitService.HandleUpstreamError(
+					ctx, account, http.StatusTooManyRequests, nil,
+					[]byte(quotaErr.ClientMessage()), parsed.Model,
+				)
+			}
+			var failoverErr *UpstreamFailoverError
+			if errors.As(err, &failoverErr) {
+				s.rateLimitService.HandleUpstreamError(ctx, account, failoverErr.StatusCode, failoverErr.ResponseHeaders, failoverErr.ResponseBody, parsed.Model)
+			}
 		}
 		return result, err
 	}

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -342,6 +342,11 @@ func TestClassifyKiroForwardError(t *testing.T) {
 
 	// nil passes through.
 	require.NoError(t, classifyKiroForwardError(nil, "m"))
+
+	quota := classifyKiroForwardError(fmt.Errorf("quota exhausted on AmazonQ"), "claude-sonnet-4-5")
+	var quotaErr *KiroEndpointQuotaExhaustedError
+	require.ErrorAs(t, quota, &quotaErr)
+	require.Equal(t, tkKiroEndpointQuotaExhaustedClient, quotaErr.ClientMessage())
 }
 
 func TestGatewayService_Forward_Kiro401TriggersRateLimitRefresh(t *testing.T) {

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -25,6 +25,26 @@ type KiroInvalidModelError struct {
 	Body       string
 }
 
+// KiroEndpointQuotaExhaustedError is raised when every Kiro upstream endpoint
+// returned HTTP 429 quota exhaustion during the automatic fallback loop.
+type KiroEndpointQuotaExhaustedError struct {
+	Body string
+}
+
+func (e *KiroEndpointQuotaExhaustedError) Error() string {
+	if e == nil {
+		return "kiro endpoint quota exhausted"
+	}
+	if strings.TrimSpace(e.Body) != "" {
+		return e.Body
+	}
+	return "kiro endpoint quota exhausted"
+}
+
+func (e *KiroEndpointQuotaExhaustedError) ClientMessage() string {
+	return tkKiroEndpointQuotaExhaustedClient
+}
+
 func (e *KiroInvalidModelError) Error() string {
 	return fmt.Sprintf("kiro invalid model %q: status=%d", e.Model, e.StatusCode)
 }
@@ -50,11 +70,18 @@ func (e *KiroInvalidModelError) ClientMessage() string {
 // the literal "HTTP 400" prefix plus the upstream "INVALID_MODEL_ID" marker so
 // an unrelated 400 (or a 400 with a different reason) does not get mislabeled
 // as a model error.
+func isKiroEndpointQuotaExhaustedError(msg string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(msg)), "quota exhausted on")
+}
+
 func classifyKiroForwardError(err error, model string) error {
 	if err == nil {
 		return nil
 	}
 	msg := err.Error()
+	if isKiroEndpointQuotaExhaustedError(msg) {
+		return &KiroEndpointQuotaExhaustedError{Body: msg}
+	}
 	if isKiroInvalidModelError(msg) {
 		return &KiroInvalidModelError{
 			StatusCode: 400,

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -361,6 +361,10 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		return s.handleAnthropicUsagePolicyBlock(ctx, account, statusCode, upstreamMsg, responseBody)
 	}
 
+	if handled, quotaDisable := s.tkMaybeHandleKiroEndpointQuotaExhausted(ctx, account, upstreamMsg, responseBody); handled {
+		return quotaDisable
+	}
+
 	switch statusCode {
 	case 400:
 		// "organization has been disabled" → 永久禁用
@@ -1221,6 +1225,9 @@ func (s *RateLimitService) handle403(ctx context.Context, account *Account, upst
 // in case 400, OAuth 401 refresh, 429 retry-after cooldown, 529 overload)
 // live outside this function and are unaffected.
 func (s *RateLimitService) handleAnthropicUpstreamError(ctx context.Context, account *Account, statusCode int, upstreamMsg string, responseBody []byte) (shouldDisable bool) {
+	if tkIsKiroMirrorStub(account) && tkIsKiroEndpointQuotaExhausted(upstreamMsg, responseBody) {
+		return s.tkHandleKiroEndpointQuotaExhausted(ctx, account, upstreamMsg)
+	}
 	// TK (prod incident 2026-05-31): a 503 whose body is the downstream gateway's
 	// own "no available accounts" pool-exhaustion signal is a transient capacity
 	// blip on the *forwarded-to* pool (e.g. a thin edge bursting on parallel haiku

--- a/backend/internal/service/ratelimit_service_tk_kiro_quota429.go
+++ b/backend/internal/service/ratelimit_service_tk_kiro_quota429.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// TK: Kiro upstream endpoint quota exhaustion (all fallback endpoints return 429).
+//
+// Prod incident 2026-07-01 (edge-us3/4/5 mirror stubs): when Runtime/IDE/CodeWhisperer/
+// AmazonQ all return 429, the edge gateway surfaced a generic 502 and prod kiro-us*
+// mirror stubs advanced the anthropic_upstream_error 3/3 ladder (30s→2m→10m), causing
+// frequent "临时不可调度" UI flicker even though edge Kiro OAuth accounts stayed healthy.
+// This path applies a fixed 10s temp_unschedulable instead — enough to fail over without
+// treating a subscription RPM blip as stub health failure.
+
+const (
+	tkKiroEndpointQuotaExhaustedCooldown = 10 * time.Second
+	tkKiroEndpointQuotaExhaustedReason   = "kiro_endpoint_quota_exhausted"
+	tkKiroEndpointQuotaExhaustedClient   = "Kiro upstream quota exhausted, please retry later"
+)
+
+func tkIsKiroEndpointQuotaExhausted(upstreamMsg string, responseBody []byte) bool {
+	haystack := strings.ToLower(strings.TrimSpace(upstreamMsg) + "\n" + strings.TrimSpace(string(responseBody)))
+	if strings.Contains(haystack, "quota exhausted on") {
+		return true
+	}
+	return strings.Contains(haystack, strings.ToLower(tkKiroEndpointQuotaExhaustedClient))
+}
+
+func (s *RateLimitService) tkMaybeHandleKiroEndpointQuotaExhausted(
+	ctx context.Context,
+	account *Account,
+	upstreamMsg string,
+	responseBody []byte,
+) (handled bool, shouldDisable bool) {
+	if s == nil || account == nil || !tkIsKiroEndpointQuotaExhausted(upstreamMsg, responseBody) {
+		return false, false
+	}
+	if account.Platform != PlatformKiro && !tkIsKiroMirrorStub(account) {
+		return false, false
+	}
+	return true, s.tkHandleKiroEndpointQuotaExhausted(ctx, account, upstreamMsg)
+}
+
+func (s *RateLimitService) tkHandleKiroEndpointQuotaExhausted(ctx context.Context, account *Account, upstreamMsg string) bool {
+	if s == nil || account == nil {
+		return false
+	}
+	until := time.Now().Add(tkKiroEndpointQuotaExhaustedCooldown)
+	msg := "Kiro upstream endpoint quota exhausted; short cooldown"
+	if trimmed := strings.TrimSpace(upstreamMsg); trimmed != "" {
+		msg = msg + ": " + trimmed
+	}
+	s.notifyAccountSchedulingBlocked(account, until, tkKiroEndpointQuotaExhaustedReason, msg)
+	state := &TempUnschedState{
+		UntilUnix:       until.Unix(),
+		TriggeredAtUnix: time.Now().Unix(),
+		StatusCode:      http.StatusTooManyRequests,
+		MatchedKeyword:  tkKiroEndpointQuotaExhaustedReason,
+		RuleIndex:       -1,
+		ErrorMessage:    truncateTempUnschedMessage([]byte(msg), tempUnschedMessageMaxBytes),
+	}
+	reason := msg
+	if raw, marshalErr := json.Marshal(state); marshalErr == nil {
+		reason = string(raw)
+	}
+	if err := s.accountRepo.SetTempUnschedulable(ctx, account.ID, until, reason); err != nil {
+		slog.Warn("kiro_endpoint_quota_exhausted_set_temp_unschedulable_failed",
+			"account_id", account.ID,
+			"error", err,
+		)
+	}
+	if s.tempUnschedCache != nil {
+		if err := s.tempUnschedCache.SetTempUnsched(ctx, account.ID, state); err != nil {
+			slog.Warn("kiro_endpoint_quota_exhausted_temp_unsched_cache_set_failed",
+				"account_id", account.ID,
+				"error", err,
+			)
+		}
+	}
+	slog.Info("kiro_endpoint_quota_exhausted_short_cooldown",
+		"account_id", account.ID,
+		"platform", account.Platform,
+		"until", until.UTC().Format(time.RFC3339),
+	)
+	return true
+}

--- a/backend/internal/service/ratelimit_service_tk_kiro_quota429.go
+++ b/backend/internal/service/ratelimit_service_tk_kiro_quota429.go
@@ -24,6 +24,12 @@ const (
 	tkKiroEndpointQuotaExhaustedClient   = "Kiro upstream quota exhausted, please retry later"
 )
 
+// KiroEndpointQuotaExhaustedRetryAfterSeconds is the HTTP Retry-After value paired
+// with tkKiroEndpointQuotaExhaustedCooldown for gateway 429 responses.
+func KiroEndpointQuotaExhaustedRetryAfterSeconds() int {
+	return int(tkKiroEndpointQuotaExhaustedCooldown / time.Second)
+}
+
 func tkIsKiroEndpointQuotaExhausted(upstreamMsg string, responseBody []byte) bool {
 	haystack := strings.ToLower(strings.TrimSpace(upstreamMsg) + "\n" + strings.TrimSpace(string(responseBody)))
 	if strings.Contains(haystack, "quota exhausted on") {

--- a/backend/internal/service/ratelimit_service_tk_kiro_quota429_test.go
+++ b/backend/internal/service/ratelimit_service_tk_kiro_quota429_test.go
@@ -1,0 +1,63 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkIsKiroEndpointQuotaExhausted(t *testing.T) {
+	require.True(t, tkIsKiroEndpointQuotaExhausted("quota exhausted on AmazonQ", nil))
+	require.True(t, tkIsKiroEndpointQuotaExhausted("", []byte(`quota exhausted on Kiro Runtime`)))
+	require.True(t, tkIsKiroEndpointQuotaExhausted(tkKiroEndpointQuotaExhaustedClient, nil))
+	require.False(t, tkIsKiroEndpointQuotaExhausted("Upstream request failed", nil))
+	require.False(t, tkIsKiroEndpointQuotaExhausted("", []byte(`{"error":{"message":"slow down"}}`)))
+}
+
+func TestHandleUpstreamError_KiroEndpointQuotaExhausted_Uses10sCooldownNotLadder(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1, 2, 3, 4, 5}}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	account := newEdgeUS4KiroAccount()
+	body := []byte("quota exhausted on AmazonQ")
+	for i := 0; i < 5; i++ {
+		shouldDisable := svc.HandleUpstreamError(context.Background(), account, http.StatusBadGateway, nil, body)
+		require.True(t, shouldDisable, "iteration %d", i)
+	}
+
+	require.Equal(t, 5, repo.tempCalls, "each quota-exhausted hit must write a short cooldown")
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Empty(t, counter.incrementIDs, "must not advance anthropic_upstream_error 3/3 ladder")
+	require.Contains(t, repo.lastTempReason, tkKiroEndpointQuotaExhaustedReason)
+}
+
+func TestHandleUpstreamError_KiroMirrorStubQuotaExhausted429_SkipsAnthropicLadder(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1, 2, 3}}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	stub := &Account{
+		ID:       71,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": "kiro",
+		},
+	}
+	msg := tkKiroEndpointQuotaExhaustedClient
+	for i := 0; i < 3; i++ {
+		shouldDisable := svc.HandleUpstreamError(context.Background(), stub, http.StatusTooManyRequests, nil, []byte(msg))
+		require.True(t, shouldDisable, "iteration %d", i)
+	}
+
+	require.Equal(t, 3, repo.tempCalls)
+	require.Empty(t, counter.incrementIDs, "kiro mirror stub must not use anthropic 3/3 ladder on quota exhaustion")
+}

--- a/backend/internal/service/ratelimit_service_tk_kiro_quota429_test.go
+++ b/backend/internal/service/ratelimit_service_tk_kiro_quota429_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestTkIsKiroEndpointQuotaExhausted(t *testing.T) {
+	require.Equal(t, 10, KiroEndpointQuotaExhaustedRetryAfterSeconds())
 	require.True(t, tkIsKiroEndpointQuotaExhausted("quota exhausted on AmazonQ", nil))
 	require.True(t, tkIsKiroEndpointQuotaExhausted("", []byte(`quota exhausted on Kiro Runtime`)))
 	require.True(t, tkIsKiroEndpointQuotaExhausted(tkKiroEndpointQuotaExhaustedClient, nil))

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -475,6 +475,13 @@
       "rationale": "HandleUpstreamError case 402 must invoke the Kiro quota-limit companion before the generic Payment required → auth_error path so Kiro 402 reached-the-limit gets the dedicated P0 reason. An upstream merge that drops this call site re-buries the alert under auth_error or skips the matcher entirely."
     },
     {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "s.tkMaybeHandleKiroEndpointQuotaExhausted(ctx, account, upstreamMsg, responseBody)"
+      ],
+      "rationale": "HandleUpstreamError must short-circuit Kiro all-endpoint 429 quota exhaustion (edge OAuth + prod kiro mirror stubs) into the 10s tkHandleKiroEndpointQuotaExhausted path before the anthropic 3/3 ladder or generic 429 cooldown. Dropping this call site restores the 2026-07-01 prod kiro-us* 临时不可调度 flicker."
+    },
+    {
       "path": "backend/internal/service/ratelimit_service_tk_oauth401_test.go",
       "must_contain": [
         "TestRateLimitService_OAuth401_AnthropicAny401SetErrorsImmediately",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -244,7 +244,8 @@
       "must_contain": [
         "account.IsKiro()",
         "service.KiroInvalidModelError",
-        "service.KiroEndpointQuotaExhaustedError"
+        "service.KiroEndpointQuotaExhaustedError",
+        "service.KiroEndpointQuotaExhaustedRetryAfterSeconds()"
       ],
       "rationale": "The RPM-increment gate (both the streaming and non-streaming paths) admits kiro accounts via `|| account.IsKiro()`. An upstream merge that rewrites these gates must preserve the kiro arm, or kiro accounts skip RPM accounting and bypass the per-account rate limit. The KiroInvalidModelError errors.As branch returns a clean 400 invalid_request_error (no cross-account failover) when the Kiro upstream rejects the model; losing it reverts to the silent empty-200 / failover-churn behavior. The KiroEndpointQuotaExhaustedError branch returns 429+Retry-After:10 instead of a generic 502 when all Kiro upstream endpoints hit quota exhaustion."
     },
@@ -361,6 +362,7 @@
         "tkIsKiroEndpointQuotaExhausted",
         "tkHandleKiroEndpointQuotaExhausted",
         "tkKiroEndpointQuotaExhaustedCooldown",
+        "KiroEndpointQuotaExhaustedRetryAfterSeconds",
         "kiro_endpoint_quota_exhausted"
       ],
       "rationale": "Kiro upstream endpoint RPM exhaustion (all fallback hosts return 429; prod 2026-07-01 kiro-us3/4/5 mirror flicker) must apply a fixed 10s temp_unschedulable on edge Kiro OAuth accounts and prod kiro mirror stubs instead of advancing the anthropic_upstream_error 3/3 ladder (30s→2m→10m). Without this companion, brief subscription quota blips mislabel healthy relay stubs as failing and the admin UI shows frequent 临时不可调度."

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -183,6 +183,7 @@
       "must_contain": [
         "account.IsKiro()",
         "kiroGateway",
+        "KiroEndpointQuotaExhaustedError",
         "BillingTier:           optionalTrimmedStringPtr(result.BillingTier)",
         "setKiroInternalThinkingMirrorHopHeader",
         "parseKiroInternalThinkingSSECommentLine"
@@ -242,15 +243,18 @@
       "path": "backend/internal/handler/gateway_handler.go",
       "must_contain": [
         "account.IsKiro()",
-        "service.KiroInvalidModelError"
+        "service.KiroInvalidModelError",
+        "service.KiroEndpointQuotaExhaustedError"
       ],
-      "rationale": "The RPM-increment gate (both the streaming and non-streaming paths) admits kiro accounts via `|| account.IsKiro()`. An upstream merge that rewrites these gates must preserve the kiro arm, or kiro accounts skip RPM accounting and bypass the per-account rate limit. The KiroInvalidModelError errors.As branch returns a clean 400 invalid_request_error (no cross-account failover) when the Kiro upstream rejects the model; losing it reverts to the silent empty-200 / failover-churn behavior."
+      "rationale": "The RPM-increment gate (both the streaming and non-streaming paths) admits kiro accounts via `|| account.IsKiro()`. An upstream merge that rewrites these gates must preserve the kiro arm, or kiro accounts skip RPM accounting and bypass the per-account rate limit. The KiroInvalidModelError errors.As branch returns a clean 400 invalid_request_error (no cross-account failover) when the Kiro upstream rejects the model; losing it reverts to the silent empty-200 / failover-churn behavior. The KiroEndpointQuotaExhaustedError branch returns 429+Retry-After:10 instead of a generic 502 when all Kiro upstream endpoints hit quota exhaustion."
     },
     {
       "path": "backend/internal/service/kiro_gateway_service_tk_errors.go",
       "must_contain": [
         "type KiroInvalidModelError",
+        "type KiroEndpointQuotaExhaustedError",
         "func classifyKiroForwardError",
+        "quota exhausted on",
         "INVALID_MODEL_ID"
       ],
       "rationale": "TK-only typed error + classifier for the Kiro upstream HTTP 400 INVALID_MODEL_ID rejection. classifyKiroForwardError is called from both forwardStreaming and forwardNonStreaming; the handler errors.As-es the typed *KiroInvalidModelError to emit a model-scoped 400. Losing this file makes kiro model-unsupported errors fall back to the generic forward-error path (opaque 500 / unwanted failover)."
@@ -350,6 +354,24 @@
         "reached the limit"
       ],
       "rationale": "Kiro OAuth subscription quota exhaustion surfaces as HTTP 402 + 'You have reached the limit.' (prod 2026-06-25 edge-us4 account 9). This companion maps that verdict to reason kiro_quota_limit + SetError stop-scheduling + immediate Feishu P0. Without it, operators either get a mislabeled auth_error card or no alert when reproducing via admin account-test."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_kiro_quota429.go",
+      "must_contain": [
+        "tkIsKiroEndpointQuotaExhausted",
+        "tkHandleKiroEndpointQuotaExhausted",
+        "tkKiroEndpointQuotaExhaustedCooldown",
+        "kiro_endpoint_quota_exhausted"
+      ],
+      "rationale": "Kiro upstream endpoint RPM exhaustion (all fallback hosts return 429; prod 2026-07-01 kiro-us3/4/5 mirror flicker) must apply a fixed 10s temp_unschedulable on edge Kiro OAuth accounts and prod kiro mirror stubs instead of advancing the anthropic_upstream_error 3/3 ladder (30s→2m→10m). Without this companion, brief subscription quota blips mislabel healthy relay stubs as failing and the admin UI shows frequent 临时不可调度."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_kiro_quota429_test.go",
+      "must_contain": [
+        "TestHandleUpstreamError_KiroEndpointQuotaExhausted_Uses10sCooldownNotLadder",
+        "TestHandleUpstreamError_KiroMirrorStubQuotaExhausted429_SkipsAnthropicLadder"
+      ],
+      "rationale": "Regression guard: Kiro all-endpoint 429 quota exhaustion writes only the 10s short cooldown and never increments anthropic_upstream_error counter — on edge Kiro OAuth and prod kiro mirror stubs alike."
     },
     {
       "path": "backend/internal/service/account_test_service.go",


### PR DESCRIPTION
## 摘要

- Kiro 四路 upstream（Runtime/IDE/CodeWhisperer/AmazonQ）同时 quota exhausted 时，edge 改回 429 + Retry-After（与 10s cooldown 同源），不再伪装 502。
- Edge Kiro OAuth 与 prod kiro-us* mirror stub 均走 10s temp_unschedulable，不 increment anthropic_upstream_error 3/3 阶梯（30s→2m→10m）。
- 缓解 prod Admin「临时不可调度」频繁闪烁；edge OAuth 账号本身仍 healthy。

## 风险

- 常规风险：仅调整 Kiro 配额耗尽的错误分类与冷却策略；其它 upstream 错误路径不变。
- 429 语义更准确，客户端可依据 Retry-After 退避；10s 冷却短于原 ladder，failover 更快但可能更频繁重试同一 stub。

## 验证

- ./scripts/preflight.sh — PASS（含 pre-commit）
- cd backend && go test -tags=unit ./internal/service -run 'TestTkIsKiroEndpointQuotaExhausted|TestHandleUpstreamError_KiroEndpointQuotaExhausted|TestHandleUpstreamError_KiroMirrorStubQuotaExhausted|TestClassifyKiroForwardError' -count=1 — PASS

## 提交

- 20ad3afa3 fix(kiro): 全 endpoint 429 配额耗尽走 10s 短时冷却而非 3/3 阶梯
- 3ae468576 fix(kiro): Retry-After 与 10s cooldown 常量同源

最新提交：3ae468576
