### PR TITLE
fix(admin): avoid duplicate upstream usage windows

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 553,
-  "hash": "a9065e532e4a115c97d9b49af4cc7c390301a8bea5c44157a040548a3ddcfc26",
+  "hash": "4cb842b809db45b81b8b47e7c3566aea051c116392dfd3ee625a1f3cf8890860",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -718,6 +718,70 @@ describe('AccountUsageCell', () => {
     expect(getUsage).not.toHaveBeenCalled()
   })
 
+  it('Anthropic OAuth 不在上游摘要里重复展示已渲染的 5h/7d 窗口', async () => {
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2017,
+          platform: 'anthropic',
+          type: 'oauth',
+          extra: {}
+        }),
+        usageOverride: {
+          source: 'passive',
+          updated_at: null,
+          five_hour: {
+            utilization: 0,
+            resets_at: '2099-03-07T12:00:00Z',
+            remaining_seconds: 3600
+          },
+          seven_day: {
+            utilization: 19,
+            resets_at: '2099-03-13T12:00:00Z',
+            remaining_seconds: 3600
+          },
+          seven_day_sonnet: {
+            utilization: 91,
+            resets_at: '2099-03-13T12:00:00Z',
+            remaining_seconds: 3600
+          },
+          upstream_quota: {
+            provider: 'anthropic',
+            source: 'passive',
+            state: 'observed',
+            subscription_tier: 'Max',
+            dimensions: [
+              { key: 'anthropic_5h', label: '5h', window: '5h', utilization: 0 },
+              { key: 'anthropic_7d', label: '7d', window: '7d', utilization: 19 },
+              { key: 'anthropic_7d_sonnet', label: '7d Sonnet', window: '7d', utilization: 91 }
+            ]
+          }
+        }
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}</div>'
+          },
+          AccountQuotaInfo: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(getUsage).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('5h|0')
+    expect(wrapper.text()).toContain('7d|19')
+    expect(wrapper.text()).toContain('7d S|91')
+    expect(wrapper.text()).toContain('anthropic')
+    expect(wrapper.text()).toContain('Max')
+    expect(wrapper.text()).not.toContain('5h 5h 0%')
+    expect(wrapper.text()).not.toContain('7d 7d 19%')
+    expect(wrapper.text()).not.toContain('7d Sonnet 7d 91%')
+  })
+
   it('OpenAI OAuth 在无 codex 快照时会回退显示 usage 接口窗口', async () => {
 	getUsage.mockResolvedValue({
 	  five_hour: {

--- a/frontend/src/components/account/usage-cells/AnthropicUsageCell.vue
+++ b/frontend/src/components/account/usage-cells/AnthropicUsageCell.vue
@@ -57,7 +57,10 @@
         :resets-at="usageInfo.seven_day_sonnet.resets_at"
         color="purple"
       />
-      <UpstreamQuotaSummary :quota="usageInfo.upstream_quota" />
+      <UpstreamQuotaSummary
+        :quota="usageInfo.upstream_quota"
+        :hidden-dimension-keys="upstreamQuotaWindowDimensionKeys"
+      />
       <div class="flex items-center gap-1.5 mt-0.5">
         <span
           v-if="usageInfo.source === 'passive'"
@@ -109,6 +112,11 @@ const props = withDefaults(defineProps<AccountUsageCellProps>(), accountUsageCel
 
 const { t } = useI18n()
 const rootRef = ref<HTMLElement | null>(null)
+const upstreamQuotaWindowDimensionKeys = [
+  'anthropic_5h',
+  'anthropic_7d',
+  'anthropic_7d_sonnet'
+]
 
 const { loading, activeQueryLoading, error, usageInfo, loadActiveUsage } = useAccountUsageFetch(
   props,

--- a/frontend/src/components/account/usage-cells/OpenAIUsageCell.vue
+++ b/frontend/src/components/account/usage-cells/OpenAIUsageCell.vue
@@ -19,7 +19,10 @@
         :show-now-when-idle="true"
         color="emerald"
       />
-      <UpstreamQuotaSummary :quota="usageInfo?.upstream_quota" />
+      <UpstreamQuotaSummary
+        :quota="usageInfo?.upstream_quota"
+        :hidden-dimension-keys="upstreamQuotaWindowDimensionKeys"
+      />
       <OpenAIQuotaResetCell :account="account">
         <template #pre-actions>
           <button
@@ -82,6 +85,10 @@ const props = withDefaults(defineProps<AccountUsageCellProps>(), accountUsageCel
 
 const { t } = useI18n()
 const rootRef = ref<HTMLElement | null>(null)
+const upstreamQuotaWindowDimensionKeys = [
+  'openai_codex_5h',
+  'openai_codex_7d'
+]
 
 const { loading, activeQueryLoading, usageInfo, loadActiveUsage } = useAccountUsageFetch(
   props,

--- a/frontend/src/components/account/usage-cells/UpstreamQuotaSummary.vue
+++ b/frontend/src/components/account/usage-cells/UpstreamQuotaSummary.vue
@@ -52,11 +52,16 @@ import type { UpstreamQuotaCredit, UpstreamQuotaDimension, UpstreamQuotaInfo } f
 const props = defineProps<{
   quota?: UpstreamQuotaInfo | null
   maxItems?: number
+  hiddenDimensionKeys?: string[]
 }>()
 
 const { t } = useI18n()
 
 const quota = computed(() => props.quota ?? null)
+const hiddenDimensionKeys = computed(() => new Set(props.hiddenDimensionKeys ?? []))
+const visibleDimensions = computed(() =>
+  (quota.value?.dimensions ?? []).filter(dim => !hiddenDimensionKeys.value.has(dim.key))
+)
 const visible = computed(() => {
   if (!quota.value) return false
   if (quota.value.state === 'unsupported') return true
@@ -66,7 +71,7 @@ const visible = computed(() => {
     !!quota.value.subscription_tier ||
     !!quota.value.subscription_tier_raw ||
     !!quota.value.retry_after_seconds ||
-    (quota.value.dimensions?.length ?? 0) > 0 ||
+    visibleDimensions.value.length > 0 ||
     (quota.value.credits?.length ?? 0) > 0
   )
 })
@@ -114,7 +119,7 @@ const quotaLines = computed(() => {
   const max = props.maxItems ?? 3
   const lines = [
     ...(quota.value?.credits ?? []).map(formatCreditLine).filter(Boolean),
-    ...(quota.value?.dimensions ?? []).map(formatDimensionLine).filter(Boolean)
+    ...visibleDimensions.value.map(formatDimensionLine).filter(Boolean)
   ] as Array<{ key: string; text: string; title: string }>
   return lines.slice(0, max)
 })

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -170,6 +170,33 @@
       "rationale": "TablePageLayout's `fluid` prop and matching modifier-scoped CSS rules. The fluid wrapper rule must keep `overflow-x-auto` (not `overflow-x-hidden`) so a narrow viewport falls back to a scrollbar instead of clipping rightmost columns. Sibling guard to the DataTable.vue fluid-overflow sentinel above — both paths must move in lockstep."
     },
     {
+      "path": "frontend/src/components/account/usage-cells/UpstreamQuotaSummary.vue",
+      "must_contain": [
+        "hiddenDimensionKeys?: string[]",
+        "const visibleDimensions = computed",
+        "visibleDimensions.value.map(formatDimensionLine)"
+      ],
+      "rationale": "Shared usage-window quota summary de-duplication owner. Account usage cells render primary 5h/7d bars first, then UpstreamQuotaSummary renders only supplemental upstream quota facts after filtering dimensions already represented by those bars. Anchors prevent an upstream-shaped component rewrite from silently reintroducing duplicate grey quota chips beside the canonical progress bars."
+    },
+    {
+      "path": "frontend/src/components/account/usage-cells/AnthropicUsageCell.vue",
+      "must_contain": [
+        ":hidden-dimension-keys=\"upstreamQuotaWindowDimensionKeys\"",
+        "anthropic_5h",
+        "anthropic_7d_sonnet"
+      ],
+      "rationale": "Anthropic OAuth usage windows have one canonical visual owner: the 5h, 7d, and 7d S progress bars. The upstream_quota block may still carry the same dimensions for contract consumers, but the UI must filter them out of the supplemental summary to avoid repeating the same window percentages in the Edge panel and Accounts list."
+    },
+    {
+      "path": "frontend/src/components/account/usage-cells/OpenAIUsageCell.vue",
+      "must_contain": [
+        ":hidden-dimension-keys=\"upstreamQuotaWindowDimensionKeys\"",
+        "openai_codex_5h",
+        "openai_codex_7d"
+      ],
+      "rationale": "OpenAI Codex OAuth usage windows mirror the Anthropic display contract: the 5h and 7d progress bars are canonical, while UpstreamQuotaSummary is only for supplemental quota facts. Anchors keep upstream merges from restoring duplicate Codex window chips."
+    },
+    {
       "path": "frontend/src/views/admin/AccountsView.vue",
       "must_contain": [
         "<TablePageLayout fluid>",


### PR DESCRIPTION
摘要
- 在共享 `UpstreamQuotaSummary` 支持按 dimension key 隐藏已由主窗口条展示的上游额度维度。
- Anthropic 账号隐藏摘要里的 `anthropic_5h`、`anthropic_7d`、`anthropic_7d_sonnet`，避免 Edge 面板和账号列表重复显示 5h/7d/7d Sonnet。
- OpenAI Codex 账号同样隐藏 `openai_codex_5h`、`openai_codex_7d` 摘要维度，保持同类 UI 口径一致。
- 为三处共享展示/注入点补充 `frontend-tk` sentinel anchor，防止后续 upstream merge 静默覆盖。

风险
- 低风险：只调整账号用量窗口共享展示层，不改变后端 `/usage` 契约、不改 Edge 面板数据流。
- sentinel-registry-reviewed：本次修改的是既有共享展示 owner，并已补充 `scripts/sentinels/frontend-tk.json` 锚点。

验证
- `pnpm --dir frontend test:run src/components/account/__tests__/AccountUsageCell.spec.ts`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend run build`
- `python3 scripts/sentinels/check-frontend-tk.py --quiet`
- `python3 scripts/checks/upstream-override-marker.py --base origin/main --pr-body ''`
- `python3 scripts/sentinels/check-registry-update-gate.py --quiet`
- `./scripts/preflight.sh`

提交
- `dd7350dc5 chore(sentinels): guard usage window dedupe anchors`
- `c8c03a6d6 fix(admin): avoid duplicate upstream usage windows`
- 最新提交：`dd7350dc5`
