### PR TITLE
fix(admin): 修复账号「测试连接」ghost click 导致弹窗被遮挡

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 554,
-  "hash": "8bab603a1413fc9271b8fa0121222365f49119d7d164f700d9ed1a9ad1e0ba1a",
+  "hash": "d66d385128f7e4f514c067a6d8ca0d71d23b27c92c3d1484f79c8b61cbcbe173",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/admin/account/AccountActionMenu.vue
+++ b/frontend/src/components/admin/account/AccountActionMenu.vue
@@ -10,47 +10,47 @@
       >
         <div class="py-1">
           <template v-if="account">
-            <button @click="$emit('test', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-dark-700">
+            <button @click.stop.prevent="emitAction('test', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="play" size="sm" class="text-green-500" :stroke-width="2" />
               {{ t('admin.accounts.testConnection') }}
             </button>
-            <button @click="$emit('stats', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-dark-700">
+            <button @click.stop.prevent="emitAction('stats', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="chart" size="sm" class="text-indigo-500" />
               {{ t('admin.accounts.viewStats') }}
             </button>
-            <button @click="$emit('schedule', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-dark-700">
+            <button @click.stop.prevent="emitAction('schedule', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="clock" size="sm" class="text-orange-500" />
               {{ t('admin.scheduledTests.schedule') }}
             </button>
             <!-- 影子账号不持凭据:重授权/刷新 token 对其无效(后端拒绝),故隐藏(外审 G4)。 -->
             <template v-if="(account.type === 'oauth' || account.type === 'setup-token') && !isShadow">
-              <button @click="$emit('reauth', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-blue-600 hover:bg-gray-100 dark:hover:bg-dark-700">
+              <button @click.stop.prevent="emitAction('reauth', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-blue-600 hover:bg-gray-100 dark:hover:bg-dark-700">
                 <Icon name="link" size="sm" />
                 {{ t('admin.accounts.reAuthorize') }}
               </button>
-              <button @click="$emit('refresh-token', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-purple-600 hover:bg-gray-100 dark:hover:bg-dark-700">
+              <button @click.stop.prevent="emitAction('refresh-token', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-purple-600 hover:bg-gray-100 dark:hover:bg-dark-700">
                 <Icon name="refresh" size="sm" />
                 {{ t('admin.accounts.refreshToken') }}
               </button>
             </template>
-            <button v-if="isOpenAIOAuthParent" @click="$emit('create-spark-shadow', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-amber-600 hover:bg-gray-100 dark:hover:bg-dark-700">
+            <button v-if="isOpenAIOAuthParent" @click.stop.prevent="emitAction('create-spark-shadow', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-amber-600 hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="sparkles" size="sm" />
               {{ t('admin.accounts.createSparkShadow') }}
             </button>
-            <button v-if="supportsPrivacy" @click="$emit('set-privacy', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-emerald-600 hover:bg-gray-100 dark:hover:bg-dark-700">
+            <button v-if="supportsPrivacy" @click.stop.prevent="emitAction('set-privacy', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-emerald-600 hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="shield" size="sm" />
               {{ t('admin.accounts.setPrivacy') }}
             </button>
-            <button v-if="canSetTier" @click="$emit('set-tier', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-amber-600 hover:bg-gray-100 dark:hover:bg-dark-700">
+            <button v-if="canSetTier" @click.stop.prevent="emitAction('set-tier', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-amber-600 hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="chart" size="sm" />
               {{ t('admin.accounts.setTierDialog.menuItem') }}
             </button>
             <div v-if="hasRecoverableState" class="my-1 border-t border-gray-100 dark:border-dark-700"></div>
-            <button v-if="hasRecoverableState" @click="$emit('recover-state', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-emerald-600 hover:bg-gray-100 dark:hover:bg-dark-700">
+            <button v-if="hasRecoverableState" @click.stop.prevent="emitAction('recover-state', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-emerald-600 hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="sync" size="sm" />
               {{ t('admin.accounts.recoverState') }}
             </button>
-            <button v-if="hasQuotaLimit" @click="$emit('reset-quota', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-teal-600 hover:bg-gray-100 dark:hover:bg-dark-700">
+            <button v-if="hasQuotaLimit" @click.stop.prevent="emitAction('reset-quota', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-teal-600 hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="refresh" size="sm" />
               {{ t('admin.accounts.resetQuota') }}
             </button>
