### PR TITLE
fix(routing): align universal key routing with direct key model support

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -666,6 +666,11 @@ func normalizeRequestedModelForLookup(platform, requestedModel string) string {
 	if trimmed == "" {
 		return ""
 	}
+	if IsOpenAICompatPlatform(platform) {
+		if canonical := canonicalizeOpenAIModelAliasSpelling(trimmed); canonical != "" {
+			return canonical
+		}
+	}
 	if platform != PlatformGemini && platform != PlatformAntigravity {
 		return trimmed
 	}

--- a/backend/internal/service/account_openai_passthrough_test.go
+++ b/backend/internal/service/account_openai_passthrough_test.go
@@ -49,6 +49,24 @@ func TestAccount_IsOpenAIPassthroughEnabled(t *testing.T) {
 	})
 }
 
+func TestAccount_OpenAICompatModelAliasSupport(t *testing.T) {
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"gpt-5.4-mini": "gpt-5.4-mini",
+			},
+		},
+	}
+
+	require.True(t, account.IsModelSupported("gpt5.4-mini"))
+	require.True(t, account.IsModelSupported("openai/gpt 5.4mini"))
+
+	mapped, matched := account.ResolveMappedModel("openai/gpt5.4-mini")
+	require.True(t, matched)
+	require.Equal(t, "gpt-5.4-mini", mapped)
+}
+
 func TestAccount_IsOpenAIOAuthPassthroughEnabled(t *testing.T) {
 	t.Run("仅OAuth类型允许返回开启", func(t *testing.T) {
 		oauthAccount := &Account{

--- a/backend/internal/service/account_service_tk_newapi_mapping.go
+++ b/backend/internal/service/account_service_tk_newapi_mapping.go
@@ -12,8 +12,10 @@ import infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 // 原生单 vendor 平台(anthropic / openai / gemini / antigravity)保留「空映射=透传该平台
 // 全部模型」——零维护、忠于上游,不受此约束。
 //
-// 三道闸之一(写时挡);另两道:路由层对 newapi 空映射组不匹配(universal_routing_tk_serving.go)、
-// ops 实时审计(ops/newapi/audit-model-mapping.py)。见 docs/approved/universal-key-routing.md。
+// 三道闸之一(写时挡)。direct-scheduler parity provider 会忠于 direct key 的账号级语义,
+// 因此写时校验是 newapi 空映射不进入生产路由的主闸；GetAvailableModels fallback 仍对
+// newapi 空映射组不匹配(universal_routing_tk_serving.go),ops 实时审计继续兜底
+// (ops/newapi/audit-model-mapping.py)。见 docs/approved/universal-key-routing.md。
 
 // ErrNewapiModelMappingRequired 是 newapi 账号缺/空 model_mapping 时的写时校验错误。
 var ErrNewapiModelMappingRequired = infraerrors.BadRequest(

--- a/backend/internal/service/api_key_service.go
+++ b/backend/internal/service/api_key_service.go
@@ -263,6 +263,15 @@ func (s *APIKeyService) SetUniversalAvailableModelsProvider(p availableModelsPro
 	s.universalResolver.SetAvailableModelsProvider(p)
 }
 
+// SetUniversalModelSupportProvider 后期绑定全能 Key 解析器的 direct-scheduler 同口径
+// 组模型支持判定源。构造期 GatewayService 尚不存在,故经 wire 就绪钩子注入。
+func (s *APIKeyService) SetUniversalModelSupportProvider(p groupModelSupportProvider) {
+	if s == nil || s.universalResolver == nil {
+		return
+	}
+	s.universalResolver.SetModelSupportProvider(p)
+}
+
 // SetRateLimitCacheInvalidator sets the optional rate limit cache invalidator.
 // Called after construction (e.g. in wire) to avoid circular dependencies.
 func (s *APIKeyService) SetRateLimitCacheInvalidator(inv RateLimitCacheInvalidator) {

--- a/backend/internal/service/universal_routing_tk_resolver.go
+++ b/backend/internal/service/universal_routing_tk_resolver.go
@@ -33,7 +33,8 @@ type UniversalRoutingResolver struct {
 	// 经 APIKeyService.SetUniversalAvailableModelsProvider 在 GatewayService 构造后绑定
 	// (避免构造期环)。受 mu 保护。nil = 未接线/降级 → Resolve 退回平台级现状(安全兜底)。
 	// 见 universal_routing_tk_serving.go。
-	modelsProvider availableModelsProvider
+	modelsProvider  availableModelsProvider
+	supportProvider groupModelSupportProvider
 }
 
 // availableGroupsLister 由 *APIKeyService 满足，给出某用户当前有权绑定的全部分组
@@ -79,12 +80,24 @@ func (r *UniversalRoutingResolver) SetAvailableModelsProvider(p availableModelsP
 	r.mu.Unlock()
 }
 
+// SetModelSupportProvider 后期注入 direct-scheduler 同口径的组模型支持判定源。
+// nil-safe; provider 取数未知时 Resolve 会退回 availableModelsProvider。
+func (r *UniversalRoutingResolver) SetModelSupportProvider(p groupModelSupportProvider) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.supportProvider = p
+	r.mu.Unlock()
+}
+
 // providerSnapshot 取当前 provider(受 mu 保护读)。
-func (r *UniversalRoutingResolver) providerSnapshot() availableModelsProvider {
+func (r *UniversalRoutingResolver) providerSnapshot() (availableModelsProvider, groupModelSupportProvider) {
 	r.mu.RLock()
-	p := r.modelsProvider
+	modelsProvider := r.modelsProvider
+	supportProvider := r.supportProvider
 	r.mu.RUnlock()
-	return p
+	return modelsProvider, supportProvider
 }
 
 // Resolve 返回该请求应落到的后端组。shape 为入口端点形状，model 为请求模型名（可空，
@@ -135,16 +148,42 @@ func (r *UniversalRoutingResolver) Resolve(ctx context.Context, apiKey *APIKey, 
 	// hint 为空(未知 channel 模型)仍退回 eligible,由下游诚实拒绝 —— provider 未接线时整体
 	// 也保持旧平台级行为(见 TestResolve_NilProviderFallsBackToPlatformLevel)。
 	if model != "" {
-		if provider := r.providerSnapshot(); provider != nil {
+		if modelsProvider, supportProvider := r.providerSnapshot(); modelsProvider != nil || supportProvider != nil {
 			served := make([]Group, 0, len(eligible))
+			knownAll := true
 			for i := range eligible {
-				if groupServesModel(ctx, provider, eligible[i], model) {
+				if supportProvider != nil {
+					gid := eligible[i].ID
+					serves, known := supportProvider(ctx, &gid, eligible[i].Platform, model)
+					if !known {
+						knownAll = false
+						continue
+					}
+					if serves {
+						served = append(served, eligible[i])
+					}
+					continue
+				}
+				if groupServesModel(ctx, modelsProvider, eligible[i], model) {
 					served = append(served, eligible[i])
 				}
 			}
+			if !knownAll && modelsProvider != nil {
+				served = served[:0]
+				for i := range eligible {
+					if groupServesModel(ctx, modelsProvider, eligible[i], model) {
+						served = append(served, eligible[i])
+					}
+				}
+				knownAll = true
+			}
 			if len(served) > 0 {
 				eligible = served
-			} else if hint := universalModelPlatformHint(model); hint != "" {
+			} else if knownAll {
+				if hint := universalModelPlatformHint(model); hint != "" {
+					return nil, ErrUniversalNoEntitledGroup
+				}
+			} else if hint := universalModelPlatformHint(model); hint != "" && modelsProvider != nil {
 				return nil, ErrUniversalNoEntitledGroup
 			}
 		}

--- a/backend/internal/service/universal_routing_tk_serving.go
+++ b/backend/internal/service/universal_routing_tk_serving.go
@@ -27,6 +27,45 @@ import "context"
 // 现状行为 —— 安全兜底,绝不黑洞 universal 流量。
 type availableModelsProvider func(ctx context.Context, groupID *int64, platform string) []string
 
+// groupModelSupportProvider 以 direct scheduler 的账号级语义判定某组是否能服务模型。
+// known=false 表示 provider 取数失败/未能判断,解析器会退回 availableModelsProvider 的
+// 旧口径,避免因为观测源短暂不可用而把 universal 流量误拒。
+type groupModelSupportProvider func(ctx context.Context, groupID *int64, platform, model string) (serves bool, known bool)
+
+// UniversalGroupSupportsModel reports whether the direct gateway scheduler could
+// find at least one account in group/platform that supports model. This is the
+// universal-key parity hook: it preserves per-account semantics that a group-level
+// served-model union loses, especially unrestricted passthrough accounts, wildcard
+// mappings, Anthropic short-id normalization, Antigravity default mappings, and
+// OpenAI alias spelling.
+func (s *GatewayService) UniversalGroupSupportsModel(ctx context.Context, groupID *int64, platform, model string) (bool, bool) {
+	if s == nil || s.accountRepo == nil || platform == "" {
+		return false, false
+	}
+	accounts, useMixed, err := s.listSchedulableAccounts(ctx, groupID, platform, false)
+	if err != nil {
+		return false, false
+	}
+	for i := range accounts {
+		acc := &accounts[i]
+		if IsOpenAICompatPlatform(platform) {
+			if !acc.IsOpenAICompatPoolMember(platform) {
+				continue
+			}
+			if acc.IsModelSupported(model) || (acc.Platform == PlatformGrok && grokGroupServesNativeCatalogModel(model)) {
+				return true, true
+			}
+			continue
+		} else if !s.isAccountAllowedForPlatform(acc, platform, useMixed) {
+			continue
+		}
+		if s.isModelSupportedByAccountWithContext(ctx, acc, model) {
+			return true, true
+		}
+	}
+	return false, true
+}
+
 // groupServesModel 判定组 g 是否真服务模型 model(上述三分流)。provider 非 nil 由调用方保证。
 func groupServesModel(ctx context.Context, provider availableModelsProvider, g Group, model string) bool {
 	gid := g.ID
@@ -54,17 +93,15 @@ func groupServesModel(ctx context.Context, provider availableModelsProvider, g G
 
 // modelInServedSet 判定 model 是否在组的显式服务集里(精确 + 归一,与 IsModelSupported 同口径)。
 func modelInServedSet(model string, served []string, platform string) bool {
+	mapping := make(map[string]string, len(served))
 	for _, m := range served {
-		if m == model {
-			return true
-		}
+		mapping[m] = m
+	}
+	if mappingSupportsRequestedModel(mapping, model) {
+		return true
 	}
 	if norm := normalizeRequestedModelForLookup(platform, model); norm != model {
-		for _, m := range served {
-			if m == norm {
-				return true
-			}
-		}
+		return mappingSupportsRequestedModel(mapping, norm)
 	}
 	return false
 }

--- a/backend/internal/service/universal_routing_tk_serving.go
+++ b/backend/internal/service/universal_routing_tk_serving.go
@@ -2,15 +2,17 @@ package service
 
 import "context"
 
-// 全能 Key 解析的「组已服务模型集」真值过滤。
+// 全能 Key 解析的「组是否支持模型」真值过滤。
 //
 // 背景:旧解析器只按 平台 + 模型名前缀 hint 盲选后端组,对「某组账号到底服不服务这个
 // 具体模型」零可见 —— newapi 平台底下多个 vendor 组(deepseek/Qwen/volcengine/
 // google-vertex/grok/…,多组是按 vendor 专属倍率计费的有意设计)里盲选必投错组 →
-// 下游 `no available accounts`。本文件给解析器加一道「组是否真服务该模型」的判别,
-// 复用 GatewayService.GetAvailableModels(与 /v1/models 同一真值)。
+// 下游 `no available accounts`。本文件给解析器加一道「组是否真支持该模型」的判别。
 //
-// 判别按组的服务集来源非对称分流(见 docs/approved/universal-key-routing.md):
+// 当前优先使用 UniversalGroupSupportsModel:复用 direct scheduler 的账号级模型支持语义,
+// 让 universal key 与同组 direct key 对同一模型的 routing entitlement 保持一致。
+// GetAvailableModels 仍保留为 provider unknown 时的 degraded fallback;fallback 按组服务集
+// 来源非对称分流(见 docs/approved/universal-key-routing.md):
 //   - GetAvailableModels 返回非 nil(组有显式 model_mapping,含全部 newapi vendor 组)
 //     → 精确成员判定 M ∈ served。把 deepseek/qwen/imagen/veo/seedance 落到声明了该
 //     模型的组,排除别的 vendor 组。
@@ -22,8 +24,9 @@ import "context"
 
 // availableModelsProvider 返回某组(按 platform)当前可调度账号 model_mapping 键的并集;
 // 无任何账号声明映射时返回 nil(native/permissive)。由 GatewayService.GetAvailableModels
-// 满足,经 APIKeyService 后期绑定(避免构造期 GatewayService 尚不存在的环;见 wire.go
-// ProvideTKUniversalModelsProvider)。provider 为 nil(未接线/降级)时,解析器退回平台级
+// 满足,作为 direct-scheduler provider unknown 时的降级兜底。经 APIKeyService 后期绑定
+// (避免构造期 GatewayService 尚不存在的环;见 wire.go ProvideTKUniversalModelsProvider)。
+// provider 为 nil(未接线/降级)时,解析器退回平台级
 // 现状行为 —— 安全兜底,绝不黑洞 universal 流量。
 type availableModelsProvider func(ctx context.Context, groupID *int64, platform string) []string
 
@@ -66,7 +69,8 @@ func (s *GatewayService) UniversalGroupSupportsModel(ctx context.Context, groupI
 	return false, true
 }
 
-// groupServesModel 判定组 g 是否真服务模型 model(上述三分流)。provider 非 nil 由调用方保证。
+// groupServesModel 是 GetAvailableModels fallback 的组服务集判定(上述三分流)。
+// provider 非 nil 由调用方保证。
 func groupServesModel(ctx context.Context, provider availableModelsProvider, g Group, model string) bool {
 	gid := g.ID
 	served := provider(ctx, &gid, g.Platform)

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -18,6 +18,16 @@ func servedProvider(byGroup map[int64][]string) availableModelsProvider {
 	}
 }
 
+func supportProvider(byGroup map[int64]bool) groupModelSupportProvider {
+	return func(_ context.Context, gid *int64, _ string, _ string) (bool, bool) {
+		if gid == nil {
+			return false, false
+		}
+		serves, ok := byGroup[*gid]
+		return serves, ok
+	}
+}
+
 // 核心:newapi 平台多 vendor 组,按「组已服务模型集」精确落到对的组,而非盲选 tiebreaker。
 func TestResolve_NewapiPicksGroupThatServesModel(t *testing.T) {
 	ctx := context.Background()
@@ -40,6 +50,158 @@ func TestResolve_NewapiPicksGroupThatServesModel(t *testing.T) {
 	g, err = r.Resolve(ctx, key, ShapeOpenAIChat, "deepseek-chat", "")
 	if err != nil || g == nil || g.ID != 11 {
 		t.Fatalf("deepseek-chat 应落 deepseek 组 gid=11, got=%v err=%v", g, err)
+	}
+}
+
+func TestResolve_UsesDirectSchedulerModelSupportBeforeServedSet(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(2, PlatformOpenAI, 5, false),
+		grp(18, PlatformNewAPI, 10, false),
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	// /v1/models-style served set is lossy for mixed groups: it only sees the
+	// mapped account and misses another OpenAI passthrough account that direct
+	// scheduling would accept. The direct-parity provider must win.
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		2:  {"gpt-5.5"},
+		18: {"qwen-max"},
+	}))
+	r.SetModelSupportProvider(supportProvider(map[int64]bool{
+		2:  true,
+		18: false,
+	}))
+	g, err := r.Resolve(ctx, universalKey(16), ShapeOpenAIChat, "gpt-5.4-mini", "")
+	if err != nil || g == nil || g.ID != 2 {
+		t.Fatalf("direct-parity provider 应使 gpt-5.4-mini 落 openai passthrough 组 gid=2, got=%v err=%v", g, err)
+	}
+}
+
+func TestResolve_ModelSupportProviderUnknownFallsBackToServedSet(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(2, PlatformOpenAI, 5, false),
+		grp(18, PlatformNewAPI, 10, false),
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		2:  {"gpt-5.4-mini"},
+		18: {"qwen-max"},
+	}))
+	r.SetModelSupportProvider(func(context.Context, *int64, string, string) (bool, bool) {
+		return false, false
+	})
+	g, err := r.Resolve(ctx, universalKey(16), ShapeOpenAIChat, "gpt5.4-mini", "")
+	if err != nil || g == nil || g.ID != 2 {
+		t.Fatalf("support provider unknown 时应 fallback 到 served-set alias 匹配 gid=2, got=%v err=%v", g, err)
+	}
+}
+
+func TestUniversalGroupSupportsModel_OpenAICompatMatchesDirectScheduler(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(2)
+	svc := &GatewayService{
+		accountRepo: stubOpenAIAccountRepo{accounts: []Account{
+			{
+				ID:       1,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Extra:    map[string]any{"openai_passthrough": true},
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{"gpt-5.5": "gpt-5.5"},
+				},
+			},
+		}},
+	}
+
+	serves, known := svc.UniversalGroupSupportsModel(ctx, &groupID, PlatformOpenAI, "gpt-5.4-mini")
+	if !known || serves {
+		t.Fatalf("openai compat support must follow direct scheduler mapping check, got serves=%v known=%v", serves, known)
+	}
+	serves, known = svc.UniversalGroupSupportsModel(ctx, &groupID, PlatformOpenAI, "gpt5.5")
+	if !known || !serves {
+		t.Fatalf("openai compat alias should match mapped model, got serves=%v known=%v", serves, known)
+	}
+}
+
+func TestUniversalGroupSupportsModel_NewapiRequiresCompatPoolMember(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(18)
+	modelMapping := map[string]any{"qwen-max": "qwen-max"}
+
+	t.Run("channel type zero rejected", func(t *testing.T) {
+		svc := &GatewayService{
+			accountRepo: stubOpenAIAccountRepo{accounts: []Account{
+				{
+					ID:          1,
+					Platform:    PlatformNewAPI,
+					ChannelType: 0,
+					Credentials: map[string]any{"model_mapping": modelMapping},
+				},
+			}},
+		}
+		serves, known := svc.UniversalGroupSupportsModel(ctx, &groupID, PlatformNewAPI, "qwen-max")
+		if !known || serves {
+			t.Fatalf("newapi channel_type=0 must not serve via universal, got serves=%v known=%v", serves, known)
+		}
+	})
+
+	t.Run("positive channel type accepted", func(t *testing.T) {
+		svc := &GatewayService{
+			accountRepo: stubOpenAIAccountRepo{accounts: []Account{
+				{
+					ID:          2,
+					Platform:    PlatformNewAPI,
+					ChannelType: 45,
+					Credentials: map[string]any{"model_mapping": modelMapping},
+				},
+			}},
+		}
+		serves, known := svc.UniversalGroupSupportsModel(ctx, &groupID, PlatformNewAPI, "qwen-max")
+		if !known || !serves {
+			t.Fatalf("newapi channel_type>0 should serve mapped model, got serves=%v known=%v", serves, known)
+		}
+	})
+}
+
+func TestModelInServedSet_UsesDirectMappingAliases(t *testing.T) {
+	cases := []struct {
+		name     string
+		platform string
+		model    string
+		served   []string
+	}{
+		{
+			name:     "openai gpt5 spelling",
+			platform: PlatformOpenAI,
+			model:    "gpt5.4-mini",
+			served:   []string{"gpt-5.4-mini"},
+		},
+		{
+			name:     "openai provider prefix and compact spelling",
+			platform: PlatformOpenAI,
+			model:    "openai/gpt 5.4mini",
+			served:   []string{"gpt-5.4-mini"},
+		},
+		{
+			name:     "wildcard mapping",
+			platform: PlatformOpenAI,
+			model:    "gpt-5.4-mini-20260702",
+			served:   []string{"gpt-5.4-mini*"},
+		},
+		{
+			name:     "gemini customtools alias",
+			platform: PlatformGemini,
+			model:    "gemini-3.1-pro-preview-customtools",
+			served:   []string{"gemini-3.1-pro-preview"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !modelInServedSet(tc.model, tc.served, tc.platform) {
+				t.Fatalf("modelInServedSet(%q, %v, %s) = false, want true", tc.model, tc.served, tc.platform)
+			}
+		})
 	}
 }
 
@@ -236,6 +398,22 @@ func user16ServingProvider() availableModelsProvider {
 		5:  {"doubao-seed-1-6-250615", "doubao-seedream-4-0-250828"},
 		// gid=1(anthropic)、gid=2(openai)缺席 → nil(native)
 	})
+}
+
+func TestResolve_User16GPTAliasPicksOpenAIGroup(t *testing.T) {
+	ctx := context.Background()
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: user16Span()})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		2:  {"gpt-5.4-mini"},
+		11: {"deepseek-chat", "deepseek-v4-flash"},
+		18: {"qwen-max", "qwen3-coder-plus"},
+		5:  {"doubao-seed-1-6-250615"},
+	}))
+
+	g, err := r.Resolve(ctx, universalKey(16), ShapeOpenAIChat, "gpt5.4-mini", "")
+	if err != nil || g == nil || g.ID != 2 {
+		t.Fatalf("user16 gpt5.4-mini 应经 universal 落 openai/GPT 专线 gid=2, got=%v err=%v", g, err)
+	}
 }
 
 // 核心收敛(user16 修复守卫):deepseek-v4-flash 发到 /v1/messages(Anthropic 形状),全能 Key

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -844,18 +844,16 @@ func ProvideTKGatewayPricingAvailability(
 }
 
 // TKUniversalModelsProviderReady is a wire sentinel: holding it proves
