### PR TITLE
fix(gateway): route Claude chat to Anthropic messages bridge

### DIFF
--- a/backend/internal/service/gateway_forward_as_chat_completions_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_test.go
@@ -3,6 +3,8 @@
 package service
 
 import (
+	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,8 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestExtractCCReasoningEffortFromBody(t *testing.T) {
@@ -112,4 +116,76 @@ func TestHandleCCStreamingFromAnthropic_PreservesMessageStartCacheUsageAndReason
 	require.NotNil(t, result.ReasoningEffort)
 	require.Equal(t, "medium", *result.ReasoningEffort)
 	require.Contains(t, rec.Body.String(), `[DONE]`)
+}
+
+func TestForwardAsChatCompletions_AnthropicAccountBridgesViaMessages(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"max_tokens":32,"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_smoke","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"usage":{"input_tokens":4,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"E2E-OPENAI-OK"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_chat_messages_bridge"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          400,
+		Name:        "anthropic-smoke",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key": "sk-ant-smoke",
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "claude-sonnet-4-6", result.Model)
+	require.Equal(t, "claude-sonnet-4-6", result.UpstreamModel)
+	require.False(t, result.Stream)
+	require.Equal(t, 4, result.Usage.InputTokens)
+	require.Equal(t, 5, result.Usage.OutputTokens)
+
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "/v1/messages", upstream.lastReq.URL.Path)
+	require.Equal(t, "claude-sonnet-4-6", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.True(t, gjson.GetBytes(upstream.lastBody, "messages").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "choices").Exists())
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "chat.completion", gjson.GetBytes(rec.Body.Bytes(), "object").String())
+	require.Equal(t, "claude-sonnet-4-6", gjson.GetBytes(rec.Body.Bytes(), "model").String())
+	require.Equal(t, "E2E-OPENAI-OK", gjson.GetBytes(rec.Body.Bytes(), "choices.0.message.content").String())
+	require.Equal(t, "stop", gjson.GetBytes(rec.Body.Bytes(), "choices.0.finish_reason").String())
+	require.True(t, gjson.GetBytes(rec.Body.Bytes(), "usage").Exists())
 }

