### PR TITLE
feat(ops): P0 规则告警配对飞书恢复绿卡

### DIFF
--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -349,6 +349,12 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 				logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] resolve event failed (event=%d): %v", activeEvent.ID, err)
 			} else {
 				eventsResolved++
+				resolvedEvent := *activeEvent
+				resolvedEvent.Status = OpsAlertStatusResolved
+				resolvedEvent.ResolvedAt = &resolvedAt
+				if s.maybeSendAlertFeishuRecovery(ctx, runtimeCfg, rule, &resolvedEvent, metricValue) {
+					feishuSent++
+				}
 			}
 		}
 	}

--- a/backend/internal/service/ops_alert_notifications_tk_feishu.go
+++ b/backend/internal/service/ops_alert_notifications_tk_feishu.go
@@ -21,13 +21,17 @@ type opsFeishuNotificationState struct {
 	limiter  *slidingWindowLimiter
 	notifier *opsFeishuNotifier
 	sentAt   map[string]time.Time
+	// firedFeishuEventIDs records alert events whose P0 firing card was actually
+	// delivered, so auto-resolve can send a paired green recovery card.
+	firedFeishuEventIDs map[int64]struct{}
 }
 
 func newOpsFeishuNotificationState() *opsFeishuNotificationState {
 	return &opsFeishuNotificationState{
-		limiter:  newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour),
-		notifier: newOpsFeishuNotifier(),
-		sentAt:   map[string]time.Time{},
+		limiter:             newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour),
+		notifier:            newOpsFeishuNotifier(),
+		sentAt:              map[string]time.Time{},
+		firedFeishuEventIDs: map[int64]struct{}{},
 	}
 }
 
@@ -124,6 +128,54 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertFeishu(ctx context.Context, run
 		return false
 	}
 	state.markSent(rule, event)
+	state.markFiringDelivered(event)
+	return true
+}
+
+func (s *OpsAlertEvaluatorService) maybeSendAlertFeishuRecovery(ctx context.Context, runtimeCfg *OpsAlertRuntimeSettings, rule *OpsAlertRule, event *OpsAlertEvent, currentMetricValue float64) bool {
+	if s == nil || s.opsService == nil || rule == nil || event == nil {
+		return false
+	}
+	if s.isEdgeNode() && isEdgeSuppressedAlertRule(rule) {
+		return false
+	}
+	if !shouldSendOpsAlertFeishuRecovery(rule, event) {
+		return false
+	}
+	cfg, err := s.opsService.GetEmailNotificationConfig(ctx)
+	if err != nil || cfg == nil || !cfg.Feishu.Enabled {
+		return false
+	}
+	if strings.TrimSpace(cfg.Feishu.WebhookURL) == "" {
+		return false
+	}
+	if runtimeCfg != nil && runtimeCfg.Silencing.Enabled {
+		if isOpsAlertSilenced(time.Now().UTC(), rule, event, runtimeCfg.Silencing) {
+			return false
+		}
+	}
+	state := s.feishuState
+	if state == nil {
+		state = newOpsFeishuNotificationState()
+		s.feishuState = state
+	}
+	if !state.shouldSendRecovery(rule, event) {
+		return false
+	}
+	notifier := state.notifier
+	if notifier == nil {
+		notifier = newOpsFeishuNotifier()
+	}
+	frontendURL := ""
+	if s.cfg != nil {
+		frontendURL = s.cfg.Server.FrontendURL
+	}
+	current := currentMetricValue
+	if err := notifier.sendRecovery(ctx, cfg.Feishu, frontendURL, rule, event, &current); err != nil {
+		logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] feishu recovery send failed event_id=%d rule_id=%d error=%s", event.ID, rule.ID, err.Error())
+		return false
+	}
+	state.markRecoverySent(rule, event)
 	return true
 }
 
