### PR TITLE
feat(gateway): Anthropic OAuth 账号支持 auth-only 透传

### DIFF
--- a/backend/internal/handler/admin/account_handler_passthrough_test.go
+++ b/backend/internal/handler/admin/account_handler_passthrough_test.go
@@ -11,6 +11,61 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAccountHandler_Create_AnthropicOAuthPassthroughExtraForwarded(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	adminSvc := newStubAdminService()
+	handler := NewAccountHandler(
+		adminSvc,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	router := gin.New()
+	router.POST("/api/v1/admin/accounts", handler.Create)
+
+	body := map[string]any{
+		"name":     "anthropic-oauth-1",
+		"platform": "anthropic",
+		"type":     "oauth",
+		"credentials": map[string]any{
+			"access_token": "oauth-token",
+		},
+		"extra": map[string]any{
+			"anthropic_oauth_passthrough": true,
+		},
+		"concurrency": 1,
+		"priority":    1,
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, adminSvc.createdAccounts, 1)
+
+	created := adminSvc.createdAccounts[0]
+	require.Equal(t, "anthropic", created.Platform)
+	require.Equal(t, "oauth", created.Type)
+	require.NotNil(t, created.Extra)
+	require.Equal(t, true, created.Extra["anthropic_oauth_passthrough"])
+}
+
 func TestAccountHandler_Create_AnthropicAPIKeyPassthroughExtraForwarded(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1770,6 +1770,17 @@ func (a *Account) IsAnthropicAPIKeyPassthroughEnabled() bool {
 	return ok && enabled
 }
 
+// IsAnthropicOAuthPassthroughEnabled 返回 Anthropic OAuth/setup-token 账号是否启用
+// 「自动透传（仅替换认证）」：跳过 fingerprint / mimic / canonical 等改写，仅替换
+// Authorization。字段：accounts.extra.anthropic_oauth_passthrough。
+func (a *Account) IsAnthropicOAuthPassthroughEnabled() bool {
+	if a == nil || a.Platform != PlatformAnthropic || !a.IsOAuth() || a.Extra == nil {
+		return false
+	}
+	enabled, ok := a.Extra["anthropic_oauth_passthrough"].(bool)
+	return ok && enabled
+}
+
 // WebSearch 模拟三态常量
 const (
 	WebSearchModeDefault  = "default"  // 跟随渠道配置

--- a/backend/internal/service/account_anthropic_oauth_passthrough_test.go
+++ b/backend/internal/service/account_anthropic_oauth_passthrough_test.go
@@ -1,0 +1,68 @@
+package service
+
+import "testing"
+
+func TestAccount_IsAnthropicOAuthPassthroughEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		account *Account
+		want    bool
+	}{
+		{
+			name: "oauth enabled",
+			account: &Account{
+				Platform: PlatformAnthropic,
+				Type:     AccountTypeOAuth,
+				Extra:    map[string]any{"anthropic_oauth_passthrough": true},
+			},
+			want: true,
+		},
+		{
+			name: "setup token enabled",
+			account: &Account{
+				Platform: PlatformAnthropic,
+				Type:     AccountTypeSetupToken,
+				Extra:    map[string]any{"anthropic_oauth_passthrough": true},
+			},
+			want: true,
+		},
+		{
+			name: "oauth disabled",
+			account: &Account{
+				Platform: PlatformAnthropic,
+				Type:     AccountTypeOAuth,
+				Extra:    map[string]any{"anthropic_oauth_passthrough": false},
+			},
+			want: false,
+		},
+		{
+			name: "api key ignored",
+			account: &Account{
+				Platform: PlatformAnthropic,
+				Type:     AccountTypeAPIKey,
+				Extra:    map[string]any{"anthropic_oauth_passthrough": true},
+			},
+			want: false,
+		},
+		{
+			name: "wrong platform",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Extra:    map[string]any{"anthropic_oauth_passthrough": true},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.account.IsAnthropicOAuthPassthroughEnabled(); got != tt.want {
+				t.Fatalf("IsAnthropicOAuthPassthroughEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/service/gateway_anthropic_oauth_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_oauth_passthrough.go
@@ -1,0 +1,183 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type anthropicPassthroughAuthKind int
+
+const (
+	anthropicPassthroughAuthAPIKey anthropicPassthroughAuthKind = iota
+	anthropicPassthroughAuthOAuth
+)
+
+func (s *GatewayService) forwardAnthropicOAuthPassthroughWithInput(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	input anthropicPassthroughForwardInput,
+) (*ForwardResult, error) {
+	return s.forwardAnthropicPassthroughWithInput(ctx, c, account, input, anthropicPassthroughAuthOAuth)
+}
+
+func (s *GatewayService) buildAnthropicPassthroughUpstreamRequest(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	token string,
+	authKind anthropicPassthroughAuthKind,
+) (*http.Request, []byte, error) {
+	switch authKind {
+	case anthropicPassthroughAuthOAuth:
+		return s.buildUpstreamRequestAnthropicOAuthPassthrough(ctx, c, account, body, token)
+	default:
+		return s.buildUpstreamRequestAnthropicAPIKeyPassthrough(ctx, c, account, body, token)
+	}
+}
+
+func (s *GatewayService) buildAnthropicPassthroughCountTokensRequest(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	token string,
+	authKind anthropicPassthroughAuthKind,
+) (*http.Request, error) {
+	switch authKind {
+	case anthropicPassthroughAuthOAuth:
+		return s.buildCountTokensRequestAnthropicOAuthPassthrough(ctx, c, account, body, token)
+	default:
+		return s.buildCountTokensRequestAnthropicAPIKeyPassthrough(ctx, c, account, body, token)
+	}
+}
+
+func (s *GatewayService) anthropicOAuthPassthroughMessagesURL(account *Account) (string, error) {
+	targetURL := claudeAPIURL
+	if account.IsCustomBaseURLEnabled() {
+		customURL := account.GetCustomBaseURL()
+		if customURL == "" {
+			return "", fmt.Errorf("custom_base_url is enabled but not configured for account %d", account.ID)
+		}
+		validatedURL, err := s.validateUpstreamBaseURL(customURL)
+		if err != nil {
+			return "", err
+		}
+		targetURL = s.buildCustomRelayURL(validatedURL, "/v1/messages", account)
+	}
+	return targetURL, nil
+}
+
+func (s *GatewayService) anthropicOAuthPassthroughCountTokensURL(account *Account) (string, error) {
+	targetURL := claudeAPICountTokensURL
+	if account.IsCustomBaseURLEnabled() {
+		customURL := account.GetCustomBaseURL()
+		if customURL == "" {
+			return "", fmt.Errorf("custom_base_url is enabled but not configured for account %d", account.ID)
+		}
+		validatedURL, err := s.validateUpstreamBaseURL(customURL)
+		if err != nil {
+			return "", err
+		}
+		targetURL = s.buildCustomRelayURL(validatedURL, "/v1/messages/count_tokens", account)
+	}
+	return targetURL, nil
+}
+
+func setAnthropicOAuthPassthroughAuthHeader(headers http.Header, token string) {
+	headers.Del("authorization")
+	headers.Del("x-api-key")
+	headers.Del("x-goog-api-key")
+	headers.Del("cookie")
+	setHeaderRaw(headers, "authorization", "Bearer "+token)
+}
+
+func (s *GatewayService) buildUpstreamRequestAnthropicOAuthPassthrough(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	token string,
+) (*http.Request, []byte, error) {
+	targetURL, err := s.anthropicOAuthPassthroughMessagesURL(account)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	clientBeta := ""
+	if c != nil && c.Request != nil {
+		clientBeta = getHeaderRaw(c.Request.Header, "anthropic-beta")
+	}
+	if sanitized, changed := sanitizeAnthropicBodyForBetaTokens(body, clientBeta); changed {
+		body = sanitized
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if c != nil && c.Request != nil {
+		copyAnthropicPassthroughHeaders(req.Header, c.Request.Header, s.anthropicPassthroughAllowTimeoutHeaders())
+	}
+
+	setAnthropicOAuthPassthroughAuthHeader(req.Header, token)
+
+	if getHeaderRaw(req.Header, "content-type") == "" {
+		setHeaderRaw(req.Header, "content-type", "application/json")
+	}
+	if getHeaderRaw(req.Header, "anthropic-version") == "" {
+		setHeaderRaw(req.Header, "anthropic-version", "2023-06-01")
+	}
+	tkEnsureClaudeCodeSessionHeader(req.Header, body, c)
+	setKiroInternalThinkingMirrorHopHeaderForAccount(req.Header, account)
+
+	return req, body, nil
+}
+
+func (s *GatewayService) buildCountTokensRequestAnthropicOAuthPassthrough(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	token string,
+) (*http.Request, error) {
+	targetURL, err := s.anthropicOAuthPassthroughCountTokensURL(account)
+	if err != nil {
+		return nil, err
+	}
+
+	clientBeta := ""
+	if c != nil && c.Request != nil {
+		clientBeta = getHeaderRaw(c.Request.Header, "anthropic-beta")
+	}
+	if sanitized, changed := sanitizeAnthropicBodyForBetaTokens(body, clientBeta); changed {
+		body = sanitized
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	if c != nil && c.Request != nil {
+		copyAnthropicPassthroughHeaders(req.Header, c.Request.Header, s.anthropicPassthroughAllowTimeoutHeaders())
+	}
+
+	setAnthropicOAuthPassthroughAuthHeader(req.Header, token)
+
+	if req.Header.Get("content-type") == "" {
+		req.Header.Set("content-type", "application/json")
+	}
+	if req.Header.Get("anthropic-version") == "" {
+		req.Header.Set("anthropic-version", "2023-06-01")
+	}
+	setKiroInternalThinkingMirrorHopHeaderForAccount(req.Header, account)
+
+	return req, nil
+}

--- a/backend/internal/service/gateway_anthropic_oauth_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_oauth_passthrough_test.go
@@ -1,0 +1,122 @@
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func newAnthropicOAuthAccountForPassthroughTest() *Account {
+	return &Account{
+		ID:          301,
+		Name:        "anthropic-oauth-pass-test",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token": "upstream-oauth-token",
+		},
+		Extra: map[string]any{
+			"anthropic_oauth_passthrough": true,
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+}
+
+func TestBuildUpstreamRequestAnthropicOAuthPassthrough_PreservesClientHeadersAndBearerAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	c.Request.Header.Set("User-Agent", "claude-cli/2.1.0")
+	c.Request.Header.Set("Authorization", "Bearer inbound-token")
+	c.Request.Header.Set("X-Api-Key", "inbound-api-key")
+	c.Request.Header.Set("Anthropic-Beta", "interleaved-thinking-2025-05-14")
+	c.Request.Header.Set("X-Stainless-Retry-Count", "3")
+
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}]}`)
+	account := newAnthropicOAuthAccountForPassthroughTest()
+
+	svc := &GatewayService{
+		cfg: &config.Config{},
+	}
+
+	req, wireBody, err := svc.buildUpstreamRequestAnthropicOAuthPassthrough(
+		context.Background(), c, account, body, "upstream-oauth-token",
+	)
+	require.NoError(t, err)
+	require.Equal(t, body, wireBody)
+	require.Equal(t, "Bearer upstream-oauth-token", getHeaderRaw(req.Header, "authorization"))
+	require.Empty(t, getHeaderRaw(req.Header, "x-api-key"))
+	require.Equal(t, "claude-cli/2.1.0", getHeaderRaw(req.Header, "user-agent"))
+	require.Equal(t, "interleaved-thinking-2025-05-14", getHeaderRaw(req.Header, "anthropic-beta"))
+	require.Equal(t, "3", getHeaderRaw(req.Header, "x-stainless-retry-count"))
+}
+
+func TestGatewayService_AnthropicOAuthPassthrough_ForwardSkipsFingerprintRewrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	c.Request.Header.Set("User-Agent", "python-requests/2.32")
+	c.Request.Header.Set("Anthropic-Beta", "oauth-2025-04-20")
+
+	body := []byte(`{"model":"claude-sonnet-4-6","stream":false,"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
+	parsed := &ParsedRequest{
+		Body:   NewRequestBodyRef(body),
+		Model:  "claude-sonnet-4-6",
+		Stream: false,
+	}
+
+	upstream := &anthropicHTTPUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"application/json"},
+				"x-request-id": []string{"rid-oauth-pass"},
+			},
+			Body: io.NopCloser(strings.NewReader(`{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-4-6","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)),
+		},
+	}
+
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			MaxLineSize: defaultMaxLineSize,
+		},
+	}
+	svc := &GatewayService{
+		cfg:                  cfg,
+		responseHeaderFilter: compileResponseHeaderFilter(cfg),
+		httpUpstream:         upstream,
+		rateLimitService:     &RateLimitService{},
+	}
+
+	account := newAnthropicOAuthAccountForPassthroughTest()
+	_, err := svc.forwardAnthropicOAuthPassthroughWithInput(context.Background(), c, account, anthropicPassthroughForwardInput{
+		Body:          body,
+		Parsed:        parsed,
+		RequestModel:  "claude-sonnet-4-6",
+		OriginalModel: "claude-sonnet-4-6",
+		RequestStream: false,
+		StartTime:     time.Now(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "python-requests/2.32", getHeaderRaw(upstream.lastReq.Header, "user-agent"))
+	require.Equal(t, "Bearer upstream-oauth-token", getHeaderRaw(upstream.lastReq.Header, "authorization"))
+	require.Empty(t, getHeaderRaw(upstream.lastReq.Header, "x-stainless-lang"), "OAuth 透传不应注入 OAuth 指纹头")
+	require.Equal(t, "claude-sonnet-4-6", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "hello", gjson.GetBytes(upstream.lastBody, "messages.0.content.0.text").String())
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4815,6 +4815,17 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		})
 	}
 
+	if account != nil && account.IsAnthropicOAuthPassthroughEnabled() {
+		return s.forwardAnthropicOAuthPassthroughWithInput(ctx, c, account, anthropicPassthroughForwardInput{
+			Body:          parsed.Body.Bytes(),
+			Parsed:        parsed,
+			RequestModel:  parsed.Model,
+			OriginalModel: parsed.Model,
+			RequestStream: parsed.Stream,
+			StartTime:     startTime,
+		})
+	}
+
 	if account != nil && account.IsBedrock() {
 		return s.forwardBedrock(ctx, c, account, parsed, startTime)
 	}
@@ -5862,12 +5873,36 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	account *Account,
 	input anthropicPassthroughForwardInput,
 ) (*ForwardResult, error) {
+	return s.forwardAnthropicPassthroughWithInput(ctx, c, account, input, anthropicPassthroughAuthAPIKey)
+}
+
+func anthropicPassthroughAuthLabel(kind anthropicPassthroughAuthKind) string {
+	if kind == anthropicPassthroughAuthOAuth {
+		return "OAuth"
+	}
+	return "API Key"
+}
+
+func (s *GatewayService) forwardAnthropicPassthroughWithInput(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	input anthropicPassthroughForwardInput,
+	authKind anthropicPassthroughAuthKind,
+) (*ForwardResult, error) {
 	token, tokenType, err := s.GetAccessToken(ctx, account)
 	if err != nil {
 		return nil, err
 	}
-	if tokenType != AccountTypeAPIKey {
-		return nil, fmt.Errorf("anthropic api key passthrough requires apikey token, got: %s", tokenType)
+	switch authKind {
+	case anthropicPassthroughAuthOAuth:
+		if tokenType != AccountTypeOAuth && tokenType != AccountTypeSetupToken {
+			return nil, fmt.Errorf("anthropic oauth passthrough requires oauth token, got: %s", tokenType)
+		}
+	default:
+		if tokenType != AccountTypeAPIKey {
+			return nil, fmt.Errorf("anthropic api key passthrough requires apikey token, got: %s", tokenType)
+		}
 	}
 
 	proxyURL := ""
@@ -5875,11 +5910,14 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 		proxyURL = account.Proxy.URL()
 	}
 
-	logger.LegacyPrintf("service.gateway", "[Anthropic 自动透传] 命中 API Key 透传分支: account=%d name=%s model=%s stream=%v",
-		account.ID, account.Name, input.RequestModel, input.RequestStream)
+	logger.LegacyPrintf("service.gateway", "[Anthropic 自动透传] 命中 %s 透传分支: account=%d name=%s model=%s stream=%v",
+		anthropicPassthroughAuthLabel(authKind), account.ID, account.Name, input.RequestModel, input.RequestStream)
 
 	if c != nil {
 		c.Set("anthropic_passthrough", true)
+		if authKind == anthropicPassthroughAuthOAuth {
+			c.Set("anthropic_oauth_passthrough", true)
+		}
 	}
 	// TK: strip the Claude Code 1M-context model alias ("...[1m]") before forward
 	// so the API-key passthrough path does not 404 + silently downgrade to 200K
@@ -5965,7 +6003,7 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	adaptiveRetryAttempted := false
 	for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
 		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, input.RequestStream)
-		upstreamReq, wireBody, err := s.buildUpstreamRequestAnthropicAPIKeyPassthrough(upstreamCtx, c, account, input.Body, token)
+		upstreamReq, wireBody, err := s.buildAnthropicPassthroughUpstreamRequest(upstreamCtx, c, account, input.Body, token, authKind)
 		releaseUpstreamCtx()
 		if err != nil {
 			return nil, err
@@ -10205,7 +10243,11 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 				logger.LegacyPrintf("service.gateway", "CountTokens passthrough model mapping: %s -> %s (account: %s)", reqModel, mappedModel, account.Name)
 			}
 		}
-		return s.forwardCountTokensAnthropicAPIKeyPassthrough(ctx, c, account, passthroughBody)
+		return s.forwardCountTokensAnthropicPassthrough(ctx, c, account, passthroughBody, anthropicPassthroughAuthAPIKey)
+	}
+
+	if account != nil && account.IsAnthropicOAuthPassthroughEnabled() {
+		return s.forwardCountTokensAnthropicPassthrough(ctx, c, account, parsed.Body.Bytes(), anthropicPassthroughAuthOAuth)
 	}
 
 	// Bedrock 不支持 count_tokens 端点
@@ -10542,14 +10584,32 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 }
 
 func (s *GatewayService) forwardCountTokensAnthropicAPIKeyPassthrough(ctx context.Context, c *gin.Context, account *Account, body []byte) error {
+	return s.forwardCountTokensAnthropicPassthrough(ctx, c, account, body, anthropicPassthroughAuthAPIKey)
+}
+
+func (s *GatewayService) forwardCountTokensAnthropicPassthrough(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	authKind anthropicPassthroughAuthKind,
+) error {
 	token, tokenType, err := s.GetAccessToken(ctx, account)
 	if err != nil {
 		s.countTokensError(c, http.StatusBadGateway, "upstream_error", "Failed to get access token")
 		return err
 	}
-	if tokenType != AccountTypeAPIKey {
-		s.countTokensError(c, http.StatusBadGateway, "upstream_error", "Invalid account token type")
-		return fmt.Errorf("anthropic api key passthrough requires apikey token, got: %s", tokenType)
+	switch authKind {
+	case anthropicPassthroughAuthOAuth:
+		if tokenType != AccountTypeOAuth && tokenType != AccountTypeSetupToken {
+			s.countTokensError(c, http.StatusBadGateway, "upstream_error", "Invalid account token type")
+			return fmt.Errorf("anthropic oauth passthrough requires oauth token, got: %s", tokenType)
+		}
+	default:
+		if tokenType != AccountTypeAPIKey {
+			s.countTokensError(c, http.StatusBadGateway, "upstream_error", "Invalid account token type")
+			return fmt.Errorf("anthropic api key passthrough requires apikey token, got: %s", tokenType)
+		}
 	}
 
 	// Pre-filter: strip fields that count_tokens rejects (see comment on the
@@ -10575,7 +10635,7 @@ func (s *GatewayService) forwardCountTokensAnthropicAPIKeyPassthrough(ctx contex
 		}
 	}
 
-	upstreamReq, err := s.buildCountTokensRequestAnthropicAPIKeyPassthrough(ctx, c, account, body, token)
+	upstreamReq, err := s.buildAnthropicPassthroughCountTokensRequest(ctx, c, account, body, token, authKind)
 	if err != nil {
 		s.countTokensError(c, http.StatusInternalServerError, "api_error", "Failed to build request")
 		return err

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 571,
-  "hash": "01573a6c427359e09cb0bd6d3b119b57930b2ed9a1820f39b93364b424b96394",
+  "hash": "37cc1f43fdb8f3476744e5ca6453673e245f2a53ab318c87bd432fec934f2311",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2260,6 +2260,36 @@
         </div>
       </div>
 
+      <!-- Anthropic OAuth 自动透传开关 -->
+      <div
+        v-if="form.platform === 'anthropic' && accountCategory === 'oauth-based'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.anthropic.oauthPassthrough') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.anthropic.oauthPassthroughDesc') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            @click="anthropicOAuthPassthroughEnabled = !anthropicOAuthPassthroughEnabled"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              anthropicOAuthPassthroughEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                anthropicOAuthPassthroughEnabled ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- 配额控制 (Anthropic OAuth/SetupToken: 亲和 + 窗口费用 + 会话 + RPM 等) -->
       <div
         v-if="form.platform === 'anthropic' && accountCategory === 'oauth-based'"
@@ -3644,6 +3674,7 @@ const codexCLIOnlyEnabled = ref(false)
 const codexCLIOnlyAppServerEnabled = ref(false)
 type AnthropicAPIKeyAuthScheme = 'x_api_key' | 'authorization_bearer'
 const anthropicPassthroughEnabled = ref(false)
+const anthropicOAuthPassthroughEnabled = ref(false)
 const anthropicAPIKeyAuthScheme = ref<AnthropicAPIKeyAuthScheme>('x_api_key')
 const webSearchEmulationMode = ref('default')
 const webSearchGlobalEnabled = ref(false)
@@ -4252,6 +4283,7 @@ watch(
     }
     if (newPlatform !== PLATFORM_ANTHROPIC) {
       anthropicPassthroughEnabled.value = false
+  anthropicOAuthPassthroughEnabled.value = false
       anthropicAPIKeyAuthScheme.value = 'x_api_key'
       webSearchEmulationMode.value = 'default'
     }
@@ -4275,6 +4307,7 @@ watch(
     }
     if (platform !== PLATFORM_ANTHROPIC || category !== 'apikey') {
       anthropicPassthroughEnabled.value = false
+  anthropicOAuthPassthroughEnabled.value = false
       anthropicAPIKeyAuthScheme.value = 'x_api_key'
       webSearchEmulationMode.value = 'default'
     }
@@ -4664,6 +4697,7 @@ const resetForm = () => {
   codexCLIOnlyEnabled.value = false
   codexCLIOnlyAppServerEnabled.value = false
   anthropicPassthroughEnabled.value = false
+  anthropicOAuthPassthroughEnabled.value = false
   anthropicAPIKeyAuthScheme.value = 'x_api_key'
   webSearchEmulationMode.value = 'default'
   // Reset quota control state
@@ -4781,6 +4815,14 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
   }
 
   return Object.keys(extra).length > 0 ? extra : undefined
+}
+
+const writeAnthropicOAuthPassthroughExtra = (extra: Record<string, unknown>) => {
+  if (anthropicOAuthPassthroughEnabled.value) {
+    extra.anthropic_oauth_passthrough = true
+  } else {
+    delete extra.anthropic_oauth_passthrough
+  }
 }
 
 const buildAnthropicExtra = (base?: Record<string, unknown>): Record<string, unknown> | undefined => {
@@ -6052,6 +6094,8 @@ const handleAnthropicExchange = async (authCode: string) => {
       extra.custom_base_url = customBaseUrl.value.trim()
     }
 
+    writeAnthropicOAuthPassthroughExtra(extra)
+
     const credentials: Record<string, unknown> = { ...tokenInfo }
     applyInterceptWarmup(credentials, interceptWarmupRequests.value, 'create')
     await createAccountAndFinish(form.platform, addMethod.value as AccountType, credentials, extra)
@@ -6170,6 +6214,8 @@ const handleCookieAuth = async (sessionKey: string) => {
           extra.custom_base_url_enabled = true
           extra.custom_base_url = customBaseUrl.value.trim()
         }
+
+        writeAnthropicOAuthPassthroughExtra(extra)
 
         const accountName = keys.length > 1 ? `${form.name} #${i + 1}` : form.name
 

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -2074,6 +2074,36 @@
         </div>
       </div>
 
+      <!-- Anthropic OAuth 自动透传开关 -->
+      <div
+        v-if="account?.platform === 'anthropic' && (account?.type === 'oauth' || account?.type === 'setup-token')"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.anthropic.oauthPassthrough') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.anthropic.oauthPassthroughDesc') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            @click="anthropicOAuthPassthroughEnabled = !anthropicOAuthPassthroughEnabled"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              anthropicOAuthPassthroughEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                anthropicOAuthPassthroughEnabled ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- 配额控制 (Anthropic OAuth/SetupToken: 亲和 + 窗口费用 + 会话 + RPM 等) -->
       <div
         v-if="account?.platform === 'anthropic' && (account?.type === 'oauth' || account?.type === 'setup-token')"
@@ -2831,6 +2861,7 @@ type CodexImageToolMode = 'inherit' | 'enabled' | 'disabled' | 'block'
 const codexImageToolMode = ref<CodexImageToolMode>('inherit')
 type AnthropicAPIKeyAuthScheme = 'x_api_key' | 'authorization_bearer'
 const anthropicPassthroughEnabled = ref(false)
+const anthropicOAuthPassthroughEnabled = ref(false)
 const anthropicAPIKeyAuthScheme = ref<AnthropicAPIKeyAuthScheme>('x_api_key')
 const webSearchEmulationMode = ref('default')
 const webSearchGlobalEnabled = ref(false)
@@ -3308,6 +3339,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   codexCLIOnlyAppServerEnabled.value = false
   codexImageToolMode.value = 'inherit'
   anthropicPassthroughEnabled.value = false
+  anthropicOAuthPassthroughEnabled.value = false
   anthropicAPIKeyAuthScheme.value = 'x_api_key'
   webSearchEmulationMode.value = 'default'
   if (newAccount.platform === PLATFORM_OPENAI && (newAccount.type === 'oauth' || newAccount.type === 'setup-token' || newAccount.type === 'apikey')) {
@@ -3855,6 +3887,7 @@ function loadQuotaControlSettings(account: Account) {
   cacheTTLOverrideTarget.value = '5m'
   customBaseUrlEnabled.value = false
   customBaseUrl.value = ''
+  anthropicOAuthPassthroughEnabled.value = false
 
   // Remaining quota control settings only apply to Anthropic accounts
   if (account.platform !== PLATFORM_ANTHROPIC) {
@@ -3865,6 +3898,9 @@ function loadQuotaControlSettings(account: Account) {
   if (account.type !== 'oauth' && account.type !== 'setup-token') {
     return
   }
+
+  anthropicOAuthPassthroughEnabled.value =
+    (account.extra as Record<string, unknown> | undefined)?.anthropic_oauth_passthrough === true
 
   // Load from extra field (via backend DTO fields)
   if (account.max_sessions != null && account.max_sessions > 0) {
@@ -4446,6 +4482,12 @@ const handleSubmit = async () => {
     if (props.account.platform === PLATFORM_ANTHROPIC && (props.account.type === 'oauth' || props.account.type === 'setup-token')) {
       const currentExtra = (updatePayload.extra as Record<string, unknown>) || (props.account.extra as Record<string, unknown>) || {}
       const newExtra: Record<string, unknown> = { ...currentExtra }
+
+      if (anthropicOAuthPassthroughEnabled.value) {
+        newExtra.anthropic_oauth_passthrough = true
+      } else {
+        delete newExtra.anthropic_oauth_passthrough
+      }
 
       // Window cost limit settings
       // Session limit settings

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -4142,6 +4142,9 @@ export default {
         apiKeyPassthrough: 'Auto passthrough (auth only)',
         apiKeyPassthroughDesc:
           'Only applies to Anthropic API Key accounts. When enabled, messages/count_tokens are forwarded in passthrough mode with auth replacement only, while billing/concurrency/audit and safety filtering are preserved. Disable to roll back immediately.',
+        oauthPassthrough: 'OAuth auto passthrough (auth only)',
+        oauthPassthroughDesc:
+          'Only applies to Anthropic OAuth/setup-token accounts. When enabled, skips fingerprint/mimic/canonical rewrites and forwards messages/count_tokens with Authorization replacement only, while billing/concurrency/audit and safety filtering are preserved.',
         mirrorPlatform: 'Mirror platform',
         mirrorPlatformHint:
           'Only for edge "mirror stub" accounts (base URL points at an internal api-<edge>.tokenkey.dev host). Declares which edge pool this stub mirrors its concurrency from: Anthropic (default) or Kiro. Leave Anthropic for normal API Key accounts.',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -4315,6 +4315,9 @@ export default {
         apiKeyPassthrough: '自动透传（仅替换认证）',
         apiKeyPassthroughDesc:
           '仅对 Anthropic API Key 生效。开启后，messages/count_tokens 请求将透传上游并仅替换认证，保留计费/并发/审计及必要安全过滤；关闭即可回滚到现有兼容链路。',
+        oauthPassthrough: 'OAuth 自动透传（仅替换认证）',
+        oauthPassthroughDesc:
+          '仅对 Anthropic OAuth/setup-token 生效。开启后跳过 fingerprint、mimic、canonical 等改写，messages/count_tokens 仅替换 Authorization；保留计费/并发/审计及必要安全过滤。',
         mirrorPlatform: '镜像平台',
         mirrorPlatformHint:
           '仅用于对接 edge 的「镜像 stub」账号（base URL 指向内部 api-<edge>.tokenkey.dev）。声明该 stub 从 edge 的哪个池镜像并发：Anthropic（默认）或 Kiro。普通 API Key 账号保持 Anthropic 即可。',

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4207,6 +4207,43 @@
         "openAIWSPassthroughPolicyModelForFrame(account, payload)"
       ],
       "rationale": "WS v2 passthrough dial/error rate-limit signals must carry the session model (first-frame model or per-frame policy resolver fallback) into persistOpenAIWSRateLimitSignal; losing these args reverts spark sub-window 429s to whole-account cooldown on passthrough ingress."
+    },
+    {
+      "path": "backend/internal/service/account.go",
+      "must_contain": [
+        "func (a *Account) IsAnthropicOAuthPassthroughEnabled() bool {",
+        "anthropic_oauth_passthrough"
+      ],
+      "rationale": "Account-level opt-in for Anthropic OAuth/setup-token auth-only passthrough (skip fingerprint/mimic/canonical on the wire). Without this extra gate, operators cannot enable the dedicated branch and the gateway falls back to the full OAuth rewrite path."
+    },
+    {
+      "path": "backend/internal/service/gateway_anthropic_oauth_passthrough.go",
+      "must_contain": [
+        "func (s *GatewayService) buildUpstreamRequestAnthropicOAuthPassthrough(",
+        "func (s *GatewayService) buildCountTokensRequestAnthropicOAuthPassthrough(",
+        "func setAnthropicOAuthPassthroughAuthHeader(headers http.Header, token string)",
+        "anthropicPassthroughAuthOAuth"
+      ],
+      "rationale": "TK companion for Anthropic OAuth auth-only passthrough upstream builders. Keeps Bearer auth replacement + header whitelist copy out of upstream-shaped gateway_service.go so merges cannot silently drop the bypass while leaving the Forward early-return intact."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "account.IsAnthropicOAuthPassthroughEnabled()",
+        "forwardAnthropicOAuthPassthroughWithInput",
+        "forwardAnthropicPassthroughWithInput",
+        "anthropicPassthroughAuthOAuth"
+      ],
+      "rationale": "Load-bearing wiring: OAuth passthrough must early-return in Forward and ForwardCountTokens BEFORE canonical/mimic/fingerprint rewrite, reusing the shared passthrough forward loop with anthropicPassthroughAuthOAuth. An upstream merge that drops either early-return re-enables fingerprint/mimic/canonical for accounts explicitly configured for raw egress."
+    },
+    {
+      "path": "backend/internal/service/gateway_anthropic_oauth_passthrough_test.go",
+      "must_contain": [
+        "TestBuildUpstreamRequestAnthropicOAuthPassthrough_PreservesClientHeadersAndBearerAuth",
+        "TestGatewayService_AnthropicOAuthPassthrough_ForwardSkipsFingerprintRewrite",
+        "x-stainless-lang"
+      ],
+      "rationale": "Focused regressions: OAuth passthrough must preserve client UA/anthropic-beta and must NOT inject OAuth fingerprint headers on the forward path."
     }
   ]
 }


### PR DESCRIPTION
## 摘要

- 为 Anthropic OAuth / setup-token 账号新增 `anthropic_oauth_passthrough` 开关，命中后走独立透传分支：仅替换上游 Bearer 鉴权，保留客户端原始请求头与 body。
- 跳过 CC fingerprint、mimic、canonical OAuth 改写链路，降低非 Claude Code 客户端或自定义 UA 场景下的兼容风险。
- 管理端创建/编辑账号弹窗与中英文文案同步支持该开关。

## 风险

- 常规风险：仅影响显式开启 `anthropic_oauth_passthrough` 的 Anthropic OAuth/setup-token 账号；默认行为不变。
- 透传路径仍会执行 sticky metadata、空块清理等既有安全/计费辅助逻辑，但不注入 OAuth 指纹头。
- 前端 dist 指纹文件 `frontend-source.json` 已随 `pnpm build` 更新，满足 preflight 资产一致性检查。

## 验证

- `cd backend && go test -tags=unit ./internal/service/ -run 'AnthropicOAuthPassthrough|IsAnthropicOAuthPassthrough' -count=1` — PASS
- `cd backend && go test -tags=unit ./internal/handler/admin/ -run 'AnthropicOAuthPassthrough' -count=1` — PASS
- `./scripts/preflight.sh` — PASS（含 frontend release asset contract）
- `python3 scripts/sentinels/check-registry-update-gate.py --base origin/main` — PASS
- `python3 scripts/sentinels/check-gateway-tk.py` — PASS (447/447)
- CI（含 marker-acknowledgement / test-unit / test-integration / preflight）— 全绿

## 提交

- c590e021b feat(gateway): Anthropic OAuth 账号支持 auth-only 透传，跳过 fingerprint/mimic/canonical
- aad987213 chore(sentinels): anchor Anthropic OAuth passthrough gateway wiring
- 最新提交：aad987213