### PR TITLE
fix(gateway): 修正 client cancel 终态与 SLA 归属

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1715,6 +1715,15 @@ func (h *GatewayHandler) ensureForwardErrorResponse(c *gin.Context, streamStarte
 	if c == nil || c.Writer == nil {
 		return false
 	}
+	// A canceled inbound request means the caller has already gone away. Writing a
+	// generic 502 here only corrupts access/ops semantics; there is no client left
+	// to receive it. Keep the established 499 classification used by failover and
+	// concurrency cancellation paths.
+	if isClientClosedRequest(c, nil) {
+		service.MarkOpsClientClosedRequest(c)
+		failoverClientGone(c)
+		return false
+	}
 	if service.IsResponseCommitted(c) {
 		return false
 	}

--- a/backend/internal/handler/gateway_handler_error_fallback_test.go
+++ b/backend/internal/handler/gateway_handler_error_fallback_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -11,6 +12,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
 func TestGatewayEnsureForwardErrorResponse_WritesFallbackWhenNotWritten(t *testing.T) {
@@ -33,6 +36,23 @@ func TestGatewayEnsureForwardErrorResponse_WritesFallbackWhenNotWritten(t *testi
 	require.True(t, ok)
 	assert.Equal(t, "upstream_error", errorObj["type"])
 	assert.Equal(t, "Upstream request failed", errorObj["message"])
+}
+
+func TestGatewayEnsureForwardErrorResponse_ClientCanceledWrites499WithoutBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c.Request = httptest.NewRequest(http.MethodPost, EndpointMessages, nil).WithContext(ctx)
+
+	h := &GatewayHandler{}
+	wrote := h.ensureForwardErrorResponse(c, false)
+
+	require.False(t, wrote)
+	require.Equal(t, statusClientClosedRequest, c.Writer.Status())
+	require.Empty(t, w.Body.String())
+	require.True(t, service.HasOpsClientClosedRequest(c))
 }
 
 // Writer 已写后 ensureForwardErrorResponse 必须把错误以 SSE 形式追加，

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1427,7 +1427,10 @@ func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status i
 	if clientRequestRejected && !upstreamError && !routingCapacityLimited {
 		phase = "request"
 	}
-	if (clientClosedRequest || status == statusClientClosedRequest) && !upstreamError && !routingCapacityLimited {
+	// A final 499 is definitive caller cancellation even when earlier attempts
+	// recorded provider errors. Keep those attempts in upstream_errors, but do not
+	// let them turn the final client-closed outcome back into an SLA fault.
+	if (status == statusClientClosedRequest || (clientClosedRequest && !upstreamError)) && !routingCapacityLimited {
 		phase = "request"
 	}
 	if routingCapacityLimited {

--- a/backend/internal/handler/ops_error_logger_tk_client_canceled.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_canceled.go
@@ -79,6 +79,20 @@ func tkOpsTerminalUpstreamStatusCode(c *gin.Context) int {
 	if c == nil {
 		return 0
 	}
+	// When an event chain exists, its last real event is the terminal outcome.
+	// Status 0 is meaningful here: it records a transport failure such as caller
+	// cancellation and must override a stale positive single-field status left by
+	// an earlier failover attempt.
+	if v, ok := c.Get(service.OpsUpstreamErrorsKey); ok {
+		if events, ok := v.([]*service.OpsUpstreamErrorEvent); ok {
+			for i := len(events) - 1; i >= 0; i-- {
+				if events[i] != nil {
+					return events[i].UpstreamStatusCode
+				}
+			}
+		}
+	}
+	// Legacy paths may only populate the single-field status.
 	if v, ok := c.Get(service.OpsUpstreamStatusCodeKey); ok {
 		switch status := v.(type) {
 		case int:
@@ -88,14 +102,6 @@ func tkOpsTerminalUpstreamStatusCode(c *gin.Context) int {
 		case int64:
 			if status > 0 {
 				return int(status)
-			}
-		}
-	}
-	if v, ok := c.Get(service.OpsUpstreamErrorsKey); ok {
-		if events, ok := v.([]*service.OpsUpstreamErrorEvent); ok && len(events) > 0 {
-			last := events[len(events)-1]
-			if last != nil && last.UpstreamStatusCode > 0 {
-				return last.UpstreamStatusCode
 			}
 		}
 	}

--- a/backend/internal/handler/ops_error_logger_tk_client_canceled.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_canceled.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 )
 
@@ -36,10 +37,13 @@ func tkUpstreamClientCanceled(c *gin.Context) bool {
 	if c == nil {
 		return false
 	}
-	// A definitive upstream HTTP status means we DID get an upstream verdict; that
-	// path is owned by status-based classification (provider health or
-	// tkUpstreamClientInducedRejection), never here.
-	if tkOpsUpstreamStatusCode(c) != 0 {
+	// A definitive FINAL upstream HTTP status means we got an upstream verdict.
+	// Do not scan backward to any older positive-status failover event here: a
+	// request can receive 502s from earlier accounts and then be canceled by the
+	// caller during the last attempt. In that sequence the terminal status-0
+	// request_error is the final outcome, while the older 502 events remain useful
+	// attempt-level provider evidence in upstream_errors.
+	if tkOpsTerminalUpstreamStatusCode(c) != 0 {
 		return false
 	}
 	// Primary signal: the inbound request context was canceled by the caller
@@ -69,4 +73,31 @@ func tkUpstreamClientCanceled(c *gin.Context) bool {
 	}
 	return strings.Contains(combined, "context canceled") ||
 		strings.Contains(combined, "context cancelled")
+}
+
+func tkOpsTerminalUpstreamStatusCode(c *gin.Context) int {
+	if c == nil {
+		return 0
+	}
+	if v, ok := c.Get(service.OpsUpstreamStatusCodeKey); ok {
+		switch status := v.(type) {
+		case int:
+			if status > 0 {
+				return status
+			}
+		case int64:
+			if status > 0 {
+				return int(status)
+			}
+		}
+	}
+	if v, ok := c.Get(service.OpsUpstreamErrorsKey); ok {
+		if events, ok := v.([]*service.OpsUpstreamErrorEvent); ok && len(events) > 0 {
+			last := events[len(events)-1]
+			if last != nil && last.UpstreamStatusCode > 0 {
+				return last.UpstreamStatusCode
+			}
+		}
+	}
+	return 0
 }

--- a/backend/internal/handler/ops_error_logger_tk_client_canceled_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_canceled_test.go
@@ -120,3 +120,52 @@ func TestClassifyOpsUpstream5xxWithStatusStaysProviderNotCancel(t *testing.T) {
 	require.Equal(t, "upstream", phase)
 	require.Equal(t, "provider", errorOwner)
 }
+
+func TestClassifyOpsUpstreamPrior5xxThenTerminalClientCancelOwnedByClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{
+		{Kind: "failover", UpstreamStatusCode: http.StatusBadGateway, Message: "edge unavailable"},
+		{Kind: "request_error", UpstreamStatusCode: 0, Message: "context canceled"},
+	})
+
+	phase, errorOwner, errorSource := classifyOpsErrorLog(
+		c, "upstream_error", "Upstream request failed", "", http.StatusBadGateway)
+
+	require.Equal(t, "request", phase)
+	require.Equal(t, "client", errorOwner)
+	require.Equal(t, "client_request", errorSource)
+}
+
+func TestClassifyOpsUpstreamTerminal5xxAfterCancelStaysProvider(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{
+		{Kind: "request_error", UpstreamStatusCode: 0, Message: "context canceled"},
+		{Kind: "failover", UpstreamStatusCode: http.StatusBadGateway, Message: "edge unavailable"},
+	})
+
+	phase, errorOwner, _ := classifyOpsErrorLog(
+		c, "upstream_error", "Upstream request failed", "", http.StatusBadGateway)
+
+	require.Equal(t, "upstream", phase)
+	require.Equal(t, "provider", errorOwner)
+}
+
+func TestClassifyOpsFinal499AfterPrior5xxOwnedByClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{
+		{Kind: "failover", UpstreamStatusCode: http.StatusBadGateway, Message: "edge unavailable"},
+	})
+
+	phase, errorOwner, errorSource := classifyOpsErrorLog(
+		c, "api_error", "", "", statusClientClosedRequest)
+
+	require.Equal(t, "request", phase)
+	require.Equal(t, "client", errorOwner)
+	require.Equal(t, "client_request", errorSource)
+}