@@ -131,6 +183,19 @@ func shouldSendOpsAlertToFeishu(rule *OpsAlertRule, event *OpsAlertEvent) bool {
 	return rule != nil && event != nil &&
 		strings.EqualFold(strings.TrimSpace(event.Status), OpsAlertStatusFiring) &&
 		strings.EqualFold(strings.TrimSpace(rule.Severity), "P0") &&
+		strings.EqualFold(strings.TrimSpace(event.Severity), "P0") &&
+		rule.NotifyEmail
+}
+
+func shouldSendOpsAlertFeishuRecovery(rule *OpsAlertRule, event *OpsAlertEvent) bool {
+	if rule == nil || event == nil {
+		return false
+	}
+	status := strings.TrimSpace(event.Status)
+	if !strings.EqualFold(status, OpsAlertStatusResolved) && !strings.EqualFold(status, OpsAlertStatusManualResolved) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(rule.Severity), "P0") &&
 		strings.EqualFold(strings.TrimSpace(event.Severity), "P0") &&
 		rule.NotifyEmail
 }
@@ -171,6 +236,53 @@ func (s *opsFeishuNotificationState) markSent(rule *OpsAlertRule, event *OpsAler
 	s.sentAt[opsFeishuDedupeKey(rule, event)] = time.Now().UTC()
 }
 
