### PR TITLE
refactor(arch): SSOT + upstream isolation closeout

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -80,6 +80,7 @@ const (
 	SubscriptionStatusActive    = "active"
 	SubscriptionStatusExpired   = "expired"
 	SubscriptionStatusSuspended = "suspended"
+	SubscriptionStatusRevoked   = "revoked"
 )
 
 // DefaultAntigravityModelMapping 是 Antigravity 平台的默认模型映射

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -110,7 +110,7 @@ const (
 	SubscriptionStatusExpired   = domain.SubscriptionStatusExpired
 	SubscriptionStatusSuspended = domain.SubscriptionStatusSuspended
 	// SubscriptionStatusRevoked 是 soft-deleted 订阅的 API 展示态，不写入 status 字段。
-	SubscriptionStatusRevoked = "revoked"
+	SubscriptionStatusRevoked = domain.SubscriptionStatusRevoked
 )
 
 // TokenKey bridge setting keys

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -577,54 +577,6 @@ type sseStreamErrorEventError struct {
 }
 
 func (e *sseStreamErrorEventError) Error() string { return "have error in stream" }
-
-// sseStreamErrorFailover 把「上游 HTTP 200 + SSE 流体内 event:error 帧」转成一个
-// failover 错误，并补全 ops 上下文。
-//
-// TK: 返回 502（Bad Gateway）而非 403。mid-stream 上游挂掉的语义是「上游服务不可用」，
-// 不是 Forbidden —— 用 403 会把它塞进 handle403 的「封号 / WAF / 额度」判定空间
-// (#810/#831/#832)，并曾与 failover_loop 对 empty-body 403 的 fast-fail 相撞
-// (commit c7785a7e)。502 与 stream-read-error 路径一致、走 TempUnscheduleRetryableError
-// 的 empty-response 钩子。上游新增的类型化检测 + ops 日志 + ResponseBody 一并保留。
-func (s *GatewayService) sseStreamErrorFailover(c *gin.Context, account *Account, resp *http.Response, sseErr *sseStreamErrorEventError) error {
-	body := []byte(sseErr.RawData)
-
-	upstreamMsg := sanitizeUpstreamErrorMessage(
-		strings.TrimSpace(extractUpstreamErrorMessage(body)),
-	)
-
-	upstreamDetail := ""
-	if s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody {
-		maxBytes := s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes
-		if maxBytes <= 0 {
-			maxBytes = 2048
-		}
-		upstreamDetail = truncateString(sseErr.RawData, maxBytes)
-	}
-
-	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-		Platform:           account.Platform,
-		AccountID:          account.ID,
-		AccountName:        account.Name,
-		UpstreamStatusCode: http.StatusBadGateway,
-		UpstreamRequestID:  resp.Header.Get("x-request-id"),
-		Kind:               "stream_error",
-		Message:            upstreamMsg,
-		Detail:             upstreamDetail,
-	})
-
-	logger.LegacyPrintf("service.gateway",
-		"[Forward] SSE error event in stream: Account=%d(%s) RequestID=%s Body=%s",
-		account.ID, account.Name, resp.Header.Get("x-request-id"),
-		truncateString(sseErr.RawData, 1000),
-	)
-
-	return &UpstreamFailoverError{
-		StatusCode:   http.StatusBadGateway,
-		ResponseBody: body,
-	}
-}
-
 // TempUnscheduleRetryableError 对 RetryableOnSameAccount 类型的 failover 错误触发临时封禁。
 // 由 handler 层在同账号重试全部用尽、切换账号时调用。
 //

