### PR TITLE
fix(gateway): Anthropic 跨厂商模型名改回 400，堵住 load-batch routing 429 漏口

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -286,6 +286,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 		if h.tkWriteDeprecatedAnthropicModelAtIngress(c, reqModel, reqLog) {
 			return
 		}
+		if h.tkWriteUnsupportedAnthropicModelAtIngress(c, reqModel, streamStarted, reqLog) {
+			return
+		}
 	}
 
 	if platform == service.PlatformGemini {
@@ -1809,6 +1812,9 @@ func (h *GatewayHandler) CountTokens(c *gin.Context) {
 	}
 
 	if h.tkWriteDeprecatedAnthropicModelAtIngress(c, parsedReq.Model, reqLog) {
+		return
+	}
+	if h.tkWriteUnsupportedAnthropicModelAtIngress(c, parsedReq.Model, false, reqLog) {
 		return
 	}
 

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -104,6 +104,9 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 	if h.tkWriteDeprecatedAnthropicModelAtIngress(c, reqModel, reqLog) {
 		return
 	}
+	if h.tkWriteUnsupportedAnthropicModelAtIngress(c, reqModel, reqStream, reqLog) {
+		return
+	}
 
 	// 解析渠道级模型映射
 	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(requestCtx, apiKey.GroupID, reqModel)

--- a/backend/internal/handler/gateway_handler_tk_unsupported_model.go
+++ b/backend/internal/handler/gateway_handler_tk_unsupported_model.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -40,4 +41,18 @@ func (h *GatewayHandler) tkWriteUnsupportedModelIfApplicable(c *gin.Context, err
 	markOpsClientRequestRejected(c)
 	h.handleStreamingAwareError(c, http.StatusBadRequest, service.TkUnsupportedModelErrType, service.TkUnsupportedModelMessage(reqModel), streamStarted)
 	return true
+}
+
+// tkWriteUnsupportedAnthropicModelAtIngress rejects non-claude-* model names on
+// Anthropic platform routes before account selection so cross-vendor dirty names
+// (model=gpt, bare opus, deepseek-*, …) never enter load-batch scheduling or
+// surface as empty-pool routing 429.
+func (h *GatewayHandler) tkWriteUnsupportedAnthropicModelAtIngress(c *gin.Context, reqModel string, streamStarted bool, reqLog *zap.Logger) bool {
+	if !service.TkIsAnthropicCrossVendorModelName(reqModel) {
+		return false
+	}
+	if reqLog != nil {
+		reqLog.Warn("gateway.unsupported_model_ingress_reject", zap.String("model", reqModel))
+	}
+	return h.tkWriteUnsupportedModelIfApplicable(c, fmt.Errorf("%w: %s (anthropic namespace)", service.ErrUnsupportedModel, reqModel), reqModel, streamStarted, reqLog)
 }

--- a/backend/internal/handler/gateway_handler_tk_unsupported_model_test.go
+++ b/backend/internal/handler/gateway_handler_tk_unsupported_model_test.go
@@ -1,0 +1,40 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkWriteUnsupportedAnthropicModelAtIngress(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	require.True(t, h.tkWriteUnsupportedAnthropicModelAtIngress(c, "gpt", false, nil))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Empty(t, w.Header().Get("Retry-After"))
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &payload))
+	errObj, ok := payload["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, service.TkUnsupportedModelErrType, errObj["type"])
+	assert.Equal(t, service.TkUnsupportedModelMessage("gpt"), errObj["message"])
+}
+
+func TestTkWriteUnsupportedAnthropicModelAtIngress_AllowsClaudeModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{}
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	require.False(t, h.tkWriteUnsupportedAnthropicModelAtIngress(c, "claude-opus-4-8", false, nil))
+}

--- a/backend/internal/handler/no_available_accounts_tk_test.go
+++ b/backend/internal/handler/no_available_accounts_tk_test.go
@@ -87,6 +87,17 @@ func TestTkSelectFailureStatusMessage(t *testing.T) {
 		assert.Empty(t, w.Header().Get("Retry-After"))
 	})
 