+func (s *opsFeishuNotificationState) markFiringDelivered(event *OpsAlertEvent) {
+	if s == nil || event == nil || event.ID <= 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.firedFeishuEventIDs == nil {
+		s.firedFeishuEventIDs = map[int64]struct{}{}
+	}
+	s.firedFeishuEventIDs[event.ID] = struct{}{}
+}
+
+func (s *opsFeishuNotificationState) shouldSendRecovery(rule *OpsAlertRule, event *OpsAlertEvent) bool {
+	if s == nil || rule == nil || event == nil || event.ID <= 0 {
+		return false
+	}
+	s.mu.Lock()
+	_, paired := s.firedFeishuEventIDs[event.ID]
+	if !paired {
+		s.mu.Unlock()
+		return false
+	}
+	key := opsFeishuRecoveryDedupeKey(rule, event)
+	_, seen := s.sentAt[key]
+	s.mu.Unlock()
+	if seen {
+		return false
+	}
+	if s.limiter == nil {
+		s.limiter = newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour)
+	}
+	return s.limiter.Allow(time.Now().UTC())
+}
+
+func (s *opsFeishuNotificationState) markRecoverySent(rule *OpsAlertRule, event *OpsAlertEvent) {
+	if s == nil || rule == nil || event == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sentAt == nil {
+		s.sentAt = map[string]time.Time{}
+	}
+	s.sentAt[opsFeishuRecoveryDedupeKey(rule, event)] = time.Now().UTC()
+	delete(s.firedFeishuEventIDs, event.ID)
+}
+
 func opsFeishuDedupeKey(rule *OpsAlertRule, event *OpsAlertEvent) string {
 	if rule == nil || event == nil {
 		return ""
@@ -189,4 +301,11 @@ func opsFeishuDedupeKey(rule *OpsAlertRule, event *OpsAlertEvent) string {
 		parts = append(parts, fmt.Sprintf("%s:%v", k, event.Dimensions[k]))
 	}
 	return strings.Join(parts, "|")
+}
+
+func opsFeishuRecoveryDedupeKey(rule *OpsAlertRule, event *OpsAlertEvent) string {
+	if rule == nil || event == nil {
+		return ""
+	}
+	return fmt.Sprintf("recovery:event:%d|rule:%d", event.ID, rule.ID)
 }

--- a/backend/internal/service/ops_feishu_alerts_tk_test.go
+++ b/backend/internal/service/ops_feishu_alerts_tk_test.go
@@ -302,6 +302,10 @@ func TestOpsFeishuNotifierBuildsRecoveryPayload(t *testing.T) {
 	event.ResolvedAt = &resolvedAt
 	event.FiredAt = firedAt
 	current := 0.0
+	event.Dimensions = map[string]any{
+		"top_cause":       `newapi ×128（#16 "Agent-陈乐晗-qwen" ×128）`,
+		"top_cause_models": "gpt5.4-mini ×128",
+	}
 
 	payload, err := notifier.buildRecoveryPayload(OpsFeishuAlertConfig{}, "https://api.tokenkey.dev", testOpsFeishuRule(), event, &current)
 	require.NoError(t, err)
@@ -314,6 +318,10 @@ func TestOpsFeishuNotifierBuildsRecoveryPayload(t *testing.T) {
 	require.Contains(t, text, "**当前值**")
 	require.Contains(t, text, "**持续时长**")
 	require.Contains(t, text, "1分")
+	require.Contains(t, text, "**主因**")
+	require.Contains(t, text, "newapi ×128")
+	require.Contains(t, text, "**模型**")
+	require.Contains(t, text, "gpt5.4-mini ×128")
 }
 
 func TestMaybeSendAlertFeishuRecoverySendsPairedGreenCard(t *testing.T) {

--- a/backend/internal/service/ops_feishu_alerts_tk_test.go
+++ b/backend/internal/service/ops_feishu_alerts_tk_test.go
@@ -234,7 +234,7 @@ func TestMaybeSendAlertFeishuP0Only(t *testing.T) {
 			},
 		},
 		{
-			name: "resolved event never sends",
+			name: "resolved event does not send firing card",
 			mutate: func(rule *OpsAlertRule, event *OpsAlertEvent) {
 				event.Status = OpsAlertStatusResolved
 			},
@@ -290,6 +290,73 @@ func TestMaybeSendAlertFeishuRateLimitsAcrossDistinctDimensions(t *testing.T) {
 	require.Equal(t, 1, doer.calls)
 }
 
+func TestOpsFeishuNotifierBuildsRecoveryPayload(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1700000060, 0).UTC()
+	firedAt := time.Unix(1700000000, 0).UTC()
+	resolvedAt := now
+	notifier := &opsFeishuNotifier{now: func() time.Time { return now }}
+	event := testOpsFeishuEvent(42)
+	event.Status = OpsAlertStatusResolved
+	event.ResolvedAt = &resolvedAt
+	event.FiredAt = firedAt
+	current := 0.0
+
+	payload, err := notifier.buildRecoveryPayload(OpsFeishuAlertConfig{}, "https://api.tokenkey.dev", testOpsFeishuRule(), event, &current)
+	require.NoError(t, err)
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	text := string(body)
+	require.Contains(t, text, "TokenKey P0 告警已恢复 · prod")
+	require.Contains(t, text, "green")
+	require.Contains(t, text, "**触发值**")
+	require.Contains(t, text, "**当前值**")
+	require.Contains(t, text, "**持续时长**")
+	require.Contains(t, text, "1分")
+}
+
+func TestMaybeSendAlertFeishuRecoverySendsPairedGreenCard(t *testing.T) {
+	t.Parallel()
+
+	doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+	svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 3, CooldownSeconds: 3600}, doer)
+	rule := testOpsFeishuRule()
+	firing := testOpsFeishuEvent(99)
+
+	require.True(t, svc.maybeSendAlertFeishu(context.Background(), nil, rule, firing))
+	require.Equal(t, 1, doer.calls)
+	require.Contains(t, doer.bodies[0], "TokenKey P0 告警")
+
+	resolvedAt := firing.FiredAt.Add(time.Minute)
+	resolved := *firing
+	resolved.Status = OpsAlertStatusResolved
+	resolved.ResolvedAt = &resolvedAt
+
+	require.True(t, svc.maybeSendAlertFeishuRecovery(context.Background(), nil, rule, &resolved, 0))
+	require.Equal(t, 2, doer.calls)
+	require.Contains(t, doer.bodies[1], "TokenKey P0 告警已恢复")
+	require.Contains(t, doer.bodies[1], "green")
+
+	require.False(t, svc.maybeSendAlertFeishuRecovery(context.Background(), nil, rule, &resolved, 0))
+	require.Equal(t, 2, doer.calls, "recovery must dedupe per event")
+}
+
+func TestMaybeSendAlertFeishuRecoverySkipsWithoutPriorFiringCard(t *testing.T) {
+	t.Parallel()
+
+	doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+	svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 3, CooldownSeconds: 3600}, doer)
+	rule := testOpsFeishuRule()
+	resolvedAt := time.Unix(1700000060, 0).UTC()
+	resolved := testOpsFeishuEvent(7)
+	resolved.Status = OpsAlertStatusResolved
+	resolved.ResolvedAt = &resolvedAt
+
+	require.False(t, svc.maybeSendAlertFeishuRecovery(context.Background(), nil, rule, resolved, 0))
+	require.Equal(t, 0, doer.calls)
+}
+
 func TestMaybeSendAlertFeishuFailureDoesNotMarkCooldown(t *testing.T) {
 	t.Parallel()
 
@@ -318,9 +385,10 @@ func newOpsFeishuAlertEvaluatorForTest(t *testing.T, feishu OpsFeishuAlertConfig
 	return &OpsAlertEvaluatorService{
 		opsService: &OpsService{settingRepo: repo},
 		feishuState: &opsFeishuNotificationState{
-			limiter:  newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour),
-			notifier: &opsFeishuNotifier{httpClient: doer},
-			sentAt:   map[string]time.Time{},
+			limiter:             newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour),
+			notifier:            &opsFeishuNotifier{httpClient: doer},
+			sentAt:              map[string]time.Time{},
+			firedFeishuEventIDs: map[int64]struct{}{},
 		},
 	}
 }

