### PR TITLE
fix(admin): Kiro 用量窗口去重并展示试用/Bonus 额度

### DIFF
--- a/backend/internal/handler/edge_tk_accounts_handler.go
+++ b/backend/internal/handler/edge_tk_accounts_handler.go
@@ -249,14 +249,17 @@ type edgeUsageProgress struct {
 // credits budget (current/limit/percent), the monthly reset date, the订阅 title,
 // and the optional trial allowance (percent + expiry + status).
 type edgeKiroUsage struct {
-	Current           float64    `json:"current,omitempty"`
-	Limit             float64    `json:"limit,omitempty"`
-	Percent           float64    `json:"percent,omitempty"`
-	NextResetDate     string     `json:"next_reset_date,omitempty"`
-	SubscriptionTitle string     `json:"subscription_title,omitempty"`
-	TrialPercent      float64    `json:"trial_percent,omitempty"`
-	TrialStatus       string     `json:"trial_status,omitempty"`
-	TrialExpiresAt    *time.Time `json:"trial_expires_at,omitempty"`
+	Current           float64           `json:"current,omitempty"`
+	Limit             float64           `json:"limit,omitempty"`
+	Percent           float64           `json:"percent,omitempty"`
+	NextResetDate     string            `json:"next_reset_date,omitempty"`
+	SubscriptionTitle string            `json:"subscription_title,omitempty"`
+	TrialCurrent      float64           `json:"trial_current,omitempty"`
+	TrialLimit        float64           `json:"trial_limit,omitempty"`
+	TrialPercent      float64           `json:"trial_percent,omitempty"`
+	TrialStatus       string            `json:"trial_status,omitempty"`
+	TrialExpiresAt    *time.Time        `json:"trial_expires_at,omitempty"`
+	Bonuses           []service.KiroBonusInfo `json:"bonuses,omitempty"`
 }
 
 // edgeSubscription is the credential-free「订阅」projection — see edgeAccountDTO.Subscription.
@@ -415,9 +418,14 @@ func toEdgeUsageWindows(u *service.UsageInfo) *edgeUsageWindows {
 			SubscriptionTitle: k.SubscriptionTitle,
 		}
 		if k.Trial != nil {
+			w.Kiro.TrialCurrent = k.Trial.Current
+			w.Kiro.TrialLimit = k.Trial.Limit
 			w.Kiro.TrialPercent = k.Trial.Percent
 			w.Kiro.TrialStatus = k.Trial.Status
 			w.Kiro.TrialExpiresAt = k.Trial.ExpiresAt
+		}
+		if len(k.Bonuses) > 0 {
+			w.Kiro.Bonuses = append([]service.KiroBonusInfo(nil), k.Bonuses...)
 		}
 	}
 	if w.FiveHour == nil && w.SevenDay == nil && w.SevenDaySonnet == nil && w.Kiro == nil && w.UpstreamQuota == nil {

--- a/backend/internal/handler/edge_tk_accounts_handler.go
+++ b/backend/internal/handler/edge_tk_accounts_handler.go
@@ -249,16 +249,16 @@ type edgeUsageProgress struct {
 // credits budget (current/limit/percent), the monthly reset date, the订阅 title,
 // and the optional trial allowance (percent + expiry + status).
 type edgeKiroUsage struct {
-	Current           float64           `json:"current,omitempty"`
-	Limit             float64           `json:"limit,omitempty"`
-	Percent           float64           `json:"percent,omitempty"`
-	NextResetDate     string            `json:"next_reset_date,omitempty"`
-	SubscriptionTitle string            `json:"subscription_title,omitempty"`
-	TrialCurrent      float64           `json:"trial_current,omitempty"`
-	TrialLimit        float64           `json:"trial_limit,omitempty"`
-	TrialPercent      float64           `json:"trial_percent,omitempty"`
-	TrialStatus       string            `json:"trial_status,omitempty"`
-	TrialExpiresAt    *time.Time        `json:"trial_expires_at,omitempty"`
+	Current           float64                 `json:"current,omitempty"`
+	Limit             float64                 `json:"limit,omitempty"`
+	Percent           float64                 `json:"percent,omitempty"`
+	NextResetDate     string                  `json:"next_reset_date,omitempty"`
+	SubscriptionTitle string                  `json:"subscription_title,omitempty"`
+	TrialCurrent      float64                 `json:"trial_current,omitempty"`
+	TrialLimit        float64                 `json:"trial_limit,omitempty"`
+	TrialPercent      float64                 `json:"trial_percent,omitempty"`
+	TrialStatus       string                  `json:"trial_status,omitempty"`
+	TrialExpiresAt    *time.Time              `json:"trial_expires_at,omitempty"`
 	Bonuses           []service.KiroBonusInfo `json:"bonuses,omitempty"`
 }
 

--- a/backend/internal/integration/kiro/rest.go
+++ b/backend/internal/integration/kiro/rest.go
@@ -420,7 +420,7 @@ func RefreshAccountInfo(account *Account) (*AccountInfo, error) {
 		}
 	}
 
-	// 解析试用配额信息
+	// 解析试用配额与 bonus credits
 	if len(usage.UsageBreakdownList) > 0 {
 		breakdown := usage.UsageBreakdownList[0]
 		if breakdown.FreeTrialInfo != nil {
@@ -439,6 +439,33 @@ func RefreshAccountInfo(account *Account) (*AccountInfo, error) {
 					info.TrialExpiresAt = int64(f)
 				}
 			}
+		}
+		for _, bonus := range breakdown.Bonuses {
+			label := strings.TrimSpace(bonus.DisplayName)
+			if label == "" {
+				label = strings.TrimSpace(bonus.BonusCode)
+			}
+			if label == "" && bonus.CurrentUsage <= 0 && bonus.UsageLimit <= 0 {
+				continue
+			}
+			item := KiroBonusInfo{
+				Code:    strings.TrimSpace(bonus.BonusCode),
+				Label:   label,
+				Current: bonus.CurrentUsage,
+				Limit:   bonus.UsageLimit,
+				Status:  strings.TrimSpace(bonus.Status),
+			}
+			if item.Limit > 0 {
+				item.Percent = (item.Current / item.Limit) * 100
+			}
+			if bonus.ExpiresAt != "" {
+				if ts, err := bonus.ExpiresAt.Int64(); err == nil && ts > 0 {
+					item.ExpiresAt = ts
+				} else if f, err := bonus.ExpiresAt.Float64(); err == nil && f > 0 {
+					item.ExpiresAt = int64(f)
+				}
+			}
+			info.Bonuses = append(info.Bonuses, item)
 		}
 	}
 

