### PR TITLE
Fix universal key endpoint routing

### DIFF
--- a/backend/internal/service/universal_routing_tk_endpoint_map.go
+++ b/backend/internal/service/universal_routing_tk_endpoint_map.go
@@ -89,9 +89,14 @@ func universalCandidatePlatforms(shape UniversalShape, forcedPlatform string, ha
 		}
 		return out
 	case ShapeAnthropicCountTokens:
-		return []string{PlatformAnthropic, PlatformAntigravity}
+		out := []string{PlatformAnthropic, PlatformAntigravity}
+		out = append(out, OpenAICompatPlatforms()...)
+		return out
 	case ShapeOpenAIChat:
 		out := OpenAICompatPlatforms()
+		if universalModelPlatformHint(model) == PlatformAnthropic {
+			out = append(out, PlatformAnthropic)
+		}
 		// Gemini-native image models (gemini-*-image, nano-banana) ride
 		// /v1/chat/completions but are served by the antigravity pool — not
 		// openai-compat. Without antigravity in candidates, universal keys

--- a/backend/internal/service/universal_routing_tk_resolver_test.go
+++ b/backend/internal/service/universal_routing_tk_resolver_test.go
@@ -105,16 +105,24 @@ func TestUniversalCandidatePlatforms(t *testing.T) {
 		t.Errorf("messages with dispatch should include openai-compat: %v", withDispatch)
 	}
 
-	// count_tokens never includes openai-compat.
+	// count_tokens uses the same group-platform split handler as direct keys, so
+	// universal keys may route OpenAI-compatible models to the compat bridge.
 	ct := universalCandidatePlatforms(ShapeAnthropicCountTokens, "", true, "")
