### PR TITLE
fix(kiro): 修复 dated haiku 模型 ID 导致 group1 空池 routing 429

### DIFF
--- a/backend/internal/service/account_tk_kiro.go
+++ b/backend/internal/service/account_tk_kiro.go
@@ -116,10 +116,19 @@ func kiroMirrorStubSupportsModel(requestedModel string) bool {
 	if requestedModel == "" {
 		return true
 	}
-	normalized := claude.NormalizeModelID(requestedModel)
-	for _, m := range KiroAdminTestModels() {
-		if requestedModel == m.ID || normalized == m.ID {
-			return true
+	// CC clients often send dated snapshot IDs (claude-haiku-4-5-20251001) while the
+	// Kiro catalog lists short IDs (claude-haiku-4-5). NormalizeModelID only expands
+	// short→dated; DenormalizeModelID collapses dated→short — both must be checked.
+	candidates := []string{
+		requestedModel,
+		claude.NormalizeModelID(requestedModel),
+		claude.DenormalizeModelID(requestedModel),
+	}
+	for _, candidate := range candidates {
+		for _, m := range KiroAdminTestModels() {
+			if candidate == m.ID {
+				return true
+			}
 		}
 	}
 	return false

--- a/backend/internal/service/account_tk_kiro_model_test.go
+++ b/backend/internal/service/account_tk_kiro_model_test.go
@@ -1,0 +1,41 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKiroMirrorStubSupportsModel_DatedHaikuSnapshotID(t *testing.T) {
+	// prod P0 2026-07-06: user16 key222 hammered claude-haiku-4-5-20251001 on group1;
+	// all four kiro-us* mirror stubs were filtered as model_unsupported because
+	// kiroMirrorStubSupportsModel only matched short catalog IDs.
+	stub := &Account{
+		Name:     "kiro-us6",
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": PlatformKiro,
+			"base_url":        "https://api-us6.tokenkey.dev",
+		},
+	}
+	require.True(t, stub.IsKiroMirrorStub())
+	require.True(t, stub.IsModelSupported("claude-haiku-4-5-20251001"))
+	require.True(t, stub.IsModelSupported("claude-haiku-4-5"))
+	require.False(t, stub.IsModelSupported("claude-fable-5"))
+}
+
+func TestGatewayService_KiroMirrorStubSupportsDatedHaiku(t *testing.T) {
+	svc := &GatewayService{}
+	stub := &Account{
+		Name:     "kiro-us5",
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": PlatformKiro,
+		},
+	}
+	require.True(t, svc.isModelSupportedByAccount(stub, "claude-haiku-4-5-20251001"))
+}

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -131,12 +131,14 @@
       "path": "backend/internal/service/account_tk_kiro.go",
       "must_contain": [
         "func (a *Account) IsKiro()",
+        "func kiroMirrorStubSupportsModel",
+        "claude.DenormalizeModelID",
         "PersistKiroProfileArnIfChanged",
         "toKiroProtoAccount",
         "func (a *Account) isKiroTLSFingerprintEnabled()",
         "CanonicalKiroTLSProfileName"
       ],
-      "rationale": "Account-domain predicate + the mapper that converts a TK account's credentials into the vendored kiroproto.Account, plus the default-on TLS-fingerprint gate (isKiroTLSFingerprintEnabled) and the canonical Kiro IDE profile name. Losing IsKiro() removes kiro from the Forward dispatch branch and the scheduling pool; losing toKiroProtoAccount breaks every upstream call; losing the TLS gate / CanonicalKiroTLSProfileName silently drops kiro back to a Go-default JA3 (ban risk)."
+      "rationale": "Account-domain predicate + kiroMirrorStubSupportsModel (dated CC snapshot IDs must DenormalizeModelID before matching KiroAdminTestModels short IDs; prod 2026-07-06 P0 empty-pool if only NormalizeModelID) + the mapper that converts a TK account's credentials into the vendored kiroproto.Account, plus the default-on TLS-fingerprint gate (isKiroTLSFingerprintEnabled) and the canonical Kiro IDE profile name. Losing IsKiro() removes kiro from the Forward dispatch branch and the scheduling pool; losing toKiroProtoAccount breaks every upstream call; losing the TLS gate / CanonicalKiroTLSProfileName silently drops kiro back to a Go-default JA3 (ban risk)."
     },
     {
       "path": "backend/internal/service/account.go",
@@ -290,6 +292,14 @@
         "tkValidateKiroAccountCreate"
       ],
       "rationale": "Load-bearing QA evidence for the account-creation ToS gate (matches the *_tk_*.go hotspot rule). Losing it removes the regression guard around the first ToS acknowledgement check."
+    },
+    {
+      "path": "backend/internal/service/account_tk_kiro_model_test.go",
+      "must_contain": [
+        "TestKiroMirrorStubSupportsModel_DatedHaikuSnapshotID",
+        "TestGatewayService_KiroMirrorStubSupportsDatedHaiku"
+      ],
+      "rationale": "Regression guard for prod 2026-07-06 P0: claude-haiku-4-5-20251001 must pass kiroMirrorStubSupportsModel on prod Kiro mirror stubs; losing it reintroduces group1 empty-pool routing 429 while Kiro edge still has quota."
     },
     {
       "path": "backend/internal/service/account_tk_kiro_tls_test.go",


### PR DESCRIPTION
## 摘要

- 修复 `kiroMirrorStubSupportsModel` 只匹配 Kiro 目录短 ID（`claude-haiku-4-5`），无法识别 CC 客户端常用的 dated snapshot ID（`claude-haiku-4-5-20251001`）。
- prod 2026-07-06 16:02 P0：user16 key「基础设施-欧阳城」在 group1 上 18 秒内 54 次 routing 空池拒绝；4 个 kiro-us* 镜像 stub 全部被误判为 model_unsupported，而 Kiro edge 侧仍有额度。
- 修复方式：在模型门控中同时检查 `NormalizeModelID` 与 `DenormalizeModelID`；补回归测试 + kiro.json sentinel 锚点。

## 风险

- 常规风险：仅影响 Kiro 镜像 stub / Kiro 账号的模型支持判定，不改变公共 API 契约。
- 部署后 group1 的 `claude-haiku-4-5-20251001` 应能正常调度到 kiro-us* 账号。

## 验证

- `go test -tags=unit ./internal/service/... -run 'TestKiroMirrorStubSupportsModel|TestGatewayService_KiroMirrorStubSupportsDatedHaiku|TestTkKiroMirrorStubModelGate' -count=1` — 通过
- prod 只读 probe 已定位根因（group1 仅 4 个 schedulable kiro stub，错误为本地空池非上游额度）
- CI 全绿（含 marker-acknowledgement / preflight / test-unit / test-integration）

## 提交

- efb4250e3 fix(kiro): accept dated haiku snapshot IDs on mirror stub model gate
- 5d7bb7ecd chore(sentinel): anchor kiro dated-haiku model gate regression
- 最新提交：5d7bb7ecd