### PR TITLE
feat(gateway): 组级不可服务模型 60s 负缓存

### DIFF
--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -160,6 +160,9 @@ func provideCleanup(
 	// resolver silently falls back to platform-level routing. See
 	// docs/approved/universal-key-routing.md.
 	_ service.TKUniversalModelsProviderReady,
+	// TokenKey: forces wire to evaluate ProvideTKGroupUnsupportedModelCache so
+	// the shared selection-time unsupported-model negative cache is wired at startup.
+	_ service.TKGroupUnsupportedModelCacheReady,
 ) func() {
 	return func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -330,7 +330,8 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	modelListFilter := service.NewModelListFilter(pricingCatalogService, pricingAvailabilityService)
 	tkGatewayHandlerModelListReady := handler.ProvideTKGatewayHandlerModelList(gatewayHandler, modelListFilter)
 	tkUniversalModelsProviderReady := service.ProvideTKUniversalModelsProvider(apiKeyService, gatewayService)
-	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, antigravityConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, holdReconcilerService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, grokOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkPricingOverlayRuntimeReady, tkGatewayAnthropicSigPreemptReady, tkAnthropicSaturationReady, tkGatewayHandlerModelListReady, tkUniversalModelsProviderReady)
+	tkGroupUnsupportedModelCacheReady := service.ProvideTKGroupUnsupportedModelCache(gatewayService, openAIGatewayService, channelService)
+	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, antigravityConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, holdReconcilerService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, grokOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkPricingOverlayRuntimeReady, tkGatewayAnthropicSigPreemptReady, tkAnthropicSaturationReady, tkGatewayHandlerModelListReady, tkUniversalModelsProviderReady, tkGroupUnsupportedModelCacheReady)
 	application := &Application{
 		Server:  httpServer,
 		Cleanup: v,
@@ -415,6 +416,8 @@ func provideCleanup(
 	_ handler.TKGatewayHandlerModelListReady,
 
 	_ service.TKUniversalModelsProviderReady,
+
+	_ service.TKGroupUnsupportedModelCacheReady,
 ) func() {
 	return func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/backend/cmd/server/wire_gen_test.go
+++ b/backend/cmd/server/wire_gen_test.go
@@ -99,6 +99,7 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 		service.TKAnthropicSaturationReady{},        // TK: forces SetAnthropicSaturationCounter wiring
 		handler.TKGatewayHandlerModelListReady{},    // TK: forces SetModelListFilter wiring
 		service.TKUniversalModelsProviderReady{},    // TK: forces universal-key models-provider wiring
+		service.TKGroupUnsupportedModelCacheReady{}, // TK: forces group unsupported negative cache wiring
 	)
 
 	require.NotPanics(t, func() {

--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -147,6 +147,9 @@ type ChannelService struct {
 
 	cache   atomic.Value // *channelCache
 	cacheSF singleflight.Group
+
+	// TK: flush group×model unsupported negative cache when channel config changes.
+	groupUnsupportedModelCacheFlush func()
 }
 
 // NewChannelService 创建渠道服务实例。
@@ -347,10 +350,23 @@ func (s *ChannelService) invalidateCache() {
 	s.cache.Store((*channelCache)(nil))
 	s.cacheSF.Forget("channel_cache")
 
+	if s.groupUnsupportedModelCacheFlush != nil {
+		s.groupUnsupportedModelCacheFlush()
+	}
+
 	// 主动重建缓存，确保 CRUD 后立即生效
 	if _, err := s.buildCache(context.Background()); err != nil {
 		slog.Warn("failed to rebuild channel cache after invalidation", "error", err)
 	}
+}
+
+// SetGroupUnsupportedModelCacheFlusher registers a callback to flush the
+// selection-time unsupported-model negative cache when channel config changes.
+func (s *ChannelService) SetGroupUnsupportedModelCacheFlusher(fn func()) {
+	if s == nil {
+		return
+	}
+	s.groupUnsupportedModelCacheFlush = fn
 }
 
 // matchWildcard 在通配符定价中查找匹配项（最先匹配到优先）

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -718,6 +718,9 @@ type GatewayService struct {
 	// model name the upstream already confirmed not-found so we stop re-forwarding
 	// it. Always on, in-memory, 60s TTL. See gateway_service_tk_model_notfound_cache.go.
 	tkModelNotFoundCache *tkModelNotFoundNegativeCache
+	// TK: per-replica group×model negative cache for selection-time
+	// ErrUnsupportedModel verdicts. See gateway_service_tk_group_unsupported_cache.go.
+	tkGroupUnsupportedCache *tkGroupUnsupportedModelNegativeCache
 }
 
 // NewGatewayService creates a new GatewayService
@@ -1691,11 +1694,14 @@ func (s *GatewayService) SelectAccountForModelWithExclusions(ctx context.Context
 
 	// Claude Code 限制可能已将 groupID 解析为 fallback group，
 	// 渠道限制预检查必须使用解析后的分组。
+	if err := s.tkGroupUnsupportedModelShortCircuit(groupID, requestedModel); err != nil {
+		return nil, err
+	}
 	if s.checkChannelPricingRestriction(ctx, groupID, requestedModel) {
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, tkOpenAICompatChannelPricingRestrictionError(requestedModel)
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkOpenAICompatChannelPricingRestrictionError(requestedModel))
 	}
 
 	// anthropic/gemini 分组支持混合调度（包含启用了 mixed_scheduling 的 antigravity 账户）
@@ -1741,13 +1747,17 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 	}
 	ctx = s.withGroupContext(ctx, group)
 
+	if err := s.tkGroupUnsupportedModelShortCircuit(groupID, requestedModel); err != nil {
+		return nil, err
+	}
+
 	// Claude Code 限制可能已将 groupID 解析为 fallback group，
 	// 渠道限制预检查必须使用解析后的分组。
 	if s.checkChannelPricingRestriction(ctx, groupID, requestedModel) {
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, tkOpenAICompatChannelPricingRestrictionError(requestedModel)
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkOpenAICompatChannelPricingRestrictionError(requestedModel))
 	}
 
 	var stickyAccountID int64
@@ -3510,7 +3520,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 
 	if selected == nil {
 		stats := s.logDetailedSelectionFailure(ctx, groupID, sessionHash, requestedModel, platform, accounts, excludedIDs, false)
-		return nil, tkWrapSelectionFailure(requestedModel, stats)
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(requestedModel, stats))
 	}
 
 	// 4. 建立粘性绑定
