### PR TITLE
fix(gateway): 退役 Anthropic 模型入口预检，堵住 load-batch routing 429 漏口

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -282,6 +282,12 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 	// 判断是否真的绑定了粘性会话：有 sessionKey 且已经绑定到某个账号
 	hasBoundSession := sessionKey != "" && sessionBoundAccountID > 0
 
+	if platform == service.PlatformAnthropic {
+		if h.tkWriteDeprecatedAnthropicModelAtIngress(c, reqModel, reqLog) {
+			return
+		}
+	}
+
 	if platform == service.PlatformGemini {
 		fs := NewFailoverState(h.maxAccountSwitchesGemini, hasBoundSession)
 
@@ -1799,6 +1805,10 @@ func (h *GatewayHandler) CountTokens(c *gin.Context) {
 	// 验证 model 必填
 	if parsedReq.Model == "" {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "model is required")
+		return
+	}
+
+	if h.tkWriteDeprecatedAnthropicModelAtIngress(c, parsedReq.Model, reqLog) {
 		return
 	}
 

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -101,6 +101,10 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		}
 	}
 
+	if h.tkWriteDeprecatedAnthropicModelAtIngress(c, reqModel, reqLog) {
+		return
+	}
+
 	// 解析渠道级模型映射
 	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(requestCtx, apiKey.GroupID, reqModel)
 

--- a/backend/internal/handler/gateway_handler_tk_deprecated_model.go
+++ b/backend/internal/handler/gateway_handler_tk_deprecated_model.go
@@ -8,10 +8,34 @@ import (
 	"go.uber.org/zap"
 )
 
-// tkWriteDeprecatedAnthropicModelIfApplicable maps a service.ErrDeprecatedAnthropicModel
-// account-selection failure to the Anthropic-shape HTTP 400 migration envelope and
-// returns true (handled). For any other error it returns false so the caller falls
-// through to unsupported-model / empty-pool handling.
+// tkWriteDeprecatedAnthropicModelResponse writes the Anthropic-shape HTTP 400
+// migration envelope when reqModel is on the retired list. Returns true when
+// handled (response committed).
+func tkWriteDeprecatedAnthropicModelResponse(c *gin.Context, reqModel string, reqLog *zap.Logger, logEvent string) bool {
+	_, replacement, ok := service.TkLookupDeprecatedAnthropicModel(reqModel)
+	if !ok {
+		return false
+	}
+	if reqLog != nil && logEvent != "" {
+		reqLog.Warn(logEvent, zap.String("model", reqModel))
+	}
+	markOpsClientRequestRejected(c)
+	service.TkWriteAnthropicDeprecatedModelError(c, reqModel, replacement)
+	return true
+}
+
+// tkWriteDeprecatedAnthropicModelAtIngress rejects retired Anthropic model IDs
+// before account selection so sunset requests never enter routing/scheduling or
+// surface as empty-pool routing 429.
+func (h *GatewayHandler) tkWriteDeprecatedAnthropicModelAtIngress(c *gin.Context, reqModel string, reqLog *zap.Logger) bool {
+	return tkWriteDeprecatedAnthropicModelResponse(c, reqModel, reqLog, "gateway.deprecated_model_ingress_reject")
+}
+
+// tkWriteDeprecatedAnthropicModelIfApplicable maps account-selection failures for
+// retired models to the Anthropic-shape HTTP 400 migration envelope and returns
+// true (handled). Covers ErrDeprecatedAnthropicModel from tkWrapSelectionFailure /
+// TkSelectionNoAvailableAccountsError, and load-batch ErrNoAvailableAccounts when
+// reqModel is still a sunset id.
 //
 // Why this exists: the Forward-path deprecated gate (gateway_anthropic_deprecated_model_tk.go)
 // only runs after an account is selected. When every whitelist account rejects a
