### PR TITLE
fix(ci): include release artifact in fidelity report

### DIFF
--- a/.github/workflows/client-fidelity-watch.yml
+++ b/.github/workflows/client-fidelity-watch.yml
@@ -348,8 +348,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .cache/fingerprint/client-fidelity-watch
-          RELEASE_JSON=".cache/fingerprint/client-release-watch/report.json"
-          RELEASE_MD=".cache/fingerprint/client-release-watch/report.md"
+          RELEASE_JSON="$(find .cache/fingerprint/client-release-watch -path '*/report.json' -print -quit 2>/dev/null || true)"
+          RELEASE_MD="$(find .cache/fingerprint/client-release-watch -path '*/report.md' -print -quit 2>/dev/null || true)"
           PROMPT_JSON=".cache/prompt-surface-watch/report.json"
           PROMPT_MD=".cache/prompt-surface-watch/report.md"
           ARGS=(
@@ -360,10 +360,10 @@ jobs:
             --report-json .cache/fingerprint/client-fidelity-watch/report.json
             --report-md .cache/fingerprint/client-fidelity-watch/report.md
           )
-          if [ -f "$RELEASE_JSON" ]; then
+          if [ -n "$RELEASE_JSON" ] && [ -f "$RELEASE_JSON" ]; then
             ARGS+=(--release-report-json "$RELEASE_JSON")
           fi
-          if [ -f "$RELEASE_MD" ]; then
+          if [ -n "$RELEASE_MD" ] && [ -f "$RELEASE_MD" ]; then
             ARGS+=(--release-report-md "$RELEASE_MD")
           fi
           if [ -f "$PROMPT_JSON" ]; then


### PR DESCRIPTION
## 摘要

- 修复 `client-fidelity-watch.yml` daily-report 对 release artifact 的读取：`actions/download-artifact` 会保留 artifact 内部的 `client-release-watch/report.*` 子目录，原硬编码路径漏读 release scan 报告
- 改为在 `.cache/fingerprint/client-release-watch` 下发现 `report.json` / `report.md`，让汇总报告同时包含 release drift 和 prod drift

## 风险

- 低风险：只改 CI daily-report 的 artifact 路径解析；无 Web / API / schema / 鉴权变更（no-web-impact）

## 验证

- `./scripts/preflight.sh` — PASS
- `python3 scripts/fingerprint/client_fidelity_watch_report.py --selftest`
- 用 #1142 合并后触发的 run `28566603772` artifact 目录复现：修复后汇总包含 3 个 `release-drift` signal 与 1 个 `prod-drift` signal

## 提交

- 61894257d fix(ci): include nested release artifact in fidelity report
- 最新提交：61894257d