-// APIKeyService.SetUniversalAvailableModelsProvider has been called with
-// GatewayService.GetAvailableModels, so the universal-key resolver can filter
-// candidate groups by which models they actually serve. provideCleanup
-// (cmd/server/wire.go) consumes this type as an unused parameter to force wire
-// to evaluate the side-effect.
+// APIKeyService's universal-key resolver has been wired to GatewayService's
+// direct-scheduler model support predicate, with GetAvailableModels retained as
+// a degraded fallback. provideCleanup (cmd/server/wire.go) consumes this type as
+// an unused parameter to force wire to evaluate the side-effect.
 type TKUniversalModelsProviderReady struct{}
 
-// ProvideTKUniversalModelsProvider wires the "group served-model set" truth
-// source (GatewayService.GetAvailableModels — the same source /v1/models uses)
-// onto the universal-key resolver post-construction. APIKeyService constructs
-// the resolver before GatewayService exists, so this late binding avoids the
-// construction cycle. Mirrors ProvideTKGatewayPricingAvailability in shape.
+// ProvideTKUniversalModelsProvider wires the universal-key resolver's model
+// support truth source post-construction. APIKeyService constructs the resolver
+// before GatewayService exists, so this late binding avoids the construction
+// cycle. Mirrors ProvideTKGatewayPricingAvailability in shape.
 //
 // Setter is nil-safe; if either dep is nil the resolver keeps its safe
 // platform-level fallback. See docs/approved/universal-key-routing.md.
