### PR TITLE
chore(release): scheme 1 direct-push + fail-closed route

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -13,9 +13,10 @@ description: Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, ro
 
 | 步骤 | 类型 | 承载 |
 |---|---|---|
-| **release 全步骤（决策→bump→push→tag，worktree 隔离）** | 机械 | `bash scripts/release-bump-and-tag.sh [--dry-run]`（`bump-and-tag` 且 main 受保护时自动 `exec release-bump-via-pr.sh`；永不写共享 checkout） |
-| **VERSION bump 经 PR（main 分支保护）** | 机械 | `bash scripts/release-bump-via-pr.sh [--dry-run] [--pr N]`（worktree bump → PR → CI → squash merge → `release-bump-and-tag.sh` tag-only） |
-| main bump 路由探测（direct-push / bump-via-pr） | 机械 | `bash scripts/release-main-push-route.sh`（`gh api …/branches/main/protection`） |
+| **release 全步骤（决策→bump→push→tag，worktree 隔离）** | 机械 | `bash scripts/release-bump-and-tag.sh [--dry-run]`（默认 **direct-push**；仅 `release-main-push-route`=`bump-via-pr` 时 delegate `release-bump-via-pr.sh`；永不写共享 checkout） |
+| **发版 bypass 一次性配置（scheme 1）** | 机械 | `bash scripts/release-configure-main-bypass.sh`（个人仓库：`enforce_admins=false`；组织仓库：`bypass_pull_request_allowances.users`） |
+| **VERSION bump 经 PR（fallback）** | 机械 | `bash scripts/release-bump-via-pr.sh [--dry-run] [--pr N]`（仅当当前 gh 账号无法 direct-push 时） |
+| main bump 路由探测（direct-push / bump-via-pr） | 机械 | `bash scripts/release-main-push-route.sh`（读 protection + 当前 gh 用户 bypass 能力） |
 | VERSION/tag 三态决策（tag-only / bump-and-tag / skip-bump-skip-tag） | 机械 | `scripts/release-decide-version.sh [--emit-suggested-bump]`（被上行脚本消费；单独跑仅用于诊断） |
 | 打 tag（含 skip-ci / VERSION 一致 / HEAD==origin/main 校验） | 机械 | `scripts/release-tag.sh vX.Y.Z`（被上行脚本调用） |
 | 读取 deployable edge 矩阵 | 机械 | `python3 deploy/aws/stage0/resolve-edge-target.py --list-deployable` |
@@ -125,7 +126,17 @@ description: Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, ro
 - GitHub Environment：**`prod`**、各 Edge 的 `edge-<edge_id>`（若有 Required reviewers，需人工批准）。新 edge 可参考已上线 edge 的变量/密钥结构，但 `EDGE_GHCR_PAT_SSM_NAME` 必须使用该 edge 自己的 SSM 路径。
 - **禁止**：VERSION bump / 发版 commit 的正文里出现字面量 `[skip ci]` 或 `[ci skip]`（任意位置都不行）。
 
-## 决策 + bump + tag：worktree 隔离（两条 bump 路径）
+## 决策 + bump + tag：worktree 隔离（scheme 1 默认 direct-push）
+
+**一次性配置**（新机器 / 新协作者 / fork 后；已配可 `--check`）：
+
+```bash
+bash scripts/release-configure-main-bypass.sh          # 写入 GitHub 分支保护
+bash scripts/release-configure-main-bypass.sh --check  # 期望 release-main-push-route=direct-push
+```
+
+- **个人仓库**（`youxuanxue/sub2api`）：GitHub 不支持 bypass 用户列表 → 脚本设 `enforce_admins=false`，**仅 repo admin** 可 bypass PR 规则直推 VERSION bump；协作者仍须 PR。
+- **组织仓库**：合并 `TK_RELEASE_BYPASS_USERS` 到 `bypass_pull_request_allowances.users`。
 
 **发版前先决策**（只读）：
 
