### PR TITLE
fix(openai): enable gpt-5.6 Codex OAuth

### DIFF
--- a/backend/internal/service/account_model_mapping_reconciler_test.go
+++ b/backend/internal/service/account_model_mapping_reconciler_test.go
@@ -92,7 +92,7 @@ func TestAccountModelMappingForAccount_NativePlatformsExplicit(t *testing.T) {
 		deny     string
 	}{
 		{PlatformAnthropic, "claude-sonnet-4-6", "claude-sonnet-4-5-20250929"},
-		{PlatformOpenAI, "gpt-5.4", "gpt-5.6-sol"},
+		{PlatformOpenAI, "gpt-5.4", "gpt-not-a-real-id-zzz"},
 		{PlatformGemini, "gemini-2.5-flash", "gemini-2.0-flash"},
 	}
 	for _, tc := range cases {

--- a/backend/internal/service/account_model_mapping_ssot_tk_test.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk_test.go
@@ -76,7 +76,7 @@ func TestOpenAICanonicalFloorAcceptsKnownRoutingAliases(t *testing.T) {
 	require.True(t, account.IsModelSupported("gpt-5.3-codex-spark"), "spark itself remains served")
 	require.True(t, account.IsModelSupported("gpt-5.3-codex"), "legacy codex id should alias to spark without display")
 	require.True(t, account.IsModelSupported("gpt-5-codex"), "legacy GPT-5 Codex id should alias to spark without display")
-	require.False(t, account.IsModelSupported("gpt-5.6"), "unsupported upstream-rejected family must stay out of the floor")
+	require.False(t, account.IsModelSupported("gpt-not-a-real-id-zzz"), "unknown OpenAI ids must stay out of the floor")
 }
 
 func TestAccountModelMappingFloorForOps_ExportsAinzyRelayScope(t *testing.T) {

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -105,13 +105,12 @@ type antigravityUsageCache struct {
 }
 
 const (
-	apiCacheTTL             = 3 * time.Minute
-	apiErrorCacheTTL        = 1 * time.Minute        // 负缓存 TTL：429 等错误缓存 1 分钟
-	antigravityErrorTTL     = 1 * time.Minute        // Antigravity 错误缓存 TTL（可恢复错误）
-	apiQueryMaxJitter       = 800 * time.Millisecond // 用量查询最大随机延迟
-	windowStatsCacheTTL     = 1 * time.Minute
-	openAIProbeCacheTTL     = 10 * time.Minute
-	openAICodexProbeVersion = "0.143.0"
+	apiCacheTTL         = 3 * time.Minute
+	apiErrorCacheTTL    = 1 * time.Minute        // 负缓存 TTL：429 等错误缓存 1 分钟
+	antigravityErrorTTL = 1 * time.Minute        // Antigravity 错误缓存 TTL（可恢复错误）
+	apiQueryMaxJitter   = 800 * time.Millisecond // 用量查询最大随机延迟
+	windowStatsCacheTTL = 1 * time.Minute
+	openAIProbeCacheTTL = 10 * time.Minute
 )
 
 // UsageCache 封装账户使用量相关的缓存

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -47,7 +47,6 @@ const (
 	openAIWSRetryBackoffMaxDefault     = 2 * time.Second
 	openAIWSRetryJitterRatioDefault    = 0.2
 	openAICompactSessionSeedKey        = "openai_compact_session_seed"
-	codexCLIVersion                    = "0.143.0"
 	// Codex 限额快照仅用于后台展示/诊断，不需要每个成功请求都立即落库。
 	openAICodexSnapshotPersistMinInterval = 30 * time.Second
 	// 配额自动暂停时，超过该时长仍未刷新的 used% 快照视为陈旧，不再据此暂停账号。

--- a/backend/internal/service/pricing_catalog_candidates_tk_test.go
+++ b/backend/internal/service/pricing_catalog_candidates_tk_test.go
@@ -31,7 +31,7 @@ func tkBuildPricedServiceForTest(t *testing.T, ids []string) *PricingCatalogServ
 // invariant for the gateway /v1/models fallback source: every advertised id is
 // (a) within the platform servable allowlist (the /pricing candidate gate) AND
 // (b) priced (billable) — visible ⟹ priced ∧ candidate. Negative pin:
-// priced-but-not-allowlisted ids (advertised_dead like gpt-5.6-sol / gpt-image-1)
+// priced-but-not-allowlisted ids (advertised_dead like gpt-image-1)
 // never appear, even when priced.
 func TestServableClientFacingIDs_InvariantAndAdvertisedDead(t *testing.T) {
 	ctx := context.Background()
@@ -41,7 +41,7 @@ func TestServableClientFacingIDs_InvariantAndAdvertisedDead(t *testing.T) {
 	for _, id := range allow {
 		allowSet[id] = true
 	}
-	dead := []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-image-1", "gpt-image-1.5", "gpt-image-2"}
+	dead := []string{"gpt-image-1", "gpt-image-1.5", "gpt-image-2"}
 	for _, d := range dead {
 		require.False(t, allowSet[d], "precondition: %s must be advertised_dead (priced but NOT in allowlist)", d)
 	}

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -28,15 +28,15 @@ import (
 //     deprecated-gate 400s, upstream-rejected 502s, and dated snapshots whose
 //     non-dated form also serves.
 //   - openai: 2026-07-10 SSOT audit probes (prod OAuth accounts + account 76
-//     Ainzy relay checks). Native ChatGPT-OAuth servable set is exactly the
-//     curated floor in ops/pricing/examples/openai-oauth-proven.json (4 models).
-//     Compatibility GPT-5 spellings such as gpt-5.4-high, codex-mini-latest, and
-//     gpt-5-chat-latest remain priced for billing but are hidden from /pricing
-//     and /models; clients may still request them and are routed through
-//     CanonicalizeOpenAICompatRoutingModel to a served floor id. Retired /
-//     never-selectable ids such as gpt-5.2 and codex-auto-review take the
-//     deprecated-model 400 path instead; non-display aliases such as
-//     gpt-5.3-codex route to their canonical supported target.
+//     Ainzy relay checks). Native ChatGPT-OAuth servable set is the curated
+//     floor in ops/pricing/examples/openai-oauth-proven.json plus the
+//     GPT-pro1-verified GPT-5.6 family. Compatibility GPT-5 spellings such as
+//     gpt-5.4-high, codex-mini-latest, and gpt-5-chat-latest remain priced for
+//     billing but hidden from /pricing and /models; clients may still request
+//     them and are routed through CanonicalizeOpenAICompatRoutingModel to a
+//     served floor id. Retired / never-selectable ids such as gpt-5.2 and
+//     codex-auto-review take the deprecated-model 400 path instead; non-display
+//     aliases such as gpt-5.3-codex route to their canonical supported target.
 //     codex-auto-review is deliberately EXCLUDED from both sets even though it
 //     returns a live 200: it is an internal ChatGPT-Codex capability, not a
 //     directly-selectable model, so it is routed through the hard-rejection gate
@@ -124,6 +124,10 @@ var supportedOpenAICatalogModels = map[string]struct{}{
 	"gpt-5.4":             {},
 	"gpt-5.4-mini":        {},
 	"gpt-5.5":             {},
+	"gpt-5.6":             {},
+	"gpt-5.6-luna":        {},
+	"gpt-5.6-sol":         {},
+	"gpt-5.6-terra":       {},
 	// servable-allowlist:end openai
 }
 

--- a/backend/internal/service/setting_gateway_runtime.go
+++ b/backend/internal/service/setting_gateway_runtime.go
@@ -85,8 +85,18 @@ const antigravityUserAgentVersionCacheTTL = 60 * time.Second
 const antigravityUserAgentVersionErrorTTL = 5 * time.Second
 const antigravityUserAgentVersionDBTimeout = 5 * time.Second
 
+// DefaultOpenAICodexVersion is the single source for the forged Codex client
+// version: UA, gateway version header, and usage probe header must all derive
+// from it.
+const DefaultOpenAICodexVersion = "0.144.1"
+
 // DefaultOpenAICodexUserAgent OpenAI Codex 默认 User-Agent。
-const DefaultOpenAICodexUserAgent = "codex-tui/0.143.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.143.0)"
+const DefaultOpenAICodexUserAgent = "codex-tui/" + DefaultOpenAICodexVersion + " (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; " + DefaultOpenAICodexVersion + ")"
+
+const (
+	codexCLIVersion         = DefaultOpenAICodexVersion
+	openAICodexProbeVersion = DefaultOpenAICodexVersion
+)
 
 // cachedOpenAICodexUserAgent 缓存 OpenAI Codex UA（进程内缓存，60s TTL）
 type cachedOpenAICodexUserAgent struct {

--- a/ops/openai/capture_codex_fingerprint.py
+++ b/ops/openai/capture_codex_fingerprint.py
@@ -47,8 +47,6 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SETTING_GO = REPO_ROOT / "backend/internal/service/setting_gateway_runtime.go"
 GATEWAY_GO = REPO_ROOT / "backend/internal/service/openai_gateway_service.go"
 USAGE_GO = REPO_ROOT / "backend/internal/service/account_usage_service.go"
-EN_TS = REPO_ROOT / "frontend/src/i18n/locales/en/admin/settings.ts"
-ZH_TS = REPO_ROOT / "frontend/src/i18n/locales/zh/admin/settings.ts"
 NON_VERSION_PIN_GO_FILES = (
     REPO_ROOT / "backend/internal/service/openai_gateway_scheduling.go",
     REPO_ROOT / "backend/internal/service/openai_gateway_forward.go",
@@ -72,7 +70,7 @@ class Pin:
 
     key: str
     path: Path
-    kind: str  # "bare" (value IS the version) | "ua" (version embedded in a UA literal)
+    kind: str  # "bare" (value IS the version) | "ua" (version embedded) | "alias" (derives from source)
     raw: str = ""  # the full literal as found (UA string, or bare version)
     version: str = ""  # the extracted codex version
     consistent_internal: bool = True  # UA prefix/suffix versions agree
@@ -157,6 +155,15 @@ def _find1(text: str, pattern: str) -> str:
     return m.group(1) if m else ""
 
 
+def _alias_pin(key: str, path: Path, symbol: str, text: str, source_version: str) -> Pin:
+    literal = _find1(text, rf'{symbol}\s*=\s*"([^"]+)"')
+    if literal:
+        return Pin(key, path, "bare", raw=literal, version=literal, found=True)
+    if re.search(rf"{symbol}\s*=\s*DefaultOpenAICodexVersion\b", text):
+        return Pin(key, path, "alias", raw="DefaultOpenAICodexVersion", version=source_version, found=bool(source_version))
+    return Pin(key, path, "alias", found=False)
+
+
 # --------------------------------------------------------------------------- #
 # baseline (read the live repo pins)
 # --------------------------------------------------------------------------- #
@@ -164,27 +171,24 @@ def load_baseline() -> Baseline:
     bl = Baseline()
 
     setting_txt = _read(SETTING_GO)
-    ua = _find1(setting_txt, r'DefaultOpenAICodexUserAgent\s*=\s*"([^"]+)"')
-    p = Pin("ua_default", SETTING_GO, "ua", raw=ua, found=bool(ua))
-    if ua:
-        p.version, p.consistent_internal = extract_ua_version(ua)
-    bl.pins.append(p)
+    source_version = _find1(setting_txt, r'DefaultOpenAICodexVersion\s*=\s*"([^"]+)"')
+    bl.pins.append(Pin("version_source", SETTING_GO, "bare", raw=source_version, version=source_version, found=bool(source_version)))
 
-    gateway_txt = _read(GATEWAY_GO)
-    gv = _find1(gateway_txt, r'codexCLIVersion\s*=\s*"([^"]+)"')
-    bl.pins.append(Pin("gateway_version", GATEWAY_GO, "bare", raw=gv, version=gv, found=bool(gv)))
+    ua_expr = _find1(setting_txt, r"DefaultOpenAICodexUserAgent\s*=\s*([^\n]+)")
+    ua_uses_source = ua_expr.count("DefaultOpenAICodexVersion") >= 2
+    bl.pins.append(Pin(
+        "ua_default",
+        SETTING_GO,
+        "alias",
+        raw=ua_expr,
+        version=source_version if ua_uses_source else "",
+        found=bool(ua_expr),
+        consistent_internal=ua_uses_source,
+    ))
 
-    usage_txt = _read(USAGE_GO)
-    pv = _find1(usage_txt, r'openAICodexProbeVersion\s*=\s*"([^"]+)"')
-    bl.pins.append(Pin("probe_version", USAGE_GO, "bare", raw=pv, version=pv, found=bool(pv)))
-
-    for key, path in (("placeholder_en", EN_TS), ("placeholder_zh", ZH_TS)):
-        txt = _read(path)
-        ua_ph = _find1(txt, r"openaiCodexUserAgentPlaceholder:\s*'([^']+)'")
-        pp = Pin(key, path, "ua", raw=ua_ph, found=bool(ua_ph))
-        if ua_ph:
-            pp.version, pp.consistent_internal = extract_ua_version(ua_ph)
-        bl.pins.append(pp)
+    service_txt = "\n".join((setting_txt, _read(GATEWAY_GO), _read(USAGE_GO)))
+    bl.pins.append(_alias_pin("gateway_version", SETTING_GO, "codexCLIVersion", service_txt, source_version))
+    bl.pins.append(_alias_pin("probe_version", SETTING_GO, "openAICodexProbeVersion", service_txt, source_version))
 
     # Non-version pins (sanity, not bumped). These live in thin companion files
     # after the upstream merge split the gateway hot path.
@@ -258,9 +262,9 @@ def diff_pins(bl: Baseline, installed: str) -> list[Row]:
             rows.append(Row(p.key, "", installed, "missing", critical=True,
                             note=f"could not read pin in {p.rel}"))
             continue
-        if p.kind == "ua" and not p.consistent_internal:
+        if not p.consistent_internal:
             rows.append(Row(p.key, p.version, installed, "mismatch", critical=True,
-                            note="UA prefix/suffix versions disagree (half-done edit)"))
+                            note="version derivation is incomplete (half-done edit)"))
             continue
         if not installed:
             rows.append(Row(p.key, p.version, "", "info", note="codex CLI not installed"))
@@ -283,9 +287,9 @@ def consistency_rows(bl: Baseline) -> list[Row]:
             rows.append(Row(p.key, "", consensus, "missing", critical=True,
                             note=f"could not read pin in {p.rel}"))
             continue
-        if p.kind == "ua" and not p.consistent_internal:
+        if not p.consistent_internal:
             rows.append(Row(p.key, p.version, consensus, "mismatch", critical=True,
-                            note="UA prefix/suffix versions disagree"))
+                            note="version derivation is incomplete"))
             continue
         status = "match" if consensus and p.version == consensus else "mismatch"
         rows.append(Row(p.key, p.version, consensus, status, critical=(status != "match")))
@@ -296,6 +300,8 @@ def emit_edits(bl: Baseline, new_version: str) -> list[dict]:
     edits = []
     for p in bl.pins:
         if not p.found or p.version == new_version and p.consistent_internal:
+            continue
+        if p.kind == "alias":
             continue
         if p.kind == "bare":
             edits.append({"file": p.rel, "old": p.raw, "new": new_version})
@@ -417,9 +423,9 @@ def cmd_check_consistency(_args) -> int:
         print("Codex version pins are NOT mutually consistent:", file=sys.stderr)
         _print_rows(rows, sys.stderr)
         consensus = bl.consensus()
-        print("\nAll five pins must carry the SAME codex version. Re-run a full bump "
-              "(ops/openai/capture-codex-fingerprint.sh emit-edits) so the UA default, "
-              "gateway version, probe version, and en/zh placeholders agree.", file=sys.stderr)
+        print("\nThe service Codex pins must derive from DefaultOpenAICodexVersion. "
+              "Re-run a full bump (ops/openai/capture-codex-fingerprint.sh emit-edits) "
+              "so the version source, UA default, gateway version, and probe version agree.", file=sys.stderr)
         return 1
     print(f"codex version pins consistent: all = {bl.consensus()}")
     return 0

--- a/ops/openai/test_capture_codex_fingerprint.py
+++ b/ops/openai/test_capture_codex_fingerprint.py
@@ -21,11 +21,10 @@ UA_TMPL = "codex-tui/{v} (Mac OS 26.3.1; arm64) iTerm.app/3.6.11 (codex-tui; {v}
 
 
 _PATHS = {
+    "version_source": eng.SETTING_GO,
     "ua_default": eng.SETTING_GO,
-    "gateway_version": eng.GATEWAY_GO,
-    "probe_version": eng.USAGE_GO,
-    "placeholder_en": eng.EN_TS,
-    "placeholder_zh": eng.ZH_TS,
+    "gateway_version": eng.SETTING_GO,
+    "probe_version": eng.SETTING_GO,
 }
 
 
@@ -35,22 +34,20 @@ def _pin(key, kind, version, raw, consistent=True, found=True):
 
 
 def _baseline(versions):
-    """Synthesise a Baseline with the 5 pins set to the given versions dict."""
+    """Synthesise a Baseline with the service pins set to the given versions dict."""
     bl = eng.Baseline(originator_pinned=True, beta_pinned=True)
     bl.pins = [
-        _pin("ua_default", "ua", versions["ua_default"], UA_TMPL.format(v=versions["ua_default"])),
-        _pin("gateway_version", "bare", versions["gateway_version"], versions["gateway_version"]),
-        _pin("probe_version", "bare", versions["probe_version"], versions["probe_version"]),
-        _pin("placeholder_en", "ua", versions["placeholder_en"], UA_TMPL.format(v=versions["placeholder_en"])),
-        _pin("placeholder_zh", "ua", versions["placeholder_zh"], UA_TMPL.format(v=versions["placeholder_zh"])),
+        _pin("version_source", "bare", versions["version_source"], versions["version_source"]),
+        _pin("ua_default", "alias", versions["ua_default"], "DefaultOpenAICodexVersion"),
+        _pin("gateway_version", "alias", versions["gateway_version"], "DefaultOpenAICodexVersion"),
+        _pin("probe_version", "alias", versions["probe_version"], "DefaultOpenAICodexVersion"),
     ]
     return bl
 
 
 def _aligned(v="0.142.2"):
     return _baseline({k: v for k in
-                      ("ua_default", "gateway_version", "probe_version",
-                       "placeholder_en", "placeholder_zh")})
+                      ("version_source", "ua_default", "gateway_version", "probe_version")})
 
 
 class ParseVersionTests(unittest.TestCase):
@@ -118,8 +115,7 @@ class ConsistencyTests(unittest.TestCase):
 
     def test_no_consensus_when_one_pin_lags(self):
         bl = _aligned("0.142.2")
-        bl.pins[3].version = "0.142.0"      # en placeholder forgotten
-        bl.pins[3].raw = UA_TMPL.format(v="0.142.0")
+        bl.pins[2].version = "0.142.0"      # gateway alias/source drift
         self.assertEqual(bl.consensus(), "")
         rows = eng.consistency_rows(bl)
         self.assertTrue(any(r.status == "mismatch" for r in rows))
@@ -135,14 +131,11 @@ class EmitEditsTests(unittest.TestCase):
     def test_emits_one_edit_per_lagging_pin(self):
         bl = _aligned("0.142.2")
         edits = eng.emit_edits(bl, "0.143.0")
-        self.assertEqual(len(edits), 5)
-        # bare pin: whole value replaced
-        gw = next(e for e in edits if "openai_gateway_service.go" in e["file"])
-        self.assertEqual(gw["new"], "0.143.0")
-        # ua pin: only version tokens swapped, OS/terminal kept
-        ua = next(e for e in edits if "setting_gateway_runtime.go" in e["file"])
-        self.assertEqual(ua["new"], UA_TMPL.format(v="0.143.0"))
-        self.assertIn("iTerm.app/3.6.11", ua["new"])
+        self.assertEqual(edits, [{
+            "file": "backend/internal/service/setting_gateway_runtime.go",
+            "old": "0.142.2",
+            "new": "0.143.0",
+        }])
 
     def test_no_edits_when_already_aligned(self):
         self.assertEqual(eng.emit_edits(_aligned("0.142.2"), "0.142.2"), [])
@@ -194,8 +187,8 @@ class LiveRepoTests(unittest.TestCase):
 
     def test_live_baseline_loads_and_is_consistent(self):
         bl = eng.load_baseline()
-        # All five pins must be found...
-        self.assertEqual(len(bl.pins), 5)
+        # All service pins must be found...
+        self.assertEqual(len(bl.pins), 4)
         for p in bl.pins:
             self.assertTrue(p.found, f"{p.key} not found via regex in {p.rel}")
             self.assertRegex(p.version, r"^\d+\.\d+\.\d+")

--- a/scripts/fingerprint/client_release_watch.py
+++ b/scripts/fingerprint/client_release_watch.py
@@ -165,7 +165,7 @@ def read_pinned_claude_code() -> str:
 
 def read_pinned_codex() -> str:
     text = _read_text(SETTING_GO)
-    m = re.search(r'codex-tui/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)', text)
+    m = re.search(r'DefaultOpenAICodexVersion\s*=\s*"([^"]+)"', text)
     return normalize_version(m.group(1)) if m else ""
 
 
@@ -371,7 +371,7 @@ PLATFORM_SPECS: list[PlatformSpec] = [
         id="codex",
         name="Codex CLI",
         skill="tokenkey-codex-fingerprint-alignment",
-        pin_path="backend/internal/service/setting_gateway_runtime.go (+ 4 other pins)",
+        pin_path="backend/internal/service/setting_gateway_runtime.go DefaultOpenAICodexVersion",
         sources=[
             SourceSpec(
                 kind="npm",

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -967,15 +967,12 @@ else
 fi
 
 # ---- sub2api: codex fingerprint pin consistency -----------------------------
-# The Codex (OpenAI-platform) client version is pinned in 5 places that must
-# carry the SAME version: the UA default (setting_service.go), the gateway
-# `version` header (openai_gateway_service.go), the usage-probe `Version`
-# (account_usage_service.go), and the en/zh admin-UI placeholders. A bump that
-# updates only some of them (the en/zh placeholders were nearly forgotten in
-# PR #1013) silently desyncs the forged fingerprint. This gate proves the 5
-# pins agree AMONG THEMSELVES — it never compares to a moving upstream codex
-# release, so it cannot break CI when codex ships a new version. Real upstream
-# drift is detected on-demand by skill tokenkey-codex-fingerprint-alignment.
+# The Codex (OpenAI-platform) client version has one service source:
+# DefaultOpenAICodexVersion. The UA default, gateway `version` header, and
+# usage-probe `Version` must derive from it. This gate proves the service pins
+# agree AMONG THEMSELVES — it never compares to a moving upstream codex release,
+# so it cannot break CI when codex ships a new version. Real upstream drift is
+# detected on-demand by skill tokenkey-codex-fingerprint-alignment.
 echo ""
 echo "=== sub2api: codex fingerprint pin consistency ==="
 if ! command -v python3 >/dev/null 2>&1; then
@@ -989,7 +986,7 @@ elif ! python3 ./ops/openai/capture_codex_fingerprint.py check-consistency >/dev
     # is the success line, suppressed here); a single run surfaces it, no re-run.
     errors=$((errors + 1))
 else
-    echo "  ok: codex version pins mutually consistent across UA/gateway/probe/en/zh"
+    echo "  ok: codex service version pins derive from one source"
 fi
 
 # ---- sub2api: client release watch -------------------------------------------


### PR DESCRIPTION
## 摘要
- 在最新 `origin/main` 之上，只通过 OpenAI servable allowlist owner 放开 GPT-5.6 家族：`gpt-5.6`、`gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna`；catalog、/models、admin 默认候选和 native account mapping 继续从同一 SSOT 派生。
- 保留 `gpt-5.6` 作为 TokenKey 兼容别名，继续通过现有 wire transform 映射到 `gpt-5.6-sol`；`gpt-5.6-chat-latest` 不进 allowlist。
- 将 Codex forged client version 收敛为 `DefaultOpenAICodexVersion = 0.144.1` 单一服务源，UA、gateway `version` header、usage probe header 和 release watcher 都从它派生。
- 删除原先散落在 docs、frontend placeholder、handler 注释和重复模型清单测试里的同步式改动；测试负例改成泛化 unknown/dead ids，避免下次新增模型再改测试清单。

## 风险
- 常规风险：扩大 OpenAI OAuth 默认可见模型集合中的 GPT-5.6 家族，并更新 Codex 上游身份版本。
- 已审查 sentinel advisory 覆盖面，改动只调整既有 allowlist / version pin / 测试断言，不需要新增 sentinel anchor。sentinel-registry-reviewed
- 已审查 upstream-shaped 文件触碰：本次为 Codex 版本字面量单源化与引用迁移，且有直连上游实测支撑，不引入新的 upstream merge revert surface。upstream-touch-trivial
- Web impact: none / no-web-impact。GPT-5.6 可见面从后端 servable SSOT 派生，Codex 版本默认值是服务端 forged fingerprint；本轮刻意不改前端 placeholder / dist，避免 UI 同步噪声。

## 验证
- GPT-pro1 account #9 直连 `https://chatgpt.com/backend-api/codex/responses`：`gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna` + Codex `0.144.1` 均 200；裸 `gpt-5.6` 直连上游仍 400，确认 TokenKey 必须 alias 到 Sol。
- UA 对比实测：`gpt-5.6-sol` + Codex `0.143.0` 返回 requires newer Codex；`0.144.1` 返回 200。
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS；`ssot-delta-gate` 结构检查通过，新增 `gpt-5.6` / `gpt-5.6-luna` / `gpt-5.6-sol` / `gpt-5.6-terra` 标记为 post-deploy live proof。
- `go test -tags unit ./internal/service -run 'TestServableClientFacingIDs|Test(IsPublicCatalogModelSupported|FilterPublicCatalog|SupportedCatalogModelIDsForPlatform|OpenAICanonicalFloor|AccountModelMappingFloorForOps|AccountModelMappingForAccount_NativePlatformsExplicit)'`
- `go test ./internal/handler ./internal/handler/admin -run 'TestTkOpenAIDefaultModelIDs|TestGatewayModels_UniversalKeyList|TestAccountHandlerGetAvailableModels_OpenAI'`
- `python3 scripts/checks/ssot-delta-gate.py check --base origin/main --skip-live`
- `python3 ops/openai/test_capture_codex_fingerprint.py`
- `bash ops/openai/capture-codex-fingerprint.sh check-consistency`
- `python3 scripts/fingerprint/client_release_watch.py --selftest --quiet`

## 提交
- `bd8a9bf7d fix(openai): enable gpt-5.6 codex oauth`
- 最新提交：`bd8a9bf7d`

