### PR TITLE
fix(grok): relay capacity 不再写账号冷却

### DIFF
--- a/backend/internal/service/grok_media.go
+++ b/backend/internal/service/grok_media.go
@@ -756,7 +756,7 @@ func (s *OpenAIGatewayService) handleGrokMediaErrorResponse(
 		return nil, &UpstreamFailoverError{
 			StatusCode:             resp.StatusCode,
 			ResponseBody:           body,
-			RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+			RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, body, false),
 		}
 	}
 

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -39,6 +41,10 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 	stateCtx, cancel := openAIAccountStateContext(ctx)
 	defer cancel()
 
+	if s.handleOpenAICompatRelayDownstreamCapacityError(stateCtx, account, statusCode, responseBody, tkFirstRequestedModel(requestedModel)) {
+		return true
+	}
+
 	if account != nil && account.Platform == PlatformOpenAI && isOpenAIContextWindowError("", responseBody) {
 		return false
 	}
@@ -68,6 +74,25 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 		s.BlockAccountScheduling(account, time.Time{}, "upstream_disable")
 	}
 	return shouldDisable
+}
+
+func (s *OpenAIGatewayService) handleOpenAICompatRelayDownstreamCapacityError(ctx context.Context, account *Account, statusCode int, responseBody []byte, requestedModel string) bool {
+	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(responseBody))
+	upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+	if !tkSkipOpenAIDownstreamCapacityPenalty(account, statusCode, upstreamMsg, responseBody) {
+		return false
+	}
+	reason := tkOpenAICompatDownstreamCapacityReason(statusCode, upstreamMsg, responseBody)
+	slog.Info("openai_compat_downstream_capacity_skip_penalty",
+		"account_id", account.ID,
+		"platform", account.Platform,
+		"status_code", statusCode,
+		"reason", reason)
+	if s != nil && s.rateLimitService != nil {
+		satCount := s.rateLimitService.recordOpenAIStubSaturation(ctx, account.ID, statusCode, reason)
+		s.rateLimitService.tkTryOpenAIMirrorModelCooldownOnDownstreamEmpty(ctx, account, satCount, requestedModel)
+	}
+	return true
 }
 
 func (s *OpenAIGatewayService) markOpenAIOAuth429RateLimited(ctx context.Context, account *Account, headers http.Header, responseBody []byte, requestedModel ...string) {

--- a/backend/internal/service/openai_embeddings.go
+++ b/backend/internal/service/openai_embeddings.go
@@ -137,7 +137,7 @@ func (s *OpenAIGatewayService) ForwardEmbeddings(
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
 				ResponseBody:           respBody,
-				RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+				RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, respBody, false),
 			}
 		}
 		writeOpenAIEmbeddingsUpstreamResponse(c, resp, respBody, s.responseHeaderFilter)

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -113,7 +113,7 @@ func (s *OpenAIGatewayService) failoverOpenAIUpstreamHTTPError(
 	return &UpstreamFailoverError{
 		StatusCode:             resp.StatusCode,
 		ResponseBody:           respBody,
-		RetryableOnSameAccount: account.IsPoolMode() && (account.IsPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
+		RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, respBody, true),
 	}
 }
 

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -179,12 +179,12 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 				Kind:               "failover",
 				Message:            upstreamMsg,
 			})
-			s.handleGrokAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+			s.handleGrokAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, upstreamModel)
 			if s.shouldFailoverUpstreamError(resp.StatusCode) {
 				return nil, &UpstreamFailoverError{
 					StatusCode:             resp.StatusCode,
 					ResponseBody:           respBody,
-					RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+					RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, respBody, false),
 				}
 			}
 			return s.handleChatCompletionsErrorResponse(resp, c, account, billingModel)

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -782,7 +782,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				return nil, &UpstreamFailoverError{
 					StatusCode:             resp.StatusCode,
 					ResponseBody:           respBody,
-					RetryableOnSameAccount: account.IsPoolMode() && (account.IsPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
+					RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, respBody, true),
 				}
 			}
 			return s.handleErrorResponse(ctx, resp, c, account, body, billingModel)

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -86,12 +86,12 @@ func (s *OpenAIGatewayService) forwardGrokResponses(
 			Kind:               "failover",
 			Message:            upstreamMsg,
 		})
-		s.handleGrokAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+		s.handleGrokAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, upstreamModel)
 		if s.shouldFailoverUpstreamError(resp.StatusCode) {
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
 				ResponseBody:           respBody,
-				RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+				RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, respBody, false),
 			}
 		}
 		return s.handleErrorResponse(ctx, resp, c, account, patchedBody, upstreamModel)
