### PR TITLE
fix(gateway): 修复 Qwen 非流式 thinking 错误归属

### DIFF
--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
@@ -121,6 +121,9 @@ func tkUpstreamClientInducedRejection(c *gin.Context, clientErrType string) bool
 	if tkOpsIsAccountLevel4xx(combined) {
 		return false
 	}
+	if strings.EqualFold(strings.TrimSpace(clientErrType), "invalid_request_error") {
+		return true
+	}
 	// Structured signal first: the upstream error envelope type.
 	if et := strings.ToLower(strings.TrimSpace(gjson.Get(body, "error.type").String())); et == "invalid_request_error" || et == "request_too_large" {
 		return true

--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
@@ -156,6 +156,19 @@ func TestClassifyOpsUpstreamClientInducedRejectionOwnedByClient(t *testing.T) {
 		require.Equal(t, "client", errorOwner)
 	})
 
+	t.Run("newapi qwen non-streaming thinking validation is client-owned", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		service.SetOpsUpstreamError(c, http.StatusBadRequest,
+			"parameter.enable_thinking must be set to false for non-streaming calls", "")
+
+		phase, errorOwner, _ := classifyOpsErrorLog(c, "invalid_request_error",
+			"parameter.enable_thinking must be set to false for non-streaming calls", "", http.StatusBadRequest)
+
+		require.Equal(t, "request", phase)
+		require.Equal(t, "client", errorOwner)
+	})
+
 	// TK (prod P0 2026-06-06, edge us5): bare "opus" on empty-mapping passthrough
 	// accounts → upstream 404 not_found_error. The gateway returns a client 400
 	// "Unsupported model", but the captured upstream status is still 404; it must
@@ -264,6 +277,7 @@ func TestClassifyOpsGenuineUpstreamErrorsStayProvider(t *testing.T) {
 		{"upstream 403 forbidden", http.StatusForbidden, "forbidden", "upstream_error", http.StatusForbidden},
 		{"account-level 400 organization disabled", http.StatusBadRequest, "This organization has been disabled.", "api_error", http.StatusBadRequest},
 		{"account-level 400 credit balance", http.StatusBadRequest, "Your credit balance is too low to access the API.", "api_error", http.StatusBadRequest},
+		{"account-level invalid request credit balance", http.StatusBadRequest, "Your credit balance is too low to access the API.", "invalid_request_error", http.StatusBadRequest},
 		// A generic 404 that is NOT a model-not-found (no "model" signal) stays provider.
 		{"generic upstream 404 not model-not-found", http.StatusNotFound, "resource not found", "upstream_error", http.StatusBadGateway},
 	}

