### PR TITLE
fix(frontend): 修复工具接入页面滚动回滚

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 607,
-  "hash": "25bda472b1143997edb028b0c45df65a0c0570189da2b173b064be295f39f7c9",
+  "file_count": 608,
+  "hash": "c081e90e1b4e80f02ed5a7e1cf13211688a2f26736b02d5ca14cd98614746ce4",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/router/__tests__/scrollBehavior.spec.ts
+++ b/frontend/src/router/__tests__/scrollBehavior.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { scrollBehavior } from '../scrollBehavior'
+
+const location = (path: string, query: string) => ({
+  path,
+  query: {},
+  hash: '',
+  fullPath: `${path}${query}`,
+  matched: [],
+  meta: {},
+  name: undefined,
+  params: {},
+  redirectedFrom: undefined,
+})
+
+describe('scrollBehavior', () => {
+  it('preserves scroll position when only query params change', () => {
+    expect(scrollBehavior(location('/quickstart', '?client=claude-code'), location('/quickstart', ''), null))
+      .toBe(false)
+  })
+
+  it('scrolls to the top when navigating to a different path', () => {
+    expect(scrollBehavior(location('/keys', ''), location('/quickstart', ''), null)).toEqual({ top: 0 })
+  })
+
+  it('restores the browser history position when provided', () => {
+    const savedPosition = { left: 12, top: 480 }
+    expect(scrollBehavior(location('/quickstart', ''), location('/keys', ''), savedPosition))
+      .toEqual(savedPosition)
+  })
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -13,6 +13,7 @@ import { useRoutePrefetch } from '@/composables/useRoutePrefetch'
 import { getSetupStatus } from '@/api/setup'
 import { resolveCompletedSetupRedirectPath } from './setupRedirect'
 import { resolveRouteDocumentTitle } from './title'
+import { scrollBehavior } from './scrollBehavior'
 import { adminRoutes } from './admin.tk'
 
 /**
@@ -466,14 +467,7 @@ const routes: RouteRecordRaw[] = [
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes,
-  scrollBehavior(_to, _from, savedPosition) {
-    // Scroll to saved position when using browser back/forward
-    if (savedPosition) {
-      return savedPosition
-    }
-    // Scroll to top for new routes
-    return { top: 0 }
-  }
+  scrollBehavior
 })
 
 /**

--- a/frontend/src/router/scrollBehavior.ts
+++ b/frontend/src/router/scrollBehavior.ts
@@ -1,0 +1,12 @@
+import type { RouterScrollBehavior } from 'vue-router'
+
+/**
+ * Keep the current viewport when a page only synchronizes its query string.
+ * Views such as Quickstart update query params as async data becomes ready;
+ * treating those updates as a new page otherwise jumps the user to the top.
+ */
+export const scrollBehavior: RouterScrollBehavior = (to, from, savedPosition) => {
+  if (savedPosition) return savedPosition
+  if (to.path === from.path) return false
+  return { top: 0 }
+}


### PR DESCRIPTION
## 摘要
修复工具接入页面在异步同步 URL query 时被路由器自动滚回顶部的问题。

同一路径的 query 更新现在保留当前滚动位置；跨页面导航和浏览器历史导航保持原有行为。

## 风险
低风险，仅调整前端路由滚动策略和对应回归测试。
sentinel-registry-reviewed

## 验证
- pnpm exec vitest run src/router/__tests__/scrollBehavior.spec.ts
- pnpm exec vitest run src/views/user/__tests__/QuickstartView.spec.ts
- pnpm exec vue-tsc --noEmit
- pnpm exec eslint src/router/scrollBehavior.ts src/router/__tests__/scrollBehavior.spec.ts src/router/index.ts
- pnpm --dir frontend run build
- ./scripts/preflight.sh：PASS

## 提交
- 7c84083b6 fix(frontend): 保留工具接入页面滚动位置
- 最新提交：7c84083b6