### PR TITLE
fix(gateway): Qwen 组错模型请求改回 client 400（load-awareness 路径）

### DIFF
--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -75,6 +75,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		return
 	}
 	reqModel := modelResult.String()
+	routingModel := service.CanonicalizeOpenAICompatRoutingModel(reqModel)
 	reqStream, ok := parseOpenAICompatibleStream(body)
 	if !ok {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", invalidStreamFieldTypeMessage)
@@ -157,7 +158,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			apiKey.GroupID,
 			"",
 			sessionHash,
-			reqModel,
+			routingModel,
 			failedAccountIDs,
 			service.OpenAIUpstreamTransportAny,
 			service.OpenAIEndpointCapabilityChatCompletions,

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -10597,8 +10597,10 @@ func (s *GatewayService) checkChannelPricingRestriction(ctx context.Context, gro
 	if groupID == nil || s.channelService == nil || requestedModel == "" {
 		return false
 	}
+	requestedModel = CanonicalizeOpenAICompatRoutingModel(requestedModel)
 	mapping := s.channelService.ResolveChannelMapping(ctx, *groupID, requestedModel)
 	billingModel := billingModelForRestriction(mapping.BillingModelSource, requestedModel, mapping.MappedModel)
+	billingModel = CanonicalizeOpenAICompatRoutingModel(billingModel)
 	if billingModel == "" {
 		return false
 	}

--- a/backend/internal/service/gateway_service_tk_group_unsupported_cache.go
+++ b/backend/internal/service/gateway_service_tk_group_unsupported_cache.go
@@ -34,7 +34,7 @@ func newTkGroupUnsupportedModelNegativeCacheWithTTL(ttl, cleanup time.Duration) 
 }
 
 func tkGroupUnsupportedModelCacheKey(groupID int64, model string) string {
-	model = strings.ToLower(strings.TrimSpace(model))
+	model = strings.ToLower(CanonicalizeOpenAICompatRoutingModel(model))
 	if model == "" || groupID <= 0 {
 		return ""
 	}
@@ -89,7 +89,7 @@ func tkGroupUnsupportedModelShortCircuit(cache *tkGroupUnsupportedModelNegativeC
 	if cache == nil || groupID == nil || *groupID <= 0 {
 		return nil
 	}
-	model = strings.TrimSpace(model)
+	model = CanonicalizeOpenAICompatRoutingModel(model)
 	if model == "" {
 		return nil
 	}
@@ -109,7 +109,7 @@ func tkGroupUnsupportedModelRecordErr(cache *tkGroupUnsupportedModelNegativeCach
 	if !errors.Is(err, ErrUnsupportedModel) {
 		return err
 	}
-	cache.put(*groupID, model)
+	cache.put(*groupID, CanonicalizeOpenAICompatRoutingModel(model))
 	return err
 }
 

--- a/backend/internal/service/gateway_service_tk_group_unsupported_cache_test.go
+++ b/backend/internal/service/gateway_service_tk_group_unsupported_cache_test.go
@@ -24,7 +24,7 @@ func TestTkGroupUnsupportedModelShortCircuit_Hit(t *testing.T) {
 	groupID := int64(18)
 	cache.put(groupID, "gpt-5.4-mini")
 
-	err := tkGroupUnsupportedModelShortCircuit(cache, &groupID, "gpt-5.4-mini")
+	err := tkGroupUnsupportedModelShortCircuit(cache, &groupID, "gpt5.4-mini")
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrUnsupportedModel)
 }

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -1464,6 +1464,7 @@ func (s *OpenAIGatewayService) selectAccountWithScheduler(
 	requireCompact bool,
 ) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
 	decision := OpenAIAccountScheduleDecision{}
+	requestedModel = CanonicalizeOpenAICompatRoutingModel(requestedModel)
 	if err := s.tkGroupUnsupportedModelShortCircuit(groupID, requestedModel); err != nil {
 		return nil, decision, err
 	}

--- a/backend/internal/service/openai_account_scheduler_tk_errors_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_errors_test.go
@@ -212,3 +212,32 @@ func TestSelectAccountWithScheduler_QwenGroupWrongModelReturnsUnsupported(t *tes
 	require.True(t, selection == nil || selection.Account == nil)
 	require.ErrorIs(t, err, ErrUnsupportedModel, "wrong model on Qwen-only group must be client-owned 400, not routing 429")
 }
+
+func TestSelectAccountWithLoadAwareness_QwenGroupWrongModelAliasReturnsUnsupported(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(18004)
+	qwenOnly := newapiAcctWithMapping(18041, "qwen-max", "qwen-plus")
+	channel := Channel{
+		ID:                 1,
+		Status:             StatusActive,
+		GroupIDs:           []int64{groupID},
+		RestrictModels:     true,
+		BillingModelSource: BillingModelSourceUpstream,
+		ModelPricing: []ChannelModelPricing{
+			{Platform: PlatformNewAPI, Models: []string{"qwen-max", "qwen-plus"}},
+		},
+	}
+	svc, _ := newSchedFixtureWithChannel(t, groupID, PlatformNewAPI, []*Account{&qwenOnly}, channel)
+	svc.cfg.Gateway.Scheduling.LoadBatchEnabled = true
+
+	selection, err := svc.SelectAccountWithLoadAwareness(ctx, &groupID, "", "gpt5.4-mini", nil)
+	require.Error(t, err)
+	require.True(t, selection == nil || selection.Account == nil)
+	require.ErrorIs(t, err, ErrUnsupportedModel, "load-awareness path must classify wrong-model as client 400")
+	assert.NotContains(t, err.Error(), "no available accounts")
+}
+
+func TestTkGroupUnsupportedModelCacheKey_AliasSpelling(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, tkGroupUnsupportedModelCacheKey(18, "gpt5.4-mini"), tkGroupUnsupportedModelCacheKey(18, "gpt-5.4-mini"))
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -540,8 +540,10 @@ func (s *OpenAIGatewayService) checkChannelPricingRestriction(ctx context.Contex
 	if groupID == nil || s.channelService == nil || requestedModel == "" {
 		return false
 	}
+	requestedModel = CanonicalizeOpenAICompatRoutingModel(requestedModel)
 	mapping := s.channelService.ResolveChannelMapping(ctx, *groupID, requestedModel)
 	billingModel := billingModelForRestriction(mapping.BillingModelSource, requestedModel, mapping.MappedModel)
+	billingModel = CanonicalizeOpenAICompatRoutingModel(billingModel)
 	if billingModel == "" {
 		return false
 	}
@@ -553,6 +555,10 @@ func (s *OpenAIGatewayService) isUpstreamModelRestrictedByChannel(ctx context.Co
 		return false
 	}
 	upstreamModel := resolveOpenAIAccountUpstreamModelForRequest(account, requestedModel, requireCompact)
+	if upstreamModel == "" {
+		return false
+	}
+	upstreamModel = CanonicalizeOpenAICompatRoutingModel(upstreamModel)
 	if upstreamModel == "" {
 		return false
 	}
@@ -1840,6 +1846,7 @@ func resolveOpenAIAccountUpstreamModelForRequest(account *Account, requestedMode
 }
 
 func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.Context, groupID *int64, sessionHash string, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool, stickyAccountID int64) (*Account, error) {
+	requestedModel = CanonicalizeOpenAICompatRoutingModel(requestedModel)
 	if err := s.tkGroupUnsupportedModelShortCircuit(groupID, requestedModel); err != nil {
 		return nil, err
 	}
@@ -2128,6 +2135,7 @@ func (s *OpenAIGatewayService) SelectAccountWithLoadAwareness(ctx context.Contex
 }
 
 func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Context, groupID *int64, sessionHash string, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool) (*AccountSelectionResult, error) {
+	requestedModel = CanonicalizeOpenAICompatRoutingModel(requestedModel)
 	if err := s.tkGroupUnsupportedModelShortCircuit(groupID, requestedModel); err != nil {
 		return nil, err
 	}
@@ -2338,7 +2346,12 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	}
 
 	if len(candidates) == 0 {
-		return nil, ErrNoAvailableAccounts
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, openAICompatNoCandidateError(requestedModel, groupPlatform, false, accounts, excludedIDs, &openAICompatNoCandidateEval{
+			ctx:            ctx,
+			svc:            s,
+			groupID:        groupID,
+			requireCompact: requireCompact,
+		}))
 	}
 
 	accountLoads := make([]AccountWithConcurrency, 0, len(candidates))

--- a/backend/internal/service/openai_model_alias.go
+++ b/backend/internal/service/openai_model_alias.go
@@ -14,6 +14,20 @@ func lastOpenAIModelSegment(model string) string {
 	return strings.TrimSpace(model)
 }
 
+// CanonicalizeOpenAICompatRoutingModel normalizes OpenAI-compat model ids for
+// account selection, channel restriction, and negative-cache keys. Wire spellings
+// such as gpt5.4-mini collapse to gpt-5.4-mini; non-OpenAI ids pass through trimmed.
+func CanonicalizeOpenAICompatRoutingModel(model string) string {
+	trimmed := strings.TrimSpace(model)
+	if trimmed == "" {
+		return ""
+	}
+	if canonical := canonicalizeOpenAIModelAliasSpelling(trimmed); canonical != "" {
+		return canonical
+	}
+	return trimmed
+}
+
 func canonicalizeOpenAIModelAliasSpelling(model string) string {
 	model = strings.ToLower(lastOpenAIModelSegment(model))
 	if model == "" {

--- a/backend/internal/service/openai_model_alias_test.go
+++ b/backend/internal/service/openai_model_alias_test.go
@@ -1,0 +1,30 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalizeOpenAICompatRoutingModel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"gpt5.4-mini", "gpt-5.4-mini"},
+		{" GPT-5.4-Mini ", "gpt-5.4-mini"},
+		{"gpt-5.4-mini", "gpt-5.4-mini"},
+		{"qwen-max", "qwen-max"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, CanonicalizeOpenAICompatRoutingModel(tc.in))
+		})
+	}
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2241,9 +2241,10 @@
     {
       "path": "backend/internal/handler/openai_chat_completions.go",
       "must_contain": [
-        "tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, reqModel)"
+        "tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, reqModel)",
+        "routingModel := service.CanonicalizeOpenAICompatRoutingModel(reqModel)"
       ],
-      "rationale": "/v1/chat/completions first-selection failure (len(failedAccountIDs)==0) must route through tkSelectFailureStatusMessage so an empty openai/newapi pool fast-fails 429 instead of 503 (PR #723, #575 parity; prod 2026-06-11: 480 empty-pool 503s in 2min when both GPT accounts hit upstream 429). Reverting this one-line hook to the upstream 503 literal compiles clean but re-exposes the Caddy passive-health melt + SDK retry storm the no_available_accounts_tk.go sentinel documents."
+      "rationale": "/v1/chat/completions first-selection failure (len(failedAccountIDs)==0) must route through tkSelectFailureStatusMessage so an empty openai/newapi pool fast-fails 429 instead of 503 (PR #723, #575 parity; prod 2026-06-11: 480 empty-pool 503s in 2min when both GPT accounts hit upstream 429). Account selection must use CanonicalizeOpenAICompatRoutingModel(routingModel) so gpt5.4-mini alias spellings hit the same restriction/negative-cache keys as gpt-5.4-mini (prod 2026-07 user16/key172). Reverting either hook compiles clean but re-exposes misclassification or alias drift."
     },
     {
       "path": "backend/internal/handler/openai_gateway_handler.go",
@@ -2274,7 +2275,7 @@
         "ErrUnsupportedModel",
         "func collectOpenAICompatSelectionFailureStats"
       ],
