### PR TITLE
fix(endpoint): align media parity routing

### DIFF
--- a/backend/internal/service/api_key_service.go
+++ b/backend/internal/service/api_key_service.go
@@ -264,7 +264,7 @@ func (s *APIKeyService) SetUniversalAvailableModelsProvider(p availableModelsPro
 }
 
 // SetUniversalModelSupportProvider 后期绑定全能 Key 解析器的 direct-scheduler 同口径
-// 组模型支持判定源。构造期 GatewayService 尚不存在,故经 wire 就绪钩子注入。
+// 组模型+协议支持判定源。构造期 GatewayService 尚不存在,故经 wire 就绪钩子注入。
 func (s *APIKeyService) SetUniversalModelSupportProvider(p groupModelSupportProvider) {
 	if s == nil || s.universalResolver == nil {
 		return

--- a/backend/internal/service/grok_media.go
+++ b/backend/internal/service/grok_media.go
@@ -10,6 +10,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -254,15 +255,23 @@ func (s *OpenAIGatewayService) BindGrokMediaVideoRequestAccount(ctx context.Cont
 }
 
 func (e GrokMediaEndpoint) upstreamURL(baseURL, requestID string) (string, error) {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return "", fmt.Errorf("grok media base url is required")
+	}
 	switch e {
 	case GrokMediaEndpointImagesGenerations:
-		return xai.BuildImagesGenerationsURL(baseURL)
+		return buildOpenAIV1SegmentURL(baseURL, "images/generations"), nil
 	case GrokMediaEndpointImagesEdits:
-		return xai.BuildImagesEditsURL(baseURL)
+		return buildOpenAIV1SegmentURL(baseURL, "images/edits"), nil
 	case GrokMediaEndpointVideosGenerations:
-		return xai.BuildVideosGenerationsURL(baseURL)
+		return buildOpenAIV1SegmentURL(baseURL, "videos/generations"), nil
 	case GrokMediaEndpointVideoStatus:
-		return xai.BuildVideoURL(baseURL, requestID)
+		requestID = strings.TrimSpace(requestID)
+		if requestID == "" {
+			return "", fmt.Errorf("request id is required")
+		}
+		return buildOpenAIV1SegmentURL(baseURL, "videos/"+url.PathEscape(requestID)), nil
 	default:
 		return "", fmt.Errorf("unsupported grok media endpoint: %s", e)
 	}
@@ -290,7 +299,11 @@ func (s *OpenAIGatewayService) ForwardGrokMedia(
 	if err != nil {
 		return nil, err
 	}
-	targetURL, err := endpoint.upstreamURL(account.GetGrokBaseURL(), requestID)
+	validatedBaseURL, err := s.validateUpstreamBaseURLForAccount(account, account.GetGrokBaseURL())
+	if err != nil {
+		return nil, err
+	}
+	targetURL, err := endpoint.upstreamURL(validatedBaseURL, requestID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -141,7 +141,7 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 		}
 		baseURL = "https://api.openai.com"
 	}
-	validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+	validatedURL, err := s.validateUpstreamBaseURLForAccount(account, baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid base_url: %w", err)
 	}

--- a/backend/internal/service/openai_gateway_count_tokens_tk_grok.go
+++ b/backend/internal/service/openai_gateway_count_tokens_tk_grok.go
@@ -26,7 +26,7 @@ func (s *OpenAIGatewayService) resolveGrokInputTokensUpstream(account *Account) 
 		if strings.TrimSpace(baseURL) == "" {
 			return "", fmt.Errorf("grok relay account %d missing base_url", account.ID)
 		}
-		validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+		validatedURL, err := s.validateUpstreamBaseURLForAccount(account, baseURL)
 		if err != nil {
 			return "", err
 		}

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -176,7 +176,7 @@ func (s *OpenAIGatewayService) resolveGrokResponsesUpstream(account *Account) (s
 		if strings.TrimSpace(baseURL) == "" {
 			return "", fmt.Errorf("grok relay account %d missing base_url", account.ID)
 		}
-		validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+		validatedURL, err := s.validateUpstreamBaseURLForAccount(account, baseURL)
 		if err != nil {
 			return "", err
 		}

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -287,6 +287,45 @@ func TestForwardGrokMediaImagesGenerationNormalizesImagineAlias(t *testing.T) {
 	require.Equal(t, ImageBillingSize1K, result.ImageSize)
 }
 
+func TestForwardGrokMediaAllowsEdgeRelayBaseURLWithAllowlistEnabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	body := []byte(`{"model":"grok-imagine-image","prompt":"draw a cat"}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	account := &Account{
+		ID:          65,
+		Name:        "grok-us4",
+		Platform:    PlatformGrok,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "edge-grok-key",
+			"base_url": "https://api-us4.tokenkey.dev",
+		},
+	}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+			Enabled:       true,
+			UpstreamHosts: []string{"api.x.ai"},
+		}}},
+		httpUpstream: upstream,
+	}
+
+	_, err := svc.ForwardGrokMedia(context.Background(), c, account, GrokMediaEndpointImagesGenerations, "", body, "application/json")
+	require.NoError(t, err)
+	require.Equal(t, "https://api-us4.tokenkey.dev/v1/images/generations", upstream.lastReq.URL.String())
+	require.Equal(t, "Bearer edge-grok-key", upstream.lastReq.Header.Get("Authorization"))
+}
+
 func TestForwardGrokMediaImagesEditMultipartConvertsToJSON(t *testing.T) {
 	t.Setenv(xai.EnvAllowUnsafeURLOverrides, "true")
 	gin.SetMode(gin.TestMode)
@@ -608,7 +647,10 @@ func TestForwardGrokResponsesStreamingUsesXAIResponsesAndSnapshots(t *testing.T)
 func TestResolveGrokResponsesUpstreamAPIKeyRelayUsesEdgeOpenAIResponses(t *testing.T) {
 	t.Parallel()
 
-	svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig()}
+	svc := &OpenAIGatewayService{cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+		Enabled:       true,
+		UpstreamHosts: []string{"api.x.ai"},
+	}}}}
 	account := &Account{
 		ID:       65,
 		Platform: PlatformGrok,

--- a/backend/internal/service/openai_gateway_grok_video_tk.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk.go
@@ -142,7 +142,7 @@ func (s *OpenAIGatewayService) grokNativeVideoSubmit(
 	if cerr != nil {
 		return nil, cerr
 	}
-	base, err := s.validateUpstreamBaseURL(grokBase)
+	base, err := s.validateUpstreamBaseURLForAccount(account, grokBase)
 	if err != nil {
 		return nil, fmt.Errorf("invalid grok base_url: %w", err)
 	}
@@ -205,7 +205,7 @@ func (s *OpenAIGatewayService) grokNativeVideoFetch(
 			account = acc
 			if freshToken, freshBase, rerr := resolveGrokVideoCredential(acc); rerr == nil {
 				token = freshToken // re-resolve: OAuth Bearer may rotate; relay api_key is stable
-				if b, verr := s.validateUpstreamBaseURL(freshBase); verr == nil && b != "" {
+				if b, verr := s.validateUpstreamBaseURLForAccount(acc, freshBase); verr == nil && b != "" {
 					base = strings.TrimRight(b, "/")
 				}
 			}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3918,7 +3918,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 	switch account.Type {
 	case AccountTypeOAuth:
 		if account.IsGrokOAuth() {
-			validatedURL, err := s.validateUpstreamBaseURL(strings.TrimSpace(account.GetGrokBaseURL()))
+			validatedURL, err := s.validateUpstreamBaseURLForAccount(account, strings.TrimSpace(account.GetGrokBaseURL()))
 			if err != nil {
 				return nil, err
 			}
@@ -3932,7 +3932,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 			return nil, fmt.Errorf("grok relay account %d missing base_url", account.ID)
 		}
 		if baseURL != "" {
-			validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+			validatedURL, err := s.validateUpstreamBaseURLForAccount(account, baseURL)
 			if err != nil {
 				return nil, err
 			}
@@ -4872,7 +4872,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	switch account.Type {
 	case AccountTypeOAuth:
 		if account.IsGrokOAuth() {
-			validatedURL, err := s.validateUpstreamBaseURL(strings.TrimSpace(account.GetGrokBaseURL()))
+			validatedURL, err := s.validateUpstreamBaseURLForAccount(account, strings.TrimSpace(account.GetGrokBaseURL()))
 			if err != nil {
 				return nil, err
 			}
@@ -4890,7 +4890,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 			}
 			targetURL = openaiPlatformAPIURL
 		} else {
-			validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+			validatedURL, err := s.validateUpstreamBaseURLForAccount(account, baseURL)
 			if err != nil {
 				return nil, err
 			}
@@ -6498,15 +6498,35 @@ func (s *OpenAIGatewayService) replaceModelInSSEBody(body, fromModel, toModel st
 }
 
 func (s *OpenAIGatewayService) validateUpstreamBaseURL(raw string) (string, error) {
-	if s.cfg != nil && !s.cfg.Security.URLAllowlist.Enabled {
-		normalized, err := urlvalidator.ValidateURLFormat(raw, s.cfg.Security.URLAllowlist.AllowInsecureHTTP)
+	return s.validateUpstreamBaseURLWithExtraHosts(raw, nil)
+}
+
+func (s *OpenAIGatewayService) validateUpstreamBaseURLForAccount(account *Account, raw string) (string, error) {
+	var extraHosts []string
+	if isEdgeMirrorStub(account, edgeIDPattern) {
+		if host := edgeMirrorHostFromBaseURL(raw); host != "" {
+			extraHosts = append(extraHosts, host)
+		}
+	}
+	return s.validateUpstreamBaseURLWithExtraHosts(raw, extraHosts)
+}
+
+func (s *OpenAIGatewayService) validateUpstreamBaseURLWithExtraHosts(raw string, extraHosts []string) (string, error) {
+	if s.cfg == nil || !s.cfg.Security.URLAllowlist.Enabled {
+		allowInsecureHTTP := false
+		if s.cfg != nil {
+			allowInsecureHTTP = s.cfg.Security.URLAllowlist.AllowInsecureHTTP
+		}
+		normalized, err := urlvalidator.ValidateURLFormat(raw, allowInsecureHTTP)
 		if err != nil {
 			return "", fmt.Errorf("invalid base_url: %w", err)
 		}
 		return normalized, nil
 	}
+	allowedHosts := append([]string{}, s.cfg.Security.URLAllowlist.UpstreamHosts...)
+	allowedHosts = append(allowedHosts, extraHosts...)
 	normalized, err := urlvalidator.ValidateHTTPSURL(raw, urlvalidator.ValidationOptions{
-		AllowedHosts:     s.cfg.Security.URLAllowlist.UpstreamHosts,
+		AllowedHosts:     allowedHosts,
 		RequireAllowlist: true,
 		AllowPrivate:     s.cfg.Security.URLAllowlist.AllowPrivateHosts,
 	})
@@ -6514,6 +6534,16 @@ func (s *OpenAIGatewayService) validateUpstreamBaseURL(raw string) (string, erro
 		return "", fmt.Errorf("invalid base_url: %w", err)
 	}
 	return normalized, nil
+}
+
+func edgeMirrorHostFromBaseURL(raw string) string {
+	normalized := normalizeEdgeBaseURL(raw)
+	if !edgeIDPattern.MatchString(normalized) {
+		return ""
+	}
+	trimmed := strings.TrimPrefix(strings.TrimPrefix(normalized, "https://"), "http://")
+	host, _, _ := strings.Cut(trimmed, "/")
+	return host
 }
 
 // buildOpenAIResponsesURL 组装 OpenAI Responses 端点。

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -2251,6 +2251,37 @@ func TestOpenAIValidateUpstreamBaseURLEnabledEnforcesAllowlist(t *testing.T) {
 	}
 }
 
+func TestOpenAIValidateUpstreamBaseURLForAccountAllowsEdgeMirrorOnly(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			URLAllowlist: config.URLAllowlistConfig{
+				Enabled:       true,
+				UpstreamHosts: []string{"api.x.ai"},
+			},
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+	account := &Account{
+		Platform: PlatformGrok,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "edge-key",
+			"base_url": "https://api-us4.tokenkey.dev",
+		},
+	}
+
+	normalized, err := svc.validateUpstreamBaseURLForAccount(account, "https://api-us4.tokenkey.dev")
+	if err != nil {
+		t.Fatalf("expected edge mirror host to pass, got %v", err)
+	}
+	if normalized != "https://api-us4.tokenkey.dev" {
+		t.Fatalf("unexpected normalized url %q", normalized)
+	}
+	if _, err := svc.validateUpstreamBaseURLForAccount(account, "https://evil.example.com"); err == nil {
+		t.Fatalf("edge mirror extra host must not allow arbitrary hosts")
+	}
+}
+
 func TestOpenAIUpdateCodexUsageSnapshotFromHeaders(t *testing.T) {
 	repo := &snapshotUpdateAccountRepo{updateExtraCalls: make(chan map[string]any, 1)}
 	svc := &OpenAIGatewayService{accountRepo: repo}

--- a/backend/internal/service/openai_gateway_v1_forward.go
+++ b/backend/internal/service/openai_gateway_v1_forward.go
@@ -46,7 +46,7 @@ func (s *OpenAIGatewayService) buildOpenAIV1TargetURL(account *Account, segment 
 			}
 			return buildOpenAIV1SegmentURL("", segment), nil
 		}
-		validated, err := s.validateUpstreamBaseURL(raw)
+		validated, err := s.validateUpstreamBaseURLForAccount(account, raw)
 		if err != nil {
 			return "", err
 		}
@@ -56,7 +56,7 @@ func (s *OpenAIGatewayService) buildOpenAIV1TargetURL(account *Account, segment 
 		// NOT the ChatGPT platform base. The Bearer is the grok OAuth token resolved
 		// by GetAccessToken's grok branch.
 		if account.IsGrokOAuth() {
-			validated, err := s.validateUpstreamBaseURL(strings.TrimSpace(account.GetGrokBaseURL()))
+			validated, err := s.validateUpstreamBaseURLForAccount(account, strings.TrimSpace(account.GetGrokBaseURL()))
 			if err != nil {
 				return "", err
 			}

--- a/backend/internal/service/universal_routing_tk_resolver.go
+++ b/backend/internal/service/universal_routing_tk_resolver.go
@@ -80,7 +80,7 @@ func (r *UniversalRoutingResolver) SetAvailableModelsProvider(p availableModelsP
 	r.mu.Unlock()
 }
 
-// SetModelSupportProvider 后期注入 direct-scheduler 同口径的组模型支持判定源。
+// SetModelSupportProvider 后期注入 direct-scheduler 同口径的组模型+协议支持判定源。
 // nil-safe; provider 取数未知时 Resolve 会退回 availableModelsProvider。
 func (r *UniversalRoutingResolver) SetModelSupportProvider(p groupModelSupportProvider) {
 	if r == nil {
@@ -157,7 +157,7 @@ func (r *UniversalRoutingResolver) Resolve(ctx context.Context, apiKey *APIKey, 
 			for i := range eligible {
 				if supportProvider != nil {
 					gid := eligible[i].ID
-					serves, known := supportProvider(ctx, &gid, eligible[i].Platform, model)
+					serves, known := supportProvider(ctx, &gid, eligible[i].Platform, model, shape)
 					if !known {
 						knownAll = false
 						continue

--- a/backend/internal/service/universal_routing_tk_serving.go
+++ b/backend/internal/service/universal_routing_tk_serving.go
@@ -9,7 +9,7 @@ import "context"
 // google-vertex/grok/…,多组是按 vendor 专属倍率计费的有意设计)里盲选必投错组 →
 // 下游 `no available accounts`。本文件给解析器加一道「组是否真支持该模型」的判别。
 //
-// 当前优先使用 UniversalGroupSupportsModel:复用 direct scheduler 的账号级模型支持语义,
+// 当前优先使用 UniversalGroupSupportsRequest:复用 direct scheduler 的账号级模型+协议支持语义,
 // 让 universal key 与同组 direct key 对同一模型的 routing entitlement 保持一致。
 // GetAvailableModels 仍保留为 provider unknown 时的 degraded fallback;fallback 按组服务集
 // 来源非对称分流(见 docs/approved/universal-key-routing.md):
@@ -30,18 +30,28 @@ import "context"
 // 现状行为 —— 安全兜底,绝不黑洞 universal 流量。
 type availableModelsProvider func(ctx context.Context, groupID *int64, platform string) []string
 
-// groupModelSupportProvider 以 direct scheduler 的账号级语义判定某组是否能服务模型。
+// groupModelSupportProvider 以 direct scheduler 的账号级语义判定某组是否能服务模型+协议形态。
 // known=false 表示 provider 取数失败/未能判断,解析器会退回 availableModelsProvider 的
 // 旧口径,避免因为观测源短暂不可用而把 universal 流量误拒。
-type groupModelSupportProvider func(ctx context.Context, groupID *int64, platform, model string) (serves bool, known bool)
+type groupModelSupportProvider func(ctx context.Context, groupID *int64, platform, model string, shape UniversalShape) (serves bool, known bool)
 
-// UniversalGroupSupportsModel reports whether the direct gateway scheduler could
+// UniversalGroupSupportsModel preserves the old model-only contract for tests and
+// degraded callers. New universal routing uses UniversalGroupSupportsRequest so
+// endpoint-specific capabilities (video, embeddings, image-capability gates) stay
+// aligned with direct keys.
+func (s *GatewayService) UniversalGroupSupportsModel(ctx context.Context, groupID *int64, platform, model string) (bool, bool) {
+	return s.UniversalGroupSupportsRequest(ctx, groupID, platform, model, ShapeSkip)
+}
+
+// UniversalGroupSupportsRequest reports whether the direct gateway scheduler could
 // find at least one account in group/platform that supports model. This is the
 // universal-key parity hook: it preserves per-account semantics that a group-level
 // served-model union loses, especially unrestricted passthrough accounts, wildcard
 // mappings, Anthropic short-id normalization, Antigravity default mappings, and
-// OpenAI alias spelling.
-func (s *GatewayService) UniversalGroupSupportsModel(ctx context.Context, groupID *int64, platform, model string) (bool, bool) {
+// OpenAI alias spelling. It also includes the endpoint shape's account capability
+// gates so a group that can "name-match" a model but cannot serve that protocol
+// does not win universal routing and fail later as an empty direct pool.
+func (s *GatewayService) UniversalGroupSupportsRequest(ctx context.Context, groupID *int64, platform, model string, shape UniversalShape) (bool, bool) {
 	if s == nil || s.accountRepo == nil || platform == "" {
 		return false, false
 	}
@@ -53,6 +63,9 @@ func (s *GatewayService) UniversalGroupSupportsModel(ctx context.Context, groupI
 		acc := &accounts[i]
 		if IsOpenAICompatPlatform(platform) {
 			if !acc.IsOpenAICompatPoolMember(platform) {
+				continue
+			}
+			if !universalOpenAICompatAccountSupportsShape(acc, shape) {
 				continue
 			}
 			if s.isModelSupportedByAccount(acc, model) || (acc.Platform == PlatformGrok && grokGroupServesNativeCatalogModel(model)) {
@@ -67,6 +80,19 @@ func (s *GatewayService) UniversalGroupSupportsModel(ctx context.Context, groupI
 		}
 	}
 	return false, true
+}
+
+func universalOpenAICompatAccountSupportsShape(account *Account, shape UniversalShape) bool {
+	switch shape {
+	case ShapeOpenAIEmbeddings:
+		return accountSupportsOpenAIRequestCapabilities(account, OpenAIEndpointCapabilityEmbeddings, "", false)
+	case ShapeOpenAIImages, ShapeOpenAIImagesEdit:
+		return accountSupportsOpenAIRequestCapabilities(account, "", OpenAIImagesCapabilityBasic, false)
+	case ShapeOpenAIVideo:
+		return accountSupportsOpenAIRequestCapabilities(account, "", "", true)
+	default:
+		return true
+	}
 }
 
 // groupServesModel 是 GetAvailableModels fallback 的组服务集判定(上述三分流)。

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -19,7 +19,7 @@ func servedProvider(byGroup map[int64][]string) availableModelsProvider {
 }
 
 func supportProvider(byGroup map[int64]bool) groupModelSupportProvider {
-	return func(_ context.Context, gid *int64, _ string, _ string) (bool, bool) {
+	return func(_ context.Context, gid *int64, _ string, _ string, _ UniversalShape) (bool, bool) {
 		if gid == nil {
 			return false, false
 		}
@@ -88,7 +88,7 @@ func TestResolve_ModelSupportProviderUnknownFallsBackToServedSet(t *testing.T) {
 		2:  {"gpt-5.4-mini"},
 		18: {"qwen-max"},
 	}))
-	r.SetModelSupportProvider(func(context.Context, *int64, string, string) (bool, bool) {
+	r.SetModelSupportProvider(func(context.Context, *int64, string, string, UniversalShape) (bool, bool) {
 		return false, false
 	})
 	g, err := r.Resolve(ctx, universalKey(16), ShapeOpenAIChat, "gpt5.4-mini", "")
@@ -183,6 +183,45 @@ func TestUniversalGroupSupportsModel_NewapiRequiresCompatPoolMember(t *testing.T
 			t.Fatalf("newapi channel_type>0 should serve mapped model, got serves=%v known=%v", serves, known)
 		}
 	})
+}
+
+func TestResolve_VeoVideoRequiresVideoCapableVertexGroup(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(2, PlatformOpenAI, 0, false),
+		grp(16, PlatformNewAPI, 60, false),
+	}
+	veoMapping := map[string]any{"veo-3.1-generate-001": "veo-3.1-generate-001"}
+	svc := &GatewayService{
+		accountRepo: groupAwareStubOpenAIAccountRepo{stubOpenAIAccountRepo{accounts: []Account{
+			{
+				ID:          63,
+				GroupIDs:    []int64{2},
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Schedulable: true,
+				ChannelType: 0,
+			},
+			{
+				ID:          47,
+				GroupIDs:    []int64{16},
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeServiceAccount,
+				Status:      StatusActive,
+				Schedulable: true,
+				ChannelType: 41,
+				Credentials: map[string]any{"model_mapping": veoMapping},
+			},
+		}}},
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetModelSupportProvider(svc.UniversalGroupSupportsRequest)
+
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIVideo, "veo-3.1-generate-001", "")
+	if err != nil || g == nil || g.ID != 16 {
+		t.Fatalf("veo video universal must skip openai channel_type=0 and pick vertex gid=16, got=%v err=%v", g, err)
+	}
 }
 
 func TestModelInServedSet_UsesDirectMappingAliases(t *testing.T) {
@@ -282,7 +321,7 @@ func TestResolve_GeminiMessagesAnthropicShapeAvoidsOpenAIPassthrough(t *testing.
 			},
 		}},
 	}
-	r.SetModelSupportProvider(svc.UniversalGroupSupportsModel)
+	r.SetModelSupportProvider(svc.UniversalGroupSupportsRequest)
 
 	g, err := r.Resolve(ctx, universalKey(1), ShapeAnthropicMessages, "gemini-2.5-flash", "")
 	if err != nil || g == nil || g.ID != 9 {

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -845,9 +845,9 @@ func ProvideTKGatewayPricingAvailability(
 
 // TKUniversalModelsProviderReady is a wire sentinel: holding it proves
 // APIKeyService's universal-key resolver has been wired to GatewayService's
-// direct-scheduler model support predicate, with GetAvailableModels retained as
-// a degraded fallback. provideCleanup (cmd/server/wire.go) consumes this type as
-// an unused parameter to force wire to evaluate the side-effect.
+// direct-scheduler model+protocol support predicate, with GetAvailableModels
+// retained as a degraded fallback. provideCleanup (cmd/server/wire.go) consumes
+// this type as an unused parameter to force wire to evaluate the side-effect.
 type TKUniversalModelsProviderReady struct{}
 
 // ProvideTKUniversalModelsProvider wires the universal-key resolver's model
@@ -862,7 +862,7 @@ func ProvideTKUniversalModelsProvider(
 	gw *GatewayService,
 ) TKUniversalModelsProviderReady {
 	if api != nil && gw != nil {
-		api.SetUniversalModelSupportProvider(gw.UniversalGroupSupportsModel)
+		api.SetUniversalModelSupportProvider(gw.UniversalGroupSupportsRequest)
 		api.SetUniversalAvailableModelsProvider(gw.GetAvailableModels)
 	}
 	return TKUniversalModelsProviderReady{}

--- a/docs/ops/endpoint-compat-baseline.md
+++ b/docs/ops/endpoint-compat-baseline.md
@@ -31,7 +31,8 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 | Universal matrix command | `bash ops/observability/endpoint-compat-audit.sh --universal-matrix --with-extras --skip-paid` |
 | SSOT model matrix command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --list --include-paid --show-excluded` |
 | SSOT display gate command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --show-excluded` |
-| In-PR display remediation | Gemini video `veo-3.1-generate-001` and Grok paid media are removed from the shared catalog/Menu allowlists until a future explicit paid gate returns `keep_displayed`; Seedream/Seedance rows that passed the paid gate stay visible. |
+| Focused parity fix anchors | `backend/internal/service/universal_routing_tk_serving.go`; `backend/internal/service/openai_gateway_service.go`; `backend/internal/service/grok_media.go`; `backend/internal/service/openai_gateway_grok.go` |
+| Display remediation state | Gemini video `veo-3.1-generate-001` and Grok paid media were removed from the shared catalog/Menu allowlists by the previous remediation. Restore only after this parity fix is released and a paid SSOT gate returns `keep_displayed`. |
 | Cleanup command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/cleanup-probe-resources.sh` |
 
 ### Evidence Pointers
@@ -54,6 +55,12 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 | `/tmp/tokenkey-ssot-gate-paid-image-full-1.8.76-20260703.log` | Full SSOT paid image gate: `DISPLAY_KEEP=6 DISPLAY_BLOCK=0 REPROBE_REQUIRED=2 FAIL=0`; Gemini image and newapi Seedream rows are display-safe; Grok image rows need retry/non-transient proof |
 | `/tmp/tokenkey-ssot-gate-paid-video-full-1.8.76-20260703.log` | Full SSOT paid video gate: `DISPLAY_KEEP=5 DISPLAY_BLOCK=1 REPROBE_REQUIRED=1 FAIL=0`; newapi Seedance rows are display-safe; Gemini video is `hide_or_provision`; Grok video needs retry/non-transient proof |
 | `/tmp/tokenkey-ssot-gate-paid-grok-media-retry-1.8.76-20260703.log` | Focused Grok paid media retry: all three Grok media rows still returned `502` and remain `reprobe_required`, not display-safe |
+| `/tmp/tokenkey-focused-media-deepctx-20260703.log` | Focused read-only media context: Grok image errors in 24h concentrate on prod account `65`; 7d video usage includes successful billed `veo-3.1-generate-001` rows |
+| `/tmp/tokenkey-focused-media-billing-20260703.log` | Focused 24h media billing/error context: billed `veo-3.1-generate-001` video rows exist; Grok media errors are 502 on image and both video endpoints |
+| `/tmp/tokenkey-grok-relay-log-grep-20260703.log` | Prod container log grep: both universal key and direct probe key selected account `65` and failed before edge with `invalid base url: host is not allowed: api-us4.tokenkey.dev` |
+| `/tmp/tokenkey-grok-image-error-triage-20260703.log` | Grok image `/v1/images/generations` focused error triage: 13/13 recent rows are 502 with no upstream event, consistent with local relay failure |
+| `/tmp/tokenkey-grok-video-error-triage-20260703.log` | Grok native `/v1/video/generations` focused error triage: 9/9 recent rows are 502 with no upstream event, consistent with local relay failure |
+| `/tmp/tokenkey-grok-videos-error-triage-20260703.log` | Grok OpenAI-compatible `/v1/videos/generations` focused error triage: 3/3 recent rows are 502 with no upstream event, consistent with local relay failure |
 | `/tmp/tokenkey-ssot-gate-embeddings-protocol-1.8.76-20260703.log` | SSOT embedding gate: Vertex AI embedding rows are `hide_or_map_vendor`; no live universal embedding row is display-safe yet |
 | `/tmp/tokenkey-ssot-gate-embedding-1.8.76-20260703.log` | Focused `text-embedding-3-small` gate: `NO_ROWS=1`; that hardcoded probe model is not currently in the displayed+priced SSOT matrix |
 | `/tmp/tokenkey-probe-cleanup-dryrun-1.8.76-20260703-134455.log` | active probe groups/keys remain `0/0`; no apply needed |
@@ -71,11 +78,11 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 | openai | embeddings `text-embedding-3-small` | unknown | unknown | unknown: repeated hardcoded-matrix SKIP `429`; not present in the current displayed+priced SSOT matrix | universal logs; embedding retry log; focused embedding gate | Do not treat this as display-safe. If OpenAI embeddings should be displayed, add the SSOT pricing/catalog row and rerun the embedding gate with a non-throttled pool. |
 | gemini | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | route_open_unservable: empty direct probe pool returned `429` | supported | direct route-gate log; universal retry log | First universal run hit transient `429`; retry passed. |
 | gemini | image | unknown | unknown | supported for all current SSOT paid image rows: `imagen-4.0-fast-generate-001`, `imagen-4.0-generate-001`, `imagen-4.0-ultra-generate-001` | full paid image gate | Direct live parity still needs a schedulable direct pool. |
-| gemini | video `veo-3.1-generate-001` | unknown | unknown | route_open_unservable: model/account not provisioned on current pool; display gate says `hide_or_provision` | paid-media post-1.8.76 log; focused paid-media gate | Hide/disable this paid surface until Gemini video account/model provisioning changes and gate returns `keep_displayed`. |
+| newapi / Google-Vertex group 16 | video `veo-3.1-generate-001` | open | supported: focused direct probe returned queued video and 24h billing context contains successful billed Veo rows | pre-fix `route_open_unservable`: universal chose OpenAI group 2 because model-only support ignored video capability; fix makes universal support provider protocol-aware | focused media logs; parity fix anchors | After release, rerun paid direct-vs-universal for the same model/protocol/group. Expected result: universal selects the same video-capable Vertex group as direct; display gate may restore only after `keep_displayed`. |
 | antigravity | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for text | direct route-gate log; universal retry log | Keep direct-vs-universal parity watch when Gemini `/v1beta` routing changes. |
 | newapi | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for text | direct route-gate log; universal retry log | Reprobe after newapi channel mapping or compatibility-pool changes. |
 | newapi | image/video | unknown | unknown | supported for all current SSOT paid image/video rows: Seedream 4.0/4.5/5.0 and Seedance 1.0/1.5/2.0 variants | full paid image/video gates | Keep `--include-paid` probes explicit; default non-paid gates do not prove media servability. |
-| grok | image/video | unknown | unknown | unknown: current paid media rows return repeated `502` and remain `reprobe_required` | full paid image/video gates; focused Grok retry | This PR hides them from the shared catalog/Menu allowlist until a non-transient paid gate returns `keep_displayed`. |
+| grok group 25 / account 65 | image/video | open | pre-fix `closed_by_gateway`: direct probe key and universal key both selected account 65 and failed locally before edge with the same edge-host allowlist error | pre-fix `closed_by_gateway`: same local relay error as direct; not a direct-vs-universal routing mismatch | full paid image/video gates; focused Grok retry; Grok relay log grep | Fix allows controlled TokenKey edge mirror hosts for mirror-stub accounts and routes Grok media URLs through the validated OpenAI-compatible builder. After release, rerun paid parity; image may still require edge/account entitlement if upstream returns 403 after the relay is reached. |
 | kiro | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | route_open_unservable: empty direct probe pool returned `429` | supported for text | direct route-gate log; universal retry log | If direct Kiro serving is claimed, run account-model probe against the target account/model. |
 | grok | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for text | direct route-gate log; universal retry log | No full-matrix rerun needed unless Grok model default or relay changes. |
 | all platforms with `/v1/responses` GET prelude | WebSocket prelude | open: `426` upgrade required | unknown | unknown | direct route-gate log | Treat `426` as expected route-open prelude, not a failure. |
@@ -102,38 +109,44 @@ This keeps `/pricing` as the single derived matrix source while turning every
 
 ## Next Probe Focus
 
-1. Treat the non-paid display gate as the current product action list. The
+1. After this parity fix is released and deployed, rerun paid direct-vs-universal
+   checks for `veo-3.1-generate-001`, `grok-imagine-image`,
+   `grok-imagine-image-quality`, and `grok-imagine-video`. For Veo, universal
+   should pick the same video-capable Google-Vertex group as the direct key. For
+   Grok, prod direct and universal should both reach the edge mirror instead of
+   failing local base-url validation; any returned upstream 403/429/5xx is then
+   an entitlement/capacity/provider result, not a universal routing defect.
+2. Treat the non-paid display gate as the current product action list. The
    dominant `hide_or_provision` blockers are selected newapi `/v1/responses`,
    Antigravity/Gemini OpenAI-compatible text protocols, Grok non-default
    `/v1/messages`, future OpenAI catalog rows, and a small Anthropic catalog
    prep set. Either hide/disable those model+protocol surfaces or provision
    real support; do not leave them as visible "maybe works" entries.
-2. Embeddings are not display-safe. `text-embedding-3-small` is not currently
+3. Embeddings are not display-safe. `text-embedding-3-small` is not currently
    in the displayed+priced SSOT matrix, and the displayed Vertex AI embedding
    rows are `hide_or_map_vendor`. Decide whether to map/provision universal
    embeddings or remove/hide those rows from the relevant surface.
-3. Paid media gate outcome: Gemini image and all current newapi Seedream /
-   Seedance rows can stay displayed. This PR removes Gemini video from the
-   Gemini/Vertex preset because it is `hide_or_provision`, and removes Grok
-   paid media from the Grok shared allowlist because the focused retry remained
-   `reprobe_required`. `gpt-image-1` is still only a hardcoded probe row for
-   the current key, not a displayed+priced SSOT row.
-4. Reprobe the three `reprobe_required` rows from the non-paid gate with a
+4. Paid media gate outcome before this fix: Gemini image and all current newapi
+   Seedream / Seedance rows can stay displayed; Veo and Grok media must remain
+   hidden/disabled until the post-fix paid gate returns `keep_displayed`.
+   `gpt-image-1` is still only a hardcoded probe row for the current key, not a
+   displayed+priced SSOT row.
+5. Reprobe the three `reprobe_required` rows from the non-paid gate with a
    longer timeout or a cleaner pool before deciding whether they are displayable
    or should join the hide/provision list.
-5. The SSOT matrix currently excludes public-pricing rows whose vendors do not
+6. The SSOT matrix currently excludes public-pricing rows whose vendors do not
    map to a universal platform/endpoint candidate. Decide whether those rows
    should become real universal surfaces or be removed/hidden from the relevant
    catalog surface.
-6. Run the SSOT display gate before release close-out:
+7. Run the SSOT display gate before release close-out:
    `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --show-excluded`
    for non-paid rows, and add `--include-paid` when paid media is intentionally
    in scope. A clean gate means every displayed+priced row in scope is live
    supported; any non-`keep_displayed` row becomes either a hide/disable task or
    a provisioning/mapping task.
-7. Reprobe Anthropic/Gemini/Kiro direct live rows only when a real schedulable
+8. Reprobe Anthropic/Gemini/Kiro direct live rows only when a real schedulable
    direct probe pool exists; current `429` rows prove route openness, not
    servability.
-8. After every direct/account probe, run probe-resource cleanup dry-run. Apply
+9. After every direct/account probe, run probe-resource cleanup dry-run. Apply
    cleanup if active `__tk_probe_*` groups or keys are nonzero. The 1.8.76
    dry-run showed active probe groups/keys remain `0/0`.

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3495,7 +3495,7 @@
         "universalShapeRequiresImageGenerationEnabled",
         "filterGroupsAllowImageGeneration",
         "supportProvider groupModelSupportProvider",
-        "supportProvider(ctx, &gid, eligible[i].Platform, model)",
+        "supportProvider(ctx, &gid, eligible[i].Platform, model, shape)",
         "else if hint := universalModelPlatformHint(model); hint != \"\"",
         "收敛为空且模型有平台 hint → ErrUniversalNoEntitledGroup(403)"
       ],
@@ -3506,23 +3506,26 @@
       "must_contain": [
         "type groupModelSupportProvider func(",
         "func (s *GatewayService) UniversalGroupSupportsModel(",
+        "func (s *GatewayService) UniversalGroupSupportsRequest(",
         "s.listSchedulableAccounts(ctx, groupID, platform, false)",
         "acc.IsOpenAICompatPoolMember(platform)",
+        "universalOpenAICompatAccountSupportsShape",
+        "accountSupportsOpenAIRequestCapabilities(account, \"\", \"\", true)",
         "s.isModelSupportedByAccount(acc, model)",
         "s.isModelSupportedByAccountWithContext(ctx, acc, model)",
         "modelInServedSet(model string, served []string, platform string)",
         "normalizeRequestedModelForLookup(platform, model)"
       ],
-      "rationale": "Universal-key model routing must use the same account-level model-support predicate as the direct schedulers before consulting the lossy group-level served-model union. This pins the provider type, the GatewayService implementation, the OpenAI-compatible pool/member + IsModelSupported path, the native gateway path, and the alias-aware served-set fallback. Dropping any of these can make a universal key choose a different backing group than a direct key for the same model while existing /v1/models output still looks plausible."
+      "rationale": "Universal-key routing must use the same account-level model+protocol predicate as the direct schedulers before consulting the lossy group-level served-model union. This pins the provider type, the GatewayService implementation, the OpenAI-compatible pool/member + IsModelSupported path, endpoint-shape capability gates (including video-capable accounts), the native gateway path, and the alias-aware served-set fallback. Dropping any of these can make a universal key choose a different backing group than a direct key for the same model/protocol while existing /v1/models output still looks plausible."
     },
     {
       "path": "backend/internal/service/wire.go",
       "must_contain": [
         "ProvideTKUniversalModelsProvider(",
-        "api.SetUniversalModelSupportProvider(gw.UniversalGroupSupportsModel)",
+        "api.SetUniversalModelSupportProvider(gw.UniversalGroupSupportsRequest)",
         "api.SetUniversalAvailableModelsProvider(gw.GetAvailableModels)"
       ],
-      "rationale": "ProvideTKUniversalModelsProvider is the runtime injection point for universal-key model routing truth. The direct-scheduler support provider must be wired alongside GetAvailableModels; tests can call SetUniversalModelSupportProvider directly and still pass if an upstream merge drops this wire call, leaving production on the old lossy fallback. Pin both setter calls so the app cannot silently boot without direct-key parity."
+      "rationale": "ProvideTKUniversalModelsProvider is the runtime injection point for universal-key model+protocol routing truth. The direct-scheduler support provider must be wired alongside GetAvailableModels; tests can call SetUniversalModelSupportProvider directly and still pass if an upstream merge drops this wire call, leaving production on the old lossy fallback. Pin both setter calls so the app cannot silently boot without direct-key parity."
     },
     {
       "path": "backend/internal/service/universal_routing_tk_serving_test.go",

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -74,6 +74,16 @@
       "rationale": "The grok OAuth arm of GetAccessToken (returns the xAI OAuth Bearer instead of routing through the IsOpenAI-gated ChatGPT/Codex token provider) AND the wiring of the Heavy-403 honesty guard into shouldFailoverOpenAIUpstreamResponse (no failover) and the error mapper (clean client 403, not a masked 502). Losing the IsGrokOAuth() branch makes grok OAuth unable to fetch a token; using broad IsGrok() here would steal first-class grok API-key relay stubs from the api_key branch. Losing the tkIsGrokEntitlement403 wiring re-arms the pool-wide 403 failover amplifier and re-masks the entitlement error as 502."
     },
     {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) validateUpstreamBaseURLForAccount(",
+        "isEdgeMirrorStub(account, edgeIDPattern)",
+        "edgeMirrorHostFromBaseURL(raw)",
+        "validateUpstreamBaseURLWithExtraHosts(raw, extraHosts)"
+      ],
+      "rationale": "Prod→edge grok API-key relay stubs use TokenKey edge hosts such as api-us4.tokenkey.dev as their base_url. The global upstream allowlist should still reject arbitrary hosts, but a mirror-stub account must be allowed to call its own edge host; otherwise prod direct and universal Grok media/responses fail locally with `invalid base url: host is not allowed` before reaching the edge. This pins the account-aware validation seam and the narrow edge-mirror host derivation."
+    },
+    {
       "path": "backend/internal/service/ratelimit_service_tk_grok_entitlement_403.go",
       "must_contain": [
         "func tkIsGrokEntitlement403",
@@ -91,14 +101,17 @@
     {
       "path": "backend/internal/service/openai_gateway_chat_completions_raw.go",
       "must_contain": [
-        "account.IsGrokOAuth()"
+        "account.IsGrokOAuth()",
+        "validateUpstreamBaseURLForAccount(account, baseURL)"
       ],
       "rationale": "The raw CC forwarder resolves the grok OAuth Bearer + api.x.ai base_url here; first-class grok API-key relay stubs intentionally use GetOpenAIApiKey/GetOpenAIBaseURL and the edge base_url. Losing this arm makes grok OAuth forward with an empty credential / wrong base URL; broadening it back to IsGrok() breaks grok API-key relay stubs."
     },
     {
       "path": "backend/internal/service/openai_gateway_v1_forward.go",
       "must_contain": [
-        "account.IsGrokOAuth()"
+        "account.IsGrokOAuth()",
+        "validateUpstreamBaseURLForAccount(account, raw)",
+        "validateUpstreamBaseURLForAccount(account, strings.TrimSpace(account.GetGrokBaseURL()))"
       ],
       "rationale": "The image/embeddings seam: buildOpenAIV1TargetURL hardcodes api.openai.com for the OAuth case; the grok OAuth arm redirects it to api.x.ai/v1. First-class grok API-key relay stubs use the API-key branch plus their edge base_url. Losing this arm points grok OAuth image requests at OpenAI; broadening it back to IsGrok() breaks grok API-key relay stubs."
     },
@@ -310,6 +323,8 @@
         "func (s *OpenAIGatewayService) grokNativeVideoFetch",
         "resolveGrokVideoCredential",
         "UsesGrokNativeVideoArm",
+        "validateUpstreamBaseURLForAccount(account, grokBase)",
+        "validateUpstreamBaseURLForAccount(acc, freshBase)",
         "/videos/generations"
       ],
       "rationale": "The grok-native video arm: submit (POST api.x.ai/v1/videos/generations -> request_id) + poll (GET api.x.ai/v1/videos/{id}) over the grok OAuth Bearer OR prod→edge relay api_key (resolveGrokVideoCredential mirrors chat raw), returning the same bridge.TaskSubmitOutcome/VideoFetchOutcome shapes the handler consumes so the vt_ public id, VideoTaskCache record, balance hold, per-second billing, terminal refund, direct video delivery and ownership-404 are all reused. Video has no new-api TaskAdaptor for xAI (GetTaskAdaptor has no xai entry), so this native arm is grok video's ONLY code path — losing it makes grok video fail outright."
@@ -390,18 +405,39 @@
       "rationale": "The xAI-shaped video submit alias POST /videos/generations (plural videos + /generations), registered in BOTH the /v1 group and the no-prefix scope. This is the path grok's native arm POSTs to ({base}/videos/generations); the gateway's canonical video routes are /video/generations (singular) + /videos (no suffix), which do NOT match it. Without this alias the prod->edge grok video relay 404s at submit: a prod grok mirror account forwards to api-<edge>.tokenkey.dev/v1/videos/generations and the edge gateway has no such route (grok chat/image relay works only because /chat/completions and /images/generations already coincide with gateway routes). Losing this alias silently re-breaks the relay while direct-to-xAI still works, so no other test would catch it."
     },
     {
+      "path": "backend/internal/service/grok_media.go",
+      "must_contain": [
+        "func (e GrokMediaEndpoint) upstreamURL(",
+        "buildOpenAIV1SegmentURL(baseURL, \"images/generations\")",
+        "buildOpenAIV1SegmentURL(baseURL, \"videos/generations\")",
+        "s.validateUpstreamBaseURLForAccount(account, account.GetGrokBaseURL())"
+      ],
+      "rationale": "Grok image/video OpenAI-compatible media forwarding must build /v1/images and /v1/videos URLs from the already validated account base_url. xAI's URL builder rejects TokenKey edge hosts, which made prod→edge Grok relay stubs fail locally before reaching edge. Losing the account-aware validation or reverting to xAI-only URL construction silently reopens the direct/universal Grok media 502."
+    },
+    {
       "path": "backend/internal/service/openai_gateway_grok.go",
       "must_contain": [
         "func (s *OpenAIGatewayService) forwardGrokResponses",
         "resolveGrokResponsesUpstream",
         "grokResponsesAuthToken",
+        "validateUpstreamBaseURLForAccount(account, baseURL)",
         "buildOpenAIResponsesURL"
       ],
       "rationale": "Grok /v1/responses forwarding must support both native OAuth (xai.BuildResponsesURL + GetAccessToken) and prod→edge apikey relay stubs (GetOpenAIApiKey + buildOpenAIResponsesURL on edge base_url). Reverting to OAuth-only silently re-breaks prod grok-us4 universal-key grok-4.3 with 502 while edge OAuth still works."
     },
     {
+      "path": "backend/internal/service/openai_gateway_count_tokens_tk_grok.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) resolveGrokInputTokensUpstream(",
+        "validateUpstreamBaseURLForAccount(account, baseURL)",
+        "buildOpenAIResponsesInputTokensURL(validatedURL)"
+      ],
+      "rationale": "Grok count_tokens uses the OpenAI Responses input_tokens endpoint. OAuth goes to xAI directly; prod→edge API-key relay stubs must validate and forward their TokenKey edge base_url just like responses/media. Losing the account-aware validation here re-breaks Claude Code token counting for grok relay stubs while chat still works."
+    },
+    {
       "path": "backend/internal/service/openai_gateway_grok_test.go",
       "must_contain": [
+        "TestForwardGrokMediaAllowsEdgeRelayBaseURLWithAllowlistEnabled",
         "TestForwardGrokResponsesAPIKeyRelayUsesEdgeResponsesURL",
         "TestResolveGrokResponsesUpstreamAPIKeyRelayUsesEdgeOpenAIResponses",
         "TestForwardAsAnthropic_GrokAPIKeyRelayUsesEdgeResponsesURL"


### PR DESCRIPTION
## 摘要

- 修复 universal key 在媒体协议上的 direct parity：组支持判定从“模型名”升级为“模型名 + endpoint 协议能力”，避免 `veo-3.1-generate-001` video 请求被普通 OpenAI 组抢走。
- 修复 Grok prod→edge relay：仅对 TokenKey edge mirror stub 放行其自身 edge host，并统一 Grok media / video / responses / count_tokens 等路径的账号感知 base_url 校验。
- 更新 endpoint compat baseline 与 sentinel registry，记录 Veo/Grok 的真实根因和发版后 paid direct-vs-universal 复测动作。

## 风险

- 常规风险：改动 gateway routing / relay 校验路径，但没有放宽任意第三方 host；额外 host 只来自 `isEdgeMirrorStub` 识别出的 TokenKey edge mirror base_url。
- Web impact: none。未改前端或公开 UI；展示恢复仍以发版后 paid SSOT gate 的 `keep_displayed` 为准。
- 这次不宣称 Grok image 已经可展示；如果发版后 edge 返回 403，需要按账号 entitlement/provisioning 处理。

## 验证

- `go test -tags unit ./internal/service`
- `go test -tags unit ./internal/server/middleware ./internal/handler`
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`
- `python3 scripts/sentinels/check-grok.py --quiet`
- `bash -o pipefail -c 'PREFLIGHT_BASE=origin/main bash scripts/preflight.sh 2>&1 | tee /tmp/tokenkey-endpoint-media-parity-preflight-20260703.log'`
- 只读 prod 证据已记录到 `docs/ops/endpoint-compat-baseline.md`，包括 `/tmp/tokenkey-grok-relay-log-grep-20260703.log`。

## 提交

- `e6003efe0 fix(endpoint): align media parity routing`

最新提交：`e6003efe0`
