### PR TITLE
fix(ci,deploy): SSOT deploy-canary + delta gate，PR CI 加速

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -45,12 +45,8 @@ jobs:
       - uses: ./.github/actions/cache-and-checkout-new-api
       - name: Fetch base ref for diff gates
         # fetch-depth alone does not guarantee origin/main on PR checkouts; preflight
-        # deleted-file / merge-base gates need origin/main...HEAD. Shallow history
-        # also omits .main-ancestry-anchor (see scripts/checks/main-ancestry-anchor.py).
-        run: |
-          git fetch --no-tags origin "${GITHUB_BASE_REF:-main}:refs/remotes/origin/${GITHUB_BASE_REF:-main}" --depth=64
-          ANCHOR=$(tr -d '[:space:]' < .main-ancestry-anchor)
-          git fetch --no-tags origin "${ANCHOR}"
+        # deleted-file / merge-base gates need origin/main...HEAD.
+        run: git fetch --no-tags origin "${GITHUB_BASE_REF:-main}:refs/remotes/origin/${GITHUB_BASE_REF:-main}" --depth=64
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,7 +11,7 @@ on:
       suite:
         description: Which CI suite to run
         required: false
-        default: all
+        default: ci
         type: choice
         options:
           - all
@@ -38,12 +38,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 64
           submodules: recursive
       # Preflight runs `go test` for QA evidence dataset validation; backend/go.mod
       # replaces new-api with ../../new-api — same sibling checkout as test/lint jobs.
       - uses: ./.github/actions/cache-and-checkout-new-api
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          check-latest: false
+          cache: false
+      - uses: ./.github/actions/go-rolling-cache
+        with:
+          prefix: preflight
       - name: Run preflight
+        env:
+          PREFLIGHT_FAST: ${{ github.event_name == 'pull_request' && '1' || '0' }}
         run: |
           if [ -x scripts/preflight.sh ]; then
             ./scripts/preflight.sh
@@ -75,6 +85,8 @@ jobs:
       - name: Unit tests
         working-directory: backend
         run: make test-unit
+      - name: Anthropic prompt surface fixture gateway
+        run: python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway
 
   test-integration:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -45,8 +45,12 @@ jobs:
       - uses: ./.github/actions/cache-and-checkout-new-api
       - name: Fetch base ref for diff gates
         # fetch-depth alone does not guarantee origin/main on PR checkouts; preflight
-        # deleted-file / merge-base gates need origin/main...HEAD.
-        run: git fetch --no-tags origin "${GITHUB_BASE_REF:-main}:refs/remotes/origin/${GITHUB_BASE_REF:-main}" --depth=64
+        # deleted-file / merge-base gates need origin/main...HEAD. Shallow history
+        # also omits .main-ancestry-anchor (see scripts/checks/main-ancestry-anchor.py).
+        run: |
+          git fetch --no-tags origin "${GITHUB_BASE_REF:-main}:refs/remotes/origin/${GITHUB_BASE_REF:-main}" --depth=64
+          ANCHOR=$(tr -d '[:space:]' < .main-ancestry-anchor)
+          git fetch --no-tags origin "${ANCHOR}"
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -43,6 +43,10 @@ jobs:
       # Preflight runs `go test` for QA evidence dataset validation; backend/go.mod
       # replaces new-api with ../../new-api — same sibling checkout as test/lint jobs.
       - uses: ./.github/actions/cache-and-checkout-new-api
+      - name: Fetch base ref for diff gates
+        # fetch-depth alone does not guarantee origin/main on PR checkouts; preflight
+        # deleted-file / merge-base gates need origin/main...HEAD.
+        run: git fetch --no-tags origin "${GITHUB_BASE_REF:-main}:refs/remotes/origin/${GITHUB_BASE_REF:-main}" --depth=64
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -65,6 +65,36 @@ jobs:
             ./dev-rules/templates/preflight.sh
           fi
 
+  ssot-delta-gate:
+    # Live SSOT proof for catalog diffs only (replaces retired daily full-matrix gate).
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    environment: prod
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 64
+      - name: Fetch base ref for catalog diff
+        run: git fetch --no-tags origin "${GITHUB_BASE_REF:-main}:refs/remotes/origin/${GITHUB_BASE_REF:-main}" --depth=64
+      - name: Skip when catalog surface unchanged
+        id: touch
+        run: |
+          set -euo pipefail
+          changed=$(python3 scripts/checks/ssot-delta-gate.py paths-changed --base "origin/${GITHUB_BASE_REF:-main}")
+          echo "changed=${changed}" >> "$GITHUB_OUTPUT"
+      - name: Focused SSOT gate (delta models only)
+        if: steps.touch.outputs.changed == 'true'
+        env:
+          TK_FULLTEST_KEY: ${{ secrets.TK_FULLTEST_KEY }}
+          TK_FULLTEST_BASE_URL: https://api.tokenkey.dev
+          TK_FULLTEST_TIMEOUT: "30"
+        run: |
+          set -euo pipefail
+          python3 scripts/checks/ssot-delta-gate.py check --base "origin/${GITHUB_BASE_REF:-main}"
+
   test-unit:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -67,12 +67,13 @@ jobs:
 
   ssot-delta-gate:
     # Live SSOT proof for catalog diffs only (replaces retired daily full-matrix gate).
+    # No `environment: prod` — that env has deploy/OIDC approval gates; this job only
+    # probes public prod API and needs TK_FULLTEST_KEY as a repository Actions secret.
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
-    environment: prod
     steps:
       - uses: actions/checkout@v6
         with:
@@ -85,6 +86,18 @@ jobs:
           set -euo pipefail
           changed=$(python3 scripts/checks/ssot-delta-gate.py paths-changed --base "origin/${GITHUB_BASE_REF:-main}")
           echo "changed=${changed}" >> "$GITHUB_OUTPUT"
