### PR TITLE
feat(ops): Antigravity gemini-2.5-pro 专项探针

### DIFF
--- a/.cursor/skills/tokenkey-modelops-planner/SKILL.md
+++ b/.cursor/skills/tokenkey-modelops-planner/SKILL.md
@@ -24,6 +24,7 @@ description: >-
 | 运营说法 / 症状 | 走哪条分支 |
 | --- | --- |
 | 目录/Menu 过时、模型可能不再 200、要刷新 allowlist | **分支 B**（本 skill 路由后读写入子 skill） |
+| Antigravity `gemini-2.5-pro` generateContent 超时 / inconclusive，要窄探 chat vs v1beta | **分支 B** → `tokenkey-servable-model-refresh` §「Antigravity gemini-2.5-pro 专项」 |
 | Qwen/DeepSeek mapping 漂、429 空池、60↔72 mirror | **分支 A** |
 | 客户要上新模型、ready_for_onboard | **分支 C**（可先 A 再 C） |
 | 单账号单模型能不能通 | `tokenkey-account-model-probe`（诊断，非 hub 子分支） |

--- a/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
+++ b/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
@@ -32,7 +32,8 @@ description: >-
   家族，Gemini 另走 discovered + seed）、**24h 流量短路**（从 `usage_logs` 拉近窗成功流量、
   与候选集求交、跳过 SSM 探测）、SSM 投递与逐模型请求、HTTP→verdict 分类、留
   `servable`、dated 去重、Go map splice、分批避开 SSM 等待窗口、自动开 PR——全在
-  `refresh-servable-allowlist.py` / `probe-servable-models.sh` / `probe-traffic-proven-models.sh`，
+  `refresh-servable-allowlist.py` / `probe-servable-models.sh` /
+  `probe-traffic-proven-models.sh` / `probe-antigravity-gemini25pro-literal.sh`，
   `selftest` 子命令覆盖，preflight `servable-allowlist generator selftest` 门禁 + sentinel 守 splice 标记。
 - **真判断（留给人/agent）**：① `inconclusive`（429/502/503）的取舍——它常是「该探测组没有
   这类账号」而非模型本身不可用（如 image 经 GPT专线组、专用 codex 池）；要不要给别的组 key
@@ -217,6 +218,25 @@ bash ops/observability/run-probe.sh --target prod --script ops/pricing/probe-ser
 - grok imagine 图/视频族走 edge-internal `/v1/images/generations` / `/v1/video/generations`。
   Antigravity 文本/能力探测走 `/antigravity/v1beta`；Studio `gemini-*-image` 图片必须走
   `ANTIGRAVITY_IMAGE_MODELS` 的 `/v1/chat/completions`，否则会把 v1beta 404 误判成 Studio 不可用。
+
+### Antigravity `gemini-2.5-pro` 专项（literal id，不进 `run` splice）
+
+全量 `ANTIGRAVITY_CHAT_MODELS` 批里 `gemini-2.5-pro` 的 `:generateContent` 常 **000 timeout /
+inconclusive**（见 `docs/all-platform-model-inventory.md`），与 chat 路径结论混在一起难判根因。
+用 **`probe-antigravity-gemini25pro-literal.sh`** 窄打 Google-Gemini 源组（默认
+`gemini-pro-agent` + `gemini-2.5-pro`），**同一 key** 并排探 `/v1/chat/completions` 与
+`/antigravity/v1beta/models/{id}:generateContent`，附账号快照（无 secret）：
+
+```bash
+bash ops/observability/run-probe.sh --target prod \
+  --script ops/pricing/probe-antigravity-gemini25pro-literal.sh \
+  --with ops/pricing/probe_reserved_resources.sh \
+  --timeout-seconds 180
+# 可选：PROBE_MODELS='gemini-2.5-pro'  PROBE_ANTIGRAVITY_SOURCE_GROUP='Google-Gemini'
+```
+
+**何时用**：antigravity allowlist 手维决策前、或 refresh 批里该 id 长期 inconclusive 需区分
+「路由/超时」vs「上游不支持」。结果**不进** `refresh-servable-allowlist.py parse_results`。
 
 ## 判断要点 / 坑
 

