### PR TITLE
fix(anthropic): reject corrupt tool continuations before upstream

### DIFF
--- a/.github/workflows/client-fidelity-watch.yml
+++ b/.github/workflows/client-fidelity-watch.yml
@@ -208,7 +208,10 @@ jobs:
           (
             cd backend
             go test -tags=unit ./internal/service \
-              -run 'TestTkExtractAnthropicPromptFingerprint|TestTkProbePromptSurfaceGatewayCoverageJSONL|TestTkNormalizeCCGeo' \
+              -run 'TestTkExtractAnthropicPromptFingerprint|TestTkValidateAnthropicToolContext|TestTkRejectInvalidAnthropicToolContext|TestTkProbePromptSurfaceGatewayCoverageJSONL|TestTkNormalizeCCGeo|TestCanonicalIdentityIsSingleSourceOfTruth|TestGetOrCreateFingerprint_CanonicalProfile' \
+              -count=1
+            go test -tags=unit ./internal/handler \
+              -run 'TestClassifyOpsUpstreamClientInducedRejectionOwnedByClient' \
               -count=1
           )
           python3 -m unittest ops.anthropic.test_probe_prompt_surfaces -v

--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
@@ -35,6 +35,9 @@ import (
 // identity verification required) are NOT — they stay provider-owned because they
 // genuinely report account health and SHOULD keep counting toward upstream_error_rate.
 func tkUpstreamClientInducedRejection(c *gin.Context, clientErrType string) bool {
+	if tkOpsHasUpstreamEventKind(c, service.OpsUpstreamKindClientToolContextCorrupt) {
+		return true
+	}
 	status := tkOpsUpstreamStatusCode(c)
 	// 413 request_too_large is always caller-fault: the body cleared TokenKey's
 	// local body-limit middleware (handler.request_body_limit) but exceeded the
@@ -129,6 +132,22 @@ func tkUpstreamClientInducedRejection(c *gin.Context, clientErrType string) bool
 		strings.Contains(combined, "request_too_large") ||
 		strings.Contains(combined, "request too large") ||
 		strings.Contains(combined, "is not supported when using")
+}
+
+func tkOpsHasUpstreamEventKind(c *gin.Context, kind string) bool {
+	if c == nil || strings.TrimSpace(kind) == "" {
+		return false
+	}
+	if v, ok := c.Get(service.OpsUpstreamErrorsKey); ok {
+		if events, ok := v.([]*service.OpsUpstreamErrorEvent); ok {
+			for _, ev := range events {
+				if ev != nil && strings.TrimSpace(ev.Kind) == kind {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // tkOpsIsAccountLevel4xx matches the upstream 4xx phrases that report account

--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
@@ -23,6 +23,21 @@ import (
 func TestClassifyOpsUpstreamClientInducedRejectionOwnedByClient(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
+	t.Run("local Anthropic tool context guard is request/client owned", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{{
+			Kind:    service.OpsUpstreamKindClientToolContextCorrupt,
+			Message: "Invalid Anthropic tool continuation: tool_result must be immediately preceded by the assistant tool_use message.",
+		}})
+
+		phase, errorOwner, errorSource := classifyOpsErrorLog(c, "invalid_request_error", "Invalid Anthropic tool continuation", "", http.StatusBadRequest)
+
+		require.Equal(t, "request", phase)
+		require.Equal(t, "client", errorOwner)
+		require.Equal(t, "client_request", errorSource)
+	})
+
 	t.Run("openai chat/completions unsupported-model 400 (structured invalid_request_error body)", func(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(rec)

--- a/backend/internal/service/gateway_request_tk_prompt_fingerprint.go
+++ b/backend/internal/service/gateway_request_tk_prompt_fingerprint.go
@@ -41,6 +41,8 @@ type tkAnthropicPromptFingerprint struct {
 	IdentityAnchorID      string
 	BillingPrefixPresent  bool
 	HasSystemReminder     bool
+	HasToolResult         bool
+	HasAssistantToolUse   bool
 	PromptSurfaceClasses  []tkCCPromptSurfaceClass
 	ReminderDateLineClass string
 	GeoStegoCanonical     bool
@@ -79,7 +81,18 @@ func tkExtractAnthropicPromptFingerprint(body []byte) tkAnthropicPromptFingerpri
 	messages := gjson.GetBytes(body, "messages")
 	if messages.IsArray() {
 		for _, msg := range messages.Array() {
-			tkApplyMessageContentFingerprint(msg.Get("content"), &fp)
+			role := msg.Get("role").String()
+			content := msg.Get("content")
+			tkApplyMessageContentFingerprint(content, &fp)
+			tkApplyMessageToolFingerprint(content, role, &fp)
+		}
+	}
+	if fp.HasToolResult {
+		if violation := tkValidateAnthropicToolContext(body, false); violation != nil {
+			fp.UnknownSurfaces = appendUniqueString(fp.UnknownSurfaces, violation.Reason)
+		}
+		if fp.SystemBlockCount == 0 && !fp.HasSystemReminder {
+			fp.UnknownSurfaces = appendUniqueString(fp.UnknownSurfaces, "tool_result_without_system_surface")
 		}
 	}
 
@@ -104,8 +117,10 @@ func tkApplySystemTextFingerprint(text string, fp *tkAnthropicPromptFingerprint)
 		strings.Contains(text, claudeCodeBillingHeaderPrefix) {
 		fp.BillingPrefixPresent = true
 	}
-	if fp.IdentityAnchorID == tkIdentityAnchorAbsent {
-		fp.IdentityAnchorID = tkMatchPromptIdentityAnchor(text)
+	anchor := tkMatchPromptIdentityAnchor(text)
+	if fp.IdentityAnchorID == tkIdentityAnchorAbsent ||
+		(fp.IdentityAnchorID == tkIdentityAnchorUnknown && anchor != tkIdentityAnchorAbsent) {
+		fp.IdentityAnchorID = anchor
 	}
 	if tkCCPromptSurfaceClassTracksLeaks(cls) {
 		dateClass := tkClassifyGeoStegoDateLine(text)
@@ -156,6 +171,22 @@ func tkApplyMessageContentFingerprint(content gjson.Result, fp *tkAnthropicPromp
 						fp.UnknownSurfaces = appendUniqueString(fp.UnknownSurfaces, "geo_stego_date_line")
 					}
 				}
+			}
+		}
+	}
+}
+
+func tkApplyMessageToolFingerprint(content gjson.Result, role string, fp *tkAnthropicPromptFingerprint) {
+	if content.Type != gjson.JSON || !content.IsArray() {
+		return
+	}
+	for _, block := range content.Array() {
+		switch block.Get("type").String() {
+		case "tool_result":
+			fp.HasToolResult = true
+		case "tool_use":
+			if role == "assistant" {
+				fp.HasAssistantToolUse = true
 			}
 		}
 	}
@@ -221,11 +252,13 @@ func tkPromptSurfaceSignature(fp tkAnthropicPromptFingerprint) string {
 		classParts = append(classParts, string(cls))
 	}
 	raw := fmt.Sprintf(
-		"sys=%d|id=%s|bill=%t|rem=%t|classes=%s|date=%s|geo=%t|unk=%s",
+		"sys=%d|id=%s|bill=%t|rem=%t|tool_result=%t|assistant_tool_use=%t|classes=%s|date=%s|geo=%t|unk=%s",
 		fp.SystemBlockCount,
 		fp.IdentityAnchorID,
 		fp.BillingPrefixPresent,
 		fp.HasSystemReminder,
+		fp.HasToolResult,
+		fp.HasAssistantToolUse,
 		strings.Join(classParts, "+"),
 		fp.ReminderDateLineClass,
 		fp.GeoStegoCanonical,
@@ -318,6 +351,8 @@ func tkLogAnthropicPromptFingerprint(
 		slog.String("identity_anchor_id", fp.IdentityAnchorID),
 		slog.Bool("billing_prefix_present", fp.BillingPrefixPresent),
 		slog.Bool("has_system_reminder", fp.HasSystemReminder),
+		slog.Bool("has_tool_result", fp.HasToolResult),
+		slog.Bool("has_assistant_tool_use", fp.HasAssistantToolUse),
 		slog.String("prompt_surface_classes", tkJoinPromptSurfaceClasses(fp.PromptSurfaceClasses)),
 		slog.String("reminder_date_line_class", fp.ReminderDateLineClass),
 		slog.Bool("geo_stego_canonical", fp.GeoStegoCanonical),

--- a/backend/internal/service/gateway_request_tk_prompt_fingerprint_test.go
+++ b/backend/internal/service/gateway_request_tk_prompt_fingerprint_test.go
@@ -136,6 +136,21 @@ func TestTkExtractAnthropicPromptFingerprint_FlagsNonImmediateToolResult(t *test
 	require.Contains(t, fp.UnknownSurfaces, "orphan_tool_result_context")
 }
 
+func TestTkExtractAnthropicPromptFingerprint_FlagsDuplicateToolResult(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"toolu_01","content":"first"},
+				{"type":"tool_result","tool_use_id":"toolu_01","content":"second"}
+			]}
+		]
+	}`)
+	fp := tkExtractAnthropicPromptFingerprint(body)
+	require.True(t, fp.HasToolResult)
+	require.Contains(t, fp.UnknownSurfaces, "duplicate_tool_result_for_tool_use")
+}
+
 func TestTkExtractAnthropicPromptFingerprint_AllowsSdkToolContinuationWithContext(t *testing.T) {
 	body := []byte(`{
 		"system":[

--- a/backend/internal/service/gateway_request_tk_prompt_fingerprint_test.go
+++ b/backend/internal/service/gateway_request_tk_prompt_fingerprint_test.go
@@ -101,6 +101,64 @@ func TestTkExtractAnthropicPromptFingerprint_PlainUserPromptSurfaceSample(t *tes
 	require.Empty(t, fp.UnknownSurfaces)
 }
 
+func TestTkExtractAnthropicPromptFingerprint_FlagsToolResultOnlyWithoutSystem(t *testing.T) {
+	body := []byte(`{
+		"max_tokens":64000,
+		"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"raw json:\n-rw-r--r-- data.json","is_error":false}]}],
+		"model":"claude-opus-4-8",
+		"stream":true,
+		"thinking":{"type":"adaptive"}
+	}`)
+	fp := tkExtractAnthropicPromptFingerprint(body)
+	require.True(t, fp.HasToolResult)
+	require.False(t, fp.HasAssistantToolUse)
+	require.Equal(t, 0, fp.SystemBlockCount)
+	require.False(t, fp.HasSystemReminder)
+	require.ElementsMatch(t, []string{
+		"orphan_tool_result_context",
+		"tool_result_without_system_surface",
+	}, fp.UnknownSurfaces)
+	require.True(t, fp.shouldLogPromptFingerprint(nil, ""))
+}
+
+func TestTkExtractAnthropicPromptFingerprint_FlagsNonImmediateToolResult(t *testing.T) {
+	body := []byte(`{
+		"system":[{"type":"text","text":"You are a Claude agent, built on Anthropic's Claude Agent SDK."}],
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"command":"echo late"}}]},
+			{"role":"user","content":[{"type":"text","text":"unrelated user turn"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"late"}]}
+		]
+	}`)
+	fp := tkExtractAnthropicPromptFingerprint(body)
+	require.True(t, fp.HasToolResult)
+	require.True(t, fp.HasAssistantToolUse)
+	require.Contains(t, fp.UnknownSurfaces, "orphan_tool_result_context")
+}
+
+func TestTkExtractAnthropicPromptFingerprint_AllowsSdkToolContinuationWithContext(t *testing.T) {
+	body := []byte(`{
+		"system":[
+			{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.198.b93; cc_entrypoint=claude-vscode;"},
+			{"type":"text","text":"You are a Claude agent, built on Anthropic's Claude Agent SDK."}
+		],
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"<system-reminder>\nToday's date is 2026-07-03.\n</system-reminder>"},{"type":"text","text":"run echo"}]},
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"command":"echo TOOL_OK"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"TOOL_OK"}]}
+		],
+		"max_tokens":64000,
+		"thinking":{"type":"adaptive"}
+	}`)
+	fp := tkExtractAnthropicPromptFingerprint(body)
+	require.True(t, fp.HasToolResult)
+	require.True(t, fp.HasAssistantToolUse)
+	require.Equal(t, 2, fp.SystemBlockCount)
+	require.Equal(t, "claude_agent_sdk", fp.IdentityAnchorID)
+	require.NotContains(t, fp.UnknownSurfaces, "orphan_tool_result_context")
+	require.NotContains(t, fp.UnknownSurfaces, "tool_result_without_system_surface")
+}
+
 func TestTkPromptFingerprintShouldLog_OnNormalize(t *testing.T) {
 	fp := tkExtractAnthropicPromptFingerprint([]byte(`{"messages":[]}`))
 	require.True(t, fp.shouldLogPromptFingerprint(

--- a/backend/internal/service/gateway_request_tk_tool_context_guard.go
+++ b/backend/internal/service/gateway_request_tk_tool_context_guard.go
@@ -66,6 +66,10 @@ func tkValidateAnthropicToolContext(body []byte, requireSystemSurface bool) *tkA
 		}
 		resultSet := make(map[string]struct{}, len(resultIDs))
 		for _, id := range resultIDs {
+			if _, duplicate := resultSet[id]; duplicate {
+				return tkToolContextViolation("duplicate_tool_result_for_tool_use", i, id,
+					"Invalid Anthropic tool continuation: tool_result.tool_use_id is duplicated in the user message.")
+			}
 			if _, ok := toolUseIDs[id]; !ok {
 				return tkToolContextViolation("orphan_tool_result_context", i, id,
 					"Invalid Anthropic tool continuation: tool_result.tool_use_id has no matching tool_use in the immediately preceding assistant message.")

--- a/backend/internal/service/gateway_request_tk_tool_context_guard.go
+++ b/backend/internal/service/gateway_request_tk_tool_context_guard.go
@@ -1,0 +1,248 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	tkClientToolContextErrorType = "invalid_request_error"
+)
+
+type tkAnthropicToolContextViolation struct {
+	Reason       string
+	Message      string
+	MessageIndex int
+	ToolUseID    string
+}
+
+type ClientToolContextCorruptError struct {
+	Reason string
+}
+
+func (e *ClientToolContextCorruptError) Error() string {
+	if e == nil || strings.TrimSpace(e.Reason) == "" {
+		return "client tool context corrupt"
+	}
+	return "client tool context corrupt: " + e.Reason
+}
+
+func tkValidateAnthropicToolContext(body []byte, requireSystemSurface bool) *tkAnthropicToolContextViolation {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return nil
+	}
+	messageRows := messages.Array()
+	hasToolResult := false
+	for i, msg := range messageRows {
+		role := msg.Get("role").String()
+		content := msg.Get("content")
+		if role != "user" || content.Type != gjson.JSON || !content.IsArray() {
+			continue
+		}
+		resultIDs, violation := tkToolResultIDsFromUserContent(content, i)
+		if violation != nil {
+			return violation
+		}
+		if len(resultIDs) == 0 {
+			continue
+		}
+		hasToolResult = true
+		if i == 0 || messageRows[i-1].Get("role").String() != "assistant" {
+			return tkToolContextViolation("orphan_tool_result_context", i, resultIDs[0],
+				"Invalid Anthropic tool continuation: tool_result must be immediately preceded by the assistant tool_use message.")
+		}
+		toolUseIDs := tkToolUseIDsFromAssistantContent(messageRows[i-1].Get("content"))
+		if len(toolUseIDs) == 0 {
+			return tkToolContextViolation("orphan_tool_result_context", i, resultIDs[0],
+				"Invalid Anthropic tool continuation: previous assistant message has no tool_use block for the tool_result.")
+		}
+		resultSet := make(map[string]struct{}, len(resultIDs))
+		for _, id := range resultIDs {
+			if _, ok := toolUseIDs[id]; !ok {
+				return tkToolContextViolation("orphan_tool_result_context", i, id,
+					"Invalid Anthropic tool continuation: tool_result.tool_use_id has no matching tool_use in the immediately preceding assistant message.")
+			}
+			resultSet[id] = struct{}{}
+		}
+		for id := range toolUseIDs {
+			if _, ok := resultSet[id]; !ok {
+				return tkToolContextViolation("missing_tool_result_for_tool_use", i, id,
+					"Invalid Anthropic tool continuation: assistant tool_use was not answered by the immediately following user tool_result message.")
+			}
+		}
+	}
+	if hasToolResult && requireSystemSurface && !tkAnthropicBodyHasSystemSurface(body) {
+		return tkToolContextViolation("tool_result_without_system_surface", -1, "",
+			"Invalid Claude Code tool continuation: tool_result request is missing the expected system prompt surface.")
+	}
+	return nil
+}
+
+func tkToolResultIDsFromUserContent(content gjson.Result, messageIndex int) ([]string, *tkAnthropicToolContextViolation) {
+	blocks := content.Array()
+	resultIDs := make([]string, 0)
+	seenNonToolResult := false
+	for _, block := range blocks {
+		blockType := block.Get("type").String()
+		if blockType != "tool_result" {
+			seenNonToolResult = true
+			continue
+		}
+		if seenNonToolResult {
+			return nil, tkToolContextViolation("tool_result_not_leading", messageIndex, block.Get("tool_use_id").String(),
+				"Invalid Anthropic tool continuation: tool_result blocks must appear before any other content in the user message.")
+		}
+		id := strings.TrimSpace(block.Get("tool_use_id").String())
+		if id == "" {
+			return nil, tkToolContextViolation("tool_result_missing_tool_use_id", messageIndex, "",
+				"Invalid Anthropic tool continuation: tool_result is missing tool_use_id.")
+		}
+		resultIDs = append(resultIDs, id)
+	}
+	return resultIDs, nil
+}
+
+func tkToolUseIDsFromAssistantContent(content gjson.Result) map[string]struct{} {
+	out := map[string]struct{}{}
+	if content.Type != gjson.JSON || !content.IsArray() {
+		return out
+	}
+	for _, block := range content.Array() {
+		if block.Get("type").String() != "tool_use" {
+			continue
+		}
+		id := strings.TrimSpace(block.Get("id").String())
+		if id != "" {
+			out[id] = struct{}{}
+		}
+	}
+	return out
+}
+
+func tkAnthropicBodyHasSystemSurface(body []byte) bool {
+	system := gjson.GetBytes(body, "system")
+	switch system.Type {
+	case gjson.String:
+		if strings.TrimSpace(system.String()) != "" {
+			return true
+		}
+	case gjson.JSON:
+		if system.IsArray() {
+			for _, item := range system.Array() {
+				if strings.TrimSpace(item.Get("text").String()) != "" {
+					return true
+				}
+			}
+		}
+	}
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return false
+	}
+	for _, msg := range messages.Array() {
+		content := msg.Get("content")
+		switch content.Type {
+		case gjson.String:
+			if strings.Contains(content.String(), "<system-reminder>") {
+				return true
+			}
+		case gjson.JSON:
+			if !content.IsArray() {
+				continue
+			}
+			for _, block := range content.Array() {
+				if block.Get("type").String() == "text" &&
+					strings.Contains(block.Get("text").String(), "<system-reminder>") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func tkToolContextViolation(reason string, messageIndex int, toolUseID string, message string) *tkAnthropicToolContextViolation {
+	return &tkAnthropicToolContextViolation{
+		Reason:       reason,
+		Message:      message,
+		MessageIndex: messageIndex,
+		ToolUseID:    toolUseID,
+	}
+}
+
+func (s *GatewayService) tkRejectInvalidAnthropicToolContext(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	requireSystemSurface bool,
+	passthrough bool,
+) error {
+	violation := tkValidateAnthropicToolContext(body, requireSystemSurface)
+	if violation == nil {
+		return nil
+	}
+	requestID := ""
+	if ctx != nil {
+		requestID, _ = ctx.Value(ctxkey.RequestID).(string)
+	}
+	accountID := int64(0)
+	accountName := ""
+	platform := PlatformAnthropic
+	if account != nil {
+		accountID = account.ID
+		accountName = account.Name
+		platform = account.Platform
+	}
+	setOpsUpstreamRequestBody(c, body)
+	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+		Platform:           platform,
+		AccountID:          accountID,
+		AccountName:        accountName,
+		UpstreamStatusCode: 0,
+		Passthrough:        passthrough,
+		Kind:               OpsUpstreamKindClientToolContextCorrupt,
+		Message:            violation.Message,
+		Detail:             fmt.Sprintf("reason=%s message_index=%d tool_use_id=%s", violation.Reason, violation.MessageIndex, violation.ToolUseID),
+	})
+	MarkOpsClientPolicyDenied(c, OpsClientPolicyDeniedReasonLocalPolicyDenied)
+	slog.Warn("gateway.anthropic_client_tool_context_rejected",
+		slog.String("request_id", requestID),
+		slog.Int64("account_id", accountID),
+		slog.String("reason", violation.Reason),
+		slog.Int("message_index", violation.MessageIndex),
+		slog.String("tool_use_id", violation.ToolUseID),
+	)
+	if c != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"type": "error",
+			"error": gin.H{
+				"type":    tkClientToolContextErrorType,
+				"message": violation.Message + " Start a new session or resume from a clean summary.",
+			},
+		})
+		MarkResponseCommitted(c)
+	}
+	return &ClientToolContextCorruptError{Reason: violation.Reason}
+}
+
+func (s *GatewayService) tkRequiresClaudeCodeSystemSurface(ctx context.Context, c *gin.Context, account *Account) bool {
+	if account != nil && s != nil && s.isCanonicalAnthropicOAuth(account) {
+		return true
+	}
+	if IsClaudeCodeClient(ctx) {
+		return true
+	}
+	if c != nil && c.Request != nil {
+		return strings.HasPrefix(strings.ToLower(strings.TrimSpace(c.GetHeader("User-Agent"))), "claude-cli/")
+	}
+	return false
+}

--- a/backend/internal/service/gateway_request_tk_tool_context_guard_test.go
+++ b/backend/internal/service/gateway_request_tk_tool_context_guard_test.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkValidateAnthropicToolContext_FlagsToolResultOnly(t *testing.T) {
+	body := []byte(`{
+		"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"ok"}]}],
+		"max_tokens":64000,
+		"thinking":{"type":"adaptive"}
+	}`)
+	violation := tkValidateAnthropicToolContext(body, false)
+	require.NotNil(t, violation)
+	require.Equal(t, "orphan_tool_result_context", violation.Reason)
+	require.Equal(t, 0, violation.MessageIndex)
+	require.Equal(t, "toolu_01", violation.ToolUseID)
+}
+
+func TestTkValidateAnthropicToolContext_AllowsSdkToolContinuation(t *testing.T) {
+	body := []byte(`{
+		"system":[
+			{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.198.b93; cc_entrypoint=claude-vscode;"},
+			{"type":"text","text":"You are a Claude agent, built on Anthropic's Claude Agent SDK."}
+		],
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"<system-reminder>\nToday's date is 2026-07-03.\n</system-reminder>"},{"type":"text","text":"run echo"}]},
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"command":"echo TOOL_OK"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"TOOL_OK"}]}
+		],
+		"max_tokens":64000,
+		"thinking":{"type":"adaptive"}
+	}`)
+	require.Nil(t, tkValidateAnthropicToolContext(body, true))
+}
+
+func TestTkValidateAnthropicToolContext_FlagsMissingParallelToolResult(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"tool_use","id":"toolu_a","name":"Read","input":{}},
+				{"type":"tool_use","id":"toolu_b","name":"Read","input":{}}
+			]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_a","content":"ok"}]}
+		]
+	}`)
+	violation := tkValidateAnthropicToolContext(body, false)
+	require.NotNil(t, violation)
+	require.Equal(t, "missing_tool_result_for_tool_use", violation.Reason)
+	require.Equal(t, "toolu_b", violation.ToolUseID)
+}
+
+func TestTkValidateAnthropicToolContext_FlagsToolResultWithoutSystemWhenRequired(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"ok"}]}
+		]
+	}`)
+	require.Nil(t, tkValidateAnthropicToolContext(body, false))
+	violation := tkValidateAnthropicToolContext(body, true)
+	require.NotNil(t, violation)
+	require.Equal(t, "tool_result_without_system_surface", violation.Reason)
+}
+
+func TestTkRejectInvalidAnthropicToolContext_WritesLocalClientErrorAndOpsEvent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"ok"}]}]}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	ctx := context.WithValue(context.Background(), ctxkey.RequestID, "req_guard")
+	account := &Account{ID: 13, Name: "oh-3-g", Platform: PlatformAnthropic}
+
+	err := (&GatewayService{}).tkRejectInvalidAnthropicToolContext(ctx, c, account, body, true, false)
+	var guardErr *ClientToolContextCorruptError
+	require.ErrorAs(t, err, &guardErr)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "Invalid Anthropic tool continuation")
+	require.True(t, IsResponseCommitted(c))
+
+	rawEvents, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	events, ok := rawEvents.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.Len(t, events, 1)
+	require.Equal(t, OpsUpstreamKindClientToolContextCorrupt, events[0].Kind)
+	require.Equal(t, int64(13), events[0].AccountID)
+	require.Equal(t, 0, events[0].UpstreamStatusCode)
+	require.Contains(t, events[0].UpstreamRequestBody, `"tool_result"`)
+}

