### PR TITLE
fix(ops): 清理遗留 probe 绑定并补齐 account-model 复用 scope

### DIFF
--- a/ops/observability/cleanup-probe-resources.sh
+++ b/ops/observability/cleanup-probe-resources.sh
@@ -130,12 +130,34 @@ disabled_groups AS (
     AND status <> 'disabled'
     AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
   RETURNING 1
+),
+legacy_soft_deleted_keys AS (
+  UPDATE api_keys
+  SET deleted_at = NOW(),
+      status = 'disabled',
+      updated_at = NOW()
+  WHERE deleted_at IS NULL
+    AND name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\'
+  RETURNING 1
+),
+legacy_soft_deleted_groups AS (
+  UPDATE groups
+  SET deleted_at = NOW(),
+      status = 'disabled',
+      updated_at = NOW()
+  WHERE deleted_at IS NULL
+    AND name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\'
+  RETURNING 1
 )
 SELECT 'deleted_account_group_bindings=' || COUNT(*) FROM deleted_bindings
 UNION ALL
 SELECT 'disabled_probe_keys=' || COUNT(*) FROM disabled_keys
 UNION ALL
-SELECT 'disabled_probe_groups=' || COUNT(*) FROM disabled_groups;
+SELECT 'disabled_probe_groups=' || COUNT(*) FROM disabled_groups
+UNION ALL
+SELECT 'soft_deleted_legacy_tkprobe_keys=' || COUNT(*) FROM legacy_soft_deleted_keys
+UNION ALL
+SELECT 'soft_deleted_legacy_tkprobe_groups=' || COUNT(*) FROM legacy_soft_deleted_groups;
 COMMIT;
 SQL
 }

--- a/ops/observability/prune-probe-resources.sh
+++ b/ops/observability/prune-probe-resources.sh
@@ -16,9 +16,11 @@ Usage:
 Default is dry-run. --apply soft-deletes non-canonical __tk_probe_* api_keys/groups.
 
 Canonical keep set (reused by live probe scripts):
-  anthropic_srcgrp_1_cc, anthropic_srcgrp_1_kiro, kiro_srcgrp_1_kiro,
+  catalog scopes: anthropic_srcgrp_1_cc, anthropic_srcgrp_1_kiro, kiro_srcgrp_1_kiro,
   openai_srcgrp_2, gemini_srcgrp_16, newapi_srcgrp_16, newapi_srcgrp_18,
   newapi_srcgrp_5, antigravity_srcgrp_21, grok_srcgrp_25
+  account-model reuse scopes: anthropic, kiro, openai, gemini, grok, antigravity, newapi
+  (always pruned: __tk_probe_tkprobe-* one-off groups from PROBE_REUSE_MODE=0)
 USAGE
 }
 
@@ -42,12 +44,24 @@ done
 
 PSQL_ARRAY=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRICING_LIB="$SCRIPT_DIR/../pricing/probe_reserved_resources.sh"
+if [ ! -f "$PRICING_LIB" ]; then
+	PRICING_LIB="$SCRIPT_DIR/probe_reserved_resources.sh"
+fi
+if [ ! -f "$PRICING_LIB" ]; then
+	echo "prune-probe-resources: missing probe_reserved_resources.sh (use run-probe --with ops/pricing/probe_reserved_resources.sh)" >&2
+	exit 1
+fi
+# shellcheck source=../pricing/probe_reserved_resources.sh
+. "$PRICING_LIB"
+
 tk_psql() {
 	"${PSQL_ARRAY[@]}" "$@"
 }
 
