### PR TITLE
feat(ci): unify client release + prompt surface into client-fidelity-watch umbrella

### DIFF
--- a/.cursor/skills/tokenkey-fingerprint-alignment-all/SKILL.md
+++ b/.cursor/skills/tokenkey-fingerprint-alignment-all/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 2. **指纹对齐（Layer 2，本 skill）** — 在 Cursor **加载本 skill 或单平台 skill 后**，跑
    `capture-all-fingerprints.sh` 做真实 capture/diff，再合一个 PR。
 
-CI 里 `.github/workflows/client-release-watch.yml` 跑 Layer 1 并开 tracking issue；
+CI 里 `.github/workflows/client-fidelity-watch.yml` 每日顺序跑 Layer 1 release scan → prompt registry-gate → prod aggregate，并开 tracking issue；
 人工/agent  remediation 从 Layer 1 的 skill 路由进入 Layer 2。
 
 一次对齐**所有**客户端指纹，合一个 PR。四条引擎**机制不同必须独立**——cc 主动重定向到

--- a/.github/workflows/client-fidelity-watch.yml
+++ b/.github/workflows/client-fidelity-watch.yml
@@ -342,6 +342,7 @@ jobs:
       - name: Merge daily fidelity report
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RELEASE_RESULT: ${{ needs.release-scan.result }}
           REGISTRY_RESULT: ${{ needs.registry-gate.result }}
           PROD_RESULT: ${{ needs.prod-aggregate.result }}
         run: |
