### PR TITLE
Fix endpoint compatibility probes and Gemini v1beta routing

### DIFF
--- a/.cursor/skills/tokenkey-account-model-probe/SKILL.md
+++ b/.cursor/skills/tokenkey-account-model-probe/SKILL.md
@@ -5,7 +5,7 @@ description: Probe a specific TokenKey prod or edge account against one model by
 
 # TokenKey Account Model Probe
 
-Run a live, low-cost probe for one account and one model. Default path reuses one reserved exclusive `__tk_probe_<platform>_group` and `__tk_probe_<platform>_key` per target host/platform, temporarily binds only the target account, sends one real gateway request, then removes the account binding. This avoids accumulating one-off debug groups and keys.
+Run a live, low-cost probe for one account and one model. Default path reuses one reserved exclusive `__tk_probe_<platform>_group` and `__tk_probe_<platform>_key` per target host/platform, temporarily binds only the target account, sends one real gateway request, then removes the account binding and disables the probe resources. This avoids accumulating or leaving active one-off debug groups and keys.
 
 Use `ops/observability/run-probe.sh`; do not SSH manually.
 
@@ -39,7 +39,7 @@ Useful options:
 - `REQUEST_TIMEOUT_SECONDS=90` caps the in-container gateway request.
 - `PROBE_REUSE_MODE=1` is the default: reuse `__tk_probe_<platform>_group` / `__tk_probe_<platform>_key`.
 - `PROBE_REUSE_MODE=0` creates a one-off `__tk_probe_tkprobe-*` group/key and soft-deletes it on cleanup.
-- `KEEP_PROBE_ARTIFACTS=1` keeps the current account binding for manual follow-up. In one-off mode it also keeps that temporary group/key. Default is cleanup.
+- `KEEP_PROBE_ARTIFACTS=1` keeps the current account binding for manual follow-up. In one-off mode it also keeps that temporary group/key; in reuse mode it leaves the reserved group/key active until manual cleanup. Default is cleanup.
 - `PROBE_LOCK_TIMEOUT_SECONDS=120` caps waiting for another same-platform reuse probe to finish.
 - `APP_CONTAINER=tokenkey APP_URL=http://localhost:8080` are the default in-container request target.
 
@@ -60,7 +60,7 @@ Never paste returned API keys or credentials. The script intentionally prints ID
 
 - Prefer this skill over creating permanent admin groups for single-account debugging.
 - This is a live probe. It may consume a tiny amount of quota and can update normal usage tables.
-- Default reuse mode intentionally leaves at most one reserved probe group/key per platform on each target host, and removes account binding after the request.
+- Default reuse mode intentionally leaves at most one reserved probe group/key per platform on each target host, disables it after cleanup, and removes account binding after the request.
 - Probe groups must stay exclusive, grant `user_allowed_groups` only to the probe key owner, and remain direct probe-key only; they must not enter universal-key routing candidates.
 - Use `ENDPOINT=messages` for Anthropic/Kiro style accounts, `chat` for OpenAI-compatible chat, and `responses` for Codex/OpenAI responses.
 - If the goal is "can the raw upstream credential serve this model" for an API-key-compatible account, direct upstream curl can be a follow-up, but the default gateway probe is the authoritative TokenKey-path proof.

--- a/.cursor/skills/tokenkey-endpoint-compat-audit/SKILL.md
+++ b/.cursor/skills/tokenkey-endpoint-compat-audit/SKILL.md
@@ -70,6 +70,18 @@ bash ops/observability/endpoint-compat-audit.sh --universal-matrix --with-extras
 
 This wraps `ops/test/gateway_full_matrix_test.sh`.
 
+Probe resource hygiene:
+
+```bash
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/observability/cleanup-probe-resources.sh
+```
+
+Default is dry-run. To disable leftover active `__tk_probe_*` groups/keys after
+diagnostics, pass `--env TK_PROBE_CLEANUP_APPLY=1`. The script disables and
+unbinds reusable probe resources; it does not delete rows.
+
 ## Interpretation Rules
 
 - `route_verdict=open` means the local route/platform gate did not reject the request. It does not prove the selected upstream can serve the model.

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -39,9 +39,9 @@ func (h *GatewayHandler) GeminiV1BetaListModels(c *gin.Context) {
 		googleError(c, http.StatusUnauthorized, "Invalid API key")
 		return
 	}
-	// 检查平台：优先使用强制平台（/antigravity 路由），否则要求 gemini 分组
+	// 检查平台：优先使用强制平台（/antigravity 路由），否则要求 gemini/antigravity 分组
 	forcePlatform, hasForcePlatform := middleware.GetForcePlatformFromContext(c)
