### PR TITLE
fix(frontend): 修正模型市场 provider 与媒体定价展示

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 606,
-  "hash": "dbe6de473350c1fc732654741fef9c6667d05cda77134eaf28aa4faf23c7ef97",
+  "file_count": 607,
+  "hash": "25bda472b1143997edb028b0c45df65a0c0570189da2b173b064be295f39f7c9",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 606,
-  "hash": "90ed331540f05b9b2fa82de051b01c48c1a3c96fefcc9384c1c7bb8f61ac8778",
+  "hash": "dbe6de473350c1fc732654741fef9c6667d05cda77134eaf28aa4faf23c7ef97",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/utils/__tests__/pricingCatalogPresentation.tk.spec.ts
+++ b/frontend/src/utils/__tests__/pricingCatalogPresentation.tk.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatCatalogMediaPrice,
+  formatCatalogPrice,
+  pricingCatalogModality,
+} from '../pricingCatalogPresentation.tk'
+
+describe('pricingCatalogPresentation', () => {
+  it('derives text, image, and video from the catalog billing mode', () => {
+    expect(pricingCatalogModality('image')).toBe('image')
+    expect(pricingCatalogModality('video')).toBe('video')
+    expect(pricingCatalogModality('token')).toBe('text')
+    expect(pricingCatalogModality(undefined)).toBe('text')
+  })
+
+  it('formats catalog prices with shared precision', () => {
+    expect(formatCatalogPrice(0)).toBe('$0')
+    expect(formatCatalogPrice(0.00125)).toBe('$0.001250')
+    expect(formatCatalogPrice(0.03480597014925373)).toBe('$0.0348')
+    expect(formatCatalogPrice(1.25)).toBe('$1.25')
+    expect(formatCatalogPrice(Number.NaN)).toBe('—')
+  })
+
+  it('does not present missing or non-positive media prices as free', () => {
+    expect(formatCatalogMediaPrice()).toBe('—')
+    expect(formatCatalogMediaPrice(0)).toBe('—')
+    expect(formatCatalogMediaPrice(-1)).toBe('—')
+    expect(formatCatalogMediaPrice(0.6)).toBe('$0.6000')
+  })
+})

--- a/frontend/src/utils/pricingCatalogPresentation.tk.ts
+++ b/frontend/src/utils/pricingCatalogPresentation.tk.ts
@@ -1,0 +1,20 @@
+export type PricingCatalogModality = 'text' | 'image' | 'video'
+
+export function pricingCatalogModality(billingMode?: string): PricingCatalogModality {
+  if (billingMode === 'image') return 'image'
+  if (billingMode === 'video') return 'video'
+  return 'text'
+}
+
+export function formatCatalogPrice(value: number): string {
+  if (!Number.isFinite(value)) return '—'
+  if (value === 0) return '$0'
+  if (value < 0.01) return `$${value.toFixed(6)}`
+  if (value < 1) return `$${value.toFixed(4)}`
+  return `$${value.toFixed(2)}`
+}
+
+export function formatCatalogMediaPrice(value?: number): string {
+  if (value == null || value <= 0) return '—'
+  return formatCatalogPrice(value)
+}

--- a/frontend/src/utils/studioMediaCatalog.tk.ts
+++ b/frontend/src/utils/studioMediaCatalog.tk.ts
@@ -6,13 +6,9 @@
 import type { MePricingModel } from '@/api/me-pricing'
 import type { PublicCatalogModel } from '@/api/pricing'
 import type { MediaPrice, MediaPriceMap, StudioModality } from '@/constants/studioMediaPresentations.tk'
+import { pricingCatalogModality } from '@/utils/pricingCatalogPresentation.tk'
 
 export type CatalogBillingIndex = ReadonlyMap<string, StudioModality>