-	if contains(ct, PlatformOpenAI) || contains(ct, PlatformNewAPI) {
-		t.Errorf("count_tokens must stay anthropic/antigravity: %v", ct)
+	if !contains(ct, PlatformAnthropic) || !contains(ct, PlatformAntigravity) ||
+		!contains(ct, PlatformOpenAI) || !contains(ct, PlatformNewAPI) || !contains(ct, PlatformGrok) {
+		t.Errorf("count_tokens candidates should include native anthropic pair plus openai-compat: %v", ct)
 	}
 
 	// chat = OpenAI-compat pool (includes grok).
 	chat := universalCandidatePlatforms(ShapeOpenAIChat, "", false, "")
 	if !contains(chat, PlatformOpenAI) || !contains(chat, PlatformNewAPI) || !contains(chat, PlatformGrok) {
 		t.Errorf("chat candidates should be openai-compat pool: %v", chat)
+	}
+	// claude models on OpenAI-shaped chat/responses may route to Anthropic,
+	// matching direct-group gateway behavior.
+	chatClaude := universalCandidatePlatforms(ShapeOpenAIChat, "", false, "claude-sonnet-4-6")
+	if !contains(chatClaude, PlatformAnthropic) {
+		t.Errorf("claude chat should include anthropic candidate: %v", chatClaude)
 	}
 	// gemini-native image on chat completions also includes antigravity.
 	chatImage := universalCandidatePlatforms(ShapeOpenAIChat, "", false, "gemini-3.1-flash-image")

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -47,8 +47,8 @@ func TestResolve_NewapiPicksGroupThatServesModel(t *testing.T) {
 func TestResolve_NativeEmptyMappingDoesNotMatchOtherVendor(t *testing.T) {
 	ctx := context.Background()
 	span := []Group{
-		grp(2, PlatformOpenAI, 5, false),    // 中继组,nil served
-		grp(11, PlatformNewAPI, 10, false),  // deepseek
+		grp(2, PlatformOpenAI, 5, false),   // 中继组,nil served
+		grp(11, PlatformNewAPI, 10, false), // deepseek
 	}
 	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
 	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
@@ -90,8 +90,8 @@ func TestResolve_GeminiNativeImageChatPicksAntigravity(t *testing.T) {
 func TestResolve_ImagenPicksVertexNewapiGroup(t *testing.T) {
 	ctx := context.Background()
 	span := []Group{
-		grp(2, PlatformOpenAI, 5, false),    // openai 中继,nil served(不支持 imagen)
-		grp(16, PlatformNewAPI, 10, false),  // google-vertex
+		grp(2, PlatformOpenAI, 5, false),   // openai 中继,nil served(不支持 imagen)
+		grp(16, PlatformNewAPI, 10, false), // google-vertex
 	}
 	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
 	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
@@ -150,6 +150,24 @@ func TestResolve_NativeAnthropicRegression(t *testing.T) {
 	}
 }
 
+// 1.8.72 prod 实测:direct Anthropic key 已支持 Claude 模型走 /v1/chat/completions
+// 与 /v1/responses。全能 key 的 OpenAI-shaped chat/responses 也应在 claude-* 模型
+// 下把 Anthropic 组纳入候选,而不是因候选只含 openai-compat 返回 403。
+func TestResolve_ClaudeOpenAIShapePicksAnthropic(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(1, PlatformAnthropic, 5, false),
+		grp(2, PlatformOpenAI, 1, false),
+		grp(11, PlatformNewAPI, 2, false),
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{})) // native groups only
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIChat, "claude-sonnet-4-6", "")
+	if err != nil || g == nil || g.ID != 1 {
+		t.Fatalf("claude @openai-shape 应落 anthropic gid=1, got=%v err=%v", g, err)
+	}
+}
+
 // 安全兜底:provider 未接线(nil)→ 退回平台级现状(不因新逻辑改变行为)。
 func TestResolve_NilProviderFallsBackToPlatformLevel(t *testing.T) {
 	ctx := context.Background()
@@ -201,11 +219,11 @@ func TestResolve_NoServingGroupWithoutHintFallsBack(t *testing.T) {
 // （direct key 绑死在 claude/Qwen 组,池里没有 deepseek 账号）。
 func user16Span() []Group {
 	return []Group{
-		dispatchGrp(5, PlatformNewAPI, 0, true),     // volcengine —— 最小 id,tiebreak 陷阱
-		grp(1, PlatformAnthropic, 1, false),         // claude(native,无 dispatch)
-		dispatchGrp(2, PlatformOpenAI, 0, true),     // GPT专线(native openai)
-		dispatchGrp(11, PlatformNewAPI, 0, true),    // deepseek
-		dispatchGrp(18, PlatformNewAPI, 0, true),    // Qwen
+		dispatchGrp(5, PlatformNewAPI, 0, true),  // volcengine —— 最小 id,tiebreak 陷阱
+		grp(1, PlatformAnthropic, 1, false),      // claude(native,无 dispatch)
+		dispatchGrp(2, PlatformOpenAI, 0, true),  // GPT专线(native openai)
+		dispatchGrp(11, PlatformNewAPI, 0, true), // deepseek
+		dispatchGrp(18, PlatformNewAPI, 0, true), // Qwen
 	}
 }
 
@@ -274,15 +292,45 @@ func TestResolve_MessagesDispatch_NewapiVendor_FilterIsLoadBearing(t *testing.T)
 	}
 }
 
-// count_tokens 候选恒为 [anthropic, antigravity],永不并入 openai-compat:deepseek 有 newapi
-// hint 且无组服务 → 403(不再盲落 anthropic 组后在下游打成 routing 429)。
-func TestResolve_CountTokensNeverDispatchesNewapi_User16(t *testing.T) {
+// 1.8.72 prod 实测:direct OpenAI/NewAPI/Grok key 的 /v1/messages/count_tokens 已可用
+// (OpenAI-compatible bridge)。全能 key 的 count_tokens 也应按模型收敛到对应
+// OpenAI-compatible vendor 组,而不是候选层 403。
+func TestResolve_CountTokensDispatchesOpenAICompat_User16(t *testing.T) {
 	ctx := context.Background()
 	r := NewUniversalRoutingResolver(&stubSpanLister{groups: user16Span()})
 	r.SetAvailableModelsProvider(user16ServingProvider())
-	g, err := r.Resolve(ctx, universalKey(16), ShapeAnthropicCountTokens, "deepseek-v4-flash", "")
-	if err != ErrUniversalNoEntitledGroup || g != nil {
-		t.Fatalf("count_tokens+deepseek 无 anthropic 服务组应 403, got=%v err=%v", g, err)
+	key := universalKey(16)
+
+	g, err := r.Resolve(ctx, key, ShapeAnthropicCountTokens, "deepseek-v4-flash", "")
+	if err != nil || g == nil || g.ID != 11 {
+		t.Fatalf("count_tokens+deepseek 应落 deepseek 组 gid=11, got=%v err=%v", g, err)
+	}
+
+	g, err = r.Resolve(ctx, key, ShapeAnthropicCountTokens, "qwen-max", "")
+	if err != nil || g == nil || g.ID != 18 {
+		t.Fatalf("count_tokens+qwen 应落 Qwen 组 gid=18, got=%v err=%v", g, err)
+	}
+
+	g, err = r.Resolve(ctx, key, ShapeAnthropicCountTokens, "gpt-5", "")
+	if err != nil || g == nil || g.ID != 2 {
+		t.Fatalf("count_tokens+gpt 应落 openai 组 gid=2, got=%v err=%v", g, err)
+	}
+}
+
+func TestResolve_CountTokensDispatchesGrok(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(25, PlatformGrok, 0, false),
+		grp(2, PlatformOpenAI, 1, false),
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		25: {"grok-4.3"},
+	}))
+
+	g, err := r.Resolve(ctx, universalKey(1), ShapeAnthropicCountTokens, "grok-4.3", "")
+	if err != nil || g == nil || g.ID != 25 {
+		t.Fatalf("count_tokens+grok 应落 grok 组 gid=25, got=%v err=%v", g, err)
 	}
 }
 
