### PR TITLE
fix(gateway): normalize dotted Claude opus aliases no-web-impact

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -139,7 +139,7 @@ jobs:
           prefix: unit
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
       - name: Unit tests
         working-directory: backend
         run: make test-unit
@@ -163,7 +163,7 @@ jobs:
           prefix: integration
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
       - name: Integration tests
         working-directory: backend
         run: make test-integration
@@ -213,7 +213,7 @@ jobs:
           prefix: lint
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
       # PR: only-new-issues (GitHub API diff). Push/workflow_dispatch: full ./... lint on backend.
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -239,7 +239,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
       - name: Run gosec lint
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: golangci/golangci-lint-action@v9
@@ -332,7 +332,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
       - name: Run pinned new-api smoke via bump helper
         run: |
           CURRENT_PIN="$(tr -d '[:space:]' < .new-api-ref)"
@@ -386,7 +386,7 @@ jobs:
             ${{ runner.os }}-go-release-
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
       # Compile cmd/server for BOTH release arches to populate the cache.
       # Flags mirror .goreleaser.yaml (CGO_ENABLED=0, linux) — but WITHOUT
       # `-tags=embed`, so no frontend dist/ is required (embed_off.go satisfies
@@ -422,7 +422,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -30,7 +30,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
       - name: Run govulncheck
         working-directory: backend
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # =============================================================================
 
 ARG NODE_IMAGE=node:24-alpine
-ARG GOLANG_IMAGE=golang:1.26.4-alpine
+ARG GOLANG_IMAGE=golang:1.26.5-alpine
 ARG ALPINE_IMAGE=alpine:3.21
 ARG POSTGRES_IMAGE=postgres:18-alpine
 ARG GOPROXY=https://goproxy.cn,direct

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine
+FROM golang:1.26.5-alpine
 
 WORKDIR /app
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/Wei-Shaw/sub2api
 
-go 1.26.4
+go 1.26.5
 
 require (
 	entgo.io/ent v0.14.5

--- a/backend/internal/service/gateway_request_tk_bare_model_alias.go
+++ b/backend/internal/service/gateway_request_tk_bare_model_alias.go
@@ -10,7 +10,8 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 )
 
-// TokenKey: bare claude family-name fallback ("opus" → latest servable opus id).
+// TokenKey: Anthropic model aliases ("opus" → latest servable opus id,
+// "opus-4.7" → "claude-opus-4-7").
 //
 // Prod incident 2026-06-10 (user_id=16): clients send the bare family word and
 // die with the #617 unsupported-model 400. Friendlier contract: a bare family