--- a/backend/internal/service/universal_routing_tk_endpoint_map.go
+++ b/backend/internal/service/universal_routing_tk_endpoint_map.go
@@ -212,6 +212,9 @@ func universalRequestPlatformHint(shape UniversalShape, model string) string {
 	}
 	switch shape {
 	case ShapeOpenAIChat:
+		if universalModelPlatformHint(m) == PlatformAnthropic {
+			return PlatformAnthropic
+		}
 		if universalAntigravityTextModel(m) {
 			return PlatformAntigravity
 		}

--- a/backend/internal/service/universal_routing_tk_resolver_test.go
+++ b/backend/internal/service/universal_routing_tk_resolver_test.go
@@ -195,6 +195,9 @@ func TestUniversalModelPlatformHint(t *testing.T) {
 }
 
 func TestUniversalRequestPlatformHint_OpenAICompatVertexMedia(t *testing.T) {
+	if got := universalRequestPlatformHint(ShapeOpenAIChat, "claude-sonnet-4-6"); got != PlatformAnthropic {
+		t.Fatalf("claude on OpenAI chat should keep anthropic hint, got %q", got)
+	}
 	if got := universalRequestPlatformHint(ShapeOpenAIImages, "imagen-4.0-generate-001"); got != PlatformNewAPI {
 		t.Fatalf("imagen on OpenAI images should hint newapi vertex, got %q", got)
 	}

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -502,6 +502,25 @@ func TestResolve_ClaudeOpenAIShapePicksAnthropic(t *testing.T) {
 	}
 }
 
+func TestResolve_ClaudeOpenAIShapePrefersAnthropicOverCompatClaudeMapping(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(1, PlatformAnthropic, 50, false),
+		grp(2, PlatformOpenAI, 1, false),
+		grp(11, PlatformNewAPI, 2, false),
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		2:  {"claude-sonnet-4-6"},
+		11: {"claude-sonnet-4-6"},
+		// gid=1(anthropic)缺席 → native nil served; claude-* hint must keep it eligible.
+	}))
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIChat, "claude-sonnet-4-6", "")
+	if err != nil || g == nil || g.ID != 1 {
+		t.Fatalf("claude @openai-shape must prefer native anthropic over compat mappings, got=%v err=%v", g, err)
+	}
+}
+
 func TestResolve_GeminiAnthropicShapePicksGemini(t *testing.T) {
 	ctx := context.Background()
 	span := []Group{

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -165,23 +165,6 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
             echo "tk_post_deploy_smoke: ${label} section soft-skipped (universal_no_entitled_group; /v1/messages probe is the canonical signal)"
             return 1
             ;;
-          *"Unsupported model"*)
-            if [[ "${label}" == "/v1/chat/completions" ]]; then
-              # Anthropic universal-key topology: a chat-shaped Claude probe can
-              # hit a non-Anthropic backing pool and surface local 400
-              # "Unsupported model" before the canonical /v1/messages probe runs.
-              echo "::warning::tk_post_deploy_smoke: ${label} returned HTTP ${http} Unsupported model — deferring Anthropic validation to /v1/messages probe." >&2
-              if [[ -n "${err_msg}" ]]; then
-                echo "  gateway message: ${err_msg}" >&2
-              fi
-              jq . "${resp_file}" >&2 2>/dev/null || cat "${resp_file}" >&2
-              echo "tk_post_deploy_smoke: ${label} section soft-skipped (unsupported_model on chat shape; /v1/messages probe is the canonical signal)"
-              return 1
-            fi
-            echo "tk_post_deploy_smoke: ${label} failed" >&2
-            jq . "${resp_file}" >&2 2>/dev/null || cat "${resp_file}" >&2
-            exit 1
-            ;;
           *"restricted to Claude Code clients"*|*"/v1/messages only"*)
             # claude_code_only group policy: the configured Anthropic key is
             # bound to a group that allows /v1/messages with a Claude Code UA

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -165,6 +165,23 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
             echo "tk_post_deploy_smoke: ${label} section soft-skipped (universal_no_entitled_group; /v1/messages probe is the canonical signal)"
             return 1
             ;;
+          *"Unsupported model"*)
+            if [[ "${label}" == "/v1/chat/completions" ]]; then
+              # Anthropic universal-key topology: a chat-shaped Claude probe can
+              # hit a non-Anthropic backing pool and surface local 400
+              # "Unsupported model" before the canonical /v1/messages probe runs.
+              echo "::warning::tk_post_deploy_smoke: ${label} returned HTTP ${http} Unsupported model — deferring Anthropic validation to /v1/messages probe." >&2
+              if [[ -n "${err_msg}" ]]; then
+                echo "  gateway message: ${err_msg}" >&2
+              fi
+              jq . "${resp_file}" >&2 2>/dev/null || cat "${resp_file}" >&2
+              echo "tk_post_deploy_smoke: ${label} section soft-skipped (unsupported_model on chat shape; /v1/messages probe is the canonical signal)"
+              return 1
+            fi
+            echo "tk_post_deploy_smoke: ${label} failed" >&2
+            jq . "${resp_file}" >&2 2>/dev/null || cat "${resp_file}" >&2
+            exit 1
+            ;;
           *"restricted to Claude Code clients"*|*"/v1/messages only"*)
             # claude_code_only group policy: the configured Anthropic key is
             # bound to a group that allows /v1/messages with a Claude Code UA