--- a/backend/internal/service/openai_gateway_bridge_dispatch.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch.go
@@ -43,6 +43,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletionsDispatched(
 	// request so GLM-style adaptors can pick it up. See docs/approved/sticky-routing.md.
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
 	body = rewriteNewAPIBridgeBodyModel(account, body, defaultMappedModel)
+	body = applyNewAPIQwenNonStreamingShape(gjson.GetBytes(body, "model").String(), body)
 	auth := bridgeAuthFromGin(c)
 	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
 	if strings.TrimSpace(in.APIKey) == "" {

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping_test.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping_test.go
@@ -82,3 +82,33 @@ func TestForwardAsChatCompletionsDispatched_RewritesGLMDatedModelBeforeBridge(t 
 		t.Fatalf("bridge body model = %q, want glm-4.7", model)
 	}
 }
+
+func TestForwardAsChatCompletionsDispatched_QwenNonStreamingDisablesThinking(t *testing.T) {
+	oldDispatch := dispatchNewAPIChatCompletions
+	t.Cleanup(func() { dispatchNewAPIChatCompletions = oldDispatch })
+
+	var capturedBody []byte
+	dispatchNewAPIChatCompletions = func(_ context.Context, _ *gin.Context, _ bridge.ChannelContextInput, body []byte) (*bridge.DispatchOutcome, *newapitypes.NewAPIError) {
+		capturedBody = append([]byte(nil), body...)
+		return &bridge.DispatchOutcome{Model: "qwen3-8b"}, nil
+	}
+
+	account := &Account{
+		ID:          60,
+		Platform:    PlatformNewAPI,
+		ChannelType: 17,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{"api_key": "test-key"},
+	}
+	svc := &OpenAIGatewayService{}
+	c, _ := gin.CreateTestContext(nil)
+	body := []byte(`{"model":"qwen3-8b","stream":false,"enable_thinking":true,"messages":[{"role":"user","content":"hi"}]}`)
+
+	_, err := svc.ForwardAsChatCompletionsDispatched(context.Background(), c, account, body, "", "")
+	if err != nil {
+		t.Fatalf("ForwardAsChatCompletionsDispatched: %v", err)
+	}
+	if got := gjson.GetBytes(capturedBody, "enable_thinking"); !got.Exists() || got.Bool() {
+		t.Fatalf("bridge body enable_thinking = %s, want false", got.Raw)
+	}
+}

--- a/backend/internal/service/openai_gateway_bridge_responses_fallback.go
+++ b/backend/internal/service/openai_gateway_bridge_responses_fallback.go
@@ -87,6 +87,38 @@ func isNewAPIResponsesProactiveChatFallbackModel(model string) bool {
 	return false
 }
 
+func isNewAPIQwen3Model(model string) bool {
+	model = strings.TrimSpace(strings.ToLower(model))
+	return !isNewAPIResponsesQwen37PreviewVariant(model) &&
+		(strings.HasPrefix(model, "qwen3-") || strings.HasPrefix(model, "qwen3."))
+}
+
+func normalizeNewAPIQwenNonStreamingPayload(model string, payload map[string]any) {
+	if !isNewAPIQwen3Model(model) || payload == nil {
+		return
+	}
+	if stream, _ := payload["stream"].(bool); stream {
+		return
+	}
+	payload["enable_thinking"] = false
+}
+
+func applyNewAPIQwenNonStreamingShape(model string, body []byte) []byte {
+	if len(body) == 0 || !isNewAPIQwen3Model(model) || gjson.GetBytes(body, "stream").Bool() {
+		return body
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return body
+	}
+	normalizeNewAPIQwenNonStreamingPayload(model, payload)
+	shaped, err := json.Marshal(payload)
+	if err != nil {
+		return body
+	}
+	return shaped
+}
+
 func applyNewAPIResponsesChatFallbackShape(model string, chatBody []byte) []byte {
 	trimmedModel := strings.TrimSpace(strings.ToLower(model))
 	if trimmedModel == "" || len(chatBody) == 0 {
@@ -95,7 +127,7 @@ func applyNewAPIResponsesChatFallbackShape(model string, chatBody []byte) []byte
 
 	requiresStream := isNewAPIResponsesChatFallbackStreamModel(trimmedModel)
 	isQwenPreview := isNewAPIResponsesQwen37PreviewVariant(trimmedModel)
-	isQwen3 := strings.HasPrefix(trimmedModel, "qwen3-") || strings.HasPrefix(trimmedModel, "qwen3.")
+	isQwen3 := isNewAPIQwen3Model(trimmedModel)
 	if !requiresStream && !isQwenPreview && !isQwen3 {
 		return chatBody
 	}
@@ -110,9 +142,8 @@ func applyNewAPIResponsesChatFallbackShape(model string, chatBody []byte) []byte
 	}
 	if isQwenPreview {
 		payload["enable_thinking"] = true
-	} else if isQwen3 {
-		payload["enable_thinking"] = false
 	}
+	normalizeNewAPIQwenNonStreamingPayload(trimmedModel, payload)
 
 	shaped, err := json.Marshal(payload)
 	if err != nil {

--- a/backend/internal/service/openai_gateway_bridge_responses_fallback.go
+++ b/backend/internal/service/openai_gateway_bridge_responses_fallback.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 	"go.uber.org/zap"
 )
 
@@ -107,12 +108,7 @@ func applyNewAPIQwenNonStreamingShape(model string, body []byte) []byte {
 	if len(body) == 0 || !isNewAPIQwen3Model(model) || gjson.GetBytes(body, "stream").Bool() {
 		return body
 	}
-	var payload map[string]any
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return body
-	}
-	normalizeNewAPIQwenNonStreamingPayload(model, payload)
-	shaped, err := json.Marshal(payload)
+	shaped, err := sjson.SetBytes(body, "enable_thinking", false)
 	if err != nil {
 		return body
 	}

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
@@ -526,6 +526,26 @@ func TestApplyNewAPIResponsesChatFallbackShape(t *testing.T) {
 	})
 }
 