@@ -147,7 +158,7 @@ bash scripts/release-bump-and-tag.sh            # decide → bump（direct 或 P
 | `bump-and-tag` + `release-main-push-route` = **direct-push** | worktree bump → `push origin HEAD:main` → tag |
 | `bump-and-tag` + route = **bump-via-pr** | 自动 `exec release-bump-via-pr.sh`（PR → merge → tag-only） |
 
-**protected main 子流程**（也可单独跑/resume）：
+**protected main 子流程（fallback）**（`release-main-push-route` = `bump-via-pr` 时）：
 
 ```bash
 bash scripts/release-bump-via-pr.sh              # 全流程
@@ -663,7 +674,7 @@ bash scripts/release-rollout-summary.sh --mode release
 | 现象 | 处理 |
 |------|------|
 | `release-bump-and-tag.sh` 无输出且 exit 1（action=tag-only） | 已修：`field()` grep 无匹配 + `set -e` 静默退出。升级后重跑；临时绕过 = worktree @ origin/main + `release-tag.sh vX.Y.Z`。 |
-| `push origin HEAD:main` / GH006 **Protected branch** | 不要手改保护规则。跑 `bash scripts/release-bump-via-pr.sh`（或让 `release-bump-and-tag.sh` 自动 delegate）。 |
+| `push origin HEAD:main` / GH006 **Protected branch** | 先 `bash scripts/release-configure-main-bypass.sh`；仍失败则 fallback `release-bump-via-pr.sh`。 |
 | bump PR CI 仅 **preflight** flaky fail | `gh run rerun <run_id> --failed`，再 `release-bump-via-pr.sh --pr <N>`；不要改 VERSION 对冲。 |
 | 发版后残留 `sub2api-release-*` / `sub2api-bump-pr-*` worktree | `git worktree list` → `git worktree remove --force <path>`；否则后续 `worktree add` / `gh pr merge --delete-branch` 会失败。 |
 | release 时主 checkout 在别的分支 / 有别人的 WIP | 正常现象（并行 agent），不要去切分支、stash 或还原别人的文件；release 脚本本来就不读写当前 checkout。 |
@@ -694,6 +705,7 @@ bash scripts/release-rollout-summary.sh --mode release
 
 - `scripts/release-bump-and-tag.sh` — release 全步骤（worktree；protected main 时 delegate PR 子流程）。
 - `scripts/release-bump-via-pr.sh` — VERSION bump 经 PR + merge + tag。
+- `scripts/release-configure-main-bypass.sh` — scheme 1：发版账号 bypass（个人 repo / 组织 repo 双路径）。
 - `scripts/release-main-push-route.sh` — direct-push vs bump-via-pr 探测。
 - `scripts/stage0/approve-github-run-env.sh` — Environment 门禁自批（warm / prod / edge）。
 - `scripts/release-decide-version.sh` — VERSION/tag 三态决策。

--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -703,7 +703,7 @@ bash scripts/release-rollout-summary.sh --mode release
 
 - `.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md` — 发版后 check violation 的 plan/apply/verify canonical 路径。
 
-- `scripts/release-bump-and-tag.sh` — release 全步骤（worktree；protected main 时 delegate PR 子流程）。
+- `scripts/release-bump-and-tag.sh` — release 全步骤（worktree；默认 direct-push，fallback 才 delegate PR）。
 - `scripts/release-bump-via-pr.sh` — VERSION bump 经 PR + merge + tag。
 - `scripts/release-configure-main-bypass.sh` — scheme 1：发版账号 bypass（个人 repo / 组织 repo 双路径）。
 - `scripts/release-main-push-route.sh` — direct-push vs bump-via-pr 探测。

--- a/scripts/release-bump-and-tag.sh
+++ b/scripts/release-bump-and-tag.sh
@@ -145,7 +145,7 @@ no-web-impact"
   if ! PUSH_ERR="$(git -C "$WT_DIR" push origin HEAD:main 2>&1)"; then
     echo "$PUSH_ERR" >&2
     if printf '%s\n' "$PUSH_ERR" | grep -qiE 'protected branch|pull request|GH006'; then
-      echo "[release-bump-and-tag] main is branch-protected; run: bash scripts/release-bump-via-pr.sh" >&2
+      echo "[release-bump-and-tag] main is branch-protected for this gh user; run: bash scripts/release-configure-main-bypass.sh (or fallback: scripts/release-bump-via-pr.sh)" >&2
     else
       echo "[release-bump-and-tag] ERROR: push rejected — origin/main moved since the worktree was created." >&2
       echo "                       Re-run this script; it will re-base the bump on the new origin/main." >&2

--- a/scripts/release-bump-and-tag.sh
+++ b/scripts/release-bump-and-tag.sh
@@ -73,9 +73,15 @@ case "$ACTION" in
   *) echo "[release-bump-and-tag] ERROR: unknown action '$ACTION'" >&2; exit 1 ;;
 esac
 
-BUMP_ROUTE="direct-push"
+BUMP_ROUTE=""
 if [ "$ACTION" = "bump-and-tag" ]; then
-  BUMP_ROUTE="$(bash "$REPO_ROOT/scripts/release-main-push-route.sh" 2>/dev/null || echo direct-push)"
+  ROUTE_ERR=""
+  if ! ROUTE_ERR="$(bash "$REPO_ROOT/scripts/release-main-push-route.sh" 2>&1)"; then
+    printf '%s\n' "$ROUTE_ERR" >&2
+    echo "[release-bump-and-tag] ERROR: release-main-push-route.sh failed; refusing to guess bump path" >&2
+    exit 2
+  fi
+  BUMP_ROUTE="$ROUTE_ERR"
 fi
 
 if [ "$DRY_RUN" -eq 1 ]; then

--- a/scripts/release-bump-via-pr.sh
+++ b/scripts/release-bump-via-pr.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# release-bump-via-pr.sh — VERSION bump through a PR when origin/main is protected.
+# release-bump-via-pr.sh — VERSION bump through a PR (fallback when direct-push
+# is unavailable for the current gh actor). Prefer scheme 1:
+#   bash scripts/release-configure-main-bypass.sh
+#   bash scripts/release-bump-and-tag.sh
 #
 # Worktree-isolated (never touches the operator checkout). Flow:
 #   release-decide-version (must be bump-and-tag)

--- a/scripts/release-configure-main-bypass.sh
+++ b/scripts/release-configure-main-bypass.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# release-configure-main-bypass.sh — Enable direct-push VERSION bumps on protected main
+# (scheme 1).
+#
+# Personal repos (User owner): GitHub does not support bypass_pull_request_allowances
+# users — we set enforce_admins=false so repository admins can bypass PR rules.
+#
+# Organization repos: merge release actors into bypass_pull_request_allowances.users.
+#
+# Usage:
+#   bash scripts/release-configure-main-bypass.sh              # configure for current gh user
+#   bash scripts/release-configure-main-bypass.sh --check      # verify direct-push route
+#   TK_RELEASE_BYPASS_USERS=u1,u2 bash scripts/release-configure-main-bypass.sh  # org only
+#
+# Requires: gh authenticated with admin rights on the repo.
+set -euo pipefail
+
+CHECK_ONLY=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --check) CHECK_ONLY=1; shift ;;
+    -h|--help)
+      sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "[release-configure-main-bypass] ERROR: unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[release-configure-main-bypass] ERROR: gh required" >&2
+  exit 2
+fi
+
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || {
+  echo "[release-configure-main-bypass] ERROR: gh repo view failed" >&2
+  exit 2
+}
+
+if ! gh api "repos/$REPO/branches/main/protection" >/dev/null 2>&1; then
+  echo "[release-configure-main-bypass] main has no branch protection; direct-push already works"
+  exit 0
+fi
+
+if [ "$CHECK_ONLY" -eq 1 ]; then
+  route="$(bash "$(dirname "$0")/release-main-push-route.sh")"
+  if [ "$route" = "direct-push" ]; then
+    echo "[release-configure-main-bypass] ok: release-main-push-route=$route"
+    exit 0
+  fi
+  echo "[release-configure-main-bypass] FAIL: release-main-push-route=$route (expected direct-push)" >&2
+  exit 1
+fi
+
+META_JSON="$(gh api "repos/$REPO" --jq '{owner_type: .owner.type, owner_login: .owner.login}')"
+PROT_JSON="$(gh api "repos/$REPO/branches/main/protection")"
+REQUESTED_CSV="${TK_RELEASE_BYPASS_USERS:-$(gh api user -q .login)}"
+
+RESULT="$(META_JSON="$META_JSON" PROT_JSON="$PROT_JSON" REQUESTED_CSV="$REQUESTED_CSV" python3 - <<'PY'
+import json, os, sys
+
+meta = json.loads(os.environ["META_JSON"])
+prot = json.loads(os.environ["PROT_JSON"])
+requested = [u.strip() for u in os.environ.get("REQUESTED_CSV", "").split(",") if u.strip()]
+is_org = meta.get("owner_type") == "Organization"
+
+reviews = prot.get("required_pull_request_reviews") or {}
+allow = reviews.get("bypass_pull_request_allowances") or {}
+existing = []
+for item in allow.get("users") or []:
+    if isinstance(item, dict) and item.get("login"):
+        existing.append(item["login"])
+    elif isinstance(item, str):
+        existing.append(item)
+
+merged = []
+seen = set()
+for u in existing + requested:
+    if u and u not in seen:
+        seen.add(u)
+        merged.append(u)
+
+enforce_admins = bool((prot.get("enforce_admins") or {}).get("enabled"))
+mode = "org-bypass-users" if is_org else "personal-enforce-admins-off"
+if not is_org:
+    enforce_admins = False
+
+checks = (prot.get("required_status_checks") or {}).get("checks") or []
+if not checks:
+    for ctx in (prot.get("required_status_checks") or {}).get("contexts") or []:
+        checks.append({"context": ctx, "app_id": None})
+
+pr_reviews = {
+    "dismiss_stale_reviews": bool(reviews.get("dismiss_stale_reviews")),
+    "require_code_owner_reviews": bool(reviews.get("require_code_owner_reviews")),
+    "require_last_push_approval": bool(reviews.get("require_last_push_approval")),
+    "required_approving_review_count": int(reviews.get("required_approving_review_count") or 0),
+}
+if is_org:
+    pr_reviews["bypass_pull_request_allowances"] = {
+        "users": merged,
+        "teams": [],
+        "apps": [],
+    }
+
+payload = {
+    "required_status_checks": {
+        "strict": bool((prot.get("required_status_checks") or {}).get("strict")),
+        "checks": [{"context": c["context"], "app_id": c.get("app_id")} for c in checks],
+    },
+    "enforce_admins": enforce_admins,
+    "required_pull_request_reviews": pr_reviews,
+    "restrictions": None,
+    "required_linear_history": bool((prot.get("required_linear_history") or {}).get("enabled")),
+    "allow_force_pushes": bool((prot.get("allow_force_pushes") or {}).get("enabled")),
+    "allow_deletions": bool((prot.get("allow_deletions") or {}).get("enabled")),
+    "block_creations": bool((prot.get("block_creations") or {}).get("enabled")),
+    "required_conversation_resolution": bool(
+        (prot.get("required_conversation_resolution") or {}).get("enabled")
+    ),
+    "lock_branch": bool((prot.get("lock_branch") or {}).get("enabled")),
+    "allow_fork_syncing": bool((prot.get("allow_fork_syncing") or {}).get("enabled")),
+}
+detail = merged if is_org else ["admin-bypass-via-enforce_admins=false"]
+print(f"apply\t{mode}\t{','.join(detail)}\t{json.dumps(payload)}")
+PY
+)"
+
+IFS=$'\t' read -r _ mode detail payload <<< "$RESULT"
+echo "[release-configure-main-bypass] mode=$mode actors=$detail"
+printf '%s\n' "$payload" | gh api -X PUT "repos/$REPO/branches/main/protection" --input - >/dev/null
+echo "[release-configure-main-bypass] done; verify: bash scripts/release-main-push-route.sh"

--- a/scripts/release-main-push-route.sh
+++ b/scripts/release-main-push-route.sh
@@ -5,7 +5,7 @@
 #   direct-push  — current gh actor may push origin HEAD:main (no bump PR)
 #   bump-via-pr  — use scripts/release-bump-via-pr.sh
 #
-# Scheme 1 routing:
+# Scheme 1 routing (see scripts/release_main_push_route.py):
 #   - No branch protection → direct-push
 #   - Organization repo: gh user listed in bypass_pull_request_allowances.users
 #   - Personal repo: enforce_admins=false and gh user has admin permission
@@ -14,6 +14,8 @@
 #
 # Exit 0 when route is determined; exit 2 on gh/network failure.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if ! command -v gh >/dev/null 2>&1; then
   echo direct-push
@@ -38,34 +40,5 @@ CURRENT_USER="$(gh api user -q .login 2>/dev/null)" || {
 
 META_JSON="$(gh api "repos/$REPO" --jq '{owner_type: .owner.type, admin: .permissions.admin}')"
 
-if PROTECTION_JSON="$PROTECTION_JSON" META_JSON="$META_JSON" CURRENT_USER="$CURRENT_USER" python3 - <<'PY'
-import json, os, sys
-
-prot = json.loads(os.environ["PROTECTION_JSON"])
-meta = json.loads(os.environ["META_JSON"])
-current = os.environ["CURRENT_USER"]
-
-if meta.get("owner_type") == "Organization":
-    reviews = prot.get("required_pull_request_reviews") or {}
-    allow = reviews.get("bypass_pull_request_allowances") or {}
-    logins = []
-    for item in allow.get("users") or []:
-        if isinstance(item, dict) and item.get("login"):
-            logins.append(item["login"])
-        elif isinstance(item, str):
-            logins.append(item)
-    if current in logins:
-        sys.exit(0)
-    sys.exit(1)
-
-# Personal repo: admins bypass when enforce_admins is disabled.
-enforce_admins = bool((prot.get("enforce_admins") or {}).get("enabled"))
-if not enforce_admins and meta.get("admin"):
-    sys.exit(0)
-sys.exit(1)
-PY
-then
-  echo direct-push
-else
-  echo bump-via-pr
-fi
+PROTECTION_JSON="$PROTECTION_JSON" META_JSON="$META_JSON" CURRENT_USER="$CURRENT_USER" \
+  python3 "$SCRIPT_DIR/release_main_push_route.py"

--- a/scripts/release-main-push-route.sh
+++ b/scripts/release-main-push-route.sh
@@ -2,10 +2,17 @@
 # release-main-push-route.sh — How to land a VERSION bump on origin/main.
 #
 # Prints one line to stdout (parseable):
-#   direct-push  — push origin HEAD:main is expected to work
-#   bump-via-pr    — main has branch protection; use scripts/release-bump-via-pr.sh
+#   direct-push  — current gh actor may push origin HEAD:main (no bump PR)
+#   bump-via-pr  — use scripts/release-bump-via-pr.sh
 #
-# Exit 0 always when route is determined; exit 2 on gh/network failure.
+# Scheme 1 routing:
+#   - No branch protection → direct-push
+#   - Organization repo: gh user listed in bypass_pull_request_allowances.users
+#   - Personal repo: enforce_admins=false and gh user has admin permission
+#
+# Configure once: bash scripts/release-configure-main-bypass.sh
+#
+# Exit 0 when route is determined; exit 2 on gh/network failure.
 set -euo pipefail
 
 if ! command -v gh >/dev/null 2>&1; then
@@ -18,8 +25,47 @@ REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || {
   exit 2
 }
 
-if gh api "repos/$REPO/branches/main/protection" >/dev/null 2>&1; then
-  echo bump-via-pr
-else
+PROTECTION_JSON=""
+if ! PROTECTION_JSON="$(gh api "repos/$REPO/branches/main/protection" 2>/dev/null)"; then
   echo direct-push
+  exit 0
+fi
+
+CURRENT_USER="$(gh api user -q .login 2>/dev/null)" || {
+  echo "[release-main-push-route] ERROR: gh api user failed" >&2
+  exit 2
+}
+
+META_JSON="$(gh api "repos/$REPO" --jq '{owner_type: .owner.type, admin: .permissions.admin}')"
+
+if PROTECTION_JSON="$PROTECTION_JSON" META_JSON="$META_JSON" CURRENT_USER="$CURRENT_USER" python3 - <<'PY'
+import json, os, sys
+
+prot = json.loads(os.environ["PROTECTION_JSON"])
+meta = json.loads(os.environ["META_JSON"])
+current = os.environ["CURRENT_USER"]
+
+if meta.get("owner_type") == "Organization":
+    reviews = prot.get("required_pull_request_reviews") or {}
+    allow = reviews.get("bypass_pull_request_allowances") or {}
+    logins = []
+    for item in allow.get("users") or []:
+        if isinstance(item, dict) and item.get("login"):
+            logins.append(item["login"])
+        elif isinstance(item, str):
+            logins.append(item)
+    if current in logins:
+        sys.exit(0)
+    sys.exit(1)
+
+# Personal repo: admins bypass when enforce_admins is disabled.
+enforce_admins = bool((prot.get("enforce_admins") or {}).get("enabled"))
+if not enforce_admins and meta.get("admin"):
+    sys.exit(0)
+sys.exit(1)
+PY
+then
+  echo direct-push
+else
+  echo bump-via-pr
 fi

--- a/scripts/release_main_push_route.py
+++ b/scripts/release_main_push_route.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Mechanical direct-push vs bump-via-pr routing for VERSION bumps on main."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+
+def decide_route(protection: dict[str, Any], meta: dict[str, Any], current_user: str) -> str:
+    """Return 'direct-push' or 'bump-via-pr' for the given gh actor."""
+    current_user = (current_user or "").strip()
+    if meta.get("owner_type") == "Organization":
+        reviews = protection.get("required_pull_request_reviews") or {}
+        allow = reviews.get("bypass_pull_request_allowances") or {}
+        logins: list[str] = []
+        for item in allow.get("users") or []:
+            if isinstance(item, dict) and item.get("login"):
+                logins.append(str(item["login"]))
+            elif isinstance(item, str):
+                logins.append(item)
+        if current_user in logins:
+            return "direct-push"
+        return "bump-via-pr"
+
+    enforce_admins = bool((protection.get("enforce_admins") or {}).get("enabled"))
+    if not enforce_admins and meta.get("admin"):
+        return "direct-push"
+    return "bump-via-pr"
+
+
+def main() -> int:
+    try:
+        protection = json.loads(os.environ["PROTECTION_JSON"])
+        meta = json.loads(os.environ["META_JSON"])
+        current_user = os.environ["CURRENT_USER"]
+    except (KeyError, json.JSONDecodeError) as exc:
+        print(f"[release-main-push-route] ERROR: {exc}", file=sys.stderr)
+        return 2
+    print(decide_route(protection, meta, current_user))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_release_bump_and_tag.py
+++ b/scripts/test_release_bump_and_tag.py
@@ -51,6 +51,7 @@ class ReleaseBumpAndTagTest(unittest.TestCase):
             "release-bump-and-tag.sh",
             "release-decide-version.sh",
             "release-main-push-route.sh",
+            "release_main_push_route.py",
             "release-tag.sh",
         ):
             src = pathlib.Path(__file__).resolve().parent / name
@@ -80,6 +81,29 @@ class ReleaseBumpAndTagTest(unittest.TestCase):
         )
         self.assertIn("dry-run: action=tag-only", proc.stdout)
         self.assertIn("target_tag=v1.0.1", proc.stdout)
+
+    def test_bump_and_tag_fails_closed_when_route_script_fails(self) -> None:
+        """bump-and-tag must not silently default to direct-push when route lookup fails."""
+        _git(self.repo, "tag", "-a", "v1.0.1", "-m", "v1.0.1")
+        _git(self.repo, "push", "-q", "origin", "v1.0.1")
+        (self.repo / "touch.txt").write_text("ahead\n")
+        _git(self.repo, "add", "touch.txt")
+        _git(self.repo, "commit", "-q", "-m", "ahead of tag")
+        _git(self.repo, "push", "-q", "origin", "main")
+
+        route = self.repo / "scripts/release-main-push-route.sh"
+        route.write_text("#!/usr/bin/env bash\nexit 2\n")
+        route.chmod(0o755)
+        proc = subprocess.run(
+            ["bash", "scripts/release-bump-and-tag.sh", "--dry-run"],
+            cwd=self.repo,
+            env=_clean_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 2, f"stdout:{proc.stdout}\nstderr:{proc.stderr}")
+        self.assertIn("refusing to guess bump path", proc.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/test_release_main_push_route.py
+++ b/scripts/test_release_main_push_route.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/release_main_push_route.py."""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+_MODULE = pathlib.Path(__file__).resolve().parent / "release_main_push_route.py"
+_spec = importlib.util.spec_from_file_location("release_main_push_route", _MODULE)
+assert _spec and _spec.loader
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+decide_route = _mod.decide_route
+
+
+class ReleaseMainPushRouteTest(unittest.TestCase):
+    def test_org_bypass_user_direct_push(self) -> None:
+        prot = {
+            "required_pull_request_reviews": {
+                "bypass_pull_request_allowances": {
+                    "users": [{"login": "alice"}],
+                },
+            },
+        }
+        meta = {"owner_type": "Organization", "admin": False}
+        self.assertEqual(decide_route(prot, meta, "alice"), "direct-push")
+
+    def test_org_non_bypass_user_pr_path(self) -> None:
+        prot = {
+            "required_pull_request_reviews": {
+                "bypass_pull_request_allowances": {
+                    "users": [{"login": "alice"}],
+                },
+            },
+        }
+        meta = {"owner_type": "Organization", "admin": True}
+        self.assertEqual(decide_route(prot, meta, "bob"), "bump-via-pr")
+
+    def test_personal_admin_enforce_admins_off(self) -> None:
+        prot = {"enforce_admins": {"enabled": False}}
+        meta = {"owner_type": "User", "admin": True}
+        self.assertEqual(decide_route(prot, meta, "owner"), "direct-push")
+
+    def test_personal_admin_enforce_admins_on(self) -> None:
+        prot = {"enforce_admins": {"enabled": True}}
+        meta = {"owner_type": "User", "admin": True}
+        self.assertEqual(decide_route(prot, meta, "owner"), "bump-via-pr")
+
+    def test_personal_non_admin(self) -> None:
+        prot = {"enforce_admins": {"enabled": False}}
+        meta = {"owner_type": "User", "admin": False}
+        self.assertEqual(decide_route(prot, meta, "collab"), "bump-via-pr")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- 补回 #1198 合并后遗漏的发版脚本改动：scheme 1 direct-push（`release-configure-main-bypass.sh` + route 探测）。
- bump 路由探测失败时 fail-closed（exit 2），不再静默回退 `direct-push`。
- 路由判定抽到 `release_main_push_route.py` 并补单测。

## 风险

- 仅影响发版工具链（`scripts/release-*`），不改变运行时网关/API 行为。
- 未配置 bypass 的环境仍走 `release-bump-via-pr.sh` fallback。
- route 探测依赖 `gh` 与 GitHub API；失败会中止 bump，需先跑 `release-configure-main-bypass.sh --check`。

## 验证

- `python3 scripts/test_release_main_push_route.py -v` — 5 passed
- `python3 scripts/test_release_bump_and_tag.py -v` — 2 passed
- `bash scripts/release-configure-main-bypass.sh --check` — 本机已配置时 expect direct-push
- no-web-impact（仅 scripts + rollout skill）

## 提交

- `719c5d539` fix(release): fail closed when main bump route lookup fails
- `595ec911b` chore(release): enable direct-push VERSION bumps via scheme 1 bypass

最新提交：719c5d539