--- a/backend/internal/integration/kiro/rest_test.go
+++ b/backend/internal/integration/kiro/rest_test.go
@@ -150,3 +150,55 @@ func TestIsInvalidProfileArnError(t *testing.T) {
 		t.Fatal("401 should not match invalid profileArn")
 	}
 }
+
+func TestRefreshAccountInfo_MapsBonusesFromUsageBreakdown(t *testing.T) {
+	var usageCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "getUsageLimits"):
+			usageCalls.Add(1)
+			_, _ = io.WriteString(w, `{
+				"usageBreakdownList": [{
+					"resourceType": "AGENTIC_REQUEST",
+					"currentUsage": 300,
+					"usageLimit": 1000,
+					"bonuses": [{
+						"bonusCode": "WELCOME500",
+						"displayName": "Welcome Bonus",
+						"currentUsage": 120,
+						"usageLimit": 500,
+						"status": "ACTIVE",
+						"expiresAt": 1893456000
+					}]
+				}],
+				"nextDateReset": 1893456000,
+				"subscriptionInfo": {"subscriptionTitle": "KIRO POWER"}
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	installTestRestClient(t, srv)
+
+	account := &Account{
+		AccessToken: "tok",
+		ProfileArn:  "arn:aws:codewhisperer:us-east-1:1:profile/test",
+	}
+	info, err := RefreshAccountInfo(account)
+	if err != nil {
+		t.Fatalf("RefreshAccountInfo() error = %v", err)
+	}
+	if usageCalls.Load() != 1 {
+		t.Fatalf("getUsageLimits calls = %d, want 1", usageCalls.Load())
+	}
+	if len(info.Bonuses) != 1 {
+		t.Fatalf("bonuses = %+v, want one entry", info.Bonuses)
+	}
+	if info.Bonuses[0].Code != "WELCOME500" || info.Bonuses[0].Limit != 500 {
+		t.Fatalf("bonus = %+v", info.Bonuses[0])
+	}
+	if info.Bonuses[0].Percent != 24 {
+		t.Fatalf("bonus percent = %v, want 24", info.Bonuses[0].Percent)
+	}
+}

--- a/backend/internal/integration/kiro/shim.go
+++ b/backend/internal/integration/kiro/shim.go
@@ -54,23 +54,35 @@ type Account struct {
 	BanTime      int64  `json:"banTime,omitempty"`
 }
 
+// KiroBonusInfo is one promotional/bonus credits bucket from getUsageLimits.
+type KiroBonusInfo struct {
+	Code      string  `json:"code,omitempty"`
+	Label     string  `json:"label,omitempty"`
+	Current   float64 `json:"current,omitempty"`
+	Limit     float64 `json:"limit,omitempty"`
+	Percent   float64 `json:"percent,omitempty"` // 0-100
+	Status    string  `json:"status,omitempty"`
+	ExpiresAt int64   `json:"expiresAt,omitempty"` // unix seconds
+}
+
 // AccountInfo carries the account metadata returned by RefreshAccountInfo.
 // Fields cover exactly what rest.go populates.
 type AccountInfo struct {
-	Email             string  `json:"email,omitempty"`
-	UserId            string  `json:"userId,omitempty"`
-	SubscriptionType  string  `json:"subscriptionType,omitempty"`
-	SubscriptionTitle string  `json:"subscriptionTitle,omitempty"`
-	UsageCurrent      float64 `json:"usageCurrent,omitempty"`
-	UsageLimit        float64 `json:"usageLimit,omitempty"`
-	UsagePercent      float64 `json:"usagePercent,omitempty"`
-	NextResetDate     string  `json:"nextResetDate,omitempty"`
-	LastRefresh       int64   `json:"lastRefresh,omitempty"`
-	TrialUsageCurrent float64 `json:"trialUsageCurrent,omitempty"`
-	TrialUsageLimit   float64 `json:"trialUsageLimit,omitempty"`
-	TrialUsagePercent float64 `json:"trialUsagePercent,omitempty"`
-	TrialStatus       string  `json:"trialStatus,omitempty"`
-	TrialExpiresAt    int64   `json:"trialExpiresAt,omitempty"`
+	Email             string          `json:"email,omitempty"`
+	UserId            string          `json:"userId,omitempty"`
+	SubscriptionType  string          `json:"subscriptionType,omitempty"`
+	SubscriptionTitle string          `json:"subscriptionTitle,omitempty"`
+	UsageCurrent      float64         `json:"usageCurrent,omitempty"`
+	UsageLimit        float64         `json:"usageLimit,omitempty"`
+	UsagePercent      float64         `json:"usagePercent,omitempty"`
+	NextResetDate     string          `json:"nextResetDate,omitempty"`
+	LastRefresh       int64           `json:"lastRefresh,omitempty"`
+	TrialUsageCurrent float64         `json:"trialUsageCurrent,omitempty"`
+	TrialUsageLimit   float64         `json:"trialUsageLimit,omitempty"`
+	TrialUsagePercent float64         `json:"trialUsagePercent,omitempty"`
+	TrialStatus       string          `json:"trialStatus,omitempty"`
+	TrialExpiresAt    int64           `json:"trialExpiresAt,omitempty"`
+	Bonuses           []KiroBonusInfo `json:"bonuses,omitempty"`
 }
 
 // PromptFilterRule defines a single custom prompt sanitization rule used by

--- a/backend/internal/service/account_usage_service_tk_kiro.go
+++ b/backend/internal/service/account_usage_service_tk_kiro.go
@@ -2,12 +2,17 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"regexp"
+	"strings"
 	"time"
 
 	kiroproto "github.com/Wei-Shaw/sub2api/internal/integration/kiro"
 )
+
+var kiroBonusKeySanitizer = regexp.MustCompile(`[^a-z0-9]+`)
 
 // KiroUsageInfo is the kiro (CodeWhisperer) credits/subscription snapshot surfaced
 // in UsageInfo. Unlike anthropic/openai's rolling 5h/7d windows, kiro exposes a
@@ -15,12 +20,24 @@ import (
 // free-trial allowance with its own expiry. Percent is 0-100 to match
 // UsageProgress.Utilization so the edge DTO can render it as a window bar.
 type KiroUsageInfo struct {
-	Current           float64        `json:"current,omitempty"`
-	Limit             float64        `json:"limit,omitempty"`
-	Percent           float64        `json:"percent,omitempty"` // 0-100
-	NextResetDate     string         `json:"next_reset_date,omitempty"`
-	SubscriptionTitle string         `json:"subscription_title,omitempty"`
-	Trial             *KiroTrialInfo `json:"trial,omitempty"`
+	Current           float64          `json:"current,omitempty"`
+	Limit             float64          `json:"limit,omitempty"`
+	Percent           float64          `json:"percent,omitempty"` // 0-100
+	NextResetDate     string           `json:"next_reset_date,omitempty"`
+	SubscriptionTitle string           `json:"subscription_title,omitempty"`
+	Trial             *KiroTrialInfo   `json:"trial,omitempty"`
+	Bonuses           []KiroBonusInfo  `json:"bonuses,omitempty"`
+}
+
+// KiroBonusInfo is one promotional/bonus credits bucket from getUsageLimits.
+type KiroBonusInfo struct {
+	Code      string     `json:"code,omitempty"`
+	Label     string     `json:"label,omitempty"`
+	Current   float64    `json:"current,omitempty"`
+	Limit     float64    `json:"limit,omitempty"`
+	Percent   float64    `json:"percent,omitempty"` // 0-100
+	Status    string     `json:"status,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
 // KiroTrialInfo is the kiro free-trial allowance (present only while a trial is
@@ -121,14 +138,53 @@ func buildKiroUsageFromInfo(info *kiroproto.AccountInfo) *UsageInfo {
 			Percent: info.TrialUsagePercent * 100,
 			Status:  info.TrialStatus,
 		}
+		if info.TrialUsageLimit > 0 && trial.Percent == 0 && info.TrialUsageCurrent > 0 {
+			trial.Percent = (info.TrialUsageCurrent / info.TrialUsageLimit) * 100
+		}
 		if info.TrialExpiresAt > 0 {
 			t := time.Unix(info.TrialExpiresAt, 0)
 			trial.ExpiresAt = &t
 		}
 		ku.Trial = trial
 	}
