### PR TITLE
fix count_tokens unsupported endpoint fallback

### DIFF
--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -671,49 +670,45 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_EmptyModelSkipsMapping(t *tes
 	require.Equal(t, body, upstream.lastBody, "空模型名时请求体不应被修改")
 }
 
-func TestGatewayService_AnthropicAPIKeyPassthrough_CountTokens404PassthroughNotError(t *testing.T) {
+func TestGatewayService_AnthropicAPIKeyPassthrough_CountTokensUnsupported404UsesLocalEstimate(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
-		name            string
-		statusCode      int
-		respBody        string
-		wantPassthrough bool
-		wantFailover    bool
+		name         string
+		statusCode   int
+		respBody     string
+		wantEstimate bool
+		wantFailover bool
 	}{
 		{
-			name:            "404 endpoint not found passes through as 404",
-			statusCode:      http.StatusNotFound,
-			respBody:        `{"error":{"message":"Not found: /v1/messages/count_tokens","type":"not_found_error"}}`,
-			wantPassthrough: true,
+			name:         "404 endpoint not found uses local estimate",
+			statusCode:   http.StatusNotFound,
+			respBody:     `{"error":{"message":"Not found: /v1/messages/count_tokens","type":"not_found_error"}}`,
+			wantEstimate: true,
 		},
 		{
-			name:            "404 generic not found does not passthrough",
-			statusCode:      http.StatusNotFound,
-			respBody:        `{"error":{"message":"resource not found","type":"not_found_error"}}`,
-			wantPassthrough: false,
+			name:       "404 generic not found does not fallback",
+			statusCode: http.StatusNotFound,
+			respBody:   `{"error":{"message":"resource not found","type":"not_found_error"}}`,
 		},
 		{
-			name:            "400 Invalid URL does not passthrough",
-			statusCode:      http.StatusBadRequest,
-			respBody:        `{"error":{"message":"Invalid URL (POST /v1/messages/count_tokens)","type":"invalid_request_error"}}`,
-			wantPassthrough: false,
+			name:       "400 Invalid URL does not fallback",
+			statusCode: http.StatusBadRequest,
+			respBody:   `{"error":{"message":"Invalid URL (POST /v1/messages/count_tokens)","type":"invalid_request_error"}}`,
 		},
 		{
-			name:            "400 model error does not passthrough",
-			statusCode:      http.StatusBadRequest,
-			respBody:        `{"error":{"message":"model not found: claude-unknown","type":"invalid_request_error"}}`,
-			wantPassthrough: false,
+			name:       "400 model error does not fallback",
+			statusCode: http.StatusBadRequest,
+			respBody:   `{"error":{"message":"model not found: claude-unknown","type":"invalid_request_error"}}`,
 		},
 		{
 			// 契约更新（count_tokens failover 修复）：5xx 现在是 failover-eligible，
 			// ForwardCountTokens 返回 *UpstreamFailoverError 且不写客户端响应，
 			// 交由 handler 的 failover loop 换号。
-			name:            "500 internal error triggers failover",
-			statusCode:      http.StatusInternalServerError,
-			respBody:        `{"error":{"message":"internal error","type":"api_error"}}`,
-			wantPassthrough: false,
-			wantFailover:    true,
+			name:         "500 internal error triggers failover",
+			statusCode:   http.StatusInternalServerError,
+			respBody:     `{"error":{"message":"internal error","type":"api_error"}}`,
+			wantFailover: true,
 		},
 	}
 
@@ -759,16 +754,11 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_CountTokens404PassthroughNotE
 
 			err := svc.ForwardCountTokens(context.Background(), c, account, parsed)
 
-			if tt.wantPassthrough {
-				// 返回 nil（不记录为错误），HTTP 状态码 404 + Anthropic 错误体
+			if tt.wantEstimate {
+				// 上游端点不支持：返回 nil（不记录为错误），HTTP 200 + 本地估算。
 				require.NoError(t, err)
-				require.Equal(t, http.StatusNotFound, rec.Code)
-				var errResp map[string]any
-				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errResp))
-				require.Equal(t, "error", errResp["type"])
-				errObj, ok := errResp["error"].(map[string]any)
-				require.True(t, ok)
-				require.Equal(t, "not_found_error", errObj["type"])
+				require.Equal(t, http.StatusOK, rec.Code)
+				require.Greater(t, int(gjson.GetBytes(rec.Body.Bytes(), "input_tokens").Int()), 0)
 			} else if tt.wantFailover {
 				// failover-eligible：返回 *UpstreamFailoverError，状态码透传，
 				// 服务层不写客户端响应（默认 200，交由 handler 耗尽时回写）。

--- a/backend/internal/service/gateway_count_tokens_breaker_test.go
+++ b/backend/internal/service/gateway_count_tokens_breaker_test.go
@@ -84,12 +84,12 @@ func TestGatewayService_ForwardCountTokens_400DoesNotTripUpstreamErrorBreaker(t 
 	require.Equal(t, 0, repo.tempCalls, "count_tokens 400 must not mark account temp_unschedulable")
 }
 
-// TestGatewayService_ForwardCountTokens_Wrapped404ReturnsNotFound 验证 #656 主路径短路：
+// TestGatewayService_ForwardCountTokens_Wrapped404ReturnsLocalEstimate 验证 #656 主路径短路：
 // 中转站不支持 count_tokens 端点、把 Spring NoResourceFoundException 包装进非标准的
-// HTTP 400 返回时，ForwardCountTokens 应在熔断/failover **之前**短路，返回 HTTP 404
-// （not_found_error）让 Claude Code 回退到本地 token 估算，且既不熔断也不罚下账号。
+// HTTP 400 返回时，ForwardCountTokens 应在熔断/failover **之前**短路，返回本地估算，
+// 且既不熔断也不罚下账号。
 // 这条覆盖的是 #656 的主路径接线（谓词本身由 TestIsCountTokensUnsupported404 覆盖）。
-func TestGatewayService_ForwardCountTokens_Wrapped404ReturnsNotFound(t *testing.T) {
+func TestGatewayService_ForwardCountTokens_Wrapped404ReturnsLocalEstimate(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	rec := httptest.NewRecorder()
@@ -135,9 +135,9 @@ func TestGatewayService_ForwardCountTokens_Wrapped404ReturnsNotFound(t *testing.
 	}
 
 	err := svc.ForwardCountTokens(context.Background(), c, account, parsed)
-	require.NoError(t, err, "wrapped-404 应短路并返回 nil（已写 404 响应），不作为错误冒泡")
-	require.Equal(t, http.StatusNotFound, rec.Code, "应短路返回 HTTP 404 让客户端本地估算")
-	require.Contains(t, rec.Body.String(), "not_found_error")
+	require.NoError(t, err, "wrapped-404 应短路并返回 nil（已写估算响应），不作为错误冒泡")
+	require.Equal(t, http.StatusOK, rec.Code, "应短路返回本地估算")
+	require.Greater(t, int(gjson.GetBytes(rec.Body.Bytes(), "input_tokens").Int()), 0)
 	require.Empty(t, counter.incrementIDs, "端点不支持不应熔断账号（短路在熔断之前）")
 	require.Equal(t, 0, repo.tempCalls, "端点不支持不应 temp_unschedulable 账号")
 }
@@ -145,11 +145,12 @@ func TestGatewayService_ForwardCountTokens_Wrapped404ReturnsNotFound(t *testing.
 // TestGatewayService_ForwardCountTokens_CapacityErrorsFailoverNoBreaker
 // 契约更新（count_tokens failover 修复，见 gateway_handler_tk_count_tokens_failover.go）：
 // count_tokens 是请求前预检端点，其 429/529 容量类错误现在
-//   (a) **不再**计入 anthropic_upstream_error breaker（不熔断主力账号——一次预检的
-//       529 把主力账号 temp_unschedulable/overload 10 分钟会拖垮整组；现场 edge us1
-//       acct1 因单次 count_tokens 529 被罚下、acct4 空闲）；
-//   (b) 返回 *UpstreamFailoverError 且**不写客户端响应**，交由 handler 的 failover
-//       loop 换号 / 池内轮换。
+//
+//	(a) **不再**计入 anthropic_upstream_error breaker（不熔断主力账号——一次预检的
+//	    529 把主力账号 temp_unschedulable/overload 10 分钟会拖垮整组；现场 edge us1
+//	    acct1 因单次 count_tokens 529 被罚下、acct4 空闲）；
+//	(b) 返回 *UpstreamFailoverError 且**不写客户端响应**，交由 handler 的 failover
+//	    loop 换号 / 池内轮换。
 //
 // 这反转了旧测试 “429StillTripsUpstreamErrorBreaker” 的契约：轮换交给 failover，
 // 状态写入交给真正的 /v1/messages 路径。

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -10559,6 +10559,11 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 		)
 	}
 
+	if shouldEstimateCountTokensLocally(account) {
+		writeEstimatedAnthropicCountTokens(c, body)
+		return nil
+	}
+
 	// TK canonical-OAuth strict ingress UA gate on count_tokens. Without this the
 	// allow-list gate would only cover /v1/messages and a third-party client could
 	// probe/drain a personal subscription via count_tokens (cohort signal bypass).
@@ -10611,14 +10616,6 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 		// count_tokens request. Silent: this strip is an expected internal sanitize
 		// of normalize side effects, not a client schema bug, so it does not log.
 		body, _ = StripCountTokensUnsupportedFields(body)
-	}
-
-	// Antigravity upstream has no native count_tokens endpoint; return a local
-	// estimate so Claude Code clients get a 200 instead of a route-layer 404.
-	if account.Platform == PlatformAntigravity {
-		estimated := estimateAnthropicCountTokensInput(body)
-		c.JSON(http.StatusOK, gin.H{"input_tokens": estimated})
-		return nil
 	}
 
 	// 应用模型映射：
