### PR TITLE
chore: enable main branch protection prerequisites

### DIFF
--- a/.github/workflows/main-ancestry-guard.yml
+++ b/.github/workflows/main-ancestry-guard.yml
@@ -44,7 +44,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  validate:
+  main-ancestry-guard:
     runs-on: ubuntu-latest
     steps:
       # fetch-depth: 0 ensures PR base is reachable locally — GitHub Actions

--- a/.github/workflows/marker-acknowledgement-pr.yml
+++ b/.github/workflows/marker-acknowledgement-pr.yml
@@ -44,7 +44,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  validate:
+  marker-acknowledgement:
     runs-on: ubuntu-latest
     steps:
       # fetch-depth: 0 so PR base..head plumbing resolves. submodules: recursive

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,16 +1,18 @@
 name: Security Scan
 
+# Weekly-only deep security scan. Push/PR security gates live in backend-ci.yml
+# (backend-security / frontend-security) — duplicate job names here would collide
+# with branch-protection required checks.
 on:
-  push:
-  pull_request:
   schedule:
     - cron: '0 3 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  backend-security:
+  security-scan-backend:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -35,7 +37,7 @@ jobs:
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
 
-  frontend-security:
+  security-scan-frontend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -78,7 +78,8 @@ name: Upstream Merge PR Shape
 #      (preflight parity, mechanical forward-drift guard).
 #
 # A green check here is a hard prerequisite for merging. Branch protection
-# on `main` should require this workflow status for `merge/upstream-*` PRs.
+# on `main` should require the `upstream-merge-pr-shape` job status for
+# `merge/upstream-*` PRs (do not add it to the global required-check list).
 
 on:
   pull_request:
@@ -90,7 +91,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  validate:
+  upstream-merge-pr-shape:
     if: startsWith(github.head_ref, 'merge/upstream-')
     runs-on: ubuntu-latest
     steps:

--- a/docs/global/upstream-merge-discipline.md
+++ b/docs/global/upstream-merge-discipline.md
@@ -31,7 +31,7 @@ Per dev-rules §"Hard Constraint Wiring" — every soft rule above MUST have an 
 
 **Anchor advancement.** `.main-ancestry-anchor` is a one-way ratchet: a known-good SHA every future HEAD must descend from (baseline `62482fa9bc30ac292ecca92341ef055a024d8a26`, locked after the PR #307 orphan-reset incident). To advance it: open a PR that updates the file AND carries the literal marker `main-ancestry-anchor-advance` + a one-line justification in a commit message. Guard Check 2 also requires the new SHA to be a descendant of the old one — the descendant check is the real ratchet, the marker is the human-attention gate.
 
-**Branch protection on `main`** SHOULD list `Upstream Merge PR Shape / validate` and `Main Ancestry Guard / validate` as required status checks (Settings → Branches → main). Known limit: GitHub doesn't expose merge-method choice, so these gates can't stop a manual "Squash and merge" click on a merge PR — they only make the wrong shape fail CI.
+**Branch protection on `main`** requires CI jobs `preflight`, `test-unit`, `test-integration`, `frontend`, `golangci-lint`, `backend-security`, `frontend-security`, plus PR gates `main-ancestry-guard` and `marker-acknowledgement`. Do **not** require `upstream-merge-pr-shape` globally — it only runs on `merge/upstream-*` PRs and skips elsewhere. Known limit: GitHub doesn't expose merge-method choice, so these gates can't stop a manual "Squash and merge" click on a merge PR — they only make the wrong shape fail CI.
 
 ## Convergence & minimal invasion (especially large upstream files)
 


### PR DESCRIPTION
## 摘要
- 重命名 3 个冲突的 `validate` CI job，使 branch protection required checks 可唯一映射
- `Security Scan` 改为仅 weekly/dispatch，避免与 `backend-ci.yml` 的 security job 重名
- 更新 `upstream-merge-discipline.md` 中的 required checks 清单

## 风险
- 低：仅 workflow 命名与触发范围调整，无业务逻辑变更
- `upstream-merge-pr-shape` 仍不在全局 required 列表（仅 `merge/upstream-*` PR 运行）

## 验证
- PR CI 应出现 `main-ancestry-guard` / `marker-acknowledgement` 新 check 名
- merge 后配置 `main` branch protection

no-web-impact

## 提交
- 86023752b chore: disambiguate CI job names for main branch protection
- 最新提交：86023752b
