### PR TITLE
fix(grok): prod→edge 中继支持 responses 与 chat completions

### DIFF
--- a/backend/internal/server/routes/gateway_test.go
+++ b/backend/internal/server/routes/gateway_test.go
@@ -125,7 +125,24 @@ func TestGatewayRoutesImagePresignPathsAreRegistered(t *testing.T) {
 	}
 }
 
-func TestGatewayRoutesGrokOnlyAllowsResponsesHTTP(t *testing.T) {
+func TestGatewayRoutesGrokAllowsChatCompletions(t *testing.T) {
+	router := newGatewayRoutesTestRouter(service.PlatformGrok)
+
+	for _, path := range []string{
+		"/v1/chat/completions",
+		"/chat/completions",
+	} {
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"model":"grok-4.3","messages":[{"role":"user","content":"hi"}]}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+		require.NotEqual(t, http.StatusNotFound, w.Code, "path=%s should reach Chat Completions handler", path)
+		require.NotContains(t, w.Body.String(), "not supported for Grok groups")
+	}
+}
+
+func TestGatewayRoutesGrokRejectsUnsupportedOpenAICompatEndpoints(t *testing.T) {
 	router := newGatewayRoutesTestRouter(service.PlatformGrok)
 
 	for _, tc := range []struct {
@@ -133,8 +150,6 @@ func TestGatewayRoutesGrokOnlyAllowsResponsesHTTP(t *testing.T) {
 		path   string
 	}{
 		{http.MethodPost, "/v1/messages"},
-		{http.MethodPost, "/v1/chat/completions"},
-		{http.MethodPost, "/chat/completions"},
 		{http.MethodGet, "/v1/responses"},
 		{http.MethodGet, "/responses"},
 		{http.MethodGet, "/backend-api/codex/responses"},

--- a/backend/internal/server/routes/gateway_tk_openai_compat_handlers.go
+++ b/backend/internal/server/routes/gateway_tk_openai_compat_handlers.go
@@ -104,10 +104,6 @@ func tkOpenAICompatResponsesWebSocketGET(h *handler.Handlers) gin.HandlerFunc {
 
 func tkOpenAICompatChatCompletionsPOST(h *handler.Handlers) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if getGroupPlatform(c) == service.PlatformGrok {
-			rejectGrokUnsupportedEndpoint(c, "Chat Completions API")
-			return
-		}
 		if isOpenAICompatPlatform(getGroupPlatform(c)) {
 			h.OpenAIGateway.ChatCompletions(c)
 			return

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -25,10 +25,6 @@ func (s *OpenAIGatewayService) forwardGrokResponses(
 	reqStream bool,
 	startTime time.Time,
 ) (*OpenAIForwardResult, error) {
-	if account.Type != AccountTypeOAuth {
-		return nil, fmt.Errorf("grok account type %s is not supported by subscription forwarding", account.Type)
-	}
-
 	upstreamModel := account.GetMappedModel(originalModel)
 	if strings.TrimSpace(upstreamModel) == "" {
 		upstreamModel = "grok-4.3"
@@ -38,14 +34,18 @@ func (s *OpenAIGatewayService) forwardGrokResponses(
 		return nil, err
 	}
 
-	token, _, err := s.GetAccessToken(ctx, account)
+	targetURL, err := s.resolveGrokResponsesUpstream(account)
+	if err != nil {
+		return nil, err
+	}
+	token, err := s.grokResponsesAuthToken(ctx, account)
 	if err != nil {
 		return nil, err
 	}
 
 	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
 	defer releaseUpstreamCtx()
-	upstreamReq, err := buildGrokResponsesRequest(upstreamCtx, c, account, patchedBody, token)
+	upstreamReq, err := buildGrokResponsesRequest(upstreamCtx, c, targetURL, patchedBody, token)
 	if err != nil {
 		return nil, err
 	}
@@ -150,10 +150,56 @@ func patchGrokResponsesBody(body []byte, upstreamModel string) ([]byte, error) {
 	return out, nil
 }
 
-func buildGrokResponsesRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token string) (*http.Request, error) {
-	targetURL, err := xai.BuildResponsesURL(account.GetGrokBaseURL())
-	if err != nil {
-		return nil, err
+// resolveGrokResponsesUpstream returns the upstream POST URL for grok /responses.
+// OAuth accounts talk to xAI directly; apikey relay stubs forward to edge
+// OpenAI-compat /v1/responses (prod→edge mirror for grok-us4).
+func (s *OpenAIGatewayService) resolveGrokResponsesUpstream(account *Account) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("openai gateway service is nil")
+	}
+	if account == nil {
+		return "", fmt.Errorf("grok responses: account is nil")
+	}
+	switch {
+	case account.IsGrokOAuth():
+		return xai.BuildResponsesURL(account.GetGrokBaseURL())
+	case account.IsGrokAPIKey():
+		baseURL := account.GetOpenAIBaseURL()
+		if strings.TrimSpace(baseURL) == "" {
+			return "", fmt.Errorf("grok relay account %d missing base_url", account.ID)
+		}
+		validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+		if err != nil {
+			return "", err
+		}
+		return buildOpenAIResponsesURL(validatedURL), nil
+	default:
+		return "", fmt.Errorf("grok account type %s is not supported for responses forwarding", account.Type)
+	}
+}
+
+func (s *OpenAIGatewayService) grokResponsesAuthToken(ctx context.Context, account *Account) (string, error) {
+	if account == nil {
+		return "", fmt.Errorf("grok responses: account is nil")
+	}
+	switch {
+	case account.IsGrokOAuth():
+		token, _, err := s.GetAccessToken(ctx, account)
+		return token, err
+	case account.IsGrokAPIKey():
+		token := account.GetOpenAIApiKey()
+		if strings.TrimSpace(token) == "" {
+			return "", fmt.Errorf("grok relay account %d missing api_key", account.ID)
+		}
+		return token, nil
+	default:
+		return "", fmt.Errorf("grok account type %s is not supported for responses forwarding", account.Type)
+	}
+}
+
+func buildGrokResponsesRequest(ctx context.Context, c *gin.Context, targetURL string, body []byte, token string) (*http.Request, error) {
+	if strings.TrimSpace(targetURL) == "" {
+		return nil, fmt.Errorf("grok responses target URL is empty")
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
@@ -187,9 +233,13 @@ func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Contex
 	if s == nil || account == nil {
 		return
 	}
+	reasonUnauthorized := "grok oauth token unauthorized"
+	if account.IsGrokAPIKey() {
+		reasonUnauthorized = "grok relay api_key unauthorized"
+	}
 	switch statusCode {
 	case http.StatusUnauthorized:
-		s.tempUnscheduleGrok(ctx, account, 10*time.Minute, "grok oauth token unauthorized")
+		s.tempUnscheduleGrok(ctx, account, 10*time.Minute, reasonUnauthorized)
 	case http.StatusForbidden:
 		s.tempUnscheduleGrok(ctx, account, 30*time.Minute, "grok entitlement or subscription tier denied")
 	case http.StatusTooManyRequests:

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -39,9 +40,10 @@ func TestPatchGrokResponsesBodySetsMappedModelAndDropsUnsupportedFields(t *testi
 	require.Equal(t, "high", gjson.GetBytes(patched, "reasoning.effort").String())
 }
 
-func TestBuildGrokResponsesRequestUsesAccountBaseURLAndBearerToken(t *testing.T) {
+func TestBuildGrokResponsesRequestUsesResolvedOAuthTargetURL(t *testing.T) {
 	t.Setenv(xai.EnvAllowUnsafeURLOverrides, "true")
 
+	svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig()}
 	account := &Account{
 		Platform: PlatformGrok,
 		Type:     AccountTypeOAuth,
@@ -49,8 +51,11 @@ func TestBuildGrokResponsesRequestUsesAccountBaseURLAndBearerToken(t *testing.T)
 			"base_url": "https://xai.test/v1/",
 		},
 	}
+	targetURL, err := svc.resolveGrokResponsesUpstream(account)
+	require.NoError(t, err)
+	require.Equal(t, "https://xai.test/v1/responses", targetURL)
 
-	req, err := buildGrokResponsesRequest(context.Background(), nil, account, []byte(`{"model":"grok-4.3"}`), "access-token")
+	req, err := buildGrokResponsesRequest(context.Background(), nil, targetURL, []byte(`{"model":"grok-4.3"}`), "access-token")
 	require.NoError(t, err)
 	require.Equal(t, http.MethodPost, req.Method)
 	require.Equal(t, "https://xai.test/v1/responses", req.URL.String())
@@ -63,20 +68,33 @@ func TestBuildGrokResponsesRequestUsesAccountBaseURLAndBearerToken(t *testing.T)
 	require.Equal(t, `{"model":"grok-4.3"}`, strings.TrimSpace(string(data)))
 }
 
-func TestBuildGrokResponsesRequestRejectsUnsafeAccountBaseURL(t *testing.T) {
+func TestBuildGrokResponsesRequestRejectsEmptyTargetURL(t *testing.T) {
 	t.Parallel()
 
+	_, err := buildGrokResponsesRequest(context.Background(), nil, " ", []byte(`{"model":"grok-4.3"}`), "access-token")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "target URL is empty")
+}
+
+func TestResolveGrokResponsesUpstreamRejectsUnsafeRelayBaseURL(t *testing.T) {
+	t.Parallel()
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+		Enabled:       true,
+		UpstreamHosts: []string{"api-us4.tokenkey.dev", "api.x.ai"},
+	}}}}
 	account := &Account{
 		Platform: PlatformGrok,
-		Type:     AccountTypeOAuth,
+		Type:     AccountTypeAPIKey,
 		Credentials: map[string]any{
-			"base_url": "https://xai.test/v1",
+			"api_key":  "edge-grok-key",
+			"base_url": "https://evil.example.com",
 		},
 	}
 
-	_, err := buildGrokResponsesRequest(context.Background(), nil, account, []byte(`{"model":"grok-4.3"}`), "access-token")
+	_, err := svc.resolveGrokResponsesUpstream(account)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid base url")
+	require.Contains(t, err.Error(), "host is not allowed")
 }
 
 func TestForwardAsChatCompletionsForGrokUsesXAIChatCompletionsAndSnapshots(t *testing.T) {
@@ -204,6 +222,91 @@ func TestForwardGrokResponsesStreamingUsesXAIResponsesAndSnapshots(t *testing.T)
 	require.Contains(t, recorder.Header().Get("Content-Type"), "text/event-stream")
 	require.Contains(t, recorder.Body.String(), "response.output_text.delta")
 	require.NotNil(t, repo.updates[52][grokQuotaSnapshotExtraKey])
+}
+
+func TestResolveGrokResponsesUpstreamAPIKeyRelayUsesEdgeOpenAIResponses(t *testing.T) {
+	t.Parallel()
+
+	svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig()}
+	account := &Account{
+		ID:       65,
+		Platform: PlatformGrok,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "edge-grok-key",
+			"base_url": "https://api-us4.tokenkey.dev",
+		},
+	}
+
+	targetURL, err := svc.resolveGrokResponsesUpstream(account)
+	require.NoError(t, err)
+	require.Equal(t, "https://api-us4.tokenkey.dev/v1/responses", targetURL)
+
+	token, err := svc.grokResponsesAuthToken(context.Background(), account)
+	require.NoError(t, err)
+	require.Equal(t, "edge-grok-key", token)
+}
+
+func TestForwardGrokResponsesAPIKeyRelayUsesEdgeResponsesURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	body := []byte(`{"model":"grok-4.3","input":"hi","stream":true}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	account := &Account{
+		ID:          65,
+		Name:        "grok-us4",
+		Platform:    PlatformGrok,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "edge-grok-key",
+			"base_url": "https://api-us4.tokenkey.dev",
+		},
+	}
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","sequence_number":0,"delta":"ok"}`,
+		"",
+		`data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_edge","model":"grok-4.3","usage":{"input_tokens":3,"output_tokens":2}}}`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+		},
+		Body: io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.forwardGrokResponses(context.Background(), c, account, body, "grok-4.3", true, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, "https://api-us4.tokenkey.dev/v1/responses", upstream.lastReq.URL.String())
+	require.Equal(t, "Bearer edge-grok-key", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "grok-4.3", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.True(t, result.Stream)
+	require.Equal(t, "resp_edge", result.ResponseID)
+	require.Contains(t, recorder.Body.String(), "response.output_text.delta")
+}
+
+func TestForwardGrokResponsesRejectsUnsupportedAccountType(t *testing.T) {
+	t.Parallel()
+
+	svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig()}
+	account := &Account{
+		Platform: PlatformGrok,
+		Type:     "custom",
+	}
+
+	_, err := svc.resolveGrokResponsesUpstream(account)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not supported for responses forwarding")
 }
 
 func TestForwardAsChatCompletionsForGrokStreamingUsesRawXAIChatCompletions(t *testing.T) {

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -157,7 +157,7 @@
         "buildOpenAIResponsesURL",
         "defaultGrokTestModelID"
       ],
-      "rationale": "Grok-specific admin test companion: API-key relay stubs use GetOpenAIApiKey/GetOpenAIBaseURL against the edge via /v1/responses (grok groups reject /v1/chat/completions), OAuth grok uses GetGrokAccessToken/GetGrokBaseURL against api.x.ai /responses, and the requested model is normalized to a chat-capable grok default. Losing this file or reverting to chat-completions reintroduces the 404 'Chat Completions API is not supported for Grok groups' admin test failure."
+      "rationale": "Grok-specific admin test companion: API-key relay stubs use GetOpenAIApiKey/GetOpenAIBaseURL against the edge via /v1/responses; OAuth grok uses GetGrokAccessToken/GetGrokBaseURL against api.x.ai /responses; requested model is normalized to a chat-capable grok default. User-facing /v1/chat/completions is separately enabled via forwardAsRawChatCompletions — admin probe intentionally stays on /responses for OAuth parity."
     },
     {
       "path": "frontend/src/constants/gatewayPlatforms.ts",
@@ -342,6 +342,38 @@
         ".POST(\"/videos/generations\""
       ],
       "rationale": "The xAI-shaped video submit alias POST /videos/generations (plural videos + /generations), registered in BOTH the /v1 group and the no-prefix scope. This is the path grok's native arm POSTs to ({base}/videos/generations); the gateway's canonical video routes are /video/generations (singular) + /videos (no suffix), which do NOT match it. Without this alias the prod->edge grok video relay 404s at submit: a prod grok mirror account forwards to api-<edge>.tokenkey.dev/v1/videos/generations and the edge gateway has no such route (grok chat/image relay works only because /chat/completions and /images/generations already coincide with gateway routes). Losing this alias silently re-breaks the relay while direct-to-xAI still works, so no other test would catch it."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_grok.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) forwardGrokResponses",
