### PR TITLE
fix(openai): edge mirror stub downstream 池空饱和降权

### DIFF
--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -149,6 +149,9 @@ func provideCleanup(
 	// saturation counter is wired onto GatewayService + RateLimitService at
 	// startup (otherwise wire dead-codes the post-construction setters).
 	_ service.TKAnthropicSaturationReady,
+	// TokenKey: forces wire to evaluate ProvideTKOpenAISaturation so the OpenAI
+	// edge-mirror saturation counter is wired at startup.
+	_ service.TKOpenAISaturationReady,
 	// TokenKey: forces wire to evaluate ProvideTKGatewayHandlerModelList so
 	// GatewayHandler.SetModelListFilter is called at startup. See R-003 /
 	// Goal 2 of docs/approved/pricing-availability-source-of-truth.md.

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -327,11 +327,13 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	tkGatewayAnthropicSigPreemptReady := service.ProvideTKGatewayAnthropicSigPreempt(gatewayService, anthropicSignaturePreemptCache)
 	anthropicSaturationCounterCache := repository.NewAnthropicSaturationCounterCache(redisClient)
 	tkAnthropicSaturationReady := service.ProvideTKAnthropicSaturation(gatewayService, rateLimitService, anthropicSaturationCounterCache)
+	openaiSaturationCounterCache := repository.NewOpenAISaturationCounterCache(redisClient)
+	tkOpenAISaturationReady := service.ProvideTKOpenAISaturation(openAIGatewayService, rateLimitService, openaiSaturationCounterCache)
 	modelListFilter := service.NewModelListFilter(pricingCatalogService, pricingAvailabilityService)
 	tkGatewayHandlerModelListReady := handler.ProvideTKGatewayHandlerModelList(gatewayHandler, modelListFilter)
 	tkUniversalModelsProviderReady := service.ProvideTKUniversalModelsProvider(apiKeyService, gatewayService)
 	tkGroupUnsupportedModelCacheReady := service.ProvideTKGroupUnsupportedModelCache(gatewayService, openAIGatewayService, channelService)
-	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, antigravityConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, holdReconcilerService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, grokOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkPricingOverlayRuntimeReady, tkGatewayAnthropicSigPreemptReady, tkAnthropicSaturationReady, tkGatewayHandlerModelListReady, tkUniversalModelsProviderReady, tkGroupUnsupportedModelCacheReady)
+	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, antigravityConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, holdReconcilerService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, grokOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkPricingOverlayRuntimeReady, tkGatewayAnthropicSigPreemptReady, tkAnthropicSaturationReady, tkOpenAISaturationReady, tkGatewayHandlerModelListReady, tkUniversalModelsProviderReady, tkGroupUnsupportedModelCacheReady)
 	application := &Application{
 		Server:  httpServer,
 		Cleanup: v,
@@ -412,6 +414,8 @@ func provideCleanup(
 	_ service.TKGatewayAnthropicSigPreemptReady,
 
 	_ service.TKAnthropicSaturationReady,
+
+	_ service.TKOpenAISaturationReady,
 
 	_ handler.TKGatewayHandlerModelListReady,
 

--- a/backend/cmd/server/wire_gen_test.go
+++ b/backend/cmd/server/wire_gen_test.go
@@ -97,6 +97,7 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 		service.TKPricingOverlayRuntimeReady{},      // TK: forces runtime overlay (settings hot-push) wiring
 		service.TKGatewayAnthropicSigPreemptReady{}, // TK: forces SetAnthropicSigPreemptCache wiring
 		service.TKAnthropicSaturationReady{},        // TK: forces SetAnthropicSaturationCounter wiring
+		service.TKOpenAISaturationReady{},           // TK: forces SetOpenAISaturationCounter wiring
 		handler.TKGatewayHandlerModelListReady{},    // TK: forces SetModelListFilter wiring
 		service.TKUniversalModelsProviderReady{},    // TK: forces universal-key models-provider wiring
 		service.TKGroupUnsupportedModelCacheReady{}, // TK: forces group unsupported negative cache wiring

--- a/backend/internal/repository/openai_saturation_counter_cache.go
+++ b/backend/internal/repository/openai_saturation_counter_cache.go
@@ -1,0 +1,80 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/redis/go-redis/v9"
+)
+
+const openaiSaturationCountPrefix = "openai_saturation_count:account:"
+
+var openaiSaturationIncrScript = redis.NewScript(`
+	local key = KEYS[1]
+	local window = tonumber(ARGV[1])
+
+	local count = redis.call('INCR', key)
+	if count == 1 then
+		redis.call('EXPIRE', key, window)
+	end
+
+	return count
+`)
+
+type openaiSaturationCounterCache struct {
+	rdb *redis.Client
+}
+
+func NewOpenAISaturationCounterCache(rdb *redis.Client) service.OpenAISaturationCounterCache {
+	return &openaiSaturationCounterCache{rdb: rdb}
+}
+
+func openaiSaturationKey(accountID int64) string {
+	return fmt.Sprintf("%s%d", openaiSaturationCountPrefix, accountID)
+}
+
+func (c *openaiSaturationCounterCache) IncrementSaturation(ctx context.Context, accountID int64, windowSeconds int) (int64, error) {
+	if windowSeconds <= 0 {
+		return 0, fmt.Errorf("invalid window: %d", windowSeconds)
+	}
+	key := openaiSaturationKey(accountID)
+	count, err := openaiSaturationIncrScript.Run(ctx, c.rdb, []string{key}, windowSeconds).Int64()
+	if err != nil {
+		return 0, fmt.Errorf("increment openai saturation: %w", err)
+	}
+	return count, nil
+}
+
+func (c *openaiSaturationCounterCache) GetSaturationBatch(ctx context.Context, accountIDs []int64) (map[int64]int64, error) {
+	out := make(map[int64]int64, len(accountIDs))
+	if len(accountIDs) == 0 {
+		return out, nil
+	}
+	keys := make([]string, len(accountIDs))
+	for i, id := range accountIDs {
+		keys[i] = openaiSaturationKey(id)
+	}
+	vals, err := c.rdb.MGet(ctx, keys...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("mget openai saturation: %w", err)
+	}
+	for i, v := range vals {
+		if v == nil {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		n, convErr := strconv.ParseInt(s, 10, 64)
+		if convErr != nil {
+			continue
+		}
+		if n != 0 {
+			out[accountIDs[i]] = n
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/repository/openai_saturation_counter_cache_test.go
+++ b/backend/internal/repository/openai_saturation_counter_cache_test.go
@@ -1,0 +1,33 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAISaturationCounterCache_IncrAndBatch(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	cache := NewOpenAISaturationCounterCache(rdb)
+	ctx := context.Background()
+
+	c, incErr := cache.IncrementSaturation(ctx, 7, 90)
+	require.NoError(t, incErr)
+	require.Equal(t, int64(1), c)
+
+	batch, batchErr := cache.GetSaturationBatch(ctx, []int64{7, 8})
+	require.NoError(t, batchErr)
+	require.Equal(t, int64(1), batch[7])
+	require.NotContains(t, batch, int64(8))
+}

--- a/backend/internal/repository/wire.go
+++ b/backend/internal/repository/wire.go
@@ -110,6 +110,7 @@ var ProviderSet = wire.NewSet(
 	NewAnthropicUpstreamErrorCounterCache,
 	NewAnthropicSignaturePreemptCache,
 	NewAnthropicSaturationCounterCache,
+	NewOpenAISaturationCounterCache,
 	NewInternal500CounterCache,
 	ProvideConcurrencyCache,
 	ProvideSessionLimitCache,

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -551,6 +551,9 @@ const (
 	// Redis 短窗计数 TTL 自行消散。为 false 时退回纯优先级/负载选择（无 saturation 项）。
 	// 详见 backend/internal/service/gateway_service_tk_saturation_penalty.go。
 	SettingKeyAnthropicSaturatedStubDeprioritizeEnabled = "gateway.anthropic_saturated_stub_deprioritize.enabled"
+	// SettingKeyOpenAISaturatedStubDeprioritizeEnabled (TK) mirrors the anthropic
+	// switch for OpenAI edge-mirror stubs (openai-us* → api-us*.tokenkey.dev).
+	SettingKeyOpenAISaturatedStubDeprioritizeEnabled = "gateway.openai_saturated_stub_deprioritize.enabled"
 	// SettingKeyEnableClaudeOAuthSystemPromptInjection 是否对 Claude OAuth mimic 路径注入 Claude Code system blocks（默认 true）
 	SettingKeyEnableClaudeOAuthSystemPromptInjection = "enable_claude_oauth_system_prompt_injection"
 	// SettingKeyClaudeOAuthSystemPrompt Claude OAuth mimic 路径注入的通用扩展 system prompt（空值使用内置默认）

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -454,6 +454,10 @@ func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
 		return nil, false, nil
 	}
+	if s.service.tkShouldClearOpenAIStickyForSaturation(ctx, account, sessionHash) {
+		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
+		return nil, false, nil
+	}
 	account = s.service.recheckOpenAICompatAccountFromDB(ctx, account, req.RequestedModel, req.GroupPlatform, req.RequireCompact)
 	if account == nil || !s.isAccountTransportCompatible(account, req.RequiredTransport) {
 		_ = s.service.deleteStickySessionAccountID(ctx, req.GroupID, sessionHash)
@@ -559,12 +563,13 @@ func (s *defaultOpenAIAccountScheduler) shouldEscapeStickyAccount(accountID int6
 }
 
 type openAIAccountCandidateScore struct {
-	account   *Account
-	loadInfo  *AccountLoadInfo
-	score     float64
-	errorRate float64
-	ttft      float64
-	hasTTFT   bool
+	account                *Account
+	loadInfo               *AccountLoadInfo
+	score                  float64
+	saturationScorePenalty float64
+	errorRate              float64
+	ttft                   float64
+	hasTTFT                bool
 }
 
 type openAIAccountCandidateHeap []openAIAccountCandidateScore
@@ -760,6 +765,7 @@ func buildOpenAIWeightedSelectionOrder(
 }
 
 func (s *defaultOpenAIAccountScheduler) buildOpenAIAccountLoadPlan(
+	ctx context.Context,
 	req OpenAIAccountScheduleRequest,
 	filtered []*Account,
 	loadMap map[int64]*AccountLoadInfo,
@@ -842,6 +848,8 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAIAccountLoadPlan(
 	}
 	plan.loadSkew = calcLoadSkewByMoments(loadRateSum, loadRateSumSquares, len(candidates))
 
+	s.service.computeOpenAISaturationPenalties(ctx, candidates)
+
 	weights := s.service.openAIWSSchedulerWeights()
 
 	// Reset 因子（use-it-or-lose-it）：在拥有「未来会话窗口结束时间」的账号中，
@@ -907,7 +915,8 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAIAccountLoadPlan(
 			weights.ErrorRate*errorFactor +
 			weights.TTFT*ttftFactor +
 			weights.Reset*resetFactor +
-			weights.QuotaHeadroom*quotaHeadroomFactor
+			weights.QuotaHeadroom*quotaHeadroomFactor -
+			item.saturationScorePenalty
 	}
 	plan.candidates = candidates
 
@@ -1135,7 +1144,7 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 		}
 	}
 
-	plan := s.buildOpenAIAccountLoadPlan(req, filtered, loadMap)
+	plan := s.buildOpenAIAccountLoadPlan(ctx, req, filtered, loadMap)
 	candidateCount := plan.candidateCount
 	topK := plan.topK
 	loadSkew := plan.loadSkew
@@ -1160,7 +1169,7 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 
 	if s.service.concurrencyService != nil {
 		if freshLoadMap, loadErr := s.service.concurrencyService.GetAccountsLoadBatchFresh(ctx, loadReq); loadErr == nil {
-			freshPlan := s.buildOpenAIAccountLoadPlan(req, filtered, freshLoadMap)
+			freshPlan := s.buildOpenAIAccountLoadPlan(ctx, req, filtered, freshLoadMap)
 			if len(freshPlan.selectionOrder) > 0 {
 				freshResult, freshCompactBlocked, freshAcquireErr := s.tryAcquireOpenAISelectionOrder(ctx, req, freshPlan.selectionOrder)
 				if freshAcquireErr != nil {

--- a/backend/internal/service/openai_account_scheduler_reset_test.go
+++ b/backend/internal/service/openai_account_scheduler_reset_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -49,7 +50,7 @@ func TestBuildOpenAIAccountLoadPlan_ResetWeightPrefersSoonestReset(t *testing.T)
 	}
 	sched := openAIResetTestScheduler(5.0)
 
-	plan := sched.buildOpenAIAccountLoadPlan(OpenAIAccountScheduleRequest{}, filtered, map[int64]*AccountLoadInfo{})
+	plan := sched.buildOpenAIAccountLoadPlan(context.Background(), OpenAIAccountScheduleRequest{}, filtered, map[int64]*AccountLoadInfo{})
 	scores := openAIPlanScores(plan)
 	require.Greater(t, scores[2], scores[1], "重置时间最早的账号（ID=2）得分更高")
 }
@@ -65,7 +66,7 @@ func TestBuildOpenAIAccountLoadPlan_ResetWeightZeroNoEffect(t *testing.T) {
 	}
 	sched := openAIResetTestScheduler(0.0)
 
-	plan := sched.buildOpenAIAccountLoadPlan(OpenAIAccountScheduleRequest{}, filtered, map[int64]*AccountLoadInfo{})
+	plan := sched.buildOpenAIAccountLoadPlan(context.Background(), OpenAIAccountScheduleRequest{}, filtered, map[int64]*AccountLoadInfo{})
 	scores := openAIPlanScores(plan)
 	require.Equal(t, scores[1], scores[2], "Reset 权重为 0 时两账号得分相同")
 }
@@ -80,7 +81,7 @@ func TestBuildOpenAIAccountLoadPlan_ResetWeightIgnoresNilWindow(t *testing.T) {
 	}
 	sched := openAIResetTestScheduler(5.0)
 
-	plan := sched.buildOpenAIAccountLoadPlan(OpenAIAccountScheduleRequest{}, filtered, map[int64]*AccountLoadInfo{})
+	plan := sched.buildOpenAIAccountLoadPlan(context.Background(), OpenAIAccountScheduleRequest{}, filtered, map[int64]*AccountLoadInfo{})
 	scores := openAIPlanScores(plan)
 	require.Greater(t, scores[2], scores[1], "拥有活跃窗口的账号得分高于无窗口账号")
 }
@@ -161,7 +162,7 @@ func TestBuildOpenAIAccountLoadPlan_QuotaHeadroomPrefersHigher7dRemaining(t *tes
 	}
 	sched := openAIQuotaHeadroomTestScheduler(1.0)
 
-	plan := sched.buildOpenAIAccountLoadPlan(OpenAIAccountScheduleRequest{}, filtered, map[int64]*AccountLoadInfo{})
+	plan := sched.buildOpenAIAccountLoadPlan(context.Background(), OpenAIAccountScheduleRequest{}, filtered, map[int64]*AccountLoadInfo{})
 	scores := openAIPlanScores(plan)
 	require.Greater(t, scores[2], scores[1], "7d 剩余额度更高的账号得分应更高")
 }
@@ -190,7 +191,7 @@ func TestBuildOpenAIAccountLoadPlan_QuotaHeadroomZeroNoEffect(t *testing.T) {
 	}
 	sched := openAIResetTestScheduler(0)
 
-	plan := sched.buildOpenAIAccountLoadPlan(OpenAIAccountScheduleRequest{}, filtered, map[int64]*AccountLoadInfo{})
+	plan := sched.buildOpenAIAccountLoadPlan(context.Background(), OpenAIAccountScheduleRequest{}, filtered, map[int64]*AccountLoadInfo{})
 	scores := openAIPlanScores(plan)
 	require.Equal(t, scores[1], scores[2], "quota_headroom 权重为 0 时不应影响打分")
 }

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -279,6 +279,8 @@ type OpenAIGatewayService struct {
 	tkPricingCatalog *PricingCatalogService
 	// TK: shared with GatewayService via ProvideTKGroupUnsupportedModelCache.
 	tkGroupUnsupportedCache *tkGroupUnsupportedModelNegativeCache
+	// TK: OpenAI edge-mirror stub downstream-capacity saturation counter (optional).
+	tkOpenAISaturationCounter OpenAISaturationCounterCache
 }
 
 // NewOpenAIGatewayService creates a new OpenAIGatewayService

--- a/backend/internal/service/openai_gateway_service_tk_saturation_penalty.go
+++ b/backend/internal/service/openai_gateway_service_tk_saturation_penalty.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+)
+
+// openAISaturationScorePenalty subtracts from the OpenAI scheduler's weighted
+// score when a stub is SUSTAINEDLY saturated. Scores are ~0..5; this constant
+// pushes saturated candidates to the bottom without excluding them.
+const openAISaturationScorePenalty = 10.0
+
+func (s *OpenAIGatewayService) SetOpenAISaturationCounter(cache OpenAISaturationCounterCache) {
+	if s != nil {
+		s.tkOpenAISaturationCounter = cache
+	}
+}
+
+func (s *OpenAIGatewayService) HasOpenAISaturationCounter() bool {
+	return s != nil && s.tkOpenAISaturationCounter != nil
+}
+
+func (s *OpenAIGatewayService) computeOpenAISaturationPenalties(ctx context.Context, candidates []openAIAccountCandidateScore) {
+	if s == nil || s.tkOpenAISaturationCounter == nil || len(candidates) == 0 {
+		return
+	}
+	if s.settingService != nil && !s.settingService.IsOpenAISaturatedStubDeprioritizeEnabled(ctx) {
+		return
+	}
+
+	ids := make([]int64, 0, len(candidates))
+	for i := range candidates {
+		acc := candidates[i].account
+		if tkIsOpenAIEdgeMirrorStub(acc) {
+			ids = append(ids, acc.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+
+	counts, err := s.tkOpenAISaturationCounter.GetSaturationBatch(ctx, ids)
+	if err != nil {
+		slog.Warn("openai_saturation_penalty_read_failed", "error", err)
+		return
+	}
+	if len(counts) == 0 {
+		return
+	}
+
+	var penalized []int64
+	for i := range candidates {
+		acc := candidates[i].account
+		if !tkIsOpenAIEdgeMirrorStub(acc) {
+			continue
+		}
+		if counts[acc.ID] >= anthropicSaturationThreshold {
+			candidates[i].saturationScorePenalty = openAISaturationScorePenalty
+			penalized = append(penalized, acc.ID)
+		}
+	}
+	if len(penalized) > 0 {
+		slog.Debug("openai_saturation_penalty_applied",
+			"account_ids", penalized,
+			"penalty", openAISaturationScorePenalty,
+			"candidate_count", len(candidates))
+	}
+}

--- a/backend/internal/service/openai_gateway_service_tk_saturation_penalty_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_saturation_penalty_test.go
@@ -1,0 +1,56 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func openAIEdgeCandidate(id int64, score float64) openAIAccountCandidateScore {
+	return openAIAccountCandidateScore{
+		account: openAIEdgeStub(id),
+		score:   score,
+	}
+}
+
+func TestComputeOpenAISaturationPenalties_DeprioritizesSaturatedStub(t *testing.T) {
+	resetOpenAISatCache()
+	svc := &OpenAIGatewayService{}
+	svc.SetOpenAISaturationCounter(&fakeSaturationCache{counts: map[int64]int64{
+		63: anthropicSaturationThreshold,
+		68: anthropicSaturationThreshold - 1,
+	}})
+
+	candidates := []openAIAccountCandidateScore{
+		openAIEdgeCandidate(63, 3.0),
+		openAIEdgeCandidate(68, 2.0),
+	}
+	svc.computeOpenAISaturationPenalties(context.Background(), candidates)
+	require.Equal(t, openAISaturationScorePenalty, candidates[0].saturationScorePenalty)
+	require.Equal(t, 0.0, candidates[1].saturationScorePenalty)
+	require.Less(t, candidates[0].score-candidates[0].saturationScorePenalty, candidates[1].score)
+}
+
+func TestComputeOpenAISaturationPenalties_KillSwitchOff(t *testing.T) {
+	resetOpenAISatCache()
+	svc := &OpenAIGatewayService{}
+	svc.SetOpenAISaturationCounter(&fakeSaturationCache{counts: map[int64]int64{63: 100}})
+	svc.settingService = NewSettingService(
+		&satSettingRepoStub{values: map[string]string{
+			SettingKeyOpenAISaturatedStubDeprioritizeEnabled: "false",
+		}},
+		&config.Config{},
+	)
+	candidates := []openAIAccountCandidateScore{openAIEdgeCandidate(63, 3.0)}
+	svc.computeOpenAISaturationPenalties(context.Background(), candidates)
+	require.Equal(t, 0.0, candidates[0].saturationScorePenalty)
+	resetOpenAISatCache()
+}
+
+func resetOpenAISatCache() {
+	openaiSatDeprioritizeCache.Store((*openaiSatDeprioritizeCacheEntry)(nil))
+}

--- a/backend/internal/service/openai_gateway_service_tk_sticky_saturation.go
+++ b/backend/internal/service/openai_gateway_service_tk_sticky_saturation.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+)
+
+// tkShouldClearOpenAIStickyForSaturation clears a sticky binding when the bound
+// OpenAI edge-mirror stub is SUSTAINEDLY returning downstream capacity signals,
+// mirroring gateway_service_tk_sticky_saturation.go for the GPT scheduler.
+func (s *OpenAIGatewayService) tkShouldClearOpenAIStickyForSaturation(ctx context.Context, account *Account, sessionHash string) bool {
+	if s == nil || s.tkOpenAISaturationCounter == nil || account == nil {
+		return false
+	}
+	if !tkIsOpenAIEdgeMirrorStub(account) {
+		return false
+	}
+	if s.settingService != nil && !s.settingService.IsOpenAISaturatedStubDeprioritizeEnabled(ctx) {
+		return false
+	}
+	counts, err := s.tkOpenAISaturationCounter.GetSaturationBatch(ctx, []int64{account.ID})
+	if err != nil {
+		return false
+	}
+	count := counts[account.ID]
+	if count < anthropicSaturationThreshold {
+		return false
+	}
+	slog.Info("openai_sticky_cleared_saturated_stub",
+		"account_id", account.ID,
+		"recent_count", count,
+		"threshold", anthropicSaturationThreshold,
+		"window_seconds", anthropicSaturationWindowSeconds,
+		"session", shortSessionHash(sessionHash),
+	)
+	return true
+}

--- a/backend/internal/service/openai_gateway_service_tk_sticky_saturation_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_sticky_saturation_test.go
@@ -1,0 +1,45 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldClearOpenAIStickyForSaturation_ThresholdBoundary(t *testing.T) {
+	resetOpenAISatCache()
+	svc := &OpenAIGatewayService{}
+	svc.SetOpenAISaturationCounter(&fakeSaturationCache{counts: map[int64]int64{
+		63: anthropicSaturationThreshold - 1,
+		64: anthropicSaturationThreshold,
+	}})
+
+	require.False(t, svc.tkShouldClearOpenAIStickyForSaturation(context.Background(), openAIEdgeStub(63), "sess"))
+	require.True(t, svc.tkShouldClearOpenAIStickyForSaturation(context.Background(), openAIEdgeStub(64), "sess"))
+}
+
+func TestShouldClearOpenAIStickyForSaturation_NonEdgeStubIgnored(t *testing.T) {
+	resetOpenAISatCache()
+	svc := &OpenAIGatewayService{}
+	svc.SetOpenAISaturationCounter(&fakeSaturationCache{counts: map[int64]int64{9: 100}})
+	oauth := &Account{ID: 9, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	require.False(t, svc.tkShouldClearOpenAIStickyForSaturation(context.Background(), oauth, "sess"))
+}
+
+func TestShouldClearOpenAIStickyForSaturation_KillSwitchOff(t *testing.T) {
+	resetOpenAISatCache()
+	svc := &OpenAIGatewayService{}
+	svc.SetOpenAISaturationCounter(&fakeSaturationCache{counts: map[int64]int64{63: 100}})
+	svc.settingService = NewSettingService(
+		&satSettingRepoStub{values: map[string]string{
+			SettingKeyOpenAISaturatedStubDeprioritizeEnabled: "false",
+		}},
+		&config.Config{},
+	)
+	require.False(t, svc.tkShouldClearOpenAIStickyForSaturation(context.Background(), openAIEdgeStub(63), "sess"))
+	resetOpenAISatCache()
+}

--- a/backend/internal/service/openai_saturation_counter.go
+++ b/backend/internal/service/openai_saturation_counter.go
@@ -1,0 +1,13 @@
+package service
+
+import "context"
+
+// OpenAISaturationCounterCache tracks, per OpenAI edge-mirror stub account, a
+// short-window count of recent downstream-capacity hits (forwarded edge returned
+// TokenKey's own "no available accounts" / failover-exhausted envelope). Same
+// semantics as AnthropicSaturationCounterCache — a routing preference, not a
+// cooldown. See ratelimit_service_tk_openai_saturation.go.
+type OpenAISaturationCounterCache interface {
+	IncrementSaturation(ctx context.Context, accountID int64, windowSeconds int) (count int64, err error)
+	GetSaturationBatch(ctx context.Context, accountIDs []int64) (map[int64]int64, error)
+}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -40,6 +40,9 @@ type RateLimitService struct {
 	// 路径上递增；由调度器读取施加 bounded 去优先级偏好。逻辑在
 	// ratelimit_service_tk_saturation.go。
 	anthropicSaturationCounter AnthropicSaturationCounterCache
+	// TK: OpenAI edge-mirror stub downstream-capacity counter (optional). See
+	// ratelimit_service_tk_openai_saturation.go.
+	openaiSaturationCounter OpenAISaturationCounterCache
 	usageCacheMu               sync.RWMutex
 	usageCache                 map[int64]*geminiUsageCacheEntry
 }
@@ -608,6 +611,21 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			// stale sticky binding — opus/haiku stay schedulable. See
 			// ratelimit_service_tk_mirror_class_429.go.
 			s.tkTryAnthropicMirrorClassCooldownOnDownstreamEmpty(ctx, account, satCount, tkFirstRequestedModel(requestedModel))
+			return true
+		}
+		// TK (prod 2026-07): OpenAI edge-mirror stubs (openai-us* → api-us*.tokenkey.dev)
+		// receive the same downstream empty-pool 429 envelope. Skip handle429 /
+		// runtime block and feed the bounded scheduler de-prioritization preference.
+		if tkSkipOpenAIDownstreamCapacityPenalty(account, statusCode, upstreamMsg, responseBody) {
+			reason := "no_available_accounts"
+			if tkSkipDownstreamFailoverExhaustedPenalty(statusCode, upstreamMsg, responseBody) {
+				reason = "all_available_accounts_exhausted"
+			}
+			slog.Info("openai_downstream_capacity_skip_penalty",
+				"account_id", account.ID,
+				"status_code", statusCode,
+				"reason", reason)
+			s.recordOpenAIStubSaturation(ctx, account.ID, statusCode, reason)
 			return true
 		}
 		// TK (G2, narrow): the sibling downstream capacity signal — a forwarded

--- a/backend/internal/service/ratelimit_service_tk_openai_downstream.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_downstream.go
@@ -1,0 +1,22 @@
+package service
+
+// tkIsOpenAIEdgeMirrorStub reports whether account is a prod OpenAI apikey stub
+// that forwards to an internal edge gateway (credentials.base_url
+// https://api-<edge>.tokenkey.dev). Downstream "No available accounts" on these
+// stubs is an edge-pool capacity signal, not OpenAI account health.
+func tkIsOpenAIEdgeMirrorStub(account *Account) bool {
+	return account != nil && account.Platform == PlatformOpenAI && isEdgeMirrorStub(account, edgeIDPattern)
+}
+
+// tkSkipOpenAIDownstreamCapacityPenalty is true when an OpenAI edge-mirror stub
+// received TokenKey's own downstream pool-exhaustion envelope. Fail over without
+// handle429 cooldown / runtime block and feed the bounded saturation preference.
+func tkSkipOpenAIDownstreamCapacityPenalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool {
+	if !tkIsOpenAIEdgeMirrorStub(account) {
+		return false
+	}
+	if tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody) {
+		return true
+	}
+	return tkSkipDownstreamFailoverExhaustedPenalty(statusCode, upstreamMsg, responseBody)
+}

--- a/backend/internal/service/ratelimit_service_tk_openai_downstream_test.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_downstream_test.go
@@ -1,0 +1,62 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func openAIEdgeStub(id int64) *Account {
+	return &Account{
+		ID:       id,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api-us6.tokenkey.dev",
+		},
+	}
+}
+
+func TestTkIsOpenAIEdgeMirrorStub(t *testing.T) {
+	require.True(t, tkIsOpenAIEdgeMirrorStub(openAIEdgeStub(63)))
+	require.False(t, tkIsOpenAIEdgeMirrorStub(&Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeOAuth}))
+	require.False(t, tkIsOpenAIEdgeMirrorStub(&Account{ID: 1, Platform: PlatformAnthropic, Type: AccountTypeAPIKey, Credentials: map[string]any{"base_url": "https://api-us6.tokenkey.dev"}}))
+}
+
+func TestTkSkipOpenAIDownstreamCapacityPenalty(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)
+	require.True(t, tkSkipOpenAIDownstreamCapacityPenalty(openAIEdgeStub(63), http.StatusTooManyRequests, "", body))
+	require.False(t, tkSkipOpenAIDownstreamCapacityPenalty(openAIEdgeStub(63), http.StatusTooManyRequests, "", []byte(`{"error":{"type":"rate_limit_error"}}`)))
+	require.False(t, tkSkipOpenAIDownstreamCapacityPenalty(&Account{ID: 9, Platform: PlatformOpenAI, Type: AccountTypeOAuth}, http.StatusTooManyRequests, "", body))
+}
+
+type fakeOpenAISaturationCounterRL struct {
+	incrementIDs []int64
+	count        int64
+}
+
+func (f *fakeOpenAISaturationCounterRL) IncrementSaturation(_ context.Context, accountID int64, _ int) (int64, error) {
+	f.incrementIDs = append(f.incrementIDs, accountID)
+	f.count++
+	return f.count, nil
+}
+
+func (f *fakeOpenAISaturationCounterRL) GetSaturationBatch(_ context.Context, _ []int64) (map[int64]int64, error) {
+	return nil, nil
+}
+
+func TestRateLimitService_HandleUpstreamError_OpenAIDownstreamNoAvailable_SkipsAndIncrements(t *testing.T) {
+	sat := &fakeOpenAISaturationCounterRL{}
+	svc := &RateLimitService{}
+	svc.SetOpenAISaturationCounter(sat)
+	account := openAIEdgeStub(63)
+	body := []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)
+
+	shouldDisable := svc.HandleUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+	require.True(t, shouldDisable)
+	require.Equal(t, []int64{63}, sat.incrementIDs)
+}