+func TestApplyNewAPIQwenNonStreamingShape(t *testing.T) {
+	t.Run("non-streaming qwen disables thinking", func(t *testing.T) {
+		body := []byte(`{"model":"qwen3-8b","stream":false,"enable_thinking":true}`)
+		shaped := applyNewAPIQwenNonStreamingShape("qwen3-8b", body)
+		require.False(t, gjson.GetBytes(shaped, "enable_thinking").Bool())
+	})
+
+	t.Run("streaming qwen preserves thinking", func(t *testing.T) {
+		body := []byte(`{"model":"qwen3-8b","stream":true,"enable_thinking":true}`)
+		shaped := applyNewAPIQwenNonStreamingShape("qwen3-8b", body)
+		require.True(t, gjson.GetBytes(shaped, "enable_thinking").Bool())
+	})
+
+	t.Run("other models remain unchanged", func(t *testing.T) {
+		body := []byte(`{"model":"deepseek-chat","stream":false,"enable_thinking":true}`)
+		shaped := applyNewAPIQwenNonStreamingShape("deepseek-chat", body)
+		require.Equal(t, string(body), string(shaped))
+	})
+}
+
 func forceChatResponsesFallbackAccount() *Account {
 	account := rawChatCompletionsTestAccount()
 	account.Extra = map[string]any{

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
@@ -544,6 +544,13 @@ func TestApplyNewAPIQwenNonStreamingShape(t *testing.T) {
 		shaped := applyNewAPIQwenNonStreamingShape("deepseek-chat", body)
 		require.Equal(t, string(body), string(shaped))
 	})
+
+	t.Run("unrelated large integers retain precision", func(t *testing.T) {
+		body := []byte(`{"model":"qwen3-8b","stream":false,"enable_thinking":true,"tools":[{"function":{"parameters":{"const":9007199254740993}}}]}`)
+		shaped := applyNewAPIQwenNonStreamingShape("qwen3-8b", body)
+		require.False(t, gjson.GetBytes(shaped, "enable_thinking").Bool())
+		require.Equal(t, "9007199254740993", gjson.GetBytes(shaped, "tools.0.function.parameters.const").Raw)
+	})
 }
 
 func forceChatResponsesFallbackAccount() *Account {

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -337,9 +337,10 @@
       "must_contain": [
         "shouldFallbackNewAPIResponsesToChat(apiErr)",
         "forwardResponsesViaNewAPIBridgeChatCompletions",
-        "isNewAPIResponsesProactiveChatFallbackModel(requestedModel)"
+        "isNewAPIResponsesProactiveChatFallbackModel(requestedModel)",
+        "applyNewAPIQwenNonStreamingShape"
       ],
-      "rationale": "NewAPI channels can support /v1/chat/completions while their adaptor does not implement ConvertOpenAIResponsesRequest for /v1/responses (prod probes: Vertex ch41 and DeepSeek ch43). ForwardAsResponsesDispatched must detect that convert_request_failed/not implemented capability gap and route through the Responses->Chat fallback companion instead of returning a client 500. Dropping this injection silently breaks the /v1/responses protocol for chat-capable NewAPI models."
+      "rationale": "NewAPI channels can support /v1/chat/completions while their adaptor does not implement ConvertOpenAIResponsesRequest for /v1/responses (prod probes: Vertex ch41 and DeepSeek ch43). ForwardAsResponsesDispatched must detect that convert_request_failed/not implemented capability gap and route through the Responses->Chat fallback companion instead of returning a client 500. Native chat dispatch must also normalize dense Qwen3 non-streaming requests through applyNewAPIQwenNonStreamingShape; otherwise DashScope rejects enable_thinking with a client-visible 400. Dropping either injection silently breaks a supported NewAPI path."
     },
     {
       "path": "backend/internal/service/openai_gateway_bridge_responses_fallback.go",
@@ -348,11 +349,29 @@
         "dispatchNewAPIChatCompletions",
         "isNewAPIResponsesConvertNotImplemented",
         "applyNewAPIResponsesChatFallbackShape",
+        "normalizeNewAPIQwenNonStreamingPayload",
+        "applyNewAPIQwenNonStreamingShape",
         "bufferChatCompletionsAsResponses",
         "bufferStreamChatCompletionsAsResponses",
         "streamChatCompletionsAsResponses"
       ],
