### PR TITLE
fix(pricing): GLM overlay 覆盖 LiteLLM 镜像漂移价

### DIFF
--- a/backend/internal/service/pricing_catalog_tk.go
+++ b/backend/internal/service/pricing_catalog_tk.go
@@ -367,10 +367,12 @@ func applyCatalogOverlayPricing(resp *PublicCatalogResponse) {
 			// 文件源已有该行：仅当它是全零占位（litellm "cost unknown"，与计费
 			// 侧 tkIsEffectivelyUnpriced 同语义）时用 overlay 价覆盖展示，保持
 			// 展示=计费；行内 context window 等元数据保留文件源的值。真实非零
-			// 文件价永不覆盖。
+			// 文件价永不覆盖，除非 overlay 是 GLM 的 BigModel 官方价（litellm
+			// 镜像里的 USD 猜测会漂移）。
 			row := &resp.Data[idx]
-			if row.Pricing.InputPer1KTokens != 0 || row.Pricing.OutputPer1KTokens != 0 ||
-				row.Pricing.CacheReadPer1K != 0 || row.Pricing.CacheWritePer1K != 0 {
+			hasFilePrice := row.Pricing.InputPer1KTokens != 0 || row.Pricing.OutputPer1KTokens != 0 ||
+				row.Pricing.CacheReadPer1K != 0 || row.Pricing.CacheWritePer1K != 0
+			if hasFilePrice && !tkOverlayOverridesLitellmSource(name, p) {
 				continue
 			}
 			row.Pricing.InputPer1KTokens = p.InputCostPerToken * 1000

--- a/backend/internal/service/pricing_catalog_tk_test.go
+++ b/backend/internal/service/pricing_catalog_tk_test.go
@@ -220,6 +220,40 @@ func TestPricingCatalogService_AppliesTKOverlayPricing(t *testing.T) {
 		"source price wins over overlay (fill-only); base tax applies on top of source")
 }
 
+// TestPricingCatalogService_GLMLitellmMirrorOverriddenByBigModelOverlay pins that
+// stale litellm USD guesses for manifest-listed GLM models do not win over the
+// BigModel-sourced overlay (prod symptom: glm-5.2 at $1.4/$4.4 per Mtok).
+func TestPricingCatalogService_GLMLitellmMirrorOverriddenByBigModelOverlay(t *testing.T) {
+	const fixture = `{
+	  "glm-5.2": {
+	    "input_cost_per_token": 1.4e-06,
+	    "output_cost_per_token": 4.4e-06,
+	    "cache_read_input_token_cost": 2.6e-07,
+	    "litellm_provider": "zhipu",
+	    "mode": "chat"
+	  }
+	}`
+	s := &PricingCatalogService{}
+	s.SetSourceForTesting(func() ([]byte, time.Time, bool) {
+		return []byte(fixture), time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC), true
+	})
+
+	resp := s.BuildPublicCatalog(context.Background())
+	require.NotNil(t, resp)
+	byID := make(map[string]PublicCatalogModel, len(resp.Data))
+	for _, m := range resp.Data {
+		byID[m.ModelID] = m
+	}
+	glm52, ok := byID["glm-5.2"]
+	require.True(t, ok)
+	cnyPer1K := func(cny float64) float64 {
+		return tkCNYPerMTokToUSDPerToken(cny) * 1_000
+	}
+	assert.InDelta(t, cnyPer1K(8)*tkOfficialListBaseTaxMultiplier, glm52.Pricing.InputPer1KTokens, 1e-12)
+	assert.InDelta(t, cnyPer1K(28)*tkOfficialListBaseTaxMultiplier, glm52.Pricing.OutputPer1KTokens, 1e-12)
+	assert.InDelta(t, cnyPer1K(2)*tkOfficialListBaseTaxMultiplier, glm52.Pricing.CacheReadPer1K, 1e-12)
+}
+
 // TestPricingCatalogService_AttachesOverlayTiers pins that input-token interval
 // (阶梯) pricing from tk_pricing_overlay.json is surfaced on Pricing.Tiers of the
 // public catalog (the fix for "公开接口拍平丢掉阶梯价"), and that the flat price is

--- a/backend/internal/service/pricing_service_tk_overlay.go
+++ b/backend/internal/service/pricing_service_tk_overlay.go
@@ -176,15 +176,36 @@ func loadTKPricingOverlay() map[string]*LiteLLMModelPricing {
 	return tkOverlayEffective
 }
 