@@ -3782,7 +3792,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 
 	if selected == nil {
 		stats := s.logDetailedSelectionFailure(ctx, groupID, sessionHash, requestedModel, nativePlatform, accounts, excludedIDs, true)
-		return nil, tkWrapSelectionFailure(requestedModel, stats)
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(requestedModel, stats))
 	}
 
 	// 4. 建立粘性绑定

--- a/backend/internal/service/gateway_service_tk_group_unsupported_cache.go
+++ b/backend/internal/service/gateway_service_tk_group_unsupported_cache.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+)
+
+// TK: per-replica negative cache for deterministic "this model is not servable in
+// this group" verdicts (ErrUnsupportedModel at account selection). Short-circuits
+// repeated hammering through listSchedulable / load-balance without touching upstream.
+// Complements tkModelNotFoundNegativeCache (Anthropic upstream 404 after Forward).
+// See docs/spec-delta-group-unsupported-model-negative-cache.md.
+
+const (
+	tkGroupUnsupportedModelNegativeCacheTTL     = 60 * time.Second
+	tkGroupUnsupportedModelNegativeCacheCleanup = time.Minute
+)
+
+type tkGroupUnsupportedModelNegativeCache struct {
+	c *gocache.Cache
+}
+
+func newTkGroupUnsupportedModelNegativeCache() *tkGroupUnsupportedModelNegativeCache {
+	return newTkGroupUnsupportedModelNegativeCacheWithTTL(tkGroupUnsupportedModelNegativeCacheTTL, tkGroupUnsupportedModelNegativeCacheCleanup)
+}
+
+func newTkGroupUnsupportedModelNegativeCacheWithTTL(ttl, cleanup time.Duration) *tkGroupUnsupportedModelNegativeCache {
+	return &tkGroupUnsupportedModelNegativeCache{c: gocache.New(ttl, cleanup)}
+}
+
+func tkGroupUnsupportedModelCacheKey(groupID int64, model string) string {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" || groupID <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d\x00%s", groupID, model)
+}
+
+func (cstore *tkGroupUnsupportedModelNegativeCache) get(groupID int64, model string) bool {
+	if cstore == nil || cstore.c == nil {
+		return false
+	}
+	key := tkGroupUnsupportedModelCacheKey(groupID, model)
+	if key == "" {
+		return false
+	}
+	_, ok := cstore.c.Get(key)
+	return ok
+}
+
+func (cstore *tkGroupUnsupportedModelNegativeCache) put(groupID int64, model string) {
+	if cstore == nil || cstore.c == nil {
+		return
+	}
+	key := tkGroupUnsupportedModelCacheKey(groupID, model)
+	if key == "" {
+		return
+	}
+	cstore.c.Set(key, struct{}{}, gocache.DefaultExpiration)
+	slog.Info("tk_group_unsupported_negative_cache_populate",
+		"group_id", groupID,
+		"model", strings.ToLower(strings.TrimSpace(model)),
+		"ttl", tkGroupUnsupportedModelNegativeCacheTTL.String())
+}
+
+func (cstore *tkGroupUnsupportedModelNegativeCache) flush() {
+	if cstore == nil || cstore.c == nil {
+		return
+	}
+	cstore.c.Flush()
+}
+
+// registerTkGroupUnsupportedModelCacheFlusher wires cache.flush to
+// ChannelService.SetGroupUnsupportedModelCacheFlusher so channel CRUD
+// invalidateCache drops stale group×model verdicts.
+func registerTkGroupUnsupportedModelCacheFlusher(ch *ChannelService, cache *tkGroupUnsupportedModelNegativeCache) {
+	if ch == nil || cache == nil {
+		return
+	}
+	ch.SetGroupUnsupportedModelCacheFlusher(cache.flush)
+}
+
+func tkGroupUnsupportedModelShortCircuit(cache *tkGroupUnsupportedModelNegativeCache, groupID *int64, model string) error {
+	if cache == nil || groupID == nil || *groupID <= 0 {
+		return nil
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return nil
+	}
+	if !cache.get(*groupID, model) {
+		return nil
+	}
+	slog.Info("tk_group_unsupported_negative_cache_hit",
+		"group_id", *groupID,
+		"model", strings.ToLower(model))
+	return fmt.Errorf("%w: %s (negative-cache)", ErrUnsupportedModel, model)
+}
+
+func tkGroupUnsupportedModelRecordErr(cache *tkGroupUnsupportedModelNegativeCache, groupID *int64, model string, err error) error {
+	if err == nil || cache == nil || groupID == nil || *groupID <= 0 {
+		return err
+	}
+	if !errors.Is(err, ErrUnsupportedModel) {
+		return err
+	}
+	cache.put(*groupID, model)
+	return err
+}
+
+func (s *GatewayService) SetTkGroupUnsupportedModelCache(cache *tkGroupUnsupportedModelNegativeCache) {
+	if s == nil {
+		return
+	}
+	s.tkGroupUnsupportedCache = cache
+}
+
+func (s *GatewayService) tkGroupUnsupportedModelShortCircuit(groupID *int64, model string) error {
+	return tkGroupUnsupportedModelShortCircuit(s.tkGroupUnsupportedCache, groupID, model)
+}
+
+func (s *GatewayService) tkGroupUnsupportedModelRecordErr(groupID *int64, model string, err error) error {
+	return tkGroupUnsupportedModelRecordErr(s.tkGroupUnsupportedCache, groupID, model, err)
+}
+
+func (s *OpenAIGatewayService) SetTkGroupUnsupportedModelCache(cache *tkGroupUnsupportedModelNegativeCache) {
+	if s == nil {
+		return
+	}
+	s.tkGroupUnsupportedCache = cache
+}
+
+func (s *OpenAIGatewayService) tkGroupUnsupportedModelShortCircuit(groupID *int64, model string) error {
+	return tkGroupUnsupportedModelShortCircuit(s.tkGroupUnsupportedCache, groupID, model)
+}
+
+func (s *OpenAIGatewayService) tkGroupUnsupportedModelRecordErr(groupID *int64, model string, err error) error {
+	return tkGroupUnsupportedModelRecordErr(s.tkGroupUnsupportedCache, groupID, model, err)
+}

