### PR TITLE
fix(ops): alert on user-visible terminal failures

### DIFF
--- a/backend/internal/repository/ops_alert_rules_seed_state_integration_test.go
+++ b/backend/internal/repository/ops_alert_rules_seed_state_integration_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestSeededAlertRuleStateAfterMigrations pins the enabled-alert-rule contract
-// after all migrations apply: the routing-capacity P0 (tk_035) ships enabled,
+// after all migrations apply: the retired routing-capacity P0 (tk_061) is gone,
 // and the never-wired latency rules (tk_036) ship disabled — so every enabled
 // rule has a working evaluator path (no silent dead rules).
 func TestSeededAlertRuleStateAfterMigrations(t *testing.T) {
@@ -25,10 +25,20 @@ func TestSeededAlertRuleStateAfterMigrations(t *testing.T) {
 		require.NoError(t, err, "metric_type %s should be seeded", metricType)
 		return enabled
 	}
+	existsFor := func(metricType string) bool {
+		var exists bool
+		err := integrationDB.QueryRowContext(ctx,
+			`SELECT EXISTS (SELECT 1 FROM ops_alert_rules WHERE metric_type = $1)`,
+			metricType,
+		).Scan(&exists)
+		require.NoError(t, err, "metric_type %s existence check should query", metricType)
+		return exists
+	}
 
-	// tk_035: the routing-capacity-rejection P0 is on by default (this PR's core).
-	require.True(t, enabledFor("routing_capacity_rejection_count"),
-		"tk_035 routing_capacity_rejection_count rule must be enabled")
+	// tk_061: the routing-capacity-rejection P0 is retired because
+	// user_visible_failure_count is now the single experience-first P0.
+	require.False(t, existsFor("routing_capacity_rejection_count"),
+		"tk_061 must remove routing_capacity_rejection_count to avoid duplicate P0 pages")
 
 	// tk_036: the unimplemented latency rules are disabled — they never fired
 	// (no evaluator case) and their full-request-duration thresholds (2000/3000ms)

--- a/backend/internal/repository/ops_repo_user_visible_failure_integration_test.go
+++ b/backend/internal/repository/ops_repo_user_visible_failure_integration_test.go
@@ -1,0 +1,98 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserVisibleFailureCountAndBreakdown(t *testing.T) {
+	ctx := context.Background()
+	_, _ = integrationDB.ExecContext(ctx, "TRUNCATE ops_error_logs RESTART IDENTITY CASCADE")
+
+	repo := NewOpsRepository(integrationDB).(*opsRepository)
+	suffix := time.Now().UnixNano()
+
+	var groupID, userID, apiKeyID int64
+	require.NoError(t, integrationDB.QueryRowContext(ctx,
+		`INSERT INTO groups (name) VALUES ($1) RETURNING id`,
+		fmt.Sprintf("uvf-group-%d", suffix)).Scan(&groupID))
+	require.NoError(t, integrationDB.QueryRowContext(ctx,
+		`INSERT INTO users (email, password_hash) VALUES ($1, 'x') RETURNING id`,
+		fmt.Sprintf("uvf-%d@example.com", suffix)).Scan(&userID))
+	require.NoError(t, integrationDB.QueryRowContext(ctx,
+		`INSERT INTO api_keys (user_id, key, name, group_id) VALUES ($1, $2, $3, $4) RETURNING id`,
+		userID, fmt.Sprintf("sk-uvf-%d", suffix), "training-key", groupID).Scan(&apiKeyID))
+	t.Cleanup(func() {
+		_, _ = integrationDB.ExecContext(context.Background(), "DELETE FROM groups WHERE id = $1", groupID)
+		_, _ = integrationDB.ExecContext(context.Background(), "DELETE FROM users WHERE id = $1", userID)
+	})
+
+	windowStart := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Hour)
+	windowEnd := windowStart.Add(time.Hour)
+	at := windowStart.Add(5 * time.Minute)
+	i64 := func(v int64) *int64 { return &v }
+
+	insert := func(owner, phase, typ string, status, upstream int, user *int64, countTokens bool, msg string) {
+		var upstreamArg any
+		if upstream > 0 {
+			upstreamArg = upstream
+		}
+		_, err := integrationDB.ExecContext(ctx, `
+			INSERT INTO ops_error_logs (
+				user_id, api_key_id, group_id, account_id,
+				error_phase, error_type, severity, status_code, error_owner,
+				platform, requested_model, upstream_status_code, upstream_error_message,
+				is_count_tokens, created_at
+			) VALUES ($1, $2, $3, 76, $4, $5, 'error', $6, $7, 'openai', 'gpt-5.5', $8, $9, $10, $11)`,
+			user, apiKeyID, groupID, phase, typ, status, owner, upstreamArg, msg, countTokens, at)
+		require.NoError(t, err)
+	}
+
+	// P0 owner scope: provider/platform terminal failures attributable to a user.
+	insert("provider", "upstream", "rate_limit_error", 429, 429, i64(userID), false, "Too many pending requests")
+	insert("platform", "internal", "api_error", 499, 0, i64(userID), false, "client cancelled after platform stall")
+	// P1 owner scope: client-owned terminal failure, also attributable.
+	insert("client", "request", "invalid_request_error", 400, 0, i64(userID), false, "prompt too long")
+
+	// Exclusions: recovered-200, count_tokens probe, and unattributed failure.
+	insert("provider", "upstream", "upstream_error", 200, 429, i64(userID), false, "recovered")
+	insert("provider", "upstream", "rate_limit_error", 429, 429, i64(userID), true, "count tokens")
+	insert("provider", "upstream", "upstream_error", 502, 502, nil, false, "no user")
+
+	filter := &service.OpsDashboardFilter{StartTime: windowStart, EndTime: windowEnd, QueryMode: service.OpsQueryModeRaw}
+
+	systemCount, err := repo.CountUserVisibleFailures(ctx, filter, "system")
+	require.NoError(t, err)
+	require.EqualValues(t, 2, systemCount, "provider/platform terminal failures count; recovered/count_tokens/unattributed/client rows do not")
+
+	clientCount, err := repo.CountUserVisibleFailures(ctx, filter, "client")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, clientCount, "client terminal failures count only in the P1 scope")
+
+	breakdown, err := repo.GetUserVisibleFailureBreakdown(ctx, filter, "system", 3)
+	require.NoError(t, err)
+	require.NotNil(t, breakdown)
+	require.EqualValues(t, 2, breakdown.Failures)
+	require.NotEmpty(t, breakdown.Users)
+	require.Equal(t, userID, breakdown.Users[0].UserID)
+	require.Equal(t, "training-key", breakdown.Users[0].APIKeyName)
+	require.NotEmpty(t, breakdown.Surfaces)
+	require.Equal(t, 429, breakdown.Surfaces[0].StatusCode)
+	require.Equal(t, 429, breakdown.Surfaces[0].UpstreamStatusCode)
+	require.NotEmpty(t, breakdown.Roots)
+	foundProviderUpstream := false
+	for _, root := range breakdown.Roots {
+		if root != nil && root.Phase == "upstream" && root.Owner == "provider" {
+			foundProviderUpstream = true
+			break
+		}
+	}
+	require.True(t, foundProviderUpstream, "breakdown roots should include the provider/upstream failure")
+}