-
-function normalizeBillingMode(raw: string | undefined): StudioModality | undefined {
-  if (raw === 'image' || raw === 'video') return raw
-  return undefined
-}
 
 /** model_id → image | video, derived from GET /api/v1/public/pricing. */
 export function buildCatalogBillingIndex(
@@ -20,8 +16,8 @@ export function buildCatalogBillingIndex(
 ): CatalogBillingIndex {
   const map = new Map<string, StudioModality>()
   for (const m of publicModels) {
-    const mode = normalizeBillingMode(m.pricing?.billing_mode)
-    if (mode) map.set(m.model_id, mode)
+    const mode = pricingCatalogModality(m.pricing?.billing_mode)
+    if (mode !== 'text') map.set(m.model_id, mode)
   }
   return map
 }
@@ -67,8 +63,8 @@ function mediaPriceFromCatalogRow(
   perSecond: number | undefined | null,
   vendor: string | undefined
 ): MediaPrice | undefined {
-  const billingMode = normalizeBillingMode(billingModeRaw)
-  if (!billingMode) return undefined
+  const billingMode = pricingCatalogModality(billingModeRaw)
+  if (billingMode === 'text') return undefined
   const hasImage = perImage != null && perImage > 0
   const hasVideo = perSecond != null && perSecond > 0
   if ((billingMode === 'image' && !hasImage) || (billingMode === 'video' && !hasVideo)) return undefined

--- a/frontend/src/views/ModelMarketplaceView.vue
+++ b/frontend/src/views/ModelMarketplaceView.vue
@@ -190,7 +190,7 @@
                     <div class="min-w-0 flex-1">
                       <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.outputPrice') }}</span>
                       <p class="flex flex-wrap items-baseline gap-1 text-sm font-semibold text-gray-900 dark:text-white">
-                        {{ formatMediaPrice(model.pricing.output_cost_per_image) }}
+                        {{ formatCatalogMediaPrice(model.pricing.output_cost_per_image) }}
                         <span class="text-[10px] font-normal text-gray-400 dark:text-dark-500">{{ t('pricing.perImage') }}</span>
                       </p>
                     </div>
@@ -199,7 +199,7 @@
                     <div class="min-w-0 flex-1">
                       <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.outputPrice') }}</span>
                       <p class="flex flex-wrap items-baseline gap-1 text-sm font-semibold text-gray-900 dark:text-white">
-                        {{ formatMediaPrice(model.pricing.output_cost_per_second) }}
+                        {{ formatCatalogMediaPrice(model.pricing.output_cost_per_second) }}
                         <span class="text-[10px] font-normal text-gray-400 dark:text-dark-500">{{ t('pricing.perSecond') }}</span>
                       </p>
                     </div>
@@ -208,13 +208,13 @@
                     <div class="flex-1">
                       <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.inputPrice') }}</span>
                       <p class="text-sm font-semibold text-gray-900 dark:text-white">
-                        {{ formatPrice(model.pricing.input_per_1k_tokens) }}
+                        {{ formatCatalogPrice(model.pricing.input_per_1k_tokens) }}
                       </p>
                     </div>
                     <div class="flex-1">
                       <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.outputPrice') }}</span>
                       <p class="text-sm font-semibold text-gray-900 dark:text-white">
-                        {{ formatPrice(model.pricing.output_per_1k_tokens) }}
+                        {{ formatCatalogPrice(model.pricing.output_per_1k_tokens) }}
                       </p>
                     </div>
                     <span class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('models.pricePerK') }}</span>
@@ -247,6 +247,12 @@ import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
 import { getPublicPricing, type PublicCatalogModel } from '@/api/pricing'
+import {
+  formatCatalogMediaPrice,
+  formatCatalogPrice,
+  pricingCatalogModality,
+  type PricingCatalogModality,
+} from '@/utils/pricingCatalogPresentation.tk'
 
 const { t, te } = useI18n()
 const authStore = useAuthStore()
@@ -266,14 +272,8 @@ const categoryFilters = computed(() => [
   { key: 'video', label: t('models.filterVideo') },
 ])
 
