### PR TITLE
chore: SSOT apipath、前端契约、sentinel（从 #1231 拆分）

### DIFF
--- a/backend/internal/apipath/apipath.go
+++ b/backend/internal/apipath/apipath.go
@@ -1,0 +1,19 @@
+// Package apipath defines canonical inbound / upstream API endpoint paths.
+//
+// This is a leaf package with zero internal imports, so any layer
+// (handler, service, middleware, observability) can import it without
+// creating import cycles.
+package apipath
+
+const (
+	Messages          = "/v1/messages"
+	ChatCompletions   = "/v1/chat/completions"
+	Embeddings        = "/v1/embeddings"
+	Responses         = "/v1/responses"
+	ImagesGenerations = "/v1/images/generations"
+	ImagesEdits       = "/v1/images/edits"
+	VideosGenerations = "/v1/videos/generations"
+	Videos            = "/v1/videos"
+	GeminiModels      = "/v1beta/models"
+	Models            = "/v1/models"
+)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1772,7 +1772,7 @@ func setDefaults() {
 		"raw.githubusercontent.com",
 	})
 	viper.SetDefault("security.url_allowlist.crs_hosts", []string{})
-	viper.SetDefault("security.url_allowlist.allow_private_hosts", false)
+	viper.SetDefault("security.url_allowlist.allow_private_hosts", true)
 	viper.SetDefault("security.url_allowlist.allow_insecure_http", true)
 	viper.SetDefault("security.response_headers.enabled", true)
 	viper.SetDefault("security.response_headers.additional_allowed", []string{})
@@ -1875,8 +1875,8 @@ func setDefaults() {
 	viper.SetDefault("database.password", "postgres")
 	viper.SetDefault("database.dbname", "sub2api")
 	viper.SetDefault("database.sslmode", "prefer")
-	viper.SetDefault("database.max_open_conns", 50)
-	viper.SetDefault("database.max_idle_conns", 10)
+	viper.SetDefault("database.max_open_conns", 256)
+	viper.SetDefault("database.max_idle_conns", 128)
 	viper.SetDefault("database.conn_max_lifetime_minutes", 30)
 	viper.SetDefault("database.conn_max_idle_time_minutes", 5)
 	viper.SetDefault("database.user_platform_quota_flusher_enabled", false)
@@ -1892,7 +1892,7 @@ func setDefaults() {
 	viper.SetDefault("redis.read_timeout_seconds", 3)
 	viper.SetDefault("redis.write_timeout_seconds", 3)
 	viper.SetDefault("redis.pool_size", 1024)
-	viper.SetDefault("redis.min_idle_conns", 10)
+	viper.SetDefault("redis.min_idle_conns", 128)
 	viper.SetDefault("redis.enable_tls", false)
 
 	// Ops (vNext)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1772,7 +1772,7 @@ func setDefaults() {
 		"raw.githubusercontent.com",
 	})
 	viper.SetDefault("security.url_allowlist.crs_hosts", []string{})
-	viper.SetDefault("security.url_allowlist.allow_private_hosts", true)
+	viper.SetDefault("security.url_allowlist.allow_private_hosts", false)
 	viper.SetDefault("security.url_allowlist.allow_insecure_http", true)
 	viper.SetDefault("security.response_headers.enabled", true)
 	viper.SetDefault("security.response_headers.additional_allowed", []string{})
