### PR TITLE
fix(frontend): 定价授权分组改跳 quickstart，全能 key 模型清单与预填

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 571,
-  "hash": "02453979be2770d557f2e9feeaf1ebeefa5a14ca27fea1d289c2a31bc20d0281",
+  "hash": "171863bed08bfb45783378c6bdb6c723e6725103500763eac4ab2d89cd6ce8b9",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 571,
-  "hash": "171863bed08bfb45783378c6bdb6c723e6725103500763eac4ab2d89cd6ce8b9",
+  "hash": "01573a6c427359e09cb0bd6d3b119b57930b2ed9a1820f39b93364b424b96394",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 571,
-  "hash": "02453979be2770d557f2e9feeaf1ebeefa5a14ca27fea1d289c2a31bc20d0281",
+  "hash": "a5f1eb0f84867079fb65eed4233073fc2eaa6ac7ac5323e79070ab2c9eb10ed6",
   "schema": 1,
   "source": "frontend/"
 }

--- a/deploy/docker-compose.e2e.override.yml
+++ b/deploy/docker-compose.e2e.override.yml
@@ -1,0 +1,8 @@
+# Ephemeral override for local Playwright e2e — publish DB/Redis to host (non-default ports).
+services:
+  postgres:
+    ports:
+      - "127.0.0.1:5433:5432"
+  redis:
+    ports:
+      - "127.0.0.1:6380:6379"

--- a/frontend/e2e/catalog-ux.e2e.ts
+++ b/frontend/e2e/catalog-ux.e2e.ts
@@ -1,0 +1,95 @@
+import { test, expect, type Page } from '@playwright/test'
+
+const EMAIL = process.env.E2E_EMAIL || 'admin@sub2api.local'
+const PASS = process.env.E2E_PASSWORD || 'Admin12345!'
+
+type PublicModel = {
+  model_id: string
+  pricing?: { billing_mode?: string }
+}
+
+async function login(page: Page): Promise<void> {
+  await page.goto('/login')
+  await page.locator('input[type=email]').first().fill(EMAIL)
+  await page.locator('input[type=password]').first().fill(PASS)
+  await page.locator('button[type=submit]').first().click()
+  await page.waitForURL((u) => !u.pathname.includes('/login'), { timeout: 30_000 })
+}
+
+async function publicCatalogCounts(baseURL: string): Promise<{ all: number; image: number; video: number }> {
+  const res = await fetch(`${baseURL}/api/v1/public/pricing`)
+  if (!res.ok) return { all: 0, image: 0, video: 0 }
+  const body = (await res.json()) as { data?: PublicModel[] }
+  const models = body.data ?? []
+  return {
+    all: models.length,
+    image: models.filter((m) => m.pricing?.billing_mode === 'image').length,
+    video: models.filter((m) => m.pricing?.billing_mode === 'video').length,
+  }
+}
+
+test.describe('catalog UX — models / pricing / quickstart', () => {
+  test('model marketplace media tabs match public billing_mode inventory', async ({ page, baseURL }) => {
+    const counts = await publicCatalogCounts(baseURL!)
+    test.skip(counts.all === 0, 'public catalog empty in this environment')
+
+    await page.goto('/models')
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+
+    const grid = page.locator('[data-tk="models-marketplace-grid"]')
+    await expect(grid).toBeVisible({ timeout: 20_000 })
+    const allCards = grid.locator('[data-tk^="models-marketplace-card-"]')
+    await expect(allCards.first()).toBeVisible()
+
+    if (counts.image > 0) {
+      await page.locator('[data-tk="models-marketplace-tab-image"]').click()
+      await expect(page.locator('[data-tk="models-marketplace-empty"]')).toHaveCount(0)
+      await expect(page.locator('[data-tk^="models-marketplace-card-"]').first()).toBeVisible()
+    }
+
+    if (counts.video > 0) {
+      await page.locator('[data-tk="models-marketplace-tab-video"]').click()
+      await expect(page.locator('[data-tk="models-marketplace-empty"]')).toHaveCount(0)
+      await expect(page.locator('[data-tk^="models-marketplace-card-"]').first()).toBeVisible()
+    }
+  })
+
+  test('pricing authorized-groups quick start lands on quickstart with model prefilled', async ({ page, baseURL }) => {
+    const counts = await publicCatalogCounts(baseURL!)
+    test.skip(counts.all === 0, 'public catalog empty in this environment')
+
+    await login(page)
+
+    const res = await fetch(`${baseURL}/api/v1/public/pricing`, {
+      headers: { Authorization: `Bearer ${await page.evaluate(() => localStorage.getItem('auth_token'))}` },
+    })
+    const body = (await res.json()) as { data?: PublicModel[] }
+    const sample = body.data?.find((m) => m.model_id) ?? body.data?.[0]
+    test.skip(!sample?.model_id, 'no sample model in catalog')
+
+    const modelId = sample.model_id
+    await page.goto(`/pricing?model=${encodeURIComponent(modelId)}`)
+    await expect(page.locator('#pricing-model-search')).toHaveValue(modelId, { timeout: 20_000 })
+
+    const quickstart = page.locator('[data-tk="pricing-quickstart-for-model"]').first()
+    await expect(quickstart).toBeVisible({ timeout: 20_000 })
+    await quickstart.click()
+
+    await page.waitForURL((u) => u.pathname === '/quickstart' && u.searchParams.get('model') === modelId, {
+      timeout: 20_000,
+    })
+
+    await expect(page.locator('[data-tk="use-key-models-empty"]')).toHaveCount(0)
+    await expect(page.locator('[data-tk="use-key-model-select"]')).toHaveValue(modelId)
+  })
+
+  test('quickstart universal key does not show empty servable-models warning', async ({ page, baseURL }) => {
+    const counts = await publicCatalogCounts(baseURL!)
+    test.skip(counts.all === 0, 'public catalog empty in this environment')
+
+    await login(page)
+    await page.goto('/quickstart')
+    await expect(page.locator('[data-tk="use-key-model-select"]')).toBeVisible({ timeout: 30_000 })
+    await expect(page.locator('[data-tk="use-key-models-empty"]')).toHaveCount(0)
+  })
+})