--- a/backend/internal/repository/ops_repo_user_visible_failure_tk.go
+++ b/backend/internal/repository/ops_repo_user_visible_failure_tk.go
@@ -1,0 +1,204 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// CountUserVisibleFailures counts terminal failures that a real, attributable
+// customer request saw. It deliberately ignores recovered upstream rows
+// (status_code < 400) and count_tokens probes via buildErrorWhere.
+func (r *opsRepository) CountUserVisibleFailures(ctx context.Context, filter *service.OpsDashboardFilter, ownerScope string) (int64, error) {
+	if r == nil || r.db == nil {
+		return 0, fmt.Errorf("nil ops repository")
+	}
+	if filter == nil {
+		return 0, fmt.Errorf("nil filter")
+	}
+	where, args, _ := buildUserVisibleFailureWhere(filter, ownerScope, 1)
+	q := `SELECT COALESCE(COUNT(*), 0) FROM ops_error_logs ` + where
+
+	var n int64
+	if err := r.db.QueryRowContext(ctx, q, args...).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (r *opsRepository) GetUserVisibleFailureBreakdown(ctx context.Context, filter *service.OpsDashboardFilter, ownerScope string, limit int) (*service.OpsUserVisibleFailureBreakdown, error) {
+	if r == nil || r.db == nil {
+		return nil, fmt.Errorf("nil ops repository")
+	}
+	if filter == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 3
+	}
+
+	failures, err := r.CountUserVisibleFailures(ctx, filter, ownerScope)
+	if err != nil {
+		return nil, err
+	}
+	successes, _, err := r.queryUsageCounts(ctx, filter, filter.StartTime.UTC(), filter.EndTime.UTC())
+	if err != nil {
+		return nil, err
+	}
+
+	users, err := r.topUserVisibleFailureUsers(ctx, filter, ownerScope, limit)
+	if err != nil {
+		return nil, err
+	}
+	surfaces, err := r.topUserVisibleFailureSurfaces(ctx, filter, ownerScope, limit)
+	if err != nil {
+		return nil, err
+	}
+	roots, err := r.topUserVisibleFailureRoots(ctx, filter, ownerScope, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	return &service.OpsUserVisibleFailureBreakdown{
+		Failures:  failures,
+		Successes: successes,
+		Users:     users,
+		Surfaces:  surfaces,
+		Roots:     roots,
+	}, nil
+}
+
+func buildUserVisibleFailureWhere(filter *service.OpsDashboardFilter, ownerScope string, startIndex int) (string, []any, int) {
+	where, args, next := buildErrorWhere(filter, filter.StartTime.UTC(), filter.EndTime.UTC(), startIndex)
+	where += " AND COALESCE(status_code, 0) >= 400"
+	where += " AND COALESCE(user_id, deleted_key_owner_user_id) IS NOT NULL"
+	switch strings.TrimSpace(ownerScope) {
+	case "client":
+		where += " AND COALESCE(error_owner, '') = 'client'"
+	default:
+		where += " AND COALESCE(error_owner, '') IN ('provider', 'platform')"
+	}
+	return where, args, next
+}
+
+func (r *opsRepository) topUserVisibleFailureUsers(ctx context.Context, filter *service.OpsDashboardFilter, ownerScope string, limit int) ([]*service.OpsUserVisibleFailureUser, error) {
+	where, args, next := buildUserVisibleFailureWhere(filter, ownerScope, 1)
+	args = append(args, limit)
+	q := `WITH base AS (
+  SELECT * FROM ops_error_logs ` + where + `
+)
+SELECT
+  COALESCE(l.user_id, l.deleted_key_owner_user_id, 0) AS user_id,
+  COALESCE(u.email, '') AS user_email,
+  COALESCE(ak.name, l.deleted_key_name, '') AS api_key_name,
+  COALESCE(g.name, '') AS group_name,
+  COUNT(*) AS n
+FROM base l
+LEFT JOIN users u ON u.id = COALESCE(l.user_id, l.deleted_key_owner_user_id)
+LEFT JOIN api_keys ak ON ak.id = l.api_key_id AND ak.deleted_at IS NULL
+LEFT JOIN groups g ON g.id = l.group_id AND g.deleted_at IS NULL
+GROUP BY 1, 2, 3, 4
+ORDER BY n DESC, user_id ASC
+LIMIT $` + fmt.Sprintf("%d", next)
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]*service.OpsUserVisibleFailureUser, 0, limit)
+	for rows.Next() {
+		row := &service.OpsUserVisibleFailureUser{}
+		if err := rows.Scan(&row.UserID, &row.UserEmail, &row.APIKeyName, &row.GroupName, &row.Count); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *opsRepository) topUserVisibleFailureSurfaces(ctx context.Context, filter *service.OpsDashboardFilter, ownerScope string, limit int) ([]*service.OpsUserVisibleFailureSurface, error) {
+	where, args, next := buildUserVisibleFailureWhere(filter, ownerScope, 1)
+	args = append(args, limit)
+	q := `WITH base AS (
+  SELECT * FROM ops_error_logs ` + where + `
+)
+SELECT
+  COALESCE(status_code, 0) AS status_code,
+  COALESCE(upstream_status_code, 0) AS upstream_status_code,
+  COALESCE(error_type, '') AS error_type,
+  COUNT(*) AS n
+FROM base
+GROUP BY 1, 2, 3
+ORDER BY n DESC, status_code ASC, upstream_status_code ASC
+LIMIT $` + fmt.Sprintf("%d", next)
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]*service.OpsUserVisibleFailureSurface, 0, limit)
+	for rows.Next() {
+		row := &service.OpsUserVisibleFailureSurface{}
+		if err := rows.Scan(&row.StatusCode, &row.UpstreamStatusCode, &row.ErrorType, &row.Count); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *opsRepository) topUserVisibleFailureRoots(ctx context.Context, filter *service.OpsDashboardFilter, ownerScope string, limit int) ([]*service.OpsUserVisibleFailureRoot, error) {
+	where, args, next := buildUserVisibleFailureWhere(filter, ownerScope, 1)
+	args = append(args, limit)
+	q := `WITH base AS (
+  SELECT * FROM ops_error_logs ` + where + `
+)
+SELECT
+  COALESCE(error_phase, '') AS phase,
+  COALESCE(error_owner, '') AS owner,
+  COALESCE(platform, '') AS platform,
+  COALESCE(NULLIF(requested_model, ''), NULLIF(model, ''), '(unknown)') AS model,
+  COALESCE(account_id, 0) AS account_id,
+  left(regexp_replace(COALESCE(upstream_error_message, error_message, ''), E'[\\n\\r]+', ' ', 'g'), 96) AS msg,
+  COUNT(*) AS n
+FROM base
+GROUP BY 1, 2, 3, 4, 5, 6
+ORDER BY n DESC, platform ASC, model ASC
+LIMIT $` + fmt.Sprintf("%d", next)
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]*service.OpsUserVisibleFailureRoot, 0, limit)
+	for rows.Next() {
+		row := &service.OpsUserVisibleFailureRoot{}
+		var accountID sql.NullInt64
+		if err := rows.Scan(&row.Phase, &row.Owner, &row.Platform, &row.Model, &accountID, &row.Message, &row.Count); err != nil {
+			return nil, err
+		}
+		if accountID.Valid {
+			row.AccountID = accountID.Int64
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -236,6 +236,12 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 			continue
 		}
 		rulesEnabled++
+		if !s.shouldEvaluateAlertRuleOnNode(rule) {
+			if s.resolveActiveSkippedRule(ctx, rule, now) {
+				eventsResolved++
+			}
+			continue
+		}
 
 		scopePlatform, scopeGroupID, scopeRegion := parseOpsAlertRuleScope(rule.Filters)
 
@@ -292,10 +298,19 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 			}
 
 			dimensions := buildOpsAlertDimensions(scopePlatform, scopeGroupID)