--- a/backend/internal/service/ops_feishu_notifier_tk.go
+++ b/backend/internal/service/ops_feishu_notifier_tk.go
@@ -85,6 +85,17 @@ func (n *opsFeishuNotifier) sendAlert(ctx context.Context, cfg OpsFeishuAlertCon
 	return sendFeishuPayload(ctx, n.httpClient, cfg, payload)
 }
 
+func (n *opsFeishuNotifier) sendRecovery(ctx context.Context, cfg OpsFeishuAlertConfig, frontendURL string, rule *OpsAlertRule, event *OpsAlertEvent, currentMetricValue *float64) error {
+	if n == nil {
+		n = newOpsFeishuNotifier()
+	}
+	payload, err := n.buildRecoveryPayload(cfg, frontendURL, rule, event, currentMetricValue)
+	if err != nil {
+		return err
+	}
+	return sendFeishuPayload(ctx, n.httpClient, cfg, payload)
+}
+
 // feishuCardPayload builds the interactive-card envelope (header template/title
 // + lark_md body) and signs it when a secret is configured. Both the ops alert
 // path (buildPayload) and the account-incident path reuse it so the card shape +
@@ -180,6 +191,23 @@ func (n *opsFeishuNotifier) buildPayload(cfg OpsFeishuAlertConfig, frontendURL s
 	return feishuCardPayload(cfg, now, "red", title, text), nil
 }
 
