### PR TITLE
fix(reconciler): surface-C 镜像 openai native stub 并发容量

### DIFF
--- a/backend/internal/handler/edge_tk_capacity_handler.go
+++ b/backend/internal/handler/edge_tk_capacity_handler.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
 )
@@ -18,6 +20,7 @@ import (
 type schedulingCapacityReader interface {
 	SumConcurrencyAnthropicByGroup(ctx context.Context, groupName string) (int64, error)
 	SumConcurrencyByPlatform(ctx context.Context, platform string) (int64, error)
+	SumConcurrencyByPlatformAndGroupID(ctx context.Context, platform string, groupID int64) (int64, error)
 }
 
 // anthropicDefaultGroupName is the group whose schedulable anthropic concurrency
@@ -66,10 +69,13 @@ type edgeCapacityResponse struct {
 // GetSchedulingCapacity handles GET /api/v1/edge/scheduling-capacity.
 //
 // platform selects which edge pool's live Σ schedulable concurrency to report,
-// mirroring the prod stub's credentials.mirror_platform:
+// mirroring the prod stub's credentials.mirror_platform (anthropic transport) or
+// native platform (openai/grok/…):
 //   - anthropic: the operator-curated "default" group (see anthropicDefaultGroupName).
 //   - kiro: all schedulable kiro accounts (the edge is single-pool-per-platform for
 //     kiro, so no group scoping — counting every kiro row IS the live pool).
+//   - openai / grok / antigravity: platform-wide by default; with group_scope=caller
+//     narrows to the authenticated caller key's group (prod mirror stubs).
 //
 // An unsupported / missing platform is rejected rather than silently defaulting,
 // so a prod misconfig surfaces loudly instead of writing a wrong number.
@@ -81,6 +87,7 @@ func (h *EdgeCapacityHandler) GetSchedulingCapacity(c *gin.Context) {
 
 	platform := strings.ToLower(strings.TrimSpace(c.DefaultQuery("platform", domain.PlatformAnthropic)))
 	ctx := c.Request.Context()
+	groupID := edgeCapacityCallerGroupID(c)
 
 	var (
 		total int64
@@ -91,8 +98,14 @@ func (h *EdgeCapacityHandler) GetSchedulingCapacity(c *gin.Context) {
 		total, err = h.accounts.SumConcurrencyAnthropicByGroup(ctx, anthropicDefaultGroupName)
 	case domain.PlatformKiro:
 		total, err = h.accounts.SumConcurrencyByPlatform(ctx, domain.PlatformKiro)
+	case domain.PlatformOpenAI, domain.PlatformGrok, domain.PlatformAntigravity:
+		if groupID > 0 {
+			total, err = h.accounts.SumConcurrencyByPlatformAndGroupID(ctx, platform, groupID)
+		} else {
+			total, err = h.accounts.SumConcurrencyByPlatform(ctx, platform)
+		}
 	default:
-		response.Error(c, http.StatusBadRequest, "unsupported platform (only anthropic, kiro)")
+		response.Error(c, http.StatusBadRequest, "unsupported platform (only anthropic, kiro, openai, grok, antigravity)")
 		return
 	}
 	if err != nil {
@@ -105,4 +118,21 @@ func (h *EdgeCapacityHandler) GetSchedulingCapacity(c *gin.Context) {
 		TotalConcurrency: total,
 		TS:               time.Now().Unix(),
 	})
+}
+
+// edgeCapacityCallerGroupID mirrors EdgeAccountsHandler's group_scope=caller filter:
+// direct caller keys narrow to their group; universal / absent keys → 0 (no filter).
+func edgeCapacityCallerGroupID(c *gin.Context) int64 {
+	if !strings.EqualFold(strings.TrimSpace(c.Query("group_scope")), "caller") {
+		return 0
+	}
+	v, ok := c.Get(middleware.EdgeCallerAPIKeyCtxKey)
+	if !ok {
+		return 0
+	}
+	ak, ok := v.(*service.APIKey)
+	if !ok || ak == nil || ak.IsUniversal() || ak.GroupID == nil {
+		return 0
+	}
+	return *ak.GroupID
 }

--- a/backend/internal/handler/edge_tk_capacity_handler_test.go
+++ b/backend/internal/handler/edge_tk_capacity_handler_test.go
@@ -10,16 +10,20 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 
 type capacityReaderStub struct {
-	sum          int64
-	platformSum  int64
-	err          error
-	lastGroup    string
-	lastPlatform string
+	sum              int64
+	platformSum      int64
+	platformGroupSum int64
+	err              error
+	lastGroup        string
+	lastPlatform     string
+	lastGroupID      int64
 }
 
 func (s *capacityReaderStub) SumConcurrencyAnthropicByGroup(_ context.Context, groupName string) (int64, error) {
@@ -30,6 +34,12 @@ func (s *capacityReaderStub) SumConcurrencyAnthropicByGroup(_ context.Context, g
 func (s *capacityReaderStub) SumConcurrencyByPlatform(_ context.Context, platform string) (int64, error) {
 	s.lastPlatform = platform
 	return s.platformSum, s.err
+}
+
+func (s *capacityReaderStub) SumConcurrencyByPlatformAndGroupID(_ context.Context, platform string, groupID int64) (int64, error) {
+	s.lastPlatform = platform
+	s.lastGroupID = groupID
+	return s.platformGroupSum, s.err
 }
 
 func performCapacityRequest(t *testing.T, h *EdgeCapacityHandler, query string) *httptest.ResponseRecorder {
@@ -72,8 +82,54 @@ func TestEdgeCapacityHandler_DefaultsToAnthropic(t *testing.T) {
 
 func TestEdgeCapacityHandler_RejectsUnsupportedPlatform(t *testing.T) {
 	h := NewEdgeCapacityHandler(&capacityReaderStub{sum: 7})
-	w := performCapacityRequest(t, h, "?platform=openai")
+	w := performCapacityRequest(t, h, "?platform=gemini")
 	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestEdgeCapacityHandler_OpenAIUsesPlatformWideSum(t *testing.T) {
+	stub := &capacityReaderStub{platformSum: 120}
+	h := NewEdgeCapacityHandler(stub)
+	w := performCapacityRequest(t, h, "?platform=openai")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var env struct {
+		Data struct {
+			Platform         string `json:"platform"`
+			TotalConcurrency int64  `json:"total_concurrency"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	require.Equal(t, "openai", env.Data.Platform)
+	require.Equal(t, int64(120), env.Data.TotalConcurrency)
+	require.Equal(t, "openai", stub.lastPlatform)
+	require.Zero(t, stub.lastGroupID)
+}
+
+func TestEdgeCapacityHandler_OpenAIGroupScopeCallerUsesGroupSum(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	groupID := int64(42)
+	stub := &capacityReaderStub{platformGroupSum: 120}
+	h := NewEdgeCapacityHandler(stub)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/edge/scheduling-capacity?platform=openai&group_scope=caller", nil)
+	c.Set(middleware.EdgeCallerAPIKeyCtxKey, &service.APIKey{
+		ID:          9,
+		GroupID:     &groupID,
+		RoutingMode: service.RoutingModeDirect,
+	})
+	h.GetSchedulingCapacity(c)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "openai", stub.lastPlatform)
+	require.Equal(t, int64(42), stub.lastGroupID)
+
+	var env struct {
+		Data struct {
+			TotalConcurrency int64 `json:"total_concurrency"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	require.Equal(t, int64(120), env.Data.TotalConcurrency)
 }
 
 func TestEdgeCapacityHandler_KiroUsesPlatformWideSum(t *testing.T) {

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -216,6 +216,27 @@ WHERE platform = $1 AND schedulable = true AND deleted_at IS NULL`
 	return sum.Int64, nil
 }
 
+// SumConcurrencyByPlatformAndGroupID returns Σ concurrency for schedulable accounts
+// of the given platform in one group. Surface-C: native-platform mirror stubs
+// (openai/grok/…) query the edge with group_scope=caller so prod mirrors the
+// stub relay key's pool rather than every schedulable row of that platform.
+func (r *accountRepository) SumConcurrencyByPlatformAndGroupID(ctx context.Context, platform string, groupID int64) (int64, error) {
+	const q = `
+SELECT COALESCE(SUM(a.concurrency), 0)::bigint
+FROM accounts a
+JOIN account_groups ag ON ag.account_id = a.id
+WHERE a.platform = $1 AND a.schedulable = true AND a.deleted_at IS NULL
+  AND ag.group_id = $2`
+	var sum sql.NullInt64
+	if err := scanSingleRow(ctx, r.sql, q, []any{platform, groupID}, &sum); err != nil {
+		return 0, fmt.Errorf("sum concurrency by platform %q group %d: %w", platform, groupID, err)
+	}
+	if !sum.Valid {
+		return 0, nil
+	}
+	return sum.Int64, nil
+}
+
 func (r *accountRepository) GetByID(ctx context.Context, id int64) (*service.Account, error) {
 	m, err := r.client.Account.Query().Where(dbaccount.IDEQ(id)).Only(ctx)
 	if err != nil {

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -1882,6 +1882,10 @@ func (s *stubAccountRepo) SumConcurrencyByPlatform(context.Context, string) (int
 	return 0, nil
 }
 
+func (s *stubAccountRepo) SumConcurrencyByPlatformAndGroupID(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+
 func (s *stubAccountRepo) ListCRSAccountIDs(ctx context.Context) (map[string]int64, error) {
 	return nil, errors.New("not implemented")
 }

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -88,6 +88,11 @@ type AccountRepository interface {
 	// pools — e.g. kiro — where the edge is single-pool-per-platform and the
 	// anthropic "default"-group scoping does not apply).
 	SumConcurrencyByPlatform(ctx context.Context, platform string) (int64, error)
+	// SumConcurrencyByPlatformAndGroupID returns Σ concurrency for schedulable
+	// accounts of the given platform in one group (surface-C: openai/grok/etc.
+	// mirror stubs query with group_scope=caller so prod mirrors the stub key's
+	// edge pool, not every row of that platform).
+	SumConcurrencyByPlatformAndGroupID(ctx context.Context, platform string, groupID int64) (int64, error)
 	// IncrementQuotaUsed 原子递增 API Key 账号的配额用量（总/日/周）
 	IncrementQuotaUsed(ctx context.Context, id int64, amount float64) error
 	// ResetQuotaUsed 重置 API Key 账号所有维度的配额用量为 0

--- a/backend/internal/service/account_service_delete_test.go
+++ b/backend/internal/service/account_service_delete_test.go
@@ -223,6 +223,10 @@ func (s *accountRepoStub) SumConcurrencyByPlatform(context.Context, string) (int
 	return 0, nil
 }
 
+func (s *accountRepoStub) SumConcurrencyByPlatformAndGroupID(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+
 func (s *accountRepoStub) RevertProxyFallback(ctx context.Context, accountID int64) error {
 	panic("unexpected RevertProxyFallback call")
 }

--- a/backend/internal/service/admin_service_bulk_update_test.go
+++ b/backend/internal/service/admin_service_bulk_update_test.go
@@ -275,6 +275,13 @@ func (s *bulkAccountRepoAnthropicSum) SumConcurrencyByPlatform(context.Context, 
 	return s.anthropicConcurrencySum, nil
 }
 
+func (s *bulkAccountRepoAnthropicSum) SumConcurrencyByPlatformAndGroupID(context.Context, string, int64) (int64, error) {
+	if s.anthropicConcurrencyErr != nil {
+		return 0, s.anthropicConcurrencyErr
+	}
+	return s.anthropicConcurrencySum, nil
+}
+
 // TestBulkUpdateAccounts_SyncAnthropicOperatorConcurrency 验证 userRepo 齐备时，
 // 批量成功后会把管理员用户（users.id=AnthropicOperatorConcurrencyUserID）的并发写成 Σ anthropic accounts。
 func TestBulkUpdateAccounts_SyncAnthropicOperatorConcurrency(t *testing.T) {

--- a/backend/internal/service/anthropic_config_reconciler.go
+++ b/backend/internal/service/anthropic_config_reconciler.go
@@ -55,6 +55,16 @@ const (
 	anthropicEdgeBalanceFloorDefault   = 9999999.0
 )
 
+// surfaceCCrossPlatformMirrorPlatforms lists native-platform prod mirror stubs whose
+// edge pool capacity is mirrored via group_scope=caller (the stub relay api-key's
+// group). Anthropic-transport stubs (cc-*, kiro-*) stay on isMirrorStub +
+// mirrorCapacityPlatform; newapi "all" stubs are excluded (no single platform sum).
+var surfaceCCrossPlatformMirrorPlatforms = []string{
+	PlatformOpenAI,
+	PlatformGrok,
+	PlatformAntigravity,
+}
+
 // anthropicReconcilerLockRelease is the compare-and-delete unlock script — only
 // the instance that holds the lock may delete it (mirrors the ops alert evaluator).
 var anthropicReconcilerLockRelease = redis.NewScript(`
@@ -455,33 +465,57 @@ func (r *AnthropicConfigReconciler) reconcileConcurrencyMirror(ctx context.Conte
 		if !r.isMirrorStub(a, re) {
 			continue
 		}
-		baseURL := strings.TrimSpace(a.GetCredential("base_url"))
-		apiKey := strings.TrimSpace(a.GetCredential("api_key"))
-		if baseURL == "" || apiKey == "" {
-			continue
-		}
-		// A mirror stub's transport platform is always anthropic-apikey, but the
-		// edge pool it represents (its capacity source) may differ — kiro rides the
-		// same relay shape. credentials.mirror_platform declares which edge pool to
-		// mirror; absent → anthropic (back-compat: every existing stub stays correct).
 		platform := mirrorCapacityPlatform(a.GetCredential("mirror_platform"))
-		total, ok := r.fetchEdgeCapacity(ctx, baseURL, apiKey, platform)
-		if !ok {
-			// Hard rule: failure/timeout/5xx/<1 → skip, never write 0.
-			continue
-		}
-		if a.Concurrency == total {
-			continue
-		}
-		want := total
-		if _, err := r.accounts.BulkUpdate(ctx, []int64{a.ID}, AccountBulkUpdate{Concurrency: &want}); err != nil {
-			slog.Warn("anthropic config reconciler: mirror concurrency write failed",
-				"account_id", a.ID, "account_name", a.Name, "want", want, "err", err)
-			continue
-		}
-		slog.Info("anthropic config reconciler: stub concurrency mirrored from edge (local deployment only)",
-			"account_id", a.ID, "account_name", a.Name, "base_url", baseURL, "concurrency", want)
+		r.applyConcurrencyMirrorFromEdge(ctx, a, platform, false)
 	}
+	for _, platform := range surfaceCCrossPlatformMirrorPlatforms {
+		stubs, err := r.accounts.ListByPlatform(ctx, platform)
+		if err != nil {
+			slog.Warn("anthropic config reconciler: list mirror stubs failed",
+				"platform", platform, "err", err)
+			continue
+		}
+		for i := range stubs {
+			a := &stubs[i]
+			if a.Type != AccountTypeAPIKey || !isEdgeMirrorStub(a, re) {
+				continue
+			}
+			poolPlatform := edgeStubPoolPlatform(a)
+			if poolPlatform == edgeStubAllPoolsPlatform {
+				continue
+			}
+			r.applyConcurrencyMirrorFromEdge(ctx, a, poolPlatform, true)
+		}
+	}
+}
+
+func (r *AnthropicConfigReconciler) applyConcurrencyMirrorFromEdge(
+	ctx context.Context,
+	a *Account,
+	platform string,
+	groupScopeCaller bool,
+) {
+	baseURL := strings.TrimSpace(a.GetCredential("base_url"))
+	apiKey := strings.TrimSpace(a.GetCredential("api_key"))
+	if baseURL == "" || apiKey == "" {
+		return
+	}
+	total, ok := r.fetchEdgeCapacity(ctx, baseURL, apiKey, platform, groupScopeCaller)
+	if !ok {
+		// Hard rule: failure/timeout/5xx/<1 → skip, never write 0.
+		return
+	}
+	if a.Concurrency == total {
+		return
+	}
+	want := total
+	if _, err := r.accounts.BulkUpdate(ctx, []int64{a.ID}, AccountBulkUpdate{Concurrency: &want}); err != nil {
+		slog.Warn("anthropic config reconciler: mirror concurrency write failed",
+			"account_id", a.ID, "account_name", a.Name, "want", want, "err", err)
+		return
+	}
+	slog.Info("anthropic config reconciler: stub concurrency mirrored from edge (local deployment only)",
+		"account_id", a.ID, "account_name", a.Name, "base_url", baseURL, "concurrency", want)
 }
 
 // mirrorCapacityPlatform normalizes a stub's credentials.mirror_platform into the
@@ -490,9 +524,9 @@ func (r *AnthropicConfigReconciler) reconcileConcurrencyMirror(ctx context.Conte
 // anthropic pool). A non-empty value is passed through verbatim (lower/trimmed)
 // rather than coerced to a known platform: the edge endpoint is the authoritative
 // validator and rejects anything it does not support, so an unknown/typo'd value
-// (e.g. "openai", "kir0") makes fetchEdgeCapacity see a 4xx and skip — never write
-// 0, never silently mirror the wrong pool. Coercing unknowns to "anthropic" here
-// would reintroduce the exact silent-wrong-pool bug this surface exists to kill.
+// (e.g. "kir0") makes fetchEdgeCapacity see a 4xx and skip — never write 0, never
+// silently mirror the wrong pool. Coercing unknowns to "anthropic" here would
+// reintroduce the exact silent-wrong-pool bug this surface exists to kill.
 func mirrorCapacityPlatform(raw string) string {
 	p := strings.ToLower(strings.TrimSpace(raw))
 	if p == "" {
@@ -502,12 +536,20 @@ func mirrorCapacityPlatform(raw string) string {
 }
 
 // fetchEdgeCapacity GETs {base_url}/api/v1/edge/scheduling-capacity?platform={platform}
-// with x-api-key auth. Returns (total, true) only on a 2xx with total_concurrency >= 1.
-func (r *AnthropicConfigReconciler) fetchEdgeCapacity(ctx context.Context, baseURL, apiKey, platform string) (int, bool) {
+// (and &group_scope=caller for native-platform mirror stubs) with x-api-key auth.
+// Returns (total, true) only on a 2xx with total_concurrency >= 1.
+func (r *AnthropicConfigReconciler) fetchEdgeCapacity(
+	ctx context.Context,
+	baseURL, apiKey, platform string,
+	groupScopeCaller bool,
+) (int, bool) {
 	if r.http == nil {
 		return 0, false
 	}
 	endpoint := strings.TrimRight(baseURL, "/") + "/api/v1/edge/scheduling-capacity?platform=" + url.QueryEscape(platform)
+	if groupScopeCaller {
+		endpoint += "&group_scope=caller"
+	}
 	reqCtx, cancel := context.WithTimeout(ctx, anthropicReconcilerHTTPTO)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)

--- a/backend/internal/service/anthropic_config_reconciler_test.go
+++ b/backend/internal/service/anthropic_config_reconciler_test.go
@@ -39,7 +39,10 @@ func (s *reconcilerAccountStub) ListByPlatform(ctx context.Context, platform str
 	if s.byPlatform != nil {
 		return s.byPlatform[platform], nil // absent platform → empty list
 	}
-	return s.accounts, nil
+	if platform == PlatformAnthropic {
+		return s.accounts, nil
+	}
+	return nil, nil
 }
 
 func (s *reconcilerAccountStub) SumConcurrencyAnthropic(ctx context.Context) (int64, error) {
@@ -57,6 +60,13 @@ func (s *reconcilerAccountStub) SumConcurrencyAnthropicByGroup(context.Context, 
 }
 
 func (s *reconcilerAccountStub) SumConcurrencyByPlatform(context.Context, string) (int64, error) {
+	if s.sumErr != nil {
+		return 0, s.sumErr
+	}
+	return s.sum, nil
+}
+
+func (s *reconcilerAccountStub) SumConcurrencyByPlatformAndGroupID(context.Context, string, int64) (int64, error) {
 	if s.sumErr != nil {
 		return 0, s.sumErr
 	}
@@ -407,6 +417,46 @@ func TestReconciler_SurfaceC_KiroStub_QueriesKiroPlatform(t *testing.T) {
 	require.Equal(t, 1, concWrites)
 }
 
+func TestReconciler_SurfaceC_OpenAIStub_QueriesOpenAIWithGroupScopeCaller(t *testing.T) {
+	stub := Account{
+		ID:          68,
+		Name:        "openai-us4",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 40,
+		Credentials: map[string]any{
+			"base_url": "https://api-us4.tokenkey.dev",
+			"api_key":  "sk-edge-key",
+		},
+	}
+	acc := &reconcilerAccountStub{
+		byPlatform: map[string][]Account{
+			PlatformAnthropic: {},
+			PlatformOpenAI:    {stub},
+		},
+		sum: 40,
+	}
+	usr := &reconcilerUserStub{user: &User{ID: 1, Concurrency: 40}}
+	r := newTestReconciler(acc, usr, &reconcilerBalanceStub{}, mirrorEnabledCfg(true, false))
+	doer := &fakeDoer{status: 200, body: `{"code":0,"message":"ok","data":{"platform":"openai","total_concurrency":120,"ts":1}}`}
+	r.http = doer
+
+	r.runOnce(context.Background())
+
+	require.Contains(t, doer.lastURL, "platform=openai")
+	require.Contains(t, doer.lastURL, "group_scope=caller")
+
+	var concWrites int
+	for _, call := range acc.bulkCalls {
+		if call.updates.Concurrency != nil {
+			concWrites++
+			require.Equal(t, 120, *call.updates.Concurrency)
+			require.Equal(t, []int64{68}, call.ids)
+		}
+	}
+	require.Equal(t, 1, concWrites)
+}
+
 // mirrorCapacityPlatform: only empty/whitespace defaults to anthropic; any
 // non-empty value is passed through verbatim (lower/trimmed) so an unknown/typo'd
 // value reaches the edge, 4xx's, and is skipped — never silently coerced to the
@@ -419,7 +469,7 @@ func TestMirrorCapacityPlatform(t *testing.T) {
 		"Anthropic": "anthropic",
 		"kiro":      "kiro",
 		" KIRO ":    "kiro",
-		"openai":    "openai", // unsupported today → passthrough, edge will 4xx
+		"openai":    "openai",
 		"kir0":      "kir0",   // typo → passthrough, NOT coerced to anthropic
 	}
 	for raw, want := range cases {

--- a/backend/internal/service/anthropic_operator_concurrency_test.go
+++ b/backend/internal/service/anthropic_operator_concurrency_test.go
@@ -34,6 +34,13 @@ func (a *accountRepoSumStub) SumConcurrencyByPlatform(context.Context, string) (
 	return a.sum, nil
 }
 
+func (a *accountRepoSumStub) SumConcurrencyByPlatformAndGroupID(context.Context, string, int64) (int64, error) {
+	if a.err != nil {
+		return 0, a.err
+	}
+	return a.sum, nil
+}
+
 type recordingUserRepoStub struct {
 	UserRepository
 

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -216,6 +216,10 @@ func (m *mockAccountRepoForPlatform) SumConcurrencyByPlatform(context.Context, s
 	return 0, nil
 }
 
+func (m *mockAccountRepoForPlatform) SumConcurrencyByPlatformAndGroupID(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockAccountRepoForPlatform) RevertProxyFallback(ctx context.Context, accountID int64) error {
 	return nil
 }

--- a/backend/internal/service/gemini_multiplatform_test.go
+++ b/backend/internal/service/gemini_multiplatform_test.go
@@ -199,6 +199,10 @@ func (m *mockAccountRepoForGemini) SumConcurrencyByPlatform(context.Context, str
 	return 0, nil
 }
 
+func (m *mockAccountRepoForGemini) SumConcurrencyByPlatformAndGroupID(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockAccountRepoForGemini) RevertProxyFallback(ctx context.Context, accountID int64) error {
 	return nil
 }

--- a/backend/internal/service/ratelimit_session_window_test.go
+++ b/backend/internal/service/ratelimit_session_window_test.go
@@ -168,6 +168,9 @@ func (m *sessionWindowMockRepo) SumConcurrencyAnthropicByGroup(context.Context, 
 func (m *sessionWindowMockRepo) SumConcurrencyByPlatform(context.Context, string) (int64, error) {
 	panic("unexpected")
 }
+func (m *sessionWindowMockRepo) SumConcurrencyByPlatformAndGroupID(context.Context, string, int64) (int64, error) {
+	panic("unexpected")
+}
 func (m *sessionWindowMockRepo) RevertProxyFallback(context.Context, int64) error {
 	panic("unexpected")
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1740,7 +1740,10 @@
       "must_contain": [
         "func (h *EdgeCapacityHandler) GetSchedulingCapacity(",
         "SumConcurrencyAnthropicByGroup(",
-        "anthropicDefaultGroupName"
+        "SumConcurrencyByPlatformAndGroupID(",
+        "anthropicDefaultGroupName",
+        "group_scope=caller",
+        "PlatformOpenAI"
       ],
       "rationale": "Edge capacity read endpoint (surface C): GET /api/v1/edge/scheduling-capacity exposes Σ schedulable anthropic concurrency so prod's reconciler can mirror a live edge's capacity onto its stub. The pool partitions by group — capacity counts ONLY the default scheduling pool (SumConcurrencyAnthropicByGroup with anthropicDefaultGroupName = \"default\", the group every edge's anthropic accounts actually belong to), not every anthropic row across all groups; a silent switch to the unscoped global sum would over-count cross-group accounts. The group name MUST stay \"default\": edges keep their anthropic accounts in an operator-managed group named \"default\", which INTENTIONALLY differs from the \"<platform>-default\" convention of the simple-mode seed + admin auto-bind (those would yield \"anthropic-default\", which returns 0 on the live edge — PR #476, then its revert). Do not \"correct\" it to anthropic-default to match the seed convention; that reintroduces the silent always-0 no-op. Read-only, off the gateway billing/concurrency chain. Silent deletion would break the prod concurrency-mirror without a compile error (prod would just stop converging)."
     },
@@ -1859,6 +1862,8 @@
       "must_contain": [
         "func (r *AnthropicConfigReconciler) reconcileConcurrencyMirror(",
         "skip, never write 0",
+        "surfaceCCrossPlatformMirrorPlatforms",
+        "group_scope=caller",
         "func (r *AnthropicConfigReconciler) reportTierDrift("
       ],
       "rationale": "Per-node in-process self-healer that drops the ops/anthropic high-frequency safe-item writes into the backend: operator-Σ alignment, prod stub pool_mode, edge balance floor, and the surface-C concurrency mirror — plus REPORT-ONLY tier drift (never silently rewrites a UI-set tier). The surface-C 'never write 0 on a failed edge read' invariant and the report-only tier-drift boundary are load-bearing correctness properties; a silent upstream-merge deletion or weakening must be caught."


### PR DESCRIPTION
## 摘要

- 修复 prod 侧 `openai-us*` native stub 并发长期卡在 40 的问题：surface-C reconciler 原先只镜像 anthropic transport stub，且 edge `scheduling-capacity` 拒绝 `platform=openai`。
- Edge 容量接口新增 `openai` / `grok` / `antigravity`，并支持 `group_scope=caller`（按 stub relay api-key 所属 group 求和）。
- Prod reconciler 对 native-platform mirror stub 拉取 edge 时追加 `group_scope=caller`，自动把 stub `concurrency` 对齐到 edge 实况（例如 3 账号各 40 → **120**）。

## 风险

- 常规风险：仅扩展 surface-C 读路径与 reconciler 写入逻辑，不改变 gateway 调度/计费链。
- Edge `scheduling-capacity` 对 openai 等为**新增**支持，不破坏既有 anthropic/kiro 行为。
- 失败/超时/5xx 仍跳过写入，**不会**把 stub 并发写成 0。

## 验证

```bash
cd backend
go test -tags=unit ./internal/handler/... -run EdgeCapacity -count=1
go test -tags=unit ./internal/service/... -run 'Reconciler_SurfaceC|MirrorCapacity' -count=1
go build -tags=unit ./...
./scripts/preflight.sh
```

本地已跑通上述测试与 preflight。

发版后在 prod 观察 reconciler 日志应出现 `stub concurrency mirrored from edge`，`openai-us3/4/6.concurrency` 应收敛到各 edge 对应 group 的 Σ。

## 提交

- `ccec3a60d` fix(reconciler): mirror native openai stub concurrency from edge

最新提交：`ccec3a60d`

Made with [Cursor](https://cursor.com)