### PR TITLE
Fix Studio image bakeoff requests and audit prompts

### DIFF
--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -32,6 +32,7 @@ description: >-
 | Admin model rollup timing（dashboard/models 冷态慢：raw 7d group-by vs usage_dashboard_model_daily + raw today 耗时/一致性） | 机械 | `ops/observability/probe-admin-model-rollup-timing.sh`（经 run-probe 投递；只读 SELECT + EXPLAIN ANALYZE） |
 | Admin group rollup timing（usage/dashboard group distribution 冷态慢：raw 7d group-by vs usage_dashboard_group_daily + raw today 耗时/一致性） | 机械 | `ops/observability/probe-admin-group-rollup-timing.sh`（经 run-probe 投递；只读 SELECT + EXPLAIN ANALYZE） |
 | 图片/视频盯盘（成功计量计费 + 错误分面 + 计费异常 + last-seen；区分 image vs video、空池 429 vs 真上游错误 vs 缺权限 401） | 机械 | `ops/observability/probe-image-video-billing.sh`（窗口盯盘，`WINDOW_MIN`/`CTX_HOURS`）+ `ops/observability/probe-image-video-deepctx.sh`（openai 账号池/报错归属/流量出处一次性深挖），均经 run-probe 投递；只读 `row_to_json` |
+| Studio 图片请求审计（Image Studio / BakeOff prompt 是否实际提交、是否同一轮、size/model 是否被前后端改写） | 机械 | `ops/observability/probe-studio-image-request-audit.sh`（经 run-probe 投递；查 `ops_system_logs component=audit.openai_image_request`；按 `WINDOW_MINUTES` / user / api_key / model / `studio_run_id` / `prompt_sha256` / request id 过滤） |
 | 用户级盯盘（一组 user_id 的请求 + 错误 + 计量计费 + 图片/视频 breakout + last-seen，单次 SSM 往返，对齐 30min 汇报节奏） | 机械 | `ops/observability/probe-user-billing-watch.sh`（经 run-probe 投递；`USER_IDS` 逗号分隔整数默认 `1,16`、`WINDOW_MINUTES` 默认 30；只读 `row_to_json`，复用 probe-image-video-billing.sh 的 image/video 判别谓词） |
 | Gateway UA/TLS / usage_logs / ops / docker 指纹交叉对比（窄时间窗） | 机械 | `ops/observability/probe-gateway-ua-tls-compare.sh`（通过 run-probe.sh 投递；`WINDOW_MINUTES` 收窄 DB 窗） |
 | `SUB2API_DEBUG_GATEWAY_BODY` 日志拉回本机（SSM gzip → S3 presigned PUT → 本地 gunzip） | 机械 | `ops/observability/fetch-gateway-debug-log.sh --target prod\|edge:<id>`（**本地** orchestrator，不走 run-probe） |
@@ -285,6 +286,79 @@ env 契约（脚本 header 是 ground truth）：
 | `docker_ua_tls_lines` | 含 UA/TLS 关键词的 docker 行样本（尾部截断） |
 
 **何时用**：edge 间 UA/TLS 行为差异、OAuth TLS fingerprint 是否生效、outage 窗口内 gateway 是否仍有 completed 行、与 §5 access log 解析互补（本 probe 偏 cross-table 指纹，parse-access-log 偏 status/latency 直方图）。
+
+## 5.1.1) Studio 图片请求审计（机械化）
+
+用户反馈 Image Studio / BakeOff 图片结果严重不符合 prompt、怀疑 prompt 被改写、同一轮对比里某个模型提交了旧 prompt，或报错截图只显示 `Failed to fetch` / `Upstream request failed` 时，先用本 probe 固定证据。它查的是后端写入 `ops_system_logs` 的 `audit.openai_image_request` 行，覆盖：
+
+- `/v1/images/generations`：Imagen / Seedream / Grok 等 OpenAI-compatible image 入口，`surface=images.generations`。
+- `/v1/chat/completions`：Studio 走 Gemini-native 图片的 chat 入口，只有带 Studio image trace header 时记录，`surface=chat.completions`。
+
+```bash
+# 最近 60 分钟 Studio 图片请求审计（默认 LIMIT=20）
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/observability/probe-studio-image-request-audit.sh \
+  --env WINDOW_MINUTES=60 \
+  --timeout-seconds 120
+
+# 用户刚反馈且知道 user/api key/model：收窄到具体人和模型
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/observability/probe-studio-image-request-audit.sh \
+  --env WINDOW_MINUTES=30 \
+  --env USER_ID=1 \
+  --env MODEL=imagen-4.0-generate-001 \
+  --timeout-seconds 120
+
+# 用户截图/前端 console 拿到了同一轮 BakeOff run id：按轮次查
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/observability/probe-studio-image-request-audit.sh \
+  --env STUDIO_RUN_ID=studio-bakeoff-image-... \
+  --env LIMIT=40 \
+  --timeout-seconds 120
+
+# 已知某个 prompt hash：查是否还有其他模型/轮次提交了同一 prompt
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/observability/probe-studio-image-request-audit.sh \
+  --env PROMPT_SHA256=<64-hex> \
+  --env WINDOW_MINUTES=360 \
+  --timeout-seconds 120
+```
+
+env 契约（脚本 header 是 ground truth）：
+
+| env | 默认 | 含义 |
+|---|---|---|
+| `WINDOW_MINUTES` | 60 | 回看分钟数，正整数；只影响窗口内分段，`last-seen with filters` 会忽略窗口给空窗兜底。 |
+| `LIMIT` | 20 | `samples` 行数上限。 |
+| `USER_ID` / `API_KEY_ID` / `ACCOUNT_ID` | （空） | 精确过滤身份或账号；整数。 |
+| `MODEL` | （空） | 同时匹配 top-level `model`、`extra.requested_model`、`extra.forward_model`。 |
+| `STUDIO_SOURCE` | （空） | `studio.image` 或 `studio.bakeoff.image`。 |
+| `STUDIO_RUN_ID` / `STUDIO_PANEL_ID` | （空） | 前端 trace header；BakeOff 同一次点击应共享一个 `studio_run_id`，panel 通常是模型 id。 |
+| `PROMPT_SHA256` | （空） | prompt 原文 SHA-256；用于比较，不输出完整 prompt。 |
+| `REQUEST_ID` / `CLIENT_REQUEST_ID` | （空） | 与 `ops_error_logs`、Docker access log、usage_logs 交叉定位。 |
+
+输出解读：
+
+| 分段 | 用途 |
+|---|---|
+| `summary` | 看窗口内是否有 audit 行、涉及几个用户/key/run/prompt hash。 |
+| `by source/model/size` | 直接看 `requested_model`/`forward_model`、`size`/`forward_size`、入口 `surface` 是否符合预期。 |
+| `by studio run` | BakeOff 一次点击的模型集合、panel 数、prompt hash 数；同一轮 `prompt_hashes > 1` 是强信号：前端实际提交了不同 prompt。 |
+| `prompt consistency by run` | 同一 `studio_run_id` 下逐个 prompt hash 展开，带 200 字节 preview；用来判断“旧 prompt/页面状态错乱” vs “同 prompt 但模型输出不佳”。 |
+| `samples` | 少量样本，含 `prompt_preview`（已脱敏且最多 1024 bytes）、`prompt_sha256`、`prompt_bytes`/`prompt_runes`、body hash、size/model、Studio trace。 |
+| `related ops_error_logs by request_id` | 同窗口内按 request id 关联真实错误；若为空，不代表请求成功，只代表没有匹配到 error row。 |
+| `last-seen with filters` | 空窗口时判断是“确实没打到审计点”还是时间窗太窄。 |
+
+判断纪律：
+- `prompt_preview` 只是脱敏截断预览，不能当完整 prompt；严格比较用 `prompt_sha256` + `prompt_bytes`/`prompt_runes`。
+- 同一 `studio_run_id`、不同模型的 `prompt_sha256` 一致：当前证据不支持“后端改了 prompt”；继续看 `size` / `forward_size` / `forward_model` / upstream error。
+- 同一 `studio_run_id` 出现多个 `prompt_sha256`：优先怀疑前端提交旧状态、页面 hydrate/缓存错乱、或用户看的不是同一轮结果；再用 `studio_panel_id` 和 `request_id` 定位具体 panel。
+- `requested_model != forward_model` 或 `size != forward_size`：说明后端确实改写了转发字段，必须回到 handler / mapper 查为什么。
+- 查不到 audit 行：只说明当前部署/窗口/入口没有该审计证据；旧事故仍只能靠 `usage_logs`、`ops_error_logs`、Docker access log、以及已开启时的 §5.2 gateway debug body 推断，不能反推“prompt 没被改”。
 
 ## 5.2) Debug gateway body 日志拉回本机（机械化，本地 orchestrator）
 

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -208,6 +208,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			forwardBody = h.gatewayService.ReplaceModelInBody(body, channelMapping.MappedModel)
 		}
 		writerSizeBeforeForward := c.Writer.Size()
