### PR TITLE
fix(arch): Wave 3 — SSOT constants, drift checker 7→12, data flow logging

### DIFF
--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -565,7 +565,7 @@ func redeemCodeFromServiceBase(rc *service.RedeemCode) RedeemCode {
 
 	// For admin_balance/admin_concurrency types, include notes so users can see
 	// why they were charged or credited by admin
-	if (rc.Type == "admin_balance" || rc.Type == "admin_concurrency") && rc.Notes != "" {
+	if (rc.Type == service.AdjustmentTypeAdminBalance || rc.Type == service.AdjustmentTypeAdminConcurrency) && rc.Notes != "" {
 		out.Notes = &rc.Notes
 	}
 

--- a/backend/internal/handler/page_handler.go
+++ b/backend/internal/handler/page_handler.go
@@ -240,9 +240,9 @@ func (h *PageHandler) checkSlugVisibility(c *gin.Context, slug string) bool {
 	if !found {
 		return false
 	}
-	if visibility == "admin" {
+	if visibility == service.RoleAdmin {
 		role, _ := middleware2.GetUserRoleFromContext(c)
-		return role == "admin"
+		return role == service.RoleAdmin
 	}
 	return true
 }
@@ -254,7 +254,7 @@ func (h *PageHandler) checkImageSlugVisibility(c *gin.Context, slug string) bool
 	if !found {
 		return false
 	}
-	return visibility != "admin"
+	return visibility != service.RoleAdmin
 }
 
 // RegisterPageRoutes registers page routes on a router group.

--- a/backend/internal/server/middleware/backend_mode_guard.go
+++ b/backend/internal/server/middleware/backend_mode_guard.go
@@ -18,7 +18,7 @@ func BackendModeUserGuard(settingService *service.SettingService) gin.HandlerFun
 			return
 		}
 		role, _ := GetUserRoleFromContext(c)
-		if role == "admin" {
+		if role == service.RoleAdmin {
 			c.Next()
 			return
 		}

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -854,7 +854,7 @@ func (s *adminServiceImpl) UpdateUser(ctx context.Context, id int64, input *Upda
 	}
 
 	// Protect admin users: cannot disable admin accounts
-	if user.Role == "admin" && input.Status == "disabled" {
+	if user.Role == RoleAdmin && input.Status == StatusDisabled {
 		return nil, errors.New("cannot disable admin user")
 	}
 
@@ -969,7 +969,7 @@ func (s *adminServiceImpl) DeleteUser(ctx context.Context, id int64) error {
 	if err != nil {
 		return err
 	}
-	if user.Role == "admin" {
+	if user.Role == RoleAdmin {
 		return errors.New("cannot delete admin user")
 	}
 

--- a/backend/internal/service/auth_email_oauth_auto.go
+++ b/backend/internal/service/auth_email_oauth_auto.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/mail"
 	"strings"
 
@@ -203,7 +204,9 @@ func (s *AuthService) createEmailOAuthUser(ctx context.Context, email, username,
 	s.postAuthUserBootstrap(ctx, user, providerType, false)
 	s.assignSubscriptions(ctx, user.ID, grantPlan.Subscriptions, "auto assigned by signup defaults")
 	// snapshot user × platform quota（fail-open）
-	_ = s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan)
+	if err := s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan); err != nil {
+		slog.Error("quota snapshot failed", "user_id", user.ID, "err", err)
+	}
 	s.bindOAuthAffiliate(ctx, user.ID, affiliateCode)
 	if invitationRedeemCode != nil {
 		if err := s.useOAuthRegistrationInvitation(ctx, invitationRedeemCode.ID, user.ID); err != nil {

--- a/backend/internal/service/auth_oauth_email_flow.go
+++ b/backend/internal/service/auth_oauth_email_flow.go
@@ -284,7 +284,9 @@ func (s *AuthService) FinalizeOAuthEmailAccount(
 	grantPlan := s.resolveSignupGrantPlan(ctx, signupSource)
 	s.assignSubscriptions(ctx, user.ID, grantPlan.Subscriptions, "auto assigned by signup defaults")
 	// snapshot user × platform quota（fail-open）
-	_ = s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan)
+	if err := s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan); err != nil {
+		slog.Error("quota snapshot failed", "user_id", user.ID, "err", err)
+	}
 	s.bindOAuthAffiliate(ctx, user.ID, affiliateCode)
 	return nil
 }

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/mail"
 	"strconv"
 	"strings"
@@ -239,7 +240,9 @@ func (s *AuthService) RegisterWithVerification(ctx context.Context, email, passw
 	s.postAuthUserBootstrap(ctx, user, "email", true)
 	s.assignSubscriptions(ctx, user.ID, grantPlan.Subscriptions, "auto assigned by signup defaults")
 	// snapshot user × platform quota（fail-open）
-	_ = s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan)
+	if err := s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan); err != nil {
+		slog.Error("quota snapshot failed", "user_id", user.ID, "err", err)
+	}
 	if s.affiliateService != nil {
 		if _, err := s.affiliateService.EnsureUserAffiliate(ctx, user.ID); err != nil {
 			logger.LegacyPrintf("service.auth", "[Auth] Failed to initialize affiliate profile for user %d: %v", user.ID, err)
@@ -562,7 +565,9 @@ func (s *AuthService) LoginOrRegisterOAuth(ctx context.Context, email, username 
 				s.postAuthUserBootstrap(ctx, user, signupSource, false)
 				s.assignSubscriptions(ctx, user.ID, grantPlan.Subscriptions, "auto assigned by signup defaults")
 				// snapshot user × platform quota（fail-open）
-				_ = s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan)
+				if err := s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan); err != nil {
+					slog.Error("quota snapshot failed", "user_id", user.ID, "err", err)
+				}
 			}
 		} else {
 			logger.LegacyPrintf("service.auth", "[Auth] Database error during oauth login: %v", err)
@@ -730,7 +735,9 @@ func (s *AuthService) loginOrRegisterOAuthWithTokenPair(ctx context.Context, ema
 					s.postAuthUserBootstrap(ctx, user, signupSource, false)
 					s.assignSubscriptions(ctx, user.ID, grantPlan.Subscriptions, "auto assigned by signup defaults")
 					// snapshot user × platform quota（fail-open）
-					_ = s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan)
+					if err := s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan); err != nil {
+						slog.Error("quota snapshot failed", "user_id", user.ID, "err", err)
+					}
 					s.bindOAuthAffiliate(ctx, user.ID, affiliateCode)
 				}
 			} else {
@@ -751,7 +758,9 @@ func (s *AuthService) loginOrRegisterOAuthWithTokenPair(ctx context.Context, ema
 					s.postAuthUserBootstrap(ctx, user, signupSource, false)
 					s.assignSubscriptions(ctx, user.ID, grantPlan.Subscriptions, "auto assigned by signup defaults")
 					// snapshot user × platform quota（fail-open）
-					_ = s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan)
+					if err := s.snapshotPlatformQuotaDefaults(ctx, user.ID, &grantPlan); err != nil {
+						slog.Error("quota snapshot failed", "user_id", user.ID, "err", err)
+					}
 					s.bindOAuthAffiliate(ctx, user.ID, affiliateCode)
 					if invitationRedeemCode != nil {
 						if err := s.redeemRepo.Use(ctx, invitationRedeemCode.ID, user.ID); err != nil {

--- a/scripts/checks/platform-registry-drift.py
+++ b/scripts/checks/platform-registry-drift.py
@@ -3,7 +3,7 @@
 
 The platform registry is written by hand on BOTH sides of the wire and the
 comments merely *ask* for lockstep. This check makes the ask mechanical.
-Six mirrored pairs, backend Go is the single source of truth:
+Eleven mirrored pairs, backend Go is the single source of truth:
 
   1. OpenAI-compat platforms
        backend/internal/engine/provider.go        OpenAICompatPlatforms()
@@ -50,6 +50,33 @@ Six mirrored pairs, backend Go is the single source of truth:
        - backend-only value → the admin UI cannot offer or render the type;
        - frontend-only value → typed forms emit a value the backend rejects.
 
+  7. Role Go↔TS lockstep
+       backend/internal/domain/constants.go       Role* string constants
+       frontend/src/types/index.ts                User.role inline union
+     Drift → the admin UI offers a role the backend rejects, or vice versa.
+
+  8. RedeemType Go↔TS lockstep
+       backend/internal/domain/constants.go       RedeemType* string constants
+       frontend/src/types/index.ts                RedeemCodeType union
+     Drift → redeem code creation form emits a type the backend rejects.
+
+  9. SubscriptionType Go↔TS lockstep
+       backend/internal/domain/constants.go       SubscriptionType* string constants
+       frontend/src/types/index.ts                SubscriptionType union
+     Drift → group subscription type selector offers invalid values.
+
+ 10. SubscriptionStatus Go↔TS lockstep
+       backend/internal/domain/constants.go       SubscriptionStatus* string constants
+       frontend/src/types/index.ts                UserSubscription.status inline union
+     Drift → subscription status badge/filter silently drops a state.
+
+ 11. GroupPlatform Go↔TS lockstep
+       backend/internal/domain/constants.go       Platform* string constants
+       frontend/src/types/index.ts                GroupPlatform union
+     Validates GroupPlatform stays in lockstep with the same Platform*
+     constant universe that backs AccountPlatform (CHECK 3). A stale subset
+     means the group-creation form cannot offer a newly added platform.
+
 Go constant names (`domain.PlatformX` / service aliases `PlatformX`) are
 resolved to their string values from constants.go, so the comparison is on
 wire values, not identifiers. All parsers tolerate gofmt / prettier
@@ -63,7 +90,7 @@ silently pass.
 Exit codes
 ----------
 
-  0 — all six pairs agree
+  0 — all eleven pairs agree
   1 — drift detected (details on stderr, both sides' file:line + sets)
   2 — parse / environment failure
 
@@ -131,6 +158,49 @@ def parse_go_account_types(text: str) -> tuple[list[str], int]:
     values = [v for v, _ in consts]
     first_line = min(line for _, line in consts)
     return values, first_line
+
+
+def _parse_go_const_group(
+    text: str, prefix: str, human_label: str
+) -> tuple[list[str], int]:
+    """Generic: <Prefix>* string constants -> ([values], first_line).
+
+    Matches lines like `PrefixFoo = "bar"` and collects the string values.
+    """
+    consts: list[tuple[str, int]] = []
+    pattern = re.compile(
+        rf'^\s*{re.escape(prefix)}[A-Za-z0-9_]*\s*=\s*"([^"]*)"', re.M
+    )
+    for m in pattern.finditer(text):
+        consts.append((m.group(1), line_of(text, m.start())))
+    if not consts:
+        raise ParseFailure(
+            f"{DOMAIN_CONSTANTS}: no `{prefix}* = \"...\"` constants found -- "
+            f"{human_label} block moved/renamed? Update platform-registry-drift.py."
+        )
+    values = [v for v, _ in consts]
+    first_line = min(line for _, line in consts)
+    return values, first_line
+
+
+def parse_go_role_constants(text: str) -> tuple[list[str], int]:
+    """Role* string constants -> ([values], first_line)."""
+    return _parse_go_const_group(text, "Role", "role")
+
+
+def parse_go_redeem_type_constants(text: str) -> tuple[list[str], int]:
+    """RedeemType* string constants -> ([values], first_line)."""
+    return _parse_go_const_group(text, "RedeemType", "redeem-type")
+
+
+def parse_go_subscription_type_constants(text: str) -> tuple[list[str], int]:
+    """SubscriptionType* string constants -> ([values], first_line)."""
+    return _parse_go_const_group(text, "SubscriptionType", "subscription-type")
+
+
+def parse_go_subscription_status_constants(text: str) -> tuple[list[str], int]:
+    """SubscriptionStatus* string constants -> ([values], first_line)."""
+    return _parse_go_const_group(text, "SubscriptionStatus", "subscription-status")
 
 
 def resolve_go_idents(
@@ -268,6 +338,64 @@ def parse_ts_union(text: str, name: str, rel: str) -> tuple[list[str], int]:
         pos = mm.end()
     if not values:
         raise ParseFailure(f"{rel}:{line}: {name} union parsed empty (not a string union?)")
+    return values, line
+
+
+def parse_ts_inline_union(
+    text: str, iface_name: str, prop_name: str, rel: str
+) -> tuple[list[str], int]:
+    """Parse an inline string-union property inside an interface/type.
+
+    Matches patterns like:
+        interface User {
+            ...
+            role: 'admin' | 'user'
+            ...
+        }
+
+    Also handles optional properties (prop?:), intersections (string & ...),
+    and parenthesized unions.
+    """
+    # Find the interface/type declaration
+    iface_m = re.search(
+        rf"export\s+(?:interface|type)\s+{re.escape(iface_name)}\b", text
+    )
+    if not iface_m:
+        raise ParseFailure(
+            f"{rel}: `export interface/type {iface_name}` not found -- "
+            "renamed/moved? Update platform-registry-drift.py."
+        )
+
+    # Find the property within the interface body (search from iface start)
+    prop_pattern = re.compile(
+        rf"^\s*{re.escape(prop_name)}\s*\??\s*:\s*",
+        re.M,
+    )
+    prop_m = prop_pattern.search(text, iface_m.end())
+    if not prop_m:
+        raise ParseFailure(
+            f"{rel}: property `{prop_name}` not found in {iface_name} -- "
+            "renamed/moved? Update platform-registry-drift.py."
+        )
+    line = line_of(text, prop_m.start())
+
+    # Extract the type expression (everything from after the colon to the next
+    # newline that doesn't start with |, or to a semicolon/closing brace).
+    type_start = prop_m.end()
+    member = re.compile(r"\s*\|?\s*(?:'([^']*)'|\"([^\"]*)\")")
+    values: list[str] = []
+    pos = type_start
+    while True:
+        mm = member.match(text, pos)
+        if not mm:
+            break
+        values.append(mm.group(1) or mm.group(2))
+        pos = mm.end()
+    if not values:
+        raise ParseFailure(
+            f"{rel}:{line}: {iface_name}.{prop_name} inline union parsed empty "
+            "(not a string union?)"
+        )
     return values, line
 
 
@@ -556,6 +684,114 @@ def run(root: Path) -> tuple[list[list[str]], list[str]]:
         failures.append(fail)
     else:
         ok_lines.append(f"ok: AccountType constant universe in lockstep {fmt_set(go_acct_types)}")
+
+    # --- CHECK 7: Role Go↔TS lockstep ---
+    # The Go Role* constants must match the TS User.role inline union exactly.
+
+    go_roles, go_role_line = parse_go_role_constants(domain_text)
+    ts_roles, ts_role_line = parse_ts_inline_union(
+        ts_types_text, "User", "role", TS_TYPES_INDEX
+    )
+
+    fail = compare_pair(
+        "Role constant universe",
+        go_roles,
+        f"{DOMAIN_CONSTANTS}:{go_role_line} Role* constants",
+        ts_roles,
+        f"{TS_TYPES_INDEX}:{ts_role_line} User.role inline union",
+    )
+    if fail:
+        failures.append(fail)
+    else:
+        ok_lines.append(f"ok: Role constant universe in lockstep {fmt_set(go_roles)}")
+
+    # --- CHECK 8: RedeemType Go↔TS lockstep ---
+    # RedeemType* constants must match the TS RedeemCodeType standalone union.
+
+    go_redeem, go_redeem_line = parse_go_redeem_type_constants(domain_text)
+    ts_redeem, ts_redeem_line = parse_ts_union(
+        ts_types_text, "RedeemCodeType", TS_TYPES_INDEX
+    )
+
+    fail = compare_pair(
+        "RedeemType constant universe",
+        go_redeem,
+        f"{DOMAIN_CONSTANTS}:{go_redeem_line} RedeemType* constants",
+        ts_redeem,
+        f"{TS_TYPES_INDEX}:{ts_redeem_line} RedeemCodeType union",
+    )
+    if fail:
+        failures.append(fail)
+    else:
+        ok_lines.append(f"ok: RedeemType constant universe in lockstep {fmt_set(go_redeem)}")
+
+    # --- CHECK 9: SubscriptionType Go↔TS lockstep ---
+    # SubscriptionType* constants must match the TS SubscriptionType standalone union.
+
+    go_sub_type, go_sub_type_line = parse_go_subscription_type_constants(domain_text)
+    ts_sub_type, ts_sub_type_line = parse_ts_union(
+        ts_types_text, "SubscriptionType", TS_TYPES_INDEX
+    )
+
+    fail = compare_pair(
+        "SubscriptionType constant universe",
+        go_sub_type,
+        f"{DOMAIN_CONSTANTS}:{go_sub_type_line} SubscriptionType* constants",
+        ts_sub_type,
+        f"{TS_TYPES_INDEX}:{ts_sub_type_line} SubscriptionType union",
+    )
+    if fail:
+        failures.append(fail)
+    else:
+        ok_lines.append(
+            f"ok: SubscriptionType constant universe in lockstep {fmt_set(go_sub_type)}"
+        )
+
+    # --- CHECK 10: SubscriptionStatus Go↔TS lockstep ---
+    # SubscriptionStatus* constants must match the TS UserSubscription.status
+    # inline union.
+
+    go_sub_status, go_sub_status_line = parse_go_subscription_status_constants(domain_text)
+    ts_sub_status, ts_sub_status_line = parse_ts_inline_union(
+        ts_types_text, "UserSubscription", "status", TS_TYPES_INDEX
+    )
+
+    fail = compare_pair(
+        "SubscriptionStatus constant universe",
+        go_sub_status,
+        f"{DOMAIN_CONSTANTS}:{go_sub_status_line} SubscriptionStatus* constants",
+        ts_sub_status,
+        f"{TS_TYPES_INDEX}:{ts_sub_status_line} UserSubscription.status inline union",
+    )
+    if fail:
+        failures.append(fail)
+    else:
+        ok_lines.append(
+            f"ok: SubscriptionStatus constant universe in lockstep {fmt_set(go_sub_status)}"
+        )
+
+    # --- CHECK 11: GroupPlatform Go↔TS lockstep ---
+    # GroupPlatform must stay in lockstep with the same Platform* constant
+    # universe that AccountPlatform is checked against (CHECK 3). A stale
+    # subset means the group-creation form cannot offer a newly added platform.
+
+    ts_group_plat, ts_group_plat_line = parse_ts_union(
+        ts_types_text, "GroupPlatform", TS_TYPES_INDEX
+    )
+
+    fail = compare_pair(
+        "GroupPlatform constant universe",
+        domain_values,
+        f"{DOMAIN_CONSTANTS}:{domain_line} Platform* constants",
+        ts_group_plat,
+        f"{TS_TYPES_INDEX}:{ts_group_plat_line} GroupPlatform union",
+    )
+    if fail:
+        failures.append(fail)
+    else:
+        ok_lines.append(
+            f"ok: GroupPlatform constant universe in lockstep {fmt_set(domain_values)}"
+        )
 
     return failures, ok_lines
 

--- a/scripts/checks/test_platform_registry_drift.py
+++ b/scripts/checks/test_platform_registry_drift.py
@@ -17,6 +17,10 @@ _spec.loader.exec_module(prd)
 
 PLATFORMS = ["anthropic", "gemini", "openai", "antigravity", "newapi", "kiro", "grok"]
 ACCOUNT_TYPES = ["oauth", "setup-token", "apikey", "upstream", "bedrock", "service_account"]
+ROLES = ["admin", "user"]
+REDEEM_TYPES = ["balance", "concurrency", "subscription", "invitation"]
+SUBSCRIPTION_TYPES = ["standard", "subscription"]
+SUBSCRIPTION_STATUSES = ["active", "expired", "suspended", "revoked"]
 
 
 def _write(root: pathlib.Path, rel: str, text: str) -> None:
@@ -79,6 +83,30 @@ def _fixture(
             AccountTypeUpstream       = "upstream"
             AccountTypeBedrock        = "bedrock"
             AccountTypeServiceAccount = "service_account"
+        )
+
+        const (
+            RoleAdmin = "admin"
+            RoleUser  = "user"
+        )
+
+        const (
+            RedeemTypeBalance      = "balance"
+            RedeemTypeConcurrency  = "concurrency"
+            RedeemTypeSubscription = "subscription"
+            RedeemTypeInvitation   = "invitation"
+        )
+
+        const (
+            SubscriptionTypeStandard     = "standard"
+            SubscriptionTypeSubscription = "subscription"
+        )
+
+        const (
+            SubscriptionStatusActive    = "active"
+            SubscriptionStatusExpired   = "expired"
+            SubscriptionStatusSuspended = "suspended"
+            SubscriptionStatusRevoked   = "revoked"
         )
         """,
     )
@@ -146,6 +174,16 @@ def _fixture(
         root,
         "frontend/src/types/index.ts",
         """
+        export interface User {
+          id: number
+          role: 'admin' | 'user'
+          status: 'active' | 'disabled'
+        }
+
+        export type GroupPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'newapi' | 'kiro' | 'grok'
+
+        export type SubscriptionType = 'standard' | 'subscription'
+
         export type AccountPlatform =
           | 'anthropic'
           | 'gemini'
@@ -156,6 +194,13 @@ def _fixture(
           | 'grok'
 
         export type AccountType = 'oauth' | 'setup-token' | 'apikey' | 'upstream' | 'bedrock' | 'service_account'
+
+        export type RedeemCodeType = 'balance' | 'concurrency' | 'subscription' | 'invitation'
+
+        export interface UserSubscription {
+          id: number
+          status: 'active' | 'expired' | 'revoked' | 'suspended'
+        }
         """,
     )
     _write(
@@ -213,6 +258,159 @@ class PlatformRegistryDriftTest(unittest.TestCase):
         self.assertIn("missing: grok", rendered)
         self.assertIn("frontend LABEL_TEXT style map", rendered)
         self.assertIn("missing: kiro", rendered)
+
+    def test_all_new_checks_pass(self) -> None:
+        """All 11 checks pass with a complete, aligned fixture."""
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            _fixture(root)
+
+            failures, ok_lines = prd.run(root)
+
+        self.assertEqual(failures, [])
+        # Verify new checks produced ok lines
+        ok_text = "\n".join(ok_lines)
+        self.assertIn("Role constant universe in lockstep", ok_text)
+        self.assertIn("RedeemType constant universe in lockstep", ok_text)
+        self.assertIn("SubscriptionType constant universe in lockstep", ok_text)
+        self.assertIn("SubscriptionStatus constant universe in lockstep", ok_text)
+        self.assertIn("GroupPlatform constant universe in lockstep", ok_text)
+
+    def test_role_drift_detected(self) -> None:
+        """CHECK 7: missing role on TS side is caught."""
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            _fixture(root)
+            # Overwrite TS to drop 'user' from User.role
+            _write(
+                root,
+                "frontend/src/types/index.ts",
+                """
+                export interface User {
+                  id: number
+                  role: 'admin'
+                  status: 'active' | 'disabled'
+                }
+                export type GroupPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'newapi' | 'kiro' | 'grok'
+                export type SubscriptionType = 'standard' | 'subscription'
+                export type AccountPlatform = 'anthropic' | 'gemini' | 'openai' | 'antigravity' | 'newapi' | 'kiro' | 'grok'
+                export type AccountType = 'oauth' | 'setup-token' | 'apikey' | 'upstream' | 'bedrock' | 'service_account'
+                export type RedeemCodeType = 'balance' | 'concurrency' | 'subscription' | 'invitation'
+                export interface UserSubscription {
+                  id: number
+                  status: 'active' | 'expired' | 'revoked' | 'suspended'
+                }
+                """,
+            )
+
+            failures, _ = prd.run(root)
+
+        role_failures = [f for f in failures if "Role constant" in f[0]]
+        self.assertEqual(len(role_failures), 1)
+        self.assertIn("only in backend", "\n".join(role_failures[0]))
+        self.assertIn("user", "\n".join(role_failures[0]))
+
+    def test_redeem_type_drift_detected(self) -> None:
+        """CHECK 8: extra value on TS side is caught."""
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            _fixture(root)
+            # Overwrite TS to add an extra redeem type
+            _write(
+                root,
+                "frontend/src/types/index.ts",
+                """
+                export interface User {
+                  id: number
+                  role: 'admin' | 'user'
+                  status: 'active' | 'disabled'
+                }
+                export type GroupPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'newapi' | 'kiro' | 'grok'
+                export type SubscriptionType = 'standard' | 'subscription'
+                export type AccountPlatform = 'anthropic' | 'gemini' | 'openai' | 'antigravity' | 'newapi' | 'kiro' | 'grok'
+                export type AccountType = 'oauth' | 'setup-token' | 'apikey' | 'upstream' | 'bedrock' | 'service_account'
+                export type RedeemCodeType = 'balance' | 'concurrency' | 'subscription' | 'invitation' | 'bogus'
+                export interface UserSubscription {
+                  id: number
+                  status: 'active' | 'expired' | 'revoked' | 'suspended'
+                }
+                """,
+            )
+
+            failures, _ = prd.run(root)
+
+        redeem_failures = [f for f in failures if "RedeemType constant" in f[0]]
+        self.assertEqual(len(redeem_failures), 1)
+        self.assertIn("only in frontend", "\n".join(redeem_failures[0]))
+        self.assertIn("bogus", "\n".join(redeem_failures[0]))
+
+    def test_subscription_status_drift_detected(self) -> None:
+        """CHECK 10: missing subscription status on TS side is caught."""
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            _fixture(root)
+            # Overwrite TS to drop 'suspended' from UserSubscription.status
+            _write(
+                root,
+                "frontend/src/types/index.ts",
+                """
+                export interface User {
+                  id: number
+                  role: 'admin' | 'user'
+                  status: 'active' | 'disabled'
+                }
+                export type GroupPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'newapi' | 'kiro' | 'grok'
+                export type SubscriptionType = 'standard' | 'subscription'
+                export type AccountPlatform = 'anthropic' | 'gemini' | 'openai' | 'antigravity' | 'newapi' | 'kiro' | 'grok'
+                export type AccountType = 'oauth' | 'setup-token' | 'apikey' | 'upstream' | 'bedrock' | 'service_account'
+                export type RedeemCodeType = 'balance' | 'concurrency' | 'subscription' | 'invitation'
+                export interface UserSubscription {
+                  id: number
+                  status: 'active' | 'expired' | 'revoked'
+                }
+                """,
+            )
+
+            failures, _ = prd.run(root)
+
+        sub_failures = [f for f in failures if "SubscriptionStatus constant" in f[0]]
+        self.assertEqual(len(sub_failures), 1)
+        self.assertIn("only in backend", "\n".join(sub_failures[0]))
+        self.assertIn("suspended", "\n".join(sub_failures[0]))
+
+    def test_group_platform_drift_detected(self) -> None:
+        """CHECK 11: GroupPlatform missing a platform is caught."""
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            _fixture(root)
+            # Overwrite TS to make GroupPlatform a stale subset (missing 'grok')
+            _write(
+                root,
+                "frontend/src/types/index.ts",
+                """
+                export interface User {
+                  id: number
+                  role: 'admin' | 'user'
+                  status: 'active' | 'disabled'
+                }
+                export type GroupPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'newapi' | 'kiro'
+                export type SubscriptionType = 'standard' | 'subscription'
+                export type AccountPlatform = 'anthropic' | 'gemini' | 'openai' | 'antigravity' | 'newapi' | 'kiro' | 'grok'
+                export type AccountType = 'oauth' | 'setup-token' | 'apikey' | 'upstream' | 'bedrock' | 'service_account'
+                export type RedeemCodeType = 'balance' | 'concurrency' | 'subscription' | 'invitation'
+                export interface UserSubscription {
+                  id: number
+                  status: 'active' | 'expired' | 'revoked' | 'suspended'
+                }
+                """,
+            )
+
+            failures, _ = prd.run(root)
+
+        gp_failures = [f for f in failures if "GroupPlatform constant" in f[0]]
+        self.assertEqual(len(gp_failures), 1)
+        self.assertIn("only in backend", "\n".join(gp_failures[0]))
+        self.assertIn("grok", "\n".join(gp_failures[0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

架构审查 Wave 3 收口：三路并发军团修复 SSOT 违规 + 漂移检查扩展 + 数据流错误日志。

**Alpha — SSOT 常量替换（F-01/F-07）：**
- `backend_mode_guard.go`、`page_handler.go`：安全中间件 `"admin"` → `service.RoleAdmin`
- `admin_service.go`：`"admin"`/`"disabled"` → `RoleAdmin`/`StatusDisabled`
- `mappers.go`：`"admin_balance"`/`"admin_concurrency"` → `service.AdjustmentTypeAdminBalance`/`AdjustmentTypeAdminConcurrency`

**Beta — 漂移检查扩展 7→12 项（F-05/F-06）：**
- 新增泛化解析器 `_parse_go_const_group` + `parse_ts_inline_union`（处理 interface 内联 union）
- CHECK 7: Role Go↔TS, CHECK 8: RedeemType, CHECK 9: SubscriptionType, CHECK 10: SubscriptionStatus, CHECK 11: GroupPlatform
- 8 项测试全绿，含 mutation testing 验证

**Gamma — 数据流错误日志（F-04）：**
- 6 处 `_ = s.snapshotPlatformQuotaDefaults(...)` → `slog.Error` 错误日志
- auth_service.go ×4, auth_oauth_email_flow.go ×1, auth_email_oauth_auto.go ×1

## 风险

- **低风险**：SSOT 替换纯值一致，drift checker 纯追加，slog.Error 不改控制流
- 3/3 对抗验证 CONFIRMED（含 mutation test）
- sentinel-registry-reviewed
- upstream-touch-trivial

## 验证

- `go build ./...` — 编译通过
- `go vet ./...` — 通过
- `python3 scripts/checks/platform-registry-drift.py` — 12/12 checks 全绿
- `python3 scripts/checks/test_platform_registry_drift.py` — 8/8 通过
- `scripts/preflight.sh` — PASS

## 提交

- 3027c78bc fix(arch): Wave 3 closeout — SSOT constants, drift checker expansion, data flow logging
- b3727483b chore: no-web-impact marker for Wave 3

最新提交：b3727483b
