### PR TITLE
fix(ci): surface client fidelity tracking links

### DIFF
--- a/.github/workflows/client-fidelity-watch.yml
+++ b/.github/workflows/client-fidelity-watch.yml
@@ -370,8 +370,14 @@ jobs:
           mkdir -p .cache/fingerprint/client-fidelity-watch
           RELEASE_JSON="$(find .cache/fingerprint/client-release-watch -path '*/report.json' -print -quit 2>/dev/null || true)"
           RELEASE_MD="$(find .cache/fingerprint/client-release-watch -path '*/report.md' -print -quit 2>/dev/null || true)"
-          RELEASE_LINKS="$(find .cache/fingerprint/client-release-watch -path '*/links.json' -print -quit 2>/dev/null || true)"
-          PROMPT_LINKS="$(find .cache/prompt-surface-watch -path '*/links.json' -print -quit 2>/dev/null || true)"
+          RELEASE_LINKS=""
+          if [ -d .cache/fingerprint/client-release-watch ]; then
+            RELEASE_LINKS="$(find .cache/fingerprint/client-release-watch -path '*/links.json' -print -quit)"
+          fi
+          PROMPT_LINKS=""
+          if [ -d .cache/prompt-surface-watch ]; then
+            PROMPT_LINKS="$(find .cache/prompt-surface-watch -path '*/links.json' -print -quit)"
+          fi
           PROMPT_JSON=".cache/prompt-surface-watch/report.json"
           PROMPT_MD=".cache/prompt-surface-watch/report.md"
           ARGS=(

--- a/.github/workflows/client-fidelity-watch.yml
+++ b/.github/workflows/client-fidelity-watch.yml
@@ -102,7 +102,9 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          python3 ops/fingerprint/open_client_release_watch_issues.py --umbrella
+          python3 ops/fingerprint/open_client_release_watch_issues.py \
+            --umbrella \
+            --links-json .cache/fingerprint/client-release-watch/links.json
 
       - name: Create or update cache refresh PR
         id: cache_pr
@@ -137,6 +139,11 @@ jobs:
           git push --force-with-lease origin "$BRANCH"
 
           cat > .cache/fingerprint/client-release-watch/cache-pr-body.md <<'EOF'
+          ## WIP / not merge-ready
+          - This PR is an automated release-drift tracking/cache refresh, not a completed fingerprint alignment.
+          - Before merging, run real client fingerprint capture and diff alignment; do not bump pins from release metadata alone.
+          - Recommended routing: `tokenkey-fingerprint-alignment-all`, or the per-platform skills listed in the watchdog report.
+
           ## Summary
           - Refresh `.cache/fingerprint/client-release-watch.json` from the latest upstream client release poll.
           - Keep the client fidelity / release watch scripts and workflows in sync when they changed in the same run.
@@ -156,9 +163,10 @@ jobs:
           if [ -n "$EXISTING" ]; then
             NUMBER="$(jq -r '.number' <<<"$EXISTING")"
             URL="$(jq -r '.url' <<<"$EXISTING")"
-            gh pr edit "$NUMBER" --title "chore: refresh client release watch cache" --body-file .cache/fingerprint/client-release-watch/cache-pr-body.md
+            gh pr edit "$NUMBER" --title "WIP: chore: refresh client release watch cache" --body-file .cache/fingerprint/client-release-watch/cache-pr-body.md
+            gh pr ready "$NUMBER" --undo || true  # preflight-allow: swallow
           else
-            URL="$(gh pr create --base main --head "$BRANCH" --title "chore: refresh client release watch cache" --body-file .cache/fingerprint/client-release-watch/cache-pr-body.md)"
+            URL="$(gh pr create --draft --base main --head "$BRANCH" --title "WIP: chore: refresh client release watch cache" --body-file .cache/fingerprint/client-release-watch/cache-pr-body.md)"
           fi
           echo "cache_pr_url=$URL" >> "$GITHUB_OUTPUT"
           echo "cache PR: $URL"
@@ -171,6 +179,7 @@ jobs:
             .cache/fingerprint/client-release-watch/report.json
             .cache/fingerprint/client-release-watch/report.md
             .cache/fingerprint/client-release-watch.json
+            .cache/fingerprint/client-release-watch/links.json
           if-no-files-found: ignore
 
   registry-gate:
@@ -240,7 +249,17 @@ jobs:
             echo "::error::Missing required secret UPSTREAM_MERGE_GH_TOKEN for issue updates."
             exit 1
           fi
-          python3 ops/observability/open_prompt_surface_watch_issues.py registry-failure --run-url "$RUN_URL" --umbrella
+          python3 ops/observability/open_prompt_surface_watch_issues.py registry-failure \
+            --run-url "$RUN_URL" \
+            --umbrella \
+            --links-json .cache/prompt-surface-watch/links.json
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: client-fidelity-prompt-${{ github.run_id }}
+          path: .cache/prompt-surface-watch/
+          if-no-files-found: ignore
 
   prod-aggregate:
     needs: registry-gate
@@ -310,7 +329,8 @@ jobs:
             --report-json .cache/prompt-surface-watch/report.json \
             --report-md .cache/prompt-surface-watch/report.md \
             --run-url "$RUN_URL" \
-            --umbrella
+            --umbrella \
+            --links-json .cache/prompt-surface-watch/links.json
 
       - uses: actions/upload-artifact@v4
         if: always() && steps.precheck.outputs.skip == 'false'
@@ -320,7 +340,7 @@ jobs:
           if-no-files-found: ignore
 
   daily-report:
-    needs: [release-scan, registry-gate, prod-aggregate]
+    needs: [release-scan, registry-gate, notify-registry-failure, prod-aggregate]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -350,6 +370,8 @@ jobs:
           mkdir -p .cache/fingerprint/client-fidelity-watch
           RELEASE_JSON="$(find .cache/fingerprint/client-release-watch -path '*/report.json' -print -quit 2>/dev/null || true)"
           RELEASE_MD="$(find .cache/fingerprint/client-release-watch -path '*/report.md' -print -quit 2>/dev/null || true)"
+          RELEASE_LINKS="$(find .cache/fingerprint/client-release-watch -path '*/links.json' -print -quit 2>/dev/null || true)"
+          PROMPT_LINKS="$(find .cache/prompt-surface-watch -path '*/links.json' -print -quit 2>/dev/null || true)"
           PROMPT_JSON=".cache/prompt-surface-watch/report.json"
           PROMPT_MD=".cache/prompt-surface-watch/report.md"
           ARGS=(
@@ -357,6 +379,7 @@ jobs:
             --registry-gate-result "$REGISTRY_RESULT"
             --prod-aggregate-result "$PROD_RESULT"
             --run-url "$RUN_URL"
+            --cache-pr-url "${{ needs.release-scan.outputs.cache_pr_url }}"
             --report-json .cache/fingerprint/client-fidelity-watch/report.json
             --report-md .cache/fingerprint/client-fidelity-watch/report.md
           )
@@ -366,13 +389,20 @@ jobs:
           if [ -n "$RELEASE_MD" ] && [ -f "$RELEASE_MD" ]; then
             ARGS+=(--release-report-md "$RELEASE_MD")
           fi
+          if [ -n "$RELEASE_LINKS" ] && [ -f "$RELEASE_LINKS" ]; then
+            ARGS+=(--release-links-json "$RELEASE_LINKS")
+          fi
           if [ -f "$PROMPT_JSON" ]; then
             ARGS+=(--prompt-prod-report-json "$PROMPT_JSON")
           fi
           if [ -f "$PROMPT_MD" ]; then
             ARGS+=(--prompt-prod-report-md "$PROMPT_MD")
           fi
+          if [ -n "$PROMPT_LINKS" ] && [ -f "$PROMPT_LINKS" ]; then
+            ARGS+=(--prompt-links-json "$PROMPT_LINKS")
+          fi
           python3 scripts/fingerprint/client_fidelity_watch_report.py "${ARGS[@]}"
+          cat .cache/fingerprint/client-fidelity-watch/report.md >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/client-release-watch.yml
+++ b/.github/workflows/client-release-watch.yml
@@ -94,7 +94,8 @@ jobs:
           GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
         run: |
           set -euo pipefail
-          python3 ops/fingerprint/open_client_release_watch_issues.py
+          python3 ops/fingerprint/open_client_release_watch_issues.py \
+            --links-json .cache/fingerprint/client-release-watch/links.json
 
       - name: Create or update cache refresh PR
         id: cache_pr
@@ -124,6 +125,11 @@ jobs:
           git push --force-with-lease origin "$BRANCH"
 
           cat > .cache/fingerprint/client-release-watch/cache-pr-body.md <<'EOF'
+          ## WIP / not merge-ready
+          - This PR is an automated release-drift tracking/cache refresh, not a completed fingerprint alignment.
+          - Before merging, run real client fingerprint capture and diff alignment; do not bump pins from release metadata alone.
+          - Recommended routing: `tokenkey-fingerprint-alignment-all`, or the per-platform skills listed in the watchdog report.
+
           ## Summary
           - Refresh `.cache/fingerprint/client-release-watch.json` from the latest upstream client release poll.
           - Keep the client release watch script/workflow in sync when they changed in the same run.
@@ -143,9 +149,10 @@ jobs:
           if [ -n "$EXISTING" ]; then
             NUMBER="$(jq -r '.number' <<<"$EXISTING")"
             URL="$(jq -r '.url' <<<"$EXISTING")"
-            gh pr edit "$NUMBER" --title "chore: refresh client release watch cache" --body-file .cache/fingerprint/client-release-watch/cache-pr-body.md
+            gh pr edit "$NUMBER" --title "WIP: chore: refresh client release watch cache" --body-file .cache/fingerprint/client-release-watch/cache-pr-body.md
+            gh pr ready "$NUMBER" --undo || true  # preflight-allow: swallow
           else
-            URL="$(gh pr create --base main --head "$BRANCH" --title "chore: refresh client release watch cache" --body-file .cache/fingerprint/client-release-watch/cache-pr-body.md)"
+            URL="$(gh pr create --draft --base main --head "$BRANCH" --title "WIP: chore: refresh client release watch cache" --body-file .cache/fingerprint/client-release-watch/cache-pr-body.md)"
           fi
           echo "cache_pr_url=$URL" >> "$GITHUB_OUTPUT"
           echo "cache PR: $URL"
@@ -158,6 +165,7 @@ jobs:
             .cache/fingerprint/client-release-watch/report.json
             .cache/fingerprint/client-release-watch/report.md
             .cache/fingerprint/client-release-watch.json
+            .cache/fingerprint/client-release-watch/links.json
           if-no-files-found: ignore
 
   contract:

--- a/ops/fingerprint/open_client_release_watch_issues.py
+++ b/ops/fingerprint/open_client_release_watch_issues.py
@@ -56,8 +56,13 @@ def issue_body_path(cache_dir: pathlib.Path, platform_id: str) -> pathlib.Path:
     return cache_dir / f"issue-{filename_safe(platform_id)}.md"
 
 
-def sync_issues(report: dict, *, cache_dir: pathlib.Path, umbrella: bool) -> None:
+def issue_url(number: str) -> str:
+    return sh(["gh", "issue", "view", number, "--json", "url", "--jq", ".url"]).stdout.strip()
+
+
+def sync_issues(report: dict, *, cache_dir: pathlib.Path, umbrella: bool) -> list[dict[str, object]]:
     ensure_base_labels()
+    links: list[dict[str, object]] = []
     for item in report.get("platforms") or []:
         platform_id = item["id"]
         platform_label = f"client-release:{label_safe(platform_id)}"
@@ -125,9 +130,30 @@ def sync_issues(report: dict, *, cache_dir: pathlib.Path, umbrella: bool) -> Non
             if existing:
                 sh(["gh", "issue", "comment", existing, "--body-file", str(body_path)])
                 sh(["gh", "issue", "edit", existing, "--add-label", labels_csv])
+                links.append({
+                    "kind": "issue",
+                    "signal_type": "release-drift",
+                    "platform_id": platform_id,
+                    "title": title,
+                    "number": int(existing),
+                    "url": issue_url(existing),
+                    "status": "updated",
+                })
                 print(f"updated drift issue #{existing} for {platform_id}")
             else:
-                sh(["gh", "issue", "create", "--title", title, "--body-file", str(body_path), "--label", labels_csv])
+                created_url = sh([
+                    "gh", "issue", "create", "--title", title, "--body-file", str(body_path), "--label", labels_csv,
+                ]).stdout.strip()
+                number_match = re.search(r"/issues/(\d+)(?:$|[?#])", created_url)
+                links.append({
+                    "kind": "issue",
+                    "signal_type": "release-drift",
+                    "platform_id": platform_id,
+                    "title": title,
+                    "number": int(number_match.group(1)) if number_match else None,
+                    "url": created_url,
+                    "status": "created",
+                })
                 print(f"created drift issue for {platform_id}")
             continue
 
@@ -158,6 +184,7 @@ def sync_issues(report: dict, *, cache_dir: pathlib.Path, umbrella: bool) -> Non
             ], text=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             sh(["gh", "issue", "close", number, "--comment", "Closing because upstream is no longer ahead of the TokenKey pin."])
             print(f"closed drift issue #{number} for {platform_id}")