+		logOpenAIStudioChatImageRequestAudit(c, apiKey, subject.UserID, account, body, forwardBody)
 		result, err := func() (*service.OpenAIForwardResult, error) {
 			defer func() {
 				if accountReleaseFunc != nil {

--- a/backend/internal/handler/openai_gateway_embeddings_images.go
+++ b/backend/internal/handler/openai_gateway_embeddings_images.go
@@ -534,6 +534,7 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 		}
 		writerSizeBeforeForward := c.Writer.Size()
 		TkSetBridgeGinAuth(c, subject.UserID, groupName)
+		logOpenAIImageGenerationRequestAudit(c, apiKey, subject.UserID, account, body, forwardBody)
 		result, err := h.gatewayService.ForwardAsImageGenerationsDispatched(c.Request.Context(), c, account, forwardBody, defaultMappedModel)
 
 		forwardDurationMs := time.Since(forwardStart).Milliseconds()

--- a/backend/internal/handler/openai_image_request_audit_tk.go
+++ b/backend/internal/handler/openai_image_request_audit_tk.go
@@ -1,0 +1,222 @@
+package handler
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/Wei-Shaw/sub2api/internal/util/logredact"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	tkImageRequestAuditComponent = "audit.openai_image_request"
+	tkImageRequestAuditMessage   = "openai_image.request_payload"
+	tkImagePromptPreviewMaxBytes = 1024
+
+	tkStudioSourceHeader = "X-TokenKey-Studio-Source"
+	tkStudioRunIDHeader  = "X-TokenKey-Studio-Run-Id"
+	tkStudioPanelHeader  = "X-TokenKey-Studio-Panel-Id"
+)
+
+func logOpenAIImageGenerationRequestAudit(c *gin.Context, apiKey *service.APIKey, userID int64, account *service.Account, body []byte, forwardBody []byte) {
+	prompt := gjson.GetBytes(body, "prompt").String()
+	logOpenAIImageRequestAudit(c, apiKey, userID, account, body, forwardBody, "images.generations", prompt, "prompt")
+}
+
+func logOpenAIStudioChatImageRequestAudit(c *gin.Context, apiKey *service.APIKey, userID int64, account *service.Account, body []byte, forwardBody []byte) {
+	if !tkIsStudioImageTrace(c) {
+		return
+	}
+	prompt, source := tkExtractOpenAIChatUserPrompt(body)
+	logOpenAIImageRequestAudit(c, apiKey, userID, account, body, forwardBody, "chat.completions", prompt, source)
+}
+
+func logOpenAIImageRequestAudit(
+	c *gin.Context,
+	apiKey *service.APIKey,
+	userID int64,
+	account *service.Account,
+	body []byte,
+	forwardBody []byte,
+	surface string,
+	prompt string,
+	promptSource string,
+) {
+	if c == nil || len(body) == 0 {
+		return
+	}
+	requestID, clientRequestID := tkRequestIDs(c)
+	requestModel := strings.TrimSpace(gjson.GetBytes(body, "model").String())
+	forwardModel := strings.TrimSpace(gjson.GetBytes(forwardBody, "model").String())
+	if forwardModel == "" {
+		forwardModel = requestModel
+	}
+
+	fields := map[string]any{
+		"request_id":               requestID,
+		"client_request_id":        clientRequestID,
+		"user_id":                  userID,
+		"api_key_id":               tkAPIKeyID(apiKey),
+		"group_id":                 tkAPIKeyGroupID(apiKey),
+		"account_id":               tkAccountID(account),
+		"platform":                 tkAccountPlatform(account),
+		"model":                    requestModel,
+		"requested_model":          requestModel,
+		"forward_model":            forwardModel,
+		"surface":                  strings.TrimSpace(surface),
+		"request_path":             tkRequestPath(c),
+		"inbound_endpoint":         GetInboundEndpoint(c),
+		"upstream_endpoint":        resolveOpenAIUpstreamEndpoint(c, account),
+		"request_body_sha256":      tkSHA256Hex(body),
+		"request_body_bytes":       len(body),
+		"forward_body_sha256":      tkSHA256Hex(forwardBody),
+		"prompt_source":            strings.TrimSpace(promptSource),
+		"prompt_preview":           tkPromptPreview(prompt),
+		"prompt_preview_truncated": len(prompt) > tkImagePromptPreviewMaxBytes,
+		"prompt_sha256":            tkSHA256Hex([]byte(prompt)),
+		"prompt_bytes":             len([]byte(prompt)),
+		"prompt_runes":             len([]rune(prompt)),
+		"size":                     tkJSONScalarString(body, "size"),
+		"forward_size":             tkJSONScalarString(forwardBody, "size"),
+		"n":                        tkImageRequestN(body),
+		"quality":                  tkJSONScalarString(body, "quality"),
+		"style":                    tkJSONScalarString(body, "style"),
+		"response_format":          tkJSONScalarString(body, "response_format"),
+		"background":               tkJSONScalarString(body, "background"),
+		"output_format":            tkJSONScalarString(body, "output_format"),
+		"moderation":               tkJSONScalarString(body, "moderation"),
+		"studio_source":            strings.TrimSpace(c.GetHeader(tkStudioSourceHeader)),
+		"studio_run_id":            strings.TrimSpace(c.GetHeader(tkStudioRunIDHeader)),
+		"studio_panel_id":          strings.TrimSpace(c.GetHeader(tkStudioPanelHeader)),
+	}
+	logger.WriteSinkEvent("info", tkImageRequestAuditComponent, tkImageRequestAuditMessage, fields)
+}
+
+func tkIsStudioImageTrace(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	source := strings.ToLower(strings.TrimSpace(c.GetHeader(tkStudioSourceHeader)))
+	return strings.Contains(source, "studio") && strings.Contains(source, "image")
+}
+
+func tkExtractOpenAIChatUserPrompt(body []byte) (string, string) {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return "", "messages"
+	}
+	for _, msg := range messages.Array() {
+		if role := strings.ToLower(strings.TrimSpace(msg.Get("role").String())); role != "" && role != "user" {
+			continue
+		}
+		content := msg.Get("content")
+		if content.Type == gjson.String {
+			return content.String(), "messages.user.content"
+		}
+		if !content.IsArray() {
+			continue
+		}
+		parts := make([]string, 0, len(content.Array()))
+		for _, part := range content.Array() {
+			if typ := strings.ToLower(strings.TrimSpace(part.Get("type").String())); typ != "" && typ != "text" {
+				continue
+			}
+			text := part.Get("text").String()
+			if strings.TrimSpace(text) != "" {
+				parts = append(parts, text)
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, "\n"), "messages.user.content[].text"
+		}
+	}
+	return "", "messages.user.content"
+}
+
+func tkRequestIDs(c *gin.Context) (string, string) {
+	if c == nil || c.Request == nil {
+		return "", ""
+	}
+	requestID := strings.TrimSpace(c.Writer.Header().Get("X-Request-Id"))
+	if requestID == "" {
+		requestID, _ = c.Request.Context().Value(ctxkey.RequestID).(string)
+		requestID = strings.TrimSpace(requestID)
+	}
+	clientRequestID, _ := c.Request.Context().Value(ctxkey.ClientRequestID).(string)
+	return requestID, strings.TrimSpace(clientRequestID)
+}
+
+func tkPromptPreview(prompt string) string {
+	preview := truncateString(prompt, tkImagePromptPreviewMaxBytes)
+	return logredact.RedactText(preview)
+}
+
+func tkSHA256Hex(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func tkJSONScalarString(body []byte, path string) string {
+	if len(body) == 0 || strings.TrimSpace(path) == "" {
+		return ""
+	}
+	value := gjson.GetBytes(body, path)
+	if !value.Exists() {
+		return ""
+	}
+	if value.Type == gjson.String {
+		return strings.TrimSpace(value.String())
+	}
+	return strings.TrimSpace(value.Raw)
+}
+
+func tkImageRequestN(body []byte) int64 {
+	n := gjson.GetBytes(body, "n")
+	if !n.Exists() || n.Int() <= 0 {
+		return 1
+	}
+	return n.Int()
+}
+
+func tkAPIKeyID(apiKey *service.APIKey) int64 {
+	if apiKey == nil {
+		return 0
+	}
+	return apiKey.ID
+}
+
+func tkAPIKeyGroupID(apiKey *service.APIKey) any {
+	if apiKey == nil || apiKey.GroupID == nil {
+		return nil
+	}
+	return *apiKey.GroupID
+}
+
+func tkAccountID(account *service.Account) int64 {
+	if account == nil {
+		return 0
+	}
+	return account.ID
+}
+
+func tkAccountPlatform(account *service.Account) string {
+	if account == nil {
+		return ""
+	}
+	return account.Platform
+}
+
+func tkRequestPath(c *gin.Context) string {
+	if c == nil || c.Request == nil || c.Request.URL == nil {
+		return ""
+	}
+	return c.Request.URL.Path
+}

--- a/backend/internal/handler/openai_image_request_audit_tk_test.go
+++ b/backend/internal/handler/openai_image_request_audit_tk_test.go
@@ -1,0 +1,126 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogOpenAIImageGenerationRequestAuditCapturesPromptTrace(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logSink, restore := captureHandlerStructuredLog(t)
+	defer restore()
+
+	groupID := int64(7)
+	prompt := "东京雨夜的霓虹小巷，电影感，浅景深 api_key=secret-token"
+	body := []byte(fmt.Sprintf(`{"model":"imagen-4.0-generate-001","prompt":%q,"size":"1:1","n":2,"quality":"high"}`, prompt))
+	forwardBody := []byte(fmt.Sprintf(`{"model":"imagen-upstream","prompt":%q,"size":"1:1","n":2}`, prompt))
+	c := newImageAuditTestContext("/v1/images/generations")
+	c.Request.Header.Set(tkStudioSourceHeader, "studio.bakeoff.image")
+	c.Request.Header.Set(tkStudioRunIDHeader, "run-123")
+	c.Request.Header.Set(tkStudioPanelHeader, "imagen-4.0-generate-001")
+
+	logOpenAIImageGenerationRequestAudit(
+		c,
+		&service.APIKey{ID: 103, GroupID: &groupID},
+		1,
+		&service.Account{ID: 57, Platform: service.PlatformOpenAI},
+		body,
+		forwardBody,
+	)
+
+	event := requireImageAuditEvent(t, logSink)
+	require.Equal(t, tkImageRequestAuditComponent, event.Component)
+	require.Equal(t, tkImageRequestAuditMessage, event.Message)
+	require.Equal(t, "req-img-1", event.Fields["request_id"])
+	require.Equal(t, "creq-img-1", event.Fields["client_request_id"])
+	require.Equal(t, int64(1), event.Fields["user_id"])
+	require.Equal(t, int64(103), event.Fields["api_key_id"])
+	require.Equal(t, int64(57), event.Fields["account_id"])
+	require.Equal(t, service.PlatformOpenAI, event.Fields["platform"])
+	require.Equal(t, "imagen-4.0-generate-001", event.Fields["requested_model"])
+	require.Equal(t, "imagen-upstream", event.Fields["forward_model"])
+	require.Equal(t, "1:1", event.Fields["size"])
+	require.Equal(t, int64(2), event.Fields["n"])
+	require.Equal(t, "studio.bakeoff.image", event.Fields["studio_source"])
+	require.Equal(t, "run-123", event.Fields["studio_run_id"])
+	require.Equal(t, "imagen-4.0-generate-001", event.Fields["studio_panel_id"])
+	require.Equal(t, tkSHA256Hex([]byte(prompt)), event.Fields["prompt_sha256"])
+	require.Contains(t, fmt.Sprint(event.Fields["prompt_preview"]), "东京雨夜的霓虹小巷")
+	require.Contains(t, fmt.Sprint(event.Fields["prompt_preview"]), "api_key=***")
+	require.NotContains(t, fmt.Sprint(event.Fields["prompt_preview"]), "secret-token")
+}
+
+func TestLogOpenAIStudioChatImageRequestAuditRequiresStudioImageHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logSink, restore := captureHandlerStructuredLog(t)
+	defer restore()
+
+	body := []byte(`{"model":"gemini-3.1-flash-image","messages":[{"role":"user","content":[{"type":"text","text":"make it neon"},{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}]}],"stream":false}`)
+	c := newImageAuditTestContext("/v1/chat/completions")
+	apiKey := &service.APIKey{ID: 104}
+	account := &service.Account{ID: 58, Platform: service.PlatformOpenAI}
+
+	logOpenAIStudioChatImageRequestAudit(c, apiKey, 1, account, body, body)
+	require.Nil(t, findImageAuditEvent(logSink), "plain chat without Studio image trace should not be audited")
+
+	c.Request.Header.Set(tkStudioSourceHeader, "studio.image")
+	c.Request.Header.Set(tkStudioRunIDHeader, "run-chat-1")
+	logOpenAIStudioChatImageRequestAudit(c, apiKey, 1, account, body, body)
+
+	event := requireImageAuditEvent(t, logSink)
+	require.Equal(t, "chat.completions", event.Fields["surface"])
+	require.Equal(t, "messages.user.content[].text", event.Fields["prompt_source"])
+	require.Equal(t, "gemini-3.1-flash-image", event.Fields["requested_model"])
+	require.Contains(t, fmt.Sprint(event.Fields["prompt_preview"]), "make it neon")
+	require.NotContains(t, fmt.Sprint(event.Fields["prompt_preview"]), "data:image")
+	require.Equal(t, "studio.image", event.Fields["studio_source"])
+	require.Equal(t, "run-chat-1", event.Fields["studio_run_id"])
+}
+
+func newImageAuditTestContext(path string) *gin.Context {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	ctx := context.WithValue(req.Context(), ctxkey.RequestID, "req-img-1")
+	ctx = context.WithValue(ctx, ctxkey.ClientRequestID, "creq-img-1")
+	c.Request = req.WithContext(ctx)
+	return c
+}
+
+func requireImageAuditEvent(t *testing.T, sink *handlerInMemoryLogSink) *logger.LogEvent {
+	t.Helper()
+	event := findImageAuditEvent(sink)
+	require.NotNil(t, event)
+	return event
+}
+
+func findImageAuditEvent(sink *handlerInMemoryLogSink) *logger.LogEvent {
+	if sink == nil {
+		return nil
+	}
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	for _, event := range sink.events {
+		if event == nil {
+			continue
+		}
+		component := strings.TrimSpace(event.Component)
+		if component == "" && event.Fields != nil {
+			component = strings.TrimSpace(fmt.Sprint(event.Fields["component"]))
+		}
+		if component == tkImageRequestAuditComponent {
+			return event
+		}
+	}
+	return nil
+}

