### PR TITLE
fix(docs): approve upstream merge anchor

### DIFF
--- a/docs/approved/upstream-merge-2026-07-02.md
+++ b/docs/approved/upstream-merge-2026-07-02.md
@@ -1,12 +1,13 @@
 ---
 title: Upstream Merge 2026-07-02 High-Risk Anchor
-status: pending
-approved_by: pending
+status: approved
+approved_by: xuejiao (PR #1154 merge)
+approved_at: 2026-07-02
 created: 2026-07-02
 authors: [agent]
 risk: high
-related_prs: []
-related_commits: []
+related_prs: [1154]
+related_commits: [39c769ee2dade9b41f9c3f64051909a131cdd8db]
 ---
 
 # Upstream Merge 2026-07-02 High-Risk Anchor


### PR DESCRIPTION
## 摘要
- 将 #1154 的高风险 upstream merge 审批锚点从 pending 更新为 approved。
- 绑定已合并的 #1154 merge commit `39c769ee2dade9b41f9c3f64051909a131cdd8db`，恢复 main 分支 R5 preflight 门禁。

## 风险
- 文档 / 审批锚点修复，不改代码、API、WebUI、数据库或部署逻辑。
- no-web-impact

## 验证
- `./scripts/preflight.sh`
- `git diff --check`

## 提交
- `c9498ce60 fix(docs): approve upstream merge anchor`