--- a/backend/internal/handler/ops_error_logger_tk_client_canceled_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_canceled_test.go
@@ -125,9 +125,13 @@ func TestClassifyOpsUpstreamPrior5xxThenTerminalClientCancelOwnedByClient(t *tes
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
+	// setOpsUpstreamError intentionally retains positive status values, so a
+	// terminal status-0 event must take precedence over this stale failover key.
+	c.Set(service.OpsUpstreamStatusCodeKey, http.StatusBadGateway)
 	c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{
 		{Kind: "failover", UpstreamStatusCode: http.StatusBadGateway, Message: "edge unavailable"},
 		{Kind: "request_error", UpstreamStatusCode: 0, Message: "context canceled"},
+		nil,
 	})
 
 	phase, errorOwner, errorSource := classifyOpsErrorLog(

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -196,6 +196,11 @@ func (s *GatewayService) forwardAnthropicPassthroughWithInput(
 				Kind:               "request_error",
 				Message:            safeErr,
 			})
+			// Match the canonical Anthropic path: caller cancellation is finalized
+			// by the handler as 499, with no body written to the closed connection.
+			if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+				return nil, err
+			}
 			c.JSON(http.StatusBadGateway, gin.H{
 				"type": "error",
 				"error": gin.H{

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -497,6 +497,13 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 				Kind:               "request_error",
 				Message:            safeErr,
 			})
+			// The outbound request inherits the caller context on non-streaming
+			// requests. If that caller disconnected, let the handler terminate the
+			// request as 499; writing a 502 here mislabels client cancellation as an
+			// upstream failure and there is no downstream client left to receive it.
+			if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+				return nil, err
+			}
 			c.JSON(http.StatusBadGateway, gin.H{
 				"type": "error",
 				"error": gin.H{

--- a/backend/internal/service/gateway_forward_client_cancel_test.go
+++ b/backend/internal/service/gateway_forward_client_cancel_test.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+func TestGatewayServiceForward_ClientCanceledTransportDoesNotWrite502(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"hello"}],"max_tokens":32}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body)).WithContext(ctx)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	svc := &GatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+			Enabled: false,
+		}}},
+		httpUpstream: &httpUpstreamRecorder{err: context.Canceled},
+	}
+	account := &Account{
+		ID:          901,
+		Name:        "anthropic-client-cancel",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{"api_key": "test-key", "base_url": "https://api.anthropic.com"},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+	parsed := &ParsedRequest{
+		Body:   NewRequestBodyRef(body),
+		Model:  "claude-opus-4-8",
+		Stream: false,
+	}
+
+	result, err := svc.Forward(ctx, c, account, parsed)
+
+	require.Nil(t, result)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, c.Writer.Written(), "service must leave client-cancel status finalization to the handler")
+	require.Empty(t, rec.Body.String())
+	events, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	require.NotEmpty(t, events)
+}

