### PR TITLE
fix: clear main golangci gofmt and unused count_tokens wrapper

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -10583,10 +10583,6 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	return nil
 }
 
-func (s *GatewayService) forwardCountTokensAnthropicAPIKeyPassthrough(ctx context.Context, c *gin.Context, account *Account, body []byte) error {
-	return s.forwardCountTokensAnthropicPassthrough(ctx, c, account, body, anthropicPassthroughAuthAPIKey)
-}
-
 func (s *GatewayService) forwardCountTokensAnthropicPassthrough(
 	ctx context.Context,
 	c *gin.Context,

--- a/backend/internal/service/gateway_service_tk_count_tokens_failover.go
+++ b/backend/internal/service/gateway_service_tk_count_tokens_failover.go
@@ -18,7 +18,7 @@ import (
 //     shouldFailoverUpstreamError 对 >=500 一律 failover，pool stub（prod→edge）
 //     透回的 503（no available accounts）同属容量类瞬时错误，不应熔断主力账号。
 //
-// 由 ForwardCountTokens 与 forwardCountTokensAnthropicAPIKeyPassthrough 共用，
+// 由 ForwardCountTokens 与 forwardCountTokensAnthropicPassthrough 共用，
 // 保证两条路径的豁免集合不漂移。
 func tkCountTokensSkipBreaker(statusCode int) bool {
 	return statusCode == http.StatusBadRequest ||
@@ -58,7 +58,7 @@ func (s *GatewayService) tkCountTokensFailoverError(account *Account, resp *http
 // WriteCountTokensFailoverError 在 count_tokens 的 failover loop 耗尽（所有候选
 // 账号都失败 / 选号落空）时，向客户端写出 count_tokens 形状的错误响应。
 //
-// 背景：ForwardCountTokens / forwardCountTokensAnthropicAPIKeyPassthrough 对可
+// 背景：ForwardCountTokens / forwardCountTokensAnthropicPassthrough 对可
 // failover 的上游状态码返回 *UpstreamFailoverError 且**不写客户端响应**（留给
 // handler 的 failover loop 决定换号 / 池内轮换 / 耗尽）。因此耗尽分支的响应写入
 // 责任落到 handler，由本方法统一成与单发路径一致的 {type:error,error:{...}} 形状。

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -43,8 +43,8 @@ type RateLimitService struct {
 	// TK: OpenAI edge-mirror stub downstream-capacity counter (optional). See
 	// ratelimit_service_tk_openai_saturation.go.
 	openaiSaturationCounter OpenAISaturationCounterCache
-	usageCacheMu               sync.RWMutex
-	usageCache                 map[int64]*geminiUsageCacheEntry
+	usageCacheMu            sync.RWMutex
+	usageCache              map[int64]*geminiUsageCacheEntry
 }
 
 type AccountRuntimeBlocker interface {
@@ -112,7 +112,6 @@ const (
 	// "is the whole pool burning down right now" question; the counter
 	// expires when the window closes so a healed deploy reads zero.
 	anthropicCooldownTierEscalationsWindowMinutes = 60
-
 )
 
 // openAICloudflareChallengeKeywords matches Cloudflare / Arkose challenge


### PR DESCRIPTION
## 摘要

- `ratelimit_service.go` gofmt 对齐 struct 字段（main CI golangci 报错点）。
- 删除未使用的 `forwardCountTokensAnthropicAPIKeyPassthrough` wrapper；`ForwardCountTokens` 已直接调用 `forwardCountTokensAnthropicPassthrough`，注释同步更新。

sentinel-registry-reviewed：删除死 wrapper + gofmt，无 load-bearing 语义变更，无需更新 sentinel registry。

## 风险

- 低风险：无行为变更，仅格式 + 死代码删除。

## 验证

```bash
cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./internal/service/...
cd backend && go test -tags=unit ./internal/service -run 'CountTokens|ForwardCountTokens' -count=1
```

## 提交

- `9f92f1d09` fix(service): clear main golangci gofmt and unused wrapper

最新提交：`9f92f1d09`