### PR TITLE
WIP: chore: refresh client release watch cache

### DIFF
--- a/.cache/fingerprint/client-release-watch.json
+++ b/.cache/fingerprint/client-release-watch.json
@@ -1,26 +1,26 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-07-07T11:45:00Z",
-  "git_sha": "198496f6195155530b384d42349a989d637f7a42",
+  "updated_at": "2026-07-09T00:18:11Z",
+  "git_sha": "8ef933ee34625effb9c3c374b954b683ee5e185f",
   "platforms": {
     "claude-code": {
       "pinned": "2.1.202",
-      "upstream_latest": "2.1.202",
-      "status": "aligned",
+      "upstream_latest": "2.1.205",
+      "status": "drift",
       "actionable": true,
       "status_note": "",
       "upstream_sources": {
         "GitHub anthropics/claude-code": {
-          "version": "2.1.202",
-          "published_at": "2026-07-06T22:51:16Z",
-          "url": "https://github.com/anthropics/claude-code/releases/tag/v2.1.202",
-          "raw_tag": "v2.1.202"
+          "version": "2.1.205",
+          "published_at": "2026-07-08T21:22:06Z",
+          "url": "https://github.com/anthropics/claude-code/releases/tag/v2.1.205",
+          "raw_tag": "v2.1.205"
         },
         "npm @anthropic-ai/claude-code": {
-          "version": "2.1.202",
+          "version": "2.1.205",
           "published_at": "",
           "url": "https://www.npmjs.com/package/@anthropic-ai/claude-code",
-          "raw_tag": "2.1.202"
+          "raw_tag": "2.1.205"
         }
       }
     },
@@ -41,73 +41,73 @@
     },
     "codex": {
       "pinned": "0.142.5",
-      "upstream_latest": "0.142.5",
-      "status": "aligned",
+      "upstream_latest": "0.143.0",
+      "status": "drift",
       "actionable": true,
       "status_note": "",
       "upstream_sources": {
         "npm @openai/codex": {
-          "version": "0.142.5",
+          "version": "0.143.0",
           "published_at": "",
           "url": "https://www.npmjs.com/package/@openai/codex",
-          "raw_tag": "0.142.5"
+          "raw_tag": "0.143.0"
         },
         "GitHub openai/codex": {
-          "version": "0.142.5",
-          "published_at": "2026-07-01T01:15:44Z",
-          "url": "https://github.com/openai/codex/releases/tag/rust-v0.142.5",
-          "raw_tag": "rust-v0.142.5"
+          "version": "0.143.0",
+          "published_at": "2026-07-08T01:31:10Z",
+          "url": "https://github.com/openai/codex/releases/tag/rust-v0.143.0",
+          "raw_tag": "rust-v0.143.0"
         }
       }
     },
     "codex-vscode": {
       "pinned": "0.142.5",
-      "upstream_latest": "0.142.5",
-      "status": "aligned",
+      "upstream_latest": "0.143.0",
+      "status": "drift",
       "actionable": true,
       "status_note": "",
       "upstream_sources": {
         "npm @openai/codex": {
-          "version": "0.142.5",
+          "version": "0.143.0",
           "published_at": "",
           "url": "https://www.npmjs.com/package/@openai/codex",
-          "raw_tag": "0.142.5"
+          "raw_tag": "0.143.0"
         },
         "GitHub openai/codex": {
-          "version": "0.142.5",
-          "published_at": "2026-07-01T01:15:44Z",
-          "url": "https://github.com/openai/codex/releases/tag/rust-v0.142.5",
-          "raw_tag": "rust-v0.142.5"
+          "version": "0.143.0",
+          "published_at": "2026-07-08T01:31:10Z",
+          "url": "https://github.com/openai/codex/releases/tag/rust-v0.143.0",
+          "raw_tag": "rust-v0.143.0"
         }
       }
     },
     "gemini-cli": {
       "pinned": "0.49.0",
-      "upstream_latest": "0.49.0",
-      "status": "aligned",
+      "upstream_latest": "0.50.0",
+      "status": "drift",
       "actionable": true,
       "status_note": "",
       "upstream_sources": {
         "npm @google/gemini-cli": {
-          "version": "0.49.0",
+          "version": "0.50.0",
           "published_at": "",
           "url": "https://www.npmjs.com/package/@google/gemini-cli",
-          "raw_tag": "0.49.0"
+          "raw_tag": "0.50.0"
         }
       }
     },
     "grok-cli": {
       "pinned": "0.2.89",
-      "upstream_latest": "0.2.89",
-      "status": "aligned",
+      "upstream_latest": "0.2.93",
+      "status": "drift",
       "actionable": true,
       "status_note": "",
       "upstream_sources": {
         "npm @xai-official/grok": {
-          "version": "0.2.89",
+          "version": "0.2.93",
           "published_at": "",
           "url": "https://www.npmjs.com/package/@xai-official/grok",
-          "raw_tag": "0.2.89"
+          "raw_tag": "0.2.93"
         }
       }
     },
