### PR TITLE
fix(anthropic): strip invalid sampling params

### DIFF
--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -1281,6 +1281,9 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_Signature400Ret
 // Parity with the main Forward() path: the passthrough path must also self-heal the
 // Opus 4.7+ "thinking.type.enabled is not supported" 400 by retrying with adaptive.
 func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_AdaptiveRequired400RetriesWithAdaptive(t *testing.T) {
+	tkAnthropicThinkingRules.Flush()
+	defer tkAnthropicThinkingRules.Flush()
+
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -1316,6 +1319,61 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_AdaptiveRequire
 	require.Equal(t, "enabled", gjson.GetBytes(upstream.bodies[0], "thinking.type").String(), "first attempt preserves client manual thinking")
 	require.Equal(t, "adaptive", gjson.GetBytes(upstream.bodies[1], "thinking.type").String(), "retry converts to adaptive")
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "thinking.budget_tokens").Exists(), "retry drops budget_tokens")
+	rule, exists := tkGetCachedAnthropicThinkingRule("claude-opus-4-8")
+	require.True(t, exists)
+	require.Equal(t, tkAnthropicThinkingRuleAdaptiveOnly, rule)
+
+	cached := tkApplyAnthropicRequestCompatibilityRules(body)
+	require.Equal(t, "adaptive", gjson.GetBytes(cached, "thinking.type").String())
+	require.False(t, gjson.GetBytes(cached, "thinking.budget_tokens").Exists(), "subsequent requests should be rectified before upstream")
+}
+
+func TestGatewayService_AnthropicMainForward_AdaptiveRequired400RetriesWithAdaptive(t *testing.T) {
+	tkAnthropicThinkingRules.Flush()
+	defer tkAnthropicThinkingRules.Flush()
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	body := []byte(`{"model":"claude-opus-4-8","thinking":{"type":"enabled","budget_tokens":1024},"max_tokens":2048,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-opus-4-8", Stream: false}
+	upstreamJSON := `{"id":"msg_adaptive_ok","type":"message","role":"assistant","model":"claude-opus-4-8","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":3,"output_tokens":2}}`
+	upstream := &anthropicHTTPUpstreamSequenceRecorder{resps: []*http.Response{
+		{
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid-main-adaptive-bad"}},
+			Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"invalid_request_error","message":"\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}}`)),
+		},
+		{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid-main-adaptive-ok"}},
+			Body:       io.NopCloser(strings.NewReader(upstreamJSON)),
+		},
+	}}
+	svc := &GatewayService{
+		cfg:              &config.Config{},
+		httpUpstream:     upstream,
+		rateLimitService: &RateLimitService{},
+		deferredService:  &DeferredService{},
+	}
+	account := newAnthropicAPIKeyAccountForTest()
+	account.Extra = nil
+
+	result, err := svc.Forward(context.Background(), c, account, parsed)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, upstream.bodies, 2)
+	require.Equal(t, "enabled", gjson.GetBytes(upstream.bodies[0], "thinking.type").String(), "first attempt preserves client manual thinking")
+	require.Equal(t, "adaptive", gjson.GetBytes(upstream.bodies[1], "thinking.type").String(), "retry converts to adaptive")
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "thinking.budget_tokens").Exists(), "retry drops budget_tokens")
+	require.Equal(t, 3, result.Usage.InputTokens)
+	require.Equal(t, 2, result.Usage.OutputTokens)
+	rule, exists := tkGetCachedAnthropicThinkingRule("claude-opus-4-8")
+	require.True(t, exists)
+	require.Equal(t, tkAnthropicThinkingRuleAdaptiveOnly, rule)
 }
 
 // Parity with the main Forward() path: the passthrough path must also self-heal a

--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -1311,7 +1311,8 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_AdaptiveRequire
 		settingService:   settingSvc,
 	}
 
-	result, err := svc.forwardAnthropicAPIKeyPassthrough(context.Background(), c, newAnthropicAPIKeyAccountForTest(), body, "claude-opus-4-8", "claude-opus-4-8", false, time.Now())
+	account := newAnthropicAPIKeyAccountForTest()
+	result, err := svc.forwardAnthropicAPIKeyPassthrough(context.Background(), c, account, body, "claude-opus-4-8", "claude-opus-4-8", false, time.Now())
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, upstreamJSON, rec.Body.String())
@@ -1319,11 +1320,11 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_AdaptiveRequire
 	require.Equal(t, "enabled", gjson.GetBytes(upstream.bodies[0], "thinking.type").String(), "first attempt preserves client manual thinking")
 	require.Equal(t, "adaptive", gjson.GetBytes(upstream.bodies[1], "thinking.type").String(), "retry converts to adaptive")
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "thinking.budget_tokens").Exists(), "retry drops budget_tokens")
-	rule, exists := tkGetCachedAnthropicThinkingRule("claude-opus-4-8")
+	rule, exists := tkGetCachedAnthropicThinkingRule(account, "claude-opus-4-8", body)
 	require.True(t, exists)
 	require.Equal(t, tkAnthropicThinkingRuleAdaptiveOnly, rule)
 
-	cached := tkApplyAnthropicRequestCompatibilityRules(body)
+	cached := tkApplyAnthropicRequestCompatibilityRules(account, body)
 	require.Equal(t, "adaptive", gjson.GetBytes(cached, "thinking.type").String())
 	require.False(t, gjson.GetBytes(cached, "thinking.budget_tokens").Exists(), "subsequent requests should be rectified before upstream")
 }
@@ -1371,7 +1372,7 @@ func TestGatewayService_AnthropicMainForward_AdaptiveRequired400RetriesWithAdapt
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "thinking.budget_tokens").Exists(), "retry drops budget_tokens")
 	require.Equal(t, 3, result.Usage.InputTokens)
 	require.Equal(t, 2, result.Usage.OutputTokens)
-	rule, exists := tkGetCachedAnthropicThinkingRule("claude-opus-4-8")
+	rule, exists := tkGetCachedAnthropicThinkingRule(account, "claude-opus-4-8", body)
 	require.True(t, exists)
 	require.Equal(t, tkAnthropicThinkingRuleAdaptiveOnly, rule)
 }

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -108,7 +108,7 @@ func (s *GatewayService) forwardAnthropicPassthroughWithInput(
 	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes, strip empty
 	// text blocks, drop explicit disabled thinking for Fable, and strip fields
 	// rejected by newer Anthropic models.
-	input.Body = tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))
+	input.Body = tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))
 	if input.Parsed != nil {
 		if err := input.Parsed.ReplaceBody(input.Body); err != nil {
 			return nil, err
@@ -485,12 +485,8 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 }
 
 func (s *GatewayService) rectifyAnthropicPassthrough400(ctx context.Context, account *Account, body []byte, model string, respBody []byte) ([]byte, string, bool) {
-	platform := ""
-	if account != nil {
-		platform = account.Platform
-	}
-	if _, ok := tkRecordAnthropicSamplingParamRuleFrom400(platform, model, http.StatusBadRequest, respBody); ok {
-		if rectified := tkStripDeprecatedSamplingParams(body); !bytes.Equal(rectified, body) {
+	if _, ok := tkRecordAnthropicSamplingParamRuleFrom400(account, model, body, http.StatusBadRequest, respBody); ok {
+		if rectified := tkStripDeprecatedSamplingParamsForAccount(account, body); !bytes.Equal(rectified, body) {
 			return rectified, "sampling_param_retry", true
 		}
 	}
@@ -501,7 +497,7 @@ func (s *GatewayService) rectifyAnthropicPassthrough400(ctx context.Context, acc
 
 	errMsg := extractUpstreamErrorMessage(respBody)
 	if isThinkingTypeAdaptiveRequiredError(errMsg) {
-		tkRecordAnthropicThinkingRuleFrom400(platform, model, http.StatusBadRequest, respBody)
+		tkRecordAnthropicThinkingRuleFrom400(account, model, body, http.StatusBadRequest, respBody)
 		if rectified, ok := RectifyThinkingTypeAdaptive(body); ok {
 			return rectified, "thinking_adaptive_retry", true
 		}

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -108,7 +108,7 @@ func (s *GatewayService) forwardAnthropicPassthroughWithInput(
 	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes, strip empty
 	// text blocks, drop explicit disabled thinking for Fable, and strip fields
 	// rejected by newer Anthropic models.
-	input.Body = tkStripDeprecatedSamplingParams(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))
+	input.Body = tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))
 	if input.Parsed != nil {
 		if err := input.Parsed.ReplaceBody(input.Body); err != nil {
 			return nil, err
@@ -501,6 +501,7 @@ func (s *GatewayService) rectifyAnthropicPassthrough400(ctx context.Context, acc
 
 	errMsg := extractUpstreamErrorMessage(respBody)
 	if isThinkingTypeAdaptiveRequiredError(errMsg) {
+		tkRecordAnthropicThinkingRuleFrom400(platform, model, http.StatusBadRequest, respBody)
 		if rectified, ok := RectifyThinkingTypeAdaptive(body); ok {
 			return rectified, "thinking_adaptive_retry", true
 		}

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -485,6 +485,16 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 }
 
 func (s *GatewayService) rectifyAnthropicPassthrough400(ctx context.Context, account *Account, body []byte, model string, respBody []byte) ([]byte, string, bool) {
+	platform := ""
+	if account != nil {
+		platform = account.Platform
+	}
+	if _, ok := tkRecordAnthropicSamplingParamRuleFrom400(platform, model, http.StatusBadRequest, respBody); ok {
+		if rectified := tkStripDeprecatedSamplingParams(body); !bytes.Equal(rectified, body) {
+			return rectified, "sampling_param_retry", true
+		}
+	}
+
 	if s.shouldRectifySignatureError(ctx, account, respBody, model) {
 		return FilterThinkingBlocksForRetry(body, model), "signature_retry_thinking", true
 	}

--- a/backend/internal/service/gateway_claude_oauth_body.go
+++ b/backend/internal/service/gateway_claude_oauth_body.go
@@ -430,7 +430,7 @@ func (s *GatewayService) applyClaudeCodeOAuthMimicryToBody(
 		body = applyToolsLastCacheBreakpoint(body)
 	}
 
-	return tkApplyAnthropicRequestCompatibilityRules(body)
+	return tkApplyAnthropicRequestCompatibilityRules(account, body)
 }
 
 // buildOAuthMetadataUserIDFromBody 是 buildOAuthMetadataUserID 的变体，

--- a/backend/internal/service/gateway_claude_oauth_body.go
+++ b/backend/internal/service/gateway_claude_oauth_body.go
@@ -430,7 +430,7 @@ func (s *GatewayService) applyClaudeCodeOAuthMimicryToBody(
 		body = applyToolsLastCacheBreakpoint(body)
 	}
 
-	return tkStripDeprecatedSamplingParams(body)
+	return tkApplyAnthropicRequestCompatibilityRules(body)
 }
 
 // buildOAuthMetadataUserIDFromBody 是 buildOAuthMetadataUserID 的变体，

--- a/backend/internal/service/gateway_count_tokens.go
+++ b/backend/internal/service/gateway_count_tokens.go
@@ -71,7 +71,7 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes, strip empty
 	// text blocks, drop explicit disabled thinking for Fable, and strip fields
 	// rejected by newer Anthropic models.
-	if err := replaceBody(tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))); err != nil {
+	if err := replaceBody(tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))); err != nil {
 		return err
 	}
 
@@ -232,8 +232,8 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 
 	// 检测 thinking block 签名错误（400）并重试一次（过滤 thinking blocks）
 	if resp.StatusCode == 400 {
-		tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, reqModel, resp.StatusCode, respBody)
-		tkRecordAnthropicThinkingRuleFrom400(account.Platform, reqModel, resp.StatusCode, respBody)
+		tkRecordAnthropicSamplingParamRuleFrom400(account, reqModel, body, resp.StatusCode, respBody)
+		tkRecordAnthropicThinkingRuleFrom400(account, reqModel, body, resp.StatusCode, respBody)
 	}
 	if resp.StatusCode == 400 && s.shouldRectifySignatureError(ctx, account, respBody, reqModel) {
 		logger.LegacyPrintf("service.gateway", "Account %d: detected thinking block signature error on count_tokens, retrying with filtered thinking blocks", account.ID)
@@ -396,8 +396,8 @@ func (s *GatewayService) forwardCountTokensAnthropicPassthrough(ctx context.Cont
 	if resp.StatusCode >= 400 {
 		if resp.StatusCode == 400 {
 			model := gjson.GetBytes(body, "model").String()
-			tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, model, resp.StatusCode, respBody)
-			tkRecordAnthropicThinkingRuleFrom400(account.Platform, model, resp.StatusCode, respBody)
+			tkRecordAnthropicSamplingParamRuleFrom400(account, model, body, resp.StatusCode, respBody)
+			tkRecordAnthropicThinkingRuleFrom400(account, model, body, resp.StatusCode, respBody)
 		}
 		if isCountTokensUnsupported404(resp.StatusCode, respBody) {
 			logger.LegacyPrintf("service.gateway",

--- a/backend/internal/service/gateway_count_tokens.go
+++ b/backend/internal/service/gateway_count_tokens.go
@@ -71,7 +71,7 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes, strip empty
 	// text blocks, drop explicit disabled thinking for Fable, and strip fields
 	// rejected by newer Anthropic models.
-	if err := replaceBody(tkStripDeprecatedSamplingParams(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))); err != nil {
+	if err := replaceBody(tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))); err != nil {
 		return err
 	}
 
@@ -231,6 +231,10 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	}
 
 	// 检测 thinking block 签名错误（400）并重试一次（过滤 thinking blocks）
+	if resp.StatusCode == 400 {
+		tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, reqModel, resp.StatusCode, respBody)
+		tkRecordAnthropicThinkingRuleFrom400(account.Platform, reqModel, resp.StatusCode, respBody)
+	}
 	if resp.StatusCode == 400 && s.shouldRectifySignatureError(ctx, account, respBody, reqModel) {
 		logger.LegacyPrintf("service.gateway", "Account %d: detected thinking block signature error on count_tokens, retrying with filtered thinking blocks", account.ID)
 		s.armSigPreemptOnError(ctx, c, account)
@@ -390,6 +394,11 @@ func (s *GatewayService) forwardCountTokensAnthropicPassthrough(ctx context.Cont
 	}
 
 	if resp.StatusCode >= 400 {
+		if resp.StatusCode == 400 {
+			model := gjson.GetBytes(body, "model").String()
+			tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, model, resp.StatusCode, respBody)
+			tkRecordAnthropicThinkingRuleFrom400(account.Platform, model, resp.StatusCode, respBody)
+		}
 		if isCountTokensUnsupported404(resp.StatusCode, respBody) {
 			logger.LegacyPrintf("service.gateway",
 				"[count_tokens] Upstream does not support count_tokens, returning local estimate: account=%d name=%s",

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -403,7 +403,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes, strip empty
 	// text blocks, drop explicit disabled thinking for Fable, and strip fields
 	// rejected by newer Anthropic models before upstream.
-	if err := replaceBody(tkStripDeprecatedSamplingParams(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))); err != nil {
+	if err := replaceBody(tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))); err != nil {
 		return nil, err
 	}
 	// Pre-filter: strip web-search history blocks the upstream cannot accept
@@ -511,6 +511,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			if readErr == nil {
 				_ = resp.Body.Close()
 				tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, reqModel, resp.StatusCode, respBody)
+				tkRecordAnthropicThinkingRuleFrom400(account.Platform, reqModel, resp.StatusCode, respBody)
 
 				if s.shouldRectifySignatureError(ctx, account, respBody, reqModel) {
 					appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
@@ -709,6 +710,53 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 				}
 
 				errMsg := extractUpstreamErrorMessage(respBody)
+				if isThinkingTypeAdaptiveRequiredError(errMsg) {
+					appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+						Platform:           account.Platform,
+						AccountID:          account.ID,
+						AccountName:        account.Name,
+						UpstreamStatusCode: resp.StatusCode,
+						UpstreamRequestID:  resp.Header.Get("x-request-id"),
+						UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
+						Kind:               "thinking_adaptive_error",
+						Message:            errMsg,
+						Detail: func() string {
+							if s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody {
+								return truncateString(string(respBody), s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes)
+							}
+							return ""
+						}(),
+					})
+
+					rectifiedBody, applied := RectifyThinkingTypeAdaptive(body)
+					if applied && time.Since(retryStart) < maxRetryElapsed {
+						logger.LegacyPrintf("service.gateway", "Account %d: detected thinking.type adaptive-only error, retrying with adaptive thinking", account.ID)
+						adaptiveRetryCtx, releaseAdaptiveRetryCtx := detachStreamUpstreamContext(ctx, reqStream)
+						adaptiveRetryReq, adaptiveWireBody, buildErr := s.buildUpstreamRequest(adaptiveRetryCtx, c, account, rectifiedBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
+						releaseAdaptiveRetryCtx()
+						if buildErr == nil {
+							adaptiveRetryResp, retryErr := s.httpUpstream.DoWithTLS(adaptiveRetryReq, proxyURL, account.ID, account.Concurrency, tlsProfile)
+							if retryErr == nil {
+								if adaptiveRetryResp.StatusCode < 400 {
+									lastWireBody = adaptiveWireBody
+									if err := replaceBody(adaptiveWireBody); err != nil {
+										_ = adaptiveRetryResp.Body.Close()
+										return nil, err
+									}
+									setOpsUpstreamRequestBody(c, adaptiveWireBody)
+								}
+								resp = adaptiveRetryResp
+								break
+							}
+							if adaptiveRetryResp != nil && adaptiveRetryResp.Body != nil {
+								_ = adaptiveRetryResp.Body.Close()
+							}
+							logger.LegacyPrintf("service.gateway", "Account %d: thinking adaptive retry failed: %v", account.ID, retryErr)
+						} else {
+							logger.LegacyPrintf("service.gateway", "Account %d: thinking adaptive retry build failed: %v", account.ID, buildErr)
+						}
+					}
+				}
 				if isThinkingBudgetConstraintError(errMsg) && s.settingService.IsBudgetRectifierEnabled(ctx) {
 					appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 						Platform:           account.Platform,

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -403,7 +403,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes, strip empty
 	// text blocks, drop explicit disabled thinking for Fable, and strip fields
 	// rejected by newer Anthropic models before upstream.
-	if err := replaceBody(tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))); err != nil {
+	if err := replaceBody(tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))); err != nil {
 		return nil, err
 	}
 	// Pre-filter: strip web-search history blocks the upstream cannot accept