--- a/scripts/test_smoke_suite.py
+++ b/scripts/test_smoke_suite.py
@@ -82,13 +82,13 @@ class SoftDegradeOrExitTest(unittest.TestCase):
     """
 
     @staticmethod
-    def _run(suite: str, http: str, body: dict) -> tuple[int, str]:
+    def _run(suite: str, http: str, body: dict, label: str = "/v1/x") -> tuple[int, str]:
         with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
             json.dump(body, f)
             resp_path = f.name
         script = (
             f'source "{SMOKE_LIB}"\n'
-            f'if soft_degrade_or_exit "/v1/x" "{http}" "{resp_path}"; then\n'
+            f'if soft_degrade_or_exit "{label}" "{http}" "{resp_path}"; then\n'
             f'  echo MARKER=continue\n'
             f'else\n'
             f'  echo MARKER=softskip\n'
@@ -140,6 +140,27 @@ class SoftDegradeOrExitTest(unittest.TestCase):
     def test_full_403_unrelated_hard_fails(self) -> None:
         rc, out = self._run(
             "full", "403", {"error": {"message": "invalid api key"}},
+        )
+        self.assertEqual(rc, 1, out)
+        self.assertNotIn("MARKER=continue", out)
+
+    def test_full_chat_400_unsupported_model_soft_skips(self) -> None:
+        rc, out = self._run(
+            "full",
+            "400",
+            {"error": {"message": "Unsupported model: claude-sonnet-4-6"}},
+            label="/v1/chat/completions",
+        )
+        self.assertEqual(rc, 0, out)
+        self.assertIn("MARKER=softskip", out)
+        self.assertIn("unsupported_model on chat shape", out)
+
+    def test_full_messages_400_unsupported_model_hard_fails(self) -> None:
+        rc, out = self._run(
+            "full",
+            "400",
+            {"error": {"message": "Unsupported model: claude-sonnet-4-6"}},
+            label="/v1/messages",
         )
         self.assertEqual(rc, 1, out)
         self.assertNotIn("MARKER=continue", out)

--- a/scripts/test_smoke_suite.py
+++ b/scripts/test_smoke_suite.py
@@ -144,16 +144,15 @@ class SoftDegradeOrExitTest(unittest.TestCase):
         self.assertEqual(rc, 1, out)
         self.assertNotIn("MARKER=continue", out)
 
-    def test_full_chat_400_unsupported_model_soft_skips(self) -> None:
+    def test_full_chat_400_unsupported_model_hard_fails(self) -> None:
         rc, out = self._run(
             "full",
             "400",
             {"error": {"message": "Unsupported model: claude-sonnet-4-6"}},
             label="/v1/chat/completions",
         )
-        self.assertEqual(rc, 0, out)
-        self.assertIn("MARKER=softskip", out)
-        self.assertIn("unsupported_model on chat shape", out)
+        self.assertEqual(rc, 1, out)
+        self.assertNotIn("MARKER=continue", out)
 
     def test_full_messages_400_unsupported_model_hard_fails(self) -> None:
         rc, out = self._run(


### PR DESCRIPTION
## 摘要
- 修正 universal routing 的 OpenAI chat shape 平台 hint：`claude-*` 在 `/v1/chat/completions` 下保持 Anthropic 优先，不再被 Antigravity catalog 或 openai/newapi 兼容组的 claude 映射抢走。
- 保留并强化 Anthropic bridge 回归：Claude chat 请求选中 Anthropic 账号后，内部上游走 `/v1/messages`，返回客户端仍是 OpenAI `chat.completion` shape。
- 收回 Stage0 smoke 对 `/v1/chat/completions` 的 400 `Unsupported model` soft-skip；chat 和 messages 段遇到 unsupported model 都硬失败，让 full smoke 真正验证转换链路。

## 风险
- 常规风险；改动 universal routing 的 Claude chat 平台偏好和 smoke 判定。
- 非 Claude 的 Antigravity-only chat model 仍保留原来的 Antigravity hint；OpenAI/NewAPI vendor 精确匹配逻辑不变。
- Web impact: none。

## 验证
- `PYTHONPATH=. python3 scripts/test_smoke_suite.py`
- `cd backend && go test -tags=unit ./internal/service -run 'TestUniversalRequestPlatformHint_OpenAICompatVertexMedia|TestResolve_ClaudeOpenAIShapePicksAnthropic|TestResolve_ClaudeOpenAIShapePrefersAnthropicOverCompatClaudeMapping|TestForwardAsChatCompletions_AnthropicAccountBridgesViaMessages|TestResolve_MessagesDispatch_NewapiDeepseekDisambiguation_User16' -count=1`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

## 提交
- `25d311832 fix(ops): soft-skip anthropic chat unsupported smoke`
- `d3d851a30 fix(gateway): prefer anthropic for Claude chat routing`
- 最新提交：`d3d851a30`