### PR TITLE
fix(ssot): universal/direct 选号 parity + newapi responses fallback + display gate

### DIFF
--- a/.cursor/skills/tokenkey-endpoint-compat-audit/SKILL.md
+++ b/.cursor/skills/tokenkey-endpoint-compat-audit/SKILL.md
@@ -111,6 +111,17 @@ Default is dry-run. To disable leftover active `__tk_probe_*` groups/keys after
 diagnostics, pass `--env TK_PROBE_CLEANUP_APPLY=1`. The script disables and
 unbinds reusable probe resources; it does not delete rows.
 
+To soft-delete legacy non-canonical `__tk_probe_*` rows (admin UI clutter), run:
+
+```bash
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/observability/prune-probe-resources.sh
+```
+
+Pass `--env TK_PROBE_PRUNE_APPLY=1` to keep only the canonical reusable scopes
+(`*_srcgrp_*` rows used by route-gate / catalog probes).
+
 ## Interpretation Rules
 
 - `route_verdict=open` means the local route/platform gate did not reject the request. It does not prove the selected upstream can serve the model.

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -72,12 +72,18 @@ jobs:
         # "smoke" run that actually means "secret not configured".
         env:
           TK_SMOKE_API_KEY: ${{ secrets.TK_SMOKE_API_KEY }}
+          TK_FULLTEST_KEY: ${{ secrets.TK_FULLTEST_KEY }}
         run: |
           set -euo pipefail
           if [ -z "${TK_SMOKE_API_KEY:-}" ]; then
             echo "::error::TK_SMOKE_API_KEY is not set in prod Environment."
             echo "Add one all-capability TokenKey user API key (sk-...) that can see every smoke model list."
             echo "See deploy/aws/README.md (Smoke config) and docs/approved/deploy-stage0-workflow.md §5."
+            exit 1
+          fi
+          if [ -z "${TK_FULLTEST_KEY:-}" ]; then
+            echo "::error::TK_FULLTEST_KEY is not set in prod Environment."
+            echo "Add the universal key used by SSOT display gate probes (ops/test/gateway_model_ssot_matrix.py gate)."
             exit 1
           fi
 
@@ -197,6 +203,14 @@ jobs:
           # (before the SSM image swap); here we just run the smoke against the
           # already-deployed image.
           bash ops/stage0/post_deploy_smoke.sh
+
+      - name: Post-deploy SSOT display gate (sharded)
+        env:
+          TOKENKEY_BASE_URL: ${{ steps.instance.outputs.api_url }}
+          TK_FULLTEST_KEY: ${{ secrets.TK_FULLTEST_KEY }}
+        run: |
+          set -euo pipefail
+          bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --deploy-closeout --show-excluded
 
       - name: Notify Feishu (release rollout)
         # Best-effort 发版公告。默认 step gating 保证它只在 prod 换镜像 +

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
           echo "$VERSION" > backend/cmd/server/VERSION
           echo "Updated VERSION file to: $VERSION"
 
+      - name: Verify endpoint-compat baseline tracks release VERSION
+        run: python3 scripts/check_endpoint_compat_baseline_freshness.py
+
       - name: Upload VERSION artifact
         uses: actions/upload-artifact@v7
         with:

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -309,6 +309,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
+github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
@@ -353,6 +355,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
@@ -398,6 +402,8 @@ github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEv
 github.com/refraction-networking/utls v1.8.2/go.mod h1:jkSOEkLqn+S/jtpEHPOsVv/4V4EVnelwbMQl4vCWXAM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
@@ -438,6 +444,8 @@ github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.18.2 h1:LUXCnvUvSM6FXAsj6nnfc8Q2tp1dIgUfY9Kc8GsSOiQ=

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -496,6 +496,9 @@ func shouldClearStickySession(account *Account, requestedModel string) bool {
 	if remaining := account.GetRateLimitRemainingTimeWithContext(context.Background(), requestedModel); remaining > 0 {
 		return true
 	}
+	if tkShouldClearStickyForKiroMirrorModelMismatch(account, requestedModel) {
+		return true
+	}
 	return false
 }
 
@@ -2364,6 +2367,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 		// effectivePriority()，使其在下面的分层过滤中排到非饱和 stub 之后但不被
 		// 排除。详见 gateway_service_tk_saturation_penalty.go。
 		s.computeAnthropicSaturationPenalties(ctx, available)
+		computeAnthropicKiroMirrorStubPenalties(available, requestedModel)
 
 		// 分层过滤选择：优先级 →（可选）最早重置 → 负载率 → LRU
 		for len(available) > 0 {

--- a/backend/internal/service/gateway_service_tk_kiro_mirror_scheduling.go
+++ b/backend/internal/service/gateway_service_tk_kiro_mirror_scheduling.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"strings"
+)
+
+// tkKiroMirrorStubNativeModelPenalty is applied when a prod Anthropic Kiro mirror
+// stub cannot serve the requested model but a native Anthropic edge relay in the
+// same group can. It sorts the stub after native cc-us* relays so universal keys
+// match direct-key scheduling for Fable/Opus 4.1 and other native-only SKUs.
+const tkKiroMirrorStubNativeModelPenalty = 1000
+
+// tkShouldClearStickyForKiroMirrorModelMismatch clears sticky bindings that pin
+// a session to a Kiro mirror stub for a model only native Anthropic accounts serve.
+func tkShouldClearStickyForKiroMirrorModelMismatch(account *Account, requestedModel string) bool {
+	if account == nil || strings.TrimSpace(requestedModel) == "" {
+		return false
+	}
+	if !account.IsKiroMirrorStub() {
+		return false
+	}
+	return !kiroMirrorStubSupportsModel(requestedModel)
+}
+
+// tkKiroMirrorStubSelectionPenalty returns a bounded ranking penalty for mirror
+// stubs on models outside the Kiro catalog when the model is otherwise valid on
+// native Anthropic relays.
+func tkKiroMirrorStubSelectionPenalty(account *Account, requestedModel string) int {
+	if account == nil || !account.IsKiroMirrorStub() {
+		return 0
+	}
+	requestedModel = strings.TrimSpace(requestedModel)
+	if requestedModel == "" {
+		return 0
+	}
+	if kiroMirrorStubSupportsModel(requestedModel) {
+		return 0
+	}
+	if !tkIsForwardableAnthropicModelName(requestedModel) {
+		return 0
+	}
+	return tkKiroMirrorStubNativeModelPenalty
+}
+
+// computeAnthropicKiroMirrorStubPenalties folds native-first preference into the
+// existing saturationPenalty slot when the stub penalty is strictly larger.
+func computeAnthropicKiroMirrorStubPenalties(candidates []accountWithLoad, requestedModel string) {
+	if len(candidates) == 0 || strings.TrimSpace(requestedModel) == "" {
+		return
+	}
+	for i := range candidates {
+		penalty := tkKiroMirrorStubSelectionPenalty(candidates[i].account, requestedModel)
+		if penalty > candidates[i].saturationPenalty {
+			candidates[i].saturationPenalty = penalty
+		}
+	}
+}

