### PR TITLE
fix(gateway): strip deprecated Opus temperature

### DIFF
--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -115,6 +115,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
+	anthropicBody = tkStripDeprecatedTemperature(anthropicBody)
 
 	// TK: thread gemini-native image aspect ratio (extra_body.google.image_config.
 	// aspect_ratio) from the raw CC body onto the relayed Anthropic body; the antigravity

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -114,6 +114,7 @@ func (s *GatewayService) ForwardAsResponses(
 
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
+	anthropicBody = tkStripDeprecatedTemperature(anthropicBody)
 
 	// 8. Get access token
 	token, tokenType, err := s.GetAccessToken(ctx, account)

--- a/backend/internal/service/gateway_request_tk_deprecated_temperature.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_temperature.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// tkModelDeprecatesTemperature reports whether Anthropic rejects the top-level
+// temperature field for this model. Live prod/edge traces on 2026-07-08 showed
+// claude-opus-4-7 returning HTTP 400 "`temperature` is deprecated for this
+// model."; Opus 4.7+ already has a distinct request surface elsewhere
+// (adaptive-only thinking), so keep the gate on the same model predicate.
+func tkModelDeprecatesTemperature(modelID string) bool {
+	return isOpus47OrNewer(modelID)
+}
+
+// tkStripDeprecatedTemperature removes only the top-level temperature field for
+// Anthropic models that now reject it. Nested JSON-schema properties named
+// "temperature" must remain intact.
+func tkStripDeprecatedTemperature(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	model := gjson.GetBytes(body, "model").String()
+	if !tkModelDeprecatesTemperature(model) || !gjson.GetBytes(body, "temperature").Exists() {
+		return body
+	}
+	stripped, err := sjson.DeleteBytes(body, "temperature")
+	if err != nil {
+		return body
+	}
+	return stripped
+}

--- a/backend/internal/service/gateway_request_tk_deprecated_temperature_test.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_temperature_test.go
@@ -1,0 +1,103 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestTkStripDeprecatedTemperature_StripIsTopLevelOnly(t *testing.T) {
+	input := []byte(`{"model":"claude-opus-4-7","temperature":0.7,"tools":[{"name":"set_temp","input_schema":{"type":"object","properties":{"temperature":{"type":"number"}}}}],"messages":[{"role":"user","content":"hi"}]}`)
+
+	got := tkStripDeprecatedTemperature(input)
+
+	require.False(t, gjson.GetBytes(got, "temperature").Exists())
+	require.True(t, gjson.GetBytes(got, "tools.0.input_schema.properties.temperature").Exists())
+	require.Equal(t, "claude-opus-4-7", gjson.GetBytes(got, "model").String())
+	require.True(t, gjson.ValidBytes(got))
+}
+
+func TestTkStripDeprecatedTemperature_NoTouchForOlderClaudeModels(t *testing.T) {
+	cases := []string{
+		`{"model":"claude-opus-4-6","temperature":0.7,"messages":[]}`,
+		`{"model":"claude-sonnet-4-6","temperature":0.7,"messages":[]}`,
+		`{"model":"claude-haiku-4-5","temperature":0.7,"messages":[]}`,
+		`{"model":"gpt-5.5","temperature":0.7,"messages":[]}`,
+	}
+	for _, body := range cases {
+		t.Run(gjson.Get(body, "model").String(), func(t *testing.T) {
+			got := tkStripDeprecatedTemperature([]byte(body))
+			require.Equal(t, body, string(got))
+		})
+	}
+}
+
+func TestForwardAsChatCompletions_AnthropicOpus47StripsTemperature(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"claude-opus-4-7","temperature":0.7,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-opus-4-7","content":[],"usage":{"input_tokens":3,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_opus47_temperature"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          52,
+		Name:        "cc-us3",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key": "sk-ant-relay",
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, gjson.GetBytes(upstream.lastBody, "temperature").Exists(),
+		"Opus 4.7+ rejects top-level temperature on Anthropic Messages")
+	require.True(t, gjson.GetBytes(upstream.lastBody, "messages").Exists())
+	require.Equal(t, "claude-opus-4-7", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, http.StatusOK, rec.Code)
+}