@@ -536,7 +536,7 @@ func (s *OpenAIGatewayService) describeGrokComposerImage(
 			return "", OpenAIUsage{}, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
 				ResponseBody:           respBody,
-				RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+				RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, respBody, false),
 			}
 		}
 		return "", OpenAIUsage{}, fmt.Errorf("grok composer image bridge upstream error: %s", upstreamMsg)
@@ -696,8 +696,11 @@ func (s *OpenAIGatewayService) updateGrokUsageSnapshot(ctx context.Context, acco
 	})
 }
 
-func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte) {
+func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte, requestedModel ...string) {
 	if s == nil || account == nil {
+		return
+	}
+	if s.handleOpenAICompatRelayDownstreamCapacityError(ctx, account, statusCode, responseBody, tkFirstRequestedModel(requestedModel)) {
 		return
 	}
 	reasonUnauthorized := "grok oauth token unauthorized"

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -1157,6 +1157,32 @@ func TestHandleGrokAccountUpstreamErrorTempUnschedulesReadinessStates(t *testing
 	}
 }
 
+func TestHandleGrokAccountUpstreamError_DownstreamCapacitySkipsRelayCooldown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	rateLimitSvc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	sat := &fakeOpenAISaturationCounterRL{}
+	rateLimitSvc.SetOpenAISaturationCounter(sat)
+	svc := &OpenAIGatewayService{
+		accountRepo:               repo,
+		rateLimitService:          rateLimitSvc,
+		tkOpenAISaturationCounter: sat,
+	}
+	account := grokEdgeStub(80)
+	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Upstream rate limit exceeded, please retry later"}}`)
+
+	for i := 0; i < 3; i++ {
+		svc.handleGrokAccountUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body, "grok-build-0.1")
+	}
+
+	require.False(t, svc.isOpenAIAccountRuntimeBlocked(account))
+	require.Equal(t, 0, repo.tempCalls, "downstream capacity must not temp-unschedule a prod grok relay stub")
+	require.Equal(t, 0, repo.setRateLimitedCalls, "downstream capacity must not whole-account rate-limit a prod grok relay stub")
+	require.Equal(t, []int64{80, 80, 80}, sat.incrementIDs)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, "grok-build-0.1", repo.modelRateLimitCalls[0].scope)
+	require.Equal(t, tkOpenAIMirrorDownstreamEmptyReason, repo.modelRateLimitCalls[0].reason)
+}
+
 func TestHandleGrokAccountUpstreamErrorDoesNotShortenExistingPause(t *testing.T) {
 	existingUntil := time.Now().Add(15 * time.Minute)
 	account := &Account{

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -535,7 +535,7 @@ func (s *OpenAIGatewayService) handleErrorResponsePassthrough(
 			StatusCode:             resp.StatusCode,
 			ResponseBody:           body,
 			ResponseHeaders:        resp.Header.Clone(),
-			RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+			RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, body, false),
 		}
 	}
 

