### PR TITLE
fix(pricing): 自动同步 prod pricing overlay runtime

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -25,6 +25,7 @@ description: Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, ro
 | Edge upgrade/smoke/rollback dispatch | 机械 | `bash scripts/stage0/dispatch-edge-deploy.sh --edge-id … --operation …` |
 | **其余 Edge rollout（bounded parallel fail-stop + smoke 标记验收）** | 机械 | `bash scripts/stage0/rollout-edges.sh --tag X.Y.Z --skip <canary>`（**默认 `--parallel 1` 顺序**，降低并发换容器对线上的影响；`N>1` 仅在可接受该影响时用） |
 | dispatch release.yml / deploy-stage0.yml + watch | 机械 | `gh workflow run` + `gh run watch --exit-status` |
+| **prod pricing overlay runtime sync** | 机械 | `deploy-stage0.yml` 在镜像切换 + external health 后，从部署 tag 的 `tk_pricing_overlay.json` 自动执行 `ops/pricing/manage-overlay-runtime.py sync-runtime --overlay-path …`；失败阻断后续 smoke |
 | prod 镜像预热（deploy 前，把 ~150s pull 移出关键路径） | 机械 | `gh workflow run warm-image-stage0.yml` + `approve-github-run-env.sh` + watch（只读、非致命；见 §「部署目标矩阵 → prod」） |
 | prod / warm Environment approval | 机械 | `bash scripts/stage0/approve-github-run-env.sh --run-id <id> --comment "…"`（批不批、何时批是判断） |
 | prod 完整 smoke（CI 唯一验收源） | 机械 | `deploy-stage0.yml` job log 内 `tk_post_deploy_smoke: OK`（`GATEWAY_SMOKE_SUITE=full`） |
@@ -111,7 +112,7 @@ description: Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, ro
 
 ## 一次性跑完（原则）
 
-- **顺序做完**：`release-bump-and-tag.sh` → **watch 到 release 成功** → 根据 `target` dispatch 对应 deploy workflow → **watch 到 deploy/smoke 成功** → **Anthropic OAuth snapshot/check + Account model_mapping check（默认）** → **再做本地/日志验收 / followup**。不要在 workflow 绿灯后就结束会话。
+- **顺序做完**：`release-bump-and-tag.sh` → **watch 到 release 成功** → 根据 `target` dispatch 对应 deploy workflow → **deploy-stage0 自动同步 pricing overlay runtime 并完成 smoke** → **Anthropic OAuth snapshot/check + Account model_mapping check（默认）** → **再做本地/日志验收 / followup**。不要在 workflow 绿灯后就结束会话。
 - **永远不在共享 checkout 里 bump/tag**：`release-bump-and-tag.sh` 自带 worktree 隔离与 fetch，不需要也不应该先 `git checkout main && git pull`（并行 agent 可能正占用 checkout——见 §「决策 + bump + tag」）。
 - **`gh run watch` 要给够时间**：多架构 `release.yml` 常见十余分钟量级；Agent 应用 `--exit-status` 跟跑到结束，不要用默认短超时提前杀掉。
 - **Environment approval 不是失败**：`prod` / `edge-<edge_id>` run 卡在 `waiting` 时，按 §「部署目标矩阵 → prod」的 approval 命令在 canary 绿后自批（执行账号非 reviewer 时回落人工）；批准后继续 watch。
