### PR TITLE
perf: frontend + backend performance optimization (-96% auth pages)

### DIFF
--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/errgroup"
 )
 
 type userUsageFilters struct {
@@ -535,28 +536,49 @@ func (h *UsageHandler) DashboardSnapshotV2(c *gin.Context) {
 		"granularity":  granularity,
 	}
 
+	// Run independent DB queries concurrently. Each goroutine writes its own
+	// local variable (no shared mutable state), and errgroup propagates the
+	// first error + cancels the rest.
+	g, gctx := errgroup.WithContext(c.Request.Context())
+
+	var trend []usagestats.TrendDataPoint
+	var models []usagestats.ModelStat
+	var groups []usagestats.GroupStat
+
 	if includeTrend {
-		trend, err := h.usageService.GetUsageTrendWithFilters(c.Request.Context(), parsed.StartTime, parsed.EndTime, granularity, parsed.Filters)
-		if err != nil {
-			response.ErrorFrom(c, err)
-			return
-		}
+		g.Go(func() error {
+			var err error
+			trend, err = h.usageService.GetUsageTrendWithFilters(gctx, parsed.StartTime, parsed.EndTime, granularity, parsed.Filters)
+			return err
+		})
+	}
+	if includeModels {
+		g.Go(func() error {
+			var err error
+			models, err = h.usageService.GetModelStatsWithFiltersBySource(gctx, parsed.StartTime, parsed.EndTime, parsed.Filters, usagestats.ModelSourceRequested)
+			return err
+		})
+	}
+	if includeGroups {
+		g.Go(func() error {
+			var err error
+			groups, err = h.usageService.GetGroupStatsWithFilters(gctx, parsed.StartTime, parsed.EndTime, parsed.Filters)
+			return err
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	if includeTrend {
 		resp["trend"] = trend
 	}
 	if includeModels {
-		models, err := h.usageService.GetModelStatsWithFiltersBySource(c.Request.Context(), parsed.StartTime, parsed.EndTime, parsed.Filters, usagestats.ModelSourceRequested)
-		if err != nil {
-			response.ErrorFrom(c, err)
-			return
-		}
 		resp["models"] = userModelStatsFromUsageStats(models)
 	}
 	if includeGroups {
-		groups, err := h.usageService.GetGroupStatsWithFilters(c.Request.Context(), parsed.StartTime, parsed.EndTime, parsed.Filters)
-		if err != nil {
-			response.ErrorFrom(c, err)
-			return
-		}
 		resp["groups"] = userGroupStatsFromUsageStats(groups)
 	}
 
@@ -651,7 +673,14 @@ func (h *UsageHandler) DashboardAPIKeysUsage(c *gin.Context) {
 		return
 	}
 
-	stats, err := h.usageService.GetBatchAPIKeyUsageStats(c.Request.Context(), validAPIKeyIDs, time.Time{}, time.Time{})
+	// Default to last 30 days at the handler level to avoid scanning all-time
+	// data. The repo also applies this default, but being explicit here prevents
+	// unbounded queries if the repo default is ever removed.
+	now := time.Now()
+	startTime := now.AddDate(0, 0, -30)
+	endTime := now
+
+	stats, err := h.usageService.GetBatchAPIKeyUsageStats(c.Request.Context(), validAPIKeyIDs, startTime, endTime)
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return

--- a/backend/internal/service/channel_available.go
+++ b/backend/internal/service/channel_available.go
@@ -5,7 +5,57 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
 )
+
+const availableCacheTTL = 30 * time.Second
+
+// availableChannelsCache caches the ListAvailable result to avoid repeated
+// full-table scans on every user page load. Channels change infrequently;
+// a 30-second TTL is a good trade-off between freshness and load.
+type availableChannelsCache struct {
+	mu        sync.RWMutex
+	result    []AvailableChannel
+	expiresAt time.Time
+	gen       uint64
+	sf        singleflight.Group
+}
+
+func (c *availableChannelsCache) get() ([]AvailableChannel, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.result == nil || time.Now().After(c.expiresAt) {
+		return nil, false
+	}
+	return c.result, true
+}
+
+func (c *availableChannelsCache) generation() uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.gen
+}
+
+func (c *availableChannelsCache) setIfCurrent(result []AvailableChannel, genAtStart uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.gen != genAtStart {
+		return
+	}
+	c.result = result
+	c.expiresAt = time.Now().Add(availableCacheTTL)
+}
+
+func (c *availableChannelsCache) invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.result = nil
+	c.gen++
+	c.sf.Forget("available")
+}
 
 // AvailableGroupRef 渠道视图中关联分组的简要信息。
 //
@@ -50,6 +100,31 @@ type AvailableChannel struct {
 // 前置条件：s.groupRepo 必须非 nil（由 wire DI 保证）。直接 nil-deref 用于 fail-fast，
 // 避免静默掩盖注入缺失。
 func (s *ChannelService) ListAvailable(ctx context.Context) ([]AvailableChannel, error) {
+	// Fast path: return cached result if still fresh.
+	if cached, ok := s.availableCache.get(); ok {
+		return cached, nil
+	}
+
+	gen := s.availableCache.generation()
+
+	// Deduplicate concurrent cache-miss rebuilds via singleflight.
+	// Use context.Background() so a cancelled first-caller doesn't fail all waiters.
+	value, err, _ := s.availableCache.sf.Do("available", func() (any, error) {
+		if cached, ok := s.availableCache.get(); ok {
+			return cached, nil
+		}
+		return s.buildAvailableChannels(context.Background(), gen)
+	})
+	if err != nil {
+		return nil, err
+	}
+	result, _ := value.([]AvailableChannel)
+	return result, nil
+}
+
+// buildAvailableChannels performs the actual DB queries and assembly, then
+// stores the result in the availableCache.
+func (s *ChannelService) buildAvailableChannels(ctx context.Context, gen uint64) ([]AvailableChannel, error) {
 	channels, err := s.repo.ListAll(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list channels: %w", err)
@@ -107,6 +182,8 @@ func (s *ChannelService) ListAvailable(ctx context.Context) ([]AvailableChannel,
 	sort.SliceStable(out, func(i, j int) bool {
 		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
 	})
+
+	s.availableCache.setIfCurrent(out, gen)
 	return out, nil
 }
 

--- a/backend/internal/service/channel_available_test.go
+++ b/backend/internal/service/channel_available_test.go
@@ -155,6 +155,48 @@ func TestListAvailable_ListActiveErrorPropagates(t *testing.T) {
 	require.Contains(t, err.Error(), "list active groups", "wrap 前缀缺失，可能 %w 被改为 %v")
 }
 
+func TestListAvailable_CacheHitSkipsListAll(t *testing.T) {
+	listAllCalls := 0
+	repo := &mockChannelRepository{
+		listAllFn: func(ctx context.Context) ([]Channel, error) {
+			listAllCalls++
+			return []Channel{{ID: 1, Name: "cached-channel", Status: StatusActive}}, nil
+		},
+	}
+	svc := NewChannelService(repo, &stubGroupRepoForAvailable{}, nil, nil)
+
+	out1, err := svc.ListAvailable(context.Background())
+	require.NoError(t, err)
+	require.Len(t, out1, 1)
+	require.Equal(t, 1, listAllCalls)
+
+	out2, err := svc.ListAvailable(context.Background())
+	require.NoError(t, err)
+	require.Len(t, out2, 1)
+	require.Equal(t, 1, listAllCalls, "second ListAvailable should hit availableCache")
+}
+
+func TestListAvailable_InvalidateCacheForcesRebuild(t *testing.T) {
+	listAllCalls := 0
+	repo := &mockChannelRepository{
+		listAllFn: func(ctx context.Context) ([]Channel, error) {
+			listAllCalls++
+			return []Channel{{ID: 1, Name: "cached-channel", Status: StatusActive}}, nil
+		},
+	}
+	svc := NewChannelService(repo, &stubGroupRepoForAvailable{}, nil, nil)
+
+	_, err := svc.ListAvailable(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, listAllCalls)
+
+	svc.invalidateCache()
+
+	_, err = svc.ListAvailable(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 3, listAllCalls, "invalidateCache rebuilds channel cache then ListAvailable rebuilds available cache")
+}
+
 func TestListAvailable_DefaultsEmptyBillingModelSource(t *testing.T) {
 	// 渠道 BillingModelSource 为空时应回填为 BillingModelSourceChannelMapped，
 	// 显式值应原样保留（由 service 层统一处理，避免各 handler 重复默认逻辑）。

--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -148,6 +148,10 @@ type ChannelService struct {
 	cache   atomic.Value // *channelCache
 	cacheSF singleflight.Group
 
+	// availableCache caches the ListAvailable result (user-facing "available channels" page).
+	// Short TTL (30s) avoids full-table scans on every page load while staying fresh enough.
+	availableCache availableChannelsCache
+
 	// TK: flush group×model unsupported negative cache when channel config changes.
 	groupUnsupportedModelCacheFlush func()
 }
@@ -349,6 +353,10 @@ func matchingPlatforms(groupPlatform string) []string {
 func (s *ChannelService) invalidateCache() {
 	s.cache.Store((*channelCache)(nil))
 	s.cacheSF.Forget("channel_cache")
+
+	// Also invalidate the user-facing available channels cache so the next
+	// ListAvailable call picks up the CRUD change.
+	s.availableCache.invalidate()
 
 	if s.groupUnsupportedModelCacheFlush != nil {
 		s.groupUnsupportedModelCacheFlush()

--- a/backend/internal/service/payment_order.go
+++ b/backend/internal/service/payment_order.go
@@ -13,6 +13,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/paymentorder"
+	"github.com/Wei-Shaw/sub2api/ent/predicate"
 	"github.com/Wei-Shaw/sub2api/internal/payment"
 	"github.com/Wei-Shaw/sub2api/internal/payment/provider"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
@@ -326,18 +327,43 @@ func (s *PaymentService) checkDailyLimit(ctx context.Context, tx *dbent.Tx, user
 		return nil
 	}
 	ts := psStartOfDayUTC(time.Now())
-	orders, err := tx.PaymentOrder.Query().Where(paymentorder.UserIDEQ(userID), paymentorder.StatusIn(OrderStatusPaid, OrderStatusRecharging, OrderStatusCompleted), paymentorder.PaidAtGTE(ts)).All(ctx)
+
+	// Use DB-level aggregation instead of loading all daily orders into memory.
+	// Balance orders contribute pay_amount; all other order types contribute amount.
+	commonPredicates := []predicate.PaymentOrder{
+		paymentorder.UserIDEQ(userID),
+		paymentorder.StatusIn(OrderStatusPaid, OrderStatusRecharging, OrderStatusCompleted),
+		paymentorder.PaidAtGTE(ts),
+	}
+
+	// Sum pay_amount for balance-type orders.
+	var balanceResult []struct{ Sum float64 }
+	err := tx.PaymentOrder.Query().
+		Where(append(commonPredicates, paymentorder.OrderTypeEQ(payment.OrderTypeBalance))...).
+		Aggregate(dbent.As(dbent.Sum(paymentorder.FieldPayAmount), "sum")).
+		Scan(ctx, &balanceResult)
 	if err != nil {
-		return fmt.Errorf("query daily usage: %w", err)
+		return fmt.Errorf("query daily balance usage: %w", err)
 	}
+
+	// Sum amount for non-balance-type orders.
+	var otherResult []struct{ Sum float64 }
+	err = tx.PaymentOrder.Query().
+		Where(append(commonPredicates, paymentorder.OrderTypeNEQ(payment.OrderTypeBalance))...).
+		Aggregate(dbent.As(dbent.Sum(paymentorder.FieldAmount), "sum")).
+		Scan(ctx, &otherResult)
+	if err != nil {
+		return fmt.Errorf("query daily non-balance usage: %w", err)
+	}
+
 	var used float64
-	for _, o := range orders {
-		if o.OrderType == payment.OrderTypeBalance {
-			used += o.PayAmount
-			continue
-		}
-		used += o.Amount
+	if len(balanceResult) > 0 {
+		used += balanceResult[0].Sum
 	}
+	if len(otherResult) > 0 {
+		used += otherResult[0].Sum
+	}
+
 	if used+amount > limit {
 		return infraerrors.TooManyRequests("DAILY_LIMIT_EXCEEDED", "daily_limit_exceeded").
 			WithMetadata(map[string]string{"remaining": fmt.Sprintf("%.2f", math.Max(0, limit-used))})

--- a/backend/internal/service/payment_order_lifecycle.go
+++ b/backend/internal/service/payment_order_lifecycle.go
@@ -366,25 +366,49 @@ func normalizeOrderLookupOutTradeNo(raw string) (string, error) {
 }
 
 func (s *PaymentService) ExpireTimedOutOrders(ctx context.Context) (int, error) {
+	const batchSize = 100
 	now := time.Now()
-	orders, err := s.entClient.PaymentOrder.Query().Where(paymentorder.StatusEQ(OrderStatusPending), paymentorder.ExpiresAtLTE(now)).All(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("query expired: %w", err)
-	}
-	n := 0
-	for _, o := range orders {
-		// Check upstream payment status before expiring — the user may have
-		// paid just before timeout and the webhook hasn't arrived yet.
-		outcome, _ := s.cancelCore(ctx, o, OrderStatusExpired, "system", "order expired")
-		if outcome == checkPaidResultAlreadyPaid {
-			slog.Info("order was paid during expiry", "orderID", o.ID)
-			continue
+	total := 0
+	var lastID int64
+
+	for {
+		query := s.entClient.PaymentOrder.Query().
+			Where(
+				paymentorder.StatusEQ(OrderStatusPending),
+				paymentorder.ExpiresAtLTE(now),
+			).
+			Order(dbent.Asc(paymentorder.FieldID)).
+			Limit(batchSize)
+		if lastID > 0 {
+			query = query.Where(paymentorder.IDGT(lastID))
 		}
-		if outcome != "" {
-			n++
+
+		orders, err := query.All(ctx)
+		if err != nil {
+			return total, fmt.Errorf("query expired: %w", err)
+		}
+		if len(orders) == 0 {
+			break
+		}
+
+		for _, o := range orders {
+			lastID = o.ID
+			outcome, _ := s.cancelCore(ctx, o, OrderStatusExpired, "system", "order expired")
+			if outcome == checkPaidResultAlreadyPaid {
+				slog.Info("order was paid during expiry", "orderID", o.ID)
+				continue
+			}
+			if outcome != "" {
+				total++
+			}
+		}
+
+		if len(orders) < batchSize {
+			break
 		}
 	}
-	return n, nil
+
+	return total, nil
 }
 
 // getOrderProvider creates a provider using the order's original instance config.

--- a/backend/internal/service/payment_order_lifecycle_test.go
+++ b/backend/internal/service/payment_order_lifecycle_test.go
@@ -5,11 +5,13 @@ package service
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/enttest"
+	"github.com/Wei-Shaw/sub2api/ent/paymentorder"
 	"github.com/Wei-Shaw/sub2api/internal/payment"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/stretchr/testify/require"
@@ -793,6 +795,109 @@ func TestPaymentOrderQueryReferenceUsesOutTradeNoForOfficialProviders(t *testing
 	require.Equal(t, "sub2_out_trade_no", paymentOrderQueryReference(order, paymentFulfillmentTestProvider{
 		key: payment.TypeWxpay,
 	}))
+}
+
+func TestExpireTimedOutOrders_ProcessesMultipleBatches(t *testing.T) {
+	ctx := context.Background()
+	client := newPaymentOrderLifecycleTestClient(t)
+
+	user, err := client.User.Create().
+		SetEmail("expire-batch@example.com").
+		SetPasswordHash("hash").
+		SetUsername("expire-batch-user").
+		Save(ctx)
+	require.NoError(t, err)
+
+	const orderCount = 101
+	for i := 0; i < orderCount; i++ {
+		_, err := client.PaymentOrder.Create().
+			SetUserID(user.ID).
+			SetUserEmail(user.Email).
+			SetUserName(user.Username).
+			SetAmount(1).
+			SetPayAmount(1).
+			SetFeeRate(0).
+			SetRechargeCode(fmt.Sprintf("EXPIRE-BATCH-%03d", i)).
+			SetOutTradeNo(fmt.Sprintf("sub2_expire_batch_%03d", i)).
+			SetPaymentType(payment.TypeAlipay).
+			SetPaymentTradeNo("").
+			SetOrderType(payment.OrderTypeBalance).
+			SetStatus(OrderStatusPending).
+			SetExpiresAt(time.Now().Add(-time.Hour)).
+			SetClientIP("127.0.0.1").
+			SetSrcHost("api.example.com").
+			Save(ctx)
+		require.NoError(t, err)
+	}
+
+	svc := newExpireTimedOutOrdersTestService(client)
+	expired, err := svc.ExpireTimedOutOrders(ctx)
+	require.NoError(t, err)
+	require.Equal(t, orderCount, expired)
+
+	remaining, err := client.PaymentOrder.Query().
+		Where(paymentorder.StatusEQ(OrderStatusPending)).
+		Count(ctx)
+	require.NoError(t, err)
+	require.Zero(t, remaining)
+}
+
+func TestExpireTimedOutOrders_CompletesWhenContextCanceled(t *testing.T) {
+	ctx := context.Background()
+	client := newPaymentOrderLifecycleTestClient(t)
+
+	user, err := client.User.Create().
+		SetEmail("expire-cancel@example.com").
+		SetPasswordHash("hash").
+		SetUsername("expire-cancel-user").
+		Save(ctx)
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		_, err := client.PaymentOrder.Create().
+			SetUserID(user.ID).
+			SetUserEmail(user.Email).
+			SetUserName(user.Username).
+			SetAmount(1).
+			SetPayAmount(1).
+			SetFeeRate(0).
+			SetRechargeCode(fmt.Sprintf("EXPIRE-CANCEL-%d", i)).
+			SetOutTradeNo(fmt.Sprintf("sub2_expire_cancel_%d", i)).
+			SetPaymentType(payment.TypeAlipay).
+			SetPaymentTradeNo("").
+			SetOrderType(payment.OrderTypeBalance).
+			SetStatus(OrderStatusPending).
+			SetExpiresAt(time.Now().Add(-time.Hour)).
+			SetClientIP("127.0.0.1").
+			SetSrcHost("api.example.com").
+			Save(ctx)
+		require.NoError(t, err)
+	}
+
+	svc := newExpireTimedOutOrdersTestService(client)
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	start := time.Now()
+	_, err = svc.ExpireTimedOutOrders(canceledCtx)
+	require.Error(t, err)
+	require.Less(t, time.Since(start), 2*time.Second, "must not spin on the same batch forever")
+}
+
+func newExpireTimedOutOrdersTestService(client *dbent.Client) *PaymentService {
+	registry := payment.NewRegistry()
+	registry.Register(&paymentOrderLifecycleQueryProvider{
+		key: payment.TypeAlipay,
+		resp: &payment.QueryOrderResponse{
+			Status: payment.ProviderStatusPending,
+			Amount: 1,
+		},
+	})
+	return &PaymentService{
+		entClient:       client,
+		registry:        registry,
+		providersLoaded: true,
+	}
 }
 
 func newPaymentOrderLifecycleTestClient(t *testing.T) *dbent.Client {

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 566,
-  "hash": "d73240d84cf3b474cb9eb3838b4c20a9edc46db6a464dff5441e05a4736b198a",
+  "hash": "02dad909c4fb73ca7adda7477e72afafaea899efaf6ffb84e8e271e781606738",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/e2e/perf-audit.e2e.ts
+++ b/frontend/e2e/perf-audit.e2e.ts
@@ -2,11 +2,11 @@
  * Performance audit: navigate every page, collect timing + network data.
  *
  * Usage:
- *   # Public pages only (no login):
- *   E2E_BASE_URL=https://api.tokenkey.dev pnpm exec playwright test e2e/perf-audit.e2e.ts
+ *   # Local stack (default base URL http://localhost:8080):
+ *   E2E_PERF_AUDIT=1 pnpm exec playwright test e2e/perf-audit.e2e.ts
  *
- *   # With auth (admin cookie):
- *   E2E_SESSION_TOKEN=<token> E2E_BASE_URL=https://api.tokenkey.dev pnpm exec playwright test e2e/perf-audit.e2e.ts
+ *   # Prod/staging snapshot (explicit opt-in):
+ *   E2E_PERF_AUDIT=1 E2E_BASE_URL=https://api.tokenkey.dev pnpm exec playwright test e2e/perf-audit.e2e.ts
  *
  * Output: e2e/artifacts/perf-report.json
  */
@@ -18,9 +18,14 @@ import { fileURLToPath } from 'url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-const BASE = process.env.E2E_BASE_URL || 'https://api.tokenkey.dev'
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8080'
 const SESSION_TOKEN = process.env.E2E_SESSION_TOKEN || ''
 const REFRESH_TOKEN = process.env.E2E_REFRESH_TOKEN || ''
+
+/** Auth pages must stay fast after Stripe/Turnstile lazy-load fixes. */
+const AUTH_PAGE_NAV_MS_BUDGET = 10_000
+
+const RUN_PERF_AUDIT = process.env.E2E_PERF_AUDIT === '1'
 
 interface RequestEntry {
   url: string
@@ -234,6 +239,8 @@ async function collectPageMetrics(
 }
 
 test.describe('Performance Audit', () => {
+  test.skip(!RUN_PERF_AUDIT, 'set E2E_PERF_AUDIT=1 to run perf audit against E2E_BASE_URL')
+
   let context: BrowserContext
   let page: Page
   const allMetrics: PageMetrics[] = []
@@ -399,6 +406,13 @@ test.describe('Performance Audit', () => {
       console.log(`  → ${p}`)
       const m = await collectPageMetrics(page, p, 'public')
       allMetrics.push(m)
+      expect(m.error, `${p} navigation failed: ${m.error}`).toBeNull()
+      if (['/login', '/register', '/forgot-password'].includes(p)) {
+        expect(
+          m.navigationMs,
+          `${p} navigation exceeded ${AUTH_PAGE_NAV_MS_BUDGET}ms budget`,
+        ).toBeLessThan(AUTH_PAGE_NAV_MS_BUDGET)
+      }
     }
   })
 

--- a/frontend/e2e/perf-audit.e2e.ts
+++ b/frontend/e2e/perf-audit.e2e.ts
@@ -1,0 +1,430 @@
+/**
+ * Performance audit: navigate every page, collect timing + network data.
+ *
+ * Usage:
+ *   # Public pages only (no login):
+ *   E2E_BASE_URL=https://api.tokenkey.dev pnpm exec playwright test e2e/perf-audit.e2e.ts
+ *
+ *   # With auth (admin cookie):
+ *   E2E_SESSION_TOKEN=<token> E2E_BASE_URL=https://api.tokenkey.dev pnpm exec playwright test e2e/perf-audit.e2e.ts
+ *
+ * Output: e2e/artifacts/perf-report.json
+ */
+import { test, expect, type Page, type BrowserContext } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const BASE = process.env.E2E_BASE_URL || 'https://api.tokenkey.dev'
+const SESSION_TOKEN = process.env.E2E_SESSION_TOKEN || ''
+const REFRESH_TOKEN = process.env.E2E_REFRESH_TOKEN || ''
+
+interface RequestEntry {
+  url: string
+  method: string
+  status: number
+  duration: number
+  size: number
+  isAPI: boolean
+}
+
+interface PageMetrics {
+  path: string
+  role: 'public' | 'user' | 'admin'
+  navigationMs: number
+  ttfb: number
+  domContentLoaded: number
+  loadEvent: number
+  fcp: number | null
+  lcp: number | null
+  requestCount: number
+  apiRequestCount: number
+  totalTransferKB: number
+  slowestRequest: { url: string; duration: number } | null
+  requests: RequestEntry[]
+  error: string | null
+}
+
+const PUBLIC_PAGES = [
+  '/home',
+  '/pricing',
+  '/login',
+  '/register',
+  '/forgot-password',
+  '/key-usage',
+]
+
+const USER_PAGES = [
+  '/dashboard',
+  '/keys',
+  '/usage',
+  '/studio',
+  '/available-channels',
+  '/profile',
+  '/subscriptions',
+  '/redeem',
+  '/affiliate',
+  '/monitor',
+]
+
+const ADMIN_PAGES = [
+  '/admin/dashboard',
+  '/admin/users',
+  '/admin/accounts',
+  '/admin/channels/pricing',
+  '/admin/groups',
+  '/admin/subscriptions',
+  '/admin/usage',
+  '/admin/announcements',
+  '/admin/proxies',
+  '/admin/redeem',
+  '/admin/promo-codes',
+  '/admin/settings',
+  '/admin/ops',
+  '/admin/channels/monitor',
+  '/admin/edge-accounts',
+  '/admin/orders',
+  '/admin/orders/dashboard',
+  '/admin/orders/plans',
+  '/admin/affiliates/invites',
+  '/admin/affiliates/rebates',
+  '/admin/affiliates/transfers',
+]
+
+async function collectPageMetrics(
+  page: Page,
+  pagePath: string,
+  role: 'public' | 'user' | 'admin',
+): Promise<PageMetrics> {
+  const requests: RequestEntry[] = []
+  const requestTimings = new Map<string, number>()
+
+  page.on('request', (req) => {
+    requestTimings.set(req.url(), Date.now())
+  })
+
+  page.on('response', async (res) => {
+    const url = res.url()
+    const startTime = requestTimings.get(url) || Date.now()
+    const duration = Date.now() - startTime
+    let size = 0
+    try {
+      const body = await res.body()
+      size = body.length
+    } catch {
+      // streaming or aborted
+    }
+    const parsedUrl = new URL(url)
+    const isAPI =
+      parsedUrl.pathname.startsWith('/api/') ||
+      parsedUrl.pathname.startsWith('/v1/')
+    requests.push({
+      url: parsedUrl.pathname + parsedUrl.search,
+      method: res.request().method(),
+      status: res.status(),
+      duration,
+      size,
+      isAPI,
+    })
+  })
+
+  const metrics: PageMetrics = {
+    path: pagePath,
+    role,
+    navigationMs: 0,
+    ttfb: 0,
+    domContentLoaded: 0,
+    loadEvent: 0,
+    fcp: null,
+    lcp: null,
+    requestCount: 0,
+    apiRequestCount: 0,
+    totalTransferKB: 0,
+    slowestRequest: null,
+    requests: [],
+    error: null,
+  }
+
+  const turnstilePages = ['/login', '/register', '/forgot-password']
+  const waitStrategy = turnstilePages.includes(pagePath)
+    ? ('domcontentloaded' as const)
+    : ('networkidle' as const)
+
+  try {
+    const navStart = Date.now()
+    const response = await page.goto(pagePath, {
+      waitUntil: waitStrategy,
+      timeout: 30_000,
+    })
+    metrics.navigationMs = Date.now() - navStart
+
+    if (response) {
+      metrics.ttfb = (await response.headerValue('x-response-time'))
+        ? parseFloat((await response.headerValue('x-response-time'))!)
+        : 0
+    }
+
+    // Wait a bit for late-firing observers
+    await page.waitForTimeout(1500)
+
+    const timing = await page.evaluate(() => {
+      const nav = performance.getEntriesByType(
+        'navigation',
+      )[0] as PerformanceNavigationTiming
+      const paintEntries = performance.getEntriesByType('paint')
+      const fcpEntry = paintEntries.find(
+        (e) => e.name === 'first-contentful-paint',
+      )
+
+      let lcp: number | null = null
+      try {
+        const lcpEntries = performance.getEntriesByType(
+          'largest-contentful-paint',
+        )
+        if (lcpEntries.length > 0) {
+          lcp = lcpEntries[lcpEntries.length - 1].startTime
+        }
+      } catch {
+        // LCP not available
+      }
+
+      return {
+        ttfb: nav ? nav.responseStart - nav.requestStart : 0,
+        domContentLoaded: nav
+          ? nav.domContentLoadedEventEnd - nav.fetchStart
+          : 0,
+        loadEvent: nav ? nav.loadEventEnd - nav.fetchStart : 0,
+        fcp: fcpEntry ? fcpEntry.startTime : null,
+        lcp,
+      }
+    })
+
+    metrics.ttfb = timing.ttfb || metrics.ttfb
+    metrics.domContentLoaded = timing.domContentLoaded
+    metrics.loadEvent = timing.loadEvent
+    metrics.fcp = timing.fcp
+    metrics.lcp = timing.lcp
+  } catch (err: any) {
+    metrics.error = err.message?.slice(0, 200) || 'unknown error'
+  }
+
+  metrics.requests = requests
+  metrics.requestCount = requests.length
+  metrics.apiRequestCount = requests.filter((r) => r.isAPI).length
+  metrics.totalTransferKB = Math.round(
+    requests.reduce((s, r) => s + r.size, 0) / 1024,
+  )
+
+  const slowest = requests.reduce(
+    (max, r) => (r.duration > (max?.duration || 0) ? r : max),
+    null as RequestEntry | null,
+  )
+  if (slowest) {
+    metrics.slowestRequest = { url: slowest.url, duration: slowest.duration }
+  }
+
+  // Cleanup listeners
+  page.removeAllListeners('request')
+  page.removeAllListeners('response')
+
+  return metrics
+}
+
+test.describe('Performance Audit', () => {
+  let context: BrowserContext
+  let page: Page
+  const allMetrics: PageMetrics[] = []
+
+  test.beforeAll(async ({ browser }) => {
+    const contextOptions: any = {
+      baseURL: BASE,
+      ignoreHTTPSErrors: true,
+    }
+
+    if (SESSION_TOKEN) {
+      contextOptions.storageState = {
+        cookies: [],
+        origins: [
+          {
+            origin: BASE,
+            localStorage: [
+              { name: 'auth_token', value: SESSION_TOKEN },
+              ...(REFRESH_TOKEN
+                ? [
+                    { name: 'refresh_token', value: REFRESH_TOKEN },
+                    {
+                      name: 'token_expires_at',
+                      value: String(Date.now() + 3600_000),
+                    },
+                  ]
+                : []),
+            ],
+          },
+        ],
+      }
+    }
+
+    context = await browser.newContext(contextOptions)
+    page = await context.newPage()
+  })
+
+  test.afterAll(async () => {
+    const outDir = path.join(__dirname, 'artifacts')
+    if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })
+
+    // Write full JSON
+    const reportPath = path.join(outDir, 'perf-report.json')
+    fs.writeFileSync(reportPath, JSON.stringify(allMetrics, null, 2))
+
+    // Write summary table to stdout
+    console.log('\n' + '='.repeat(100))
+    console.log('PERFORMANCE AUDIT SUMMARY')
+    console.log('='.repeat(100))
+    console.log(
+      [
+        'Path'.padEnd(35),
+        'Role'.padEnd(8),
+        'Nav ms'.padStart(8),
+        'TTFB'.padStart(8),
+        'DCL'.padStart(8),
+        'FCP'.padStart(8),
+        'LCP'.padStart(8),
+        'Reqs'.padStart(6),
+        'APIs'.padStart(6),
+        'KB'.padStart(8),
+        'Slowest'.padStart(8),
+      ].join(' '),
+    )
+    console.log('-'.repeat(100))
+
+    for (const m of allMetrics) {
+      if (m.error) {
+        console.log(`${m.path.padEnd(35)} ${m.role.padEnd(8)} ERROR: ${m.error}`)
+        continue
+      }
+      console.log(
+        [
+          m.path.padEnd(35),
+          m.role.padEnd(8),
+          String(Math.round(m.navigationMs)).padStart(8),
+          String(Math.round(m.ttfb)).padStart(8),
+          String(Math.round(m.domContentLoaded)).padStart(8),
+          (m.fcp !== null ? String(Math.round(m.fcp)) : '-').padStart(8),
+          (m.lcp !== null ? String(Math.round(m.lcp)) : '-').padStart(8),
+          String(m.requestCount).padStart(6),
+          String(m.apiRequestCount).padStart(6),
+          String(m.totalTransferKB).padStart(8),
+          (m.slowestRequest
+            ? String(Math.round(m.slowestRequest.duration))
+            : '-'
+          ).padStart(8),
+        ].join(' '),
+      )
+    }
+
+    // Flag slow pages
+    console.log('\n' + '='.repeat(100))
+    console.log('SLOW PAGES (navigation > 3000ms or LCP > 2500ms)')
+    console.log('='.repeat(100))
+    const slow = allMetrics.filter(
+      (m) =>
+        !m.error &&
+        (m.navigationMs > 3000 || (m.lcp !== null && m.lcp > 2500)),
+    )
+    if (slow.length === 0) {
+      console.log('None detected.')
+    } else {
+      for (const m of slow) {
+        console.log(
+          `  ${m.path} — nav: ${Math.round(m.navigationMs)}ms, LCP: ${m.lcp !== null ? Math.round(m.lcp) + 'ms' : 'N/A'}`,
+        )
+      }
+    }
+
+    // Flag heavy API pages
+    console.log('\n' + '='.repeat(100))
+    console.log('HEAVY API PAGES (> 5 API calls on load)')
+    console.log('='.repeat(100))
+    const heavy = allMetrics.filter(
+      (m) => !m.error && m.apiRequestCount > 5,
+    )
+    if (heavy.length === 0) {
+      console.log('None detected.')
+    } else {
+      for (const m of heavy) {
+        console.log(`  ${m.path} — ${m.apiRequestCount} API calls:`)
+        const apiReqs = m.requests.filter((r) => r.isAPI)
+        for (const r of apiReqs) {
+          console.log(
+            `    ${r.method} ${r.url} — ${r.duration}ms (${Math.round(r.size / 1024)}KB)`,
+          )
+        }
+      }
+    }
+
+    // Flag slow individual requests
+    console.log('\n' + '='.repeat(100))
+    console.log('SLOW API REQUESTS (> 1000ms)')
+    console.log('='.repeat(100))
+    const slowReqs: { page: string; req: RequestEntry }[] = []
+    for (const m of allMetrics) {
+      for (const r of m.requests) {
+        if (r.isAPI && r.duration > 1000) {
+          slowReqs.push({ page: m.path, req: r })
+        }
+      }
+    }
+    if (slowReqs.length === 0) {
+      console.log('None detected.')
+    } else {
+      for (const { page: pg, req } of slowReqs.sort(
+        (a, b) => b.req.duration - a.req.duration,
+      )) {
+        console.log(
+          `  [${pg}] ${req.method} ${req.url} — ${req.duration}ms`,
+        )
+      }
+    }
+
+    console.log('\n' + `Full report: ${reportPath}`)
+    await context.close()
+  })
+
+  test('audit public pages', async () => {
+    test.setTimeout(120_000)
+    for (const p of PUBLIC_PAGES) {
+      console.log(`  → ${p}`)
+      const m = await collectPageMetrics(page, p, 'public')
+      allMetrics.push(m)
+    }
+  })
+
+  test('audit user pages', async () => {
+    if (!SESSION_TOKEN) {
+      test.skip()
+      return
+    }
+    test.setTimeout(180_000)
+    for (const p of USER_PAGES) {
+      console.log(`  → ${p}`)
+      const m = await collectPageMetrics(page, p, 'user')
+      allMetrics.push(m)
+    }
+  })
+
+  test('audit admin pages', async () => {
+    if (!SESSION_TOKEN) {
+      test.skip()
+      return
+    }
+    test.setTimeout(300_000)
+    for (const p of ADMIN_PAGES) {
+      console.log(`  → ${p}`)
+      const m = await collectPageMetrics(page, p, 'admin')
+      allMetrics.push(m)
+    }
+  })
+})

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,6 +10,22 @@ import { useAppStore, useAuthStore, useSubscriptionStore, useAnnouncementStore, 
 import { getSetupStatus } from '@/api/setup'
 import { isNetworkError } from '@/api/client.tk'
 
+/**
+ * User-side views to keep alive across navigations.
+ * Names must match the defineOptions({ name }) in each view component.
+ * Admin views are cached separately inside AdminShellView.
+ * Payment result/callback pages are intentionally excluded — they must
+ * always fetch fresh state.
+ */
+const cachedUserViews = [
+  'UserDashboardView',
+  'UserUsageView',
+  'UserKeysView',
+  'UserProfileView',
+  'UserStudioView',
+  'KeyUsageView',
+]
+
 const router = useRouter()
 const route = useRoute()
 const appStore = useAppStore()
@@ -160,7 +176,11 @@ onMounted(async () => {
 
 <template>
   <NavigationProgress />
-  <RouterView />
+  <RouterView v-slot="{ Component }">
+    <KeepAlive :include="cachedUserViews">
+      <component :is="Component" />
+    </KeepAlive>
+  </RouterView>
   <Toast />
   <AnnouncementPopup />
   <AdminComplianceDialog />

--- a/frontend/src/components/auth/PendingOAuthCreateAccountForm.vue
+++ b/frontend/src/components/auth/PendingOAuthCreateAccountForm.vue
@@ -88,11 +88,16 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { onMounted, onUnmounted, ref, watch, defineAsyncComponent } from 'vue'
 import { useI18n } from 'vue-i18n'
-import TurnstileWidget from '@/components/TurnstileWidget.vue'
 import { getPublicSettings, sendPendingOAuthVerifyCode } from '@/api/auth'
 import { useAppStore } from '@/stores'
+
+// Lazy-load TurnstileWidget: Cloudflare's challenge script sends continuous
+// heartbeat requests that prevent Playwright's networkidle from resolving.
+const TurnstileWidget = defineAsyncComponent(
+  () => import('@/components/TurnstileWidget.vue'),
+)
 
 export type PendingOAuthCreateAccountPayload = {
   email: string

--- a/frontend/src/components/payment/StripePaymentInline.vue
+++ b/frontend/src/components/payment/StripePaymentInline.vue
@@ -111,7 +111,7 @@ let elementsInstance: StripeElements | null = null
 
 onMounted(async () => {
   try {
-    const { loadStripe } = await import('@stripe/stripe-js')
+    const { loadStripe } = await import('@stripe/stripe-js/pure')
     const stripe = await loadStripe(props.publishableKey)
     if (!stripe) { initError.value = t('payment.stripeLoadFailed'); return }
 

--- a/frontend/src/views/KeyUsageView.vue
+++ b/frontend/src/views/KeyUsageView.vue
@@ -411,8 +411,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, onMounted, onUnmounted, onActivated, onDeactivated, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
+
+defineOptions({ name: 'KeyUsageView' })
 import { useAppStore } from '@/stores'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
 import Icon from '@/components/icons/Icon.vue'
@@ -917,8 +919,16 @@ onMounted(() => {
   resetTimer = setInterval(() => { now.value = new Date() }, 60000)
 })
 
+onActivated(() => {
+  if (!resetTimer) resetTimer = setInterval(() => { now.value = new Date() }, 60000)
+})
+
+onDeactivated(() => {
+  if (resetTimer) { clearInterval(resetTimer); resetTimer = null }
+})
+
 onUnmounted(() => {
-  if (resetTimer) clearInterval(resetTimer)
+  if (resetTimer) { clearInterval(resetTimer); resetTimer = null }
 })
 </script>
 

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -1002,7 +1002,7 @@ async function loadMyCatalog(): Promise<void> {
 }
 
 async function loadInitialCatalog(): Promise<void> {
-  if (!hasSavedAuthToken()) {
+  if (!hasSavedAuthToken() && !authStore.isAuthenticated) {
     viewMode.value = 'public'
     await loadPublicCatalog()
     return

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -461,9 +461,11 @@
   </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted, onUnmounted, toRaw, watch, defineAsyncComponent } from 'vue'
+import { ref, reactive, computed, onMounted, onActivated, onDeactivated, onUnmounted, toRaw, watch, defineAsyncComponent } from 'vue'
 import { useIntervalFn } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
+
+defineOptions({ name: 'AdminAccountsView' })
 import { useAppStore } from '@/stores/app'
 import { useAuthStore } from '@/stores/auth'
 import { adminAPI } from '@/api/admin'
@@ -1968,6 +1970,9 @@ const handleClickOutside = (event: MouseEvent) => {
   }
 }
 
+let lastFetchedAt = 0
+const STALE_THRESHOLD_MS = 30_000
+
 onMounted(async () => {
   load()
   try {
@@ -1992,9 +1997,23 @@ onMounted(async () => {
   } else {
     pauseAutoRefresh()
   }
+  lastFetchedAt = Date.now()
+})
+
+onActivated(() => {
+  if (autoRefreshEnabled.value) resumeAutoRefresh()
+  if (Date.now() - lastFetchedAt > STALE_THRESHOLD_MS) {
+    load()
+    lastFetchedAt = Date.now()
+  }
+})
+
+onDeactivated(() => {
+  pauseAutoRefresh()
 })
 
 onUnmounted(() => {
+  pauseAutoRefresh()
   window.removeEventListener('scroll', handleScroll, true)
   document.removeEventListener('click', handleClickOutside)
 })

--- a/frontend/src/views/admin/AdminShellView.vue
+++ b/frontend/src/views/admin/AdminShellView.vue
@@ -1,6 +1,10 @@
 <template>
   <component :is="shellless ? 'div' : AppLayout">
-    <RouterView />
+    <RouterView v-slot="{ Component }">
+      <KeepAlive :include="cachedAdminViews">
+        <component :is="Component" />
+      </KeepAlive>
+    </RouterView>
   </component>
 </template>
 
@@ -10,6 +14,17 @@ import { RouterView, useRoute } from 'vue-router'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import { TK_ADMIN_UI_ZOOM } from '@/constants/layout'
 import '@/styles/admin-ui-zoom.tk.css'
+
+/**
+ * Admin views to keep alive across navigations within the admin shell.
+ * Names must match the defineOptions({ name }) in each view component.
+ * Settings / Ops pages are excluded — they should always show fresh state.
+ */
+const cachedAdminViews = [
+  'AdminAccountsView',
+  'AdminChannelsView',
+  'AdminUsersView',
+]
 
 const route = useRoute()
 const TK_ADMIN_UI_ZOOM_CLASS = 'tk-admin-ui-zoom'

--- a/frontend/src/views/admin/ChannelsView.vue
+++ b/frontend/src/views/admin/ChannelsView.vue
@@ -623,8 +623,10 @@
   </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted, onUnmounted } from 'vue'
+import { ref, reactive, computed, onMounted, onActivated, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+
+defineOptions({ name: 'AdminChannelsView' })
 import { useAppStore } from '@/stores/app'
 import { extractApiErrorMessage } from '@/utils/apiError'
 import { adminAPI } from '@/api/admin'
@@ -1476,11 +1478,22 @@ async function confirmDelete() {
 }
 
 // ── Lifecycle ──
+let lastFetchedAt = 0
+const STALE_THRESHOLD_MS = 30_000
+
 onMounted(() => {
   loadChannels()
   loadGroups()
   loadWebSearchGlobalState()
   document.addEventListener('click', handleRuleAccountClickOutside)
+  lastFetchedAt = Date.now()
+})
+
+onActivated(() => {
+  if (Date.now() - lastFetchedAt > STALE_THRESHOLD_MS) {
+    loadChannels()
+    lastFetchedAt = Date.now()
+  }
 })
 
 onUnmounted(() => {

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -350,7 +350,7 @@
   </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { useAppStore } from '@/stores/app'
@@ -419,7 +419,6 @@ let chartLoadSeq = 0
 let userTrendLoadSeq = 0
 let rankingLoadSeq = 0
 const rankingLimit = 12
-let initialChartTimer: number | null = null
 
 // Helper function to format date in local timezone
 const formatLocalDate = (date: Date): string => {
@@ -702,93 +701,14 @@ const onDateRangeChange = (range: {
   loadChartData()
 }
 
-// Load data
-const loadDashboardStatsSnapshot = async () => {
-  const currentSeq = ++statsLoadSeq
+// Load data — single SnapshotV2 call with all facets
+const loadAllDashboardData = async () => {
+  const currentStatsSeq = ++statsLoadSeq
+  const currentChartSeq = ++chartLoadSeq
+  const currentUserTrendSeq = ++userTrendLoadSeq
   if (!stats.value) loading.value = true
-  try {
-    const response = await adminAPI.dashboard.getSnapshotV2({
-      start_date: startDate.value,
-      end_date: endDate.value,
-      ...(dashboardWindowParams(activePreset.value)),
-      granularity: granularity.value,
-      include_stats: true,
-      include_trend: false,
-      include_model_stats: false,
-      include_group_stats: false,
-      include_users_trend: false
-    })
-    if (currentSeq !== statsLoadSeq) return
-    if (response.stats) stats.value = response.stats
-  } catch (error) {
-    if (currentSeq !== statsLoadSeq) return
-    appStore.showError(t('admin.dashboard.failedToLoad'))
-    console.error('Error loading dashboard stats snapshot:', error)
-  } finally {
-    if (currentSeq === statsLoadSeq) loading.value = false
-  }
-}
-
-const loadDashboardTrendSnapshot = async (currentSeq: number) => {
   chartsLoading.value = true
-  try {
-    const response = await adminAPI.dashboard.getSnapshotV2({
-      start_date: startDate.value,
-      end_date: endDate.value,
-      ...(dashboardWindowParams(activePreset.value)),
-      granularity: granularity.value,
-      include_stats: false,
-      include_trend: true,
-      include_model_stats: false,
-      include_group_stats: false,
-      include_users_trend: false
-    })
-    if (currentSeq !== chartLoadSeq) return
-    trendData.value = response.trend || []
-  } catch (error) {
-    if (currentSeq !== chartLoadSeq) return
-    trendData.value = []
-    console.error('Error loading dashboard trend snapshot:', error)
-  } finally {
-    if (currentSeq === chartLoadSeq) chartsLoading.value = false
-  }
-}
-
-const loadDashboardModelStatsSnapshot = async (currentSeq: number) => {
   modelStatsLoading.value = true
-  try {
-    const response = await adminAPI.dashboard.getSnapshotV2({
-      start_date: startDate.value,
-      end_date: endDate.value,
-      ...(dashboardWindowParams(activePreset.value)),
-      granularity: granularity.value,
-      include_stats: false,
-      include_trend: false,
-      include_model_stats: true,
-      include_group_stats: false,
-      include_users_trend: false
-    })
-    if (currentSeq !== chartLoadSeq) return
-    modelStats.value = response.models || []
-  } catch (error) {
-    if (currentSeq !== chartLoadSeq) return
-    modelStats.value = []
-    console.error('Error loading dashboard model snapshot:', error)
-  } finally {
-    if (currentSeq === chartLoadSeq) modelStatsLoading.value = false
-  }
-}
-
-const loadDashboardChartsSnapshot = async () => {
-  const currentSeq = ++chartLoadSeq
-  await Promise.allSettled([
-    loadDashboardTrendSnapshot(currentSeq),
-    loadDashboardModelStatsSnapshot(currentSeq),
-  ])
-}
-
-const loadUserUsageTrend = async () => {
-  const currentSeq = ++userTrendLoadSeq
   userTrendLoading.value = true
   try {
     const response = await adminAPI.dashboard.getSnapshotV2({
@@ -796,21 +716,42 @@ const loadUserUsageTrend = async () => {
       end_date: endDate.value,
       ...(dashboardWindowParams(activePreset.value)),
       granularity: granularity.value,
-      include_stats: false,
-      include_trend: false,
-      include_model_stats: false,
+      include_stats: true,
+      include_trend: true,
+      include_model_stats: true,
       include_group_stats: false,
       include_users_trend: true,
       users_trend_limit: 12
     })
-    if (currentSeq !== userTrendLoadSeq) return
-    userTrend.value = response.users_trend || []
+    if (currentStatsSeq === statsLoadSeq && response.stats) {
+      stats.value = response.stats
+    }
+    if (currentChartSeq === chartLoadSeq) {
+      trendData.value = response.trend || []
+      modelStats.value = response.models || []
+    }
+    if (currentUserTrendSeq === userTrendLoadSeq) {
+      userTrend.value = response.users_trend || []
+    }
   } catch (error) {
-    if (currentSeq !== userTrendLoadSeq) return
-    userTrend.value = []
-    console.error('Error loading user usage trend:', error)
+    if (currentStatsSeq === statsLoadSeq) {
+      appStore.showError(t('admin.dashboard.failedToLoad'))
+    }
+    if (currentChartSeq === chartLoadSeq) {
+      trendData.value = []
+      modelStats.value = []
+    }
+    if (currentUserTrendSeq === userTrendLoadSeq) {
+      userTrend.value = []
+    }
+    console.error('Error loading dashboard snapshot:', error)
   } finally {
-    if (currentSeq === userTrendLoadSeq) userTrendLoading.value = false
+    if (currentStatsSeq === statsLoadSeq) loading.value = false
+    if (currentChartSeq === chartLoadSeq) {
+      chartsLoading.value = false
+      modelStatsLoading.value = false
+    }
+    if (currentUserTrendSeq === userTrendLoadSeq) userTrendLoading.value = false
   }
 }
 
@@ -846,35 +787,25 @@ const loadUserSpendingRanking = async () => {
 }
 
 const loadDashboardStats = async () => {
-  await loadDashboardStatsSnapshot()
-  void loadChartData()
+  await Promise.all([
+    loadAllDashboardData(),
+    loadUserSpendingRanking()
+  ])
 }
 
 const loadChartData = async () => {
   await Promise.all([
-    loadDashboardChartsSnapshot(),
-    loadUserUsageTrend(),
+    loadAllDashboardData(),
     loadUserSpendingRanking()
   ])
 }
 
 onMounted(() => {
-  chartsLoading.value = true
-  modelStatsLoading.value = true
-  userTrendLoading.value = true
   rankingLoading.value = true
-  void loadDashboardStatsSnapshot()
-  initialChartTimer = window.setTimeout(() => {
-    void loadChartData()
-    initialChartTimer = null
-  }, 120)
-})
-
-onUnmounted(() => {
-  if (initialChartTimer !== null) {
-    window.clearTimeout(initialChartTimer)
-    initialChartTimer = null
-  }
+  void Promise.all([
+    loadAllDashboardData(),
+    loadUserSpendingRanking()
+  ])
 })
 </script>
 

--- a/frontend/src/views/admin/UsersView.vue
+++ b/frontend/src/views/admin/UsersView.vue
@@ -769,8 +769,10 @@
   </template>
 
 <script setup lang="ts">
-import { ref, shallowRef, reactive, computed, onMounted, onUnmounted } from 'vue'
+import { ref, shallowRef, reactive, computed, onMounted, onActivated, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+
+defineOptions({ name: 'AdminUsersView' })
 import { useAppStore } from '@/stores/app'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 import { formatDateTime } from '@/utils/format'
@@ -1857,6 +1859,9 @@ const handleScroll = () => {
   closeActionMenu()
 }
 
+let lastFetchedAt = 0
+const STALE_THRESHOLD_MS = 30_000
+
 onMounted(async () => {
   await loadAttributeDefinitions()
   loadSavedFilters()
@@ -1870,6 +1875,14 @@ onMounted(async () => {
   }
   document.addEventListener('click', handleClickOutside)
   window.addEventListener('scroll', handleScroll, true)
+  lastFetchedAt = Date.now()
+})
+
+onActivated(() => {
+  if (Date.now() - lastFetchedAt > STALE_THRESHOLD_MS) {
+    loadUsers()
+    lastFetchedAt = Date.now()
+  }
 })
 
 onUnmounted(() => {

--- a/frontend/src/views/auth/EmailVerifyView.vue
+++ b/frontend/src/views/auth/EmailVerifyView.vue
@@ -146,13 +146,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
+import { computed, ref, onMounted, onUnmounted, watch, defineAsyncComponent } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { AuthLayout } from '@/components/layout'
 import Icon from '@/components/icons/Icon.vue'
-import TurnstileWidget from '@/components/TurnstileWidget.vue'
 import { useAuthStore, useAppStore } from '@/stores'
+
+// Lazy-load TurnstileWidget: Cloudflare's challenge script sends continuous
+// heartbeat requests that prevent Playwright's networkidle from resolving.
+const TurnstileWidget = defineAsyncComponent(
+  () => import('@/components/TurnstileWidget.vue'),
+)
 import {
   persistOAuthTokenContext,
   getPublicSettings,

--- a/frontend/src/views/auth/ForgotPasswordView.vue
+++ b/frontend/src/views/auth/ForgotPasswordView.vue
@@ -125,12 +125,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, reactive, onMounted, watch } from 'vue'
+import { computed, ref, reactive, onMounted, watch, defineAsyncComponent } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { AuthLayout } from '@/components/layout'
 import Icon from '@/components/icons/Icon.vue'
-import TurnstileWidget from '@/components/TurnstileWidget.vue'
 import { useAppStore } from '@/stores'
+
+// Lazy-load TurnstileWidget: Cloudflare's challenge script sends continuous
+// heartbeat requests that prevent Playwright's networkidle from resolving.
+// Loading it async keeps the initial page render fast and avoids blocking FCP.
+const TurnstileWidget = defineAsyncComponent(
+  () => import('@/components/TurnstileWidget.vue'),
+)
 import { getPublicSettings, forgotPassword } from '@/api/auth'
 import { buildAuthErrorMessage } from '@/utils/authError'
 

--- a/frontend/src/views/auth/RegisterView.vue
+++ b/frontend/src/views/auth/RegisterView.vue
@@ -298,7 +298,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, reactive, onMounted, onUnmounted, watch } from 'vue'
+import { computed, ref, reactive, onMounted, onUnmounted, watch, defineAsyncComponent } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { AuthLayout } from '@/components/layout'
@@ -308,8 +308,13 @@ import WechatOAuthSection from '@/components/auth/WechatOAuthSection.vue'
 import EmailOAuthButtons from '@/components/auth/EmailOAuthButtons.vue'
 import LoginAgreementPrompt from '@/components/auth/LoginAgreementPrompt.vue'
 import Icon from '@/components/icons/Icon.vue'
-import TurnstileWidget from '@/components/TurnstileWidget.vue'
 import { useAuthStore, useAppStore } from '@/stores'
+
+// Lazy-load TurnstileWidget: Cloudflare's challenge script sends continuous
+// heartbeat requests that prevent Playwright's networkidle from resolving.
+const TurnstileWidget = defineAsyncComponent(
+  () => import('@/components/TurnstileWidget.vue'),
+)
 import {
   getPublicSettings,
   isWeChatWebOAuthEnabled,

--- a/frontend/src/views/user/DashboardView.vue
+++ b/frontend/src/views/user/DashboardView.vue
@@ -15,7 +15,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'; import { useAuthStore } from '@/stores/auth'; import { usageAPI, type UserDashboardStats as UserStatsType } from '@/api/usage'
+import { ref, computed, onMounted, onActivated } from 'vue'; import { useAuthStore } from '@/stores/auth'; import { usageAPI, type UserDashboardStats as UserStatsType } from '@/api/usage'
+
+defineOptions({ name: 'UserDashboardView' })
 import AppLayout from '@/components/layout/AppLayout.vue'; import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import UserDashboardStats from '@/components/user/dashboard/UserDashboardStats.vue'; import UserDashboardCharts from '@/components/user/dashboard/UserDashboardCharts.vue'
 import UserDashboardRecentUsage from '@/components/user/dashboard/UserDashboardRecentUsage.vue'; import UserDashboardQuickActions from '@/components/user/dashboard/UserDashboardQuickActions.vue'
@@ -36,5 +38,15 @@ const loadRecent = async () => { loadingUsage.value = true; try { const res = aw
 const loadPlatformQuotas = async () => { try { const data = await getMyPlatformQuotas(); platformQuotas.value = data.platform_quotas ?? [] } catch (error) { console.warn('Failed to load platform quotas:', error); platformQuotas.value = [] } }
 const refreshAll = () => { loadStats(); loadCharts(); loadRecent(); loadPlatformQuotas() }
 
-onMounted(() => { refreshAll() })
+let lastFetchedAt = 0
+const STALE_THRESHOLD_MS = 30_000
+
+onMounted(() => { refreshAll(); lastFetchedAt = Date.now() })
+
+onActivated(() => {
+  if (Date.now() - lastFetchedAt > STALE_THRESHOLD_MS) {
+    refreshAll()
+    lastFetchedAt = Date.now()
+  }
+})
 </script>

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -1153,8 +1153,10 @@
 </template>
 
 <script setup lang="ts">
-	import { ref, reactive, computed, onMounted, onUnmounted, type ComponentPublicInstance } from 'vue'
+	import { ref, reactive, computed, onMounted, onActivated, onDeactivated, onUnmounted, type ComponentPublicInstance } from 'vue'
 	import { useI18n } from 'vue-i18n'
+
+	defineOptions({ name: 'UserKeysView' })
 	import { useRoute, useRouter } from 'vue-router'
 	import { useAppStore } from '@/stores/app'
 	import { useOnboardingStore } from '@/stores/onboarding'
@@ -2025,6 +2027,9 @@ function applyCreateKeyFromQuery(): void {
   void router.replace({ query: q })
 }
 
+let lastFetchedAt = 0
+const STALE_THRESHOLD_MS = 30_000
+
 onMounted(() => {
   loadSavedColumns()
   loadApiKeys()
@@ -2033,10 +2038,23 @@ onMounted(() => {
   loadPublicSettings()
   document.addEventListener('click', closeGroupSelector)
   resetTimer = setInterval(() => { now.value = new Date() }, 60000)
+  lastFetchedAt = Date.now()
+})
+
+onActivated(() => {
+  if (!resetTimer) resetTimer = setInterval(() => { now.value = new Date() }, 60000)
+  if (Date.now() - lastFetchedAt > STALE_THRESHOLD_MS) {
+    loadApiKeys()
+    lastFetchedAt = Date.now()
+  }
+})
+
+onDeactivated(() => {
+  if (resetTimer) { clearInterval(resetTimer); resetTimer = null }
 })
 
 onUnmounted(() => {
   document.removeEventListener('click', closeGroupSelector)
-  if (resetTimer) clearInterval(resetTimer)
+  if (resetTimer) { clearInterval(resetTimer); resetTimer = null }
 })
 </script>

--- a/frontend/src/views/user/ProfileView.vue
+++ b/frontend/src/views/user/ProfileView.vue
@@ -49,8 +49,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, onActivated, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+
+defineOptions({ name: 'UserProfileView' })
 import { Icon } from '@/components/icons'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import ProfileBalanceNotifyCard from '@/components/user/profile/ProfileBalanceNotifyCard.vue'
@@ -77,7 +79,10 @@ const wechatOAuthMPEnabled = ref<boolean | undefined>(undefined)
 const oidcOAuthEnabled = ref(false)
 const oidcOAuthProviderName = ref('OIDC')
 
-onMounted(async () => {
+let lastFetchedAt = 0
+const STALE_THRESHOLD_MS = 30_000
+
+const loadProfile = async () => {
   const profileRefresh = authStore.refreshUser().catch((error) => {
     console.error('Failed to refresh profile:', error)
   })
@@ -107,5 +112,14 @@ onMounted(async () => {
     })
 
   await Promise.all([profileRefresh, settingsLoad])
+  lastFetchedAt = Date.now()
+}
+
+onMounted(() => { loadProfile() })
+
+onActivated(() => {
+  if (Date.now() - lastFetchedAt > STALE_THRESHOLD_MS) {
+    loadProfile()
+  }
 })
 </script>

--- a/frontend/src/views/user/StripePaymentView.vue
+++ b/frontend/src/views/user/StripePaymentView.vue
@@ -165,7 +165,7 @@ onMounted(async () => {
     const publishableKey = paymentStore.config?.stripe_publishable_key
     if (!publishableKey) { initError.value = t('payment.stripeNotConfigured'); return }
 
-    const { loadStripe } = await import('@stripe/stripe-js')
+    const { loadStripe } = await import('@stripe/stripe-js/pure')
     const stripe = await loadStripe(publishableKey)
     if (!stripe) { initError.value = t('payment.stripeLoadFailed'); return }
 

--- a/frontend/src/views/user/StripePopupView.vue
+++ b/frontend/src/views/user/StripePopupView.vue
@@ -117,7 +117,7 @@ async function initStripe(clientSecret: string, publishableKey: string) {
     return
   }
   try {
-    const { loadStripe } = await import('@stripe/stripe-js')
+    const { loadStripe } = await import('@stripe/stripe-js/pure')
     const stripe = await loadStripe(publishableKey)
     if (!stripe) { error.value = t('payment.stripeLoadFailed'); return }
 

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -213,8 +213,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
+import { computed, onMounted, onActivated, onUnmounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+
+defineOptions({ name: 'UserUsageView' })
 import { useAppStore } from '@/stores/app'
 import { keysAPI, usageAPI, userGroupsAPI } from '@/api'
 import AppLayout from '@/components/layout/AppLayout.vue'
@@ -871,12 +873,23 @@ const switchToErrors = () => {
   if (errorRows.value.length === 0) void loadErrors()
 }
 
+let lastFetchedAt = 0
+const STALE_THRESHOLD_MS = 30_000
+
 onMounted(() => {
   loadSavedColumns()
   loadSavedErrColumns()
   document.addEventListener('click', handleColumnClickOutside)
   void loadFilterOptions()
   refreshData()
+  lastFetchedAt = Date.now()
+})
+
+onActivated(() => {
+  if (Date.now() - lastFetchedAt > STALE_THRESHOLD_MS) {
+    refreshData()
+    lastFetchedAt = Date.now()
+  }
 })
 
 onUnmounted(() => {

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -156,9 +156,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onActivated, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+
+defineOptions({ name: 'UserStudioView' })
 import AppLayout from '@/components/layout/AppLayout.vue'
 import ChatStudio from '@/views/user/studio/ChatStudio.vue'
 import ImageStudio from '@/views/user/studio/ImageStudio.vue'
@@ -552,7 +554,18 @@ async function bootstrap(): Promise<void> {
   }
 }
 
+let lastFetchedAt = 0
+const STALE_THRESHOLD_MS = 30_000
+
 onMounted(() => {
   void bootstrap()
+  lastFetchedAt = Date.now()
+})
+
+onActivated(() => {
+  if (Date.now() - lastFetchedAt > STALE_THRESHOLD_MS) {
+    void bootstrap()
+    lastFetchedAt = Date.now()
+  }
 })
 </script>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -44,7 +44,8 @@ const ENTRY_HTML_PRELOAD_BLOCKLIST = [
   '/OAuthAuthorizationFlow',
   '/DashboardView-',
   '/admin-dashboard-view-',
-  '/vendor-chart-'
+  '/vendor-chart-',
+  '/vendor-stripe-'
 ]
 
 export default defineConfig(({ mode }) => {
@@ -103,6 +104,14 @@ export default defineConfig(({ mode }) => {
               id.includes('/@vue/')
             ) {
               return 'vendor-vue'
+            }
+
+            // @stripe/stripe-js wrapper (~10KB) has a module-level side effect
+            // that injects a <script> tag loading the external Stripe SDK (~1MB).
+            // Isolate it so the side effect only fires when a payment route chunk
+            // is actually evaluated — never on /home, /login, /dashboard, etc.
+            if (id.includes('/@stripe/stripe-js/') || id.includes('/stripe-js/')) {
+              return 'vendor-stripe'
             }
 
             // xlsx 仅 UsageView 导出时动态引入，单独成块，避免被绝大多数后台页面急切下载/解析（~430KB）


### PR DESCRIPTION
最新提交：5a6f914b5

## 摘要

全站性能优化，覆盖前端资源加载、后端查询效率、SPA 路由缓存三大维度；并 rebase 到最新 main，补齐 xj-review 指出的测试与 perf-audit 门禁。

**前端：**
- Stripe SDK 延迟加载（`@stripe/stripe-js/pure` + vendor-stripe chunk）
- Turnstile 异步化（register/forgot-password/OAuth 等表单）
- Admin Dashboard 4 次 getSnapshotV2 合并为 1 次
- KeepAlive 路由缓存 + 30s stale 刷新 + onDeactivated 暂停定时器
- PricingView 使用 `hasSavedAuthToken()` 修复认证竞态

**后端：**
- usage_handler errgroup 并行查询
- payment_order SUM 聚合替代全量加载
- ExpireTimedOutOrders keyset 分页防无限循环
- channel_available singleflight 缓存 + invalidate 联动

**测试/门禁：**
- 新增 ListAvailable 缓存与 ExpireTimedOutOrders 分批回归测试
- perf-audit e2e 改为 `E2E_PERF_AUDIT=1` 显式启用，默认 localhost，auth 页含 navigationMs 断言

## 风险

- KeepAlive 30s stale 阈值下极端情况数据可能略滞后
- channel_available 30s TTL（admin CRUD 已通过 invalidateCache 覆盖）
- rebase 后需等 CI 全绿再合并

## 验证

- [x] `./scripts/preflight.sh` PASS（worktree HEAD 5a6f914b5）
- [x] `go test -tags=unit ./internal/service/... -run 'TestListAvailable_Cache|TestExpireTimedOutOrders'` PASS
- [x] `pnpm --dir frontend run build` 成功并刷新 frontend-source.json
- [ ] GitHub CI 全绿（push 后触发）

## 提交

```
5a6f914b5 test(perf): address review findings for PR #1225
13d62f847 perf: comprehensive frontend + backend performance optimization
```

sentinel-registry-reviewed
upstream-touch-trivial
