### PR TITLE
fix(volcengine): 从 Ark 清单移除 glm-4-7-251222，GLM 改走 DashScope

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -727,6 +727,9 @@ func normalizeRequestedModelForLookup(platform, requestedModel string) string {
 			return canonical
 		}
 	}
+	if canonical := normalizeGLMVolcengineDatedModelID(trimmed); canonical != "" {
+		return canonical
+	}
 	if platform != PlatformGemini && platform != PlatformAntigravity {
 		return trimmed
 	}

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -659,6 +659,11 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 
 	// 智谱 GLM（z.ai 公开 SKU：glm-5.2 / glm-5.1 / glm-5 / glm-5-turbo / glm-4.7 / glm-4.6 / glm-4.5 等）
 	// 匹配顺序：先判别最高 tier，再依次降级。
+	if canonical := normalizeGLMVolcengineDatedModelID(modelLower); canonical != "" {
+		if pricing := s.fallbackPrices[canonical]; pricing != nil {
+			return pricing
+		}
+	}
 	if strings.Contains(modelLower, "glm-5.2") {
 		return s.fallbackPrices["glm-5.2"]
 	}

--- a/backend/internal/service/model_alias_tk_glm_volcengine.go
+++ b/backend/internal/service/model_alias_tk_glm_volcengine.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"regexp"
+	"strings"
+)
+
+// VolcEngine Ark exposes GLM chat SKUs as glm-{major}-{minor}-{YYMMDD|YYYYMMDD}
+// (e.g. glm-4-7-251222). TokenKey serves GLM via Qwen/DashScope as glm-4.7.
+// Clients that still send the VolcEngine dated id should route/bill as glm-4.7,
+// not fail after the VolcEngine account mapping was withdrawn.
+var tkGLMVolcengineDatedModelPattern = regexp.MustCompile(`^glm-(\d+)-(\d+)-(\d{6}|\d{8})$`)
+
+func normalizeGLMVolcengineDatedModelID(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	sub := tkGLMVolcengineDatedModelPattern.FindStringSubmatch(m)
+	if sub == nil {
+		return ""
+	}
+	return "glm-" + sub[1] + "." + sub[2]
+}

