### PR TITLE
fix(ops): persist Feishu alert delivery evidence

### DIFF
--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -24,7 +24,7 @@ description: >-
 | ⚠写侧止血：恢复 anthropic 可调度 / 清陈旧冷却（`MODE=edge-oauth-pool` 恢复 OAuth 池+补 group_id / `prod-mirror-cooldown` 清 cc-·kiro- 镜像冷却；before/after 自证） | 机械(写) | `ops/observability/remediate-schedulable-pool.sh`（经 run-probe 投递；§10 交接修复时用，非只读、须先有结论） |
 | Docker access log 解析（status/model/minute/latency 直方图 + marker 计数） | 机械 | `ops/observability/parse-access-log.py --stdin\|--file\|--docker` |
 | live-host 运行态漂移（运行镜像 tag vs 部署 tag + deploy_via_ssm 注入的 env：SERVER_FRONTEND_URL / QA_CAPTURE_EXPORT_STORAGE_*）| 机械 | `ops/stage0/assert-live-host-state.sh <instance_id> [expected_tag]`（只读 SSM，advisory；verdict 逻辑+`--selftest` 在 `ops/stage0/live_host_state_verdict.py`，已进 preflight；deploy-stage0 部署后 + ops-daily-diagnostics 每日审计自动跑）|