+	if len(info.Bonuses) > 0 {
+		ku.Bonuses = make([]KiroBonusInfo, 0, len(info.Bonuses))
+		for _, bonus := range info.Bonuses {
+			ku.Bonuses = append(ku.Bonuses, mapKiroBonusFromProto(bonus))
+		}
+	}
 	usage.KiroUsage = ku
 	return usage
+}
+
+func mapKiroBonusFromProto(bonus kiroproto.KiroBonusInfo) KiroBonusInfo {
+	out := KiroBonusInfo{
+		Code:    strings.TrimSpace(bonus.Code),
+		Label:   strings.TrimSpace(bonus.Label),
+		Current: bonus.Current,
+		Limit:   bonus.Limit,
+		Percent: bonus.Percent,
+		Status:  strings.TrimSpace(bonus.Status),
+	}
+	if out.Label == "" {
+		out.Label = out.Code
+	}
+	if out.Limit > 0 && out.Percent == 0 && out.Current > 0 {
+		out.Percent = (out.Current / out.Limit) * 100
+	}
+	if bonus.ExpiresAt > 0 {
+		t := time.Unix(bonus.ExpiresAt, 0)
+		out.ExpiresAt = &t
+	}
+	return out
+}
+
+func kiroBonusQuotaKey(code string) string {
+	slug := strings.Trim(kiroBonusKeySanitizer.ReplaceAllString(strings.ToLower(strings.TrimSpace(code)), "_"), "_")
+	if slug == "" {
+		slug = "unknown"
+	}
+	return "kiro_bonus_" + slug
 }
 
 // syncKiroActiveToPassive persists the active kiro snapshot to Account.Extra so the