-      "rationale": "openAICompatNoCandidateError is the SHARED single exit for BOTH OpenAI-compat pool-emptied points (prod 2026-06-13): selectByLoadBalance len(filtered)==0 AND selectAccountForModelWithExclusions selectBestAccount→nil. When EVERY schedulable account was rejected purely because it does not serve the requested model NAME (account model_mapping OR per-account upstream channel restriction), it returns service.ErrUnsupportedModel (→ HTTP 400 invalid_request_error via tkSelectFailureStatusMessage) instead of an empty-pool 429 that reads as a capacity signal and fires ops alerts. tkOpenAICompatChannelPricingRestrictionError applies the same client-owned contract to group-level channel pricing allowlist rejects (prod 2026-07: Qwen-group direct key hammering gpt-5.4-mini). collectOpenAICompatSelectionFailureStatsForRequest counts passthrough accounts blocked only by isUpstreamModelRestrictedByChannel as model_unsupported; a model-supporting-but-filtered account stays Unschedulable so it SUPPRESSES the 400 (genuine capacity → keep 429)."
+      "rationale": "openAICompatNoCandidateError is the SHARED single exit for ALL THREE OpenAI-compat pool-emptied points (prod 2026-06-13 / 2026-07): selectByLoadBalance len(filtered)==0, selectAccountForModelWithExclusions selectBestAccount→nil, AND selectAccountWithLoadAwareness Layer-2 len(candidates)==0 (LoadBatchEnabled prod default). When EVERY schedulable account was rejected purely because it does not serve the requested model NAME (account model_mapping OR per-account upstream channel restriction), it returns service.ErrUnsupportedModel (→ HTTP 400 invalid_request_error via tkSelectFailureStatusMessage) instead of an empty-pool 429 that reads as a capacity signal and fires ops alerts. tkOpenAICompatChannelPricingRestrictionError applies the same client-owned contract to group-level channel pricing allowlist rejects (prod 2026-07: Qwen-group direct key hammering gpt-5.4-mini). collectOpenAICompatSelectionFailureStatsForRequest counts passthrough accounts blocked only by isUpstreamModelRestrictedByChannel as model_unsupported; a model-supporting-but-filtered account stays Unschedulable so it SUPPRESSES the 400 (genuine capacity → keep 429)."
     },
     {
       "path": "backend/internal/service/openai_account_scheduler.go",
@@ -2289,9 +2290,11 @@
       "path": "backend/internal/service/openai_gateway_service.go",
       "must_contain": [
         "tkOpenAICompatChannelPricingRestrictionError(requestedModel)",
-        "openAICompatNoCandidateEval"
+        "openAICompatNoCandidateEval",
+        "CanonicalizeOpenAICompatRoutingModel(requestedModel)",
+        "func (s *OpenAIGatewayService) selectAccountWithLoadAwareness"
       ],
-      "rationale": "selectAccountForModelWithExclusions (the priority/LRU path used by count_tokens + sticky/legacy callers) must route its selected==nil exit through the SAME openAICompatNoCandidateError as the load-balance scheduler, so an unservable model NAME surfaces ErrUnsupportedModel→400 on every OpenAI-compat surface, not just /v1/chat/completions (prod 2026-06-13 parity). Reverting to the bare noAvailableOpenAISelectionError compiles clean but re-buries unservable-model as empty-pool 429 on these surfaces and makes the handler's ErrUnsupportedModel→400 mapping dead code there."
+      "rationale": "selectAccountForModelWithExclusions AND selectAccountWithLoadAwareness (LoadBatch Layer-2 len(candidates)==0, prod default) must route pool-emptied-by-unservable-model exits through openAICompatNoCandidateError, canonicalize model spellings at selection entry, and surface ErrUnsupportedModel→400 on every OpenAI-compat surface — not just scheduler selectByLoadBalance (prod 2026-07: Qwen direct key gpt5.4-mini still hit routing/platform 429 when LoadBatch path returned bare ErrNoAvailableAccounts). Reverting either hook compiles clean but re-buries unservable-model as empty-pool 429."
     },
     {
       "path": "backend/internal/service/gateway_service.go",
@@ -2311,6 +2314,7 @@
       "path": "backend/internal/service/openai_account_scheduler_tk_errors_test.go",
       "must_contain": [
         "TestSelectAccountWithScheduler_QwenGroupWrongModelReturnsUnsupported",
+        "TestSelectAccountWithLoadAwareness_QwenGroupWrongModelAliasReturnsUnsupported",
         "collectOpenAICompatSelectionFailureStatsForRequest"
       ],
       "rationale": "Regression coverage for prod 2026-07 wrong-key/wrong-group model requests: upstream channel restriction on passthrough accounts and Qwen-only groups must surface ErrUnsupportedModel instead of routing/platform 429."
@@ -2321,6 +2325,7 @@
         "type tkGroupUnsupportedModelNegativeCache",
         "func tkGroupUnsupportedModelShortCircuit",
         "func tkGroupUnsupportedModelRecordErr",
+        "CanonicalizeOpenAICompatRoutingModel",
         "tk_group_unsupported_negative_cache_hit",
         "tk_group_unsupported_negative_cache_populate",
         "SetTkGroupUnsupportedModelCache",
@@ -2332,7 +2337,8 @@
       "path": "backend/internal/service/gateway_service_tk_group_unsupported_cache_test.go",
       "must_contain": [
         "TestSelectAccountWithScheduler_CacheHitShortCircuits",
-        "TestChannelInvalidateCache_FlushesGroupUnsupportedCache"
+        "TestChannelInvalidateCache_FlushesGroupUnsupportedCache",
+        "gpt5.4-mini"
       ],
       "rationale": "Regression: cache hit must short-circuit OpenAI-compat scheduler; channel CRUD invalidation must flush stale group×model verdicts."
     },