--- a/backend/internal/service/gateway_service_tk_group_unsupported_cache_test.go
+++ b/backend/internal/service/gateway_service_tk_group_unsupported_cache_test.go
@@ -1,0 +1,105 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkGroupUnsupportedModelCacheKey_NormalizesModel(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "18\x00gpt-5.4-mini", tkGroupUnsupportedModelCacheKey(18, " GPT-5.4-Mini "))
+	require.Equal(t, "", tkGroupUnsupportedModelCacheKey(18, "   "))
+	require.Equal(t, "", tkGroupUnsupportedModelCacheKey(0, "gpt-4"))
+}
+
+func TestTkGroupUnsupportedModelShortCircuit_Hit(t *testing.T) {
+	t.Parallel()
+	cache := newTkGroupUnsupportedModelNegativeCache()
+	groupID := int64(18)
+	cache.put(groupID, "gpt-5.4-mini")
+
+	err := tkGroupUnsupportedModelShortCircuit(cache, &groupID, "gpt-5.4-mini")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrUnsupportedModel)
+}
+
+func TestTkGroupUnsupportedModelShortCircuit_Miss(t *testing.T) {
+	t.Parallel()
+	cache := newTkGroupUnsupportedModelNegativeCache()
+	groupID := int64(18)
+
+	err := tkGroupUnsupportedModelShortCircuit(cache, &groupID, "gpt-5.4-mini")
+	require.NoError(t, err)
+}
+
+func TestTkGroupUnsupportedModelShortCircuit_Expires(t *testing.T) {
+	cache := newTkGroupUnsupportedModelNegativeCacheWithTTL(20*time.Millisecond, 10*time.Millisecond)
+	groupID := int64(18)
+	cache.put(groupID, "gpt-5.4-mini")
+
+	require.Error(t, tkGroupUnsupportedModelShortCircuit(cache, &groupID, "gpt-5.4-mini"))
+	time.Sleep(30 * time.Millisecond)
+	require.NoError(t, tkGroupUnsupportedModelShortCircuit(cache, &groupID, "gpt-5.4-mini"))
+}
+
+func TestTkGroupUnsupportedModelRecordErr_OnlyUnsupported(t *testing.T) {
+	t.Parallel()
+	cache := newTkGroupUnsupportedModelNegativeCache()
+	groupID := int64(18)
+
+	_ = tkGroupUnsupportedModelRecordErr(cache, &groupID, "gpt-5.4-mini", ErrNoAvailableAccounts)
+	require.False(t, cache.get(groupID, "gpt-5.4-mini"))
+
+	err := tkGroupUnsupportedModelRecordErr(cache, &groupID, "gpt-5.4-mini",
+		errors.Join(ErrUnsupportedModel, errors.New("channel pricing restriction")))
+	require.ErrorIs(t, err, ErrUnsupportedModel)
+	require.True(t, cache.get(groupID, "gpt-5.4-mini"))
+}
+
+func TestSelectAccountWithScheduler_CacheHitShortCircuits(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(91002)
+	svc, _ := newAPISchedFixture(t, groupID, PlatformNewAPI, []*Account{newAPIAccount(91102, 7)})
+	cache := newTkGroupUnsupportedModelNegativeCache()
+	cache.put(groupID, "gpt-5.4-mini")
+	svc.SetTkGroupUnsupportedModelCache(cache)
+
+	_, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.4-mini", nil, OpenAIUpstreamTransportAny, false)
+	require.ErrorIs(t, err, ErrUnsupportedModel)
+	require.Contains(t, err.Error(), "negative-cache")
+}
+
+func TestChannelInvalidateCache_FlushesGroupUnsupportedCache(t *testing.T) {
+	cache := newTkGroupUnsupportedModelNegativeCache()
+	cache.put(18, "gpt-5.4-mini")
+	repo := &mockChannelRepository{
+		listAllFn: func(_ context.Context) ([]Channel, error) {
+			return nil, nil
+		},
+		getGroupPlatformsFn: func(_ context.Context, _ []int64) (map[int64]string, error) {
+			return map[int64]string{}, nil
+		},
+	}
+	svc := newTestChannelService(repo)
+	svc.SetGroupUnsupportedModelCacheFlusher(cache.flush)
+	svc.invalidateCache()
+	require.False(t, cache.get(18, "gpt-5.4-mini"))
+}
+
+func TestProvideTKGroupUnsupportedModelCache_WiresSharedInstance(t *testing.T) {
+	gw := &GatewayService{}
+	openai := &OpenAIGatewayService{}
+	ch := &ChannelService{}
+	_ = ProvideTKGroupUnsupportedModelCache(gw, openai, ch)
+	require.Same(t, gw.tkGroupUnsupportedCache, openai.tkGroupUnsupportedCache)
+	require.NotNil(t, gw.tkGroupUnsupportedCache)
+
+	gw.tkGroupUnsupportedCache.put(7, "bad-model")
+	require.True(t, openai.tkGroupUnsupportedCache.get(7, "bad-model"))
+}

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -281,8 +281,13 @@ func (s *defaultOpenAIAccountScheduler) Select(
 	// 入口对齐——channel pricing 限制属于 group/channel 治理面，必须在选号
 	// 前置拒绝。两个调度入口语义漂移会让运营在排查时彻底失去对账号选择
 	// 行为的预期。
-	if s != nil && s.service != nil && s.service.checkChannelPricingRestriction(ctx, req.GroupID, req.RequestedModel) {
-		return nil, decision, tkOpenAICompatChannelPricingRestrictionError(req.RequestedModel)
+	if s != nil && s.service != nil {
+		if err := s.service.tkGroupUnsupportedModelShortCircuit(req.GroupID, req.RequestedModel); err != nil {
+			return nil, decision, err
+		}
+		if s.service.checkChannelPricingRestriction(ctx, req.GroupID, req.RequestedModel) {
+			return nil, decision, s.service.tkGroupUnsupportedModelRecordErr(req.GroupID, req.RequestedModel, tkOpenAICompatChannelPricingRestrictionError(req.RequestedModel))
+		}
 	}
 
 	previousResponseID := strings.TrimSpace(req.PreviousResponseID)
@@ -1112,12 +1117,12 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 		// TK: when the schedulable pool was emptied PURELY because no account serves
 		// the requested model name, surface ErrUnsupportedModel (→ HTTP 400) instead
 		// of an empty-pool 429. See openAICompatNoCandidateError (TK companion).
-		return nil, 0, 0, 0, openAICompatNoCandidateError(req.RequestedModel, req.GroupPlatform, false, accounts, req.ExcludedIDs, &openAICompatNoCandidateEval{
+		return nil, 0, 0, 0, s.service.tkGroupUnsupportedModelRecordErr(req.GroupID, req.RequestedModel, openAICompatNoCandidateError(req.RequestedModel, req.GroupPlatform, false, accounts, req.ExcludedIDs, &openAICompatNoCandidateEval{
 			ctx:            ctx,
 			svc:            s.service,
 			groupID:        req.GroupID,
 			requireCompact: req.RequireCompact,
-		})
+		}))
 	}
 
 	loadMap := map[int64]*AccountLoadInfo{}
@@ -1459,6 +1464,9 @@ func (s *OpenAIGatewayService) selectAccountWithScheduler(
 	requireCompact bool,
 ) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
 	decision := OpenAIAccountScheduleDecision{}
+	if err := s.tkGroupUnsupportedModelShortCircuit(groupID, requestedModel); err != nil {
+		return nil, decision, err
+	}
 	scheduler := s.getOpenAIAccountScheduler(ctx)
 	if scheduler == nil {
 		decision.Layer = openAIAccountScheduleLayerLoadBalance
@@ -1518,7 +1526,7 @@ func (s *OpenAIGatewayService) selectAccountWithScheduler(
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, decision, tkOpenAICompatChannelPricingRestrictionError(requestedModel)
+		return nil, decision, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkOpenAICompatChannelPricingRestrictionError(requestedModel))
 	}
 
 	var stickyAccountID int64

--- a/backend/internal/service/openai_account_scheduler_tk_errors.go
+++ b/backend/internal/service/openai_account_scheduler_tk_errors.go
@@ -89,7 +89,11 @@ func openAICompatNoCandidateError(requestedModel, groupPlatform string, compactB
 			stats = collectOpenAICompatSelectionFailureStats(accounts, requestedModel, excludedIDs)
 		}
 		if tkSelectionFailedDueToUnsupportedModel(stats) {
-			return fmt.Errorf("%w: %s (%s)", ErrUnsupportedModel, requestedModel, summarizeSelectionFailureStats(stats))
+			err := fmt.Errorf("%w: %s (%s)", ErrUnsupportedModel, requestedModel, summarizeSelectionFailureStats(stats))
+			if eval != nil && eval.svc != nil && eval.groupID != nil {
+				err = eval.svc.tkGroupUnsupportedModelRecordErr(eval.groupID, requestedModel, err)
+			}
+			return err
 		}
 	}
 	if groupPlatform != "" && groupPlatform != PlatformOpenAI {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -417,6 +417,8 @@ type OpenAIGatewayService struct {
 	// gate (docs/approved/priced-or-it-doesnt-ship.md). Injected via
 	// SetPricingCatalogService (TK companion). nil = gate disabled (fail-open).
 	tkPricingCatalog *PricingCatalogService
+	// TK: shared with GatewayService via ProvideTKGroupUnsupportedModelCache.
+	tkGroupUnsupportedCache *tkGroupUnsupportedModelNegativeCache
 }
 
 // NewOpenAIGatewayService creates a new OpenAIGatewayService
@@ -1838,11 +1840,14 @@ func resolveOpenAIAccountUpstreamModelForRequest(account *Account, requestedMode
 }
 
 func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.Context, groupID *int64, sessionHash string, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool, stickyAccountID int64) (*Account, error) {
+	if err := s.tkGroupUnsupportedModelShortCircuit(groupID, requestedModel); err != nil {
+		return nil, err
+	}
 	if s.checkChannelPricingRestriction(ctx, groupID, requestedModel) {
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, tkOpenAICompatChannelPricingRestrictionError(requestedModel)
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkOpenAICompatChannelPricingRestrictionError(requestedModel))
 	}
 
 	// TK: resolve scheduling-pool platform once per request and thread it