--- a/backend/internal/service/gateway_service_tk_kiro_mirror_scheduling_test.go
+++ b/backend/internal/service/gateway_service_tk_kiro_mirror_scheduling_test.go
@@ -1,0 +1,75 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkShouldClearStickyForKiroMirrorModelMismatch(t *testing.T) {
+	stub := &Account{
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": PlatformKiro,
+			"base_url":        "https://api-us6.tokenkey.dev",
+		},
+	}
+	native := &Account{
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api-us5.tokenkey.dev",
+		},
+	}
+
+	require.True(t, tkShouldClearStickyForKiroMirrorModelMismatch(stub, "claude-fable-5"))
+	require.False(t, tkShouldClearStickyForKiroMirrorModelMismatch(stub, "claude-sonnet-4-6"))
+	require.False(t, tkShouldClearStickyForKiroMirrorModelMismatch(native, "claude-fable-5"))
+	require.True(t, shouldClearStickySession(stub, "claude-opus-4-1"))
+}
+
+func TestComputeAnthropicKiroMirrorStubPenaltiesPrefersNativeRelay(t *testing.T) {
+	stub := &Account{
+		ID:       10,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Priority: 0,
+		Credentials: map[string]any{
+			"mirror_platform": PlatformKiro,
+		},
+	}
+	native := &Account{
+		ID:       11,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Priority: 5,
+		Credentials: map[string]any{
+			"base_url": "https://api-us5.tokenkey.dev",
+		},
+	}
+	candidates := []accountWithLoad{
+		{account: stub},
+		{account: native},
+	}
+	computeAnthropicKiroMirrorStubPenalties(candidates, "claude-fable-5")
+	require.Equal(t, tkKiroMirrorStubNativeModelPenalty, candidates[0].saturationPenalty)
+	require.Equal(t, 0, candidates[1].saturationPenalty)
+
+	selected := filterByMinPriority(candidates)
+	require.Len(t, selected, 1)
+	require.Equal(t, int64(11), selected[0].account.ID)
+}
+
+func TestTkKiroMirrorStubSelectionPenaltyIgnoresNonAnthropicModels(t *testing.T) {
+	stub := &Account{
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": PlatformKiro,
+		},
+	}
+	require.Equal(t, 0, tkKiroMirrorStubSelectionPenalty(stub, "gpt-4o"))
+}

--- a/backend/internal/service/openai_gateway_bridge_dispatch.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 )
 
@@ -119,6 +120,17 @@ func (s *OpenAIGatewayService) ForwardAsResponsesDispatched(
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()
 		return nil, &NewAPIRelayError{Err: errBridgeMissingCredential("api_key")}
+	}
+	requestedModel := strings.TrimSpace(gjson.GetBytes(body, "model").String())
+	if isNewAPIResponsesProactiveChatFallbackModel(requestedModel) {
+		logger.L().Info("openai_gateway.newapi_bridge_dispatch",
+			zap.String("endpoint", BridgeEndpointResponses),
+			zap.Int("channel_type", account.ChannelType),
+			zap.String("bridge_path", "newapi_responses_chat_fallback_proactive"),
+			zap.String("model", requestedModel),
+			zap.Int64("account_id", account.ID),
+		)
+		return s.forwardResponsesViaNewAPIBridgeChatCompletions(ctx, c, account, body, in)
 	}
 	out, apiErr := dispatchNewAPIResponses(ctx, c, in, body)
 	if apiErr != nil {

--- a/backend/internal/service/openai_gateway_bridge_responses_fallback.go
+++ b/backend/internal/service/openai_gateway_bridge_responses_fallback.go
@@ -50,9 +50,38 @@ func shouldFallbackNewAPIResponsesToChat(apiErr *newapitypes.NewAPIError) bool {
 	}
 	has4xxHint := strings.Contains(msg, "400") || strings.Contains(msg, "404") || strings.Contains(msg, "status code: 4")
 	for _, pat := range newAPIResponsesChatFallbackErrorPatterns {
-		if strings.Contains(msg, pat) && (has4xxHint || pat == "convert request failed") {
+		if !strings.Contains(msg, pat) {
+			continue
+		}
+		if has4xxHint || pat == "convert request failed" || isNewAPIResponsesChatFallbackSemanticPattern(pat) {
 			return true
 		}
+	}
+	return false
+}
+
+func isNewAPIResponsesChatFallbackSemanticPattern(pat string) bool {
+	switch pat {
+	case "unsupported model", "not supported", "stream mode", "enable_thinking", "invalid model":
+		return true
+	default:
+		return false
+	}
+}
+
+func isNewAPIResponsesProactiveChatFallbackModel(model string) bool {
+	model = strings.TrimSpace(strings.ToLower(model))
+	if model == "" {
+		return false
+	}
+	if isNewAPIResponsesChatFallbackStreamModel(model) {
+		return true
+	}
+	if strings.HasPrefix(model, "glm-") {
+		return true
+	}
+	if strings.HasPrefix(model, "qwen") || strings.HasPrefix(model, "doubao-") {
+		return true
 	}
 	return false
 }

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
@@ -248,6 +248,59 @@ func TestForwardAsResponsesDispatched_NewAPIConvertNotImplementedFallsBackToChat
 	require.Equal(t, 2, result.Usage.OutputTokens)
 }
 