@@ -2348,9 +2354,26 @@
       "path": "backend/internal/service/openai_account_scheduler.go",
       "must_contain": [
         "tkGroupUnsupportedModelShortCircuit",
-        "tkGroupUnsupportedModelRecordErr"
+        "tkGroupUnsupportedModelRecordErr",
+        "CanonicalizeOpenAICompatRoutingModel(requestedModel)"
       ],
-      "rationale": "OpenAI-compat scheduler Select and selectAccountWithScheduler must consult/populate the shared group unsupported negative cache at the same entry points as channel pricing restriction."
+      "rationale": "OpenAI-compat scheduler Select and selectAccountWithScheduler must consult/populate the shared group unsupported negative cache at the same entry points as channel pricing restriction, and canonicalize requested model spellings before cache/restriction lookups."
+    },
+    {
+      "path": "backend/internal/service/openai_model_alias.go",
+      "must_contain": [
+        "func CanonicalizeOpenAICompatRoutingModel(",
+        "canonicalizeOpenAIModelAliasSpelling"
+      ],
+      "rationale": "Single source for OpenAI-compat routing model spellings (gpt5.4-mini→gpt-5.4-mini) shared by account selection, channel restriction, negative cache, and /v1/chat/completions routingModel. Upstream merges dropping alias canonicalization silently re-open prod misclassification when clients use hyphenless model ids."
+    },
+    {
+      "path": "backend/internal/service/openai_model_alias_test.go",
+      "must_contain": [
+        "TestCanonicalizeOpenAICompatRoutingModel",
+        "gpt5.4-mini"
+      ],
+      "rationale": "Regression: hyphenless gpt5.4-mini wire spelling must canonicalize to gpt-5.4-mini for routing/restriction/cache parity."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_model_cooldown.go",


### PR DESCRIPTION
## 摘要

- 修复 prod 上 user 16 / api_key 172（Qwen/newapi 组）持续请求 `gpt5.4-mini` 仍落成 **routing/platform/429** `No available accounts` 的问题：#1159 已覆盖 scheduler/legacy 路径，但 **`selectAccountWithLoadAwareness` Layer 2** 在 upstream 渠道过滤清空候选池后仍返回裸 `ErrNoAvailableAccounts`。
- 该出口改走 `openAICompatNoCandidateError` → `ErrUnsupportedModel` → handler **400 invalid_request_error / error_owner=client**。
- 新增 `CanonicalizeOpenAICompatRoutingModel`，统一 `gpt5.4-mini` ↔ `gpt-5.4-mini` 在选号、渠道限制、negative cache 上的口径。
- universal passthrough gemini 误路由已在 #1168 独立合并；本 PR 仅保留 load-awareness 错模型 400 分类。

## 风险

- 常规风险：仅影响账号选号失败时的错误分类；真正空池/满载仍保留 429。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service/... ./internal/handler/... -count=1
./scripts/preflight.sh
```

新增/扩展回归：
- `TestSelectAccountWithLoadAwareness_QwenGroupWrongModelAliasReturnsUnsupported`（`gpt5.4-mini` + LoadBatch + upstream 渠道）
- `TestCanonicalizeOpenAICompatRoutingModel`
- negative cache alias 命中测试

## 提交

- 54d67d02f fix(gateway): classify wrong-model load-awareness failures as client 400
- f1a834052 chore(sentinels): anchor load-awareness wrong-model 400 classification

最新提交：f1a834052