-| Gateway "http request completed" 最近 N 行 tail（脱敏 → JSON array，轻量原始日志） | 机械 | `ops/observability/probe-tail-gateway-logs.sh`（经 run-probe 投递；`LIMIT` 默认 50、`SINCE` 默认 24h、`CONTAINER` 默认 tokenkey） |
+| Gateway "http request completed" 最近 N 行 tail（脱敏 → JSON array，轻量原始日志） | 机械 | `ops/observability/probe-tail-gateway-logs.sh`（经 run-probe 投递；`LIMIT` 默认 50、`SINCE` 默认 24h、`CONTAINER` 默认 auto，按 active-color 解析 tokenkey-blue/green） |
 | Dashboard 预聚合覆盖度诊断（"使用趋势只显示 2 天"：usage_dashboard_daily/hourly vs raw usage_logs + aggregation watermark） | 机械 | `ops/observability/probe-dashboard-aggregate-coverage.sh`（经 run-probe 投递；只读 `row_to_json`） |
 | Admin UI access-log 性能画像（/admin 前端资源 + /api/v1/admin/* latency p50/p90/p95 + slow samples） | 机械 | `ops/observability/probe-admin-ui-perf.sh`（经 run-probe 投递；只读 Docker logs 聚合） |
 | Admin UI API timing（逐页接口 curl TTFB/total/size/非 2xx，含 dashboard/usage/accounts/ops/payment 等页面形状） | 机械 | `ops/observability/probe-admin-ui-api-timing.sh`（经 run-probe 投递；只读 admin API key + curl，无 mutating endpoints） |
@@ -275,7 +275,7 @@ env 契约（脚本 header 是 ground truth）：
 | `LIMIT` | 500 | `usage_logs` 行数上限（`ORDER BY ul.id DESC`；与 `WINDOW_MINUTES` 叠加时先时间过滤再 limit） |
 | `SINCE` | 48h | `docker logs tokenkey --since` 窗口 |
 | `WINDOW_MINUTES` | （空） | 正整数时：`usage_logs` 与 `ops_system_logs` 仅查 `now() - interval 'N minutes'` |
-| `CONTAINER` | tokenkey | Docker 容器名 |
+| `CONTAINER` | auto | Docker 容器名；auto 按 active-color 解析 tokenkey-blue/green，再回退 legacy tokenkey |
 
 输出 schema 要点：
 

--- a/backend/internal/repository/ops_repo_alerts.go
+++ b/backend/internal/repository/ops_repo_alerts.go
@@ -7,9 +7,33 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
+
+const opsAlertEventSelectColumns = `
+  id,
+  COALESCE(rule_id, 0),
+  COALESCE(severity, ''),
+  COALESCE(status, ''),
+  COALESCE(title, ''),
+  COALESCE(description, ''),
+  metric_value,
+  threshold_value,
+  dimensions,
+  fired_at,
+  resolved_at,
+  email_sent,
+  COALESCE(feishu_firing_sent, false),
+  feishu_firing_sent_at,
+  COALESCE(feishu_firing_status, ''),
+  COALESCE(feishu_firing_error, ''),
+  COALESCE(feishu_recovery_sent, false),
+  feishu_recovery_sent_at,
+  COALESCE(feishu_recovery_status, ''),
+  COALESCE(feishu_recovery_error, ''),
+  created_at`
 
 func (r *opsRepository) ListAlertRules(ctx context.Context) ([]*service.OpsAlertRule, error) {
 	if r == nil || r.db == nil {
@@ -338,20 +362,7 @@ func (r *opsRepository) ListAlertEvents(ctx context.Context, filter *service.Ops
 	limitArg := "$" + itoa(len(args))
 
 	q := `
-SELECT
-  id,
-  COALESCE(rule_id, 0),
-  COALESCE(severity, ''),
-  COALESCE(status, ''),
-  COALESCE(title, ''),
-  COALESCE(description, ''),
-  metric_value,
-  threshold_value,
-  dimensions,
-  fired_at,
-  resolved_at,
-  email_sent,
-  created_at
+SELECT` + opsAlertEventSelectColumns + `
 FROM ops_alert_events
 ` + where + `
 ORDER BY fired_at DESC, id DESC
@@ -365,47 +376,11 @@ LIMIT ` + limitArg
 
 	out := []*service.OpsAlertEvent{}
 	for rows.Next() {
-		var ev service.OpsAlertEvent
-		var metricValue sql.NullFloat64
-		var thresholdValue sql.NullFloat64
-		var dimensionsRaw []byte
-		var resolvedAt sql.NullTime
-		if err := rows.Scan(
-			&ev.ID,
-			&ev.RuleID,
-			&ev.Severity,
-			&ev.Status,
-			&ev.Title,
-			&ev.Description,
-			&metricValue,
-			&thresholdValue,
-			&dimensionsRaw,
-			&ev.FiredAt,
-			&resolvedAt,
-			&ev.EmailSent,
-			&ev.CreatedAt,
-		); err != nil {
+		ev, err := scanOpsAlertEvent(rows)
+		if err != nil {
 			return nil, err
 		}
-		if metricValue.Valid {
-			v := metricValue.Float64
-			ev.MetricValue = &v
-		}
-		if thresholdValue.Valid {
-			v := thresholdValue.Float64
-			ev.ThresholdValue = &v
-		}
-		if resolvedAt.Valid {
-			v := resolvedAt.Time
-			ev.ResolvedAt = &v
-		}
-		if len(dimensionsRaw) > 0 && string(dimensionsRaw) != "null" {
-			var decoded map[string]any
-			if err := json.Unmarshal(dimensionsRaw, &decoded); err == nil {
-				ev.Dimensions = decoded
-			}
-		}
-		out = append(out, &ev)
+		out = append(out, ev)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -422,20 +397,7 @@ func (r *opsRepository) GetAlertEventByID(ctx context.Context, eventID int64) (*
 	}
 
 	q := `
-SELECT
-  id,
-  COALESCE(rule_id, 0),
-  COALESCE(severity, ''),
-  COALESCE(status, ''),
-  COALESCE(title, ''),
-  COALESCE(description, ''),
-  metric_value,
-  threshold_value,
-  dimensions,
-  fired_at,
-  resolved_at,
-  email_sent,
-  created_at
+SELECT` + opsAlertEventSelectColumns + `
 FROM ops_alert_events
 WHERE id = $1`
 
@@ -459,20 +421,7 @@ func (r *opsRepository) GetActiveAlertEvent(ctx context.Context, ruleID int64) (
 	}
 
 	q := `
-SELECT
-  id,
-  COALESCE(rule_id, 0),
-  COALESCE(severity, ''),
-  COALESCE(status, ''),
-  COALESCE(title, ''),
-  COALESCE(description, ''),
-  metric_value,
-  threshold_value,
-  dimensions,
-  fired_at,
-  resolved_at,
-  email_sent,
-  created_at
+SELECT` + opsAlertEventSelectColumns + `
 FROM ops_alert_events
 WHERE rule_id = $1 AND status = $2
 ORDER BY fired_at DESC
@@ -498,20 +447,7 @@ func (r *opsRepository) GetLatestAlertEvent(ctx context.Context, ruleID int64) (
 	}
 
 	q := `
-SELECT
-  id,
-  COALESCE(rule_id, 0),
-  COALESCE(severity, ''),
-  COALESCE(status, ''),
-  COALESCE(title, ''),
-  COALESCE(description, ''),
-  metric_value,
-  threshold_value,
-  dimensions,
-  fired_at,
-  resolved_at,
-  email_sent,
-  created_at
+SELECT` + opsAlertEventSelectColumns + `
 FROM ops_alert_events
 WHERE rule_id = $1
 ORDER BY fired_at DESC
@@ -558,20 +494,7 @@ INSERT INTO ops_alert_events (
 ) VALUES (
   $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,NOW()
 )
-RETURNING
-  id,
-  COALESCE(rule_id, 0),
-  COALESCE(severity, ''),
-  COALESCE(status, ''),
-  COALESCE(title, ''),
-  COALESCE(description, ''),
-  metric_value,
-  threshold_value,
-  dimensions,
-  fired_at,
-  resolved_at,
-  email_sent,
-  created_at`
+RETURNING` + opsAlertEventSelectColumns
 
 	row := r.db.QueryRowContext(
 		ctx,
@@ -621,6 +544,68 @@ func (r *opsRepository) UpdateAlertEventEmailSent(ctx context.Context, eventID i
 	}
 
 	_, err := r.db.ExecContext(ctx, "UPDATE ops_alert_events SET email_sent = $2 WHERE id = $1", eventID, emailSent)
+	return err
+}
+
+func (r *opsRepository) UpdateAlertEventFeishuDelivery(ctx context.Context, eventID int64, phase string, sent bool, status string, errMessage string, sentAt *time.Time) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("nil ops repository")
+	}
+	if eventID <= 0 {
+		return fmt.Errorf("invalid event id")
+	}
+	phase = strings.TrimSpace(phase)
+	status = truncateOpsAlertFeishuDeliveryString(strings.TrimSpace(status), 128)
+	if status == "" {
+		return fmt.Errorf("invalid feishu status")
+	}
+	errMessage = truncateOpsAlertFeishuDeliveryString(strings.TrimSpace(errMessage), 2048)
+
+	var q string
+	switch phase {
+	case service.OpsAlertFeishuPhaseFiring:
+		q = `
+UPDATE ops_alert_events
+SET
+  feishu_firing_sent = COALESCE(feishu_firing_sent, false) OR $2,
+  feishu_firing_sent_at = CASE
+    WHEN $2 THEN COALESCE($5::timestamptz, NOW())
+    WHEN $5::timestamptz IS NOT NULL THEN $5::timestamptz
+    ELSE feishu_firing_sent_at
+  END,
+  feishu_firing_status = CASE
+    WHEN COALESCE(feishu_firing_sent, false) AND NOT $2 THEN feishu_firing_status
+    ELSE $3
+  END,
+  feishu_firing_error = CASE
+    WHEN COALESCE(feishu_firing_sent, false) AND NOT $2 THEN feishu_firing_error
+    ELSE $4
+  END
+WHERE id = $1`
+	case service.OpsAlertFeishuPhaseRecovery:
+		q = `
+UPDATE ops_alert_events
+SET
+  feishu_recovery_sent = COALESCE(feishu_recovery_sent, false) OR $2,
+  feishu_recovery_sent_at = CASE
+    WHEN $2 THEN COALESCE($5::timestamptz, NOW())
+    WHEN $5::timestamptz IS NOT NULL THEN $5::timestamptz
+    ELSE feishu_recovery_sent_at
+  END,
+  feishu_recovery_status = CASE
+    WHEN COALESCE(feishu_recovery_sent, false) AND NOT $2 THEN feishu_recovery_status
+    ELSE $3
+  END,
+  feishu_recovery_error = CASE
+    WHEN COALESCE(feishu_recovery_sent, false) AND NOT $2 THEN feishu_recovery_error
+    ELSE $4
+  END
+WHERE id = $1`
+	default:
+		return fmt.Errorf("invalid feishu phase")
+	}
+
+	_, err := r.db.ExecContext(ctx, q, eventID, sent, status, errMessage, opsNullTime(sentAt))
 	return err
 }
 
@@ -749,6 +734,8 @@ func scanOpsAlertEvent(row opsAlertEventRow) (*service.OpsAlertEvent, error) {
 	var thresholdValue sql.NullFloat64
 	var dimensionsRaw []byte
 	var resolvedAt sql.NullTime
+	var feishuFiringSentAt sql.NullTime
+	var feishuRecoverySentAt sql.NullTime
 
 	if err := row.Scan(
 		&ev.ID,
@@ -763,6 +750,14 @@ func scanOpsAlertEvent(row opsAlertEventRow) (*service.OpsAlertEvent, error) {
 		&ev.FiredAt,
 		&resolvedAt,
 		&ev.EmailSent,
+		&ev.FeishuFiringSent,
+		&feishuFiringSentAt,
+		&ev.FeishuFiringStatus,
+		&ev.FeishuFiringError,
+		&ev.FeishuRecoverySent,
+		&feishuRecoverySentAt,
+		&ev.FeishuRecoveryStatus,
+		&ev.FeishuRecoveryError,
 		&ev.CreatedAt,
 	); err != nil {
 		return nil, err
@@ -778,6 +773,14 @@ func scanOpsAlertEvent(row opsAlertEventRow) (*service.OpsAlertEvent, error) {
 	if resolvedAt.Valid {
 		v := resolvedAt.Time
 		ev.ResolvedAt = &v
+	}
+	if feishuFiringSentAt.Valid {
+		v := feishuFiringSentAt.Time
+		ev.FeishuFiringSentAt = &v
+	}
+	if feishuRecoverySentAt.Valid {
+		v := feishuRecoverySentAt.Time
+		ev.FeishuRecoverySentAt = &v
 	}
 	if len(dimensionsRaw) > 0 && string(dimensionsRaw) != "null" {
 		var decoded map[string]any
@@ -836,6 +839,20 @@ func buildOpsAlertEventsWhere(filter *service.OpsAlertEventFilter) (string, []an
 	}
 
 	return "WHERE " + strings.Join(clauses, " AND "), args
+}
+
+func truncateOpsAlertFeishuDeliveryString(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	if len(s) <= max {
+		return s
+	}
+	cut := s[:max]
+	for len(cut) > 0 && !utf8.ValidString(cut) {
+		cut = cut[:len(cut)-1]
+	}
+	return cut
 }
 
 func opsNullJSONMap(v map[string]any) (any, error) {

--- a/backend/internal/service/ops_alert_models.go
+++ b/backend/internal/service/ops_alert_models.go
@@ -19,6 +19,14 @@ const (
 	OpsAlertMetricRoutingCapacityRejectionCount = "routing_capacity_rejection_count"
 )
 
+const (
+	OpsAlertFeishuPhaseFiring   = "firing"
+	OpsAlertFeishuPhaseRecovery = "recovery"
+
+	OpsAlertFeishuStatusSent   = "sent"
+	OpsAlertFeishuStatusFailed = "failed"
+)
+
 type OpsAlertRule struct {
 	ID          int64  `json:"id"`
 	Name        string `json:"name"`
@@ -63,6 +71,15 @@ type OpsAlertEvent struct {
 
 	EmailSent bool      `json:"email_sent"`
 	CreatedAt time.Time `json:"created_at"`
+
+	FeishuFiringSent     bool       `json:"feishu_firing_sent"`
+	FeishuFiringSentAt   *time.Time `json:"feishu_firing_sent_at,omitempty"`
+	FeishuFiringStatus   string     `json:"feishu_firing_status,omitempty"`
+	FeishuFiringError    string     `json:"feishu_firing_error,omitempty"`
+	FeishuRecoverySent   bool       `json:"feishu_recovery_sent"`
+	FeishuRecoverySentAt *time.Time `json:"feishu_recovery_sent_at,omitempty"`
+	FeishuRecoveryStatus string     `json:"feishu_recovery_status,omitempty"`
+	FeishuRecoveryError  string     `json:"feishu_recovery_error,omitempty"`
 }
 
 type OpsAlertSilence struct {

--- a/backend/internal/service/ops_alert_notifications_tk_feishu.go
+++ b/backend/internal/service/ops_alert_notifications_tk_feishu.go
@@ -100,17 +100,25 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertFeishu(ctx context.Context, run
 		return false
 	}
 	if !shouldSendOpsAlertToFeishu(rule, event) {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseFiring, false, "skip_severity_or_status", "", nil)
 		return false
 	}
 	cfg, err := s.opsService.GetEmailNotificationConfig(ctx)
-	if err != nil || cfg == nil || !cfg.Feishu.Enabled {
+	if err != nil {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseFiring, false, OpsAlertFeishuStatusFailed, err.Error(), nil)
+		return false
+	}
+	if cfg == nil || !cfg.Feishu.Enabled {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseFiring, false, "skip_config_disabled", "", nil)
 		return false
 	}
 	if strings.TrimSpace(cfg.Feishu.WebhookURL) == "" {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseFiring, false, "skip_webhook_missing", "", nil)
 		return false
 	}
 	if runtimeCfg != nil && runtimeCfg.Silencing.Enabled {
 		if isOpsAlertSilenced(time.Now().UTC(), rule, event, runtimeCfg.Silencing) {
+			s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseFiring, false, "skip_silenced", "", nil)
 			return false
 		}
 	}
@@ -120,6 +128,7 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertFeishu(ctx context.Context, run
 		s.feishuState = state
 	}
 	if !state.shouldSend(rule, event, cfg.Feishu) {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseFiring, false, "skip_cooldown_or_rate_limited", "", nil)
 		return false
 	}
 	notifier := state.notifier
@@ -135,9 +144,17 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertFeishu(ctx context.Context, run
 		frontendURL = s.cfg.Server.FrontendURL
 	}
 	if err := notifier.sendAlert(ctx, cfg.Feishu, frontendURL, rule, event); err != nil {
-		logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] feishu alert send failed event_id=%d rule_id=%d error=%s", event.ID, rule.ID, err.Error())
+		errMessage := sanitizeFeishuWebhookError(err, cfg.Feishu.WebhookURL)
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseFiring, false, OpsAlertFeishuStatusFailed, errMessage, nil)
+		logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] feishu alert send failed event_id=%d rule_id=%d error=%s", event.ID, rule.ID, errMessage)
 		return false
 	}
+	sentAt := time.Now().UTC()
+	s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseFiring, true, OpsAlertFeishuStatusSent, "", &sentAt)
+	event.FeishuFiringSent = true
+	event.FeishuFiringSentAt = &sentAt
+	event.FeishuFiringStatus = OpsAlertFeishuStatusSent
+	event.FeishuFiringError = ""
 	state.markSent(rule, event)
 	state.markFiringDelivered(event)
 	return true
@@ -148,20 +165,29 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertFeishuRecovery(ctx context.Cont
 		return false
 	}
 	if s.isEdgeNode() && isEdgeSuppressedAlertRule(rule) {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, "skip_severity_or_status", "", nil)
 		return false
 	}
 	if !shouldSendOpsAlertFeishuRecovery(rule, event) {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, "skip_severity_or_status", "", nil)
 		return false
 	}
 	cfg, err := s.opsService.GetEmailNotificationConfig(ctx)
-	if err != nil || cfg == nil || !cfg.Feishu.Enabled {
+	if err != nil {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, OpsAlertFeishuStatusFailed, err.Error(), nil)
+		return false
+	}
+	if cfg == nil || !cfg.Feishu.Enabled {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, "skip_config_disabled", "", nil)
 		return false
 	}
 	if strings.TrimSpace(cfg.Feishu.WebhookURL) == "" {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, "skip_webhook_missing", "", nil)
 		return false
 	}
 	if runtimeCfg != nil && runtimeCfg.Silencing.Enabled {
 		if isOpsAlertSilenced(time.Now().UTC(), rule, event, runtimeCfg.Silencing) {
+			s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, "skip_silenced", "", nil)
 			return false
 		}
 	}
@@ -170,7 +196,12 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertFeishuRecovery(ctx context.Cont
 		state = newOpsFeishuNotificationState()
 		s.feishuState = state
 	}
+	if !state.hasFiringDelivered(event) {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, "skip_no_firing_card", "", nil)
+		return false
+	}
 	if !state.shouldSendRecovery(rule, event) {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, "skip_cooldown_or_rate_limited", "", nil)
 		return false
 	}
 	notifier := state.notifier
@@ -183,11 +214,33 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertFeishuRecovery(ctx context.Cont
 	}
 	current := currentMetricValue
 	if err := notifier.sendRecovery(ctx, cfg.Feishu, frontendURL, rule, event, &current); err != nil {
-		logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] feishu recovery send failed event_id=%d rule_id=%d error=%s", event.ID, rule.ID, err.Error())
+		errMessage := sanitizeFeishuWebhookError(err, cfg.Feishu.WebhookURL)
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, OpsAlertFeishuStatusFailed, errMessage, nil)
+		logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] feishu recovery send failed event_id=%d rule_id=%d error=%s", event.ID, rule.ID, errMessage)
 		return false
 	}
+	sentAt := time.Now().UTC()
+	s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, true, OpsAlertFeishuStatusSent, "", &sentAt)
+	event.FeishuRecoverySent = true
+	event.FeishuRecoverySentAt = &sentAt
+	event.FeishuRecoveryStatus = OpsAlertFeishuStatusSent
+	event.FeishuRecoveryError = ""
 	state.markRecoverySent(rule, event)
 	return true
+}
+
+func (s *OpsAlertEvaluatorService) recordAlertFeishuDelivery(ctx context.Context, event *OpsAlertEvent, phase string, sent bool, status string, errMessage string, sentAt *time.Time) {
+	if s == nil || s.opsService == nil || s.opsService.opsRepo == nil || event == nil || event.ID <= 0 {
+		return
+	}
+	status = truncateString(strings.TrimSpace(status), 128)
+	if status == "" {
+		return
+	}
+	errMessage = truncateString(strings.TrimSpace(errMessage), 2048)
+	if err := s.opsService.UpdateAlertEventFeishuDelivery(ctx, event.ID, phase, sent, status, errMessage, sentAt); err != nil {
+		logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] feishu delivery status update failed event_id=%d phase=%s status=%s error=%s", event.ID, phase, status, err.Error())
+	}
 }
 
 func shouldSendOpsAlertToFeishu(rule *OpsAlertRule, event *OpsAlertEvent) bool {
@@ -225,6 +278,9 @@ func opsAlertFeishuSeverityAllowed(rule *OpsAlertRule, event *OpsAlertEvent) boo
 
 func (s *opsFeishuNotificationState) shouldSend(rule *OpsAlertRule, event *OpsAlertEvent, cfg OpsFeishuAlertConfig) bool {
 	if s == nil || rule == nil || event == nil {
+		return false
+	}
+	if event.FeishuFiringSent {
 		return false
 	}
 	now := time.Now().UTC()
@@ -275,8 +331,12 @@ func (s *opsFeishuNotificationState) shouldSendRecovery(rule *OpsAlertRule, even
 	if s == nil || rule == nil || event == nil || event.ID <= 0 {
 		return false
 	}
+	if event.FeishuRecoverySent {
+		return false
+	}
 	s.mu.Lock()
 	_, paired := s.firedFeishuEventIDs[event.ID]
+	paired = paired || event.FeishuFiringSent
 	if !paired {
 		s.mu.Unlock()
 		return false
@@ -291,6 +351,19 @@ func (s *opsFeishuNotificationState) shouldSendRecovery(rule *OpsAlertRule, even
 		s.limiter = newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour)
 	}
 	return s.limiter.Allow(time.Now().UTC())
+}
+
+func (s *opsFeishuNotificationState) hasFiringDelivered(event *OpsAlertEvent) bool {
+	if s == nil || event == nil || event.ID <= 0 {
+		return false
+	}
+	if event.FeishuFiringSent {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, paired := s.firedFeishuEventIDs[event.ID]
+	return paired
 }
 
 func (s *opsFeishuNotificationState) markRecoverySent(rule *OpsAlertRule, event *OpsAlertEvent) {

--- a/backend/internal/service/ops_alerts.go
+++ b/backend/internal/service/ops_alerts.go
@@ -230,3 +230,25 @@ func (s *OpsService) UpdateAlertEventEmailSent(ctx context.Context, eventID int6
 	}
 	return s.opsRepo.UpdateAlertEventEmailSent(ctx, eventID, emailSent)
 }
+
+func (s *OpsService) UpdateAlertEventFeishuDelivery(ctx context.Context, eventID int64, phase string, sent bool, status string, errMessage string, sentAt *time.Time) error {
+	if err := s.RequireMonitoringEnabled(ctx); err != nil {
+		return err
+	}
+	if s.opsRepo == nil {
+		return infraerrors.ServiceUnavailable("OPS_REPO_UNAVAILABLE", "Ops repository not available")
+	}
+	if eventID <= 0 {
+		return infraerrors.BadRequest("INVALID_EVENT_ID", "invalid event id")
+	}
+	phase = strings.TrimSpace(phase)
+	if phase != OpsAlertFeishuPhaseFiring && phase != OpsAlertFeishuPhaseRecovery {
+		return infraerrors.BadRequest("INVALID_FEISHU_PHASE", "invalid feishu phase")
+	}
+	status = truncateString(strings.TrimSpace(status), 128)
+	if status == "" {
+		return infraerrors.BadRequest("INVALID_FEISHU_STATUS", "invalid feishu status")
+	}
+	errMessage = truncateString(strings.TrimSpace(errMessage), 2048)
+	return s.opsRepo.UpdateAlertEventFeishuDelivery(ctx, eventID, phase, sent, status, errMessage, sentAt)
+}

--- a/backend/internal/service/ops_feishu_alerts_tk_test.go
+++ b/backend/internal/service/ops_feishu_alerts_tk_test.go
@@ -24,6 +24,15 @@ type recordingFeishuHTTPDoer struct {
 	bodies []string
 }
 
+type recordedFeishuDelivery struct {
+	eventID    int64
+	phase      string
+	sent       bool
+	status     string
+	errMessage string
+	sentAt     *time.Time
+}
+
 func (d *recordingFeishuHTTPDoer) Do(req *http.Request) (*http.Response, error) {
 	d.calls++
 	if req.Body != nil {
@@ -295,6 +304,83 @@ func TestMaybeSendAlertFeishuAllowsClientVisibleP1(t *testing.T) {
 	require.Contains(t, doer.bodies[0], "**根因在哪**")
 }
 
+func TestMaybeSendAlertFeishuRecordsFiringDeliveryStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sent", func(t *testing.T) {
+		t.Parallel()
+
+		records := []recordedFeishuDelivery{}
+		repo := &opsRepoMock{
+			UpdateAlertEventFeishuDeliveryFn: func(ctx context.Context, eventID int64, phase string, sent bool, status string, errMessage string, sentAt *time.Time) error {
+				records = append(records, recordedFeishuDelivery{eventID: eventID, phase: phase, sent: sent, status: status, errMessage: errMessage, sentAt: sentAt})
+				return nil
+			},
+		}
+		doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+		svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 3, CooldownSeconds: 3600}, doer)
+		svc.opsService.opsRepo = repo
+
+		event := testOpsFeishuEvent(11)
+		require.True(t, svc.maybeSendAlertFeishu(context.Background(), nil, testOpsFeishuRule(), event))
+		require.Len(t, records, 1)
+		require.Equal(t, event.ID, records[0].eventID)
+		require.Equal(t, OpsAlertFeishuPhaseFiring, records[0].phase)
+		require.True(t, records[0].sent)
+		require.Equal(t, OpsAlertFeishuStatusSent, records[0].status)
+		require.Empty(t, records[0].errMessage)
+		require.NotNil(t, records[0].sentAt)
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		t.Parallel()
+
+		records := []recordedFeishuDelivery{}
+		repo := &opsRepoMock{
+			UpdateAlertEventFeishuDeliveryFn: func(ctx context.Context, eventID int64, phase string, sent bool, status string, errMessage string, sentAt *time.Time) error {
+				records = append(records, recordedFeishuDelivery{eventID: eventID, phase: phase, sent: sent, status: status, errMessage: errMessage, sentAt: sentAt})
+				return nil
+			},
+		}
+		doer := &recordingFeishuHTTPDoer{err: errors.New("Post \"https://open.feishu.cn/open-apis/bot/v2/hook/raw-token\": dial tcp failed")}
+		svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/raw-token", RateLimitPerHour: 3, CooldownSeconds: 3600}, doer)
+		svc.opsService.opsRepo = repo
+
+		require.False(t, svc.maybeSendAlertFeishu(context.Background(), nil, testOpsFeishuRule(), testOpsFeishuEvent(12)))
+		require.Len(t, records, 1)
+		require.Equal(t, OpsAlertFeishuPhaseFiring, records[0].phase)
+		require.False(t, records[0].sent)
+		require.Equal(t, OpsAlertFeishuStatusFailed, records[0].status)
+		require.Nil(t, records[0].sentAt)
+		require.NotContains(t, records[0].errMessage, "raw-token")
+		require.Contains(t, records[0].errMessage, "https://open.feishu.cn/<redacted>")
+	})
+
+	t.Run("config disabled", func(t *testing.T) {
+		t.Parallel()
+
+		records := []recordedFeishuDelivery{}
+		repo := &opsRepoMock{
+			UpdateAlertEventFeishuDeliveryFn: func(ctx context.Context, eventID int64, phase string, sent bool, status string, errMessage string, sentAt *time.Time) error {
+				records = append(records, recordedFeishuDelivery{eventID: eventID, phase: phase, sent: sent, status: status, errMessage: errMessage, sentAt: sentAt})
+				return nil
+			},
+		}
+		doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+		svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: false}, doer)
+		svc.opsService.opsRepo = repo
+
+		require.False(t, svc.maybeSendAlertFeishu(context.Background(), nil, testOpsFeishuRule(), testOpsFeishuEvent(13)))
+		require.Equal(t, 0, doer.calls)
+		require.Len(t, records, 1)
+		require.Equal(t, OpsAlertFeishuPhaseFiring, records[0].phase)
+		require.False(t, records[0].sent)
+		require.Equal(t, "skip_config_disabled", records[0].status)
+		require.Empty(t, records[0].errMessage)
+		require.Nil(t, records[0].sentAt)
+	})
+}
+
 func TestBuildOpsFeishuClientVisibleTextOmitsScopeAndWrapsBreakdowns(t *testing.T) {
 	t.Parallel()
 
@@ -453,11 +539,38 @@ func TestMaybeSendAlertFeishuRecoverySendsClientVisibleP1GreenCard(t *testing.T)
 	require.Contains(t, doer.bodies[1], "**谁受影响**")
 }
 
-func TestMaybeSendAlertFeishuRecoverySkipsWithoutPriorFiringCard(t *testing.T) {
+func TestMaybeSendAlertFeishuRecoveryUsesPersistedFiringDelivery(t *testing.T) {
 	t.Parallel()
 
 	doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
 	svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 3, CooldownSeconds: 3600}, doer)
+	rule := testOpsFeishuRule()
+	resolvedAt := time.Unix(1700000060, 0).UTC()
+	resolved := testOpsFeishuEvent(101)
+	resolved.Status = OpsAlertStatusResolved
+	resolved.ResolvedAt = &resolvedAt
+	resolved.FeishuFiringSent = true
+
+	require.True(t, svc.maybeSendAlertFeishuRecovery(context.Background(), nil, rule, resolved, 0))
+	require.Equal(t, 1, doer.calls)
+	require.Contains(t, doer.bodies[0], "TokenKey P0 告警已恢复")
+	require.True(t, resolved.FeishuRecoverySent)
+	require.Equal(t, OpsAlertFeishuStatusSent, resolved.FeishuRecoveryStatus)
+}
+
+func TestMaybeSendAlertFeishuRecoverySkipsWithoutPriorFiringCard(t *testing.T) {
+	t.Parallel()
+
+	records := []recordedFeishuDelivery{}
+	repo := &opsRepoMock{
+		UpdateAlertEventFeishuDeliveryFn: func(ctx context.Context, eventID int64, phase string, sent bool, status string, errMessage string, sentAt *time.Time) error {
+			records = append(records, recordedFeishuDelivery{eventID: eventID, phase: phase, sent: sent, status: status, errMessage: errMessage, sentAt: sentAt})
+			return nil
+		},
+	}
+	doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+	svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 3, CooldownSeconds: 3600}, doer)
+	svc.opsService.opsRepo = repo
 	rule := testOpsFeishuRule()
 	resolvedAt := time.Unix(1700000060, 0).UTC()
 	resolved := testOpsFeishuEvent(7)
@@ -466,6 +579,10 @@ func TestMaybeSendAlertFeishuRecoverySkipsWithoutPriorFiringCard(t *testing.T) {
 
 	require.False(t, svc.maybeSendAlertFeishuRecovery(context.Background(), nil, rule, resolved, 0))
 	require.Equal(t, 0, doer.calls)
+	require.Len(t, records, 1)
+	require.Equal(t, OpsAlertFeishuPhaseRecovery, records[0].phase)
+	require.False(t, records[0].sent)
+	require.Equal(t, "skip_no_firing_card", records[0].status)
 }
 
 func TestMaybeSendAlertFeishuFailureDoesNotMarkCooldown(t *testing.T) {

--- a/backend/internal/service/ops_port.go
+++ b/backend/internal/service/ops_port.go
@@ -81,6 +81,7 @@ type OpsRepository interface {
 	CreateAlertEvent(ctx context.Context, event *OpsAlertEvent) (*OpsAlertEvent, error)
 	UpdateAlertEventStatus(ctx context.Context, eventID int64, status string, resolvedAt *time.Time) error
 	UpdateAlertEventEmailSent(ctx context.Context, eventID int64, emailSent bool) error
+	UpdateAlertEventFeishuDelivery(ctx context.Context, eventID int64, phase string, sent bool, status string, errMessage string, sentAt *time.Time) error
 
 	// Alert silences
 	CreateAlertSilence(ctx context.Context, input *OpsAlertSilence) (*OpsAlertSilence, error)

--- a/backend/internal/service/ops_repo_mock_test.go
+++ b/backend/internal/service/ops_repo_mock_test.go
@@ -7,13 +7,14 @@ import (
 
 // opsRepoMock is a test-only OpsRepository implementation with optional function hooks.
 type opsRepoMock struct {
-	InsertErrorLogFn              func(ctx context.Context, input *OpsInsertErrorLogInput) (int64, error)
-	BatchInsertErrorLogsFn        func(ctx context.Context, inputs []*OpsInsertErrorLogInput) (int64, error)
-	BatchInsertSystemLogsFn       func(ctx context.Context, inputs []*OpsInsertSystemLogInput) (int64, error)
-	ListSystemLogsFn              func(ctx context.Context, filter *OpsSystemLogFilter) (*OpsSystemLogList, error)
-	DeleteSystemLogsFn            func(ctx context.Context, filter *OpsSystemLogCleanupFilter) (int64, error)
-	InsertSystemLogCleanupAuditFn func(ctx context.Context, input *OpsSystemLogCleanupAudit) error
-	LookupDeletedKeyAuditFn       func(ctx context.Context, key string) (*DeletedKeyAuditResult, error)
+	InsertErrorLogFn                 func(ctx context.Context, input *OpsInsertErrorLogInput) (int64, error)
+	BatchInsertErrorLogsFn           func(ctx context.Context, inputs []*OpsInsertErrorLogInput) (int64, error)
+	BatchInsertSystemLogsFn          func(ctx context.Context, inputs []*OpsInsertSystemLogInput) (int64, error)
+	ListSystemLogsFn                 func(ctx context.Context, filter *OpsSystemLogFilter) (*OpsSystemLogList, error)
+	DeleteSystemLogsFn               func(ctx context.Context, filter *OpsSystemLogCleanupFilter) (int64, error)
+	InsertSystemLogCleanupAuditFn    func(ctx context.Context, input *OpsSystemLogCleanupAudit) error
+	LookupDeletedKeyAuditFn          func(ctx context.Context, key string) (*DeletedKeyAuditResult, error)
+	UpdateAlertEventFeishuDeliveryFn func(ctx context.Context, eventID int64, phase string, sent bool, status string, errMessage string, sentAt *time.Time) error
 }
 
 func (m *opsRepoMock) InsertErrorLog(ctx context.Context, input *OpsInsertErrorLogInput) (int64, error) {
@@ -191,6 +192,13 @@ func (m *opsRepoMock) UpdateAlertEventStatus(ctx context.Context, eventID int64,
 }
 
 func (m *opsRepoMock) UpdateAlertEventEmailSent(ctx context.Context, eventID int64, emailSent bool) error {
+	return nil
+}
+
+func (m *opsRepoMock) UpdateAlertEventFeishuDelivery(ctx context.Context, eventID int64, phase string, sent bool, status string, errMessage string, sentAt *time.Time) error {
+	if m.UpdateAlertEventFeishuDeliveryFn != nil {
+		return m.UpdateAlertEventFeishuDeliveryFn(ctx, eventID, phase, sent, status, errMessage, sentAt)
+	}
 	return nil
 }
 

--- a/backend/migrations/tk_063_ops_alert_feishu_delivery_status.sql
+++ b/backend/migrations/tk_063_ops_alert_feishu_delivery_status.sql
@@ -1,0 +1,19 @@
+-- tk_063_ops_alert_feishu_delivery_status.sql
+--
+-- Persist Feishu delivery evidence per alert event. A single alert event can
+-- produce two independent cards: the firing card and the paired recovery card.
+-- Keeping separate columns avoids the common post-mortem ambiguity where a
+-- resolved event overwrites the firing-card evidence.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+ALTER TABLE ops_alert_events
+  ADD COLUMN IF NOT EXISTS feishu_firing_sent BOOLEAN DEFAULT false,
+  ADD COLUMN IF NOT EXISTS feishu_firing_sent_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS feishu_firing_status TEXT DEFAULT '',
+  ADD COLUMN IF NOT EXISTS feishu_firing_error TEXT DEFAULT '',
+  ADD COLUMN IF NOT EXISTS feishu_recovery_sent BOOLEAN DEFAULT false,
+  ADD COLUMN IF NOT EXISTS feishu_recovery_sent_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS feishu_recovery_status TEXT DEFAULT '',
+  ADD COLUMN IF NOT EXISTS feishu_recovery_error TEXT DEFAULT '';

--- a/ops/observability/probe-alert-config.sh
+++ b/ops/observability/probe-alert-config.sh
@@ -50,3 +50,23 @@ WHERE created_at >= now() - interval '14 days'
 GROUP BY severity, status
 ORDER BY severity, status;
 " 2>/dev/null || echo "(ops_alert_events table missing or schema differs)"
+
+echo "=== recent_alert_events_14d_delivery (latest 50) ==="
+psql -F $'\t' -c "
+SELECT
+  id,
+  fired_at,
+  severity,
+  status,
+  email_sent,
+  feishu_firing_sent,
+  COALESCE(feishu_firing_status, '') AS feishu_firing_status,
+  left(COALESCE(feishu_firing_error, ''), 240) AS feishu_firing_error,
+  feishu_recovery_sent,
+  COALESCE(feishu_recovery_status, '') AS feishu_recovery_status,
+  left(COALESCE(feishu_recovery_error, ''), 240) AS feishu_recovery_error
+FROM ops_alert_events
+WHERE created_at >= now() - interval '14 days'
+ORDER BY fired_at DESC, id DESC
+LIMIT 50;
+" 2>/dev/null || echo "(ops_alert_events feishu delivery columns missing or schema differs)"

--- a/ops/observability/probe-edge-health.sh
+++ b/ops/observability/probe-edge-health.sh
@@ -28,15 +28,54 @@
 #               (For a past burst post-mortem pass e.g. SINCE=15h, then read the
 #                counts as "since N hours ago" — this probe does not slice to an
 #                exact UTC window; for that use parse-access-log.py on a pull.)
-#   CONTAINER   gateway container name. Default tokenkey.
+#   CONTAINER   gateway container name. Default auto. auto resolves
+#               /var/lib/tokenkey/active-color to tokenkey-blue/green and
+#               falls back to the legacy tokenkey container.
+#   ACTIVE_COLOR_FILE
+#               active-color file path for CONTAINER=auto
+#               (default /var/lib/tokenkey/active-color; test seam).
 #
 # Not pipefail (grep -c exits 1 on zero matches and we WANT the 0); set -u only.
 set -u
 
 PLATFORM="${PLATFORM:-anthropic}"
 SINCE="${SINCE:-2h}"
-CONTAINER="${CONTAINER:-tokenkey}"
+CONTAINER_INPUT="${CONTAINER:-auto}"
+ACTIVE_COLOR_FILE="${ACTIVE_COLOR_FILE:-/var/lib/tokenkey/active-color}"
 PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+
+resolve_gateway_container() {
+  local requested="$1"
+  if [ "$requested" != "auto" ]; then
+    printf '%s\n' "$requested"
+    return 0
+  fi
+
+  local color candidate
+  if [ -f "$ACTIVE_COLOR_FILE" ]; then
+    color="$(tr -d '[:space:]' < "$ACTIVE_COLOR_FILE" 2>/dev/null || true)"  # preflight-allow: swallow - unreadable active-color falls back to legacy container
+    case "$color" in
+      blue|green)
+        candidate="tokenkey-$color"
+        if docker inspect "$candidate" >/dev/null 2>&1; then
+          printf '%s\n' "$candidate"
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
+  for candidate in tokenkey tokenkey-blue tokenkey-green; do
+    if docker inspect "$candidate" >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  printf '%s\n' tokenkey
+}
+
+CONTAINER="$(resolve_gateway_container "$CONTAINER_INPUT")"
 
 echo "=== docker ps (tokenkey stack) ==="
 docker ps --filter name=tokenkey --format '{{.Names}}\t{{.Status}}' 2>/dev/null || true  # preflight-allow: swallow — diagnostic header only
@@ -57,6 +96,7 @@ SELECT 'ACCT '||row_to_json(t)::text FROM (
 " 2>&1
 
 echo "=== TRAFFIC (access-log counts over --since $SINCE) ==="
+echo "CONTAINER input=$CONTAINER_INPUT resolved=$CONTAINER"
 LOGF="$(mktemp /tmp/eh_full.XXXXXX)"
 docker logs "$CONTAINER" --since "$SINCE" >"$LOGF" 2>&1 || true  # preflight-allow: swallow — no-logs window is a valid 0-count, not a probe failure
 COMPLETED="$(grep -F 'http request completed' "$LOGF" 2>/dev/null || true)"  # preflight-allow: swallow — grep exit 1 on zero matches is the wanted empty result

--- a/ops/observability/probe-gateway-ua-tls-compare.sh
+++ b/ops/observability/probe-gateway-ua-tls-compare.sh
@@ -6,16 +6,23 @@
 #   LIMIT          rows per source (default 500)
 #   SINCE          docker logs window (default 48h)
 #   WINDOW_MINUTES if set, usage_logs/ops filter to last N minutes (overrides LIMIT ordering scope)
-#   CONTAINER      gateway container (default tokenkey)
+#   CONTAINER      gateway container (default auto). auto resolves
+#                  /var/lib/tokenkey/active-color to tokenkey-blue/green and
+#                  falls back to the legacy tokenkey container.
+#   ACTIVE_COLOR_FILE
+#                  active-color file path for CONTAINER=auto
+#                  (default /var/lib/tokenkey/active-color; test seam).
 set -u
 
 LIMIT="${LIMIT:-500}"
 SINCE="${SINCE:-48h}"
 WINDOW_MINUTES="${WINDOW_MINUTES:-}"
-CONTAINER="${CONTAINER:-tokenkey}"
+CONTAINER="${CONTAINER:-auto}"
+ACTIVE_COLOR_FILE="${ACTIVE_COLOR_FILE:-/var/lib/tokenkey/active-color}"
 
-python3 - "$LIMIT" "$SINCE" "$CONTAINER" "$WINDOW_MINUTES" <<'PY'
+python3 - "$LIMIT" "$SINCE" "$CONTAINER" "$WINDOW_MINUTES" "$ACTIVE_COLOR_FILE" <<'PY'
 import json
+import pathlib
 import re
 import subprocess
 import sys
@@ -23,8 +30,9 @@ from collections import Counter
 
 limit = int(sys.argv[1])
 since = sys.argv[2]
-container = sys.argv[3]
+container_arg = sys.argv[3]
 window_minutes = sys.argv[4].strip() if len(sys.argv) > 4 else ""
+active_color_file = sys.argv[5] if len(sys.argv) > 5 else "/var/lib/tokenkey/active-color"
 time_where_ul = ""
 time_where_ops = ""
 if window_minutes.isdigit() and int(window_minutes) > 0:
@@ -52,6 +60,42 @@ ua_tls_keys = (
     "protocol",
     "client_ip",
 )
+
+
+def docker_inspect_exists(name: str) -> bool:
+    proc = subprocess.run(
+        ["docker", "inspect", name, "--format", "{{.Name}}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def resolve_container(container: str) -> tuple[str, list[str]]:
+    notes: list[str] = []
+    if container != "auto":
+        return container, ["explicit"]
+
+    path = pathlib.Path(active_color_file)
+    if path.is_file():
+        color = path.read_text(encoding="utf-8", errors="ignore").strip()
+        notes.append(f"active-color={color or '<empty>'}")
+        if color in ("blue", "green"):
+            candidate = f"tokenkey-{color}"
+            if docker_inspect_exists(candidate):
+                return candidate, notes + ["active-color container exists"]
+            notes.append(f"{candidate} missing")
+    else:
+        notes.append("active-color missing")
+
+    for candidate in ("tokenkey", "tokenkey-blue", "tokenkey-green"):
+        if docker_inspect_exists(candidate):
+            return candidate, notes + [f"fallback={candidate}"]
+    return "tokenkey", notes + ["fallback=tokenkey-unverified"]
+
+
+container, container_resolution = resolve_container(container_arg)
 
 
 def psql_json(sql: str) -> list[dict]:
@@ -310,7 +354,9 @@ out = {
     "meta": {
         "limit": limit,
         "since": since,
+        "container_input": container_arg,
         "container": container,
+        "container_resolution": container_resolution,
         "window_minutes": int(window_minutes) if window_minutes.isdigit() else None,
     },
     "usage_logs": {

--- a/ops/observability/probe-traffic-logs.sh
+++ b/ops/observability/probe-traffic-logs.sh
@@ -10,7 +10,12 @@
 #                — +2m buffer covers minute boundaries when filtering by completed_at.)
 #   PATH_KEY    path substring required on http-request-completed lines.
 #               Default /v1/messages.
-#   CONTAINER   gateway container name. Default tokenkey.
+#   CONTAINER   gateway container name. Default auto. auto resolves
+#               /var/lib/tokenkey/active-color to tokenkey-blue/green and
+#               falls back to the legacy tokenkey container.
+#   ACTIVE_COLOR_FILE
+#               active-color file path for CONTAINER=auto
+#               (default /var/lib/tokenkey/active-color; test seam).
 #
 # Reports line counts at the end so the caller can detect zero-match patterns
 # (e.g. log-format drift renaming "http request completed" to "http_request_completed").
@@ -20,7 +25,41 @@ set -u
 
 SINCE="${SINCE:-1h}"
 PATH_KEY="${PATH_KEY:-/v1/messages}"
-CONTAINER="${CONTAINER:-tokenkey}"
+CONTAINER_INPUT="${CONTAINER:-auto}"
+ACTIVE_COLOR_FILE="${ACTIVE_COLOR_FILE:-/var/lib/tokenkey/active-color}"
+
+resolve_gateway_container() {
+  local requested="$1"
+  if [ "$requested" != "auto" ]; then
+    printf '%s\n' "$requested"
+    return 0
+  fi
+
+  local color candidate
+  if [ -f "$ACTIVE_COLOR_FILE" ]; then
+    color="$(tr -d '[:space:]' < "$ACTIVE_COLOR_FILE" 2>/dev/null || true)"  # preflight-allow: swallow - unreadable active-color falls back to legacy container
+    case "$color" in
+      blue|green)
+        candidate="tokenkey-$color"
+        if docker inspect "$candidate" >/dev/null 2>&1; then
+          printf '%s\n' "$candidate"
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
+  for candidate in tokenkey tokenkey-blue tokenkey-green; do
+    if docker inspect "$candidate" >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  printf '%s\n' tokenkey
+}
+
+CONTAINER="$(resolve_gateway_container "$CONTAINER_INPUT")"
 
 docker logs "$CONTAINER" --since "$SINCE" 2>&1 \
   | grep -F 'http request completed' \
@@ -32,7 +71,7 @@ docker logs "$CONTAINER" --since "$SINCE" 2>&1 \
 
 ACC=$(wc -l < /tmp/acc.txt)
 SSE=$(wc -l < /tmp/sse.txt)
-echo "probe_traffic_logs container=$CONTAINER since=$SINCE path_key=$PATH_KEY acc_lines=$ACC sse_lines=$SSE"
+echo "probe_traffic_logs container_input=$CONTAINER_INPUT container=$CONTAINER since=$SINCE path_key=$PATH_KEY acc_lines=$ACC sse_lines=$SSE"
 if [ "$ACC" = "0" ] && [ "$SSE" = "0" ]; then
   echo "probe_traffic_logs WARN both files empty — check (a) docker logs uptime vs SINCE, (b) log format drift, (c) container name" >&2
 fi

--- a/ops/observability/test_probe_tail_gateway_logs.py
+++ b/ops/observability/test_probe_tail_gateway_logs.py
@@ -11,17 +11,25 @@ import textwrap
 import unittest
 
 _SCRIPT = pathlib.Path(__file__).resolve().parent / "probe-tail-gateway-logs.sh"
+_SYNTAX_SCRIPTS = (
+    _SCRIPT,
+    pathlib.Path(__file__).resolve().parent / "probe-traffic-logs.sh",
+    pathlib.Path(__file__).resolve().parent / "probe-edge-health.sh",
+    pathlib.Path(__file__).resolve().parent / "probe-gateway-ua-tls-compare.sh",
+)
 
 
 class ProbeTailGatewayLogsTest(unittest.TestCase):
     def test_syntax_clean(self) -> None:
-        proc = subprocess.run(
-            ["bash", "-n", str(_SCRIPT)],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        for script in _SYNTAX_SCRIPTS:
+            with self.subTest(script=script.name):
+                proc = subprocess.run(
+                    ["bash", "-n", str(script)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(proc.returncode, 0, msg=proc.stderr)
 
     def test_auto_container_resolves_active_color(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -178,6 +178,19 @@
       "rationale": "TK companion that keeps Feishu alerting limited to P0 plus the explicit P1 client_visible_failure_count real-user failure exception on prod only (edge nodes suppress both user-visible P0 and client-visible P1 via isEdgeSuppressedAlertRule / isProdOnlyAlertRule), tied to the existing external-notification opt-in, and protected by per-rule/dimension cooldown plus global hourly rate limiting. Paired green recovery cards must fire only after a delivered firing card (firedFeishuEventIDs) and use a separate recovery dedupe key so resolve notifications are not blocked by the firing cooldown. Dropping any anchor turns a low-noise OPC pager into either silence or chat noise. FrontendURL threads the per-node public base URL into the card so prod vs each edge is distinguishable; losing it silently regresses every card back to an unattributable 'overall'."
     },
     {
+      "path": "backend/internal/repository/ops_repo_alerts.go",
+      "must_contain": [
+        "opsAlertEventSelectColumns",
+        "  COALESCE(feishu_firing_sent, false),",
+        "  COALESCE(feishu_recovery_sent, false),",
+        "func (r *opsRepository) UpdateAlertEventFeishuDelivery(",
+        "feishu_firing_sent = COALESCE(feishu_firing_sent, false) OR $2",
+        "case service.OpsAlertFeishuPhaseRecovery:",
+        "&ev.FeishuFiringSent"
+      ],
+      "rationale": "Ops alert Feishu delivery evidence is persisted in alert events so operators can distinguish webhook skips/failures from rule silence and recovery cards can remain paired after a process restart. The repository must keep the nullable migration-safe COALESCE reads plus monotonic sent flags; dropping these anchors compiles cleanly but regresses the original blind spot where a firing event existed with no delivery evidence."
+    },
+    {
       "path": "backend/internal/service/ops_feishu_notifier_tk.go",
       "must_contain": [
         "func sanitizeFeishuWebhook(",


### PR DESCRIPTION
## 摘要
- 在 `ops_alert_events` 持久化 Feishu firing/recovery 投递证据：sent、sent_at、status、error，用于排查“规则触发但飞书未收到”的盲点。
- Feishu 发送链路记录 sent / failed / skip_*，错误信息会脱敏并截断；recovery 绿卡可使用已持久化的 firing delivered 证据，支持进程重启后配对恢复。
- 线上 observability probes 默认 `CONTAINER=auto`，按 blue/green active-color 解析 app 容器，并在 alert config probe 输出最近 Feishu delivery 字段。
- 为 `backend/internal/repository/ops_repo_alerts.go` 增加 `gateway-tk` sentinel，锚住 Feishu delivery 持久化读写语义。

## 风险
- high-risk-anchor：新增数据库迁移已获本轮用户审批；迁移是 nullable additive schema change，读侧 `COALESCE` 兼容旧行，不删除历史数据。
- Feishu delivery 落库是 best-effort；落库失败只记录日志，不阻塞原告警发送路径。
- no-web-impact：本次是 ops 内部观测字段、后端投递状态和 probe 输出，不改变用户 Web 交互。
- sentinel-registry-reviewed / upstream-touch-guarded：触达 upstream-shaped repository/service 文件，已新增 sentinel 覆盖 load-bearing 持久化语义。

## 验证
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `go test -tags unit ./internal/service -run 'OpsFeishu|Alert'`（backend/）
- `go test ./internal/repository -run 'TestInsertSystemMetricsUsesCurrentColumnPlaceholderCount|TestDoesNotExist'`（backend/）
- `python3 -m unittest ops.observability.test_probe_tail_gateway_logs -v`

## 提交
- `75a6d354a` fix(ops): persist Feishu alert delivery evidence no-web-impact

最新提交：`75a6d354a`
