### PR TITLE
fix: harden fingerprint evidence workflow

### DIFF
--- a/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
+++ b/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
@@ -10,6 +10,18 @@ description: >-
 
 **指纹范畴（OAuth mimic 路径）**：不仅是 `User-Agent` 版本。完整出站指纹 = **TLS JA3** + **HTTP 头**（`User-Agent`、`anthropic-beta` 全集、`x-stainless-*`、`x-app`）+ **system 表面**（`x-anthropic-billing-header` 块、identity anchor、geo-stego 类）。ingress `usage_logs.user_agent`（如 `OpenAI/Python`）≠ 上游所见；用 `gateway.anthropic_oauth_mimic_egress` 或 `probe-oauth-mimicry-chain.sh` 验证出站。见 `docs/spec-delta-cc-oauth-mimicry-fingerprint-scope.md`。
 
+先机械分类证据 cohort，再比较对应 baseline：
+
+```bash
+python3 ops/anthropic/capture_cc_fingerprint.py classify-config \
+  --config-dir "${TOKENKEY_CC_CAPTURE_CONFIG_DIR:-$HOME/.claude}" \
+  --claude-bin "$HOME/.local/bin/claude"
+```
+
+- `first_party_oauth`：允许比较 OAuth beta。
+- `third_party_token` / `first_party_non_oauth`：只验证 UA、Stainless、system 等通用 HTTP 表面；OAuth beta 必须为 `NOT_OBSERVED`，禁止据此改 OAuth baseline。
+- TLS 只接受 collector 或 passive pcap；`baseline_stub_http_only` 必须为 `NOT_OBSERVED`。
+
 关联：`cc0-claude0-launcher` skill（cc0-here 环境）、`tokenkey-anthropic-oauth-config` skill（ja3 变更时的 TLS profile apply）、`docs/spec-delta-cc-canonical-ua-beta-2.1.152.md`（PR #423 实例）。
 
 ## 每日漂移流程（手动按需 —— sessionStart 自动触发已关停）
@@ -141,6 +153,19 @@ bash ops/anthropic/capture-cc-fingerprint.sh capture --http
 # 仅 TLS：bash ops/anthropic/capture-cc-fingerprint.sh capture
 ```
 
+使用本机 `~/.claude/settings.json`、交互 REPL cohort 或 collector 不可用时，走 interactive 路径：
+
+```bash
+# pcap 必须在同一个真实终端先授权；脚本只接受 sudo -n，绝不后台弹密码提示。
+sudo -v
+TOKENKEY_CC_CAPTURE_CONFIG_DIR="$HOME/.claude" \
+  bash ops/anthropic/capture-cc-interactive.sh capture --tls-pcap
+
+# HTTP-only 会把 TLS 标为 NOT_OBSERVED，并以 coverage incomplete 退出。
+TOKENKEY_CC_CAPTURE_CONFIG_DIR="$HOME/.claude" \
+  bash ops/anthropic/capture-cc-interactive.sh capture --http-only
+```
+
 `--http` 现在除 header 外还落 **`system_anchors`**（每个 system 块 text 的前 ~160 字符，仅锚点不存正文）；`bundle-from-artifacts` 汇总进 bundle 的 `system.anchors`，供 `system.identity_anchor` / `system.billing_prefix` diff 行使用（仅 TLS 跑则该维 SKIP）。
 
 ### 2.3 门禁
@@ -152,6 +177,8 @@ python3 ops/anthropic/capture_cc_fingerprint.py check --bundle .tls_list/…-cc-
 # 仅 TLS ja3（每日 hook / 开 PR 用）
 bash ops/anthropic/capture-cc-fingerprint.sh check-tls --bundle .tls_list/….bundle.json
 ```
+
+统一退出码：`0=全部要求证据已观察且 aligned`、`1=drift`、`2=invalid evidence / execution error`、`3=coverage incomplete / not observed`。不得把 `SKIP`、stub 或 3p OAuth beta 缺失解释为 aligned。
 
 ### 2.4 HTTP mitm 链（已修复）
 
@@ -172,7 +199,7 @@ plain claude + CC0_USER_OVERLAY OAuth
 
 ### 2.5 多请求 beta 一致性校验（默认必跑）
 
-`capture --http` 是**单次**抓包做 diff/check。完整 skill 跑法在单次 capture 之后**必须**再跑 comprehensive，跨 haiku/sonnet/opus 各 N 次并统计每族 beta 是否全一致（排查灰度 / 分裂）：
+`capture --http` 是**单次**抓包做 diff/check。完整 skill 跑法在单次 capture 之后**必须**再跑 comprehensive，跨 haiku/sonnet/opus 各 N 次并统计每族 HTTP record 的 beta 是否全一致（排查灰度 / 分裂）：
 
 ```bash
 bash ops/anthropic/capture-http-comprehensive.sh
@@ -183,6 +210,7 @@ bash ops/anthropic/capture-http-comprehensive.sh
 输出每个 model 族的 `N requests, M unique beta header(s)` + `OK/WARN`；末尾自动用最新 `tls-observed` bundle 跑一次 repo `diff` / `check`。复用 §2.4 同一条 mitm 链（gost + cc0 OAuth）。
 
 任一 model 族出现 `WARN`（多种 beta）→ 在 PR / spec-delta 中记录分布，**禁止**在未抓包证据下改 beta 常量。
+只有 `first_party_oauth` cohort 才把该分布与 OAuth mimicry baseline 比较；其它 cohort 只记录分布。
 
 ### 2.6 Geo stego / wire body shape（**内建于 capture；claude CLI + mitm，无 cc0/gost**）
 
@@ -364,6 +392,8 @@ bash ops/anthropic/cc_fingerprint_apply_http_runtime.sh
 - 未抓包就改 system prompt 锚点 / 注入 banner（`cc-system-prompt.json` + Go 副本）；banner 两文件须字节一致
 - 试图 byte 对齐 system prompt 全文（动态：cwd/git/date/env）——只对齐锚点
 - 从旧 patch 推断 ja3
+- 把 HTTP-only bundle 内的 baseline stub 当成新 JA3 证据
+- 用 3p / API-key cohort 的 beta 修改 OAuth baseline
 - ja3 变了却只改 HTTP 常量
 - 用 `cc0-here` 直接做 HTTP mitm（应走 `http_capture_invoke.sh`）
 - 跳过 comprehensive 直接开 PR（beta 分裂未验证）

--- a/.cursor/skills/tokenkey-fingerprint-alignment-all/SKILL.md
+++ b/.cursor/skills/tokenkey-fingerprint-alignment-all/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 ## 两层入口（版本发现 → 指纹对齐）
 
 1. **版本发现（Layer 1）** — `bash ops/fingerprint/client-release-watch.sh scan --plan`
-   轮询 GitHub/npm/Homebrew 的客户端 release，对比 TokenKey pin。**只报警、不 capture、不 bump**。
+   轮询 GitHub/npm/Homebrew 的客户端 release，对比 TokenKey pin。`--plan` **严格只读**：不写 state/report/cache，只报警、不 capture、不 bump。
    输出会指向应加载的 skill（本 umbrella 或单平台 skill）。
 2. **指纹对齐（Layer 2，本 skill）** — 在 Cursor **加载本 skill 或单平台 skill 后**，跑
    `capture-all-fingerprints.sh` 做真实 capture/diff，再合一个 PR。
@@ -41,7 +41,8 @@ bash ops/fingerprint/capture-all-fingerprints.sh \
   --cc-arg --http \
   --kiro-arg --proxy-port --kiro-arg 7890 \
   --antigravity-arg --proxy-port --antigravity-arg 8080
-#   → 末尾打印 combined drift report；退出码 1=有平台漂移，0=全齐/跳过，2=出错
+#   → 末尾打印 combined coverage + drift report：
+#     0=全部要求证据已观察且 aligned，1=drift，2=error/invalid evidence，3=incomplete/skipped
 # 只跑部分引擎：--skip-cc / --skip-kiro / --skip-antigravity / --skip-codex
 # codex 无前置、默认就跑；本机没装 codex 时用 --skip-codex。
 ```
