### PR TITLE
fix(ci): catch golangci-lint debt before merge

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -243,14 +243,15 @@ jobs:
         run: |
           expected=$(awk '/^go /{print $2; exit}' backend/go.mod)
           go version | grep -Fq "go${expected}"
-      # PR: only-new-issues (GitHub API diff). Push/workflow_dispatch: full ./... lint on backend.
+      # Full lint on PR and push. `only-new-issues` masked base/main lint debt:
+      # PRs stayed green while push-to-main full lint failed after merge.
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9
           args: --concurrency=4 --timeout=30m
           working-directory: backend
-          only-new-issues: ${{ github.event_name == 'pull_request' }}
+          only-new-issues: false
 
   backend-security:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 1') || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'security'))

--- a/backend/internal/service/gateway_request_tk_deprecated_sampling.go
+++ b/backend/internal/service/gateway_request_tk_deprecated_sampling.go
@@ -81,6 +81,8 @@ func tkClaudeFamilyVersionAtLeast(modelID, family string, minMajor, minMinor int
 // Anthropic models that now reject them, and removes top_p for current Claude
 // models that reject temperature+top_p in the same request. Nested JSON-schema
 // properties with the same names must remain intact.
+//
+//nolint:unused // sentinel/test wrapper; production paths use the account-aware variant below.
 func tkStripDeprecatedSamplingParams(body []byte) []byte {
 	return tkStripDeprecatedSamplingParamsForAccount(nil, body)
 }


### PR DESCRIPTION
摘要
- 修复 #1320 合并后 main CI 的 `golangci-lint` 失败：`tkStripDeprecatedSamplingParams` 是 gateway TK sentinel 固定锚点和测试 wrapper，生产路径使用 account-aware 变体，因此给 wrapper 加 `nolint:unused` 并说明原因。
- 深挖后确认根因是 CI 差异：PR 上 `golangci-lint` 使用 `only-new-issues`，会隐藏 base/main 已有 lint debt；main push 使用 full lint，所以红灯延迟到合并后才暴露。
- 将 PR 阶段的 `golangci-lint` 改为 full lint（`only-new-issues: false`），让这类问题在 PR 合并前阻断，而不是合并后再开补救 PR。

风险
- PR lint 会比以前更严格：如果 main/base 已有 lint debt，后续 PR 会被拦住，必须先修 main 红灯。这是有意收紧，避免红灯继续传染到 merge 后。
- service 侧仅增加 lint 抑制说明，不改变运行时代码路径或请求改写行为。
- Web impact: none；无前端、公共契约变更。

验证
- `go test -tags unit ./internal/service -run 'TestTkStripDeprecatedSamplingParams|TestTkModelDeprecatesSamplingParams|TestForwardAsChatCompletions_AnthropicOpus47StripsDeprecatedSamplingParams|TestApplyClaudeCodeOAuthMimicry_AnthropicOpus47StripsDeprecatedSamplingParams'`（在 `backend/` 下）
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run --path-mode=abs --concurrency=4 --timeout=30m`（在 `backend/` 下，结果 `0 issues.`）
- `git diff --check`
- `./scripts/preflight.sh`

提交
- 43c3c9717 ci: run full golangci-lint on PRs no-web-impact
- f78f8e9a2 fix(service): keep sampling strip sentinel lint-clean no-web-impact
- 最新提交：43c3c9717