### PR TITLE
fix(antigravity): route Claude chat compat via messages

### DIFF
--- a/backend/internal/service/gateway_antigravity_openai_compat_tk.go
+++ b/backend/internal/service/gateway_antigravity_openai_compat_tk.go
@@ -1,0 +1,18 @@
+package service
+
+import "net/http"
+
+const antigravityOpenAICompatMessagesRelayUnavailableBody = `{"error":{"type":"server_error","message":"Antigravity OpenAI-compatible Claude routing requires an API-key edge relay account"},"type":"error"}`
+
+func antigravityOpenAICompatMessagesRelayFailover(account *Account) *UpstreamFailoverError {
+	if account == nil || account.Platform != PlatformAntigravity {
+		return nil
+	}
+	if account.Type == AccountTypeAPIKey && account.GetBaseURL() != "" {
+		return nil
+	}
+	return &UpstreamFailoverError{
+		StatusCode:   http.StatusServiceUnavailable,
+		ResponseBody: []byte(antigravityOpenAICompatMessagesRelayUnavailableBody),
+	}
+}

--- a/backend/internal/service/gateway_antigravity_openai_compat_tk_test.go
+++ b/backend/internal/service/gateway_antigravity_openai_compat_tk_test.go
@@ -1,0 +1,136 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForwardAsChatCompletions_AntigravityAPIKeyUsesMessagesRelay(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_ag_edge_chat"}},
+		Body: io.NopCloser(strings.NewReader(`event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"usage":{"input_tokens":3,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`)),
+	}}
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          1,
+		Platform:    PlatformAntigravity,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "edge-key",
+			"base_url": "https://edge.example.com",
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "https://edge.example.com/antigravity/v1/messages?beta=true", upstream.lastReq.URL.String())
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestForwardAsChatCompletions_AntigravityOAuthFailsOverBeforeAnthropicURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+
+	upstream := &httpUpstreamRecorder{}
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:       2,
+		Platform: PlatformAntigravity,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "ag-token",
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, nil)
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr), "err = %v", err)
+	require.Equal(t, http.StatusServiceUnavailable, failoverErr.StatusCode)
+	require.Empty(t, upstream.requests)
+}
+
+func TestForwardAsResponses_AntigravityOAuthFailsOverBeforeAnthropicURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","input":"hello","stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+
+	upstream := &httpUpstreamRecorder{}
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:       3,
+		Platform: PlatformAntigravity,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "ag-token",
+		},
+	}
+
+	result, err := svc.ForwardAsResponses(context.Background(), c, account, body, nil)
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr), "err = %v", err)
+	require.Equal(t, http.StatusServiceUnavailable, failoverErr.StatusCode)
+	require.Empty(t, upstream.requests)
+}

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -43,6 +43,9 @@ func (s *GatewayService) ForwardAsChatCompletions(
 	originalModel := ccReq.Model
 	clientStream := ccReq.Stream
 	includeUsage := ccReq.StreamOptions != nil && ccReq.StreamOptions.IncludeUsage
+	if failoverErr := antigravityOpenAICompatMessagesRelayFailover(account); failoverErr != nil {
+		return nil, failoverErr
+	}
 
 	// 2. Convert CC → Responses → Anthropic (chained conversion)
 	responsesReq, err := apicompat.ChatCompletionsToResponses(&ccReq)

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -44,6 +44,9 @@ func (s *GatewayService) ForwardAsResponses(
 	}
 	originalModel := responsesReq.Model
 	clientStream := responsesReq.Stream
+	if failoverErr := antigravityOpenAICompatMessagesRelayFailover(account); failoverErr != nil {
+		return nil, failoverErr
+	}
 
 	// 2. Convert Responses → Anthropic
 	anthropicReq, err := apicompat.ResponsesToAnthropicRequest(&responsesReq)

--- a/backend/internal/service/gateway_gemini_native_openai_compat_tk.go
+++ b/backend/internal/service/gateway_gemini_native_openai_compat_tk.go
@@ -1,6 +1,10 @@
 package service
 
-import "github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
+import (
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
+)
 
 // UsesGeminiNativeOpenAICompat reports whether OpenAI chat/responses requests
 // should be forwarded through GeminiMessagesCompatService.
@@ -9,8 +13,14 @@ func UsesGeminiNativeOpenAICompat(platform, model string) bool {
 	case PlatformGemini:
 		return true
 	case PlatformAntigravity:
-		return !antigravity.IsImageModel(model)
+		return isAntigravityGeminiNativeTextModel(model)
 	default:
 		return false
 	}
+}
+
+func isAntigravityGeminiNativeTextModel(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	m = strings.TrimPrefix(m, "models/")
+	return strings.HasPrefix(m, "gemini-") && !antigravity.IsImageModel(model)
 }