@@ -19,18 +43,11 @@ import (
 // used to fall back to ErrNoAvailableAccounts → routing 429 + Retry-After even though
 // the client can never succeed without migrating off the sunset id.
 func (h *GatewayHandler) tkWriteDeprecatedAnthropicModelIfApplicable(c *gin.Context, err error, reqModel string, reqLog *zap.Logger) bool {
-	if !errors.Is(err, service.ErrDeprecatedAnthropicModel) {
-		return false
+	if errors.Is(err, service.ErrDeprecatedAnthropicModel) {
+		return tkWriteDeprecatedAnthropicModelResponse(c, reqModel, reqLog, "gateway.select_account_deprecated_model")
 	}
-	if reqLog != nil {
-		reqLog.Warn("gateway.select_account_deprecated_model",
-			zap.String("model", reqModel),
-			zap.Error(err),
-		)
+	if isOpsNoAvailableAccountError(err) {
+		return tkWriteDeprecatedAnthropicModelResponse(c, reqModel, reqLog, "gateway.select_account_deprecated_model")
 	}
-	markOpsClientRequestRejected(c)
-	if _, replacement, ok := service.TkLookupDeprecatedAnthropicModel(reqModel); ok {
-		service.TkWriteAnthropicDeprecatedModelError(c, reqModel, replacement)
-	}
-	return true
+	return false
 }

--- a/backend/internal/handler/gateway_handler_tk_deprecated_model_test.go
+++ b/backend/internal/handler/gateway_handler_tk_deprecated_model_test.go
@@ -33,9 +33,41 @@ func TestTkWriteDeprecatedAnthropicModelIfApplicable(t *testing.T) {
 	assert.Equal(t, service.TkDeprecatedAnthropicErrorType, errObj["type"])
 }
 
-func TestTkWriteDeprecatedAnthropicModelIfApplicable_IgnoresOtherErrors(t *testing.T) {
+func TestTkWriteDeprecatedAnthropicModelIfApplicable_NoAvailableAccountsUpgradesDeprecated(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	require.True(t, h.tkWriteDeprecatedAnthropicModelIfApplicable(c, service.ErrNoAvailableAccounts, "claude-3-5-haiku-20241022", nil))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Empty(t, w.Header().Get("Retry-After"))
+}
+
+func TestTkWriteDeprecatedAnthropicModelIfApplicable_IgnoresCapacityForCurrentModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	h := &GatewayHandler{}
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	require.False(t, h.tkWriteDeprecatedAnthropicModelIfApplicable(c, service.ErrNoAvailableAccounts, "claude-3-5-sonnet-20241022", nil))
+	require.False(t, h.tkWriteDeprecatedAnthropicModelIfApplicable(c, service.ErrNoAvailableAccounts, "claude-sonnet-4-6", nil))
+}
+
+func TestTkWriteDeprecatedAnthropicModelAtIngress(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	require.True(t, h.tkWriteDeprecatedAnthropicModelAtIngress(c, "claude-3-5-haiku-20241022", nil))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Empty(t, w.Header().Get("Retry-After"))
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &payload))
+	errObj, ok := payload["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, service.TkDeprecatedAnthropicErrorType, errObj["type"])
 }

--- a/backend/internal/handler/no_available_accounts_tk.go
+++ b/backend/internal/handler/no_available_accounts_tk.go
@@ -86,6 +86,11 @@ func tkSelectFailureStatusMessage(c *gin.Context, err error, reqModel string) (i
 		return http.StatusBadRequest, service.TkUnsupportedModelErrType, service.TkUnsupportedModelMessage(reqModel)
 	}
 	if isOpsNoAvailableAccountError(err) {
+		if _, replacement, ok := service.TkLookupDeprecatedAnthropicModel(reqModel); ok {
+			markOpsClientRequestRejected(c)
+			return http.StatusBadRequest, service.TkDeprecatedAnthropicErrorType,
+				service.TkBuildDeprecatedAnthropicMessage(reqModel, replacement)
+		}
 		return tkNoAvailableAccounts(c), "api_error", "No available accounts: " + err.Error()
 	}
 	return http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable"

--- a/backend/internal/handler/no_available_accounts_tk_test.go
+++ b/backend/internal/handler/no_available_accounts_tk_test.go
@@ -61,6 +61,16 @@ func TestTkSelectFailureStatusMessage(t *testing.T) {
 		assert.Empty(t, w.Header().Get("Retry-After"))
 	})
 
+	t.Run("no_available_accounts_with_deprecated_model_returns_400", func(t *testing.T) {
+		c, w := newCtx(t)
+		status, errType, msg := tkSelectFailureStatusMessage(c, service.ErrNoAvailableAccounts, "claude-3-5-haiku-20241022")
+
+		require.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, service.TkDeprecatedAnthropicErrorType, errType)
+		assert.Contains(t, msg, "claude-3-5-haiku-20241022")
+		assert.Empty(t, w.Header().Get("Retry-After"))
+	})
+
 	t.Run("unsupported_model_returns_400_invalid_request", func(t *testing.T) {
 		// The scheduler determined no account in the pool serves this model NAME
 		// (e.g. a client sending "deepseek-chat" to a pool mapping only

--- a/backend/internal/service/gateway_anthropic_deprecated_model_tk.go
+++ b/backend/internal/service/gateway_anthropic_deprecated_model_tk.go
@@ -132,6 +132,17 @@ func tkDeprecatedAnthropicSelectionFailure(requestedModel string) error {
 	return nil
 }
 
+// TkSelectionNoAvailableAccountsError returns ErrDeprecatedAnthropicModel when
+// requestedModel is on the retired list; otherwise ErrNoAvailableAccounts.
+// Load-batch scheduling uses this instead of bare ErrNoAvailableAccounts so sunset
+// ids classify as client 400, not routing 429 (see PR #1255 + load-batch gap).
+func TkSelectionNoAvailableAccountsError(requestedModel string) error {
+	if err := tkDeprecatedAnthropicSelectionFailure(requestedModel); err != nil {
+		return err
+	}
+	return ErrNoAvailableAccounts
+}
+
 // TkWriteAnthropicDeprecatedModelError emits the Anthropic-shape 400 error
 // for a retired model request and aborts further gin handling. Safe to call
 // with c == nil (no-op).

--- a/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
+++ b/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
@@ -138,3 +138,15 @@ func TestTkWrapSelectionFailure_DeprecatedModelBeatsRouting429(t *testing.T) {
 	require.False(t, errors.Is(err, ErrNoAvailableAccounts))
 	require.False(t, errors.Is(err, ErrUnsupportedModel))
 }
+
+func TestTkSelectionNoAvailableAccountsError_DeprecatedModel(t *testing.T) {
+	err := TkSelectionNoAvailableAccountsError("claude-3-5-haiku-20241022")
+	require.ErrorIs(t, err, ErrDeprecatedAnthropicModel)
+	require.NotContains(t, strings.ToLower(err.Error()), "no available accounts")
+}
+
+func TestTkSelectionNoAvailableAccountsError_CurrentModel(t *testing.T) {
+	err := TkSelectionNoAvailableAccountsError("claude-sonnet-4-6")
+	require.ErrorIs(t, err, ErrNoAvailableAccounts)
+	require.False(t, errors.Is(err, ErrDeprecatedAnthropicModel))
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1813,7 +1813,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 		return nil, err
 	}
 	if len(accounts) == 0 {
-		return nil, ErrNoAvailableAccounts
+		return nil, TkSelectionNoAvailableAccountsError(requestedModel)
 	}
 	ctx = s.withRPMPrefetch(ctx, accounts)
 
@@ -2330,7 +2330,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 			)
 			return nil, ErrThinPoolAllExcluded
 		}
