### PR TITLE
fix(glm): newapi bridge 转发前改写 dated GLM model id

### DIFF
--- a/backend/internal/service/gateway_bridge_dispatch.go
+++ b/backend/internal/service/gateway_bridge_dispatch.go
@@ -94,6 +94,7 @@ func (s *GatewayService) ForwardAsChatCompletionsDispatched(
 	}
 	recordBridgeDispatch()
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
+	body = rewriteNewAPIBridgeBodyModel(account, body, "")
 	auth := bridgeAuthFromGin(c)
 	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
 	if strings.TrimSpace(in.APIKey) == "" {
@@ -145,6 +146,7 @@ func (s *GatewayService) ForwardAsResponsesDispatched(
 	}
 	recordBridgeDispatch()
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
+	body = rewriteNewAPIBridgeBodyModel(account, body, "")
 	auth := bridgeAuthFromGin(c)
 	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
 	if strings.TrimSpace(in.APIKey) == "" {

--- a/backend/internal/service/openai_gateway_bridge_dispatch.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch.go
@@ -42,6 +42,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletionsDispatched(
 	// inject prompt_cache_key into body AND set X-Session-Id header on the gin
 	// request so GLM-style adaptors can pick it up. See docs/approved/sticky-routing.md.
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
+	body = rewriteNewAPIBridgeBodyModel(account, body, defaultMappedModel)
 	auth := bridgeAuthFromGin(c)
 	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
 	if strings.TrimSpace(in.APIKey) == "" {
@@ -90,6 +91,7 @@ func dispatchNewAPIAccountTestChatCompletions(
 	body []byte,
 ) error {
 	recordBridgeDispatch()
+	body = rewriteNewAPIBridgeBodyModel(account, body, "")
 	in := newAPIBridgeChannelInput(account, 0, "")
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()
@@ -115,6 +117,7 @@ func (s *OpenAIGatewayService) ForwardAsResponsesDispatched(
 	}
 	recordBridgeDispatch()
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
+	body = rewriteNewAPIBridgeBodyModel(account, body, "")
 	auth := bridgeAuthFromGin(c)
 	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
 	if strings.TrimSpace(in.APIKey) == "" {
@@ -187,6 +190,7 @@ func (s *OpenAIGatewayService) ForwardAsEmbeddingsDispatched(
 	}
 	recordBridgeDispatch()
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
+	body = rewriteNewAPIBridgeBodyModel(account, body, defaultMappedModel)
 	auth := bridgeAuthFromGin(c)
 	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
 	if strings.TrimSpace(in.APIKey) == "" {
@@ -238,6 +242,7 @@ func (s *OpenAIGatewayService) ForwardAsImageGenerationsDispatched(
 	}
 	recordBridgeDispatch()
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
+	body = rewriteNewAPIBridgeBodyModel(account, body, defaultMappedModel)
 	auth := bridgeAuthFromGin(c)
 	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
 	if strings.TrimSpace(in.APIKey) == "" {

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// rewriteNewAPIBridgeBodyModel applies account-level model_mapping (including TK
+// dated GLM alias via resolveOpenAIForwardModel) before the newapi adaptor reads
+// body.model. Non-bridge paths already rewrite upstream model; bridge dispatch
+// previously forwarded the client id verbatim and upstreams like DashScope reject
+// VolcEngine dated SKUs such as glm-4-7-251222.
+func rewriteNewAPIBridgeBodyModel(account *Account, body []byte, defaultMappedModel string) []byte {
+	originalModel := strings.TrimSpace(gjson.GetBytes(body, "model").String())
+	if originalModel == "" || account == nil {
+		return body
+	}
+	billingModel := resolveOpenAIForwardModel(account, originalModel, defaultMappedModel)
+	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
+	if upstreamModel == "" || upstreamModel == originalModel {
+		return body
+	}
+	rewritten := ReplaceModelInBody(body, upstreamModel)
+	if normalizedBody, normalized := NormalizeGLMOpenAIReasoningEffort(rewritten, upstreamModel); normalized {
+		return normalizedBody
+	}
+	return rewritten
+}

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping_test.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping_test.go
@@ -1,0 +1,84 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+func TestRewriteNewAPIBridgeBodyModel_GLMDatedAlias(t *testing.T) {
+	account := &Account{
+		Platform: PlatformNewAPI,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"glm-4.7": "glm-4.7",
+			},
+		},
+	}
+	body := []byte(`{"model":"glm-4-7-251222","messages":[{"role":"user","content":"hi"}]}`)
+	got := rewriteNewAPIBridgeBodyModel(account, body, "")
+	if model := gjson.GetBytes(got, "model").String(); model != "glm-4.7" {
+		t.Fatalf("rewriteNewAPIBridgeBodyModel model = %q, want glm-4.7", model)
+	}
+}
+
+func TestResolveOpenAIForwardModel_GLMDatedVolcengineAlias(t *testing.T) {
+	account := &Account{
+		Platform: PlatformNewAPI,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"glm-4.7": "glm-4.7",
+			},
+		},
+	}
+	if got := resolveOpenAIForwardModel(account, "glm-4-7-251222", ""); got != "glm-4.7" {
+		t.Fatalf("resolveOpenAIForwardModel(glm-4-7-251222) = %q, want glm-4.7", got)
+	}
+}
+
+func TestForwardAsChatCompletionsDispatched_RewritesGLMDatedModelBeforeBridge(t *testing.T) {
+	oldDispatch := dispatchNewAPIChatCompletions
+	t.Cleanup(func() { dispatchNewAPIChatCompletions = oldDispatch })
+
+	var capturedBody []byte
+	dispatchNewAPIChatCompletions = func(_ context.Context, _ *gin.Context, in bridge.ChannelContextInput, body []byte) (*bridge.DispatchOutcome, *newapitypes.NewAPIError) {
+		if strings.TrimSpace(in.APIKey) == "" {
+			t.Fatal("expected bridge api key")
+		}
+		capturedBody = append([]byte(nil), body...)
+		return &bridge.DispatchOutcome{
+			Model: "glm-4.7",
+		}, nil
+	}
+
+	account := &Account{
+		ID:          60,
+		Platform:    PlatformNewAPI,
+		ChannelType: 17,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key": "test-key",
+			"model_mapping": map[string]any{
+				"glm-4.7": "glm-4.7",
+			},
+		},
+	}
+	svc := &OpenAIGatewayService{}
+	c, _ := gin.CreateTestContext(nil)
+	body := []byte(`{"model":"glm-4-7-251222","messages":[{"role":"user","content":"hi"}]}`)
+
+	_, err := svc.ForwardAsChatCompletionsDispatched(context.Background(), c, account, body, "", "")
+	if err != nil {
+		t.Fatalf("ForwardAsChatCompletionsDispatched: %v", err)
+	}
+	if model := gjson.GetBytes(capturedBody, "model").String(); model != "glm-4.7" {
+		t.Fatalf("bridge body model = %q, want glm-4.7", model)
+	}
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -704,6 +704,23 @@
       "rationale": "Anthropic-shaped requests converted to Chat Completions must preserve metadata blobs and apply unified sticky injection so Claude Code identities and session affinity survive OpenAI-compat bridge paths during scheduling."
     },
     {
+      "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping.go",
+      "must_contain": [
+        "resolveOpenAIForwardModel",
+        "ReplaceModelInBody",
+        "rewriteNewAPIBridgeBodyModel"
+      ],
+      "rationale": "NewAPI bridge dispatch must rewrite body.model via account model_mapping (including dated GLM alias glm-4-7-251222 -> glm-4.7) before the adaptor forwards upstream. Without this companion, legacy clients keep the VolcEngine dated id and DashScope upstream returns model_not_found even though ResolveMappedModel already normalizes for routing/billing."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_bridge_dispatch.go",
+      "must_contain": [
+        "rewriteNewAPIBridgeBodyModel(account, body, defaultMappedModel)",
+        "rewriteNewAPIBridgeBodyModel(account, body, \"\")"
+      ],
+      "rationale": "Bridge chat/embeddings/images dispatch and admin account-test probes must call rewriteNewAPIBridgeBodyModel after sticky injection so upstream model_mapping alias applies on the newapi adaptor path."
+    },
+    {
       "path": "backend/internal/service/openai_codex_transform.go",
       "must_contain": [
         "Wei-Shaw/sub2api#2500",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -417,12 +417,13 @@
     {
       "path": "backend/internal/service/gateway_bridge_dispatch.go",
       "must_contain": [
-        "s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)"
+        "s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)",
+        "rewriteNewAPIBridgeBodyModel(account, body, \"\")"
       ],
       "must_not_contain": [
         "tkWrapBridgeRelayError(c, apiErr)"
       ],
-      "rationale": "The Anthropic-gateway bridge boundary (GatewayService ForwardAsChatCompletionsDispatched / ForwardAsResponsesDispatched, 2 sites) is the same penalty chokepoint class as openai_gateway_bridge_dispatch.go and must stay wired identically: zero penalty-less tkWrapBridgeRelayError(c, apiErr) calls. Without this entry only the OpenAI-gateway file was anchored and a refactor here would silently drop the account penalty for messages-dispatch newapi traffic."
+      "rationale": "The Anthropic-gateway bridge boundary (GatewayService ForwardAsChatCompletionsDispatched / ForwardAsResponsesDispatched, 2 sites) is the same penalty chokepoint class as openai_gateway_bridge_dispatch.go and must stay wired identically: zero penalty-less tkWrapBridgeRelayError(c, apiErr) calls. Without this entry only the OpenAI-gateway file was anchored and a refactor here would silently drop the account penalty for messages-dispatch newapi traffic. Both bridge dispatch sites must also rewrite body.model via rewriteNewAPIBridgeBodyModel so dated GLM ids reach DashScope as glm-4.7."
     },
     {
       "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go",


### PR DESCRIPTION
## 摘要

- PR #1241 已在 routing/计费侧把 `glm-4-7-251222` 归一化到 `glm-4.7`，但 newapi bridge 仍直透 body.model，DashScope 上游返回 `model_not_found`（prod 单账号 probe 已复现）。
- 新增 `rewriteNewAPIBridgeBodyModel()`，与 `forwardAsRawChatCompletions` 对齐：sticky 注入后调用 `resolveOpenAIForwardModel` + `ReplaceModelInBody`，覆盖 OpenAI gateway 与 messages gateway 的全部 bridge dispatch 入口。

## 风险

- 常规风险：仅影响 newapi bridge 路径的 upstream model 字段；已有 account mapping 行为不变，只是补上 bridge 缺口。
- 无 Web / 契约 / schema 变更。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service \
  -run 'TestRewriteNewAPIBridgeBodyModel|TestForwardAsChatCompletionsDispatched_RewritesGLM|TestNormalizeGLMVolcengineDatedModelID|TestAccount_GLMDated' -count=1

python3 scripts/sentinels/check-newapi.py
python3 scripts/sentinels/check-gateway-tk.py
```

发版后 prod 复验：

```bash
bash ops/observability/run-probe.sh --target prod \
  --script ops/stage0/probe_account_model.sh \
  --env ACCOUNT_ID=60 --env MODEL=glm-4-7-251222 --env ENDPOINT=chat
```

期望 `verdict=servable`，`usage_match.model=glm-4.7`。

## 提交

- 77e9f3cfa fix(glm): newapi bridge 转发前改写 dated GLM model id

最新提交：77e9f3cfa

Made with [Cursor](https://cursor.com)