### PR TITLE
fix(openai): spark 429 按模型限流，避免整账号误冷却

### DIFF
--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -50,29 +50,43 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 		return false
 	}
 
-	if statusCode == http.StatusTooManyRequests {
-		s.markOpenAIOAuth429RateLimited(stateCtx, account, headers, responseBody)
-	}
 	if s == nil || account == nil || s.rateLimitService == nil {
+		if statusCode == http.StatusTooManyRequests {
+			s.markOpenAIOAuth429RateLimited(stateCtx, account, headers, responseBody, requestedModel...)
+		}
 		return false
 	}
 	if len(requestedModel) > 0 && s.rateLimitService.HandleUpstreamModelNotFound(stateCtx, account, requestedModel[0], statusCode, responseBody) {
 		return true
 	}
-	shouldDisable := s.rateLimitService.HandleUpstreamError(stateCtx, account, statusCode, headers, responseBody)
+	shouldDisable := s.rateLimitService.HandleUpstreamError(stateCtx, account, statusCode, headers, responseBody, requestedModel...)
+	if statusCode == http.StatusTooManyRequests {
+		s.markOpenAIOAuth429RateLimited(stateCtx, account, headers, responseBody, requestedModel...)
+		return false
+	}
 	if shouldDisable {
 		s.BlockAccountScheduling(account, time.Time{}, "upstream_disable")
 	}
 	return shouldDisable
 }
 
-func (s *OpenAIGatewayService) markOpenAIOAuth429RateLimited(ctx context.Context, account *Account, headers http.Header, responseBody []byte) {
+func (s *OpenAIGatewayService) markOpenAIOAuth429RateLimited(ctx context.Context, account *Account, headers http.Header, responseBody []byte, requestedModel ...string) {
 	if s == nil || !isOpenAIOAuthAccount(account) {
 		return
 	}
 	// Spark 影子：不按 /responses 429 的 global x-codex-* 信号做内存运行时熔断(同 handle429,外审第8轮 P1)。
 	// 同时避免把 spark 的 429 计入全局 429 storm 计数(recordOpenAIOAuth429),否则会误伤母账号 failover 决策。
 	if account.IsShadow() {
+		return
+	}
+	reqModel := ""
+	if len(requestedModel) > 0 {
+		reqModel = requestedModel[0]
+	}
+	// Spark sub-window 429 while the account-wide codex window is healthy: durable
+	// cooldown lives in model_rate_limits (HandleUpstreamError path 2). Do not
+	// whole-account runtime-block or the account idles gpt-5.4/5.5 capacity.
+	if tkShouldOpenAICodex429BeModelScoped(account, headers, responseBody, reqModel) {
 		return
 	}
 	s.recordOpenAIOAuth429()

--- a/backend/internal/service/openai_account_runtime_block_fastpath_test.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath_test.go
@@ -158,3 +158,55 @@ func TestShouldStopOpenAIOAuth429Failover_StopsGrokAfterFirst429Switch(t *testin
 	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(apiKeyAccount, http.StatusTooManyRequests, 1))
 	require.False(t, svc.ShouldStopOpenAIOAuth429Failover(account, http.StatusInternalServerError, 1))
 }
+
+// Prod incident 2026-07-06 (GPT-pro1): spark usage_limit_reached 429 with a healthy
+// account-wide codex window must model-scope — not whole-account runtime-block or
+// SetRateLimited — so gpt-5.4/5.5 keep scheduling on the same OAuth account.
+func TestHandleOpenAIAccountUpstreamError_Spark429HealthyWindow_ModelScopedOnly(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := &OpenAIGatewayService{
+		rateLimitService: newG4RateLimitService(repo),
+	}
+	account := newOpenAICodexAccount(9, AccountTypeOAuth)
+	body := []byte(`{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"pro","resets_at":1783336071,"resets_in_seconds":14903}}`)
+
+	shouldDisable := svc.handleOpenAIAccountUpstreamError(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		codexGeneralWindowHeaders(4, 1),
+		body,
+		codexSparkModel,
+	)
+
+	require.False(t, shouldDisable)
+	require.False(t, svc.isOpenAIAccountRuntimeBlocked(account), "spark sub-limit must not whole-account runtime-block")
+	require.Len(t, repo.modelRateLimitCalls, 1, "spark cooldown must be model-scoped")
+	require.Equal(t, codexSparkModel, repo.modelRateLimitCalls[0].scope)
+	require.Zero(t, repo.setRateLimitedCalls, "healthy general window must not SetRateLimited whole account")
+}
+
+func TestHandleOpenAIAccountUpstreamError_Spark429GeneralWindowExhausted_WholeAccount(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := &OpenAIGatewayService{
+		rateLimitService: newG4RateLimitService(repo),
+	}
+	account := newOpenAICodexAccount(9, AccountTypeOAuth)
+	body := codexUsageLimitBody
+	headers := codexGeneralWindowHeaders(100, 1)
+	headers.Set("x-codex-primary-reset-after-seconds", "7620")
+
+	shouldDisable := svc.handleOpenAIAccountUpstreamError(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		headers,
+		body,
+		codexSparkModel,
+	)
+
+	require.False(t, shouldDisable)
+	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account), "account-wide window exhaustion must runtime-block")
+	require.Empty(t, repo.modelRateLimitCalls)
+	require.Equal(t, 1, repo.setRateLimitedCalls)
+}

