### PR TITLE
fix(kiro): 将超长输入归为客户端错误

### DIFF
--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -496,6 +496,20 @@ func TestClassifyKiroForwardError_EventStreamValidationDoesNotFailover(t *testin
 	require.NotErrorAs(t, err, &failoverErr)
 }
 
+func TestClassifyKiroForwardError_EventStreamInputTooLongDoesNotFailover(t *testing.T) {
+	err := classifyKiroForwardError(
+		fmt.Errorf(`kiro event stream error: CONTENT_LENGTH_EXCEEDS_THRESHOLD: {"message":"Your input exceeds the context window of this model. Please adjust your input and try again."}`),
+		"claude-sonnet-4-6",
+	)
+	var invalidRequestErr *KiroInvalidRequestError
+	require.ErrorAs(t, err, &invalidRequestErr)
+	require.Equal(t, http.StatusBadRequest, invalidRequestErr.StatusCode)
+	require.Contains(t, invalidRequestErr.ClientMessage(), "input exceeds the context window")
+
+	var failoverErr *UpstreamFailoverError
+	require.NotErrorAs(t, err, &failoverErr)
+}
+
 func TestKiroGatewayService_Forward_NonStreaming_InvalidModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
@@ -550,6 +564,15 @@ func TestClassifyKiroForwardError(t *testing.T) {
 	require.ErrorAs(t, validation, &invalidRequestErr)
 	require.Equal(t, "invalid tool schema", invalidRequestErr.ClientMessage())
 	require.NotErrorAs(t, other, &invalidModelErr)
+
+	inputTooLong := classifyKiroForwardError(
+		fmt.Errorf("HTTP 400 from CodeWhisperer: {\"reason\":\"CONTENT_LENGTH_EXCEEDS_THRESHOLD\",\"message\":\"Input is too long.\"}"),
+		"claude-sonnet-4-6",
+	)
+	require.ErrorAs(t, inputTooLong, &invalidRequestErr)
+	require.Equal(t, http.StatusBadRequest, invalidRequestErr.StatusCode)
+	require.Equal(t, "Input is too long.", invalidRequestErr.ClientMessage())
+	require.NotErrorAs(t, inputTooLong, &failoverErr)
 
 	// 500 with the marker substring → still not classified as invalid-model.
 	notFourHundred := classifyKiroForwardError(

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -510,6 +510,19 @@ func TestClassifyKiroForwardError_EventStreamInputTooLongDoesNotFailover(t *test
 	require.NotErrorAs(t, err, &failoverErr)
 }
 
+func TestClassifyKiroForwardError_EventStreamProviderExceptionWinsOverInputTooLongText(t *testing.T) {
+	err := classifyKiroForwardError(
+		fmt.Errorf(`kiro event stream error: InternalServerException: {"message":"upstream failed while checking whether input exceeds the context window"}`),
+		"claude-sonnet-4-6",
+	)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+
+	var invalidRequestErr *KiroInvalidRequestError
+	require.NotErrorAs(t, err, &invalidRequestErr)
+}
+
 func TestKiroGatewayService_Forward_NonStreaming_InvalidModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -183,7 +183,16 @@ func isKiroProfileArnError(msg string) bool {
 func isKiroValidationErrorBody(body []byte) bool {
 	lower := strings.ToLower(string(body))
 	return strings.Contains(lower, "validationexception") ||
-		strings.Contains(lower, "invalidrequestexception")
+		strings.Contains(lower, "invalidrequestexception") ||
+		isKiroInputTooLongError(lower)
+}
+
+func isKiroInputTooLongError(text string) bool {
+	lower := strings.ToLower(text)
+	return strings.Contains(lower, "content_length_exceeds_threshold") ||
+		strings.Contains(lower, "input is too long") ||
+		strings.Contains(lower, "input exceeds the context window") ||
+		strings.Contains(lower, "input exceeds the context length")
 }
 
 // parseKiroEventStreamError maps AWS EventStream exception frames to the same
@@ -207,7 +216,8 @@ func parseKiroEventStreamError(msg string) (int, []byte, bool) {
 	case strings.Contains(lower, "validationexception"),
 		strings.Contains(lower, "invalidrequestexception"),
 		strings.Contains(lower, "invalidmodelexception"),
-		strings.Contains(lower, "modelnotfound"):
+		strings.Contains(lower, "modelnotfound"),
+		isKiroInputTooLongError(lower):
 		status = http.StatusBadRequest
 	case strings.Contains(lower, "resourcenotfoundexception"):
 		status = http.StatusNotFound

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -216,8 +216,7 @@ func parseKiroEventStreamError(msg string) (int, []byte, bool) {
 	case strings.Contains(lower, "validationexception"),
 		strings.Contains(lower, "invalidrequestexception"),
 		strings.Contains(lower, "invalidmodelexception"),
-		strings.Contains(lower, "modelnotfound"),
-		isKiroInputTooLongError(lower):
+		strings.Contains(lower, "modelnotfound"):
 		status = http.StatusBadRequest
 	case strings.Contains(lower, "resourcenotfoundexception"):
 		status = http.StatusNotFound
@@ -227,6 +226,8 @@ func parseKiroEventStreamError(msg string) (int, []byte, bool) {
 		strings.Contains(lower, "serviceunavailableexception"),
 		strings.Contains(lower, "dependencyfailedexception"):
 		status = http.StatusBadGateway
+	case isKiroInputTooLongError(lower):
+		status = http.StatusBadRequest
 	default:
 		// Unknown exception names are still upstream failures. 502 preserves
 		// failover without pretending the provider returned a client 4xx.

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -211,6 +211,7 @@
         "TestKiroGatewayService_Forward_EventStreamThrottlingTriggersFailover",
         "TestKiroGatewayService_Forward_EmptyEventStreamExceptionPreservesFailoverClass",
         "TestClassifyKiroForwardError_EventStreamInputTooLongDoesNotFailover",
+        "TestClassifyKiroForwardError_EventStreamProviderExceptionWinsOverInputTooLongText",
         "committed stream must not be retried",
         "discard me",
         "recovered"

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -210,11 +210,12 @@
         "TestKiroGatewayService_Forward_Streaming_PreContentReadErrorTriggersFailover",
         "TestKiroGatewayService_Forward_EventStreamThrottlingTriggersFailover",
         "TestKiroGatewayService_Forward_EmptyEventStreamExceptionPreservesFailoverClass",
+        "TestClassifyKiroForwardError_EventStreamInputTooLongDoesNotFailover",
         "committed stream must not be retried",
         "discard me",
         "recovered"
       ],
-      "rationale": "Service-layer regression evidence for both sides of the truncated-response contract: non-streaming partial state is fully discarded before fallback, while a stream that already committed output emits an SSE error and never calls another upstream endpoint."
+      "rationale": "Service-layer regression evidence for both sides of the truncated-response contract: non-streaming partial state is fully discarded before fallback, while a stream that already committed output emits an SSE error and never calls another upstream endpoint. It also pins Kiro's content-length validation as a client-owned non-failover error so context overflow cannot regress to provider 502 churn."
     },
     {
       "path": "backend/internal/service/kiro_sse_encoder.go",
@@ -327,12 +328,13 @@
         "type KiroEndpointQuotaExhaustedError",
         "func classifyKiroForwardError",
         "func parseKiroEventStreamError",
+        "func isKiroInputTooLongError",
         "func isKiroTransportError",
         "errKiroEmptyResponse",
         "quota exhausted on",
         "INVALID_MODEL_ID"
       ],
-      "rationale": "TK-only typed error + classifier for the Kiro upstream HTTP 400 INVALID_MODEL_ID rejection. classifyKiroForwardError is called from both forwardStreaming and forwardNonStreaming; the handler errors.As-es the typed *KiroInvalidModelError to emit a model-scoped 400. Losing this file makes kiro model-unsupported errors fall back to the generic forward-error path (opaque 500 / unwanted failover)."
+      "rationale": "TK-only typed error + classifier for Kiro request rejections, including INVALID_MODEL_ID and CONTENT_LENGTH_EXCEEDS_THRESHOLD. classifyKiroForwardError is called from both forwardStreaming and forwardNonStreaming; the handler maps typed invalid model/request errors to client-owned 400 responses without cross-account failover. Losing this file makes Kiro validation errors fall back to the generic forward-error path (opaque 502 / unwanted failover / polluted SLA)."
     },
     {
       "path": "backend/internal/service/wire.go",


### PR DESCRIPTION
## 摘要

- 将 Kiro `CONTENT_LENGTH_EXCEEDS_THRESHOLD`、`Input is too long` 和明确的 context-window 超限错误识别为客户端 validation。
- 对 HTTP 400 与 EventStream 两种上游形状统一返回 `KiroInvalidRequestError`，避免误记 provider 502 和无效跨账号 failover。
- 保持结构化 provider exception 优先于文本启发式，确保真实上游 5xx 继续 failover。
- 更新 Kiro sentinel，机械守卫正向分类与 provider 5xx 冲突边界。

## 风险

- 匹配范围仅限明确的输入超长标记；已知 provider exception 类型优先，未知异常仍保持 502/failover。
- 不修改数据库、鉴权、计费或前端。
- Web impact: none

## 验证

- `go test -tags unit ./internal/service -run TestClassifyKiroForwardError -count=1 -v`
- `go test -tags unit ./internal/service -count=1`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `git diff --check`
- xj-review pipeline re-review：0 findings

## 提交

- `f99342a28 fix(kiro): 将超长输入归为客户端错误`
- `332cb5643 fix(kiro): address R-001 — preserve provider exception precedence`

最新提交：`332cb5643`