### PR TITLE
feat(dashboard): 按分组展示可观测缓存命中率

### DIFF
--- a/.testing/user-stories/stories/US-006-sticky-routing-prompt-cache.md
+++ b/.testing/user-stories/stories/US-006-sticky-routing-prompt-cache.md
@@ -2,15 +2,16 @@
 
 - ID: US-006
 - Title: Upstream prompt-cache 粘性路由（统一注入）
-- Version: V1.0
+- Version: V1.1
 - Priority: P0
 - As a / I want / So that: 作为 TokenKey 网关运营方，我希望来自同一逻辑会话的请求能携带稳定的 sticky 标识送达上游，以便最大化 OpenAI/Anthropic/GLM 的 prompt cache 命中率，把长程 Agent 任务的 token 成本降下来。
 - Trace: 角色×能力（运营×成本控制）+ 系统事件（每条 gateway 转发请求）+ 防御需求（避免跨 api_key 缓存串桶）
 - Risk Focus:
   - 逻辑错误：派生算法稳定性（同输入同输出）；优先级回退（header > metadata.user_id > prompt_cache_key > derived hash）
   - 行为回归：客户端已送 prompt_cache_key 时不被覆盖；既有 compat 路径自动注入仍可用
+  - 行为回归：分组缓存统计新增字段保持旧字段兼容；raw 与 group daily rollup 分解一致
   - 安全问题：跨 api_key 不互踩；hash 不泄露 system 内容；real Claude Code 客户端的 metadata.user_id 不被改写
-  - 运行时问题：strategy 计算热路径性能（每请求 1 次）；并发 derive 一致
+  - 运行时问题：strategy 计算热路径性能（每请求 1 次）；并发 derive 一致；Dashboard 复用 snapshot group 分面而非 N+1 请求
 
 ## Acceptance Criteria
 
@@ -22,6 +23,9 @@
 6. AC-006 (回归 / 客户端键优先)：Given 客户端 body 已带 `prompt_cache_key`，When 网关派生，Then 客户端值不被覆盖（`TestUS201_DerivePrefersClientPromptCacheKey` + `TestUS201_InjectOpenAI_DoesNotOverrideExisting`）。
 7. AC-007 (安全 / 不串桶)：Given 两个不同 `api_key_id` + 完全相同 system + tools，When 派生，Then 两个 key 不相同（`TestUS201_NoCrossAPIKeyCollision`）。
 8. AC-008 (安全 / 不可逆)：Given system prompt 含敏感字符串，When 派生，Then 输出 16-hex 键不含原文任何子串（`TestUS201_HashNotReversible`）。
+9. AC-009 (正向 / 分组契约)：Given group stats 同时包含 raw 与 rollup 时段，When 查询 snapshot group 分面，Then 每个分组返回 input/output/cache-create/cache-read 分项，且相加等于 `total_tokens`。
+10. AC-010 (负向 / 遥测不可用)：Given `billing_tier=kiro-estimated` 的 usage row，When 聚合 prompt cache，Then其 input 进入 `cache_telemetry_unavailable_input_tokens` 并从可观测命中率分母剔除；纯 Kiro 分组显示“不可观测”而不是 `0%`。
+11. AC-011 (端到端 / 行动排序)：Given 超过 5 个乱序分组且包含混合可观测流量，When 管理员打开 Dashboard，Then真实 UI 按 prompt token 影响量降序只显示前 5 个，点击分组携带当前窗口进入 Usage 明细。
 
 ## Assertions
 
@@ -31,6 +35,9 @@
 - AC-005 后：`StickyStrategy{GlobalEnabled:false, Mode:auto}.EffectiveMode() == passthrough`
 - AC-006 后：注入函数返回 `(body 不变, mut=false, err=nil)`
 - AC-007 后：`derive(api_key=1, body) != derive(api_key=2, body)`
+- AC-009 后：`input + output + cache_creation + cache_read == total_tokens`
+- AC-010 后：可观测分母 `== input - unavailable + cache_creation + cache_read`，分母为 0 时 UI 不渲染 `0.0%`
+- AC-011 后：分组行数 `<= 5`，相邻行 prompt token 单调不增
 - 失败时 testify `require` 立即终止，非 0 退出码
 
 ## Linked Tests
@@ -49,7 +56,15 @@
 - `backend/internal/service/sticky_session_injector_test.go`::`TestUS201_InjectOpenAI_DoesNotOverrideExisting`
 - `backend/internal/service/sticky_session_injector_test.go`::`TestUS201_PassthroughDoesNotDerive`
 - `backend/internal/service/sticky_session_injector_test.go`::`TestUS201_InjectXSessionIDHeader`
-- 运行命令: `cd backend && go test -tags=unit -v -run 'TestUS201_' ./internal/service/`
+- `backend/internal/repository/usage_log_repo_request_type_test.go`::`TestUsageLogRepositoryGetGroupStatsAccountCostColumn`
+- `backend/internal/repository/usage_log_repo_integration_test.go`::`TestUsageLogRepoSuite`（运行时筛选 `TestGroupStatsRollupParity_EqualsLegacyRawScanWithUngrouped` 子测试）
+- `frontend/src/views/admin/__tests__/DashboardView.spec.ts`（分组影响量排序、不可观测与 drilldown 行为）
+- `frontend/src/views/admin/__tests__/UsageView.spec.ts`（drilldown 的分组与绝对时间窗被 Usage 请求消费）
+- `frontend/e2e/dashboard-cache.e2e.ts`（真实浏览器 desktop/mobile 视觉与交互验收）
+- 运行命令: `cd backend && go test -tags=unit -v -run 'TestUS201_|TestUsageLogRepositoryGetGroupStats' ./internal/service/ ./internal/repository/`
+- 运行命令: `cd backend && go test -tags=integration -v -run 'TestUsageLogRepoSuite/TestGroupStatsRollupParity_EqualsLegacyRawScanWithUngrouped' ./internal/repository/`
+- 运行命令: `pnpm --dir frontend exec vitest run src/views/admin/__tests__/DashboardView.spec.ts`
+- 运行命令: `pnpm --dir frontend exec playwright test e2e/dashboard-cache.e2e.ts --project=chromium`
 
 ## Evidence
 

--- a/.testing/user-stories/stories/US-006-sticky-routing-prompt-cache.md
+++ b/.testing/user-stories/stories/US-006-sticky-routing-prompt-cache.md
@@ -63,7 +63,7 @@
 - `frontend/e2e/dashboard-cache.e2e.ts`（真实浏览器 desktop/mobile 视觉与交互验收）
 - 运行命令: `cd backend && go test -tags=unit -v -run 'TestUS201_|TestUsageLogRepositoryGetGroupStats' ./internal/service/ ./internal/repository/`
 - 运行命令: `cd backend && go test -tags=integration -v -run 'TestUsageLogRepoSuite/TestGroupStatsRollupParity_EqualsLegacyRawScanWithUngrouped' ./internal/repository/`
-- 运行命令: `pnpm --dir frontend exec vitest run src/views/admin/__tests__/DashboardView.spec.ts`
+- 运行命令: `pnpm --dir frontend exec vitest run src/views/admin/__tests__/DashboardView.spec.ts src/views/admin/__tests__/UsageView.spec.ts`
 - 运行命令: `pnpm --dir frontend exec playwright test e2e/dashboard-cache.e2e.ts --project=chromium`
 
 ## Evidence
@@ -72,4 +72,4 @@
 
 ## Status
 
-- [x] InTest（注入器骨架 + 派生算法 + 13 个测试已落盘并通过；P1 wire-in 待并入主线后切 Done）
+- [x] InTest（V1.1 实现与自动化验证已完成，待合并后切 Done）

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ FRONTEND_CRITICAL_VITEST := \
 	src/views/user/__tests__/PaymentResultView.spec.ts \
 	src/components/user/profile/__tests__/ProfileInfoCard.spec.ts \
 	src/views/admin/__tests__/SettingsView.spec.ts \
+	src/views/admin/__tests__/DashboardView.spec.ts \
+	src/views/admin/__tests__/UsageView.spec.ts \
 	src/views/user/__tests__/UsageView.spec.ts \
 	src/composables/__tests__/useTkExportPanel.spec.ts
 

--- a/backend/internal/handler/admin/dashboard_handler_cache_test.go
+++ b/backend/internal/handler/admin/dashboard_handler_cache_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -55,6 +56,27 @@ func (r *dashboardUsageRepoCacheProbe) GetUserUsageTrend(
 		Tokens:     20,
 		Cost:       2,
 		ActualCost: 1,
+	}}, nil
+}
+
+func (r *dashboardUsageRepoCacheProbe) GetGroupStatsWithFilters(
+	ctx context.Context,
+	startTime, endTime time.Time,
+	userID, apiKeyID, accountID, groupID int64,
+	requestType *int16,
+	stream *bool,
+	billingType *int8,
+) ([]usagestats.GroupStat, error) {
+	return []usagestats.GroupStat{{
+		GroupID:                              7,
+		GroupName:                            "kiro-group",
+		Requests:                             2,
+		InputTokens:                          100,
+		OutputTokens:                         20,
+		CacheCreationTokens:                  5,
+		CacheReadTokens:                      30,
+		CacheTelemetryUnavailableInputTokens: 40,
+		TotalTokens:                          155,
 	}}, nil
 }
 
@@ -125,4 +147,35 @@ func TestDashboardHandler_GetUserUsageTrend_UsesCache(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec2.Code)
 	require.Equal(t, "hit", rec2.Header().Get("X-Snapshot-Cache"))
 	require.Equal(t, int32(1), repo.usersTrendCalls.Load())
