### PR TITLE
fix(migrations): PR 阶段拦截已 ship migration 的 checksum 篡改

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -78,7 +78,7 @@ description: Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, ro
    - 数据层：Ent schema、migrations、repository、默认设置初始化。
    - 运维面：release/deploy workflow、Stage0 SSM primitive、Caddy/compose、smoke scripts、ops workflow。
    - 上游隔离：是否删除 upstream-owned 文件/route/method，是否触发 sentinel registry。
-6. 跑本地门禁：执行 `bash scripts/preflight.sh`；失败必须进入风险结论，不能给出“可放心发布”的结论。
+6. 跑本地门禁：执行 `bash scripts/preflight.sh`；失败必须进入风险结论，不能给出“可放心发布”的结论。其中 `migration immutability` 段会拦截对已合并 migration 文件的修改（典型症状：deploy 时 `checksum mismatch`）；应新建 `tk_NNN_*.sql` 而不是改旧文件。
 7. 输出中文结论，必须包含：
    - `范围`：`${PREV_TAG}..${NEW_REF}`、commit 数、主要提交。
    - `发布契约`：release/deploy/Docker/deps/VERSION 是否变化。

--- a/scripts/checks/migration-immutability.py
+++ b/scripts/checks/migration-immutability.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Gate modifications to already-shipped SQL migrations.
+
+Applied migrations record a SHA256 checksum in schema_migrations. Editing an
+existing file after merge causes startup failures such as:
+
+    migration tk_044_....sql checksum mismatch (db=... file=...)
+
+This check scans backend/migrations/*.sql changed between the merge base and
+HEAD. Modifications, deletions, and renames of files that already exist on the
+base ref are rejected. Add a NEW numbered migration instead.
+
+Emergency restore of a mistakenly edited migration is allowed only when the
+restored file content exactly matches a checksum already shipped on a release
+tag (typically reverting to the last good release).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+
+
+class Violation(NamedTuple):
+    kind: str
+    path: str
+    detail: str = ""
+
+
+def git(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def migration_checksum(content: str) -> str:
+    return hashlib.sha256(content.strip().encode()).hexdigest()
+
+
+def resolve_range(base: str | None, head: str) -> tuple[str | None, str | None]:
+    candidates: list[str] = []
+    if base:
+        candidates.append(base)
+    candidates.extend(["origin/main", "main", "HEAD^1", "HEAD^"])
+    for candidate in candidates:
+        if not candidate:
+            continue
+        if git("rev-parse", "--verify", candidate).returncode != 0:
+            continue
+        if git("merge-base", candidate, head).returncode == 0:
+            return candidate, head
+    return None, head
+
+
+def path_exists_at_ref(ref: str, rel_path: str) -> bool:
+    return git("cat-file", "-e", f"{ref}:{rel_path}").returncode == 0
+
+
+def list_release_tags() -> list[str]:
+    res = git("tag", "--list", "v*", "--sort=-v:refname")
+    if res.returncode != 0:
+        return []
+    return [tag for tag in res.stdout.splitlines() if RELEASE_TAG_RE.match(tag)]
+
+
+def release_tags_ancestor_of(ref: str) -> list[str]:
+    return [
+        tag
+        for tag in list_release_tags()
+        if git("merge-base", "--is-ancestor", tag, ref).returncode == 0
+    ]
+
+
+def release_checksums_for(rel_path: str, tags: list[str]) -> set[str]:
+    out: set[str] = set()
+    for tag in tags:
+        show = git("show", f"{tag}:{rel_path}")
+        if show.returncode != 0:
+            continue
+        out.add(migration_checksum(show.stdout))
+    return out
+
+
+def changed_migration_paths(base: str, head: str) -> list[tuple[str, str, str]]:
+    """Return tuples of (status, old_path, new_path)."""
+    res = git("diff", "--name-status", f"{base}..{head}", "--", "backend/migrations")
+    if res.returncode != 0:
+        raise RuntimeError(res.stderr.strip() or "git diff failed")
+    rows: list[tuple[str, str, str]] = []
+    for line in res.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        if status.startswith("R") and len(parts) >= 3:
+            rows.append((status, parts[1], parts[2]))
+        elif len(parts) >= 2:
+            rows.append((status, parts[1], parts[1]))
+    return rows
+
+def scan(base: str, head: str) -> list[Violation]:
+    violations: list[Violation] = []
+    shipped_tags = release_tags_ancestor_of(base)
+    for status, old_path, new_path in changed_migration_paths(base, head):
+        if not old_path.endswith(".sql"):
+            continue
+
+        if status.startswith("A"):
+            continue
+
+        if status.startswith("D"):
+            violations.append(
+                Violation("deleted", old_path, "applied migrations must not be deleted"),
+            )
+            continue
+
+        if status.startswith("R"):
+            if path_exists_at_ref(base, old_path):
+                violations.append(
+                    Violation(
+                        "renamed",
+                        old_path,
+                        f"renamed to {new_path}; create a new migration instead",
+                    ),
+                )
+            continue
+
+        if not status.startswith("M"):
+            continue
+
+        if not path_exists_at_ref(base, old_path):
+            continue
+
+        base_show = git("show", f"{base}:{old_path}")
+        head_show = git("show", f"{head}:{new_path}")
+        if base_show.returncode != 0 or head_show.returncode != 0:
+            violations.append(
+                Violation("modified", old_path, "could not read base/head contents"),
+            )
+            continue
+
+        base_sum = migration_checksum(base_show.stdout)
+        head_sum = migration_checksum(head_show.stdout)
+        if base_sum == head_sum:
+            continue
+
+        shipped = release_checksums_for(old_path, shipped_tags)
+        if head_sum in shipped:
+            continue
+
+        violations.append(
+            Violation(
+                "modified",
+                old_path,
+                f"checksum changed ({base_sum[:12]}… → {head_sum[:12]}…); add a new tk_NNN migration instead",
+            ),
+        )
+    return violations
+
+
+def selftest() -> int:
+    failures: list[str] = []
+
+    cases = [
+        ("empty", "", ""),
+        ("spaces", "  SELECT 1;\n", "SELECT 1;"),
+        ("comment", "-- hi\nSELECT 1;", "-- hi\nSELECT 1;"),
+    ]
+    for name, a, b in cases:
+        if migration_checksum(a) != migration_checksum(b):
+            failures.append(f"checksum trim mismatch: {name}")
+
+    if failures:
+        print("FAIL: migration-immutability selftest")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    print("ok: migration-immutability selftest")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", default=os.environ.get("PREFLIGHT_BASE"))
+    ap.add_argument("--head", default="HEAD")
+    ap.add_argument("--quiet", action="store_true")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    base, head = resolve_range(args.base, args.head)
+    if not base:
+        if not args.quiet:
+            print("skip: cannot resolve base ref for migration immutability check")
+        return 2
+
+    try:
+        violations = scan(base, head)
+    except RuntimeError as exc:
+        print(f"FAIL: migration immutability check: {exc}")
+        return 1
+
+    if violations:
+        print("FAIL: already-shipped SQL migrations must stay immutable")
+        for item in violations:
+            suffix = f" ({item.detail})" if item.detail else ""
+            print(f"  - {item.kind}: {item.path}{suffix}")
+        print(
+            "Create a new backend/migrations/tk_NNN_*.sql migration instead of editing an existing file."
+        )
+        print(
+            "Emergency restore: revert the file to content that matches a shipped release tag checksum."
+        )
+        return 1
+
+    if not args.quiet:
+        print(f"ok: no immutable migration edits in {base}..{head}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/checks/test_migration_immutability.py
+++ b/scripts/checks/test_migration_immutability.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Tests for scripts/checks/migration-immutability.py."""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+_MOD_PATH = pathlib.Path(__file__).resolve().parent / "migration-immutability.py"
+_spec = importlib.util.spec_from_file_location("migration_immutability", _MOD_PATH)
+mi = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+_spec.loader.exec_module(mi)
+
+
+class MigrationImmutabilityTest(unittest.TestCase):
+    def _init_repo(self, root: pathlib.Path) -> None:
+        subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "test"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+        )
+
+    def _commit_all(self, root: pathlib.Path, message: str) -> None:
+        subprocess.run(["git", "add", "-A"], cwd=root, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", message], cwd=root, check=True, capture_output=True)
+
+    def test_modified_existing_migration_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            mig_dir = root / "backend/migrations"
+            mig_dir.mkdir(parents=True)
+            path = mig_dir / "tk_001_seed.sql"
+            path.write_text("SELECT 1;\n")
+            self._init_repo(root)
+            self._commit_all(root, "base")
+            subprocess.run(["git", "tag", "v1.0.0"], cwd=root, check=True, capture_output=True)
+            path.write_text("SELECT 2;\n")
+            self._commit_all(root, "modify migration")
+            with mock.patch.object(mi, "ROOT", root):
+                violations = mi.scan("HEAD^", "HEAD")
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].kind, "modified")
+
+    def test_restore_to_shipped_checksum_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            mig_dir = root / "backend/migrations"
+            mig_dir.mkdir(parents=True)
+            path = mig_dir / "tk_001_seed.sql"
+            original = "SELECT 1;\n"
+            path.write_text(original)
+            self._init_repo(root)
+            self._commit_all(root, "base")
+            subprocess.run(["git", "tag", "v1.0.0"], cwd=root, check=True, capture_output=True)
+            path.write_text("SELECT 2;\n")
+            self._commit_all(root, "bad edit")
+            path.write_text(original)
+            self._commit_all(root, "restore")
+            with mock.patch.object(mi, "ROOT", root):
+                violations = mi.scan("HEAD~2", "HEAD")
+            self.assertEqual(violations, [])
+
+    def test_added_migration_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            mig_dir = root / "backend/migrations"
+            mig_dir.mkdir(parents=True)
+            (mig_dir / "tk_001_seed.sql").write_text("SELECT 1;\n")
+            self._init_repo(root)
+            self._commit_all(root, "base")
+            (mig_dir / "tk_002_more.sql").write_text("SELECT 2;\n")
+            self._commit_all(root, "add migration")
+            with mock.patch.object(mi, "ROOT", root):
+                violations = mi.scan("HEAD^", "HEAD")
+            self.assertEqual(violations, [])
+
+    def test_deleted_migration_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            mig_dir = root / "backend/migrations"
+            mig_dir.mkdir(parents=True)
+            path = mig_dir / "tk_001_seed.sql"
+            path.write_text("SELECT 1;\n")
+            self._init_repo(root)
+            self._commit_all(root, "base")
+            path.unlink()
+            self._commit_all(root, "delete migration")
+            with mock.patch.object(mi, "ROOT", root):
+                violations = mi.scan("HEAD^", "HEAD")
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].kind, "deleted")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1495,6 +1495,29 @@ else
 fi
 
 echo ""
+echo "=== sub2api: migration immutability ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for migration immutability)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/migration-immutability.py --selftest >/dev/null; then
+    echo "  FAIL: migration immutability selftest failed"
+    echo "        — run: python3 scripts/checks/migration-immutability.py --selftest"
+    errors=$((errors + 1))
+else
+    _mig_base="${PREFLIGHT_BASE:-origin/main}"
+    python3 ./scripts/checks/migration-immutability.py --base "${_mig_base}" --head HEAD --quiet
+    _mig_rc=$?
+    if [ "$_mig_rc" -eq 1 ]; then
+        errors=$((errors + 1))
+    elif [ "$_mig_rc" -eq 2 ]; then
+        echo "  skip: cannot resolve ${_mig_base}..HEAD (fetch origin/main); release deploy will fail on checksum mismatch"
+    else
+        echo "  ok: no edits to already-shipped SQL migrations"
+    fi
+    unset _mig_base _mig_rc
+fi
+
+echo ""
 echo "=== sub2api: Stage0 deploy tag-validation sharing ==="
 # The X.Y.Z(-rc.N/-beta.N) release-tag gate is a single shared script so the
 # three deploy workflows never grow divergent copies (the Lightsail copy had


### PR DESCRIPTION
## 摘要

- 新增 `scripts/checks/migration-immutability.py`：扫描 `origin/main..HEAD` 内对 `backend/migrations/*.sql` 的修改/删除/重命名；已合并 migration 被改内容则 preflight FAIL。
- 接入 `scripts/preflight.sh`（pre-commit + `backend-ci`），xj-review 跑 preflight 时会自动转成 blocking finding。
- 正确做法仍是新建 `tk_NNN_*.sql`；紧急回滚只允许恢复到 merge base 祖先 release tag 上曾 ship 过的 checksum。
- 文档说明放在 check 脚本 docstring 与 release-rollout skill（未改 `backend/migrations/README.md`，避免误触 high-risk-anchor）。

## 风险

- 低风险：纯门禁脚本 + skill 说明，无运行时行为变化。
- 误报面：若修改 migration 且内容不在任何已 ship release tag 上，会被拦——这正是预期。

## 验证

- `python3 scripts/checks/migration-immutability.py --selftest`
- `python3 scripts/checks/test_migration_immutability.py -v`
- 回放 v1.8.66..v1.8.67 → FAIL（`tk_044` checksum 变更）
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` → PASS

## 提交

- 89d3c9158 fix(migrations): block edited shipped SQL in preflight before deploy fails

最新提交：89d3c9158