-	if !hasForcePlatform && (apiKey.Group == nil || apiKey.Group.Platform != service.PlatformGemini) {
+	if !hasForcePlatform && !geminiV1BetaGroupPlatformAllowed(apiKey) {
 		googleError(c, http.StatusBadRequest, "API key group platform is not gemini")
 		return
 	}
@@ -87,9 +87,9 @@ func (h *GatewayHandler) GeminiV1BetaGetModel(c *gin.Context) {
 		googleError(c, http.StatusUnauthorized, "Invalid API key")
 		return
 	}
-	// 检查平台：优先使用强制平台（/antigravity 路由），否则要求 gemini 分组
+	// 检查平台：优先使用强制平台（/antigravity 路由），否则要求 gemini/antigravity 分组
 	forcePlatform, hasForcePlatform := middleware.GetForcePlatformFromContext(c)
-	if !hasForcePlatform && (apiKey.Group == nil || apiKey.Group.Platform != service.PlatformGemini) {
+	if !hasForcePlatform && !geminiV1BetaGroupPlatformAllowed(apiKey) {
 		googleError(c, http.StatusBadRequest, "API key group platform is not gemini")
 		return
 	}
@@ -154,9 +154,9 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 		zap.Any("group_id", apiKey.GroupID),
 	)
 
-	// 检查平台：优先使用强制平台（/antigravity 路由，中间件已设置 request.Context），否则要求 gemini 分组
+	// 检查平台：优先使用强制平台（/antigravity 路由，中间件已设置 request.Context），否则要求 gemini/antigravity 分组
 	if !middleware.HasForcePlatform(c) {
-		if apiKey.Group == nil || apiKey.Group.Platform != service.PlatformGemini {
+		if !geminiV1BetaGroupPlatformAllowed(apiKey) {
 			googleError(c, http.StatusBadRequest, "API key group platform is not gemini")
 			return
 		}
@@ -566,6 +566,18 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 			zap.Int("switch_count", fs.SwitchCount),
 		)
 		return
+	}
+}
+
+func geminiV1BetaGroupPlatformAllowed(apiKey *service.APIKey) bool {
+	if apiKey == nil || apiKey.Group == nil {
+		return false
+	}
+	switch apiKey.Group.Platform {
+	case service.PlatformGemini, service.PlatformAntigravity:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/backend/internal/handler/gemini_v1beta_handler_test.go
+++ b/backend/internal/handler/gemini_v1beta_handler_test.go
@@ -50,6 +50,38 @@ func TestGeminiV1BetaHandler_PlatformRoutingInvariant(t *testing.T) {
 	}
 }
 
+func TestGeminiV1BetaGroupPlatformAllowed(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiKey   *service.APIKey
+		expected bool
+	}{
+		{name: "nil key", apiKey: nil, expected: false},
+		{name: "nil group", apiKey: &service.APIKey{}, expected: false},
+		{
+			name:     "gemini group",
+			apiKey:   &service.APIKey{Group: &service.Group{Platform: service.PlatformGemini}},
+			expected: true,
+		},
+		{
+			name:     "antigravity group",
+			apiKey:   &service.APIKey{Group: &service.Group{Platform: service.PlatformAntigravity}},
+			expected: true,
+		},
+		{
+			name:     "openai group",
+			apiKey:   &service.APIKey{Group: &service.Group{Platform: service.PlatformOpenAI}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, geminiV1BetaGroupPlatformAllowed(tt.apiKey))
+		})
+	}
+}
+
 // TestGeminiV1BetaHandler_ListModelsAntigravityFallback 验证 ListModels 的 antigravity 降级逻辑
 // 当没有 gemini 账户但有 antigravity 账户时，应返回静态模型列表
 func TestGeminiV1BetaHandler_ListModelsAntigravityFallback(t *testing.T) {

--- a/backend/internal/server/middleware/universal_routing_tk_test.go
+++ b/backend/internal/server/middleware/universal_routing_tk_test.go
@@ -200,6 +200,58 @@ func TestAuthMiddleware_UniversalKeySwapsBackingGroupEndToEnd(t *testing.T) {
 	}
 }
 
