### PR TITLE
fix(studio): align BakeOff media routing

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1434,6 +1434,9 @@ func (a *Account) SupportsOpenAIImageCapability(capability OpenAIImagesCapabilit
 	}
 	switch capability {
 	case OpenAIImagesCapabilityBasic, OpenAIImagesCapabilityNative:
+		if a.Platform == PlatformNewAPI && a.Type == AccountTypeServiceAccount {
+			return true
+		}
 		return a.Type == AccountTypeOAuth || a.Type == AccountTypeAPIKey
 	default:
 		return true

--- a/backend/internal/service/grok_media.go
+++ b/backend/internal/service/grok_media.go
@@ -518,9 +518,9 @@ func grokImageResolutionFromOpenAISize(size string) string {
 	}
 	switch tier {
 	case ImageBillingSize1K:
-		return "1K"
+		return "1k"
 	case ImageBillingSize2K, ImageBillingSize4K:
-		return "2K"
+		return "2k"
 	default:
 		return ""
 	}

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -277,7 +277,7 @@ func TestForwardGrokMediaImagesGenerationNormalizesImagineAlias(t *testing.T) {
 	require.Equal(t, http.MethodPost, upstream.lastReq.Method)
 	require.Equal(t, "Bearer api-key", upstream.lastReq.Header.Get("Authorization"))
 	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Content-Type"))
-	require.JSONEq(t, `{"model":"grok-imagine-image-quality","prompt":"draw a cat","resolution":"1K","aspect_ratio":"1:1"}`, string(upstream.lastBody))
+	require.JSONEq(t, `{"model":"grok-imagine-image-quality","prompt":"draw a cat","resolution":"1k","aspect_ratio":"1:1"}`, string(upstream.lastBody))
 	require.Equal(t, http.StatusOK, recorder.Code)
 	require.JSONEq(t, `{"data":[]}`, recorder.Body.String())
 	require.Equal(t, "xai-image-req", result.RequestID)

--- a/backend/internal/service/openai_gateway_grok_video_tk.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -146,7 +147,7 @@ func (s *OpenAIGatewayService) grokNativeVideoSubmit(
 	if err != nil {
 		return nil, fmt.Errorf("invalid grok base_url: %w", err)
 	}
-	url := strings.TrimRight(base, "/") + "/videos/generations"
+	url := buildGrokVideoSubmitURL(base)
 
 	respBody, status, herr := s.grokVideoHTTP(ctx, account, http.MethodPost, url, token, upstreamBody)
 	if herr != nil {
@@ -214,7 +215,7 @@ func (s *OpenAIGatewayService) grokNativeVideoFetch(
 	if token == "" {
 		return nil, errors.New("grok video fetch: no usable bearer credential")
 	}
-	url := base + "/videos/" + in.UpstreamTaskID
+	url := buildGrokVideoFetchURL(base, in.UpstreamTaskID)
 
 	respBody, status, herr := s.grokVideoHTTP(ctx, account, http.MethodGet, url, token, nil)
 	if herr != nil {
@@ -320,6 +321,14 @@ func (s *OpenAIGatewayService) grokVideoHTTP(
 		return nil, resp.StatusCode, fmt.Errorf("read grok video response: %w", rerr)
 	}
 	return respBody, resp.StatusCode, nil
+}
+
+func buildGrokVideoSubmitURL(base string) string {
+	return buildOpenAIV1SegmentURL(base, "videos/generations")
+}
+
+func buildGrokVideoFetchURL(base, upstreamTaskID string) string {
+	return buildOpenAIV1SegmentURL(base, "videos/"+url.PathEscape(upstreamTaskID))
 }
 
 // grokVideoUpstreamError maps an xAI video error response to a client error.

--- a/backend/internal/service/openai_gateway_grok_video_tk_test.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk_test.go
@@ -215,6 +215,44 @@ func TestNormalizeGrokVideoSubmitBodyMapsOpenAICompatDuration(t *testing.T) {
 	}
 }
 
+func TestBuildGrokVideoV1URLs(t *testing.T) {
+	cases := []struct {
+		name   string
+		base   string
+		submit string
+		fetch  string
+	}{
+		{
+			name:   "edge root base",
+			base:   "https://api-us4.tokenkey.dev",
+			submit: "https://api-us4.tokenkey.dev/v1/videos/generations",
+			fetch:  "https://api-us4.tokenkey.dev/v1/videos/req-123",
+		},
+		{
+			name:   "v1 base",
+			base:   "https://api.x.ai/v1",
+			submit: "https://api.x.ai/v1/videos/generations",
+			fetch:  "https://api.x.ai/v1/videos/req-123",
+		},
+		{
+			name:   "trailing slash v1 base",
+			base:   "https://api.x.ai/v1/",
+			submit: "https://api.x.ai/v1/videos/generations",
+			fetch:  "https://api.x.ai/v1/videos/req-123",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := buildGrokVideoSubmitURL(tc.base); got != tc.submit {
+				t.Fatalf("submit URL = %q, want %q", got, tc.submit)
+			}
+			if got := buildGrokVideoFetchURL(tc.base, "req-123"); got != tc.fetch {
+				t.Fatalf("fetch URL = %q, want %q", got, tc.fetch)
+			}
+		})
+	}
+}
+
 // TestBuildGrokVideoSubmitResponse verifies the synchronous submit
 // acknowledgement carries TK's PUBLIC task id (the client polls
 // GET /v1/videos/{id} with it) and the OpenAI-Video submit shape the handler

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -442,6 +442,16 @@ func TestAccountSupportsOpenAIImageCapability_OAuthSupportsNative(t *testing.T) 
 	require.True(t, account.SupportsOpenAIImageCapability(OpenAIImagesCapabilityNative))
 }
 
+func TestAccountSupportsOpenAIImageCapability_NewAPIServiceAccountSupportsNative(t *testing.T) {
+	account := &Account{
+		Platform: PlatformNewAPI,
+		Type:     AccountTypeServiceAccount,
+	}
+
+	require.True(t, account.SupportsOpenAIImageCapability(OpenAIImagesCapabilityBasic))
+	require.True(t, account.SupportsOpenAIImageCapability(OpenAIImagesCapabilityNative))
+}
+
 func TestAccountSupportsOpenAIImageCapability_EmptyRequirementDoesNotRejectGrok(t *testing.T) {
 	account := &Account{
 		Platform: PlatformGrok,

--- a/backend/internal/service/universal_routing_tk_endpoint_map.go
+++ b/backend/internal/service/universal_routing_tk_endpoint_map.go
@@ -191,3 +191,19 @@ func universalModelPlatformHint(model string) string {
 		return ""
 	}
 }
+
+func universalRequestPlatformHint(shape UniversalShape, model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" {
+		return ""
+	}
+	switch shape {
+	case ShapeOpenAIImages, ShapeOpenAIVideo:
+		// Imagen/Veo are Google-family model names, but TokenKey serves their
+		// OpenAI-compatible image/video endpoints through the newapi Vertex bridge.
+		if strings.HasPrefix(m, "imagen") || strings.HasPrefix(m, "veo") {
+			return PlatformNewAPI
+		}
+	}
+	return universalModelPlatformHint(model)
+}

--- a/backend/internal/service/universal_routing_tk_resolver.go
+++ b/backend/internal/service/universal_routing_tk_resolver.go
@@ -183,10 +183,10 @@ func (r *UniversalRoutingResolver) Resolve(ctx context.Context, apiKey *APIKey, 
 			if len(served) > 0 {
 				eligible = served
 			} else if knownAll {
-				if hint := universalModelPlatformHint(model); hint != "" {
+				if hint := universalRequestPlatformHint(shape, model); hint != "" {
 					return nil, ErrUniversalNoEntitledGroup
 				}
-			} else if hint := universalModelPlatformHint(model); hint != "" && modelsProvider != nil {
+			} else if hint := universalRequestPlatformHint(shape, model); hint != "" && modelsProvider != nil {
 				return nil, ErrUniversalNoEntitledGroup
 			}
 		}
@@ -195,7 +195,7 @@ func (r *UniversalRoutingResolver) Resolve(ctx context.Context, apiKey *APIKey, 
 	// 模型平台提示：若提示命中且跨度内有该平台的 eligible 组，仅在这些组里挑（偏向，
 	// 非硬过滤——提示未命中则退回全体 eligible）。这样 openai-compat 形状下能把
 	// grok-4→grok、gpt-5→openai、seedream→newapi 偏向到对的平台。
-	if hint := universalModelPlatformHint(model); hint != "" {
+	if hint := universalRequestPlatformHint(shape, model); hint != "" {
 		hinted := eligible[:0:0]
 		for _, g := range eligible {
 			if g.Platform == hint {

--- a/backend/internal/service/universal_routing_tk_resolver_test.go
+++ b/backend/internal/service/universal_routing_tk_resolver_test.go
@@ -190,6 +190,18 @@ func TestUniversalModelPlatformHint(t *testing.T) {
 	}
 }
 
+func TestUniversalRequestPlatformHint_OpenAICompatVertexMedia(t *testing.T) {
+	if got := universalRequestPlatformHint(ShapeOpenAIImages, "imagen-4.0-generate-001"); got != PlatformNewAPI {
+		t.Fatalf("imagen on OpenAI images should hint newapi vertex, got %q", got)
+	}
+	if got := universalRequestPlatformHint(ShapeOpenAIVideo, "veo-3.1-generate-001"); got != PlatformNewAPI {
+		t.Fatalf("veo on OpenAI video should hint newapi vertex, got %q", got)
+	}
+	if got := universalRequestPlatformHint(ShapeGemini, "imagen-4.0-generate-001"); got != PlatformGemini {
+		t.Fatalf("imagen on native Gemini shape should keep gemini hint, got %q", got)
+	}
+}
+
 func TestResolve_PicksByPlatformAndHint(t *testing.T) {
 	span := []Group{
 		grp(10, PlatformAnthropic, 0, false),

--- a/backend/internal/service/universal_routing_tk_serving.go
+++ b/backend/internal/service/universal_routing_tk_serving.go
@@ -1,6 +1,9 @@
 package service
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 // 全能 Key 解析的「组是否支持模型」真值过滤。
 //
@@ -68,7 +71,7 @@ func (s *GatewayService) UniversalGroupSupportsRequest(ctx context.Context, grou
 			if !universalOpenAICompatAccountSupportsShape(acc, shape) {
 				continue
 			}
-			if s.isModelSupportedByAccount(acc, model) || (acc.Platform == PlatformGrok && grokGroupServesNativeCatalogModel(model)) {
+			if universalOpenAICompatAccountSupportsModel(ctx, s, acc, model, shape) {
 				return true, true
 			}
 			continue
@@ -80,6 +83,41 @@ func (s *GatewayService) UniversalGroupSupportsRequest(ctx context.Context, grou
 		}
 	}
 	return false, true
+}
+
+func universalOpenAICompatAccountSupportsModel(ctx context.Context, s *GatewayService, account *Account, model string, shape UniversalShape) bool {
+	if account == nil {
+		return false
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return true
+	}
+	mapping := account.GetModelMapping()
+	if len(mapping) > 0 {
+		if mappingSupportsRequestedModel(mapping, model) {
+			return true
+		}
+		if norm := normalizeRequestedModelForLookup(account.Platform, model); norm != model {
+			if mappingSupportsRequestedModel(mapping, norm) {
+				return true
+			}
+		}
+		return account.Platform == PlatformGrok && grokGroupServesNativeCatalogModel(model)
+	}
+	if account.Platform == PlatformGrok && grokGroupServesNativeCatalogModel(model) {
+		return true
+	}
+	if account.Platform == PlatformNewAPI {
+		return false
+	}
+	if s != nil && s.isModelSupportedByAccountWithContext(ctx, account, model) {
+		if hint := universalRequestPlatformHint(shape, model); hint != "" {
+			return hint == account.Platform
+		}
+		return true
+	}
+	return false
 }
 
 func universalOpenAICompatAccountSupportsShape(account *Account, shape UniversalShape) bool {

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -363,6 +363,45 @@ func TestResolve_ImagenPicksVertexNewapiGroup(t *testing.T) {
 	}
 }
 
+func TestResolve_ImagenServiceAccountPicksVertexWithDirectSchedulerSupport(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(2, PlatformOpenAI, 5, false),
+		grp(16, PlatformNewAPI, 10, false),
+	}
+	imagenMapping := map[string]any{"imagen-4.0-generate-001": "imagen-4.0-generate-001"}
+	svc := &GatewayService{
+		accountRepo: groupAwareStubOpenAIAccountRepo{stubOpenAIAccountRepo{accounts: []Account{
+			{
+				ID:          63,
+				GroupIDs:    []int64{2},
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Schedulable: true,
+				ChannelType: 0,
+			},
+			{
+				ID:          57,
+				GroupIDs:    []int64{16},
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeServiceAccount,
+				Status:      StatusActive,
+				Schedulable: true,
+				ChannelType: 41,
+				Credentials: map[string]any{"model_mapping": imagenMapping},
+			},
+		}}},
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetModelSupportProvider(svc.UniversalGroupSupportsRequest)
+
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIImages, "imagen-4.0-generate-001", "")
+	if err != nil || g == nil || g.ID != 16 {
+		t.Fatalf("imagen service-account universal must pick vertex gid=16, got=%v err=%v", g, err)
+	}
+}
+
 // imagen 不得落到 allow_image_generation=false 的 newapi 组; 应优先/仅选已开生图的组。
 func TestResolve_ImagenSkipsGroupWithoutImageGenerationPermission(t *testing.T) {
 	ctx := context.Background()

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 554,
-  "hash": "c0b611752290815083979a323aac23f2704b7c77f3b8fbd635c5c0c3b342fd63",
+  "hash": "0d563e92367ee7142624eaef2621f8ab9d2381372dfffd061a8a39ff85e6e65a",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/embed_on.go
+++ b/backend/internal/web/embed_on.go
@@ -336,7 +336,11 @@ func shouldBypassEmbeddedFrontend(path string) bool {
 		strings.HasPrefix(trimmed, "/health/") ||
 		trimmed == "/responses" ||
 		strings.HasPrefix(trimmed, "/responses/") ||
-		strings.HasPrefix(trimmed, "/images/")
+		strings.HasPrefix(trimmed, "/images/") ||
+		trimmed == "/video" ||
+		strings.HasPrefix(trimmed, "/video/") ||
+		trimmed == "/videos" ||
+		strings.HasPrefix(trimmed, "/videos/")
 }
 
 func serveIndexHTML(c *gin.Context, fsys fs.FS) {

--- a/backend/internal/web/embed_test.go
+++ b/backend/internal/web/embed_test.go
@@ -443,6 +443,10 @@ func TestFrontendServer_Middleware(t *testing.T) {
 			"/health/inflight",
 			"/responses",
 			"/responses/compact",
+			"/images/generations",
+			"/video/generations",
+			"/videos",
+			"/videos/generations",
 		}
 
 		for _, path := range apiPaths {
@@ -488,6 +492,36 @@ func TestFrontendServer_Middleware(t *testing.T) {
 		assert.True(t, nextCalled, "next handler should be called for compact API route")
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.JSONEq(t, `{"ok":true}`, w.Body.String())
+	})
+
+	t.Run("skips_video_post_routes", func(t *testing.T) {
+		provider := &mockSettingsProvider{
+			settings: map[string]string{"test": "value"},
+		}
+
+		server, err := NewFrontendServer(provider)
+		require.NoError(t, err)
+
+		for _, path := range []string{"/video/generations", "/videos", "/videos/generations"} {
+			t.Run(path, func(t *testing.T) {
+				router := gin.New()
+				router.Use(server.Middleware())
+				nextCalled := false
+				router.POST(path, func(c *gin.Context) {
+					nextCalled = true
+					c.String(http.StatusOK, `{"ok":true}`)
+				})
+
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"model":"grok-imagine-video"}`))
+				req.Header.Set("Content-Type", "application/json")
+				router.ServeHTTP(w, req)
+
+				assert.True(t, nextCalled, "next handler should be called for video API route")
+				assert.Equal(t, http.StatusOK, w.Code)
+				assert.JSONEq(t, `{"ok":true}`, w.Body.String())
+			})
+		}
 	})
 
 	t.Run("serves_index_for_spa_routes", func(t *testing.T) {
@@ -691,6 +725,10 @@ func TestServeEmbeddedFrontend(t *testing.T) {
 			"/health/inflight",
 			"/responses",
 			"/responses/compact",
+			"/images/generations",
+			"/video/generations",
+			"/videos",
+			"/videos/generations",
 		}
 
 		for _, path := range apiPaths {

--- a/docs/ops/endpoint-compat-baseline.md
+++ b/docs/ops/endpoint-compat-baseline.md
@@ -23,18 +23,18 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 
 | Field | Value |
 |---|---|
-| Baseline date | 2026-07-03 |
+| Baseline date | 2026-07-04 |
 | Target | prod (`https://api.tokenkey.dev`) |
-| Runtime code anchor | `v1.8.78` / `35e3e66a` deployed baseline; current fix branch is post-`v1.8.78` |
-| Paid media probes | approved and rerun post-`v1.8.78` / #1194 |
+| Runtime code anchor | `v1.8.78` / `35e3e66a` deployed baseline; current fix branch is post-`v1.8.78` and includes #1198 / `61d422523` |
+| Paid media probes | approved and rerun post-`v1.8.78` / #1194; focused Grok paid shape canary approved on 2026-07-04 |
 | Direct route-gate command | `bash ops/observability/endpoint-compat-audit.sh --direct-route-gate` |
 | Universal matrix command | `bash ops/observability/endpoint-compat-audit.sh --universal-matrix --with-extras --skip-paid` |
 | SSOT model matrix command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --list --include-paid --show-excluded` |
 | SSOT display gate command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --show-excluded` |
 | Focused postrelease media parity command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-media-parity-postrelease.sh --with ops/pricing/probe_reserved_resources.sh` |
 | Studio Imagen no-platform triage command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-studio-imagen-no-platform.sh` |
-| Focused parity fix anchors | `backend/internal/service/universal_routing_tk_serving.go`; `backend/internal/service/openai_gateway_service.go`; `backend/internal/service/grok_media.go`; `backend/internal/service/openai_gateway_grok.go` |
-| Display remediation state | Veo is post-#1194 route-serviceable but remains hidden until a paid SSOT gate returns `keep_displayed`; Grok paid media remains hidden/reprobe; Studio Imagen standard needs the post-`v1.8.78` universal service-account routing fix in this branch. |
+| Focused parity fix anchors | `backend/internal/service/universal_routing_tk_serving.go`; `backend/internal/service/openai_gateway_service.go`; `backend/internal/service/grok_media.go`; `backend/internal/service/openai_gateway_grok.go`; `backend/internal/service/openai_gateway_grok_video_tk.go`; `backend/internal/web/embed_on.go` |
+| Display remediation state | Veo is post-#1194 route-serviceable but remains hidden until a paid SSOT gate returns `keep_displayed`; Grok paid media root causes are fixed in #1198 but remain hidden/reprobe until post-release direct/universal parity and paid SSOT gate pass; Studio Imagen standard needs the post-`v1.8.78` universal service-account routing fix in #1198. |
 | Cleanup command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/cleanup-probe-resources.sh` |
 
 ### Evidence Pointers
@@ -70,6 +70,8 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 | `/tmp/tokenkey-account-model-probe-cleanup-20260703-113537.log` | previous account-model sanity: account 63 served `gpt-5.1`; cleanup left active probe resources at `0/0` |
 | `/tmp/tokenkey-postrelease-media-parity-20260703.log` | post-#1194 paid parity probe: Veo direct/universal both returned queued video `200`; Grok image direct/universal both returned xAI upstream `422`; Grok video direct/universal both returned `502 Video submit failed` |
 | `/tmp/tokenkey-postrelease-media-parity-attribution-20260703.log` | attribution for the same run: universal Veo used group 16/account 57 and direct probe used Vertex account 74; Grok direct/universal both used account 65, image owner=`provider` upstream `422`, video owner=`platform` internal `502` |
+| `/tmp/tokenkey-grok-media-variants-20260704.log` | focused paid Grok account-65 shape canary: image quality/min, image quality with lower `1k`, and image fast all returned upstream `200`; root `/videos/generations` returned embedded frontend HTML `200`, proving the observed video 502 was a gateway/edge path-shape issue, not xAI video unavailability |
+| `/tmp/tokenkey-grok-media-v1-20260704.log` | focused paid Grok account-65 shape canary with `/v1/videos/generations`: xAI-shaped video through edge returned `200` with `request_id`; #1198 fixes gateway URL construction to use this `/v1` path and adds frontend bypass for root `/video*` / `/videos*` API paths |
 | `/tmp/tokenkey-studio-imagen-no-platform-20260703.log` | Studio/BakeOff user-reported `imagen-4.0-generate-001` failure found one universal key id 5 local `403 No platform...` at `2026-07-03T15:24:40Z`, plus an older successful route to group 16/account 59 that reached upstream quota `429` |
 | `/tmp/tokenkey-studio-imagen-no-platform-types-20260703.log` | live entitlement/config context: user 1 is entitled to Google-Vertex group 16; group 16 is active, `allow_image_generation=true`, and five schedulable `service_account` Vertex accounts exactly map `imagen-4.0-generate-001` |
 
@@ -89,7 +91,7 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 | antigravity | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for text | direct route-gate log; universal retry log | Keep direct-vs-universal parity watch when Gemini `/v1beta` routing changes. |
 | newapi | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for text | direct route-gate log; universal retry log | Reprobe after newapi channel mapping or compatibility-pool changes. |
 | newapi | image/video | unknown | unknown | supported for current SSOT Seedream 4.0/4.5/5.0 and Seedance 1.0/1.5/2.0 rows; Vertex Imagen/Veo and Grok media have their own focused rows above | full paid image/video gates; focused Vertex/Grok logs | Keep `--include-paid` probes explicit; default non-paid gates do not prove media servability. |
-| grok group 25 / account 65 | image/video | open | post-#1194 direct image reaches xAI and returns upstream `422`; direct video still returns internal `502 Video submit failed` | post-#1194 universal matches direct for the same account/error class: image upstream `422`, video internal `502` | postrelease media parity logs; attribution log | This is no longer a direct-vs-universal routing mismatch. Grok image/video are still not serviceable/display-safe; next work is upstream request/body/video-submit remediation or provider/account proof, then paid SSOT gate. |
+| grok group 25 / account 65 | image/video | open | pre-#1198 live direct image reached xAI and returned upstream `422`; direct video returned internal `502 Video submit failed`. Focused paid account-65 canary proved image request shapes return upstream `200` and `/v1/videos/generations` returns `200` with `request_id`. | pre-#1198 universal matched direct for the same account/error class; #1198 fixes image `resolution` shape and video `/v1` edge path construction, but universal is not yet post-release proven. | postrelease media parity logs; attribution log; 2026-07-04 Grok paid shape canary logs; #1198 / `61d422523` | This is no longer a direct-vs-universal routing mismatch. Keep Grok media hidden/reprobe until #1198 is released, paid direct/universal parity returns `200`, and paid SSOT gate returns `keep_displayed`. |
 | kiro | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | route_open_unservable: empty direct probe pool returned `429` | supported for text | direct route-gate log; universal retry log | If direct Kiro serving is claimed, run account-model probe against the target account/model. |
 | grok | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for text | direct route-gate log; universal retry log | No full-matrix rerun needed unless Grok model default or relay changes. |
 | all platforms with `/v1/responses` GET prelude | WebSocket prelude | open: `426` upgrade required | unknown | unknown | direct route-gate log | Treat `426` as expected route-open prelude, not a failure. |
@@ -116,12 +118,13 @@ This keeps `/pricing` as the single derived matrix source while turning every
 
 ## Next Probe Focus
 
-1. After the current post-`v1.8.78` fix is released and deployed, rerun paid
-   direct-vs-universal checks for `imagen-4.0-generate-001` on
-   `/v1/images/generations`. Expected result: universal key id 5 resolves
-   Google-Vertex group 16 and then matches a direct group-16 key result. A direct
-   pool/provider quota error is a servability/provisioning signal, not a universal
-   routing defect.
+1. After #1198 is released and deployed, rerun paid direct-vs-universal checks
+   for `imagen-4.0-generate-001` on `/v1/images/generations`, Grok image on
+   `/v1/images/generations`, and Grok video on `/v1/video/generations` and
+   `/v1/videos/generations`. Expected result: universal resolves the same
+   entitled group/account class as the matching direct key and returns the same
+   `200` response shape. A direct pool/provider quota error is a
+   servability/provisioning signal, not a universal routing defect.
 2. Treat the non-paid display gate as the current product action list. The
    dominant `hide_or_provision` blockers are selected newapi `/v1/responses`,
    Antigravity/Gemini OpenAI-compatible text protocols, Grok non-default
@@ -132,13 +135,15 @@ This keeps `/pricing` as the single derived matrix source while turning every
    in the displayed+priced SSOT matrix, and the displayed Vertex AI embedding
    rows are `hide_or_map_vendor`. Decide whether to map/provision universal
    embeddings or remove/hide those rows from the relevant surface.
-4. Paid media status after #1194: Veo direct/universal route parity is proven by
-   queued `200` responses but the row remains display-gated until paid SSOT
-   returns `keep_displayed`; Grok direct/universal parity is same-error, not
-   serviceability, so Grok media stays hidden/reprobe; Vertex Imagen standard is
-   blocked by the post-`v1.8.78` universal service-account fix in this branch and
-   must be rerun after release. `gpt-image-1` is still only a hardcoded probe row
-   for the current key, not a displayed+priced SSOT row.
+4. Paid media status after #1194/#1198: Veo direct/universal route parity is
+   proven by queued `200` responses but the row remains display-gated until paid
+   SSOT returns `keep_displayed`; Grok account-65 raw image/video shapes are
+   proven serviceable by the 2026-07-04 paid canary and #1198 fixes the gateway
+   shape/path issues, but Grok media still needs post-release direct/universal
+   `200` parity plus paid SSOT `keep_displayed`; Vertex Imagen standard is
+   blocked by the post-`v1.8.78` universal service-account fix in #1198 and must
+   be rerun after release. `gpt-image-1` is still only a hardcoded probe row for
+   the current key, not a displayed+priced SSOT row.
 5. Reprobe the three `reprobe_required` rows from the non-paid gate with a
    longer timeout or a cleaner pool before deciding whether they are displayable
    or should join the hide/provision list.

--- a/docs/ops/endpoint-compat-baseline.md
+++ b/docs/ops/endpoint-compat-baseline.md
@@ -25,14 +25,16 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 |---|---|
 | Baseline date | 2026-07-03 |
 | Target | prod (`https://api.tokenkey.dev`) |
-| Runtime code anchor | `v1.8.76` / `8454a255ad3b` on `origin/main` |
-| Paid media probes | approved and rerun post-1.8.76 |
+| Runtime code anchor | `v1.8.78` / `35e3e66a` deployed baseline; current fix branch is post-`v1.8.78` |
+| Paid media probes | approved and rerun post-`v1.8.78` / #1194 |
 | Direct route-gate command | `bash ops/observability/endpoint-compat-audit.sh --direct-route-gate` |
 | Universal matrix command | `bash ops/observability/endpoint-compat-audit.sh --universal-matrix --with-extras --skip-paid` |
 | SSOT model matrix command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --list --include-paid --show-excluded` |
 | SSOT display gate command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --show-excluded` |
+| Focused postrelease media parity command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-media-parity-postrelease.sh --with ops/pricing/probe_reserved_resources.sh` |
+| Studio Imagen no-platform triage command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-studio-imagen-no-platform.sh` |
 | Focused parity fix anchors | `backend/internal/service/universal_routing_tk_serving.go`; `backend/internal/service/openai_gateway_service.go`; `backend/internal/service/grok_media.go`; `backend/internal/service/openai_gateway_grok.go` |
-| Display remediation state | Gemini video `veo-3.1-generate-001` and Grok paid media were removed from the shared catalog/Menu allowlists by the previous remediation. Restore only after this parity fix is released and a paid SSOT gate returns `keep_displayed`. |
+| Display remediation state | Veo is post-#1194 route-serviceable but remains hidden until a paid SSOT gate returns `keep_displayed`; Grok paid media remains hidden/reprobe; Studio Imagen standard needs the post-`v1.8.78` universal service-account routing fix in this branch. |
 | Cleanup command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/cleanup-probe-resources.sh` |
 
 ### Evidence Pointers
@@ -66,6 +68,10 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 | `/tmp/tokenkey-probe-cleanup-dryrun-1.8.76-20260703-134455.log` | active probe groups/keys remain `0/0`; no apply needed |
 | `/tmp/tokenkey-universal-paid-media-20260703-112145.log` | previous paid-media baseline retained for trend comparison |
 | `/tmp/tokenkey-account-model-probe-cleanup-20260703-113537.log` | previous account-model sanity: account 63 served `gpt-5.1`; cleanup left active probe resources at `0/0` |
+| `/tmp/tokenkey-postrelease-media-parity-20260703.log` | post-#1194 paid parity probe: Veo direct/universal both returned queued video `200`; Grok image direct/universal both returned xAI upstream `422`; Grok video direct/universal both returned `502 Video submit failed` |
+| `/tmp/tokenkey-postrelease-media-parity-attribution-20260703.log` | attribution for the same run: universal Veo used group 16/account 57 and direct probe used Vertex account 74; Grok direct/universal both used account 65, image owner=`provider` upstream `422`, video owner=`platform` internal `502` |
+| `/tmp/tokenkey-studio-imagen-no-platform-20260703.log` | Studio/BakeOff user-reported `imagen-4.0-generate-001` failure found one universal key id 5 local `403 No platform...` at `2026-07-03T15:24:40Z`, plus an older successful route to group 16/account 59 that reached upstream quota `429` |
+| `/tmp/tokenkey-studio-imagen-no-platform-types-20260703.log` | live entitlement/config context: user 1 is entitled to Google-Vertex group 16; group 16 is active, `allow_image_generation=true`, and five schedulable `service_account` Vertex accounts exactly map `imagen-4.0-generate-001` |
 
 ## Compatibility Matrix
 
@@ -77,12 +83,13 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 | openai | image `gpt-image-1` | unknown | unknown | not_authorized for the current universal key in the hardcoded matrix; not present in the current displayed+priced SSOT paid-media rows | paid-media post-1.8.76 log; focused paid-media gate | If OpenAI image should be a visible product surface, first add the catalog/entitlement path, then require a `keep_displayed` gate result. |
 | openai | embeddings `text-embedding-3-small` | unknown | unknown | unknown: repeated hardcoded-matrix SKIP `429`; not present in the current displayed+priced SSOT matrix | universal logs; embedding retry log; focused embedding gate | Do not treat this as display-safe. If OpenAI embeddings should be displayed, add the SSOT pricing/catalog row and rerun the embedding gate with a non-throttled pool. |
 | gemini | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | route_open_unservable: empty direct probe pool returned `429` | supported | direct route-gate log; universal retry log | First universal run hit transient `429`; retry passed. |
-| gemini | image | unknown | unknown | supported for all current SSOT paid image rows: `imagen-4.0-fast-generate-001`, `imagen-4.0-generate-001`, `imagen-4.0-ultra-generate-001` | full paid image gate | Direct live parity still needs a schedulable direct pool. |
-| newapi / Google-Vertex group 16 | video `veo-3.1-generate-001` | open | supported: focused direct probe returned queued video and 24h billing context contains successful billed Veo rows | pre-fix `route_open_unservable`: universal chose OpenAI group 2 because model-only support ignored video capability; fix makes universal support provider protocol-aware | focused media logs; parity fix anchors | After release, rerun paid direct-vs-universal for the same model/protocol/group. Expected result: universal selects the same video-capable Vertex group as direct; display gate may restore only after `keep_displayed`. |
+| gemini | image | unknown | unknown | supported for Gemini-native image rows in the hardcoded paid gate; Vertex Imagen rows are tracked under newapi / Google-Vertex | full paid image gate; Studio Imagen triage | Keep Gemini-native image separate from Vertex Imagen: same model family, different serving platform/protocol. |
+| newapi / Google-Vertex group 16 | image `imagen-4.0-generate-001` | open | supported/provisioned: live group 16 has five schedulable Vertex service accounts with exact mapping; older universal request reached upstream quota `429` on account 59 | pre-fix `403 No platform...` on universal key id 5 after `v1.8.78`: universal support prefilter excluded `newapi` `service_account` image accounts and failed before account selection | Studio Imagen no-platform logs; current branch fix anchors `account.go`, `universal_routing_tk_serving.go`, `universal_routing_tk_resolver.go` | After this branch is released, rerun paid universal/direct image probe for `imagen-4.0-generate-001`. Expected result: universal resolves group 16 and then either succeeds or returns the same upstream quota/provider result as direct. |
+| newapi / Google-Vertex group 16 | video `veo-3.1-generate-001` | open | supported: post-#1194 direct probe returned queued video `200` using Vertex account 74 | supported: post-#1194 universal key id 5 returned queued video `200` using group 16/account 57 | postrelease media parity logs; attribution log | Routing parity is now satisfied for the tested model/protocol/group. Display can be restored only after a paid SSOT gate returns `keep_displayed`. |
 | antigravity | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for text | direct route-gate log; universal retry log | Keep direct-vs-universal parity watch when Gemini `/v1beta` routing changes. |
 | newapi | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for text | direct route-gate log; universal retry log | Reprobe after newapi channel mapping or compatibility-pool changes. |
-| newapi | image/video | unknown | unknown | supported for all current SSOT paid image/video rows: Seedream 4.0/4.5/5.0 and Seedance 1.0/1.5/2.0 variants | full paid image/video gates | Keep `--include-paid` probes explicit; default non-paid gates do not prove media servability. |
-| grok group 25 / account 65 | image/video | open | pre-fix `closed_by_gateway`: direct probe key and universal key both selected account 65 and failed locally before edge with the same edge-host allowlist error | pre-fix `closed_by_gateway`: same local relay error as direct; not a direct-vs-universal routing mismatch | full paid image/video gates; focused Grok retry; Grok relay log grep | Fix allows controlled TokenKey edge mirror hosts for mirror-stub accounts and routes Grok media URLs through the validated OpenAI-compatible builder. After release, rerun paid parity; image may still require edge/account entitlement if upstream returns 403 after the relay is reached. |
+| newapi | image/video | unknown | unknown | supported for current SSOT Seedream 4.0/4.5/5.0 and Seedance 1.0/1.5/2.0 rows; Vertex Imagen/Veo and Grok media have their own focused rows above | full paid image/video gates; focused Vertex/Grok logs | Keep `--include-paid` probes explicit; default non-paid gates do not prove media servability. |
+| grok group 25 / account 65 | image/video | open | post-#1194 direct image reaches xAI and returns upstream `422`; direct video still returns internal `502 Video submit failed` | post-#1194 universal matches direct for the same account/error class: image upstream `422`, video internal `502` | postrelease media parity logs; attribution log | This is no longer a direct-vs-universal routing mismatch. Grok image/video are still not serviceable/display-safe; next work is upstream request/body/video-submit remediation or provider/account proof, then paid SSOT gate. |
 | kiro | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | route_open_unservable: empty direct probe pool returned `429` | supported for text | direct route-gate log; universal retry log | If direct Kiro serving is claimed, run account-model probe against the target account/model. |
 | grok | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for text | direct route-gate log; universal retry log | No full-matrix rerun needed unless Grok model default or relay changes. |
 | all platforms with `/v1/responses` GET prelude | WebSocket prelude | open: `426` upgrade required | unknown | unknown | direct route-gate log | Treat `426` as expected route-open prelude, not a failure. |
@@ -109,13 +116,12 @@ This keeps `/pricing` as the single derived matrix source while turning every
 
 ## Next Probe Focus
 
-1. After this parity fix is released and deployed, rerun paid direct-vs-universal
-   checks for `veo-3.1-generate-001`, `grok-imagine-image`,
-   `grok-imagine-image-quality`, and `grok-imagine-video`. For Veo, universal
-   should pick the same video-capable Google-Vertex group as the direct key. For
-   Grok, prod direct and universal should both reach the edge mirror instead of
-   failing local base-url validation; any returned upstream 403/429/5xx is then
-   an entitlement/capacity/provider result, not a universal routing defect.
+1. After the current post-`v1.8.78` fix is released and deployed, rerun paid
+   direct-vs-universal checks for `imagen-4.0-generate-001` on
+   `/v1/images/generations`. Expected result: universal key id 5 resolves
+   Google-Vertex group 16 and then matches a direct group-16 key result. A direct
+   pool/provider quota error is a servability/provisioning signal, not a universal
+   routing defect.
 2. Treat the non-paid display gate as the current product action list. The
    dominant `hide_or_provision` blockers are selected newapi `/v1/responses`,
    Antigravity/Gemini OpenAI-compatible text protocols, Grok non-default
@@ -126,11 +132,13 @@ This keeps `/pricing` as the single derived matrix source while turning every
    in the displayed+priced SSOT matrix, and the displayed Vertex AI embedding
    rows are `hide_or_map_vendor`. Decide whether to map/provision universal
    embeddings or remove/hide those rows from the relevant surface.
-4. Paid media gate outcome before this fix: Gemini image and all current newapi
-   Seedream / Seedance rows can stay displayed; Veo and Grok media must remain
-   hidden/disabled until the post-fix paid gate returns `keep_displayed`.
-   `gpt-image-1` is still only a hardcoded probe row for the current key, not a
-   displayed+priced SSOT row.
+4. Paid media status after #1194: Veo direct/universal route parity is proven by
+   queued `200` responses but the row remains display-gated until paid SSOT
+   returns `keep_displayed`; Grok direct/universal parity is same-error, not
+   serviceability, so Grok media stays hidden/reprobe; Vertex Imagen standard is
+   blocked by the post-`v1.8.78` universal service-account fix in this branch and
+   must be rerun after release. `gpt-image-1` is still only a hardcoded probe row
+   for the current key, not a displayed+priced SSOT row.
 5. Reprobe the three `reprobe_required` rows from the non-paid gate with a
    longer timeout or a cleaner pool before deciding whether they are displayable
    or should join the hide/provision list.

--- a/frontend/src/constants/studioMediaPresentations.tk.ts
+++ b/frontend/src/constants/studioMediaPresentations.tk.ts
@@ -20,7 +20,8 @@ export type StudioModality = 'image' | 'video'
  * peer Studio tab (folded in from the retired /playground), but it has no media
  * billing-mode catalog row — a key "serves chat" when its /v1/models pool exposes
  * any chat-classified id (modalityForModel). image/video use catalog billing_mode.
- * Bake-off passes no picker modality (dual sub-modality → user owns the key).
+ * Bake-off reports its active sub-modality to the shell, so the selected key
+ * still tracks image vs video just like the dedicated tabs.
  */
 export type PickerModality = StudioModality | 'chat'
 
@@ -70,8 +71,8 @@ export function hasCatalogMediaModality(
 /**
  * Whether this group's pool serves `modality` for the SHELL's key picker.
  * Dispatches chat (any chat-classified id in the pool) vs media (catalog
- * billing_mode). Bake-off passes no picker modality (dual sub-modality → user
- * owns the key).
+ * billing_mode). Bake-off passes its active image/video sub-modality, so
+ * the shell keeps the selected key aligned with the child mode.
  */
 export function groupServes(
   modality: PickerModality,
@@ -93,7 +94,7 @@ export interface ModalityKeyOption {
   id: number
   /** A key literally named "trial" is the historical default landing key. */
   isTrial: boolean
-  /** Model ids exposed by this key's group (its GET /v1/models pool). */
+  /** Model ids exposed by this key's group, or universal entitlement ids. */
   availableIds: ReadonlySet<string>
 }
 

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -480,7 +480,10 @@ const props = defineProps<{
   rateMultiplier: number
   catalogLoading?: boolean
 }>()
-const emit = defineEmits<{ (e: 'spent'): void }>()
+const emit = defineEmits<{
+  (e: 'spent'): void
+  (e: 'modality-change', modality: StudioModality): void
+}>()
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -535,6 +538,8 @@ const isBusy = computed(
 const activeRunTs = ref<number | null>(null)
 
 const library = useMediaLibrary(props.userId)
+
+watch(modality, (m) => emit('modality-change', m), { immediate: true })
 
 function tagVideoPlayback(taskId: string, url: string): void {
   void tagStudioVideoPlayback(playbackDeps, taskId, url)

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -149,6 +149,7 @@
         :rate-multiplier="1"
         :catalog-loading="mediaCatalogLoading"
         @spent="refreshBalance"
+        @modality-change="onBakeoffModalityChange"
       />
     </div>
   </AppLayout>
@@ -181,6 +182,7 @@ import {
   pickModalityKey,
   type ModalityKeyOption,
   type PickerModality,
+  type StudioModality,
   type MediaPrice,
   type MediaPriceMap,
 } from '@/constants/studioMediaPresentations.tk'
@@ -205,6 +207,7 @@ function initialView(): StudioView {
   return (VIEW_MODES as readonly string[]).includes(m) ? (m as StudioView) : 'chat'
 }
 const view = ref<StudioView>(initialView())
+const bakeoffModality = ref<StudioModality>('video')
 const keys = ref<ApiKey[]>([])
 const selectedKeyId = ref<number | null>(null)
 const gatewayBase = ref('')
@@ -212,6 +215,7 @@ const gatewayBase = ref('')
 // group up front so the picker (and the dropdown annotations) can reason about
 // EVERY key's modality, not just the one currently selected.
 const groupModelSets = ref<Map<string, Set<string>>>(new Map())
+const groupProbeReps = ref<Map<string, ApiKey>>(new Map())
 /** Cross-group entitlement index (me/pricing-catalog authorized_groups_by_model). */
 const userEntitledIds = ref<Set<string>>(new Set())
 const universalPriceMap = ref<MediaPriceMap>(new Map())
@@ -259,12 +263,11 @@ const availableIds = computed<Set<string>>(() =>
 
 const anyKeyServesVideo = computed(() => keys.value.some((k) => keyServesModality(k, 'video')))
 
-// The single modality the picker can optimize a key for. Bake-off has its OWN
-// internal image/video toggle, so no single key serves both of its sub-modes —
-// we leave its key selection to the user there (null = don't auto-pick / annotate).
-// Chat / image / video each map straight to a PickerModality.
+// The single modality the picker can optimize a key for. Bake-off has its own
+// internal image/video toggle, but the shell still owns key selection so the
+// selected key must track the active sub-modality.
 const pickerModality = computed<PickerModality | null>(() =>
-  view.value === 'bakeoff' ? null : view.value
+  view.value === 'bakeoff' ? bakeoffModality.value : view.value
 )
 
 function modalityOptions(): ModalityKeyOption[] {
@@ -352,10 +355,29 @@ function orderedGroupEntries(reps: Map<string, ApiKey>, priorityGk: string): [st
 
 let backgroundProbeGen = 0
 
+async function ensurePickerGroupProbes(): Promise<void> {
+  const missing = [...groupProbeReps.value.entries()].filter(([gk]) => !groupModelSets.value.has(gk))
+  if (missing.length === 0) return
+  modelsLoading.value = true
+  try {
+    await probeGroupEntries(missing)
+  } finally {
+    modelsLoading.value = false
+  }
+}
+
 function repickKeyForCurrentModality(): void {
   const m = pickerModality.value
   if (!m) return
   selectedKeyId.value = pickModalityKey(modalityOptions(), m, selectedKeyId.value, catalogBillingIndex.value)
+}
+
+async function onBakeoffModalityChange(modality: StudioModality): Promise<void> {
+  bakeoffModality.value = modality
+  if (!probed.value || view.value !== 'bakeoff') return
+  await ensurePickerGroupProbes()
+  selectedKeyId.value = pickModalityKey(modalityOptions(), modality, selectedKeyId.value, catalogBillingIndex.value)
+  if (selectedKeyId.value != null) await ensurePriceCatalog(selectedKeyId.value)
 }
 
 /** Finish probing groups the fast path skipped; refresh key annotations when done. */
@@ -414,8 +436,9 @@ watch(view, async (v) => {
   if (!probed.value) return
   const m = pickerModality.value
   if (!m) return
+  if (m === 'image' || m === 'video') await ensurePickerGroupProbes()
   selectedKeyId.value = pickModalityKey(modalityOptions(), m, selectedKeyId.value, catalogBillingIndex.value)
-  if (v === 'image' || v === 'video') {
+  if (v === 'image' || v === 'video' || v === 'bakeoff') {
     const id = selectedKeyId.value
     if (id != null) await ensurePriceCatalog(id)
   }
@@ -447,6 +470,7 @@ async function bootstrap(): Promise<void> {
     }
 
     const reps = groupRepresentatives(keys.value)
+    groupProbeReps.value = reps
     const seedGk = groupKeyOf(seedKey)
     const hasUniversal = keys.value.some(isUniversalKey)
     const landingView = view.value
@@ -494,13 +518,13 @@ async function bootstrap(): Promise<void> {
         modelsLoading.value = false
         return
       }
-      selectedKeyId.value = seed
+      selectedKeyId.value = pickModalityKey(modalityOptions(), bakeoffModality.value, seed, catalogBillingIndex.value)
       if (ordered.length > 1) {
         void finishBackgroundProbe(reps, new Set([seedGk]))
       } else {
         modelsLoading.value = false
       }
-      await ensurePriceCatalog(seed)
+      if (selectedKeyId.value != null) await ensurePriceCatalog(selectedKeyId.value)
       probed.value = true
       return
     }

--- a/frontend/src/views/user/studio/__tests__/MediaStudioView.spec.ts
+++ b/frontend/src/views/user/studio/__tests__/MediaStudioView.spec.ts
@@ -71,7 +71,18 @@ vi.mock('../VideoStudio.vue', () => ({
     </div>`,
   },
 }))
-vi.mock('../BakeOff.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('../BakeOff.vue', () => ({
+  default: {
+    name: 'BakeOff',
+    props: ['apiKey', 'catalogLoading', 'priceMap', 'availableIds', 'keyId'],
+    emits: ['modality-change', 'spent'],
+    template: `<div data-testid="bakeoff-stub">
+      <span data-testid="bakeoff-stub-key">{{ apiKey }}</span>
+      <button data-testid="bakeoff-stub-image" @click="$emit('modality-change', 'image')">image</button>
+      <button data-testid="bakeoff-stub-video" @click="$emit('modality-change', 'video')">video</button>
+    </div>`,
+  },
+}))
 
 const i18n = createI18n({
   legacy: false,
@@ -231,5 +242,57 @@ describe('MediaStudioView bootstrap', () => {
     })
     await flushPromises()
     expect(videoStudio.props('catalogLoading')).toBe(false)
+  })
+
+  it('switches BakeOff to an image-serving key when the child image mode is selected', async () => {
+    listKeys.mockResolvedValue({
+      items: [
+        { id: 1, name: 'trial', key: 'sk-chat', group: { id: 10, name: 'chat' } },
+        { id: 2, name: 'imagen', key: 'sk-image', group: { id: 16, name: 'Google-Vertex' } },
+      ],
+    })
+    gatewayListModels.mockImplementation((key: string) => {
+      if (key === 'sk-image') return Promise.resolve({ data: [{ id: 'imagen-4.0-generate-001' }] })
+      return Promise.resolve({ data: [{ id: 'gpt-5.1' }] })
+    })
+    getPublicPricing.mockResolvedValue({
+      data: [
+        {
+          model_id: 'imagen-4.0-generate-001',
+          pricing: { billing_mode: 'image', output_cost_per_image: 0.04 },
+        },
+      ],
+    })
+    getMePricingCatalog.mockImplementation((opts?: { apiKeyId?: number }) => {
+      if (opts?.apiKeyId === 2) {
+        return Promise.resolve({
+          authorized_groups_by_model: {},
+          models: [
+            {
+              model_id: 'imagen-4.0-generate-001',
+              billing_mode: 'image',
+              your_price: { currency: 'USD', per_image: 0.04 },
+            },
+          ],
+        })
+      }
+      return Promise.resolve({ authorized_groups_by_model: {}, models: [] })
+    })
+
+    const wrapper = mount(MediaStudioView, {
+      global: { plugins: [i18n], stubs: { 'router-link': true } },
+    })
+    await flushPromises()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="studio-mode-bakeoff"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="bakeoff-stub-key"]').text()).toBe('sk-chat')
+
+    await wrapper.find('[data-testid="bakeoff-stub-image"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="bakeoff-stub-key"]').text()).toBe('sk-image')
+    expect(getMePricingCatalog).toHaveBeenCalledWith({ apiKeyId: 2 })
   })
 })

--- a/ops/observability/probe-media-parity-postrelease.sh
+++ b/ops/observability/probe-media-parity-postrelease.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# probe-media-parity-postrelease.sh - focused paid direct-vs-universal media parity probe.
+#
+# Runs on prod via ops/observability/run-probe.sh. It reuses the canonical
+# source-group probe keys (__tk_probe_<platform>_srcgrp_<gid>_key) for direct
+# requests, then compares them with one existing universal key that is entitled
+# to both the Vertex and Grok prod groups. Keys are never printed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPANION="$SCRIPT_DIR/probe_reserved_resources.sh"
+if [ ! -f "$COMPANION" ]; then
+	COMPANION="$SCRIPT_DIR/../pricing/probe_reserved_resources.sh"
+fi
+if [ ! -f "$COMPANION" ]; then
+	echo "probe-media-parity: missing probe_reserved_resources.sh companion" >&2
+	exit 2
+fi
+# shellcheck source=../pricing/probe_reserved_resources.sh
+. "$COMPANION"
+
+PSQL_ARRAY=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
+PROD="${PROD_BASE:-https://api.tokenkey.dev}"
+RUN_ID="${RUN_ID:-media-parity-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+REQ_SLEEP="${REQ_SLEEP:-2}"
+
+VEO_GROUP_ID="${VEO_GROUP_ID:-16}"
+GROK_GROUP_ID="${GROK_GROUP_ID:-25}"
+VEO_MODEL="${VEO_MODEL:-veo-3.1-generate-001}"
+GROK_IMAGE_MODELS="${GROK_IMAGE_MODELS:-grok-imagine-image grok-imagine-image-quality}"
+GROK_VIDEO_MODEL="${GROK_VIDEO_MODEL:-grok-imagine-video}"
+
+TK_PROBE_PARITY_SCOPES=""
+
+psql_scalar() {
+	"${PSQL_ARRAY[@]}" -c "$1" | head -n1 | tr -d '\r'
+}
+
+psql_rows() {
+	"${PSQL_ARRAY[@]}" -c "$1" 2>&1
+}
+
+cleanup() {
+	local scope
+	for scope in $TK_PROBE_PARITY_SCOPES; do
+		[ -n "$scope" ] || continue
+		tk_probe_clear_bindings "$scope" >/dev/null 2>&1 || true # preflight-allow: probe cleanup best-effort
+	done
+	tk_probe_release_reuse_locks
+}
+trap cleanup EXIT
+
+copy_source_group_policy() { # $1=source_group_id
+	local source_group_id="$1"
+	[[ "$source_group_id" =~ ^[0-9]+$ ]] || return 0
+	if [[ ! "$TK_PROBE_GROUP_ID" =~ ^[0-9]+$ ]]; then
+		return 0
+	fi
+	tk_probe_psql -c "
+UPDATE groups dst
+SET
+  allow_messages_dispatch = src.allow_messages_dispatch,
+  messages_dispatch_model_config = src.messages_dispatch_model_config,
+  allow_image_generation = src.allow_image_generation,
+  updated_at = NOW()
+FROM groups src
+WHERE dst.id = ${TK_PROBE_GROUP_ID}
+  AND src.id = ${source_group_id}
+  AND src.deleted_at IS NULL;
+" >/dev/null 2>&1 || true # preflight-allow: policy copy is diagnostic-only
+	tk_probe_psql -c "
+UPDATE api_keys
+SET updated_at = NOW()
+WHERE group_id = ${TK_PROBE_GROUP_ID}
+  AND deleted_at IS NULL;
+" >/dev/null 2>&1 || true # preflight-allow: policy copy is diagnostic-only
+}
+
+prepare_direct_key() { # $1=label $2=platform $3=source_group_id
+	local label="$1" platform="$2" source_group_id="$3" requested_scope
+	requested_scope="${platform}_srcgrp_${source_group_id}"
+	if ! tk_probe_prepare_catalog "$requested_scope" "$platform" source_group_id "$source_group_id"; then
+		printf 'PREP\t%s\tplatform=%s\tsource_group_id=%s\tstatus=direct_pool_empty_or_config_error\n' "$label" "$platform" "$source_group_id"
+		return 1
+	fi
+	copy_source_group_policy "$source_group_id"
+	TK_PROBE_PARITY_SCOPES="${TK_PROBE_PARITY_SCOPES} ${TK_PROBE_SCOPE:-$requested_scope}"
+	printf 'PREP\t%s\tplatform=%s\tsource_group_id=%s\tprobe_scope=%s\tprobe_group_id=%s\tprobe_key_id=%s\tstatus=ready\n' \
+		"$label" "$platform" "$source_group_id" "${TK_PROBE_SCOPE:-$requested_scope}" "$TK_PROBE_GROUP_ID" "$TK_PROBE_KEY_ID"
+	return 0
+}
+
+select_universal_key() {
+	local wanted_id="${UNIVERSAL_KEY_ID:-}"
+	if [ -n "$wanted_id" ]; then
+		if [[ ! "$wanted_id" =~ ^[0-9]+$ ]]; then
+			echo "probe-media-parity: UNIVERSAL_KEY_ID must be numeric" >&2
+			return 1
+		fi
+		UNIVERSAL_KEY_ID="$wanted_id"
+	else
+		UNIVERSAL_KEY_ID="$(psql_scalar "
+SELECT COALESCE((
+  SELECT k.id::text
+  FROM api_keys k
+  WHERE k.routing_mode = 'universal'
+    AND k.status = 'active'
+    AND k.deleted_at IS NULL
+    AND EXISTS (
+      SELECT 1 FROM user_allowed_groups u
+      WHERE u.user_id = k.user_id AND u.group_id = ${VEO_GROUP_ID}
+    )
+    AND EXISTS (
+      SELECT 1 FROM user_allowed_groups u
+      WHERE u.user_id = k.user_id AND u.group_id = ${GROK_GROUP_ID}
+    )
+  ORDER BY CASE WHEN k.id = 5 THEN 0 ELSE 1 END, k.id
+  LIMIT 1
+), '');
+")"
+	fi
+	if [[ ! "${UNIVERSAL_KEY_ID:-}" =~ ^[0-9]+$ ]]; then
+		echo "probe-media-parity: no active universal key can access both source groups ${VEO_GROUP_ID}/${GROK_GROUP_ID}" >&2
+		return 1
+	fi
+	UNIVERSAL_KEY="$(psql_scalar "
+SELECT COALESCE((
+  SELECT key FROM api_keys
+  WHERE id = ${UNIVERSAL_KEY_ID}
+    AND routing_mode = 'universal'
+    AND status = 'active'
+    AND deleted_at IS NULL
+  LIMIT 1
+), '');
+")"
+	if [ -z "$UNIVERSAL_KEY" ]; then
+		echo "probe-media-parity: selected universal key id=${UNIVERSAL_KEY_ID} is not usable" >&2
+		return 1
+	fi
+	printf 'UNIVERSAL\tkey_id=%s\tstatus=ready\n' "$UNIVERSAL_KEY_ID"
+	psql_rows "
+SELECT row_to_json(t)
+FROM (
+  SELECT k.id AS key_id, k.user_id, k.name,
+         bool_or(u.group_id = ${VEO_GROUP_ID}) AS has_veo_group,
+         bool_or(u.group_id = ${GROK_GROUP_ID}) AS has_grok_group
+  FROM api_keys k
+  LEFT JOIN user_allowed_groups u ON u.user_id = k.user_id
+  WHERE k.id = ${UNIVERSAL_KEY_ID}
+    AND k.deleted_at IS NULL
+  GROUP BY k.id, k.user_id, k.name
+) t;
+"
+}
+
+body_image() {
+	local model="$1"
+	printf '{"model":"%s","prompt":"a small red circle on white","n":1,"size":"1024x1024"}' "$model"
+}
+
+body_video() {
+	local model="$1"
+	printf '{"model":"%s","prompt":"a small red ball rolling on a table","seconds":"4"}' "$model"
+}
+
+snippet() {
+	head -c 260 "$1" | tr '\r\n\t' '   ' | sed 's/[[:space:]]\+/ /g'
+}
+
+shape_for() { # $1=modality $2=http_code $3=bodyfile
+	local modality="$1" code="$2" bodyfile="$3"
+	if [ "$code" != "200" ]; then
+		echo "error"
+		return
+	fi
+	case "$modality" in
+	image)
+		if grep -q '"data"' "$bodyfile"; then echo "ok"; else echo "mismatch"; fi
+		;;
+	video)
+		if grep -Eq '"(id|task_id)"[[:space:]]*:' "$bodyfile"; then echo "ok"; else echo "mismatch"; fi
+		;;
+	*)
+		echo "unknown"
+		;;
+	esac
+}
+
+query_attribution() { # $1=label $2=key_id $3=model $4=path $5=started_at
+	local label="$1" key_id="$2" model="$3" path="$4" started_at="$5"
+	local emodel epath estart
+	emodel="$(tk_probe_sql_escape "$model")"
+	epath="$(tk_probe_sql_escape "$path")"
+	estart="$(tk_probe_sql_escape "$started_at")"
+	printf 'ATTR_BEGIN\t%s\n' "$label"
+	psql_rows "
+WITH recent AS (
+  SELECT 'usage'::text AS src, id, created_at, request_id, api_key_id, account_id, group_id,
+         model, requested_model, inbound_endpoint, upstream_endpoint,
+         NULL::text AS error_phase, NULL::text AS error_type,
+         NULL::int AS status_code, NULL::int AS upstream_status_code,
+         NULL::text AS error_owner, ''::text AS msg
+  FROM usage_logs
+  WHERE created_at >= '${estart}'::timestamptz - interval '5 seconds'
+    AND created_at <= clock_timestamp() + interval '5 seconds'
+    AND api_key_id = ${key_id}
+    AND (model = '${emodel}' OR requested_model = '${emodel}' OR upstream_model = '${emodel}')
+    AND (inbound_endpoint = '${epath}' OR inbound_endpoint ILIKE '%video%' OR inbound_endpoint ILIKE '%image%')
+  UNION ALL
+  SELECT 'error'::text AS src, id, created_at, COALESCE(NULLIF(request_id,''), NULLIF(client_request_id,''), '') AS request_id,
+         api_key_id, account_id, group_id, model, NULL::text AS requested_model,
+         inbound_endpoint, request_path AS upstream_endpoint, error_phase, error_type,
+         status_code, upstream_status_code, error_owner,
+         left(COALESCE(NULLIF(upstream_error_message,''), NULLIF(error_message,''), ''), 220) AS msg
+  FROM ops_error_logs
+  WHERE created_at >= '${estart}'::timestamptz - interval '5 seconds'
+    AND created_at <= clock_timestamp() + interval '5 seconds'
+    AND api_key_id = ${key_id}
+    AND model = '${emodel}'
+    AND (inbound_endpoint = '${epath}' OR request_path = '${epath}' OR inbound_endpoint ILIKE '%video%' OR request_path ILIKE '%video%' OR inbound_endpoint ILIKE '%image%' OR request_path ILIKE '%image%')
+)
+SELECT row_to_json(t)
+FROM (
+  SELECT src, id, created_at AT TIME ZONE 'UTC' AS ts_utc, request_id, api_key_id,
+         account_id, group_id, model, requested_model, inbound_endpoint, upstream_endpoint,
+         error_phase, error_type, status_code, upstream_status_code, error_owner, msg
+  FROM recent
+  ORDER BY created_at DESC, id DESC
+  LIMIT 4
+) t;
+"
+	printf 'ATTR_END\t%s\n' "$label"
+}
+
+attr_only() {
+	local since="$1" esince key_ids models_sql
+	esince="$(tk_probe_sql_escape "$since")"
+	if ! select_universal_key >/dev/null; then
+		exit 1
+	fi
+	key_ids="$(psql_scalar "
+SELECT COALESCE(string_agg(id::text, ',' ORDER BY id), '')
+FROM api_keys
+WHERE deleted_at IS NULL
+  AND (
+    id = ${UNIVERSAL_KEY_ID}
+    OR name IN ('__tk_probe_newapi_srcgrp_16_key', '__tk_probe_grok_srcgrp_25_key')
+  );
+")"
+	if [ -z "$key_ids" ]; then
+		echo "ATTR_ONLY no key ids found" >&2
+		exit 1
+	fi
+	models_sql="'$(tk_probe_sql_escape "$VEO_MODEL")','$(tk_probe_sql_escape "$GROK_VIDEO_MODEL")'"
+	local model
+	for model in $GROK_IMAGE_MODELS; do
+		models_sql="${models_sql},'$(tk_probe_sql_escape "$model")'"
+	done
+	printf 'ATTR_ONLY\tsince=%s\tkey_ids=%s\n' "$since" "$key_ids"
+	psql_rows "
+WITH recent AS (
+  SELECT 'usage'::text AS src, id, created_at, request_id, api_key_id, account_id, group_id,
+         model, requested_model, inbound_endpoint, upstream_endpoint,
+         NULL::text AS error_phase, NULL::text AS error_type,
+         NULL::int AS status_code, NULL::int AS upstream_status_code,
+         NULL::text AS error_owner, ''::text AS msg
+  FROM usage_logs
+  WHERE created_at >= '${esince}'::timestamptz - interval '10 seconds'
+    AND api_key_id IN (${key_ids})
+    AND (model IN (${models_sql}) OR requested_model IN (${models_sql}) OR upstream_model IN (${models_sql}))
+    AND (inbound_endpoint ILIKE '%video%' OR inbound_endpoint ILIKE '%image%')
+  UNION ALL
+  SELECT 'error'::text AS src, id, created_at, COALESCE(NULLIF(request_id,''), NULLIF(client_request_id,''), '') AS request_id,
+         api_key_id, account_id, group_id, model, NULL::text AS requested_model,
+         inbound_endpoint, request_path AS upstream_endpoint, error_phase, error_type,
+         status_code, upstream_status_code, error_owner,
+         left(COALESCE(NULLIF(upstream_error_message,''), NULLIF(error_message,''), ''), 260) AS msg
+  FROM ops_error_logs
+  WHERE created_at >= '${esince}'::timestamptz - interval '10 seconds'
+    AND api_key_id IN (${key_ids})
+    AND model IN (${models_sql})
+    AND (inbound_endpoint ILIKE '%video%' OR request_path ILIKE '%video%' OR inbound_endpoint ILIKE '%image%' OR request_path ILIKE '%image%')
+)
+SELECT row_to_json(t)
+FROM (
+  SELECT src, id, created_at AT TIME ZONE 'UTC' AS ts_utc, request_id, api_key_id,
+         account_id, group_id, model, requested_model, inbound_endpoint, upstream_endpoint,
+         error_phase, error_type, status_code, upstream_status_code, error_owner, msg
+  FROM recent
+  ORDER BY created_at DESC, id DESC
+  LIMIT 40
+) t;
+"
+}
+
+post_probe() { # $1=label $2=kind $3=key_id $4=key $5=modality $6=model $7=path $8=body
+	local label="$1" kind="$2" key_id="$3" key="$4" modality="$5" model="$6" path="$7" body="$8"
+	local started_at bodyfile code shape task_id
+	started_at="$(psql_scalar "SELECT clock_timestamp();")"
+	bodyfile="$(mktemp)"
+	code="$(curl -sS -o "$bodyfile" -w '%{http_code}' -m 120 -X POST "$PROD$path" \
+		-H "Authorization: Bearer $key" \
+		-H 'content-type: application/json' \
+		-H "x-tokenkey-probe-run: $RUN_ID" \
+		--data-binary "$body" 2>/dev/null || printf '000')"
+	shape="$(shape_for "$modality" "$code" "$bodyfile")"
+	task_id="$(sed -n 's/.*"\(task_id\|id\)"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\2/p' "$bodyfile" | head -n1)"
+	printf 'RESULT\t%s\tkind=%s\tkey_id=%s\tmodality=%s\tmodel=%s\tpath=%s\thttp=%s\tshape=%s\ttask_id=%s\tsnippet=%s\n' \
+		"$label" "$kind" "$key_id" "$modality" "$model" "$path" "$code" "$shape" "${task_id:-}" "$(snippet "$bodyfile")"
+	rm -f "$bodyfile"
+	sleep "$REQ_SLEEP"
+	query_attribution "$label" "$key_id" "$model" "$path" "$started_at"
+}
+
+main() {
+	if [ -n "${ATTR_ONLY_SINCE:-}" ]; then
+		attr_only "$ATTR_ONLY_SINCE"
+		return 0
+	fi
+
+	echo "RUN	run_id=${RUN_ID}	base=${PROD}"
+	if ! select_universal_key; then
+		exit 1
+	fi
+
+	if prepare_direct_key veo newapi "$VEO_GROUP_ID"; then
+		VEO_DIRECT_KEY="$TK_PROBE_KEY"
+		VEO_DIRECT_KEY_ID="$TK_PROBE_KEY_ID"
+		post_probe direct_veo direct "$VEO_DIRECT_KEY_ID" "$VEO_DIRECT_KEY" video "$VEO_MODEL" /v1/video/generations "$(body_video "$VEO_MODEL")"
+		post_probe universal_veo universal "$UNIVERSAL_KEY_ID" "$UNIVERSAL_KEY" video "$VEO_MODEL" /v1/video/generations "$(body_video "$VEO_MODEL")"
+	fi
+
+	if prepare_direct_key grok grok "$GROK_GROUP_ID"; then
+		GROK_DIRECT_KEY="$TK_PROBE_KEY"
+		GROK_DIRECT_KEY_ID="$TK_PROBE_KEY_ID"
+		local model
+		for model in $GROK_IMAGE_MODELS; do
+			post_probe "direct_${model}" direct "$GROK_DIRECT_KEY_ID" "$GROK_DIRECT_KEY" image "$model" /v1/images/generations "$(body_image "$model")"
+			post_probe "universal_${model}" universal "$UNIVERSAL_KEY_ID" "$UNIVERSAL_KEY" image "$model" /v1/images/generations "$(body_image "$model")"
+		done
+		post_probe direct_grok_video direct "$GROK_DIRECT_KEY_ID" "$GROK_DIRECT_KEY" video "$GROK_VIDEO_MODEL" /v1/video/generations "$(body_video "$GROK_VIDEO_MODEL")"
+		post_probe universal_grok_video universal "$UNIVERSAL_KEY_ID" "$UNIVERSAL_KEY" video "$GROK_VIDEO_MODEL" /v1/video/generations "$(body_video "$GROK_VIDEO_MODEL")"
+	fi
+}
+
+main

--- a/ops/observability/probe-media-parity-postrelease.sh
+++ b/ops/observability/probe-media-parity-postrelease.sh
@@ -29,6 +29,7 @@ GROK_GROUP_ID="${GROK_GROUP_ID:-25}"
 VEO_MODEL="${VEO_MODEL:-veo-3.1-generate-001}"
 GROK_IMAGE_MODELS="${GROK_IMAGE_MODELS:-grok-imagine-image grok-imagine-image-quality}"
 GROK_VIDEO_MODEL="${GROK_VIDEO_MODEL:-grok-imagine-video}"
+GROK_VIDEO_PATHS="${GROK_VIDEO_PATHS:-/v1/video/generations /v1/videos/generations}"
 
 TK_PROBE_PARITY_SCOPES=""
 
@@ -165,6 +166,13 @@ body_video() {
 
 snippet() {
 	head -c 260 "$1" | tr '\r\n\t' '   ' | sed 's/[[:space:]]\+/ /g'
+}
+
+path_label() {
+	local path="${1#/}"
+	path="${path//\//_}"
+	path="${path//-/_}"
+	printf '%s' "$path"
 }
 
 shape_for() { # $1=modality $2=http_code $3=bodyfile
@@ -338,8 +346,12 @@ main() {
 			post_probe "direct_${model}" direct "$GROK_DIRECT_KEY_ID" "$GROK_DIRECT_KEY" image "$model" /v1/images/generations "$(body_image "$model")"
 			post_probe "universal_${model}" universal "$UNIVERSAL_KEY_ID" "$UNIVERSAL_KEY" image "$model" /v1/images/generations "$(body_image "$model")"
 		done
-		post_probe direct_grok_video direct "$GROK_DIRECT_KEY_ID" "$GROK_DIRECT_KEY" video "$GROK_VIDEO_MODEL" /v1/video/generations "$(body_video "$GROK_VIDEO_MODEL")"
-		post_probe universal_grok_video universal "$UNIVERSAL_KEY_ID" "$UNIVERSAL_KEY" video "$GROK_VIDEO_MODEL" /v1/video/generations "$(body_video "$GROK_VIDEO_MODEL")"
+		local path suffix
+		for path in $GROK_VIDEO_PATHS; do
+			suffix="$(path_label "$path")"
+			post_probe "direct_grok_video_${suffix}" direct "$GROK_DIRECT_KEY_ID" "$GROK_DIRECT_KEY" video "$GROK_VIDEO_MODEL" "$path" "$(body_video "$GROK_VIDEO_MODEL")"
+			post_probe "universal_grok_video_${suffix}" universal "$UNIVERSAL_KEY_ID" "$UNIVERSAL_KEY" video "$GROK_VIDEO_MODEL" "$path" "$(body_video "$GROK_VIDEO_MODEL")"
+		done
 	fi
 }
 

--- a/ops/observability/probe-studio-imagen-no-platform.sh
+++ b/ops/observability/probe-studio-imagen-no-platform.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# probe-studio-imagen-no-platform.sh - read-only triage for Studio image
+# "No platform in your plan can serve model ..." errors.
+#
+# Runs inside prod/edge via ops/observability/run-probe.sh. Outputs row_to_json
+# rows and never prints API key secrets or request bodies.
+set -u
+
+PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+WINDOW_HOURS="${WINDOW_HOURS:-168}"
+LIMIT="${LIMIT:-40}"
+MODEL="${MODEL:-imagen-4.0-generate-001}"
+
+validate_int() {
+  local name="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9]*) echo "bad ${name} (want positive integer)" >&2; exit 2 ;;
+  esac
+  if [ "$value" -le 0 ]; then
+    echo "bad ${name} (want positive integer)" >&2
+    exit 2
+  fi
+}
+
+sql_quote() {
+  local escaped
+  escaped=$(printf '%s' "$1" | sed "s/'/''/g")
+  printf "'%s'" "$escaped"
+}
+
+validate_int WINDOW_HOURS "$WINDOW_HOURS"
+validate_int LIMIT "$LIMIT"
+if [ "$LIMIT" -gt 200 ]; then
+  echo "bad LIMIT (max 200 to keep SSM stdout bounded)" >&2
+  exit 2
+fi
+if [ "${#MODEL}" -gt 256 ] || [[ "$MODEL" =~ [[:cntrl:]] ]]; then
+  echo "bad MODEL" >&2
+  exit 2
+fi
+
+Q_MODEL=$(sql_quote "$MODEL")
+
+BASE_CTE="WITH bounds AS (
+  SELECT now() - interval '${WINDOW_HOURS} hours' AS since,
+         now() AS until
+), base AS (
+  SELECT l.*
+  FROM ops_error_logs l, bounds b
+  WHERE l.created_at >= b.since
+    AND l.created_at < b.until
+    AND (
+      l.model = ${Q_MODEL}
+      OR l.requested_model = ${Q_MODEL}
+      OR l.upstream_model = ${Q_MODEL}
+      OR l.error_message ILIKE '%' || ${Q_MODEL} || '%'
+      OR l.upstream_error_message ILIKE '%' || ${Q_MODEL} || '%'
+    )
+)"
+
+echo "=== meta ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  now() AT TIME ZONE 'UTC' AS now_utc,
+  now() AT TIME ZONE 'Asia/Shanghai' AS now_cst,
+  ${WINDOW_HOURS}::int AS window_hours,
+  ${LIMIT}::int AS limit_rows,
+  ${Q_MODEL}::text AS model_filter) t;" 2>&1
+
+echo
+echo "=== imagen summary ==="
+$PSQL -c "${BASE_CTE}
+SELECT row_to_json(t) FROM (SELECT
+  count(*) AS rows,
+  min(created_at) AT TIME ZONE 'UTC' AS first_at_utc,
+  max(created_at) AT TIME ZONE 'UTC' AS last_at_utc,
+  count(*) FILTER (WHERE error_message ILIKE '%No platform in your plan can serve%') AS no_platform_rows,
+  count(DISTINCT user_id) FILTER (WHERE user_id IS NOT NULL) AS users,
+  count(DISTINCT api_key_id) FILTER (WHERE api_key_id IS NOT NULL) AS api_keys
+  FROM base) t;" 2>&1
+
+echo
+echo "=== imagen by key/error ==="
+$PSQL -c "${BASE_CTE}
+SELECT row_to_json(t) FROM (SELECT
+  l.user_id,
+  l.api_key_id,
+  k.name AS key_name,
+  k.routing_mode,
+  k.group_id AS key_group_id,
+  l.group_id AS error_group_id,
+  l.request_path,
+  l.inbound_endpoint,
+  l.status_code,
+  l.error_phase,
+  l.error_type,
+  left(COALESCE(NULLIF(l.error_message, ''), NULLIF(l.upstream_error_message, ''), ''), 220) AS msg,
+  count(*) AS rows,
+  min(l.created_at) AT TIME ZONE 'UTC' AS first_at_utc,
+  max(l.created_at) AT TIME ZONE 'UTC' AS last_at_utc
+  FROM base l
+  LEFT JOIN api_keys k ON k.id = l.api_key_id AND k.deleted_at IS NULL
+  GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12
+  ORDER BY rows DESC, last_at_utc DESC
+  LIMIT 30) t;" 2>&1
+
+echo
+echo "=== imagen samples ==="
+$PSQL -c "${BASE_CTE}
+SELECT row_to_json(t) FROM (SELECT
+  l.id,
+  l.created_at AT TIME ZONE 'UTC' AS ts_utc,
+  l.created_at AT TIME ZONE 'Asia/Shanghai' AS ts_cst,
+  COALESCE(NULLIF(l.request_id, ''), NULLIF(l.client_request_id, ''), '') AS request_id,
+  l.user_id,
+  l.api_key_id,
+  k.name AS key_name,
+  k.routing_mode,
+  k.group_id AS key_group_id,
+  l.group_id AS error_group_id,
+  l.account_id,
+  l.model,
+  l.requested_model,
+  l.upstream_model,
+  l.request_path,
+  l.inbound_endpoint,
+  l.status_code,
+  l.error_phase,
+  l.error_type,
+  l.error_owner,
+  left(COALESCE(NULLIF(l.error_message, ''), NULLIF(l.upstream_error_message, ''), ''), 260) AS msg
+  FROM base l
+  LEFT JOIN api_keys k ON k.id = l.api_key_id AND k.deleted_at IS NULL
+  ORDER BY l.created_at DESC, l.id DESC
+  LIMIT ${LIMIT}) t;" 2>&1
+
+echo
+echo "=== no-platform any model ==="
+$PSQL -c "WITH bounds AS (
+  SELECT now() - interval '${WINDOW_HOURS} hours' AS since,
+         now() AS until
+), base AS (
+  SELECT l.*
+  FROM ops_error_logs l, bounds b
+  WHERE l.created_at >= b.since
+    AND l.created_at < b.until
+    AND l.error_message ILIKE '%No platform in your plan can serve%'
+)
+SELECT row_to_json(t) FROM (SELECT
+  COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), NULLIF(upstream_model, ''), '<missing>') AS model,
+  request_path,
+  inbound_endpoint,
+  status_code,
+  count(*) AS rows,
+  min(created_at) AT TIME ZONE 'UTC' AS first_at_utc,
+  max(created_at) AT TIME ZONE 'UTC' AS last_at_utc,
+  left(max(error_message), 220) AS sample_msg
+  FROM base
+  GROUP BY 1,2,3,4
+  ORDER BY rows DESC, last_at_utc DESC
+  LIMIT 40) t;" 2>&1
+
+echo
+echo "=== entitled newapi image groups for affected users ==="
+$PSQL -c "${BASE_CTE}, users AS (
+  SELECT DISTINCT user_id FROM base WHERE user_id IS NOT NULL
+), entitled AS (
+  SELECT DISTINCT u.user_id, g.id AS group_id, g.name AS group_name, g.platform,
+         g.status AS group_status, g.allow_image_generation, g.sort_order
+  FROM users u
+  JOIN user_allowed_groups uag ON uag.user_id = u.user_id
+  JOIN groups g ON g.id = uag.group_id
+  WHERE g.deleted_at IS NULL
+    AND g.platform = 'newapi'
+)
+SELECT row_to_json(t) FROM (SELECT
+  e.user_id,
+  e.group_id,
+  e.group_name,
+  e.group_status,
+  e.allow_image_generation,
+  e.sort_order,
+  count(a.id) FILTER (WHERE a.id IS NOT NULL) AS bound_accounts,
+  count(a.id) FILTER (
+    WHERE a.status = 'active'
+      AND a.schedulable = true
+      AND (a.expires_at IS NULL OR a.expires_at > now())
+      AND (a.overload_until IS NULL OR a.overload_until <= now())
+      AND (a.rate_limit_reset_at IS NULL OR a.rate_limit_reset_at <= now())
+      AND (a.temp_unschedulable_until IS NULL OR a.temp_unschedulable_until <= now())
+  ) AS repo_schedulable_like_accounts,
+  count(a.id) FILTER (WHERE a.credentials->'model_mapping' ? ${Q_MODEL}) AS mapping_exact_accounts,
+  string_agg(
+    DISTINCT concat(
+      a.id::text, ':', COALESCE(a.name, ''), ':ct=', COALESCE(a.channel_type::text, ''),
+      ':type=', COALESCE(a.type, ''),
+      ':active=', (a.status = 'active')::text,
+      ':sched=', COALESCE(a.schedulable::text, ''),
+      ':maps=', COALESCE((a.credentials->'model_mapping' ? ${Q_MODEL})::text, 'false')
+    ),
+    ', ' ORDER BY concat(
+      a.id::text, ':', COALESCE(a.name, ''), ':ct=', COALESCE(a.channel_type::text, ''),
+      ':type=', COALESCE(a.type, ''),
+      ':active=', (a.status = 'active')::text,
+      ':sched=', COALESCE(a.schedulable::text, ''),
+      ':maps=', COALESCE((a.credentials->'model_mapping' ? ${Q_MODEL})::text, 'false')
+    )
+  ) FILTER (WHERE a.id IS NOT NULL) AS account_samples
+  FROM entitled e
+  LEFT JOIN account_groups ag ON ag.group_id = e.group_id
+  LEFT JOIN accounts a ON a.id = ag.account_id AND a.deleted_at IS NULL AND a.platform = e.platform
+  GROUP BY 1,2,3,4,5,6
+  ORDER BY e.sort_order, e.group_id
+  LIMIT 60) t;" 2>&1

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3496,7 +3496,7 @@
         "filterGroupsAllowImageGeneration",
         "supportProvider groupModelSupportProvider",
         "supportProvider(ctx, &gid, eligible[i].Platform, model, shape)",
