### PR TITLE
fix(service): normalize model mapping lookup casing

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -647,28 +647,80 @@ func normalizeRequestedModelForLookup(platform, requestedModel string) string {
 }
 
 func mappingSupportsRequestedModel(mapping map[string]string, requestedModel string) bool {
-	if requestedModel == "" {
-		return false
-	}
-	if _, exists := mapping[requestedModel]; exists {
-		return true
-	}
-	for pattern := range mapping {
-		if matchWildcard(pattern, requestedModel) {
-			return true
-		}
-	}
-	return false
+	_, matched := resolveRequestedModelInMapping(mapping, requestedModel)
+	return matched
 }
 
 func resolveRequestedModelInMapping(mapping map[string]string, requestedModel string) (mappedModel string, matched bool) {
+	requestedModel = strings.TrimSpace(requestedModel)
 	if requestedModel == "" {
 		return "", false
 	}
 	if mappedModel, exists := mapping[requestedModel]; exists {
 		return mappedModel, true
 	}
-	return matchWildcardMappingResult(mapping, requestedModel)
+	lookupKey := normalizeModelMappingLookupKey(requestedModel)
+	if lookupKey != "" && lookupKey != requestedModel {
+		if mappedModel, exists := mapping[lookupKey]; exists {
+			return mappedModel, true
+		}
+	}
+	if lookupKey != "" {
+		for _, key := range sortedModelMappingKeys(mapping) {
+			if key == requestedModel || key == lookupKey {
+				continue
+			}
+			if normalizeModelMappingLookupKey(key) == lookupKey {
+				return mapping[key], true
+			}
+		}
+	}
+	if mappedModel, matched := matchWildcardMappingResult(mapping, requestedModel); matched {
+		return mappedModel, true
+	}
+	if lookupKey != "" && lookupKey != requestedModel {
+		if mappedModel, matched := matchNormalizedWildcardMappingResult(mapping, lookupKey); matched {
+			return mappedModel, true
+		}
+	}
+	return requestedModel, false
+}
+
+func normalizeModelMappingLookupKey(model string) string {
+	return strings.ToLower(strings.TrimSpace(model))
+}
+
+func sortedModelMappingKeys(mapping map[string]string) []string {
+	keys := make([]string, 0, len(mapping))
+	for key := range mapping {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func matchNormalizedWildcardMappingResult(mapping map[string]string, requestedModel string) (string, bool) {
+	type patternMatch struct {
+		pattern string
+		target  string
+	}
+	var matches []patternMatch
+	for pattern, target := range mapping {
+		normalizedPattern := normalizeModelMappingLookupKey(pattern)
+		if matchWildcard(normalizedPattern, requestedModel) {
+			matches = append(matches, patternMatch{pattern: pattern, target: target})
+		}
+	}
+	if len(matches) == 0 {
+		return requestedModel, false
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		if len(matches[i].pattern) != len(matches[j].pattern) {
+			return len(matches[i].pattern) > len(matches[j].pattern)
+		}
+		return matches[i].pattern < matches[j].pattern
+	})
+	return matches[0].target, true
 }
 
 // IsModelSupported 检查模型是否在 model_mapping 中（支持通配符）

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -430,6 +430,30 @@ func TestAccountResolveMappedModel(t *testing.T) {
 			expectedMatch:  true,
 		},
 		{
+			name:     "newapi mapping matches mixed-case client spelling and returns canonical upstream",
+			platform: PlatformNewAPI,
+			credentials: map[string]any{
+				"model_mapping": map[string]any{
+					"deepseek-v4-pro": "deepseek-v4-pro",
+				},
+			},
+			requestedModel: "DeepSeek-V4-Pro",
+			expectedModel:  "deepseek-v4-pro",
+			expectedMatch:  true,
+		},
+		{
+			name: "case-insensitive lookup prefers exact requested spelling when configured",
+			credentials: map[string]any{
+				"model_mapping": map[string]any{
+					"DeepSeek-V4-Pro": "custom-upstream",
+					"deepseek-v4-pro": "deepseek-v4-pro",
+				},
+			},
+			requestedModel: "DeepSeek-V4-Pro",
+			expectedModel:  "custom-upstream",
+			expectedMatch:  true,
+		},
+		{
 			name: "wildcard passthrough mapping still counts as matched",
 			credentials: map[string]any{
 				"model_mapping": map[string]any{
@@ -438,6 +462,18 @@ func TestAccountResolveMappedModel(t *testing.T) {
 			},
 			requestedModel: "gpt-5.4",
 			expectedModel:  "gpt-5.4",
+			expectedMatch:  true,
+		},
+		{
+			name:     "wildcard mapping matches mixed-case client spelling",
+			platform: PlatformNewAPI,
+			credentials: map[string]any{
+				"model_mapping": map[string]any{
+					"deepseek-v4-*": "deepseek-v4-flash",
+				},
+			},
+			requestedModel: "deepSeek-v4-flash",
+			expectedModel:  "deepseek-v4-flash",
 			expectedMatch:  true,
 		},
 		{
@@ -489,6 +525,29 @@ func TestAccountResolveMappedModel(t *testing.T) {
 				t.Fatalf("ResolveMappedModel(%q) = (%q, %v), want (%q, %v)", tt.requestedModel, mappedModel, matched, tt.expectedModel, tt.expectedMatch)
 			}
 		})
+	}
+}
+
+func TestAccountIsModelSupported_MixedCaseMappingLookup(t *testing.T) {
+	t.Parallel()
+
+	account := &Account{
+		Platform: PlatformNewAPI,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"deepseek-v4-pro":   "deepseek-v4-pro",
+				"deepseek-v4-flash": "deepseek-v4-flash",
+			},
+		},
+	}
+
+	for _, model := range []string{"DeepSeek-V4-Pro", "deepSeek-v4-pro", "DeepSeek-V4-Flash", "deepSeek-v4-flash"} {
+		if !account.IsModelSupported(model) {
+			t.Fatalf("IsModelSupported(%q) = false, want true", model)
+		}
+	}
+	if account.IsModelSupported("DeepSeek-V4-Max") {
+		t.Fatalf("unexpected support for unmapped mixed-case model")
 	}
 }
 

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -255,6 +255,18 @@ func TestModelInServedSet_UsesDirectMappingAliases(t *testing.T) {
 			model:    "gemini-3.1-pro-preview-customtools",
 			served:   []string{"gemini-3.1-pro-preview"},
 		},