+// tkOverlayOverridesLitellmSource reports whether a TK overlay row is the
+// authoritative official list price and must replace a non-zero litellm-mirror
+// entry. GLM chat models use BigModel.cn as the sole pricing source; the
+// litellm mirror often carries stale USD guesses (e.g. glm-5.2 at $1.4/$4.4 per
+// Mtok) that must not win over the curated overlay.
+func tkOverlayOverridesLitellmSource(modelID string, overlay *LiteLLMModelPricing) bool {
+	if overlay == nil {
+		return false
+	}
+	if strings.ToLower(strings.TrimSpace(overlay.LiteLLMProvider)) != "zhipu" {
+		return false
+	}
+	m := strings.ToLower(strings.TrimSpace(modelID))
+	if !strings.HasPrefix(m, "glm-") {
+		return false
+	}
+	return isTkCuratedNewAPIModelListed(modelID)
+}
+
 // applyTKPricingOverlay fills in TK-owned pricing for models the loaded source
 // does not already carry — or carries only as an effectively-unpriced (all-zero)
-// placeholder. Real source prices are never overwritten (see file header).
+// placeholder. Real source prices are never overwritten (see file header),
+// except for GLM rows where the overlay is the authoritative BigModel list price.
 func applyTKPricingOverlay(result map[string]*LiteLLMModelPricing) {
 	if result == nil {
 		return
 	}
 	for name, pricing := range loadTKPricingOverlay() {
-		if existing, ok := result[name]; ok && !tkIsEffectivelyUnpriced(existing) {
+		existing, ok := result[name]
+		if ok && !tkIsEffectivelyUnpriced(existing) && !tkOverlayOverridesLitellmSource(name, pricing) {
 			continue
 		}
 		result[name] = pricing

--- a/backend/internal/service/pricing_service_tk_overlay_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_test.go
@@ -146,6 +146,27 @@ func TestTKPricingOverlay_ZeroPlaceholderIsReplaced(t *testing.T) {
 	require.InDelta(t, 3.625e-9, pro.CacheReadInputTokenCost, 1e-15)
 }
 
+func TestApplyTKPricingOverlay_GLMAuthoritativeOverLitellm(t *testing.T) {
+	svc := &PricingService{}
+	body := []byte(`{
+		"glm-5.2": {
+			"input_cost_per_token": 1.4e-06,
+			"output_cost_per_token": 4.4e-06,
+			"cache_read_input_token_cost": 2.6e-07,
+			"litellm_provider": "zhipu",
+			"mode": "chat"
+		}
+	}`)
+	data, err := svc.parsePricingData(body)
+	require.NoError(t, err)
+
+	glm := data["glm-5.2"]
+	require.NotNil(t, glm)
+	require.InDelta(t, tkCNYPerMTokToUSDPerToken(8), glm.InputCostPerToken, 1e-15)
+	require.InDelta(t, tkCNYPerMTokToUSDPerToken(28), glm.OutputCostPerToken, 1e-15)
+	require.InDelta(t, tkCNYPerMTokToUSDPerToken(2), glm.CacheReadInputTokenCost, 1e-15)
+}
+
 // TestTKIsEffectivelyUnpriced pins the predicate: zero-everything (and nil) are
 // unpriced; any single non-zero cost field — token, cache, or media — counts as
 // priced, so media entries (per-image / per-second only) are never mistaken for

--- a/backend/internal/service/pricing_tk_base_tax_test.go
+++ b/backend/internal/service/pricing_tk_base_tax_test.go
@@ -90,6 +90,9 @@ func TestPricingService_GetModelPricing_AppliesBaseTaxOnLookup(t *testing.T) {
 
 	glm := svc.GetModelPricing("glm-5.2")
 	require.NotNil(t, glm)
-	assert.InDelta(t, 3e-6*tkOfficialListBaseTaxMultiplier, glm.InputCostPerToken, 1e-15)
-	assert.InDelta(t, 4e-6*tkOfficialListBaseTaxMultiplier, glm.OutputCostPerToken, 1e-15)
+	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(8)*tkOfficialListBaseTaxMultiplier, glm.InputCostPerToken, 1e-15,
+		"manifest-listed GLM uses BigModel overlay, not litellm mirror")
+	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(28)*tkOfficialListBaseTaxMultiplier, glm.OutputCostPerToken, 1e-15)
+	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(8), data["glm-5.2"].InputCostPerToken, 1e-15,
+		"parsePricingData overlay replaces litellm glm row with BigModel pre-tax rate")
 }

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -130,6 +130,7 @@
       "must_contain": [
         "TestPublicCatalog_FiltersUnservableClaudeAndGpt",
         "TestIsPublicCatalogModelSupported",
+        "TestPricingCatalogService_GLMLitellmMirrorOverriddenByBigModelOverlay",
         "withdrawn VolcEngine GLM SKU pruned from storefront",
         "TestSupportedCatalogModelIDsForPlatform_Antigravity",
         "TestSupportedCatalogModelIDsForPlatform_Grok"
@@ -137,9 +138,19 @@
       "rationale": "Regression coverage for the public-catalog support filter: asserts retired/unservable claude+gpt rows are pruned, servable ones kept, Antigravity exposes only its live served+priced set (including the #1265 Claude subset while excluding gpt-oss/dead/unpriced rows), curated newapi display=false rows are hidden, and unknown/unmapped vendors stay hidden until a universal mapping exists. Pinned so an upstream merge that rewrites the catalog test file cannot silently drop the filter's regression guard. (This file also matches the *_tk_*.go hotspot via its _tk_test.go suffix, so the registry-update gate requires it to be tracked in a sentinel registry; pricing-availability is its correct domain.)"
     },
     {
+      "path": "backend/internal/service/pricing_tk_base_tax_test.go",
+      "must_contain": [
+        "TestPricingService_GetModelPricing_AppliesBaseTaxOnLookup",
+        "tkCNYPerMTokToUSDPerToken(8)",
+        "manifest-listed GLM uses BigModel overlay"
+      ],
+      "rationale": "Pins billing/catalog base-tax lookup regression for CN-origin providers, including the GLM authoritative-overlay path: GetModelPricing must apply zhipu 1.06 tax on the BigModel-sourced overlay rate even when litellm mirror carries a different non-zero glm-5.2 row."
+    },
+    {
       "path": "backend/internal/service/pricing_catalog_tk.go",
       "must_contain": [
         "func applyCatalogOverlayPricing",
+        "tkOverlayOverridesLitellmSource",
         "applyCatalogOverlayPricing(resp)",
         "func (s *PricingCatalogService) InvalidateCache"
       ],
@@ -216,6 +227,8 @@
       "path": "backend/internal/service/pricing_service_tk_overlay.go",
       "must_contain": [
         "func parseTKOverlayBytes",
+        "func tkOverlayOverridesLitellmSource",
+        "func applyTKPricingOverlay",
         "func rebuildTKOverlayUnion",
         "tkOverlayMu",
         "tkOverlayEffective"


### PR DESCRIPTION
## 摘要

- 根因：生产 `model_pricing.json`（LiteLLM 镜像）里 `glm-5.2` 仍是非零占位价（约 $1.4/$4.4 per Mtok），fill-only overlay 不会覆盖，导致 `/pricing` 与计费偏离 BigModel 官方 ¥8/¥28（6.7 汇率 + 1.06 税）。
- 修复：对 manifest 已上架的 `zhipu`/`glm-*` 模型，TK overlay（BigModel 官方价）优先于 LiteLLM 镜像；计费与公开价目表路径同步。
- 发版后 `glm-5.2` 预期展示：输入 **$0.001266/1K**、输出 **$0.004430/1K**（当前线上为 $0.001484 / $0.004664）。

## 风险

- 常规风险：仅影响 GLM 系列在 LiteLLM 镜像已有非零价时的解析优先级；其他厂商 fill-only 语义不变。
- 计费价将下调至 BigModel 换算价（与 #1298 意图一致）。

## 验证

```bash
cd backend && go test -tags=unit -run 'TestPricingCatalogService_GLMLitellmMirrorOverriddenByBigModelOverlay|TestApplyTKPricingOverlay_GLMAuthoritativeOverLitellm|TestPricingService_GetModelPricing_AppliesBaseTaxOnLookup' ./internal/service/ -count=1
./scripts/preflight.sh
python3 ./scripts/sentinels/check-registry-update-gate.py --base origin/main --head HEAD
```

- 上述测试、preflight、sentinel registry gate 均已通过。

## 提交

- `950e96872` fix(pricing): GLM overlay 覆盖 LiteLLM 镜像漂移价
- `9d6efb1c6` fix(pricing): 修复 GLM overlay CI 回归与 sentinel 锚点

最新提交：`9d6efb1c6`