--- a/backend/internal/service/model_alias_tk_glm_volcengine_test.go
+++ b/backend/internal/service/model_alias_tk_glm_volcengine_test.go
@@ -1,0 +1,38 @@
+//go:build unit
+
+package service
+
+import "testing"
+
+func TestNormalizeGLMVolcengineDatedModelID(t *testing.T) {
+	for in, want := range map[string]string{
+		"glm-4-7-251222": "glm-4.7",
+		"GLM-4-7-251222": "glm-4.7",
+		" glm-5-2-260115 ": "glm-5.2",
+		"glm-4.7":           "",
+		"glm-4.7-flash":     "",
+		"glm-4-32b-0414-128k": "",
+		"doubao-seed-1-6-250615": "",
+	} {
+		if got := normalizeGLMVolcengineDatedModelID(in); got != want {
+			t.Errorf("normalizeGLMVolcengineDatedModelID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestAccount_GLMDatedVolcengineAliasRoutesViaDashScopeMapping(t *testing.T) {
+	account := &Account{
+		Platform: PlatformNewAPI,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"glm-4.7": "glm-4.7",
+			},
+		},
+	}
+	if !account.IsModelSupported("glm-4-7-251222") {
+		t.Fatal("dated VolcEngine GLM id must match DashScope glm-4.7 mapping")
+	}
+	if got := account.GetMappedModel("glm-4-7-251222"); got != "glm-4.7" {
+		t.Fatalf("GetMappedModel(glm-4-7-251222) = %q, want glm-4.7", got)
+	}
+}

--- a/backend/internal/service/pricing_catalog_tk.go
+++ b/backend/internal/service/pricing_catalog_tk.go
@@ -309,7 +309,7 @@ func buildCatalogFromBytes(data []byte, modTime time.Time) *PublicCatalogRespons
 
 // applyCatalogOverlayPricing fill-only-merges TK-overlay-priced models the file
 // source lacks into the public catalog, so overlay-only models (deepseek-v4-pro,
-// doubao-*, glm-4-7-251222, …) surface with their prices in the public catalog
+// doubao-*, …) surface with their prices in the public catalog
 // AND Your-Menu (me_pricing_catalog reads BuildPublicCatalog as metaByID).
 //
 // The runtime price file is a TRIMMED litellm mirror; models litellm lacks are

--- a/backend/internal/service/pricing_catalog_tk_test.go
+++ b/backend/internal/service/pricing_catalog_tk_test.go
@@ -150,7 +150,7 @@ func TestPublicCatalog_ChatRowsWithImageCostsStayTokenCatalogRows(t *testing.T) 
 
 // TestPricingCatalogService_AppliesTKOverlayPricing pins the display-side overlay
 // merge: models priced ONLY in tk_pricing_overlay.json (deepseek-v4-pro, doubao-*,
-// glm-4-7-251222 / glm-5.2, plus media rows such as Veo/Grok image/video) must
+// glm-5.2, plus media rows such as Veo/Grok image/video) must
 // surface in the public catalog / Your-Menu with their prices, matching the
 // billing path that already applies the overlay. The merge is fill-only: a model
 // the file source prices natively keeps the source value (overlay never overrides).
@@ -180,8 +180,6 @@ func TestPricingCatalogService_AppliesTKOverlayPricing(t *testing.T) {
 	assert.InDelta(t, 0.00087, pro.Pricing.OutputPer1KTokens, 1e-9, "deepseek-v4-pro output = overlay $0.87/M")
 	_, ok = byID["doubao-seed-2-0-pro-260215"]
 	assert.True(t, ok, "doubao overlay model must surface")
-	_, ok = byID["glm-4-7-251222"]
-	assert.True(t, ok, "glm-4-7 overlay model must surface")
 	glm52, ok := byID["glm-5.2"]
 	require.True(t, ok, "direct Z.AI GLM overlay model must surface")
 	assert.Equal(t, PlatformNewAPI, inferPlatformFromVendor(glm52.Vendor), "zhipu provider must classify as newapi")
@@ -346,6 +344,7 @@ func TestPublicCatalog_FiltersUnservableClaudeAndGpt(t *testing.T) {
 	  "gemini-2.5-pro":            {"input_cost_per_token":0.00000125,"output_cost_per_token":0.00001,"litellm_provider":"vertex_ai-language-models"},
 	  "deepseek-chat":             {"input_cost_per_token":0.0000003,"output_cost_per_token":0.0000011,"litellm_provider":"deepseek"},
 	  "deepseek-v3-2-251201":      {"input_cost_per_token":0.0000002,"output_cost_per_token":0.0000004,"litellm_provider":"volcengine"},
+	  "glm-4-7-251222":            {"input_cost_per_token":0.0000001,"output_cost_per_token":0.0000001,"litellm_provider":"volcengine"},
 	  "glm-4-32b-0414-128k":       {"input_cost_per_token":0.0000001,"output_cost_per_token":0.0000001,"litellm_provider":"zhipu"},
 	  "glm-5-turbo":               {"input_cost_per_token":0.0000012,"output_cost_per_token":0.000004,"litellm_provider":"zhipu"},
 	  "minimax-m2.7":              {"input_cost_per_token":0.000001,"output_cost_per_token":0.000008,"litellm_provider":"minimax"}
@@ -377,6 +376,7 @@ func TestPublicCatalog_FiltersUnservableClaudeAndGpt(t *testing.T) {
 	assert.True(t, got["gemini-2.5-pro"], "gemini vendor passes through")
 	assert.True(t, got["deepseek-chat"], "manifest display=true deepseek kept")
 	assert.False(t, got["deepseek-v3-2-251201"], "priced-but-unlisted volcengine residue pruned")
+	assert.False(t, got["glm-4-7-251222"], "withdrawn VolcEngine GLM SKU pruned from storefront (serve glm-4.7 via DashScope)")
 	assert.False(t, got["glm-4-32b-0414-128k"], "withdrawn GLM SKU pruned from storefront")
 	assert.False(t, got["glm-5-turbo"], "removed direct-only GLM SKU hidden from storefront")
 	assert.False(t, got["minimax-m2.7"], "unmapped vendor hidden until universal mapping exists")
@@ -407,6 +407,7 @@ func TestIsPublicCatalogModelSupported(t *testing.T) {
 		{"vertex_ai-language-models", "gemini-2.5-pro", true}, // other vendor: pass-through
 		{"deepseek", "deepseek-chat", true},
 		{"volcengine", "deepseek-v3-2-251201", false},
+		{"volcengine", "glm-4-7-251222", false},
 		{"zhipu", "glm-4-32b-0414-128k", false},
 		{"zhipu", "glm-5.2", true},
 		{"zhipu", "glm-5-turbo", false}, // direct-only GLM pool removed; no manifest display path

--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -732,6 +732,9 @@ func normalizeModelNameForPricing(model string) string {
 	if canonical := canonicalizeOpenAIModelAliasSpelling(model); canonical != "" {
 		return canonical
 	}
+	if canonical := normalizeGLMVolcengineDatedModelID(model); canonical != "" {
+		return canonical
+	}
 	return model
 }
 

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "note": "TK-owned pricing overlay for models the runtime price source lacks. Merged into PricingService AFTER any source load (Wei-Shaw remote OR disk fallback); an entry below applies when the source key is ABSENT or the source entry is EFFECTIVELY UNPRICED (every cost field 0.0 — litellm's 'unknown', not 'free'; see tkIsEffectivelyUnpriced). The Wei-Shaw runtime mirror is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries, so imagen-*/veo-* resolve to nothing there; litellm itself also lags new provider models (deepseek-v4-*) or carries them as zero placeholders (deepseek-v3-2-251201), which then bill $0. Media price = vertex_ai provider (TK media flow routes through Vertex ch41); falls back to gemini only when no vertex variant exists. Text price = provider official list price. Self-deprecating: the day the source carries a real (non-zero) price under the bare key, the source value wins and the entry below is ignored. The overlay cannot CORRECT wrong NON-ZERO source prices (deepseek-chat/reasoner still carry the pre-V4 rate in the mirror) — use channel pricing (DB) for that. Video entries MUST declare failure_billing (currently only 'success_only' is legal): TokenKey refunds the user in full when a video task ends failed, which is only loss-free if the provider does not charge for failed tasks — the person pricing a new video model verifies that on the official page and declares it here; scripts/checks/pricing-overlay.py enforces the field, and any other value must first change the refund design.",
-    "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); volcengine doubao-*/glm-4-7-251222/deepseek-v3-2-251201: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=6.7); glm-4.7 matches Zhipu official; qwen3.7-max* / qwen3.7-plus / qwen3.6-flash / qwen3-coder-plus / qwen-max / qwen-plus: Alibaba DashScope China-mainland (Beijing) RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source; the qwen3.7-* / qwen3.6-flash / qwen3-coder-plus values were corrected 2026-06-13 from a prior USD-list basis ≈÷7.27 to the table's canonical CNY/USD=6.7); qwen2.5-coder-32b/7b: retired & absent from current Alibaba list — proxy-filled from lineage successors qwen3-coder-plus / qwen3-coder-flash, Beijing RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source); seedream/seedance media: VolcEngine Ark official model-pricing page (https://www.volcengine.com/docs/82379/1099320), captured 2026-06-12/2026-07-02, CNY/USD=6.7 — per-image flat price; per-second video price derived at each model's max supported tier (1080p@24fps; 2.0-fast 720p), online standard rate, derivation formula in per-entry source; only IDs present in the live configured Ark account and priced from official sources are served — seedream-4.5/5.0 need separate 2K activation probes/pricing before serving, seedance-1.0-lite and wan2.1 returned unsupported on 2026-07-02; video failure_billing evidence: seedance entries carry the verified official Ark wording (success-only, captured 2026-06-12); veo entries are metric-inferred (billed per generated output second) with the official Google sentence still pending capture",
+    "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); volcengine doubao-*/deepseek-v3-2-251201: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=6.7); glm-4.7 matches Zhipu official; qwen3.7-max* / qwen3.7-plus / qwen3.6-flash / qwen3-coder-plus / qwen-max / qwen-plus: Alibaba DashScope China-mainland (Beijing) RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source; the qwen3.7-* / qwen3.6-flash / qwen3-coder-plus values were corrected 2026-06-13 from a prior USD-list basis ≈÷7.27 to the table's canonical CNY/USD=6.7); qwen2.5-coder-32b/7b: retired & absent from current Alibaba list — proxy-filled from lineage successors qwen3-coder-plus / qwen3-coder-flash, Beijing RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source); seedream/seedance media: VolcEngine Ark official model-pricing page (https://www.volcengine.com/docs/82379/1099320), captured 2026-06-12/2026-07-02, CNY/USD=6.7 — per-image flat price; per-second video price derived at each model's max supported tier (1080p@24fps; 2.0-fast 720p), online standard rate, derivation formula in per-entry source; only IDs present in the live configured Ark account and priced from official sources are served — seedream-4.5/5.0 need separate 2K activation probes/pricing before serving, seedance-1.0-lite and wan2.1 returned unsupported on 2026-07-02; video failure_billing evidence: seedance entries carry the verified official Ark wording (success-only, captured 2026-06-12); veo entries are metric-inferred (billed per generated output second) with the official Google sentence still pending capture",
     "regen": "manual curation; no auto-sync (entries are few + slow-moving). If they proliferate, add provider-aware sync."
   },
   "grok-imagine-image": {
@@ -836,30 +836,6 @@
     "output_cost_per_token": 5.373134328358209e-07,
     "cache_read_input_token_cost": 1.791044776119403e-07,
     "source": "VolcEngine Ark official 在线推理(常规) (model-pricing page, captured 2026-06-11; CNY/USD=6.7; flat, USD=¥/M÷6.7)."
-  },
-  "glm-4-7-251222": {
-    "litellm_provider": "volcengine",
-    "mode": "chat",
-    "input_cost_per_token": 4.4776119402985074e-07,
-    "output_cost_per_token": 2.08955223880597e-06,
-    "cache_read_input_token_cost": 8.955223880597015e-08,
-    "intervals": [
-      {
-        "min_tokens": 0,
-        "max_tokens": 32000,
-        "input_cost_per_token": 4.4776119402985074e-07,
-        "output_cost_per_token": 2.08955223880597e-06,
-        "cache_read_input_token_cost": 8.955223880597015e-08
-      },
-      {
-        "min_tokens": 32000,
-        "max_tokens": null,
-        "input_cost_per_token": 5.970149253731343e-07,
-        "output_cost_per_token": 2.3880597014925373e-06,
-        "cache_read_input_token_cost": 1.1940298507462688e-07
-      }
-    ],
-    "source": "VolcEngine Ark official 在线推理(常规) (model-pricing page, captured 2026-06-11; CNY/USD=6.7; tiered by input tokens, USD=¥/M÷6.7). [0,32K] uses the output>0.2K tier (TK tiers by input only). Whole-request input-tier via overlay intervals; per-tier cache-hit price."
   },
   "qwen3.7-max": {
     "litellm_provider": "dashscope",

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -471,18 +471,6 @@
       "display": true,
       "notes": "volcengine account 7 (VolcEngine Ark, channel_type=45). Chat model mapped by tk_020. Priced in overlay from VolcEngine Ark official model-pricing page. Reprobed 2026-06-23 via direct Ark /api/v3/chat/completions and returned 200 servable."
     },
-    "newapi/glm-4-7-251222": {
-      "platform": "newapi",
-      "model_id": "glm-4-7-251222",
-      "served_on": [
-        "7"
-      ],
-      "channel_type": 45,
-      "price_source": "overlay",
-      "price_key": "glm-4-7-251222",
-      "display": true,
-      "notes": "volcengine account 7 (VolcEngine Ark, channel_type=45). Chat model mapped by tk_020. Priced in overlay from VolcEngine Ark official model-pricing page. Reprobed 2026-06-23 via direct Ark /api/v3/chat/completions and returned 200 servable."
-    },
     "newapi/doubao-seedance-1-0-pro-250528": {
       "platform": "newapi",
       "model_id": "doubao-seedance-1-0-pro-250528",

--- a/backend/internal/service/tk_served_models_manifest_tk.go
+++ b/backend/internal/service/tk_served_models_manifest_tk.go
@@ -12,7 +12,8 @@ import (
 // asserts this file agrees with overlay price + account model_mapping; the
 // public /pricing presentation filter and the per-user newapi Group Catalog
 // whitelist fallback consume the same embedded source so priced-but-unwired
-// models (deepseek-v3-2-251201) and withdrawn SKUs (glm-4-32b upstream 400)
+// models (deepseek-v3-2-251201) and withdrawn SKUs (glm-4-32b upstream 400,
+// glm-4-7-251222 VolcEngine duplicate — GLM served via DashScope as glm-4.7)
 // cannot mislead the storefront.
 
 //go:embed tk_served_models.json

--- a/backend/internal/service/tk_served_models_manifest_tk_test.go
+++ b/backend/internal/service/tk_served_models_manifest_tk_test.go
@@ -18,6 +18,9 @@ func TestIsTkCuratedNewAPIModelListed(t *testing.T) {
 	if isTkCuratedNewAPIModelListed("glm-4-32b-0414-128k") {
 		t.Fatal("glm-4-32b-0414-128k must not be manifest-listed after upstream 400 withdrawal")
 	}
+	if isTkCuratedNewAPIModelListed("glm-4-7-251222") {
+		t.Fatal("glm-4-7-251222 must not be manifest-listed after VolcEngine GLM withdrawal (serve glm-4.7 via DashScope)")
+	}
 }
 
 func TestIsTkCuratedNewAPIModelDisplayed(t *testing.T) {

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -655,7 +655,7 @@ func user16Span() []Group {
 func user16ServingProvider() availableModelsProvider {
 	return servedProvider(map[int64][]string{
 		11: {"deepseek-chat", "deepseek-v4-pro", "deepseek-reasoner", "deepseek-v4-flash"},
-		18: {"qwen-max", "qwen3-235b-a22b", "qwen3-coder-plus"},
+		18: {"qwen-max", "qwen3-235b-a22b", "qwen3-coder-plus", "glm-4.7"},
 		5:  {"doubao-seed-1-6-250615", "doubao-seedream-4-0-250828"},
 		// gid=1(anthropic)、gid=2(openai)缺席 → nil(native)
 	})
@@ -691,6 +691,13 @@ func TestResolve_MessagesDispatch_NewapiDeepseekDisambiguation_User16(t *testing
 	g, err := r.Resolve(ctx, key, ShapeAnthropicMessages, "deepseek-v4-flash", "")
 	if err != nil || g == nil || g.ID != 11 {
 		t.Fatalf("deepseek-v4-flash @/v1/messages 应落 deepseek 组 gid=11, got=%v err=%v", g, err)
+	}
+
+	// VolcEngine dated GLM id should alias to DashScope glm-4.7 and land Qwen group(18),
+	// not the volcengine tiebreak trap group(5) after glm-4-7-251222 was withdrawn there.
+	g, err = r.Resolve(ctx, key, ShapeOpenAIChat, "glm-4-7-251222", "")
+	if err != nil || g == nil || g.ID != 18 {
+		t.Fatalf("glm-4-7-251222 should route to Qwen gid=18 via glm-4.7 alias, got=%v err=%v", g, err)
 	}
 
 	// 同跨度同端点,claude-opus-4-8 仍正确落 anthropic 组(1)—— 不被 dispatch 并入的

--- a/backend/migrations/tk_059_prune_volcengine_glm47_from_mapping.sql
+++ b/backend/migrations/tk_059_prune_volcengine_glm47_from_mapping.sql
@@ -1,0 +1,31 @@
+-- TokenKey: align volcengine account model_mapping with tk_served_models.json SSOT.
+--
+-- glm-4-7-251222 was removed from the served-models manifest: GLM chat models are
+-- served preferentially via Qwen/DashScope accounts 60/72 (glm-4.7, …), not
+-- VolcEngine Ark account 7. Keeping the VolcEngine-specific SKU id in
+-- credentials.model_mapping advertised a duplicate path the gateway could route
+-- but should not prefer — the same class of drift catalog-serving-drift.py
+-- guards against (#812).
+--
+-- Idempotent: re-running is a no-op when the key is already absent.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH upd AS (
+    UPDATE accounts
+    SET credentials = jsonb_set(
+            credentials,
+            '{model_mapping}',
+            COALESCE(credentials -> 'model_mapping', '{}'::jsonb) - 'glm-4-7-251222',
+            true
+        ),
+        updated_at = NOW()
+    WHERE id = 7
+      AND platform = 'newapi'
+      AND deleted_at IS NULL
+      AND credentials -> 'model_mapping' ? 'glm-4-7-251222'
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;

--- a/backend/migrations/tk_059_prune_volcengine_glm47_from_mapping.sql
+++ b/backend/migrations/tk_059_prune_volcengine_glm47_from_mapping.sql
@@ -2,10 +2,12 @@
 --
 -- glm-4-7-251222 was removed from the served-models manifest: GLM chat models are
 -- served preferentially via Qwen/DashScope accounts 60/72 (glm-4.7, …), not
--- VolcEngine Ark account 7. Keeping the VolcEngine-specific SKU id in
--- credentials.model_mapping advertised a duplicate path the gateway could route
--- but should not prefer — the same class of drift catalog-serving-drift.py
--- guards against (#812).
+-- VolcEngine Ark account 7. Legacy clients may still send the VolcEngine dated
+-- id; runtime alias normalizeGLMVolcengineDatedModelID maps it to glm-4.7 for
+-- routing/billing while this migration prunes the duplicate VolcEngine mapping.
+-- Keeping the VolcEngine-specific SKU id in credentials.model_mapping would
+-- advertise a duplicate path the gateway could route but should not prefer —
+-- the same class of drift catalog-serving-drift.py guards against (#812).
 --
 -- Idempotent: re-running is a no-op when the key is already absent.
 

--- a/docs/all-platform-model-inventory.md
+++ b/docs/all-platform-model-inventory.md
@@ -194,7 +194,7 @@ overlay `litellm_provider="volcengine"` 共 27 条；`tk_served_models.json` 当
 
 > `deepseek-v3-2-251201` 曾出现在 litellm mirror / overlay，但 **tk_020 故意不在账号 7 服务**（VolcEngine 自报价 ~4× 官方 DeepSeek 价），也 **不在 manifest**；2026-07-01 已从 overlay 移除以对齐 SSOT（定价=服务=展示均以 manifest 为准）。其 servable 家应在 DeepSeek 直连（账号 39），待正式 onboarding 后再进 manifest。
 >
-> `glm-4-7-251222` 曾是 VolcEngine Ark 上的 GLM 4.7 dated SKU；2026-07-06 从 manifest / overlay / 账号 7 mapping 移除。GLM chat 优先走 Qwen/DashScope 账号 60/72 的 `glm-4.7`（tk_054），不再经 VolcEngine 重复暴露。
+> `glm-4-7-251222` 曾是 VolcEngine Ark 上的 GLM 4.7 dated SKU；2026-07-06 从 manifest / overlay / 账号 7 mapping 移除。GLM chat 优先走 Qwen/DashScope 账号 60/72 的 `glm-4.7`（tk_054），不再经 VolcEngine 重复暴露；遗留客户端仍发 dated id 时，网关会把 `glm-4-7-251222` 归一化到 `glm-4.7` 后路由/计费。
 
 - 媒体类的 `servable_unpriced` 风险全被 **media 400 守卫**收口为干净报错，无资损。
 - 故意排除的上游媒体变体（`seedream-4.5/5.0(-lite)`、`seedance-1.0-pro-fast`、`seedance-1.0-lite`）见 §4/§5。

--- a/docs/all-platform-model-inventory.md
+++ b/docs/all-platform-model-inventory.md
@@ -182,17 +182,19 @@ servable allowlist 共 **8**（与公开目录、overlay xai 同源）：
 
 **(b) VolcEngine / Doubao + 媒体（账号 7，ct=45）**
 
-overlay `litellm_provider="volcengine"` 共 28 条；`tk_served_models.json` 当前正面清单是账号 7 的 24 条（19 chat + 1 image + 4 video），都必须同时满足 mapping + overlay + 实测/既有 served 证据。
+overlay `litellm_provider="volcengine"` 共 27 条；`tk_served_models.json` 当前正面清单是账号 7 的 23 条（18 chat + 1 image + 4 video），都必须同时满足 mapping + overlay + 实测/既有 served 证据。
 
 | mode | servable id（manifest/account_mapping）|
 |---|---|
 | chat | `doubao-seed-2-0-pro-260215`、`doubao-seed-2-0-code-preview-260215`、`doubao-seed-2-0-lite-260215`、`doubao-seed-2-0-lite-260428`、`doubao-seed-2-0-mini-260215`、`doubao-seed-2-0-mini-260428` |
 | chat | `doubao-seed-1-8-251228`、`doubao-seed-1-6-250615`、`doubao-seed-1-6-251015`、`doubao-seed-1-6-flash-250615`、`doubao-seed-1-6-flash-250828`、`doubao-seed-1-6-vision-250815` |
-| chat | `doubao-seed-character-251128`、`doubao-seed-code-preview-251028`、`doubao-1-5-pro-32k-250115`、`doubao-1-5-pro-32k-character-250715`、`doubao-1-5-lite-32k-250115`、`doubao-1-5-vision-pro-32k-250115`、`glm-4-7-251222` |
+| chat | `doubao-seed-character-251128`、`doubao-seed-code-preview-251028`、`doubao-1-5-pro-32k-250115`、`doubao-1-5-pro-32k-character-250715`、`doubao-1-5-lite-32k-250115`、`doubao-1-5-vision-pro-32k-250115` |
 | image | `doubao-seedream-4-0-250828`（no-prefix `seedream-4-0-250828` 只是 parity 计费键，不进 manifest）|
 | video | `doubao-seedance-1-0-pro-250528`、`doubao-seedance-1-5-pro-251215`、`doubao-seedance-2-0-260128`、`doubao-seedance-2-0-fast-260128`（no-prefix `seedance-1-0-pro-*` 只是 parity 计费键）；`failure_billing=success_only` |
 
 > `deepseek-v3-2-251201` 曾出现在 litellm mirror / overlay，但 **tk_020 故意不在账号 7 服务**（VolcEngine 自报价 ~4× 官方 DeepSeek 价），也 **不在 manifest**；2026-07-01 已从 overlay 移除以对齐 SSOT（定价=服务=展示均以 manifest 为准）。其 servable 家应在 DeepSeek 直连（账号 39），待正式 onboarding 后再进 manifest。
+>
+> `glm-4-7-251222` 曾是 VolcEngine Ark 上的 GLM 4.7 dated SKU；2026-07-06 从 manifest / overlay / 账号 7 mapping 移除。GLM chat 优先走 Qwen/DashScope 账号 60/72 的 `glm-4.7`（tk_054），不再经 VolcEngine 重复暴露。
 
 - 媒体类的 `servable_unpriced` 风险全被 **media 400 守卫**收口为干净报错，无资损。
 - 故意排除的上游媒体变体（`seedream-4.5/5.0(-lite)`、`seedance-1.0-pro-fast`、`seedance-1.0-lite`）见 §4/§5。

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2427,6 +2427,22 @@
       "rationale": "Regression: hyphenless gpt5.4-mini wire spelling must canonicalize to gpt-5.4-mini for routing/restriction/cache parity."
     },
     {
+      "path": "backend/internal/service/model_alias_tk_glm_volcengine.go",
+      "must_contain": [
+        "func normalizeGLMVolcengineDatedModelID(",
+        "tkGLMVolcengineDatedModelPattern"
+      ],
+      "rationale": "VolcEngine Ark GLM dated ids (glm-4-7-251222) normalize to DashScope canonical glm-4.7 for account mapping lookup, universal routing, and pricing after the VolcEngine duplicate SKU was withdrawn from account 7. Without this alias, legacy clients keep requesting the dated id and miss Qwen/DashScope pools even though glm-4.7 remains served."
+    },
+    {
+      "path": "backend/internal/service/model_alias_tk_glm_volcengine_test.go",
+      "must_contain": [
+        "TestNormalizeGLMVolcengineDatedModelID",
+        "TestAccount_GLMDatedVolcengineAliasRoutesViaDashScopeMapping"
+      ],
+      "rationale": "Regression: dated VolcEngine GLM ids must map to glm-4.7 for newapi account model_mapping support and upstream forwarding."
+    },
+    {
       "path": "backend/internal/service/ratelimit_service_tk_model_cooldown.go",
       "must_contain": [
         "func tkAnthropicModelClass(model string) string",

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -124,7 +124,7 @@
         "grok-imagine-image",
         "grok-imagine-video"
       ],
-      "rationale": "Grok pricing rows. Chat models with no usable token price still serve and alert, so losing grok-4.3 / grok-build-0.1 would re-open the served-zero-cost grok chat hole; image models with no usable static price are REJECTED with a pre-spend 400 by TkImageModelUnpriced, and video models likewise by TkVideoModelUnpriced — so losing media rows makes grok image/video generation fail outright. grok-imagine-video is priced per output second at the MAX reachable tier ($0.08/s, 720p+input) per the overlay's never-under-charge convention."
+      "rationale": "Grok pricing rows. Chat models with no usable token price still serve and alert, so losing grok-4.3 / grok-build-0.1 would re-open the served-zero-cost grok chat hole; image models with no usable static price are REJECTED with a pre-spend 400 by TkImageModelUnpriced, and video models likewise by TkVideoModelUnpriced — so losing media rows makes grok image/video generation fail outright. grok-imagine-video is priced per output second at the MAX reachable tier ($0.08/s, 720p+input) per the overlay's never-under-charge convention. Non-grok overlay entries (VolcEngine doubao, DashScope GLM, etc.) live in the same JSON file but are guarded by pricing-availability sentinels; glm-4-7-251222 was withdrawn 2026-07-06 in favor of DashScope glm-4.7."
     },
     {
       "path": "backend/migrations/tk_028_allow_grok_model_availability_platform.sql",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -94,7 +94,7 @@
         "func isTkCuratedNewAPICatalogRowDisplayed(",
         "func isNewAPILongTailCatalogVendor("
       ],
-      "rationale": "Runtime embed of tk_served_models.json — gates runtime newapi intent to manifest-listed models and public /pricing + Group Catalog display rows to manifest display=true only. Without it, priced overlay residue (deepseek-v3-2-251201), withdrawn SKUs, or entitlement-blocked GLM rows reappear on storefront/menu surfaces and mislead users into 400/429 requests while still looking priced."
+      "rationale": "Runtime embed of tk_served_models.json — gates runtime newapi intent to manifest-listed models and public /pricing + Group Catalog display rows to manifest display=true only. Without it, priced overlay residue (deepseek-v3-2-251201), withdrawn SKUs (e.g. glm-4-7-251222 VolcEngine duplicate — GLM served via DashScope as glm-4.7), or entitlement-blocked GLM rows reappear on storefront/menu surfaces and mislead users into 400/429 requests while still looking priced."
     },
     {
       "path": "backend/internal/service/pricing_catalog_candidates_tk.go",
@@ -118,6 +118,7 @@
       "must_contain": [
         "TestPublicCatalog_FiltersUnservableClaudeAndGpt",
         "TestIsPublicCatalogModelSupported",
+        "withdrawn VolcEngine GLM SKU pruned from storefront",
         "TestSupportedCatalogModelIDsForPlatform_Antigravity",
         "TestSupportedCatalogModelIDsForPlatform_Grok"
       ],
@@ -130,7 +131,7 @@
         "applyCatalogOverlayPricing(resp)",
         "func (s *PricingCatalogService) InvalidateCache"
       ],
-      "rationale": "Display-side TK pricing-overlay merge. BuildPublicCatalog reads the trimmed litellm price file (model_pricing.json) and, unlike the billing path (GetModelPricing → applyTKPricingOverlay), did NOT apply the overlay — so every model priced ONLY in tk_pricing_overlay.json (the entire VolcEngine fifth-platform batch: doubao-*/glm-4-7-251222, plus deepseek-v4-pro) showed empty/missing prices in the public /pricing catalog AND Your-Menu (me_pricing_catalog reads BuildPublicCatalog as metaByID), even though billing was correct. applyCatalogOverlayPricing fill-merges the overlay's token-priced models into the catalog so display matches billing, with absent-or-zero semantics: a real non-zero file price wins, an all-zero placeholder row gets its displayed price replaced (same predicate family as billing's tkIsEffectivelyUnpriced). Channel pricing stays a strictly higher tier upstream; the merge is gated behind a non-degraded catalog (len(resp.Data)>0) to preserve the AC-005 degraded→empty contract. An upstream merge refactoring BuildPublicCatalog could silently drop the applyCatalogOverlayPricing(resp) call, regressing every overlay-only model back to an empty price row."
+      "rationale": "Display-side TK pricing-overlay merge. BuildPublicCatalog reads the trimmed litellm price file (model_pricing.json) and, unlike the billing path (GetModelPricing → applyTKPricingOverlay), did NOT apply the overlay — so every model priced ONLY in tk_pricing_overlay.json (the VolcEngine fifth-platform doubao-* batch, plus deepseek-v4-pro; GLM chat is DashScope-first as glm-4.7, not VolcEngine glm-4-7-251222) showed empty/missing prices in the public /pricing catalog AND Your-Menu (me_pricing_catalog reads BuildPublicCatalog as metaByID), even though billing was correct. applyCatalogOverlayPricing fill-merges the overlay's token-priced models into the catalog so display matches billing, with absent-or-zero semantics: a real non-zero file price wins, an all-zero placeholder row gets its displayed price replaced (same predicate family as billing's tkIsEffectivelyUnpriced). Channel pricing stays a strictly higher tier upstream; the merge is gated behind a non-degraded catalog (len(resp.Data)>0) to preserve the AC-005 degraded→empty contract. An upstream merge refactoring BuildPublicCatalog could silently drop the applyCatalogOverlayPricing(resp) call, regressing every overlay-only model back to an empty price row."
     },
     {
       "path": "backend/internal/service/billing_service.go",
@@ -197,7 +198,7 @@
         "\"served_on\"",
         "\"display\""
       ],
-      "rationale": "The served-models MANIFEST itself — the single declarative source of intent consumed by scripts/checks/catalog-serving-drift.py (now), the tokenkey-onboard-model skill (now), and a future newapi reconciler (//go:embed of this file, co-located with tk_pricing_overlay.json so the same Go package can embed both). Pinning the schema keys (entries / price_source / served_on / display) stops an upstream merge or refactor from silently truncating the manifest to an empty/legacy shape that would make the drift guard vacuously pass while the intent->migration->price agreement it encodes is lost. Co-located with the overlay so the same preflight parses both and the same package will embed both."
+      "rationale": "The served-models MANIFEST itself — the single declarative source of intent consumed by scripts/checks/catalog-serving-drift.py (now), the tokenkey-onboard-model skill (now), and a future newapi reconciler (//go:embed of this file, co-located with tk_pricing_overlay.json so the same Go package can embed both). Pinning the schema keys (entries / price_source / served_on / display) stops an upstream merge or refactor from silently truncating the manifest to an empty/legacy shape that would make the drift guard vacuously pass while the intent->migration->price agreement it encodes is lost. GLM chat models follow DashScope-first policy (glm-4.7 on Qwen accounts 60/72); VolcEngine glm-4-7-251222 was withdrawn 2026-07-06. Co-located with the overlay so the same preflight parses both and the same package will embed both."
     },
     {
       "path": "backend/internal/service/pricing_service_tk_overlay.go",


### PR DESCRIPTION
## 摘要

- 从 VolcEngine 账号 7 的可服务清单移除 `glm-4-7-251222`（manifest、overlay、公开目录过滤）。
- 新增 migration `tk_059`，幂等删除账号 7 `model_mapping` 中的该 SKU。
- GLM chat 由 Qwen/DashScope 账号 60/72 的 `glm-4.7` 提供（DashScope 优先原则）。
- 遗留客户端仍发 VolcEngine dated id（如 `glm-4-7-251222`）时，网关归一化到 `glm-4.7` 后正常路由/计费，不会空池 429。

## 风险

- 公开目录仍只展示 `glm-4.7`，不展示 dated VolcEngine SKU（避免重复入口）。
- 合并后需在 prod 跑 migration `tk_059`，账号 7 mapping 才会同步下线。
- 常规风险：无公共 API 契约变更。Web impact: none

## 验证

- `go test -tags=unit ./internal/service/ -run 'TestNormalizeGLMVolcengineDatedModelID|TestAccount_GLMDatedVolcengineAliasRoutesViaDashScopeMapping|TestResolve_MessagesDispatch_NewapiDeepseekDisambiguation_User16'` 通过
- `python3 scripts/sentinels/check-registry-update-gate.py --base origin/main --head HEAD` 通过
- 已 rebase 到最新 `origin/main`；上一轮 CI 全绿后再追加 alias 提交，待 CI 复验

## 提交

- `35d120c06` fix(volcengine): drop glm-4-7-251222 from Ark servable list
- `2172be467` chore(sentinels): sync registry after VolcEngine GLM withdrawal
- `a8a56c87d` fix(glm): alias VolcEngine dated ids to DashScope glm-4.7 for routing

最新提交：`a8a56c87d`