### PR TITLE
fix(openai): stop codex substring fallback from rewriting gpt-5.3-chat-latest

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -41,22 +41,27 @@ var codexModelMap = map[string]string{
 	"gpt-5.3-codex-medium":       "gpt-5.3-codex",
 	"gpt-5.3-codex-high":         "gpt-5.3-codex",
 	"gpt-5.3-codex-xhigh":        "gpt-5.3-codex",
-	"gpt-5.2":                    "gpt-5.2",
-	"gpt-5.2-none":               "gpt-5.2",
-	"gpt-5.2-low":                "gpt-5.2",
-	"gpt-5.2-medium":             "gpt-5.2",
-	"gpt-5.2-high":               "gpt-5.2",
-	"gpt-5.2-xhigh":              "gpt-5.2",
-	"gpt-5":                      "gpt-5.4",
-	"gpt-5-mini":                 "gpt-5.4",
-	"gpt-5-nano":                 "gpt-5.4",
-	"gpt-5.1":                    "gpt-5.4",
-	"gpt-5.1-codex":              "gpt-5.3-codex",
-	"gpt-5.1-codex-max":          "gpt-5.3-codex",
-	"gpt-5.1-codex-mini":         "gpt-5.3-codex",
-	"gpt-5.2-codex":              "gpt-5.2",
-	"codex-mini-latest":          "gpt-5.3-codex",
-	"gpt-5-codex":                "gpt-5.3-codex",
+	// TK 2026-07 SSOT audit hotfix: exact-match self-mapping short-circuits
+	// normalizeKnownOpenAICodexModel's `strings.Contains(normalized, "gpt-5.3")`
+	// substring fallback (openai_model_alias.go), which would otherwise silently
+	// rewrite this id to gpt-5.3-codex before it reaches OpenAI.
+	"gpt-5.3-chat-latest": "gpt-5.3-chat-latest",
+	"gpt-5.2":             "gpt-5.2",
+	"gpt-5.2-none":        "gpt-5.2",
+	"gpt-5.2-low":         "gpt-5.2",
+	"gpt-5.2-medium":      "gpt-5.2",
+	"gpt-5.2-high":        "gpt-5.2",
+	"gpt-5.2-xhigh":       "gpt-5.2",
+	"gpt-5":               "gpt-5.4",
+	"gpt-5-mini":          "gpt-5.4",
+	"gpt-5-nano":          "gpt-5.4",
+	"gpt-5.1":             "gpt-5.4",
+	"gpt-5.1-codex":       "gpt-5.3-codex",
+	"gpt-5.1-codex-max":   "gpt-5.3-codex",
+	"gpt-5.1-codex-mini":  "gpt-5.3-codex",
+	"gpt-5.2-codex":       "gpt-5.2",
+	"codex-mini-latest":   "gpt-5.3-codex",
+	"gpt-5-codex":         "gpt-5.3-codex",
 }
 
 var codexVersionModelPrefixes = []struct {

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -41,27 +41,27 @@ var codexModelMap = map[string]string{
 	"gpt-5.3-codex-medium":       "gpt-5.3-codex",
 	"gpt-5.3-codex-high":         "gpt-5.3-codex",
 	"gpt-5.3-codex-xhigh":        "gpt-5.3-codex",
+	"gpt-5.2":                    "gpt-5.2",
+	"gpt-5.2-none":               "gpt-5.2",
+	"gpt-5.2-low":                "gpt-5.2",
+	"gpt-5.2-medium":             "gpt-5.2",
+	"gpt-5.2-high":               "gpt-5.2",
+	"gpt-5.2-xhigh":              "gpt-5.2",
+	"gpt-5":                      "gpt-5.4",
+	"gpt-5-mini":                 "gpt-5.4",
+	"gpt-5-nano":                 "gpt-5.4",
+	"gpt-5.1":                    "gpt-5.4",
+	"gpt-5.1-codex":              "gpt-5.3-codex",
+	"gpt-5.1-codex-max":          "gpt-5.3-codex",
+	"gpt-5.1-codex-mini":         "gpt-5.3-codex",
+	"gpt-5.2-codex":              "gpt-5.2",
+	"codex-mini-latest":          "gpt-5.3-codex",
+	"gpt-5-codex":                "gpt-5.3-codex",
 	// TK 2026-07 SSOT audit hotfix: exact-match self-mapping short-circuits
 	// normalizeKnownOpenAICodexModel's `strings.Contains(normalized, "gpt-5.3")`
 	// substring fallback (openai_model_alias.go), which would otherwise silently
 	// rewrite this id to gpt-5.3-codex before it reaches OpenAI.
 	"gpt-5.3-chat-latest": "gpt-5.3-chat-latest",
-	"gpt-5.2":             "gpt-5.2",
-	"gpt-5.2-none":        "gpt-5.2",
-	"gpt-5.2-low":         "gpt-5.2",
-	"gpt-5.2-medium":      "gpt-5.2",
-	"gpt-5.2-high":        "gpt-5.2",
-	"gpt-5.2-xhigh":       "gpt-5.2",
-	"gpt-5":               "gpt-5.4",
-	"gpt-5-mini":          "gpt-5.4",
-	"gpt-5-nano":          "gpt-5.4",
-	"gpt-5.1":             "gpt-5.4",
-	"gpt-5.1-codex":       "gpt-5.3-codex",
-	"gpt-5.1-codex-max":   "gpt-5.3-codex",
-	"gpt-5.1-codex-mini":  "gpt-5.3-codex",
-	"gpt-5.2-codex":       "gpt-5.2",
-	"codex-mini-latest":   "gpt-5.3-codex",
-	"gpt-5-codex":         "gpt-5.3-codex",
 }
 
 var codexVersionModelPrefixes = []struct {

--- a/backend/internal/service/openai_model_mapping_test.go
+++ b/backend/internal/service/openai_model_mapping_test.go
@@ -241,6 +241,7 @@ func TestNormalizeCodexModel(t *testing.T) {
 		"gpt-5.3-codex-spark-high":  "gpt-5.3-codex-spark",
 		"gpt-5.3-codex-spark-xhigh": "gpt-5.3-codex-spark",
 		"gpt-5.3":                   "gpt-5.3-codex",
+		"gpt-5.3-chat-latest":       "gpt-5.3-chat-latest",
 		"gpt-image-2":               "gpt-image-2",
 		"gpt-5.4-nano":              "gpt-5.4-nano",
 		"gpt-5.4-nano-high":         "gpt-5.4-nano",
@@ -309,6 +310,12 @@ func TestNormalizeOpenAIModelForUpstream(t *testing.T) {
 			account: &Account{Type: AccountTypeOAuth},
 			model:   "codex-mini-latest",
 			want:    "gpt-5.3-codex",
+		},
+		{
+			name:    "oauth keeps gpt-5.3-chat-latest unrewritten (SSOT audit hotfix: substring fallback would otherwise misclassify it as gpt-5.3-codex)",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "gpt-5.3-chat-latest",
+			want:    "gpt-5.3-chat-latest",
 		},
 		{
 			name:    "oauth spark model not remapped",


### PR DESCRIPTION
## 摘要
- OAuth 账号经 `normalizeOpenAIModelForUpstream` 路由时，子串回退（`strings.Contains(normalized, "gpt-5.3")`）会把 `gpt-5.3-chat-latest` 静默改写为 `gpt-5.3-codex` 再发往 OpenAI。
- 在 `codexModelMap` 增加精确匹配的自映射项，使 `gpt-5.3-chat-latest` 在子串回退之前短路返回。
- 从进行中的 OpenAI SSOT 9 点审计中拆出的独立最小热修，用于解除 `gpt-5.3-chat-latest` 上游可服务性 live-probe 的干净信号。

## 风险
- 仅影响 OpenAI OAuth 上游模型名归一化路径；不改 API 契约、不改前端。
- no-web-impact

## 验证
- [x] `go build ./...`
- [x] `go test ./internal/service/...`（新增自映射用例覆盖）
- [x] `make test`（Go 全绿）
- [x] `./scripts/preflight.sh` 全通过
- [x] CI：`preflight` / `test-unit` / `test-integration` / `golangci-lint` / `frontend` / `backend-security` / `frontend-security` 均通过

## 提交
- 3850797 fix(openai): stop codex substring fallback from rewriting gpt-5.3-chat-latest
- 89f0061 fix(openai): move gpt-5.3-chat-latest self-mapping to end of codexModelMap
- 最新提交：89f0061