### PR TITLE
fix(grok): Studio 全能 Key 提交 grok-imagine-video 不再 403

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -11295,9 +11295,10 @@ func (s *GatewayService) GetAvailableModels(ctx context.Context, groupID *int64,
 			}
 		}
 	}
+	mergeGrokNativeCatalogModels(platform, modelSet)
 
-	// If no account has model_mapping, return nil (use default)
-	if !hasAnyMapping {
+	// If no account has model_mapping and no platform-native catalog merge, return nil (use default)
+	if !hasAnyMapping && len(modelSet) == 0 {
 		if s.modelsListCache != nil {
 			s.modelsListCache.Set(cacheKey, []string(nil), s.modelsListCacheTTL)
 			modelsListCacheStoreTotal.Add(1)

--- a/backend/internal/service/gateway_service_tk_grok_models.go
+++ b/backend/internal/service/gateway_service_tk_grok_models.go
@@ -1,0 +1,26 @@
+package service
+
+// mergeGrokNativeCatalogModels unions the curated grok served set into modelSet
+// for grok-platform groups. Native xAI OAuth accounts serve grok-imagine media and
+// probed chat ids through dedicated native arms regardless of chat-only
+// credentials.model_mapping entries (messages-dispatch aliases, claude→grok maps).
+// Without this union, GetAvailableModels / universal routing only see mapping keys
+// and Studio-advertised grok-imagine-video 403s with universal_no_entitled_group.
+func mergeGrokNativeCatalogModels(platform string, modelSet map[string]struct{}) {
+	if platform != PlatformGrok || len(supportedGrokCatalogModels) == 0 || modelSet == nil {
+		return
+	}
+	for id := range supportedGrokCatalogModels {
+		modelSet[id] = struct{}{}
+	}
+}
+
+// grokGroupServesNativeCatalogModel reports whether model is in the curated grok
+// native catalog that unrestricted OAuth arms serve without a channel whitelist.
+func grokGroupServesNativeCatalogModel(model string) bool {
+	if len(supportedGrokCatalogModels) == 0 {
+		return universalModelPlatformHint(model) == PlatformGrok
+	}
+	_, ok := supportedGrokCatalogModels[model]
+	return ok
+}

--- a/backend/internal/service/gateway_service_tk_grok_models_test.go
+++ b/backend/internal/service/gateway_service_tk_grok_models_test.go
@@ -1,0 +1,84 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+)
+
+func TestMergeGrokNativeCatalogModels_UnionsCuratedSet(t *testing.T) {
+	modelSet := map[string]struct{}{
+		"claude-sonnet-4-6": {},
+	}
+	mergeGrokNativeCatalogModels(PlatformGrok, modelSet)
+	if _, ok := modelSet["grok-imagine-video"]; !ok {
+		t.Fatal("expected grok-imagine-video in merged model set")
+	}
+	if _, ok := modelSet["claude-sonnet-4-6"]; !ok {
+		t.Fatal("expected existing mapping keys to be preserved")
+	}
+}
+
+func TestMergeGrokNativeCatalogModels_NoOpForOtherPlatforms(t *testing.T) {
+	modelSet := map[string]struct{}{"gpt-5": {}}
+	mergeGrokNativeCatalogModels(PlatformOpenAI, modelSet)
+	if _, ok := modelSet["grok-imagine-video"]; ok {
+		t.Fatal("openai platform must not pull grok catalog models")
+	}
+}
+
+func TestGetAvailableModels_GrokUnionsNativeCatalogWithChatMapping(t *testing.T) {
+	resetGatewayHotpathStatsForTest()
+	groupID := int64(60)
+	repo := &modelsListAccountRepoStub{
+		byGroup: map[int64][]Account{
+			groupID: {
+				{
+					ID:       1,
+					Platform: PlatformGrok,
+					Credentials: map[string]any{
+						"model_mapping": map[string]any{
+							"claude-sonnet-4-6": "grok-4.3",
+						},
+					},
+				},
+			},
+		},
+	}
+	svc := &GatewayService{
+		accountRepo:        repo,
+		modelsListCache:    gocache.New(time.Minute, time.Minute),
+		modelsListCacheTTL: time.Minute,
+	}
+	models := svc.GetAvailableModels(context.Background(), &groupID, PlatformGrok)
+	if len(models) == 0 {
+		t.Fatal("expected non-empty grok model list")
+	}
+	foundVideo := false
+	for _, m := range models {
+		if m == "grok-imagine-video" {
+			foundVideo = true
+			break
+		}
+	}
+	if !foundVideo {
+		t.Fatalf("grok GetAvailableModels must include grok-imagine-video, got %v", models)
+	}
+}
+
+func TestResolve_GrokImagineVideoWithChatOnlyMapping(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{grp(60, PlatformGrok, 0, false)}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		60: {"claude-sonnet-4-6", "grok-4.3"},
+	}))
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIVideo, "grok-imagine-video", "")
+	if err != nil || g == nil || g.Platform != PlatformGrok {
+		t.Fatalf("grok-imagine-video should resolve to grok group, got=%v err=%v", g, err)
+	}
+}

