### PR TITLE
test(ssot): derive model catalog assertions from source of truth

### DIFF
--- a/backend/internal/handler/admin/account_handler_available_models_test.go
+++ b/backend/internal/handler/admin/account_handler_available_models_test.go
@@ -47,6 +47,16 @@ func modelIDSet(models []struct {
 	return ids
 }
 
+func availableModelIDs(models []struct {
+	ID string `json:"id"`
+}) []string {
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		ids = append(ids, m.ID)
+	}
+	return ids
+}
+
 type syncUpstreamHTTPUpstream struct {
 	resp *http.Response
 	err  error
@@ -222,19 +232,10 @@ func TestAccountHandlerGetAvailableModels_OpenAIOAuthPassthroughFallsBackToDefau
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.NotEmpty(t, resp.Data)
-	ids := modelIDSet(resp.Data)
-	for _, want := range []string{"gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5"} {
-		require.True(t, ids[want], "servable OpenAI probe result %s should appear in OpenAI admin defaults", want)
-	}
-	for _, hidden := range []string{
-		"gpt-5", "gpt-5-chat", "gpt-5-chat-latest", "gpt-5-mini", "gpt-5-nano",
-		"gpt-5-pro", "gpt-5-search-api", "gpt-5.1", "gpt-5.1-chat-latest",
-		"gpt-5-codex", "gpt-5.2", "gpt-5.2-pro", "gpt-5.3", "gpt-5.3-codex", "gpt-5.4-pro",
-		"gpt-5.6-sol", "gpt-5.6-terra", "gpt-image-1", "gpt-image-1.5", "gpt-image-2",
-		"codex-auto-review",
-	} {
-		require.False(t, ids[hidden], "non-live-proven OpenAI model %s must not appear in OpenAI admin defaults", hidden)
-	}
+	require.ElementsMatch(t,
+		service.ServableClientFacingIDs(context.Background(), service.PlatformOpenAI, nil, nil),
+		availableModelIDs(resp.Data),
+		"OpenAI admin defaults must mirror the unified servable SSOT")
 }
 
 func TestAccountHandlerGetAvailableModels_OpenAINoMappingDropsAdvertisedDead(t *testing.T) {
@@ -263,19 +264,10 @@ func TestAccountHandlerGetAvailableModels_OpenAINoMappingDropsAdvertisedDead(t *
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.NotEmpty(t, resp.Data)
-	ids := modelIDSet(resp.Data)
-	for _, want := range []string{"gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5"} {
-		require.True(t, ids[want], "servable OpenAI probe result %s should appear in OpenAI admin defaults", want)
-	}
-	for _, hidden := range []string{
-		"gpt-5", "gpt-5-chat", "gpt-5-chat-latest", "gpt-5-mini", "gpt-5-nano",
-		"gpt-5-pro", "gpt-5-search-api", "gpt-5.1", "gpt-5.1-chat-latest",
-		"gpt-5-codex", "gpt-5.2", "gpt-5.2-pro", "gpt-5.3", "gpt-5.3-codex", "gpt-5.4-pro",
-		"gpt-5.6-sol", "gpt-5.6-terra", "gpt-image-1", "gpt-image-1.5", "gpt-image-2",
-		"codex-auto-review",
-	} {
-		require.False(t, ids[hidden], "non-live-proven OpenAI model %s must not appear in OpenAI admin defaults", hidden)
-	}
+	require.ElementsMatch(t,
+		service.ServableClientFacingIDs(context.Background(), service.PlatformOpenAI, nil, nil),
+		availableModelIDs(resp.Data),
+		"OpenAI admin defaults must mirror the unified servable SSOT")
 }
 
 func TestAccountHandlerGetAvailableModels_GeminiOAuthDropsAdvertisedDead(t *testing.T) {

--- a/backend/internal/handler/gateway_handler_tk_model_list_test.go
+++ b/backend/internal/handler/gateway_handler_tk_model_list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/gemini"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
@@ -138,20 +139,10 @@ func TestTkAntigravityDefaultModels_PricedServableSetIncludesReprobedGeminiIDs(t
 		ids[m.ID] = true
 		require.Equal(t, "model", m.Type, "all returned models must keep the Claude model-list shape")
 	}
-	for _, want := range []string{
-		"gemini-2.5-flash",
-		"gemini-2.5-flash-lite",
-		"gemini-2.5-flash-thinking",
-		"gemini-3-flash",
-		"gemini-3-flash-agent",
-		"gemini-3.1-flash-image", // served via antigravity pool (2026-06-27 image probe 200)
-		"gemini-3.1-pro-low",
-		"gemini-3.5-flash-extra-low",
-		"gemini-3.5-flash-low",
-		"gemini-pro-agent",
-	} {
-		require.True(t, ids[want], "%s should be visible in /antigravity/models after pricing closure", want)
-	}
+	require.ElementsMatch(t,
+		service.ServableClientFacingIDs(context.Background(), service.PlatformAntigravity, nil, pricingSvc),
+		modelIDsFromAntigravityModels(result),
+		"/antigravity/models must mirror the unified priced+servable SSOT")
 	for _, deny := range []string{"gemini-2.5-pro", "claude-fable-5", "gpt-oss-120b-medium"} {
 		require.False(t, ids[deny], "%s must not leak into /antigravity/models", deny)
 	}
@@ -162,22 +153,10 @@ func TestTkOpenAIDefaultModelIDs_DropsAdvertisedDead(t *testing.T) {
 	result := h.tkOpenAIDefaultModelIDs(context.Background(), service.PlatformOpenAI)
 	require.NotEmpty(t, result)
 
-	ids := make(map[string]bool, len(result))
-	for _, m := range result {
-		ids[m.ID] = true
-	}
-	for _, want := range []string{"gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5"} {
-		require.True(t, ids[want], "servable OpenAI probe result %s should remain visible", want)
-	}
-	for _, hidden := range []string{
-		"gpt-5", "gpt-5-chat", "gpt-5-chat-latest", "gpt-5-mini", "gpt-5-nano",
-		"gpt-5-pro", "gpt-5-search-api", "gpt-5.1", "gpt-5.1-chat-latest",
-		"gpt-5-codex", "gpt-5.2", "gpt-5.2-pro", "gpt-5.3", "gpt-5.3-codex", "gpt-5.4-pro",
-		"gpt-5.6-sol", "gpt-5.6-terra", "gpt-image-1", "gpt-image-1.5", "gpt-image-2",
-		"codex-auto-review", // internal capability, never client-selectable (deprecated-model gate)
-	} {
-		require.False(t, ids[hidden], "non-live-proven OpenAI model %s must not reach /v1/models fallback", hidden)
-	}
+	require.ElementsMatch(t,
+		service.ServableClientFacingIDs(context.Background(), service.PlatformOpenAI, nil, nil),
+		modelIDsFromOpenAIModels(result),
+		"OpenAI default model list must mirror the unified servable SSOT")
 }
 
 // --- tkGeminiFallbackModelsList ---
@@ -250,6 +229,22 @@ func buildPricingJSON(models []antigravity.ClaudeModel) string {
 		ids[i] = m.ID
 	}
 	return buildPricingJSONFromIDs(ids)
+}
+
+func modelIDsFromAntigravityModels(models []antigravity.ClaudeModel) []string {
+	ids := make([]string, len(models))
+	for i, m := range models {
+		ids[i] = m.ID
+	}
+	return ids
+}
+
+func modelIDsFromOpenAIModels(models []openai.Model) []string {
+	ids := make([]string, len(models))
+	for i, m := range models {
+		ids[i] = m.ID
+	}
+	return ids
 }
 
 // buildPricingJSONFromIDs builds a pricing JSON where each provided model ID

--- a/backend/internal/handler/gateway_models_test.go
+++ b/backend/internal/handler/gateway_models_test.go
@@ -158,14 +158,10 @@ func TestGatewayModels_UniversalKeyListsEntitledGroupUnion(t *testing.T) {
 	var got gatewayModelsResponseForTest
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	ids := modelIDsForTest(got.Data)
-	require.Contains(t, ids, "gpt-5.4", "universal OpenAI group fallback must use OpenAI SSOT")
-	require.Contains(t, ids, "gpt-5.3-codex-spark", "universal OpenAI group fallback must include SSOT delta-gate 200 model")
-	require.Contains(t, ids, "gpt-5.4-mini", "universal OpenAI group fallback must include current OpenAI SSOT")
-	require.Contains(t, ids, "gemini-2.5-flash", "universal Gemini group fallback must use Gemini SSOT")
-	require.NotContains(t, ids, "gpt-5-pro", "SSOT delta-gate 403 model must not leak into universal list")
-	require.NotContains(t, ids, "gpt-5.2", "legacy OpenAI pricing-only model must not leak into universal list")
-	require.NotContains(t, ids, "gpt-5.6-sol", "non-allowlisted OpenAI model must not leak into universal list")
-	require.NotContains(t, ids, "leaked-global-model", "universal list must not scan the global schedulable pool")
+	require.ElementsMatch(t, gatewayModelsSSOTUnionForTest(
+		service.ServableClientFacingIDs(context.Background(), service.PlatformOpenAI, nil, nil),
+		service.ServableClientFacingIDs(context.Background(), service.PlatformGemini, nil, nil),
+	), ids, "universal list must be exactly the entitled OpenAI+Gemini SSOT union and must not scan the global schedulable pool")
 }
 
 func TestGatewayModels_GeminiGroupFallsBackToGeminiModels(t *testing.T) {
@@ -661,4 +657,18 @@ func modelIDsForTest(models []gatewayModelItemForTest) []string {
 		ids = append(ids, model.ID)
 	}
 	return ids
+}
+
+func gatewayModelsSSOTUnionForTest(groups ...[]string) []string {
+	seen := make(map[string]struct{})
+	for _, group := range groups {
+		for _, id := range group {
+			seen[id] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for id := range seen {
+		out = append(out, id)
+	}
+	return out
 }

--- a/backend/internal/service/account_model_mapping_ssot_tk_test.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk_test.go
@@ -45,41 +45,13 @@ func TestAccount_IsOpenAIAinzyRelay(t *testing.T) {
 func TestOpenAIAinzyRelayFloorIsProbeCuratedOnly(t *testing.T) {
 	t.Parallel()
 	mapping := openAIAinzyRelayAccountModelMappingFloor(context.Background(), nil, nil)
-	require.Len(t, mapping, 4)
-	for _, model := range []string{
-		"gpt-5.3-codex-spark",
-		"gpt-5.4",
-		"gpt-5.4-mini",
-		"gpt-5.5",
-	} {
-		require.Contains(t, mapping, model)
-	}
-	require.NotContains(t, mapping, "codex-auto-review")
-	require.NotContains(t, mapping, "gpt-5-pro")
-	require.NotContains(t, mapping, "gpt-5-codex")
-	require.NotContains(t, mapping, "gpt-5.3-codex")
+	requireIdentityMappingForIDs(t, mapping, supportedCatalogModelIDsFromMap(supportedOpenAIAinzyRelayCatalogModels))
 }
 
 func TestOpenAICanonicalFloorUsesServableOpenAIAllowlist(t *testing.T) {
 	t.Parallel()
 	mapping := openAICanonicalAccountModelMappingFloor(context.Background(), nil, nil)
-	require.Len(t, mapping, 4)
-	for _, model := range []string{
-		"gpt-5.3-codex-spark",
-		"gpt-5.4",
-		"gpt-5.4-mini",
-		"gpt-5.5",
-	} {
-		require.Contains(t, mapping, model)
-	}
-	require.NotContains(t, mapping, "codex-auto-review")
-	require.NotContains(t, mapping, "gpt-5")
-	require.NotContains(t, mapping, "gpt-5-pro")
-	require.NotContains(t, mapping, "gpt-5.5-pro")
-	require.NotContains(t, mapping, "gpt-5.6-sol")
-	require.NotContains(t, mapping, "gpt-image-1")
-	require.NotContains(t, mapping, "gpt-5.2")
-	require.NotContains(t, mapping, "gpt-5-codex")
+	requireIdentityMappingForIDs(t, mapping, supportedCatalogModelIDsForPlatform(PlatformOpenAI))
 }
 
 func TestOpenAICanonicalFloorAcceptsKnownRoutingAliases(t *testing.T) {
@@ -113,17 +85,10 @@ func TestAccountModelMappingFloorForOps_ExportsAinzyRelayScope(t *testing.T) {
 	require.NoError(t, err)
 	ainzy, ok := doc.Platforms[accountModelMappingPlatformOpenAIAinzyRelay]
 	require.True(t, ok)
-	require.Len(t, ainzy, 4)
-	require.Contains(t, ainzy, "gpt-5.4-mini")
-	require.NotContains(t, ainzy, "gpt-5-pro")
-	require.NotContains(t, ainzy, "gpt-5.2")
-	require.NotContains(t, ainzy, "codex-auto-review")
+	requireIdentityMappingForIDs(t, ainzy, supportedCatalogModelIDsFromMap(supportedOpenAIAinzyRelayCatalogModels))
 	canonical, ok := doc.Platforms[PlatformOpenAI]
 	require.True(t, ok)
-	require.Len(t, canonical, 4)
-	require.Contains(t, canonical, "gpt-5.3-codex-spark")
-	require.NotContains(t, canonical, "gpt-5-pro")
-	require.NotContains(t, canonical, "codex-auto-review")
+	requireIdentityMappingForIDs(t, canonical, supportedCatalogModelIDsForPlatform(PlatformOpenAI))
 }
 
 func TestAccountModelMappingForAccount_AinzyUsesCuratedFloor(t *testing.T) {
@@ -136,7 +101,14 @@ func TestAccountModelMappingForAccount_AinzyUsesCuratedFloor(t *testing.T) {
 		},
 	}, nil, nil, nil)
 	require.True(t, ok)
-	require.Len(t, mapping, 4)
-	require.Contains(t, mapping, "gpt-5.4-mini")
-	require.NotContains(t, mapping, "codex-auto-review")
+	requireIdentityMappingForIDs(t, mapping, supportedCatalogModelIDsFromMap(supportedOpenAIAinzyRelayCatalogModels))
+}
+
+func requireIdentityMappingForIDs(t *testing.T, mapping map[string]string, ids []string) {
+	t.Helper()
+	require.NotEmpty(t, ids, "SSOT id list must be populated")
+	require.Len(t, mapping, len(ids), "mapping must contain exactly the SSOT ids")
+	for _, id := range ids {
+		require.Equal(t, id, mapping[id], "mapping for %s must be identity", id)
+	}
 }

--- a/backend/internal/service/openai_deprecated_model_tk_test.go
+++ b/backend/internal/service/openai_deprecated_model_tk_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -9,50 +10,48 @@ import (
 )
 
 func TestTkIsDeprecatedOpenAIModel(t *testing.T) {
-	cases := []struct {
-		name           string
-		model          string
-		wantDeprecated bool
-		wantReplaceTo  string
-	}{
-		{"gpt-5.2 deprecated -> gpt-5.5", "gpt-5.2", true, "gpt-5.5"},
-		{"gpt-5.2-pro deprecated -> gpt-5.5", "gpt-5.2-pro", true, "gpt-5.5"},
-		{"codex-auto-review deprecated -> no replacement", "codex-auto-review", true, ""},
-
-		{"gpt-5.4 current passes", "gpt-5.4", false, ""},
-		{"gpt-5.5 current passes", "gpt-5.5", false, ""},
-		{"gpt-5.3-codex alias passes", "gpt-5.3-codex", false, ""},
-		{"gpt-5-codex alias passes", "gpt-5-codex", false, ""},
-		{"gpt-5.3-codex-spark current passes", "gpt-5.3-codex-spark", false, ""},
-		{"gpt-5.3-chat-latest current passes", "gpt-5.3-chat-latest", false, ""},
-		{"empty string passes", "", false, ""},
-		{"non-openai model passes", "claude-sonnet-4-6", false, ""},
+	for model, wantReplacement := range tkDeprecatedOpenAIModels {
+		t.Run(model, func(t *testing.T) {
+			replacement, deprecated := tkIsDeprecatedOpenAIModel(model)
+			require.True(t, deprecated, "deprecated table key %q must resolve", model)
+			require.Equal(t, wantReplacement, replacement)
+		})
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			replacement, deprecated := tkIsDeprecatedOpenAIModel(tc.model)
-			require.Equal(t, tc.wantDeprecated, deprecated, "deprecated flag for %q", tc.model)
-			if tc.wantDeprecated {
-				require.Equal(t, tc.wantReplaceTo, replacement)
-			} else {
-				require.Empty(t, replacement)
-			}
-		})
+	servableOpenAI := ServableClientFacingIDs(context.Background(), PlatformOpenAI, nil, nil)
+	require.NotEmpty(t, servableOpenAI, "openai servable SSOT must be populated")
+	for _, model := range servableOpenAI {
+		replacement, deprecated := tkIsDeprecatedOpenAIModel(model)
+		require.False(t, deprecated, "servable openai model %q must not be deprecated", model)
+		require.Empty(t, replacement)
+	}
+
+	for _, model := range []string{
+		"gpt-5.3-codex",
+		"gpt-5-codex",
+		"gpt-5.3-chat-latest",
+		"",
+		"claude-sonnet-4-6",
+	} {
+		replacement, deprecated := tkIsDeprecatedOpenAIModel(model)
+		require.False(t, deprecated, "non-deprecated example %q must pass", model)
+		require.Empty(t, replacement)
 	}
 }
 
 func TestTkLookupDeprecatedOpenAIModel(t *testing.T) {
-	matched, replacement, ok := TkLookupDeprecatedOpenAIModel("gpt-5.2")
-	require.True(t, ok)
-	require.Equal(t, "gpt-5.2", matched)
-	require.Equal(t, "gpt-5.5", replacement)
+	for model, wantReplacement := range tkDeprecatedOpenAIModels {
+		matched, replacement, ok := TkLookupDeprecatedOpenAIModel(model)
+		require.True(t, ok, "deprecated table key %q must resolve", model)
+		require.Equal(t, model, matched)
+		require.Equal(t, wantReplacement, replacement)
+	}
 
 	// gpt-5.2-pro is silently rewritten to gpt-5.2 by the routing-alias substring
 	// fallback (openai_model_alias.go) before selection failure is observed — the
 	// lookup must catch the routed form too, mirroring the anthropic raw+normalized
 	// lookup order.
-	matched, replacement, ok = TkLookupDeprecatedOpenAIModel(CanonicalizeOpenAICompatRoutingModel("gpt-5.2-pro"))
+	matched, replacement, ok := TkLookupDeprecatedOpenAIModel(CanonicalizeOpenAICompatRoutingModel("gpt-5.2-pro"))
 	require.True(t, ok)
 	require.Equal(t, "gpt-5.2", matched)
 	require.Equal(t, "gpt-5.5", replacement)
@@ -77,21 +76,6 @@ func TestTkBuildDeprecatedOpenAIModelMessage(t *testing.T) {
 	msg = TkBuildDeprecatedOpenAIModelMessage("codex-auto-review", "")
 	require.Contains(t, msg, "codex-auto-review")
 	require.Contains(t, msg, "not directly selectable")
-}
-
-// Guards against silent table edits during upstream merges / future PRs.
-func TestTkDeprecatedOpenAIModelsTableIsExhaustive(t *testing.T) {
-	expected := map[string]struct{}{
-		"gpt-5.2":           {},
-		"gpt-5.2-pro":       {},
-		"codex-auto-review": {},
-	}
-	require.Len(t, tkDeprecatedOpenAIModels, len(expected),
-		"deprecated openai model table size changed; update this assertion intentionally")
-	for id := range expected {
-		_, ok := tkDeprecatedOpenAIModels[id]
-		require.Truef(t, ok, "deprecated model %q must remain on the gate list", id)
-	}
 }
 
 func TestTkDeprecatedOpenAISelectionFailure(t *testing.T) {

--- a/backend/internal/service/pricing_catalog_candidates_tk_test.go
+++ b/backend/internal/service/pricing_catalog_candidates_tk_test.go
@@ -140,21 +140,8 @@ func TestTkServableCandidateIDs(t *testing.T) {
 	t.Run("antigravity draws from the empirically-servable gemini plus live Claude allowlist", func(t *testing.T) {
 		svc, _, _ := newAvailabilityTestService(t)
 		ids := tkServableCandidateIDs(ctx, PlatformAntigravity, svc)
-		for _, want := range []string{
-			"gemini-2.5-flash",
-			"gemini-2.5-flash-lite",
-			"gemini-2.5-flash-thinking",
-			"gemini-3-flash",
-			"gemini-3.1-flash-image", // served via antigravity pool (2026-06-27 image probe 200)
-			"gemini-3.5-flash",       // 2026-06-27 prod 200 → added
-			"gemini-3.5-flash-low",
-			"gemini-pro-agent",
-			"claude-sonnet-4-6",
-			"claude-opus-4-6",
-			"claude-opus-4-6-thinking",
-		} {
-			require.True(t, contains(ids, want), "servable antigravity id %s present", want)
-		}
+		require.ElementsMatch(t, supportedCatalogModelIDsForPlatform(PlatformAntigravity), ids,
+			"antigravity candidates must mirror the servable SSOT")
 		// gemini-2.5-pro stays off antigravity (no real 200 — served via gemini/Vertex instead).
 		for _, offPlatform := range []string{"claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5", "gpt-oss-120b-medium", "gemini-2.5-pro"} {
 			require.False(t, contains(ids, offPlatform),

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 598,
-  "hash": "1cf874e243eb21435dc9e155e9978f9f8a9eb2e06e29d37139398c9ae11e9732",
+  "hash": "63d5488ca24828ea59aa1a560974ec64e7b3e03035e68371760c51c5206aa700",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
+++ b/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
@@ -12,6 +12,7 @@ import {
   buildModelMappingObject,
   getModelsByPlatform,
   getPresetMappingsByPlatform,
+  qwen3DenseModels,
   splitModelMappingObject
 } from '../useModelWhitelist'
 
@@ -48,9 +49,9 @@ describe('useModelWhitelist', () => {
     // INTERIM truth lives in tk_served_models.json (backend manifest); PR-C
     // will derive this list from a servable endpoint.
     const newapiModels = getModelsByPlatform('newapi')
-    expect(newapiModels).toContain('qwen3-8b')
-    expect(newapiModels).toContain('qwen3-14b')
-    expect(newapiModels).toContain('qwen3-32b')
+    for (const model of qwen3DenseModels) {
+      expect(newapiModels).toContain(model)
+    }
   })
 
   it('long-tail direct providers keep static lists', () => {
@@ -58,7 +59,9 @@ describe('useModelWhitelist', () => {
     const qwen = getModelsByPlatform('qwen')
     expect(qwen.length).toBeGreaterThan(0)
     // dense ids are also offered on the direct qwen platform
-    expect(qwen).toContain('qwen3-32b')
+    for (const model of qwen3DenseModels) {
+      expect(qwen).toContain(model)
+    }
   })
 
   it('unknown platform yields an empty list (custom input is the escape hatch)', () => {

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -13,7 +13,7 @@
 // 兼容聚合器）实际可服务的稠密档位。单独成组，便于同时喂给 newapi 与直连
 // qwen 两个 picker，且与 qwenModels 里已有的 MoE 档（qwen3-235b-a22b）/ qwq
 // 不重复。
-const qwen3DenseModels = [
+export const qwen3DenseModels = [
   'qwen3-8b', 'qwen3-14b', 'qwen3-32b'
 ]
 


### PR DESCRIPTION
## 摘要
- 移除 #1297 相关测试里重复手写的 OpenAI / Ainzy / Antigravity / qwen3 正向模型列表，改为从现有 SSOT 派生断言。
- 后端测试复用 `ServableClientFacingIDs`、`supportedCatalogModelIDsForPlatform`、`tkDeprecatedOpenAIModels` 等单一事实来源；前端测试复用导出的 `qwen3DenseModels`。
- 将 OpenAI admin/default/universal model-list 的 hidden 样本列表收敛为精确 SSOT 集合断言，避免继续维护补集样本。
- 将 deprecated OpenAI 测试里的当前可服务 OpenAI 非废弃样本改为遍历 `ServableClientFacingIDs`，只保留空串、跨平台 ID、兼容路由别名等真正边界负例。
- 收敛 Ainzy / canonical OpenAI floor 测试中由精确 SSOT identity 断言已经覆盖的 `NotContains` 负例，保留真正覆盖 alias 行为的负例。
- 刷新 `backend/internal/web/dist/frontend-source.json`，保持 embedded frontend dist source hash 与前端源码一致。
- sentinel-registry-reviewed：本 PR 只收敛既有 load-bearing surface 的测试断言复用，不新增/删除 sentinel anchor，现有 sentinel 覆盖不需要调整。

## 风险
- 低风险：主要是测试断言去重和前端测试 helper 导出，生产行为不变。
- Web impact: none。前端运行时逻辑未改变，dist 仅刷新源码哈希契约。

## 验证
- `go test -tags unit ./internal/service -run TestTkIsDeprecatedOpenAIModel`
- `go test -tags unit ./internal/service -run 'Test(OpenAIAinzyRelayFloorIsProbeCuratedOnly|OpenAICanonicalFloorUsesServableOpenAIAllowlist|AccountModelMappingFloorForOps_ExportsAinzyRelayScope|AccountModelMappingForAccount_AinzyUsesCuratedFloor)'`
- `go test -tags unit ./internal/service`
- `go test -tags unit ./internal/handler ./internal/handler/admin`
- `pnpm --dir frontend test:run src/composables/__tests__/useModelWhitelist.spec.ts`
- `pnpm --dir frontend run build`
- `./scripts/preflight.sh`

## 提交
- `c4beb7e1e` test(ssot): derive model catalog assertions from source of truth
- 最新提交：`c4beb7e1e`