+    return links
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -169,12 +196,20 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Tag issues with client-fidelity-watch (umbrella workflow)",
     )
+    ap.add_argument(
+        "--links-json",
+        type=pathlib.Path,
+        help="Write opened/updated issue links for downstream daily reports",
+    )
     args = ap.parse_args(argv)
     if not args.report_json.is_file():
         print(f"missing report: {args.report_json}", file=sys.stderr)
         return 2
     report = json.loads(args.report_json.read_text(encoding="utf-8"))
-    sync_issues(report, cache_dir=args.cache_dir, umbrella=args.umbrella)
+    links = sync_issues(report, cache_dir=args.cache_dir, umbrella=args.umbrella)
+    links_json = args.links_json or (args.cache_dir / "links.json")
+    links_json.parent.mkdir(parents=True, exist_ok=True)
+    links_json.write_text(json.dumps({"links": links}, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return 0
 
 

--- a/ops/fingerprint/test_open_client_release_watch_issues.py
+++ b/ops/fingerprint/test_open_client_release_watch_issues.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import sys
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from open_client_release_watch_issues import filename_safe, issue_body_path
+from open_client_release_watch_issues import filename_safe, issue_body_path, sync_issues
 
 
 class OpenClientReleaseWatchIssuesTest(unittest.TestCase):
@@ -16,6 +19,72 @@ class OpenClientReleaseWatchIssuesTest(unittest.TestCase):
         platform_id = "claude-code"
         path = issue_body_path(Path(".cache/fingerprint/client-release-watch"), platform_id)
         self.assertEqual(path.name, f"issue-{filename_safe(platform_id)}.md")
+
+    def test_sync_issues_returns_no_links_for_aligned_report(self) -> None:
+        report = {
+            "platforms": [
+                {
+                    "id": "codex-cli",
+                    "name": "Codex CLI",
+                    "pinned": "1",
+                    "upstream_latest": "1",
+                    "drift": False,
+                }
+            ]
+        }
+        with patch("open_client_release_watch_issues.ensure_base_labels"), \
+            patch("open_client_release_watch_issues.ensure_label"), \
+            patch("open_client_release_watch_issues.sh") as mock_sh:
+            mock_sh.return_value.stdout = "[]"
+            self.assertEqual(sync_issues(report, cache_dir=Path(".cache/fingerprint/client-release-watch"), umbrella=True), [])
+
+    def test_sync_issues_returns_existing_drift_issue_link(self) -> None:
+        report = {
+            "run_url": "https://github.com/youxuanxue/sub2api/actions/runs/1",
+            "platforms": [
+                {
+                    "id": "claude-code",
+                    "name": "Claude Code",
+                    "pinned": "2.1.197",
+                    "upstream_latest": "2.1.198",
+                    "status": "drift",
+                    "pin_path": "internal/example.go",
+                    "skill": "tokenkey-cc-fingerprint-alignment",
+                    "upstream_sources": {
+                        "npm": {
+                            "version": "2.1.198",
+                            "url": "https://www.npmjs.com/package/@anthropic-ai/claude-code",
+                        }
+                    },
+                    "drift": True,
+                }
+            ],
+        }
+
+        def fake_sh(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+            if args[:3] == ["gh", "issue", "list"]:
+                return subprocess.CompletedProcess(args, 0, stdout="1136", stderr="")
+            if args[:3] == ["gh", "issue", "view"]:
+                return subprocess.CompletedProcess(
+                    args,
+                    0,
+                    stdout="https://github.com/youxuanxue/sub2api/issues/1136\n",
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as tmp, \
+            patch("open_client_release_watch_issues.ensure_base_labels"), \
+            patch("open_client_release_watch_issues.ensure_label"), \
+            patch("open_client_release_watch_issues.sh", side_effect=fake_sh):
+            links = sync_issues(report, cache_dir=Path(tmp), umbrella=True)
+
+        self.assertEqual(len(links), 1)
+        self.assertEqual(links[0]["signal_type"], "release-drift")
+        self.assertEqual(links[0]["platform_id"], "claude-code")
+        self.assertEqual(links[0]["number"], 1136)
+        self.assertEqual(links[0]["status"], "updated")
+        self.assertEqual(links[0]["url"], "https://github.com/youxuanxue/sub2api/issues/1136")
 
 
 if __name__ == "__main__":

--- a/ops/observability/open_prompt_surface_watch_issues.py
+++ b/ops/observability/open_prompt_surface_watch_issues.py
@@ -44,6 +44,10 @@ def sh(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[st
     return subprocess.run(args, text=True, check=check, capture_output=True)
 
 
+def issue_url(number: str) -> str:
+    return sh(["gh", "issue", "view", number, "--json", "url", "--jq", ".url"]).stdout.strip()
+
+
 def ensure_label(name: str, color: str, description: str) -> None:
     subprocess.run(
         ["gh", "label", "create", name, "--color", color, "--description", description[:100]],
@@ -140,7 +144,7 @@ def open_or_update_issue(
     title: str,
     body: str,
     drift_labels: list[str],
-) -> None:
+) -> dict[str, object]:
     ensure_base_labels()
     labels_csv = ",".join(drift_labels)
     existing = find_open_issue(sig_label)
@@ -151,12 +155,29 @@ def open_or_update_issue(
         sh(["gh", "issue", "comment", existing, "--body-file", str(body_path)])
         sh(["gh", "issue", "edit", existing, "--add-label", labels_csv])
         print(f"updated issue #{existing} ({sig_label})")
-        return
-    sh(["gh", "issue", "create", "--title", title[:250], "--body-file", str(body_path), "--label", labels_csv])
+        return {
+            "kind": "issue",
+            "title": title[:250],
+            "number": int(existing),
+            "url": issue_url(existing),
+            "status": "updated",
+        }
+    created_url = sh([
+        "gh", "issue", "create", "--title", title[:250], "--body-file", str(body_path), "--label", labels_csv,
+    ]).stdout.strip()
+    number_match = re.search(r"/issues/(\d+)(?:$|[?#])", created_url)
     print(f"created issue ({sig_label})")
+    return {
+        "kind": "issue",
+        "title": title[:250],
+        "number": int(number_match.group(1)) if number_match else None,
+        "url": created_url,
+        "status": "created",
+    }
 
 
-def close_issue(number: str, comment: str) -> None:
+def close_issue(number: str, comment: str) -> dict[str, object]:
+    url = issue_url(number)
     sh(["gh", "issue", "comment", number, "--body", comment])
     subprocess.run(
         ["gh", "issue", "edit", number, "--add-label", "prompt-surface:aligned", "--remove-label", "prompt-surface:prod-drift,prompt-surface:registry-failure"],
@@ -166,6 +187,7 @@ def close_issue(number: str, comment: str) -> None:
     )
     sh(["gh", "issue", "close", number, "--comment", "Closing because the watch signal cleared."])
     print(f"closed issue #{number}")
+    return {"kind": "issue", "number": int(number), "url": url, "status": "closed"}
 
 
 def drift_labels_for(base: list[str], *, umbrella: bool) -> list[str]:
@@ -176,7 +198,7 @@ def drift_labels_for(base: list[str], *, umbrella: bool) -> list[str]:
 
 def cmd_registry_failure(args: argparse.Namespace) -> int:
     body = registry_failure_body(args.run_url)
-    open_or_update_issue(
+    link = open_or_update_issue(
         sig_label=SIG_REGISTRY,
         title="[prompt-surface] registry-gate failed",
         body=body,
@@ -185,6 +207,7 @@ def cmd_registry_failure(args: argparse.Namespace) -> int:
             "prompt-surface:registry-failure", SIG_REGISTRY,
         ], umbrella=args.umbrella),
     )
+    write_links(args.links_json, [{**link, "signal_type": "registry-failure"}])
     return 0
 
 
@@ -193,13 +216,15 @@ def cmd_registry_recover(args: argparse.Namespace) -> int:
     existing = find_open_issue(SIG_REGISTRY)
     if not existing:
         print("no open registry-gate failure issue")
+        write_links(args.links_json, [])
         return 0
     comment = "\n".join([
         "Registry-gate passed on the latest watchdog run.",
         "",
         f"- Watchdog run: {args.run_url or 'n/a'}",
     ]) + "\n"
-    close_issue(existing, comment)
+    link = close_issue(existing, comment)
+    write_links(args.links_json, [{**link, "signal_type": "registry-failure"}])
     return 0
 
 
@@ -211,7 +236,7 @@ def cmd_prod_sync(args: argparse.Namespace) -> int:
     summary = report.get("summary") or {}
     if summary.get("has_actionable_drift"):
         body = prod_drift_body(report, args.run_url, report_md)
-        open_or_update_issue(
+        link = open_or_update_issue(
             sig_label=SIG_PROD_DRIFT,
             title="[prompt-surface] prod fingerprint actionable drift",
             body=body,
@@ -220,14 +245,24 @@ def cmd_prod_sync(args: argparse.Namespace) -> int:
                 "prompt-surface:prod-drift", SIG_PROD_DRIFT,
             ], umbrella=args.umbrella),
         )
+        write_links(args.links_json, [{**link, "signal_type": "prod-drift"}])
         return 0
     ensure_base_labels()
     existing = find_open_issue(SIG_PROD_DRIFT)
     if not existing:
         print("no open prod drift issue")
+        write_links(args.links_json, [])
         return 0
-    close_issue(existing, prod_recover_body(args.run_url, report))
+    link = close_issue(existing, prod_recover_body(args.run_url, report))
+    write_links(args.links_json, [{**link, "signal_type": "prod-drift"}])
     return 0
+
+
+def write_links(path: pathlib.Path | None, links: list[dict[str, object]]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"links": links}, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -237,16 +272,19 @@ def main(argv: list[str] | None = None) -> int:
     p_fail = sub.add_parser("registry-failure")
     p_fail.add_argument("--run-url", default="")
     p_fail.add_argument("--umbrella", action="store_true")
+    p_fail.add_argument("--links-json", type=pathlib.Path)
 
     p_rec = sub.add_parser("registry-recover")
     p_rec.add_argument("--run-url", default="")
     p_rec.add_argument("--umbrella", action="store_true")
+    p_rec.add_argument("--links-json", type=pathlib.Path)
 
     p_prod = sub.add_parser("prod-sync")
     p_prod.add_argument("--report-json", type=pathlib.Path, required=True)
     p_prod.add_argument("--report-md", type=pathlib.Path)
     p_prod.add_argument("--run-url", default="")
     p_prod.add_argument("--umbrella", action="store_true")
+    p_prod.add_argument("--links-json", type=pathlib.Path)
 
     args = ap.parse_args(argv)
     if args.command == "registry-failure":

--- a/ops/observability/test_open_prompt_surface_watch_issues.py
+++ b/ops/observability/test_open_prompt_surface_watch_issues.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -16,6 +17,7 @@ from open_prompt_surface_watch_issues import (
     prod_drift_body,
     prod_recover_body,
     registry_failure_body,
+    write_links,
 )
 
 
@@ -51,6 +53,13 @@ class OpenPromptSurfaceWatchIssuesTest(unittest.TestCase):
         self.assertNotIn(":", path.name)
         self.assertEqual(path.name, f"issue-{filename_safe(SIG_PROD_DRIFT)}.md")
         self.assertIn("ps-sig-prod-drift", path.name)
+
+    def test_write_links_persists_structured_links(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "links.json"
+            write_links(path, [{"kind": "issue", "signal_type": "prod-drift", "url": "https://example/issues/1"}])
+            self.assertIn("prod-drift", path.read_text(encoding="utf-8"))
+            self.assertIn("https://example/issues/1", path.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":

--- a/scripts/fingerprint/client_fidelity_watch_report.py
+++ b/scripts/fingerprint/client_fidelity_watch_report.py
@@ -44,10 +44,37 @@ def load_json(path: Path | None) -> dict[str, Any] | None:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def load_links(path: Path | None) -> list[dict[str, Any]]:
+    data = load_json(path)
+    if not data:
+        return []
+    links = data.get("links")
+    return links if isinstance(links, list) else []
+
+
+def find_link(
+    links: list[dict[str, Any]],
+    *,
+    signal_type: str,
+    platform_id: str | None = None,
+    kind: str | None = None,
+) -> dict[str, Any] | None:
+    for link in links:
+        if link.get("signal_type") != signal_type:
+            continue
+        if platform_id is not None and link.get("platform_id") != platform_id:
+            continue
+        if kind is not None and link.get("kind") != kind:
+            continue
+        return link
+    return None
+
+
 def collect_signals(
     *,
     release_report: dict[str, Any] | None,
     prompt_prod_report: dict[str, Any] | None,
+    tracking_links: list[dict[str, Any]],
     release_scan_result: str,
     registry_gate_result: str,
     prod_aggregate_result: str,
@@ -55,47 +82,68 @@ def collect_signals(
     signals: list[dict[str, Any]] = []
 
     if release_scan_result == "failure":
-        signals.append({
+        sig = {
             "signal_type": "release-scan-failure",
             "status": "actionable",
             "detail": "release-scan job failed before producing a usable client release report",
-        })
+        }
+        link = find_link(tracking_links, signal_type="release-scan-failure", kind="issue")
+        if link:
+            sig["tracking"] = link
+        signals.append(sig)
 
     if registry_gate_result == "failure":
-        signals.append({
+        sig = {
             "signal_type": "registry-failure",
             "status": "actionable",
             "detail": "registry-gate job failed (registry, fixture gateway, or unit tests)",
-        })
+        }
+        link = find_link(tracking_links, signal_type="registry-failure", kind="issue")
+        if link:
+            sig["tracking"] = link
+        signals.append(sig)
 
     if release_report:
         for item in release_report.get("platforms") or []:
             if item.get("drift") and not item.get("issue_suppressed"):
-                signals.append({
+                platform_id = item.get("id")
+                sig = {
                     "signal_type": "release-drift",
                     "status": "actionable",
-                    "platform_id": item.get("id"),
+                    "platform_id": platform_id,
                     "name": item.get("name"),
                     "pinned": item.get("pinned"),
                     "upstream_latest": item.get("upstream_latest"),
                     "skill": item.get("skill"),
-                })
+                }
+                link = find_link(tracking_links, signal_type="release-drift", platform_id=platform_id, kind="issue")
+                if link:
+                    sig["tracking"] = link
+                signals.append(sig)
 
     if prompt_prod_report:
         summary = prompt_prod_report.get("summary") or {}
         if summary.get("has_actionable_drift"):
-            signals.append({
+            sig = {
                 "signal_type": "prod-drift",
                 "status": "actionable",
                 "alerts": summary.get("alerts") or [],
                 "rows": summary.get("count", 0),
-            })
+            }
+            link = find_link(tracking_links, signal_type="prod-drift", kind="issue")
+            if link:
+                sig["tracking"] = link
+            signals.append(sig)
     elif prod_aggregate_result == "failure" and registry_gate_result == "success":
-        signals.append({
+        sig = {
             "signal_type": "prod-drift",
             "status": "actionable",
             "detail": "prod-aggregate job failed (probe/aggregate error or actionable drift)",
-        })
+        }
+        link = find_link(tracking_links, signal_type="prod-drift", kind="issue")
+        if link:
+            sig["tracking"] = link
+        signals.append(sig)
 
     if (
         not signals
@@ -124,22 +172,37 @@ def render_markdown(payload: dict[str, Any]) -> str:
     lines.extend(["", "## Signals", ""])
     for sig in payload.get("signals") or []:
         st = sig.get("signal_type")
+        tracking = sig.get("tracking") or {}
+        tracking_text = f" — tracking: {tracking.get('url')}" if tracking.get("url") else ""
         if st == "release-drift":
             lines.append(
-                f"- **release-drift** `{sig.get('platform_id')}`: pin `{sig.get('pinned')}` < upstream `{sig.get('upstream_latest')}` → skill `{sig.get('skill')}`"
+                f"- **release-drift** `{sig.get('platform_id')}`: pin `{sig.get('pinned')}` < upstream `{sig.get('upstream_latest')}` → skill `{sig.get('skill')}`{tracking_text}"
             )
         elif st == "release-scan-failure":
-            lines.append(f"- **release-scan-failure**: {sig.get('detail')}")
+            lines.append(f"- **release-scan-failure**: {sig.get('detail')}{tracking_text}")
         elif st == "registry-failure":
-            lines.append(f"- **registry-failure**: {sig.get('detail')}")
+            lines.append(f"- **registry-failure**: {sig.get('detail')}{tracking_text}")
         elif st == "prod-drift":
             alerts = sig.get("alerts") or []
             if alerts:
-                lines.append(f"- **prod-drift**: {', '.join(alerts)}")
+                lines.append(f"- **prod-drift**: {', '.join(alerts)}{tracking_text}")
             else:
-                lines.append(f"- **prod-drift**: {sig.get('detail', 'actionable drift')}")
+                lines.append(f"- **prod-drift**: {sig.get('detail', 'actionable drift')}{tracking_text}")
         elif st == "aligned":
             lines.append("- **aligned**: no actionable signals")
+    tracking_links = payload.get("tracking_links") or []
+    cache_pr_url = payload.get("cache_pr_url") or ""
+    if tracking_links or cache_pr_url:
+        lines.extend(["", "## Tracking links", ""])
+        lines.append("| Type | Target | Status | Link |")
+        lines.append("|---|---|---|---|")
+        for link in tracking_links:
+            target = link.get("platform_id") or link.get("signal_type") or link.get("title") or "n/a"
+            number = f"#{link.get('number')}" if link.get("number") else link.get("title", "n/a")
+            url = link.get("url") or "n/a"
+            lines.append(f"| `{link.get('kind', 'link')}` | `{target}` | `{link.get('status', 'n/a')}` | [{number}]({url}) |")
+        if cache_pr_url:
+            lines.append(f"| `pr` | `client-release-watch-cache` | `open/update` | [cache PR]({cache_pr_url}) |")
     lines.extend(["", "## Issue routing (by signal type)", ""])
     lines.append("| Signal type | GitHub label | Next command |")
     lines.append("|---|---|---|")
@@ -162,6 +225,8 @@ def build_payload(
     release_markdown: str | None,
     prompt_prod_report: dict[str, Any] | None,
     prompt_prod_markdown: str | None,
+    tracking_links: list[dict[str, Any]],
+    cache_pr_url: str,
     release_scan_result: str,
     registry_gate_result: str,
     prod_aggregate_result: str,
@@ -171,6 +236,7 @@ def build_payload(
     signals = collect_signals(
         release_report=release_report,
         prompt_prod_report=prompt_prod_report,
+        tracking_links=tracking_links,
         release_scan_result=release_scan_result,
         registry_gate_result=registry_gate_result,
         prod_aggregate_result=prod_aggregate_result,
@@ -192,6 +258,8 @@ def build_payload(
             "prod-aggregate": prod_aggregate_result,
         },
         "signals": signals,
+        "tracking_links": tracking_links,
+        "cache_pr_url": cache_pr_url,
         "routing_table": ROUTING_TABLE,
         "sections": {
             "release_markdown": release_markdown,
@@ -208,6 +276,9 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--release-report-md", type=Path)
     ap.add_argument("--prompt-prod-report-json", type=Path)
     ap.add_argument("--prompt-prod-report-md", type=Path)
+    ap.add_argument("--release-links-json", type=Path)
+    ap.add_argument("--prompt-links-json", type=Path)
+    ap.add_argument("--cache-pr-url", default="")
     ap.add_argument("--release-scan-result", default="success")
     ap.add_argument("--registry-gate-result", default="unknown")
     ap.add_argument("--prod-aggregate-result", default="unknown")
@@ -224,6 +295,24 @@ def main(argv: list[str] | None = None) -> int:
             release_markdown=None,
             prompt_prod_report={"summary": {"has_actionable_drift": True, "alerts": ["x=1"], "count": 1}},
             prompt_prod_markdown="- alert",
+            tracking_links=[
+                {
+                    "kind": "issue",
+                    "signal_type": "release-drift",
+                    "platform_id": "claude-code",
+                    "number": 1,
+                    "url": "https://example/issues/1",
+                    "status": "updated",
+                },
+                {
+                    "kind": "issue",
+                    "signal_type": "prod-drift",
+                    "number": 2,
+                    "url": "https://example/issues/2",
+                    "status": "updated",
+                },
+            ],
+            cache_pr_url="https://example/pull/3",
             release_scan_result="success",
             registry_gate_result="success",
             prod_aggregate_result="failure",
@@ -231,14 +320,18 @@ def main(argv: list[str] | None = None) -> int:
         assert payload["workflow_should_fail"] is True
         assert any(s["signal_type"] == "release-drift" for s in payload["signals"])
         assert any(s["signal_type"] == "prod-drift" for s in payload["signals"])
+        assert payload["signals"][0]["tracking"]["url"] == "https://example/issues/1"
+        assert payload["cache_pr_url"] == "https://example/pull/3"
         md = render_markdown(payload)
-        assert "release-drift" in md and "prod-drift" in md
+        assert "release-drift" in md and "prod-drift" in md and "Tracking links" in md
         failed_release = build_payload(
             run_url="https://example/run/2",
             release_report=None,
             release_markdown=None,
             prompt_prod_report=None,
             prompt_prod_markdown=None,
+            tracking_links=[],
+            cache_pr_url="",
             release_scan_result="failure",
             registry_gate_result="skipped",
             prod_aggregate_result="skipped",
@@ -251,6 +344,10 @@ def main(argv: list[str] | None = None) -> int:
 
     release_report = load_json(args.release_report_json)
     prompt_prod_report = load_json(args.prompt_prod_report_json)
+    tracking_links = [
+        *load_links(args.release_links_json),
+        *load_links(args.prompt_links_json),
+    ]
     release_md = args.release_report_md.read_text(encoding="utf-8") if args.release_report_md and args.release_report_md.is_file() else None
     prompt_md = args.prompt_prod_report_md.read_text(encoding="utf-8") if args.prompt_prod_report_md and args.prompt_prod_report_md.is_file() else None
 
@@ -260,6 +357,8 @@ def main(argv: list[str] | None = None) -> int:
         release_markdown=release_md,
         prompt_prod_report=prompt_prod_report,
         prompt_prod_markdown=prompt_md,
+        tracking_links=tracking_links,
+        cache_pr_url=args.cache_pr_url,
         release_scan_result=args.release_scan_result,
         registry_gate_result=args.registry_gate_result,
         prod_aggregate_result=args.prod_aggregate_result,


### PR DESCRIPTION
## Summary
- Add structured issue link artifacts for release drift, registry-gate failures, and prod drift, then render them in the daily client-fidelity report and GitHub step summary.
- Mark automated release-drift cache PRs as `WIP:` and draft in both the umbrella and legacy workflows.
- Add WIP body language that says the cache PR is not merge-ready until real fingerprint capture/diff alignment is run, recommending `tokenkey-fingerprint-alignment-all` or the per-platform skill.

## Test plan
- [x] `python3 scripts/fingerprint/client_fidelity_watch_report.py --selftest`
- [x] `python3 -m unittest ops.fingerprint.test_open_client_release_watch_issues ops.observability.test_open_prompt_surface_watch_issues -v`
- [x] `python3 -m py_compile ops/fingerprint/open_client_release_watch_issues.py ops/fingerprint/test_open_client_release_watch_issues.py ops/observability/open_prompt_surface_watch_issues.py ops/observability/test_open_prompt_surface_watch_issues.py scripts/fingerprint/client_fidelity_watch_report.py`
- [x] `git diff --check origin/main...HEAD`
- [x] `python3 -m unittest discover -s scripts/fingerprint -p 'test_*.py'`
- [x] `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
