### PR TITLE
feat(admin): unify model-mapping preset SSOT endpoint for account onboarding

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -2086,8 +2086,15 @@ func (h *AccountHandler) GetAvailableModels(c *gin.Context) {
 		mapping := account.GetModelMapping()
 		if len(mapping) == 0 {
 			if account.ChannelType == newapiconstant.ChannelTypeVertexAi {
-				ids := service.VertexNewAPIChannelServableModelIDs()
-				sort.Strings(ids)
+				ids, err := h.adminService.GetAccountModelMappingPresetIDs(
+					c.Request.Context(),
+					service.PlatformNewAPI,
+					account.ChannelType,
+				)
+				if err != nil {
+					response.Error(c, http.StatusInternalServerError, "failed to resolve model mapping preset")
+					return
+				}
 				models := make([]openai.Model, 0, len(ids))
 				for _, id := range ids {
 					models = append(models, openai.Model{

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -28,7 +28,6 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
-	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/gin-gonic/gin"
 	"golang.org/x/sync/errgroup"
 )
@@ -2085,16 +2084,16 @@ func (h *AccountHandler) GetAvailableModels(c *gin.Context) {
 	if account.Platform == service.PlatformNewAPI {
 		mapping := account.GetModelMapping()
 		if len(mapping) == 0 {
-			if account.ChannelType == newapiconstant.ChannelTypeVertexAi {
-				ids, err := h.adminService.GetAccountModelMappingPresetIDs(
-					c.Request.Context(),
-					service.PlatformNewAPI,
-					account.ChannelType,
-				)
-				if err != nil {
-					response.Error(c, http.StatusInternalServerError, "failed to resolve model mapping preset")
-					return
-				}
+			ids, err := h.adminService.GetAccountModelMappingPresetIDs(
+				c.Request.Context(),
+				service.PlatformNewAPI,
+				account.ChannelType,
+			)
+			if err != nil {
+				response.Error(c, http.StatusInternalServerError, "failed to resolve model mapping preset")
+				return
+			}
+			if len(ids) > 0 {
 				models := make([]openai.Model, 0, len(ids))
 				for _, id := range ids {
 					models = append(models, openai.Model{

--- a/backend/internal/handler/admin/account_handler_tk_model_mapping_preset.go
+++ b/backend/internal/handler/admin/account_handler_tk_model_mapping_preset.go
@@ -1,0 +1,62 @@
+package admin
+
+import (
+	"strconv"
+	"strings"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+var accountModelMappingPresetPlatforms = map[string]struct{}{
+	service.PlatformAnthropic:   {},
+	service.PlatformOpenAI:      {},
+	service.PlatformGemini:      {},
+	service.PlatformAntigravity: {},
+	service.PlatformGrok:        {},
+	service.PlatformKiro:        {},
+	service.PlatformNewAPI:      {},
+}
+
+// GetModelMappingPresets returns empirically verified model_mapping preset IDs.
+// GET /api/v1/admin/accounts/model-mapping-presets?platform=grok&channel_type=0
+func (h *AccountHandler) GetModelMappingPresets(c *gin.Context) {
+	platform := strings.TrimSpace(strings.ToLower(c.Query("platform")))
+	if platform == "claude" {
+		platform = service.PlatformAnthropic
+	}
+	if platform == "xai" {
+		platform = service.PlatformGrok
+	}
+	if platform == "" {
+		response.ErrorFrom(c, infraerrors.BadRequest("VALIDATION_ERROR", "platform is required"))
+		return
+	}
+	if _, ok := accountModelMappingPresetPlatforms[platform]; !ok {
+		response.ErrorFrom(c, infraerrors.BadRequest("INVALID_PLATFORM", "unsupported platform"))
+		return
+	}
+
+	channelType := 0
+	if raw := strings.TrimSpace(c.Query("channel_type")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			response.ErrorFrom(c, infraerrors.BadRequest("VALIDATION_ERROR", "invalid channel_type"))
+			return
+		}
+		channelType = parsed
+	}
+
+	ids, err := h.adminService.GetAccountModelMappingPresetIDs(c.Request.Context(), platform, channelType)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	if ids == nil {
+		ids = []string{}
+	}
+	response.Success(c, gin.H{"model_ids": ids})
+}

--- a/backend/internal/handler/admin/account_handler_tk_model_mapping_preset_test.go
+++ b/backend/internal/handler/admin/account_handler_tk_model_mapping_preset_test.go
@@ -1,0 +1,76 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func setupModelMappingPresetsRouter(adminSvc service.AdminService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewAccountHandler(
+		adminSvc,
+		nil, nil, nil, nil,
+		nil, nil, nil, nil, nil,
+		nil, nil, nil, nil,
+	)
+	router.GET("/api/v1/admin/accounts/model-mapping-presets", handler.GetModelMappingPresets)
+	return router
+}
+
+func TestGetModelMappingPresets_Grok(t *testing.T) {
+	router := setupModelMappingPresetsRouter(newStubAdminService())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/accounts/model-mapping-presets?platform=grok", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data struct {
+			ModelIDs []string `json:"model_ids"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.Data.ModelIDs)
+	require.Contains(t, resp.Data.ModelIDs, service.GrokDefaultTestModelID)
+}
+
+func TestGetModelMappingPresets_NewAPIVertex(t *testing.T) {
+	router := setupModelMappingPresetsRouter(newStubAdminService())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/admin/accounts/model-mapping-presets?platform=newapi&channel_type="+strconv.Itoa(newapiconstant.ChannelTypeVertexAi),
+		nil,
+	)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data struct {
+			ModelIDs []string `json:"model_ids"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Contains(t, resp.Data.ModelIDs, "gemini-2.5-flash")
+}
+
+func TestGetModelMappingPresets_InvalidPlatform(t *testing.T) {
+	router := setupModelMappingPresetsRouter(newStubAdminService())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/accounts/model-mapping-presets?platform=unknown", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/backend/internal/handler/admin/account_handler_tk_model_mapping_preset_test.go
+++ b/backend/internal/handler/admin/account_handler_tk_model_mapping_preset_test.go
@@ -65,6 +65,28 @@ func TestGetModelMappingPresets_NewAPIVertex(t *testing.T) {
 	require.Contains(t, resp.Data.ModelIDs, "gemini-2.5-flash")
 }
 
+func TestGetModelMappingPresets_NewAPIDeepSeek(t *testing.T) {
+	router := setupModelMappingPresetsRouter(newStubAdminService())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/admin/accounts/model-mapping-presets?platform=newapi&channel_type="+strconv.Itoa(newapiconstant.ChannelTypeDeepSeek),
+		nil,
+	)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Data struct {
+			ModelIDs []string `json:"model_ids"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Contains(t, resp.Data.ModelIDs, "deepseek-chat")
+}
+
 func TestGetModelMappingPresets_InvalidPlatform(t *testing.T) {
 	router := setupModelMappingPresetsRouter(newStubAdminService())
 

--- a/backend/internal/handler/admin/admin_service_stub_test.go
+++ b/backend/internal/handler/admin/admin_service_stub_test.go
@@ -280,6 +280,10 @@ func (s *stubAdminService) GetGroupModelsListCandidates(ctx context.Context, id 
 	return []string{"claude-sonnet-4-6"}, nil
 }
 
+func (s *stubAdminService) GetAccountModelMappingPresetIDs(ctx context.Context, platform string, channelType int) ([]string, error) {
+	return service.AccountModelMappingPresetIDs(ctx, platform, channelType, nil), nil
+}
+
 func (s *stubAdminService) CreateGroup(ctx context.Context, input *service.CreateGroupInput) (*service.Group, error) {
 	group := service.Group{ID: 200, Name: input.Name, Status: service.StatusActive}
 	return &group, nil

--- a/backend/internal/handler/admin/channel_handler_tk_newapi_admin.go
+++ b/backend/internal/handler/admin/channel_handler_tk_newapi_admin.go
@@ -142,9 +142,18 @@ func (h *TKChannelAdminHandler) ListChannelTypes(c *gin.Context) {
 // GET /api/v1/admin/channel-type-models
 func (h *TKChannelAdminHandler) ListChannelTypeModels(c *gin.Context) {
 	out := newapifusion.ChannelTypeModelsJSON()
-	if ids := service.VertexNewAPIChannelServableModelIDs(); len(ids) > 0 {
-		sort.Strings(ids)
-		out[strconv.Itoa(newapiconstant.ChannelTypeVertexAi)] = ids
+	vertexIDs := service.VertexNewAPIChannelServableModelIDs()
+	if h.adminService != nil {
+		if ids, err := h.adminService.GetAccountModelMappingPresetIDs(
+			c.Request.Context(),
+			service.PlatformNewAPI,
+			newapiconstant.ChannelTypeVertexAi,
+		); err == nil && len(ids) > 0 {
+			vertexIDs = ids
+		}
+	}
+	if len(vertexIDs) > 0 {
+		out[strconv.Itoa(newapiconstant.ChannelTypeVertexAi)] = vertexIDs
 	}
 	response.Success(c, out)
 }
@@ -173,7 +182,18 @@ func (h *TKChannelAdminHandler) FetchUpstreamModels(c *gin.Context) {
 	// Return TokenKey's empirical Gemini/Vertex servable preset instead.
 	if req.ChannelType == newapiconstant.ChannelTypeVertexAi {
 		ids := service.VertexNewAPIChannelServableModelIDs()
-		sort.Strings(ids)
+		if h.adminService != nil {
+			var err error
+			ids, err = h.adminService.GetAccountModelMappingPresetIDs(
+				c.Request.Context(),
+				service.PlatformNewAPI,
+				newapiconstant.ChannelTypeVertexAi,
+			)
+			if err != nil {
+				response.Error(c, http.StatusInternalServerError, "failed to resolve model mapping preset")
+				return
+			}
+		}
 		models := h.discoveryFilter.Apply(
 			c.Request.Context(),
 			service.PlatformGemini,

--- a/backend/internal/handler/admin/channel_handler_tk_newapi_admin.go
+++ b/backend/internal/handler/admin/channel_handler_tk_newapi_admin.go
@@ -142,18 +142,27 @@ func (h *TKChannelAdminHandler) ListChannelTypes(c *gin.Context) {
 // GET /api/v1/admin/channel-type-models
 func (h *TKChannelAdminHandler) ListChannelTypeModels(c *gin.Context) {
 	out := newapifusion.ChannelTypeModelsJSON()
-	vertexIDs := service.VertexNewAPIChannelServableModelIDs()
-	if h.adminService != nil {
-		if ids, err := h.adminService.GetAccountModelMappingPresetIDs(
-			c.Request.Context(),
-			service.PlatformNewAPI,
-			newapiconstant.ChannelTypeVertexAi,
-		); err == nil && len(ids) > 0 {
-			vertexIDs = ids
+	ctx := c.Request.Context()
+	overlayPreset := func(channelType int) {
+		var ids []string
+		if h.adminService != nil {
+			var err error
+			ids, err = h.adminService.GetAccountModelMappingPresetIDs(ctx, service.PlatformNewAPI, channelType)
+			if err != nil {
+				return
+			}
+		} else if channelType == newapiconstant.ChannelTypeVertexAi {
+			ids = service.VertexNewAPIChannelServableModelIDs()
+		} else {
+			ids = service.NewAPIModelMappingPresetIDsForChannelType(channelType)
+		}
+		if len(ids) > 0 {
+			out[strconv.Itoa(channelType)] = ids
 		}
 	}
-	if len(vertexIDs) > 0 {
-		out[strconv.Itoa(newapiconstant.ChannelTypeVertexAi)] = vertexIDs
+	overlayPreset(newapiconstant.ChannelTypeVertexAi)
+	for _, ct := range service.NewAPIManifestPresetChannelTypes() {
+		overlayPreset(ct)
 	}
 	response.Success(c, out)
 }

--- a/backend/internal/handler/admin/channel_handler_tk_vertex_models_test.go
+++ b/backend/internal/handler/admin/channel_handler_tk_vertex_models_test.go
@@ -37,6 +37,29 @@ func TestListChannelTypeModels_VertexAIUsesTokenKeyServablePreset(t *testing.T) 
 	require.Contains(t, resp.Data["41"], "imagen-4.0-fast-generate-001")
 }
 
+func TestListChannelTypeModels_ManifestChannelsUseTokenKeyPresets(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewTKChannelAdminHandler(nil, newStubAdminService(), nil, nil)
+	router := gin.New()
+	router.GET("/channel-type-models", h.ListChannelTypeModels)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/channel-type-models", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Data map[string][]string `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	require.Contains(t, resp.Data["43"], "deepseek-chat")
+	require.Contains(t, resp.Data["17"], "qwen3.7-max")
+	require.Contains(t, resp.Data["26"], "glm-5-turbo")
+	require.Contains(t, resp.Data["45"], "doubao-seed-2-0-pro-260215")
+}
+
 func TestFetchUpstreamModels_VertexAIDoesNotRequireAPIKey(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	h := NewTKChannelAdminHandler(nil, nil, nil, nil)

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -311,6 +311,7 @@ func registerAccountRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 	accounts := admin.Group("/accounts")
 	{
 		accounts.GET("", h.Admin.Account.List)
+		accounts.GET("/model-mapping-presets", h.Admin.Account.GetModelMappingPresets)
 		accounts.GET("/:id", h.Admin.Account.GetByID)
 		accounts.POST("", h.Admin.Account.Create)
 		accounts.POST("/check-mixed-channel", h.Admin.Account.CheckMixedChannel)

--- a/backend/internal/service/account_model_mapping_preset_tk.go
+++ b/backend/internal/service/account_model_mapping_preset_tk.go
@@ -24,6 +24,8 @@ func AccountModelMappingPresetIDs(ctx context.Context, platform string, channelT
 	case PlatformNewAPI:
 		if channelType == newapiconstant.ChannelTypeVertexAi {
 			ids = supportedCatalogModelIDsForPlatform(PlatformGemini)
+		} else {
+			ids = tkServedModelsManifestPresetIDsByChannelType(channelType)
 		}
 	default:
 		return nil
@@ -33,6 +35,24 @@ func AccountModelMappingPresetIDs(ctx context.Context, platform string, channelT
 	}
 	sort.Strings(ids)
 	return ids
+}
+
+// NewAPIModelMappingPresetIDsForChannelType exposes preset lookup for handlers
+// that cannot reach AdminService (tests, nil adminService fallback).
+func NewAPIModelMappingPresetIDsForChannelType(channelType int) []string {
+	return AccountModelMappingPresetIDs(context.Background(), PlatformNewAPI, channelType, nil)
+}
+
+// NewAPIManifestPresetChannelTypes returns channel_type values with TK-verified
+// presets in tk_served_models.json (excludes Vertex ch41, which uses Gemini catalog).
+func NewAPIManifestPresetChannelTypes() []int {
+	loadTkServedModelsManifest()
+	out := make([]int, 0, len(tkServedModelsManifestIDsByChannelType))
+	for ct := range tkServedModelsManifestIDsByChannelType {
+		out = append(out, ct)
+	}
+	sort.Ints(out)
+	return out
 }
 
 func normalizeAccountModelMappingPresetPlatform(platform string) string {

--- a/backend/internal/service/account_model_mapping_preset_tk.go
+++ b/backend/internal/service/account_model_mapping_preset_tk.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
+// AccountModelMappingPresetIDs returns TokenKey's empirically verified model IDs
+// for admin account model_mapping auto-fill (Create/Edit when mapping is empty).
+// Native platforms share tkServableCandidateIDs with the group selector; grok/kiro
+// and newapi ch41 (Vertex SA) use their platform-specific servable sets. Other
+// newapi channel types return empty — no TK-verified preset without upstream fetch.
+func AccountModelMappingPresetIDs(ctx context.Context, platform string, channelType int, availability MePricingAvailability) []string {
+	platform = normalizeAccountModelMappingPresetPlatform(platform)
+	var ids []string
+	switch platform {
+	case PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity, PlatformGrok:
+		ids = tkServableCandidateIDs(ctx, platform, availability)
+	case PlatformKiro:
+		ids = kiroModelMappingPresetIDs()
+	case PlatformNewAPI:
+		if channelType == newapiconstant.ChannelTypeVertexAi {
+			ids = supportedCatalogModelIDsForPlatform(PlatformGemini)
+		}
+	default:
+		return nil
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func normalizeAccountModelMappingPresetPlatform(platform string) string {
+	platform = strings.TrimSpace(strings.ToLower(platform))
+	if platform == "claude" {
+		return PlatformAnthropic
+	}
+	if platform == "xai" {
+		return PlatformGrok
+	}
+	return platform
+}
+
+func kiroModelMappingPresetIDs() []string {
+	models := KiroAdminTestModels()
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		id := strings.TrimSpace(m.ID)
+		if id == "" {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/backend/internal/service/account_model_mapping_preset_tk_test.go
+++ b/backend/internal/service/account_model_mapping_preset_tk_test.go
@@ -39,8 +39,39 @@ func TestAccountModelMappingPresetIDs_NewAPIVertexMatchesGeminiServable(t *testi
 
 func TestAccountModelMappingPresetIDs_NewAPIOtherChannelEmpty(t *testing.T) {
 	t.Parallel()
-	ids := AccountModelMappingPresetIDs(context.Background(), PlatformNewAPI, newapiconstant.ChannelTypeDeepSeek, nil)
+	// Moonshot (25) is not in tk_served_models manifest — no TK-verified preset.
+	ids := AccountModelMappingPresetIDs(context.Background(), PlatformNewAPI, 25, nil)
 	require.Empty(t, ids)
+}
+
+func TestAccountModelMappingPresetIDs_NewAPIDeepSeekUsesManifest(t *testing.T) {
+	t.Parallel()
+	ids := AccountModelMappingPresetIDs(context.Background(), PlatformNewAPI, newapiconstant.ChannelTypeDeepSeek, nil)
+	require.NotEmpty(t, ids)
+	require.Contains(t, ids, "deepseek-chat")
+	require.Contains(t, ids, "deepseek-v4-pro")
+}
+
+func TestAccountModelMappingPresetIDs_NewAPIAliUsesManifest(t *testing.T) {
+	t.Parallel()
+	ids := AccountModelMappingPresetIDs(context.Background(), PlatformNewAPI, newapiconstant.ChannelTypeAli, nil)
+	require.NotEmpty(t, ids)
+	require.Contains(t, ids, "qwen3.7-max")
+}
+
+func TestAccountModelMappingPresetIDs_NewAPIZhipuV4UsesManifest(t *testing.T) {
+	t.Parallel()
+	ids := AccountModelMappingPresetIDs(context.Background(), PlatformNewAPI, newapiconstant.ChannelTypeZhipu_v4, nil)
+	require.NotEmpty(t, ids)
+	require.Contains(t, ids, "glm-5-turbo")
+	require.NotContains(t, ids, "qwen3.7-max")
+}
+
+func TestAccountModelMappingPresetIDs_NewAPIVolcEngineUsesManifest(t *testing.T) {
+	t.Parallel()
+	ids := AccountModelMappingPresetIDs(context.Background(), PlatformNewAPI, newapiconstant.ChannelTypeVolcEngine, nil)
+	require.NotEmpty(t, ids)
+	require.Contains(t, ids, "doubao-seed-2-0-pro-260215")
 }
 
 func TestAccountModelMappingPresetIDs_UnknownPlatformEmpty(t *testing.T) {

--- a/backend/internal/service/account_model_mapping_preset_tk_test.go
+++ b/backend/internal/service/account_model_mapping_preset_tk_test.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountModelMappingPresetIDs_GrokUsesServableCatalog(t *testing.T) {
+	t.Parallel()
+	ids := AccountModelMappingPresetIDs(context.Background(), PlatformGrok, 0, nil)
+	require.NotEmpty(t, ids)
+	require.Contains(t, ids, GrokDefaultTestModelID)
+	for _, id := range ids {
+		require.Contains(t, supportedGrokCatalogModels, id)
+	}
+}
+
+func TestAccountModelMappingPresetIDs_KiroUsesAdminTestModels(t *testing.T) {
+	t.Parallel()
+	ids := AccountModelMappingPresetIDs(context.Background(), PlatformKiro, 0, nil)
+	want := make([]string, 0, len(KiroAdminTestModels()))
+	for _, m := range KiroAdminTestModels() {
+		want = append(want, m.ID)
+	}
+	require.ElementsMatch(t, want, ids)
+}
+
+func TestAccountModelMappingPresetIDs_NewAPIVertexMatchesGeminiServable(t *testing.T) {
+	t.Parallel()
+	ids := AccountModelMappingPresetIDs(context.Background(), PlatformNewAPI, newapiconstant.ChannelTypeVertexAi, nil)
+	require.NotEmpty(t, ids)
+	require.Contains(t, ids, "gemini-2.5-flash")
+	require.Contains(t, ids, "imagen-4.0-fast-generate-001")
+	require.ElementsMatch(t, VertexNewAPIChannelServableModelIDs(), ids)
+}
+
+func TestAccountModelMappingPresetIDs_NewAPIOtherChannelEmpty(t *testing.T) {
+	t.Parallel()
+	ids := AccountModelMappingPresetIDs(context.Background(), PlatformNewAPI, newapiconstant.ChannelTypeDeepSeek, nil)
+	require.Empty(t, ids)
+}
+
+func TestAccountModelMappingPresetIDs_UnknownPlatformEmpty(t *testing.T) {
+	t.Parallel()
+	require.Empty(t, AccountModelMappingPresetIDs(context.Background(), "totally-unknown", 0, nil))
+}
+
+func TestAccountModelMappingPresetIDs_ClaudeAliasMatchesAnthropic(t *testing.T) {
+	t.Parallel()
+	require.Equal(
+		t,
+		AccountModelMappingPresetIDs(context.Background(), PlatformAnthropic, 0, nil),
+		AccountModelMappingPresetIDs(context.Background(), "claude", 0, nil),
+	)
+}

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -58,6 +58,7 @@ type AdminService interface {
 	GetAllGroupsIncludingInactive(ctx context.Context) ([]Group, error)
 	GetGroup(ctx context.Context, id int64) (*Group, error)
 	GetGroupModelsListCandidates(ctx context.Context, id int64, platform string) ([]string, error)
+	GetAccountModelMappingPresetIDs(ctx context.Context, platform string, channelType int) ([]string, error)
 	CreateGroup(ctx context.Context, input *CreateGroupInput) (*Group, error)
 	UpdateGroup(ctx context.Context, id int64, input *UpdateGroupInput) (*Group, error)
 	DeleteGroup(ctx context.Context, id int64) error
@@ -1869,6 +1870,12 @@ func (s *adminServiceImpl) GetGroupModelsListCandidates(ctx context.Context, id 
 		}
 	}
 	return candidates, nil
+}
+
+func (s *adminServiceImpl) GetAccountModelMappingPresetIDs(ctx context.Context, platform string, channelType int) ([]string, error) {
+	ids := AccountModelMappingPresetIDs(ctx, platform, channelType, s.availability)
+	sort.Strings(ids)
+	return ids, nil
 }
 
 func defaultModelsListCandidateIDs(platform string) []string {

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -1,5 +1,11 @@
 package service
 
+import (
+	"context"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
 // TokenKey: the empirically-servable claude + gpt model sets, shared by the
 // public /pricing catalog (isPublicCatalogModelSupported) and the per-user
 // "Your Menu" unrestricted-account fallback (supportedCatalogModelIDsForPlatform).
@@ -363,8 +369,8 @@ func supportedCatalogModelIDsForPlatform(platform string) []string {
 
 // VertexNewAPIChannelServableModelIDs returns TokenKey's empirically verified
 // Gemini/Vertex wire IDs for newapi channel_type 41 (Vertex SA bridge). Admin
-// UIs use this as the preset model_mapping list — same SSOT as
-// supportedGeminiCatalogModels / public catalog gemini gate.
+// UIs use this as the preset model_mapping list — delegated to
+// AccountModelMappingPresetIDs (single SSOT).
 func VertexNewAPIChannelServableModelIDs() []string {
-	return supportedCatalogModelIDsForPlatform(PlatformGemini)
+	return AccountModelMappingPresetIDs(context.Background(), PlatformNewAPI, newapiconstant.ChannelTypeVertexAi, nil)
 }

--- a/backend/internal/service/tk_served_models_manifest_tk.go
+++ b/backend/internal/service/tk_served_models_manifest_tk.go
@@ -28,9 +28,9 @@ type tkServedModelsManifestEntry struct {
 }
 
 var (
-	tkServedModelsManifestOnce              sync.Once
-	tkServedModelsManifestIDs               map[string]struct{}
-	tkServedModelsManifestIDsByChannelType  map[int][]string
+	tkServedModelsManifestOnce             sync.Once
+	tkServedModelsManifestIDs              map[string]struct{}
+	tkServedModelsManifestIDsByChannelType map[int][]string
 )
 
 func loadTkServedModelsManifestIDs() map[string]struct{} {

--- a/backend/internal/service/tk_served_models_manifest_tk.go
+++ b/backend/internal/service/tk_served_models_manifest_tk.go
@@ -3,6 +3,7 @@ package service
 import (
 	_ "embed"
 	"encoding/json"
+	"sort"
 	"sync"
 )
 
@@ -22,31 +23,72 @@ type tkServedModelsManifestFile struct {
 }
 
 type tkServedModelsManifestEntry struct {
-	ModelID string `json:"model_id"`
+	ModelID     string `json:"model_id"`
+	ChannelType int    `json:"channel_type"`
 }
 
 var (
-	tkServedModelsManifestOnce sync.Once
-	tkServedModelsManifestIDs  map[string]struct{}
+	tkServedModelsManifestOnce              sync.Once
+	tkServedModelsManifestIDs               map[string]struct{}
+	tkServedModelsManifestIDsByChannelType  map[int][]string
 )
 
 func loadTkServedModelsManifestIDs() map[string]struct{} {
+	loadTkServedModelsManifest()
+	return tkServedModelsManifestIDs
+}
+
+func loadTkServedModelsManifest() {
 	tkServedModelsManifestOnce.Do(func() {
 		var doc tkServedModelsManifestFile
 		if err := json.Unmarshal(tkServedModelsManifestRaw, &doc); err != nil {
 			tkServedModelsManifestIDs = map[string]struct{}{}
+			tkServedModelsManifestIDsByChannelType = map[int][]string{}
 			return
 		}
 		out := make(map[string]struct{}, len(doc.Entries))
+		byChannel := make(map[int]map[string]struct{})
 		for _, e := range doc.Entries {
 			if e.ModelID == "" {
 				continue
 			}
 			out[e.ModelID] = struct{}{}
+			if e.ChannelType <= 0 {
+				continue
+			}
+			if byChannel[e.ChannelType] == nil {
+				byChannel[e.ChannelType] = make(map[string]struct{})
+			}
+			byChannel[e.ChannelType][e.ModelID] = struct{}{}
 		}
 		tkServedModelsManifestIDs = out
+		tkServedModelsManifestIDsByChannelType = make(map[int][]string, len(byChannel))
+		for ct, ids := range byChannel {
+			list := make([]string, 0, len(ids))
+			for id := range ids {
+				list = append(list, id)
+			}
+			sort.Strings(list)
+			tkServedModelsManifestIDsByChannelType[ct] = list
+		}
 	})
-	return tkServedModelsManifestIDs
+}
+
+// tkServedModelsManifestPresetIDsByChannelType returns empirically verified
+// newapi model IDs for a channel_type declared in tk_served_models.json.
+// Unknown or unprobed channel types return nil.
+func tkServedModelsManifestPresetIDsByChannelType(channelType int) []string {
+	loadTkServedModelsManifest()
+	if channelType <= 0 {
+		return nil
+	}
+	ids := tkServedModelsManifestIDsByChannelType[channelType]
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]string, len(ids))
+	copy(out, ids)
+	return out
 }
 
 // isTkCuratedNewAPIModelListed reports whether modelID is declared in the

--- a/backend/internal/service/tk_served_models_manifest_tk_test.go
+++ b/backend/internal/service/tk_served_models_manifest_tk_test.go
@@ -24,3 +24,25 @@ func TestIsNewAPILongTailCatalogVendor(t *testing.T) {
 		t.Fatal("anthropic must not be newapi long-tail")
 	}
 }
+
+func TestTkServedModelsManifestPresetIDsByChannelType(t *testing.T) {
+	deepseek := tkServedModelsManifestPresetIDsByChannelType(43)
+	if len(deepseek) == 0 {
+		t.Fatal("deepseek channel_type 43 must have manifest presets")
+	}
+	if !containsString(deepseek, "deepseek-chat") {
+		t.Fatal("deepseek-chat must be in ch43 preset")
+	}
+	if tkServedModelsManifestPresetIDsByChannelType(25) != nil {
+		t.Fatal("unprobed channel_type 25 must return nil preset")
+	}
+}
+
+func containsString(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 548,
-  "hash": "a5a3685c63b7e2825417fc536812cdb297d4c1fcc324699f777ff1819ce4841c",
+  "hash": "75b881a97dcfb6dda0c441faa3ae816c47b9d3496ef0f4852c464a70e073fdeb",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -649,6 +649,26 @@ export async function getAntigravityDefaultModelMapping(): Promise<Record<string
 }
 
 /**
+ * TokenKey servable model_mapping preset IDs for admin account Create/Edit auto-fill.
+ * Single SSOT for native platforms, grok, kiro, and newapi ch41 (Vertex SA).
+ */
+export async function getModelMappingPresets(
+  platform: string,
+  channelType = 0
+): Promise<string[]> {
+  const { data } = await apiClient.get<{ model_ids: string[] }>(
+    '/admin/accounts/model-mapping-presets',
+    {
+      params: {
+        platform,
+        ...(channelType > 0 ? { channel_type: channelType } : {}),
+      },
+    }
+  )
+  return data.model_ids ?? []
+}
+
+/**
  * Refresh OpenAI token using refresh token
  * @param refreshToken - The refresh token
  * @param proxyId - Optional proxy ID
@@ -852,6 +872,7 @@ export const accountsAPI = {
   importCodexSession,
   createOpenAICodexPAT,
   getAntigravityDefaultModelMapping,
+  getModelMappingPresets,
   batchClearError,
   batchRefresh,
   setPrivacy,

--- a/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
+++ b/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/api/admin/accounts', () => ({
-  getAntigravityDefaultModelMapping: vi.fn()
-}))
 vi.mock('@/api/admin/groups', () => ({
   getModelsListCandidates: vi.fn()
+}))
+vi.mock('@/api/admin/accounts', () => ({
+  getAntigravityDefaultModelMapping: vi.fn(),
+  getModelMappingPresets: vi.fn(),
 }))
 
 import {
@@ -28,6 +29,8 @@ describe('useModelWhitelist', () => {
     expect(getModelsByPlatform('anthropic')).toEqual([])
     expect(getModelsByPlatform('gemini')).toEqual([])
     expect(getModelsByPlatform('antigravity')).toEqual([])
+    expect(getModelsByPlatform('grok')).toEqual([])
+    expect(getModelsByPlatform('kiro')).toEqual([])
   })
 
   it('newapi keeps its own static list (channel-driven, no backend allowlist)', () => {

--- a/frontend/src/composables/__tests__/useServableModels.spec.ts
+++ b/frontend/src/composables/__tests__/useServableModels.spec.ts
@@ -1,37 +1,36 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { getModelsListCandidates } from '@/api/admin/groups'
+import { getModelMappingPresets } from '@/api/admin/accounts'
 
-vi.mock('@/api/admin/groups', () => ({
-  getModelsListCandidates: vi.fn()
+vi.mock('@/api/admin/accounts', () => ({
+  getModelMappingPresets: vi.fn()
 }))
 
 import { useServableModels, servableModelsFor, isApiBackedPlatform } from '../useServableModels'
 
-const mockGet = vi.mocked(getModelsListCandidates)
+const mockGet = vi.mocked(getModelMappingPresets)
 
 describe('useServableModels', () => {
   beforeEach(() => {
     mockGet.mockReset()
   })
 
-  it('isApiBackedPlatform covers the 4 self-healing platforms only', () => {
-    for (const p of ['anthropic', 'claude', 'openai', 'gemini', 'antigravity']) {
+  it('isApiBackedPlatform covers preset SSOT platforms', () => {
+    for (const p of ['anthropic', 'claude', 'openai', 'gemini', 'antigravity', 'grok', 'xai', 'kiro']) {
       expect(isApiBackedPlatform(p)).toBe(true)
     }
-    for (const p of ['newapi', 'zhipu', 'kiro', 'totally-unknown']) {
+    for (const p of ['newapi', 'zhipu', 'totally-unknown']) {
       expect(isApiBackedPlatform(p)).toBe(false)
     }
   })
 
-  it('ensureLoaded fetches the self-healing list with id=0 and caches it (claude→anthropic)', async () => {
+  it('ensureLoaded fetches the preset list and caches it (claude→anthropic)', async () => {
     mockGet.mockResolvedValueOnce(['claude-opus-4-8', 'claude-sonnet-4-6'])
     const { ensureLoaded } = useServableModels()
 
     await ensureLoaded('claude')
 
-    expect(mockGet).toHaveBeenCalledWith(0, 'anthropic')
+    expect(mockGet).toHaveBeenCalledWith('anthropic')
     expect(servableModelsFor('claude')).toEqual(['claude-opus-4-8', 'claude-sonnet-4-6'])
-    // cached: a second ensureLoaded does not refetch
     await ensureLoaded('anthropic')
     expect(mockGet).toHaveBeenCalledTimes(1)
   })
@@ -47,15 +46,13 @@ describe('useServableModels', () => {
   })
 
   it('surfaces the message from the interceptor-flattened error object (not [object Object])', async () => {
-    // api/client.ts rejects with a plain object { status, code, message }, not an
-    // Error — String(e) used to store "[object Object]" here.
-    mockGet.mockRejectedValueOnce({ status: 500, code: 'INTERNAL', message: 'candidate fetch failed' })
+    mockGet.mockRejectedValueOnce({ status: 500, code: 'INTERNAL', message: 'preset fetch failed' })
     const { ensureLoaded, error } = useServableModels()
 
     await ensureLoaded('gemini')
 
     expect(servableModelsFor('gemini')).toEqual([])
-    expect(error.value).toBe('candidate fetch failed')
+    expect(error.value).toBe('preset fetch failed')
     expect(error.value).not.toBe('[object Object]')
   })
 

--- a/frontend/src/composables/__tests__/useTkAccountNewApiPlatform.spec.ts
+++ b/frontend/src/composables/__tests__/useTkAccountNewApiPlatform.spec.ts
@@ -22,14 +22,14 @@ const {
   showInfoMock,
   fetchUpstreamModelsMock,
   listChannelTypesMock,
-  listChannelTypeModelsMock,
+  getModelMappingPresetsMock,
 } = vi.hoisted(() => ({
   showErrorMock: vi.fn(),
   showSuccessMock: vi.fn(),
   showInfoMock: vi.fn(),
   fetchUpstreamModelsMock: vi.fn(),
   listChannelTypesMock: vi.fn(),
-  listChannelTypeModelsMock: vi.fn(),
+  getModelMappingPresetsMock: vi.fn(),
 }))
 
 vi.mock('@/stores/app', () => ({
@@ -43,7 +43,10 @@ vi.mock('@/stores/app', () => ({
 vi.mock('@/api/admin/channels', () => ({
   fetchUpstreamModels: fetchUpstreamModelsMock,
   listChannelTypes: listChannelTypesMock,
-  listChannelTypeModels: listChannelTypeModelsMock,
+}))
+
+vi.mock('@/api/admin/accounts', () => ({
+  getModelMappingPresets: getModelMappingPresetsMock,
 }))
 
 vi.mock('@/api/admin', () => ({
@@ -74,11 +77,12 @@ describe('useTkAccountNewApiPlatform', () => {
     showInfoMock.mockReset()
     fetchUpstreamModelsMock.mockReset()
     listChannelTypesMock.mockReset()
-    listChannelTypeModelsMock.mockReset()
+    getModelMappingPresetsMock.mockReset()
     listChannelTypesMock.mockResolvedValue([])
-    listChannelTypeModelsMock.mockResolvedValue({
-      '41': ['gemini-2.5-flash', 'imagen-4.0-fast-generate-001'],
-    })
+    getModelMappingPresetsMock.mockResolvedValue([
+      'gemini-2.5-flash',
+      'imagen-4.0-fast-generate-001',
+    ])
   })
 
   describe('populateFromAccount', () => {
@@ -124,7 +128,7 @@ describe('useTkAccountNewApiPlatform', () => {
       expect(hook.modelMappings.value).toEqual([])
     })
 
-    it('Vertex ch41 + 空 mapping → 自动填入 channel-type-models 预设', async () => {
+    it('Vertex ch41 + 空 mapping → 自动填入 model-mapping-presets 预设', async () => {
       const hook = useTkAccountNewApiPlatform({ isNewapi: () => true })
       hook.populateFromAccount({ channel_type: 41, credentials: {} })
       await nextTick()

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -361,7 +361,7 @@ export const commonErrorCodes = [
 
 // 按平台获取模型
 export function getModelsByPlatform(platform: string): string[] {
-  // API-backed platforms (anthropic/claude/openai/gemini/antigravity) come from
+  // API-backed platforms (anthropic/claude/openai/gemini/antigravity/grok/kiro) come from
   // the self-healing backend cache (reactive — computeds re-run when the fetch
   // resolves; [] while pending or on error → custom input is the escape hatch).
   if (isApiBackedPlatform(platform)) {
@@ -375,8 +375,6 @@ export function getModelsByPlatform(platform: string): string[] {
     case 'deepseek': return deepseekModels
     case 'mistral': return mistralModels
     case 'meta': return metaModels
-    case 'xai':
-    case 'grok': return xaiModels
     case 'cohere': return cohereModels
     case 'yi': return yiModels
     case 'moonshot': return moonshotModels

--- a/frontend/src/composables/useServableModels.ts
+++ b/frontend/src/composables/useServableModels.ts
@@ -1,23 +1,19 @@
 import { reactive, ref } from 'vue'
-import { getModelsListCandidates } from '@/api/admin/groups'
+import { getModelMappingPresets } from '@/api/admin/accounts'
 import { unknownToErrorMessage } from '@/utils/authError'
-import type { GroupPlatform } from '@/types'
 
-// TK (R-003, follow-up to PR #752): the self-healing servable model lists for the
-// platforms whose candidates the backend authoritatively tracks (empirical
-// allowlist + live model_availability pruning). The admin model-whitelist
-// selector derives its candidates from here instead of hardcoded arrays, so an
-// upstream-retired model (e.g. access-gated claude-fable-5) auto-drops without a
-// manual frontend edit, and per-platform truth is honoured (gone on anthropic,
-// still servable on antigravity). newapi (channel-driven) and the long-tail
-// direct providers keep their static lists in useModelWhitelist — the backend
-// has no empirical source for those.
-const API_PLATFORMS: Record<string, GroupPlatform> = {
+// TK: admin model-whitelist / model_mapping preset SSOT — one backend endpoint
+// for native platforms, grok, kiro, and newapi ch41 (Vertex SA). Long-tail direct
+// providers keep static lists in useModelWhitelist.
+const API_PLATFORMS: Record<string, string> = {
   anthropic: 'anthropic',
   claude: 'anthropic',
   openai: 'openai',
   gemini: 'gemini',
-  antigravity: 'antigravity'
+  antigravity: 'antigravity',
+  grok: 'grok',
+  xai: 'grok',
+  kiro: 'kiro',
 }
 
 // Module-level reactive cache keyed by BACKEND platform, shared across all
@@ -33,7 +29,14 @@ export function isApiBackedPlatform(platform: string): boolean {
 
 // One representative frontend name per backend platform — used by the selector's
 // no-platform ("all models") case to fetch + union every self-healing list.
-export const apiBackedPlatforms: readonly string[] = ['anthropic', 'openai', 'gemini', 'antigravity']
+export const apiBackedPlatforms: readonly string[] = [
+  'anthropic',
+  'openai',
+  'gemini',
+  'antigravity',
+  'grok',
+  'kiro',
+]
 
 // servableModelsFor returns the cached self-healing list for an API-backed
 // platform (reactive — Vue computeds re-run when the fetch resolves), `[]` while
@@ -46,9 +49,7 @@ export function servableModelsFor(platform: string): string[] | undefined {
 }
 
 export function useServableModels() {
-  // ensureLoaded fetches the per-platform self-healing candidate list once and
-  // caches it. id=0 → platform defaults (the candidate list with no
-  // account-specific additions), which is exactly what the selector needs.
+  // ensureLoaded fetches the per-platform preset list once and caches it.
   async function ensureLoaded(platform: string): Promise<void> {
     const backend = API_PLATFORMS[platform]
     if (!backend || cache[backend] !== undefined || inflight.has(backend)) return
@@ -56,13 +57,10 @@ export function useServableModels() {
     loading.value = true
     error.value = null
     try {
-      cache[backend] = await getModelsListCandidates(0, backend)
+      cache[backend] = await getModelMappingPresets(backend)
     } catch (e) {
-      // The axios interceptor (api/client.ts) rejects with a flattened plain
-      // object { status, code, message, ... }, not an Error — so String(e) would
-      // store "[object Object]". Pull the backend message via the shared helper.
       error.value = unknownToErrorMessage(e, 'Failed to load servable models')
-      cache[backend] = [] // loaded-empty; the selector's custom input stays the escape hatch
+      cache[backend] = []
     } finally {
       inflight.delete(backend)
       loading.value = false

--- a/frontend/src/composables/useTkAccountNewApiPlatform.ts
+++ b/frontend/src/composables/useTkAccountNewApiPlatform.ts
@@ -1,12 +1,12 @@
 import { ref, computed, watch, type Ref, type ComputedRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
-import { fetchUpstreamModels, listChannelTypeModels, type FetchedUpstreamModel } from '@/api/admin/channels'
+import { fetchUpstreamModels, type FetchedUpstreamModel } from '@/api/admin/channels'
+import { getModelMappingPresets } from '@/api/admin/accounts'
 import { useNewApiChannelTypes } from '@/composables/useNewApiChannelTypes'
 import { isNewApiUpstreamFetchableChannelType } from '@/constants/newApiUpstreamFetchableChannelTypes'
 import {
   isNewApiVertexServiceAccountChannelType,
-  NEW_API_CHANNEL_TYPE_VERTEX_AI,
 } from '@/constants/newApiChannelTypes.tk'
 import { buildModelMappingObject } from '@/composables/useModelWhitelist'
 import { unknownToErrorMessage } from '@/utils/authError'
@@ -77,39 +77,19 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
   const modelMappings = ref<Array<{ from: string; to: string }>>([])
   const restrictionMode = ref<'whitelist' | 'mapping'>('whitelist')
   const fetchLoading = ref(false)
-  const channelTypeModelsByType = ref<Record<string, string[]>>({})
-  let channelTypeModelsLoad: Promise<void> | null = null
-
-  async function ensureChannelTypeModelsLoaded(): Promise<void> {
-    if (Object.keys(channelTypeModelsByType.value).length > 0) {
-      return
-    }
-    if (!channelTypeModelsLoad) {
-      channelTypeModelsLoad = listChannelTypeModels()
-        .then((data) => {
-          channelTypeModelsByType.value = data ?? {}
-        })
-        .catch(() => {
-          channelTypeModelsByType.value = {}
-        })
-    }
-    await channelTypeModelsLoad
-  }
 
   /**
-   * channel_type 41 (Vertex SA) has no upstream GET /v1/models — preset from
-   * GET /admin/channel-type-models (TokenKey empirical Gemini/Vertex allowlist).
+   * channel_type with a TK-verified preset (e.g. 41 Vertex SA) auto-fills from
+   * GET /admin/accounts/model-mapping-presets when whitelist is empty.
    */
   async function applyChannelTypePresetModelsIfEmpty(): Promise<void> {
-    if (!options.isNewapi() || !isNewApiVertexServiceAccountChannelType(channelType.value)) {
+    if (!options.isNewapi() || channelType.value <= 0) {
       return
     }
     if (restrictionMode.value !== 'whitelist' || allowedModels.value.length > 0) {
       return
     }
-    await ensureChannelTypeModelsLoaded()
-    const preset =
-      channelTypeModelsByType.value[String(NEW_API_CHANNEL_TYPE_VERTEX_AI)] ?? []
+    const preset = await getModelMappingPresets('newapi', channelType.value)
     if (preset.length === 0) {
       return
     }
@@ -260,9 +240,6 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
    */
   function bootstrap(): void {
     void channelTypesCatalog.load().catch(() => { /* 错误已写入 channelTypesCatalog.error */ })
-    if (options.isNewapi()) {
-      void ensureChannelTypeModelsLoaded()
-    }
   }
 
   /**


### PR DESCRIPTION
## 摘要

- 新增 `GET /api/v1/admin/accounts/model-mapping-presets`，作为 Admin 账号 onboarding 时 `model_mapping` 预设 ID 的单一事实来源（SSOT）。
- 后端 `AccountModelMappingPresetIDs` 统一 Grok/Kiro/NewAPI 等平台的预设逻辑；原生四平台与 `tkServableCandidateIDs` 同源。
- **NewAPI 覆盖范围**：
  - ch41（Vertex SA）→ Gemini 实测 catalog（7 id）
  - ch17/26/43/45（DashScope / ZhipuV4 / DeepSeek / VolcEngine）→ 从 `tk_served_models.json` manifest 按 channel_type 派生
  - 其它 channel_type → **空**（未接入/未实测不自动填）
- 前端 `useServableModels` / `useTkAccountNewApiPlatform` 通过 preset API 拉取；空白名单时自动预填。

sentinel-registry-reviewed
upstream-touch-trivial

## 风险

- **公共契约**：新增 Admin API 路由；NewAPI 已实测 channel 的 model_mapping 自动填充行为有可见变化（DeepSeek/Qwen/GLM/Volc 等）。
- **回归面**：`ListChannelTypeModels`、`GetAvailableModels` 空 mapping 分支与 preset SSOT 对齐；manifest 是唯一 long-tail 真值，新增 channel 需先写入 manifest。
- **Sentinel**：新增 TK companion 文件已人工审阅（PR 标记 `sentinel-registry-reviewed`）。

## 验证

- `./scripts/preflight.sh` — PASS
- `go test -tags=unit ./internal/service/ -run 'TestAccountModelMappingPresetIDs|TestTkServedModelsManifest' -count=1` — PASS
- `go test -tags=unit ./internal/handler/admin/ -run 'TestGetModelMappingPresets|TestListChannelTypeModels|TestAccountHandlerGetAvailableModels_NewAPI' -count=1` — PASS
- `pnpm vitest run src/composables/__tests__/useServableModels.spec.ts src/composables/__tests__/useModelWhitelist.spec.ts src/composables/__tests__/useTkAccountNewApiPlatform.spec.ts` — PASS

## 提交

- d868685aa feat(admin): unify model-mapping preset SSOT endpoint for account onboarding
- 90690a15d fix(test): align useServableModels spec with preset SSOT API
- df936b4da feat(admin): extend newapi preset SSOT to manifest channel types
- 08b6179a3 fix(lint): gofmt tk_served_models_manifest_tk var block

最新提交：08b6179a3
