### PR TITLE
chore: 添加本地 preflight Python bootstrap 脚本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ vendor/
 # Go 编译缓存
 backend/.gocache/
 
+# Local preflight Python venv (scripts/bootstrap-local-python.sh)
+.venv/
+
 # ===================
 # Node.js / Vue 前端
 # ===================

--- a/requirements-preflight.txt
+++ b/requirements-preflight.txt
@@ -1,0 +1,3 @@
+# Python deps for local scripts/preflight.sh gates (workflow YAML, ops/ tools).
+# CI installs PyYAML via actions/setup-python; macOS CommandLineTools python3.9 lacks it.
+pyyaml>=6.0

--- a/scripts/bootstrap-local-python.sh
+++ b/scripts/bootstrap-local-python.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Bootstrap a repo-local Python 3.12+ venv for preflight / ops scripts.
+#
+# macOS ships python3 3.9 without datetime.UTC and usually without PyYAML.
+# CI uses actions/setup-python 3.x and is unaffected.
+#
+# Usage:
+#   bash scripts/bootstrap-local-python.sh          # create .venv + install deps
+#   bash scripts/bootstrap-local-python.sh --check # verify .venv is usable
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VENV="$REPO_ROOT/.venv"
+REQ="$REPO_ROOT/requirements-preflight.txt"
+WRAPPER="$HOME/.local/bin/python3"
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "bootstrap-local-python: missing $1 on PATH" >&2
+    exit 1
+  }
+}
+
+check_venv() {
+  if [[ ! -x "$VENV/bin/python" ]]; then
+    echo "bootstrap-local-python: .venv missing — run without --check first" >&2
+    return 1
+  fi
+  "$VENV/bin/python" - <<'PY'
+import datetime as dt
+import yaml
+
+assert hasattr(dt, "UTC")
+print(yaml.__version__)
+PY
+}
+
+if [[ "${1:-}" == "--check" ]]; then
+  check_venv >/dev/null
+  echo "ok: .venv python usable (PyYAML + datetime.UTC)"
+  exit 0
+fi
+
+need_cmd uv
+[[ -f "$REQ" ]] || { echo "bootstrap-local-python: missing $REQ" >&2; exit 1; }
+
+echo "bootstrap-local-python: creating $VENV (python 3.12+)"
+uv venv "$VENV" --python 3.12
+uv pip install -p "$VENV" -r "$REQ"
+
+check_venv >/dev/null
+
+mkdir -p "$(dirname "$WRAPPER")"
+cat >"$WRAPPER" <<EOF
+#!/bin/sh
+exec $VENV/bin/python "\$@"
+EOF
+chmod +x "$WRAPPER"
+
+echo "bootstrap-local-python: wrote $WRAPPER -> $VENV/bin/python"
+echo "bootstrap-local-python: verify with: python3 --version && python3 -c 'import yaml'"
+
+if command -v go >/dev/null 2>&1; then
+  _goproxy="$(go env GOPROXY 2>/dev/null || true)"
+  if [[ "$_goproxy" == *"proxy.golang.org"* && "$_goproxy" != *"goproxy.cn"* ]]; then
+    echo "bootstrap-local-python: hint — if 'go generate ./ent' hangs on module download,"
+    echo "  run: go env -w GOPROXY=https://goproxy.cn,https://proxy.golang.org,direct"
+  fi
+fi


### PR DESCRIPTION
## 摘要

- 新增 `scripts/bootstrap-local-python.sh` + `requirements-preflight.txt`，一键创建 repo 级 `.venv`（Python 3.12+、PyYAML）
- 写入 `~/.local/bin/python3` wrapper，修复 macOS CLT `python3.9` 导致的本地 preflight 误报（`datetime.UTC` / PyYAML）
- `.gitignore` 忽略 `.venv/`；脚本 `--check` 可验证环境

## 风险

- 低风险，仅新增可选本地 bootstrap 脚本，不改变 CI 或运行时行为
- 首次运行需本机已安装 `uv`

## 验证

```bash
bash scripts/bootstrap-local-python.sh
bash scripts/bootstrap-local-python.sh --check
./scripts/preflight.sh
```

- bootstrap `--check` 通过
- preflight 全绿

## 提交

- 9bbd0c0 chore: 添加本地 preflight Python bootstrap 脚本

最新提交：9bbd0c0

Made with [Cursor](https://cursor.com)