+}
+
+func TestDashboardHandler_SnapshotV2GroupStatsIncludesCacheTelemetryFields(t *testing.T) {
+	t.Cleanup(resetDashboardReadCachesForTest)
+	resetDashboardReadCachesForTest()
+
+	gin.SetMode(gin.TestMode)
+	repo := &dashboardUsageRepoCacheProbe{}
+	dashboardSvc := service.NewDashboardService(repo, nil, nil, nil)
+	handler := NewDashboardHandler(dashboardSvc, nil)
+	router := gin.New()
+	router.GET("/admin/dashboard/snapshot-v2", handler.GetSnapshotV2)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/dashboard/snapshot-v2?include_stats=false&include_trend=false&include_model_stats=false&include_group_stats=true", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var payload struct {
+		Data struct {
+			Groups []map[string]any `json:"groups"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	require.Len(t, payload.Data.Groups, 1)
+	group := payload.Data.Groups[0]
+	require.Equal(t, float64(100), group["input_tokens"])
+	require.Equal(t, float64(20), group["output_tokens"])
+	require.Equal(t, float64(5), group["cache_creation_tokens"])
+	require.Equal(t, float64(30), group["cache_read_tokens"])
+	require.Equal(t, float64(40), group["cache_telemetry_unavailable_input_tokens"])
 }

--- a/backend/internal/pkg/usagestats/usage_log_types.go
+++ b/backend/internal/pkg/usagestats/usage_log_types.go
@@ -137,13 +137,18 @@ type GroupUsageSummary struct {
 
 // GroupStat represents usage statistics for a single group
 type GroupStat struct {
-	GroupID     int64   `json:"group_id"`
-	GroupName   string  `json:"group_name"`
-	Requests    int64   `json:"requests"`
-	TotalTokens int64   `json:"total_tokens"`
-	Cost        float64 `json:"cost"`         // 标准计费
-	ActualCost  float64 `json:"actual_cost"`  // 实际扣除
-	AccountCost float64 `json:"account_cost"` // 账号成本
+	GroupID                              int64   `json:"group_id"`
+	GroupName                            string  `json:"group_name"`
+	Requests                             int64   `json:"requests"`
+	InputTokens                          int64   `json:"input_tokens"`
+	OutputTokens                         int64   `json:"output_tokens"`
+	CacheCreationTokens                  int64   `json:"cache_creation_tokens"`
+	CacheReadTokens                      int64   `json:"cache_read_tokens"`
+	CacheTelemetryUnavailableInputTokens int64   `json:"cache_telemetry_unavailable_input_tokens"`
+	TotalTokens                          int64   `json:"total_tokens"`
+	Cost                                 float64 `json:"cost"`         // 标准计费
+	ActualCost                           float64 `json:"actual_cost"`  // 实际扣除
+	AccountCost                          float64 `json:"account_cost"` // 账号成本
 }
 
 // UserUsageTrendPoint represents user usage trend data point

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -628,20 +628,27 @@ func TestUsageLogRepositoryGetGroupStatsAccountCostColumn(t *testing.T) {
 	start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(24 * time.Hour)
 
-	mock.ExpectQuery("FROM usage_logs").
+	mock.ExpectQuery("FILTER \\(WHERE ul.billing_tier = 'kiro-estimated'\\)").
 		WithArgs(start, end).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"group_id", "group_name", "requests", "total_tokens",
+			"group_id", "group_name", "requests", "input_tokens", "output_tokens",
+			"cache_creation_tokens", "cache_read_tokens", "cache_telemetry_unavailable_input_tokens",
 			"cost", "actual_cost", "account_cost",
 		}).
-			AddRow(int64(1), "azure-cc", int64(100), int64(5000), 10.0, 8.5, 7.2).
-			AddRow(int64(2), "max", int64(50), int64(2000), 5.0, 4.0, 3.5))
+			AddRow(int64(1), "azure-cc", int64(100), int64(1000), int64(3000), int64(500), int64(500), int64(1000), 10.0, 8.5, 7.2).
+			AddRow(int64(2), "max", int64(50), int64(500), int64(1000), int64(200), int64(300), int64(0), 5.0, 4.0, 3.5))
 
 	results, err := repo.GetGroupStatsWithFilters(context.Background(), start, end, 0, 0, 0, 0, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 	require.Equal(t, int64(1), results[0].GroupID)
 	require.Equal(t, "azure-cc", results[0].GroupName)
+	require.Equal(t, int64(1000), results[0].InputTokens)
+	require.Equal(t, int64(3000), results[0].OutputTokens)
+	require.Equal(t, int64(500), results[0].CacheCreationTokens)
+	require.Equal(t, int64(500), results[0].CacheReadTokens)
+	require.Equal(t, int64(1000), results[0].CacheTelemetryUnavailableInputTokens)
+	require.Equal(t, int64(5000), results[0].TotalTokens)
 	require.Equal(t, 10.0, results[0].Cost)
 	require.Equal(t, 8.5, results[0].ActualCost)
 	require.Equal(t, 7.2, results[0].AccountCost)
@@ -665,9 +672,10 @@ func TestUsageLogRepositoryGetGroupStatsRollupFallbackUntilMetricsBackfill(t *te
 	mock.ExpectQuery("FROM usage_logs").
 		WithArgs(start, end).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"group_id", "group_name", "requests", "total_tokens",
+			"group_id", "group_name", "requests", "input_tokens", "output_tokens",
+			"cache_creation_tokens", "cache_read_tokens", "cache_telemetry_unavailable_input_tokens",
 			"cost", "actual_cost", "account_cost",
-		}).AddRow(int64(1), "azure-cc", int64(100), int64(5000), 10.0, 8.5, 7.2))
+		}).AddRow(int64(1), "azure-cc", int64(100), int64(1000), int64(3000), int64(500), int64(500), int64(1000), 10.0, 8.5, 7.2))
 
 	results, err := repo.GetGroupStatsWithFilters(context.Background(), start, end, 0, 0, 0, 0, nil, nil, nil)
 	require.NoError(t, err)
@@ -710,12 +718,25 @@ func TestUsageLogRepositoryGetGroupStatsRollupMergesCompletedDaysAndRawTail(t *t
 			AddRow(int64(1), "azure-cc", int64(3), int64(30), int64(40), int64(2), int64(1), 0.7, 0.6, 0.5).
 			AddRow(int64(3), "other", int64(1), int64(5), int64(7), int64(0), int64(0), 0.2, 0.1, 0.1))
 
+	mock.ExpectQuery("AND ul.billing_tier = 'kiro-estimated'").
+		WithArgs(start, end).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"group_id", "cache_telemetry_unavailable_input_tokens",
+		}).
+			AddRow(int64(1), int64(30)).
+			AddRow(int64(3), int64(5)))
+
 	results, err := repo.GetGroupStatsWithFilters(context.Background(), start, end, 0, 0, 0, 0, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, results, 4)
 	require.Equal(t, int64(1), results[0].GroupID)
 	require.Equal(t, "azure-cc", results[0].GroupName)
 	require.Equal(t, int64(13), results[0].Requests)
+	require.Equal(t, int64(130), results[0].InputTokens)
+	require.Equal(t, int64(240), results[0].OutputTokens)
+	require.Equal(t, int64(7), results[0].CacheCreationTokens)
+	require.Equal(t, int64(4), results[0].CacheReadTokens)
+	require.Equal(t, int64(30), results[0].CacheTelemetryUnavailableInputTokens)
 	require.Equal(t, int64(381), results[0].TotalTokens)
 	require.InDelta(t, 2.7, results[0].Cost, 1e-9)
 	require.InDelta(t, 2.1, results[0].ActualCost, 1e-9)
@@ -1403,9 +1424,10 @@ func TestUsageLogRepositoryGetGroupStatsWithUsageFiltersAppliesRequestedModelFil
 	mock.ExpectQuery("AND COALESCE\\(NULLIF\\(TRIM\\(ul.requested_model\\), ''\\), ul.model\\) = \\$3").
 		WithArgs(start, end, "gpt-5").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"group_id", "group_name", "requests", "total_tokens",
+			"group_id", "group_name", "requests", "input_tokens", "output_tokens",
+			"cache_creation_tokens", "cache_read_tokens", "cache_telemetry_unavailable_input_tokens",
 			"cost", "actual_cost", "account_cost",
-		}).AddRow(int64(1), "default", int64(1), int64(30), 0.1, 0.08, 0.07))
+		}).AddRow(int64(1), "default", int64(1), int64(10), int64(20), int64(0), int64(0), int64(0), 0.1, 0.08, 0.07))
 
 	results, err := repo.GetGroupStatsWithUsageFilters(context.Background(), start, end, filters)
 	require.NoError(t, err)

--- a/backend/internal/repository/usage_log_repo_tk_group_rollup.go
+++ b/backend/internal/repository/usage_log_repo_tk_group_rollup.go
@@ -90,15 +90,16 @@ func (r *usageLogRepository) groupUsageSummaryFromRollup(ctx context.Context, to
 }
 
 type groupStatAgg struct {
-	groupName           string
-	requests            int64
-	inputTokens         int64
-	outputTokens        int64
-	cacheCreationTokens int64
-	cacheReadTokens     int64
-	cost                float64
-	actualCost          float64
-	accountCost         float64
+	groupName                            string
+	requests                             int64
+	inputTokens                          int64
+	outputTokens                         int64
+	cacheCreationTokens                  int64
+	cacheReadTokens                      int64
+	cacheTelemetryUnavailableInputTokens int64
+	cost                                 float64
+	actualCost                           float64
+	accountCost                          float64
 }
 
 func shouldUseGroupDailyStatsRollup(userID, apiKeyID, accountID int64, requestType *int16, stream *bool, billingType *int8) bool {
@@ -262,16 +263,62 @@ func (r *usageLogRepository) getGroupStatsFromRollup(
 		}
 	}
 
+	// billing_tier is not part of the daily rollup. Read only Kiro-estimated rows
+	// from the selected raw window so their input is never
+	// mistaken for observable cache telemetry, without widening the rollup schema.
+	telemetryQuery := `
+		SELECT
+			COALESCE(ul.group_id, 0) AS group_id,
+			COALESCE(SUM(ul.input_tokens), 0)
+		FROM usage_logs ul
+		WHERE ul.created_at >= $1 AND ul.created_at < $2
+		  AND ul.billing_tier = 'kiro-estimated'
+	`
+	telemetryArgs := []any{startTime, endTime}
+	if groupID > 0 {
+		telemetryQuery += " AND ul.group_id = $3"
+		telemetryArgs = append(telemetryArgs, groupID)
+	}
+	telemetryQuery += " GROUP BY ul.group_id"
+	telemetryRows, err := r.sql.QueryContext(ctx, telemetryQuery, telemetryArgs...)
+	if err != nil {
+		return nil, false, err
+	}
+	for telemetryRows.Next() {
+		var id, unavailableInput int64
+		if err := telemetryRows.Scan(&id, &unavailableInput); err != nil {
+			_ = telemetryRows.Close()
+			return nil, false, err
+		}
+		a, ok := byGroupID[id]
+		if !ok {
+			a = &groupStatAgg{}
+			byGroupID[id] = a
+		}
+		a.cacheTelemetryUnavailableInputTokens = unavailableInput
+	}
+	if err := telemetryRows.Close(); err != nil {
+		return nil, false, err
+	}
+	if err := telemetryRows.Err(); err != nil {
+		return nil, false, err
+	}
+
 	results := make([]usagestats.GroupStat, 0, len(byGroupID))
 	for id, a := range byGroupID {
 		results = append(results, usagestats.GroupStat{
-			GroupID:     id,
-			GroupName:   a.groupName,
-			Requests:    a.requests,
-			TotalTokens: a.inputTokens + a.outputTokens + a.cacheCreationTokens + a.cacheReadTokens,
-			Cost:        a.cost,
-			ActualCost:  a.actualCost,
-			AccountCost: a.accountCost,
+			GroupID:                              id,
+			GroupName:                            a.groupName,
+			Requests:                             a.requests,
+			InputTokens:                          a.inputTokens,
+			OutputTokens:                         a.outputTokens,
+			CacheCreationTokens:                  a.cacheCreationTokens,
+			CacheReadTokens:                      a.cacheReadTokens,
+			CacheTelemetryUnavailableInputTokens: a.cacheTelemetryUnavailableInputTokens,
+			TotalTokens:                          a.inputTokens + a.outputTokens + a.cacheCreationTokens + a.cacheReadTokens,
+			Cost:                                 a.cost,
+			ActualCost:                           a.actualCost,
+			AccountCost:                          a.accountCost,
 		})
 	}
 	sort.Slice(results, func(i, j int) bool {

--- a/backend/internal/repository/usage_log_repo_tk_group_rollup_integration_test.go
+++ b/backend/internal/repository/usage_log_repo_tk_group_rollup_integration_test.go
@@ -44,6 +44,27 @@ func (s *UsageLogRepoSuite) rollupParityCreateUngroupedLog(user *service.User, a
 	s.Require().NoError(err)
 }
 
+func (s *UsageLogRepoSuite) rollupParityCreateKiroLog(user *service.User, apiKey *service.APIKey, account *service.Account, groupID *int64, in, out, cacheCreate, cacheRead int, cost float64, createdAt time.Time) {
+	billingTier := "kiro-estimated"
+	log := &service.UsageLog{
+		UserID:              user.ID,
+		APIKeyID:            apiKey.ID,
+		AccountID:           account.ID,
+		GroupID:             groupID,
+		Model:               "claude-3",
+		InputTokens:         in,
+		OutputTokens:        out,
+		CacheCreationTokens: cacheCreate,
+		CacheReadTokens:     cacheRead,
+		BillingTier:         &billingTier,
+		TotalCost:           cost,
+		ActualCost:          cost,
+		CreatedAt:           createdAt,
+	}
+	_, err := s.repo.Create(s.ctx, log)
+	s.Require().NoError(err)
+}
+
 // TestGroupRollupParity_EqualsLegacyRawScan is the load-bearing equality test for
 // the per-(group, day) rollup that backs GetAllGroupUsageSummary. It builds a
 // fixture spanning two groups over completed past days + today, then asserts:
@@ -133,10 +154,10 @@ func (s *UsageLogRepoSuite) TestGroupStatsRollupParity_EqualsLegacyRawScanWithUn
 
 	// Real groups across completed days + today's raw tail.
 	s.rollupParityCreateLog(user, key, acc, grpA.ID, 10, 20, 0, 0, 0.50, day5)
-	s.rollupParityCreateLog(user, key, acc, grpA.ID, 5, 7, 1, 2, 0.10, todayPoint)
+	s.rollupParityCreateKiroLog(user, key, acc, &grpA.ID, 5, 7, 1, 2, 0.10, todayPoint)
 	s.rollupParityCreateLog(user, key, acc, grpB.ID, 2, 3, 0, 0, 0.20, day2)
 	// Ungrouped usage must stay visible as group_id=0 in group distribution.
-	s.rollupParityCreateUngroupedLog(user, key, acc, 3, 4, 5, 6, 0.20, day2)
+	s.rollupParityCreateKiroLog(user, key, acc, nil, 3, 4, 5, 6, 0.20, day2)
 	s.rollupParityCreateUngroupedLog(user, key, acc, 7, 8, 0, 1, 0.05, todayPoint)
 
 	// Before aggregation the metrics marker is absent, so this is the legacy raw
@@ -146,6 +167,11 @@ func (s *UsageLogRepoSuite) TestGroupStatsRollupParity_EqualsLegacyRawScanWithUn
 	preIdx := indexGroupStats(pre)
 	s.Require().Contains(preIdx, int64(0), "legacy raw path must expose ungrouped usage as group_id=0")
 	s.Equal(int64(2), preIdx[0].Requests)
+	s.Equal(int64(10), preIdx[0].InputTokens)
+	s.Equal(int64(12), preIdx[0].OutputTokens)
+	s.Equal(int64(5), preIdx[0].CacheCreationTokens)
+	s.Equal(int64(7), preIdx[0].CacheReadTokens)
+	s.Equal(int64(3), preIdx[0].CacheTelemetryUnavailableInputTokens)
 	s.Equal(int64(34), preIdx[0].TotalTokens)
 	s.InDelta(0.25, preIdx[0].ActualCost, 1e-9)
 
@@ -163,6 +189,11 @@ func (s *UsageLogRepoSuite) TestGroupStatsRollupParity_EqualsLegacyRawScanWithUn
 		s.Require().True(ok, "rollup path missing group_id=%d", groupID)
 		s.Equal(want.GroupName, got.GroupName, "group_name group_id=%d", groupID)
 		s.Equal(want.Requests, got.Requests, "requests group_id=%d", groupID)
+		s.Equal(want.InputTokens, got.InputTokens, "input_tokens group_id=%d", groupID)
+		s.Equal(want.OutputTokens, got.OutputTokens, "output_tokens group_id=%d", groupID)
+		s.Equal(want.CacheCreationTokens, got.CacheCreationTokens, "cache_creation_tokens group_id=%d", groupID)
+		s.Equal(want.CacheReadTokens, got.CacheReadTokens, "cache_read_tokens group_id=%d", groupID)
+		s.Equal(want.CacheTelemetryUnavailableInputTokens, got.CacheTelemetryUnavailableInputTokens, "cache_telemetry_unavailable_input_tokens group_id=%d", groupID)
 		s.Equal(want.TotalTokens, got.TotalTokens, "tokens group_id=%d", groupID)
 		s.InDelta(want.Cost, got.Cost, 1e-9, "cost group_id=%d", groupID)
 		s.InDelta(want.ActualCost, got.ActualCost, 1e-9, "actual_cost group_id=%d", groupID)

--- a/backend/internal/repository/usage_log_repo_trend.go
+++ b/backend/internal/repository/usage_log_repo_trend.go
@@ -476,7 +476,11 @@ func (r *usageLogRepository) getGroupStatsWithFilters(ctx context.Context, start
 			COALESCE(ul.group_id, 0) as group_id,
 			COALESCE(g.name, '') as group_name,
 			COUNT(*) as requests,
-			COALESCE(SUM(ul.input_tokens + ul.output_tokens + ul.cache_creation_tokens + ul.cache_read_tokens), 0) as total_tokens,
+			COALESCE(SUM(ul.input_tokens), 0) as input_tokens,
+			COALESCE(SUM(ul.output_tokens), 0) as output_tokens,
+			COALESCE(SUM(ul.cache_creation_tokens), 0) as cache_creation_tokens,
+			COALESCE(SUM(ul.cache_read_tokens), 0) as cache_read_tokens,
+			COALESCE(SUM(ul.input_tokens) FILTER (WHERE ul.billing_tier = 'kiro-estimated'), 0) as cache_telemetry_unavailable_input_tokens,
 			COALESCE(SUM(ul.total_cost), 0) as cost,
 			COALESCE(SUM(ul.actual_cost), 0) as actual_cost,
 			COALESCE(SUM(COALESCE(ul.account_stats_cost, ul.total_cost) * COALESCE(ul.account_rate_multiplier, 1)), 0) as account_cost
@@ -513,7 +517,7 @@ func (r *usageLogRepository) getGroupStatsWithFilters(ctx context.Context, start
 		args = append(args, int16(*billingType))
 	}
 	query, args = appendUsageLogBillingModeQueryFilter(query, args, billingMode, "ul")
-	query += " GROUP BY ul.group_id, g.name ORDER BY total_tokens DESC"
+	query += " GROUP BY ul.group_id, g.name ORDER BY (COALESCE(SUM(ul.input_tokens), 0) + COALESCE(SUM(ul.output_tokens), 0) + COALESCE(SUM(ul.cache_creation_tokens), 0) + COALESCE(SUM(ul.cache_read_tokens), 0)) DESC"
 
 	rows, err := r.sql.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -533,13 +537,18 @@ func (r *usageLogRepository) getGroupStatsWithFilters(ctx context.Context, start
 			&row.GroupID,
 			&row.GroupName,
 			&row.Requests,
-			&row.TotalTokens,
+			&row.InputTokens,
+			&row.OutputTokens,
+			&row.CacheCreationTokens,
+			&row.CacheReadTokens,
+			&row.CacheTelemetryUnavailableInputTokens,
 			&row.Cost,
 			&row.ActualCost,
 			&row.AccountCost,
 		); err != nil {
 			return nil, err
 		}
+		row.TotalTokens = row.InputTokens + row.OutputTokens + row.CacheCreationTokens + row.CacheReadTokens
 		results = append(results, row)
 	}
 	if err := rows.Err(); err != nil {

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 605,
-  "hash": "fcc68971ee723565e48f868bfe73145cf942baea03be76c887dd53965b33d111",
+  "hash": "e7a1bea9a439d9259cd693bed15eca83e91d774f82861b73e7758e8d2ffb303e",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 605,
-  "hash": "2f5b9f0662403f2e02dffcb370fd4c81dc94a006b5f4171b6b26c54262026003",
+  "hash": "fcc68971ee723565e48f868bfe73145cf942baea03be76c887dd53965b33d111",
   "schema": 1,
   "source": "frontend/"
 }

--- a/docs/approved/sticky-routing.md
+++ b/docs/approved/sticky-routing.md
@@ -253,36 +253,28 @@ type GroupStat struct {
 
 ### 6.1 User Story
 
-`.testing/user-stories/stories/US-201-sticky-routing.md`（编号待定）覆盖：
-- AC-001 (正向, OpenAI Codex)：Cursor 客户端连续 5 个请求未送 prompt_cache_key + 同 system → 全部上游 body 注入相同的 `tk_*` key
-- AC-002 (正向, Anthropic mimic)：非 Claude Code UA + Anthropic OAuth 账号 + 客户端无 metadata → 网关注入 metadata.user_id
-- AC-003 (负向, 真 Claude Code)：UA=Claude Code + Anthropic OAuth → 不注入 metadata（不打架）
-- AC-004 (负向, group=off)：分组 mode=off → 不论客户端送什么都不派生
-- AC-005 (负向, global=off)：全局开关关闭 → 所有分组都不派生
-- AC-006 (回归)：客户端已送 prompt_cache_key → 网关不覆盖（passthrough 优先）
-- AC-007 (回归, compat 路径)：`gpt-5.4` 现有自动注入行为不变
+`.testing/user-stories/stories/US-006-sticky-routing-prompt-cache.md` 是本设计的验收 SSOT。缓存可视化修订由 AC-009 至 AC-011 覆盖：分组 Token 契约与 raw/rollup 一致、Kiro 不可观测输入不计作 miss、Top 5 排序与同窗口分组钻取。
 
 ### 6.2 测试文件
 
 | 文件 | 覆盖 |
 |---|---|
 | `backend/internal/service/sticky_session_injector_test.go` | Derive 五级回退；各 Inject* 方法 |
-| `backend/internal/service/sticky_session_strategy_test.go` | global/group 合成；StickyMode 三档行为 |
-| `backend/internal/service/openai_gateway_service_sticky_test.go` | 既有 hot-path 测试加 sticky 注入用例 |
-| `backend/internal/handler/openai_gateway_handler_messages_sticky_test.go` | Messages→OpenAI 路径 |
-| `backend/internal/service/gateway_service_sticky_test.go` | Anthropic mimic / Claude Code skip |
-| `frontend/src/components/keys/__tests__/UseKeyModal.spec.ts` | 已加（P0） |
-| `frontend/src/views/admin/__tests__/GroupsViewSticky.spec.ts` | 分组下拉 |
-| `frontend/src/views/admin/__tests__/DashboardCacheCard.spec.ts` | 命中率卡片 |
+| `backend/internal/repository/usage_log_repo_request_type_test.go` | raw/rollup SQL 契约、Token 分项与 Kiro 不可观测输入 |
+| `backend/internal/repository/usage_log_repo_tk_group_rollup_integration_test.go` | PostgreSQL raw/rollup 分组统计 parity |
+| `backend/internal/handler/admin/dashboard_handler_cache_test.go` | snapshot-v2 分组字段 JSON 契约 |
+| `frontend/src/views/admin/__tests__/DashboardView.spec.ts` | 总体/分组可观测状态、Top 5 与钻取参数 |
+| `frontend/src/views/admin/__tests__/UsageView.spec.ts` | Usage 消费分组与绝对时间窗 |
+| `frontend/e2e/dashboard-cache.e2e.ts` | 真实浏览器 desktop/mobile 展示与钻取 |
 
 ### 6.3 风险覆盖
 
 | 风险类型 | 场景 | 测试 |
 |---|---|---|
-| 逻辑错误 | 派生算法稳定性（同输入得同输出） | `TestUS201_DeriveStable` |
-| 行为回归 | 既有 compat 自动注入 | `TestUS201_CompatAutoInjectUnchanged` |
-| 安全问题 | 跨 api_key 不互踩；hash 不泄露 system 内容 | `TestUS201_NoCrossAPIKeyCollision`, `TestUS201_HashNotReversible` |
-| 运行时问题 | strategy 计算的 hot-path 性能；并发 derive 一致 | benchmark + `-race` |
+| 逻辑错误 | 可观测分母、影响量排序、raw/rollup parity | repository tests + `DashboardView.spec.ts` |
+| 行为回归 | snapshot 旧字段兼容、纯 Kiro 不显示 `0%` | handler contract + frontend tests |
+| 端到端体验 | 同窗口分组钻取、desktop/mobile 无溢出 | `UsageView.spec.ts` + Playwright |
+| 上游覆盖 | TK 聚合与 UI 入口被 upstream rewrite 冲掉 | gateway/frontend sentinel registries |
 
 ---
 

--- a/docs/approved/sticky-routing.md
+++ b/docs/approved/sticky-routing.md
@@ -1,9 +1,9 @@
 ---
 title: Sticky Routing & Prompt Cache Optimization
-status: shipped
-approved_by: xuejiao (post-hoc 2026-04-19)
-approved_at: 2026-04-19
-shipped_at: 2026-04-19
+status: approved
+approved_by: "xuejiao (design revision, this session, 2026-07-16)"
+approved_at: 2026-07-16
+previous_version_shipped_at: 2026-04-19
 authors: [agent]
 created: 2026-04-17
 related_prs: []
@@ -213,28 +213,39 @@ SettingKeyStickyRoutingEnabled = "gateway.sticky_routing.enabled"  // bool, defa
 
 ### 5.1 后端聚合
 
-`backend/internal/handler/admin/dashboard_handler.go` 已有 `total_cache_read_tokens`。新增按时间窗 + 按 group/api_key 的命中率字段：
+复用现有 `GET /admin/dashboard/snapshot-v2?include_group_stats=true`，禁止新增只服务同一意图的 cache-stats endpoint。`GroupStat` 在既有成本字段之外返回可核算的 prompt token 分解：
 
 ```go
-type CacheStats struct {
-    InputTokens     int64   `json:"input_tokens"`
-    CacheReadTokens int64   `json:"cache_read_tokens"`
-    HitRate         float64 `json:"hit_rate"`  // CacheReadTokens / (InputTokens + CacheReadTokens)
+type GroupStat struct {
+    InputTokens                         int64 `json:"input_tokens"`
+    OutputTokens                        int64 `json:"output_tokens"`
+    CacheCreationTokens                 int64 `json:"cache_creation_tokens"`
+    CacheReadTokens                     int64 `json:"cache_read_tokens"`
+    CacheTelemetryUnavailableInputTokens int64 `json:"cache_telemetry_unavailable_input_tokens"`
 }
 ```
 
-新接口（小步加，不动既有）：
-- `GET /admin/dashboard/cache-stats?window=24h&group_by=api_key`
-- 复用现有 `usage_logs` 查询，加 `GROUP BY api_key_id`。
+`cache_telemetry_unavailable_input_tokens` 的 SSOT 是持久化 usage row 的 `billing_tier='kiro-estimated'`。Kiro 上游只返回 credits，TokenKey 本地估算 input，不能把这部分当作 cache miss。混合分组的可观测分母为：
+
+```text
+(input_tokens - cache_telemetry_unavailable_input_tokens)
++ cache_creation_tokens
++ cache_read_tokens
+```
+
+命中率由前端基于整数 token 聚合后计算，API 不持久化易漂移的百分比。group daily rollup 已包含 input/output/cache 分项；不可观测 input 在选定窗口按 usage row 精确聚合，不按 group.platform 或分组名称猜测。
 
 ### 5.2 前端卡片
 
-`frontend/src/views/admin/DashboardView.vue` 加一个 "Prompt Cache 命中率" 卡片：
-- 顶部数字：过去 24h 整体命中率（百分比 + 绝对节省的 input tokens）
-- 下方 mini-table：top 5 API key by 命中率（升序，凸显需要优化的）
-- 颜色：>50% 绿、20-50% 黄、<20% 红
+`frontend/src/views/admin/DashboardView.vue` 的旧 Today/Total 全站卡片替换为一个行动导向的分组卡片：
 
-无需 chart 库新依赖（用现有 stat-card 组件 + 简单 v-for 列表）。
+- 顶部只显示当前筛选窗口的**可观测命中率**；默认窗口沿用 Dashboard 的滚动 24 小时，不复用 calendar-day `stats.today_*`。
+- 下方最多显示 5 个分组，按 prompt 影响量 `input + cache_creation + cache_read` 降序，而不是按百分比制造小流量噪声。
+- 每行只保留分组名、可观测命中率（或不可观测状态）、cache read 绝对量；点击进入带相同时间窗和 `group_id` 的 Usage 明细。
+- 可观测分母为 0 且存在不可观测 input 时显示“不可观测”，禁止显示 `0%`；混合流量显示可观测部分的百分比并标记“部分可观测”。
+- 不设置跨平台统一健康阈值；不同上游的 cache 语义不同，颜色阈值会制造虚假结论。
+
+无需 chart 库或新组件；该行为只在 Dashboard 消费，页面 owner 负责展示与 drilldown 编排。
 
 ---
 
@@ -321,7 +332,7 @@ type CacheStats struct {
 
 1. ✅ **字段命名 `sticky_routing_mode`** — 已采用。理由：覆盖更广（含 NewAPI X-Session-Id 等非 cache 场景），与 `prompt_cache_*` 解耦。
    schema：`backend/ent/schema/group.go` enum；migration：`backend/migrations/tk_002_add_groups_sticky_routing_mode.sql`。
-2. ✅ **Dashboard 卡片只读最近 24h** — 已采用。`frontend/src/views/admin/DashboardView.vue` 仅暴露 `promptCacheHitRateToday/Total`，不引入时间窗切换。
+2. ✅ **Dashboard 卡片跟随当前筛选窗口** — 2026-07-16 修订批准：默认仍是滚动 24h；移除误导性的 Today/Total 双值，改为分组影响量 Top 5 与不可观测状态。
 3. ✅ **derive 兜底用 system 前 2KB** — 已采用。常量：`backend/internal/service/sticky_session_injector.go::stickyDerivedSystemPromptCap = 2 * 1024`。极少数超长 system prompt 撞桶问题观察后再优化。
 4. ✅ **NewAPI X-Session-Id 与 OpenAI/Anthropic 注入同 PR** — 已采用（实际是 `a68dee5b` 一次提交全部落地）。访问点：`backend/internal/service/openai_gateway_bridge_dispatch.go::applyStickyToNewAPIBridge`。
 

--- a/docs/approved/sticky-routing.md
+++ b/docs/approved/sticky-routing.md
@@ -283,7 +283,7 @@ type GroupStat struct {
 > **实施实情（2026-04-19 事后盘点）**：本表是设计当时拟定的"理想 8-PR 切分"。
 > 代码实际以**单提交 `a68dee5b`**（2026-04-18）一次性落地（schema + injector + 6 处接入点 + 单测 + UI），未拆 PR。
 > 这违反了 `product-dev.mdc` §阶段 2 → 审批 → §阶段 3 顺序，详见 §11 实施情况。
-> 下次同等规模特性必须按本表切分。
+> 本表仅保留历史设计意图，不作为后续拆 PR 规范；当前遵循 `product-dev.mdc` 的默认单 PR 路径。
 
 | 顺序 | 内容 | PR 标题 | 可独立 review |
 |---|---|---|---|
@@ -296,7 +296,7 @@ type GroupStat struct {
 | 7 | 全局 + 分组 UI | `feat: ui controls for sticky routing strategy` | ✅ |
 | 8 | Dashboard cache 命中率卡片 | `feat: cache hit rate dashboard card` | ✅ |
 
-> 本设计文档（pending）merge 后才能进入 PR 2-8。
+> 历史原计划是在设计文档从 pending 转为 approved 后再实施；当前审批状态以本文 frontmatter 为准。
 
 ---
 

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -12,3 +12,7 @@ dist/
 # 忽略缓存
 .cache/
 .vite/
+
+# Playwright generated output
+e2e/artifacts/
+e2e/report/

--- a/frontend/e2e/dashboard-cache.e2e.ts
+++ b/frontend/e2e/dashboard-cache.e2e.ts
@@ -242,6 +242,7 @@ async function assertCacheCard(page: Page, screenshotName: string): Promise<void
   ])
   await expect(card.getByText('Small OpenAI')).toHaveCount(0)
   await expect(card.getByText('Tiny Anthropic')).toHaveCount(0)
+  await expect(card.getByTestId('prompt-cache-overall-status')).toContainText(/部分可观测|Partially observable/i)
 
   const kiroRow = rows.filter({ hasText: 'Claude Kiro' })
   await expect(kiroRow).toContainText(/不可观测|Not observable/i)

--- a/frontend/e2e/dashboard-cache.e2e.ts
+++ b/frontend/e2e/dashboard-cache.e2e.ts
@@ -1,0 +1,280 @@
+import { expect, test, type Page, type Route } from '@playwright/test'
+
+const ADMIN = {
+  id: 1,
+  username: 'cache-admin',
+  email: 'cache-admin@tokenkey.local',
+  role: 'admin',
+  balance: 100,
+  concurrency: 10,
+  status: 'active',
+  allowed_groups: null,
+  balance_notify_enabled: false,
+  balance_notify_threshold: null,
+  balance_notify_extra_emails: [],
+  created_at: '2026-07-16T00:00:00Z',
+  updated_at: '2026-07-16T00:00:00Z',
+}
+
+const GROUPS = [
+  {
+    group_id: 102,
+    group_name: 'Claude Kiro',
+    requests: 120,
+    input_tokens: 1_180_000,
+    output_tokens: 20_000,
+    cache_creation_tokens: 0,
+    cache_read_tokens: 0,
+    cache_telemetry_unavailable_input_tokens: 1_180_000,
+    total_tokens: 1_200_000,
+    cost: 0,
+    actual_cost: 0,
+    account_cost: 0,
+  },
+  {
+    group_id: 101,
+    group_name: 'GPT Production',
+    requests: 100,
+    input_tokens: 150_000,
+    output_tokens: 50_000,
+    cache_creation_tokens: 50_000,
+    cache_read_tokens: 750_000,
+    cache_telemetry_unavailable_input_tokens: 0,
+    total_tokens: 1_000_000,
+    cost: 0,
+    actual_cost: 0,
+    account_cost: 0,
+  },
+  {
+    group_id: 103,
+    group_name: 'DeepSeek',
+    requests: 90,
+    input_tokens: 480_000,
+    output_tokens: 40_000,
+    cache_creation_tokens: 80_000,
+    cache_read_tokens: 200_000,
+    cache_telemetry_unavailable_input_tokens: 0,
+    total_tokens: 800_000,
+    cost: 0,
+    actual_cost: 0,
+    account_cost: 0,
+  },
+  {
+    group_id: 104,
+    group_name: 'Gemini',
+    requests: 80,
+    input_tokens: 300_000,
+    output_tokens: 50_000,
+    cache_creation_tokens: 50_000,
+    cache_read_tokens: 200_000,
+    cache_telemetry_unavailable_input_tokens: 0,
+    total_tokens: 600_000,
+    cost: 0,
+    actual_cost: 0,
+    account_cost: 0,
+  },
+  {
+    group_id: 105,
+    group_name: 'Grok',
+    requests: 70,
+    input_tokens: 260_000,
+    output_tokens: 40_000,
+    cache_creation_tokens: 50_000,
+    cache_read_tokens: 150_000,
+    cache_telemetry_unavailable_input_tokens: 0,
+    total_tokens: 500_000,
+    cost: 0,
+    actual_cost: 0,
+    account_cost: 0,
+  },
+  {
+    group_id: 106,
+    group_name: 'Small OpenAI',
+    requests: 20,
+    input_tokens: 100_000,
+    output_tokens: 20_000,
+    cache_creation_tokens: 30_000,
+    cache_read_tokens: 50_000,
+    cache_telemetry_unavailable_input_tokens: 0,
+    total_tokens: 200_000,
+    cost: 0,
+    actual_cost: 0,
+    account_cost: 0,
+  },
+  {
+    group_id: 107,
+    group_name: 'Tiny Anthropic',
+    requests: 10,
+    input_tokens: 70_000,
+    output_tokens: 10_000,
+    cache_creation_tokens: 10_000,
+    cache_read_tokens: 10_000,
+    cache_telemetry_unavailable_input_tokens: 0,
+    total_tokens: 100_000,
+    cost: 0,
+    actual_cost: 0,
+    account_cost: 0,
+  },
+]
+
+const DASHBOARD_STATS = {
+  total_users: 10,
+  today_new_users: 1,
+  active_users: 5,
+  hourly_active_users: 2,
+  stats_updated_at: '2026-07-16T08:00:00Z',
+  stats_stale: false,
+  total_api_keys: 8,
+  active_api_keys: 7,
+  total_accounts: 12,
+  normal_accounts: 11,
+  error_accounts: 1,
+  ratelimit_accounts: 0,
+  overload_accounts: 0,
+  total_requests: 1_000,
+  total_input_tokens: 2_540_000,
+  total_output_tokens: 230_000,
+  total_cache_creation_tokens: 270_000,
+  total_cache_read_tokens: 1_360_000,
+  total_tokens: 4_400_000,
+  total_cost: 10,
+  total_actual_cost: 8,
+  total_account_cost: 7,
+  today_requests: 500,
+  today_input_tokens: 2_540_000,
+  today_output_tokens: 230_000,
+  today_cache_creation_tokens: 270_000,
+  today_cache_read_tokens: 1_360_000,
+  today_tokens: 4_400_000,
+  today_cost: 5,
+  today_actual_cost: 4,
+  today_account_cost: 3.5,
+  average_duration_ms: 250,
+  uptime: 3_600,
+  rpm: 12,
+  tpm: 25_000,
+}
+
+function success(data: unknown): string {
+  return JSON.stringify({ code: 0, message: 'success', data })
+}
+
+async function fulfillJSON(route: Route, data: unknown): Promise<void> {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: success(data),
+  })
+}
+
+async function prepareDashboard(page: Page, viewport: { width: number; height: number }): Promise<URL> {
+  let snapshotURL: URL | null = null
+  await page.setViewportSize(viewport)
+  await page.addInitScript((admin) => {
+    localStorage.setItem('auth_token', 'e2e-admin-token')
+    localStorage.setItem('auth_user', JSON.stringify(admin))
+  }, ADMIN)
+
+  await page.route('**/setup/status', (route) => fulfillJSON(route, { needs_setup: false, step: '' }))
+  await page.route('**/api/v1/auth/me', (route) => fulfillJSON(route, ADMIN))
+  await page.route('**/api/v1/admin/compliance', (route) =>
+    fulfillJSON(route, {
+      required: false,
+      version: 'e2e',
+      document_path_zh: '',
+      document_path_en: '',
+      document_url_zh: '',
+      document_url_en: '',
+      ack_phrase_zh: '',
+      ack_phrase_en: '',
+    })
+  )
+  await page.route('**/api/v1/settings/public', (route) =>
+    fulfillJSON(route, { site_name: 'TokenKey', backend_mode_enabled: false, custom_menu_items: [] })
+  )
+  await page.route('**/api/v1/subscriptions/active', (route) => fulfillJSON(route, []))
+  await page.route('**/api/v1/announcements*', (route) => fulfillJSON(route, []))
+  await page.route('**/api/v1/keys*', (route) =>
+    fulfillJSON(route, { items: [], total: 0, page: 1, page_size: 100, pages: 0 })
+  )
+  await page.route('**/api/v1/admin/dashboard/snapshot-v2*', (route) => {
+    snapshotURL = new URL(route.request().url())
+    return fulfillJSON(route, {
+      generated_at: '2026-07-16T08:00:00Z',
+      start_date: '2026-07-15',
+      end_date: '2026-07-16',
+      granularity: 'hour',
+      stats: DASHBOARD_STATS,
+      trend: [],
+      models: [],
+      groups: GROUPS,
+      users_trend: [],
+    })
+  })
+  await page.route('**/api/v1/admin/dashboard/users-ranking*', (route) =>
+    fulfillJSON(route, {
+      ranking: [],
+      total_actual_cost: 0,
+      total_requests: 0,
+      total_tokens: 0,
+      start_date: '2026-07-15',
+      end_date: '2026-07-16',
+    })
+  )
+
+  await page.goto('/admin/dashboard')
+  await expect(page.getByTestId('prompt-cache-card')).toBeVisible({ timeout: 20_000 })
+  expect(snapshotURL).not.toBeNull()
+  return snapshotURL!
+}
+
+async function assertCacheCard(page: Page, screenshotName: string): Promise<void> {
+  const card = page.getByTestId('prompt-cache-card')
+  const rows = card.getByTestId('prompt-cache-group-row')
+
+  await expect(rows).toHaveCount(5)
+  await expect(rows).toHaveText([
+    /Claude Kiro/,
+    /GPT Production/,
+    /DeepSeek/,
+    /Gemini/,
+    /Grok/,
+  ])
+  await expect(card.getByText('Small OpenAI')).toHaveCount(0)
+  await expect(card.getByText('Tiny Anthropic')).toHaveCount(0)
+
+  const kiroRow = rows.filter({ hasText: 'Claude Kiro' })
+  await expect(kiroRow).toContainText(/不可观测|Not observable/i)
+  await expect(kiroRow).not.toContainText(/(?:^|\s)0(?:\.0)?%/)
+
+  const overflow = await page.evaluate(() => ({
+    document: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    card: (() => {
+      const el = document.querySelector<HTMLElement>('[data-testid="prompt-cache-card"]')
+      return el ? el.scrollWidth - el.clientWidth : 0
+    })(),
+  }))
+  expect(overflow.document, 'page must not overflow horizontally').toBeLessThanOrEqual(1)
+  expect(overflow.card, 'cache card must not overflow horizontally').toBeLessThanOrEqual(1)
+
+  await card.screenshot({ path: `e2e/artifacts/${screenshotName}` })
+}
+
+test.describe('admin prompt-cache group observability', () => {
+  test('desktop ranks by impact and treats Kiro as unobservable', async ({ page }) => {
+    const snapshotURL = await prepareDashboard(page, { width: 1440, height: 900 })
+    await assertCacheCard(page, 'dashboard-cache-desktop.png')
+
+    await page.getByTestId('prompt-cache-group-row').filter({ hasText: 'GPT Production' }).click()
+    await page.waitForURL(/\/admin\/usage\?/)
+    const usageURL = new URL(page.url())
+    expect(usageURL.searchParams.get('group_id')).toBe('101')
+    expect(usageURL.searchParams.get('start_ts')).toBe(snapshotURL.searchParams.get('start_ts'))
+    expect(usageURL.searchParams.get('end_ts')).toBe(snapshotURL.searchParams.get('end_ts'))
+  })
+
+  test('390px mobile keeps the ranked cache card within the viewport', async ({ page }) => {
+    await prepareDashboard(page, { width: 390, height: 844 })
+    await assertCacheCard(page, 'dashboard-cache-mobile-390.png')
+  })
+})

--- a/frontend/src/i18n/tk/legacyMissing.tk.ts
+++ b/frontend/src/i18n/tk/legacyMissing.tk.ts
@@ -426,12 +426,13 @@ const en: LocaleOverlay = {
   },
   "admin": {
     "dashboard": {
-      "promptCacheHitRate": "Prompt Cache Hit Rate",
-      "promptCacheHitRateHint": "cache_read / (cache_read + input + cache_create). Higher = better. Sticky routing aims to maximize this.",
-      "cacheReadTokens": "Cache Read",
-      "cacheCreateTokens": "Cache Created",
-      "promptCacheToday": "Today",
-      "promptCacheTotal": "Total"
+      "promptCacheObservableHitRate": "Observable Prompt Cache Hit Rate",
+      "promptCacheHitRateHint": "Excludes input without upstream cache telemetry.",
+      "promptCacheSelectedWindow": "Selected period",
+      "promptCacheUnavailable": "Not observable",
+      "promptCachePartiallyObservable": "Partially observable",
+      "promptCacheNoTraffic": "No prompt traffic in this period",
+      "cacheReadTokens": "Cache Read"
     },
     "users": {
       "form": {
@@ -1257,12 +1258,13 @@ const zh: LocaleOverlay = {
   },
   "admin": {
     "dashboard": {
-      "promptCacheHitRate": "Prompt Cache 命中率",
-      "promptCacheHitRateHint": "命中率 = cache_read / (cache_read + input + cache_create)。值越高越好。粘性路由的目标就是把这一项尽量推高。",
-      "cacheReadTokens": "命中缓存",
-      "cacheCreateTokens": "写入缓存",
-      "promptCacheToday": "今日",
-      "promptCacheTotal": "累计"
+      "promptCacheObservableHitRate": "Prompt Cache 可观测命中率",
+      "promptCacheHitRateHint": "不计入上游未返回缓存明细的输入 Token。",
+      "promptCacheSelectedWindow": "当前筛选时段",
+      "promptCacheUnavailable": "不可观测",
+      "promptCachePartiallyObservable": "部分可观测",
+      "promptCacheNoTraffic": "当前时段暂无 Prompt 流量",
+      "cacheReadTokens": "命中缓存"
     },
     "users": {
       "form": {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1734,6 +1734,11 @@ export interface GroupStat {
   group_id: number
   group_name: string
   requests: number
+  input_tokens: number
+  output_tokens: number
+  cache_creation_tokens: number
+  cache_read_tokens: number
+  cache_telemetry_unavailable_input_tokens: number
   total_tokens: number
   cost: number // 标准计费
   actual_cost: number // 实际扣除

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -251,6 +251,13 @@
                   {{ t('admin.dashboard.promptCacheUnavailable') }}
                 </p>
                 <p v-else class="mt-2 text-2xl font-bold text-gray-400">—</p>
+                <p
+                  v-if="promptCacheOverview.rate !== null && promptCacheOverview.hasUnavailableTelemetry"
+                  class="mt-1 text-xs font-medium text-amber-600 dark:text-amber-400"
+                  data-testid="prompt-cache-overall-status"
+                >
+                  {{ t('admin.dashboard.promptCachePartiallyObservable') }}
+                </p>
                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
                   {{ t('admin.dashboard.promptCacheHitRateHint') }}
                 </p>

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -215,11 +215,10 @@
           </div>
         </div>
 
-        <!-- Row 3: Prompt Cache Hit Rate (sticky-routing observability) -->
-        <!-- See docs/approved/sticky-routing.md §6 (success metric). -->
-        <div class="card p-4">
-          <div class="flex items-start gap-3">
-            <div class="rounded-lg bg-cyan-100 p-2 dark:bg-cyan-900/30">
+        <!-- Row 3: observable prompt-cache performance by group -->
+        <div class="card p-4" data-testid="prompt-cache-card">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-start">
+            <div class="self-start rounded-lg bg-cyan-100 p-2 dark:bg-cyan-900/30">
               <Icon
                 name="bolt"
                 size="md"
@@ -227,48 +226,78 @@
                 :stroke-width="2"
               />
             </div>
-            <div class="flex-1">
-              <div class="flex items-baseline justify-between">
-                <p class="text-xs font-medium text-gray-500 dark:text-gray-400">
-                  {{ t('admin.dashboard.promptCacheHitRate') }}
+            <div class="min-w-0 flex-1 lg:grid lg:grid-cols-[minmax(12rem,0.7fr)_minmax(24rem,1.3fr)] lg:gap-8">
+              <div>
+                <div class="flex flex-wrap items-baseline justify-between gap-2">
+                  <p class="text-xs font-medium text-gray-500 dark:text-gray-400">
+                    {{ t('admin.dashboard.promptCacheObservableHitRate') }}
+                  </p>
+                  <p class="text-[11px] text-gray-400 dark:text-gray-500">
+                    {{ t('admin.dashboard.promptCacheSelectedWindow') }}
+                  </p>
+                </div>
+                <p
+                  v-if="promptCacheOverview.rate !== null"
+                  class="mt-2 text-2xl font-bold text-cyan-600 dark:text-cyan-400"
+                  data-testid="prompt-cache-rate"
+                >
+                  {{ formatPercent(promptCacheOverview.rate) }}
                 </p>
-                <p class="text-[11px] text-gray-400 dark:text-gray-500">
+                <p
+                  v-else-if="promptCacheOverview.hasUnavailableTelemetry"
+                  class="mt-2 text-lg font-semibold text-gray-700 dark:text-gray-200"
+                  data-testid="prompt-cache-status"
+                >
+                  {{ t('admin.dashboard.promptCacheUnavailable') }}
+                </p>
+                <p v-else class="mt-2 text-2xl font-bold text-gray-400">—</p>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
                   {{ t('admin.dashboard.promptCacheHitRateHint') }}
                 </p>
               </div>
-              <div class="mt-2 grid grid-cols-2 gap-4">
-                <!-- Today -->
-                <div>
-                  <p class="text-xs text-gray-500 dark:text-gray-400">
-                    {{ t('admin.dashboard.promptCacheToday') }}
-                  </p>
-                  <p class="text-2xl font-bold text-cyan-600 dark:text-cyan-400">
-                    {{ formatPercent(promptCacheHitRateToday) }}
-                  </p>
-                  <p class="text-xs text-gray-500 dark:text-gray-400">
-                    {{ t('admin.dashboard.cacheReadTokens') }}:
-                    {{ formatTokens(stats.today_cache_read_tokens) }}
-                    ·
-                    {{ t('admin.dashboard.cacheCreateTokens') }}:
-                    {{ formatTokens(stats.today_cache_creation_tokens) }}
-                  </p>
-                </div>
-                <!-- Total -->
-                <div>
-                  <p class="text-xs text-gray-500 dark:text-gray-400">
-                    {{ t('admin.dashboard.promptCacheTotal') }}
-                  </p>
-                  <p class="text-2xl font-bold text-gray-900 dark:text-white">
-                    {{ formatPercent(promptCacheHitRateTotal) }}
-                  </p>
-                  <p class="text-xs text-gray-500 dark:text-gray-400">
-                    {{ t('admin.dashboard.cacheReadTokens') }}:
-                    {{ formatTokens(stats.total_cache_read_tokens) }}
-                    ·
-                    {{ t('admin.dashboard.cacheCreateTokens') }}:
-                    {{ formatTokens(stats.total_cache_creation_tokens) }}
-                  </p>
-                </div>
+
+              <div v-if="promptCacheOverview.groups.length" class="mt-4 min-w-0 lg:mt-0">
+                <button
+                  v-for="row in promptCacheOverview.groups"
+                  :key="row.group.group_id"
+                  type="button"
+                  class="grid w-full grid-cols-[minmax(0,1fr)_auto_auto_auto] items-center gap-2 border-b border-gray-100 px-2 py-2 text-left last:border-b-0 hover:bg-gray-50 dark:border-dark-700 dark:hover:bg-dark-800/50"
+                  data-testid="prompt-cache-group-row"
+                  :data-group-id="row.group.group_id"
+                  @click="goToGroupUsage(row.group.group_id)"
+                >
+                  <span class="min-w-0 truncate text-sm font-medium text-gray-900 dark:text-white">
+                    {{ row.group.group_name || t('admin.dashboard.noGroup') }}
+                  </span>
+                  <span class="whitespace-nowrap text-xs text-gray-500 dark:text-gray-400">
+                    {{ t('admin.dashboard.cacheReadTokens') }} {{ formatTokens(row.cacheReadTokens) }}
+                  </span>
+                  <span
+                    v-if="row.rate !== null"
+                    class="min-w-14 whitespace-nowrap text-right text-sm font-semibold text-gray-900 dark:text-white"
+                    data-testid="prompt-cache-rate"
+                  >
+                    {{ formatPercent(row.rate) }}
+                  </span>
+                  <span
+                    v-else
+                    class="whitespace-nowrap text-xs font-medium text-gray-500 dark:text-gray-400"
+                    data-testid="prompt-cache-status"
+                  >
+                    {{ t('admin.dashboard.promptCacheUnavailable') }}
+                  </span>
+                  <Icon name="chevronRight" size="xs" class="text-gray-400" />
+                  <span
+                    v-if="row.partiallyObservable"
+                    class="col-start-2 col-span-3 text-right text-[11px] text-amber-600 dark:text-amber-400"
+                    data-testid="prompt-cache-status"
+                  >
+                    {{ t('admin.dashboard.promptCachePartiallyObservable') }}
+                  </span>
+                </button>
+              </div>
+              <div v-else class="mt-4 text-sm text-gray-500 dark:text-gray-400 lg:mt-0">
+                {{ t('admin.dashboard.promptCacheNoTraffic') }}
               </div>
             </div>
           </div>
@@ -449,6 +478,7 @@ import type {
   DashboardStats,
   TrendDataPoint,
   ModelStat,
+  GroupStat,
   UserUsageTrendPoint,
   UserSpendingRankingItem
 } from '@/types'
@@ -499,6 +529,8 @@ const dashboardChartsLoading = computed(() => chartsLoading.value || modelStatsL
 // Chart data
 const trendData = ref<TrendDataPoint[]>([])
 const modelStats = ref<ModelStat[]>([])
+const groupStats = ref<GroupStat[]>([])
+const loadedDashboardRollingWindow = ref<{ start_ts: number; end_ts: number } | null>(null)
 const userTrend = ref<UserUsageTrendPoint[]>([])
 const rankingItems = ref<UserSpendingRankingItem[]>([])
 const rankingTotalActualCost = ref(0)
@@ -740,56 +772,64 @@ const formatDuration = (ms: number): string => {
   return `${Math.round(ms)}ms`
 }
 
-// Prompt cache hit-rate (sticky-routing observability).
-// Definition: cache_read / (cache_read + input + cache_create).
-// Returns null when the denominator is 0 so the UI can render a "—" placeholder.
-const computeHitRate = (
-  cacheRead: number | undefined,
-  input: number | undefined,
-  cacheCreate: number | undefined
-): number | null => {
-  const r = cacheRead ?? 0
-  const i = input ?? 0
-  const c = cacheCreate ?? 0
-  const denom = r + i + c
-  if (denom <= 0) return null
-  return r / denom
-}
+const promptCacheOverview = computed(() => {
+  const rows = groupStats.value.map((group) => {
+    const inputTokens = Math.max(0, toFiniteNumber(group.input_tokens))
+    const unavailableInputTokens = Math.min(
+      inputTokens,
+      Math.max(0, toFiniteNumber(group.cache_telemetry_unavailable_input_tokens))
+    )
+    const cacheCreationTokens = Math.max(0, toFiniteNumber(group.cache_creation_tokens))
+    const cacheReadTokens = Math.max(0, toFiniteNumber(group.cache_read_tokens))
+    const observableDenominator = inputTokens - unavailableInputTokens + cacheCreationTokens + cacheReadTokens
+    return {
+      group,
+      cacheReadTokens,
+      unavailableInputTokens,
+      observableDenominator,
+      impactTokens: inputTokens + cacheCreationTokens + cacheReadTokens,
+      rate: observableDenominator > 0 ? cacheReadTokens / observableDenominator : null,
+      partiallyObservable: unavailableInputTokens > 0 && observableDenominator > 0
+    }
+  })
 
-const promptCacheHitRateToday = computed(() =>
-  computeHitRate(
-    stats.value?.today_cache_read_tokens,
-    stats.value?.today_input_tokens,
-    stats.value?.today_cache_creation_tokens
-  )
-)
-
-const promptCacheHitRateTotal = computed(() =>
-  computeHitRate(
-    stats.value?.total_cache_read_tokens,
-    stats.value?.total_input_tokens,
-    stats.value?.total_cache_creation_tokens
-  )
-)
+  const observableDenominator = rows.reduce((sum, row) => sum + row.observableDenominator, 0)
+  const cacheReadTokens = rows.reduce((sum, row) => sum + row.cacheReadTokens, 0)
+  return {
+    rate: observableDenominator > 0 ? cacheReadTokens / observableDenominator : null,
+    hasUnavailableTelemetry: rows.some((row) => row.unavailableInputTokens > 0),
+    groups: rows
+      .filter((row) => row.impactTokens > 0)
+      .sort((a, b) => b.impactTokens - a.impactTokens || a.group.group_id - b.group.group_id)
+      .slice(0, 5)
+  }
+})
 
 const formatPercent = (rate: number | null): string => {
   if (rate === null) return '—'
   return `${(rate * 100).toFixed(1)}%`
 }
 
+const usageDrilldownQuery = (filter: { user_id?: string; group_id?: string }) => ({
+  ...filter,
+  start_date: startDate.value,
+  end_date: endDate.value,
+  // Usage consumes absolute rolling instants, not Dashboard's server-TZ range token.
+  // Reuse the window that produced the visible snapshot so the drilldown is exact.
+  ...(loadedDashboardRollingWindow.value ?? rollingWindowTs(activePreset.value) ?? {})
+})
+
 const goToUserUsage = (item: UserSpendingRankingItem) => {
   void router.push({
     path: '/admin/usage',
-    query: {
-      user_id: String(item.user_id),
-      start_date: startDate.value,
-      end_date: endDate.value,
-      // The /admin/usage list parser only consumes absolute start_ts/end_ts (+
-      // date strings); it does NOT understand the server-TZ `range` token, so we
-      // forward only the rolling absolute window here. Server-TZ alignment of the
-      // usage-list drilldown itself is a separate change to parseUsageListTimeRange.
-      ...(rollingWindowTs(activePreset.value) ?? {})
-    }
+    query: usageDrilldownQuery({ user_id: String(item.user_id) })
+  })
+}
+
+const goToGroupUsage = (groupId: number) => {
+  void router.push({
+    path: '/admin/usage',
+    query: usageDrilldownQuery({ group_id: String(groupId) })
   })
 }
 
@@ -825,16 +865,17 @@ const loadAllDashboardData = async () => {
   chartsLoading.value = true
   modelStatsLoading.value = true
   userTrendLoading.value = true
+  const rollingWindow = rollingWindowTs(activePreset.value)
   try {
     const response = await adminAPI.dashboard.getSnapshotV2({
       start_date: startDate.value,
       end_date: endDate.value,
-      ...(dashboardWindowParams(activePreset.value)),
+      ...(rollingWindow ?? dashboardWindowParams(activePreset.value)),
       granularity: granularity.value,
       include_stats: true,
       include_trend: true,
       include_model_stats: true,
-      include_group_stats: false,
+      include_group_stats: true,
       include_users_trend: true,
       users_trend_limit: 12
     })
@@ -844,6 +885,8 @@ const loadAllDashboardData = async () => {
     if (currentChartSeq === chartLoadSeq) {
       trendData.value = response.trend || []
       modelStats.value = response.models || []
+      groupStats.value = response.groups || []
+      loadedDashboardRollingWindow.value = rollingWindow
     }
     if (currentUserTrendSeq === userTrendLoadSeq) {
       userTrend.value = response.users_trend || []
@@ -855,6 +898,8 @@ const loadAllDashboardData = async () => {
     if (currentChartSeq === chartLoadSeq) {
       trendData.value = []
       modelStats.value = []
+      groupStats.value = []
+      loadedDashboardRollingWindow.value = null
     }
     if (currentUserTrendSeq === userTrendLoadSeq) {
       userTrend.value = []

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -407,6 +407,7 @@ const applyRouteQueryFilters = () => {
   const queryStartDate = getSingleQueryValue(route.query.start_date)
   const queryEndDate = getSingleQueryValue(route.query.end_date)
   const queryUserId = getNumericQueryValue(route.query.user_id)
+  const queryGroupId = getNumericQueryValue(route.query.group_id)
   const queryStartTs = getNumericQueryValue(route.query.start_ts)
   const queryEndTs = getNumericQueryValue(route.query.end_ts)
 
@@ -431,6 +432,7 @@ const applyRouteQueryFilters = () => {
   filters.value = {
     ...filters.value,
     user_id: queryUserId,
+    group_id: queryGroupId,
     start_date: startDate.value,
     end_date: endDate.value
   }

--- a/frontend/src/views/admin/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.spec.ts
@@ -1,12 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
-import type { DashboardStats } from '@/types'
+import type { DashboardStats, GroupStat } from '@/types'
 import DashboardView from '../DashboardView.vue'
 
-const { getSnapshotV2, getUserUsageTrend, getUserSpendingRanking } = vi.hoisted(() => ({
+const { getSnapshotV2, getUserUsageTrend, getUserSpendingRanking, routerPush } = vi.hoisted(() => ({
   getSnapshotV2: vi.fn(),
   getUserUsageTrend: vi.fn(),
-  getUserSpendingRanking: vi.fn()
+  getUserSpendingRanking: vi.fn(),
+  routerPush: vi.fn()
 }))
 
 vi.mock('@/api/admin', () => ({
@@ -27,7 +28,7 @@ vi.mock('@/stores/app', () => ({
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({
-    push: vi.fn()
+    push: routerPush
   })
 }))
 
@@ -101,6 +102,22 @@ const createDashboardStats = (): DashboardStats => ({
   tpm: 0
 })
 
+const createGroupStat = (overrides: Partial<GroupStat>): GroupStat => ({
+  group_id: 1,
+  group_name: 'group-1',
+  requests: 1,
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_creation_tokens: 0,
+  cache_read_tokens: 0,
+  cache_telemetry_unavailable_input_tokens: 0,
+  total_tokens: 0,
+  cost: 0,
+  actual_cost: 0,
+  account_cost: 0,
+  ...overrides
+})
+
 const mountDashboard = () =>
   mount(DashboardView, {
     global: {
@@ -123,11 +140,13 @@ describe('admin DashboardView', () => {
     getSnapshotV2.mockReset()
     getUserUsageTrend.mockReset()
     getUserSpendingRanking.mockReset()
+    routerPush.mockReset()
 
     getSnapshotV2.mockResolvedValue({
       stats: createDashboardStats(),
       trend: [],
-      models: []
+      models: [],
+      groups: []
     })
     getUserUsageTrend.mockResolvedValue({
       trend: [],
@@ -165,7 +184,7 @@ describe('admin DashboardView', () => {
       include_stats: true,
       include_trend: true,
       include_model_stats: true,
-      include_group_stats: false,
+      include_group_stats: true,
       include_users_trend: true,
       users_trend_limit: 12
     }))
@@ -175,6 +194,65 @@ describe('admin DashboardView', () => {
 
     expect(getSnapshotV2).toHaveBeenCalledTimes(1)
     expect(getUserSpendingRanking).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the observable rate and the five highest-impact groups', async () => {
+    vi.setSystemTime(new Date('2026-07-16T08:43:21Z'))
+    const endTs = Date.UTC(2026, 6, 16, 8, 43, 0)
+    const startTs = endTs - 24 * 60 * 60 * 1000
+    getSnapshotV2.mockResolvedValue({
+      stats: createDashboardStats(),
+      trend: [],
+      models: [],
+      groups: [
+        createGroupStat({ group_id: 6, group_name: 'sixth', input_tokens: 10, total_tokens: 10 }),
+        createGroupStat({ group_id: 2, group_name: 'kiro', input_tokens: 800, cache_telemetry_unavailable_input_tokens: 800, total_tokens: 800 }),
+        createGroupStat({ group_id: 4, group_name: 'fourth', input_tokens: 100, cache_read_tokens: 100, total_tokens: 200 }),
+        createGroupStat({ group_id: 1, group_name: 'largest', input_tokens: 600, cache_read_tokens: 400, total_tokens: 1000 }),
+        createGroupStat({ group_id: 5, group_name: 'fifth', input_tokens: 100, total_tokens: 100 }),
+        createGroupStat({ group_id: 3, group_name: 'partial', input_tokens: 300, cache_read_tokens: 100, cache_telemetry_unavailable_input_tokens: 200, total_tokens: 400 })
+      ]
+    })
+
+    const wrapper = mountDashboard()
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="prompt-cache-card"] [data-testid="prompt-cache-rate"]').text()).toBe('39.7%')
+    const rows = wrapper.findAll('[data-testid="prompt-cache-group-row"]')
+    expect(rows).toHaveLength(5)
+    expect(rows.map((row) => row.attributes('data-group-id'))).toEqual(['1', '2', '3', '4', '5'])
+    expect(rows[1].get('[data-testid="prompt-cache-status"]').text()).toBe('admin.dashboard.promptCacheUnavailable')
+    expect(rows[1].text()).not.toContain('0.0%')
+    expect(rows[2].get('[data-testid="prompt-cache-status"]').text()).toBe('admin.dashboard.promptCachePartiallyObservable')
+    expect(rows[2].get('[data-testid="prompt-cache-rate"]').text()).toBe('50.0%')
+
+    await rows[0].trigger('click')
+    expect(routerPush).toHaveBeenCalledWith(expect.objectContaining({
+      path: '/admin/usage',
+      query: expect.objectContaining({ group_id: '1', start_ts: startTs, end_ts: endTs })
+    }))
+  })
+
+  it('shows unavailable instead of zero when all prompt traffic lacks cache telemetry', async () => {
+    getSnapshotV2.mockResolvedValue({
+      stats: createDashboardStats(),
+      trend: [],
+      models: [],
+      groups: [createGroupStat({
+        group_id: 9,
+        group_name: 'kiro-only',
+        input_tokens: 900,
+        cache_telemetry_unavailable_input_tokens: 900,
+        total_tokens: 900
+      })]
+    })
+
+    const wrapper = mountDashboard()
+    await flushPromises()
+
+    const card = wrapper.get('[data-testid="prompt-cache-card"]')
+    expect(card.get('[data-testid="prompt-cache-status"]').text()).toBe('admin.dashboard.promptCacheUnavailable')
+    expect(card.text()).not.toContain('0.0%')
   })
 
   it('uses DOM legend buttons for recent usage and toggles the matching dataset', async () => {

--- a/frontend/src/views/admin/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.spec.ts
@@ -218,6 +218,7 @@ describe('admin DashboardView', () => {
     await flushPromises()
 
     expect(wrapper.get('[data-testid="prompt-cache-card"] [data-testid="prompt-cache-rate"]').text()).toBe('39.7%')
+    expect(wrapper.get('[data-testid="prompt-cache-overall-status"]').text()).toBe('admin.dashboard.promptCachePartiallyObservable')
     const rows = wrapper.findAll('[data-testid="prompt-cache-group-row"]')
     expect(rows).toHaveLength(5)
     expect(rows.map((row) => row.attributes('data-group-id'))).toEqual(['1', '2', '3', '4', '5'])

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -3,7 +3,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 
 import UsageView from '../UsageView.vue'
 
-const { list, getStats, getSnapshotV2, getById, getModelStats, listErrorLogs } = vi.hoisted(() => {
+const { list, getStats, getSnapshotV2, getById, getModelStats, listErrorLogs, routeQuery } = vi.hoisted(() => {
   vi.stubGlobal('localStorage', {
     getItem: vi.fn(() => null),
     setItem: vi.fn(),
@@ -17,6 +17,7 @@ const { list, getStats, getSnapshotV2, getById, getModelStats, listErrorLogs } =
     getById: vi.fn(),
     getModelStats: vi.fn(),
     listErrorLogs: vi.fn(),
+    routeQuery: {} as Record<string, string>,
   }
 })
 
@@ -110,9 +111,13 @@ vi.mock('vue-i18n', async () => {
 
 vi.mock('vue-router', () => ({
   useRoute: () => ({
-    query: {}
+    query: routeQuery
   })
 }))
+
+beforeEach(() => {
+  for (const key of Object.keys(routeQuery)) delete routeQuery[key]
+})
 
 const AppLayoutStub = { template: '<div><slot /></div>' }
 const UsageFiltersStub = { template: '<div><slot name="after-reset" /></div>' }
@@ -235,6 +240,35 @@ describe('admin UsageView distribution metric toggles', () => {
       include_summary: 0,
       include_endpoints: 1,
     }))
+  })
+
+  it('applies a group drilldown and its exact dashboard window to usage requests', async () => {
+    Object.assign(routeQuery, {
+      group_id: '101',
+      start_date: '2026-07-15',
+      end_date: '2026-07-16',
+      start_ts: String(Date.UTC(2026, 6, 15, 8, 43, 0)),
+      end_ts: String(Date.UTC(2026, 6, 16, 8, 43, 0)),
+    })
+
+    mount(UsageView, {
+      global: { stubs: {
+        AppLayout: AppLayoutStub, UsageStatsCards: true, UsageFilters: UsageFiltersStub,
+        UsageTable: true, UsageExportProgress: true, UsageCleanupDialog: true,
+        UserBalanceHistoryModal: true, AuditLogModal: true, Pagination: true, Select: true,
+        DateRangePicker: true, Icon: true, TokenUsageTrend: true,
+        ModelDistributionChart: true, GroupDistributionChart: true, EndpointDistributionChart: true,
+      } },
+    })
+
+    await flushPromises()
+    const expected = {
+      group_id: 101,
+      start_ts: Date.UTC(2026, 6, 15, 8, 43, 0),
+      end_ts: Date.UTC(2026, 6, 16, 8, 43, 0),
+    }
+    expect(list).toHaveBeenCalledWith(expect.objectContaining(expected), expect.anything())
+    expect(getStats).toHaveBeenCalledWith(expect.objectContaining(expected))
   })
 
   it('loads summary first and endpoint distribution only after the chart enters view', async () => {

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1478,9 +1478,13 @@
         "import { dashboardWindowParams, rollingWindowTs } from '@/utils/dashboardWindow.tk'",
         "const goToUserUsage = (item: UserSpendingRankingItem) => {",
         "...(dashboardWindowParams(activePreset.value))",
-        "...(rollingWindowTs(activePreset.value) ?? {})"
+        "...(rollingWindow ?? dashboardWindowParams(activePreset.value))",
+        "loadedDashboardRollingWindow.value ?? rollingWindowTs(activePreset.value) ?? {}",
+        "const promptCacheOverview = computed(() => {",
+        "cache_telemetry_unavailable_input_tokens",
+        "include_group_stats: true"
       ],
-      "rationale": "The admin Dashboard's own requests (snapshot-v2 / user-ranking) carry the TK window via dashboardWindowParams(): rolling presets → absolute epoch-ms (timezone-independent), calendar presets ('今天'/昨天/本月/上月) → a server-TZ `range` token resolved by the backend (parseNamedRange). The `range` path is load-bearing — without it the admin per-user '今日消费' window follows the operator's browser timezone and silently disagrees with the customer dashboard (timezone.Today()) and the daily rollup buckets for the same user/day. The goToUserUsage drilldown deliberately keeps rollingWindowTs() instead, because /admin/usage's parser consumes only absolute start_ts/end_ts (+ date strings) and would silently drop a `range` token. If an upstream-shaped DashboardView rewrite collapses these two helpers, either the dashboard calendar windows fall back to browser-local date strings (mismatch returns) or the drilldown emits a dead param — both while still compiling."
+      "rationale": "The admin Dashboard's own requests carry the TK window via dashboardWindowParams(): rolling presets use absolute epoch-ms and calendar presets use a server-TZ range token. Drilldowns deliberately reuse the exact successfully loaded rolling window because /admin/usage consumes absolute start_ts/end_ts, not range. The same snapshot group facet owns the prompt-cache overview: it excludes Kiro-estimated unavailable input, ranks the top five groups by prompt-token impact, and avoids an extra endpoint. These anchors prevent an upstream-shaped Dashboard rewrite from silently restoring timezone drift, widening drilldowns, or dropping cache observability while still compiling."
     },
     {
       "path": "frontend/src/views/admin/UsageView.vue",
@@ -1489,9 +1493,11 @@
         "const getTimeWindowParams = () => selectedAbsoluteWindow.value ?? rollingWindowTs(activePreset.value)",
         "...(getTimeWindowParams() ?? {})",
         "start_time: timeWindow ? new Date(timeWindow.start_ts).toISOString()",
-        ":start-ts=\"getTimeWindowParams()?.start_ts\""
+        ":start-ts=\"getTimeWindowParams()?.start_ts\"",
+        "const queryGroupId = getNumericQueryValue(route.query.group_id)",
+        "group_id: queryGroupId"
       ],
-      "rationale": "Admin Usage rolling presets must send absolute epoch-ms windows to list, stats, charts, endpoint/model distributions, errors, and dashboard drilldown routes. Dropping any of this wiring silently restores widened local-date queries for default rolling windows, which is a production latency regression rather than an obvious functional break."
+      "rationale": "Admin Usage rolling presets must send absolute epoch-ms windows to list, stats, charts, endpoint/model distributions, errors, and dashboard drilldown routes. Dashboard group drilldowns must also consume group_id into the shared filters so the URL selection reaches every Usage query. Dropping this wiring silently restores widened local-date queries or shows unfiltered usage after a group click."
     },
     {
       "path": "frontend/src/constants/storefrontSeo.tk.ts",

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1482,6 +1482,7 @@
         "loadedDashboardRollingWindow.value ?? rollingWindowTs(activePreset.value) ?? {}",
         "const promptCacheOverview = computed(() => {",
         "cache_telemetry_unavailable_input_tokens",
+        "data-testid=\"prompt-cache-overall-status\"",
         "include_group_stats: true"
       ],
       "rationale": "The admin Dashboard's own requests carry the TK window via dashboardWindowParams(): rolling presets use absolute epoch-ms and calendar presets use a server-TZ range token. Drilldowns deliberately reuse the exact successfully loaded rolling window because /admin/usage consumes absolute start_ts/end_ts, not range. The same snapshot group facet owns the prompt-cache overview: it excludes Kiro-estimated unavailable input, ranks the top five groups by prompt-token impact, and avoids an extra endpoint. These anchors prevent an upstream-shaped Dashboard rewrite from silently restoring timezone drift, widening drilldowns, or dropping cache observability while still compiling."

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4272,9 +4272,11 @@
         "func (r *usageLogRepository) groupDailyMetricsBackfilled(",
         "FROM usage_dashboard_group_daily gd",
         "WHERE gd.bucket_date > DATE '",
-        "win.rawSpans"
+        "win.rawSpans",
+        "ul.billing_tier = 'kiro-estimated'",
+        "CacheTelemetryUnavailableInputTokens"
       ],
-      "rationale": "TK read path for Dashboard/Usage group distribution: completed server-TZ days come from usage_dashboard_group_daily metrics, raw head/tail spans come from usage_logs, and the metrics-backfill marker prevents old cost-only rows from being trusted. Anchors the fast path and correctness gate so group distribution cannot silently regress to the 0.9s raw scan or zero historical tokens."
+      "rationale": "TK read path for Dashboard/Usage group distribution: completed server-TZ days come from usage_dashboard_group_daily metrics, raw head/tail spans come from usage_logs, and the metrics-backfill marker prevents old cost-only rows from being trusted. A narrow raw-window query also derives Kiro-estimated input whose cache telemetry is unavailable, keeping it out of the observable hit-rate denominator without widening the rollup schema. Anchors the fast path and cache-observability correctness so neither can disappear silently."
     },
     {
       "path": "backend/internal/repository/dashboard_aggregation_repo.go",
@@ -4338,6 +4340,15 @@
       "must_contain": [
         "return r.getUserSpendingRankingRollup(ctx, startTime, endTime, limit)"
       ]
+    },
+    {
+      "path": "backend/internal/repository/usage_log_repo_trend.go",
+      "must_contain": [
+        "COALESCE(SUM(ul.input_tokens), 0) as input_tokens",
+        "FILTER (WHERE ul.billing_tier = 'kiro-estimated')",
+        "row.TotalTokens = row.InputTokens + row.OutputTokens + row.CacheCreationTokens + row.CacheReadTokens"
+      ],
+      "rationale": "The raw fallback for Dashboard/Usage group stats must expose the same input/output/cache components as the daily-rollup path and mark Kiro-estimated input as cache-telemetry unavailable. The frontend computes observable hit rate from these integer fields; dropping any component or the billing-tier filter can silently turn unavailable traffic into cache misses while legacy total/cost assertions remain green."
     },
     {
       "path": "backend/internal/service/universal_routing_tk_resolver.go",


### PR DESCRIPTION
## 摘要

- 将 Dashboard 误导性的 Today/Total 全局缓存卡片替换为当前筛选窗口的可观测 Prompt Cache 命中率，默认沿用滚动 24 小时。
- 按 `input + cache_creation + cache_read` 的 Prompt Token 影响量展示 Top 5 分组；纯 Kiro 流量显示“不可观测”，总体或分组混合流量显示“部分可观测”。
- 复用 `snapshot-v2?include_group_stats=true`，不新增端点；点击分组会把同一 `group_id` 与精确 `start_ts/end_ts` 传入 Usage，并由 Usage 请求实际消费。
- 补齐 raw/rollup 分组 Token 契约、前后端行为测试、真实浏览器桌面/移动验收、审批测试映射及上游覆盖 sentinel。

## 风险

- `GroupStat` 新增 Token 分项字段，属于向后兼容的公共响应扩展；无数据库 schema 迁移、无状态写入变化。
- rollup 路径为识别 `billing_tier='kiro-estimated'` 增加一条窄窗口 raw 聚合查询；已有 sqlmock、raw/rollup parity fixture 与查询语义 sentinel 约束。
- 本机 rootless Docker 不可用，PostgreSQL testcontainer 未能在本地启动；GitHub CI 的完整 `test-integration` 已在最新提交通过，验证缺口已由 CI 环境补齐。
- high-risk-anchor: `docs/approved/sticky-routing.md`
- sentinel-registry-reviewed

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：修复后完整重跑通过
- `go test ./internal/repository ./internal/handler/admin ./internal/pkg/usagestats -count=1`：通过
- `go test ./internal/service -count=1`：通过
- `make test-frontend-critical`：114/114 通过
- `pnpm --dir frontend run typecheck`：通过
- `pnpm --dir frontend run lint:check`：通过
- `pnpm --dir frontend run build`：通过，embedded frontend fingerprint 已更新
- `pnpm --dir frontend exec playwright test e2e/dashboard-cache.e2e.ts --project=chromium`：2/2 通过；覆盖 1440×900、390×844、Top 5、总体/分组部分可观测、Kiro 不可观测、无横向溢出及精确窗口分组钻取
- `scripts/export_agent_contract.py --check`、Story 质量检查、approved-doc invariants、前后端 sentinel：通过
- `$xj-review` full_conformance：R-001 至 R-003 已修复，复审 pipeline 0 finding
- GitHub CI（最新提交 `616ebd501`）：13 项成功、6 项按条件跳过、0 失败；unit、integration、frontend、lint、安全与 preflight 全绿

## 提交

- `fd31544cf` feat(dashboard): 按分组展示可观测缓存命中率
- `e78ada27f` fix(dashboard): address R-001..R-002 - align observability contract
- `616ebd501` fix(docs): address R-003 - align approval history

最新提交：`616ebd501`
