### PR TITLE
chore(stage0): harden instance replacement tag resolution

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -306,12 +306,8 @@ TARGET=t4g.large   # 回退时改成 t4g.small，命令完全一样
 #    就会把线上静默降级（2026-06-05：prod 从 1.7.70 被 resize 降回 1.7.11）。
 OLD_ID=$(aws cloudformation describe-stacks --region "$REGION" --stack-name "$STACK" \
   --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' --output text)
-CMD=$(aws ssm send-command --region "$REGION" --instance-ids "$OLD_ID" \
-  --document-name AWS-RunShellScript \
-  --parameters 'commands=["docker inspect --format={{.Config.Image}} tokenkey | sed s/.*://"]' \
-  --query 'Command.CommandId' --output text); sleep 5
-RUNNING_TAG=$(aws ssm get-command-invocation --region "$REGION" \
-  --command-id "$CMD" --instance-id "$OLD_ID" --query StandardOutputContent --output text | tr -d '[:space:]')
+RUNNING_TAG=$(bash ops/stage0/resolve-prod-running-tag-via-ssm.sh \
+  --region "$REGION" --instance-id "$OLD_ID")
 echo "运行态 tag = $RUNNING_TAG"   # 必须非空、且等于你期望的线上版本；否则停手核对
 
 # 1) change-set 预览 — 确认 CFN 只 replace Instance + 重绑 EIP，DataVolume 绝不能被 replace。
@@ -344,13 +340,12 @@ for i in $(seq 1 30); do
     --query 'InstanceInformationList[0].PingStatus' --output text 2>/dev/null)
   [ "$PING" = "Online" ] && { echo "SSM Online"; break; }; sleep 10
 done
-# 关键：确认新机真跑的是 $RUNNING_TAG（cloud-init 必须已正确 bootstrap；否则 #582 没生效或没救活）
-CMD=$(aws ssm send-command --region "$REGION" --instance-ids "$NEW_ID" \
-  --document-name AWS-RunShellScript \
-  --parameters 'commands=["docker inspect --format={{.Config.Image}} tokenkey","docker inspect --format={{.State.Health.Status}} tokenkey"]' \
-  --query 'Command.CommandId' --output text); sleep 6
-aws ssm get-command-invocation --region "$REGION" --command-id "$CMD" --instance-id "$NEW_ID" \
-  --query StandardOutputContent --output text   # 期望 sub2api:$RUNNING_TAG + healthy
+# 关键：确认新机真跑的是 $RUNNING_TAG（cloud-init 必须已正确 bootstrap；否则 #582 没生效或没救活）。
+# helper 自动识别 prod blue/green active container；旧 legacy tokenkey 容器也可 fallback。
+NEW_RUNNING_TAG=$(bash ops/stage0/resolve-prod-running-tag-via-ssm.sh \
+  --region "$REGION" --instance-id "$NEW_ID")
+test "$NEW_RUNNING_TAG" = "$RUNNING_TAG"
+bash ops/stage0/assert-live-host-state.sh "$NEW_ID" "$RUNNING_TAG" "post-replace live-host assert"
 curl -fsS https://api.tokenkey.dev/health && echo OK                    # 期望 200
 # 业务冒烟：参照 §升级 SOP 的 smoke（ops/stage0/post_deploy_smoke.sh）。
 