@@ -299,7 +347,6 @@ func TestResolve_UniversalBenchmarkUnservedModels_User16(t *testing.T) {
 		{ShapeOpenAIChat, "kimi-2.6"},
 		{ShapeOpenAIChat, "deepseek-v3-2-251201"},
 		{ShapeOpenAIChat, "glm-4-32b-0414-128k"},
-		{ShapeOpenAIChat, "claude-haiku-4-5"}, // anthropic hint, openai-compat 候选无 anthropic
 		{ShapeOpenAIChat, "gemini-pro-agent"},
 	}
 	for _, tc := range cases {

--- a/docs/approved/universal-key-routing.md
+++ b/docs/approved/universal-key-routing.md
@@ -64,8 +64,10 @@ GPT 请求按 GPT 组的价/倍率,每用户还能有自己的专属倍率。
   再 → 候选平台集合,**从 `OpenAICompatPlatforms()` / `engine.capability` 派生**(不硬编码,
   满足 compat-pool 漂移门)。
   - `/v1/messages` → `[anthropic, antigravity]`(跨度内有 messages-dispatch 组时并入 openai-compat);
-    `…/count_tokens` → 仅 `[anthropic, antigravity]`。
-  - `/v1/chat/completions`、`/v1/responses`(含 codex、无前缀别名)→ `[openai, newapi, grok]`。
+    `…/count_tokens` → `[anthropic, antigravity] + openai-compat`(direct key 已支持
+    OpenAI/NewAPI/Grok count_tokens bridge,全能 key 同步纳入候选)。
+  - `/v1/chat/completions`、`/v1/responses`(含 codex、无前缀别名)→ `[openai, newapi, grok]`;
+    claude-* 模型额外纳入 `[anthropic]`,复用 direct Anthropic key 已支持的 OpenAI-shaped bridge。
   - `/v1/embeddings`、`/v1/images/generations`、`/v1/video/*` → capability(`[openai, newapi]`);
     `/v1/images/edits` → `[openai]`。
   - `/v1beta/models/*` POST → `[gemini, antigravity]`;GET 元数据(含 `/v1/models`)→ 跳过。
@@ -109,7 +111,8 @@ GPT 请求按 GPT 组的价/倍率,每用户还能有自己的专属倍率。
 2. 一个请求只落一个平台,不拆分、**不跨平台 failover**。
 3. 模型不在任何被授权组 → 干脆报错(不静默兜底到错平台)。
 4. 同名模型撞多平台 → 模型提示偏向 + 确定性排序(可由 sort_order 调);非"自动选最便宜/最快"。
-5. `count_tokens` 仅 anthropic/antigravity;`/v1/models` PR1 回落默认(PR3 给并集)。
+5. `count_tokens` 按模型在 Anthropic/Antigravity/OpenAI-compatible 授权组内收敛;
+   `/v1/models` PR1 回落默认(PR3 给并集)。
 6. 安全:全能 key 泄露面=该用户全部授权平台 → 默认全能宜配 key 级总额度;想锁单平台关开关。
 7. images/edits 与 video 是 multipart/poll,按端点形状路由(候选≤2),不深挖 body 模型名。
 8. 后台没有的能力变不出来(无视频账号的平台不会凭空有视频)。


### PR DESCRIPTION
## Summary

- Expand universal-key `/v1/messages/count_tokens` candidates to include OpenAI-compatible platforms (`openai`, `newapi`, `grok`) in addition to Anthropic/Antigravity.
- Allow `claude-*` models on universal-key `/v1/chat/completions` and `/v1/responses` to resolve to Anthropic groups, matching direct-key behavior verified on prod 1.8.72.
- Update universal-key routing tests and the approved design note to reflect the post-1.8.72 endpoint matrix.

## Evidence

Prod 1.8.72 probe showed direct keys already support:

- OpenAI/NewAPI/Grok `/v1/messages/count_tokens` -> 200.
- Anthropic direct key `/v1/chat/completions` and `/v1/responses` for `claude-sonnet-4-6` -> 200.

The same matrix showed universal key `tk#5` still returned 403 for:

- `gpt-5.4-mini`, `qwen3.7-max`, `deepseek-chat`, `grok-4.3` on `/v1/messages/count_tokens`.
- `claude-sonnet-4-6` on `/v1/chat/completions` and `/v1/responses`.

This PR fixes those resolver candidate gaps.

sentinel-registry-reviewed: changed files are existing universal routing anchors already covered by `gateway-tk` sentinels; no new load-bearing file or injection point was introduced.

## Tests

- `go test -count=1 -tags=unit ./internal/service -run 'TestUniversal|TestResolve_'`
- `go test -count=1 -tags=unit ./internal/server/middleware -run 'Test.*Universal|TestUniversal'`
- `go test -count=1 -tags=unit ./internal/service`
- commit hook `scripts/preflight.sh` passed