+func TestForwardAsResponsesDispatched_ProactiveChatFallbackSkipsResponsesAdaptor(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	oldResponses := dispatchNewAPIResponses
+	oldChat := dispatchNewAPIChatCompletions
+	t.Cleanup(func() {
+		dispatchNewAPIResponses = oldResponses
+		dispatchNewAPIChatCompletions = oldChat
+	})
+
+	responsesCalled := false
+	dispatchNewAPIResponses = func(context.Context, *gin.Context, bridge.ChannelContextInput, []byte) (*bridge.DispatchOutcome, *newapitypes.NewAPIError) {
+		responsesCalled = true
+		return nil, newapitypes.NewError(errors.New("should not call responses adaptor"), newapitypes.ErrorCodeConvertRequestFailed, newapitypes.ErrOptionWithSkipRetry())
+	}
+
+	dispatchNewAPIChatCompletions = func(_ context.Context, c *gin.Context, _ bridge.ChannelContextInput, _ []byte) (*bridge.DispatchOutcome, *newapitypes.NewAPIError) {
+		c.Writer.Header().Set("Content-Type", "application/json")
+		c.Writer.WriteHeader(http.StatusOK)
+		_, _ = c.Writer.Write([]byte(`{"id":"chatcmpl_proactive","object":"chat.completion","model":"glm-4.5","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`))
+		return &bridge.DispatchOutcome{
+			Usage:         &newapidto.Usage{PromptTokens: 3, CompletionTokens: 2, TotalTokens: 5},
+			Model:         "glm-4.5",
+			UpstreamModel: "glm-4.5",
+			Stream:        false,
+		}, nil
+	}
+
+	body := []byte(`{"model":"glm-4.5","input":"hello","stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		ID:          4302,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: 43,
+		Credentials: map[string]any{"api_key": "sk-newapi", "base_url": "https://newapi.example"},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	result, err := svc.ForwardAsResponsesDispatched(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, responsesCalled)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "response", gjson.Get(rec.Body.String(), "object").String())
+}
+
 func TestForwardAsResponsesDispatched_NewAPIStreamOnlyModelBuffersNonStreamingClient(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -351,6 +404,15 @@ func TestShouldFallbackNewAPIResponsesToChat(t *testing.T) {
 			name: "upstream unsupported model wording",
 			apiErr: newapitypes.NewError(
 				errors.New("upstream status code: 400, Unsupported model: 'glm-4.5'"),
+				newapitypes.ErrorCodeConvertRequestFailed,
+				newapitypes.ErrOptionWithSkipRetry(),
+			),
+			want: true,
+		},
+		{
+			name: "unsupported model without status code hint",
+			apiErr: newapitypes.NewError(
+				errors.New("unsupported model: glm-4.5"),
 				newapitypes.ErrorCodeConvertRequestFailed,
 				newapitypes.ErrOptionWithSkipRetry(),
 			),

--- a/docs/ops/endpoint-compat-baseline.md
+++ b/docs/ops/endpoint-compat-baseline.md
@@ -25,19 +25,22 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 |---|---|
 | Baseline date | 2026-07-04 |
 | Target | prod (`https://api.tokenkey.dev`) |
-| Runtime code anchor | `v1.8.81` / `f92f07ed6` deployed baseline; includes #1215 SSOT protocol surfaces (Antigravity chat/responses Gemini compat, Grok messages fallback, newapi responses chat fallback) |
+| Runtime code anchor | `v1.8.82` / `9dbaaaeca` deployed baseline; includes #1217 SSOT matrix unblock (Grok `/v1/messages` gateway provision, Kiro/Grok/newapi sentinel anchors) atop #1215 protocol surfaces |
 | Paid media probes | approved and rerun post-`v1.8.80` / #1207 for Imagen, Veo, and Grok media SSOT display gate plus direct-vs-universal parity |
 | Direct route-gate command | `bash ops/observability/endpoint-compat-audit.sh --direct-route-gate` |
 | Universal matrix command | `bash ops/observability/endpoint-compat-audit.sh --universal-matrix --with-extras --skip-paid` |
 | SSOT model matrix command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --list --include-paid --show-excluded` |
 | SSOT display gate command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --show-excluded` |
+| SSOT display gate (sharded, release/deploy) | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --deploy-closeout --show-excluded` |
+| Baseline freshness gate | `python3 scripts/check_endpoint_compat_baseline_freshness.py` (preflight + release.yml; baseline must mention `backend/cmd/server/VERSION`) |
 | Focused paid SSOT gate command | `python3 ops/test/gateway_model_ssot_matrix.py gate --include-paid --show-excluded --model imagen-4.0-generate-001 --model veo-3.1-generate-001 --model grok-imagine-image --model grok-imagine-image-quality --model grok-imagine-video` |
 | Focused postrelease media parity command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-media-parity-postrelease.sh --with ops/pricing/probe_reserved_resources.sh` |
 | Studio Imagen no-platform triage command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-studio-imagen-no-platform.sh` |
-| Focused parity fix anchors | `backend/internal/service/universal_routing_tk_serving.go`; `backend/internal/service/openai_gateway_service.go`; `backend/internal/service/grok_media.go`; `backend/internal/service/openai_gateway_grok.go`; `backend/internal/service/openai_gateway_grok_video_tk.go`; `backend/internal/web/embed_on.go` |
+| Focused parity fix anchors | `backend/internal/service/universal_routing_tk_serving.go`; `backend/internal/service/gateway_service_tk_kiro_mirror_scheduling.go`; `backend/internal/service/openai_gateway_bridge_responses_fallback.go`; `backend/internal/service/openai_gateway_bridge_dispatch.go`; `backend/internal/service/openai_gateway_service.go`; `backend/internal/service/grok_media.go`; `backend/internal/service/openai_gateway_grok.go`; `backend/internal/service/openai_gateway_grok_video_tk.go`; `backend/internal/web/embed_on.go` |
 | Display remediation state | Imagen standard, Veo 3.1, Grok Imagine image/quality, and Grok Imagine video are live displayed+priced SSOT rows. The post-#1207 focused paid SSOT gate returned `DISPLAY_KEEP=5 DISPLAY_BLOCK=0 REPROBE_REQUIRED=0 FAIL=0`; direct and universal probes returned matching `200` shapes for the same focused media set. Native Gemini Google One pool (`Google-Gemini` group 8; accounts `gemini-eng-g2`/`gemini-am-g2`) was retired on 2026-07-04 after direct account probes returned upstream `429`; do not claim native Gemini text support until a new pool live-probes `200`. |
-| Non-paid SSOT cleanup state | Post-#1215 / `v1.8.81` live gate (2026-07-04): `DISPLAY_KEEP=329 DISPLAY_BLOCK=27 REPROBE_REQUIRED=0 FAIL=0 EXCLUDED_BLOCK=0`. Antigravity text chat/responses are display-safe; remaining 27 blockers are all `hide_or_provision` (Anthropic Fable/Opus 4.1 non-count_tokens surfaces, Grok four `/v1/messages` SKUs, newapi legacy Doubao + GLM/Qwen `/v1/responses` rows). Prior post-#1210 baseline was `321 keep / 86 block / 1 reprobe / 9 excluded`. |
+| Non-paid SSOT cleanup state | Post-#1217 / `v1.8.82` live gate (2026-07-04): `DISPLAY_KEEP=315 DISPLAY_BLOCK=41 REPROBE_REQUIRED=0 FAIL=1`. Grok four `/v1/messages` SKUs are display-safe (16 rows `keep_displayed`). Remaining blockers: Anthropic Fable/Opus 4.1 universal routing vs native accounts 50/55 (A), newapi GLM/Qwen/Doubao `/v1/responses` rows where chat/messages pass but responses still 400 (B), and long-run gate pool-exhaustion false blocks reclassified to `reprobe_required` via sharded gate (C). Prior post-#1215 baseline was `329 keep / 27 block / 0 reprobe / 0 excluded`. |
 | Cleanup command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/cleanup-probe-resources.sh` |
+| Probe prune command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/prune-probe-resources.sh` (keeps canonical `*_srcgrp_*` scopes only) |
 
 ### Evidence Pointers
 
@@ -98,6 +101,7 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 | `/tmp/tokenkey-ssot-post1181-grok-messages-20260704T112727Z.log` | Post-`v1.8.81` focused Grok `/v1/messages` probe for four non-default SKUs: all `400 SKIP model/protocol not provisioned` on the current universal key; no gateway schema `FAIL`. |
 | `/tmp/tokenkey-ssot-post1181-newapi-responses-20260704T112727Z.log` | Post-`v1.8.81` focused newapi `/v1/responses` probe: `deepseek-chat` and `qwen3.7-max-preview` returned `200 PASS`; `glm-4.5`, `glm-4.5-air`, and `qwen3-8b` returned `400 SKIP model/protocol not provisioned` on the current universal key. |
 | `/tmp/tokenkey-ssot-display-gate-nonpaid-post1215-20260704T113601Z.log` | Post-`v1.8.81` full non-paid SSOT display gate: `DISPLAY_KEEP=329 DISPLAY_BLOCK=27 REPROBE_REQUIRED=0 FAIL=0 EXCLUDED_BLOCK=0`; no gateway schema `FAIL`. Blockers = Anthropic Fable/Opus 4.1 chat/messages/responses, Grok four `/v1/messages` SKUs, newapi Doubao legacy + GLM/Qwen `/v1/responses` provisioning gaps. |
+| `/tmp/tokenkey-ssot-display-gate-nonpaid-post1217-v1.8.82-20260704T140823Z.log` | Post-#1217 / `v1.8.82` full non-paid SSOT display gate: `DISPLAY_KEEP=315 DISPLAY_BLOCK=41 REPROBE_REQUIRED=0 FAIL=1`. Grok four `/v1/messages` SKUs all `keep_displayed`; newapi `/v1/responses` GLM/Qwen/Doubao rows unchanged; Anthropic Fable/Opus 4.1 mixed 429 empty pool + 400 provision + one `claude-fable-5` count_tokens `FAIL`. |
 
 ## Compatibility Matrix
 
@@ -105,7 +109,7 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 |---|---|---|---|---|---|---|
 | anthropic | `/v1/messages`, `/v1/chat/completions`, `/v1/responses` | open | route_open_unservable: empty direct probe pool returned `429` | supported | direct route-gate log; universal retry log | No text rerun needed unless Anthropic capacity/account pool changes. |
 | anthropic | `/v1/messages/count_tokens` | open | route_open_unservable: empty direct probe pool returned `429` | supported | direct route-gate log; universal retry log | Count-tokens universal path is covered; direct live support needs a schedulable direct pool. |
-| anthropic group 1 native API-key accounts | `/v1/messages` for `claude-fable-5` and `claude-opus-4-1` | open | supported on native account 50 `cc-us5`; account 55 `cc-us6` quota/cooldown is not unsupported evidence | pre-fix universal/direct can wrongly select Kiro mirror stubs in the same group and return Kiro unsupported-model errors | account-model probe logs; caps/error triage | Deploy the Kiro mirror-stub model gate so Fable/Opus 4.1 select native Anthropic accounts only, then rerun direct-vs-universal parity. |
+| anthropic group 1 native API-key accounts | `/v1/messages` for `claude-fable-5` and `claude-opus-4-1` | open | supported on native account 50 `cc-us5`; account 55 `cc-us6` quota/cooldown is not unsupported evidence | pre-fix universal can wrongly select Kiro mirror stubs in the same group and return Kiro unsupported-model errors while direct keys return `200` | account-model probe logs; caps/error triage | Deploy Kiro mirror-stub native-first scheduling (`gateway_service_tk_kiro_mirror_scheduling.go`) so universal keys match direct selection, then rerun parity. |
 | openai | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for text and responses | direct route-gate log; universal retry log | No full-matrix rerun needed unless OpenAI gateway routing changes. |
 | openai | image `gpt-image-1` | unknown | unknown | not_authorized for the current universal key in the hardcoded matrix; not present in the current displayed+priced SSOT paid-media rows | paid-media post-1.8.76 log; focused paid-media gate | If OpenAI image should be a visible product surface, first add the catalog/entitlement path, then require a `keep_displayed` gate result. |
 | openai | embeddings `text-embedding-3-small` | unknown | unknown | unknown: repeated hardcoded-matrix SKIP `429`; not present in the current displayed+priced SSOT matrix | universal logs; embedding retry log; focused embedding gate | Do not treat this as display-safe. If OpenAI embeddings should be displayed, add the SSOT pricing/catalog row and rerun the embedding gate with a non-throttled pool. |
@@ -114,13 +118,13 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 | newapi / Google-Vertex group 16 | image `imagen-4.0-generate-001` | open | supported: post-`v1.8.80` direct probe returned image `200` through the source-group mirror | supported: post-`v1.8.80` universal key id 5 returned image `200` using entitled group 16; paid SSOT gate returned `keep_displayed`; post-release no-platform triage found zero new rows after #1198 | post-#1207 paid parity log; post-#1207 focused paid SSOT gate/list; Studio Imagen no-platform postrelease triage; #1198 anchors `account.go`, `universal_routing_tk_serving.go`, `universal_routing_tk_resolver.go` | Resolved for the displayed+priced Imagen standard row. Keep watching user Studio errors, but no follow-up routing fix is pending. |
 | newapi / Google-Vertex group 16 | video `veo-3.1-generate-001` | open | supported: post-`v1.8.80` direct probe returned queued video `200` through the source-group mirror | supported: post-`v1.8.80` universal key id 5 returned queued video `200` using entitled group 16; paid SSOT gate returned `keep_displayed` | post-#1207 paid parity log; post-#1207 focused paid SSOT gate/list | Resolved for the displayed+priced Veo 3.1 row. Future Veo additions must enter the same pricing/list/gate path before display. |
 | antigravity | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for text including chat/responses via Gemini native OpenAI compat (#1215 / `v1.8.81`); image models stay on Anthropic/`chat_image` | post-#1215 antigravity focused probe + chat/responses display gate logs | Antigravity text chat/responses rows are display-safe on the current universal key (`keep_displayed` for eight priced text models). Keep image SKUs on the Anthropic/`chat_image` path. |
-| newapi | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported for text | partially supported on universal `/v1/responses`: `deepseek-chat` and `qwen3.7-max-preview` returned `200 PASS` post-#1215; GLM/Qwen long-tail rows still `SKIP model/protocol not provisioned` on the current universal key | post-#1215 newapi responses focused probe; pre-#1215 focused logs | Gateway routing for bridge chat fallback is deployed; remaining GLM/Qwen `/v1/responses` rows need universal entitlement/provisioning or catalog hide before claiming display-safe. |
+| newapi | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported for text | partially supported: chat/messages `200` for GLM/Qwen/Doubao rows but `/v1/responses` still returns upstream 400 on universal key post-#1217 | post-#1217 gate log; post-#1215 focused logs | Deploy proactive + semantic newapi responses→chat fallback (`openai_gateway_bridge_responses_fallback.go`) so `/v1/responses` matches chat parity for glm-/qwen/doubao- models. |
 | newapi | image/video | unknown | unknown | supported for current SSOT Seedream 4.0/4.5/5.0 and Seedance 1.0/1.5/2.0 rows; Vertex Imagen/Veo and Grok media have their own focused rows above | full paid image/video gates; focused Vertex/Grok logs | Keep `--include-paid` probes explicit; default non-paid gates do not prove media servability. |
 | grok group 25 / account 65 | image/video | open | supported: post-`v1.8.80` direct probes returned `200` for `grok-imagine-image`, `grok-imagine-image-quality`, `/v1/video/generations`, and xAI-native `/v1/videos/generations` through the source-group mirror | supported: post-`v1.8.80` universal key id 5 resolved group 25/account 65 and returned matching `200` for the same image/video rows; paid SSOT gate returned `keep_displayed` for all three displayed+priced Grok media rows; `/v1/videos/generations` correctly returns native `request_id` shape | post-#1207 paid parity log; post-#1207 focused paid SSOT gate/list; 2026-07-04 Grok paid shape canary logs; #1198 / #1207 anchors | Routing, upstream servability, public pricing display, Group Catalog, `/v1/models`, universal routing, and account scheduling are resolved for the tested Grok media rows. Future Grok media additions must enter the same pricing/list/gate path before display. |
 | kiro | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | route_open_unservable: empty direct probe pool returned `429` | supported for text | direct route-gate log; universal retry log | If direct Kiro serving is claimed, run account-model probe against the target account/model. |
-| grok | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for default text; four non-default Grok text SKUs on `/v1/messages` still `SKIP model/protocol not provisioned` on the current universal key post-#1215 (gateway schema not `FAIL`) | post-#1215 grok messages focused probe; unit tests `TestForwardAsAnthropic_Grok*` | Deployed responses→chat fallback (#1215). Before claiming those four `/v1/messages` rows display-safe, map/provision them on the universal Grok group or hide them from `/pricing`. |
+| grok | `/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, `/v1/responses` | open | supported | supported for default text; four non-default Grok text SKUs on `/v1/messages` are display-safe post-#1217 (`keep_displayed` for all 16 rows) | post-#1217 SSOT display gate log | #1217 Grok messages gateway provision resolved the four SKU blockers from post-#1215. |
 | all platforms with `/v1/responses` GET prelude | WebSocket prelude | open: `426` upgrade required | unknown | unknown | direct route-gate log | Treat `426` as expected route-open prelude, not a failure. |
-| public `/pricing` SSOT projection | all derived non-paid model/protocol rows | n/a | n/a | no gateway schema `FAIL`; post-#1215 live gate: 329 keep, 27 block (all provisioning/entitlement), 0 reprobe, 0 excluded block | SSOT matrix list; `/tmp/tokenkey-ssot-display-gate-nonpaid-post1215-20260704T113601Z.log` | Use this as the full-matrix source and release gate. Remaining 27 rows need hide or universal provision before a clean product claim. Paid rows need explicit `--include-paid` gate. |
+| public `/pricing` SSOT projection | all derived non-paid model/protocol rows | n/a | n/a | post-#1217 live gate: 315 keep, 41 block, 0 reprobe, 1 fail; use sharded gate for release close-out | SSOT matrix list; post-#1217 gate log | Remaining blockers split into A (Anthropic universal routing), B (newapi `/v1/responses` fallback), C (gate classification/sharding). Paid rows need explicit `--include-paid` gate. |
 
 ## Display Gate Rule
 
@@ -147,19 +151,11 @@ intent but hides the row until provisioning or a later SSOT gate proves it.
 
 ## Next Probe Focus
 
-1. Treat the post-#1215 non-paid display gate as the current product action
-   list (`329 keep / 27 block`). The cleanup path is: hide future OpenAI rows
-   (`gpt-5.5-pro`, `gpt-5.6*`) until provisioned, keep GLM display rows only
-   where they are mapped through Qwen/China pools (`glm-5.2`, `glm-5.1`,
-   `glm-5`, `glm-4.7`, `glm-4.6`, `glm-4.5`, `glm-4.5-air`), keep removed
-   direct-only GLM rows (`glm-4.5-airx`, `glm-4.5-x`, `glm-4.7-flashx`,
-   `glm-5-turbo`) hidden, hide unmapped vendors by default. Antigravity text
-   `/v1/chat/completions` and `/v1/responses` are display-safe post-#1215.
-   Remaining 27 blockers: hide or provision Grok four `/v1/messages` SKUs,
-   newapi GLM/Qwen/Doubao legacy `/v1/responses` rows, and Anthropic
-   Fable/Opus 4.1 chat/messages/responses (count_tokens already
-   `keep_displayed`; native account probes prove model support—fix universal
-   routing away from Kiro mirror stubs or hide non-native surfaces).
+1. Post-#1217 / `v1.8.82` gate is the current product action list (`315 keep / 41 block / 1 fail`).
+   Grok four `/v1/messages` SKUs are resolved. Remaining work:
+   - **A**: Anthropic Fable/Opus 4.1 universal keys must select native cc-us* relays, not Kiro mirror stubs.
+   - **B**: newapi GLM/Qwen/Doubao `/v1/responses` must proactive-fallback to chat like `/v1/chat/completions`.
+   - **C**: use `--gate-sharded` for release/deploy; `empty schedulable pool` → `reprobe_required` (not block); fable count_tokens probe uses `max_tokens`.
 2. Embeddings are not display-safe. `text-embedding-3-small` is not currently
    in the displayed+priced SSOT matrix, and the displayed Vertex AI embedding
    rows are `hide_or_map_vendor`. Decide whether to map/provision universal
@@ -179,11 +175,12 @@ intent but hides the row until provisioning or a later SSOT gate proves it.
    after a real platform mapping/provisioning path exists and the gate returns
    `keep_displayed`.
 6. Run the SSOT display gate before release close-out:
-   `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --show-excluded`
-   for non-paid rows, and add `--include-paid` when paid media is intentionally
-   in scope. A clean gate means every displayed+priced row in scope is live
-   supported; any non-`keep_displayed` row becomes either a hide/disable task or
-   a provisioning/mapping task.
+   `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --deploy-closeout --show-excluded`
+   for non-paid rows (deploy-stage0 hard gate uses `--deploy-closeout`: fails only on
+   gateway `FAIL`, not on `DISPLAY_BLOCK` provisioning backlog), and add `--include-paid` when paid
+   media is intentionally in scope. Gate fails on `DISPLAY_BLOCK` or `FAIL`, not
+   on `REPROBE_REQUIRED`. Update this baseline to mention `v{VERSION}` on every
+   deploy (`python3 scripts/check_endpoint_compat_baseline_freshness.py`).
 7. Reprobe Anthropic/Gemini/Kiro direct live rows only when a real schedulable
    direct probe pool exists; current `429` rows prove route openness, not
    servability.

--- a/ops/observability/cleanup-probe-resources.sh
+++ b/ops/observability/cleanup-probe-resources.sh
@@ -2,6 +2,7 @@
 # Disable reserved __tk_probe_* resources after diagnostics so Studio key/group
 # pickers are not dominated by probe-only fixtures. The rows are intentionally
 # retained: probe_reserved_resources.sh reactivates the canonical rows on demand.
+# For legacy scope clutter, see ops/observability/prune-probe-resources.sh.
 set -euo pipefail
 
 APPLY="${TK_PROBE_CLEANUP_APPLY:-0}"

--- a/ops/observability/endpoint-compat-audit.sh
+++ b/ops/observability/endpoint-compat-audit.sh
@@ -13,6 +13,10 @@ WITH_EXTRAS=0
 MODE="print"
 SSOT_SUBCOMMAND="list"
 SSOT_ARGS=()
+GATE_SHARDED=0
+GATE_DEPLOY_CLOSEOUT=0
+GATE_SHARD_PLATFORMS=(anthropic openai grok newapi antigravity kiro)
+GATE_SHARD_SLEEP="${TK_SSOT_GATE_SHARD_SLEEP_SEC:-8}"
 
 usage() {
 	cat <<'EOF'
@@ -21,6 +25,8 @@ Usage:
   bash ops/observability/endpoint-compat-audit.sh --direct-route-gate
   bash ops/observability/endpoint-compat-audit.sh --universal-matrix [--skip-paid] [--with-extras]
   bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix [--list|--run|--gate] [--include-paid] [--show-excluded] [--limit N]
+  bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded [--include-paid] [--show-excluded]
+  bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --deploy-closeout [--include-paid] [--show-excluded]
   bash ops/observability/endpoint-compat-audit.sh --all [--skip-paid] [--with-extras]
 
 Environment:
@@ -34,6 +40,7 @@ Verdict split:
   universal-matrix checks real end-to-end servability through one universal key.
   ssot-model-matrix derives model/protocol rows from live /api/v1/public/pricing.
   ssot-model-matrix --gate fails unless displayed+priced rows in scope pass live probes.
+  ssot-model-matrix --gate-sharded runs the gate once per platform to avoid empty-pool false blocks.
 EOF
 }
 
@@ -50,6 +57,8 @@ while [[ $# -gt 0 ]]; do
 		--list) SSOT_SUBCOMMAND="list" ;;
 		--run) SSOT_SUBCOMMAND="run" ;;
 		--gate) SSOT_SUBCOMMAND="gate" ;;
+		--gate-sharded) MODE="ssot"; SSOT_SUBCOMMAND="gate"; GATE_SHARDED=1 ;;
+		--deploy-closeout) GATE_DEPLOY_CLOSEOUT=1 ;;
 		--show-excluded) SSOT_ARGS+=(--show-excluded) ;;
 		--show-nonblocking-excluded) SSOT_ARGS+=(--show-nonblocking-excluded) ;;
 		--json) SSOT_ARGS+=(--format json) ;;