--- a/backend/internal/service/openai_gateway_service_tk_saturation_penalty.go
+++ b/backend/internal/service/openai_gateway_service_tk_saturation_penalty.go
@@ -28,7 +28,7 @@ func (s *OpenAIGatewayService) computeOpenAISaturationPenalties(ctx context.Cont
 	ids := make([]int64, 0, len(candidates))
 	for i := range candidates {
 		acc := candidates[i].account
-		if tkIsOpenAIEdgeMirrorStub(acc) {
+		if tkIsOpenAICompatEdgeMirrorStub(acc) {
 			ids = append(ids, acc.ID)
 		}
 	}
@@ -48,7 +48,7 @@ func (s *OpenAIGatewayService) computeOpenAISaturationPenalties(ctx context.Cont
 	var penalized []int64
 	for i := range candidates {
 		acc := candidates[i].account
-		if !tkIsOpenAIEdgeMirrorStub(acc) {
+		if !tkIsOpenAICompatEdgeMirrorStub(acc) {
 			continue
 		}
 		if counts[acc.ID] >= openAIEdgeMirrorStubSaturationThreshold {

--- a/backend/internal/service/openai_gateway_service_tk_saturation_penalty_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_saturation_penalty_test.go
@@ -17,6 +17,13 @@ func openAIEdgeCandidate(id int64, score float64) openAIAccountCandidateScore {
 	}
 }
 
+func grokEdgeCandidate(id int64, score float64) openAIAccountCandidateScore {
+	return openAIAccountCandidateScore{
+		account: grokEdgeStub(id),
+		score:   score,
+	}
+}
+
 func TestComputeOpenAISaturationPenalties_DeprioritizesSaturatedStub(t *testing.T) {
 	resetOpenAISatCache()
 	svc := &OpenAIGatewayService{}
@@ -28,6 +35,23 @@ func TestComputeOpenAISaturationPenalties_DeprioritizesSaturatedStub(t *testing.
 	candidates := []openAIAccountCandidateScore{
 		openAIEdgeCandidate(63, 3.0),
 		openAIEdgeCandidate(68, 2.0),
+	}
+	svc.computeOpenAISaturationPenalties(context.Background(), candidates)
+	require.Equal(t, openAISaturationScorePenalty, candidates[0].saturationScorePenalty)
+	require.Equal(t, 0.0, candidates[1].saturationScorePenalty)
+	require.Less(t, candidates[0].score-candidates[0].saturationScorePenalty, candidates[1].score)
+}
+
+func TestComputeOpenAISaturationPenalties_DeprioritizesGrokRelayStub(t *testing.T) {
+	resetOpenAISatCache()
+	svc := &OpenAIGatewayService{}
+	svc.SetOpenAISaturationCounter(&fakeSaturationCache{counts: map[int64]int64{
+		80: openAIEdgeMirrorStubSaturationThreshold,
+	}})
+
+	candidates := []openAIAccountCandidateScore{
+		grokEdgeCandidate(80, 3.0),
+		grokEdgeCandidate(81, 2.0),
 	}
 	svc.computeOpenAISaturationPenalties(context.Background(), candidates)
 	require.Equal(t, openAISaturationScorePenalty, candidates[0].saturationScorePenalty)

--- a/backend/internal/service/openai_gateway_service_tk_sticky_saturation.go
+++ b/backend/internal/service/openai_gateway_service_tk_sticky_saturation.go
@@ -6,13 +6,14 @@ import (
 )
 
 // tkShouldClearOpenAIStickyForSaturation clears a sticky binding when the bound
-// OpenAI edge-mirror stub is SUSTAINEDLY returning downstream capacity signals,
-// mirroring gateway_service_tk_sticky_saturation.go for the GPT scheduler.
+// OpenAI-compatible edge-mirror stub is SUSTAINEDLY returning downstream
+// capacity signals, mirroring gateway_service_tk_sticky_saturation.go for the
+// GPT scheduler.
 func (s *OpenAIGatewayService) tkShouldClearOpenAIStickyForSaturation(ctx context.Context, account *Account, sessionHash string) bool {
 	if s == nil || s.tkOpenAISaturationCounter == nil || account == nil {
 		return false
 	}
-	if !tkIsOpenAIEdgeMirrorStub(account) {
+	if !tkIsOpenAICompatEdgeMirrorStub(account) {
 		return false
 	}
 	if s.settingService != nil && !s.settingService.IsOpenAISaturatedStubDeprioritizeEnabled(ctx) {

--- a/backend/internal/service/openai_gateway_service_tk_sticky_saturation_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_sticky_saturation_test.go
@@ -22,6 +22,16 @@ func TestShouldClearOpenAIStickyForSaturation_ThresholdBoundary(t *testing.T) {
 	require.True(t, svc.tkShouldClearOpenAIStickyForSaturation(context.Background(), openAIEdgeStub(64), "sess"))
 }
 
+func TestShouldClearOpenAIStickyForSaturation_GrokRelayStub(t *testing.T) {
+	resetOpenAISatCache()
+	svc := &OpenAIGatewayService{}
+	svc.SetOpenAISaturationCounter(&fakeSaturationCache{counts: map[int64]int64{
+		80: openAIEdgeMirrorStubSaturationThreshold,
+	}})
+
+	require.True(t, svc.tkShouldClearOpenAIStickyForSaturation(context.Background(), grokEdgeStub(80), "sess"))
+}
+
 func TestShouldClearOpenAIStickyForSaturation_NonEdgeStubIgnored(t *testing.T) {
 	resetOpenAISatCache()
 	svc := &OpenAIGatewayService{}

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -442,7 +442,7 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		return nil, &UpstreamFailoverError{
 			StatusCode:             resp.StatusCode,
 			ResponseBody:           body,
-			RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+			RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, body, false),
 		}
 	}
 
@@ -620,7 +620,7 @@ func (s *OpenAIGatewayService) handleCompatErrorResponse(
 		return nil, &UpstreamFailoverError{
 			StatusCode:             resp.StatusCode,
 			ResponseBody:           body,
-			RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+			RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, body, false),
 		}
 	}
 

--- a/backend/internal/service/openai_gateway_v1_forward.go
+++ b/backend/internal/service/openai_gateway_v1_forward.go
@@ -184,7 +184,7 @@ func (s *OpenAIGatewayService) forwardOpenAIV1JSON(
 				ResponseBody: respBody,
 				// TK: 用 account 级判定（含 TK 默认 503/529 + per-account 覆写）而非
 				// 裸 pkg 默认，与其它 pool 路径一致（见 account_tk_pool_retry.go）。
-				RetryableOnSameAccount: account.IsPoolMode() && (account.IsPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
+				RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, respBody, true),
 			}
 		}
 		return s.handleErrorResponse(ctx, resp, c, account, body)

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -643,7 +643,7 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
 				ResponseBody:           respBody,
-				RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+				RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, respBody, false),
 			}
 		}
 		return s.handleOpenAIImagesErrorResponse(upstreamCtx, resp, c, account, upstreamModel)

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -920,7 +920,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesErrorResponse(
 		return nil, &UpstreamFailoverError{
 			StatusCode:             resp.StatusCode,
 			ResponseBody:           body,
-			RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+			RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, body, false),
 		}
 	}
 
@@ -1613,7 +1613,7 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
 				ResponseBody:           respBody,
-				RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+				RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, resp.StatusCode, upstreamMsg, respBody, false),
 			}
 		}
 		return s.handleOpenAIImagesErrorResponse(upstreamCtx, resp, c, account, requestModel)