-			// TK (us7 P0 2026-06-13): attach the top offending model/reason so the
-			// notification card is self-diagnosing (real fire vs client noise)
-			// without an SSH/dashboard drill. Best-effort — never blocks firing.
-			if cause, users, models := s.computeTopCause(ctx, rule, windowStart, windowEnd, scopePlatform, scopeGroupID); cause != "" || users != "" || models != "" {
+			// TK: attach a first-screen breakdown so the notification card is
+			// self-diagnosing without an SSH/dashboard drill. Best-effort — never
+			// blocks firing.
+			if extra := s.computeUserVisibleFailureDimensions(ctx, rule, windowStart, windowEnd, scopePlatform, scopeGroupID); len(extra) > 0 {
+				if dimensions == nil {
+					dimensions = map[string]any{}
+				}
+				for k, v := range extra {
+					if strings.TrimSpace(v) != "" {
+						dimensions[k] = v
+					}
+				}
+			} else if cause, users, models := s.computeTopCause(ctx, rule, windowStart, windowEnd, scopePlatform, scopeGroupID); cause != "" || users != "" || models != "" {
 				if dimensions == nil {
 					dimensions = map[string]any{}
 				}
@@ -361,6 +376,45 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 
 	result := truncateString(fmt.Sprintf("rules=%d enabled=%d evaluated=%d created=%d resolved=%d emails_sent=%d feishu_sent=%d", rulesTotal, rulesEnabled, rulesEvaluated, eventsCreated, eventsResolved, emailsSent, feishuSent), 2048)
 	s.recordHeartbeatSuccess(runAt, time.Since(startedAt), result)
+}
+
+func (s *OpsAlertEvaluatorService) shouldEvaluateAlertRuleOnNode(rule *OpsAlertRule) bool {
+	if s == nil || rule == nil {
+		return true
+	}
+	return !s.isEdgeNode() || !isProdOnlyAlertRule(rule)
+}
+
+func isProdOnlyAlertRule(rule *OpsAlertRule) bool {
+	if rule == nil {
+		return false
+	}
+	switch strings.TrimSpace(rule.MetricType) {
+	case OpsAlertMetricUserVisibleFailureCount:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *OpsAlertEvaluatorService) resolveActiveSkippedRule(ctx context.Context, rule *OpsAlertRule, now time.Time) bool {
+	if s == nil || s.opsRepo == nil || rule == nil || rule.ID <= 0 {
+		return false
+	}
+	activeEvent, err := s.opsRepo.GetActiveAlertEvent(ctx, rule.ID)
+	if err != nil {
+		logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] get skipped active event failed (rule=%d): %v", rule.ID, err)
+		return false
+	}
+	if activeEvent == nil {
+		return false
+	}
+	resolvedAt := now.UTC()
+	if err := s.opsRepo.UpdateAlertEventStatus(ctx, activeEvent.ID, OpsAlertStatusResolved, &resolvedAt); err != nil {
+		logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] resolve skipped active event failed (event=%d rule=%d): %v", activeEvent.ID, rule.ID, err)
+		return false
+	}
+	return true
 }
 
 func (s *OpsAlertEvaluatorService) pruneRuleStates(rules []*OpsAlertRule) {
@@ -664,7 +718,7 @@ func (s *OpsAlertEvaluatorService) computeRuleMetric(
 			return 0, false
 		}
 		return float64(n), true
-	case "routing_capacity_rejection_count":
+	case OpsAlertMetricRoutingCapacityRejectionCount:
 		// Count of routing/scheduling-phase capacity rejections over the rule
 		// window — the client-visible "no available accounts" empty-pool fast-fail
 		// (429, #575) plus relayed cc-<edge> downstream-capacity rejections,
@@ -684,6 +738,25 @@ func (s *OpsAlertEvaluatorService) computeRuleMetric(
 			Platform:  platform,
 			GroupID:   groupID,
 		})
+		if err != nil {
+			return 0, false
+		}
+		return float64(n), true
+	case OpsAlertMetricUserVisibleFailureCount, OpsAlertMetricClientVisibleFailureCount:
+		// Count of terminal, attributable user-visible failures over the rule
+		// window. This is the experience-first guardrail: P0 for provider/platform
+		// owned failures, P1 for client-owned input/usage failures that still need
+		// ops/customer follow-up. Like routing_capacity_rejection_count, this is a
+		// count metric, so the rate sample floor intentionally does not apply.
+		if s == nil || s.opsRepo == nil {
+			return 0, false
+		}
+		n, err := s.opsRepo.CountUserVisibleFailures(ctx, &OpsDashboardFilter{
+			StartTime: start,
+			EndTime:   end,
+			Platform:  platform,
+			GroupID:   groupID,
+		}, userVisibleFailureOwnerScopeForMetric(strings.TrimSpace(rule.MetricType)))
 		if err != nil {
 			return 0, false
 		}

--- a/backend/internal/service/ops_alert_evaluator_service_test.go
+++ b/backend/internal/service/ops_alert_evaluator_service_test.go
@@ -24,6 +24,12 @@ type stubOpsRepo struct {
 	routingByPlatformErr error
 	routingByModel       []*OpsRoutingRejectionModel
 	routingByModelErr    error
+
+	userVisibleFailures     int64
+	clientVisibleFailures   int64
+	userVisibleFailuresErr  error
+	userVisibleBreakdown    *OpsUserVisibleFailureBreakdown
+	userVisibleBreakdownErr error
 }
 
 func (s *stubOpsRepo) GetDashboardOverview(ctx context.Context, filter *OpsDashboardFilter) (*OpsDashboardOverview, error) {
@@ -55,6 +61,23 @@ func (s *stubOpsRepo) TopRoutingCapacityRejectionByModel(ctx context.Context, fi
 		return nil, s.routingByModelErr
 	}
 	return s.routingByModel, nil
+}
+
+func (s *stubOpsRepo) CountUserVisibleFailures(ctx context.Context, filter *OpsDashboardFilter, ownerScope string) (int64, error) {
+	if s.userVisibleFailuresErr != nil {
+		return 0, s.userVisibleFailuresErr
+	}
+	if ownerScope == "client" {
+		return s.clientVisibleFailures, nil
+	}
+	return s.userVisibleFailures, nil
+}
+
+func (s *stubOpsRepo) GetUserVisibleFailureBreakdown(ctx context.Context, filter *OpsDashboardFilter, ownerScope string, limit int) (*OpsUserVisibleFailureBreakdown, error) {
+	if s.userVisibleBreakdownErr != nil {
+		return nil, s.userVisibleBreakdownErr
+	}
+	return s.userVisibleBreakdown, nil
 }
 
 // GetTopErrorCause is overridden (the embedded OpsRepository is nil) so the
@@ -323,7 +346,7 @@ func TestComputeRuleMetricRateSampleFloor(t *testing.T) {
 
 			svc := &OpsAlertEvaluatorService{
 				opsRepo: &stubOpsRepo{overview: &OpsDashboardOverview{
-					RequestCountTotal:   tt.requestSLA,
+					RequestCountTotal: tt.requestSLA,
 					UpstreamErrorRate: 1.0, // 100% of the (few) requests failed upstream
 				}},
 			}
@@ -396,6 +419,46 @@ func TestComputeRuleMetricRoutingCapacityRejectionCount(t *testing.T) {
 		}
 		rule := &OpsAlertRule{MetricType: "routing_capacity_rejection_count"}
 		_, ok := svc.computeRuleMetric(ctx, rule, nil, start, end, "", nil, 100)
+		require.False(t, ok)
+	})
+}
+
+func TestComputeRuleMetricUserVisibleFailureCounts(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now().UTC().Add(-5 * time.Minute)
+	end := time.Now().UTC()
+	ctx := context.Background()
+
+	t.Run("provider/platform user-visible failures use the P0 count metric", func(t *testing.T) {
+		t.Parallel()
+		svc := &OpsAlertEvaluatorService{
+			opsRepo: &stubOpsRepo{userVisibleFailures: 148},
+		}
+		rule := &OpsAlertRule{MetricType: OpsAlertMetricUserVisibleFailureCount}
+		got, ok := svc.computeRuleMetric(ctx, rule, nil, start, end, "", nil, 1000)
+		require.True(t, ok)
+		require.InDelta(t, 148.0, got, 0.0001)
+	})
+
+	t.Run("client-owned visible failures use the P1 count metric", func(t *testing.T) {
+		t.Parallel()
+		svc := &OpsAlertEvaluatorService{
+			opsRepo: &stubOpsRepo{clientVisibleFailures: 51},
+		}
+		rule := &OpsAlertRule{MetricType: OpsAlertMetricClientVisibleFailureCount}
+		got, ok := svc.computeRuleMetric(ctx, rule, nil, start, end, "", nil, 1000)
+		require.True(t, ok)
+		require.InDelta(t, 51.0, got, 0.0001)
+	})
+
+	t.Run("query error => skipped", func(t *testing.T) {
+		t.Parallel()
+		svc := &OpsAlertEvaluatorService{
+			opsRepo: &stubOpsRepo{userVisibleFailuresErr: context.DeadlineExceeded},
+		}
+		rule := &OpsAlertRule{MetricType: OpsAlertMetricUserVisibleFailureCount}
+		_, ok := svc.computeRuleMetric(ctx, rule, nil, start, end, "", nil, 1000)
 		require.False(t, ok)
 	})
 }
@@ -483,6 +546,36 @@ func TestComputeTopCauseRoutingCapacityRejection(t *testing.T) {
 	})
 }
 