@@ -143,16 +143,16 @@
     },
     "kiro-cli": {
       "pinned": "2.11.0",
-      "upstream_latest": "2.11.0",
-      "status": "aligned",
+      "upstream_latest": "2.11.1",
+      "status": "drift",
       "actionable": true,
       "status_note": "",
       "upstream_sources": {
         "Homebrew cask kiro-cli": {
-          "version": "2.11.0",
+          "version": "2.11.1",
           "published_at": "",
-          "url": "https://desktop-release.q.us-east-1.amazonaws.com/2.11.0/Kiro%20CLI.dmg",
-          "raw_tag": "2.11.0"
+          "url": "https://desktop-release.q.us-east-1.amazonaws.com/2.11.1/Kiro%20CLI.dmg",
+          "raw_tag": "2.11.1"
         }
       }
     }


### PR DESCRIPTION
## WIP / not merge-ready
- This PR is an automated release-drift tracking/cache refresh, not a completed fingerprint alignment.
- Before merging, run real client fingerprint capture and diff alignment; do not bump pins from release metadata alone.
- Recommended routing: `tokenkey-fingerprint-alignment-all`, or the per-platform skills listed in the watchdog report.

## Summary
- Refresh `.cache/fingerprint/client-release-watch.json` from the latest upstream client release poll.
- Keep the client fidelity / release watch scripts and workflows in sync when they changed in the same run.

## Watchdog report
# Client release watch report

- Generated: `2026-07-09T00:18:11Z`
- Git SHA: `8ef933ee34625effb9c3c374b954b683ee5e185f`
- Drift count: **5**

| Platform | Pinned | Upstream latest | Status | Skill |
|---|---:|---:|---|---|
| Claude Code | `2.1.202` | `2.1.205` | `drift` | `tokenkey-cc-fingerprint-alignment` |
| Claude Code (Stainless SDK) | `0.94.0` | `0.110.0` | `drift` | `tokenkey-cc-fingerprint-alignment` |
| Codex CLI | `0.142.5` | `0.143.0` | `drift` | `tokenkey-codex-fingerprint-alignment` |
| Codex VS Code / Copilot | `0.142.5` | `0.143.0` | `drift` | `tokenkey-codex-fingerprint-alignment` |
| Gemini CLI | `0.49.0` | `0.50.0` | `drift` | `tokenkey-gemini-fingerprint-alignment` |
| Grok CLI | `0.2.89` | `0.2.93` | `drift` | `tokenkey-grok-fingerprint-alignment` |
| Antigravity IDE | `2.2.1` | `2.2.1` | `aligned` | `tokenkey-antigravity-fingerprint-alignment` |
| Kiro IDE | `0.12.333` | `0.12.333` | `aligned` | `tokenkey-kiro-fingerprint-alignment` |
| Kiro CLI | `2.11.0` | `2.11.1` | `drift` | `tokenkey-kiro-fingerprint-alignment` |