+func (n *opsFeishuNotifier) buildRecoveryPayload(cfg OpsFeishuAlertConfig, frontendURL string, rule *OpsAlertRule, event *OpsAlertEvent, currentMetricValue *float64) (map[string]any, error) {
+	if rule == nil || event == nil {
+		return nil, errors.New("missing alert context")
+	}
+	nodeLabel, dashboardURL := deriveOpsNodeIdentity(frontendURL)
+	text := buildOpsFeishuRecoveryText(rule, event, nodeLabel, dashboardURL, currentMetricValue)
+	now := time.Now
+	if n != nil && n.now != nil {
+		now = n.currentTime
+	}
+	title := "TokenKey P0 告警已恢复"
+	if nodeLabel != "" && nodeLabel != "overall" {
+		title = title + " · " + nodeLabel
+	}
+	return feishuCardPayload(cfg, now, "green", title, text), nil
+}
+
 func (n *opsFeishuNotifier) currentTime() time.Time {
 	if n != nil && n.now != nil {
 		return n.now()
@@ -250,6 +278,62 @@ func buildOpsFeishuAlertText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLabel
 		topCauseLine,
 		escapeFeishuText(formatAlertTime(event.FiredAt)),
 		advice,
+	)
+}
+
+func buildOpsFeishuRecoveryText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLabel, dashboardURL string, currentMetricValue *float64) string {
+	metricValue := "-"
+	thresholdValue := fmt.Sprintf("%.2f", rule.Threshold)
+	if event.MetricValue != nil {
+		metricValue = fmt.Sprintf("%.2f", *event.MetricValue)
+	}
+	if event.ThresholdValue != nil {
+		thresholdValue = fmt.Sprintf("%.2f", *event.ThresholdValue)
+	}
+	currentValue := "-"
+	if currentMetricValue != nil {
+		currentValue = fmt.Sprintf("%.2f", *currentMetricValue)
+	}
+	dimensions := formatOpsFeishuDimensions(event.Dimensions)
+	if dimensions == "" {
+		dimensions = "overall"
+	}
+	if strings.TrimSpace(nodeLabel) == "" {
+		nodeLabel = "overall"
+	}
+	durationText := "未知"
+	resolvedAt := time.Time{}
+	if event.ResolvedAt != nil {
+		resolvedAt = event.ResolvedAt.UTC()
+	}
+	if !event.FiredAt.IsZero() && !resolvedAt.IsZero() {
+		d := resolvedAt.Sub(event.FiredAt.UTC())
+		if d < 0 {
+			d = 0
+		}
+		durationText = formatPoolOutageDuration(d)
+	}
+	resolvedTimeText := "-"
+	if !resolvedAt.IsZero() {
+		resolvedTimeText = formatAlertTime(resolvedAt)
+	}
+	note := "指标已回落到阈值以下，告警自动解除。建议确认根因是否已消除，避免复发。"
+	if strings.TrimSpace(dashboardURL) != "" {
+		note = fmt.Sprintf("[打开 Ops Dashboard](%s) 复核指标与账号可用性。指标已回落到阈值以下，告警自动解除。", dashboardURL)
+	}
+	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**触发值**：%s\n**当前值**：%s\n**范围**：%s\n**持续时长**：%s\n**触发时间**：%s\n**恢复时间**：%s\n\n**说明**：%s",
+		escapeFeishuText(nodeLabel),
+		escapeFeishuText(strings.TrimSpace(rule.Name)),
+		escapeFeishuText(strings.TrimSpace(rule.MetricType)),
+		escapeFeishuText(strings.TrimSpace(rule.Operator)),
+		escapeFeishuText(thresholdValue),
+		escapeFeishuText(metricValue),
+		escapeFeishuText(currentValue),
+		escapeFeishuText(dimensions),
+		escapeFeishuText(durationText),
+		escapeFeishuText(formatAlertTime(event.FiredAt)),
+		escapeFeishuText(resolvedTimeText),
+		note,
 	)
 }
 

--- a/backend/internal/service/ops_feishu_notifier_tk.go
+++ b/backend/internal/service/ops_feishu_notifier_tk.go
@@ -252,21 +252,7 @@ func buildOpsFeishuAlertText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLabel
 	// attached it (error-rate rules). Rendered as its own line right under 范围 so
 	// an operator can tell a real fire from client noise (e.g. a hammered
 	// access-gated model) without drilling the dashboard.
-	topCauseLine := ""
-	if cause := opsFeishuTopCause(event.Dimensions); cause != "" {
-		topCauseLine = fmt.Sprintf("\n**主因**：%s", escapeFeishuText(cause))
-	}
-	// routing_capacity_rejection_count attaches the per-user (client) concentration
-	// as its own dimension so it renders on a SECOND line under 主因 (readability,
-	// instead of a long single line), and so it can be dropped on edge nodes where
-	// the only client is the prod mirror-relay. Absent on edges and non-rejection
-	// rules.
-	if users := opsFeishuTopCauseUsers(event.Dimensions); users != "" {
-		topCauseLine += fmt.Sprintf("\n**用户**：%s", escapeFeishuText(users))
-	}
-	if models := opsFeishuTopCauseModels(event.Dimensions); models != "" {
-		topCauseLine += fmt.Sprintf("\n**模型**：%s", escapeFeishuText(models))
-	}
+	topCauseLine := buildOpsFeishuTopCauseLines(event.Dimensions)
 	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**当前值**：%s\n**范围**：%s%s\n**时间**：%s\n\n**建议**：%s",
 		escapeFeishuText(nodeLabel),
 		escapeFeishuText(strings.TrimSpace(rule.Name)),
@@ -321,7 +307,8 @@ func buildOpsFeishuRecoveryText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLa
 	if strings.TrimSpace(dashboardURL) != "" {
 		note = fmt.Sprintf("[打开 Ops Dashboard](%s) 复核指标与账号可用性。指标已回落到阈值以下，告警自动解除。", dashboardURL)
 	}
