### PR TITLE
fix(ops): stop stale prompt and diagnostics drift

### DIFF
--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -312,7 +312,9 @@ jobs:
               "sudo docker inspect tokenkey --format 'tokenkey_status={{.State.Status}} tokenkey_health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' 2>/dev/null || true",
               "sudo docker inspect tokenkey-postgres --format 'postgres_status={{.State.Status}}' 2>/dev/null || true",
               "sudo docker inspect tokenkey-redis --format 'redis_status={{.State.Status}}' 2>/dev/null || true",
-              "sudo docker compose -f /var/lib/tokenkey/docker-compose.yml --env-file /var/lib/tokenkey/.env exec -T tokenkey wget -qO- http://localhost:8080/health",
+              "echo ===INTERNAL_HEALTH===",
+              "if sudo docker compose -f /var/lib/tokenkey/docker-compose.yml --env-file /var/lib/tokenkey/.env exec -T tokenkey wget -qO- http://localhost:8080/health; then echo; echo internal_health_status=ok; else rc=$?; echo internal_health_status=failed exit=$rc; fi",
+              "echo ===END_INTERNAL_HEALTH===",
               "SIG_OUT=/tmp/prod-ops-runtime-signals",
               "sudo rm -rf \"$SIG_OUT\" && sudo mkdir -p \"$SIG_OUT\" && sudo chmod 0777 \"$SIG_OUT\"",
               "sudo docker logs tokenkey --since " + quoted_since + " > \"$SIG_OUT/tokenkey.log\" 2>&1 || true",
@@ -333,9 +335,15 @@ jobs:
           ]
           print(json.dumps({"commands": commands}))
           PY
+            RUNTIME_SSM_TRANSPORT_OK=false
             if CMD_ID="$(aws ssm send-command --region "$TARGET_REGION" --instance-ids "$INSTANCE_ID" --document-name AWS-RunShellScript --comment "prod-ops runtime diagnostics target=$TARGET_ID" --parameters "file://$OUT/runtime-params.json" --query 'Command.CommandId' --output text 2>>"$STDERR")"; then
+              RUNTIME_SSM_TRANSPORT_OK=true
               echo "runtime ssm command-id=$CMD_ID" >> "$STDOUT"
-              DEADLINE=$(( $(date +%s) + 180 ))
+              RUNTIME_WAIT_SECONDS=180
+              if [ "$TARGET_ID" = "prod" ]; then
+                RUNTIME_WAIT_SECONDS=300
+              fi
+              DEADLINE=$(( $(date +%s) + RUNTIME_WAIT_SECONDS ))
               STATUS="InProgress"
               while true; do
                 STATUS="$(aws ssm get-command-invocation --region "$TARGET_REGION" --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" --query 'Status' --output text 2>/dev/null || echo InProgress)"
@@ -347,6 +355,10 @@ jobs:
               aws ssm get-command-invocation --region "$TARGET_REGION" --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" --query 'StandardErrorContent' --output text > "$OUT/runtime-stderr.txt" 2>>"$STDERR" || true
               tail -c 8192 "$OUT/runtime-stdout.txt" >> "$STDOUT" || true
               tail -c 4096 "$OUT/runtime-stderr.txt" >> "$STDERR" || true
+              if grep -q '^internal_health_status=failed' "$OUT/runtime-stdout.txt"; then
+                INTERNAL_HEALTH_SUMMARY="$(grep '^internal_health_status=failed' "$OUT/runtime-stdout.txt" | tail -1)"
+                add_finding "internal_health" "warning" "warning" "Internal container health probe failed for $TARGET_ID" "The in-container /health probe reported ${INTERNAL_HEALTH_SUMMARY}; runtime log signal collection continued." "internal-health|$TARGET_ID"
+              fi
               if grep -q '^===END_LOG_SIGNAL_COUNTS===$' "$OUT/runtime-stdout.txt"; then
                 awk '/^===LOG_SIGNAL_COUNTS===$/{f=1;next} /^===END_LOG_SIGNAL_COUNTS===$/{f=0} f' "$OUT/runtime-stdout.txt" > "$OUT/log-signal-counts.json" || true
                 python3 - <<'PY' "$OUT/log-signal-counts.json" "$FINDINGS" "$TARGET_ID" "$DIAGNOSTICS_LOG_SINCE"
