### PR TITLE
chore(openai): isolate count_tokens fallback owner

### DIFF
--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strings"
 
-	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/gin-gonic/gin"
@@ -21,7 +20,6 @@ import (
 const (
 	openAIResponsesInputItemTokenOverhead = 3
 	openAIResponsesContentPartOverhead    = 1
-	openAIInputTokensFallbackMinimum      = 1
 )
 
 type openAIInputTokensCountRequest struct {
@@ -76,7 +74,7 @@ func (s *OpenAIGatewayService) ForwardCountTokensAsAnthropic(
 
 	token, _, err := s.getInputTokensAuthToken(ctx, account)
 	if err != nil {
-		if isOpenAICompatCountTokensCapabilityGap(account, err) {
+		if shouldEstimateOpenAIInputTokensForAuthError(account, err) {
 			writeEstimatedAnthropicCountTokens(c, body)
 			return nil
 		}
@@ -110,20 +108,17 @@ func (s *OpenAIGatewayService) ForwardCountTokensAsAnthropic(
 	}
 
 	if resp.StatusCode >= 400 {
-		upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
-		if account.Type == AccountTypeOAuth && isOpenAIOAuthInputTokensUnsupported(resp.StatusCode, respBody) {
+		fallback := classifyOpenAIInputTokensFallback(account, resp.StatusCode, respBody)
+		switch fallback.Kind {
+		case openAIInputTokensFallbackOAuthEstimate:
 			writeOpenAIOAuthInputTokensFallback(c, account, prepared, resp.StatusCode)
 			return nil
-		}
-		if isOpenAIInputTokensUnsupported(resp.StatusCode, respBody) {
-			writeEstimatedAnthropicCountTokens(c, body)
-			return nil
-		}
-		if isOpenAICompatInputTokensCapabilityGap(account, resp.StatusCode, upstreamMsg, respBody) {
+		case openAIInputTokensFallbackAnthropicEstimate:
 			writeEstimatedAnthropicCountTokens(c, body)
 			return nil
 		}
 
+		upstreamMsg := fallback.UpstreamMessage
 		if s.rateLimitService != nil {
 			s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 		}
@@ -268,117 +263,6 @@ func writeAnthropicCountTokensError(c *gin.Context, status int, errType, message
 			"message": message,
 		},
 	})
-}
-
-func isOpenAIInputTokensUnsupported(statusCode int, body []byte) bool {
-	if statusCode != http.StatusNotFound {
-		return false
-	}
-	msg := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(body)))
-	return strings.Contains(msg, "input_tokens") && strings.Contains(msg, "not found")
-}
-
-func writeOpenAIOAuthInputTokensFallback(c *gin.Context, account *Account, prepared *openAIInputTokensCountPrepared, statusCode int) {
-	estimated := openAIInputTokensFallbackMinimum
-	if got, err := estimateOpenAIInputTokens(prepared.Request); err == nil {
-		if got > 0 {
-			estimated = got
-		}
-		logger.L().Info("openai count_tokens: oauth fallback to local tiktoken estimate",
-			zap.Int64("account_id", account.ID),
-			zap.Int("upstream_status", statusCode),
-			zap.Int("estimated_input_tokens", estimated),
-			zap.String("upstream_model", prepared.UpstreamModel),
-		)
-	} else {
-		logger.L().Warn("openai count_tokens: oauth local tiktoken fallback failed, using minimum estimate",
-			zap.Int64("account_id", account.ID),
-			zap.Int("upstream_status", statusCode),
-			zap.Int("estimated_input_tokens", estimated),
-			zap.String("upstream_model", prepared.UpstreamModel),
-			zap.Error(err),
-		)
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"input_tokens": estimated,
-	})
-}
-
-func isOpenAIOAuthInputTokensUnsupported(statusCode int, body []byte) bool {
-	switch statusCode {
-	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
-	default:
-		return false
-	}
-
-	bodyLower := strings.ToLower(string(body))
-	msg := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(body)))
-	code := strings.ToLower(strings.TrimSpace(extractUpstreamErrorCode(body)))
-
-	if code == "missing_scope" ||
-		strings.Contains(bodyLower, "api.responses.write") ||
-		strings.Contains(bodyLower, "missing scopes") ||
-		strings.Contains(bodyLower, "insufficient_scope") {
-		return true
-	}
-
-	if statusCode == http.StatusNotFound && isOpenAIInputTokensUnsupported(statusCode, body) {
-		return true
-	}
-
-	return strings.Contains(msg, "input_tokens") &&
-		(strings.Contains(msg, "not found") ||
-			strings.Contains(msg, "not supported") ||
-			strings.Contains(msg, "unsupported"))
-}
-
-func isOpenAICompatCountTokensCapabilityGap(account *Account, err error) bool {
-	if account == nil || err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	if account.Platform == PlatformNewAPI {
-		if account.Type == AccountTypeServiceAccount && account.ChannelType == newapiconstant.ChannelTypeVertexAi {
-			return true
-		}
-		return strings.Contains(msg, "api_key not found")
-	}
-	return false
-}
-
-func isOpenAICompatInputTokensCapabilityGap(account *Account, statusCode int, upstreamMsg string, body []byte) bool {
-	msg := strings.ToLower(strings.TrimSpace(upstreamMsg))
-	if msg == "" {
-		msg = strings.ToLower(strings.TrimSpace(string(body)))
-	}
-	if msg == "" {
-		return false
-	}
-	if strings.Contains(msg, "input_tokens") &&
-		(strings.Contains(msg, "missing") || strings.Contains(msg, "not found") || strings.Contains(msg, "unsupported")) {
-		return true
-	}
-	if statusCode == http.StatusNotFound && openAICompatInputTokensBare404CanEstimate(account) && strings.Contains(msg, "not found") {
-		return true
-	}
-	if strings.Contains(msg, "upstream returned 403") &&
-		(strings.Contains(msg, "access/policy rejection") || strings.Contains(msg, "rejected by upstream")) {
-		return true
-	}
-	return false
-}
-
-func openAICompatInputTokensBare404CanEstimate(account *Account) bool {
-	if account == nil || account.Type == AccountTypeOAuth {
-		return false
-	}
-	switch account.Platform {
-	case PlatformOpenAI, PlatformNewAPI, PlatformGrok:
-		return true
-	default:
-		return false
-	}
 }
 
 func estimateOpenAIInputTokens(req openAIInputTokensCountRequest) (int, error) {

--- a/backend/internal/service/openai_gateway_count_tokens_fallback.go
+++ b/backend/internal/service/openai_gateway_count_tokens_fallback.go
@@ -1,0 +1,151 @@
+package service
+
+import (
+	"net/http"
+	"strings"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+const openAIInputTokensFallbackMinimum = 1
+
+type openAIInputTokensFallbackKind int
+
+const (
+	openAIInputTokensFallbackNone openAIInputTokensFallbackKind = iota
+	openAIInputTokensFallbackOAuthEstimate
+	openAIInputTokensFallbackAnthropicEstimate
+)
+
+type openAIInputTokensFallbackDecision struct {
+	Kind            openAIInputTokensFallbackKind
+	UpstreamMessage string
+}
+
+func shouldEstimateOpenAIInputTokensForAuthError(account *Account, err error) bool {
+	if account == nil || err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if account.Platform == PlatformNewAPI {
+		if account.Type == AccountTypeServiceAccount && account.ChannelType == newapiconstant.ChannelTypeVertexAi {
+			return true
+		}
+		return strings.Contains(msg, "api_key not found")
+	}
+	return false
+}
+
+func classifyOpenAIInputTokensFallback(account *Account, statusCode int, body []byte) openAIInputTokensFallbackDecision {
+	upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(body)))
+	if account != nil && account.Type == AccountTypeOAuth && isOpenAIOAuthInputTokensUnsupported(statusCode, body) {
+		return openAIInputTokensFallbackDecision{Kind: openAIInputTokensFallbackOAuthEstimate, UpstreamMessage: upstreamMsg}
+	}
+	if isOpenAIInputTokensUnsupported(statusCode, body) {
+		return openAIInputTokensFallbackDecision{Kind: openAIInputTokensFallbackAnthropicEstimate, UpstreamMessage: upstreamMsg}
+	}
+	if isOpenAICompatInputTokensCapabilityGap(account, statusCode, upstreamMsg, body) {
+		return openAIInputTokensFallbackDecision{Kind: openAIInputTokensFallbackAnthropicEstimate, UpstreamMessage: upstreamMsg}
+	}
+	return openAIInputTokensFallbackDecision{Kind: openAIInputTokensFallbackNone, UpstreamMessage: upstreamMsg}
+}
+
+func isOpenAIInputTokensUnsupported(statusCode int, body []byte) bool {
+	if statusCode != http.StatusNotFound {
+		return false
+	}
+	msg := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(body)))
+	return strings.Contains(msg, "input_tokens") && strings.Contains(msg, "not found")
+}
+
+func writeOpenAIOAuthInputTokensFallback(c *gin.Context, account *Account, prepared *openAIInputTokensCountPrepared, statusCode int) {
+	estimated := openAIInputTokensFallbackMinimum
+	if got, err := estimateOpenAIInputTokens(prepared.Request); err == nil {
+		if got > 0 {
+			estimated = got
+		}
+		logger.L().Info("openai count_tokens: oauth fallback to local tiktoken estimate",
+			zap.Int64("account_id", account.ID),
+			zap.Int("upstream_status", statusCode),
+			zap.Int("estimated_input_tokens", estimated),
+			zap.String("upstream_model", prepared.UpstreamModel),
+		)
+	} else {
+		logger.L().Warn("openai count_tokens: oauth local tiktoken fallback failed, using minimum estimate",
+			zap.Int64("account_id", account.ID),
+			zap.Int("upstream_status", statusCode),
+			zap.Int("estimated_input_tokens", estimated),
+			zap.String("upstream_model", prepared.UpstreamModel),
+			zap.Error(err),
+		)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"input_tokens": estimated,
+	})
+}
+
+func isOpenAIOAuthInputTokensUnsupported(statusCode int, body []byte) bool {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+	default:
+		return false
+	}
+
+	bodyLower := strings.ToLower(string(body))
+	msg := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(body)))
+	code := strings.ToLower(strings.TrimSpace(extractUpstreamErrorCode(body)))
+
+	if code == "missing_scope" ||
+		strings.Contains(bodyLower, "api.responses.write") ||
+		strings.Contains(bodyLower, "missing scopes") ||
+		strings.Contains(bodyLower, "insufficient_scope") {
+		return true
+	}
+
+	if statusCode == http.StatusNotFound && isOpenAIInputTokensUnsupported(statusCode, body) {
+		return true
+	}
+
+	return strings.Contains(msg, "input_tokens") &&
+		(strings.Contains(msg, "not found") ||
+			strings.Contains(msg, "not supported") ||
+			strings.Contains(msg, "unsupported"))
+}
+
+func isOpenAICompatInputTokensCapabilityGap(account *Account, statusCode int, upstreamMsg string, body []byte) bool {
+	msg := strings.ToLower(strings.TrimSpace(upstreamMsg))
+	if msg == "" {
+		msg = strings.ToLower(strings.TrimSpace(string(body)))
+	}
+	if msg == "" {
+		return false
+	}
+	if strings.Contains(msg, "input_tokens") &&
+		(strings.Contains(msg, "missing") || strings.Contains(msg, "not found") || strings.Contains(msg, "unsupported")) {
+		return true
+	}
+	if statusCode == http.StatusNotFound && openAICompatInputTokensBare404CanEstimate(account) && strings.Contains(msg, "not found") {
+		return true
+	}
+	if strings.Contains(msg, "upstream returned 403") &&
+		(strings.Contains(msg, "access/policy rejection") || strings.Contains(msg, "rejected by upstream")) {
+		return true
+	}
+	return false
+}
+
+func openAICompatInputTokensBare404CanEstimate(account *Account) bool {
+	if account == nil || account.Type == AccountTypeOAuth {
+		return false
+	}
+	switch account.Platform {
+	case PlatformOpenAI, PlatformNewAPI, PlatformGrok:
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/service/openai_gateway_count_tokens_fallback_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_fallback_test.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyOpenAIInputTokensFallback(t *testing.T) {
+	cases := []struct {
+		name       string
+		account    *Account
+		statusCode int
+		body       string
+		want       openAIInputTokensFallbackKind
+	}{
+		{
+			name:       "oauth_missing_scope_uses_tiktoken_estimate",
+			account:    &Account{Type: AccountTypeOAuth, Platform: PlatformOpenAI},
+			statusCode: http.StatusForbidden,
+			body:       `{"error":{"code":"missing_scope","message":"Missing scopes: api.responses.write"}}`,
+			want:       openAIInputTokensFallbackOAuthEstimate,
+		},
+		{
+			name:       "oauth_plain_unauthorized_does_not_estimate",
+			account:    &Account{Type: AccountTypeOAuth, Platform: PlatformOpenAI},
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":{"type":"authentication_error","message":"unauthorized"}}`,
+			want:       openAIInputTokensFallbackNone,
+		},
+		{
+			name:       "api_key_input_tokens_404_uses_anthropic_estimate",
+			account:    &Account{Type: AccountTypeAPIKey, Platform: PlatformOpenAI},
+			statusCode: http.StatusNotFound,
+			body:       `{"error":{"message":"The /v1/responses/input_tokens endpoint was not found"}}`,
+			want:       openAIInputTokensFallbackAnthropicEstimate,
+		},
+		{
+			name:       "api_key_bare_404_uses_anthropic_estimate",
+			account:    &Account{Type: AccountTypeAPIKey, Platform: PlatformOpenAI},
+			statusCode: http.StatusNotFound,
+			body:       `{"message":"Not Found"}`,
+			want:       openAIInputTokensFallbackAnthropicEstimate,
+		},
+		{
+			name:       "policy_403_envelope_uses_anthropic_estimate",
+			account:    &Account{Type: AccountTypeAPIKey, Platform: PlatformOpenAI},
+			statusCode: http.StatusBadGateway,
+			body:       `{"error":{"message":"Upstream returned 403 for this request. This is an upstream access/policy rejection unrelated to request size."}}`,
+			want:       openAIInputTokensFallbackAnthropicEstimate,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyOpenAIInputTokensFallback(tt.account, tt.statusCode, []byte(tt.body))
+			require.Equal(t, tt.want, got.Kind)
+		})
+	}
+}
+
+func TestShouldEstimateOpenAIInputTokensForAuthError(t *testing.T) {
+	require.True(t, shouldEstimateOpenAIInputTokensForAuthError(
+		&Account{Type: AccountTypeAPIKey, Platform: PlatformNewAPI},
+		fmt.Errorf("api_key not found"),
+	))
+	require.True(t, shouldEstimateOpenAIInputTokensForAuthError(
+		&Account{Type: AccountTypeServiceAccount, Platform: PlatformNewAPI, ChannelType: newapiconstant.ChannelTypeVertexAi},
+		fmt.Errorf("invalid private key"),
+	))
+	require.False(t, shouldEstimateOpenAIInputTokensForAuthError(
+		&Account{Type: AccountTypeOAuth, Platform: PlatformOpenAI},
+		fmt.Errorf("unauthorized"),
+	))
+}


### PR DESCRIPTION
## 摘要
- 将 OpenAI `count_tokens` 的 fallback 判定从 `openai_gateway_count_tokens.go` 抽到 `openai_gateway_count_tokens_fallback.go`，让主转发函数只保留编排逻辑。
- 保留现有行为：OAuth `input_tokens` unsupported/missing-scope 继续走 tiktoken 本地估算；OpenAI/NewAPI/Grok capability gap 继续走 Anthropic 形状本地估算。
- 新增 focused unit test 锁定 fallback 分类与 NewAPI auth error 降级判定。

## 风险
- 低风险内部重构，不改变 API/WebUI/配置/数据库行为。
- no-web-impact
- upstream-touch-trivial：本 PR 触碰 upstream-shaped `openai_gateway_count_tokens.go`，但只把刚合并后的 fallback 判定搬到 companion owner；没有引入新协议行为或删除 upstream 能力。

## 验证
- `go -C backend test -tags=unit ./internal/service -run 'TestClassifyOpenAIInputTokensFallback|TestShouldEstimateOpenAIInputTokensForAuthError|TestOpenAIGatewayService_ForwardCountTokensAsAnthropic|TestOpenAIGatewayService_OpenAIOAuthInputTokensFallbackUsesMinimumWhenEstimateFails|TestEstimateOpenAIInputTokens|TestOpenAIInputTokensEncodingForModel' -count=1`
- `golangci-lint run --concurrency=4 --timeout=30m ./internal/service`
- `git diff --check`
- `./scripts/preflight.sh`

## 提交
- `05ba895a8 chore(openai): isolate count tokens fallback owner`
- 最新提交：`05ba895a8`
