### PR TITLE
fix(grok): align 429 fallback cooldown with openai

### DIFF
--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -713,9 +713,9 @@ func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Contex
 	case http.StatusForbidden:
 		s.tempUnscheduleGrok(ctx, account, 30*time.Minute, "grok entitlement or subscription tier denied")
 	case http.StatusTooManyRequests:
-		cooldown := 2 * time.Minute
-		if snapshot := xai.ParseQuotaHeaders(headers, statusCode); snapshot != nil && snapshot.RetryAfterSeconds != nil && *snapshot.RetryAfterSeconds > 0 {
-			cooldown = time.Duration(*snapshot.RetryAfterSeconds) * time.Second
+		cooldown, ok := s.grok429Cooldown(ctx, account, headers)
+		if !ok {
+			return
 		}
 		s.tempUnscheduleGrok(ctx, account, cooldown, "grok rate limited")
 	default:
@@ -724,6 +724,16 @@ func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Contex
 		}
 	}
 	_ = responseBody
+}
+
+func (s *OpenAIGatewayService) grok429Cooldown(ctx context.Context, account *Account, headers http.Header) (time.Duration, bool) {
+	if snapshot := xai.ParseQuotaHeaders(headers, http.StatusTooManyRequests); snapshot != nil && snapshot.RetryAfterSeconds != nil && *snapshot.RetryAfterSeconds > 0 {
+		return time.Duration(*snapshot.RetryAfterSeconds) * time.Second, true
+	}
+	if s != nil && s.rateLimitService != nil {
+		return s.rateLimitService.get429FallbackCooldown(ctx, account)
+	}
+	return openAIOAuth429FallbackCooldown, true
 }
 
 func (s *OpenAIGatewayService) tempUnscheduleGrok(ctx context.Context, account *Account, cooldown time.Duration, reason string) {

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -1136,6 +1136,13 @@ func TestHandleGrokAccountUpstreamErrorTempUnschedulesReadinessStates(t *testing
 			wantMinCooldown: 44 * time.Second,
 			wantMaxCooldown: 46 * time.Second,
 		},
+		{
+			name:            "rate limited without retry after uses openai fallback",
+			status:          http.StatusTooManyRequests,
+			wantReason:      "grok rate limited",
+			wantMinCooldown: openAIOAuth429FallbackCooldown - time.Second,
+			wantMaxCooldown: openAIOAuth429FallbackCooldown + time.Second,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1155,6 +1162,26 @@ func TestHandleGrokAccountUpstreamErrorTempUnschedulesReadinessStates(t *testing
 			require.True(t, repo.lastTempUnschedUntil.Before(before.Add(tt.wantMaxCooldown)))
 		})
 	}
+}
+
+func TestHandleGrokAccountUpstreamErrorUsesConfigured429Fallback(t *testing.T) {
+	repo := &grokQuotaAccountRepo{}
+	settingRepo := newMockSettingRepo()
+	data, _ := json.Marshal(RateLimit429CooldownSettings{Enabled: true, CooldownSeconds: 12})
+	settingRepo.data[SettingKeyRateLimit429CooldownSettings] = string(data)
+	rateLimitSvc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	rateLimitSvc.SetSettingService(NewSettingService(settingRepo, &config.Config{}))
+	svc := &OpenAIGatewayService{accountRepo: repo, rateLimitService: rateLimitSvc}
+	account := &Account{ID: 61, Platform: PlatformGrok, Type: AccountTypeOAuth}
+
+	before := time.Now()
+	svc.handleGrokAccountUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, nil)
+	after := time.Now()
+
+	require.Equal(t, 1, repo.tempUnschedCalls)
+	require.Equal(t, "grok rate limited", repo.lastTempUnschedReason)
+	require.False(t, repo.lastTempUnschedUntil.Before(before.Add(12*time.Second)))
+	require.False(t, repo.lastTempUnschedUntil.After(after.Add(12*time.Second)))
 }
 
 func TestHandleGrokAccountUpstreamError_DownstreamCapacitySkipsRelayCooldown(t *testing.T) {


### PR DESCRIPTION
## 摘要
- Grok 上游 429 有有效 `Retry-After` 时继续按上游秒数冷却。
- Grok 上游 429 没有有效 `Retry-After` 时，改为复用 OpenAI OAuth 429 fallback 策略，不再固定 2 分钟。
- 补充默认 fallback 和配置化 fallback 的回归测试。

## 风险
- 低风险：影响范围限定在 Grok OAuth 账号收到上游 429 后的本地临时冷却时长。
- 配置禁用 429 fallback 时，行为与 OpenAI 策略一致，可不做本地 fallback 冷却。
- no-web-impact；无 Web 表面变更。
- sentinel-registry-reviewed：已复核本次仅调整现有 Grok 429 冷却策略，无新增/删除 load-bearing sentinel anchor。

## 验证
- `go test -tags=unit ./internal/service -run 'TestHandleGrokAccountUpstreamError(TempUnschedulesReadinessStates|UsesConfigured429Fallback|_DownstreamCapacitySkipsRelayCooldown|DoesNotShortenExistingPause)$'`
- `./scripts/preflight.sh`

## 提交
- `72685b7a8` fix(grok): align 429 fallback cooldown with openai

最新提交：72685b7a8