### PR TITLE
fix(ci): clear golangci unused and gofmt drift on main

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -180,7 +180,7 @@ type AccountWithConcurrency struct {
 	CurrentConcurrency int `json:"current_concurrency"`
 	// 以下字段仅对 Anthropic OAuth/SetupToken 账号有效，且仅在启用相应功能时返回
 	ActiveSessions *int `json:"active_sessions,omitempty"` // 当前活跃会话数
-	CurrentRPM        *int     `json:"current_rpm,omitempty"`         // 当前分钟 RPM 计数
+	CurrentRPM     *int `json:"current_rpm,omitempty"`     // 当前分钟 RPM 计数
 	// EdgeID is the edge a prod anthropic mirror stub relays to (api-us1 → "us1"),
 	// empty for non-stub accounts. TK: lets the accounts UI expand a stub row into
 	// that edge's accounts inline (unified prod+edge governance). Derived, not

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -1051,30 +1051,6 @@ func (s *AccountUsageService) getAntigravityUsage(ctx context.Context, account *
 	return usage, nil
 }
 
-func (s *AccountUsageService) getGrokUsage(ctx context.Context, account *Account) (*UsageInfo, error) {
-	if s.grokQuotaFetcher == nil {
-		now := time.Now()
-		return &UsageInfo{UpdatedAt: &now}, nil
-	}
-	usage := s.grokQuotaFetcher.BuildUsageInfo(account)
-	if usage.GrokQuotaSnapshotState == "" {
-		if usage.ErrorCode == "quota_unknown" {
-			usage.GrokQuotaSnapshotState = "unknown_until_first_response"
-		} else {
-			usage.GrokQuotaSnapshotState = "observed"
-		}
-	}
-
-	if s.usageLogRepo != nil && account != nil {
-		if stats, err := s.usageLogRepo.GetAccountTodayStats(ctx, account.ID); err == nil && stats != nil {
-			usage.GrokLocalUsage = windowStatsFromAccountStats(stats)
-		}
-	}
-
-	enrichUsageWithAccountError(usage, account)
-	return usage, nil
-}
-
 // recalcAntigravityRemainingSeconds 重新计算 Antigravity UsageInfo 中各窗口的 RemainingSeconds
 // 用于从缓存取出时更新倒计时，避免返回过时的剩余秒数
 func recalcAntigravityRemainingSeconds(info *UsageInfo) {

--- a/backend/internal/service/gateway_request_tk_cc_geo_stego.go
+++ b/backend/internal/service/gateway_request_tk_cc_geo_stego.go
@@ -1,12 +1,8 @@
 package service
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
 )
 
 // TokenKey: normalize Claude Code client geo steganography in outbound
@@ -33,6 +29,7 @@ var (
 	tkCCGeoStegoTodayDateRE    = regexp.MustCompile("Today[''\u2019\u02bc\u02b9]s date is (\\d{4})[/-](\\d{2})[/-](\\d{2})\\.")
 	tkCCGeoStegoTodayDateNowRE = regexp.MustCompile("Today[''\u2019\u02bc\u02b9]s date is now (\\d{4})[/-](\\d{2})[/-](\\d{2})\\.")
 	tkCCGeoStegoDateTokenRE    = regexp.MustCompile(`^(\d{4})[/-](\d{2})[/-](\d{2})$`)
+	tkPromptGeoSlashDateRE     = regexp.MustCompile(`(?i)Today.?s date is(?: now)? \d{4}/\d{2}/\d{2}\.`)
 )
 
 func tkNormalizeCCGeoStegoText(text string) (string, bool) {
@@ -59,128 +56,4 @@ func tkNormalizeCCGeoDateToken(date string) (string, bool) {
 
 func tkNormalizeAnthropicCCGeoStego(body []byte) ([]byte, bool) {
 	return tkNormalizeAnthropicCCPromptSurface(body, "")
-}
-
-func tkNormalizeAnthropicCCGeoStegoSystem(body []byte) ([]byte, bool) {
-	system := gjson.GetBytes(body, "system")
-	if !system.Exists() {
-		return body, false
-	}
-
-	switch system.Type {
-	case gjson.String:
-		newText, ok := tkNormalizeCCGeoStegoText(system.String())
-		if !ok {
-			return body, false
-		}
-		out, err := sjson.SetBytes(body, "system", newText)
-		if err != nil {
-			return body, false
-		}
-		return out, true
-	case gjson.JSON:
-		if !system.IsArray() {
-			return body, false
-		}
-		out := body
-		changed := false
-		for i, item := range system.Array() {
-			if item.Get("type").String() != "text" {
-				continue
-			}
-			text := item.Get("text").String()
-			newText, ok := tkNormalizeCCGeoStegoText(text)
-			if !ok {
-				continue
-			}
-			path := fmt.Sprintf("system.%d.text", i)
-			next, err := sjson.SetBytes(out, path, newText)
-			if err != nil {
-				continue
-			}
-			out = next
-			changed = true
-		}
-		return out, changed
-	default:
-		return body, false
-	}
-}
-
-func tkNormalizeAnthropicCCGeoStegoMessages(body []byte) ([]byte, bool) {
-	messages := gjson.GetBytes(body, "messages")
-	if !messages.IsArray() {
-		return body, false
-	}
-
-	out := body
-	changed := false
-	for mi, msg := range messages.Array() {
-		content := msg.Get("content")
-		switch content.Type {
-		case gjson.String:
-			newText, ok := tkNormalizeCCGeoStegoText(content.String())
-			if !ok {
-				continue
-			}
-			path := fmt.Sprintf("messages.%d.content", mi)
-			next, err := sjson.SetBytes(out, path, newText)
-			if err != nil {
-				continue
-			}
-			out = next
-			changed = true
-		case gjson.JSON:
-			if !content.IsArray() {
-				continue
-			}
-			for ci, block := range content.Array() {
-				blockType := block.Get("type").String()
-				if blockType == "text" {
-					text := block.Get("text").String()
-					newText, ok := tkNormalizeCCGeoStegoText(text)
-					if ok {
-						path := fmt.Sprintf("messages.%d.content.%d.text", mi, ci)
-						next, err := sjson.SetBytes(out, path, newText)
-						if err == nil {
-							out = next
-							changed = true
-						}
-					}
-				}
-				if block.Get("attachment.type").String() == "date_change" {
-					date := block.Get("attachment.newDate").String()
-					newDate, ok := tkNormalizeCCGeoDateToken(date)
-					if ok {
-						path := fmt.Sprintf("messages.%d.content.%d.attachment.newDate", mi, ci)
-						next, err := sjson.SetBytes(out, path, newDate)
-						if err == nil {
-							out = next
-							changed = true
-						}
-					}
-				}
-			}
-		}
-	}
-	return out, changed
-}
-
-var tkWireCCGeoStegoSlashDateRE = regexp.MustCompile(`Today's date is \d{4}/\d{2}/\d{2}\.`)
-var tkPromptGeoSlashDateRE = regexp.MustCompile(`(?i)Today.?s date is(?: now)? \d{4}/\d{2}/\d{2}\.`)
-
-func tkWireStillHasCCGeoStegoDateSignals(body []byte) bool {
-	if len(body) == 0 {
-		return false
-	}
-	s := string(body)
-	if tkPromptGeoSlashDateRE.MatchString(s) || tkWireCCGeoStegoSlashDateRE.MatchString(s) {
-		return true
-	}
-	if strings.Contains(s, "Today\u2019s") ||
-		strings.Contains(s, "Today\u02bcs") ||
-		strings.Contains(s, "Today\u02b9s") {
-		return true
-	}
-	return false
 }

--- a/backend/internal/service/tier_service.go
+++ b/backend/internal/service/tier_service.go
@@ -330,19 +330,6 @@ func extraInt(m map[string]any, key string) int {
 	}
 }
 
-func extraFloat(m map[string]any, key string) float64 {
-	switch v := m[key].(type) {
-	case float64:
-		return v
-	case int:
-		return float64(v)
-	case int64:
-		return float64(v)
-	default:
-		return 0
-	}
-}
-
 func extraBool(m map[string]any, key string) bool {
 	b, _ := m[key].(bool)
 	return b

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2126,11 +2126,11 @@
       "must_contain": [
         "func tkNormalizeAnthropicCCGeoStego",
         "tkNormalizeAnthropicCCPromptSurface",
-        "func tkWireStillHasCCGeoStegoDateSignals",
+        "tkPromptGeoSlashDateRE",
         "tkNormalizeChangeCCGeoStego",
         "Today's date is $1-$2-$3."
       ],
-      "rationale": "CC geo-stego date-line helpers; tkNormalizeAnthropicCCGeoStego delegates to gateway_request_tk_cc_prompt_surface.go."
+      "rationale": "CC geo-stego date-line helpers; tkNormalizeAnthropicCCGeoStego delegates to gateway_request_tk_cc_prompt_surface.go; tkPromptGeoSlashDateRE stays for prompt-surface fingerprint detection."
     },
     {
       "path": "backend/internal/service/account_tk_oauth_email.go",


### PR DESCRIPTION
## 摘要

- 修复 `backend-ci` 上 `golangci-lint` 阻塞：`account_handler.go` gofmt、移除 usage-window 重构后遗留的 dead code（`getGrokUsage`、geo-stego 旧路径、`extraFloat`）
- 同步更新 `gateway-tk.json` geo-stego sentinel，锚点改为 `tkPromptGeoSlashDateRE`（prompt-surface 委托路径）

## 风险

低风险：纯删除未引用代码 + 格式修正，无运行时行为变化。

## 验证

- `golangci-lint run`（backend 全量）0 issues
- `go test -tags=unit ./internal/service/...` 通过
- `./scripts/preflight.sh` 通过

## 提交

- b89ce49db fix(ci): clear golangci unused and gofmt drift on main

最新提交：b89ce49db