--- a/backend/internal/service/gateway_request_tk_fable_test.go
+++ b/backend/internal/service/gateway_request_tk_fable_test.go
@@ -83,14 +83,14 @@ func TestTkStripFableDisabledThinking_ModelVariants(t *testing.T) {
 // TestTkStripFableDisabledThinking_SanitizeChainShape mirrors the exact
 // composition used at all three gateway_service.go pre-send sites:
 //
-//	tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))
+//	tkStripDeprecatedTemperature(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))
 //
 // and proves the composed outbound body carries no thinking member.
 func TestTkStripFableDisabledThinking_SanitizeChainShape(t *testing.T) {
 	account := &Account{ID: 1, Name: "fable-test", Platform: PlatformAnthropic}
 	body := []byte(`{"model":"claude-fable-5","thinking":{"type":"disabled"},"messages":[{"role":"user","content":[{"type":"text","text":"hello"},{"type":"text","text":""}]}],"max_tokens":100}`)
 
-	out := tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))
+	out := tkStripDeprecatedTemperature(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))
 
 	require.False(t, gjson.GetBytes(out, "thinking").Exists())
 	require.Equal(t, "claude-fable-5", gjson.GetBytes(out, "model").String())

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1525,7 +1525,7 @@ func (s *GatewayService) applyClaudeCodeOAuthMimicryToBody(
 		body = applyToolsLastCacheBreakpoint(body)
 	}
 
-	return body
+	return tkStripDeprecatedTemperature(body)
 }
 
 // buildOAuthMetadataUserIDFromBody 是 buildOAuthMetadataUserID 的变体，
@@ -5161,7 +5161,8 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	// body as JSON; both prevent an upstream 400 before the first call.
 	// tkStripFableDisabledThinking: fable rejects explicit thinking.type=disabled
 	// with a 400 (gateway_request_tk_fable.go).
-	if err := replaceBody(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))); err != nil {
+	// tkStripDeprecatedTemperature: Opus 4.7+ rejects top-level temperature.
+	if err := replaceBody(tkStripDeprecatedTemperature(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))); err != nil {
 		return nil, err
 	}
 	// Pre-filter: remove thinking blocks with missing/invalid signatures before forwarding.