-# Scopes kept by tk_probe_canonical_scope for current ops scripts.
-CANONICAL_SCOPES=(
+# Catalog/route-gate scopes kept by tk_probe_canonical_scope for current ops scripts.
+CANONICAL_CATALOG_SCOPES=(
 	anthropic_srcgrp_1_cc
 	anthropic_srcgrp_1_kiro
 	kiro_srcgrp_1_kiro
@@ -59,6 +73,10 @@ CANONICAL_SCOPES=(
 	antigravity_srcgrp_21
 	grok_srcgrp_25
 )
+CANONICAL_SCOPES=("${CANONICAL_CATALOG_SCOPES[@]}")
+while IFS= read -r scope; do
+	[ -n "$scope" ] && CANONICAL_SCOPES+=("$scope")
+done < <(tk_probe_platform_reuse_scopes)
 
 keep_sql_values() {
 	local scope first=1
@@ -92,6 +110,17 @@ SELECT 'prune_candidates_keys=' || COUNT(*) FROM api_keys
 WHERE deleted_at IS NULL
   AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
   AND name NOT IN ${KEEP_NAMES};
+SELECT 'prune_candidates_legacy_tkprobe_groups=' || COUNT(*) FROM groups
+WHERE name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\'
+  AND deleted_at IS NULL;
+SELECT 'stale_probe_bindings=' || COUNT(*) FROM account_groups ag
+JOIN groups g ON g.id = ag.group_id
+WHERE g.deleted_at IS NULL
+  AND g.name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
+  AND (
+    g.name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\'
+    OR g.name NOT IN ${KEEP_NAMES}
+  );
 SELECT 'kept_group_names=' || COALESCE(string_agg(name, ', ' ORDER BY name), '')
 FROM groups
 WHERE deleted_at IS NULL AND name IN ${KEEP_NAMES};

--- a/ops/observability/test_prune_probe_resources.sh
+++ b/ops/observability/test_prune_probe_resources.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Static checks for prune-probe-resources.sh canonical keep set.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRUNE="$ROOT/prune-probe-resources.sh"
+RESOURCES="$ROOT/../pricing/probe_reserved_resources.sh"
+
+# shellcheck source=../pricing/probe_reserved_resources.sh
+. "$RESOURCES"
+
+text="$(cat "$PRUNE")"
+
+while IFS= read -r scope; do
+	[ -z "$scope" ] && continue
+	if ! grep -q "$scope" <<<"$text"; then
+		echo "FAIL: prune script missing platform reuse scope from probe_reserved_resources: ${scope}" >&2
+		exit 1
+	fi
+done < <(tk_probe_platform_reuse_scopes)
+
+if ! grep -q 'prune_candidates_legacy_tkprobe_groups' <<<"$text"; then
+	echo "FAIL: prune script should report legacy tkprobe group candidates" >&2
+	exit 1
+fi
+if ! grep -q 'stale_probe_bindings' <<<"$text"; then
+	echo "FAIL: prune script should report stale probe account_groups bindings" >&2
+	exit 1
+fi
+if ! grep -q 'probe_reserved_resources.sh' <<<"$text"; then
+	echo "FAIL: prune script should source probe_reserved_resources.sh for shared scope list" >&2
+	exit 1
+fi
+if ! grep -q 'PRICING_LIB="$SCRIPT_DIR/probe_reserved_resources.sh"' <<<"$text"; then
+	echo "FAIL: prune script should fall back to /tmp companion path for run-probe delivery" >&2
+	exit 1
+fi
+
+echo "test_prune_probe_resources: PASS"

--- a/ops/pricing/probe_reserved_resources.sh
+++ b/ops/pricing/probe_reserved_resources.sh
@@ -177,6 +177,43 @@ tk_probe_key_name() {
 	printf '__tk_probe_%s_key' "$1"
 }
 
+# Platform slugs for probe_account_model.sh PROBE_REUSE_MODE=1
+# (__tk_probe_<platform>_group / __tk_probe_<platform>_key). prune-probe-resources.sh
+# merges these into its canonical keep set.
+tk_probe_platform_reuse_scopes() {
+	printf '%s\n' anthropic kiro openai gemini grok antigravity newapi
+}
+
+tk_probe_is_legacy_oneoff_probe_name() { # $1=group or key name
+	case "$1" in
+	__tk_probe_tkprobe*) return 0 ;;
+	esac
+	return 1
+}
+
+# Remove stale __tk_probe_* bindings before reuse-mode account-model probes rebind.
+# Keeps the current reuse group (e.g. __tk_probe_kiro_group) when provided.
+tk_probe_unbind_account_from_stale_probe_groups() { # $1=account_id $2=keep_group_name
+	local account_id="$1" keep_group_name="${2:-}"
+	local keep_clause=""
+	if [[ ! "$account_id" =~ ^[0-9]+$ ]]; then
+		echo "probe_reserved_resources: invalid account id '$account_id' for stale probe unbind" >&2
+		return 1
+	fi
+	if [ -n "$keep_group_name" ]; then
+		keep_clause="AND g.name <> '$(tk_probe_sql_escape "$keep_group_name")'"
+	fi
+	tk_probe_psql -c "
+DELETE FROM account_groups ag
+USING groups g
+WHERE ag.account_id = ${account_id}
+  AND ag.group_id = g.id
+  AND g.deleted_at IS NULL
+  AND g.name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
+  ${keep_clause};
+" >/dev/null
+}
+
 # Same lock path as tokenkey-account-model-probe (PROBE_REUSE_MODE=1) so catalog
 # refresh and single-account probes never DELETE/rebind the same __tk_probe_* group concurrently.
 tk_probe_reuse_lock_path() {

--- a/ops/pricing/test_probe_reserved_resources.sh
+++ b/ops/pricing/test_probe_reserved_resources.sh
@@ -26,6 +26,16 @@ TK_PROBE_LEGACY_SCOPE=1
 assert_eq "$(tk_probe_canonical_scope endpoint_matrix_grok grok source_group_id 25)" "endpoint_matrix_grok" "legacy scope override"
 unset TK_PROBE_LEGACY_SCOPE
 
+assert_eq "$(tk_probe_platform_reuse_scopes | tr '\n' ' ' | sed 's/ $//')" "anthropic kiro openai gemini grok antigravity newapi" "platform reuse scopes"
+if ! tk_probe_is_legacy_oneoff_probe_name "__tk_probe_tkprobe-2-20260629T102307Z-3222117"; then
+	echo "FAIL: tkprobe legacy group name should match legacy oneoff probe pattern" >&2
+	exit 1
+fi
+if tk_probe_is_legacy_oneoff_probe_name "__tk_probe_kiro_group"; then
+	echo "FAIL: reusable kiro probe group should not match legacy oneoff pattern" >&2
+	exit 1
+fi
+
 TK_PROBE_TEST_SCENARIO=case_match
 TK_PROBE_LAST_SQL=""
 tk_probe_psql() {
@@ -60,6 +70,9 @@ tk_probe_psql() {
 			printf '1\n'
 		fi
 		;;
+	unbind)
+		printf '\n'
+		;;
 	*)
 		printf '\n'
 		;;
@@ -72,6 +85,16 @@ TK_PROBE_GROUP_ID=39
 TK_PROBE_TEST_SCENARIO=case_match
 tk_probe_bind_from_group_id probe 16
 tk_probe_bind_from_group_id_like probe 1 'cc-%'
+TK_PROBE_TEST_SCENARIO=unbind
+tk_probe_unbind_account_from_stale_probe_groups 66 '__tk_probe_kiro_group'
+if ! printf '%s' "$TK_PROBE_LAST_SQL" | grep -q "DELETE FROM account_groups ag"; then
+	echo "FAIL: stale probe unbind should delete account_groups rows" >&2
+	exit 1
+fi
+if ! printf '%s' "$TK_PROBE_LAST_SQL" | grep -q "__tk_probe_kiro_group"; then
+	echo "FAIL: stale probe unbind should keep the current reuse group" >&2
+	exit 1
+fi
 TK_PROBE_TEST_SCENARIO=group_id
 tk_probe_clear_bindings probe
 if ! printf '%s' "$TK_PROBE_LAST_SQL" | grep -q "status = 'disabled'"; then

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -26,6 +26,16 @@ REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-90}"
 PROBE_USER_ID=1
 
 PSQL=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -q -A -t -v ON_ERROR_STOP=1)
+PSQL_ARRAY=("${PSQL[@]}")
+PROBE_RESOURCES="${SCRIPT_DIR}/../pricing/probe_reserved_resources.sh"
+if [ ! -f "$PROBE_RESOURCES" ]; then
+  PROBE_RESOURCES="${SCRIPT_DIR}/probe_reserved_resources.sh"
+fi
+if [ ! -f "$PROBE_RESOURCES" ]; then
+  fail_json "missing probe_reserved_resources.sh companion (deliver with run-probe --with ops/pricing/probe_reserved_resources.sh)"
+fi
+# shellcheck source=../pricing/probe_reserved_resources.sh
+. "$PROBE_RESOURCES"
 
 sql_escape() {
   printf "%s" "$1" | sed "s/'/''/g"
@@ -301,6 +311,11 @@ INSERT INTO user_allowed_groups (user_id, group_id, created_at)
 VALUES (${PROBE_USER_ID}, ${GROUP_ID}, NOW())
 ON CONFLICT (user_id, group_id) DO NOTHING;
 " >/dev/null
+
+if [[ "$PROBE_REUSE_MODE" == "1" ]]; then
+  tk_probe_unbind_account_from_stale_probe_groups "$ACCOUNT_ID" "$GROUP_NAME" || \
+    fail_json "failed to unbind stale __tk_probe_* groups for account_id=${ACCOUNT_ID}"
+fi
 
 "${PSQL[@]}" -c "
 DELETE FROM account_groups WHERE group_id = ${GROUP_ID};

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -48,6 +48,16 @@ class ProbeAccountModelTest(unittest.TestCase):
         self.assertIn("/var/lib/tokenkey/active-color", script)
         self.assertIn("app container not running", script)
 
+    def test_reuse_mode_unbinds_stale_probe_groups_before_bind(self) -> None:
+        script = _SCRIPT.read_text()
+        self.assertIn("probe_reserved_resources.sh", script)
+        self.assertIn("tk_probe_unbind_account_from_stale_probe_groups", script)
+        self.assertIn('if [[ "$PROBE_REUSE_MODE" == "1" ]]; then', script)
+        self.assertIn("${SCRIPT_DIR}/probe_reserved_resources.sh", script)
+        unbind_at = script.index("tk_probe_unbind_account_from_stale_probe_groups")
+        bind_at = script.index("INSERT INTO account_groups (account_id, group_id, priority, created_at)")
+        self.assertLess(unbind_at, bind_at)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要

- 复用模式探测前解除账号对其他 `__tk_probe_*` 的绑定，避免 edge 账号长期挂在多个 probe 分组。
- `prune` / `cleanup` 覆盖平台 scope 与 `tkprobe` 遗留组；补齐对应 shell/python 测试。

## 风险

- 低风险：仅 ops 脚本与测试，无 backend/Web 行为变更。

## 验证

- `bash ops/observability/test_prune_probe_resources.sh`
- `bash ops/pricing/test_probe_reserved_resources.sh`
- `python3 ops/stage0/test_probe_account_model.py`

## 提交

- 465fd19df fix(ops): 清理遗留 probe 绑定并补齐 account-model 复用 scope

最新提交：465fd19df

Made with [Cursor](https://cursor.com)