-        "else if hint := universalModelPlatformHint(model); hint != \"\"",
+        "else if hint := universalRequestPlatformHint(shape, model); hint != \"\"",
         "收敛为空且模型有平台 hint → ErrUniversalNoEntitledGroup(403)"
       ],
       "rationale": "Universal Key (全能 Key) per-request resolver: maps a routing_mode=universal key to a concrete backing group from the owner's live entitlement span (GetAvailableGroups, short-TTL cached), filtered by endpoint-shape candidate platforms, with deterministic pick (subscription-held -> sort_order -> id). docs/approved/universal-key-routing.md §4.3. Dropping this file disables universal-key routing entirely (every universal key would fall through with a nil group). Pins the constructor, Resolve entrypoint, the no-entitled-group sentinel error, and the deterministic picker. Load-bearing P0 gate (prod 2026-07-01 user16 universal key #245): when groupServesModel filters eligible to empty AND the model has a platform hint, Resolve must return ErrUniversalNoEntitledGroup (middleware 403) — NOT fall back to a wrong openai-compat group and surface routing-phase 429 No available accounts (routing_capacity_rejection storm). Universal/direct-key parity now depends on the direct-scheduler supportProvider branch running before the GetAvailableModels fallback; losing that branch silently reverts OpenAI passthrough, wildcard, Anthropic alias, and Antigravity default-mapping parity. An upstream merge that restores the old served-empty fallback or drops supportProvider silently re-opens the amplifier; the hint branch plus supportProvider call are the mechanical anchors."