+        "resolveGrokResponsesUpstream",
+        "grokResponsesAuthToken",
+        "buildOpenAIResponsesURL"
+      ],
+      "rationale": "Grok /v1/responses forwarding must support both native OAuth (xai.BuildResponsesURL + GetAccessToken) and prod→edge apikey relay stubs (GetOpenAIApiKey + buildOpenAIResponsesURL on edge base_url). Reverting to OAuth-only silently re-breaks prod grok-us4 universal-key grok-4.3 with 502 while edge OAuth still works."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_grok_test.go",
+      "must_contain": [
+        "TestForwardGrokResponsesAPIKeyRelayUsesEdgeResponsesURL",
+        "TestResolveGrokResponsesUpstreamAPIKeyRelayUsesEdgeOpenAIResponses"
+      ],
+      "rationale": "Load-bearing QA for grok responses apikey relay: pins edge /v1/responses URL + Bearer api_key on forwardGrokResponses. Revert to OAuth-only passes other tests but breaks prod grok-us4."
+    },
+    {
+      "path": "backend/internal/server/routes/gateway_test.go",
+      "must_contain": [
+        "TestGatewayRoutesGrokAllowsChatCompletions"
+      ],
+      "rationale": "Route-table guard: grok groups must reach OpenAIGateway.ChatCompletions (prod→edge relay uses forwardAsRawChatCompletions). Re-adding rejectGrokUnsupportedEndpoint for chat/completions silently breaks grok-cli/Codex clients that POST /v1/chat/completions while /v1/responses still works."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions_raw_test.go",
+      "must_contain": [
+        "TestForwardAsRawChatCompletions_GrokAPIKeyRelayUsesEdgeKeyAndBaseURL"
+      ],
+      "rationale": "Service-layer guard for prod grok-us4 apikey relay on /v1/chat/completions: pins edge base_url + api_key Bearer to /chat/completions. Route enablement alone is insufficient if this forward path regresses."
     },
     {
       "path": "backend/internal/service/grok_token_provider.go",


### PR DESCRIPTION
## 摘要

- `forwardGrokResponses` 支持 `grok-us4` 等 apikey 中继：prod 转发到 edge `/v1/responses`，Bearer 使用 edge `api_key`（OAuth 账号仍直连 xAI）。
- 放开 Grok 分组对 `POST /v1/chat/completions` 的路由 404 拦截，复用已有 `forwardAsRawChatCompletions`（apikey→edge `/v1/chat/completions`，OAuth→xAI）。
- 全能 Key + 空 `model_mapping` 下，edge OAuth 可访问的 grok 模型名原样透传。

## 风险

- 常规风险：公共网关行为变更（Grok 分组新增可用端点），无 schema/鉴权模型变化。
- prod `grok-us4` 若仍 `rate_limited=true` 或 edge OAuth 配额耗尽，用户仍可能 429/403（运维面，非本 PR 代码缺陷）。
- Messages API / Responses WebSocket / count_tokens 对 Grok 仍 404（未改）。

## 验证

```bash
./scripts/preflight.sh
cd backend && go test -tags=unit ./internal/service/ -run 'Grok|grok|RawChatCompletions_Grok' -count=1
cd backend && go test -tags=unit ./internal/server/routes/ -run 'Grok' -count=1
```

发版后 prod 建议用全能 Key 实测：

```bash
curl -sS https://api.tokenkey.dev/v1/responses \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"grok-4.3","input":"ping","stream":false}'

curl -sS https://api.tokenkey.dev/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"grok-4.3","messages":[{"role":"user","content":"ping"}],"stream":false}'
```

## 提交

- `7bd4525c7` fix(grok): prod→edge 中继支持 responses/chat completions

最新提交：7bd4525c7