@@ -409,7 +421,7 @@ jobs:
               if [ "$STATUS" = "Success" ]; then
                 add_finding "ssm_runtime" "ok" "info" "SSM runtime diagnostics passed for $TARGET_ID" "Docker runtime diagnostics completed on $INSTANCE_ID." "ssm-runtime|$TARGET_ID"
               else
-                add_finding "ssm_runtime" "manual_ops" "error" "SSM runtime diagnostics failed for $TARGET_ID" "SSM runtime diagnostics finished with status=$STATUS on $INSTANCE_ID." "ssm-runtime|$TARGET_ID|$STATUS"
+                add_finding "ssm_runtime" "manual_ops" "error" "SSM runtime diagnostics failed for $TARGET_ID" "SSM runtime diagnostics finished with status=$STATUS on $INSTANCE_ID after waiting up to ${RUNTIME_WAIT_SECONDS}s." "ssm-runtime|$TARGET_ID|$STATUS"
               fi
             else
               add_finding "ssm_send_command" "manual_ops" "error" "Could not send SSM command for $TARGET_ID" "SSM SendCommand failed for $INSTANCE_ID in $TARGET_REGION." "ssm-send|$TARGET_ID"
@@ -417,6 +429,8 @@ jobs:
 
             if [ "$INCLUDE_ERROR_CLUSTERING" != "true" ]; then
               add_finding "error_clustering" "skip" "info" "Error clustering skipped for $TARGET_ID" "diagnostics_include_error_clustering=false; runtime/health-only lightweight diagnostics." "error-clustering|$TARGET_ID|lightweight-skip"
+            elif [ "$RUNTIME_SSM_TRANSPORT_OK" != "true" ]; then
+              add_finding "error_clustering" "skip" "info" "Error clustering skipped for $TARGET_ID" "Runtime SSM SendCommand failed; suppressing downstream error_clustering SSM checks for the same transport root cause." "error-clustering|$TARGET_ID|runtime-ssm-send-failed"
             elif [ "${TARGET_PLATFORM:-ec2}" = "lightsail" ]; then
               # ops/stage0/deploy-error-clustering-binary.sh resolves InstanceId via
               # CloudFormation; Lightsail edges have no CFN stack. Lightweight diagnostics

--- a/backend/internal/service/gateway_request_tk_cc_prompt_surface_test.go
+++ b/backend/internal/service/gateway_request_tk_cc_prompt_surface_test.go
@@ -143,6 +143,18 @@ func TestTkNormalizeAnthropicCCPromptSurfaceNormalizesKnownSystemText(t *testing
 	require.Contains(t, got, "Today's date is 2026-07-01.")
 }
 