-	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**触发值**：%s\n**当前值**：%s\n**范围**：%s\n**持续时长**：%s\n**触发时间**：%s\n**恢复时间**：%s\n\n**说明**：%s",
+	topCauseLine := buildOpsFeishuTopCauseLines(event.Dimensions)
+	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**触发值**：%s\n**当前值**：%s\n**范围**：%s%s\n**持续时长**：%s\n**触发时间**：%s\n**恢复时间**：%s\n\n**说明**：%s",
 		escapeFeishuText(nodeLabel),
 		escapeFeishuText(strings.TrimSpace(rule.Name)),
 		escapeFeishuText(strings.TrimSpace(rule.MetricType)),
@@ -330,11 +317,28 @@ func buildOpsFeishuRecoveryText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLa
 		escapeFeishuText(metricValue),
 		escapeFeishuText(currentValue),
 		escapeFeishuText(dimensions),
+		topCauseLine,
 		escapeFeishuText(durationText),
 		escapeFeishuText(formatAlertTime(event.FiredAt)),
 		escapeFeishuText(resolvedTimeText),
 		note,
 	)
+}
+
+// buildOpsFeishuTopCauseLines renders 主因/用户/模型 breakdown lines shared by
+// firing and recovery cards from evaluator-stashed event dimensions.
+func buildOpsFeishuTopCauseLines(dimensions map[string]any) string {
+	lines := ""
+	if cause := opsFeishuTopCause(dimensions); cause != "" {
+		lines += fmt.Sprintf("\n**主因**：%s", escapeFeishuText(cause))
+	}
+	if users := opsFeishuTopCauseUsers(dimensions); users != "" {
+		lines += fmt.Sprintf("\n**用户**：%s", escapeFeishuText(users))
+	}
+	if models := opsFeishuTopCauseModels(dimensions); models != "" {
+		lines += fmt.Sprintf("\n**模型**：%s", escapeFeishuText(models))
+	}
+	return lines
 }
 
 // opsFeishuTopCause extracts the pre-formatted "主因" string the alert evaluator

