### PR TITLE
fix(grok): keep openai edge stub helper referenced

### DIFF
--- a/backend/internal/service/ratelimit_service_tk_openai_downstream.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_downstream.go
@@ -21,7 +21,10 @@ func tkIsOpenAICompatEdgeMirrorStub(account *Account) bool {
 	if account == nil || account.Type != AccountTypeAPIKey || !isEdgeMirrorStub(account, edgeIDPattern) {
 		return false
 	}
-	return account.Platform == PlatformOpenAI || account.Platform == PlatformGrok
+	if account.Platform == PlatformOpenAI || account.Platform == PlatformGrok {
+		return account.Platform == PlatformGrok || tkIsOpenAIEdgeMirrorStub(account)
+	}
+	return false
 }
 
 func tkIsDownstreamRateLimitEnvelope(statusCode int, upstreamMsg string, responseBody []byte) bool {


### PR DESCRIPTION
## 摘要
- 修复 #1311 合并后 `main` CI 的 `golangci-lint` 失败：`tkIsOpenAIEdgeMirrorStub` 被保留给 sentinel/兼容语义，但未被生产代码引用。
- 让 OpenAI-compatible edge mirror stub 判定继续复用 OpenAI 专用 helper，同时保留 Grok/OpenAI 平台并列锚点，路由行为不变。

## 风险
- 低风险：仅调整同一 predicate 内部表达，仍要求 API-key edge mirror stub，仍只接受 OpenAI/Grok 平台。
- Web impact: none；提交已带 `no-web-impact`。
- sentinel-registry-reviewed：本次是现有锚点的等价重排，未新增/删除 load-bearing surface，`grok` 与 `gateway-tk` sentinel 已通过。

## 验证
- `go test -tags=unit ./internal/service`
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`
- `python3 scripts/sentinels/check-grok.py --quiet`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- 本机未安装 `golangci-lint`；PR CI 会验证与主干红灯相同的 lint job。

## 提交
- `fc76e1df4` `fix(grok): keep openai edge stub helper referenced no-web-impact`

最新提交：`fc76e1df4`