--- a/backend/internal/service/gateway_forward_client_cancel_test.go
+++ b/backend/internal/service/gateway_forward_client_cancel_test.go
@@ -15,43 +15,54 @@ import (
 
 func TestGatewayServiceForward_ClientCanceledTransportDoesNotWrite502(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"hello"}],"max_tokens":32}`)
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
-	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body)).WithContext(ctx)
-	c.Request.Header.Set("Content-Type", "application/json")
+	for _, tc := range []struct {
+		name  string
+		extra map[string]any
+	}{
+		{name: "canonical"},
+		{name: "api-key passthrough", extra: map[string]any{"anthropic_passthrough": true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"hello"}],"max_tokens":32}`)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body)).WithContext(ctx)
+			c.Request.Header.Set("Content-Type", "application/json")
 
-	svc := &GatewayService{
-		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
-			Enabled: false,
-		}}},
-		httpUpstream: &httpUpstreamRecorder{err: context.Canceled},
-	}
-	account := &Account{
-		ID:          901,
-		Name:        "anthropic-client-cancel",
-		Platform:    PlatformAnthropic,
-		Type:        AccountTypeAPIKey,
-		Concurrency: 1,
-		Credentials: map[string]any{"api_key": "test-key", "base_url": "https://api.anthropic.com"},
-		Status:      StatusActive,
-		Schedulable: true,
-	}
-	parsed := &ParsedRequest{
-		Body:   NewRequestBodyRef(body),
-		Model:  "claude-opus-4-8",
-		Stream: false,
-	}
+			svc := &GatewayService{
+				cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+					Enabled: false,
+				}}},
+				httpUpstream: &httpUpstreamRecorder{err: context.Canceled},
+			}
+			account := &Account{
+				ID:          901,
+				Name:        "anthropic-client-cancel",
+				Platform:    PlatformAnthropic,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{"api_key": "test-key", "base_url": "https://api.anthropic.com"},
+				Extra:       tc.extra,
+				Status:      StatusActive,
+				Schedulable: true,
+			}
+			parsed := &ParsedRequest{
+				Body:   NewRequestBodyRef(body),
+				Model:  "claude-opus-4-8",
+				Stream: false,
+			}
 