--- a/ops/pricing/README.md
+++ b/ops/pricing/README.md
@@ -23,6 +23,7 @@ hand-maintained empirical sets in the same file.
 | File | Role |
 | --- | --- |
 | `probe-servable-models.sh` | Runs on prod or an edge via `ops/observability/run-probe.sh`. Sends one minimal real request per candidate model and emits `platform⇥model⇥http⇥verdict` TSV. A model is **servable** iff it returns a real `200`. Always auto-ensures reusable `__tk_probe_<scope>_group` / `__tk_probe_<scope>_key` per platform via `probe_reserved_resources.sh` (no direct-key fallback, no dependency on `TK_SMOKE_API_KEY` or customer keys). The companion is mandatory — deliver it with `run-probe.sh --with ops/pricing/probe_reserved_resources.sh` (the orchestrator and every manual invocation below do). |
+| `probe-antigravity-gemini25pro-literal.sh` | Focused prod probe for literal Antigravity chat ids on the `Google-Gemini` source group (default: `gemini-pro-agent`, `gemini-2.5-pro`). Hits both `/v1/chat/completions` and `/antigravity/v1beta/models/{id}:generateContent`, emits TSV plus a non-secret account snapshot. Companion: `probe_reserved_resources.sh`. Used when the broad servable refresh batch cannot distinguish generateContent timeout vs routing gaps for `gemini-2.5-pro`. |
 | `probe_reserved_resources.sh` | Shared DB helpers for reserved probe groups/keys (same namespace as `tokenkey-account-model-probe`). Per-scope `flock` on `/tmp/tokenkey-account-model-probe-<scope>.lock` serializes `account_groups` mutations vs account-model probes. Catalog refresh copies schedulable accounts from canonical source group ids by default, probes, then clears `account_groups` bindings and releases locks on EXIT. Group-name overrides are legacy diagnostics only. |
 | `probe-traffic-proven-models.sh` | Runs on prod via `ops/observability/run-probe.sh`. Read-only over `usage_logs`: emits `platform⇥model⇥hits` for every model that served **real successful traffic** in the last `TRAFFIC_HOURS` (default 24). Feeds the `--skip-proven-by-traffic` short-circuit below. Positive evidence only — a model with no recent traffic is simply absent (never an unsupported signal). |
 | `refresh-servable-allowlist.py` | Refreshes the shared public-catalog/user-menu servable sets. It derives candidates, runs probes (uploads `probe_reserved_resources.sh` via `run-probe.sh --with`), keeps `verdict==servable`, de-duplicates dated snapshots, and splices the anthropic/openai/gemini Go blocks. `selftest` covers deterministic glue (no prod). Optional `--skip-proven-by-traffic` short-circuits candidates already proven by 24h traffic out of the probe batches. |
@@ -205,6 +206,22 @@ channel pricing is exactly the tool for that. Alert digest cadence is
   group's group id and extend the probe to re-add them.
 - This is a snapshot. Re-run after the served fleet changes (new model family,
   account/tier changes, an upstream sunset).
+
+### Antigravity `gemini-2.5-pro` literal probe
+
+The broad servable batch times out on `gemini-2.5-pro` generateContent (see
+`docs/all-platform-model-inventory.md`). When you need a focused before/after
+signal without rerunning the full refresh:
+
+```bash
+bash ops/observability/run-probe.sh --target prod \
+  --script ops/pricing/probe-antigravity-gemini25pro-literal.sh \
+  --with ops/pricing/probe_reserved_resources.sh \
+  --timeout-seconds 180
+```
+
+Optional: `PROBE_MODELS='gemini-2.5-pro'` or
+`PROBE_ANTIGRAVITY_SOURCE_GROUP='Google-Gemini'`.
 
 See also `.cursor/skills/tokenkey-online-log-troubleshooting` for the prod
 read-only access posture and `ops/observability/run-probe.sh` for the SSM

