### PR TITLE
fix(migrations): 修复 #1353 分区索引迁移阻塞

### DIFF
--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -57,10 +57,39 @@ const paymentOrdersOutTradeNoUniqueIndex = "paymentorder_out_trade_no_unique"
 const schedulerOutboxPendingDedupKeyMigration = "153_scheduler_outbox_pending_dedup_key_index_notx.sql"
 const schedulerOutboxPendingDedupKeyIndex = "idx_scheduler_outbox_pending_dedup_key"
 const opsSystemLogsAPIKeyIDIndexMigration = "155_add_ops_system_logs_api_key_id_index_notx.sql"
+const opsSystemLogsAPIKeyIDIndex = "idx_ops_system_logs_api_key_id_created_at"
 const opsSystemLogsAPIKeyIDIndexDDL = `CREATE INDEX IF NOT EXISTS idx_ops_system_logs_api_key_id_created_at ON ops_system_logs (api_key_id, created_at DESC)`
 const opsMonthlyPartitionsMigration = "tk_041_provision_ops_monthly_partitions.sql"
 const latestAPIKeyIPIndexMigration = "174_add_usage_logs_api_key_latest_ip_index_notx.sql"
 const latestAPIKeyIPIndex = "idx_usage_logs_api_key_latest_ip"
+const opsSystemLogsHostIndexMigration = "175a_add_ops_system_logs_host_index_notx.sql"
+const opsSystemLogsHostIndex = "idx_ops_system_logs_host_created_at"
+const opsSystemLogsHostIndexDDL = `CREATE INDEX IF NOT EXISTS idx_ops_system_logs_host_created_at ON ops_system_logs (host, created_at DESC)`
+
+type nonTransactionalIndexPolicy struct {
+	indexName              string
+	partitionedTable       string
+	partitionedFallbackDDL string
+}
+
+var nonTransactionalIndexPolicies = map[string]nonTransactionalIndexPolicy{
+	schedulerOutboxPendingDedupKeyMigration: {
+		indexName: schedulerOutboxPendingDedupKeyIndex,
+	},
+	opsSystemLogsAPIKeyIDIndexMigration: {
+		indexName:              opsSystemLogsAPIKeyIDIndex,
+		partitionedTable:       "ops_system_logs",
+		partitionedFallbackDDL: opsSystemLogsAPIKeyIDIndexDDL,
+	},
+	latestAPIKeyIPIndexMigration: {
+		indexName: latestAPIKeyIPIndex,
+	},
+	opsSystemLogsHostIndexMigration: {
+		indexName:              opsSystemLogsHostIndex,
+		partitionedTable:       "ops_system_logs",
+		partitionedFallbackDDL: opsSystemLogsHostIndexDDL,
+	},
+}
 
 type migrationChecksumCompatibilityRule struct {
 	fileChecksum       string
@@ -230,40 +259,8 @@ func applyMigrationsFS(ctx context.Context, db *sql.DB, fsys fs.FS) error {
 		}
 
 		if nonTx {
-			if err := prepareNonTransactionalMigration(ctx, db, name); err != nil {
-				return fmt.Errorf("prepare migration %s: %w", name, err)
-			}
-
-			if name == opsSystemLogsAPIKeyIDIndexMigration {
-				partitioned, err := pgpartition.IsPartitioned(ctx, db, "ops_system_logs")
-				if err != nil {
-					return fmt.Errorf("check ops_system_logs partition state for migration %s: %w", name, err)
-				}
-				if partitioned {
-					if _, err := db.ExecContext(ctx, opsSystemLogsAPIKeyIDIndexDDL); err != nil {
-						return fmt.Errorf("apply migration %s (partitioned fallback): %w", name, err)
-					}
-					if _, err := db.ExecContext(ctx, "INSERT INTO schema_migrations (filename, checksum) VALUES ($1, $2)", name, checksum); err != nil {
-						return fmt.Errorf("record migration %s (non-tx): %w", name, err)
-					}
-					continue
-				}
-			}
-
-			// *_notx.sql：用于 CREATE/DROP INDEX CONCURRENTLY 场景，必须非事务执行。
-			// 逐条语句执行，避免将多条 CONCURRENTLY 语句放入同一个隐式事务块。
-			statements := splitSQLStatements(content)
-			for i, stmt := range statements {
-				trimmed := strings.TrimSpace(stmt)
-				if trimmed == "" {
-					continue
-				}
-				if stripSQLLineComment(trimmed) == "" {
-					continue
-				}
-				if _, err := db.ExecContext(ctx, trimmed); err != nil {
-					return fmt.Errorf("apply migration %s (non-tx statement %d): %w", name, i+1, err)
-				}
+			if err := applyNonTransactionalMigration(ctx, db, name, content); err != nil {
+				return err
 			}
 			if _, err := db.ExecContext(ctx, "INSERT INTO schema_migrations (filename, checksum) VALUES ($1, $2)", name, checksum); err != nil {
 				return fmt.Errorf("record migration %s (non-tx): %w", name, err)
@@ -315,17 +312,48 @@ func shouldRecordMigrationWithoutExecution(ctx context.Context, db *sql.DB, name
 	return true, nil
 }
 
+func applyNonTransactionalMigration(ctx context.Context, db *sql.DB, name, content string) error {
+	policy, hasPolicy := nonTransactionalIndexPolicies[name]
+	if hasPolicy && policy.partitionedTable != "" {
+		partitioned, err := pgpartition.IsPartitioned(ctx, db, policy.partitionedTable)
+		if err != nil {
+			return fmt.Errorf("check %s partition state for migration %s: %w", policy.partitionedTable, name, err)
+		}
+		if partitioned {
+			if _, err := db.ExecContext(ctx, policy.partitionedFallbackDDL); err != nil {
+				return fmt.Errorf("apply migration %s (partitioned fallback): %w", name, err)
+			}
+			return nil
+		}
+	}
+
+	if err := prepareNonTransactionalMigration(ctx, db, name); err != nil {
+		return fmt.Errorf("prepare migration %s: %w", name, err)
+	}
+
+	// *_notx.sql migrations run statement-by-statement so PostgreSQL does not
+	// wrap CONCURRENTLY operations in an implicit transaction block.
+	for i, stmt := range splitSQLStatements(content) {
+		trimmed := strings.TrimSpace(stmt)
+		if trimmed == "" || stripSQLLineComment(trimmed) == "" {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, trimmed); err != nil {
+			return fmt.Errorf("apply migration %s (non-tx statement %d): %w", name, i+1, err)
+		}
+	}
+	return nil
+}
+
 func prepareNonTransactionalMigration(ctx context.Context, db *sql.DB, name string) error {
-	switch name {
-	case paymentOrdersOutTradeNoUniqueMigration:
+	if name == paymentOrdersOutTradeNoUniqueMigration {
 		return preparePaymentOrdersOutTradeNoUniqueMigration(ctx, db)
-	case schedulerOutboxPendingDedupKeyMigration:
-		return dropInvalidIndexIfPresent(ctx, db, schedulerOutboxPendingDedupKeyIndex)
-	case latestAPIKeyIPIndexMigration:
-		return dropInvalidIndexIfPresent(ctx, db, latestAPIKeyIPIndex)
-	default:
+	}
+	policy, ok := nonTransactionalIndexPolicies[name]
+	if !ok || policy.indexName == "" {
 		return nil
 	}
+	return dropInvalidIndexIfPresent(ctx, db, policy.indexName)
 }
 
 func preparePaymentOrdersOutTradeNoUniqueMigration(ctx context.Context, db *sql.DB) error {

--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -70,6 +70,7 @@ type nonTransactionalIndexPolicy struct {
 	indexName              string
 	partitionedTable       string
 	partitionedFallbackDDL string
+	partitionedIndexExpr   string
 }
 
 var nonTransactionalIndexPolicies = map[string]nonTransactionalIndexPolicy{
@@ -85,9 +86,9 @@ var nonTransactionalIndexPolicies = map[string]nonTransactionalIndexPolicy{
 		indexName: latestAPIKeyIPIndex,
 	},
 	opsSystemLogsHostIndexMigration: {
-		indexName:              opsSystemLogsHostIndex,
-		partitionedTable:       "ops_system_logs",
-		partitionedFallbackDDL: opsSystemLogsHostIndexDDL,
+		indexName:            opsSystemLogsHostIndex,
+		partitionedTable:     "ops_system_logs",
+		partitionedIndexExpr: "host, created_at DESC",
 	},
 }
 
@@ -320,6 +321,12 @@ func applyNonTransactionalMigration(ctx context.Context, db *sql.DB, name, conte
 			return fmt.Errorf("check %s partition state for migration %s: %w", policy.partitionedTable, name, err)
 		}
 		if partitioned {
+			if policy.partitionedIndexExpr != "" {
+				if err := createPartitionedIndexConcurrently(ctx, db, policy); err != nil {
+					return fmt.Errorf("apply migration %s (partitioned online index): %w", name, err)
+				}
+				return nil
+			}
 			if _, err := db.ExecContext(ctx, policy.partitionedFallbackDDL); err != nil {
 				return fmt.Errorf("apply migration %s (partitioned fallback): %w", name, err)
 			}

--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -64,7 +64,6 @@ const latestAPIKeyIPIndexMigration = "174_add_usage_logs_api_key_latest_ip_index
 const latestAPIKeyIPIndex = "idx_usage_logs_api_key_latest_ip"
 const opsSystemLogsHostIndexMigration = "175a_add_ops_system_logs_host_index_notx.sql"
 const opsSystemLogsHostIndex = "idx_ops_system_logs_host_created_at"
-const opsSystemLogsHostIndexDDL = `CREATE INDEX IF NOT EXISTS idx_ops_system_logs_host_created_at ON ops_system_logs (host, created_at DESC)`
 
 type nonTransactionalIndexPolicy struct {
 	indexName              string

--- a/backend/internal/repository/migrations_runner_notx_test.go
+++ b/backend/internal/repository/migrations_runner_notx_test.go
@@ -317,6 +317,81 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ops_system_logs_api_key_id_created_a
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestApplyMigrationsFS_OpsSystemLogsHostIndex_UsesBlockingIndexOnPartitionedTable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	prepareMigrationsBootstrapExpectations(mock)
+	mock.ExpectQuery("SELECT checksum FROM schema_migrations WHERE filename = \\$1").
+		WithArgs(opsSystemLogsHostIndexMigration).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("pg_partitioned_table").
+		WithArgs("ops_system_logs").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_ops_system_logs_host_created_at ON ops_system_logs \\(host, created_at DESC\\)").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO schema_migrations \\(filename, checksum\\) VALUES \\(\\$1, \\$2\\)").
+		WithArgs(opsSystemLogsHostIndexMigration, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("SELECT pg_advisory_unlock\\(\\$1\\)").
+		WithArgs(migrationsAdvisoryLockID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	fsys := fstest.MapFS{
+		opsSystemLogsHostIndexMigration: &fstest.MapFile{
+			Data: []byte(`
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ops_system_logs_host_created_at
+  ON ops_system_logs (host, created_at DESC);
+`),
+		},
+	}
+
+	err = applyMigrationsFS(context.Background(), db, fsys)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestApplyMigrationsFS_OpsSystemLogsHostIndex_DropsInvalidIndexBeforeNonPartitionedRetry(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	prepareMigrationsBootstrapExpectations(mock)
+	mock.ExpectQuery("SELECT checksum FROM schema_migrations WHERE filename = \\$1").
+		WithArgs(opsSystemLogsHostIndexMigration).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("pg_partitioned_table").
+		WithArgs("ops_system_logs").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectQuery("SELECT EXISTS \\(").
+		WithArgs(opsSystemLogsHostIndex).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec("DROP INDEX CONCURRENTLY IF EXISTS idx_ops_system_logs_host_created_at").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ops_system_logs_host_created_at").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO schema_migrations \\(filename, checksum\\) VALUES \\(\\$1, \\$2\\)").
+		WithArgs(opsSystemLogsHostIndexMigration, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("SELECT pg_advisory_unlock\\(\\$1\\)").
+		WithArgs(migrationsAdvisoryLockID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	fsys := fstest.MapFS{
+		opsSystemLogsHostIndexMigration: &fstest.MapFile{
+			Data: []byte(`
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ops_system_logs_host_created_at
+  ON ops_system_logs (host, created_at DESC);
+`),
+		},
+	}
+
+	err = applyMigrationsFS(context.Background(), db, fsys)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestApplyMigrationsFS_TransactionalMigration(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/backend/internal/repository/migrations_runner_notx_test.go
+++ b/backend/internal/repository/migrations_runner_notx_test.go
@@ -317,7 +317,7 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ops_system_logs_api_key_id_created_a
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestApplyMigrationsFS_OpsSystemLogsHostIndex_UsesBlockingIndexOnPartitionedTable(t *testing.T) {
+func TestApplyMigrationsFS_OpsSystemLogsHostIndex_BuildsPartitionIndexesConcurrently(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
@@ -329,8 +329,39 @@ func TestApplyMigrationsFS_OpsSystemLogsHostIndex_UsesBlockingIndexOnPartitioned
 	mock.ExpectQuery("pg_partitioned_table").
 		WithArgs("ops_system_logs").
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
-	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_ops_system_logs_host_created_at ON ops_system_logs \\(host, created_at DESC\\)").
+	mock.ExpectQuery("SELECT i.indisvalid").
+		WithArgs("public", opsSystemLogsHostIndex).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT child_ns.nspname, child.relname, child.oid").
+		WithArgs("ops_system_logs").
+		WillReturnRows(sqlmock.NewRows([]string{"nspname", "relname", "oid"}).
+			AddRow("public", "ops_system_logs_legacy", 41001).
+			AddRow("public", "ops_system_logs_202608", 41002))
+	mock.ExpectQuery("SELECT i.indisvalid").
+		WithArgs("public", "idx_ops_system_logs_host_created_at_p41001").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectExec(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_ops_system_logs_host_created_at_p41001" ON "public"\."ops_system_logs_legacy" \(host, created_at DESC\)`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT i.indisvalid").
+		WithArgs("public", "idx_ops_system_logs_host_created_at_p41002").
+		WillReturnRows(sqlmock.NewRows([]string{"indisvalid"}).AddRow(false))
+	mock.ExpectExec(`DROP INDEX CONCURRENTLY IF EXISTS "public"\."idx_ops_system_logs_host_created_at_p41002"`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_ops_system_logs_host_created_at_p41002" ON "public"\."ops_system_logs_202608" \(host, created_at DESC\)`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`CREATE INDEX IF NOT EXISTS "idx_ops_system_logs_host_created_at" ON ONLY "ops_system_logs" \(host, created_at DESC\)`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT EXISTS \\(").
+		WithArgs("idx_ops_system_logs_host_created_at", "idx_ops_system_logs_host_created_at_p41001").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectExec(`ALTER INDEX "idx_ops_system_logs_host_created_at" ATTACH PARTITION "public"\."idx_ops_system_logs_host_created_at_p41001"`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT EXISTS \\(").
+		WithArgs("idx_ops_system_logs_host_created_at", "idx_ops_system_logs_host_created_at_p41002").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery("SELECT i.indisvalid").
+		WithArgs("public", opsSystemLogsHostIndex).
+		WillReturnRows(sqlmock.NewRows([]string{"indisvalid"}).AddRow(true))
 	mock.ExpectExec("INSERT INTO schema_migrations \\(filename, checksum\\) VALUES \\(\\$1, \\$2\\)").
 		WithArgs(opsSystemLogsHostIndexMigration, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))

--- a/backend/internal/repository/migrations_runner_tk_partitioned_index.go
+++ b/backend/internal/repository/migrations_runner_tk_partitioned_index.go
@@ -1,0 +1,168 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/lib/pq"
+)
+
+type tablePartition struct {
+	schema string
+	name   string
+	oid    uint32
+}
+
+func createPartitionedIndexConcurrently(ctx context.Context, db *sql.DB, policy nonTransactionalIndexPolicy) error {
+	valid, err := qualifiedIndexIsValid(ctx, db, "public", policy.indexName)
+	if err != nil {
+		return err
+	}
+	if valid {
+		return nil
+	}
+
+	partitions, err := listTablePartitions(ctx, db, policy.partitionedTable)
+	if err != nil {
+		return err
+	}
+
+	for _, partition := range partitions {
+		childIndex := fmt.Sprintf("%s_p%d", policy.indexName, partition.oid)
+		invalid, err := qualifiedIndexIsInvalid(ctx, db, partition.schema, childIndex)
+		if err != nil {
+			return err
+		}
+		qualifiedIndex := pq.QuoteIdentifier(partition.schema) + "." + pq.QuoteIdentifier(childIndex)
+		if invalid {
+			if _, err := db.ExecContext(ctx, "DROP INDEX CONCURRENTLY IF EXISTS "+qualifiedIndex); err != nil {
+				return fmt.Errorf("drop invalid partition index %s: %w", childIndex, err)
+			}
+		}
+		createDDL := fmt.Sprintf(
+			"CREATE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s.%s (%s)",
+			pq.QuoteIdentifier(childIndex),
+			pq.QuoteIdentifier(partition.schema),
+			pq.QuoteIdentifier(partition.name),
+			policy.partitionedIndexExpr,
+		)
+		if _, err := db.ExecContext(ctx, createDDL); err != nil {
+			return fmt.Errorf("create partition index %s: %w", childIndex, err)
+		}
+	}
+
+	parentDDL := fmt.Sprintf(
+		"CREATE INDEX IF NOT EXISTS %s ON ONLY %s (%s)",
+		pq.QuoteIdentifier(policy.indexName),
+		pq.QuoteIdentifier(policy.partitionedTable),
+		policy.partitionedIndexExpr,
+	)
+	if _, err := db.ExecContext(ctx, parentDDL); err != nil {
+		return fmt.Errorf("create partitioned parent index %s: %w", policy.indexName, err)
+	}
+
+	for _, partition := range partitions {
+		childIndex := fmt.Sprintf("%s_p%d", policy.indexName, partition.oid)
+		attached, err := partitionIndexIsAttached(ctx, db, policy.indexName, childIndex)
+		if err != nil {
+			return err
+		}
+		if attached {
+			continue
+		}
+		attachDDL := fmt.Sprintf(
+			"ALTER INDEX %s ATTACH PARTITION %s.%s",
+			pq.QuoteIdentifier(policy.indexName),
+			pq.QuoteIdentifier(partition.schema),
+			pq.QuoteIdentifier(childIndex),
+		)
+		if _, err := db.ExecContext(ctx, attachDDL); err != nil {
+			return fmt.Errorf("attach partition index %s: %w", childIndex, err)
+		}
+	}
+
+	valid, err = qualifiedIndexIsValid(ctx, db, "public", policy.indexName)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return fmt.Errorf("partitioned parent index %s remains invalid after attaching all known partitions", policy.indexName)
+	}
+	return nil
+}
+
+func listTablePartitions(ctx context.Context, db *sql.DB, table string) ([]tablePartition, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT child_ns.nspname, child.relname, child.oid
+		FROM pg_inherits inheritance
+		JOIN pg_class parent ON parent.oid = inheritance.inhparent
+		JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+		JOIN pg_class child ON child.oid = inheritance.inhrelid
+		JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
+		WHERE parent_ns.nspname = current_schema() AND parent.relname = $1
+		ORDER BY child.oid`, table)
+	if err != nil {
+		return nil, fmt.Errorf("list partitions for %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var partitions []tablePartition
+	for rows.Next() {
+		var partition tablePartition
+		if err := rows.Scan(&partition.schema, &partition.name, &partition.oid); err != nil {
+			return nil, fmt.Errorf("scan partition for %s: %w", table, err)
+		}
+		partitions = append(partitions, partition)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate partitions for %s: %w", table, err)
+	}
+	if len(partitions) == 0 {
+		return nil, fmt.Errorf("partitioned table %s has no partitions", table)
+	}
+	return partitions, nil
+}
+
+func qualifiedIndexIsInvalid(ctx context.Context, db *sql.DB, schema, index string) (bool, error) {
+	valid, exists, err := qualifiedIndexState(ctx, db, schema, index)
+	return exists && !valid, err
+}
+
+func qualifiedIndexIsValid(ctx context.Context, db *sql.DB, schema, index string) (bool, error) {
+	valid, exists, err := qualifiedIndexState(ctx, db, schema, index)
+	return exists && valid, err
+}
+
+func qualifiedIndexState(ctx context.Context, db *sql.DB, schema, index string) (valid, exists bool, err error) {
+	err = db.QueryRowContext(ctx, `
+		SELECT i.indisvalid
+		FROM pg_index i
+		JOIN pg_class c ON c.oid = i.indexrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = $1 AND c.relname = $2`, schema, index).Scan(&valid)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, fmt.Errorf("check index %s.%s: %w", schema, index, err)
+	}
+	return valid, true, nil
+}
+
+func partitionIndexIsAttached(ctx context.Context, db *sql.DB, parentIndex, childIndex string) (bool, error) {
+	var attached bool
+	err := db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_inherits inheritance
+			JOIN pg_class parent ON parent.oid = inheritance.inhparent
+			JOIN pg_class child ON child.oid = inheritance.inhrelid
+			WHERE parent.relname = $1 AND child.relname = $2
+		)`, parentIndex, childIndex).Scan(&attached)
+	if err != nil {
+		return false, fmt.Errorf("check partition index attachment %s -> %s: %w", childIndex, parentIndex, err)
+	}
+	return attached, nil
+}

--- a/backend/internal/repository/pgpartition_integration_test.go
+++ b/backend/internal/repository/pgpartition_integration_test.go
@@ -48,6 +48,56 @@ func TestPgPartition_OpsSystemLogsConvertedByMigration(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCreatePartitionedIndexConcurrently_AttachesEveryPartitionAndRetries(t *testing.T) {
+	ctx := context.Background()
+	table := "pgpart_itest_online_index"
+	parentIndex := "idx_pgpart_itest_online_host_created"
+	qTable := pq.QuoteIdentifier(table)
+	_, _ = integrationDB.ExecContext(ctx, "DROP TABLE IF EXISTS "+qTable+" CASCADE")
+	t.Cleanup(func() {
+		_, _ = integrationDB.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+qTable+" CASCADE")
+	})
+
+	_, err := integrationDB.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (host TEXT, created_at TIMESTAMPTZ NOT NULL) PARTITION BY RANGE (created_at);
+		CREATE TABLE %s PARTITION OF %s FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
+		CREATE TABLE %s PARTITION OF %s FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
+		INSERT INTO %s VALUES ('edge-a', '2026-01-15'), ('edge-b', '2026-02-15');`,
+		qTable,
+		pq.QuoteIdentifier(table+"_p1"), qTable,
+		pq.QuoteIdentifier(table+"_p2"), qTable,
+		qTable,
+	))
+	require.NoError(t, err)
+
+	policy := nonTransactionalIndexPolicy{
+		indexName:            parentIndex,
+		partitionedTable:     table,
+		partitionedIndexExpr: "host, created_at DESC",
+	}
+	require.NoError(t, createPartitionedIndexConcurrently(ctx, integrationDB, policy))
+	// A second run covers interrupted rollout retries after all child indexes are attached.
+	require.NoError(t, createPartitionedIndexConcurrently(ctx, integrationDB, policy))
+
+	var valid bool
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT i.indisvalid
+		FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+		WHERE c.relname = $1`, parentIndex).Scan(&valid))
+	require.True(t, valid)
+
+	var tablePartitions, indexPartitions int
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT count(*) FROM pg_inherits i
+		JOIN pg_class parent ON parent.oid = i.inhparent
+		WHERE parent.relname = $1`, table).Scan(&tablePartitions))
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT count(*) FROM pg_inherits i
+		JOIN pg_class parent ON parent.oid = i.inhparent
+		WHERE parent.relname = $1`, parentIndex).Scan(&indexPartitions))
+	require.Equal(t, tablePartitions, indexPartitions)
+}
+
 // TestPgPartition_EnsureMonthlySkipsLegacyOverlap mirrors the post-conversion state: a
 // wide legacy partition covers everything up to next month, so EnsureMonthly's current
 // month overlaps it (42P17) and must be skipped while future months are still created.

--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -102,3 +102,31 @@ restores the file and removes the entry in the same change.
   should be taken as-is from upstream. Delete this entry once the merge is on
   `main` and `git diff --diff-filter=D upstream/main..HEAD -- backend/` no
   longer lists it.
+
+## frontend/src/components/account/__tests__/CreateAccountModal.grok.spec.ts
+
+- **Upstream path:**
+  `frontend/src/components/account/__tests__/CreateAccountModal.grok.spec.ts`.
+- **Deletion commit + PR:** `3fa27f851ca7149560e4dcfec7baf065aabcad9d`
+  — "fix(upstream): address R-001..R-002 — restore Grok OAuth create wiring",
+  landed via [PR #1353](https://github.com/youxuanxue/sub2api/pull/1353).
+- **Reason:** the file read `CreateAccountModal.vue` as text and asserted that
+  selected strings and call counts existed. Those assertions passed while the
+  Grok header override UI was unreachable in TokenKey's canonical direct
+  refresh-token flow and while that submit path silently dropped the custom
+  upstream configuration. The replacement tests mount the component and prove
+  both credential persistence and protected-header rejection in
+  `frontend/src/components/account/__tests__/CreateAccountModal.spec.ts`.
+- **Regression cost:** a future upstream merge may resurrect the source-text
+  test and create false confidence without failing compilation or CI. The Grok
+  sentinel registry therefore anchors the mounted behavior test names plus the
+  validation and credential-application call sites.
+- **Upstream tests lost:** three source-text assertions covering API-key setup
+  strings, OAuth custom-upstream strings, and raw invocation counts. Their
+  useful intent is retained by the mounted behavior tests and existing Grok
+  account-type coverage; only the existence-only implementation assertions are
+  intentionally discarded.
+- **Re-adopt when:** upstream replaces this file with mounted component tests
+  that exercise the direct refresh-token journey and assert the submitted
+  credentials. Merge those behavioral cases into the shared modal spec and
+  remove this ledger entry; do not re-adopt the source-text version.

--- a/docs/agent_integration.md
+++ b/docs/agent_integration.md
@@ -340,7 +340,6 @@ Do not hand-edit this file; run `python3 scripts/export_agent_contract.py`.
 - `DELETE /keys/:id` from `backend/internal/server/routes/user.go`
 - `GET /keys/:id` from `backend/internal/server/routes/user.go`
 - `PUT /keys/:id` from `backend/internal/server/routes/user.go`
-- `GET /payment/channels` from `backend/internal/server/routes/payment.go`
 - `GET /payment/checkout-info` from `backend/internal/server/routes/payment.go`
 - `GET /payment/config` from `backend/internal/server/routes/payment.go`
 - `GET /payment/limits` from `backend/internal/server/routes/payment.go`

--- a/scripts/export_agent_contract.py
+++ b/scripts/export_agent_contract.py
@@ -26,7 +26,7 @@ the soft count warning noisy, implement a Go AST walker or runtime route dump.
 
 # What this script DOES enforce today
 
-Three cheap, high-signal contract guards that catch the regressions we
+Four cheap, high-signal contract guards that catch the regressions we
 have actually seen:
 
   A) **Notes-section coverage**: every TokenKey first-class platform
@@ -47,12 +47,18 @@ have actually seen:
      soft signal, not a hard fail — the prefix-resolution debt makes
      hard-fail premature.
 
+  D) **Retired-route tombstones**: security-sensitive contract removals are
+     registered once with their source literal and replacement. Generation
+     removes stale inventory bullets; `--check` hard-fails if either the
+     documentation or the cited source resurrects a retired route.
+
 Usage::
 
     python3 scripts/export_agent_contract.py            # refresh CLI section
     python3 scripts/export_agent_contract.py --check    # CI drift gate
 
-`--check` exits 1 on Notes coverage or CLI projection drift; the count
+`--check` exits 1 on Notes coverage, generated projection drift, or retired
+route resurrection; the count
 warning (C) never blocks. This is intentional: route docs lag by a
 few PRs in healthy projects, and we do not want the gate so strict that
 it becomes the thing devs route around. We reserve hard-fail for "doc
@@ -79,6 +85,11 @@ HANDLE_PATTERN = re.compile(
     r'\b\w+\.Handle\(\s*"(?:' + "|".join(HTTP_VERBS) + r')"\s*,'
 )
 DOC_BULLET = re.compile(r"^- `(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) ", re.MULTILINE)
+DOC_ROUTE_BULLET = re.compile(
+    r"^- `(?P<method>GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) "
+    r"(?P<path>[^`]+)` from `(?P<source>[^`]+)`\n?",
+    re.MULTILINE,
+)
 NOTES_MARKER = "# Agent Contract Notes"
 CLI_START_MARKER = "## CLI"
 CLI_END_MARKER = "## MCP"
@@ -96,6 +107,18 @@ CLI_ENTRYPOINTS = (
 #   PlatformGrok).
 REQUIRED_PLATFORMS = ("openai", "anthropic", "gemini", "antigravity", "newapi", "kiro", "grok")
 
+# Public contracts intentionally removed for security or compatibility reasons.
+# The source literal is the leaf path used inside its Gin route group.
+RETIRED_HTTP_ROUTES = (
+    {
+        "method": "GET",
+        "path": "/payment/channels",
+        "source": "backend/internal/server/routes/payment.go",
+        "source_literal": "/channels",
+        "replacement": "/payment/checkout-info",
+    },
+)
+
 COUNT_TOLERANCE = 0.10  # ±10% considered noise
 
 
@@ -112,6 +135,51 @@ def count_source_registrations() -> int:
 
 def count_doc_bullets(doc: str) -> int:
     return len(DOC_BULLET.findall(doc))
+
+
+def prune_retired_route_bullets(
+    doc: str, retired_routes: Iterable[dict[str, str]] = RETIRED_HTTP_ROUTES
+) -> str:
+    retired = {(route["method"], route["path"]) for route in retired_routes}
+
+    def replace(match: re.Match[str]) -> str:
+        key = (match.group("method"), match.group("path"))
+        return "" if key in retired else match.group(0)
+
+    return DOC_ROUTE_BULLET.sub(replace, doc)
+
+
+def find_retired_route_bullets(
+    doc: str, retired_routes: Iterable[dict[str, str]] = RETIRED_HTTP_ROUTES
+) -> list[dict[str, str]]:
+    documented = {
+        (match.group("method"), match.group("path"))
+        for match in DOC_ROUTE_BULLET.finditer(doc)
+    }
+    return [
+        route
+        for route in retired_routes
+        if (route["method"], route["path"]) in documented
+    ]
+
+
+def find_retired_source_registrations(
+    repo_root: Path = REPO_ROOT,
+    retired_routes: Iterable[dict[str, str]] = RETIRED_HTTP_ROUTES,
+) -> list[dict[str, str]]:
+    resurrected: list[dict[str, str]] = []
+    for route in retired_routes:
+        source_path = repo_root / route["source"]
+        if not source_path.exists():
+            continue
+        source = source_path.read_text(encoding="utf-8")
+        method = re.escape(route["method"])
+        literal = re.escape(route["source_literal"])
+        direct = re.compile(rf'\.{method}\(\s*"{literal}"')
+        handle = re.compile(rf'\.Handle\(\s*"{method}"\s*,\s*"{literal}"')
+        if direct.search(source) or handle.search(source):
+            resurrected.append(route)
+    return resurrected
 
 
 def check_notes_coverage(doc: str, required: Iterable[str]) -> list[str]:
@@ -260,21 +328,33 @@ def main() -> int:
         return 1
 
     doc = DOC_PATH.read_text(encoding="utf-8")
+    resurrected_routes = find_retired_source_registrations()
+    if resurrected_routes:
+        for route in resurrected_routes:
+            sys.stderr.write(
+                f"FAIL: retired route was re-registered in {route['source']}: "
+                f"{route['method']} {route['path']}; replacement is "
+                f"{route['replacement']}.\n"
+            )
+        return 1
     try:
-        expected_doc = replace_cli_contract(doc, render_cli_contract())
+        expected_doc = prune_retired_route_bullets(
+            replace_cli_contract(doc, render_cli_contract())
+        )
     except RuntimeError as e:
         sys.stderr.write(f"FAIL: {e}\n")
         return 1
-    cli_drift = expected_doc != doc
-    if cli_drift and args.check:
+    generated_drift = expected_doc != doc
+    stale_retired_routes = find_retired_route_bullets(doc)
+    if generated_drift and args.check:
         sys.stderr.write(
-            "FAIL: generated CLI contract drifted. "
+            "FAIL: generated agent contract drifted. "
             "Run: python3 scripts/export_agent_contract.py\n"
         )
-    elif cli_drift:
+    elif generated_drift:
         DOC_PATH.write_text(expected_doc, encoding="utf-8")
         doc = expected_doc
-        print("updated docs/agent_integration.md CLI contract")
+        print("updated docs/agent_integration.md generated contract")
     src_count = count_source_registrations()
     doc_count = count_doc_bullets(doc)
     missing = check_notes_coverage(doc, REQUIRED_PLATFORMS)
@@ -303,7 +383,16 @@ def main() -> int:
         )
         return 1
 
-    if cli_drift and args.check:
+    if stale_retired_routes and args.check:
+        for route in stale_retired_routes:
+            sys.stderr.write(
+                f"FAIL: retired route remains in agent contract: "
+                f"{route['method']} {route['path']}; replacement is "
+                f"{route['replacement']}.\n"
+            )
+        return 1
+
+    if generated_drift and args.check:
         return 1
 
     if args.check:

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4986,6 +4986,24 @@
         "x-stainless-lang"
       ],
       "rationale": "Focused regressions: OAuth passthrough must preserve client UA/anthropic-beta and must NOT inject OAuth fingerprint headers on the forward path."
+    },
+    {
+      "path": "backend/internal/repository/migrations_runner.go",
+      "must_contain": [
+        "opsSystemLogsHostIndexMigration = \"175a_add_ops_system_logs_host_index_notx.sql\"",
+        "partitionedFallbackDDL: opsSystemLogsHostIndexDDL",
+        "applyNonTransactionalMigration(ctx, db, name, content)",
+        "return dropInvalidIndexIfPresent(ctx, db, policy.indexName)"
+      ],
+      "rationale": "PR #1353 added a host index migration using CREATE INDEX CONCURRENTLY, but prod ops_system_logs is a partitioned PostgreSQL parent where CONCURRENTLY is rejected. The shared non-transactional index policy must keep the 175a filename mapped to a blocking parent-index fallback, while non-partitioned deployments must drop an invalid interrupted index before retrying. Losing either hook makes the next prod rollout fail at startup or record a no-op retry as successful."
+    },
+    {
+      "path": "backend/internal/repository/migrations_runner_notx_test.go",
+      "must_contain": [
+        "TestApplyMigrationsFS_OpsSystemLogsHostIndex_UsesBlockingIndexOnPartitionedTable",
+        "TestApplyMigrationsFS_OpsSystemLogsHostIndex_DropsInvalidIndexBeforeNonPartitionedRetry"
+      ],
+      "rationale": "Behavioral regression coverage for the 175a migration on both live shapes: TokenKey prod's partitioned ops_system_logs parent must use the blocking fallback, and a non-partitioned interrupted concurrent build must remove the invalid index before retrying."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4991,19 +4991,39 @@
       "path": "backend/internal/repository/migrations_runner.go",
       "must_contain": [
         "opsSystemLogsHostIndexMigration = \"175a_add_ops_system_logs_host_index_notx.sql\"",
-        "partitionedFallbackDDL: opsSystemLogsHostIndexDDL",
+        "partitionedIndexExpr: \"host, created_at DESC\"",
+        "createPartitionedIndexConcurrently(ctx, db, policy)",
         "applyNonTransactionalMigration(ctx, db, name, content)",
         "return dropInvalidIndexIfPresent(ctx, db, policy.indexName)"
       ],
-      "rationale": "PR #1353 added a host index migration using CREATE INDEX CONCURRENTLY, but prod ops_system_logs is a partitioned PostgreSQL parent where CONCURRENTLY is rejected. The shared non-transactional index policy must keep the 175a filename mapped to a blocking parent-index fallback, while non-partitioned deployments must drop an invalid interrupted index before retrying. Losing either hook makes the next prod rollout fail at startup or record a no-op retry as successful."
+      "rationale": "The upstream-shared migration runner owns only the declarative 175a policy and one thin call site. The TokenKey online partition-index implementation stays in a companion file to minimize upstream conflict surface while retaining invalid-index cleanup for non-partitioned deployments."
     },
     {
       "path": "backend/internal/repository/migrations_runner_notx_test.go",
       "must_contain": [
-        "TestApplyMigrationsFS_OpsSystemLogsHostIndex_UsesBlockingIndexOnPartitionedTable",
+        "TestApplyMigrationsFS_OpsSystemLogsHostIndex_BuildsPartitionIndexesConcurrently",
         "TestApplyMigrationsFS_OpsSystemLogsHostIndex_DropsInvalidIndexBeforeNonPartitionedRetry"
       ],
-      "rationale": "Behavioral regression coverage for the 175a migration on both live shapes: TokenKey prod's partitioned ops_system_logs parent must use the blocking fallback, and a non-partitioned interrupted concurrent build must remove the invalid index before retrying."
+      "rationale": "Behavioral regression coverage for both live shapes: TokenKey prod partitioned ops_system_logs parent must use the online child-build/attach path, and a non-partitioned interrupted concurrent build must remove an invalid index before retrying."
+    },
+    {
+      "path": "backend/internal/repository/pgpartition_integration_test.go",
+      "must_contain": [
+        "TestCreatePartitionedIndexConcurrently_AttachesEveryPartitionAndRetries",
+        "createPartitionedIndexConcurrently(ctx, integrationDB, policy)",
+        "require.Equal(t, tablePartitions, indexPartitions)"
+      ],
+      "rationale": "Real PostgreSQL coverage proves the online partition-index sequence produces a valid parent, attaches one index per table partition, and remains idempotent on retry; sqlmock alone cannot validate PostgreSQL partitioned-index state transitions."
+    },
+    {
+      "path": "backend/internal/repository/migrations_runner_tk_partitioned_index.go",
+      "must_contain": [
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s.%s (%s)",
+        "CREATE INDEX IF NOT EXISTS %s ON ONLY %s (%s)",
+        "ALTER INDEX %s ATTACH PARTITION %s.%s",
+        "partitioned parent index %s remains invalid"
+      ],
+      "rationale": "Prod ops_system_logs is a 12 GB partitioned parent. The companion must build child indexes concurrently, create the metadata-only parent, attach all children, and refuse to record an invalid parent; replacing it with a recursive blocking CREATE INDEX can stall production writes."
     }
   ]
 }

--- a/scripts/test_export_agent_contract.py
+++ b/scripts/test_export_agent_contract.py
@@ -1,0 +1,41 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import export_agent_contract
+
+
+class RetiredRouteContractTest(unittest.TestCase):
+    def test_prune_retired_route_removes_only_tombstoned_bullet(self) -> None:
+        doc = """\
+- `GET /payment/channels` from `stale/generated/source.go`
+- `GET /payment/checkout-info` from `backend/internal/server/routes/payment.go`
+"""
+
+        self.assertEqual(
+            export_agent_contract.prune_retired_route_bullets(doc),
+            "- `GET /payment/checkout-info` from `backend/internal/server/routes/payment.go`\n",
+        )
+
+    def test_source_registration_of_retired_route_is_rejected(self) -> None:
+        route = {
+            "method": "GET",
+            "path": "/payment/channels",
+            "source": "routes/payment.go",
+            "source_literal": "/channels",
+            "replacement": "/payment/checkout-info",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / route["source"]
+            source.parent.mkdir(parents=True)
+            source.write_text('authenticated.GET("/channels", handler)\n', encoding="utf-8")
+
+            self.assertEqual(
+                export_agent_contract.find_retired_source_registrations(root, (route,)),
+                [route],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- 修复 PR #1353 的 `175a_add_ops_system_logs_host_index_notx.sql` 在 prod 分区父表上执行 `CREATE INDEX CONCURRENTLY` 必然失败的问题。
- 分区环境改为在线索引流程：逐子分区 `CREATE INDEX CONCURRENTLY`，创建 `ON ONLY` 父索引，再逐个 `ATTACH PARTITION`；只有父索引 `indisvalid=true` 后才记录 migration 成功。
- 非分区环境保留原始 concurrent migration，并在重试前清理失败留下的 invalid index。
- 为 `/payment/channels` 建立退休契约 tombstone，生成器清理旧文档条目并硬拦源码复活；支持入口保持为 `/payment/checkout-info`。
- 补齐 PR #1353 的 upstream 删除 ledger，并用 semantic sentinel 锚住 migration policy、在线 companion、行为测试与真实 PostgreSQL 集成测试。

`upstream-touch-guarded`
`contract-deletion-notice`

## 风险

- 高风险 migration runner 修复。prod 只读核查确认 PostgreSQL `18.4`，`ops_system_logs` 是分区父表，2 个分区约 `12 GB / 830 万行`；PR #1353 migrations 当前尚未在线上执行。
- 不再使用递归 blocking parent `CREATE INDEX`，避免在 12 GB 表上长时间阻塞写入。子分区 concurrent build 仍会消耗数据库 I/O/CPU，`ON ONLY` 与 `ATTACH PARTITION` 会获取短暂元数据锁，发布时需继续观察数据库负载和 migration 日志。
- 在线流程支持三类中断重试：invalid child index、部分 child 已 attach、父索引已 valid 但 migration 尚未记账。
- 实现位于 `migrations_runner_tk_partitioned_index.go` companion，共享 upstream runner 只保留声明式 policy 与薄调用点。
- `/payment/channels` 不恢复：该接口会泄露内部渠道配置。prod 最近 24 小时 `176,834` 个完成请求中调用数为 0，前端已使用 `/payment/checkout-info`。

## 验证

- `go -C backend test ./internal/repository -run 'Migration|Migrations|PartitionedIndex' -count=1`
- `go -C backend test ./migrations -count=1`
- `go -C backend test -tags=unit ./... -count=1`
- `TESTCONTAINERS_RYUK_DISABLED=true DOCKER_HOST=unix://$HOME/.colima/default/docker.sock go -C backend test -tags=integration ./... -count=1`
- 真实 PostgreSQL 18：`TestCreatePartitionedIndexConcurrently_AttachesEveryPartitionAndRetries` 通过，父索引 valid、index partition 数与 table partition 数一致，二次执行幂等。
- `python3 -m unittest scripts.test_export_agent_contract`
- `python3 scripts/export_agent_contract.py --check`
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run --concurrency=4 --timeout=30m`：`0 issues`。
- xj-review pipeline：preflight failures `0`，warn candidates `0`，medium+ findings `0`。

## 迁移

- 分区 `ops_system_logs`：为每个直接子分区创建稳定命名的 concurrent index，清理 invalid child 后重试；创建 metadata-only 父索引并幂等 attach，最终校验父索引有效性。
- 非分区 `ops_system_logs`：若同名 index invalid，先 `DROP INDEX CONCURRENTLY IF EXISTS`，再执行原 migration。
- 若完整父索引已存在但 migration 尚未记账，重试直接接受 valid 父索引。
- 未修改 `175a` SQL 文件，保持 migration immutability。

## 契约

- 删除生成文档中的幽灵路由 `GET /payment/channels`。
- contract generator 以 `method + path` 匹配退休契约，避免伪造 source 标签绕过。
- 若 `payment.go` 重新注册 `/channels`，contract check 直接失败。

## 提交

- `7f9d3c0d5 fix(migrations): unblock partitioned ops index rollout`
- `5847cc40a test(sentinels): pin PR1353 migration fallback`
- `ea851e52f fix(migrations): build partition indexes online`
- `5caa4cddb Merge remote-tracking branch 'origin/main' into fix/pr1353-migration-contract`
- `c1a79ee25 fix(migrations): remove obsolete blocking index DDL`

最新提交：`c1a79ee25`