@@ -1745,6 +1745,6 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthResponseError(
 		StatusCode:             upstreamErr.StatusCode,
 		ResponseBody:           responseBody,
 		ResponseHeaders:        headers,
-		RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(upstreamErr.StatusCode),
+		RetryableOnSameAccount: tkOpenAICompatRetryableOnSameAccount(account, upstreamErr.StatusCode, "", responseBody, false),
 	}
 }

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -301,6 +301,10 @@ func (s *RateLimitService) CheckErrorPolicy(ctx context.Context, account *Accoun
 func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte, requestedModel ...string) (shouldDisable bool) {
 	customErrorCodesEnabled := account.IsCustomErrorCodesEnabled()
 
+	if s.handleOpenAICompatDownstreamCapacityPenalty(ctx, account, statusCode, responseBody, tkFirstRequestedModel(requestedModel)) {
+		return true
+	}
+
 	// 池模式默认不标记本地账号状态；仅当用户显式配置自定义错误码时按本地策略处理。
 	if account.IsPoolMode() && !customErrorCodesEnabled && account.Platform != PlatformAnthropic {
 		slog.Info("pool_mode_error_skipped", "account_id", account.ID, "status_code", statusCode)
@@ -604,22 +608,6 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			// stale sticky binding — opus/haiku stay schedulable. See
 			// ratelimit_service_tk_mirror_class_429.go.
 			s.tkTryAnthropicMirrorClassCooldownOnDownstreamEmpty(ctx, account, satCount, tkFirstRequestedModel(requestedModel))
-			return true
-		}
-		// TK (prod 2026-07): OpenAI edge-mirror stubs (openai-us* → api-us*.tokenkey.dev)
-		// receive the same downstream empty-pool 429 envelope. Skip handle429 /
-		// runtime block and feed the bounded scheduler de-prioritization preference.
-		if tkSkipOpenAIDownstreamCapacityPenalty(account, statusCode, upstreamMsg, responseBody) {
-			reason := "no_available_accounts"
-			if tkSkipDownstreamFailoverExhaustedPenalty(statusCode, upstreamMsg, responseBody) {
-				reason = "all_available_accounts_exhausted"
-			}
-			slog.Info("openai_downstream_capacity_skip_penalty",
-				"account_id", account.ID,
-				"status_code", statusCode,
-				"reason", reason)
-			satCount := s.recordOpenAIStubSaturation(ctx, account.ID, statusCode, reason)
-			s.tkTryOpenAIMirrorModelCooldownOnDownstreamEmpty(ctx, account, satCount, tkFirstRequestedModel(requestedModel))
 			return true
 		}
 		// TK (G2, narrow): the sibling downstream capacity signal — a forwarded

--- a/backend/internal/service/ratelimit_service_tk_openai_downstream.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_downstream.go
@@ -1,5 +1,12 @@
 package service
 
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
 // tkIsOpenAIEdgeMirrorStub reports whether account is a prod OpenAI apikey stub
 // that forwards to an internal edge gateway (credentials.base_url
 // https://api-<edge>.tokenkey.dev). Downstream "No available accounts" on these
@@ -8,15 +15,81 @@ func tkIsOpenAIEdgeMirrorStub(account *Account) bool {
 	return account != nil && account.Platform == PlatformOpenAI && isEdgeMirrorStub(account, edgeIDPattern)
 }
 
-// tkSkipOpenAIDownstreamCapacityPenalty is true when an OpenAI edge-mirror stub
-// received TokenKey's own downstream pool-exhaustion envelope. Fail over without
-// handle429 cooldown / runtime block and feed the bounded saturation preference.
+// tkIsOpenAICompatEdgeMirrorStub reports whether account is an OpenAI-compatible
+// prod apikey relay stub backed by an internal edge gateway.
+func tkIsOpenAICompatEdgeMirrorStub(account *Account) bool {
+	if account == nil || account.Type != AccountTypeAPIKey || !isEdgeMirrorStub(account, edgeIDPattern) {
+		return false
+	}
+	return account.Platform == PlatformOpenAI || account.Platform == PlatformGrok
+}
+
+func tkIsDownstreamRateLimitEnvelope(statusCode int, upstreamMsg string, responseBody []byte) bool {
+	if statusCode != http.StatusTooManyRequests {
+		return false
+	}
+	hay := strings.ToLower(strings.TrimSpace(upstreamMsg) + "\n" + string(responseBody))
+	return strings.Contains(hay, "upstream rate limit exceeded")
+}
+
+func tkOpenAICompatDownstreamCapacityReason(statusCode int, upstreamMsg string, responseBody []byte) string {
+	switch {
+	case tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody):
+		return "no_available_accounts"
+	case tkSkipDownstreamFailoverExhaustedPenalty(statusCode, upstreamMsg, responseBody):
+		return "all_available_accounts_exhausted"
+	case tkIsDownstreamRateLimitEnvelope(statusCode, upstreamMsg, responseBody):
+		return "upstream_rate_limit_exhausted"
+	default:
+		return "downstream_capacity"
+	}
+}
+
+// tkSkipOpenAIDownstreamCapacityPenalty is true when an OpenAI-compatible
+// edge-mirror stub received TokenKey's own downstream pool-exhaustion envelope.
+// Fail over without handle429 cooldown / runtime block and feed the bounded
+// saturation preference.
 func tkSkipOpenAIDownstreamCapacityPenalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool {
-	if !tkIsOpenAIEdgeMirrorStub(account) {
+	if !tkIsOpenAICompatEdgeMirrorStub(account) {
 		return false
 	}
 	if tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody) {
 		return true
 	}
-	return tkSkipDownstreamFailoverExhaustedPenalty(statusCode, upstreamMsg, responseBody)
+	if tkSkipDownstreamFailoverExhaustedPenalty(statusCode, upstreamMsg, responseBody) {
+		return true
+	}
+	return tkIsDownstreamRateLimitEnvelope(statusCode, upstreamMsg, responseBody)
+}
+
+func tkOpenAICompatRetryableOnSameAccount(account *Account, statusCode int, upstreamMsg string, responseBody []byte, includeTransient bool) bool {
+	if account == nil || !account.IsPoolMode() {
+		return false
+	}
+	if tkSkipOpenAIDownstreamCapacityPenalty(account, statusCode, upstreamMsg, responseBody) {
+		return false
+	}
+	if account.IsPoolModeRetryableStatus(statusCode) {
+		return true
+	}
+	return includeTransient && isOpenAITransientProcessingError(statusCode, upstreamMsg, responseBody)
+}
+
+func (s *RateLimitService) handleOpenAICompatDownstreamCapacityPenalty(ctx context.Context, account *Account, statusCode int, responseBody []byte, requestedModel string) bool {
+	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(responseBody))
+	upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+	if !tkSkipOpenAIDownstreamCapacityPenalty(account, statusCode, upstreamMsg, responseBody) {
+		return false
+	}
+	reason := tkOpenAICompatDownstreamCapacityReason(statusCode, upstreamMsg, responseBody)
+	slog.Info("openai_compat_downstream_capacity_skip_penalty",
+		"account_id", account.ID,
+		"platform", account.Platform,
+		"status_code", statusCode,
+		"reason", reason)
+	if s != nil {
+		satCount := s.recordOpenAIStubSaturation(ctx, account.ID, statusCode, reason)
+		s.tkTryOpenAIMirrorModelCooldownOnDownstreamEmpty(ctx, account, satCount, requestedModel)
+	}
+	return true
 }