-		return nil, ErrNoAvailableAccounts
+		return nil, TkSelectionNoAvailableAccountsError(requestedModel)
 	}
 
 	accountLoads := make([]AccountWithConcurrency, 0, len(candidates))
@@ -2424,7 +2424,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 			MaxWaiting:     cfg.FallbackMaxWaiting,
 		})
 	}
-	return nil, ErrNoAvailableAccounts
+	return nil, TkSelectionNoAvailableAccountsError(requestedModel)
 }
 
 func (s *GatewayService) tryAcquireByLegacyOrder(ctx context.Context, candidates []*Account, groupID *int64, sessionHash string, preferOAuth bool) (*AccountSelectionResult, bool, error) {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1292,12 +1292,13 @@
         "ErrDeprecatedAnthropicModel",
         "tkDeprecatedAnthropicSelectionFailure",
         "tkDeprecatedAnthropicModels",
+        "func TkSelectionNoAvailableAccountsError",
         "claude-3-5-sonnet-20241022",
         "claude-3-7-sonnet-20250219",
         "claude-sonnet-4-20250514",
         "claude-opus-4-20250514"
       ],
-      "rationale": "Anchors the customer-facing deprecation gate for retired / soon-to-sunset Anthropic model IDs. PR #329 / #327 removed the IDs from admin dropdowns + default chain but did NOT short-circuit requests; this module turns hardcoded-client requests into a friendly 400 + migration suggestion instead of an opaque upstream not_found_error or routing 429 when selection fails before Forward. ErrDeprecatedAnthropicModel + tkDeprecatedAnthropicSelectionFailure pin the account-selection failure path (mixed model_unsupported + unschedulable stats previously fell through to empty-pool 429). The table literal IDs are pinned because dropping any silently re-opens the cliff for a specific client population. See /xj-review R-001 (decision path c)."
+      "rationale": "Anchors the customer-facing deprecation gate for retired / soon-to-sunset Anthropic model IDs. PR #329 / #327 removed the IDs from admin dropdowns + default chain but did NOT short-circuit requests; this module turns hardcoded-client requests into a friendly 400 + migration suggestion instead of an opaque upstream not_found_error or routing 429 when selection fails before Forward. ErrDeprecatedAnthropicModel + tkDeprecatedAnthropicSelectionFailure pin the account-selection failure path (mixed model_unsupported + unschedulable stats previously fell through to empty-pool 429). TkSelectionNoAvailableAccountsError pins the load-batch empty-pool returns in SelectAccountWithLoadAwareness (PR #1257 gap after #1255). The table literal IDs are pinned because dropping any silently re-opens the cliff for a specific client population. See /xj-review R-001 (decision path c)."
     },
     {
       "path": "backend/internal/service/gateway_service.go",
@@ -2547,26 +2548,46 @@
       "path": "backend/internal/handler/gateway_handler.go",
       "must_contain": [
         "h.tkWriteDeprecatedAnthropicModelIfApplicable(c, err, reqModel, reqLog)",
-        "h.tkWriteUnsupportedModelIfApplicable(c, err, reqModel, streamStarted, reqLog)"
+        "h.tkWriteUnsupportedModelIfApplicable(c, err, reqModel, streamStarted, reqLog)",
+        "h.tkWriteDeprecatedAnthropicModelAtIngress(c, reqModel, reqLog)",
+        "h.tkWriteDeprecatedAnthropicModelAtIngress(c, parsedReq.Model, reqLog)"
       ],
-      "rationale": "Handler half of unsupported-model + deprecated-model fixes on /v1/messages: select-account failures call tkWriteDeprecatedAnthropicModelIfApplicable BEFORE tkWriteUnsupportedModelIfApplicable, mapping ErrDeprecatedAnthropicModel to the Anthropic-shape migration 400 (client-owned) instead of routing 429 when the Forward-path gate never ran. Unsupported-model mapping stays on the next branch. Upstream merge that drops either early-return silently re-opens retry-storm 429s."
+      "rationale": "Handler half of unsupported-model + deprecated-model fixes on /v1/messages and count_tokens: tkWriteDeprecatedAnthropicModelAtIngress rejects sunset ids before scheduling (#1257); select-account failures call tkWriteDeprecatedAnthropicModelIfApplicable BEFORE tkWriteUnsupportedModelIfApplicable, mapping ErrDeprecatedAnthropicModel to the Anthropic-shape migration 400 (client-owned) instead of routing 429 when the Forward-path gate never ran."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "return nil, TkSelectionNoAvailableAccountsError(requestedModel)"
+      ],
+      "rationale": "Load-batch SelectAccountWithLoadAwareness empty-pool returns (zero schedulable accounts, Layer-2 no candidates, Layer-3 session-quota exhausted) must route through TkSelectionNoAvailableAccountsError so retired Anthropic model IDs become ErrDeprecatedAnthropicModel instead of bare ErrNoAvailableAccounts → routing 429. PR #1255 fixed tkWrapSelectionFailure only; this sentinel pins the three load-batch exit sites (#1257)."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_responses.go",
+      "must_contain": [
+        "h.tkWriteDeprecatedAnthropicModelAtIngress(c, reqModel, reqLog)"
+      ],
+      "rationale": "/v1/responses Anthropic ingress must reject retired model IDs before selection (#1257)."
     },
     {
       "path": "backend/internal/handler/gateway_handler_tk_deprecated_model.go",
       "must_contain": [
         "func (h *GatewayHandler) tkWriteDeprecatedAnthropicModelIfApplicable",
+        "func (h *GatewayHandler) tkWriteDeprecatedAnthropicModelAtIngress",
+        "func tkWriteDeprecatedAnthropicModelResponse",
+        "isOpsNoAvailableAccountError(err)",
         "service.ErrDeprecatedAnthropicModel",
         "service.TkWriteAnthropicDeprecatedModelError"
       ],
-      "rationale": "Companion wiring for deprecated-model account-selection failures on native Anthropic ingress. Without this handler hook, tkWrapSelectionFailure can return ErrDeprecatedAnthropicModel but /v1/messages would still fall through to empty-pool 429 handling."
+      "rationale": "Companion wiring for deprecated-model account-selection failures on native Anthropic ingress. tkWriteDeprecatedAnthropicModelAtIngress rejects before scheduling; tkWriteDeprecatedAnthropicModelIfApplicable upgrades load-batch ErrNoAvailableAccounts when reqModel is sunset (#1257)."
     },
     {
       "path": "backend/internal/handler/no_available_accounts_tk.go",
       "must_contain": [
         "service.ErrDeprecatedAnthropicModel",
+        "service.TkLookupDeprecatedAnthropicModel(reqModel)",
         "service.TkBuildDeprecatedAnthropicMessage"
       ],
-      "rationale": "OpenAI-compat + count_tokens select-failure mapper: tkSelectFailureStatusMessage must classify ErrDeprecatedAnthropicModel as HTTP 400 invalid_request_error (no Retry-After) before the empty-pool 429 branch."
+      "rationale": "OpenAI-compat + count_tokens select-failure mapper: tkSelectFailureStatusMessage must classify ErrDeprecatedAnthropicModel as HTTP 400 invalid_request_error (no Retry-After) before the empty-pool 429 branch, and upgrade bare ErrNoAvailableAccounts when reqModel is a sunset id (#1257)."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_unsupported_model.go",


### PR DESCRIPTION
## 摘要

- #1255 只在 `tkWrapSelectionFailure` / handler 识别 `ErrDeprecatedAnthropicModel` 时回 400；**load-batch 调度**（Layer 2/3 候选为空）仍返回裸 `ErrNoAvailableAccounts` → routing 429 + Retry-After。
- 补三层防线：Anthropic 入口预检（`/v1/messages`、`count_tokens`、`/v1/responses`）、`TkSelectionNoAvailableAccountsError`（load-batch 三处空池返回点）、选号失败兜底（`tkWriteDeprecatedAnthropicModelIfApplicable` / `tkSelectFailureStatusMessage` 对 sunset `reqModel` 升格）。
- 客户端仍打 `claude-3-5-haiku-20241022` 等退役 ID 时，直接收到 **400 invalid_request_error + 迁移文案**，不再触发 `routing_capacity_rejection` 风暴。

## 风险

- 常规风险：仅影响 retired 列表内的 Anthropic 模型 ID；当前可用模型（如 `claude-sonnet-4-6`）池满时仍正常 429 routing。
- 入口预检在选号前拦截 sunset id——与 #1255 一致，不再允许「靠 admin mapping 继续透明转发退役名」；有意推动客户端迁移。
- 无公共 API 字段变更。Web impact: none

## 验证

- `cd backend && go test -tags=unit ./internal/service -run 'TestTkDeprecated|TestTkWrapSelectionFailure|TestTkSelectionNoAvailableAccounts'` — PASS
- `cd backend && go test -tags=unit ./internal/handler -run 'TestTkSelectFailureStatusMessage|TestTkWriteDeprecated'` — PASS

## 提交

- `8d2ae2c18` fix(gateway): 退役 Anthropic 模型入口预检与 load-batch 空池改回 400

最新提交：`8d2ae2c18`

Made with [Cursor](https://cursor.com)