+func TestGoogleAuthMiddleware_UniversalGeminiShapeSwapsToAntigravityGroup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	antigravityGroup := service.Group{ID: 21, Name: "uni-antigravity", Status: service.StatusActive, Platform: service.PlatformAntigravity, SubscriptionType: service.SubscriptionTypeStandard, Hydrated: true}
+	user := &service.User{ID: 8, Role: service.RoleUser, Status: service.StatusActive, Balance: 100, Concurrency: 3}
+	apiKey := &service.APIKey{ID: 101, UserID: user.ID, Key: "uni-google-key", Status: service.StatusActive, RoutingMode: service.RoutingModeUniversal, User: user}
+
+	apiKeyRepo := &stubApiKeyRepo{getByKey: func(_ context.Context, key string) (*service.APIKey, error) {
+		if key != apiKey.Key {
+			return nil, service.ErrAPIKeyNotFound
+		}
+		clone := *apiKey
+		cu := *user
+		clone.User = &cu
+		return &clone, nil
+	}}
+	userRepo := &stubUserRepo{getByID: func(_ context.Context, id int64) (*service.User, error) {
+		if id != user.ID {
+			return nil, service.ErrUserNotFound
+		}
+		cu := *user
+		return &cu, nil
+	}}
+	groupRepo := &universalGroupRepoStub{active: []service.Group{antigravityGroup}}
+	subRepo := &stubUserSubscriptionRepo{}
+
+	cfg := &config.Config{RunMode: config.RunModeStandard}
+	apiKeyService := service.NewAPIKeyService(apiKeyRepo, userRepo, groupRepo, subRepo, nil, nil, cfg)
+	subscriptionService := service.NewSubscriptionService(groupRepo, subRepo, nil, nil, cfg)
+
+	router := gin.New()
+	router.Use(APIKeyAuthWithSubscriptionGoogle(apiKeyService, subscriptionService, cfg))
+	var seenPlatform string
+	var seenGroupID int64
+	router.POST("/v1beta/models/*modelAction", func(c *gin.Context) {
+		if k, ok := GetAPIKeyFromContext(c); ok && k.GroupID != nil && k.Group != nil {
+			seenGroupID = *k.GroupID
+			seenPlatform = k.Group.Platform
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-3-flash-agent:generateContent", strings.NewReader(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`))
+	req.Header.Set("x-goog-api-key", apiKey.Key)
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Equal(t, antigravityGroup.ID, seenGroupID)
+	require.Equal(t, service.PlatformAntigravity, seenPlatform)
+}
+
 func newTestCtx(method, path, body string) (*gin.Context, *httptest.ResponseRecorder) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()

--- a/ops/observability/cleanup-probe-resources.sh
+++ b/ops/observability/cleanup-probe-resources.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Disable reserved __tk_probe_* resources after diagnostics so Studio key/group
+# pickers are not dominated by probe-only fixtures. The rows are intentionally
+# retained: probe_reserved_resources.sh reactivates the canonical rows on demand.
+set -euo pipefail
+
+APPLY="${TK_PROBE_CLEANUP_APPLY:-0}"
+LIMIT="${TK_PROBE_CLEANUP_LIMIT:-40}"
+PSQL_ARRAY=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
+
+usage() {
+	cat <<'USAGE'
+Usage:
+  bash ops/observability/cleanup-probe-resources.sh [--apply] [--limit N]
+
+Default is dry-run. --apply deletes account_groups bindings for __tk_probe_*
+groups and disables matching probe groups/API keys; it never deletes rows.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--apply)
+		APPLY=1
+		shift
+		;;
+	--limit)
+		LIMIT="${2:-}"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "cleanup-probe-resources: unknown arg: $1" >&2
+		usage >&2
+		exit 1
+		;;
+	esac
+done
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]] || [ "$LIMIT" -lt 1 ]; then
+	echo "cleanup-probe-resources: --limit must be a positive integer" >&2
+	exit 1
+fi
+if [[ "$APPLY" != "0" && "$APPLY" != "1" ]]; then
+	echo "cleanup-probe-resources: TK_PROBE_CLEANUP_APPLY must be 0 or 1" >&2
+	exit 1
+fi
+
+tk_psql() {
+	"${PSQL_ARRAY[@]}" "$@"
+}
+
+print_snapshot() {
+	local label="$1"
+	printf 'snapshot=%s\n' "$label"
+	tk_psql <<SQL
+WITH probe_groups AS (
+  SELECT id, name, status
+  FROM groups
+  WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
+    AND deleted_at IS NULL
+),
+probe_keys AS (
+  SELECT k.id, k.name, k.status
+  FROM api_keys k
+  WHERE k.deleted_at IS NULL
+    AND (
+      k.name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
+      OR k.group_id IN (SELECT id FROM probe_groups)
+    )
+),
+probe_bindings AS (
+  SELECT ag.account_id, ag.group_id
+  FROM account_groups ag
+  WHERE ag.group_id IN (SELECT id FROM probe_groups)
+)
+SELECT 'active_probe_groups=' || COUNT(*) FROM probe_groups WHERE status = 'active'
+UNION ALL
+SELECT 'active_probe_keys=' || COUNT(*) FROM probe_keys WHERE status = 'active'
+UNION ALL
+SELECT 'probe_account_group_bindings=' || COUNT(*) FROM probe_bindings
+UNION ALL
+SELECT 'probe_group_rows=' || COUNT(*) FROM probe_groups
+UNION ALL
+SELECT 'probe_key_rows=' || COUNT(*) FROM probe_keys
+UNION ALL
+SELECT 'active_group_sample=' || COALESCE(string_agg(name, ', ' ORDER BY name), '')
+FROM (SELECT name FROM probe_groups WHERE status = 'active' ORDER BY name LIMIT ${LIMIT}) s
+UNION ALL
+SELECT 'active_key_sample=' || COALESCE(string_agg(name, ', ' ORDER BY name), '')
+FROM (SELECT name FROM probe_keys WHERE status = 'active' ORDER BY name LIMIT ${LIMIT}) s;
+SQL
+}
+
+apply_cleanup() {
+	tk_psql <<'SQL'
+BEGIN;
+WITH probe_groups AS (
+  SELECT id
+  FROM groups
+  WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
+    AND deleted_at IS NULL
+),
+deleted_bindings AS (
+  DELETE FROM account_groups
+  WHERE group_id IN (SELECT id FROM probe_groups)
+  RETURNING 1
+),
+disabled_keys AS (
+  UPDATE api_keys
+  SET status = 'disabled',
+      updated_at = NOW()
+  WHERE deleted_at IS NULL
+    AND status <> 'disabled'
+    AND (
+      name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
+      OR group_id IN (SELECT id FROM probe_groups)
+    )
+  RETURNING 1
+),
+disabled_groups AS (
+  UPDATE groups
+  SET status = 'disabled',
+      updated_at = NOW()
+  WHERE deleted_at IS NULL
+    AND status <> 'disabled'
+    AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
+  RETURNING 1
+)
+SELECT 'deleted_account_group_bindings=' || COUNT(*) FROM deleted_bindings
+UNION ALL
+SELECT 'disabled_probe_keys=' || COUNT(*) FROM disabled_keys
+UNION ALL
+SELECT 'disabled_probe_groups=' || COUNT(*) FROM disabled_groups;
+COMMIT;
+SQL
+}
+
+if [ "$APPLY" = "1" ]; then
+	printf 'mode=apply\n'
+	print_snapshot before
+	apply_cleanup
+	print_snapshot after
+else
+	printf 'mode=dry_run\n'
+	print_snapshot current
+fi

--- a/ops/observability/probe-endpoint-matrix.sh
+++ b/ops/observability/probe-endpoint-matrix.sh
@@ -25,15 +25,42 @@ PSQL_ARRAY=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -
 PSQL='sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1'
 PROD="${PROD_BASE:-https://api.tokenkey.dev}"
 
-# Canonical prod source groups (case-sensitive); override via env if needed.
-declare -A SOURCE_GROUP=(
-	[anthropic]="${PROBE_ANTHROPIC_MIRROR_GROUP:-claude}"
-	[openai]="${PROBE_OPENAI_SOURCE_GROUP:-GPT专线}"
-	[gemini]="${PROBE_GEMINI_PLATFORM_SOURCE_GROUP:-Gemini-PA}"
-	[antigravity]="${PROBE_ANTIGRAVITY_SOURCE_GROUP:-Google-Gemini}"
-	[newapi]="${PROBE_NEWAPI_SOURCE_GROUP:-Qwen}"
-	[kiro]="${PROBE_KIRO_SOURCE_GROUP:-kiro}"
-	[grok]="${PROBE_GROK_SOURCE_GROUP:-grok}"
+# Canonical prod source group ids. Display names are operator-editable and have
+# drifted often enough to produce false config_error rows; legacy name overrides
+# remain available only for explicit diagnostics.
+probe_source_group_id() { # $1=logical source pool
+	case "$1" in
+	openai) echo 2 ;;
+	anthropic_mirror) echo 1 ;;
+	gemini_vertex) echo 16 ;;
+	dashscope) echo 18 ;;
+	grok_prod) echo 25 ;;
+	antigravity) echo 21 ;;
+	*)
+		echo "probe-endpoint-matrix: unknown source group key '$1'" >&2
+		return 1
+		;;
+	esac
+}
+
+declare -A SOURCE_GROUP_ID=(
+	[anthropic]="${PROBE_ANTHROPIC_MIRROR_GROUP_ID:-$(probe_source_group_id anthropic_mirror)}"
+	[openai]="${PROBE_OPENAI_SOURCE_GROUP_ID:-$(probe_source_group_id openai)}"
+	[gemini]="${PROBE_GEMINI_SOURCE_GROUP_ID:-$(probe_source_group_id gemini_vertex)}"
+	[antigravity]="${PROBE_ANTIGRAVITY_SOURCE_GROUP_ID:-$(probe_source_group_id antigravity)}"
+	[newapi]="${PROBE_NEWAPI_SOURCE_GROUP_ID:-${PROBE_DASHSCOPE_SOURCE_GROUP_ID:-$(probe_source_group_id dashscope)}}"
+	[kiro]="${PROBE_KIRO_SOURCE_GROUP_ID:-$(probe_source_group_id anthropic_mirror)}"
+	[grok]="${PROBE_GROK_SOURCE_GROUP_ID:-$(probe_source_group_id grok_prod)}"
+)
+
+declare -A SOURCE_GROUP_NAME=(
+	[anthropic]="${PROBE_ANTHROPIC_MIRROR_GROUP:-}"
+	[openai]="${PROBE_OPENAI_SOURCE_GROUP:-}"
+	[gemini]="${PROBE_GEMINI_PLATFORM_SOURCE_GROUP:-${PROBE_GEMINI_SOURCE_GROUP:-}}"
+	[antigravity]="${PROBE_ANTIGRAVITY_SOURCE_GROUP:-}"
+	[newapi]="${PROBE_NEWAPI_SOURCE_GROUP:-${PROBE_DASHSCOPE_SOURCE_GROUP:-}}"
+	[kiro]="${PROBE_KIRO_SOURCE_GROUP:-}"
+	[grok]="${PROBE_GROK_SOURCE_GROUP:-}"
 )
 
 MODEL_claude='claude-sonnet-4-6'