@@ -1875,8 +1875,8 @@ func setDefaults() {
 	viper.SetDefault("database.password", "postgres")
 	viper.SetDefault("database.dbname", "sub2api")
 	viper.SetDefault("database.sslmode", "prefer")
-	viper.SetDefault("database.max_open_conns", 256)
-	viper.SetDefault("database.max_idle_conns", 128)
+	viper.SetDefault("database.max_open_conns", 50)
+	viper.SetDefault("database.max_idle_conns", 10)
 	viper.SetDefault("database.conn_max_lifetime_minutes", 30)
 	viper.SetDefault("database.conn_max_idle_time_minutes", 5)
 	viper.SetDefault("database.user_platform_quota_flusher_enabled", false)
@@ -1892,7 +1892,7 @@ func setDefaults() {
 	viper.SetDefault("redis.read_timeout_seconds", 3)
 	viper.SetDefault("redis.write_timeout_seconds", 3)
 	viper.SetDefault("redis.pool_size", 1024)
-	viper.SetDefault("redis.min_idle_conns", 128)
+	viper.SetDefault("redis.min_idle_conns", 10)
 	viper.SetDefault("redis.enable_tls", false)
 
 	// Ops (vNext)

--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -65,10 +65,11 @@ const (
 
 // Redeem type constants
 const (
-	RedeemTypeBalance      = "balance"
-	RedeemTypeConcurrency  = "concurrency"
-	RedeemTypeSubscription = "subscription"
-	RedeemTypeInvitation   = "invitation"
+	RedeemTypeBalance          = "balance"
+	RedeemTypeConcurrency      = "concurrency"
+	RedeemTypeSubscription     = "subscription"
+	RedeemTypeInvitation       = "invitation"
+	RedeemTypeAffiliateBalance = "affiliate_balance"
 )
 
 // PromoCode status constants

--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -12,20 +12,6 @@ const (
 	StatusExpired  = "expired"
 )
 
-// StatusInactiveAPI is the API-facing value returned instead of StatusDisabled
-// for Account, Group, and ApiKey resources. User resources return StatusDisabled
-// directly.
-const StatusInactiveAPI = "inactive"
-
-// NormalizeStatusForAPI maps internal DB status values to API-facing values.
-// StatusDisabled is surfaced as "inactive" for non-User resources.
-func NormalizeStatusForAPI(dbStatus string) string {
-	if dbStatus == StatusDisabled {
-		return StatusInactiveAPI
-	}
-	return dbStatus
-}
-
 // Role constants
 const (
 	RoleAdmin = "admin"

--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -12,6 +12,20 @@ const (
 	StatusExpired  = "expired"
 )
 
+// StatusInactiveAPI is the API-facing value returned instead of StatusDisabled
+// for Account, Group, and ApiKey resources. User resources return StatusDisabled
+// directly.
+const StatusInactiveAPI = "inactive"
+
+// NormalizeStatusForAPI maps internal DB status values to API-facing values.
+// StatusDisabled is surfaced as "inactive" for non-User resources.
+func NormalizeStatusForAPI(dbStatus string) string {
+	if dbStatus == StatusDisabled {
+		return StatusInactiveAPI
+	}
+	return dbStatus
+}
+
 // Role constants
 const (
 	RoleAdmin = "admin"

--- a/backend/internal/handler/admin/account_data.go
+++ b/backend/internal/handler/admin/account_data.go
@@ -794,7 +794,7 @@ func normalizeProxyStatus(status string) string {
 		return service.StatusActive
 	case "inactive", service.StatusDisabled:
 		return "inactive"
-	case "expired":
+	case service.StatusExpired:
 		// 导入 expired 代理按 inactive 处理，避免导入即触发到期改投逻辑
 		return "inactive"
 	default:

--- a/backend/internal/handler/admin/redeem_handler.go
+++ b/backend/internal/handler/admin/redeem_handler.go
@@ -180,10 +180,10 @@ func (h *RedeemHandler) CreateAndRedeem(c *gin.Context) {
 	// 向后兼容：旧版调用方（如 Sub2ApiPay）不传 type 字段，默认当作 balance 充值处理。
 	// 请勿删除此默认值逻辑，否则会导致旧版调用方 400 报错。
 	if req.Type == "" {
-		req.Type = "balance"
+		req.Type = service.RedeemTypeBalance
 	}
 
-	if req.Type == "subscription" {
+	if req.Type == service.RedeemTypeSubscription {
 		if req.GroupID == nil {
 			response.BadRequest(c, "group_id is required for subscription type")
 			return

--- a/backend/internal/handler/endpoint.go
+++ b/backend/internal/handler/endpoint.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 )
@@ -15,15 +16,16 @@ import (
 // ──────────────────────────────────────────────────────────
 
 const (
-	EndpointMessages          = "/v1/messages"
-	EndpointChatCompletions   = "/v1/chat/completions"
-	EndpointEmbeddings        = "/v1/embeddings"
-	EndpointResponses         = "/v1/responses"
-	EndpointImagesGenerations = "/v1/images/generations"
-	EndpointImagesEdits       = "/v1/images/edits"
-	EndpointVideosGenerations = "/v1/videos/generations"
-	EndpointVideos            = "/v1/videos"
-	EndpointGeminiModels      = "/v1beta/models"
+	EndpointMessages          = apipath.Messages
+	EndpointChatCompletions   = apipath.ChatCompletions
+	EndpointEmbeddings        = apipath.Embeddings
+	EndpointResponses         = apipath.Responses
+	EndpointImagesGenerations = apipath.ImagesGenerations
+	EndpointImagesEdits       = apipath.ImagesEdits
+	EndpointVideosGenerations = apipath.VideosGenerations
+	EndpointVideos            = apipath.Videos
+	EndpointGeminiModels      = apipath.GeminiModels
+	EndpointModels            = apipath.Models
 )
 
 // gin.Context keys used by the middleware and helpers below.

--- a/backend/internal/handler/payment_handler.go
+++ b/backend/internal/handler/payment_handler.go
@@ -94,7 +94,7 @@ func (h *PaymentHandler) GetPlans(c *gin.Context) {
 // GetChannels returns enabled payment channels.
 // GET /api/v1/payment/channels
 func (h *PaymentHandler) GetChannels(c *gin.Context) {
-	channels, _, err := h.channelService.List(c.Request.Context(), pagination.PaginationParams{Page: 1, PageSize: 1000}, "active", "")
+	channels, _, err := h.channelService.List(c.Request.Context(), pagination.PaginationParams{Page: 1, PageSize: 1000}, service.StatusActive, "")
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return

--- a/backend/internal/observability/qa/service.go
+++ b/backend/internal/observability/qa/service.go
@@ -16,6 +16,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
+
 	"github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/qarecord"
 	"github.com/Wei-Shaw/sub2api/internal/config"
@@ -78,12 +80,12 @@ const (
 	qaCaptureStatusCapturedToDLQ     = "captured_dlq"
 	qaCapturePersistModeAsync        = "async"
 	qaCapturePersistModeSyncFallback = "sync_fallback"
-	qaEndpointChatCompletions        = "/v1/chat/completions"
-	qaEndpointMessages               = "/v1/messages"
-	qaEndpointResponses              = "/v1/responses"
-	qaEndpointGeminiModels           = "/v1beta/models"
-	qaEndpointEmbeddings             = "/v1/embeddings"
-	qaEndpointImagesGenerations      = "/v1/images/generations"
+	qaEndpointChatCompletions        = apipath.ChatCompletions
+	qaEndpointMessages               = apipath.Messages
+	qaEndpointResponses              = apipath.Responses
+	qaEndpointGeminiModels           = apipath.GeminiModels
+	qaEndpointEmbeddings             = apipath.Embeddings
+	qaEndpointImagesGenerations      = apipath.ImagesGenerations
 	qaEndpointVideoGenerations       = "/v1/video/generations"
 	qaEndpointVideoGenerationsTask   = "/v1/video/generations/:task_id"
 )

--- a/backend/internal/observability/trajectory/wire_shape.go
+++ b/backend/internal/observability/trajectory/wire_shape.go
@@ -3,6 +3,8 @@ package trajectory
 import (
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
+
 	"github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/internal/domain"
 )
@@ -37,10 +39,10 @@ const (
 // cannot be imported without a cycle) is robust, and a qa-package endpoint-shape
 // test (TestWireShapeMatchesCaptureEndpoints) guards against drift.
 const (
-	endpointMessages        = "/v1/messages"
-	endpointChatCompletions = "/v1/chat/completions"
-	endpointResponses       = "/v1/responses"
-	endpointGeminiModels    = "/v1beta/models"
+	endpointMessages        = apipath.Messages
+	endpointChatCompletions = apipath.ChatCompletions
+	endpointResponses       = apipath.Responses
+	endpointGeminiModels    = apipath.GeminiModels
 )
 
 // WireShapeForRecord returns the wire shape of a captured record. The normalized

--- a/backend/internal/repository/redeem_code_repo.go
+++ b/backend/internal/repository/redeem_code_repo.go
@@ -395,7 +395,7 @@ func (r *redeemCodeRepository) SumPositiveBalanceByUser(ctx context.Context, use
 		Where(
 			redeemcode.UsedByEQ(userID),
 			redeemcode.ValueGT(0),
-			redeemcode.TypeIn("balance", "admin_balance"),
+			redeemcode.TypeIn(service.RedeemTypeBalance, service.AdjustmentTypeAdminBalance),
 		).
 		Aggregate(dbent.As(dbent.Sum(redeemcode.FieldValue), "sum")).
 		Scan(ctx, &result)

--- a/backend/internal/server/middleware/api_key_auth.go
+++ b/backend/internal/server/middleware/api_key_auth.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
@@ -25,7 +26,7 @@ func skipsBillingEnforcement(method, path string) bool {
 		return false
 	}
 	switch path {
-	case "/v1/models", "/v1/usage", "/v1beta/models", "/antigravity/models", "/antigravity/v1/models", "/antigravity/v1/usage", "/antigravity/v1beta/models":
+	case apipath.Models, "/v1/usage", apipath.GeminiModels, "/antigravity/models", "/antigravity/v1/models", "/antigravity/v1/usage", "/antigravity/v1beta/models":
 		return true
 	default:
 		return false

--- a/backend/internal/service/anthropic_config_reconciler.go
+++ b/backend/internal/service/anthropic_config_reconciler.go
@@ -579,7 +579,7 @@ func (r *AnthropicConfigReconciler) reconcileConcurrencyMirror(ctx context.Conte
 func mirrorCapacityPlatform(raw string) string {
 	p := strings.ToLower(strings.TrimSpace(raw))
 	if p == "" {
-		return "anthropic"
+		return PlatformAnthropic
 	}
 	return p
 }

--- a/backend/internal/service/channel_monitor_const.go
+++ b/backend/internal/service/channel_monitor_const.go
@@ -3,6 +3,7 @@ package service
 import (
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 )
 
@@ -46,11 +47,11 @@ const (
 	monitorChallengeMax = 50
 
 	// providerOpenAIPath OpenAI Chat Completions 路径。
-	providerOpenAIPath = "/v1/chat/completions"
+	providerOpenAIPath = apipath.ChatCompletions
 	// providerOpenAIResponsesPath OpenAI Responses API 路径。
-	providerOpenAIResponsesPath = "/v1/responses"
+	providerOpenAIResponsesPath = apipath.Responses
 	// providerAnthropicPath Anthropic Messages 路径。
-	providerAnthropicPath = "/v1/messages"
+	providerAnthropicPath = apipath.Messages
 	// providerGeminiPathTemplate Gemini generateContent 路径模板（含 model 占位）。
 	providerGeminiPathTemplate = "/v1beta/models/%s:generateContent"
 

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -83,7 +83,7 @@ const (
 	RedeemTypeConcurrency      = domain.RedeemTypeConcurrency
 	RedeemTypeSubscription     = domain.RedeemTypeSubscription
 	RedeemTypeInvitation       = domain.RedeemTypeInvitation
-	RedeemTypeAffiliateBalance = "affiliate_balance"
+	RedeemTypeAffiliateBalance = domain.RedeemTypeAffiliateBalance
 )
 
 // PromoCode status constants

--- a/backend/internal/service/image_generation_intent.go
+++ b/backend/internal/service/image_generation_intent.go
@@ -3,11 +3,12 @@ package service
 import (
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
 	"github.com/tidwall/gjson"
 )
 
 const (
-	openAIResponsesEndpoint          = "/v1/responses"
+	openAIResponsesEndpoint          = apipath.Responses
 	openAIResponsesCompactEndpoint   = "/v1/responses/compact"
 	imageGenerationPermissionMessage = "Image generation is not enabled for this group"
 )
@@ -65,7 +66,7 @@ func IsImageGenerationIntentMap(endpoint string, requestedModel string, reqBody 
 // IsImageGenerationEndpoint identifies dedicated generated-image endpoints.
 func IsImageGenerationEndpoint(endpoint string) bool {
 	switch normalizeImageGenerationEndpoint(endpoint) {
-	case "/v1/images/generations", "/v1/images/edits", "/images/generations", "/images/edits":
+	case apipath.ImagesGenerations, apipath.ImagesEdits, "/images/generations", "/images/edits":
 		return true
 	default:
 		return false

--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -883,7 +883,7 @@ func accountInGroupScope(a *Account, groupPlatform string) bool {
 		return false
 	}
 	switch groupPlatform {
-	case "openai", "newapi":
+	case PlatformOpenAI, PlatformNewAPI:
 		return a.IsOpenAICompatPoolMember(groupPlatform)
 	default:
 		return a.Platform == groupPlatform

--- a/backend/internal/service/openai_embeddings.go
+++ b/backend/internal/service/openai_embeddings.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
@@ -243,5 +244,5 @@ func firstPositiveGJSONInt(values ...gjson.Result) int {
 }
 
 func buildOpenAIEmbeddingsURL(base string) string {
-	return buildOpenAIEndpointURL(base, "/v1/embeddings")
+	return buildOpenAIEndpointURL(base, apipath.Embeddings)
 }

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
@@ -76,7 +77,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropicDispatched(
 	origWriter := c.Writer
 	origPath := c.Request.URL.Path
 	c.Writer = captureWriter
-	c.Request.URL.Path = "/v1/chat/completions"
+	c.Request.URL.Path = apipath.ChatCompletions
 
 	var dispatchPanic any
 	var out *bridge.DispatchOutcome

--- a/backend/internal/service/openai_gateway_bridge_responses_fallback.go
+++ b/backend/internal/service/openai_gateway_bridge_responses_fallback.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
@@ -265,7 +266,7 @@ func (s *OpenAIGatewayService) forwardResponsesViaNewAPIBridgeChatCompletions(
 		}()
 		c.Writer = captureWriter
 		if c.Request != nil && c.Request.URL != nil {
-			c.Request.URL.Path = "/v1/chat/completions"
+			c.Request.URL.Path = apipath.ChatCompletions
 		}
 		out, apiErr = dispatchNewAPIChatCompletions(ctx, c, in, chatBody)
 	}()

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
@@ -535,5 +536,5 @@ func (s *OpenAIGatewayService) bufferRawChatCompletions(
 //
 // 与 buildOpenAIResponsesURL 是姐妹函数。
 func buildOpenAIChatCompletionsURL(base string) string {
-	return buildOpenAIEndpointURL(base, "/v1/chat/completions")
+	return buildOpenAIEndpointURL(base, apipath.ChatCompletions)
 }

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
@@ -6204,7 +6205,7 @@ func edgeMirrorHostFromBaseURL(raw string) string {
 // - base 已是 /responses：原样返回
 // - 其他情况：追加 /v1/responses
 func buildOpenAIResponsesURL(base string) string {
-	return buildOpenAIEndpointURL(base, "/v1/responses")
+	return buildOpenAIEndpointURL(base, apipath.Responses)
 }
 
 func trimOpenAIEncryptedReasoningItems(reqBody map[string]any) bool {

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
@@ -28,8 +29,8 @@ import (
 )
 
 const (
-	openAIImagesGenerationsEndpoint = "/v1/images/generations"
-	openAIImagesEditsEndpoint       = "/v1/images/edits"
+	openAIImagesGenerationsEndpoint = apipath.ImagesGenerations
+	openAIImagesEditsEndpoint       = apipath.ImagesEdits
 
 	openAIImagesGenerationsURL = "https://api.openai.com/v1/images/generations"
 	openAIImagesEditsURL       = "https://api.openai.com/v1/images/edits"

--- a/backend/internal/service/upstream_models.go
+++ b/backend/internal/service/upstream_models.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/apipath"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
@@ -377,35 +378,35 @@ func upstreamModelsProxyURL(account *Account) string {
 
 func buildV1ModelsURL(base string) string {
 	normalized := strings.TrimRight(strings.TrimSpace(base), "/")
-	if strings.HasSuffix(normalized, "/v1/models") {
+	if strings.HasSuffix(normalized, apipath.Models) {
 		return normalized
 	}
 	if strings.HasSuffix(normalized, "/v1") {
 		return normalized + "/models"
 	}
-	return normalized + "/v1/models"
+	return normalized + apipath.Models
 }
 
 func buildOpenAIModelsURL(base string) string {
 	normalized := strings.TrimRight(strings.TrimSpace(base), "/")
-	if strings.HasSuffix(normalized, "/v1/models") {
+	if strings.HasSuffix(normalized, apipath.Models) {
 		return normalized
 	}
 	if strings.HasSuffix(normalized, "/v1") {
 		return normalized + "/models"
 	}
-	return normalized + "/v1/models"
+	return normalized + apipath.Models
 }
 
 func buildGeminiModelsURL(base string) string {
 	normalized := strings.TrimRight(strings.TrimSpace(base), "/")
-	if strings.HasSuffix(normalized, "/v1beta/models") {
+	if strings.HasSuffix(normalized, apipath.GeminiModels) {
 		return normalized
 	}
 	if strings.HasSuffix(normalized, "/v1beta") {
 		return normalized + "/models"
 	}
-	return normalized + "/v1beta/models"
+	return normalized + apipath.GeminiModels
 }
 
 type upstreamModelEntry struct {

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 570,
-  "hash": "04a04948d9d6d7d6027dfd9ab5d37db4f3e7da6b8ee1e0749416da567f35f197",
+  "hash": "3685609aaa111d62e89ff6f6df8ae1172a5ddff13ec27d769b0d9ae5c290877b",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/admin/payment.ts
+++ b/frontend/src/api/admin/payment.ts
@@ -7,7 +7,6 @@ import { apiClient } from '../client'
 import type {
   DashboardStats,
   PaymentOrder,
-  PaymentChannel,
   SubscriptionPlan,
   ProviderInstance
 } from '@/types/payment'
@@ -119,28 +118,6 @@ export const adminPaymentAPI = {
   /** Query and finalize a pending refund */
   queryRefund(id: number) {
     return apiClient.post<RefundResult>(`/admin/payment/orders/${id}/refund/query`)
-  },
-
-  // ==================== Channels ====================
-
-  /** Get all payment channels */
-  getChannels() {
-    return apiClient.get<PaymentChannel[]>('/admin/payment/channels')
-  },
-
-  /** Create a payment channel */
-  createChannel(data: Partial<PaymentChannel>) {
-    return apiClient.post<PaymentChannel>('/admin/payment/channels', data)
-  },
-
-  /** Update a payment channel */
-  updateChannel(id: number, data: Partial<PaymentChannel>) {
-    return apiClient.put<PaymentChannel>(`/admin/payment/channels/${id}`, data)
-  },
-
-  /** Delete a payment channel */
-  deleteChannel(id: number) {
-    return apiClient.delete(`/admin/payment/channels/${id}`)
   },
 
   // ==================== Subscription Plans ====================

--- a/frontend/src/api/subscriptions.ts
+++ b/frontend/src/api/subscriptions.ts
@@ -8,19 +8,26 @@ import type { UserSubscription, SubscriptionProgress } from '@/types'
 
 /**
  * Subscription summary for user dashboard
+ * Matches Go SubscriptionSummaryItem + summary envelope
  */
+export interface SubscriptionSummaryItem {
+  id: number
+  group_id: number
+  group_name: string
+  status: string
+  daily_used_usd?: number
+  daily_limit_usd?: number
+  weekly_used_usd?: number
+  weekly_limit_usd?: number
+  monthly_used_usd?: number
+  monthly_limit_usd?: number
+  expires_at?: string
+}
+
 export interface SubscriptionSummary {
   active_count: number
-  subscriptions: Array<{
-    id: number
-    group_name: string
-    status: string
-    daily_progress: number | null
-    weekly_progress: number | null
-    monthly_progress: number | null
-    expires_at: string | null
-    days_remaining: number | null
-  }>
+  total_used_usd: number
+  subscriptions: SubscriptionSummaryItem[]
 }
 
 /**
@@ -40,10 +47,18 @@ export async function getActiveSubscriptions(): Promise<UserSubscription[]> {
 }
 
 /**
+ * Progress info for a single subscription (matches Go SubscriptionProgressInfo)
+ */
+export interface SubscriptionProgressInfo {
+  subscription: UserSubscription
+  progress: SubscriptionProgress | null
+}
+
+/**
  * Get progress for all user's active subscriptions
  */
-export async function getSubscriptionsProgress(): Promise<SubscriptionProgress[]> {
-  const response = await apiClient.get<SubscriptionProgress[]>('/subscriptions/progress')
+export async function getSubscriptionsProgress(): Promise<SubscriptionProgressInfo[]> {
+  const response = await apiClient.get<SubscriptionProgressInfo[]>('/subscriptions/progress')
   return response.data
 }
 
@@ -55,22 +70,9 @@ export async function getSubscriptionSummary(): Promise<SubscriptionSummary> {
   return response.data
 }
 
-/**
- * Get progress for a specific subscription
- */
-export async function getSubscriptionProgress(
-  subscriptionId: number
-): Promise<SubscriptionProgress> {
-  const response = await apiClient.get<SubscriptionProgress>(
-    `/subscriptions/${subscriptionId}/progress`
-  )
-  return response.data
-}
-
 export default {
   getMySubscriptions,
   getActiveSubscriptions,
   getSubscriptionsProgress,
-  getSubscriptionSummary,
-  getSubscriptionProgress
+  getSubscriptionSummary
 }

--- a/frontend/src/components/account/AccountCapacityCell.vue
+++ b/frontend/src/components/account/AccountCapacityCell.vue
@@ -34,6 +34,7 @@ import { useI18n } from 'vue-i18n'
 import type { Account } from '@/types'
 import CapacityBadge from '@/components/account/CapacityBadge.vue'
 import QuotaBadge from '@/components/account/QuotaBadge.vue'
+import { PLATFORM_ANTHROPIC } from '@/constants/gatewayPlatforms'
 
 const props = defineProps<{
   account: Account
@@ -54,7 +55,7 @@ const concurrencyClass = computed(() => {
 
 // ====== Anthropic OAuth / setup-token ======
 const isAnthropicOAuthOrSetupToken = computed(() =>
-  props.account.platform === 'anthropic' &&
+  props.account.platform === PLATFORM_ANTHROPIC &&
   (props.account.type === 'oauth' || props.account.type === 'setup-token')
 )
 

--- a/frontend/src/components/account/AccountQuotaInfo.vue
+++ b/frontend/src/components/account/AccountQuotaInfo.vue
@@ -31,6 +31,7 @@
 import { computed, ref, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { Account, GeminiCredentials } from '@/types'
+import { PLATFORM_GEMINI } from '@/constants/gatewayPlatforms'
 
 const props = defineProps<{
   account: Account
@@ -57,7 +58,7 @@ const isGoogleOne = computed(() => {
 
 // 是否应该显示配额信息
 const shouldShowQuota = computed(() => {
-  return props.account.platform === 'gemini'
+  return props.account.platform === PLATFORM_GEMINI
 })
 
 // Tier 标签文本

--- a/frontend/src/components/account/AccountTestModal.vue
+++ b/frontend/src/components/account/AccountTestModal.vue
@@ -252,6 +252,7 @@ import { useClipboard } from '@/composables/useClipboard'
 import { buildApiUrl } from '@/api/client'
 import { adminAPI } from '@/api/admin'
 import type { Account, ClaudeModel } from '@/types'
+import { PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 const { t } = useI18n()
 const { copyToClipboard } = useClipboard()
@@ -287,7 +288,7 @@ const loadingModels = ref(false)
 let abortController: AbortController | null = null
 const generatedImages = ref<PreviewImage[]>([])
 const testMode = ref<'default' | 'compact'>('default')
-const isOpenAIAccount = computed(() => props.account?.platform === 'openai')
+const isOpenAIAccount = computed(() => props.account?.platform === PLATFORM_OPENAI)
 const openAITestModeOptions = computed(() => [
   { value: 'default', label: t('admin.accounts.openai.testModeDefault') },
   { value: 'compact', label: t('admin.accounts.openai.testModeCompact') }
@@ -298,13 +299,13 @@ const supportsGeminiImageTest = computed(() => {
   const modelID = selectedModelId.value.toLowerCase()
   if (!modelID.startsWith('gemini-') || !modelID.includes('-image')) return false
 
-  return props.account?.platform === 'gemini' || (props.account?.platform === 'antigravity' && props.account?.type === 'apikey')
+  return props.account?.platform === PLATFORM_GEMINI || (props.account?.platform === PLATFORM_ANTIGRAVITY && props.account?.type === 'apikey')
 })
 
 const supportsOpenAIImageTest = computed(() => {
   const modelID = selectedModelId.value.toLowerCase()
   if (!modelID.startsWith('gpt-image-')) return false
-  return props.account?.platform === 'openai'
+  return props.account?.platform === PLATFORM_OPENAI
 })
 
 const supportsImageTest = computed(() => supportsGeminiImageTest.value || supportsOpenAIImageTest.value)
@@ -348,12 +349,12 @@ const loadAvailableModels = async () => {
   selectedModelId.value = '' // Reset selection before loading
   try {
     const models = await adminAPI.accounts.getAvailableModels(props.account.id)
-    availableModels.value = props.account.platform === 'gemini' || props.account.platform === 'antigravity'
+    availableModels.value = props.account.platform === PLATFORM_GEMINI || props.account.platform === PLATFORM_ANTIGRAVITY
       ? sortTestModels(models)
       : models
     // Default selection by platform
     if (availableModels.value.length > 0) {
-      if (props.account.platform === 'gemini' || props.account.platform === 'antigravity') {
+      if (props.account.platform === PLATFORM_GEMINI || props.account.platform === PLATFORM_ANTIGRAVITY) {
         selectedModelId.value = availableModels.value[0].id
       } else {
         // Try to select Sonnet as default, otherwise use first model

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -18,6 +18,7 @@ import GeminiUsageCell from './usage-cells/GeminiUsageCell.vue'
 import GrokUsageCell from './usage-cells/GrokUsageCell.vue'
 import KiroUsageCell from './usage-cells/KiroUsageCell.vue'
 import { usesLocalUsageWindows } from '@/utils/accountUsageBatch.tk'
+import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI, PLATFORM_GROK, PLATFORM_KIRO, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 const props = withDefaults(defineProps<AccountUsageCellProps>(), accountUsageCellPropDefaults)
 
@@ -29,7 +30,7 @@ const activeCell = computed(() => {
   }
 
   if (
-    account.platform === 'anthropic' &&
+    account.platform === PLATFORM_ANTHROPIC &&
     (account.type === 'oauth' || account.type === 'setup-token')
   ) {
     return AnthropicUsageCell
@@ -39,25 +40,25 @@ const activeCell = computed(() => {
   // have a common upstream percentage-quota protocol, but the backend returns
   // TokenKey account billing windows through the same passive endpoint.
   if (
-    (account.platform === 'openai' && account.type === 'oauth') ||
+    (account.platform === PLATFORM_OPENAI && account.type === 'oauth') ||
     usesLocalUsageWindows(account)
   ) {
     return OpenAIUsageCell
   }
 
-  if (account.platform === 'grok') {
+  if (account.platform === PLATFORM_GROK) {
     return account.type === 'oauth' ? GrokUsageCell : OpenAIUsageCell
   }
 
-  if (account.platform === 'antigravity' && account.type === 'oauth') {
+  if (account.platform === PLATFORM_ANTIGRAVITY && account.type === 'oauth') {
     return AntigravityUsageCell
   }
 
-  if (account.platform === 'gemini') {
+  if (account.platform === PLATFORM_GEMINI) {
     return GeminiUsageCell
   }
 
-  if (account.platform === 'kiro') {
+  if (account.platform === PLATFORM_KIRO) {
     return KiroUsageCell
   }
 

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -1159,6 +1159,7 @@ import {
   resolveOpenAIWSModeConcurrencyHintKey
 } from '@/utils/openaiWsMode'
 import type { OpenAIWSMode } from '@/utils/openaiWsMode'
+import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 interface Props {
   show: boolean
   accountIds: number[]
@@ -1194,7 +1195,7 @@ const isMixedPlatform = computed(() => targetSelectedPlatforms.value.length > 1)
 const allOpenAIPassthroughCapable = computed(() => {
   return (
     targetSelectedPlatforms.value.length === 1 &&
-    targetSelectedPlatforms.value[0] === 'openai' &&
+    targetSelectedPlatforms.value[0] === PLATFORM_OPENAI &&
     targetSelectedTypes.value.length > 0 &&
     targetSelectedTypes.value.every(t => t === 'oauth' || t === 'setup-token' || t === 'apikey')
   )
@@ -1203,7 +1204,7 @@ const allOpenAIPassthroughCapable = computed(() => {
 const allOpenAIOAuth = computed(() => {
   return (
     targetSelectedPlatforms.value.length === 1 &&
-    targetSelectedPlatforms.value[0] === 'openai' &&
+    targetSelectedPlatforms.value[0] === PLATFORM_OPENAI &&
     targetSelectedTypes.value.length > 0 &&
     targetSelectedTypes.value.every(t => t === 'oauth' || t === 'setup-token')
   )
@@ -1212,7 +1213,7 @@ const allOpenAIOAuth = computed(() => {
 const allOpenAIAPIKey = computed(() => {
   return (
     targetSelectedPlatforms.value.length === 1 &&
-    targetSelectedPlatforms.value[0] === 'openai' &&
+    targetSelectedPlatforms.value[0] === PLATFORM_OPENAI &&
     targetSelectedTypes.value.length > 0 &&
     targetSelectedTypes.value.every(t => t === 'apikey')
   )
@@ -1222,7 +1223,7 @@ const allOpenAIAPIKey = computed(() => {
 const allAnthropicOAuthOrSetupToken = computed(() => {
   return (
     targetSelectedPlatforms.value.length === 1 &&
-    targetSelectedPlatforms.value[0] === 'anthropic' &&
+    targetSelectedPlatforms.value[0] === PLATFORM_ANTHROPIC &&
     targetSelectedTypes.value.every(t => t === 'oauth' || t === 'setup-token')
   )
 })
@@ -1608,7 +1609,7 @@ const canPreCheck = () =>
   enableGroups.value &&
   groupIds.value.length > 0 &&
   targetSelectedPlatforms.value.length === 1 &&
-  (targetSelectedPlatforms.value[0] === 'antigravity' || targetSelectedPlatforms.value[0] === 'anthropic')
+  (targetSelectedPlatforms.value[0] === PLATFORM_ANTIGRAVITY || targetSelectedPlatforms.value[0] === PLATFORM_ANTHROPIC)
 
 const handleClose = () => {
   showMixedChannelWarning.value = false

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -3448,6 +3448,7 @@ import { useTkAccountKiroPlatform } from '@/composables/useTkAccountKiroPlatform
 import AccountGrokPlatformFields from './AccountGrokPlatformFields.vue'
 import { useTkAccountGrokPlatform } from '@/composables/useTkAccountGrokPlatform'
 import { PLATFORM_LABELS } from '@/composables/usePlatformOptions'
+import { PLATFORM_ANTHROPIC, PLATFORM_OPENAI, PLATFORM_GEMINI, PLATFORM_ANTIGRAVITY, PLATFORM_NEWAPI, PLATFORM_KIRO, PLATFORM_GROK } from '@/constants/gatewayPlatforms'
 
 // Type for exposed OAuthAuthorizationFlow component
 // Note: defineExpose automatically unwraps refs, so we use the unwrapped types
@@ -3468,25 +3469,25 @@ const { t } = useI18n()
 const authStore = useAuthStore()
 
 const oauthStepTitle = computed(() => {
-  if (form.platform === 'openai') return t('admin.accounts.oauth.openai.title')
-  if (form.platform === 'gemini') return t('admin.accounts.oauth.gemini.title')
-  if (form.platform === 'antigravity') return t('admin.accounts.oauth.antigravity.title')
-  if (form.platform === 'grok') return t('admin.accounts.oauth.grok.title')
+  if (form.platform === PLATFORM_OPENAI) return t('admin.accounts.oauth.openai.title')
+  if (form.platform === PLATFORM_GEMINI) return t('admin.accounts.oauth.gemini.title')
+  if (form.platform === PLATFORM_ANTIGRAVITY) return t('admin.accounts.oauth.antigravity.title')
+  if (form.platform === PLATFORM_GROK) return t('admin.accounts.oauth.grok.title')
   return t('admin.accounts.oauth.title')
 })
 
 // Platform-specific hints for API Key type
 const baseUrlHint = computed(() => {
-  if (form.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
-  if (form.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
-  if (form.platform === 'grok' && form.type === 'apikey') return t('admin.accounts.grokPlatform.relayBaseUrlHint')
+  if (form.platform === PLATFORM_OPENAI) return t('admin.accounts.openai.baseUrlHint')
+  if (form.platform === PLATFORM_GEMINI) return t('admin.accounts.gemini.baseUrlHint')
+  if (form.platform === PLATFORM_GROK && form.type === 'apikey') return t('admin.accounts.grokPlatform.relayBaseUrlHint')
   return t('admin.accounts.baseUrlHint')
 })
 
 const apiKeyHint = computed(() => {
-  if (form.platform === 'openai') return t('admin.accounts.openai.apiKeyHint')
-  if (form.platform === 'gemini') return t('admin.accounts.gemini.apiKeyHint')
-  if (form.platform === 'grok' && form.type === 'apikey') return t('admin.accounts.grokPlatform.relayApiKeyHint')
+  if (form.platform === PLATFORM_OPENAI) return t('admin.accounts.openai.apiKeyHint')
+  if (form.platform === PLATFORM_GEMINI) return t('admin.accounts.gemini.apiKeyHint')
+  if (form.platform === PLATFORM_GROK && form.type === 'apikey') return t('admin.accounts.grokPlatform.relayApiKeyHint')
   return t('admin.accounts.apiKeyHint')
 })
 
@@ -3513,34 +3514,34 @@ const grokOAuth = useGrokOAuth() // For Grok OAuth
 
 // Computed: current OAuth state for template binding
 const currentAuthUrl = computed(() => {
-  if (form.platform === 'openai') return openaiOAuth.authUrl.value
-  if (form.platform === 'gemini') return geminiOAuth.authUrl.value
-  if (form.platform === 'antigravity') return antigravityOAuth.authUrl.value
-  if (form.platform === 'grok') return grokOAuth.authUrl.value
+  if (form.platform === PLATFORM_OPENAI) return openaiOAuth.authUrl.value
+  if (form.platform === PLATFORM_GEMINI) return geminiOAuth.authUrl.value
+  if (form.platform === PLATFORM_ANTIGRAVITY) return antigravityOAuth.authUrl.value
+  if (form.platform === PLATFORM_GROK) return grokOAuth.authUrl.value
   return oauth.authUrl.value
 })
 
 const currentSessionId = computed(() => {
-  if (form.platform === 'openai') return openaiOAuth.sessionId.value
-  if (form.platform === 'gemini') return geminiOAuth.sessionId.value
-  if (form.platform === 'antigravity') return antigravityOAuth.sessionId.value
-  if (form.platform === 'grok') return grokOAuth.sessionId.value
+  if (form.platform === PLATFORM_OPENAI) return openaiOAuth.sessionId.value
+  if (form.platform === PLATFORM_GEMINI) return geminiOAuth.sessionId.value
+  if (form.platform === PLATFORM_ANTIGRAVITY) return antigravityOAuth.sessionId.value
+  if (form.platform === PLATFORM_GROK) return grokOAuth.sessionId.value
   return oauth.sessionId.value
 })
 
 const currentOAuthLoading = computed(() => {
-  if (form.platform === 'openai') return openaiOAuth.loading.value
-  if (form.platform === 'gemini') return geminiOAuth.loading.value
-  if (form.platform === 'antigravity') return antigravityOAuth.loading.value
-  if (form.platform === 'grok') return grokOAuth.loading.value
+  if (form.platform === PLATFORM_OPENAI) return openaiOAuth.loading.value
+  if (form.platform === PLATFORM_GEMINI) return geminiOAuth.loading.value
+  if (form.platform === PLATFORM_ANTIGRAVITY) return antigravityOAuth.loading.value
+  if (form.platform === PLATFORM_GROK) return grokOAuth.loading.value
   return oauth.loading.value
 })
 
 const currentOAuthError = computed(() => {
-  if (form.platform === 'openai') return openaiOAuth.error.value
-  if (form.platform === 'gemini') return geminiOAuth.error.value
-  if (form.platform === 'antigravity') return antigravityOAuth.error.value
-  if (form.platform === 'grok') return grokOAuth.error.value
+  if (form.platform === PLATFORM_OPENAI) return openaiOAuth.error.value
+  if (form.platform === PLATFORM_GEMINI) return geminiOAuth.error.value
+  if (form.platform === PLATFORM_ANTIGRAVITY) return antigravityOAuth.error.value
+  if (form.platform === PLATFORM_GROK) return grokOAuth.error.value
   return oauth.error.value
 })
 
@@ -3708,7 +3709,7 @@ const {
   handleFetchUpstreamModels: newapiHandleFetchUpstreamModels,
   applyChannelTypePresetModelsIfEmpty: newapiApplyChannelPresetIfEmpty,
 } = useTkAccountNewApiPlatform({
-  isNewapi: () => form.platform === 'newapi',
+  isNewapi: () => form.platform === PLATFORM_NEWAPI,
 })
 
 const newapiIsVertexServiceAccount = computed(() =>
@@ -3818,7 +3819,7 @@ const normalizeOpenAIMessagesCompactionThreshold = (): number | null => {
 }
 
 const validateOpenAIMessagesCompactionForm = (): boolean => {
-  if (form.platform !== 'openai') {
+  if (form.platform !== PLATFORM_OPENAI) {
     return true
   }
   if (!openAIMessagesCompactionEnabled.value) {
@@ -3870,7 +3871,7 @@ const geminiTierGcp = ref<'gcp_standard' | 'gcp_enterprise'>('gcp_standard')
 const geminiTierAIStudio = ref<'aistudio_free' | 'aistudio_paid'>('aistudio_free')
 
 const geminiSelectedTier = computed(() => {
-  if (form.platform !== 'gemini') return ''
+  if (form.platform !== PLATFORM_GEMINI) return ''
   if (accountCategory.value === 'apikey') return geminiTierAIStudio.value
   switch (geminiOAuthType.value) {
     case 'google_one':
@@ -3891,13 +3892,13 @@ const openAIWSModeOptions = computed(() => [
 
 const openaiResponsesWebSocketV2Mode = computed({
   get: () => {
-    if (form.platform === 'openai' && accountCategory.value === 'apikey') {
+    if (form.platform === PLATFORM_OPENAI && accountCategory.value === 'apikey') {
       return openaiAPIKeyResponsesWebSocketV2Mode.value
     }
     return openaiOAuthResponsesWebSocketV2Mode.value
   },
   set: (mode: OpenAIWSMode) => {
-    if (form.platform === 'openai' && accountCategory.value === 'apikey') {
+    if (form.platform === PLATFORM_OPENAI && accountCategory.value === 'apikey') {
       openaiAPIKeyResponsesWebSocketV2Mode.value = mode
       return
     }
@@ -3910,7 +3911,7 @@ const openAIWSModeConcurrencyHintKey = computed(() =>
 )
 
 const isOpenAIModelRestrictionDisabled = computed(() =>
-  form.platform === 'openai' && openaiPassthroughEnabled.value
+  form.platform === PLATFORM_OPENAI && openaiPassthroughEnabled.value
 )
 
 const mixedChannelWarningMessageText = computed(() => {
@@ -3985,7 +3986,7 @@ const form = reactive({
 watch(
   () => form.platform,
   (platform) => {
-    if (platform === 'newapi') {
+    if (platform === PLATFORM_NEWAPI) {
       newapiBootstrap()
       void newapiApplyChannelPresetIfEmpty()
     }
@@ -3993,7 +3994,7 @@ watch(
 )
 
 watch(newapiChannelType, () => {
-  if (form.platform === 'newapi') {
+  if (form.platform === PLATFORM_NEWAPI) {
     void newapiApplyChannelPresetIfEmpty()
   }
 })
@@ -4015,24 +4016,24 @@ const prefillAccountEmailFromToken = (tokenInfo: Record<string, unknown> | null 
 // Helper to check if current type needs OAuth flow
 const isOAuthFlow = computed(() => {
   // Antigravity upstream 类型不需要 OAuth 流程
-  if (form.platform === 'antigravity' && antigravityAccountType.value === 'upstream') {
+  if (form.platform === PLATFORM_ANTIGRAVITY && antigravityAccountType.value === 'upstream') {
     return false
   }
   // Bedrock 类型不需要 OAuth 流程
-  if (form.platform === 'anthropic' && accountCategory.value === 'bedrock') {
+  if (form.platform === PLATFORM_ANTHROPIC && accountCategory.value === 'bedrock') {
     return false
   }
   // newapi (5th platform) is API-key only — no OAuth flow.
-  if (form.platform === 'newapi') {
+  if (form.platform === PLATFORM_NEWAPI) {
     return false
   }
   // kiro (6th platform) creates by pasting OAuth tokens directly — no interactive OAuth step.
-  if (form.platform === 'kiro') {
+  if (form.platform === PLATFORM_KIRO) {
     return false
   }
   // grok (7th platform) creates by pasting a refresh_token — no interactive OAuth step
   // (xAI's public client is loopback-only; the token is minted out-of-band).
-  if (form.platform === 'grok') {
+  if (form.platform === PLATFORM_GROK) {
     return false
   }
   return accountCategory.value === 'oauth-based'
@@ -4051,16 +4052,16 @@ const expiresAtInput = computed({
 
 const canExchangeCode = computed(() => {
   const authCode = oauthFlowRef.value?.authCode || ''
-  if (form.platform === 'openai') {
+  if (form.platform === PLATFORM_OPENAI) {
     return authCode.trim() && openaiOAuth.sessionId.value && !openaiOAuth.loading.value
   }
-  if (form.platform === 'gemini') {
+  if (form.platform === PLATFORM_GEMINI) {
     return authCode.trim() && geminiOAuth.sessionId.value && !geminiOAuth.loading.value
   }
-  if (form.platform === 'antigravity') {
+  if (form.platform === PLATFORM_ANTIGRAVITY) {
     return authCode.trim() && antigravityOAuth.sessionId.value && !antigravityOAuth.loading.value
   }
-  if (form.platform === 'grok') {
+  if (form.platform === PLATFORM_GROK) {
     return authCode.trim() && grokOAuth.sessionId.value && !grokOAuth.loading.value
   }
   return authCode.trim() && oauth.sessionId.value && !oauth.loading.value
@@ -4081,7 +4082,7 @@ const onShown = () => {
   // 第五平台 newapi：触发一次（已缓存）的 channel-type catalog 加载
   newapiBootstrap()
   // Antigravity: 默认使用映射模式并填充默认映射
-  if (form.platform === 'antigravity') {
+  if (form.platform === PLATFORM_ANTIGRAVITY) {
     antigravityModelRestrictionMode.value = 'mapping'
     fetchAntigravityDefaultMappings().then(mappings => {
       antigravityModelMappings.value = [...mappings]
@@ -4121,29 +4122,29 @@ watch(
   [accountCategory, addMethod, antigravityAccountType, () => form.platform],
   ([category, method, agType]) => {
     // Antigravity upstream 类型（实际创建为 apikey）
-    if (form.platform === 'antigravity' && agType === 'upstream') {
+    if (form.platform === PLATFORM_ANTIGRAVITY && agType === 'upstream') {
       form.type = 'apikey'
       return
     }
     // Bedrock 类型
-    if (form.platform === 'anthropic' && category === 'bedrock') {
+    if (form.platform === PLATFORM_ANTHROPIC && category === 'bedrock') {
       form.type = 'bedrock' as AccountType
       return
     }
     // kiro (6th platform): always oauth type (token paste), regardless of addMethod.
-    if (form.platform === 'kiro') {
+    if (form.platform === PLATFORM_KIRO) {
       form.type = 'oauth'
       return
     }
     // grok (7th platform): OAuth refresh_token or first-class API-key relay stub.
-    if (form.platform === 'grok') {
+    if (form.platform === PLATFORM_GROK) {
       form.type = category === 'apikey' ? 'apikey' : 'oauth'
       return
     }
-    if ((form.platform === 'gemini' || form.platform === 'anthropic') && category === 'service_account') {
+    if ((form.platform === PLATFORM_GEMINI || form.platform === PLATFORM_ANTHROPIC) && category === 'service_account') {
       form.type = 'service_account' as AccountType
     } else if (category === 'oauth-based') {
-      form.type = form.platform === 'anthropic' ? method as AccountType : 'oauth'
+      form.type = form.platform === PLATFORM_ANTHROPIC ? method as AccountType : 'oauth'
     } else {
       form.type = 'apikey'
     }
@@ -4157,18 +4158,18 @@ watch(
   (newPlatform) => {
     // Reset base URL based on platform
     apiKeyBaseUrl.value =
-      (newPlatform === 'openai')
+      (newPlatform === PLATFORM_OPENAI)
         ? 'https://api.openai.com'
-        : newPlatform === 'gemini'
+        : newPlatform === PLATFORM_GEMINI
           ? 'https://generativelanguage.googleapis.com'
-          : newPlatform === 'grok'
+          : newPlatform === PLATFORM_GROK
             ? ''
             : 'https://api.anthropic.com'
     // Clear model-related settings
     allowedModels.value = []
     modelMappings.value = []
     // Antigravity: 默认使用映射模式并填充默认映射
-    if (newPlatform === 'antigravity') {
+    if (newPlatform === PLATFORM_ANTIGRAVITY) {
       antigravityModelRestrictionMode.value = 'mapping'
       fetchAntigravityDefaultMappings().then(mappings => {
         antigravityModelMappings.value = [...mappings]
@@ -4176,7 +4177,7 @@ watch(
       antigravityWhitelistModels.value = []
       accountCategory.value = 'oauth-based'
       antigravityAccountType.value = 'oauth'
-    } else if (newPlatform === 'newapi') {
+    } else if (newPlatform === PLATFORM_NEWAPI) {
       // D1: newapi 是 apikey-only，把 accountCategory 翻到 apikey 让 watcher A
       // 把 form.type 同步成 'apikey'，与 submit 路径硬编码的 type:'apikey'
       // 对齐；否则路径 1 (fresh open + 直接点 NewAPI) 会因 form.type='oauth'
@@ -4188,7 +4189,7 @@ watch(
       antigravityModelRestrictionMode.value = 'mapping'
       // newapi 自身的字段重置由 composable.reset() 在 resetForm 中负责，
       // 平台切换不清除已填字段（避免误触切换造成数据丢失）。
-    } else if (newPlatform === 'kiro') {
+    } else if (newPlatform === PLATFORM_KIRO) {
       // 第六平台 kiro：oauth-token 直填，accountCategory 设为 oauth-based 让
       // watcher A 把 form.type 同步成 'oauth'（与后端 type=oauth 契约对齐），
       // 同时避免渲染通用 apikey / 配额块。kiro 字段重置由 composable.reset()
@@ -4198,7 +4199,7 @@ watch(
       antigravityWhitelistModels.value = []
       antigravityModelMappings.value = []
       antigravityModelRestrictionMode.value = 'mapping'
-    } else if (newPlatform === 'grok') {
+    } else if (newPlatform === PLATFORM_GROK) {
       // 第七平台 grok 默认创建 OAuth 账号；需要 prod→edge relay stub 时可切到
       // API Key，提交 platform=grok,type=apikey。
       accountCategory.value = 'oauth-based'
@@ -4213,17 +4214,17 @@ watch(
       antigravityModelMappings.value = []
       antigravityModelRestrictionMode.value = 'mapping'
     }
-    if (newPlatform === 'grok') {
+    if (newPlatform === PLATFORM_GROK) {
       accountCategory.value = 'oauth-based'
       addMethod.value = 'oauth'
       modelRestrictionMode.value = 'mapping'
       form.concurrency = 1
       form.load_factor = null
     }
-    if (newPlatform !== 'gemini' && newPlatform !== 'anthropic' && accountCategory.value === 'service_account') {
+    if (newPlatform !== PLATFORM_GEMINI && newPlatform !== PLATFORM_ANTHROPIC && accountCategory.value === 'service_account') {
       accountCategory.value = 'oauth-based'
     }
-    if (newPlatform !== 'anthropic' && accountCategory.value === 'bedrock') {
+    if (newPlatform !== PLATFORM_ANTHROPIC && accountCategory.value === 'bedrock') {
       accountCategory.value = 'oauth-based'
     }
     // Reset Bedrock fields when switching platforms
@@ -4236,10 +4237,10 @@ watch(
     bedrockApiKeyValue.value = ''
     vertexSa.reset()
     // Reset Anthropic/Antigravity-specific settings when switching to other platforms
-    if (newPlatform !== 'anthropic' && newPlatform !== 'antigravity') {
+    if (newPlatform !== PLATFORM_ANTHROPIC && newPlatform !== PLATFORM_ANTIGRAVITY) {
       interceptWarmupRequests.value = false
     }
-    if (newPlatform !== 'openai') {
+    if (newPlatform !== PLATFORM_OPENAI) {
       openaiPassthroughEnabled.value = false
       openAIMessagesCompactionEnabled.value = false
       openAIMessagesCompactionInputTokensThreshold.value = null
@@ -4249,7 +4250,7 @@ watch(
       codexCLIOnlyEnabled.value = false
       codexCLIOnlyAppServerEnabled.value = false
     }
-    if (newPlatform !== 'anthropic') {
+    if (newPlatform !== PLATFORM_ANTHROPIC) {
       anthropicPassthroughEnabled.value = false
       anthropicAPIKeyAuthScheme.value = 'x_api_key'
       webSearchEmulationMode.value = 'default'
@@ -4268,11 +4269,11 @@ watch(
 watch(
   [accountCategory, () => form.platform],
   ([category, platform]) => {
-    if (platform === 'openai' && category !== 'oauth-based') {
+    if (platform === PLATFORM_OPENAI && category !== 'oauth-based') {
       codexCLIOnlyEnabled.value = false
       codexCLIOnlyAppServerEnabled.value = false
     }
-    if (platform !== 'anthropic' || category !== 'apikey') {
+    if (platform !== PLATFORM_ANTHROPIC || category !== 'apikey') {
       anthropicPassthroughEnabled.value = false
       anthropicAPIKeyAuthScheme.value = 'x_api_key'
       webSearchEmulationMode.value = 'default'
@@ -4283,7 +4284,7 @@ watch(
 watch(
   [() => props.show, () => form.platform, accountCategory],
   async ([show, platform, category]) => {
-    if (!show || platform !== 'gemini' || category !== 'oauth-based') {
+    if (!show || platform !== PLATFORM_GEMINI || category !== 'oauth-based') {
       geminiAIStudioOAuthEnabled.value = false
       return
     }
@@ -4317,7 +4318,7 @@ watch(
 watch(
   [antigravityModelRestrictionMode, () => form.platform],
   ([, platform]) => {
-    if (platform !== 'antigravity') return
+    if (platform !== PLATFORM_ANTIGRAVITY) return
     // Antigravity 默认不做限制：白名单留空表示允许所有（包含未来新增模型）。
     // 如果需要快速填充常用模型，可在组件内点“填充相关模型”。
   }
@@ -4500,7 +4501,7 @@ const splitTempUnschedKeywords = (value: string) => {
     .filter((item) => item.length > 0)
 }
 
-const needsMixedChannelCheck = (platform: AccountPlatform) => platform === 'antigravity' || platform === 'anthropic'
+const needsMixedChannelCheck = (platform: AccountPlatform) => platform === PLATFORM_ANTIGRAVITY || platform === PLATFORM_ANTHROPIC
 
 const buildMixedChannelDetails = (resp?: CheckMixedChannelResponse) => {
   const details = resp?.details
@@ -4716,7 +4717,7 @@ const handleClose = () => {
 }
 
 const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknown> | undefined => {
-  if (form.platform !== 'openai') {
+  if (form.platform !== PLATFORM_OPENAI) {
     return base
   }
 
@@ -4783,7 +4784,7 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
 }
 
 const buildAnthropicExtra = (base?: Record<string, unknown>): Record<string, unknown> | undefined => {
-  if (form.platform !== 'anthropic' || accountCategory.value !== 'apikey') {
+  if (form.platform !== PLATFORM_ANTHROPIC || accountCategory.value !== 'apikey') {
     return base
   }
 
@@ -4904,7 +4905,7 @@ const handleSubmit = async () => {
   }
 
   // For Bedrock type, create directly
-  if (form.platform === 'anthropic' && accountCategory.value === 'bedrock') {
+  if (form.platform === PLATFORM_ANTHROPIC && accountCategory.value === 'bedrock') {
     if (!form.name.trim()) {
       appStore.showError(t('admin.accounts.pleaseEnterAccountName'))
       return
@@ -4966,7 +4967,7 @@ const handleSubmit = async () => {
   }
 
   // 第五平台 newapi：apikey 或 Vertex service_account (channel_type 41)。
-  if (form.platform === 'newapi') {
+  if (form.platform === PLATFORM_NEWAPI) {
     if (!form.name.trim()) {
       appStore.showError(t('admin.accounts.pleaseEnterAccountName'))
       return
@@ -5023,7 +5024,7 @@ const handleSubmit = async () => {
 
   // 第六平台 kiro：oauth-token 直填，type=oauth；表单校验 + credentials 拼装
   // （含 tos_acknowledged 强制勾选）都委托给 composable。
-  if (form.platform === 'kiro') {
+  if (form.platform === PLATFORM_KIRO) {
     if (!form.name.trim()) {
       appStore.showError(t('admin.accounts.pleaseEnterAccountName'))
       return
@@ -5051,7 +5052,7 @@ const handleSubmit = async () => {
 
   // 第七平台 grok：OAuth 账号粘 refresh_token；prod→edge relay stub 走
   // first-class platform=grok,type=apikey。
-  if (form.platform === 'grok') {
+  if (form.platform === PLATFORM_GROK) {
     if (!form.name.trim()) {
       appStore.showError(t('admin.accounts.pleaseEnterAccountName'))
       return
@@ -5097,7 +5098,7 @@ const handleSubmit = async () => {
   }
 
   // For Antigravity upstream type, create directly
-  if (form.platform === 'antigravity' && antigravityAccountType.value === 'upstream') {
+  if (form.platform === PLATFORM_ANTIGRAVITY && antigravityAccountType.value === 'upstream') {
     if (!form.name.trim()) {
       appStore.showError(t('admin.accounts.pleaseEnterAccountName'))
       return
@@ -5134,7 +5135,7 @@ const handleSubmit = async () => {
     return
   }
 
-  if ((form.platform === 'gemini' || form.platform === 'anthropic') && accountCategory.value === 'service_account') {
+  if ((form.platform === PLATFORM_GEMINI || form.platform === PLATFORM_ANTHROPIC) && accountCategory.value === 'service_account') {
     if (!form.name.trim()) {
       appStore.showError(t('admin.accounts.pleaseEnterAccountName'))
       return
@@ -5153,9 +5154,9 @@ const handleSubmit = async () => {
 
   // Determine default base URL based on platform
   const defaultBaseUrl =
-    form.platform === 'openai'
+    form.platform === PLATFORM_OPENAI
       ? 'https://api.openai.com'
-      : form.platform === 'gemini'
+      : form.platform === PLATFORM_GEMINI
         ? 'https://generativelanguage.googleapis.com'
         : 'https://api.anthropic.com'
 
@@ -5164,12 +5165,12 @@ const handleSubmit = async () => {
     base_url: apiKeyBaseUrl.value.trim() || defaultBaseUrl,
     api_key: apiKeyValue.value.trim()
   }
-  if (form.platform === 'gemini') {
+  if (form.platform === PLATFORM_GEMINI) {
     credentials.tier_id = geminiTierAIStudio.value
   }
   // TK: edge mirror-stub pool selector (surface-C). Only anthropic apikey stubs
   // participate; default 'anthropic' keeps non-stub accounts unaffected.
-  if (form.platform === 'anthropic') {
+  if (form.platform === PLATFORM_ANTHROPIC) {
     credentials.mirror_platform = mirrorPlatform.value
   }
 
@@ -5180,7 +5181,7 @@ const handleSubmit = async () => {
       credentials.model_mapping = modelMapping
     }
   }
-  if (form.platform === 'openai') {
+  if (form.platform === PLATFORM_OPENAI) {
     applyOpenAIEndpointCapabilities(credentials)
     const compactModelMapping = buildOpenAICompactModelMapping()
     if (compactModelMapping) {
@@ -5231,18 +5232,18 @@ const goBackToBasicInfo = () => {
 }
 
 const handleGenerateUrl = async () => {
-  if (form.platform === 'openai') {
+  if (form.platform === PLATFORM_OPENAI) {
     await openaiOAuth.generateAuthUrl(form.proxy_id)
-  } else if (form.platform === 'gemini') {
+  } else if (form.platform === PLATFORM_GEMINI) {
     await geminiOAuth.generateAuthUrl(
       form.proxy_id,
       oauthFlowRef.value?.projectId,
       geminiOAuthType.value,
       geminiSelectedTier.value
     )
-  } else if (form.platform === 'antigravity') {
+  } else if (form.platform === PLATFORM_ANTIGRAVITY) {
     await antigravityOAuth.generateAuthUrl(form.proxy_id)
-  } else if (form.platform === 'grok') {
+  } else if (form.platform === PLATFORM_GROK) {
     await grokOAuth.generateAuthUrl(form.proxy_id)
   } else {
     await oauth.generateAuthUrl(addMethod.value, form.proxy_id)
@@ -5250,11 +5251,11 @@ const handleGenerateUrl = async () => {
 }
 
 const handleValidateRefreshToken = (rt: string) => {
-  if (form.platform === 'openai') {
+  if (form.platform === PLATFORM_OPENAI) {
     handleOpenAIValidateRT(rt)
-  } else if (form.platform === 'antigravity') {
+  } else if (form.platform === PLATFORM_ANTIGRAVITY) {
     handleAntigravityValidateRT(rt)
-  } else if (form.platform === 'grok') {
+  } else if (form.platform === PLATFORM_GROK) {
     handleGrokValidateRT(rt)
   }
 }
@@ -5280,7 +5281,7 @@ const createAccountAndFinish = async (
   const finalExtra = (type === 'apikey' || type === 'bedrock')
     ? buildAPIKeyOrBedrockExtra(extra)
     : extra
-  if (platform === 'openai') {
+  if (platform === PLATFORM_OPENAI) {
     if (type === 'apikey') {
       applyOpenAIEndpointCapabilities(credentials)
     }
@@ -5291,7 +5292,7 @@ const createAccountAndFinish = async (
       delete credentials.compact_model_mapping
     }
   }
-  if (platform === 'grok') {
+  if (platform === PLATFORM_GROK) {
     if (!credentials.base_url) {
       credentials.base_url = apiKeyBaseUrl.value.trim() || 'https://api.x.ai/v1'
     }
@@ -5436,7 +5437,7 @@ const handleOpenAIExchange = async (authCode: string) => {
     const credentials = oauthClient.buildCredentials(tokenInfo)
     const oauthExtra = oauthClient.buildExtraInfo(tokenInfo) as Record<string, unknown> | undefined
     const extra = buildOpenAIExtra(oauthExtra)
-    const shouldCreateOpenAI = form.platform === 'openai'
+    const shouldCreateOpenAI = form.platform === PLATFORM_OPENAI
 
     // Add model mapping for OpenAI OAuth accounts（透传模式下不应用）
     if (shouldCreateOpenAI && !isOpenAIModelRestrictionDisabled.value) {
@@ -5668,7 +5669,7 @@ const handleOpenAIBatchRT = async (refreshTokenInput: string, clientId?: string)
   let successCount = 0
   let failedCount = 0
   const errors: string[] = []
-  const shouldCreateOpenAI = form.platform === 'openai'
+  const shouldCreateOpenAI = form.platform === PLATFORM_OPENAI
 
   try {
     for (let i = 0; i < refreshTokens.length; i++) {

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -2587,6 +2587,16 @@ import {
   isValidAccountEmail,
   resolveAccountEmail
 } from '@/utils/accountEmail.tk'
+import {
+  PLATFORM_ANTHROPIC,
+  PLATFORM_OPENAI,
+  PLATFORM_GEMINI,
+  PLATFORM_ANTIGRAVITY,
+  PLATFORM_NEWAPI,
+  PLATFORM_KIRO,
+  PLATFORM_GROK
+} from '@/constants/gatewayPlatforms'
+import { STATUS_ACTIVE } from '@/constants/channel'
 
 interface Props {
   show: boolean
@@ -2612,9 +2622,9 @@ const isSparkShadow = computed(() => props.account?.parent_account_id != null)
 // Platform-specific hint for Base URL
 const baseUrlHint = computed(() => {
   if (!props.account) return t('admin.accounts.baseUrlHint')
-  if (props.account.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
-  if (props.account.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
-  if (props.account.platform === 'grok' && props.account.type === 'apikey') return t('admin.accounts.grokPlatform.relayBaseUrlHint')
+  if (props.account.platform === PLATFORM_OPENAI) return t('admin.accounts.openai.baseUrlHint')
+  if (props.account.platform === PLATFORM_GEMINI) return t('admin.accounts.gemini.baseUrlHint')
+  if (props.account.platform === PLATFORM_GROK && props.account.type === 'apikey') return t('admin.accounts.grokPlatform.relayBaseUrlHint')
   return t('admin.accounts.baseUrlHint')
 })
 
@@ -2670,12 +2680,12 @@ const {
   refreshStoredPricingStatus: newapiRefreshStoredPricingStatus,
   applyChannelTypePresetModelsIfEmpty: newapiApplyChannelPresetIfEmpty,
 } = useTkAccountNewApiPlatform({
-  isNewapi: () => props.account?.platform === 'newapi',
+  isNewapi: () => props.account?.platform === PLATFORM_NEWAPI,
   storedAccount: () => (props.account ? { id: props.account.id, channel_type: props.account.channel_type } : null),
 })
 
 watch(newapiChannelType, () => {
-  if (props.account?.platform === 'newapi') {
+  if (props.account?.platform === PLATFORM_NEWAPI) {
     void newapiApplyChannelPresetIfEmpty()
   }
 })
@@ -2971,7 +2981,7 @@ const normalizeOpenAIMessagesCompactionThreshold = (): number | null => {
 }
 
 const validateOpenAIMessagesCompactionForm = (): boolean => {
-  if (props.account?.platform !== 'openai') {
+  if (props.account?.platform !== PLATFORM_OPENAI) {
     return true
   }
   if (!openAIMessagesCompactionEnabled.value) {
@@ -3075,7 +3085,7 @@ const normalizeOpenAIResponsesMode = (mode: unknown): OpenAIResponsesMode => {
   return 'auto'
 }
 const isOpenAIModelRestrictionDisabled = computed(() =>
-  props.account?.platform === 'openai' && openaiPassthroughEnabled.value
+  props.account?.platform === PLATFORM_OPENAI && openaiPassthroughEnabled.value
 )
 const openAIResponsesStatusKey = computed(() => {
   if (openAIResponsesMode.value === 'force_responses') {
@@ -3095,7 +3105,7 @@ const openAIResponsesStatusKey = computed(() => {
 })
 const openAICompactStatusKey = computed(() => {
   const extra = props.account?.extra as Record<string, unknown> | undefined
-  if (!props.account || props.account.platform !== 'openai') return ''
+  if (!props.account || props.account.platform !== PLATFORM_OPENAI) return ''
   const mode = typeof extra?.openai_compact_mode === 'string' ? extra.openai_compact_mode : 'auto'
   if (mode === 'force_on') return 'admin.accounts.openai.compactSupported'
   if (mode === 'force_off') return 'admin.accounts.openai.compactUnsupported'
@@ -3141,9 +3151,9 @@ const tempUnschedPresets = computed(() => [
 
 // Computed: default base URL based on platform
 const defaultBaseUrl = computed(() => {
-  if (props.account?.platform === 'openai') return 'https://api.openai.com'
-  if (props.account?.platform === 'gemini') return 'https://generativelanguage.googleapis.com'
-  if (props.account?.platform === 'grok') return ''
+  if (props.account?.platform === PLATFORM_OPENAI) return 'https://api.openai.com'
+  if (props.account?.platform === PLATFORM_GEMINI) return 'https://generativelanguage.googleapis.com'
+  if (props.account?.platform === PLATFORM_GROK) return ''
   return 'https://api.anthropic.com'
 })
 
@@ -3254,7 +3264,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   form.load_factor = newAccount.load_factor ?? null
   form.priority = newAccount.priority
   form.rate_multiplier = newAccount.rate_multiplier ?? 1
-  form.status = (newAccount.status === 'active' || newAccount.status === 'inactive' || newAccount.status === 'error')
+  form.status = (newAccount.status === STATUS_ACTIVE || newAccount.status === 'inactive' || newAccount.status === 'error')
     ? newAccount.status
     : 'active'
   form.group_ids = newAccount.group_ids || []
@@ -3266,7 +3276,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   autoPauseOnExpired.value = newAccount.auto_pause_on_expired === true
   vertexSa.reset()
   antigravityProjectId.value =
-    newAccount.platform === 'antigravity' &&
+    newAccount.platform === PLATFORM_ANTIGRAVITY &&
     newAccount.type === 'oauth' &&
     typeof credentials?.antigravity_project_id === 'string'
       ? credentials.antigravity_project_id.trim()
@@ -3300,7 +3310,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   anthropicPassthroughEnabled.value = false
   anthropicAPIKeyAuthScheme.value = 'x_api_key'
   webSearchEmulationMode.value = 'default'
-  if (newAccount.platform === 'openai' && (newAccount.type === 'oauth' || newAccount.type === 'setup-token' || newAccount.type === 'apikey')) {
+  if (newAccount.platform === PLATFORM_OPENAI && (newAccount.type === 'oauth' || newAccount.type === 'setup-token' || newAccount.type === 'apikey')) {
     openaiPassthroughEnabled.value = extra?.openai_passthrough === true || extra?.openai_oauth_passthrough === true
     openAICompactMode.value = (extra?.openai_compact_mode as OpenAICompactMode) || 'auto'
     openAIMessagesCompactionEnabled.value = extra?.messages_compaction_enabled === true
@@ -3351,7 +3361,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
       openAICompactModelMappings.value = Object.entries(compactMappings).map(([from, to]) => ({ from, to }))
     }
   }
-  if (newAccount.platform === 'anthropic' && newAccount.type === 'apikey') {
+  if (newAccount.platform === PLATFORM_ANTHROPIC && newAccount.type === 'apikey') {
     anthropicPassthroughEnabled.value = extra?.anthropic_passthrough === true
     anthropicAPIKeyAuthScheme.value = extra?.anthropic_apikey_auth_scheme === 'authorization_bearer'
       ? 'authorization_bearer'
@@ -3398,7 +3408,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   }
 
   // Load antigravity model mapping (Antigravity 只支持映射模式)
-  if (newAccount.platform === 'antigravity') {
+  if (newAccount.platform === PLATFORM_ANTIGRAVITY) {
     const credentials = newAccount.credentials as Record<string, unknown> | undefined
 
     // Antigravity 始终使用映射模式
@@ -3434,7 +3444,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
 
   loadTempUnschedRules(credentials)
 
-  if (newAccount.platform === 'kiro') {
+  if (newAccount.platform === PLATFORM_KIRO) {
     kiro.populateFromAccount({
       credentials: (newAccount.credentials as Record<string, unknown> | undefined) || {},
       credentials_status: newAccount.credentials_status,
@@ -3443,7 +3453,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   // 第七平台 grok OAuth：refresh_token 是敏感字段，编辑时留空表示保留现有值
   // （composable 不回填），base_url 回填。API-key relay stub 走下面的通用
   // apikey 编辑字段，不应进入 OAuth composable。
-  if (newAccount.platform === 'grok' && newAccount.type === 'oauth') {
+  if (newAccount.platform === PLATFORM_GROK && newAccount.type === 'oauth') {
     grokPopulateFromAccount({
       credentials: (newAccount.credentials as Record<string, unknown> | undefined) || {},
     })
@@ -3453,11 +3463,11 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   if (newAccount.type === 'apikey' && newAccount.credentials) {
     const credentials = newAccount.credentials as Record<string, unknown>
     const platformDefaultUrl =
-      newAccount.platform === 'openai'
+      newAccount.platform === PLATFORM_OPENAI
         ? 'https://api.openai.com'
-        : newAccount.platform === 'gemini'
+        : newAccount.platform === PLATFORM_GEMINI
           ? 'https://generativelanguage.googleapis.com'
-          : newAccount.platform === 'grok'
+          : newAccount.platform === PLATFORM_GROK
             ? ''
             : 'https://api.anthropic.com'
     editBaseUrl.value = (credentials.base_url as string) || platformDefaultUrl
@@ -3466,7 +3476,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
 
     // 第五平台 newapi：把现有账号的 channel_type / credentials 一次性灌进
     // composable，模式（whitelist / mapping）由 composable 自行推断。
-    if (newAccount.platform === 'newapi') {
+    if (newAccount.platform === PLATFORM_NEWAPI) {
       newapiPopulateFromAccount({
         channel_type: newAccount.channel_type,
         credentials,
@@ -3528,7 +3538,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   } else if (newAccount.type === 'upstream' && newAccount.credentials) {
     const credentials = newAccount.credentials as Record<string, unknown>
     editBaseUrl.value = (credentials.base_url as string) || ''
-  } else if (newAccount.platform === 'newapi' && newAccount.type === 'service_account' && newAccount.credentials) {
+  } else if (newAccount.platform === PLATFORM_NEWAPI && newAccount.type === 'service_account' && newAccount.credentials) {
     // 第五平台 newapi + Vertex service_account (channel_type=41 …): channel_type
     // + base_url + model_mapping selector 走 newapi composable（与 apikey 路径
     // 同一套结构化 selector），Vertex SA 专属字段（service_account_json 写一次 /
@@ -3544,7 +3554,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
       void newapiRefreshStoredPricingStatus()
     }
     vertexSa.populateFromCredentials(credentials)
-  } else if ((newAccount.platform === 'gemini' || newAccount.platform === 'anthropic') && newAccount.type === 'service_account' && newAccount.credentials) {
+  } else if ((newAccount.platform === PLATFORM_GEMINI || newAccount.platform === PLATFORM_ANTHROPIC) && newAccount.type === 'service_account' && newAccount.credentials) {
     const credentials = newAccount.credentials as Record<string, unknown>
     vertexSa.populateFromCredentials(credentials)
 
@@ -3552,17 +3562,17 @@ const syncFormFromAccount = (newAccount: Account | null) => {
     loadModelRestrictionFromMapping(credentials.model_mapping as Record<string, unknown> | undefined)
   } else {
     const platformDefaultUrl =
-      newAccount.platform === 'openai'
+      newAccount.platform === PLATFORM_OPENAI
         ? 'https://api.openai.com'
-        : newAccount.platform === 'gemini'
+        : newAccount.platform === PLATFORM_GEMINI
           ? 'https://generativelanguage.googleapis.com'
-          : newAccount.platform === 'grok'
+          : newAccount.platform === PLATFORM_GROK
             ? ''
             : 'https://api.anthropic.com'
     editBaseUrl.value = platformDefaultUrl
 
     // Load model mappings for OpenAI/Grok OAuth accounts
-    if ((newAccount.platform === 'openai' || newAccount.platform === 'grok') && newAccount.credentials) {
+    if ((newAccount.platform === PLATFORM_OPENAI || newAccount.platform === PLATFORM_GROK) && newAccount.credentials) {
       const oauthCredentials = newAccount.credentials as Record<string, unknown>
       loadModelRestrictionFromMapping(oauthCredentials.model_mapping as Record<string, unknown> | undefined)
     } else {
@@ -3847,7 +3857,7 @@ function loadQuotaControlSettings(account: Account) {
   customBaseUrl.value = ''
 
   // Remaining quota control settings only apply to Anthropic accounts
-  if (account.platform !== 'anthropic') {
+  if (account.platform !== PLATFORM_ANTHROPIC) {
     return
   }
 
@@ -3927,7 +3937,7 @@ function toPositiveNumber(value: unknown) {
   return Math.trunc(num)
 }
 
-const needsMixedChannelCheck = () => props.account?.platform === 'antigravity' || props.account?.platform === 'anthropic'
+const needsMixedChannelCheck = () => props.account?.platform === PLATFORM_ANTIGRAVITY || props.account?.platform === PLATFORM_ANTHROPIC
 
 const buildMixedChannelDetails = (resp?: CheckMixedChannelResponse) => {
   const details = resp?.details
@@ -4078,7 +4088,7 @@ const handleSubmit = async () => {
     // 第七平台 grok（oauth，非 apikey）：仅在重粘了 refresh_token 或改了 base_url 时
     // 才发 credentials。refresh_token 留空 = 保留现有（后端 MergePreservingSensitiveCreds
     // + 后台刷新器处理）；重粘则后端 resolveGrokTokenOnSave 活体校验 + 重新 prime。
-    if (props.account.platform === 'grok' && props.account.type === 'oauth') {
+    if (props.account.platform === PLATFORM_GROK && props.account.type === 'oauth') {
       const bundle = grokBuildSubmitBundle('edit')
       if (!bundle) return
       if (Object.keys(bundle.credentials).length > 0) {
@@ -4086,7 +4096,7 @@ const handleSubmit = async () => {
       }
     }
 
-    if (props.account.platform === 'kiro') {
+    if (props.account.platform === PLATFORM_KIRO) {
       const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
       const bundle = kiro.buildSubmitBundle('edit', {
         credentialsStatus: props.account.credentials_status,
@@ -4107,8 +4117,8 @@ const handleSubmit = async () => {
     // For apikey type, handle credentials update
     if (props.account.type === 'apikey') {
       const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
-      const isNewAPI = props.account.platform === 'newapi'
-      const shouldApplyModelMapping = !(props.account.platform === 'openai' && openaiPassthroughEnabled.value)
+      const isNewAPI = props.account.platform === PLATFORM_NEWAPI
+      const shouldApplyModelMapping = !(props.account.platform === PLATFORM_OPENAI && openaiPassthroughEnabled.value)
 
       // 第五平台 newapi：校验 + credentials 拼装一律走 composable.buildSubmitBundle
       // （edit 模式下 api_key 留空表示保留现有密钥；非 newapi 路径下使用
@@ -4147,7 +4157,7 @@ const handleSubmit = async () => {
         updatePayload.channel_type = bundle.channelType
       } else {
         const submittedBaseUrl = editBaseUrl.value.trim() || defaultBaseUrl.value
-        if (props.account.platform === 'grok' && !submittedBaseUrl) {
+        if (props.account.platform === PLATFORM_GROK && !submittedBaseUrl) {
           appStore.showError(t('admin.accounts.upstream.pleaseEnterBaseUrl'))
           return
         }
@@ -4159,9 +4169,9 @@ const handleSubmit = async () => {
           return
         }
         // TK: edge mirror-stub pool selector (surface-C). anthropic apikey only.
-        if (props.account.platform === 'anthropic') {
+        if (props.account.platform === PLATFORM_ANTHROPIC) {
           newCredentials.mirror_platform = editMirrorPlatform.value
-        } else if (props.account.platform === 'grok') {
+        } else if (props.account.platform === PLATFORM_GROK) {
           newCredentials.mirror_platform = 'grok'
         }
         if (shouldApplyModelMapping) {
@@ -4180,7 +4190,7 @@ const handleSubmit = async () => {
           newCredentials.model_mapping = currentCredentials.model_mapping
         }
       }
-      if (props.account.platform === 'openai') {
+      if (props.account.platform === PLATFORM_OPENAI) {
         const compactModelMapping = buildModelMappingObject('mapping', [], openAICompactModelMappings.value)
         if (compactModelMapping) {
           newCredentials.compact_model_mapping = compactModelMapping
@@ -4188,7 +4198,7 @@ const handleSubmit = async () => {
           delete newCredentials.compact_model_mapping
         }
       }
-      if (props.account.platform === 'openai') {
+      if (props.account.platform === PLATFORM_OPENAI) {
         applyOpenAIEndpointCapabilities(newCredentials)
         const compactModelMapping = buildModelMappingObject('mapping', [], openAICompactModelMappings.value)
         if (compactModelMapping) {
@@ -4248,7 +4258,7 @@ const handleSubmit = async () => {
       }
 
       updatePayload.credentials = newCredentials
-    } else if (props.account.platform === 'newapi' && props.account.type === 'service_account') {
+    } else if (props.account.platform === PLATFORM_NEWAPI && props.account.type === 'service_account') {
       const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
 
       if (!newapiChannelType.value || newapiChannelType.value <= 0) {
@@ -4275,7 +4285,7 @@ const handleSubmit = async () => {
       }
 
       updatePayload.credentials = merged
-    } else if ((props.account.platform === 'gemini' || props.account.platform === 'anthropic') && props.account.type === 'service_account') {
+    } else if ((props.account.platform === PLATFORM_GEMINI || props.account.platform === PLATFORM_ANTHROPIC) && props.account.type === 'service_account') {
       const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
 
       const merged = vertexSa.mergeCredentialsForEdit(
@@ -4368,13 +4378,13 @@ const handleSubmit = async () => {
     }
 
     // OpenAI/Grok OAuth: persist model mapping to credentials
-    if ((props.account.platform === 'openai' || props.account.platform === 'grok') && props.account.type === 'oauth') {
+    if ((props.account.platform === PLATFORM_OPENAI || props.account.platform === PLATFORM_GROK) && props.account.type === 'oauth') {
       const currentCredentials = isSparkShadow.value
         ? {}
         : (updatePayload.credentials as Record<string, unknown>) ||
           ((props.account.credentials as Record<string, unknown>) || {})
       const newCredentials: Record<string, unknown> = { ...currentCredentials }
-      if (props.account.platform === 'openai') {
+      if (props.account.platform === PLATFORM_OPENAI) {
         applyOpenAIModelMappingCredentials(newCredentials)
       } else {
         const modelMapping = buildModelRestrictionMapping()
@@ -4390,7 +4400,7 @@ const handleSubmit = async () => {
 
     // Antigravity: persist model mapping to credentials (applies to all antigravity types)
     // Antigravity 只支持映射模式
-    if (props.account.platform === 'antigravity') {
+    if (props.account.platform === PLATFORM_ANTIGRAVITY) {
       const currentCredentials = (updatePayload.credentials as Record<string, unknown>) ||
         ((props.account.credentials as Record<string, unknown>) || {})
       const newCredentials: Record<string, unknown> = { ...currentCredentials }
@@ -4416,7 +4426,7 @@ const handleSubmit = async () => {
     }
 
     // For antigravity accounts, handle mixed_scheduling and allow_overages in extra
-    if (props.account.platform === 'antigravity') {
+    if (props.account.platform === PLATFORM_ANTIGRAVITY) {
       const currentExtra = (props.account.extra as Record<string, unknown>) || {}
       const newExtra: Record<string, unknown> = { ...currentExtra }
       if (mixedScheduling.value) {
@@ -4433,7 +4443,7 @@ const handleSubmit = async () => {
     }
 
     // For Anthropic OAuth/SetupToken accounts, handle quota control settings in extra
-    if (props.account.platform === 'anthropic' && (props.account.type === 'oauth' || props.account.type === 'setup-token')) {
+    if (props.account.platform === PLATFORM_ANTHROPIC && (props.account.type === 'oauth' || props.account.type === 'setup-token')) {
       const currentExtra = (updatePayload.extra as Record<string, unknown>) || (props.account.extra as Record<string, unknown>) || {}
       const newExtra: Record<string, unknown> = { ...currentExtra }
 
@@ -4515,7 +4525,7 @@ const handleSubmit = async () => {
     }
 
     // For Anthropic API Key accounts, handle passthrough mode + web search emulation in extra
-    if (props.account.platform === 'anthropic' && props.account.type === 'apikey') {
+    if (props.account.platform === PLATFORM_ANTHROPIC && props.account.type === 'apikey') {
       const currentExtra = (updatePayload.extra as Record<string, unknown>) || (props.account.extra as Record<string, unknown>) || {}
       const newExtra: Record<string, unknown> = { ...currentExtra }
       if (anthropicPassthroughEnabled.value) {
@@ -4537,7 +4547,7 @@ const handleSubmit = async () => {
     }
 
     // For OpenAI OAuth/SetupToken/API Key accounts, handle passthrough mode in extra
-    if (props.account.platform === 'openai' && (props.account.type === 'oauth' || props.account.type === 'setup-token' || props.account.type === 'apikey')) {
+    if (props.account.platform === PLATFORM_OPENAI && (props.account.type === 'oauth' || props.account.type === 'setup-token' || props.account.type === 'apikey')) {
       const currentExtra = (props.account.extra as Record<string, unknown>) || {}
       const newExtra: Record<string, unknown> = { ...currentExtra }
       const hadCodexCLIOnlyEnabled = currentExtra.codex_cli_only === true

--- a/frontend/src/components/account/GrokQuotaProbeCell.vue
+++ b/frontend/src/components/account/GrokQuotaProbeCell.vue
@@ -50,6 +50,7 @@ import { useI18n } from 'vue-i18n'
 import { adminAPI } from '@/api/admin'
 import type { GrokQuotaProbeResult, GrokQuotaWindow } from '@/api/admin/grok'
 import type { Account } from '@/types'
+import { PLATFORM_GROK } from '@/constants/gatewayPlatforms'
 
 const props = defineProps<{
   account: Account
@@ -57,7 +58,7 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
-const visible = computed(() => props.account.platform === 'grok' && props.account.type === 'oauth')
+const visible = computed(() => props.account.platform === PLATFORM_GROK && props.account.type === 'oauth')
 const loading = ref(false)
 const error = ref<string | null>(null)
 const data = ref<GrokQuotaProbeResult | null>(null)

--- a/frontend/src/components/account/OAuthAuthorizationFlow.vue
+++ b/frontend/src/components/account/OAuthAuthorizationFlow.vue
@@ -719,6 +719,7 @@ import { useClipboard } from '@/composables/useClipboard'
 import Icon from '@/components/icons/Icon.vue'
 import type { AddMethod, AuthInputMethod } from '@/composables/useAccountOAuth'
 import type { AccountPlatform } from '@/types'
+import { PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI, PLATFORM_GROK, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 interface Props {
   addMethod: AddMethod
@@ -776,14 +777,14 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const showLocalCallbackNotice = computed(() => props.platform === 'openai' || props.platform === 'grok')
+const showLocalCallbackNotice = computed(() => props.platform === PLATFORM_OPENAI || props.platform === PLATFORM_GROK)
 
 // Get translation key based on platform
 const getOAuthKey = (key: string) => {
-  if (props.platform === 'openai') return `admin.accounts.oauth.openai.${key}`
-  if (props.platform === 'gemini') return `admin.accounts.oauth.gemini.${key}`
-  if (props.platform === 'antigravity') return `admin.accounts.oauth.antigravity.${key}`
-  if (props.platform === 'grok') return `admin.accounts.oauth.grok.${key}`
+  if (props.platform === PLATFORM_OPENAI) return `admin.accounts.oauth.openai.${key}`
+  if (props.platform === PLATFORM_GEMINI) return `admin.accounts.oauth.gemini.${key}`
+  if (props.platform === PLATFORM_ANTIGRAVITY) return `admin.accounts.oauth.antigravity.${key}`
+  if (props.platform === PLATFORM_GROK) return `admin.accounts.oauth.grok.${key}`
   return `admin.accounts.oauth.${key}`
 }
 
@@ -800,9 +801,9 @@ const oauthAuthCode = computed(() => t(getOAuthKey('authCode')))
 const oauthAuthCodePlaceholder = computed(() => t(getOAuthKey('authCodePlaceholder')))
 const oauthAuthCodeHint = computed(() => t(getOAuthKey('authCodeHint')))
 const oauthImportantNotice = computed(() => {
-  if (props.platform === 'openai') return t('admin.accounts.oauth.openai.importantNotice')
-  if (props.platform === 'antigravity') return t('admin.accounts.oauth.antigravity.importantNotice')
-  if (props.platform === 'grok') return t('admin.accounts.oauth.grok.importantNotice')
+  if (props.platform === PLATFORM_OPENAI) return t('admin.accounts.oauth.openai.importantNotice')
+  if (props.platform === PLATFORM_ANTIGRAVITY) return t('admin.accounts.oauth.antigravity.importantNotice')
+  if (props.platform === PLATFORM_GROK) return t('admin.accounts.oauth.grok.importantNotice')
   return ''
 })
 
@@ -858,7 +859,7 @@ watch(inputMethod, (newVal) => {
 // Auto-extract code from callback URL (OpenAI/Gemini/Antigravity/Grok)
 // e.g., http://localhost:8085/callback?code=xxx...&state=...
 watch(authCodeInput, (newVal) => {
-  if (props.platform !== 'openai' && props.platform !== 'gemini' && props.platform !== 'antigravity' && props.platform !== 'grok') return
+  if (props.platform !== PLATFORM_OPENAI && props.platform !== PLATFORM_GEMINI && props.platform !== PLATFORM_ANTIGRAVITY && props.platform !== PLATFORM_GROK) return
 
   const trimmed = newVal.trim()
   // Check if it looks like a URL with code parameter
@@ -868,7 +869,7 @@ watch(authCodeInput, (newVal) => {
       const url = trimmed.includes('?') ? new URL(trimmed) : new URL(`http://localhost/callback?${trimmed.replace(/^\?/, '')}`)
       const code = url.searchParams.get('code')
       const stateParam = url.searchParams.get('state')
-      if ((props.platform === 'openai' || props.platform === 'gemini' || props.platform === 'antigravity' || props.platform === 'grok') && stateParam) {
+      if ((props.platform === PLATFORM_OPENAI || props.platform === PLATFORM_GEMINI || props.platform === PLATFORM_ANTIGRAVITY || props.platform === PLATFORM_GROK) && stateParam) {
         oauthState.value = stateParam
       }
       if (code && code !== trimmed) {
@@ -879,7 +880,7 @@ watch(authCodeInput, (newVal) => {
       // If URL parsing fails, try regex extraction
       const match = trimmed.match(/[?&]code=([^&]+)/)
       const stateMatch = trimmed.match(/[?&]state=([^&]+)/)
-      if ((props.platform === 'openai' || props.platform === 'gemini' || props.platform === 'antigravity' || props.platform === 'grok') && stateMatch && stateMatch[1]) {
+      if ((props.platform === PLATFORM_OPENAI || props.platform === PLATFORM_GEMINI || props.platform === PLATFORM_ANTIGRAVITY || props.platform === PLATFORM_GROK) && stateMatch && stateMatch[1]) {
         oauthState.value = stateMatch[1]
       }
       if (match && match[1] && match[1] !== trimmed) {

--- a/frontend/src/components/account/OpenAIQuotaResetCell.vue
+++ b/frontend/src/components/account/OpenAIQuotaResetCell.vue
@@ -187,6 +187,7 @@ import {
 import UsageProgressBar from './UsageProgressBar.vue'
 import { normalizeCodexAdditionalLimits } from '@/constants/codexRateLimitWindows.tk'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
+import { PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 const props = defineProps<{
   account: Account
@@ -195,7 +196,7 @@ const props = defineProps<{
 const { t } = useI18n()
 
 // Visible only for OpenAI OAuth accounts.
-const visible = computed(() => props.account.platform === 'openai' && props.account.type === 'oauth')
+const visible = computed(() => props.account.platform === PLATFORM_OPENAI && props.account.type === 'oauth')
 
 const loading = ref(false)
 const resetting = ref(false)

--- a/frontend/src/components/account/ReAuthAccountModal.vue
+++ b/frontend/src/components/account/ReAuthAccountModal.vue
@@ -196,6 +196,7 @@ import type { Account } from '@/types'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import Icon from '@/components/icons/Icon.vue'
 import OAuthAuthorizationFlow from './OAuthAuthorizationFlow.vue'
+import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 // Type for exposed OAuthAuthorizationFlow component
 // Note: defineExpose automatically unwraps refs, so we use the unwrapped types
@@ -236,11 +237,11 @@ const addMethod = ref<AddMethod>('oauth')
 const geminiOAuthType = ref<'code_assist' | 'google_one' | 'ai_studio'>('code_assist')
 
 // Computed - check platform
-const isOpenAI = computed(() => props.account?.platform === 'openai')
+const isOpenAI = computed(() => props.account?.platform === PLATFORM_OPENAI)
 const isOpenAILike = computed(() => isOpenAI.value)
-const isGemini = computed(() => props.account?.platform === 'gemini')
-const isAnthropic = computed(() => props.account?.platform === 'anthropic')
-const isAntigravity = computed(() => props.account?.platform === 'antigravity')
+const isGemini = computed(() => props.account?.platform === PLATFORM_GEMINI)
+const isAnthropic = computed(() => props.account?.platform === PLATFORM_ANTHROPIC)
+const isAntigravity = computed(() => props.account?.platform === PLATFORM_ANTIGRAVITY)
 
 // Computed - current OAuth state based on platform
 const currentAuthUrl = computed(() => {

--- a/frontend/src/components/account/usage-cells/useAccountUsageFetch.ts
+++ b/frontend/src/components/account/usage-cells/useAccountUsageFetch.ts
@@ -19,6 +19,7 @@ import {
   usesLocalUsageWindows,
   usesPassiveUsageOnMount as accountUsesPassiveUsageOnMount
 } from '@/utils/accountUsageBatch.tk'
+import { PLATFORM_GEMINI, PLATFORM_KIRO, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 // Module-level cache shared across all usage cell instances
 const _usageCache = new Map<number, { data: AccountUsageInfo; ts: number }>()
@@ -215,7 +216,7 @@ export function useAccountUsageFetch(
   if (options?.enableOpenAIRefreshKeyWatch) {
     watch(openAIUsageRefreshKey, (nextKey, prevKey) => {
       if (!prevKey || nextKey === prevKey) return
-      if (props.account.platform !== 'openai' || props.account.type !== 'oauth') return
+      if (props.account.platform !== PLATFORM_OPENAI || props.account.type !== 'oauth') return
 
       _usageCache.delete(props.account.id)
       requestAutoLoad()
@@ -230,7 +231,7 @@ export function useAccountUsageFetch(
 
       // Kiro: explicit 刷新 pulls live credits once (#1031). Must run before the
       // batch-passive early return (kiro is batch-capable but not batch-only on refresh).
-      if (props.account.platform === 'kiro') {
+      if (props.account.platform === PLATFORM_KIRO) {
         _usageCache.delete(props.account.id)
         loadActiveUsage().catch((e) => {
           console.error('Failed to refresh kiro usage after manual refresh:', e)
@@ -299,8 +300,8 @@ export function useAccountUsageFetch(
 
 export function showUsageWindowsForAccount(account: Account): boolean {
   if (
-    account.platform === 'gemini' ||
-    account.platform === 'kiro' ||
+    account.platform === PLATFORM_GEMINI ||
+    account.platform === PLATFORM_KIRO ||
     usesLocalUsageWindows(account)
   ) {
     return true

--- a/frontend/src/components/account/usage-cells/useGeminiUsageMeta.ts
+++ b/frontend/src/components/account/usage-cells/useGeminiUsageMeta.ts
@@ -1,6 +1,7 @@
 import { computed, type ComputedRef, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { Account, AccountUsageInfo, GeminiCredentials, WindowStats } from '@/types'
+import { PLATFORM_GEMINI } from '@/constants/gatewayPlatforms'
 
 export function useGeminiUsageMeta(
   account: Account,
@@ -9,25 +10,25 @@ export function useGeminiUsageMeta(
   const { t } = useI18n()
 
   const geminiTier = computed(() => {
-    if (account.platform !== 'gemini') return null
+    if (account.platform !== PLATFORM_GEMINI) return null
     const creds = account.credentials as GeminiCredentials | undefined
     return creds?.tier_id || null
   })
 
   const geminiOAuthType = computed(() => {
-    if (account.platform !== 'gemini') return null
+    if (account.platform !== PLATFORM_GEMINI) return null
     const creds = account.credentials as GeminiCredentials | undefined
     return (creds?.oauth_type || '').trim() || null
   })
 
   const isGeminiCodeAssist = computed(() => {
-    if (account.platform !== 'gemini') return false
+    if (account.platform !== PLATFORM_GEMINI) return false
     const creds = account.credentials as GeminiCredentials | undefined
     return creds?.oauth_type === 'code_assist' || (!creds?.oauth_type && !!creds?.project_id)
   })
 
   const geminiChannelShort = computed((): 'ai studio' | 'gcp' | 'google one' | 'client' | null => {
-    if (account.platform !== 'gemini') return null
+    if (account.platform !== PLATFORM_GEMINI) return null
 
     if (account.type === 'apikey') return 'ai studio'
 
@@ -39,7 +40,7 @@ export function useGeminiUsageMeta(
   })
 
   const geminiUserLevel = computed((): string | null => {
-    if (account.platform !== 'gemini') return null
+    if (account.platform !== PLATFORM_GEMINI) return null
 
     const tier = (geminiTier.value || '').toString().trim()
     const tierLower = tier.toLowerCase()
@@ -88,7 +89,7 @@ export function useGeminiUsageMeta(
   })
 
   const geminiAuthTypeLabel = computed(() => {
-    if (account.platform !== 'gemini') return null
+    if (account.platform !== PLATFORM_GEMINI) return null
     if (!geminiChannelShort.value) return null
     return geminiUserLevel.value
       ? `${geminiChannelShort.value} ${geminiUserLevel.value}`
@@ -167,7 +168,7 @@ export function useGeminiUsageMeta(
   })
 
   const geminiUsesSharedDaily = computed(() => {
-    if (account.platform !== 'gemini') return false
+    if (account.platform !== PLATFORM_GEMINI) return false
     return (
       !!usageInfo.value?.gemini_shared_daily ||
       !!usageInfo.value?.gemini_shared_minute ||
@@ -197,7 +198,7 @@ export function useGeminiUsageMeta(
       color: 'indigo' | 'emerald'
     }>
   > = computed(() => {
-    if (account.platform !== 'gemini') return []
+    if (account.platform !== PLATFORM_GEMINI) return []
     if (!usageInfo.value) return []
 
     const bars: Array<{
@@ -252,7 +253,7 @@ export function useGeminiUsageMeta(
   })
 
   const showGeminiTodayStats = computed(() => {
-    return account.platform === 'gemini' && account.type === 'service_account'
+    return account.platform === PLATFORM_GEMINI && account.type === 'service_account'
   })
 
   return {

--- a/frontend/src/components/admin/account/AccountActionMenu.vue
+++ b/frontend/src/components/admin/account/AccountActionMenu.vue
@@ -66,6 +66,7 @@ import { computed, watch, onUnmounted, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@/components/icons'
 import type { Account } from '@/types'
+import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 const props = defineProps<{ show: boolean; account: Account | null; position: { top: number; left: number } | null }>()
 const emit = defineEmits(['close', 'test', 'stats', 'schedule', 'reauth', 'refresh-token', 'recover-state', 'reset-quota', 'set-privacy', 'set-tier', 'create-spark-shadow'])
@@ -109,8 +110,8 @@ const isTempUnschedulable = computed(() => props.account?.temp_unschedulable_unt
 const hasRecoverableState = computed(() => {
   return props.account?.status === 'error' || Boolean(isRateLimited.value) || Boolean(isOverloaded.value) || Boolean(isTempUnschedulable.value)
 })
-const isAntigravityOAuth = computed(() => props.account?.platform === 'antigravity' && props.account?.type === 'oauth')
-const isOpenAIOAuth = computed(() => props.account?.platform === 'openai' && props.account?.type === 'oauth')
+const isAntigravityOAuth = computed(() => props.account?.platform === PLATFORM_ANTIGRAVITY && props.account?.type === 'oauth')
+const isOpenAIOAuth = computed(() => props.account?.platform === PLATFORM_OPENAI && props.account?.type === 'oauth')
 // 影子账号(链接型,持 parent_account_id)不持凭据、type 不可变,凭据/隐私类操作对其无效。
 const isShadow = computed(() => props.account?.parent_account_id != null)
 // A "parent" OpenAI OAuth account is one that is NOT itself a shadow (parent_account_id == null)
@@ -123,7 +124,7 @@ const supportsPrivacy = computed(() => (isAntigravityOAuth.value || isOpenAIOAut
 // offered "设置 Tier" on stubs where the apply call always errors out.
 const canSetTier = computed(
   () =>
-    props.account?.platform === 'anthropic' &&
+    props.account?.platform === PLATFORM_ANTHROPIC &&
     (props.account?.type === 'oauth' || props.account?.type === 'setup-token')
 )
 const hasQuotaLimit = computed(() => {

--- a/frontend/src/components/admin/account/AccountTestModal.vue
+++ b/frontend/src/components/admin/account/AccountTestModal.vue
@@ -256,6 +256,7 @@ import { useClipboard } from '@/composables/useClipboard'
 import { buildApiUrl } from '@/api/client'
 import { adminAPI } from '@/api/admin'
 import type { Account, ClaudeModel } from '@/types'
+import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI, PLATFORM_KIRO, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 const { t } = useI18n()
 const { copyToClipboard } = useClipboard()
@@ -299,23 +300,23 @@ const supportsGeminiImageTest = computed(() => {
   const modelID = selectedModelId.value.toLowerCase()
   if (!modelID.startsWith('gemini-') || !modelID.includes('-image')) return false
 
-  return props.account?.platform === 'gemini' || (props.account?.platform === 'antigravity' && props.account?.type === 'apikey')
+  return props.account?.platform === PLATFORM_GEMINI || (props.account?.platform === PLATFORM_ANTIGRAVITY && props.account?.type === 'apikey')
 })
 
 const supportsOpenAIImageTest = computed(() => {
   const modelID = selectedModelId.value.toLowerCase()
   if (!modelID.startsWith('gpt-image-')) return false
-  return props.account?.platform === 'openai'
+  return props.account?.platform === PLATFORM_OPENAI
 })
 
 const supportsImageTest = computed(() => supportsGeminiImageTest.value || supportsOpenAIImageTest.value)
 
 const isKiroTestAccount = computed(() => (
-  props.account?.platform === 'kiro' ||
+  props.account?.platform === PLATFORM_KIRO ||
   (
-    props.account?.platform === 'anthropic' &&
+    props.account?.platform === PLATFORM_ANTHROPIC &&
     props.account?.type === 'apikey' &&
-    String(props.account?.credentials?.mirror_platform || '').trim().toLowerCase() === 'kiro'
+    String(props.account?.credentials?.mirror_platform || '').trim().toLowerCase() === PLATFORM_KIRO
   )
 ))
 
@@ -373,14 +374,14 @@ const loadAvailableModels = async () => {
   modelsError.value = ''
   try {
     const models = await adminAPI.accounts.getAvailableModels(props.account.id)
-    availableModels.value = props.account.platform === 'gemini' || props.account.platform === 'antigravity'
+    availableModels.value = props.account.platform === PLATFORM_GEMINI || props.account.platform === PLATFORM_ANTIGRAVITY
       ? sortTestModels(models)
       : models
     // Default selection by platform
     if (availableModels.value.length > 0) {
-      if (props.account.platform === 'gemini') {
+      if (props.account.platform === PLATFORM_GEMINI) {
         selectedModelId.value = availableModels.value[0].id
-      } else if (props.account.platform === 'antigravity') {
+      } else if (props.account.platform === PLATFORM_ANTIGRAVITY) {
         // Backend pins AntigravityDefaultTestModelID first; gemini-only policy — no sonnet default.
         selectedModelId.value = availableModels.value[0].id
       } else if (isKiroTestAccount.value) {

--- a/frontend/src/components/admin/account/EdgeAccountActionMenuTk.vue
+++ b/frontend/src/components/admin/account/EdgeAccountActionMenuTk.vue
@@ -63,6 +63,7 @@ import { computed, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@/components/icons'
 import type { EdgeAccountSummary } from '@/api/admin/edgeAccounts'
+import { PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 const props = defineProps<{
   show: boolean
@@ -98,7 +99,7 @@ const isTempUnsched = computed(() => isFuture(props.account?.temp_unschedulable_
 // Reset-quota resets the OpenAI OAuth (codex) rolling window — the case where it is
 // clearly meaningful; anthropic oauth uses window-cost cleared via clear-rate-limit.
 const canResetQuota = computed(
-  () => props.account?.platform === 'openai' && props.account?.type === 'oauth'
+  () => props.account?.platform === PLATFORM_OPENAI && props.account?.type === 'oauth'
 )
 
 const handleKeydown = (event: KeyboardEvent) => {

--- a/frontend/src/components/admin/account/EdgeAccountPanelTk.vue
+++ b/frontend/src/components/admin/account/EdgeAccountPanelTk.vue
@@ -239,6 +239,7 @@ import {
   isStubTempUnschedActive
 } from '@/utils/edgeAccounts.tk'
 import { sortEdgeAccountsAbnormalFirst } from '@/utils/accountsEdgePanels.tk'
+import { PLATFORM_KIRO } from '@/constants/gatewayPlatforms'
 
 const props = defineProps<{
   /** The prod cc-<edge> mirror-stub row this panel expands under. */
@@ -383,7 +384,7 @@ watch(
   (next, prev) => {
     if (!next || next === prev) return
     for (const a of props.edge?.accounts ?? []) {
-      if (a.platform === 'kiro') void fetchActiveUsageInto(a.id, true)
+      if (a.platform === PLATFORM_KIRO) void fetchActiveUsageInto(a.id, true)
     }
   }
 )

--- a/frontend/src/components/admin/account/ReAuthAccountModal.vue
+++ b/frontend/src/components/admin/account/ReAuthAccountModal.vue
@@ -201,6 +201,7 @@ import type { Account } from '@/types'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import Icon from '@/components/icons/Icon.vue'
 import OAuthAuthorizationFlow from '@/components/account/OAuthAuthorizationFlow.vue'
+import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI, PLATFORM_GROK, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 // Type for exposed OAuthAuthorizationFlow component
 // Note: defineExpose automatically unwraps refs, so we use the unwrapped types
@@ -242,12 +243,12 @@ const addMethod = ref<AddMethod>('oauth')
 const geminiOAuthType = ref<'code_assist' | 'google_one' | 'ai_studio'>('code_assist')
 
 // Computed - check platform
-const isOpenAI = computed(() => props.account?.platform === 'openai')
+const isOpenAI = computed(() => props.account?.platform === PLATFORM_OPENAI)
 const isOpenAILike = computed(() => isOpenAI.value)
-const isGemini = computed(() => props.account?.platform === 'gemini')
-const isAnthropic = computed(() => props.account?.platform === 'anthropic')
-const isAntigravity = computed(() => props.account?.platform === 'antigravity')
-const isGrok = computed(() => props.account?.platform === 'grok')
+const isGemini = computed(() => props.account?.platform === PLATFORM_GEMINI)
+const isAnthropic = computed(() => props.account?.platform === PLATFORM_ANTHROPIC)
+const isAntigravity = computed(() => props.account?.platform === PLATFORM_ANTIGRAVITY)
+const isGrok = computed(() => props.account?.platform === PLATFORM_GROK)
 
 // Computed - current OAuth state based on platform
 const currentAuthUrl = computed(() => {

--- a/frontend/src/components/admin/channel/types.ts
+++ b/frontend/src/components/admin/channel/types.ts
@@ -1,4 +1,6 @@
 import type { BillingMode, PricingInterval } from '@/api/admin/channels'
+import { tkAdminPlatformSoftBadgeClass } from '@/constants/gatewayPlatforms'
+import { platformTextClass } from '@/utils/platformColors'
 
 type TranslateFn = (key: string, params?: Record<string, unknown>) => string
 
@@ -233,25 +235,10 @@ function checkIntervalOverlap(sorted: IntervalFormEntry[], t: TranslateFn): stri
 
 /** 平台对应的模型 tag 样式（背景+文字） */
 export function getPlatformTagClass(platform: string): string {
-  switch (platform) {
-    case 'anthropic': return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
-    case 'openai': return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-    case 'gemini': return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-    case 'antigravity': return 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
-    case 'newapi': return 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400'
-    case 'grok': return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300'
-    default: return 'bg-gray-100 text-gray-700 dark:bg-gray-900/30 dark:text-gray-400'
-  }
+  return tkAdminPlatformSoftBadgeClass(platform)
 }
 
 /** 平台对应的模型文字色（仅 text-*，用于 input/text 场景）— 与 getPlatformTagClass 同色系 */
 export function getPlatformTextClass(platform: string): string {
-  switch (platform) {
-    case 'anthropic': return 'text-orange-700 dark:text-orange-400'
-    case 'openai': return 'text-emerald-700 dark:text-emerald-400'
-    case 'gemini': return 'text-blue-700 dark:text-blue-400'
-    case 'antigravity': return 'text-purple-700 dark:text-purple-400'
-    case 'grok': return 'text-slate-700 dark:text-slate-300'
-    default: return ''
-  }
+  return platformTextClass(platform)
 }

--- a/frontend/src/components/admin/group/GroupRPMOverridesModal.vue
+++ b/frontend/src/components/admin/group/GroupRPMOverridesModal.vue
@@ -216,6 +216,7 @@ import BaseDialog from '@/components/common/BaseDialog.vue'
 import Pagination from '@/components/common/Pagination.vue'
 import Icon from '@/components/icons/Icon.vue'
 import PlatformIcon from '@/components/common/PlatformIcon.vue'
+import { platformTextClass } from '@/utils/platformColors'
 
 interface LocalEntry extends GroupRPMOverrideEntry {}
 
@@ -246,14 +247,7 @@ const pageSize = ref(10)
 
 let searchTimeout: ReturnType<typeof setTimeout>
 
-const platformColorClass = computed(() => {
-  switch (props.group?.platform) {
-    case 'anthropic': return 'text-orange-700 dark:text-orange-400'
-    case 'openai': return 'text-emerald-700 dark:text-emerald-400'
-    case 'antigravity': return 'text-purple-700 dark:text-purple-400'
-    default: return 'text-blue-700 dark:text-blue-400'
-  }
-})
+const platformColorClass = computed(() => platformTextClass(props.group?.platform ?? ''))
 
 const isDirty = computed(() => {
   if (localEntries.value.length !== serverEntries.value.length) return true

--- a/frontend/src/components/admin/group/GroupRateMultipliersModal.vue
+++ b/frontend/src/components/admin/group/GroupRateMultipliersModal.vue
@@ -249,6 +249,7 @@ import BaseDialog from '@/components/common/BaseDialog.vue'
 import Pagination from '@/components/common/Pagination.vue'
 import Icon from '@/components/icons/Icon.vue'
 import PlatformIcon from '@/components/common/PlatformIcon.vue'
+import { platformTextClass } from '@/utils/platformColors'
 
 interface LocalEntry extends GroupRateMultiplierEntry {}
 
@@ -280,15 +281,7 @@ const batchFactor = ref<number | null>(null)
 
 let searchTimeout: ReturnType<typeof setTimeout>
 
-const platformColorClass = computed(() => {
-  switch (props.group?.platform) {
-    case 'anthropic': return 'text-orange-700 dark:text-orange-400'
-    case 'openai': return 'text-emerald-700 dark:text-emerald-400'
-    case 'antigravity': return 'text-purple-700 dark:text-purple-400'
-    case 'newapi': return 'text-cyan-700 dark:text-cyan-400'
-    default: return 'text-blue-700 dark:text-blue-400'
-  }
-})
+const platformColorClass = computed(() => platformTextClass(props.group?.platform ?? ''))
 
 // 是否显示"最终倍率"预览列
 const showFinalRate = computed(() => {

--- a/frontend/src/components/admin/user/GroupReplaceModal.vue
+++ b/frontend/src/components/admin/user/GroupReplaceModal.vue
@@ -79,6 +79,7 @@
 import { ref, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { getPlatformLabel } from '@/composables/usePlatformOptions'
+import { STATUS_ACTIVE } from '@/constants/channel'
 import { useAppStore } from '@/stores/app'
 import { adminAPI } from '@/api/admin'
 import type { AdminUser, AdminGroup } from '@/types'
@@ -104,7 +105,7 @@ const submitting = ref(false)
 const availableGroups = computed(() => {
   if (!props.oldGroup) return []
   return props.allGroups.filter(
-    g => g.status === 'active' && g.is_exclusive && g.subscription_type === 'standard' && g.id !== props.oldGroup!.id
+    g => g.status === STATUS_ACTIVE && g.is_exclusive && g.subscription_type === 'standard' && g.id !== props.oldGroup!.id
   )
 })
 

--- a/frontend/src/components/admin/user/UserAllowedGroupsModal.vue
+++ b/frontend/src/components/admin/user/UserAllowedGroupsModal.vue
@@ -182,6 +182,7 @@
 import { ref, watch, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { getPlatformLabel } from '@/composables/usePlatformOptions'
+import { STATUS_ACTIVE } from '@/constants/channel'
 import { useAppStore } from '@/stores/app'
 import { adminAPI } from '@/api/admin'
 import type { AdminUser, Group, GroupPlatform } from '@/types'
@@ -230,7 +231,7 @@ const load = async () => {
   try {
     const res = await adminAPI.groups.list(1, 1000)
     // 只显示标准类型且活跃的分组
-    groups.value = res.items.filter((g) => g.subscription_type === 'standard' && g.status === 'active')
+    groups.value = res.items.filter((g) => g.subscription_type === 'standard' && g.status === STATUS_ACTIVE)
 
     // 初始化配置
     const userAllowedGroups = props.user?.allowed_groups || []

--- a/frontend/src/components/admin/user/UserPlatformQuotaModal.vue
+++ b/frontend/src/components/admin/user/UserPlatformQuotaModal.vue
@@ -121,6 +121,7 @@ import { useAppStore } from '@/stores/app'
 import { adminAPI } from '@/api/admin'
 import type { AdminUser, PlatformQuotaItem, PlatformQuotaPlatform, PlatformQuotaWindow } from '@/types'
 import BaseDialog from '@/components/common/BaseDialog.vue'
+import { STATUS_ACTIVE } from '@/constants/channel'
 
 const props = defineProps<{ show: boolean; user: AdminUser | null }>()
 const emit = defineEmits(['close', 'success'])
@@ -141,7 +142,7 @@ interface QuotaRow {
 }
 
 const hasActiveSubscription = computed(() =>
-  props.user?.subscriptions?.some((s) => s.status === 'active') ?? false
+  props.user?.subscriptions?.some((s) => s.status === STATUS_ACTIVE) ?? false
 )
 
 const loading = ref(false)

--- a/frontend/src/components/common/ChannelTypeBadge.vue
+++ b/frontend/src/components/common/ChannelTypeBadge.vue
@@ -22,6 +22,7 @@
 import { computed, onMounted } from 'vue'
 import { useNewApiChannelTypes } from '@/composables/useNewApiChannelTypes'
 import type { AccountPlatform } from '@/types'
+import { PLATFORM_NEWAPI } from '@/constants/gatewayPlatforms'
 
 interface Props {
   platform: AccountPlatform | string
@@ -33,7 +34,7 @@ const props = defineProps<Props>()
 const { types, load } = useNewApiChannelTypes()
 
 onMounted(() => {
-  if (props.platform === 'newapi') {
+  if (props.platform === PLATFORM_NEWAPI) {
     void load().catch(() => {
       /* swallow — fallback label below covers the empty state */
     })
@@ -41,7 +42,7 @@ onMounted(() => {
 })
 
 const label = computed(() => {
-  if (props.platform !== 'newapi') return ''
+  if (props.platform !== PLATFORM_NEWAPI) return ''
   const ct = props.channelType
   if (!ct || ct <= 0) return ''
   const found = types.value.find((c) => c.channel_type === ct)

--- a/frontend/src/components/common/GroupBadge.vue
+++ b/frontend/src/components/common/GroupBadge.vue
@@ -32,6 +32,14 @@ import { useI18n } from 'vue-i18n'
 import type { SubscriptionType, GroupPlatform } from '@/types'
 import { useAppStore } from '@/stores/app'
 import { formatPeakRateWindow, serverTimezoneLabel } from '@/utils/peak-rate'
+import {
+  PLATFORM_ANTHROPIC,
+  PLATFORM_OPENAI,
+  PLATFORM_GEMINI,
+  PLATFORM_NEWAPI,
+  PLATFORM_ANTIGRAVITY,
+  PLATFORM_GROK,
+} from '@/constants/gatewayPlatforms'
 import PlatformIcon from './PlatformIcon.vue'
 
 interface Props {
@@ -161,22 +169,22 @@ const labelClass = computed(() => {
   }
 
   // 正常状态或无天数：根据平台显示主题色
-  if (props.platform === 'anthropic') {
+  if (props.platform === PLATFORM_ANTHROPIC) {
     return `${base} bg-orange-200/60 text-orange-800 dark:bg-orange-800/40 dark:text-orange-300`
   }
-  if (props.platform === 'openai') {
+  if (props.platform === PLATFORM_OPENAI) {
     return `${base} bg-emerald-200/60 text-emerald-800 dark:bg-emerald-800/40 dark:text-emerald-300`
   }
-  if (props.platform === 'gemini') {
+  if (props.platform === PLATFORM_GEMINI) {
     return `${base} bg-blue-200/60 text-blue-800 dark:bg-blue-800/40 dark:text-blue-300`
   }
-  if (props.platform === 'newapi') {
+  if (props.platform === PLATFORM_NEWAPI) {
     return `${base} bg-cyan-200/60 text-cyan-800 dark:bg-cyan-800/40 dark:text-cyan-300`
   }
-  if (props.platform === 'antigravity') {
+  if (props.platform === PLATFORM_ANTIGRAVITY) {
     return `${base} bg-purple-200/60 text-purple-800 dark:bg-purple-800/40 dark:text-purple-300`
   }
-  if (props.platform === 'grok') {
+  if (props.platform === PLATFORM_GROK) {
     return `${base} bg-zinc-300/70 text-zinc-800 dark:bg-zinc-700/60 dark:text-zinc-200`
   }
   return `${base} bg-violet-200/60 text-violet-800 dark:bg-violet-800/40 dark:text-violet-300`
@@ -188,33 +196,33 @@ const peakRateClass = computed(() => {
 
 // Badge color based on platform and subscription type
 const badgeClass = computed(() => {
-  if (props.platform === 'anthropic') {
+  if (props.platform === PLATFORM_ANTHROPIC) {
     // Claude: orange theme
     return isSubscription.value
       ? 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
       : 'bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-400'
-  } else if (props.platform === 'openai') {
+  } else if (props.platform === PLATFORM_OPENAI) {
     // OpenAI: green theme
     return isSubscription.value
       ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
       : 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-400'
   }
-  if (props.platform === 'gemini') {
+  if (props.platform === PLATFORM_GEMINI) {
     return isSubscription.value
       ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
       : 'bg-sky-50 text-sky-700 dark:bg-sky-900/20 dark:text-sky-400'
   }
-  if (props.platform === 'newapi') {
+  if (props.platform === PLATFORM_NEWAPI) {
     return isSubscription.value
       ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300'
       : 'bg-cyan-50 text-cyan-700 dark:bg-cyan-900/20 dark:text-cyan-300'
   }
-  if (props.platform === 'antigravity') {
+  if (props.platform === PLATFORM_ANTIGRAVITY) {
     return isSubscription.value
       ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
       : 'bg-fuchsia-50 text-fuchsia-700 dark:bg-fuchsia-900/20 dark:text-fuchsia-400'
   }
-  if (props.platform === 'grok') {
+  if (props.platform === PLATFORM_GROK) {
     return isSubscription.value
       ? 'bg-zinc-200 text-zinc-800 dark:bg-zinc-700 dark:text-zinc-100'
       : 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200'

--- a/frontend/src/components/common/GroupSelector.vue
+++ b/frontend/src/components/common/GroupSelector.vue
@@ -62,6 +62,7 @@ import { useI18n } from 'vue-i18n'
 import GroupBadge from './GroupBadge.vue'
 import Icon from '@/components/icons/Icon.vue'
 import type { AdminGroup, GroupPlatform } from '@/types'
+import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI } from '@/constants/gatewayPlatforms'
 
 const { t } = useI18n()
 
@@ -92,9 +93,9 @@ const filteredGroups = computed(() => {
   let result: AdminGroup[] = props.groups
   if (props.platform) {
     // antigravity 账户启用混合调度后，可选择 anthropic/gemini 分组
-    if (props.platform === 'antigravity' && props.mixedScheduling) {
+    if (props.platform === PLATFORM_ANTIGRAVITY && props.mixedScheduling) {
       result = result.filter(
-        (g) => g.platform === 'antigravity' || g.platform === 'anthropic' || g.platform === 'gemini'
+        (g) => g.platform === PLATFORM_ANTIGRAVITY || g.platform === PLATFORM_ANTHROPIC || g.platform === PLATFORM_GEMINI
       )
     } else {
       // 默认：只能选择同 platform 的分组

--- a/frontend/src/components/common/PlatformTypeBadge.vue
+++ b/frontend/src/components/common/PlatformTypeBadge.vue
@@ -60,6 +60,7 @@ import { getPlatformLabel } from '@/composables/usePlatformOptions'
 import type { AccountPlatform, AccountType } from '@/types'
 import PlatformIcon from './PlatformIcon.vue'
 import Icon from '@/components/icons/Icon.vue'
+import { PLATFORM_ANTIGRAVITY, PLATFORM_OPENAI, tkAdminPlatformSoftBadgeClass } from '@/constants/gatewayPlatforms'
 
 const { t } = useI18n()
 
@@ -116,46 +117,9 @@ const planLabel = computed(() => {
   }
 })
 
-// Color map mirrors GATEWAY_PLATFORMS color hints — keep both classes (700 / 600)
-// in sync if a new platform is added. `gemini` keeps the historic blue, and
-// truly unknown platforms fall back to a neutral gray so we never silently mislabel.
-const platformClass = computed(() => {
-  switch (props.platform) {
-    case 'anthropic':
-      return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
-    case 'openai':
-      return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-    case 'gemini':
-      return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-    case 'antigravity':
-      return 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
-    case 'newapi':
-      return 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400'
-    case 'grok':
-      return 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300'
-    default:
-      return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
-  }
-})
+const platformClass = computed(() => tkAdminPlatformSoftBadgeClass(props.platform))
 
-const typeClass = computed(() => {
-  switch (props.platform) {
-    case 'anthropic':
-      return 'bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400'
-    case 'openai':
-      return 'bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400'
-    case 'gemini':
-      return 'bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400'
-    case 'antigravity':
-      return 'bg-purple-100 text-purple-600 dark:bg-purple-900/30 dark:text-purple-400'
-    case 'newapi':
-      return 'bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400'
-    case 'grok':
-      return 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'
-    default:
-      return 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
-  }
-})
+const typeClass = computed(() => tkAdminPlatformSoftBadgeClass(props.platform))
 
 const planBadgeClass = computed(() => {
   if (props.planType && props.planType.toLowerCase() === 'abnormal') {
@@ -184,7 +148,7 @@ const expiresLabel = computed(() => {
 const privacyBadge = computed(() => {
   if (props.type !== 'oauth' || !props.privacyMode) return null
   // 支持 OpenAI 和 Antigravity 平台
-  if (props.platform !== 'openai' && props.platform !== 'antigravity') return null
+  if (props.platform !== PLATFORM_OPENAI && props.platform !== PLATFORM_ANTIGRAVITY) return null
 
   const shieldCheck = 'M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z'
   const shieldX = 'M12 9v3.75m0-10.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285zM12 18h.008v.008H12V18z'

--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -234,6 +234,7 @@ import {
   type UseKeyFlavor,
 } from '@/composables/useTkUseKey'
 import type { GroupPlatform } from '@/types'
+import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI, PLATFORM_GROK, PLATFORM_NEWAPI, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 interface Props {
   show: boolean
@@ -378,7 +379,7 @@ function formatCtx(n?: number): string {
 // 本指南不做 gemini_text/gemini_image 的逐模型细分（那只在后端 /models 生效）。
 // 空/未传 = 不限制（向后兼容旧分组）。非 antigravity 平台不受影响。
 const antigravityClaudeAllowed = computed(() => {
-  if (props.platform !== 'antigravity') return true
+  if (props.platform !== PLATFORM_ANTIGRAVITY) return true
   const scopes = props.supportedModelScopes
   if (!scopes || scopes.length === 0) return true
   return scopes.includes('claude')
@@ -574,7 +575,7 @@ const currentTabs = computed(() => {
 // instructions are identical (codex CLI + opencode), and our gateway already
 // routes both platforms through the OpenAI-compat handlers.
 const isOpenAICompatPlatform = computed(
-  () => props.platform === 'openai' || props.platform === 'newapi' || props.platform === 'grok',
+  () => props.platform === PLATFORM_OPENAI || props.platform === PLATFORM_NEWAPI || props.platform === PLATFORM_GROK,
 )
 
 const platformDescription = computed(() => {
@@ -690,7 +691,7 @@ const currentFiles = computed((): FileConfig[] => {
   // flavor. base / auth / endpoint / body shape are all correct-by-construction.
   if (activeClientTab.value === 'curl' || activeClientTab.value === 'python') {
     const flavor = activeFlavor.value ?? 'anthropic'
-    const isAntigravity = props.platform === 'antigravity'
+    const isAntigravity = props.platform === PLATFORM_ANTIGRAVITY
     return activeClientTab.value === 'curl'
       ? [generateCurl(flavor, baseRoot, apiKey, model, isAntigravity)]
       : [generatePython(flavor, baseRoot, apiKey, model, isAntigravity)]
@@ -717,7 +718,7 @@ const currentFiles = computed((): FileConfig[] => {
     case 'gemini':
       return [generateGeminiCliContent(baseUrl, apiKey, model)]
     case 'antigravity':
-      if (activeClientTab.value === 'gemini') {
+      if (activeClientTab.value === PLATFORM_GEMINI) {
         return [generateGeminiCliContent(`${baseUrl}/antigravity`, apiKey, model)]
       }
       return generateAnthropicFiles(`${baseUrl}/antigravity`, apiKey, model)
@@ -959,7 +960,7 @@ function generateCurl(
   isAntigravity: boolean,
 ): FileConfig {
   const agPrefix = isAntigravity ? '/antigravity' : ''
-  if (flavor === 'anthropic') {
+  if (flavor === PLATFORM_ANTHROPIC) {
     const envModel = anthropicEnvModel(model)
     return {
       path: 'cURL',
@@ -974,7 +975,7 @@ function generateCurl(
   }'`,
     }
   }
-  if (flavor === 'gemini') {
+  if (flavor === PLATFORM_GEMINI) {
     return {
       path: 'cURL',
       content: `curl "${baseRoot}${agPrefix}/v1beta/models/${model}:generateContent" \\
@@ -1006,7 +1007,7 @@ function generatePython(
   isAntigravity: boolean,
 ): FileConfig {
   const agPrefix = isAntigravity ? '/antigravity' : ''
-  if (flavor === 'anthropic') {
+  if (flavor === PLATFORM_ANTHROPIC) {
     const envModel = anthropicEnvModel(model)
     return {
       path: 'Python (anthropic SDK)',
@@ -1021,7 +1022,7 @@ msg = client.messages.create(
 print(msg.content[0].text)`,
     }
   }
-  if (flavor === 'gemini') {
+  if (flavor === PLATFORM_GEMINI) {
     return {
       path: 'Python (requests)',
       content: `import requests
@@ -1461,10 +1462,10 @@ function generateOpenCodeConfig(platform: string, baseUrl: string, apiKey: strin
     }
   }
 
-  if (platform === 'gemini') {
+  if (platform === PLATFORM_GEMINI) {
     provider[platform].npm = '@ai-sdk/google'
     provider[platform].models = geminiModels
-  } else if (platform === 'anthropic') {
+  } else if (platform === PLATFORM_ANTHROPIC) {
     provider[platform].npm = '@ai-sdk/anthropic'
   } else if (platform === 'antigravity-claude') {
     provider[platform].npm = '@ai-sdk/anthropic'
@@ -1474,12 +1475,12 @@ function generateOpenCodeConfig(platform: string, baseUrl: string, apiKey: strin
     provider[platform].npm = '@ai-sdk/google'
     provider[platform].name = 'Antigravity (Gemini)'
     provider[platform].models = antigravityGeminiModels
-  } else if (platform === 'openai') {
+  } else if (platform === PLATFORM_OPENAI) {
     provider[platform].models = openaiModels
   }
 
   const agent =
-    platform === 'openai'
+    platform === PLATFORM_OPENAI
       ? {
           build: {
             options: {

--- a/frontend/src/components/payment/SubscriptionPlanCard.vue
+++ b/frontend/src/components/payment/SubscriptionPlanCard.vue
@@ -105,6 +105,8 @@ import type { SubscriptionPlan } from '@/types/payment'
 import type { UserSubscription } from '@/types'
 import { useAppStore } from '@/stores/app'
 import { hasPeakRate as groupHasPeakRate, formatPeakRateWindow, serverTimezoneLabel } from '@/utils/peak-rate'
+import { PLATFORM_ANTIGRAVITY } from '@/constants/gatewayPlatforms'
+import { STATUS_ACTIVE } from '@/constants/channel'
 import {
   platformAccentBarClass,
   platformBadgeLightClass,
@@ -122,7 +124,7 @@ const { t } = useI18n()
 
 const platform = computed(() => props.plan.group_platform || '')
 const isRenewal = computed(() =>
-  props.activeSubscriptions?.some(s => s.group_id === props.plan.group_id && s.status === 'active') ?? false
+  props.activeSubscriptions?.some(s => s.group_id === props.plan.group_id && s.status === STATUS_ACTIVE) ?? false
 )
 
 // Derived color classes from central config
@@ -161,7 +163,7 @@ const MODEL_SCOPE_LABELS: Record<string, string> = {
 }
 
 const modelScopeLabels = computed(() => {
-  if (platform.value !== 'antigravity') return []
+  if (platform.value !== PLATFORM_ANTIGRAVITY) return []
   const scopes = props.plan.supported_model_scopes
   if (!scopes || scopes.length === 0) return []
   return scopes.map(s => MODEL_SCOPE_LABELS[s] || s)

--- a/frontend/src/components/user/PlatformUsageBreakdown.vue
+++ b/frontend/src/components/user/PlatformUsageBreakdown.vue
@@ -46,6 +46,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/icons/Icon.vue'
+import { getPlatformLabel } from '@/composables/usePlatformOptions'
 import type { PlatformUsage } from '@/api/admin/dashboard'
 
 const props = defineProps<{
@@ -90,14 +91,7 @@ const sortedBreakdown = computed<BreakdownRow[]>(() => {
 
 const hasBreakdown = computed(() => sortedBreakdown.value.length > 0)
 
-const PLATFORM_LABELS: Record<string, string> = {
-  anthropic: 'Claude',
-  openai: 'OpenAI',
-  gemini: 'Gemini',
-  antigravity: 'Antigravity'
-}
-
 function platformLabel(platform: string): string {
-  return PLATFORM_LABELS[platform] ?? platform
+  return getPlatformLabel(platform)
 }
 </script>

--- a/frontend/src/components/user/dashboard/UserDashboardStats.vue
+++ b/frontend/src/components/user/dashboard/UserDashboardStats.vue
@@ -224,6 +224,8 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/icons/Icon.vue'
+import { getPlatformLabel } from '@/composables/usePlatformOptions'
+import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
 import type { UserDashboardStats as UserStatsType } from '@/api/usage'
 import type { PlatformQuotaItem } from '@/types'
 
@@ -245,14 +247,7 @@ const props = defineProps<{
 }>()
 const { t } = useI18n()
 
-const PLATFORM_LABELS: Record<string, string> = {
-  anthropic: 'Claude',
-  openai: 'OpenAI',
-  gemini: 'Gemini',
-  antigravity: 'Antigravity'
-}
-
-const platformLabel = (p: string) => PLATFORM_LABELS[p] ?? p
+const platformLabel = (p: string) => getPlatformLabel(p)
 
 const sortedPlatforms = computed(() => {
   const list = props.stats?.by_platform ?? []
@@ -276,7 +271,7 @@ const platformCards = computed<FusedPlatformCard[]>(() => {
   // 无需显式排除；__other__ 由下方差值补差逻辑单独追加。
   const platforms = new Set<string>([...byPlat.keys(), ...byQuota.keys()])
 
-  const PLATFORM_ORDER = ['anthropic', 'openai', 'gemini', 'antigravity', 'grok']
+  const PLATFORM_ORDER: readonly string[] = GATEWAY_PLATFORMS
   const cards: FusedPlatformCard[] = []
 
   for (const p of platforms) {

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -349,6 +349,7 @@ const bedrockPresetMappings = [
 // 使用 fetchAntigravityDefaultMappings() 异步获取
 import { getAntigravityDefaultModelMapping } from '@/api/admin/accounts'
 import { isApiBackedPlatform, servableModelsFor } from '@/composables/useServableModels'
+import { PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI, PLATFORM_GROK, PLATFORM_NEWAPI, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 let _antigravityDefaultMappingsCache: { from: string; to: string }[] | null = null
 
@@ -417,11 +418,11 @@ export function getModelsByPlatform(platform: string): string[] {
 
 // 按平台获取预设映射
 export function getPresetMappingsByPlatform(platform: string) {
-  if (platform === 'openai') return openaiPresetMappings
-  if (platform === 'newapi') return newapiPresetMappings
-  if (platform === 'gemini') return geminiPresetMappings
-  if (platform === 'grok' || platform === 'xai') return grokPresetMappings
-  if (platform === 'antigravity') return antigravityPresetMappings
+  if (platform === PLATFORM_OPENAI) return openaiPresetMappings
+  if (platform === PLATFORM_NEWAPI) return newapiPresetMappings
+  if (platform === PLATFORM_GEMINI) return geminiPresetMappings
+  if (platform === PLATFORM_GROK || platform === 'xai') return grokPresetMappings
+  if (platform === PLATFORM_ANTIGRAVITY) return antigravityPresetMappings
   if (platform === 'bedrock') return bedrockPresetMappings
   return anthropicPresetMappings
 }

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -321,14 +321,28 @@ const antigravityPresetMappings = [
 
 // Bedrock 预设映射（与后端 DefaultBedrockModelMapping 保持一致）
 const bedrockPresetMappings = [
+  // Claude Fable
   { label: 'Fable 5', from: 'claude-fable-5', to: 'anthropic.claude-fable-5', color: 'bg-rose-100 text-rose-700 hover:bg-rose-200 dark:bg-rose-900/30 dark:text-rose-400' },
-  { label: 'Opus 4.6', from: 'claude-opus-4-6', to: 'us.anthropic.claude-opus-4-6-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
-  { label: 'Opus 4.7', from: 'claude-opus-4-7', to: 'us.anthropic.claude-opus-4-7-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  // Claude Opus
   { label: 'Opus 4.8', from: 'claude-opus-4-8', to: 'us.anthropic.claude-opus-4-8-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  { label: 'Opus 4.7', from: 'claude-opus-4-7', to: 'us.anthropic.claude-opus-4-7-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  { label: 'Opus 4.6-thinking', from: 'claude-opus-4-6-thinking', to: 'us.anthropic.claude-opus-4-6-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  { label: 'Opus 4.6', from: 'claude-opus-4-6', to: 'us.anthropic.claude-opus-4-6-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  { label: 'Opus 4.5-thinking', from: 'claude-opus-4-5-thinking', to: 'us.anthropic.claude-opus-4-5-20251101-v1:0', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  { label: 'Opus 4.5-20251101', from: 'claude-opus-4-5-20251101', to: 'us.anthropic.claude-opus-4-5-20251101-v1:0', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  { label: 'Opus 4.1', from: 'claude-opus-4-1', to: 'us.anthropic.claude-opus-4-1-20250805-v1:0', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  { label: 'Opus 4', from: 'claude-opus-4-20250514', to: 'us.anthropic.claude-opus-4-20250514-v1:0', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  // Claude Sonnet
+  { label: 'Sonnet 5', from: 'claude-sonnet-5', to: 'us.anthropic.claude-sonnet-5-v1', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
+  { label: 'Sonnet 4.6-thinking', from: 'claude-sonnet-4-6-thinking', to: 'us.anthropic.claude-sonnet-4-6', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
   { label: 'Sonnet 4.6', from: 'claude-sonnet-4-6', to: 'us.anthropic.claude-sonnet-4-6', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
-  { label: 'Opus 4.5', from: 'claude-opus-4-5-thinking', to: 'us.anthropic.claude-opus-4-5-20251101-v1:0', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
   { label: 'Sonnet 4.5', from: 'claude-sonnet-4-5', to: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
+  { label: 'Sonnet 4.5-thinking', from: 'claude-sonnet-4-5-thinking', to: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
+  { label: 'Sonnet 4.5-20250929', from: 'claude-sonnet-4-5-20250929', to: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
+  { label: 'Sonnet 4', from: 'claude-sonnet-4-20250514', to: 'us.anthropic.claude-sonnet-4-20250514-v1:0', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
+  // Claude Haiku
   { label: 'Haiku 4.5', from: 'claude-haiku-4-5', to: 'us.anthropic.claude-haiku-4-5-20251001-v1:0', color: 'bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-400' },
+  { label: 'Haiku 4.5-20251001', from: 'claude-haiku-4-5-20251001', to: 'us.anthropic.claude-haiku-4-5-20251001-v1:0', color: 'bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-400' },
 ]
 
 // Antigravity 默认映射（从后端 API 获取，与 constants.go 保持一致）

--- a/frontend/src/composables/useTkAccountNewApiPlatform.ts
+++ b/frontend/src/composables/useTkAccountNewApiPlatform.ts
@@ -20,8 +20,8 @@ import { unknownToErrorMessage } from '@/utils/authError'
 export interface UseTkAccountNewApiPlatformOptions {
   /**
    * 当前 modal 是否真的处在 newapi 平台上下文：
-   *   - CreateAccountModal: () => form.platform === 'newapi'
-   *   - EditAccountModal:   () => account.platform === 'newapi'
+   *   - CreateAccountModal: () => form.platform === PLATFORM_NEWAPI
+   *   - EditAccountModal:   () => account.platform === PLATFORM_NEWAPI
    * 只读 getter 而非 boolean，方便随父组件状态变化。
    */
   isNewapi: () => boolean

--- a/frontend/src/composables/useTkUseKey.ts
+++ b/frontend/src/composables/useTkUseKey.ts
@@ -24,6 +24,7 @@
 import { computed, ref, type Ref } from 'vue'
 import { getMePricingCatalog, type MePricingModel } from '@/api/me-pricing'
 import type { GroupPlatform } from '@/types'
+import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI } from '@/constants/gatewayPlatforms'
 
 /**
  * A snippet "flavor" is the single-model protocol a given client tab speaks.
@@ -164,7 +165,7 @@ export function useTkUseKey(args: UseTkUseKeyArgs) {
   }
 
   const isClaudeCodeOnly = computed(
-    () => args.platform.value === 'anthropic' && args.claudeCodeOnly.value === true,
+    () => args.platform.value === PLATFORM_ANTHROPIC && args.claudeCodeOnly.value === true,
   )
 
   function cancelTest(): void {
@@ -197,8 +198,8 @@ export function useTkUseKey(args: UseTkUseKeyArgs) {
     if (keyOnly) {
       url = `${root}/v1/models`
       init = { method: 'GET', headers: { Authorization: `Bearer ${key}`, Accept: 'application/json' }, signal: ctrl.signal }
-    } else if (flavor === 'anthropic') {
-      const isAntigravity = args.platform.value === 'antigravity'
+    } else if (flavor === PLATFORM_ANTHROPIC) {
+      const isAntigravity = args.platform.value === PLATFORM_ANTIGRAVITY
       url = `${root}${isAntigravity ? '/antigravity' : ''}/v1/messages`
       init = {
         method: 'POST',
@@ -212,8 +213,8 @@ export function useTkUseKey(args: UseTkUseKeyArgs) {
         body: JSON.stringify({ model, max_tokens: 16, messages: [{ role: 'user', content: 'ping' }] }),
         signal: ctrl.signal,
       }
-    } else if (flavor === 'gemini') {
-      const isAntigravity = args.platform.value === 'antigravity'
+    } else if (flavor === PLATFORM_GEMINI) {
+      const isAntigravity = args.platform.value === PLATFORM_ANTIGRAVITY
       const gBase = `${root}${isAntigravity ? '/antigravity' : ''}/v1beta`
       url = `${gBase}/models/${encodeURIComponent(model)}:generateContent`
       init = {

--- a/frontend/src/constants/channel.ts
+++ b/frontend/src/constants/channel.ts
@@ -3,6 +3,10 @@ export const CHANNEL_STATUS_ACTIVE = 'active' as const
 export const CHANNEL_STATUS_DISABLED = 'disabled' as const
 export type ChannelStatus = typeof CHANNEL_STATUS_ACTIVE | typeof CHANNEL_STATUS_DISABLED
 
+/** Generic status aliases — usable across entity types (users, groups, keys, accounts). */
+export const STATUS_ACTIVE = CHANNEL_STATUS_ACTIVE
+export const STATUS_DISABLED = CHANNEL_STATUS_DISABLED
+
 /** Billing mode values (must match service.BillingMode* constants in Go). */
 export const BILLING_MODE_TOKEN = 'token' as const
 export const BILLING_MODE_PER_REQUEST = 'per_request' as const

--- a/frontend/src/constants/mirrorPlatformOptions.tk.ts
+++ b/frontend/src/constants/mirrorPlatformOptions.tk.ts
@@ -1,3 +1,4 @@
+import { PLATFORM_KIRO } from '@/constants/gatewayPlatforms'
 // TokenKey-only. An anthropic + apikey "mirror stub" relays prod traffic to an
 // edge node (credentials.base_url points at an internal api-<edge>.tokenkey.dev
 // host). credentials.mirror_platform declares WHICH edge pool's live Σ schedulable
@@ -25,5 +26,5 @@ export const MIRROR_PLATFORM_OPTIONS: MirrorPlatformOption[] = [
 
 // normalizeMirrorPlatform mirrors the backend default: empty / unknown → 'anthropic'.
 export function normalizeMirrorPlatform(raw: unknown): MirrorPlatform {
-  return raw === 'kiro' ? 'kiro' : 'anthropic'
+  return raw === PLATFORM_KIRO ? 'kiro' : 'anthropic'
 }

--- a/frontend/src/constants/newApiUpstreamFetchableChannelTypes.ts
+++ b/frontend/src/constants/newApiUpstreamFetchableChannelTypes.ts
@@ -3,7 +3,7 @@
  * aligned with new-api `web/src/constants/channel.constants.js` MODEL_FETCHABLE_CHANNEL_TYPES.
  */
 export const NEW_API_UPSTREAM_FETCHABLE_CHANNEL_TYPES = new Set<number>([
-  1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43, 45
+  1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43, 45, 54
 ])
 
 export function isNewApiUpstreamFetchableChannelType(channelType: number): boolean {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1385,7 +1385,7 @@ export interface OpenAICodexPATCreateRequest {
 
 // ==================== Usage & Redeem Types ====================
 
-export type RedeemCodeType = 'balance' | 'concurrency' | 'subscription' | 'invitation'
+export type RedeemCodeType = 'balance' | 'concurrency' | 'subscription' | 'invitation' | 'affiliate_balance'
 export type UsageRequestType = 'unknown' | 'sync' | 'stream' | 'ws_v2' | 'cyber'
 export type ImageSizeSource = 'output' | 'input' | 'default' | 'legacy'
 export type ImageSizeBreakdown = Record<string, number>
@@ -1755,28 +1755,24 @@ export interface UserSubscription {
   group?: Group
 }
 
+export interface UsageWindowProgress {
+  limit_usd: number
+  used_usd: number
+  remaining_usd: number
+  percentage: number
+  window_start: string
+  resets_at: string
+  resets_in_seconds: number
+}
+
 export interface SubscriptionProgress {
-  subscription_id: number
-  daily: {
-    used: number
-    limit: number | null
-    percentage: number
-    reset_in_seconds: number | null
-  } | null
-  weekly: {
-    used: number
-    limit: number | null
-    percentage: number
-    reset_in_seconds: number | null
-  } | null
-  monthly: {
-    used: number
-    limit: number | null
-    percentage: number
-    reset_in_seconds: number | null
-  } | null
-  expires_at: string | null
-  days_remaining: number | null
+  id: number
+  group_name: string
+  expires_at: string
+  expires_in_days: number
+  daily?: UsageWindowProgress | null
+  weekly?: UsageWindowProgress | null
+  monthly?: UsageWindowProgress | null
 }
 
 export interface AssignSubscriptionRequest {

--- a/frontend/src/utils/accountPlatformFilters.ts
+++ b/frontend/src/utils/accountPlatformFilters.ts
@@ -1,4 +1,5 @@
 import type { Account } from '@/types'
+import { PLATFORM_ANTHROPIC, PLATFORM_KIRO } from '@/constants/gatewayPlatforms'
 
 export const ACCOUNT_KIRO_STUB_PLATFORM_FILTER = '__kiro_stub__'
 
@@ -11,9 +12,9 @@ export function isKiroRelayStubAccount(account: Account): boolean {
       ? account.credentials.mirror_platform.trim().toLowerCase()
       : ''
   return (
-    account.platform === 'anthropic' &&
+    account.platform === PLATFORM_ANTHROPIC &&
     account.type === 'apikey' &&
-    mirrorPlatform === 'kiro' &&
+    mirrorPlatform === PLATFORM_KIRO &&
     ACCOUNT_EDGE_BASE_URL_PATTERN.test(baseUrl)
   )
 }
@@ -23,8 +24,8 @@ export function accountMatchesPlatformFilter(account: Account, platform: string)
   if (platform === ACCOUNT_KIRO_STUB_PLATFORM_FILTER) {
     return isKiroRelayStubAccount(account)
   }
-  if (platform === 'kiro') {
-    return account.platform === 'kiro' || isKiroRelayStubAccount(account)
+  if (platform === PLATFORM_KIRO) {
+    return account.platform === PLATFORM_KIRO || isKiroRelayStubAccount(account)
   }
   return account.platform === platform
 }

--- a/frontend/src/utils/accountUsageBatch.tk.ts
+++ b/frontend/src/utils/accountUsageBatch.tk.ts
@@ -5,20 +5,21 @@
  * POST /admin/accounts/usage/batch (mirrors backend GetPassiveUsageBatch gates).
  */
 import type { Account } from '@/types'
+import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI, PLATFORM_GROK, PLATFORM_KIRO, PLATFORM_NEWAPI, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 /** Accounts whose upstream adapter reports TokenKey-local 5h/7d billing windows. */
 export function usesLocalUsageWindows(account: Account): boolean {
-  if (account.platform === 'newapi' || account.platform === 'grok') return true
-  return account.platform === 'antigravity' && account.type !== 'oauth'
+  if (account.platform === PLATFORM_NEWAPI || account.platform === PLATFORM_GROK) return true
+  return account.platform === PLATFORM_ANTIGRAVITY && account.type !== 'oauth'
 }
 
 /** Rows whose list load is satisfied by the batch passive endpoint (no mount fan-out). */
 export function isBatchPassiveCapable(account: Account): boolean {
-  if (account.platform === 'kiro') return true
-  if (account.platform === 'openai' && account.type === 'oauth') return true
+  if (account.platform === PLATFORM_KIRO) return true
+  if (account.platform === PLATFORM_OPENAI && account.type === 'oauth') return true
   if (usesLocalUsageWindows(account)) return true
   return (
-    account.platform === 'anthropic' &&
+    account.platform === PLATFORM_ANTHROPIC &&
     (account.type === 'oauth' || account.type === 'setup-token')
   )
 }
@@ -31,6 +32,6 @@ export function usesPassiveUsageOnMount(account: Account): boolean {
 /** Whether AccountUsageCell may ever load usage for this account. */
 export function canSelfFetchUsage(account: Account): boolean {
   if (isBatchPassiveCapable(account)) return true
-  if (account.platform === 'gemini') return true
-  return account.platform === 'antigravity' && account.type === 'oauth'
+  if (account.platform === PLATFORM_GEMINI) return true
+  return account.platform === PLATFORM_ANTIGRAVITY && account.type === 'oauth'
 }

--- a/frontend/src/utils/accountUsageRefresh.ts
+++ b/frontend/src/utils/accountUsageRefresh.ts
@@ -1,4 +1,5 @@
 import type { Account } from '@/types'
+import { PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
 const normalizeUsageRefreshValue = (value: unknown): string => {
   if (value == null) return ''
@@ -6,7 +7,7 @@ const normalizeUsageRefreshValue = (value: unknown): string => {
 }
 
 export const buildOpenAIUsageRefreshKey = (account: Pick<Account, 'id' | 'platform' | 'type' | 'updated_at' | 'last_used_at' | 'rate_limit_reset_at' | 'extra'>): string => {
-  if (account.platform !== 'openai' || account.type !== 'oauth') {
+  if (account.platform !== PLATFORM_OPENAI || account.type !== 'oauth') {
     return ''
   }
 

--- a/frontend/src/utils/ccswitchImport.ts
+++ b/frontend/src/utils/ccswitchImport.ts
@@ -1,4 +1,5 @@
 import type { GroupPlatform } from '@/types'
+import { PLATFORM_GEMINI } from '@/constants/gatewayPlatforms'
 
 export const OPENAI_CC_SWITCH_CODEX_MODEL = 'gpt-5.5'
 
@@ -27,7 +28,7 @@ export function resolveCcSwitchImportConfig(
   switch (platform || 'anthropic') {
     case 'antigravity':
       return {
-        app: clientType === 'gemini' ? 'gemini' : 'claude',
+        app: clientType === PLATFORM_GEMINI ? 'gemini' : 'claude',
         endpoint: `${baseUrl}/antigravity`
       }
     case 'openai':

--- a/frontend/src/utils/channelFormConversion.ts
+++ b/frontend/src/utils/channelFormConversion.ts
@@ -28,7 +28,7 @@ import {
   mTokToPerToken,
   perTokenToMTok,
 } from '@/components/admin/channel/types'
-import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
+import { GATEWAY_PLATFORMS, PLATFORM_ANTHROPIC, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 import type { AdminGroup, GroupPlatform } from '@/types'
 
 /** Form-level pricing rule (per-platform sub-rule rendered inside a section). */
@@ -214,7 +214,7 @@ export function formSectionsToApi(
   const wsEmulation: Record<string, boolean> = {}
   for (const section of sections) {
     if (!section.enabled) continue
-    if (section.platform === 'anthropic') {
+    if (section.platform === PLATFORM_ANTHROPIC) {
       wsEmulation[section.platform] = !!section.web_search_emulation
     }
   }
@@ -227,7 +227,7 @@ export function formSectionsToApi(
   const codexImageGenerationBridge: Record<string, boolean> = {}
   for (const section of sections) {
     if (!section.enabled) continue
-    if (section.platform === 'openai') {
+    if (section.platform === PLATFORM_OPENAI) {
       codexImageGenerationBridge[section.platform] =
         !!section.codex_image_generation_bridge
     }
@@ -244,7 +244,7 @@ export function formSectionsToApi(
   let bedrockCCCompatEnabled: boolean | undefined
   for (const section of sections) {
     if (!section.enabled) continue
-    if (section.platform === 'anthropic') {
+    if (section.platform === PLATFORM_ANTHROPIC) {
       bedrockCCCompatEnabled = !!section.bedrock_cc_compat
     }
   }

--- a/frontend/src/utils/edgeAccounts.tk.ts
+++ b/frontend/src/utils/edgeAccounts.tk.ts
@@ -7,6 +7,7 @@
 
 import type { EdgeAccountSummary, EdgeAccountsResult } from '@/api/admin/edgeAccounts'
 import type { Account, WindowStats, AccountUsageInfo } from '@/types'
+import { STATUS_ACTIVE } from '@/constants/channel'
 
 /**
  * Count of effectively-schedulable accounts in an edge slice.
@@ -200,7 +201,7 @@ function isFuture(ts?: string | null): boolean {
  */
 export function matchesStatusFilter(s: EdgeStatusBearing, status: string): boolean {
   if (!status || status === EDGE_STATUS_ALL) return true
-  const active = s.status === 'active'
+  const active = s.status === STATUS_ACTIVE
   const rateLimited = isFuture(s.rate_limit_reset_at)
   const tempUnsched = isFuture(s.temp_unschedulable_until)
   switch (status) {
@@ -267,8 +268,8 @@ export function matchesCombinedStatusFilter(
 ): boolean {
   if (!status || status === EDGE_STATUS_ALL) return true
   const stub = edgeStubStatusBearing(edge)
-  if (status === 'active') {
-    return matchesStatusFilter(stub, 'active') && matchesStatusFilter(account, 'active')
+  if (status === STATUS_ACTIVE) {
+    return matchesStatusFilter(stub, STATUS_ACTIVE) && matchesStatusFilter(account, STATUS_ACTIVE)
   }
   return matchesStatusFilter(stub, status) || matchesStatusFilter(account, status)
 }
@@ -281,7 +282,7 @@ export function matchesCombinedStatusFilter(
  */
 export function matchesStubOnlyStatusFilter(edge: EdgeAccountsResult, status: string): boolean {
   if (!status || status === EDGE_STATUS_ALL) return true
-  if (status === 'active') return false
+  if (status === STATUS_ACTIVE) return false
   return matchesStatusFilter(edgeStubStatusBearing(edge), status)
 }
 

--- a/frontend/src/utils/platformColors.ts
+++ b/frontend/src/utils/platformColors.ts
@@ -4,13 +4,14 @@
  * All components that need platform-specific styling should import from here
  * instead of defining their own color mappings.
  *
- * `newapi` (the fifth gateway platform) uses cyan throughout, matching
- * `gatewayPlatforms.ts` (line 14, 30, 38). Adding a new platform must extend
- * the `Platform` union type below + every variant map; TypeScript's exhaustive
+ * `Platform` is derived from `GATEWAY_PLATFORMS` so it stays in sync
+ * automatically when a new platform is added. TypeScript's exhaustive
  * `Record<Platform, …>` guarantees the compiler will reject silent omissions.
  */
 
-export type Platform = 'anthropic' | 'openai' | 'antigravity' | 'gemini' | 'newapi' | 'grok'
+import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
+
+export type Platform = (typeof GATEWAY_PLATFORMS)[number]
 
 // ── Badge (bg + text + border, for inline badges with border) ───────
 const BADGE: Record<Platform, string> = {
@@ -19,6 +20,7 @@ const BADGE: Record<Platform, string> = {
   antigravity: 'bg-purple-500/10 text-purple-600 border-purple-500/30 dark:text-purple-400',
   gemini: 'bg-blue-500/10 text-blue-600 border-blue-500/30 dark:text-blue-400',
   newapi: 'bg-cyan-500/10 text-cyan-600 border-cyan-500/30 dark:text-cyan-400',
+  kiro: 'bg-teal-500/10 text-teal-600 border-teal-500/30 dark:text-teal-400',
   grok: 'bg-zinc-800/10 text-zinc-800 border-zinc-800/30 dark:bg-zinc-500/10 dark:text-zinc-200 dark:border-zinc-500/30',
 }
 const BADGE_DEFAULT = 'bg-slate-500/10 text-slate-600 border-slate-500/30 dark:text-slate-400'
@@ -30,6 +32,7 @@ const BADGE_LIGHT: Record<Platform, string> = {
   antigravity: 'bg-purple-500/10 text-purple-600 dark:bg-purple-500/10 dark:text-purple-300',
   gemini: 'bg-blue-500/10 text-blue-600 dark:bg-blue-500/10 dark:text-blue-300',
   newapi: 'bg-cyan-500/10 text-cyan-600 dark:bg-cyan-500/10 dark:text-cyan-300',
+  kiro: 'bg-teal-500/10 text-teal-600 dark:bg-teal-500/10 dark:text-teal-300',
   grok: 'bg-zinc-800/10 text-zinc-800 dark:bg-zinc-500/10 dark:text-zinc-200',
 }
 
@@ -40,6 +43,7 @@ const BORDER: Record<Platform, string> = {
   antigravity: 'border-purple-500/20 dark:border-purple-500/20',
   gemini: 'border-blue-500/20 dark:border-blue-500/20',
   newapi: 'border-cyan-500/20 dark:border-cyan-500/20',
+  kiro: 'border-teal-500/20 dark:border-teal-500/20',
   grok: 'border-zinc-800/20 dark:border-zinc-500/20',
 }
 const BORDER_DEFAULT = 'border-gray-200 dark:border-dark-700'
@@ -51,6 +55,7 @@ const ACCENT_BAR: Record<Platform, string> = {
   antigravity: 'bg-gradient-to-r from-purple-400 to-purple-500',
   gemini: 'bg-gradient-to-r from-blue-400 to-blue-500',
   newapi: 'bg-gradient-to-r from-cyan-400 to-cyan-500',
+  kiro: 'bg-gradient-to-r from-teal-400 to-teal-500',
   grok: 'bg-gradient-to-r from-zinc-700 to-zinc-900',
 }
 const ACCENT_BAR_DEFAULT = 'bg-gradient-to-r from-primary-400 to-primary-500'
@@ -62,6 +67,7 @@ const TEXT: Record<Platform, string> = {
   antigravity: 'text-purple-600 dark:text-purple-400',
   gemini: 'text-blue-600 dark:text-blue-400',
   newapi: 'text-cyan-600 dark:text-cyan-400',
+  kiro: 'text-teal-600 dark:text-teal-400',
   grok: 'text-zinc-800 dark:text-zinc-200',
 }
 const TEXT_DEFAULT = 'text-primary-600 dark:text-primary-400'
@@ -73,6 +79,7 @@ const ICON: Record<Platform, string> = {
   antigravity: 'text-purple-500 dark:text-purple-400',
   gemini: 'text-blue-500 dark:text-blue-400',
   newapi: 'text-cyan-500 dark:text-cyan-400',
+  kiro: 'text-teal-500 dark:text-teal-400',
   grok: 'text-zinc-800 dark:text-zinc-200',
 }
 const ICON_DEFAULT = 'text-primary-500 dark:text-primary-400'
@@ -84,6 +91,7 @@ const BUTTON: Record<Platform, string> = {
   antigravity: 'bg-purple-500 text-white hover:bg-purple-600 active:bg-purple-700 dark:bg-purple-500/80 dark:hover:bg-purple-500',
   gemini: 'bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 dark:bg-blue-500/80 dark:hover:bg-blue-500',
   newapi: 'bg-cyan-500 text-white hover:bg-cyan-600 active:bg-cyan-700 dark:bg-cyan-500/80 dark:hover:bg-cyan-500',
+  kiro: 'bg-teal-500 text-white hover:bg-teal-600 active:bg-teal-700 dark:bg-teal-500/80 dark:hover:bg-teal-500',
   grok: 'bg-zinc-800 text-white hover:bg-zinc-900 active:bg-black dark:bg-zinc-700 dark:hover:bg-zinc-600',
 }
 const BUTTON_DEFAULT = 'bg-primary-500 text-white hover:bg-primary-600 dark:bg-primary-600 dark:hover:bg-primary-500'
@@ -95,6 +103,7 @@ const DISCOUNT: Record<Platform, string> = {
   antigravity: 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300',
   gemini: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
   newapi: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300',
+  kiro: 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300',
   grok: 'bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200',
 }
 const DISCOUNT_DEFAULT = 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
@@ -106,6 +115,7 @@ const GRADIENT: Record<Platform, string> = {
   antigravity: 'from-purple-500 to-purple-600',
   gemini: 'from-blue-500 to-blue-600',
   newapi: 'from-cyan-500 to-cyan-600',
+  kiro: 'from-teal-500 to-teal-600',
   grok: 'from-zinc-700 to-zinc-900',
 }
 const GRADIENT_DEFAULT = 'from-primary-500 to-primary-600'
@@ -117,6 +127,7 @@ const GRADIENT_TEXT: Record<Platform, string> = {
   antigravity: 'text-purple-100',
   gemini: 'text-blue-100',
   newapi: 'text-cyan-100',
+  kiro: 'text-teal-100',
   grok: 'text-zinc-100',
 }
 const GRADIENT_TEXT_DEFAULT = 'text-primary-100'
@@ -127,6 +138,7 @@ const GRADIENT_SUBTEXT: Record<Platform, string> = {
   antigravity: 'text-purple-200',
   gemini: 'text-blue-200',
   newapi: 'text-cyan-200',
+  kiro: 'text-teal-200',
   grok: 'text-zinc-300',
 }
 const GRADIENT_SUBTEXT_DEFAULT = 'text-primary-200'
@@ -134,14 +146,7 @@ const GRADIENT_SUBTEXT_DEFAULT = 'text-primary-200'
 // ── Public API ──────────────────────────────────────────────────────
 
 function isPlatform(p: string): p is Platform {
-  return (
-    p === 'anthropic' ||
-    p === 'openai' ||
-    p === 'antigravity' ||
-    p === 'gemini' ||
-    p === 'newapi' ||
-    p === 'grok'
-  )
+  return (GATEWAY_PLATFORMS as readonly string[]).includes(p)
 }
 
 export function platformBadgeClass(p: string): string {
@@ -195,6 +200,7 @@ export function platformLabel(p: string): string {
     case 'antigravity': return 'Antigravity'
     case 'gemini': return 'Gemini'
     case 'newapi': return 'Extension Engine'
+    case 'kiro': return 'Kiro'
     case 'grok': return 'Grok'
     default: return p || 'API'
   }

--- a/frontend/src/views/KeyUsageView.vue
+++ b/frontend/src/views/KeyUsageView.vue
@@ -419,6 +419,7 @@ import { useAppStore } from '@/stores'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { buildGatewayUrl } from '@/api/client'
+import { STATUS_ACTIVE } from '@/constants/channel'
 
 const { t, locale } = useI18n()
 const appStore = useAppStore()
@@ -589,7 +590,7 @@ const statusInfo = computed(() => {
     return {
       label: t('keyUsage.quotaMode'),
       statusText: statusMap[data.status] || data.status || 'Unknown',
-      isActive: isValid && data.status === 'active',
+      isActive: isValid && data.status === STATUS_ACTIVE,
     }
   }
 

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -490,6 +490,8 @@ import AccountTableActions from '@/components/admin/account/AccountTableActions.
 import EdgeAccountPanelTk from '@/components/admin/account/EdgeAccountPanelTk.vue'
 import { useTkAccountsEdgePanels } from '@/composables/useTkAccountsEdgePanels'
 import AccountTableFilters from '@/components/admin/account/AccountTableFilters.vue'
+import { STATUS_ACTIVE } from '@/constants/channel'
+import { PLATFORM_ANTIGRAVITY, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 import AccountBulkActionsBar from '@/components/admin/account/AccountBulkActionsBar.vue'
 import AccountActionMenu from '@/components/admin/account/AccountActionMenu.vue'
 const ImportDataModal = defineAsyncComponent(() => import('@/components/admin/account/ImportDataModal.vue'))
@@ -1235,7 +1237,7 @@ const { pause: pauseAutoRefresh, resume: resumeAutoRefresh } = useIntervalFn(
 
 // Antigravity 订阅等级辅助函数
 function getAntigravityTierFromRow(row: any): string | null {
-  if (row.platform !== 'antigravity') return null
+  if (row.platform !== PLATFORM_ANTIGRAVITY) return null
   const extra = row.extra as Record<string, unknown> | undefined
   if (!extra) return null
   const lca = extra.load_code_assist as Record<string, unknown> | undefined
@@ -1264,7 +1266,7 @@ function accountDisplayEmail(row: any): string {
 }
 
 function getOpenAICompactState(row: any): 'supported' | 'unsupported' | 'unknown' | null {
-  if (row.platform !== 'openai' || (row.type !== 'oauth' && row.type !== 'apikey')) return null
+  if (row.platform !== PLATFORM_OPENAI || (row.type !== 'oauth' && row.type !== 'apikey')) return null
   const extra = row.extra as Record<string, unknown> | undefined
   const mode = typeof extra?.openai_compact_mode === 'string' ? extra.openai_compact_mode : 'auto'
   if (mode === 'force_on') return 'supported'
@@ -1666,14 +1668,14 @@ const accountMatchesCurrentFilters = (account: Account) => {
     const tempUnschedUntil = account.temp_unschedulable_until ? new Date(account.temp_unschedulable_until).getTime() : Number.NaN
     const isTempUnschedulable = Number.isFinite(tempUnschedUntil) && tempUnschedUntil > now
 
-    if (filters.status === 'active') {
-      if (account.status !== 'active' || isRateLimited || isTempUnschedulable || !account.schedulable) return false
+    if (filters.status === STATUS_ACTIVE) {
+      if (account.status !== STATUS_ACTIVE || isRateLimited || isTempUnschedulable || !account.schedulable) return false
     } else if (filters.status === 'rate_limited') {
-      if (account.status !== 'active' || !isRateLimited || isTempUnschedulable) return false
+      if (account.status !== STATUS_ACTIVE || !isRateLimited || isTempUnschedulable) return false
     } else if (filters.status === 'temp_unschedulable') {
-      if (account.status !== 'active' || !isTempUnschedulable) return false
+      if (account.status !== STATUS_ACTIVE || !isTempUnschedulable) return false
     } else if (filters.status === 'unschedulable') {
-      if (account.status !== 'active' || account.schedulable || isRateLimited || isTempUnschedulable) return false
+      if (account.status !== STATUS_ACTIVE || account.schedulable || isRateLimited || isTempUnschedulable) return false
     } else if (account.status !== filters.status) {
       return false
     }
@@ -1840,7 +1842,7 @@ const handleResetQuota = async (a: Account) => {
 
 const privacyResultMessageKey = (account: Account): { type: 'success' | 'error'; key: string } => {
   const mode = typeof account.extra?.privacy_mode === 'string' ? account.extra.privacy_mode : ''
-  if (account.platform === 'openai') {
+  if (account.platform === PLATFORM_OPENAI) {
     switch (mode) {
       case 'training_off':
         return { type: 'success', key: 'admin.accounts.privacyTrainingOff' }
@@ -1850,7 +1852,7 @@ const privacyResultMessageKey = (account: Account): { type: 'success' | 'error';
         return { type: 'error', key: 'admin.accounts.privacyFailed' }
     }
   }
-  if (account.platform === 'antigravity') {
+  if (account.platform === PLATFORM_ANTIGRAVITY) {
     if (mode === 'privacy_set') {
       return { type: 'success', key: 'admin.accounts.privacyAntigravitySet' }
     }

--- a/frontend/src/views/admin/AnnouncementsView.vue
+++ b/frontend/src/views/admin/AnnouncementsView.vue
@@ -262,6 +262,7 @@ import Icon from '@/components/icons/Icon.vue'
 
 import AnnouncementTargetingEditor from '@/components/admin/announcements/AnnouncementTargetingEditor.vue'
 import AnnouncementReadStatusDialog from '@/components/admin/announcements/AnnouncementReadStatusDialog.vue'
+import { STATUS_ACTIVE } from '@/constants/channel'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -316,7 +317,7 @@ const columns = computed<Column[]>(() => [
 
 const statusLabel = (status: string) => {
   if (status === 'draft') return t('admin.announcements.statusLabels.draft')
-  if (status === 'active') return t('admin.announcements.statusLabels.active')
+  if (status === STATUS_ACTIVE) return t('admin.announcements.statusLabels.active')
   if (status === 'archived') return t('admin.announcements.statusLabels.archived')
   return status
 }

--- a/frontend/src/views/admin/ChannelsView.vue
+++ b/frontend/src/views/admin/ChannelsView.vue
@@ -637,6 +637,7 @@ import type { AdminGroup, GroupPlatform } from '@/types'
 import type { Column } from '@/components/common/types'
 import { platformTextClass, platformBadgeLightClass } from '@/utils/platformColors'
 import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
+import { STATUS_ACTIVE, STATUS_DISABLED } from '@/constants/channel'
 import {
   apiToFormSections,
   formSectionsToApi,
@@ -1442,7 +1443,7 @@ async function handleSubmit() {
 
 // ── Toggle status ──
 async function toggleChannelStatus(channel: Channel) {
-  const newStatus = channel.status === 'active' ? 'disabled' : 'active'
+  const newStatus = channel.status === STATUS_ACTIVE ? STATUS_DISABLED : STATUS_ACTIVE
   try {
     await adminAPI.channels.update(channel.id, { status: newStatus })
     if (filters.status && filters.status !== newStatus) {

--- a/frontend/src/views/admin/PromoCodesView.vue
+++ b/frontend/src/views/admin/PromoCodesView.vue
@@ -400,6 +400,7 @@ import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import Select from '@/components/common/Select.vue'
 import Icon from '@/components/icons/Icon.vue'
+import { STATUS_ACTIVE } from '@/constants/channel'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -492,7 +493,7 @@ const getStatusClass = (status: string, row: PromoCode) => {
   if (row.max_uses > 0 && row.used_count >= row.max_uses) {
     return 'badge-gray'
   }
-  return status === 'active' ? 'badge-success' : 'badge-gray'
+  return status === STATUS_ACTIVE ? 'badge-success' : 'badge-gray'
 }
 
 const getStatusLabel = (status: string, row: PromoCode) => {
@@ -502,7 +503,7 @@ const getStatusLabel = (status: string, row: PromoCode) => {
   if (row.max_uses > 0 && row.used_count >= row.max_uses) {
     return t('admin.promo.statusMaxUsed')
   }
-  return status === 'active' ? t('admin.promo.statusActive') : t('admin.promo.statusDisabled')
+  return status === STATUS_ACTIVE ? t('admin.promo.statusActive') : t('admin.promo.statusDisabled')
 }
 
 // API calls

--- a/frontend/src/views/admin/RiskControlView.vue
+++ b/frontend/src/views/admin/RiskControlView.vue
@@ -1139,6 +1139,7 @@ import { useAppStore } from '@/stores/app'
 import { extractApiErrorMessage } from '@/utils/apiError'
 import { formatDateTime as formatDateTimeValue } from '@/utils/format'
 import { useVisibilityAwarePoller } from '@/composables/useVisibilityAwarePoller'
+import { STATUS_ACTIVE, STATUS_DISABLED } from '@/constants/channel'
 
 type SettingsTab = 'basic' | 'scope' | 'runtime' | 'response' | 'riskThresholds' | 'retention' | 'keywords'
 type WorkerSlotState = 'active' | 'idle' | 'disabled'
@@ -1864,7 +1865,7 @@ async function loadLogs() {
 }
 
 function canUnbanRow(row: ContentModerationLog): boolean {
-  return Boolean(row.auto_banned && row.user_id && row.user_status === 'disabled')
+  return Boolean(row.auto_banned && row.user_id && row.user_status === STATUS_DISABLED)
 }
 
 function inputSummaryText(row: ContentModerationLog): string {
@@ -2132,7 +2133,7 @@ function resultBadgeClass(row: ContentModerationLog): string {
 }
 
 function workerSlotClass(state: WorkerSlotState): string {
-  if (state === 'active') {
+  if (state === STATUS_ACTIVE) {
     return 'border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/60 dark:bg-sky-900/20 dark:text-sky-300'
   }
   if (state === 'idle') {
@@ -2142,7 +2143,7 @@ function workerSlotClass(state: WorkerSlotState): string {
 }
 
 function workerDotClass(state: WorkerSlotState): string {
-  if (state === 'active') return 'bg-sky-500'
+  if (state === STATUS_ACTIVE) return 'bg-sky-500'
   if (state === 'idle') return 'bg-emerald-500'
   return 'bg-gray-300 dark:bg-dark-500'
 }

--- a/frontend/src/views/admin/SubscriptionsView.vue
+++ b/frontend/src/views/admin/SubscriptionsView.vue
@@ -776,6 +776,7 @@ import GroupBadge from '@/components/common/GroupBadge.vue'
 import GroupOptionItem from '@/components/common/GroupOptionItem.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { getRemainingDurationParts, isOneTimeDailyQuota, type RemainingDurationParts } from '@/utils/subscriptionQuota'
+import { STATUS_ACTIVE } from '@/constants/channel'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -993,7 +994,7 @@ const platformFilterOptions = optionsWithAll(() => t('admin.subscriptions.allPla
 // Group options for assign (only subscription type groups)
 const subscriptionGroupOptions = computed(() =>
   groups.value
-    .filter((g) => g.subscription_type === 'subscription' && g.status === 'active')
+    .filter((g) => g.subscription_type === 'subscription' && g.status === STATUS_ACTIVE)
     .map((g) => ({
       value: g.id,
       label: g.name,

--- a/frontend/src/views/admin/UsersView.vue
+++ b/frontend/src/views/admin/UsersView.vue
@@ -798,6 +798,7 @@ import UserConcurrencyCell from '@/components/user/UserConcurrencyCell.vue'
 import PlatformUsageBreakdown from '@/components/user/PlatformUsageBreakdown.vue'
 import PlatformCostCell from '@/components/user/PlatformCostCell.vue'
 import UserPlatformQuotaCell from '@/components/user/UserPlatformQuotaCell.vue'
+import { STATUS_ACTIVE, STATUS_DISABLED } from '@/constants/channel'
 import UserCreateModal from '@/components/admin/user/UserCreateModal.vue'
 import InviteTrialModal from '@/components/admin/user/InviteTrialModal.vue'
 import UserEditModal from '@/components/admin/user/UserEditModal.vue'
@@ -1069,7 +1070,7 @@ const getUserGroups = (user: AdminUser) => {
   const exclusive: AdminGroup[] = []
   const publicGroups: AdminGroup[] = []
   for (const g of allGroups.value) {
-    if (g.status !== 'active' || g.subscription_type !== 'standard') continue
+    if (g.status !== STATUS_ACTIVE || g.subscription_type !== 'standard') continue
     if (g.is_exclusive) {
       if (user.allowed_groups?.includes(g.id)) {
         exclusive.push(g)
@@ -1101,7 +1102,7 @@ const groupFilterOptions = computed(() => {
     { value: '', label: t('admin.users.allAuthorizedGroups') }
   ]
   for (const g of allGroups.value) {
-    if (g.status !== 'active' || !g.is_exclusive || g.subscription_type !== 'standard') continue
+    if (g.status !== STATUS_ACTIVE || !g.is_exclusive || g.subscription_type !== 'standard') continue
     options.push({ value: g.name, label: g.name })
   }
   return options
@@ -1748,11 +1749,11 @@ const closeEditModal = () => {
 }
 
 const handleToggleStatus = async (user: AdminUser) => {
-  const newStatus = user.status === 'active' ? 'disabled' : 'active'
+  const newStatus = user.status === STATUS_ACTIVE ? STATUS_DISABLED : STATUS_ACTIVE
   try {
     await adminAPI.users.toggleStatus(user.id, newStatus)
     appStore.showSuccess(
-      newStatus === 'active' ? t('admin.users.userEnabled') : t('admin.users.userDisabled')
+      newStatus === STATUS_ACTIVE ? t('admin.users.userEnabled') : t('admin.users.userDisabled')
     )
     loadUsers()
   } catch (error: any) {

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -1192,6 +1192,8 @@ import {
   buildCcSwitchImportDeeplink,
   type CcSwitchClientType
 } from '@/utils/ccswitchImport'
+import { STATUS_ACTIVE } from '@/constants/channel'
+import { PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI } from '@/constants/gatewayPlatforms'
 
 // Helper to format date for datetime-local input
 const formatDateTimeLocal = (isoDate: string): string => {
@@ -1410,7 +1412,7 @@ const statusOptions = computed(() => [
 
 const shouldSubmitEditStatus = (key: ApiKey, status: 'active' | 'inactive') => {
   if (key.status === 'quota_exhausted' || key.status === 'expired') {
-    return status === 'active'
+    return status === STATUS_ACTIVE
   }
   return true
 }
@@ -1623,11 +1625,11 @@ const editKey = (key: ApiKey) => {
 }
 
 const toggleKeyStatus = async (key: ApiKey) => {
-  const newStatus = key.status === 'active' ? 'inactive' : 'active'
+  const newStatus = key.status === STATUS_ACTIVE ? 'inactive' : 'active'
   try {
     await keysAPI.toggleStatus(key.id, newStatus)
     appStore.showSuccess(
-      newStatus === 'active' ? t('keys.keyEnabledSuccess') : t('keys.keyDisabledSuccess')
+      newStatus === STATUS_ACTIVE ? t('keys.keyEnabledSuccess') : t('keys.keyDisabledSuccess')
     )
     loadApiKeys()
   } catch (error) {
@@ -1914,14 +1916,14 @@ const importToCcswitch = (row: ApiKey) => {
   const platform = row.group?.platform || 'anthropic'
 
   // For antigravity platform, show client selection dialog
-  if (platform === 'antigravity') {
+  if (platform === PLATFORM_ANTIGRAVITY) {
     pendingCcsRow.value = row
     showCcsClientSelect.value = true
     return
   }
 
   // For other platforms, execute directly
-  executeCcsImport(row, platform === 'gemini' ? 'gemini' : 'claude')
+  executeCcsImport(row, platform === PLATFORM_GEMINI ? 'gemini' : 'claude')
 }
 
 const executeCcsImport = (row: ApiKey, clientType: CcSwitchClientType) => {

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -264,7 +264,8 @@ fi
 # auto-paused by this path). The exemption is line-scoped and self-documenting.
 drift2_hits="$(grep -nE '!\s*account\.IsOpenAI\(\)' \
     backend/internal/service/openai_account_scheduler.go \
-    backend/internal/service/openai_gateway_service.go 2>/dev/null \
+    backend/internal/service/openai_gateway_service.go \
+    backend/internal/service/openai_ws_forwarder.go 2>/dev/null \
     | grep -v 'compat-pool-exempt' || true)"
 if [ -n "$drift2_hits" ]; then
     echo "  FAIL: scheduling filter still uses bare !account.IsOpenAI()"

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1267,10 +1267,10 @@
         "export function usesPassiveUsageOnMount(account: Account): boolean",
         "export function canSelfFetchUsage(account: Account): boolean",
         "export function usesLocalUsageWindows(account: Account): boolean",
-        "account.platform === 'kiro'",
-        "account.platform === 'openai' && account.type === 'oauth'",
-        "account.platform === 'newapi' || account.platform === 'grok'",
-        "account.platform === 'antigravity' && account.type !== 'oauth'"
+        "account.platform === PLATFORM_KIRO",
+        "account.platform === PLATFORM_OPENAI && account.type === 'oauth'",
+        "account.platform === PLATFORM_NEWAPI || account.platform === PLATFORM_GROK",
+        "account.platform === PLATFORM_ANTIGRAVITY && account.type !== 'oauth'"
       ],
       "rationale": "Single source of truth for which admin list rows are served by POST /admin/accounts/usage/batch (Anthropic OAuth/SetupToken, OpenAI OAuth, Kiro, and local-window adapters: NewAPI/Grok/Antigravity API-key stubs). Shared by useTkAccountUsageBatch and useAccountUsageFetch so batch eligibility and cell self-fetch gates cannot drift. Dropping or narrowing this module reintroduces per-row /usage fan-out or blanks passive kiro/openai/grok/newapi/antigravity rows on edge/prod account lists."
     },

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1443,6 +1443,14 @@
         "PrerenderMiddleware()"
       ],
       "rationale": "Companion file holding crawler prerender integration; deleting it or inlining back into embed_on.go re-opens upstream merge conflict surface and drops SEO prerender silently if the call site is lost."
+    },
+    {
+      "path": "frontend/src/App.vue",
+      "must_contain": [
+        "cachedUserViews",
+        "<KeepAlive :include=\"cachedUserViews\">"
+      ],
+      "rationale": "TK wraps the RouterView in a KeepAlive with an explicit include list (cachedUserViews) so user-facing views (Dashboard, Usage, Keys, Profile, Studio, KeyUsage) preserve component state across navigation instead of re-mounting. Upstream App.vue has no KeepAlive; an upstream merge that replaces the template block drops the wrapper silently, causing every navigation to remount and lose in-progress form/filter state on all cached views."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3966,6 +3966,82 @@
         "g.Go(func() error { usageData = h.buildUsageData(gctx, apiKey.ID); return nil })"
       ],
       "rationale": "GatewayHandler.Usage (/key-usage) perf fix: three query groups must run concurrently via errgroup. Reverting to sequential best-effort blocks restores prod TTFB with identical response bytes. Sibling perf-query-shape sentinel pins the same shape; this entry satisfies the gateway-tk registry update gate when the upstream-shaped handler is edited with deletions."
+    },
+    {
+      "path": "backend/internal/service/openai_ws_forwarder.go",
+      "must_contain": [
+        "resolveOpenAICodexUserAgent(context.Background(), s, account, inboundUA)"
+      ],
+      "rationale": "WS forwarder buildOpenAIWSHeaders must call resolveOpenAICodexUserAgent to normalize the upstream Codex UA for WebSocket connections, same as the HTTP path in openai_gateway_service.go. Without this call, WS connections (Codex real-time) forward arbitrary client identity upstream, which OpenAI classifies as Uncategorized and which degrades account health. The function definition is anchored in openai_gateway_service.go; this entry pins the WS call site."
+    },
+    {
+      "path": "backend/internal/service/openai_ws_forwarder.go",
+      "must_contain": [
+        "!account.IsOpenAICompatPoolMember(groupPlatform)"
+      ],
+      "rationale": "WS forwarder SelectAccountByPreviousResponseID sticky-session path must use IsOpenAICompatPoolMember (not bare IsOpenAI) to correctly include newapi accounts in the compat scheduling pool. This is the same compat-pool predicate guarded by preflight Check B in the HTTP paths (openai_account_scheduler.go, openai_gateway_service.go); losing it in the WS path silently rejects newapi accounts for WS sticky sessions even when the group platform is newapi."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages.go",
+      "must_contain": [
+        "compatReplayGuardEnabled && !account.IsOpenAIOAuth()"
+      ],
+      "rationale": "Compat replay guard in ForwardAsAnthropicMessages must gate on IsOpenAIOAuth: OAuth accounts already have native Codex session continuation and must NOT get the TodoGuard appended (it corrupts their continuation context). Losing this predicate applies the replay guard to OAuth sessions, breaking Codex continuation for OpenAI OAuth accounts."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages.go",
+      "must_contain": [
+        "account.IsOpenAIOAuth() && promptCacheKey != \"\" && strings.TrimSpace(c.GetHeader(\"conversation_id\")) == \"\""
+      ],
+      "rationale": "OAuth prompt-cache header cleanup in ForwardAsAnthropicMessages: when an OAuth account has a prompt cache key but no conversation_id header, the stale conversation_id must be removed from the upstream request so it does not collide with the session continuation state. Losing this predicate either leaks stale conversation_id upstream (corrupting continuation) or strips it when it should be preserved."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages.go",
+      "must_contain": [
+        "if account.IsOpenAIOAuth() && promptCacheKey != \"\" {"
+      ],
+      "rationale": "OAuth turn-state binding in ForwardAsAnthropicMessages response path: after a successful upstream response, the x-codex-turn-state header must be captured and bound to the prompt cache key for OAuth accounts so subsequent requests can restore session state. Losing this drops turn-state persistence for OpenAI OAuth sessions, breaking multi-turn Codex continuation."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions.go",
+      "must_contain": [
+        "account.IsOpenAIOAuth() && shouldAutoInjectPromptCacheKeyForCompat(upstreamModel)"
+      ],
+      "rationale": "Auto-inject prompt cache key for OAuth compat in ForwardAsChatCompletions: when an OAuth account has no explicit prompt cache key but the model supports it, a deterministic key is derived so the session gets continuation benefits automatically. Losing this predicate disables auto-injection, degrading first-turn latency and breaking implicit session caching for compat entry OAuth accounts."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions.go",
+      "must_contain": [
+        "if account.IsOpenAIOAuth() {\n\t\tvar reqBody map[string]any"
+      ],
+      "rationale": "Codex OAuth transform in ForwardAsChatCompletions: OAuth accounts must have applyCodexOAuthTransformWithOptions applied to the request body, which normalizes instructions, system prompts, and other Codex-specific fields. Losing this gate sends raw non-Codex-shaped bodies upstream on OAuth accounts, causing classification mismatches and potential rejections."
+    },
+    {
+      "path": "backend/internal/handler/auth_handler.go",
+      "must_contain": [
+        "login_turnstile_skipped",
+        "login_without_turnstile"
+      ],
+      "rationale": "TK login policy: Turnstile verification is intentionally bypassed for the control-plane login (TokenKey does not deploy Cloudflare Turnstile). The slog.Info line serves as both the runtime audit trail and the sentinel anchor. An upstream merge that re-introduces Turnstile verification at this call site would silently break login for all TK deployments that do not have Turnstile configured."
+    },
+    {
+      "path": "backend/internal/service/account_service.go",
+      "must_contain": [
+        "AccountListPlatformKiroStubFilter",
+        "SumConcurrencyByPlatform(ctx context.Context, platform string) (int64, error)",
+        "validateNewapiAccountModelMapping(account.Platform, account.Credentials)"
+      ],
+      "rationale": "Three TK-specific touches in the upstream-shaped account_service.go: (1) AccountListPlatformKiroStubFilter constant enables admin UI filtering of Kiro stub accounts from the account list; (2) SumConcurrencyByPlatform interface method supports edge capacity calculation for non-anthropic single-pool-per-platform pools (e.g. Kiro); (3) validateNewapiAccountModelMapping call enforces the newapi multi-vendor model_mapping invariant on account create/update. Losing any of these silently regresses Kiro admin visibility, edge capacity reporting, or newapi account validation."
+    },
+    {
+      "path": "backend/internal/config/config.go",
+      "must_contain": [
+        "AccessTokenExpireMinutes int",
+        "RefreshTokenExpireDays int",
+        "RefreshWindowMinutes int",
+        "RateLimitReaperIntervalSeconds int"
+      ],
+      "rationale": "TK JWT expiry granularity and rate-limit reaper config fields in the upstream-shaped config.go. AccessTokenExpireMinutes (minute-granularity access token TTL, higher priority than the upstream ExpireHour), RefreshTokenExpireDays (refresh token TTL), and RefreshWindowMinutes (pre-expiry refresh window) together implement TK's short-lived access + long-lived refresh token pair policy. RateLimitReaperIntervalSeconds is the TK fix for upstream Wei-Shaw/sub2api#2538 (accounts stuck in scheduling limbo after 429 expiry). Losing these fields silently falls back to upstream's hour-granularity single-token auth and disables the reaper, re-opening the #2538 stuck-account bug."
     }
   ]
 }

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "rationale": "Load-bearing files and symbols that anchor TokenKey's seventh platform `grok` (xAI / SuperGrok Heavy OAuth). Unlike kiro, xAI speaks the OpenAI-compatible wire protocol, so grok is an OpenAICompatPool member and REUSES the OpenAI-compat routing/scheduling/forward/billing path; the only grok-specific code is the OAuth refresh, the two forward seams that make the OAuth branch forward like the apikey branch (plain Bearer + api.x.ai base_url, NOT the ChatGPT/Codex branch), and the Heavy-403 honesty guard. If any sentinel below is missing, the platform either silently disappears from scheduling/UI or mis-forwards/mis-bills at runtime. Single source of truth read by both `scripts/preflight.sh` and `.github/workflows/upstream-merge-pr-shape.yml`. Adding a new load-bearing surface for grok MUST add a sentinel here in the same commit.",
   "sentinels": [
     {

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -328,7 +328,7 @@
         "AccountKiroPlatformFields",
         "kiro.populateFromAccount",
         "kiro.buildSubmitBundle",
-        "props.account.platform === 'kiro'"
+        "props.account.platform === PLATFORM_KIRO"
       ],
       "rationale": "Two Kiro account-edit anchors. (1) Surface-C mirror-stub pool selector: the operator's only no-SQL way to set credentials.mirror_platform=kiro on an existing edge stub (e.g. kiro-edge-us1). Losing it strands the live fix: the kiro stub keeps mirroring the anthropic Σ. (2) Kiro OAuth credential edit wiring: AccountKiroPlatformFields + populate/submit bundle let operators rotate access_token/refresh_token, region/auth_method, IdC client_id/client_secret, Profile ARN, and ToS acknowledgement without delete+recreate. An upstream merge that rewrites EditAccountModal must preserve this branch or live Kiro accounts become unrepairable from the UI."
     },

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -177,8 +177,8 @@
       "path": "frontend/src/utils/accountUsageBatch.tk.ts",
       "must_contain": [
         "export function usesLocalUsageWindows(account: Account): boolean",
-        "account.platform === 'newapi' || account.platform === 'grok'",
-        "account.platform === 'antigravity' && account.type !== 'oauth'",
+        "account.platform === PLATFORM_NEWAPI || account.platform === PLATFORM_GROK",
+        "account.platform === PLATFORM_ANTIGRAVITY && account.type !== 'oauth'",
         "if (usesLocalUsageWindows(account)) return true"
       ],
       "rationale": "Frontend SSOT for local-window usage rows. NewAPI Vertex, Grok, and Antigravity relay stubs are served by the passive batch endpoint and render generic 5h/7d bars; losing this helper or narrowing it blanks those rows or reintroduces per-row /usage fan-out."


### PR DESCRIPTION
## 摘要

从 #1231 拆出对 TokenKey 有实际价值、且 upstream 摩擦可控的改动：

- `apipath/` leaf package + Go endpoint/常量 SSOT（不含 config default 实验）
- 前端 API 契约修复（订阅类型、死代码清理）
- 前端 platform/status/color SSOT 常量统一
- sentinel 加固（U-01..U-04），与 #1232 perf sentinel 合并保留
- `RedeemTypeAffiliateBalance` domain 常量 SSOT（不含 repository 层 domain 迁移）

**明确排除**：连接池 viper default 变更、domain Batch 1、`NormalizeStatusForAPI`（留给 #1234）。

## 风险

- 常规风险：前端 dist 嵌入 + 契约字段对齐；无 schema/鉴权变更。
- 已 rebase 到 `origin/main`（含 #1232）。

## 验证

- `./scripts/preflight.sh` PASS
- `make build-frontend` PASS

## 提交

- 865ba066e refactor(backend): config alignment, apipath leaf package, Go SSOT fixes (C-01, C-02, R-02, G-01, G-02, A-02)
- 6db93e2b1 fix(frontend): resolve API contract bugs and TypeScript type drift (R-01, T-01..T-05)
- b01327452 chore(sentinels): strengthen upstream merge protection gates (U-01..U-04)
- a19e4b4ce refactor(frontend): SSOT constant unification — platform strings, colors, status (S-01..S-05)
- 2eb9b5c82 fix(domain): add RedeemTypeAffiliateBalance to domain constants (preflight drift fix)
- 655d36800 chore(config): keep upstream pool and allow_private_hosts defaults
- d48ee0cd6 fix(domain): drop unused NormalizeStatusForAPI from split PR

最新提交：d48ee0cd6