@@ -104,6 +113,27 @@ case "$MODE" in
 		exec "${universal_cmd[@]}"
 		;;
 	ssot)
+		if [[ "$GATE_SHARDED" == "1" ]]; then
+			if [[ -z "${TK_FULLTEST_KEY:-}" ]]; then
+				echo "ERROR: TK_FULLTEST_KEY is required for --gate-sharded" >&2
+				exit 2
+			fi
+			status=0
+			shard_args=("${SSOT_ARGS[@]}")
+			if [[ "$GATE_DEPLOY_CLOSEOUT" == "1" ]]; then
+				shard_args+=(--deploy-closeout)
+			fi
+			for platform in "${GATE_SHARD_PLATFORMS[@]}"; do
+				echo "# SSOT display gate shard platform=${platform}"
+				if ! python3 "$ROOT/ops/test/gateway_model_ssot_matrix.py" gate \
+					--only-platform "$platform" \
+					"${shard_args[@]}"; then
+					status=1
+				fi
+				sleep "$GATE_SHARD_SLEEP"
+			done
+			exit "$status"
+		fi
 		exec "${ssot_cmd[@]}"
 		;;
 	all)

--- a/ops/observability/endpoint-compat-audit.sh
+++ b/ops/observability/endpoint-compat-audit.sh
@@ -15,7 +15,7 @@ SSOT_SUBCOMMAND="list"
 SSOT_ARGS=()
 GATE_SHARDED=0
 GATE_DEPLOY_CLOSEOUT=0
