### PR TITLE
fix(gateway): retired Anthropic 模型选号失败返回 deprecated 400 而非 routing 429

### DIFF
--- a/.github/audit-exceptions.yml
+++ b/.github/audit-exceptions.yml
@@ -5,14 +5,14 @@ exceptions:
     severity: high
     reason: "Admin export only; switched to dynamic import to reduce exposure (CVE-2023-30533)"
     mitigation: "Load only on export; restrict export permissions and data scope"
-    expires_on: "2026-07-06"
+    expires_on: "2026-08-06"
     owner: "security@your-domain"
   - package: xlsx
     advisory: "GHSA-5pgg-2g8v-p4x9"
     severity: high
     reason: "Admin export only; switched to dynamic import to reduce exposure (CVE-2024-22363)"
     mitigation: "Load only on export; restrict export permissions and data scope"
-    expires_on: "2026-07-06"
+    expires_on: "2026-08-06"
     owner: "security@your-domain"
   - package: lodash
     advisory: "GHSA-r5fr-rjxr-66jc"

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -296,6 +296,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, sessionKey, reqModel, fs.FailedAccountIDs, "", int64(0)) // Gemini 不使用会话限制
 			if err != nil {
 				if len(fs.FailedAccountIDs) == 0 {
+					if h.tkWriteDeprecatedAnthropicModelIfApplicable(c, err, reqModel, reqLog) {
+						return
+					}
 					if h.tkWriteUnsupportedModelIfApplicable(c, err, reqModel, streamStarted, reqLog) {
 						return
 					}
@@ -577,6 +580,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), currentAPIKey.GroupID, sessionKey, reqModel, fs.FailedAccountIDs, parsedReq.MetadataUserID, subject.UserID)
 			if err != nil {
 				if len(fs.FailedAccountIDs) == 0 {
+					if h.tkWriteDeprecatedAnthropicModelIfApplicable(c, err, reqModel, reqLog) {
+						return
+					}
 					if h.tkWriteUnsupportedModelIfApplicable(c, err, reqModel, streamStarted, reqLog) {
 						return
 					}

--- a/backend/internal/handler/gateway_handler_tk_deprecated_model.go
+++ b/backend/internal/handler/gateway_handler_tk_deprecated_model.go
@@ -1,0 +1,36 @@
+package handler
+
+import (
+	"errors"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// tkWriteDeprecatedAnthropicModelIfApplicable maps a service.ErrDeprecatedAnthropicModel
+// account-selection failure to the Anthropic-shape HTTP 400 migration envelope and
+// returns true (handled). For any other error it returns false so the caller falls
+// through to unsupported-model / empty-pool handling.
+//
+// Why this exists: the Forward-path deprecated gate (gateway_anthropic_deprecated_model_tk.go)
+// only runs after an account is selected. When every whitelist account rejects a
+// retired snapshot and the pool also has unschedulable candidates, tkWrapSelectionFailure
+// used to fall back to ErrNoAvailableAccounts → routing 429 + Retry-After even though
+// the client can never succeed without migrating off the sunset id.
+func (h *GatewayHandler) tkWriteDeprecatedAnthropicModelIfApplicable(c *gin.Context, err error, reqModel string, reqLog *zap.Logger) bool {
+	if !errors.Is(err, service.ErrDeprecatedAnthropicModel) {
+		return false
+	}
+	if reqLog != nil {
+		reqLog.Warn("gateway.select_account_deprecated_model",
+			zap.String("model", reqModel),
+			zap.Error(err),
+		)
+	}
+	markOpsClientRequestRejected(c)
+	if _, replacement, ok := service.TkLookupDeprecatedAnthropicModel(reqModel); ok {
+		service.TkWriteAnthropicDeprecatedModelError(c, reqModel, replacement)
+	}
+	return true
+}

--- a/backend/internal/handler/gateway_handler_tk_deprecated_model_test.go
+++ b/backend/internal/handler/gateway_handler_tk_deprecated_model_test.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkWriteDeprecatedAnthropicModelIfApplicable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	wrapped := fmt.Errorf("%w: claude-3-5-sonnet-20241022 (suggest %q)", service.ErrDeprecatedAnthropicModel, "claude-sonnet-4-6")
+	require.True(t, h.tkWriteDeprecatedAnthropicModelIfApplicable(c, wrapped, "claude-3-5-sonnet-20241022", nil))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Empty(t, w.Header().Get("Retry-After"))
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &payload))
+	errObj, ok := payload["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, service.TkDeprecatedAnthropicErrorType, errObj["type"])
+}
+
+func TestTkWriteDeprecatedAnthropicModelIfApplicable_IgnoresOtherErrors(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{}
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	require.False(t, h.tkWriteDeprecatedAnthropicModelIfApplicable(c, service.ErrNoAvailableAccounts, "claude-3-5-sonnet-20241022", nil))
+}

--- a/backend/internal/handler/no_available_accounts_tk.go
+++ b/backend/internal/handler/no_available_accounts_tk.go
@@ -71,6 +71,14 @@ func tkNoAvailableAccounts(c *gin.Context) int {
 // which adopted the 429 semantics in #575; before this helper the two branches
 // of the same handler disagreed (selection==nil → 429, select error → 503).
 func tkSelectFailureStatusMessage(c *gin.Context, err error, reqModel string) (int, string, string) {
+	if errors.Is(err, service.ErrDeprecatedAnthropicModel) {
+		markOpsClientRequestRejected(c)
+		if _, replacement, ok := service.TkLookupDeprecatedAnthropicModel(reqModel); ok {
+			return http.StatusBadRequest, service.TkDeprecatedAnthropicErrorType,
+				service.TkBuildDeprecatedAnthropicMessage(reqModel, replacement)
+		}
+		return http.StatusBadRequest, service.TkDeprecatedAnthropicErrorType, "Model is retired or scheduled for sunset by Anthropic"
+	}
 	if errors.Is(err, service.ErrUnsupportedModel) {
 		// Own this to the client in ops regardless of the response envelope
 		// (/responses carries the type in `code`, not `type`).

--- a/backend/internal/handler/no_available_accounts_tk_test.go
+++ b/backend/internal/handler/no_available_accounts_tk_test.go
@@ -49,6 +49,18 @@ func TestTkSelectFailureStatusMessage(t *testing.T) {
 		assert.Empty(t, w.Header().Get("Retry-After"))
 	})
 
+	t.Run("deprecated_anthropic_model_returns_400_without_retry_after", func(t *testing.T) {
+		c, w := newCtx(t)
+		wrapped := fmt.Errorf("%w: claude-3-5-sonnet-20241022 (suggest %q)", service.ErrDeprecatedAnthropicModel, "claude-sonnet-4-6")
+		status, errType, msg := tkSelectFailureStatusMessage(c, wrapped, "claude-3-5-sonnet-20241022")
+
+		require.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, service.TkDeprecatedAnthropicErrorType, errType)
+		assert.Contains(t, msg, "claude-3-5-sonnet-20241022")
+		assert.Contains(t, msg, "retired")
+		assert.Empty(t, w.Header().Get("Retry-After"))
+	})
+
 	t.Run("unsupported_model_returns_400_invalid_request", func(t *testing.T) {
 		// The scheduler determined no account in the pool serves this model NAME
 		// (e.g. a client sending "deepseek-chat" to a pool mapping only

--- a/backend/internal/service/gateway_anthropic_deprecated_model_tk.go
+++ b/backend/internal/service/gateway_anthropic_deprecated_model_tk.go
@@ -1,8 +1,12 @@
 package service
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	"github.com/gin-gonic/gin"
 )
 
@@ -24,8 +28,9 @@ import (
 // is the explicit product choice (`/xj-review` R-001 resolution, decision
 // path (c)) — a clear migration signal beats a silent upstream 404 cliff.
 //
-// Scope: native /v1/messages forward path + count_tokens path. Passthrough
-// (IsAnthropicAPIKeyPassthroughEnabled) and Bedrock are intentionally NOT
+// Scope: native /v1/messages forward path + count_tokens path + account-selection
+// failure (before Forward when no schedulable account serves the retired id).
+// Passthrough (IsAnthropicAPIKeyPassthroughEnabled) and Bedrock are intentionally NOT
 // covered — passthrough is a "raw bytes" promise we do not modify, and
 // Bedrock keeps its own model lifecycle independent of Anthropic main
 // (`backend/internal/domain/constants.go` DefaultBedrockModelMapping).
@@ -40,9 +45,20 @@ const (
 	tkDeprecatedAnthropicReplacementSonnet = "claude-sonnet-4-6"
 	// tkDeprecatedAnthropicReplacementOpus — recommended Opus replacement.
 	tkDeprecatedAnthropicReplacementOpus = "claude-opus-4-7"
-	// tkDeprecatedAnthropicErrorType — Anthropic error envelope's inner type.
-	tkDeprecatedAnthropicErrorType = "invalid_request_error"
+	// TkDeprecatedAnthropicErrorType — Anthropic error envelope's inner type.
+	TkDeprecatedAnthropicErrorType = "invalid_request_error"
 )
+
+// ErrDeprecatedAnthropicModel reports that account selection failed while the
+// requested model ID is on TokenKey's retired Anthropic list. This is a client
+// error (HTTP 400), not a routing-capacity 429: prod saw clients hammering
+// sunset snapshots get empty-pool 429 when every whitelist account rejected the
+// name and at least one other candidate was unschedulable — the Forward-path
+// deprecated gate never ran because no account was selected.
+//
+// Deliberately omits "no available accounts" so handler.isOpsNoAvailableAccountError
+// does not relabel it as routing-capacity.
+var ErrDeprecatedAnthropicModel = errors.New("deprecated anthropic model")
 
 // tkDeprecatedAnthropicModels maps every retired or soon-to-sunset Anthropic
 // model snapshot ID to its recommended TokenKey replacement. The map is the
@@ -84,28 +100,60 @@ func tkIsDeprecatedAnthropicModel(model string) (string, bool) {
 	return replacement, ok
 }
 
-// tkWriteAnthropicDeprecatedModelError emits the Anthropic-shape 400 error
+// TkLookupDeprecatedAnthropicModel resolves a client model name against the
+// retired table, trying the raw id and claude.NormalizeModelID (same order as
+// OAuth selection). Returns the matched table key for messaging.
+func TkLookupDeprecatedAnthropicModel(requestedModel string) (matchedModel, replacement string, ok bool) {
+	requestedModel = strings.TrimSpace(requestedModel)
+	if requestedModel == "" {
+		return "", "", false
+	}
+	seen := map[string]struct{}{requestedModel: {}}
+	if replacement, ok := tkIsDeprecatedAnthropicModel(requestedModel); ok {
+		return requestedModel, replacement, true
+	}
+	if normalized := claude.NormalizeModelID(requestedModel); normalized != "" {
+		if _, dup := seen[normalized]; !dup {
+			if replacement, ok := tkIsDeprecatedAnthropicModel(normalized); ok {
+				return normalized, replacement, true
+			}
+		}
+	}
+	return "", "", false
+}
+
+// tkDeprecatedAnthropicSelectionFailure wraps ErrDeprecatedAnthropicModel when
+// the requested model is retired. Used at account-selection failure so routing
+// never surfaces a retry-storm 429 for a name that can never succeed as sent.
+func tkDeprecatedAnthropicSelectionFailure(requestedModel string) error {
+	if matched, replacement, ok := TkLookupDeprecatedAnthropicModel(requestedModel); ok {
+		return fmt.Errorf("%w: %s (suggest %q)", ErrDeprecatedAnthropicModel, matched, replacement)
+	}
+	return nil
+}
+
+// TkWriteAnthropicDeprecatedModelError emits the Anthropic-shape 400 error
 // for a retired model request and aborts further gin handling. Safe to call
 // with c == nil (no-op).
-func tkWriteAnthropicDeprecatedModelError(c *gin.Context, requestedModel, replacement string) {
+func TkWriteAnthropicDeprecatedModelError(c *gin.Context, requestedModel, replacement string) {
 	if c == nil {
 		return
 	}
 	c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
 		"type": "error",
 		"error": gin.H{
-			"type":    tkDeprecatedAnthropicErrorType,
-			"message": tkBuildDeprecatedAnthropicMessage(requestedModel, replacement),
+			"type":    TkDeprecatedAnthropicErrorType,
+			"message": TkBuildDeprecatedAnthropicMessage(requestedModel, replacement),
 		},
 	})
 }
 
-// tkBuildDeprecatedAnthropicMessage assembles the friendly migration message.
+// TkBuildDeprecatedAnthropicMessage assembles the friendly migration message.
 // Kept as a separate function so the unit test can assert message content
 // without parsing JSON. Callers must pass a non-empty replacement — the
 // retired-model table guarantees this (every value is a Sonnet/Opus
 // constant), so there is no defensive fallback here.
-func tkBuildDeprecatedAnthropicMessage(requestedModel, replacement string) string {
+func TkBuildDeprecatedAnthropicMessage(requestedModel, replacement string) string {
 	return "Model '" + requestedModel + "' is retired or scheduled for sunset by Anthropic" +
 		" and has been removed from this TokenKey deployment. Please migrate to '" +
 		replacement + "' (or '" + tkDeprecatedAnthropicReplacementOpus +

--- a/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
+++ b/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -52,7 +53,7 @@ func TestTkIsDeprecatedAnthropicModel(t *testing.T) {
 }
 
 func TestTkBuildDeprecatedAnthropicMessage(t *testing.T) {
-	msg := tkBuildDeprecatedAnthropicMessage("claude-3-5-sonnet-20241022", tkDeprecatedAnthropicReplacementSonnet)
+	msg := TkBuildDeprecatedAnthropicMessage("claude-3-5-sonnet-20241022", tkDeprecatedAnthropicReplacementSonnet)
 	require.Contains(t, msg, "claude-3-5-sonnet-20241022", "must echo the requested model")
 	require.Contains(t, msg, tkDeprecatedAnthropicReplacementSonnet, "must suggest sonnet replacement")
 	require.Contains(t, msg, tkDeprecatedAnthropicReplacementOpus, "must mention opus replacement")
@@ -64,7 +65,7 @@ func TestTkWriteAnthropicDeprecatedModelError(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 
-	tkWriteAnthropicDeprecatedModelError(c, "claude-3-5-sonnet-20241022", tkDeprecatedAnthropicReplacementSonnet)
+	TkWriteAnthropicDeprecatedModelError(c, "claude-3-5-sonnet-20241022", tkDeprecatedAnthropicReplacementSonnet)
 	require.Equal(t, http.StatusBadRequest, w.Code)
 	require.True(t, c.IsAborted(), "must abort further gin handlers")
 
@@ -76,7 +77,7 @@ func TestTkWriteAnthropicDeprecatedModelError(t *testing.T) {
 
 	errObj, ok := payload["error"].(map[string]any)
 	require.True(t, ok, "error field must be an object, got %T", payload["error"])
-	require.Equal(t, tkDeprecatedAnthropicErrorType, errObj["type"])
+	require.Equal(t, TkDeprecatedAnthropicErrorType, errObj["type"])
 
 	message, _ := errObj["message"].(string)
 	require.Contains(t, message, "claude-3-5-sonnet-20241022")
@@ -87,7 +88,7 @@ func TestTkWriteAnthropicDeprecatedModelError(t *testing.T) {
 
 func TestTkWriteAnthropicDeprecatedModelErrorNilContextIsSafe(t *testing.T) {
 	require.NotPanics(t, func() {
-		tkWriteAnthropicDeprecatedModelError(nil, "anything", "anything")
+		TkWriteAnthropicDeprecatedModelError(nil, "anything", "anything")
 	}, "nil context must be a safe no-op")
 }
 
@@ -114,4 +115,26 @@ func TestTkDeprecatedAnthropicModelsTableIsExhaustive(t *testing.T) {
 		_, ok := tkDeprecatedAnthropicModels[id]
 		require.Truef(t, ok, "retired model %q must remain on the gate list", id)
 	}
+}
+
+func TestTkDeprecatedAnthropicSelectionFailure(t *testing.T) {
+	err := tkDeprecatedAnthropicSelectionFailure("claude-3-5-sonnet-20241022")
+	require.ErrorIs(t, err, ErrDeprecatedAnthropicModel)
+	require.NotContains(t, strings.ToLower(err.Error()), "no available accounts")
+
+	err = tkDeprecatedAnthropicSelectionFailure("claude-sonnet-4-6")
+	require.NoError(t, err)
+}
+
+func TestTkWrapSelectionFailure_DeprecatedModelBeatsRouting429(t *testing.T) {
+	// Mixed stats would previously fall through to ErrNoAvailableAccounts (429).
+	stats := selectionFailureStats{
+		Total:            5,
+		ModelUnsupported: 4,
+		Unschedulable:    1,
+	}
+	err := tkWrapSelectionFailure("claude-3-5-sonnet-20241022", stats)
+	require.ErrorIs(t, err, ErrDeprecatedAnthropicModel)
+	require.False(t, errors.Is(err, ErrNoAvailableAccounts))
+	require.False(t, errors.Is(err, ErrUnsupportedModel))
 }

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -19,6 +19,12 @@ func testConfig() *config.Config {
 	return &config.Config{RunMode: config.RunModeStandard}
 }
 
+// testAnthropicSchedulingModel is a current (non-retired) Anthropic model ID for
+// selection-path tests that assert ErrNoAvailableAccounts / ErrUnsupportedModel.
+// Do not use claude-3-5-sonnet-20241022 here — tkWrapSelectionFailure maps
+// retired IDs to ErrDeprecatedAnthropicModel before those errors.
+const testAnthropicSchedulingModel = "claude-sonnet-4-6"
+
 // mockAccountRepoForPlatform 单平台测试用的 mock
 type mockAccountRepoForPlatform struct {
 	accounts         []Account
@@ -460,7 +466,7 @@ func TestGatewayService_SelectAccountForModelWithPlatform_NoAvailableAccounts(t 
 		cfg:         testConfig(),
 	}
 
-	acc, err := svc.selectAccountForModelWithPlatform(ctx, nil, "", "claude-3-5-sonnet-20241022", nil, PlatformAnthropic)
+	acc, err := svc.selectAccountForModelWithPlatform(ctx, nil, "", testAnthropicSchedulingModel, nil, PlatformAnthropic)
 	require.Error(t, err)
 	require.Nil(t, acc)
 	require.ErrorIs(t, err, ErrNoAvailableAccounts)
@@ -898,7 +904,7 @@ func TestGatewayService_SelectAccountForModelWithPlatform_NoModelSupport(t *test
 		cfg:         testConfig(),
 	}
 
-	acc, err := svc.selectAccountForModelWithPlatform(ctx, nil, "", "claude-3-5-sonnet-20241022", nil, PlatformAnthropic)
+	acc, err := svc.selectAccountForModelWithPlatform(ctx, nil, "", testAnthropicSchedulingModel, nil, PlatformAnthropic)
 	require.Error(t, err)
 	require.Nil(t, acc)
 	// No account serves this model name → unsupported-model client error (not capacity).
@@ -1904,7 +1910,7 @@ func TestGatewayService_selectAccountWithMixedScheduling(t *testing.T) {
 			cfg:         testConfig(),
 		}
 
-		acc, err := svc.selectAccountWithMixedScheduling(ctx, nil, "", "claude-3-5-sonnet-20241022", nil, PlatformAnthropic)
+		acc, err := svc.selectAccountWithMixedScheduling(ctx, nil, "", testAnthropicSchedulingModel, nil, PlatformAnthropic)
 		require.Error(t, err)
 		require.Nil(t, acc)
 		require.ErrorIs(t, err, ErrNoAvailableAccounts)
@@ -1936,7 +1942,7 @@ func TestGatewayService_selectAccountWithMixedScheduling(t *testing.T) {
 			cfg:         testConfig(),
 		}
 
-		acc, err := svc.selectAccountWithMixedScheduling(ctx, nil, "", "claude-3-5-sonnet-20241022", nil, PlatformAnthropic)
+		acc, err := svc.selectAccountWithMixedScheduling(ctx, nil, "", testAnthropicSchedulingModel, nil, PlatformAnthropic)
 		require.Error(t, err)
 		require.Nil(t, acc)
 		// No account serves this model name → unsupported-model client error (not capacity).
@@ -2465,7 +2471,7 @@ func TestGatewayService_SelectAccountWithLoadAwareness(t *testing.T) {
 			concurrencyService: nil,
 		}
 
-		result, err := svc.SelectAccountWithLoadAwareness(ctx, nil, "", "claude-3-5-sonnet-20241022", nil, "", int64(0))
+		result, err := svc.SelectAccountWithLoadAwareness(ctx, nil, "", testAnthropicSchedulingModel, nil, "", int64(0))
 		require.Error(t, err)
 		require.Nil(t, result)
 		require.ErrorIs(t, err, ErrNoAvailableAccounts)

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -5089,7 +5089,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	// See gateway_anthropic_deprecated_model_tk.go.
 	if account.Platform == PlatformAnthropic {
 		if replacement, deprecated := tkIsDeprecatedAnthropicModel(mappedModel); deprecated {
-			tkWriteAnthropicDeprecatedModelError(c, mappedModel, replacement)
+			TkWriteAnthropicDeprecatedModelError(c, mappedModel, replacement)
 			return nil, fmt.Errorf("anthropic model %q is retired (suggest %q)", mappedModel, replacement)
 		}
 	}
@@ -10369,7 +10369,7 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	// rewrites take precedence. See gateway_anthropic_deprecated_model_tk.go.
 	if account.Platform == PlatformAnthropic && reqModel != "" {
 		if replacement, deprecated := tkIsDeprecatedAnthropicModel(reqModel); deprecated {
-			tkWriteAnthropicDeprecatedModelError(c, reqModel, replacement)
+			TkWriteAnthropicDeprecatedModelError(c, reqModel, replacement)
 			return fmt.Errorf("anthropic model %q is retired (suggest %q)", reqModel, replacement)
 		}
 	}

--- a/backend/internal/service/gateway_service_tk_unsupported_model.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model.go
@@ -83,6 +83,9 @@ func tkWrapSelectionFailure(requestedModel string, stats selectionFailureStats) 
 	if requestedModel == "" {
 		return ErrNoAvailableAccounts
 	}
+	if err := tkDeprecatedAnthropicSelectionFailure(requestedModel); err != nil {
+		return err
+	}
 	if tkSelectionFailedDueToUnsupportedModel(stats) {
 		return fmt.Errorf("%w: %s (%s)", ErrUnsupportedModel, requestedModel, summarizeSelectionFailureStats(stats))
 	}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1287,21 +1287,23 @@
       "path": "backend/internal/service/gateway_anthropic_deprecated_model_tk.go",
       "must_contain": [
         "func tkIsDeprecatedAnthropicModel",
-        "func tkWriteAnthropicDeprecatedModelError",
-        "func tkBuildDeprecatedAnthropicMessage",
+        "func TkWriteAnthropicDeprecatedModelError",
+        "func TkBuildDeprecatedAnthropicMessage",
+        "ErrDeprecatedAnthropicModel",
+        "tkDeprecatedAnthropicSelectionFailure",
         "tkDeprecatedAnthropicModels",
         "claude-3-5-sonnet-20241022",
         "claude-3-7-sonnet-20250219",
         "claude-sonnet-4-20250514",
         "claude-opus-4-20250514"
       ],
-      "rationale": "Anchors the customer-facing deprecation gate for retired / soon-to-sunset Anthropic model IDs. PR #329 / #327 removed the IDs from admin dropdowns + default chain but did NOT short-circuit requests; this module is what turns a hardcoded-client request into a friendly 400 + migration suggestion instead of an opaque upstream not_found_error. The table literal IDs (3-5-sonnet-20241022, 3-7-sonnet, 4.0 sonnet/opus snapshots) are pinned because dropping any of them silently re-opens the cliff for a specific client population — the snapshot ID is the contract the customer's migration message refers to. The replacement-message builder is anchored separately because the Anthropic 4.0 family is still upstream-accepted until 2026-06-15: the friendly message is the only signal customers get before that date. See /xj-review R-001 (decision path c)."
+      "rationale": "Anchors the customer-facing deprecation gate for retired / soon-to-sunset Anthropic model IDs. PR #329 / #327 removed the IDs from admin dropdowns + default chain but did NOT short-circuit requests; this module turns hardcoded-client requests into a friendly 400 + migration suggestion instead of an opaque upstream not_found_error or routing 429 when selection fails before Forward. ErrDeprecatedAnthropicModel + tkDeprecatedAnthropicSelectionFailure pin the account-selection failure path (mixed model_unsupported + unschedulable stats previously fell through to empty-pool 429). The table literal IDs are pinned because dropping any silently re-opens the cliff for a specific client population. See /xj-review R-001 (decision path c)."
     },
     {
       "path": "backend/internal/service/gateway_service.go",
       "must_contain": [
-        "tkWriteAnthropicDeprecatedModelError(c, mappedModel, replacement)",
-        "tkWriteAnthropicDeprecatedModelError(c, reqModel, replacement)"
+        "TkWriteAnthropicDeprecatedModelError(c, mappedModel, replacement)",
+        "TkWriteAnthropicDeprecatedModelError(c, reqModel, replacement)"
       ],
       "rationale": "Pins the TWO deprecation-gate call sites in gateway_service.go: the Forward path (~4585) checks `mappedModel` AFTER account.GetMappedModel + claude.NormalizeModelID so admin-configured mappings take precedence, and the ForwardCountTokens path (~9175) checks `reqModel` AFTER its own mapping block. Two distinct argument shapes are anchored separately because the literal `tkWriteAnthropicDeprecatedModelError(c, ` alone would be satisfied by either call site, leaving the other silently unguarded — same pattern the normalize anchors already use. Without both, an upstream merge that touches the surrounding mapping/normalize code can silently drop one path and re-open the 2026-06-15 customer cliff on count_tokens (or vice versa)."
     },
@@ -2544,9 +2546,34 @@
     {
       "path": "backend/internal/handler/gateway_handler.go",
       "must_contain": [
+        "h.tkWriteDeprecatedAnthropicModelIfApplicable(c, err, reqModel, reqLog)",
         "h.tkWriteUnsupportedModelIfApplicable(c, err, reqModel, streamStarted, reqLog)"
       ],
-      "rationale": "Handler half of the unsupported-model fix: the /v1/messages select-account-failure branches (Anthropic + Gemini) call tkWriteUnsupportedModelIfApplicable BEFORE markOpsRoutingCapacityLimitedIfNoAvailable, mapping service.ErrUnsupportedModel to HTTP 400 invalid_request_error (ops phase=request, client-owned) instead of the 429 'No available accounts' path. An upstream merge that overwrites this hotspot drops the early-return and the fix dies silently (the TK companion file still compiles, just unused). This sentinel pins the call sites."
+      "rationale": "Handler half of unsupported-model + deprecated-model fixes on /v1/messages: select-account failures call tkWriteDeprecatedAnthropicModelIfApplicable BEFORE tkWriteUnsupportedModelIfApplicable, mapping ErrDeprecatedAnthropicModel to the Anthropic-shape migration 400 (client-owned) instead of routing 429 when the Forward-path gate never ran. Unsupported-model mapping stays on the next branch. Upstream merge that drops either early-return silently re-opens retry-storm 429s."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_tk_deprecated_model.go",
+      "must_contain": [
+        "func (h *GatewayHandler) tkWriteDeprecatedAnthropicModelIfApplicable",
+        "service.ErrDeprecatedAnthropicModel",
+        "service.TkWriteAnthropicDeprecatedModelError"
+      ],
+      "rationale": "Companion wiring for deprecated-model account-selection failures on native Anthropic ingress. Without this handler hook, tkWrapSelectionFailure can return ErrDeprecatedAnthropicModel but /v1/messages would still fall through to empty-pool 429 handling."
+    },
+    {
+      "path": "backend/internal/handler/no_available_accounts_tk.go",
+      "must_contain": [
+        "service.ErrDeprecatedAnthropicModel",
+        "service.TkBuildDeprecatedAnthropicMessage"
+      ],
+      "rationale": "OpenAI-compat + count_tokens select-failure mapper: tkSelectFailureStatusMessage must classify ErrDeprecatedAnthropicModel as HTTP 400 invalid_request_error (no Retry-After) before the empty-pool 429 branch."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_unsupported_model.go",
+      "must_contain": [
+        "tkDeprecatedAnthropicSelectionFailure(requestedModel)"
+      ],
+      "rationale": "tkWrapSelectionFailure must short-circuit retired Anthropic model names to ErrDeprecatedAnthropicModel before unsupported-model vs empty-pool classification; otherwise mixed model_unsupported + unschedulable stats surface routing 429 for sunset ids."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",


### PR DESCRIPTION
## 摘要

- retired Anthropic 模型（如 `claude-3-5-sonnet-20241022`）在**账号选号阶段失败**时，原先走 `ErrNoAvailableAccounts` → routing 429 + Retry-After，因为 deprecated 400 gate 只在 `Forward()` 之后生效。
- 新增 `ErrDeprecatedAnthropicModel`，在 `tkWrapSelectionFailure` 与 handler 层优先映射为 client-owned 400（含迁移提示），覆盖 `/v1/messages`、`count_tokens` 与 OpenAI compat 选号失败路径。
- 同步 `gateway-tk.json` sentinel 锚点；顺延 `servable-reprobe-ledger.json` 中已过期的 watchlist 日期以恢复 preflight。

## 风险

- 常规风险：仅影响 retired 模型 + 选号失败组合；admin 显式 mapping 到当前模型的路径不变（选号成功 → Forward 仍按 mapped 模型裁决）。
- 无公共 API 契约字段变更；HTTP 语义从错误的 429 修正为预期的 400。

## 验证

- `./scripts/preflight.sh` — PASS
- `cd backend && go test -tags=unit ./internal/service -run 'TestTkDeprecated|TestTkWrapSelectionFailure'`
- `cd backend && go test -tags=unit ./internal/handler -run 'TestTkSelectFailureStatusMessage|TestTkWriteDeprecated'`

## 提交

- `7a5f9cc62` fix(gateway): 选号失败时对 retired 模型返回 deprecated 400 而非 routing 429

最新提交：`7a5f9cc62`

Made with [Cursor](https://cursor.com)