+func TestComputeUserVisibleFailureDimensions(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now().UTC().Add(-5 * time.Minute)
+	end := time.Now().UTC()
+	ctx := context.Background()
+	rule := &OpsAlertRule{MetricType: OpsAlertMetricUserVisibleFailureCount}
+	svc := &OpsAlertEvaluatorService{opsRepo: &stubOpsRepo{
+		userVisibleBreakdown: &OpsUserVisibleFailureBreakdown{
+			Failures:  148,
+			Successes: 17336,
+			Users: []*OpsUserVisibleFailureUser{{
+				UserID: 16, UserEmail: "compute@tk.com", APIKeyName: "训练组-何易纯", GroupName: "GPT专线", Count: 138,
+			}},
+			Surfaces: []*OpsUserVisibleFailureSurface{{
+				StatusCode: 429, UpstreamStatusCode: 429, ErrorType: "rate_limit_error", Count: 148,
+			}},
+			Roots: []*OpsUserVisibleFailureRoot{{
+				Phase: "upstream", Owner: "provider", Platform: "openai", Model: "gpt-5.5", AccountID: 76, Message: "Too many pending requests", Count: 148,
+			}},
+		},
+	}}
+
+	got := svc.computeUserVisibleFailureDimensions(ctx, rule, start, end, "", nil)
+	require.Equal(t, `#16 compute@tk.com ×138（key "训练组-何易纯" / group GPT专线）`, got["user_visible_affected"])
+	require.Equal(t, "失败 148 / 成功 17336 / 失败率 0.85% / 5m", got["user_visible_impact"])
+	require.Equal(t, "final 429 / upstream 429 / rate limit error ×148", got["user_visible_surface"])
+	require.Equal(t, "upstream/provider / openai / gpt-5.5 / account #76 / Too many pending requests ×148", got["user_visible_root"])
+}
+
 // TestIsEdgeNode pins the node-identity predicate that drives edge-only alert
 // suppression. It MUST match the card-title node label derived by
 // deriveOpsNodeIdentity from the same frontend URL, so a card that would read
@@ -515,18 +608,36 @@ func TestIsEdgeNode(t *testing.T) {
 }
 
 // TestIsEdgeSuppressedAlertRule pins WHICH rules are silenced on a mirror-relay
-// edge. Only the routing-capacity-rejection P0 qualifies: edge-local events still
-// persist for diagnostics, while human paging for client-visible pool exhaustion
-// is centralized on prod. Capacity/error signals that ARE meaningful on an edge
-// must still page.
+// edge. The retired routing-capacity rule stays defensively suppressed, and the
+// prod-only user-visible P0 is suppressed as a notification backstop. Capacity/
+// error signals that ARE meaningful on an edge must still page.
 func TestIsEdgeSuppressedAlertRule(t *testing.T) {
 	t.Parallel()
 	require.True(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "routing_capacity_rejection_count"}))
 	require.True(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "  routing_capacity_rejection_count  "}))
+	require.True(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: OpsAlertMetricUserVisibleFailureCount}))
+	require.False(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: OpsAlertMetricClientVisibleFailureCount}))
 	require.False(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "pool_load_rate"}))
 	require.False(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "upstream_error_rate"}))
 	require.False(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "group_available_accounts"}))
 	require.False(t, isEdgeSuppressedAlertRule(nil))
+}
+
+func TestShouldEvaluateAlertRuleOnNode(t *testing.T) {
+	t.Parallel()
+
+	userVisibleRule := &OpsAlertRule{MetricType: OpsAlertMetricUserVisibleFailureCount}
+	clientVisibleRule := &OpsAlertRule{MetricType: OpsAlertMetricClientVisibleFailureCount}
+	routingRule := &OpsAlertRule{MetricType: OpsAlertMetricRoutingCapacityRejectionCount}
+
+	edge := &OpsAlertEvaluatorService{cfg: &config.Config{Server: config.ServerConfig{FrontendURL: "https://api-us6.tokenkey.dev"}}}
+	require.False(t, edge.shouldEvaluateAlertRuleOnNode(userVisibleRule), "user-visible P0 is prod-only")
+	require.True(t, edge.shouldEvaluateAlertRuleOnNode(clientVisibleRule), "client-owned P1 remains edge-evaluable")
+	require.True(t, edge.shouldEvaluateAlertRuleOnNode(routingRule), "retired routing rule is not changed at evaluator level")
+
+	prod := &OpsAlertEvaluatorService{cfg: &config.Config{Server: config.ServerConfig{FrontendURL: "https://api.tokenkey.dev"}}}
+	require.True(t, prod.shouldEvaluateAlertRuleOnNode(userVisibleRule))
+	require.True(t, prod.shouldEvaluateAlertRuleOnNode(clientVisibleRule))
 }
 
 // TestMaybeSendAlertNotificationsEdgeSuppression verifies the composed gate: on an

--- a/backend/internal/service/ops_alert_models.go
+++ b/backend/internal/service/ops_alert_models.go
@@ -13,6 +13,12 @@ const (
 	OpsAlertStatusManualResolved = "manual_resolved"
 )
 
