### PR TITLE
fix(kiro): 规范化 dated Claude id 并扩充 Kiro 可服务模型清单

### DIFF
--- a/.cursor/skills/tokenkey-account-model-probe/SKILL.md
+++ b/.cursor/skills/tokenkey-account-model-probe/SKILL.md
@@ -79,3 +79,16 @@ bash ops/observability/run-probe.sh \
 ```
 
 For Kiro OAuth auth drift, switch to `tokenkey-kiro-reauth`. For any modelops work (catalog refresh, mapping drift, onboard), enter via `tokenkey-modelops-planner` first.
+
+## Batch Kiro Claude model matrix
+
+When validating which Claude ids a Kiro account (native edge OAuth or prod mirror stub) actually serves, run the batch wrapper (loops `probe_account_model.sh`):
+
+```bash
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/stage0/probe_kiro_claude_models.sh \
+  --env ACCOUNT_ID=66
+```
+
+Override the default model list with `MODELS="claude-haiku-4-5 claude-opus-4-8 ..."` if needed.

--- a/backend/internal/handler/admin/account_handler_available_models_test.go
+++ b/backend/internal/handler/admin/account_handler_available_models_test.go
@@ -371,7 +371,8 @@ func TestAccountHandlerGetAvailableModels_KiroOAuthUsesShortModelIDs(t *testing.
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	ids := modelIDSet(resp.Data)
 	require.True(t, ids["claude-sonnet-4-5"])
-	require.False(t, ids["claude-sonnet-4-5-20250929"], "Kiro rejects Anthropic dated snapshot IDs")
+	require.True(t, ids["claude-haiku-4-5"], "Kiro serves Haiku 4.5 on CodeWhisperer")
+	require.False(t, ids["claude-sonnet-4-5-20250929"], "admin list exposes short IDs only; dated IDs are normalized at forward time")
 }
 
 func TestAccountHandlerGetAvailableModels_GrokUsesGrokCatalog(t *testing.T) {

--- a/backend/internal/integration/kiro/translator.go
+++ b/backend/internal/integration/kiro/translator.go
@@ -37,6 +37,16 @@ var modelAliases = []modelMapping{
 // (claude-sonnet-4-20250514) are not accidentally rewritten.
 var claudeVersionPattern = regexp.MustCompile(`claude-(opus|sonnet|haiku)-(\d+)-(\d{1,2})\b`)
 
+// claudeDatedSnapshotSuffix strips Anthropic dated snapshot tails such as
+// -20251001 after dash→dot normalization (claude-haiku-4-5-20251001 →
+// claude-haiku-4.5-20251001 → claude-haiku-4.5). Kiro/CodeWhisperer rejects
+// the intermediate form with HTTP 400 INVALID_MODEL_ID.
+var claudeDatedSnapshotSuffix = regexp.MustCompile(`(?i)-20\d{6}$`)
+
+func stripAnthropicDatedSnapshot(model string) string {
+	return claudeDatedSnapshotSuffix.ReplaceAllString(model, "")
+}
+
 // Thinking 模式提示
 const ThinkingModePrompt = `<thinking_mode>enabled</thinking_mode>
 <max_thinking_length>200000</max_thinking_length>`
@@ -80,19 +90,21 @@ func ParseModelAndThinking(model string, thinkingSuffix string) (string, bool) {
 	// 1) Explicit aliases: dated snapshots, cross-family legacy IDs, non-Anthropic fallbacks.
 	for _, m := range modelAliases {
 		if strings.Contains(lower, m.key) {
-			return m.value, thinking
+			return stripAnthropicDatedSnapshot(m.value), thinking
 		}
 	}
 
 	// 2) Format normalization: claude-{family}-N-M → claude-{family}-N.M.
 	//    New versions (claude-opus-4-8, etc.) flow through here without code changes.
 	if claudeVersionPattern.MatchString(lower) {
-		return claudeVersionPattern.ReplaceAllString(lower, "claude-$1-$2.$3"), thinking
+		return stripAnthropicDatedSnapshot(
+			claudeVersionPattern.ReplaceAllString(lower, "claude-$1-$2.$3"),
+		), thinking
 	}
 
 	// 3) Already a valid Kiro model (dot form or bare family like claude-sonnet-4): pass through.
 	if strings.HasPrefix(lower, "claude-") {
-		return model, thinking
+		return stripAnthropicDatedSnapshot(model), thinking
 	}
 
 	return model, thinking

--- a/backend/internal/integration/kiro/translator_test.go
+++ b/backend/internal/integration/kiro/translator_test.go
@@ -39,6 +39,19 @@ func TestClaudeToKiro_MinimalUserMessage(t *testing.T) {
 	}
 }
 
+func TestMapModel_DatedAnthropicSnapshotsStripToDotForm(t *testing.T) {
+	cases := map[string]string{
+		"claude-haiku-4-5-20251001":  "claude-haiku-4.5",
+		"claude-sonnet-4-5-20250929": "claude-sonnet-4.5",
+		"claude-opus-4-8":            "claude-opus-4.8",
+	}
+	for input, want := range cases {
+		if got := MapModel(input); got != want {
+			t.Fatalf("MapModel(%q): want %q, got %q", input, want, got)
+		}
+	}
+}
+
 // TestKiroToClaudeResponse_Basic asserts the basic fields of the Claude-shaped
 // response synthesized from a Kiro completion.
 func TestKiroToClaudeResponse_Basic(t *testing.T) {

--- a/backend/internal/service/account_tk_kiro.go
+++ b/backend/internal/service/account_tk_kiro.go
@@ -31,16 +31,24 @@ func (a *Account) IsKiroMirrorStub() bool {
 
 const KiroDefaultTestModel = "claude-sonnet-4-5"
 
-// KiroAdminTestModels returns the safe client-facing model IDs for admin account
-// tests. Kiro rejects dated Anthropic snapshot IDs such as
-// claude-sonnet-4-5-20250929; the Kiro translator accepts the short IDs and
-// normalizes them to the CodeWhisperer wire form.
+// KiroAdminTestModels returns the empirically-servable client-facing Claude model
+// IDs for admin account tests and mapping presets. Dated Anthropic snapshot IDs
+// (e.g. claude-haiku-4-5-20251001) are normalized by the Kiro translator before
+// upstream; this list intentionally exposes the short undated IDs operators should
+// pick in the admin UI. Live probe source: ops/stage0/probe_kiro_claude_models.sh
+// (edge us6 account 2 + prod mirror 66, 2026-07-02).
 func KiroAdminTestModels() []claude.Model {
 	return []claude.Model{
 		{
 			ID:          KiroDefaultTestModel,
 			Type:        "model",
 			DisplayName: "Claude Sonnet 4.5",
+			CreatedAt:   "",
+		},
+		{
+			ID:          "claude-haiku-4-5",
+			Type:        "model",
+			DisplayName: "Claude Haiku 4.5",
 			CreatedAt:   "",
 		},
 		{
@@ -53,6 +61,24 @@ func KiroAdminTestModels() []claude.Model {
 			ID:          "claude-sonnet-5",
 			Type:        "model",
 			DisplayName: "Claude Sonnet 5",
+			CreatedAt:   "",
+		},
+		{
+			ID:          "claude-opus-4-5",
+			Type:        "model",
+			DisplayName: "Claude Opus 4.5",
+			CreatedAt:   "",
+		},
+		{
+			ID:          "claude-opus-4-6",
+			Type:        "model",
+			DisplayName: "Claude Opus 4.6",
+			CreatedAt:   "",
+		},
+		{
+			ID:          "claude-opus-4-7",
+			Type:        "model",
+			DisplayName: "Claude Opus 4.7",
 			CreatedAt:   "",
 		},
 		{

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown.go
@@ -57,6 +57,7 @@ const (
 	anthropicModelClassOpus    = "opus"
 	anthropicModelClassSonnet  = "sonnet"
 	anthropicModelClassHaiku   = "haiku"
+	anthropicModelClassFable   = "fable"
 	anthropicModelClassUnknown = ""
 
 	// tkAnthropicModelCooldownReason is recorded on the model_rate_limits
@@ -77,7 +78,7 @@ const (
 )
 
 // tkAnthropicModelClass normalizes an Anthropic model name to its capacity
-// class (opus / sonnet / haiku). Returns "" when the class can't be
+// class (opus / sonnet / haiku / fable). Returns "" when the class can't be
 // determined — callers MUST treat unknown as "not model-scoped" and fall
 // back to account-level handling rather than guessing.
 //
@@ -96,6 +97,8 @@ func tkAnthropicModelClass(model string) string {
 		return anthropicModelClassSonnet
 	case strings.Contains(name, "haiku"):
 		return anthropicModelClassHaiku
+	case strings.Contains(name, "fable"):
+		return anthropicModelClassFable
 	default:
 		return anthropicModelClassUnknown
 	}

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
@@ -43,6 +43,8 @@ func TestTkAnthropicModelClass_Boundaries(t *testing.T) {
 		{"claude-3-5-sonnet-20241022", anthropicModelClassSonnet},
 		{"claude-3-5-haiku-20241022", anthropicModelClassHaiku},
 		{"claude-haiku-4-5", anthropicModelClassHaiku},
+		{"claude-fable-5", anthropicModelClassFable},
+		{"fable", anthropicModelClassFable},
 		{"  claude-opus-4-8  ", anthropicModelClassOpus},
 		{"", anthropicModelClassUnknown},
 		{"gpt-5.4", anthropicModelClassUnknown},
@@ -58,6 +60,7 @@ func TestTkAnthropicModelClassScopeKeyForModel(t *testing.T) {
 	require.Equal(t, tkModelClassScope("opus"), tkAnthropicModelClassScopeKeyForModel("claude-opus-4-8"))
 	require.Equal(t, tkModelClassScope("sonnet"), tkAnthropicModelClassScopeKeyForModel("claude-sonnet-4-5"))
 	require.Equal(t, tkModelClassScope("haiku"), tkAnthropicModelClassScopeKeyForModel("claude-3-5-haiku"))
+	require.Equal(t, tkModelClassScope("fable"), tkAnthropicModelClassScopeKeyForModel("claude-fable-5"))
 	require.Empty(t, tkAnthropicModelClassScopeKeyForModel("gpt-5.4"))
 	require.Empty(t, tkAnthropicModelClassScopeKeyForModel(""))
 }

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Canonical account-model gateway probe — also used by edge native oauth smoke.
+# Batch Kiro Claude matrix: ops/stage0/probe_kiro_claude_models.sh (see tokenkey-account-model-probe skill).
 # Skill wrapper: .cursor/skills/tokenkey-account-model-probe/scripts/probe_account_model.sh
 set -euo pipefail
 

--- a/ops/stage0/probe_kiro_claude_models.sh
+++ b/ops/stage0/probe_kiro_claude_models.sh
@@ -8,14 +8,46 @@ MODELS="${MODELS:-claude-haiku-4-5-20251001 claude-haiku-4-5 claude-sonnet-4-5 c
 MAX_TOKENS="${MAX_TOKENS:-8}"
 REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-60}"
 
-results=()
 for model in $MODELS; do
-  out="$(ACCOUNT_ID="$ACCOUNT_ID" MODEL="$model" ENDPOINT=messages MAX_TOKENS="$MAX_TOKENS" \
+  err_file="$(mktemp)"
+  probe_error=""
+  if ! out="$(ACCOUNT_ID="$ACCOUNT_ID" MODEL="$model" ENDPOINT=messages MAX_TOKENS="$MAX_TOKENS" \
     REQUEST_TIMEOUT_SECONDS="$REQUEST_TIMEOUT_SECONDS" PROBE_REUSE_MODE=1 \
-    bash "$SCRIPT_DIR/probe_account_model.sh" 2>/dev/null || true)"
-  verdict="$(printf '%s' "$out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("verdict","parse_error"))' 2>/dev/null || echo parse_error)"
-  http_code="$(printf '%s' "$out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("http_status",""))' 2>/dev/null || echo "")"
-  err_msg="$(printf '%s' "$out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print((d.get("response_body_excerpt") or d.get("error") or "")[:120])' 2>/dev/null || echo "")"
-  printf '{"model":"%s","verdict":"%s","http_status":"%s","detail":"%s"}\n' \
-    "$model" "$verdict" "$http_code" "$(printf '%s' "$err_msg" | sed 's/"/\\"/g')"
+    bash "$SCRIPT_DIR/probe_account_model.sh" 2>"$err_file")"; then
+    probe_error="$(tr '\n' ' ' <"$err_file" | sed -E 's/[[:space:]]+/ /g' | cut -c1-240)"
+  fi
+  rm -f "$err_file"
+  TK_PROBE_RESULT_JSON="$out" TK_PROBE_ERROR="$probe_error" python3 - "$model" <<'PY'
+import json
+import os
+import re
+import sys
+
+model = sys.argv[1]
+raw = os.environ.get("TK_PROBE_RESULT_JSON", "")
+probe_error = os.environ.get("TK_PROBE_ERROR", "")
+
+try:
+    data = json.loads(raw)
+except Exception as exc:
+    detail = re.sub(r"\s+", " ", probe_error or str(exc)).strip()
+    row = {
+        "model": model,
+        "verdict": "parse_error",
+        "http_code": "",
+        "detail": detail[:120],
+    }
+else:
+    response = data.get("response") or {}
+    detail = response.get("body_excerpt") or data.get("error") or ""
+    detail = re.sub(r"\s+", " ", str(detail)).strip()
+    row = {
+        "model": model,
+        "verdict": data.get("verdict", "parse_error"),
+        "http_code": data.get("http_code", ""),
+        "detail": detail[:120],
+    }
+
+print(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+PY
 done

--- a/ops/stage0/probe_kiro_claude_models.sh
+++ b/ops/stage0/probe_kiro_claude_models.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Batch-probe Claude model IDs against one Kiro account via the gateway probe harness.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACCOUNT_ID="${ACCOUNT_ID:?ACCOUNT_ID required}"
+MODELS="${MODELS:-claude-haiku-4-5-20251001 claude-haiku-4-5 claude-sonnet-4-5 claude-sonnet-4-6 claude-sonnet-5 claude-opus-4-5 claude-opus-4-6 claude-opus-4-7 claude-opus-4-8 claude-opus-5}"
+MAX_TOKENS="${MAX_TOKENS:-8}"
+REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-60}"
+
+results=()
+for model in $MODELS; do
+  out="$(ACCOUNT_ID="$ACCOUNT_ID" MODEL="$model" ENDPOINT=messages MAX_TOKENS="$MAX_TOKENS" \
+    REQUEST_TIMEOUT_SECONDS="$REQUEST_TIMEOUT_SECONDS" PROBE_REUSE_MODE=1 \
+    bash "$SCRIPT_DIR/probe_account_model.sh" 2>/dev/null || true)"
+  verdict="$(printf '%s' "$out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("verdict","parse_error"))' 2>/dev/null || echo parse_error)"
+  http_code="$(printf '%s' "$out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("http_status",""))' 2>/dev/null || echo "")"
+  err_msg="$(printf '%s' "$out" | python3 -c 'import json,sys; d=json.load(sys.stdin); print((d.get("response_body_excerpt") or d.get("error") or "")[:120])' 2>/dev/null || echo "")"
+  printf '{"model":"%s","verdict":"%s","http_status":"%s","detail":"%s"}\n' \
+    "$model" "$verdict" "$http_code" "$(printf '%s' "$err_msg" | sed 's/"/\\"/g')"
+done

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1127,6 +1127,7 @@ for _smoke_script in \
   ./ops/stage0/load_smoke_github_env.sh \
   ./ops/stage0/smoke_lib.sh \
   ./ops/stage0/probe_account_model.sh \
+  ./ops/stage0/probe_kiro_claude_models.sh \
   ./ops/stage0/edge_native_anthropic_smoke.sh \
   ./ops/stage0/post_deploy_smoke.sh \
   ./ops/stage0/edge_post_deploy_smoke.sh \


### PR DESCRIPTION
## 摘要

- Kiro translator 在 dash→dot 规范化后剥离 Anthropic dated 后缀（`-20251001` 等），修复 `claude-haiku-4-5-20251001` 被转成 `claude-haiku-4.5-20251001` 导致 CodeWhisperer `INVALID_MODEL_ID` 的问题。
- 按 prod/edge 实测扩充 `KiroAdminTestModels`（新增 haiku 4.5、opus 4.5/4.6/4.7；不含上游未开放的 `claude-opus-5` 与 `claude-fable-5`）。
- Anthropic class 限流 scope 新增 `anthropic:class:fable`，与 opus/sonnet/haiku 对齐（prod Kiro mirror 同样适用）。
- 新增批量探测脚本 `ops/stage0/probe_kiro_claude_models.sh`，接入 account-model-probe skill 与 preflight 语法检查，并修正 JSONL 输出读取 `probe_account_model.sh` 的 `http_code` / `response.body_excerpt` 结构。

sentinel-registry-reviewed

## 风险

- 常规风险：Kiro 上游模型能力以 CodeWhisperer 为准；`claude-fable-5` / `claude-opus-5` 仍会被上游拒绝（已实测），不在 admin 测试列表中。
- dated 后缀剥离仅作用于 Kiro translator 路径，不影响原生 Anthropic OAuth 请求 id 语义与计费 key。
- `Web impact: none` — admin 可用模型列表由后端 API 驱动，前端无硬编码变更。

## 验证

- `./scripts/preflight.sh` PASS
- `go test ./internal/integration/kiro ./internal/service ./internal/handler/admin` PASS
- `bash -n ops/stage0/probe_kiro_claude_models.sh` PASS
- stub 验证 `ops/stage0/probe_kiro_claude_models.sh` 成功/失败两条 JSONL 输出路径 PASS
- prod/edge 实测（发版前基线，account 66 / edge us6 account 2）：
  - servable：`claude-haiku-4-5`、`claude-sonnet-*`、`claude-opus-4.5–4.8`；裸名 `opus`/`sonnet`/`haiku` 经 bare alias 可通
  - upstream_rejected：`claude-fable-5`、`claude-opus-5`、`claude-haiku-4-5-20251001`（发版后 dated haiku 应随 translator 修复变为 servable，需 deploy 后复测）

## 提交

- `8f783f34e` fix(kiro): normalize dated Claude ids and expand servable admin models
- `49e0a6be6` fix(ops): emit valid Kiro probe JSONL

最新提交：49e0a6be6