--- a/backend/internal/service/openai_gateway_v1_forward.go
+++ b/backend/internal/service/openai_gateway_v1_forward.go
@@ -178,9 +178,7 @@ func (s *OpenAIGatewayService) forwardOpenAIV1JSON(
 				Message:            upstreamMsg,
 				Detail:             upstreamDetail,
 			})
-			if s.rateLimitService != nil {
-				s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
-			}
+			s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, upstreamModel)
 			return nil, &UpstreamFailoverError{
 				StatusCode:   resp.StatusCode,
 				ResponseBody: respBody,

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"log/slog"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -330,6 +331,30 @@ const (
 func tkIsOpenAICodexMeteredModel(model string) bool {
 	name := strings.ToLower(strings.TrimSpace(model))
 	return strings.Contains(name, "codex") && strings.Contains(name, "spark")
+}
+
+// tkShouldOpenAICodex429BeModelScoped reports whether an OpenAI OAuth 429 should
+// narrow to (account × model) cooldown instead of whole-account penalties.
+// Preconditions mirror handle429 body path (path 2) before account-level
+// SetRateLimited: path 1 declined (no >=100% account-wide window in headers),
+// body carries a parseable usage_limit_reached reset, and the mapped model is a
+// codex metered sub-limit (spark). Used by the OpenAI gateway runtime-block
+// fast-path so spark sub-window 429s do not whole-account BlockAccountScheduling.
+func tkShouldOpenAICodex429BeModelScoped(account *Account, headers http.Header, responseBody []byte, requestedModel string) bool {
+	if account == nil || account.Platform != PlatformOpenAI || !account.IsOAuth() {
+		return false
+	}
+	if calculateOpenAI429ResetTime(headers) != nil {
+		return false
+	}
+	if parseOpenAIRateLimitResetTime(responseBody) == nil {
+		return false
+	}
+	scopeKey := strings.TrimSpace(account.GetMappedModel(requestedModel))
+	if scopeKey == "" || !tkIsOpenAICodexMeteredModel(scopeKey) {
+		return false
+	}
+	return true
 }
 
 // tkTryOpenAICodexModelScopedCooldown narrows a codex per-model metered (spark)

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
@@ -566,3 +566,19 @@ func TestTkIsOpenAICodexMeteredModel(t *testing.T) {
 		require.Falsef(t, tkIsOpenAICodexMeteredModel(m), "model=%q should NOT be metered", m)
 	}
 }
+
+func TestTkShouldOpenAICodex429BeModelScoped(t *testing.T) {
+	account := newOpenAICodexAccount(1, AccountTypeOAuth)
+	body := codexUsageLimitBody
+	healthy := codexGeneralWindowHeaders(4, 1)
+
+	require.True(t, tkShouldOpenAICodex429BeModelScoped(account, healthy, body, codexSparkModel))
+	require.False(t, tkShouldOpenAICodex429BeModelScoped(account, healthy, body, "gpt-5.4"))
+	require.False(t, tkShouldOpenAICodex429BeModelScoped(account, healthy, body, ""))
+	require.False(t, tkShouldOpenAICodex429BeModelScoped(
+		newOpenAICodexAccount(2, AccountTypeAPIKey), healthy, body, codexSparkModel))
+
+	exhausted := codexGeneralWindowHeaders(100, 1)
+	exhausted.Set("x-codex-primary-reset-after-seconds", "7620")
+	require.False(t, tkShouldOpenAICodex429BeModelScoped(account, exhausted, body, codexSparkModel))
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1111,11 +1111,12 @@
     {
       "path": "backend/internal/service/openai_account_runtime_block_fastpath.go",
       "must_contain": [
-        "shouldDisable := s.rateLimitService.HandleUpstreamError(stateCtx, account, statusCode, headers, responseBody)",
+        "shouldDisable := s.rateLimitService.HandleUpstreamError(stateCtx, account, statusCode, headers, responseBody, requestedModel...)",
+        "tkShouldOpenAICodex429BeModelScoped(account, headers, responseBody, reqModel)",
         "s.BlockAccountScheduling(account, time.Time{}, \"upstream_disable\")",
         "openAIOAuth429StormThreshold"
       ],
-      "rationale": "OPC companion for upstream OpenAI cooldown scheduling (#2698 / 1e406fed): centralizes HandleUpstreamError + BlockAccountScheduling + OAuth 429 storm guard so openai_gateway_service.go and openai_account_scheduler.go stay thin. Pinning HandleUpstreamError's shouldDisable capture and upstream_disable block path prevents silent reversion to `_ =` side-effect-only handling. OAuth 429 storm threshold anchors the TK failover guard that limits account switches during burst 429s."
+      "rationale": "OPC companion for upstream OpenAI cooldown scheduling (#2698 / 1e406fed): centralizes HandleUpstreamError + BlockAccountScheduling + OAuth 429 storm guard so openai_gateway_service.go and openai_account_scheduler.go stay thin. HandleUpstreamError MUST receive requestedModel so spark usage_limit_reached 429s hit model_rate_limits (path 2) instead of whole-account SetRateLimited while the account-wide codex window is healthy (prod GPT-pro1 2026-07-06). tkShouldOpenAICodex429BeModelScoped gates markOpenAIOAuth429RateLimited so model-scoped spark cooldowns do not whole-account BlockAccountScheduling. Pinning shouldDisable capture and upstream_disable block path prevents silent reversion to `_ =` side-effect-only handling. OAuth 429 storm threshold anchors the TK failover guard that limits account switches during burst 429s."
     },
     {
       "path": "backend/internal/service/openai_oauth_passthrough_test.go",

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -111,9 +111,10 @@
       "must_contain": [
         "account.IsGrokOAuth()",
         "validateUpstreamBaseURLForAccount(account, raw)",
-        "validateUpstreamBaseURLForAccount(account, strings.TrimSpace(account.GetGrokBaseURL()))"
+        "validateUpstreamBaseURLForAccount(account, strings.TrimSpace(account.GetGrokBaseURL()))",
+        "s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, upstreamModel)"
       ],
-      "rationale": "The image/embeddings seam: buildOpenAIV1TargetURL hardcodes api.openai.com for the OAuth case; the grok OAuth arm redirects it to api.x.ai/v1. First-class grok API-key relay stubs use the API-key branch plus their edge base_url. Losing this arm points grok OAuth image requests at OpenAI; broadening it back to IsGrok() breaks grok API-key relay stubs."
+      "rationale": "The image/embeddings seam: buildOpenAIV1TargetURL hardcodes api.openai.com for the OAuth case; the grok OAuth arm redirects it to api.x.ai/v1. First-class grok API-key relay stubs use the API-key branch plus their edge base_url. Losing this arm points grok OAuth image requests at OpenAI; broadening it back to IsGrok() breaks grok API-key relay stubs. Failover path MUST route upstream errors through handleOpenAIAccountUpstreamError with upstreamModel (not bare HandleUpstreamError) so spark/model-scoped 429 cooldown semantics stay consistent with chat/responses paths."
     },
     {
       "path": "backend/internal/service/tk_pricing_overlay.json",


### PR DESCRIPTION
## 摘要

- 修复 OpenAI OAuth 在 `gpt-5.3-codex-spark` 收到 `usage_limit_reached` 429 时，错误地将整账号写入 `rate_limit_reset_at` 并 runtime-block，导致同账号上 gpt-5.5/mini 仍可用却被 TK 停调度（GPT-pro1 2026-07-06 事件）。
- `handleOpenAIAccountUpstreamError` 现在把 `requestedModel` 传给 `HandleUpstreamError`，启用已有 spark model-scoped 路径（`model_rate_limits`）。
- `markOpenAIOAuth429RateLimited` 在 spark 子窗口 429 + 账号级 Codex 窗口健康时跳过整账号内存 block；账号级 5h/7d ≥100% 仍整账号冷却。
- `openai_gateway_v1_forward` failover 路径改为走统一 upstream-error 处理并携带 model。
- 同步更新 `gateway-tk.json` / `grok.json` sentinel 锚点（`requestedModel...`、`tkShouldOpenAICodex429BeModelScoped`、v1 failover 路由）。

## 风险

- 常规风险；仅影响 OpenAI OAuth 429 惩罚范围判定，不改变账号级窗口打满时的整账号冷却语义。
- Web impact: none（调度/限流后端行为；Admin 限流展示将更符合模型级 vs 账号级实际状态）。

## 验证

- `go test -tags=unit ./internal/service -run 'TestHandleOpenAIAccountUpstreamError_Spark429|TestTkShouldOpenAICodex429BeModelScoped|TestCodexSpark429' -count=1` — 通过
- `python3 scripts/sentinels/check-gateway-tk.py` / `check-grok.py` / `check-registry-update-gate.py` — 通过
- prod 探测（合并前）：账号 9 spark 仍上游 429；5.5/mini 在手动恢复 TK 状态后可正常计费 — 与修复意图一致

## 提交

- ecf242a53 fix(openai): scope spark 429 cooldown to model instead of whole account
- 0d1a9fef3 fix(openai): anchor spark model-scoped 429 sentinels for PR #1242
- 最新提交：0d1a9fef3