@@ -1871,12 +1876,12 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 		// PURELY by unservable model name surfaces ErrUnsupportedModel (→ HTTP 400),
 		// not an empty-pool 429 — parity with the selectByLoadBalance path so
 		// count_tokens / sticky callers do not misclassify (prod 2026-06-13).
-		return nil, openAICompatNoCandidateError(requestedModel, groupPlatform, compactBlocked, accounts, excludedIDs, &openAICompatNoCandidateEval{
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, openAICompatNoCandidateError(requestedModel, groupPlatform, compactBlocked, accounts, excludedIDs, &openAICompatNoCandidateEval{
 			ctx:            ctx,
 			svc:            s,
 			groupID:        groupID,
 			requireCompact: requireCompact,
-		})
+		}))
 	}
 
 	hydrated, err := s.hydrateSelectedAccount(ctx, selected)
@@ -2123,11 +2128,14 @@ func (s *OpenAIGatewayService) SelectAccountWithLoadAwareness(ctx context.Contex
 }
 
 func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Context, groupID *int64, sessionHash string, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool) (*AccountSelectionResult, error) {
+	if err := s.tkGroupUnsupportedModelShortCircuit(groupID, requestedModel); err != nil {
+		return nil, err
+	}
 	if s.checkChannelPricingRestriction(ctx, groupID, requestedModel) {
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, tkOpenAICompatChannelPricingRestrictionError(requestedModel)
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkOpenAICompatChannelPricingRestrictionError(requestedModel))
 	}
 
 	// TK: resolve scheduling-pool platform once per request and thread it

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -751,6 +751,7 @@ var ProviderSet = wire.NewSet(
 	// resolver (APIKeyService) post-construction so resolution filters candidate
 	// groups by the models they actually serve. Consumed by provideCleanup.
 	ProvideTKUniversalModelsProvider,
+	ProvideTKGroupUnsupportedModelCache,
 	// TokenKey: runtime hot-pushable pricing overlay — wires the settings-blob
 	// getter + catalog-cache invalidator onto PricingService, does the initial
 	// load, and subscribes to the settings pub/sub for immediate reloads. Lets a
@@ -1110,4 +1111,27 @@ func ProvideTKPricingMissingNotifier(
 		geminiCompat.SetPricedServingGateDeps(catalog, billing, setting, n, resolver)
 	}
 	return n
+}
+
+// TKGroupUnsupportedModelCacheReady is a wire sentinel: holding it proves the
+// shared group×model unsupported negative cache is wired onto both gateways and
+// channel invalidation flush.
+type TKGroupUnsupportedModelCacheReady struct{}
+
+// ProvideTKGroupUnsupportedModelCache wires a shared per-replica negative cache
+// onto GatewayService and OpenAIGatewayService and registers channel flush.
+func ProvideTKGroupUnsupportedModelCache(
+	gw *GatewayService,
+	openaiGw *OpenAIGatewayService,
+	ch *ChannelService,
+) TKGroupUnsupportedModelCacheReady {
+	cache := newTkGroupUnsupportedModelNegativeCache()
+	if gw != nil {
+		gw.SetTkGroupUnsupportedModelCache(cache)
+	}
+	if openaiGw != nil {
+		openaiGw.SetTkGroupUnsupportedModelCache(cache)
+	}
+	registerTkGroupUnsupportedModelCacheFlusher(ch, cache)
+	return TKGroupUnsupportedModelCacheReady{}
 }

