### PR TITLE
fix(ops): 优化飞书告警明细换行

### DIFF
--- a/backend/internal/repository/ops_repo_user_visible_failure_integration_test.go
+++ b/backend/internal/repository/ops_repo_user_visible_failure_integration_test.go
@@ -27,8 +27,8 @@ func TestUserVisibleFailureCountAndBreakdown(t *testing.T) {
 		`INSERT INTO users (email, password_hash) VALUES ($1, 'x') RETURNING id`,
 		fmt.Sprintf("uvf-%d@example.com", suffix)).Scan(&userID))
 	require.NoError(t, integrationDB.QueryRowContext(ctx,
-		`INSERT INTO api_keys (user_id, key, name, group_id) VALUES ($1, $2, $3, $4) RETURNING id`,
-		userID, fmt.Sprintf("sk-uvf-%d", suffix), "training-key", groupID).Scan(&apiKeyID))
+		`INSERT INTO api_keys (user_id, key, name, routing_mode) VALUES ($1, $2, $3, 'universal') RETURNING id`,
+		userID, fmt.Sprintf("sk-uvf-%d", suffix), "training-key").Scan(&apiKeyID))
 	t.Cleanup(func() {
 		_, _ = integrationDB.ExecContext(context.Background(), "DELETE FROM groups WHERE id = $1", groupID)
 		_, _ = integrationDB.ExecContext(context.Background(), "DELETE FROM users WHERE id = $1", userID)
@@ -83,6 +83,7 @@ func TestUserVisibleFailureCountAndBreakdown(t *testing.T) {
 	require.NotEmpty(t, breakdown.Users)
 	require.Equal(t, userID, breakdown.Users[0].UserID)
 	require.Equal(t, "training-key", breakdown.Users[0].APIKeyName)
+	require.Equal(t, service.RoutingModeUniversal, breakdown.Users[0].APIKeyRoutingMode)
 	require.NotEmpty(t, breakdown.Surfaces)
 	require.Equal(t, 429, breakdown.Surfaces[0].StatusCode)
 	require.Equal(t, 429, breakdown.Surfaces[0].UpstreamStatusCode)

--- a/backend/internal/repository/ops_repo_user_visible_failure_tk.go
+++ b/backend/internal/repository/ops_repo_user_visible_failure_tk.go
@@ -94,13 +94,14 @@ SELECT
   COALESCE(l.user_id, l.deleted_key_owner_user_id, 0) AS user_id,
   COALESCE(u.email, '') AS user_email,
   COALESCE(ak.name, l.deleted_key_name, '') AS api_key_name,
+  COALESCE(ak.routing_mode, '') AS api_key_routing_mode,
   COALESCE(g.name, '') AS group_name,
   COUNT(*) AS n
 FROM base l
 LEFT JOIN users u ON u.id = COALESCE(l.user_id, l.deleted_key_owner_user_id)
 LEFT JOIN api_keys ak ON ak.id = l.api_key_id AND ak.deleted_at IS NULL
 LEFT JOIN groups g ON g.id = l.group_id AND g.deleted_at IS NULL
-GROUP BY 1, 2, 3, 4
+GROUP BY 1, 2, 3, 4, 5
 ORDER BY n DESC, user_id ASC
 LIMIT $` + fmt.Sprintf("%d", next)
 
@@ -113,7 +114,7 @@ LIMIT $` + fmt.Sprintf("%d", next)
 	out := make([]*service.OpsUserVisibleFailureUser, 0, limit)
 	for rows.Next() {
 		row := &service.OpsUserVisibleFailureUser{}
-		if err := rows.Scan(&row.UserID, &row.UserEmail, &row.APIKeyName, &row.GroupName, &row.Count); err != nil {
+		if err := rows.Scan(&row.UserID, &row.UserEmail, &row.APIKeyName, &row.APIKeyRoutingMode, &row.GroupName, &row.Count); err != nil {
 			return nil, err
 		}
 		out = append(out, row)

--- a/backend/internal/service/ops_alert_evaluator_service_test.go
+++ b/backend/internal/service/ops_alert_evaluator_service_test.go
@@ -558,7 +558,7 @@ func TestComputeUserVisibleFailureDimensions(t *testing.T) {
 			Failures:  148,
 			Successes: 17336,
 			Users: []*OpsUserVisibleFailureUser{{
-				UserID: 16, UserEmail: "compute@tk.com", APIKeyName: "训练组-何易纯", GroupName: "GPT专线", Count: 138,
+				UserID: 16, UserEmail: "compute@tk.com", APIKeyName: "训练组-何易纯", APIKeyRoutingMode: RoutingModeUniversal, GroupName: "GPT专线", Count: 138,
 			}},
 			Surfaces: []*OpsUserVisibleFailureSurface{{
 				StatusCode: 429, UpstreamStatusCode: 429, ErrorType: "rate_limit_error", Count: 148,
@@ -570,7 +570,7 @@ func TestComputeUserVisibleFailureDimensions(t *testing.T) {
 	}}
 
 	got := svc.computeUserVisibleFailureDimensions(ctx, rule, start, end, "", nil)
-	require.Equal(t, `#16 compute@tk.com ×138（key "训练组-何易纯" / group GPT专线）`, got["user_visible_affected"])
+	require.Equal(t, `#16 compute@tk.com ×138（key "训练组-何易纯" / universal key / group GPT专线）`, got["user_visible_affected"])
 	require.Equal(t, "失败 148 / 成功 17336 / 失败率 0.85% / 5m", got["user_visible_impact"])
 	require.Equal(t, "final 429 / upstream 429 / rate limit error ×148", got["user_visible_surface"])
 	require.Equal(t, "upstream/provider / openai / gpt-5.5 / account #76 / Too many pending requests ×148", got["user_visible_root"])

--- a/backend/internal/service/ops_alert_top_cause_tk.go
+++ b/backend/internal/service/ops_alert_top_cause_tk.go
@@ -70,11 +70,12 @@ type OpsUserVisibleFailureBreakdown struct {
 }
 
 type OpsUserVisibleFailureUser struct {
-	UserID     int64
-	UserEmail  string
-	APIKeyName string
-	GroupName  string
-	Count      int64
+	UserID            int64
+	UserEmail         string
+	APIKeyName        string
+	APIKeyRoutingMode string
+	GroupName         string
+	Count             int64
 }
 
 type OpsUserVisibleFailureSurface struct {
@@ -354,6 +355,12 @@ func formatUserVisibleFailureAffected(users []*OpsUserVisibleFailureUser) string
 		details := make([]string, 0, 2)
 		if key := sanitizeFeishuLabel(u.APIKeyName); key != "" {
 			details = append(details, `key "`+key+`"`)
+		}
+		switch strings.TrimSpace(u.APIKeyRoutingMode) {
+		case RoutingModeUniversal:
+			details = append(details, "universal key")
+		case RoutingModeDirect:
+			details = append(details, "direct key")
 		}
 		if group := sanitizeFeishuLabel(u.GroupName); group != "" {
 			details = append(details, "group "+group)

--- a/backend/internal/service/ops_alert_top_cause_tk_test.go
+++ b/backend/internal/service/ops_alert_top_cause_tk_test.go
@@ -128,6 +128,36 @@ func TestBuildOpsFeishuAlertTextTopCauseLine(t *testing.T) {
 	})
 }
 
+func TestFormatUserVisibleFailureAffectedShowsAPIKeyRoutingMode(t *testing.T) {
+	got := formatUserVisibleFailureAffected([]*OpsUserVisibleFailureUser{
+		{
+			UserID:            16,
+			UserEmail:         "compute@tk.com",
+			APIKeyName:        "benchmark组-赵欣宇",
+			APIKeyRoutingMode: RoutingModeUniversal,
+			GroupName:         "GPT专线",
+			Count:             171,
+		},
+		{
+			UserID:            17,
+			UserEmail:         "ops@tk.com",
+			APIKeyName:        "direct-bench",
+			APIKeyRoutingMode: RoutingModeDirect,
+			Count:             20,
+		},
+		{
+			UserID:     18,
+			UserEmail:  "deleted@tk.com",
+			APIKeyName: "deleted-key",
+			Count:      3,
+		},
+	})
+
+	require.Contains(t, got, `#16 compute@tk.com ×171（key "benchmark组-赵欣宇" / universal key / group GPT专线）`)
+	require.Contains(t, got, `#17 ops@tk.com ×20（key "direct-bench" / direct key）`)
+	require.Contains(t, got, `#18 deleted@tk.com ×3（key "deleted-key"）`)
+}
+
 func TestFormatRoutingRejectionByModel(t *testing.T) {
 	t.Run("top three requested models", func(t *testing.T) {
 		require.Equal(t,

--- a/backend/internal/service/ops_feishu_alerts_tk_test.go
+++ b/backend/internal/service/ops_feishu_alerts_tk_test.go
@@ -295,6 +295,43 @@ func TestMaybeSendAlertFeishuAllowsClientVisibleP1(t *testing.T) {
 	require.Contains(t, doer.bodies[0], "**根因在哪**")
 }
 
+func TestBuildOpsFeishuClientVisibleTextOmitsScopeAndWrapsBreakdowns(t *testing.T) {
+	t.Parallel()
+
+	rule := testOpsFeishuRule()
+	rule.Name = "真实用户客户端失败增多"
+	rule.Severity = "P1"
+	rule.MetricType = OpsAlertMetricClientVisibleFailureCount
+	rule.Operator = ">="
+	rule.Threshold = 20
+	event := testOpsFeishuEvent(100)
+	event.Severity = "P1"
+	triggerValue := 171.0
+	threshold := 20.0
+	event.MetricValue = &triggerValue
+	event.ThresholdValue = &threshold
+	resolvedAt := event.FiredAt.Add(31*time.Minute + 26*time.Second)
+	event.ResolvedAt = &resolvedAt
+	event.Dimensions = map[string]any{
+		"user_visible_affected": `#16 compute@tk.com ×171（key "benchmark组-赵欣宇"） · #17 ops@tk.com ×20（key "benchmark组-李雷"）`,
+		"user_visible_impact":   "失败 171 / 成功 751 / 失败率 18.55% / 5m",
+		"user_visible_surface":  "final 403 / invalid request error ×171",
+		"user_visible_root":     `auth/client / openai / No platform in your plan can serve model "gpt-5-mini". ×88 · auth/client / openai / No platform in your plan can serve model "gpt-5.1". ×83`,
+	}
+	currentValue := 1.0
+
+	firing := buildOpsFeishuAlertText(rule, event, "prod", "")
+	recovery := buildOpsFeishuRecoveryText(rule, event, "prod", "", &currentValue)
+
+	for _, text := range []string{firing, recovery} {
+		require.NotContains(t, text, "**范围**")
+		require.Contains(t, text, "**谁受影响**：\n#16 compute@tk.com ×171")
+		require.Contains(t, text, "\n#17 ops@tk.com ×20")
+		require.Contains(t, text, "**根因在哪**：\nauth/client / openai / No platform in your plan can serve model \"gpt-5-mini\". ×88")
+		require.Contains(t, text, "\nauth/client / openai / No platform in your plan can serve model \"gpt-5.1\". ×83")
+	}
+}
+
 func TestMaybeSendAlertFeishuSendsAndDedupesByCooldown(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/ops_feishu_notifier_tk.go
+++ b/backend/internal/service/ops_feishu_notifier_tk.go
@@ -224,10 +224,6 @@ func buildOpsFeishuAlertText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLabel
 	if event.ThresholdValue != nil {
 		thresholdValue = fmt.Sprintf("%.2f", *event.ThresholdValue)
 	}
-	dimensions := formatOpsFeishuDimensions(event.Dimensions)
-	if dimensions == "" {
-		dimensions = "overall"
-	}
 	if strings.TrimSpace(nodeLabel) == "" {
 		nodeLabel = "overall"
 	}
@@ -246,18 +242,17 @@ func buildOpsFeishuAlertText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLabel
 	// back to plain prose so the card still reads cleanly.
 	advice := buildOpsFeishuAdvice(rule.MetricType, sev, dashboardURL)
 	// TK (us7 P0 2026-06-13): the top offending model/reason, when the evaluator
-	// attached it (error-rate rules). Rendered as its own line right under 范围 so
-	// an operator can tell a real fire from client noise (e.g. a hammered
-	// access-gated model) without drilling the dashboard.
+	// attached it (error-rate rules). Rendered as its own line under the metric
+	// value so an operator can tell a real fire from client noise (e.g. a
+	// hammered access-gated model) without drilling the dashboard.
 	topCauseLine := buildOpsFeishuBreakdownLines(rule.MetricType, event.Dimensions)
-	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**当前值**：%s\n**范围**：%s%s\n**时间**：%s\n\n**建议**：%s",
+	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**当前值**：%s%s\n**时间**：%s\n\n**建议**：%s",
 		escapeFeishuText(nodeLabel),
 		escapeFeishuText(strings.TrimSpace(rule.Name)),
 		escapeFeishuText(strings.TrimSpace(rule.MetricType)),
 		escapeFeishuText(strings.TrimSpace(rule.Operator)),
 		escapeFeishuText(thresholdValue),
 		escapeFeishuText(metricValue),
-		escapeFeishuText(dimensions),
 		topCauseLine,
 		escapeFeishuText(formatAlertTime(event.FiredAt)),
 		advice,
@@ -296,10 +291,6 @@ func buildOpsFeishuRecoveryText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLa
 	if currentMetricValue != nil {
 		currentValue = fmt.Sprintf("%.2f", *currentMetricValue)
 	}
-	dimensions := formatOpsFeishuDimensions(event.Dimensions)
-	if dimensions == "" {
-		dimensions = "overall"
-	}
 	if strings.TrimSpace(nodeLabel) == "" {
 		nodeLabel = "overall"
 	}
@@ -324,7 +315,7 @@ func buildOpsFeishuRecoveryText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLa
 		note = fmt.Sprintf("[打开 Ops Dashboard](%s) 复核指标与账号可用性。指标已回落到阈值以下，告警自动解除。", dashboardURL)
 	}
 	topCauseLine := buildOpsFeishuBreakdownLines(rule.MetricType, event.Dimensions)
-	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**触发值**：%s\n**当前值**：%s\n**范围**：%s%s\n**持续时长**：%s\n**触发时间**：%s\n**恢复时间**：%s\n\n**说明**：%s",
+	return fmt.Sprintf("**节点**：%s\n**规则**：%s\n**指标**：%s %s %s\n**触发值**：%s\n**当前值**：%s%s\n**持续时长**：%s\n**触发时间**：%s\n**恢复时间**：%s\n\n**说明**：%s",
 		escapeFeishuText(nodeLabel),
 		escapeFeishuText(strings.TrimSpace(rule.Name)),
 		escapeFeishuText(strings.TrimSpace(rule.MetricType)),
@@ -332,7 +323,6 @@ func buildOpsFeishuRecoveryText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLa
 		escapeFeishuText(thresholdValue),
 		escapeFeishuText(metricValue),
 		escapeFeishuText(currentValue),
-		escapeFeishuText(dimensions),
 		topCauseLine,
 		escapeFeishuText(durationText),
 		escapeFeishuText(formatAlertTime(event.FiredAt)),
@@ -387,7 +377,7 @@ func buildOpsFeishuTopCauseLines(dimensions map[string]any) string {
 func buildOpsFeishuUserVisibleFailureLines(dimensions map[string]any) string {
 	lines := ""
 	if affected := opsFeishuDimensionString(dimensions, "user_visible_affected"); affected != "" {
-		lines += fmt.Sprintf("\n**谁受影响**：%s", escapeFeishuText(affected))
+		lines += opsFeishuBreakdownField("谁受影响", affected)
 	}
 	if impact := opsFeishuDimensionString(dimensions, "user_visible_impact"); impact != "" {
 		lines += fmt.Sprintf("\n**影响多大**：%s", escapeFeishuText(impact))
@@ -396,9 +386,31 @@ func buildOpsFeishuUserVisibleFailureLines(dimensions map[string]any) string {
 		lines += fmt.Sprintf("\n**用户看到什么**：%s", escapeFeishuText(surface))
 	}
 	if root := opsFeishuDimensionString(dimensions, "user_visible_root"); root != "" {
-		lines += fmt.Sprintf("\n**根因在哪**：%s", escapeFeishuText(root))
+		lines += opsFeishuBreakdownField("根因在哪", root)
 	}
 	return lines
+}
+
+func opsFeishuBreakdownField(label, value string) string {
+	parts := splitOpsFeishuBreakdown(value)
+	if len(parts) == 0 {
+		return ""
+	}
+	if len(parts) == 1 {
+		return fmt.Sprintf("\n**%s**：%s", label, escapeFeishuText(parts[0]))
+	}
+	return fmt.Sprintf("\n**%s**：\n%s", label, escapeFeishuText(strings.Join(parts, "\n")))
+}
+
+func splitOpsFeishuBreakdown(value string) []string {
+	rawParts := strings.Split(strings.TrimSpace(value), " · ")
+	parts := make([]string, 0, len(rawParts))
+	for _, p := range rawParts {
+		if part := strings.TrimSpace(p); part != "" {
+			parts = append(parts, part)
+		}
+	}
+	return parts
 }
 
 func opsFeishuDimensionString(dimensions map[string]any, key string) string {
@@ -458,20 +470,6 @@ func opsFeishuTopCauseModels(dimensions map[string]any) string {
 		}
 	}
 	return ""
-}
-
-func formatOpsFeishuDimensions(dimensions map[string]any) string {
-	if len(dimensions) == 0 {
-		return ""
-	}
-	parts := make([]string, 0, 2)
-	if v, ok := dimensions["platform"]; ok {
-		parts = append(parts, fmt.Sprintf("platform=%v", v))
-	}
-	if v, ok := dimensions["group_id"]; ok {
-		parts = append(parts, fmt.Sprintf("group_id=%v", v))
-	}
-	return strings.Join(parts, " ")
 }
 
 func signFeishuWebhook(timestamp string, signingSecret string) string {


### PR DESCRIPTION
摘要
- 移除飞书告警 firing/recovery 卡片中的「范围」行，降低无效信息噪声。
- 将真实用户失败告警里的「谁受影响」和「根因在哪」按多项 breakdown 换行呈现，便于快速定位多个用户或多个原因。
- 在「谁受影响」的 API key 详情里标记 `universal key` / `direct key`，帮助区分 universal 解析问题与固定分组问题。
- 增加回归测试覆盖 firing/recovery 文本、多项换行格式、API key routing mode 标记，以及 repository breakdown 读回 routing_mode。

风险
- 低风险：仅调整 ops 飞书通知文本渲染和 breakdown 查询字段，不改告警阈值、通知发送、API、DB schema 或 Web UI。
- Web impact: none
- sentinel-registry-reviewed：已确认本次仅调整既有告警文案格式和既有 breakdown 查询字段，不新增/删除 load-bearing sentinel anchor，无需更新 scripts/sentinels/gateway-tk.json。

验证
- cd backend && go test -tags unit ./internal/service -run 'Test(FormatUserVisibleFailureAffectedShowsAPIKeyRoutingMode|ComputeUserVisibleFailureDimensions|MaybeSendAlertFeishuAllowsClientVisibleP1|BuildOpsFeishuClientVisibleTextOmitsScopeAndWrapsBreakdowns|MaybeSendAlertFeishuRecoverySendsClientVisibleP1GreenCard|OpsFeishuNotifierBuildsRecoveryPayload|BuildOpsFeishuAlertTextTopCauseLine)'
- cd backend && go test -tags unit ./internal/repository
- ./scripts/preflight.sh
- 尝试：cd backend && go test -tags integration ./internal/repository -run TestUserVisibleFailureCountAndBreakdown -count=1；本机 testcontainers 报 rootless Docker not found，未能执行集成测试。

提交
- e86dac263 fix(ops): improve Feishu alert breakdown formatting
- 31d541c08 fix(ops): label alert API key routing mode
- 最新提交：31d541c08