@@ -64,6 +91,76 @@ classify_route() { # $1=code $2=bodyfile -> open|closed|other
 }
 
 snippet() { head -c 180 "$1" | tr '\n' ' ' | sed 's/[[:space:]]+/ /g'; }
+
+copy_source_group_policy() { # $1=bind_kind $2=bind_val
+	local bind_kind="$1" bind_val="$2" where=""
+	if [[ ! "$TK_PROBE_GROUP_ID" =~ ^[0-9]+$ ]]; then
+		return 0
+	fi
+	case "$bind_kind" in
+	source_group)
+		where="src.name = '$(tk_probe_sql_escape "$bind_val")'"
+		;;
+	group_like)
+		where="src.name = '$(tk_probe_sql_escape "${bind_val%%|*}")'"
+		;;
+	source_group_id)
+		[[ "$bind_val" =~ ^[0-9]+$ ]] || return 0
+		where="src.id = ${bind_val}"
+		;;
+	group_id_like)
+		local source_group_id="${bind_val%%|*}"
+		[[ "$source_group_id" =~ ^[0-9]+$ ]] || return 0
+		where="src.id = ${source_group_id}"
+		;;
+	*)
+		return 0
+		;;
+	esac
+	tk_probe_psql -c "
+UPDATE groups dst
+SET
+  allow_messages_dispatch = src.allow_messages_dispatch,
+  messages_dispatch_model_config = src.messages_dispatch_model_config,
+  allow_image_generation = src.allow_image_generation,
+  updated_at = NOW()
+FROM groups src
+WHERE dst.id = ${TK_PROBE_GROUP_ID}
+  AND ${where}
+  AND src.deleted_at IS NULL;
+" >/dev/null 2>&1 || true # preflight-allow: swallow
+	tk_probe_psql -c "
+UPDATE api_keys
+SET updated_at = NOW()
+WHERE group_id = ${TK_PROBE_GROUP_ID}
+  AND deleted_at IS NULL;
+" >/dev/null 2>&1 || true # preflight-allow: swallow
+}
+
+prepare_route_gate_probe() { # $1=scope $2=platform $3=bind_kind $4=bind_val
+	local scope="$1" platform="$2" bind_kind="$3" bind_val="$4"
+	if tk_probe_prepare_catalog "$scope" "$platform" "$bind_kind" "$bind_val"; then
+		copy_source_group_policy "$bind_kind" "$bind_val"
+		return 0
+	fi
+	scope="${TK_PROBE_SCOPE:-$scope}"
+
+	# Route-gate evidence is still meaningful with an empty probe group: closed
+	# endpoints return the local 404 feature gate, while open endpoints proceed
+	# to scheduler/account selection and usually report 429 no-available-accounts.
+	TK_PROBE_GROUP_ID=""
+	TK_PROBE_KEY=""
+	TK_PROBE_KEY_ID=""
+	if ! tk_probe_acquire_reuse_lock "$scope"; then
+		return 1
+	fi
+	tk_probe_ensure_group "$scope" "$platform" || return 1
+	tk_probe_ensure_key "$scope" || return 1
+	tk_probe_psql -c "DELETE FROM account_groups WHERE group_id = ${TK_PROBE_GROUP_ID};" >/dev/null 2>&1 || true # preflight-allow: route-gate empty pool fallback
+	copy_source_group_policy "$bind_kind" "$bind_val"
+	echo "probe-endpoint-matrix: continuing with empty probe group for route-gate scope=$scope platform=$platform source=$bind_kind:$bind_val" >&2
+	return 0
+}
 
 body_messages() {
 	local m="$1"
@@ -166,63 +263,54 @@ tk_probe_catalog_cleanup() {
 
 main() {
 	trap tk_probe_catalog_cleanup EXIT
-	local platform scope source bind_kind bind_val key
+	local platform scope source_name source_id bind_kind bind_val key
 
 	printf 'platform\tendpoint\thttp_code\troute_verdict\tsnippet\n'
 
 	for platform in anthropic openai gemini antigravity newapi kiro grok; do
 		scope="endpoint_matrix_${platform}"
-		source="${SOURCE_GROUP[$platform]:-}"
-		bind_kind=source_group
-		bind_val="$source"
+		source_name="${SOURCE_GROUP_NAME[$platform]:-}"
+		source_id="${SOURCE_GROUP_ID[$platform]:-}"
+		if [ -n "$source_name" ]; then
+			bind_kind=source_group
+			bind_val="$source_name"
+		else
+			bind_kind=source_group_id
+			bind_val="$source_id"
+		fi
 
 		# anthropic prod matrix uses cc-* mirrors (platform=anthropic on claude group)
 		if [ "$platform" = anthropic ]; then
-			bind_kind=group_like
-			bind_val="${source}|cc-%"
+			if [ -n "$source_name" ]; then
+				bind_kind=group_like
+				bind_val="${source_name}|cc-%"
+			else
+				bind_kind=group_id_like
+				bind_val="${source_id}|cc-%"
+			fi
 		fi
 		# kiro: prod has no native platform=kiro customer group; bind kiro-* prod
 		# mirrors (platform=anthropic credentials) while keeping probe group.platform=kiro
 		# so route gates match a kiro-platform API key.
 		if [ "$platform" = kiro ]; then
-			bind_kind=group_like
-			bind_val="${SOURCE_GROUP[anthropic]}|kiro-%"
+			if [ -n "$source_name" ]; then
+				bind_kind=group_like
+				bind_val="${source_name}|kiro-%"
+			else
+				bind_kind=group_id_like
+				bind_val="${source_id}|kiro-%"
+			fi
 		fi
 		# grok on prod: grok group schedules on prod gateway (mirrors may relay to edge)
 		if [ "$platform" = grok ]; then
 			:
 		fi
 
-		if ! tk_probe_prepare_catalog "$scope" "$platform" "$bind_kind" "$bind_val"; then
-			emit "$platform" '*' '000' 'config_error' "failed source=$source bind=$bind_kind:$bind_val"
+		if ! prepare_route_gate_probe "$scope" "$platform" "$bind_kind" "$bind_val"; then
+			emit "$platform" '*' '000' 'config_error' "failed source_id=$source_id source_name=$source_name bind=$bind_kind:$bind_val"
 			continue
 		fi
-		# Mirror dispatch + image flags from the canonical source group so messages
-		# probes reflect prod group policy (probe groups default allow_messages_dispatch=false).
-		if [ "$bind_kind" = source_group ]; then
-			tk_probe_psql -c "
-UPDATE groups dst
-SET
-  allow_messages_dispatch = src.allow_messages_dispatch,
-  messages_dispatch_model_config = src.messages_dispatch_model_config,
-  allow_image_generation = src.allow_image_generation,
-  updated_at = NOW()
-FROM groups src
-WHERE dst.id = ${TK_PROBE_GROUP_ID}
-  AND src.name = '$(tk_probe_sql_escape "$source")'
-  AND src.deleted_at IS NULL;
-" >/dev/null 2>&1 || true # preflight-allow: swallow
-			# Bust in-memory API key cache: group policy is copied above but running
-			# replicas may still serve stale AllowMessagesDispatch from Redis until
-			# the key row is touched.
-			tk_probe_psql -c "
-UPDATE api_keys
-SET updated_at = NOW()
-WHERE group_id = ${TK_PROBE_GROUP_ID}
-  AND deleted_at IS NULL;
-" >/dev/null 2>&1 || true # preflight-allow: swallow
-		fi
-		TK_PROBE_CATALOG_SCOPES="${TK_PROBE_CATALOG_SCOPES} ${scope}"
+		TK_PROBE_CATALOG_SCOPES="${TK_PROBE_CATALOG_SCOPES} ${TK_PROBE_SCOPE:-$scope}"
 		key="$TK_PROBE_KEY"
 		pick_auth_and_probe "$platform" "$key"
 		sleep 1

--- a/ops/pricing/probe-antigravity-gemini25pro-literal.sh
+++ b/ops/pricing/probe-antigravity-gemini25pro-literal.sh
@@ -34,7 +34,7 @@ tk_probe_catalog_key() { # $1=scope $2=platform $3=bind_kind $4=bind_val -> sets
 	if ! tk_probe_prepare_catalog "$scope" "$platform" "$bind_kind" "$bind_val"; then
 		return 1
 	fi
-	TK_PROBE_CATALOG_SCOPES="${TK_PROBE_CATALOG_SCOPES} ${scope}"
+	TK_PROBE_CATALOG_SCOPES="${TK_PROBE_CATALOG_SCOPES} ${TK_PROBE_SCOPE:-$scope}"
 	REPLY_KEY="$TK_PROBE_KEY"
 }
 

--- a/ops/pricing/probe-servable-models.sh
+++ b/ops/pricing/probe-servable-models.sh
@@ -448,7 +448,7 @@ tk_probe_catalog_key() { # $1=scope $2=platform $3=bind_kind $4=bind_val -> sets
 	if ! tk_probe_prepare_catalog "$scope" "$platform" "$bind_kind" "$bind_val"; then
 		return 1
 	fi
-	TK_PROBE_CATALOG_SCOPES="${TK_PROBE_CATALOG_SCOPES} ${scope}"
+	TK_PROBE_CATALOG_SCOPES="${TK_PROBE_CATALOG_SCOPES} ${TK_PROBE_SCOPE:-$scope}"
 	REPLY_KEY="$TK_PROBE_KEY"
 }
 

--- a/ops/pricing/probe_reserved_resources.sh
+++ b/ops/pricing/probe_reserved_resources.sh
@@ -29,6 +29,8 @@ TK_PROBE_LOCK_TIMEOUT_SECONDS="${TK_PROBE_LOCK_TIMEOUT_SECONDS:-${PROBE_LOCK_TIM
 TK_PROBE_GROUP_ID=""
 TK_PROBE_KEY=""
 TK_PROBE_KEY_ID=""
+TK_PROBE_SCOPE=""
+TK_PROBE_REQUESTED_SCOPE=""
 TK_PROBE_LOCK_SCOPES=()
 TK_PROBE_LOCK_FDS=()
 
@@ -103,6 +105,68 @@ import sys
 scope = re.sub(r"[^a-z0-9]+", "_", sys.argv[1].strip().lower()).strip("_")
 print((scope or "platform")[:48])
 PY
+}
+
+tk_probe_scope_slug() {
+	python3 - "$1" <<'PY'
+import re
+import sys
+
+scope = re.sub(r"[^a-z0-9]+", "_", sys.argv[1].strip().lower()).strip("_")
+print((scope or "value")[:48])
+PY
+}
+
+tk_probe_scope_for_account_ids() {
+	python3 - "$1" <<'PY'
+import hashlib
+import re
+import sys
+
+ids = re.findall(r"\d+", sys.argv[1])
+if not ids:
+    print("acct_none")
+elif len(ids) == 1:
+    print(f"acct_{ids[0]}")
+else:
+    normalized = ",".join(sorted(ids, key=lambda x: int(x)))
+    print("acctset_" + hashlib.sha1(normalized.encode()).hexdigest()[:10])
+PY
+}
+
+tk_probe_canonical_scope() { # $1=requested $2=platform $3=bind_kind $4=bind_val
+	local requested="$1" platform="$2" bind_kind="$3" bind_val="$4"
+	local platform_slug source pattern ids_slug
+	if [ "${TK_PROBE_LEGACY_SCOPE:-0}" = "1" ]; then
+		printf '%s' "$requested"
+		return 0
+	fi
+	platform_slug="$(tk_probe_scope_slug "$platform")"
+	case "$bind_kind" in
+	source_group_id)
+		printf '%s_srcgrp_%s' "$platform_slug" "$(tk_probe_scope_slug "$bind_val")"
+		;;
+	group_id_like)
+		source="${bind_val%%|*}"
+		pattern="$(tk_probe_scope_slug "${bind_val#*|}")"
+		printf '%s_srcgrp_%s_%s' "$platform_slug" "$(tk_probe_scope_slug "$source")" "$pattern"
+		;;
+	source_group)
+		printf '%s_group_%s' "$platform_slug" "$(tk_probe_scope_slug "$bind_val")"
+		;;
+	group_like)
+		source="${bind_val%%|*}"
+		pattern="$(tk_probe_scope_slug "${bind_val#*|}")"
+		printf '%s_group_%s_%s' "$platform_slug" "$(tk_probe_scope_slug "$source")" "$pattern"
+		;;
+	account_ids)
+		ids_slug="$(tk_probe_scope_for_account_ids "$bind_val")"
+		printf '%s_%s' "$platform_slug" "$ids_slug"
+		;;
+	*)
+		tk_probe_scope_slug "$requested"
+		;;
+	esac
 }
 
 tk_probe_group_name() {
@@ -216,6 +280,11 @@ tk_probe_ensure_key() { # $1=scope
 		echo "probe_reserved_resources: ensure_key requires TK_PROBE_GROUP_ID" >&2
 		return 1
 	fi
+	new_key="sk-tkprobe-$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(18).replace("-", "").replace("_", "")[:24])
+PY
+)"
 	local existing_id
 	existing_id="$(tk_probe_sql_scalar "
 SELECT COALESCE((
@@ -233,6 +302,7 @@ SELECT COALESCE((
 UPDATE api_keys
 SET
   user_id = ${TK_PROBE_USER_ID},
+  key = '$(tk_probe_sql_escape "$new_key")',
   status = 'active',
   routing_mode = 'direct',
   quota = 0,
@@ -251,11 +321,6 @@ WHERE id = ${TK_PROBE_KEY_ID}
 RETURNING key;
 ")"
 	else
-		new_key="sk-tkprobe-$(python3 - <<'PY'
-import secrets
-print(secrets.token_urlsafe(18).replace("-", "").replace("_", "")[:24])
-PY
-)"
 		TK_PROBE_KEY_ID="$(tk_probe_sql_scalar "
 INSERT INTO api_keys (
   user_id, key, name, group_id, status, routing_mode,
@@ -289,9 +354,23 @@ SELECT COALESCE((
   WHERE name = '$(tk_probe_sql_escape "$group_name")' AND deleted_at IS NULL
   ORDER BY id LIMIT 1
 ), '');
-")"
+	")"
 	if [[ "$group_id" =~ ^[0-9]+$ ]]; then
 		tk_probe_psql -c "DELETE FROM account_groups WHERE group_id = ${group_id};" >/dev/null
+		tk_probe_psql -c "
+UPDATE api_keys
+SET status = 'disabled',
+    updated_at = NOW()
+WHERE group_id = ${group_id}
+  AND name = '$(tk_probe_sql_escape "$(tk_probe_key_name "$scope")")'
+  AND deleted_at IS NULL;
+UPDATE groups
+SET status = 'disabled',
+    updated_at = NOW()
+WHERE id = ${group_id}
+  AND name = '$(tk_probe_sql_escape "$group_name")'
+  AND deleted_at IS NULL;
+" >/dev/null
 	fi
 }
 
@@ -474,7 +553,10 @@ SELECT COUNT(*)::text FROM account_groups WHERE group_id = ${TK_PROBE_GROUP_ID};
 # (group_like bind_val = "GROUP|PATTERN", split on the first '|').
 # (group_id_like bind_val = "GROUP_ID|PATTERN", split on the first '|').
 tk_probe_prepare_catalog() { # $1=scope $2=platform $3=bind_kind $4=bind_val
-	local scope="$1" platform="$2" bind_kind="$3" bind_val="$4"
+	local requested_scope="$1" platform="$2" bind_kind="$3" bind_val="$4" scope
+	scope="$(tk_probe_canonical_scope "$requested_scope" "$platform" "$bind_kind" "$bind_val")"
+	TK_PROBE_REQUESTED_SCOPE="$requested_scope"
+	TK_PROBE_SCOPE="$scope"
 	TK_PROBE_GROUP_ID=""
 	TK_PROBE_KEY=""
 	TK_PROBE_KEY_ID=""
@@ -496,5 +578,8 @@ tk_probe_prepare_catalog() { # $1=scope $2=platform $3=bind_kind $4=bind_val
 		echo "probe_reserved_resources: unknown bind_kind '$bind_kind'" >&2
 		return 1
 		;;
-	esac
+	esac || {
+		tk_probe_clear_bindings "$scope" >/dev/null 2>&1 || true # preflight-allow: cleanup failed probe resource
+		return 1
+	}
 }

--- a/ops/pricing/probe_reserved_resources.sh
+++ b/ops/pricing/probe_reserved_resources.sh
@@ -16,7 +16,7 @@
 #   tk_probe_bind_from_group SCOPE GNAME    -> copy schedulable accounts from source group name (legacy)
 #   tk_probe_bind_from_group_id SCOPE GID    -> copy schedulable accounts from source group id
 #   tk_probe_bind_from_group_id_like SCOPE GID PATTERN -> copy source group id accounts whose name matches SQL LIKE
-#   tk_probe_clear_bindings SCOPE           -> remove account_groups rows only
+#   tk_probe_clear_bindings SCOPE           -> remove account_groups rows and disable probe key/group
 #   tk_probe_prepare_catalog SCOPE PLATFORM BIND_KIND BIND_VAL -> ensure + bind + key
 #   tk_probe_reuse_lock_path SCOPE              -> lock file path (shared with account-model-probe)
 #   tk_probe_acquire_reuse_lock SCOPE           -> flock until release (serializes account_groups mutations)

--- a/ops/pricing/test_probe_reserved_resources.sh
+++ b/ops/pricing/test_probe_reserved_resources.sh
@@ -19,8 +19,15 @@ assert_eq "$(tk_probe_group_name 'openai')" "__tk_probe_openai_group" "group nam
 assert_eq "$(tk_probe_key_name 'newapi_google')" "__tk_probe_newapi_google_key" "key name"
 assert_eq "$(tk_probe_reuse_lock_path 'anthropic')" "/tmp/tokenkey-account-model-probe-anthropic.lock" "reuse lock path"
 assert_eq "$(tk_probe_sql_escape "it's")" "it''s" "sql escape"
+assert_eq "$(tk_probe_canonical_scope endpoint_matrix_grok grok source_group_id 25)" "grok_srcgrp_25" "source group id canonical scope"
+assert_eq "$(tk_probe_canonical_scope endpoint_matrix_anthropic anthropic group_id_like '1|cc-%')" "anthropic_srcgrp_1_cc" "group id like canonical scope"
+assert_eq "$(tk_probe_canonical_scope openai_ct_acct_63 openai account_ids '63')" "openai_acct_63" "account id canonical scope"
+TK_PROBE_LEGACY_SCOPE=1
+assert_eq "$(tk_probe_canonical_scope endpoint_matrix_grok grok source_group_id 25)" "endpoint_matrix_grok" "legacy scope override"
+unset TK_PROBE_LEGACY_SCOPE
 
 TK_PROBE_TEST_SCENARIO=case_match
+TK_PROBE_LAST_SQL=""
 tk_probe_psql() {
 	local sql=""
 	while [ "$#" -gt 0 ]; do
@@ -30,6 +37,7 @@ tk_probe_psql() {
 		fi
 		shift
 	done
+	TK_PROBE_LAST_SQL="$sql"
 	case "$TK_PROBE_TEST_SCENARIO" in
 	case_match)
 		if printf '%s' "$sql" | grep -q "SELECT COALESCE"; then
@@ -45,6 +53,13 @@ tk_probe_psql() {
 			printf '2\n'
 		fi
 		;;
+	group_id)
+		if printf '%s' "$sql" | grep -q "SELECT COALESCE"; then
+			printf '39\n'
+		else
+			printf '1\n'
+		fi
+		;;
 	*)
 		printf '\n'
 		;;
@@ -57,6 +72,12 @@ TK_PROBE_GROUP_ID=39
 TK_PROBE_TEST_SCENARIO=case_match
 tk_probe_bind_from_group_id probe 16
 tk_probe_bind_from_group_id_like probe 1 'cc-%'
+TK_PROBE_TEST_SCENARIO=group_id
+tk_probe_clear_bindings probe
+if ! printf '%s' "$TK_PROBE_LAST_SQL" | grep -q "status = 'disabled'"; then
+	echo "FAIL: clear_bindings should disable reusable probe key/group" >&2
+	exit 1
+fi
 
 TK_PROBE_TEST_SCENARIO=ambiguous
 if tk_probe_resolve_source_group 'google-vertex' >/tmp/tk-probe-resolve.out 2>/tmp/tk-probe-resolve.err; then

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -31,6 +31,14 @@ sql_escape() {
   printf "%s" "$1" | sed "s/'/''/g"
 }
 
+new_probe_api_key() {
+  printf 'sk-%s-%s' "$PROBE_ID" "$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(18).replace("-", "").replace("_", "")[:24])
+PY
+)"
+}
+
 fail_json() {
   local message="$1"
   python3 - "$message" <<'PY'
@@ -177,11 +185,7 @@ if [[ "$PROBE_REUSE_MODE" == "1" ]]; then
     fail_json "timed out waiting for probe reuse lock"
   fi
 else
-  API_KEY="sk-${PROBE_ID}-$(python3 - <<'PY'
-import secrets
-print(secrets.token_urlsafe(18).replace("-", "").replace("_", "")[:24])
-PY
-)"
+  API_KEY="$(new_probe_api_key)"
 fi
 
 GROUP_ID=""
@@ -194,7 +198,8 @@ cleanup() {
     if [[ "$PROBE_REUSE_MODE" == "1" ]]; then
       "${PSQL[@]}" -c "
 	DELETE FROM account_groups WHERE group_id = ${GROUP_ID};
-	UPDATE groups SET updated_at=NOW() WHERE id = ${GROUP_ID} AND name = '$(sql_escape "$GROUP_NAME")' AND deleted_at IS NULL;
+	UPDATE api_keys SET status='disabled', updated_at=NOW() WHERE group_id = ${GROUP_ID} AND name = '$(sql_escape "$KEY_NAME")' AND deleted_at IS NULL;
+	UPDATE groups SET status='disabled', updated_at=NOW() WHERE id = ${GROUP_ID} AND name = '$(sql_escape "$GROUP_NAME")' AND deleted_at IS NULL;
 	" >/dev/null 2>&1 || true # preflight-allow: swallow
     else
       "${PSQL[@]}" -c "
@@ -305,6 +310,7 @@ ON CONFLICT (account_id, group_id) DO NOTHING;
 " >/dev/null
 
 if [[ "$PROBE_REUSE_MODE" == "1" ]]; then
+  NEW_API_KEY="$(new_probe_api_key)"
   API_KEY_ROW="$("${PSQL[@]}" -c "
 WITH existing AS (
   SELECT id
@@ -323,6 +329,7 @@ SELECT COALESCE((SELECT id::text FROM existing), '');
 UPDATE api_keys
 SET
   user_id = ${PROBE_USER_ID},
+  key = '$(sql_escape "$NEW_API_KEY")',
   status = 'active',
   routing_mode = 'direct',
   quota = 0,
@@ -341,11 +348,7 @@ WHERE id = ${API_KEY_ID}
 RETURNING key;
 " | tr -d '\n')"
   else
-    API_KEY="sk-${PROBE_ID}-$(python3 - <<'PY'
-import secrets
-print(secrets.token_urlsafe(18).replace("-", "").replace("_", "")[:24])
-PY
-)"
+    API_KEY="$NEW_API_KEY"
     psql_capture_numeric API_KEY_ID "failed to insert probe API key name=${KEY_NAME} group_id=${GROUP_ID}" "
 INSERT INTO api_keys (
   user_id, key, name, group_id, status, routing_mode,

--- a/ops/test/gateway_full_matrix_test.sh
+++ b/ops/test/gateway_full_matrix_test.sh
@@ -83,7 +83,7 @@ M_ANTIGRAVITY_TEXT="${TK_FULLTEST_MODEL_ANTIGRAVITY_TEXT:-gemini-3-flash-agent}"
 M_NEWAPI_TEXT="${TK_FULLTEST_MODEL_NEWAPI_TEXT:-deepseek-chat}"
 M_NEWAPI_IMAGE="${TK_FULLTEST_MODEL_NEWAPI_IMAGE:-doubao-seedream-4-0-250828}"
 M_NEWAPI_VIDEO="${TK_FULLTEST_MODEL_NEWAPI_VIDEO:-doubao-seedance-2-0-260128}"
-M_GROK_TEXT="${TK_FULLTEST_MODEL_GROK_TEXT:-grok-4}"
+M_GROK_TEXT="${TK_FULLTEST_MODEL_GROK_TEXT:-grok-4.3}"
 M_KIRO_TEXT="${TK_FULLTEST_MODEL_KIRO_TEXT:-claude-sonnet-4-6}"
 
 # ---- 结果累计 ----
@@ -140,15 +140,19 @@ BODYFILE=""
 do_post() {
   local path="$1" key="$2" body="$3"
   BODYFILE="$(mktemp)"
-  CODE="$(curl -sS -o "$BODYFILE" -w '%{http_code}' -m "$TIMEOUT" -X POST "$BASE$path" \
+  if ! CODE="$(curl -sS -o "$BODYFILE" -w '%{http_code}' -m "$TIMEOUT" -X POST "$BASE$path" \
     -H "Authorization: Bearer $key" -H 'anthropic-version: 2023-06-01' \
-    -H 'content-type: application/json' --data-binary "$body" 2>/dev/null || echo 000)"
+    -H 'content-type: application/json' --data-binary "$body" 2>/dev/null)"; then
+    CODE="000"
+  fi
 }
 do_get() {
   local path="$1" key="$2"
   BODYFILE="$(mktemp)"
-  CODE="$(curl -sS -o "$BODYFILE" -w '%{http_code}' -m "$TIMEOUT" "$BASE$path" \
-    -H "Authorization: Bearer $key" 2>/dev/null || echo 000)"
+  if ! CODE="$(curl -sS -o "$BODYFILE" -w '%{http_code}' -m "$TIMEOUT" "$BASE$path" \
+    -H "Authorization: Bearer $key" 2>/dev/null)"; then
+    CODE="000"
+  fi
 }
 
 # shape_ok JQFILTER -> echo 1 if 200 & filter true else 0


### PR DESCRIPTION
## Summary
- Allow universal Google `/v1beta` requests to use Antigravity backing groups, matching the universal resolver's endpoint-shape routing.
- Stabilize direct endpoint route-gate probes on prod source group IDs and keep route-gate evidence when a source pool is empty.
- Canonicalize reusable probe resources by platform/source/account binding, rotate secrets on reactivation, and disable probe groups/keys on cleanup so Studio is not polluted by active `__tk_probe_*` keys.
- Add `cleanup-probe-resources.sh` for dry-run/apply hygiene, update the full matrix Grok model/curl timeout classification, and clarify the shared cleanup helper contract after review.

## Prod Probe Evidence
- Paid universal media matrix approved and run: `PASS=13 SKIP=5 FAIL=0`.
  - Log: `/tmp/tokenkey-universal-paid-media-20260703-112145.log`
  - Paid PASS: Gemini image, NewAPI image, NewAPI video.
  - Paid SKIP: OpenAI image timeout/connection interruption, Gemini video account/model not provisioned.
- Direct route-gate canonical run: no `config_error`; Anthropic/Gemini/Kiro empty pools return route-open 429, WS prelude returns 426, OpenAI/Antigravity/NewAPI/Grok live rows return 200.
  - Log: `/tmp/tokenkey-direct-route-gate-canonical3-20260703-112947.log`
- Probe resource cleanup applied on prod:
  - Before: `active_probe_groups=51`, `active_probe_keys=50`, `probe_account_group_bindings=0`.
  - After: `active_probe_groups=0`, `active_probe_keys=0`, `probe_account_group_bindings=0`.
  - Log: `/tmp/tokenkey-probe-resource-cleanup-apply-20260703-112447.log`
- Post-verification cleanup dry-runs after direct matrix and account-model probe both show active probe groups/keys remain 0.
- Account-model probe sanity check: account 63 served `gpt-5.1` via reused `__tk_probe_openai_key`, then cleanup left active probe resources at 0.
  - Log: `/tmp/tokenkey-account-model-probe-cleanup-20260703-113537.log`

## Validation
- `cd backend && go test -tags unit ./internal/handler ./internal/server/middleware ./internal/service`
- `bash -n` for changed probe/matrix scripts
- `bash ops/pricing/test_probe_reserved_resources.sh`
- `bash scripts/preflight.sh`
- Review fix loop also reran: `bash -n ops/stage0/probe_account_model.sh`, `bash -n ops/pricing/probe_reserved_resources.sh`, `bash ops/pricing/test_probe_reserved_resources.sh`, `bash scripts/preflight.sh`

## Commits
- `8bdaa42b8dced2c1ea8aa13c1ed53374f168bbc8` — `fix: align endpoint probes and gemini v1beta routing`
- `10905e89ef28f9d997c4b65f67463befc8872571` — `fix(review): clarify probe cleanup helper contract`

Latest reviewed head: `10905e89ef28f9d997c4b65f67463befc8872571`.

No deployment performed.

sentinel-registry-reviewed: Gemini v1beta route-gate change reviewed; existing gateway sentinel coverage is sufficient for this bounded compatibility fix.
no-web-impact: backend gateway and ops scripts only; no frontend web surface changes.
