### PR TITLE
fix(admin): 分组操作展示真实错误

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 598,
-  "hash": "fc5fd150ec960f66f0951f534dfe59e15b2f783051224c7a09291161a6772cf0",
+  "hash": "6ba513a70044cda4aeebc599661931b8ad998a8d0ad1c80e06f93027e3f8f1fa",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -3407,6 +3407,7 @@ import GroupRPMOverridesModal from "@/components/admin/group/GroupRPMOverridesMo
 import GroupCapacityBadge from "@/components/common/GroupCapacityBadge.vue";
 import { VueDraggable } from "vue-draggable-plus";
 import { createStableObjectKeyResolver } from "@/utils/stableObjectKey";
+import { extractApiErrorMessage } from "@/utils/apiError";
 import { useKeyedDebouncedSearch } from "@/composables/useKeyedDebouncedSearch";
 import { getPersistedPageSize } from "@/composables/usePersistedPageSize";
 import { usePlatformOptions } from "@/composables/usePlatformOptions";
@@ -4573,7 +4574,7 @@ const handleCreateGroup = async () => {
     }
   } catch (error: any) {
     appStore.showError(
-      error.response?.data?.detail || t("admin.groups.failedToCreate"),
+      extractApiErrorMessage(error, t("admin.groups.failedToCreate")),
     );
     console.error("Error creating group:", error);
     // Don't advance tour on error
@@ -4757,7 +4758,7 @@ const handleUpdateGroup = async () => {
     loadGroups();
   } catch (error: any) {
     appStore.showError(
-      error.response?.data?.detail || t("admin.groups.failedToUpdate"),
+      extractApiErrorMessage(error, t("admin.groups.failedToUpdate")),
     );
     console.error("Error updating group:", error);
   } finally {
@@ -4815,7 +4816,7 @@ const confirmDelete = async () => {
     loadGroups();
   } catch (error: any) {
     appStore.showError(
-      error.response?.data?.detail || t("admin.groups.failedToDelete"),
+      extractApiErrorMessage(error, t("admin.groups.failedToDelete")),
     );
     console.error("Error deleting group:", error);
   }
@@ -4996,7 +4997,7 @@ const saveSortOrder = async () => {
     loadGroups();
   } catch (error: any) {
     appStore.showError(
-      error.response?.data?.detail || t("admin.groups.failedToUpdateSortOrder"),
+      extractApiErrorMessage(error, t("admin.groups.failedToUpdateSortOrder")),
     );
     console.error("Error updating sort order:", error);
   } finally {

--- a/frontend/src/views/admin/__tests__/GroupsView.columnSettings.spec.ts
+++ b/frontend/src/views/admin/__tests__/GroupsView.columnSettings.spec.ts
@@ -8,6 +8,7 @@ const {
   listGroups,
   getAllGroups,
   getModelsListCandidates,
+  createGroupApi,
   getUsageSummary,
   getCapacitySummary,
   listAccounts,
@@ -19,6 +20,7 @@ const {
   listGroups: vi.fn(),
   getAllGroups: vi.fn(),
   getModelsListCandidates: vi.fn(),
+  createGroupApi: vi.fn(),
   getUsageSummary: vi.fn(),
   getCapacitySummary: vi.fn(),
   listAccounts: vi.fn(),
@@ -30,6 +32,8 @@ const {
 
 const messages: Record<string, string> = {
   'admin.groups.columnSettings': 'Column Settings',
+  'admin.groups.createGroup': 'Create Group',
+  'admin.groups.failedToCreate': 'Failed to create group',
   'admin.groups.columns.name': 'Name',
   'admin.groups.columns.platform': 'Platform',
   'admin.groups.columns.billingType': 'Billing Type',
@@ -50,7 +54,7 @@ vi.mock('@/api/admin', () => ({
       getModelsListCandidates,
       getUsageSummary,
       getCapacitySummary,
-      create: vi.fn(),
+      create: createGroupApi,
       update: vi.fn(),
       delete: vi.fn(),
       updateSortOrder: vi.fn(),
@@ -224,6 +228,7 @@ describe('admin GroupsView column settings', () => {
     listGroups.mockReset()
     getAllGroups.mockReset()
     getModelsListCandidates.mockReset()
+    createGroupApi.mockReset()
     getUsageSummary.mockReset()
     getCapacitySummary.mockReset()
     listAccounts.mockReset()
@@ -241,6 +246,7 @@ describe('admin GroupsView column settings', () => {
     })
     getAllGroups.mockResolvedValue([])
     getModelsListCandidates.mockResolvedValue([])
+    createGroupApi.mockResolvedValue(createGroup())
     getUsageSummary.mockResolvedValue([])
     getCapacitySummary.mockResolvedValue([])
     listAccounts.mockResolvedValue({ items: [], total: 0, page: 1, page_size: 20, pages: 0 })
@@ -324,5 +330,24 @@ describe('admin GroupsView column settings', () => {
     await clickColumnToggle(wrapper, 'Capacity')
     expect(getUsageSummary).toHaveBeenCalledTimes(1)
     expect(getCapacitySummary).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the backend create error message instead of the generic fallback', async () => {
+    createGroupApi.mockRejectedValueOnce({
+      status: 400,
+      code: 400,
+      message: 'rate_multiplier must be > 0',
+    })
+    const wrapper = await mountView()
+
+    await wrapper.get('[data-tour="groups-create-btn"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-tour="group-form-name"]').setValue('bad group')
+    await wrapper.get('form#create-group-form').trigger('submit')
+    await flushPromises()
+
+    expect(createGroupApi).toHaveBeenCalledTimes(1)
+    expect(showError).toHaveBeenCalledWith('rate_multiplier must be > 0')
+    expect(showError).not.toHaveBeenCalledWith('Failed to create group')
   })
 })


### PR DESCRIPTION
## 摘要
- 修复分组创建、更新、删除、排序失败时只显示泛化 toast 的问题，统一用 `extractApiErrorMessage` 展示 API client 扁平化错误、后端 detail/message 或网络错误。
- 补充分组创建失败回归测试，确保后端错误信息不会被降级成 `创建分组失败`。
- 刷新 `backend/internal/web/dist/frontend-source.json`，保持内嵌前端发布产物 hash 与当前源码一致。

## 风险
- 低风险：只调整分组页错误提示提取，不改变创建接口 payload 和后端逻辑。
- sentinel-registry-reviewed：本次仅复用既有错误提取工具替换错误展示路径，未新增需要 sentinel anchor 的负载面。

## 验证
- `pnpm --dir frontend test:run src/views/admin/__tests__/GroupsView.columnSettings.spec.ts src/views/admin/__tests__/groupsMessagesDispatch.spec.ts src/views/admin/__tests__/groupsModelsList.spec.ts`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend run build`
- `./scripts/preflight.sh`

## 提交
- `25bd9e8 fix(admin): surface group mutation errors`
- 最新提交：`25bd9e8`