--- a/backend/internal/service/gateway_service_tk_sse_stream_failover.go
+++ b/backend/internal/service/gateway_service_tk_sse_stream_failover.go
@@ -1,0 +1,58 @@
+package service
+
+// TK-only SSE stream error failover: maps mid-stream event:error frames to 502 failover errors.
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/gin-gonic/gin"
+)
+
+// sseStreamErrorFailover 把「上游 HTTP 200 + SSE 流体内 event:error 帧」转成一个
+// failover 错误，并补全 ops 上下文。
+//
+// TK: 返回 502（Bad Gateway）而非 403。mid-stream 上游挂掉的语义是「上游服务不可用」，
+// 不是 Forbidden —— 用 403 会把它塞进 handle403 的「封号 / WAF / 额度」判定空间
+// (#810/#831/#832)，并曾与 failover_loop 对 empty-body 403 的 fast-fail 相撞
+// (commit c7785a7e)。502 与 stream-read-error 路径一致、走 TempUnscheduleRetryableError
+// 的 empty-response 钩子。上游新增的类型化检测 + ops 日志 + ResponseBody 一并保留。
+func (s *GatewayService) sseStreamErrorFailover(c *gin.Context, account *Account, resp *http.Response, sseErr *sseStreamErrorEventError) error {
+	body := []byte(sseErr.RawData)
+
+	upstreamMsg := sanitizeUpstreamErrorMessage(
+		strings.TrimSpace(extractUpstreamErrorMessage(body)),
+	)
+
+	upstreamDetail := ""
+	if s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody {
+		maxBytes := s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes
+		if maxBytes <= 0 {
+			maxBytes = 2048
+		}
+		upstreamDetail = truncateString(sseErr.RawData, maxBytes)
+	}
+
+	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+		Platform:           account.Platform,
+		AccountID:          account.ID,
+		AccountName:        account.Name,
+		UpstreamStatusCode: http.StatusBadGateway,
+		UpstreamRequestID:  resp.Header.Get("x-request-id"),
+		Kind:               "stream_error",
+		Message:            upstreamMsg,
+		Detail:             upstreamDetail,
+	})
+
+	logger.LegacyPrintf("service.gateway",
+		"[Forward] SSE error event in stream: Account=%d(%s) RequestID=%s Body=%s",
+		account.ID, account.Name, resp.Header.Get("x-request-id"),
+		truncateString(sseErr.RawData, 1000),
+	)
+
+	return &UpstreamFailoverError{
+		StatusCode:   http.StatusBadGateway,
+		ResponseBody: body,
+	}
+}

--- a/scripts/checks/platform-registry-drift.py
+++ b/scripts/checks/platform-registry-drift.py
@@ -3,7 +3,7 @@
 
 The platform registry is written by hand on BOTH sides of the wire and the
 comments merely *ask* for lockstep. This check makes the ask mechanical.
-Three mirrored pairs, backend Go is the single source of truth:
+Five mirrored pairs, backend Go is the single source of truth:
 
   1. OpenAI-compat platforms
        backend/internal/engine/provider.go        OpenAICompatPlatforms()
@@ -29,6 +29,20 @@ Three mirrored pairs, backend Go is the single source of truth:
        - frontend-only value → the union advertises a platform the backend
          rejects, so typed forms/filters can emit an invalid value.
 
+  4. Ent schema platform enum coverage
+       backend/internal/engine/provider.go        AllSchedulingPlatforms()
+       backend/ent/schema/account.go              field.String("platform")
+     The ent schema does NOT use a Values() enum constraint — the platform
+     field is a free string. This check is therefore informational: it
+     verifies the field exists (it would be a hard error if the schema
+     regressed to a constrained enum that omitted a scheduling platform).
+
+  5. Frontend style mapping coverage
+       backend/internal/engine/provider.go        AllSchedulingPlatforms()
+       frontend/src/constants/gatewayPlatforms.ts SOFT_BADGE + LABEL_TEXT
+     A platform missing from the style maps renders as unstyled (gray
+     fallback) in the admin UI — easy to miss in review.
+
 Go constant names (`domain.PlatformX` / service aliases `PlatformX`) are
 resolved to their string values from constants.go, so the comparison is on
 wire values, not identifiers. All parsers tolerate gofmt / prettier
@@ -42,7 +56,7 @@ silently pass.
 Exit codes
 ----------
 