@@ -3511,7 +3511,8 @@
         "acc.IsOpenAICompatPoolMember(platform)",
         "universalOpenAICompatAccountSupportsShape",
         "accountSupportsOpenAIRequestCapabilities(account, \"\", \"\", true)",
-        "s.isModelSupportedByAccount(acc, model)",
+        "universalOpenAICompatAccountSupportsModel(ctx, s, acc, model, shape)",
+        "s.isModelSupportedByAccountWithContext(ctx, account, model)",
         "s.isModelSupportedByAccountWithContext(ctx, acc, model)",
         "modelInServedSet(model string, served []string, platform string)",
         "normalizeRequestedModelForLookup(platform, model)"


### PR DESCRIPTION
## 摘要

- 修复 Studio BakeOff / Media Studio 的 media key 路由与展示对齐问题。
- 恢复 Grok 视频生成路由，并扩展 parity probe 覆盖 Grok video alias。
- 启用 scheme 1 发版 direct-push（`release-configure-main-bypass.sh` + route 探测），bump 路由失败时 fail-closed，不再静默回退 direct-push。

## 风险

- Studio / Grok media 路由变更影响 `/studio` 与 Grok 视频网关路径；需 smoke 确认 BakeOff 与 Grok video alias。
- 发版脚本行为变更：route 探测失败将中止 bump（exit 2）；已配置 bypass 的环境仍走 direct-push。
- 本 PR 含 release 工具链变更，与 Studio 修复同分支；合并前确认发版脚本改动符合预期。

## 验证

- `python3 scripts/test_release_main_push_route.py -v` — 5 passed
- `python3 scripts/test_release_bump_and_tag.py -v` — 2 passed
- `./scripts/preflight.sh` — PASS（含 release 脚本语法与 route 单测）
- `bash scripts/release-configure-main-bypass.sh --check` — direct-push 路由（本机 gh 已配置时）
- Studio / Grok 行为：待 PR CI 全绿；合并前建议手动点验 BakeOff media picker

## 提交

- `01c9fc0bc` fix(release): fail closed when main bump route lookup fails
- `611de1c19` chore(release): enable direct-push VERSION bumps via scheme 1 bypass
- `784695721` fix(ops): cover grok video aliases in parity probe
- `296303bae` docs(ops): update endpoint media baseline
- `61d422523` fix(grok): restore media generation routing
- `dd1cd343f` fix(studio): align bakeoff media routing

最新提交：01c9fc0bc