@@ -214,6 +215,12 @@ gh run list --workflow=deploy-stage0.yml --limit 3 --json databaseId,event,creat
 gh workflow run deploy-stage0.yml \
   -f tag="$TARGET_TAG"
 ```
+
+`deploy-stage0.yml` 会在 SSM 换镜像且 external health 通过后，自动从 `v$TARGET_TAG` 读取
+`backend/internal/service/tk_pricing_overlay.json` 并同步到 prod
+`settings.tk_pricing_overlay_runtime`，随后才跑完整 smoke。价格改动不需要人工另跑
+`manage-overlay-runtime.py sync-runtime`；若该步骤失败，部署 run 会在 smoke 前失败，按日志修
+sync 脚本或 AWS/SSM/DB 通道后重跑 deploy。
 
 **Environment approval（机械命令，时机是判断）**：canary full smoke 绿后再批 prod deploy：
 

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -181,6 +181,21 @@ jobs:
           API_URL: ${{ steps.instance.outputs.api_url }}
         run: bash ops/stage0/external_health.sh "$API_URL"
 
+      - name: Sync pricing overlay runtime
+        # The compiled-in tk_pricing_overlay.json is the pricing SSOT, but prod
+        # also has a hot runtime layer for no-release model pricing. A stale
+        # runtime row wins over the newly deployed binary unless deploy syncs it.
+        # Use the overlay from the DEPLOYED tag, not the workflow checkout's
+        # current main, so rollback deploys restore the matching runtime price set.
+        run: |
+          set -euo pipefail
+          TARGET_REF="v${INPUT_TAG}"
+          git fetch origin "refs/tags/${TARGET_REF}:refs/tags/${TARGET_REF}" --force
+          git show "${TARGET_REF}:backend/internal/service/tk_pricing_overlay.json" > /tmp/tk_pricing_overlay_runtime.json
+          python3 scripts/checks/pricing-overlay.py --path /tmp/tk_pricing_overlay_runtime.json
+          python3 ops/pricing/manage-overlay-runtime.py sync-runtime \
+            --overlay-path /tmp/tk_pricing_overlay_runtime.json
+
       - name: Post-deploy data invariant check (exclusive-group orphans)
         # ADVISORY ONLY — never blocks the deploy. Reads (read-only) whether any
         # API key is bound to an exclusive standard group whose user is NOT in

--- a/ops/pricing/manage-overlay-runtime.py
+++ b/ops/pricing/manage-overlay-runtime.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import argparse
 import base64
 import gzip
+import hashlib
 import importlib.util
 import json
 import subprocess
@@ -126,17 +127,24 @@ def read_runtime_blob(instance_id: str) -> dict:
         fail(f"runtime settings blob decode failed (host gzip|base64 read-back): {e}")
 
 
-def load_repo_overlay() -> dict:
+def overlay_path(args) -> Path:
+    p = Path(getattr(args, "overlay_path", "") or OVERLAY_PATH)
+    if not p.is_absolute():
+        p = REPO_ROOT / p
+    return p
+
+
+def load_repo_overlay(path: Path = OVERLAY_PATH) -> dict:
     try:
-        return json.loads(OVERLAY_PATH.read_text())
+        return json.loads(path.read_text())
     except (OSError, json.JSONDecodeError) as e:
-        fail(f"cannot read repo overlay {OVERLAY_PATH}: {e}")
+        fail(f"cannot read repo overlay {path}: {e}")
 
 
 # --- subcommands --------------------------------------------------------------
 
 def cmd_check(_args) -> int:
-    repo = load_repo_overlay()
+    repo = load_repo_overlay(overlay_path(_args))
     inst = _SSM.resolve_prod_instance()
     runtime = read_runtime_blob(inst)
     drift = compute_overlay_drift(repo, runtime)
@@ -155,11 +163,19 @@ def cmd_check(_args) -> int:
 
 
 def cmd_sync_runtime(args) -> int:
-    # 1. validate the repo overlay with the SAME gate the PR ran.
-    gate = subprocess.run([sys.executable, str(OVERLAY_GATE)], cwd=str(REPO_ROOT))
-    if gate.returncode != 0:
-        fail("pricing-overlay.py gate failed; refusing to push an invalid overlay")
-    overlay_bytes = OVERLAY_PATH.read_bytes()
+    # 1. validate the repo overlay with the SAME gate the PR ran. When deploying
+    # a historical tag, the caller passes a temp overlay extracted from that tag;
+    # do not run today's stricter anchor set against an older artifact (rollback
+    # must not be blocked by anchors added after the target tag). That tag's CI
+    # already validated its overlay; here we still parse + require non-empty below.
+    path = overlay_path(args)
+    if path.resolve() == OVERLAY_PATH.resolve():
+        gate = subprocess.run([sys.executable, str(OVERLAY_GATE), "--path", str(path)], cwd=str(REPO_ROOT))
+        if gate.returncode != 0:
+            fail("pricing-overlay.py gate failed; refusing to push an invalid overlay")
+    else:
+        print(f"  note: validating non-default overlay path with parse/non-empty checks only: {path}")
+    overlay_bytes = path.read_bytes()
     # sanity: must parse + be non-empty
     doc = json.loads(overlay_bytes)
     if not overlay_entries(doc):
@@ -189,25 +205,26 @@ def cmd_sync_runtime(args) -> int:
     # Decode on the host, re-base64 the plain JSON, decode that inside Postgres. The stored
     # `value` is the exact overlay JSON (byte-identical to the old :'v' path); `check` reads
     # it back unchanged.
-    upsert = (
+    expected_len = len(overlay_bytes.decode("utf-8"))
+    expected_md5 = hashlib.md5(overlay_bytes).hexdigest()
+    shell = (
+        "set -euo pipefail\n"
+        f"JSON_B64=\"$(echo {gz_b64} | base64 -d | gunzip | base64 | tr -d '\\n')\"\n"
+        f"echo \"json_b64_len=${{#JSON_B64}} expected_raw_b64_len={len(base64.b64encode(overlay_bytes).decode())}\"\n"
+        "echo '=== upsert tk_pricing_overlay_runtime ==='\n"
+        f"{PSQL} <<SQL\n"
         f"INSERT INTO settings (key, value, updated_at) VALUES "
         f"('{SETTING_KEY}', convert_from(decode('$JSON_B64','base64'),'UTF8'), NOW()) "
-        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW();"
-    )
-    shell = (
-        "set -uo pipefail\n"
-        f"PSQL='{PSQL}'\n"
-        f"RC='{REDISCLI}'\n"
-        f"JSON_B64=\"$(echo {gz_b64} | base64 -d | gunzip | base64 | tr -d '\\n')\"\n"
-        "echo '=== upsert tk_pricing_overlay_runtime ==='\n"
-        f"$PSQL -c \"{upsert}\" </dev/null && echo UPSERT_OK\n"
+        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW();\n"
+        f"SELECT key || '|' || length(value)::text || '|' || md5(value) "
+        f"FROM settings WHERE key='{SETTING_KEY}';\n"
+        "SQL\n"
+        "echo UPSERT_OK\n"
         "echo '=== publish settings_updated (fan-out reload) ==='\n"
         # Best-effort: the UPSERT above is the durable truth; PUBLISH only makes the reload
         # immediate. Surface (don't swallow) a failure so the operator knows replicas will
         # lag to the poll interval instead of reloading now.
-        "$RC PUBLISH settings_updated refresh </dev/null || echo 'WARN: redis PUBLISH failed; replicas reload within the pricing poll interval, not immediately'\n"
-        "echo '=== settings_after ==='\n"
-        f"$PSQL -c \"SELECT key, length(value) AS bytes FROM settings WHERE key='{SETTING_KEY}';\" </dev/null\n"
+        f"{REDISCLI} PUBLISH settings_updated refresh </dev/null || echo 'WARN: redis PUBLISH failed; replicas reload within the pricing poll interval, not immediately'\n"
     )
     b64 = base64.b64encode(shell.encode()).decode()
     if len(b64) > 90_000:  # headroom under the 97KB SSM SendCommand parameter ceiling
@@ -217,6 +234,9 @@ def cmd_sync_runtime(args) -> int:
     print(out)
     if "UPSERT_OK" not in out:
         fail("UPSERT did not report success — inspect the SSM output above (psql error? guard?)")
+    expected_line = f"{SETTING_KEY}|{expected_len}|{expected_md5}"
+    if expected_line not in out:
+        fail(f"UPSERT read-back mismatch: expected {expected_line!r} in SSM output")
     # Post-sync verify: re-read the settings row (DB truth, not the in-memory replica cache)
     # and confirm it now matches git. Catches a silently-partial/failed write that still
     # returned Success (the SSM stdout-truncation class of bug that motivated this hardening).
@@ -281,9 +301,13 @@ def main() -> int:
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--selftest", action="store_true", help="offline drift-logic test")
     sub = ap.add_subparsers(dest="cmd")
-    sub.add_parser("check", help="read-only drift audit (git vs prod runtime)")
+    cp = sub.add_parser("check", help="read-only drift audit (git vs prod runtime)")
+    cp.add_argument("--overlay-path", default=str(OVERLAY_PATH),
+                    help="pricing overlay JSON to compare (default: repo embedded overlay)")
     sp = sub.add_parser("sync-runtime", help="hot-push repo overlay to prod settings")
     sp.add_argument("--dry-run", action="store_true")
+    sp.add_argument("--overlay-path", default=str(OVERLAY_PATH),
+                    help="pricing overlay JSON to push (default: repo embedded overlay)")
     args = ap.parse_args()
 
     if args.selftest:

--- a/scripts/checks/pricing-overlay.py
+++ b/scripts/checks/pricing-overlay.py
@@ -32,6 +32,7 @@ Exit 0 ok, 1 violation, 2 missing dep / file / unparseable.
 
 from __future__ import annotations
 
+import argparse
 import json
 import pathlib
 import sys
@@ -64,13 +65,21 @@ THINKING_ANCHORS = ("qwen3-8b", "qwen3-14b", "qwen3-32b")
 
 
 def main() -> int:
-    quiet = "--quiet" in sys.argv
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--quiet", action="store_true", help="suppress success output")
+    ap.add_argument("--path", type=pathlib.Path, default=OVERLAY,
+                    help="overlay JSON to validate (default: repo embedded overlay)")
+    args = ap.parse_args()
+    quiet = args.quiet
+    overlay = args.path
+    if not overlay.is_absolute():
+        overlay = REPO_ROOT / overlay
 
-    if not OVERLAY.is_file():
-        print(f"  FAIL: pricing overlay not found: {OVERLAY}", flush=True)
+    if not overlay.is_file():
+        print(f"  FAIL: pricing overlay not found: {overlay}", flush=True)
         return 2
     try:
-        data = json.loads(OVERLAY.read_text(encoding="utf-8"))
+        data = json.loads(overlay.read_text(encoding="utf-8"))
     except (ValueError, OSError) as exc:
         print(f"  FAIL: pricing overlay unparseable: {exc}", flush=True)
         return 2


### PR DESCRIPTION
## 摘要
- 让 `deploy-stage0.yml` 在 prod 镜像切换并通过 external health 后，自动从部署 tag 的 `tk_pricing_overlay.json` 同步 `settings.tk_pricing_overlay_runtime`，再进入 smoke。
- 增强 `manage-overlay-runtime.py`：支持 `--overlay-path`、heredoc 写入、length/md5 回读校验，避免 stale runtime shadow 和 SSM 写入假成功。
- `pricing-overlay.py` 支持 `--path`，release rollout skill 已记录该自动化路径。

## 风险
- 部署流程新增一个 prod runtime settings 同步步骤；失败会在 smoke 前阻断 deploy，避免旧 runtime 价格继续覆盖新 binary。
- rollback 使用目标 tag 的 overlay 文件同步 runtime，避免当前 main 覆盖历史 tag 价格。
- Web impact: none。
- sentinel-registry-reviewed：`scripts/checks/pricing-overlay.py` 仅新增 CLI `--path` 参数，未改变 load-bearing pricing overlay anchors；不需要新增 sentinel。

## 验证
- `bash scripts/preflight.sh`：PASS。
- `python3 ops/pricing/manage-overlay-runtime.py --selftest`：PASS。
- `python3 scripts/checks/pricing-overlay.py --path backend/internal/service/tk_pricing_overlay.json --quiet`：PASS。
- `python3 ops/pricing/manage-overlay-runtime.py sync-runtime --dry-run --overlay-path <tmp overlay>`：PASS。
- `python3 ops/pricing/manage-overlay-runtime.py check`：prod runtime overlay clean，131 == 131。
- `python3 ops/pricing/manage-overlay-runtime.py sync-runtime`：clean 状态幂等，无重复写入。

## 提交
- `5ec2134c0` fix(pricing): sync overlay runtime during prod deploy

最新提交：`5ec2134c0`