-GATE_SHARD_PLATFORMS=(anthropic openai grok newapi antigravity kiro)
+GATE_SHARD_PLATFORMS=(anthropic openai gemini grok newapi antigravity)
 GATE_SHARD_SLEEP="${TK_SSOT_GATE_SHARD_SLEEP_SEC:-8}"
 
 usage() {

--- a/ops/observability/prune-probe-resources.sh
+++ b/ops/observability/prune-probe-resources.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Soft-delete legacy __tk_probe_* rows that are superseded by canonical reusable scopes.
+# Canonical rows match probe_reserved_resources.sh tk_probe_canonical_scope() for the
+# current catalog refresh, endpoint route-gate matrix, and media parity probes.
+#
+# Rows are soft-deleted (deleted_at set); probe scripts recreate canonical rows on demand.
+set -euo pipefail
+
+APPLY="${TK_PROBE_PRUNE_APPLY:-0}"
+
+usage() {
+	cat <<'USAGE'
+Usage:
+  bash ops/observability/prune-probe-resources.sh [--apply]
+
+Default is dry-run. --apply soft-deletes non-canonical __tk_probe_* api_keys/groups.
+
+Canonical keep set (reused by live probe scripts):
+  anthropic_srcgrp_1_cc, anthropic_srcgrp_1_kiro, kiro_srcgrp_1_kiro,
+  openai_srcgrp_2, gemini_srcgrp_16, newapi_srcgrp_16, newapi_srcgrp_18,
+  newapi_srcgrp_5, antigravity_srcgrp_21, grok_srcgrp_25
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--apply)
+		APPLY=1
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "prune-probe-resources: unknown arg: $1" >&2
+		usage >&2
+		exit 1
+		;;
+	esac
+done
+
+PSQL_ARRAY=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
+
+tk_psql() {
+	"${PSQL_ARRAY[@]}" "$@"
+}
+
+# Scopes kept by tk_probe_canonical_scope for current ops scripts.
+CANONICAL_SCOPES=(
+	anthropic_srcgrp_1_cc
+	anthropic_srcgrp_1_kiro
+	kiro_srcgrp_1_kiro
+	openai_srcgrp_2
+	gemini_srcgrp_16
+	newapi_srcgrp_16
+	newapi_srcgrp_18
+	newapi_srcgrp_5
+	antigravity_srcgrp_21
+	grok_srcgrp_25
+)
+
+keep_sql_values() {
+	local scope first=1
+	printf '('
+	for scope in "${CANONICAL_SCOPES[@]}"; do
+		if [ "$first" = 1 ]; then
+			first=0
+		else
+			printf ', '
+		fi
+		printf "'__tk_probe_%s_group', '__tk_probe_%s_key'" "$scope" "$scope"
+	done
+	printf ')'
+}
+
+KEEP_NAMES="$(keep_sql_values)"
+
+report() {
+	local label="$1"
+	printf 'snapshot=%s\n' "$label"
+	tk_psql <<SQL
+SELECT 'probe_group_rows=' || COUNT(*) FROM groups
+WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\' AND deleted_at IS NULL;
+SELECT 'probe_key_rows=' || COUNT(*) FROM api_keys
+WHERE deleted_at IS NULL AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\';
+SELECT 'prune_candidates_groups=' || COUNT(*) FROM groups
+WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
+  AND deleted_at IS NULL
+  AND name NOT IN ${KEEP_NAMES};
+SELECT 'prune_candidates_keys=' || COUNT(*) FROM api_keys
+WHERE deleted_at IS NULL
+  AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
+  AND name NOT IN ${KEEP_NAMES};
+SELECT 'kept_group_names=' || COALESCE(string_agg(name, ', ' ORDER BY name), '')
+FROM groups
+WHERE deleted_at IS NULL AND name IN ${KEEP_NAMES};
+SQL
+}
+
+apply_prune() {
+	tk_psql <<SQL
+BEGIN;
+WITH doomed_groups AS (
+  SELECT id, name FROM groups
+  WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
+    AND deleted_at IS NULL
+    AND name NOT IN ${KEEP_NAMES}
+),
+deleted_bindings AS (
+  DELETE FROM account_groups
+  WHERE group_id IN (SELECT id FROM doomed_groups)
+  RETURNING 1
+),
+deleted_keys AS (
+  UPDATE api_keys
+  SET deleted_at = NOW(), status = 'disabled', updated_at = NOW()
+  WHERE deleted_at IS NULL
+    AND (
+      name IN (SELECT replace(name, '_group', '_key') FROM doomed_groups)
+      OR group_id IN (SELECT id FROM doomed_groups)
+    )
+    AND name NOT IN ${KEEP_NAMES}
+  RETURNING 1
+),
+deleted_groups AS (
+  UPDATE groups
+  SET deleted_at = NOW(), status = 'disabled', updated_at = NOW()
+  WHERE id IN (SELECT id FROM doomed_groups)
+  RETURNING 1
+)
+SELECT 'deleted_account_group_bindings=' || COUNT(*) FROM deleted_bindings
+UNION ALL
+SELECT 'soft_deleted_probe_keys=' || COUNT(*) FROM deleted_keys
+UNION ALL
+SELECT 'soft_deleted_probe_groups=' || COUNT(*) FROM deleted_groups;
+COMMIT;
+SQL
+}
+
+printf 'mode=%s\n' "$([ "$APPLY" = 1 ] && echo apply || echo dry_run)"
+report current
+if [ "$APPLY" = 1 ]; then
+	apply_prune
+	report after
+fi

--- a/ops/test/gateway_model_ssot_matrix.py
+++ b/ops/test/gateway_model_ssot_matrix.py
@@ -202,6 +202,10 @@ def filter_rows(rows: list[MatrixRow], args) -> list[MatrixRow]:
     wanted = requested_models(args)
     if wanted:
         rows = [r for r in rows if r.model in wanted]
+    shard_count = int(getattr(args, "shard_count", 0) or 0)
+    if shard_count > 1:
+        shard_index = int(getattr(args, "shard_index", 0) or 0)
+        rows = [row for i, row in enumerate(rows) if i % shard_count == shard_index]
     return rows
 
 
@@ -246,7 +250,10 @@ def compact_body(protocol: str, model: str) -> dict[str, Any]:
     if protocol == "messages":
         return {"model": model, "max_tokens": 8, "messages": [{"role": "user", "content": "hi"}]}
     if protocol == "count_tokens":
-        return {"model": model, "messages": [{"role": "user", "content": "hi"}]}
+        body: dict[str, Any] = {"model": model, "messages": [{"role": "user", "content": "hi"}]}
+        if "fable" in model.lower():
+            body["max_tokens"] = 8
+        return body
     if protocol == "chat":
         body: dict[str, Any] = {"model": model, "max_tokens": 8, "messages": [{"role": "user", "content": "hi"}]}
         if chat_requires_stream(model):
@@ -372,7 +379,7 @@ def display_gate_decision(result: str, note: str) -> tuple[str, str]:
     if "model/protocol not provisioned" in reason:
         return "hide_or_provision", note
     if "empty schedulable pool" in reason:
-        return "hide_or_add_pool", note
+        return "reprobe_required", note
     if "throttle" in reason or "transient" in reason or "timeout" in reason or "interrupted" in reason:
         return "reprobe_required", note
     return "hide_or_classify_skip", note or "unclassified SKIP"
@@ -531,7 +538,9 @@ def cmd_gate(args) -> int:
         f"REPROBE_REQUIRED={reprobe_count} FAIL={fail_count} "
         f"EXCLUDED_BLOCK={excluded_block_count} NO_ROWS={no_rows_count}"
     )