--- a/backend/internal/service/ratelimit_service_tk_openai_downstream_test.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_downstream_test.go
@@ -21,17 +21,49 @@ func openAIEdgeStub(id int64) *Account {
 	}
 }
 
+func grokEdgeStub(id int64) *Account {
+	return &Account{
+		ID:       id,
+		Platform: PlatformGrok,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":   "edge-grok-key",
+			"base_url":  "https://api-us6.tokenkey.dev",
+			"pool_mode": true,
+		},
+	}
+}
+
 func TestTkIsOpenAIEdgeMirrorStub(t *testing.T) {
 	require.True(t, tkIsOpenAIEdgeMirrorStub(openAIEdgeStub(63)))
 	require.False(t, tkIsOpenAIEdgeMirrorStub(&Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeOAuth}))
 	require.False(t, tkIsOpenAIEdgeMirrorStub(&Account{ID: 1, Platform: PlatformAnthropic, Type: AccountTypeAPIKey, Credentials: map[string]any{"base_url": "https://api-us6.tokenkey.dev"}}))
 }
 
+func TestTkIsOpenAICompatEdgeMirrorStub_IncludesGrokRelayStub(t *testing.T) {
+	require.True(t, tkIsOpenAICompatEdgeMirrorStub(openAIEdgeStub(63)))
+	require.True(t, tkIsOpenAICompatEdgeMirrorStub(grokEdgeStub(64)))
+	require.False(t, tkIsOpenAICompatEdgeMirrorStub(&Account{ID: 65, Platform: PlatformGrok, Type: AccountTypeOAuth}))
+	require.False(t, tkIsOpenAICompatEdgeMirrorStub(&Account{ID: 66, Platform: PlatformGrok, Type: AccountTypeAPIKey, Credentials: map[string]any{"base_url": "https://api.x.ai/v1"}}))
+}
+
 func TestTkSkipOpenAIDownstreamCapacityPenalty(t *testing.T) {
 	body := []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)
 	require.True(t, tkSkipOpenAIDownstreamCapacityPenalty(openAIEdgeStub(63), http.StatusTooManyRequests, "", body))
