### PR TITLE
feat(storefront): model marketplace + landing expansion + native English copy

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 570,
-  "hash": "c32e46d4d00dee65625dac44b0255129334509a12cf100746cac9e8950ce0554",
+  "hash": "06678ae61d1f226bac407d428d9ff67c8f118e7d46b16d37057c475a04ec5376",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 570,
-  "hash": "06678ae61d1f226bac407d428d9ff67c8f118e7d46b16d37057c475a04ec5376",
+  "hash": "253e0c303555922472cfdf38d61b6f2496eab95fe515e73e50119ce620d5b03e",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 569,
-  "hash": "667491675028bd35a6aae57ac341c7963232636d9b795605a17d7e11de232273",
+  "file_count": 570,
+  "hash": "c32e46d4d00dee65625dac44b0255129334509a12cf100746cac9e8950ce0554",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/prerender.go
+++ b/backend/internal/web/prerender.go
@@ -124,7 +124,7 @@ func prerenderHomeHTML() string {
 <li>Google (Gemini 2.5 Pro, Flash)</li>
 <li>Amazon (Kiro)</li>
 <li>xAI (Grok)</li>
-<li>DeepSeek</li>
+<li>Alibaba Cloud Qwen (通义千问)</li>
 <li>Midjourney</li>
 <li>Runway (Video)</li>
 <li>Suno (Music)</li>
@@ -192,7 +192,7 @@ func prerenderPricingHTML() string {
 func prerenderQuickstartHTML() string {
 	title := "Quick Start - TokenKey AI API Gateway"
 	desc := "2 分钟开始使用 TokenKey AI API。获取 API Key，配置 Claude Code / Cursor / Codex / Cline，立即调用所有主流 AI 模型。"
-	ogDesc := "Get started in 2 minutes. One API key for Claude, GPT, Gemini, DeepSeek, and more."
+	ogDesc := "Get started in 2 minutes. One API key for Claude, GPT, Gemini, Qwen, and more."
 	head := prerenderHead(title, desc, ogDesc, "/quickstart")
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="zh-CN">
@@ -235,7 +235,7 @@ func prerenderQuickstartHTML() string {
 func prerenderModelsHTML() string {
 	title := "Model Marketplace - TokenKey AI API Gateway"
 	desc := "Browse and compare AI models by capability, provider, and price. Text, image, and video models in one catalog with transparent per-model pricing."
-	ogDesc := "Browse Claude, GPT, Gemini, DeepSeek, and more. Filter by modality and provider, then jump to live pricing."
+	ogDesc := "Browse Claude, GPT, Gemini, Qwen, and more. Filter by modality and provider, then jump to live pricing."
 	head := prerenderHead(title, desc, ogDesc, "/models")
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="zh-CN">

--- a/backend/internal/web/prerender.go
+++ b/backend/internal/web/prerender.go
@@ -95,27 +95,27 @@ func prerenderHomeHTML() string {
 <p>%s</p>
 
 <section>
-<h2>Official Quality</h2>
+<h2>Direct to Official APIs</h2>
 <p>官方品质 API 调用。直连官方接口，无中间商，延迟低、稳定性高。每一次请求都等同于直接调用官方 API。</p>
 </section>
 
 <section>
-<h2>One Key for Everything</h2>
+<h2>Every Modality, One Key</h2>
 <p>一个 Key 全搞定。文本生成、图像创作、视频制作，所有主流 AI 模型统一接入，无需管理多个 API Key。</p>
 </section>
 
 <section>
-<h2>Predictable Pricing</h2>
+<h2>Predictable, Quota-based Pricing</h2>
 <p>订阅配额，费用可预测。按日/周/月订阅配额，团队共享，超限自动停。费用透明、可预期。</p>
 </section>
 
 <section>
-<h2>Built-in Studio</h2>
+<h2>Built-in Studio Workspace</h2>
 <p>内置 Studio 创作工作台——Chat、Image、Video、BakeOff 多模型对比，一站式体验所有 AI 能力。</p>
 </section>
 
 <section>
-<h2>Supported Providers</h2>
+<h2>Supported Models</h2>
 <ul>
 <li>OpenAI (GPT-4o, GPT-4, o1, o3)</li>
 <li>Anthropic (Claude Opus, Sonnet, Haiku)</li>
@@ -130,7 +130,7 @@ func prerenderHomeHTML() string {
 </section>
 
 <section>
-<h2>Free Trial</h2>
+<h2>Get Started Free</h2>
 <p>%s</p>
 <p>%s</p>
 </section>
@@ -140,7 +140,7 @@ func prerenderHomeHTML() string {
 </nav>
 
 <noscript>
-<p>TokenKey requires JavaScript for the full interactive experience. Please enable JavaScript to access the dashboard, model catalog, and API management features.</p>
+<p>Enable JavaScript to access the dashboard, model catalog, and API management features.</p>
 </noscript>
 </body>
 </html>`, head, storefrontSiteTitle, storefrontZHHeroSubtitle, storefrontZHFreeTrial, storefrontENFreeTrial)
@@ -161,19 +161,19 @@ func prerenderPricingHTML() string {
 <p>%s</p>
 
 <section>
-<h2>Pricing Model</h2>
-<p>TokenKey offers transparent, official API pricing with real-time model availability monitoring. Subscription quota plans available for predictable costs.</p>
+<h2>Pricing</h2>
+<p>Transparent, per-model pricing with no markup on vendor rates. Quota-based plans let you cap spend before it happens.</p>
 <ul>
-<li>Official API pricing, per-model transparent rates</li>
-<li>All mainstream AI models: text, image, and video</li>
-<li>Real-time model availability monitoring</li>
-<li>Subscription quota plans for predictable budgeting</li>
+<li>Vendor-rate pricing with per-model transparency</li>
+<li>Text, image, and video models in one catalog</li>
+<li>Live model availability dashboard</li>
+<li>Quota plans for predictable monthly budgets</li>
 </ul>
 </section>
 
 <section>
 <h2>Full Model Catalog</h2>
-<p>JavaScript is required to view the full interactive pricing catalog with real-time model availability and detailed per-model quota information.</p>
+<p>Enable JavaScript to browse the interactive pricing catalog with live availability and per-model quota details.</p>
 </section>
 
 <nav>
@@ -181,7 +181,7 @@ func prerenderPricingHTML() string {
 </nav>
 
 <noscript>
-<p>TokenKey requires JavaScript to display the full interactive pricing catalog. Please enable JavaScript to see detailed model pricing, quota information, and subscription management.</p>
+<p>Enable JavaScript to view the full interactive pricing catalog, quota details, and subscription management.</p>
 </noscript>
 </body>
 </html>`, head, title, desc)
@@ -190,7 +190,7 @@ func prerenderPricingHTML() string {
 func prerenderQuickstartHTML() string {
 	title := "Quick Start - TokenKey AI API Gateway"
 	desc := "2 分钟开始使用 TokenKey AI API。获取 API Key，配置 Claude Code / Cursor / Codex / Cline，立即调用所有主流 AI 模型。"
-	ogDesc := "Get started with TokenKey in 2 minutes. One API Key for Claude, GPT, Gemini, DeepSeek and more."
+	ogDesc := "Get started in 2 minutes. One API key for Claude, GPT, Gemini, DeepSeek, and more."
 	head := prerenderHead(title, desc, ogDesc, "/quickstart")
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="zh-CN">
@@ -202,7 +202,7 @@ func prerenderQuickstartHTML() string {
 <p>%s</p>
 
 <section>
-<h2>Supported Tools</h2>
+<h2>Works With</h2>
 <ul>
 <li>Claude Code</li>
 <li>Cursor</li>
@@ -214,7 +214,7 @@ func prerenderQuickstartHTML() string {
 </section>
 
 <section>
-<h2>Free Trial</h2>
+<h2>Get Started Free</h2>
 <p>%s</p>
 </section>
 
@@ -224,7 +224,7 @@ func prerenderQuickstartHTML() string {
 </nav>
 
 <noscript>
-<p>TokenKey requires JavaScript for the interactive quick start guide. Please enable JavaScript to get your API key and configuration snippets.</p>
+<p>Enable JavaScript for the interactive quick-start guide, API key generation, and configuration snippets.</p>
 </noscript>
 </body>
 </html>`, head, title, desc, storefrontENFreeTrial)

--- a/backend/internal/web/prerender.go
+++ b/backend/internal/web/prerender.go
@@ -52,6 +52,8 @@ func PrerenderMiddleware() gin.HandlerFunc {
 			html = prerenderPricingHTML()
 		case "/quickstart":
 			html = prerenderQuickstartHTML()
+		case "/models":
+			html = prerenderModelsHTML()
 		default:
 			c.Next()
 			return
@@ -228,4 +230,40 @@ func prerenderQuickstartHTML() string {
 </noscript>
 </body>
 </html>`, head, title, desc, storefrontENFreeTrial)
+}
+
+func prerenderModelsHTML() string {
+	title := "Model Marketplace - TokenKey AI API Gateway"
+	desc := "Browse and compare AI models by capability, provider, and price. Text, image, and video models in one catalog with transparent per-model pricing."
+	ogDesc := "Browse Claude, GPT, Gemini, DeepSeek, and more. Filter by modality and provider, then jump to live pricing."
+	head := prerenderHead(title, desc, ogDesc, "/models")
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+%s
+</head>
+<body>
+<h1>%s</h1>
+<p>%s</p>
+
+<section>
+<h2>Model Marketplace</h2>
+<p>Browse the full public catalog by text, image, or video capability. Filter by provider and search by model id.</p>
+<ul>
+<li>Card-based browsing with vendor facets</li>
+<li>Per-model input/output pricing at a glance</li>
+<li>Links to the interactive pricing catalog for details</li>
+</ul>
+</section>
+
+<nav>
+<a href="/">Back to Home / 返回首页</a>
+<a href="/pricing">View Pricing / 查看定价</a>
+</nav>
+
+<noscript>
+<p>Enable JavaScript to browse the interactive model marketplace and pricing catalog.</p>
+</noscript>
+</body>
+</html>`, head, title, desc)
 }

--- a/backend/internal/web/prerender_seo_tk.go
+++ b/backend/internal/web/prerender_seo_tk.go
@@ -8,12 +8,12 @@ const (
 	storefrontCanonicalOrigin = "https://api.tokenkey.dev"
 	storefrontOGImageURL      = "https://api.tokenkey.dev/og-cover.png"
 
-	storefrontZHMetaDescription = "TokenKey - AI API Gateway. 每一次调用，都是官方品质。文本、图像、视频，一个 Key 全搞定。Official quality AI API access."
+	storefrontZHMetaDescription = "TokenKey - AI API Gateway. 每一次调用，都是官方品质。文本、图像、视频，一个 Key 全搞定。One key for every AI model, routed direct."
 	storefrontZHOGDescription   = "每一次调用，都是官方品质。一个 API Key，所有主流 AI 模型。文本、图像、视频。订阅配额，费用可预测。"
 	storefrontZHHeroTitle       = "每一次调用，都是官方品质。"
 	storefrontZHHeroSubtitle    = "一个 API Key，所有主流 AI 模型。文本、图像、视频。订阅配额，费用可预测。"
 	storefrontZHFreeTrial       = "免费试用，送 100 万 tokens。足够测试你的真实工作流。只需邮箱，无需信用卡。"
 
-	storefrontENTwitterDescription = "Official quality AI API access. Text, image, video. One Key for everything."
-	storefrontENFreeTrial          = "Start free with 1M tokens included. Enough to test your real workflow. Email only, no card required."
+	storefrontENTwitterDescription = "One API key for Claude, GPT, Gemini, and more. Direct-to-vendor quality, predictable pricing."
+	storefrontENFreeTrial          = "Try free with 1M tokens on us. Enough to run your real workload end-to-end. Just an email — no credit card required."
 )

--- a/backend/internal/web/prerender_test.go
+++ b/backend/internal/web/prerender_test.go
@@ -75,6 +75,14 @@ func TestPrerenderMiddleware(t *testing.T) {
 			wantBody:   "Quick Start",
 		},
 		{
+			name:       "googlebot models prerender",
+			path:       "/models",
+			ua:         "Googlebot",
+			wantStatus: http.StatusOK,
+			wantHeader: "1",
+			wantBody:   "Model Marketplace",
+		},
+		{
 			name:       "crawler unknown route falls through",
 			path:       "/dashboard",
 			ua:         "Googlebot",

--- a/frontend/src/components/home/HomeTkLanding.tk.vue
+++ b/frontend/src/components/home/HomeTkLanding.tk.vue
@@ -140,6 +140,15 @@
               </span>
             </p>
 
+            <!-- Free Trial Badge -->
+            <div class="mb-6">
+              <span
+                class="inline-flex items-center gap-1.5 rounded-full border border-primary-200 bg-primary-50/80 px-4 py-1.5 text-sm font-medium text-primary-700 dark:border-primary-800 dark:bg-primary-900/30 dark:text-primary-300"
+              >
+                {{ t('home.freeTrial.badge') }}
+              </span>
+            </div>
+
             <!-- CTA Button -->
             <div>
               <router-link
@@ -276,6 +285,49 @@
           </div>
         </div>
 
+        <!-- Browse All Models CTA -->
+        <div class="mb-16 text-center">
+          <router-link
+            to="/models"
+            class="inline-flex items-center gap-2 rounded-full border border-primary-200 bg-primary-50 px-5 py-2.5 text-sm font-medium text-primary-700 transition-all hover:bg-primary-100 hover:shadow-md dark:border-primary-800 dark:bg-primary-900/30 dark:text-primary-300 dark:hover:bg-primary-900/50"
+          >
+            {{ t('models.browseAll') }}
+            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+            </svg>
+          </router-link>
+        </div>
+
+        <!-- Use Cases -->
+        <div class="mb-8 text-center">
+          <h2 class="mb-3 text-2xl font-bold text-gray-900 dark:text-white">
+            {{ t('home.useCases.title') }}
+          </h2>
+          <p class="text-sm text-gray-600 dark:text-dark-400">
+            {{ t('home.useCases.subtitle') }}
+          </p>
+        </div>
+        <div class="mb-16 grid gap-6 md:grid-cols-3">
+          <div
+            v-for="uc in useCaseCards"
+            :key="uc.key"
+            class="group rounded-2xl border border-gray-200/50 bg-white/60 p-6 backdrop-blur-sm transition-all duration-300 hover:shadow-xl hover:shadow-primary-500/10 dark:border-dark-700/50 dark:bg-dark-800/60"
+          >
+            <div
+              class="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br shadow-lg transition-transform group-hover:scale-110"
+              :class="uc.gradient"
+            >
+              <Icon :name="uc.icon" size="lg" class="text-white" />
+            </div>
+            <h3 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
+              {{ t(uc.title) }}
+            </h3>
+            <p class="text-sm leading-relaxed text-gray-600 dark:text-dark-400">
+              {{ t(uc.desc) }}
+            </p>
+          </div>
+        </div>
+
         <!-- Problems → Why us (integrated section): pain points lead into the comparison -->
         <div class="mb-8 text-center">
           <h2 class="text-2xl font-bold text-gray-900 dark:text-white">
@@ -346,6 +398,43 @@
           </table>
         </div>
 
+        <!-- FAQ Accordion -->
+        <div class="mb-8 text-center">
+          <h2 class="text-2xl font-bold text-gray-900 dark:text-white">
+            {{ t('home.faq.title') }}
+          </h2>
+        </div>
+        <div class="mb-16 space-y-3">
+          <div
+            v-for="key in faqKeys"
+            :key="key"
+            class="overflow-hidden rounded-xl border border-gray-200/50 bg-white/60 backdrop-blur-sm dark:border-dark-700/50 dark:bg-dark-800/60"
+          >
+            <button
+              class="flex w-full items-center justify-between px-6 py-4 text-left transition-colors hover:bg-gray-50/80 dark:hover:bg-dark-700/40"
+              @click="toggleFaq(key)"
+            >
+              <span class="text-sm font-medium text-gray-900 dark:text-white">
+                {{ t(`home.faq.items.${key}.q`) }}
+              </span>
+              <Icon
+                name="chevronDown"
+                size="sm"
+                class="flex-shrink-0 text-gray-400 transition-transform duration-200 dark:text-dark-500"
+                :class="{ 'rotate-180': openFaqItems[key] }"
+              />
+            </button>
+            <div
+              v-show="openFaqItems[key]"
+              class="border-t border-gray-200/50 px-6 py-4 dark:border-dark-700/50"
+            >
+              <p class="text-sm leading-relaxed text-gray-600 dark:text-dark-400">
+                {{ t(`home.faq.items.${key}.a`) }}
+              </p>
+            </div>
+          </div>
+        </div>
+
         <!-- CTA band -->
         <div
           class="rounded-2xl border border-primary-200/60 bg-gradient-to-br from-primary-50 to-white p-10 text-center backdrop-blur-sm dark:border-primary-800/60 dark:from-dark-800/80 dark:to-dark-900/60"
@@ -391,7 +480,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore, useAppStore } from '@/stores'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
@@ -462,6 +551,38 @@ const heroCards = [
 // Static iteration keys for the pain-point / comparison i18n blocks.
 const painPointKeys = ['expensive', 'complex', 'unstable', 'noControl'] as const
 const comparisonRows = ['unified', 'quota', 'quality', 'multimodal', 'monitoring'] as const
+
+// Use-case cards
+const useCaseCards = [
+  {
+    key: 'aiCoding',
+    icon: 'terminal',
+    gradient: 'from-primary-500 to-primary-600 shadow-primary-500/30',
+    title: 'home.useCases.aiCoding.title',
+    desc: 'home.useCases.aiCoding.desc',
+  },
+  {
+    key: 'creativeStudio',
+    icon: 'sparkles',
+    gradient: 'from-pink-500 to-rose-600 shadow-pink-500/30',
+    title: 'home.useCases.creativeStudio.title',
+    desc: 'home.useCases.creativeStudio.desc',
+  },
+  {
+    key: 'teamSharing',
+    icon: 'users',
+    gradient: 'from-blue-500 to-indigo-600 shadow-blue-500/30',
+    title: 'home.useCases.teamSharing.title',
+    desc: 'home.useCases.teamSharing.desc',
+  },
+] as const
+
+// FAQ accordion
+const faqKeys = ['differ', 'models', 'billing', 'tools', 'trial', 'quotaUp'] as const
+const openFaqItems = reactive<Record<string, boolean>>({})
+function toggleFaq(key: string) {
+  openFaqItems[key] = !openFaqItems[key]
+}
 
 const authStore = useAuthStore()
 const appStore = useAppStore()

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -659,6 +659,21 @@ const PriceTagIcon = {
     )
 }
 
+const ModelMarketplaceIcon = {
+  render: () =>
+    h(
+      'svg',
+      { fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', 'stroke-width': '1.5' },
+      [
+        h('path', {
+          'stroke-linecap': 'round',
+          'stroke-linejoin': 'round',
+          d: 'M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 002.25-2.25V6a2.25 2.25 0 00-2.25-2.25H6A2.25 2.25 0 003.75 6v2.25A2.25 2.25 0 006 10.5zm0 9.75h2.25A2.25 2.25 0 0010.5 18v-2.25a2.25 2.25 0 00-2.25-2.25H6a2.25 2.25 0 00-2.25 2.25V18A2.25 2.25 0 006 20.25zm9.75-9.75H18a2.25 2.25 0 002.25-2.25V6A2.25 2.25 0 0018 3.75h-2.25A2.25 2.25 0 0013.5 6v2.25a2.25 2.25 0 002.25 2.25z'
+        })
+      ]
+    )
+}
+
 const ChevronDownIcon = {
   render: () =>
     h(
@@ -696,6 +711,7 @@ function buildSelfNavItems(withDashboard: boolean): NavItem[] {
     items.push({ path: '/dashboard', label: t('nav.dashboard'), icon: DashboardIcon })
   }
   items.push({ path: '/quickstart', label: t('nav.quickstart'), icon: RocketIcon })
+  items.push({ path: '/models', label: t('nav.modelMarketplace'), icon: ModelMarketplaceIcon })
   items.push({ path: '/studio', label: t('nav.studio'), icon: StudioIcon })
   items.push(
     { path: '/keys', label: t('nav.apiKeys'), icon: KeyIcon },

--- a/frontend/src/constants/homeProviders.tk.ts
+++ b/frontend/src/constants/homeProviders.tk.ts
@@ -34,8 +34,7 @@ export const HOME_PROVIDER_CARDS: HomeProviderCard[] = [
   { id: 'gpt', labelKey: 'home.providers.gpt', glyph: 'G', gradient: 'from-green-500 to-green-600', badge: 'supported', modalities: ['image'] },
   { id: 'gemini', labelKey: 'home.providers.gemini', glyph: 'G', gradient: 'from-blue-500 to-blue-600', badge: 'supported', modalities: ['image', 'video'] },
   { id: 'kiro', labelKey: 'home.providers.kiro', glyph: 'K', gradient: 'from-indigo-500 to-indigo-600', badge: 'supported' },
-  { id: 'deepseek', labelKey: 'home.providers.deepseek', glyph: 'D', gradient: 'from-sky-500 to-blue-700', badge: 'supported' },
-  { id: 'volcengine', labelKey: 'home.providers.volcengine', glyph: '豆', gradient: 'from-red-500 to-rose-600', badge: 'supported', modalities: ['image'] },
+  { id: 'qwen', labelKey: 'home.providers.qwen', glyph: 'Q', gradient: 'from-violet-500 to-purple-600', badge: 'supported', modalities: ['image'] },
   // 泛化卡: 不点名具体上游, 只表达「可接入」, 样式弱于实测卡。
   { id: 'compat', labelKey: 'home.providers.compatTitle', glyph: '+', gradient: 'from-gray-500 to-gray-600', badge: 'compatible' },
 ]

--- a/frontend/src/constants/storefrontSeo.tk.ts
+++ b/frontend/src/constants/storefrontSeo.tk.ts
@@ -11,7 +11,7 @@ export const STOREFRONT_SEO = {
   ogImageUrl: 'https://api.tokenkey.dev/og-cover.png',
   zh: {
     metaDescription:
-      'TokenKey - AI API Gateway. 每一次调用，都是官方品质。文本、图像、视频，一个 Key 全搞定。Official quality AI API access.',
+      'TokenKey - AI API Gateway. 每一次调用，都是官方品质。文本、图像、视频，一个 Key 全搞定。One key for every AI model, routed direct.',
     ogDescription:
       '每一次调用，都是官方品质。一个 API Key，所有主流 AI 模型。文本、图像、视频。订阅配额，费用可预测。',
     heroTitle: '每一次调用，都是官方品质。',
@@ -20,13 +20,13 @@ export const STOREFRONT_SEO = {
     ctaDescriptionZh: '足够测试你的真实工作流。只需邮箱，无需信用卡。',
   },
   en: {
-    twitterDescription: 'Official quality AI API access. Text, image, video. One Key for everything.',
-    heroTitle: 'Every call, official quality.',
+    twitterDescription: 'One API key for Claude, GPT, Gemini, and more. Direct-to-vendor quality, predictable pricing.',
+    heroTitle: 'One key. Every model. Zero compromises.',
     heroSubtitle:
-      'One API Key, all major AI models. Text, image, video. Subscription quota, predictable costs.',
+      'Access Claude, GPT, Gemini, and DeepSeek through a single API key — routed directly to official endpoints with built-in quota controls.',
     freeTrialEn:
-      'Start free with 1M tokens included. Enough to test your real workflow. Email only, no card required.',
-    ctaDescriptionEn: 'Enough to test your real workflow. Email only, no card required.',
+      'Try free with 1M tokens on us. Enough to run your real workload end-to-end. Just an email — no credit card required.',
+    ctaDescriptionEn: 'Run your real workload end-to-end. Just an email — no credit card required.',
   },
 } as const
 

--- a/frontend/src/constants/storefrontSeo.tk.ts
+++ b/frontend/src/constants/storefrontSeo.tk.ts
@@ -23,7 +23,7 @@ export const STOREFRONT_SEO = {
     twitterDescription: 'One API key for Claude, GPT, Gemini, and more. Direct-to-vendor quality, predictable pricing.',
     heroTitle: 'One key. Every model. Zero compromises.',
     heroSubtitle:
-      'Access Claude, GPT, Gemini, and DeepSeek through a single API key — routed directly to official endpoints with built-in quota controls.',
+      'Access Claude, GPT, Gemini, and Alibaba Cloud Qwen through a single API key — routed directly to official endpoints with built-in quota controls.',
     freeTrialEn:
       'Try free with 1M tokens on us. Enough to run your real workload end-to-end. Just an email — no credit card required.',
     ctaDescriptionEn: 'Run your real workload end-to-end. Just an email — no credit card required.',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -722,6 +722,23 @@ export default {
     }
   },
 
+  // Model Marketplace (TK storefront)
+  models: {
+    title: 'Model Marketplace',
+    subtitle: 'Browse and compare AI models by capability, provider, and price',
+    filterAll: 'All',
+    filterText: 'Text',
+    filterImage: 'Image',
+    filterVideo: 'Video',
+    searchPlaceholder: 'Search models...',
+    pricePerK: '/ 1K tokens',
+    viewPricing: 'View Pricing Details',
+    noModels: 'No models match your filters.',
+    browseAll: 'Browse All Models',
+    inputPrice: 'Input',
+    outputPrice: 'Output',
+  },
+
   // Navigation
   nav: {
     dashboard: 'Dashboard',
@@ -765,6 +782,7 @@ export default {
     channelMonitor: 'Channel Monitor',
     channelStatus: 'Channel Status',
     riskControl: 'Risk Control',
+    modelMarketplace: 'Model Marketplace',
   },
 
   // Auth

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -737,6 +737,19 @@ export default {
     browseAll: 'Browse All Models',
     inputPrice: 'Input',
     outputPrice: 'Output',
+    providers: 'Providers',
+    capabilities: {
+      vision: 'Vision',
+      tools: 'Tools',
+      function_calling: 'Function calling',
+      thinking: 'Extended thinking',
+      reasoning: 'Reasoning',
+      image_generation: 'Image generation',
+      video_generation: 'Video generation',
+      audio: 'Audio',
+      json: 'JSON mode',
+      prompt_caching: 'Prompt caching',
+    },
   },
 
   // Navigation

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -720,6 +720,23 @@ export default {
     }
   },
 
+  // Model Marketplace (TK storefront)
+  models: {
+    title: '模型市场',
+    subtitle: '按能力、供应商和价格浏览对比 AI 模型',
+    filterAll: '全部',
+    filterText: '文本',
+    filterImage: '图片',
+    filterVideo: '视频',
+    searchPlaceholder: '搜索模型...',
+    pricePerK: '/ 1K tokens',
+    viewPricing: '查看定价详情',
+    noModels: '没有匹配的模型。',
+    browseAll: '浏览全部模型',
+    inputPrice: '输入',
+    outputPrice: '输出',
+  },
+
   // Navigation
   nav: {
     dashboard: '仪表盘',
@@ -763,6 +780,7 @@ export default {
     channelMonitor: '渠道监控',
     channelStatus: '渠道状态',
     riskControl: '风控中心',
+    modelMarketplace: '模型市场',
   },
 
   // Auth

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -735,6 +735,19 @@ export default {
     browseAll: '浏览全部模型',
     inputPrice: '输入',
     outputPrice: '输出',
+    providers: '供应商',
+    capabilities: {
+      vision: '图像输入',
+      tools: '工具调用',
+      function_calling: '工具调用',
+      thinking: '深度思考',
+      reasoning: '深度思考',
+      image_generation: '图像生成',
+      video_generation: '视频生成',
+      audio: '音频',
+      json: 'JSON 模式',
+      prompt_caching: '提示缓存',
+    },
   },
 
   // Navigation

--- a/frontend/src/i18n/tk/home.tk.ts
+++ b/frontend/src/i18n/tk/home.tk.ts
@@ -40,7 +40,7 @@ const en: HomeLocaleOverlay = {
       },
       stability: {
         title: 'Every Modality, One Key',
-        desc: 'Text, image, video, and code. Claude, GPT, Gemini, DeepSeek — all through a single API key. Built-in Studio for multimodal workflows.',
+        desc: 'Text, image, video, and code. Claude, GPT, Gemini, Qwen — all through a single API key. Built-in Studio for multimodal workflows.',
       },
       billing: {
         title: 'Predictable, Quota-based Pricing',
@@ -97,8 +97,7 @@ const en: HomeLocaleOverlay = {
       gpt: 'GPT',
       gemini: 'Gemini',
       kiro: 'Kiro',
-      deepseek: 'DeepSeek',
-      volcengine: 'Doubao · VolcEngine',
+      qwen: 'Alibaba Cloud Qwen',
       compatTitle: '200+ OpenAI-Compatible Models',
     },
     freeTrial: {
@@ -130,7 +129,7 @@ const en: HomeLocaleOverlay = {
         },
         models: {
           q: 'Which AI models are supported?',
-          a: 'Claude, GPT, Gemini, DeepSeek, Doubao, plus 200+ OpenAI-compatible models. Text, image, and video generation.',
+          a: 'Claude, GPT, Gemini, Alibaba Cloud Qwen, plus 200+ OpenAI-compatible models. Text, image, and video generation.',
         },
         billing: {
           q: 'How does billing work?',
@@ -178,7 +177,7 @@ const zh: HomeLocaleOverlay = {
       },
       stability: {
         title: '全模态覆盖',
-        desc: '文本、图像、视频。Claude / GPT / Gemini / DeepSeek。一个 Key 全搞定。内置 Studio 创作工作台。',
+        desc: '文本、图像、视频。Claude / GPT / Gemini / 通义千问。一个 Key 全搞定。内置 Studio 创作工作台。',
       },
       billing: {
         title: '订阅配额，费用可预测',
@@ -235,8 +234,7 @@ const zh: HomeLocaleOverlay = {
       gpt: 'GPT',
       gemini: 'Gemini',
       kiro: 'Kiro',
-      deepseek: 'DeepSeek',
-      volcengine: '豆包·VolcEngine',
+      qwen: '通义千问',
       compatTitle: '200+ OpenAI 兼容模型',
     },
     freeTrial: {
@@ -268,7 +266,7 @@ const zh: HomeLocaleOverlay = {
         },
         models: {
           q: '支持哪些 AI 模型？',
-          a: 'Claude、GPT、Gemini、DeepSeek、豆包，以及 200+ OpenAI 兼容模型。支持文本、图像、视频生成。',
+          a: 'Claude、GPT、Gemini、通义千问（阿里云百炼），以及 200+ OpenAI 兼容模型。支持文本、图像、视频生成。',
         },
         billing: {
           q: '计费方式是怎样的？',

--- a/frontend/src/i18n/tk/home.tk.ts
+++ b/frontend/src/i18n/tk/home.tk.ts
@@ -26,62 +26,62 @@ const en: HomeLocaleOverlay = {
       subtitle: STOREFRONT_SEO.en.heroSubtitle,
     },
     tags: {
-      subscriptionToApi: 'Native Access',
-      nativeFidelity: 'Full Features',
-      failover: 'Instant Failover',
+      subscriptionToApi: 'Direct Access',
+      nativeFidelity: 'Full Fidelity',
+      failover: 'Auto Failover',
       multiPlatform: 'Any Model',
       stickySession: 'Sticky Sessions',
-      quotaControl: 'Quota Control',
+      quotaControl: 'Quota Controls',
     },
     cards: {
       native: {
-        title: 'Official Quality, Native Pass-through',
-        desc: 'Every request goes directly to official APIs. No downgrades, no dilution, no third-party routing.',
+        title: 'Direct to Official APIs',
+        desc: 'Every request hits the vendor endpoint directly. No downgrades, no third-party proxies, no quality loss.',
       },
       stability: {
-        title: 'Full Multimodal Coverage',
-        desc: 'Text, image, video. Claude / GPT / Gemini / DeepSeek. One Key for everything. Built-in Studio workspace.',
+        title: 'Every Modality, One Key',
+        desc: 'Text, image, video, and code. Claude, GPT, Gemini, DeepSeek — all through a single API key. Built-in Studio for multimodal workflows.',
       },
       billing: {
-        title: 'Subscription Quota, Predictable Costs',
-        desc: 'Stop guessing your token bill. Daily/weekly/monthly subscription quota, team sharing, auto-stop on limit.',
+        title: 'Predictable, Quota-based Pricing',
+        desc: 'No more surprise token bills. Set daily, weekly, or monthly quotas per team. Hard caps stop spend automatically.',
       },
     },
     comparison: {
-      title: 'Why Choose Us?',
+      title: 'How We Compare',
       headers: {
-        feature: 'Comparison',
-        official: 'Official Direct',
+        feature: 'Feature',
+        official: 'Vendor API',
         thirdParty: 'Third-party Relay',
         us: 'TokenKey',
       },
       items: {
         unified: {
-          feature: 'Unified Access',
+          feature: 'Single API Key',
           official: '✗',
           thirdParty: '✗',
           us: '✓',
         },
         quota: {
-          feature: 'Quota Management',
+          feature: 'Built-in Quotas',
           official: '✗',
           thirdParty: '✗',
           us: '✓',
         },
         quality: {
-          feature: 'Quality Guarantee',
+          feature: 'Vendor-grade Quality',
           official: '✓',
           thirdParty: '✗',
           us: '✓',
         },
         multimodal: {
-          feature: 'Multimodal Unified',
+          feature: 'Multimodal Support',
           official: '✗',
           thirdParty: 'Partial',
           us: '✓',
         },
         monitoring: {
-          feature: 'Real-time Monitoring',
+          feature: 'Usage Monitoring',
           official: '✗',
           thirdParty: '✗',
           us: '✓',
@@ -89,8 +89,8 @@ const en: HomeLocaleOverlay = {
       },
     },
     providers: {
-      title: 'Supported AI Models',
-      description: 'One key, switch between models freely',
+      title: 'Supported Models',
+      description: 'One key to access any model, swap anytime',
       supported: 'Supported',
       compatible: 'Compatible',
       claude: 'Claude',
@@ -101,8 +101,57 @@ const en: HomeLocaleOverlay = {
       volcengine: 'Doubao · VolcEngine',
       compatTitle: '200+ OpenAI-Compatible Models',
     },
+    freeTrial: {
+      badge: '🎁 Free Trial: 1M Tokens',
+      startFree: 'Start free — no card required',
+    },
+    useCases: {
+      title: 'Built for Every AI Workflow',
+      subtitle: 'Start free. Scale to production.',
+      aiCoding: {
+        title: 'AI Coding Agent',
+        desc: 'Power Claude Code, Cursor, Codex, and Cline with one key. No per-seat license, pay by actual usage.',
+      },
+      creativeStudio: {
+        title: 'Creative Studio',
+        desc: 'Generate images with GPT, videos with Gemini and Runway, all from a unified workspace.',
+      },
+      teamSharing: {
+        title: 'Team API Sharing',
+        desc: 'One subscription, multiple team members. Quota-controlled, usage-tracked, no overspend surprises.',
+      },
+    },
+    faq: {
+      title: 'Frequently Asked Questions',
+      items: {
+        differ: {
+          q: 'How does TokenKey differ from third-party relay services?',
+          a: 'Every request goes directly to official APIs with full feature fidelity — no third-party routing, no quality downgrades.',
+        },
+        models: {
+          q: 'Which AI models are supported?',
+          a: 'Claude, GPT, Gemini, DeepSeek, Doubao, plus 200+ OpenAI-compatible models. Text, image, and video generation.',
+        },
+        billing: {
+          q: 'How does billing work?',
+          a: 'Subscription-based quota (daily/weekly/monthly). Predictable costs, auto-stop on limit — no surprise bills.',
+        },
+        tools: {
+          q: 'Can I use TokenKey with Claude Code / Cursor / Codex?',
+          a: 'Yes — set ANTHROPIC_BASE_URL and you are ready. Native support for sticky sessions, extended thinking, and streaming.',
+        },
+        trial: {
+          q: 'Is there a free trial?',
+          a: '1M tokens free, email registration only, no credit card required. Start building immediately.',
+        },
+        quotaUp: {
+          q: 'What happens when my quota is used up?',
+          a: 'Requests pause until the next billing cycle or you top up. No hidden overage charges.',
+        },
+      },
+    },
     cta: {
-      title: 'Start Free · 1M Tokens Included',
+      title: 'Try Free — 1M Tokens on Us',
       description: STOREFRONT_SEO.en.ctaDescriptionEn,
     },
   },
@@ -189,6 +238,55 @@ const zh: HomeLocaleOverlay = {
       deepseek: 'DeepSeek',
       volcengine: '豆包·VolcEngine',
       compatTitle: '200+ OpenAI 兼容模型',
+    },
+    freeTrial: {
+      badge: '🎁 免费试用：100 万 Tokens',
+      startFree: '免费开始，无需信用卡',
+    },
+    useCases: {
+      title: '为每种 AI 工作流而生',
+      subtitle: '免费开始，按需扩展。',
+      aiCoding: {
+        title: 'AI 编程助手',
+        desc: '一个 Key 驱动 Claude Code、Cursor、Codex、Cline。无需按席位付费，按实际用量计费。',
+      },
+      creativeStudio: {
+        title: '创意工作室',
+        desc: '用 GPT 生成图像，用 Gemini 和 Runway 生成视频，统一工作台一站搞定。',
+      },
+      teamSharing: {
+        title: '团队 API 共享',
+        desc: '一份订阅，多人共用。配额可控，用量可追踪，杜绝超支意外。',
+      },
+    },
+    faq: {
+      title: '常见问题',
+      items: {
+        differ: {
+          q: 'TokenKey 和第三方中转服务有什么区别？',
+          a: '每次请求都直达官方 API，特性完整透传——不路由第三方，不降级质量。',
+        },
+        models: {
+          q: '支持哪些 AI 模型？',
+          a: 'Claude、GPT、Gemini、DeepSeek、豆包，以及 200+ OpenAI 兼容模型。支持文本、图像、视频生成。',
+        },
+        billing: {
+          q: '计费方式是怎样的？',
+          a: '订阅配额制（按日/周/月），费用可预测，超限自动暂停——不会有意外账单。',
+        },
+        tools: {
+          q: '可以用 TokenKey 接入 Claude Code / Cursor / Codex 吗？',
+          a: '可以——设置 ANTHROPIC_BASE_URL 即可。原生支持会话保持、扩展思考和流式输出。',
+        },
+        trial: {
+          q: '有免费试用吗？',
+          a: '100 万 tokens 免费，仅需邮箱注册，无需绑定信用卡。立即开始使用。',
+        },
+        quotaUp: {
+          q: '配额用完了怎么办？',
+          a: '请求会暂停，直到下一个计费周期或充值。不会有隐性超额费用。',
+        },
+      },
     },
     cta: {
       title: '免费试用 · 送 100 万 tokens',

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -168,6 +168,16 @@ const routes: RouteRecordRaw[] = [
     }
   },
   {
+    path: '/models',
+    name: 'ModelMarketplace',
+    component: () => import('@/views/ModelMarketplaceView.vue'),
+    meta: {
+      requiresAuth: false,
+      title: 'Model Marketplace',
+      titleKey: 'models.title'
+    }
+  },
+  {
     path: '/pricing',
     name: 'Pricing',
     component: () => import('@/views/PricingView.vue'),

--- a/frontend/src/views/ModelMarketplaceView.vue
+++ b/frontend/src/views/ModelMarketplaceView.vue
@@ -74,7 +74,7 @@
           <aside class="hidden w-56 shrink-0 lg:block">
             <div class="sticky top-6 rounded-xl border border-gray-200/60 bg-white/80 p-4 backdrop-blur-sm dark:border-dark-700/60 dark:bg-dark-800/80">
               <h3 class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-400">
-                Providers
+                {{ t('models.providers') }}
               </h3>
               <ul class="space-y-1">
                 <li>
@@ -178,7 +178,7 @@
                     class="rounded-md px-2 py-0.5 text-[10px] font-medium"
                     :class="capabilityClass(cap)"
                   >
-                    {{ cap }}
+                    {{ formatCapabilityLabel(cap) }}
                   </span>
                 </div>
 
@@ -226,7 +226,7 @@ import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
 import { getPublicPricing, type PublicCatalogModel } from '@/api/pricing'
 
-const { t } = useI18n()
+const { t, te } = useI18n()
 const authStore = useAuthStore()
 
 const isAuthenticated = computed(() => authStore.isAuthenticated)
@@ -294,6 +294,12 @@ function formatPrice(price: number): string {
   if (price < 0.001) return `$${price.toFixed(6)}`
   if (price < 0.01) return `$${price.toFixed(4)}`
   return `$${price.toFixed(3)}`
+}
+
+function formatCapabilityLabel(cap: string): string {
+  const key = `models.capabilities.${cap}`
+  if (te(key)) return t(key)
+  return cap.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
 function capabilityClass(cap: string): string {

--- a/frontend/src/views/ModelMarketplaceView.vue
+++ b/frontend/src/views/ModelMarketplaceView.vue
@@ -1,0 +1,327 @@
+<template>
+  <div
+    class="relative flex min-h-screen flex-col bg-gradient-to-br from-gray-50 via-primary-50/30 to-gray-100 dark:from-dark-950 dark:via-dark-900 dark:to-dark-950"
+  >
+    <main class="relative z-10 flex-1 px-4 pb-16 pt-6 sm:px-6">
+      <div class="mx-auto max-w-6xl">
+        <!-- Header -->
+        <div class="mb-8 text-center">
+          <h1 class="mb-2 text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
+            {{ t('models.title') }}
+          </h1>
+          <p class="text-base text-gray-600 dark:text-dark-400">
+            {{ t('models.subtitle') }}
+          </p>
+          <!-- Back nav -->
+          <div class="mt-4 flex items-center justify-center gap-3">
+            <router-link
+              to="/home"
+              class="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-dark-400 dark:hover:bg-dark-800 dark:hover:text-white"
+            >
+              <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+              </svg>
+              {{ t('pricing.nav.home') }}
+            </router-link>
+            <router-link
+              to="/pricing"
+              class="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-dark-400 dark:hover:bg-dark-800 dark:hover:text-white"
+            >
+              {{ t('models.viewPricing') }}
+            </router-link>
+          </div>
+        </div>
+
+        <!-- Search + Filter Bar -->
+        <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <!-- Search -->
+          <div class="relative flex-1 sm:max-w-sm">
+            <svg
+              class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+              fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+            </svg>
+            <input
+              v-model="searchQuery"
+              type="text"
+              :placeholder="t('models.searchPlaceholder')"
+              class="w-full rounded-lg border border-gray-200 bg-white py-2 pl-10 pr-4 text-sm text-gray-900 placeholder-gray-400 transition-colors focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-dark-700 dark:bg-dark-800 dark:text-white dark:placeholder-dark-500"
+            />
+          </div>
+
+          <!-- Category Filter Pills -->
+          <div class="flex flex-wrap gap-2">
+            <button
+              v-for="filter in categoryFilters"
+              :key="filter.key"
+              @click="activeCategory = filter.key"
+              class="rounded-full px-4 py-1.5 text-sm font-medium transition-all"
+              :class="
+                activeCategory === filter.key
+                  ? 'bg-primary-500 text-white shadow-sm'
+                  : 'bg-white text-gray-600 hover:bg-gray-100 dark:bg-dark-800 dark:text-dark-300 dark:hover:bg-dark-700'
+              "
+            >
+              {{ filter.label }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Content: Sidebar + Grid -->
+        <div class="flex flex-col gap-6 lg:flex-row">
+          <!-- Provider Sidebar (desktop) -->
+          <aside class="hidden w-56 shrink-0 lg:block">
+            <div class="sticky top-6 rounded-xl border border-gray-200/60 bg-white/80 p-4 backdrop-blur-sm dark:border-dark-700/60 dark:bg-dark-800/80">
+              <h3 class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-400">
+                Providers
+              </h3>
+              <ul class="space-y-1">
+                <li>
+                  <button
+                    @click="activeVendor = null"
+                    class="w-full rounded-lg px-3 py-1.5 text-left text-sm transition-colors"
+                    :class="
+                      activeVendor === null
+                        ? 'bg-primary-50 font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                        : 'text-gray-600 hover:bg-gray-50 dark:text-dark-300 dark:hover:bg-dark-700'
+                    "
+                  >
+                    {{ t('models.filterAll') }}
+                    <span class="ml-1 text-xs text-gray-400 dark:text-dark-500">({{ filteredByCategory.length }})</span>
+                  </button>
+                </li>
+                <li v-for="vendor in vendorList" :key="vendor.name">
+                  <button
+                    @click="activeVendor = vendor.name"
+                    class="w-full rounded-lg px-3 py-1.5 text-left text-sm transition-colors"
+                    :class="
+                      activeVendor === vendor.name
+                        ? 'bg-primary-50 font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                        : 'text-gray-600 hover:bg-gray-50 dark:text-dark-300 dark:hover:bg-dark-700'
+                    "
+                  >
+                    {{ vendor.name }}
+                    <span class="ml-1 text-xs text-gray-400 dark:text-dark-500">({{ vendor.count }})</span>
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </aside>
+
+          <!-- Mobile Provider Filter -->
+          <div class="flex flex-wrap gap-2 lg:hidden">
+            <button
+              @click="activeVendor = null"
+              class="rounded-full px-3 py-1 text-xs font-medium transition-all"
+              :class="
+                activeVendor === null
+                  ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
+                  : 'bg-gray-100 text-gray-600 dark:bg-dark-800 dark:text-dark-300'
+              "
+            >
+              {{ t('models.filterAll') }}
+            </button>
+            <button
+              v-for="vendor in vendorList"
+              :key="'m-' + vendor.name"
+              @click="activeVendor = vendor.name"
+              class="rounded-full px-3 py-1 text-xs font-medium transition-all"
+              :class="
+                activeVendor === vendor.name
+                  ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
+                  : 'bg-gray-100 text-gray-600 dark:bg-dark-800 dark:text-dark-300'
+              "
+            >
+              {{ vendor.name }} ({{ vendor.count }})
+            </button>
+          </div>
+
+          <!-- Model Cards Grid -->
+          <div class="min-w-0 flex-1">
+            <!-- Loading -->
+            <div v-if="loading" class="flex items-center justify-center py-20">
+              <div class="h-8 w-8 animate-spin rounded-full border-2 border-primary-500 border-t-transparent"></div>
+            </div>
+
+            <!-- Empty -->
+            <div v-else-if="filteredModels.length === 0" class="py-20 text-center">
+              <p class="text-gray-500 dark:text-dark-400">{{ t('models.noModels') }}</p>
+            </div>
+
+            <!-- Grid -->
+            <div v-else class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              <router-link
+                v-for="model in filteredModels"
+                :key="model.model_id"
+                :to="{ path: '/pricing', query: { model: model.model_id } }"
+                class="group rounded-xl border border-gray-200/60 bg-white p-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary-300 hover:shadow-lg hover:shadow-primary-500/10 dark:border-dark-700/60 dark:bg-dark-800 dark:hover:border-primary-700"
+              >
+                <!-- Model Name + Vendor -->
+                <div class="mb-3 flex items-start justify-between gap-2">
+                  <h3 class="min-w-0 break-all text-sm font-semibold text-gray-900 group-hover:text-primary-600 dark:text-white dark:group-hover:text-primary-400">
+                    {{ model.model_id }}
+                  </h3>
+                  <span
+                    v-if="model.vendor"
+                    class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-dark-700 dark:text-dark-300"
+                  >
+                    {{ model.vendor }}
+                  </span>
+                </div>
+
+                <!-- Capabilities -->
+                <div class="mb-3 flex flex-wrap gap-1.5">
+                  <span
+                    v-for="cap in model.capabilities"
+                    :key="cap"
+                    class="rounded-md px-2 py-0.5 text-[10px] font-medium"
+                    :class="capabilityClass(cap)"
+                  >
+                    {{ cap }}
+                  </span>
+                </div>
+
+                <!-- Pricing -->
+                <div v-if="model.pricing" class="flex items-center gap-4 border-t border-gray-100 pt-3 dark:border-dark-700">
+                  <div class="flex-1">
+                    <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.inputPrice') }}</span>
+                    <p class="text-sm font-semibold text-gray-900 dark:text-white">
+                      {{ formatPrice(model.pricing.input_per_1k_tokens) }}
+                    </p>
+                  </div>
+                  <div class="flex-1">
+                    <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.outputPrice') }}</span>
+                    <p class="text-sm font-semibold text-gray-900 dark:text-white">
+                      {{ formatPrice(model.pricing.output_per_1k_tokens) }}
+                    </p>
+                  </div>
+                  <span class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('models.pricePerK') }}</span>
+                </div>
+              </router-link>
+            </div>
+          </div>
+        </div>
+
+        <!-- Bottom CTA -->
+        <div class="mt-12 text-center">
+          <router-link
+            :to="isAuthenticated ? '/quickstart' : '/register'"
+            class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-6 py-2.5 text-sm font-medium text-white shadow-lg shadow-primary-500/30 transition-all hover:bg-primary-600"
+          >
+            {{ isAuthenticated ? t('nav.quickstart') : t('auth.createAccount') }}
+            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+            </svg>
+          </router-link>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '@/stores/auth'
+import { getPublicPricing, type PublicCatalogModel } from '@/api/pricing'
+
+const { t } = useI18n()
+const authStore = useAuthStore()
+
+const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+const loading = ref(true)
+const models = ref<PublicCatalogModel[]>([])
+const searchQuery = ref('')
+const activeCategory = ref<string>('all')
+const activeVendor = ref<string | null>(null)
+
+const categoryFilters = computed(() => [
+  { key: 'all', label: t('models.filterAll') },
+  { key: 'text', label: t('models.filterText') },
+  { key: 'image', label: t('models.filterImage') },
+  { key: 'video', label: t('models.filterVideo') },
+])
+
+// Filter by category (capability-based)
+const filteredByCategory = computed(() => {
+  if (activeCategory.value === 'all') return models.value
+  if (activeCategory.value === 'image') {
+    return models.value.filter(m => m.capabilities.includes('image_generation'))
+  }
+  if (activeCategory.value === 'video') {
+    return models.value.filter(m => m.capabilities.includes('video_generation'))
+  }
+  // text: exclude image/video-only models
+  return models.value.filter(m =>
+    !m.capabilities.includes('image_generation') && !m.capabilities.includes('video_generation')
+  )
+})
+
+// Vendor list derived from category-filtered models
+const vendorList = computed(() => {
+  const map = new Map<string, number>()
+  for (const m of filteredByCategory.value) {
+    const v = m.vendor || 'Unknown'
+    map.set(v, (map.get(v) || 0) + 1)
+  }
+  return Array.from(map.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count)
+})
+
+// Final filtered list
+const filteredModels = computed(() => {
+  let result = filteredByCategory.value
+
+  // Vendor filter
+  if (activeVendor.value) {
+    result = result.filter(m => (m.vendor || 'Unknown') === activeVendor.value)
+  }
+
+  // Search filter
+  if (searchQuery.value.trim()) {
+    const q = searchQuery.value.toLowerCase().trim()
+    result = result.filter(m => m.model_id.toLowerCase().includes(q))
+  }
+
+  return result
+})
+
+function formatPrice(price: number): string {
+  if (price === 0) return 'Free'
+  if (price < 0.001) return `$${price.toFixed(6)}`
+  if (price < 0.01) return `$${price.toFixed(4)}`
+  return `$${price.toFixed(3)}`
+}
+
+function capabilityClass(cap: string): string {
+  switch (cap) {
+    case 'vision':
+      return 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
+    case 'image_generation':
+      return 'bg-purple-50 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300'
+    case 'video_generation':
+      return 'bg-pink-50 text-pink-700 dark:bg-pink-900/30 dark:text-pink-300'
+    case 'tools':
+    case 'function_calling':
+      return 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300'
+    case 'thinking':
+      return 'bg-teal-50 text-teal-700 dark:bg-teal-900/30 dark:text-teal-300'
+    default:
+      return 'bg-gray-50 text-gray-600 dark:bg-dark-700 dark:text-dark-300'
+  }
+}
+
+onMounted(async () => {
+  try {
+    const response = await getPublicPricing()
+    models.value = response.data
+  } catch (e) {
+    console.error('Failed to load model catalog:', e)
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -542,7 +542,7 @@
  */
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { getPublicPricing, type PublicCatalogResponse } from '@/api/pricing'
 import {
   getMePricingCatalog,
@@ -562,6 +562,7 @@ import {
 import { exportPricingCsv } from '@/composables/useTkPricingExport'
 
 const { t } = useI18n()
+const route = useRoute()
 const router = useRouter()
 
 // 「授权分组」badge 点击：跳到 Keys 页并自动打开「创建密钥」面板、预置该分组。
@@ -1096,8 +1097,24 @@ function reload(): void {
   void load()
 }
 
-onMounted(() => {
-  void load()
+/** Deep link from /models marketplace cards: ?model=<id> pre-fills exact search. */
+function applyModelDeepLinkFromRoute(): void {
+  const raw = route.query.model
+  const modelId =
+    typeof raw === 'string'
+      ? raw.trim()
+      : Array.isArray(raw)
+        ? (raw[0]?.trim() ?? '')
+        : ''
+  if (!modelId) return
+  viewMode.value = 'public'
+  modelSearchQuery.value = modelId
+  modelSearchMode.value = 'exact'
+}
+
+onMounted(async () => {
+  await load()
+  applyModelDeepLinkFromRoute()
   void appStore.fetchPublicSettings()
 })
 </script>

--- a/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
+++ b/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import ModelMarketplaceView from '../ModelMarketplaceView.vue'
+import type { PublicCatalogModel, PublicCatalogResponse } from '@/api/pricing'
+
+const { getPublicPricing, authState } = vi.hoisted(() => ({
+  getPublicPricing: vi.fn(),
+  authState: { isAuthenticated: false },
+}))
+
+vi.mock('@/api/pricing', () => ({
+  getPublicPricing,
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => authState,
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  const modelsEn: Record<string, string> = {
+    'models.title': 'Model Marketplace',
+    'models.subtitle': 'Browse models',
+    'models.filterAll': 'All',
+    'models.filterText': 'Text',
+    'models.filterImage': 'Image',
+    'models.filterVideo': 'Video',
+    'models.searchPlaceholder': 'Search models...',
+    'models.noModels': 'No models match your filters.',
+    'models.providers': 'Providers',
+    'models.inputPrice': 'Input',
+    'models.outputPrice': 'Output',
+    'models.pricePerK': '/ 1K tokens',
+    'models.viewPricing': 'View Pricing Details',
+    'models.capabilities.image_generation': 'Image generation',
+    'models.capabilities.video_generation': 'Video generation',
+    'pricing.nav.home': 'Home',
+    'nav.quickstart': 'Quick Start',
+    'auth.createAccount': 'Create account',
+  }
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => modelsEn[key] ?? key,
+      te: (key: string) => key in modelsEn,
+    }),
+  }
+})
+
+function catalog(models: PublicCatalogModel[]): PublicCatalogResponse {
+  return { object: 'list', updated_at: '2025-01-01T00:00:00Z', data: models }
+}
+
+function model(
+  model_id: string,
+  vendor: string,
+  capabilities: string[] = []
+): PublicCatalogModel {
+  return {
+    model_id,
+    vendor,
+    capabilities,
+    pricing: {
+      currency: 'USD',
+      input_per_1k_tokens: 0.001,
+      output_per_1k_tokens: 0.002,
+    },
+  }
+}
+
+function mountMarketplace() {
+  return mount(ModelMarketplaceView, {
+    global: {
+      stubs: {
+        RouterLink: { props: ['to'], template: '<a><slot /></a>' },
+      },
+    },
+  })
+}
+
+describe('ModelMarketplaceView', () => {
+  beforeEach(() => {
+    getPublicPricing.mockReset()
+    authState.isAuthenticated = false
+  })
+
+  it('renders image models when image filter is selected', async () => {
+    getPublicPricing.mockResolvedValue(
+      catalog([
+        model('gpt-4o-mini', 'OpenAI'),
+        model('imagen-4.0-generate-001', 'Google', ['image_generation']),
+      ])
+    )
+
+    const wrapper = mountMarketplace()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('gpt-4o-mini')
+    expect(wrapper.text()).toContain('imagen-4.0-generate-001')
+
+    const imageBtn = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Image'))
+    expect(imageBtn).toBeTruthy()
+    await imageBtn!.trigger('click')
+
+    expect(wrapper.text()).toContain('imagen-4.0-generate-001')
+    expect(wrapper.text()).not.toContain('gpt-4o-mini')
+    expect(wrapper.text()).toContain('Image generation')
+  })
+
+  it('shows empty state when search matches no models', async () => {
+    getPublicPricing.mockResolvedValue(catalog([model('gpt-4o-mini', 'OpenAI')]))
+
+    const wrapper = mountMarketplace()
+    await flushPromises()
+
+    const search = wrapper.get('input[type="text"]')
+    await search.setValue('does-not-exist')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No models match your filters.')
+    expect(wrapper.text()).not.toContain('gpt-4o-mini')
+  })
+})

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -5,7 +5,7 @@ import PricingView from '../PricingView.vue'
 import type { PublicCatalogResponse } from '@/api/pricing'
 import type { MePricingCatalogResponse } from '@/api/me-pricing'
 
-const { getPublicPricing, getMePricingCatalog, authState, exportPricingCsv, showSuccess, showError } =
+const { getPublicPricing, getMePricingCatalog, authState, exportPricingCsv, showSuccess, showError, routeState } =
   vi.hoisted(() => ({
     getPublicPricing: vi.fn(),
     getMePricingCatalog: vi.fn(),
@@ -13,6 +13,7 @@ const { getPublicPricing, getMePricingCatalog, authState, exportPricingCsv, show
     exportPricingCsv: vi.fn(),
     showSuccess: vi.fn(),
     showError: vi.fn(),
+    routeState: { query: {} as Record<string, string | string[] | undefined> },
   }))
 
 vi.mock('@/api/pricing', () => ({
@@ -44,6 +45,11 @@ vi.mock('@/stores/app', () => ({
     showSuccess,
     showError,
   }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => routeState,
+  useRouter: () => ({ push: vi.fn() }),
 }))
 
 vi.mock('vue-i18n', async () => {
@@ -234,6 +240,22 @@ describe('PricingView', () => {
     localStorage.clear()
     authState.isAuthenticated = false
     authState.isAdmin = false
+    routeState.query = {}
+  })
+
+  it('prefills exact model search from ?model= deep link', async () => {
+    routeState.query = { model: 'gpt-4o-mini' }
+    getPublicPricing.mockResolvedValue(
+      publicCatalog([publicModel('gpt-4o-mini'), publicModel('gpt-5.4')])
+    )
+
+    const wrapper = mountPricingView()
+    await flushPromises()
+
+    const search = wrapper.get('#pricing-model-search')
+    expect((search.element as HTMLInputElement).value).toBe('gpt-4o-mini')
+    expect(wrapper.text()).toContain('gpt-4o-mini')
+    expect(wrapper.text()).not.toContain('gpt-5.4')
   })
 
   it('shows max output column when catalog includes max_output_tokens', async () => {


### PR DESCRIPTION
## 摘要

店面 P1+P2 改造：模型市场 + 着陆页扩展 + 英文文案原生化；并修复 xj-review 阻塞项。

- **P1: 模型市场** — 新增 `/models` 页面，卡片式浏览，支持类别筛选（全部/文本/图像/视频）、厂商侧边栏、搜索。侧边栏导航入口 + 着陆页「Browse All Models」CTA。
- **P2-1: 免费试用可见性** — "100万 tokens 免费" 徽章出现在 hero 区、用例副标题、CTA 按钮（3 处展示）。
- **P2-2: 着陆页扩展** — 6 项 FAQ 手风琴 + 3 张用例卡片（AI 编程助手 / 创意工作室 / 团队 API 共享）。
- **P2-3: 英文叙事独立** — 所有英文文案以原生美式英语重写（Stripe/Vercel 调性），替代翻译痕迹。后端 prerender HTML 同步对齐。
- **Review 修复** — `/pricing?model=` deep link 接线；`/models` crawler prerender；供应商/能力标签 i18n；ModelMarketplace + Pricing 聚焦测试。
- **门面品牌对齐** — 着陆页/SEO/prerender 中 DeepSeek、豆包/VolcEngine 营销文案统一改为阿里 Qwen（英文 Alibaba Cloud Qwen，中文通义千问/百炼）；provider 卡合并为单张 Qwen 卡。

## 风险

低风险。纯前端展示层变更 + 后端 SEO prerender 文案/路由调整，不触碰业务逻辑、数据层、网关或计费。模型列表仍走 `/api/v1/public/pricing` SSOT。

## 验证

- [x] `pnpm build` 通过（typecheck + production bundle + dist freshness）
- [x] `go test -tags=unit ./internal/web/ -run TestPrerender` 通过
- [x] `pnpm exec vitest run src/views/__tests__/ModelMarketplaceView.spec.ts src/views/__tests__/PricingView.spec.ts` — 18 tests 全绿
- [x] `scripts/preflight.sh` 全部 PASS
- [ ] CI: `backend-ci` + `marker-acknowledgement` workflow

## 提交

- `f58d622cf` feat(storefront): model marketplace + landing expansion + native English copy
- `bac5855f5` fix(storefront): address xj-review findings for model marketplace PR
- `bad3f85bb` fix(storefront): replace DeepSeek/VolcEngine marketing copy with Qwen

## 标记

sentinel-registry-reviewed
upstream-touch-trivial

---
最新提交：bad3f85bb
