### PR TITLE
fix(frontend): 修复模型市场图片/视频筛选为空

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 571,
-  "hash": "02453979be2770d557f2e9feeaf1ebeefa5a14ca27fea1d289c2a31bc20d0281",
+  "hash": "a5f1eb0f84867079fb65eed4233073fc2eaa6ac7ac5323e79070ab2c9eb10ed6",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/ModelMarketplaceView.vue
+++ b/frontend/src/views/ModelMarketplaceView.vue
@@ -244,19 +244,26 @@ const categoryFilters = computed(() => [
   { key: 'video', label: t('models.filterVideo') },
 ])
 
-// Filter by category (capability-based)
+type MarketplaceCategory = 'text' | 'image' | 'video'
+
+/** Align with PricingView + public catalog: media rows use pricing.billing_mode, not capabilities. */
+function modelListingCategory(m: PublicCatalogModel): MarketplaceCategory {
+  const mode = m.pricing?.billing_mode
+  if (mode === 'image') return 'image'
+  if (mode === 'video') return 'video'
+  return 'text'
+}
+
+// Filter by category (billing_mode-driven — same truth as /pricing modality tabs)
 const filteredByCategory = computed(() => {
   if (activeCategory.value === 'all') return models.value
   if (activeCategory.value === 'image') {
-    return models.value.filter(m => m.capabilities.includes('image_generation'))
+    return models.value.filter((m) => modelListingCategory(m) === 'image')
   }
   if (activeCategory.value === 'video') {
-    return models.value.filter(m => m.capabilities.includes('video_generation'))
+    return models.value.filter((m) => modelListingCategory(m) === 'video')
   }
-  // text: exclude image/video-only models
-  return models.value.filter(m =>
-    !m.capabilities.includes('image_generation') && !m.capabilities.includes('video_generation')
-  )
+  return models.value.filter((m) => modelListingCategory(m) === 'text')
 })
 
 // Vendor list derived from category-filtered models

--- a/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
+++ b/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
@@ -55,17 +55,18 @@ function catalog(models: PublicCatalogModel[]): PublicCatalogResponse {
 function model(
   model_id: string,
   vendor: string,
-  capabilities: string[] = []
+  overrides: Partial<PublicCatalogModel> = {}
 ): PublicCatalogModel {
   return {
     model_id,
     vendor,
-    capabilities,
+    capabilities: [],
     pricing: {
       currency: 'USD',
       input_per_1k_tokens: 0.001,
       output_per_1k_tokens: 0.002,
     },
+    ...overrides,
   }
 }
 
@@ -85,29 +86,58 @@ describe('ModelMarketplaceView', () => {
     authState.isAuthenticated = false
   })
 
-  it('renders image models when image filter is selected', async () => {
+  it('filters image models by pricing.billing_mode, not capabilities tags', async () => {
     getPublicPricing.mockResolvedValue(
       catalog([
         model('gpt-4o-mini', 'OpenAI'),
-        model('imagen-4.0-generate-001', 'Google', ['image_generation']),
+        model('imagen-4.0-generate-001', 'Google', {
+          pricing: {
+            currency: 'USD',
+            billing_mode: 'image',
+            input_per_1k_tokens: 0,
+            output_per_1k_tokens: 0,
+            output_cost_per_image: 0.04,
+          },
+        }),
       ])
     )
 
     const wrapper = mountMarketplace()
     await flushPromises()
 
-    expect(wrapper.text()).toContain('gpt-4o-mini')
-    expect(wrapper.text()).toContain('imagen-4.0-generate-001')
-
-    const imageBtn = wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Image'))
+    const imageBtn = wrapper.findAll('button').find((b) => b.text().includes('Image'))
     expect(imageBtn).toBeTruthy()
     await imageBtn!.trigger('click')
 
     expect(wrapper.text()).toContain('imagen-4.0-generate-001')
     expect(wrapper.text()).not.toContain('gpt-4o-mini')
-    expect(wrapper.text()).toContain('Image generation')
+  })
+
+  it('filters video models by pricing.billing_mode', async () => {
+    getPublicPricing.mockResolvedValue(
+      catalog([
+        model('gpt-4o-mini', 'OpenAI'),
+        model('veo-3.1-generate-preview', 'Google', {
+          pricing: {
+            currency: 'USD',
+            billing_mode: 'video',
+            input_per_1k_tokens: 0,
+            output_per_1k_tokens: 0,
+            output_cost_per_second: 0.5,
+          },
+        }),
+      ])
+    )
+
+    const wrapper = mountMarketplace()
+    await flushPromises()
+
+    const videoBtn = wrapper.findAll('button').find((b) => b.text().includes('Video'))
+    expect(videoBtn).toBeTruthy()
+    await videoBtn!.trigger('click')
+
+    expect(wrapper.text()).toContain('veo-3.1-generate-preview')
+    expect(wrapper.text()).not.toContain('gpt-4o-mini')
   })
 
   it('shows empty state when search matches no models', async () => {


### PR DESCRIPTION
## 摘要

- `/models` 的图片/视频 Tab 改用 `pricing.billing_mode` 筛选（与 `/pricing` 一致）
- 根因：前端误用 `capabilities` 里的 `image_generation` / `video_generation`，而 public catalog 从不输出这些 tag，媒体模型只带 `billing_mode: image|video`

## 风险

- 常规风险，仅影响模型市场分类筛选逻辑

## 验证

```bash
cd frontend && pnpm test:run src/views/__tests__/ModelMarketplaceView.spec.ts
```

- 3 passed（含 billing_mode 图片/视频筛选）

## 提交

- b07c72f fix(frontend): 模型市场图片/视频筛选改用 billing_mode

最新提交：b07c72f

sentinel-registry-reviewed

Made with [Cursor](https://cursor.com)