@@ -864,6 +862,7 @@ func ProvideTKUniversalModelsProvider(
 	gw *GatewayService,
 ) TKUniversalModelsProviderReady {
 	if api != nil && gw != nil {
+		api.SetUniversalModelSupportProvider(gw.UniversalGroupSupportsModel)
 		api.SetUniversalAvailableModelsProvider(gw.GetAvailableModels)
 	}
 	return TKUniversalModelsProviderReady{}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3400,10 +3400,56 @@
         "func pickUniversalBackingGroup(",
         "universalShapeRequiresImageGenerationEnabled",
         "filterGroupsAllowImageGeneration",
+        "supportProvider groupModelSupportProvider",
+        "supportProvider(ctx, &gid, eligible[i].Platform, model)",
         "else if hint := universalModelPlatformHint(model); hint != \"\"",
         "收敛为空且模型有平台 hint → ErrUniversalNoEntitledGroup(403)"
       ],
-      "rationale": "Universal Key (全能 Key) per-request resolver: maps a routing_mode=universal key to a concrete backing group from the owner's live entitlement span (GetAvailableGroups, short-TTL cached), filtered by endpoint-shape candidate platforms, with deterministic pick (subscription-held -> sort_order -> id). docs/approved/universal-key-routing.md §4.3. Dropping this file disables universal-key routing entirely (every universal key would fall through with a nil group). Pins the constructor, Resolve entrypoint, the no-entitled-group sentinel error, and the deterministic picker. Load-bearing P0 gate (prod 2026-07-01 user16 universal key #245): when groupServesModel filters eligible to empty AND the model has a platform hint, Resolve must return ErrUniversalNoEntitledGroup (middleware 403) — NOT fall back to a wrong openai-compat group and surface routing-phase 429 No available accounts (routing_capacity_rejection storm). An upstream merge that restores the old served-empty fallback silently re-opens the amplifier; the else-if hint branch is the mechanical anchor."
+      "rationale": "Universal Key (全能 Key) per-request resolver: maps a routing_mode=universal key to a concrete backing group from the owner's live entitlement span (GetAvailableGroups, short-TTL cached), filtered by endpoint-shape candidate platforms, with deterministic pick (subscription-held -> sort_order -> id). docs/approved/universal-key-routing.md §4.3. Dropping this file disables universal-key routing entirely (every universal key would fall through with a nil group). Pins the constructor, Resolve entrypoint, the no-entitled-group sentinel error, and the deterministic picker. Load-bearing P0 gate (prod 2026-07-01 user16 universal key #245): when groupServesModel filters eligible to empty AND the model has a platform hint, Resolve must return ErrUniversalNoEntitledGroup (middleware 403) — NOT fall back to a wrong openai-compat group and surface routing-phase 429 No available accounts (routing_capacity_rejection storm). Universal/direct-key parity now depends on the direct-scheduler supportProvider branch running before the GetAvailableModels fallback; losing that branch silently reverts OpenAI passthrough, wildcard, Anthropic alias, and Antigravity default-mapping parity. An upstream merge that restores the old served-empty fallback or drops supportProvider silently re-opens the amplifier; the hint branch plus supportProvider call are the mechanical anchors."
+    },
+    {
+      "path": "backend/internal/service/universal_routing_tk_serving.go",
+      "must_contain": [
+        "type groupModelSupportProvider func(",
+        "func (s *GatewayService) UniversalGroupSupportsModel(",
+        "s.listSchedulableAccounts(ctx, groupID, platform, false)",
+        "acc.IsOpenAICompatPoolMember(platform)",
+        "acc.IsModelSupported(model)",
+        "s.isModelSupportedByAccountWithContext(ctx, acc, model)",
+        "modelInServedSet(model string, served []string, platform string)",
+        "normalizeRequestedModelForLookup(platform, model)"
+      ],
+      "rationale": "Universal-key model routing must use the same account-level model-support predicate as the direct schedulers before consulting the lossy group-level served-model union. This pins the provider type, the GatewayService implementation, the OpenAI-compatible pool/member + IsModelSupported path, the native gateway path, and the alias-aware served-set fallback. Dropping any of these can make a universal key choose a different backing group than a direct key for the same model while existing /v1/models output still looks plausible."
+    },
+    {
+      "path": "backend/internal/service/wire.go",
+      "must_contain": [
+        "ProvideTKUniversalModelsProvider(",
+        "api.SetUniversalModelSupportProvider(gw.UniversalGroupSupportsModel)",
+        "api.SetUniversalAvailableModelsProvider(gw.GetAvailableModels)"
+      ],
+      "rationale": "ProvideTKUniversalModelsProvider is the runtime injection point for universal-key model routing truth. The direct-scheduler support provider must be wired alongside GetAvailableModels; tests can call SetUniversalModelSupportProvider directly and still pass if an upstream merge drops this wire call, leaving production on the old lossy fallback. Pin both setter calls so the app cannot silently boot without direct-key parity."
+    },
+    {
+      "path": "backend/internal/service/universal_routing_tk_serving_test.go",
+      "must_contain": [
+        "TestResolve_UsesDirectSchedulerModelSupportBeforeServedSet",
+        "TestResolve_ModelSupportProviderUnknownFallsBackToServedSet",
+        "TestUniversalGroupSupportsModel_OpenAICompatMatchesDirectScheduler",
+        "TestUniversalGroupSupportsModel_NewapiRequiresCompatPoolMember",
+        "TestModelInServedSet_UsesDirectMappingAliases",
+        "TestResolve_User16GPTAliasPicksOpenAIGroup"
+      ],
+      "rationale": "Focused regression coverage for universal/direct-key model-support parity: direct provider wins over the served-set fallback, provider unknown fails over safely, OpenAI-compatible mapping and newapi pool membership match direct scheduler semantics, served-set fallback is alias/wildcard aware, and the user16 gpt5.4-mini alias resolves to the OpenAI group instead of newapi. These tests are the semantic guard for the production 429 regression."
+    },
+    {
+      "path": "backend/internal/service/account_openai_passthrough_test.go",
+      "must_contain": [
+        "TestAccount_OpenAICompatModelAliasSupport",
+        "gpt5.4-mini",
+        "openai/gpt 5.4mini"
+      ],
+      "rationale": "Account-level OpenAI-compatible alias canonicalization is shared by direct scheduler model checks, mapping resolution, and universal-key served-set fallback. Pin the focused test so a future cleanup cannot drop gpt5/openai-prefixed spelling parity while the generic Codex billing alias tests still pass."
     },
     {
       "path": "backend/internal/service/universal_routing_tk_endpoint_map.go",


### PR DESCRIPTION
## 摘要
- 将 universal key 的模型服务判定改为优先使用 direct scheduler 的账号级语义，避免组级 served-model 并集漏掉 passthrough 账号、通配符映射和平台专属模型归一。
- 补齐 OpenAI-compat 模型 alias 在 `model_mapping` lookup 中的归一，覆盖 `gpt5.4-mini`、`openai/gpt 5.4mini` 等写法。
- 保留 `/v1/models` served-set 作为 provider unknown 时的降级，并补充 user16 `gpt5.4-mini` 落 openai/GPT 专线的回归测试。
- Review follow-up: 补充 gateway sentinel registry 锚点，锁住 direct provider、wire 注入和关键回归测试，避免后续 upstream merge 静默回退到旧口径。

## 风险
- 影响 universal key 的 routing 决策；direct key 调度路径保持原语义，只复用其模型支持判定口径。
- 已更新 `scripts/sentinels/gateway-tk.json`：锚定 `UniversalGroupSupportsModel`、`SetUniversalModelSupportProvider` runtime wiring、resolver supportProvider 分支和 focused tests。
- Web impact: none。仅后端 service/routing 逻辑、sentinel registry 与单元测试变更，无前端页面或 API schema 变化。

## 验证
- `go test ./internal/service -tags unit -run 'TestUniversalGroupSupportsModel|TestResolve_User16GPTAliasPicksOpenAIGroup|TestResolve_UsesDirectSchedulerModelSupportBeforeServedSet|TestResolve_ModelSupportProviderUnknownFallsBackToServedSet|TestModelInServedSet|TestAccount_OpenAICompatModelAliasSupport'`
- `go test ./internal/server/middleware -tags unit -run 'TestUniversal|TestMaybeResolveUniversal'`
- `go test ./cmd/server -tags unit -run 'TestWire|TestProvide|TestInject'`
- `python3 -m json.tool scripts/sentinels/gateway-tk.json >/tmp/gateway-tk-json-check.txt`
- `git diff --check origin/main...HEAD`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

## 提交
- 272e779fd fix(routing): align universal key model support with direct keys
- 73a9079a3 fix(review): anchor universal routing parity

最新提交：73a9079a3