--- a/backend/internal/service/gateway_request_tk_tool_context_guard_test.go
+++ b/backend/internal/service/gateway_request_tk_tool_context_guard_test.go
@@ -58,6 +58,22 @@ func TestTkValidateAnthropicToolContext_FlagsMissingParallelToolResult(t *testin
 	require.Equal(t, "toolu_b", violation.ToolUseID)
 }
 
+func TestTkValidateAnthropicToolContext_FlagsDuplicateToolResult(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_a","name":"Read","input":{}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"toolu_a","content":"first"},
+				{"type":"tool_result","tool_use_id":"toolu_a","content":"second"}
+			]}
+		]
+	}`)
+	violation := tkValidateAnthropicToolContext(body, false)
+	require.NotNil(t, violation)
+	require.Equal(t, "duplicate_tool_result_for_tool_use", violation.Reason)
+	require.Equal(t, "toolu_a", violation.ToolUseID)
+}
+
 func TestTkValidateAnthropicToolContext_FlagsToolResultWithoutSystemWhenRequired(t *testing.T) {
 	body := []byte(`{
 		"messages":[

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -5358,6 +5358,11 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	if account.Platform == PlatformAnthropic {
 		body = s.applySigPreemptIfArmed(ctx, c, account, body, reqModel)
 	}
+	if account.Platform == PlatformAnthropic {
+		if err := s.tkRejectInvalidAnthropicToolContext(ctx, c, account, body, s.tkRequiresClaudeCodeSystemSurface(ctx, c, account), false); err != nil {
+			return nil, err
+		}
+	}
 
 	// 重试间复用同一请求体，避免每次 string(body) 产生额外分配。
 	setOpsUpstreamRequestBody(c, body)
@@ -6110,6 +6115,11 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	// account has been recently throwing signature_error.
 	if account.Platform == PlatformAnthropic {
 		input.Body = s.applySigPreemptIfArmed(ctx, c, account, input.Body, input.RequestModel)
+	}
+	if account.Platform == PlatformAnthropic {
+		if err := s.tkRejectInvalidAnthropicToolContext(ctx, c, account, input.Body, s.tkRequiresClaudeCodeSystemSurface(ctx, c, account), true); err != nil {
+			return nil, err
+		}
 	}
 
 	// 重试间复用同一请求体，避免每次 string(body) 产生额外分配。
@@ -10869,6 +10879,11 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	if account.Platform == PlatformAnthropic {
 		body = s.applySigPreemptIfArmed(ctx, c, account, body, reqModel)
 	}
+	if account.Platform == PlatformAnthropic {
+		if err := s.tkRejectInvalidAnthropicToolContext(ctx, c, account, body, s.tkRequiresClaudeCodeSystemSurface(ctx, c, account), false); err != nil {
+			return err
+		}
+	}
 
 	// 构建上游请求
 	upstreamReq, wireBody, err := s.buildCountTokensRequest(ctx, c, account, body, token, tokenType, reqModel, shouldMimicClaudeCode)
@@ -11046,6 +11061,11 @@ func (s *GatewayService) forwardCountTokensAnthropicAPIKeyPassthrough(ctx contex
 	// TK: CC prompt-surface normalize (passthrough skips the full normalize hook).
 	if s != nil && s.settingService != nil && s.settingService.IsAnthropicRequestNormalizeEnabled(ctx) {
 		body, _ = tkApplyAnthropicCCPromptSurfaceNormalize(ctx, c, account, body)
+	}
+	if account.Platform == PlatformAnthropic {
+		if err := s.tkRejectInvalidAnthropicToolContext(ctx, c, account, body, s.tkRequiresClaudeCodeSystemSurface(ctx, c, account), true); err != nil {
+			return err
+		}
 	}
 
 	upstreamReq, err := s.buildCountTokensRequestAnthropicAPIKeyPassthrough(ctx, c, account, body, token)

--- a/backend/internal/service/identity_service_tk_canonical_http_test.go
+++ b/backend/internal/service/identity_service_tk_canonical_http_test.go
@@ -186,6 +186,43 @@ func TestGetOrCreateFingerprint_CanonicalProfile_DoesNotAdoptIngressUAUpgrade(t 
 	require.Equal(t, "client-seed", fp.ClientID)
 }
 
+func TestGetOrCreateFingerprint_CanonicalProfile_NormalizesObservedIncidentUAs(t *testing.T) {
+	resetResolver(t)
+	cache := &fingerprintCacheRecorder{}
+	svc := NewIdentityService(cache)
+
+	observedUAs := []string{
+		"claude-cli/2.1.187 (external, cli)",
+		"claude-cli/2.1.197 (external, cli)",
+		"claude-cli/2.1.195 (external, claude-vscode, agent-sdk/0.3.195)",
+		"claude-cli/2.1.196 (external, claude-vscode, agent-sdk/0.3.196)",
+		"claude-cli/2.1.198 (external, claude-vscode, agent-sdk/0.3.198)",
+	}
+	expectedUA := GetCanonicalUserAgentForContext(context.Background())
+	var clientID string
+
+	for _, ua := range observedUAs {
+		t.Run(ua, func(t *testing.T) {
+			hdr := http.Header{}
+			hdr.Set("User-Agent", ua)
+			hdr.Set("X-Stainless-Package-Version", "9.9.9")
+			hdr.Set("X-Stainless-OS", "Linux")
+			hdr.Set("X-Stainless-Runtime-Version", "v99.99.99")
+
+			fp, err := svc.GetOrCreateFingerprint(context.Background(), 13, hdr, canonicalTLSFingerprintProfileName)
+			require.NoError(t, err)
+			require.Equal(t, expectedUA, fp.UserAgent)
+			require.Equal(t, canonicalHTTPObservedStatic.StainlessPackageVersion, fp.StainlessPackageVersion)
+			require.Equal(t, canonicalHTTPObservedStatic.StainlessOS, fp.StainlessOS)
+			require.Equal(t, canonicalHTTPObservedStatic.StainlessRuntimeVersion, fp.StainlessRuntimeVersion)
+			if clientID == "" {
+				clientID = fp.ClientID
+			}
+			require.Equal(t, clientID, fp.ClientID)
+		})
+	}
+}
+
 func TestGetOrCreateFingerprint_CanonicalProfile_AdoptsResolverUpdate(t *testing.T) {
 	resetResolver(t)
 	cache := &fingerprintCacheRecorder{}

--- a/backend/internal/service/ops_upstream_context.go
+++ b/backend/internal/service/ops_upstream_context.go
@@ -32,6 +32,11 @@ const (
 	// these; gateway.anthropic_request_normalized slog is the canonical audit path.
 	OpsUpstreamKindRequestNormalized = "request_normalized"
 
+	// OpsUpstreamKindClientToolContextCorrupt marks a local Anthropic request
+	// rejection before any upstream call because user/tool_result context no
+	// longer matches the required immediately preceding assistant/tool_use turn.
+	OpsUpstreamKindClientToolContextCorrupt = "client_tool_context_corrupt"
+
 	// OpsInternalErrorDetailKey carries a sanitized, truncated detail string for
 	// internal-phase errors (cache/redis/db/context failures) that bubble up as
 	// 5xx from middleware. Distinct from upstream-* keys so dashboards don't

--- a/ops/anthropic/probe_prompt_surfaces.py
+++ b/ops/anthropic/probe_prompt_surfaces.py
@@ -145,14 +145,104 @@ def analyze_system_surfaces(registry: dict, system_texts: list[str]) -> dict:
     }
 
 
+def analyze_tool_continuation_shape(messages, system_texts: list[str], message_texts: list[str]) -> dict:
+    has_tool_result = False
+    has_assistant_tool_use = False
+    violation = ""
+    if isinstance(messages, list):
+        for i, msg in enumerate(messages):
+            if not isinstance(msg, dict):
+                continue
+            role = str(msg.get("role") or "")
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            if role == "user":
+                result_ids, result_violation = tool_result_ids_from_user_content(content)
+                if result_violation and not violation:
+                    violation = result_violation
+                if result_ids:
+                    has_tool_result = True
+                    if not violation:
+                        violation = validate_previous_assistant_tool_use(messages, i, result_ids)
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                block_type = str(block.get("type") or "")
+                if block_type == "tool_result":
+                    has_tool_result = True
+                elif block_type == "tool_use" and role == "assistant":
+                    has_assistant_tool_use = True
+    unknown: list[str] = []
+    has_system_reminder = any("<system-reminder>" in text for text in message_texts)
+    if violation:
+        unknown.append(violation)
+    if has_tool_result and not system_texts and not has_system_reminder:
+        unknown.append("tool_result_without_system_surface")
+    return {
+        "has_tool_result": has_tool_result,
+        "has_assistant_tool_use": has_assistant_tool_use,
+        "tool_continuation_violation": violation,
+        "tool_continuation_unknown_surfaces": unknown,
+    }
+
+
+def tool_result_ids_from_user_content(content: list) -> tuple[list[str], str]:
+    result_ids: list[str] = []
+    seen_non_tool_result = False
+    for block in content:
+        if not isinstance(block, dict):
+            seen_non_tool_result = True
+            continue
+        if str(block.get("type") or "") != "tool_result":
+            seen_non_tool_result = True
+            continue
+        if seen_non_tool_result:
+            return [], "tool_result_not_leading"
+        tool_use_id = str(block.get("tool_use_id") or "").strip()
+        if not tool_use_id:
+            return [], "tool_result_missing_tool_use_id"
+        result_ids.append(tool_use_id)
+    return result_ids, ""
+
+
+def validate_previous_assistant_tool_use(messages: list, index: int, result_ids: list[str]) -> str:
+    if index == 0:
+        return "orphan_tool_result_context"
+    previous = messages[index - 1]
+    if not isinstance(previous, dict) or str(previous.get("role") or "") != "assistant":
+        return "orphan_tool_result_context"
+    tool_use_ids: set[str] = set()
+    previous_content = previous.get("content")
+    if isinstance(previous_content, list):
+        for block in previous_content:
+            if not isinstance(block, dict) or str(block.get("type") or "") != "tool_use":
+                continue
+            tool_use_id = str(block.get("id") or "").strip()
+            if tool_use_id:
+                tool_use_ids.add(tool_use_id)
+    if not tool_use_ids:
+        return "orphan_tool_result_context"
+    result_set = set(result_ids)
+    for tool_use_id in result_ids:
+        if tool_use_id not in tool_use_ids:
+            return "orphan_tool_result_context"
+    for tool_use_id in tool_use_ids:
+        if tool_use_id not in result_set:
+            return "missing_tool_result_for_tool_use"
+    return ""
+
+
 def analyze_record(registry: dict, geo_mod, rec: dict) -> dict:
     geo_row = geo_mod.analyze_record(rec)
     wire = geo_mod.body_wire_from_record(rec)
     system_texts: list[str] = []
     message_texts: list[str] = []
+    raw_messages = None
     if wire is not None:
         system_texts = geo_mod.extract_system_texts(wire.get("system"))
-        for msg in wire.get("messages") or []:
+        raw_messages = wire.get("messages")
+        for msg in raw_messages or []:
             if not isinstance(msg, dict):
                 continue
             content = msg.get("content")
@@ -165,7 +255,9 @@ def analyze_record(registry: dict, geo_mod, rec: dict) -> dict:
     else:
         body = rec.get("body") or {}
         system_texts = geo_mod.extract_system_texts(body.get("system"))
+        raw_messages = body.get("messages")
     sys_row = analyze_system_surfaces(registry, system_texts)
+    tool_row = analyze_tool_continuation_shape(raw_messages, system_texts, message_texts)
     unknown: list[str] = []
     if geo_row.get("needs_normalize"):
         unknown.append("geo_stego_date_line")
@@ -176,9 +268,11 @@ def analyze_record(registry: dict, geo_mod, rec: dict) -> dict:
         unknown.append("cc_environment_section")
     if "The user's email address is" in combined_text:
         unknown.append("cc_user_email")
+    unknown.extend(tool_row["tool_continuation_unknown_surfaces"])
     return {
         **geo_row,
         **sys_row,
+        **tool_row,
         "unknown_surfaces": unknown,
         "needs_attention": bool(unknown),
     }

--- a/ops/anthropic/probe_prompt_surfaces.py
+++ b/ops/anthropic/probe_prompt_surfaces.py
@@ -187,9 +187,27 @@ def analyze_tool_continuation_shape(messages, system_texts: list[str], message_t
     }
 
 
+def extract_message_texts(messages) -> list[str]:
+    texts: list[str] = []
+    if not isinstance(messages, list):
+        return texts
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            texts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    texts.append(str(block.get("text") or ""))
+    return texts
+
+
 def tool_result_ids_from_user_content(content: list) -> tuple[list[str], str]:
     result_ids: list[str] = []
     seen_non_tool_result = False
+    seen_result_ids: set[str] = set()
     for block in content:
         if not isinstance(block, dict):
             seen_non_tool_result = True
@@ -202,6 +220,9 @@ def tool_result_ids_from_user_content(content: list) -> tuple[list[str], str]:
         tool_use_id = str(block.get("tool_use_id") or "").strip()
         if not tool_use_id:
             return [], "tool_result_missing_tool_use_id"
+        if tool_use_id in seen_result_ids:
+            return [], "duplicate_tool_result_for_tool_use"
+        seen_result_ids.add(tool_use_id)
         result_ids.append(tool_use_id)
     return result_ids, ""
 
@@ -242,20 +263,12 @@ def analyze_record(registry: dict, geo_mod, rec: dict) -> dict:
     if wire is not None:
         system_texts = geo_mod.extract_system_texts(wire.get("system"))
         raw_messages = wire.get("messages")
-        for msg in raw_messages or []:
-            if not isinstance(msg, dict):
-                continue
-            content = msg.get("content")
-            if isinstance(content, str):
-                message_texts.append(content)
-            elif isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        message_texts.append(str(block.get("text") or ""))
+        message_texts = extract_message_texts(raw_messages)
     else:
         body = rec.get("body") or {}
         system_texts = geo_mod.extract_system_texts(body.get("system"))
         raw_messages = body.get("messages")
+        message_texts = extract_message_texts(raw_messages)
     sys_row = analyze_system_surfaces(registry, system_texts)
     tool_row = analyze_tool_continuation_shape(raw_messages, system_texts, message_texts)
     unknown: list[str] = []

--- a/ops/anthropic/prompt_surface_registry.json
+++ b/ops/anthropic/prompt_surface_registry.json
@@ -85,6 +85,15 @@
       "prod_alert_value": "tool_result_missing_tool_use_id"
     },
     {
+      "id": "duplicate_tool_result_for_tool_use",
+      "probe_module": "tool_continuation_shape",
+      "locations": ["messages[].content[].tool_use_id"],
+      "signals": ["multiple tool_result blocks answer the same tool_use_id"],
+      "gateway_normalize": null,
+      "prod_fingerprint_field": "unknown_surfaces",
+      "prod_alert_value": "duplicate_tool_result_for_tool_use"
+    },
+    {
       "id": "tool_result_without_system_surface",
       "probe_module": "tool_continuation_shape",
       "locations": ["system", "messages[].content[].type"],

--- a/ops/anthropic/prompt_surface_registry.json
+++ b/ops/anthropic/prompt_surface_registry.json
@@ -49,6 +49,51 @@
       "prod_alert_value": "cc_user_email"
     },
     {
+      "id": "orphan_tool_result_context",
+      "probe_module": "tool_continuation_shape",
+      "locations": ["messages[].content[].type"],
+      "signals": ["tool_result not immediately preceded by a matching assistant tool_use"],
+      "gateway_normalize": null,
+      "prod_fingerprint_field": "unknown_surfaces",
+      "prod_alert_value": "orphan_tool_result_context"
+    },
+    {
+      "id": "missing_tool_result_for_tool_use",
+      "probe_module": "tool_continuation_shape",
+      "locations": ["messages[].content[].type"],
+      "signals": ["assistant tool_use not fully answered by the immediately following user tool_result message"],
+      "gateway_normalize": null,
+      "prod_fingerprint_field": "unknown_surfaces",
+      "prod_alert_value": "missing_tool_result_for_tool_use"
+    },
+    {
+      "id": "tool_result_not_leading",
+      "probe_module": "tool_continuation_shape",
+      "locations": ["messages[].content[].type"],
+      "signals": ["tool_result appears after non-tool_result content in a user message"],
+      "gateway_normalize": null,
+      "prod_fingerprint_field": "unknown_surfaces",
+      "prod_alert_value": "tool_result_not_leading"
+    },
+    {
+      "id": "tool_result_missing_tool_use_id",
+      "probe_module": "tool_continuation_shape",
+      "locations": ["messages[].content[].tool_use_id"],
+      "signals": ["tool_result is missing tool_use_id"],
+      "gateway_normalize": null,
+      "prod_fingerprint_field": "unknown_surfaces",
+      "prod_alert_value": "tool_result_missing_tool_use_id"
+    },
+    {
+      "id": "tool_result_without_system_surface",
+      "probe_module": "tool_continuation_shape",
+      "locations": ["system", "messages[].content[].type"],
+      "signals": ["tool_result with no system block and no system-reminder"],
+      "gateway_normalize": null,
+      "prod_fingerprint_field": "unknown_surfaces",
+      "prod_alert_value": "tool_result_without_system_surface"
+    },
+    {
       "id": "system_identity_anchor",
       "probe_module": "system_anchor",
       "locations": ["system[].text"],

--- a/ops/anthropic/test_probe_prompt_surfaces.py
+++ b/ops/anthropic/test_probe_prompt_surfaces.py
@@ -53,6 +53,105 @@ class TestPromptSurfaceAnalyze(unittest.TestCase):
         self.assertEqual(billing["identity_anchor_id"], "claude_code_cli")
         self.assertTrue(billing["billing_prefix_present"])
 
+    def test_analyze_tool_result_only_shape(self) -> None:
+        records = [
+            {
+                "scenario": "incident_tool_result_only",
+                "body_wire": {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": "toolu_01",
+                                    "content": "raw json:\n-rw-r--r-- data.json",
+                                    "is_error": False,
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+            {
+                "scenario": "sdk_tool_continuation",
+                "body_wire": {
+                    "system": [
+                        {
+                            "type": "text",
+                            "text": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+                        }
+                    ],
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "<system-reminder>\nToday's date is 2026-07-03.\n</system-reminder>"}
+                            ],
+                        },
+                        {
+                            "role": "assistant",
+                            "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {}}],
+                        },
+                        {
+                            "role": "user",
+                            "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "ok"}],
+                        },
+                    ],
+                },
+            },
+            {
+                "scenario": "non_immediate_tool_result",
+                "body_wire": {
+                    "system": [
+                        {
+                            "type": "text",
+                            "text": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+                        }
+                    ],
+                    "messages": [
+                        {
+                            "role": "assistant",
+                            "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {}}],
+                        },
+                        {
+                            "role": "user",
+                            "content": [{"type": "text", "text": "unrelated"}],
+                        },
+                        {
+                            "role": "user",
+                            "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "late"}],
+                        },
+                    ],
+                },
+            },
+        ]
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+            for rec in records:
+                f.write(json.dumps(rec) + "\n")
+            path = Path(f.name)
+        proc = subprocess.run(
+            [sys.executable, str(PROBE), str(path), "--json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        rows = json.loads(proc.stdout)
+        incident = next(r for r in rows if r.get("scenario") == "incident_tool_result_only")
+        self.assertTrue(incident["has_tool_result"])
+        self.assertFalse(incident["has_assistant_tool_use"])
+        self.assertIn("orphan_tool_result_context", incident["unknown_surfaces"])
+        self.assertIn("tool_result_without_system_surface", incident["unknown_surfaces"])
+        sdk = next(r for r in rows if r.get("scenario") == "sdk_tool_continuation")
+        self.assertTrue(sdk["has_tool_result"])
+        self.assertTrue(sdk["has_assistant_tool_use"])
+        self.assertNotIn("orphan_tool_result_context", sdk["unknown_surfaces"])
+        non_immediate = next(r for r in rows if r.get("scenario") == "non_immediate_tool_result")
+        self.assertTrue(non_immediate["has_tool_result"])
+        self.assertTrue(non_immediate["has_assistant_tool_use"])
+        self.assertIn("orphan_tool_result_context", non_immediate["unknown_surfaces"])
+
 
 class TestPromptSurfaceAggregate(unittest.TestCase):
     def test_flags_unknown_surfaces(self) -> None:
@@ -63,6 +162,8 @@ class TestPromptSurfaceAggregate(unittest.TestCase):
                     "reminder_date_line_class": "SLASH_UNICODE",
                     "identity_anchor_id": "claude_code_cli",
                     "unknown_surfaces": "geo_stego_date_line",
+                    "has_tool_result": True,
+                    "has_assistant_tool_use": False,
                 }
             ]
         }
@@ -77,6 +178,7 @@ class TestPromptSurfaceAggregate(unittest.TestCase):
         )
         self.assertEqual(proc.returncode, 1)
         self.assertIn("actionable_drift", proc.stdout)