+	require.True(t, tkSkipOpenAIDownstreamCapacityPenalty(grokEdgeStub(64), http.StatusTooManyRequests, "", body))
 	require.False(t, tkSkipOpenAIDownstreamCapacityPenalty(openAIEdgeStub(63), http.StatusTooManyRequests, "", []byte(`{"error":{"type":"rate_limit_error"}}`)))
 	require.False(t, tkSkipOpenAIDownstreamCapacityPenalty(&Account{ID: 9, Platform: PlatformOpenAI, Type: AccountTypeOAuth}, http.StatusTooManyRequests, "", body))
+}
+
+func TestTkSkipOpenAIDownstreamCapacityPenalty_GrokRateLimitEnvelope(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Upstream rate limit exceeded, please retry later"}}`)
+	require.True(t, tkSkipOpenAIDownstreamCapacityPenalty(grokEdgeStub(64), http.StatusTooManyRequests, "", body))
+	require.Equal(t, "upstream_rate_limit_exhausted", tkOpenAICompatDownstreamCapacityReason(http.StatusTooManyRequests, "", body))
+	require.False(t, tkOpenAICompatRetryableOnSameAccount(grokEdgeStub(64), http.StatusTooManyRequests, "", body, false))
+
+	providerBody := []byte(`{"error":{"message":"You have exceeded your current request limit."}}`)
+	require.False(t, tkSkipOpenAIDownstreamCapacityPenalty(grokEdgeStub(64), http.StatusTooManyRequests, "", providerBody))
+	require.True(t, tkOpenAICompatRetryableOnSameAccount(grokEdgeStub(64), http.StatusTooManyRequests, "", providerBody, false))
 }
 
 type fakeOpenAISaturationCounterRL struct {

--- a/backend/internal/service/ratelimit_service_tk_openai_mirror_model.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_mirror_model.go
@@ -7,8 +7,9 @@ import (
 	"time"
 )
 
-// TK — prod-side per-model cooldown for header-less edge empty-pool 429s on OpenAI
-// edge-mirror stubs (openai-us* → api-us*.tokenkey.dev).
+// TK — prod-side per-model cooldown for header-less edge empty-pool 429s on
+// OpenAI-compatible edge-mirror stubs (openai-us*/grok-us* →
+// api-us*.tokenkey.dev).
 //
 // Mirrors ratelimit_service_tk_mirror_class_429.go for the GPT line: when edge
 // spark (or another mapped model) is dry but gpt-5.4 still has headroom on the
@@ -31,7 +32,7 @@ func (s *RateLimitService) tkTryOpenAIMirrorModelCooldownOnDownstreamEmpty(
 	if s == nil || s.accountRepo == nil || account == nil {
 		return false
 	}
-	if !tkIsOpenAIEdgeMirrorStub(account) {
+	if !tkIsOpenAICompatEdgeMirrorStub(account) {
 		return false
 	}
 	if saturationCount < edgeMirrorStubSaturationThreshold {

--- a/backend/internal/service/ratelimit_service_tk_openai_mirror_model_test.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_mirror_model_test.go
@@ -43,6 +43,30 @@ func TestOpenAIMirrorModel_SustainedSpark_WritesModelScopedCooldown(t *testing.T
 	require.Empty(t, repo.tempCalls)
 }
 
+func TestOpenAIMirrorModel_SustainedGrok_WritesModelScopedCooldown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc, _ := newOpenAIMirrorModelService(repo)
+	account := grokEdgeStub(80)
+	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Upstream rate limit exceeded, please retry later"}}`)
+	before := time.Now()
+
+	for i := 0; i < 4; i++ {
+		require.True(t, svc.HandleUpstreamError(context.Background(), account,
+			http.StatusTooManyRequests, http.Header{}, body, "grok-build-0.1"))
+	}
+	after := time.Now()
+
+	require.NotEmpty(t, repo.modelRateLimitCalls)
+	first := repo.modelRateLimitCalls[0]
+	require.Equal(t, int64(80), first.accountID)
+	require.Equal(t, "grok-build-0.1", first.scope)
+	require.Equal(t, tkOpenAIMirrorDownstreamEmptyReason, first.reason)
+	require.False(t, first.resetAt.Before(before))
+	require.False(t, first.resetAt.After(after.Add(time.Duration(edgeMirrorStubSaturationWindowSeconds)*time.Second)))
+	require.Zero(t, repo.setRateLimitedCalls)
+	require.Empty(t, repo.tempCalls)
+}
+
 func TestOpenAIMirrorModel_BelowThreshold_NoCooldown(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
 	svc, _ := newOpenAIMirrorModelService(repo)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3453,13 +3453,14 @@
       "rationale": "Write side of OpenAI saturation de-prioritization: increments the per-stub short-window counter ONLY on the downstream-capacity skip-penalty path. Never advances handle429 / ladder — preference feed only. Dropping this file stops feeding the counter and scheduler preference becomes inert."
     },
     {
-      "path": "backend/internal/service/ratelimit_service.go",
+      "path": "backend/internal/service/ratelimit_service_tk_openai_downstream.go",
       "must_contain": [
+        "func (s *RateLimitService) handleOpenAICompatDownstreamCapacityPenalty(",
         "satCount := s.recordOpenAIStubSaturation(ctx, account.ID, statusCode, reason)",
-        "s.tkTryOpenAIMirrorModelCooldownOnDownstreamEmpty(ctx, account, satCount, tkFirstRequestedModel(requestedModel))",
-        "openai_downstream_capacity_skip_penalty"
+        "s.tkTryOpenAIMirrorModelCooldownOnDownstreamEmpty(ctx, account, satCount, requestedModel)",
+        "openai_compat_downstream_capacity_skip_penalty"
       ],
-      "rationale": "Thin injection of OpenAI saturation counter increments at the HandleUpstreamError downstream-capacity skip branch (429 no-available / failover-exhausted on openai-us* edge mirror stubs). Sits AFTER the skip decision so cooldown/ladder stay untouched — only feeds de-prioritization preference. Upstream merge rewriting the skip branch would silently drop the feed."
+      "rationale": "Thin injection of OpenAI-compatible saturation counter increments at the downstream-capacity skip branch (429 no-available / failover-exhausted / TokenKey downstream rate-limit envelope on openai-us* and grok edge mirror stubs). Sits AFTER the skip decision so cooldown/ladder stay untouched; only feeds de-prioritization preference and optional model-scoped cooldown. Upstream merge rewriting the skip helper would silently drop the feed."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_openai_mirror_model.go",

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -90,6 +90,16 @@
       "rationale": "The xAI Heavy-only entitlement-403 classifier + clean client message. Without it a grok 403 (standard/expired/downgraded Heavy) fails over pool-wide and is masked into a 502 — the single xAI policy change that would silently kill a thin grok pool (the marquee sharp edge)."
     },
     {
+      "path": "backend/internal/service/ratelimit_service_tk_openai_downstream.go",
+      "must_contain": [
+        "func tkIsOpenAICompatEdgeMirrorStub(",
+        "account.Platform == PlatformOpenAI || account.Platform == PlatformGrok",
+        "func tkIsDownstreamRateLimitEnvelope(",
+        "upstream rate limit exceeded"
+      ],
+      "rationale": "Grok prod relay stubs are OpenAI-compatible edge mirror API-key accounts. TokenKey downstream capacity envelopes from edge (including `Upstream rate limit exceeded`) must be classified as relay capacity, not xAI account health; otherwise prod writes temp_unschedulable on every grok relay stub and local routing collapses into `No available accounts`."
+    },
+    {
       "path": "backend/internal/service/openai_gateway_chat_completions.go",
       "must_contain": [
         "account.IsGrok()"
@@ -440,9 +450,10 @@
         "TestForwardGrokMediaAllowsEdgeRelayBaseURLWithAllowlistEnabled",
         "TestForwardGrokResponsesAPIKeyRelayUsesEdgeResponsesURL",
         "TestResolveGrokResponsesUpstreamAPIKeyRelayUsesEdgeOpenAIResponses",
-        "TestForwardAsAnthropic_GrokAPIKeyRelayUsesEdgeChatCompletionsURL"
+        "TestForwardAsAnthropic_GrokAPIKeyRelayUsesEdgeChatCompletionsURL",
+        "TestHandleGrokAccountUpstreamError_DownstreamCapacitySkipsRelayCooldown"
       ],
-      "rationale": "Load-bearing QA for grok apikey relay and Anthropic-shaped /v1/messages prod→edge path: native-catalog SKUs must forward to edge /v1/chat/completions with Bearer api_key (SSOT provision path). Revert to OAuth-only or responses-first routing passes other tests but breaks prod grok-us4 Claude-Code clients on catalog SKUs."
+      "rationale": "Load-bearing QA for grok apikey relay and Anthropic-shaped /v1/messages prod->edge path: native-catalog SKUs must forward to edge /v1/chat/completions with Bearer api_key (SSOT provision path), and TokenKey downstream capacity envelopes must not runtime-block/temp-unschedule relay stubs. Revert to OAuth-only, responses-first routing, or treating relay capacity as xAI account health passes other tests but breaks prod grok clients."
     },
     {
       "path": "backend/internal/server/routes/gateway_test.go",


### PR DESCRIPTION
## 摘要

- 将 prod->edge Grok API-key relay stub 纳入 OpenAI-compatible edge mirror 识别，TokenKey 下游容量包络不再当作 xAI 账号健康错误处理。
- 对 `No available accounts`、failover exhausted、`Upstream rate limit exceeded` 这类下游容量信号只记录饱和偏好和必要的模型级短冷却，避免写 whole-account temp/rate-limit 导致 prod 本地池被打空。
- 补齐 Grok/OpenAI-compatible 回归测试，并更新 `gateway-tk` / `grok` sentinel，防止共享 helper 被后续 merge 改回 OpenAI-only。
- 合入当前 `origin/main`，修复 `main-ancestry-guard` 对 PR head 必须包含 base commit 的要求。

## 风险

- 常规风险：调整 Grok/OpenAI-compatible relay stub 的 429/容量包络处理路径。
- 真正来自 xAI/provider 的 429 仍保留原有 failover/限流处理；本次只跳过 TokenKey 下游容量 envelope 对账号健康的惩罚。
- Web impact: none，后端网关与 sentinel/test 变更，无前端行为变更。

## 验证

- `go test -tags=unit ./internal/service`
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`
- `python3 scripts/sentinels/check-grok.py --quiet`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`（合入 `origin/main` 后重跑，PASS）

## 提交

- `943c91c4a` Merge remote-tracking branch 'origin/main' into fix/grok-relay-capacity-envelope
- `784dfb01b` fix(grok): treat relay capacity as downstream saturation no-web-impact

最新提交：`943c91c4a`