--- a/deploy/aws/RUNBOOK-disaster-recovery.md
+++ b/deploy/aws/RUNBOOK-disaster-recovery.md
@@ -102,16 +102,18 @@ reboot 后走 §1 确认容器起来 + §last 验证。
 **原理**：`DataVolume` 是 CFN 栈内资源且 `Retain`，**只要不删栈**，它就一直是同一个物理卷。让 CFN 重建 `Instance` 资源，新实例 UserData 会 `attach-volume` 这个现存卷并按 fstab UUID 挂回 `/var/lib/tokenkey`，PG/Redis/`.env.secret` 全部原样。
 
 ```bash
-# 触发 Instance 资源替换：update-stack 改任一驱动 Instance 重建的属性即可，
-# 最干净是把 ImageTag 显式设成当前 prod 版本（值不变也会因 metadata 触发 replace；
-# 或临时改 InstanceType 再改回）。先确认当前 tag：
-aws cloudformation describe-stacks --stack-name "$STACK" \
-  --query "Stacks[0].Parameters[?ParameterKey=='ImageTag'].ParameterValue" --output text
+# 触发 Instance 资源替换：update-stack 改任一驱动 Instance 重建的属性即可。
+# 先决定新机 bootstrap 用的 ImageTag。旧实例仍能 SSM 时，机械读取运行态 tag：
+RUNNING_TAG=$(bash ops/stage0/resolve-prod-running-tag-via-ssm.sh \
+  --region "$AWS_REGION" --stack "$STACK")
+# 若旧实例已误删 / 无法 SSM，必须人工填写 last known-good semver
+# （例如最近一次成功 deploy-stage0 的 tag）；不要用陈旧 CFN ImageTag 或 mutable latest。
+# RUNNING_TAG=1.8.91
 
 # 用 change-set 预览（永远先 dry-run）：
 aws cloudformation create-change-set --stack-name "$STACK" \
   --change-set-name dr-replace-instance --use-previous-template \
-  --parameters ParameterKey=ImageTag,ParameterValue=<当前或目标semver> \
+  --parameters ParameterKey=ImageTag,ParameterValue="$RUNNING_TAG" \
                $(其余参数用 UsePreviousValue=true) \
   --capabilities CAPABILITY_NAMED_IAM
 aws cloudformation describe-change-set --stack-name "$STACK" --change-set-name dr-replace-instance \

--- a/ops/stage0/assert-live-host-state.sh
+++ b/ops/stage0/assert-live-host-state.sh
@@ -128,7 +128,11 @@ verdict_args=()
 [[ -n "${REQUIRE_ENV:-}" ]] && verdict_args+=(--require-env "${REQUIRE_ENV}")
 
 set +e
-verdict_out="$(printf '%s\n' "${probe_out}" | python3 "${SCRIPT_DIR}/live_host_state_verdict.py" "${verdict_args[@]}")"
+if [[ -n "${EXPECTED_TAG}" || -n "${REQUIRE_ENV:-}" ]]; then
+  verdict_out="$(printf '%s\n' "${probe_out}" | python3 "${SCRIPT_DIR}/live_host_state_verdict.py" "${verdict_args[@]}")"
+else
+  verdict_out="$(printf '%s\n' "${probe_out}" | python3 "${SCRIPT_DIR}/live_host_state_verdict.py")"
+fi
 verdict_rc=$?
 set -e
 

--- a/ops/stage0/resolve-prod-running-tag-via-ssm.sh
+++ b/ops/stage0/resolve-prod-running-tag-via-ssm.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+#
+# Resolve the Stage0 prod host's *runtime* app image tag via read-only SSM.
+#
+# Why this exists:
+#   CloudFormation ImageTag is a bootstrap-only value. Normal prod releases use
+#   deploy-stage0's SSM blue/green path, so CFN ImageTag intentionally lags the
+#   running image. Any operation that replaces the EC2 instance must pin ImageTag
+#   to the runtime tag first, or the new instance can bootstrap an old image.
+#
+# Output:
+#   default: tag only (e.g. 1.8.91), suitable for RUNNING_TAG=$(...)
+#   --json:  {"instance_id":...,"container":...,"image":...,"tag":...}
+#
+# Read-only: CloudFormation Describe* + SSM RunShellScript probe containing only
+# docker inspect / active-color reads.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<'USAGE'
+Resolve the Stage0 prod host's *runtime* app image tag via read-only SSM.
+
+Why this exists:
+  CloudFormation ImageTag is a bootstrap-only value. Normal prod releases use
+  deploy-stage0's SSM blue/green path, so CFN ImageTag intentionally lags the
+  running image. Any operation that replaces the EC2 instance must pin ImageTag
+  to the runtime tag first, or the new instance can bootstrap an old image.
+
+Output:
+  default: tag only (e.g. 1.8.91), suitable for RUNNING_TAG=$(...)
+  --json:  {"instance_id":...,"container":...,"image":...,"tag":...}
+
+Read-only: CloudFormation Describe* + SSM RunShellScript probe containing only
+docker inspect / active-color reads.
+
+Usage:
+  ops/stage0/resolve-prod-running-tag-via-ssm.sh [--region us-east-1] [--stack tokenkey-prod-stage0]
+  ops/stage0/resolve-prod-running-tag-via-ssm.sh --instance-id i-... [--json]
+
+Options:
+  --region REGION       AWS region. Default: $AWS_REGION / $AWS_DEFAULT_REGION / us-east-1.
+  --stack STACK         Prod CFN stack to resolve when --instance-id is omitted.
+                        Default: $PROD_STACK_NAME / tokenkey-prod-stage0.
+  --instance-id ID      Skip CFN resolution and probe this EC2 instance directly.
+  --container NAME      auto | tokenkey | tokenkey-blue | tokenkey-green. Default: auto.
+  --json                Emit JSON instead of the bare tag.
+  --timeout-seconds N   SSM polling budget. Default: 120.
+USAGE
+}
+
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+STACK="${PROD_STACK_NAME:-tokenkey-prod-stage0}"
+INSTANCE_ID=""
+APP_CONTAINER="auto"
+JSON_OUTPUT=0
+TIMEOUT_SECONDS=120
+COMMENT="resolve-prod-running-tag"
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --region) REGION="${2:-}"; shift 2 ;;
+    --stack) STACK="${2:-}"; shift 2 ;;
+    --instance-id) INSTANCE_ID="${2:-}"; shift 2 ;;
+    --container) APP_CONTAINER="${2:-}"; shift 2 ;;
+    --json) JSON_OUTPUT=1; shift ;;
+    --timeout-seconds) TIMEOUT_SECONDS="${2:-}"; shift 2 ;;
+    *) echo "resolve-prod-running-tag: unknown arg: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "${REGION}" || -z "${STACK}" ]]; then
+  echo "resolve-prod-running-tag: --region and --stack must be non-empty" >&2
+  exit 1
+fi
+if [[ ! "${TIMEOUT_SECONDS}" =~ ^[0-9]+$ || "${TIMEOUT_SECONDS}" -le 0 ]]; then
+  echo "resolve-prod-running-tag: --timeout-seconds must be a positive integer" >&2
+  exit 1
+fi
+case "${APP_CONTAINER}" in
+  auto|tokenkey|tokenkey-blue|tokenkey-green) ;;
+  *) echo "resolve-prod-running-tag: --container must be auto, tokenkey, tokenkey-blue, or tokenkey-green" >&2; exit 1 ;;
+esac
+
+aws_region() {
+  aws --region "${REGION}" "$@"
+}
+
+if [[ -z "${INSTANCE_ID}" ]]; then
+  INSTANCE_ID="$(aws_region cloudformation describe-stacks \
+    --stack-name "${STACK}" \
+    --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
+    --output text 2>&1)" || {
+      echo "resolve-prod-running-tag: describe-stacks failed for ${STACK} in ${REGION}" >&2
+      printf '%s\n' "${INSTANCE_ID}" >&2
+      exit 2
+    }
+  if [[ -z "${INSTANCE_ID}" || "${INSTANCE_ID}" == "None" ]]; then
+    INSTANCE_ID="$(aws_region cloudformation describe-stack-resources \
+      --stack-name "${STACK}" \
+      --query "StackResources[?ResourceType=='AWS::EC2::Instance']|[0].PhysicalResourceId" \
+      --output text 2>/dev/null || true)"  # preflight-allow: swallow -- describe-stacks output is authoritative; this fallback is optional and checked below
+  fi
+fi
+if [[ -z "${INSTANCE_ID}" || "${INSTANCE_ID}" == "None" ]]; then
+  echo "resolve-prod-running-tag: could not resolve InstanceId for stack ${STACK}" >&2
+  exit 2
+fi
+if [[ "${INSTANCE_ID}" != i-* ]]; then
+  echo "resolve-prod-running-tag: expected EC2 instance id (i-*), got ${INSTANCE_ID}" >&2
+  exit 1
+fi
+
+read -r -d '' REMOTE_PROBE <<PROBE || true  # preflight-allow: swallow -- read -d '' returns nonzero at heredoc EOF under set -e
+set -u
+requested_container='${APP_CONTAINER}'
+app_container="\$requested_container"
+active_color=""
+fallback_used=false
+
+if [ -r /var/lib/tokenkey/active-color ]; then
+  active_color=\$(sed -n '1p' /var/lib/tokenkey/active-color 2>/dev/null | tr -d '[:space:]')
+fi
+
+if [ "\$requested_container" = auto ]; then
+  app_container=tokenkey
+  case "\$active_color" in
+    blue|green)
+      candidate="tokenkey-\$active_color"
+      if docker inspect "\$candidate" >/dev/null 2>&1; then
+        app_container="\$candidate"
+      fi
+      ;;
+  esac
+fi
+
+img=\$(docker inspect "\$app_container" --format '{{.Config.Image}}' 2>/dev/null || true)  # preflight-allow: swallow -- missing active-color candidate falls back or is reported by parser
+if [ -z "\$img" ] && [ "\$requested_container" = auto ] && [ "\$app_container" != tokenkey ]; then
+  app_container=tokenkey
+  fallback_used=true
+  img=\$(docker inspect "\$app_container" --format '{{.Config.Image}}' 2>/dev/null || true)  # preflight-allow: swallow -- legacy fallback may be absent; parser fails closed
+fi
+
+printf 'ACTIVE_COLOR {"value":"%s"}\n' "\$active_color"
+printf 'APPCONTAINER {"name":"%s","requested":"%s","fallback_used":%s}\n' "\$app_container" "\$requested_container" "\$fallback_used"
+printf 'RUNIMAGE {"image":"%s"}\n' "\$img"
+PROBE
+
+REMOTE_B64="$(printf '%s' "${REMOTE_PROBE}" | base64 | tr -d '\n')"
+PARAMS="$(python3 - "${REMOTE_B64}" <<'PY'
+import json
+import sys
+
+print(json.dumps({"commands": [f"echo {sys.argv[1]} | base64 -d | bash"]}))
+PY
+)"
+
+cmd_id="$(aws_region ssm send-command \
+  --instance-ids "${INSTANCE_ID}" \
+  --document-name AWS-RunShellScript \
+  --comment "${COMMENT}" \
+  --parameters "${PARAMS}" \
+  --query 'Command.CommandId' --output text 2>&1)" || {
+    echo "resolve-prod-running-tag: could not start SSM command on ${INSTANCE_ID}" >&2
+    printf '%s\n' "${cmd_id}" >&2
+    exit 2
+  }
+
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+status="Pending"
+while :; do
+  status="$(aws_region ssm get-command-invocation \
+    --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+    --query 'Status' --output text 2>/dev/null || echo Pending)"
+  case "${status}" in
+    Success|Failed|Cancelled|TimedOut) break ;;
+  esac
+  [[ $(date +%s) -ge ${deadline} ]] && { status=TimedOut; break; }
+  sleep 2
+done
+
+probe_out="$(aws_region ssm get-command-invocation \
+  --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+  --query 'StandardOutputContent' --output text 2>/dev/null || true)"  # preflight-allow: swallow -- status/output validation below turns this into a hard helper failure
+
+if [[ "${status}" != "Success" || -z "${probe_out}" ]]; then
+  probe_err="$(aws_region ssm get-command-invocation \
+    --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+    --query 'StandardErrorContent' --output text 2>/dev/null || true)"  # preflight-allow: swallow -- diagnostic stderr is best-effort after a failed probe
+  echo "resolve-prod-running-tag: could not read host state (ssm status=${status})" >&2
+  [[ -n "${probe_err}" && "${probe_err}" != "None" ]] && printf '%s\n' "${probe_err}" >&2
+  exit 2
+fi
+
+parsed="$(PROBE_OUT="${probe_out}" INSTANCE_ID="${INSTANCE_ID}" python3 - <<'PY'
+import json
+import os
+import sys
+
+facts = {"instance_id": os.environ["INSTANCE_ID"], "active_color": "", "container": "", "requested_container": "", "fallback_used": False, "image": ""}
+for raw in os.environ["PROBE_OUT"].splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    parts = raw.split(None, 1)
+    if len(parts) != 2:
+        continue
+    tag, payload = parts
+    try:
+        obj = json.loads(payload)
+    except ValueError:
+        continue
+    if tag == "ACTIVE_COLOR":
+        facts["active_color"] = obj.get("value") or ""
+    elif tag == "APPCONTAINER":
+        facts["container"] = obj.get("name") or ""
+        facts["requested_container"] = obj.get("requested") or ""
+        facts["fallback_used"] = bool(obj.get("fallback_used"))
+    elif tag == "RUNIMAGE":
+        facts["image"] = obj.get("image") or ""
+
+image = facts["image"]
+if not image:
+    print(json.dumps({"error": "running image unknown", **facts}, sort_keys=True), file=sys.stderr)
+    sys.exit(2)
+if ":" not in image:
+    print(json.dumps({"error": "running image has no tag", **facts}, sort_keys=True), file=sys.stderr)
+    sys.exit(2)
+tag = image.rsplit(":", 1)[1].strip()
+if not tag:
+    print(json.dumps({"error": "running image tag empty", **facts}, sort_keys=True), file=sys.stderr)
+    sys.exit(2)
+facts["tag"] = tag
+print(json.dumps(facts, sort_keys=True))
+PY
+)" || {
+  echo "resolve-prod-running-tag: failed to parse runtime image from host probe" >&2
+  exit 2
+}
+
+tag="$(printf '%s' "${parsed}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag"])')"
+image="$(printf '%s' "${parsed}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["image"])')"
+if ! bash "${SCRIPT_DIR}/validate-deploy-tag.sh" "${tag}" >/dev/null; then
+  echo "resolve-prod-running-tag: running image tag is not a Stage0 release tag: tag=${tag} image=${image}" >&2
+  exit 2
+fi
+
+if [[ "${JSON_OUTPUT}" -eq 1 ]]; then
+  printf '%s\n' "${parsed}"
+else
+  printf '%s\n' "${tag}"
+fi

--- a/ops/stage0/test_assert_live_host_state.py
+++ b/ops/stage0/test_assert_live_host_state.py
@@ -17,7 +17,9 @@ _SCRIPT = pathlib.Path(__file__).resolve().parent / "assert-live-host-state.sh"
 
 
 class AssertLiveHostStateTransportTest(unittest.TestCase):
-    def _run_with_fake_aws(self, *, region: str | None = None) -> subprocess.CompletedProcess[str]:
+    def _run_with_fake_aws(
+        self, *, region: str | None = None, expected_tag: str | None = "1.8.40"
+    ) -> subprocess.CompletedProcess[str]:
         tmp = pathlib.Path(tempfile.mkdtemp(prefix="assert-live-host-state-"))
         calls = tmp / "aws-calls.txt"
         fake_bin = tmp / "bin"
@@ -69,8 +71,11 @@ class AssertLiveHostStateTransportTest(unittest.TestCase):
         env.pop("AWS_DEFAULT_REGION", None)
         if region is not None:
             env["AWS_REGION"] = region
+        cmd = ["bash", str(_SCRIPT), "i-test"]
+        if expected_tag is not None:
+            cmd.append(expected_tag)
         proc = subprocess.run(
-            ["bash", str(_SCRIPT), "i-test", "1.8.40"],
+            cmd,
             env=env,
             capture_output=True,
             text=True,
@@ -85,6 +90,12 @@ class AssertLiveHostStateTransportTest(unittest.TestCase):
         self.assertIn("OK: live host matches intended state", proc.stdout)
         self.assertTrue(proc.calls)  # type: ignore[attr-defined]
         self.assertTrue(all(not call.startswith("--region ") for call in proc.calls))  # type: ignore[attr-defined]
+        self.assertNotIn("unbound variable", proc.stderr)
+
+    def test_no_expected_tag_runs_daily_audit_mode_without_unbound_array(self) -> None:
+        proc = self._run_with_fake_aws(expected_tag=None)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertIn("OK: live host matches intended state", proc.stdout)
         self.assertNotIn("unbound variable", proc.stderr)
 
     def test_region_is_passed_before_ssm_subcommand(self) -> None:

--- a/ops/stage0/test_resolve_prod_running_tag_via_ssm.py
+++ b/ops/stage0/test_resolve_prod_running_tag_via_ssm.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Tests for resolve-prod-running-tag-via-ssm.sh transport and parsing.
+
+The script is an AWS/SSM wrapper, so these tests stub aws and return deterministic
+probe output. No network or live AWS state is used.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent / "resolve-prod-running-tag-via-ssm.sh"
+
+
+class ResolveProdRunningTagViaSsmTest(unittest.TestCase):
+    def _run(
+        self,
+        *args: str,
+        image: str = "ghcr.io/youxuanxue/sub2api:1.8.91",
+    ) -> subprocess.CompletedProcess[str]:
+        tmp = pathlib.Path(tempfile.mkdtemp(prefix="resolve-prod-running-tag-"))
+        calls = tmp / "aws-calls.txt"
+        fake_bin = tmp / "bin"
+        fake_bin.mkdir()
+        (fake_bin / "aws").write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                printf '%s\\n' "$*" >> {str(calls)!r}
+                if [[ "${{1:-}}" == "--region" ]]; then
+                  shift 2
+                fi
+                case "$*" in
+                  'cloudformation describe-stacks '*)
+                    printf 'i-test\\n'
+                    ;;
+                  'ssm send-command '*)
+                    printf 'cmd-123\\n'
+                    ;;
+                  'ssm get-command-invocation --command-id cmd-123 --instance-id i-test --query Status --output text'|\
+                  'ssm get-command-invocation --command-id cmd-123 --instance-id i-direct --query Status --output text')
+                    printf 'Success\\n'
+                    ;;
+                  'ssm get-command-invocation --command-id cmd-123 --instance-id i-test --query StandardOutputContent --output text'|\
+                  'ssm get-command-invocation --command-id cmd-123 --instance-id i-direct --query StandardOutputContent --output text')
+                    cat <<'OUT'
+                ACTIVE_COLOR {{"value":"green"}}
+                APPCONTAINER {{"name":"tokenkey-green","requested":"auto","fallback_used":false}}
+                RUNIMAGE {{"image":"{image}"}}
+                OUT
+                    ;;
+                  *)
+                    printf 'unexpected aws call: %s\\n' "$*" >&2
+                    exit 9
+                    ;;
+                esac
+                """
+            ),
+            encoding="utf-8",
+        )
+        (fake_bin / "aws").chmod(0o755)
+        env = {
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        }
+        proc = subprocess.run(
+            ["bash", str(_SCRIPT), "--timeout-seconds", "5", *args],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        proc.calls = calls.read_text(encoding="utf-8").splitlines()  # type: ignore[attr-defined]
+        return proc
+
+    def test_resolves_stack_instance_and_prints_bare_tag(self) -> None:
+        proc = self._run()
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "1.8.91")
+        self.assertTrue(any("cloudformation describe-stacks" in c for c in proc.calls))  # type: ignore[attr-defined]
+        self.assertTrue(any("ssm send-command" in c for c in proc.calls))  # type: ignore[attr-defined]
+
+    def test_instance_id_skips_cloudformation_and_json_includes_runtime_facts(self) -> None:
+        proc = self._run("--instance-id", "i-direct", "--json")
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["instance_id"], "i-direct")
+        self.assertEqual(data["container"], "tokenkey-green")
+        self.assertEqual(data["image"], "ghcr.io/youxuanxue/sub2api:1.8.91")
+        self.assertEqual(data["tag"], "1.8.91")
+        self.assertFalse(any("cloudformation describe-stacks" in c for c in proc.calls))  # type: ignore[attr-defined]
+
+    def test_rejects_mutable_latest_tag(self) -> None:
+        proc = self._run(image="ghcr.io/youxuanxue/sub2api:latest")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("not a Stage0 release tag", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- 新增 `ops/stage0/resolve-prod-running-tag-via-ssm.sh`，通过只读 SSM 自动识别 prod blue/green active container，并输出运行态 release tag；默认拒绝 `latest` 等非 Stage0 semver tag。
- 更新 prod resize / disaster recovery SOP，用 helper pin replacement `ImageTag`，避免实例替换时按陈旧 CFN `ImageTag` 静默退版。
- 修复 `assert-live-host-state.sh` 在 daily audit 模式不传 expected tag 时的空数组 `unbound variable` 问题，并补充 fake-AWS 回归测试。

## 风险
- 低风险：新增/修改均为 ops 只读工具、测试和 runbook；不改线上配置、不改部署 workflow、不改应用运行逻辑。
- helper 使用 `validate-deploy-tag.sh` fail-closed 校验运行态 tag，防止把 mutable `latest` 当作 replacement pin。
- Web impact: none。

## 验证
- `python3 -m unittest ops.stage0.test_assert_live_host_state ops.stage0.test_resolve_prod_running_tag_via_ssm`
- `bash ops/stage0/resolve-prod-running-tag-via-ssm.sh --region us-east-1 --stack tokenkey-prod-stage0 --json` → 只读返回 `container=tokenkey-green`, `tag=1.8.91`
- `bash scripts/preflight.sh` → PASS

## 提交
- `a81ebd197` chore(stage0): harden instance replacement tag resolution
- 最新提交：`a81ebd197`
