### PR TITLE
fix(ops): raise user-visible failure alert threshold

### DIFF
--- a/backend/internal/repository/ops_alert_rules_seed_state_integration_test.go
+++ b/backend/internal/repository/ops_alert_rules_seed_state_integration_test.go
@@ -26,6 +26,21 @@ func TestSeededAlertRuleStateAfterMigrations(t *testing.T) {
 		return enabled
 	}
 
+	type seededRule struct {
+		enabled       bool
+		threshold     float64
+		windowMinutes int
+	}
+	ruleFor := func(metricType string) seededRule {
+		var rule seededRule
+		err := integrationDB.QueryRowContext(ctx,
+			`SELECT enabled, threshold, window_minutes FROM ops_alert_rules WHERE metric_type = $1 ORDER BY id LIMIT 1`,
+			metricType,
+		).Scan(&rule.enabled, &rule.threshold, &rule.windowMinutes)
+		require.NoError(t, err, "metric_type %s should be seeded", metricType)
+		return rule
+	}
+
 	absentFor := func(metricType string) {
 		var id int64
 		err := integrationDB.QueryRowContext(ctx,
@@ -36,8 +51,13 @@ func TestSeededAlertRuleStateAfterMigrations(t *testing.T) {
 	}
 
 	// tk_060: user-experience-first P0/P1 guardrails.
-	require.True(t, enabledFor("user_visible_failure_count"),
+	userVisibleFailureRule := ruleFor("user_visible_failure_count")
+	require.True(t, userVisibleFailureRule.enabled,
 		"tk_060 user_visible_failure_count rule must be enabled")
+	require.Equal(t, 50.0, userVisibleFailureRule.threshold,
+		"tk_064 raises the prod P0 user-visible threshold to 50 failures")
+	require.Equal(t, 5, userVisibleFailureRule.windowMinutes,
+		"prod P0 user-visible threshold is evaluated over 5 minutes")
 	require.True(t, enabledFor("client_visible_failure_count"),
 		"tk_060 client_visible_failure_count rule must be enabled")
 

--- a/backend/migrations/tk_064_raise_user_visible_failure_threshold.sql
+++ b/backend/migrations/tk_064_raise_user_visible_failure_threshold.sql
@@ -1,0 +1,17 @@
+-- tk_064_raise_user_visible_failure_threshold.sql
+--
+-- Raise the prod P0 real-user experience pager from 20 failures / 5m to
+-- 50 failures / 5m. This keeps the rule focused on clear user-visible incident
+-- volume while preserving the same provider/platform-owned failure scope.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+UPDATE ops_alert_rules
+SET
+  threshold = 50.0,
+  window_minutes = 5,
+  description = 'prod 节点 5 分钟内真实用户可感知的 provider/platform 终态失败累计 ≥ 50 时触发。统计 status_code>=400、error_owner IN (provider,platform)、is_count_tokens=false 且可归属真实用户的请求；不包含 recovered-200。edge 节点运行时跳过该规则，避免和 prod 聚合线重复。该规则是用户体验兜底，根因由飞书卡片 breakdown 展示。',
+  updated_at = NOW()
+WHERE name = '真实用户体验受损'
+  AND metric_type = 'user_visible_failure_count';


### PR DESCRIPTION
## 摘要
- 将 prod P0 `user_visible_failure_count` 告警阈值调整为 5m 内 50 次错误。
- 新增 `tk_064` migration 更新已部署规则，并补充迁移后 seed 状态断言。
- 将分支合入当前 `origin/main`，修复 `main-ancestry-guard` 失败。

## 风险
- 影响范围限于 ops alert rule 配置；会降低 20-49 次/5m provider/platform 真实用户失败的 P0 告警噪声。
- Web impact: none。

## 验证
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` PASS。
- `./scripts/preflight.sh` PASS（提交前）。
- `go test -tags=unit ./internal/service -run 'TestComputeRuleMetricUserVisibleFailureCounts|TestComputeUserVisibleFailureDimensions|TestMaybeSendAlertFeishuUserVisibleP0|TestBuildOpsFeishuClientVisibleTextOmitsScopeAndWrapsBreakdowns'` PASS。\n- 远端 CI 先前除 `main-ancestry-guard` 外均通过；本地已合入当前 `origin/main` 修复 ancestry，push 后继续监控。\n\n## 提交\n- `f24804ac4` merge origin/main into fix/user-visible-alert-threshold\n- `44c744f04` fix(ops): raise user-visible failure alert threshold\n- 最新提交：`f24804ac4`