-type MarketplaceCategory = 'text' | 'image' | 'video'
-
-/** Align with PricingView + public catalog: media rows use pricing.billing_mode, not capabilities. */
-function modelListingCategory(m: PublicCatalogModel): MarketplaceCategory {
-  const mode = m.pricing?.billing_mode
-  if (mode === 'image') return 'image'
-  if (mode === 'video') return 'video'
-  return 'text'
+function modelListingCategory(m: PublicCatalogModel): PricingCatalogModality {
+  return pricingCatalogModality(m.pricing?.billing_mode)
 }
 
 /** LiteLLM uses modality-specific Vertex provider names; the marketplace groups by provider. */
@@ -323,18 +323,6 @@ const filteredModels = computed(() => {
 
   return result
 })
-
-function formatPrice(price: number): string {
-  if (price === 0) return 'Free'
-  if (price < 0.01) return `$${price.toFixed(6)}`
-  if (price < 1) return `$${price.toFixed(4)}`
-  return `$${price.toFixed(2)}`
-}
-
-function formatMediaPrice(price?: number): string {
-  if (price == null || !Number.isFinite(price) || price <= 0) return '—'
-  return formatPrice(price)
-}
 
 function formatCapabilityLabel(cap: string): string {
   const key = `models.capabilities.${cap}`

--- a/frontend/src/views/ModelMarketplaceView.vue
+++ b/frontend/src/views/ModelMarketplaceView.vue
@@ -168,7 +168,7 @@
                     v-if="model.vendor"
                     class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-dark-700 dark:text-dark-300"
                   >
-                    {{ model.vendor }}
+                    {{ marketplaceVendor(model) }}
                   </span>
                 </div>
 
@@ -186,19 +186,39 @@
 
                 <!-- Pricing -->
                 <div v-if="model.pricing" class="flex items-center gap-4 border-t border-gray-100 pt-3 dark:border-dark-700">
-                  <div class="flex-1">
-                    <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.inputPrice') }}</span>
-                    <p class="text-sm font-semibold text-gray-900 dark:text-white">
-                      {{ formatPrice(model.pricing.input_per_1k_tokens) }}
-                    </p>
-                  </div>
-                  <div class="flex-1">
-                    <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.outputPrice') }}</span>
-                    <p class="text-sm font-semibold text-gray-900 dark:text-white">
-                      {{ formatPrice(model.pricing.output_per_1k_tokens) }}
-                    </p>
-                  </div>
-                  <span class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('models.pricePerK') }}</span>
+                  <template v-if="modelListingCategory(model) === 'image'">
+                    <div class="min-w-0 flex-1">
+                      <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.outputPrice') }}</span>
+                      <p class="flex flex-wrap items-baseline gap-1 text-sm font-semibold text-gray-900 dark:text-white">
+                        {{ formatMediaPrice(model.pricing.output_cost_per_image) }}
+                        <span class="text-[10px] font-normal text-gray-400 dark:text-dark-500">{{ t('pricing.perImage') }}</span>
+                      </p>
+                    </div>
+                  </template>
+                  <template v-else-if="modelListingCategory(model) === 'video'">
+                    <div class="min-w-0 flex-1">
+                      <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.outputPrice') }}</span>
+                      <p class="flex flex-wrap items-baseline gap-1 text-sm font-semibold text-gray-900 dark:text-white">
+                        {{ formatMediaPrice(model.pricing.output_cost_per_second) }}
+                        <span class="text-[10px] font-normal text-gray-400 dark:text-dark-500">{{ t('pricing.perSecond') }}</span>
+                      </p>
+                    </div>
+                  </template>
+                  <template v-else>
+                    <div class="flex-1">
+                      <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.inputPrice') }}</span>
+                      <p class="text-sm font-semibold text-gray-900 dark:text-white">
+                        {{ formatPrice(model.pricing.input_per_1k_tokens) }}
+                      </p>
+                    </div>
+                    <div class="flex-1">
+                      <span class="text-[10px] uppercase tracking-wider text-gray-400 dark:text-dark-500">{{ t('models.outputPrice') }}</span>
+                      <p class="text-sm font-semibold text-gray-900 dark:text-white">
+                        {{ formatPrice(model.pricing.output_per_1k_tokens) }}
+                      </p>
+                    </div>
+                    <span class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('models.pricePerK') }}</span>
+                  </template>
                 </div>
               </router-link>
             </div>
@@ -256,6 +276,12 @@ function modelListingCategory(m: PublicCatalogModel): MarketplaceCategory {
   return 'text'
 }
 