@@ -62,7 +62,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch, onUnmounted } from 'vue'
+import { computed, watch, onUnmounted, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@/components/icons'
 import type { Account } from '@/types'
@@ -70,6 +70,27 @@ import type { Account } from '@/types'
 const props = defineProps<{ show: boolean; account: Account | null; position: { top: number; left: number } | null }>()
 const emit = defineEmits(['close', 'test', 'stats', 'schedule', 'reauth', 'refresh-token', 'recover-state', 'reset-quota', 'set-privacy', 'set-tier', 'create-spark-shadow'])
 const { t } = useI18n()
+
+type MenuActionEvent =
+  | 'test'
+  | 'stats'
+  | 'schedule'
+  | 'reauth'
+  | 'refresh-token'
+  | 'recover-state'
+  | 'reset-quota'
+  | 'set-privacy'
+  | 'set-tier'
+  | 'create-spark-shadow'
+
+// Defer menu teardown until after the click finishes. Synchronous close unmounts
+// the z-[9998] backdrop while the pointer is still over the row "more" trigger;
+// the ghost click reopens the menu above the test modal (z-50), which looks like
+// "flash, no dialog" to operators (prod cc-us5 repro).
+const emitAction = (event: MenuActionEvent, account: Account) => {
+  emit(event, account)
+  void nextTick(() => emit('close'))
+}
 const isRateLimited = computed(() => {
   if (props.account?.rate_limit_reset_at && new Date(props.account.rate_limit_reset_at) > new Date()) {
     return true

--- a/frontend/src/components/admin/account/AccountTestModal.vue
+++ b/frontend/src/components/admin/account/AccountTestModal.vue
@@ -3,6 +3,7 @@
     :show="show"
     :title="t('admin.accounts.testAccountConnection')"
     width="normal"
+    :z-index="10000"
     @close="handleClose"
   >
     <div class="space-y-4">

--- a/frontend/src/components/admin/account/__tests__/AccountActionMenu.spark_shadow.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountActionMenu.spark_shadow.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import AccountActionMenu from '../AccountActionMenu.vue'
 import type { Account } from '@/types'
 
@@ -116,11 +116,32 @@ describe('AccountActionMenu — spark shadow 按钮可见性', () => {
     expect(sparkBtn).toBeDefined()
 
     sparkBtn!.click()
-    await wrapper.vm.$nextTick()
+    await flushPromises()
 
     const emitted = wrapper.emitted('create-spark-shadow')
     expect(emitted).toBeTruthy()
     expect(emitted![0][0]).toMatchObject({ id: account.id, platform: 'openai' })
+    expect(wrapper.emitted('close')).toBeTruthy()
+
+    wrapper.unmount()
+  })
+
+  it('测试连接先 emit test，nextTick 后再 emit close（避免 ghost click 重开菜单）', async () => {
+    const account = makeAccount({ platform: 'anthropic', type: 'apikey', name: 'cc-us5' })
+    const wrapper = mount(AccountActionMenu, {
+      props: { show: true, account, position },
+      attachTo: document.body,
+    })
+
+    const testBtn = getBodyButtons().find((b) => b.textContent?.includes('admin.accounts.testConnection'))
+    expect(testBtn).toBeDefined()
+
+    testBtn!.click()
+    expect(wrapper.emitted('test')).toBeTruthy()
+    expect(wrapper.emitted('close')).toBeFalsy()
+
+    await flushPromises()
+    expect(wrapper.emitted('close')).toBeTruthy()
 
     wrapper.unmount()
   })

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1396,6 +1396,10 @@ const cols = computed(() =>
 
 const handleEdit = (a: Account) => { edAcc.value = a; showEdit.value = true }
 const openMenu = (a: Account, e: MouseEvent) => {
+  // Safety net when a menu action opens a modal but a ghost click hits the row
+  // "more" trigger before the deferred menu close runs.
+  if (isAnyModalOpen.value) return
+
   menu.acc = a
 
   const target = e.currentTarget as HTMLElement


### PR DESCRIPTION
## 摘要

- 修复 prod 运营反馈：账号管理页 cc-us5 等账号点击「操作 → 测试连接」时菜单闪过、测试弹窗不出现。
- 根因：菜单项同步 `$emit('close')` 卸载 backdrop 后，ghost click 落到同行「更多」按钮，`openMenu` 重开 z-9999 菜单，盖住 z-50 测试弹窗。
- 修复：`AccountActionMenu` 延迟关闭 + `openMenu` 在已有弹窗时忽略；测试弹窗 z-index 提升至 10000。

## 风险

- 常规风险，纯前端交互修复；影响所有账号操作菜单项（测试连接/查看统计/定时测试等），不改变 API 契约。
- 已重建 `backend/internal/web/dist/frontend-source.json`。
- sentinel-registry-reviewed：`AccountActionMenu.vue` 已有 `frontend-tk.json` 锚点（canSetTier gating）；本次仅改 ghost-click 交互（emitAction 延迟 close + click.stop.prevent），未改 tier/影子账号等 load-bearing 语义，无需扩 registry。

## 验证

```bash
cd frontend && pnpm test:run \
  src/components/admin/account/__tests__/AccountActionMenu.spark_shadow.spec.ts \
  src/components/admin/account/__tests__/AccountActionMenu.spec.ts
```

- 11 tests passed
- `./scripts/preflight.sh` PASS（含 frontend dist freshness）
- 已 rebase 到最新 `origin/main`（修复 main-ancestry-guard）

## 提交

- c32ac775a fix(admin): 修复账号操作菜单「测试连接」ghost click 导致弹窗被遮挡

最新提交：c32ac775a
