### PR TITLE
refactor(domain): repository 层实体终态（Batch 1+2，从 #1231 拆分）

### DIFF
--- a/backend/ent/schema/model_availability.go
+++ b/backend/ent/schema/model_availability.go
@@ -30,14 +30,14 @@ import (
 //   - ok           — verified within 24h AND 24h success rate >=95%
 //   - stale        — 24h success rate 80-95%, OR last_seen_ok >24h ago
 //   - unreachable  — last_failure_kind=model_not_found (single sample) OR
-//                    24h success rate <80%
+//     24h success rate <80%
 //   - untested     — no samples ever
 //
 // last_failure_kind taxonomy (kept narrow, do not invent):
 //   - "" (cleared on success)
 //   - model_not_found  / not_found  — strong / medium signal, model-level
 //   - rate_limited / auth_failure   — INCONCLUSIVE, account-level; do not flip
-//                                     status, only refresh last_checked_at
+//     status, only refresh last_checked_at
 //   - upstream_5xx / network_error / bad_response_shape — soft signal, accumulate
 type ModelAvailability struct {
 	ent.Schema

--- a/backend/internal/domain/MIGRATION.md
+++ b/backend/internal/domain/MIGRATION.md
@@ -1,0 +1,85 @@
+# domain/ Migration Plan (A-01: service/ decomposition)
+
+## Goal
+
+Break the structural layer violation where `repository/` imports `service/`
+(upward dependency). Shared types/constants/errors move to `domain/` so
+`repository/` can import `domain/` instead.
+
+## Batch 1 (this commit)
+
+**Moved to domain/:**
+
+| File | Symbols | Count |
+|------|---------|-------|
+| `errors.go` | 31 error sentinel vars (ErrUserNotFound, ErrAPIKeyNotFound, etc.) | 31 |
+| `scheduler_events.go` | SchedulerOutboxEvent* constants (6) | 6 |
+| `usage_cleanup.go` | UsageCleanupStatus* constants (5) | 5 |
+| `constants.go` (pre-existing) | Status/Role/Platform/AccountType/RedeemType/etc. constants (34) | 34 |
+
+**Impact:**
+- 1169 `service.*` references in repository/ replaced with `domain.*`
+- 6 repository files completely dropped the `service/` import
+- 175 repository files still import `service/` (down from 181)
+- Backward-compatible: service/ re-exports all moved symbols as aliases
+
+## Top 20 remaining candidates (by usage count in repository/)
+
+| # | Symbol | Type | Uses | Methods | Est. effort |
+|---|--------|------|------|---------|-------------|
+| 1 | Account | struct | 299 | 177 | XL - needs method extraction first |
+| 2 | User | struct | 208 | ~20 | L - many methods reference service internals |
+| 3 | APIKey | struct | 127 | ~15 | L |
+| 4 | Group | struct | 109 | ~10 | M |
+| 5 | UsageLog | struct | 84 | ~5 | M |
+| 6 | Proxy | struct | 56 | 0 | S - good candidate |
+| 7 | RedeemCode | struct | 39 | ~2 | S |
+| 8 | UserSubscription | struct | 33 | ~3 | S |
+| 9 | OpsDashboardFilter | struct | 28 | 4 | S |
+| 10 | UsageCleanupTask | struct | 25 | 1 | S - good candidate |
+| 11 | UsageCleanupFilters | struct | 22 | 0 | S - good candidate |
+| 12 | OpsPercentiles | struct | 21 | 0 | S - good candidate |
+| 13 | UserPlatformQuotaRecord | struct | 20 | 0 | S - good candidate |
+| 14 | BillingCache | interface | 19 | N/A | M - interface, deferred |
+| 15 | UsageBillingCommand | struct | 18 | 0 | S - good candidate |
+| 16 | UserListFilters | struct | 17 | 0 | S - good candidate |
+| 17 | SchedulerBucket | struct | 16 | 2 | S |
+| 18 | OpsErrorLogFilter | struct | 16 | 3 | S |
+| 19 | ChannelModelPricing | struct | 16 | 6 | M |
+| 20 | AccountGroup | struct | 11 | 0 | S - but references Account/Group |
+
+## Batch 2 (entity separation — repository reads domain entities)
+
+**Moved entity definitions out of upstream-shaped `service/` files into `domain/`:**
+
+| File | Symbols |
+|------|---------|
+| `proxy.go` | `Proxy` (+ `IsActive`/`IsExpired`/`URL`) |
+| `usage_cleanup_entities.go` | `UsageCleanupFilters`, `UsageCleanupTask` |
+| `usage_billing_command.go` | `UsageBillingCommand` (+ `Normalize`) |
+| `user_list_filters.go` | `UserListFilters` |
+| `user_platform_quota_record.go` | `UserPlatformQuotaRecord` |
+| `ops_percentiles.go` | `OpsPercentiles` |
+
+**Impact:** repository/ references above types via `domain.*`; `service/` keeps
+`type Foo = domain.Foo` aliases so handler/service callers unchanged.
+
+**Remaining (batch 3+):** large aggregates (`Account`, `User`, `APIKey`, `Group`)
+still live in `service/` until method-free subsets can be extracted without
+rewriting upstream merge surfaces.
+
+## Recommended batch 3
+
+Move the remaining small structs with few methods, plus begin extracting
+method-free subsets of the big structs (Account, User, APIKey, Group).
+
+## Pattern
+
+For each migrated type:
+1. Define in `domain/` (canonical owner)
+2. Add `type Foo = domain.Foo` alias in `service/` (backward compat)
+3. Update `repository/` imports to use `domain.Foo`
+4. handler/ and other service/ callers keep working via the alias
+
+Interfaces are deferred until their method signatures no longer reference
+un-migrated service types.

--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -12,6 +12,20 @@ const (
 	StatusExpired  = "expired"
 )
 
+// StatusInactiveAPI is the API-facing value returned instead of StatusDisabled
+// for Account, Group, and ApiKey resources. User resources return StatusDisabled
+// directly.
+const StatusInactiveAPI = "inactive"
+
+// NormalizeStatusForAPI maps internal DB status values to API-facing values.
+// StatusDisabled is surfaced as "inactive" for non-User resources.
+func NormalizeStatusForAPI(dbStatus string) string {
+	if dbStatus == StatusDisabled {
+		return StatusInactiveAPI
+	}
+	return dbStatus
+}
+
 // Role constants
 const (
 	RoleAdmin = "admin"

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -1,0 +1,72 @@
+// Package domain error sentinels.
+//
+// These sentinel errors are shared across layers (service, repository, handler).
+// Moving them here breaks the repository -> service import for error identity checks.
+//
+// Migration note: service/ re-exports each symbol as a var alias so existing
+// callers (handler/, service/ internal) continue to compile unchanged.
+package domain
+
+import (
+	"errors"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+)
+
+// ---- entity not-found sentinels ----
+
+var (
+	ErrUserNotFound    = infraerrors.NotFound("USER_NOT_FOUND", "user not found")
+	ErrAPIKeyNotFound  = infraerrors.NotFound("API_KEY_NOT_FOUND", "api key not found")
+	ErrAccountNotFound = infraerrors.NotFound("ACCOUNT_NOT_FOUND", "account not found")
+	ErrGroupNotFound   = infraerrors.NotFound("GROUP_NOT_FOUND", "group not found")
+	ErrChannelNotFound = infraerrors.NotFound("CHANNEL_NOT_FOUND", "channel not found")
+	ErrProxyNotFound   = infraerrors.NotFound("PROXY_NOT_FOUND", "proxy not found")
+	ErrSettingNotFound = infraerrors.NotFound("SETTING_NOT_FOUND", "setting not found")
+
+	ErrRedeemCodeNotFound = infraerrors.NotFound("REDEEM_CODE_NOT_FOUND", "redeem code not found")
+	ErrPromoCodeNotFound  = infraerrors.NotFound("PROMO_CODE_NOT_FOUND", "promo code not found")
+	ErrUsageLogNotFound   = infraerrors.NotFound("USAGE_LOG_NOT_FOUND", "usage log not found")
+
+	ErrSubscriptionNotFound           = infraerrors.NotFound("SUBSCRIPTION_NOT_FOUND", "subscription not found")
+	ErrAttributeDefinitionNotFound    = infraerrors.NotFound("ATTRIBUTE_DEFINITION_NOT_FOUND", "attribute definition not found")
+	ErrAffiliateProfileNotFound       = infraerrors.NotFound("AFFILIATE_PROFILE_NOT_FOUND", "affiliate profile not found")
+	ErrChannelMonitorNotFound         = infraerrors.NotFound("CHANNEL_MONITOR_NOT_FOUND", "channel monitor not found")
+	ErrChannelMonitorTemplateNotFound = infraerrors.NotFound(
+		"CHANNEL_MONITOR_TEMPLATE_NOT_FOUND", "channel monitor request template not found",
+	)
+)
+
+// ---- conflict sentinels ----
+
+var (
+	ErrEmailExists    = infraerrors.Conflict("EMAIL_EXISTS", "email already exists")
+	ErrGroupExists    = infraerrors.Conflict("GROUP_EXISTS", "group name already exists")
+	ErrChannelExists  = infraerrors.Conflict("CHANNEL_EXISTS", "channel name already exists")
+	ErrAPIKeyExists   = infraerrors.Conflict("API_KEY_EXISTS", "api key already exists")
+	ErrRedeemCodeUsed = infraerrors.Conflict("REDEEM_CODE_USED", "redeem code already used")
+
+	ErrAttributeKeyExists          = infraerrors.Conflict("ATTRIBUTE_KEY_EXISTS", "attribute key already exists")
+	ErrSubscriptionAlreadyExists   = infraerrors.Conflict("SUBSCRIPTION_ALREADY_EXISTS", "subscription already exists for this user and group")
+	ErrSubscriptionRestoreConflict = infraerrors.Conflict("SUBSCRIPTION_RESTORE_CONFLICT", "subscription already exists for this user and group")
+	ErrAffiliateCodeTaken          = infraerrors.Conflict("AFFILIATE_CODE_TAKEN", "affiliate code already in use")
+)
+
+// ---- bad-request sentinels ----
+
+var (
+	ErrAccountNilInput      = infraerrors.BadRequest("ACCOUNT_NIL_INPUT", "account input cannot be nil")
+	ErrSubscriptionNilInput = infraerrors.BadRequest("SUBSCRIPTION_NIL_INPUT", "subscription input cannot be nil")
+	ErrAffiliateQuotaEmpty  = infraerrors.BadRequest("AFFILIATE_QUOTA_EMPTY", "no affiliate quota available to transfer")
+
+	ErrIdentityProviderInvalid = infraerrors.BadRequest("IDENTITY_PROVIDER_INVALID", "identity provider is invalid")
+
+	ErrAffiliateCodeInvalid = infraerrors.BadRequest("AFFILIATE_CODE_INVALID", "invalid affiliate code")
+)
+
+// ---- billing sentinels (plain errors, not ApplicationError) ----
+
+var (
+	ErrUsageBillingRequestIDRequired = errors.New("usage billing request_id is required")
+	ErrUsageBillingRequestConflict   = errors.New("usage billing request fingerprint conflict")
+)

--- a/backend/internal/domain/ops_percentiles.go
+++ b/backend/internal/domain/ops_percentiles.go
@@ -1,0 +1,11 @@
+package domain
+
+// OpsPercentiles holds latency percentile summary values for ops dashboards.
+type OpsPercentiles struct {
+	P50 *int `json:"p50_ms"`
+	P90 *int `json:"p90_ms"`
+	P95 *int `json:"p95_ms"`
+	P99 *int `json:"p99_ms"`
+	Avg *int `json:"avg_ms"`
+	Max *int `json:"max_ms"`
+}

--- a/backend/internal/domain/proxy.go
+++ b/backend/internal/domain/proxy.go
@@ -1,0 +1,45 @@
+package domain
+
+import (
+	"net"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// Proxy is the canonical proxy entity (repository reads/writes this shape).
+type Proxy struct {
+	ID             int64
+	Name           string
+	Protocol       string
+	Host           string
+	Port           int
+	Username       string
+	Password       string
+	Status         string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	ExpiresAt      *time.Time
+	FallbackMode   string
+	BackupProxyID  *int64
+	ExpiryWarnDays int
+}
+
+func (p *Proxy) IsActive() bool {
+	return p.Status == StatusActive
+}
+
+func (p *Proxy) IsExpired(now time.Time) bool {
+	return p.ExpiresAt != nil && !p.ExpiresAt.After(now)
+}
+
+func (p *Proxy) URL() string {
+	u := &url.URL{
+		Scheme: p.Protocol,
+		Host:   net.JoinHostPort(p.Host, strconv.Itoa(p.Port)),
+	}
+	if p.Username != "" && p.Password != "" {
+		u.User = url.UserPassword(p.Username, p.Password)
+	}
+	return u.String()
+}

--- a/backend/internal/domain/scheduler_events.go
+++ b/backend/internal/domain/scheduler_events.go
@@ -1,0 +1,15 @@
+package domain
+
+// Scheduler outbox event type constants.
+//
+// These string constants identify the kind of change that triggered a
+// scheduler cache rebuild. They are produced by repository/ (outbox insert)
+// and consumed by service/ (cache rebuild loop), so they belong in domain/.
+const (
+	SchedulerOutboxEventAccountChanged       = "account_changed"
+	SchedulerOutboxEventAccountGroupsChanged = "account_groups_changed"
+	SchedulerOutboxEventAccountBulkChanged   = "account_bulk_changed"
+	SchedulerOutboxEventAccountLastUsed      = "account_last_used"
+	SchedulerOutboxEventGroupChanged         = "group_changed"
+	SchedulerOutboxEventFullRebuild          = "full_rebuild"
+)

--- a/backend/internal/domain/usage_billing_command.go
+++ b/backend/internal/domain/usage_billing_command.go
@@ -1,0 +1,90 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// UsageBillingCommand describes one billable request applied at most once.
+type UsageBillingCommand struct {
+	RequestID          string
+	APIKeyID           int64
+	RequestFingerprint string
+	RequestPayloadHash string
+
+	UserID              int64
+	AccountID           int64
+	SubscriptionID      *int64
+	AccountType         string
+	Model               string
+	ServiceTier         string
+	ReasoningEffort     string
+	BillingType         int8
+	InputTokens         int
+	OutputTokens        int
+	CacheCreationTokens int
+	CacheReadTokens     int
+	ImageCount          int
+	MediaType           string
+
+	BalanceCost         float64
+	SubscriptionCost    float64
+	APIKeyQuotaCost     float64
+	APIKeyRateLimitCost float64
+	AccountQuotaCost    float64
+
+	TkHoldRequestID string
+}
+
+func (c *UsageBillingCommand) Normalize() {
+	if c == nil {
+		return
+	}
+	c.RequestID = strings.TrimSpace(c.RequestID)
+	if strings.TrimSpace(c.RequestFingerprint) == "" {
+		c.RequestFingerprint = buildUsageBillingFingerprint(c)
+	}
+}
+
+func buildUsageBillingFingerprint(c *UsageBillingCommand) string {
+	if c == nil {
+		return ""
+	}
+	raw := fmt.Sprintf(
+		"%d|%d|%d|%s|%s|%s|%s|%d|%d|%d|%d|%d|%d|%s|%d|%0.10f|%0.10f|%0.10f|%0.10f|%0.10f",
+		c.UserID,
+		c.AccountID,
+		c.APIKeyID,
+		strings.TrimSpace(c.AccountType),
+		strings.TrimSpace(c.Model),
+		strings.TrimSpace(c.ServiceTier),
+		strings.TrimSpace(c.ReasoningEffort),
+		c.BillingType,
+		c.InputTokens,
+		c.OutputTokens,
+		c.CacheCreationTokens,
+		c.CacheReadTokens,
+		c.ImageCount,
+		strings.TrimSpace(c.MediaType),
+		valueOrZero(c.SubscriptionID),
+		c.BalanceCost,
+		c.SubscriptionCost,
+		c.APIKeyQuotaCost,
+		c.APIKeyRateLimitCost,
+		c.AccountQuotaCost,
+	)
+	if payloadHash := strings.TrimSpace(c.RequestPayloadHash); payloadHash != "" {
+		raw += "|" + payloadHash
+	}
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+func valueOrZero(v *int64) int64 {
+	if v == nil {
+		return 0
+	}
+	return *v
+}

--- a/backend/internal/domain/usage_billing_command_test.go
+++ b/backend/internal/domain/usage_billing_command_test.go
@@ -1,0 +1,19 @@
+package domain
+
+import "testing"
+
+func TestUsageBillingCommandNormalize_TrimsRequestID(t *testing.T) {
+	cmd := &UsageBillingCommand{RequestID: "  req-1  ", UserID: 1, AccountID: 2, APIKeyID: 3}
+	cmd.Normalize()
+	if cmd.RequestID != "req-1" {
+		t.Fatalf("RequestID = %q, want req-1", cmd.RequestID)
+	}
+	if cmd.RequestFingerprint == "" {
+		t.Fatal("expected fingerprint to be populated")
+	}
+}
+
+func TestUsageBillingCommandNormalize_NilSafe(t *testing.T) {
+	var cmd *UsageBillingCommand
+	cmd.Normalize()
+}

--- a/backend/internal/domain/usage_cleanup.go
+++ b/backend/internal/domain/usage_cleanup.go
@@ -1,0 +1,13 @@
+package domain
+
+// Usage cleanup task status constants.
+//
+// These are used by both service/ (business logic) and repository/ (persistence),
+// so they belong in domain/.
+const (
+	UsageCleanupStatusPending   = "pending"
+	UsageCleanupStatusRunning   = "running"
+	UsageCleanupStatusSucceeded = "succeeded"
+	UsageCleanupStatusFailed    = "failed"
+	UsageCleanupStatusCanceled  = "canceled"
+)

--- a/backend/internal/domain/usage_cleanup_entities.go
+++ b/backend/internal/domain/usage_cleanup_entities.go
@@ -1,0 +1,33 @@
+package domain
+
+import "time"
+
+// UsageCleanupFilters defines cleanup task filter criteria.
+type UsageCleanupFilters struct {
+	StartTime   time.Time `json:"start_time"`
+	EndTime     time.Time `json:"end_time"`
+	UserID      *int64    `json:"user_id,omitempty"`
+	APIKeyID    *int64    `json:"api_key_id,omitempty"`
+	AccountID   *int64    `json:"account_id,omitempty"`
+	GroupID     *int64    `json:"group_id,omitempty"`
+	Model       *string   `json:"model,omitempty"`
+	RequestType *int16    `json:"request_type,omitempty"`
+	Stream      *bool     `json:"stream,omitempty"`
+	BillingType *int8     `json:"billing_type,omitempty"`
+}
+
+// UsageCleanupTask represents a usage-log cleanup job.
+type UsageCleanupTask struct {
+	ID          int64
+	Status      string
+	Filters     UsageCleanupFilters
+	CreatedBy   int64
+	DeletedRows int64
+	ErrorMsg    *string
+	CanceledBy  *int64
+	CanceledAt  *time.Time
+	StartedAt   *time.Time
+	FinishedAt  *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/backend/internal/domain/user_list_filters.go
+++ b/backend/internal/domain/user_list_filters.go
@@ -1,0 +1,13 @@
+package domain
+
+// UserListFilters contains filter options for listing users.
+type UserListFilters struct {
+	Status               string
+	Role                 string
+	Search               string
+	GroupName            string
+	APIKeyGroupID        int64
+	Attributes           map[int64]string
+	IncludeSubscriptions *bool
+	IncludeDeleted       bool
+}

--- a/backend/internal/domain/user_platform_quota_record.go
+++ b/backend/internal/domain/user_platform_quota_record.go
@@ -1,0 +1,18 @@
+package domain
+
+import "time"
+
+// UserPlatformQuotaRecord is the cross-layer quota transport shape.
+type UserPlatformQuotaRecord struct {
+	UserID             int64
+	Platform           string
+	DailyLimitUSD      *float64
+	WeeklyLimitUSD     *float64
+	MonthlyLimitUSD    *float64
+	DailyUsageUSD      float64
+	WeeklyUsageUSD     float64
+	MonthlyUsageUSD    float64
+	DailyWindowStart   *time.Time
+	WeeklyWindowStart  *time.Time
+	MonthlyWindowStart *time.Time
+}

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -87,7 +87,7 @@ func newAccountRepositoryWithSQL(client *dbent.Client, sqlq sqlExecutor, schedul
 
 func (r *accountRepository) Create(ctx context.Context, account *service.Account) error {
 	if account == nil {
-		return service.ErrAccountNilInput
+		return domain.ErrAccountNilInput
 	}
 
 	builder := r.client.Account.Create().
@@ -147,13 +147,13 @@ func (r *accountRepository) Create(ctx context.Context, account *service.Account
 
 	created, err := builder.Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrAccountNotFound, nil)
+		return translatePersistenceError(err, domain.ErrAccountNotFound, nil)
 	}
 
 	account.ID = created.ID
 	account.CreatedAt = created.CreatedAt
 	account.UpdatedAt = created.UpdatedAt
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &account.ID, nil, buildSchedulerGroupPayload(account.GroupIDs)); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &account.ID, nil, buildSchedulerGroupPayload(account.GroupIDs)); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue account create failed: account=%d err=%v", account.ID, err)
 	}
 	return nil
@@ -219,7 +219,7 @@ WHERE platform = $1 AND schedulable = true AND deleted_at IS NULL`
 func (r *accountRepository) GetByID(ctx context.Context, id int64) (*service.Account, error) {
 	m, err := r.client.Account.Query().Where(dbaccount.IDEQ(id)).Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrAccountNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrAccountNotFound, nil)
 	}
 
 	accounts, err := r.accountsToService(ctx, []*dbent.Account{m})
@@ -227,7 +227,7 @@ func (r *accountRepository) GetByID(ctx context.Context, id int64) (*service.Acc
 		return nil, err
 	}
 	if len(accounts) == 0 {
-		return nil, service.ErrAccountNotFound
+		return nil, domain.ErrAccountNotFound
 	}
 	return &accounts[0], nil
 }
@@ -288,7 +288,7 @@ func (r *accountRepository) GetByIDs(ctx context.Context, ids []int64) ([]*servi
 		// Prefer the preloaded proxy edge when available, but only attach an
 		// active proxy — disabled proxies must not surface as account.Proxy so
 		// outbound forwarding skips them. See upstream #2159.
-		if entAcc.Edges.Proxy != nil && entAcc.Edges.Proxy.Status == service.StatusActive {
+		if entAcc.Edges.Proxy != nil && entAcc.Edges.Proxy.Status == domain.StatusActive {
 			out.Proxy = proxyEntityToService(entAcc.Edges.Proxy)
 		}
 
@@ -399,7 +399,7 @@ func (r *accountRepository) Update(ctx context.Context, account *service.Account
 		return nil
 	}
 	schedulable := account.Schedulable
-	if account.Status == service.StatusError {
+	if account.Status == domain.StatusError {
 		schedulable = false
 	}
 
@@ -494,10 +494,10 @@ func (r *accountRepository) Update(ctx context.Context, account *service.Account
 
 	updated, err := builder.Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrAccountNotFound, nil)
+		return translatePersistenceError(err, domain.ErrAccountNotFound, nil)
 	}
 	account.UpdatedAt = updated.UpdatedAt
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &account.ID, nil, buildSchedulerGroupPayload(account.GroupIDs)); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &account.ID, nil, buildSchedulerGroupPayload(account.GroupIDs)); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue account update failed: account=%d err=%v", account.ID, err)
 	}
 	// 普通账号编辑（如 model_mapping / credentials）也需要立即刷新单账号快照，
@@ -511,7 +511,7 @@ func (r *accountRepository) UpdateCredentials(ctx context.Context, id int64, cre
 		SetCredentials(normalizeJSONMap(credentials)).
 		Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrAccountNotFound, nil)
+		return translatePersistenceError(err, domain.ErrAccountNotFound, nil)
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
 	return nil
@@ -553,7 +553,7 @@ func (r *accountRepository) Delete(ctx context.Context, id int64) error {
 		}
 	}
 	r.deleteSchedulerAccountSnapshot(ctx, id)
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, buildSchedulerGroupPayload(groupIDs)); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, buildSchedulerGroupPayload(groupIDs)); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue account delete failed: account=%d err=%v", id, err)
 	}
 	return nil
@@ -568,10 +568,10 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 
 	if platform == service.AccountListPlatformKiroStubFilter {
 		q = q.Where(accountKiroRelayStubPredicate())
-	} else if platform == service.PlatformKiro {
+	} else if platform == domain.PlatformKiro {
 		q = q.Where(
 			dbaccount.Or(
-				dbaccount.PlatformEQ(service.PlatformKiro),
+				dbaccount.PlatformEQ(domain.PlatformKiro),
 				accountKiroRelayStubPredicate(),
 			),
 		)
@@ -583,7 +583,7 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 	}
 	if status != "" {
 		switch status {
-		case service.StatusActive:
+		case domain.StatusActive:
 			q = q.Where(
 				dbaccount.StatusEQ(status),
 				dbaccount.SchedulableEQ(true),
@@ -601,7 +601,7 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 			)
 		case "rate_limited":
 			q = q.Where(
-				dbaccount.StatusEQ(service.StatusActive),
+				dbaccount.StatusEQ(domain.StatusActive),
 				dbaccount.RateLimitResetAtGT(time.Now()),
 				dbpredicate.Account(func(s *entsql.Selector) {
 					col := s.C("temp_unschedulable_until")
@@ -613,7 +613,7 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 			)
 		case "temp_unschedulable":
 			q = q.Where(
-				dbaccount.StatusEQ(service.StatusActive),
+				dbaccount.StatusEQ(domain.StatusActive),
 				dbpredicate.Account(func(s *entsql.Selector) {
 					col := s.C("temp_unschedulable_until")
 					s.Where(entsql.And(
@@ -624,7 +624,7 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 			)
 		case "unschedulable":
 			q = q.Where(
-				dbaccount.StatusEQ(service.StatusActive),
+				dbaccount.StatusEQ(domain.StatusActive),
 				dbaccount.SchedulableEQ(false),
 				dbaccount.Or(
 					dbaccount.RateLimitResetAtIsNil(),
@@ -695,8 +695,8 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 
 func accountKiroRelayStubPredicate() dbpredicate.Account {
 	return dbaccount.And(
-		dbaccount.PlatformEQ(service.PlatformAnthropic),
-		dbaccount.TypeEQ(service.AccountTypeAPIKey),
+		dbaccount.PlatformEQ(domain.PlatformAnthropic),
+		dbaccount.TypeEQ(domain.AccountTypeAPIKey),
 		dbpredicate.Account(func(s *entsql.Selector) {
 			s.Where(entsql.ExprP(fmt.Sprintf("LOWER(TRIM(%s->>'mirror_platform')) = 'kiro'", s.C(dbaccount.FieldCredentials))))
 			s.Where(entsql.ExprP(fmt.Sprintf("(%s->>'base_url') ~ '^https://api-[a-z0-9]+\\.tokenkey\\.dev/?$'", s.C(dbaccount.FieldCredentials))))
@@ -785,7 +785,7 @@ func accountListOrder(params pagination.PaginationParams) []func(*entsql.Selecto
 
 func (r *accountRepository) ListByGroup(ctx context.Context, groupID int64) ([]service.Account, error) {
 	accounts, err := r.queryAccountsByGroup(ctx, groupID, accountGroupQueryOptions{
-		status: service.StatusActive,
+		status: domain.StatusActive,
 	})
 	if err != nil {
 		return nil, err
@@ -795,7 +795,7 @@ func (r *accountRepository) ListByGroup(ctx context.Context, groupID int64) ([]s
 
 func (r *accountRepository) ListActive(ctx context.Context) ([]service.Account, error) {
 	accounts, err := r.client.Account.Query().
-		Where(dbaccount.StatusEQ(service.StatusActive)).
+		Where(dbaccount.StatusEQ(domain.StatusActive)).
 		Order(dbent.Asc(dbaccount.FieldPriority)).
 		All(ctx)
 	if err != nil {
@@ -872,7 +872,7 @@ func (r *accountRepository) ListByPlatform(ctx context.Context, platform string)
 	accounts, err := r.client.Account.Query().
 		Where(
 			dbaccount.PlatformEQ(platform),
-			dbaccount.StatusEQ(service.StatusActive),
+			dbaccount.StatusEQ(domain.StatusActive),
 		).
 		Order(dbent.Asc(dbaccount.FieldPriority)).
 		All(ctx)
@@ -896,7 +896,7 @@ func (r *accountRepository) UpdateLastUsed(ctx context.Context, id int64) error 
 			strconv.FormatInt(id, 10): now.Unix(),
 		},
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountLastUsed, &id, nil, payload); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountLastUsed, &id, nil, payload); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue last used failed: account=%d err=%v", id, err)
 	}
 	return nil
@@ -931,7 +931,7 @@ func (r *accountRepository) BatchUpdateLastUsed(ctx context.Context, updates map
 		lastUsedPayload[strconv.FormatInt(id, 10)] = ts.Unix()
 	}
 	payload := map[string]any{"last_used": lastUsedPayload}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountLastUsed, nil, nil, payload); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountLastUsed, nil, nil, payload); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue batch last used failed: err=%v", err)
 	}
 	return nil
@@ -940,14 +940,14 @@ func (r *accountRepository) BatchUpdateLastUsed(ctx context.Context, updates map
 func (r *accountRepository) SetError(ctx context.Context, id int64, errorMsg string) error {
 	_, err := r.client.Account.Update().
 		Where(dbaccount.IDEQ(id)).
-		SetStatus(service.StatusError).
+		SetStatus(domain.StatusError).
 		SetErrorMessage(errorMsg).
 		SetSchedulable(false).
 		Save(ctx)
 	if err != nil {
 		return err
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue set error failed: account=%d err=%v", id, err)
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
@@ -1025,13 +1025,13 @@ func (r *accountRepository) syncSchedulerAccountSnapshots(ctx context.Context, a
 func (r *accountRepository) ClearError(ctx context.Context, id int64) error {
 	_, err := r.client.Account.Update().
 		Where(dbaccount.IDEQ(id)).
-		SetStatus(service.StatusActive).
+		SetStatus(domain.StatusActive).
 		SetErrorMessage("").
 		Save(ctx)
 	if err != nil {
 		return err
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue clear error failed: account=%d err=%v", id, err)
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
@@ -1048,7 +1048,7 @@ func (r *accountRepository) AddToGroup(ctx context.Context, accountID, groupID i
 		return err
 	}
 	payload := buildSchedulerGroupPayload([]int64{groupID})
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountGroupsChanged, &accountID, nil, payload); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountGroupsChanged, &accountID, nil, payload); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue add to group failed: account=%d group=%d err=%v", accountID, groupID, err)
 	}
 	return nil
@@ -1065,7 +1065,7 @@ func (r *accountRepository) RemoveFromGroup(ctx context.Context, accountID, grou
 		return err
 	}
 	payload := buildSchedulerGroupPayload([]int64{groupID})
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountGroupsChanged, &accountID, nil, payload); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountGroupsChanged, &accountID, nil, payload); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue remove from group failed: account=%d group=%d err=%v", accountID, groupID, err)
 	}
 	return nil
@@ -1138,7 +1138,7 @@ func (r *accountRepository) BindGroups(ctx context.Context, accountID int64, gro
 		}
 	}
 	payload := buildSchedulerGroupPayload(mergeGroupIDs(existingGroupIDs, groupIDs))
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountGroupsChanged, &accountID, nil, payload); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountGroupsChanged, &accountID, nil, payload); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue bind groups failed: account=%d err=%v", accountID, err)
 	}
 	return nil
@@ -1148,7 +1148,7 @@ func (r *accountRepository) ListSchedulable(ctx context.Context) ([]service.Acco
 	now := time.Now()
 	accounts, err := r.client.Account.Query().
 		Where(
-			dbaccount.StatusEQ(service.StatusActive),
+			dbaccount.StatusEQ(domain.StatusActive),
 			dbaccount.SchedulableEQ(true),
 			tempUnschedulablePredicate(),
 			notExpiredPredicate(now),
@@ -1165,7 +1165,7 @@ func (r *accountRepository) ListSchedulable(ctx context.Context) ([]service.Acco
 
 func (r *accountRepository) ListSchedulableByGroupID(ctx context.Context, groupID int64) ([]service.Account, error) {
 	return r.queryAccountsByGroup(ctx, groupID, accountGroupQueryOptions{
-		status:      service.StatusActive,
+		status:      domain.StatusActive,
 		schedulable: true,
 	})
 }
@@ -1218,7 +1218,7 @@ func (r *accountRepository) ListSchedulableCapacityByGroupIDs(ctx context.Contex
 			AND (a.overload_until IS NULL OR a.overload_until <= $3)
 			AND (a.rate_limit_reset_at IS NULL OR a.rate_limit_reset_at <= $3)
 		ORDER BY ag.group_id ASC, ag.priority ASC, a.priority ASC, a.id ASC
-	`, pq.Array(groupIDs), service.StatusActive, time.Now())
+	`, pq.Array(groupIDs), domain.StatusActive, time.Now())
 	if err != nil {
 		return nil, err
 	}
@@ -1259,7 +1259,7 @@ func (r *accountRepository) ListSchedulableByPlatform(ctx context.Context, platf
 	accounts, err := r.client.Account.Query().
 		Where(
 			dbaccount.PlatformEQ(platform),
-			dbaccount.StatusEQ(service.StatusActive),
+			dbaccount.StatusEQ(domain.StatusActive),
 			dbaccount.SchedulableEQ(true),
 			tempUnschedulablePredicate(),
 			notExpiredPredicate(now),
@@ -1277,7 +1277,7 @@ func (r *accountRepository) ListSchedulableByPlatform(ctx context.Context, platf
 func (r *accountRepository) ListSchedulableByGroupIDAndPlatform(ctx context.Context, groupID int64, platform string) ([]service.Account, error) {
 	// 单平台查询复用多平台逻辑，保持过滤条件与排序策略一致。
 	return r.queryAccountsByGroup(ctx, groupID, accountGroupQueryOptions{
-		status:      service.StatusActive,
+		status:      domain.StatusActive,
 		schedulable: true,
 		platforms:   []string{platform},
 	})
@@ -1293,7 +1293,7 @@ func (r *accountRepository) ListSchedulableByPlatforms(ctx context.Context, plat
 	accounts, err := r.client.Account.Query().
 		Where(
 			dbaccount.PlatformIn(platforms...),
-			dbaccount.StatusEQ(service.StatusActive),
+			dbaccount.StatusEQ(domain.StatusActive),
 			dbaccount.SchedulableEQ(true),
 			tempUnschedulablePredicate(),
 			notExpiredPredicate(now),
@@ -1313,7 +1313,7 @@ func (r *accountRepository) ListSchedulableUngroupedByPlatform(ctx context.Conte
 	accounts, err := r.client.Account.Query().
 		Where(
 			dbaccount.PlatformEQ(platform),
-			dbaccount.StatusEQ(service.StatusActive),
+			dbaccount.StatusEQ(domain.StatusActive),
 			dbaccount.SchedulableEQ(true),
 			dbaccount.Not(dbaccount.HasAccountGroups()),
 			tempUnschedulablePredicate(),
@@ -1337,7 +1337,7 @@ func (r *accountRepository) ListSchedulableUngroupedByPlatforms(ctx context.Cont
 	accounts, err := r.client.Account.Query().
 		Where(
 			dbaccount.PlatformIn(platforms...),
-			dbaccount.StatusEQ(service.StatusActive),
+			dbaccount.StatusEQ(domain.StatusActive),
 			dbaccount.SchedulableEQ(true),
 			dbaccount.Not(dbaccount.HasAccountGroups()),
 			tempUnschedulablePredicate(),
@@ -1359,7 +1359,7 @@ func (r *accountRepository) ListSchedulableByGroupIDAndPlatforms(ctx context.Con
 	}
 	// 复用按分组查询逻辑，保证分组优先级 + 账号优先级的排序与筛选一致。
 	return r.queryAccountsByGroup(ctx, groupID, accountGroupQueryOptions{
-		status:      service.StatusActive,
+		status:      domain.StatusActive,
 		schedulable: true,
 		platforms:   platforms,
 	})
@@ -1375,7 +1375,7 @@ func (r *accountRepository) SetRateLimited(ctx context.Context, id int64, resetA
 	if err != nil {
 		return err
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue rate limit failed: account=%d err=%v", id, err)
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
@@ -1426,9 +1426,9 @@ func (r *accountRepository) SetModelRateLimit(ctx context.Context, id int64, sco
 		return err
 	}
 	if affected == 0 {
-		return service.ErrAccountNotFound
+		return domain.ErrAccountNotFound
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue model rate limit failed: account=%d err=%v", id, err)
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
@@ -1443,7 +1443,7 @@ func (r *accountRepository) SetOverloaded(ctx context.Context, id int64, until t
 	if err != nil {
 		return err
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue overload failed: account=%d err=%v", id, err)
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
@@ -1470,7 +1470,7 @@ func (r *accountRepository) SetTempUnschedulable(ctx context.Context, id int64, 
 	if affected <= 0 {
 		return nil
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue temp unschedulable failed: account=%d err=%v", id, err)
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
@@ -1489,7 +1489,7 @@ func (r *accountRepository) ClearTempUnschedulable(ctx context.Context, id int64
 	if err != nil {
 		return err
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue clear temp unschedulable failed: account=%d err=%v", id, err)
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
@@ -1506,7 +1506,7 @@ func (r *accountRepository) ClearRateLimit(ctx context.Context, id int64) error 
 	if err != nil {
 		return err
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue clear rate limit failed: account=%d err=%v", id, err)
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
@@ -1529,9 +1529,9 @@ func (r *accountRepository) ClearAntigravityQuotaScopes(ctx context.Context, id 
 		return err
 	}
 	if affected == 0 {
-		return service.ErrAccountNotFound
+		return domain.ErrAccountNotFound
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue clear quota scopes failed: account=%d err=%v", id, err)
 	}
 	return nil
@@ -1553,9 +1553,9 @@ func (r *accountRepository) ClearModelRateLimits(ctx context.Context, id int64) 
 		return err
 	}
 	if affected == 0 {
-		return service.ErrAccountNotFound
+		return domain.ErrAccountNotFound
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue clear model rate limit failed: account=%d err=%v", id, err)
 	}
 	r.syncSchedulerAccountSnapshot(ctx, id)
@@ -1578,7 +1578,7 @@ func (r *accountRepository) UpdateSessionWindow(ctx context.Context, id int64, s
 	}
 	// 触发调度器缓存更新（仅当窗口时间有变化时）
 	if start != nil || end != nil {
-		if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 			logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue session window update failed: account=%d err=%v", id, err)
 		}
 	}
@@ -1593,7 +1593,7 @@ func (r *accountRepository) UpdateSessionWindowEnd(ctx context.Context, id int64
 	if err != nil {
 		return err
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue session window end update failed: account=%d err=%v", id, err)
 	}
 	return nil
@@ -1607,7 +1607,7 @@ func (r *accountRepository) SetSchedulable(ctx context.Context, id int64, schedu
 	if err != nil {
 		return err
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue schedulable change failed: account=%d err=%v", id, err)
 	}
 	if !schedulable {
@@ -1635,7 +1635,7 @@ func (r *accountRepository) AutoPauseExpiredAccounts(ctx context.Context, now ti
 		return 0, err
 	}
 	if rows > 0 {
-		if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventFullRebuild, nil, nil, nil); err != nil {
+		if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventFullRebuild, nil, nil, nil); err != nil {
 			logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue auto pause rebuild failed: err=%v", err)
 		}
 	}
@@ -1669,10 +1669,10 @@ func (r *accountRepository) UpdateExtra(ctx context.Context, id int64, updates m
 		return err
 	}
 	if affected == 0 {
-		return service.ErrAccountNotFound
+		return domain.ErrAccountNotFound
 	}
 	if shouldEnqueueSchedulerOutboxForExtraUpdates(updates) {
-		if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 			logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue extra update failed: account=%d err=%v", id, err)
 		}
 	} else {
@@ -1810,11 +1810,11 @@ func (r *accountRepository) BulkUpdate(ctx context.Context, ids []int64, updates
 	}
 	if rows > 0 {
 		payload := map[string]any{"account_ids": ids}
-		if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountBulkChanged, nil, nil, payload); err != nil {
+		if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountBulkChanged, nil, nil, payload); err != nil {
 			logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue bulk update failed: err=%v", err)
 		}
 		shouldSync := false
-		if updates.Status != nil && (*updates.Status == service.StatusError || *updates.Status == service.StatusDisabled) {
+		if updates.Status != nil && (*updates.Status == domain.StatusError || *updates.Status == domain.StatusDisabled) {
 			shouldSync = true
 		}
 		if updates.Schedulable != nil && !*updates.Schedulable {
@@ -1987,8 +1987,8 @@ func notExpiredPredicate(now time.Time) dbpredicate.Account {
 // direct) should mark the bound accounts inactive separately.
 //
 // See upstream #2159.
-func (r *accountRepository) loadProxies(ctx context.Context, proxyIDs []int64) (map[int64]*service.Proxy, error) {
-	proxyMap := make(map[int64]*service.Proxy)
+func (r *accountRepository) loadProxies(ctx context.Context, proxyIDs []int64) (map[int64]*domain.Proxy, error) {
+	proxyMap := make(map[int64]*domain.Proxy)
 	proxyIDs = uniquePositiveInt64s(proxyIDs)
 	if len(proxyIDs) == 0 {
 		return proxyMap, nil
@@ -2002,7 +2002,7 @@ func (r *accountRepository) loadProxies(ctx context.Context, proxyIDs []int64) (
 		proxies, err := r.client.Proxy.Query().
 			Where(
 				dbproxy.IDIn(proxyIDs[start:end]...),
-				dbproxy.StatusEQ(service.StatusActive),
+				dbproxy.StatusEQ(domain.StatusActive),
 			).
 			All(ctx)
 		if err != nil {
@@ -2285,7 +2285,7 @@ func (r *accountRepository) FindByExtraField(ctx context.Context, key string, va
 		).
 		All(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrAccountNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrAccountNotFound, nil)
 	}
 
 	return r.accountsToService(ctx, accounts)
@@ -2447,7 +2447,7 @@ func (r *accountRepository) IncrementQuotaUsed(ctx context.Context, id int64, am
 
 	// 任一维度配额刚超限时触发调度快照刷新
 	if limit > 0 && newUsed >= limit && (newUsed-amount) < limit {
-		if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 			logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue quota exceeded failed: account=%d err=%v", id, err)
 		}
 	}
@@ -2468,7 +2468,7 @@ func (r *accountRepository) ResetQuotaUsed(ctx context.Context, id int64) error 
 		return err
 	}
 	// 重置配额后触发调度快照刷新，使账号重新参与调度
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue quota reset failed: account=%d err=%v", id, err)
 	}
 	return nil
@@ -2488,7 +2488,7 @@ func (r *accountRepository) RevertProxyFallback(ctx context.Context, accountID i
 	if n == 0 {
 		return service.ErrAccountNotInFallback
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventAccountChanged, &accountID, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] revert fallback enqueue failed: account=%d err=%v", accountID, err)
 	}
 	return nil

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/accountgroup"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/suite"
@@ -101,9 +102,9 @@ func TestAccountRepoSuite(t *testing.T) {
 func (s *AccountRepoSuite) TestCreate() {
 	account := &service.Account{
 		Name:        "test-create",
-		Platform:    service.PlatformAnthropic,
-		Type:        service.AccountTypeOAuth,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformAnthropic,
+		Type:        domain.AccountTypeOAuth,
+		Status:      domain.StatusActive,
 		Credentials: map[string]any{},
 		Extra:       map[string]any{},
 		Concurrency: 3,
@@ -138,23 +139,23 @@ func (s *AccountRepoSuite) TestUpdate() {
 }
 
 func (s *AccountRepoSuite) TestUpdate_SyncSchedulerSnapshotOnDisabled() {
-	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "sync-update", Status: service.StatusActive, Schedulable: true})
+	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "sync-update", Status: domain.StatusActive, Schedulable: true})
 	cacheRecorder := &schedulerCacheRecorder{}
 	s.repo.schedulerCache = cacheRecorder
 
-	account.Status = service.StatusDisabled
+	account.Status = domain.StatusDisabled
 	err := s.repo.Update(s.ctx, account)
 	s.Require().NoError(err, "Update")
 
 	s.Require().Len(cacheRecorder.setAccounts, 1)
 	s.Require().Equal(account.ID, cacheRecorder.setAccounts[0].ID)
-	s.Require().Equal(service.StatusDisabled, cacheRecorder.setAccounts[0].Status)
+	s.Require().Equal(domain.StatusDisabled, cacheRecorder.setAccounts[0].Status)
 }
 
 func (s *AccountRepoSuite) TestUpdate_SyncSchedulerSnapshotOnCredentialsChange() {
 	account := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "sync-credentials-update",
-		Status:      service.StatusActive,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 		Credentials: map[string]any{
 			"model_mapping": map[string]any{
@@ -197,7 +198,7 @@ func (s *AccountRepoSuite) TestDelete_RemovesSchedulerAccountSnapshot() {
 			account.ID: {
 				ID:          account.ID,
 				Name:        account.Name,
-				Status:      service.StatusActive,
+				Status:      domain.StatusActive,
 				Schedulable: true,
 			},
 		},
@@ -252,13 +253,13 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 		{
 			name: "filter_by_platform",
 			setup: func(client *dbent.Client) {
-				mustCreateAccount(s.T(), client, &service.Account{Name: "a1", Platform: service.PlatformAnthropic})
-				mustCreateAccount(s.T(), client, &service.Account{Name: "a2", Platform: service.PlatformOpenAI})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "a1", Platform: domain.PlatformAnthropic})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "a2", Platform: domain.PlatformOpenAI})
 			},
-			platform:  service.PlatformOpenAI,
+			platform:  domain.PlatformOpenAI,
 			wantCount: 1,
 			validate: func(accounts []service.Account) {
-				s.Require().Equal(service.PlatformOpenAI, accounts[0].Platform)
+				s.Require().Equal(domain.PlatformOpenAI, accounts[0].Platform)
 			},
 		},
 		{
@@ -266,8 +267,8 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 			setup: func(client *dbent.Client) {
 				mustCreateAccount(s.T(), client, &service.Account{
 					Name:     "kiro-stub",
-					Platform: service.PlatformAnthropic,
-					Type:     service.AccountTypeAPIKey,
+					Platform: domain.PlatformAnthropic,
+					Type:     domain.AccountTypeAPIKey,
 					Credentials: map[string]any{
 						"api_key":         "tk-edge",
 						"base_url":        "https://api-us4.tokenkey.dev",
@@ -276,8 +277,8 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 				})
 				mustCreateAccount(s.T(), client, &service.Account{
 					Name:     "plain-anthropic-edge",
-					Platform: service.PlatformAnthropic,
-					Type:     service.AccountTypeAPIKey,
+					Platform: domain.PlatformAnthropic,
+					Type:     domain.AccountTypeAPIKey,
 					Credentials: map[string]any{
 						"api_key":         "tk-edge",
 						"base_url":        "https://api-us4.tokenkey.dev",
@@ -286,16 +287,16 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 				})
 				mustCreateAccount(s.T(), client, &service.Account{
 					Name:     "kiro-oauth",
-					Platform: service.PlatformKiro,
-					Type:     service.AccountTypeOAuth,
+					Platform: domain.PlatformKiro,
+					Type:     domain.AccountTypeOAuth,
 					Credentials: map[string]any{
 						"access_token": "access",
 					},
 				})
 				mustCreateAccount(s.T(), client, &service.Account{
 					Name:     "kiro-non-edge",
-					Platform: service.PlatformAnthropic,
-					Type:     service.AccountTypeAPIKey,
+					Platform: domain.PlatformAnthropic,
+					Type:     domain.AccountTypeAPIKey,
 					Credentials: map[string]any{
 						"api_key":         "key",
 						"base_url":        "https://api.anthropic.com",
@@ -307,8 +308,8 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 			wantCount: 1,
 			validate: func(accounts []service.Account) {
 				s.Require().Equal("kiro-stub", accounts[0].Name)
-				s.Require().Equal(service.PlatformAnthropic, accounts[0].Platform)
-				s.Require().Equal(service.AccountTypeAPIKey, accounts[0].Type)
+				s.Require().Equal(domain.PlatformAnthropic, accounts[0].Platform)
+				s.Require().Equal(domain.AccountTypeAPIKey, accounts[0].Type)
 			},
 		},
 		{
@@ -316,8 +317,8 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 			setup: func(client *dbent.Client) {
 				mustCreateAccount(s.T(), client, &service.Account{
 					Name:     "kiro-stub",
-					Platform: service.PlatformAnthropic,
-					Type:     service.AccountTypeAPIKey,
+					Platform: domain.PlatformAnthropic,
+					Type:     domain.AccountTypeAPIKey,
 					Credentials: map[string]any{
 						"api_key":         "tk-edge",
 						"base_url":        "https://api-us4.tokenkey.dev",
@@ -326,8 +327,8 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 				})
 				mustCreateAccount(s.T(), client, &service.Account{
 					Name:     "plain-anthropic-edge",
-					Platform: service.PlatformAnthropic,
-					Type:     service.AccountTypeAPIKey,
+					Platform: domain.PlatformAnthropic,
+					Type:     domain.AccountTypeAPIKey,
 					Credentials: map[string]any{
 						"api_key":         "tk-edge",
 						"base_url":        "https://api-us4.tokenkey.dev",
@@ -336,16 +337,16 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 				})
 				mustCreateAccount(s.T(), client, &service.Account{
 					Name:     "kiro-oauth",
-					Platform: service.PlatformKiro,
-					Type:     service.AccountTypeOAuth,
+					Platform: domain.PlatformKiro,
+					Type:     domain.AccountTypeOAuth,
 					Credentials: map[string]any{
 						"access_token": "access",
 					},
 				})
 				mustCreateAccount(s.T(), client, &service.Account{
 					Name:     "kiro-non-edge",
-					Platform: service.PlatformAnthropic,
-					Type:     service.AccountTypeAPIKey,
+					Platform: domain.PlatformAnthropic,
+					Type:     domain.AccountTypeAPIKey,
 					Credentials: map[string]any{
 						"api_key":         "key",
 						"base_url":        "https://api.anthropic.com",
@@ -353,7 +354,7 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 					},
 				})
 			},
-			platform:  service.PlatformKiro,
+			platform:  domain.PlatformKiro,
 			wantCount: 2,
 			validate: func(accounts []service.Account) {
 				names := make([]string, 0, len(accounts))
@@ -366,48 +367,48 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 		{
 			name: "filter_by_type",
 			setup: func(client *dbent.Client) {
-				mustCreateAccount(s.T(), client, &service.Account{Name: "t1", Type: service.AccountTypeOAuth})
-				mustCreateAccount(s.T(), client, &service.Account{Name: "t2", Type: service.AccountTypeAPIKey})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "t1", Type: domain.AccountTypeOAuth})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "t2", Type: domain.AccountTypeAPIKey})
 			},
-			accType:   service.AccountTypeAPIKey,
+			accType:   domain.AccountTypeAPIKey,
 			wantCount: 1,
 			validate: func(accounts []service.Account) {
-				s.Require().Equal(service.AccountTypeAPIKey, accounts[0].Type)
+				s.Require().Equal(domain.AccountTypeAPIKey, accounts[0].Type)
 			},
 		},
 		{
 			name: "filter_by_status",
 			setup: func(client *dbent.Client) {
-				mustCreateAccount(s.T(), client, &service.Account{Name: "s1", Status: service.StatusActive})
-				mustCreateAccount(s.T(), client, &service.Account{Name: "s2", Status: service.StatusDisabled})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "s1", Status: domain.StatusActive})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "s2", Status: domain.StatusDisabled})
 			},
-			status:    service.StatusDisabled,
+			status:    domain.StatusDisabled,
 			wantCount: 1,
 			validate: func(accounts []service.Account) {
-				s.Require().Equal(service.StatusDisabled, accounts[0].Status)
+				s.Require().Equal(domain.StatusDisabled, accounts[0].Status)
 			},
 		},
 		{
 			name: "filter_by_status_active_excludes_runtime_blocked_accounts",
 			setup: func(client *dbent.Client) {
-				mustCreateAccount(s.T(), client, &service.Account{Name: "active-normal", Status: service.StatusActive})
-				rateLimited := mustCreateAccount(s.T(), client, &service.Account{Name: "active-rate-limited", Status: service.StatusActive})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "active-normal", Status: domain.StatusActive})
+				rateLimited := mustCreateAccount(s.T(), client, &service.Account{Name: "active-rate-limited", Status: domain.StatusActive})
 				err := client.Account.UpdateOneID(rateLimited.ID).
 					SetRateLimitResetAt(time.Now().Add(10 * time.Minute)).
 					Exec(context.Background())
 				s.Require().NoError(err)
-				tempUnsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-temp-unsched", Status: service.StatusActive})
+				tempUnsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-temp-unsched", Status: domain.StatusActive})
 				err = client.Account.UpdateOneID(tempUnsched.ID).
 					SetTempUnschedulableUntil(time.Now().Add(15 * time.Minute)).
 					Exec(context.Background())
 				s.Require().NoError(err)
-				unsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-unsched", Status: service.StatusActive})
+				unsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-unsched", Status: domain.StatusActive})
 				err = client.Account.UpdateOneID(unsched.ID).
 					SetSchedulable(false).
 					Exec(context.Background())
 				s.Require().NoError(err)
 			},
-			status:    service.StatusActive,
+			status:    domain.StatusActive,
 			wantCount: 1,
 			validate: func(accounts []service.Account) {
 				s.Require().Equal("active-normal", accounts[0].Name)
@@ -416,19 +417,19 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 		{
 			name: "filter_by_status_unschedulable_excludes_rate_limited_and_temp_unschedulable",
 			setup: func(client *dbent.Client) {
-				mustCreateAccount(s.T(), client, &service.Account{Name: "active-normal", Status: service.StatusActive, Schedulable: true})
-				unsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-unsched", Status: service.StatusActive})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "active-normal", Status: domain.StatusActive, Schedulable: true})
+				unsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-unsched", Status: domain.StatusActive})
 				err := client.Account.UpdateOneID(unsched.ID).
 					SetSchedulable(false).
 					Exec(context.Background())
 				s.Require().NoError(err)
-				rateLimited := mustCreateAccount(s.T(), client, &service.Account{Name: "active-rate-limited", Status: service.StatusActive})
+				rateLimited := mustCreateAccount(s.T(), client, &service.Account{Name: "active-rate-limited", Status: domain.StatusActive})
 				err = client.Account.UpdateOneID(rateLimited.ID).
 					SetSchedulable(false).
 					SetRateLimitResetAt(time.Now().Add(10 * time.Minute)).
 					Exec(context.Background())
 				s.Require().NoError(err)
-				tempUnsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-temp-unsched", Status: service.StatusActive})
+				tempUnsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-temp-unsched", Status: domain.StatusActive})
 				err = client.Account.UpdateOneID(tempUnsched.ID).
 					SetSchedulable(false).
 					SetTempUnschedulableUntil(time.Now().Add(15 * time.Minute)).
@@ -444,12 +445,12 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 		{
 			name: "filter_by_status_rate_limited_excludes_temp_unschedulable",
 			setup: func(client *dbent.Client) {
-				rateLimited := mustCreateAccount(s.T(), client, &service.Account{Name: "active-rate-limited", Status: service.StatusActive})
+				rateLimited := mustCreateAccount(s.T(), client, &service.Account{Name: "active-rate-limited", Status: domain.StatusActive})
 				err := client.Account.UpdateOneID(rateLimited.ID).
 					SetRateLimitResetAt(time.Now().Add(10 * time.Minute)).
 					Exec(context.Background())
 				s.Require().NoError(err)
-				tempUnsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-temp-unsched", Status: service.StatusActive})
+				tempUnsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-temp-unsched", Status: domain.StatusActive})
 				err = client.Account.UpdateOneID(tempUnsched.ID).
 					SetRateLimitResetAt(time.Now().Add(20 * time.Minute)).
 					SetTempUnschedulableUntil(time.Now().Add(15 * time.Minute)).
@@ -465,12 +466,12 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 		{
 			name: "filter_by_status_temp_unschedulable_excludes_manually_unschedulable",
 			setup: func(client *dbent.Client) {
-				tempUnsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-temp-unsched", Status: service.StatusActive, Schedulable: true})
+				tempUnsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-temp-unsched", Status: domain.StatusActive, Schedulable: true})
 				err := client.Account.UpdateOneID(tempUnsched.ID).
 					SetTempUnschedulableUntil(time.Now().Add(15 * time.Minute)).
 					Exec(context.Background())
 				s.Require().NoError(err)
-				unsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-unsched", Status: service.StatusActive})
+				unsched := mustCreateAccount(s.T(), client, &service.Account{Name: "active-unsched", Status: domain.StatusActive})
 				err = client.Account.UpdateOneID(unsched.ID).
 					SetSchedulable(false).
 					Exec(context.Background())
@@ -566,8 +567,8 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 
 func (s *AccountRepoSuite) TestListByGroup() {
 	group := mustCreateGroup(s.T(), s.client, &service.Group{Name: "g-list"})
-	acc1 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "a1", Status: service.StatusActive})
-	acc2 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "a2", Status: service.StatusActive})
+	acc1 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "a1", Status: domain.StatusActive})
+	acc2 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "a2", Status: domain.StatusActive})
 	mustBindAccountToGroup(s.T(), s.client, acc1.ID, group.ID, 2)
 	mustBindAccountToGroup(s.T(), s.client, acc2.ID, group.ID, 1)
 
@@ -579,8 +580,8 @@ func (s *AccountRepoSuite) TestListByGroup() {
 }
 
 func (s *AccountRepoSuite) TestListActive() {
-	mustCreateAccount(s.T(), s.client, &service.Account{Name: "active1", Status: service.StatusActive})
-	mustCreateAccount(s.T(), s.client, &service.Account{Name: "inactive1", Status: service.StatusDisabled})
+	mustCreateAccount(s.T(), s.client, &service.Account{Name: "active1", Status: domain.StatusActive})
+	mustCreateAccount(s.T(), s.client, &service.Account{Name: "inactive1", Status: domain.StatusDisabled})
 
 	accounts, err := s.repo.ListActive(s.ctx)
 	s.Require().NoError(err, "ListActive")
@@ -589,19 +590,19 @@ func (s *AccountRepoSuite) TestListActive() {
 }
 
 func (s *AccountRepoSuite) TestListByPlatform() {
-	mustCreateAccount(s.T(), s.client, &service.Account{Name: "p1", Platform: service.PlatformAnthropic, Status: service.StatusActive})
-	mustCreateAccount(s.T(), s.client, &service.Account{Name: "p2", Platform: service.PlatformOpenAI, Status: service.StatusActive})
+	mustCreateAccount(s.T(), s.client, &service.Account{Name: "p1", Platform: domain.PlatformAnthropic, Status: domain.StatusActive})
+	mustCreateAccount(s.T(), s.client, &service.Account{Name: "p2", Platform: domain.PlatformOpenAI, Status: domain.StatusActive})
 
-	accounts, err := s.repo.ListByPlatform(s.ctx, service.PlatformAnthropic)
+	accounts, err := s.repo.ListByPlatform(s.ctx, domain.PlatformAnthropic)
 	s.Require().NoError(err, "ListByPlatform")
 	s.Require().Len(accounts, 1)
-	s.Require().Equal(service.PlatformAnthropic, accounts[0].Platform)
+	s.Require().Equal(domain.PlatformAnthropic, accounts[0].Platform)
 }
 
 // --- Preload and VirtualFields ---
 
 func (s *AccountRepoSuite) TestPreload_And_VirtualFields() {
-	proxy := mustCreateProxy(s.T(), s.client, &service.Proxy{Name: "p1"})
+	proxy := mustCreateProxy(s.T(), s.client, &domain.Proxy{Name: "p1"})
 	group := mustCreateGroup(s.T(), s.client, &service.Group{Name: "g1"})
 
 	account := mustCreateAccount(s.T(), s.client, &service.Account{
@@ -636,8 +637,8 @@ func (s *AccountRepoSuite) TestPreload_And_VirtualFields() {
 // for "disable this proxy"), rather than continuing to route through a proxy
 // the operator explicitly turned off.
 func (s *AccountRepoSuite) TestPreload_SkipsDisabledProxy() {
-	disabledProxy := mustCreateProxy(s.T(), s.client, &service.Proxy{Name: "p-disabled", Status: "disabled"})
-	activeProxy := mustCreateProxy(s.T(), s.client, &service.Proxy{Name: "p-active"})
+	disabledProxy := mustCreateProxy(s.T(), s.client, &domain.Proxy{Name: "p-disabled", Status: "disabled"})
+	activeProxy := mustCreateProxy(s.T(), s.client, &domain.Proxy{Name: "p-active"})
 
 	accDisabled := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:    "acc-with-disabled-proxy",
@@ -760,23 +761,23 @@ func (s *AccountRepoSuite) TestListSchedulableByGroupID_TimeBoundaries_And_Statu
 }
 
 func (s *AccountRepoSuite) TestListSchedulableByPlatform() {
-	mustCreateAccount(s.T(), s.client, &service.Account{Name: "a1", Platform: service.PlatformAnthropic, Schedulable: true})
-	mustCreateAccount(s.T(), s.client, &service.Account{Name: "a2", Platform: service.PlatformOpenAI, Schedulable: true})
+	mustCreateAccount(s.T(), s.client, &service.Account{Name: "a1", Platform: domain.PlatformAnthropic, Schedulable: true})
+	mustCreateAccount(s.T(), s.client, &service.Account{Name: "a2", Platform: domain.PlatformOpenAI, Schedulable: true})
 
-	accounts, err := s.repo.ListSchedulableByPlatform(s.ctx, service.PlatformAnthropic)
+	accounts, err := s.repo.ListSchedulableByPlatform(s.ctx, domain.PlatformAnthropic)
 	s.Require().NoError(err)
 	s.Require().Len(accounts, 1)
-	s.Require().Equal(service.PlatformAnthropic, accounts[0].Platform)
+	s.Require().Equal(domain.PlatformAnthropic, accounts[0].Platform)
 }
 
 func (s *AccountRepoSuite) TestListSchedulableByGroupIDAndPlatform() {
 	group := mustCreateGroup(s.T(), s.client, &service.Group{Name: "g-sp"})
-	a1 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "a1", Platform: service.PlatformAnthropic, Schedulable: true})
-	a2 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "a2", Platform: service.PlatformOpenAI, Schedulable: true})
+	a1 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "a1", Platform: domain.PlatformAnthropic, Schedulable: true})
+	a2 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "a2", Platform: domain.PlatformOpenAI, Schedulable: true})
 	mustBindAccountToGroup(s.T(), s.client, a1.ID, group.ID, 1)
 	mustBindAccountToGroup(s.T(), s.client, a2.ID, group.ID, 2)
 
-	accounts, err := s.repo.ListSchedulableByGroupIDAndPlatform(s.ctx, group.ID, service.PlatformAnthropic)
+	accounts, err := s.repo.ListSchedulableByGroupIDAndPlatform(s.ctx, group.ID, domain.PlatformAnthropic)
 	s.Require().NoError(err)
 	s.Require().Len(accounts, 1)
 	s.Require().Equal(a1.ID, accounts[0].ID)
@@ -797,12 +798,12 @@ func (s *AccountRepoSuite) TestSetSchedulable() {
 }
 
 func (s *AccountRepoSuite) TestBulkUpdate_SyncSchedulerSnapshotOnDisabled() {
-	account1 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "bulk-1", Status: service.StatusActive, Schedulable: true})
-	account2 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "bulk-2", Status: service.StatusActive, Schedulable: true})
+	account1 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "bulk-1", Status: domain.StatusActive, Schedulable: true})
+	account2 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "bulk-2", Status: domain.StatusActive, Schedulable: true})
 	cacheRecorder := &schedulerCacheRecorder{}
 	s.repo.schedulerCache = cacheRecorder
 
-	disabled := service.StatusDisabled
+	disabled := domain.StatusDisabled
 	rows, err := s.repo.BulkUpdate(s.ctx, []int64{account1.ID, account2.ID}, service.AccountBulkUpdate{
 		Status: &disabled,
 	})
@@ -976,20 +977,20 @@ func (s *AccountRepoSuite) TestUpdateLastUsed() {
 // --- SetError ---
 
 func (s *AccountRepoSuite) TestSetError() {
-	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-err", Status: service.StatusActive, Schedulable: true})
+	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-err", Status: domain.StatusActive, Schedulable: true})
 
 	s.Require().NoError(s.repo.SetError(s.ctx, account.ID, "something went wrong"))
 
 	got, err := s.repo.GetByID(s.ctx, account.ID)
 	s.Require().NoError(err)
-	s.Require().Equal(service.StatusError, got.Status)
+	s.Require().Equal(domain.StatusError, got.Status)
 	s.Require().Equal("something went wrong", got.ErrorMessage)
 	s.Require().False(got.Schedulable)
 }
 
 func (s *AccountRepoSuite) TestUpdateErrorStatusUnschedulesAccount() {
-	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-update-err", Status: service.StatusActive, Schedulable: true})
-	account.Status = service.StatusError
+	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-update-err", Status: domain.StatusActive, Schedulable: true})
+	account.Status = domain.StatusError
 	account.ErrorMessage = "token revoked"
 	account.Schedulable = true
 
@@ -997,7 +998,7 @@ func (s *AccountRepoSuite) TestUpdateErrorStatusUnschedulesAccount() {
 
 	got, err := s.repo.GetByID(s.ctx, account.ID)
 	s.Require().NoError(err)
-	s.Require().Equal(service.StatusError, got.Status)
+	s.Require().Equal(domain.StatusError, got.Status)
 	s.Require().Equal("token revoked", got.ErrorMessage)
 	s.Require().False(got.Schedulable)
 }
@@ -1005,7 +1006,7 @@ func (s *AccountRepoSuite) TestUpdateErrorStatusUnschedulesAccount() {
 func (s *AccountRepoSuite) TestClearError_SyncSchedulerSnapshotOnRecovery() {
 	account := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:         "acc-clear-err",
-		Status:       service.StatusError,
+		Status:       domain.StatusError,
 		ErrorMessage: "temporary error",
 	})
 	cacheRecorder := &schedulerCacheRecorder{}
@@ -1015,11 +1016,11 @@ func (s *AccountRepoSuite) TestClearError_SyncSchedulerSnapshotOnRecovery() {
 
 	got, err := s.repo.GetByID(s.ctx, account.ID)
 	s.Require().NoError(err)
-	s.Require().Equal(service.StatusActive, got.Status)
+	s.Require().Equal(domain.StatusActive, got.Status)
 	s.Require().Empty(got.ErrorMessage)
 	s.Require().Len(cacheRecorder.setAccounts, 1)
 	s.Require().Equal(account.ID, cacheRecorder.setAccounts[0].ID)
-	s.Require().Equal(service.StatusActive, cacheRecorder.setAccounts[0].Status)
+	s.Require().Equal(domain.StatusActive, cacheRecorder.setAccounts[0].Status)
 }
 
 // --- UpdateSessionWindow ---
@@ -1070,7 +1071,7 @@ func (s *AccountRepoSuite) TestUpdateExtra_NilExtra() {
 func (s *AccountRepoSuite) TestUpdateExtra_SchedulerNeutralSkipsOutboxAndSyncsFreshSnapshot() {
 	account := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:     "acc-extra-neutral",
-		Platform: service.PlatformOpenAI,
+		Platform: domain.PlatformOpenAI,
 		Extra:    map[string]any{"codex_usage_updated_at": "old"},
 	})
 	cacheRecorder := &schedulerCacheRecorder{
@@ -1078,7 +1079,7 @@ func (s *AccountRepoSuite) TestUpdateExtra_SchedulerNeutralSkipsOutboxAndSyncsFr
 			account.ID: {
 				ID:       account.ID,
 				Platform: account.Platform,
-				Status:   service.StatusDisabled,
+				Status:   domain.StatusDisabled,
 				Extra: map[string]any{
 					"codex_usage_updated_at": "old",
 				},
@@ -1105,15 +1106,15 @@ func (s *AccountRepoSuite) TestUpdateExtra_SchedulerNeutralSkipsOutboxAndSyncsFr
 	s.Require().Zero(outboxCount)
 	s.Require().Len(cacheRecorder.setAccounts, 1)
 	s.Require().NotNil(cacheRecorder.accounts[account.ID])
-	s.Require().Equal(service.StatusActive, cacheRecorder.accounts[account.ID].Status)
+	s.Require().Equal(domain.StatusActive, cacheRecorder.accounts[account.ID].Status)
 	s.Require().Equal("2026-03-11T10:00:00Z", cacheRecorder.accounts[account.ID].Extra["codex_usage_updated_at"])
 }
 
 func (s *AccountRepoSuite) TestUpdateExtra_ExhaustedCodexSnapshotSyncsSchedulerCache() {
 	account := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:     "acc-extra-codex-exhausted",
-		Platform: service.PlatformOpenAI,
-		Type:     service.AccountTypeOAuth,
+		Platform: domain.PlatformOpenAI,
+		Type:     domain.AccountTypeOAuth,
 		Extra:    map[string]any{},
 	})
 	cacheRecorder := &schedulerCacheRecorder{}
@@ -1133,14 +1134,14 @@ func (s *AccountRepoSuite) TestUpdateExtra_ExhaustedCodexSnapshotSyncsSchedulerC
 	s.Require().Equal(0, count)
 	s.Require().Len(cacheRecorder.setAccounts, 1)
 	s.Require().Equal(account.ID, cacheRecorder.setAccounts[0].ID)
-	s.Require().Equal(service.StatusActive, cacheRecorder.setAccounts[0].Status)
+	s.Require().Equal(domain.StatusActive, cacheRecorder.setAccounts[0].Status)
 	s.Require().Equal(100.0, cacheRecorder.setAccounts[0].Extra["codex_7d_used_percent"])
 }
 
 func (s *AccountRepoSuite) TestUpdateExtra_SchedulerRelevantStillEnqueuesOutbox() {
 	account := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:     "acc-extra-mixed",
-		Platform: service.PlatformAntigravity,
+		Platform: domain.PlatformAntigravity,
 		Extra:    map[string]any{},
 	})
 	_, err := s.repo.sql.ExecContext(s.ctx, "TRUNCATE scheduler_outbox")
@@ -1189,10 +1190,10 @@ func (s *AccountRepoSuite) TestGetByCRSAccountID_EmptyString() {
 func (s *AccountRepoSuite) TestGetByCRSAccountID_ExcludesSparkShadow() {
 	crsID := "crs-shadow-only-99"
 	parent := mustCreateAccount(s.T(), s.client, &service.Account{
-		Name: "crs-mother", Platform: service.PlatformOpenAI, Type: service.AccountTypeOAuth,
+		Name: "crs-mother", Platform: domain.PlatformOpenAI, Type: domain.AccountTypeOAuth,
 	})
 	mustCreateAccount(s.T(), s.client, &service.Account{
-		Name: "crs-shadow", Platform: service.PlatformOpenAI, Type: service.AccountTypeOAuth,
+		Name: "crs-shadow", Platform: domain.PlatformOpenAI, Type: domain.AccountTypeOAuth,
 		ParentAccountID: &parent.ID,
 		QuotaDimension:  service.QuotaDimensionSpark,
 		Extra:           map[string]any{"crs_account_id": crsID},
@@ -1207,11 +1208,11 @@ func (s *AccountRepoSuite) TestGetByCRSAccountID_ExcludesSparkShadow() {
 // CRS 同步映射(否则后续 CRS 同步会把影子当普通账号更新)。
 func (s *AccountRepoSuite) TestListCRSAccountIDs_ExcludesSparkShadow() {
 	parent := mustCreateAccount(s.T(), s.client, &service.Account{
-		Name: "crs-list-mother", Platform: service.PlatformOpenAI, Type: service.AccountTypeOAuth,
+		Name: "crs-list-mother", Platform: domain.PlatformOpenAI, Type: domain.AccountTypeOAuth,
 	})
 	shadowCRSID := "crs-list-shadow-77"
 	mustCreateAccount(s.T(), s.client, &service.Account{
-		Name: "crs-list-shadow", Platform: service.PlatformOpenAI, Type: service.AccountTypeOAuth,
+		Name: "crs-list-shadow", Platform: domain.PlatformOpenAI, Type: domain.AccountTypeOAuth,
 		ParentAccountID: &parent.ID,
 		QuotaDimension:  service.QuotaDimensionSpark,
 		Extra:           map[string]any{"crs_account_id": shadowCRSID},
@@ -1290,22 +1291,22 @@ func (s *AccountRepoSuite) TestBulkUpdate_EmptyUpdates() {
 
 func (s *AccountRepoSuite) TestSumConcurrencyAnthropic_FilterByPlatformAndSchedulable() {
 	mustCreateAccount(s.T(), s.client, &service.Account{
-		Name: "sum-auth-4", Platform: service.PlatformAnthropic, Type: service.AccountTypeOAuth, Concurrency: 4,
+		Name: "sum-auth-4", Platform: domain.PlatformAnthropic, Type: domain.AccountTypeOAuth, Concurrency: 4,
 	})
 	mustCreateAccount(s.T(), s.client, &service.Account{
-		Name: "sum-auth-5", Platform: service.PlatformAnthropic, Type: service.AccountTypeOAuth, Concurrency: 5,
+		Name: "sum-auth-5", Platform: domain.PlatformAnthropic, Type: domain.AccountTypeOAuth, Concurrency: 5,
 	})
 	mustCreateAccount(s.T(), s.client, &service.Account{
-		Name: "sum-apikey-big", Platform: service.PlatformAnthropic, Type: service.AccountTypeAPIKey, Concurrency: 900,
+		Name: "sum-apikey-big", Platform: domain.PlatformAnthropic, Type: domain.AccountTypeAPIKey, Concurrency: 900,
 	})
 	mustCreateAccount(s.T(), s.client, &service.Account{
-		Name: "sum-openai-oauth", Platform: service.PlatformOpenAI, Type: service.AccountTypeOAuth, Concurrency: 800,
+		Name: "sum-openai-oauth", Platform: domain.PlatformOpenAI, Type: domain.AccountTypeOAuth, Concurrency: 800,
 	})
 	// Non-schedulable anthropic row must be excluded from the operator-concurrency
 	// sum (mirrors ops/anthropic operator SQL: AND schedulable = true). The fixture
 	// forces schedulable=true, so flip it directly afterwards.
 	unsched := mustCreateAccount(s.T(), s.client, &service.Account{
-		Name: "sum-anthropic-unsched", Platform: service.PlatformAnthropic, Type: service.AccountTypeAPIKey, Concurrency: 50,
+		Name: "sum-anthropic-unsched", Platform: domain.PlatformAnthropic, Type: domain.AccountTypeAPIKey, Concurrency: 50,
 	})
 	s.Require().NoError(s.client.Account.UpdateOneID(unsched.ID).SetSchedulable(false).Exec(s.ctx))
 

--- a/backend/internal/repository/account_repo_spark_shadow_test.go
+++ b/backend/internal/repository/account_repo_spark_shadow_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -16,9 +17,9 @@ func TestAccountRepoSparkShadowRoundTrip(t *testing.T) {
 
 	parent := &service.Account{
 		Name:     "parent",
-		Platform: service.PlatformOpenAI,
-		Type:     service.AccountTypeOAuth,
-		Status:   service.StatusActive,
+		Platform: domain.PlatformOpenAI,
+		Type:     domain.AccountTypeOAuth,
+		Status:   domain.StatusActive,
 	}
 	if err := repo.Create(ctx, parent); err != nil {
 		t.Fatalf("create parent: %v", err)
@@ -26,9 +27,9 @@ func TestAccountRepoSparkShadowRoundTrip(t *testing.T) {
 	pid := parent.ID
 	shadow := &service.Account{
 		Name:            "shadow",
-		Platform:        service.PlatformOpenAI,
-		Type:            service.AccountTypeOAuth,
-		Status:          service.StatusActive,
+		Platform:        domain.PlatformOpenAI,
+		Type:            domain.AccountTypeOAuth,
+		Status:          domain.StatusActive,
 		ParentAccountID: &pid,
 		QuotaDimension:  service.QuotaDimensionSpark,
 	}
@@ -59,9 +60,9 @@ func TestListShadowsByParent(t *testing.T) {
 	// Create parent1 and its spark shadow
 	parent1 := &service.Account{
 		Name:     "list-parent1",
-		Platform: service.PlatformOpenAI,
-		Type:     service.AccountTypeOAuth,
-		Status:   service.StatusActive,
+		Platform: domain.PlatformOpenAI,
+		Type:     domain.AccountTypeOAuth,
+		Status:   domain.StatusActive,
 	}
 	if err := repo.Create(ctx, parent1); err != nil {
 		t.Fatalf("create parent1: %v", err)
@@ -70,9 +71,9 @@ func TestListShadowsByParent(t *testing.T) {
 
 	shadow1 := &service.Account{
 		Name:            "shadow1",
-		Platform:        service.PlatformOpenAI,
-		Type:            service.AccountTypeOAuth,
-		Status:          service.StatusActive,
+		Platform:        domain.PlatformOpenAI,
+		Type:            domain.AccountTypeOAuth,
+		Status:          domain.StatusActive,
 		ParentAccountID: &pid1,
 		QuotaDimension:  service.QuotaDimensionSpark,
 	}
@@ -83,9 +84,9 @@ func TestListShadowsByParent(t *testing.T) {
 	// Create parent2 and its spark shadow (must NOT appear in parent1's list)
 	parent2 := &service.Account{
 		Name:     "list-parent2",
-		Platform: service.PlatformOpenAI,
-		Type:     service.AccountTypeOAuth,
-		Status:   service.StatusActive,
+		Platform: domain.PlatformOpenAI,
+		Type:     domain.AccountTypeOAuth,
+		Status:   domain.StatusActive,
 	}
 	if err := repo.Create(ctx, parent2); err != nil {
 		t.Fatalf("create parent2: %v", err)
@@ -94,9 +95,9 @@ func TestListShadowsByParent(t *testing.T) {
 
 	shadow2 := &service.Account{
 		Name:            "shadow2",
-		Platform:        service.PlatformOpenAI,
-		Type:            service.AccountTypeOAuth,
-		Status:          service.StatusActive,
+		Platform:        domain.PlatformOpenAI,
+		Type:            domain.AccountTypeOAuth,
+		Status:          domain.StatusActive,
 		ParentAccountID: &pid2,
 		QuotaDimension:  service.QuotaDimensionSpark,
 	}
@@ -107,9 +108,9 @@ func TestListShadowsByParent(t *testing.T) {
 	// Create 1 unrelated normal account (no parent, global dimension)
 	unrelated := &service.Account{
 		Name:     "unrelated",
-		Platform: service.PlatformOpenAI,
-		Type:     service.AccountTypeOAuth,
-		Status:   service.StatusActive,
+		Platform: domain.PlatformOpenAI,
+		Type:     domain.AccountTypeOAuth,
+		Status:   domain.StatusActive,
 	}
 	if err := repo.Create(ctx, unrelated); err != nil {
 		t.Fatalf("create unrelated: %v", err)

--- a/backend/internal/repository/account_repo_test.go
+++ b/backend/internal/repository/account_repo_test.go
@@ -11,7 +11,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	_ "github.com/Wei-Shaw/sub2api/ent/runtime"
-	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/stretchr/testify/require"
 
 	"entgo.io/ent/dialect"
@@ -30,11 +30,11 @@ func TestAccountsToService_LargeActiveAccountSetDoesNotExceedPostgresParameterLi
 		accounts = append(accounts, &dbent.Account{
 			ID:          int64(i + 1),
 			Name:        "large-active",
-			Platform:    service.PlatformOpenAI,
-			Type:        service.AccountTypeOAuth,
+			Platform:    domain.PlatformOpenAI,
+			Type:        domain.AccountTypeOAuth,
 			Credentials: map[string]any{},
 			Extra:       map[string]any{},
-			Status:      service.StatusActive,
+			Status:      domain.StatusActive,
 			Schedulable: true,
 		})
 	}

--- a/backend/internal/repository/account_repo_tk_capacity_batch.go
+++ b/backend/internal/repository/account_repo_tk_capacity_batch.go
@@ -7,6 +7,7 @@ import (
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	dbaccount "github.com/Wei-Shaw/sub2api/ent/account"
 	dbaccountgroup "github.com/Wei-Shaw/sub2api/ent/accountgroup"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -42,7 +43,7 @@ func (r *accountRepository) ListSchedulableByGroupIDs(ctx context.Context, group
 			// Mirror queryAccountsByGroup's schedulable predicate set exactly.
 			dbaccountgroup.HasAccountWith(
 				dbaccount.DeletedAtIsNil(),
-				dbaccount.StatusEQ(service.StatusActive),
+				dbaccount.StatusEQ(domain.StatusActive),
 				dbaccount.SchedulableEQ(true),
 				tempUnschedulablePredicate(),
 				notExpiredPredicate(now),

--- a/backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go
+++ b/backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,7 +89,7 @@ func TestEnqueueOutboxForJustExpiredAccounts_RepoEnqueuesAccountChangedForExpire
 	require.NoError(t, integrationDB.QueryRowContext(t.Context(),
 		`SELECT COUNT(*) FROM scheduler_outbox
 		 WHERE event_type = $1 AND account_id = $2`,
-		service.SchedulerOutboxEventAccountChanged, id).Scan(&rows))
+		domain.SchedulerOutboxEventAccountChanged, id).Scan(&rows))
 	require.Equal(t, 1, rows,
 		"reaper must enqueue exactly one account_changed event per expired account")
 }
@@ -176,7 +176,7 @@ func TestEnqueueOutboxForJustExpiredAccounts_RepoDedupsRepeatedTicksWithin1Secon
 	require.NoError(t, integrationDB.QueryRowContext(t.Context(),
 		`SELECT COUNT(*) FROM scheduler_outbox
 		 WHERE event_type = $1 AND account_id = $2`,
-		service.SchedulerOutboxEventAccountChanged, id).Scan(&rows))
+		domain.SchedulerOutboxEventAccountChanged, id).Scan(&rows))
 	require.Equal(t, 1, rows,
 		"after two back-to-back reaper ticks, exactly one outbox row should exist")
 }

--- a/backend/internal/repository/affiliate_repo.go
+++ b/backend/internal/repository/affiliate_repo.go
@@ -11,6 +11,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/user"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/lib/pq"
 )
@@ -65,7 +66,7 @@ func NewAffiliateRepository(client *dbent.Client, _ *sql.DB) service.AffiliateRe
 
 func (r *affiliateRepository) EnsureUserAffiliate(ctx context.Context, userID int64) (*service.AffiliateSummary, error) {
 	if userID <= 0 {
-		return nil, service.ErrUserNotFound
+		return nil, domain.ErrUserNotFound
 	}
 	client := clientFromContext(ctx, r.client)
 	return ensureUserAffiliateWithClient(ctx, client, userID)
@@ -273,7 +274,7 @@ FROM cleared`, userID)
 			if err := rows.Err(); err != nil {
 				return err
 			}
-			return service.ErrAffiliateQuotaEmpty
+			return domain.ErrAffiliateQuotaEmpty
 		}
 		if err := rows.Scan(&transferred); err != nil {
 			_ = rows.Close()
@@ -283,7 +284,7 @@ FROM cleared`, userID)
 			return err
 		}
 		if transferred <= 0 {
-			return service.ErrAffiliateQuotaEmpty
+			return domain.ErrAffiliateQuotaEmpty
 		}
 
 		affected, err := txClient.User.Update().
@@ -295,7 +296,7 @@ FROM cleared`, userID)
 			return fmt.Errorf("credit user balance by affiliate quota: %w", err)
 		}
 		if affected == 0 {
-			return service.ErrUserNotFound
+			return domain.ErrUserNotFound
 		}
 
 		newBalance, err = queryUserBalance(txCtx, txClient, userID)
@@ -620,7 +621,7 @@ LIMIT $`+fmt.Sprint(len(args)-1)+` OFFSET $`+fmt.Sprint(len(args)), args...)
 
 func (r *affiliateRepository) GetAffiliateUserOverview(ctx context.Context, userID int64) (*service.AffiliateUserOverview, error) {
 	if userID <= 0 {
-		return nil, service.ErrUserNotFound
+		return nil, domain.ErrUserNotFound
 	}
 	client := clientFromContext(ctx, r.client)
 	rows, err := client.QueryContext(ctx, affiliateUserOverviewSQL, userID)
@@ -633,7 +634,7 @@ func (r *affiliateRepository) GetAffiliateUserOverview(ctx context.Context, user
 		if err := rows.Err(); err != nil {
 			return nil, err
 		}
-		return nil, service.ErrUserNotFound
+		return nil, domain.ErrUserNotFound
 	}
 
 	var overview service.AffiliateUserOverview
@@ -725,7 +726,7 @@ func ensureUserAffiliateWithClient(ctx context.Context, client affiliateQueryExe
 	if err == nil {
 		return summary, nil
 	}
-	if !errors.Is(err, service.ErrAffiliateProfileNotFound) {
+	if !errors.Is(err, domain.ErrAffiliateProfileNotFound) {
 		return nil, err
 	}
 
@@ -773,7 +774,7 @@ WHERE user_id = $1`, userID)
 		if err := rows.Err(); err != nil {
 			return nil, err
 		}
-		return nil, service.ErrAffiliateProfileNotFound
+		return nil, domain.ErrAffiliateProfileNotFound
 	}
 
 	var out service.AffiliateSummary
@@ -829,7 +830,7 @@ LIMIT 1`, strings.ToUpper(strings.TrimSpace(code)))
 		if err := rows.Err(); err != nil {
 			return nil, err
 		}
-		return nil, service.ErrAffiliateProfileNotFound
+		return nil, domain.ErrAffiliateProfileNotFound
 	}
 
 	var out service.AffiliateSummary
@@ -873,7 +874,7 @@ func queryUserBalance(ctx context.Context, client affiliateQueryExecer, userID i
 		if err := rows.Err(); err != nil {
 			return 0, err
 		}
-		return 0, service.ErrUserNotFound
+		return 0, domain.ErrUserNotFound
 	}
 	var balance float64
 	if err := rows.Scan(&balance); err != nil {
@@ -908,7 +909,7 @@ LIMIT 1`, userID)
 		if err := rows.Err(); err != nil {
 			return nil, err
 		}
-		return nil, service.ErrUserNotFound
+		return nil, domain.ErrUserNotFound
 	}
 
 	var snapshot affiliateTransferSnapshot
@@ -953,11 +954,11 @@ func isAffiliateUniqueViolation(err error) bool {
 // 唯一性冲突返回 ErrAffiliateCodeTaken。
 func (r *affiliateRepository) UpdateUserAffCode(ctx context.Context, userID int64, newCode string) error {
 	if userID <= 0 {
-		return service.ErrUserNotFound
+		return domain.ErrUserNotFound
 	}
 	code := strings.ToUpper(strings.TrimSpace(newCode))
 	if code == "" {
-		return service.ErrAffiliateCodeInvalid
+		return domain.ErrAffiliateCodeInvalid
 	}
 
 	return r.withTx(ctx, func(txCtx context.Context, txClient *dbent.Client) error {
@@ -972,13 +973,13 @@ SET aff_code = $1,
 WHERE user_id = $2`, code, userID)
 		if err != nil {
 			if isAffiliateUniqueViolation(err) {
-				return service.ErrAffiliateCodeTaken
+				return domain.ErrAffiliateCodeTaken
 			}
 			return fmt.Errorf("update aff_code: %w", err)
 		}
 		affected, _ := res.RowsAffected()
 		if affected == 0 {
-			return service.ErrUserNotFound
+			return domain.ErrUserNotFound
 		}
 		return nil
 	})
@@ -987,7 +988,7 @@ WHERE user_id = $2`, code, userID)
 // ResetUserAffCode 把 aff_code 还原为系统随机码，并清除 aff_code_custom 标记。
 func (r *affiliateRepository) ResetUserAffCode(ctx context.Context, userID int64) (string, error) {
 	if userID <= 0 {
-		return "", service.ErrUserNotFound
+		return "", domain.ErrUserNotFound
 	}
 	var newCode string
 	err := r.withTx(ctx, func(txCtx context.Context, txClient *dbent.Client) error {
@@ -1013,7 +1014,7 @@ WHERE user_id = $2`, candidate, userID)
 			}
 			affected, _ := res.RowsAffected()
 			if affected == 0 {
-				return service.ErrUserNotFound
+				return domain.ErrUserNotFound
 			}
 			newCode = candidate
 			return nil
@@ -1029,7 +1030,7 @@ WHERE user_id = $2`, candidate, userID)
 // SetUserRebateRate 设置或清除用户专属返利比例。ratePercent==nil 表示清除（沿用全局）。
 func (r *affiliateRepository) SetUserRebateRate(ctx context.Context, userID int64, ratePercent *float64) error {
 	if userID <= 0 {
-		return service.ErrUserNotFound
+		return domain.ErrUserNotFound
 	}
 	return r.withTx(ctx, func(txCtx context.Context, txClient *dbent.Client) error {
 		if _, err := ensureUserAffiliateWithClient(txCtx, txClient, userID); err != nil {
@@ -1047,7 +1048,7 @@ WHERE user_id = $2`, nullableArg(ratePercent), userID)
 		}
 		affected, _ := res.RowsAffected()
 		if affected == 0 {
-			return service.ErrUserNotFound
+			return domain.ErrUserNotFound
 		}
 		return nil
 	})

--- a/backend/internal/repository/affiliate_repo_integration_test.go
+++ b/backend/internal/repository/affiliate_repo_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -50,8 +51,8 @@ func TestAffiliateRepository_TransferQuotaToBalance_UsesClaimedQuotaBeforeClear(
 	u := mustCreateUser(t, client, &service.User{
 		Email:        fmt.Sprintf("affiliate-transfer-%d@example.com", time.Now().UnixNano()),
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 		Balance:      5.5,
 		Concurrency:  5,
 	})
@@ -123,15 +124,15 @@ func TestAffiliateRepository_AccrueQuota_ReusesOuterTransaction(t *testing.T) {
 	inviter := mustCreateUser(t, client, &service.User{
 		Email:        fmt.Sprintf("affiliate-inviter-%d@example.com", time.Now().UnixNano()),
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 		Concurrency:  5,
 	})
 	invitee := mustCreateUser(t, client, &service.User{
 		Email:        fmt.Sprintf("affiliate-invitee-%d@example.com", time.Now().UnixNano()+1),
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 		Concurrency:  5,
 	})
 
@@ -181,8 +182,8 @@ func TestAffiliateRepository_TransferQuotaToBalance_EmptyQuota(t *testing.T) {
 	u := mustCreateUser(t, client, &service.User{
 		Email:        fmt.Sprintf("affiliate-empty-%d@example.com", time.Now().UnixNano()),
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 		Balance:      3.21,
 		Concurrency:  5,
 	})
@@ -194,7 +195,7 @@ VALUES ($1, $2, 0, 0, NOW(), NOW())`, u.ID, affCode)
 	require.NoError(t, err)
 
 	transferred, balance, err := repo.TransferQuotaToBalance(txCtx, u.ID)
-	require.ErrorIs(t, err, service.ErrAffiliateQuotaEmpty)
+	require.ErrorIs(t, err, domain.ErrAffiliateQuotaEmpty)
 	require.InDelta(t, 0.0, transferred, 1e-9)
 	require.InDelta(t, 0.0, balance, 1e-9)
 
@@ -223,8 +224,8 @@ func TestAffiliateRepository_AdminCustomCode(t *testing.T) {
 	u := mustCreateUser(t, client, &service.User{
 		Email:        fmt.Sprintf("affiliate-custom-%d@example.com", time.Now().UnixNano()),
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	})
 
 	original, err := repo.EnsureUserAffiliate(txCtx, u.ID)
@@ -248,7 +249,7 @@ func TestAffiliateRepository_AdminCustomCode(t *testing.T) {
 
 	// Old system code should no longer match
 	_, err = repo.GetAffiliateByCode(txCtx, originalCode)
-	require.ErrorIs(t, err, service.ErrAffiliateProfileNotFound)
+	require.ErrorIs(t, err, domain.ErrAffiliateProfileNotFound)
 
 	// Reset back to a fresh system code, clears custom flag
 	newSysCode, err := repo.ResetUserAffCode(txCtx, u.ID)
@@ -262,7 +263,7 @@ func TestAffiliateRepository_AdminCustomCode(t *testing.T) {
 
 	// The old custom code is now free again
 	_, err = repo.GetAffiliateByCode(txCtx, customCode)
-	require.ErrorIs(t, err, service.ErrAffiliateProfileNotFound)
+	require.ErrorIs(t, err, domain.ErrAffiliateProfileNotFound)
 }
 
 // TestAffiliateRepository_AdminCustomCode_Conflict isolates the unique-violation
@@ -280,12 +281,12 @@ func TestAffiliateRepository_AdminCustomCode_Conflict(t *testing.T) {
 	taker := mustCreateUser(t, client, &service.User{
 		Email:        fmt.Sprintf("affiliate-conflict-taker-%d@example.com", time.Now().UnixNano()),
 		PasswordHash: "hash",
-		Role:         service.RoleUser, Status: service.StatusActive,
+		Role:         domain.RoleUser, Status: domain.StatusActive,
 	})
 	requester := mustCreateUser(t, client, &service.User{
 		Email:        fmt.Sprintf("affiliate-conflict-req-%d@example.com", time.Now().UnixNano()),
 		PasswordHash: "hash",
-		Role:         service.RoleUser, Status: service.StatusActive,
+		Role:         domain.RoleUser, Status: domain.StatusActive,
 	})
 
 	takenCode := fmt.Sprintf("HOT%09d", time.Now().UnixNano()%1_000_000_000)
@@ -293,7 +294,7 @@ func TestAffiliateRepository_AdminCustomCode_Conflict(t *testing.T) {
 
 	// Now requester tries to grab the same code → conflict.
 	err := repo.UpdateUserAffCode(txCtx, requester.ID, takenCode)
-	require.ErrorIs(t, err, service.ErrAffiliateCodeTaken)
+	require.ErrorIs(t, err, domain.ErrAffiliateCodeTaken)
 }
 
 // TestAffiliateRepository_AdminRebateRate covers per-user exclusive rate
@@ -309,14 +310,14 @@ func TestAffiliateRepository_AdminRebateRate(t *testing.T) {
 	u1 := mustCreateUser(t, client, &service.User{
 		Email:        fmt.Sprintf("affiliate-rate-%d-a@example.com", time.Now().UnixNano()),
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	})
 	u2 := mustCreateUser(t, client, &service.User{
 		Email:        fmt.Sprintf("affiliate-rate-%d-b@example.com", time.Now().UnixNano()),
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	})
 
 	// Set exclusive rate for u1
@@ -368,7 +369,7 @@ func TestAffiliateRepository_ListUsersWithCustomSettings(t *testing.T) {
 	plainEmail := fmt.Sprintf("affiliate-plain-%d@example.com", time.Now().UnixNano())
 	uPlain := mustCreateUser(t, client, &service.User{
 		Email: plainEmail, PasswordHash: "hash",
-		Role: service.RoleUser, Status: service.StatusActive,
+		Role: domain.RoleUser, Status: domain.StatusActive,
 	})
 	_, err := repo.EnsureUserAffiliate(txCtx, uPlain.ID)
 	require.NoError(t, err)
@@ -377,7 +378,7 @@ func TestAffiliateRepository_ListUsersWithCustomSettings(t *testing.T) {
 	uCode := mustCreateUser(t, client, &service.User{
 		Email:        fmt.Sprintf("affiliate-codeonly-%d@example.com", time.Now().UnixNano()),
 		PasswordHash: "hash",
-		Role:         service.RoleUser, Status: service.StatusActive,
+		Role:         domain.RoleUser, Status: domain.StatusActive,
 	})
 	require.NoError(t, repo.UpdateUserAffCode(txCtx, uCode.ID, fmt.Sprintf("VIP%09d", time.Now().UnixNano()%1_000_000_000)))
 
@@ -385,7 +386,7 @@ func TestAffiliateRepository_ListUsersWithCustomSettings(t *testing.T) {
 	uRate := mustCreateUser(t, client, &service.User{
 		Email:        fmt.Sprintf("affiliate-rateonly-%d@example.com", time.Now().UnixNano()),
 		PasswordHash: "hash",
-		Role:         service.RoleUser, Status: service.StatusActive,
+		Role:         domain.RoleUser, Status: domain.StatusActive,
 	})
 	r := 33.3
 	require.NoError(t, repo.SetUserRebateRate(txCtx, uRate.ID, &r))

--- a/backend/internal/repository/allowed_groups_contract_integration_test.go
+++ b/backend/internal/repository/allowed_groups_contract_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -25,12 +26,12 @@ func TestUserRepository_RemoveGroupFromAllowedGroups_RemovesAllOccurrences(t *te
 
 	targetGroup, err := entClient.Group.Create().
 		SetName(uniqueTestValue(t, "target-group")).
-		SetStatus(service.StatusActive).
+		SetStatus(domain.StatusActive).
 		Save(ctx)
 	require.NoError(t, err)
 	otherGroup, err := entClient.Group.Create().
 		SetName(uniqueTestValue(t, "other-group")).
-		SetStatus(service.StatusActive).
+		SetStatus(domain.StatusActive).
 		Save(ctx)
 	require.NoError(t, err)
 
@@ -39,8 +40,8 @@ func TestUserRepository_RemoveGroupFromAllowedGroups_RemovesAllOccurrences(t *te
 	u1 := &service.User{
 		Email:         uniqueTestValue(t, "u1") + "@example.com",
 		PasswordHash:  "test-password-hash",
-		Role:          service.RoleUser,
-		Status:        service.StatusActive,
+		Role:          domain.RoleUser,
+		Status:        domain.StatusActive,
 		Concurrency:   5,
 		AllowedGroups: []int64{targetGroup.ID, otherGroup.ID},
 	}
@@ -49,8 +50,8 @@ func TestUserRepository_RemoveGroupFromAllowedGroups_RemovesAllOccurrences(t *te
 	u2 := &service.User{
 		Email:         uniqueTestValue(t, "u2") + "@example.com",
 		PasswordHash:  "test-password-hash",
-		Role:          service.RoleUser,
-		Status:        service.StatusActive,
+		Role:          domain.RoleUser,
+		Status:        domain.StatusActive,
 		Concurrency:   5,
 		AllowedGroups: []int64{targetGroup.ID},
 	}
@@ -59,8 +60,8 @@ func TestUserRepository_RemoveGroupFromAllowedGroups_RemovesAllOccurrences(t *te
 	u3 := &service.User{
 		Email:         uniqueTestValue(t, "u3") + "@example.com",
 		PasswordHash:  "test-password-hash",
-		Role:          service.RoleUser,
-		Status:        service.StatusActive,
+		Role:          domain.RoleUser,
+		Status:        domain.StatusActive,
 		Concurrency:   5,
 		AllowedGroups: []int64{otherGroup.ID},
 	}
@@ -87,12 +88,12 @@ func TestGroupRepository_DeleteCascade_PreservesApiKeyGroupID(t *testing.T) {
 
 	targetGroup, err := entClient.Group.Create().
 		SetName(uniqueTestValue(t, "delete-cascade-target")).
-		SetStatus(service.StatusActive).
+		SetStatus(domain.StatusActive).
 		Save(ctx)
 	require.NoError(t, err)
 	otherGroup, err := entClient.Group.Create().
 		SetName(uniqueTestValue(t, "delete-cascade-other")).
-		SetStatus(service.StatusActive).
+		SetStatus(domain.StatusActive).
 		Save(ctx)
 	require.NoError(t, err)
 
@@ -103,8 +104,8 @@ func TestGroupRepository_DeleteCascade_PreservesApiKeyGroupID(t *testing.T) {
 	u := &service.User{
 		Email:         uniqueTestValue(t, "cascade-user") + "@example.com",
 		PasswordHash:  "test-password-hash",
-		Role:          service.RoleUser,
-		Status:        service.StatusActive,
+		Role:          domain.RoleUser,
+		Status:        domain.StatusActive,
 		Concurrency:   5,
 		AllowedGroups: []int64{targetGroup.ID, otherGroup.ID},
 	}
@@ -115,7 +116,7 @@ func TestGroupRepository_DeleteCascade_PreservesApiKeyGroupID(t *testing.T) {
 		Key:     uniqueTestValue(t, "sk-test-delete-cascade"),
 		Name:    "test key",
 		GroupID: &targetGroup.ID,
-		Status:  service.StatusActive,
+		Status:  domain.StatusActive,
 	}
 	require.NoError(t, apiKeyRepo.Create(ctx, key))
 
@@ -124,7 +125,7 @@ func TestGroupRepository_DeleteCascade_PreservesApiKeyGroupID(t *testing.T) {
 
 	// Deleted group should be hidden by default queries (soft-delete semantics).
 	_, err = groupRepo.GetByID(ctx, targetGroup.ID)
-	require.ErrorIs(t, err, service.ErrGroupNotFound)
+	require.ErrorIs(t, err, domain.ErrGroupNotFound)
 
 	activeGroups, err := groupRepo.ListActive(ctx)
 	require.NoError(t, err)

--- a/backend/internal/repository/announcement_repo.go
+++ b/backend/internal/repository/announcement_repo.go
@@ -7,6 +7,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/announcement"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
@@ -57,7 +58,7 @@ func (r *announcementRepository) GetByID(ctx context.Context, id int64) (*servic
 		Where(announcement.IDEQ(id)).
 		Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrAnnouncementNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrAnnouncementNotFound, nil)
 	}
 	return announcementEntityToService(m), nil
 }
@@ -94,7 +95,7 @@ func (r *announcementRepository) Update(ctx context.Context, a *service.Announce
 
 	updated, err := builder.Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrAnnouncementNotFound, nil)
+		return translatePersistenceError(err, domain.ErrAnnouncementNotFound, nil)
 	}
 
 	a.UpdatedAt = updated.UpdatedAt
@@ -200,7 +201,7 @@ func announcementListOrders(params pagination.PaginationParams) []func(*entsql.S
 func (r *announcementRepository) ListActive(ctx context.Context, now time.Time) ([]service.Announcement, error) {
 	q := r.client.Announcement.Query().
 		Where(
-			announcement.StatusEQ(service.AnnouncementStatusActive),
+			announcement.StatusEQ(domain.AnnouncementStatusActive),
 			announcement.Or(announcement.StartsAtIsNil(), announcement.StartsAtLTE(now)),
 			announcement.Or(announcement.EndsAtIsNil(), announcement.EndsAtGT(now)),
 		).

--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/ent/group"
 	"github.com/Wei-Shaw/sub2api/ent/schema/mixins"
 	"github.com/Wei-Shaw/sub2api/ent/user"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
@@ -73,7 +74,7 @@ func (r *apiKeyRepository) Create(ctx context.Context, key *service.APIKey) erro
 		key.CreatedAt = created.CreatedAt
 		key.UpdatedAt = created.UpdatedAt
 	}
-	return translatePersistenceError(err, nil, service.ErrAPIKeyExists)
+	return translatePersistenceError(err, nil, domain.ErrAPIKeyExists)
 }
 
 func (r *apiKeyRepository) GetByID(ctx context.Context, id int64) (*service.APIKey, error) {
@@ -84,7 +85,7 @@ func (r *apiKeyRepository) GetByID(ctx context.Context, id int64) (*service.APIK
 		Only(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return nil, service.ErrAPIKeyNotFound
+			return nil, domain.ErrAPIKeyNotFound
 		}
 		return nil, err
 	}
@@ -103,7 +104,7 @@ func (r *apiKeyRepository) GetKeyAndOwnerID(ctx context.Context, id int64) (stri
 		Only(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return "", 0, service.ErrAPIKeyNotFound
+			return "", 0, domain.ErrAPIKeyNotFound
 		}
 		return "", 0, err
 	}
@@ -122,7 +123,7 @@ func (r *apiKeyRepository) GetByKey(ctx context.Context, key string) (*service.A
 		Only(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return nil, service.ErrAPIKeyNotFound
+			return nil, domain.ErrAPIKeyNotFound
 		}
 		return nil, err
 	}
@@ -212,7 +213,7 @@ func (r *apiKeyRepository) GetByKeyForAuth(ctx context.Context, key string) (*se
 		Only(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return nil, service.ErrAPIKeyNotFound
+			return nil, domain.ErrAPIKeyNotFound
 		}
 		return nil, err
 	}
@@ -291,7 +292,7 @@ func (r *apiKeyRepository) Update(ctx context.Context, key *service.APIKey) erro
 	}
 	if affected == 0 {
 		// 更新影响行数为 0，说明记录不存在或已被软删除。
-		return service.ErrAPIKeyNotFound
+		return domain.ErrAPIKeyNotFound
 	}
 
 	// 使用同一时间戳回填，避免并发删除导致二次查询失败。
@@ -310,7 +311,7 @@ func (r *apiKeyRepository) Delete(ctx context.Context, id int64) error {
 		Save(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return service.ErrAPIKeyNotFound
+			return domain.ErrAPIKeyNotFound
 		}
 		return err
 	}
@@ -324,7 +325,7 @@ func (r *apiKeyRepository) Delete(ctx context.Context, id int64) error {
 		if exists {
 			return nil
 		}
-		return service.ErrAPIKeyNotFound
+		return domain.ErrAPIKeyNotFound
 	}
 	return nil
 }
@@ -394,7 +395,7 @@ func (r *apiKeyRepository) deleteWithAudit(ctx context.Context, exec *dbent.Clie
 		if exists {
 			return nil
 		}
-		return service.ErrAPIKeyNotFound
+		return domain.ErrAPIKeyNotFound
 	}
 	return nil
 }
@@ -603,7 +604,7 @@ func (r *apiKeyRepository) IncrementQuotaUsed(ctx context.Context, id int64, amo
 		Save(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return 0, service.ErrAPIKeyNotFound
+			return 0, domain.ErrAPIKeyNotFound
 		}
 		return 0, err
 	}
@@ -629,7 +630,7 @@ func (r *apiKeyRepository) IncrementQuotaUsedAndGetState(ctx context.Context, id
 	state := &service.APIKeyQuotaUsageState{}
 	if err := scanSingleRow(ctx, r.sql, query, []any{amount, service.StatusAPIKeyQuotaExhausted, id}, &state.QuotaUsed, &state.Quota, &state.Key, &state.Status); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, service.ErrAPIKeyNotFound
+			return nil, domain.ErrAPIKeyNotFound
 		}
 		return nil, err
 	}
@@ -646,7 +647,7 @@ func (r *apiKeyRepository) UpdateLastUsed(ctx context.Context, id int64, usedAt 
 		return err
 	}
 	if affected == 0 {
-		return service.ErrAPIKeyNotFound
+		return domain.ErrAPIKeyNotFound
 	}
 	return nil
 }
@@ -700,7 +701,7 @@ func (r *apiKeyRepository) GetRateLimitData(ctx context.Context, id int64) (resu
 		}
 	}()
 	if !rows.Next() {
-		return nil, service.ErrAPIKeyNotFound
+		return nil, domain.ErrAPIKeyNotFound
 	}
 	data := &service.APIKeyRateLimitData{}
 	if err := rows.Scan(&data.Usage5h, &data.Usage1d, &data.Usage7d, &data.Window5hStart, &data.Window1dStart, &data.Window7dStart); err != nil {

--- a/backend/internal/repository/api_key_repo_integration_test.go
+++ b/backend/internal/repository/api_key_repo_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func (s *APIKeyRepoSuite) TestCreate() {
 		UserID: user.ID,
 		Key:    "sk-create-test",
 		Name:   "Test Key",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 
 	err := s.repo.Create(s.ctx, key)
@@ -68,7 +69,7 @@ func (s *APIKeyRepoSuite) TestGetByKey() {
 		Key:     "sk-getbykey",
 		Name:    "My Key",
 		GroupID: &group.ID,
-		Status:  service.StatusActive,
+		Status:  domain.StatusActive,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, key))
 
@@ -90,9 +91,9 @@ func (s *APIKeyRepoSuite) TestGetByKeyForAuth_PreservesMessagesDispatchModelConf
 	user := s.mustCreateUser("getbykey-auth-dispatch@test.com")
 	group, err := s.client.Group.Create().
 		SetName("g-auth-dispatch").
-		SetPlatform(service.PlatformOpenAI).
-		SetStatus(service.StatusActive).
-		SetSubscriptionType(service.SubscriptionTypeStandard).
+		SetPlatform(domain.PlatformOpenAI).
+		SetStatus(domain.StatusActive).
+		SetSubscriptionType(domain.SubscriptionTypeStandard).
 		SetRateMultiplier(1).
 		SetAllowMessagesDispatch(true).
 		SetDefaultMappedModel("gpt-5.4").
@@ -112,7 +113,7 @@ func (s *APIKeyRepoSuite) TestGetByKeyForAuth_PreservesMessagesDispatchModelConf
 		Key:     "sk-getbykey-auth-dispatch",
 		Name:    "Dispatch Key",
 		GroupID: &group.ID,
-		Status:  service.StatusActive,
+		Status:  domain.StatusActive,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, key))
 
@@ -133,12 +134,12 @@ func (s *APIKeyRepoSuite) TestUpdate() {
 		UserID: user.ID,
 		Key:    "sk-update",
 		Name:   "Original",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, key))
 
 	key.Name = "Renamed"
-	key.Status = service.StatusDisabled
+	key.Status = domain.StatusDisabled
 	err := s.repo.Update(s.ctx, key)
 	s.Require().NoError(err, "Update")
 
@@ -147,7 +148,7 @@ func (s *APIKeyRepoSuite) TestUpdate() {
 	s.Require().Equal("sk-update", got.Key, "Update should not change key")
 	s.Require().Equal(user.ID, got.UserID, "Update should not change user_id")
 	s.Require().Equal("Renamed", got.Name)
-	s.Require().Equal(service.StatusDisabled, got.Status)
+	s.Require().Equal(domain.StatusDisabled, got.Status)
 }
 
 func (s *APIKeyRepoSuite) TestUpdate_ClearGroupID() {
@@ -158,7 +159,7 @@ func (s *APIKeyRepoSuite) TestUpdate_ClearGroupID() {
 		Key:     "sk-clear-group",
 		Name:    "Group Key",
 		GroupID: &group.ID,
-		Status:  service.StatusActive,
+		Status:  domain.StatusActive,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, key))
 
@@ -179,7 +180,7 @@ func (s *APIKeyRepoSuite) TestDelete() {
 		UserID: user.ID,
 		Key:    "sk-delete",
 		Name:   "Delete Me",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, key))
 
@@ -198,7 +199,7 @@ func (s *APIKeyRepoSuite) TestCreate_AfterSoftDelete_AllowsSameKey() {
 		UserID: user.ID,
 		Key:    reusedKey,
 		Name:   "First Key",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, first), "create first key")
 
@@ -208,7 +209,7 @@ func (s *APIKeyRepoSuite) TestCreate_AfterSoftDelete_AllowsSameKey() {
 		UserID: user.ID,
 		Key:    reusedKey,
 		Name:   "Second Key",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, second), "create second key with same key")
 	s.Require().NotZero(second.ID)
@@ -366,7 +367,7 @@ func (s *APIKeyRepoSuite) TestCRUD_Search_ClearGroupID() {
 	s.Require().Equal(group.ID, got.Group.ID)
 
 	key.Name = "Renamed"
-	key.Status = service.StatusDisabled
+	key.Status = domain.StatusDisabled
 	key.GroupID = nil
 	s.Require().NoError(s.repo.Update(s.ctx, key), "Update")
 
@@ -375,7 +376,7 @@ func (s *APIKeyRepoSuite) TestCRUD_Search_ClearGroupID() {
 	s.Require().Equal("sk-test-1", got2.Key, "Update should not change key")
 	s.Require().Equal(user.ID, got2.UserID, "Update should not change user_id")
 	s.Require().Equal("Renamed", got2.Name)
-	s.Require().Equal(service.StatusDisabled, got2.Status)
+	s.Require().Equal(domain.StatusDisabled, got2.Status)
 	s.Require().Nil(got2.GroupID)
 
 	keys, page, err := s.repo.ListByUserID(s.ctx, user.ID, pagination.PaginationParams{Page: 1, PageSize: 10}, service.APIKeyListFilters{})
@@ -419,8 +420,8 @@ func (s *APIKeyRepoSuite) mustCreateUser(email string) *service.User {
 	u, err := s.client.User.Create().
 		SetEmail(email).
 		SetPasswordHash("test-password-hash").
-		SetStatus(service.StatusActive).
-		SetRole(service.RoleUser).
+		SetStatus(domain.StatusActive).
+		SetRole(domain.RoleUser).
 		Save(s.ctx)
 	s.Require().NoError(err, "create user")
 	return userEntityToService(u)
@@ -431,7 +432,7 @@ func (s *APIKeyRepoSuite) mustCreateGroup(name string) *service.Group {
 
 	g, err := s.client.Group.Create().
 		SetName(name).
-		SetStatus(service.StatusActive).
+		SetStatus(domain.StatusActive).
 		Save(s.ctx)
 	s.Require().NoError(err, "create group")
 	return groupEntityToService(g)
@@ -445,7 +446,7 @@ func (s *APIKeyRepoSuite) mustCreateApiKey(userID int64, key, name string, group
 		Key:     key,
 		Name:    name,
 		GroupID: groupID,
-		Status:  service.StatusActive,
+		Status:  domain.StatusActive,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, k), "create api key")
 	return k
@@ -468,7 +469,7 @@ func (s *APIKeyRepoSuite) TestIncrementQuotaUsed_Basic() {
 
 func (s *APIKeyRepoSuite) TestIncrementQuotaUsed_NotFound() {
 	_, err := s.repo.IncrementQuotaUsed(s.ctx, 999999, 1.0)
-	s.Require().ErrorIs(err, service.ErrAPIKeyNotFound, "不存在的 key 应返回 ErrAPIKeyNotFound")
+	s.Require().ErrorIs(err, domain.ErrAPIKeyNotFound, "不存在的 key 应返回 ErrAPIKeyNotFound")
 }
 
 func (s *APIKeyRepoSuite) TestIncrementQuotaUsed_DeletedKey() {
@@ -478,7 +479,7 @@ func (s *APIKeyRepoSuite) TestIncrementQuotaUsed_DeletedKey() {
 	s.Require().NoError(s.repo.Delete(s.ctx, key.ID), "Delete")
 
 	_, err := s.repo.IncrementQuotaUsed(s.ctx, key.ID, 1.0)
-	s.Require().ErrorIs(err, service.ErrAPIKeyNotFound, "已删除的 key 应返回 ErrAPIKeyNotFound")
+	s.Require().ErrorIs(err, domain.ErrAPIKeyNotFound, "已删除的 key 应返回 ErrAPIKeyNotFound")
 }
 
 func (s *APIKeyRepoSuite) TestIncrementQuotaUsedAndGetState() {
@@ -513,8 +514,8 @@ func TestIncrementQuotaUsed_Concurrent(t *testing.T) {
 	u, err := client.User.Create().
 		SetEmail("concurrent-incr-" + time.Now().Format(time.RFC3339Nano) + "@test.com").
 		SetPasswordHash("hash").
-		SetStatus(service.StatusActive).
-		SetRole(service.RoleUser).
+		SetStatus(domain.StatusActive).
+		SetRole(domain.RoleUser).
 		Save(ctx)
 	require.NoError(t, err, "create user")
 
@@ -522,7 +523,7 @@ func TestIncrementQuotaUsed_Concurrent(t *testing.T) {
 		UserID: u.ID,
 		Key:    "sk-concurrent-" + time.Now().Format(time.RFC3339Nano),
 		Name:   "Concurrent",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, k), "create api key")
 	t.Cleanup(func() {
@@ -562,7 +563,7 @@ func (s *APIKeyRepoSuite) TestDeleteWithAudit_WritesAuditAndSoftDeletes() {
 		UserID: user.ID,
 		Key:    "sk-del-audit-1",
 		Name:   "Audit Me",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, key))
 
@@ -587,7 +588,7 @@ func (s *APIKeyRepoSuite) TestDeleteWithAudit_WritesAuditAndSoftDeletes() {
 
 func (s *APIKeyRepoSuite) TestDeleteWithAudit_RepeatIsIdempotent() {
 	user := s.mustCreateUser("delwithaudit-idem@test.com")
-	key := &service.APIKey{UserID: user.ID, Key: "sk-del-audit-2", Name: "K", Status: service.StatusActive}
+	key := &service.APIKey{UserID: user.ID, Key: "sk-del-audit-2", Name: "K", Status: domain.StatusActive}
 	s.Require().NoError(s.repo.Create(s.ctx, key))
 
 	s.Require().NoError(s.repo.DeleteWithAudit(s.ctx, key.ID))
@@ -596,5 +597,5 @@ func (s *APIKeyRepoSuite) TestDeleteWithAudit_RepeatIsIdempotent() {
 
 func (s *APIKeyRepoSuite) TestDeleteWithAudit_NotFound() {
 	err := s.repo.DeleteWithAudit(s.ctx, 999999)
-	s.Require().ErrorIs(err, service.ErrAPIKeyNotFound)
+	s.Require().ErrorIs(err, domain.ErrAPIKeyNotFound)
 }

--- a/backend/internal/repository/api_key_repo_last_used_unit_test.go
+++ b/backend/internal/repository/api_key_repo_last_used_unit_test.go
@@ -8,6 +8,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/enttest"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 
@@ -40,8 +41,8 @@ func mustCreateAPIKeyRepoUser(t *testing.T, ctx context.Context, client *dbent.C
 	u, err := client.User.Create().
 		SetEmail(email).
 		SetPasswordHash("test-password-hash").
-		SetRole(service.RoleUser).
-		SetStatus(service.StatusActive).
+		SetRole(domain.RoleUser).
+		SetStatus(domain.StatusActive).
 		Save(ctx)
 	require.NoError(t, err)
 	return userEntityToService(u)
@@ -57,7 +58,7 @@ func TestAPIKeyRepository_CreateWithLastUsedAt(t *testing.T) {
 		UserID:     user.ID,
 		Key:        "sk-create-last-used",
 		Name:       "CreateWithLastUsed",
-		Status:     service.StatusActive,
+		Status:     domain.StatusActive,
 		LastUsedAt: &lastUsed,
 	}
 
@@ -80,7 +81,7 @@ func TestAPIKeyRepository_UpdateLastUsed(t *testing.T) {
 		UserID: user.ID,
 		Key:    "sk-update-last-used",
 		Name:   "UpdateLastUsed",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, key))
 
@@ -107,13 +108,13 @@ func TestAPIKeyRepository_UpdateLastUsedDeletedKey(t *testing.T) {
 		UserID: user.ID,
 		Key:    "sk-update-last-used-deleted",
 		Name:   "UpdateLastUsedDeleted",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, key))
 	require.NoError(t, repo.Delete(ctx, key.ID))
 
 	err := repo.UpdateLastUsed(ctx, key.ID, time.Now().UTC())
-	require.ErrorIs(t, err, service.ErrAPIKeyNotFound)
+	require.ErrorIs(t, err, domain.ErrAPIKeyNotFound)
 }
 
 func TestAPIKeyRepository_UpdateLastUsedDBError(t *testing.T) {
@@ -125,7 +126,7 @@ func TestAPIKeyRepository_UpdateLastUsedDBError(t *testing.T) {
 		UserID: user.ID,
 		Key:    "sk-update-last-used-db-error",
 		Name:   "UpdateLastUsedDBError",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, key))
 
@@ -143,16 +144,16 @@ func TestAPIKeyRepository_CreateDuplicateKey(t *testing.T) {
 		UserID: user.ID,
 		Key:    "sk-duplicate",
 		Name:   "first",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	second := &service.APIKey{
 		UserID: user.ID,
 		Key:    "sk-duplicate",
 		Name:   "second",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 
 	require.NoError(t, repo.Create(ctx, first))
 	err := repo.Create(ctx, second)
-	require.ErrorIs(t, err, service.ErrAPIKeyExists)
+	require.ErrorIs(t, err, domain.ErrAPIKeyExists)
 }

--- a/backend/internal/repository/api_key_repo_messages_dispatch_unit_test.go
+++ b/backend/internal/repository/api_key_repo_messages_dispatch_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -13,9 +14,9 @@ func TestGroupEntityToService_PreservesMessagesDispatchModelConfig(t *testing.T)
 	group := &dbent.Group{
 		ID:                    1,
 		Name:                  "openai-dispatch",
-		Platform:              service.PlatformOpenAI,
-		Status:                service.StatusActive,
-		SubscriptionType:      service.SubscriptionTypeStandard,
+		Platform:              domain.PlatformOpenAI,
+		Status:                domain.StatusActive,
+		SubscriptionType:      domain.SubscriptionTypeStandard,
 		RateMultiplier:        1,
 		AllowMessagesDispatch: true,
 		DefaultMappedModel:    "gpt-5.4",
@@ -41,9 +42,9 @@ func TestAPIKeyRepository_GetByKeyForAuth_PreservesMessagesDispatchModelConfig_S
 
 	group, err := client.Group.Create().
 		SetName("g-auth-dispatch-unit").
-		SetPlatform(service.PlatformOpenAI).
-		SetStatus(service.StatusActive).
-		SetSubscriptionType(service.SubscriptionTypeStandard).
+		SetPlatform(domain.PlatformOpenAI).
+		SetStatus(domain.StatusActive).
+		SetSubscriptionType(domain.SubscriptionTypeStandard).
 		SetRateMultiplier(1).
 		SetAllowMessagesDispatch(true).
 		SetDefaultMappedModel("gpt-5.4").
@@ -63,7 +64,7 @@ func TestAPIKeyRepository_GetByKeyForAuth_PreservesMessagesDispatchModelConfig_S
 		Key:     "sk-getbykey-auth-dispatch-unit",
 		Name:    "Dispatch Key Unit",
 		GroupID: &group.ID,
-		Status:  service.StatusActive,
+		Status:  domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, key))
 

--- a/backend/internal/repository/channel_monitor_repo.go
+++ b/backend/internal/repository/channel_monitor_repo.go
@@ -10,6 +10,7 @@ import (
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/channelmonitor"
 	"github.com/Wei-Shaw/sub2api/ent/channelmonitorhistory"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/lib/pq"
 )
@@ -58,7 +59,7 @@ func (r *channelMonitorRepository) Create(ctx context.Context, m *service.Channe
 
 	created, err := builder.Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrChannelMonitorNotFound, nil)
+		return translatePersistenceError(err, domain.ErrChannelMonitorNotFound, nil)
 	}
 	m.ID = created.ID
 	m.CreatedAt = created.CreatedAt
@@ -71,7 +72,7 @@ func (r *channelMonitorRepository) GetByID(ctx context.Context, id int64) (*serv
 		Where(channelmonitor.IDEQ(id)).
 		Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrChannelMonitorNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrChannelMonitorNotFound, nil)
 	}
 	return entToServiceMonitor(row), nil
 }
@@ -105,7 +106,7 @@ func (r *channelMonitorRepository) Update(ctx context.Context, m *service.Channe
 
 	updated, err := updater.Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrChannelMonitorNotFound, nil)
+		return translatePersistenceError(err, domain.ErrChannelMonitorNotFound, nil)
 	}
 	m.UpdatedAt = updated.UpdatedAt
 	return nil
@@ -114,7 +115,7 @@ func (r *channelMonitorRepository) Update(ctx context.Context, m *service.Channe
 func (r *channelMonitorRepository) Delete(ctx context.Context, id int64) error {
 	client := clientFromContext(ctx, r.client)
 	if err := client.ChannelMonitor.DeleteOneID(id).Exec(ctx); err != nil {
-		return translatePersistenceError(err, service.ErrChannelMonitorNotFound, nil)
+		return translatePersistenceError(err, domain.ErrChannelMonitorNotFound, nil)
 	}
 	return nil
 }
@@ -186,7 +187,7 @@ func (r *channelMonitorRepository) MarkChecked(ctx context.Context, id int64, ch
 	if err := client.ChannelMonitor.UpdateOneID(id).
 		SetLastCheckedAt(checkedAt).
 		Exec(ctx); err != nil {
-		return translatePersistenceError(err, service.ErrChannelMonitorNotFound, nil)
+		return translatePersistenceError(err, domain.ErrChannelMonitorNotFound, nil)
 	}
 	return nil
 }

--- a/backend/internal/repository/channel_monitor_template_repo.go
+++ b/backend/internal/repository/channel_monitor_template_repo.go
@@ -8,6 +8,7 @@ import (
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/channelmonitor"
 	"github.com/Wei-Shaw/sub2api/ent/channelmonitorrequesttemplate"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -40,7 +41,7 @@ func (r *channelMonitorRequestTemplateRepository) Create(ctx context.Context, t 
 
 	created, err := builder.Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrChannelMonitorTemplateNotFound, nil)
+		return translatePersistenceError(err, domain.ErrChannelMonitorTemplateNotFound, nil)
 	}
 	t.ID = created.ID
 	t.CreatedAt = created.CreatedAt
@@ -53,7 +54,7 @@ func (r *channelMonitorRequestTemplateRepository) GetByID(ctx context.Context, i
 		Where(channelmonitorrequesttemplate.IDEQ(id)).
 		Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrChannelMonitorTemplateNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrChannelMonitorTemplateNotFound, nil)
 	}
 	return entToServiceTemplate(row), nil
 }
@@ -73,7 +74,7 @@ func (r *channelMonitorRequestTemplateRepository) Update(ctx context.Context, t 
 	}
 	updated, err := updater.Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrChannelMonitorTemplateNotFound, nil)
+		return translatePersistenceError(err, domain.ErrChannelMonitorTemplateNotFound, nil)
 	}
 	t.UpdatedAt = updated.UpdatedAt
 	return nil
@@ -82,7 +83,7 @@ func (r *channelMonitorRequestTemplateRepository) Update(ctx context.Context, t 
 func (r *channelMonitorRequestTemplateRepository) Delete(ctx context.Context, id int64) error {
 	client := clientFromContext(ctx, r.client)
 	if err := client.ChannelMonitorRequestTemplate.DeleteOneID(id).Exec(ctx); err != nil {
-		return translatePersistenceError(err, service.ErrChannelMonitorTemplateNotFound, nil)
+		return translatePersistenceError(err, domain.ErrChannelMonitorTemplateNotFound, nil)
 	}
 	return nil
 }
@@ -120,7 +121,7 @@ func (r *channelMonitorRequestTemplateRepository) ApplyToMonitors(ctx context.Co
 		Where(channelmonitorrequesttemplate.IDEQ(id)).
 		Only(ctx)
 	if err != nil {
-		return 0, translatePersistenceError(err, service.ErrChannelMonitorTemplateNotFound, nil)
+		return 0, translatePersistenceError(err, domain.ErrChannelMonitorTemplateNotFound, nil)
 	}
 
 	updater := client.ChannelMonitor.Update().

--- a/backend/internal/repository/channel_repo.go
+++ b/backend/internal/repository/channel_repo.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/lib/pq"
@@ -52,7 +53,7 @@ func (r *channelRepository) Create(ctx context.Context, channel *service.Channel
 		).Scan(&channel.ID, &channel.CreatedAt, &channel.UpdatedAt)
 		if err != nil {
 			if isUniqueViolation(err) {
-				return service.ErrChannelExists
+				return domain.ErrChannelExists
 			}
 			return fmt.Errorf("insert channel: %w", err)
 		}
@@ -90,7 +91,7 @@ func (r *channelRepository) GetByID(ctx context.Context, id int64) (*service.Cha
 		 FROM channels WHERE id = $1`, id,
 	).Scan(&ch.ID, &ch.Name, &ch.Description, &ch.Status, &modelMappingJSON, &ch.BillingModelSource, &ch.RestrictModels, &ch.Features, &featuresConfigJSON, &ch.ApplyPricingToAccountStats, &ch.CreatedAt, &ch.UpdatedAt)
 	if err == sql.ErrNoRows {
-		return nil, service.ErrChannelNotFound
+		return nil, domain.ErrChannelNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get channel: %w", err)
@@ -136,13 +137,13 @@ func (r *channelRepository) Update(ctx context.Context, channel *service.Channel
 		)
 		if err != nil {
 			if isUniqueViolation(err) {
-				return service.ErrChannelExists
+				return domain.ErrChannelExists
 			}
 			return fmt.Errorf("update channel: %w", err)
 		}
 		rows, _ := result.RowsAffected()
 		if rows == 0 {
-			return service.ErrChannelNotFound
+			return domain.ErrChannelNotFound
 		}
 
 		// 更新分组关联
@@ -177,7 +178,7 @@ func (r *channelRepository) Delete(ctx context.Context, id int64) error {
 	}
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return service.ErrChannelNotFound
+		return domain.ErrChannelNotFound
 	}
 	return nil
 }

--- a/backend/internal/repository/fixtures_integration_test.go
+++ b/backend/internal/repository/fixtures_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	dbaccount "github.com/Wei-Shaw/sub2api/ent/account"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -24,10 +25,10 @@ func mustCreateUser(t *testing.T, client *dbent.Client, u *service.User) *servic
 		u.PasswordHash = "test-password-hash"
 	}
 	if u.Role == "" {
-		u.Role = service.RoleUser
+		u.Role = domain.RoleUser
 	}
 	if u.Status == "" {
-		u.Status = service.StatusActive
+		u.Status = domain.StatusActive
 	}
 	if u.Concurrency == 0 {
 		u.Concurrency = 5
@@ -74,13 +75,13 @@ func mustCreateGroup(t *testing.T, client *dbent.Client, g *service.Group) *serv
 	ctx := context.Background()
 
 	if g.Platform == "" {
-		g.Platform = service.PlatformAnthropic
+		g.Platform = domain.PlatformAnthropic
 	}
 	if g.Status == "" {
-		g.Status = service.StatusActive
+		g.Status = domain.StatusActive
 	}
 	if g.SubscriptionType == "" {
-		g.SubscriptionType = service.SubscriptionTypeStandard
+		g.SubscriptionType = domain.SubscriptionTypeStandard
 	}
 
 	create := client.Group.Create().
@@ -118,7 +119,7 @@ func mustCreateGroup(t *testing.T, client *dbent.Client, g *service.Group) *serv
 	return g
 }
 
-func mustCreateProxy(t *testing.T, client *dbent.Client, p *service.Proxy) *service.Proxy {
+func mustCreateProxy(t *testing.T, client *dbent.Client, p *domain.Proxy) *domain.Proxy {
 	t.Helper()
 	ctx := context.Background()
 
@@ -132,7 +133,7 @@ func mustCreateProxy(t *testing.T, client *dbent.Client, p *service.Proxy) *serv
 		p.Port = 8080
 	}
 	if p.Status == "" {
-		p.Status = service.StatusActive
+		p.Status = domain.StatusActive
 	}
 
 	create := client.Proxy.Create().
@@ -168,13 +169,13 @@ func mustCreateAccount(t *testing.T, client *dbent.Client, a *service.Account) *
 	ctx := context.Background()
 
 	if a.Platform == "" {
-		a.Platform = service.PlatformAnthropic
+		a.Platform = domain.PlatformAnthropic
 	}
 	if a.Type == "" {
-		a.Type = service.AccountTypeOAuth
+		a.Type = domain.AccountTypeOAuth
 	}
 	if a.Status == "" {
-		a.Status = service.StatusActive
+		a.Status = domain.StatusActive
 	}
 	if a.Concurrency == 0 {
 		a.Concurrency = 3
@@ -255,7 +256,7 @@ func mustCreateApiKey(t *testing.T, client *dbent.Client, k *service.APIKey) *se
 	ctx := context.Background()
 
 	if k.Status == "" {
-		k.Status = service.StatusActive
+		k.Status = domain.StatusActive
 	}
 	if k.Key == "" {
 		k.Key = "sk-" + time.Now().Format("150405.000000")
@@ -329,10 +330,10 @@ func mustCreateRedeemCode(t *testing.T, client *dbent.Client, c *service.RedeemC
 	ctx := context.Background()
 
 	if c.Status == "" {
-		c.Status = service.StatusUnused
+		c.Status = domain.StatusUnused
 	}
 	if c.Type == "" {
-		c.Type = service.RedeemTypeBalance
+		c.Type = domain.RedeemTypeBalance
 	}
 	if c.Code == "" {
 		c.Code = "rc-" + time.Now().Format("150405.000000")
@@ -371,7 +372,7 @@ func mustCreateSubscription(t *testing.T, client *dbent.Client, s *service.UserS
 	ctx := context.Background()
 
 	if s.Status == "" {
-		s.Status = service.SubscriptionStatusActive
+		s.Status = domain.SubscriptionStatusActive
 	}
 	now := time.Now()
 	if s.StartsAt.IsZero() {

--- a/backend/internal/repository/gateway_routing_integration_test.go
+++ b/backend/internal/repository/gateway_routing_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/suite"
 )
@@ -36,18 +37,18 @@ func (s *GatewayRoutingSuite) TestListSchedulableByPlatforms_GeminiAndAntigravit
 	// 创建各平台账户
 	geminiAcc := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "gemini-oauth",
-		Platform:    service.PlatformGemini,
-		Type:        service.AccountTypeOAuth,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformGemini,
+		Type:        domain.AccountTypeOAuth,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 		Priority:    1,
 	})
 
 	antigravityAcc := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "antigravity-oauth",
-		Platform:    service.PlatformAntigravity,
-		Type:        service.AccountTypeOAuth,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformAntigravity,
+		Type:        domain.AccountTypeOAuth,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 		Priority:    2,
 		Credentials: map[string]any{
@@ -60,17 +61,17 @@ func (s *GatewayRoutingSuite) TestListSchedulableByPlatforms_GeminiAndAntigravit
 	// 创建不应被选中的 anthropic 账户
 	mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "anthropic-oauth",
-		Platform:    service.PlatformAnthropic,
-		Type:        service.AccountTypeOAuth,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformAnthropic,
+		Type:        domain.AccountTypeOAuth,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 		Priority:    0,
 	})
 
 	// 查询 gemini + antigravity 平台
 	accounts, err := s.accountRepo.ListSchedulableByPlatforms(s.ctx, []string{
-		service.PlatformGemini,
-		service.PlatformAntigravity,
+		domain.PlatformGemini,
+		domain.PlatformAntigravity,
 	})
 
 	s.Require().NoError(err)
@@ -81,9 +82,9 @@ func (s *GatewayRoutingSuite) TestListSchedulableByPlatforms_GeminiAndAntigravit
 	for _, acc := range accounts {
 		platforms[acc.Platform] = true
 	}
-	s.Require().True(platforms[service.PlatformGemini], "应包含 gemini 账户")
-	s.Require().True(platforms[service.PlatformAntigravity], "应包含 antigravity 账户")
-	s.Require().False(platforms[service.PlatformAnthropic], "不应包含 anthropic 账户")
+	s.Require().True(platforms[domain.PlatformGemini], "应包含 gemini 账户")
+	s.Require().True(platforms[domain.PlatformAntigravity], "应包含 antigravity 账户")
+	s.Require().False(platforms[domain.PlatformAnthropic], "不应包含 anthropic 账户")
 
 	// 验证账户 ID 匹配
 	ids := make(map[int64]bool)
@@ -99,21 +100,21 @@ func (s *GatewayRoutingSuite) TestListSchedulableByGroupIDAndPlatforms_WithGroup
 	// 创建 gemini 分组
 	group := mustCreateGroup(s.T(), s.client, &service.Group{
 		Name:     "gemini-group",
-		Platform: service.PlatformGemini,
-		Status:   service.StatusActive,
+		Platform: domain.PlatformGemini,
+		Status:   domain.StatusActive,
 	})
 
 	// 创建账户
 	boundAcc := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "bound-antigravity",
-		Platform:    service.PlatformAntigravity,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformAntigravity,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 	})
 	unboundAcc := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "unbound-antigravity",
-		Platform:    service.PlatformAntigravity,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformAntigravity,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 	})
 
@@ -122,8 +123,8 @@ func (s *GatewayRoutingSuite) TestListSchedulableByGroupIDAndPlatforms_WithGroup
 
 	// 查询分组内的账户
 	accounts, err := s.accountRepo.ListSchedulableByGroupIDAndPlatforms(s.ctx, group.ID, []string{
-		service.PlatformGemini,
-		service.PlatformAntigravity,
+		domain.PlatformGemini,
+		domain.PlatformAntigravity,
 	})
 
 	s.Require().NoError(err)
@@ -141,25 +142,25 @@ func (s *GatewayRoutingSuite) TestListSchedulableByPlatform_Antigravity() {
 	// 创建多种平台账户
 	mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "gemini-1",
-		Platform:    service.PlatformGemini,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformGemini,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 	})
 
 	antigravity := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "antigravity-1",
-		Platform:    service.PlatformAntigravity,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformAntigravity,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 	})
 
 	// 只查询 antigravity 平台
-	accounts, err := s.accountRepo.ListSchedulableByPlatform(s.ctx, service.PlatformAntigravity)
+	accounts, err := s.accountRepo.ListSchedulableByPlatform(s.ctx, domain.PlatformAntigravity)
 
 	s.Require().NoError(err)
 	s.Require().Len(accounts, 1)
 	s.Require().Equal(antigravity.ID, accounts[0].ID)
-	s.Require().Equal(service.PlatformAntigravity, accounts[0].Platform)
+	s.Require().Equal(domain.PlatformAntigravity, accounts[0].Platform)
 }
 
 // TestSchedulableFilter_ExcludesInactive 验证不可调度账户被过滤
@@ -167,28 +168,28 @@ func (s *GatewayRoutingSuite) TestSchedulableFilter_ExcludesInactive() {
 	// 创建可调度账户
 	activeAcc := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "active-antigravity",
-		Platform:    service.PlatformAntigravity,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformAntigravity,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 	})
 
 	// 创建不可调度账户（需要先创建再更新，因为 fixture 默认设置 Schedulable=true）
 	inactiveAcc := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:     "inactive-antigravity",
-		Platform: service.PlatformAntigravity,
-		Status:   service.StatusActive,
+		Platform: domain.PlatformAntigravity,
+		Status:   domain.StatusActive,
 	})
 	s.Require().NoError(s.client.Account.UpdateOneID(inactiveAcc.ID).SetSchedulable(false).Exec(s.ctx))
 
 	// 创建错误状态账户
 	mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "error-antigravity",
-		Platform:    service.PlatformAntigravity,
-		Status:      service.StatusError,
+		Platform:    domain.PlatformAntigravity,
+		Status:      domain.StatusError,
 		Schedulable: true,
 	})
 
-	accounts, err := s.accountRepo.ListSchedulableByPlatform(s.ctx, service.PlatformAntigravity)
+	accounts, err := s.accountRepo.ListSchedulableByPlatform(s.ctx, domain.PlatformAntigravity)
 
 	s.Require().NoError(err)
 	s.Require().Len(accounts, 1, "应只返回可调度的 active 账户")
@@ -201,15 +202,15 @@ func (s *GatewayRoutingSuite) TestPlatformRoutingDecision() {
 	// 创建两种平台的账户
 	geminiAcc := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "gemini-route-test",
-		Platform:    service.PlatformGemini,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformGemini,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 	})
 
 	antigravityAcc := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name:        "antigravity-route-test",
-		Platform:    service.PlatformAntigravity,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformAntigravity,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 	})
 
@@ -238,7 +239,7 @@ func (s *GatewayRoutingSuite) TestPlatformRoutingDecision() {
 
 			// 模拟 Handler 层的路由决策
 			var routedService string
-			if account.Platform == service.PlatformAntigravity {
+			if account.Platform == domain.PlatformAntigravity {
 				routedService = "AntigravityGatewayService.ForwardGemini"
 			} else {
 				routedService = "GeminiMessagesCompatService.ForwardNative"

--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -10,6 +10,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/group"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -93,11 +94,11 @@ func (r *groupRepository) Create(ctx context.Context, groupIn *service.Group) er
 		groupIn.ID = created.ID
 		groupIn.CreatedAt = created.CreatedAt
 		groupIn.UpdatedAt = created.UpdatedAt
-		if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventGroupChanged, nil, &groupIn.ID, nil); err != nil {
+		if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventGroupChanged, nil, &groupIn.ID, nil); err != nil {
 			logger.LegacyPrintf("repository.group", "[SchedulerOutbox] enqueue group create failed: group=%d err=%v", groupIn.ID, err)
 		}
 	}
-	return translatePersistenceError(err, nil, service.ErrGroupExists)
+	return translatePersistenceError(err, nil, domain.ErrGroupExists)
 }
 
 func (r *groupRepository) GetByID(ctx context.Context, id int64) (*service.Group, error) {
@@ -121,7 +122,7 @@ func (r *groupRepository) GetByIDLite(ctx context.Context, id int64) (*service.G
 		Where(group.IDEQ(id)).
 		Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrGroupNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrGroupNotFound, nil)
 	}
 	return groupEntityToService(m), nil
 }
@@ -224,10 +225,10 @@ func (r *groupRepository) Update(ctx context.Context, groupIn *service.Group) er
 
 	updated, err := builder.Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrGroupNotFound, service.ErrGroupExists)
+		return translatePersistenceError(err, domain.ErrGroupNotFound, domain.ErrGroupExists)
 	}
 	groupIn.UpdatedAt = updated.UpdatedAt
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventGroupChanged, nil, &groupIn.ID, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventGroupChanged, nil, &groupIn.ID, nil); err != nil {
 		logger.LegacyPrintf("repository.group", "[SchedulerOutbox] enqueue group update failed: group=%d err=%v", groupIn.ID, err)
 	}
 	return nil
@@ -236,9 +237,9 @@ func (r *groupRepository) Update(ctx context.Context, groupIn *service.Group) er
 func (r *groupRepository) Delete(ctx context.Context, id int64) error {
 	_, err := r.client.Group.Delete().Where(group.IDEQ(id)).Exec(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrGroupNotFound, nil)
+		return translatePersistenceError(err, domain.ErrGroupNotFound, nil)
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventGroupChanged, nil, &id, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventGroupChanged, nil, &id, nil); err != nil {
 		logger.LegacyPrintf("repository.group", "[SchedulerOutbox] enqueue group delete failed: group=%d err=%v", id, err)
 	}
 	return nil
@@ -452,7 +453,7 @@ func groupListOrder(params pagination.PaginationParams) []func(*entsql.Selector)
 
 func (r *groupRepository) ListActive(ctx context.Context) ([]service.Group, error) {
 	groups, err := r.client.Group.Query().
-		Where(group.StatusEQ(service.StatusActive)).
+		Where(group.StatusEQ(domain.StatusActive)).
 		Order(dbent.Asc(group.FieldSortOrder), dbent.Asc(group.FieldID)).
 		All(ctx)
 	if err != nil {
@@ -488,7 +489,7 @@ func (r *groupRepository) ListActiveIDs(ctx context.Context) ([]int64, error) {
 			WHERE status = $1
 			  AND deleted_at IS NULL
 			ORDER BY sort_order ASC, id ASC
-		`, service.StatusActive)
+		`, domain.StatusActive)
 		if err != nil {
 			return nil, err
 		}
@@ -509,7 +510,7 @@ func (r *groupRepository) ListActiveIDs(ctx context.Context) ([]int64, error) {
 	}
 
 	groups, err := r.client.Group.Query().
-		Where(group.StatusEQ(service.StatusActive)).
+		Where(group.StatusEQ(domain.StatusActive)).
 		Select(group.FieldID).
 		Order(dbent.Asc(group.FieldSortOrder), dbent.Asc(group.FieldID)).
 		All(ctx)
@@ -525,7 +526,7 @@ func (r *groupRepository) ListActiveIDs(ctx context.Context) ([]int64, error) {
 
 func (r *groupRepository) ListActiveByPlatform(ctx context.Context, platform string) ([]service.Group, error) {
 	groups, err := r.client.Group.Query().
-		Where(group.StatusEQ(service.StatusActive), group.PlatformEQ(platform)).
+		Where(group.StatusEQ(domain.StatusActive), group.PlatformEQ(platform)).
 		Order(dbent.Asc(group.FieldSortOrder), dbent.Asc(group.FieldID)).
 		All(ctx)
 	if err != nil {
@@ -624,7 +625,7 @@ func (r *groupRepository) DeleteAccountGroupsByGroupID(ctx context.Context, grou
 		return 0, err
 	}
 	affected, _ := res.RowsAffected()
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventGroupChanged, nil, &groupID, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventGroupChanged, nil, &groupID, nil); err != nil {
 		logger.LegacyPrintf("repository.group", "[SchedulerOutbox] enqueue group account clear failed: group=%d err=%v", groupID, err)
 	}
 	return affected, nil
@@ -633,7 +634,7 @@ func (r *groupRepository) DeleteAccountGroupsByGroupID(ctx context.Context, grou
 func (r *groupRepository) DeleteCascade(ctx context.Context, id int64) ([]int64, error) {
 	g, err := r.client.Group.Query().Where(group.IDEQ(id)).Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrGroupNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrGroupNotFound, nil)
 	}
 	groupSvc := groupEntityToService(g)
 
@@ -672,7 +673,7 @@ func (r *groupRepository) DeleteCascade(ctx context.Context, id int64) ([]int64,
 		return nil, err
 	}
 	if lockedID == 0 {
-		return nil, service.ErrGroupNotFound
+		return nil, domain.ErrGroupNotFound
 	}
 
 	var affectedUserIDs []int64
@@ -724,7 +725,7 @@ func (r *groupRepository) DeleteCascade(ctx context.Context, id int64) ([]int64,
 			return nil, err
 		}
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventGroupChanged, nil, &id, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventGroupChanged, nil, &id, nil); err != nil {
 		logger.LegacyPrintf("repository.group", "[SchedulerOutbox] enqueue group cascade delete failed: group=%d err=%v", id, err)
 	}
 
@@ -853,7 +854,7 @@ func (r *groupRepository) BindAccountsToGroup(ctx context.Context, groupID int64
 	}
 
 	// 发送调度器事件
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventGroupChanged, nil, &groupID, nil); err != nil {
+	if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventGroupChanged, nil, &groupID, nil); err != nil {
 		logger.LegacyPrintf("repository.group", "[SchedulerOutbox] enqueue bind accounts to group failed: group=%d err=%v", groupID, err)
 	}
 
@@ -894,7 +895,7 @@ func (r *groupRepository) UpdateSortOrders(ctx context.Context, updates []servic
 		return err
 	}
 	if existingCount != len(groupIDs) {
-		return service.ErrGroupNotFound
+		return domain.ErrGroupNotFound
 	}
 
 	args := make([]any, 0, len(groupIDs)*2+1)
@@ -925,11 +926,11 @@ func (r *groupRepository) UpdateSortOrders(ctx context.Context, updates []servic
 		return err
 	}
 	if affected != int64(len(groupIDs)) {
-		return service.ErrGroupNotFound
+		return domain.ErrGroupNotFound
 	}
 
 	for _, id := range groupIDs {
-		if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventGroupChanged, nil, &id, nil); err != nil {
+		if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventGroupChanged, nil, &id, nil); err != nil {
 			logger.LegacyPrintf("repository.group", "[SchedulerOutbox] enqueue group sort update failed: group=%d err=%v", id, err)
 		}
 	}

--- a/backend/internal/repository/group_repo_integration_test.go
+++ b/backend/internal/repository/group_repo_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/suite"
@@ -51,11 +52,11 @@ func TestGroupRepoSuite(t *testing.T) {
 func (s *GroupRepoSuite) TestCreate() {
 	group := &service.Group{
 		Name:             "test-create",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 
 	err := s.repo.Create(s.ctx, group)
@@ -70,17 +71,17 @@ func (s *GroupRepoSuite) TestCreate() {
 func (s *GroupRepoSuite) TestGetByID_NotFound() {
 	_, err := s.repo.GetByID(s.ctx, 999999)
 	s.Require().Error(err, "expected error for non-existent ID")
-	s.Require().ErrorIs(err, service.ErrGroupNotFound)
+	s.Require().ErrorIs(err, domain.ErrGroupNotFound)
 }
 
 func (s *GroupRepoSuite) TestGetByIDLite_DoesNotUseAccountCount() {
 	group := &service.Group{
 		Name:             "lite-group",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, group))
 
@@ -96,11 +97,11 @@ func (s *GroupRepoSuite) TestGetByIDLite_DoesNotUseAccountCount() {
 func (s *GroupRepoSuite) TestUpdate() {
 	group := &service.Group{
 		Name:             "original",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, group))
 
@@ -116,11 +117,11 @@ func (s *GroupRepoSuite) TestUpdate() {
 func (s *GroupRepoSuite) TestGetByID_PreservesMessagesDispatchModelConfig() {
 	group := &service.Group{
 		Name:                  "openai-dispatch",
-		Platform:              service.PlatformOpenAI,
+		Platform:              domain.PlatformOpenAI,
 		RateMultiplier:        1.0,
 		IsExclusive:           false,
-		Status:                service.StatusActive,
-		SubscriptionType:      service.SubscriptionTypeStandard,
+		Status:                domain.StatusActive,
+		SubscriptionType:      domain.SubscriptionTypeStandard,
 		AllowMessagesDispatch: true,
 		DefaultMappedModel:    "gpt-5.4",
 		MessagesDispatchModelConfig: service.OpenAIMessagesDispatchModelConfig{
@@ -145,11 +146,11 @@ func (s *GroupRepoSuite) TestGetByID_PreservesMessagesCompactionPolicy() {
 	threshold := 220000
 	group := &service.Group{
 		Name:                                   "openai-compaction",
-		Platform:                               service.PlatformOpenAI,
+		Platform:                               domain.PlatformOpenAI,
 		RateMultiplier:                         1.0,
 		IsExclusive:                            false,
-		Status:                                 service.StatusActive,
-		SubscriptionType:                       service.SubscriptionTypeStandard,
+		Status:                                 domain.StatusActive,
+		SubscriptionType:                       domain.SubscriptionTypeStandard,
 		MessagesCompactionEnabled:              &enabled,
 		MessagesCompactionInputTokensThreshold: &threshold,
 	}
@@ -167,11 +168,11 @@ func (s *GroupRepoSuite) TestGetByID_PreservesMessagesCompactionPolicy() {
 func (s *GroupRepoSuite) TestDelete() {
 	group := &service.Group{
 		Name:             "to-delete",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, group))
 
@@ -180,7 +181,7 @@ func (s *GroupRepoSuite) TestDelete() {
 
 	_, err = s.repo.GetByID(s.ctx, group.ID)
 	s.Require().Error(err, "expected error after delete")
-	s.Require().ErrorIs(err, service.ErrGroupNotFound)
+	s.Require().ErrorIs(err, domain.ErrGroupNotFound)
 }
 
 // --- List / ListWithFilters ---
@@ -191,19 +192,19 @@ func (s *GroupRepoSuite) TestList() {
 
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "g1",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "g2",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 
 	groups, page, err := s.repo.List(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10})
@@ -216,7 +217,7 @@ func (s *GroupRepoSuite) TestListWithFilters_Platform() {
 	baseGroups, _, err := s.repo.ListWithFilters(
 		s.ctx,
 		pagination.PaginationParams{Page: 1, PageSize: 10},
-		service.PlatformOpenAI,
+		domain.PlatformOpenAI,
 		"",
 		"",
 		nil,
@@ -225,70 +226,70 @@ func (s *GroupRepoSuite) TestListWithFilters_Platform() {
 
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "g1",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "g2",
-		Platform:         service.PlatformOpenAI,
+		Platform:         domain.PlatformOpenAI,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 
-	groups, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, service.PlatformOpenAI, "", "", nil)
+	groups, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, domain.PlatformOpenAI, "", "", nil)
 	s.Require().NoError(err)
 	s.Require().Len(groups, len(baseGroups)+1)
 	// Verify all groups are OpenAI platform
 	for _, g := range groups {
-		s.Require().Equal(service.PlatformOpenAI, g.Platform)
+		s.Require().Equal(domain.PlatformOpenAI, g.Platform)
 	}
 }
 
 func (s *GroupRepoSuite) TestListWithFilters_Status() {
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "g1",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "g2",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusDisabled,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusDisabled,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 
-	groups, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", service.StatusDisabled, "", nil)
+	groups, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", domain.StatusDisabled, "", nil)
 	s.Require().NoError(err)
 	s.Require().Len(groups, 1)
-	s.Require().Equal(service.StatusDisabled, groups[0].Status)
+	s.Require().Equal(domain.StatusDisabled, groups[0].Status)
 }
 
 func (s *GroupRepoSuite) TestListWithFilters_IsExclusive() {
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "g1",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "g2",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      true,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 
 	isExclusive := true
@@ -322,11 +323,11 @@ func (s *GroupRepoSuite) TestListWithFilters_Search() {
 	newGroup := func(name string) *service.Group {
 		return &service.Group{
 			Name:             name,
-			Platform:         service.PlatformAnthropic,
+			Platform:         domain.PlatformAnthropic,
 			RateMultiplier:   1.0,
 			IsExclusive:      false,
-			Status:           service.StatusActive,
-			SubscriptionType: service.SubscriptionTypeStandard,
+			Status:           domain.StatusActive,
+			SubscriptionType: domain.SubscriptionTypeStandard,
 		}
 	}
 
@@ -406,27 +407,27 @@ func (s *GroupRepoSuite) TestListWithFilters_Search() {
 func (s *GroupRepoSuite) TestUpdateSortOrders_BatchCaseWhen() {
 	g1 := &service.Group{
 		Name:             "sort-g1",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	g2 := &service.Group{
 		Name:             "sort-g2",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	g3 := &service.Group{
 		Name:             "sort-g3",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, g1))
 	s.Require().NoError(s.repo.Create(s.ctx, g2))
@@ -454,11 +455,11 @@ func (s *GroupRepoSuite) TestUpdateSortOrders_BatchCaseWhen() {
 func (s *GroupRepoSuite) TestUpdateSortOrders_MissingGroupNoPartialUpdate() {
 	g1 := &service.Group{
 		Name:             "sort-no-partial",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, g1))
 
@@ -471,7 +472,7 @@ func (s *GroupRepoSuite) TestUpdateSortOrders_MissingGroupNoPartialUpdate() {
 		{ID: 99999999, SortOrder: 1},
 	})
 	s.Require().Error(err)
-	s.Require().ErrorIs(err, service.ErrGroupNotFound)
+	s.Require().ErrorIs(err, domain.ErrGroupNotFound)
 
 	after, err := s.repo.GetByID(s.ctx, g1.ID)
 	s.Require().NoError(err)
@@ -481,19 +482,19 @@ func (s *GroupRepoSuite) TestUpdateSortOrders_MissingGroupNoPartialUpdate() {
 func (s *GroupRepoSuite) TestListWithFilters_AccountCount() {
 	g1 := &service.Group{
 		Name:             "g1",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	g2 := &service.Group{
 		Name:             "g2",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      true,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, g1))
 	s.Require().NoError(s.repo.Create(s.ctx, g2))
@@ -503,7 +504,7 @@ func (s *GroupRepoSuite) TestListWithFilters_AccountCount() {
 		s.ctx,
 		s.tx,
 		"INSERT INTO accounts (name, platform, type) VALUES ($1, $2, $3) RETURNING id",
-		[]any{"acc1", service.PlatformAnthropic, service.AccountTypeOAuth},
+		[]any{"acc1", domain.PlatformAnthropic, domain.AccountTypeOAuth},
 		&accountID,
 	))
 	_, err := s.tx.ExecContext(s.ctx, "INSERT INTO account_groups (account_id, group_id, priority, created_at) VALUES ($1, $2, $3, NOW())", accountID, g1.ID, 1)
@@ -512,7 +513,7 @@ func (s *GroupRepoSuite) TestListWithFilters_AccountCount() {
 	s.Require().NoError(err)
 
 	isExclusive := true
-	groups, page, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, service.PlatformAnthropic, service.StatusActive, "", &isExclusive)
+	groups, page, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, domain.PlatformAnthropic, domain.StatusActive, "", &isExclusive)
 	s.Require().NoError(err, "ListWithFilters")
 	s.Require().Equal(int64(1), page.Total)
 	s.Require().Len(groups, 1)
@@ -528,19 +529,19 @@ func (s *GroupRepoSuite) TestListActive() {
 
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "active1",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "inactive1",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusDisabled,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusDisabled,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 
 	groups, err := s.repo.ListActive(s.ctx)
@@ -560,30 +561,30 @@ func (s *GroupRepoSuite) TestListActive() {
 func (s *GroupRepoSuite) TestListActiveByPlatform() {
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "g1",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "g2",
-		Platform:         service.PlatformOpenAI,
+		Platform:         domain.PlatformOpenAI,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "g3",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusDisabled,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusDisabled,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 
-	groups, err := s.repo.ListActiveByPlatform(s.ctx, service.PlatformAnthropic)
+	groups, err := s.repo.ListActiveByPlatform(s.ctx, domain.PlatformAnthropic)
 	s.Require().NoError(err, "ListActiveByPlatform")
 	// 1 default anthropic group + 1 test active anthropic group = 2 total
 	s.Require().Len(groups, 2)
@@ -603,11 +604,11 @@ func (s *GroupRepoSuite) TestListActiveByPlatform() {
 func (s *GroupRepoSuite) TestExistsByName() {
 	s.Require().NoError(s.repo.Create(s.ctx, &service.Group{
 		Name:             "existing-group",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}))
 
 	exists, err := s.repo.ExistsByName(s.ctx, "existing-group")
@@ -624,11 +625,11 @@ func (s *GroupRepoSuite) TestExistsByName() {
 func (s *GroupRepoSuite) TestGetAccountCount() {
 	group := &service.Group{
 		Name:             "g-count",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, group))
 
@@ -637,7 +638,7 @@ func (s *GroupRepoSuite) TestGetAccountCount() {
 		s.ctx,
 		s.tx,
 		"INSERT INTO accounts (name, platform, type) VALUES ($1, $2, $3) RETURNING id",
-		[]any{"a1", service.PlatformAnthropic, service.AccountTypeOAuth},
+		[]any{"a1", domain.PlatformAnthropic, domain.AccountTypeOAuth},
 		&a1,
 	))
 	var a2 int64
@@ -645,7 +646,7 @@ func (s *GroupRepoSuite) TestGetAccountCount() {
 		s.ctx,
 		s.tx,
 		"INSERT INTO accounts (name, platform, type) VALUES ($1, $2, $3) RETURNING id",
-		[]any{"a2", service.PlatformAnthropic, service.AccountTypeOAuth},
+		[]any{"a2", domain.PlatformAnthropic, domain.AccountTypeOAuth},
 		&a2,
 	))
 
@@ -662,11 +663,11 @@ func (s *GroupRepoSuite) TestGetAccountCount() {
 func (s *GroupRepoSuite) TestGetAccountCount_Empty() {
 	group := &service.Group{
 		Name:             "g-empty",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, group))
 
@@ -681,11 +682,11 @@ func (s *GroupRepoSuite) TestGetAccountCount_Empty() {
 func (s *GroupRepoSuite) TestListWithFilters_ActiveAccountCount_LessThanTotal() {
 	g := &service.Group{
 		Name:             "g-mixed-status",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, g))
 
@@ -694,7 +695,7 @@ func (s *GroupRepoSuite) TestListWithFilters_ActiveAccountCount_LessThanTotal() 
 		s.Require().NoError(scanSingleRow(
 			s.ctx, s.tx,
 			"INSERT INTO accounts (name, platform, type, status, schedulable) VALUES ($1, $2, $3, $4, $5) RETURNING id",
-			[]any{name, service.PlatformAnthropic, service.AccountTypeOAuth, status, schedulable},
+			[]any{name, domain.PlatformAnthropic, domain.AccountTypeOAuth, status, schedulable},
 			&id,
 		))
 		return id
@@ -707,17 +708,17 @@ func (s *GroupRepoSuite) TestListWithFilters_ActiveAccountCount_LessThanTotal() 
 	}
 
 	// account 1: active + schedulable → counts toward both total and active
-	link(insertAccount("acc-active-sched", service.StatusActive, true), 1)
+	link(insertAccount("acc-active-sched", domain.StatusActive, true), 1)
 	// account 2: disabled → counts toward total only
-	link(insertAccount("acc-disabled", service.StatusDisabled, true), 2)
+	link(insertAccount("acc-disabled", domain.StatusDisabled, true), 2)
 	// account 3: active + not schedulable → counts toward total only
-	link(insertAccount("acc-unschedulable", service.StatusActive, false), 3)
+	link(insertAccount("acc-unschedulable", domain.StatusActive, false), 3)
 
 	// --- ListWithFilters path ---
 	isExclusive := false
 	groups, _, err := s.repo.ListWithFilters(s.ctx,
 		pagination.PaginationParams{Page: 1, PageSize: 100},
-		service.PlatformAnthropic, service.StatusActive, "", &isExclusive)
+		domain.PlatformAnthropic, domain.StatusActive, "", &isExclusive)
 	s.Require().NoError(err)
 
 	var found *service.Group
@@ -744,42 +745,42 @@ func (s *GroupRepoSuite) TestListWithFilters_ActiveAccountCount_LessThanTotal() 
 func (s *GroupRepoSuite) TestListWithFilters_RateLimitedAccountCount() {
 	g := &service.Group{
 		Name:             "g-rate-limited",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, g))
 
 	var normalID int64
 	s.Require().NoError(scanSingleRow(s.ctx, s.tx,
 		"INSERT INTO accounts (name, platform, type) VALUES ($1, $2, $3) RETURNING id",
-		[]any{"acc-normal", service.PlatformAnthropic, service.AccountTypeOAuth},
+		[]any{"acc-normal", domain.PlatformAnthropic, domain.AccountTypeOAuth},
 		&normalID))
 
 	var rateLimitedID int64
 	s.Require().NoError(scanSingleRow(s.ctx, s.tx,
 		"INSERT INTO accounts (name, platform, type, rate_limit_reset_at) VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour') RETURNING id",
-		[]any{"acc-rate-limited", service.PlatformAnthropic, service.AccountTypeOAuth},
+		[]any{"acc-rate-limited", domain.PlatformAnthropic, domain.AccountTypeOAuth},
 		&rateLimitedID))
 
 	var overloadedID int64
 	s.Require().NoError(scanSingleRow(s.ctx, s.tx,
 		"INSERT INTO accounts (name, platform, type, overload_until) VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour') RETURNING id",
-		[]any{"acc-overloaded", service.PlatformAnthropic, service.AccountTypeOAuth},
+		[]any{"acc-overloaded", domain.PlatformAnthropic, domain.AccountTypeOAuth},
 		&overloadedID))
 
 	var tempUnschedulableID int64
 	s.Require().NoError(scanSingleRow(s.ctx, s.tx,
 		"INSERT INTO accounts (name, platform, type, temp_unschedulable_until) VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour') RETURNING id",
-		[]any{"acc-temp-unschedulable", service.PlatformAnthropic, service.AccountTypeOAuth},
+		[]any{"acc-temp-unschedulable", domain.PlatformAnthropic, domain.AccountTypeOAuth},
 		&tempUnschedulableID))
 
 	var expiredID int64
 	s.Require().NoError(scanSingleRow(s.ctx, s.tx,
 		"INSERT INTO accounts (name, platform, type, expires_at, auto_pause_on_expired) VALUES ($1, $2, $3, NOW() - INTERVAL '1 hour', TRUE) RETURNING id",
-		[]any{"acc-expired", service.PlatformAnthropic, service.AccountTypeOAuth},
+		[]any{"acc-expired", domain.PlatformAnthropic, domain.AccountTypeOAuth},
 		&expiredID))
 
 	_, err := s.tx.ExecContext(s.ctx,
@@ -806,7 +807,7 @@ func (s *GroupRepoSuite) TestListWithFilters_RateLimitedAccountCount() {
 	isExclusive := false
 	groups, _, err := s.repo.ListWithFilters(s.ctx,
 		pagination.PaginationParams{Page: 1, PageSize: 100},
-		service.PlatformAnthropic, service.StatusActive, "", &isExclusive)
+		domain.PlatformAnthropic, domain.StatusActive, "", &isExclusive)
 	s.Require().NoError(err)
 
 	var found *service.Group
@@ -838,11 +839,11 @@ func (s *GroupRepoSuite) TestListWithFilters_RateLimitedAccountCount() {
 func (s *GroupRepoSuite) TestDeleteAccountGroupsByGroupID() {
 	g := &service.Group{
 		Name:             "g-del",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, g))
 	var accountID int64
@@ -850,7 +851,7 @@ func (s *GroupRepoSuite) TestDeleteAccountGroupsByGroupID() {
 		s.ctx,
 		s.tx,
 		"INSERT INTO accounts (name, platform, type) VALUES ($1, $2, $3) RETURNING id",
-		[]any{"acc-del", service.PlatformAnthropic, service.AccountTypeOAuth},
+		[]any{"acc-del", domain.PlatformAnthropic, domain.AccountTypeOAuth},
 		&accountID,
 	))
 	_, err := s.tx.ExecContext(s.ctx, "INSERT INTO account_groups (account_id, group_id, priority, created_at) VALUES ($1, $2, $3, NOW())", accountID, g.ID, 1)
@@ -868,11 +869,11 @@ func (s *GroupRepoSuite) TestDeleteAccountGroupsByGroupID() {
 func (s *GroupRepoSuite) TestDeleteAccountGroupsByGroupID_MultipleAccounts() {
 	g := &service.Group{
 		Name:             "g-multi",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, g))
 
@@ -882,7 +883,7 @@ func (s *GroupRepoSuite) TestDeleteAccountGroupsByGroupID_MultipleAccounts() {
 			s.ctx,
 			s.tx,
 			"INSERT INTO accounts (name, platform, type) VALUES ($1, $2, $3) RETURNING id",
-			[]any{name, service.PlatformAnthropic, service.AccountTypeOAuth},
+			[]any{name, domain.PlatformAnthropic, domain.AccountTypeOAuth},
 			&id,
 		))
 		return id
@@ -910,11 +911,11 @@ func (s *GroupRepoSuite) TestDeleteAccountGroupsByGroupID_MultipleAccounts() {
 func (s *GroupRepoSuite) TestDelete_SoftDelete_NotVisibleInList() {
 	group := &service.Group{
 		Name:             "to-soft-delete",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, group))
 
@@ -935,17 +936,17 @@ func (s *GroupRepoSuite) TestDelete_SoftDelete_NotVisibleInList() {
 	// 验证 GetByID 也无法找到
 	_, err = s.repo.GetByID(s.ctx, group.ID)
 	s.Require().Error(err)
-	s.Require().ErrorIs(err, service.ErrGroupNotFound)
+	s.Require().ErrorIs(err, domain.ErrGroupNotFound)
 }
 
 func (s *GroupRepoSuite) TestDelete_SoftDeletedGroup_lockForUpdate() {
 	group := &service.Group{
 		Name:             "lock-soft-delete",
-		Platform:         service.PlatformAnthropic,
+		Platform:         domain.PlatformAnthropic,
 		RateMultiplier:   1.0,
 		IsExclusive:      false,
-		Status:           service.StatusActive,
-		SubscriptionType: service.SubscriptionTypeStandard,
+		Status:           domain.StatusActive,
+		SubscriptionType: domain.SubscriptionTypeStandard,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, group))
 
@@ -957,5 +958,5 @@ func (s *GroupRepoSuite) TestDelete_SoftDeletedGroup_lockForUpdate() {
 	// 这证明 lockForUpdate 的 deleted_at IS NULL 过滤正在工作
 	_, err = s.repo.GetByID(s.ctx, group.ID)
 	s.Require().Error(err, "should fail to get soft-deleted group")
-	s.Require().ErrorIs(err, service.ErrGroupNotFound)
+	s.Require().ErrorIs(err, domain.ErrGroupNotFound)
 }

--- a/backend/internal/repository/group_repo_sort_integration_test.go
+++ b/backend/internal/repository/group_repo_sort_integration_test.go
@@ -3,6 +3,7 @@
 package repository
 
 import (
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
@@ -12,9 +13,9 @@ import (
 // 且排序基于 total 账号数而非 active 账号数。
 func (s *GroupRepoSuite) TestListWithAccountCountSort_AttachesActiveCount() {
 	// Group A: 2 total, 1 active (1 disabled account)
-	gA := &service.Group{Name: "sort-count-a", Platform: service.PlatformAnthropic, RateMultiplier: 1, Status: service.StatusActive, SubscriptionType: service.SubscriptionTypeStandard}
+	gA := &service.Group{Name: "sort-count-a", Platform: domain.PlatformAnthropic, RateMultiplier: 1, Status: domain.StatusActive, SubscriptionType: domain.SubscriptionTypeStandard}
 	// Group B: 1 total, 1 active
-	gB := &service.Group{Name: "sort-count-b", Platform: service.PlatformAnthropic, RateMultiplier: 1, Status: service.StatusActive, SubscriptionType: service.SubscriptionTypeStandard}
+	gB := &service.Group{Name: "sort-count-b", Platform: domain.PlatformAnthropic, RateMultiplier: 1, Status: domain.StatusActive, SubscriptionType: domain.SubscriptionTypeStandard}
 	s.Require().NoError(s.repo.Create(s.ctx, gA))
 	s.Require().NoError(s.repo.Create(s.ctx, gB))
 
@@ -22,7 +23,7 @@ func (s *GroupRepoSuite) TestListWithAccountCountSort_AttachesActiveCount() {
 		var id int64
 		s.Require().NoError(scanSingleRow(s.ctx, s.tx,
 			"INSERT INTO accounts (name, platform, type, status) VALUES ($1, $2, $3, $4) RETURNING id",
-			[]any{name, service.PlatformAnthropic, service.AccountTypeOAuth, status},
+			[]any{name, domain.PlatformAnthropic, domain.AccountTypeOAuth, status},
 			&id))
 		return id
 	}
@@ -34,14 +35,14 @@ func (s *GroupRepoSuite) TestListWithAccountCountSort_AttachesActiveCount() {
 	}
 
 	// gA: 1 active + 1 disabled → total=2, active=1
-	link(insertAccount("sa-active", service.StatusActive), gA.ID, 1)
-	link(insertAccount("sa-disabled", service.StatusDisabled), gA.ID, 2)
+	link(insertAccount("sa-active", domain.StatusActive), gA.ID, 1)
+	link(insertAccount("sa-disabled", domain.StatusDisabled), gA.ID, 2)
 	// gB: 1 active → total=1, active=1
-	link(insertAccount("sb-active", service.StatusActive), gB.ID, 1)
+	link(insertAccount("sb-active", domain.StatusActive), gB.ID, 1)
 
 	groups, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{
 		Page: 1, PageSize: 100, SortBy: "account_count", SortOrder: "desc",
-	}, service.PlatformAnthropic, service.StatusActive, "", nil)
+	}, domain.PlatformAnthropic, domain.StatusActive, "", nil)
 	s.Require().NoError(err)
 
 	byID := make(map[int64]service.Group, len(groups))
@@ -69,8 +70,8 @@ func (s *GroupRepoSuite) TestListWithAccountCountSort_AttachesActiveCount() {
 }
 
 func (s *GroupRepoSuite) TestList_DefaultSortBySortOrderAsc() {
-	g1 := &service.Group{Name: "g1", Platform: service.PlatformAnthropic, RateMultiplier: 1, Status: service.StatusActive, SubscriptionType: service.SubscriptionTypeStandard, SortOrder: 20}
-	g2 := &service.Group{Name: "g2", Platform: service.PlatformAnthropic, RateMultiplier: 1, Status: service.StatusActive, SubscriptionType: service.SubscriptionTypeStandard, SortOrder: 10}
+	g1 := &service.Group{Name: "g1", Platform: domain.PlatformAnthropic, RateMultiplier: 1, Status: domain.StatusActive, SubscriptionType: domain.SubscriptionTypeStandard, SortOrder: 20}
+	g2 := &service.Group{Name: "g2", Platform: domain.PlatformAnthropic, RateMultiplier: 1, Status: domain.StatusActive, SubscriptionType: domain.SubscriptionTypeStandard, SortOrder: 10}
 	s.Require().NoError(s.repo.Create(s.ctx, g1))
 	s.Require().NoError(s.repo.Create(s.ctx, g2))
 
@@ -88,8 +89,8 @@ func (s *GroupRepoSuite) TestList_DefaultSortBySortOrderAsc() {
 }
 
 func (s *GroupRepoSuite) TestList_SortBySortOrderDesc() {
-	g1 := &service.Group{Name: "g1", Platform: service.PlatformAnthropic, RateMultiplier: 1, Status: service.StatusActive, SubscriptionType: service.SubscriptionTypeStandard, SortOrder: 40}
-	g2 := &service.Group{Name: "g2", Platform: service.PlatformAnthropic, RateMultiplier: 1, Status: service.StatusActive, SubscriptionType: service.SubscriptionTypeStandard, SortOrder: 50}
+	g1 := &service.Group{Name: "g1", Platform: domain.PlatformAnthropic, RateMultiplier: 1, Status: domain.StatusActive, SubscriptionType: domain.SubscriptionTypeStandard, SortOrder: 40}
+	g2 := &service.Group{Name: "g2", Platform: domain.PlatformAnthropic, RateMultiplier: 1, Status: domain.StatusActive, SubscriptionType: domain.SubscriptionTypeStandard, SortOrder: 50}
 	s.Require().NoError(s.repo.Create(s.ctx, g1))
 	s.Require().NoError(s.repo.Create(s.ctx, g2))
 

--- a/backend/internal/repository/media_s3_store_test.go
+++ b/backend/internal/repository/media_s3_store_test.go
@@ -13,9 +13,9 @@ import (
 // inline base64 instead of crashing or silently pointing at an empty bucket.
 func TestNewMediaStore_DisabledWhenUnconfigured(t *testing.T) {
 	cases := []config.MediaStorageConfig{
-		{},                                  // nothing set
-		{Driver: "s3"},                      // bucket missing
-		{Bucket: "b"},                       // driver missing
+		{},             // nothing set
+		{Driver: "s3"}, // bucket missing
+		{Bucket: "b"},  // driver missing
 		{Driver: "", Bucket: "b", Region: "us-east-1"}, // driver empty
 	}
 	for i, mc := range cases {

--- a/backend/internal/repository/ops_repo_dashboard.go
+++ b/backend/internal/repository/ops_repo_dashboard.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -63,8 +64,8 @@ func (r *opsRepository) getDashboardOverviewRaw(ctx context.Context, filter *ser
 	if err != nil {
 		if isQueryTimeoutErr(err) {
 			degraded = true
-			duration = service.OpsPercentiles{}
-			ttft = service.OpsPercentiles{}
+			duration = domain.OpsPercentiles{}
+			ttft = domain.OpsPercentiles{}
 		} else {
 			return nil, err
 		}
@@ -168,8 +169,8 @@ type opsDashboardPartial struct {
 
 	tokenConsumed int64
 
-	duration service.OpsPercentiles
-	ttft     service.OpsPercentiles
+	duration domain.OpsPercentiles
+	ttft     domain.OpsPercentiles
 }
 
 func (r *opsRepository) getDashboardOverviewPreaggregated(ctx context.Context, filter *service.OpsDashboardFilter) (*service.OpsDashboardOverview, error) {
@@ -632,8 +633,8 @@ func (r *opsRepository) queryRawPartial(ctx context.Context, filter *service.Ops
 	cancelLatency()
 	if err != nil {
 		if isQueryTimeoutErr(err) {
-			duration = service.OpsPercentiles{}
-			ttft = service.OpsPercentiles{}
+			duration = domain.OpsPercentiles{}
+			ttft = domain.OpsPercentiles{}
 			ttftSampleCount = 0
 		} else {
 			return nil, err
@@ -685,11 +686,11 @@ func (r *opsRepository) rawOpsDataExists(ctx context.Context, filter *service.Op
 
 type opsPercentileSegment struct {
 	weight int64
-	p      service.OpsPercentiles
+	p      domain.OpsPercentiles
 }
 
-func combineApproxPercentiles(segments []opsPercentileSegment) service.OpsPercentiles {
-	weightedInt := func(get func(service.OpsPercentiles) *int) *int {
+func combineApproxPercentiles(segments []opsPercentileSegment) domain.OpsPercentiles {
+	weightedInt := func(get func(domain.OpsPercentiles) *int) *int {
 		var sum float64
 		var w int64
 		for _, seg := range segments {
@@ -710,7 +711,7 @@ func combineApproxPercentiles(segments []opsPercentileSegment) service.OpsPercen
 		return &out
 	}
 
-	maxInt := func(get func(service.OpsPercentiles) *int) *int {
+	maxInt := func(get func(domain.OpsPercentiles) *int) *int {
 		var max *int
 		for _, seg := range segments {
 			v := get(seg.p)
@@ -725,13 +726,13 @@ func combineApproxPercentiles(segments []opsPercentileSegment) service.OpsPercen
 		return max
 	}
 
-	return service.OpsPercentiles{
-		P50: weightedInt(func(p service.OpsPercentiles) *int { return p.P50 }),
-		P90: weightedInt(func(p service.OpsPercentiles) *int { return p.P90 }),
-		P95: maxInt(func(p service.OpsPercentiles) *int { return p.P95 }),
-		P99: maxInt(func(p service.OpsPercentiles) *int { return p.P99 }),
-		Avg: weightedInt(func(p service.OpsPercentiles) *int { return p.Avg }),
-		Max: maxInt(func(p service.OpsPercentiles) *int { return p.Max }),
+	return domain.OpsPercentiles{
+		P50: weightedInt(func(p domain.OpsPercentiles) *int { return p.P50 }),
+		P90: weightedInt(func(p domain.OpsPercentiles) *int { return p.P90 }),
+		P95: maxInt(func(p domain.OpsPercentiles) *int { return p.P95 }),
+		P99: maxInt(func(p domain.OpsPercentiles) *int { return p.P99 }),
+		Avg: weightedInt(func(p domain.OpsPercentiles) *int { return p.Avg }),
+		Max: maxInt(func(p domain.OpsPercentiles) *int { return p.Max }),
 	}
 }
 
@@ -792,7 +793,7 @@ FROM usage_logs ul
 	return successCount, tokenConsumed, nil
 }
 
-func (r *opsRepository) queryUsageLatency(ctx context.Context, filter *service.OpsDashboardFilter, start, end time.Time) (duration service.OpsPercentiles, ttft service.OpsPercentiles, ttftSampleCount int64, err error) {
+func (r *opsRepository) queryUsageLatency(ctx context.Context, filter *service.OpsDashboardFilter, start, end time.Time) (duration domain.OpsPercentiles, ttft domain.OpsPercentiles, ttftSampleCount int64, err error) {
 	join, where, args, _ := buildUsageWhere(filter, start, end, 1)
 	q := `
 SELECT
@@ -824,7 +825,7 @@ FROM usage_logs ul
 		&dP50, &dP90, &dP95, &dP99, &dAvg, &dMax,
 		&tP50, &tP90, &tP95, &tP99, &tAvg, &tMax, &tCount,
 	); err != nil {
-		return service.OpsPercentiles{}, service.OpsPercentiles{}, 0, err
+		return domain.OpsPercentiles{}, domain.OpsPercentiles{}, 0, err
 	}
 
 	duration.P50 = floatToIntPtr(dP50)

--- a/backend/internal/repository/ops_repo_openai_token_stats.go
+++ b/backend/internal/repository/ops_repo_openai_token_stats.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -37,7 +38,7 @@ func (r *opsRepository) GetOpenAITokenStats(ctx context.Context, filter *service
 	// id 通常不是 gpt 前缀（如 moonshot-v1-32k、claude-shape、自定义渠道名），
 	// platform=newapi 时若沿用 gpt% 过滤会让该卡片几乎永远空表，等价于 newapi
 	// 没有可观测性。仅在 platform=newapi 时跳过该前缀过滤。详见 US-024。
-	if dashboardFilter.Platform != service.PlatformNewAPI {
+	if dashboardFilter.Platform != domain.PlatformNewAPI {
 		where += " AND ul.model LIKE 'gpt%'"
 	}
 

--- a/backend/internal/repository/ops_repo_routing_capacity_rejection_integration_test.go
+++ b/backend/internal/repository/ops_repo_routing_capacity_rejection_integration_test.go
@@ -49,9 +49,9 @@ func TestRoutingCapacityRejectionCountIsolatesRoutingPhase(t *testing.T) {
 	insert("routing", "platform", "openai", "", "gpt-5.1", 429)                      // a second platform's empty-pool rejection
 
 	// NOT routing — must NOT be counted, even though some are 429:
-	insert("auth", "client", "anthropic", "claude-sonnet-4-5", "", 429)      // user-level rate limit (their own quota)
+	insert("auth", "client", "anthropic", "claude-sonnet-4-5", "", 429)     // user-level rate limit (their own quota)
 	insert("upstream", "provider", "anthropic", "claude-opus-4-8", "", 429) // real provider rate_limit_error
-	insert("request", "client", "openai", "gpt-5.1", "", 429)                // concurrency/queue client limit
+	insert("request", "client", "openai", "gpt-5.1", "", 429)               // concurrency/queue client limit
 	insert("internal", "platform", "gemini", "gemini-2.5-pro", "", 500)     // non-capacity platform error
 	insert("upstream", "provider", "openai", "gpt-5.1", "", 502)            // ordinary provider failure
 

--- a/backend/internal/repository/ops_write_pressure_integration_test.go
+++ b/backend/internal/repository/ops_write_pressure_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -50,22 +51,22 @@ func TestEnqueueSchedulerOutbox_DeduplicatesIdempotentEvents(t *testing.T) {
 	_, _ = integrationDB.ExecContext(ctx, "TRUNCATE scheduler_outbox RESTART IDENTITY")
 
 	accountID := int64(12345)
-	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
-	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, domain.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, domain.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
 
 	var count int
-	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", domain.SchedulerOutboxEventAccountChanged).Scan(&count))
 	require.Equal(t, 1, count)
 
 	var firstID int64
-	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT id FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&firstID))
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT id FROM scheduler_outbox WHERE event_type = $1", domain.SchedulerOutboxEventAccountChanged).Scan(&firstID))
 	events, err := NewSchedulerOutboxRepository(integrationDB).ListAfterAndReleaseDedup(ctx, 0, 100)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	require.Equal(t, firstID, events[0].ID)
 
-	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
-	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, domain.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", domain.SchedulerOutboxEventAccountChanged).Scan(&count))
 	require.Equal(t, 2, count)
 }
 
@@ -74,16 +75,16 @@ func TestSchedulerOutbox_ListAfterAndReleaseDedup_AllowsSameKeyWhileEventInFligh
 	_, _ = integrationDB.ExecContext(ctx, "TRUNCATE scheduler_outbox RESTART IDENTITY")
 
 	accountID := int64(17345)
-	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, domain.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
 
 	events, err := NewSchedulerOutboxRepository(integrationDB).ListAfterAndReleaseDedup(ctx, 0, 100)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 
-	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, domain.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
 
 	var count int
-	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", domain.SchedulerOutboxEventAccountChanged).Scan(&count))
 	require.Equal(t, 2, count)
 
 	var pendingKeys int
@@ -97,11 +98,11 @@ func TestEnqueueSchedulerOutbox_CoalescesAccountStateBurst(t *testing.T) {
 
 	accountID := int64(22345)
 	for range 50 {
-		require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
+		require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, domain.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
 	}
 
 	var count int
-	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", domain.SchedulerOutboxEventAccountChanged).Scan(&count))
 	t.Logf("same-account account_changed burst: calls=50 inserted=%d", count)
 	require.Equal(t, 1, count)
 }
@@ -113,11 +114,11 @@ func TestEnqueueSchedulerOutbox_DoesNotDeduplicateDifferentPayload(t *testing.T)
 	accountID := int64(32345)
 	payload1 := map[string]any{"group_ids": []int64{1}}
 	payload2 := map[string]any{"group_ids": []int64{2}}
-	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, payload1))
-	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, payload2))
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, domain.SchedulerOutboxEventAccountChanged, &accountID, nil, payload1))
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, domain.SchedulerOutboxEventAccountChanged, &accountID, nil, payload2))
 
 	var count int
-	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", domain.SchedulerOutboxEventAccountChanged).Scan(&count))
 	require.Equal(t, 2, count)
 }
 
@@ -128,10 +129,10 @@ func TestEnqueueSchedulerOutbox_DoesNotDeduplicateLastUsed(t *testing.T) {
 	accountID := int64(67890)
 	payload1 := map[string]any{"last_used": map[string]int64{"67890": 100}}
 	payload2 := map[string]any{"last_used": map[string]int64{"67890": 200}}
-	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountLastUsed, &accountID, nil, payload1))
-	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountLastUsed, &accountID, nil, payload2))
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, domain.SchedulerOutboxEventAccountLastUsed, &accountID, nil, payload1))
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, domain.SchedulerOutboxEventAccountLastUsed, &accountID, nil, payload2))
 
 	var count int
-	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountLastUsed).Scan(&count))
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", domain.SchedulerOutboxEventAccountLastUsed).Scan(&count))
 	require.Equal(t, 2, count)
 }

--- a/backend/internal/repository/promo_code_repo.go
+++ b/backend/internal/repository/promo_code_repo.go
@@ -7,6 +7,7 @@ import (
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/promocode"
 	"github.com/Wei-Shaw/sub2api/ent/promocodeusage"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
@@ -52,7 +53,7 @@ func (r *promoCodeRepository) GetByID(ctx context.Context, id int64) (*service.P
 		Only(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return nil, service.ErrPromoCodeNotFound
+			return nil, domain.ErrPromoCodeNotFound
 		}
 		return nil, err
 	}
@@ -65,7 +66,7 @@ func (r *promoCodeRepository) GetByCode(ctx context.Context, code string) (*serv
 		Only(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return nil, service.ErrPromoCodeNotFound
+			return nil, domain.ErrPromoCodeNotFound
 		}
 		return nil, err
 	}
@@ -80,7 +81,7 @@ func (r *promoCodeRepository) GetByCodeForUpdate(ctx context.Context, code strin
 		Only(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return nil, service.ErrPromoCodeNotFound
+			return nil, domain.ErrPromoCodeNotFound
 		}
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func (r *promoCodeRepository) Update(ctx context.Context, code *service.PromoCod
 	updated, err := builder.Save(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return service.ErrPromoCodeNotFound
+			return domain.ErrPromoCodeNotFound
 		}
 		return err
 	}

--- a/backend/internal/repository/proxy_expiry_integration_test.go
+++ b/backend/internal/repository/proxy_expiry_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/suite"
 )
@@ -27,8 +28,8 @@ func (s *ProxyExpirySuite) SetupTest() {
 func TestProxyExpirySuite(t *testing.T) { suite.Run(t, new(ProxyExpirySuite)) }
 
 func (s *ProxyExpirySuite) mkProxy(name, mode string, expiresAt *time.Time, backupID *int64) int64 {
-	p := &service.Proxy{Name: name, Protocol: "http", Host: "127.0.0.1", Port: 8080,
-		Status: service.StatusActive, FallbackMode: mode, ExpiryWarnDays: 7,
+	p := &domain.Proxy{Name: name, Protocol: "http", Host: "127.0.0.1", Port: 8080,
+		Status: domain.StatusActive, FallbackMode: mode, ExpiryWarnDays: 7,
 		ExpiresAt: expiresAt, BackupProxyID: backupID}
 	s.Require().NoError(s.repo.Create(s.ctx, p))
 	return p.ID
@@ -61,7 +62,7 @@ func (s *ProxyExpirySuite) TestSweep_DirectMode() {
 	s.Require().GreaterOrEqual(changed, int64(1))
 
 	got, _ := s.repo.GetByID(s.ctx, pid)
-	s.Require().Equal(service.StatusExpired, got.Status)
+	s.Require().Equal(domain.StatusExpired, got.Status)
 	s.Require().Nil(s.accountProxyID(aid))
 	var origin *int64
 	err = scanSingleRow(s.ctx, s.tx, `SELECT proxy_fallback_origin_id FROM accounts WHERE id=$1`, []any{aid}, &origin)
@@ -95,7 +96,7 @@ func (s *ProxyExpirySuite) TestSweep_NoneMode_KeepsAccount() {
 	_, err := s.repo.SweepExpiredProxies(s.ctx, time.Now())
 	s.Require().NoError(err)
 	got, _ := s.repo.GetByID(s.ctx, pid)
-	s.Require().Equal(service.StatusExpired, got.Status)
+	s.Require().Equal(domain.StatusExpired, got.Status)
 	s.Require().Equal(pid, *s.accountProxyID(aid))
 	var origin *int64
 	err = scanSingleRow(s.ctx, s.tx, `SELECT proxy_fallback_origin_id FROM accounts WHERE id=$1`, []any{aid}, &origin)

--- a/backend/internal/repository/proxy_repo.go
+++ b/backend/internal/repository/proxy_repo.go
@@ -9,6 +9,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/proxy"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -31,7 +32,7 @@ func newProxyRepositoryWithSQL(client *dbent.Client, sqlq sqlExecutor) *proxyRep
 	return &proxyRepository{client: client, sql: sqlq}
 }
 
-func (r *proxyRepository) Create(ctx context.Context, proxyIn *service.Proxy) error {
+func (r *proxyRepository) Create(ctx context.Context, proxyIn *domain.Proxy) error {
 	builder := r.client.Proxy.Create().
 		SetName(proxyIn.Name).
 		SetProtocol(proxyIn.Protocol).
@@ -60,20 +61,20 @@ func (r *proxyRepository) Create(ctx context.Context, proxyIn *service.Proxy) er
 	return err
 }
 
-func (r *proxyRepository) GetByID(ctx context.Context, id int64) (*service.Proxy, error) {
+func (r *proxyRepository) GetByID(ctx context.Context, id int64) (*domain.Proxy, error) {
 	m, err := r.client.Proxy.Get(ctx, id)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return nil, service.ErrProxyNotFound
+			return nil, domain.ErrProxyNotFound
 		}
 		return nil, err
 	}
 	return proxyEntityToService(m), nil
 }
 
-func (r *proxyRepository) ListByIDs(ctx context.Context, ids []int64) ([]service.Proxy, error) {
+func (r *proxyRepository) ListByIDs(ctx context.Context, ids []int64) ([]domain.Proxy, error) {
 	if len(ids) == 0 {
-		return []service.Proxy{}, nil
+		return []domain.Proxy{}, nil
 	}
 
 	proxies, err := r.client.Proxy.Query().
@@ -83,14 +84,14 @@ func (r *proxyRepository) ListByIDs(ctx context.Context, ids []int64) ([]service
 		return nil, err
 	}
 
-	out := make([]service.Proxy, 0, len(proxies))
+	out := make([]domain.Proxy, 0, len(proxies))
 	for i := range proxies {
 		out = append(out, *proxyEntityToService(proxies[i]))
 	}
 	return out, nil
 }
 
-func (r *proxyRepository) Update(ctx context.Context, proxyIn *service.Proxy) error {
+func (r *proxyRepository) Update(ctx context.Context, proxyIn *domain.Proxy) error {
 	builder := r.client.Proxy.UpdateOneID(proxyIn.ID).
 		SetName(proxyIn.Name).
 		SetProtocol(proxyIn.Protocol).
@@ -126,7 +127,7 @@ func (r *proxyRepository) Update(ctx context.Context, proxyIn *service.Proxy) er
 		return nil
 	}
 	if dbent.IsNotFound(err) {
-		return service.ErrProxyNotFound
+		return domain.ErrProxyNotFound
 	}
 	return err
 }
@@ -136,12 +137,12 @@ func (r *proxyRepository) Delete(ctx context.Context, id int64) error {
 	return err
 }
 
-func (r *proxyRepository) List(ctx context.Context, params pagination.PaginationParams) ([]service.Proxy, *pagination.PaginationResult, error) {
+func (r *proxyRepository) List(ctx context.Context, params pagination.PaginationParams) ([]domain.Proxy, *pagination.PaginationResult, error) {
 	return r.ListWithFilters(ctx, params, "", "", "")
 }
 
 // ListWithFilters lists proxies with optional filtering by protocol, status, and search query
-func (r *proxyRepository) ListWithFilters(ctx context.Context, params pagination.PaginationParams, protocol, status, search string) ([]service.Proxy, *pagination.PaginationResult, error) {
+func (r *proxyRepository) ListWithFilters(ctx context.Context, params pagination.PaginationParams, protocol, status, search string) ([]domain.Proxy, *pagination.PaginationResult, error) {
 	q := r.client.Proxy.Query()
 	if protocol != "" {
 		q = q.Where(proxy.ProtocolEQ(protocol))
@@ -170,7 +171,7 @@ func (r *proxyRepository) ListWithFilters(ctx context.Context, params pagination
 		return nil, nil, err
 	}
 
-	outProxies := make([]service.Proxy, 0, len(proxies))
+	outProxies := make([]domain.Proxy, 0, len(proxies))
 	for i := range proxies {
 		outProxies = append(outProxies, *proxyEntityToService(proxies[i]))
 	}
@@ -293,14 +294,14 @@ func proxyListOrder(params pagination.PaginationParams) []func(*entsql.Selector)
 	return []func(*entsql.Selector){dbent.Desc(field), dbent.Desc(proxy.FieldID)}
 }
 
-func (r *proxyRepository) ListActive(ctx context.Context) ([]service.Proxy, error) {
+func (r *proxyRepository) ListActive(ctx context.Context) ([]domain.Proxy, error) {
 	proxies, err := r.client.Proxy.Query().
-		Where(proxy.StatusEQ(service.StatusActive)).
+		Where(proxy.StatusEQ(domain.StatusActive)).
 		All(ctx)
 	if err != nil {
 		return nil, err
 	}
-	outProxies := make([]service.Proxy, 0, len(proxies))
+	outProxies := make([]domain.Proxy, 0, len(proxies))
 	for i := range proxies {
 		outProxies = append(outProxies, *proxyEntityToService(proxies[i]))
 	}
@@ -408,7 +409,7 @@ func (r *proxyRepository) GetAccountCountsForProxies(ctx context.Context) (count
 // ListActiveWithAccountCount returns all active proxies with account count, sorted by creation time descending
 func (r *proxyRepository) ListActiveWithAccountCount(ctx context.Context) ([]service.ProxyWithAccountCount, error) {
 	proxies, err := r.client.Proxy.Query().
-		Where(proxy.StatusEQ(service.StatusActive)).
+		Where(proxy.StatusEQ(domain.StatusActive)).
 		Order(dbent.Desc(proxy.FieldCreatedAt)).
 		All(ctx)
 	if err != nil {
@@ -437,11 +438,11 @@ func (r *proxyRepository) ListActiveWithAccountCount(ctx context.Context) ([]ser
 	return result, nil
 }
 
-func proxyEntityToService(m *dbent.Proxy) *service.Proxy {
+func proxyEntityToService(m *dbent.Proxy) *domain.Proxy {
 	if m == nil {
 		return nil
 	}
-	out := &service.Proxy{
+	out := &domain.Proxy{
 		ID:             m.ID,
 		Name:           m.Name,
 		Protocol:       m.Protocol,
@@ -464,7 +465,7 @@ func proxyEntityToService(m *dbent.Proxy) *service.Proxy {
 	return out
 }
 
-func applyProxyEntityToService(dst *service.Proxy, src *dbent.Proxy) {
+func applyProxyEntityToService(dst *domain.Proxy, src *dbent.Proxy) {
 	if dst == nil || src == nil {
 		return
 	}
@@ -474,12 +475,12 @@ func applyProxyEntityToService(dst *service.Proxy, src *dbent.Proxy) {
 }
 
 // ListAllForFallback 返回所有代理（含过期/非活跃），供改投逻辑使用。
-func (r *proxyRepository) ListAllForFallback(ctx context.Context) ([]service.Proxy, error) {
+func (r *proxyRepository) ListAllForFallback(ctx context.Context) ([]domain.Proxy, error) {
 	proxies, err := r.client.Proxy.Query().All(ctx)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]service.Proxy, 0, len(proxies))
+	out := make([]domain.Proxy, 0, len(proxies))
 	for i := range proxies {
 		out = append(out, *proxyEntityToService(proxies[i]))
 	}
@@ -497,7 +498,7 @@ func (r *proxyRepository) SweepExpiredProxies(ctx context.Context, now time.Time
 	if err != nil {
 		return 0, err
 	}
-	byID := make(map[int64]service.Proxy, len(all))
+	byID := make(map[int64]domain.Proxy, len(all))
 	for _, p := range all {
 		byID[p.ID] = p
 	}
@@ -506,7 +507,7 @@ func (r *proxyRepository) SweepExpiredProxies(ctx context.Context, now time.Time
 	accountsTouched := false
 
 	for _, p := range all {
-		if p.Status != service.StatusActive || !p.IsExpired(now) {
+		if p.Status != domain.StatusActive || !p.IsExpired(now) {
 			continue
 		}
 
@@ -527,7 +528,7 @@ func (r *proxyRepository) SweepExpiredProxies(ctx context.Context, now time.Time
 	}
 
 	if accountsTouched {
-		if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventFullRebuild, nil, nil, nil); err != nil {
+		if err := enqueueSchedulerOutbox(ctx, r.sql, domain.SchedulerOutboxEventFullRebuild, nil, nil, nil); err != nil {
 			logger.LegacyPrintf("repository.proxy", "[SchedulerOutbox] enqueue proxy expiry rebuild failed: err=%v", err)
 		}
 	}
@@ -565,7 +566,7 @@ func (r *proxyRepository) sweepOneExpiredProxy(ctx context.Context, proxyID int6
 func (r *proxyRepository) sweepOneExpiredProxyOnExec(ctx context.Context, exec sqlExecutor, proxyID int64, target *int64, change bool) (int64, error) {
 	if _, err := exec.ExecContext(ctx,
 		`UPDATE proxies SET status=$1, updated_at=NOW() WHERE id=$2 AND deleted_at IS NULL`,
-		service.StatusExpired, proxyID); err != nil {
+		domain.StatusExpired, proxyID); err != nil {
 		return 0, err
 	}
 	if !change {
@@ -594,7 +595,7 @@ func (r *proxyRepository) sweepOneExpiredProxyOnExec(ctx context.Context, exec s
 // CountExpired 返回已过期（status=expired）的代理数量。
 func (r *proxyRepository) CountExpired(ctx context.Context) (int64, error) {
 	var c int64
-	err := scanSingleRow(ctx, r.sql, `SELECT COUNT(*) FROM proxies WHERE status=$1 AND deleted_at IS NULL`, []any{service.StatusExpired}, &c)
+	err := scanSingleRow(ctx, r.sql, `SELECT COUNT(*) FROM proxies WHERE status=$1 AND deleted_at IS NULL`, []any{domain.StatusExpired}, &c)
 	return c, err
 }
 
@@ -605,6 +606,6 @@ func (r *proxyRepository) CountExpiringSoon(ctx context.Context, now time.Time) 
 		SELECT COUNT(*) FROM proxies
 		WHERE deleted_at IS NULL AND status=$1 AND expires_at IS NOT NULL
 		  AND expires_at > $2 AND expires_at <= $2 + (expiry_warn_days || ' days')::interval`,
-		[]any{service.StatusActive, now}, &c)
+		[]any{domain.StatusActive, now}, &c)
 	return c, err
 }

--- a/backend/internal/repository/proxy_repo_integration_test.go
+++ b/backend/internal/repository/proxy_repo_integration_test.go
@@ -10,7 +10,6 @@ import (
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
-	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/backend/internal/repository/proxy_repo_integration_test.go
+++ b/backend/internal/repository/proxy_repo_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/suite"
@@ -34,12 +35,12 @@ func TestProxyRepoSuite(t *testing.T) {
 // --- Create / GetByID / Update / Delete ---
 
 func (s *ProxyRepoSuite) TestCreate() {
-	proxy := &service.Proxy{
+	proxy := &domain.Proxy{
 		Name:     "test-create",
 		Protocol: "http",
 		Host:     "127.0.0.1",
 		Port:     8080,
-		Status:   service.StatusActive,
+		Status:   domain.StatusActive,
 	}
 
 	err := s.repo.Create(s.ctx, proxy)
@@ -57,12 +58,12 @@ func (s *ProxyRepoSuite) TestGetByID_NotFound() {
 }
 
 func (s *ProxyRepoSuite) TestUpdate() {
-	proxy := &service.Proxy{
+	proxy := &domain.Proxy{
 		Name:     "original",
 		Protocol: "http",
 		Host:     "127.0.0.1",
 		Port:     8080,
-		Status:   service.StatusActive,
+		Status:   domain.StatusActive,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, proxy))
 
@@ -76,12 +77,12 @@ func (s *ProxyRepoSuite) TestUpdate() {
 }
 
 func (s *ProxyRepoSuite) TestDelete() {
-	proxy := &service.Proxy{
+	proxy := &domain.Proxy{
 		Name:     "to-delete",
 		Protocol: "http",
 		Host:     "127.0.0.1",
 		Port:     8080,
-		Status:   service.StatusActive,
+		Status:   domain.StatusActive,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, proxy))
 
@@ -95,8 +96,8 @@ func (s *ProxyRepoSuite) TestDelete() {
 // --- List / ListWithFilters ---
 
 func (s *ProxyRepoSuite) TestList() {
-	s.mustCreateProxy(&service.Proxy{Name: "p1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: service.StatusActive})
-	s.mustCreateProxy(&service.Proxy{Name: "p2", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: service.StatusActive})
+	s.mustCreateProxy(&domain.Proxy{Name: "p1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: domain.StatusActive})
+	s.mustCreateProxy(&domain.Proxy{Name: "p2", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: domain.StatusActive})
 
 	proxies, page, err := s.repo.List(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10})
 	s.Require().NoError(err, "List")
@@ -105,8 +106,8 @@ func (s *ProxyRepoSuite) TestList() {
 }
 
 func (s *ProxyRepoSuite) TestListWithFilters_Protocol() {
-	s.mustCreateProxy(&service.Proxy{Name: "p1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: service.StatusActive})
-	s.mustCreateProxy(&service.Proxy{Name: "p2", Protocol: "socks5", Host: "127.0.0.1", Port: 8081, Status: service.StatusActive})
+	s.mustCreateProxy(&domain.Proxy{Name: "p1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: domain.StatusActive})
+	s.mustCreateProxy(&domain.Proxy{Name: "p2", Protocol: "socks5", Host: "127.0.0.1", Port: 8081, Status: domain.StatusActive})
 
 	proxies, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "socks5", "", "")
 	s.Require().NoError(err)
@@ -115,18 +116,18 @@ func (s *ProxyRepoSuite) TestListWithFilters_Protocol() {
 }
 
 func (s *ProxyRepoSuite) TestListWithFilters_Status() {
-	s.mustCreateProxy(&service.Proxy{Name: "p1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: service.StatusActive})
-	s.mustCreateProxy(&service.Proxy{Name: "p2", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: service.StatusDisabled})
+	s.mustCreateProxy(&domain.Proxy{Name: "p1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: domain.StatusActive})
+	s.mustCreateProxy(&domain.Proxy{Name: "p2", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: domain.StatusDisabled})
 
-	proxies, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", service.StatusDisabled, "")
+	proxies, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", domain.StatusDisabled, "")
 	s.Require().NoError(err)
 	s.Require().Len(proxies, 1)
-	s.Require().Equal(service.StatusDisabled, proxies[0].Status)
+	s.Require().Equal(domain.StatusDisabled, proxies[0].Status)
 }
 
 func (s *ProxyRepoSuite) TestListWithFilters_Search() {
-	s.mustCreateProxy(&service.Proxy{Name: "production-proxy", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: service.StatusActive})
-	s.mustCreateProxy(&service.Proxy{Name: "dev-proxy", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: service.StatusActive})
+	s.mustCreateProxy(&domain.Proxy{Name: "production-proxy", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: domain.StatusActive})
+	s.mustCreateProxy(&domain.Proxy{Name: "dev-proxy", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: domain.StatusActive})
 
 	proxies, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", "", "prod")
 	s.Require().NoError(err)
@@ -137,8 +138,8 @@ func (s *ProxyRepoSuite) TestListWithFilters_Search() {
 // --- ListActive ---
 
 func (s *ProxyRepoSuite) TestListActive() {
-	s.mustCreateProxy(&service.Proxy{Name: "active1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: service.StatusActive})
-	s.mustCreateProxy(&service.Proxy{Name: "inactive1", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: service.StatusDisabled})
+	s.mustCreateProxy(&domain.Proxy{Name: "active1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: domain.StatusActive})
+	s.mustCreateProxy(&domain.Proxy{Name: "inactive1", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: domain.StatusDisabled})
 
 	proxies, err := s.repo.ListActive(s.ctx)
 	s.Require().NoError(err, "ListActive")
@@ -149,14 +150,14 @@ func (s *ProxyRepoSuite) TestListActive() {
 // --- ExistsByHostPortAuth ---
 
 func (s *ProxyRepoSuite) TestExistsByHostPortAuth() {
-	s.mustCreateProxy(&service.Proxy{
+	s.mustCreateProxy(&domain.Proxy{
 		Name:     "p1",
 		Protocol: "http",
 		Host:     "1.2.3.4",
 		Port:     8080,
 		Username: "user",
 		Password: "pass",
-		Status:   service.StatusActive,
+		Status:   domain.StatusActive,
 	})
 
 	exists, err := s.repo.ExistsByHostPortAuth(s.ctx, "1.2.3.4", 8080, "user", "pass")
@@ -169,14 +170,14 @@ func (s *ProxyRepoSuite) TestExistsByHostPortAuth() {
 }
 
 func (s *ProxyRepoSuite) TestExistsByHostPortAuth_NoAuth() {
-	s.mustCreateProxy(&service.Proxy{
+	s.mustCreateProxy(&domain.Proxy{
 		Name:     "p-noauth",
 		Protocol: "http",
 		Host:     "5.6.7.8",
 		Port:     8081,
 		Username: "",
 		Password: "",
-		Status:   service.StatusActive,
+		Status:   domain.StatusActive,
 	})
 
 	exists, err := s.repo.ExistsByHostPortAuth(s.ctx, "5.6.7.8", 8081, "", "")
@@ -187,7 +188,7 @@ func (s *ProxyRepoSuite) TestExistsByHostPortAuth_NoAuth() {
 // --- CountAccountsByProxyID ---
 
 func (s *ProxyRepoSuite) TestCountAccountsByProxyID() {
-	proxy := s.mustCreateProxy(&service.Proxy{Name: "p-count", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: service.StatusActive})
+	proxy := s.mustCreateProxy(&domain.Proxy{Name: "p-count", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: domain.StatusActive})
 	s.mustInsertAccount("a1", &proxy.ID)
 	s.mustInsertAccount("a2", &proxy.ID)
 	s.mustInsertAccount("a3", nil) // no proxy
@@ -198,7 +199,7 @@ func (s *ProxyRepoSuite) TestCountAccountsByProxyID() {
 }
 
 func (s *ProxyRepoSuite) TestCountAccountsByProxyID_Zero() {
-	proxy := s.mustCreateProxy(&service.Proxy{Name: "p-zero", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: service.StatusActive})
+	proxy := s.mustCreateProxy(&domain.Proxy{Name: "p-zero", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: domain.StatusActive})
 
 	count, err := s.repo.CountAccountsByProxyID(s.ctx, proxy.ID)
 	s.Require().NoError(err)
@@ -208,8 +209,8 @@ func (s *ProxyRepoSuite) TestCountAccountsByProxyID_Zero() {
 // --- GetAccountCountsForProxies ---
 
 func (s *ProxyRepoSuite) TestGetAccountCountsForProxies() {
-	p1 := s.mustCreateProxy(&service.Proxy{Name: "p1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: service.StatusActive})
-	p2 := s.mustCreateProxy(&service.Proxy{Name: "p2", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: service.StatusActive})
+	p1 := s.mustCreateProxy(&domain.Proxy{Name: "p1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: domain.StatusActive})
+	p2 := s.mustCreateProxy(&domain.Proxy{Name: "p2", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: domain.StatusActive})
 
 	s.mustInsertAccount("a1", &p1.ID)
 	s.mustInsertAccount("a2", &p1.ID)
@@ -232,9 +233,9 @@ func (s *ProxyRepoSuite) TestGetAccountCountsForProxies_Empty() {
 func (s *ProxyRepoSuite) TestListActiveWithAccountCount() {
 	base := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
 
-	p1 := s.mustCreateProxyWithTimes("p1", service.StatusActive, base.Add(-1*time.Hour))
-	p2 := s.mustCreateProxyWithTimes("p2", service.StatusActive, base)
-	s.mustCreateProxyWithTimes("p3-inactive", service.StatusDisabled, base.Add(1*time.Hour))
+	p1 := s.mustCreateProxyWithTimes("p1", domain.StatusActive, base.Add(-1*time.Hour))
+	p2 := s.mustCreateProxyWithTimes("p2", domain.StatusActive, base)
+	s.mustCreateProxyWithTimes("p3-inactive", domain.StatusDisabled, base.Add(1*time.Hour))
 
 	s.mustInsertAccount("a1", &p1.ID)
 	s.mustInsertAccount("a2", &p1.ID)
@@ -254,8 +255,8 @@ func (s *ProxyRepoSuite) TestListActiveWithAccountCount() {
 // --- Combined original test ---
 
 func (s *ProxyRepoSuite) TestExistsByHostPortAuth_And_AccountCountAggregates() {
-	p1 := s.mustCreateProxy(&service.Proxy{Name: "p1", Protocol: "http", Host: "1.2.3.4", Port: 8080, Username: "u", Password: "p", Status: service.StatusActive})
-	p2 := s.mustCreateProxy(&service.Proxy{Name: "p2", Protocol: "http", Host: "5.6.7.8", Port: 8081, Username: "", Password: "", Status: service.StatusActive})
+	p1 := s.mustCreateProxy(&domain.Proxy{Name: "p1", Protocol: "http", Host: "1.2.3.4", Port: 8080, Username: "u", Password: "p", Status: domain.StatusActive})
+	p2 := s.mustCreateProxy(&domain.Proxy{Name: "p2", Protocol: "http", Host: "5.6.7.8", Port: 8081, Username: "", Password: "", Status: domain.StatusActive})
 
 	exists, err := s.repo.ExistsByHostPortAuth(s.ctx, "1.2.3.4", 8080, "u", "p")
 	s.Require().NoError(err, "ExistsByHostPortAuth")
@@ -289,17 +290,17 @@ func (s *ProxyRepoSuite) TestExistsByHostPortAuth_And_AccountCountAggregates() {
 	}
 }
 
-func (s *ProxyRepoSuite) mustCreateProxy(p *service.Proxy) *service.Proxy {
+func (s *ProxyRepoSuite) mustCreateProxy(p *domain.Proxy) *domain.Proxy {
 	s.T().Helper()
 	s.Require().NoError(s.repo.Create(s.ctx, p), "create proxy")
 	return p
 }
 
-func (s *ProxyRepoSuite) mustCreateProxyWithTimes(name, status string, createdAt time.Time) *service.Proxy {
+func (s *ProxyRepoSuite) mustCreateProxyWithTimes(name, status string, createdAt time.Time) *domain.Proxy {
 	s.T().Helper()
 
 	// Use the repository create for standard fields, then update timestamps via raw SQL to keep deterministic ordering.
-	p := s.mustCreateProxy(&service.Proxy{
+	p := s.mustCreateProxy(&domain.Proxy{
 		Name:     name,
 		Protocol: "http",
 		Host:     "127.0.0.1",
@@ -321,8 +322,8 @@ func (s *ProxyRepoSuite) mustInsertAccount(name string, proxyID *int64) {
 		s.ctx,
 		"INSERT INTO accounts (name, platform, type, proxy_id) VALUES ($1, $2, $3, $4)",
 		name,
-		service.PlatformAnthropic,
-		service.AccountTypeOAuth,
+		domain.PlatformAnthropic,
+		domain.AccountTypeOAuth,
 		pid,
 	)
 	s.Require().NoError(err, "insert account")

--- a/backend/internal/repository/proxy_repo_sort_integration_test.go
+++ b/backend/internal/repository/proxy_repo_sort_integration_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
-	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
 func (s *ProxyRepoSuite) TestListWithFiltersAndAccountCount_SortByAccountCountDesc() {

--- a/backend/internal/repository/proxy_repo_sort_integration_test.go
+++ b/backend/internal/repository/proxy_repo_sort_integration_test.go
@@ -5,13 +5,14 @@ package repository
 import (
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
 func (s *ProxyRepoSuite) TestListWithFiltersAndAccountCount_SortByAccountCountDesc() {
-	p1 := s.mustCreateProxy(&service.Proxy{Name: "p1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: service.StatusActive})
-	p2 := s.mustCreateProxy(&service.Proxy{Name: "p2", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: service.StatusActive})
+	p1 := s.mustCreateProxy(&domain.Proxy{Name: "p1", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: domain.StatusActive})
+	p2 := s.mustCreateProxy(&domain.Proxy{Name: "p2", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: domain.StatusActive})
 	s.mustInsertAccount("a1", &p1.ID)
 	s.mustInsertAccount("a2", &p1.ID)
 	s.mustInsertAccount("a3", &p2.ID)
@@ -37,10 +38,10 @@ func (s *ProxyRepoSuite) TestListWithFiltersAndAccountCount_SortByExpiry() {
 
 	// 创建顺序(=ID 升序)刻意打乱,使其不同于任何有效期顺序:
 	// 一旦排序退回按 id(没加 case "expiry"),此测试必然失败。
-	pLater := s.mustCreateProxy(&service.Proxy{Name: "p-later", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: service.StatusActive, ExpiresAt: &later})
-	pNever := s.mustCreateProxy(&service.Proxy{Name: "p-never", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: service.StatusActive, ExpiresAt: nil})
-	pExpired := s.mustCreateProxy(&service.Proxy{Name: "p-expired", Protocol: "http", Host: "127.0.0.1", Port: 8082, Status: service.StatusActive, ExpiresAt: &past})
-	pSoon := s.mustCreateProxy(&service.Proxy{Name: "p-soon", Protocol: "http", Host: "127.0.0.1", Port: 8083, Status: service.StatusActive, ExpiresAt: &soon})
+	pLater := s.mustCreateProxy(&domain.Proxy{Name: "p-later", Protocol: "http", Host: "127.0.0.1", Port: 8080, Status: domain.StatusActive, ExpiresAt: &later})
+	pNever := s.mustCreateProxy(&domain.Proxy{Name: "p-never", Protocol: "http", Host: "127.0.0.1", Port: 8081, Status: domain.StatusActive, ExpiresAt: nil})
+	pExpired := s.mustCreateProxy(&domain.Proxy{Name: "p-expired", Protocol: "http", Host: "127.0.0.1", Port: 8082, Status: domain.StatusActive, ExpiresAt: &past})
+	pSoon := s.mustCreateProxy(&domain.Proxy{Name: "p-soon", Protocol: "http", Host: "127.0.0.1", Port: 8083, Status: domain.StatusActive, ExpiresAt: &soon})
 
 	// 升序:最快到期在前,NULL(永不过期)垫底
 	asc, _, err := s.repo.ListWithFiltersAndAccountCount(s.ctx, pagination.PaginationParams{

--- a/backend/internal/repository/redeem_code_repo.go
+++ b/backend/internal/repository/redeem_code_repo.go
@@ -8,6 +8,7 @@ import (
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/redeemcode"
 	"github.com/Wei-Shaw/sub2api/ent/user"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
@@ -73,7 +74,7 @@ func (r *redeemCodeRepository) GetByID(ctx context.Context, id int64) (*service.
 		Only(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return nil, service.ErrRedeemCodeNotFound
+			return nil, domain.ErrRedeemCodeNotFound
 		}
 		return nil, err
 	}
@@ -86,7 +87,7 @@ func (r *redeemCodeRepository) GetByCode(ctx context.Context, code string) (*ser
 		Only(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return nil, service.ErrRedeemCodeNotFound
+			return nil, domain.ErrRedeemCodeNotFound
 		}
 		return nil, err
 	}
@@ -111,18 +112,18 @@ func (r *redeemCodeRepository) ListWithFilters(ctx context.Context, params pagin
 	if status != "" {
 		now := time.Now()
 		switch status {
-		case service.StatusExpired:
+		case domain.StatusExpired:
 			q = q.Where(redeemcode.Or(
-				redeemcode.StatusEQ(service.StatusExpired),
+				redeemcode.StatusEQ(domain.StatusExpired),
 				redeemcode.And(
-					redeemcode.StatusEQ(service.StatusUnused),
+					redeemcode.StatusEQ(domain.StatusUnused),
 					redeemcode.ExpiresAtNotNil(),
 					redeemcode.ExpiresAtLTE(now),
 				),
 			))
-		case service.StatusUnused:
+		case domain.StatusUnused:
 			q = q.Where(
-				redeemcode.StatusEQ(service.StatusUnused),
+				redeemcode.StatusEQ(domain.StatusUnused),
 				redeemcode.Or(
 					redeemcode.ExpiresAtIsNil(),
 					redeemcode.ExpiresAtGT(now),
@@ -228,7 +229,7 @@ func (r *redeemCodeRepository) Update(ctx context.Context, code *service.RedeemC
 	updated, err := up.Save(ctx)
 	if err != nil {
 		if dbent.IsNotFound(err) {
-			return service.ErrRedeemCodeNotFound
+			return domain.ErrRedeemCodeNotFound
 		}
 		return err
 	}
@@ -279,12 +280,12 @@ func (r *redeemCodeRepository) batchUpdate(ctx context.Context, client *dbent.Cl
 		return 0, err
 	}
 	if len(existing) != len(ids) {
-		return 0, service.ErrRedeemCodeNotFound
+		return 0, domain.ErrRedeemCodeNotFound
 	}
 	if fields.TouchesUsedSensitiveFields() {
 		for _, code := range existing {
-			if code.Status == service.StatusUsed {
-				return 0, service.ErrRedeemCodeUsed
+			if code.Status == domain.StatusUsed {
+				return 0, domain.ErrRedeemCodeUsed
 			}
 		}
 	}
@@ -316,7 +317,7 @@ func (r *redeemCodeRepository) batchUpdate(ctx context.Context, client *dbent.Cl
 		return 0, err
 	}
 	if affected != len(ids) {
-		return 0, service.ErrRedeemCodeNotFound
+		return 0, domain.ErrRedeemCodeNotFound
 	}
 	return int64(affected), nil
 }
@@ -325,8 +326,8 @@ func (r *redeemCodeRepository) Use(ctx context.Context, id, userID int64) error 
 	now := time.Now()
 	client := clientFromContext(ctx, r.client)
 	affected, err := client.RedeemCode.Update().
-		Where(redeemcode.IDEQ(id), redeemcode.StatusEQ(service.StatusUnused)).
-		SetStatus(service.StatusUsed).
+		Where(redeemcode.IDEQ(id), redeemcode.StatusEQ(domain.StatusUnused)).
+		SetStatus(domain.StatusUsed).
 		SetUsedBy(userID).
 		SetUsedAt(now).
 		Save(ctx)
@@ -334,7 +335,7 @@ func (r *redeemCodeRepository) Use(ctx context.Context, id, userID int64) error 
 		return err
 	}
 	if affected == 0 {
-		return service.ErrRedeemCodeUsed
+		return domain.ErrRedeemCodeUsed
 	}
 	return nil
 }

--- a/backend/internal/repository/redeem_code_repo_integration_test.go
+++ b/backend/internal/repository/redeem_code_repo_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/suite"
@@ -55,9 +56,9 @@ func (s *RedeemCodeRepoSuite) TestCreate() {
 	expiresAt := time.Now().UTC().Add(2 * time.Hour)
 	code := &service.RedeemCode{
 		Code:      "TEST-CREATE",
-		Type:      service.RedeemTypeBalance,
+		Type:      domain.RedeemTypeBalance,
 		Value:     100,
-		Status:    service.StatusUnused,
+		Status:    domain.StatusUnused,
 		ExpiresAt: &expiresAt,
 	}
 
@@ -74,8 +75,8 @@ func (s *RedeemCodeRepoSuite) TestCreate() {
 
 func (s *RedeemCodeRepoSuite) TestCreateBatch() {
 	codes := []service.RedeemCode{
-		{Code: "BATCH-1", Type: service.RedeemTypeBalance, Value: 10, Status: service.StatusUnused},
-		{Code: "BATCH-2", Type: service.RedeemTypeBalance, Value: 20, Status: service.StatusUnused},
+		{Code: "BATCH-1", Type: domain.RedeemTypeBalance, Value: 10, Status: domain.StatusUnused},
+		{Code: "BATCH-2", Type: domain.RedeemTypeBalance, Value: 20, Status: domain.StatusUnused},
 	}
 
 	err := s.repo.CreateBatch(s.ctx, codes)
@@ -93,14 +94,14 @@ func (s *RedeemCodeRepoSuite) TestCreateBatch() {
 func (s *RedeemCodeRepoSuite) TestGetByID_NotFound() {
 	_, err := s.repo.GetByID(s.ctx, 999999)
 	s.Require().Error(err, "expected error for non-existent ID")
-	s.Require().ErrorIs(err, service.ErrRedeemCodeNotFound)
+	s.Require().ErrorIs(err, domain.ErrRedeemCodeNotFound)
 }
 
 func (s *RedeemCodeRepoSuite) TestGetByCode() {
 	_, err := s.client.RedeemCode.Create().
 		SetCode("GET-BY-CODE").
-		SetType(service.RedeemTypeBalance).
-		SetStatus(service.StatusUnused).
+		SetType(domain.RedeemTypeBalance).
+		SetStatus(domain.StatusUnused).
 		SetValue(0).
 		SetNotes("").
 		SetValidityDays(30).
@@ -115,7 +116,7 @@ func (s *RedeemCodeRepoSuite) TestGetByCode() {
 func (s *RedeemCodeRepoSuite) TestGetByCode_NotFound() {
 	_, err := s.repo.GetByCode(s.ctx, "NON-EXISTENT")
 	s.Require().Error(err, "expected error for non-existent code")
-	s.Require().ErrorIs(err, service.ErrRedeemCodeNotFound)
+	s.Require().ErrorIs(err, domain.ErrRedeemCodeNotFound)
 }
 
 // --- Delete ---
@@ -123,8 +124,8 @@ func (s *RedeemCodeRepoSuite) TestGetByCode_NotFound() {
 func (s *RedeemCodeRepoSuite) TestDelete() {
 	created, err := s.client.RedeemCode.Create().
 		SetCode("TO-DELETE").
-		SetType(service.RedeemTypeBalance).
-		SetStatus(service.StatusUnused).
+		SetType(domain.RedeemTypeBalance).
+		SetStatus(domain.StatusUnused).
 		SetValue(0).
 		SetNotes("").
 		SetValidityDays(30).
@@ -136,14 +137,14 @@ func (s *RedeemCodeRepoSuite) TestDelete() {
 
 	_, err = s.repo.GetByID(s.ctx, created.ID)
 	s.Require().Error(err, "expected error after delete")
-	s.Require().ErrorIs(err, service.ErrRedeemCodeNotFound)
+	s.Require().ErrorIs(err, domain.ErrRedeemCodeNotFound)
 }
 
 // --- List / ListWithFilters ---
 
 func (s *RedeemCodeRepoSuite) TestList() {
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "LIST-1", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUnused}))
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "LIST-2", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUnused}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "LIST-1", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUnused}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "LIST-2", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUnused}))
 
 	codes, page, err := s.repo.List(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10})
 	s.Require().NoError(err, "List")
@@ -152,45 +153,45 @@ func (s *RedeemCodeRepoSuite) TestList() {
 }
 
 func (s *RedeemCodeRepoSuite) TestListWithFilters_Type() {
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "TYPE-BAL", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUnused}))
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "TYPE-SUB", Type: service.RedeemTypeSubscription, Value: 0, Status: service.StatusUnused}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "TYPE-BAL", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUnused}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "TYPE-SUB", Type: domain.RedeemTypeSubscription, Value: 0, Status: domain.StatusUnused}))
 
-	codes, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, service.RedeemTypeSubscription, "", "")
+	codes, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, domain.RedeemTypeSubscription, "", "")
 	s.Require().NoError(err)
 	s.Require().Len(codes, 1)
-	s.Require().Equal(service.RedeemTypeSubscription, codes[0].Type)
+	s.Require().Equal(domain.RedeemTypeSubscription, codes[0].Type)
 }
 
 func (s *RedeemCodeRepoSuite) TestListWithFilters_Status() {
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "STAT-UNUSED", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUnused}))
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "STAT-USED", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUsed}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "STAT-UNUSED", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUnused}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "STAT-USED", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUsed}))
 
-	codes, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", service.StatusUsed, "")
+	codes, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", domain.StatusUsed, "")
 	s.Require().NoError(err)
 	s.Require().Len(codes, 1)
-	s.Require().Equal(service.StatusUsed, codes[0].Status)
+	s.Require().Equal(domain.StatusUsed, codes[0].Status)
 }
 
 func (s *RedeemCodeRepoSuite) TestListWithFilters_StatusExpiredByExpiresAt() {
 	past := time.Now().UTC().Add(-time.Hour)
 	future := time.Now().UTC().Add(time.Hour)
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "STAT-EXPIRED-BY-TIME", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUnused, ExpiresAt: &past}))
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "STAT-UNUSED-FUTURE", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUnused, ExpiresAt: &future}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "STAT-EXPIRED-BY-TIME", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUnused, ExpiresAt: &past}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "STAT-UNUSED-FUTURE", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUnused, ExpiresAt: &future}))
 
-	expired, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", service.StatusExpired, "")
+	expired, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", domain.StatusExpired, "")
 	s.Require().NoError(err)
 	s.Require().Len(expired, 1)
 	s.Require().Equal("STAT-EXPIRED-BY-TIME", expired[0].Code)
 
-	unused, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", service.StatusUnused, "")
+	unused, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", domain.StatusUnused, "")
 	s.Require().NoError(err)
 	s.Require().Len(unused, 1)
 	s.Require().Equal("STAT-UNUSED-FUTURE", unused[0].Code)
 }
 
 func (s *RedeemCodeRepoSuite) TestListWithFilters_Search() {
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "ALPHA-CODE", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUnused}))
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "BETA-CODE", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUnused}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "ALPHA-CODE", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUnused}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "BETA-CODE", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUnused}))
 
 	codes, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", "", "alpha")
 	s.Require().NoError(err)
@@ -202,8 +203,8 @@ func (s *RedeemCodeRepoSuite) TestListWithFilters_GroupPreload() {
 	group := s.createGroup(uniqueTestValue(s.T(), "g-preload"))
 	_, err := s.client.RedeemCode.Create().
 		SetCode("WITH-GROUP").
-		SetType(service.RedeemTypeSubscription).
-		SetStatus(service.StatusUnused).
+		SetType(domain.RedeemTypeSubscription).
+		SetStatus(domain.StatusUnused).
 		SetValue(0).
 		SetNotes("").
 		SetValidityDays(30).
@@ -223,9 +224,9 @@ func (s *RedeemCodeRepoSuite) TestListWithFilters_GroupPreload() {
 func (s *RedeemCodeRepoSuite) TestUpdate() {
 	code := &service.RedeemCode{
 		Code:   "UPDATE-ME",
-		Type:   service.RedeemTypeBalance,
+		Type:   domain.RedeemTypeBalance,
 		Value:  10,
-		Status: service.StatusUnused,
+		Status: domain.StatusUnused,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, code))
 
@@ -242,28 +243,28 @@ func (s *RedeemCodeRepoSuite) TestBatchUpdate_PartialFieldsAndClear() {
 	group := s.createGroup(uniqueTestValue(s.T(), "batch-update-group"))
 	groupID := group.ID
 	expiresAt := time.Now().UTC().Add(2 * time.Hour)
-	status := service.StatusDisabled
+	status := domain.StatusDisabled
 	notes := "batch note"
 
 	codeA := &service.RedeemCode{
 		Code:   "BATCH-UP-A",
-		Type:   service.RedeemTypeBalance,
+		Type:   domain.RedeemTypeBalance,
 		Value:  10,
-		Status: service.StatusUnused,
+		Status: domain.StatusUnused,
 		Notes:  "old",
 	}
 	codeB := &service.RedeemCode{
 		Code:   "BATCH-UP-B",
-		Type:   service.RedeemTypeBalance,
+		Type:   domain.RedeemTypeBalance,
 		Value:  20,
-		Status: service.StatusUnused,
+		Status: domain.StatusUnused,
 		Notes:  "old",
 	}
 	untouched := &service.RedeemCode{
 		Code:   "BATCH-UP-C",
-		Type:   service.RedeemTypeBalance,
+		Type:   domain.RedeemTypeBalance,
 		Value:  30,
-		Status: service.StatusUnused,
+		Status: domain.StatusUnused,
 		Notes:  "keep",
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, codeA))
@@ -282,9 +283,9 @@ func (s *RedeemCodeRepoSuite) TestBatchUpdate_PartialFieldsAndClear() {
 	gotA, err := s.repo.GetByID(s.ctx, codeA.ID)
 	s.Require().NoError(err)
 	s.Require().Equal("BATCH-UP-A", gotA.Code)
-	s.Require().Equal(service.RedeemTypeBalance, gotA.Type)
+	s.Require().Equal(domain.RedeemTypeBalance, gotA.Type)
 	s.Require().Equal(float64(10), gotA.Value)
-	s.Require().Equal(service.StatusDisabled, gotA.Status)
+	s.Require().Equal(domain.StatusDisabled, gotA.Status)
 	s.Require().Equal(notes, gotA.Notes)
 	s.Require().NotNil(gotA.ExpiresAt)
 	s.Require().WithinDuration(expiresAt, *gotA.ExpiresAt, time.Second)
@@ -293,12 +294,12 @@ func (s *RedeemCodeRepoSuite) TestBatchUpdate_PartialFieldsAndClear() {
 
 	gotB, err := s.repo.GetByID(s.ctx, codeB.ID)
 	s.Require().NoError(err)
-	s.Require().Equal(service.StatusDisabled, gotB.Status)
+	s.Require().Equal(domain.StatusDisabled, gotB.Status)
 	s.Require().Equal(notes, gotB.Notes)
 
 	gotUntouched, err := s.repo.GetByID(s.ctx, untouched.ID)
 	s.Require().NoError(err)
-	s.Require().Equal(service.StatusUnused, gotUntouched.Status)
+	s.Require().Equal(domain.StatusUnused, gotUntouched.Status)
 	s.Require().Equal("keep", gotUntouched.Notes)
 	s.Require().Nil(gotUntouched.ExpiresAt)
 	s.Require().Nil(gotUntouched.GroupID)
@@ -319,9 +320,9 @@ func (s *RedeemCodeRepoSuite) TestBatchUpdate_PartialFieldsAndClear() {
 func (s *RedeemCodeRepoSuite) TestBatchUpdate_InvalidIDRollsBack() {
 	code := &service.RedeemCode{
 		Code:   "BATCH-UP-ROLLBACK",
-		Type:   service.RedeemTypeBalance,
+		Type:   domain.RedeemTypeBalance,
 		Value:  10,
-		Status: service.StatusUnused,
+		Status: domain.StatusUnused,
 		Notes:  "keep",
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, code))
@@ -329,7 +330,7 @@ func (s *RedeemCodeRepoSuite) TestBatchUpdate_InvalidIDRollsBack() {
 
 	_, err := s.repo.BatchUpdate(s.ctx, []int64{code.ID, 999999}, service.RedeemCodeBatchUpdateFields{Notes: &notes})
 	s.Require().Error(err)
-	s.Require().True(errors.Is(err, service.ErrRedeemCodeNotFound))
+	s.Require().True(errors.Is(err, domain.ErrRedeemCodeNotFound))
 
 	got, getErr := s.repo.GetByID(s.ctx, code.ID)
 	s.Require().NoError(getErr)
@@ -339,27 +340,27 @@ func (s *RedeemCodeRepoSuite) TestBatchUpdate_InvalidIDRollsBack() {
 func (s *RedeemCodeRepoSuite) TestBatchUpdate_UsedCodeRejectsSensitiveFields() {
 	code := &service.RedeemCode{
 		Code:   "BATCH-UP-USED",
-		Type:   service.RedeemTypeBalance,
+		Type:   domain.RedeemTypeBalance,
 		Value:  10,
-		Status: service.StatusUsed,
+		Status: domain.StatusUsed,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, code))
-	status := service.StatusDisabled
+	status := domain.StatusDisabled
 
 	_, err := s.repo.BatchUpdate(s.ctx, []int64{code.ID}, service.RedeemCodeBatchUpdateFields{Status: &status})
 	s.Require().Error(err)
-	s.Require().True(errors.Is(err, service.ErrRedeemCodeUsed))
+	s.Require().True(errors.Is(err, domain.ErrRedeemCodeUsed))
 
 	got, getErr := s.repo.GetByID(s.ctx, code.ID)
 	s.Require().NoError(getErr)
-	s.Require().Equal(service.StatusUsed, got.Status)
+	s.Require().Equal(domain.StatusUsed, got.Status)
 }
 
 // --- Use ---
 
 func (s *RedeemCodeRepoSuite) TestUse() {
 	user := s.createUser(uniqueTestValue(s.T(), "use") + "@example.com")
-	code := &service.RedeemCode{Code: "USE-ME", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUnused}
+	code := &service.RedeemCode{Code: "USE-ME", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUnused}
 	s.Require().NoError(s.repo.Create(s.ctx, code))
 
 	err := s.repo.Use(s.ctx, code.ID, user.ID)
@@ -367,7 +368,7 @@ func (s *RedeemCodeRepoSuite) TestUse() {
 
 	got, err := s.repo.GetByID(s.ctx, code.ID)
 	s.Require().NoError(err)
-	s.Require().Equal(service.StatusUsed, got.Status)
+	s.Require().Equal(domain.StatusUsed, got.Status)
 	s.Require().NotNil(got.UsedBy)
 	s.Require().Equal(user.ID, *got.UsedBy)
 	s.Require().NotNil(got.UsedAt)
@@ -375,7 +376,7 @@ func (s *RedeemCodeRepoSuite) TestUse() {
 
 func (s *RedeemCodeRepoSuite) TestUse_Idempotency() {
 	user := s.createUser(uniqueTestValue(s.T(), "idem") + "@example.com")
-	code := &service.RedeemCode{Code: "IDEM-CODE", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUnused}
+	code := &service.RedeemCode{Code: "IDEM-CODE", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUnused}
 	s.Require().NoError(s.repo.Create(s.ctx, code))
 
 	err := s.repo.Use(s.ctx, code.ID, user.ID)
@@ -384,17 +385,17 @@ func (s *RedeemCodeRepoSuite) TestUse_Idempotency() {
 	// Second use should fail
 	err = s.repo.Use(s.ctx, code.ID, user.ID)
 	s.Require().Error(err, "Use expected error on second call")
-	s.Require().ErrorIs(err, service.ErrRedeemCodeUsed)
+	s.Require().ErrorIs(err, domain.ErrRedeemCodeUsed)
 }
 
 func (s *RedeemCodeRepoSuite) TestUse_AlreadyUsed() {
 	user := s.createUser(uniqueTestValue(s.T(), "already") + "@example.com")
-	code := &service.RedeemCode{Code: "ALREADY-USED", Type: service.RedeemTypeBalance, Value: 0, Status: service.StatusUsed}
+	code := &service.RedeemCode{Code: "ALREADY-USED", Type: domain.RedeemTypeBalance, Value: 0, Status: domain.StatusUsed}
 	s.Require().NoError(s.repo.Create(s.ctx, code))
 
 	err := s.repo.Use(s.ctx, code.ID, user.ID)
 	s.Require().Error(err, "expected error for already used code")
-	s.Require().ErrorIs(err, service.ErrRedeemCodeUsed)
+	s.Require().ErrorIs(err, domain.ErrRedeemCodeUsed)
 }
 
 // --- ListByUser ---
@@ -406,8 +407,8 @@ func (s *RedeemCodeRepoSuite) TestListByUser() {
 	usedAt1 := base
 	_, err := s.client.RedeemCode.Create().
 		SetCode("USER-1").
-		SetType(service.RedeemTypeBalance).
-		SetStatus(service.StatusUsed).
+		SetType(domain.RedeemTypeBalance).
+		SetStatus(domain.StatusUsed).
 		SetValue(0).
 		SetNotes("").
 		SetValidityDays(30).
@@ -419,8 +420,8 @@ func (s *RedeemCodeRepoSuite) TestListByUser() {
 	usedAt2 := base.Add(1 * time.Hour)
 	_, err = s.client.RedeemCode.Create().
 		SetCode("USER-2").
-		SetType(service.RedeemTypeBalance).
-		SetStatus(service.StatusUsed).
+		SetType(domain.RedeemTypeBalance).
+		SetStatus(domain.StatusUsed).
 		SetValue(0).
 		SetNotes("").
 		SetValidityDays(30).
@@ -443,8 +444,8 @@ func (s *RedeemCodeRepoSuite) TestListByUser_WithGroupPreload() {
 
 	_, err := s.client.RedeemCode.Create().
 		SetCode("WITH-GRP").
-		SetType(service.RedeemTypeSubscription).
-		SetStatus(service.StatusUsed).
+		SetType(domain.RedeemTypeSubscription).
+		SetStatus(domain.StatusUsed).
 		SetValue(0).
 		SetNotes("").
 		SetValidityDays(30).
@@ -465,8 +466,8 @@ func (s *RedeemCodeRepoSuite) TestListByUser_DefaultLimit() {
 	user := s.createUser(uniqueTestValue(s.T(), "deflimit") + "@example.com")
 	_, err := s.client.RedeemCode.Create().
 		SetCode("DEF-LIM").
-		SetType(service.RedeemTypeBalance).
-		SetStatus(service.StatusUsed).
+		SetType(domain.RedeemTypeBalance).
+		SetStatus(domain.StatusUsed).
 		SetValue(0).
 		SetNotes("").
 		SetValidityDays(30).
@@ -489,12 +490,12 @@ func (s *RedeemCodeRepoSuite) TestCreateBatch_Filters_Use_Idempotency_ListByUser
 	groupID := group.ID
 
 	codes := []service.RedeemCode{
-		{Code: "CODEA", Type: service.RedeemTypeBalance, Value: 1, Status: service.StatusUnused, Notes: ""},
-		{Code: "CODEB", Type: service.RedeemTypeSubscription, Value: 0, Status: service.StatusUnused, Notes: "", GroupID: &groupID, ValidityDays: 7},
+		{Code: "CODEA", Type: domain.RedeemTypeBalance, Value: 1, Status: domain.StatusUnused, Notes: ""},
+		{Code: "CODEB", Type: domain.RedeemTypeSubscription, Value: 0, Status: domain.StatusUnused, Notes: "", GroupID: &groupID, ValidityDays: 7},
 	}
 	s.Require().NoError(s.repo.CreateBatch(s.ctx, codes), "CreateBatch")
 
-	list, page, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, service.RedeemTypeSubscription, service.StatusUnused, "code")
+	list, page, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, domain.RedeemTypeSubscription, domain.StatusUnused, "code")
 	s.Require().NoError(err, "ListWithFilters")
 	s.Require().Equal(int64(1), page.Total)
 	s.Require().Len(list, 1)
@@ -506,7 +507,7 @@ func (s *RedeemCodeRepoSuite) TestCreateBatch_Filters_Use_Idempotency_ListByUser
 	s.Require().NoError(s.repo.Use(s.ctx, codeB.ID, user.ID), "Use")
 	err = s.repo.Use(s.ctx, codeB.ID, user.ID)
 	s.Require().Error(err, "Use expected error on second call")
-	s.Require().ErrorIs(err, service.ErrRedeemCodeUsed)
+	s.Require().ErrorIs(err, domain.ErrRedeemCodeUsed)
 
 	codeA, err := s.repo.GetByCode(s.ctx, "CODEA")
 	s.Require().NoError(err, "GetByCode")

--- a/backend/internal/repository/redeem_code_repo_sort_integration_test.go
+++ b/backend/internal/repository/redeem_code_repo_sort_integration_test.go
@@ -3,13 +3,14 @@
 package repository
 
 import (
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
 func (s *RedeemCodeRepoSuite) TestListWithFilters_SortByValueAsc() {
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "VALUE-20", Type: service.RedeemTypeBalance, Value: 20, Status: service.StatusUnused}))
-	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "VALUE-10", Type: service.RedeemTypeBalance, Value: 10, Status: service.StatusUnused}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "VALUE-20", Type: domain.RedeemTypeBalance, Value: 20, Status: domain.StatusUnused}))
+	s.Require().NoError(s.repo.Create(s.ctx, &service.RedeemCode{Code: "VALUE-10", Type: domain.RedeemTypeBalance, Value: 10, Status: domain.StatusUnused}))
 
 	codes, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{
 		Page:      1,

--- a/backend/internal/repository/scheduler_cache_integration_test.go
+++ b/backend/internal/repository/scheduler_cache_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +19,7 @@ func TestSchedulerCacheSnapshotUsesSlimMetadataButKeepsFullAccount(t *testing.T)
 	rdb := testRedis(t)
 	cache := NewSchedulerCache(rdb)
 
-	bucket := service.SchedulerBucket{GroupID: 2, Platform: service.PlatformGemini, Mode: service.SchedulerModeSingle}
+	bucket := service.SchedulerBucket{GroupID: 2, Platform: domain.PlatformGemini, Mode: service.SchedulerModeSingle}
 	now := time.Now().UTC().Truncate(time.Second)
 	limitReset := now.Add(10 * time.Minute)
 	overloadUntil := now.Add(2 * time.Minute)
@@ -28,9 +29,9 @@ func TestSchedulerCacheSnapshotUsesSlimMetadataButKeepsFullAccount(t *testing.T)
 	account := service.Account{
 		ID:          101,
 		Name:        "gemini-heavy",
-		Platform:    service.PlatformGemini,
-		Type:        service.AccountTypeOAuth,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformGemini,
+		Type:        domain.AccountTypeOAuth,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 		Concurrency: 3,
 		Priority:    7,
@@ -120,16 +121,16 @@ func TestSchedulerCacheUpdateLastUsedOnlyTouchesMetaKey(t *testing.T) {
 	rdb := testRedis(t)
 	cache := NewSchedulerCache(rdb)
 
-	bucket := service.SchedulerBucket{GroupID: 3, Platform: service.PlatformAnthropic, Mode: service.SchedulerModeSingle}
+	bucket := service.SchedulerBucket{GroupID: 3, Platform: domain.PlatformAnthropic, Mode: service.SchedulerModeSingle}
 	t0 := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
 	t1 := t0.Add(time.Hour)
 
 	account := service.Account{
 		ID:          202,
 		Name:        "claude-lru",
-		Platform:    service.PlatformAnthropic,
-		Type:        service.AccountTypeOAuth,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformAnthropic,
+		Type:        domain.AccountTypeOAuth,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 		Concurrency: 2,
 		Priority:    1,

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -5,6 +5,7 @@ package repository
 import (
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -12,8 +13,8 @@ import (
 func TestBuildSchedulerMetadataAccount_KeepsOpenAIWSFlags(t *testing.T) {
 	account := service.Account{
 		ID:       42,
-		Platform: service.PlatformOpenAI,
-		Type:     service.AccountTypeOAuth,
+		Platform: domain.PlatformOpenAI,
+		Type:     domain.AccountTypeOAuth,
 		Extra: map[string]any{
 			"openai_oauth_responses_websockets_v2_enabled": true,
 			"openai_oauth_responses_websockets_v2_mode":    service.OpenAIWSIngressModePassthrough,
@@ -44,7 +45,7 @@ func TestBuildSchedulerMetadataAccount_KeepsPrivacyMode(t *testing.T) {
 	t.Run("openai_training_off", func(t *testing.T) {
 		account := service.Account{
 			ID:       1,
-			Platform: service.PlatformOpenAI,
+			Platform: domain.PlatformOpenAI,
 			Extra: map[string]any{
 				"privacy_mode": service.PrivacyModeTrainingOff,
 			},
@@ -60,7 +61,7 @@ func TestBuildSchedulerMetadataAccount_KeepsPrivacyMode(t *testing.T) {
 	t.Run("antigravity_privacy_set", func(t *testing.T) {
 		account := service.Account{
 			ID:       2,
-			Platform: service.PlatformAntigravity,
+			Platform: domain.PlatformAntigravity,
 			Extra: map[string]any{
 				"privacy_mode": service.AntigravityPrivacySet,
 			},
@@ -75,7 +76,7 @@ func TestBuildSchedulerMetadataAccount_KeepsPrivacyMode(t *testing.T) {
 	t.Run("training_set_failed_remains_unset", func(t *testing.T) {
 		account := service.Account{
 			ID:       3,
-			Platform: service.PlatformOpenAI,
+			Platform: domain.PlatformOpenAI,
 			Extra: map[string]any{
 				"privacy_mode": service.PrivacyModeFailed,
 			},
@@ -92,7 +93,7 @@ func TestBuildSchedulerMetadataAccount_KeepsPrivacyMode(t *testing.T) {
 func TestBuildSchedulerMetadataAccount_KeepsSlimGroupMembership(t *testing.T) {
 	account := service.Account{
 		ID:       42,
-		Platform: service.PlatformAnthropic,
+		Platform: domain.PlatformAnthropic,
 		GroupIDs: []int64{7, 9, 7, 0},
 		AccountGroups: []service.AccountGroup{
 			{
@@ -165,7 +166,7 @@ func TestBuildSchedulerMetadataAccount_KeepsQuotaAutoPauseFields(t *testing.T) {
 func TestBuildSchedulerMetadataAccount_KeepsModelRateLimits(t *testing.T) {
 	account := service.Account{
 		ID:       90,
-		Platform: service.PlatformAntigravity,
+		Platform: domain.PlatformAntigravity,
 		Extra: map[string]any{
 			"model_rate_limits": map[string]any{
 				"gemini-3-flash": map[string]any{
@@ -192,8 +193,8 @@ func TestBuildSchedulerMetadataAccount_KeepsSparkShadowRoutingIdentity(t *testin
 	parentID := int64(100)
 	account := service.Account{
 		ID:              200,
-		Platform:        service.PlatformOpenAI,
-		Type:            service.AccountTypeOAuth,
+		Platform:        domain.PlatformOpenAI,
+		Type:            domain.AccountTypeOAuth,
 		ParentAccountID: &parentID,
 		QuotaDimension:  service.QuotaDimensionSpark,
 		Credentials: map[string]any{
@@ -221,8 +222,8 @@ func TestBuildSchedulerMetadataAccount_KeepsMirrorStubRoutingMetadata(t *testing
 	account := service.Account{
 		ID:       300,
 		Name:     "kiro-us6",
-		Platform: service.PlatformAnthropic,
-		Type:     service.AccountTypeAPIKey,
+		Platform: domain.PlatformAnthropic,
+		Type:     domain.AccountTypeAPIKey,
 		Credentials: map[string]any{
 			"api_key":         "tk-edge",
 			"base_url":        "https://api-us6.tokenkey.dev",

--- a/backend/internal/repository/scheduler_outbox_repo.go
+++ b/backend/internal/repository/scheduler_outbox_repo.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -210,9 +211,9 @@ func schedulerOutboxDedupKey(eventType string, accountID *int64, groupID *int64,
 
 func schedulerOutboxEventSupportsDedup(eventType string) bool {
 	switch eventType {
-	case service.SchedulerOutboxEventAccountChanged,
-		service.SchedulerOutboxEventGroupChanged,
-		service.SchedulerOutboxEventFullRebuild:
+	case domain.SchedulerOutboxEventAccountChanged,
+		domain.SchedulerOutboxEventGroupChanged,
+		domain.SchedulerOutboxEventFullRebuild:
 		return true
 	default:
 		return false

--- a/backend/internal/repository/scheduler_snapshot_outbox_integration_test.go
+++ b/backend/internal/repository/scheduler_snapshot_outbox_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -36,9 +37,9 @@ func TestSchedulerSnapshotOutboxReplay(t *testing.T) {
 
 	account := &service.Account{
 		Name:        "outbox-replay-" + time.Now().Format("150405.000000"),
-		Platform:    service.PlatformOpenAI,
-		Type:        service.AccountTypeAPIKey,
-		Status:      service.StatusActive,
+		Platform:    domain.PlatformOpenAI,
+		Type:        domain.AccountTypeAPIKey,
+		Status:      domain.StatusActive,
 		Schedulable: true,
 		Concurrency: 3,
 		Priority:    1,
@@ -60,7 +61,7 @@ func TestSchedulerSnapshotOutboxReplay(t *testing.T) {
 	// 自 #1723 起 outbox 的 account_last_used 路径只刷 sched:meta，完整键由快照
 	// 重建/账号变更刷新。若仍断言完整键，本测试会改为被 startup rebuild 的副作用
 	// 兜过（名实不符、对 outbox 回归零覆盖）。
-	bucket := service.SchedulerBucket{GroupID: 0, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	bucket := service.SchedulerBucket{GroupID: 0, Platform: domain.PlatformOpenAI, Mode: service.SchedulerModeSingle}
 	snapshotHasAccount := func() (*service.Account, bool) {
 		snap, hit, err := cache.GetSnapshot(ctx, bucket)
 		if err != nil || !hit {

--- a/backend/internal/repository/setting_repo.go
+++ b/backend/internal/repository/setting_repo.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/setting"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -21,7 +22,7 @@ func (r *settingRepository) Get(ctx context.Context, key string) (*service.Setti
 	m, err := r.client.Setting.Query().Where(setting.KeyEQ(key)).Only(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
-			return nil, service.ErrSettingNotFound
+			return nil, domain.ErrSettingNotFound
 		}
 		return nil, err
 	}

--- a/backend/internal/repository/setting_repo_integration_test.go
+++ b/backend/internal/repository/setting_repo_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -44,7 +44,7 @@ func (s *SettingRepoSuite) TestSet_Upsert() {
 func (s *SettingRepoSuite) TestGetValue_Missing() {
 	_, err := s.repo.GetValue(s.ctx, "nonexistent")
 	s.Require().Error(err, "expected error for missing key")
-	s.Require().ErrorIs(err, service.ErrSettingNotFound)
+	s.Require().ErrorIs(err, domain.ErrSettingNotFound)
 }
 
 func (s *SettingRepoSuite) TestSetMultiple_AndGetMultiple() {
@@ -85,7 +85,7 @@ func (s *SettingRepoSuite) TestDelete() {
 	s.Require().NoError(s.repo.Delete(s.ctx, "todelete"), "Delete")
 	_, err := s.repo.GetValue(s.ctx, "todelete")
 	s.Require().Error(err, "expected missing key error after Delete")
-	s.Require().ErrorIs(err, service.ErrSettingNotFound)
+	s.Require().ErrorIs(err, domain.ErrSettingNotFound)
 }
 
 func (s *SettingRepoSuite) TestDelete_Idempotent() {

--- a/backend/internal/repository/simple_mode_admin_concurrency.go
+++ b/backend/internal/repository/simple_mode_admin_concurrency.go
@@ -8,7 +8,7 @@ import (
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/setting"
 	dbuser "github.com/Wei-Shaw/sub2api/ent/user"
-	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 )
 
 const (
@@ -32,7 +32,7 @@ func ensureSimpleModeAdminConcurrency(ctx context.Context, client *dbent.Client)
 
 	if _, err := client.User.Update().
 		Where(
-			dbuser.RoleEQ(service.RoleAdmin),
+			dbuser.RoleEQ(domain.RoleAdmin),
 			dbuser.ConcurrencyEQ(simpleModeLegacyAdminConcurrency),
 		).
 		SetConcurrency(simpleModeTargetAdminConcurrency).

--- a/backend/internal/repository/simple_mode_default_groups.go
+++ b/backend/internal/repository/simple_mode_default_groups.go
@@ -6,7 +6,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/group"
-	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 )
 
 func ensureSimpleModeDefaultGroups(ctx context.Context, client *dbent.Client) error {
@@ -20,12 +20,12 @@ func ensureSimpleModeDefaultGroups(ctx context.Context, client *dbent.Client) er
 	// so missing this seed silently strands fresh newapi accounts outside
 	// any scheduling pool. Antigravity keeps the historical 2-group seed.
 	requiredByPlatform := map[string]int{
-		service.PlatformAnthropic:   1,
-		service.PlatformOpenAI:      1,
-		service.PlatformGemini:      1,
-		service.PlatformNewAPI:      1,
-		service.PlatformAntigravity: 2,
-		service.PlatformGrok:        1,
+		domain.PlatformAnthropic:   1,
+		domain.PlatformOpenAI:      1,
+		domain.PlatformGemini:      1,
+		domain.PlatformNewAPI:      1,
+		domain.PlatformAntigravity: 2,
+		domain.PlatformGrok:        1,
 	}
 
 	for platform, minCount := range requiredByPlatform {
@@ -36,7 +36,7 @@ func ensureSimpleModeDefaultGroups(ctx context.Context, client *dbent.Client) er
 			return fmt.Errorf("count groups for platform %s: %w", platform, err)
 		}
 
-		if platform == service.PlatformAntigravity {
+		if platform == domain.PlatformAntigravity {
 			if count < minCount {
 				for i := count; i < minCount; i++ {
 					name := fmt.Sprintf("%s-default-%d", platform, i+1)
@@ -73,8 +73,8 @@ func createGroupIfNotExists(ctx context.Context, client *dbent.Client, name, pla
 		SetName(name).
 		SetDescription("Auto-created default group").
 		SetPlatform(platform).
-		SetStatus(service.StatusActive).
-		SetSubscriptionType(service.SubscriptionTypeStandard).
+		SetStatus(domain.StatusActive).
+		SetSubscriptionType(domain.SubscriptionTypeStandard).
 		SetRateMultiplier(1.0).
 		SetIsExclusive(false).
 		Save(ctx)

--- a/backend/internal/repository/simple_mode_default_groups_integration_test.go
+++ b/backend/internal/repository/simple_mode_default_groups_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/ent/group"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -28,12 +29,12 @@ func TestEnsureSimpleModeDefaultGroups_CreatesMissingDefaults(t *testing.T) {
 		require.True(t, exists, "expected group %s to exist", name)
 	}
 
-	assertGroupExists(service.PlatformAnthropic + "-default")
-	assertGroupExists(service.PlatformOpenAI + "-default")
-	assertGroupExists(service.PlatformGemini + "-default")
-	assertGroupExists(service.PlatformNewAPI + "-default")
-	assertGroupExists(service.PlatformAntigravity + "-default-1")
-	assertGroupExists(service.PlatformAntigravity + "-default-2")
+	assertGroupExists(domain.PlatformAnthropic + "-default")
+	assertGroupExists(domain.PlatformOpenAI + "-default")
+	assertGroupExists(domain.PlatformGemini + "-default")
+	assertGroupExists(domain.PlatformNewAPI + "-default")
+	assertGroupExists(domain.PlatformAntigravity + "-default-1")
+	assertGroupExists(domain.PlatformAntigravity + "-default-2")
 }
 
 func TestEnsureSimpleModeDefaultGroups_IgnoresSoftDeletedGroups(t *testing.T) {
@@ -46,10 +47,10 @@ func TestEnsureSimpleModeDefaultGroups_IgnoresSoftDeletedGroups(t *testing.T) {
 
 	// Create and then soft-delete an anthropic default group.
 	g, err := client.Group.Create().
-		SetName(service.PlatformAnthropic + "-default").
-		SetPlatform(service.PlatformAnthropic).
-		SetStatus(service.StatusActive).
-		SetSubscriptionType(service.SubscriptionTypeStandard).
+		SetName(domain.PlatformAnthropic + "-default").
+		SetPlatform(domain.PlatformAnthropic).
+		SetStatus(domain.StatusActive).
+		SetSubscriptionType(domain.SubscriptionTypeStandard).
 		SetRateMultiplier(1.0).
 		SetIsExclusive(false).
 		Save(seedCtx)
@@ -61,7 +62,7 @@ func TestEnsureSimpleModeDefaultGroups_IgnoresSoftDeletedGroups(t *testing.T) {
 	require.NoError(t, ensureSimpleModeDefaultGroups(seedCtx, client))
 
 	// New active one should exist.
-	count, err := client.Group.Query().Where(group.NameEQ(service.PlatformAnthropic+"-default"), group.DeletedAtIsNil()).Count(seedCtx)
+	count, err := client.Group.Query().Where(group.NameEQ(domain.PlatformAnthropic+"-default"), group.DeletedAtIsNil()).Count(seedCtx)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 }
@@ -74,12 +75,12 @@ func TestEnsureSimpleModeDefaultGroups_AntigravityNeedsTwoGroupsOnlyByCount(t *t
 	seedCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	mustCreateGroup(t, client, &service.Group{Name: "ag-custom-1-" + time.Now().Format(time.RFC3339Nano), Platform: service.PlatformAntigravity})
-	mustCreateGroup(t, client, &service.Group{Name: "ag-custom-2-" + time.Now().Format(time.RFC3339Nano), Platform: service.PlatformAntigravity})
+	mustCreateGroup(t, client, &service.Group{Name: "ag-custom-1-" + time.Now().Format(time.RFC3339Nano), Platform: domain.PlatformAntigravity})
+	mustCreateGroup(t, client, &service.Group{Name: "ag-custom-2-" + time.Now().Format(time.RFC3339Nano), Platform: domain.PlatformAntigravity})
 
 	require.NoError(t, ensureSimpleModeDefaultGroups(seedCtx, client))
 
-	count, err := client.Group.Query().Where(group.PlatformEQ(service.PlatformAntigravity), group.DeletedAtIsNil()).Count(seedCtx)
+	count, err := client.Group.Query().Where(group.PlatformEQ(domain.PlatformAntigravity), group.DeletedAtIsNil()).Count(seedCtx)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, count, 2)
 }

--- a/backend/internal/repository/soft_delete_ent_integration_test.go
+++ b/backend/internal/repository/soft_delete_ent_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/ent/apikey"
 	"github.com/Wei-Shaw/sub2api/ent/schema/mixins"
 	"github.com/Wei-Shaw/sub2api/ent/usersubscription"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -46,14 +47,14 @@ func TestEntSoftDelete_ApiKey_DefaultFilterAndSkip(t *testing.T) {
 		UserID: u.ID,
 		Key:    uniqueSoftDeleteValue(t, "sk-soft-delete"),
 		Name:   "soft-delete",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, key), "create api key")
 
 	require.NoError(t, repo.Delete(ctx, key.ID), "soft delete api key")
 
 	_, err := repo.GetByID(ctx, key.ID)
-	require.ErrorIs(t, err, service.ErrAPIKeyNotFound, "deleted rows should be hidden by default")
+	require.ErrorIs(t, err, domain.ErrAPIKeyNotFound, "deleted rows should be hidden by default")
 
 	_, err = client.APIKey.Query().Where(apikey.IDEQ(key.ID)).Only(ctx)
 	require.Error(t, err, "default ent query should not see soft-deleted rows")
@@ -78,7 +79,7 @@ func TestEntSoftDelete_ApiKey_DeleteIdempotent(t *testing.T) {
 		UserID: u.ID,
 		Key:    uniqueSoftDeleteValue(t, "sk-soft-delete2"),
 		Name:   "soft-delete2",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, key), "create api key")
 
@@ -98,7 +99,7 @@ func TestEntSoftDelete_ApiKey_HardDeleteViaSkipSoftDelete(t *testing.T) {
 		UserID: u.ID,
 		Key:    uniqueSoftDeleteValue(t, "sk-soft-delete3"),
 		Name:   "soft-delete3",
-		Status: service.StatusActive,
+		Status: domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, key), "create api key")
 
@@ -121,7 +122,7 @@ func createEntGroup(t *testing.T, ctx context.Context, client *dbent.Client, nam
 
 	g, err := client.Group.Create().
 		SetName(name).
-		SetStatus(service.StatusActive).
+		SetStatus(domain.StatusActive).
 		Save(ctx)
 	require.NoError(t, err, "create ent group")
 	return g
@@ -138,7 +139,7 @@ func TestEntSoftDelete_UserSubscription_DefaultFilterAndSkip(t *testing.T) {
 	sub := &service.UserSubscription{
 		UserID:    u.ID,
 		GroupID:   g.ID,
-		Status:    service.SubscriptionStatusActive,
+		Status:    domain.SubscriptionStatusActive,
 		ExpiresAt: time.Now().Add(24 * time.Hour),
 	}
 	require.NoError(t, repo.Create(ctx, sub), "create user subscription")
@@ -170,7 +171,7 @@ func TestEntSoftDelete_UserSubscription_DeleteIdempotent(t *testing.T) {
 	sub := &service.UserSubscription{
 		UserID:    u.ID,
 		GroupID:   g.ID,
-		Status:    service.SubscriptionStatusActive,
+		Status:    domain.SubscriptionStatusActive,
 		ExpiresAt: time.Now().Add(24 * time.Hour),
 	}
 	require.NoError(t, repo.Create(ctx, sub), "create user subscription")
@@ -192,7 +193,7 @@ func TestEntSoftDelete_UserSubscription_ListExcludesDeleted(t *testing.T) {
 	sub1 := &service.UserSubscription{
 		UserID:    u.ID,
 		GroupID:   g1.ID,
-		Status:    service.SubscriptionStatusActive,
+		Status:    domain.SubscriptionStatusActive,
 		ExpiresAt: time.Now().Add(24 * time.Hour),
 	}
 	require.NoError(t, repo.Create(ctx, sub1), "create subscription 1")
@@ -200,7 +201,7 @@ func TestEntSoftDelete_UserSubscription_ListExcludesDeleted(t *testing.T) {
 	sub2 := &service.UserSubscription{
 		UserID:    u.ID,
 		GroupID:   g2.ID,
-		Status:    service.SubscriptionStatusActive,
+		Status:    domain.SubscriptionStatusActive,
 		ExpiresAt: time.Now().Add(24 * time.Hour),
 	}
 	require.NoError(t, repo.Create(ctx, sub2), "create subscription 2")

--- a/backend/internal/repository/usage_billing_repo.go
+++ b/backend/internal/repository/usage_billing_repo.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
@@ -19,7 +20,7 @@ func NewUsageBillingRepository(_ *dbent.Client, sqlDB *sql.DB) service.UsageBill
 	return &usageBillingRepository{db: sqlDB}
 }
 
-func (r *usageBillingRepository) Apply(ctx context.Context, cmd *service.UsageBillingCommand) (_ *service.UsageBillingApplyResult, err error) {
+func (r *usageBillingRepository) Apply(ctx context.Context, cmd *domain.UsageBillingCommand) (_ *service.UsageBillingApplyResult, err error) {
 	if cmd == nil {
 		return &service.UsageBillingApplyResult{}, nil
 	}
@@ -29,7 +30,7 @@ func (r *usageBillingRepository) Apply(ctx context.Context, cmd *service.UsageBi
 
 	cmd.Normalize()
 	if cmd.RequestID == "" {
-		return nil, service.ErrUsageBillingRequestIDRequired
+		return nil, domain.ErrUsageBillingRequestIDRequired
 	}
 
 	tx, err := r.db.BeginTx(ctx, nil)
@@ -62,7 +63,7 @@ func (r *usageBillingRepository) Apply(ctx context.Context, cmd *service.UsageBi
 	return result, nil
 }
 
-func (r *usageBillingRepository) claimUsageBillingKey(ctx context.Context, tx *sql.Tx, cmd *service.UsageBillingCommand) (bool, error) {
+func (r *usageBillingRepository) claimUsageBillingKey(ctx context.Context, tx *sql.Tx, cmd *domain.UsageBillingCommand) (bool, error) {
 	var id int64
 	err := tx.QueryRowContext(ctx, `
 		INSERT INTO usage_billing_dedup (request_id, api_key_id, request_fingerprint)
@@ -80,7 +81,7 @@ func (r *usageBillingRepository) claimUsageBillingKey(ctx context.Context, tx *s
 			return false, err
 		}
 		if strings.TrimSpace(existingFingerprint) != strings.TrimSpace(cmd.RequestFingerprint) {
-			return false, service.ErrUsageBillingRequestConflict
+			return false, domain.ErrUsageBillingRequestConflict
 		}
 		return false, nil
 	}
@@ -95,7 +96,7 @@ func (r *usageBillingRepository) claimUsageBillingKey(ctx context.Context, tx *s
 	`, cmd.RequestID, cmd.APIKeyID).Scan(&archivedFingerprint)
 	if err == nil {
 		if strings.TrimSpace(archivedFingerprint) != strings.TrimSpace(cmd.RequestFingerprint) {
-			return false, service.ErrUsageBillingRequestConflict
+			return false, domain.ErrUsageBillingRequestConflict
 		}
 		return false, nil
 	}
@@ -105,7 +106,7 @@ func (r *usageBillingRepository) claimUsageBillingKey(ctx context.Context, tx *s
 	return true, nil
 }
 
-func (r *usageBillingRepository) applyUsageBillingEffects(ctx context.Context, tx *sql.Tx, cmd *service.UsageBillingCommand, result *service.UsageBillingApplyResult) error {
+func (r *usageBillingRepository) applyUsageBillingEffects(ctx context.Context, tx *sql.Tx, cmd *domain.UsageBillingCommand, result *service.UsageBillingApplyResult) error {
 	// TK: consume the pre-flight balance hold in the SAME transaction as the
 	// deduction below (see usage_billing_repo_tk_hold.go).
 	if err := tkConsumeBalanceHoldInTx(ctx, tx, cmd.TkHoldRequestID); err != nil {
@@ -141,7 +142,7 @@ func (r *usageBillingRepository) applyUsageBillingEffects(ctx context.Context, t
 		}
 	}
 
-	if cmd.AccountQuotaCost > 0 && (strings.EqualFold(cmd.AccountType, service.AccountTypeAPIKey) || strings.EqualFold(cmd.AccountType, service.AccountTypeBedrock)) {
+	if cmd.AccountQuotaCost > 0 && (strings.EqualFold(cmd.AccountType, domain.AccountTypeAPIKey) || strings.EqualFold(cmd.AccountType, domain.AccountTypeBedrock)) {
 		quotaState, err := incrementUsageBillingAccountQuota(ctx, tx, cmd.AccountID, cmd.AccountQuotaCost)
 		if err != nil {
 			return err
@@ -177,7 +178,7 @@ func incrementUsageBillingSubscription(ctx context.Context, tx *sql.Tx, subscrip
 	if affected > 0 {
 		return nil
 	}
-	return service.ErrSubscriptionNotFound
+	return domain.ErrSubscriptionNotFound
 }
 
 func deductUsageBillingBalance(ctx context.Context, tx *sql.Tx, userID int64, amount float64) (float64, bool, error) {
@@ -204,7 +205,7 @@ func deductUsageBillingBalance(ctx context.Context, tx *sql.Tx, userID int64, am
 		RETURNING balance
 	`, amount, userID).Scan(&newBalance)
 	if errors.Is(err, sql.ErrNoRows) {
-		return 0, false, service.ErrUserNotFound
+		return 0, false, domain.ErrUserNotFound
 	}
 	if err != nil {
 		return 0, false, err
@@ -230,7 +231,7 @@ func incrementUsageBillingAPIKeyQuota(ctx context.Context, tx *sql.Tx, apiKeyID 
 		RETURNING quota > 0 AND quota_used >= quota AND quota_used - $1 < quota
 	`, amount, apiKeyID, service.StatusAPIKeyActive, service.StatusAPIKeyQuotaExhausted).Scan(&exhausted)
 	if errors.Is(err, sql.ErrNoRows) {
-		return false, service.ErrAPIKeyNotFound
+		return false, domain.ErrAPIKeyNotFound
 	}
 	if err != nil {
 		return false, err
@@ -258,7 +259,7 @@ func incrementUsageBillingAPIKeyRateLimit(ctx context.Context, tx *sql.Tx, apiKe
 		return err
 	}
 	if affected == 0 {
-		return service.ErrAPIKeyNotFound
+		return domain.ErrAPIKeyNotFound
 	}
 	return nil
 }
@@ -328,7 +329,7 @@ func incrementUsageBillingAccountQuota(ctx context.Context, tx *sql.Tx, accountI
 			return nil, err
 		}
 		_ = rows.Close()
-		return nil, service.ErrAccountNotFound
+		return nil, domain.ErrAccountNotFound
 	}
 	if err := rows.Err(); err != nil {
 		_ = rows.Close()
@@ -349,7 +350,7 @@ func incrementUsageBillingAccountQuota(ctx context.Context, tx *sql.Tx, accountI
 	crossedDaily := state.DailyLimit > 0 && state.DailyUsed >= state.DailyLimit && (state.DailyUsed-amount) < state.DailyLimit
 	crossedWeekly := state.WeeklyLimit > 0 && state.WeeklyUsed >= state.WeeklyLimit && (state.WeeklyUsed-amount) < state.WeeklyLimit
 	if crossedTotal || crossedDaily || crossedWeekly {
-		if err := enqueueSchedulerOutbox(ctx, tx, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil); err != nil {
+		if err := enqueueSchedulerOutbox(ctx, tx, domain.SchedulerOutboxEventAccountChanged, &accountID, nil, nil); err != nil {
 			logger.LegacyPrintf("repository.usage_billing", "[SchedulerOutbox] enqueue quota exceeded failed: account=%d err=%v", accountID, err)
 			return nil, err
 		}

--- a/backend/internal/repository/usage_billing_repo_integration_test.go
+++ b/backend/internal/repository/usage_billing_repo_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -33,16 +34,16 @@ func TestUsageBillingRepositoryApply_DeduplicatesBalanceBilling(t *testing.T) {
 	})
 	account := mustCreateAccount(t, client, &service.Account{
 		Name: "usage-billing-account-" + uuid.NewString(),
-		Type: service.AccountTypeAPIKey,
+		Type: domain.AccountTypeAPIKey,
 	})
 
 	requestID := uuid.NewString()
-	cmd := &service.UsageBillingCommand{
+	cmd := &domain.UsageBillingCommand{
 		RequestID:           requestID,
 		APIKeyID:            apiKey.ID,
 		UserID:              user.ID,
 		AccountID:           account.ID,
-		AccountType:         service.AccountTypeAPIKey,
+		AccountType:         domain.AccountTypeAPIKey,
 		BalanceCost:         1.25,
 		APIKeyQuotaCost:     1.25,
 		APIKeyRateLimitCost: 1.25,
@@ -91,8 +92,8 @@ func TestUsageBillingRepositoryApply_DeduplicatesSubscriptionBilling(t *testing.
 	})
 	group := mustCreateGroup(t, client, &service.Group{
 		Name:             "usage-billing-group-" + uuid.NewString(),
-		Platform:         service.PlatformAnthropic,
-		SubscriptionType: service.SubscriptionTypeSubscription,
+		Platform:         domain.PlatformAnthropic,
+		SubscriptionType: domain.SubscriptionTypeSubscription,
 	})
 	apiKey := mustCreateApiKey(t, client, &service.APIKey{
 		UserID:  user.ID,
@@ -106,7 +107,7 @@ func TestUsageBillingRepositoryApply_DeduplicatesSubscriptionBilling(t *testing.
 	})
 
 	requestID := uuid.NewString()
-	cmd := &service.UsageBillingCommand{
+	cmd := &domain.UsageBillingCommand{
 		RequestID:        requestID,
 		APIKeyID:         apiKey.ID,
 		UserID:           user.ID,
@@ -145,7 +146,7 @@ func TestUsageBillingRepositoryApply_RequestFingerprintConflict(t *testing.T) {
 	})
 
 	requestID := uuid.NewString()
-	_, err := repo.Apply(ctx, &service.UsageBillingCommand{
+	_, err := repo.Apply(ctx, &domain.UsageBillingCommand{
 		RequestID:   requestID,
 		APIKeyID:    apiKey.ID,
 		UserID:      user.ID,
@@ -153,13 +154,13 @@ func TestUsageBillingRepositoryApply_RequestFingerprintConflict(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = repo.Apply(ctx, &service.UsageBillingCommand{
+	_, err = repo.Apply(ctx, &domain.UsageBillingCommand{
 		RequestID:   requestID,
 		APIKeyID:    apiKey.ID,
 		UserID:      user.ID,
 		BalanceCost: 2.50,
 	})
-	require.ErrorIs(t, err, service.ErrUsageBillingRequestConflict)
+	require.ErrorIs(t, err, domain.ErrUsageBillingRequestConflict)
 }
 
 func TestUsageBillingRepositoryApply_UpdatesAccountQuota(t *testing.T) {
@@ -178,18 +179,18 @@ func TestUsageBillingRepositoryApply_UpdatesAccountQuota(t *testing.T) {
 	})
 	account := mustCreateAccount(t, client, &service.Account{
 		Name: "usage-billing-account-quota-" + uuid.NewString(),
-		Type: service.AccountTypeAPIKey,
+		Type: domain.AccountTypeAPIKey,
 		Extra: map[string]any{
 			"quota_limit": 100.0,
 		},
 	})
 
-	_, err := repo.Apply(ctx, &service.UsageBillingCommand{
+	_, err := repo.Apply(ctx, &domain.UsageBillingCommand{
 		RequestID:        uuid.NewString(),
 		APIKeyID:         apiKey.ID,
 		UserID:           user.ID,
 		AccountID:        account.ID,
-		AccountType:      service.AccountTypeAPIKey,
+		AccountType:      domain.AccountTypeAPIKey,
 		AccountQuotaCost: 3.5,
 	})
 	require.NoError(t, err)
@@ -217,7 +218,7 @@ func TestUsageBillingRepositoryApply_EnqueuesSchedulerOutboxOnQuotaCrossing(t *t
 		})
 		account := mustCreateAccount(t, client, &service.Account{
 			Name:  "usage-billing-outbox-" + uuid.NewString(),
-			Type:  service.AccountTypeAPIKey,
+			Type:  domain.AccountTypeAPIKey,
 			Extra: extra,
 		})
 		return apiKey.ID, account.ID
@@ -228,7 +229,7 @@ func TestUsageBillingRepositoryApply_EnqueuesSchedulerOutboxOnQuotaCrossing(t *t
 		var count int
 		require.NoError(t, integrationDB.QueryRowContext(ctx,
 			"SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1 AND account_id = $2",
-			service.SchedulerOutboxEventAccountChanged, accountID,
+			domain.SchedulerOutboxEventAccountChanged, accountID,
 		).Scan(&count))
 		return count
 	}
@@ -238,33 +239,33 @@ func TestUsageBillingRepositoryApply_EnqueuesSchedulerOutboxOnQuotaCrossing(t *t
 			"quota_daily_limit": 10.0,
 		})
 		// 第一次低于日限额：不应入队 outbox
-		_, err := repo.Apply(ctx, &service.UsageBillingCommand{
+		_, err := repo.Apply(ctx, &domain.UsageBillingCommand{
 			RequestID:        uuid.NewString(),
 			APIKeyID:         apiKeyID,
 			AccountID:        accountID,
-			AccountType:      service.AccountTypeAPIKey,
+			AccountType:      domain.AccountTypeAPIKey,
 			AccountQuotaCost: 4,
 		})
 		require.NoError(t, err)
 		require.Equal(t, 0, outboxCountFor(t, accountID), "below limit should not enqueue")
 
 		// 第二次跨越日限额：应入队一次 outbox
-		_, err = repo.Apply(ctx, &service.UsageBillingCommand{
+		_, err = repo.Apply(ctx, &domain.UsageBillingCommand{
 			RequestID:        uuid.NewString(),
 			APIKeyID:         apiKeyID,
 			AccountID:        accountID,
-			AccountType:      service.AccountTypeAPIKey,
+			AccountType:      domain.AccountTypeAPIKey,
 			AccountQuotaCost: 8,
 		})
 		require.NoError(t, err)
 		require.Equal(t, 1, outboxCountFor(t, accountID), "crossing daily limit should enqueue once")
 
 		// 再次递增（已超）：不应重复入队
-		_, err = repo.Apply(ctx, &service.UsageBillingCommand{
+		_, err = repo.Apply(ctx, &domain.UsageBillingCommand{
 			RequestID:        uuid.NewString(),
 			APIKeyID:         apiKeyID,
 			AccountID:        accountID,
-			AccountType:      service.AccountTypeAPIKey,
+			AccountType:      domain.AccountTypeAPIKey,
 			AccountQuotaCost: 2,
 		})
 		require.NoError(t, err)
@@ -275,11 +276,11 @@ func TestUsageBillingRepositoryApply_EnqueuesSchedulerOutboxOnQuotaCrossing(t *t
 		apiKeyID, accountID := newFixture(t, map[string]any{
 			"quota_weekly_limit": 10.0,
 		})
-		_, err := repo.Apply(ctx, &service.UsageBillingCommand{
+		_, err := repo.Apply(ctx, &domain.UsageBillingCommand{
 			RequestID:        uuid.NewString(),
 			APIKeyID:         apiKeyID,
 			AccountID:        accountID,
-			AccountType:      service.AccountTypeAPIKey,
+			AccountType:      domain.AccountTypeAPIKey,
 			AccountQuotaCost: 15, // 单次即跨越
 		})
 		require.NoError(t, err)
@@ -338,7 +339,7 @@ func TestUsageBillingRepositoryApply_DeduplicatesAgainstArchivedKey(t *testing.T
 	})
 
 	requestID := uuid.NewString()
-	cmd := &service.UsageBillingCommand{
+	cmd := &domain.UsageBillingCommand{
 		RequestID:   requestID,
 		APIKeyID:    apiKey.ID,
 		UserID:      user.ID,

--- a/backend/internal/repository/usage_billing_repo_tk_hold.go
+++ b/backend/internal/repository/usage_billing_repo_tk_hold.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -31,7 +32,7 @@ func (r *usageBillingRepository) ReserveBalanceHold(ctx context.Context, cmd *se
 		return false, errors.New("usage billing repository db is nil")
 	}
 	if cmd.RequestID == "" {
-		return false, service.ErrUsageBillingRequestIDRequired
+		return false, domain.ErrUsageBillingRequestIDRequired
 	}
 
 	tx, err := r.db.BeginTx(ctx, nil)

--- a/backend/internal/repository/usage_billing_repo_tk_hold_integration_test.go
+++ b/backend/internal/repository/usage_billing_repo_tk_hold_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -140,12 +141,12 @@ func TestApply_ConsumesHandedOffHoldAtomically(t *testing.T) {
 	require.True(t, reserved)
 	require.InDelta(t, 5, holdBalance(t, user.ID), 1e-9)
 
-	cmd := &service.UsageBillingCommand{
+	cmd := &domain.UsageBillingCommand{
 		RequestID:       uuid.NewString(), // billing id may differ from the hold id (WS turns)
 		APIKeyID:        apiKey.ID,
 		UserID:          user.ID,
 		AccountID:       1,
-		AccountType:     service.AccountTypeAPIKey,
+		AccountType:     domain.AccountTypeAPIKey,
 		Model:           "test-model",
 		BalanceCost:     3,
 		TkHoldRequestID: holdID,

--- a/backend/internal/repository/usage_billing_repo_tk_video_refund.go
+++ b/backend/internal/repository/usage_billing_repo_tk_video_refund.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -30,7 +31,7 @@ func (r *usageBillingRepository) ApplyVideoRefund(ctx context.Context, cmd *serv
 		return false, errors.New("usage billing repository db is nil")
 	}
 	if cmd.RequestID == "" {
-		return false, service.ErrUsageBillingRequestIDRequired
+		return false, domain.ErrUsageBillingRequestIDRequired
 	}
 
 	tx, err := r.db.BeginTx(ctx, nil)
@@ -45,7 +46,7 @@ func (r *usageBillingRepository) ApplyVideoRefund(ctx context.Context, cmd *serv
 
 	// Reuse the forward-billing claim (same conflict semantics): build a
 	// minimal command so the fingerprint is deterministic for retries.
-	claimCmd := &service.UsageBillingCommand{
+	claimCmd := &domain.UsageBillingCommand{
 		RequestID:   cmd.RequestID,
 		APIKeyID:    cmd.APIKeyID,
 		UserID:      cmd.UserID,

--- a/backend/internal/repository/usage_billing_repo_tk_video_refund_integration_test.go
+++ b/backend/internal/repository/usage_billing_repo_tk_video_refund_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -53,16 +54,16 @@ func TestUsageBillingRepositoryApplyVideoRefund_BalanceRoundTrip(t *testing.T) {
 	})
 	account := mustCreateAccount(t, client, &service.Account{
 		Name: "video-refund-account-" + uuid.NewString(),
-		Type: service.AccountTypeAPIKey,
+		Type: domain.AccountTypeAPIKey,
 	})
 
 	// Forward charge (what video submit billing applies).
-	forward := &service.UsageBillingCommand{
+	forward := &domain.UsageBillingCommand{
 		RequestID:       "local:" + uuid.NewString(),
 		APIKeyID:        apiKey.ID,
 		UserID:          user.ID,
 		AccountID:       account.ID,
-		AccountType:     service.AccountTypeAPIKey,
+		AccountType:     domain.AccountTypeAPIKey,
 		BalanceCost:     0.87,
 		APIKeyQuotaCost: 0.87,
 	}
@@ -117,15 +118,15 @@ func TestUsageBillingRepositoryApplyVideoRefund_ReactivatesExhaustedKey(t *testi
 	})
 	account := mustCreateAccount(t, client, &service.Account{
 		Name: "video-refund-exhaust-account-" + uuid.NewString(),
-		Type: service.AccountTypeAPIKey,
+		Type: domain.AccountTypeAPIKey,
 	})
 
-	forward := &service.UsageBillingCommand{
+	forward := &domain.UsageBillingCommand{
 		RequestID:       "local:" + uuid.NewString(),
 		APIKeyID:        apiKey.ID,
 		UserID:          user.ID,
 		AccountID:       account.ID,
-		AccountType:     service.AccountTypeAPIKey,
+		AccountType:     domain.AccountTypeAPIKey,
 		BalanceCost:     1.25,
 		APIKeyQuotaCost: 1.25, // > quota 1 → exhausts the key
 	}

--- a/backend/internal/repository/usage_billing_repo_unit_test.go
+++ b/backend/internal/repository/usage_billing_repo_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -83,7 +84,7 @@ func TestApplyUsageBillingEffects_FlagsBalanceOverdraft(t *testing.T) {
 	mock.ExpectCommit()
 
 	result := &service.UsageBillingApplyResult{Applied: true}
-	err = (&usageBillingRepository{}).applyUsageBillingEffects(ctx, tx, &service.UsageBillingCommand{
+	err = (&usageBillingRepository{}).applyUsageBillingEffects(ctx, tx, &domain.UsageBillingCommand{
 		UserID:      42,
 		BalanceCost: 10,
 	}, result)
@@ -113,7 +114,7 @@ func TestDeductUsageBillingBalance_ReturnsUserNotFoundWhenNoUserUpdated(t *testi
 	mock.ExpectRollback()
 
 	_, _, err = deductUsageBillingBalance(ctx, tx, 42, 10)
-	require.ErrorIs(t, err, service.ErrUserNotFound)
+	require.ErrorIs(t, err, domain.ErrUserNotFound)
 	require.NoError(t, tx.Rollback())
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/backend/internal/repository/usage_cleanup_repo.go
+++ b/backend/internal/repository/usage_cleanup_repo.go
@@ -11,6 +11,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	dbusagecleanuptask "github.com/Wei-Shaw/sub2api/ent/usagecleanuptask"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
@@ -28,7 +29,7 @@ func newUsageCleanupRepositoryWithSQL(client *dbent.Client, sqlq sqlExecutor) *u
 	return &usageCleanupRepository{client: client, sql: sqlq}
 }
 
-func (r *usageCleanupRepository) CreateTask(ctx context.Context, task *service.UsageCleanupTask) error {
+func (r *usageCleanupRepository) CreateTask(ctx context.Context, task *domain.UsageCleanupTask) error {
 	if task == nil {
 		return nil
 	}
@@ -38,7 +39,7 @@ func (r *usageCleanupRepository) CreateTask(ctx context.Context, task *service.U
 	return r.createTaskWithSQL(ctx, task)
 }
 
-func (r *usageCleanupRepository) ListTasks(ctx context.Context, params pagination.PaginationParams) ([]service.UsageCleanupTask, *pagination.PaginationResult, error) {
+func (r *usageCleanupRepository) ListTasks(ctx context.Context, params pagination.PaginationParams) ([]domain.UsageCleanupTask, *pagination.PaginationResult, error) {
 	if r.client != nil {
 		return r.listTasksWithEnt(ctx, params)
 	}
@@ -47,7 +48,7 @@ func (r *usageCleanupRepository) ListTasks(ctx context.Context, params paginatio
 		return nil, nil, err
 	}
 	if total == 0 {
-		return []service.UsageCleanupTask{}, paginationResultFromTotal(0, params), nil
+		return []domain.UsageCleanupTask{}, paginationResultFromTotal(0, params), nil
 	}
 
 	query := `
@@ -64,9 +65,9 @@ func (r *usageCleanupRepository) ListTasks(ctx context.Context, params paginatio
 	}
 	defer func() { _ = rows.Close() }()
 
-	tasks := make([]service.UsageCleanupTask, 0)
+	tasks := make([]domain.UsageCleanupTask, 0)
 	for rows.Next() {
-		var task service.UsageCleanupTask
+		var task domain.UsageCleanupTask
 		var filtersJSON []byte
 		var errMsg sql.NullString
 		var canceledBy sql.NullInt64
@@ -116,7 +117,7 @@ func (r *usageCleanupRepository) ListTasks(ctx context.Context, params paginatio
 	return tasks, paginationResultFromTotal(total, params), nil
 }
 
-func (r *usageCleanupRepository) ClaimNextPendingTask(ctx context.Context, staleRunningAfterSeconds int64) (*service.UsageCleanupTask, error) {
+func (r *usageCleanupRepository) ClaimNextPendingTask(ctx context.Context, staleRunningAfterSeconds int64) (*domain.UsageCleanupTask, error) {
 	if staleRunningAfterSeconds <= 0 {
 		staleRunningAfterSeconds = 1800
 	}
@@ -145,7 +146,7 @@ func (r *usageCleanupRepository) ClaimNextPendingTask(ctx context.Context, stale
 		RETURNING tasks.id, tasks.status, tasks.filters, tasks.created_by, tasks.deleted_rows, tasks.error_message,
 			tasks.started_at, tasks.finished_at, tasks.created_at, tasks.updated_at
 	`
-	var task service.UsageCleanupTask
+	var task domain.UsageCleanupTask
 	var filtersJSON []byte
 	var errMsg sql.NullString
 	var startedAt sql.NullTime
@@ -155,10 +156,10 @@ func (r *usageCleanupRepository) ClaimNextPendingTask(ctx context.Context, stale
 		r.sql,
 		query,
 		[]any{
-			service.UsageCleanupStatusPending,
-			service.UsageCleanupStatusRunning,
+			domain.UsageCleanupStatusPending,
+			domain.UsageCleanupStatusRunning,
 			staleRunningAfterSeconds,
-			service.UsageCleanupStatusRunning,
+			domain.UsageCleanupStatusRunning,
 		},
 		&task.ID,
 		&task.Status,
@@ -234,11 +235,11 @@ func (r *usageCleanupRepository) CancelTask(ctx context.Context, taskID int64, c
 	`
 	var id int64
 	err := scanSingleRow(ctx, r.sql, query, []any{
-		service.UsageCleanupStatusCanceled,
+		domain.UsageCleanupStatusCanceled,
 		taskID,
 		canceledBy,
-		service.UsageCleanupStatusPending,
-		service.UsageCleanupStatusRunning,
+		domain.UsageCleanupStatusPending,
+		domain.UsageCleanupStatusRunning,
 	}, &id)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
@@ -261,7 +262,7 @@ func (r *usageCleanupRepository) MarkTaskSucceeded(ctx context.Context, taskID i
 			updated_at = NOW()
 		WHERE id = $3
 	`
-	_, err := r.sql.ExecContext(ctx, query, service.UsageCleanupStatusSucceeded, deletedRows, taskID)
+	_, err := r.sql.ExecContext(ctx, query, domain.UsageCleanupStatusSucceeded, deletedRows, taskID)
 	return err
 }
 
@@ -278,11 +279,11 @@ func (r *usageCleanupRepository) MarkTaskFailed(ctx context.Context, taskID int6
 			updated_at = NOW()
 		WHERE id = $4
 	`
-	_, err := r.sql.ExecContext(ctx, query, service.UsageCleanupStatusFailed, deletedRows, errorMsg, taskID)
+	_, err := r.sql.ExecContext(ctx, query, domain.UsageCleanupStatusFailed, deletedRows, errorMsg, taskID)
 	return err
 }
 
-func (r *usageCleanupRepository) DeleteUsageLogsBatch(ctx context.Context, filters service.UsageCleanupFilters, limit int) (int64, error) {
+func (r *usageCleanupRepository) DeleteUsageLogsBatch(ctx context.Context, filters domain.UsageCleanupFilters, limit int) (int64, error) {
 	if filters.StartTime.IsZero() || filters.EndTime.IsZero() {
 		return 0, fmt.Errorf("cleanup filters missing time range")
 	}
@@ -320,7 +321,7 @@ func (r *usageCleanupRepository) DeleteUsageLogsBatch(ctx context.Context, filte
 	return deleted, nil
 }
 
-func buildUsageCleanupWhere(filters service.UsageCleanupFilters) (string, []any) {
+func buildUsageCleanupWhere(filters domain.UsageCleanupFilters) (string, []any) {
 	conditions := make([]string, 0, 8)
 	args := make([]any, 0, 8)
 	idx := 1
@@ -379,7 +380,7 @@ func buildUsageCleanupWhere(filters service.UsageCleanupFilters) (string, []any)
 	return strings.Join(conditions, " AND "), args
 }
 
-func (r *usageCleanupRepository) createTaskWithEnt(ctx context.Context, task *service.UsageCleanupTask) error {
+func (r *usageCleanupRepository) createTaskWithEnt(ctx context.Context, task *domain.UsageCleanupTask) error {
 	client := clientFromContext(ctx, r.client)
 	filtersJSON, err := json.Marshal(task.Filters)
 	if err != nil {
@@ -401,7 +402,7 @@ func (r *usageCleanupRepository) createTaskWithEnt(ctx context.Context, task *se
 	return nil
 }
 
-func (r *usageCleanupRepository) createTaskWithSQL(ctx context.Context, task *service.UsageCleanupTask) error {
+func (r *usageCleanupRepository) createTaskWithSQL(ctx context.Context, task *domain.UsageCleanupTask) error {
 	filtersJSON, err := json.Marshal(task.Filters)
 	if err != nil {
 		return fmt.Errorf("marshal cleanup filters: %w", err)
@@ -421,7 +422,7 @@ func (r *usageCleanupRepository) createTaskWithSQL(ctx context.Context, task *se
 	return nil
 }
 
-func (r *usageCleanupRepository) listTasksWithEnt(ctx context.Context, params pagination.PaginationParams) ([]service.UsageCleanupTask, *pagination.PaginationResult, error) {
+func (r *usageCleanupRepository) listTasksWithEnt(ctx context.Context, params pagination.PaginationParams) ([]domain.UsageCleanupTask, *pagination.PaginationResult, error) {
 	client := clientFromContext(ctx, r.client)
 	query := client.UsageCleanupTask.Query()
 	total, err := query.Clone().Count(ctx)
@@ -429,7 +430,7 @@ func (r *usageCleanupRepository) listTasksWithEnt(ctx context.Context, params pa
 		return nil, nil, err
 	}
 	if total == 0 {
-		return []service.UsageCleanupTask{}, paginationResultFromTotal(0, params), nil
+		return []domain.UsageCleanupTask{}, paginationResultFromTotal(0, params), nil
 	}
 	rows, err := query.
 		Order(dbent.Desc(dbusagecleanuptask.FieldCreatedAt), dbent.Desc(dbusagecleanuptask.FieldID)).
@@ -439,7 +440,7 @@ func (r *usageCleanupRepository) listTasksWithEnt(ctx context.Context, params pa
 	if err != nil {
 		return nil, nil, err
 	}
-	tasks := make([]service.UsageCleanupTask, 0, len(rows))
+	tasks := make([]domain.UsageCleanupTask, 0, len(rows))
 	for _, row := range rows {
 		task, err := usageCleanupTaskFromEnt(row)
 		if err != nil {
@@ -481,9 +482,9 @@ func (r *usageCleanupRepository) cancelTaskWithEnt(ctx context.Context, taskID i
 	affected, err := client.UsageCleanupTask.Update().
 		Where(
 			dbusagecleanuptask.IDEQ(taskID),
-			dbusagecleanuptask.StatusIn(service.UsageCleanupStatusPending, service.UsageCleanupStatusRunning),
+			dbusagecleanuptask.StatusIn(domain.UsageCleanupStatusPending, domain.UsageCleanupStatusRunning),
 		).
-		SetStatus(service.UsageCleanupStatusCanceled).
+		SetStatus(domain.UsageCleanupStatusCanceled).
 		SetCanceledBy(canceledBy).
 		SetCanceledAt(now).
 		SetFinishedAt(now).
@@ -501,7 +502,7 @@ func (r *usageCleanupRepository) markTaskSucceededWithEnt(ctx context.Context, t
 	now := time.Now()
 	_, err := client.UsageCleanupTask.Update().
 		Where(dbusagecleanuptask.IDEQ(taskID)).
-		SetStatus(service.UsageCleanupStatusSucceeded).
+		SetStatus(domain.UsageCleanupStatusSucceeded).
 		SetDeletedRows(deletedRows).
 		SetFinishedAt(now).
 		SetUpdatedAt(now).
@@ -514,7 +515,7 @@ func (r *usageCleanupRepository) markTaskFailedWithEnt(ctx context.Context, task
 	now := time.Now()
 	_, err := client.UsageCleanupTask.Update().
 		Where(dbusagecleanuptask.IDEQ(taskID)).
-		SetStatus(service.UsageCleanupStatusFailed).
+		SetStatus(domain.UsageCleanupStatusFailed).
 		SetDeletedRows(deletedRows).
 		SetErrorMessage(errorMsg).
 		SetFinishedAt(now).
@@ -523,8 +524,8 @@ func (r *usageCleanupRepository) markTaskFailedWithEnt(ctx context.Context, task
 	return err
 }
 
-func usageCleanupTaskFromEnt(row *dbent.UsageCleanupTask) (service.UsageCleanupTask, error) {
-	task := service.UsageCleanupTask{
+func usageCleanupTaskFromEnt(row *dbent.UsageCleanupTask) (domain.UsageCleanupTask, error) {
+	task := domain.UsageCleanupTask{
 		ID:          row.ID,
 		Status:      row.Status,
 		CreatedBy:   row.CreatedBy,
@@ -534,7 +535,7 @@ func usageCleanupTaskFromEnt(row *dbent.UsageCleanupTask) (service.UsageCleanupT
 	}
 	if len(row.Filters) > 0 {
 		if err := json.Unmarshal(row.Filters, &task.Filters); err != nil {
-			return service.UsageCleanupTask{}, fmt.Errorf("parse cleanup filters: %w", err)
+			return domain.UsageCleanupTask{}, fmt.Errorf("parse cleanup filters: %w", err)
 		}
 	}
 	if row.ErrorMessage != nil {

--- a/backend/internal/repository/usage_cleanup_repo_ent_test.go
+++ b/backend/internal/repository/usage_cleanup_repo_ent_test.go
@@ -10,8 +10,8 @@ import (
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/enttest"
 	dbusagecleanuptask "github.com/Wei-Shaw/sub2api/ent/usagecleanuptask"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
-	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 
 	"entgo.io/ent/dialect"
@@ -42,17 +42,17 @@ func TestUsageCleanupRepositoryEntCreateAndList(t *testing.T) {
 
 	start := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
 	end := start.Add(24 * time.Hour)
-	task := &service.UsageCleanupTask{
-		Status:    service.UsageCleanupStatusPending,
-		Filters:   service.UsageCleanupFilters{StartTime: start, EndTime: end},
+	task := &domain.UsageCleanupTask{
+		Status:    domain.UsageCleanupStatusPending,
+		Filters:   domain.UsageCleanupFilters{StartTime: start, EndTime: end},
 		CreatedBy: 9,
 	}
 	require.NoError(t, repo.CreateTask(context.Background(), task))
 	require.NotZero(t, task.ID)
 
-	task2 := &service.UsageCleanupTask{
-		Status:    service.UsageCleanupStatusRunning,
-		Filters:   service.UsageCleanupFilters{StartTime: start.Add(-24 * time.Hour), EndTime: end.Add(-24 * time.Hour)},
+	task2 := &domain.UsageCleanupTask{
+		Status:    domain.UsageCleanupStatusRunning,
+		Filters:   domain.UsageCleanupFilters{StartTime: start.Add(-24 * time.Hour), EndTime: end.Add(-24 * time.Hour)},
 		CreatedBy: 10,
 	}
 	require.NoError(t, repo.CreateTask(context.Background(), task2))
@@ -78,16 +78,16 @@ func TestUsageCleanupRepositoryEntListEmpty(t *testing.T) {
 func TestUsageCleanupRepositoryEntGetStatusAndProgress(t *testing.T) {
 	repo, client := newUsageCleanupEntRepo(t)
 
-	task := &service.UsageCleanupTask{
-		Status:    service.UsageCleanupStatusPending,
-		Filters:   service.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
+	task := &domain.UsageCleanupTask{
+		Status:    domain.UsageCleanupStatusPending,
+		Filters:   domain.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
 		CreatedBy: 3,
 	}
 	require.NoError(t, repo.CreateTask(context.Background(), task))
 
 	status, err := repo.GetTaskStatus(context.Background(), task.ID)
 	require.NoError(t, err)
-	require.Equal(t, service.UsageCleanupStatusPending, status)
+	require.Equal(t, domain.UsageCleanupStatusPending, status)
 
 	_, err = repo.GetTaskStatus(context.Background(), task.ID+99)
 	require.ErrorIs(t, err, sql.ErrNoRows)
@@ -101,9 +101,9 @@ func TestUsageCleanupRepositoryEntGetStatusAndProgress(t *testing.T) {
 func TestUsageCleanupRepositoryEntCancelAndFinish(t *testing.T) {
 	repo, client := newUsageCleanupEntRepo(t)
 
-	task := &service.UsageCleanupTask{
-		Status:    service.UsageCleanupStatusPending,
-		Filters:   service.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
+	task := &domain.UsageCleanupTask{
+		Status:    domain.UsageCleanupStatusPending,
+		Filters:   domain.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
 		CreatedBy: 5,
 	}
 	require.NoError(t, repo.CreateTask(context.Background(), task))
@@ -114,12 +114,12 @@ func TestUsageCleanupRepositoryEntCancelAndFinish(t *testing.T) {
 
 	loaded, err := client.UsageCleanupTask.Get(context.Background(), task.ID)
 	require.NoError(t, err)
-	require.Equal(t, service.UsageCleanupStatusCanceled, loaded.Status)
+	require.Equal(t, domain.UsageCleanupStatusCanceled, loaded.Status)
 	require.NotNil(t, loaded.CanceledBy)
 	require.NotNil(t, loaded.CanceledAt)
 	require.NotNil(t, loaded.FinishedAt)
 
-	loaded.Status = service.UsageCleanupStatusSucceeded
+	loaded.Status = domain.UsageCleanupStatusSucceeded
 	_, err = client.UsageCleanupTask.Update().Where(dbusagecleanuptask.IDEQ(task.ID)).SetStatus(loaded.Status).Save(context.Background())
 	require.NoError(t, err)
 
@@ -131,9 +131,9 @@ func TestUsageCleanupRepositoryEntCancelAndFinish(t *testing.T) {
 func TestUsageCleanupRepositoryEntCancelError(t *testing.T) {
 	repo, client := newUsageCleanupEntRepo(t)
 
-	task := &service.UsageCleanupTask{
-		Status:    service.UsageCleanupStatusPending,
-		Filters:   service.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
+	task := &domain.UsageCleanupTask{
+		Status:    domain.UsageCleanupStatusPending,
+		Filters:   domain.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
 		CreatedBy: 5,
 	}
 	require.NoError(t, repo.CreateTask(context.Background(), task))
@@ -146,9 +146,9 @@ func TestUsageCleanupRepositoryEntCancelError(t *testing.T) {
 func TestUsageCleanupRepositoryEntMarkResults(t *testing.T) {
 	repo, client := newUsageCleanupEntRepo(t)
 
-	task := &service.UsageCleanupTask{
-		Status:    service.UsageCleanupStatusRunning,
-		Filters:   service.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
+	task := &domain.UsageCleanupTask{
+		Status:    domain.UsageCleanupStatusRunning,
+		Filters:   domain.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
 		CreatedBy: 12,
 	}
 	require.NoError(t, repo.CreateTask(context.Background(), task))
@@ -156,13 +156,13 @@ func TestUsageCleanupRepositoryEntMarkResults(t *testing.T) {
 	require.NoError(t, repo.MarkTaskSucceeded(context.Background(), task.ID, 6))
 	loaded, err := client.UsageCleanupTask.Get(context.Background(), task.ID)
 	require.NoError(t, err)
-	require.Equal(t, service.UsageCleanupStatusSucceeded, loaded.Status)
+	require.Equal(t, domain.UsageCleanupStatusSucceeded, loaded.Status)
 	require.Equal(t, int64(6), loaded.DeletedRows)
 	require.NotNil(t, loaded.FinishedAt)
 
-	task2 := &service.UsageCleanupTask{
-		Status:    service.UsageCleanupStatusRunning,
-		Filters:   service.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
+	task2 := &domain.UsageCleanupTask{
+		Status:    domain.UsageCleanupStatusRunning,
+		Filters:   domain.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
 		CreatedBy: 12,
 	}
 	require.NoError(t, repo.CreateTask(context.Background(), task2))
@@ -170,16 +170,16 @@ func TestUsageCleanupRepositoryEntMarkResults(t *testing.T) {
 	require.NoError(t, repo.MarkTaskFailed(context.Background(), task2.ID, 4, "boom"))
 	loaded2, err := client.UsageCleanupTask.Get(context.Background(), task2.ID)
 	require.NoError(t, err)
-	require.Equal(t, service.UsageCleanupStatusFailed, loaded2.Status)
+	require.Equal(t, domain.UsageCleanupStatusFailed, loaded2.Status)
 	require.Equal(t, "boom", *loaded2.ErrorMessage)
 }
 
 func TestUsageCleanupRepositoryEntInvalidStatus(t *testing.T) {
 	repo, _ := newUsageCleanupEntRepo(t)
 
-	task := &service.UsageCleanupTask{
+	task := &domain.UsageCleanupTask{
 		Status:    "invalid",
-		Filters:   service.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
+		Filters:   domain.UsageCleanupFilters{StartTime: time.Now().UTC(), EndTime: time.Now().UTC().Add(time.Hour)},
 		CreatedBy: 1,
 	}
 	require.Error(t, repo.CreateTask(context.Background(), task))
@@ -195,7 +195,7 @@ func TestUsageCleanupRepositoryEntListInvalidFilters(t *testing.T) {
 		context.Background(),
 		`INSERT INTO usage_cleanup_tasks (status, filters, created_by, deleted_rows, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?)`,
-		service.UsageCleanupStatusPending,
+		domain.UsageCleanupStatusPending,
 		[]byte("invalid-json"),
 		int64(1),
 		int64(0),
@@ -216,13 +216,13 @@ func TestUsageCleanupTaskFromEntFull(t *testing.T) {
 	canceledAt := start.Add(time.Minute)
 	startedAt := start.Add(2 * time.Minute)
 	finishedAt := start.Add(3 * time.Minute)
-	filters := service.UsageCleanupFilters{StartTime: start, EndTime: end}
+	filters := domain.UsageCleanupFilters{StartTime: start, EndTime: end}
 	filtersJSON, err := json.Marshal(filters)
 	require.NoError(t, err)
 
 	task, err := usageCleanupTaskFromEnt(&dbent.UsageCleanupTask{
 		ID:           10,
-		Status:       service.UsageCleanupStatusFailed,
+		Status:       domain.UsageCleanupStatusFailed,
 		Filters:      filtersJSON,
 		CreatedBy:    11,
 		DeletedRows:  7,
@@ -236,7 +236,7 @@ func TestUsageCleanupTaskFromEntFull(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(10), task.ID)
-	require.Equal(t, service.UsageCleanupStatusFailed, task.Status)
+	require.Equal(t, domain.UsageCleanupStatusFailed, task.Status)
 	require.NotNil(t, task.ErrorMsg)
 	require.NotNil(t, task.CanceledBy)
 	require.NotNil(t, task.CanceledAt)

--- a/backend/internal/repository/usage_cleanup_repo_test.go
+++ b/backend/internal/repository/usage_cleanup_repo_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
@@ -33,9 +34,9 @@ func TestUsageCleanupRepositoryCreateTask(t *testing.T) {
 
 	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(24 * time.Hour)
-	task := &service.UsageCleanupTask{
-		Status:    service.UsageCleanupStatusPending,
-		Filters:   service.UsageCleanupFilters{StartTime: start, EndTime: end},
+	task := &domain.UsageCleanupTask{
+		Status:    domain.UsageCleanupStatusPending,
+		Filters:   domain.UsageCleanupFilters{StartTime: start, EndTime: end},
 		CreatedBy: 12,
 	}
 	now := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -65,9 +66,9 @@ func TestUsageCleanupRepositoryCreateTaskQueryError(t *testing.T) {
 	db, mock := newSQLMock(t)
 	repo := &usageCleanupRepository{sql: db}
 
-	task := &service.UsageCleanupTask{
-		Status:    service.UsageCleanupStatusPending,
-		Filters:   service.UsageCleanupFilters{StartTime: time.Now(), EndTime: time.Now().Add(time.Hour)},
+	task := &domain.UsageCleanupTask{
+		Status:    domain.UsageCleanupStatusPending,
+		Filters:   domain.UsageCleanupFilters{StartTime: time.Now(), EndTime: time.Now().Add(time.Hour)},
 		CreatedBy: 1,
 	}
 
@@ -100,7 +101,7 @@ func TestUsageCleanupRepositoryListTasks(t *testing.T) {
 
 	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(2 * time.Hour)
-	filters := service.UsageCleanupFilters{StartTime: start, EndTime: end}
+	filters := domain.UsageCleanupFilters{StartTime: start, EndTime: end}
 	filtersJSON, err := json.Marshal(filters)
 	require.NoError(t, err)
 
@@ -112,7 +113,7 @@ func TestUsageCleanupRepositoryListTasks(t *testing.T) {
 		"started_at", "finished_at", "created_at", "updated_at",
 	}).AddRow(
 		int64(1),
-		service.UsageCleanupStatusSucceeded,
+		domain.UsageCleanupStatusSucceeded,
 		filtersJSON,
 		int64(2),
 		int64(9),
@@ -135,7 +136,7 @@ func TestUsageCleanupRepositoryListTasks(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, tasks, 1)
 	require.Equal(t, int64(1), tasks[0].ID)
-	require.Equal(t, service.UsageCleanupStatusSucceeded, tasks[0].Status)
+	require.Equal(t, domain.UsageCleanupStatusSucceeded, tasks[0].Status)
 	require.Equal(t, int64(2), tasks[0].CreatedBy)
 	require.Equal(t, int64(9), tasks[0].DeletedRows)
 	require.NotNil(t, tasks[0].ErrorMsg)
@@ -171,7 +172,7 @@ func TestUsageCleanupRepositoryListTasksInvalidFilters(t *testing.T) {
 		"started_at", "finished_at", "created_at", "updated_at",
 	}).AddRow(
 		int64(1),
-		service.UsageCleanupStatusSucceeded,
+		domain.UsageCleanupStatusSucceeded,
 		[]byte("not-json"),
 		int64(2),
 		int64(9),
@@ -200,7 +201,7 @@ func TestUsageCleanupRepositoryClaimNextPendingTaskNone(t *testing.T) {
 	repo := &usageCleanupRepository{sql: db}
 
 	mock.ExpectQuery("UPDATE usage_cleanup_tasks").
-		WithArgs(service.UsageCleanupStatusPending, service.UsageCleanupStatusRunning, int64(1800), service.UsageCleanupStatusRunning).
+		WithArgs(domain.UsageCleanupStatusPending, domain.UsageCleanupStatusRunning, int64(1800), domain.UsageCleanupStatusRunning).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "status", "filters", "created_by", "deleted_rows", "error_message",
 			"started_at", "finished_at", "created_at", "updated_at",
@@ -218,7 +219,7 @@ func TestUsageCleanupRepositoryClaimNextPendingTask(t *testing.T) {
 
 	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(24 * time.Hour)
-	filters := service.UsageCleanupFilters{StartTime: start, EndTime: end}
+	filters := domain.UsageCleanupFilters{StartTime: start, EndTime: end}
 	filtersJSON, err := json.Marshal(filters)
 	require.NoError(t, err)
 
@@ -227,7 +228,7 @@ func TestUsageCleanupRepositoryClaimNextPendingTask(t *testing.T) {
 		"started_at", "finished_at", "created_at", "updated_at",
 	}).AddRow(
 		int64(4),
-		service.UsageCleanupStatusRunning,
+		domain.UsageCleanupStatusRunning,
 		filtersJSON,
 		int64(7),
 		int64(0),
@@ -239,14 +240,14 @@ func TestUsageCleanupRepositoryClaimNextPendingTask(t *testing.T) {
 	)
 
 	mock.ExpectQuery("UPDATE usage_cleanup_tasks").
-		WithArgs(service.UsageCleanupStatusPending, service.UsageCleanupStatusRunning, int64(1800), service.UsageCleanupStatusRunning).
+		WithArgs(domain.UsageCleanupStatusPending, domain.UsageCleanupStatusRunning, int64(1800), domain.UsageCleanupStatusRunning).
 		WillReturnRows(rows)
 
 	task, err := repo.ClaimNextPendingTask(context.Background(), 1800)
 	require.NoError(t, err)
 	require.NotNil(t, task)
 	require.Equal(t, int64(4), task.ID)
-	require.Equal(t, service.UsageCleanupStatusRunning, task.Status)
+	require.Equal(t, domain.UsageCleanupStatusRunning, task.Status)
 	require.Equal(t, int64(7), task.CreatedBy)
 	require.NotNil(t, task.StartedAt)
 	require.Nil(t, task.ErrorMsg)
@@ -258,7 +259,7 @@ func TestUsageCleanupRepositoryClaimNextPendingTaskError(t *testing.T) {
 	repo := &usageCleanupRepository{sql: db}
 
 	mock.ExpectQuery("UPDATE usage_cleanup_tasks").
-		WithArgs(service.UsageCleanupStatusPending, service.UsageCleanupStatusRunning, int64(1800), service.UsageCleanupStatusRunning).
+		WithArgs(domain.UsageCleanupStatusPending, domain.UsageCleanupStatusRunning, int64(1800), domain.UsageCleanupStatusRunning).
 		WillReturnError(sql.ErrConnDone)
 
 	_, err := repo.ClaimNextPendingTask(context.Background(), 1800)
@@ -275,7 +276,7 @@ func TestUsageCleanupRepositoryClaimNextPendingTaskInvalidFilters(t *testing.T) 
 		"started_at", "finished_at", "created_at", "updated_at",
 	}).AddRow(
 		int64(4),
-		service.UsageCleanupStatusRunning,
+		domain.UsageCleanupStatusRunning,
 		[]byte("invalid"),
 		int64(7),
 		int64(0),
@@ -287,7 +288,7 @@ func TestUsageCleanupRepositoryClaimNextPendingTaskInvalidFilters(t *testing.T) 
 	)
 
 	mock.ExpectQuery("UPDATE usage_cleanup_tasks").
-		WithArgs(service.UsageCleanupStatusPending, service.UsageCleanupStatusRunning, int64(1800), service.UsageCleanupStatusRunning).
+		WithArgs(domain.UsageCleanupStatusPending, domain.UsageCleanupStatusRunning, int64(1800), domain.UsageCleanupStatusRunning).
 		WillReturnRows(rows)
 
 	_, err := repo.ClaimNextPendingTask(context.Background(), 1800)
@@ -300,7 +301,7 @@ func TestUsageCleanupRepositoryMarkTaskSucceeded(t *testing.T) {
 	repo := &usageCleanupRepository{sql: db}
 
 	mock.ExpectExec("UPDATE usage_cleanup_tasks").
-		WithArgs(service.UsageCleanupStatusSucceeded, int64(12), int64(9)).
+		WithArgs(domain.UsageCleanupStatusSucceeded, int64(12), int64(9)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err := repo.MarkTaskSucceeded(context.Background(), 9, 12)
@@ -313,7 +314,7 @@ func TestUsageCleanupRepositoryMarkTaskFailed(t *testing.T) {
 	repo := &usageCleanupRepository{sql: db}
 
 	mock.ExpectExec("UPDATE usage_cleanup_tasks").
-		WithArgs(service.UsageCleanupStatusFailed, int64(4), "boom", int64(2)).
+		WithArgs(domain.UsageCleanupStatusFailed, int64(4), "boom", int64(2)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err := repo.MarkTaskFailed(context.Background(), 2, 4, "boom")
@@ -327,11 +328,11 @@ func TestUsageCleanupRepositoryGetTaskStatus(t *testing.T) {
 
 	mock.ExpectQuery("SELECT status FROM usage_cleanup_tasks").
 		WithArgs(int64(9)).
-		WillReturnRows(sqlmock.NewRows([]string{"status"}).AddRow(service.UsageCleanupStatusPending))
+		WillReturnRows(sqlmock.NewRows([]string{"status"}).AddRow(domain.UsageCleanupStatusPending))
 
 	status, err := repo.GetTaskStatus(context.Background(), 9)
 	require.NoError(t, err)
-	require.Equal(t, service.UsageCleanupStatusPending, status)
+	require.Equal(t, domain.UsageCleanupStatusPending, status)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -366,7 +367,7 @@ func TestUsageCleanupRepositoryCancelTask(t *testing.T) {
 	repo := &usageCleanupRepository{sql: db}
 
 	mock.ExpectQuery("UPDATE usage_cleanup_tasks").
-		WithArgs(service.UsageCleanupStatusCanceled, int64(6), int64(9), service.UsageCleanupStatusPending, service.UsageCleanupStatusRunning).
+		WithArgs(domain.UsageCleanupStatusCanceled, int64(6), int64(9), domain.UsageCleanupStatusPending, domain.UsageCleanupStatusRunning).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(6)))
 
 	ok, err := repo.CancelTask(context.Background(), 6, 9)
@@ -380,7 +381,7 @@ func TestUsageCleanupRepositoryCancelTaskNoRows(t *testing.T) {
 	repo := &usageCleanupRepository{sql: db}
 
 	mock.ExpectQuery("UPDATE usage_cleanup_tasks").
-		WithArgs(service.UsageCleanupStatusCanceled, int64(6), int64(9), service.UsageCleanupStatusPending, service.UsageCleanupStatusRunning).
+		WithArgs(domain.UsageCleanupStatusCanceled, int64(6), int64(9), domain.UsageCleanupStatusPending, domain.UsageCleanupStatusRunning).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
 	ok, err := repo.CancelTask(context.Background(), 6, 9)
@@ -393,7 +394,7 @@ func TestUsageCleanupRepositoryDeleteUsageLogsBatchMissingRange(t *testing.T) {
 	db, _ := newSQLMock(t)
 	repo := &usageCleanupRepository{sql: db}
 
-	_, err := repo.DeleteUsageLogsBatch(context.Background(), service.UsageCleanupFilters{}, 10)
+	_, err := repo.DeleteUsageLogsBatch(context.Background(), domain.UsageCleanupFilters{}, 10)
 	require.Error(t, err)
 }
 
@@ -405,7 +406,7 @@ func TestUsageCleanupRepositoryDeleteUsageLogsBatch(t *testing.T) {
 	end := start.Add(24 * time.Hour)
 	userID := int64(3)
 	model := " gpt-4 "
-	filters := service.UsageCleanupFilters{
+	filters := domain.UsageCleanupFilters{
 		StartTime: start,
 		EndTime:   end,
 		UserID:    &userID,
@@ -428,7 +429,7 @@ func TestUsageCleanupRepositoryDeleteUsageLogsBatchQueryError(t *testing.T) {
 
 	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(24 * time.Hour)
-	filters := service.UsageCleanupFilters{StartTime: start, EndTime: end}
+	filters := domain.UsageCleanupFilters{StartTime: start, EndTime: end}
 
 	mock.ExpectQuery("DELETE FROM usage_logs").
 		WithArgs(start, end, 5).
@@ -450,7 +451,7 @@ func TestBuildUsageCleanupWhere(t *testing.T) {
 	stream := true
 	billingType := int8(2)
 
-	where, args := buildUsageCleanupWhere(service.UsageCleanupFilters{
+	where, args := buildUsageCleanupWhere(domain.UsageCleanupFilters{
 		StartTime:   start,
 		EndTime:     end,
 		UserID:      &userID,
@@ -472,7 +473,7 @@ func TestBuildUsageCleanupWhereRequestTypePriority(t *testing.T) {
 	requestType := int16(service.RequestTypeWSV2)
 	stream := false
 
-	where, args := buildUsageCleanupWhere(service.UsageCleanupFilters{
+	where, args := buildUsageCleanupWhere(domain.UsageCleanupFilters{
 		StartTime:   start,
 		EndTime:     end,
 		RequestType: &requestType,
@@ -488,7 +489,7 @@ func TestBuildUsageCleanupWhereRequestTypeLegacyFallback(t *testing.T) {
 	end := start.Add(24 * time.Hour)
 	requestType := int16(service.RequestTypeStream)
 
-	where, args := buildUsageCleanupWhere(service.UsageCleanupFilters{
+	where, args := buildUsageCleanupWhere(domain.UsageCleanupFilters{
 		StartTime:   start,
 		EndTime:     end,
 		RequestType: &requestType,
@@ -503,7 +504,7 @@ func TestBuildUsageCleanupWhereModelEmpty(t *testing.T) {
 	end := start.Add(24 * time.Hour)
 	model := "   "
 
-	where, args := buildUsageCleanupWhere(service.UsageCleanupFilters{
+	where, args := buildUsageCleanupWhere(domain.UsageCleanupFilters{
 		StartTime: start,
 		EndTime:   end,
 		Model:     &model,

--- a/backend/internal/repository/usage_log_repo.go
+++ b/backend/internal/repository/usage_log_repo.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/ent/schema/mixins"
 	dbuser "github.com/Wei-Shaw/sub2api/ent/user"
 	dbusersub "github.com/Wei-Shaw/sub2api/ent/usersubscription"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
@@ -1479,7 +1480,7 @@ func (r *usageLogRepository) GetByID(ctx context.Context, id int64) (log *servic
 		if err = rows.Err(); err != nil {
 			return nil, err
 		}
-		return nil, service.ErrUsageLogNotFound
+		return nil, domain.ErrUsageLogNotFound
 	}
 	log, err = scanUsageLog(rows)
 	if err != nil {
@@ -1623,7 +1624,7 @@ func (r *usageLogRepository) fillDashboardEntityStats(ctx context.Context, stats
 		ctx,
 		r.sql,
 		apiKeyStatsQuery,
-		[]any{service.StatusActive},
+		[]any{domain.StatusActive},
 		&stats.TotalAPIKeys,
 		&stats.ActiveAPIKeys,
 	); err != nil {
@@ -1644,7 +1645,7 @@ func (r *usageLogRepository) fillDashboardEntityStats(ctx context.Context, stats
 		ctx,
 		r.sql,
 		accountStatsQuery,
-		[]any{service.StatusActive, service.StatusError, now, now},
+		[]any{domain.StatusActive, domain.StatusError, now, now},
 		&stats.TotalAccounts,
 		&stats.NormalAccounts,
 		&stats.ErrorAccounts,
@@ -2471,7 +2472,7 @@ func (r *usageLogRepository) GetUserDashboardStats(ctx context.Context, userID i
 		ctx,
 		r.sql,
 		"SELECT COUNT(*) FROM api_keys WHERE user_id = $1 AND status = $2 AND deleted_at IS NULL",
-		[]any{userID, service.StatusActive},
+		[]any{userID, domain.StatusActive},
 		&stats.ActiveAPIKeys,
 	); err != nil {
 		return nil, err

--- a/backend/internal/repository/usage_log_repo_integration_test.go
+++ b/backend/internal/repository/usage_log_repo_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
@@ -800,11 +801,11 @@ func (s *UsageLogRepoSuite) TestDashboardStats_TodayTotalsAndPerformance() {
 
 	group := mustCreateGroup(s.T(), s.client, &service.Group{Name: "g-ul"})
 	apiKey1 := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: userToday.ID, Key: "sk-ul-1", Name: "ul1"})
-	mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: userOld.ID, Key: "sk-ul-2", Name: "ul2", Status: service.StatusDisabled})
+	mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: userOld.ID, Key: "sk-ul-2", Name: "ul2", Status: domain.StatusDisabled})
 
 	resetAt := now.Add(10 * time.Minute)
 	accNormal := mustCreateAccount(s.T(), s.client, &service.Account{Name: "a-normal", Schedulable: true})
-	mustCreateAccount(s.T(), s.client, &service.Account{Name: "a-error", Status: service.StatusError, Schedulable: true})
+	mustCreateAccount(s.T(), s.client, &service.Account{Name: "a-error", Status: domain.StatusError, Schedulable: true})
 	mustCreateAccount(s.T(), s.client, &service.Account{Name: "a-rl", RateLimitedAt: &now, RateLimitResetAt: &resetAt, Schedulable: true})
 	mustCreateAccount(s.T(), s.client, &service.Account{Name: "a-ov", OverloadUntil: &resetAt, Schedulable: true})
 

--- a/backend/internal/repository/usage_log_repo_tk_group_rollup_integration_test.go
+++ b/backend/internal/repository/usage_log_repo_tk_group_rollup_integration_test.go
@@ -5,6 +5,7 @@ package repository
 import (
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -66,9 +67,9 @@ func (s *UsageLogRepoSuite) TestGroupRollupParity_EqualsLegacyRawScan() {
 
 	user := mustCreateUser(s.T(), s.client, &service.User{Email: "grp-rollup@test.com"})
 	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-grp-rollup", Name: "k"})
-	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "grp-rollup-acc", Platform: service.PlatformAnthropic})
-	grpA := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-rollup-A", Platform: service.PlatformAnthropic})
-	grpB := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-rollup-B", Platform: service.PlatformOpenAI})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "grp-rollup-acc", Platform: domain.PlatformAnthropic})
+	grpA := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-rollup-A", Platform: domain.PlatformAnthropic})
+	grpB := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-rollup-B", Platform: domain.PlatformOpenAI})
 
 	// group A: day5 0.50, day2 0.30, today 0.10 -> total 0.90, today 0.10
 	s.rollupParityCreateLog(user, key, acc, grpA.ID, 10, 20, 0, 0, 0.50, day5)
@@ -127,9 +128,9 @@ func (s *UsageLogRepoSuite) TestGroupStatsRollupParity_EqualsLegacyRawScanWithUn
 
 	user := mustCreateUser(s.T(), s.client, &service.User{Email: "grp-stats-rollup@test.com"})
 	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-grp-stats-rollup", Name: "k"})
-	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "grp-stats-rollup-acc", Platform: service.PlatformAnthropic})
-	grpA := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-stats-rollup-A", Platform: service.PlatformAnthropic})
-	grpB := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-stats-rollup-B", Platform: service.PlatformOpenAI})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "grp-stats-rollup-acc", Platform: domain.PlatformAnthropic})
+	grpA := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-stats-rollup-A", Platform: domain.PlatformAnthropic})
+	grpB := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-stats-rollup-B", Platform: domain.PlatformOpenAI})
 
 	// Real groups across completed days + today's raw tail.
 	s.rollupParityCreateLog(user, key, acc, grpA.ID, 10, 20, 0, 0, 0.50, day5)
@@ -192,8 +193,8 @@ func (s *UsageLogRepoSuite) TestGroupStatsRollupWaitsForMetricsBackfill() {
 
 	user := mustCreateUser(s.T(), s.client, &service.User{Email: "grp-stats-metrics-backfill@test.com"})
 	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-grp-stats-metrics-backfill", Name: "k"})
-	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "grp-stats-metrics-backfill-acc", Platform: service.PlatformAnthropic})
-	grp := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-stats-metrics-backfill", Platform: service.PlatformAnthropic})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "grp-stats-metrics-backfill-acc", Platform: domain.PlatformAnthropic})
+	grp := mustCreateGroup(s.T(), s.client, &service.Group{Name: "grp-stats-metrics-backfill", Platform: domain.PlatformAnthropic})
 	s.rollupParityCreateLog(user, key, acc, grp.ID, 11, 13, 2, 3, 0.42, day5)
 
 	// Simulate an old deployment: tk_038's historical cost backfill marker exists

--- a/backend/internal/repository/usage_log_repo_tk_model_rollup_integration_test.go
+++ b/backend/internal/repository/usage_log_repo_tk_model_rollup_integration_test.go
@@ -5,6 +5,7 @@ package repository
 import (
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
@@ -59,7 +60,7 @@ func (s *UsageLogRepoSuite) TestModelStatsRollupWaitsForBackfillMarkerAndMatches
 
 	user := mustCreateUser(s.T(), s.client, &service.User{Email: "model-rollup@test.com"})
 	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-model-rollup", Name: "k"})
-	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "model-rollup-acc", Platform: service.PlatformAnthropic})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "model-rollup-acc", Platform: domain.PlatformAnthropic})
 
 	s.modelRollupParityCreateLog(user, key, acc, "claude-sonnet-4-6", "upstream-sonnet", 10, 20, 1, 2, 0.50, day5)
 	s.modelRollupParityCreateLog(user, key, acc, "claude-opus-4-6", "upstream-opus", 2, 3, 0, 1, 0.20, day2)

--- a/backend/internal/repository/usage_log_repo_tk_user_platform_rollup_integration_test.go
+++ b/backend/internal/repository/usage_log_repo_tk_user_platform_rollup_integration_test.go
@@ -5,6 +5,7 @@ package repository
 import (
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -64,11 +65,11 @@ func (s *UsageLogRepoSuite) TestRollupParity_BatchAndRanking() {
 	user2 := mustCreateUser(s.T(), s.client, &service.User{Email: "rollup-u2@test.com"})
 	key1 := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user1.ID, Key: "sk-rollup-1", Name: "k"})
 	key2 := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user2.ID, Key: "sk-rollup-2", Name: "k"})
-	accAnthropic := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-acc-anthropic", Platform: service.PlatformAnthropic})
-	accOpenAI := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-acc-openai", Platform: service.PlatformOpenAI})
+	accAnthropic := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-acc-anthropic", Platform: domain.PlatformAnthropic})
+	accOpenAI := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-acc-openai", Platform: domain.PlatformOpenAI})
 	// Anthropic account, but the group platform is openai -> COALESCE must report openai.
-	grpAnthropic := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-grp-anthropic", Platform: service.PlatformAnthropic})
-	grpOpenAI := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-grp-openai", Platform: service.PlatformOpenAI})
+	grpAnthropic := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-grp-anthropic", Platform: domain.PlatformAnthropic})
+	grpOpenAI := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-grp-openai", Platform: domain.PlatformOpenAI})
 
 	// user1, anthropic platform:
 	//   day5: 0.50 (10/20 tok), day2: 0.30 (10/20), today: 0.10 (10/20)
@@ -99,17 +100,17 @@ func (s *UsageLogRepoSuite) TestRollupParity_BatchAndRanking() {
 	s.InDelta(1.30, stats[user1.ID].TotalActualCost, 1e-9)
 	s.InDelta(0.10, stats[user1.ID].TodayActualCost, 1e-9)
 	b1 := indexByPlatform(stats[user1.ID].ByPlatform)
-	s.InDelta(0.90, b1[service.PlatformAnthropic].TotalActualCost, 1e-9) // 0.50+0.30+0.10
-	s.InDelta(0.10, b1[service.PlatformAnthropic].TodayActualCost, 1e-9)
-	s.InDelta(0.40, b1[service.PlatformOpenAI].TotalActualCost, 1e-9, "COALESCE(g.platform,a.platform) override -> openai")
-	s.InDelta(0.00, b1[service.PlatformOpenAI].TodayActualCost, 1e-9)
+	s.InDelta(0.90, b1[domain.PlatformAnthropic].TotalActualCost, 1e-9) // 0.50+0.30+0.10
+	s.InDelta(0.10, b1[domain.PlatformAnthropic].TodayActualCost, 1e-9)
+	s.InDelta(0.40, b1[domain.PlatformOpenAI].TotalActualCost, 1e-9, "COALESCE(g.platform,a.platform) override -> openai")
+	s.InDelta(0.00, b1[domain.PlatformOpenAI].TodayActualCost, 1e-9)
 
 	// user2 total: 0.70+0.20 = 0.90; today 0.20; openai only
 	s.InDelta(0.90, stats[user2.ID].TotalActualCost, 1e-9)
 	s.InDelta(0.20, stats[user2.ID].TodayActualCost, 1e-9)
 	b2 := indexByPlatform(stats[user2.ID].ByPlatform)
-	s.InDelta(0.90, b2[service.PlatformOpenAI].TotalActualCost, 1e-9)
-	s.InDelta(0.20, b2[service.PlatformOpenAI].TodayActualCost, 1e-9)
+	s.InDelta(0.90, b2[domain.PlatformOpenAI].TotalActualCost, 1e-9)
+	s.InDelta(0.20, b2[domain.PlatformOpenAI].TodayActualCost, 1e-9)
 
 	// --- GetBatchUserUsageStats: narrow today-only window ---
 	narrow, err := s.repo.GetBatchUserUsageStats(s.ctx, []int64{user1.ID, user2.ID}, today, now.Add(time.Hour))
@@ -155,8 +156,8 @@ func (s *UsageLogRepoSuite) TestRollupParity_EqualsLegacyRawScan() {
 	today := timezone.Today()
 	user := mustCreateUser(s.T(), s.client, &service.User{Email: "rollup-legacy@test.com"})
 	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-rollup-legacy", Name: "k"})
-	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-legacy-acc", Platform: service.PlatformAnthropic})
-	grp := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-legacy-grp", Platform: service.PlatformAnthropic})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-legacy-acc", Platform: domain.PlatformAnthropic})
+	grp := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-legacy-grp", Platform: domain.PlatformAnthropic})
 
 	// Spread rows across 4 completed days; the rollup must equal the raw window sum.
 	for d := 1; d <= 4; d++ {
@@ -211,8 +212,8 @@ func (s *UsageLogRepoSuite) TestRollupParity_ColdStartPartialCoverage() {
 	today := timezone.Today()
 	user := mustCreateUser(s.T(), s.client, &service.User{Email: "rollup-coldstart@test.com"})
 	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-rollup-coldstart", Name: "k"})
-	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-coldstart-acc", Platform: service.PlatformAnthropic})
-	grp := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-coldstart-grp", Platform: service.PlatformAnthropic})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-coldstart-acc", Platform: domain.PlatformAnthropic})
+	grp := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-coldstart-grp", Platform: domain.PlatformAnthropic})
 
 	// Raw rows across 10 completed days.
 	for d := 1; d <= 10; d++ {
@@ -270,8 +271,8 @@ func (s *UsageLogRepoSuite) TestRollupParity_EmptyEffectivePlatform() {
 	today := timezone.Today()
 	user := mustCreateUser(s.T(), s.client, &service.User{Email: "rollup-empty@test.com"})
 	key := mustCreateApiKey(s.T(), s.client, &service.APIKey{UserID: user.ID, Key: "sk-rollup-empty", Name: "k"})
-	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-empty-acc", Platform: service.PlatformAnthropic})
-	grp := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-empty-grp", Platform: service.PlatformAnthropic})
+	acc := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rollup-empty-acc", Platform: domain.PlatformAnthropic})
+	grp := mustCreateGroup(s.T(), s.client, &service.Group{Name: "rollup-empty-grp", Platform: domain.PlatformAnthropic})
 
 	// Force both platforms empty so COALESCE(NULLIF(g.platform,''), a.platform) = ''.
 	_, err := s.repo.sql.ExecContext(s.ctx, "UPDATE accounts SET platform = '' WHERE id = $1", acc.ID)

--- a/backend/internal/repository/user_attribute_repo.go
+++ b/backend/internal/repository/user_attribute_repo.go
@@ -6,6 +6,7 @@ import (
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/userattributedefinition"
 	"github.com/Wei-Shaw/sub2api/ent/userattributevalue"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -35,7 +36,7 @@ func (r *userAttributeDefinitionRepository) Create(ctx context.Context, def *ser
 		Save(ctx)
 
 	if err != nil {
-		return translatePersistenceError(err, nil, service.ErrAttributeKeyExists)
+		return translatePersistenceError(err, nil, domain.ErrAttributeKeyExists)
 	}
 
 	def.ID = created.ID
@@ -52,7 +53,7 @@ func (r *userAttributeDefinitionRepository) GetByID(ctx context.Context, id int6
 		Where(userattributedefinition.IDEQ(id)).
 		Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrAttributeDefinitionNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrAttributeDefinitionNotFound, nil)
 	}
 	return defEntityToService(e), nil
 }
@@ -64,7 +65,7 @@ func (r *userAttributeDefinitionRepository) GetByKey(ctx context.Context, key st
 		Where(userattributedefinition.KeyEQ(key)).
 		Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrAttributeDefinitionNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrAttributeDefinitionNotFound, nil)
 	}
 	return defEntityToService(e), nil
 }
@@ -85,7 +86,7 @@ func (r *userAttributeDefinitionRepository) Update(ctx context.Context, def *ser
 		Save(ctx)
 
 	if err != nil {
-		return translatePersistenceError(err, service.ErrAttributeDefinitionNotFound, service.ErrAttributeKeyExists)
+		return translatePersistenceError(err, domain.ErrAttributeDefinitionNotFound, domain.ErrAttributeKeyExists)
 	}
 
 	def.UpdatedAt = updated.UpdatedAt
@@ -98,7 +99,7 @@ func (r *userAttributeDefinitionRepository) Delete(ctx context.Context, id int64
 	_, err := client.UserAttributeDefinition.Delete().
 		Where(userattributedefinition.IDEQ(id)).
 		Exec(ctx)
-	return translatePersistenceError(err, service.ErrAttributeDefinitionNotFound, nil)
+	return translatePersistenceError(err, domain.ErrAttributeDefinitionNotFound, nil)
 }
 
 func (r *userAttributeDefinitionRepository) List(ctx context.Context, enabledOnly bool) ([]service.UserAttributeDefinition, error) {
@@ -132,7 +133,7 @@ func (r *userAttributeDefinitionRepository) UpdateDisplayOrders(ctx context.Cont
 		if _, err := tx.UserAttributeDefinition.UpdateOneID(id).
 			SetDisplayOrder(order).
 			Save(ctx); err != nil {
-			return translatePersistenceError(err, service.ErrAttributeDefinitionNotFound, nil)
+			return translatePersistenceError(err, domain.ErrAttributeDefinitionNotFound, nil)
 		}
 	}
 

--- a/backend/internal/repository/user_platform_quota_service_adapter.go
+++ b/backend/internal/repository/user_platform_quota_service_adapter.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
 // userPlatformQuotaServiceAdapter 将 repository 层的 userPlatformQuotaRepository
-// 适配为 service.UserPlatformQuotaRepository 接口（返回 *service.UserPlatformQuotaRecord）。
+// 适配为 service.UserPlatformQuotaRepository 接口（返回 *domain.UserPlatformQuotaRecord）。
 type userPlatformQuotaServiceAdapter struct {
 	inner *userPlatformQuotaRepository
 }
@@ -26,7 +27,7 @@ func NewUserPlatformQuotaServiceAdapter(repo UserPlatformQuotaRepository) servic
 	return &userPlatformQuotaServiceAdapter{inner: impl}
 }
 
-func (a *userPlatformQuotaServiceAdapter) GetByUserPlatform(ctx context.Context, userID int64, platform string) (*service.UserPlatformQuotaRecord, error) {
+func (a *userPlatformQuotaServiceAdapter) GetByUserPlatform(ctx context.Context, userID int64, platform string) (*domain.UserPlatformQuotaRecord, error) {
 	rec, err := a.inner.GetByUserPlatform(ctx, userID, platform)
 	if err != nil || rec == nil {
 		return nil, err
@@ -40,14 +41,14 @@ func (a *userPlatformQuotaServiceAdapter) IncrementUsageWithReset(ctx context.Co
 }
 
 // ListByUser 查询用户的所有平台配额记录。
-func (a *userPlatformQuotaServiceAdapter) ListByUser(ctx context.Context, userID int64) ([]service.UserPlatformQuotaRecord, error) {
+func (a *userPlatformQuotaServiceAdapter) ListByUser(ctx context.Context, userID int64) ([]domain.UserPlatformQuotaRecord, error) {
 	rows, err := a.inner.ListByUser(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]service.UserPlatformQuotaRecord, len(rows))
+	out := make([]domain.UserPlatformQuotaRecord, len(rows))
 	for i, r := range rows {
-		out[i] = service.UserPlatformQuotaRecord{
+		out[i] = domain.UserPlatformQuotaRecord{
 			UserID:             r.UserID,
 			Platform:           r.Platform,
 			DailyLimitUSD:      r.DailyLimitUSD,
@@ -64,8 +65,8 @@ func (a *userPlatformQuotaServiceAdapter) ListByUser(ctx context.Context, userID
 	return out, nil
 }
 
-// BulkInsertInitial 将 service.UserPlatformQuotaRecord 切片转换后调用底层 repo。
-func (a *userPlatformQuotaServiceAdapter) BulkInsertInitial(ctx context.Context, records []service.UserPlatformQuotaRecord) error {
+// BulkInsertInitial 将 domain.UserPlatformQuotaRecord 切片转换后调用底层 repo。
+func (a *userPlatformQuotaServiceAdapter) BulkInsertInitial(ctx context.Context, records []domain.UserPlatformQuotaRecord) error {
 	repoRecords := make([]UserPlatformQuotaRecord, len(records))
 	for i, r := range records {
 		repoRecords[i] = UserPlatformQuotaRecord{
@@ -80,7 +81,7 @@ func (a *userPlatformQuotaServiceAdapter) BulkInsertInitial(ctx context.Context,
 }
 
 // UpsertForUser 全量替换该用户所有平台限额。
-func (a *userPlatformQuotaServiceAdapter) UpsertForUser(ctx context.Context, userID int64, records []service.UserPlatformQuotaRecord) error {
+func (a *userPlatformQuotaServiceAdapter) UpsertForUser(ctx context.Context, userID int64, records []domain.UserPlatformQuotaRecord) error {
 	repoRecords := toRepoRecords(records)
 	return a.inner.UpsertForUser(ctx, userID, repoRecords)
 }
@@ -122,7 +123,7 @@ type genericUserPlatformQuotaAdapter struct {
 	inner UserPlatformQuotaRepository
 }
 
-func (a *genericUserPlatformQuotaAdapter) GetByUserPlatform(ctx context.Context, userID int64, platform string) (*service.UserPlatformQuotaRecord, error) {
+func (a *genericUserPlatformQuotaAdapter) GetByUserPlatform(ctx context.Context, userID int64, platform string) (*domain.UserPlatformQuotaRecord, error) {
 	rec, err := a.inner.GetByUserPlatform(ctx, userID, platform)
 	if err != nil || rec == nil {
 		return nil, err
@@ -136,14 +137,14 @@ func (a *genericUserPlatformQuotaAdapter) IncrementUsageWithReset(ctx context.Co
 }
 
 // ListByUser 查询用户的所有平台配额记录（通用 adapter 实现）。
-func (a *genericUserPlatformQuotaAdapter) ListByUser(ctx context.Context, userID int64) ([]service.UserPlatformQuotaRecord, error) {
+func (a *genericUserPlatformQuotaAdapter) ListByUser(ctx context.Context, userID int64) ([]domain.UserPlatformQuotaRecord, error) {
 	rows, err := a.inner.ListByUser(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]service.UserPlatformQuotaRecord, len(rows))
+	out := make([]domain.UserPlatformQuotaRecord, len(rows))
 	for i, r := range rows {
-		out[i] = service.UserPlatformQuotaRecord{
+		out[i] = domain.UserPlatformQuotaRecord{
 			UserID:             r.UserID,
 			Platform:           r.Platform,
 			DailyLimitUSD:      r.DailyLimitUSD,
@@ -160,8 +161,8 @@ func (a *genericUserPlatformQuotaAdapter) ListByUser(ctx context.Context, userID
 	return out, nil
 }
 
-// BulkInsertInitial 将 service.UserPlatformQuotaRecord 切片转换后调用底层 generic repo。
-func (a *genericUserPlatformQuotaAdapter) BulkInsertInitial(ctx context.Context, records []service.UserPlatformQuotaRecord) error {
+// BulkInsertInitial 将 domain.UserPlatformQuotaRecord 切片转换后调用底层 generic repo。
+func (a *genericUserPlatformQuotaAdapter) BulkInsertInitial(ctx context.Context, records []domain.UserPlatformQuotaRecord) error {
 	repoRecords := make([]UserPlatformQuotaRecord, len(records))
 	for i, r := range records {
 		repoRecords[i] = UserPlatformQuotaRecord{
@@ -176,7 +177,7 @@ func (a *genericUserPlatformQuotaAdapter) BulkInsertInitial(ctx context.Context,
 }
 
 // UpsertForUser 全量替换（通用 adapter 实现）。
-func (a *genericUserPlatformQuotaAdapter) UpsertForUser(ctx context.Context, userID int64, records []service.UserPlatformQuotaRecord) error {
+func (a *genericUserPlatformQuotaAdapter) UpsertForUser(ctx context.Context, userID int64, records []domain.UserPlatformQuotaRecord) error {
 	repoRecords := toRepoRecords(records)
 	return a.inner.UpsertForUser(ctx, userID, repoRecords)
 }
@@ -213,9 +214,9 @@ func (a *genericUserPlatformQuotaAdapter) BatchSnapshotUsage(ctx context.Context
 	return err
 }
 
-// toServiceRecord 将 repository.UserPlatformQuotaRecord 转换为 service.UserPlatformQuotaRecord。
-func toServiceRecord(rec *UserPlatformQuotaRecord) *service.UserPlatformQuotaRecord {
-	return &service.UserPlatformQuotaRecord{
+// toServiceRecord 将 repository.UserPlatformQuotaRecord 转换为 domain.UserPlatformQuotaRecord。
+func toServiceRecord(rec *UserPlatformQuotaRecord) *domain.UserPlatformQuotaRecord {
+	return &domain.UserPlatformQuotaRecord{
 		UserID:             rec.UserID,
 		Platform:           rec.Platform,
 		DailyLimitUSD:      rec.DailyLimitUSD,
@@ -230,8 +231,8 @@ func toServiceRecord(rec *UserPlatformQuotaRecord) *service.UserPlatformQuotaRec
 	}
 }
 
-// toRepoRecords 将 service.UserPlatformQuotaRecord 切片转换为 repository.UserPlatformQuotaRecord（含 limit 字段，含 usage/window_start）。
-func toRepoRecords(records []service.UserPlatformQuotaRecord) []UserPlatformQuotaRecord {
+// toRepoRecords 将 domain.UserPlatformQuotaRecord 切片转换为 repository.UserPlatformQuotaRecord（含 limit 字段，含 usage/window_start）。
+func toRepoRecords(records []domain.UserPlatformQuotaRecord) []UserPlatformQuotaRecord {
 	out := make([]UserPlatformQuotaRecord, len(records))
 	for i, r := range records {
 		out[i] = UserPlatformQuotaRecord{

--- a/backend/internal/repository/user_profile_identity_repo.go
+++ b/backend/internal/repository/user_profile_identity_repo.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/ent/authidentitychannel"
 	"github.com/Wei-Shaw/sub2api/ent/identityadoptiondecision"
 	dbpredicate "github.com/Wei-Shaw/sub2api/ent/predicate"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
@@ -363,7 +364,7 @@ func (r *userRepository) ListUserAuthIdentities(ctx context.Context, userID int6
 func (r *userRepository) UnbindUserAuthProvider(ctx context.Context, userID int64, provider string) error {
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	if provider == "" || provider == "email" {
-		return service.ErrIdentityProviderInvalid
+		return domain.ErrIdentityProviderInvalid
 	}
 
 	return r.WithUserProfileIdentityTx(ctx, func(txCtx context.Context) error {

--- a/backend/internal/repository/user_profile_identity_repo_unit_test.go
+++ b/backend/internal/repository/user_profile_identity_repo_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/ent/authidentity"
 	"github.com/Wei-Shaw/sub2api/ent/authidentitychannel"
 	"github.com/Wei-Shaw/sub2api/ent/identityadoptiondecision"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -22,8 +23,8 @@ func TestUserRepositoryBindAuthIdentityToUserCanonicalizesLegacyWeChatAlias(t *t
 		Email:        "wechat-legacy@example.com",
 		Username:     "wechat-legacy",
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, user))
 
@@ -113,8 +114,8 @@ func TestUserRepositoryUpsertIdentityAdoptionDecisionIsIdempotentUnderConcurrenc
 		Email:        "repo-adoption@example.com",
 		Username:     "repo-adoption",
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, user))
 

--- a/backend/internal/repository/user_repo.go
+++ b/backend/internal/repository/user_repo.go
@@ -20,6 +20,7 @@ import (
 	dbuser "github.com/Wei-Shaw/sub2api/ent/user"
 	"github.com/Wei-Shaw/sub2api/ent/userallowedgroup"
 	"github.com/Wei-Shaw/sub2api/ent/usersubscription"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/lib/pq"
@@ -103,7 +104,7 @@ func (r *userRepository) createUser(ctx context.Context, txClient *dbent.Client,
 		SetTrajExportEnabled(userIn.TrajExportEnabled).
 		Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, nil, service.ErrEmailExists)
+		return translatePersistenceError(err, nil, domain.ErrEmailExists)
 	}
 
 	if err := r.syncUserAllowedGroupsWithClient(ctx, txClient, created.ID, userIn.AllowedGroups); err != nil {
@@ -120,7 +121,7 @@ func (r *userRepository) createUser(ctx context.Context, txClient *dbent.Client,
 func (r *userRepository) GetByID(ctx context.Context, id int64) (*service.User, error) {
 	m, err := r.client.User.Query().Where(dbuser.IDEQ(id)).Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 
 	out := userEntityToService(m)
@@ -138,7 +139,7 @@ func (r *userRepository) GetByIDIncludeDeleted(ctx context.Context, id int64) (*
 	ctx = mixins.SkipSoftDelete(ctx)
 	m, err := r.client.User.Query().Where(dbuser.IDEQ(id)).Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	out := userEntityToService(m)
 	groups, err := r.loadAllowedGroups(ctx, []int64{id})
@@ -160,7 +161,7 @@ func (r *userRepository) GetByEmail(ctx context.Context, email string) (*service
 		return nil, err
 	}
 	if len(matches) == 0 {
-		return nil, service.ErrUserNotFound
+		return nil, domain.ErrUserNotFound
 	}
 	if len(matches) > 1 {
 		return nil, fmt.Errorf("normalized email lookup matched multiple users for %q", strings.TrimSpace(email))
@@ -224,7 +225,7 @@ func (r *userRepository) updateUser(ctx context.Context, txClient *dbent.Client,
 
 	existing, err := clientFromContext(ctx, txClient).User.Get(ctx, userIn.ID)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	oldEmail := existing.Email
 
@@ -258,7 +259,7 @@ func (r *userRepository) updateUser(ctx context.Context, txClient *dbent.Client,
 	}
 	updated, err := updateOp.Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrUserNotFound, service.ErrEmailExists)
+		return translatePersistenceError(err, domain.ErrUserNotFound, domain.ErrEmailExists)
 	}
 
 	if err := r.syncUserAllowedGroupsWithClient(ctx, txClient, updated.ID, userIn.AllowedGroups); err != nil {
@@ -366,7 +367,7 @@ func (r *userRepository) Delete(ctx context.Context, id int64) error {
 
 	tx, err := r.client.Tx(ctx)
 	if err != nil && !errors.Is(err, dbent.ErrTxStarted) {
-		return translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	exec := r.client
 	if err == nil {
@@ -381,7 +382,7 @@ func (r *userRepository) Delete(ctx context.Context, id int64) error {
 
 	if tx != nil {
 		if err := tx.Commit(); err != nil {
-			return translatePersistenceError(err, service.ErrUserNotFound, nil)
+			return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 		}
 	}
 	return nil
@@ -393,42 +394,42 @@ func (r *userRepository) deleteUser(ctx context.Context, exec *dbent.Client, id 
 		Where(authidentity.UserIDEQ(id)).
 		IDs(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	if len(identityIDs) > 0 {
 		if _, err := exec.IdentityAdoptionDecision.Update().
 			Where(identityadoptiondecision.IdentityIDIn(identityIDs...)).
 			ClearIdentityID().
 			Save(ctx); err != nil {
-			return translatePersistenceError(err, service.ErrUserNotFound, nil)
+			return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 		}
 		if _, err := exec.AuthIdentityChannel.Delete().
 			Where(authidentitychannel.IdentityIDIn(identityIDs...)).
 			Exec(ctx); err != nil {
-			return translatePersistenceError(err, service.ErrUserNotFound, nil)
+			return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 		}
 		if _, err := exec.AuthIdentity.Delete().
 			Where(authidentity.UserIDEQ(id)).
 			Exec(ctx); err != nil {
-			return translatePersistenceError(err, service.ErrUserNotFound, nil)
+			return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 		}
 	}
 
 	affected, err := exec.User.Delete().Where(dbuser.IDEQ(id)).Exec(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	if affected == 0 {
-		return service.ErrUserNotFound
+		return domain.ErrUserNotFound
 	}
 	return nil
 }
 
 func (r *userRepository) List(ctx context.Context, params pagination.PaginationParams) ([]service.User, *pagination.PaginationResult, error) {
-	return r.ListWithFilters(ctx, params, service.UserListFilters{})
+	return r.ListWithFilters(ctx, params, domain.UserListFilters{})
 }
 
-func (r *userRepository) ListWithFilters(ctx context.Context, params pagination.PaginationParams, filters service.UserListFilters) ([]service.User, *pagination.PaginationResult, error) {
+func (r *userRepository) ListWithFilters(ctx context.Context, params pagination.PaginationParams, filters domain.UserListFilters) ([]service.User, *pagination.PaginationResult, error) {
 	// SkipSoftDelete 仅作用于 User 身份解析（下方 Count/All）；订阅、分组等关联实体沿用原始 ctx，避免穿透到这些同样带软删除的实体而带出已删除行。
 	userCtx := ctx
 	if filters.IncludeDeleted {
@@ -523,7 +524,7 @@ func (r *userRepository) ListWithFilters(ctx context.Context, params pagination.
 		subs, err := r.client.UserSubscription.Query().
 			Where(
 				usersubscription.UserIDIn(userIDs...),
-				usersubscription.StatusEQ(service.SubscriptionStatusActive),
+				usersubscription.StatusEQ(domain.SubscriptionStatusActive),
 			).
 			WithGroup().
 			All(ctx)
@@ -754,10 +755,10 @@ func (r *userRepository) UpdateBalance(ctx context.Context, id int64, amount flo
 	}
 	n, err := update.Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	if n == 0 {
-		return service.ErrUserNotFound
+		return domain.ErrUserNotFound
 	}
 	return nil
 }
@@ -786,7 +787,7 @@ func (r *userRepository) DeductBalance(ctx context.Context, id int64, amount flo
 		return err
 	}
 	if n == 0 {
-		return service.ErrUserNotFound
+		return domain.ErrUserNotFound
 	}
 	return nil
 }
@@ -795,10 +796,10 @@ func (r *userRepository) UpdateConcurrency(ctx context.Context, id int64, amount
 	client := clientFromContext(ctx, r.client)
 	n, err := client.User.Update().Where(dbuser.IDEQ(id)).AddConcurrency(amount).Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	if n == 0 {
-		return service.ErrUserNotFound
+		return domain.ErrUserNotFound
 	}
 	return nil
 }
@@ -852,7 +853,7 @@ func ensureNormalizedEmailAvailableWithClient(ctx context.Context, client *dbent
 	}
 	for _, match := range matches {
 		if match.ID != userID {
-			return service.ErrEmailExists
+			return domain.ErrEmailExists
 		}
 	}
 	return nil
@@ -922,13 +923,13 @@ func (r *userRepository) RemoveGroupFromUserAllowedGroups(ctx context.Context, u
 func (r *userRepository) GetFirstAdmin(ctx context.Context) (*service.User, error) {
 	m, err := r.client.User.Query().
 		Where(
-			dbuser.RoleEQ(service.RoleAdmin),
-			dbuser.StatusEQ(service.StatusActive),
+			dbuser.RoleEQ(domain.RoleAdmin),
+			dbuser.StatusEQ(domain.StatusActive),
 		).
 		Order(dbent.Asc(dbuser.FieldID)).
 		First(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 
 	out := userEntityToService(m)
@@ -1045,7 +1046,7 @@ func (r *userRepository) UpdateTotpSecret(ctx context.Context, userID int64, enc
 	}
 	_, err := update.Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	return nil
 }
@@ -1058,7 +1059,7 @@ func (r *userRepository) EnableTotp(ctx context.Context, userID int64) error {
 		SetTotpEnabledAt(time.Now()).
 		Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	return nil
 }
@@ -1072,7 +1073,7 @@ func (r *userRepository) DisableTotp(ctx context.Context, userID int64) error {
 		ClearTotpSecretEncrypted().
 		Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	return nil
 }

--- a/backend/internal/repository/user_repo_apikey_group_filter_integration_test.go
+++ b/backend/internal/repository/user_repo_apikey_group_filter_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/suite"
@@ -40,8 +41,8 @@ func (s *UserRepoAPIKeyGroupFilterSuite) mustCreateUser(email string) *service.U
 	u := &service.User{
 		Email:        email,
 		PasswordHash: "test-password-hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 		Concurrency:  5,
 	}
 	s.Require().NoError(s.repo.Create(s.ctx, u), "create user")
@@ -52,7 +53,7 @@ func (s *UserRepoAPIKeyGroupFilterSuite) mustCreateGroup(name string) *dbent.Gro
 	s.T().Helper()
 	g, err := s.client.Group.Create().
 		SetName(name).
-		SetStatus(service.StatusActive).
+		SetStatus(domain.StatusActive).
 		Save(s.ctx)
 	s.Require().NoError(err, "create group")
 	return g
@@ -85,7 +86,7 @@ func (s *UserRepoAPIKeyGroupFilterSuite) listByAPIKeyGroup(groupID int64) []serv
 	users, _, err := s.repo.ListWithFilters(
 		s.ctx,
 		pagination.PaginationParams{Page: 1, PageSize: 50},
-		service.UserListFilters{APIKeyGroupID: groupID},
+		domain.UserListFilters{APIKeyGroupID: groupID},
 	)
 	s.Require().NoError(err, "ListWithFilters")
 	return users
@@ -137,7 +138,7 @@ func (s *UserRepoAPIKeyGroupFilterSuite) TestAPIKeyGroupAndStatusFilter() {
 	// disabled 用户，key 也绑 target 分组 → 只用 group 过滤会命中，但 status=active 后排除
 	disabled := s.mustCreateUser("disabled-hit@test.com")
 	s.mustCreateAPIKey(disabled.ID, "sk-disabled", "K2", &g.ID)
-	_, err := s.client.User.UpdateOneID(disabled.ID).SetStatus(service.StatusDisabled).Save(s.ctx)
+	_, err := s.client.User.UpdateOneID(disabled.ID).SetStatus(domain.StatusDisabled).Save(s.ctx)
 	s.Require().NoError(err, "disable user")
 
 	// active 用户，key 绑其它分组 → group 过滤排除
@@ -148,9 +149,9 @@ func (s *UserRepoAPIKeyGroupFilterSuite) TestAPIKeyGroupAndStatusFilter() {
 	users, _, err := s.repo.ListWithFilters(
 		s.ctx,
 		pagination.PaginationParams{Page: 1, PageSize: 50},
-		service.UserListFilters{
+		domain.UserListFilters{
 			APIKeyGroupID: g.ID,
-			Status:        service.StatusActive,
+			Status:        domain.StatusActive,
 		},
 	)
 	s.Require().NoError(err)
@@ -167,7 +168,7 @@ func (s *UserRepoAPIKeyGroupFilterSuite) TestZeroGroupIDNoFilter() {
 	users, _, err := s.repo.ListWithFilters(
 		s.ctx,
 		pagination.PaginationParams{Page: 1, PageSize: 50},
-		service.UserListFilters{APIKeyGroupID: 0},
+		domain.UserListFilters{APIKeyGroupID: 0},
 	)
 	s.Require().NoError(err)
 	s.Require().ElementsMatch([]int64{u1.ID, u2.ID}, s.ids(users))

--- a/backend/internal/repository/user_repo_email_identity_integration_test.go
+++ b/backend/internal/repository/user_repo_email_identity_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/Wei-Shaw/sub2api/ent/authidentity"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -13,8 +14,8 @@ func (s *UserRepoSuite) TestCreate_CreatesEmailAuthIdentityForNormalEmail() {
 	user := &service.User{
 		Email:        "repo-create@example.com",
 		PasswordHash: "test-password-hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 		Concurrency:  2,
 	}
 
@@ -36,8 +37,8 @@ func (s *UserRepoSuite) TestCreate_SkipsEmailAuthIdentityForSyntheticLinuxDoEmai
 	user := &service.User{
 		Email:        "linuxdo-legacy-user@linuxdo-connect.invalid",
 		PasswordHash: "test-password-hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 		Concurrency:  2,
 	}
 

--- a/backend/internal/repository/user_repo_email_lookup_unit_test.go
+++ b/backend/internal/repository/user_repo_email_lookup_unit_test.go
@@ -10,6 +10,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/enttest"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 
@@ -45,8 +46,8 @@ func TestUserRepositoryGetByEmailNormalizesLegacySpacingAndCase(t *testing.T) {
 		Email:        " Legacy@Example.com ",
 		Username:     "legacy-user",
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	})
 	require.NoError(t, err)
 
@@ -63,8 +64,8 @@ func TestUserRepositoryExistsByEmailNormalizesLegacySpacingAndCase(t *testing.T)
 		Email:        " Legacy@Example.com ",
 		Username:     "legacy-user",
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	})
 	require.NoError(t, err)
 
@@ -81,8 +82,8 @@ func TestUserRepositoryCreateRejectsNormalizedEmailDuplicate(t *testing.T) {
 		Email:        " Existing@Example.com ",
 		Username:     "existing-user",
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	})
 	require.NoError(t, err)
 
@@ -90,10 +91,10 @@ func TestUserRepositoryCreateRejectsNormalizedEmailDuplicate(t *testing.T) {
 		Email:        "existing@example.com",
 		Username:     "duplicate-user",
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	})
-	require.ErrorIs(t, err, service.ErrEmailExists)
+	require.ErrorIs(t, err, domain.ErrEmailExists)
 }
 
 func TestUserRepositoryUpdateRejectsNormalizedEmailDuplicate(t *testing.T) {
@@ -104,8 +105,8 @@ func TestUserRepositoryUpdateRejectsNormalizedEmailDuplicate(t *testing.T) {
 		Email:        " Existing@Example.com ",
 		Username:     "existing-user",
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, first))
 
@@ -113,14 +114,14 @@ func TestUserRepositoryUpdateRejectsNormalizedEmailDuplicate(t *testing.T) {
 		Email:        "second@example.com",
 		Username:     "second-user",
 		PasswordHash: "hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	}
 	require.NoError(t, repo.Create(ctx, second))
 
 	second.Email = " existing@example.com "
 	err := repo.Update(ctx, second)
-	require.ErrorIs(t, err, service.ErrEmailExists)
+	require.ErrorIs(t, err, domain.ErrEmailExists)
 }
 
 func TestUserRepositoryGetByEmailReportsNormalizedEmailConflict(t *testing.T) {
@@ -131,8 +132,8 @@ func TestUserRepositoryGetByEmailReportsNormalizedEmailConflict(t *testing.T) {
 		SetEmail("Conflict@Example.com").
 		SetUsername("conflict-user-1").
 		SetPasswordHash("hash").
-		SetRole(service.RoleUser).
-		SetStatus(service.StatusActive).
+		SetRole(domain.RoleUser).
+		SetStatus(domain.StatusActive).
 		Save(ctx)
 	require.NoError(t, err)
 
@@ -140,8 +141,8 @@ func TestUserRepositoryGetByEmailReportsNormalizedEmailConflict(t *testing.T) {
 		SetEmail(" conflict@example.com ").
 		SetUsername("conflict-user-2").
 		SetPasswordHash("hash").
-		SetRole(service.RoleUser).
-		SetStatus(service.StatusActive).
+		SetRole(domain.RoleUser).
+		SetStatus(domain.StatusActive).
 		Save(ctx)
 	require.NoError(t, err)
 
@@ -183,8 +184,8 @@ func TestUserRepositoryCreateSerializesNormalizedEmailConflictsUnderConcurrency(
 			Email:        " Race@Example.com ",
 			Username:     "race-user-1",
 			PasswordHash: "hash",
-			Role:         service.RoleUser,
-			Status:       service.StatusActive,
+			Role:         domain.RoleUser,
+			Status:       domain.StatusActive,
 		})}
 	}()
 
@@ -195,8 +196,8 @@ func TestUserRepositoryCreateSerializesNormalizedEmailConflictsUnderConcurrency(
 			Email:        "race@example.com",
 			Username:     "race-user-2",
 			PasswordHash: "hash",
-			Role:         service.RoleUser,
-			Status:       service.StatusActive,
+			Role:         domain.RoleUser,
+			Status:       domain.StatusActive,
 		})}
 	}()
 
@@ -213,7 +214,7 @@ func TestUserRepositoryCreateSerializesNormalizedEmailConflictsUnderConcurrency(
 		switch err {
 		case nil:
 			successes++
-		case service.ErrEmailExists:
+		case domain.ErrEmailExists:
 			conflicts++
 		default:
 			t.Fatalf("unexpected create error: %v", err)

--- a/backend/internal/repository/user_repo_include_deleted_integration_test.go
+++ b/backend/internal/repository/user_repo_include_deleted_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ func TestUserRepo_ListWithFilters_IncludeDeleted(t *testing.T) {
 
 	// 默认（不含已删）：只返回活跃用户。
 	usersDefault, resDefault, err := repo.ListWithFilters(ctx, params,
-		service.UserListFilters{Search: "shared-keyword-"})
+		domain.UserListFilters{Search: "shared-keyword-"})
 	require.NoError(t, err)
 	require.Len(t, usersDefault, 1)
 	require.Equal(t, active.ID, usersDefault[0].ID)
@@ -33,7 +34,7 @@ func TestUserRepo_ListWithFilters_IncludeDeleted(t *testing.T) {
 
 	// IncludeDeleted=true：两个都返回，且 Total 与结果集一致。
 	usersAll, resAll, err := repo.ListWithFilters(ctx, params,
-		service.UserListFilters{Search: "shared-keyword-", IncludeDeleted: true})
+		domain.UserListFilters{Search: "shared-keyword-", IncludeDeleted: true})
 	require.NoError(t, err)
 	require.Len(t, usersAll, 2)
 	require.EqualValues(t, 2, resAll.Total, "Count 必须与结果集行数一致")
@@ -59,7 +60,7 @@ func TestUserRepo_GetByIDIncludeDeleted(t *testing.T) {
 
 	// 默认 GetByID：找不到（被软删过滤）。
 	_, err := repo.GetByID(ctx, u.ID)
-	require.ErrorIs(t, err, service.ErrUserNotFound)
+	require.ErrorIs(t, err, domain.ErrUserNotFound)
 
 	// GetByIDIncludeDeleted：找得到，且 DeletedAt 非空。
 	got, err := repo.GetByIDIncludeDeleted(ctx, u.ID)

--- a/backend/internal/repository/user_repo_integration_test.go
+++ b/backend/internal/repository/user_repo_integration_test.go
@@ -10,6 +10,7 @@ import (
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/authidentity"
 	"github.com/Wei-Shaw/sub2api/ent/authidentitychannel"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/suite"
@@ -49,10 +50,10 @@ func (s *UserRepoSuite) mustCreateUser(u *service.User) *service.User {
 		u.PasswordHash = "test-password-hash"
 	}
 	if u.Role == "" {
-		u.Role = service.RoleUser
+		u.Role = domain.RoleUser
 	}
 	if u.Status == "" {
-		u.Status = service.StatusActive
+		u.Status = domain.StatusActive
 	}
 	if u.Concurrency == 0 {
 		u.Concurrency = 5
@@ -67,7 +68,7 @@ func (s *UserRepoSuite) mustCreateGroup(name string) *service.Group {
 
 	g, err := s.client.Group.Create().
 		SetName(name).
-		SetStatus(service.StatusActive).
+		SetStatus(domain.StatusActive).
 		Save(s.ctx)
 	s.Require().NoError(err, "create group")
 	return groupEntityToService(g)
@@ -82,7 +83,7 @@ func (s *UserRepoSuite) mustCreateSubscription(userID, groupID int64, mutate fun
 		SetGroupID(groupID).
 		SetStartsAt(now.Add(-1 * time.Hour)).
 		SetExpiresAt(now.Add(24 * time.Hour)).
-		SetStatus(service.SubscriptionStatusActive).
+		SetStatus(domain.SubscriptionStatusActive).
 		SetAssignedAt(now).
 		SetNotes("")
 
@@ -102,8 +103,8 @@ func (s *UserRepoSuite) TestCreate() {
 		Email:        "create@test.com",
 		Username:     "testuser",
 		PasswordHash: "test-password-hash",
-		Role:         service.RoleUser,
-		Status:       service.StatusActive,
+		Role:         domain.RoleUser,
+		Status:       domain.StatusActive,
 	})
 
 	s.Require().NotZero(user.ID, "expected ID to be set")
@@ -240,30 +241,30 @@ func (s *UserRepoSuite) TestList() {
 }
 
 func (s *UserRepoSuite) TestListWithFilters_Status() {
-	s.mustCreateUser(&service.User{Email: "active@test.com", Status: service.StatusActive})
-	s.mustCreateUser(&service.User{Email: "disabled@test.com", Status: service.StatusDisabled})
+	s.mustCreateUser(&service.User{Email: "active@test.com", Status: domain.StatusActive})
+	s.mustCreateUser(&service.User{Email: "disabled@test.com", Status: domain.StatusDisabled})
 
-	users, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, service.UserListFilters{Status: service.StatusActive})
+	users, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, domain.UserListFilters{Status: domain.StatusActive})
 	s.Require().NoError(err)
 	s.Require().Len(users, 1)
-	s.Require().Equal(service.StatusActive, users[0].Status)
+	s.Require().Equal(domain.StatusActive, users[0].Status)
 }
 
 func (s *UserRepoSuite) TestListWithFilters_Role() {
-	s.mustCreateUser(&service.User{Email: "user@test.com", Role: service.RoleUser})
-	s.mustCreateUser(&service.User{Email: "admin@test.com", Role: service.RoleAdmin})
+	s.mustCreateUser(&service.User{Email: "user@test.com", Role: domain.RoleUser})
+	s.mustCreateUser(&service.User{Email: "admin@test.com", Role: domain.RoleAdmin})
 
-	users, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, service.UserListFilters{Role: service.RoleAdmin})
+	users, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, domain.UserListFilters{Role: domain.RoleAdmin})
 	s.Require().NoError(err)
 	s.Require().Len(users, 1)
-	s.Require().Equal(service.RoleAdmin, users[0].Role)
+	s.Require().Equal(domain.RoleAdmin, users[0].Role)
 }
 
 func (s *UserRepoSuite) TestListWithFilters_Search() {
 	s.mustCreateUser(&service.User{Email: "alice@test.com", Username: "Alice"})
 	s.mustCreateUser(&service.User{Email: "bob@test.com", Username: "Bob"})
 
-	users, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, service.UserListFilters{Search: "alice"})
+	users, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, domain.UserListFilters{Search: "alice"})
 	s.Require().NoError(err)
 	s.Require().Len(users, 1)
 	s.Require().Contains(users[0].Email, "alice")
@@ -273,27 +274,27 @@ func (s *UserRepoSuite) TestListWithFilters_SearchByUsername() {
 	s.mustCreateUser(&service.User{Email: "u1@test.com", Username: "JohnDoe"})
 	s.mustCreateUser(&service.User{Email: "u2@test.com", Username: "JaneSmith"})
 
-	users, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, service.UserListFilters{Search: "john"})
+	users, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, domain.UserListFilters{Search: "john"})
 	s.Require().NoError(err)
 	s.Require().Len(users, 1)
 	s.Require().Equal("JohnDoe", users[0].Username)
 }
 
 func (s *UserRepoSuite) TestListWithFilters_LoadsActiveSubscriptions() {
-	user := s.mustCreateUser(&service.User{Email: "sub@test.com", Status: service.StatusActive})
+	user := s.mustCreateUser(&service.User{Email: "sub@test.com", Status: domain.StatusActive})
 	groupActive := s.mustCreateGroup("g-sub-active")
 	groupExpired := s.mustCreateGroup("g-sub-expired")
 
 	_ = s.mustCreateSubscription(user.ID, groupActive.ID, func(c *dbent.UserSubscriptionCreate) {
-		c.SetStatus(service.SubscriptionStatusActive)
+		c.SetStatus(domain.SubscriptionStatusActive)
 		c.SetExpiresAt(time.Now().Add(1 * time.Hour))
 	})
 	_ = s.mustCreateSubscription(user.ID, groupExpired.ID, func(c *dbent.UserSubscriptionCreate) {
-		c.SetStatus(service.SubscriptionStatusExpired)
+		c.SetStatus(domain.SubscriptionStatusExpired)
 		c.SetExpiresAt(time.Now().Add(-1 * time.Hour))
 	})
 
-	users, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, service.UserListFilters{Search: "sub@"})
+	users, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, domain.UserListFilters{Search: "sub@"})
 	s.Require().NoError(err, "ListWithFilters")
 	s.Require().Len(users, 1, "expected 1 user")
 	s.Require().Len(users[0].Subscriptions, 1, "expected 1 active subscription")
@@ -305,24 +306,24 @@ func (s *UserRepoSuite) TestListWithFilters_CombinedFilters() {
 	s.mustCreateUser(&service.User{
 		Email:    "a@example.com",
 		Username: "Alice",
-		Role:     service.RoleUser,
-		Status:   service.StatusActive,
+		Role:     domain.RoleUser,
+		Status:   domain.StatusActive,
 		Balance:  10,
 	})
 	target := s.mustCreateUser(&service.User{
 		Email:    "b@example.com",
 		Username: "Bob",
-		Role:     service.RoleAdmin,
-		Status:   service.StatusActive,
+		Role:     domain.RoleAdmin,
+		Status:   domain.StatusActive,
 		Balance:  1,
 	})
 	s.mustCreateUser(&service.User{
 		Email:  "c@example.com",
-		Role:   service.RoleAdmin,
-		Status: service.StatusDisabled,
+		Role:   domain.RoleAdmin,
+		Status: domain.StatusDisabled,
 	})
 
-	users, page, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, service.UserListFilters{Status: service.StatusActive, Role: service.RoleAdmin, Search: "b@"})
+	users, page, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, domain.UserListFilters{Status: domain.StatusActive, Role: domain.RoleAdmin, Search: "b@"})
 	s.Require().NoError(err, "ListWithFilters")
 	s.Require().Equal(int64(1), page.Total, "ListWithFilters total mismatch")
 	s.Require().Len(users, 1, "ListWithFilters len mismatch")
@@ -483,13 +484,13 @@ func (s *UserRepoSuite) TestRemoveGroupFromAllowedGroups_NoMatch() {
 func (s *UserRepoSuite) TestGetFirstAdmin() {
 	admin1 := s.mustCreateUser(&service.User{
 		Email:  "admin1@example.com",
-		Role:   service.RoleAdmin,
-		Status: service.StatusActive,
+		Role:   domain.RoleAdmin,
+		Status: domain.StatusActive,
 	})
 	s.mustCreateUser(&service.User{
 		Email:  "admin2@example.com",
-		Role:   service.RoleAdmin,
-		Status: service.StatusActive,
+		Role:   domain.RoleAdmin,
+		Status: domain.StatusActive,
 	})
 
 	got, err := s.repo.GetFirstAdmin(s.ctx)
@@ -500,8 +501,8 @@ func (s *UserRepoSuite) TestGetFirstAdmin() {
 func (s *UserRepoSuite) TestGetFirstAdmin_NoAdmin() {
 	s.mustCreateUser(&service.User{
 		Email:  "user@example.com",
-		Role:   service.RoleUser,
-		Status: service.StatusActive,
+		Role:   domain.RoleUser,
+		Status: domain.StatusActive,
 	})
 
 	_, err := s.repo.GetFirstAdmin(s.ctx)
@@ -511,13 +512,13 @@ func (s *UserRepoSuite) TestGetFirstAdmin_NoAdmin() {
 func (s *UserRepoSuite) TestGetFirstAdmin_DisabledAdminIgnored() {
 	s.mustCreateUser(&service.User{
 		Email:  "disabled@example.com",
-		Role:   service.RoleAdmin,
-		Status: service.StatusDisabled,
+		Role:   domain.RoleAdmin,
+		Status: domain.StatusDisabled,
 	})
 	activeAdmin := s.mustCreateUser(&service.User{
 		Email:  "active@example.com",
-		Role:   service.RoleAdmin,
-		Status: service.StatusActive,
+		Role:   domain.RoleAdmin,
+		Status: domain.StatusActive,
 	})
 
 	got, err := s.repo.GetFirstAdmin(s.ctx)
@@ -531,21 +532,21 @@ func (s *UserRepoSuite) TestCRUD_And_Filters_And_AtomicUpdates() {
 	user1 := s.mustCreateUser(&service.User{
 		Email:    "a@example.com",
 		Username: "Alice",
-		Role:     service.RoleUser,
-		Status:   service.StatusActive,
+		Role:     domain.RoleUser,
+		Status:   domain.StatusActive,
 		Balance:  10,
 	})
 	user2 := s.mustCreateUser(&service.User{
 		Email:    "b@example.com",
 		Username: "Bob",
-		Role:     service.RoleAdmin,
-		Status:   service.StatusActive,
+		Role:     domain.RoleAdmin,
+		Status:   domain.StatusActive,
 		Balance:  1,
 	})
 	s.mustCreateUser(&service.User{
 		Email:  "c@example.com",
-		Role:   service.RoleAdmin,
-		Status: service.StatusDisabled,
+		Role:   domain.RoleAdmin,
+		Status: domain.StatusDisabled,
 	})
 
 	got, err := s.repo.GetByID(s.ctx, user1.ID)
@@ -585,7 +586,7 @@ func (s *UserRepoSuite) TestCRUD_And_Filters_And_AtomicUpdates() {
 	s.Require().Equal(user1.Concurrency+3, got5.Concurrency)
 
 	params := pagination.PaginationParams{Page: 1, PageSize: 10}
-	users, page, err := s.repo.ListWithFilters(s.ctx, params, service.UserListFilters{Status: service.StatusActive, Role: service.RoleAdmin, Search: "b@"})
+	users, page, err := s.repo.ListWithFilters(s.ctx, params, domain.UserListFilters{Status: domain.StatusActive, Role: domain.RoleAdmin, Search: "b@"})
 	s.Require().NoError(err, "ListWithFilters")
 	s.Require().Equal(int64(1), page.Total, "ListWithFilters total mismatch")
 	s.Require().Len(users, 1, "ListWithFilters len mismatch")
@@ -597,18 +598,18 @@ func (s *UserRepoSuite) TestCRUD_And_Filters_And_AtomicUpdates() {
 func (s *UserRepoSuite) TestUpdateBalance_NotFound() {
 	err := s.repo.UpdateBalance(s.ctx, 999999, 10.0)
 	s.Require().Error(err, "expected error for non-existent user")
-	s.Require().ErrorIs(err, service.ErrUserNotFound)
+	s.Require().ErrorIs(err, domain.ErrUserNotFound)
 }
 
 func (s *UserRepoSuite) TestUpdateConcurrency_NotFound() {
 	err := s.repo.UpdateConcurrency(s.ctx, 999999, 5)
 	s.Require().Error(err, "expected error for non-existent user")
-	s.Require().ErrorIs(err, service.ErrUserNotFound)
+	s.Require().ErrorIs(err, domain.ErrUserNotFound)
 }
 
 func (s *UserRepoSuite) TestDeductBalance_NotFound() {
 	err := s.repo.DeductBalance(s.ctx, 999999, 5)
 	s.Require().Error(err, "expected error for non-existent user")
 	// DeductBalance 在用户不存在时返回 ErrUserNotFound
-	s.Require().ErrorIs(err, service.ErrUserNotFound)
+	s.Require().ErrorIs(err, domain.ErrUserNotFound)
 }

--- a/backend/internal/repository/user_repo_sort_integration_test.go
+++ b/backend/internal/repository/user_repo_sort_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )

--- a/backend/internal/repository/user_repo_sort_integration_test.go
+++ b/backend/internal/repository/user_repo_sort_integration_test.go
@@ -37,7 +37,7 @@ func (s *UserRepoSuite) TestListWithFilters_SortByEmailAsc() {
 		PageSize:  10,
 		SortBy:    "email",
 		SortOrder: "asc",
-	}, service.UserListFilters{})
+	}, domain.UserListFilters{})
 	s.Require().NoError(err)
 	s.Require().Len(users, 2)
 	s.Require().Equal("a-first@example.com", users[0].Email)
@@ -108,7 +108,7 @@ func (s *UserRepoSuite) TestListWithFilters_SortByLastActiveAtAsc() {
 		PageSize:  10,
 		SortBy:    "last_active_at",
 		SortOrder: "asc",
-	}, service.UserListFilters{})
+	}, domain.UserListFilters{})
 	s.Require().NoError(err)
 	s.Require().Len(users, 3)
 	s.Require().Equal("earlier-active@example.com", users[0].Email)
@@ -153,7 +153,7 @@ func (s *UserRepoSuite) TestListWithFilters_SortByLastUsedAtDesc_UsesUsageLogsNo
 		PageSize:  10,
 		SortBy:    "last_used_at",
 		SortOrder: "desc",
-	}, service.UserListFilters{})
+	}, domain.UserListFilters{})
 	s.Require().NoError(err)
 	s.Require().Len(users, 3)
 	s.Require().Equal(rightSource.ID, users[0].ID)

--- a/backend/internal/repository/user_repo_tk_auth.go
+++ b/backend/internal/repository/user_repo_tk_auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	dbuser "github.com/Wei-Shaw/sub2api/ent/user"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
@@ -25,7 +26,7 @@ import (
 func (r *userRepository) GetByIDForAuth(ctx context.Context, id int64) (*service.User, error) {
 	m, err := r.client.User.Query().Where(dbuser.IDEQ(id)).Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	return userEntityToService(m), nil
 }

--- a/backend/internal/repository/user_repo_tk_onboarding.go
+++ b/backend/internal/repository/user_repo_tk_onboarding.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	dbuser "github.com/Wei-Shaw/sub2api/ent/user"
-	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 )
 
 // MarkOnboardingTourSeen writes users.onboarding_tour_seen_at = NOW() exactly
@@ -24,7 +24,7 @@ func (r *userRepository) MarkOnboardingTourSeen(ctx context.Context, userID int6
 		SetOnboardingTourSeenAt(time.Now()).
 		Save(ctx)
 	if err != nil {
-		return translatePersistenceError(err, service.ErrUserNotFound, nil)
+		return translatePersistenceError(err, domain.ErrUserNotFound, nil)
 	}
 	return nil
 }

--- a/backend/internal/repository/user_subscription_repo.go
+++ b/backend/internal/repository/user_subscription_repo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/ent/schema/mixins"
 	"github.com/Wei-Shaw/sub2api/ent/user"
 	"github.com/Wei-Shaw/sub2api/ent/usersubscription"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
@@ -24,7 +25,7 @@ func NewUserSubscriptionRepository(client *dbent.Client) service.UserSubscriptio
 
 func (r *userSubscriptionRepository) Create(ctx context.Context, sub *service.UserSubscription) error {
 	if sub == nil {
-		return service.ErrSubscriptionNilInput
+		return domain.ErrSubscriptionNilInput
 	}
 
 	client := clientFromContext(ctx, r.client)
@@ -58,7 +59,7 @@ func (r *userSubscriptionRepository) Create(ctx context.Context, sub *service.Us
 	if err == nil {
 		applyUserSubscriptionEntityToService(sub, created)
 	}
-	return translatePersistenceError(err, nil, service.ErrSubscriptionAlreadyExists)
+	return translatePersistenceError(err, nil, domain.ErrSubscriptionAlreadyExists)
 }
 
 func (r *userSubscriptionRepository) GetByID(ctx context.Context, id int64) (*service.UserSubscription, error) {
@@ -70,7 +71,7 @@ func (r *userSubscriptionRepository) GetByID(ctx context.Context, id int64) (*se
 		WithAssignedByUser().
 		Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrSubscriptionNotFound, nil)
 	}
 	return userSubscriptionEntityToService(m), nil
 }
@@ -85,7 +86,7 @@ func (r *userSubscriptionRepository) GetByIDIncludeDeleted(ctx context.Context, 
 		WithAssignedByUser().
 		Only(queryCtx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrSubscriptionNotFound, nil)
 	}
 	return userSubscriptionEntityToServicePreserveStatus(m), nil
 }
@@ -97,7 +98,7 @@ func (r *userSubscriptionRepository) GetByUserIDAndGroupID(ctx context.Context, 
 		WithGroup().
 		Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrSubscriptionNotFound, nil)
 	}
 	return userSubscriptionEntityToService(m), nil
 }
@@ -108,20 +109,20 @@ func (r *userSubscriptionRepository) GetActiveByUserIDAndGroupID(ctx context.Con
 		Where(
 			usersubscription.UserIDEQ(userID),
 			usersubscription.GroupIDEQ(groupID),
-			usersubscription.StatusEQ(service.SubscriptionStatusActive),
+			usersubscription.StatusEQ(domain.SubscriptionStatusActive),
 			usersubscription.ExpiresAtGT(time.Now()),
 		).
 		WithGroup().
 		Only(ctx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+		return nil, translatePersistenceError(err, domain.ErrSubscriptionNotFound, nil)
 	}
 	return userSubscriptionEntityToService(m), nil
 }
 
 func (r *userSubscriptionRepository) Update(ctx context.Context, sub *service.UserSubscription) error {
 	if sub == nil {
-		return service.ErrSubscriptionNilInput
+		return domain.ErrSubscriptionNilInput
 	}
 
 	client := clientFromContext(ctx, r.client)
@@ -146,7 +147,7 @@ func (r *userSubscriptionRepository) Update(ctx context.Context, sub *service.Us
 		applyUserSubscriptionEntityToService(sub, updated)
 		return nil
 	}
-	return translatePersistenceError(err, service.ErrSubscriptionNotFound, service.ErrSubscriptionAlreadyExists)
+	return translatePersistenceError(err, domain.ErrSubscriptionNotFound, domain.ErrSubscriptionAlreadyExists)
 }
 
 func (r *userSubscriptionRepository) Delete(ctx context.Context, id int64) error {
@@ -165,7 +166,7 @@ func (r *userSubscriptionRepository) Restore(ctx context.Context, subscriptionID
 		SetUpdatedAt(time.Now()).
 		Save(queryCtx)
 	if err != nil {
-		return nil, translatePersistenceError(err, service.ErrSubscriptionNotFound, service.ErrSubscriptionRestoreConflict)
+		return nil, translatePersistenceError(err, domain.ErrSubscriptionNotFound, domain.ErrSubscriptionRestoreConflict)
 	}
 	return r.GetByID(ctx, subscriptionID)
 }
@@ -188,7 +189,7 @@ func (r *userSubscriptionRepository) ListActiveByUserID(ctx context.Context, use
 	subs, err := client.UserSubscription.Query().
 		Where(
 			usersubscription.UserIDEQ(userID),
-			usersubscription.StatusEQ(service.SubscriptionStatusActive),
+			usersubscription.StatusEQ(domain.SubscriptionStatusActive),
 			usersubscription.ExpiresAtGT(time.Now()),
 		).
 		WithGroup().
@@ -226,7 +227,7 @@ func (r *userSubscriptionRepository) ListByGroupID(ctx context.Context, groupID 
 func (r *userSubscriptionRepository) List(ctx context.Context, params pagination.PaginationParams, userID, groupID *int64, status, platform, sortBy, sortOrder string) ([]service.UserSubscription, *pagination.PaginationResult, error) {
 	client := clientFromContext(ctx, r.client)
 	q := client.UserSubscription.Query()
-	includeSoftDeleted := status == "" || status == service.SubscriptionStatusRevoked
+	includeSoftDeleted := status == "" || status == domain.SubscriptionStatusRevoked
 	if userID != nil {
 		q = q.Where(usersubscription.UserIDEQ(*userID))
 	}
@@ -244,24 +245,24 @@ func (r *userSubscriptionRepository) List(ctx context.Context, params pagination
 	// Status filtering with real-time expiration check
 	now := time.Now()
 	switch status {
-	case service.SubscriptionStatusActive:
+	case domain.SubscriptionStatusActive:
 		// Active: status is active AND not yet expired
 		q = q.Where(
-			usersubscription.StatusEQ(service.SubscriptionStatusActive),
+			usersubscription.StatusEQ(domain.SubscriptionStatusActive),
 			usersubscription.ExpiresAtGT(now),
 		)
-	case service.SubscriptionStatusExpired:
+	case domain.SubscriptionStatusExpired:
 		// Expired: status is expired OR (status is active but already expired)
 		q = q.Where(
 			usersubscription.Or(
-				usersubscription.StatusEQ(service.SubscriptionStatusExpired),
+				usersubscription.StatusEQ(domain.SubscriptionStatusExpired),
 				usersubscription.And(
-					usersubscription.StatusEQ(service.SubscriptionStatusActive),
+					usersubscription.StatusEQ(domain.SubscriptionStatusActive),
 					usersubscription.ExpiresAtLTE(now),
 				),
 			),
 		)
-	case service.SubscriptionStatusRevoked:
+	case domain.SubscriptionStatusRevoked:
 		// Revoked is a DTO/API display state backed by user_subscriptions.deleted_at.
 		q = q.Where(usersubscription.DeletedAtNotNil())
 	case "":
@@ -335,7 +336,7 @@ func (r *userSubscriptionRepository) ExistsByUserIDAndGroupID(ctx context.Contex
 		Where(
 			usersubscription.UserIDEQ(userID),
 			usersubscription.GroupIDEQ(groupID),
-			usersubscription.StatusEQ(service.SubscriptionStatusActive),
+			usersubscription.StatusEQ(domain.SubscriptionStatusActive),
 			usersubscription.ExpiresAtGT(time.Now()),
 		).
 		Exist(ctx)
@@ -350,7 +351,7 @@ func (r *userSubscriptionRepository) ExtendExpiry(ctx context.Context, subscript
 	_, err := client.UserSubscription.UpdateOneID(subscriptionID).
 		SetExpiresAt(newExpiresAt).
 		Save(ctx)
-	return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+	return translatePersistenceError(err, domain.ErrSubscriptionNotFound, nil)
 }
 
 func (r *userSubscriptionRepository) UpdateStatus(ctx context.Context, subscriptionID int64, status string) error {
@@ -358,7 +359,7 @@ func (r *userSubscriptionRepository) UpdateStatus(ctx context.Context, subscript
 	_, err := client.UserSubscription.UpdateOneID(subscriptionID).
 		SetStatus(status).
 		Save(ctx)
-	return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+	return translatePersistenceError(err, domain.ErrSubscriptionNotFound, nil)
 }
 
 func (r *userSubscriptionRepository) UpdateNotes(ctx context.Context, subscriptionID int64, notes string) error {
@@ -366,7 +367,7 @@ func (r *userSubscriptionRepository) UpdateNotes(ctx context.Context, subscripti
 	_, err := client.UserSubscription.UpdateOneID(subscriptionID).
 		SetNotes(notes).
 		Save(ctx)
-	return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+	return translatePersistenceError(err, domain.ErrSubscriptionNotFound, nil)
 }
 
 func (r *userSubscriptionRepository) ActivateWindows(ctx context.Context, id int64, start time.Time) error {
@@ -376,7 +377,7 @@ func (r *userSubscriptionRepository) ActivateWindows(ctx context.Context, id int
 		SetWeeklyWindowStart(start).
 		SetMonthlyWindowStart(start).
 		Save(ctx)
-	return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+	return translatePersistenceError(err, domain.ErrSubscriptionNotFound, nil)
 }
 
 func (r *userSubscriptionRepository) ResetDailyUsage(ctx context.Context, id int64, newWindowStart time.Time) error {
@@ -385,7 +386,7 @@ func (r *userSubscriptionRepository) ResetDailyUsage(ctx context.Context, id int
 		SetDailyUsageUsd(0).
 		SetDailyWindowStart(newWindowStart).
 		Save(ctx)
-	return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+	return translatePersistenceError(err, domain.ErrSubscriptionNotFound, nil)
 }
 
 func (r *userSubscriptionRepository) ResetWeeklyUsage(ctx context.Context, id int64, newWindowStart time.Time) error {
@@ -394,7 +395,7 @@ func (r *userSubscriptionRepository) ResetWeeklyUsage(ctx context.Context, id in
 		SetWeeklyUsageUsd(0).
 		SetWeeklyWindowStart(newWindowStart).
 		Save(ctx)
-	return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+	return translatePersistenceError(err, domain.ErrSubscriptionNotFound, nil)
 }
 
 func (r *userSubscriptionRepository) ResetMonthlyUsage(ctx context.Context, id int64, newWindowStart time.Time) error {
@@ -403,7 +404,7 @@ func (r *userSubscriptionRepository) ResetMonthlyUsage(ctx context.Context, id i
 		SetMonthlyUsageUsd(0).
 		SetMonthlyWindowStart(newWindowStart).
 		Save(ctx)
-	return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+	return translatePersistenceError(err, domain.ErrSubscriptionNotFound, nil)
 }
 
 // IncrementUsage 原子性地累加订阅用量。
@@ -440,17 +441,17 @@ func (r *userSubscriptionRepository) IncrementUsage(ctx context.Context, id int6
 	}
 
 	// affected == 0：订阅不存在或已删除
-	return service.ErrSubscriptionNotFound
+	return domain.ErrSubscriptionNotFound
 }
 
 func (r *userSubscriptionRepository) BatchUpdateExpiredStatus(ctx context.Context) (int64, error) {
 	client := clientFromContext(ctx, r.client)
 	n, err := client.UserSubscription.Update().
 		Where(
-			usersubscription.StatusEQ(service.SubscriptionStatusActive),
+			usersubscription.StatusEQ(domain.SubscriptionStatusActive),
 			usersubscription.ExpiresAtLTE(time.Now()),
 		).
-		SetStatus(service.SubscriptionStatusExpired).
+		SetStatus(domain.SubscriptionStatusExpired).
 		Save(ctx)
 	return int64(n), err
 }
@@ -461,7 +462,7 @@ func (r *userSubscriptionRepository) ListExpired(ctx context.Context) ([]service
 	client := clientFromContext(ctx, r.client)
 	subs, err := client.UserSubscription.Query().
 		Where(
-			usersubscription.StatusEQ(service.SubscriptionStatusActive),
+			usersubscription.StatusEQ(domain.SubscriptionStatusActive),
 			usersubscription.ExpiresAtLTE(time.Now()),
 		).
 		All(ctx)
@@ -482,7 +483,7 @@ func (r *userSubscriptionRepository) CountActiveByGroupID(ctx context.Context, g
 	count, err := client.UserSubscription.Query().
 		Where(
 			usersubscription.GroupIDEQ(groupID),
-			usersubscription.StatusEQ(service.SubscriptionStatusActive),
+			usersubscription.StatusEQ(domain.SubscriptionStatusActive),
 			usersubscription.ExpiresAtGT(time.Now()),
 		).
 		Count(ctx)
@@ -579,7 +580,7 @@ func userSubscriptionEntityToServiceWithStatusMapping(m *dbent.UserSubscription,
 	}
 	status := m.Status
 	if mapDeletedToRevoked && m.DeletedAt != nil {
-		status = service.SubscriptionStatusRevoked
+		status = domain.SubscriptionStatusRevoked
 	}
 	out := &service.UserSubscription{
 		ID:                 m.ID,

--- a/backend/internal/repository/user_subscription_repo_integration_test.go
+++ b/backend/internal/repository/user_subscription_repo_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/suite"
@@ -36,13 +37,13 @@ func (s *UserSubscriptionRepoSuite) mustCreateUser(email string, role string) *s
 	s.T().Helper()
 
 	if role == "" {
-		role = service.RoleUser
+		role = domain.RoleUser
 	}
 
 	u, err := s.client.User.Create().
 		SetEmail(email).
 		SetPasswordHash("test-password-hash").
-		SetStatus(service.StatusActive).
+		SetStatus(domain.StatusActive).
 		SetRole(role).
 		Save(s.ctx)
 	s.Require().NoError(err, "create user")
@@ -54,7 +55,7 @@ func (s *UserSubscriptionRepoSuite) mustCreateGroup(name string) *service.Group 
 
 	g, err := s.client.Group.Create().
 		SetName(name).
-		SetStatus(service.StatusActive).
+		SetStatus(domain.StatusActive).
 		Save(s.ctx)
 	s.Require().NoError(err, "create group")
 	return groupEntityToService(g)
@@ -69,7 +70,7 @@ func (s *UserSubscriptionRepoSuite) mustCreateSubscription(userID, groupID int64
 		SetGroupID(groupID).
 		SetStartsAt(now.Add(-1 * time.Hour)).
 		SetExpiresAt(now.Add(24 * time.Hour)).
-		SetStatus(service.SubscriptionStatusActive).
+		SetStatus(domain.SubscriptionStatusActive).
 		SetAssignedAt(now).
 		SetNotes("")
 
@@ -85,13 +86,13 @@ func (s *UserSubscriptionRepoSuite) mustCreateSubscription(userID, groupID int64
 // --- Create / GetByID / Update / Delete ---
 
 func (s *UserSubscriptionRepoSuite) TestCreate() {
-	user := s.mustCreateUser("sub-create@test.com", service.RoleUser)
+	user := s.mustCreateUser("sub-create@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-create")
 
 	sub := &service.UserSubscription{
 		UserID:    user.ID,
 		GroupID:   group.ID,
-		Status:    service.SubscriptionStatusActive,
+		Status:    domain.SubscriptionStatusActive,
 		ExpiresAt: time.Now().Add(24 * time.Hour),
 	}
 
@@ -106,9 +107,9 @@ func (s *UserSubscriptionRepoSuite) TestCreate() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestGetByID_WithPreloads() {
-	user := s.mustCreateUser("preload@test.com", service.RoleUser)
+	user := s.mustCreateUser("preload@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-preload")
-	admin := s.mustCreateUser("admin@test.com", service.RoleAdmin)
+	admin := s.mustCreateUser("admin@test.com", domain.RoleAdmin)
 
 	sub := s.mustCreateSubscription(user.ID, group.ID, func(c *dbent.UserSubscriptionCreate) {
 		c.SetAssignedBy(admin.ID)
@@ -130,7 +131,7 @@ func (s *UserSubscriptionRepoSuite) TestGetByID_NotFound() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestUpdate() {
-	user := s.mustCreateUser("update@test.com", service.RoleUser)
+	user := s.mustCreateUser("update@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-update")
 	created := s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -146,7 +147,7 @@ func (s *UserSubscriptionRepoSuite) TestUpdate() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestDelete() {
-	user := s.mustCreateUser("delete@test.com", service.RoleUser)
+	user := s.mustCreateUser("delete@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-delete")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -158,38 +159,38 @@ func (s *UserSubscriptionRepoSuite) TestDelete() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestGetByIDIncludeDeleted_PreservesPersistedStatus() {
-	user := s.mustCreateUser("include-deleted@test.com", service.RoleUser)
+	user := s.mustCreateUser("include-deleted@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-include-deleted")
 	sub := s.mustCreateSubscription(user.ID, group.ID, func(c *dbent.UserSubscriptionCreate) {
-		c.SetStatus(service.SubscriptionStatusActive)
+		c.SetStatus(domain.SubscriptionStatusActive)
 	})
 
 	s.Require().NoError(s.repo.Delete(s.ctx, sub.ID), "Delete")
 
 	got, err := s.repo.GetByIDIncludeDeleted(s.ctx, sub.ID)
 	s.Require().NoError(err, "GetByIDIncludeDeleted")
-	s.Require().Equal(service.SubscriptionStatusActive, got.Status)
+	s.Require().Equal(domain.SubscriptionStatusActive, got.Status)
 	s.Require().NotNil(got.DeletedAt)
 	s.Require().NotNil(got.User)
 	s.Require().NotNil(got.Group)
 }
 
 func (s *UserSubscriptionRepoSuite) TestRestore() {
-	user := s.mustCreateUser("restore@test.com", service.RoleUser)
+	user := s.mustCreateUser("restore@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-restore")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
 	s.Require().NoError(s.repo.Delete(s.ctx, sub.ID), "Delete")
 
-	restored, err := s.repo.Restore(s.ctx, sub.ID, service.SubscriptionStatusExpired)
+	restored, err := s.repo.Restore(s.ctx, sub.ID, domain.SubscriptionStatusExpired)
 	s.Require().NoError(err, "Restore")
-	s.Require().Equal(service.SubscriptionStatusExpired, restored.Status)
+	s.Require().Equal(domain.SubscriptionStatusExpired, restored.Status)
 	s.Require().Nil(restored.DeletedAt)
 
 	got, err := s.repo.GetByID(s.ctx, sub.ID)
 	s.Require().NoError(err, "GetByID after restore")
 	s.Require().Nil(got.DeletedAt)
-	s.Require().Equal(service.SubscriptionStatusExpired, got.Status)
+	s.Require().Equal(domain.SubscriptionStatusExpired, got.Status)
 }
 
 func (s *UserSubscriptionRepoSuite) TestDelete_Idempotent() {
@@ -199,7 +200,7 @@ func (s *UserSubscriptionRepoSuite) TestDelete_Idempotent() {
 // --- GetByUserIDAndGroupID / GetActiveByUserIDAndGroupID ---
 
 func (s *UserSubscriptionRepoSuite) TestGetByUserIDAndGroupID() {
-	user := s.mustCreateUser("byuser@test.com", service.RoleUser)
+	user := s.mustCreateUser("byuser@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-byuser")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -215,7 +216,7 @@ func (s *UserSubscriptionRepoSuite) TestGetByUserIDAndGroupID_NotFound() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestGetActiveByUserIDAndGroupID() {
-	user := s.mustCreateUser("active@test.com", service.RoleUser)
+	user := s.mustCreateUser("active@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-active")
 
 	active := s.mustCreateSubscription(user.ID, group.ID, func(c *dbent.UserSubscriptionCreate) {
@@ -228,7 +229,7 @@ func (s *UserSubscriptionRepoSuite) TestGetActiveByUserIDAndGroupID() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestGetActiveByUserIDAndGroupID_ExpiredIgnored() {
-	user := s.mustCreateUser("expired@test.com", service.RoleUser)
+	user := s.mustCreateUser("expired@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-expired")
 
 	s.mustCreateSubscription(user.ID, group.ID, func(c *dbent.UserSubscriptionCreate) {
@@ -242,13 +243,13 @@ func (s *UserSubscriptionRepoSuite) TestGetActiveByUserIDAndGroupID_ExpiredIgnor
 // --- ListByUserID / ListActiveByUserID ---
 
 func (s *UserSubscriptionRepoSuite) TestListByUserID() {
-	user := s.mustCreateUser("listby@test.com", service.RoleUser)
+	user := s.mustCreateUser("listby@test.com", domain.RoleUser)
 	g1 := s.mustCreateGroup("g-list1")
 	g2 := s.mustCreateGroup("g-list2")
 
 	s.mustCreateSubscription(user.ID, g1.ID, nil)
 	s.mustCreateSubscription(user.ID, g2.ID, func(c *dbent.UserSubscriptionCreate) {
-		c.SetStatus(service.SubscriptionStatusExpired)
+		c.SetStatus(domain.SubscriptionStatusExpired)
 		c.SetExpiresAt(time.Now().Add(-24 * time.Hour))
 	})
 
@@ -261,7 +262,7 @@ func (s *UserSubscriptionRepoSuite) TestListByUserID() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestListActiveByUserID() {
-	user := s.mustCreateUser("listactive@test.com", service.RoleUser)
+	user := s.mustCreateUser("listactive@test.com", domain.RoleUser)
 	g1 := s.mustCreateGroup("g-act1")
 	g2 := s.mustCreateGroup("g-act2")
 
@@ -269,21 +270,21 @@ func (s *UserSubscriptionRepoSuite) TestListActiveByUserID() {
 		c.SetExpiresAt(time.Now().Add(24 * time.Hour))
 	})
 	s.mustCreateSubscription(user.ID, g2.ID, func(c *dbent.UserSubscriptionCreate) {
-		c.SetStatus(service.SubscriptionStatusExpired)
+		c.SetStatus(domain.SubscriptionStatusExpired)
 		c.SetExpiresAt(time.Now().Add(-24 * time.Hour))
 	})
 
 	subs, err := s.repo.ListActiveByUserID(s.ctx, user.ID)
 	s.Require().NoError(err, "ListActiveByUserID")
 	s.Require().Len(subs, 1)
-	s.Require().Equal(service.SubscriptionStatusActive, subs[0].Status)
+	s.Require().Equal(domain.SubscriptionStatusActive, subs[0].Status)
 }
 
 // --- ListByGroupID ---
 
 func (s *UserSubscriptionRepoSuite) TestListByGroupID() {
-	user1 := s.mustCreateUser("u1@test.com", service.RoleUser)
-	user2 := s.mustCreateUser("u2@test.com", service.RoleUser)
+	user1 := s.mustCreateUser("u1@test.com", domain.RoleUser)
+	user2 := s.mustCreateUser("u2@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-listgrp")
 
 	s.mustCreateSubscription(user1.ID, group.ID, nil)
@@ -302,7 +303,7 @@ func (s *UserSubscriptionRepoSuite) TestListByGroupID() {
 // --- List with filters ---
 
 func (s *UserSubscriptionRepoSuite) TestList_NoFilters() {
-	user := s.mustCreateUser("list@test.com", service.RoleUser)
+	user := s.mustCreateUser("list@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-list")
 	s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -313,8 +314,8 @@ func (s *UserSubscriptionRepoSuite) TestList_NoFilters() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestList_FilterByUserID() {
-	user1 := s.mustCreateUser("filter1@test.com", service.RoleUser)
-	user2 := s.mustCreateUser("filter2@test.com", service.RoleUser)
+	user1 := s.mustCreateUser("filter1@test.com", domain.RoleUser)
+	user2 := s.mustCreateUser("filter2@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-filter")
 
 	s.mustCreateSubscription(user1.ID, group.ID, nil)
@@ -327,7 +328,7 @@ func (s *UserSubscriptionRepoSuite) TestList_FilterByUserID() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestList_FilterByGroupID() {
-	user := s.mustCreateUser("grpfilter@test.com", service.RoleUser)
+	user := s.mustCreateUser("grpfilter@test.com", domain.RoleUser)
 	g1 := s.mustCreateGroup("g-f1")
 	g2 := s.mustCreateGroup("g-f2")
 
@@ -341,37 +342,37 @@ func (s *UserSubscriptionRepoSuite) TestList_FilterByGroupID() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestList_FilterByStatus() {
-	user1 := s.mustCreateUser("statfilter1@test.com", service.RoleUser)
-	user2 := s.mustCreateUser("statfilter2@test.com", service.RoleUser)
+	user1 := s.mustCreateUser("statfilter1@test.com", domain.RoleUser)
+	user2 := s.mustCreateUser("statfilter2@test.com", domain.RoleUser)
 	group1 := s.mustCreateGroup("g-stat-1")
 	group2 := s.mustCreateGroup("g-stat-2")
 
 	s.mustCreateSubscription(user1.ID, group1.ID, func(c *dbent.UserSubscriptionCreate) {
-		c.SetStatus(service.SubscriptionStatusActive)
+		c.SetStatus(domain.SubscriptionStatusActive)
 		c.SetExpiresAt(time.Now().Add(24 * time.Hour))
 	})
 	s.mustCreateSubscription(user2.ID, group2.ID, func(c *dbent.UserSubscriptionCreate) {
-		c.SetStatus(service.SubscriptionStatusExpired)
+		c.SetStatus(domain.SubscriptionStatusExpired)
 		c.SetExpiresAt(time.Now().Add(-24 * time.Hour))
 	})
 
-	subs, _, err := s.repo.List(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, nil, nil, service.SubscriptionStatusExpired, "", "", "")
+	subs, _, err := s.repo.List(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, nil, nil, domain.SubscriptionStatusExpired, "", "", "")
 	s.Require().NoError(err)
 	s.Require().Len(subs, 1)
-	s.Require().Equal(service.SubscriptionStatusExpired, subs[0].Status)
+	s.Require().Equal(domain.SubscriptionStatusExpired, subs[0].Status)
 }
 
 func (s *UserSubscriptionRepoSuite) TestList_IncludesRevokedWhenStatusEmpty() {
-	user1 := s.mustCreateUser("allstatus1@test.com", service.RoleUser)
-	user2 := s.mustCreateUser("allstatus2@test.com", service.RoleUser)
-	user3 := s.mustCreateUser("allstatus3@test.com", service.RoleUser)
+	user1 := s.mustCreateUser("allstatus1@test.com", domain.RoleUser)
+	user2 := s.mustCreateUser("allstatus2@test.com", domain.RoleUser)
+	user3 := s.mustCreateUser("allstatus3@test.com", domain.RoleUser)
 	group1 := s.mustCreateGroup("g-allstatus-1")
 	group2 := s.mustCreateGroup("g-allstatus-2")
 	group3 := s.mustCreateGroup("g-allstatus-3")
 
 	s.mustCreateSubscription(user1.ID, group1.ID, nil)
 	s.mustCreateSubscription(user2.ID, group2.ID, func(c *dbent.UserSubscriptionCreate) {
-		c.SetStatus(service.SubscriptionStatusExpired)
+		c.SetStatus(domain.SubscriptionStatusExpired)
 		c.SetExpiresAt(time.Now().Add(-24 * time.Hour))
 	})
 	revoked := s.mustCreateSubscription(user3.ID, group3.ID, nil)
@@ -390,15 +391,15 @@ func (s *UserSubscriptionRepoSuite) TestList_IncludesRevokedWhenStatusEmpty() {
 		}
 	}
 	s.Require().NotNil(gotRevoked, "all status should include soft-deleted subscription")
-	s.Require().Equal(service.SubscriptionStatusRevoked, gotRevoked.Status)
+	s.Require().Equal(domain.SubscriptionStatusRevoked, gotRevoked.Status)
 	s.Require().NotNil(gotRevoked.DeletedAt)
 	s.Require().NotNil(gotRevoked.User)
 	s.Require().NotNil(gotRevoked.Group)
 }
 
 func (s *UserSubscriptionRepoSuite) TestList_FilterByRevokedStatus() {
-	user1 := s.mustCreateUser("revokedfilter1@test.com", service.RoleUser)
-	user2 := s.mustCreateUser("revokedfilter2@test.com", service.RoleUser)
+	user1 := s.mustCreateUser("revokedfilter1@test.com", domain.RoleUser)
+	user2 := s.mustCreateUser("revokedfilter2@test.com", domain.RoleUser)
 	group1 := s.mustCreateGroup("g-revoked-1")
 	group2 := s.mustCreateGroup("g-revoked-2")
 
@@ -406,20 +407,20 @@ func (s *UserSubscriptionRepoSuite) TestList_FilterByRevokedStatus() {
 	revoked := s.mustCreateSubscription(user2.ID, group2.ID, nil)
 	s.Require().NoError(s.repo.Delete(s.ctx, revoked.ID))
 
-	subs, pag, err := s.repo.List(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, nil, nil, service.SubscriptionStatusRevoked, "", "", "")
+	subs, pag, err := s.repo.List(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, nil, nil, domain.SubscriptionStatusRevoked, "", "", "")
 	s.Require().NoError(err)
 	s.Require().Len(subs, 1)
 	s.Require().Equal(int64(1), pag.Total)
 	s.Require().Equal(revoked.ID, subs[0].ID)
 	s.Require().NotEqual(active.ID, subs[0].ID)
-	s.Require().Equal(service.SubscriptionStatusRevoked, subs[0].Status)
+	s.Require().Equal(domain.SubscriptionStatusRevoked, subs[0].Status)
 	s.Require().NotNil(subs[0].DeletedAt)
 }
 
 // --- Usage tracking ---
 
 func (s *UserSubscriptionRepoSuite) TestIncrementUsage() {
-	user := s.mustCreateUser("usage@test.com", service.RoleUser)
+	user := s.mustCreateUser("usage@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-usage")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -434,7 +435,7 @@ func (s *UserSubscriptionRepoSuite) TestIncrementUsage() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestIncrementUsage_Accumulates() {
-	user := s.mustCreateUser("accum@test.com", service.RoleUser)
+	user := s.mustCreateUser("accum@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-accum")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -447,7 +448,7 @@ func (s *UserSubscriptionRepoSuite) TestIncrementUsage_Accumulates() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestActivateWindows() {
-	user := s.mustCreateUser("activate@test.com", service.RoleUser)
+	user := s.mustCreateUser("activate@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-activate")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -464,7 +465,7 @@ func (s *UserSubscriptionRepoSuite) TestActivateWindows() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestResetDailyUsage() {
-	user := s.mustCreateUser("resetd@test.com", service.RoleUser)
+	user := s.mustCreateUser("resetd@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-resetd")
 	sub := s.mustCreateSubscription(user.ID, group.ID, func(c *dbent.UserSubscriptionCreate) {
 		c.SetDailyUsageUsd(10.0)
@@ -484,7 +485,7 @@ func (s *UserSubscriptionRepoSuite) TestResetDailyUsage() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestResetWeeklyUsage() {
-	user := s.mustCreateUser("resetw@test.com", service.RoleUser)
+	user := s.mustCreateUser("resetw@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-resetw")
 	sub := s.mustCreateSubscription(user.ID, group.ID, func(c *dbent.UserSubscriptionCreate) {
 		c.SetWeeklyUsageUsd(15.0)
@@ -504,7 +505,7 @@ func (s *UserSubscriptionRepoSuite) TestResetWeeklyUsage() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestResetMonthlyUsage() {
-	user := s.mustCreateUser("resetm@test.com", service.RoleUser)
+	user := s.mustCreateUser("resetm@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-resetm")
 	sub := s.mustCreateSubscription(user.ID, group.ID, func(c *dbent.UserSubscriptionCreate) {
 		c.SetMonthlyUsageUsd(25.0)
@@ -524,20 +525,20 @@ func (s *UserSubscriptionRepoSuite) TestResetMonthlyUsage() {
 // --- UpdateStatus / ExtendExpiry / UpdateNotes ---
 
 func (s *UserSubscriptionRepoSuite) TestUpdateStatus() {
-	user := s.mustCreateUser("status@test.com", service.RoleUser)
+	user := s.mustCreateUser("status@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-status")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
-	err := s.repo.UpdateStatus(s.ctx, sub.ID, service.SubscriptionStatusExpired)
+	err := s.repo.UpdateStatus(s.ctx, sub.ID, domain.SubscriptionStatusExpired)
 	s.Require().NoError(err, "UpdateStatus")
 
 	got, err := s.repo.GetByID(s.ctx, sub.ID)
 	s.Require().NoError(err)
-	s.Require().Equal(service.SubscriptionStatusExpired, got.Status)
+	s.Require().Equal(domain.SubscriptionStatusExpired, got.Status)
 }
 
 func (s *UserSubscriptionRepoSuite) TestExtendExpiry() {
-	user := s.mustCreateUser("extend@test.com", service.RoleUser)
+	user := s.mustCreateUser("extend@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-extend")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -551,7 +552,7 @@ func (s *UserSubscriptionRepoSuite) TestExtendExpiry() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestUpdateNotes() {
-	user := s.mustCreateUser("notes@test.com", service.RoleUser)
+	user := s.mustCreateUser("notes@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-notes")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -566,7 +567,7 @@ func (s *UserSubscriptionRepoSuite) TestUpdateNotes() {
 // --- ListExpired / BatchUpdateExpiredStatus ---
 
 func (s *UserSubscriptionRepoSuite) TestListExpired() {
-	user := s.mustCreateUser("listexp@test.com", service.RoleUser)
+	user := s.mustCreateUser("listexp@test.com", domain.RoleUser)
 	groupActive := s.mustCreateGroup("g-listexp-active")
 	groupExpired := s.mustCreateGroup("g-listexp-expired")
 
@@ -583,7 +584,7 @@ func (s *UserSubscriptionRepoSuite) TestListExpired() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestBatchUpdateExpiredStatus() {
-	user := s.mustCreateUser("batch@test.com", service.RoleUser)
+	user := s.mustCreateUser("batch@test.com", domain.RoleUser)
 	groupFuture := s.mustCreateGroup("g-batch-future")
 	groupPast := s.mustCreateGroup("g-batch-past")
 
@@ -599,16 +600,16 @@ func (s *UserSubscriptionRepoSuite) TestBatchUpdateExpiredStatus() {
 	s.Require().Equal(int64(1), affected)
 
 	gotActive, _ := s.repo.GetByID(s.ctx, active.ID)
-	s.Require().Equal(service.SubscriptionStatusActive, gotActive.Status)
+	s.Require().Equal(domain.SubscriptionStatusActive, gotActive.Status)
 
 	gotExpired, _ := s.repo.GetByID(s.ctx, expiredActive.ID)
-	s.Require().Equal(service.SubscriptionStatusExpired, gotExpired.Status)
+	s.Require().Equal(domain.SubscriptionStatusExpired, gotExpired.Status)
 }
 
 // --- ExistsByUserIDAndGroupID ---
 
 func (s *UserSubscriptionRepoSuite) TestExistsByUserIDAndGroupID() {
-	user := s.mustCreateUser("exists@test.com", service.RoleUser)
+	user := s.mustCreateUser("exists@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-exists")
 
 	s.mustCreateSubscription(user.ID, group.ID, nil)
@@ -627,7 +628,7 @@ func (s *UserSubscriptionRepoSuite) TestExistsByUserIDAndGroupID() {
 // "exists" — otherwise reassignment is blocked with a 409 validity_days_mismatch
 // even though the previous subscription is functionally dead.
 func (s *UserSubscriptionRepoSuite) TestExistsByUserIDAndGroupID_IgnoresExpiredAndNonActive() {
-	user := s.mustCreateUser("exists-expired@test.com", service.RoleUser)
+	user := s.mustCreateUser("exists-expired@test.com", domain.RoleUser)
 	groupExpiredByDate := s.mustCreateGroup("g-expired-by-date")
 	groupExpiredByStatus := s.mustCreateGroup("g-expired-by-status")
 	groupSuspended := s.mustCreateGroup("g-suspended")
@@ -638,11 +639,11 @@ func (s *UserSubscriptionRepoSuite) TestExistsByUserIDAndGroupID_IgnoresExpiredA
 	})
 	// status=expired row — should not block reassignment.
 	s.mustCreateSubscription(user.ID, groupExpiredByStatus.ID, func(c *dbent.UserSubscriptionCreate) {
-		c.SetStatus(service.SubscriptionStatusExpired)
+		c.SetStatus(domain.SubscriptionStatusExpired)
 	})
 	// status=suspended row — should not block reassignment.
 	s.mustCreateSubscription(user.ID, groupSuspended.ID, func(c *dbent.UserSubscriptionCreate) {
-		c.SetStatus(service.SubscriptionStatusSuspended)
+		c.SetStatus(domain.SubscriptionStatusSuspended)
 	})
 
 	for _, gid := range []int64{groupExpiredByDate.ID, groupExpiredByStatus.ID, groupSuspended.ID} {
@@ -653,7 +654,7 @@ func (s *UserSubscriptionRepoSuite) TestExistsByUserIDAndGroupID_IgnoresExpiredA
 }
 
 func (s *UserSubscriptionRepoSuite) TestExistsActiveByUserIDAndGroupID_IgnoresSoftDeletedRows() {
-	user := s.mustCreateUser("exists-active@test.com", service.RoleUser)
+	user := s.mustCreateUser("exists-active@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-exists-active")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -671,13 +672,13 @@ func (s *UserSubscriptionRepoSuite) TestExistsActiveByUserIDAndGroupID_IgnoresSo
 // --- CountByGroupID / CountActiveByGroupID ---
 
 func (s *UserSubscriptionRepoSuite) TestCountByGroupID() {
-	user1 := s.mustCreateUser("cnt1@test.com", service.RoleUser)
-	user2 := s.mustCreateUser("cnt2@test.com", service.RoleUser)
+	user1 := s.mustCreateUser("cnt1@test.com", domain.RoleUser)
+	user2 := s.mustCreateUser("cnt2@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-count")
 
 	s.mustCreateSubscription(user1.ID, group.ID, nil)
 	s.mustCreateSubscription(user2.ID, group.ID, func(c *dbent.UserSubscriptionCreate) {
-		c.SetStatus(service.SubscriptionStatusExpired)
+		c.SetStatus(domain.SubscriptionStatusExpired)
 		c.SetExpiresAt(time.Now().Add(-24 * time.Hour))
 	})
 
@@ -687,8 +688,8 @@ func (s *UserSubscriptionRepoSuite) TestCountByGroupID() {
 }
 
 func (s *UserSubscriptionRepoSuite) TestCountActiveByGroupID() {
-	user1 := s.mustCreateUser("cntact1@test.com", service.RoleUser)
-	user2 := s.mustCreateUser("cntact2@test.com", service.RoleUser)
+	user1 := s.mustCreateUser("cntact1@test.com", domain.RoleUser)
+	user2 := s.mustCreateUser("cntact2@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-cntact")
 
 	s.mustCreateSubscription(user1.ID, group.ID, func(c *dbent.UserSubscriptionCreate) {
@@ -706,8 +707,8 @@ func (s *UserSubscriptionRepoSuite) TestCountActiveByGroupID() {
 // --- DeleteByGroupID ---
 
 func (s *UserSubscriptionRepoSuite) TestDeleteByGroupID() {
-	user1 := s.mustCreateUser("delgrp1@test.com", service.RoleUser)
-	user2 := s.mustCreateUser("delgrp2@test.com", service.RoleUser)
+	user1 := s.mustCreateUser("delgrp1@test.com", domain.RoleUser)
+	user2 := s.mustCreateUser("delgrp2@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-delgrp")
 
 	s.mustCreateSubscription(user1.ID, group.ID, nil)
@@ -724,7 +725,7 @@ func (s *UserSubscriptionRepoSuite) TestDeleteByGroupID() {
 // --- Combined scenario ---
 
 func (s *UserSubscriptionRepoSuite) TestActiveExpiredBoundaries_UsageAndReset_BatchUpdateExpiredStatus() {
-	user := s.mustCreateUser("subr@example.com", service.RoleUser)
+	user := s.mustCreateUser("subr@example.com", domain.RoleUser)
 	groupActive := s.mustCreateGroup("g-subr-active")
 	groupExpired := s.mustCreateGroup("g-subr-expired")
 
@@ -766,13 +767,13 @@ func (s *UserSubscriptionRepoSuite) TestActiveExpiredBoundaries_UsageAndReset_Ba
 
 	updated, err := s.repo.GetByID(s.ctx, expiredActive.ID)
 	s.Require().NoError(err, "GetByID expired")
-	s.Require().Equal(service.SubscriptionStatusExpired, updated.Status, "expected status expired")
+	s.Require().Equal(domain.SubscriptionStatusExpired, updated.Status, "expected status expired")
 }
 
 // --- 软删除过滤测试 ---
 
 func (s *UserSubscriptionRepoSuite) TestIncrementUsage_SoftDeletedGroup() {
-	user := s.mustCreateUser("softdeleted@test.com", service.RoleUser)
+	user := s.mustCreateUser("softdeleted@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-softdeleted")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -783,13 +784,13 @@ func (s *UserSubscriptionRepoSuite) TestIncrementUsage_SoftDeletedGroup() {
 	// IncrementUsage 应该失败，因为分组已软删除
 	err = s.repo.IncrementUsage(s.ctx, sub.ID, 1.0)
 	s.Require().Error(err, "should fail for soft-deleted group")
-	s.Require().ErrorIs(err, service.ErrSubscriptionNotFound)
+	s.Require().ErrorIs(err, domain.ErrSubscriptionNotFound)
 }
 
 func (s *UserSubscriptionRepoSuite) TestIncrementUsage_NotFound() {
 	err := s.repo.IncrementUsage(s.ctx, 999999, 1.0)
 	s.Require().Error(err, "should fail for non-existent subscription")
-	s.Require().ErrorIs(err, service.ErrSubscriptionNotFound)
+	s.Require().ErrorIs(err, domain.ErrSubscriptionNotFound)
 }
 
 // --- nil 入参测试 ---
@@ -797,19 +798,19 @@ func (s *UserSubscriptionRepoSuite) TestIncrementUsage_NotFound() {
 func (s *UserSubscriptionRepoSuite) TestCreate_NilInput() {
 	err := s.repo.Create(s.ctx, nil)
 	s.Require().Error(err, "Create should fail with nil input")
-	s.Require().ErrorIs(err, service.ErrSubscriptionNilInput)
+	s.Require().ErrorIs(err, domain.ErrSubscriptionNilInput)
 }
 
 func (s *UserSubscriptionRepoSuite) TestUpdate_NilInput() {
 	err := s.repo.Update(s.ctx, nil)
 	s.Require().Error(err, "Update should fail with nil input")
-	s.Require().ErrorIs(err, service.ErrSubscriptionNilInput)
+	s.Require().ErrorIs(err, domain.ErrSubscriptionNilInput)
 }
 
 // --- 并发用量更新测试 ---
 
 func (s *UserSubscriptionRepoSuite) TestIncrementUsage_Concurrent() {
-	user := s.mustCreateUser("concurrent@test.com", service.RoleUser)
+	user := s.mustCreateUser("concurrent@test.com", domain.RoleUser)
 	group := s.mustCreateGroup("g-concurrent")
 	sub := s.mustCreateSubscription(user.ID, group.ID, nil)
 
@@ -868,7 +869,7 @@ func (s *UserSubscriptionRepoSuite) TestTxContext_RollbackIsolation() {
 		UserID:     userEnt.ID,
 		GroupID:    groupEnt.ID,
 		ExpiresAt:  time.Now().AddDate(0, 0, 30),
-		Status:     service.SubscriptionStatusActive,
+		Status:     domain.SubscriptionStatusActive,
 		AssignedAt: time.Now(),
 		Notes:      "tx",
 	}
@@ -879,5 +880,5 @@ func (s *UserSubscriptionRepoSuite) TestTxContext_RollbackIsolation() {
 	tx = nil
 
 	_, err = repo.GetByID(context.Background(), sub.ID)
-	s.Require().ErrorIs(err, service.ErrSubscriptionNotFound)
+	s.Require().ErrorIs(err, domain.ErrSubscriptionNotFound)
 }

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 )
 
 var (
-	ErrAccountNotFound      = infraerrors.NotFound("ACCOUNT_NOT_FOUND", "account not found")
-	ErrAccountNilInput      = infraerrors.BadRequest("ACCOUNT_NIL_INPUT", "account input cannot be nil")
+	ErrAccountNotFound      = domain.ErrAccountNotFound
+	ErrAccountNilInput      = domain.ErrAccountNilInput
 	ErrAccountNotInFallback = infraerrors.BadRequest("ACCOUNT_NOT_IN_FALLBACK", "account is not in proxy fallback state")
 )
 

--- a/backend/internal/service/affiliate_service.go
+++ b/backend/internal/service/affiliate_service.go
@@ -7,16 +7,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 )
 
 var (
-	ErrAffiliateProfileNotFound = infraerrors.NotFound("AFFILIATE_PROFILE_NOT_FOUND", "affiliate profile not found")
-	ErrAffiliateCodeInvalid     = infraerrors.BadRequest("AFFILIATE_CODE_INVALID", "invalid affiliate code")
-	ErrAffiliateCodeTaken       = infraerrors.Conflict("AFFILIATE_CODE_TAKEN", "affiliate code already in use")
+	ErrAffiliateProfileNotFound = domain.ErrAffiliateProfileNotFound
+	ErrAffiliateCodeInvalid     = domain.ErrAffiliateCodeInvalid
+	ErrAffiliateCodeTaken       = domain.ErrAffiliateCodeTaken
 	ErrAffiliateAlreadyBound    = infraerrors.Conflict("AFFILIATE_ALREADY_BOUND", "affiliate inviter already bound")
-	ErrAffiliateQuotaEmpty      = infraerrors.BadRequest("AFFILIATE_QUOTA_EMPTY", "no affiliate quota available to transfer")
+	ErrAffiliateQuotaEmpty      = domain.ErrAffiliateQuotaEmpty
 )
 
 const (

--- a/backend/internal/service/api_key_service.go
+++ b/backend/internal/service/api_key_service.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
@@ -21,9 +22,9 @@ import (
 )
 
 var (
-	ErrAPIKeyNotFound     = infraerrors.NotFound("API_KEY_NOT_FOUND", "api key not found")
+	ErrAPIKeyNotFound     = domain.ErrAPIKeyNotFound
 	ErrGroupNotAllowed    = infraerrors.Forbidden("GROUP_NOT_ALLOWED", "user is not allowed to bind this group")
-	ErrAPIKeyExists       = infraerrors.Conflict("API_KEY_EXISTS", "api key already exists")
+	ErrAPIKeyExists       = domain.ErrAPIKeyExists
 	ErrAPIKeyTooShort     = infraerrors.BadRequest("API_KEY_TOO_SHORT", "api key must be at least 16 characters")
 	ErrAPIKeyInvalidChars = infraerrors.BadRequest("API_KEY_INVALID_CHARS", "api key can only contain letters, numbers, underscores, and hyphens")
 	ErrAPIKeyRateLimited  = infraerrors.TooManyRequests("API_KEY_RATE_LIMITED", "too many failed attempts, please try again later")

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -17,6 +17,7 @@ import (
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/ent/authidentity"
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 
@@ -27,7 +28,7 @@ import (
 var (
 	ErrInvalidCredentials      = infraerrors.Unauthorized("INVALID_CREDENTIALS", "invalid email or password")
 	ErrUserNotActive           = infraerrors.Forbidden("USER_NOT_ACTIVE", "user is not active")
-	ErrEmailExists             = infraerrors.Conflict("EMAIL_EXISTS", "email already exists")
+	ErrEmailExists             = domain.ErrEmailExists
 	ErrEmailReserved           = infraerrors.BadRequest("EMAIL_RESERVED", "email is reserved")
 	ErrInvalidToken            = infraerrors.Unauthorized("INVALID_TOKEN", "invalid token")
 	ErrTokenExpired            = infraerrors.Unauthorized("TOKEN_EXPIRED", "token has expired")

--- a/backend/internal/service/channel_monitor_const.go
+++ b/backend/internal/service/channel_monitor_const.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/apipath"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 )
 
@@ -110,9 +111,7 @@ const (
 
 // 业务错误（统一在此声明，避免散落）。
 var (
-	ErrChannelMonitorNotFound = infraerrors.NotFound(
-		"CHANNEL_MONITOR_NOT_FOUND", "channel monitor not found",
-	)
+	ErrChannelMonitorNotFound        = domain.ErrChannelMonitorNotFound
 	ErrChannelMonitorInvalidProvider = infraerrors.BadRequest(
 		"CHANNEL_MONITOR_INVALID_PROVIDER", "provider must be one of openai/anthropic/gemini",
 	)

--- a/backend/internal/service/channel_monitor_template_types.go
+++ b/backend/internal/service/channel_monitor_template_types.go
@@ -1,8 +1,10 @@
 package service
 
 import (
-	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 )
 
 // ChannelMonitorRequestTemplate 请求模板（service 层模型）。
@@ -51,9 +53,7 @@ type ChannelMonitorRequestTemplateUpdateParams struct {
 
 // 模板相关错误（命名与现有 ErrChannelMonitor* 风格保持一致）。
 var (
-	ErrChannelMonitorTemplateNotFound = infraerrors.NotFound(
-		"CHANNEL_MONITOR_TEMPLATE_NOT_FOUND", "channel monitor request template not found",
-	)
+	ErrChannelMonitorTemplateNotFound        = domain.ErrChannelMonitorTemplateNotFound
 	ErrChannelMonitorTemplateInvalidProvider = infraerrors.BadRequest(
 		"CHANNEL_MONITOR_TEMPLATE_INVALID_PROVIDER", "template provider must be one of openai/anthropic/gemini",
 	)

--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/tidwall/gjson"
@@ -16,8 +17,8 @@ import (
 )
 
 var (
-	ErrChannelNotFound       = infraerrors.NotFound("CHANNEL_NOT_FOUND", "channel not found")
-	ErrChannelExists         = infraerrors.Conflict("CHANNEL_EXISTS", "channel name already exists")
+	ErrChannelNotFound       = domain.ErrChannelNotFound
+	ErrChannelExists         = domain.ErrChannelExists
 	ErrGroupAlreadyInChannel = infraerrors.Conflict(
 		"GROUP_ALREADY_IN_CHANNEL",
 		"one or more groups already belong to another channel",

--- a/backend/internal/service/group_service.go
+++ b/backend/internal/service/group_service.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 )
 
 var (
-	ErrGroupNotFound = infraerrors.NotFound("GROUP_NOT_FOUND", "group not found")
-	ErrGroupExists   = infraerrors.Conflict("GROUP_EXISTS", "group name already exists")
+	ErrGroupNotFound = domain.ErrGroupNotFound
+	ErrGroupExists   = domain.ErrGroupExists
 )
 
 type GroupRepository interface {

--- a/backend/internal/service/ops_dashboard_models.go
+++ b/backend/internal/service/ops_dashboard_models.go
@@ -1,6 +1,10 @@
 package service
 
-import "time"
+import (
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+)
 
 type OpsDashboardFilter struct {
 	StartTime time.Time
@@ -20,14 +24,7 @@ type OpsRateSummary struct {
 	Avg     float64 `json:"avg"`
 }
 
-type OpsPercentiles struct {
-	P50 *int `json:"p50_ms"`
-	P90 *int `json:"p90_ms"`
-	P95 *int `json:"p95_ms"`
-	P99 *int `json:"p99_ms"`
-	Avg *int `json:"avg_ms"`
-	Max *int `json:"max_ms"`
-}
+type OpsPercentiles = domain.OpsPercentiles
 
 type OpsDashboardOverview struct {
 	StartTime time.Time `json:"start_time"`

--- a/backend/internal/service/promo_service.go
+++ b/backend/internal/service/promo_service.go
@@ -9,12 +9,13 @@ import (
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 )
 
 var (
-	ErrPromoCodeNotFound    = infraerrors.NotFound("PROMO_CODE_NOT_FOUND", "promo code not found")
+	ErrPromoCodeNotFound    = domain.ErrPromoCodeNotFound
 	ErrPromoCodeExpired     = infraerrors.BadRequest("PROMO_CODE_EXPIRED", "promo code has expired")
 	ErrPromoCodeDisabled    = infraerrors.BadRequest("PROMO_CODE_DISABLED", "promo code is disabled")
 	ErrPromoCodeMaxUsed     = infraerrors.BadRequest("PROMO_CODE_MAX_USED", "promo code has reached maximum uses")

--- a/backend/internal/service/proxy.go
+++ b/backend/internal/service/proxy.go
@@ -1,10 +1,7 @@
 package service
 
 import (
-	"net"
-	"net/url"
-	"strconv"
-	"time"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 )
 
 const (
@@ -13,42 +10,7 @@ const (
 	FallbackModeDirect = "direct"
 )
 
-type Proxy struct {
-	ID             int64
-	Name           string
-	Protocol       string
-	Host           string
-	Port           int
-	Username       string
-	Password       string
-	Status         string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	ExpiresAt      *time.Time
-	FallbackMode   string
-	BackupProxyID  *int64
-	ExpiryWarnDays int
-}
-
-func (p *Proxy) IsActive() bool {
-	return p.Status == StatusActive
-}
-
-// IsExpired 报告代理是否已过期（基于 expires_at，与 status 无关）。
-func (p *Proxy) IsExpired(now time.Time) bool {
-	return p.ExpiresAt != nil && !p.ExpiresAt.After(now)
-}
-
-func (p *Proxy) URL() string {
-	u := &url.URL{
-		Scheme: p.Protocol,
-		Host:   net.JoinHostPort(p.Host, strconv.Itoa(p.Port)),
-	}
-	if p.Username != "" && p.Password != "" {
-		u.User = url.UserPassword(p.Username, p.Password)
-	}
-	return u.String()
-}
+type Proxy = domain.Proxy
 
 type ProxyWithAccountCount struct {
 	Proxy

--- a/backend/internal/service/proxy_service.go
+++ b/backend/internal/service/proxy_service.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 )
 
 var (
-	ErrProxyNotFound = infraerrors.NotFound("PROXY_NOT_FOUND", "proxy not found")
+	ErrProxyNotFound = domain.ErrProxyNotFound
 	ErrProxyInUse    = infraerrors.Conflict("PROXY_IN_USE", "proxy is in use by accounts")
 )
 

--- a/backend/internal/service/redeem_service.go
+++ b/backend/internal/service/redeem_service.go
@@ -10,14 +10,15 @@ import (
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 )
 
 var (
-	ErrRedeemCodeNotFound  = infraerrors.NotFound("REDEEM_CODE_NOT_FOUND", "redeem code not found")
-	ErrRedeemCodeUsed      = infraerrors.Conflict("REDEEM_CODE_USED", "redeem code already used")
+	ErrRedeemCodeNotFound  = domain.ErrRedeemCodeNotFound
+	ErrRedeemCodeUsed      = domain.ErrRedeemCodeUsed
 	ErrRedeemCodeExpired   = infraerrors.Conflict("REDEEM_CODE_EXPIRED", "redeem code expired")
 	ErrInsufficientBalance = infraerrors.BadRequest("INSUFFICIENT_BALANCE", "insufficient balance")
 	ErrRedeemRateLimited   = infraerrors.TooManyRequests("REDEEM_RATE_LIMITED", "too many failed attempts, please try again later")

--- a/backend/internal/service/scheduler_events.go
+++ b/backend/internal/service/scheduler_events.go
@@ -1,10 +1,13 @@
 package service
 
+import "github.com/Wei-Shaw/sub2api/internal/domain"
+
+// Scheduler outbox event type constants — canonical definitions are in domain/.
 const (
-	SchedulerOutboxEventAccountChanged       = "account_changed"
-	SchedulerOutboxEventAccountGroupsChanged = "account_groups_changed"
-	SchedulerOutboxEventAccountBulkChanged   = "account_bulk_changed"
-	SchedulerOutboxEventAccountLastUsed      = "account_last_used"
-	SchedulerOutboxEventGroupChanged         = "group_changed"
-	SchedulerOutboxEventFullRebuild          = "full_rebuild"
+	SchedulerOutboxEventAccountChanged       = domain.SchedulerOutboxEventAccountChanged
+	SchedulerOutboxEventAccountGroupsChanged = domain.SchedulerOutboxEventAccountGroupsChanged
+	SchedulerOutboxEventAccountBulkChanged   = domain.SchedulerOutboxEventAccountBulkChanged
+	SchedulerOutboxEventAccountLastUsed      = domain.SchedulerOutboxEventAccountLastUsed
+	SchedulerOutboxEventGroupChanged         = domain.SchedulerOutboxEventGroupChanged
+	SchedulerOutboxEventFullRebuild          = domain.SchedulerOutboxEventFullRebuild
 )

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
@@ -47,7 +48,7 @@ func coerceDeprecatedDingTalkCorpPolicy(policy string) string {
 
 var (
 	ErrRegistrationDisabled   = infraerrors.Forbidden("REGISTRATION_DISABLED", "registration is currently disabled")
-	ErrSettingNotFound        = infraerrors.NotFound("SETTING_NOT_FOUND", "setting not found")
+	ErrSettingNotFound        = domain.ErrSettingNotFound
 	ErrDefaultSubGroupInvalid = infraerrors.BadRequest(
 		"DEFAULT_SUBSCRIPTION_GROUP_INVALID",
 		"default subscription group must exist and be subscription type",

--- a/backend/internal/service/subscription_service.go
+++ b/backend/internal/service/subscription_service.go
@@ -11,6 +11,7 @@ import (
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/dgraph-io/ristretto"
@@ -25,19 +26,19 @@ var MaxExpiresAt = time.Date(2099, 12, 31, 23, 59, 59, 0, time.UTC)
 const MaxValidityDays = 36500
 
 var (
-	ErrSubscriptionNotFound        = infraerrors.NotFound("SUBSCRIPTION_NOT_FOUND", "subscription not found")
+	ErrSubscriptionNotFound        = domain.ErrSubscriptionNotFound
 	ErrSubscriptionExpired         = infraerrors.Forbidden("SUBSCRIPTION_EXPIRED", "subscription has expired")
 	ErrSubscriptionSuspended       = infraerrors.Forbidden("SUBSCRIPTION_SUSPENDED", "subscription is suspended")
-	ErrSubscriptionAlreadyExists   = infraerrors.Conflict("SUBSCRIPTION_ALREADY_EXISTS", "subscription already exists for this user and group")
+	ErrSubscriptionAlreadyExists   = domain.ErrSubscriptionAlreadyExists
 	ErrSubscriptionAssignConflict  = infraerrors.Conflict("SUBSCRIPTION_ASSIGN_CONFLICT", "subscription exists but request conflicts with existing assignment semantics")
 	ErrSubscriptionNotRevoked      = infraerrors.Conflict("SUBSCRIPTION_NOT_REVOKED", "subscription is not revoked")
-	ErrSubscriptionRestoreConflict = infraerrors.Conflict("SUBSCRIPTION_RESTORE_CONFLICT", "subscription already exists for this user and group")
+	ErrSubscriptionRestoreConflict = domain.ErrSubscriptionRestoreConflict
 	ErrGroupNotSubscriptionType    = infraerrors.BadRequest("GROUP_NOT_SUBSCRIPTION_TYPE", "group is not a subscription type")
 	ErrInvalidInput                = infraerrors.BadRequest("INVALID_INPUT", "at least one of resetDaily, resetWeekly, or resetMonthly must be true")
 	ErrDailyLimitExceeded          = infraerrors.TooManyRequests("DAILY_LIMIT_EXCEEDED", "daily usage limit exceeded")
 	ErrWeeklyLimitExceeded         = infraerrors.TooManyRequests("WEEKLY_LIMIT_EXCEEDED", "weekly usage limit exceeded")
 	ErrMonthlyLimitExceeded        = infraerrors.TooManyRequests("MONTHLY_LIMIT_EXCEEDED", "monthly usage limit exceeded")
-	ErrSubscriptionNilInput        = infraerrors.BadRequest("SUBSCRIPTION_NIL_INPUT", "subscription input cannot be nil")
+	ErrSubscriptionNilInput        = domain.ErrSubscriptionNilInput
 	ErrAdjustWouldExpire           = infraerrors.BadRequest("ADJUST_WOULD_EXPIRE", "adjustment would result in expired subscription (remaining days must be > 0)")
 )
 

--- a/backend/internal/service/usage_billing.go
+++ b/backend/internal/service/usage_billing.go
@@ -4,93 +4,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
-	"fmt"
-	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 )
 
-var ErrUsageBillingRequestIDRequired = errors.New("usage billing request_id is required")
-var ErrUsageBillingRequestConflict = errors.New("usage billing request fingerprint conflict")
+var ErrUsageBillingRequestIDRequired = domain.ErrUsageBillingRequestIDRequired
+var ErrUsageBillingRequestConflict = domain.ErrUsageBillingRequestConflict
 
-// UsageBillingCommand describes one billable request that must be applied at most once.
-type UsageBillingCommand struct {
-	RequestID          string
-	APIKeyID           int64
-	RequestFingerprint string
-	RequestPayloadHash string
-
-	UserID              int64
-	AccountID           int64
-	SubscriptionID      *int64
-	AccountType         string
-	Model               string
-	ServiceTier         string
-	ReasoningEffort     string
-	BillingType         int8
-	InputTokens         int
-	OutputTokens        int
-	CacheCreationTokens int
-	CacheReadTokens     int
-	ImageCount          int
-	MediaType           string
-
-	BalanceCost         float64
-	SubscriptionCost    float64
-	APIKeyQuotaCost     float64
-	APIKeyRateLimitCost float64
-	AccountQuotaCost    float64
-
-	// TkHoldRequestID, when non-empty, is the pre-flight balance-hold ledger key
-	// this settlement must consume (refund) in the SAME transaction as the
-	// balance deduction — closing the release-before-settle gap of the overdraft
-	// fix (see usage_billing_hold_tk.go). Deliberately excluded from the billing
-	// fingerprint: a retried apply must dedup identically with or without it.
-	TkHoldRequestID string
-}
-
-func (c *UsageBillingCommand) Normalize() {
-	if c == nil {
-		return
-	}
-	c.RequestID = strings.TrimSpace(c.RequestID)
-	if strings.TrimSpace(c.RequestFingerprint) == "" {
-		c.RequestFingerprint = buildUsageBillingFingerprint(c)
-	}
-}
-
-func buildUsageBillingFingerprint(c *UsageBillingCommand) string {
-	if c == nil {
-		return ""
-	}
-	raw := fmt.Sprintf(
-		"%d|%d|%d|%s|%s|%s|%s|%d|%d|%d|%d|%d|%d|%s|%d|%0.10f|%0.10f|%0.10f|%0.10f|%0.10f",
-		c.UserID,
-		c.AccountID,
-		c.APIKeyID,
-		strings.TrimSpace(c.AccountType),
-		strings.TrimSpace(c.Model),
-		strings.TrimSpace(c.ServiceTier),
-		strings.TrimSpace(c.ReasoningEffort),
-		c.BillingType,
-		c.InputTokens,
-		c.OutputTokens,
-		c.CacheCreationTokens,
-		c.CacheReadTokens,
-		c.ImageCount,
-		strings.TrimSpace(c.MediaType),
-		valueOrZero(c.SubscriptionID),
-		c.BalanceCost,
-		c.SubscriptionCost,
-		c.APIKeyQuotaCost,
-		c.APIKeyRateLimitCost,
-		c.AccountQuotaCost,
-	)
-	if payloadHash := strings.TrimSpace(c.RequestPayloadHash); payloadHash != "" {
-		raw += "|" + payloadHash
-	}
-	sum := sha256.Sum256([]byte(raw))
-	return hex.EncodeToString(sum[:])
-}
+type UsageBillingCommand = domain.UsageBillingCommand
 
 func HashUsageRequestPayload(payload []byte) string {
 	if len(payload) == 0 {
@@ -98,13 +19,6 @@ func HashUsageRequestPayload(payload []byte) string {
 	}
 	sum := sha256.Sum256(payload)
 	return hex.EncodeToString(sum[:])
-}
-
-func valueOrZero(v *int64) int64 {
-	if v == nil {
-		return 0
-	}
-	return *v
 }
 
 // AccountQuotaState holds the post-increment quota state returned by the DB transaction.

--- a/backend/internal/service/usage_cleanup.go
+++ b/backend/internal/service/usage_cleanup.go
@@ -2,58 +2,22 @@ package service
 
 import (
 	"context"
-	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 )
 
+// Usage cleanup status constants — canonical definitions are in domain/.
 const (
-	UsageCleanupStatusPending   = "pending"
-	UsageCleanupStatusRunning   = "running"
-	UsageCleanupStatusSucceeded = "succeeded"
-	UsageCleanupStatusFailed    = "failed"
-	UsageCleanupStatusCanceled  = "canceled"
+	UsageCleanupStatusPending   = domain.UsageCleanupStatusPending
+	UsageCleanupStatusRunning   = domain.UsageCleanupStatusRunning
+	UsageCleanupStatusSucceeded = domain.UsageCleanupStatusSucceeded
+	UsageCleanupStatusFailed    = domain.UsageCleanupStatusFailed
+	UsageCleanupStatusCanceled  = domain.UsageCleanupStatusCanceled
 )
 
-// UsageCleanupFilters 定义清理任务过滤条件
-// 时间范围为必填，其他字段可选
-// JSON 序列化用于存储任务参数
-//
-// start_time/end_time 使用 RFC3339 时间格式
-// 以 UTC 或用户时区解析后的时间为准
-//
-// 说明：
-// - nil 表示未设置该过滤条件
-// - 过滤条件均为精确匹配
-type UsageCleanupFilters struct {
-	StartTime   time.Time `json:"start_time"`
-	EndTime     time.Time `json:"end_time"`
-	UserID      *int64    `json:"user_id,omitempty"`
-	APIKeyID    *int64    `json:"api_key_id,omitempty"`
-	AccountID   *int64    `json:"account_id,omitempty"`
-	GroupID     *int64    `json:"group_id,omitempty"`
-	Model       *string   `json:"model,omitempty"`
-	RequestType *int16    `json:"request_type,omitempty"`
-	Stream      *bool     `json:"stream,omitempty"`
-	BillingType *int8     `json:"billing_type,omitempty"`
-}
-
-// UsageCleanupTask 表示使用记录清理任务
-// 状态包含 pending/running/succeeded/failed/canceled
-type UsageCleanupTask struct {
-	ID          int64
-	Status      string
-	Filters     UsageCleanupFilters
-	CreatedBy   int64
-	DeletedRows int64
-	ErrorMsg    *string
-	CanceledBy  *int64
-	CanceledAt  *time.Time
-	StartedAt   *time.Time
-	FinishedAt  *time.Time
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-}
+type UsageCleanupFilters = domain.UsageCleanupFilters
+type UsageCleanupTask = domain.UsageCleanupTask
 
 // UsageCleanupRepository 定义清理任务持久层接口
 type UsageCleanupRepository interface {

--- a/backend/internal/service/usage_service.go
+++ b/backend/internal/service/usage_service.go
@@ -7,13 +7,13 @@ import (
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
-	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 )
 
 var (
-	ErrUsageLogNotFound = infraerrors.NotFound("USAGE_LOG_NOT_FOUND", "usage log not found")
+	ErrUsageLogNotFound = domain.ErrUsageLogNotFound
 )
 
 // CreateUsageLogRequest 创建使用日志请求

--- a/backend/internal/service/user_attribute.go
+++ b/backend/internal/service/user_attribute.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 )
 
 // Error definitions for user attribute operations
 var (
-	ErrAttributeDefinitionNotFound = infraerrors.NotFound("ATTRIBUTE_DEFINITION_NOT_FOUND", "attribute definition not found")
-	ErrAttributeKeyExists          = infraerrors.Conflict("ATTRIBUTE_KEY_EXISTS", "attribute key already exists")
+	ErrAttributeDefinitionNotFound = domain.ErrAttributeDefinitionNotFound
+	ErrAttributeKeyExists          = domain.ErrAttributeKeyExists
 	ErrInvalidAttributeType        = infraerrors.BadRequest("INVALID_ATTRIBUTE_TYPE", "invalid attribute type")
 	ErrAttributeValidationFailed   = infraerrors.BadRequest("ATTRIBUTE_VALIDATION_FAILED", "attribute value validation failed")
 )

--- a/backend/internal/service/user_platform_quota_port.go
+++ b/backend/internal/service/user_platform_quota_port.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 )
 
 // ErrUserPlatformQuotaNotFound service 层 sentinel：quota 记录不存在。
@@ -28,21 +30,7 @@ type UserPlatformQuotaSnapshot struct {
 	MonthlyWindowStart time.Time
 }
 
-// UserPlatformQuotaRecord service 层传输结构体（与 repository 层解耦）。
-type UserPlatformQuotaRecord struct {
-	UserID          int64
-	Platform        string
-	DailyLimitUSD   *float64
-	WeeklyLimitUSD  *float64
-	MonthlyLimitUSD *float64
-	DailyUsageUSD   float64
-	WeeklyUsageUSD  float64
-	MonthlyUsageUSD float64
-	// 窗口起始时间（可选，用于未来 reset 校验）
-	DailyWindowStart   *time.Time
-	WeeklyWindowStart  *time.Time
-	MonthlyWindowStart *time.Time
-}
+type UserPlatformQuotaRecord = domain.UserPlatformQuotaRecord
 
 // UserPlatformQuotaRepository 定义 service 层所需的 user × platform quota 数据访问端口。
 // repository 包的 userPlatformQuotaRepository 实现此接口。

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"image"
@@ -29,14 +30,14 @@ import (
 )
 
 var (
-	ErrUserNotFound             = infraerrors.NotFound("USER_NOT_FOUND", "user not found")
+	ErrUserNotFound             = domain.ErrUserNotFound
 	ErrPasswordIncorrect        = infraerrors.BadRequest("PASSWORD_INCORRECT", "current password is incorrect")
 	ErrInsufficientPerms        = infraerrors.Forbidden("INSUFFICIENT_PERMISSIONS", "insufficient permissions")
 	ErrNotifyCodeUserRateLimit  = infraerrors.TooManyRequests("NOTIFY_CODE_USER_RATE_LIMIT", "too many verification codes requested, please try again later")
 	ErrAvatarInvalid            = infraerrors.BadRequest("AVATAR_INVALID", "avatar must be a valid image data URL or http(s) URL")
 	ErrAvatarTooLarge           = infraerrors.BadRequest("AVATAR_TOO_LARGE", "avatar image must be 100KB or smaller")
 	ErrAvatarNotImage           = infraerrors.BadRequest("AVATAR_NOT_IMAGE", "avatar content must be an image")
-	ErrIdentityProviderInvalid  = infraerrors.BadRequest("IDENTITY_PROVIDER_INVALID", "identity provider is invalid")
+	ErrIdentityProviderInvalid  = domain.ErrIdentityProviderInvalid
 	ErrIdentityRedirectInvalid  = infraerrors.BadRequest("IDENTITY_REDIRECT_INVALID", "identity redirect path is invalid")
 	ErrIdentityUnbindLastMethod = infraerrors.Conflict(
 		"IDENTITY_UNBIND_LAST_METHOD",
@@ -63,25 +64,7 @@ var (
 	avatarQualitySteps = []int{88, 80, 72, 64, 56, 48, 40, 32}
 )
 
-// UserListFilters contains all filter options for listing users
-type UserListFilters struct {
-	Status    string // User status filter
-	Role      string // User role filter
-	Search    string // Search in email, username
-	GroupName string // Filter by allowed group name (fuzzy match)
-	// APIKeyGroupID filters users who own at least one non-soft-deleted API key
-	// bound to this group (api_keys.group_id). 0 = no filter. Covers all three
-	// group types since it matches the key's group directly, not allowed_groups.
-	APIKeyGroupID int64
-	Attributes    map[int64]string // Custom attribute filters: attributeID -> value
-	// IncludeSubscriptions controls whether ListWithFilters should load active subscriptions.
-	// For large datasets this can be expensive; admin list pages should enable it on demand.
-	// nil means not specified (default: load subscriptions for backward compatibility).
-	IncludeSubscriptions *bool
-	// IncludeDeleted 为 true 时绕过软删除过滤，返回含已删除（deleted_at 非空）的用户。
-	// 仅供 /admin/usage 的 SearchUsers 端点使用，其他列表调用方不要设置。
-	IncludeDeleted bool
-}
+type UserListFilters = domain.UserListFilters
 
 type UserRepository interface {
 	Create(ctx context.Context, user *User) error

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -848,8 +848,8 @@
       "must_contain": [
         "func (r *accountRepository) SumConcurrencyAnthropic",
         "WHERE platform = $1 AND schedulable = true AND deleted_at IS NULL",
-        "dbproxy.StatusEQ(service.StatusActive)",
-        "entAcc.Edges.Proxy.Status == service.StatusActive"
+        "dbproxy.StatusEQ(domain.StatusActive)",
+        "entAcc.Edges.Proxy.Status == domain.StatusActive"
       ],
       "rationale": "TK proxy-status filter (upstream #2159): account preload paths MUST filter out non-active proxies on both the manual loadProxies query and the WithProxy() edge-preload branch. Disabled proxies leaking back into account.Proxy contradicts operator intent and re-routes traffic through proxies that were explicitly turned off (compliance/IP-rotation regression). SumConcurrencyAnthropic is operator-facing: admin concurrency for user id 1 mirrors Σ concurrency of non-deleted **schedulable=true** anthropic rows (2026-05-23: filter narrowed from Σ-all to Σ-schedulable so admin-bypass api-key stubs with schedulable=false are excluded). The `AND schedulable = true` clause is the load-bearing anchor: it MUST stay byte-identical to the operator-concurrency SQL emitted by ops/anthropic/manage-anthropic-config.py (render_admin_operator_concurrency_sync_sql + OPERATOR_CONCURRENCY_SQL) so the Go control plane (admin account CRUD → SyncAnthropicOperatorConcurrency) and the SSM apply pipeline share ONE Σ rule and never clobber each other. Dropping the query, or an upstream merge that 'simplifies' away the schedulable filter, silently desyncs the control plane from edge/prod tier apply injection."
     },
@@ -864,7 +864,7 @@
     {
       "path": "backend/internal/repository/user_subscription_repo.go",
       "must_contain": [
-        "usersubscription.StatusEQ(service.SubscriptionStatusActive)",
+        "usersubscription.StatusEQ(domain.SubscriptionStatusActive)",
         "usersubscription.ExpiresAtGT(time.Now())"
       ],
       "rationale": "TK active-subscription predicate (upstream #2478): ExistsByUserIDAndGroupID and GetActiveByUserIDAndGroupID MUST gate on BOTH status=active AND expires_at>now. Without this, expired-yet-not-soft-deleted rows return exists=true and the reassignment flow blocks legitimate renewals with 409 validity_days_mismatch — a user-paid-but-no-access regression."
@@ -3040,11 +3040,18 @@
       "rationale": "Hold hand-off threading (PR #746): postUsageBillingParams.TkHoldRequestID → UsageBillingCommand inside buildUsageBillingCommand. Same silent-revert risk as the openai_gateway_service.go entry — both sides of the thread are pinned."
     },
     {
-      "path": "backend/internal/service/usage_billing.go",
+      "path": "backend/internal/domain/usage_billing_command.go",
       "must_contain": [
         "TkHoldRequestID string"
       ],
-      "rationale": "UsageBillingCommand.TkHoldRequestID is the contract the repository's settlement transaction consumes the hold by (PR #746). Deliberately excluded from the billing fingerprint; losing the field severs handler→settlement hand-off."
+      "rationale": "UsageBillingCommand.TkHoldRequestID is the contract the repository's settlement transaction consumes the hold by (PR #746). Entity now lives in domain/; service keeps a type alias."
+    },
+    {
+      "path": "backend/internal/service/usage_billing.go",
+      "must_contain": [
+        "type UsageBillingCommand = domain.UsageBillingCommand"
+      ],
+      "rationale": "service/ re-exports domain UsageBillingCommand so handler wiring stays on the service import path."
     },
     {
       "path": "backend/internal/service/wire.go",


### PR DESCRIPTION
## 摘要

独立 PR 完成 domain 层终态（Batch 1 + Batch 2），采用「实体定义迁入 `domain/*.go`，`service/` 仅保留 `type Foo = domain.Foo` 别名」策略，避免在 upstream 形 service 文件里继续堆叠 struct 定义。

- Batch 1：errors / scheduler / usage-cleanup 常量；repository 层 `service.*` → `domain.*`
- Batch 2：Proxy、UsageCleanup*、UsageBillingCommand、UserListFilters、UserPlatformQuotaRecord、OpsPercentiles 实体分离
- 已 rebase 到 `origin/main`（含 #1233），冲突在 `channel_monitor_const.go`（apipath + domain 并存）与 `gateway-tk.json` sentinel 合并
- **不含**连接池 viper default 变更（#1231 已 revert 意图）
- **不含** apipath / 前端 SSOT（见 #1233，已合并）

## 风险

- 常规风险（分层 / 大量 repository import 改写）：111 文件，repository 全面换 import，Batch 3 大聚合仍留 service/
- sentinel registry：`affiliate_repo.go` / `user_repo.go` / `model_availability.go` 变更仅为 import 路径替换，无查询语义变化；PR 描述标记 sentinel-registry-reviewed

## 验证

- `./scripts/preflight.sh` PASS
- `go test -tags=unit ./internal/domain/... ./internal/repository/...` PASS
- integration 编译修复：`user_repo_sort_integration_test` 补 domain import；proxy integration 测试移除未用 service import

## 提交

- be7a51582 refactor(domain): complete entity separation for repository layer
- cd2b6c2d9 fix(domain): repair integration test imports after entity migration

最新提交：cd2b6c2d9

## 关系

- 替代 #1231 的 domain 半态部分
- 基于 #1233（已合并）rebase 后提交
