### PR TITLE
fix(gateway): 错组/错模型请求归类为客户端 400，不再污染 SLA 分子

### DIFF
--- a/backend/internal/handler/no_available_accounts_tk_test.go
+++ b/backend/internal/handler/no_available_accounts_tk_test.go
@@ -38,15 +38,15 @@ func TestTkSelectFailureStatusMessage(t *testing.T) {
 		assert.Contains(t, msg, "No available accounts")
 	})
 
-	t.Run("wrapped_no_available_accounts_returns_429", func(t *testing.T) {
+	t.Run("channel_pricing_restriction_returns_400", func(t *testing.T) {
 		c, w := newCtx(t)
-		wrapped := fmt.Errorf("%w supporting model: gpt-5.2 (channel pricing restriction)", service.ErrNoAvailableAccounts)
+		wrapped := fmt.Errorf("%w: gpt-5.2 (channel pricing restriction)", service.ErrUnsupportedModel)
 		status, errType, msg := tkSelectFailureStatusMessage(c, wrapped, "gpt-5.2")
 
-		require.Equal(t, http.StatusTooManyRequests, status)
-		assert.Equal(t, "api_error", errType)
-		assert.Equal(t, tkNoAvailableAccountsRetryAfterSeconds, w.Header().Get("Retry-After"))
-		assert.Contains(t, msg, "gpt-5.2")
+		require.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, service.TkUnsupportedModelErrType, errType)
+		assert.Equal(t, service.TkUnsupportedModelMessage("gpt-5.2"), msg)
+		assert.Empty(t, w.Header().Get("Retry-After"))
 	})
 
 	t.Run("unsupported_model_returns_400_invalid_request", func(t *testing.T) {

--- a/backend/internal/handler/ops_error_logger_test.go
+++ b/backend/internal/handler/ops_error_logger_test.go
@@ -788,7 +788,6 @@ func TestClassifyOpsUnsupportedModelExcludedFromSLA(t *testing.T) {
 		"No available accounts: no available accounts supporting model: made-up-model",
 		"No available accounts: no available OpenAI accounts supporting model: made-up-model",
 		"No available Gemini accounts: no available Gemini accounts supporting model: made-up-model",
-		"No available accounts: no available accounts supporting model: made-up-model (channel pricing restriction)",
 	}
 
 	for _, message := range tests {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1695,7 +1695,7 @@ func (s *GatewayService) SelectAccountForModelWithExclusions(ctx context.Context
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, tkOpenAICompatChannelPricingRestrictionError(requestedModel)
 	}
 
 	// anthropic/gemini 分组支持混合调度（包含启用了 mixed_scheduling 的 antigravity 账户）
@@ -1747,7 +1747,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, tkOpenAICompatChannelPricingRestrictionError(requestedModel)
 	}
 
 	var stickyAccountID int64

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -282,7 +282,7 @@ func (s *defaultOpenAIAccountScheduler) Select(
 	// 前置拒绝。两个调度入口语义漂移会让运营在排查时彻底失去对账号选择
 	// 行为的预期。
 	if s != nil && s.service != nil && s.service.checkChannelPricingRestriction(ctx, req.GroupID, req.RequestedModel) {
-		return nil, decision, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, req.RequestedModel)
+		return nil, decision, tkOpenAICompatChannelPricingRestrictionError(req.RequestedModel)
 	}
 
 	previousResponseID := strings.TrimSpace(req.PreviousResponseID)
@@ -1112,7 +1112,12 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 		// TK: when the schedulable pool was emptied PURELY because no account serves
 		// the requested model name, surface ErrUnsupportedModel (→ HTTP 400) instead
 		// of an empty-pool 429. See openAICompatNoCandidateError (TK companion).
-		return nil, 0, 0, 0, openAICompatNoCandidateError(req.RequestedModel, req.GroupPlatform, false, accounts, req.ExcludedIDs)
+		return nil, 0, 0, 0, openAICompatNoCandidateError(req.RequestedModel, req.GroupPlatform, false, accounts, req.ExcludedIDs, &openAICompatNoCandidateEval{
+			ctx:            ctx,
+			svc:            s.service,
+			groupID:        req.GroupID,
+			requireCompact: req.RequireCompact,
+		})
 	}
 
 	loadMap := map[int64]*AccountLoadInfo{}
@@ -1513,7 +1518,7 @@ func (s *OpenAIGatewayService) selectAccountWithScheduler(
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, decision, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, decision, tkOpenAICompatChannelPricingRestrictionError(requestedModel)
 	}
 
 	var stickyAccountID int64

--- a/backend/internal/service/openai_account_scheduler_tk_channel_restriction_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_channel_restriction_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -67,6 +68,7 @@ func TestP01_Scheduler_ChannelPricingRestriction_Blocks(t *testing.T) {
 
 	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-restricted", nil, OpenAIUpstreamTransportAny, false)
 	require.Error(t, err, "P0-1: scheduler must block requests for models outside channel pricing whitelist")
+	require.True(t, errors.Is(err, ErrUnsupportedModel), "channel pricing restriction is a client model error, got %v", err)
 	require.True(t, selection == nil || selection.Account == nil, "no account may be selected when model is restricted")
 	require.Contains(t, strings.ToLower(err.Error()), "channel pricing restriction",
 		"error must clearly indicate the restriction reason for operator triage")

--- a/backend/internal/service/openai_account_scheduler_tk_errors.go
+++ b/backend/internal/service/openai_account_scheduler_tk_errors.go
@@ -56,11 +56,10 @@ func openAICompatErrorPlatformLabel(groupPlatform string) string {
 // When nil, collectOpenAICompatSelectionFailureStats falls back to account-level
 // model_mapping only (legacy unit tests).
 type openAICompatNoCandidateEval struct {
-	ctx                context.Context
-	svc                *OpenAIGatewayService
-	groupID            *int64
-	requireCompact     bool
-	requiredCapability OpenAIEndpointCapability
+	ctx            context.Context
+	svc            *OpenAIGatewayService
+	groupID        *int64
+	requireCompact bool
 }
 
 // tkOpenAICompatChannelPricingRestrictionError reports that the requested model is

--- a/backend/internal/service/openai_account_scheduler_tk_errors.go
+++ b/backend/internal/service/openai_account_scheduler_tk_errors.go
@@ -1,6 +1,10 @@
 package service
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"strings"
+)
 
 // openAICompatErrorPlatformLabel returns the platform identifier to embed in
 // "no available accounts" error messages produced by the OpenAI-compat
@@ -46,9 +50,45 @@ func openAICompatErrorPlatformLabel(groupPlatform string) string {
 // openai/newapi pools with the anthropic 400 behavior. The len(accounts)==0 branch
 // (no schedulable account seen at all → no model evidence) and the post-load-balance
 // "couldn't acquire a slot" branches stay 429: those are genuine capacity gaps.
-func openAICompatNoCandidateError(requestedModel, groupPlatform string, compactBlocked bool, accounts []Account, excludedIDs map[int64]struct{}) error {
+//
+// openAICompatNoCandidateEval carries scheduler context needed to classify a
+// pool-emptied failure as "model unservable in this group" vs transient capacity.
+// When nil, collectOpenAICompatSelectionFailureStats falls back to account-level
+// model_mapping only (legacy unit tests).
+type openAICompatNoCandidateEval struct {
+	ctx                context.Context
+	svc                *OpenAIGatewayService
+	groupID            *int64
+	requireCompact     bool
+	requiredCapability OpenAIEndpointCapability
+}
+
+// tkOpenAICompatChannelPricingRestrictionError reports that the requested model is
+// outside the group's channel servable/pricing allowlist. Caller fault → HTTP 400
+// (ErrUnsupportedModel), not an empty-pool 429 that pollutes SLA / capacity alerts.
+func tkOpenAICompatChannelPricingRestrictionError(requestedModel string) error {
+	requestedModel = strings.TrimSpace(requestedModel)
+	if requestedModel == "" {
+		return fmt.Errorf("%w (channel pricing restriction)", ErrUnsupportedModel)
+	}
+	return fmt.Errorf("%w: %s (channel pricing restriction)", ErrUnsupportedModel, requestedModel)
+}
+
+func openAICompatNoCandidateError(requestedModel, groupPlatform string, compactBlocked bool, accounts []Account, excludedIDs map[int64]struct{}, eval *openAICompatNoCandidateEval) error {
 	if requestedModel != "" {
-		stats := collectOpenAICompatSelectionFailureStats(accounts, requestedModel, excludedIDs)
+		var stats selectionFailureStats
+		if eval != nil && eval.svc != nil && eval.ctx != nil {
+			stats = eval.svc.collectOpenAICompatSelectionFailureStatsForRequest(
+				eval.ctx,
+				eval.groupID,
+				requestedModel,
+				eval.requireCompact,
+				accounts,
+				excludedIDs,
+			)
+		} else {
+			stats = collectOpenAICompatSelectionFailureStats(accounts, requestedModel, excludedIDs)
+		}
 		if tkSelectionFailedDueToUnsupportedModel(stats) {
 			return fmt.Errorf("%w: %s (%s)", ErrUnsupportedModel, requestedModel, summarizeSelectionFailureStats(stats))
 		}
@@ -60,32 +100,15 @@ func openAICompatNoCandidateError(requestedModel, groupPlatform string, compactB
 }
 
 // collectOpenAICompatSelectionFailureStats categorizes each schedulable account
-// that survived to the candidate filter into the shared selectionFailureStats so
-// tkSelectionFailedDueToUnsupportedModel can decide "purely unsupported model" vs
-// "transient capacity". It deliberately only distinguishes the model-support axis
-// (Account.IsModelSupported — the same check isAccountRequestCompatible applies):
-//
-//   - account does NOT support the model name  → ModelUnsupported (evidence the
-//     name is unserved);
-//   - account supports the model but was excluded or filtered for any other
-//     reason (runtime block, capability, transport, upstream restriction) →
-//     Unschedulable, which SUPPRESSES the 400: the model IS served, just not
-//     selectable right now, so the client should get the 429 capacity hint, not a
-//     misleading "Unsupported model".
-//
-// Eligible is 0 by construction here (any fully-eligible account would be in
-// `filtered`); ModelRateLimited is not tracked on this path (account-level rate
-// limits are filtered out of the schedulable list upstream). The net predicate
-// therefore fires only when at least one account is model-unsupported AND none
-// supports the model.
+// in the group's pool using account-level model_mapping only. Prefer
+// collectOpenAICompatSelectionFailureStatsForRequest when channel upstream
+// restrictions apply.
 func collectOpenAICompatSelectionFailureStats(accounts []Account, requestedModel string, excludedIDs map[int64]struct{}) selectionFailureStats {
 	stats := selectionFailureStats{Total: len(accounts)}
 	for i := range accounts {
 		acc := &accounts[i]
 		if excludedIDs != nil {
 			if _, excluded := excludedIDs[acc.ID]; excluded {
-				// A previously-attempted account may well serve the model; never
-				// let an excluded account contribute "unsupported" evidence.
 				stats.Unschedulable++
 				continue
 			}
@@ -98,4 +121,59 @@ func collectOpenAICompatSelectionFailureStats(accounts []Account, requestedModel
 		stats.Unschedulable++
 	}
 	return stats
+}
+
+// collectOpenAICompatSelectionFailureStatsForRequest mirrors the scheduler's
+// model-servability axis: account model_mapping AND per-account upstream channel
+// restrictions (BillingModelSourceUpstream). Prod 2026-07: a Qwen-group direct
+// key hammering gpt-5.4-mini produced routing/platform 429s because passthrough
+// accounts reported IsModelSupported=true while channel upstream pricing excluded
+// the upstream model — those accounts must count as model_unsupported (client
+// fault), not unschedulable capacity.
+func (s *OpenAIGatewayService) collectOpenAICompatSelectionFailureStatsForRequest(
+	ctx context.Context,
+	groupID *int64,
+	requestedModel string,
+	requireCompact bool,
+	accounts []Account,
+	excludedIDs map[int64]struct{},
+) selectionFailureStats {
+	stats := selectionFailureStats{Total: len(accounts)}
+	needsUpstreamCheck := s != nil && s.needsUpstreamChannelRestrictionCheck(ctx, groupID)
+	for i := range accounts {
+		acc := &accounts[i]
+		if excludedIDs != nil {
+			if _, excluded := excludedIDs[acc.ID]; excluded {
+				stats.Unschedulable++
+				continue
+			}
+		}
+		if requestedModel != "" && s.isOpenAICompatModelUnservableForRequest(ctx, groupID, acc, requestedModel, requireCompact, needsUpstreamCheck) {
+			stats.ModelUnsupported++
+			stats.SampleMappingIDs = appendSelectionFailureSampleID(stats.SampleMappingIDs, acc.ID)
+			continue
+		}
+		stats.Unschedulable++
+	}
+	return stats
+}
+
+func (s *OpenAIGatewayService) isOpenAICompatModelUnservableForRequest(
+	ctx context.Context,
+	groupID *int64,
+	account *Account,
+	requestedModel string,
+	requireCompact bool,
+	needsUpstreamCheck bool,
+) bool {
+	if account == nil || strings.TrimSpace(requestedModel) == "" {
+		return false
+	}
+	if !account.IsModelSupported(requestedModel) {
+		return true
+	}
+	if needsUpstreamCheck && groupID != nil && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, account, requestedModel, requireCompact) {
+		return true
+	}
+	return false
 }

--- a/backend/internal/service/openai_account_scheduler_tk_errors_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_errors_test.go
@@ -3,6 +3,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestOpenAICompatNoCandidateError(t *testing.T) {
 			newapiAcctWithMapping(39, "deepseek-v4-pro", "deepseek-v4-flash"),
 		}
 
-		err := openAICompatNoCandidateError("deepseek-chat", PlatformNewAPI, false, accounts, nil)
+		err := openAICompatNoCandidateError("deepseek-chat", PlatformNewAPI, false, accounts, nil, nil)
 
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrUnsupportedModel), "expected ErrUnsupportedModel, got %v", err)
@@ -56,7 +57,7 @@ func TestOpenAICompatNoCandidateError(t *testing.T) {
 			newapiAcctWithMapping(40, "deepseek-chat"),
 		}
 
-		err := openAICompatNoCandidateError("deepseek-chat", PlatformNewAPI, false, accounts, nil)
+		err := openAICompatNoCandidateError("deepseek-chat", PlatformNewAPI, false, accounts, nil, nil)
 
 		require.Error(t, err)
 		assert.False(t, errors.Is(err, ErrUnsupportedModel))
@@ -71,7 +72,7 @@ func TestOpenAICompatNoCandidateError(t *testing.T) {
 			newapiAcctWithMapping(39, "deepseek-chat"),
 		}
 
-		err := openAICompatNoCandidateError("deepseek-chat", PlatformNewAPI, false, accounts, map[int64]struct{}{39: {}})
+		err := openAICompatNoCandidateError("deepseek-chat", PlatformNewAPI, false, accounts, map[int64]struct{}{39: {}}, nil)
 
 		require.Error(t, err)
 		assert.False(t, errors.Is(err, ErrUnsupportedModel))
@@ -80,7 +81,7 @@ func TestOpenAICompatNoCandidateError(t *testing.T) {
 	t.Run("empty_model_never_unsupported", func(t *testing.T) {
 		accounts := []Account{newapiAcctWithMapping(39, "deepseek-v4-pro")}
 
-		err := openAICompatNoCandidateError("", PlatformNewAPI, false, accounts, nil)
+		err := openAICompatNoCandidateError("", PlatformNewAPI, false, accounts, nil, nil)
 
 		require.Error(t, err)
 		assert.False(t, errors.Is(err, ErrUnsupportedModel))
@@ -92,7 +93,7 @@ func TestOpenAICompatNoCandidateError(t *testing.T) {
 		// by the response-path unsupported-model classifier (path B).
 		accounts := []Account{{ID: 9, Platform: PlatformOpenAI}}
 
-		err := openAICompatNoCandidateError("gpt-9-turbo", "", false, accounts, nil)
+		err := openAICompatNoCandidateError("gpt-9-turbo", "", false, accounts, nil, nil)
 
 		require.Error(t, err)
 		assert.False(t, errors.Is(err, ErrUnsupportedModel))
@@ -121,4 +122,93 @@ func TestCollectOpenAICompatSelectionFailureStats(t *testing.T) {
 		assert.Equal(t, 1, stats.Unschedulable)
 		assert.False(t, tkSelectionFailedDueToUnsupportedModel(stats))
 	})
+}
+
+func TestCollectOpenAICompatSelectionFailureStatsForRequest_UpstreamChannelRestriction(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(18001)
+	channel := Channel{
+		ID:                 1,
+		Status:             StatusActive,
+		GroupIDs:           []int64{groupID},
+		RestrictModels:     true,
+		BillingModelSource: BillingModelSourceUpstream,
+		ModelPricing: []ChannelModelPricing{
+			{Platform: PlatformNewAPI, Models: []string{"qwen-max"}},
+		},
+	}
+	svc, _ := newSchedFixtureWithChannel(t, groupID, PlatformNewAPI, []*Account{newAPIAccount(18011, 7)}, channel)
+
+	// Passthrough account: IsModelSupported is true, but upstream channel pricing
+	// excludes gpt-5.4-mini — must classify as model_unsupported (client fault).
+	stats := svc.collectOpenAICompatSelectionFailureStatsForRequest(
+		ctx,
+		&groupID,
+		"gpt-5.4-mini",
+		false,
+		[]Account{*newAPIAccount(18011, 7)},
+		nil,
+	)
+	require.Equal(t, 1, stats.ModelUnsupported)
+	require.Equal(t, 0, stats.Unschedulable)
+	require.True(t, tkSelectionFailedDueToUnsupportedModel(stats))
+}
+
+func TestOpenAICompatNoCandidateError_UpstreamChannelRestrictionReturnsUnsupported(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(18002)
+	channel := Channel{
+		ID:                 1,
+		Status:             StatusActive,
+		GroupIDs:           []int64{groupID},
+		RestrictModels:     true,
+		BillingModelSource: BillingModelSourceUpstream,
+		ModelPricing: []ChannelModelPricing{
+			{Platform: PlatformNewAPI, Models: []string{"qwen-max"}},
+		},
+	}
+	svc, _ := newSchedFixtureWithChannel(t, groupID, PlatformNewAPI, []*Account{newAPIAccount(18021, 7)}, channel)
+
+	err := openAICompatNoCandidateError(
+		"gpt-5.4-mini",
+		PlatformNewAPI,
+		false,
+		[]Account{*newAPIAccount(18021, 7)},
+		nil,
+		&openAICompatNoCandidateEval{ctx: ctx, svc: svc, groupID: &groupID},
+	)
+	require.ErrorIs(t, err, ErrUnsupportedModel)
+	assert.NotContains(t, err.Error(), "no available accounts")
+}
+
+func TestSelectAccountWithScheduler_QwenGroupWrongModelReturnsUnsupported(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(18003)
+	qwenOnly := newapiAcctWithMapping(18031, "qwen-max", "qwen-plus")
+	channel := Channel{
+		ID:                 1,
+		Status:             StatusActive,
+		GroupIDs:           []int64{groupID},
+		RestrictModels:     true,
+		BillingModelSource: BillingModelSourceRequested,
+		ModelPricing: []ChannelModelPricing{
+			{Platform: PlatformNewAPI, Models: []string{"qwen-max", "qwen-plus"}},
+		},
+	}
+	svc, _ := newSchedFixtureWithChannel(t, groupID, PlatformNewAPI, []*Account{&qwenOnly}, channel)
+
+	selection, _, err := svc.SelectAccountWithSchedulerForCapability(
+		ctx,
+		&groupID,
+		"",
+		"",
+		"gpt-5.4-mini",
+		nil,
+		OpenAIUpstreamTransportAny,
+		OpenAIEndpointCapabilityChatCompletions,
+		false,
+	)
+	require.Error(t, err)
+	require.True(t, selection == nil || selection.Account == nil)
+	require.ErrorIs(t, err, ErrUnsupportedModel, "wrong model on Qwen-only group must be client-owned 400, not routing 429")
 }

--- a/backend/internal/service/openai_channel_restriction_test.go
+++ b/backend/internal/service/openai_channel_restriction_test.go
@@ -35,7 +35,7 @@ func TestOpenAISelectAccountForModelWithExclusions_ChannelMappedRestrictionRejec
 
 	groupID := int64(10)
 	_, err := svc.SelectAccountForModelWithExclusions(context.Background(), &groupID, "", "gpt-4.1", nil)
-	require.ErrorIs(t, err, ErrNoAvailableAccounts)
+	require.ErrorIs(t, err, ErrUnsupportedModel)
 	require.Contains(t, err.Error(), "channel pricing restriction")
 }
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1842,7 +1842,7 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, tkOpenAICompatChannelPricingRestrictionError(requestedModel)
 	}
 
 	// TK: resolve scheduling-pool platform once per request and thread it
@@ -1871,7 +1871,12 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 		// PURELY by unservable model name surfaces ErrUnsupportedModel (→ HTTP 400),
 		// not an empty-pool 429 — parity with the selectByLoadBalance path so
 		// count_tokens / sticky callers do not misclassify (prod 2026-06-13).
-		return nil, openAICompatNoCandidateError(requestedModel, groupPlatform, compactBlocked, accounts, excludedIDs)
+		return nil, openAICompatNoCandidateError(requestedModel, groupPlatform, compactBlocked, accounts, excludedIDs, &openAICompatNoCandidateEval{
+			ctx:            ctx,
+			svc:            s,
+			groupID:        groupID,
+			requireCompact: requireCompact,
+		})
 	}
 
 	hydrated, err := s.hydrateSelectedAccount(ctx, selected)
@@ -2122,7 +2127,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, tkOpenAICompatChannelPricingRestrictionError(requestedModel)
 	}
 
 	// TK: resolve scheduling-pool platform once per request and thread it

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2266,25 +2266,53 @@
       "path": "backend/internal/service/openai_account_scheduler_tk_errors.go",
       "must_contain": [
         "func openAICompatNoCandidateError",
+        "tkOpenAICompatChannelPricingRestrictionError",
+        "collectOpenAICompatSelectionFailureStatsForRequest",
+        "isOpenAICompatModelUnservableForRequest",
+        "isUpstreamModelRestrictedByChannel",
         "tkSelectionFailedDueToUnsupportedModel(stats)",
         "ErrUnsupportedModel",
         "func collectOpenAICompatSelectionFailureStats"
       ],
-      "rationale": "openAICompatNoCandidateError is the SHARED single exit for BOTH OpenAI-compat pool-emptied points (prod 2026-06-13): selectByLoadBalance len(filtered)==0 AND selectAccountForModelWithExclusions selectBestAccount→nil. When EVERY schedulable account was rejected purely because it does not serve the requested model NAME, it returns service.ErrUnsupportedModel (→ HTTP 400 invalid_request_error via tkSelectFailureStatusMessage) instead of an empty-pool 429 that reads as a capacity signal and fires ops alerts. collectOpenAICompatSelectionFailureStats counts a model-supporting-but-filtered account as Unschedulable so it SUPPRESSES the 400 (the model is served, just not selectable now → keep 429), mirroring the anthropic tkWrapSelectionFailure predicate. Losing this companion on an upstream merge silently reverts unservable-model requests to the misleading empty-pool 429."
+      "rationale": "openAICompatNoCandidateError is the SHARED single exit for BOTH OpenAI-compat pool-emptied points (prod 2026-06-13): selectByLoadBalance len(filtered)==0 AND selectAccountForModelWithExclusions selectBestAccount→nil. When EVERY schedulable account was rejected purely because it does not serve the requested model NAME (account model_mapping OR per-account upstream channel restriction), it returns service.ErrUnsupportedModel (→ HTTP 400 invalid_request_error via tkSelectFailureStatusMessage) instead of an empty-pool 429 that reads as a capacity signal and fires ops alerts. tkOpenAICompatChannelPricingRestrictionError applies the same client-owned contract to group-level channel pricing allowlist rejects (prod 2026-07: Qwen-group direct key hammering gpt-5.4-mini). collectOpenAICompatSelectionFailureStatsForRequest counts passthrough accounts blocked only by isUpstreamModelRestrictedByChannel as model_unsupported; a model-supporting-but-filtered account stays Unschedulable so it SUPPRESSES the 400 (genuine capacity → keep 429)."
     },
     {
       "path": "backend/internal/service/openai_account_scheduler.go",
       "must_contain": [
-        "openAICompatNoCandidateError(req.RequestedModel, req.GroupPlatform, false, accounts, req.ExcludedIDs)"
+        "tkOpenAICompatChannelPricingRestrictionError(req.RequestedModel)",
+        "openAICompatNoCandidateEval"
       ],
       "rationale": "The candidate-filter-empty branch (len(filtered)==0) in selectByLoadBalance must route through openAICompatNoCandidateError (TK companion) so a pool emptied purely by unservable model NAME surfaces ErrUnsupportedModel→400, not empty-pool 429 (prod 2026-06-13). Reverting this one-line hook to the inline noAvailableOpenAISelectionError/platform-label returns compiles clean but re-buries 'client asked for a model nobody serves' inside the 429 capacity family, re-triggering false ops alerts. Only this branch routes here — the len(accounts)==0 and post-load-balance slot-acquire branches stay 429 (genuine capacity)."
     },
     {
       "path": "backend/internal/service/openai_gateway_service.go",
       "must_contain": [
-        "openAICompatNoCandidateError(requestedModel, groupPlatform, compactBlocked, accounts, excludedIDs)"
+        "tkOpenAICompatChannelPricingRestrictionError(requestedModel)",
+        "openAICompatNoCandidateEval"
       ],
       "rationale": "selectAccountForModelWithExclusions (the priority/LRU path used by count_tokens + sticky/legacy callers) must route its selected==nil exit through the SAME openAICompatNoCandidateError as the load-balance scheduler, so an unservable model NAME surfaces ErrUnsupportedModel→400 on every OpenAI-compat surface, not just /v1/chat/completions (prod 2026-06-13 parity). Reverting to the bare noAvailableOpenAISelectionError compiles clean but re-buries unservable-model as empty-pool 429 on these surfaces and makes the handler's ErrUnsupportedModel→400 mapping dead code there."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "tkOpenAICompatChannelPricingRestrictionError(requestedModel)"
+      ],
+      "rationale": "Anthropic/Gemini SelectAccountWithLoadAwareness entry must classify group channel pricing allowlist rejects as ErrUnsupportedModel (client-owned HTTP 400), not ErrNoAvailableAccounts empty-pool 429, keeping ops SLA/error_owner aligned with the OpenAI-compat scheduler paths."
+    },
+    {
+      "path": "backend/internal/handler/no_available_accounts_tk_test.go",
+      "must_contain": [
+        "channel_pricing_restriction_returns_400"
+      ],
+      "rationale": "Regression guard: channel pricing restriction and pure unsupported-model selection failures must map to HTTP 400 invalid_request_error via tkSelectFailureStatusMessage, not empty-pool 429 + Retry-After."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler_tk_errors_test.go",
+      "must_contain": [
+        "TestSelectAccountWithScheduler_QwenGroupWrongModelReturnsUnsupported",
+        "collectOpenAICompatSelectionFailureStatsForRequest"
+      ],
+      "rationale": "Regression coverage for prod 2026-07 wrong-key/wrong-group model requests: upstream channel restriction on passthrough accounts and Qwen-only groups must surface ErrUnsupportedModel instead of routing/platform 429."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_model_cooldown.go",


### PR DESCRIPTION
## 摘要

- 修复 OpenAI-compat 调度路径把「组内不服务该模型」误判为 `routing/platform` 空池 429 的问题（prod 案例：Qwen 组 direct key 打 `gpt-5.4-mini`）。
- 组级渠道定价拦截（`checkChannelPricingRestriction`）与池空统计中的上游渠道限制（`isUpstreamModelRestrictedByChannel`）统一走 `ErrUnsupportedModel` → HTTP 400 + `error_owner=client`。
- passthrough 账号在 `IsModelSupported=true` 但被渠道 upstream 定价排除时，现计入 `model_unsupported`，不再被当成瞬时空池。

## 风险

- 行为变更：原先返回 429 + Retry-After 的部分「模型不在本组可服务范围」请求将变为 400 `invalid_request_error`；客户端不应再对这类错误做容量退避重试。
- 真容量空池（组内有人能服务该模型、只是当下全不可用）仍保持 429 + `error_owner=platform`，不受影响。

## 验证

- `./scripts/preflight.sh` PASS（含 gateway-tk sentinel 更新）
- `go test -tags=unit ./internal/service -run 'TestOpenAICompatNoCandidateError|TestCollectOpenAICompat|TestP01_Scheduler_Channel|TestSelectAccountWithScheduler_Qwen'`
- `go test -tags=unit ./internal/handler -run 'TestTkSelectFailureStatusMessage'`

## 提交

- `67d10da3f` fix(gateway): classify wrong-group model requests as client-owned 400

最新提交：67d10da3f