+	t.Run("load_batch_cross_vendor_gpt_returns_400", func(t *testing.T) {
+		c, w := newCtx(t)
+		err := service.TkSelectionNoAvailableAccountsError("gpt")
+		status, errType, msg := tkSelectFailureStatusMessage(c, err, "gpt")
+
+		require.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, service.TkUnsupportedModelErrType, errType)
+		assert.Equal(t, service.TkUnsupportedModelMessage("gpt"), msg)
+		assert.Empty(t, w.Header().Get("Retry-After"))
+	})
+
 	t.Run("no_available_compact_accounts_returns_429", func(t *testing.T) {
 		c, _ := newCtx(t)
 		status, _, _ := tkSelectFailureStatusMessage(c, service.ErrNoAvailableCompactAccounts, "gpt-5.2")

--- a/backend/internal/handler/openai_stream_validation_test.go
+++ b/backend/internal/handler/openai_stream_validation_test.go
@@ -97,7 +97,8 @@ func TestGatewayOpenAICompatibleHandlersAllowBooleanStreamToContinue(t *testing.
 		{
 			name: "responses_false",
 			path: "/v1/responses",
-			body: `{"model":"gpt-5","stream":false,"input":"hello"}`,
+			// claude-* so ingress cross-vendor 400 does not short-circuit CC-only 403.
+			body: `{"model":"claude-opus-4-8","stream":false,"input":"hello"}`,
 			run: func(c *gin.Context) {
 				(&GatewayHandler{gatewayService: &service.GatewayService{}}).Responses(c)
 			},

--- a/backend/internal/service/gateway_anthropic_deprecated_model_tk.go
+++ b/backend/internal/service/gateway_anthropic_deprecated_model_tk.go
@@ -140,6 +140,9 @@ func TkSelectionNoAvailableAccountsError(requestedModel string) error {
 	if err := tkDeprecatedAnthropicSelectionFailure(requestedModel); err != nil {
 		return err
 	}
+	if err := tkAnthropicCrossVendorSelectionFailure(requestedModel); err != nil {
+		return err
+	}
 	return ErrNoAvailableAccounts
 }
 

--- a/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
+++ b/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
@@ -150,3 +150,9 @@ func TestTkSelectionNoAvailableAccountsError_CurrentModel(t *testing.T) {
 	require.ErrorIs(t, err, ErrNoAvailableAccounts)
 	require.False(t, errors.Is(err, ErrDeprecatedAnthropicModel))
 }
+
+func TestTkSelectionNoAvailableAccountsError_CrossVendorModel(t *testing.T) {
+	err := TkSelectionNoAvailableAccountsError("gpt")
+	require.ErrorIs(t, err, ErrUnsupportedModel)
+	require.NotContains(t, strings.ToLower(err.Error()), "no available accounts")
+}

--- a/backend/internal/service/gateway_service_tk_unsupported_model.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 )
 
 // ErrUnsupportedModel reports that account selection failed solely because the
@@ -86,10 +88,44 @@ func tkWrapSelectionFailure(requestedModel string, stats selectionFailureStats) 
 	if err := tkDeprecatedAnthropicSelectionFailure(requestedModel); err != nil {
 		return err
 	}
+	if err := tkAnthropicCrossVendorSelectionFailure(requestedModel); err != nil {
+		return err
+	}
 	if tkSelectionFailedDueToUnsupportedModel(stats) {
 		return fmt.Errorf("%w: %s (%s)", ErrUnsupportedModel, requestedModel, summarizeSelectionFailureStats(stats))
 	}
 	return fmt.Errorf("%w supporting model: %s (%s)", ErrNoAvailableAccounts, requestedModel, summarizeSelectionFailureStats(stats))
+}
+
+// tkAnthropicCrossVendorSelectionFailure wraps ErrUnsupportedModel when the
+// requested model name is outside the Anthropic claude-* namespace (e.g. bare
+// "gpt", "opus", deepseek-*). Mirrors tkDeprecatedAnthropicSelectionFailure:
+// beats mixed model_unsupported + unschedulable stats and load-batch bare
+// ErrNoAvailableAccounts so wrong-model traffic never surfaces routing 429.
+//
+// Prod 2026-07-07 (user_id=16, api_key_id=121): claude-group direct key hammering
+// model=gpt on /v1/messages via load-batch empty-pool returned routing/platform 429
+// even though #1255/#1257 fixed retired ids only.
+func tkAnthropicCrossVendorSelectionFailure(requestedModel string) error {
+	requestedModel = strings.TrimSpace(requestedModel)
+	if requestedModel == "" {
+		return nil
+	}
+	if tkIsForwardableAnthropicModelName(requestedModel) {
+		return nil
+	}
+	if normalized := claude.NormalizeModelID(requestedModel); normalized != "" && normalized != requestedModel {
+		if tkIsForwardableAnthropicModelName(normalized) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %s (anthropic namespace)", ErrUnsupportedModel, requestedModel)
+}
+
+// TkIsAnthropicCrossVendorModelName reports whether reqModel is outside the
+// Anthropic claude-* namespace. Exported for handler ingress pre-checks.
+func TkIsAnthropicCrossVendorModelName(requestedModel string) bool {
+	return tkAnthropicCrossVendorSelectionFailure(requestedModel) != nil
 }
 
 // tkIsForwardableAnthropicModelName reports whether a (normalized) model name is

--- a/backend/internal/service/gateway_service_tk_unsupported_model_test.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model_test.go
@@ -92,6 +92,36 @@ func TestTkWrapSelectionFailure(t *testing.T) {
 			t.Fatalf("capacity failure must not be classified as unsupported model: %v", err)
 		}
 	})
+
+	t.Run("cross-vendor model beats mixed stats routing 429", func(t *testing.T) {
+		stats := selectionFailureStats{
+			Total:            5,
+			ModelUnsupported: 4,
+			Unschedulable:    1,
+		}
+		err := tkWrapSelectionFailure("gpt", stats)
+		if !errors.Is(err, ErrUnsupportedModel) {
+			t.Fatalf("want ErrUnsupportedModel for cross-vendor name, got %v", err)
+		}
+		if errors.Is(err, ErrNoAvailableAccounts) {
+			t.Fatalf("cross-vendor must not fall through to empty pool: %v", err)
+		}
+	})
+}
+
+func TestTkIsAnthropicCrossVendorModelName(t *testing.T) {
+	if !TkIsAnthropicCrossVendorModelName("gpt") {
+		t.Fatal("gpt must be cross-vendor on anthropic ingress")
+	}
+	if !TkIsAnthropicCrossVendorModelName("deepseek-v4-flash") {
+		t.Fatal("deepseek must be cross-vendor on anthropic ingress")
+	}
+	if TkIsAnthropicCrossVendorModelName("claude-opus-4-8") {
+		t.Fatal("claude-opus-4-8 must not be cross-vendor")
+	}
+	if TkIsAnthropicCrossVendorModelName("") {
+		t.Fatal("empty model is out of scope for cross-vendor ingress")
+	}
 }
 
 // Tk cross-vendor dirty-model guard (prod 2026-06-16, edge us3 oh1-ls-b ID 4):

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1312,6 +1312,7 @@
         "tkDeprecatedAnthropicSelectionFailure",
         "tkDeprecatedAnthropicModels",
         "func TkSelectionNoAvailableAccountsError",