--- a/docs/spec-delta-group-unsupported-model-negative-cache.md
+++ b/docs/spec-delta-group-unsupported-model-negative-cache.md
@@ -1,0 +1,130 @@
+# spec-delta: 组级不可服务模型负缓存（本地 400 短路）
+
+**Date:** 2026-07-02  
+**Depends on:** #1159（`ErrUnsupportedModel` 调度期归类已合并）  
+**Companion:** `gateway_service_tk_model_notfound_cache.go`（Anthropic 上游 404 负缓存，60s）  
+**Type:** 常规风险 — 网关内部优化；对外 HTTP 契约不变
+
+## Background
+
+prod 2026-07：`api_key_id=172`（Qwen 组 `group_id=18`）持续请求 `gpt-5.4-mini`，在 #1159 之前落库为 routing/platform 429；合并后改为本地 400 + `error_owner=client`，**仍不走上游**。
+
+但每一次请求仍会完整执行账号选择热路径：
+
+- 鉴权 → 列举组内可调度账号 → 渠道定价/映射检查 →（可能）逐账号 upstream 渠道限制扫描 → 池空统计 → 写 400。
+
+客户端 hammer 同一错模型时，浪费的是**网关调度算力**，不是上游配额。Anthropic 已有「上游 404 确认后 60s 负缓存」(`tkModelNotFoundNegativeCache`)，但：
+
+1. 仅 `platform=anthropic`，且在 **Forward 前** 生效（需至少一次真实上游 404 才 populate）。
+2. **不覆盖** OpenAI-compat / newapi 调度期本地 `ErrUnsupportedModel`（#1159 主路径）。
+3. **不覆盖** Anthropic 调度期本地 unsupported（`tkWrapSelectionFailure` 在选号阶段即返回，未进 Forward）。
+
+目标：对「组内确定不可服务该模型名」的判决做**短时负缓存**，重复请求在选号入口直接 400，跳过账号池扫描。
+
+## Delta
+
+### ADDED
+
+**`tkGroupUnsupportedModelNegativeCache`**（命名可微调，语义固定）
+
+| 项 | 约定 |
+|---|---|
+| 存储 | 进程内 `go-cache`（与 `tkModelNotFoundNegativeCache` 同_primitive_） |
+| TTL | **60s**（与 Anthropic 404 负缓存对齐；配置变更靠 TTL + 主动失效兜底） |
+| Key | `group_id` + `\x00` + `lower(trim(requested_model))` |
+| Value | 空 struct（存在即判决）；不区分 channel_pricing vs pool_unsupported（客户端契约相同） |
+| 读（short-circuit） | 选号**之前**，`group_id != nil` 且 `requested_model` 非空 |
+| 写（populate） | 调度器/gateway **首次**因下列原因返回 `ErrUnsupportedModel` 时 |
+| 主动失效 | `channelService.invalidateCache()` 时 **flush 整个**负缓存（渠道定价/映射变更后不允许 stale reject） |
+
+**Populate 触发点（写缓存）** — 仅 `errors.Is(err, ErrUnsupportedModel)` 且为**确定性** client fault：
+
+1. `tkOpenAICompatChannelPricingRestrictionError`（组级 `checkChannelPricingRestriction`）
+2. `openAICompatNoCandidateError` 且 `tkSelectionFailedDueToUnsupportedModel(stats)`（含 upstream 渠道限制导致的 pure unsupported）
+3. `tkWrapSelectionFailure` 且 `tkSelectionFailedDueToUnsupportedModel(stats)`（Anthropic/Gemini 等同路径）
+
+**Short-circuit 挂点（读缓存）** — 单一入口，避免 handler 分叉：
+
+- `OpenAIGatewayService.selectAccountWithScheduler` 入口（在 `checkChannelPricingRestriction` 之前或紧后合并为一次 lookup）
+- `GatewayService.SelectAccountWithLoadAwareness` 入口（Anthropic/Gemini 对齐）
+- 命中时直接返回 `ErrUnsupportedModel`（复用现有 error 链），**不**列举账号、**不**走 load-balance
+
+**Handler / Ops 契约**
+
+- Short-circuit 命中仍走 `tkSelectFailureStatusMessage` / `tkWriteUnsupportedModelIfApplicable` 既有 400 路径。
+- 必须调用 `markOpsClientRequestRejected(c)`（与首次判决一致）。
+- 日志：`tk_group_unsupported_negative_cache_hit` / `_populate`（info，含 `group_id`、`model`、`ttl`）。
+
+**Sentinel**（`scripts/sentinels/gateway-tk.json`）
+
+- 新 companion：`gateway_service_tk_group_unsupported_cache.go`（或扩展现有 `*_tk_errors.go` 若更简洁）
+- 锚点：`tkGroupUnsupportedModelNegativeCache`、`tkGroupUnsupportedModelShortCircuit`、`tkGroupUnsupportedModelRecord`
+- 回归测试文件 + 函数名锚点
+
+### MODIFIED
+
+- `channel_service.go`：`invalidateCache()` 回调 Gateway 负缓存 flush（通过注入的 invalidator 或 Gateway 注册的 hook，避免 service→handler 反转；优先 **callback 接口** 于 `GatewayService` / `OpenAIGatewayService` 构造时注册）。
+- 不修改对外 HTTP status/body/error type。
+
+### REMOVED
+
+- 无。
+
+### NOT in scope（明确不做）
+
+| 排除项 | 原因 |
+|---|---|
+| 真容量空池 429 | 瞬态，负缓存会误伤退避语义 |
+| `group_id == nil` | 无稳定组维度，保持现状 |
+| Redis 跨副本共享 | 优化缓存，非正确性；与 Anthropic 404 缓存一致做 per-replica |
+| 按 `api_key_id` 分 key | 同组错模型对所有 key 成立；多 key 不增加维度 |
+| 替代 Anthropic 上游 404 缓存 | 互补；上游 404 缓存仍在 Forward 前处理「已转发后确认不存在」 |
+| 缓存 403 / 上游 400 | 仅调度期 `ErrUnsupportedModel` |
+
+## Scenarios
+
+### 核心正向
+
+1. **Given** group 18 渠道定价不允许 `gpt-5.4-mini`，**When** 同一 replica 60s 内第 2+ 次相同 `(group_id, model)` 请求，**Then** 选号入口 short-circuit → HTTP 400 `invalid_request_error`，**不调用** `ListSchedulable*` / load-balance。
+2. **Given** Qwen 组池内账号全因 `model_unsupported`（含 upstream 渠道限制）被拒，**When** 重复请求，**Then** 同上。
+
+### 核心负向
+
+1. **Given** 组内有人能服务该模型、只是当下全忙/被限，**When** 空池 429，**Then** **不** populate 负缓存；后续请求仍走完整选号。
+2. **Given** 负缓存已命中，**When** 管理员修改渠道可服务模型列表并触发 `invalidateCache()`，**Then** 下一次请求重新走完整选号（可成功或新判决）。
+
+### 回归
+
+1. Anthropic `tkModelNotFoundShortCircuit`（上游 404 路径）行为不变。
+2. #1159 已有测试（`TestSelectAccountWithScheduler_QwenGroupWrongModelReturnsUnsupported`、`channel_pricing_restriction_returns_400`）在**无缓存冷启动**下仍通过。
+3. TTL 过期后（测试用小 TTL）自动恢复完整选号。
+
+## Validation
+
+```bash
+go test -tags=unit ./internal/service/... -run 'TestTkGroupUnsupported|TestSelectAccountWithScheduler_CacheHit|TestChannelInvalidateCache_Flushes|TestProvideTKGroupUnsupported|TestP01_Scheduler_Channel|TestSelectAccountWithScheduler_Qwen|TestOpenAICompatNoCandidate'
+go test -tags=unit ./internal/handler/... -run 'Unsupported|ChannelPricing|TkSelectFailure'
+go build -o /dev/null ./cmd/server/...
+```
+
+2026-07-02: 上述 service/handler 回归测试与 `go build ./cmd/server/...` 已通过（本地）。
+
+## 风险与合并顺序
+
+- **公共契约**：HTTP 400 语义不变；仅减少重复调度工作。`no-web-impact`。
+- **陈旧判决窗口**：最长 60s；渠道变更靠 `invalidateCache` flush。可接受——与 Anthropic 404 负缓存同哲学。
+- **#1156**：SLA `error_owner` SSOT 独立；本特性不改变分子口径。
+
+## 实现草图（单文件优先）
+
+```
+selectAccountWithScheduler / SelectAccountWithLoadAwareness
+  └─ tkGroupUnsupportedModelShortCircuit(ctx, groupID, model) → ErrUnsupportedModel?
+  └─ ... existing selection ...
+  └─ on ErrUnsupportedModel (deterministic) → tkGroupUnsupportedModelRecord(groupID, model)
+
+channelService.invalidateCache()
+  └─ registered flush callback → tkGroupUnsupportedModelNegativeCache.Flush()
+```
+
+Companion 文件建议：`backend/internal/service/gateway_service_tk_group_unsupported_cache.go`（与 `*_model_notfound_cache.go` 并列，避免 `openai_account_scheduler_tk_errors.go` 继续膨胀）。

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2280,7 +2280,8 @@
       "path": "backend/internal/service/openai_account_scheduler.go",
       "must_contain": [
         "tkOpenAICompatChannelPricingRestrictionError(req.RequestedModel)",
-        "openAICompatNoCandidateEval"
+        "openAICompatNoCandidateEval",
+        "tkGroupUnsupportedModelShortCircuit"
       ],
       "rationale": "The candidate-filter-empty branch (len(filtered)==0) in selectByLoadBalance must route through openAICompatNoCandidateError (TK companion) so a pool emptied purely by unservable model NAME surfaces ErrUnsupportedModel→400, not empty-pool 429 (prod 2026-06-13). Reverting this one-line hook to the inline noAvailableOpenAISelectionError/platform-label returns compiles clean but re-buries 'client asked for a model nobody serves' inside the 429 capacity family, re-triggering false ops alerts. Only this branch routes here — the len(accounts)==0 and post-load-balance slot-acquire branches stay 429 (genuine capacity)."
     },