+func TestTkNormalizeAnthropicCCPromptSurfaceNormalizesInteractiveCLIToolSystemText(t *testing.T) {
+	in := []byte(`{"system":[{"type":"text","text":"x-anthropic-billing-header: cc-session"},{"type":"text","text":"You are an interactive CLI tool that helps users safely and efficiently.\n# Environment\nTZ=Asia/Shanghai\nPWD=/work\n\nToday's date is 2026/07/01."}],"messages":[{"role":"user","content":"hi"}]}`)
+	out, changed := tkNormalizeAnthropicCCPromptSurface(in, "edge-oauth@tokenkey.dev")
+	require.True(t, changed)
+	got := string(out)
+	require.NotContains(t, got, "# Environment")
+	require.NotContains(t, got, "Asia/Shanghai")
+	require.NotContains(t, got, "PWD=/work")
+	require.Contains(t, got, "Today's date is 2026-07-01.")
+	require.Empty(t, tkCCPromptSurfaceBodyUnknownSurfaces(out))
+}
+
 func TestTkWireStillHasCCPromptSurfaceLeaks(t *testing.T) {
 	require.True(t, tkWireStillHasCCPromptSurfaceLeaks([]byte(`{"messages":[{"role":"user","content":"<system-reminder>\n# Environment\nTZ=Asia/Shanghai\n</system-reminder>"}]}`)))
 	require.False(t, tkWireStillHasCCPromptSurfaceLeaks([]byte(`{"messages":[{"role":"user","content":"# Environment\nTZ=Asia/Shanghai"}]}`)))

--- a/backend/internal/service/gateway_request_tk_prompt_fingerprint.go
+++ b/backend/internal/service/gateway_request_tk_prompt_fingerprint.go
@@ -31,6 +31,7 @@ var tkPromptSurfaceIdentityPrefixes = []struct {
 	{"claude_code_cli", "You are Claude Code, Anthropic's official CLI for Claude"},
 	{"claude_agent_sdk", "You are a Claude agent, built on Anthropic's Claude Agent SDK"},
 	{"interactive_agent", "You are an interactive agent that helps users with software engineering tasks"},
+	{"interactive_cli_tool", "You are an interactive CLI tool that helps users"},
 	{"file_search_specialist", "You are a file search specialist for Claude Code"},
 	{"summarization_assistant", "You are a helpful AI assistant tasked with summarizing conversations"},
 }

--- a/backend/internal/service/gateway_request_tk_prompt_fingerprint_test.go
+++ b/backend/internal/service/gateway_request_tk_prompt_fingerprint_test.go
@@ -64,6 +64,16 @@ func TestTkExtractAnthropicPromptFingerprint_InteractiveAgentAnchor(t *testing.T
 	require.ElementsMatch(t, []tkCCPromptSurfaceClass{tkCCPromptSurfaceKnownSystem}, fp.PromptSurfaceClasses)
 }
 
+func TestTkExtractAnthropicPromptFingerprint_InteractiveCLIToolAnchor(t *testing.T) {
+	body := []byte(`{
+		"system":[{"type":"text","text":"You are an interactive CLI tool that helps users safely and efficiently.\n# Environment\nTZ=Asia/Shanghai"}]
+	}`)
+	fp := tkExtractAnthropicPromptFingerprint(body)
+	require.Equal(t, "interactive_cli_tool", fp.IdentityAnchorID)
+	require.ElementsMatch(t, []tkCCPromptSurfaceClass{tkCCPromptSurfaceKnownSystem}, fp.PromptSurfaceClasses)
+	require.Contains(t, fp.UnknownSurfaces, "cc_environment_section")
+}
+
 func TestTkExtractAnthropicPromptFingerprint_UnknownIdentity(t *testing.T) {
 	body := []byte(`{"system":[{"type":"text","text":"You are a generic assistant."}]}`)
 	fp := tkExtractAnthropicPromptFingerprint(body)

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -380,6 +380,7 @@ var (
 		"You are Claude Code, Anthropic's official CLI for Claude",      // 标准版 & Agent SDK 版（含 running within...）
 		"You are a Claude agent, built on Anthropic's Claude Agent SDK", // Agent SDK 变体
 		"You are an interactive agent that helps users with software engineering tasks",
+		"You are an interactive CLI tool that helps users",
 		"You are a file search specialist for Claude Code",                     // Explore Agent 版
 		"You are a helpful AI assistant tasked with summarizing conversations", // Compact 版
 	}

--- a/ops/anthropic/prompt_surface_registry.json
+++ b/ops/anthropic/prompt_surface_registry.json
@@ -66,6 +66,10 @@
           "prefix": "You are an interactive agent that helps users with software engineering tasks"
         },
         {
+          "id": "interactive_cli_tool",
+          "prefix": "You are an interactive CLI tool that helps users"
+        },
+        {
           "id": "file_search_specialist",
           "prefix": "You are a file search specialist for Claude Code"
         },

--- a/ops/observability/test_ops_daily_diagnostics_workflow.py
+++ b/ops/observability/test_ops_daily_diagnostics_workflow.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Regression tests for Ops Daily Diagnostics workflow control-flow guards."""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ops-daily-diagnostics.yml"
+
+
+def workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def extract_runtime_params_commands() -> list[str]:
+    marker = 'python3 - <<\'PY\' > "$OUT/runtime-params.json"\n'
+    text = workflow_text()
+    start = text.index(marker) + len(marker)
+    end = text.index("\n          PY", start)
+    script = textwrap.dedent(text[start:end])
+    old_since = os.environ.get("DIAGNOSTICS_LOG_SINCE")
+    os.environ["DIAGNOSTICS_LOG_SINCE"] = "24h"
+    try:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exec(compile(script, str(WORKFLOW), "exec"), {})
+        return json.loads(stdout.getvalue())["commands"]
+    finally:
+        if old_since is None:
+            os.environ.pop("DIAGNOSTICS_LOG_SINCE", None)
+        else:
+            os.environ["DIAGNOSTICS_LOG_SINCE"] = old_since
+
+
+class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
+    def test_internal_health_probe_cannot_abort_log_signal_collection(self) -> None:
+        commands = extract_runtime_params_commands()
+        internal_start = commands.index("echo ===INTERNAL_HEALTH===")
+        internal_probe = commands[internal_start + 1]
+        internal_end = commands.index("echo ===END_INTERNAL_HEALTH===")
+        log_start = commands.index("echo ===LOG_SIGNAL_COUNTS===")
+
+        self.assertLess(internal_start, internal_end)
+        self.assertLess(internal_end, log_start)
+        self.assertTrue(
+            internal_probe.startswith("if sudo docker compose "),
+            msg=internal_probe,
+        )
+        self.assertIn("internal_health_status=failed exit=$rc", internal_probe)
+        self.assertIn("then echo; echo internal_health_status=ok", internal_probe)
+
+    def test_prod_runtime_wait_uses_named_300_second_deadline(self) -> None:
+        text = workflow_text()
+        self.assertIn("RUNTIME_WAIT_SECONDS=180", text)
+        self.assertIn('if [ "$TARGET_ID" = "prod" ]; then', text)
+        self.assertIn("RUNTIME_WAIT_SECONDS=300", text)
+        self.assertIn("DEADLINE=$(( $(date +%s) + RUNTIME_WAIT_SECONDS ))", text)
+        self.assertIn(
+            "after waiting up to ${RUNTIME_WAIT_SECONDS}s",
+            text,
+        )
+
+    def test_ssm_transport_failure_suppresses_downstream_clustering(self) -> None:
+        text = workflow_text()
+        init = text.index("RUNTIME_SSM_TRANSPORT_OK=false")
+        send_success = text.index("RUNTIME_SSM_TRANSPORT_OK=true", init)
+        suppress = text.index('elif [ "$RUNTIME_SSM_TRANSPORT_OK" != "true" ]; then')
+        lightsail = text.index('elif [ "${TARGET_PLATFORM:-ec2}" = "lightsail" ]; then')
+        binary_check = text.index("error_clustering_binary_check", lightsail)
+
+        self.assertLess(init, send_success)
+        self.assertLess(send_success, suppress)
+        self.assertLess(suppress, lightsail)
+        self.assertLess(lightsail, binary_check)
+        self.assertIn(
+            "Runtime SSM SendCommand failed; suppressing downstream error_clustering SSM checks",
+            text,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/sentinels/cc-system-prompt.json
+++ b/scripts/sentinels/cc-system-prompt.json
@@ -6,6 +6,7 @@
       "You are Claude Code, Anthropic's official CLI for Claude",
       "You are a Claude agent, built on Anthropic's Claude Agent SDK",
       "You are an interactive agent that helps users with software engineering tasks",
+      "You are an interactive CLI tool that helps users",
       "You are a file search specialist for Claude Code",
       "You are a helpful AI assistant tasked with summarizing conversations"
     ],
@@ -43,6 +44,7 @@
         "You are Claude Code, Anthropic's official CLI for Claude",
         "You are a Claude agent, built on Anthropic's Claude Agent SDK",
         "You are an interactive agent that helps users with software engineering tasks",
+        "You are an interactive CLI tool that helps users",
         "You are a file search specialist for Claude Code",
         "You are a helpful AI assistant tasked with summarizing conversations"
       ],


### PR DESCRIPTION
## 摘要

- 修复 `#1135` 的根因：prod prompt-surface drift 样本来自已被 validator 接受、但 prompt-surface registry / gateway fingerprint 尚未登记的 `You are an interactive CLI tool that helps users` Claude Code identity anchor；补齐 sentinel、registry、gateway fingerprint 和 prompt-prefix 去重链路，并验证该系统块会被 normalizer 清理 `# Environment`。
- 修复 `#980` / `#773` 对应的 prod runtime diagnostics 脆弱点：内部容器 `/health` 探测失败不再在 `set -e` 下截断后续 log signal marker；prod SSM runtime poller 等待窗口从 180s 提高到 300s。
- 降低 `#373` / `#374` / `#375` 这类 SSM 传输故障的重复告警：runtime `ssm_send_command` 已失败时，跳过 downstream `error_clustering_*` SSM 检查，只保留根因信号。

## 风险

- 常规风险：影响 prod ops diagnostics workflow 和 Anthropic prompt-surface normalizer/fingerprint 分类，不改用户可见 Web UI、不改数据库 schema、不改鉴权边界。
- `#1135` 需要合并部署后由下一轮 prompt-surface watch 验证线上 drift 清除；当前 PR 已用线上 probe 证据确认现象匹配该缺失 anchor。
- `#980` / `#773` 需要合并后由下一轮 ops daily diagnostics 或手动 workflow_dispatch 验证告警不再复发。

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` PASS
- pre-commit hook `scripts/preflight.sh` PASS
- `python3 -m unittest discover -s ops/observability -p 'test_*.py' -t ops/observability -q` PASS
- `python3 -m unittest ops.anthropic.test_probe_prompt_surfaces -q` PASS
- `python3 ops/anthropic/probe_prompt_surfaces.py --check-registry` PASS
- `python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway` PASS
- `python3 scripts/sentinels/check-cc-system-prompt.py --selftest && python3 scripts/sentinels/check-cc-system-prompt.py` PASS
- `cd backend && go test -tags=unit ./internal/service -run 'TestTkExtractAnthropicPromptFingerprint|TestTkNormalizeAnthropicCCPromptSurface|TestTkWireStillHasCCPromptSurfaceLeaks' -count=1` PASS
- 只读线上证据：`bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-prompt-surface-fingerprints.sh --env SINCE=24h --env LIMIT=40 --timeout-seconds 180` 显示 drift 样本为 `prompt_surface_classes=known_cc_system,unknown_system,generic_system_text,generic_user_text`、`unknown_surfaces=cc_environment_section`，与缺失 `interactive_cli_tool` identity anchor 的修复路径一致。
- 只读 edge 证据：`python3 deploy/aws/stage0/resolve-edge-target.py --list-deployable` 返回 `us3 us4 us5 us6`；`uk1` 当前 `deployable=false` 且矩阵记录 2026-06-23 retired。

## 提交

- `6892f3b66 fix(ops): stop stale prompt and diagnostics drift`
- 最新提交：`6892f3b66`

## 影响面

Web impact: none (`no-web-impact`)。本 PR 只改 ops workflow、Anthropic prompt surface registry / gateway fingerprint 识别、以及相应测试。

sentinel-registry-reviewed