+        "tkAnthropicCrossVendorSelectionFailure(requestedModel)",
         "claude-3-5-sonnet-20241022",
         "claude-3-7-sonnet-20250219",
         "claude-sonnet-4-20250514",
@@ -2569,7 +2570,9 @@
         "h.tkWriteDeprecatedAnthropicModelIfApplicable(c, err, reqModel, reqLog)",
         "h.tkWriteUnsupportedModelIfApplicable(c, err, reqModel, streamStarted, reqLog)",
         "h.tkWriteDeprecatedAnthropicModelAtIngress(c, reqModel, reqLog)",
-        "h.tkWriteDeprecatedAnthropicModelAtIngress(c, parsedReq.Model, reqLog)"
+        "h.tkWriteUnsupportedAnthropicModelAtIngress(c, reqModel, streamStarted, reqLog)",
+        "h.tkWriteDeprecatedAnthropicModelAtIngress(c, parsedReq.Model, reqLog)",
+        "h.tkWriteUnsupportedAnthropicModelAtIngress(c, parsedReq.Model, false, reqLog)"
       ],
       "rationale": "Handler half of unsupported-model + deprecated-model fixes on /v1/messages and count_tokens: tkWriteDeprecatedAnthropicModelAtIngress rejects sunset ids before scheduling (#1257); select-account failures call tkWriteDeprecatedAnthropicModelIfApplicable BEFORE tkWriteUnsupportedModelIfApplicable, mapping ErrDeprecatedAnthropicModel to the Anthropic-shape migration 400 (client-owned) instead of routing 429 when the Forward-path gate never ran."
     },
