### PR TITLE
fix(ops): 保障真实用户体验受损飞书 P0 告警送达

### DIFF
--- a/backend/internal/service/ops_alert_notifications_tk_feishu.go
+++ b/backend/internal/service/ops_alert_notifications_tk_feishu.go
@@ -17,10 +17,11 @@ type opsAlertNotificationResult struct {
 }
 
 type opsFeishuNotificationState struct {
-	mu       sync.Mutex
-	limiter  *slidingWindowLimiter
-	notifier *opsFeishuNotifier
-	sentAt   map[string]time.Time
+	mu              sync.Mutex
+	limiter         *slidingWindowLimiter
+	recoveryLimiter *slidingWindowLimiter
+	notifier        *opsFeishuNotifier
+	sentAt          map[string]time.Time
 	// firedFeishuEventIDs records alert events whose P0 firing card was actually
 	// delivered, so auto-resolve can send a paired green recovery card.
 	firedFeishuEventIDs map[int64]struct{}
@@ -29,6 +30,7 @@ type opsFeishuNotificationState struct {
 func newOpsFeishuNotificationState() *opsFeishuNotificationState {
 	return &opsFeishuNotificationState{
 		limiter:             newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour),
+		recoveryLimiter:     newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour),
 		notifier:            newOpsFeishuNotifier(),
 		sentAt:              map[string]time.Time{},
 		firedFeishuEventIDs: map[int64]struct{}{},
@@ -200,7 +202,7 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertFeishuRecovery(ctx context.Cont
 		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, "skip_no_firing_card", "", nil)
 		return false
 	}
-	if !state.shouldSendRecovery(rule, event) {
+	if !state.shouldSendRecovery(rule, event, cfg.Feishu) {
 		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, "skip_cooldown_or_rate_limited", "", nil)
 		return false
 	}
@@ -296,11 +298,24 @@ func (s *opsFeishuNotificationState) shouldSend(rule *OpsAlertRule, event *OpsAl
 		return false
 	}
 	s.mu.Unlock()
+	if opsFeishuBypassFiringRateLimit(rule, event) {
+		return true
+	}
 	if s.limiter == nil {
 		s.limiter = newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour)
 	}
 	s.limiter.SetLimit(cfg.RateLimitPerHour)
 	return s.limiter.Allow(now)