-	result, err := svc.Forward(ctx, c, account, parsed)
+			result, err := svc.Forward(ctx, c, account, parsed)
 
-	require.Nil(t, result)
-	require.ErrorIs(t, err, context.Canceled)
-	require.False(t, c.Writer.Written(), "service must leave client-cancel status finalization to the handler")
-	require.Empty(t, rec.Body.String())
-	events, ok := c.Get(OpsUpstreamErrorsKey)
-	require.True(t, ok)
-	require.NotEmpty(t, events)
+			require.Nil(t, result)
+			require.ErrorIs(t, err, context.Canceled)
+			require.False(t, c.Writer.Written(), "service must leave client-cancel status finalization to the handler")
+			require.Empty(t, rec.Body.String())
+			events, ok := c.Get(OpsUpstreamErrorsKey)
+			require.True(t, ok)
+			require.NotEmpty(t, events)
+		})
+	}
 }

--- a/ops/observability/probe-ops-error-request-shape.sh
+++ b/ops/observability/probe-ops-error-request-shape.sh
@@ -110,10 +110,16 @@ WITH base AS (
     AND ('${ERROR_MESSAGE_LIKE_SQL}' = '' OR l.error_message ILIKE '%' || '${ERROR_MESSAGE_LIKE_SQL}' || '%')
 )
 SELECT row_to_json(t) FROM (
-  SELECT left(error_message, 160) AS error_message, COUNT(*) AS rows
+  SELECT
+    error_phase,
+    error_owner,
+    upstream_status_code,
+    left(error_message, 160) AS error_message,
+    left(upstream_error_message, 160) AS upstream_error_message,
+    COUNT(*) AS rows
   FROM base
-  GROUP BY 1
-  ORDER BY rows DESC, error_message
+  GROUP BY 1,2,3,4,5
+  ORDER BY rows DESC, error_owner, error_message
 ) t;
 " 2>&1
 