--- a/ops/pricing/probe-antigravity-gemini25pro-literal.sh
+++ b/ops/pricing/probe-antigravity-gemini25pro-literal.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# probe-antigravity-gemini25pro-literal.sh — focused Antigravity probe for literal
+# gemini-2.5-pro on prod Google-Gemini group. Emits TSV: tag\tmodel\tcode\tverdict\thint
+#
+# Canonical client path: POST /antigravity/v1beta/models/<id>:generateContent
+# Also probes /v1/chat/completions (standard servable refresh shape) for comparison.
+#
+# Usage (on prod host via run-probe.sh):
+#   bash ops/observability/run-probe.sh --target prod \
+#     --script ops/pricing/probe-antigravity-gemini25pro-literal.sh \
+#     --with ops/pricing/probe_reserved_resources.sh \
+#     --timeout-seconds 180
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ ! -f "$SCRIPT_DIR/probe_reserved_resources.sh" ]; then
+	echo "missing probe_reserved_resources.sh companion" >&2
+	exit 2
+fi
+# shellcheck source=probe_reserved_resources.sh
+. "$SCRIPT_DIR/probe_reserved_resources.sh"
+
+PSQL='sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1'
+PROD="${PROD_BASE:-https://api.tokenkey.dev}"
+PROBE_ANTIGRAVITY_SOURCE_GROUP="${PROBE_ANTIGRAVITY_SOURCE_GROUP:-Google-Gemini}"
+CURL_TIMEOUT="${CURL_TIMEOUT:-90}"
+MODELS="${PROBE_MODELS:-gemini-pro-agent gemini-2.5-pro}"
+
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+
+TK_PROBE_CATALOG_SCOPES=""
+tk_probe_catalog_key() { # $1=scope $2=platform $3=bind_kind $4=bind_val -> sets REPLY_KEY
+	local scope="$1" platform="$2" bind_kind="$3" bind_val="$4"
+	if ! tk_probe_prepare_catalog "$scope" "$platform" "$bind_kind" "$bind_val"; then
+		return 1
+	fi
+	TK_PROBE_CATALOG_SCOPES="${TK_PROBE_CATALOG_SCOPES} ${scope}"
+	REPLY_KEY="$TK_PROBE_KEY"
+}
+
+tk_probe_catalog_cleanup() {
+	local scope
+	for scope in $TK_PROBE_CATALOG_SCOPES; do
+		[ -n "$scope" ] || continue
+		tk_probe_clear_bindings "$scope" || true # preflight-allow: swallow
+	done
+	tk_probe_release_reuse_locks
+}
+
+trap tk_probe_catalog_cleanup EXIT
+
+verdict() {
+	local code="$1" f="$2"
+	case "$code" in
+	200) echo "servable" ;;
+	400 | 404)
+		if grep -qiE 'retired|sunset|not_found|does not exist|invalid model|unknown model|model_not_found|not supported|removed from|not a valid' "$f" 2>/dev/null; then
+			echo "unsupported"
+		else echo "inconclusive"; fi ;;
+	429)
+		if grep -qiE 'no available accounts' "$f" 2>/dev/null; then echo "not_allowlisted"; else echo "inconclusive"; fi ;;
+	502 | 503) echo "relay_or_upstream" ;;
+	401 | 403) echo "auth_error" ;;
+	000) echo "timeout" ;;
+	*) echo "inconclusive" ;;
+	esac
+}
+
+hint_from_body() {
+	local f="$1" code="$2"
+	if [ "$code" = "000" ]; then echo "curl timeout or no response"; return; fi
+	if grep -qiE 'no available accounts' "$f" 2>/dev/null; then echo "TK scheduling empty pool"; return; fi
+	if grep -qiE '502|bad gateway|upstream' "$f" 2>/dev/null; then echo "prod->edge relay failure"; return; fi
+	head -c 120 "$f" 2>/dev/null | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g'
+}
+
+body_chat() {
+	printf '{"model":"%s","max_tokens":16,"messages":[{"role":"user","content":"Say OK in one word"}]}' "$1"
+}
+
+body_generate() {
+	printf '{"contents":[{"role":"user","parts":[{"text":"Say OK in one word"}]}]}'
+}
+
+probe_one() { # $1=tag $2=model $3=path $4=body
+	local tag="$1" model="$2" path="$3" body="$4" f code v hint
+	f="$(mktemp)"
+	code="$(curl -s -o "$f" -w '%{http_code}' -m "$CURL_TIMEOUT" -X POST "$PROD$path" \
+		-H "Authorization: Bearer $AGKEY" -H 'content-type: application/json' \
+		--data-binary "$body")"
+	v="$(verdict "$code" "$f")"
+	hint="$(hint_from_body "$f" "$code")"
+	emit "$tag" "$model" "$code" "$v" "$hint"
+	rm -f "$f"
+}
+
+# Resolve probe key bound to Google-Gemini schedulable antigravity accounts.
+if ! tk_probe_catalog_key antigravity antigravity source_group "$PROBE_ANTIGRAVITY_SOURCE_GROUP"; then
+	emit "setup" "*" "000" "config_error" "failed to prepare __tk_probe_antigravity_* (source_group=$PROBE_ANTIGRAVITY_SOURCE_GROUP)"
+	exit 1
+fi
+AGKEY="$REPLY_KEY"
+
+printf 'probe_meta\tgroup=%s\tprod=%s\tmodels=%s\n' "$PROBE_ANTIGRAVITY_SOURCE_GROUP" "$PROD" "$MODELS"
+
+for m in $MODELS; do
+	probe_one "antigravity_chat" "$m" "/v1/chat/completions" "$(body_chat "$m")"
+	probe_one "antigravity_generate" "$m" "/antigravity/v1beta/models/${m}:generateContent" "$(body_generate)"
+done
+
+# Account snapshot for relay diagnosis (no secrets).
+tk_probe_psql -c "
+SELECT a.id, a.name, a.platform, a.status, a.schedulable,
+       COALESCE(a.credentials->>'base_url', '') AS relay_base_url
+FROM accounts a
+JOIN account_groups ag ON ag.account_id = a.id
+JOIN groups g ON g.id = ag.group_id
+WHERE g.name = '$(tk_probe_sql_escape "$PROBE_ANTIGRAVITY_SOURCE_GROUP")'
+  AND g.deleted_at IS NULL AND a.deleted_at IS NULL
+ORDER BY a.id;
+" | while IFS='|' read -r id name platform status sched base; do
+	printf 'account\t%s\tname=%s\tstatus=%s\tsched=%s\trelay=%s\n' "$id" "$name" "$status" "$sched" "$base"
+done


### PR DESCRIPTION
## 摘要

- 新增 `ops/pricing/probe-antigravity-gemini25pro-literal.sh`：在 prod 上对 Google-Gemini 组的 Antigravity 模型做窄范围探测（默认 `gemini-pro-agent`、`gemini-2.5-pro`），同时打 `/v1/chat/completions` 与 `/antigravity/v1beta/...:generateContent`。
- 更新 `ops/pricing/README.md` 登记脚本与运行示例。
- 挂到 `tokenkey-servable-model-refresh`（Antigravity 专项小节）与 `tokenkey-modelops-planner`（路由表），agent 走 modelops 路径时可发现该脚本。

## 风险

低 — 仅 ops 脚本与 skill 文档；不改网关运行时、不改 Web。

Web impact: none

## 验证

- `./scripts/preflight.sh` — PASS（pre-commit ×2）
- `bash -n ops/pricing/probe-antigravity-gemini25pro-literal.sh` — OK
- prod 实跑需 AWS/SSM（未在本机执行）

## 提交

- c64d731eb feat(ops): add focused Antigravity gemini-2.5-pro literal probe
- 5b7b402ca docs(skill): wire gemini-2.5-pro literal probe into modelops skills

最新提交：5b7b402ca