@@ -61,6 +62,8 @@ bash ops/fingerprint/capture-all-fingerprints.sh \
   fingerprint pin consistency 兜「半截 bump」。
 
 然后 `scripts/preflight.sh` 全绿 → 一个分支、一个 PR 覆盖各平台的产物变更。
+
+最终结论必须逐平台使用 `aligned / drift / incomplete / skipped / error`。显式 `--skip-*` 或证据未观察时返回 3，禁止输出“所有指纹已对齐”。Claude Code 子报告还必须区分 `first_party_oauth` 与 3p/API-key cohort，并拒绝把 HTTP-only TLS stub 当作 JA3 证据。
 
 ## 边界
 

--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -23,6 +23,32 @@ restores the file and removes the entry in the same change.
 
 ---
 
+## frontend/src/components/account/__tests__/CreateAccountModal.grok.spec.ts
+
+- **Upstream path:** `frontend/src/components/account/__tests__/CreateAccountModal.grok.spec.ts`.
+- **Deletion commit + PR:** `3fa27f851ca7149560e4dcfec7baf065aabcad9d`
+  — "fix(upstream): address R-001..R-002 — restore Grok OAuth create wiring",
+  landed through [PR #1353](https://github.com/youxuanxue/sub2api/pull/1353).
+- **Reason:** the deleted file only read `CreateAccountModal.vue` as text and
+  asserted source substrings/counts. PR #1353 moved the load-bearing Grok OAuth
+  create checks into the mounted `CreateAccountModal.spec.ts`: it now exercises
+  the direct refresh-token flow, persists custom upstream/header credentials,
+  and rejects protected header names. The same change added Grok semantic
+  sentinel coverage, so keeping the source-text test would duplicate weaker
+  assertions rather than protect a distinct behavior.
+- **Regression cost:** future upstream edits to this standalone spec will not
+  merge automatically. Upstream-merge review must compare its intent against
+  the mounted Grok cases and semantic sentinel, then port any genuinely new
+  behavior assertion into those owners.
+- **Upstream tests lost:** three source-string assertions were removed. Their
+  load-bearing OAuth upstream-config behavior is covered by mounted component
+  tests; API-key setup remains covered by the shared modal/component suite and
+  frontend sentinels.
+- **Re-adopt when:** upstream replaces this file with behavior-level component
+  tests that cover a distinct workflow not owned by `CreateAccountModal.spec.ts`,
+  or the mounted Grok tests are intentionally split back into a dedicated file.
+  In either case, restore the test and remove this ledger entry together.
+
 ## backend/internal/handler/openai_embeddings.go
 
 - **Upstream path:** `backend/internal/handler/openai_embeddings.go`

--- a/ops/anthropic/capture-cc-fingerprint.sh
+++ b/ops/anthropic/capture-cc-fingerprint.sh
@@ -225,7 +225,7 @@ cmd_capture() {
   claude_bin="$(resolve_claude_bin)"
 
   mkdir -p "$OUT_DIR"
-  local stamp cc_version token work tls_capture http_log bundle_path
+  local stamp cc_version token work tls_capture http_log bundle_path auth_route config_info
   stamp="$(date -u +%Y%m%dT%H%M%SZ)"
   cc_version="$("$claude_bin" --version 2>/dev/null | awk '{print $1}' || true)"
   token="tk-cc-capture-${stamp}-$$"
@@ -238,6 +238,14 @@ cmd_capture() {
 
   http_log=""
   if [[ "$with_http" == "1" ]]; then
+    if ! config_info="$(python3 "$PY" classify-config \
+      --config-dir "${CC0_USER_OVERLAY:-$HOME/.cache/cc0/claude-user-overlay}" \
+      --claude-bin "$claude_bin")"; then
+      echo "error: capture auth route is unknown; refusing to compare cohorts" >&2
+      exit 3
+    fi
+    auth_route="$(printf '%s' "$config_info" | jq -r '.auth_route')"
+    echo "http_auth_route=$auth_route"
     http_log="$(run_http_capture "$work")" || exit 1
   fi
 
@@ -251,7 +259,7 @@ cmd_capture() {
     --collector "$COLLECTOR_ORIGIN:8090"
   )
   if [[ -n "$http_log" ]]; then
-    bundle_args+=(--http-log "$http_log")
+    bundle_args+=(--http-log "$http_log" --http-cohort "$auth_route")
   fi
   if [[ -n "${cc_version:-}" ]]; then
     bundle_args+=(--cc-version "$cc_version")
@@ -260,7 +268,11 @@ cmd_capture() {
 
   echo "bundle=$bundle_path"
   python3 "$PY" diff --bundle "$bundle_path"
-  python3 "$PY" check --bundle "$bundle_path"
+  if [[ "$with_http" == "1" ]]; then
+    python3 "$PY" check --bundle "$bundle_path"
+  else
+    python3 "$PY" check-tls --bundle "$bundle_path"
+  fi
 
   if [[ "${TOKENKEY_CC_CAPTURE_GEO:-1}" == "1" && "$with_http" == "1" ]]; then
     local geo_fix=1

--- a/ops/anthropic/capture-cc-interactive.sh
+++ b/ops/anthropic/capture-cc-interactive.sh
@@ -44,7 +44,7 @@ HTTP path keeps the user's ANTHROPIC_BASE_URL and steers via HTTP(S)_PROXY mitm.
 Set TOKENKEY_CC_CAPTURE_DIRECT_ANTHROPIC=1 to require gost upstream to Anthropic.
 
 Options:
-  --http-only              Skip TLS; seed bundle TLS from baseline (HTTP-only drift).
+  --http-only              Skip TLS; mark TLS not-observed (HTTP-only evidence).
   --tls-pcap               Force passive pcap during interactive mitm (skip collector).
   --tls-pcap-standalone    Use direct/bare Claude TLS trigger instead of mitm loopback pcap.
   --no-tls-pcap-fallback   Do not auto-fallback to pcap when collector fails.
@@ -65,15 +65,11 @@ require_cmd() {
 }
 
 require_sudo_for_pcap() {
-  # Non-interactive sessions cannot answer a sudo password prompt.
-  if [[ ! -t 0 ]]; then
-    if ! sudo -n true 2>/dev/null; then
-      echo "error: passive pcap needs interactive sudo for tcpdump" >&2
-      echo "  Run this capture in your terminal (not a non-interactive agent) so macOS can prompt for your password." >&2
-      echo "  Or pre-authorize once: sudo -v" >&2
-      echo "  Optional: brew install --cask wireshark-chmodbpf  # reduces capture friction on macOS" >&2
-      return 1
-    fi
+  if ! sudo -n true 2>/dev/null; then
+    echo "error: passive pcap requires a pre-authorized sudo timestamp" >&2
+    echo "  Run 'sudo -v' in this same terminal, then retry the capture." >&2
+    echo "  Optional: install Wireshark ChmodBPF and use a non-sudo capture path." >&2
+    return 1
   fi
   return 0
 }
@@ -466,8 +462,8 @@ run_tls_pcap_capture() {
 
   echo "  bpf filter: $filter"
 
-  echo "Starting tcpdump for up to ${PCAP_SECONDS}s (sudo may prompt) ..."
-  sudo tcpdump ${iface_arg[@]+"${iface_arg[@]}"} -s 0 -w "$pcap" -G "$PCAP_SECONDS" -W 1 "$filter" \
+  echo "Starting tcpdump for up to ${PCAP_SECONDS}s (sudo pre-authorized) ..."
+  sudo -n tcpdump ${iface_arg[@]+"${iface_arg[@]}"} -s 0 -w "$pcap" -G "$PCAP_SECONDS" -W 1 "$filter" \
     >"$work/tcpdump.err" 2>&1 &
   local tcpdump_pid=$!
   sleep 1
@@ -503,8 +499,8 @@ run_tls_pcap_via_mitm() {
   tsv="$work/${stamp}-cc-interactive-mitm.tshark.tsv"
 
   echo "TLS pcap (interactive mitm): iface=$PCAP_IFACE filter='tcp port $proxy_port'" >&2
-  echo "Starting tcpdump for interactive REPL session (sudo may prompt) ..." >&2
-  sudo tcpdump -i "$PCAP_IFACE" -s 0 -w "$pcap" -G "$PCAP_SECONDS" -W 1 "tcp port $proxy_port" \
+  echo "Starting tcpdump for interactive REPL session (sudo pre-authorized) ..." >&2
+  sudo -n tcpdump -i "$PCAP_IFACE" -s 0 -w "$pcap" -G "$PCAP_SECONDS" -W 1 "tcp port $proxy_port" \
     >"$work/tcpdump.err" 2>&1 &
   echo "$!" >"$work/tcpdump.pid"
   sleep 1
@@ -584,13 +580,17 @@ run_interactive_http_capture() {
   echo "Automated Claude REPL via expect (silent, up to ${expect_timeout}s) — do not type in this shell; wait for completion ..." >&2
   run_one() {
     local model="$1"
+    local expect_rc=0
     export TK_CAPTURE_WORK="$work"
     export TK_CAPTURE_MODEL="$model"
     export TK_CAPTURE_PROMPT="$PROMPT"
     export TK_CAPTURE_CONFIG_DIR="$config_dir"
     export TK_CAPTURE_CLAUDE_BIN="$claude_bin"
     echo "  expect model=$model ..." >&2
-    expect "$EXPECT_SCRIPT" >"$work/expect-${model##*-}.out" 2>"$work/expect-${model##*-}.err" || true
+    expect "$EXPECT_SCRIPT" >"$work/expect-${model##*-}.out" 2>"$work/expect-${model##*-}.err" || expect_rc=$?
+    if [[ "$expect_rc" -ne 0 ]]; then
+      echo "  warn: expect model=$model exited rc=$expect_rc; validating captured records before deciding" >&2
+    fi
     echo "  expect model=$model done (see $work/expect-${model##*-}.err on failure)" >&2
     sleep 2
   }
@@ -731,6 +731,12 @@ cmd_capture() {
   claude_bin="$(resolve_claude_bin)"
   local config_dir
   config_dir="$(resolve_config_dir "$claude_bin")"
+  local config_info auth_route
+  if ! config_info="$(python3 "$PY" classify-config --config-dir "$config_dir" --claude-bin "$claude_bin")"; then
+    echo "error: capture auth route is unknown; refusing to compare cohorts" >&2
+    return 3
+  fi
+  auth_route="$(printf '%s' "$config_info" | jq -r '.auth_route')"
 
   mkdir -p "$OUT_DIR"
   local stamp cc_version token work http_log tls_capture bundle_path collector_label
@@ -748,7 +754,7 @@ cmd_capture() {
     tls_mode="pcap"
   fi
 
-  echo "cc_version=${cc_version:-unknown} claude_bin=$claude_bin config_dir=$config_dir tls_mode=$tls_mode"
+  echo "cc_version=${cc_version:-unknown} claude_bin=$claude_bin config_dir=$config_dir tls_mode=$tls_mode auth_route=$auth_route"
   run_tls_capture_with_fallback "$work" "$token" "$config_dir" "$claude_bin" "$cc_version" "$stamp" "$tls_mode" "$pcap_fallback" "$pcap_standalone"
 
   if [[ -f "$work/pcap-deferred" ]]; then
@@ -771,6 +777,7 @@ cmd_capture() {
     --http-log "$http_log"
     --out "$bundle_path"
     --collector "$collector_label"
+    --http-cohort "$auth_route"
   )
   if [[ -n "${cc_version:-}" ]]; then
     bundle_args+=(--cc-version "$cc_version")

--- a/ops/anthropic/capture-http-comprehensive.sh
+++ b/ops/anthropic/capture-http-comprehensive.sh
@@ -11,7 +11,7 @@ OUT_DIR="${TOKENKEY_CC_CAPTURE_OUT_DIR:-$REPO_ROOT/.tls_list}"
 MITM_PORT="${TOKENKEY_CC_CAPTURE_MITM_PORT:-11803}"
 GOST_PORT="${CC0_GOST_HTTP_PORT:-11800}"
 
-# Repeat counts per family (total requests = sum).
+# Claude invocations per family. One invocation may emit multiple HTTP records.
 HAIKU_N="${TOKENKEY_CC_CAPTURE_HAIKU_N:-3}"
 SONNET_N="${TOKENKEY_CC_CAPTURE_SONNET_N:-3}"
 OPUS_N="${TOKENKEY_CC_CAPTURE_OPUS_N:-2}"
@@ -28,6 +28,15 @@ require_cmd mitmdump
 require_cmd python3
 require_cmd jq
 [[ -x "$HTTP_INVOKE" ]] || { echo "error: missing $HTTP_INVOKE (need #427 http_capture_invoke.sh)" >&2; exit 1; }
+
+CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
+CONFIG_DIR="${CC0_USER_OVERLAY:-$HOME/.cache/cc0/claude-user-overlay}"
+if ! config_info="$(python3 "$PY" classify-config --config-dir "$CONFIG_DIR" --claude-bin "$CLAUDE_BIN")"; then
+  echo "error: capture auth route is unknown; refusing to compare cohorts" >&2
+  exit 3
+fi
+HTTP_COHORT="$(printf '%s' "$config_info" | jq -r '.auth_route')"
+echo "http_auth_route=$HTTP_COHORT"
 
 _cc0_port_open() {
   python3 - "$1" "$2" <<'PY'
@@ -112,13 +121,13 @@ for line in open(path, encoding="utf-8"):
 print("=== HTTP capture consistency ===")
 for v, betas in sorted(by_variant.items()):
     uniq = list(dict.fromkeys(betas))
-    print(f"{v}: {len(betas)} requests, {len(uniq)} unique beta header(s)")
+    print(f"{v}: {len(betas)} HTTP records, {len(uniq)} unique beta header(s)")
     for i, b in enumerate(betas, 1):
         print(f"  [{i}] {b}")
     if len(uniq) == 1:
-        print(f"  OK all {v} requests identical")
+        print(f"  OK all {v} HTTP records identical")
     else:
-        print(f"  WARN {v} beta headers differ across requests")
+        print(f"  WARN {v} beta headers differ across HTTP records")
 PY
 
 # Pick last TLS bundle or run quick TLS - use latest tls-observed if exists
@@ -137,7 +146,8 @@ python3 "$PY" bundle-from-artifacts \
   --http-log "$http_log" \
   --cc-version "${cc_ver:-unknown}" \
   --out "$bundle" \
-  --collector "https://tls.sub2api.org:8090"
+  --collector "https://tls.sub2api.org:8090" \
+  --http-cohort "$HTTP_COHORT"
 
 echo "bundle=$bundle"
 python3 "$PY" diff --bundle "$bundle"

--- a/ops/anthropic/capture_cc_fingerprint.py
+++ b/ops/anthropic/capture_cc_fingerprint.py
@@ -437,8 +437,20 @@ def bundle_from_artifacts(
     collector_url: str = "",
     http_cohort: str = "",
 ) -> dict[str, Any]:
-    tls_source = str(tls_observed.get("source") or collector_url or "unknown")
-    tls_observed_on_wire = tls_source != "baseline_stub_http_only"
+    artifact_tls_source = str(tls_observed.get("source") or "")
+    tls_source = artifact_tls_source or collector_url or "unknown"
+    if artifact_tls_source == "baseline_stub_http_only":
+        tls_observed_on_wire = False
+        tls_evidence_valid = True
+    elif artifact_tls_source.startswith("passive-pcap"):
+        tls_observed_on_wire = True
+        tls_evidence_valid = True
+    elif not artifact_tls_source and collector_url:
+        tls_observed_on_wire = True
+        tls_evidence_valid = True
+    else:
+        tls_observed_on_wire = False
+        tls_evidence_valid = False
     http_present = bool(http_by_variant or http_variants or system_anchors)
     return {
         "schema_version": SCHEMA_VERSION,
@@ -449,6 +461,7 @@ def bundle_from_artifacts(
             "tls": {
                 "source": tls_source,
                 "observed": tls_observed_on_wire,
+                "valid": tls_evidence_valid,
             },
             "http": {
                 "source": "mitm" if http_present else "none",
@@ -501,12 +514,24 @@ def diff_baseline_vs_capture(
         tls_evidence.get("source") or cap_tls.get("source") or capture.get("collector") or ""
     )
     tls_was_observed = bool(tls_evidence.get("observed", True))
+    tls_evidence_valid = bool(tls_evidence.get("valid", True))
     if tls_source == "baseline_stub_http_only":
         tls_was_observed = False
     for key in ("ja3_hash", "ja3_raw"):
         tk = str(base_tls.get(key) or "")
         cap = str(cap_tls.get(key) or "")
-        if not tls_was_observed:
+        if explicit_tls_evidence and not tls_evidence_valid:
+            rows.append(
+                DiffRow(
+                    f"tls.{key}",
+                    tk,
+                    cap,
+                    "invalid_evidence",
+                    critical=True,
+                    note=f"Unsupported TLS evidence source {tls_source or 'unknown'}; use collector or passive pcap",
+                )
+            )
+        elif not tls_was_observed:
             rows.append(
                 DiffRow(
                     f"tls.{key}",

--- a/ops/anthropic/capture_cc_fingerprint.py
+++ b/ops/anthropic/capture_cc_fingerprint.py
@@ -38,6 +38,12 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = 1
+EXIT_ALIGNED = 0
+EXIT_DRIFT = 1
+EXIT_ERROR = 2
+EXIT_INCOMPLETE = 3
+FIRST_PARTY_OAUTH = "first_party_oauth"
+THIRD_PARTY_TOKEN = "third_party_token"
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _BETA_CONST_MAP: dict[str, str] | None = None
 CONSTANTS_GO = REPO_ROOT / "backend/internal/pkg/claude/constants.go"
@@ -72,7 +78,7 @@ class DiffRow:
     field: str
     tokenkey: str
     captured: str
-    status: str  # match | mismatch | missing_capture | missing_tokenkey
+    status: str  # match | mismatch | missing_capture | not_observed | invalid_evidence
     critical: bool
     note: str = ""
 
@@ -143,6 +149,51 @@ def _resolve_betas(constants_src: str, func_name: str) -> list[str]:
 def _ua_version(ua: str) -> str:
     m = re.search(r"claude-cli/(\d+\.\d+\.\d+)", ua or "")
     return m.group(1) if m else ""
+
+
+def classify_capture_config(
+    config_dir: Path,
+    *,
+    auth_status: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Classify the HTTP evidence cohort without exposing credential values."""
+    base_url = "https://api.anthropic.com"
+    settings_path = config_dir / "settings.json"
+    if settings_path.is_file():
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        env = settings.get("env") or {}
+        for key in ("ANTHROPIC_BASE_URL", "CLAUDE_CODE_API_BASE_URL"):
+            raw = str(env.get(key) or "").strip()
+            if raw:
+                base_url = raw
+                break
+
+    from urllib.parse import urlparse
+
+    parsed = urlparse(base_url)
+    host = (parsed.hostname or "api.anthropic.com").lower()
+    status = auth_status or {}
+    auth_method = str(status.get("authMethod") or "")
+    api_provider = str(status.get("apiProvider") or "")
+    logged_in = bool(status.get("loggedIn"))
+
+    if host != "api.anthropic.com":
+        cohort = THIRD_PARTY_TOKEN
+    elif logged_in and auth_method == "oauth_token" and api_provider == "firstParty":
+        cohort = FIRST_PARTY_OAUTH
+    elif logged_in:
+        cohort = "first_party_non_oauth"
+    else:
+        cohort = "unknown"
+
+    return {
+        "auth_route": cohort,
+        "base_url": f"{parsed.scheme or 'https'}://{parsed.netloc or host}",
+        "base_host": host,
+        "logged_in": logged_in,
+        "auth_method": auth_method,
+        "api_provider": api_provider,
+    }
 
 
 def _load_system_prompt_anchors(repo_root: Path | None = None) -> dict[str, Any]:
@@ -384,16 +435,32 @@ def bundle_from_artifacts(
     http_variants: dict[str, dict[str, Any]] | None = None,
     system_anchors: list[str] | None = None,
     collector_url: str = "",
+    http_cohort: str = "",
 ) -> dict[str, Any]:
+    tls_source = str(tls_observed.get("source") or collector_url or "unknown")
+    tls_observed_on_wire = tls_source != "baseline_stub_http_only"
+    http_present = bool(http_by_variant or http_variants or system_anchors)
     return {
         "schema_version": SCHEMA_VERSION,
         "captured_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "cc_version": cc_version,
         "collector": collector_url,
+        "evidence": {
+            "tls": {
+                "source": tls_source,
+                "observed": tls_observed_on_wire,
+            },
+            "http": {
+                "source": "mitm" if http_present else "none",
+                "observed": http_present,
+                "cohort": http_cohort or ("legacy_unknown" if http_present else "none"),
+            },
+        },
         "tls": {
             "ja3_hash": tls_observed.get("ja3_hash", ""),
             "ja3_raw": tls_observed.get("ja3_raw", ""),
             "user_agent": tls_observed.get("user_agent", ""),
+            "source": tls_source,
             "stainless_package_version": tls_observed.get(
                 "stainless_package_version", ""
             ),
@@ -427,18 +494,38 @@ def diff_baseline_vs_capture(
 
     cap_tls = capture.get("tls") or {}
     base_tls = baseline.get("tls") or {}
+    evidence = capture.get("evidence") or {}
+    tls_evidence = evidence.get("tls") or {}
+    explicit_tls_evidence = "tls" in evidence
+    tls_source = str(
+        tls_evidence.get("source") or cap_tls.get("source") or capture.get("collector") or ""
+    )
+    tls_was_observed = bool(tls_evidence.get("observed", True))
+    if tls_source == "baseline_stub_http_only":
+        tls_was_observed = False
     for key in ("ja3_hash", "ja3_raw"):
         tk = str(base_tls.get(key) or "")
         cap = str(cap_tls.get(key) or "")
-        if not cap:
+        if not tls_was_observed:
             rows.append(
                 DiffRow(
                     f"tls.{key}",
                     tk,
                     cap,
-                    "missing_capture",
-                    critical=False,
-                    note="Run TLS collector capture",
+                    "not_observed",
+                    critical=True,
+                    note=f"TLS value came from {tls_source or 'a non-wire source'}; run collector or passive pcap",
+                )
+            )
+        elif not cap:
+            rows.append(
+                DiffRow(
+                    f"tls.{key}",
+                    tk,
+                    cap,
+                    "invalid_evidence" if explicit_tls_evidence else "missing_capture",
+                    critical=True,
+                    note="Observed TLS evidence is missing a required JA3 field",
                 )
             )
         elif tk == cap:
@@ -458,12 +545,17 @@ def diff_baseline_vs_capture(
     cap_cc = capture.get("cc_version") or _ua_version(cap_tls.get("user_agent", ""))
     canon_ver = baseline["canonical_http"]["default_version"]
     mimic_ver = baseline["mimic_http"]["cli_version"]
+    version_status = "match" if canon_ver == cap_cc else "mismatch"
+    mimic_version_status = "match" if mimic_ver == cap_cc else "mismatch"
+    if not cap_cc:
+        version_status = "invalid_evidence"
+        mimic_version_status = "invalid_evidence"
     rows.append(
         DiffRow(
             "canonical.user_agent_version",
             canon_ver,
             cap_cc,
-            "match" if canon_ver == cap_cc else "mismatch",
+            version_status,
             critical="canonical.user_agent_version" in CRITICAL_HTTP_FIELDS,
         )
     )
@@ -472,7 +564,7 @@ def diff_baseline_vs_capture(
             "mimic.cli_version",
             mimic_ver,
             cap_cc,
-            "match" if mimic_ver == cap_cc else "mismatch",
+            mimic_version_status,
             critical="mimic.cli_version" in CRITICAL_HTTP_FIELDS,
         )
     )
@@ -486,12 +578,23 @@ def diff_baseline_vs_capture(
     )
     canon_stainless = baseline["canonical_http"]["stainless_package_version"]
     mimic_stainless = baseline["mimic_http"]["stainless_package_version"]
+    http_evidence = evidence.get("http") or {}
+    stainless_status = "match" if canon_stainless == cap_stainless else "mismatch"
+    mimic_stainless_status = "match" if mimic_stainless == cap_stainless else "mismatch"
+    if not cap_stainless:
+        missing_status = (
+            "invalid_evidence"
+            if bool(http_evidence.get("observed"))
+            else "missing_capture"
+        )
+        stainless_status = missing_status
+        mimic_stainless_status = missing_status
     rows.append(
         DiffRow(
             "canonical.stainless_package_version",
             canon_stainless,
             cap_stainless,
-            "match" if canon_stainless == cap_stainless else "mismatch",
+            stainless_status,
             critical="canonical.stainless_package_version" in CRITICAL_HTTP_FIELDS,
         )
     )
@@ -500,7 +603,7 @@ def diff_baseline_vs_capture(
             "mimic.stainless_package_version",
             mimic_stainless,
             cap_stainless,
-            "match" if mimic_stainless == cap_stainless else "mismatch",
+            mimic_stainless_status,
             critical="mimic.stainless_package_version" in CRITICAL_HTTP_FIELDS,
         )
     )
@@ -562,12 +665,44 @@ def diff_baseline_vs_capture(
 
     http = capture.get("http") or {}
     variants = capture.get("http_variants") or {}
+    explicit_http_evidence = "http" in evidence
+    http_cohort = str(http_evidence.get("cohort") or "")
     for variant, beta_key in (("haiku", "haiku_mimicry"), ("sonnet", "sonnet_mimicry")):
         rec = http.get(variant)
         dist = variants.get(variant) or {}
         unique = dist.get("unique") or []
         tk_betas = baseline["betas"][beta_key]
         is_critical = f"betas.{beta_key}" in CRITICAL_HTTP_FIELDS
+
+        if explicit_http_evidence and http_cohort in {
+            THIRD_PARTY_TOKEN,
+            "first_party_non_oauth",
+        }:
+            rows.append(
+                DiffRow(
+                    f"betas.{beta_key}",
+                    ",".join(tk_betas),
+                    f"cohort={http_cohort}",
+                    "not_observed",
+                    critical=is_critical,
+                    note="OAuth beta baseline is comparable only to first_party_oauth traffic",
+                )
+            )
+            continue
+        if explicit_http_evidence and bool(http_evidence.get("observed")) and http_cohort not in {
+            FIRST_PARTY_OAUTH,
+        }:
+            rows.append(
+                DiffRow(
+                    f"betas.{beta_key}",
+                    ",".join(tk_betas),
+                    f"cohort={http_cohort or 'missing'}",
+                    "invalid_evidence",
+                    critical=is_critical,
+                    note="HTTP evidence must declare a recognized cohort before beta comparison",
+                )
+            )
+            continue
 
         # Resolve the observed beta-set distribution. Prefer the full per-family
         # distribution (http_variants); fall back to the single representative
@@ -732,12 +867,15 @@ def format_diff_report(rows: list[DiffRow], *, capture_path: str = "") -> str:
         lines.append(f"capture: {capture_path}")
     mismatches = [r for r in rows if r.status == "mismatch" and r.critical]
     missing = [r for r in rows if r.status == "missing_capture" and r.critical]
+    not_observed = [r for r in rows if r.status == "not_observed" and r.critical]
+    invalid = [r for r in rows if r.status == "invalid_evidence" and r.critical]
     investigate = [r for r in rows if r.status == "needs_investigation"]
     matches = [r for r in rows if r.status == "match"]
 
     lines.append(
         f"match={len(matches)} mismatch={len(mismatches)} "
-        f"needs_investigation={len(investigate)} missing_capture={len(missing)}"
+        f"needs_investigation={len(investigate)} missing_capture={len(missing)} "
+        f"not_observed={len(not_observed)} invalid_evidence={len(invalid)}"
     )
     lines.append("")
     for r in rows:
@@ -746,10 +884,14 @@ def format_diff_report(rows: list[DiffRow], *, capture_path: str = "") -> str:
             "mismatch": "FAIL",
             "needs_investigation": "INVESTIGATE",
             "missing_capture": "SKIP",
+            "not_observed": "NOT_OBSERVED",
+            "invalid_evidence": "INVALID_EVIDENCE",
         }.get(r.status, r.status)
         crit = (
             " [critical]"
-            if r.critical and r.status in ("mismatch", "missing_capture")
+            if r.critical
+            and r.status
+            in ("mismatch", "missing_capture", "not_observed", "invalid_evidence")
             else ""
         )
         lines.append(f"{flag}{crit} {r.field}")
@@ -758,7 +900,8 @@ def format_diff_report(rows: list[DiffRow], *, capture_path: str = "") -> str:
             lines.append(f"  captured: {r.captured[:200]}")
             if r.note:
                 lines.append(f"  note: {r.note}")
-    if investigate:
+    beta_investigate = [r for r in investigate if r.field.startswith("betas.")]
+    if beta_investigate:
         lines.append("")
         lines.append(
             "note: bimodal beta field(s) observed — NOT a hard mismatch (exit 0)."
@@ -791,6 +934,26 @@ def has_actionable_mismatch(rows: list[DiffRow]) -> bool:
 
 def has_needs_investigation(rows: list[DiffRow]) -> bool:
     return any(r.status == "needs_investigation" for r in rows)
+
+
+def has_invalid_evidence(rows: list[DiffRow]) -> bool:
+    return any(r.status == "invalid_evidence" and r.critical for r in rows)
+
+
+def has_incomplete_coverage(rows: list[DiffRow]) -> bool:
+    return any(
+        r.status in {"missing_capture", "not_observed"} and r.critical for r in rows
+    )
+
+
+def diff_exit_code(rows: list[DiffRow]) -> int:
+    if has_invalid_evidence(rows):
+        return EXIT_ERROR
+    if has_actionable_mismatch(rows):
+        return EXIT_DRIFT
+    if has_incomplete_coverage(rows):
+        return EXIT_INCOMPLETE
+    return EXIT_ALIGNED
 
 
 def has_tls_mismatch(rows: list[DiffRow]) -> bool:
@@ -1087,6 +1250,7 @@ def cmd_check_tls(args: argparse.Namespace) -> int:
             json.dumps(
                 {
                     "tls_mismatch": has_tls_mismatch(rows),
+                    "exit_code": diff_exit_code(tls_rows),
                     "rows": [
                         {
                             "field": r.field,
@@ -1103,7 +1267,7 @@ def cmd_check_tls(args: argparse.Namespace) -> int:
         )
     else:
         print(format_diff_report(rows, capture_path=str(args.bundle)))
-    return 1 if has_tls_mismatch(rows) else 0
+    return diff_exit_code([r for r in rows if r.field.startswith("tls.")])
 
 
 def cmd_write_drift_spec(args: argparse.Namespace) -> int:
@@ -1127,9 +1291,7 @@ def cmd_diff(args: argparse.Namespace) -> int:
     bundle = load_capture_bundle(Path(args.bundle))
     rows = diff_baseline_vs_capture(baseline, bundle)
     print(format_diff_report(rows, capture_path=str(args.bundle)))
-    if args.check and has_actionable_mismatch(rows):
-        return 1
-    return 0
+    return diff_exit_code(rows) if args.check else EXIT_ALIGNED
 
 
 def cmd_bundle_from_artifacts(args: argparse.Namespace) -> int:
@@ -1154,12 +1316,38 @@ def cmd_bundle_from_artifacts(args: argparse.Namespace) -> int:
         http_variants=http_variants,
         system_anchors=system_anchors,
         collector_url=args.collector or "",
+        http_cohort=args.http_cohort or "",
     )
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     print(out)
     return 0
+
+
+def cmd_classify_config(args: argparse.Namespace) -> int:
+    config_dir = Path(args.config_dir).expanduser()
+    auth_status: dict[str, Any] = {}
+    env = os.environ.copy()
+    env["CLAUDE_CONFIG_DIR"] = str(config_dir)
+    try:
+        proc = subprocess.run(
+            [args.claude_bin, "auth", "status"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+            env=env,
+        )
+        if proc.returncode == 0:
+            parsed = json.loads(proc.stdout)
+            if isinstance(parsed, dict):
+                auth_status = parsed
+    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        auth_status = {}
+    payload = classify_capture_config(config_dir, auth_status=auth_status)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return EXIT_ALIGNED if payload["auth_route"] != "unknown" else EXIT_INCOMPLETE
 
 
 def _load_kiro_ja3_engine() -> Any:
@@ -1231,7 +1419,7 @@ def build_parser() -> argparse.ArgumentParser:
     diff.add_argument(
         "--check",
         action="store_true",
-        help="Exit 1 when critical mismatches exist",
+        help="Exit 1 on drift, 2 on invalid evidence, 3 on incomplete coverage",
     )
     diff.set_defaults(func=cmd_diff)
 
@@ -1259,7 +1447,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     tls = sub.add_parser(
         "check-tls",
-        help="Exit 1 when bundle TLS ja3 mismatches TokenKey baseline",
+        help="Gate TLS evidence: 0 aligned, 1 drift, 2 invalid, 3 not observed",
     )
     tls.add_argument("--bundle", required=True)
     tls.add_argument("--repo-root", default="")
@@ -1283,8 +1471,21 @@ def build_parser() -> argparse.ArgumentParser:
     bfa.add_argument("--http-log", default="")
     bfa.add_argument("--cc-version", default="")
     bfa.add_argument("--collector", default="")
+    bfa.add_argument(
+        "--http-cohort",
+        choices=(FIRST_PARTY_OAUTH, THIRD_PARTY_TOKEN, "first_party_non_oauth"),
+        default="",
+    )
     bfa.add_argument("--out", required=True)
     bfa.set_defaults(func=cmd_bundle_from_artifacts)
+
+    classify = sub.add_parser(
+        "classify-config",
+        help="Classify capture auth route/base URL without printing credentials",
+    )
+    classify.add_argument("--config-dir", required=True)
+    classify.add_argument("--claude-bin", required=True)
+    classify.set_defaults(func=cmd_classify_config)
 
     pcap = sub.add_parser(
         "tls-observed-from-pcap",

--- a/ops/anthropic/capture_interactive_repl.exp
+++ b/ops/anthropic/capture_interactive_repl.exp
@@ -56,8 +56,11 @@ expect {
     exp_continue
   }
   timeout {
+    send "\x03"
+    after 500
     send "\x04"
-    exp_continue
+    after 500
+    exit 124
   }
   eof
 }

--- a/ops/anthropic/http_capture_invoke.sh
+++ b/ops/anthropic/http_capture_invoke.sh
@@ -67,6 +67,7 @@ OUT="$WORK_DIR/claude-${TAG}.out"
 ERR="$WORK_DIR/claude-${TAG}.err"
 
 # Neutral cwd: avoid sub2api project SessionStart context short-circuiting /v1/messages.
+set +e
 (
   cd /tmp || exit 1
   env -i \
@@ -90,13 +91,16 @@ ERR="$WORK_DIR/claude-${TAG}.err"
     "$CLAUDE_BIN" \
     -p "$PROMPT" \
     --model "$MODEL" \
+    --allowedTools '' \
     --max-budget-usd 0.15 \
     --output-format text \
     </dev/null >"$OUT" 2>"$ERR"
-) || true  # preflight-allow: swallow
+)
+rc=$?
+set -e
 
 if [[ -s "$ERR" ]]; then
   sed -n '1,5p' "$ERR" >&2 || true  # preflight-allow: swallow
 fi
 
-exit 0
+exit "$rc"

--- a/ops/anthropic/test_capture_cc_fingerprint.py
+++ b/ops/anthropic/test_capture_cc_fingerprint.py
@@ -234,6 +234,26 @@ class BundleRoundtripTests(unittest.TestCase):
         self.assertTrue(all(r.status == "not_observed" for r in tls_rows))
         self.assertEqual(mod.EXIT_INCOMPLETE, mod.diff_exit_code(tls_rows))
 
+    def test_unsupported_tls_source_is_invalid_evidence(self) -> None:
+        baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
+        bundle = mod.bundle_from_artifacts(
+            cc_version=baseline["canonical_http"]["default_version"],
+            tls_observed={
+                "ja3_hash": baseline["tls"]["ja3_hash"],
+                "ja3_raw": baseline["tls"]["ja3_raw"],
+                "source": "manual-cache",
+            },
+        )
+        self.assertFalse(bundle["evidence"]["tls"]["observed"])
+        self.assertFalse(bundle["evidence"]["tls"]["valid"])
+        tls_rows = [
+            row
+            for row in mod.diff_baseline_vs_capture(baseline, bundle)
+            if row.field.startswith("tls.")
+        ]
+        self.assertTrue(all(row.status == "invalid_evidence" for row in tls_rows))
+        self.assertEqual(mod.EXIT_ERROR, mod.diff_exit_code(tls_rows))
+
     def test_third_party_http_does_not_compare_oauth_betas(self) -> None:
         baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
         bundle = mod.bundle_from_artifacts(

--- a/ops/anthropic/test_capture_cc_fingerprint.py
+++ b/ops/anthropic/test_capture_cc_fingerprint.py
@@ -219,6 +219,92 @@ class BundleRoundtripTests(unittest.TestCase):
             loaded = mod.load_capture_bundle(path)
             self.assertEqual(loaded["cc_version"], baseline["canonical_http"]["default_version"])
 
+    def test_http_only_stub_is_not_tls_evidence(self) -> None:
+        baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
+        bundle = mod.bundle_from_artifacts(
+            cc_version=baseline["canonical_http"]["default_version"],
+            tls_observed={
+                "ja3_hash": baseline["tls"]["ja3_hash"],
+                "ja3_raw": baseline["tls"]["ja3_raw"],
+                "source": "baseline_stub_http_only",
+            },
+        )
+        rows = mod.diff_baseline_vs_capture(baseline, bundle)
+        tls_rows = [r for r in rows if r.field.startswith("tls.")]
+        self.assertTrue(all(r.status == "not_observed" for r in tls_rows))
+        self.assertEqual(mod.EXIT_INCOMPLETE, mod.diff_exit_code(tls_rows))
+
+    def test_third_party_http_does_not_compare_oauth_betas(self) -> None:
+        baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
+        bundle = mod.bundle_from_artifacts(
+            cc_version=baseline["canonical_http"]["default_version"],
+            tls_observed={
+                "ja3_hash": baseline["tls"]["ja3_hash"],
+                "ja3_raw": baseline["tls"]["ja3_raw"],
+                "source": "passive-pcap:test",
+                "stainless_package_version": baseline["canonical_http"][
+                    "stainless_package_version"
+                ],
+            },
+            http_by_variant={
+                "haiku": {
+                    "anthropic_beta": "interleaved-thinking",
+                    "x_stainless": {
+                        "X-Stainless-Runtime-Version": baseline["canonical_http"][
+                            "stainless_runtime_version"
+                        ]
+                    },
+                }
+            },
+            system_anchors=[baseline["system"]["identity_prefixes"][0]],
+            http_cohort=mod.THIRD_PARTY_TOKEN,
+        )
+        rows = mod.diff_baseline_vs_capture(baseline, bundle)
+        beta_rows = [r for r in rows if r.field.startswith("betas.")]
+        self.assertTrue(beta_rows)
+        self.assertTrue(all(r.status == "not_observed" for r in beta_rows))
+        self.assertFalse(mod.has_actionable_mismatch(rows))
+        self.assertEqual(mod.EXIT_INCOMPLETE, mod.diff_exit_code(rows))
+
+    def test_unknown_http_cohort_is_invalid_evidence(self) -> None:
+        baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
+        bundle = mod.bundle_from_artifacts(
+            cc_version=baseline["canonical_http"]["default_version"],
+            tls_observed={
+                "ja3_hash": baseline["tls"]["ja3_hash"],
+                "ja3_raw": baseline["tls"]["ja3_raw"],
+                "source": "passive-pcap:test",
+            },
+            http_by_variant={"haiku": {"anthropic_beta": "interleaved-thinking"}},
+        )
+        rows = mod.diff_baseline_vs_capture(baseline, bundle)
+        self.assertTrue(mod.has_invalid_evidence(rows))
+        self.assertEqual(mod.EXIT_ERROR, mod.diff_exit_code(rows))
+
+
+class CaptureConfigClassificationTests(unittest.TestCase):
+    def test_third_party_base_url_wins_over_auth_status_label(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config = pathlib.Path(tmp)
+            (config / "settings.json").write_text(
+                json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://api.tokenkey.dev", "ANTHROPIC_AUTH_TOKEN": "redacted"}}),
+                encoding="utf-8",
+            )
+            result = mod.classify_capture_config(
+                config,
+                auth_status={"loggedIn": True, "authMethod": "oauth_token", "apiProvider": "firstParty"},
+            )
+        self.assertEqual(mod.THIRD_PARTY_TOKEN, result["auth_route"])
+        self.assertEqual("api.tokenkey.dev", result["base_host"])
+
+    def test_direct_anthropic_oauth_is_first_party_cohort(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = mod.classify_capture_config(
+                pathlib.Path(tmp),
+                auth_status={"loggedIn": True, "authMethod": "oauth_token", "apiProvider": "firstParty"},
+            )
+        self.assertEqual(mod.FIRST_PARTY_OAUTH, result["auth_route"])
+
     def test_has_tls_mismatch_true_only_for_tls_fields(self) -> None:
         baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
         tls_rows = mod.diff_baseline_vs_capture(

--- a/ops/anthropic/test_capture_cc_interactive.py
+++ b/ops/anthropic/test_capture_cc_interactive.py
@@ -91,5 +91,29 @@ class ValidateInteractiveHTTPLogTest(unittest.TestCase):
                 mod.validate_interactive_http_log(log)
 
 
+class InteractiveDriverContractTest(unittest.TestCase):
+    def test_timeout_exits_instead_of_restarting_forever(self) -> None:
+        script = (_MOD_PATH.parent / "capture_interactive_repl.exp").read_text(
+            encoding="utf-8"
+        )
+        timeout_body = script.split("timeout {", 1)[1].split("}", 1)[0]
+        self.assertIn("exit 124", timeout_body)
+        self.assertNotIn("exp_continue", timeout_body)
+
+    def test_pcap_requires_pre_authorized_noninteractive_sudo(self) -> None:
+        script = (_MOD_PATH.parent / "capture-cc-interactive.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("sudo -n true", script)
+        self.assertIn("sudo -n tcpdump", script)
+        self.assertNotIn("sudo tcpdump", script)
+
+    def test_headless_capture_declares_allowed_tools(self) -> None:
+        script = (_MOD_PATH.parent / "http_capture_invoke.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("--allowedTools ''", script)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ops/fingerprint/capture-all-fingerprints.sh
+++ b/ops/fingerprint/capture-all-fingerprints.sh
@@ -21,16 +21,16 @@
 #     has no prerequisite stack and never needs an IDE/proxy window, so it always
 #     runs. Mechanically it is the odd one out: the gate is `check`, not `capture`.
 # This umbrella only SEQUENCES them and AGGREGATES the result; it does not merge
-# their capture mechanics. Exit non-zero if any engine reports actionable drift,
-# so CI / a wrapper skill can gate a single combined PR.
+# their capture mechanics. It fails distinctly for drift, invalid evidence/error,
+# and incomplete coverage so a wrapper cannot mistake skipped evidence for alignment.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-CC="$REPO_ROOT/ops/anthropic/capture-cc-fingerprint.sh"
-KIRO="$REPO_ROOT/ops/kiro/capture-kiro-fingerprint.sh"
-ANTIGRAVITY="$REPO_ROOT/ops/antigravity/capture-antigravity-fingerprint.sh"
-CODEX="$REPO_ROOT/ops/openai/capture-codex-fingerprint.sh"
+CC="${TOKENKEY_CAPTURE_ALL_CC:-$REPO_ROOT/ops/anthropic/capture-cc-fingerprint.sh}"
+KIRO="${TOKENKEY_CAPTURE_ALL_KIRO:-$REPO_ROOT/ops/kiro/capture-kiro-fingerprint.sh}"
+ANTIGRAVITY="${TOKENKEY_CAPTURE_ALL_ANTIGRAVITY:-$REPO_ROOT/ops/antigravity/capture-antigravity-fingerprint.sh}"
+CODEX="${TOKENKEY_CAPTURE_ALL_CODEX:-$REPO_ROOT/ops/openai/capture-codex-fingerprint.sh}"
 
 SKIP_CC=0
 SKIP_KIRO=0
@@ -61,7 +61,8 @@ runs (skip it with --skip-codex if codex is not installed). On drift, refresh th
 drifted platform(s)' artifacts and open ONE PR
 (see .cursor/skills/tokenkey-fingerprint-alignment-all).
 
-Exit: 0 = all aligned/skipped, 1 = at least one engine drifted, 2 = a run errored.
+Exit: 0 = all required evidence aligned, 1 = drift, 2 = error/invalid evidence,
+      3 = incomplete coverage (including explicitly skipped engines).
 EOF
 }
 
@@ -80,7 +81,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# status codes per engine: aligned | drift | skipped | error
+# status codes per engine: aligned | drift | incomplete | skipped | error
 CC_STATUS="skipped"
 KIRO_STATUS="skipped"
 ANTIGRAVITY_STATUS="skipped"
@@ -96,6 +97,7 @@ if [[ "$SKIP_CC" == "0" ]]; then
   case "$rc" in
     0) CC_STATUS="aligned" ;;
     1) CC_STATUS="drift" ;;
+    3) CC_STATUS="incomplete" ;;
     *) CC_STATUS="error" ;;
   esac
 fi
@@ -108,6 +110,7 @@ if [[ "$SKIP_KIRO" == "0" ]]; then
   case "$rc" in
     0) KIRO_STATUS="aligned" ;;
     1) KIRO_STATUS="drift" ;;
+    3) KIRO_STATUS="incomplete" ;;
     *) KIRO_STATUS="error" ;;
   esac
 fi
@@ -120,6 +123,7 @@ if [[ "$SKIP_ANTIGRAVITY" == "0" ]]; then
   case "$rc" in
     0) ANTIGRAVITY_STATUS="aligned" ;;
     1) ANTIGRAVITY_STATUS="drift" ;;
+    3) ANTIGRAVITY_STATUS="incomplete" ;;
     *) ANTIGRAVITY_STATUS="error" ;;
   esac
 fi
@@ -133,6 +137,7 @@ if [[ "$SKIP_CODEX" == "0" ]]; then
   case "$rc" in
     0) CODEX_STATUS="aligned" ;;
     1) CODEX_STATUS="drift" ;;
+    3) CODEX_STATUS="incomplete" ;;
     *) CODEX_STATUS="error" ;;
   esac
 fi
@@ -145,13 +150,25 @@ printf "  %-14s %s\n" "antigravity" "$ANTIGRAVITY_STATUS"
 printf "  %-14s %s\n" "codex"       "$CODEX_STATUS"
 echo "==================================================================="
 
-overall=0
+has_drift=0
+has_error=0
+has_incomplete=0
 for st in "$CC_STATUS" "$KIRO_STATUS" "$ANTIGRAVITY_STATUS" "$CODEX_STATUS"; do
   case "$st" in
-    drift) overall=1 ;;
-    error) [[ "$overall" -eq 0 ]] && overall=2 ;;
+    drift) has_drift=1 ;;
+    error) has_error=1 ;;
+    incomplete|skipped) has_incomplete=1 ;;
   esac
 done
+if [[ "$has_error" -eq 1 ]]; then
+  overall=2
+elif [[ "$has_drift" -eq 1 ]]; then
+  overall=1
+elif [[ "$has_incomplete" -eq 1 ]]; then
+  overall=3
+else
+  overall=0
+fi
 
 if [[ "$overall" -eq 1 ]]; then
   echo "→ drift detected. Refresh the drifted platform(s)' artifacts and open ONE PR"
@@ -160,13 +177,16 @@ if [[ "$overall" -eq 1 ]]; then
   echo "  ops/kiro emit-profile -> tk_canonical_kiro_ide.json; antigravity drift bumps"
   echo "  DefaultUserAgentVersion in internal/pkg/antigravity/oauth.go (+ oauth_test.go);"
   echo "  codex drift runs ops/openai emit-edits to bump the 5 codex version pins."
-elif [[ "$overall" -eq 0 ]]; then
-  echo "→ all engines aligned (or skipped). Nothing to commit."
-else
+elif [[ "$overall" -eq 2 ]]; then
   echo "→ an engine ERRORED (rc=2): capture/env failure, NOT fingerprint drift."
   echo "  Common causes: cc0 stack down; kiro got no traffic (sudo + a real Kiro"
   echo "  request needed; Kiro must egress on the captured iface/proxy); Antigravity"
   echo "  not routed through mitm :8080 or not trusting the CA. Fix and re-run."
   echo "  Do NOT refresh any fingerprint artifact on an rc=2 — there is no drift evidence."
+elif [[ "$overall" -eq 3 ]]; then
+  echo "→ coverage incomplete (rc=3): at least one engine was skipped or lacked valid evidence."
+  echo "  Do not claim all fingerprints aligned; collect the missing dimensions and re-run."
+else
+  echo "→ all required engine evidence is observed and aligned. Nothing to commit."
 fi
 exit "$overall"

--- a/ops/fingerprint/client-release-watch.sh
+++ b/ops/fingerprint/client-release-watch.sh
@@ -13,7 +13,7 @@ PY="$REPO_ROOT/scripts/fingerprint/client_release_watch.py"
 usage() {
   cat <<'EOF'
 Usage:
-  client-release-watch.sh [scan] [--plan] [--quiet]   # poll upstream + report (default)
+  client-release-watch.sh [scan] [--plan] [--quiet]   # --plan is strictly read-only
   client-release-watch.sh plan [--report-json PATH]    # skill routing from last/new scan
   client-release-watch.sh selftest                      # engine self-test
 

--- a/ops/fingerprint/test_capture_all_fingerprints.py
+++ b/ops/fingerprint/test_capture_all_fingerprints.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Exit-contract tests for the combined fingerprint orchestrator."""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "ops/fingerprint/capture-all-fingerprints.sh"
+
+
+class CaptureAllExitContractTest(unittest.TestCase):
+    def _run(self, codes: tuple[int, int, int, int], *args: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths: list[Path] = []
+            for index, code in enumerate(codes):
+                path = Path(tmp) / f"engine-{index}.sh"
+                path.write_text(f"#!/usr/bin/env bash\nexit {code}\n", encoding="utf-8")
+                paths.append(path)
+            env = {
+                **os.environ,
+                "TOKENKEY_CAPTURE_ALL_CC": str(paths[0]),
+                "TOKENKEY_CAPTURE_ALL_KIRO": str(paths[1]),
+                "TOKENKEY_CAPTURE_ALL_ANTIGRAVITY": str(paths[2]),
+                "TOKENKEY_CAPTURE_ALL_CODEX": str(paths[3]),
+            }
+            return subprocess.run(
+                ["bash", str(SCRIPT), *args],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+            )
+
+    def test_all_observed_and_aligned_exits_zero(self) -> None:
+        result = self._run((0, 0, 0, 0))
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+
+    def test_drift_exits_one(self) -> None:
+        result = self._run((1, 0, 0, 0))
+        self.assertEqual(1, result.returncode)
+
+    def test_error_takes_precedence(self) -> None:
+        result = self._run((1, 2, 0, 0))
+        self.assertEqual(2, result.returncode)
+
+    def test_incomplete_or_skipped_exits_three(self) -> None:
+        self.assertEqual(3, self._run((3, 0, 0, 0)).returncode)
+        self.assertEqual(3, self._run((0, 0, 0, 0), "--skip-cc").returncode)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/fingerprint/client_release_watch.py
+++ b/scripts/fingerprint/client_release_watch.py
@@ -821,7 +821,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--plan",
         action="store_true",
-        help="After scan, print skill routing (load skill in Cursor, then run capture commands)",
+        help="Read-only scan: print report + skill routing without writing cache/report files",
     )
     parser.add_argument(
         "--plan-only",
@@ -848,10 +848,14 @@ def main(argv: list[str] | None = None) -> int:
     platforms = [scan_platform(spec, offline_upstream=offline) for spec in PLATFORM_SPECS]
     report = build_report(platforms, run_url=args.run_url, git_sha=args.git_sha)
 
-    args.report_json.parent.mkdir(parents=True, exist_ok=True)
-    args.report_json.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    args.report_md.write_text(render_markdown(report), encoding="utf-8")
-    write_state(args.state, report)
+    if not args.plan:
+        args.report_json.parent.mkdir(parents=True, exist_ok=True)
+        args.report_json.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        args.report_md.write_text(render_markdown(report), encoding="utf-8")
+        write_state(args.state, report)
 
     if not args.quiet:
         print(render_markdown(report))

--- a/scripts/fingerprint/test_client_release_watch.py
+++ b/scripts/fingerprint/test_client_release_watch.py
@@ -297,6 +297,29 @@ class MainIntegrationTest(unittest.TestCase):
             self.assertEqual(data["summary"]["drift_count"], 7)
             self.assertEqual(data["summary"]["platform_count"], 9)
 
+            plan_report = tmp_path / "plan-report.json"
+            plan_markdown = tmp_path / "plan-report.md"
+            plan_state = tmp_path / "plan-state.json"
+            with mock.patch("builtins.print"):
+                plan_code = crw.main(
+                    [
+                        "--offline-fixture",
+                        str(fixture_path),
+                        "--report-json",
+                        str(plan_report),
+                        "--report-md",
+                        str(plan_markdown),
+                        "--state",
+                        str(plan_state),
+                        "--plan",
+                        "--quiet",
+                    ]
+                )
+            self.assertIn(plan_code, (0, 1))
+            self.assertFalse(plan_report.exists())
+            self.assertFalse(plan_markdown.exists())
+            self.assertFalse(plan_state.exists())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要

- 为 Claude Code capture bundle 增加 TLS provenance 与 HTTP auth cohort；只有 `first_party_oauth` 流量比较 OAuth beta，3p/API-key cohort 标记 `NOT_OBSERVED`。
- TLS 仅接受 collector 或 passive-pcap provenance；HTTP-only baseline stub 标记未观察，未知显式 source 标记 invalid evidence。
- 统一退出码为 0 aligned、1 drift、2 invalid/error、3 incomplete/skipped；umbrella 不再把 skipped 当 aligned。
- pcap 启动前要求同一终端已有 `sudo -v`，后台只使用 `sudo -n`；REPL expect timeout 硬退出。
- `claude -p` capture 补 `--allowedTools` 并保留真实退出码；`client-release-watch scan --plan` 严格只读。
- 更新 CC/umbrella skills，补记 PR #1353 的 Grok 测试 deletion ledger，并将 `dev-rules` gitlink 对齐 #87 合并后的 `c2de8c4`。

## 风险

- 常规风险，修改运维采集与证据判定，不修改运行时 gateway、TLS profile、OAuth beta 或客户端指纹常量。
- 新增退出码 3 是有意契约变化：缺失/跳过证据不再静默成功。
- `.tls_list` 仍保持本机 gitignored，不改变证据存储策略。
- Web impact: none
- `sentinel-registry-reviewed`
- `upstream-touch-trivial`

## 验证

- 指纹聚焦 unittest：47 passed，1 个本机 capture fixture 因不存在而 skipped。
- `python3 -m unittest ops.anthropic.test_capture_cc_fingerprint -v`：28 passed，1 skipped。
- 两个修改后的 skill 均通过 `quick_validate.py`。
- live `client-release-watch scan --plan` 前后 state hash 不变。
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS。

## 提交

- `2eba72fc9 docs: register merged Grok test deletion`
- `517ef615c fix: make fingerprint evidence cohort-aware`
- `ec094df55 fix(fingerprint): address R-001 — validate TLS evidence provenance`
- `2f72572cc chore: bump dev-rules after #87`
- 最新提交：2f72572cc