-  0 — all three pairs agree
+  0 — all five pairs agree
   1 — drift detected (details on stderr, both sides' file:line + sets)
   2 — parse / environment failure
 
@@ -63,6 +77,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DOMAIN_CONSTANTS = "backend/internal/domain/constants.go"
 ENGINE_PROVIDER = "backend/internal/engine/provider.go"
 DISPATCH_PREDICATE = "backend/internal/service/openai_messages_dispatch_tk_newapi.go"
+ENT_SCHEMA_ACCOUNT = "backend/ent/schema/account.go"
 TS_GATEWAY_PLATFORMS = "frontend/src/constants/gatewayPlatforms.ts"
 TS_TYPES_INDEX = "frontend/src/types/index.ts"
 
@@ -234,6 +249,108 @@ def parse_ts_union(text: str, name: str, rel: str) -> tuple[list[str], int]:
     return values, line
 
 
+def parse_go_all_scheduling(
+    text: str, consts: dict[str, tuple[str, int]]
+) -> tuple[list[str], int]:
+    """AllSchedulingPlatforms() []string { return []string{...} } → values."""
+    m = re.search(r"func\s+AllSchedulingPlatforms\s*\(\s*\)\s*\[\]string\s*\{", text)
+    if not m:
+        raise ParseFailure(
+            f"{ENGINE_PROVIDER}: `func AllSchedulingPlatforms() []string` not found — "
+            "renamed/moved? Update platform-registry-drift.py."
+        )
+    line = line_of(text, m.start())
+    slice_m = re.compile(r"return\s+\[\]string\s*\{([^{}]*)\}", re.S).search(text, m.end())
+    if not slice_m:
+        raise ParseFailure(
+            f"{ENGINE_PROVIDER}:{line}: AllSchedulingPlatforms body has no "
+            "`return []string{{...}}` literal"
+        )
+    tokens = re.findall(GO_MEMBER_RE, slice_m.group(1))
+    if not tokens:
+        raise ParseFailure(
+            f"{ENGINE_PROVIDER}:{line}: AllSchedulingPlatforms slice literal parsed empty"
+        )
+    return resolve_go_idents(tokens, consts, f"{ENGINE_PROVIDER}:{line}"), line
+
+
+def parse_ent_platform_field(text: str) -> tuple[list[str] | None, int]:
+    """Parse ent schema account.go for the platform field definition.
+
+    Returns (enum_values, line) where enum_values is:
+      - a list of string values if the field uses .Values("a","b",...) constraint
+      - None if the field is a free string (no Values() enum)
+
+    Raises ParseFailure if the platform field is not found at all.
+    """
+    m = re.search(r'field\.String\(\s*"platform"\s*\)', text)
+    if not m:
+        raise ParseFailure(
+            f"{ENT_SCHEMA_ACCOUNT}: `field.String(\"platform\")` not found — "
+            "platform field removed or renamed? Update platform-registry-drift.py."
+        )
+    line = line_of(text, m.start())
+
+    # Look for a .Values(...) call chained on the same field builder.
+    # The field builder ends at a comma or closing paren at the same indent.
+    # Scan forward from the field.String("platform") match until we hit the next
+    # field.* definition or the end of the Fields() return block.
+    next_field = re.search(r"field\.\w+\(", text[m.end() :])
+    scope_end = m.end() + next_field.start() if next_field else len(text)
+    field_chain = text[m.end() : scope_end]
+
+    values_m = re.search(r"\.Values\s*\(([^)]*)\)", field_chain)
+    if not values_m:
+        return None, line
+
+    values = [
+        a or b
+        for a, b in re.findall(r'"([^"]*)"|`([^`]*)`', values_m.group(1))
+    ]
+    if not values:
+        raise ParseFailure(
+            f"{ENT_SCHEMA_ACCOUNT}:{line}: platform field has .Values() but "
+            "the values list parsed empty"
+        )
+    return values, line
+
+
+def parse_ts_record_keys(text: str, name: str, rel: str) -> tuple[list[str], int]:
+    """const NAME: Record<...> = { key1: ..., key2: ..., } → keys.
+
+    Parses both `Record<string, string>` and `Record<SomeType, string>` shapes.
+    Tolerates multiline objects and trailing commas.
+    """
+    m = re.search(rf"(?:export\s+)?const\s+{name}\b[^=]*=\s*\{{", text)
+    if not m:
+        raise ParseFailure(
+            f"{rel}: `const {name}` with object literal not found — "
+            "renamed/moved? Update platform-registry-drift.py."
+        )
+    line = line_of(text, m.start())
+
+    # Find the matching closing brace (simple: no nested objects expected in
+    # Tailwind class string maps).
+    depth = 1
+    pos = m.end()
+    while pos < len(text) and depth > 0:
+        if text[pos] == "{":
+            depth += 1
+        elif text[pos] == "}":
+            depth -= 1
+        pos += 1
+    if depth != 0:
+        raise ParseFailure(f"{rel}:{line}: {name} object literal is not closed")
+
+    body = text[m.end() : pos - 1]
+    # Keys can be bare identifiers or quoted strings.
+    keys = re.findall(r"(?:^|,)\s*(?:'([^']*)'|\"([^\"]*)\"|([\w]+))\s*:", body)
+    values = [a or b or c for a, b, c in keys]
+    if not values:
+        raise ParseFailure(f"{rel}:{line}: {name} object literal has no keys")
+    return values, line
+
+
 def fmt_set(values: list[str]) -> str:
     return "[" + ", ".join(sorted(set(values))) + "]"
 
@@ -264,12 +381,32 @@ def compare_pair(
     return lines
 
 
+def compare_superset(
+    label: str,
+    required: list[str],
+    required_loc: str,
+    actual: list[str],
+    actual_loc: str,
+) -> list[str]:
+    """Return failure lines when `actual` is not a superset of `required`."""
+    missing = sorted(set(required) - set(actual))
+    if not missing:
+        return []
+    return [
+        f"FAIL: {label} — missing required values",
+        f"  required {required_loc}  {fmt_set(required)}",
+        f"  actual   {actual_loc}  {fmt_set(actual)}",
+        f"  missing: {', '.join(missing)}",
+    ]
+
+
 def run(root: Path) -> tuple[list[list[str]], list[str]]:
     """Returns (failures, ok_lines)."""
     consts = parse_domain_constants(read(root, DOMAIN_CONSTANTS))
 
     engine_text = read(root, ENGINE_PROVIDER)
     go_compat, go_compat_line = parse_go_compat(engine_text, consts)
+    go_sched, go_sched_line = parse_go_all_scheduling(engine_text, consts)
 
     dispatch_text = read(root, DISPATCH_PREDICATE)
     go_dispatch, go_dispatch_line = parse_go_dispatch(dispatch_text, consts, go_compat)
@@ -290,6 +427,8 @@ def run(root: Path) -> tuple[list[list[str]], list[str]]:
 
     failures: list[list[str]] = []
     ok_lines: list[str] = []
+
+    # --- CHECKs 1-3: exact bilateral lockstep ---
 
     for label, gv, gl, tv, tl in [
         (
@@ -319,6 +458,62 @@ def run(root: Path) -> tuple[list[list[str]], list[str]]:
             failures.append(fail)
         else:
             ok_lines.append(f"ok: {label} in lockstep {fmt_set(gv)}")
+
+    # --- CHECK 4: ent schema platform enum coverage ---
+    # The ent schema uses field.String("platform") without a Values() enum
+    # constraint (free string), so this check is informational: it verifies the
+    # field still exists as a free string. If someone adds a Values() enum to the
+    # schema, this check catches any scheduling platform omitted from that enum.
+
+    ent_text = read(root, ENT_SCHEMA_ACCOUNT)
+    ent_values, ent_line = parse_ent_platform_field(ent_text)
+
+    if ent_values is not None:
+        # Schema constrains platform to an enum — every scheduling platform must
+        # be in that enum or accounts for it cannot be persisted.
+        fail = compare_superset(
+            "ent schema platform enum ⊇ AllSchedulingPlatforms()",
+            go_sched,
+            f"{ENGINE_PROVIDER}:{go_sched_line} AllSchedulingPlatforms()",
+            ent_values,
+            f"{ENT_SCHEMA_ACCOUNT}:{ent_line} field.String(\"platform\").Values()",
+        )
+        if fail:
+            failures.append(fail)
+        else:
+            ok_lines.append(
+                f"ok: ent schema platform enum covers all scheduling platforms "
+                f"{fmt_set(go_sched)}"
+            )
+    else:
+        ok_lines.append(
+            f"ok: ent schema platform field is a free string (no Values() enum) — "
+            f"no coverage gap possible [{ENT_SCHEMA_ACCOUNT}:{ent_line}]"
+        )
+
+    # --- CHECK 5: frontend style mapping coverage ---
+    # Every scheduling platform should have entries in the admin UI style maps
+    # (SOFT_BADGE and LABEL_TEXT). A missing key falls through to a generic gray
+    # fallback — functional but visually inconsistent and easy to miss in review.
+
+    for map_name in ("SOFT_BADGE", "LABEL_TEXT"):
+        ts_keys, ts_keys_line = parse_ts_record_keys(
+            ts_const_text, map_name, TS_GATEWAY_PLATFORMS
+        )
+        fail = compare_superset(
+            f"frontend {map_name} style map ⊇ AllSchedulingPlatforms()",
+            go_sched,
+            f"{ENGINE_PROVIDER}:{go_sched_line} AllSchedulingPlatforms()",
+            ts_keys,
+            f"{TS_GATEWAY_PLATFORMS}:{ts_keys_line} {map_name}",
+        )
+        if fail:
+            failures.append(fail)
+        else:
+            ok_lines.append(
+                f"ok: {map_name} style map covers all scheduling platforms "
+                f"{fmt_set(go_sched)}"
+            )
 
     return failures, ok_lines
 

--- a/scripts/checks/platform-registry-drift.py
+++ b/scripts/checks/platform-registry-drift.py
@@ -299,7 +299,7 @@ def parse_ent_platform_field(text: str) -> tuple[list[str] | None, int]:
     scope_end = m.end() + next_field.start() if next_field else len(text)
     field_chain = text[m.end() : scope_end]
 
-    values_m = re.search(r"\.Values\s*\(([^)]*)\)", field_chain)
+    values_m = re.search(r"\.\s*Values\s*\(([^)]*)\)", field_chain)
     if not values_m:
         return None, line
 

--- a/scripts/checks/test_platform_registry_drift.py
+++ b/scripts/checks/test_platform_registry_drift.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Tests for scripts/checks/platform-registry-drift.py."""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import tempfile
+import textwrap
+import unittest
+
+_MOD_PATH = pathlib.Path(__file__).resolve().parent / "platform-registry-drift.py"
+_spec = importlib.util.spec_from_file_location("platform_registry_drift", _MOD_PATH)
+prd = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+_spec.loader.exec_module(prd)
+
+
+PLATFORMS = ["anthropic", "gemini", "openai", "antigravity", "newapi", "kiro", "grok"]
+
+
+def _write(root: pathlib.Path, rel: str, text: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
+
+
+def _ts_array(values: list[str]) -> str:
+    return "[" + ", ".join(repr(v) for v in values) + "]"
+
+
+def _ts_record(values: list[str]) -> str:
+    lines = [f"  {value}: 'class-{value}'," for value in values]
+    return "{\n" + "\n".join(lines) + "\n}"
+
+
+def _ent_platform_field(values: list[str] | None = None) -> str:
+    if values is None:
+        return """
+            field.String("platform").
+                MaxLen(50).
+                NotEmpty(),
+        """
+    quoted = ", ".join(f'"{v}"' for v in values)
+    return f"""
+        field.String("platform").
+            Values({quoted}).
+            NotEmpty(),
+    """
+
+
+def _fixture(
+    root: pathlib.Path,
+    *,
+    ent_values: list[str] | None = None,
+    soft_badge: list[str] | None = None,
+    label_text: list[str] | None = None,
+) -> None:
+    _write(
+        root,
+        "backend/internal/domain/constants.go",
+        """
+        package domain
+
+        const (
+            PlatformAnthropic = "anthropic"
+            PlatformGemini = "gemini"
+            PlatformOpenAI = "openai"
+            PlatformAntigravity = "antigravity"
+            PlatformNewAPI = "newapi"
+            PlatformKiro = "kiro"
+            PlatformGrok = "grok"
+        )
+        """,
+    )
+    _write(
+        root,
+        "backend/internal/engine/provider.go",
+        """
+        package engine
+
+        import "github.com/Wei-Shaw/sub2api/internal/domain"
+
+        func OpenAICompatPlatforms() []string {
+            return []string{domain.PlatformOpenAI, domain.PlatformNewAPI, domain.PlatformGrok}
+        }
+
+        func AllSchedulingPlatforms() []string {
+            return []string{
+                domain.PlatformAnthropic,
+                domain.PlatformGemini,
+                domain.PlatformOpenAI,
+                domain.PlatformAntigravity,
+                domain.PlatformNewAPI,
+                domain.PlatformKiro,
+                domain.PlatformGrok,
+            }
+        }
+        """,
+    )
+    _write(
+        root,
+        "backend/internal/service/openai_messages_dispatch_tk_newapi.go",
+        """
+        package service
+
+        import (
+            "github.com/Wei-Shaw/sub2api/internal/domain"
+            "github.com/Wei-Shaw/sub2api/internal/engine"
+        )
+
+        type Group struct{ Platform string }
+
+        func tkGroupKeepsDispatchConfig(g Group) bool {
+            if engine.IsOpenAICompatPlatform(g.Platform) {
+                return true
+            }
+            return g.Platform == domain.PlatformGemini
+        }
+        """,
+    )
+    _write(
+        root,
+        "backend/ent/schema/account.go",
+        f"""
+        package schema
+
+        import "entgo.io/ent/schema/field"
+
+        func fields() {{
+            {_ent_platform_field(ent_values)}
+            field.String("type").NotEmpty()
+        }}
+        """,
+    )
+    _write(
+        root,
+        "frontend/src/types/index.ts",
+        """
+        export type AccountPlatform =
+          | 'anthropic'
+          | 'gemini'
+          | 'openai'
+          | 'antigravity'
+          | 'newapi'
+          | 'kiro'
+          | 'grok'
+        """,
+    )
+    _write(
+        root,
+        "frontend/src/constants/gatewayPlatforms.ts",
+        f"""
+        export const OPENAI_COMPAT_PLATFORMS = {_ts_array(["openai", "newapi", "grok"])} as const
+        export const GROUP_DISPATCH_CONFIG_PLATFORMS = {_ts_array(["openai", "newapi", "gemini", "grok"])} as const
+
+        const SOFT_BADGE: Record<string, string> = {_ts_record(soft_badge or PLATFORMS)}
+
+        const LABEL_TEXT: Record<string, string> = {_ts_record(label_text or PLATFORMS)}
+        """,
+    )
+
+
+class PlatformRegistryDriftTest(unittest.TestCase):
+    def test_free_ent_string_and_complete_style_maps_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            _fixture(root)
+
+            failures, ok_lines = prd.run(root)
+
+        self.assertEqual(failures, [])
+        self.assertTrue(any("free string" in line for line in ok_lines))
+        self.assertTrue(any("SOFT_BADGE style map covers" in line for line in ok_lines))
+        self.assertTrue(any("LABEL_TEXT style map covers" in line for line in ok_lines))
+
+    def test_ent_enum_missing_scheduling_platform_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            _fixture(root, ent_values=[p for p in PLATFORMS if p != "grok"])
+
+            failures, _ = prd.run(root)
+
+        self.assertEqual(len(failures), 1)
+        self.assertIn("ent schema platform enum", failures[0][0])
+        self.assertIn("missing: grok", "\n".join(failures[0]))
+
+    def test_style_maps_missing_scheduling_platforms_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            _fixture(
+                root,
+                soft_badge=[p for p in PLATFORMS if p != "grok"],
+                label_text=[p for p in PLATFORMS if p != "kiro"],
+            )
+
+            failures, _ = prd.run(root)
+
+        rendered = "\n\n".join("\n".join(fail) for fail in failures)
+        self.assertEqual(len(failures), 2)
+        self.assertIn("frontend SOFT_BADGE style map", rendered)
+        self.assertIn("missing: grok", rendered)
+        self.assertIn("frontend LABEL_TEXT style map", rendered)
+        self.assertIn("missing: kiro", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2252,6 +2252,10 @@ echo "=== sub2api: platform registry drift ==="
 if ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required by platform-registry-drift.py)"
     errors=$((errors + 1))
+elif ! python3 ./scripts/checks/test_platform_registry_drift.py >/dev/null; then
+    echo "  FAIL: platform-registry-drift regression tests failed"
+    echo "        — run: python3 scripts/checks/test_platform_registry_drift.py"
+    errors=$((errors + 1))
 elif ! python3 ./scripts/checks/platform-registry-drift.py --quiet; then
     errors=$((errors + 1))
 else

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -73,8 +73,9 @@
 #        major as the release Dockerfile (ARG NODE_IMAGE). Driven by
 #        `scripts/checks/node-version-align.py`.
 #   platform registry drift      — Go ↔ TS platform registry lockstep
-#        (OpenAI-compat list, dispatch-config platforms, Platform universe).
-#        Driven by `scripts/checks/platform-registry-drift.py`.
+#        (OpenAI-compat list, dispatch-config platforms, Platform universe,
+#        Ent platform enum coverage, admin UI style maps). Driven by
+#        `scripts/checks/platform-registry-drift.py`.
 #   upstream deletion ledger     — every upstream-owned file deleted in TK must
 #        appear verbatim in `docs/DEPRECATIONS.md` (CLAUDE.md §5.x). Driven by
 #        `scripts/checks/upstream-deletion-ledger.py`. Skips when upstream remote
@@ -2243,8 +2244,9 @@ fi
 
 # ---- sub2api: platform registry drift ----------------------------------------
 # Go ↔ TS platform registry lockstep: OpenAI-compat list, dispatch-config
-# platforms, Platform constant universe. Drift → admin UI cannot render or
-# silently drops dispatch config. Gate: scripts/checks/platform-registry-drift.py.
+# platforms, Platform constant universe, Ent enum coverage, and admin UI style
+# maps. Drift → admin UI cannot render, cannot persist enum-constrained
+# platforms, or silently drops dispatch config. Gate: scripts/checks/platform-registry-drift.py.
 echo ""
 echo "=== sub2api: platform registry drift ==="
 if ! command -v python3 >/dev/null 2>&1; then


### PR DESCRIPTION
## 摘要

架构审查 Wave 2 收口：SSOT 违规的最后一英里修复 + 机械守卫扩展。

- **SSOT 常量替换**：`channel_handler_tk_newapi_admin.go`、`account_test_service.go`、`openai_oauth_handler.go` 中残留的 `"newapi"` / `"apikey"` / `"oauth"` 硬编码字符串全部替换为 `domain.*` / `service.*` 常量引用
- **机械守卫扩展**：`platform-registry-drift.py` 新增 CHECK 6（AccountType constant universe Go↔TS 同步），从 5 项检查扩展到 7 项（含 CHECK 5 覆盖 2 个样式映射），回归测试同步更新

## 风险

- **低风险**：纯引用替换，值不变。drift check 新增纯追加。
- sentinel-registry-reviewed
- upstream-conflict-surface-accepted

## 验证

- `go build ./...` — 编译通过
- `go test -tags=unit ./internal/service/...` — 全部通过
- `python3 scripts/checks/test_platform_registry_drift.py` — 3/3 通过
- `scripts/preflight.sh` — PASS（含 7 项 drift 检测全绿）

## 提交

- d02faf9ad fix(ssot): eliminate remaining hardcoded platform/account-type strings

最新提交：d02faf9ad