+        self.assertIn("tool_result_without_assistant_tool_use: 1", proc.stdout)
 
 
 if __name__ == "__main__":

--- a/ops/anthropic/test_probe_prompt_surfaces.py
+++ b/ops/anthropic/test_probe_prompt_surfaces.py
@@ -125,6 +125,48 @@ class TestPromptSurfaceAnalyze(unittest.TestCase):
                     ],
                 },
             },
+            {
+                "scenario": "raw_body_system_reminder_tool_result",
+                "body": {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "<system-reminder>\nToday's date is 2026-07-03.\n</system-reminder>",
+                                }
+                            ],
+                        },
+                        {
+                            "role": "assistant",
+                            "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {}}],
+                        },
+                        {
+                            "role": "user",
+                            "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "ok"}],
+                        },
+                    ]
+                },
+            },
+            {
+                "scenario": "duplicate_tool_result",
+                "body_wire": {
+                    "messages": [
+                        {
+                            "role": "assistant",
+                            "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {}}],
+                        },
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "tool_result", "tool_use_id": "toolu_01", "content": "first"},
+                                {"type": "tool_result", "tool_use_id": "toolu_01", "content": "second"},
+                            ],
+                        },
+                    ]
+                },
+            },
         ]
         with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
             for rec in records:
@@ -151,6 +193,12 @@ class TestPromptSurfaceAnalyze(unittest.TestCase):
         self.assertTrue(non_immediate["has_tool_result"])
         self.assertTrue(non_immediate["has_assistant_tool_use"])
         self.assertIn("orphan_tool_result_context", non_immediate["unknown_surfaces"])