+/** LiteLLM uses modality-specific Vertex provider names; the marketplace groups by provider. */
+function marketplaceVendor(m: PublicCatalogModel): string {
+  const vendor = m.vendor?.trim() || 'Unknown'
+  return vendor === 'vertex_ai' || vendor.startsWith('vertex_ai-') ? 'vertex_ai' : vendor
+}
+
 // Filter by category (billing_mode-driven — same truth as /pricing modality tabs)
 const filteredByCategory = computed(() => {
   if (activeCategory.value === 'all') return models.value
@@ -272,7 +298,7 @@ const filteredByCategory = computed(() => {
 const vendorList = computed(() => {
   const map = new Map<string, number>()
   for (const m of filteredByCategory.value) {
-    const v = m.vendor || 'Unknown'
+    const v = marketplaceVendor(m)
     map.set(v, (map.get(v) || 0) + 1)
   }
   return Array.from(map.entries())
@@ -286,7 +312,7 @@ const filteredModels = computed(() => {
 
   // Vendor filter
   if (activeVendor.value) {
-    result = result.filter(m => (m.vendor || 'Unknown') === activeVendor.value)
+    result = result.filter(m => marketplaceVendor(m) === activeVendor.value)
   }
 
   // Search filter
@@ -300,9 +326,14 @@ const filteredModels = computed(() => {
 
 function formatPrice(price: number): string {
   if (price === 0) return 'Free'
-  if (price < 0.001) return `$${price.toFixed(6)}`
-  if (price < 0.01) return `$${price.toFixed(4)}`
-  return `$${price.toFixed(3)}`
+  if (price < 0.01) return `$${price.toFixed(6)}`
+  if (price < 1) return `$${price.toFixed(4)}`
+  return `$${price.toFixed(2)}`
+}
+
+function formatMediaPrice(price?: number): string {
+  if (price == null || !Number.isFinite(price) || price <= 0) return '—'
+  return formatPrice(price)
 }
 
 function formatCapabilityLabel(cap: string): string {

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -569,6 +569,11 @@ import {
   filterPricingCatalogByModel,
   type PricingCatalogSearchMode
 } from '@/utils/pricingCatalogSearch'
+import {
+  formatCatalogPrice as formatPrice,
+  pricingCatalogModality,
+  type PricingCatalogModality
+} from '@/utils/pricingCatalogPresentation.tk'
 import { exportPricingCsv } from '@/composables/useTkPricingExport'
 
 const { t } = useI18n()
@@ -662,7 +667,7 @@ const modelSearchMode = ref<PricingCatalogSearchMode>('fuzzy')
 // Modality filter (text / image / video) — billing_mode-driven so media models
 // (image per-image, video per-second) are discoverable instead of buried in a
 // token-centric list.
-type PricingModality = 'all' | 'text' | 'image' | 'video'
+type PricingModality = 'all' | PricingCatalogModality
 const pricingModality = ref<PricingModality>('all')
 const modalityOptions = computed<{ value: PricingModality; label: string }[]>(() => [
   { value: 'all', label: t('pricing.modality.all') },
@@ -670,12 +675,6 @@ const modalityOptions = computed<{ value: PricingModality; label: string }[]>(()
   { value: 'image', label: t('pricing.modality.image') },
   { value: 'video', label: t('pricing.modality.video') }
 ])
-
-function rowModality(billingMode?: string): PricingModality {
-  if (billingMode === 'image') return 'image'
-  if (billingMode === 'video') return 'video'
-  return 'text'
-}
 
 function hasSavedAuthToken(): boolean {
   try {
@@ -823,7 +822,7 @@ const normalizedRows = computed<NormalizedRow[]>(() => {
 const filteredRows = computed(() => {
   const byName = filterPricingCatalogByModel(normalizedRows.value, modelSearchQuery.value, modelSearchMode.value)
   if (pricingModality.value === 'all') return byName
-  return byName.filter((r) => rowModality(r.billingMode) === pricingModality.value)
+  return byName.filter((r) => pricingCatalogModality(r.billingMode) === pricingModality.value)
 })
 
 const hasCacheColumns = computed(() =>
@@ -941,14 +940,6 @@ const exploreBanner = computed<ExploreBanner | null>(() => {
 })
 
 // ============================== misc formatters ==============================
-
-function formatPrice(value: number): string {
-  if (!Number.isFinite(value)) return '—'
-  if (value === 0) return '$0'
-  if (value < 0.01) return `$${value.toFixed(6)}`
-  if (value < 1) return `$${value.toFixed(4)}`
-  return `$${value.toFixed(2)}`
-}
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat().format(value)

--- a/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
+++ b/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
@@ -35,6 +35,8 @@ vi.mock('vue-i18n', async () => {
     'models.viewPricing': 'View Pricing Details',
     'models.capabilities.image_generation': 'Image generation',
     'models.capabilities.video_generation': 'Video generation',
+    'pricing.perImage': '/ image',
+    'pricing.perSecond': '/ second',
     'pricing.nav.home': 'Home',
     'nav.quickstart': 'Quick Start',
     'auth.createAccount': 'Create account',
@@ -138,6 +140,88 @@ describe('ModelMarketplaceView', () => {
 
     expect(wrapper.text()).toContain('veo-3.1-generate-preview')
     expect(wrapper.text()).not.toContain('gpt-4o-mini')
+  })
+
+  it('shows media unit pricing instead of treating zero token prices as free', async () => {
+    getPublicPricing.mockResolvedValue(
+      catalog([
+        model('doubao-seedream-5-0-260128', 'volcengine', {
+          pricing: {
+            currency: 'USD',
+            billing_mode: 'image',
+            input_per_1k_tokens: 0,
+            output_per_1k_tokens: 0,
+            output_cost_per_image: 0.03480597014925373,
+          },
+        }),
+        model('doubao-seedance-2-0-fast-260128', 'volcengine', {
+          pricing: {
+            currency: 'USD',
+            billing_mode: 'video',
+            input_per_1k_tokens: 0,
+            output_per_1k_tokens: 0,
+            output_cost_per_second: 0.1265671641791045,
+          },
+        }),
+        model('future-image-with-missing-price', 'volcengine', {
+          pricing: {
+            currency: 'USD',
+            billing_mode: 'image',
+            input_per_1k_tokens: 0,
+            output_per_1k_tokens: 0,
+          },
+        }),
+      ])
+    )
+
+    const wrapper = mountMarketplace()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('$0.0348 / image')
+    expect(wrapper.text()).toContain('$0.1266 / second')
+    expect(wrapper.text()).toContain('— / image')
+    expect(wrapper.text()).not.toContain('Free')
+    expect(wrapper.text()).not.toContain('/ 1K tokens')
+  })
+
+  it('groups all Vertex provider variants under vertex_ai', async () => {
+    getPublicPricing.mockResolvedValue(
+      catalog([
+        model('gemini-2.5-pro', 'vertex_ai-language-models'),
+        model('imagen-4.0-generate-001', 'vertex_ai', {
+          pricing: {
+            currency: 'USD',
+            billing_mode: 'image',
+            input_per_1k_tokens: 0,
+            output_per_1k_tokens: 0,
+            output_cost_per_image: 0.04,
+          },
+        }),
+        model('veo-3.1-generate-001', 'vertex_ai-video-models', {
+          pricing: {
+            currency: 'USD',
+            billing_mode: 'video',
+            input_per_1k_tokens: 0,
+            output_per_1k_tokens: 0,
+            output_cost_per_second: 0.6,
+          },
+        }),
+      ])
+    )
+
+    const wrapper = mountMarketplace()
+    await flushPromises()
+
+    const vertexButtons = wrapper
+      .findAll('button')
+      .filter((button) => button.text().trim() === 'vertex_ai (3)')
+    expect(vertexButtons).toHaveLength(2)
+    expect(wrapper.findAll('button').some((button) => button.text().includes('vertex_ai-language-models'))).toBe(false)
+
+    await vertexButtons[0].trigger('click')
+    expect(wrapper.text()).toContain('gemini-2.5-pro')
+    expect(wrapper.text()).toContain('imagen-4.0-generate-001')
+    expect(wrapper.text()).toContain('veo-3.1-generate-001')
   })
 
   it('shows empty state when search matches no models', async () => {

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -154,12 +154,41 @@
       "rationale": "Single source of truth for the client-side media cost MIRROR (price on the Generate button + cost panel + pricing estimator). Must stay aligned with backend CalculateImageCost / CalculateVideoCost; deleting it silently drops the pre-generation price the whole 'price on the button' UX depends on."
     },
     {
+      "path": "frontend/src/utils/pricingCatalogPresentation.tk.ts",
+      "must_contain": [
+        "export function pricingCatalogModality",
+        "export function formatCatalogPrice",
+        "export function formatCatalogMediaPrice"
+      ],
+      "rationale": "Single source of truth for public pricing-catalog modality and price presentation across /models, /pricing, and Studio catalog consumers. Losing this owner can compile green if pages reintroduce local billing_mode branches, then silently split text/image/video membership or price precision between catalog surfaces."
+    },
+    {
+      "path": "frontend/src/views/ModelMarketplaceView.vue",
+      "must_contain": [
+        "from '@/utils/pricingCatalogPresentation.tk'",
+        "formatCatalogMediaPrice",
+        "pricingCatalogModality",
+        "marketplaceVendor"
+      ],
+      "rationale": "The /models injection point for shared catalog modality/price presentation plus provider-family normalization. Anchors prevent an upstream rewrite from restoring token-only Free labels for priced media or splitting Vertex modality-specific provider aliases back into separate vendors."
+    },
+    {
+      "path": "frontend/src/utils/studioMediaCatalog.tk.ts",
+      "must_contain": [
+        "from '@/utils/pricingCatalogPresentation.tk'",
+        "pricingCatalogModality"
+      ],
+      "rationale": "Studio catalog membership must consume the same billing_mode classifier as /models and /pricing. A local classifier here would recreate a second modality owner and allow Studio availability to drift from the public catalog tabs."
+    },
+    {
       "path": "frontend/src/views/PricingView.vue",
       "must_contain": [
         "row.billingMode === 'image'",
-        "row.billingMode === 'video'"
+        "row.billingMode === 'video'",
+        "from '@/utils/pricingCatalogPresentation.tk'",
+        "pricingCatalogModality"
       ],
-      "rationale": "The /pricing media rendering branches (per-image / per-second). Without them media models render as '—' (the pre-batch-2 bug); an upstream merge that reverts the price cell to token-only silently hides image/video prices from buyers."
+      "rationale": "The /pricing media rendering branches (per-image / per-second) and shared catalog-modality owner wiring. Without them media models render as '—' (the pre-batch-2 bug), or /pricing can classify billing_mode differently from /models and Studio; an upstream merge that reverts the price cell or localizes the classifier silently hides or misgroups image/video prices from buyers."
     },
     {
       "path": "frontend/src/components/layout/AppLayout.vue",


### PR DESCRIPTION
## 摘要

- 将 `vertex_ai-language-models` 等 Vertex provider 变体统一归并为 `vertex_ai`，文本、图片、视频继续由 modality 筛选区分。
- 图片和视频模型按 `billing_mode` 展示每张或每秒单位价，不再把 token 价为 0 误显示为 Free。
- 媒体单位价缺失或无效时显示不可用占位，并补充 provider 归并、媒体价格和缺价边界回归测试。
- 将 `/models`、`/pricing` 和 Studio 的 catalog modality/价格展示规则收敛到共享 owner，并增加 sentinel 防止上游覆盖后静默分叉。
- 同步嵌入式前端 source hash。

## 风险

- 常规风险，仅调整公开模型市场的展示与筛选，不修改 catalog API、计费价格或服务路由。
- load-bearing 展示逻辑已有共享 owner、聚焦回归测试及 frontend sentinel 锚点。

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS（合并最新 `origin/main` 后全量重跑）
- Vitest 定向验证：4 files / 31 tests passed
- `pnpm run typecheck`：PASS
- 定向 ESLint：PASS
- `pnpm run build`：PASS，embedded frontend dist source hash 已同步
- Playwright 真实 UI：桌面 1440px 与移动 390px；Vertex provider 归并正确，媒体条目显示单位价，无横向溢出

## 提交

- `f8ac50e84` fix(frontend): correct marketplace provider pricing display
- `25e5b554e` fix(frontend): address R-001 — centralize catalog presentation
- `540cc999e` merge latest `origin/main`