### PR TITLE
fix(ops): classify Anthropic 400 validation as client

### DIFF
--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1350,7 +1350,7 @@ func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status i
 			phase = "request"
 		}
 	}
-	phase = tkOpsClassifyFinalClientValidationPhase(phase, upstreamError, routingCapacityLimited, errType, message, status)
+	phase = tkOpsClassifyFinalClientValidationPhase(phase, upstreamError, routingCapacityLimited, errType, message, code, status)
 	errorOwner = classifyOpsErrorOwner(phase, message)
 	errorSource = classifyOpsErrorSource(phase, message)
 	return phase, errorOwner, errorSource

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1350,6 +1350,7 @@ func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status i
 			phase = "request"
 		}
 	}
+	phase = tkOpsClassifyFinalClientValidationPhase(phase, upstreamError, routingCapacityLimited, errType, message, status)
 	errorOwner = classifyOpsErrorOwner(phase, message)
 	errorSource = classifyOpsErrorSource(phase, message)
 	return phase, errorOwner, errorSource

--- a/backend/internal/handler/ops_error_logger_tk_client_validation.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_validation.go
@@ -5,35 +5,154 @@ import (
 	"strings"
 )
 
-func tkOpsClassifyFinalClientValidationPhase(phase string, upstreamError, routingCapacityLimited bool, errType, message string, status int) string {
+func tkOpsClassifyFinalClientValidationPhase(phase string, upstreamError, routingCapacityLimited bool, errType, message, code string, status int) string {
 	if phase != "internal" || upstreamError || routingCapacityLimited {
 		return phase
 	}
-	if tkOpsFinalClientValidationAPIError(errType, message, status) {
+	if tkOpsFinalClientValidationAPIError(errType, message, code, status) {
 		return "request"
 	}
 	return phase
 }
 
 // tkOpsFinalClientValidationAPIError catches client request-validation errors
-// that were already flattened into a final Anthropic/OpenAI-style api_error
-// response before ops logging sees them. These have no upstream context, so they
-// cannot ride tkUpstreamClientInducedRejection, but they are still caller-fault.
-func tkOpsFinalClientValidationAPIError(errType, message string, status int) bool {
-	if status != http.StatusBadRequest || strings.TrimSpace(errType) != "api_error" {
+// that were flattened into a final api_error before ops logging sees them.
+// Upstream-context errors ride tkUpstreamClientInducedRejection instead.
+func tkOpsFinalClientValidationAPIError(errType, message, code string, status int) bool {
+	if strings.TrimSpace(strings.ToLower(errType)) != "api_error" {
 		return false
 	}
+	switch status {
+	case http.StatusBadRequest, http.StatusRequestEntityTooLarge, http.StatusUnprocessableEntity:
+	default:
+		return false
+	}
+
 	msg := strings.ToLower(strings.TrimSpace(message))
-	if msg == "" {
+	code = strings.ToLower(strings.TrimSpace(code))
+	if msg == "" && code == "" {
 		return false
 	}
-	return tkOpsAnthropicSamplingParamConflict(msg)
+	if tkOpsIsAccountLevel4xx(msg) {
+		return false
+	}
+	if tkOpsClientValidationCode(code) {
+		return true
+	}
+	if status == http.StatusRequestEntityTooLarge && tkOpsRequestSizeValidationMessage(msg) {
+		return true
+	}
+	return tkOpsRequestParameterValidationMessage(msg)
 }
 
-func tkOpsAnthropicSamplingParamConflict(lowerMessage string) bool {
+func tkOpsClientValidationCode(code string) bool {
+	switch code {
+	case "bad_request",
+		"invalid_request",
+		"invalid_request_error",
+		"invalid_parameter",
+		"invalid_value",
+		"missing_required_parameter",
+		"parameter_missing",
+		"unknown_parameter",
+		"unsupported_parameter",
+		"request_too_large":
+		return true
+	default:
+		return false
+	}
+}
+
+func tkOpsRequestParameterValidationMessage(lowerMessage string) bool {
+	if lowerMessage == "" {
+		return false
+	}
 	compact := strings.NewReplacer("`", "", "'", "", "\"", "", " ", "").Replace(lowerMessage)
-	return strings.Contains(compact, "temperatureandtop_pcannotbothbespecified") ||
-		(strings.Contains(compact, "temperature") &&
-			strings.Contains(compact, "top_p") &&
-			strings.Contains(compact, "cannotbothbespecified"))
+	if strings.Contains(compact, "temperatureandtop_pcannotbothbespecified") {
+		return true
+	}
+	if strings.Contains(lowerMessage, "extra inputs are not permitted") ||
+		strings.Contains(lowerMessage, "unsupported parameter") ||
+		strings.Contains(lowerMessage, "unknown parameter") ||
+		strings.Contains(lowerMessage, "unknown_parameter") ||
+		strings.Contains(lowerMessage, "unrecognized request argument") ||
+		strings.Contains(lowerMessage, "missing required parameter") ||
+		strings.Contains(lowerMessage, "required parameter") ||
+		strings.Contains(lowerMessage, "invalid request body") ||
+		strings.Contains(lowerMessage, "failed to parse request body") {
+		return true
+	}
+
+	if strings.Contains(lowerMessage, "invalid value") &&
+		(strings.Contains(lowerMessage, "parameter") || strings.Contains(lowerMessage, "param") || tkOpsMessageMentionsRequestField(lowerMessage)) {
+		return true
+	}
+
+	if !tkOpsMessageMentionsRequestField(lowerMessage) {
+		return false
+	}
+	return strings.Contains(lowerMessage, "cannot both be specified") ||
+		strings.Contains(lowerMessage, "cannot be specified") ||
+		strings.Contains(lowerMessage, "not supported") ||
+		strings.Contains(lowerMessage, "not permitted") ||
+		strings.Contains(lowerMessage, "not allowed") ||
+		strings.Contains(lowerMessage, "deprecated") ||
+		strings.Contains(lowerMessage, "non-default") ||
+		strings.Contains(lowerMessage, "input should be") ||
+		strings.Contains(lowerMessage, "must be") ||
+		strings.Contains(lowerMessage, "expected")
+}
+
+func tkOpsRequestSizeValidationMessage(lowerMessage string) bool {
+	return (strings.Contains(lowerMessage, "request") ||
+		strings.Contains(lowerMessage, "body") ||
+		strings.Contains(lowerMessage, "payload") ||
+		strings.Contains(lowerMessage, "prompt")) &&
+		(strings.Contains(lowerMessage, "too large") ||
+			strings.Contains(lowerMessage, "too long") ||
+			strings.Contains(lowerMessage, "exceed"))
+}
+
+func tkOpsMessageMentionsRequestField(lowerMessage string) bool {
+	if strings.Contains(lowerMessage, "parameter") ||
+		strings.Contains(lowerMessage, "param") ||
+		strings.Contains(lowerMessage, "field") ||
+		strings.Contains(lowerMessage, "argument") {
+		return true
+	}
+	for _, field := range []string{
+		"temperature",
+		"top_p",
+		"top_k",
+		"max_tokens",
+		"max_output_tokens",
+		"max_input_tokens",
+		"max_completion_tokens",
+		"stop_sequences",
+		"service_tier",
+		"metadata",
+		"stream",
+		"model",
+		"messages",
+		"system",
+		"input",
+		"instructions",
+		"thinking",
+		"budget_tokens",
+		"output_config",
+		"effort",
+		"tools",
+		"tool_choice",
+		"response_format",
+		"parallel_tool_calls",
+		"context_management",
+		"betas",
+		"enable_thinking",
+		"prompt_cache_key",
+	} {
+		if strings.Contains(lowerMessage, field) {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/handler/ops_error_logger_tk_client_validation.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_validation.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+)
+
+func tkOpsClassifyFinalClientValidationPhase(phase string, upstreamError, routingCapacityLimited bool, errType, message string, status int) string {
+	if phase != "internal" || upstreamError || routingCapacityLimited {
+		return phase
+	}
+	if tkOpsFinalClientValidationAPIError(errType, message, status) {
+		return "request"
+	}
+	return phase
+}
+
+// tkOpsFinalClientValidationAPIError catches client request-validation errors
+// that were already flattened into a final Anthropic/OpenAI-style api_error
+// response before ops logging sees them. These have no upstream context, so they
+// cannot ride tkUpstreamClientInducedRejection, but they are still caller-fault.
+func tkOpsFinalClientValidationAPIError(errType, message string, status int) bool {
+	if status != http.StatusBadRequest || strings.TrimSpace(errType) != "api_error" {
+		return false
+	}
+	msg := strings.ToLower(strings.TrimSpace(message))
+	if msg == "" {
+		return false
+	}
+	return tkOpsAnthropicSamplingParamConflict(msg)
+}
+
+func tkOpsAnthropicSamplingParamConflict(lowerMessage string) bool {
+	compact := strings.NewReplacer("`", "", "'", "", "\"", "", " ", "").Replace(lowerMessage)
+	return strings.Contains(compact, "temperatureandtop_pcannotbothbespecified") ||
+		(strings.Contains(compact, "temperature") &&
+			strings.Contains(compact, "top_p") &&
+			strings.Contains(compact, "cannotbothbespecified"))
+}

--- a/backend/internal/handler/ops_error_logger_tk_client_validation_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_validation_test.go
@@ -12,33 +12,66 @@ import (
 func TestClassifyOpsFinalClientValidationAPIErrorOwnedByClient(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	t.Run("anthropic sampling params conflict flattened as api_error", func(t *testing.T) {
-		rec := httptest.NewRecorder()
-		c, _ := gin.CreateTestContext(rec)
-		body := []byte("{\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"`temperature` and `top_p` cannot both be specified for this model. Please use only one.\"}}")
+	tests := []struct {
+		name    string
+		body    []byte
+		message string
+		code    string
+	}{
+		{
+			name: "anthropic sampling params conflict flattened as api_error",
+			body: []byte("{\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"`temperature` and `top_p` cannot both be specified for this model. Please use only one.\"}}"),
+		},
+		{
+			name:    "prod compact fingerprint without separator still matches",
+			message: "temperatureandtop_p cannot both be specified for this model. Please use only one.",
+		},
+		{
+			name:    "top_k non-default deprecated sampling parameter",
+			message: "Setting top_k to a non-default value returns a 400 error for this model.",
+		},
+		{
+			name:    "top_p extra inputs validator",
+			message: "top_p: Extra inputs are not permitted",
+		},
+		{
+			name:    "unsupported temperature parameter",
+			message: "Unsupported parameter: temperature",
+		},
+		{
+			name:    "invalid value for temperature parameter",
+			message: "Invalid value for parameter 'temperature'",
+		},
+		{
+			name:    "request schema field validation",
+			message: "thinking.budget_tokens: Input should be greater than or equal to 1024",
+		},
+		{
+			name: "structured client validation code",
+			code: "unknown_parameter",
+		},
+	}
 
-		parsed := parseOpsErrorResponse(body)
-		errType := normalizeOpsErrorType(parsed.ErrorType, parsed.Code)
-		phase, errorOwner, errorSource := classifyOpsErrorLog(c, errType, parsed.Message, parsed.Code, http.StatusBadRequest)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			errType, message, code := "api_error", tt.message, tt.code
+			if len(tt.body) > 0 {
+				parsed := parseOpsErrorResponse(tt.body)
+				errType = normalizeOpsErrorType(parsed.ErrorType, parsed.Code)
+				message = parsed.Message
+				code = parsed.Code
+			}
 
-		require.Equal(t, "api_error", errType)
-		require.Equal(t, "request", phase)
-		require.Equal(t, "client", errorOwner)
-		require.Equal(t, "client_request", errorSource)
-	})
+			phase, errorOwner, errorSource := classifyOpsErrorLog(c, errType, message, code, http.StatusBadRequest)
 
-	t.Run("prod compact fingerprint without separator still matches", func(t *testing.T) {
-		rec := httptest.NewRecorder()
-		c, _ := gin.CreateTestContext(rec)
-
-		phase, errorOwner, errorSource := classifyOpsErrorLog(c, "api_error",
-			"temperatureandtop_p cannot both be specified for this model. Please use only one.",
-			"", http.StatusBadRequest)
-
-		require.Equal(t, "request", phase)
-		require.Equal(t, "client", errorOwner)
-		require.Equal(t, "client_request", errorSource)
-	})
+			require.Equal(t, "api_error", errType)
+			require.Equal(t, "request", phase)
+			require.Equal(t, "client", errorOwner)
+			require.Equal(t, "client_request", errorSource)
+		})
+	}
 }
 
 func TestClassifyOpsFinalClientValidationAPIErrorDoesNotOvermatch(t *testing.T) {
@@ -50,13 +83,18 @@ func TestClassifyOpsFinalClientValidationAPIErrorDoesNotOvermatch(t *testing.T) 
 		status  int
 	}{
 		{
-			name:    "same validation phrase with non-400 final status stays platform",
+			name:    "same validation phrase with non-4xx final status stays platform",
 			message: "`temperature` and `top_p` cannot both be specified for this model. Please use only one.",
 			status:  http.StatusBadGateway,
 		},
 		{
 			name:    "generic final 400 api_error stays platform",
 			message: "Internal server error",
+			status:  http.StatusBadRequest,
+		},
+		{
+			name:    "account-level 400 credit balance stays platform without upstream context",
+			message: "Your credit balance is too low to access the API.",
 			status:  http.StatusBadRequest,
 		},
 	}

--- a/backend/internal/handler/ops_error_logger_tk_client_validation_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_validation_test.go
@@ -1,0 +1,91 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyOpsFinalClientValidationAPIErrorOwnedByClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("anthropic sampling params conflict flattened as api_error", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		body := []byte("{\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"`temperature` and `top_p` cannot both be specified for this model. Please use only one.\"}}")
+
+		parsed := parseOpsErrorResponse(body)
+		errType := normalizeOpsErrorType(parsed.ErrorType, parsed.Code)
+		phase, errorOwner, errorSource := classifyOpsErrorLog(c, errType, parsed.Message, parsed.Code, http.StatusBadRequest)
+
+		require.Equal(t, "api_error", errType)
+		require.Equal(t, "request", phase)
+		require.Equal(t, "client", errorOwner)
+		require.Equal(t, "client_request", errorSource)
+	})
+
+	t.Run("prod compact fingerprint without separator still matches", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+
+		phase, errorOwner, errorSource := classifyOpsErrorLog(c, "api_error",
+			"temperatureandtop_p cannot both be specified for this model. Please use only one.",
+			"", http.StatusBadRequest)
+
+		require.Equal(t, "request", phase)
+		require.Equal(t, "client", errorOwner)
+		require.Equal(t, "client_request", errorSource)
+	})
+}
+
+func TestClassifyOpsFinalClientValidationAPIErrorDoesNotOvermatch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name    string
+		message string
+		status  int
+	}{
+		{
+			name:    "same validation phrase with non-400 final status stays platform",
+			message: "`temperature` and `top_p` cannot both be specified for this model. Please use only one.",
+			status:  http.StatusBadGateway,
+		},
+		{
+			name:    "generic final 400 api_error stays platform",
+			message: "Internal server error",
+			status:  http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+
+			phase, errorOwner, errorSource := classifyOpsErrorLog(c, "api_error", tt.message, "", tt.status)
+
+			require.Equal(t, "internal", phase)
+			require.Equal(t, "platform", errorOwner)
+			require.Equal(t, "gateway", errorSource)
+		})
+	}
+}
+
+func TestClassifyOpsRoutingCapacityWinsOverFinalClientValidationAPIError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	markOpsRoutingCapacityLimited(c)
+
+	phase, errorOwner, errorSource := classifyOpsErrorLog(c, "api_error",
+		"`temperature` and `top_p` cannot both be specified for this model. Please use only one.",
+		"", http.StatusBadRequest)
+
+	require.Equal(t, "routing", phase)
+	require.Equal(t, "platform", errorOwner)
+	require.Equal(t, "gateway", errorSource)
+}