+const (
+	OpsAlertMetricUserVisibleFailureCount       = "user_visible_failure_count"
+	OpsAlertMetricClientVisibleFailureCount     = "client_visible_failure_count"
+	OpsAlertMetricRoutingCapacityRejectionCount = "routing_capacity_rejection_count"
+)
+
 type OpsAlertRule struct {
 	ID          int64  `json:"id"`
 	Name        string `json:"name"`

--- a/backend/internal/service/ops_alert_notifications_tk_feishu.go
+++ b/backend/internal/service/ops_alert_notifications_tk_feishu.go
@@ -61,13 +61,20 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertNotifications(ctx context.Conte
 	return result
 }
 
-// isEdgeSuppressedAlertRule reports whether a rule's P0 notifications are pure
-// noise on a prod→edge mirror-relay edge and should be silenced there. Today only
-// routing_capacity_rejection_count qualifies (see maybeSendAlertNotifications);
-// kept as a named predicate so the policy is one obvious list, not an inline
-// string compare.
+// isEdgeSuppressedAlertRule reports whether a rule's notifications are pure noise
+// on a prod→edge mirror-relay edge and should be silenced there. Most prod-only
+// rules are skipped earlier by the evaluator; this predicate is the defensive
+// notification-layer gate for any event created by an older binary or manual path.
 func isEdgeSuppressedAlertRule(rule *OpsAlertRule) bool {
-	return rule != nil && strings.TrimSpace(rule.MetricType) == "routing_capacity_rejection_count"
+	if rule == nil {
+		return false
+	}
+	switch strings.TrimSpace(rule.MetricType) {
+	case OpsAlertMetricRoutingCapacityRejectionCount, OpsAlertMetricUserVisibleFailureCount:
+		return true
+	default:
+		return false
+	}
 }
 
 // isEdgeNode reports whether this node is a prod→edge mirror-relay edge
@@ -182,8 +189,7 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertFeishuRecovery(ctx context.Cont
 func shouldSendOpsAlertToFeishu(rule *OpsAlertRule, event *OpsAlertEvent) bool {
 	return rule != nil && event != nil &&
 		strings.EqualFold(strings.TrimSpace(event.Status), OpsAlertStatusFiring) &&
-		strings.EqualFold(strings.TrimSpace(rule.Severity), "P0") &&
-		strings.EqualFold(strings.TrimSpace(event.Severity), "P0") &&
+		opsAlertFeishuSeverityAllowed(rule, event) &&
 		rule.NotifyEmail
 }
 
@@ -195,9 +201,22 @@ func shouldSendOpsAlertFeishuRecovery(rule *OpsAlertRule, event *OpsAlertEvent) 
 	if !strings.EqualFold(status, OpsAlertStatusResolved) && !strings.EqualFold(status, OpsAlertStatusManualResolved) {
 		return false
 	}
-	return strings.EqualFold(strings.TrimSpace(rule.Severity), "P0") &&
-		strings.EqualFold(strings.TrimSpace(event.Severity), "P0") &&
+	return opsAlertFeishuSeverityAllowed(rule, event) &&
 		rule.NotifyEmail
+}
+
+func opsAlertFeishuSeverityAllowed(rule *OpsAlertRule, event *OpsAlertEvent) bool {
+	if rule == nil || event == nil {
+		return false
+	}
+	ruleSeverity := strings.ToUpper(strings.TrimSpace(rule.Severity))
+	eventSeverity := strings.ToUpper(strings.TrimSpace(event.Severity))
+	if ruleSeverity == "P0" && eventSeverity == "P0" {
+		return true
+	}
+	return ruleSeverity == "P1" &&
+		eventSeverity == "P1" &&
+		strings.TrimSpace(rule.MetricType) == OpsAlertMetricClientVisibleFailureCount
 }
 
 func (s *opsFeishuNotificationState) shouldSend(rule *OpsAlertRule, event *OpsAlertEvent, cfg OpsFeishuAlertConfig) bool {

--- a/backend/internal/service/ops_alert_top_cause_tk.go
+++ b/backend/internal/service/ops_alert_top_cause_tk.go
@@ -58,6 +58,42 @@ type OpsRoutingRejectionModel struct {
 	Count int64
 }
 
+// OpsUserVisibleFailureBreakdown is the first-screen payload for the "real user
+// experience degraded" Feishu rules. It keeps the four operator questions
+// separate so the card stays scannable: who, impact, user-visible surface, root.
+type OpsUserVisibleFailureBreakdown struct {
+	Failures  int64
+	Successes int64
+	Users     []*OpsUserVisibleFailureUser
+	Surfaces  []*OpsUserVisibleFailureSurface
+	Roots     []*OpsUserVisibleFailureRoot
+}
+
+type OpsUserVisibleFailureUser struct {
+	UserID     int64
+	UserEmail  string
+	APIKeyName string
+	GroupName  string
+	Count      int64
+}
+
+type OpsUserVisibleFailureSurface struct {
+	StatusCode         int
+	UpstreamStatusCode int
+	ErrorType          string
+	Count              int64
+}
+
+type OpsUserVisibleFailureRoot struct {
+	Phase     string
+	Owner     string
+	Platform  string
+	Model     string
+	AccountID int64
+	Message   string
+	Count     int64
+}
+
 // opsTopCauseMetricTypes are the rule metric types for which a top-cause
 // breakdown is meaningful (rate metrics over ops_error_logs). Other rule types
 // (system gauges, group-availability counts) get no breakdown — keeping the
@@ -116,7 +152,7 @@ func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *Op
 	// standalone 用户 line is retired); the notifier keeps its reader for
 	// already-stored historical events. Best-effort: a failure must not block the
 	// alert.
-	if metricType == "routing_capacity_rejection_count" {
+	if metricType == OpsAlertMetricRoutingCapacityRejectionCount {
 		filter := &OpsDashboardFilter{
 			StartTime: start,
 			EndTime:   end,
@@ -146,6 +182,49 @@ func (s *OpsAlertEvaluatorService) computeTopCause(ctx context.Context, rule *Op
 		return "", "", ""
 	}
 	return formatOpsTopCause(causes), "", ""
+}
+
+func userVisibleFailureOwnerScopeForMetric(metricType string) string {
+	switch strings.TrimSpace(metricType) {
+	case OpsAlertMetricClientVisibleFailureCount:
+		return "client"
+	default:
+		return "system"
+	}
+}
+
+func (s *OpsAlertEvaluatorService) computeUserVisibleFailureDimensions(ctx context.Context, rule *OpsAlertRule, start, end time.Time, platform string, groupID *int64) map[string]string {
+	if s == nil || s.opsRepo == nil || rule == nil {
+		return nil
+	}
+	metricType := strings.TrimSpace(rule.MetricType)
+	if metricType != OpsAlertMetricUserVisibleFailureCount && metricType != OpsAlertMetricClientVisibleFailureCount {
+		return nil
+	}
+	breakdown, err := s.opsRepo.GetUserVisibleFailureBreakdown(ctx, &OpsDashboardFilter{
+		StartTime: start,
+		EndTime:   end,
+		Platform:  platform,
+		GroupID:   groupID,
+		QueryMode: OpsQueryModeRaw,
+	}, userVisibleFailureOwnerScopeForMetric(metricType), 3)
+	if err != nil || breakdown == nil {
+		return nil
+	}
+	out := map[string]string{}
+	if affected := formatUserVisibleFailureAffected(breakdown.Users); affected != "" {
+		out["user_visible_affected"] = affected
+	}
+	if impact := formatUserVisibleFailureImpact(breakdown, start, end); impact != "" {
+		out["user_visible_impact"] = impact
+	}
+	if surface := formatUserVisibleFailureSurface(breakdown.Surfaces); surface != "" {
+		out["user_visible_surface"] = surface
+	}
+	if root := formatUserVisibleFailureRoot(breakdown.Roots); root != "" {
+		out["user_visible_root"] = root
+	}
+	return out
 }
 
 // formatOpsTopCause renders up to two causes as a compact one-line string, e.g.
@@ -254,6 +333,110 @@ func formatRoutingRejectionByModel(models []*OpsRoutingRejectionModel) string {
 		}
 		name := sanitizeFeishuModelLabel(m.Model)
 		parts = append(parts, fmt.Sprintf("%s ×%d", name, m.Count))
+		if len(parts) >= 3 {
+			break
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+func formatUserVisibleFailureAffected(users []*OpsUserVisibleFailureUser) string {
+	parts := make([]string, 0, 3)
+	for _, u := range users {
+		if u == nil || u.Count <= 0 {
+			continue
+		}
+		user := fmt.Sprintf("#%d", u.UserID)
+		if email := sanitizeFeishuLabel(u.UserEmail); email != "" {
+			user += " " + email
+		}
+		seg := fmt.Sprintf("%s ×%d", user, u.Count)
+		details := make([]string, 0, 2)
+		if key := sanitizeFeishuLabel(u.APIKeyName); key != "" {
+			details = append(details, `key "`+key+`"`)
+		}
+		if group := sanitizeFeishuLabel(u.GroupName); group != "" {
+			details = append(details, "group "+group)
+		}
+		if len(details) > 0 {
+			seg += "（" + strings.Join(details, " / ") + "）"
+		}
+		parts = append(parts, seg)
+		if len(parts) >= 3 {
+			break
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+func formatUserVisibleFailureImpact(b *OpsUserVisibleFailureBreakdown, start, end time.Time) string {
+	if b == nil {
+		return ""
+	}
+	windowMinutes := int(end.Sub(start).Round(time.Minute).Minutes())
+	if windowMinutes <= 0 {
+		windowMinutes = 1
+	}
+	total := b.Successes + b.Failures
+	rate := 0.0
+	if total > 0 {
+		rate = float64(b.Failures) * 100 / float64(total)
+	}
+	return fmt.Sprintf("失败 %d / 成功 %d / 失败率 %.2f%% / %dm", b.Failures, b.Successes, rate, windowMinutes)
+}
+
+func formatUserVisibleFailureSurface(surfaces []*OpsUserVisibleFailureSurface) string {
+	parts := make([]string, 0, 3)
+	for _, s := range surfaces {
+		if s == nil || s.Count <= 0 {
+			continue
+		}
+		status := fmt.Sprintf("final %d", s.StatusCode)
+		if s.UpstreamStatusCode > 0 {
+			status += fmt.Sprintf(" / upstream %d", s.UpstreamStatusCode)
+		}
+		typ := sanitizeFeishuLabel(s.ErrorType)
+		if typ != "" {
+			status += " / " + typ
+		}
+		parts = append(parts, fmt.Sprintf("%s ×%d", status, s.Count))
+		if len(parts) >= 3 {
+			break
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+func formatUserVisibleFailureRoot(roots []*OpsUserVisibleFailureRoot) string {
+	parts := make([]string, 0, 3)
+	for _, r := range roots {
+		if r == nil || r.Count <= 0 {
+			continue
+		}
+		phase := sanitizeFeishuLabel(r.Phase)
+		owner := sanitizeFeishuLabel(r.Owner)
+		platform := sanitizeFeishuLabel(r.Platform)
+		model := sanitizeFeishuModelLabel(r.Model)
+		if phase == "" {
+			phase = "unknown"
+		}
+		if owner == "" {
+			owner = "unknown"
+		}
+		seg := fmt.Sprintf("%s/%s", phase, owner)
+		if platform != "" {
+			seg += " / " + platform
+		}
+		if model != "" && model != "(unknown)" {
+			seg += " / " + model
+		}
+		if r.AccountID > 0 {
+			seg += fmt.Sprintf(" / account #%d", r.AccountID)
+		}
+		if msg := sanitizeFeishuLabel(r.Message); msg != "" {
+			seg += " / " + msg
+		}
+		parts = append(parts, fmt.Sprintf("%s ×%d", seg, r.Count))
 		if len(parts) >= 3 {
 			break
 		}

--- a/backend/internal/service/ops_feishu_alerts_tk_test.go
+++ b/backend/internal/service/ops_feishu_alerts_tk_test.go
@@ -219,7 +219,7 @@ func TestOpsFeishuNotifierSanitizesWebhookErrors(t *testing.T) {
 	require.Equal(t, "Post \"https://open.feishu.cn/<redacted>\": dial tcp failed", rootErr)
 }
 
-func TestMaybeSendAlertFeishuP0Only(t *testing.T) {
+func TestMaybeSendAlertFeishuP0AndClientVisibleP1Only(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -227,7 +227,7 @@ func TestMaybeSendAlertFeishuP0Only(t *testing.T) {
 		mutate func(rule *OpsAlertRule, event *OpsAlertEvent)
 	}{
 		{
-			name: "P1 rule never sends",
+			name: "ordinary P1 rule never sends",
 			mutate: func(rule *OpsAlertRule, event *OpsAlertEvent) {
 				rule.Severity = "P1"
 				event.Severity = "P1"
@@ -263,6 +263,36 @@ func TestMaybeSendAlertFeishuP0Only(t *testing.T) {
 			require.Equal(t, 0, doer.calls)
 		})
 	}
+}
+
+func TestMaybeSendAlertFeishuAllowsClientVisibleP1(t *testing.T) {
+	t.Parallel()
+
+	doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+	svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 3, CooldownSeconds: 3600}, doer)
+	rule := testOpsFeishuRule()
+	rule.Name = "真实用户客户端失败增多"
+	rule.Severity = "P1"
+	rule.MetricType = OpsAlertMetricClientVisibleFailureCount
+	rule.Operator = ">="
+	rule.Threshold = 20
+	event := testOpsFeishuEvent(1)
+	event.Severity = "P1"
+	event.Dimensions = map[string]any{
+		"user_visible_affected": "#16 compute@tk.com ×21",
+		"user_visible_impact":   "失败 21 / 成功 17336 / 失败率 0.12% / 5m",
+		"user_visible_surface":  "final 400 / invalid_request_error ×21",
+		"user_visible_root":     "request/client / openai / gpt-5.5 / prompt too long ×21",
+	}
+
+	require.True(t, svc.maybeSendAlertFeishu(context.Background(), nil, rule, event))
+	require.Equal(t, 1, doer.calls)
+	require.Contains(t, doer.bodies[0], "TokenKey P1 告警")
+	require.Contains(t, doer.bodies[0], "orange")
+	require.Contains(t, doer.bodies[0], "**谁受影响**")
+	require.Contains(t, doer.bodies[0], "**影响多大**")
+	require.Contains(t, doer.bodies[0], "**用户看到什么**")
+	require.Contains(t, doer.bodies[0], "**根因在哪**")
 }
 
 func TestMaybeSendAlertFeishuSendsAndDedupesByCooldown(t *testing.T) {
@@ -303,7 +333,7 @@ func TestOpsFeishuNotifierBuildsRecoveryPayload(t *testing.T) {
 	event.FiredAt = firedAt
 	current := 0.0
 	event.Dimensions = map[string]any{
-		"top_cause":       `newapi ×128（#16 "Agent-陈乐晗-qwen" ×128）`,
+		"top_cause":        `newapi ×128（#16 "Agent-陈乐晗-qwen" ×128）`,
 		"top_cause_models": "gpt5.4-mini ×128",
 	}
 
@@ -348,6 +378,42 @@ func TestMaybeSendAlertFeishuRecoverySendsPairedGreenCard(t *testing.T) {
 
 	require.False(t, svc.maybeSendAlertFeishuRecovery(context.Background(), nil, rule, &resolved, 0))
 	require.Equal(t, 2, doer.calls, "recovery must dedupe per event")
+}
+
+func TestMaybeSendAlertFeishuRecoverySendsClientVisibleP1GreenCard(t *testing.T) {
+	t.Parallel()
+
+	doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+	svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 3, CooldownSeconds: 3600}, doer)
+	rule := testOpsFeishuRule()
+	rule.Name = "真实用户客户端失败增多"
+	rule.Severity = "P1"
+	rule.MetricType = OpsAlertMetricClientVisibleFailureCount
+	rule.Operator = ">="
+	rule.Threshold = 20
+	firing := testOpsFeishuEvent(100)
+	firing.Severity = "P1"
+	firing.Dimensions = map[string]any{
+		"user_visible_affected": "#16 compute@tk.com ×21",
+		"user_visible_impact":   "失败 21 / 成功 17336 / 失败率 0.12% / 5m",
+		"user_visible_surface":  "final 400 / invalid_request_error ×21",
+		"user_visible_root":     "request/client / openai / gpt-5.5 / prompt too long ×21",
+	}
+
+	require.True(t, svc.maybeSendAlertFeishu(context.Background(), nil, rule, firing))
+	require.Equal(t, 1, doer.calls)
+	require.Contains(t, doer.bodies[0], "TokenKey P1 告警")
+
+	resolvedAt := firing.FiredAt.Add(time.Minute)
+	resolved := *firing
+	resolved.Status = OpsAlertStatusResolved
+	resolved.ResolvedAt = &resolvedAt
+
+	require.True(t, svc.maybeSendAlertFeishuRecovery(context.Background(), nil, rule, &resolved, 0))
+	require.Equal(t, 2, doer.calls)
+	require.Contains(t, doer.bodies[1], "TokenKey P1 告警已恢复")
+	require.Contains(t, doer.bodies[1], "green")
+	require.Contains(t, doer.bodies[1], "**谁受影响**")
 }
 
 func TestMaybeSendAlertFeishuRecoverySkipsWithoutPriorFiringCard(t *testing.T) {

--- a/backend/internal/service/ops_feishu_notifier_tk.go
+++ b/backend/internal/service/ops_feishu_notifier_tk.go
@@ -184,11 +184,11 @@ func (n *opsFeishuNotifier) buildPayload(cfg OpsFeishuAlertConfig, frontendURL s
 	if n != nil && n.now != nil {
 		now = n.currentTime
 	}
-	title := "TokenKey P0 告警"
+	title := "TokenKey " + opsFeishuSeverityTitle(event.Severity, rule.Severity) + " 告警"
 	if nodeLabel != "" && nodeLabel != "overall" {
 		title = title + " · " + nodeLabel
 	}
-	return feishuCardPayload(cfg, now, "red", title, text), nil
+	return feishuCardPayload(cfg, now, opsFeishuHeaderTemplate(event.Severity, rule.Severity), title, text), nil
 }
 
 func (n *opsFeishuNotifier) buildRecoveryPayload(cfg OpsFeishuAlertConfig, frontendURL string, rule *OpsAlertRule, event *OpsAlertEvent, currentMetricValue *float64) (map[string]any, error) {
@@ -201,7 +201,7 @@ func (n *opsFeishuNotifier) buildRecoveryPayload(cfg OpsFeishuAlertConfig, front
 	if n != nil && n.now != nil {
 		now = n.currentTime
 	}
-	title := "TokenKey P0 告警已恢复"
+	title := "TokenKey " + opsFeishuSeverityTitle(event.Severity, rule.Severity) + " 告警已恢复"
 	if nodeLabel != "" && nodeLabel != "overall" {
 		title = title + " · " + nodeLabel
 	}
@@ -244,15 +244,12 @@ func buildOpsFeishuAlertText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLabel
 	// dashboardURL is our own constructed URL (base + opsDashboardPath); render
 	// it as a lark_md link. When the node has no frontend_url configured we fall
 	// back to plain prose so the card still reads cleanly.
-	advice := fmt.Sprintf("打开 Ops Dashboard 检查账号可用性 / 网关健康，并处理该 %s rule 指向的容量问题。", sev)
-	if strings.TrimSpace(dashboardURL) != "" {
-		advice = fmt.Sprintf("[打开 Ops Dashboard](%s) 检查账号可用性 / 网关健康，并处理该 %s rule 指向的容量问题。", dashboardURL, sev)
-	}
+	advice := buildOpsFeishuAdvice(rule.MetricType, sev, dashboardURL)
 	// TK (us7 P0 2026-06-13): the top offending model/reason, when the evaluator
 	// attached it (error-rate rules). Rendered as its own line right under 范围 so
 	// an operator can tell a real fire from client noise (e.g. a hammered
 	// access-gated model) without drilling the dashboard.
-	topCauseLine := buildOpsFeishuTopCauseLines(event.Dimensions)
+	topCauseLine := buildOpsFeishuBreakdownLines(rule.MetricType, event.Dimensions)
 	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**当前值**：%s\n**范围**：%s%s\n**时间**：%s\n\n**建议**：%s",
 		escapeFeishuText(nodeLabel),
 		escapeFeishuText(strings.TrimSpace(rule.Name)),
@@ -265,6 +262,25 @@ func buildOpsFeishuAlertText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLabel
 		escapeFeishuText(formatAlertTime(event.FiredAt)),
 		advice,
 	)
+}
+
+func buildOpsFeishuAdvice(metricType, severity, dashboardURL string) string {
+	sev := strings.TrimSpace(severity)
+	if sev == "" {
+		sev = "告警"
+	}
+	linkPrefix := "打开 Ops Dashboard"
+	if strings.TrimSpace(dashboardURL) != "" {
+		linkPrefix = fmt.Sprintf("[打开 Ops Dashboard](%s)", dashboardURL)
+	}
+	switch strings.TrimSpace(metricType) {
+	case OpsAlertMetricUserVisibleFailureCount:
+		return fmt.Sprintf("%s 按 user/key/model/root 定位真实用户终态失败，优先止损并确认上游/平台根因。", linkPrefix)
+	case OpsAlertMetricClientVisibleFailureCount:
+		return fmt.Sprintf("%s 按 user/key/root 定位客户侧参数、内容、权限、限额或用法问题，并同步运营跟进客户。", linkPrefix)
+	default:
+		return fmt.Sprintf("%s 检查账号可用性 / 网关健康，并处理该 %s rule 指向的容量问题。", linkPrefix, sev)
+	}
 }
 
 func buildOpsFeishuRecoveryText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLabel, dashboardURL string, currentMetricValue *float64) string {
@@ -307,7 +323,7 @@ func buildOpsFeishuRecoveryText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLa
 	if strings.TrimSpace(dashboardURL) != "" {
 		note = fmt.Sprintf("[打开 Ops Dashboard](%s) 复核指标与账号可用性。指标已回落到阈值以下，告警自动解除。", dashboardURL)
 	}
-	topCauseLine := buildOpsFeishuTopCauseLines(event.Dimensions)
+	topCauseLine := buildOpsFeishuBreakdownLines(rule.MetricType, event.Dimensions)
 	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**触发值**：%s\n**当前值**：%s\n**范围**：%s%s\n**持续时长**：%s\n**触发时间**：%s\n**恢复时间**：%s\n\n**说明**：%s",
 		escapeFeishuText(nodeLabel),
 		escapeFeishuText(strings.TrimSpace(rule.Name)),
@@ -325,6 +341,33 @@ func buildOpsFeishuRecoveryText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLa
 	)
 }
 
+func opsFeishuSeverityTitle(values ...string) string {
+	for _, v := range values {
+		sev := strings.ToUpper(strings.TrimSpace(v))
+		if sev != "" {
+			return sev
+		}
+	}
+	return "告警"
+}
+
+func opsFeishuHeaderTemplate(values ...string) string {
+	for _, v := range values {
+		if strings.EqualFold(strings.TrimSpace(v), "P1") {
+			return "orange"
+		}
+	}
+	return "red"
+}
+
+func buildOpsFeishuBreakdownLines(metricType string, dimensions map[string]any) string {
+	if strings.TrimSpace(metricType) == OpsAlertMetricUserVisibleFailureCount ||
+		strings.TrimSpace(metricType) == OpsAlertMetricClientVisibleFailureCount {
+		return buildOpsFeishuUserVisibleFailureLines(dimensions)
+	}
+	return buildOpsFeishuTopCauseLines(dimensions)
+}
+
 // buildOpsFeishuTopCauseLines renders 主因/用户/模型 breakdown lines shared by
 // firing and recovery cards from evaluator-stashed event dimensions.
 func buildOpsFeishuTopCauseLines(dimensions map[string]any) string {
@@ -339,6 +382,35 @@ func buildOpsFeishuTopCauseLines(dimensions map[string]any) string {
 		lines += fmt.Sprintf("\n**模型**：%s", escapeFeishuText(models))
 	}
 	return lines
+}
+
+func buildOpsFeishuUserVisibleFailureLines(dimensions map[string]any) string {
+	lines := ""
+	if affected := opsFeishuDimensionString(dimensions, "user_visible_affected"); affected != "" {
+		lines += fmt.Sprintf("\n**谁受影响**：%s", escapeFeishuText(affected))
+	}
+	if impact := opsFeishuDimensionString(dimensions, "user_visible_impact"); impact != "" {
+		lines += fmt.Sprintf("\n**影响多大**：%s", escapeFeishuText(impact))
+	}
+	if surface := opsFeishuDimensionString(dimensions, "user_visible_surface"); surface != "" {
+		lines += fmt.Sprintf("\n**用户看到什么**：%s", escapeFeishuText(surface))
+	}
+	if root := opsFeishuDimensionString(dimensions, "user_visible_root"); root != "" {
+		lines += fmt.Sprintf("\n**根因在哪**：%s", escapeFeishuText(root))
+	}
+	return lines
+}
+
+func opsFeishuDimensionString(dimensions map[string]any, key string) string {
+	if len(dimensions) == 0 {
+		return ""
+	}
+	if v, ok := dimensions[key]; ok {
+		if s, ok := v.(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
 }
 
 // opsFeishuTopCause extracts the pre-formatted "主因" string the alert evaluator

--- a/backend/internal/service/ops_port.go
+++ b/backend/internal/service/ops_port.go
@@ -44,6 +44,13 @@ type OpsRepository interface {
 	// over the same routing-capacity rejection window/scope. It powers the
 	// no-available-accounts P0 card's "模型" line.
 	TopRoutingCapacityRejectionByModel(ctx context.Context, filter *OpsDashboardFilter, limit int) ([]*OpsRoutingRejectionModel, error)
+	// CountUserVisibleFailures counts terminal user-visible failures over the
+	// alert window. ownerScope is "system" (provider/platform, P0) or "client"
+	// (client-owned usage/input failures, P1).
+	CountUserVisibleFailures(ctx context.Context, filter *OpsDashboardFilter, ownerScope string) (int64, error)
+	// GetUserVisibleFailureBreakdown returns the first-screen Feishu breakdown
+	// for the same user-visible failure window/scope.
+	GetUserVisibleFailureBreakdown(ctx context.Context, filter *OpsDashboardFilter, ownerScope string, limit int) (*OpsUserVisibleFailureBreakdown, error)
 	GetThroughputTrend(ctx context.Context, filter *OpsDashboardFilter, bucketSeconds int) (*OpsThroughputTrendResponse, error)
 	GetLatencyHistogram(ctx context.Context, filter *OpsDashboardFilter) (*OpsLatencyHistogramResponse, error)
 	GetErrorTrend(ctx context.Context, filter *OpsDashboardFilter, bucketSeconds int) (*OpsErrorTrendResponse, error)

--- a/backend/internal/service/ops_repo_mock_test.go
+++ b/backend/internal/service/ops_repo_mock_test.go
@@ -98,6 +98,14 @@ func (m *opsRepoMock) TopRoutingCapacityRejectionByModel(ctx context.Context, fi
 	return nil, nil
 }
 
+func (m *opsRepoMock) CountUserVisibleFailures(ctx context.Context, filter *OpsDashboardFilter, ownerScope string) (int64, error) {
+	return 0, nil
+}
+
+func (m *opsRepoMock) GetUserVisibleFailureBreakdown(ctx context.Context, filter *OpsDashboardFilter, ownerScope string, limit int) (*OpsUserVisibleFailureBreakdown, error) {
+	return nil, nil
+}
+
 func (m *opsRepoMock) GetThroughputTrend(ctx context.Context, filter *OpsDashboardFilter, bucketSeconds int) (*OpsThroughputTrendResponse, error) {
 	return &OpsThroughputTrendResponse{}, nil
 }

--- a/backend/migrations/tk_060_seed_user_visible_failure_alerts.sql
+++ b/backend/migrations/tk_060_seed_user_visible_failure_alerts.sql
@@ -1,0 +1,45 @@
+-- tk_060_seed_user_visible_failure_alerts.sql
+--
+-- Experience-first Feishu coverage: root-cause alerts such as
+-- routing_capacity_rejection_count and upstream_error_rate are intentionally
+-- narrow. They explain why a class of failures happened, but they cannot be the
+-- single guardrail for "real users are seeing terminal failures". These two
+-- rules make that user-experience signal explicit:
+--
+--   * P0 user_visible_failure_count: provider/platform-owned terminal failures.
+--     This rule is evaluated on prod only; edge nodes skip it at runtime because
+--     prod is the user-facing aggregation point and can fail over between edges.
+--     This catches final upstream 429/5xx, platform 499/5xx, routing capacity
+--     failures, and any other non-client terminal failures attributable to real
+--     users, including cases deliberately excluded from upstream_error_rate.
+--
+--   * P1 client_visible_failure_count: client-owned terminal failures. These are
+--     still real customer experience failures, but the action is operational
+--     follow-up/customer communication rather than platform incident repair.
+--
+-- Both metrics count only attributable real-user rows (user_id or deleted-key
+-- owner present), status_code >= 400, and is_count_tokens=false. Recovered-200
+-- rows never count.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+INSERT INTO ops_alert_rules (
+    name, description, enabled, metric_type, operator, threshold,
+    window_minutes, sustained_minutes, severity, notify_email, cooldown_minutes,
+    created_at, updated_at
+) VALUES (
+    '真实用户体验受损',
+    'prod 节点 5 分钟内真实用户可感知的 provider/platform 终态失败累计 ≥ 20 时触发。统计 status_code>=400、error_owner IN (provider,platform)、is_count_tokens=false 且可归属真实用户的请求；不包含 recovered-200。edge 节点运行时跳过该规则，避免和 prod 聚合线重复。该规则是用户体验兜底，根因由飞书卡片 breakdown 展示。',
+    true, 'user_visible_failure_count', '>=', 20.0, 5, 1, 'P0', true, 10, NOW(), NOW()
+) ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO ops_alert_rules (
+    name, description, enabled, metric_type, operator, threshold,
+    window_minutes, sustained_minutes, severity, notify_email, cooldown_minutes,
+    created_at, updated_at
+) VALUES (
+    '真实用户客户端失败增多',
+    '5 分钟内真实用户可感知的 client-owned 终态失败累计 ≥ 20 时触发。统计 status_code>=400、error_owner=client、is_count_tokens=false 且可归属真实用户的请求；用于运营同步客户参数、内容、权限、限额或用法问题。',
+    true, 'client_visible_failure_count', '>=', 20.0, 5, 1, 'P1', true, 10, NOW(), NOW()
+) ON CONFLICT (name) DO NOTHING;

--- a/backend/migrations/tk_061_remove_routing_capacity_rejection_alert.sql
+++ b/backend/migrations/tk_061_remove_routing_capacity_rejection_alert.sql
@@ -1,0 +1,48 @@
+-- tk_061_remove_routing_capacity_rejection_alert.sql
+--
+-- Retire the old "无可用账号拒绝激增" routing_capacity_rejection_count P0.
+--
+-- The new user_visible_failure_count P0 seeded in tk_060 is the single
+-- experience-first guardrail for real users seeing terminal provider/platform
+-- failures. Keeping the narrower routing-capacity rule active would double-page
+-- the same empty-pool/no-available-account incident: once as the user-visible
+-- failure, and again as one root-cause-specific signal.
+--
+-- Remove the default rule instead of leaving a second Feishu entry point. Any
+-- still-firing event is resolved first because the evaluator will no longer see
+-- the rule after deletion. Silences are also cleaned so no orphaned UI state
+-- remains. Historical ops_alert_events are intentionally preserved; rule_id has
+-- no foreign key and event title/description keep the incident context.
+--
+-- Idempotent: once the rule is gone each statement matches 0 rows.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+UPDATE ops_alert_events
+   SET status = 'resolved',
+       resolved_at = NOW()
+ WHERE status = 'firing'
+   AND rule_id IN (
+       SELECT id
+         FROM ops_alert_rules
+        WHERE name = '无可用账号拒绝激增'
+          AND metric_type = 'routing_capacity_rejection_count'
+   );
+
+DO $$
+BEGIN
+    IF to_regclass('public.ops_alert_silences') IS NOT NULL THEN
+        DELETE FROM ops_alert_silences
+         WHERE rule_id IN (
+               SELECT id
+                 FROM ops_alert_rules
+                WHERE name = '无可用账号拒绝激增'
+                  AND metric_type = 'routing_capacity_rejection_count'
+           );
+    END IF;
+END $$;
+
+DELETE FROM ops_alert_rules
+ WHERE name = '无可用账号拒绝激增'
+   AND metric_type = 'routing_capacity_rejection_count';

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -159,7 +159,9 @@
       "must_contain": [
         "maybeSendAlertFeishuRecovery",
         "markFiringDelivered",
-        "strings.EqualFold(strings.TrimSpace(rule.Severity), \"P0\")",
+        "opsAlertFeishuSeverityAllowed",
+        "ruleSeverity == \"P0\" && eventSeverity == \"P0\"",
+        "OpsAlertMetricClientVisibleFailureCount",
         "rule.NotifyEmail",
         "opsFeishuDedupeKey",
         "opsFeishuRecoveryDedupeKey",
@@ -167,7 +169,7 @@
         "s.limiter.SetLimit(cfg.RateLimitPerHour)",
         "s.cfg.Server.FrontendURL"
       ],
-      "rationale": "TK companion that keeps Feishu alerting P0-only, tied to the existing external-notification opt-in, and protected by per-rule/dimension cooldown plus global hourly rate limiting. Paired green recovery cards must fire only after a delivered firing card (firedFeishuEventIDs) and use a separate recovery dedupe key so resolve notifications are not blocked by the firing cooldown. Dropping any anchor turns a low-noise OPC pager into either silence or chat noise. FrontendURL threads the per-node public base URL into the card so prod vs each edge is distinguishable; losing it silently regresses every card back to an unattributable 'overall'."
+      "rationale": "TK companion that keeps Feishu alerting limited to P0 plus the explicit P1 client_visible_failure_count real-user failure exception, tied to the existing external-notification opt-in, and protected by per-rule/dimension cooldown plus global hourly rate limiting. Paired green recovery cards must fire only after a delivered firing card (firedFeishuEventIDs) and use a separate recovery dedupe key so resolve notifications are not blocked by the firing cooldown. Dropping any anchor turns a low-noise OPC pager into either silence or chat noise. FrontendURL threads the per-node public base URL into the card so prod vs each edge is distinguishable; losing it silently regresses every card back to an unattributable 'overall'."
     },
     {
       "path": "backend/internal/service/ops_feishu_notifier_tk.go",


### PR DESCRIPTION
## 摘要
- 新增全局 `user_visible_failure_count` P0 规则：prod 节点真实用户可感知的 provider/platform 终态失败，阈值 `20/5m`，`cooldown_minutes=10`，发送飞书；edge 节点运行时跳过该规则，避免重复告警。
- 新增全局 `client_visible_failure_count` P1 规则：`error_owner=client` 的参数/内容/用法终态失败，阈值 `20/5m`，`cooldown_minutes=10`，也发送飞书，便于运营同步客户。
- 移除旧的 `routing_capacity_rejection_count` / `无可用账号拒绝激增` P0 seed 规则：迁移会先 resolve 仍在 firing 的老事件、清理 silences，再删除规则，避免和新的真实用户体验 P0 重复告警。
- 飞书卡片对真实用户失败的首屏聚焦四件事：谁受影响、影响多大、用户看到什么、根因在哪；恢复卡片沿用 paired recovery 路径。
- 新增 repository 查询与 breakdown 维度，排除 recovered-200，只统计 `status_code >= 400` 且可归属真实用户的终态失败。

## 风险
- 新增 ops alert seed/removal migrations，会改变生产告警规则；commit 已带 high-risk-anchor。
- 更新 gateway TK sentinel，锚住新的 Feishu 准入策略：P0 全量允许，P1 仅允许 `client_visible_failure_count`。
- sentinel-registry-reviewed
- no-web-impact

## 验证
- `go test -tags unit ./internal/service`
- `go test -tags unit ./internal/repository -run TestNonExistentForCompileOnly`
- `go test -tags integration ./migrations`
- `git diff --check`
- `./scripts/preflight.sh`
- `go test -tags integration ./internal/repository -run TestUserVisibleFailureCountAndBreakdown` 本机未通过：本机 testcontainers 启动失败，`rootless Docker not found`，未进入代码断言。

## 提交
- 8c7316507 fix(ops): alert on user-visible terminal failures