@@ -144,7 +150,26 @@ SELECT row_to_json(t) FROM (
     group_id,
     request_path,
     COALESCE(requested_model, model) AS model,
-    left(error_message, 120) AS error_message
+    error_phase,
+    error_type,
+    error_owner,
+    error_source,
+    upstream_status_code,
+    network_error_type,
+    duration_ms,
+    left(error_message, 120) AS error_message,
+    left(upstream_error_message, 160) AS upstream_error_message,
+    COALESCE(jsonb_array_length(upstream_errors), 0) AS upstream_event_count,
+    (
+      SELECT string_agg(
+        concat_ws(':', ordinality::text, COALESCE(ev->>'kind',''),
+                  COALESCE(NULLIF(ev->>'upstream_status_code',''),'0'),
+                  left(COALESCE(ev->>'message',''), 80)),
+        ' | ' ORDER BY ordinality
+      )
+      FROM jsonb_array_elements(COALESCE(upstream_errors, '[]'::jsonb))
+           WITH ORDINALITY AS event(ev, ordinality)
+    ) AS upstream_event_summary
   FROM base
   ORDER BY created_at DESC
   LIMIT ${LIMIT}

--- a/ops/observability/probe-ops-error-request-shape.sh
+++ b/ops/observability/probe-ops-error-request-shape.sh
@@ -159,7 +159,9 @@ SELECT row_to_json(t) FROM (
     duration_ms,
     left(error_message, 120) AS error_message,
     left(upstream_error_message, 160) AS upstream_error_message,
-    COALESCE(jsonb_array_length(upstream_errors), 0) AS upstream_event_count,
+    CASE WHEN jsonb_typeof(upstream_errors) = 'array'
+         THEN jsonb_array_length(upstream_errors)
+         ELSE 0 END AS upstream_event_count,
     (
       SELECT string_agg(
         concat_ws(':', ordinality::text, COALESCE(ev->>'kind',''),
@@ -167,7 +169,11 @@ SELECT row_to_json(t) FROM (
                   left(COALESCE(ev->>'message',''), 80)),
         ' | ' ORDER BY ordinality
       )
-      FROM jsonb_array_elements(COALESCE(upstream_errors, '[]'::jsonb))
+      FROM jsonb_array_elements(
+             CASE WHEN jsonb_typeof(upstream_errors) = 'array'
+                  THEN upstream_errors
+                  ELSE '[]'::jsonb END
+           )
            WITH ORDINALITY AS event(ev, ordinality)
     ) AS upstream_event_summary
   FROM base

--- a/ops/observability/probe-sla-breakdown.sh
+++ b/ops/observability/probe-sla-breakdown.sh
@@ -1,20 +1,30 @@
 #!/usr/bin/env bash
 # probe-sla-breakdown.sh — Read-only SLA dashboard-equivalent breakdown (24h default).
+# WINDOW_MINUTES, when set, overrides WINDOW_HOURS for release-boundary queries.
 set -u
 PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
 WINDOW_HOURS="${WINDOW_HOURS:-24}"
+WINDOW_MINUTES="${WINDOW_MINUTES:-}"
 case "$WINDOW_HOURS" in
   ''|*[!0-9]*) echo "[probe-sla-breakdown] ERROR: WINDOW_HOURS not positive int: '$WINDOW_HOURS'" >&2; exit 2 ;;
 esac
+if [ -n "$WINDOW_MINUTES" ]; then
+  case "$WINDOW_MINUTES" in
+    *[!0-9]*) echo "[probe-sla-breakdown] ERROR: WINDOW_MINUTES not positive int: '$WINDOW_MINUTES'" >&2; exit 2 ;;
+  esac
+  WINDOW_INTERVAL="${WINDOW_MINUTES} minute"
+else
+  WINDOW_INTERVAL="${WINDOW_HOURS} hour"
+fi
 
 echo "=== meta ==="
-printf 'window=%s hour\n' "$WINDOW_HOURS"
+printf 'window=%s\n' "$WINDOW_INTERVAL"
 
 echo
 echo "=== sla_overview ==="
 $PSQL -c "
 WITH bounds AS (
-  SELECT now() - interval '${WINDOW_HOURS} hour' AS since, now() AS until
+  SELECT now() - interval '${WINDOW_INTERVAL}' AS since, now() AS until
 ), success AS (
   SELECT COUNT(*)::bigint AS success_count
   FROM usage_logs ul, bounds b
@@ -46,7 +56,7 @@ echo
 echo "=== by_status_sla_scope ==="
 $PSQL -c "
 WITH bounds AS (
-  SELECT now() - interval '${WINDOW_HOURS} hour' AS since, now() AS until
+  SELECT now() - interval '${WINDOW_INTERVAL}' AS since, now() AS until
 )
 SELECT row_to_json(t) FROM (
   SELECT
@@ -68,7 +78,7 @@ echo
 echo "=== by_phase_owner_sla ==="
 $PSQL -c "
 WITH bounds AS (
-  SELECT now() - interval '${WINDOW_HOURS} hour' AS since, now() AS until
+  SELECT now() - interval '${WINDOW_INTERVAL}' AS since, now() AS until
 )
 SELECT row_to_json(t) FROM (
   SELECT
@@ -91,7 +101,7 @@ echo
 echo "=== top_error_messages_sla ==="
 $PSQL -c "
 WITH bounds AS (
-  SELECT now() - interval '${WINDOW_HOURS} hour' AS since, now() AS until
+  SELECT now() - interval '${WINDOW_INTERVAL}' AS since, now() AS until
 )
 SELECT row_to_json(t) FROM (
   SELECT
@@ -115,7 +125,7 @@ echo
 echo "=== client_faults_by_status ==="
 $PSQL -c "
 WITH bounds AS (
-  SELECT now() - interval '${WINDOW_HOURS} hour' AS since, now() AS until
+  SELECT now() - interval '${WINDOW_INTERVAL}' AS since, now() AS until
 )
 SELECT row_to_json(t) FROM (
   SELECT

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3083,21 +3083,25 @@
       "path": "backend/internal/handler/ops_error_logger_tk_client_canceled.go",
       "must_contain": [
         "func tkUpstreamClientCanceled(c *gin.Context) bool",
-        "if tkOpsUpstreamStatusCode(c) != 0 {",
+        "if tkOpsTerminalUpstreamStatusCode(c) != 0 {",
+        "func tkOpsTerminalUpstreamStatusCode(c *gin.Context) int",
         "errors.Is(reqErr, context.Canceled)",
         "deadline exceeded",
         "context canceled"
       ],
-      "rationale": "Issue #625 (prod + us2/us3/uk1 quad P0 2026-06-06T07:00-07:16Z, false page): one client issuing non-streaming claude-opus-4-6 with a timeout shorter than opus latency cancelled mid-flight; the outbound request failed with `context canceled` and NO upstream HTTP status, so classifyOpsErrorLog relabelled it phase=upstream / error_owner=provider and it counted toward upstream_error_rate. Because prod relays the same request to edges via cc-* stub accounts, one cancel propagated down the chain and prod + every relayed edge each recorded a 502 -> simultaneous false P0 across the fleet. This predicate owns a client/caller disconnect to the client (phase=request) so it drops out of upstream_error_rate, mirroring tkUpstreamClientInducedRejection. The status gate (only status 0) keeps real upstream 5xx provider-owned; the deadline-exceeded/timeout exclusion keeps server-side timeouts provider-owned (genuine slowness evidence). Dropping the deadline exclusion would silently hide real upstream timeouts; dropping the predicate restores the quad-P0 false page."
+      "rationale": "Issue #625 (prod + us2/us3/uk1 quad P0 2026-06-06T07:00-07:16Z, false page): one client issuing non-streaming claude-opus-4-6 with a timeout shorter than opus latency cancelled mid-flight; the outbound request failed with `context canceled` and NO upstream HTTP status, so classifyOpsErrorLog relabelled it phase=upstream / error_owner=provider and it counted toward upstream_error_rate. Because prod relays the same request to edges via cc-* stub accounts, one cancel propagated down the chain and prod + every relayed edge each recorded a 502 -> simultaneous false P0 across the fleet. This predicate owns a client/caller disconnect to the client (phase=request) so it drops out of upstream_error_rate, mirroring tkUpstreamClientInducedRejection. The terminal-status gate keeps a real final upstream 5xx provider-owned but deliberately does not let an older failover 5xx override a later status-0 request_error=context canceled; attempt-level 5xx evidence remains in upstream_errors while the final caller outcome is client-owned. The deadline-exceeded/timeout exclusion keeps server-side timeouts provider-owned (genuine slowness evidence). Dropping the deadline exclusion would silently hide real upstream timeouts; scanning backward to any historical positive status restores the false provider classification after failover."
     },
     {
       "path": "backend/internal/handler/ops_error_logger_tk_client_canceled_test.go",
       "must_contain": [
         "TestClassifyOpsUpstreamClientCanceledOwnedByClient",
         "TestClassifyOpsUpstreamDeadlineExceededStaysProvider",
-        "TestClassifyOpsUpstream5xxWithStatusStaysProviderNotCancel"
+        "TestClassifyOpsUpstream5xxWithStatusStaysProviderNotCancel",
+        "TestClassifyOpsUpstreamPrior5xxThenTerminalClientCancelOwnedByClient",
+        "TestClassifyOpsUpstreamTerminal5xxAfterCancelStaysProvider",
+        "TestClassifyOpsFinal499AfterPrior5xxOwnedByClient"
       ],
-      "rationale": "Focused regressions proving the issue #625 boundary: (1) a status-0 `context canceled` transport error (and an inbound Request.Context() cancel with no cancel signature in the message) classify as error_owner=client so they drop out of upstream_error_rate; (2) status-0 `context deadline exceeded` and `i/o timeout` stay error_owner=provider so genuine upstream slowness keeps counting; (3) a real upstream 5xx WITH a status code stays provider via the status gate. Dropping these lets an upstream merge silently revert the quad-P0 fix through the classifier."
+      "rationale": "Focused regressions proving the issue #625 boundary: a status-0 `context canceled` transport error is client-owned; deadline/timeout remains provider-owned; a real final upstream 5xx remains provider-owned; an older failover 5xx followed by terminal cancel is client-owned; the reverse ordering remains provider-owned; and a final 499 remains client-owned even with earlier upstream events. Dropping these lets an upstream merge silently revert the quad-P0 fix or reintroduce failover-history pollution."
     },
     {
       "path": "backend/internal/handler/ops_error_logger_tk_downstream_capacity.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3085,6 +3085,8 @@
         "func tkUpstreamClientCanceled(c *gin.Context) bool",
         "if tkOpsTerminalUpstreamStatusCode(c) != 0 {",
         "func tkOpsTerminalUpstreamStatusCode(c *gin.Context) int",
+        "for i := len(events) - 1; i >= 0; i-- {",
+        "return events[i].UpstreamStatusCode",
         "errors.Is(reqErr, context.Canceled)",
         "deadline exceeded",
         "context canceled"
@@ -3102,6 +3104,48 @@
         "TestClassifyOpsFinal499AfterPrior5xxOwnedByClient"
       ],
       "rationale": "Focused regressions proving the issue #625 boundary: a status-0 `context canceled` transport error is client-owned; deadline/timeout remains provider-owned; a real final upstream 5xx remains provider-owned; an older failover 5xx followed by terminal cancel is client-owned; the reverse ordering remains provider-owned; and a final 499 remains client-owned even with earlier upstream events. Dropping these lets an upstream merge silently revert the quad-P0 fix or reintroduce failover-history pollution."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler.go",
+      "must_contain": [
+        "func (h *GatewayHandler) ensureForwardErrorResponse(c *gin.Context, streamStarted bool) bool",
+        "if isClientClosedRequest(c, nil) {",
+        "service.MarkOpsClientClosedRequest(c)",
+        "failoverClientGone(c)"
+      ],
+      "rationale": "Client-cancel terminal response wiring: a Forward error after the inbound request context is canceled must bypass the generic 502 fallback, mark ops client-closed state, and finalize an uncommitted response as 499 without writing a body. This handler call site is shared by native Anthropic, Gemini, Responses, and compatibility surfaces; an upstream merge can delete the short-circuit while service tests still prove only that transport cancellation was propagated."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_error_fallback_test.go",
+      "must_contain": [
+        "TestGatewayEnsureForwardErrorResponse_ClientCanceledWrites499WithoutBody"
+      ],
+      "rationale": "Focused handler regression proving canceled inbound requests terminate as 499, write no response body, and carry the ops client-closed marker instead of falling through to the generic upstream 502 response."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward.go",
+      "must_contain": [
+        "if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {",
+        "return nil, err"
+      ],
+      "rationale": "Canonical Anthropic transport wiring must propagate context cancellation to the handler before writing the generic 502 JSON body. The handler owns final 499 classification; retaining this branch prevents client disconnects from becoming provider-owned upstream errors."
+    },
+    {
+      "path": "backend/internal/service/gateway_anthropic_passthrough.go",
+      "must_contain": [
+        "if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {",
+        "return nil, err"
+      ],
+      "rationale": "Anthropic API-key and OAuth passthrough return before the canonical Forward loop, so their shared transport-error branch must independently propagate caller cancellation without writing 502. Omitting this anchor makes client-cancel semantics depend on account passthrough configuration."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_client_cancel_test.go",
+      "must_contain": [
+        "TestGatewayServiceForward_ClientCanceledTransportDoesNotWrite502",
+        "api-key passthrough",
+        "require.False(t, c.Writer.Written()"
+      ],
+      "rationale": "Focused service regression covers both canonical and API-key passthrough Anthropic transport paths: context.Canceled must be returned intact, no 502/body may be written, and sanitized attempt evidence remains available for ops classification."
     },
     {
       "path": "backend/internal/handler/ops_error_logger_tk_downstream_capacity.go",


### PR DESCRIPTION
## 摘要

- 客户端已断开时不再由 forward fallback 补写通用 502，统一按 499 终止且不向已关闭连接写 body。
- Ops 分类改为读取最终 upstream event：保留旧 failover 5xx 的 attempt 证据，但最终 `context canceled` / 499 归 client；真实最终 5xx 与 deadline/timeout 仍归 provider。
- canonical、API-key passthrough 与 OAuth passthrough 的 Anthropic transport 统一传播 client cancel，不再因账号配置产生不同的 502 终态。
- 扩展只读错误与 SLA probe，支持部署边界分钟窗口、owner/phase、脱敏 upstream message 和事件链；非数组 `upstream_errors` 也可安全诊断。
- 同步更新 gateway sentinel，锚定 handler、transport、分类实现与聚焦回归测试。

## 风险

- 仅改变客户端取消后的终态与监控归属，不改变真实上游 5xx、deadline/timeout、重试或账号惩罚策略。
- Web impact: none。
- 历史 `ops_error_logs` 不回填；修复仅影响新请求。生产发布仍需走 Stage0 release rollout。

## 验证

- `./scripts/preflight.sh`：PASS（原提交及 xj-review 修复后均通过）。
- `go test ./internal/handler ./internal/service -count=1`：PASS。
- `bash -n ops/observability/probe-ops-error-request-shape.sh ops/observability/probe-sla-breakdown.sh`：PASS。
- prod 账号 66/69/70/71 对 `claude-opus-4-8` 独占探测均为 `HTTP 200` 且 usage 精确归因。
- 探测后最近 15 分钟 `/v1/messages + claude-opus-4-8` 最终错误为 0。
- sentinel-registry-reviewed：handler 499、canonical/passthrough transport、终态 cancel / 最终 5xx / 最终 499 均有实现与测试锚点。

## 提交

- `362e72f06 fix(gateway): 按终态归类客户端取消`
- `1f68c3be4 fix(gateway): 收口 client cancel 审查问题`

最新提交：1f68c3be4