@@ -352,6 +353,7 @@ jobs:
           PROMPT_JSON=".cache/prompt-surface-watch/report.json"
           PROMPT_MD=".cache/prompt-surface-watch/report.md"
           ARGS=(
+            --release-scan-result "$RELEASE_RESULT"
             --registry-gate-result "$REGISTRY_RESULT"
             --prod-aggregate-result "$PROD_RESULT"
             --run-url "$RUN_URL"

--- a/.github/workflows/client-fidelity-watch.yml
+++ b/.github/workflows/client-fidelity-watch.yml
@@ -1,0 +1,394 @@
+name: Client Fidelity Watch
+
+# Umbrella daily watch: client release poll → prompt registry gate → prod aggregate.
+# One schedule, one daily report artifact, unified issue labels (client-fidelity-watch + signal type).
+# Prod actionable drift and registry-gate failure fail the workflow (red).
+
+on:
+  schedule:
+    # 08:03 Asia/Shanghai (23:03 UTC). Sequential: release scan → registry-gate → prod-aggregate.
+    - cron: "3 23 * * *"
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "docker logs --since for prod fingerprint probe"
+        required: false
+        default: "24h"
+      dry_run:
+        description: "Run checks but do NOT open/update GitHub issues or cache PR"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+concurrency:
+  group: client-fidelity-watch
+  cancel-in-progress: false
+
+jobs:
+  release-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      has_drift: ${{ steps.watch.outputs.has_drift }}
+      drift_count: ${{ steps.watch.outputs.drift_count }}
+      cache_changed: ${{ steps.watch.outputs.cache_changed }}
+      cache_pr_url: ${{ steps.cache_pr.outputs.cache_pr_url }}
+    steps:
+      - name: Check required token
+        env:
+          UPSTREAM_MERGE_GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+        run: |
+          if [ -z "${UPSTREAM_MERGE_GH_TOKEN:-}" ]; then
+            echo "::error::Missing required secret UPSTREAM_MERGE_GH_TOKEN for issue updates and cache PR branches."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Configure authenticated origin
+        env:
+          UPSTREAM_MERGE_GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+        run: git remote set-url origin "https://x-access-token:${UPSTREAM_MERGE_GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      - name: Configure git identity
+        run: |
+          git config user.name "tk-client-fidelity-watch[bot]"
+          git config user.email "client-fidelity-watch@tokenkey.dev"
+
+      - name: Scan upstream client releases
+        id: watch
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          SHA="$(git rev-parse HEAD)"
+          python3 scripts/fingerprint/client_release_watch.py \
+            --git-sha "$SHA" \
+            --run-url "$RUN_URL" \
+            --report-json .cache/fingerprint/client-release-watch/report.json \
+            --report-md .cache/fingerprint/client-release-watch/report.md \
+            --state .cache/fingerprint/client-release-watch.json || WATCH_EXIT=$?
+          WATCH_EXIT="${WATCH_EXIT:-0}"
+          python3 -m json.tool .cache/fingerprint/client-release-watch/report.json >/dev/null
+          HAS_DRIFT="$(python3 -c "import json;print('true' if json.load(open('.cache/fingerprint/client-release-watch/report.json'))['summary']['has_actionable_drift'] else 'false')")"
+          DRIFT_COUNT="$(python3 -c "import json;print(json.load(open('.cache/fingerprint/client-release-watch/report.json'))['summary']['drift_count'])")"
+          {
+            echo "has_drift=$HAS_DRIFT"
+            echo "drift_count=$DRIFT_COUNT"
+          } >> "$GITHUB_OUTPUT"
+          if git diff --quiet -- .cache/fingerprint/client-release-watch.json; then
+            echo "cache_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "cache_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+
+      - name: Open or update drift tracking issues
+        if: inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python3 ops/fingerprint/open_client_release_watch_issues.py --umbrella
+
+      - name: Create or update cache refresh PR
+        id: cache_pr
+        if: inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "cache_pr_url=" >> "$GITHUB_OUTPUT"
+          meta_changed=false
+          if ! git diff --quiet -- \
+            scripts/fingerprint/client_release_watch.py \
+            .github/workflows/client-release-watch.yml \
+            .github/workflows/client-fidelity-watch.yml \
+            ops/fingerprint/open_client_release_watch_issues.py; then
+            meta_changed=true
+          fi
+          if [ "${{ steps.watch.outputs.cache_changed }}" != "true" ] && [ "$meta_changed" != "true" ]; then
+            echo "No client-release-watch cache changes to propose."
+            exit 0
+          fi
+
+          BRANCH="chore/client-release-watch-cache"
+          git checkout -B "$BRANCH"
+          git add -f .cache/fingerprint/client-release-watch.json \
+            scripts/fingerprint/client_release_watch.py \
+            scripts/fingerprint/test_client_release_watch.py \
+            .github/workflows/client-release-watch.yml \
+            .github/workflows/client-fidelity-watch.yml \
+            ops/fingerprint/open_client_release_watch_issues.py
+          git commit -m "chore: refresh client release watch cache"
+          git push --force-with-lease origin "$BRANCH"
+
+          cat > .cache/fingerprint/client-release-watch/cache-pr-body.md <<'EOF'
+          ## Summary
+          - Refresh `.cache/fingerprint/client-release-watch.json` from the latest upstream client release poll.
+          - Keep the client fidelity / release watch scripts and workflows in sync when they changed in the same run.
+
+          ## Watchdog report
+          EOF
+          cat .cache/fingerprint/client-release-watch/report.md >> .cache/fingerprint/client-release-watch/cache-pr-body.md
+          cat >> .cache/fingerprint/client-release-watch/cache-pr-body.md <<'EOF'
+
+          ## Test plan
+          - [x] `python3 scripts/fingerprint/client_release_watch.py --selftest`
+          - [x] `python3 -m unittest discover -s scripts/fingerprint -p 'test_*.py'`
+          - [x] `python3 -m json.tool .cache/fingerprint/client-release-watch/report.json`
+          EOF
+
+          EXISTING="$(gh pr list --state open --base main --head "$BRANCH" --json number,url --jq '.[0] // empty')"
+          if [ -n "$EXISTING" ]; then
+            NUMBER="$(jq -r '.number' <<<"$EXISTING")"
+            URL="$(jq -r '.url' <<<"$EXISTING")"
+            gh pr edit "$NUMBER" --title "chore: refresh client release watch cache" --body-file .cache/fingerprint/client-release-watch/cache-pr-body.md
+          else
+            URL="$(gh pr create --base main --head "$BRANCH" --title "chore: refresh client release watch cache" --body-file .cache/fingerprint/client-release-watch/cache-pr-body.md)"
+          fi
+          echo "cache_pr_url=$URL" >> "$GITHUB_OUTPUT"
+          echo "cache PR: $URL"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: client-fidelity-release-${{ github.run_id }}
+          path: |
+            .cache/fingerprint/client-release-watch/report.json
+            .cache/fingerprint/client-release-watch/report.md
+            .cache/fingerprint/client-release-watch.json
+          if-no-files-found: ignore
+
+  registry-gate:
+    needs: release-scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/cache-and-checkout-new-api
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          check-latest: false
+          cache: true
+          cache-dependency-path: backend/go.sum
+
+      - name: Registry + fixture gateway gate
+        run: |
+          set -euo pipefail
+          python3 ops/anthropic/probe_prompt_surfaces.py --check-registry
+          python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway
+          (
+            cd backend
+            go test -tags=unit ./internal/service \
+              -run 'TestTkExtractAnthropicPromptFingerprint|TestTkProbePromptSurfaceGatewayCoverageJSONL|TestTkNormalizeCCGeo' \
+              -count=1
+          )
+          python3 -m unittest ops.anthropic.test_probe_prompt_surfaces -v
+          python3 -m unittest ops.anthropic.test_probe_cc_geo_stego -v
+          python3 -m unittest ops.observability.test_probe_prompt_surface_fingerprints -v
+          python3 -m unittest ops.observability.test_open_prompt_surface_watch_issues -v
+          python3 -m unittest ops.fingerprint.test_open_client_release_watch_issues -v
+          python3 scripts/fingerprint/client_fidelity_watch_report.py --selftest
+
+      - name: Close recovered registry-gate tracking issue
+        if: success() && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::Missing required secret UPSTREAM_MERGE_GH_TOKEN for issue updates."
+            exit 1
+          fi
+          python3 ops/observability/open_prompt_surface_watch_issues.py registry-recover --run-url "$RUN_URL" --umbrella
+
+  notify-registry-failure:
+    needs: registry-gate
+    if: always() && needs.registry-gate.result == 'failure' && inputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Open registry-gate failure issue
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::Missing required secret UPSTREAM_MERGE_GH_TOKEN for issue updates."
+            exit 1
+          fi
+          python3 ops/observability/open_prompt_surface_watch_issues.py registry-failure --run-url "$RUN_URL" --umbrella
+
+  prod-aggregate:
+    needs: registry-gate
+    if: always() && needs.registry-gate.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      SINCE: ${{ inputs.since || '24h' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Precheck OIDC role
+        id: precheck
+        run: |
+          if [ -z "${OIDC_ROLE_ARN:-}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::AWS_OIDC_ROLE_ARN empty — skipping prod aggregate"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials via OIDC
+        if: steps.precheck.outputs.skip == 'false'
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Probe prod fingerprint logs (read-only SSM)
+        if: steps.precheck.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          mkdir -p .cache/prompt-surface-watch
+          bash ops/observability/run-probe.sh \
+            --target prod \
+            --script ops/observability/probe-prompt-surface-fingerprints.sh \
+            --env "SINCE=${SINCE}" \
+            --env "LIMIT=40" \
+            --comment "client-fidelity-watch prod fingerprint aggregate" \
+            --timeout-seconds 120 \
+            > .cache/prompt-surface-watch/prod-fingerprints.json || true  # preflight-allow: swallow
+          python3 ops/observability/prompt_surface_aggregate.py \
+            --input .cache/prompt-surface-watch/prod-fingerprints.json \
+            --report-json .cache/prompt-surface-watch/report.json \
+            --report-md .cache/prompt-surface-watch/report.md || AGG=$?
+          cat .cache/prompt-surface-watch/report.md || true  # preflight-allow: swallow
+          exit "${AGG:-0}"
+
+      - name: Sync prod drift tracking issue
+        if: always() && steps.precheck.outputs.skip == 'false' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::Missing required secret UPSTREAM_MERGE_GH_TOKEN for issue updates."
+            exit 1
+          fi
+          if [ ! -f .cache/prompt-surface-watch/report.json ]; then
+            echo "No aggregate report — skipping issue sync"
+            exit 0
+          fi
+          python3 ops/observability/open_prompt_surface_watch_issues.py prod-sync \
+            --report-json .cache/prompt-surface-watch/report.json \
+            --report-md .cache/prompt-surface-watch/report.md \
+            --run-url "$RUN_URL" \
+            --umbrella
+
+      - uses: actions/upload-artifact@v4
+        if: always() && steps.precheck.outputs.skip == 'false'
+        with:
+          name: client-fidelity-prompt-${{ github.run_id }}
+          path: .cache/prompt-surface-watch/
+          if-no-files-found: ignore
+
+  daily-report:
+    needs: [release-scan, registry-gate, prod-aggregate]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: client-fidelity-release-${{ github.run_id }}
+          path: .cache/fingerprint/client-release-watch
+        continue-on-error: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: client-fidelity-prompt-${{ github.run_id }}
+          path: .cache/prompt-surface-watch
+        continue-on-error: true
+
+      - name: Merge daily fidelity report
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REGISTRY_RESULT: ${{ needs.registry-gate.result }}
+          PROD_RESULT: ${{ needs.prod-aggregate.result }}
+        run: |
+          set -euo pipefail
+          mkdir -p .cache/fingerprint/client-fidelity-watch
+          RELEASE_JSON=".cache/fingerprint/client-release-watch/report.json"
+          RELEASE_MD=".cache/fingerprint/client-release-watch/report.md"
+          PROMPT_JSON=".cache/prompt-surface-watch/report.json"
+          PROMPT_MD=".cache/prompt-surface-watch/report.md"
+          ARGS=(
+            --registry-gate-result "$REGISTRY_RESULT"
+            --prod-aggregate-result "$PROD_RESULT"
+            --run-url "$RUN_URL"
+            --report-json .cache/fingerprint/client-fidelity-watch/report.json
+            --report-md .cache/fingerprint/client-fidelity-watch/report.md
+          )
+          if [ -f "$RELEASE_JSON" ]; then
+            ARGS+=(--release-report-json "$RELEASE_JSON")
+          fi
+          if [ -f "$RELEASE_MD" ]; then
+            ARGS+=(--release-report-md "$RELEASE_MD")
+          fi
+          if [ -f "$PROMPT_JSON" ]; then
+            ARGS+=(--prompt-prod-report-json "$PROMPT_JSON")
+          fi
+          if [ -f "$PROMPT_MD" ]; then
+            ARGS+=(--prompt-prod-report-md "$PROMPT_MD")
+          fi
+          python3 scripts/fingerprint/client_fidelity_watch_report.py "${ARGS[@]}"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: client-fidelity-watch-${{ github.run_id }}
+          path: .cache/fingerprint/client-fidelity-watch/
+          if-no-files-found: ignore
+
+  contract:
+    needs: [release-scan, registry-gate, prod-aggregate]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Summarize run
+        run: |
+          echo "release has_drift=${{ needs.release-scan.outputs.has_drift }}"
+          echo "release drift_count=${{ needs.release-scan.outputs.drift_count }}"
+          echo "release cache_pr_url=${{ needs.release-scan.outputs.cache_pr_url }}"
+          echo "registry-gate=${{ needs.registry-gate.result }}"
+          echo "prod-aggregate=${{ needs.prod-aggregate.result }}"

--- a/.github/workflows/client-release-watch.yml
+++ b/.github/workflows/client-release-watch.yml
@@ -1,13 +1,11 @@
 name: Client Release Watch
 
+# Manual-only legacy entry. Daily schedule moved to client-fidelity-watch.yml.
 # Poll public release channels for Claude Code, Codex, Antigravity, Kiro, Gemini CLI, Grok CLI, etc.;
 # compare against TokenKey fingerprint pins; open/update tracking issues when upstream
 # ships a newer client version so operators can run the matching alignment skill early.
 
 on:
-  schedule:
-    # 07:11 Asia/Shanghai. GitHub cron is UTC. Offset from cc/upstream issue watchdogs.
-    - cron: "11 23 * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -96,126 +94,7 @@ jobs:
           GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import json
-          import pathlib
-          import re
-          import subprocess
-
-          report = json.loads(pathlib.Path('.cache/fingerprint/client-release-watch/report.json').read_text(encoding='utf-8'))
-
-          def sh(args, **kwargs):
-              return subprocess.run(args, text=True, check=True, capture_output=True, **kwargs)
-
-          def label_safe(value: str) -> str:
-              return re.sub(r'[^A-Za-z0-9_.:-]+', '-', value)[:50] or 'unknown'
-
-          def ensure_label(name: str, color: str, description: str) -> None:
-              subprocess.run(
-                  ['gh', 'label', 'create', name, '--color', color, '--description', description[:100]],
-                  text=True,
-                  stdout=subprocess.DEVNULL,
-                  stderr=subprocess.DEVNULL,
-              )
-
-          base_labels = {
-              'client-release-watch': ('BFD4F2', 'Client release watch signal'),
-              'automated': ('C5DEF5', 'Automated signal'),
-              'needs-triage': ('FBCA04', 'Needs human triage'),
-              'client-release:drift': ('D73A4A', 'Upstream client newer than TokenKey pin'),
-              'client-release:aligned': ('0E8A16', 'Client release aligned with pin'),
-          }
-          for name, (color, desc) in base_labels.items():
-              ensure_label(name, color, desc)
-
-          for item in report.get('platforms') or []:
-              platform_id = item['id']
-              platform_label = f"client-release:{label_safe(platform_id)}"
-              ensure_label(platform_label, 'BFD4F2', f'Client release watch platform {platform_id}')
-
-              upstream = item.get('upstream_latest') or 'unknown'
-              issue_signature = f"client-release-{platform_id}-{upstream}"
-              sig = f"{platform_id}-{upstream}"
-              sig_label = label_safe(f"cr-sig:{sig}")
-              ensure_label(sig_label, 'BFD4F2', f'Client release watch signature {sig}')
-
-              title = f"[client-release] {item.get('name')} upstream {upstream} > pin {item.get('pinned') or 'n/a'}"[:250]
-              body_lines = [
-                  '## Client release watch finding',
-                  '',
-                  f"- Platform: `{platform_id}`",
-                  f"- Pinned: `{item.get('pinned')}`",
-                  f"- Upstream latest: `{upstream}`",
-                  f"- Status: `{item.get('status')}`",
-                  f"- Pin path: `{item.get('pin_path')}`",
-                  f"- Alignment skill: `{item.get('skill')}`",
-                  f"- Watchdog run: {report.get('run_url') or 'n/a'}",
-                  f"- Signature: `{issue_signature}`",
-                  '',
-                  '## Upstream sources',
-                  '',
-              ]
-              for label, info in (item.get('upstream_sources') or {}).items():
-                  body_lines.append(f"- {label}: `{info.get('version')}` — {info.get('url')}")
-              if item.get('fetch_errors'):
-                  body_lines.extend(['', '## Fetch errors', ''])
-                  body_lines.extend(f"- {err}" for err in item['fetch_errors'])
-              body_lines.extend([
-                  '',
-                  '## Expected follow-up',
-                  '',
-                  f"1. Local routing: `bash ops/fingerprint/client-release-watch.sh plan`",
-                  f"2. Load skill in Cursor: `{item.get('skill')}` (or `tokenkey-fingerprint-alignment-all` for one PR)",
-                  f"3. Run that skill's capture commands — do not bump pins from release metadata alone.",
-              ])
-              body_path = pathlib.Path(f'.cache/fingerprint/client-release-watch/issue-{platform_id}.md')
-              body_path.write_text('\n'.join(body_lines) + '\n', encoding='utf-8')
-
-              if item.get('drift') and not item.get('issue_suppressed'):
-                  labels = ','.join([
-                      'client-release-watch', 'automated', 'needs-triage',
-                      'client-release:drift', platform_label, sig_label,
-                  ])
-                  existing = sh([
-                      'gh', 'issue', 'list', '--state', 'open', '--label', sig_label,
-                      '--json', 'number', '--limit', '1', '--jq', '.[0].number // empty',
-                  ]).stdout.strip()
-                  if existing:
-                      sh(['gh', 'issue', 'comment', existing, '--body-file', str(body_path)])
-                      sh(['gh', 'issue', 'edit', existing, '--add-label', labels])
-                      print(f'updated drift issue #{existing} for {platform_id}')
-                  else:
-                      sh(['gh', 'issue', 'create', '--title', title, '--body-file', str(body_path), '--label', labels])
-                      print(f'created drift issue for {platform_id}')
-              else:
-                  existing_raw = sh([
-                      'gh', 'issue', 'list', '--state', 'open', '--label', platform_label,
-                      '--json', 'number,labels', '--limit', '20',
-                  ]).stdout.strip()
-                  if not existing_raw or existing_raw == '[]':
-                      continue
-                  for row in json.loads(existing_raw):
-                      number = str(row['number'])
-                      labels = {lbl['name'] for lbl in row.get('labels') or []}
-                      if 'client-release:drift' not in labels:
-                          continue
-                      comment = '\n'.join([
-                          'Watchdog now reports this platform as aligned with upstream (or not ahead of the pin).',
-                          '',
-                          f"- Platform: `{platform_id}`",
-                          f"- Pinned: `{item.get('pinned')}`",
-                          f"- Upstream latest: `{upstream}`",
-                          f"- Watchdog run: {report.get('run_url') or 'n/a'}",
-                      ]) + '\n'
-                      sh(['gh', 'issue', 'comment', number, '--body', comment])
-                      subprocess.run([
-                          'gh', 'issue', 'edit', number,
-                          '--add-label', 'client-release:aligned',
-                          '--remove-label', 'client-release:drift',
-                      ], text=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                      sh(['gh', 'issue', 'close', number, '--comment', 'Closing because upstream is no longer ahead of the TokenKey pin.'])
-                      print(f'closed drift issue #{number} for {platform_id}')
-          PY
+          python3 ops/fingerprint/open_client_release_watch_issues.py
 
       - name: Create or update cache refresh PR
         id: cache_pr
@@ -226,7 +105,11 @@ jobs:
           set -euo pipefail
           echo "cache_pr_url=" >> "$GITHUB_OUTPUT"
           meta_changed=false
-          if ! git diff --quiet -- scripts/fingerprint/client_release_watch.py .github/workflows/client-release-watch.yml; then
+          if ! git diff --quiet -- \
+            scripts/fingerprint/client_release_watch.py \
+            .github/workflows/client-release-watch.yml \
+            .github/workflows/client-fidelity-watch.yml \
+            ops/fingerprint/open_client_release_watch_issues.py; then
             meta_changed=true
           fi
           if [ "${{ steps.watch.outputs.cache_changed }}" != "true" ] && [ "$meta_changed" != "true" ]; then
@@ -236,7 +119,7 @@ jobs:
 
           BRANCH="chore/client-release-watch-cache"
           git checkout -B "$BRANCH"
-          git add -f .cache/fingerprint/client-release-watch.json scripts/fingerprint/client_release_watch.py scripts/fingerprint/test_client_release_watch.py .github/workflows/client-release-watch.yml
+          git add -f .cache/fingerprint/client-release-watch.json scripts/fingerprint/client_release_watch.py scripts/fingerprint/test_client_release_watch.py .github/workflows/client-release-watch.yml .github/workflows/client-fidelity-watch.yml ops/fingerprint/open_client_release_watch_issues.py
           git commit -m "chore: refresh client release watch cache"
           git push --force-with-lease origin "$BRANCH"
 

--- a/.github/workflows/prompt-surface-watch.yml
+++ b/.github/workflows/prompt-surface-watch.yml
@@ -1,13 +1,11 @@
 name: Prompt Surface Watch
 
+# Manual-only legacy entry. Daily schedule moved to client-fidelity-watch.yml.
 # Daily read-only watch: registry + fixture gateway gate in CI; prod fingerprint
 # aggregation via SSM on the same schedule. Opens/updates GitHub tracking issues
 # on registry-gate failure or prod actionable drift (closes when clear).
 
 on:
-  schedule:
-    # 08:03 Asia/Shanghai (23:03 UTC). After client-release-watch + cc-issue-watchdog.
-    - cron: "3 23 * * *"
   workflow_dispatch:
     inputs:
       since:

--- a/ops/fingerprint/open_client_release_watch_issues.py
+++ b/ops/fingerprint/open_client_release_watch_issues.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Open/update/close GitHub issues for client-release-watch drift signals."""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_REPORT = REPO_ROOT / ".cache/fingerprint/client-release-watch/report.json"
+DEFAULT_CACHE_DIR = REPO_ROOT / ".cache/fingerprint/client-release-watch"
+
+LABEL_CLIENT_FIDELITY = "client-fidelity-watch"
+
+BASE_LABELS = {
+    "client-release-watch": ("BFD4F2", "Client release watch signal"),
+    LABEL_CLIENT_FIDELITY: ("1D76DB", "Client fidelity umbrella watch"),
+    "automated": ("C5DEF5", "Automated signal"),
+    "needs-triage": ("FBCA04", "Needs human triage"),
+    "client-release:drift": ("D73A4A", "Upstream client newer than TokenKey pin"),
+    "client-release:aligned": ("0E8A16", "Client release aligned with pin"),
+}
+
+
+def label_safe(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.:-]+", "-", value)[:50] or "unknown"
+
+
+def filename_safe(value: str) -> str:
+    """Filesystem-safe slug (no colons — artifact upload rejects them)."""
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value)[:80] or "unknown"
+
+
+def sh(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, text=True, check=check, capture_output=True)
+
+
+def ensure_label(name: str, color: str, description: str) -> None:
+    subprocess.run(
+        ["gh", "label", "create", name, "--color", color, "--description", description[:100]],
+        text=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def ensure_base_labels() -> None:
+    for name, (color, desc) in BASE_LABELS.items():
+        ensure_label(name, color, desc)
+
+
+def issue_body_path(cache_dir: pathlib.Path, platform_id: str) -> pathlib.Path:
+    return cache_dir / f"issue-{filename_safe(platform_id)}.md"
+
+
+def sync_issues(report: dict, *, cache_dir: pathlib.Path, umbrella: bool) -> None:
+    ensure_base_labels()
+    for item in report.get("platforms") or []:
+        platform_id = item["id"]
+        platform_label = f"client-release:{label_safe(platform_id)}"
+        ensure_label(platform_label, "BFD4F2", f"Client release watch platform {platform_id}")
+
+        upstream = item.get("upstream_latest") or "unknown"
+        issue_signature = f"client-release-{platform_id}-{upstream}"
+        sig = f"{platform_id}-{upstream}"
+        sig_label = label_safe(f"cr-sig:{sig}")
+        ensure_label(sig_label, "BFD4F2", f"Client release watch signature {sig}")
+
+        title = (
+            f"[client-release] {item.get('name')} upstream {upstream} > pin {item.get('pinned') or 'n/a'}"
+        )[:250]
+        body_lines = [
+            "## Client release watch finding",
+            "",
+            f"- Signal type: `release-drift`",
+            f"- Platform: `{platform_id}`",
+            f"- Pinned: `{item.get('pinned')}`",
+            f"- Upstream latest: `{upstream}`",
+            f"- Status: `{item.get('status')}`",
+            f"- Pin path: `{item.get('pin_path')}`",
+            f"- Alignment skill: `{item.get('skill')}`",
+            f"- Watchdog run: {report.get('run_url') or 'n/a'}",
+            f"- Signature: `{issue_signature}`",
+            "",
+            "## Upstream sources",
+            "",
+        ]
+        for label, info in (item.get("upstream_sources") or {}).items():
+            body_lines.append(f"- {label}: `{info.get('version')}` — {info.get('url')}")
+        if item.get("fetch_errors"):
+            body_lines.extend(["", "## Fetch errors", ""])
+            body_lines.extend(f"- {err}" for err in item["fetch_errors"])
+        body_lines.extend([
+            "",
+            "## Expected follow-up",
+            "",
+            "1. Local routing: `bash ops/fingerprint/client-release-watch.sh plan`",
+            f"2. Load skill in Cursor: `{item.get('skill')}` (or `tokenkey-fingerprint-alignment-all` for one PR)",
+            "3. Run that skill's capture commands — do not bump pins from release metadata alone.",
+        ])
+        body_path = issue_body_path(cache_dir, platform_id)
+        body_path.parent.mkdir(parents=True, exist_ok=True)
+        body_path.write_text("\n".join(body_lines) + "\n", encoding="utf-8")
+
+        if item.get("drift") and not item.get("issue_suppressed"):
+            labels = [
+                "client-release-watch",
+                LABEL_CLIENT_FIDELITY,
+                "automated",
+                "needs-triage",
+                "client-release:drift",
+                platform_label,
+                sig_label,
+            ]
+            if not umbrella:
+                labels = [lbl for lbl in labels if lbl != LABEL_CLIENT_FIDELITY]
+            labels_csv = ",".join(labels)
+            existing = sh([
+                "gh", "issue", "list", "--state", "open", "--label", sig_label,
+                "--json", "number", "--limit", "1", "--jq", ".[0].number // empty",
+            ]).stdout.strip()
+            if existing:
+                sh(["gh", "issue", "comment", existing, "--body-file", str(body_path)])
+                sh(["gh", "issue", "edit", existing, "--add-label", labels_csv])
+                print(f"updated drift issue #{existing} for {platform_id}")
+            else:
+                sh(["gh", "issue", "create", "--title", title, "--body-file", str(body_path), "--label", labels_csv])
+                print(f"created drift issue for {platform_id}")
+            continue
+
+        existing_raw = sh([
+            "gh", "issue", "list", "--state", "open", "--label", platform_label,
+            "--json", "number,labels", "--limit", "20",
+        ]).stdout.strip()
+        if not existing_raw or existing_raw == "[]":
+            continue
+        for row in json.loads(existing_raw):
+            number = str(row["number"])
+            labels = {lbl["name"] for lbl in row.get("labels") or []}
+            if "client-release:drift" not in labels:
+                continue
+            comment = "\n".join([
+                "Watchdog now reports this platform as aligned with upstream (or not ahead of the pin).",
+                "",
+                f"- Platform: `{platform_id}`",
+                f"- Pinned: `{item.get('pinned')}`",
+                f"- Upstream latest: `{upstream}`",
+                f"- Watchdog run: {report.get('run_url') or 'n/a'}",
+            ]) + "\n"
+            sh(["gh", "issue", "comment", number, "--body", comment])
+            subprocess.run([
+                "gh", "issue", "edit", number,
+                "--add-label", "client-release:aligned",
+                "--remove-label", "client-release:drift",
+            ], text=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            sh(["gh", "issue", "close", number, "--comment", "Closing because upstream is no longer ahead of the TokenKey pin."])
+            print(f"closed drift issue #{number} for {platform_id}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--report-json", type=pathlib.Path, default=DEFAULT_REPORT)
+    ap.add_argument("--cache-dir", type=pathlib.Path, default=DEFAULT_CACHE_DIR)
+    ap.add_argument(
+        "--umbrella",
+        action="store_true",
+        help="Tag issues with client-fidelity-watch (umbrella workflow)",
+    )
+    args = ap.parse_args(argv)
+    if not args.report_json.is_file():
+        print(f"missing report: {args.report_json}", file=sys.stderr)
+        return 2
+    report = json.loads(args.report_json.read_text(encoding="utf-8"))
+    sync_issues(report, cache_dir=args.cache_dir, umbrella=args.umbrella)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/fingerprint/test_open_client_release_watch_issues.py
+++ b/ops/fingerprint/test_open_client_release_watch_issues.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Unit tests for client-release-watch issue helpers."""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from open_client_release_watch_issues import filename_safe, issue_body_path
+
+
+class OpenClientReleaseWatchIssuesTest(unittest.TestCase):
+    def test_issue_body_path_is_filesystem_safe(self) -> None:
+        platform_id = "claude-code"
+        path = issue_body_path(Path(".cache/fingerprint/client-release-watch"), platform_id)
+        self.assertEqual(path.name, f"issue-{filename_safe(platform_id)}.md")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/observability/open_prompt_surface_watch_issues.py
+++ b/ops/observability/open_prompt_surface_watch_issues.py
@@ -12,8 +12,11 @@ import sys
 SIG_REGISTRY = "ps-sig:registry-gate-failure"
 SIG_PROD_DRIFT = "ps-sig:prod-drift"
 
+LABEL_CLIENT_FIDELITY = "client-fidelity-watch"
+
 BASE_LABELS = {
     "prompt-surface-watch": ("BFD4F2", "Prompt surface watch signal"),
+    LABEL_CLIENT_FIDELITY: ("1D76DB", "Client fidelity umbrella watch"),
     "automated": ("C5DEF5", "Automated signal"),
     "needs-triage": ("FBCA04", "Needs human triage"),
     "prompt-surface:registry-failure": ("D73A4A", "Registry/fixture gate failed"),
@@ -26,6 +29,15 @@ BASE_LABELS = {
 
 def label_safe(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.:-]+", "-", value)[:50] or "unknown"
+
+
+def filename_safe(value: str) -> str:
+    """Filesystem-safe slug (GitHub artifact upload rejects colons in paths)."""
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value)[:80] or "unknown"
+
+
+def issue_body_path(sig_label: str) -> pathlib.Path:
+    return pathlib.Path(f".cache/prompt-surface-watch/issue-{filename_safe(sig_label)}.md")
 
 
 def sh(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -132,7 +144,7 @@ def open_or_update_issue(
     ensure_base_labels()
     labels_csv = ",".join(drift_labels)
     existing = find_open_issue(sig_label)
-    body_path = pathlib.Path(f".cache/prompt-surface-watch/issue-{label_safe(sig_label)}.md")
+    body_path = issue_body_path(sig_label)
     body_path.parent.mkdir(parents=True, exist_ok=True)
     body_path.write_text(body, encoding="utf-8")
     if existing:
@@ -156,16 +168,22 @@ def close_issue(number: str, comment: str) -> None:
     print(f"closed issue #{number}")
 
 
+def drift_labels_for(base: list[str], *, umbrella: bool) -> list[str]:
+    if umbrella and LABEL_CLIENT_FIDELITY not in base:
+        return [base[0], LABEL_CLIENT_FIDELITY, *base[1:]]
+    return base
+
+
 def cmd_registry_failure(args: argparse.Namespace) -> int:
     body = registry_failure_body(args.run_url)
     open_or_update_issue(
         sig_label=SIG_REGISTRY,
         title="[prompt-surface] registry-gate failed",
         body=body,
-        drift_labels=[
+        drift_labels=drift_labels_for([
             "prompt-surface-watch", "automated", "needs-triage",
             "prompt-surface:registry-failure", SIG_REGISTRY,
-        ],
+        ], umbrella=args.umbrella),
     )
     return 0
 
@@ -197,10 +215,10 @@ def cmd_prod_sync(args: argparse.Namespace) -> int:
             sig_label=SIG_PROD_DRIFT,
             title="[prompt-surface] prod fingerprint actionable drift",
             body=body,
-            drift_labels=[
+            drift_labels=drift_labels_for([
                 "prompt-surface-watch", "automated", "needs-triage",
                 "prompt-surface:prod-drift", SIG_PROD_DRIFT,
-            ],
+            ], umbrella=args.umbrella),
         )
         return 0
     ensure_base_labels()
@@ -218,14 +236,17 @@ def main(argv: list[str] | None = None) -> int:
 
     p_fail = sub.add_parser("registry-failure")
     p_fail.add_argument("--run-url", default="")
+    p_fail.add_argument("--umbrella", action="store_true")
 
     p_rec = sub.add_parser("registry-recover")
     p_rec.add_argument("--run-url", default="")
+    p_rec.add_argument("--umbrella", action="store_true")
 
     p_prod = sub.add_parser("prod-sync")
     p_prod.add_argument("--report-json", type=pathlib.Path, required=True)
     p_prod.add_argument("--report-md", type=pathlib.Path)
     p_prod.add_argument("--run-url", default="")
+    p_prod.add_argument("--umbrella", action="store_true")
 
     args = ap.parse_args(argv)
     if args.command == "registry-failure":

--- a/ops/observability/test_open_prompt_surface_watch_issues.py
+++ b/ops/observability/test_open_prompt_surface_watch_issues.py
@@ -11,6 +11,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from open_prompt_surface_watch_issues import (
     SIG_PROD_DRIFT,
     SIG_REGISTRY,
+    filename_safe,
+    issue_body_path,
     prod_drift_body,
     prod_recover_body,
     registry_failure_body,
@@ -43,6 +45,12 @@ class OpenPromptSurfaceWatchIssuesTest(unittest.TestCase):
         body = prod_recover_body("https://example/run/3", {"summary": {"count": 10, "has_actionable_drift": False}})
         self.assertIn("no actionable prod fingerprint drift", body)
         self.assertIn("https://example/run/3", body)
+
+    def test_issue_body_path_strips_colons_for_artifacts(self) -> None:
+        path = issue_body_path(SIG_PROD_DRIFT)
+        self.assertNotIn(":", path.name)
+        self.assertEqual(path.name, f"issue-{filename_safe(SIG_PROD_DRIFT)}.md")
+        self.assertIn("ps-sig-prod-drift", path.name)
 
 
 if __name__ == "__main__":

--- a/scripts/fingerprint/client_fidelity_watch_report.py
+++ b/scripts/fingerprint/client_fidelity_watch_report.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +16,12 @@ ROUTING_TABLE = [
         "label": "client-release:drift",
         "skill": "tokenkey-fingerprint-alignment-all or per-platform skill",
         "next_command": "bash ops/fingerprint/client-release-watch.sh plan",
+    },
+    {
+        "signal_type": "release-scan-failure",
+        "label": "client-release-watch",
+        "skill": "(inspect client release watch run)",
+        "next_command": "python3 scripts/fingerprint/client_release_watch.py --selftest",
     },
     {
         "signal_type": "registry-failure",
@@ -43,10 +48,18 @@ def collect_signals(
     *,
     release_report: dict[str, Any] | None,
     prompt_prod_report: dict[str, Any] | None,
+    release_scan_result: str,
     registry_gate_result: str,
     prod_aggregate_result: str,
 ) -> list[dict[str, Any]]:
     signals: list[dict[str, Any]] = []
+
+    if release_scan_result == "failure":
+        signals.append({
+            "signal_type": "release-scan-failure",
+            "status": "actionable",
+            "detail": "release-scan job failed before producing a usable client release report",
+        })
 
     if registry_gate_result == "failure":
         signals.append({
@@ -84,7 +97,12 @@ def collect_signals(
             "detail": "prod-aggregate job failed (probe/aggregate error or actionable drift)",
         })
 
-    if not signals and registry_gate_result == "success" and prod_aggregate_result in {"success", "skipped"}:
+    if (
+        not signals
+        and release_scan_result == "success"
+        and registry_gate_result == "success"
+        and prod_aggregate_result in {"success", "skipped"}
+    ):
         signals.append({"signal_type": "aligned", "status": "clear", "detail": "no actionable fidelity signals"})
 
     return signals
@@ -110,6 +128,8 @@ def render_markdown(payload: dict[str, Any]) -> str:
             lines.append(
                 f"- **release-drift** `{sig.get('platform_id')}`: pin `{sig.get('pinned')}` < upstream `{sig.get('upstream_latest')}` → skill `{sig.get('skill')}`"
             )
+        elif st == "release-scan-failure":
+            lines.append(f"- **release-scan-failure**: {sig.get('detail')}")
         elif st == "registry-failure":
             lines.append(f"- **registry-failure**: {sig.get('detail')}")
         elif st == "prod-drift":
@@ -142,6 +162,7 @@ def build_payload(
     release_markdown: str | None,
     prompt_prod_report: dict[str, Any] | None,
     prompt_prod_markdown: str | None,
+    release_scan_result: str,
     registry_gate_result: str,
     prod_aggregate_result: str,
 ) -> dict[str, Any]:
@@ -150,13 +171,15 @@ def build_payload(
     signals = collect_signals(
         release_report=release_report,
         prompt_prod_report=prompt_prod_report,
+        release_scan_result=release_scan_result,
         registry_gate_result=registry_gate_result,
         prod_aggregate_result=prod_aggregate_result,
     )
     workflow_should_fail = any(
-        sig.get("signal_type") in {"registry-failure", "prod-drift"} and sig.get("status") == "actionable"
+        sig.get("signal_type") in {"release-scan-failure", "registry-failure", "prod-drift"}
+        and sig.get("status") == "actionable"
         for sig in signals
-    ) or registry_gate_result == "failure" or prod_aggregate_result == "failure"
+    ) or release_scan_result == "failure" or registry_gate_result == "failure" or prod_aggregate_result == "failure"
 
     return {
         "schema_version": 1,
@@ -164,7 +187,7 @@ def build_payload(
         "run_url": run_url,
         "workflow_should_fail": workflow_should_fail,
         "job_results": {
-            "release-scan": "success",
+            "release-scan": release_scan_result,
             "registry-gate": registry_gate_result,
             "prod-aggregate": prod_aggregate_result,
         },
@@ -185,6 +208,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--release-report-md", type=Path)
     ap.add_argument("--prompt-prod-report-json", type=Path)
     ap.add_argument("--prompt-prod-report-md", type=Path)
+    ap.add_argument("--release-scan-result", default="success")
     ap.add_argument("--registry-gate-result", default="unknown")
     ap.add_argument("--prod-aggregate-result", default="unknown")
     ap.add_argument("--run-url", default="")
@@ -200,6 +224,7 @@ def main(argv: list[str] | None = None) -> int:
             release_markdown=None,
             prompt_prod_report={"summary": {"has_actionable_drift": True, "alerts": ["x=1"], "count": 1}},
             prompt_prod_markdown="- alert",
+            release_scan_result="success",
             registry_gate_result="success",
             prod_aggregate_result="failure",
         )
@@ -208,6 +233,19 @@ def main(argv: list[str] | None = None) -> int:
         assert any(s["signal_type"] == "prod-drift" for s in payload["signals"])
         md = render_markdown(payload)
         assert "release-drift" in md and "prod-drift" in md
+        failed_release = build_payload(
+            run_url="https://example/run/2",
+            release_report=None,
+            release_markdown=None,
+            prompt_prod_report=None,
+            prompt_prod_markdown=None,
+            release_scan_result="failure",
+            registry_gate_result="skipped",
+            prod_aggregate_result="skipped",
+        )
+        assert failed_release["workflow_should_fail"] is True
+        assert failed_release["job_results"]["release-scan"] == "failure"
+        assert any(s["signal_type"] == "release-scan-failure" for s in failed_release["signals"])
         print("client-fidelity-watch report selftest ok")
         return 0
 
@@ -222,6 +260,7 @@ def main(argv: list[str] | None = None) -> int:
         release_markdown=release_md,
         prompt_prod_report=prompt_prod_report,
         prompt_prod_markdown=prompt_md,
+        release_scan_result=args.release_scan_result,
         registry_gate_result=args.registry_gate_result,
         prod_aggregate_result=args.prod_aggregate_result,
     )

--- a/scripts/fingerprint/client_fidelity_watch_report.py
+++ b/scripts/fingerprint/client_fidelity_watch_report.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Merge client-release + prompt-surface watch outputs into one daily fidelity report."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUT_DIR = REPO_ROOT / ".cache/fingerprint/client-fidelity-watch"
+
+ROUTING_TABLE = [
+    {
+        "signal_type": "release-drift",
+        "label": "client-release:drift",
+        "skill": "tokenkey-fingerprint-alignment-all or per-platform skill",
+        "next_command": "bash ops/fingerprint/client-release-watch.sh plan",
+    },
+    {
+        "signal_type": "registry-failure",
+        "label": "prompt-surface:registry-failure",
+        "skill": "(inline fix — registry + fixture gateway tests)",
+        "next_command": "python3 ops/anthropic/probe_prompt_surfaces.py --check-registry",
+    },
+    {
+        "signal_type": "prod-drift",
+        "label": "prompt-surface:prod-drift",
+        "skill": "(compare prod fingerprints vs prompt_surface_registry.json)",
+        "next_command": "bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-prompt-surface-fingerprints.sh --env SINCE=24h --env LIMIT=40",
+    },
+]
+
+
+def load_json(path: Path | None) -> dict[str, Any] | None:
+    if path is None or not path.is_file():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def collect_signals(
+    *,
+    release_report: dict[str, Any] | None,
+    prompt_prod_report: dict[str, Any] | None,
+    registry_gate_result: str,
+    prod_aggregate_result: str,
+) -> list[dict[str, Any]]:
+    signals: list[dict[str, Any]] = []
+
+    if registry_gate_result == "failure":
+        signals.append({
+            "signal_type": "registry-failure",
+            "status": "actionable",
+            "detail": "registry-gate job failed (registry, fixture gateway, or unit tests)",
+        })
+
+    if release_report:
+        for item in release_report.get("platforms") or []:
+            if item.get("drift") and not item.get("issue_suppressed"):
+                signals.append({
+                    "signal_type": "release-drift",
+                    "status": "actionable",
+                    "platform_id": item.get("id"),
+                    "name": item.get("name"),
+                    "pinned": item.get("pinned"),
+                    "upstream_latest": item.get("upstream_latest"),
+                    "skill": item.get("skill"),
+                })
+
+    if prompt_prod_report:
+        summary = prompt_prod_report.get("summary") or {}
+        if summary.get("has_actionable_drift"):
+            signals.append({
+                "signal_type": "prod-drift",
+                "status": "actionable",
+                "alerts": summary.get("alerts") or [],
+                "rows": summary.get("count", 0),
+            })
+    elif prod_aggregate_result == "failure" and registry_gate_result == "success":
+        signals.append({
+            "signal_type": "prod-drift",
+            "status": "actionable",
+            "detail": "prod-aggregate job failed (probe/aggregate error or actionable drift)",
+        })
+
+    if not signals and registry_gate_result == "success" and prod_aggregate_result in {"success", "skipped"}:
+        signals.append({"signal_type": "aligned", "status": "clear", "detail": "no actionable fidelity signals"})
+
+    return signals
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Client fidelity watch — daily report",
+        "",
+        f"- Generated: `{payload.get('generated_at')}`",
+        f"- Run: {payload.get('run_url') or 'n/a'}",
+        f"- Workflow blocking: `{payload.get('workflow_should_fail')}`",
+        "",
+        "## Job results",
+        "",
+    ]
+    for name, result in (payload.get("job_results") or {}).items():
+        lines.append(f"- `{name}`: **{result}**")
+    lines.extend(["", "## Signals", ""])
+    for sig in payload.get("signals") or []:
+        st = sig.get("signal_type")
+        if st == "release-drift":
+            lines.append(
+                f"- **release-drift** `{sig.get('platform_id')}`: pin `{sig.get('pinned')}` < upstream `{sig.get('upstream_latest')}` → skill `{sig.get('skill')}`"
+            )
+        elif st == "registry-failure":
+            lines.append(f"- **registry-failure**: {sig.get('detail')}")
+        elif st == "prod-drift":
+            alerts = sig.get("alerts") or []
+            if alerts:
+                lines.append(f"- **prod-drift**: {', '.join(alerts)}")
+            else:
+                lines.append(f"- **prod-drift**: {sig.get('detail', 'actionable drift')}")
+        elif st == "aligned":
+            lines.append("- **aligned**: no actionable signals")
+    lines.extend(["", "## Issue routing (by signal type)", ""])
+    lines.append("| Signal type | GitHub label | Next command |")
+    lines.append("|---|---|---|")
+    for row in ROUTING_TABLE:
+        lines.append(f"| `{row['signal_type']}` | `{row['label']}` | `{row['next_command']}` |")
+    lines.append("")
+    release_md = payload.get("sections", {}).get("release_markdown")
+    if release_md:
+        lines.extend(["## Client release watch (detail)", "", release_md.strip(), ""])
+    prompt_md = payload.get("sections", {}).get("prompt_prod_markdown")
+    if prompt_md:
+        lines.extend(["## Prompt surface prod aggregate (detail)", "", prompt_md.strip(), ""])
+    return "\n".join(lines) + "\n"
+
+
+def build_payload(
+    *,
+    run_url: str,
+    release_report: dict[str, Any] | None,
+    release_markdown: str | None,
+    prompt_prod_report: dict[str, Any] | None,
+    prompt_prod_markdown: str | None,
+    registry_gate_result: str,
+    prod_aggregate_result: str,
+) -> dict[str, Any]:
+    from datetime import datetime, timezone
+
+    signals = collect_signals(
+        release_report=release_report,
+        prompt_prod_report=prompt_prod_report,
+        registry_gate_result=registry_gate_result,
+        prod_aggregate_result=prod_aggregate_result,
+    )
+    workflow_should_fail = any(
+        sig.get("signal_type") in {"registry-failure", "prod-drift"} and sig.get("status") == "actionable"
+        for sig in signals
+    ) or registry_gate_result == "failure" or prod_aggregate_result == "failure"
+
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "run_url": run_url,
+        "workflow_should_fail": workflow_should_fail,
+        "job_results": {
+            "release-scan": "success",
+            "registry-gate": registry_gate_result,
+            "prod-aggregate": prod_aggregate_result,
+        },
+        "signals": signals,
+        "routing_table": ROUTING_TABLE,
+        "sections": {
+            "release_markdown": release_markdown,
+            "prompt_prod_markdown": prompt_prod_markdown,
+        },
+        "release_summary": (release_report or {}).get("summary"),
+        "prompt_prod_summary": (prompt_prod_report or {}).get("summary") if prompt_prod_report else None,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--release-report-json", type=Path)
+    ap.add_argument("--release-report-md", type=Path)
+    ap.add_argument("--prompt-prod-report-json", type=Path)
+    ap.add_argument("--prompt-prod-report-md", type=Path)
+    ap.add_argument("--registry-gate-result", default="unknown")
+    ap.add_argument("--prod-aggregate-result", default="unknown")
+    ap.add_argument("--run-url", default="")
+    ap.add_argument("--report-json", type=Path, default=DEFAULT_OUT_DIR / "report.json")
+    ap.add_argument("--report-md", type=Path, default=DEFAULT_OUT_DIR / "report.md")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.selftest:
+        payload = build_payload(
+            run_url="https://example/run/1",
+            release_report={"platforms": [{"id": "claude-code", "drift": True, "issue_suppressed": False, "name": "CC", "pinned": "1", "upstream_latest": "2", "skill": "tokenkey-cc-fingerprint-alignment"}], "summary": {}},
+            release_markdown=None,
+            prompt_prod_report={"summary": {"has_actionable_drift": True, "alerts": ["x=1"], "count": 1}},
+            prompt_prod_markdown="- alert",
+            registry_gate_result="success",
+            prod_aggregate_result="failure",
+        )
+        assert payload["workflow_should_fail"] is True
+        assert any(s["signal_type"] == "release-drift" for s in payload["signals"])
+        assert any(s["signal_type"] == "prod-drift" for s in payload["signals"])
+        md = render_markdown(payload)
+        assert "release-drift" in md and "prod-drift" in md
+        print("client-fidelity-watch report selftest ok")
+        return 0
+
+    release_report = load_json(args.release_report_json)
+    prompt_prod_report = load_json(args.prompt_prod_report_json)
+    release_md = args.release_report_md.read_text(encoding="utf-8") if args.release_report_md and args.release_report_md.is_file() else None
+    prompt_md = args.prompt_prod_report_md.read_text(encoding="utf-8") if args.prompt_prod_report_md and args.prompt_prod_report_md.is_file() else None
+
+    payload = build_payload(
+        run_url=args.run_url,
+        release_report=release_report,
+        release_markdown=release_md,
+        prompt_prod_report=prompt_prod_report,
+        prompt_prod_markdown=prompt_md,
+        registry_gate_result=args.registry_gate_result,
+        prod_aggregate_result=args.prod_aggregate_result,
+    )
+    args.report_json.parent.mkdir(parents=True, exist_ok=True)
+    args.report_json.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    args.report_md.write_text(render_markdown(payload), encoding="utf-8")
+    print(render_markdown(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 摘要

- 新增 `client-fidelity-watch.yml` umbrella workflow：每日顺序执行 release scan → prompt registry-gate → prod aggregate → daily report，统一运营入口与 `client-fidelity-watch` label
- 将 `client-release-watch` / `prompt-surface-watch` 的 cron 迁移到 umbrella；原 workflow 保留 `workflow_dispatch` 作为手动 legacy 入口
- 抽取 `open_client_release_watch_issues.py`，修复 prompt-surface issue cache 路径含 `:` 导致 artifact 上传失败的问题，并更新 `tokenkey-fingerprint-alignment-all` skill 指向新 workflow
- 修复 daily report 对 release-scan 失败的状态表达：release scan 失败会进入 job results / signals，并标记 workflow blocking

## 风险

- 常规风险：CI workflow 编排与 issue 脚本重构；无 schema / 鉴权 / Web 变更（commit 含 `Web impact: none`）
- release drift 仍只开 issue、不变红（既有设计）；release-scan 运行失败、registry-gate 失败、prod drift / prod aggregate 失败会使 umbrella workflow 或报告标红
- 日常 cron 从两个独立 workflow 合并到一个 schedule，需观察首日 run 时序与 issue 去重

## 验证

- `./scripts/preflight.sh` — PASS（含 client release watch 8 tests、prompt surface drift 6 tests）
- `python3 -m unittest ops.observability.test_open_prompt_surface_watch_issues ops.fingerprint.test_open_client_release_watch_issues`
- `python3 scripts/fingerprint/client_fidelity_watch_report.py --selftest`
- `python3 scripts/fingerprint/client_fidelity_watch_report.py --release-scan-result failure --registry-gate-result skipped --prod-aggregate-result skipped --report-json /tmp/client-fidelity-failed-release.json --report-md /tmp/client-fidelity-failed-release.md`

## 提交

- 16adcf0b4 feat(ci): unify client release + prompt surface into client-fidelity-watch umbrella
- 1de800be2 fix(ci): surface release scan failures in fidelity report
- 最新提交：1de800be2
