### PR TITLE
fix(frontend): 修复已登录用户从模型市场跳转到定价页显示 0 个模型

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 571,
-  "hash": "ac34ad10bd4fe4e227afff8030daaa4b3be502b81d79efe95bd6f722b072d1f5",
+  "hash": "02453979be2770d557f2e9feeaf1ebeefa5a14ca27fea1d289c2a31bc20d0281",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -1098,7 +1098,7 @@ function reload(): void {
 }
 
 /** Deep link from /models marketplace cards: ?model=<id> pre-fills exact search. */
-function applyModelDeepLinkFromRoute(): void {
+async function applyModelDeepLinkFromRoute(): Promise<void> {
   const raw = route.query.model
   const modelId =
     typeof raw === 'string'
@@ -1108,13 +1108,20 @@ function applyModelDeepLinkFromRoute(): void {
         : ''
   if (!modelId) return
   viewMode.value = 'public'
+  selectedKeyId.value = 0
+  selectedGroupId.value = 0
   modelSearchQuery.value = modelId
   modelSearchMode.value = 'exact'
+  // Authenticated users default to the "my" catalog on load(); public rows stay
+  // empty until we fetch the public catalog for this deep link.
+  if (!publicCatalog.value?.data?.length) {
+    await loadPublicCatalog()
+  }
 }
 
 onMounted(async () => {
   await load()
-  applyModelDeepLinkFromRoute()
+  await applyModelDeepLinkFromRoute()
   void appStore.fetchPublicSettings()
 })
 </script>

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -258,6 +258,22 @@ describe('PricingView', () => {
     expect(wrapper.text()).not.toContain('gpt-5.4')
   })
 
+  it('loads public catalog for ?model= deep link when authenticated', async () => {
+    authState.isAuthenticated = true
+    routeState.query = { model: 'claude-opus-4-8' }
+    getMePricingCatalog.mockResolvedValue(meCatalog())
+    getPublicPricing.mockResolvedValue(
+      publicCatalog([publicModel('claude-opus-4-8'), publicModel('gpt-5.4')])
+    )
+
+    const wrapper = mountPricingView()
+    await flushPromises()
+
+    expect(getPublicPricing).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('claude-opus-4-8')
+    expect(wrapper.text()).not.toContain('gpt-5.4')
+  })
+
   it('shows max output column when catalog includes max_output_tokens', async () => {
     const catalog: PublicCatalogResponse = {
       object: 'list',


### PR DESCRIPTION
## 摘要

- 修复 `/pricing?model=<id>` deep link 在**已登录**状态下显示「0 个模型」的问题
- 根因：登录用户默认加载 my catalog，deep link 只切换 `viewMode=public` 但未拉取 public catalog
- 修复：deep link 时若 public catalog 为空则补拉 `loadPublicCatalog()`，并重置 key/group 筛选

sentinel-registry-reviewed：`PricingView.vue` 已有 `frontend-tk.json` 锚点；本次为 deep link 加载路径补全，无需新增 sentinel。

## 风险

- 常规风险，仅影响定价页 deep link 加载路径
- 未登录用户行为不变

## 验证

```bash
cd frontend && pnpm test:run src/views/__tests__/PricingView.spec.ts
```

- 17 passed（含新增 `loads public catalog for ?model= deep link when authenticated`）

## 提交

- 464ddd9 fix(frontend): 已登录用户从模型市场 deep link 到定价页时加载 public catalog
- b952371 fix(frontend): 刷新 embedded dist 源码 hash（PricingView deep link 修复）

最新提交：b952371