--- a/backend/internal/service/universal_routing_tk_serving.go
+++ b/backend/internal/service/universal_routing_tk_serving.go
@@ -33,7 +33,15 @@ func groupServesModel(ctx context.Context, provider availableModelsProvider, g G
 	served := provider(ctx, &gid, g.Platform)
 	if served != nil {
 		// 组有显式 model_mapping → 精确成员判定。
-		return modelInServedSet(model, served, g.Platform)
+		if modelInServedSet(model, served, g.Platform) {
+			return true
+		}
+		// Grok native OAuth: chat-only mapping entries must not hide the curated
+		// grok-imagine media + probed chat catalog that fillAccountFallback advertises.
+		if g.Platform == PlatformGrok && grokGroupServesNativeCatalogModel(model) {
+			return true
+		}
+		return false
 	}
 	// served == nil:native/permissive(无账号声明映射,或 provider 取数失败)。
 	if g.Platform == PlatformNewAPI {

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -337,6 +337,37 @@
       "rationale": "Load-bearing QA evidence for the grok-native video arm: resolveGrokVideoCredential pins OAuth vs prod→edge relay api_key (revert to access_token-only silently re-breaks prod grok-us4 video submit), the xAI status-enum -> videoTerminalOutcome mapping (drift would skip terminal-success retention or terminal-failure refund), and the submit acknowledgement shape (must carry TK's public task id, not the upstream request_id)."
     },
     {
+      "path": "backend/internal/service/gateway_service_tk_grok_models.go",
+      "must_contain": [
+        "func mergeGrokNativeCatalogModels",
+        "func grokGroupServesNativeCatalogModel",
+        "supportedGrokCatalogModels"
+      ],
+      "rationale": "Unions the curated grok native catalog (grok-imagine media + probed chat ids) into GetAvailableModels and universal routing service checks. Grok accounts with chat-only credentials.model_mapping (messages-dispatch aliases) otherwise advertise grok-imagine-video in Studio/pricing but universal keys 403 with universal_no_entitled_group at /v1/video/generations submit."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "mergeGrokNativeCatalogModels(platform, modelSet)"
+      ],
+      "rationale": "Injection point wiring mergeGrokNativeCatalogModels into GetAvailableModels after account model_mapping aggregation. Upstream merges of the models-list helper can drop this line and silently re-break grok-imagine-video universal routing while the companion file still compiles."
+    },
+    {
+      "path": "backend/internal/service/universal_routing_tk_serving.go",
+      "must_contain": [
+        "grokGroupServesNativeCatalogModel(model)"
+      ],
+      "rationale": "Universal routing must treat curated grok native catalog models as served even when GetAvailableModels returns a chat-only explicit mapping set; without this guard Studio-advertised grok-imagine-video fails before dispatch with No platform in your plan can serve model."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_grok_models_test.go",
+      "must_contain": [
+        "TestResolve_GrokImagineVideoWithChatOnlyMapping",
+        "TestGetAvailableModels_GrokUnionsNativeCatalogWithChatMapping"
+      ],
+      "rationale": "Regression guard for grok-imagine-video universal routing when grok groups carry chat-only model_mapping: both GetAvailableModels union and Resolve(ShapeOpenAIVideo) must stay aligned with the pricing-catalog advertised native catalog."
+    },
+    {
       "path": "backend/internal/server/routes/gateway_tk_openai_compat_handlers.go",
       "must_contain": [
         ".POST(\"/videos/generations\""


### PR DESCRIPTION
## 摘要

- 修复 Studio/BakeOff 使用全能 Key 提交 `grok-imagine-video` 时返回 `No platform in your plan can serve model "grok-imagine-video"` 的问题。
- Grok 组若仅有 chat 用的 `model_mapping`（如 messages-dispatch 别名），pricing catalog 仍会展示 grok-imagine 媒体模型，但 `GetAvailableModels` / universal routing 只认 mapping 键，导致路由 403。
- 将 `supportedGrokCatalogModels` 合并进 grok 组的可用模型集，并在 `groupServesModel` 对 native catalog 做兜底，与 pricing catalog / native video arm 行为对齐。

## 风险

- 常规风险：仅影响 grok 平台 + 全能 Key 的 universal 路由与 `/v1/models` 聚合；不改变 volcengine/newapi 视频路径。
- 若 grok 组本身不在用户权限跨度内，仍无法服务（行为正确）。

## 验证

```bash
cd backend && go test -tags unit ./internal/service -run 'TestMergeGrokNativeCatalogModels|TestGetAvailableModels_GrokUnions|TestResolve_GrokImagineVideo' -count=1
cd backend && go test -tags unit ./internal/service -run 'TestResolve_' -count=1
./scripts/preflight.sh
```

- 上述测试与 preflight 均已通过。

## 提交

- `2f68514d2` fix(grok): 全能 Key 路由 grok-imagine-video 与 native catalog 对齐
- `9f9169614` chore(grok): 锚定 grok native catalog 与 universal 路由修复面

最新提交：9f9169614