@@ -20,10 +21,11 @@ import (
 // (new opus 4.9 row, new `claude-zenith-6` family) changes the answer with
 // ZERO code edits. Trigger is strictly LEXICAL-EXACT (after lower+trim and the
 // existing tkStripContextWindowModelAlias pass): the model must equal a family
-// word or `claude-<family>`. Everything else — full ids, dated snapshots,
-// retired names like "claude-3-5-haiku-20241022" (versioned ⇒ natural miss;
-// the deprecated-model interceptor keeps owning it), unknown families,
-// substrings — is returned byte-identical with zero rewrites. The rewrite
+// word, `claude-<family>`, or a supported dotted shorthand like `opus-4.7`.
+// Everything else — full ids, dated snapshots, retired names like
+// "claude-3-5-haiku-20241022" (versioned ⇒ natural miss; the deprecated-model
+// interceptor keeps owning it), unknown families, substrings — is returned
+// byte-identical with zero rewrites. The rewrite
 // happens at the handler throat BEFORE channel mapping / session hash /
 // scheduling / usage recording, so every downstream consumer (including the
 // originalModel billing key) sees only the resolved full id.
@@ -77,6 +79,34 @@ func tkDeriveBareModelAliases(set map[string]struct{}) map[string]string {
 	return out
 }
 
+// tkDeriveDottedVersionAliases derives compatibility aliases for clients that
+// spell Claude family versions with a dot and no required "claude-" prefix:
+// "opus-4.7" / "claude-opus-4.7" route to "claude-opus-4-7" when that
+// canonical id is actually servable.
+func tkDeriveDottedVersionAliases(set map[string]struct{}) map[string]string {
+	out := map[string]string{}
+	for id := range set {
+		m := tkBareAliasFamilyPattern.FindStringSubmatch(id)
+		if m == nil {
+			continue
+		}
+		segs := strings.Split(strings.TrimPrefix(m[2], "-"), "-")
+		if len(segs) != 2 {
+			continue
+		}
+		out[m[1]+"-"+segs[0]+"."+segs[1]] = id
+	}
+	return out
+}
+
+func tkDeriveAnthropicModelAliases(set map[string]struct{}) map[string]string {
+	out := tkDeriveBareModelAliases(set)
+	for alias, canonical := range tkDeriveDottedVersionAliases(set) {
+		out[alias] = canonical
+	}
+	return out
+}
+
 // Lazily derived once per process from the compile-time servable table.
 var (
 	tkBareModelAliasOnce sync.Once
@@ -85,14 +115,14 @@ var (
 
 func tkBareModelAliasMap() map[string]string {
 	tkBareModelAliasOnce.Do(func() {
-		tkBareModelAliases = tkDeriveBareModelAliases(supportedAnthropicCatalogModels)
+		tkBareModelAliases = tkDeriveAnthropicModelAliases(supportedAnthropicCatalogModels)
 	})
 	return tkBareModelAliases
 }
 
-// tkResolveBareModelAlias maps a bare family name to its latest servable full
-// id. Hit requires lexical-exact equality (after lower+trim and stripping a
-// trailing "[1m]"-style alias) with a family word or `claude-<family>`.
+// tkResolveBareModelAlias maps supported shorthand aliases to their servable
+// full ids. Hit requires lexical-exact equality after lower+trim and stripping
+// a trailing "[1m]"-style alias.
 func tkResolveBareModelAlias(model string, aliases map[string]string) (string, bool) {
 	normalized := strings.ToLower(strings.TrimSpace(model))
 	if normalized == "" {
@@ -135,7 +165,7 @@ func TkApplyBareModelAlias(platform string, parsed *ParsedRequest) ([]byte, stri
 	}
 	parsed.Model = resolved
 	logger.LegacyPrintf("service.gateway",
-		"[Forward] bare model alias resolved family name to latest servable id before scheduling: requested=%s resolved=%s",
+		"[Forward] anthropic model alias resolved before scheduling: requested=%s resolved=%s",
 		requested, resolved)
 	return newBody, resolved
 }

--- a/backend/internal/service/gateway_request_tk_bare_model_alias_test.go
+++ b/backend/internal/service/gateway_request_tk_bare_model_alias_test.go
@@ -12,7 +12,7 @@ import (
 // prefix-wins (haiku-4-5 vs dated) and family emergence (zenith is not
 // hand-listed anywhere in the implementation).
 var fixtureBareAliasSet = map[string]struct{}{
-	"claude-opus-4-1": {}, "claude-opus-4-9": {}, "claude-opus-4-10": {},
+	"claude-opus-4-1": {}, "claude-opus-4-7": {}, "claude-opus-4-9": {}, "claude-opus-4-10": {},
 	"claude-sonnet-4-5": {}, "claude-sonnet-4-6": {},
 	"claude-haiku-4-5": {}, "claude-haiku-4-5-20251001": {},
 	"claude-fable-5": {}, "claude-zenith-6-2": {},
@@ -28,6 +28,25 @@ func TestTkDeriveBareModelAliases_Fixture(t *testing.T) {
 	}
 	if got := tkDeriveBareModelAliases(fixtureBareAliasSet); !reflect.DeepEqual(got, want) {
 		t.Fatalf("derived aliases:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestTkDeriveDottedVersionAliases_Fixture(t *testing.T) {
+	aliases := tkDeriveDottedVersionAliases(fixtureBareAliasSet)
+	for in, want := range map[string]string{
+		"opus-4.1":   "claude-opus-4-1",
+		"opus-4.7":   "claude-opus-4-7",
+		"opus-4.10":  "claude-opus-4-10",
+		"sonnet-4.6": "claude-sonnet-4-6",
+		"haiku-4.5":  "claude-haiku-4-5",
+		"zenith-6.2": "claude-zenith-6-2",
+	} {
+		if got := aliases[in]; got != want {
+			t.Errorf("dotted alias %q = %q, want %q", in, got, want)
+		}
+	}
+	if got := aliases["haiku-4.5.20251001"]; got != "" {
+		t.Fatalf("dated model must not derive a dotted shorthand alias, got %q", got)
 	}
 }
 
@@ -48,10 +67,11 @@ func TestTkDeriveBareModelAliases_RealTablePin(t *testing.T) {
 }
 
 func TestTkResolveBareModelAlias_Trigger(t *testing.T) {
-	aliases := tkDeriveBareModelAliases(fixtureBareAliasSet)
+	aliases := tkDeriveAnthropicModelAliases(fixtureBareAliasSet)
 	for in, want := range map[string]string{
 		"opus": "claude-opus-4-10", "Opus ": "claude-opus-4-10", "OPUS": "claude-opus-4-10",
 		"claude-opus": "claude-opus-4-10", "opus[1m]": "claude-opus-4-10",
+		"opus-4.7": "claude-opus-4-7", "claude-opus-4.7": "claude-opus-4-7",
 		"sonnet": "claude-sonnet-4-6", "claude-haiku": "claude-haiku-4-5",
 		"fable": "claude-fable-5", "zenith": "claude-zenith-6-2",
 	} {
@@ -60,16 +80,46 @@ func TestTkResolveBareModelAlias_Trigger(t *testing.T) {
 		}
 	}
 	for _, in := range []string{
-		"claude-opus-4-8",            // full id — never rewritten
-		"claude-opus-4-8[1m]",        // strips to full id, still miss
-		"claude-sonnet-4-5-20250929", // dated snapshot
-		"claude-3-5-haiku-20241022",  // retired: versioned → natural miss; deprecated interceptor owns it
-		"Claude-Opus-4.8",            // dotted variant — not a bare family word
+		"claude-opus-4-8",                            // full id — never rewritten
+		"claude-opus-4-8[1m]",                        // strips to full id, still miss
+		"claude-sonnet-4-5-20250929",                 // dated snapshot
+		"claude-3-5-haiku-20241022",                  // retired: versioned → natural miss; deprecated interceptor owns it
+		"Claude-Opus-4.8",                            // dotted variant without a fixture-backed canonical id
 		"gpt", "gemini", "claude-zzz-5", "", "opusx", // no fuzzy/substring matching
 	} {
 		if got, ok := tkResolveBareModelAlias(in, aliases); ok {
 			t.Errorf("resolve(%q) = (%q, true), want miss", in, got)
 		}
+	}
+}
+
+func TestTkApplyBareModelAlias_DottedVersionRewrite(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		model    string
+		resolved string
+	}{
+		{"no prefix", "opus-4.7", "claude-opus-4-7"},
+		{"claude prefix", "claude-opus-4.7", "claude-opus-4-7"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := []byte(`{"model":"` + tc.model + `","max_tokens":1}`)
+			parsed, err := ParseGatewayRequest(NewRequestBodyRef(append([]byte(nil), orig...)), PlatformAnthropic)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			newBody, resolved := TkApplyBareModelAlias(PlatformAnthropic, parsed)
+			if resolved != tc.resolved {
+				t.Fatalf("resolved = %q, want %q", resolved, tc.resolved)
+			}
+			want := []byte(`{"model":"` + tc.resolved + `","max_tokens":1}`)
+			if !bytes.Equal(newBody, want) {
+				t.Fatalf("dotted rewrite:\n got=%s\nwant=%s", newBody, want)
+			}
+			if parsed.Model != tc.resolved || !bytes.Equal(parsed.Body.Bytes(), want) {
+				t.Fatalf("parsed not refreshed: model=%q body=%s", parsed.Model, parsed.Body.Bytes())
+			}
+		})
 	}
 }
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -7,7 +7,7 @@
 # =============================================================================
 
 ARG NODE_IMAGE=node:24-alpine
-ARG GOLANG_IMAGE=golang:1.26.4-alpine
+ARG GOLANG_IMAGE=golang:1.26.5-alpine
 ARG ALPINE_IMAGE=alpine:3.20
 ARG GOPROXY=https://goproxy.cn,direct
 ARG GOSUMDB=sum.golang.google.cn

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2838,10 +2838,11 @@
       "path": "backend/internal/service/gateway_request_tk_bare_model_alias.go",
       "must_contain": [
         "func tkDeriveBareModelAliases(set map[string]struct{}) map[string]string",
+        "func tkDeriveDottedVersionAliases(set map[string]struct{}) map[string]string",
         "func TkApplyBareModelAlias(platform string, parsed *ParsedRequest) ([]byte, string)",
-        "tkDeriveBareModelAliases(supportedAnthropicCatalogModels)"
+        "tkDeriveAnthropicModelAliases(supportedAnthropicCatalogModels)"
       ],
-      "rationale": "Bare claude family-name fallback (\"opus\"/\"sonnet\"/\"haiku\"/\"fable\"/\"claude-<family>\" → latest servable full id), derived dynamically from the servable allowlist (pricing_catalog_supported_models_tk.go) with no hand-kept family list — a servable refresh changes the answer with zero code edits. Trigger is lexical-exact only (after lower+trim and [1m] strip); full ids, dated snapshots and the retired claude-3-5-haiku-20241022 are natural byte-identical misses, so the deprecated-model interceptor and the #617 unsupported-model 400 contract are untouched. If this companion or its derivation from the real table is silently dropped by an upstream merge, bare family names regress to 'Unsupported model' 400s."
+      "rationale": "Anthropic shorthand model aliases (\"opus\"/\"sonnet\"/\"haiku\"/\"fable\"/\"claude-<family>\" → latest servable full id, plus dotted version aliases like \"opus-4.7\"/\"claude-opus-4.7\" → the catalog-backed canonical id), derived dynamically from the servable allowlist (pricing_catalog_supported_models_tk.go) with no hand-kept family list. A servable refresh changes the answer with zero code edits. Trigger is lexical-exact only (after lower+trim and [1m] strip); full ids, dated snapshots and the retired claude-3-5-haiku-20241022 are natural byte-identical misses, so the deprecated-model interceptor and unsupported-model 400 contract are untouched. If this companion or its derivation from the real table is silently dropped by an upstream merge, shorthand names regress to 'Unsupported model' 400s."
     },
     {
       "path": "backend/internal/handler/gateway_handler.go",

--- a/tools/error_clustering/go.mod
+++ b/tools/error_clustering/go.mod
@@ -1,5 +1,5 @@
 module tokenkey.dev/tools/error_clustering
 
-go 1.26.4
+go 1.26.5
 
 require github.com/lib/pq v1.10.9


### PR DESCRIPTION
## 摘要

- 将 TokenKey Anthropic shorthand alias 扩展到 dotted 版本写法：`opus-4.7` / `claude-opus-4.7` 会在调度前规范化为 `claude-opus-4-7`。
- dotted alias 仍从 servable allowlist 派生，只对真实存在的 canonical id 生效，避免未知版本被模糊映射。
- 更新 gateway TK sentinel registry，守住 alias owner 与运行时派生入口。
- 将 Go patch pin 从 1.26.4 升到 1.26.5，修复 `backend-security` 的 `GO-2026-5856` / `crypto/tls` govulncheck 阻塞；同步 CI 断言和 Docker builder 镜像。

## 风险

- 风险低到常规：alias 改动只影响 Anthropic shorthand model alias 的请求入口，完整模型 ID、dated snapshot、retired model 拦截路径保持不变。
- Go patch 升级是标准库安全补丁，CI、release warm cache、Docker builder pin 同步更新。
- Web impact: none；后端 gateway 请求规范化与 CI/构建工具链修复，无前端展示或 API 字段变更。
- sentinel-registry-reviewed：已确认 Dockerfile / deploy Dockerfile 仅更新 Go builder 安全补丁 pin；brand sentinel 的 label 锚点不受影响，不需要新增 brand registry anchor。

## 验证

- `go test -tags unit ./internal/service -run 'TestTk(DeriveBareModelAliases|DeriveDottedVersionAliases|ResolveBareModelAlias|ApplyBareModelAlias)'`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...`（backend）
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

## 提交

- `0204788` fix(gateway): normalize dotted Claude opus aliases no-web-impact
- `3b7ed46` fix(ci): bump Go to 1.26.5 for govulncheck no-web-impact

最新提交：`3b7ed46`