--- a/backend/internal/service/ops_settings_models.go
+++ b/backend/internal/service/ops_settings_models.go
@@ -43,7 +43,8 @@ type OpsFeishuAlertConfig struct {
 	// AccountIncidentDigestEnabled 是账号失效事件中「临时冷却」类（429/529/temp）自愈
 	// 聚合摘要的总开关。**零值 false = 默认关（opt-in）**——运营判定这类自愈橙头摘要在
 	// provider 抖动时是噪音，会淹没真故障 P0。仅当显式设为 true 才发摘要；永久失效 P0、
-	// 池级全不可调度 P0、恢复绿卡走另一条路径，恒发不受此开关影响。
+	// 池级全不可调度 P0、以及 ops 规则 P0 的配对恢复绿卡，走 Feishu 专用路径，
+	// 恒发不受此开关影响。
 	//
 	// 历史上 enable 语义曾错绑在 AccountIncidentDigestSeconds>0（见 PR#730），但
 	// normalizeOpsFeishuAlertConfig 的 0→600 回填使 seconds 永不为 0，致 enable 恒真、

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -118,14 +118,17 @@
     {
       "path": "backend/internal/service/ops_alert_notifications_tk_feishu.go",
       "must_contain": [
-        "maybeSendAlertFeishu",
+        "maybeSendAlertFeishuRecovery",
+        "markFiringDelivered",
         "strings.EqualFold(strings.TrimSpace(rule.Severity), \"P0\")",
         "rule.NotifyEmail",
         "opsFeishuDedupeKey",
+        "opsFeishuRecoveryDedupeKey",
+        "firedFeishuEventIDs",
         "s.limiter.SetLimit(cfg.RateLimitPerHour)",
         "s.cfg.Server.FrontendURL"
       ],
-      "rationale": "TK companion that keeps Feishu alerting P0-only, tied to the existing external-notification opt-in, and protected by per-rule/dimension cooldown plus global hourly rate limiting. Dropping any anchor turns a low-noise OPC pager into either silence or chat noise. FrontendURL threads the per-node public base URL into the card so prod vs each edge is distinguishable; losing it silently regresses every card back to an unattributable 'overall'."
+      "rationale": "TK companion that keeps Feishu alerting P0-only, tied to the existing external-notification opt-in, and protected by per-rule/dimension cooldown plus global hourly rate limiting. Paired green recovery cards must fire only after a delivered firing card (firedFeishuEventIDs) and use a separate recovery dedupe key so resolve notifications are not blocked by the firing cooldown. Dropping any anchor turns a low-noise OPC pager into either silence or chat noise. FrontendURL threads the per-node public base URL into the card so prod vs each edge is distinguishable; losing it silently regresses every card back to an unattributable 'overall'."
     },
     {
       "path": "backend/internal/service/ops_feishu_notifier_tk.go",
@@ -134,9 +137,11 @@
         "sanitizeFeishuWebhookError",
         "signFeishuWebhook",
         "SigningSecret",
-        "deriveOpsNodeIdentity"
+        "deriveOpsNodeIdentity",
+        "buildRecoveryPayload",
+        "buildOpsFeishuRecoveryText"
       ],
-      "rationale": "Feishu webhook delivery must keep secrets out of logs/errors and support the optional bot signing secret. These are safety properties that compile cleanly if accidentally removed. deriveOpsNodeIdentity turns the per-node frontend_url into the card's node label + ops dashboard deep-link; removing it compiles cleanly but makes every node's P0 card indistinguishable again."
+      "rationale": "Feishu webhook delivery must keep secrets out of logs/errors and support the optional bot signing secret. These are safety properties that compile cleanly if accidentally removed. deriveOpsNodeIdentity turns the per-node frontend_url into the card's node label + ops dashboard deep-link; removing it compiles cleanly but makes every node's P0 card indistinguishable again. buildRecoveryPayload/buildOpsFeishuRecoveryText are the paired green-card path for auto-resolved P0 ops rules; dropping them silently removes recovery notifications while firing cards still page."
     },
     {
       "path": "backend/internal/service/ops_settings_models.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -139,7 +139,8 @@
         "SigningSecret",
         "deriveOpsNodeIdentity",
         "buildRecoveryPayload",
-        "buildOpsFeishuRecoveryText"
+        "buildOpsFeishuRecoveryText",
+        "buildOpsFeishuTopCauseLines"
       ],
       "rationale": "Feishu webhook delivery must keep secrets out of logs/errors and support the optional bot signing secret. These are safety properties that compile cleanly if accidentally removed. deriveOpsNodeIdentity turns the per-node frontend_url into the card's node label + ops dashboard deep-link; removing it compiles cleanly but makes every node's P0 card indistinguishable again. buildRecoveryPayload/buildOpsFeishuRecoveryText are the paired green-card path for auto-resolved P0 ops rules; dropping them silently removes recovery notifications while firing cards still page."
     },


### PR DESCRIPTION
## 摘要

- Ops alert evaluator 在 P0 规则**自动 resolve** 时，若该事件已成功发送过红色飞书触发卡，则补发**绿色恢复卡**（标题 `TokenKey P0 告警已恢复 · {节点}`）。
- 恢复卡携带触发值、当前值、持续时长、触发/恢复时间，并**复用 firing 时的主因/用户/模型 breakdown**（与红色卡一致）。
- 配对 ledger（`firedFeishuEventIDs`）保证「没收到红卡就不发绿卡」；恢复通知使用独立 dedupe key，不受 firing cooldown 阻塞。

## 风险

- 常规风险：仅扩展 Feishu 通知路径，不改变告警判定阈值或 resolve 逻辑。
- 进程重启发生在「红卡已发、尚未 resolve」之间时，内存 ledger 丢失，绿卡可能漏发（与池级恢复卡同类限制）。
- Admin 手动 resolve 暂不发绿卡（仅 evaluator 自动 resolve）。

## 验证

- `go test -tags=unit ./internal/service/ -run 'TestOpsFeishu|TestMaybeSendAlertFeishu' -count=1` — PASS
- `./scripts/preflight.sh` — PASS

## 提交

- e5c3d2129 feat(ops): 为 P0 规则告警补配对飞书恢复绿卡
- 485b2ed84 fix(ops): 恢复绿卡携带 firing 时的主因/模型上下文

最新提交：485b2ed84