@@ -2583,9 +2586,19 @@
     {
       "path": "backend/internal/handler/gateway_handler_responses.go",
       "must_contain": [
-        "h.tkWriteDeprecatedAnthropicModelAtIngress(c, reqModel, reqLog)"
+        "h.tkWriteDeprecatedAnthropicModelAtIngress(c, reqModel, reqLog)",
+        "h.tkWriteUnsupportedAnthropicModelAtIngress(c, reqModel, reqStream, reqLog)"
       ],
-      "rationale": "/v1/responses Anthropic ingress must reject retired model IDs before selection (#1257)."
+      "rationale": "/v1/responses Anthropic ingress must reject retired model IDs and cross-vendor dirty names before selection (#1257 + cross-vendor 400 gate)."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_tk_unsupported_model.go",
+      "must_contain": [
+        "func (h *GatewayHandler) tkWriteUnsupportedAnthropicModelAtIngress",
+        "gateway.unsupported_model_ingress_reject",
+        "service.TkIsAnthropicCrossVendorModelName"
+      ],
+      "rationale": "Anthropic ingress pre-check for non-claude-* model names (model=gpt, deepseek-*, bare opus): reject with HTTP 400 before load-batch scheduling so client-fault requests never surface routing/platform 429 (prod 2026-07-07 user16 key121)."
     },
     {
       "path": "backend/internal/handler/gateway_handler_tk_deprecated_model.go",
@@ -2611,9 +2624,11 @@
     {
       "path": "backend/internal/service/gateway_service_tk_unsupported_model.go",
       "must_contain": [
-        "tkDeprecatedAnthropicSelectionFailure(requestedModel)"
+        "tkDeprecatedAnthropicSelectionFailure(requestedModel)",
+        "tkAnthropicCrossVendorSelectionFailure(requestedModel)",
+        "func TkIsAnthropicCrossVendorModelName"
       ],
-      "rationale": "tkWrapSelectionFailure must short-circuit retired Anthropic model names to ErrDeprecatedAnthropicModel before unsupported-model vs empty-pool classification; otherwise mixed model_unsupported + unschedulable stats surface routing 429 for sunset ids."
+      "rationale": "tkWrapSelectionFailure must short-circuit retired Anthropic model names to ErrDeprecatedAnthropicModel and non-claude-* cross-vendor dirty names to ErrUnsupportedModel before empty-pool classification; otherwise mixed model_unsupported + unschedulable stats or load-batch bare ErrNoAvailableAccounts surface routing 429 for client-fault model names (prod 2026-07-07 user16 key121 model=gpt)."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",


### PR DESCRIPTION
## 摘要

- #1255/#1257 已把 **retired Anthropic 模型** 从 routing 429 收敛到 400；prod 上 user16 / key121（claude 组）误投 `model=gpt` 仍经 **load-batch 裸 `ErrNoAvailableAccounts`** 落 **routing/platform 429**。
- 本 PR 对齐 OpenAI/Qwen 错模型 400 行为：对非 `claude-*` 跨厂商脏名补 **ingress 预检** + **`tkAnthropicCrossVendorSelectionFailure`**（beat mixed unschedulable stats）+ **`TkSelectionNoAvailableAccountsError`** 扩展，客户端直接收到 `400 invalid_request_error / Unsupported model: gpt`，不再 Retry-After 重试风暴。

## 风险

- **行为变更（公共契约）**：Anthropic 平台路由上，非 `claude-*` 模型名（如 `gpt`、`opus`、`*deepseek*`）由 routing 429 改为 **400**；真实 claude 模型与容量空池 429 不变。
- 无 schema / Web / 配置迁移；`Web impact: none`。

## 验证

- `go test -tags=unit ./internal/service/ -run 'TestTkWrapSelectionFailure|TestTkIsAnthropicCrossVendor|TestTkSelectionNoAvailableAccountsError'` — PASS
- `go test -tags=unit ./internal/handler/ -run 'TestTkWriteUnsupportedAnthropic|TestTkSelectFailureStatusMessage'` — PASS
- `python3 scripts/sentinels/check-gateway-tk.py` — PASS (458/458)
- prod 根因对齐：user16 key121 `model=gpt` + `/v1/messages` + claude 组 → 修复后应 400 client-owned，不再进 SLA routing 429 分子

## 提交

- cbccc073e fix(gateway): Anthropic 跨厂商模型名入口与 load-batch 改回 400

最新提交：cbccc073e

Made with [Cursor](https://cursor.com)