@@ -151,6 +207,7 @@ func (s *AccountUsageService) syncKiroActiveToPassive(ctx context.Context, accou
 		"kiro_trial_percent":      nil,
 		"kiro_trial_status":       nil,
 		"kiro_trial_expiry":       nil,
+		"kiro_bonuses":            nil,
 	}
 	if ku.NextResetDate != "" {
 		updates["kiro_next_reset"] = ku.NextResetDate
@@ -167,6 +224,11 @@ func (s *AccountUsageService) syncKiroActiveToPassive(ctx context.Context, accou
 		}
 		if ku.Trial.ExpiresAt != nil {
 			updates["kiro_trial_expiry"] = ku.Trial.ExpiresAt.Unix()
+		}
+	}
+	if len(ku.Bonuses) > 0 {
+		if raw, err := json.Marshal(ku.Bonuses); err == nil {
+			updates["kiro_bonuses"] = string(raw)
 		}
 	}
 	if err := s.accountRepo.UpdateExtra(ctx, accountID, updates); err != nil {
@@ -193,8 +255,9 @@ func (s *AccountUsageService) buildPassiveKiroUsage(account *Account) *UsageInfo
 	subTitle, _ := extra["kiro_subscription_title"].(string)
 
 	trial := buildPassiveKiroTrial(extra)
+	bonuses := buildPassiveKiroBonuses(extra)
 
-	if limit <= 0 && current <= 0 && percent <= 0 && nextReset == "" && subTitle == "" && trial == nil {
+	if limit <= 0 && current <= 0 && percent <= 0 && nextReset == "" && subTitle == "" && trial == nil && len(bonuses) == 0 {
 		return usage
 	}
 
@@ -205,6 +268,7 @@ func (s *AccountUsageService) buildPassiveKiroUsage(account *Account) *UsageInfo
 		NextResetDate:     nextReset,
 		SubscriptionTitle: subTitle,
 		Trial:             trial,
+		Bonuses:           bonuses,
 	}
 	if sampledAt := parseExtraSampledAt(extra["kiro_usage_sampled_at"]); sampledAt != nil {
 		usage.UpdatedAt = sampledAt
@@ -235,4 +299,19 @@ func buildPassiveKiroTrial(extra map[string]any) *KiroTrialInfo {
 		trial.ExpiresAt = &t
 	}
 	return trial
+}
+
+func buildPassiveKiroBonuses(extra map[string]any) []KiroBonusInfo {
+	raw, ok := extra["kiro_bonuses"].(string)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var bonuses []KiroBonusInfo
+	if err := json.Unmarshal([]byte(raw), &bonuses); err != nil {
+		return nil
+	}
+	if len(bonuses) == 0 {
+		return nil
+	}
+	return bonuses
 }

--- a/backend/internal/service/account_usage_service_tk_kiro.go
+++ b/backend/internal/service/account_usage_service_tk_kiro.go
@@ -20,13 +20,13 @@ var kiroBonusKeySanitizer = regexp.MustCompile(`[^a-z0-9]+`)
 // free-trial allowance with its own expiry. Percent is 0-100 to match
 // UsageProgress.Utilization so the edge DTO can render it as a window bar.
 type KiroUsageInfo struct {
-	Current           float64          `json:"current,omitempty"`
-	Limit             float64          `json:"limit,omitempty"`
-	Percent           float64          `json:"percent,omitempty"` // 0-100
-	NextResetDate     string           `json:"next_reset_date,omitempty"`
-	SubscriptionTitle string           `json:"subscription_title,omitempty"`
-	Trial             *KiroTrialInfo   `json:"trial,omitempty"`
-	Bonuses           []KiroBonusInfo  `json:"bonuses,omitempty"`
+	Current           float64         `json:"current,omitempty"`
+	Limit             float64         `json:"limit,omitempty"`
+	Percent           float64         `json:"percent,omitempty"` // 0-100
+	NextResetDate     string          `json:"next_reset_date,omitempty"`
+	SubscriptionTitle string          `json:"subscription_title,omitempty"`
+	Trial             *KiroTrialInfo  `json:"trial,omitempty"`
+	Bonuses           []KiroBonusInfo `json:"bonuses,omitempty"`
 }
 
 // KiroBonusInfo is one promotional/bonus credits bucket from getUsageLimits.

--- a/backend/internal/service/account_usage_service_tk_kiro_test.go
+++ b/backend/internal/service/account_usage_service_tk_kiro_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	kiroproto "github.com/Wei-Shaw/sub2api/internal/integration/kiro"
 )
@@ -40,6 +41,17 @@ func TestBuildKiroUsageFromInfo_MapsCreditsAndTrial(t *testing.T) {
 		TrialUsagePercent: 0.1,
 		TrialStatus:       "ACTIVE",
 		TrialExpiresAt:    1893456000,
+		Bonuses: []kiroproto.KiroBonusInfo{
+			{
+				Code:      "WELCOME500",
+				Label:     "Welcome Bonus",
+				Current:   120,
+				Limit:     500,
+				Percent:   24,
+				Status:    "ACTIVE",
+				ExpiresAt: 1893456000,
+			},
+		},
 	}
 
 	usage := buildKiroUsageFromInfo(info)
@@ -71,6 +83,12 @@ func TestBuildKiroUsageFromInfo_MapsCreditsAndTrial(t *testing.T) {
 	if ku.Trial.ExpiresAt == nil || ku.Trial.ExpiresAt.Unix() != 1893456000 {
 		t.Fatalf("trial expires_at = %v, want unix 1893456000", ku.Trial.ExpiresAt)
 	}
+	if len(ku.Bonuses) != 1 {
+		t.Fatalf("bonuses = %+v, want one entry", ku.Bonuses)
+	}
+	if ku.Bonuses[0].Code != "WELCOME500" || ku.Bonuses[0].Limit != 500 {
+		t.Fatalf("bonus = %+v", ku.Bonuses[0])
+	}
 }
 
 func TestBuildKiroUsageFromInfo_NoTrialWhenAbsent(t *testing.T) {
@@ -99,6 +117,7 @@ func TestBuildPassiveKiroUsage_RoundTripFromExtra(t *testing.T) {
 			"kiro_trial_percent":      float64(10),
 			"kiro_trial_status":       "ACTIVE",
 			"kiro_trial_expiry":       float64(1893456000),
+			"kiro_bonuses":            `[{"code":"WELCOME500","label":"Welcome Bonus","current":120,"limit":500,"percent":24,"status":"ACTIVE","expires_at":"2026-07-01T00:00:00Z"}]`,
 			"kiro_usage_sampled_at":   "2026-06-27T00:00:00Z",
 		},
 	}