-      "rationale": "TK companion for NewAPI /v1/responses fallback: convert the client Responses request to Chat Completions, dispatch through the NewAPI bridge, then convert the captured Chat response back to Responses JSON/SSE. GLM/Qwen stream-only upstream shaping must buffer SSE into JSON for non-stream clients. Without this file ch41/ch43 regress to new_api_error convert_request_failed even though the same model is servicable through /v1/chat/completions."
+      "rationale": "TK companion for NewAPI /v1/responses fallback: convert the client Responses request to Chat Completions, dispatch through the NewAPI bridge, then convert the captured Chat response back to Responses JSON/SSE. It also owns the shared dense-Qwen3 non-streaming request shape used by native chat dispatch. GLM/Qwen stream-only upstream shaping must buffer SSE into JSON for non-stream clients, while dense Qwen3 must send enable_thinking=false when stream=false. Without this file ch41/ch43 regress to conversion errors or upstream request-validation 400s."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping_test.go",
+      "must_contain": [
+        "TestForwardAsChatCompletionsDispatched_QwenNonStreamingDisablesThinking"
+      ],
+      "rationale": "Full bridge-boundary regression for the production Qwen3 non-streaming failure: a client-supplied enable_thinking=true must reach the NewAPI adaptor as false after model rewrite. This anchors the real dispatch call site rather than only testing the shape helper."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_responses_chat_fallback_test.go",
+      "must_contain": [
+        "TestApplyNewAPIQwenNonStreamingShape",
+        "streaming qwen preserves thinking",
+        "other models remain unchanged"
+      ],
+      "rationale": "Boundary tests for the shared Qwen request-shape owner: normalize only non-streaming dense Qwen3 requests, preserve streaming thinking, and leave unrelated models byte-identical."
     },
     {
       "path": "backend/internal/service/pricing_service.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -369,9 +369,10 @@
       "must_contain": [
         "TestApplyNewAPIQwenNonStreamingShape",
         "streaming qwen preserves thinking",
-        "other models remain unchanged"
+        "other models remain unchanged",
+        "unrelated large integers retain precision"
       ],
-      "rationale": "Boundary tests for the shared Qwen request-shape owner: normalize only non-streaming dense Qwen3 requests, preserve streaming thinking, and leave unrelated models byte-identical."
+      "rationale": "Boundary tests for the shared Qwen request-shape owner: normalize only non-streaming dense Qwen3 requests, preserve streaming thinking, leave unrelated models byte-identical, and patch without rounding large JSON integers elsewhere in the request."
     },
     {
       "path": "backend/internal/service/pricing_service.go",


### PR DESCRIPTION
## 摘要

- NewAPI 原生 `/v1/chat/completions` 对非流式、非 preview 的 Qwen3 请求统一写入 `enable_thinking=false`，避免 DashScope 返回 `parameter.enable_thinking must be set to false for non-streaming calls`。
- `/v1/responses` fallback 与原生 chat 复用同一个 request-shape owner；流式 Qwen 和其他模型保持原样。
- 请求归一化使用 byte-level JSON patch，不解码重编码其他字段，避免大整数精度损失。
- 上游 400 已保留为 `invalid_request_error` 时归为 client request，不再错误计入 provider SLA；账号欠费、组织禁用等 account-level 400 仍保持 provider 归属。
- NewAPI sentinel 同时锚住实现、dispatch 接线与复现测试。`sentinel-registry-reviewed`

## 风险

- 行为变化仅影响 NewAPI 非流式 Qwen3 请求；流式请求、Qwen preview 和其他模型有负向回归保护。
- `R-001` 已闭环：大整数测试证明归一化不会改写无关 JSON 数值。
- 错误归属只复用已有结构化 `invalid_request_error` 信号，并保留 account-level 4xx 优先守卫。
- no-web-impact：仅修改 gateway 请求归一化与 ops attribution，无 Web surface 变化。

## 验证

- `go test -tags=unit ./internal/service -count=1`
- `go test -tags=unit ./internal/handler -count=1`
- `go test ./internal/integration/kiro ./internal/observability/qa ./internal/observability/trajectory -count=1`
- `python3 scripts/sentinels/check-newapi.py`
- `python3 scripts/sentinels/check-kiro.py`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`（PASS）
- prod 保留资源实测：Kiro 账号 69、71 对 `claude-opus-4-8` 均为 `verdict=servable`，未执行账号启停或降容。

## 提交

- `104025f9a fix(gateway): normalize non-streaming Qwen thinking`
- `4ec3ec470 fix(gateway): preserve Qwen request numeric precision`

最新提交：4ec3ec470