+        raw_body = next(r for r in rows if r.get("scenario") == "raw_body_system_reminder_tool_result")
+        self.assertTrue(raw_body["has_tool_result"])
+        self.assertNotIn("tool_result_without_system_surface", raw_body["unknown_surfaces"])
+        duplicate = next(r for r in rows if r.get("scenario") == "duplicate_tool_result")
+        self.assertTrue(duplicate["has_tool_result"])
+        self.assertIn("duplicate_tool_result_for_tool_use", duplicate["unknown_surfaces"])
 
 
 class TestPromptSurfaceAggregate(unittest.TestCase):

--- a/ops/observability/prompt_surface_aggregate.py
+++ b/ops/observability/prompt_surface_aggregate.py
@@ -25,6 +25,12 @@ def canonical_geo_classes(registry: dict) -> set[str]:
     return {"NONE", "ISO_DASH_ASCII"}
 
 
+def truthy(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() == "true"
+
+
 def aggregate(payload: dict, registry: dict) -> dict:
     fps = payload.get("fingerprints") or []
     sig_counter: Counter[str] = Counter()
@@ -33,6 +39,8 @@ def aggregate(payload: dict, registry: dict) -> dict:
     unknown_surfaces: Counter[str] = Counter()
     noncanonical_geo = 0
     cc_environment = 0
+    tool_result_rows = 0
+    tool_result_without_assistant_tool_use = 0
     canonical_geo = canonical_geo_classes(registry)
 
     for row in fps:
@@ -52,6 +60,11 @@ def aggregate(payload: dict, registry: dict) -> dict:
                     unknown_surfaces[item] += 1
                     if item == "cc_environment_section":
                         cc_environment += 1
+        has_tool_result = truthy(row.get("has_tool_result"))
+        if has_tool_result:
+            tool_result_rows += 1
+            if not truthy(row.get("has_assistant_tool_use")):
+                tool_result_without_assistant_tool_use += 1
 
     alerts: list[str] = []
     agg_cfg = registry.get("aggregate") or {}
@@ -70,6 +83,8 @@ def aggregate(payload: dict, registry: dict) -> dict:
         "unknown_surfaces": dict(unknown_surfaces),
         "noncanonical_geo_count": noncanonical_geo,
         "cc_environment_leak_count": cc_environment,
+        "tool_result_rows": tool_result_rows,
+        "tool_result_without_assistant_tool_use": tool_result_without_assistant_tool_use,
         "alerts": alerts,
         "has_actionable_drift": bool(alerts),
     }