@@ -119,6 +138,9 @@ func TestBuildPassiveKiroUsage_RoundTripFromExtra(t *testing.T) {
 	}
 	if ku.Trial == nil || ku.Trial.Status != "ACTIVE" || ku.Trial.ExpiresAt == nil {
 		t.Fatalf("trial not reconstructed: %+v", ku.Trial)
+	}
+	if len(ku.Bonuses) != 1 || ku.Bonuses[0].Code != "WELCOME500" {
+		t.Fatalf("bonuses not reconstructed: %+v", ku.Bonuses)
 	}
 	if usage.UpdatedAt == nil {
 		t.Fatal("UpdatedAt should come from kiro_usage_sampled_at")
@@ -189,6 +211,7 @@ func TestSyncKiroActiveToPassive_ClearsStaleTrialAndSubscriptionKeys(t *testing.
 		"kiro_trial_status",
 		"kiro_trial_expiry",
 		"kiro_next_reset",
+		"kiro_bonuses",
 	} {
 		if got, ok := repo.updates[key]; !ok || got != nil {
 			t.Fatalf("%s = %v (present=%v), want explicit nil clear", key, got, ok)
@@ -217,6 +240,55 @@ func TestPersistKiroProfileArnIfChanged_WritesResolvedArn(t *testing.T) {
 	}
 	if got := account.GetKiroProfileArn(); got != "arn:aws:codewhisperer:us-east-1:1:profile/fresh" {
 		t.Fatalf("in-memory profile_arn = %q", got)
+	}
+}
+
+func TestBuildKiroUpstreamQuota_IncludesTrialAndBonuses(t *testing.T) {
+	now := time.Now()
+	expires := now.Add(24 * time.Hour)
+	usage := &UsageInfo{
+		Source:    "active",
+		UpdatedAt: &now,
+		KiroUsage: &KiroUsageInfo{
+			Current:           300,
+			Limit:             1000,
+			Percent:           30,
+			SubscriptionTitle: "KIRO POWER",
+			Trial: &KiroTrialInfo{
+				Current: 5,
+				Limit:   50,
+				Percent: 10,
+				Status:  "ACTIVE",
+			},
+			Bonuses: []KiroBonusInfo{
+				{
+					Code:    "WELCOME500",
+					Label:   "Welcome Bonus",
+					Current: 120,
+					Limit:   500,
+					Percent: 24,
+					Status:  "ACTIVE",
+					ExpiresAt: &expires,
+				},
+			},
+		},
+	}
+
+	info := buildKiroUpstreamQuota(usage)
+	if info == nil || info.State != "observed" {
+		t.Fatalf("upstream quota = %+v", info)
+	}
+	if len(info.Credits) != 3 {
+		t.Fatalf("credits len = %d, want 3", len(info.Credits))
+	}
+	if info.Credits[0].Key != "kiro_credits" {
+		t.Fatalf("first credit key = %q", info.Credits[0].Key)
+	}
+	if info.Credits[1].Key != "kiro_trial" {
+		t.Fatalf("second credit key = %q", info.Credits[1].Key)
+	}
+	if info.Credits[2].Key != "kiro_bonus_welcome500" {
+		t.Fatalf("third credit key = %q", info.Credits[2].Key)
 	}
 }
 

--- a/backend/internal/service/account_usage_service_tk_upstream_quota.go
+++ b/backend/internal/service/account_usage_service_tk_upstream_quota.go
@@ -183,6 +183,26 @@ func buildKiroUpstreamQuota(usage *UsageInfo) *UpstreamQuotaInfo {
 			Status:      k.Trial.Status,
 		})
 	}
+	for _, bonus := range k.Bonuses {
+		current := bonus.Current
+		limit := bonus.Limit
+		percent := bonus.Percent
+		remaining := limit - current
+		if remaining < 0 {
+			remaining = 0
+		}
+		label := firstNonEmptyQuotaString(bonus.Label, bonus.Code, "Kiro bonus")
+		info.Credits = append(info.Credits, UpstreamQuotaCredit{
+			Key:         kiroBonusQuotaKey(bonus.Code),
+			Label:       label,
+			Current:     &current,
+			Limit:       &limit,
+			Remaining:   &remaining,
+			Utilization: &percent,
+			ExpiresAt:   bonus.ExpiresAt,
+			Status:      bonus.Status,
+		})
+	}
 	info.State = "observed"
 	return info
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 554,
-  "hash": "89a9d376339bc857bd9e780eb6770b757e664abe104610690e2d3f31439bbbd0",
+  "hash": "8bab603a1413fc9271b8fa0121222365f49119d7d164f700d9ed1a9ad1e0ba1a",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/admin/edgeAccounts.ts
+++ b/frontend/src/api/admin/edgeAccounts.ts
@@ -88,15 +88,29 @@ export interface EdgeUsageProgress {
 }
 
 /** Kiro credits snapshot for one account (mirrors backend edgeKiroUsage). */
+export interface EdgeKiroBonusUsage {
+  code?: string
+  label?: string
+  current?: number
+  limit?: number
+  percent?: number
+  status?: string
+  expires_at?: string | null
+}
+
+/** Kiro credits snapshot for one account (mirrors backend edgeKiroUsage). */
 export interface EdgeKiroUsage {
   current?: number
   limit?: number
   percent?: number
   next_reset_date?: string
   subscription_title?: string
+  trial_current?: number
+  trial_limit?: number
   trial_percent?: number
   trial_status?: string
   trial_expires_at?: string | null
+  bonuses?: EdgeKiroBonusUsage[] | null
 }
 
 /** Credential-free 订阅 projection (mirrors backend edgeSubscription). */

