### PR TITLE
fix(routing): universal gemini /v1/messages 不再误路由到 Codex passthrough

### DIFF
--- a/backend/internal/service/account_openai_passthrough_test.go
+++ b/backend/internal/service/account_openai_passthrough_test.go
@@ -54,7 +54,7 @@ func TestGatewayService_IsModelSupportedByAccount_OpenAIPassthroughRejectsForeig
 	passthrough := &Account{
 		Platform: PlatformOpenAI,
 		Type:     AccountTypeOAuth,
-		Extra:    map[string]any{
+		Extra: map[string]any{
 			"openai_passthrough": true,
 		},
 	}
@@ -66,7 +66,7 @@ func TestGatewayService_IsModelSupportedByAccount_OpenAIPassthroughRejectsForeig
 	mappedPassthrough := &Account{
 		Platform: PlatformOpenAI,
 		Type:     AccountTypeOAuth,
-		Extra:    map[string]any{
+		Extra: map[string]any{
 			"openai_passthrough": true,
 		},
 		Credentials: map[string]any{

--- a/backend/internal/service/account_openai_passthrough_test.go
+++ b/backend/internal/service/account_openai_passthrough_test.go
@@ -49,6 +49,34 @@ func TestAccount_IsOpenAIPassthroughEnabled(t *testing.T) {
 	})
 }
 
+func TestGatewayService_IsModelSupportedByAccount_OpenAIPassthroughRejectsForeignPlatformModels(t *testing.T) {
+	svc := &GatewayService{}
+	passthrough := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra:    map[string]any{
+			"openai_passthrough": true,
+		},
+	}
+	require.False(t, svc.isModelSupportedByAccount(passthrough, "gemini-2.5-flash"))
+	require.False(t, svc.isModelSupportedByAccount(passthrough, "claude-sonnet-4-6"))
+	require.True(t, svc.isModelSupportedByAccount(passthrough, "gpt-5.4-mini"))
+	require.True(t, svc.isModelSupportedByAccount(passthrough, "o3-mini"))
+
+	mappedPassthrough := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra:    map[string]any{
+			"openai_passthrough": true,
+		},
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"gpt-5.5": "gpt-5.5"},
+		},
+	}
+	require.False(t, svc.isModelSupportedByAccount(mappedPassthrough, "gpt-5.4-mini"))
+	require.True(t, svc.isModelSupportedByAccount(mappedPassthrough, "gpt5.5"))
+}
+
 func TestAccount_OpenAICompatModelAliasSupport(t *testing.T) {
 	account := &Account{
 		Platform: PlatformOpenAI,

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4014,8 +4014,16 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 		_, ok := ResolveBedrockModelID(account, requestedModel)
 		return ok
 	}
-	// OpenAI 透传模式：仅替换认证，允许所有模型
+	// OpenAI 透传模式：仅替换认证。空 mapping 时允许 openai-hint 模型；有 mapping 时
+	// 仍以 mapping 为准（与 IsModelSupported 一致）。非 openai-hint 模型不得因 passthrough
+	// 被 universal 路由误投到 Codex（1.8.74 prod smoke: gemini-2.5-flash @/v1/messages）。
 	if account.Platform == PlatformOpenAI && account.IsOpenAIPassthroughEnabled() {
+		if len(account.GetModelMapping()) > 0 {
+			return account.IsModelSupported(requestedModel)
+		}
+		if hint := universalModelPlatformHint(requestedModel); hint != "" && hint != PlatformOpenAI {
+			return false
+		}
 		return true
 	}
 	// OAuth/SetupToken 账号使用 Anthropic 标准映射（短ID → 长ID）

--- a/backend/internal/service/universal_routing_tk_endpoint_map.go
+++ b/backend/internal/service/universal_routing_tk_endpoint_map.go
@@ -84,6 +84,11 @@ func universalCandidatePlatforms(shape UniversalShape, forcedPlatform string, ha
 	switch shape {
 	case ShapeAnthropicMessages:
 		out := []string{PlatformAnthropic, PlatformAntigravity}
+		// Gemini /v1/messages (Anthropic-shaped bridge + tools) must reach gemini or
+		// antigravity pools — not openai-compat Codex passthrough.
+		if universalModelPlatformHint(model) == PlatformGemini {
+			out = append(out, PlatformGemini)
+		}
 		if hasMessagesDispatch {
 			out = append(out, OpenAICompatPlatforms()...)
 		}

--- a/backend/internal/service/universal_routing_tk_resolver_test.go
+++ b/backend/internal/service/universal_routing_tk_resolver_test.go
@@ -104,6 +104,10 @@ func TestUniversalCandidatePlatforms(t *testing.T) {
 	if !contains(withDispatch, PlatformOpenAI) {
 		t.Errorf("messages with dispatch should include openai-compat: %v", withDispatch)
 	}
+	gemMessages := universalCandidatePlatforms(ShapeAnthropicMessages, "", true, "gemini-2.5-flash")
+	if !contains(gemMessages, PlatformGemini) {
+		t.Errorf("gemini /v1/messages should include gemini platform: %v", gemMessages)
+	}
 
 	// count_tokens uses the same group-platform split handler as direct keys, so
 	// universal keys may route OpenAI-compatible models to the compat bridge.

--- a/backend/internal/service/universal_routing_tk_serving.go
+++ b/backend/internal/service/universal_routing_tk_serving.go
@@ -55,7 +55,7 @@ func (s *GatewayService) UniversalGroupSupportsModel(ctx context.Context, groupI
 			if !acc.IsOpenAICompatPoolMember(platform) {
 				continue
 			}
-			if acc.IsModelSupported(model) || (acc.Platform == PlatformGrok && grokGroupServesNativeCatalogModel(model)) {
+			if s.isModelSupportedByAccount(acc, model) || (acc.Platform == PlatformGrok && grokGroupServesNativeCatalogModel(model)) {
 				return true, true
 			}
 			continue

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -124,6 +124,27 @@ func TestUniversalGroupSupportsModel_OpenAICompatMatchesDirectScheduler(t *testi
 	}
 }
 
+func TestUniversalGroupSupportsModel_OpenAIPassthroughRejectsGemini(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(2)
+	svc := &GatewayService{
+		accountRepo: stubOpenAIAccountRepo{accounts: []Account{{
+			ID:       1,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Extra:    map[string]any{"openai_passthrough": true},
+		}}},
+	}
+	serves, known := svc.UniversalGroupSupportsModel(ctx, &groupID, PlatformOpenAI, "gemini-2.5-flash")
+	if !known || serves {
+		t.Fatalf("openai passthrough must not claim gemini models, got serves=%v known=%v", serves, known)
+	}
+	serves, known = svc.UniversalGroupSupportsModel(ctx, &groupID, PlatformOpenAI, "gpt-5.4-mini")
+	if !known || !serves {
+		t.Fatalf("openai passthrough should still claim gpt models, got serves=%v known=%v", serves, known)
+	}
+}
+
 func TestUniversalGroupSupportsModel_NewapiRequiresCompatPoolMember(t *testing.T) {
 	ctx := context.Background()
 	groupID := int64(18)
@@ -228,6 +249,44 @@ func TestResolve_NativeEmptyMappingDoesNotMatchOtherVendor(t *testing.T) {
 	g, err = r.Resolve(ctx, key, ShapeOpenAIChat, "gpt-5", "")
 	if err != nil || g == nil || g.ID != 2 {
 		t.Fatalf("gpt-5 应落 openai gid=2, got=%v err=%v", g, err)
+	}
+}
+
+// 1.8.74 prod smoke: /v1/messages + gemini-2.5-flash (tools) 经 universal key 必须落
+// antigravity/gemini,不能因 openai passthrough 的「全模型 true」在 tiebreak 里胜过
+// antigravity 并打到 Codex（"not supported when using Codex with a ChatGPT account"）。
+func TestResolve_GeminiMessagesAnthropicShapeAvoidsOpenAIPassthrough(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		dispatchGrp(2, PlatformOpenAI, 5, true), // Codex passthrough + messages dispatch
+		grp(9, PlatformAntigravity, 10, false),
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		9: {"gemini-2.5-flash", "claude-sonnet-4-6"},
+	}))
+	svc := &GatewayService{
+		accountRepo: stubOpenAIAccountRepo{accounts: []Account{
+			{
+				ID:       100,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Extra:    map[string]any{"openai_passthrough": true},
+			},
+			{
+				ID:       101,
+				Platform: PlatformAntigravity,
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{"gemini-2.5-flash": "gemini-2.5-flash"},
+				},
+			},
+		}},
+	}
+	r.SetModelSupportProvider(svc.UniversalGroupSupportsModel)
+
+	g, err := r.Resolve(ctx, universalKey(1), ShapeAnthropicMessages, "gemini-2.5-flash", "")
+	if err != nil || g == nil || g.ID != 9 {
+		t.Fatalf("gemini @/v1/messages 应落 antigravity gid=9, got=%v err=%v", g, err)
 	}
 }
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3038,6 +3038,14 @@
       "rationale": "TK fix (PR #806): the injection point in isModelSupportedByAccount that routes a cross-vendor model name on a passthrough (empty model_mapping) anthropic direct account to the local Path A 400 instead of forwarding it to api.anthropic.com. Pinning the full guard expression also anchors the passthrough-only scope (len(GetModelMapping())==0) so a refactor cannot silently widen it to over-block mapped accounts or narrow it to re-open the leak. Pairs with the predicate sentinel on gateway_service_tk_unsupported_model.go."
     },
     {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "account.IsOpenAIPassthroughEnabled()",
+        "universalModelPlatformHint(requestedModel); hint != \"\" && hint != PlatformOpenAI"
+      ],
+      "rationale": "TK fix (1.8.74 prod smoke): OpenAI passthrough empty mapping must not make UniversalGroupSupportsModel claim foreign-hint models (gemini/claude/newapi) on the openai-compat pool — that misroutes universal /v1/messages to Codex. Pins the passthrough branch foreign-hint rejection alongside mapped-account IsModelSupported fallback."
+    },
+    {
       "path": "backend/internal/service/ratelimit_service_tk_pool_exhausted.go",
       "must_contain": [
         "func tkPoolExhaustedEnabled(platform string) bool {",
@@ -3414,7 +3422,7 @@
         "func (s *GatewayService) UniversalGroupSupportsModel(",
         "s.listSchedulableAccounts(ctx, groupID, platform, false)",
         "acc.IsOpenAICompatPoolMember(platform)",
-        "acc.IsModelSupported(model)",
+        "s.isModelSupportedByAccount(acc, model)",
         "s.isModelSupportedByAccountWithContext(ctx, acc, model)",
         "modelInServedSet(model string, served []string, platform string)",
         "normalizeRequestedModelForLookup(platform, model)"
@@ -3436,6 +3444,8 @@
         "TestResolve_UsesDirectSchedulerModelSupportBeforeServedSet",
         "TestResolve_ModelSupportProviderUnknownFallsBackToServedSet",
         "TestUniversalGroupSupportsModel_OpenAICompatMatchesDirectScheduler",
+        "TestUniversalGroupSupportsModel_OpenAIPassthroughRejectsGemini",
+        "TestResolve_GeminiMessagesAnthropicShapeAvoidsOpenAIPassthrough",
         "TestUniversalGroupSupportsModel_NewapiRequiresCompatPoolMember",
         "TestModelInServedSet_UsesDirectMappingAliases",
         "TestResolve_User16GPTAliasPicksOpenAIGroup"
@@ -3446,6 +3456,7 @@
       "path": "backend/internal/service/account_openai_passthrough_test.go",
       "must_contain": [
         "TestAccount_OpenAICompatModelAliasSupport",
+        "TestGatewayService_IsModelSupportedByAccount_OpenAIPassthroughRejectsForeignPlatformModels",
         "gpt5.4-mini",
         "openai/gpt 5.4mini"
       ],
@@ -3458,6 +3469,7 @@
         "func universalCandidatePlatforms(",
         "out := OpenAICompatPlatforms()",
         "antigravity.IsImageModel(model)",
+        "universalModelPlatformHint(model) == PlatformGemini",
         "engine.CapabilityForEndpoint(bridgeEndpoint)",
         "func universalModelPlatformHint("
       ],


### PR DESCRIPTION
## 摘要

- 修复 1.8.74 prod deploy smoke 回归：universal key 请求 `gemini-2.5-flash`（`/v1/messages` + tools）被误路由到 OpenAI Codex passthrough 组，上游返回「not supported when using Codex with a ChatGPT account」。
- 根因是 #1161 的 `UniversalGroupSupportsModel` 对 OpenAI passthrough 空 mapping 账号沿用 `IsModelSupported`（任意模型均 true），在 tiebreak 中胜过 antigravity。
- 修复：`isModelSupportedByAccount` 对 OpenAI passthrough 拒绝 foreign platform hint；compat 路径改走 direct scheduler 同口径；`/v1/messages` 在 gemini hint 时追加 `PlatformGemini` 候选；同步 gateway TK sentinel 锚点。

## 风险

- 常规风险，范围限于 universal 路由与 OpenAI passthrough 模型支持判定；Anthropic 侧已有独立 cross-vendor 守卫，无需 parallel fix。
- OpenAI passthrough 仍允许 openai-hint 模型（gpt/o 系列等）；有显式 mapping 的账号行为不变。

## 验证

- preflight 全绿（含 gateway TK sentinel registry）
- `go test -tags=unit ./internal/service -run 'TestResolve_GeminiMessagesAnthropicShapeAvoidsOpenAIPassthrough|TestUniversalGroupSupportsModel_OpenAIPassthrough|TestGatewayService_IsModelSupportedByAccount_OpenAIPassthrough|TestUniversalGroupSupportsModel_OpenAICompat|TestUniversalCandidatePlatforms' -count=1` → ok

## 提交

- dbab844fa fix(routing): stop OpenAI passthrough from stealing universal gemini /v1/messages

最新提交：dbab844fa