--- a/backend/internal/server/middleware/cors.go
+++ b/backend/internal/server/middleware/cors.go
@@ -53,6 +53,7 @@ func CORS(cfg config.CORSConfig) gin.HandlerFunc {
 	allowHeaders := []string{
 		"Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization",
 		"accept", "origin", "Cache-Control", "X-Requested-With", "X-API-Key",
+		"X-TokenKey-Studio-Source", "X-TokenKey-Studio-Run-Id", "X-TokenKey-Studio-Panel-Id",
 	}
 	// OpenAI Node SDK 会发送 x-stainless-* 请求头，需在 CORS 中显式放行。
 	openAIProperties := []string{

--- a/backend/internal/server/middleware/cors_test.go
+++ b/backend/internal/server/middleware/cors_test.go
@@ -101,8 +101,12 @@ func TestCORS_AllowedOrigin_HasAllowHeaders(t *testing.T) {
 			middleware(c)
 
 			// 应设置 Allow-Headers、Allow-Methods 和 Max-Age
-			assert.NotEmpty(t, w.Header().Get("Access-Control-Allow-Headers"),
+			allowHeaders := w.Header().Get("Access-Control-Allow-Headers")
+			assert.NotEmpty(t, allowHeaders,
 				"允许的 origin 应收到 Allow-Headers")
+			assert.Contains(t, allowHeaders, "X-TokenKey-Studio-Source")
+			assert.Contains(t, allowHeaders, "X-TokenKey-Studio-Run-Id")
+			assert.Contains(t, allowHeaders, "X-TokenKey-Studio-Panel-Id")
 			assert.NotEmpty(t, w.Header().Get("Access-Control-Allow-Methods"),
 				"允许的 origin 应收到 Allow-Methods")
 			assert.Equal(t, "86400", w.Header().Get("Access-Control-Max-Age"),

--- a/backend/internal/service/ops_system_log_sink_test.go
+++ b/backend/internal/service/ops_system_log_sink_test.go
@@ -51,6 +51,11 @@ func TestOpsSystemLogSink_ShouldIndex(t *testing.T) {
 			want:  true,
 		},
 		{
+			name:  "image request audit component",
+			event: &logger.LogEvent{Level: "info", Component: "audit.openai_image_request"},
+			want:  true,
+		},
+		{
 			name: "audit component from fields (real zap path)",
 			event: &logger.LogEvent{
 				Level:     "info",

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 554,
-  "hash": "97ffebe3d3439d4718e99896bc2003bad3448e0089353bc2cd762ebca7b4abd6",
+  "hash": "89a9d376339bc857bd9e780eb6770b757e664abe104610690e2d3f31439bbbd0",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/__tests__/playground.spec.ts
+++ b/frontend/src/api/__tests__/playground.spec.ts
@@ -40,6 +40,35 @@ describe('gatewayImageGenerations payload', () => {
     await gatewayImageGenerations('k', 'http://x', { model: 'm', prompt: 'hi', size: '1024x1024', n: 2 })
     expect(getBody()).toEqual({ model: 'm', prompt: 'hi', size: '1024x1024', n: 2 })
   })
+
+  it('adds Studio trace headers without changing the image payload', async () => {
+    let sentBody: Record<string, unknown> = {}
+    let sentHeaders: Record<string, string> = {}
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, init: RequestInit) => {
+        sentBody = JSON.parse((init.body as string) || '{}')
+        sentHeaders = init.headers as Record<string, string>
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      })
+    )
+
+    await gatewayImageGenerations(
+      'k',
+      'http://x',
+      { model: 'imagen-4.0-fast-generate-001', prompt: 'hi' },
+      undefined,
+      { studioSource: 'studio.bakeoff.image', studioRunId: 'run-1', studioPanelId: 'imagen-fast' }
+    )
+
+    expect(sentBody).toEqual({ model: 'imagen-4.0-fast-generate-001', prompt: 'hi' })
+    expect(sentHeaders['X-TokenKey-Studio-Source']).toBe('studio.bakeoff.image')
+    expect(sentHeaders['X-TokenKey-Studio-Run-Id']).toBe('run-1')
+    expect(sentHeaders['X-TokenKey-Studio-Panel-Id']).toBe('imagen-fast')
+  })
 })
 
 describe('gatewayImagePresign', () => {

--- a/frontend/src/api/playground.ts
+++ b/frontend/src/api/playground.ts
@@ -46,6 +46,18 @@ export const PLAYGROUND_FETCH_TIMEOUT_MS = 60_000
  */
 export const PLAYGROUND_VIDEO_FETCH_TIMEOUT_MS = 180_000
 
+export interface GatewayRequestTrace {
+  studioSource?: string
+  studioRunId?: string
+  studioPanelId?: string
+}
+
+export function gatewayTraceRunId(prefix: string): string {
+  const safePrefix = safeGatewayHeaderValue(prefix) || 'studio'
+  const randomPart = Math.random().toString(36).slice(2, 8)
+  return `${safePrefix}-${Date.now().toString(36)}-${randomPart}`
+}
+
 function stripTrailingSlashes(u: string): string {
   return u.replace(/\/+$/, '')
 }
@@ -90,7 +102,7 @@ export async function gatewayListModels(
 async function gatewayRequestJSON(
   apiKey: string,
   url: string,
-  init: { method: 'GET' | 'POST'; body?: unknown; timeoutMs: number },
+  init: { method: 'GET' | 'POST'; body?: unknown; timeoutMs: number; trace?: GatewayRequestTrace },
   signal?: AbortSignal
 ): Promise<unknown> {
   const ctrl = new AbortController()
@@ -111,6 +123,7 @@ async function gatewayRequestJSON(
       headers: {
         Authorization: `Bearer ${apiKey}`,
         Accept: 'application/json',
+        ...gatewayTraceHeaders(init.trace),
         ...(init.body !== undefined ? { 'Content-Type': 'application/json' } : {})
       },
       ...(init.body !== undefined ? { body: JSON.stringify(init.body) } : {}),
@@ -139,6 +152,22 @@ async function gatewayRequestJSON(
       signal.removeEventListener('abort', onAbort)
     }
   }
+}
+
+function gatewayTraceHeaders(trace?: GatewayRequestTrace): Record<string, string> {
+  if (!trace) return {}
+  const headers: Record<string, string> = {}
+  const source = safeGatewayHeaderValue(trace.studioSource)
+  const runId = safeGatewayHeaderValue(trace.studioRunId)
+  const panelId = safeGatewayHeaderValue(trace.studioPanelId)
+  if (source) headers['X-TokenKey-Studio-Source'] = source
+  if (runId) headers['X-TokenKey-Studio-Run-Id'] = runId
+  if (panelId) headers['X-TokenKey-Studio-Panel-Id'] = panelId
+  return headers
+}
+
+function safeGatewayHeaderValue(value: string | undefined): string {
+  return (value || '').replace(/[\r\n]/g, ' ').trim().slice(0, 128)
 }
 
 export async function gatewayChatCompletion(
@@ -182,7 +211,8 @@ export async function gatewayImageGenerations(
   apiKey: string,
   gatewayBaseUrl: string,
   body: ImageGenerationRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  trace?: GatewayRequestTrace
 ): Promise<unknown> {
   const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/images/generations`
   const payload: Record<string, unknown> = { model: body.model, prompt: body.prompt }
@@ -191,7 +221,7 @@ export async function gatewayImageGenerations(
   return gatewayRequestJSON(
     apiKey,
     url,
-    { method: 'POST', body: payload, timeoutMs: PLAYGROUND_IMAGE_TIMEOUT_MS },
+    { method: 'POST', body: payload, timeoutMs: PLAYGROUND_IMAGE_TIMEOUT_MS, trace },
     signal
   )
 }
@@ -273,7 +303,8 @@ export async function gatewayGeminiImageViaChat(
   apiKey: string,
   gatewayBaseUrl: string,
   body: GeminiImageViaChatRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  trace?: GatewayRequestTrace
 ): Promise<unknown> {
   const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/chat/completions`
   const payload: Record<string, unknown> = {
@@ -287,7 +318,7 @@ export async function gatewayGeminiImageViaChat(
   return gatewayRequestJSON(
     apiKey,
     url,
-    { method: 'POST', body: payload, timeoutMs: PLAYGROUND_IMAGE_TIMEOUT_MS },
+    { method: 'POST', body: payload, timeoutMs: PLAYGROUND_IMAGE_TIMEOUT_MS, trace },
     signal
   )
 }

--- a/frontend/src/constants/__tests__/studioMediaPresentations.tk.spec.ts
+++ b/frontend/src/constants/__tests__/studioMediaPresentations.tk.spec.ts
@@ -193,6 +193,10 @@ describe('resolveAvailableModels (transparent model picker)', () => {
     expect(out.every((r) => r.presentation.imageSizes === SEEDREAM_IMAGE_SIZES)).toBe(true)
   })
 
+  it('declares a valid Seedream default wire size, not an aspect-ratio token', () => {
+    expect(SEEDREAM_IMAGE_SIZES[0]).toEqual({ ratio: '1:1', value: '2048x2048' })
+  })
+
   it('uses the routed doubao Seedance id as canonical and treats no-prefix as an alias', () => {
     const out = resolveAvailableModels(
       'video',

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -418,7 +418,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { gatewayGeminiImageViaChat, gatewayImageGenerations, gatewayVideoSubmit } from '@/api/playground'
+import { gatewayGeminiImageViaChat, gatewayImageGenerations, gatewayTraceRunId, gatewayVideoSubmit } from '@/api/playground'
 import {
   extractChatImageItems,
   extractImageItems,
@@ -489,8 +489,8 @@ const { copiedUrl, copyCardLink, downloadCardVideo } = useStudioVideoCardActions
 const { generateAudio } = useStudioVideoSubmitOptions()
 
 const MAX_PANELS = 6
-/** Imagen / seedream: ratio code on /v1/images/generations (see ImageStudio sentSize). */
-const DEFAULT_IMAGEN_SIZE = '1:1'
+/** Fallback only for models that do not curate imageSizes. Undefined means omit `size`. */
+const DEFAULT_BAKEOFF_IMAGE_SIZE: string | undefined = undefined
 /** Gemini-native image: aspect_ratio via /v1/chat/completions extra_body.google.image_config. */
 const DEFAULT_GEMINI_ASPECT = '1:1'
 
@@ -517,6 +517,8 @@ interface BakePanel {
   /** Video only: this model's snapped duration (seconds) actually submitted. */
   seconds?: number
   state: 'idle' | 'processing' | 'succeeded' | 'failed'
+  /** Exact size/aspect value submitted for image panels; absent means omit size. */
+  imageSize?: string
   src?: string
   taskId?: string
   url?: string
@@ -695,7 +697,7 @@ function panelSeconds(r: ResolvedMediaModel): number {
 const totalCost = computed(() =>
   selectedResolved().reduce((sum, r) => {
     if (modality.value === 'image') {
-      return sum + estimateImageCost({ baseImagePrice: r.baseImagePrice || 0, size: DEFAULT_IMAGEN_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
+      return sum + bakeoffImageCost(r)
     }
     return sum + estimateVideoCost({ perSecond: r.perSecond || 0, seconds: panelSeconds(r), rateMultiplier: props.rateMultiplier })
   }, 0)
@@ -705,7 +707,12 @@ const totalCost = computed(() =>
 const totalHold = computed(() =>
   selectedResolved().reduce((sum, r) => {
     if (modality.value === 'image') {
-      return sum + estimateImageHoldCost({ baseImagePrice: r.baseImagePrice || 0, n: 1, rateMultiplier: props.rateMultiplier })
+      if (bakeoffImagePricesFlat(r)) return sum + bakeoffImageCost(r)
+      return sum + estimateImageHoldCost({
+        baseImagePrice: r.baseImagePrice || 0,
+        n: 1,
+        rateMultiplier: props.rateMultiplier,
+      })
     }
     return sum + estimateVideoCost({ perSecond: r.perSecond || 0, seconds: panelSeconds(r), rateMultiplier: props.rateMultiplier })
   }, 0)
@@ -764,6 +771,7 @@ async function run(): Promise<void> {
   running.value = true
   lastRunPrompt.value = text
   const runTs = Date.now()
+  const studioRunId = gatewayTraceRunId(`studio-bakeoff-${runTs}`)
   activeRunTs.value = runTs
   poll.stopAll()
   // Seed panels.
@@ -772,9 +780,10 @@ async function run(): Promise<void> {
     servedId: r.servedId,
     label: r.presentation.displayName,
     vendorLabel: r.presentation.vendorLabel,
+    imageSize: modality.value === 'image' ? bakeoffImageSize(r) : undefined,
     cost:
       modality.value === 'image'
-        ? estimateImageCost({ baseImagePrice: r.baseImagePrice || 0, size: DEFAULT_IMAGEN_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
+        ? bakeoffImageCost(r)
         : estimateVideoCost({ perSecond: r.perSecond || 0, seconds: panelSeconds(r), rateMultiplier: props.rateMultiplier }),
     seconds: modality.value === 'video' ? panelSeconds(r) : undefined,
     state: 'processing',
@@ -786,7 +795,7 @@ async function run(): Promise<void> {
       await Promise.all(
         panels.value.map(async (panel) => {
           try {
-            const items = await generateBakeoffImage(panel.servedId, text)
+            const items = await generateBakeoffImage(panel.servedId, text, panel.imageSize, studioRunId)
             if (!items.length) throw new Error('no_image')
             const it = items[0]
             panel.src = it.src
@@ -799,7 +808,7 @@ async function run(): Promise<void> {
               revisedPrompt: it.revisedPrompt,
               model: panel.servedId,
               vendorLabel: panel.vendorLabel,
-              size: DEFAULT_IMAGEN_SIZE,
+              size: panel.imageSize ?? '',
               cost: panel.cost,
               ts: runTs,
             })
@@ -860,21 +869,44 @@ async function run(): Promise<void> {
 }
 
 /** Route like ImageStudio: gemini-native via chat; imagen/seedream via /v1/images/generations. */
-async function generateBakeoffImage(modelId: string, prompt: string) {
+function bakeoffImageSize(r: ResolvedMediaModel): string | undefined {
+  return r.presentation.imageSizes?.[0]?.value ?? DEFAULT_BAKEOFF_IMAGE_SIZE
+}
+
+function bakeoffImagePricesFlat(r: ResolvedMediaModel): boolean {
+  return !!r.presentation.flatImageBilling || !!r.presentation.flatPricePerImage
+}
+
+function bakeoffImageCost(r: ResolvedMediaModel): number {
+  return estimateImageCost({
+    baseImagePrice: r.baseImagePrice || 0,
+    size: bakeoffImagePricesFlat(r) ? '1K' : bakeoffImageSize(r) || '2K',
+    n: 1,
+    rateMultiplier: props.rateMultiplier,
+  })
+}
+
+async function generateBakeoffImage(modelId: string, prompt: string, imageSize?: string, studioRunId?: string) {
+  const trace = {
+    studioSource: 'studio.bakeoff.image',
+    studioRunId,
+    studioPanelId: modelId,
+  }
   if (isGeminiNativeImageModel(modelId)) {
     const raw = await gatewayGeminiImageViaChat(props.apiKey, props.gatewayBase, {
       model: modelId,
       prompt,
-      aspectRatio: DEFAULT_GEMINI_ASPECT,
-    })
+      aspectRatio: imageSize || DEFAULT_GEMINI_ASPECT,
+    }, undefined, trace)
     return extractChatImageItems(raw)
   }
-  const raw = await gatewayImageGenerations(props.apiKey, props.gatewayBase, {
+  const payload: Parameters<typeof gatewayImageGenerations>[2] = {
     model: modelId,
     prompt,
-    size: DEFAULT_IMAGEN_SIZE,
     n: 1,
-  })
+  }
+  if (imageSize) payload.size = imageSize
+  const raw = await gatewayImageGenerations(props.apiKey, props.gatewayBase, payload, undefined, trace)
   return extractImageItems(raw)
 }
 

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -243,7 +243,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { gatewayImageGenerations, gatewayGeminiImageViaChat, gatewayImageToPrompt } from '@/api/playground'
+import { gatewayImageGenerations, gatewayGeminiImageViaChat, gatewayImageToPrompt, gatewayTraceRunId } from '@/api/playground'
 import { extractImageItems, extractChatImageItems, pickVisionChatModel } from '@/constants/playgroundMedia.tk'
 import ImageUpload from '@/components/common/ImageUpload.vue'
 import {
@@ -498,6 +498,7 @@ async function generate(): Promise<void> {
   errorMessage.value = ''
   errorCode.value = ''
   sending.value = true
+  const trace = { studioSource: 'studio.image', studioRunId: gatewayTraceRunId('studio-image') }
   try {
     // Gemini-native image rides /v1/chat/completions (image returned as markdown in
     // the chat response — the universal path that works for antigravity + newapi
@@ -509,7 +510,7 @@ async function generate(): Promise<void> {
         prompt: text,
         aspectRatio: sentSize.value, // ratio code → extra_body.google.image_config.aspect_ratio
         inputImage: inputImage.value || undefined // image-to-image when an input image is staged
-      })
+      }, undefined, trace)
       items = extractChatImageItems(raw)
     } else {
       const raw = await gatewayImageGenerations(props.apiKey, props.gatewayBase, {
@@ -517,7 +518,7 @@ async function generate(): Promise<void> {
         prompt: text,
         size: sentSize.value,
         n: n.value,
-      })
+      }, undefined, trace)
       items = extractImageItems(raw)
     }
     if (!items.length) throw new Error(t('studio.image.noResult'))

--- a/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/BakeOff.spec.ts
@@ -40,6 +40,7 @@ vi.mock('@/stores/app', () => ({
 vi.mock('@/api/playground', () => ({
   gatewayImageGenerations: vi.fn(),
   gatewayGeminiImageViaChat: vi.fn(),
+  gatewayTraceRunId: vi.fn((prefix: string) => `${prefix}-test-run`),
   gatewayVideoSubmit: vi.fn(),
   gatewayImagePresign: vi.fn(),
 }))
@@ -264,19 +265,55 @@ describe('BakeOff image routing', () => {
     expect(playground.gatewayGeminiImageViaChat).toHaveBeenCalledWith(
       'sk-test',
       'https://api.example.com',
-      expect.objectContaining({ model: 'gemini-3.1-flash-image', aspectRatio: '1:1' })
+      expect.objectContaining({ model: 'gemini-3.1-flash-image', aspectRatio: '1:1' }),
+      undefined,
+      expect.objectContaining({ studioSource: 'studio.bakeoff.image', studioPanelId: 'gemini-3.1-flash-image' })
     )
     expect(playground.gatewayImageGenerations).toHaveBeenCalledWith(
       'sk-test',
       'https://api.example.com',
-      expect.objectContaining({ model: 'imagen-4.0-fast-generate-001', size: '1:1' })
+      expect.objectContaining({ model: 'imagen-4.0-fast-generate-001', size: '1:1' }),
+      undefined,
+      expect.objectContaining({ studioSource: 'studio.bakeoff.image', studioPanelId: 'imagen-4.0-fast-generate-001' })
     )
     expect(playground.gatewayImageGenerations).toHaveBeenCalledWith(
       'sk-test',
       'https://api.example.com',
-      expect.objectContaining({ model: 'seedream-4-0-250828', size: '1:1' })
+      expect.objectContaining({ model: 'seedream-4-0-250828', size: '2048x2048' }),
+      undefined,
+      expect.objectContaining({ studioSource: 'studio.bakeoff.image', studioPanelId: 'seedream-4-0-250828' })
     )
     expect(libraryMock.addImages).toHaveBeenCalled()
+  })
+
+  it('omits image size for image models without curated size support', async () => {
+    const wrapper = mount(BakeOff, {
+      props: {
+        ...baseProps,
+        availableIds: new Set(['imagen-4.0-fast-generate-001', 'grok-imagine-image']),
+        priceMap: new Map([
+          ['imagen-4.0-fast-generate-001', { perImage: 0.02, billingMode: 'image' }],
+          ['grok-imagine-image', { perImage: 0.02, billingMode: 'image' }],
+        ]),
+      },
+      global: { plugins: [i18n], stubs: { RouterLink: true } },
+    })
+    await wrapper.get('[data-testid="bakeoff-mode-image"]').trigger('click')
+    for (const tier of wrapper.findAll('[data-testid="bakeoff-tier"]')) {
+      await tier.trigger('click')
+    }
+    await wrapper.get('textarea').setValue('a red apple')
+    await wrapper.get('[data-testid="studio-bakeoff-run"]').trigger('click')
+    await flushPromises()
+
+    const grokCall = vi.mocked(playground.gatewayImageGenerations).mock.calls.find((call) => {
+      return call[2].model === 'grok-imagine-image'
+    })
+    expect(grokCall?.[2]).toEqual({
+      model: 'grok-imagine-image',
+      prompt: 'a red apple',
+      n: 1,
+    })
   })
 
   it('allows selecting five image models for bake-off', async () => {

--- a/ops/observability/probe-studio-image-request-audit.sh
+++ b/ops/observability/probe-studio-image-request-audit.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# probe-studio-image-request-audit.sh - read-only Studio image request audit:
+# prompt/source/size/model body fingerprints for Image Studio and BakeOff.
+# Runs INSIDE the TokenKey host (prod or edge) via run-probe.sh. Output is
+# row_to_json so parsing is field-named, not column-index.
+#
+#   bash ops/observability/run-probe.sh --target prod \
+#     --script ops/observability/probe-studio-image-request-audit.sh \
+#     [--env WINDOW_MINUTES=60] [--env LIMIT=20] \
+#     [--env USER_ID=1] [--env API_KEY_ID=123] [--env MODEL=imagen-4.0-generate-001] \
+#     [--env STUDIO_RUN_ID=studio-bakeoff-image-...] [--env PROMPT_SHA256=...]
+#
+# Filters are optional and are ANDed together:
+#   USER_ID, API_KEY_ID, ACCOUNT_ID, MODEL, STUDIO_SOURCE, STUDIO_RUN_ID,
+#   STUDIO_PANEL_ID, PROMPT_SHA256, REQUEST_ID, CLIENT_REQUEST_ID.
+#
+# Interpret:
+#   - Same studio_run_id + multiple prompt_sha256 values => different prompt was
+#     submitted for panels in the same UI run.
+#   - Same prompt_sha256 but wrong output => inspect model/size/forward_model and
+#     upstream errors; this audit does not prove image semantic correctness.
+#   - No rows can mean the deployment predates this audit hook, the request was
+#     outside WINDOW_MINUTES, or the caller did not hit a Studio image path.
+set -u
+
+WINDOW_MINUTES="${WINDOW_MINUTES:-60}"
+LIMIT="${LIMIT:-20}"
+USER_ID="${USER_ID:-}"
+API_KEY_ID="${API_KEY_ID:-}"
+ACCOUNT_ID="${ACCOUNT_ID:-}"
+MODEL="${MODEL:-}"
+STUDIO_SOURCE="${STUDIO_SOURCE:-}"
+STUDIO_RUN_ID="${STUDIO_RUN_ID:-}"
+STUDIO_PANEL_ID="${STUDIO_PANEL_ID:-}"
+PROMPT_SHA256="${PROMPT_SHA256:-}"
+REQUEST_ID="${REQUEST_ID:-}"
+CLIENT_REQUEST_ID="${CLIENT_REQUEST_ID:-}"
+
+validate_int() {
+  local name="$1"
+  local value="$2"
+  case "$value" in ''|*[!0-9]*) echo "bad ${name} (want positive integer)" >&2; exit 2;; esac
+  if [ "$value" -le 0 ]; then
+    echo "bad ${name} (want positive integer)" >&2
+    exit 2
+  fi
+}
+
+validate_optional_int() {
+  local name="$1"
+  local value="$2"
+  [ -z "$value" ] && return 0
+  case "$value" in *[!0-9]*) echo "bad ${name} (want integer)" >&2; exit 2;; esac
+}
+
+validate_text_filter() {
+  local name="$1"
+  local value="$2"
+  [ -z "$value" ] && return 0
+  if [ "${#value}" -gt 512 ]; then
+    echo "bad ${name} (too long; max 512 bytes for probe filter)" >&2
+    exit 2
+  fi
+  if [[ "$value" =~ [[:cntrl:]] ]]; then
+    echo "bad ${name} (control characters are not allowed)" >&2
+    exit 2
+  fi
+}
+
+sql_quote() {
+  local escaped
+  escaped=$(printf '%s' "$1" | sed "s/'/''/g")
+  printf "'%s'" "$escaped"
+}
+
+add_filter() {
+  FILTER_SQL="${FILTER_SQL}
+  AND $1"
+}
+
+validate_int "WINDOW_MINUTES" "$WINDOW_MINUTES"
+validate_int "LIMIT" "$LIMIT"
+if [ "$LIMIT" -gt 200 ]; then
+  echo "bad LIMIT (max 200 to keep SSM stdout bounded)" >&2
+  exit 2
+fi
+validate_optional_int "USER_ID" "$USER_ID"
+validate_optional_int "API_KEY_ID" "$API_KEY_ID"
+validate_optional_int "ACCOUNT_ID" "$ACCOUNT_ID"
+validate_text_filter "MODEL" "$MODEL"
+validate_text_filter "STUDIO_SOURCE" "$STUDIO_SOURCE"
+validate_text_filter "STUDIO_RUN_ID" "$STUDIO_RUN_ID"
+validate_text_filter "STUDIO_PANEL_ID" "$STUDIO_PANEL_ID"
+validate_text_filter "PROMPT_SHA256" "$PROMPT_SHA256"
+validate_text_filter "REQUEST_ID" "$REQUEST_ID"
+validate_text_filter "CLIENT_REQUEST_ID" "$CLIENT_REQUEST_ID"
+if [ -n "$PROMPT_SHA256" ] && [[ ! "$PROMPT_SHA256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+  echo "bad PROMPT_SHA256 (want 64 hex chars)" >&2
+  exit 2
+fi
+
+PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+FILTER_SQL=""
+
+if [ -n "$USER_ID" ]; then add_filter "user_id = ${USER_ID}"; fi
+if [ -n "$API_KEY_ID" ]; then add_filter "api_key_id = ${API_KEY_ID}"; fi
+if [ -n "$ACCOUNT_ID" ]; then add_filter "account_id = ${ACCOUNT_ID}"; fi
+if [ -n "$MODEL" ]; then
+  Q=$(sql_quote "$MODEL")
+  add_filter "(model = ${Q} OR extra->>'requested_model' = ${Q} OR extra->>'forward_model' = ${Q})"
+fi
+if [ -n "$STUDIO_SOURCE" ]; then
+  Q=$(sql_quote "$STUDIO_SOURCE")
+  add_filter "extra->>'studio_source' = ${Q}"
+fi
+if [ -n "$STUDIO_RUN_ID" ]; then
+  Q=$(sql_quote "$STUDIO_RUN_ID")
+  add_filter "extra->>'studio_run_id' = ${Q}"
+fi
+if [ -n "$STUDIO_PANEL_ID" ]; then
+  Q=$(sql_quote "$STUDIO_PANEL_ID")
+  add_filter "extra->>'studio_panel_id' = ${Q}"
+fi
+if [ -n "$PROMPT_SHA256" ]; then
+  Q=$(sql_quote "$PROMPT_SHA256")
+  add_filter "extra->>'prompt_sha256' = ${Q}"
+fi
+if [ -n "$REQUEST_ID" ]; then
+  Q=$(sql_quote "$REQUEST_ID")
+  add_filter "(request_id = ${Q} OR extra->>'request_id' = ${Q})"
+fi
+if [ -n "$CLIENT_REQUEST_ID" ]; then
+  Q=$(sql_quote "$CLIENT_REQUEST_ID")
+  add_filter "(client_request_id = ${Q} OR extra->>'client_request_id' = ${Q})"
+fi
+
+BASE_CTE="WITH base AS (
+  SELECT
+    id, created_at, level, component, message, request_id, client_request_id,
+    user_id, api_key_id, account_id, platform, model, extra
+  FROM ops_system_logs
+  WHERE created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+    AND component = 'audit.openai_image_request'
+    AND message = 'openai_image.request_payload'
+    ${FILTER_SQL}
+)"
+
+LAST_SEEN_CTE="WITH base AS (
+  SELECT created_at, user_id, api_key_id, account_id, model, extra
+  FROM ops_system_logs
+  WHERE component = 'audit.openai_image_request'
+    AND message = 'openai_image.request_payload'
+    ${FILTER_SQL}
+)"
+
+echo "=== meta ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  now() AT TIME ZONE 'UTC'                         AS now_utc,
+  now() AT TIME ZONE 'Asia/Shanghai'              AS now_cst,
+  ${WINDOW_MINUTES}::int                          AS window_minutes,
+  ${LIMIT}::int                                   AS limit_rows,
+  NULLIF($(sql_quote "$USER_ID"), '')             AS user_id_filter,
+  NULLIF($(sql_quote "$API_KEY_ID"), '')          AS api_key_id_filter,
+  NULLIF($(sql_quote "$ACCOUNT_ID"), '')          AS account_id_filter,
+  NULLIF($(sql_quote "$MODEL"), '')               AS model_filter,
+  NULLIF($(sql_quote "$STUDIO_SOURCE"), '')       AS studio_source_filter,
+  NULLIF($(sql_quote "$STUDIO_RUN_ID"), '')       AS studio_run_id_filter,
+  NULLIF($(sql_quote "$STUDIO_PANEL_ID"), '')     AS studio_panel_id_filter,
+  NULLIF($(sql_quote "$PROMPT_SHA256"), '')       AS prompt_sha256_filter,
+  NULLIF($(sql_quote "$REQUEST_ID"), '')          AS request_id_filter,
+  NULLIF($(sql_quote "$CLIENT_REQUEST_ID"), '')   AS client_request_id_filter) t;" 2>&1
+
+echo
+echo "=== summary ==="
+$PSQL -c "${BASE_CTE}
+SELECT row_to_json(t) FROM (SELECT
+  count(*)                                                          AS rows,
+  min(created_at) AT TIME ZONE 'UTC'                                AS first_at_utc,
+  max(created_at) AT TIME ZONE 'UTC'                                AS last_at_utc,
+  count(DISTINCT user_id) FILTER (WHERE user_id IS NOT NULL)        AS distinct_users,
+  count(DISTINCT api_key_id) FILTER (WHERE api_key_id IS NOT NULL)  AS distinct_api_keys,
+  count(DISTINCT account_id) FILTER (WHERE account_id IS NOT NULL)  AS distinct_accounts,
+  count(DISTINCT NULLIF(extra->>'studio_run_id', ''))               AS distinct_studio_runs,
+  count(DISTINCT NULLIF(extra->>'prompt_sha256', ''))               AS distinct_prompt_hashes,
+  count(*) FILTER (WHERE NULLIF(extra->>'prompt_preview', '') IS NULL) AS missing_prompt_rows
+  FROM base) t;" 2>&1
+
+echo
+echo "=== by source/model/size ==="
+$PSQL -c "${BASE_CTE}
+SELECT row_to_json(t) FROM (SELECT
+  COALESCE(NULLIF(extra->>'studio_source', ''), '<missing>') AS studio_source,
+  COALESCE(NULLIF(extra->>'surface', ''), '<missing>')       AS surface,
+  COALESCE(NULLIF(model, ''), NULLIF(extra->>'requested_model', ''), '<missing>') AS model,
+  COALESCE(NULLIF(extra->>'forward_model', ''), '<missing>') AS forward_model,
+  COALESCE(NULLIF(extra->>'size', ''), '<missing>')          AS size,
+  COALESCE(NULLIF(extra->>'forward_size', ''), '<missing>')  AS forward_size,
+  count(*)                                                   AS rows,
+  count(DISTINCT NULLIF(extra->>'prompt_sha256', ''))        AS prompt_hashes,
+  min(created_at) AT TIME ZONE 'UTC'                         AS first_at_utc,
+  max(created_at) AT TIME ZONE 'UTC'                         AS last_at_utc
+  FROM base
+  GROUP BY 1,2,3,4,5,6
+  ORDER BY rows DESC, last_at_utc DESC
+  LIMIT 50) t;" 2>&1
+
+echo
+echo "=== by studio run ==="
+$PSQL -c "${BASE_CTE}
+SELECT row_to_json(t) FROM (SELECT
+  COALESCE(NULLIF(extra->>'studio_run_id', ''), '<missing>') AS studio_run_id,
+  COALESCE(NULLIF(extra->>'studio_source', ''), '<missing>') AS studio_source,
+  count(*)                                                   AS rows,
+  string_agg(DISTINCT COALESCE(NULLIF(model, ''), NULLIF(extra->>'requested_model', ''), '<missing>'), ', ') AS models,
+  count(DISTINCT NULLIF(extra->>'studio_panel_id', ''))      AS panels,
+  count(DISTINCT NULLIF(extra->>'prompt_sha256', ''))        AS prompt_hashes,
+  min(created_at) AT TIME ZONE 'UTC'                         AS first_at_utc,
+  max(created_at) AT TIME ZONE 'UTC'                         AS last_at_utc
+  FROM base
+  GROUP BY 1,2
+  ORDER BY last_at_utc DESC
+  LIMIT 40) t;" 2>&1
+
+echo
+echo "=== prompt consistency by run ==="
+$PSQL -c "${BASE_CTE}
+SELECT row_to_json(t) FROM (SELECT
+  COALESCE(NULLIF(extra->>'studio_run_id', ''), '<missing>') AS studio_run_id,
+  NULLIF(extra->>'prompt_sha256', '')                        AS prompt_sha256,
+  left(COALESCE(extra->>'prompt_preview', ''), 200)          AS prompt_preview_200,
+  count(*)                                                   AS rows,
+  string_agg(DISTINCT COALESCE(NULLIF(model, ''), NULLIF(extra->>'requested_model', ''), '<missing>'), ', ') AS models,
+  min(created_at) AT TIME ZONE 'UTC'                         AS first_at_utc,
+  max(created_at) AT TIME ZONE 'UTC'                         AS last_at_utc
+  FROM base
+  GROUP BY 1,2,3
+  ORDER BY studio_run_id DESC, rows DESC, last_at_utc DESC
+  LIMIT 80) t;" 2>&1
+
+echo
+echo "=== samples ==="
+$PSQL -c "${BASE_CTE}
+SELECT row_to_json(t) FROM (SELECT
+  id,
+  created_at AT TIME ZONE 'UTC'           AS ts_utc,
+  created_at AT TIME ZONE 'Asia/Shanghai' AS ts_cst,
+  request_id,
+  client_request_id,
+  user_id,
+  api_key_id,
+  extra->>'group_id' AS group_id,
+  account_id,
+  platform,
+  model,
+  extra->>'requested_model' AS requested_model,
+  extra->>'forward_model' AS forward_model,
+  extra->>'surface' AS surface,
+  extra->>'request_path' AS request_path,
+  extra->>'inbound_endpoint' AS inbound_endpoint,
+  extra->>'upstream_endpoint' AS upstream_endpoint,
+  extra->>'studio_source' AS studio_source,
+  extra->>'studio_run_id' AS studio_run_id,
+  extra->>'studio_panel_id' AS studio_panel_id,
+  extra->>'prompt_source' AS prompt_source,
+  extra->>'prompt_preview' AS prompt_preview,
+  extra->>'prompt_preview_truncated' AS prompt_preview_truncated,
+  extra->>'prompt_sha256' AS prompt_sha256,
+  extra->>'prompt_bytes' AS prompt_bytes,
+  extra->>'prompt_runes' AS prompt_runes,
+  extra->>'size' AS size,
+  extra->>'forward_size' AS forward_size,
+  extra->>'n' AS n,
+  extra->>'quality' AS quality,
+  extra->>'style' AS style,
+  extra->>'response_format' AS response_format,
+  extra->>'background' AS background,
+  extra->>'output_format' AS output_format,
+  extra->>'moderation' AS moderation,
+  extra->>'request_body_sha256' AS request_body_sha256,
+  extra->>'request_body_bytes' AS request_body_bytes,
+  extra->>'forward_body_sha256' AS forward_body_sha256
+  FROM base
+  ORDER BY created_at DESC, id DESC
+  LIMIT ${LIMIT}) t;" 2>&1
+
+echo
+echo "=== related ops_error_logs by request_id ==="
+$PSQL -c "${BASE_CTE},
+ids AS (
+  SELECT DISTINCT request_id FROM base WHERE NULLIF(request_id, '') IS NOT NULL
+)
+SELECT row_to_json(t) FROM (SELECT
+  e.created_at AT TIME ZONE 'UTC' AS ts_utc,
+  e.request_id,
+  e.client_request_id,
+  e.user_id,
+  e.api_key_id,
+  e.account_id,
+  e.platform,
+  e.model,
+  e.request_path,
+  e.error_phase,
+  e.error_type,
+  e.error_owner,
+  e.status_code,
+  e.upstream_status_code,
+  left(COALESCE(e.upstream_error_message, e.error_message, ''), 220) AS msg
+  FROM ops_error_logs e
+  JOIN ids ON ids.request_id = e.request_id
+  WHERE e.created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+  ORDER BY e.created_at DESC
+  LIMIT 30) t;" 2>&1
+
+echo
+echo "=== last-seen with filters (any time) ==="
+$PSQL -c "${LAST_SEEN_CTE}
+SELECT row_to_json(t) FROM (SELECT
+  max(created_at) AT TIME ZONE 'UTC' AS last_at_utc,
+  max(created_at) AT TIME ZONE 'Asia/Shanghai' AS last_at_cst
+  FROM base) t;" 2>&1

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -886,9 +886,11 @@
       "must_contain": [
         "gatewayImageGenerations",
         "gatewayVideoFetch",
-        "/v1/video/generations/"
+        "/v1/video/generations/",
+        "X-TokenKey-Studio-Source",
+        "gatewayTraceHeaders"
       ],
-      "rationale": "Gateway media calls for the playground (images sync POST with 180s timeout, video submit + per-task fetch). Paths must stay the TK gateway aliases registered in routes/gateway_tk_openai_compat_handlers.go."
+      "rationale": "Gateway media calls for the playground (images sync POST with 180s timeout, video submit + per-task fetch). Paths must stay the TK gateway aliases registered in routes/gateway_tk_openai_compat_handlers.go. gatewayTraceHeaders forwards X-TokenKey-Studio-* on Studio image/video submits so backend audit.openai_image_request can correlate BakeOff/ImageStudio runs."
     },
     {
       "path": "frontend/src/components/user/dashboard/UserDashboardCharts.vue",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2853,9 +2853,27 @@
     {
       "path": "backend/internal/handler/openai_gateway_embeddings_images.go",
       "must_contain": [
-        "TkImageModelUnpriced"
+        "TkImageModelUnpriced",
+        "logOpenAIImageGenerationRequestAudit(c, apiKey, subject.UserID, account, body, forwardBody)"
       ],
-      "rationale": "Second TK hook for the media unpriced-reject policy: ImageGenerations() is the OpenAI-compat pool entry for POST /images/generations (newapi groups route here, NOT through openai_images.go Images()). The first guard rollout missed this entry and unpriced image requests sailed to the upstream — caught by local e2e. Dropping this call silently re-opens that exact hole."
+      "rationale": "Second TK hook for the media unpriced-reject policy: ImageGenerations() is the OpenAI-compat pool entry for POST /images/generations (newapi groups route here, NOT through openai_images.go Images()). The first guard rollout missed this entry and unpriced image requests sailed to the upstream — caught by local e2e. Dropping this call silently re-opens that exact hole. The logOpenAIImageGenerationRequestAudit injection is the Studio/ImageStudio/BakeOff prompt+size audit hook for POST /v1/images/generations; losing it compiles clean but removes ops visibility for image request debugging (probe-studio-image-request-audit.sh)."
+    },
+    {
+      "path": "backend/internal/handler/openai_image_request_audit_tk.go",
+      "must_contain": [
+        "func logOpenAIImageGenerationRequestAudit(",
+        "func logOpenAIStudioChatImageRequestAudit(",
+        "tkImageRequestAuditComponent = \"audit.openai_image_request\"",
+        "logredact.RedactText(preview)"
+      ],
+      "rationale": "TK companion for Studio image request audit logging: captures prompt hash/preview (redacted), size/forward_model, and X-TokenKey-Studio-* trace headers on /v1/images/generations and Studio-traced Gemini image chat paths. Deleting this file silently removes the audit sink that probe-studio-image-request-audit.sh reads."
+    },
+    {
+      "path": "backend/internal/handler/openai_chat_completions.go",
+      "must_contain": [
+        "logOpenAIStudioChatImageRequestAudit(c, apiKey, subject.UserID, account, body, forwardBody)"
+      ],
+      "rationale": "Studio Gemini-native image requests hit /v1/chat/completions with X-TokenKey-Studio-Source containing 'studio'+'image'; this one-line audit hook is the only server-side prompt trace for that path. Upstream merges that rewrite the forward block can drop it without compile failure while ImageStudio/BakeOff chat-image debugging goes blind."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_saturation_penalty.go",


### PR DESCRIPTION
## 摘要

- 修复 Studio BakeOff 图片请求：按各 model presentation 的 `imageSizes` 合约发送 `size`/`aspectRatio`，不再硬编码 Imagen 风格尺寸；flat-priced 模型成本估算同步修正。
- 新增 Studio 图片请求审计日志（prompt hash/preview、model/size 转发字段、Studio trace headers），覆盖 `/v1/images/generations` 与 Gemini 图片 chat 路径。
- 新增只读探针 `ops/observability/probe-studio-image-request-audit.sh`，并在 `tokenkey-online-log-troubleshooting` skill 中记录排查流程。
- rebase 到 `origin/main`（含 #1181/#1188）；endpoint compat baseline 已在 main 合并，本 PR 仅保留 Studio 修复与 sentinel 锚点。

## 风险

- 审计日志写入 ops 结构化日志，含 prompt preview（经 logredact 脱敏）；仅 Studio trace header 触发的 chat 路径才审计，避免普通 chat 噪声。
- CORS 新增 3 个 `X-TokenKey-Studio-*` header，前后端需对齐（已同 PR 修改）。

## 验证

- rebase `origin/main` 完成；`git merge-base --is-ancestor origin/main HEAD` 通过
- `PREFLIGHT_BASE=origin/main ./scripts/preflight.sh` PASS
- `go test -tags=unit ./internal/handler/ -run TestLogOpenAIImage` 绿
- `pnpm vitest run src/views/user/studio/__tests__/BakeOff.spec.ts src/api/__tests__/playground.spec.ts src/constants/__tests__/studioMediaPresentations.tk.spec.ts` 67/67 绿
- `python3 scripts/checks/frontend-dist-freshness.py --check backend/internal/web/dist` 绿

## 提交

- `7f2f865a8` fix: stabilize studio image bakeoff requests
- `6235ea2cf` fix(review): anchor Studio image request audit sentinels

最新提交：6235ea2cf

sentinel-registry-reviewed