+		{
+			name:     "newapi served set matches mixed-case deepseek",
+			platform: PlatformNewAPI,
+			model:    "DeepSeek-V4-Pro",
+			served:   []string{"deepseek-v4-pro"},
+		},
+		{
+			name:     "newapi served wildcard matches mixed-case deepseek",
+			platform: PlatformNewAPI,
+			model:    "deepSeek-v4-flash",
+			served:   []string{"deepseek-v4-*"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -262,6 +274,29 @@ func TestModelInServedSet_UsesDirectMappingAliases(t *testing.T) {
 				t.Fatalf("modelInServedSet(%q, %v, %s) = false, want true", tc.model, tc.served, tc.platform)
 			}
 		})
+	}
+}
+
+func TestUniversalOpenAICompatAccountSupportsModel_MixedCaseMappingLookup(t *testing.T) {
+	t.Parallel()
+
+	account := &Account{
+		Platform: PlatformNewAPI,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"deepseek-v4-pro":   "deepseek-v4-pro",
+				"deepseek-v4-flash": "deepseek-v4-flash",
+			},
+		},
+	}
+
+	for _, model := range []string{"DeepSeek-V4-Pro", "deepSeek-v4-pro", "DeepSeek-V4-Flash", "deepSeek-v4-flash"} {
+		if !universalOpenAICompatAccountSupportsModel(context.Background(), nil, account, model, ShapeOpenAIChat) {
+			t.Fatalf("universalOpenAICompatAccountSupportsModel(%q) = false, want true", model)
+		}
+	}
+	if universalOpenAICompatAccountSupportsModel(context.Background(), nil, account, "DeepSeek-V4-Max", ShapeOpenAIChat) {
+		t.Fatalf("unexpected universal support for unmapped mixed-case model")
 	}
 }
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3893,6 +3893,16 @@
       "rationale": "Universal-key routing must use the same account-level model+protocol predicate as the direct schedulers before consulting the lossy group-level served-model union. This pins the provider type, the GatewayService implementation, the OpenAI-compatible pool/member + IsModelSupported path, endpoint-shape capability gates (including video-capable accounts), the native gateway path, and the alias-aware served-set fallback. Dropping any of these can make a universal key choose a different backing group than a direct key for the same model/protocol while existing /v1/models output still looks plausible."
     },
     {
+      "path": "backend/internal/service/account.go",
+      "must_contain": [
+        "func normalizeModelMappingLookupKey(model string) string",
+        "return strings.ToLower(strings.TrimSpace(model))",
+        "if normalizeModelMappingLookupKey(key) == lookupKey",
+        "func matchNormalizedWildcardMappingResult(mapping map[string]string, requestedModel string)"
+      ],
+      "rationale": "Account-level model_mapping lookup must treat client model-name casing variants as the same upstream capability while preserving explicit exact-spelling priority. This is load-bearing for universal and direct OpenAI-compatible routing: DeepSeek-V4-Pro / deepSeek-v4-pro must hit account mappings keyed as deepseek-v4-pro instead of emptying the pool into client-visible 403/400. account.go is upstream-shaped, so pin the normalization fallback and normalized wildcard path to prevent an upstream merge from silently reverting to case-sensitive lookup while the admin-visible raw model_mapping remains unchanged."
+    },
+    {
       "path": "backend/internal/service/wire_tk.go",
       "must_contain": [
         "ProvideTKUniversalModelsProvider(",
@@ -3911,9 +3921,27 @@
         "TestResolve_GeminiMessagesAnthropicShapeAvoidsOpenAIPassthrough",
         "TestUniversalGroupSupportsModel_NewapiRequiresCompatPoolMember",
         "TestModelInServedSet_UsesDirectMappingAliases",
+        "newapi served set matches mixed-case deepseek",
+        "newapi served wildcard matches mixed-case deepseek",
+        "TestUniversalOpenAICompatAccountSupportsModel_MixedCaseMappingLookup",
         "TestResolve_User16GPTAliasPicksOpenAIGroup"
       ],
       "rationale": "Focused regression coverage for universal/direct-key model-support parity: direct provider wins over the served-set fallback, provider unknown fails over safely, OpenAI-compatible mapping and newapi pool membership match direct scheduler semantics, served-set fallback is alias/wildcard aware, and the user16 gpt5.4-mini alias resolves to the OpenAI group instead of newapi. These tests are the semantic guard for the production 429 regression."
+    },
+    {
+      "path": "backend/internal/service/account_wildcard_test.go",
+      "must_contain": [
+        "newapi mapping matches mixed-case client spelling and returns canonical upstream",
+        "case-insensitive lookup prefers exact requested spelling when configured",
+        "wildcard mapping matches mixed-case client spelling",
+        "TestAccountIsModelSupported_MixedCaseMappingLookup",
+        "DeepSeek-V4-Pro",
+        "deepSeek-v4-pro",
+        "DeepSeek-V4-Flash",
+        "deepSeek-v4-flash",
+        "DeepSeek-V4-Max"
+      ],
+      "rationale": "Focused regression coverage for account model_mapping case-normalized lookup. It pins both mapping resolution and IsModelSupported so mixed-case DeepSeek client spellings route to the canonical lowercase upstream names, exact requested spelling remains highest priority, normalized wildcard matching still works, and unmapped mixed-case variants remain rejected."
     },
     {
       "path": "backend/internal/service/account_openai_passthrough_test.go",


### PR DESCRIPTION
## 摘要
- 修复 `model_mapping` 查找的大小写归一问题：原始精确匹配仍最高优先级，随后按 lowercase exact、case-insensitive key、原始 wildcard、归一化 wildcard 回退。
- 覆盖 universal NewAPI 路由和账号 `IsModelSupported`，让 `DeepSeek-V4-Pro`、`deepSeek-v4-pro`、`DeepSeek-V4-Flash` 等客户端变形输入命中上游支持的 `deepseek-v4-*`。
- 增加 gateway TK sentinel registry 语义锚点，防止后续 upstream merge 静默冲掉账号级 model_mapping 大小写归一查找和对应回归测试。
- 生产账号 39 已先热修 `model_mapping`，客户可立即使用；本 PR 固化通用逻辑。
- no-web-impact

## 风险
- 影响依赖 `model_mapping` 的服务层账号匹配路径，重点风险是大小写变形输入的命中顺序。
- 已保留显式原始大小写 key 的最高优先级，避免覆盖已有定制映射；wildcard 仍按既有具体度排序。
- 已补 semantic sentinel 锚点；`account.go` 仍是 upstream-shaped 文件，preflight 的 upstream insertion invasiveness 仅保留 advisory，无新增 upstream conflict file。
- sentinel-registry-reviewed

## 验证
- `cd backend && go test -tags=unit ./internal/service -run 'TestAccount(ResolveMappedModel|IsModelSupported_MixedCaseMappingLookup)|TestModelInServedSet|TestUniversalOpenAICompatAccountSupportsModel_MixedCaseMappingLookup'`
- `python3 ./scripts/sentinels/check-gateway-tk.py --quiet`
- `python3 ./scripts/sentinels/check-registry-update-gate.py --base origin/main --head HEAD`
- `./scripts/preflight.sh`

## 提交
- `9452cf167` fix(service): normalize model mapping lookup casing no-web-impact
- `ac10e408f` test(sentinel): pin model mapping case lookup no-web-impact
- 最新提交：`ac10e408f`
