### PR TITLE
fix(admin): 稳定账号操作菜单定位与恢复入口

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 598,
-  "hash": "2fd4d744d17f3b059460d5977fcbc8414895c4518e02de08ae1ac4eff52ac0dd",
+  "hash": "f56a6787c5536418640ec0aa601ed504bc345fb548483281d4dd5fced72fe468",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 598,
-  "hash": "b09dff5c847d520e0592672ce23a8b98e2b7cc89faee34a71c0708b09d8540d7",
+  "hash": "2fd4d744d17f3b059460d5977fcbc8414895c4518e02de08ae1ac4eff52ac0dd",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/admin/account/AccountActionMenu.vue
+++ b/frontend/src/components/admin/account/AccountActionMenu.vue
@@ -86,7 +86,8 @@ const menuStyle = ref<Record<string, string>>({ top: '0px', left: '0px' })
 let positionRaf = 0
 
 const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(value, max))
-const requestPositionFrame = (callback: FrameRequestCallback) => {
+type AnimationFrameHandler = (time: number) => void
+const requestPositionFrame = (callback: AnimationFrameHandler) => {
   if (typeof window.requestAnimationFrame === 'function') {
     return window.requestAnimationFrame(callback)
   }

--- a/frontend/src/components/admin/account/AccountActionMenu.vue
+++ b/frontend/src/components/admin/account/AccountActionMenu.vue
@@ -1,11 +1,12 @@
 <template>
   <Teleport to="body">
-    <div v-if="show && position">
+    <div v-if="show && (position || anchor)">
       <!-- Backdrop: click anywhere outside to close -->
       <div class="fixed inset-0 z-[9998]" @click="emit('close')"></div>
       <div
+        ref="contentRef"
         class="action-menu-content fixed z-[9999] w-52 overflow-hidden rounded-xl bg-white shadow-lg ring-1 ring-black/5 dark:bg-dark-800"
-        :style="{ top: position.top + 'px', left: position.left + 'px' }"
+        :style="menuStyle"
         @click.stop
       >
         <div class="py-1">
@@ -45,8 +46,8 @@
               <Icon name="chart" size="sm" />
               {{ t('admin.accounts.setTierDialog.menuItem') }}
             </button>
-            <div v-if="hasRecoverableState" class="my-1 border-t border-gray-100 dark:border-dark-700"></div>
-            <button v-if="hasRecoverableState" @click.stop.prevent="emitAction('recover-state', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-emerald-600 hover:bg-gray-100 dark:hover:bg-dark-700">
+            <div class="my-1 border-t border-gray-100 dark:border-dark-700"></div>
+            <button @click.stop.prevent="emitAction('recover-state', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-emerald-600 hover:bg-gray-100 dark:hover:bg-dark-700" :title="t('admin.accounts.recoverStateHint')">
               <Icon name="sync" size="sm" />
               {{ t('admin.accounts.recoverState') }}
             </button>
@@ -62,15 +63,89 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch, onUnmounted, nextTick } from 'vue'
+import { computed, watch, onUnmounted, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@/components/icons'
 import type { Account } from '@/types'
 import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
-const props = defineProps<{ show: boolean; account: Account | null; position: { top: number; left: number } | null }>()
+const props = defineProps<{
+  show: boolean
+  account: Account | null
+  position: { top: number; left: number } | null
+  anchor?: HTMLElement | null
+}>()
 const emit = defineEmits(['close', 'test', 'stats', 'schedule', 'reauth', 'refresh-token', 'recover-state', 'reset-quota', 'set-privacy', 'set-tier', 'create-spark-shadow'])
 const { t } = useI18n()
+
+const DEFAULT_MENU_WIDTH = 208
+const DEFAULT_MENU_HEIGHT = 240
+const VIEWPORT_PADDING = 8
+const contentRef = ref<HTMLElement | null>(null)
+const menuStyle = ref<Record<string, string>>({ top: '0px', left: '0px' })
+let positionRaf = 0
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(value, max))
+const requestPositionFrame = (callback: FrameRequestCallback) => {
+  if (typeof window.requestAnimationFrame === 'function') {
+    return window.requestAnimationFrame(callback)
+  }
+  return window.setTimeout(() => callback(window.performance?.now?.() ?? Date.now()), 0)
+}
+const cancelPositionFrame = (handle: number) => {
+  if (typeof window.cancelAnimationFrame === 'function') {
+    window.cancelAnimationFrame(handle)
+    return
+  }
+  window.clearTimeout(handle)
+}
+
+const resolveMenuSize = () => ({
+  width: contentRef.value?.offsetWidth || DEFAULT_MENU_WIDTH,
+  height: contentRef.value?.offsetHeight || DEFAULT_MENU_HEIGHT
+})
+
+const updateMenuPosition = () => {
+  if (!props.show) return
+  const { width, height } = resolveMenuSize()
+  const viewportWidth = window.innerWidth
+  const viewportHeight = window.innerHeight
+
+  let left = props.position?.left ?? VIEWPORT_PADDING
+  let top = props.position?.top ?? VIEWPORT_PADDING
+
+  if (props.anchor?.isConnected) {
+    const rect = props.anchor.getBoundingClientRect()
+    if (viewportWidth < 768) {
+      left = rect.left + rect.width / 2 - width / 2
+    } else {
+      left = rect.right - width
+    }
+    top = rect.bottom + 4
+
+    if (top + height > viewportHeight - VIEWPORT_PADDING) {
+      top = rect.top - height - 4
+    }
+  }
+
+  const maxLeft = Math.max(VIEWPORT_PADDING, viewportWidth - width - VIEWPORT_PADDING)
+  const maxTop = Math.max(VIEWPORT_PADDING, viewportHeight - height - VIEWPORT_PADDING)
+  menuStyle.value = {
+    left: `${clamp(left, VIEWPORT_PADDING, maxLeft)}px`,
+    top: `${clamp(top, VIEWPORT_PADDING, maxTop)}px`
+  }
+}
+
+const schedulePositionUpdate = () => {
+  if (!props.show) return
+  void nextTick(() => {
+    if (positionRaf) cancelPositionFrame(positionRaf)
+    positionRaf = requestPositionFrame(() => {
+      positionRaf = 0
+      updateMenuPosition()
+    })
+  })
+}
 
 type MenuActionEvent =
   | 'test'
@@ -92,24 +167,6 @@ const emitAction = (event: MenuActionEvent, account: Account) => {
   emit(event, account)
   void nextTick(() => emit('close'))
 }
-const isRateLimited = computed(() => {
-  if (props.account?.rate_limit_reset_at && new Date(props.account.rate_limit_reset_at) > new Date()) {
-    return true
-  }
-  const modelLimits = (props.account?.extra as Record<string, unknown> | undefined)?.model_rate_limits as
-    | Record<string, { rate_limit_reset_at: string }>
-    | undefined
-  if (modelLimits) {
-    const now = new Date()
-    return Object.values(modelLimits).some(info => new Date(info.rate_limit_reset_at) > now)
-  }
-  return false
-})
-const isOverloaded = computed(() => props.account?.overload_until && new Date(props.account.overload_until) > new Date())
-const isTempUnschedulable = computed(() => props.account?.temp_unschedulable_until && new Date(props.account.temp_unschedulable_until) > new Date())
-const hasRecoverableState = computed(() => {
-  return props.account?.status === 'error' || Boolean(isRateLimited.value) || Boolean(isOverloaded.value) || Boolean(isTempUnschedulable.value)
-})
 const isAntigravityOAuth = computed(() => props.account?.platform === PLATFORM_ANTIGRAVITY && props.account?.type === 'oauth')
 const isOpenAIOAuth = computed(() => props.account?.platform === PLATFORM_OPENAI && props.account?.type === 'oauth')
 // 影子账号(链接型,持 parent_account_id)不持凭据、type 不可变,凭据/隐私类操作对其无效。
@@ -146,14 +203,25 @@ watch(
   (visible) => {
     if (visible) {
       window.addEventListener('keydown', handleKeydown)
+      window.addEventListener('resize', schedulePositionUpdate)
+      schedulePositionUpdate()
     } else {
       window.removeEventListener('keydown', handleKeydown)
+      window.removeEventListener('resize', schedulePositionUpdate)
     }
   },
   { immediate: true }
 )
 
+watch(
+  () => [props.anchor, props.position?.top, props.position?.left, props.account?.id],
+  schedulePositionUpdate,
+  { flush: 'post' }
+)
+
 onUnmounted(() => {
+  if (positionRaf) cancelPositionFrame(positionRaf)
   window.removeEventListener('keydown', handleKeydown)
+  window.removeEventListener('resize', schedulePositionUpdate)
 })
 </script>

--- a/frontend/src/components/admin/account/__tests__/AccountActionMenu.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountActionMenu.spec.ts
@@ -125,7 +125,7 @@ describe('AccountActionMenu — anchored positioning', () => {
 
     const originalRaf = window.requestAnimationFrame
     const originalCancelRaf = window.cancelAnimationFrame
-    window.requestAnimationFrame = ((cb: FrameRequestCallback) => window.setTimeout(() => cb(Date.now()), 0)) as typeof window.requestAnimationFrame
+    window.requestAnimationFrame = ((cb: (time: number) => void) => window.setTimeout(() => cb(Date.now()), 0)) as typeof window.requestAnimationFrame
     window.cancelAnimationFrame = ((handle: number) => window.clearTimeout(handle)) as typeof window.cancelAnimationFrame
 
     const wrapper = mountMenu(

--- a/frontend/src/components/admin/account/__tests__/AccountActionMenu.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountActionMenu.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import AccountActionMenu from '../AccountActionMenu.vue'
 import type { Account } from '@/types'
@@ -20,12 +20,13 @@ function makeAccount(partial: Partial<Account>): Account {
   } as Account
 }
 
-function mountMenu(account: Account) {
+function mountMenu(account: Account, extraProps: Record<string, unknown> = {}) {
   return mount(AccountActionMenu, {
     props: {
       show: true,
       account,
-      position: { top: 0, left: 0 }
+      position: { top: 0, left: 0 },
+      ...extraProps
     },
     global: {
       // Render Teleport content inline so find() can see it; stub Icon.
@@ -36,7 +37,20 @@ function mountMenu(account: Account) {
 
 function hasTierItem(account: Account): boolean {
   const wrapper = mountMenu(account)
-  return wrapper.findAll('button').some(b => b.text().includes(TIER_ITEM_KEY))
+  try {
+    return wrapper.findAll('button').some(b => b.text().includes(TIER_ITEM_KEY))
+  } finally {
+    wrapper.unmount()
+  }
+}
+
+function hasRecoverStateItem(account: Account): boolean {
+  const wrapper = mountMenu(account)
+  try {
+    return wrapper.findAll('button').some(b => b.text().includes('admin.accounts.recoverState'))
+  } finally {
+    wrapper.unmount()
+  }
 }
 
 describe('AccountActionMenu — 设置 Tier gating', () => {
@@ -66,5 +80,74 @@ describe('AccountActionMenu — 设置 Tier gating', () => {
 
   it('hides tier action for non-anthropic accounts', () => {
     expect(hasTierItem(makeAccount({ platform: 'openai', type: 'oauth' }))).toBe(false)
+  })
+})
+
+describe('AccountActionMenu — 恢复状态入口', () => {
+  it('keeps recover-state visible even when the current row has no recoverable flags', () => {
+    expect(hasRecoverStateItem(makeAccount({
+      status: 'active',
+      rate_limit_reset_at: null,
+      overload_until: null,
+      temp_unschedulable_until: null
+    }))).toBe(true)
+  })
+
+  it('emits recover-state with the account payload', async () => {
+    const account = makeAccount({ id: 42, status: 'active' })
+    const wrapper = mountMenu(account)
+    const recoverButton = wrapper.findAll('button').find(b => b.text().includes('admin.accounts.recoverState'))
+
+    expect(recoverButton).toBeDefined()
+    await recoverButton!.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.emitted('recover-state')?.[0]?.[0]).toMatchObject({ id: 42 })
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+})
+
+describe('AccountActionMenu — anchored positioning', () => {
+  it('aligns the menu to the trigger rect instead of the pointer position fallback', async () => {
+    const anchor = document.createElement('button')
+    document.body.appendChild(anchor)
+    vi.spyOn(anchor, 'getBoundingClientRect').mockReturnValue({
+      left: 500,
+      right: 560,
+      top: 80,
+      bottom: 104,
+      width: 60,
+      height: 24,
+      x: 500,
+      y: 80,
+      toJSON: () => ({})
+    } as DOMRect)
+
+    const originalRaf = window.requestAnimationFrame
+    const originalCancelRaf = window.cancelAnimationFrame
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) => window.setTimeout(() => cb(Date.now()), 0)) as typeof window.requestAnimationFrame
+    window.cancelAnimationFrame = ((handle: number) => window.clearTimeout(handle)) as typeof window.cancelAnimationFrame
+
+    const wrapper = mountMenu(
+      makeAccount({ status: 'active' }),
+      {
+        anchor,
+        position: { top: 999, left: 999 }
+      }
+    )
+
+    try {
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+      await flushPromises()
+
+      const style = wrapper.get('.action-menu-content').attributes('style')
+      expect(style).toContain('left: 352px')
+      expect(style).toContain('top: 108px')
+    } finally {
+      wrapper.unmount()
+      anchor.remove()
+      window.requestAnimationFrame = originalRaf
+      window.cancelAnimationFrame = originalCancelRaf
+    }
   })
 })

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -443,7 +443,7 @@
     <AccountTestModal v-if="lazyMount('test', showTest)" :show="showTest" :account="testingAcc" @close="closeTestModal" />
     <AccountStatsModal v-if="lazyMount('stats', showStats)" :show="showStats" :account="statsAcc" @close="closeStatsModal" />
     <ScheduledTestsPanel v-if="lazyMount('schedule', showSchedulePanel)" :show="showSchedulePanel" :account-id="scheduleAcc?.id ?? null" :model-options="scheduleModelOptions" @close="closeSchedulePanel" />
-    <AccountActionMenu v-if="lazyMount('menu', menu.show)" :show="menu.show" :account="menu.acc" :position="menu.pos" @close="menu.show = false" @test="handleTest" @stats="handleViewStats" @schedule="handleSchedule" @reauth="handleReAuth" @refresh-token="handleRefresh" @recover-state="handleRecoverState" @reset-quota="handleResetQuota" @set-privacy="handleSetPrivacy" @set-tier="tierCtl.open" @create-spark-shadow="handleCreateSparkShadow" />
+    <AccountActionMenu v-if="lazyMount('menu', menu.show)" :show="menu.show" :account="menu.acc" :position="menu.pos" :anchor="menu.anchor" @close="closeActionMenu" @test="handleTest" @stats="handleViewStats" @schedule="handleSchedule" @reauth="handleReAuth" @refresh-token="handleRefresh" @recover-state="handleRecoverState" @reset-quota="handleResetQuota" @set-privacy="handleSetPrivacy" @set-tier="tierCtl.open" @create-spark-shadow="handleCreateSparkShadow" />
     <AccountTierModal
       v-if="lazyMount('tier', tierCtl.show.value)"
       :show="tierCtl.show.value"
@@ -679,7 +679,7 @@ const lazyMount = (key: string, show: boolean): boolean => {
   return everOpened.has(key)
 }
 const togglingSchedulable = ref<number | null>(null)
-const menu = reactive<{show:boolean, acc:Account|null, pos:{top:number, left:number}|null}>({ show: false, acc: null, pos: null })
+const menu = reactive<{show:boolean, acc:Account|null, pos:{top:number, left:number}|null, anchor:HTMLElement|null}>({ show: false, acc: null, pos: null, anchor: null })
 const exportingData = ref(false)
 
 // Column settings
@@ -1504,6 +1504,10 @@ const cols = computed(() =>
 )
 
 const handleEdit = (a: Account) => { edAcc.value = a; showEdit.value = true }
+const closeActionMenu = () => {
+  menu.show = false
+  menu.anchor = null
+}
 const openMenu = (a: Account, e: MouseEvent) => {
   // Safety net when a menu action opens a modal but a ghost click hits the row
   // "more" trigger before the deferred menu close runs.
@@ -1514,11 +1518,12 @@ const openMenu = (a: Account, e: MouseEvent) => {
   const target = e.currentTarget as HTMLElement
   if (target) {
     const rect = target.getBoundingClientRect()
-    const menuWidth = 200
+    const menuWidth = 208
     const menuHeight = 240
     const padding = 8
     const viewportWidth = window.innerWidth
     const viewportHeight = window.innerHeight
+    menu.anchor = target
 
     let left: number
     let top: number
@@ -1543,17 +1548,18 @@ const openMenu = (a: Account, e: MouseEvent) => {
       }
     } else {
       left = Math.max(padding, Math.min(
-        e.clientX - menuWidth,
+        rect.right - menuWidth,
         viewportWidth - menuWidth - padding
       ))
-      top = e.clientY
+      top = rect.bottom + 4
       if (top + menuHeight > viewportHeight - padding) {
-        top = viewportHeight - menuHeight - padding
+        top = Math.max(padding, Math.min(rect.top - menuHeight - 4, viewportHeight - menuHeight - padding))
       }
     }
 
     menu.pos = { top, left }
   } else {
+    menu.anchor = null
     menu.pos = { top: e.clientY, left: e.clientX - 200 }
   }
 
@@ -1834,7 +1840,7 @@ const patchAccountInList = (updatedAccount: Account) => {
     syncPaginationAfterLocalRemoval()
     removeSelectedAccounts([mergedAccount.id])
     if (menu.acc?.id === mergedAccount.id) {
-      menu.show = false
+      closeActionMenu()
       menu.acc = null
     }
     return
@@ -2063,7 +2069,7 @@ const proxyExpiryText = (p?: AccountProxy | null): string => {
 
 // 滚动时关闭操作菜单（不关闭列设置下拉菜单）
 const handleScroll = () => {
-  menu.show = false
+  closeActionMenu()
 }
 
 // 点击外部关闭列设置下拉菜单


### PR DESCRIPTION
## 摘要
- 修复账号列表“更多”菜单打开后相对按钮漂移的问题，菜单改为锚定触发按钮并按真实尺寸贴边。
- 恢复“恢复状态”操作入口，改为常驻显示并继续调用现有 recover-state 后端 no-op 安全路径。
- 补充菜单定位与恢复入口回归测试，并刷新 embedded frontend dist source hash。
- 修复 CI frontend lint 对 `FrameRequestCallback` 全局类型引用的 `no-undef` 报错。

## 风险
- 仅影响管理员账号列表行级操作菜单展示与点击入口；不改后端状态恢复语义。
- sentinel-registry-reviewed：已确认本次是既有 load-bearing surface 内部修复，不新增 sentinel owner 或契约锚点。

## 验证
- pnpm --dir frontend lint:check
- pnpm --dir frontend test:run src/components/admin/account/__tests__/AccountActionMenu.spec.ts src/components/admin/account/__tests__/AccountActionMenu.spark_shadow.spec.ts
- pnpm --dir frontend typecheck
- pnpm --dir frontend run build
- ./scripts/preflight.sh

## 提交
- 03feded28 fix(admin): stabilize account action menu
- eff10f898 fix(admin): satisfy account menu frontend lint

最新提交：eff10f898