+      - name: Validate TK_FULLTEST_KEY (repository secret)
+        if: steps.touch.outputs.changed == 'true'
+        env:
+          TK_FULLTEST_KEY: ${{ secrets.TK_FULLTEST_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TK_FULLTEST_KEY:-}" ]; then
+            echo "::error::TK_FULLTEST_KEY is not set as a repository Actions secret."
+            echo "::error::ssot-delta-gate cannot use the prod Environment secret without deployment approval."
+            echo "::error::Add the same key under Settings → Secrets and variables → Actions → Repository secrets."
+            exit 1
+          fi
       - name: Focused SSOT gate (delta models only)
         if: steps.touch.outputs.changed == 'true'
         env:

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -204,13 +204,14 @@ jobs:
           # already-deployed image.
           bash ops/stage0/post_deploy_smoke.sh
 
-      - name: Post-deploy SSOT display gate (sharded)
+      - name: Post-deploy SSOT display gate (deploy canary)
         env:
           TOKENKEY_BASE_URL: ${{ steps.instance.outputs.api_url }}
           TK_FULLTEST_KEY: ${{ secrets.TK_FULLTEST_KEY }}
+          TK_FULLTEST_TIMEOUT: "30"
         run: |
           set -euo pipefail
-          bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --deploy-closeout --show-excluded
+          bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout
 
       - name: Notify Feishu (release rollout)
         # Best-effort 发版公告。默认 step gating 保证它只在 prod 换镜像 +

--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -1130,7 +1130,7 @@ jobs:
             echo "::warning::recent-success probe failed; running full SSOT without log skip"
             : > .ssot-gate/recent-success.tsv
           fi
-          SKIP_LINES=$(grep -cv '^#' .ssot-gate/recent-success.tsv || true)
+          SKIP_LINES=$(grep -cv '^#' .ssot-gate/recent-success.tsv || true) # preflight-allow: swallow
           echo "skip_lines=${SKIP_LINES}" >> "$GITHUB_OUTPUT"
 
       - name: Full SSOT display gate (sharded, log-skip)

--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -8,7 +8,6 @@ name: Ops Daily Diagnostics
 on:
   schedule:
     - cron: "0 2 * * *"
-    - cron: "0 18 * * *"
   workflow_dispatch:
     inputs:
       operation:
@@ -20,7 +19,6 @@ on:
           - diagnostics
           - error_clustering
           - log_dump
-          - ssot_gate
       target_selector:
         description: "Diagnostics target selector: all, prod, edge:*, or edge:<id>. log_dump supports prod only."
         required: false
@@ -69,7 +67,7 @@ permissions:
 
 jobs:
   discover-targets:
-    if: (github.event_name == 'schedule' && github.event.schedule == '0 2 * * *') || (github.event_name == 'workflow_dispatch' && inputs.operation != 'log_dump' && inputs.operation != 'ssot_gate')
+    if: (github.event_name == 'schedule' && github.event.schedule == '0 2 * * *') || (github.event_name == 'workflow_dispatch' && inputs.operation != 'log_dump')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1064,91 +1062,3 @@ jobs:
         with:
           name: prod-logs-${{ github.run_id }}
           path: logs.txt
-
-  ssot-display-gate:
-    # Full catalog SSOT at off-peak (18:00 UTC = 02:00 Asia/Shanghai). Skips rows
-    # with successful usage_logs in the last 24h to avoid re-proving steady traffic.
-    if: (github.event_name == 'schedule' && github.event.schedule == '0 18 * * *') || (github.event_name == 'workflow_dispatch' && inputs.operation == 'ssot_gate')
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    permissions:
-      contents: read
-      id-token: write
-    environment: prod
-    env:
-      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
-      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
-      STACK_NAME: ${{ vars.PROD_STACK_NAME || 'tokenkey-prod-stage0' }}
-      TK_SSOT_GATE_SHARD_SLEEP_SEC: "2"
-      TK_FULLTEST_TIMEOUT: "30"
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Validate prod SSOT secrets
-        env:
-          TK_FULLTEST_KEY: ${{ secrets.TK_FULLTEST_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "${TK_FULLTEST_KEY:-}" ]; then
-            echo "::error::TK_FULLTEST_KEY is not set in prod Environment."
-            exit 1
-          fi
-          if [ -z "${OIDC_ROLE_ARN:-}" ]; then
-            echo "::error::AWS_OIDC_ROLE_ARN repo variable not set."
-            exit 1
-          fi
-
-      - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Resolve prod API URL
-        id: prod
-        run: |
-          set -euo pipefail
-          API_URL=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
-            --query 'Stacks[0].Outputs[?OutputKey==`ApiUrl`].OutputValue' --output text)
-          if [ -z "$API_URL" ] || [ "$API_URL" = "None" ]; then
-            echo "::error::could not resolve ApiUrl from stack $STACK_NAME"
-            exit 1
-          fi
-          echo "api_url=$API_URL" >> "$GITHUB_OUTPUT"
-
-      - name: Fetch recent successful usage rows (24h skip set)
-        id: recent
-        run: |
-          set -euo pipefail
-          mkdir -p .ssot-gate
-          if ! bash ops/observability/run-probe.sh --target prod \
-            --script ops/observability/probe-ssot-recent-success.sh \
-            --env WINDOW_HOURS=24 \
-            --env MIN_COUNT=1 \
-            --comment "ops-daily ssot recent-success skip set" \
-            --timeout-seconds 120 > .ssot-gate/recent-success.tsv 2> .ssot-gate/recent-success.stderr; then
-            echo "::warning::recent-success probe failed; running full SSOT without log skip"
-            : > .ssot-gate/recent-success.tsv
-          fi
-          SKIP_LINES=$(grep -cv '^#' .ssot-gate/recent-success.tsv || true) # preflight-allow: swallow
-          echo "skip_lines=${SKIP_LINES}" >> "$GITHUB_OUTPUT"
-
-      - name: Full SSOT display gate (sharded, log-skip)
-        env:
-          TOKENKEY_BASE_URL: ${{ steps.prod.outputs.api_url }}
-          TK_FULLTEST_KEY: ${{ secrets.TK_FULLTEST_KEY }}
-          TK_SSOT_SKIP_RECENT_FILE: ${{ github.workspace }}/.ssot-gate/recent-success.tsv
-        run: |
-          set -euo pipefail
-          bash ops/observability/endpoint-compat-audit.sh \
-            --ssot-model-matrix --gate-sharded --show-excluded \
-            --skip-recent-file "$TK_SSOT_SKIP_RECENT_FILE" \
-            2>&1 | tee .ssot-gate/gate.log
-          tail -5 .ssot-gate/gate.log >> "$GITHUB_STEP_SUMMARY"
-
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: ssot-gate-${{ github.run_id }}
-          path: .ssot-gate/
-          retention-days: 14

--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -8,6 +8,7 @@ name: Ops Daily Diagnostics
 on:
   schedule:
     - cron: "0 2 * * *"
+    - cron: "0 18 * * *"
   workflow_dispatch:
     inputs:
       operation:
@@ -19,6 +20,7 @@ on:
           - diagnostics
           - error_clustering
           - log_dump
+          - ssot_gate
       target_selector:
         description: "Diagnostics target selector: all, prod, edge:*, or edge:<id>. log_dump supports prod only."
         required: false
@@ -67,7 +69,7 @@ permissions:
 
 jobs:
   discover-targets:
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.operation != 'log_dump')
+    if: (github.event_name == 'schedule' && github.event.schedule == '0 2 * * *') || (github.event_name == 'workflow_dispatch' && inputs.operation != 'log_dump' && inputs.operation != 'ssot_gate')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1062,3 +1064,91 @@ jobs:
         with:
           name: prod-logs-${{ github.run_id }}
           path: logs.txt
+
+  ssot-display-gate:
+    # Full catalog SSOT at off-peak (18:00 UTC = 02:00 Asia/Shanghai). Skips rows
+    # with successful usage_logs in the last 24h to avoid re-proving steady traffic.
+    if: (github.event_name == 'schedule' && github.event.schedule == '0 18 * * *') || (github.event_name == 'workflow_dispatch' && inputs.operation == 'ssot_gate')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
+    environment: prod
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      STACK_NAME: ${{ vars.PROD_STACK_NAME || 'tokenkey-prod-stage0' }}
+      TK_SSOT_GATE_SHARD_SLEEP_SEC: "2"
+      TK_FULLTEST_TIMEOUT: "30"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate prod SSOT secrets
+        env:
+          TK_FULLTEST_KEY: ${{ secrets.TK_FULLTEST_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TK_FULLTEST_KEY:-}" ]; then
+            echo "::error::TK_FULLTEST_KEY is not set in prod Environment."
+            exit 1
+          fi
+          if [ -z "${OIDC_ROLE_ARN:-}" ]; then
+            echo "::error::AWS_OIDC_ROLE_ARN repo variable not set."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve prod API URL
+        id: prod
+        run: |
+          set -euo pipefail
+          API_URL=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`ApiUrl`].OutputValue' --output text)
+          if [ -z "$API_URL" ] || [ "$API_URL" = "None" ]; then
+            echo "::error::could not resolve ApiUrl from stack $STACK_NAME"
+            exit 1
+          fi
+          echo "api_url=$API_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch recent successful usage rows (24h skip set)
+        id: recent
+        run: |
+          set -euo pipefail
+          mkdir -p .ssot-gate
+          if ! bash ops/observability/run-probe.sh --target prod \
+            --script ops/observability/probe-ssot-recent-success.sh \
+            --env WINDOW_HOURS=24 \
+            --env MIN_COUNT=1 \
+            --comment "ops-daily ssot recent-success skip set" \
+            --timeout-seconds 120 > .ssot-gate/recent-success.tsv 2> .ssot-gate/recent-success.stderr; then
+            echo "::warning::recent-success probe failed; running full SSOT without log skip"
+            : > .ssot-gate/recent-success.tsv
+          fi
+          SKIP_LINES=$(grep -cv '^#' .ssot-gate/recent-success.tsv || true)
+          echo "skip_lines=${SKIP_LINES}" >> "$GITHUB_OUTPUT"
+
+      - name: Full SSOT display gate (sharded, log-skip)
+        env:
+          TOKENKEY_BASE_URL: ${{ steps.prod.outputs.api_url }}
+          TK_FULLTEST_KEY: ${{ secrets.TK_FULLTEST_KEY }}
+          TK_SSOT_SKIP_RECENT_FILE: ${{ github.workspace }}/.ssot-gate/recent-success.tsv
+        run: |
+          set -euo pipefail
+          bash ops/observability/endpoint-compat-audit.sh \
+            --ssot-model-matrix --gate-sharded --show-excluded \
+            --skip-recent-file "$TK_SSOT_SKIP_RECENT_FILE" \
+            2>&1 | tee .ssot-gate/gate.log
+          tail -5 .ssot-gate/gate.log >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ssot-gate-${{ github.run_id }}
+          path: .ssot-gate/
+          retention-days: 14