--- a/frontend/src/components/account/usage-cells/KiroUsageCell.vue
+++ b/frontend/src/components/account/usage-cells/KiroUsageCell.vue
@@ -47,6 +47,12 @@
           color="amber"
         />
         <div
+          v-if="kiro.trial.limit"
+          class="pl-[36px] text-[9px] leading-tight text-gray-400 dark:text-gray-500"
+        >
+          {{ formatCredits(kiro.trial.current) }} / {{ formatCredits(kiro.trial.limit) }}
+        </div>
+        <div
           v-if="kiro.trial.expires_at"
           class="pl-[36px] text-[9px] leading-tight text-gray-400 dark:text-gray-500"
         >
@@ -54,15 +60,26 @@
         </div>
       </template>
 
-      <!-- Subscription title -->
-      <div
-        v-if="kiro.subscription_title"
-        class="text-[9px] leading-tight text-gray-400 dark:text-gray-500 truncate max-w-[200px]"
-        :title="kiro.subscription_title"
-      >
-        {{ kiro.subscription_title }}
-      </div>
-      <UpstreamQuotaSummary :quota="usageInfo?.upstream_quota" />
+      <!-- Bonus / promotional credits -->
+      <template v-for="bonus in kiro.bonuses ?? []" :key="bonusKey(bonus)">
+        <UsageProgressBar
+          :label="bonusLabel(bonus)"
+          :utilization="bonus.percent ?? 0"
+          :resets-at="bonus.expires_at || null"
+          color="emerald"
+        />
+        <div
+          v-if="bonus.limit"
+          class="pl-[36px] text-[9px] leading-tight text-gray-400 dark:text-gray-500"
+        >
+          {{ formatCredits(bonus.current) }} / {{ formatCredits(bonus.limit) }}
+        </div>
+      </template>
+
+      <UpstreamQuotaSummary
+        :quota="usageInfo?.upstream_quota"
+        :hidden-credit-key-prefixes="upstreamQuotaHiddenCreditPrefixes"
+      />
 
       <div class="flex items-center gap-1.5 mt-0.5">
         <span
@@ -130,6 +147,7 @@ import { useI18n } from 'vue-i18n'
 import UsageProgressBar from '../UsageProgressBar.vue'
 import UpstreamQuotaSummary from './UpstreamQuotaSummary.vue'
 import { formatDateOnly } from '@/utils/format'