@@ -109,6 +124,9 @@ def main() -> int:
         "",
         f"- rows: {report['summary']['count']}",
         f"- actionable_drift: {report['summary']['has_actionable_drift']}",
+        f"- tool_result_rows: {report['summary']['tool_result_rows']}",
+        "- tool_result_without_assistant_tool_use: "
+        f"{report['summary']['tool_result_without_assistant_tool_use']}",
     ]
     for alert in report["summary"].get("alerts") or []:
         md_lines.append(f"- alert: {alert}")

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3,6 +3,45 @@
   "rationale": "Load-bearing TokenKey gateway/service injections that intentionally live in upstream-shaped hotspot files. These touches are small and compile-clean if dropped, so upstream merges can silently revert them unless preflight and upstream-merge PR shape check their literal hooks.",
   "sentinels": [
     {
+      "path": "backend/internal/service/gateway_request_tk_prompt_fingerprint.go",
+      "must_contain": [
+        "HasToolResult         bool",
+        "HasAssistantToolUse   bool",
+        "tkValidateAnthropicToolContext(body, false)",
+        "tool_result_without_system_surface",
+        "slog.Bool(\"has_tool_result\", fp.HasToolResult)"
+      ],
+      "rationale": "Anthropic prompt fingerprint logs must keep tool-continuation visibility: whether the forwarded body contains user/tool_result, whether any assistant/tool_use exists, and whether a tool_result body is missing the expected Claude Code system surface. These fields are the production watch signal for the oh-3-g(#13) incident class; dropping them compiles cleanly but blinds client-fidelity-watch to orphan tool_result context before it reaches account-health symptoms."
+    },
+    {
+      "path": "backend/internal/service/gateway_request_tk_tool_context_guard.go",
+      "must_contain": [
+        "func tkValidateAnthropicToolContext(body []byte, requireSystemSurface bool)",
+        "func (s *GatewayService) tkRejectInvalidAnthropicToolContext(",
+        "OpsUpstreamKindClientToolContextCorrupt",
+        "tool_result must be immediately preceded by the assistant tool_use message",
+        "tool_result_without_system_surface"
+      ],
+      "rationale": "Local Anthropic tool-context guard for corrupt continuations: a user/tool_result must be immediately preceded by the assistant/tool_use it answers, all tool_use ids must match, and Claude Code OAuth continuations must retain the expected system surface. The guard rejects the request locally with client-owned invalid_request_error before any upstream call. If an upstream merge drops this companion, malformed resumed sessions can again burn Anthropic account health with provider-looking 400s."
+    },
+    {
+      "path": "backend/internal/service/gateway_request_tk_tool_context_guard_test.go",
+      "must_contain": [
+        "TestTkValidateAnthropicToolContext_FlagsToolResultOnly",
+        "TestTkValidateAnthropicToolContext_AllowsSdkToolContinuation",
+        "TestTkRejectInvalidAnthropicToolContext_WritesLocalClientErrorAndOpsEvent"
+      ],
+      "rationale": "Focused regressions for the Anthropic tool-context guard: incident-shaped tool_result-only bodies are rejected, valid SDK tool continuations pass, and local rejection writes the client-owned ops event used by downstream classification."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "s.tkRejectInvalidAnthropicToolContext(ctx, c, account, body, s.tkRequiresClaudeCodeSystemSurface(ctx, c, account), false)",
+        "s.tkRejectInvalidAnthropicToolContext(ctx, c, account, input.Body, s.tkRequiresClaudeCodeSystemSurface(ctx, c, account), true)"
+      ],
+      "rationale": "Load-bearing wiring for the local Anthropic tool-context guard on both OAuth and API-key passthrough forwarding/count_tokens paths. The companion helper alone is insufficient; if these gateway_service.go call sites are dropped, corrupt user/tool_result continuations will bypass local validation and hit upstream accounts again."
+    },
+    {
       "path": "backend/internal/service/ratelimit_service_tk_openai_client_induced_403.go",
       "must_contain": [
         "func tkIsOpenAIClientInducedCapability403(upstreamMsg string, responseBody []byte) string",


### PR DESCRIPTION
## 摘要
- 在 Anthropic `/v1/messages` 与 `count_tokens` 出站前校验 tool continuation：`user/tool_result` 必须紧邻对应的 `assistant/tool_use`，并校验 tool_use_id 完整匹配、无重复。
- 对损坏上下文本地返回 400 `invalid_request_error`，写入 `client_tool_context_corrupt` ops event，并归因为 request/client，避免继续打上游账号。
- 扩展 client-fidelity-watch/prompt surface probe，识别 pair-aware tool continuation 异常、重复 tool_result、缺 system surface 的事故形态，并补 gateway sentinel 锚点。

## 风险
- 行为变化只影响 malformed Anthropic tool continuation 请求；合法 SDK/Claude Code tool continuation 已有正向回归覆盖。
- Web impact: none。

## 验证
- `./scripts/preflight.sh`：PASS。
- `go test -tags=unit ./internal/service -run 'TestTkExtractAnthropicPromptFingerprint|TestTkValidateAnthropicToolContext|TestTkRejectInvalidAnthropicToolContext|TestTkProbePromptSurfaceGatewayCoverageJSONL|TestTkNormalizeCCGeo|TestCanonicalIdentityIsSingleSourceOfTruth|TestGetOrCreateFingerprint_CanonicalProfile' -count=1`：PASS。
- `go test -tags=unit ./internal/handler -run 'TestClassifyOpsUpstreamClientInducedRejectionOwnedByClient' -count=1`：PASS。
- `python3 ops/anthropic/probe_prompt_surfaces.py --check-registry`、`--check-fixture-gateway`：PASS。
- `python3 -m unittest ops.anthropic.test_probe_prompt_surfaces ops.observability.test_probe_prompt_surface_fingerprints ops.observability.test_open_prompt_surface_watch_issues -v`：PASS。
- `python3 dev-rules/scripts/review/pipeline.py find --scope origin/main...HEAD --preflight /tmp/xj-review-preflight.txt --json`：preflight finding 0，warn candidate 0。

## 提交
- `ceed2cb0c` fix(anthropic): reject corrupt tool continuations before upstream
- `abbbf2e7f` fix(anthropic): harden tool continuation review fixes

最新提交：`abbbf2e7f`