--- a/backend/internal/service/ratelimit_service_tk_openai_saturation.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_saturation.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+)
+
+// TK — OpenAI edge-mirror stub de-prioritization (increment side). Mirrors
+// ratelimit_service_tk_saturation.go for the GPT line: prod openai-us* apikey
+// stubs forward to api-us*.tokenkey.dev; when the edge pool is momentarily empty
+// the stub receives our own "No available accounts" 429. Fail over without
+// cooling the stub, but feed this counter so the scheduler stops picking the
+// saturated stub first on every request.
+
+func (s *RateLimitService) SetOpenAISaturationCounter(cache OpenAISaturationCounterCache) {
+	s.openaiSaturationCounter = cache
+}
+
+func (s *RateLimitService) recordOpenAIStubSaturation(ctx context.Context, accountID int64, statusCode int, reason string) int64 {
+	if s == nil || s.openaiSaturationCounter == nil {
+		return 0
+	}
+	count, err := s.openaiSaturationCounter.IncrementSaturation(ctx, accountID, anthropicSaturationWindowSeconds)
+	if err != nil {
+		slog.Warn("openai_stub_saturation_increment_failed",
+			"account_id", accountID,
+			"reason", reason,
+			"error", err)
+		return 0
+	}
+	if count == anthropicSaturationThreshold {
+		slog.Info("openai_stub_saturated_deprioritized",
+			"account_id", accountID,
+			"recent_count", count,
+			"threshold", anthropicSaturationThreshold,
+			"window_seconds", anthropicSaturationWindowSeconds,
+			"status_code", statusCode,
+			"reason", reason)
+	}
+	return count
+}