@@ -2313,6 +2314,43 @@
         "collectOpenAICompatSelectionFailureStatsForRequest"
       ],
       "rationale": "Regression coverage for prod 2026-07 wrong-key/wrong-group model requests: upstream channel restriction on passthrough accounts and Qwen-only groups must surface ErrUnsupportedModel instead of routing/platform 429."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_group_unsupported_cache.go",
+      "must_contain": [
+        "type tkGroupUnsupportedModelNegativeCache",
+        "func tkGroupUnsupportedModelShortCircuit",
+        "func tkGroupUnsupportedModelRecordErr",
+        "tk_group_unsupported_negative_cache_hit",
+        "tk_group_unsupported_negative_cache_populate",
+        "SetTkGroupUnsupportedModelCache",
+        "SetGroupUnsupportedModelCacheFlusher"
+      ],
+      "rationale": "Per-replica group×model negative cache for selection-time ErrUnsupportedModel (prod 2026-07 hammer). Short-circuits repeated wrong-model requests before listSchedulable/load-balance; flushes on channel invalidateCache. Complements tkModelNotFoundNegativeCache (Anthropic upstream 404 only)."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_group_unsupported_cache_test.go",
+      "must_contain": [
+        "TestSelectAccountWithScheduler_CacheHitShortCircuits",
+        "TestChannelInvalidateCache_FlushesGroupUnsupportedCache"
+      ],
+      "rationale": "Regression: cache hit must short-circuit OpenAI-compat scheduler; channel CRUD invalidation must flush stale group×model verdicts."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "tkGroupUnsupportedModelShortCircuit",
+        "tkGroupUnsupportedModelRecordErr"
+      ],
+      "rationale": "Anthropic/Gemini SelectAccountWithLoadAwareness and SelectAccountForModelWithExclusions must consult the group unsupported negative cache before expensive account selection."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler.go",
+      "must_contain": [
+        "tkGroupUnsupportedModelShortCircuit",
+        "tkGroupUnsupportedModelRecordErr"
+      ],
+      "rationale": "OpenAI-compat scheduler Select and selectAccountWithScheduler must consult/populate the shared group unsupported negative cache at the same entry points as channel pricing restriction."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_model_cooldown.go",