--- a/frontend/src/components/keys/UseKeyGuide.vue
+++ b/frontend/src/components/keys/UseKeyGuide.vue
@@ -225,6 +225,8 @@ interface Props {
   routingMode?: KeyRoutingMode
   /** The api key's numeric id — used to load its live servable model menu. */
   apiKeyId?: number | null
+  /** Deep-link model id (e.g. from /pricing authorized-groups quick start). */
+  initialModel?: string | null
   /** anthropic group gated to claude-cli / /v1/messages only (group.claude_code_only). */
   claudeCodeOnly?: boolean
   allowMessagesDispatch?: boolean
@@ -312,18 +314,23 @@ const tk = useTkUseKey({
   apiKeyId: toRef(props, 'apiKeyId'),
   apiKey: toRef(props, 'apiKey'),
   platform: toRef(props, 'platform'),
+  routingMode: toRef(props, 'routingMode'),
   claudeCodeOnly: toRef(props, 'claudeCodeOnly'),
   baseRoot,
 })
 
 // (Re)load the live servable model menu whenever the key changes.
 watch(
-  () => props.apiKeyId,
-  (id) => {
+  () => [props.apiKeyId, props.initialModel] as const,
+  async ([id, initialModel]) => {
     if (id == null) return
     keyRevealed.value = false
     tk.testState.value = { status: 'idle' }
-    void tk.loadModels()
+    await tk.loadModels()
+    const flavor = tk.applyInitialModel(initialModel)
+    if (flavor === 'anthropic') activeClientTab.value = 'claude'
+    else if (flavor === 'gemini') activeClientTab.value = 'gemini'
+    else if (flavor === 'openai') activeClientTab.value = 'codex'
   },
   { immediate: true },
 )

--- a/frontend/src/components/keys/UseKeyGuide.vue
+++ b/frontend/src/components/keys/UseKeyGuide.vue
@@ -36,6 +36,7 @@
           <div v-if="activeFlavor" class="flex items-center gap-3 flex-wrap">
             <label class="w-14 text-sm font-medium text-gray-700 dark:text-gray-300 shrink-0">{{ t('keys.useKeyModal.modelLabel') }}</label>
             <select
+              data-tk="use-key-model-select"
               :value="selectedModel"
               @change="onPickModel"
               :disabled="tkModelsLoading || !pickerModels.length"
@@ -54,7 +55,11 @@
             </div>
           </div>
           <p v-if="activeFlavor && tkModelsLoading" class="text-xs text-gray-400 pl-[4.25rem]">{{ t('keys.useKeyModal.modelsLoading') }}</p>
-          <p v-else-if="activeFlavor && !pickerModels.length" class="text-xs text-amber-600 dark:text-amber-400 pl-[4.25rem]">{{ t('keys.useKeyModal.modelsEmpty') }}</p>
+          <p
+            v-else-if="activeFlavor && showModelsCatalogEmpty"
+            data-tk="use-key-models-empty"
+            class="text-xs text-amber-600 dark:text-amber-400 pl-[4.25rem]"
+          >{{ t('keys.useKeyModal.modelsEmpty') }}</p>
 
           <!-- Base URL (locked, read-only) -->
           <div class="flex items-center gap-3">
@@ -338,6 +343,9 @@ watch(
 // Models offered in the picker for the current flavor.
 const pickerModels = computed(() => (activeFlavor.value ? tk.modelsForFlavor(activeFlavor.value) : []))
 const selectedModel = computed(() => (activeFlavor.value ? tk.effectiveModel(activeFlavor.value) : ''))
+const showModelsCatalogEmpty = computed(() =>
+  activeFlavor.value ? tk.shouldWarnModelsEmpty(activeFlavor.value) : false,
+)
 const currentModelMeta = computed(() =>
   pickerModels.value.find((m) => m.id === selectedModel.value),
 )

--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -11,6 +11,7 @@
       :base-url="baseUrl"
       :platform="platform"
       :routing-mode="routingMode"
+      :initial-model="initialModel"
       :claude-code-only="claudeCodeOnly"
       :allow-messages-dispatch="allowMessagesDispatch"
       :supported-model-scopes="supportedModelScopes"
@@ -41,6 +42,7 @@ interface Props {
   baseUrl: string
   platform: GroupPlatform | null
   apiKeyId?: number | null
+  initialModel?: string | null
   routingMode?: KeyRoutingMode
   claudeCodeOnly?: boolean
   allowMessagesDispatch?: boolean

--- a/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
+++ b/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
@@ -17,8 +17,12 @@ vi.mock('@/composables/useClipboard', () => ({
 // Mocking the catalog API also severs the real api/client → i18n import chain,
 // keeping the partial vue-i18n mock above sufficient.
 const getMePricingCatalog = vi.fn()
+const getPublicPricing = vi.fn()
 vi.mock('@/api/me-pricing', () => ({
   getMePricingCatalog: (...args: unknown[]) => getMePricingCatalog(...args)
+}))
+vi.mock('@/api/pricing', () => ({
+  getPublicPricing: (...args: unknown[]) => getPublicPricing(...args)
 }))
 
 import UseKeyModal from '../UseKeyModal.vue'
@@ -37,7 +41,9 @@ function mountModal(props: Record<string, unknown>) {
 
 beforeEach(() => {
   getMePricingCatalog.mockReset()
+  getPublicPricing.mockReset()
   getMePricingCatalog.mockResolvedValue({ models: [] })
+  getPublicPricing.mockResolvedValue({ data: [] })
 })
 
 describe('UseKeyModal — preserved snippet correctness', () => {
@@ -234,5 +240,36 @@ describe('UseKeyModal — universal keys', () => {
     expect(wrapper.text()).not.toContain('keys.useKeyModal.noGroupTitle')
     expect(wrapper.text()).toContain('keys.useKeyModal.cliTabs.claudeCode')
     expect(wrapper.text()).toContain('keys.useKeyModal.cliTabs.codexCli')
+  })
+
+  it('loads cross-group model menu via entitlement index instead of per-key catalog', async () => {
+    getMePricingCatalog.mockResolvedValue({
+      authorized_groups_by_model: {
+        'claude-opus-4-8': [{ id: 1, name: 'anthropic' }],
+      },
+      models: [],
+    })
+    getPublicPricing.mockResolvedValue({
+      data: [
+        {
+          model_id: 'claude-opus-4-8',
+          capabilities: ['thinking'],
+          context_window: 200000,
+        },
+      ],
+    })
+
+    const wrapper = mountModal({
+      platform: null,
+      routingMode: 'universal',
+      apiKeyId: 42,
+    })
+    await flushPromises()
+
+    expect(getMePricingCatalog).toHaveBeenCalledWith()
+    expect(getMePricingCatalog).not.toHaveBeenCalledWith(expect.objectContaining({ apiKeyId: 42 }))
+    expect(getPublicPricing).toHaveBeenCalled()
+    expect(wrapper.text()).not.toContain('keys.useKeyModal.modelsEmpty')
+    expect(wrapper.find('select').findAll('option').some((o) => o.text().includes('claude-opus-4-8'))).toBe(true)
   })
 })

--- a/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
+++ b/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
@@ -272,4 +272,20 @@ describe('UseKeyModal — universal keys', () => {
     expect(wrapper.text()).not.toContain('keys.useKeyModal.modelsEmpty')
     expect(wrapper.find('select').findAll('option').some((o) => o.text().includes('claude-opus-4-8'))).toBe(true)
   })
+
+  it('hides modelsEmpty warning when initialModel is deep-linked', async () => {
+    getMePricingCatalog.mockResolvedValue({ authorized_groups_by_model: {}, models: [] })
+    getPublicPricing.mockResolvedValue({ data: [] })
+
+    const wrapper = mountModal({
+      platform: null,
+      routingMode: 'universal',
+      apiKeyId: 42,
+      initialModel: 'claude-haiku-4-5',
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('keys.useKeyModal.modelsEmpty')
+    expect(wrapper.find('[data-tk="use-key-model-select"]').exists()).toBe(true)
+  })
 })

--- a/frontend/src/composables/useTkUseKey.ts
+++ b/frontend/src/composables/useTkUseKey.ts
@@ -23,8 +23,10 @@
 
 import { computed, ref, type Ref } from 'vue'
 import { getMePricingCatalog, type MePricingModel } from '@/api/me-pricing'
-import type { GroupPlatform } from '@/types'
+import { getPublicPricing } from '@/api/pricing'
+import type { GroupPlatform, KeyRoutingMode } from '@/types'
 import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_GEMINI } from '@/constants/gatewayPlatforms'
+import { servableModelsFromUniversalEntitlement } from '@/utils/studioUniversalKey.tk'
 
 /**
  * A snippet "flavor" is the single-model protocol a given client tab speaks.
@@ -104,10 +106,20 @@ interface UseTkUseKeyArgs {
   apiKeyId: Ref<number | null | undefined>
   apiKey: Ref<string>
   platform: Ref<GroupPlatform | null>
+  routingMode?: Ref<KeyRoutingMode | undefined>
   /** anthropic groups gated to claude-cli / /v1/messages only */
   claudeCodeOnly: Ref<boolean | undefined>
   /** stripped gateway root, e.g. https://api.tokenkey.dev (no /v1) */
   baseRoot: Ref<string>
+}
+
+function mapMePricingModels(models: MePricingModel[]): UseKeyServableModel[] {
+  return models.map((m) => ({
+    id: m.model_id,
+    capabilities: m.capabilities ?? [],
+    contextWindow: m.context_window,
+    maxOutput: m.max_output_tokens,
+  }))
 }
 
 export function useTkUseKey(args: UseTkUseKeyArgs) {
@@ -129,13 +141,13 @@ export function useTkUseKey(args: UseTkUseKeyArgs) {
     if (id == null) return
     modelsLoading.value = true
     try {
-      const res = await getMePricingCatalog({ apiKeyId: id })
-      servableModels.value = (res.models ?? []).map((m: MePricingModel) => ({
-        id: m.model_id,
-        capabilities: m.capabilities ?? [],
-        contextWindow: m.context_window,
-        maxOutput: m.max_output_tokens,
-      }))
+      if (args.routingMode?.value === 'universal') {
+        const [meCatalog, publicCatalog] = await Promise.all([getMePricingCatalog(), getPublicPricing()])
+        servableModels.value = servableModelsFromUniversalEntitlement(meCatalog, publicCatalog.data ?? [])
+      } else {
+        const res = await getMePricingCatalog({ apiKeyId: id })
+        servableModels.value = mapMePricingModels(res.models ?? [])
+      }
     } catch {
       // Load failure leaves servableModels empty; the modal then shows its
       // "couldn't load — type manually" hint and snippets use the fallback id.
@@ -162,6 +174,15 @@ export function useTkUseKey(args: UseTkUseKeyArgs) {
     selectedByFlavor.value = { ...selectedByFlavor.value, [flavor]: id }
     // a fresh model choice invalidates a prior test verdict
     if (testState.value.status !== 'idle') testState.value = { status: 'idle' }
+  }
+
+  /** Pre-select a model from a deep link (e.g. /pricing → /quickstart?model=). */
+  function applyInitialModel(modelId: string | null | undefined): UseKeyFlavor | null {
+    const id = modelId?.trim()
+    if (!id) return null
+    const flavor = flavorOfModel(id)
+    setModel(flavor, id)
+    return flavor
   }
 
   const isClaudeCodeOnly = computed(
@@ -263,6 +284,7 @@ export function useTkUseKey(args: UseTkUseKeyArgs) {
     modelsForFlavor,
     effectiveModel,
     setModel,
+    applyInitialModel,
     runTest,
   }
 }

--- a/frontend/src/composables/useTkUseKey.ts
+++ b/frontend/src/composables/useTkUseKey.ts
@@ -185,6 +185,11 @@ export function useTkUseKey(args: UseTkUseKeyArgs) {
     return flavor
   }
 
+  function shouldWarnModelsEmpty(flavor: UseKeyFlavor): boolean {
+    if (selectedByFlavor.value[flavor]) return false
+    return modelsForFlavor(flavor).length === 0
+  }
+
   const isClaudeCodeOnly = computed(
     () => args.platform.value === PLATFORM_ANTHROPIC && args.claudeCodeOnly.value === true,
   )
@@ -285,6 +290,7 @@ export function useTkUseKey(args: UseTkUseKeyArgs) {
     effectiveModel,
     setModel,
     applyInitialModel,
+    shouldWarnModelsEmpty,
     runTest,
   }
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -97,8 +97,9 @@ export default {
         authorizedGroups: 'Authorized Groups'
       },
       authorizedGroups: {
-        createKeyHint: 'Create an API key in {group}',
-        exclusive: 'exclusive'
+        groupHint: '{group} can serve this model',
+        exclusive: 'exclusive',
+        quickstart: 'Quick start',
       },
       empty: {
         noAccess: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -95,8 +95,9 @@ export default {
         authorizedGroups: '授权分组'
       },
       authorizedGroups: {
-        createKeyHint: '在 {group} 创建 API Key',
-        exclusive: '专属'
+        groupHint: '{group} 可服务此模型',
+        exclusive: '专属',
+        quickstart: '快速开始',
       },
       empty: {
         noAccess: {

--- a/frontend/src/utils/__tests__/studioUniversalKey.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioUniversalKey.tk.spec.ts
@@ -3,6 +3,7 @@ import {
   entitledModelIds,
   isUniversalKey,
   priceMapFromPublicCatalog,
+  servableModelsFromUniversalEntitlement,
 } from '../studioUniversalKey.tk'
 import type { ApiKey } from '@/types'
 
@@ -41,5 +42,30 @@ describe('studioUniversalKey', () => {
     expect(map.get('veo-3.1-generate-001')?.perSecond).toBe(0.6)
     expect(map.get('veo-3.1-generate-001')?.billingMode).toBe('video')
     expect(map.has('gpt-4o')).toBe(false)
+  })
+
+  it('builds servable models from entitlement index and public catalog metadata', () => {
+    const models = servableModelsFromUniversalEntitlement(
+      {
+        authorized_groups_by_model: {
+          'claude-opus-4-8': [{ id: 1, name: 'anthropic' }],
+          'gpt-5.5': [{ id: 2, name: 'openai' }],
+          'orphan-model': [{ id: 3, name: 'newapi' }],
+        },
+      } as never,
+      [
+        {
+          model_id: 'claude-opus-4-8',
+          capabilities: ['thinking'],
+          context_window: 200000,
+          max_output_tokens: 32000,
+        },
+        { model_id: 'gpt-5.5', capabilities: ['tools'], context_window: 128000 },
+      ] as never
+    )
+    expect(models.map((m) => m.id)).toEqual(['claude-opus-4-8', 'gpt-5.5', 'orphan-model'])
+    expect(models[0]?.capabilities).toEqual(['thinking'])
+    expect(models[0]?.contextWindow).toBe(200000)
+    expect(models[2]?.capabilities).toEqual([])
   })
 })

--- a/frontend/src/utils/studioUniversalKey.tk.ts
+++ b/frontend/src/utils/studioUniversalKey.tk.ts
@@ -1,12 +1,13 @@
 /**
- * TokenKey-only: helpers for Universal (全能) API keys in the Studio.
+ * TokenKey-only: helpers for Universal (全能) API keys in Studio / Use Key guide.
  *
  * Per-request routing (video/image/chat) works on universal keys — the gap is
- * Studio discovery: GET /v1/models skips universal resolution (metadata endpoint)
+ * discovery UIs: GET /v1/models skips universal resolution (metadata endpoint)
  * and me/pricing-catalog rejects api_key_id when group_id IS NULL.
  */
 import type { ApiKey } from '@/types'
 import type { MePricingCatalogResponse } from '@/api/me-pricing'
+import type { PublicCatalogModel } from '@/api/pricing'
 
 export {
   buildCatalogBillingIndex,
@@ -26,4 +27,37 @@ export function entitledModelIds(catalog: MePricingCatalogResponse | null): Set<
   const idx = catalog?.authorized_groups_by_model
   if (!idx) return new Set()
   return new Set(Object.keys(idx))
+}
+
+export interface UniversalServableModel {
+  id: string
+  capabilities: string[]
+  contextWindow?: number
+  maxOutput?: number
+}
+
+/** Build a live servable menu for universal keys: entitlement index ∩ public catalog metadata. */
+export function servableModelsFromUniversalEntitlement(
+  meCatalog: MePricingCatalogResponse | null,
+  publicModels: readonly Pick<
+    PublicCatalogModel,
+    'model_id' | 'capabilities' | 'context_window' | 'max_output_tokens'
+  >[],
+): UniversalServableModel[] {
+  const entitled = entitledModelIds(meCatalog)
+  if (entitled.size === 0) return []
+
+  const byId = new Map(publicModels.map((m) => [m.model_id, m]))
+  const out: UniversalServableModel[] = []
+  for (const id of entitled) {
+    const pub = byId.get(id)
+    out.push({
+      id,
+      capabilities: pub?.capabilities ?? [],
+      contextWindow: pub?.context_window,
+      maxOutput: pub?.max_output_tokens,
+    })
+  }
+  out.sort((a, b) => a.id.localeCompare(b.id))
+  return out
 }

--- a/frontend/src/views/ModelMarketplaceView.vue
+++ b/frontend/src/views/ModelMarketplaceView.vue
@@ -244,19 +244,26 @@ const categoryFilters = computed(() => [
   { key: 'video', label: t('models.filterVideo') },
 ])
 
-// Filter by category (capability-based)
+type MarketplaceCategory = 'text' | 'image' | 'video'
+
+/** Align with PricingView + public catalog: media rows use pricing.billing_mode, not capabilities. */
+function modelListingCategory(m: PublicCatalogModel): MarketplaceCategory {
+  const mode = m.pricing?.billing_mode
+  if (mode === 'image') return 'image'
+  if (mode === 'video') return 'video'
+  return 'text'
+}
+
+// Filter by category (billing_mode-driven — same truth as /pricing modality tabs)
 const filteredByCategory = computed(() => {
   if (activeCategory.value === 'all') return models.value
   if (activeCategory.value === 'image') {
-    return models.value.filter(m => m.capabilities.includes('image_generation'))
+    return models.value.filter((m) => modelListingCategory(m) === 'image')
   }
   if (activeCategory.value === 'video') {
-    return models.value.filter(m => m.capabilities.includes('video_generation'))
+    return models.value.filter((m) => modelListingCategory(m) === 'video')
   }
-  // text: exclude image/video-only models
-  return models.value.filter(m =>
-    !m.capabilities.includes('image_generation') && !m.capabilities.includes('video_generation')
-  )
+  return models.value.filter((m) => modelListingCategory(m) === 'text')
 })
 
 // Vendor list derived from category-filtered models

--- a/frontend/src/views/ModelMarketplaceView.vue
+++ b/frontend/src/views/ModelMarketplaceView.vue
@@ -55,6 +55,7 @@
             <button
               v-for="filter in categoryFilters"
               :key="filter.key"
+              :data-tk="`models-marketplace-tab-${filter.key}`"
               @click="activeCategory = filter.key"
               class="rounded-full px-4 py-1.5 text-sm font-medium transition-all"
               :class="
@@ -145,15 +146,16 @@
             </div>
 
             <!-- Empty -->
-            <div v-else-if="filteredModels.length === 0" class="py-20 text-center">
+            <div v-else-if="filteredModels.length === 0" data-tk="models-marketplace-empty" class="py-20 text-center">
               <p class="text-gray-500 dark:text-dark-400">{{ t('models.noModels') }}</p>
             </div>
 
             <!-- Grid -->
-            <div v-else class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <div v-else class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3" data-tk="models-marketplace-grid">
               <router-link
                 v-for="model in filteredModels"
                 :key="model.model_id"
+                :data-tk="`models-marketplace-card-${model.model_id}`"
                 :to="{ path: '/pricing', query: { model: model.model_id } }"
                 class="group rounded-xl border border-gray-200/60 bg-white p-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary-300 hover:shadow-lg hover:shadow-primary-500/10 dark:border-dark-700/60 dark:bg-dark-800 dark:hover:border-primary-700"
               >
@@ -244,19 +246,26 @@ const categoryFilters = computed(() => [
   { key: 'video', label: t('models.filterVideo') },
 ])
 
-// Filter by category (capability-based)
+type MarketplaceCategory = 'text' | 'image' | 'video'
+
+/** Align with PricingView + public catalog: media rows use pricing.billing_mode, not capabilities. */
+function modelListingCategory(m: PublicCatalogModel): MarketplaceCategory {
+  const mode = m.pricing?.billing_mode
+  if (mode === 'image') return 'image'
+  if (mode === 'video') return 'video'
+  return 'text'
+}
+
+// Filter by category (billing_mode-driven — same truth as /pricing modality tabs)
 const filteredByCategory = computed(() => {
   if (activeCategory.value === 'all') return models.value
   if (activeCategory.value === 'image') {
-    return models.value.filter(m => m.capabilities.includes('image_generation'))
+    return models.value.filter((m) => modelListingCategory(m) === 'image')
   }
   if (activeCategory.value === 'video') {
-    return models.value.filter(m => m.capabilities.includes('video_generation'))
+    return models.value.filter((m) => modelListingCategory(m) === 'video')
   }
-  // text: exclude image/video-only models
-  return models.value.filter(m =>
-    !m.capabilities.includes('image_generation') && !m.capabilities.includes('video_generation')
-  )
+  return models.value.filter((m) => modelListingCategory(m) === 'text')
 })
 
 // Vendor list derived from category-filtered models

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -471,25 +471,35 @@
                       data-tk="pricing-col-authorized-groups"
                       class="px-3 py-3 align-top"
                     >
-                      <div class="flex flex-wrap gap-1.5">
+                      <div class="flex flex-col gap-1.5">
+                        <div v-if="row.authorizedGroups?.length" class="flex flex-wrap gap-1.5">
+                          <span
+                            v-for="g in row.authorizedGroups"
+                            :key="g.id"
+                            :title="t('pricing.my.authorizedGroups.groupHint', { group: g.name })"
+                            class="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium"
+                            :class="[
+                              g.is_exclusive
+                                ? 'border-primary-200 bg-primary-50 text-primary-700 dark:border-primary-700/50 dark:bg-primary-900/30 dark:text-primary-200'
+                                : 'border-gray-200 bg-gray-50 text-gray-600 dark:border-dark-700 dark:bg-dark-800/60 dark:text-dark-300',
+                              g.is_current_for_key ? 'ring-1 ring-primary-400/60' : ''
+                            ]"
+                          >
+                            <span>{{ g.name }}</span>
+                            <span v-if="g.is_exclusive" class="text-[10px] opacity-70">{{
+                              t('pricing.my.authorizedGroups.exclusive')
+                            }}</span>
+                          </span>
+                        </div>
                         <button
-                          v-for="g in row.authorizedGroups || []"
-                          :key="g.id"
+                          v-if="row.authorizedGroups?.length"
                           type="button"
-                          :title="t('pricing.my.authorizedGroups.createKeyHint', { group: g.name })"
-                          class="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium transition-colors"
-                          :class="[
-                            g.is_exclusive
-                              ? 'border-primary-200 bg-primary-50 text-primary-700 hover:bg-primary-100 dark:border-primary-700/50 dark:bg-primary-900/30 dark:text-primary-200 dark:hover:bg-primary-900/50'
-                              : 'border-gray-200 bg-gray-50 text-gray-600 hover:bg-gray-100 dark:border-dark-700 dark:bg-dark-800/60 dark:text-dark-300 dark:hover:bg-dark-700',
-                            g.is_current_for_key ? 'ring-1 ring-primary-400/60' : ''
-                          ]"
-                          @click="onCreateKeyForGroup(g)"
+                          data-tk="pricing-quickstart-for-model"
+                          class="inline-flex w-fit items-center gap-1 text-xs font-medium text-primary-600 hover:text-primary-700 hover:underline dark:text-primary-400 dark:hover:text-primary-300"
+                          @click="onQuickstartForModel(row.model_id)"
                         >
-                          <span>{{ g.name }}</span>
-                          <span v-if="g.is_exclusive" class="text-[10px] opacity-70">{{
-                            t('pricing.my.authorizedGroups.exclusive')
-                          }}</span>
+                          {{ t('pricing.my.authorizedGroups.quickstart') }}
+                          <Icon name="arrowRight" size="xs" class="opacity-70" />
                         </button>
                         <span
                           v-if="!row.authorizedGroups || row.authorizedGroups.length === 0"
@@ -565,10 +575,9 @@ const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 
-// 「授权分组」badge 点击：跳到 Keys 页并自动打开「创建密钥」面板、预置该分组。
-// 用路由 name（'Keys'）而非硬编码路径，避免 path 漂移。
-function onCreateKeyForGroup(g: MePricingModelGroup): void {
-  void router.push({ name: 'Keys', query: { create: '1', group_id: String(g.id) } })
+// 「授权分组」列：分组 badge 仅作信息展示；单一「快速开始」入口跳到 /quickstart 并预填模型。
+function onQuickstartForModel(modelId: string): void {
+  void router.push({ path: '/quickstart', query: { model: modelId } })
 }
 const authStore = useAuthStore()
 const appStore = useAppStore()

--- a/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
+++ b/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
@@ -55,17 +55,18 @@ function catalog(models: PublicCatalogModel[]): PublicCatalogResponse {
 function model(
   model_id: string,
   vendor: string,
-  capabilities: string[] = []
+  overrides: Partial<PublicCatalogModel> = {}
 ): PublicCatalogModel {
   return {
     model_id,
     vendor,
-    capabilities,
+    capabilities: [],
     pricing: {
       currency: 'USD',
       input_per_1k_tokens: 0.001,
       output_per_1k_tokens: 0.002,
     },
+    ...overrides,
   }
 }
 
@@ -85,29 +86,58 @@ describe('ModelMarketplaceView', () => {
     authState.isAuthenticated = false
   })
 
-  it('renders image models when image filter is selected', async () => {
+  it('filters image models by pricing.billing_mode, not capabilities tags', async () => {
     getPublicPricing.mockResolvedValue(
       catalog([
         model('gpt-4o-mini', 'OpenAI'),
-        model('imagen-4.0-generate-001', 'Google', ['image_generation']),
+        model('imagen-4.0-generate-001', 'Google', {
+          pricing: {
+            currency: 'USD',
+            billing_mode: 'image',
+            input_per_1k_tokens: 0,
+            output_per_1k_tokens: 0,
+            output_cost_per_image: 0.04,
+          },
+        }),
       ])
     )
 
     const wrapper = mountMarketplace()
     await flushPromises()
 
-    expect(wrapper.text()).toContain('gpt-4o-mini')
-    expect(wrapper.text()).toContain('imagen-4.0-generate-001')
-
-    const imageBtn = wrapper
-      .findAll('button')
-      .find((b) => b.text().includes('Image'))
+    const imageBtn = wrapper.findAll('button').find((b) => b.text().includes('Image'))
     expect(imageBtn).toBeTruthy()
     await imageBtn!.trigger('click')
 
     expect(wrapper.text()).toContain('imagen-4.0-generate-001')
     expect(wrapper.text()).not.toContain('gpt-4o-mini')
-    expect(wrapper.text()).toContain('Image generation')
+  })
+
+  it('filters video models by pricing.billing_mode', async () => {
+    getPublicPricing.mockResolvedValue(
+      catalog([
+        model('gpt-4o-mini', 'OpenAI'),
+        model('veo-3.1-generate-preview', 'Google', {
+          pricing: {
+            currency: 'USD',
+            billing_mode: 'video',
+            input_per_1k_tokens: 0,
+            output_per_1k_tokens: 0,
+            output_cost_per_second: 0.5,
+          },
+        }),
+      ])
+    )
+
+    const wrapper = mountMarketplace()
+    await flushPromises()
+
+    const videoBtn = wrapper.findAll('button').find((b) => b.text().includes('Video'))
+    expect(videoBtn).toBeTruthy()
+    await videoBtn!.trigger('click')
+
+    expect(wrapper.text()).toContain('veo-3.1-generate-preview')
+    expect(wrapper.text()).not.toContain('gpt-4o-mini')
   })
 
   it('shows empty state when search matches no models', async () => {

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -5,7 +5,7 @@ import PricingView from '../PricingView.vue'
 import type { PublicCatalogResponse } from '@/api/pricing'
 import type { MePricingCatalogResponse } from '@/api/me-pricing'
 
-const { getPublicPricing, getMePricingCatalog, authState, exportPricingCsv, showSuccess, showError, routeState } =
+const { getPublicPricing, getMePricingCatalog, authState, exportPricingCsv, showSuccess, showError, routeState, routerPush } =
   vi.hoisted(() => ({
     getPublicPricing: vi.fn(),
     getMePricingCatalog: vi.fn(),
@@ -14,6 +14,7 @@ const { getPublicPricing, getMePricingCatalog, authState, exportPricingCsv, show
     showSuccess: vi.fn(),
     showError: vi.fn(),
     routeState: { query: {} as Record<string, string | string[] | undefined> },
+    routerPush: vi.fn(),
   }))
 
 vi.mock('@/api/pricing', () => ({
@@ -49,7 +50,7 @@ vi.mock('@/stores/app', () => ({
 
 vi.mock('vue-router', () => ({
   useRoute: () => routeState,
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: routerPush }),
 }))
 
 vi.mock('vue-i18n', async () => {
@@ -118,8 +119,9 @@ vi.mock('vue-i18n', async () => {
     'pricing.export.success': 'Pricing exported',
     'pricing.export.empty': 'Public catalog is empty — nothing to export',
     'pricing.my.columns.authorizedGroups': 'Authorized Groups',
-    'pricing.my.authorizedGroups.createKeyHint': 'Create a key in {group}',
+    'pricing.my.authorizedGroups.groupHint': '{group} can serve this model',
     'pricing.my.authorizedGroups.exclusive': 'exclusive',
+    'pricing.my.authorizedGroups.quickstart': 'Quick start',
   }
   return {
     ...actual,
@@ -237,6 +239,7 @@ describe('PricingView', () => {
     exportPricingCsv.mockReset()
     showSuccess.mockReset()
     showError.mockReset()
+    routerPush.mockReset()
     localStorage.clear()
     authState.isAuthenticated = false
     authState.isAdmin = false
@@ -485,6 +488,40 @@ describe('PricingView', () => {
     expect(wrapper.text()).toContain('Batch')
     expect(wrapper.text()).toContain('exclusive')
     expect(wrapper.find('[data-tk="pricing-col-authorized-groups"]').exists()).toBe(true)
+  })
+
+  it('navigates to quickstart with model when authorized-groups quick start is clicked', async () => {
+    authState.isAuthenticated = true
+    localStorage.setItem('auth_token', 'token')
+    getMePricingCatalog.mockResolvedValue(
+      meCatalog({
+        authorized_groups_by_model: {
+          'claude-haiku-4-5': [
+            {
+              id: 10,
+              name: 'claude',
+              platform: 'anthropic',
+              is_exclusive: true,
+              is_current_for_key: true,
+              rate_multiplier: 1,
+            },
+          ],
+        },
+      })
+    )
+    getPublicPricing.mockResolvedValue(publicCatalog([publicModel('claude-haiku-4-5')]))
+
+    const wrapper = mountPricingView()
+    await flushPromises()
+
+    await wrapper.get('[data-tk="pricing-filter-group"]').setValue('public')
+    await flushPromises()
+
+    await wrapper.get('[data-tk="pricing-quickstart-for-model"]').trigger('click')
+    expect(routerPush).toHaveBeenCalledWith({
+      path: '/quickstart',
+      query: { model: 'claude-haiku-4-5' },
+    })
   })
 
   it('labels exclusive groups in the group filter while viewing the public catalog', async () => {

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -1990,9 +1990,7 @@ function formatResetTime(resetAt: string | null): string {
   return `${mins}m`
 }
 
-// Deep-link from the /pricing「授权分组」column: ?create=1&group_id=N opens the
-// create-key dialog with that group preselected. Runs after groups load so the
-// group_id is validated against the user's accessible set before binding.
+// Deep-link: ?create=1&group_id=N opens the create-key dialog with that group preselected.
 function applyCreateKeyFromQuery(): void {
   if (route.query.create !== '1') return
   const gid = Number(route.query.group_id)

--- a/frontend/src/views/user/QuickstartView.vue
+++ b/frontend/src/views/user/QuickstartView.vue
@@ -27,6 +27,7 @@
               </label>
               <select
                 v-model="selectedKeyId"
+                data-tk="quickstart-key-select"
                 class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-dark-600 dark:bg-dark-900 dark:text-gray-100"
               >
                 <option v-for="k in keys" :key="k.id" :value="k.id">

--- a/frontend/src/views/user/QuickstartView.vue
+++ b/frontend/src/views/user/QuickstartView.vue
@@ -63,6 +63,7 @@
             :base-url="baseUrl"
             :platform="selectedKey.group?.platform ?? null"
             :routing-mode="selectedKey.routing_mode"
+            :initial-model="initialModelFromQuery"
             :claude-code-only="selectedKey.group?.claude_code_only || false"
             :allow-messages-dispatch="selectedKey.group?.allow_messages_dispatch || false"
             :supported-model-scopes="selectedKey.group?.supported_model_scopes"
@@ -86,6 +87,7 @@ import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import * as keysAPI from '@/api/keys'
 import type { ApiKey } from '@/types'
+import { isUniversalKey } from '@/utils/studioUniversalKey.tk'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import GroupBadge from '@/components/common/GroupBadge.vue'
@@ -123,6 +125,28 @@ function parseKeyIdFromQuery(): number | null {
   return Number.isFinite(id) ? id : null
 }
 
+function parseModelFromQuery(): string | null {
+  const raw = route.query.model
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (!value) return null
+  const model = String(value).trim()
+  return model || null
+}
+
+const initialModelFromQuery = computed(() => parseModelFromQuery())
+
+function pickDefaultKeyId(items: ApiKey[]): number | null {
+  if (!items.length) return null
+  const fromQuery = parseKeyIdFromQuery()
+  if (fromQuery != null && items.some((k) => k.id === fromQuery)) return fromQuery
+  if (parseModelFromQuery()) {
+    const universal = items.find(isUniversalKey)
+    if (universal) return universal.id
+  }
+  const trial = items.find((k) => k.name?.toLowerCase() === 'trial')
+  return (trial || items[0])?.id ?? null
+}
+
 watch(selectedKeyId, (id) => {
   if (id == null) return
   const current = parseKeyIdFromQuery()
@@ -152,7 +176,7 @@ async function loadKeys() {
     }
     const fromQuery = parseKeyIdFromQuery()
     const match = fromQuery != null ? keys.value.find((k) => k.id === fromQuery) : undefined
-    selectedKeyId.value = match?.id ?? keys.value[0]?.id ?? null
+    selectedKeyId.value = match?.id ?? pickDefaultKeyId(keys.value)
   } catch (e: unknown) {
     keysError.value = e instanceof Error ? e.message : String(e)
   } finally {

--- a/frontend/src/views/user/__tests__/QuickstartView.spec.ts
+++ b/frontend/src/views/user/__tests__/QuickstartView.spec.ts
@@ -48,11 +48,13 @@ vi.mock('@/components/keys/UseKeyGuide.vue', () => ({
       'apiKeyId',
       'platform',
       'routingMode',
+      'initialModel',
       'claudeCodeOnly',
       'allowMessagesDispatch',
       'supportedModelScopes',
     ],
-    template: '<div data-test="use-key-guide">{{ routingMode }}|{{ platform ?? "" }}</div>',
+    template:
+      '<div data-test="use-key-guide">{{ routingMode }}|{{ platform ?? "" }}|{{ initialModel ?? "" }}</div>',
   },
 }))
 
@@ -121,8 +123,25 @@ describe('QuickstartView', () => {
   it('embeds UseKeyGuide for universal keys without a fixed group platform', async () => {
     const wrapper = await mountView()
     const guide = wrapper.get('[data-test="use-key-guide"]')
-    expect(guide.text()).toBe('universal|')
+    expect(guide.text()).toBe('universal||')
     expect(wrapper.text()).not.toContain('keys.useKeyModal.noGroupTitle')
+  })
+
+  it('prefers universal key and passes model query to UseKeyGuide', async () => {
+    routeQuery.value = { model: 'claude-haiku-4-5' }
+    listKeys.mockResolvedValue({
+      items: [
+        { ...universalKey(), id: 5, name: 'Direct', routing_mode: 'direct', group_id: 1, group: { id: 1, name: 'claude' } },
+        universalKey(),
+      ],
+      total: 2,
+      page: 1,
+      page_size: 100,
+      pages: 1,
+    })
+    const wrapper = await mountView()
+    expect((wrapper.get('select').element as HTMLSelectElement).value).toBe('42')
+    expect(wrapper.get('[data-test="use-key-guide"]').text()).toContain('claude-haiku-4-5')
   })
 
   it('selects key from ?keyId= query on load', async () => {


### PR DESCRIPTION
## 摘要

本 PR 已合并原 #1250 + #1251，统一修复 catalog 发现与 quickstart 体验：

- **模型市场**（#1250）：图片/视频 Tab 按 `pricing.billing_mode` 筛选，与 `/pricing` 一致。
- **Quickstart 全能 key**（#1251）：`useTkUseKey` 用 entitlement 索引加载可服务模型，修复「未能加载可服务模型清单」。
- **定价页授权分组**（#1251）：分组 badge 只读 + 单一「快速开始」→ `/quickstart?model=…`。
- **Deep-link 体验**：Quickstart 优先全能 key、预填模型；deep-link 模型时不再误报 `modelsEmpty`。
- **E2E**：新增 `frontend/e2e/catalog-ux.e2e.ts`（Playwright 真实 UI 走查 models/pricing/quickstart）。

sentinel-registry-reviewed
upstream-touch-trivial

## 风险

- 常规风险：仅前端 UX + embedded dist；无 API/后端契约变化。
- 定价页不再从授权分组跳 Keys 建 direct key（Keys 页 `?create=1&group_id=` deep link 仍保留）。

## 验证

```bash
cd frontend && pnpm exec vitest run \
  src/views/__tests__/ModelMarketplaceView.spec.ts \
  src/views/__tests__/PricingView.spec.ts \
  src/views/user/__tests__/QuickstartView.spec.ts \
  src/components/keys/__tests__/UseKeyModal.spec.ts \
  src/utils/__tests__/studioUniversalKey.tk.spec.ts
# 44 passed

./scripts/preflight.sh  # PASS（frontend dist manifest 已同步）

# Playwright（需 playwright install chromium + 本地栈）
cd deploy && docker-compose -f docker-compose.dev.yml -f docker-compose.e2e.override.yml up -d postgres redis
# backend: go run ./cmd/server（DATABASE_PORT=5433 REDIS_PORT=6380 …）
cd frontend && E2E_BASE_URL=http://127.0.0.1:8080 pnpm exec playwright test e2e/catalog-ux.e2e.ts
```

## 提交

- 67ae8988a chore(deploy): 本地 Playwright e2e 用非冲突端口暴露 PG/Redis
- 7681c078d merge: 合并 #1250 并补 catalog UX e2e 与 deep-link 体验修复
- 5af9ec25c fix(frontend): 定价授权分组改跳 quickstart 并修复全能 key 模型清单
- b07c72fd2 fix(frontend): 模型市场图片/视频筛选改用 billing_mode

最新提交：67ae8988a