### PR TITLE
fix(pricing): show catalog price in group menu

### DIFF
--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -30,9 +30,9 @@ package service
 // HideUserRateOverrides), but it is NO LONGER applied to model prices.
 //
 // Multi-channel dedupe rule: when the same model_id appears on multiple
-// active channels mapped to the target group, we keep the row with the
-// LOWEST combined input+output (official) price — the headline price equals
-// the cheapest catalog path for that model.
+// active channels mapped to the target group, public-catalog prices win when
+// present. For channel-only/custom rows with no public-catalog entry, we keep
+// the row with the LOWEST combined input+output channel price.
 
 import (
 	"context"
@@ -565,7 +565,7 @@ func (s *MePricingCatalogService) buildModelsForGroup(
 					if m.Platform != targetGroup.Platform {
 						continue
 					}
-					candidate := buildModelEntry(m, effectiveRate)
+					candidate := buildChannelServedEntry(m, effectiveRate, metaByID)
 					if existing, ok := bestByModel[m.Name]; ok {
 						bestByModel[m.Name] = pickCheaperModel(existing, candidate)
 					} else {
@@ -938,14 +938,39 @@ func buildAccountFallbackEntry(modelID string, rate float64, metaByID map[string
 		YourPrice:    MePricingPrice{Currency: "USD"},
 		Capabilities: []string{},
 	}
-	meta, ok := metaByID[modelID]
-	if !ok {
-		if stripped, stripOK := stripVendorPrefixForCatalogLookup(modelID); stripOK {
-			meta, ok = metaByID[stripped]
-		}
-	}
+	meta, ok := lookupMePricingCatalogModel(modelID, metaByID)
 	if !ok {
 		return entry
+	}
+	applyCatalogMetaToMePricingModel(&entry, meta, rate)
+	return entry
+}
+
+func buildChannelServedEntry(m SupportedModel, rate float64, metaByID map[string]PublicCatalogModel) MePricingModel {
+	entry := buildModelEntry(m, rate)
+	if meta, ok := lookupMePricingCatalogModel(m.Name, metaByID); ok {
+		applyCatalogMetaToMePricingModel(&entry, meta, rate)
+	}
+	return entry
+}
+
+func lookupMePricingCatalogModel(modelID string, metaByID map[string]PublicCatalogModel) (PublicCatalogModel, bool) {
+	meta, ok := metaByID[modelID]
+	if ok {
+		return meta, true
+	}
+	if stripped, stripOK := stripVendorPrefixForCatalogLookup(modelID); stripOK {
+		meta, ok = metaByID[stripped]
+		if ok {
+			return meta, true
+		}
+	}
+	return PublicCatalogModel{}, false
+}
+
+func applyCatalogMetaToMePricingModel(entry *MePricingModel, meta PublicCatalogModel, rate float64) {
+	if entry == nil {
+		return
 	}
 	entry.Vendor = meta.Vendor
 	if meta.Pricing.BillingMode != "" {
@@ -958,7 +983,6 @@ func buildAccountFallbackEntry(modelID string, rate float64, metaByID map[string
 	// Media units (nil when 0 — non-media models stay token-only).
 	entry.YourPrice.PerImage = scaleCatalogPrice(meta.Pricing.OutputCostPerImage, rate)
 	entry.YourPrice.PerSecond = scaleCatalogPrice(meta.Pricing.OutputCostPerSecond, rate)
-	return entry
 }
 
 // scaleCatalogPrice multiplies a PublicCatalogPricing value (already in

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -700,11 +700,10 @@ func TestBuildForUser_AccountWhitelistOnly_NoChannels(t *testing.T) {
 	assert.InDelta(t, 0.0025, *byID["gpt-4o"].YourPrice.InputPer1K, 1e-9, "0.0025 catalog 官方价")
 }
 
-// TestBuildForUser_ChannelAndAccount_ChannelWins guards the "channel
-// price is authoritative on conflict" rule. The catalog input for the
-// shared model is set to a very different number than the channel price
-// so a regression that overwrote channel rows would be obvious.
-func TestBuildForUser_ChannelAndAccount_ChannelWins(t *testing.T) {
+// TestBuildForUser_ChannelAndAccount_CatalogPriceWins guards the current
+// pricing-page contract: channels decide whether the target group can serve a
+// model, but displayed prices come from the public catalog when present.
+func TestBuildForUser_ChannelAndAccount_CatalogPriceWins(t *testing.T) {
 	gOpenAI := mkGroupForMe(30, "GPT", "openai", 1.0)
 	k1 := mkKeyForMe(1, 7, "gpt-key", ptrI(30))
 	channel := mkChannelWithModel(100, "operator-ch",
@@ -732,10 +731,48 @@ func TestBuildForUser_ChannelAndAccount_ChannelWins(t *testing.T) {
 		byID[m.ModelID] = m
 	}
 	require.NotNil(t, byID["gpt-5.2"].YourPrice.InputPer1K)
-	assert.InDelta(t, 1.0, *byID["gpt-5.2"].YourPrice.InputPer1K, 1e-9,
-		"0.001 channel × 1000 (per-token → per-1k) × 1.0 rate; catalog 0.999 MUST NOT win")
+	assert.InDelta(t, 0.999, *byID["gpt-5.2"].YourPrice.InputPer1K, 1e-9,
+		"catalog official price must win over stale channel pricing")
 	require.NotNil(t, byID["gpt-4o"].YourPrice.InputPer1K)
 	assert.InDelta(t, 0.0025, *byID["gpt-4o"].YourPrice.InputPer1K, 1e-9, "gpt-4o is account-only — catalog 0.0025 × 1.0 rate")
+}
+
+func TestBuildForUser_ChannelGLM52UsesCatalogOfficialPrice(t *testing.T) {
+	gNewapi := mkGroupForMe(50, "zhipu", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 7, "zhipu-key", ptrI(50))
+	channel := mkChannelWithModel(100, "stale-zhipu-channel",
+		[]AvailableGroupRef{{ID: 50, Platform: "newapi"}},
+		[]SupportedModel{mkSupportedModel("glm-5.2", "newapi", mkPricing(0.000001484, 0.000004664, 0.000000276))},
+	)
+	catalog := &PublicCatalogResponse{
+		Data: []PublicCatalogModel{
+			mkPublicCatalogModel(
+				"glm-5.2",
+				"zhipu",
+				tkCNYPerMTokToUSDPerToken(8)*tkOfficialListBaseTaxMultiplier*1000,
+				tkCNYPerMTokToUSDPerToken(28)*tkOfficialListBaseTaxMultiplier*1000,
+				tkCNYPerMTokToUSDPerToken(2)*tkOfficialListBaseTaxMultiplier*1000,
+			),
+		},
+	}
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gNewapi}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{channel}},
+		&fakeCatalogProvider{resp: catalog},
+	)
+
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1)
+	row := resp.Models[0]
+	assert.Equal(t, "glm-5.2", row.ModelID)
+	assert.Equal(t, "zhipu", row.Vendor)
+	require.NotNil(t, row.YourPrice.InputPer1K)
+	require.NotNil(t, row.YourPrice.OutputPer1K)
+	require.NotNil(t, row.YourPrice.CacheReadPer1K)
+	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(8)*tkOfficialListBaseTaxMultiplier*1000, *row.YourPrice.InputPer1K, 1e-12)
+	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(28)*tkOfficialListBaseTaxMultiplier*1000, *row.YourPrice.OutputPer1K, 1e-12)
+	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(2)*tkOfficialListBaseTaxMultiplier*1000, *row.YourPrice.CacheReadPer1K, 1e-12)
 }
 
 // TestBuildForUser_AuthorizedGroups_CrossGroup pins the "授权分组" column: each

--- a/docs/spec-delta-glm52-menu-catalog-price.md
+++ b/docs/spec-delta-glm52-menu-catalog-price.md
@@ -1,0 +1,28 @@
+# GLM 5.2 Group Menu Catalog Price Delta
+
+## Background
+
+`/pricing` 的分组目录展示价应当来自 public catalog 官方价。GLM 5.2 的
+overlay/fallback 已按 BigModel 官方价源修正，但分组目录的 channel-served
+row 仍可能优先读取 channel 里残留的旧价，导致用户看到旧的 input/output/cache
+read 价格。
+
+## Delta
+
+MODIFIED:
+
+- 分组目录中，channel 仍决定目标分组是否可服务模型。
+- 当 public catalog 存在同名模型时，展示价改为 public catalog 官方价。
+- 当 public catalog 不存在该模型时，保留原 channel-only/custom 模型的 channel
+  价格展示兜底。
+
+## Scenarios
+
+- `glm-5.2` channel 中残留旧价格时，分组目录展示 BigModel catalog 官方价。
+- account fallback 和 channel-served row 复用同一 catalog lookup 规则。
+- 未进入 public catalog 的自定义 channel 模型继续展示 channel 配置价。
+
+## Validation
+
+- `go test -tags=unit ./internal/service`
+- `./scripts/preflight.sh`


### PR DESCRIPTION
摘要
- 修复分组目录里 channel 配置价覆盖 public catalog 官方价的问题；channel 仍决定分组是否可服务模型，展示价优先来自 catalog。
- 复用 catalog lookup 逻辑到 channel-served rows，并保留 catalog 缺失时退回 channel-only/custom 价格的兼容路径。
- 增加 glm-5.2 回归测试，用旧 channel 价 $0.001484 / $0.004664 / $0.000276 证明分组目录应展示 catalog 官方价。
- 补充 `docs/spec-delta-glm52-menu-catalog-price.md` 作为 Web/config/contract 对齐证据：前端继续消费既有 me pricing catalog DTO 字段，后端修正字段取值来源。

风险
- 影响分组目录 / me pricing catalog 的展示价格来源；网关计费与 channel pricing override 计费链不变。
- channel-only/custom 模型如果没有 public catalog row，仍按原 channel 价格展示。
- sentinel-registry-reviewed：已检查本次只调整既有分组目录价格选择逻辑和测试，不新增 load-bearing surface 或 sentinel anchor。

验证
- go test -tags=unit ./internal/service
- ./scripts/preflight.sh

提交
- 82b48c4cd fix(pricing): show catalog price in group menu
- 0f1a0bc5f docs(pricing): record group menu price delta
- 最新提交：0f1a0bc5f