--- a/backend/internal/service/setting_service_tk_openai_saturation.go
+++ b/backend/internal/service/setting_service_tk_openai_saturation.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	openaiSatDeprioritizeCacheTTL  = 60 * time.Second
+	openaiSatDeprioritizeErrorTTL  = 5 * time.Second
+	openaiSatDeprioritizeDBTimeout = 5 * time.Second
+)
+
+type openaiSatDeprioritizeCacheEntry struct {
+	enabled   bool
+	expiresAt int64
+}
+
+var openaiSatDeprioritizeCache atomic.Value // *openaiSatDeprioritizeCacheEntry
+var openaiSatDeprioritizeSF singleflight.Group
+
+func (s *SettingService) IsOpenAISaturatedStubDeprioritizeEnabled(ctx context.Context) bool {
+	if s == nil || s.settingRepo == nil {
+		return true
+	}
+	if cached, ok := openaiSatDeprioritizeCache.Load().(*openaiSatDeprioritizeCacheEntry); ok && cached != nil {
+		if time.Now().UnixNano() < cached.expiresAt {
+			return cached.enabled
+		}
+	}
+	val, _, _ := openaiSatDeprioritizeSF.Do(SettingKeyOpenAISaturatedStubDeprioritizeEnabled, func() (any, error) {
+		if cached, ok := openaiSatDeprioritizeCache.Load().(*openaiSatDeprioritizeCacheEntry); ok && cached != nil {
+			if time.Now().UnixNano() < cached.expiresAt {
+				return cached.enabled, nil
+			}
+		}
+		dbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), openaiSatDeprioritizeDBTimeout)
+		defer cancel()
+		raw, err := s.settingRepo.GetValue(dbCtx, SettingKeyOpenAISaturatedStubDeprioritizeEnabled)
+		if err != nil {
+			slog.Warn("failed to get openai saturated-stub deprioritize setting", "error", err)
+			openaiSatDeprioritizeCache.Store(&openaiSatDeprioritizeCacheEntry{
+				enabled:   true,
+				expiresAt: time.Now().Add(openaiSatDeprioritizeErrorTTL).UnixNano(),
+			})
+			return true, nil
+		}
+		enabled := strings.TrimSpace(raw) != "false"
+		openaiSatDeprioritizeCache.Store(&openaiSatDeprioritizeCacheEntry{
+			enabled:   enabled,
+			expiresAt: time.Now().Add(openaiSatDeprioritizeCacheTTL).UnixNano(),
+		})
+		return enabled, nil
+	})
+	if b, ok := val.(bool); ok {
+		return b
+	}
+	return true
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -771,6 +771,7 @@ var ProviderSet = wire.NewSet(
 	// RateLimitService (skip-penalty write). Consumed by provideCleanup so wire
 	// forces evaluation.
 	ProvideTKAnthropicSaturation,
+	ProvideTKOpenAISaturation,
 	// TokenKey: account-incident → Feishu notifier. Builds the notifier, starts
 	// its digest ticker, and wires it onto RateLimitService post-construction.
 	// Returns the instance so provideCleanup (cmd/server/wire.go) can Stop() the

--- a/backend/internal/service/wire_tk.go
+++ b/backend/internal/service/wire_tk.go
@@ -171,6 +171,28 @@ func ProvideTKAnthropicSaturation(
 	return TKAnthropicSaturationReady{}
 }
 
+// TKOpenAISaturationReady is a wire sentinel consumed by provideCleanup so wire
+// forces SetOpenAISaturationCounter on OpenAIGatewayService + RateLimitService.
+type TKOpenAISaturationReady struct{}
+
+// ProvideTKOpenAISaturation wires the Redis-backed OpenAI edge-mirror saturation
+// counter into the OpenAI scheduler (read) and rate-limit skip-penalty path
+// (write). See openai_gateway_service_tk_saturation_penalty.go /
+// ratelimit_service_tk_openai_saturation.go.
+func ProvideTKOpenAISaturation(
+	openai *OpenAIGatewayService,
+	rl *RateLimitService,
+	cache OpenAISaturationCounterCache,
+) TKOpenAISaturationReady {
+	if openai != nil {
+		openai.SetOpenAISaturationCounter(cache)
+	}
+	if rl != nil {
+		rl.SetOpenAISaturationCounter(cache)
+	}
+	return TKOpenAISaturationReady{}
+}
+
 // ProvideTKAccountIncidentNotifier builds the account-incident Feishu notifier,
 // starts its background digest ticker, and wires it onto RateLimitService
 // post-construction. It returns the concrete instance (not a sentinel) so

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2332,13 +2332,12 @@ else
     _wire_gen_changed=0
     _wire_changed_file=""
     for _wf in $(git diff --name-only "$_wire_base"...HEAD -- 'backend/**/wire.go' 2>/dev/null); do
-        if [ "$_wf" = "$_wire_gen" ]; then
-            _wire_gen_changed=1
-        else
-            _wire_inputs_changed=1
-            _wire_changed_file="$_wf"
-        fi
+        _wire_inputs_changed=1
+        _wire_changed_file="$_wf"
     done
+    if git diff --name-only "$_wire_base"...HEAD -- "$_wire_gen" 2>/dev/null | grep -q .; then
+        _wire_gen_changed=1
+    fi
     if [ "$_wire_inputs_changed" -eq 1 ] && [ "$_wire_gen_changed" -eq 0 ]; then
         echo "  FAIL: wire.go input changed ($_wire_changed_file) but wire_gen.go was not regenerated. Run 'go generate ./cmd/server' in backend/"
         errors=$((errors + 1))

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3004,6 +3004,94 @@
       "rationale": "Wire glue that attaches the saturation counter onto BOTH GatewayService (read) and RateLimitService (write) post-construction, keeping the upstream NewGatewayService/NewRateLimitService signatures stable. One provider, two setters — if either setter call is dropped, one half of the feature goes inert (scheduler can't read, or skip path can't write). The TKAnthropicSaturationReady sentinel forces wire to evaluate it; these anchors pin the dual-setter wiring."
     },
     {
+      "path": "backend/internal/service/openai_gateway_service_tk_saturation_penalty.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) computeOpenAISaturationPenalties(",
+        "openAISaturationScorePenalty = 10.0",
+        "IsOpenAISaturatedStubDeprioritizeEnabled"
+      ],
+      "rationale": "Read side of OpenAI edge-mirror stub saturated de-prioritization (prod 2026-07 recovered-200 incident): prod openai-us* apikey stubs forward to api-us*.tokenkey.dev; when the edge OAuth pool is empty the stub receives TokenKey's own downstream-capacity 429 and load_balance keeps selecting it first, wasting a failover hop every request. Mirrors gateway_service_tk_saturation_penalty.go for the GPT scheduler: a bounded score penalty (-10) folded into buildOpenAIAccountLoadPlan, never excluding the stub from the candidate set. Dropping this file silently reverts prod to hammering saturated stubs."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service_tk_sticky_saturation.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) tkShouldClearOpenAIStickyForSaturation(",
+        "count < anthropicSaturationThreshold",
+        "openai_sticky_cleared_saturated_stub"
+      ],
+      "rationale": "Sticky-side completion of OpenAI saturated mirror-stub de-prioritization: selectBySessionHash honors sticky bindings that bypass load_balance penalties unless cleared here when the bound openai-us* stub is SUSTAINEDLY saturated. Without this helper sticky sessions keep selecting the dead stub first every request (same failure mode as anthropic cc-us5 2026-06-19). PREFERENCE not cooldown — shares the kill-switch and 90s counter TTL."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler.go",
+      "must_contain": [
+        "s.service.tkShouldClearOpenAIStickyForSaturation(ctx, account, sessionHash)",
+        "s.service.computeOpenAISaturationPenalties(ctx, candidates)",
+        "item.saturationScorePenalty"
+      ],
+      "rationale": "Scheduler wiring for OpenAI saturated-stub preference: sticky clear hook in selectBySessionHash and saturation penalty fold-in inside buildOpenAIAccountLoadPlan. Either hook dropped silently disables half the feature (sticky keeps dead stub, or load_balance ignores saturation)."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_openai_saturation.go",
+      "must_contain": [
+        "func (s *RateLimitService) recordOpenAIStubSaturation(",
+        "openai_stub_saturated_deprioritized"
+      ],
+      "rationale": "Write side of OpenAI saturation de-prioritization: increments the per-stub short-window counter ONLY on the downstream-capacity skip-penalty path. Never advances handle429 / ladder — preference feed only. Dropping this file stops feeding the counter and scheduler preference becomes inert."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "s.recordOpenAIStubSaturation(ctx, account.ID, statusCode, reason)",
+        "openai_downstream_capacity_skip_penalty"
+      ],
+      "rationale": "Thin injection of OpenAI saturation counter increments at the HandleUpstreamError downstream-capacity skip branch (429 no-available / failover-exhausted on openai-us* edge mirror stubs). Sits AFTER the skip decision so cooldown/ladder stay untouched — only feeds de-prioritization preference. Upstream merge rewriting the skip branch would silently drop the feed."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_openai_downstream.go",
+      "must_contain": [
+        "func tkIsOpenAIEdgeMirrorStub(",
+        "func tkSkipOpenAIDownstreamCapacityPenalty(",
+        "isEdgeMirrorStub(account, edgeIDPattern)"
+      ],
+      "rationale": "OpenAI edge-mirror stub classifier + downstream pool-exhaustion skip predicate. Without tkSkipOpenAIDownstreamCapacityPenalty, prod openai-us* stubs receive handle429 cooldown on edge empty-pool 429s and collapse the prod mirror pool (prod 2026-07 recovered-200 incident). Mirrors ratelimit_service_tk_downstream_no_available.go semantics for the GPT line."
+    },
+    {
+      "path": "backend/internal/repository/openai_saturation_counter_cache.go",
+      "must_contain": [
+        "func NewOpenAISaturationCounterCache(",
+        "openai_saturation_count:account:",
+        "openaiSaturationIncrScript",
+        "func (c *openaiSaturationCounterCache) GetSaturationBatch("
+      ],
+      "rationale": "Redis-backed fixed-window counter for OpenAI saturation de-prioritization. Mirrors anthropic_saturation_counter_cache.go; deleting this repo file breaks the wire provider and disables the feature."
+    },
+    {
+      "path": "backend/internal/service/setting_service_tk_openai_saturation.go",
+      "must_contain": [
+        "func (s *SettingService) IsOpenAISaturatedStubDeprioritizeEnabled(",
+        "SettingKeyOpenAISaturatedStubDeprioritizeEnabled"
+      ],
+      "rationale": "Kill-switch accessor (default ON, fail-open) for OpenAI saturated-stub de-prioritization. Mirrors setting_service_tk_saturation.go for the GPT line."
+    },
+    {
+      "path": "backend/internal/service/wire_tk.go",
+      "must_contain": [
+        "func ProvideTKOpenAISaturation(",
+        "openai.SetOpenAISaturationCounter(cache)",
+        "rl.SetOpenAISaturationCounter(cache)"
+      ],
+      "rationale": "Wire glue attaching the OpenAI saturation counter onto OpenAIGatewayService (read) and RateLimitService (write). Dual-setter wiring — if either setter call is dropped, one half of the feature goes inert."
+    },
+    {
+      "path": "backend/cmd/server/wire_gen.go",
+      "must_contain": [
+        "openaiSaturationCounterCache := repository.NewOpenAISaturationCounterCache(redisClient)",
+        "tkOpenAISaturationReady := service.ProvideTKOpenAISaturation(",
+        "tkOpenAISaturationReady,"
+      ],
+      "rationale": "Generated wire output for OpenAI edge-mirror saturation counter DI. Upstream wire regen can drop the provider evaluation silently; these literals anchor the post-construction wiring survives merge/regen until intentionally updated."
+    },
+    {
       "path": "backend/internal/handler/openai_chat_completions.go",
       "must_contain": [
         "hold, holdReject := h.tkApplyBalanceHold(c, apiKey, reqModel, body)",


### PR DESCRIPTION
## 摘要

prod 上 `openai-us3/us4/us6` apikey stub 转发 edge 时，edge OAuth 池空会返回 TokenKey 自身 429（`No available accounts`）。OpenAI 线此前缺少 Anthropic 已有的 downstream-empty 治理，导致 stub 持续被 sticky/load_balance 选中、产生大量 recovered-200 wasted hop。

本 PR 对齐 Anthropic 机制：
- 识别 `isEdgeMirrorStub` 的 downstream 429，跳过 `handle429` 冷却惩罚
- 90s 窗口计数饱和（阈值 4），load_balance 降权 -10
- 饱和时清 sticky 绑定
- admin setting kill-switch：`gateway.openai_saturated_stub_deprioritize.enabled`
- gateway-tk sentinel 锚点 + wire_gen DI 锚点

sentinel-registry-reviewed

## 风险

- 常规风险：仅影响 OpenAI edge mirror stub 调度路径，不改变真实 upstream 429 惩罚逻辑
- 若 edge 池短暂抖动，stub 可能被短暂降权（预期行为）

## 验证

```bash
cd backend && go test -tags=unit ./internal/service -run 'TestTkIsOpenAI|TestComputeOpenAISaturation|TestShouldClearOpenAISticky|DownstreamNoAvailable|Saturation|StickyForSaturation|OpenAIDownstream'
cd backend && go test -tags=unit ./internal/repository -run TestOpenAISaturationCounter
./scripts/preflight.sh
make test
```

## 提交

- db0fd26 fix(openai): 对 edge mirror stub 的 downstream 池空信号做饱和降权
- a203be3 fix(review): anchor OpenAI saturation sentinels and wire_gen preflight gate

最新提交：a203be3