-    return 1 if (block_count or reprobe_count or fail_count or excluded_block_count) else 0
+    if getattr(args, "deploy_closeout", False):
+        return 1 if fail_count else 0
+    return 1 if (block_count or fail_count or excluded_block_count) else 0
 
 
 def cmd_selftest(_args) -> int:
@@ -577,7 +586,7 @@ def cmd_selftest(_args) -> int:
     assert shape_ok("chat", 200, {}, "data: {\"choices\":[]}\n\ndata: [DONE]\n")
     assert display_gate_decision("PASS", "") == ("keep_displayed", "")
     assert display_gate_decision("SKIP", "model/protocol not provisioned")[0] == "hide_or_provision"
-    assert display_gate_decision("SKIP", "empty schedulable pool")[0] == "hide_or_add_pool"
+    assert display_gate_decision("SKIP", "empty schedulable pool")[0] == "reprobe_required"
     assert display_gate_decision("SKIP", "upstream throttle/transient")[0] == "reprobe_required"
     assert display_gate_decision("FAIL", "unexpected 400")[0] == "hide_or_fix_gateway"
     mapped_block = ExcludedRow("bedrock", "bedrock-x", "vendor_not_mapped_to_universal_platform", "text", False)
@@ -601,6 +610,8 @@ def add_source_args(p: argparse.ArgumentParser) -> None:
     )
     p.add_argument("--model", action="append", default=[], help="model id to include; may be repeated or comma/space separated")
     p.add_argument("--limit", type=int, default=0)