@@ -510,8 +510,8 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			respBody, readErr := s.readUpstreamErrorBody(resp)
 			if readErr == nil {
 				_ = resp.Body.Close()
-				tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, reqModel, resp.StatusCode, respBody)
-				tkRecordAnthropicThinkingRuleFrom400(account.Platform, reqModel, resp.StatusCode, respBody)
+				tkRecordAnthropicSamplingParamRuleFrom400(account, reqModel, body, resp.StatusCode, respBody)
+				tkRecordAnthropicThinkingRuleFrom400(account, reqModel, body, resp.StatusCode, respBody)
 
 				if s.shouldRectifySignatureError(ctx, account, respBody, reqModel) {
 					appendOpsUpstreamError(c, OpsUpstreamErrorEvent{

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -510,6 +510,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			respBody, readErr := s.readUpstreamErrorBody(resp)
 			if readErr == nil {
 				_ = resp.Body.Close()
+				tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, reqModel, resp.StatusCode, respBody)
 
 				if s.shouldRectifySignatureError(ctx, account, respBody, reqModel) {
 					appendOpsUpstreamError(c, OpsUpstreamErrorEvent{

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -118,7 +118,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
-	anthropicBody = tkStripDeprecatedSamplingParams(anthropicBody)
+	anthropicBody = tkApplyAnthropicRequestCompatibilityRules(anthropicBody)
 
 	// TK: thread gemini-native image aspect ratio (extra_body.google.image_config.
 	// aspect_ratio) from the raw CC body onto the relayed Anthropic body; the antigravity
@@ -173,6 +173,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 		if resp.StatusCode == http.StatusBadRequest {
 			tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, mappedModel, resp.StatusCode, respBody)
+			tkRecordAnthropicThinkingRuleFrom400(account.Platform, mappedModel, resp.StatusCode, respBody)
 		}
 
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -171,6 +171,9 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		respBody, _ := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		if resp.StatusCode == http.StatusBadRequest {
+			tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, mappedModel, resp.StatusCode, respBody)
+		}
 
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -118,7 +118,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
-	anthropicBody = tkApplyAnthropicRequestCompatibilityRules(anthropicBody)
+	anthropicBody = tkApplyAnthropicRequestCompatibilityRules(account, anthropicBody)
 
 	// TK: thread gemini-native image aspect ratio (extra_body.google.image_config.
 	// aspect_ratio) from the raw CC body onto the relayed Anthropic body; the antigravity
@@ -172,8 +172,8 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 		if resp.StatusCode == http.StatusBadRequest {
-			tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, mappedModel, resp.StatusCode, respBody)
-			tkRecordAnthropicThinkingRuleFrom400(account.Platform, mappedModel, resp.StatusCode, respBody)
+			tkRecordAnthropicSamplingParamRuleFrom400(account, mappedModel, anthropicBody, resp.StatusCode, respBody)
+			tkRecordAnthropicThinkingRuleFrom400(account, mappedModel, anthropicBody, resp.StatusCode, respBody)
 		}
 
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -165,6 +165,9 @@ func (s *GatewayService) ForwardAsResponses(
 		respBody, _ := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		if resp.StatusCode == http.StatusBadRequest {
+			tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, mappedModel, resp.StatusCode, respBody)
+		}
 
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -117,7 +117,7 @@ func (s *GatewayService) ForwardAsResponses(
 
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
-	anthropicBody = tkStripDeprecatedSamplingParams(anthropicBody)
+	anthropicBody = tkApplyAnthropicRequestCompatibilityRules(anthropicBody)
 
 	// 8. Get access token
 	token, tokenType, err := s.GetAccessToken(ctx, account)
@@ -167,6 +167,7 @@ func (s *GatewayService) ForwardAsResponses(
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 		if resp.StatusCode == http.StatusBadRequest {
 			tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, mappedModel, resp.StatusCode, respBody)
+			tkRecordAnthropicThinkingRuleFrom400(account.Platform, mappedModel, resp.StatusCode, respBody)
 		}
 
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -117,7 +117,7 @@ func (s *GatewayService) ForwardAsResponses(
 
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
-	anthropicBody = tkApplyAnthropicRequestCompatibilityRules(anthropicBody)
+	anthropicBody = tkApplyAnthropicRequestCompatibilityRules(account, anthropicBody)
 
 	// 8. Get access token
 	token, tokenType, err := s.GetAccessToken(ctx, account)
@@ -166,8 +166,8 @@ func (s *GatewayService) ForwardAsResponses(
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 		if resp.StatusCode == http.StatusBadRequest {
-			tkRecordAnthropicSamplingParamRuleFrom400(account.Platform, mappedModel, resp.StatusCode, respBody)
-			tkRecordAnthropicThinkingRuleFrom400(account.Platform, mappedModel, resp.StatusCode, respBody)
+			tkRecordAnthropicSamplingParamRuleFrom400(account, mappedModel, anthropicBody, resp.StatusCode, respBody)
+			tkRecordAnthropicThinkingRuleFrom400(account, mappedModel, anthropicBody, resp.StatusCode, respBody)
 		}
 
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))

--- a/backend/internal/service/gateway_request_tk_deprecated_sampling.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_sampling.go
@@ -82,6 +82,10 @@ func tkClaudeFamilyVersionAtLeast(modelID, family string, minMajor, minMinor int
 // models that reject temperature+top_p in the same request. Nested JSON-schema
 // properties with the same names must remain intact.
 func tkStripDeprecatedSamplingParams(body []byte) []byte {
+	return tkStripDeprecatedSamplingParamsForAccount(nil, body)
+}
+
+func tkStripDeprecatedSamplingParamsForAccount(account *Account, body []byte) []byte {
 	if len(body) == 0 {
 		return body
 	}
@@ -92,10 +96,8 @@ func tkStripDeprecatedSamplingParams(body []byte) []byte {
 		return tkStripTopLevelSamplingFields(out, body)
 	}
 
-	if cachedRule, ok := tkGetCachedSamplingParamRule(model); ok {
+	if cachedRule, ok := tkGetCachedSamplingParamRule(account, model, body); ok {
 		switch cachedRule {
-		case tkSamplingParamRuleStripAll:
-			return tkStripTopLevelSamplingFields(out, body)
 		case tkSamplingParamRuleStripTopPWithTemperature:
 			if gjson.GetBytes(out, "temperature").Exists() && gjson.GetBytes(out, "top_p").Exists() {
 				stripped, err := sjson.DeleteBytes(out, "top_p")
@@ -105,6 +107,12 @@ func tkStripDeprecatedSamplingParams(body []byte) []byte {
 				out = stripped
 			}
 			return out
+		case tkSamplingParamRuleStripTemperature:
+			return tkStripTopLevelSamplingField(out, body, "temperature")
+		case tkSamplingParamRuleStripTopP:
+			return tkStripTopLevelSamplingField(out, body, "top_p")
+		case tkSamplingParamRuleStripTopK:
+			return tkStripTopLevelSamplingField(out, body, "top_k")
 		}
 	}
 
@@ -118,6 +126,17 @@ func tkStripDeprecatedSamplingParams(body []byte) []byte {
 		out = stripped
 	}
 	return out
+}
+
+func tkStripTopLevelSamplingField(body []byte, fallback []byte, field string) []byte {
+	if !gjson.GetBytes(body, field).Exists() {
+		return body
+	}
+	stripped, err := sjson.DeleteBytes(body, field)
+	if err != nil {
+		return fallback
+	}
+	return stripped
 }
 
 func tkStripTopLevelSamplingFields(body []byte, fallback []byte) []byte {

--- a/backend/internal/service/gateway_request_tk_deprecated_sampling.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_sampling.go
@@ -17,12 +17,12 @@ var tkDeprecatedSamplingTopLevelFields = []string{
 // tkModelDeprecatesSamplingParams reports whether Anthropic rejects non-default
 // top-level sampling params for this model. Live prod/edge traces on 2026-07-08
 // showed claude-opus-4-7 returning HTTP 400 for both `temperature` and `top_p`;
-// Anthropic's compatibility notes list temperature/top_p/top_k together for
-// Opus 4.7+, Sonnet 4.6+, and Sonnet 5+.
+// Anthropic's compatibility notes list temperature/top_p/top_k as removed for
+// Opus 4.7+ and Sonnet 5+. Sonnet 4.6 keeps the older temperature+top_p
+// mutual-exclusion behavior handled below.
 func tkModelDeprecatesSamplingParams(modelID string) bool {
 	return isOpus47OrNewer(modelID) ||
 		tkClaudeFamilyMajorAtLeast(modelID, "opus", 5) ||
-		tkClaudeFamilyVersionAtLeast(modelID, "sonnet", 4, 6) ||
 		tkClaudeFamilyMajorAtLeast(modelID, "sonnet", 5)
 }
 

--- a/backend/internal/service/gateway_request_tk_deprecated_sampling.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_sampling.go
@@ -30,7 +30,7 @@ func tkModelRejectsTemperatureTopPCombination(modelID string) bool {
 	if tkModelDeprecatesSamplingParams(modelID) {
 		return false
 	}
-	return tkClaudeFamilyVersionAtLeast(modelID, "opus", 4, 5) ||
+	return tkClaudeFamilyVersionAtLeast(modelID, "opus", 4, 1) ||
 		tkClaudeFamilyVersionAtLeast(modelID, "sonnet", 4, 5) ||
 		tkClaudeFamilyVersionAtLeast(modelID, "haiku", 4, 5)
 }
@@ -89,17 +89,23 @@ func tkStripDeprecatedSamplingParams(body []byte) []byte {
 	out := body
 
 	if tkModelDeprecatesSamplingParams(model) {
-		for _, field := range tkDeprecatedSamplingTopLevelFields {
-			if !gjson.GetBytes(out, field).Exists() {
-				continue
+		return tkStripTopLevelSamplingFields(out, body)
+	}
+
+	if cachedRule, ok := tkGetCachedSamplingParamRule(model); ok {
+		switch cachedRule {
+		case tkSamplingParamRuleStripAll:
+			return tkStripTopLevelSamplingFields(out, body)
+		case tkSamplingParamRuleStripTopPWithTemperature:
+			if gjson.GetBytes(out, "temperature").Exists() && gjson.GetBytes(out, "top_p").Exists() {
+				stripped, err := sjson.DeleteBytes(out, "top_p")
+				if err != nil {
+					return body
+				}
+				out = stripped
 			}
-			stripped, err := sjson.DeleteBytes(out, field)
-			if err != nil {
-				return body
-			}
-			out = stripped
+			return out
 		}
-		return out
 	}
 
 	if tkModelRejectsTemperatureTopPCombination(model) &&
@@ -108,6 +114,21 @@ func tkStripDeprecatedSamplingParams(body []byte) []byte {
 		stripped, err := sjson.DeleteBytes(out, "top_p")
 		if err != nil {
 			return body
+		}
+		out = stripped
+	}
+	return out
+}
+
+func tkStripTopLevelSamplingFields(body []byte, fallback []byte) []byte {
+	out := body
+	for _, field := range tkDeprecatedSamplingTopLevelFields {
+		if !gjson.GetBytes(out, field).Exists() {
+			continue
+		}
+		stripped, err := sjson.DeleteBytes(out, field)
+		if err != nil {
+			return fallback
 		}
 		out = stripped
 	}

--- a/backend/internal/service/gateway_request_tk_deprecated_sampling.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_sampling.go
@@ -18,11 +18,21 @@ var tkDeprecatedSamplingTopLevelFields = []string{
 // top-level sampling params for this model. Live prod/edge traces on 2026-07-08
 // showed claude-opus-4-7 returning HTTP 400 for both `temperature` and `top_p`;
 // Anthropic's compatibility notes list temperature/top_p/top_k together for
-// Opus 4.7+ and Sonnet 5+.
+// Opus 4.7+, Sonnet 4.6+, and Sonnet 5+.
 func tkModelDeprecatesSamplingParams(modelID string) bool {
 	return isOpus47OrNewer(modelID) ||
 		tkClaudeFamilyMajorAtLeast(modelID, "opus", 5) ||
+		tkClaudeFamilyVersionAtLeast(modelID, "sonnet", 4, 6) ||
 		tkClaudeFamilyMajorAtLeast(modelID, "sonnet", 5)
+}
+
+func tkModelRejectsTemperatureTopPCombination(modelID string) bool {
+	if tkModelDeprecatesSamplingParams(modelID) {
+		return false
+	}
+	return tkClaudeFamilyVersionAtLeast(modelID, "opus", 4, 5) ||
+		tkClaudeFamilyVersionAtLeast(modelID, "sonnet", 4, 5) ||
+		tkClaudeFamilyVersionAtLeast(modelID, "haiku", 4, 5)
 }
 
 func tkClaudeFamilyMajorAtLeast(modelID, family string, minMajor int) bool {
@@ -53,23 +63,49 @@ func tkClaudeFamilyMajorAtLeast(modelID, family string, minMajor int) bool {
 	return err == nil && major >= minMajor
 }
 
+func tkClaudeFamilyVersionAtLeast(modelID, family string, minMajor, minMinor int) bool {
+	lower := strings.ToLower(modelID)
+	if !strings.Contains(lower, family) {
+		return false
+	}
+	matches := claudeVersionRe.FindStringSubmatch(lower)
+	if matches == nil {
+		return false
+	}
+	major, _ := strconv.Atoi(matches[1])
+	minor, _ := strconv.Atoi(matches[2])
+	return major > minMajor || (major == minMajor && minor >= minMinor)
+}
+
 // tkStripDeprecatedSamplingParams removes only top-level sampling fields for
-// Anthropic models that now reject them. Nested JSON-schema properties with the
-// same names must remain intact.
+// Anthropic models that now reject them, and removes top_p for current Claude
+// models that reject temperature+top_p in the same request. Nested JSON-schema
+// properties with the same names must remain intact.
 func tkStripDeprecatedSamplingParams(body []byte) []byte {
 	if len(body) == 0 {
 		return body
 	}
 	model := gjson.GetBytes(body, "model").String()
-	if !tkModelDeprecatesSamplingParams(model) {
-		return body
-	}
 	out := body
-	for _, field := range tkDeprecatedSamplingTopLevelFields {
-		if !gjson.GetBytes(out, field).Exists() {
-			continue
+
+	if tkModelDeprecatesSamplingParams(model) {
+		for _, field := range tkDeprecatedSamplingTopLevelFields {
+			if !gjson.GetBytes(out, field).Exists() {
+				continue
+			}
+			stripped, err := sjson.DeleteBytes(out, field)
+			if err != nil {
+				return body
+			}
+			out = stripped
 		}
-		stripped, err := sjson.DeleteBytes(out, field)
+		return out
+	}
+
+	if tkModelRejectsTemperatureTopPCombination(model) &&
+		gjson.GetBytes(out, "temperature").Exists() &&
+		gjson.GetBytes(out, "top_p").Exists() {
+		stripped, err := sjson.DeleteBytes(out, "top_p")
 		if err != nil {
 			return body
 		}

--- a/backend/internal/service/gateway_request_tk_deprecated_sampling_test.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_sampling_test.go
@@ -174,6 +174,32 @@ func TestTkSamplingParamRuleFromAnthropic400(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestTkAnthropicThinkingRuleFrom400(t *testing.T) {
+	adaptiveBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}}`)
+	rule, ok := tkAnthropicThinkingRuleFrom400("claude-next-preview", http.StatusBadRequest, adaptiveBody)
+	require.True(t, ok)
+	require.Equal(t, tkAnthropicThinkingRuleAdaptiveOnly, rule)
+
+	budgetBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"thinking.budget_tokens: Input should be greater than or equal to 1024"}}`)
+	_, ok = tkAnthropicThinkingRuleFrom400("claude-sonnet-4-5", http.StatusBadRequest, budgetBody)
+	require.False(t, ok)
+
+	prefillBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Prefilling assistant messages is not supported for this model."}}`)
+	_, ok = tkAnthropicThinkingRuleFrom400("claude-opus-4-8", http.StatusBadRequest, prefillBody)
+	require.False(t, ok)
+
+	signatureBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.0: Invalid signature in thinking block"}}`)
+	_, ok = tkAnthropicThinkingRuleFrom400("claude-sonnet-4-5", http.StatusBadRequest, signatureBody)
+	require.False(t, ok)
+
+	overloadedBody := []byte(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)
+	_, ok = tkAnthropicThinkingRuleFrom400("claude-next-preview", http.StatusBadRequest, overloadedBody)
+	require.False(t, ok)
+
+	_, ok = tkAnthropicThinkingRuleFrom400("claude-next-preview", http.StatusTooManyRequests, adaptiveBody)
+	require.False(t, ok)
+}
+
 func TestTkStripDeprecatedSamplingParams_UsesCachedSamplingRule(t *testing.T) {
 	tkSamplingParamRules.Flush()
 	defer tkSamplingParamRules.Flush()
@@ -186,6 +212,20 @@ func TestTkStripDeprecatedSamplingParams_UsesCachedSamplingRule(t *testing.T) {
 	require.True(t, gjson.GetBytes(got, "temperature").Exists())
 	require.False(t, gjson.GetBytes(got, "top_p").Exists())
 	require.True(t, gjson.GetBytes(got, "top_k").Exists())
+}
+
+func TestTkApplyAnthropicRequestCompatibilityRules_UsesCachedAdaptiveThinkingRule(t *testing.T) {
+	tkAnthropicThinkingRules.Flush()
+	defer tkAnthropicThinkingRules.Flush()
+
+	body := []byte(`{"model":"claude-next-preview","thinking":{"type":"enabled","budget_tokens":1024},"max_tokens":2048,"messages":[]}`)
+	require.Equal(t, body, tkApplyAnthropicRequestCompatibilityRules(body))
+
+	tkPutCachedAnthropicThinkingRule("claude-next-preview", tkAnthropicThinkingRuleAdaptiveOnly)
+	got := tkApplyAnthropicRequestCompatibilityRules(body)
+	require.Equal(t, "adaptive", gjson.GetBytes(got, "thinking.type").String())
+	require.False(t, gjson.GetBytes(got, "thinking.budget_tokens").Exists())
+	require.Equal(t, "claude-next-preview", gjson.GetBytes(got, "model").String())
 }
 
 func TestRectifyAnthropicPassthrough400_SamplingParamRetryCachesRule(t *testing.T) {

--- a/backend/internal/service/gateway_request_tk_deprecated_sampling_test.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_sampling_test.go
@@ -59,6 +59,18 @@ func TestTkStripDeprecatedSamplingParams_StripsTopPWhenTemperatureAlsoPresent(t 
 	require.True(t, gjson.ValidBytes(got))
 }
 
+func TestTkStripDeprecatedSamplingParams_StripsTopPForOpus41(t *testing.T) {
+	input := []byte(`{"model":"claude-opus-4-1-20250805","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[{"role":"user","content":"hi"}]}`)
+
+	got := tkStripDeprecatedSamplingParams(input)
+
+	require.True(t, gjson.GetBytes(got, "temperature").Exists())
+	require.False(t, gjson.GetBytes(got, "top_p").Exists())
+	require.True(t, gjson.GetBytes(got, "top_k").Exists())
+	require.Equal(t, "claude-opus-4-1-20250805", gjson.GetBytes(got, "model").String())
+	require.True(t, gjson.ValidBytes(got))
+}
+
 func TestTkStripDeprecatedSamplingParams_StripsTopPForDatedHaiku45(t *testing.T) {
 	input := []byte(`{"model":"claude-haiku-4-5-20251001","temperature":1,"top_p":0.999,"messages":[{"role":"user","content":"hi"}]}`)
 
@@ -117,6 +129,8 @@ func TestTkModelRejectsTemperatureTopPCombination(t *testing.T) {
 		{"claude-sonnet-4-5-20250929", true},
 		{"claude-haiku-4-5", true},
 		{"claude-haiku-4-5-20251001", true},
+		{"claude-opus-4-1", true},
+		{"claude-opus-4-1-20250805", true},
 		{"anthropic.claude-opus-4-5-v1:0", true},
 		{"claude-opus-4-6", true},
 		{"claude-opus-4-7", false},
@@ -130,6 +144,69 @@ func TestTkModelRejectsTemperatureTopPCombination(t *testing.T) {
 			require.Equal(t, tc.want, tkModelRejectsTemperatureTopPCombination(tc.model))
 		})
 	}
+}
+
+func TestTkSamplingParamRuleFromAnthropic400(t *testing.T) {
+	conflictBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"` + "`temperature` and `top_p` cannot both be specified for this model. Please use only one." + `"}}`)
+	rule, ok := tkSamplingParamRuleFromAnthropic400("claude-sonnet-4-5", http.StatusBadRequest, conflictBody)
+	require.True(t, ok)
+	require.Equal(t, tkSamplingParamRuleStripTopPWithTemperature, rule)
+
+	unsupportedBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"temperature: Extra inputs are not permitted"}}`)
+	rule, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, unsupportedBody)
+	require.True(t, ok)
+	require.Equal(t, tkSamplingParamRuleStripAll, rule)
+
+	overloadedBody := []byte(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)
+	_, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, overloadedBody)
+	require.False(t, ok)
+
+	rangeBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"temperature: Input should be less than or equal to 1"}}`)
+	_, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, rangeBody)
+	require.False(t, ok)
+
+	prefillBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Prefilling assistant messages is not supported for this model."}}`)
+	_, ok = tkSamplingParamRuleFromAnthropic400("claude-opus-4-8", http.StatusBadRequest, prefillBody)
+	require.False(t, ok)
+
+	thinkingBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.0: thinking or redacted_thinking blocks in the latest assistant message cannot be modified."}}`)
+	_, ok = tkSamplingParamRuleFromAnthropic400("claude-sonnet-4-5", http.StatusBadRequest, thinkingBody)
+	require.False(t, ok)
+}
+
+func TestTkStripDeprecatedSamplingParams_UsesCachedSamplingRule(t *testing.T) {
+	tkSamplingParamRules.Flush()
+	defer tkSamplingParamRules.Flush()
+
+	body := []byte(`{"model":"claude-next-preview","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[]}`)
+	require.Equal(t, body, tkStripDeprecatedSamplingParams(body))
+
+	tkPutCachedSamplingParamRule("claude-next-preview", tkSamplingParamRuleStripTopPWithTemperature)
+	got := tkStripDeprecatedSamplingParams(body)
+	require.True(t, gjson.GetBytes(got, "temperature").Exists())
+	require.False(t, gjson.GetBytes(got, "top_p").Exists())
+	require.True(t, gjson.GetBytes(got, "top_k").Exists())
+}
+
+func TestRectifyAnthropicPassthrough400_SamplingParamRetryCachesRule(t *testing.T) {
+	tkSamplingParamRules.Flush()
+	defer tkSamplingParamRules.Flush()
+
+	body := []byte(`{"model":"claude-next-preview","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[]}`)
+	respBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"You should either alter temperature or top_p, but not both."}}`)
+	svc := &GatewayService{}
+	account := &Account{Platform: PlatformAnthropic}
+
+	got, kind, ok := svc.rectifyAnthropicPassthrough400(context.Background(), account, body, "claude-next-preview", respBody)
+
+	require.True(t, ok)
+	require.Equal(t, "sampling_param_retry", kind)
+	require.True(t, gjson.GetBytes(got, "temperature").Exists())
+	require.False(t, gjson.GetBytes(got, "top_p").Exists())
+	require.True(t, gjson.GetBytes(got, "top_k").Exists())
+	rule, exists := tkGetCachedSamplingParamRule("claude-next-preview")
+	require.True(t, exists)
+	require.Equal(t, tkSamplingParamRuleStripTopPWithTemperature, rule)
 }
 
 func TestForwardAsChatCompletions_AnthropicOpus47StripsDeprecatedSamplingParams(t *testing.T) {

--- a/backend/internal/service/gateway_request_tk_deprecated_sampling_test.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_sampling_test.go
@@ -34,10 +34,46 @@ func TestTkStripDeprecatedSamplingParams_StripIsTopLevelOnly(t *testing.T) {
 
 func TestTkStripDeprecatedSamplingParams_NoTouchForOlderClaudeModels(t *testing.T) {
 	cases := []string{
-		`{"model":"claude-opus-4-6","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[]}`,
-		`{"model":"claude-sonnet-4-6","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[]}`,
-		`{"model":"claude-haiku-4-5","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[]}`,
+		`{"model":"claude-opus-4-6","top_p":0.9,"top_k":40,"messages":[]}`,
+		`{"model":"claude-haiku-4-5","top_p":0.9,"top_k":40,"messages":[]}`,
 		`{"model":"gpt-5.5","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[]}`,
+	}
+	for _, body := range cases {
+		t.Run(gjson.Get(body, "model").String(), func(t *testing.T) {
+			got := tkStripDeprecatedSamplingParams([]byte(body))
+			require.Equal(t, body, string(got))
+		})
+	}
+}
+
+func TestTkStripDeprecatedSamplingParams_StripsTopPWhenTemperatureAlsoPresent(t *testing.T) {
+	input := []byte(`{"model":"claude-sonnet-4-5","temperature":0.7,"top_p":0.9,"top_k":40,"tools":[{"name":"set_temp","input_schema":{"type":"object","properties":{"top_p":{"type":"number"}}}}],"messages":[{"role":"user","content":"hi"}]}`)
+
+	got := tkStripDeprecatedSamplingParams(input)
+
+	require.True(t, gjson.GetBytes(got, "temperature").Exists())
+	require.False(t, gjson.GetBytes(got, "top_p").Exists())
+	require.True(t, gjson.GetBytes(got, "top_k").Exists())
+	require.True(t, gjson.GetBytes(got, "tools.0.input_schema.properties.top_p").Exists())
+	require.Equal(t, "claude-sonnet-4-5", gjson.GetBytes(got, "model").String())
+	require.True(t, gjson.ValidBytes(got))
+}
+
+func TestTkStripDeprecatedSamplingParams_StripsTopPForDatedHaiku45(t *testing.T) {
+	input := []byte(`{"model":"claude-haiku-4-5-20251001","temperature":1,"top_p":0.999,"messages":[{"role":"user","content":"hi"}]}`)
+
+	got := tkStripDeprecatedSamplingParams(input)
+
+	require.True(t, gjson.GetBytes(got, "temperature").Exists())
+	require.False(t, gjson.GetBytes(got, "top_p").Exists())
+	require.Equal(t, "claude-haiku-4-5-20251001", gjson.GetBytes(got, "model").String())
+	require.True(t, gjson.ValidBytes(got))
+}
+
+func TestTkStripDeprecatedSamplingParams_DoesNotStripSingleSamplingParamFor45(t *testing.T) {
+	cases := []string{
+		`{"model":"claude-sonnet-4-5","temperature":0.7,"messages":[]}`,
+		`{"model":"claude-haiku-4-5","top_p":0.9,"messages":[]}`,
 	}
 	for _, body := range cases {
 		t.Run(gjson.Get(body, "model").String(), func(t *testing.T) {
@@ -55,17 +91,43 @@ func TestTkModelDeprecatesSamplingParams(t *testing.T) {
 		{"claude-opus-4-7", true},
 		{"claude-opus-4.8", true},
 		{"anthropic.claude-opus-5-v1:0", true},
+		{"claude-sonnet-4-6", true},
+		{"claude-sonnet-4-6-20260708", true},
 		{"claude-sonnet-5", true},
 		{"claude-sonnet-5-20260708", true},
 		{"anthropic.claude-sonnet-5-v1:0", true},
 		{"claude-opus-4-6", false},
-		{"claude-sonnet-4-7", false},
+		{"claude-sonnet-4-5", false},
 		{"claude-haiku-5-0", false},
 		{"gpt-5.5", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.model, func(t *testing.T) {
 			require.Equal(t, tc.want, tkModelDeprecatesSamplingParams(tc.model))
+		})
+	}
+}
+
+func TestTkModelRejectsTemperatureTopPCombination(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"claude-sonnet-4-5", true},
+		{"claude-sonnet-4-5-20250929", true},
+		{"claude-haiku-4-5", true},
+		{"claude-haiku-4-5-20251001", true},
+		{"anthropic.claude-opus-4-5-v1:0", true},
+		{"claude-opus-4-6", true},
+		{"claude-opus-4-7", false},
+		{"claude-sonnet-4-6", false},
+		{"claude-sonnet-5", false},
+		{"claude-3-5-sonnet-20241022", false},
+		{"gpt-5.5", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			require.Equal(t, tc.want, tkModelRejectsTemperatureTopPCombination(tc.model))
 		})
 	}
 }
@@ -133,6 +195,65 @@ data: {"type":"message_stop"}
 	require.Equal(t, http.StatusOK, rec.Code)
 }
 
+func TestForwardAsChatCompletions_AnthropicSonnet45StripsTopPConflict(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"claude-sonnet-4-5","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"usage":{"input_tokens":3,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_sonnet45_sampling"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          54,
+		Name:        "cc-us4",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key": "sk-ant-relay",
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, gjson.GetBytes(upstream.lastBody, "temperature").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "top_p").Exists(),
+		"Claude 4.5 rejects temperature and top_p in the same Anthropic Messages request")
+	require.Equal(t, "claude-sonnet-4-5", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
 func TestApplyClaudeCodeOAuthMimicry_AnthropicOpus47StripsDeprecatedSamplingParams(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-7","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[{"role":"user","content":"hello"}]}`)
 	svc := &GatewayService{}
@@ -152,4 +273,23 @@ func TestApplyClaudeCodeOAuthMimicry_AnthropicOpus47StripsDeprecatedSamplingPara
 		"OAuth mimicry normalize must not leave deprecated top-level top_k for Opus 4.7+")
 	require.True(t, gjson.GetBytes(got, "messages").Exists())
 	require.Equal(t, "claude-opus-4-7", gjson.GetBytes(got, "model").String())
+}
+
+func TestApplyClaudeCodeOAuthMimicry_AnthropicHaiku45StripsTopPConflict(t *testing.T) {
+	body := []byte(`{"model":"claude-haiku-4-5","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[{"role":"user","content":"hello"}]}`)
+	svc := &GatewayService{}
+	account := &Account{
+		ID:       55,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+	}
+
+	got := svc.applyClaudeCodeOAuthMimicryToBody(context.Background(), nil, account, body, nil, "claude-haiku-4-5")
+
+	require.True(t, gjson.GetBytes(got, "temperature").Exists())
+	require.False(t, gjson.GetBytes(got, "top_p").Exists(),
+		"OAuth mimicry normalize must not leave top_p next to temperature for Haiku 4.5")
+	require.True(t, gjson.GetBytes(got, "top_k").Exists())
+	require.True(t, gjson.GetBytes(got, "messages").Exists())
+	require.Equal(t, "claude-haiku-4-5-20251001", gjson.GetBytes(got, "model").String())
 }

--- a/backend/internal/service/gateway_request_tk_deprecated_sampling_test.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_sampling_test.go
@@ -171,17 +171,17 @@ func TestTkSamplingParamRuleFromAnthropic400(t *testing.T) {
 	unsupportedBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"temperature: Extra inputs are not permitted"}}`)
 	rule, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, unsupportedBody)
 	require.True(t, ok)
-	require.Equal(t, tkSamplingParamRuleStripAll, rule)
+	require.Equal(t, tkSamplingParamRuleStripTemperature, rule)
 
 	unknownParamBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Unknown parameter: top_k"}}`)
 	rule, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, unknownParamBody)
 	require.True(t, ok)
-	require.Equal(t, tkSamplingParamRuleStripAll, rule)
+	require.Equal(t, tkSamplingParamRuleStripTopK, rule)
 
 	unrecognizedParamBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Unrecognized request argument supplied: top_p"}}`)
 	rule, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, unrecognizedParamBody)
 	require.True(t, ok)
-	require.Equal(t, tkSamplingParamRuleStripAll, rule)
+	require.Equal(t, tkSamplingParamRuleStripTopP, rule)
 
 	nonSamplingUnknownParamBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Unknown parameter: max_tokens"}}`)
 	_, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, nonSamplingUnknownParamBody)
@@ -234,13 +234,40 @@ func TestTkStripDeprecatedSamplingParams_UsesCachedSamplingRule(t *testing.T) {
 	tkSamplingParamRules.Flush()
 	defer tkSamplingParamRules.Flush()
 
+	account := &Account{ID: 77, Platform: PlatformAnthropic}
 	body := []byte(`{"model":"claude-next-preview","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[]}`)
-	require.Equal(t, body, tkStripDeprecatedSamplingParams(body))
+	require.Equal(t, body, tkStripDeprecatedSamplingParamsForAccount(account, body))
 
-	tkPutCachedSamplingParamRule("claude-next-preview", tkSamplingParamRuleStripTopPWithTemperature)
-	got := tkStripDeprecatedSamplingParams(body)
+	tkPutCachedSamplingParamRule(account, "claude-next-preview", body, tkSamplingParamRuleStripTopPWithTemperature)
+	got := tkStripDeprecatedSamplingParamsForAccount(account, body)
 	require.True(t, gjson.GetBytes(got, "temperature").Exists())
 	require.False(t, gjson.GetBytes(got, "top_p").Exists())
+	require.True(t, gjson.GetBytes(got, "top_k").Exists())
+}
+
+func TestTkStripDeprecatedSamplingParams_CachedRuleScopedByAccountAndRequestShape(t *testing.T) {
+	tkSamplingParamRules.Flush()
+	defer tkSamplingParamRules.Flush()
+
+	account := &Account{ID: 78, Platform: PlatformAnthropic}
+	otherAccount := &Account{ID: 79, Platform: PlatformAnthropic}
+	failedShape := []byte(`{"model":"claude-next-preview","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[]}`)
+	tkPutCachedSamplingParamRule(account, "claude-next-preview", failedShape, tkSamplingParamRuleStripTemperature)
+
+	noSampling := []byte(`{"model":"claude-next-preview","messages":[]}`)
+	require.Equal(t, noSampling, tkStripDeprecatedSamplingParamsForAccount(account, noSampling),
+		"model-level cache must not touch requests without the failed sampling shape")
+
+	differentShape := []byte(`{"model":"claude-next-preview","top_p":0.9,"messages":[]}`)
+	require.Equal(t, differentShape, tkStripDeprecatedSamplingParamsForAccount(account, differentShape),
+		"same model with different sampling fields must remain untouched")
+
+	require.Equal(t, failedShape, tkStripDeprecatedSamplingParamsForAccount(otherAccount, failedShape),
+		"sampling compatibility cache must not cross account boundaries")
+
+	got := tkStripDeprecatedSamplingParamsForAccount(account, failedShape)
+	require.False(t, gjson.GetBytes(got, "temperature").Exists())
+	require.True(t, gjson.GetBytes(got, "top_p").Exists())
 	require.True(t, gjson.GetBytes(got, "top_k").Exists())
 }
 
@@ -248,14 +275,19 @@ func TestTkApplyAnthropicRequestCompatibilityRules_UsesCachedAdaptiveThinkingRul
 	tkAnthropicThinkingRules.Flush()
 	defer tkAnthropicThinkingRules.Flush()
 
+	account := &Account{ID: 80, Platform: PlatformAnthropic}
 	body := []byte(`{"model":"claude-next-preview","thinking":{"type":"enabled","budget_tokens":1024},"max_tokens":2048,"messages":[]}`)
-	require.Equal(t, body, tkApplyAnthropicRequestCompatibilityRules(body))
+	require.Equal(t, body, tkApplyAnthropicRequestCompatibilityRules(account, body))
 
-	tkPutCachedAnthropicThinkingRule("claude-next-preview", tkAnthropicThinkingRuleAdaptiveOnly)
-	got := tkApplyAnthropicRequestCompatibilityRules(body)
+	tkPutCachedAnthropicThinkingRule(account, "claude-next-preview", body, tkAnthropicThinkingRuleAdaptiveOnly)
+	got := tkApplyAnthropicRequestCompatibilityRules(account, body)
 	require.Equal(t, "adaptive", gjson.GetBytes(got, "thinking.type").String())
 	require.False(t, gjson.GetBytes(got, "thinking.budget_tokens").Exists())
 	require.Equal(t, "claude-next-preview", gjson.GetBytes(got, "model").String())
+
+	withoutThinking := []byte(`{"model":"claude-next-preview","messages":[]}`)
+	require.Equal(t, withoutThinking, tkApplyAnthropicRequestCompatibilityRules(account, withoutThinking),
+		"thinking cache must not touch normal requests without the failed thinking shape")
 }
 
 func TestRectifyAnthropicPassthrough400_SamplingParamRetryCachesRule(t *testing.T) {
@@ -265,7 +297,7 @@ func TestRectifyAnthropicPassthrough400_SamplingParamRetryCachesRule(t *testing.
 	body := []byte(`{"model":"claude-next-preview","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[]}`)
 	respBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"You should either alter temperature or top_p, but not both."}}`)
 	svc := &GatewayService{}
-	account := &Account{Platform: PlatformAnthropic}
+	account := &Account{ID: 81, Platform: PlatformAnthropic}
 
 	got, kind, ok := svc.rectifyAnthropicPassthrough400(context.Background(), account, body, "claude-next-preview", respBody)
 
@@ -274,7 +306,7 @@ func TestRectifyAnthropicPassthrough400_SamplingParamRetryCachesRule(t *testing.
 	require.True(t, gjson.GetBytes(got, "temperature").Exists())
 	require.False(t, gjson.GetBytes(got, "top_p").Exists())
 	require.True(t, gjson.GetBytes(got, "top_k").Exists())
-	rule, exists := tkGetCachedSamplingParamRule("claude-next-preview")
+	rule, exists := tkGetCachedSamplingParamRule(account, "claude-next-preview", body)
 	require.True(t, exists)
 	require.Equal(t, tkSamplingParamRuleStripTopPWithTemperature, rule)
 }

--- a/backend/internal/service/gateway_request_tk_deprecated_sampling_test.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_sampling_test.go
@@ -59,6 +59,18 @@ func TestTkStripDeprecatedSamplingParams_StripsTopPWhenTemperatureAlsoPresent(t 
 	require.True(t, gjson.ValidBytes(got))
 }
 
+func TestTkStripDeprecatedSamplingParams_StripsTopPForSonnet46(t *testing.T) {
+	input := []byte(`{"model":"claude-sonnet-4-6","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[{"role":"user","content":"hi"}]}`)
+
+	got := tkStripDeprecatedSamplingParams(input)
+
+	require.True(t, gjson.GetBytes(got, "temperature").Exists())
+	require.False(t, gjson.GetBytes(got, "top_p").Exists())
+	require.True(t, gjson.GetBytes(got, "top_k").Exists())
+	require.Equal(t, "claude-sonnet-4-6", gjson.GetBytes(got, "model").String())
+	require.True(t, gjson.ValidBytes(got))
+}
+
 func TestTkStripDeprecatedSamplingParams_StripsTopPForOpus41(t *testing.T) {
 	input := []byte(`{"model":"claude-opus-4-1-20250805","temperature":0.7,"top_p":0.9,"top_k":40,"messages":[{"role":"user","content":"hi"}]}`)
 
@@ -86,6 +98,9 @@ func TestTkStripDeprecatedSamplingParams_DoesNotStripSingleSamplingParamFor45(t 
 	cases := []string{
 		`{"model":"claude-sonnet-4-5","temperature":0.7,"messages":[]}`,
 		`{"model":"claude-haiku-4-5","top_p":0.9,"messages":[]}`,
+		`{"model":"claude-sonnet-4-6","temperature":0.7,"messages":[]}`,
+		`{"model":"claude-sonnet-4-6","top_p":0.9,"messages":[]}`,
+		`{"model":"claude-sonnet-4-6","top_k":40,"messages":[]}`,
 	}
 	for _, body := range cases {
 		t.Run(gjson.Get(body, "model").String(), func(t *testing.T) {
@@ -103,8 +118,8 @@ func TestTkModelDeprecatesSamplingParams(t *testing.T) {
 		{"claude-opus-4-7", true},
 		{"claude-opus-4.8", true},
 		{"anthropic.claude-opus-5-v1:0", true},
-		{"claude-sonnet-4-6", true},
-		{"claude-sonnet-4-6-20260708", true},
+		{"claude-sonnet-4-6", false},
+		{"claude-sonnet-4-6-20260708", false},
 		{"claude-sonnet-5", true},
 		{"claude-sonnet-5-20260708", true},
 		{"anthropic.claude-sonnet-5-v1:0", true},
@@ -134,7 +149,8 @@ func TestTkModelRejectsTemperatureTopPCombination(t *testing.T) {
 		{"anthropic.claude-opus-4-5-v1:0", true},
 		{"claude-opus-4-6", true},
 		{"claude-opus-4-7", false},
-		{"claude-sonnet-4-6", false},
+		{"claude-sonnet-4-6", true},
+		{"claude-sonnet-4-6-20260708", true},
 		{"claude-sonnet-5", false},
 		{"claude-3-5-sonnet-20241022", false},
 		{"gpt-5.5", false},
@@ -156,6 +172,20 @@ func TestTkSamplingParamRuleFromAnthropic400(t *testing.T) {
 	rule, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, unsupportedBody)
 	require.True(t, ok)
 	require.Equal(t, tkSamplingParamRuleStripAll, rule)
+
+	unknownParamBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Unknown parameter: top_k"}}`)
+	rule, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, unknownParamBody)
+	require.True(t, ok)
+	require.Equal(t, tkSamplingParamRuleStripAll, rule)
+
+	unrecognizedParamBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Unrecognized request argument supplied: top_p"}}`)
+	rule, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, unrecognizedParamBody)
+	require.True(t, ok)
+	require.Equal(t, tkSamplingParamRuleStripAll, rule)
+
+	nonSamplingUnknownParamBody := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Unknown parameter: max_tokens"}}`)
+	_, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, nonSamplingUnknownParamBody)
+	require.False(t, ok)
 
 	overloadedBody := []byte(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)
 	_, ok = tkSamplingParamRuleFromAnthropic400("claude-next", http.StatusBadRequest, overloadedBody)

--- a/backend/internal/service/gateway_request_tk_sampling_param_cache.go
+++ b/backend/internal/service/gateway_request_tk_sampling_param_cache.go
@@ -118,7 +118,11 @@ func tkIsUnsupportedSamplingParamMessage(lowerMessage string) bool {
 	}
 	return strings.Contains(lowerMessage, "not supported for this model") ||
 		strings.Contains(lowerMessage, "extra inputs are not permitted") ||
-		strings.Contains(lowerMessage, "unsupported parameter")
+		strings.Contains(lowerMessage, "unsupported parameter") ||
+		strings.Contains(lowerMessage, "unknown parameter") ||
+		strings.Contains(lowerMessage, "unknown_parameter") ||
+		strings.Contains(lowerMessage, "unrecognized request argument") ||
+		strings.Contains(lowerMessage, "unrecognized parameter")
 }
 
 func tkApplyAnthropicRequestCompatibilityRules(body []byte) []byte {

--- a/backend/internal/service/gateway_request_tk_sampling_param_cache.go
+++ b/backend/internal/service/gateway_request_tk_sampling_param_cache.go
@@ -1,0 +1,122 @@
+package service
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	tkSamplingParamRuleCacheTTL     = 60 * time.Second
+	tkSamplingParamRuleCacheCleanup = time.Minute
+)
+
+type tkSamplingParamRule string
+
+const (
+	tkSamplingParamRuleStripTopPWithTemperature tkSamplingParamRule = "strip_top_p_with_temperature"
+	tkSamplingParamRuleStripAll                 tkSamplingParamRule = "strip_all_sampling"
+)
+
+var tkSamplingParamRules = gocache.New(tkSamplingParamRuleCacheTTL, tkSamplingParamRuleCacheCleanup)
+
+func tkSamplingParamRuleCacheKey(model string) string {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" {
+		return ""
+	}
+	return model
+}
+
+func tkGetCachedSamplingParamRule(model string) (tkSamplingParamRule, bool) {
+	if tkSamplingParamRules == nil {
+		return "", false
+	}
+	key := tkSamplingParamRuleCacheKey(model)
+	if key == "" {
+		return "", false
+	}
+	v, ok := tkSamplingParamRules.Get(key)
+	if !ok {
+		return "", false
+	}
+	rule, ok := v.(tkSamplingParamRule)
+	return rule, ok
+}
+
+func tkPutCachedSamplingParamRule(model string, rule tkSamplingParamRule) {
+	if tkSamplingParamRules == nil || rule == "" {
+		return
+	}
+	key := tkSamplingParamRuleCacheKey(model)
+	if key == "" {
+		return
+	}
+	tkSamplingParamRules.Set(key, rule, gocache.DefaultExpiration)
+}
+
+func tkRecordAnthropicSamplingParamRuleFrom400(platform, model string, status int, body []byte) (tkSamplingParamRule, bool) {
+	if platform != PlatformAnthropic {
+		return "", false
+	}
+	rule, ok := tkSamplingParamRuleFromAnthropic400(model, status, body)
+	if !ok {
+		return "", false
+	}
+	tkPutCachedSamplingParamRule(model, rule)
+	slog.Info("tk_anthropic_sampling_param_rule_cache_populate",
+		"model", strings.ToLower(strings.TrimSpace(model)),
+		"rule", string(rule),
+		"ttl", tkSamplingParamRuleCacheTTL.String())
+	return rule, true
+}
+
+func tkSamplingParamRuleFromAnthropic400(model string, status int, body []byte) (tkSamplingParamRule, bool) {
+	if status != http.StatusBadRequest || strings.TrimSpace(model) == "" || !tkIsAnthropicInvalidRequestErrorBody(body) {
+		return "", false
+	}
+	msg := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(body)))
+	if msg == "" {
+		msg = strings.ToLower(strings.TrimSpace(string(body)))
+	}
+	if tkIsTemperatureTopPConflictMessage(msg) {
+		return tkSamplingParamRuleStripTopPWithTemperature, true
+	}
+	if tkIsUnsupportedSamplingParamMessage(msg) {
+		return tkSamplingParamRuleStripAll, true
+	}
+	return "", false
+}
+
+func tkIsAnthropicInvalidRequestErrorBody(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	errType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.type").String()))
+	return errType == "invalid_request_error"
+}
+
+func tkIsTemperatureTopPConflictMessage(lowerMessage string) bool {
+	if !strings.Contains(lowerMessage, "temperature") || !strings.Contains(lowerMessage, "top_p") {
+		return false
+	}
+	compact := strings.NewReplacer("`", "", "'", "", "\"", "", " ", "").Replace(lowerMessage)
+	return strings.Contains(compact, "temperatureandtop_pcannotbothbespecified") ||
+		(strings.Contains(compact, "eitheraltertemperatureortop_p") && strings.Contains(compact, "notboth"))
+}
+
+func tkIsUnsupportedSamplingParamMessage(lowerMessage string) bool {
+	hasSamplingParam := strings.Contains(lowerMessage, "temperature") ||
+		strings.Contains(lowerMessage, "top_p") ||
+		strings.Contains(lowerMessage, "top_k")
+	if !hasSamplingParam {
+		return false
+	}
+	return strings.Contains(lowerMessage, "not supported for this model") ||
+		strings.Contains(lowerMessage, "extra inputs are not permitted") ||
+		strings.Contains(lowerMessage, "unsupported parameter")
+}