--- a/backend/internal/service/gateway_gemini_native_openai_compat_tk_test.go
+++ b/backend/internal/service/gateway_gemini_native_openai_compat_tk_test.go
@@ -11,9 +11,21 @@ func TestUsesGeminiNativeOpenAICompat(t *testing.T) {
 		}
 	})
 
-	t.Run("antigravity text uses compat bridge", func(t *testing.T) {
+	t.Run("antigravity gemini text uses compat bridge", func(t *testing.T) {
 		if !UsesGeminiNativeOpenAICompat(PlatformAntigravity, "gemini-3.5-flash") {
 			t.Fatalf("expected antigravity text to use compat bridge")
+		}
+	})
+
+	t.Run("antigravity claude uses messages bridge", func(t *testing.T) {
+		if UsesGeminiNativeOpenAICompat(PlatformAntigravity, "claude-sonnet-4-6") {
+			t.Fatalf("expected antigravity Claude model to use messages bridge")
+		}
+	})
+
+	t.Run("antigravity models-prefixed gemini text uses compat bridge", func(t *testing.T) {
+		if !UsesGeminiNativeOpenAICompat(PlatformAntigravity, "models/gemini-pro-agent") {
+			t.Fatalf("expected prefixed antigravity Gemini text to use compat bridge")
 		}
 	})
 


### PR DESCRIPTION
## 摘要
- 修复 Antigravity OpenAI 兼容 chat/responses 路由：只有 Gemini-native 文本模型才走 `GeminiMessagesCompatService`。
- `claude-sonnet-4-6` 等 Claude 模型改走 Messages bridge，避免请求落到 `/antigravity/v1beta/models/{model}:generateContent` 后被 Gemini 账号池判定 unsupported。
- 补上 Antigravity Claude Messages bridge 的 edge relay 回归：APIKey stub 必须打到 `/antigravity/v1/messages`，直连 OAuth 不能误发到 Anthropic 默认 URL，而是 failover 给调度器尝试 edge stub。

## 风险
- 常规风险：收紧 Antigravity OpenAI-compatible 的 Gemini-native 分流条件，并只允许本地 Messages bridge 使用 APIKey edge relay；不改变 Gemini 平台和 Antigravity Gemini 文本/图片既有路径。
- `no-web-impact`：本次只改 backend gateway routing/service tests，不触达 Web UI、前端资源或浏览器行为。
- `sentinel-registry-reviewed`：已检查本次改动触达 gateway TK 热点，现有聚焦测试覆盖路由语义，无需新增 sentinel anchor。

## 验证
- `go test -tags unit ./internal/service -run 'TestForwardAsChatCompletions_Antigravity|TestForwardAsResponses_Antigravity|TestUsesGeminiNativeOpenAICompat' -count=1`
- `go test -tags unit ./internal/service -count=1`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

## 提交
- `0b13b597c` fix(antigravity): fail over local oauth chat compat
- `3b7f764d2` fix(antigravity): route claude chat compat via messages

最新提交：0b13b597c