@@ -5941,7 +5942,8 @@ func (s *GatewayService) forwardAnthropicPassthroughWithInput(
 	// the body as JSON; both prevent an upstream 400.
 	// tkStripFableDisabledThinking: fable rejects explicit thinking.type=disabled
 	// with a 400 (gateway_request_tk_fable.go).
-	input.Body = tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account)))
+	// tkStripDeprecatedTemperature: Opus 4.7+ rejects top-level temperature.
+	input.Body = tkStripDeprecatedTemperature(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))
 	if input.Parsed != nil {
 		// 透传分支也会改写实际 wire body，成功 usage hash 依赖这里同步当前 body。
 		if err := input.Parsed.ReplaceBody(input.Body); err != nil {
@@ -10287,7 +10289,8 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	// an upstream 400 (here also guarding the per-account upstream-error breaker).
 	// tkStripFableDisabledThinking: fable rejects explicit thinking.type=disabled
 	// with a 400 (gateway_request_tk_fable.go).
-	if err := replaceBody(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))); err != nil {
+	// tkStripDeprecatedTemperature: Opus 4.7+ rejects top-level temperature.
+	if err := replaceBody(tkStripDeprecatedTemperature(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))); err != nil {
 		return err
 	}
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2810,6 +2810,25 @@
       "rationale": "Proactive pre-send strip of explicit thinking:{type:\"disabled\"} for Fable-tier models. Upstream rejects the explicit disabled shape on fable with a 400 ('\"thinking.type.disabled\" is not supported for this model …', prod 2026-06-10 user 16) while Opus 4.7+ still accepts it — so the gate is isFableModel, NOT requiresAdaptiveOnlyThinking, and omitting the field is the documented equivalent (same rule the bedrock path already applies in sanitizeBedrockThinking's disabled case). If this function is silently dropped, fable clients sending thinking.type=disabled regress to raw upstream 400s on the direct Anthropic path."
     },
     {
+      "path": "backend/internal/service/gateway_request_tk_deprecated_temperature.go",
+      "must_contain": [
+        "func tkStripDeprecatedTemperature(body []byte) []byte",
+        "return isOpus47OrNewer(modelID)",
+        "tkModelDeprecatesTemperature(model)",
+        "sjson.DeleteBytes(body, \"temperature\")"
+      ],
+      "rationale": "Proactive pre-send strip of top-level temperature for Anthropic Opus 4.7+ models. Prod/edge traces on 2026-07-08 showed claude-opus-4-7 upstream 400 'temperature is deprecated for this model' after the gateway preserved or injected the field. The gate deliberately reuses the Opus 4.7+ predicate so older Claude families and non-Anthropic bodies keep their request surface, while only the top-level field is deleted. Dropping this companion silently re-opens platform-owned internal 400s for chat/messages/responses/count_tokens paths."
+    },
+    {
+      "path": "backend/internal/service/gateway_request_tk_deprecated_temperature_test.go",
+      "must_contain": [
+        "TestTkStripDeprecatedTemperature_StripIsTopLevelOnly",
+        "TestTkStripDeprecatedTemperature_NoTouchForOlderClaudeModels",
+        "TestForwardAsChatCompletions_AnthropicOpus47StripsTemperature"
+      ],
+      "rationale": "Focused regressions for the Opus 4.7+ temperature deprecation: top-level temperature is stripped, nested JSON-schema properties named temperature are preserved, older Claude/non-Claude models are untouched, and the Anthropic Chat Completions forwarding path sends the stripped wire body upstream."
+    },
+    {
       "path": "backend/internal/service/gateway_request_tk_bare_model_alias.go",
       "must_contain": [
         "func tkDeriveBareModelAliases(set map[string]struct{}) map[string]string",
@@ -2828,10 +2847,10 @@
     {
       "path": "backend/internal/service/gateway_service.go",
       "must_contain": [
-        "replaceBody(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))",
-        "input.Body = tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account)))"
+        "replaceBody(tkStripDeprecatedTemperature(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))))",
+        "input.Body = tkStripDeprecatedTemperature(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))"
       ],
-      "rationale": "The three pre-send sanitize chains (main Forward ~4834, API-Key passthrough ~5526, count_tokens ~9922) must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking so an explicit thinking.type=disabled never reaches upstream for fable models. An upstream merge that restores the bare two-function chain silently reverts the fix and fable+disabled requests 400 again. The replaceBody form covers both Forward and count_tokens; the input.Body form covers the passthrough path."
+      "rationale": "The three pre-send sanitize chains (main Forward ~4834, API-Key passthrough ~5526, count_tokens ~9922) must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking and tkStripDeprecatedTemperature so explicit thinking.type=disabled never reaches fable upstreams and top-level temperature never reaches Opus 4.7+ Anthropic upstreams. An upstream merge that restores the bare two-function chain silently reverts either fix and surfaces raw upstream 400s again. The replaceBody form covers both Forward and count_tokens; the input.Body form covers the passthrough path."
     },
     {
       "path": "backend/internal/handler/api_key_handler.go",


### PR DESCRIPTION
## 摘要
- 修复 `claude-opus-4-7` 近 1 小时高频平台侧 400：Anthropic 上游返回 `temperature is deprecated for this model`。
- 新增 `tkStripDeprecatedTemperature`，仅对 Opus 4.7+ Anthropic 出站 body 删除顶层 `temperature`，并接入 Chat Completions→Messages、Responses relay、native Forward、API-key passthrough、count_tokens/OAuth mimicry 路径。
- 保留工具 JSON schema 等嵌套 `temperature` 字段，避免误删业务参数；更新 gateway TK sentinel registry 防止后续上游合并漏掉清理链或测试。
- no-web-impact：纯后端 gateway 出站请求清理，无 Web/config/contract 展示面变化。

## 风险
- 风险中低：行为只收窄到 Opus 4.7+ 的顶层 `temperature` 删除；旧 Claude、非 Claude 模型和嵌套 schema 字段保持原样。
- 对客户端的可见变化是原本会触发上游 400 的 Opus 4.7+ `temperature` 被网关兼容化后继续转发。
- 回滚方式：回退本 PR commit 即恢复原透传行为。

## 验证
- `go test -tags unit ./internal/service -run 'TestTkStripDeprecatedTemperature|TestForwardAsChatCompletions_AnthropicOpus47StripsTemperature|TestTkStripFableDisabledThinking_SanitizeChainShape' -count=1`
- `go test -tags unit ./internal/pkg/apicompat -run 'TestChatCompletionsToResponses_Temperature|TestAnthropicToResponses_Temperature' -count=1`
- `go test -tags unit ./internal/service -count=1`
- `./scripts/preflight.sh`

## 提交
- `8a3438901 fix(gateway): strip deprecated Opus temperature no-web-impact`
- 最新提交：`8a3438901`