+}
+
+func opsFeishuBypassFiringRateLimit(rule *OpsAlertRule, event *OpsAlertEvent) bool {
+	if rule == nil || event == nil {
+		return false
+	}
+	return strings.TrimSpace(rule.MetricType) == OpsAlertMetricUserVisibleFailureCount &&
+		strings.EqualFold(strings.TrimSpace(rule.Severity), "P0") &&
+		strings.EqualFold(strings.TrimSpace(event.Severity), "P0") &&
+		strings.EqualFold(strings.TrimSpace(event.Status), OpsAlertStatusFiring)
 }
 
 func (s *opsFeishuNotificationState) markSent(rule *OpsAlertRule, event *OpsAlertEvent) {
@@ -327,7 +342,7 @@ func (s *opsFeishuNotificationState) markFiringDelivered(event *OpsAlertEvent) {
 	s.firedFeishuEventIDs[event.ID] = struct{}{}
 }
 
-func (s *opsFeishuNotificationState) shouldSendRecovery(rule *OpsAlertRule, event *OpsAlertEvent) bool {
+func (s *opsFeishuNotificationState) shouldSendRecovery(rule *OpsAlertRule, event *OpsAlertEvent, cfg OpsFeishuAlertConfig) bool {
 	if s == nil || rule == nil || event == nil || event.ID <= 0 {
 		return false
 	}
@@ -347,10 +362,11 @@ func (s *opsFeishuNotificationState) shouldSendRecovery(rule *OpsAlertRule, even
 	if seen {
 		return false
 	}
-	if s.limiter == nil {
-		s.limiter = newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour)
+	if s.recoveryLimiter == nil {
+		s.recoveryLimiter = newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour)
 	}
-	return s.limiter.Allow(time.Now().UTC())
+	s.recoveryLimiter.SetLimit(cfg.RateLimitPerHour)
+	return s.recoveryLimiter.Allow(time.Now().UTC())
 }
 
 func (s *opsFeishuNotificationState) hasFiringDelivered(event *OpsAlertEvent) bool {

--- a/backend/internal/service/ops_feishu_alerts_tk_test.go
+++ b/backend/internal/service/ops_feishu_alerts_tk_test.go
@@ -443,6 +443,69 @@ func TestMaybeSendAlertFeishuRateLimitsAcrossDistinctDimensions(t *testing.T) {
 	require.Equal(t, 1, doer.calls)
 }
 
+func TestMaybeSendAlertFeishuUserVisibleP0BypassesFiringRateLimit(t *testing.T) {
+	t.Parallel()
+
+	doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+	svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 1, CooldownSeconds: 60}, doer)
+	rule := testOpsFeishuRule()
+	rule.Name = "真实用户体验受损"
+	rule.MetricType = OpsAlertMetricUserVisibleFailureCount
+
+	first := testOpsFeishuEvent(1)
+	first.Dimensions = map[string]any{
+		"user_visible_affected": "#16 compute@tk.com ×187",
+		"user_visible_impact":   "失败 187 / 成功 5387 / 失败率 3.36% / 5m",
+	}
+	second := testOpsFeishuEvent(2)
+	second.Dimensions = map[string]any{
+		"user_visible_affected": "#17 ops@tk.com ×42",
+		"user_visible_impact":   "失败 42 / 成功 1000 / 失败率 4.03% / 5m",
+	}
+
+	require.True(t, svc.maybeSendAlertFeishu(context.Background(), nil, rule, first))
+	require.True(t, svc.maybeSendAlertFeishu(context.Background(), nil, rule, second))
+	require.Equal(t, 2, doer.calls)
+}
+
+func TestMaybeSendAlertFeishuUserVisibleP0StillDedupesByCooldown(t *testing.T) {
+	t.Parallel()
+
+	doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+	svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 1, CooldownSeconds: 3600}, doer)
+	rule := testOpsFeishuRule()
+	rule.Name = "真实用户体验受损"
+	rule.MetricType = OpsAlertMetricUserVisibleFailureCount
+	event := testOpsFeishuEvent(16)
+	event.Dimensions = map[string]any{
+		"user_visible_affected": "#16 compute@tk.com ×187",
+		"user_visible_impact":   "失败 187 / 成功 5387 / 失败率 3.36% / 5m",
+	}
+
+	require.True(t, svc.maybeSendAlertFeishu(context.Background(), nil, rule, event))
+	require.False(t, svc.maybeSendAlertFeishu(context.Background(), nil, rule, event))
+	require.Equal(t, 1, doer.calls)
+}
+
+func TestMaybeSendAlertFeishuRecoveryDoesNotConsumeFiringRateLimit(t *testing.T) {
+	t.Parallel()
+
+	doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+	svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 1, CooldownSeconds: 60}, doer)
+	rule := testOpsFeishuRule()
+
+	resolvedAt := time.Unix(1700000060, 0).UTC()
+	resolved := testOpsFeishuEvent(1)
+	resolved.Status = OpsAlertStatusResolved
+	resolved.ResolvedAt = &resolvedAt
+	resolved.FeishuFiringSent = true
+	require.True(t, svc.maybeSendAlertFeishuRecovery(context.Background(), nil, rule, resolved, 0))
+
+	require.True(t, svc.maybeSendAlertFeishu(context.Background(), nil, rule, testOpsFeishuEvent(2)))
+	require.False(t, svc.maybeSendAlertFeishu(context.Background(), nil, rule, testOpsFeishuEvent(3)))
+	require.Equal(t, 2, doer.calls)
+}
+
 func TestOpsFeishuNotifierBuildsRecoveryPayload(t *testing.T) {
 	t.Parallel()
 
@@ -614,6 +677,7 @@ func newOpsFeishuAlertEvaluatorForTest(t *testing.T, feishu OpsFeishuAlertConfig
 		opsService: &OpsService{settingRepo: repo},
 		feishuState: &opsFeishuNotificationState{
 			limiter:             newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour),
+			recoveryLimiter:     newSlidingWindowLimiter(opsFeishuAlertRateLimitPerHourDefault, time.Hour),
 			notifier:            &opsFeishuNotifier{httpClient: doer},
 			sentAt:              map[string]time.Time{},
 			firedFeishuEventIDs: map[int64]struct{}{},


### PR DESCRIPTION
摘要
- 将「真实用户体验受损」P0 firing 从全局飞书发送限流中拆出，避免 recovery 或其他告警占满配额后吞掉真实用户受损告警。
- 保留同类告警 cooldown/dedupe，避免同一 P0 重复刷屏。
- recovery 改为独立 limiter，不再消耗 firing 配额。
- Web impact: none.

风险
- 影响范围限定在 ops Feishu 告警发送状态机。
- P0 用户体验 firing 仍受同类 cooldown 保护；P1 和其他 P0 仍走普通限流。
- sentinel-registry-reviewed：已确认本次是现有 Feishu 告警状态机行为修复，不需要新增 sentinel anchor。

验证
- `go test -tags unit ./internal/service -run 'TestMaybeSendAlertFeishu|TestOpsFeishu'`
- `go test -tags unit ./internal/service`
- `./scripts/preflight.sh`
- prod 配置已临时调整为 `rate_limit_per_hour=12`、`cooldown_seconds=600` 并通过 `probe-alert-config.sh` 复查。

提交
- 213e06000 fix(ops): protect user-visible Feishu P0 firing no-web-impact
- 最新提交：213e06000