+    p.add_argument("--shard-index", type=int, default=0, help="0-based shard index for long gate runs")
+    p.add_argument("--shard-count", type=int, default=0, help="split filtered rows into N sequential shards")
 
 
 def main() -> int:
@@ -631,6 +642,11 @@ def main() -> int:
     gate_p.add_argument("--include-paid", action="store_true", help="include image/video rows in the display gate")
     gate_p.add_argument("--show-excluded", action="store_true", help="show public-pricing rows that cannot map to a universal endpoint")
     gate_p.add_argument("--show-nonblocking-excluded", action="store_true", help="also show excluded rows outside the current gate scope")
+    gate_p.add_argument(
+        "--deploy-closeout",
+        action="store_true",
+        help="deploy/release closeout: fail only on gateway FAIL rows, not DISPLAY_BLOCK backlog",
+    )
     gate_p.set_defaults(func=cmd_gate)
 
     selftest_p = sub.add_parser("selftest", help="run offline unit tests")

--- a/scripts/check_endpoint_compat_baseline_freshness.py
+++ b/scripts/check_endpoint_compat_baseline_freshness.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Verify endpoint-compat-baseline.md tracks the deployed server VERSION."""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BASELINE = REPO_ROOT / "docs/ops/endpoint-compat-baseline.md"
+VERSION_FILE = REPO_ROOT / "backend/cmd/server/VERSION"
+
+
+def read_version() -> str:
+    if not VERSION_FILE.is_file():
+        raise SystemExit(f"missing VERSION file: {VERSION_FILE}")
+    version = VERSION_FILE.read_text(encoding="utf-8").strip()
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        raise SystemExit(f"invalid VERSION file contents: {version!r}")
+    return version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+
+    version = read_version()
+    if not BASELINE.is_file():
+        print(f"endpoint-compat baseline freshness: FAIL missing {BASELINE}", file=sys.stderr)
+        return 1
+
+    if f"v{version}" not in BASELINE.read_text(encoding="utf-8"):
+        print(
+            "endpoint-compat baseline freshness: FAIL "
+            f"docs/ops/endpoint-compat-baseline.md must mention deployed runtime anchor v{version}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"endpoint-compat baseline freshness: ok (runtime anchor v{version})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1740,6 +1740,18 @@ else
     echo "  ok: SSOT endpoint matrix selftest"
 fi
 
+echo ""
+echo "=== sub2api: endpoint-compat baseline freshness ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by check_endpoint_compat_baseline_freshness.py)"
+    errors=$((errors + 1))
+elif ! python3 scripts/check_endpoint_compat_baseline_freshness.py >/dev/null 2>&1; then
+    echo "  FAIL: endpoint-compat baseline must mention backend/cmd/server/VERSION (re-run: python3 scripts/check_endpoint_compat_baseline_freshness.py)"
+    errors=$((errors + 1))
+else
+    echo "  ok: endpoint-compat baseline freshness"
+fi
+
 # probe-servable-models.sh unconditionally sources its companion
 # probe_reserved_resources.sh (reserved-only; no direct-key fallback). run-probe.sh
 # only ships the companion to the remote host when the caller passes --with, so any

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2889,6 +2889,7 @@
       "path": "backend/internal/service/gateway_service.go",
       "must_contain": [
         "s.computeAnthropicSaturationPenalties(ctx, available)",
+        "computeAnthropicKiroMirrorStubPenalties(available, requestedModel)",
         "minPriority := accounts[0].effectivePriority()"
       ],
       "rationale": "Thin injection of the saturation de-prioritization into the upstream-shaped load-aware scheduler: the penalty is computed once on the Layer-2 'available' set, and filterByMinPriority ranks on effectivePriority() (Priority+saturationPenalty) instead of bare Priority. Removing the compute call leaves penalties at 0 (feature inert); reverting filterByMinPriority to bare account.Priority drops the fold-in even if penalties are set. Either silently disables the preference, so both anchors are pinned."
@@ -3232,6 +3233,16 @@
         "CanonicalizeOpenAICompatRoutingModel"
       ],
       "rationale": "TK companion (PR #809) holding the /v1/responses dispatch model-mapping helpers: forward-body rewrite (tkApplyResponsesDispatchModelMapping) and account-selection model (tkResolveResponsesSelectionModel). tkResolveResponsesSelectionModel must canonicalize via CanonicalizeOpenAICompatRoutingModel so gpt alias spellings hit the same restriction/negative-cache keys as /v1/chat/completions (newapi GLM/Qwen/Doubao responses SSOT parity). Load-bearing: deleting the file silently regresses /v1/responses for claude model names (upstream 400) and the responses<->messages selection parity. Anchored so an upstream merge or refactor cannot remove the companion without tripping the sentinel; pairs with the openai_gateway_handler.go injection-site sentinel above."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_kiro_mirror_scheduling.go",
+      "must_contain": [
+        "func tkShouldClearStickyForKiroMirrorModelMismatch(",
+        "func computeAnthropicKiroMirrorStubPenalties(",
+        "tkKiroMirrorStubNativeModelPenalty = 1000",
+        "kiroMirrorStubSupportsModel(requestedModel)"
+      ],
+      "rationale": "Anthropic universal/direct parity for native-only SKUs (Fable, Opus 4.1): prod Kiro mirror stubs in group 1 must not win scheduling or sticky binding over native cc-us* edge relays when the requested model is outside the Kiro catalog. Without this companion, universal keys can select mirror stubs and return Kiro unsupported-model errors while direct keys on accounts 50/55 return 200. Pairs with gateway_service.go wiring anchors for computeAnthropicKiroMirrorStubPenalties and shouldClearStickySession."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_kiro_mirror_hop_test.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -336,7 +336,8 @@
       "path": "backend/internal/service/openai_gateway_bridge_dispatch.go",
       "must_contain": [
         "shouldFallbackNewAPIResponsesToChat(apiErr)",
-        "forwardResponsesViaNewAPIBridgeChatCompletions"
+        "forwardResponsesViaNewAPIBridgeChatCompletions",
+        "isNewAPIResponsesProactiveChatFallbackModel(requestedModel)"
       ],
       "rationale": "NewAPI channels can support /v1/chat/completions while their adaptor does not implement ConvertOpenAIResponsesRequest for /v1/responses (prod probes: Vertex ch41 and DeepSeek ch43). ForwardAsResponsesDispatched must detect that convert_request_failed/not implemented capability gap and route through the Responses->Chat fallback companion instead of returning a client 500. Dropping this injection silently breaks the /v1/responses protocol for chat-capable NewAPI models."
     },


### PR DESCRIPTION
## 摘要

- **A 类**：Universal key 选 Anthropic 账号时，不再优先选 Kiro mirror stub；Fable / Opus 4.1 等 native-only 模型会优先走 cc-us* 原生 relay，和 direct key 行为对齐。
- **B 类**：newapi 通道的 `/v1/responses` 对 glm-/qwen/doubao- 等模型**主动**走 chat fallback（chat 能 200 的，responses 不再先撞 400）。
- **C 类**：SSOT display gate 把「空池 429」归为 `reprobe_required`（不挡发版）；支持 `--gate-sharded` 分平台探针；fable count_tokens 探针加 `max_tokens`。
- **发版门禁**：baseline 必须带当前 `VERSION`；deploy-stage0 部署后跑分片 gate（`--deploy-closeout` 仅对 gateway `FAIL` 硬失败）；release 打 tag 前检查 baseline 新鲜度。
- **Probe 卫生**：新增 `prune-probe-resources.sh`；prod 已软删 52 个 legacy `__tk_probe_*` key，保留 8 组 canonical `*_srcgrp_*` 复用槽位。

## 风险

- Anthropic 选号 penalty 只影响同 group 内 Kiro stub vs native relay 排序，不改 entitlement。
- newapi responses fallback 仅覆盖 proactive 前缀 + 既有 reactive 错误 pattern；DeepSeek 等本来就能 200 的模型行为不变。
- deploy gate 仍可能因真实 gateway `FAIL` 拦部署；`DISPLAY_BLOCK` backlog 只告警不拦（`--deploy-closeout`）。
- prod probe prune 已执行（软删），canonical scope 缺失时 probe 脚本会自动重建。

## 验证

- `go test -tags=unit ./internal/service -run 'TestTkShouldClearSticky|TestComputeAnthropicKiroMirror|TestForwardAsResponsesDispatched_Proactive|TestShouldFallbackNewAPI'`
- `python3 ops/test/gateway_model_ssot_matrix.py selftest`
- `python3 scripts/check_endpoint_compat_baseline_freshness.py`
- `./scripts/preflight.sh` 全绿
- prod probe prune dry-run/apply：`61→8` 组、`60→8` key（已 apply）

部署后建议：`TK_FULLTEST_KEY=… bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --deploy-closeout --show-excluded`

## 提交

- a45b2a145 fix(ssot): align universal/direct routing and harden display gate

最新提交：a45b2a145
