### PR TITLE
fix: surface Kiro stream read errors

### DIFF
--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -109,7 +109,7 @@ func (s *KiroGatewayService) Forward(
 	}
 
 	if req.Stream {
-		result, err := s.forwardStreaming(ctx, c, doer, kiroAcct, payload, &req, requestID, model, startTime)
+		result, err := s.forwardStreaming(ctx, c, account, doer, kiroAcct, payload, &req, requestID, model, startTime)
 		if err == nil {
 			PersistKiroProfileArnIfChanged(ctx, s.accountRepo, account, kiroAcct)
 		}
@@ -211,6 +211,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 func (s *KiroGatewayService) forwardStreaming(
 	ctx context.Context,
 	c *gin.Context,
+	account *Account,
 	doer kiroproto.HTTPDoer,
 	kiroAcct *kiroproto.Account,
 	payload *kiroproto.KiroPayload,
@@ -314,12 +315,29 @@ func (s *KiroGatewayService) forwardStreaming(
 
 	// If the upstream failed before producing any content, surface the error so
 	// the handler can decide on failover instead of emitting a half-finished
-	// SSE stream. (Once content has begun — enc.started — we close out the
-	// stream cleanly because the client has already received a 200 + bytes.)
+	// SSE stream. Once content has begun, SSE has no resume/failover point; send
+	// a protocol-level error event instead of forging message_delta/message_stop,
+	// otherwise clients such as Claude Code treat an incomplete Kiro stream as a
+	// successful assistant turn.
 	// classifyKiroForwardError maps a recognized HTTP 400 INVALID_MODEL_ID into
 	// a typed *KiroInvalidModelError so the handler can return a clean 400.
 	if callErr != nil && !enc.started {
 		return nil, classifyKiroForwardError(callErr, model)
+	}
+	if callErr != nil {
+		msg := "upstream stream disconnected: " + sanitizeStreamError(callErr)
+		recordKiroStreamError(c, account, msg)
+		writeKiroStreamError(c, flusher, "stream_read_error", msg)
+		return nil, fmt.Errorf("kiro stream read error: %w", callErr)
+	}
+	if callbackErr != nil && !enc.started {
+		return nil, fmt.Errorf("kiro stream error: %w", callbackErr)
+	}
+	if callbackErr != nil {
+		msg := "upstream stream disconnected: " + sanitizeStreamError(callbackErr)
+		recordKiroStreamError(c, account, msg)
+		writeKiroStreamError(c, flusher, "stream_read_error", msg)
+		return nil, fmt.Errorf("kiro stream callback error: %w", callbackErr)
 	}
 
 	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
@@ -347,13 +365,6 @@ func (s *KiroGatewayService) forwardStreaming(
 	publishKiroInternalThinkingSideChannel(c, w, nil, thinkingBuf)
 	flusher.Flush()
 
-	if callbackErr != nil {
-		// Content already streamed; log-level handling happens in the handler via
-		// the returned ForwardResult/usage. We still return nil error to avoid a
-		// double-write to the client after SSE has begun.
-		_ = callbackErr
-	}
-
 	return &ForwardResult{
 		RequestID:     requestID,
 		Usage:         ClaudeUsage{InputTokens: inputTokens, OutputTokens: outputToks},
@@ -364,6 +375,49 @@ func (s *KiroGatewayService) forwardStreaming(
 		FirstTokenMs:  firstTokMs,
 		BillingTier:   kiroproto.KiroEstimatedBillingTier,
 	}, nil
+}
+
+func recordKiroStreamError(c *gin.Context, account *Account, message string) {
+	setOpsUpstreamError(c, 0, message, "")
+	event := OpsUpstreamErrorEvent{
+		Platform:           PlatformKiro,
+		UpstreamStatusCode: 0,
+		Kind:               "stream_error",
+		Message:            message,
+	}
+	if account != nil {
+		event.Platform = account.Platform
+		event.AccountID = account.ID
+		event.AccountName = account.Name
+	}
+	appendOpsUpstreamError(c, event)
+}
+
+func writeKiroStreamError(c *gin.Context, flusher http.Flusher, errType, message string) {
+	if c == nil || c.Writer == nil {
+		return
+	}
+	if errType == "" {
+		errType = "stream_read_error"
+	}
+	if message == "" {
+		message = errType
+	}
+	body, err := json.Marshal(map[string]any{
+		"type": "error",
+		"error": map[string]string{
+			"type":    errType,
+			"message": message,
+		},
+	})
+	if err != nil {
+		body = []byte(fmt.Sprintf(`{"type":"error","error":{"type":%q,"message":%q}}`, errType, message))
+	}
+	_, _ = fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", body)
+	if flusher != nil {
+		flusher.Flush()
+	}
+	MarkResponseCommitted(c)
 }
 
 // logKiroCredits records the Kiro upstream credits cost at info level for

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -215,6 +215,52 @@ func TestKiroGatewayService_Forward_Streaming(t *testing.T) {
 	require.Contains(t, out, "event: message_stop")
 }
 
+func TestKiroGatewayService_Forward_Streaming_MidStreamReadErrorSendsSSEError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	frame := buildKiroEventStreamMessage("assistantResponseEvent",
+		[]byte(`{"content":"partial answer","inputTokens":8,"outputTokens":3}`))
+	truncatedPrelude := []byte{0, 0, 0, 20}
+	upstream := &kiroFakeUpstream{body: append(frame, truncatedPrelude...)}
+
+	svc := NewKiroGatewayService(upstream, nil, nil)
+
+	body, _ := json.Marshal(map[string]any{
+		"model":      "claude-sonnet-4",
+		"messages":   []map[string]any{{"role": "user", "content": "hi"}},
+		"max_tokens": 16,
+		"stream":     true,
+	})
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-sonnet-4", Stream: true}
+
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), parsed, time.Now())
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.True(t, IsResponseCommitted(c))
+
+	out := rec.Body.String()
+	require.Contains(t, out, "event: message_start")
+	require.Contains(t, out, "partial answer")
+	require.Contains(t, out, "event: error")
+	require.Contains(t, out, `"type":"stream_read_error"`)
+	require.Contains(t, out, "upstream stream disconnected: unexpected EOF")
+	require.NotContains(t, out, "event: message_delta")
+	require.NotContains(t, out, "event: message_stop")
+
+	rawEvents, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	events, ok := rawEvents.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.Len(t, events, 1)
+	require.Equal(t, "stream_error", events[0].Kind)
+	require.Equal(t, PlatformKiro, events[0].Platform)
+	require.Equal(t, int64(99), events[0].AccountID)
+	require.Contains(t, events[0].Message, "unexpected EOF")
+}
+
 // kiroStatusUpstream returns a canned non-200 response with a fixed body,
 // modeling the Kiro upstream rejecting a request (e.g. 400 INVALID_MODEL_ID).
 // The vendored CallKiroAPIWithDoer reads the body into its error string, so all


### PR DESCRIPTION
## 摘要

- 修复 Kiro 流式转发在上游已输出部分内容后读流失败时，仍伪造 `message_delta` / `message_stop` 的问题。
- Kiro 上游中途断流或 callback 报错后，改为向下游发送 Anthropic 标准 SSE `event: error`，`error.type=stream_read_error`。
- 同步记录 `ops_upstream_errors kind=stream_error`，便于后续从线上日志定位 Kiro 断流根因。
- 增加回归测试：模拟 Kiro EventStream 先输出 partial answer，再收到截断 frame，断言客户端收到 error 而不是正常结束。

## 历史修复与本次差异

这次现象和之前 Anthropic 流式保活 / Claude Code watchdog 修复属于同一类用户体感：任务实际上没有完成，但客户端把流当成正常结束或继续等待失败。

已确认的历史修复：

- 本仓 PR #302：<https://github.com/youxuanxue/sub2api/pull/302>
  - 导入上游 Anthropic API Key passthrough 流式 keepalive 修复。
  - 对应上游 PR #2552：<https://github.com/Wei-Shaw/sub2api/pull/2552>
  - 关键提交：`164e2f610`，为 Anthropic API Key 透传流式分支增加 keepalive ping。
- 上游 PR #3626：<https://github.com/Wei-Shaw/sub2api/pull/3626>
  - 关键提交：`a5781fe31`，修 Claude Code stream keepalive stalls。
  - 对 Claude Code >= 2.1.193，在 content block 打开期间用空 `content_block_delta` keepalive，而不是只发 `ping`。

这两个修复都落在普通 Anthropic / Anthropic API Key passthrough 的 `gateway_service.go` 流式路径。最近 TokenKey Anthropic 请求更多路由到 Kiro us3/us4/us5/us6 后，会走 `kiro_gateway_service.go` 的 Kiro EventStream -> Anthropic SSE 独立转码路径；该路径没有覆盖“已发部分内容后上游读流失败”的错误终止语义。

本 PR 补的是 Kiro 专属缺口：已经开始向客户端写 SSE 后，如果 Kiro 上游读流失败，不再合成正常 `message_stop`，而是明确发 `event: error`，让 Claude Code 知道本轮没有正常完成。

## 风险

- 影响范围：仅 Kiro streaming 分支。
- 不改变非流式 Kiro 响应。
- 不改变普通 Anthropic / Anthropic API Key passthrough 路径。
- 已开流后不做 failover，符合 SSE 无法 resume 的既有语义；只把原先错误的“正常结束”改成协议级错误。

## 验证

已运行：

```bash
go test -tags=unit ./internal/service -run 'TestKiroGatewayService_Forward_Streaming'
go test -tags=unit ./internal/service -run 'TestKiro|TestClassifyKiro|TestGatewayService_Forward_Kiro'
go test -tags=unit ./internal/service
scripts/preflight.sh
```

PR CI 已全绿：

- `main-ancestry-guard`
- `preflight`
- `test-unit`
- `test-integration`
- `golangci-lint`
- `backend-security`
- `frontend-security`
- `frontend`
- `marker-acknowledgement`

## 门禁说明

- no-web-impact
- sentinel-registry-reviewed: 本次只修改既有 Kiro 流式错误终止语义，并补了聚焦回归测试；没有新增对外 Web/API 字段、配置项或新的 load-bearing sentinel anchor 需求。