--- a/backend/internal/service/gateway_request_tk_sampling_param_cache.go
+++ b/backend/internal/service/gateway_request_tk_sampling_param_cache.go
@@ -3,6 +3,7 @@ package service
 import (
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,24 +20,54 @@ type tkSamplingParamRule string
 
 const (
 	tkSamplingParamRuleStripTopPWithTemperature tkSamplingParamRule = "strip_top_p_with_temperature"
-	tkSamplingParamRuleStripAll                 tkSamplingParamRule = "strip_all_sampling"
+	tkSamplingParamRuleStripTemperature         tkSamplingParamRule = "strip_temperature"
+	tkSamplingParamRuleStripTopP                tkSamplingParamRule = "strip_top_p"
+	tkSamplingParamRuleStripTopK                tkSamplingParamRule = "strip_top_k"
 )
 
 var tkSamplingParamRules = gocache.New(tkSamplingParamRuleCacheTTL, tkSamplingParamRuleCacheCleanup)
 
-func tkSamplingParamRuleCacheKey(model string) string {
+func tkAnthropicCompatibilityCacheScope(account *Account) string {
+	if account == nil || account.ID <= 0 {
+		return ""
+	}
+	return strconv.FormatInt(account.ID, 10)
+}
+
+func tkSamplingParamRuleCacheKey(account *Account, model string, body []byte) string {
+	scope := tkAnthropicCompatibilityCacheScope(account)
+	if scope == "" {
+		return ""
+	}
 	model = strings.ToLower(strings.TrimSpace(model))
 	if model == "" {
 		return ""
 	}
-	return model
+	shape := tkSamplingParamRuleRequestShape(body)
+	if shape == "" {
+		return ""
+	}
+	return scope + "|" + model + "|" + shape
 }
 
-func tkGetCachedSamplingParamRule(model string) (tkSamplingParamRule, bool) {
+func tkSamplingParamRuleRequestShape(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var fields []string
+	for _, field := range tkDeprecatedSamplingTopLevelFields {
+		if gjson.GetBytes(body, field).Exists() {
+			fields = append(fields, field)
+		}
+	}
+	return strings.Join(fields, ",")
+}
+
+func tkGetCachedSamplingParamRule(account *Account, model string, body []byte) (tkSamplingParamRule, bool) {
 	if tkSamplingParamRules == nil {
 		return "", false
 	}
-	key := tkSamplingParamRuleCacheKey(model)
+	key := tkSamplingParamRuleCacheKey(account, model, body)
 	if key == "" {
 		return "", false
 	}
@@ -48,29 +79,31 @@ func tkGetCachedSamplingParamRule(model string) (tkSamplingParamRule, bool) {
 	return rule, ok
 }
 
-func tkPutCachedSamplingParamRule(model string, rule tkSamplingParamRule) {
+func tkPutCachedSamplingParamRule(account *Account, model string, requestBody []byte, rule tkSamplingParamRule) {
 	if tkSamplingParamRules == nil || rule == "" {
 		return
 	}
-	key := tkSamplingParamRuleCacheKey(model)
+	key := tkSamplingParamRuleCacheKey(account, model, requestBody)
 	if key == "" {
 		return
 	}
 	tkSamplingParamRules.Set(key, rule, gocache.DefaultExpiration)
 }
 
-func tkRecordAnthropicSamplingParamRuleFrom400(platform, model string, status int, body []byte) (tkSamplingParamRule, bool) {
-	if platform != PlatformAnthropic {
+func tkRecordAnthropicSamplingParamRuleFrom400(account *Account, model string, requestBody []byte, status int, body []byte) (tkSamplingParamRule, bool) {
+	if account == nil || account.Platform != PlatformAnthropic {
 		return "", false
 	}
 	rule, ok := tkSamplingParamRuleFromAnthropic400(model, status, body)
 	if !ok {
 		return "", false
 	}
-	tkPutCachedSamplingParamRule(model, rule)
+	tkPutCachedSamplingParamRule(account, model, requestBody, rule)
 	slog.Info("tk_anthropic_sampling_param_rule_cache_populate",
+		"account_id", account.ID,
 		"model", strings.ToLower(strings.TrimSpace(model)),
 		"rule", string(rule),
+		"shape", tkSamplingParamRuleRequestShape(requestBody),
 		"ttl", tkSamplingParamRuleCacheTTL.String())
 	return rule, true
 }
@@ -86,8 +119,8 @@ func tkSamplingParamRuleFromAnthropic400(model string, status int, body []byte) 
 	if tkIsTemperatureTopPConflictMessage(msg) {
 		return tkSamplingParamRuleStripTopPWithTemperature, true
 	}
-	if tkIsUnsupportedSamplingParamMessage(msg) {
-		return tkSamplingParamRuleStripAll, true
+	if rule, ok := tkUnsupportedSamplingParamRuleFromMessage(msg); ok {
+		return rule, true
 	}
 	return "", false
 }
@@ -109,6 +142,22 @@ func tkIsTemperatureTopPConflictMessage(lowerMessage string) bool {
 		(strings.Contains(compact, "eitheraltertemperatureortop_p") && strings.Contains(compact, "notboth"))
 }
 
+func tkUnsupportedSamplingParamRuleFromMessage(lowerMessage string) (tkSamplingParamRule, bool) {
+	if !tkIsUnsupportedSamplingParamMessage(lowerMessage) {
+		return "", false
+	}
+	switch {
+	case strings.Contains(lowerMessage, "temperature"):
+		return tkSamplingParamRuleStripTemperature, true
+	case strings.Contains(lowerMessage, "top_p"):
+		return tkSamplingParamRuleStripTopP, true
+	case strings.Contains(lowerMessage, "top_k"):
+		return tkSamplingParamRuleStripTopK, true
+	default:
+		return "", false
+	}
+}
+
 func tkIsUnsupportedSamplingParamMessage(lowerMessage string) bool {
 	hasSamplingParam := strings.Contains(lowerMessage, "temperature") ||
 		strings.Contains(lowerMessage, "top_p") ||
@@ -125,6 +174,6 @@ func tkIsUnsupportedSamplingParamMessage(lowerMessage string) bool {
 		strings.Contains(lowerMessage, "unrecognized parameter")
 }
 
-func tkApplyAnthropicRequestCompatibilityRules(body []byte) []byte {
-	return tkApplyCachedAnthropicThinkingRule(tkStripDeprecatedSamplingParams(body))
+func tkApplyAnthropicRequestCompatibilityRules(account *Account, body []byte) []byte {
+	return tkApplyCachedAnthropicThinkingRule(account, tkStripDeprecatedSamplingParamsForAccount(account, body))
 }

--- a/backend/internal/service/gateway_request_tk_sampling_param_cache.go
+++ b/backend/internal/service/gateway_request_tk_sampling_param_cache.go
@@ -120,3 +120,7 @@ func tkIsUnsupportedSamplingParamMessage(lowerMessage string) bool {
 		strings.Contains(lowerMessage, "extra inputs are not permitted") ||
 		strings.Contains(lowerMessage, "unsupported parameter")
 }
+
+func tkApplyAnthropicRequestCompatibilityRules(body []byte) []byte {
+	return tkApplyCachedAnthropicThinkingRule(tkStripDeprecatedSamplingParams(body))
+}

--- a/backend/internal/service/gateway_request_tk_thinking_rule_cache.go
+++ b/backend/internal/service/gateway_request_tk_thinking_rule_cache.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	tkAnthropicThinkingRuleCacheTTL     = 60 * time.Second
+	tkAnthropicThinkingRuleCacheCleanup = time.Minute
+)
+
+type tkAnthropicThinkingRule string
+
+const (
+	tkAnthropicThinkingRuleAdaptiveOnly tkAnthropicThinkingRule = "thinking_type_adaptive"
+)
+
+var tkAnthropicThinkingRules = gocache.New(tkAnthropicThinkingRuleCacheTTL, tkAnthropicThinkingRuleCacheCleanup)
+
+func tkAnthropicThinkingRuleCacheKey(model string) string {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" {
+		return ""
+	}
+	return model
+}
+
+func tkGetCachedAnthropicThinkingRule(model string) (tkAnthropicThinkingRule, bool) {
+	if tkAnthropicThinkingRules == nil {
+		return "", false
+	}
+	key := tkAnthropicThinkingRuleCacheKey(model)
+	if key == "" {
+		return "", false
+	}
+	v, ok := tkAnthropicThinkingRules.Get(key)
+	if !ok {
+		return "", false
+	}
+	rule, ok := v.(tkAnthropicThinkingRule)
+	return rule, ok
+}
+
+func tkPutCachedAnthropicThinkingRule(model string, rule tkAnthropicThinkingRule) {
+	if tkAnthropicThinkingRules == nil || rule == "" {
+		return
+	}
+	key := tkAnthropicThinkingRuleCacheKey(model)
+	if key == "" {
+		return
+	}
+	tkAnthropicThinkingRules.Set(key, rule, gocache.DefaultExpiration)
+}
+
+func tkRecordAnthropicThinkingRuleFrom400(platform, model string, status int, body []byte) (tkAnthropicThinkingRule, bool) {
+	if platform != PlatformAnthropic {
+		return "", false
+	}
+	rule, ok := tkAnthropicThinkingRuleFrom400(model, status, body)
+	if !ok {
+		return "", false
+	}
+	tkPutCachedAnthropicThinkingRule(model, rule)
+	slog.Info("tk_anthropic_thinking_rule_cache_populate",
+		"model", strings.ToLower(strings.TrimSpace(model)),
+		"rule", string(rule),
+		"ttl", tkAnthropicThinkingRuleCacheTTL.String())
+	return rule, true
+}
+
+func tkAnthropicThinkingRuleFrom400(model string, status int, body []byte) (tkAnthropicThinkingRule, bool) {
+	if status != http.StatusBadRequest || strings.TrimSpace(model) == "" || !tkIsAnthropicInvalidRequestErrorBody(body) {
+		return "", false
+	}
+	errMsg := strings.TrimSpace(extractUpstreamErrorMessage(body))
+	if errMsg == "" {
+		errMsg = strings.TrimSpace(string(body))
+	}
+	if isThinkingTypeAdaptiveRequiredError(errMsg) {
+		return tkAnthropicThinkingRuleAdaptiveOnly, true
+	}
+	return "", false
+}
+
+func tkApplyCachedAnthropicThinkingRule(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	model := gjson.GetBytes(body, "model").String()
+	rule, ok := tkGetCachedAnthropicThinkingRule(model)
+	if !ok {
+		return body
+	}
+	switch rule {
+	case tkAnthropicThinkingRuleAdaptiveOnly:
+		if rectified, applied := RectifyThinkingTypeAdaptive(body); applied {
+			return rectified
+		}
+	}
+	return body
+}

--- a/backend/internal/service/gateway_request_tk_thinking_rule_cache.go
+++ b/backend/internal/service/gateway_request_tk_thinking_rule_cache.go
@@ -23,19 +23,37 @@ const (
 
 var tkAnthropicThinkingRules = gocache.New(tkAnthropicThinkingRuleCacheTTL, tkAnthropicThinkingRuleCacheCleanup)
 
-func tkAnthropicThinkingRuleCacheKey(model string) string {
+func tkAnthropicThinkingRuleCacheKey(account *Account, model string, body []byte) string {
+	scope := tkAnthropicCompatibilityCacheScope(account)
+	if scope == "" {
+		return ""
+	}
 	model = strings.ToLower(strings.TrimSpace(model))
 	if model == "" {
 		return ""
 	}
-	return model
+	shape := tkAnthropicThinkingRuleRequestShape(body)
+	if shape == "" {
+		return ""
+	}
+	return scope + "|" + model + "|" + shape
 }
 
-func tkGetCachedAnthropicThinkingRule(model string) (tkAnthropicThinkingRule, bool) {
+func tkAnthropicThinkingRuleRequestShape(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	if gjson.GetBytes(body, "thinking.type").String() != "enabled" {
+		return ""
+	}
+	return "thinking.type=enabled"
+}
+
+func tkGetCachedAnthropicThinkingRule(account *Account, model string, body []byte) (tkAnthropicThinkingRule, bool) {
 	if tkAnthropicThinkingRules == nil {
 		return "", false
 	}
-	key := tkAnthropicThinkingRuleCacheKey(model)
+	key := tkAnthropicThinkingRuleCacheKey(account, model, body)
 	if key == "" {
 		return "", false
 	}
@@ -47,29 +65,31 @@ func tkGetCachedAnthropicThinkingRule(model string) (tkAnthropicThinkingRule, bo
 	return rule, ok
 }
 
-func tkPutCachedAnthropicThinkingRule(model string, rule tkAnthropicThinkingRule) {
+func tkPutCachedAnthropicThinkingRule(account *Account, model string, requestBody []byte, rule tkAnthropicThinkingRule) {
 	if tkAnthropicThinkingRules == nil || rule == "" {
 		return
 	}
-	key := tkAnthropicThinkingRuleCacheKey(model)
+	key := tkAnthropicThinkingRuleCacheKey(account, model, requestBody)
 	if key == "" {
 		return
 	}
 	tkAnthropicThinkingRules.Set(key, rule, gocache.DefaultExpiration)
 }
 
-func tkRecordAnthropicThinkingRuleFrom400(platform, model string, status int, body []byte) (tkAnthropicThinkingRule, bool) {
-	if platform != PlatformAnthropic {
+func tkRecordAnthropicThinkingRuleFrom400(account *Account, model string, requestBody []byte, status int, body []byte) (tkAnthropicThinkingRule, bool) {
+	if account == nil || account.Platform != PlatformAnthropic {
 		return "", false
 	}
 	rule, ok := tkAnthropicThinkingRuleFrom400(model, status, body)
 	if !ok {
 		return "", false
 	}
-	tkPutCachedAnthropicThinkingRule(model, rule)
+	tkPutCachedAnthropicThinkingRule(account, model, requestBody, rule)
 	slog.Info("tk_anthropic_thinking_rule_cache_populate",
+		"account_id", account.ID,
 		"model", strings.ToLower(strings.TrimSpace(model)),
 		"rule", string(rule),
+		"shape", tkAnthropicThinkingRuleRequestShape(requestBody),
 		"ttl", tkAnthropicThinkingRuleCacheTTL.String())
 	return rule, true
 }
@@ -88,12 +108,12 @@ func tkAnthropicThinkingRuleFrom400(model string, status int, body []byte) (tkAn
 	return "", false
 }
 
-func tkApplyCachedAnthropicThinkingRule(body []byte) []byte {
+func tkApplyCachedAnthropicThinkingRule(account *Account, body []byte) []byte {
 	if len(body) == 0 {
 		return body
 	}
 	model := gjson.GetBytes(body, "model").String()
-	rule, ok := tkGetCachedAnthropicThinkingRule(model)
+	rule, ok := tkGetCachedAnthropicThinkingRule(account, model, body)
 	if !ok {
 		return body
 	}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -734,7 +734,7 @@
       "path": "backend/internal/service/gateway_claude_oauth_body.go",
       "must_contain": [
         "!strings.Contains(strings.ToLower(modelID), \"haiku\")",
-        "return tkStripDeprecatedSamplingParams(body)"
+        "return tkApplyAnthropicRequestCompatibilityRules(body)"
       ]
     },
     {
@@ -3046,11 +3046,32 @@
       "rationale": "Proactive pre-send strip of top-level sampling params for Anthropic Opus 4.7+ and Sonnet 5+ models. Prod/edge traces on 2026-07-08 showed claude-opus-4-7 upstream 400s first for 'temperature is deprecated for this model' and then for '`top_p` is deprecated for this model' after the gateway preserved or injected those fields; Anthropic compatibility notes group temperature/top_p/top_k together for this model surface. The gate keeps older Claude families and non-Anthropic bodies unchanged, while only the top-level fields are deleted so nested JSON-schema properties survive. Dropping this companion silently re-opens platform-owned internal 400s for chat/messages/responses/count_tokens paths."
     },
     {
+      "path": "backend/internal/service/gateway_request_tk_sampling_param_cache.go",
+      "must_contain": [
+        "func tkRecordAnthropicSamplingParamRuleFrom400(platform, model string, status int, body []byte)",
+        "func tkApplyAnthropicRequestCompatibilityRules(body []byte) []byte",
+        "tkApplyCachedAnthropicThinkingRule(tkStripDeprecatedSamplingParams(body))",
+        "tkSamplingParamRuleCacheTTL     = 60 * time.Second"
+      ],
+      "rationale": "Short-lived Anthropic request-compatibility cache entry point. Sampling-param 400s populate model-scoped rules for the exact deprecated/unsupported parameter messages, and the unified apply hook composes static sampling stripping with cached thinking-shape repair before the next upstream call. Dropping this companion or bypassing tkApplyAnthropicRequestCompatibilityRules silently reverts repeated 400s to hitting upstream every time."
+    },
+    {
+      "path": "backend/internal/service/gateway_request_tk_thinking_rule_cache.go",
+      "must_contain": [
+        "func tkRecordAnthropicThinkingRuleFrom400(platform, model string, status int, body []byte)",
+        "isThinkingTypeAdaptiveRequiredError(errMsg)",
+        "RectifyThinkingTypeAdaptive(body)",
+        "tkAnthropicThinkingRuleCacheTTL     = 60 * time.Second"
+      ],
+      "rationale": "Short-lived Anthropic adaptive-thinking compatibility cache. Only 400 invalid_request_error messages that explicitly say thinking.type.enabled is not supported learn the adaptive-only rule; budget, prefill, signature, 429 and overloaded errors must not become model-level rewrites. Dropping this companion makes Opus/Fable-style adaptive-required 400s repeat for every request until static model rules catch up."
+    },
+    {
       "path": "backend/internal/service/gateway_request_tk_deprecated_sampling_test.go",
       "must_contain": [
         "TestTkStripDeprecatedSamplingParams_StripIsTopLevelOnly",
         "TestTkStripDeprecatedSamplingParams_NoTouchForOlderClaudeModels",
         "TestTkModelDeprecatesSamplingParams",
+        "TestTkAnthropicThinkingRuleFrom400",
         "TestForwardAsChatCompletions_AnthropicOpus47StripsDeprecatedSamplingParams",
         "TestApplyClaudeCodeOAuthMimicry_AnthropicOpus47StripsDeprecatedSamplingParams"
       ],
@@ -3076,23 +3097,23 @@
     {
       "path": "backend/internal/service/gateway_forward.go",
       "must_contain": [
-        "replaceBody(tkStripDeprecatedSamplingParams(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))))"
+        "replaceBody(tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))))"
       ],
-      "rationale": "The native Forward pre-send sanitize chain must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking and tkStripDeprecatedSamplingParams so explicit thinking.type=disabled never reaches fable upstreams and top-level sampling params never reach Opus 4.7+/Sonnet 5+ Anthropic upstreams. An upstream merge that restores the bare two-function chain silently reverts either fix and surfaces raw upstream 400s again."
+      "rationale": "The native Forward pre-send sanitize chain must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking and tkApplyAnthropicRequestCompatibilityRules so explicit thinking.type=disabled never reaches fable upstreams, top-level sampling params never reach Opus 4.7+/Sonnet 5+ Anthropic upstreams, and short-cached adaptive-thinking rules apply before the next upstream call. An upstream merge that restores the bare two-function chain silently reverts these fixes and surfaces raw upstream 400s again."
     },
     {
       "path": "backend/internal/service/gateway_count_tokens.go",
       "must_contain": [
-        "replaceBody(tkStripDeprecatedSamplingParams(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))))"
+        "replaceBody(tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))))"
       ],
-      "rationale": "The count_tokens pre-send sanitize chain must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking and tkStripDeprecatedSamplingParams so explicit thinking.type=disabled never reaches fable upstreams and top-level sampling params never reach Opus 4.7+/Sonnet 5+ Anthropic upstreams."
+      "rationale": "The count_tokens pre-send sanitize chain must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking and tkApplyAnthropicRequestCompatibilityRules so explicit thinking.type=disabled never reaches fable upstreams, top-level sampling params never reach Opus 4.7+/Sonnet 5+ Anthropic upstreams, and short-cached compatibility rules reduce repeated upstream 400s."
     },
     {
       "path": "backend/internal/service/gateway_anthropic_passthrough.go",
       "must_contain": [
-        "input.Body = tkStripDeprecatedSamplingParams(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))"
+        "input.Body = tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))"
       ],
-      "rationale": "Passthrough sanitize chain split from gateway_service.go must retain both fable-disabled-thinking and Opus 4.7+/Sonnet 5+ deprecated sampling-param stripping."
+      "rationale": "Passthrough sanitize chain split from gateway_service.go must retain fable-disabled-thinking stripping, Opus 4.7+/Sonnet 5+ deprecated sampling-param stripping, and short-cached adaptive-thinking compatibility rewrites."
     },
     {
       "path": "backend/internal/handler/api_key_handler.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -734,7 +734,7 @@
       "path": "backend/internal/service/gateway_claude_oauth_body.go",
       "must_contain": [
         "!strings.Contains(strings.ToLower(modelID), \"haiku\")",
-        "return tkApplyAnthropicRequestCompatibilityRules(body)"
+        "return tkApplyAnthropicRequestCompatibilityRules(account, body)"
       ]
     },
     {
@@ -3048,22 +3048,24 @@
     {
       "path": "backend/internal/service/gateway_request_tk_sampling_param_cache.go",
       "must_contain": [
-        "func tkRecordAnthropicSamplingParamRuleFrom400(platform, model string, status int, body []byte)",
-        "func tkApplyAnthropicRequestCompatibilityRules(body []byte) []byte",
-        "tkApplyCachedAnthropicThinkingRule(tkStripDeprecatedSamplingParams(body))",
+        "func tkRecordAnthropicSamplingParamRuleFrom400(account *Account, model string, requestBody []byte, status int, body []byte)",
+        "func tkApplyAnthropicRequestCompatibilityRules(account *Account, body []byte) []byte",
+        "tkApplyCachedAnthropicThinkingRule(account, tkStripDeprecatedSamplingParamsForAccount(account, body))",
+        "func tkSamplingParamRuleRequestShape(body []byte) string",
         "tkSamplingParamRuleCacheTTL     = 60 * time.Second"
       ],
-      "rationale": "Short-lived Anthropic request-compatibility cache entry point. Sampling-param 400s populate model-scoped rules for the exact deprecated/unsupported parameter messages, and the unified apply hook composes static sampling stripping with cached thinking-shape repair before the next upstream call. Dropping this companion or bypassing tkApplyAnthropicRequestCompatibilityRules silently reverts repeated 400s to hitting upstream every time."
+      "rationale": "Short-lived Anthropic request-compatibility cache entry point. Sampling-param 400s populate account+model+request-shape scoped rules for exact deprecated/unsupported parameter messages, and the unified apply hook composes static sampling stripping with cached thinking-shape repair before the next matching upstream call. Dropping this companion or bypassing tkApplyAnthropicRequestCompatibilityRules silently reverts repeated 400s to hitting upstream every time; broadening the cache back to model-only risks mutating unrelated normal requests."
     },
     {
       "path": "backend/internal/service/gateway_request_tk_thinking_rule_cache.go",
       "must_contain": [
-        "func tkRecordAnthropicThinkingRuleFrom400(platform, model string, status int, body []byte)",
+        "func tkRecordAnthropicThinkingRuleFrom400(account *Account, model string, requestBody []byte, status int, body []byte)",
+        "func tkAnthropicThinkingRuleRequestShape(body []byte) string",
         "isThinkingTypeAdaptiveRequiredError(errMsg)",
         "RectifyThinkingTypeAdaptive(body)",
         "tkAnthropicThinkingRuleCacheTTL     = 60 * time.Second"
       ],
-      "rationale": "Short-lived Anthropic adaptive-thinking compatibility cache. Only 400 invalid_request_error messages that explicitly say thinking.type.enabled is not supported learn the adaptive-only rule; budget, prefill, signature, 429 and overloaded errors must not become model-level rewrites. Dropping this companion makes Opus/Fable-style adaptive-required 400s repeat for every request until static model rules catch up."
+      "rationale": "Short-lived Anthropic adaptive-thinking compatibility cache. Only 400 invalid_request_error messages that explicitly say thinking.type.enabled is not supported learn the adaptive-only rule, scoped to the same account, model, and request thinking shape; budget, prefill, signature, 429 and overloaded errors must not become model-level rewrites. Dropping this companion makes Opus/Fable-style adaptive-required 400s repeat for every matching request until static model rules catch up."
     },
     {
       "path": "backend/internal/service/gateway_request_tk_deprecated_sampling_test.go",
@@ -3097,21 +3099,21 @@
     {
       "path": "backend/internal/service/gateway_forward.go",
       "must_contain": [
-        "replaceBody(tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))))"
+        "replaceBody(tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))))"
       ],
       "rationale": "The native Forward pre-send sanitize chain must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking and tkApplyAnthropicRequestCompatibilityRules so explicit thinking.type=disabled never reaches fable upstreams, top-level sampling params never reach Opus 4.7+/Sonnet 5+ Anthropic upstreams, and short-cached adaptive-thinking rules apply before the next upstream call. An upstream merge that restores the bare two-function chain silently reverts these fixes and surfaces raw upstream 400s again."
     },
     {
       "path": "backend/internal/service/gateway_count_tokens.go",
       "must_contain": [
-        "replaceBody(tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))))"
+        "replaceBody(tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))))"
       ],
       "rationale": "The count_tokens pre-send sanitize chain must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking and tkApplyAnthropicRequestCompatibilityRules so explicit thinking.type=disabled never reaches fable upstreams, top-level sampling params never reach Opus 4.7+/Sonnet 5+ Anthropic upstreams, and short-cached compatibility rules reduce repeated upstream 400s."
     },
     {
       "path": "backend/internal/service/gateway_anthropic_passthrough.go",
       "must_contain": [
-        "input.Body = tkApplyAnthropicRequestCompatibilityRules(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))"
+        "input.Body = tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))"
       ],
       "rationale": "Passthrough sanitize chain split from gateway_service.go must retain fable-disabled-thinking stripping, Opus 4.7+/Sonnet 5+ deprecated sampling-param stripping, and short-cached adaptive-thinking compatibility rewrites."
     },


### PR DESCRIPTION
## 摘要
- 已 rebase 到最新 `origin/main`，包含已合并的 #1308 / #1316：Anthropic 400 请求/参数校验最终归类为 `request/client`，且不再相对新主干删除已发布 migration。
- TokenKey 网关在发往 Anthropic 前统一应用兼容性修复：Opus 4.7+ / Sonnet 5+ 剥离顶层 `temperature`、`top_p`、`top_k`；Opus 4.1+、Claude 4.5 系列、Sonnet 4.6 在 `temperature` + `top_p` 同传时删除顶层 `top_p`。
- 结合 #1308 的 4xx client-validation 词表，短 TTL 学习缓存识别 sampling 参数的 `unknown/unrecognized parameter` 文案；仍只学习明确可安全修复的 Anthropic HTTP 400 `invalid_request_error`。
- 采样参数短缓存已从“模型级”收窄为“账号 + 模型 + 请求采样字段形状”级，并且只剥上游错误明确点名的字段：`strip_temperature` / `strip_top_p` / `strip_top_k` / `strip_top_p_with_temperature`。同模型但无采样字段、字段组合不同、或不同账号的正常请求不会命中该缓存。
- adaptive-only thinking 短缓存同样收窄为“账号 + 模型 + thinking.type=enabled 请求形状”级；后续无 thinking 或非 enabled 的正常请求不会因为模型名被缓存而改写。
- 主 `/v1/messages` 与 API-key passthrough 命中 `thinking.type.enabled` 不支持的 400 时会改为 `thinking.type=adaptive` 并重试一次；native/messages、Chat Completions、Responses、count_tokens 记录可学习规则供后续匹配请求命中。
- 不缓存/不静默修复 prefilling assistant messages、thinking 历史块签名/修改、budget 数值错误、temperature 范围错误、missing required、request too large、413/429/529 等会改变语义或非模型兼容性的错误。
- 更新 gateway TK sentinel registry，锚住新的兼容性入口、请求形状缓存和 thinking-cache companion。
- `no-web-impact`
- `sentinel-registry-reviewed`

## 官方依据
- Anthropic Errors：400 `invalid_request_error` 属请求验证错误；413/429/529 等不是本次模型参数兼容缓存对象。
- Claude 4 migration：Opus 4.7+ / Sonnet 5+ 对 `temperature` / `top_p` / `top_k` 有兼容限制；Sonnet 4.6 不按全剥离处理，仅保留 `temperature` 与 `top_p` 互斥修复。
- API release notes：模型能力和参数约束会随版本变化，短 TTL 学习缓存用于降低重复上游 400，同时通过账号+请求形状作用域保留自愈空间。

## 风险
- 低到中：改动集中在发往 Anthropic 前的 body 兼容性修复、可修复 400 的一次 retry、以及短 TTL 兼容缓存；不改计费、调度、前端或公共 API 契约。
- 缓存仅接受 Anthropic `invalid_request_error` 且命中明确文案；TTL 60s，按账号 + 模型 + 请求形状过期，不再按模型名泛化。
- nested tool schema 中同名字段保持不动；`invalid value` / `missing required` / `request too large` / budget / prefill / signature 等语义敏感错误保持原有路径，只由 #1308 归类为 client，不在网关改写。
- preflight 的 upstream-insertion-invasiveness 为 advisory：本次保持 companion 承载主要逻辑，仅在上游热点保留必要一行记录/调用与 retry 接线。

## 验证
- `go test -tags unit ./internal/service -run 'TestTkSamplingParamRuleFromAnthropic400|TestTkAnthropicThinkingRuleFrom400|TestTkStripDeprecatedSamplingParams|TestTkApplyAnthropicRequestCompatibilityRules|TestRectifyAnthropicPassthrough400_SamplingParamRetryCachesRule|TestGatewayService_AnthropicMainForward_AdaptiveRequired400RetriesWithAdaptive|TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_AdaptiveRequired400RetriesWithAdaptive|TestForwardAsChatCompletions_Anthropic(Opus47StripsDeprecatedSamplingParams|Sonnet45StripsTopPConflict)|TestApplyClaudeCodeOAuthMimicry_Anthropic(Opus47StripsDeprecatedSamplingParams|Haiku45StripsTopPConflict)'`
- `go test -tags unit ./internal/handler -run 'TestClassifyOps(FinalClientValidationAPIError|RoutingCapacityWinsOverFinalClientValidationAPIError|UpstreamClientInducedRejectionOwnedByClient|GenuineUpstreamErrorsStayProvider|RoutingCapacityWinsOverClientInduced)'`
- `go test -tags unit ./internal/service`
- `python3 -m json.tool scripts/sentinels/gateway-tk.json >/tmp/gateway-tk-jsoncheck.out`
- `./scripts/preflight.sh`

## 提交
- `e89fb2b` fix(anthropic): strip invalid sampling params no-web-impact
- `e63c8fb` fix(anthropic): cache sampling param rejections no-web-impact
- `4a98e2e` fix(anthropic): cache adaptive thinking rejections no-web-impact
- `c13e340` fix(anthropic): align 400 compatibility cache no-web-impact
- `a642578` fix(anthropic): scope compatibility cache safely no-web-impact
- 最新提交：`a642578`