@@ -10753,15 +10750,14 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	if resp.StatusCode >= 400 {
 		// TK(#656): 部分国产 Anthropic 兼容中转站不支持 count_tokens 端点时，把
 		// 404/NoResourceFoundException 语义包装进非标准的 400/500 返回。优先在熔断与
-		// failover 之前短路：返回 404 让 Claude Code fallback 到本地 token 估算（与
-		// passthrough 路径一致），既不罚下账号（500-wrap 不计入熔断），也不浪费
+		// failover 之前短路：直接返回本地估算，既不罚下账号（500-wrap 不计入熔断），也不浪费
 		// failover 名额（同组其他账号多半同一上游、同样不支持）。
 		if isCountTokensUnsupported404(resp.StatusCode, respBody) {
 			logger.LegacyPrintf("service.gateway",
-				"[count_tokens] Upstream does not support count_tokens (status=%d), returning 404: account=%d name=%s msg=%s",
+				"[count_tokens] Upstream does not support count_tokens (status=%d), returning local estimate: account=%d name=%s msg=%s",
 				resp.StatusCode, account.ID, account.Name,
 				truncateString(sanitizeUpstreamErrorMessage(extractUpstreamErrorMessage(respBody)), 512))
-			s.countTokensError(c, http.StatusNotFound, "not_found_error", "count_tokens endpoint is not supported by upstream")
+			writeEstimatedAnthropicCountTokens(c, body)
 			return nil
 		}
 
@@ -10896,24 +10892,24 @@ func (s *GatewayService) forwardCountTokensAnthropicAPIKeyPassthrough(ctx contex
 	}
 
 	if resp.StatusCode >= 400 {
-		// 同 ForwardCountTokens：count_tokens 预检端点的 400/429/529 不计入熔断
-		// （tkCountTokensSkipBreaker）。
-		if s.rateLimitService != nil && !tkCountTokensSkipBreaker(resp.StatusCode) {
-			s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
-		}
-
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
 
-		// 中转站不支持 count_tokens 端点时（404），返回 404 让客户端 fallback 到本地估算。
+		// 中转站不支持 count_tokens 端点时（404），直接返回本地估算。
 		// 仅在错误消息明确指向 count_tokens endpoint 不存在时生效，避免误吞其他 404（如错误 base_url）。
 		// 返回 nil 避免 handler 层记录为错误，也不设置 ops 上游错误上下文。
 		if isCountTokensUnsupported404(resp.StatusCode, respBody) {
 			logger.LegacyPrintf("service.gateway",
-				"[count_tokens] Upstream does not support count_tokens (404), returning 404: account=%d name=%s msg=%s",
+				"[count_tokens] Upstream does not support count_tokens (404), returning local estimate: account=%d name=%s msg=%s",
 				account.ID, account.Name, truncateString(upstreamMsg, 512))
-			s.countTokensError(c, http.StatusNotFound, "not_found_error", "count_tokens endpoint is not supported by upstream")
+			writeEstimatedAnthropicCountTokens(c, body)
 			return nil
+		}
+
+		// 同 ForwardCountTokens：count_tokens 预检端点的 400/429/529 不计入熔断
+		// （tkCountTokensSkipBreaker）。
+		if s.rateLimitService != nil && !tkCountTokensSkipBreaker(resp.StatusCode) {
+			s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 		}
 
 		upstreamDetail := ""

--- a/backend/internal/service/gateway_service_tk_count_tokens_estimate.go
+++ b/backend/internal/service/gateway_service_tk_count_tokens_estimate.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 
+	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 )
 
@@ -67,6 +69,27 @@ func estimateAnthropicCountTokensInput(body []byte) int {
 		return 0
 	}
 	return total
+}
+
+func writeEstimatedAnthropicCountTokens(c *gin.Context, body []byte) {
+	if c == nil {
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"input_tokens": estimateAnthropicCountTokensInput(body),
+	})
+}
+
+func shouldEstimateCountTokensLocally(account *Account) bool {
+	if account == nil {
+		return false
+	}
+	switch account.Platform {
+	case PlatformAntigravity, PlatformGemini, PlatformKiro:
+		return true
+	default:
+		return false
+	}
 }
 
 func estimateTokensForAnthropicText(s string) int {

--- a/backend/internal/service/gateway_service_tk_count_tokens_estimate_test.go
+++ b/backend/internal/service/gateway_service_tk_count_tokens_estimate_test.go
@@ -47,6 +47,40 @@ func TestForwardCountTokens_AntigravityReturnsLocalEstimate(t *testing.T) {
 	require.Contains(t, rec.Body.String(), `"input_tokens"`)
 }
 
+func TestForwardCountTokens_NonAnthropicLocalEstimatePlatforms(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name     string
+		platform string
+		typ      string
+	}{
+		{name: "gemini service account", platform: PlatformGemini, typ: AccountTypeServiceAccount},
+		{name: "gemini oauth", platform: PlatformGemini, typ: AccountTypeOAuth},
+		{name: "kiro oauth", platform: PlatformKiro, typ: AccountTypeOAuth},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", nil)
+
+			svc := &GatewayService{}
+			account := &Account{ID: 10, Platform: tc.platform, Type: tc.typ}
+			parsed := &ParsedRequest{
+				Model: "claude-sonnet-4-6",
+				Body:  mustNewRequestBodyRef([]byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}`)),
+			}
+
+			err := svc.ForwardCountTokens(c.Request.Context(), c, account, parsed)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.Contains(t, rec.Body.String(), `"input_tokens"`)
+		})
+	}
+}
+
 func mustNewRequestBodyRef(body []byte) *RequestBodyRef {
 	ref := NewRequestBodyRef(body)
 	if ref == nil {

--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -113,7 +113,7 @@ func (s *OpenAIGatewayService) ForwardCountTokensAsAnthropic(
 
 	if resp.StatusCode >= 400 {
 		upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
-		if account.Type == AccountTypeOAuth && isOpenAIOAuthInputTokensUnsupported(resp.StatusCode) {
+		if account.Type == AccountTypeOAuth && isOpenAIOAuthInputTokensUnsupported(resp.StatusCode, respBody) {
 			writeEstimatedAnthropicCountTokens(c, body)
 			return nil
 		}
@@ -244,13 +244,18 @@ func isOpenAIInputTokensUnsupported(statusCode int, body []byte) bool {
 	return strings.Contains(msg, "input_tokens") && strings.Contains(msg, "not found")
 }
 
-func isOpenAIOAuthInputTokensUnsupported(statusCode int) bool {
+func isOpenAIOAuthInputTokensUnsupported(statusCode int, body []byte) bool {
 	switch statusCode {
 	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
-		return true
 	default:
 		return false
 	}
+	msg := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(body)))
+	if msg == "" {
+		msg = strings.ToLower(strings.TrimSpace(string(body)))
+	}
+	return strings.Contains(msg, "input_tokens") &&
+		(strings.Contains(msg, "not found") || strings.Contains(msg, "unsupported"))
 }
 
 func isOpenAICompatCountTokensCapabilityGap(account *Account, err error) bool {

--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -78,6 +78,10 @@ func (s *OpenAIGatewayService) ForwardCountTokensAsAnthropic(
 
 	token, _, err := s.getInputTokensAuthToken(ctx, account)
 	if err != nil {
+		if isOpenAICompatCountTokensCapabilityGap(account, err) {
+			writeEstimatedAnthropicCountTokens(c, body)
+			return nil
+		}
 		writeAnthropicCountTokensError(c, http.StatusBadGateway, "upstream_error", "Failed to get access token")
 		return fmt.Errorf("get access token: %w", err)
 	}
@@ -108,18 +112,22 @@ func (s *OpenAIGatewayService) ForwardCountTokensAsAnthropic(
 	}
 
 	if resp.StatusCode >= 400 {
-		if s.rateLimitService != nil {
-			s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
-		}
-
 		upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
 		if account.Type == AccountTypeOAuth && isOpenAIOAuthInputTokensUnsupported(resp.StatusCode) {
-			writeAnthropicCountTokensError(c, http.StatusNotFound, "not_found_error", "Token counting is not supported for this OpenAI account type")
+			writeEstimatedAnthropicCountTokens(c, body)
 			return nil
 		}
 		if isOpenAIInputTokensUnsupported(resp.StatusCode, respBody) {
-			writeAnthropicCountTokensError(c, http.StatusNotFound, "not_found_error", "Token counting is not supported by upstream")
+			writeEstimatedAnthropicCountTokens(c, body)
 			return nil
+		}
+		if isOpenAICompatInputTokensCapabilityGap(resp.StatusCode, upstreamMsg, respBody) {
+			writeEstimatedAnthropicCountTokens(c, body)
+			return nil
+		}
+
+		if s.rateLimitService != nil {
+			s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 		}
 
 		upstreamDetail := ""
@@ -148,8 +156,8 @@ func (s *OpenAIGatewayService) ForwardCountTokensAsAnthropic(
 
 	inputTokens := gjson.GetBytes(respBody, "input_tokens")
 	if !inputTokens.Exists() {
-		writeAnthropicCountTokensError(c, http.StatusBadGateway, "upstream_error", "Upstream response missing input_tokens")
-		return fmt.Errorf("input_tokens response missing input_tokens field")
+		writeEstimatedAnthropicCountTokens(c, body)
+		return nil
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -243,4 +251,34 @@ func isOpenAIOAuthInputTokensUnsupported(statusCode int) bool {
 	default:
 		return false
 	}
+}
+
+func isOpenAICompatCountTokensCapabilityGap(account *Account, err error) bool {
+	if account == nil || err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if account.Platform == PlatformNewAPI {
+		return strings.Contains(msg, "api_key not found")
+	}
+	return false
+}
+
+func isOpenAICompatInputTokensCapabilityGap(statusCode int, upstreamMsg string, body []byte) bool {
+	msg := strings.ToLower(strings.TrimSpace(upstreamMsg))
+	if msg == "" {
+		msg = strings.ToLower(strings.TrimSpace(string(body)))
+	}
+	if msg == "" {
+		return false
+	}
+	if strings.Contains(msg, "input_tokens") &&
+		(strings.Contains(msg, "missing") || strings.Contains(msg, "not found") || strings.Contains(msg, "unsupported")) {
+		return true
+	}
+	if strings.Contains(msg, "upstream returned 403") &&
+		(strings.Contains(msg, "access/policy rejection") || strings.Contains(msg, "rejected by upstream")) {
+		return true
+	}
+	return false
 }

--- a/backend/internal/service/openai_gateway_count_tokens_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_test.go
@@ -98,10 +98,128 @@ func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_OAuthFallsBackWhenPl
 
 	err := svc.ForwardCountTokensAsAnthropic(context.Background(), c, account, body, "gpt-5.4")
 	require.NoError(t, err)
-	require.Equal(t, http.StatusNotFound, rec.Code)
-	require.Contains(t, rec.Body.String(), "Token counting is not supported for this OpenAI account type")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Greater(t, int(gjson.GetBytes(rec.Body.Bytes(), "input_tokens").Int()), 0)
 	require.NotNil(t, upstream.lastReq)
 	require.Equal(t, "https://api.openai.com/v1/responses/input_tokens", upstream.lastReq.URL.String())
 	require.Equal(t, "Bearer oauth-token", upstream.lastReq.Header.Get("authorization"))
 	require.Empty(t, upstream.lastReq.Header.Get("Chatgpt-Account-Id"))
+}
+
+func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_NewAPIAuthGapUsesLocalEstimate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"qwen3.7-max","messages":[{"role":"user","content":"hello"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		ID:          303,
+		Name:        "newapi-qwen",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"key":      "newapi-channel-key",
+			"base_url": "https://newapi.example",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	err := svc.ForwardCountTokensAsAnthropic(context.Background(), c, account, body, "")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Greater(t, int(gjson.GetBytes(rec.Body.Bytes(), "input_tokens").Int()), 0)
+}
+
+func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_InputTokensPolicy403UsesLocalEstimate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"error":{"message":"Upstream returned 403 for this request. Request body 113 bytes for model \"gpt-5.4-mini\" was rejected by upstream. This is an upstream access/policy rejection unrelated to request size; retry the request, and contact administrator if it persists."}}`,
+		)),
+	}}
+
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+			Enabled:           false,
+			AllowInsecureHTTP: true,
+		}}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          304,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "http://upstream.example",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	err := svc.ForwardCountTokensAsAnthropic(context.Background(), c, account, body, "gpt-5.4-mini")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Greater(t, int(gjson.GetBytes(rec.Body.Bytes(), "input_tokens").Int()), 0)
+	require.NotNil(t, upstream.lastReq)
+}
+
+func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_MissingInputTokensUsesLocalEstimate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"grok-4.3","messages":[{"role":"user","content":"hello"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"object":"response.input_tokens"}`)),
+	}}
+
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+			Enabled:           false,
+			AllowInsecureHTTP: true,
+		}}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          305,
+		Name:        "grok-relay",
+		Platform:    PlatformGrok,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "xai-test",
+			"base_url": "http://grok.example/v1",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	err := svc.ForwardCountTokensAsAnthropic(context.Background(), c, account, body, "")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Greater(t, int(gjson.GetBytes(rec.Body.Bytes(), "input_tokens").Int()), 0)
+	require.NotNil(t, upstream.lastReq)
 }

--- a/backend/internal/service/openai_gateway_count_tokens_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_test.go
@@ -76,7 +76,7 @@ func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_OAuthFallsBackWhenPl
 	upstream := &httpUpstreamRecorder{resp: &http.Response{
 		StatusCode: http.StatusUnauthorized,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"unauthorized"}}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"input_tokens endpoint unsupported for this account type"}}`)),
 	}}
 
 	svc := &OpenAIGatewayService{
@@ -104,6 +104,45 @@ func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_OAuthFallsBackWhenPl
 	require.Equal(t, "https://api.openai.com/v1/responses/input_tokens", upstream.lastReq.URL.String())
 	require.Equal(t, "Bearer oauth-token", upstream.lastReq.Header.Get("authorization"))
 	require.Empty(t, upstream.lastReq.Header.Get("Chatgpt-Account-Id"))
+}
+
+func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_OAuth401DoesNotUseLocalEstimate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"claude-opus-4-1","messages":[{"role":"user","content":"hello"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"authentication_error","message":"unauthorized"}}`)),
+	}}
+
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          203,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token": "oauth-token",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	err := svc.ForwardCountTokensAsAnthropic(context.Background(), c, account, body, "gpt-5.4")
+	require.Error(t, err)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Contains(t, rec.Body.String(), "Upstream request failed")
+	require.NotNil(t, upstream.lastReq)
 }
 
 func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_NewAPIAuthGapUsesLocalEstimate(t *testing.T) {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2068,9 +2068,9 @@
         "func isCountTokensUnsupported404(statusCode int, body []byte) bool {",
         "strings.Contains(msg, \"noresourcefoundexception\")",
         "strings.Contains(msg, \"no static resource\")",
-        "count_tokens (status=%d), returning 404"
+        "count_tokens (status=%d), returning local estimate"
       ],
-      "rationale": "TK #656 count_tokens non-standard not-found fallback. Some Chinese Anthropic-compatible relays that do not support /v1/messages/count_tokens wrap a Spring NoResourceFoundException / 'No static resource v1/messages/count_tokens' into a non-standard HTTP 400/500 instead of a clean 404. isCountTokensUnsupported404 is widened to recognize these (narrowed to count_tokens-endpoint mention + strong Spring not-found signals so a real invalid_request_error like #2109 temperature is NOT swallowed; includes raw-body fallback), and the main ForwardCountTokens path short-circuits to 404 BEFORE the breaker/failover so Claude Code falls back to local token estimation while the account is neither penalized nor wasted on failover (same posture as the passthrough variant). Anchor the widened strong-signal predicates + the main-path 404 short-circuit log so an upstream merge cannot silently narrow it back to status==404-only and re-break these relays."
+      "rationale": "TK #656 count_tokens non-standard not-found fallback. Some Chinese Anthropic-compatible relays that do not support /v1/messages/count_tokens wrap a Spring NoResourceFoundException / 'No static resource v1/messages/count_tokens' into a non-standard HTTP 400/500 instead of a clean 404. isCountTokensUnsupported404 is widened to recognize these (narrowed to count_tokens-endpoint mention + strong Spring not-found signals so a real invalid_request_error like #2109 temperature is NOT swallowed; includes raw-body fallback), and the main ForwardCountTokens path short-circuits to a server-side local token estimate BEFORE the breaker/failover so the account is neither penalized nor wasted on failover (same posture as the passthrough variant). Anchor the widened strong-signal predicates + the main-path local-estimate short-circuit log so an upstream merge cannot silently narrow it back to status==404-only and re-break these relays."
     },
     {
       "path": "backend/internal/service/gateway_service.go",


### PR DESCRIPTION
## Summary
- return server-side local `input_tokens` estimates when `/v1/messages/count_tokens` upstream capability is missing instead of surfacing 404/502 capability gaps
- keep real request/auth/network/errors visible; capability gaps short-circuit before account breaker/failover accounting
- cover Gemini/Antigravity/Kiro local estimates, Anthropic-compatible unsupported endpoint fallbacks, and OpenAI-compatible `/v1/responses/input_tokens` gaps including NewAPI/Grok cases
- update the gateway TK sentinel anchor from old 404 fallback behavior to the new local-estimate contract

## Prod probe evidence
Ran the prod endpoint matrix before implementation via SSM command `07122536-da87-44f3-a4db-fd764b5d3b6b` on `2026-07-02`.

Observed `/v1/messages/count_tokens` behavior:
- Anthropic: real prod request succeeded on account 55; matrix default model failed with pool/model rate limit, not upstream capability.
- Antigravity: returned `200 {"input_tokens":1}`.
- OpenAI: account 63 failed through `/v1/responses/input_tokens` with upstream 403 policy rejection surfaced as 502.
- Gemini: account 74 failed as unsupported service-account platform for count_tokens.
- NewAPI: account 60 failed because channel credentials do not expose the OpenAI-compatible `api_key` path expected by input_tokens.
- Kiro: no native prod `platform=kiro` pool; count_tokens selection had no available native accounts.
- Grok: relay returned success-shaped response without `input_tokens`.

## Tests
- `./scripts/preflight.sh`
- `go test ./internal/service`
- `go test -tags=unit ./internal/service`

no-web-impact
sentinel-registry-reviewed