## Notes

- Claude Code (Stainless SDK): npm SDK semver is advisory; Claude Code on-wire X-Stainless-Package-Version remains capture ground truth.

## Action required

### Claude Code

- Pinned: `2.1.202`
- Upstream latest: `2.1.205`
- Pin path: `deploy/aws/stage0/anthropic-http-mimicry-baselines.json`
- Run skill: `tokenkey-cc-fingerprint-alignment`
- Next command: `bash ops/anthropic/capture-cc-fingerprint.sh check env`
- Next command: `bash ops/anthropic/capture-cc-fingerprint.sh capture --http`
- Next command: `python3 ops/anthropic/capture_cc_fingerprint.py diff --bundle <bundle>`
- GitHub anthropics/claude-code: `2.1.205` — https://github.com/anthropics/claude-code/releases/tag/v2.1.205
- npm @anthropic-ai/claude-code: `2.1.205` — https://www.npmjs.com/package/@anthropic-ai/claude-code

### Codex CLI

- Pinned: `0.142.5`
- Upstream latest: `0.143.0`
- Pin path: `backend/internal/service/setting_service.go (+ 4 other pins)`
- Run skill: `tokenkey-codex-fingerprint-alignment`
- Next command: `bash ops/openai/capture-codex-fingerprint.sh check env`
- Next command: `bash ops/openai/capture-codex-fingerprint.sh check`
- Next command: `bash ops/openai/capture-codex-fingerprint.sh emit-edits`
- npm @openai/codex: `0.143.0` — https://www.npmjs.com/package/@openai/codex
- GitHub openai/codex: `0.143.0` — https://github.com/openai/codex/releases/tag/rust-v0.143.0

### Gemini CLI

- Pinned: `0.49.0`
- Upstream latest: `0.50.0`
- Pin path: `backend/internal/pkg/geminicli/constants.go`
- Run skill: `tokenkey-gemini-fingerprint-alignment`
- Next command: `npm view @google/gemini-cli version`
- Next command: `grep GeminiCLIUserAgent backend/internal/pkg/geminicli/constants.go`
- npm @google/gemini-cli: `0.50.0` — https://www.npmjs.com/package/@google/gemini-cli

### Grok CLI

- Pinned: `0.2.89`
- Upstream latest: `0.2.93`
- Pin path: `backend/internal/pkg/xai/oauth.go DefaultGrokCLIVersion`
- Run skill: `tokenkey-grok-fingerprint-alignment`
- Next command: `npm view @xai-official/grok version`
- Next command: `grep DefaultGrokCLIVersion backend/internal/pkg/xai/oauth.go`
- npm @xai-official/grok: `0.2.93` — https://www.npmjs.com/package/@xai-official/grok

### Kiro CLI

- Pinned: `2.11.0`
- Upstream latest: `2.11.1`
- Pin path: `backend/internal/pkg/kiro/constants.go DefaultKiroCLIVersion`
- Run skill: `tokenkey-kiro-fingerprint-alignment`
- Next command: `brew info --cask kiro-cli`
- Next command: `/Applications/Kiro\ CLI.app/Contents/MacOS/kiro-cli --version`
- Next command: `rg DefaultKiroCLIVersion backend/internal/pkg/kiro/constants.go`
- Homebrew cask kiro-cli: `2.11.1` — https://desktop-release.q.us-east-1.amazonaws.com/2.11.1/Kiro%20CLI.dmg


## Test plan
- [x] `python3 scripts/fingerprint/client_release_watch.py --selftest`
- [x] `python3 -m unittest discover -s scripts/fingerprint -p 'test_*.py'`
- [x] `python3 -m json.tool .cache/fingerprint/client-release-watch/report.json`
