### PR TITLE
fix: tighten unsupported anthropic error classification

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -3737,9 +3737,6 @@ func (s *GatewayService) diagnoseSelectionFailure(
 	if _, excluded := excludedIDs[acc.ID]; excluded {
 		return selectionFailureDiagnosis{Category: "excluded"}
 	}
-	if !s.isAccountSchedulableForSelection(acc) {
-		return selectionFailureDiagnosis{Category: "unschedulable", Detail: "generic_unschedulable"}
-	}
 	if isPlatformFilteredForSelection(acc, platform, allowMixedScheduling) {
 		return selectionFailureDiagnosis{
 			Category: "platform_filtered",
@@ -3751,6 +3748,9 @@ func (s *GatewayService) diagnoseSelectionFailure(
 			Category: "model_unsupported",
 			Detail:   fmt.Sprintf("model=%s", requestedModel),
 		}
+	}
+	if !s.isAccountSchedulableForSelection(acc) {
+		return selectionFailureDiagnosis{Category: "unschedulable", Detail: "generic_unschedulable"}
 	}
 	if !s.isAccountSchedulableForModelSelection(ctx, acc, requestedModel) {
 		remaining := acc.GetRateLimitRemainingTimeWithContext(ctx, requestedModel).Truncate(time.Second)

--- a/backend/internal/service/gateway_service_tk_unsupported_model_test.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model_test.go
@@ -25,9 +25,14 @@ func TestTkSelectionFailedDueToUnsupportedModel(t *testing.T) {
 			want:  false,
 		},
 		{
-			name:  "unsupported plus an unschedulable candidate -> false (may support once recovered)",
+			name:  "unsupported plus an unschedulable supporting candidate -> false (capacity after recovery)",
 			stats: selectionFailureStats{Total: 5, ModelUnsupported: 4, Unschedulable: 1},
 			want:  false,
+		},
+		{
+			name:  "unsupported candidates stay unsupported even when some are unschedulable",
+			stats: selectionFailureStats{Total: 5, ModelUnsupported: 5},
+			want:  true,
 		},
 		{
 			name:  "an eligible candidate exists -> false",
@@ -124,6 +129,39 @@ func TestTkIsAnthropicCrossVendorModelName(t *testing.T) {
 	}
 }
 
+func TestDiagnoseSelectionFailure_ModelUnsupportedPrecedesUnschedulable(t *testing.T) {
+	svc := &GatewayService{}
+	unsupportedUnsched := &Account{
+		ID:          1,
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: false,
+		Credentials: map[string]any{
+			"mirror_platform": PlatformKiro,
+		},
+	}
+	got := svc.diagnoseSelectionFailure(nil, unsupportedUnsched, "gpt-4o", PlatformAnthropic, nil, false)
+	if got.Category != "model_unsupported" {
+		t.Fatalf("unsupported unschedulable account misclassified: got=%+v", got)
+	}
+
+	supportingUnsched := &Account{
+		ID:          2,
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: false,
+		Credentials: map[string]any{
+			"base_url": "https://api-us3.tokenkey.dev",
+		},
+	}
+	got = svc.diagnoseSelectionFailure(nil, supportingUnsched, "claude-opus-4-8", PlatformAnthropic, nil, false)
+	if got.Category != "unschedulable" {
+		t.Fatalf("supporting unschedulable account must stay capacity-owned: got=%+v", got)
+	}
+}
+
 // Tk cross-vendor dirty-model guard (prod 2026-06-16, edge us3 oh1-ls-b ID 4):
 // a passthrough anthropic OAuth account forwarded non-claude names
 // (deepseek-v4-flash) to api.anthropic.com → 404 + abuse fingerprint. The guard
@@ -133,7 +171,7 @@ func TestTkIsAnthropicCrossVendorModelName(t *testing.T) {
 func TestTkIsForwardableAnthropicModelName(t *testing.T) {
 	forwardable := []string{
 		"claude-opus-4-8",
-		"claude-haiku-4-6",            // same-family stale/typo: intentionally allowed (upstream tolerates)
+		"claude-haiku-4-6",           // same-family stale/typo: intentionally allowed (upstream tolerates)
 		"claude-sonnet-4-5-20250929", // dated snapshot
 		"Claude-Opus-4-8",            // case-insensitive
 		" claude-opus-4-8 ",          // trimmed

--- a/backend/internal/service/gateway_service_tk_unsupported_model_test.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model_test.go
@@ -141,7 +141,7 @@ func TestDiagnoseSelectionFailure_ModelUnsupportedPrecedesUnschedulable(t *testi
 			"mirror_platform": PlatformKiro,
 		},
 	}
-	got := svc.diagnoseSelectionFailure(nil, unsupportedUnsched, "gpt-4o", PlatformAnthropic, nil, false)
+	got := svc.diagnoseSelectionFailure(nil, unsupportedUnsched, "claude-fable-5", PlatformAnthropic, nil, false)
 	if got.Category != "model_unsupported" {
 		t.Fatalf("unsupported unschedulable account misclassified: got=%+v", got)
 	}

--- a/ops/stage0/load_smoke_github_env.sh
+++ b/ops/stage0/load_smoke_github_env.sh
@@ -47,8 +47,8 @@ command -v jq >/dev/null 2>&1 || {
 }
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-REPO="$(cd "${REPO_ROOT}" && gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || {
-  echo "tk_load_smoke_github_env: gh cannot resolve GitHub repo (gh repo set-default?)" >&2
+REPO="$(bash "${REPO_ROOT}/scripts/lib/resolve-gh-repo.sh" "${REPO_ROOT}" 2>/dev/null)" || {
+  echo "tk_load_smoke_github_env: failed to resolve GitHub repo from origin/gh context" >&2
   exit 1
 }
 gh auth status >/dev/null 2>&1 || {

--- a/scripts/lib/resolve-gh-repo.sh
+++ b/scripts/lib/resolve-gh-repo.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# resolve-gh-repo.sh — Resolve the GitHub OWNER/REPO slug for this worktree.
+#
+# Resolution order:
+#   1. Parse git remote `origin` when it points at github.com.
+#   2. Fallback to `gh repo view` for non-standard layouts.
+#
+# Usage:
+#   bash scripts/lib/resolve-gh-repo.sh [repo-root]
+#
+# Exit codes:
+#   0 — resolved and printed OWNER/REPO
+#   1 — could not resolve
+
+set -euo pipefail
+
+REPO_ROOT="${1:-$(pwd)}"
+
+origin_url="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)"
+if [[ -n "$origin_url" ]]; then
+  case "$origin_url" in
+    git@github.com:*.git)
+      repo="${origin_url#git@github.com:}"
+      repo="${repo%.git}"
+      ;;
+    git@github.com:*)
+      repo="${origin_url#git@github.com:}"
+      ;;
+    https://github.com/*/*.git)
+      repo="${origin_url#https://github.com/}"
+      repo="${repo%.git}"
+      ;;
+    https://github.com/*/*)
+      repo="${origin_url#https://github.com/}"
+      ;;
+    ssh://git@github.com/*/*.git)
+      repo="${origin_url#ssh://git@github.com/}"
+      repo="${repo%.git}"
+      ;;
+    ssh://git@github.com/*/*)
+      repo="${origin_url#ssh://git@github.com/}"
+      ;;
+    *)
+      repo=""
+      ;;
+  esac
+  if [[ -n "${repo:-}" && "$repo" != */*/* ]]; then
+    printf '%s\n' "$repo"
+    exit 0
+  fi
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  repo="$(cd "$REPO_ROOT" && gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
+  if [[ -n "$repo" ]]; then
+    printf '%s\n' "$repo"
+    exit 0
+  fi
+fi
+
+exit 1

--- a/scripts/release-configure-main-bypass.sh
+++ b/scripts/release-configure-main-bypass.sh
@@ -32,8 +32,8 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 2
 fi
 
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || {
-  echo "[release-configure-main-bypass] ERROR: gh repo view failed" >&2
+REPO="$(bash "$(dirname "$0")/lib/resolve-gh-repo.sh" "$(pwd)" 2>/dev/null)" || {
+  echo "[release-configure-main-bypass] ERROR: failed to resolve GitHub repo" >&2
   exit 2
 }
 

--- a/scripts/release-configure-main-bypass.sh
+++ b/scripts/release-configure-main-bypass.sh
@@ -32,7 +32,9 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 2
 fi
 
-REPO="$(bash "$(dirname "$0")/lib/resolve-gh-repo.sh" "$(pwd)" 2>/dev/null)" || {
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO="$(bash "$SCRIPT_DIR/lib/resolve-gh-repo.sh" "$REPO_ROOT" 2>/dev/null)" || {
   echo "[release-configure-main-bypass] ERROR: failed to resolve GitHub repo" >&2
   exit 2
 }

--- a/scripts/release-main-push-route.sh
+++ b/scripts/release-main-push-route.sh
@@ -16,6 +16,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_RESOLVER="$SCRIPT_DIR/lib/resolve-gh-repo.sh"
 
 if ! command -v gh >/dev/null 2>&1; then
@@ -23,7 +24,7 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 0
 fi
 
-REPO="$(bash "$REPO_RESOLVER" "$(pwd)" 2>/dev/null)" || {
+REPO="$(bash "$REPO_RESOLVER" "$REPO_ROOT" 2>/dev/null)" || {
   echo "[release-main-push-route] ERROR: failed to resolve GitHub repo" >&2
   exit 2
 }

--- a/scripts/release-main-push-route.sh
+++ b/scripts/release-main-push-route.sh
@@ -16,14 +16,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_RESOLVER="$SCRIPT_DIR/lib/resolve-gh-repo.sh"
 
 if ! command -v gh >/dev/null 2>&1; then
   echo direct-push
   exit 0
 fi
 
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || {
-  echo "[release-main-push-route] ERROR: gh repo view failed" >&2
+REPO="$(bash "$REPO_RESOLVER" "$(pwd)" 2>/dev/null)" || {
+  echo "[release-main-push-route] ERROR: failed to resolve GitHub repo" >&2
   exit 2
 }
 

--- a/scripts/stage0/approve-github-run-env.sh
+++ b/scripts/stage0/approve-github-run-env.sh
@@ -44,8 +44,8 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 2
 fi
 
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || {
-  echo "approve-github-run-env: gh repo view failed" >&2
+REPO="$(bash "$REPO_ROOT/scripts/lib/resolve-gh-repo.sh" "$REPO_ROOT" 2>/dev/null)" || {
+  echo "approve-github-run-env: failed to resolve GitHub repo" >&2
   exit 2
 }
 

--- a/scripts/stage0/load_smoke_github_env.py
+++ b/scripts/stage0/load_smoke_github_env.py
@@ -34,6 +34,28 @@ def _gh_json(args: list[str]) -> object:
 
 
 def resolve_repo(repo_root: str) -> str:
+    origin = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if origin.returncode == 0:
+        url = origin.stdout.strip()
+        prefixes = (
+            ("git@github.com:", ""),
+            ("https://github.com/", ""),
+            ("ssh://git@github.com/", ""),
+        )
+        for prefix, _ in prefixes:
+            if url.startswith(prefix):
+                repo = url[len(prefix):]
+                if repo.endswith(".git"):
+                    repo = repo[:-4]
+                if repo.count("/") == 1:
+                    return repo
+
     proc = subprocess.run(
         ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
         cwd=repo_root,


### PR DESCRIPTION
## 摘要
- 在 `#1263` 已修复 Anthropic 跨厂商模型名 400 语义之后，补齐剩余增量：同属 `claude-*` 命名空间但对当前账号不支持的模型，不再因为组内存在 unschedulable 账号就被诊断成容量问题。
- 保持真实容量不足仍返回 `429`，只把“账号根本不支持该模型”的失败稳定归到 client-owned `400 invalid_request_error`。
- 统一仓库内 GitHub repo 解析：优先从 `origin` remote 推导 `owner/repo`，不再依赖漂移的 `gh` 当前上下文；并修复从子目录调用 release 脚本时的 repo-root 解析。

## 风险
- 错误分类补强只影响失败归因，不改实际选号、转发或上游请求内容。
- repo 解析修复只影响脚本选中的 GitHub repo；优先使用当前仓库的 `origin`，无法解析时才回退 `gh repo view`。
- `#1263` 已覆盖的跨厂商脏模型名（如 `gpt`）不在本 PR 的新增价值范围内；本 PR 关注 `claude-*` 同命名空间 unsupported 与 unschedulable 的边界。
- sentinel-registry-reviewed

## 验证
- `go test -tags unit ./internal/service -run 'TestTk(SelectionFailedDueToUnsupportedModel|WrapSelectionFailure)|TestDiagnoseSelectionFailure_ModelUnsupportedPrecedesUnschedulable'`
- `go test ./internal/handler -run 'TestTkSelectFailureStatusMessage'`
- `bash ops/stage0/load_smoke_github_env.sh --check prod`
- `bash scripts/release-main-push-route.sh`
- `cd backend/internal/service && bash ../../../scripts/release-configure-main-bypass.sh --check`
- `./scripts/preflight.sh`

## 提交
- `4f7bc1063 fix: classify unsupported anthropic requests before capacity`
- `9b8a3b8f6 fix: resolve github repo from origin before gh context`
- `2140108b8 fix: narrow #1264 to post-#1263 delta`
- 最新提交：`2140108b8`


- no-web-impact


<!-- ci-refresh: 2026-07-07T19:26:00+08:00 -->