+import type { KiroBonusInfo } from '@/types'
 import {
   accountUsageCellPropDefaults,
   type AccountUsageCellProps
@@ -140,18 +158,27 @@ const props = withDefaults(defineProps<AccountUsageCellProps>(), accountUsageCel
 
 const { t } = useI18n()
 const rootRef = ref<HTMLElement | null>(null)
+const upstreamQuotaHiddenCreditPrefixes = ['kiro_']
 
 const { loading, activeQueryLoading, error, usageInfo, loadActiveUsage } = useAccountUsageFetch(
   props,
   rootRef
 )
 
-// kiro_usage rides on the same AccountUsageInfo the other cells read (active getUsage
-// JSON, or the edge passive DTO lifted in edgeAccounts.tk.ts → toUsageInfo).
 const kiro = computed(() => usageInfo.value?.kiro_usage ?? null)
 
 function formatCredits(n?: number): string {
   if (n == null) return '0'
   return Number.isInteger(n) ? String(n) : n.toFixed(2)
+}
+
+function bonusKey(bonus: KiroBonusInfo): string {
+  return bonus.code || bonus.label || 'bonus'
+}
+
+function bonusLabel(bonus: KiroBonusInfo): string {
+  const label = (bonus.label || bonus.code || '').trim()
+  if (!label) return t('admin.accounts.usageWindow.kiroBonus')
+  return label.length <= 8 ? label : `${label.slice(0, 7)}…`
 }
 </script>

--- a/frontend/src/components/account/usage-cells/UpstreamQuotaSummary.vue
+++ b/frontend/src/components/account/usage-cells/UpstreamQuotaSummary.vue
@@ -53,14 +53,27 @@ const props = defineProps<{
   quota?: UpstreamQuotaInfo | null
   maxItems?: number
   hiddenDimensionKeys?: string[]
+  hiddenCreditKeys?: string[]
+  hiddenCreditKeyPrefixes?: string[]
 }>()
 
 const { t } = useI18n()
 
 const quota = computed(() => props.quota ?? null)
 const hiddenDimensionKeys = computed(() => new Set(props.hiddenDimensionKeys ?? []))
+const hiddenCreditKeys = computed(() => new Set(props.hiddenCreditKeys ?? []))
+const hiddenCreditKeyPrefixes = computed(() => props.hiddenCreditKeyPrefixes ?? [])
 const visibleDimensions = computed(() =>
   (quota.value?.dimensions ?? []).filter(dim => !hiddenDimensionKeys.value.has(dim.key))
+)
+const visibleCredits = computed(() =>
+  (quota.value?.credits ?? []).filter(credit => {
+    if (hiddenCreditKeys.value.has(credit.key)) return false
+    for (const prefix of hiddenCreditKeyPrefixes.value) {
+      if (prefix && credit.key.startsWith(prefix)) return false
+    }
+    return true
+  })
 )
 const visible = computed(() => {
   if (!quota.value) return false
@@ -72,7 +85,7 @@ const visible = computed(() => {
     !!quota.value.subscription_tier_raw ||
     !!quota.value.retry_after_seconds ||
     visibleDimensions.value.length > 0 ||
-    (quota.value.credits?.length ?? 0) > 0
+    visibleCredits.value.length > 0
   )
 })
 
@@ -118,7 +131,7 @@ const retryAfterLabel = computed(() => {
 const quotaLines = computed(() => {
   const max = props.maxItems ?? 3
   const lines = [
-    ...(quota.value?.credits ?? []).map(formatCreditLine).filter(Boolean),
+    ...visibleCredits.value.map(formatCreditLine).filter(Boolean),
     ...visibleDimensions.value.map(formatDimensionLine).filter(Boolean)
   ] as Array<{ key: string; text: string; title: string }>
   return lines.slice(0, max)

--- a/frontend/src/components/account/usage-cells/__tests__/UpstreamQuotaSummary.spec.ts
+++ b/frontend/src/components/account/usage-cells/__tests__/UpstreamQuotaSummary.spec.ts
@@ -1,0 +1,58 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import UpstreamQuotaSummary from '../UpstreamQuotaSummary.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackWarn: false,
+  missingWarn: false,
+  messages: { en: {} }
+})
+
+describe('UpstreamQuotaSummary hidden credits', () => {
+  it('filters duplicate kiro credit lines while keeping the subscription badge', () => {
+    const wrapper = mount(UpstreamQuotaSummary, {
+      props: {
+        quota: {
+          provider: 'kiro',
+          source: 'passive',
+          state: 'observed',
+          subscription_tier_raw: 'KIRO POWER',
+          credits: [
+            {
+              key: 'kiro_credits',
+              label: 'KIRO POWER',
+              current: 729,
+              limit: 10000,
+              remaining: 9271
+            },
+            {
+              key: 'kiro_trial',
+              label: 'Kiro trial',
+              current: 5,
+              limit: 50,
+              remaining: 45
+            },
+            {
+              key: 'kiro_bonus_welcome500',
+              label: 'Welcome Bonus',
+              current: 120,
+              limit: 500,
+              remaining: 380
+            }
+          ]
+        },
+        hiddenCreditKeyPrefixes: ['kiro_']
+      },
+      global: {
+        plugins: [i18n]
+      }
+    })
+
+    expect(wrapper.text()).toContain('KIRO POWER')
+    expect(wrapper.text()).not.toContain('9.3K/10.0K')
+    expect(wrapper.text()).not.toContain('Welcome Bonus')
+  })
+})

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -4894,7 +4894,8 @@ export default {
         activeQuery: 'Query',
         kiroCredits: 'Credits',
         kiroTrial: 'Trial',
-        kiroTrialExpires: 'Trial ends'
+        kiroTrialExpires: 'Trial ends',
+        kiroBonus: 'Bonus'
       },
       openaiQuotaReset: {
         count: 'Credits',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -4003,7 +4003,8 @@ export default {
         activeQuery: '查询',
         kiroCredits: '额度',
         kiroTrial: '试用',
-        kiroTrialExpires: '试用到期'
+        kiroTrialExpires: '试用到期',
+        kiroBonus: '奖励'
       },
       openaiQuotaReset: {
         count: '次数',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1103,6 +1103,16 @@ export interface AccountUsageInfo {
   kiro_usage?: KiroUsageInfo | null
 }
 
+export interface KiroBonusInfo {
+  code?: string
+  label?: string
+  current?: number
+  limit?: number
+  percent?: number
+  status?: string
+  expires_at?: string | null
+}
+
 // Kiro credits 快照（对齐后端 service.KiroUsageInfo）。percent 为 0-100。
 export interface KiroUsageInfo {
   current?: number
@@ -1117,6 +1127,7 @@ export interface KiroUsageInfo {
     status?: string
     expires_at?: string | null
   } | null
+  bonuses?: KiroBonusInfo[] | null
 }
 
 // OpenAI Codex usage snapshot (from response headers)

--- a/frontend/src/utils/__tests__/edgeAccountsTk.spec.ts
+++ b/frontend/src/utils/__tests__/edgeAccountsTk.spec.ts
@@ -177,9 +177,22 @@ describe('toUsageInfo', () => {
             percent: 30,
             next_reset_date: '2026-07-01',
             subscription_title: 'Kiro Pro',
+            trial_current: 5,
+            trial_limit: 50,
             trial_percent: 10,
             trial_status: 'ACTIVE',
-            trial_expires_at: '2026-07-15T00:00:00Z'
+            trial_expires_at: '2026-07-15T00:00:00Z',
+            bonuses: [
+              {
+                code: 'WELCOME500',
+                label: 'Welcome Bonus',
+                current: 120,
+                limit: 500,
+                percent: 24,
+                status: 'ACTIVE',
+                expires_at: '2026-08-01T00:00:00Z'
+              }
+            ]
           }
         }
       })
@@ -189,7 +202,10 @@ describe('toUsageInfo', () => {
     expect(info?.kiro_usage?.next_reset_date).toBe('2026-07-01')
     expect(info?.kiro_usage?.subscription_title).toBe('Kiro Pro')
     expect(info?.kiro_usage?.trial?.percent).toBe(10)
+    expect(info?.kiro_usage?.trial?.current).toBe(5)
+    expect(info?.kiro_usage?.trial?.limit).toBe(50)
     expect(info?.kiro_usage?.trial?.expires_at).toBe('2026-07-15T00:00:00Z')
+    expect(info?.kiro_usage?.bonuses?.[0]?.code).toBe('WELCOME500')
     expect(info?.upstream_quota?.provider).toBe('kiro')
     expect(info?.upstream_quota?.credits?.[0]?.remaining).toBe(700)
   })

--- a/frontend/src/utils/edgeAccounts.tk.ts
+++ b/frontend/src/utils/edgeAccounts.tk.ts
@@ -444,13 +444,30 @@ export function toUsageInfo(s: EdgeAccountSummary): AccountUsageInfo | null {
           next_reset_date: k.next_reset_date,
           subscription_title: k.subscription_title,
           trial:
-            k.trial_percent != null || k.trial_expires_at || k.trial_status
+            k.trial_percent != null ||
+            k.trial_current != null ||
+            k.trial_limit != null ||
+            k.trial_expires_at ||
+            k.trial_status
               ? {
+                  current: k.trial_current,
+                  limit: k.trial_limit,
                   percent: k.trial_percent,
                   status: k.trial_status,
                   expires_at: k.trial_expires_at ?? null
                 }
-              : null
+              : null,
+          bonuses: k.bonuses?.length
+            ? k.bonuses.map(b => ({
+                code: b.code,
+                label: b.label,
+                current: b.current,
+                limit: b.limit,
+                percent: b.percent,
+                status: b.status,
+                expires_at: b.expires_at ?? null
+              }))
+            : null
         }
       : null
   }

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -174,7 +174,9 @@
       "path": "frontend/src/components/account/usage-cells/UpstreamQuotaSummary.vue",
       "must_contain": [
         "hiddenDimensionKeys?: string[]",
-        "const visibleDimensions = computed",
+        "hiddenCreditKeys?: string[]",
+        "hiddenCreditKeyPrefixes?: string[]",
+        "const visibleCredits = computed",
         "visibleDimensions.value.map(formatDimensionLine)"
       ],
       "rationale": "Shared usage-window quota summary de-duplication owner. Account usage cells render primary 5h/7d bars first, then UpstreamQuotaSummary renders only supplemental upstream quota facts after filtering dimensions already represented by those bars. Anchors prevent an upstream-shaped component rewrite from silently reintroducing duplicate grey quota chips beside the canonical progress bars."
@@ -196,6 +198,15 @@
         "openai_codex_7d"
       ],
       "rationale": "OpenAI Codex OAuth usage windows mirror the Anthropic display contract: the 5h and 7d progress bars are canonical, while UpstreamQuotaSummary is only for supplemental quota facts. Anchors keep upstream merges from restoring duplicate Codex window chips."
+    },
+    {
+      "path": "frontend/src/components/account/usage-cells/KiroUsageCell.vue",
+      "must_contain": [
+        ":hidden-credit-key-prefixes=\"upstreamQuotaHiddenCreditPrefixes\"",
+        "upstreamQuotaHiddenCreditPrefixes = ['kiro_']",
+        "kiro.bonuses"
+      ],
+      "rationale": "Kiro credits/trial/bonus progress bars are the canonical visual owner; UpstreamQuotaSummary must hide all kiro_* credit chips to avoid repeating the same monthly/trial/bonus numbers while still showing the subscription tier badge."
     },
     {
       "path": "frontend/src/views/admin/AccountsView.vue",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -425,6 +425,8 @@
         "persistKiroProfileArnIfChanged",
         "func (s *AccountUsageService) buildPassiveKiroUsage",
         "func buildKiroUsageFromInfo",
+        "buildPassiveKiroBonuses",
+        "kiro_bonuses",
         "func (s *AccountUsageService) syncKiroActiveToPassive"
       ],
       "rationale": "The kiro usage producer. getKiroUsage calls the vendored CodeWhisperer GetUsageLimits (RefreshAccountInfo) on the manual 查询 path and writes the snapshot back to passive Extra via syncKiroActiveToPassive; buildPassiveKiroUsage rebuilds it with no upstream call for the edge accounts overview; buildKiroUsageFromInfo maps kiro.AccountInfo (credits/重置/试用/订阅) onto UsageInfo.KiroUsage. Losing this file regresses kiro accounts to empty usage windows (no credits/额度/重置/试用 ever populated)."
@@ -445,6 +447,7 @@
         "func attachUpstreamQuotaForAccount",
         "func buildKiroUpstreamQuota",
         "Key:         \"kiro_credits\"",
+        "kiroBonusQuotaKey",
         "Key:         \"kiro_trial\""
       ],
       "rationale": "Unified upstream_quota adapter for Kiro credits/subscription/trial. Kiro has no 5h/7d upstream window; its upstream capacity is CodeWhisperer credits + monthly reset + trial expiry. Losing this projection leaves UsageInfo.KiroUsage present but the shared upstream quota UI blank."


### PR DESCRIPTION
## 摘要

- 修复 Kiro 账号「用量窗口」列重复展示同一月度 credits 的问题（进度条 `额度` vs `UpstreamQuotaSummary` 的 `KIRO POWER 9.3K/10.0K` 实为同一池子的已用/剩余两种格式）。
- `KiroUsageCell` 作为 canonical 展示：月度额度、试用额度、Bonus 各一条进度条；`UpstreamQuotaSummary` 仅保留订阅档 badge（如 KIRO POWER），通过 `hiddenCreditKeyPrefixes=['kiro_']` 隐藏重复数字。
- 后端从 AWS `getUsageLimits` 解析 `bonuses[]`，经 passive Extra 持久化并在 Edge DTO / `upstream_quota` 投影；试用额度补齐 current/limit 字段。

## 风险

- 常规风险：仅影响 admin 账号列表/Edge 概览的 Kiro 用量展示，不改变网关调度或计费逻辑。
- 已有 passive 快照不含 bonuses/trial 完整字段的账号，需点一次「查询」主动刷新后才会出现 Bonus/试用行。

## 验证

- `./scripts/preflight.sh` — PASS（含 pre-commit）
- `go test -tags=unit ./internal/service/... -run 'Kiro|BuildKiro'`
- `go test -tags=unit ./internal/integration/kiro/... -run RefreshAccountInfo_MapsBonuses`
- `pnpm --dir frontend test:run src/components/account/usage-cells/__tests__/UpstreamQuotaSummary.spec.ts src/utils/__tests__/edgeAccountsTk.spec.ts`
- `pnpm --dir frontend build`（已同步 `frontend-source.json`）

## 提交

- `79d78fe7a` fix(admin): dedupe Kiro quota UI and surface trial/bonus buckets
- `ca283ffa8` chore: gofmt Kiro quota handler and usage service files

最新提交：ca283ffa8