### PR DESCRIPTION
## 摘要
- 将最终 4xx 且被包装成 `api_error` 的请求参数/schema 校验错误归类为 `request/client`，避免计入 platform/provider SLA fault。
- 规则从原先的 `temperature/top_p` 互斥文案扩宽到 `temperature`、`top_p`、`top_k` 及同类参数错误：unsupported/unknown parameter、extra inputs、invalid value、missing required parameter、request_too_large 等。
- 保持边界：仅无 upstream 上下文、非 routing capacity、原 phase 仍为 `internal` 时生效；generic `api_error`、account health 4xx、routing capacity 不受影响。
- `no-web-impact`
- `sentinel-registry-reviewed`

## 风险
- 低：只改 ops 错误日志归因，不改请求执行、计费、账号调度或前端。
- 匹配条件限定在明确的请求参数/schema 校验信号，避免把真实平台内部错误移出 SLA fault。

## 验证
- `go test -tags unit ./internal/handler -run 'TestClassifyOps(FinalClientValidationAPIError|RoutingCapacityWinsOverFinalClientValidationAPIError|UpstreamClientInducedRejectionOwnedByClient|GenuineUpstreamErrorsStayProvider|RoutingCapacityWinsOverClientInduced)'`
- `go test -tags unit ./internal/handler`
- `./scripts/preflight.sh`

## 提交
- `02d1d59eb` fix(ops): classify Anthropic 400 validation as client no-web-impact
- `77afcfd9c` fix(ops): broaden client validation classification no-web-impact
- 最新提交：`77afcfd9c`