### PR DESCRIPTION
## 摘要

- 在账号选号入口对 `ErrUnsupportedModel`（错组/错模型、#1159 已归类为客户端 400）增加 per-replica 60s 负缓存，key 为 `(group_id, normalized_model)`。
- 首次请求仍走完整选号并返回 400；60s 内同组同模型直接短路 400，跳过 `listSchedulable` / load-balance，不打上游。
- Channel CRUD 触发 `invalidateCache` 时 flush 缓存；真容量 429 不写入缓存。`sentinel-registry-reviewed` `no-web-impact`。

## 风险

- 常规风险：仅减少重复 hammer 的 CPU/调度开销，HTTP 契约与 `error_owner=client` 语义不变。
- 若组内账号/映射在 TTL 内变更，最坏 60s 内仍返回旧 400 直至过期或 channel 失效 flush；与 Anthropic upstream 404 负缓存策略一致。
- 多副本各自维护内存缓存，不跨节点共享（与现有 notfound 负缓存相同）。

## 验证

- `go test -tags=unit ./internal/service/ -run 'TestTkGroupUnsupported|TestChannelInvalidateCache_FlushesGroupUnsupported|TestSelectAccountWithScheduler_CacheHit'`
- `go build ./cmd/server/...`
- `./scripts/preflight.sh`（含 gateway-tk sentinel）

## 提交

- e94182b78 feat(gateway): cache group unsupported model verdicts for 60s

最新提交：e94182b78
