### PR TITLE
fix(gateway): lower default token hold reserve

### DIFF
--- a/backend/internal/handler/openai_gateway_handler_tk_hold.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_hold.go
@@ -36,7 +36,7 @@ const tkInsufficientBalanceForHoldMsg = "Insufficient account balance to reserve
 // Explicit client ceilings are still honored as hard reserve inputs; only the
 // omitted-ceiling path uses this lower estimate so a short-lived auth/balance
 // cache snapshot does not reject hundreds of ordinary requests.
-const tkHoldDefaultOutputReserveTokens = 4096
+const tkHoldDefaultOutputReserveTokens = 256
 
 // tkParseMaxOutputTokens extracts the output-token ceiling from the request,
 // falling back to a low default reserve when the client omits it. Field names

--- a/backend/internal/handler/openai_gateway_handler_tk_hold.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_hold.go
@@ -12,9 +12,9 @@ import (
 
 // TK: pre-flight balance HOLD injection for OpenAI-compatible routes.
 //
-// Reserves an upper-bound cost on the user balance BEFORE forwarding so that
-// concurrent requests cannot overdraw it (the post-hoc deduct has no floor —
-// see service/usage_billing_hold_tk.go for the invariant). Balance users only:
+// Reserves a pre-flight amount on the user balance BEFORE forwarding so
+// concurrent requests cannot freely overdraw it (the post-hoc deduct has no
+// floor — see service/usage_billing_hold_tk.go). Balance users only:
 // subscription requests have no balance to overdraw and are skipped.
 //
 // Hold lifecycle (the release-before-settle rule): the reservation must outlive
@@ -31,16 +31,15 @@ import (
 // insufficient-balance mapping).
 const tkInsufficientBalanceForHoldMsg = "Insufficient account balance to reserve this request"
 
-// tkHoldFallbackMaxOutputTokens is the conservative output-token upper bound
-// used when a request omits max_tokens / max_completion_tokens /
-// max_output_tokens. The hold must be an upper bound on actual cost; without a
-// client-declared ceiling we assume a large output so the reservation cannot
-// under-cover. (PR-follow-up: derive the exact per-model max-output from
-// pricing metadata to tighten this.)
-const tkHoldFallbackMaxOutputTokens = 200000
+// tkHoldDefaultOutputReserveTokens is the UX-friendly output-token reserve used
+// when a request omits max_tokens / max_completion_tokens / max_output_tokens.
+// Explicit client ceilings are still honored as hard reserve inputs; only the
+// omitted-ceiling path uses this lower estimate so a short-lived auth/balance
+// cache snapshot does not reject hundreds of ordinary requests.
+const tkHoldDefaultOutputReserveTokens = 4096
 
 // tkParseMaxOutputTokens extracts the output-token ceiling from the request,
-// falling back to a conservative bound when the client omits it. Field names
+// falling back to a low default reserve when the client omits it. Field names
 // per surface: max_tokens (chat, anthropic messages), max_completion_tokens
 // (chat), max_output_tokens (responses) — max() of whatever is present.
 func tkParseMaxOutputTokens(body []byte) int {
@@ -52,7 +51,7 @@ func tkParseMaxOutputTokens(body []byte) int {
 		m = mo
 	}
 	if m <= 0 {
-		m = tkHoldFallbackMaxOutputTokens
+		m = tkHoldDefaultOutputReserveTokens
 	}
 	return m
 }
@@ -131,7 +130,7 @@ func (h *OpenAIGatewayHandler) tkApplyBalanceHold(c *gin.Context, apiKey *servic
 
 // tkApplyBalanceHoldNoOutput is tkApplyBalanceHold for routes that produce no
 // output tokens (embeddings): the output side of the estimate is zero instead
-// of the fallback ceiling, so an embeddings call is not blocked by a hold three
+// of the default reserve, so an embeddings call is not blocked by a hold three
 // orders of magnitude above its real cost.
 func (h *OpenAIGatewayHandler) tkApplyBalanceHoldNoOutput(c *gin.Context, apiKey *service.APIKey, reqModel string, body []byte) (hold *tkHoldHandle, reject bool) {
 	return h.tkApplyTokenHold(c, apiKey, reqModel, body, 0, "")

--- a/backend/internal/handler/openai_gateway_handler_tk_hold_test.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_hold_test.go
@@ -33,8 +33,8 @@ func TestTkParseMaxOutputTokens(t *testing.T) {
 }
 
 func TestTkDefaultOutputReserveTokens_StaysLow(t *testing.T) {
-	if tkHoldDefaultOutputReserveTokens > 4096 {
-		t.Fatalf("default output reserve = %d, want <= 4096", tkHoldDefaultOutputReserveTokens)
+	if tkHoldDefaultOutputReserveTokens != 256 {
+		t.Fatalf("default output reserve = %d, want 256", tkHoldDefaultOutputReserveTokens)
 	}
 	if tkParseMaxOutputTokens([]byte(`{}`)) != tkHoldDefaultOutputReserveTokens {
 		t.Fatal("omitted max token fields must use the low default reserve")

--- a/backend/internal/handler/openai_gateway_handler_tk_hold_test.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_hold_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
-// The output-token ceiling feeds the hold's upper bound, so missing a surface's
-// field name silently under-caps nothing (fallback is huge) but over-caps cost:
-// every supported field spelling must be honoured, and absence must fall back
-// to the conservative ceiling.
+// The output-token count feeds the pre-flight hold. Explicit field spellings
+// must still be honored as hard reserve inputs, while omitted ceilings use the
+// low UX reserve instead of a model-sized maximum that can poison auth balance
+// snapshots for several minutes.
 func TestTkParseMaxOutputTokens(t *testing.T) {
 	cases := []struct {
 		name string
@@ -21,14 +21,23 @@ func TestTkParseMaxOutputTokens(t *testing.T) {
 		{"chat max_completion_tokens", `{"max_completion_tokens":2048}`, 2048},
 		{"responses max_output_tokens", `{"max_output_tokens":4096}`, 4096},
 		{"max of multiple fields", `{"max_tokens":100,"max_output_tokens":300,"max_completion_tokens":200}`, 300},
-		{"absent falls back", `{}`, tkHoldFallbackMaxOutputTokens},
-		{"zero falls back", `{"max_tokens":0}`, tkHoldFallbackMaxOutputTokens},
-		{"negative falls back", `{"max_tokens":-5}`, tkHoldFallbackMaxOutputTokens},
+		{"absent falls back to low reserve", `{}`, tkHoldDefaultOutputReserveTokens},
+		{"zero falls back to low reserve", `{"max_tokens":0}`, tkHoldDefaultOutputReserveTokens},
+		{"negative falls back to low reserve", `{"max_tokens":-5}`, tkHoldDefaultOutputReserveTokens},
 	}
 	for _, tc := range cases {
 		if got := tkParseMaxOutputTokens([]byte(tc.body)); got != tc.want {
 			t.Errorf("%s: tkParseMaxOutputTokens(%s) = %d, want %d", tc.name, tc.body, got, tc.want)
 		}
+	}
+}
+
+func TestTkDefaultOutputReserveTokens_StaysLow(t *testing.T) {
+	if tkHoldDefaultOutputReserveTokens > 4096 {
+		t.Fatalf("default output reserve = %d, want <= 4096", tkHoldDefaultOutputReserveTokens)
+	}
+	if tkParseMaxOutputTokens([]byte(`{}`)) != tkHoldDefaultOutputReserveTokens {
+		t.Fatal("omitted max token fields must use the low default reserve")
 	}
 }
 

--- a/backend/internal/service/billing_service_tk_hold.go
+++ b/backend/internal/service/billing_service_tk_hold.go
@@ -2,23 +2,24 @@ package service
 
 import "strings"
 
-// TK: pre-flight HOLD estimates — the LOAD-BEARING property is hold >= actual.
-// If any estimate can fall below the eventual billed cost, the overdraft
-// invariant (see usage_billing_hold_tk.go) is void. So every estimate is a
-// deliberate UPPER BOUND on what computeTokenBreakdown / CalculateImageCost /
-// CalculateVideoCost will later bill; the cost is some over-reservation, which
-// only briefly shrinks AVAILABLE balance and is corrected by exact settlement.
+// TK: pre-flight HOLD estimates. These helpers price the caller-provided
+// reserve inputs using conservative unit prices. Token holds are a true upper
+// bound only when the caller passes a real output ceiling; callers may
+// deliberately pass a lower default reserve for omitted ceilings to avoid
+// rejecting ordinary traffic on stale low-balance snapshots. Exact settlement
+// remains the source of truth for the final bill.
 
-// EstimateTokenHold returns an upper bound on the actual cost of a token-billed
-// request (chat / responses / messages; embeddings pass maxOutputTokens=0).
+// EstimateTokenHold returns the reserve amount for a token-billed request
+// (chat / responses / messages; embeddings pass maxOutputTokens=0).
 //
-// Upper-bound construction vs. computeTokenBreakdown's actual formula:
+// Conservative construction vs. computeTokenBreakdown's actual formula:
 //   - input side: every prompt token is priced at the MAX of all input-side
 //     unit prices (input / cache-creation 5m / 1h / priority). At billing time
 //     each token is one of input | cache_read | cache_creation; cache_read is
 //     the cheapest and cache_creation the dearest, so max() dominates any split.
-//   - output side: max_tokens (the hard ceiling the model cannot exceed) at the
-//     MAX of output / priority-output / image-output unit price.
+//   - output side: the caller-provided maxOutputTokens at the MAX of output /
+//     priority-output / image-output unit price. This is a hard upper bound
+//     only when maxOutputTokens came from an explicit client ceiling.
 //   - long-context: applied whenever promptTokens COULD cross the model
 //     threshold (actual triggers on input+cache_read ≤ promptTokens, so this is
 //     a safe over-approximation).

--- a/backend/internal/service/billing_service_tk_hold_test.go
+++ b/backend/internal/service/billing_service_tk_hold_test.go
@@ -8,11 +8,10 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/config"
 )
 
-// The load-bearing property of the overdraft fix: the hold estimate must be an
-// UPPER BOUND on whatever the request can actually be billed. If any reachable
-// token distribution (input ≤ prompt, output ≤ max_tokens) costs more than the
-// hold, the "balance never goes negative" guarantee is void. These tests pin
-// that property across token splits and service tiers.
+// Explicit token ceilings still get the strong overdraft property: the hold is
+// an UPPER BOUND on whatever the request can actually be billed. These tests
+// pin that property across token splits and service tiers for the path where
+// maxOut is a real client ceiling.
 
 func TestEstimateTokenHold_IsUpperBoundOverDistributions(t *testing.T) {
 	s := NewBillingService(&config.Config{}, nil) // fallback pricing, no pricingService

--- a/backend/internal/service/openai_gateway_service_tk_hold.go
+++ b/backend/internal/service/openai_gateway_service_tk_hold.go
@@ -12,13 +12,15 @@ import (
 // TK: pre-flight balance HOLD wiring for the OpenAI-compatible gateway (chat /
 // responses / messages / embeddings / images / video — the balance-billed
 // overdraft surface; Anthropic-native traffic is predominantly subscription,
-// which does not touch balance). Estimates an upper bound, reserves it
-// atomically before forward, and releases at request end. See
-// usage_billing_hold_tk.go for the invariant and billing_service_tk_hold.go
-// for the upper-bound formulas.
+// which does not touch balance). Estimates a request reserve, deducts it
+// atomically before forward, and releases at request end. Explicit output
+// ceilings can be reserved as upper bounds; omitted token ceilings use the
+// handler's low default reserve to protect UX. See usage_billing_hold_tk.go
+// for the concurrency argument and billing_service_tk_hold.go for the pricing
+// formulas.
 
-// tkReserveBalanceHold reserves an upper-bound hold via the repository's narrow
-// hold capability. Returns:
+// tkReserveBalanceHold reserves a hold via the repository's narrow hold
+// capability. Returns:
 //   - held=true            → balance reserved; the caller owns the release
 //     (request-end refund, or hand-off to settlement).
 //   - held=false, reject=true  → insufficient balance; caller rejects with 403.
@@ -59,7 +61,7 @@ func tkReleaseBalanceHold(ctx context.Context, repo UsageBillingRepository, requ
 }
 
 // tkHoldRateMultiplier resolves the SAME user×group rate multiplier the billing
-// path applies to the balance, so the hold cannot under-estimate via a smaller
+// path applies to the balance, so the hold is not reduced by a smaller
 // multiplier. Mirrors the resolution in RecordUsage (openai_gateway_service.go).
 func (s *OpenAIGatewayService) tkHoldRateMultiplier(ctx context.Context, user *User, apiKey *APIKey) float64 {
 	multiplier := 1.0
@@ -83,11 +85,13 @@ func (s *OpenAIGatewayService) tkHoldGatingDisabled() bool {
 	return s.cfg != nil && s.cfg.RunMode == config.RunModeSimple
 }
 
-// TkReserveTokenHold estimates an upper-bound token cost and reserves it.
+// TkReserveTokenHold estimates a token-cost reserve and deducts it.
 // requestID must be derived from the usage-billing request id
 // (TkResolveUsageBillingRequestID) so reconciliation can anchor a hold to its
 // request. promptTokens must be an UPPER BOUND on the request's input tokens
-// (callers over-estimate); embeddings pass maxOutputTokens=0.
+// (callers over-estimate). maxOutputTokens is an upper bound only when callers
+// pass an explicit client ceiling; omitted output ceilings may use a low
+// default reserve. Embeddings pass maxOutputTokens=0.
 //
 // Returns held (caller owns the release) and reject (caller returns 403). A
 // pricing/DB failure is fail-open (held=false, reject=false) + an ALERT log: a

--- a/backend/internal/service/usage_billing_hold_tk.go
+++ b/backend/internal/service/usage_billing_hold_tk.go
@@ -11,17 +11,18 @@ import (
 // `balance >= amount` floor, so N concurrent requests from a barely-positive
 // balance all pass admission, all get served, then all deduct — driving the
 // balance arbitrarily negative. Post-hoc anything cannot un-serve an
-// already-served request; the only fix is to RESERVE an upper-bound estimate
-// of the cost BEFORE forwarding and RELEASE it when the request ends. Actual
-// billing stays untouched on the async path.
+// already-served request; the fix is to RESERVE an estimate of the cost BEFORE
+// forwarding and RELEASE it when the request ends. Actual billing stays
+// untouched on the async path.
 //
 // Invariant: reserve is atomic `UPDATE users SET balance = balance - hold
 // WHERE balance >= hold`. Row-lock serialization ⇒ after admitting k concurrent
-// requests balance = B - Σholdᵢ ≥ 0, so Σholdᵢ ≤ B. If hold is a true upper
-// bound (actualᵢ ≤ holdᵢ — guaranteed by the EstimateHold* formulas in
-// billing_service_tk_hold.go), then final balance = B - Σactualᵢ ≥ B - Σholdᵢ ≥ 0.
-// Provably never negative. The hold's deliberate over-estimate only briefly
-// shrinks AVAILABLE balance; settlement still bills exact actual.
+// requests balance = B - Σholdᵢ ≥ 0, so Σholdᵢ ≤ B. For explicit request
+// ceilings the hold can be a true upper bound and the old non-negative proof
+// applies. For omitted token output ceilings the gateway intentionally reserves
+// a low default instead: this still collapses concurrent overdraft
+// amplification, but it is not a mathematical guarantee that final balance can
+// never go below zero. Settlement still bills exact actual.
 //
 // Release ordering is part of the invariant: billing settles asynchronously,
 // so a hold refunded at handler return while its bill is still queued would


### PR DESCRIPTION
摘要
- 将未显式提供 `max_tokens` / `max_completion_tokens` / `max_output_tokens` 的 token hold 默认输出预留从 200000 降到 256，避免短时 auth/balance 缓存快照因过高预留连续拒绝真实用户请求。
- 显式客户端输出上限仍按原字段取 max 后参与预留；embeddings 仍按 0 输出预留。
- 更新 hold 相关注释，明确省预留路径不再声明严格 upper-bound，不误导后续维护。

风险
- 行为变化限制在 OpenAI-compatible balance hold 的“未声明输出上限”路径；可能降低对超长输出请求的预扣覆盖，但最终账单仍按实际 settlement 扣费。
- Web impact: none；本 PR 无前端、配置、公共契约变更。
- sentinel-registry-reviewed：本次只调整既有 hold surface 的预留策略和测试，不新增/删除 load-bearing surface，不需要更新 sentinel registry。

验证
- `go test -tags unit ./internal/handler -run 'TestTk(ParseMaxOutputTokens|DefaultOutputReserveTokens|HoldHandle)'`（在 `backend/` 下）
- `go test -tags unit ./internal/service -run 'TestEstimate(TokenHold|ImageHold|VideoHold)|TestMaxFloat'`（在 `backend/` 下）
- `git diff --check`
- `./scripts/preflight.sh`

提交
- 0694c6bac fix(gateway): reserve 256 tokens by default no-web-impact
- 78bdb0966 fix(gateway): lower default token hold reserve no-web-impact
- 最新提交：0694c6bac