--- a/docs/ops/endpoint-compat-baseline.md
+++ b/docs/ops/endpoint-compat-baseline.md
@@ -31,9 +31,9 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 | Universal matrix command | `bash ops/observability/endpoint-compat-audit.sh --universal-matrix --with-extras --skip-paid` |
 | SSOT model matrix command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --list --include-paid --show-excluded` |
 | SSOT display gate command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --show-excluded` |
-| SSOT display gate (sharded, daily off-peak) | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --show-excluded --skip-recent-file /path/to/recent.tsv` (scheduled 18:00 UTC ≈ 02:00 CST via `ops-daily-diagnostics` job `ssot-display-gate`) |
+| SSOT delta gate (catalog PR/push) | `python3 scripts/checks/ssot-delta-gate.py check --base origin/main` (CI job `ssot-delta-gate`; probes only diff-scoped model ids) |
 | SSOT deploy canary (prod post-deploy) | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout` |
-| SSOT recent-success skip probe | `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-ssot-recent-success.sh --env WINDOW_HOURS=24` |
+| SSOT recent-success skip probe (ad hoc) | `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-ssot-recent-success.sh --env WINDOW_HOURS=24` |
 | Baseline freshness gate | `python3 scripts/check_endpoint_compat_baseline_freshness.py` (preflight + release.yml; baseline must mention `backend/cmd/server/VERSION`) |
 | Focused paid SSOT gate command | `python3 ops/test/gateway_model_ssot_matrix.py gate --include-paid --show-excluded --model imagen-4.0-generate-001 --model veo-3.1-generate-001 --model grok-imagine-image --model grok-imagine-image-quality --model grok-imagine-video` |
 | Focused postrelease media parity command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-media-parity-postrelease.sh --with ops/pricing/probe_reserved_resources.sh` |
@@ -178,16 +178,13 @@ intent but hides the row until provisioning or a later SSOT gate proves it.
    public-pricing rows whose vendors do not map to a universal platform/endpoint
    candidate should remain hidden by default. Re-display only after a real
    platform mapping/provisioning path exists and the gate returns `keep_displayed`.
-6. Run the SSOT display gate before release close-out:
-   daily off-peak full gate:
-   `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --show-excluded --skip-recent-file recent.tsv`
-   (skips `(model, modality)` rows with successful `usage_logs` in the last 24h).
-   Prod deploy uses deploy-canary only:
-   `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout`
-   Add `--include-paid` when paid media is intentionally in scope. Strict catalog gate
-   (`--gate` without `--deploy-closeout`) fails on `DISPLAY_BLOCK`; deploy-canary
-   closeout fails only on gateway `FAIL`. Update this baseline to mention `v{VERSION}` on every
-   deploy (`python3 scripts/check_endpoint_compat_baseline_freshness.py`).
+6. Run SSOT gates before release close-out:
+   **Structural** (every commit via preflight): `catalog-serving-drift.py`,
+   `display-coverage-gate.py check --base origin/main`.
+   **Live delta** (CI when catalog paths change): `python3 scripts/checks/ssot-delta-gate.py check --base origin/main` — probes only models added/changed in the PR (not the full catalog).
+   **Deploy canary** (prod post-deploy): `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout`.
+   Add `--include-paid` when paid media is intentionally in scope. Do **not** schedule daily full `--gate-sharded` scans (account-ban risk); use focused `--model` reprobes from this baseline when a row regresses.
+   Update this baseline to mention `v{VERSION}` on every deploy (`python3 scripts/check_endpoint_compat_baseline_freshness.py`).
 7. Reprobe Anthropic/Gemini/Kiro direct live rows only when a real schedulable
    direct probe pool exists; current `429` rows prove route openness, not
    servability.

--- a/docs/ops/endpoint-compat-baseline.md
+++ b/docs/ops/endpoint-compat-baseline.md
@@ -31,7 +31,9 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 | Universal matrix command | `bash ops/observability/endpoint-compat-audit.sh --universal-matrix --with-extras --skip-paid` |
 | SSOT model matrix command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --list --include-paid --show-excluded` |
 | SSOT display gate command | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --show-excluded` |
-| SSOT display gate (sharded, release/deploy) | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --deploy-closeout --show-excluded` |
+| SSOT display gate (sharded, daily off-peak) | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --show-excluded --skip-recent-file /path/to/recent.tsv` (scheduled 18:00 UTC ≈ 02:00 CST via `ops-daily-diagnostics` job `ssot-display-gate`) |
+| SSOT deploy canary (prod post-deploy) | `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout` |
+| SSOT recent-success skip probe | `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-ssot-recent-success.sh --env WINDOW_HOURS=24` |
 | Baseline freshness gate | `python3 scripts/check_endpoint_compat_baseline_freshness.py` (preflight + release.yml; baseline must mention `backend/cmd/server/VERSION`) |
 | Focused paid SSOT gate command | `python3 ops/test/gateway_model_ssot_matrix.py gate --include-paid --show-excluded --model imagen-4.0-generate-001 --model veo-3.1-generate-001 --model grok-imagine-image --model grok-imagine-image-quality --model grok-imagine-video` |
 | Focused postrelease media parity command | `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-media-parity-postrelease.sh --with ops/pricing/probe_reserved_resources.sh` |
@@ -177,11 +179,14 @@ intent but hides the row until provisioning or a later SSOT gate proves it.
    candidate should remain hidden by default. Re-display only after a real
    platform mapping/provisioning path exists and the gate returns `keep_displayed`.
 6. Run the SSOT display gate before release close-out:
-   `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --deploy-closeout --show-excluded`
-   for non-paid rows (deploy-stage0 hard gate uses `--deploy-closeout`: fails only on
-   gateway `FAIL`, not on `DISPLAY_BLOCK` provisioning backlog), and add `--include-paid` when paid
-   media is intentionally in scope. Gate fails on `DISPLAY_BLOCK` or `FAIL`, not
-   on `REPROBE_REQUIRED`. Update this baseline to mention `v{VERSION}` on every
+   daily off-peak full gate:
+   `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --show-excluded --skip-recent-file recent.tsv`
+   (skips `(model, modality)` rows with successful `usage_logs` in the last 24h).
+   Prod deploy uses deploy-canary only:
+   `bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout`
+   Add `--include-paid` when paid media is intentionally in scope. Strict catalog gate
+   (`--gate` without `--deploy-closeout`) fails on `DISPLAY_BLOCK`; deploy-canary
+   closeout fails only on gateway `FAIL`. Update this baseline to mention `v{VERSION}` on every
    deploy (`python3 scripts/check_endpoint_compat_baseline_freshness.py`).
 7. Reprobe Anthropic/Gemini/Kiro direct live rows only when a real schedulable
    direct probe pool exists; current `429` rows prove route openness, not

--- a/ops/observability/endpoint-compat-audit.sh
+++ b/ops/observability/endpoint-compat-audit.sh
@@ -44,9 +44,10 @@ Verdict split:
   universal-matrix checks real end-to-end servability through one universal key.
   ssot-model-matrix derives model/protocol rows from live /api/v1/public/pricing.
   ssot-model-matrix --gate fails unless displayed+priced rows in scope pass live probes.
-  ssot-model-matrix --gate-sharded runs the gate once per platform to avoid empty-pool false blocks.
+  ssot-model-matrix --gate-sharded runs the gate once per platform (manual/ad hoc only; not scheduled — account-ban risk).
   ssot-model-matrix --gate --deploy-canary probes one golden path per platform for deploy closeout.
-  --skip-recent-file skips (model, modality) rows with recent successful usage_logs evidence.
+  Catalog PRs: python3 scripts/checks/ssot-delta-gate.py check --base origin/main (CI job; delta models only).
+  --skip-recent-file skips (model, modality) rows with recent successful usage_logs evidence (ad hoc sharded runs).
 EOF
 }
 

--- a/ops/observability/endpoint-compat-audit.sh
+++ b/ops/observability/endpoint-compat-audit.sh
@@ -15,6 +15,8 @@ SSOT_SUBCOMMAND="list"
 SSOT_ARGS=()
 GATE_SHARDED=0
 GATE_DEPLOY_CLOSEOUT=0
+GATE_DEPLOY_CANARY=0
+SKIP_RECENT_FILE="${TK_SSOT_SKIP_RECENT_FILE:-}"
 GATE_SHARD_PLATFORMS=()
 GATE_SHARD_SLEEP="${TK_SSOT_GATE_SHARD_SLEEP_SEC:-8}"
 
@@ -27,6 +29,8 @@ Usage:
   bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix [--list|--run|--gate] [--include-paid] [--show-excluded] [--limit N]
   bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded [--include-paid] [--show-excluded]
   bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --deploy-closeout [--include-paid] [--show-excluded]
+  bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout
+  bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate-sharded --skip-recent-file /path/to/recent.tsv
   bash ops/observability/endpoint-compat-audit.sh --all [--skip-paid] [--with-extras]
 
 Environment:
@@ -41,6 +45,8 @@ Verdict split:
   ssot-model-matrix derives model/protocol rows from live /api/v1/public/pricing.
   ssot-model-matrix --gate fails unless displayed+priced rows in scope pass live probes.
   ssot-model-matrix --gate-sharded runs the gate once per platform to avoid empty-pool false blocks.
+  ssot-model-matrix --gate --deploy-canary probes one golden path per platform for deploy closeout.
+  --skip-recent-file skips (model, modality) rows with recent successful usage_logs evidence.
 EOF
 }
 
@@ -59,6 +65,12 @@ while [[ $# -gt 0 ]]; do
 		--gate) SSOT_SUBCOMMAND="gate" ;;
 		--gate-sharded) MODE="ssot"; SSOT_SUBCOMMAND="gate"; GATE_SHARDED=1 ;;
 		--deploy-closeout) GATE_DEPLOY_CLOSEOUT=1 ;;
+		--deploy-canary) MODE="ssot"; SSOT_SUBCOMMAND="gate"; GATE_DEPLOY_CANARY=1 ;;
+		--skip-recent-file)
+			[[ $# -ge 2 ]] || { echo "$1 requires a value" >&2; usage >&2; exit 2; }
+			SKIP_RECENT_FILE="$2"
+			shift
+			;;
 		--show-excluded) SSOT_ARGS+=(--show-excluded) ;;
 		--show-nonblocking-excluded) SSOT_ARGS+=(--show-nonblocking-excluded) ;;
 		--json) SSOT_ARGS+=(--format json) ;;
@@ -135,6 +147,9 @@ case "$MODE" in
 			if [[ "$GATE_DEPLOY_CLOSEOUT" == "1" ]]; then
 				shard_args+=(--deploy-closeout)
 			fi
+			if [[ -n "$SKIP_RECENT_FILE" ]]; then
+				shard_args+=(--skip-recent-file "$SKIP_RECENT_FILE")
+			fi
 			for platform in "${GATE_SHARD_PLATFORMS[@]}"; do
 				echo "# SSOT display gate shard platform=${platform}"
 				if ! python3 "$ROOT/ops/test/gateway_model_ssot_matrix.py" gate \
@@ -145,6 +160,23 @@ case "$MODE" in
 				sleep "$GATE_SHARD_SLEEP"
 			done
 			exit "$status"
+		fi
+		if [[ "$GATE_DEPLOY_CANARY" == "1" ]]; then
+			if [[ -z "${TK_FULLTEST_KEY:-}" ]]; then
+				echo "ERROR: TK_FULLTEST_KEY is required for --deploy-canary" >&2
+				exit 2
+			fi
+			canary_cmd=(python3 "$ROOT/ops/test/gateway_model_ssot_matrix.py" gate --deploy-canary)
+			if [[ "$GATE_DEPLOY_CLOSEOUT" == "1" ]]; then
+				canary_cmd+=(--deploy-closeout)
+			fi
+			if ((${#SSOT_ARGS[@]} > 0)); then
+				canary_cmd+=("${SSOT_ARGS[@]}")
+			fi
+			if [[ -n "$SKIP_RECENT_FILE" ]]; then
+				canary_cmd+=(--skip-recent-file "$SKIP_RECENT_FILE")
+			fi
+			exec "${canary_cmd[@]}"
 		fi
 		exec "${ssot_cmd[@]}"
 		;;

--- a/ops/observability/probe-ssot-recent-success.sh
+++ b/ops/observability/probe-ssot-recent-success.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# probe-ssot-recent-success.sh — models/modalities with successful usage_logs in a window.
+# Runs on TokenKey prod host via run-probe.sh. Output TSV:
+#   model<TAB>modality<TAB>count
+#
+# Env:
+#   WINDOW_HOURS   default 24
+#   MIN_COUNT      default 1 (minimum successful rows to treat as "normally serving")
+set -u
+
+WINDOW_HOURS="${WINDOW_HOURS:-24}"
+MIN_COUNT="${MIN_COUNT:-1}"
+PSQL=(docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -F $'\t')
+
+echo "# ssot_recent_success window_hours=${WINDOW_HOURS} min_count=${MIN_COUNT} db_now=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+"${PSQL[@]}" -c "
+SELECT model,
+       CASE
+         WHEN COALESCE(billing_mode, 'token') = 'image' THEN 'image'
+         WHEN COALESCE(billing_mode, 'token') = 'video' THEN 'video'
+         WHEN model ILIKE '%embedding%' THEN 'embeddings'
+         ELSE 'text'
+       END AS modality,
+       count(*)::bigint AS n
+FROM usage_logs
+WHERE created_at >= now() - interval '${WINDOW_HOURS} hours'
+GROUP BY 1, 2
+HAVING count(*) >= ${MIN_COUNT}
+ORDER BY n DESC, model ASC;
+"

--- a/ops/test/gateway_model_ssot_matrix.py
+++ b/ops/test/gateway_model_ssot_matrix.py
@@ -19,6 +19,11 @@ import urllib.request
 from dataclasses import asdict, dataclass
 from typing import Any
 
+_OPS_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+if _OPS_TEST_DIR not in sys.path:
+    sys.path.insert(0, _OPS_TEST_DIR)
+from ssot_recent_success import load_skip_keys, parse_recent_success_tsv
+
 DEFAULT_BASE_URL = os.environ.get("TK_FULLTEST_BASE_URL", "https://api.tokenkey.dev")
 DEFAULT_TIMEOUT = float(os.environ.get("TK_FULLTEST_TIMEOUT", "90"))
 
@@ -45,6 +50,25 @@ VENDOR_PLATFORM = {
 
 PLATFORM_CHOICES = ("anthropic", "openai", "gemini", "antigravity", "newapi", "grok", "kiro")
 GEMINI_NATIVE_PLATFORMS = {"antigravity"}
+
+# Deploy-canary: one golden path per platform (+ Anthropic count_tokens).
+DEPLOY_CANARY_PROTOCOLS: dict[str, list[str]] = {
+    "anthropic": ["chat", "count_tokens"],
+    "openai": ["chat"],
+    "gemini": ["chat"],
+    "antigravity": ["chat"],
+    "newapi": ["chat"],
+    "grok": ["chat"],
+    "kiro": ["chat"],
+}
+DEFAULT_DEPLOY_CANARY_MODEL: dict[str, str] = {
+    "anthropic": "claude-sonnet-4-6",
+    "openai": "gpt-5.4",
+    "gemini": "gemini-2.5-flash",
+    "antigravity": "gemini-3.5-flash",
+    "newapi": "qwen3-8b",
+    "grok": "grok-code-fast-1",
+}
 MESSAGE_POLICY_PLATFORMS = {"openai", "newapi"}
 
 
@@ -193,6 +217,33 @@ def load_matrix(args) -> tuple[list[MatrixRow], list[ExcludedRow]]:
     base = args.base_url.rstrip("/")
     payload = fetch_json(f"{base}/api/v1/public/pricing", args.timeout)
     return rows_from_public_catalog(payload, f"live-pricing:{base}/api/v1/public/pricing")
+
+
+def preferred_deploy_canary_model(platform: str) -> str:
+    env_key = f"TK_SSOT_CANARY_{platform.upper()}_MODEL"
+    return os.environ.get(env_key, DEFAULT_DEPLOY_CANARY_MODEL.get(platform, "")).strip()
+
+
+def select_deploy_canary_rows(rows: list[MatrixRow]) -> list[MatrixRow]:
+    by_platform: dict[str, list[MatrixRow]] = {}
+    for row in rows:
+        by_platform.setdefault(row.platform, []).append(row)
+    selected: list[MatrixRow] = []
+    for platform, protocols in DEPLOY_CANARY_PROTOCOLS.items():
+        platform_rows = by_platform.get(platform) or []
+        if not platform_rows:
+            continue
+        preferred = preferred_deploy_canary_model(platform)
+        for protocol in protocols:
+            candidates = [r for r in platform_rows if r.protocol == protocol]
+            if preferred:
+                preferred_rows = [r for r in candidates if r.model == preferred]
+                if preferred_rows:
+                    candidates = preferred_rows
+            if candidates:
+                selected.append(candidates[0])
+    selected.sort(key=lambda r: (r.platform, r.protocol, r.model))
+    return selected
 
 
 def filter_rows(rows: list[MatrixRow], args) -> list[MatrixRow]:
@@ -497,16 +548,34 @@ def cmd_gate(args) -> int:
     rows = filter_rows(rows, args)
     if not args.include_paid:
         rows = [r for r in rows if not r.paid]
+    if getattr(args, "deploy_canary", False):
+        rows = select_deploy_canary_rows(rows)
     if args.limit:
         rows = rows[: args.limit]
 
+    skip_keys: set[tuple[str, str]] = set()
+    skip_file = getattr(args, "skip_recent_file", "") or os.environ.get("TK_SSOT_SKIP_RECENT_FILE", "")
+    if skip_file:
+        skip_keys = load_skip_keys(
+            skip_file,
+            min_count=int(os.environ.get("TK_SSOT_SKIP_MIN_COUNT", "1")),
+        )
+
     scoped_excluded = filter_excluded(excluded, args)
     no_rows_count = 1 if not rows and not scoped_excluded else 0
-    keep_count = block_count = reprobe_count = fail_count = excluded_block_count = 0
+    keep_count = block_count = reprobe_count = fail_count = excluded_block_count = log_skip_count = 0
     print("platform\tmodality\tprotocol\tmodel\thttp\tresult\tdisplay_gate\taction")
     if no_rows_count:
         print("n/a\tn/a\tn/a\tn/a\t0\tSKIP\tnot_in_public_pricing_scope\tno displayed+priced matrix rows matched")
     for row in rows:
+        if skip_keys and (row.model, row.modality) in skip_keys:
+            log_skip_count += 1
+            keep_count += 1
+            print(
+                f"{row.platform}\t{row.modality}\t{row.protocol}\t{row.model}\t0\t"
+                "LOG_SKIP\tkeep_displayed\trecent_success_24h"
+            )
+            continue
         code, result, note, _body_text = probe_matrix_row(args, row)
         gate, action = display_gate_decision(result, note)
         if gate == "keep_displayed":
@@ -537,7 +606,8 @@ def cmd_gate(args) -> int:
         "DISPLAY_KEEP="
         f"{keep_count} DISPLAY_BLOCK={block_count + excluded_block_count} "
         f"REPROBE_REQUIRED={reprobe_count} FAIL={fail_count} "
-        f"EXCLUDED_BLOCK={excluded_block_count} NO_ROWS={no_rows_count}"
+        f"EXCLUDED_BLOCK={excluded_block_count} NO_ROWS={no_rows_count} "
+        f"LOG_SKIP={log_skip_count}"
     )
     if getattr(args, "deploy_closeout", False):
         return 1 if fail_count else 0
@@ -597,6 +667,11 @@ def cmd_selftest(_args) -> int:
     assert excluded_matches_protocol(ExcludedRow("vertex", "e", "x", "embeddings", False), "embeddings")
     assert not excluded_matches_protocol(ExcludedRow("vertex", "e", "x", "embeddings", False), "chat")
     assert "kiro" in PLATFORM_CHOICES, "deploy-stage0 sharded gate includes kiro; argparse must accept it"
+    canary = select_deploy_canary_rows(rows)
+    assert canary, "deploy-canary must select at least one row from fixture catalog"
+    assert all(r.protocol in DEPLOY_CANARY_PROTOCOLS.get(r.platform, []) for r in canary)
+    skip_keys = parse_recent_success_tsv("gpt-5.1\ttext\t10\n", min_count=1)
+    assert ("gpt-5.1", "text") in skip_keys
     print("gateway_model_ssot_matrix selftest: PASS")
     return 0
 
@@ -654,6 +729,16 @@ def main() -> int:
         "--deploy-closeout",
         action="store_true",
         help="deploy/release closeout: fail only on gateway FAIL rows, not DISPLAY_BLOCK backlog",
+    )
+    gate_p.add_argument(
+        "--deploy-canary",
+        action="store_true",
+        help="deploy closeout canary: probe one golden path per platform instead of the full matrix",
+    )
+    gate_p.add_argument(
+        "--skip-recent-file",
+        default="",
+        help="TSV of model/modality/count rows to skip (normally serving in recent usage_logs)",
     )
     gate_p.set_defaults(func=cmd_gate)
 

--- a/ops/test/ssot_recent_success.py
+++ b/ops/test/ssot_recent_success.py
@@ -1,15 +1,7 @@
 """Parse recent successful usage rows for SSOT gate skip keys."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
-
-
-@dataclass(frozen=True)
-class RecentSuccessKey:
-    model: str
-    modality: str
-    count: int
 
 
 def billing_mode_to_modality(billing_mode: str, model: str) -> str:

--- a/ops/test/ssot_recent_success.py
+++ b/ops/test/ssot_recent_success.py
@@ -1,0 +1,58 @@
+"""Parse recent successful usage rows for SSOT gate skip keys."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RecentSuccessKey:
+    model: str
+    modality: str
+    count: int
+
+
+def billing_mode_to_modality(billing_mode: str, model: str) -> str:
+    mode = (billing_mode or "token").strip().lower()
+    if mode == "image":
+        return "image"
+    if mode == "video":
+        return "video"
+    model_l = model.lower()
+    if "embedding" in model_l:
+        return "embeddings"
+    return "text"
+
+
+def parse_recent_success_tsv(text: str, *, min_count: int = 1) -> set[tuple[str, str]]:
+    """Return (model, modality) keys safe to skip live SSOT probes."""
+    keys: set[tuple[str, str]] = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        model = parts[0].strip()
+        if not model:
+            continue
+        if len(parts) >= 3 and parts[1].strip() in {"text", "image", "video", "embeddings"}:
+            modality = parts[1].strip()
+            count_s = parts[2].strip()
+        else:
+            modality = billing_mode_to_modality(parts[1].strip(), model)
+            count_s = parts[2].strip() if len(parts) >= 3 else parts[1].strip()
+        try:
+            count = int(float(count_s))
+        except ValueError:
+            continue
+        if count < min_count:
+            continue
+        keys.add((model, modality))
+    return keys
+
+
+def load_skip_keys(path: str | Path, *, min_count: int = 1) -> set[tuple[str, str]]:
+    text = Path(path).read_text(encoding="utf-8")
+    return parse_recent_success_tsv(text, min_count=min_count)

--- a/ops/test/test_ssot_recent_success.py
+++ b/ops/test/test_ssot_recent_success.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Unit tests for SSOT recent-success skip key parsing."""
+from __future__ import annotations
+
+import unittest
+
+from ssot_recent_success import billing_mode_to_modality, parse_recent_success_tsv
+
+
+class TestSSOTRecentSuccess(unittest.TestCase):
+    def test_billing_mode_to_modality(self) -> None:
+        self.assertEqual(billing_mode_to_modality("token", "gpt-5"), "text")
+        self.assertEqual(billing_mode_to_modality("image", "seedream"), "image")
+        self.assertEqual(billing_mode_to_modality("video", "seedance"), "video")
+        self.assertEqual(billing_mode_to_modality("token", "text-embedding-3-small"), "embeddings")
+
+    def test_parse_recent_success_tsv(self) -> None:
+        keys = parse_recent_success_tsv(
+            "# comment\nclaude-sonnet-4-6\ttext\t12\nseedream-5\timage\t3\n",
+            min_count=5,
+        )
+        self.assertIn(("claude-sonnet-4-6", "text"), keys)
+        self.assertNotIn(("seedream-5", "image"), keys)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/checks/ssot-delta-gate.py
+++ b/scripts/checks/ssot-delta-gate.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""ssot-delta-gate — live SSOT proof for catalog diffs only (no full-matrix scan).
+
+Replaces the retired daily full SSOT gate (account-ban risk from ~356 HTTP probes).
+Structural SSOT (servable ↔ priced ↔ display intent) stays in catalog-serving-drift.py
+and display-coverage-gate.py (preflight, zero HTTP). This gate adds the runtime layer:
+when a PR touches the catalog surface, probe ONLY the changed model ids via
+ops/test/gateway_model_ssot_matrix.py gate --model ….
+
+Catalog touch paths (any diff base..HEAD):
+  - backend/internal/service/tk_served_models.json
+  - backend/internal/service/pricing_catalog_supported_models_tk.go
+  - backend/internal/service/tk_pricing_overlay.json
+  - backend/migrations/tk_*.sql
+
+Subcommands:
+  paths-changed  — prints true/false (for GHA step outputs)
+  discover       — list model ids that would be live-probed
+  check          — run focused gate (or --skip-live for preflight / offline)
+  selftest       — fixture selftest
+
+Exit: 0 ok/skip, 1 gate fail, 2 error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+GO_REL = "backend/internal/service/pricing_catalog_supported_models_tk.go"
+MANIFEST_REL = "backend/internal/service/tk_served_models.json"
+OVERLAY_REL = "backend/internal/service/tk_pricing_overlay.json"
+MIGRATION_PREFIX = "backend/migrations/tk_"
+ALLOWLIST_PLATFORMS = ("anthropic", "openai", "gemini", "antigravity", "grok")
+MATRIX = REPO / "ops/test/gateway_model_ssot_matrix.py"
+
+MODEL_ID_RE = re.compile(r'"([a-zA-Z0-9][a-zA-Z0-9._-]{0,127})"\s*:\s*"')
+MIGRATION_ADDED_MODEL_RE = re.compile(
+    r'^\+\s*"(?P<id>[a-zA-Z0-9][a-zA-Z0-9._-]{0,127})"\s*:\s*"(?P=id)"'
+)
+
+
+def _git(*args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(REPO), *args], text=True)
+
+
+def _base_resolves(base: str) -> bool:
+    try:
+        _git("rev-parse", "--verify", "--quiet", f"{base}^{{commit}}")
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def changed_paths(base: str) -> list[str]:
+    if not _base_resolves(base):
+        return []
+    raw = _git("diff", "--name-only", f"{base}...HEAD")
+    return [p for p in raw.splitlines() if p.strip()]
+
+
+def catalog_paths_changed(base: str) -> bool:
+    for path in changed_paths(base):
+        if path in (MANIFEST_REL, GO_REL, OVERLAY_REL):
+            return True
+        if path.startswith(MIGRATION_PREFIX) and path.endswith(".sql"):
+            return True
+    return False
+
+
+def parse_allowlist(go_text: str) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for plat in ALLOWLIST_PLATFORMS:
+        m = re.search(
+            rf"servable-allowlist:begin {plat}(.*?)servable-allowlist:end {plat}",
+            go_text,
+            re.S,
+        )
+        out[plat] = set(re.findall(r'"([^"]+)":\s*\{\}', m.group(1))) if m else set()
+    return out
+
+
+def _read_at(base: str, rel: str) -> str:
+    try:
+        return _git("show", f"{base}:{rel}")
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def _load_manifest(text: str) -> dict[str, dict]:
+    if not text.strip():
+        return {}
+    data = json.loads(text)
+    entries = data.get("entries") or {}
+    return {k: v for k, v in entries.items() if isinstance(v, dict)}
+
+
+def _overlay_priced(entry: object) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    return (
+        (entry.get("input_cost_per_token") or 0) > 0
+        or (entry.get("output_cost_per_token") or 0) > 0
+        or (entry.get("output_cost_per_image") or 0) > 0
+        or (entry.get("output_cost_per_second") or 0) > 0
+    )
+
+
+def manifest_delta_models(base: str) -> set[str]:
+    base_entries = _load_manifest(_read_at(base, MANIFEST_REL))
+    head_entries = _load_manifest((REPO / MANIFEST_REL).read_text(encoding="utf-8"))
+    out: set[str] = set()
+    for key, head in head_entries.items():
+        if not head.get("display"):
+            continue
+        model_id = str(head.get("model_id") or "").strip()
+        if not model_id:
+            continue
+        base_entry = base_entries.get(key)
+        if base_entry is None:
+            out.add(model_id)
+            continue
+        if not base_entry.get("display"):
+            out.add(model_id)
+            continue
+        for field in ("model_id", "served_on", "price_source", "price_key", "display"):
+            if base_entry.get(field) != head.get(field):
+                out.add(model_id)
+                break
+    return out
+
+
+def allowlist_delta_models(base: str) -> set[str]:
+    base_al = parse_allowlist(_read_at(base, GO_REL))
+    head_al = parse_allowlist((REPO / GO_REL).read_text(encoding="utf-8"))
+    out: set[str] = set()
+    for plat in ALLOWLIST_PLATFORMS:
+        out |= head_al.get(plat, set()) - base_al.get(plat, set())
+    return out
+
+
+def overlay_delta_models(base: str) -> set[str]:
+    try:
+        base_overlay = json.loads(_read_at(base, OVERLAY_REL) or "{}")
+    except json.JSONDecodeError:
+        base_overlay = {}
+    try:
+        head_overlay = json.loads((REPO / OVERLAY_REL).read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return set()
+    out: set[str] = set()
+    for key, head_entry in head_overlay.items():
+        if key == "_meta":
+            continue
+        base_entry = base_overlay.get(key)
+        if _overlay_priced(head_entry) and not _overlay_priced(base_entry):
+            out.add(key)
+    return out
+
+
+def migration_delta_models(base: str) -> set[str]:
+    if not _base_resolves(base):
+        return set()
+    out: set[str] = set()
+    for path in changed_paths(base):
+        if not path.startswith(MIGRATION_PREFIX) or not path.endswith(".sql"):
+            continue
+        try:
+            diff = _git("diff", f"{base}...HEAD", "--", path)
+        except subprocess.CalledProcessError:
+            continue
+        for line in diff.splitlines():
+            if not line.startswith("+") or line.startswith("+++"):
+                continue
+            m = MIGRATION_ADDED_MODEL_RE.match(line)
+            if m:
+                out.add(m.group("id"))
+                continue
+            for mid in MODEL_ID_RE.findall(line):
+                if mid not in {"model_mapping", "credentials", "jsonb"}:
+                    out.add(mid)
+    return out
+
+
+def discover_models(base: str) -> set[str]:
+    if not catalog_paths_changed(base):
+        return set()
+    models: set[str] = set()
+    models |= manifest_delta_models(base)
+    models |= allowlist_delta_models(base)
+    models |= overlay_delta_models(base)
+    models |= migration_delta_models(base)
+    return {m for m in models if m and m != "_meta"}
+
+
+def run_focused_gate(models: set[str], *, base_url: str, key: str) -> int:
+    cmd = [
+        sys.executable,
+        str(MATRIX),
+        "gate",
+        "--show-excluded",
+        "--base-url",
+        base_url,
+    ]
+    for model in sorted(models):
+        cmd.extend(["--model", model])
+    env = os.environ.copy()
+    env["TK_FULLTEST_KEY"] = key
+    env.setdefault("TK_FULLTEST_BASE_URL", base_url)
+    print(f"ssot-delta-gate: running focused gate for {len(models)} model(s)")
+    for model in sorted(models):
+        print(f"    model: {model}")
+    proc = subprocess.run(cmd, cwd=REPO, env=env)
+    return proc.returncode
+
+
+def cmd_paths_changed(args) -> int:
+    if not _base_resolves(args.base):
+        print("false")
+        return 0
+    print("true" if catalog_paths_changed(args.base) else "false")
+    return 0
+
+
+def cmd_discover(args) -> int:
+    if not _base_resolves(args.base):
+        print(f"ssot-delta-gate: skip (base {args.base!r} not resolvable)", file=sys.stderr)
+        return 0
+    if not catalog_paths_changed(args.base):
+        print("ssot-delta-gate: skip (no catalog-surface paths changed)")
+        return 0
+    models = discover_models(args.base)
+    if not models:
+        print("ssot-delta-gate: ok (catalog changed but no models require live probe)")
+        return 0
+    for model in sorted(models):
+        print(model)
+    return 0
+
+
+def cmd_check(args) -> int:
+    if not _base_resolves(args.base):
+        print(f"ssot-delta-gate: skip (base {args.base!r} not resolvable locally)")
+        return 0
+    if not catalog_paths_changed(args.base):
+        print("ssot-delta-gate: skip (no catalog-surface paths changed)")
+        return 0
+    models = discover_models(args.base)
+    if not models:
+        print("ssot-delta-gate: ok (catalog changed; deletions/config-only — no live probe)")
+        return 0
+    if args.skip_live:
+        print(
+            f"ssot-delta-gate: skip-live ({len(models)} model(s) — CI ssot-delta-gate job runs live gate)"
+        )
+        for model in sorted(models):
+            print(f"    pending-live: {model}")
+        return 0
+    key = args.key or os.environ.get("TK_FULLTEST_KEY", "")
+    if not key:
+        print("ssot-delta-gate: error: TK_FULLTEST_KEY required for live gate", file=sys.stderr)
+        return 2
+    base_url = args.base_url or os.environ.get(
+        "TK_FULLTEST_BASE_URL", "https://api.tokenkey.dev"
+    )
+    rc = run_focused_gate(models, base_url=base_url, key=key)
+    if rc == 0:
+        print("ssot-delta-gate: ok (focused live gate passed)")
+    return rc
+
+
+def cmd_selftest(_args) -> int:
+    base_go = (
+        "// servable-allowlist:begin openai\n"
+        '\t"gpt-5": {},\n'
+        "// servable-allowlist:end openai\n"
+    )
+    head_go = (
+        "// servable-allowlist:begin openai\n"
+        '\t"gpt-5": {},\n\t"gpt-5.6-sol": {},\n'
+        "// servable-allowlist:end openai\n"
+    )
+    bal, hal = parse_allowlist(base_go), parse_allowlist(head_go)
+    assert hal["openai"] - bal["openai"] == {"gpt-5.6-sol"}
+
+    base_manifest = json.dumps(
+        {
+            "entries": {
+                "newapi/qwen3-8b": {
+                    "platform": "newapi",
+                    "model_id": "qwen3-8b",
+                    "display": False,
+                    "served_on": ["60"],
+                    "price_source": "overlay",
+                    "price_key": "qwen3-8b",
+                }
+            }
+        }
+    )
+    head_manifest = json.dumps(
+        {
+            "entries": {
+                "newapi/qwen3-8b": {
+                    "platform": "newapi",
+                    "model_id": "qwen3-8b",
+                    "display": True,
+                    "served_on": ["60"],
+                    "price_source": "overlay",
+                    "price_key": "qwen3-8b",
+                }
+            }
+        }
+    )
+    bm = _load_manifest(base_manifest)
+    hm = _load_manifest(head_manifest)
+    assert hm["newapi/qwen3-8b"]["display"] is True
+    assert bm["newapi/qwen3-8b"]["display"] is False
+
+    line = '+                "glm-4.7-flash": "glm-4.7-flash",'
+    m = MIGRATION_ADDED_MODEL_RE.match(line)
+    assert m and m.group("id") == "glm-4.7-flash"
+
+    assert _overlay_priced({"output_cost_per_image": 0.04})
+    assert not _overlay_priced({"input_cost_per_token": 0})
+
+    print("ssot-delta-gate selftest: PASS")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="focused live SSOT gate for catalog diffs")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    for name in ("paths-changed", "discover", "check"):
+        p = sub.add_parser(name)
+        p.add_argument("--base", default="origin/main")
+        if name == "check":
+            p.add_argument(
+                "--skip-live",
+                action="store_true",
+                help="preflight/offline: list pending models without HTTP",
+            )
+            p.add_argument("--key", default="", help="override TK_FULLTEST_KEY")
+            p.add_argument("--base-url", default="", help="override TK_FULLTEST_BASE_URL")
+        p.set_defaults(func=globals()[f"cmd_{name.replace('-', '_')}"])
+    st = sub.add_parser("selftest")
+    st.set_defaults(func=cmd_selftest)
+    args = ap.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1789,6 +1789,24 @@ else
     echo "  ok: SSOT endpoint matrix selftest"
 fi
 
+# ---- sub2api: SSOT delta gate (structural; live in CI ssot-delta-gate job) ---
+# Replaces the retired daily full SSOT matrix scan (account-ban risk). Structural
+# SSOT stays in catalog-serving-drift + display-coverage-gate; live HTTP probes
+# only the model ids touched in this diff (scripts/checks/ssot-delta-gate.py).
+echo ""
+echo "=== sub2api: SSOT delta gate (structural) ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by ssot-delta-gate.py)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/ssot-delta-gate.py selftest >/dev/null 2>&1; then
+    echo "  FAIL: ssot-delta-gate.py selftest (re-run: python3 scripts/checks/ssot-delta-gate.py selftest)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/ssot-delta-gate.py check --base "${PREFLIGHT_BASE:-origin/main}" --skip-live; then
+    errors=$((errors + 1))
+else
+    echo "  ok: SSOT delta gate structural check (live gate runs in CI when catalog paths change)"
+fi
+
 echo ""
 echo "=== sub2api: endpoint-compat baseline freshness ==="
 if ! command -v python3 >/dev/null 2>&1; then

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1502,6 +1502,8 @@ echo "=== sub2api: main ancestry anchor ==="
 if ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required to read .main-ancestry-anchor)"
     errors=$((errors + 1))
+elif [ "$_preflight_fast" = "1" ]; then
+    echo "  skip: main-ancestry anchor (preflight-fast; main-ancestry-guard covers PRs with full history)"
 elif ! python3 ./scripts/checks/main-ancestry-anchor.py; then
     errors=$((errors + 1))
 fi

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -114,6 +114,12 @@ _preflight_bg_dir="$(mktemp -d "${TMPDIR:-/tmp}/preflight-bg.XXXXXX")"
 # then drop the scratch dir.
 trap 'git config --local --unset core.bare >/dev/null 2>&1 || true; { cat "$_preflight_bg_dir"/*.pid 2>/dev/null | xargs kill; wait; } 2>/dev/null; rm -rf "$_preflight_bg_dir"' EXIT
 
+_preflight_fast=0
+case "${PREFLIGHT_FAST:-}" in 1|true|yes|TRUE|YES) _preflight_fast=1 ;; esac
+if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && [ "${PREFLIGHT_FAST:-}" != "0" ]; then
+    _preflight_fast=1
+fi
+
 # ---- TK: background-job helpers ----------------------------------------------
 # The most expensive sub2api gates (QA go test, the unittest-discover suites,
 # the dockerized Caddyfile adapt) are independent of every other section, so
@@ -869,6 +875,8 @@ if ! command -v python3 >/dev/null 2>&1; then
     errors=$((errors + 1))
 elif ! python3 ./ops/anthropic/probe_prompt_surfaces.py --check-registry >/dev/null; then
     errors=$((errors + 1))
+elif [ "$_preflight_fast" = "1" ]; then
+    echo "  ok: prompt surface registry (fixture gateway runs in CI test-unit)"
 elif ! python3 ./ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway >/dev/null; then
     errors=$((errors + 1))
 else
@@ -1206,6 +1214,7 @@ for _smoke_script in \
   ./ops/stage0/edge_native_anthropic_smoke.sh \
   ./ops/stage0/post_deploy_smoke.sh \
   ./ops/stage0/edge_post_deploy_smoke.sh \
+  ./ops/observability/probe-ssot-recent-success.sh \
   ./scripts/stage0/dispatch-edge-deploy.sh; do
   if ! bash -n "${_smoke_script}"; then
     echo "  FAIL: ${_smoke_script} has bash syntax errors"
@@ -1770,6 +1779,9 @@ if ! command -v python3 >/dev/null 2>&1; then
     errors=$((errors + 1))
 elif ! python3 ops/test/gateway_model_ssot_matrix.py selftest >/dev/null 2>&1; then
     echo "  FAIL: gateway_model_ssot_matrix.py selftest (re-run: python3 ops/test/gateway_model_ssot_matrix.py selftest)"
+    errors=$((errors + 1))
+elif ! python3 -m unittest discover -s ops/test -p 'test_ssot_recent_success.py' -t ops/test -q >/dev/null 2>&1; then
+    echo "  FAIL: test_ssot_recent_success.py (re-run: python3 -m unittest discover -s ops/test -p test_ssot_recent_success.py -t ops/test)"
     errors=$((errors + 1))
 else
     echo "  ok: SSOT endpoint matrix selftest"
@@ -2354,8 +2366,15 @@ fi
 # and diffs to catch drift. Non-destructive: restores the directory after.
 echo ""
 echo "=== sub2api: Ent generation staleness ==="
+_ent_schema_changed=0
+if git rev-parse --verify origin/main >/dev/null 2>&1 && \
+   git diff --name-only origin/main...HEAD 2>/dev/null | grep -q '^backend/ent/schema/'; then
+    _ent_schema_changed=1
+fi
 if ! command -v go >/dev/null 2>&1; then
     echo "  skip: go not on PATH"
+elif [ "$_preflight_fast" = "1" ] && [ "$_ent_schema_changed" = "0" ]; then
+    echo "  skip: Ent generation staleness (preflight-fast; no backend/ent/schema changes)"
 else
     _ent_rc=0
     ( cd backend && go generate ./ent ) >/dev/null 2>&1 || _ent_rc=$?


### PR DESCRIPTION
## 摘要

- **deploy-stage0**：post-deploy SSOT 从全量 sharded gate（~356 行 / ~15 min）改为 **deploy-canary**（每 platform 一条黄金路径，~1–2 min）。
- **全量 daily gate 已移除**：不再 schedule `ssot-display-gate`（避免 ~356 次 HTTP 探测的账号封禁风险）。改为 **delta live gate**：`scripts/checks/ssot-delta-gate.py` 仅在 PR 触达 catalog 面（manifest / allowlist / overlay / `tk_*.sql`）时，对 diff 里的 model id 跑 focused `gate --model`；结构 SSOT 仍由 preflight 的 `catalog-serving-drift` + `display-coverage-gate` 覆盖（零 HTTP）。
- **backend-ci**：preflight 加 Go rolling cache、`fetch-depth: 64`、PR `PREFLIGHT_FAST`（跳过 Ent regen / prompt fixture go test / shallow 下 main-ancestry）；`--check-fixture-gateway` 并入 test-unit；新增 job `ssot-delta-gate`；dispatch 默认 suite 改为 `ci`。

## 风险

- deploy-canary 不在发版时证明全 catalog；单次 catalog 变更靠 **delta gate**（CI）+ **结构 preflight** 保证可服务/已定价/已展示配置一致；平台级回归靠 deploy-canary。
- 未改 catalog 面的 PR 不会跑 live delta gate（by design）；纯代码变更不影响 SSOT 面。
- `probe-ssot-recent-success.sh` 保留供 ad hoc / 手动 sharded 跑，不再 daily 调度。

## 验证

```bash
python3 scripts/checks/ssot-delta-gate.py selftest
python3 scripts/checks/ssot-delta-gate.py check --base origin/main --skip-live
python3 ops/test/gateway_model_ssot_matrix.py selftest
python3 -m unittest discover -s ops/test -p test_ssot_recent_success.py -t ops/test -v
PREFLIGHT_BASE=origin/main PREFLIGHT_FAST=1 ./scripts/preflight.sh
python3 scripts/export_agent_contract.py --check
```

本地 preflight（`PREFLIGHT_FAST=1`）已通过；CI preflight 已通过；其余 job 见 PR checks。

## 提交

- af24afb58 fix(ci,deploy): 发版 SSOT 改 canary，全量 gate 挪 daily 低峰
- 88965486c fix(ci): fetch base ref so preflight diff gates work on shallow checkout
- 3fb4299e4 fix(ci): fetch main-ancestry anchor on shallow preflight checkout
- 75813e5b5 fix(ci): skip main-ancestry anchor under preflight-fast shallow checkout
- ff14a50c0 feat(ops): replace daily full SSOT gate with delta live gate

最新提交：ff14a50c0