### PR TITLE
fix(admin): 刷新账号编辑弹窗的分组选项

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 608,
-  "hash": "c081e90e1b4e80f02ed5a7e1cf13211688a2f26736b02d5ca14cd98614746ce4",
+  "hash": "814e73ee84a0bddf7943a5809743520538860527439626f8629dcebcd4a03b10",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1092,6 +1092,22 @@ const resetAutoRefreshCache = () => {
 
 const isFirstLoad = ref(true)
 
+const loadAccountDependencies = async () => {
+  try {
+    const [p, g, gAll] = await Promise.all([
+      adminAPI.proxies.getAll(),
+      adminAPI.groups.getAll(),
+      // Inactive-inclusive set for chip resolution only (disabled-group bindings).
+      adminAPI.groups.getAllIncludingInactive()
+    ])
+    proxies.value = p
+    groups.value = g
+    groupsForChips.value = gAll
+  } catch (error) {
+    console.error('Failed to load proxies/groups:', error)
+  }
+}
+
 const load = async () => {
   const requestParams = params as any
   syncAccountListDerivedParams()
@@ -1106,6 +1122,10 @@ const load = async () => {
   isFirstLoad.value = false
   await baseLoad()
   refreshAccountRowMetrics()
+}
+
+const refreshAccountPage = async () => {
+  await Promise.all([load(), loadAccountDependencies()])
 }
 
 const reload = async () => {
@@ -1293,7 +1313,8 @@ const refreshAccountsIncrementally = async () => {
 }
 
 const handleManualRefresh = async () => {
-  await load()
+  lastFetchedAt = Date.now()
+  await refreshAccountPage()
   await refreshEdges({ force: true })
   // load() already starts the batch passive-usage refresh for Anthropic/OpenAI/Kiro
   // rows (override path). Bump the token so the residual self-fetch platforms
@@ -2128,22 +2149,12 @@ const handleClickOutside = (event: MouseEvent) => {
 
 let lastFetchedAt = 0
 const STALE_THRESHOLD_MS = 30_000
+let hasCompletedInitialMount = false
 
 onMounted(async () => {
-  load()
-  try {
-    const [p, g, gAll] = await Promise.all([
-      adminAPI.proxies.getAll(),
-      adminAPI.groups.getAll(),
-      // Inactive-inclusive set for chip resolution only (disabled-group bindings).
-      adminAPI.groups.getAllIncludingInactive()
-    ])
-    proxies.value = p
-    groups.value = g
-    groupsForChips.value = gAll
-  } catch (error) {
-    console.error('Failed to load proxies/groups:', error)
-  }
+  lastFetchedAt = Date.now()
+  await refreshAccountPage()
+  hasCompletedInitialMount = true
   window.addEventListener('scroll', handleScroll, true)
   document.addEventListener('click', handleClickOutside)
 
@@ -2153,14 +2164,16 @@ onMounted(async () => {
   } else {
     pauseAutoRefresh()
   }
-  lastFetchedAt = Date.now()
 })
 
 onActivated(() => {
   if (autoRefreshEnabled.value) resumeAutoRefresh()
+  if (!hasCompletedInitialMount) return
+
+  void loadAccountDependencies()
   if (Date.now() - lastFetchedAt > STALE_THRESHOLD_MS) {
-    load()
     lastFetchedAt = Date.now()
+    void load()
   }
 })
 

--- a/frontend/src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts
@@ -185,6 +185,68 @@ describe('admin AccountsView bulk edit scope', () => {
     expect(wrapper.get('[data-test="bulk-edit-modal"]').attributes('data-target-mode')).toBe('filtered')
   })
 
+  it('reloads account group choices during a manual refresh', async () => {
+    getAllGroups
+      .mockResolvedValueOnce([{ id: 19, name: 'china', platform: 'newapi' }])
+      .mockResolvedValueOnce([
+        { id: 19, name: 'china', platform: 'newapi' },
+        { id: 285, name: 'Kimi', platform: 'newapi' }
+      ])
+    getAllIncludingInactive
+      .mockResolvedValueOnce([{ id: 19, name: 'china', platform: 'newapi' }])
+      .mockResolvedValueOnce([
+        { id: 19, name: 'china', platform: 'newapi' },
+        { id: 285, name: 'Kimi', platform: 'newapi' }
+      ])
+
+    const wrapper = mount(AccountsView, {
+      global: {
+        stubs: {
+          AppLayout: { template: '<div><slot /></div>' },
+          TablePageLayout: {
+            template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
+          },
+          DataTable: DataTableStub,
+          Pagination: true,
+          ConfirmDialog: true,
+          AccountTableActions: AccountTableActionsStub,
+          AccountTableFilters: { template: '<div></div>' },
+          AccountBulkActionsBar: AccountBulkActionsBarStub,
+          AccountActionMenu: true,
+          ImportDataModal: true,
+          ReAuthAccountModal: true,
+          AccountTestModal: true,
+          AccountStatsModal: true,
+          ScheduledTestsPanel: true,
+          SyncFromCrsModal: true,
+          TempUnschedStatusModal: true,
+          ErrorPassthroughRulesModal: true,
+          TLSFingerprintProfilesModal: true,
+          CreateAccountModal: true,
+          EditAccountModal: true,
+          BulkEditAccountModal: BulkEditAccountModalStub,
+          PlatformTypeBadge: true,
+          AccountCapacityCell: true,
+          AccountStatusIndicator: true,
+          AccountTodayStatsCell: true,
+          AccountGroupsCell: true,
+          AccountUsageCell: true,
+          Icon: true
+        }
+      }
+    })
+
+    await flushPromises()
+    expect(getAllGroups).toHaveBeenCalledTimes(1)
+    expect(getAllIncludingInactive).toHaveBeenCalledTimes(1)
+
+    await wrapper.get('[data-test="refresh-accounts"]').trigger('click')
+    await flushPromises()
+
+    expect(getAllGroups).toHaveBeenCalledTimes(2)
+    expect(getAllIncludingInactive).toHaveBeenCalledTimes(2)
+  })
+
   it('uses the compact account operation columns by default', async () => {
     listAccounts.mockResolvedValue({
       items: [

--- a/frontend/src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
+import { KeepAlive, defineComponent, h } from 'vue'
 
 import AccountsView from '../AccountsView.vue'
 
@@ -91,7 +92,7 @@ const AccountBulkActionsBarStub = {
 }
 
 const AccountTableActionsStub = {
-  emits: ['refresh'],
+  emits: ['refresh', 'sync', 'create'],
   template: `
     <div>
       <button data-test="refresh-accounts" @click="$emit('refresh')">refresh</button>
@@ -105,6 +106,66 @@ const BulkEditAccountModalStub = {
   props: ['show', 'target'],
   template: '<div data-test="bulk-edit-modal" :data-show="String(show)" :data-target-mode="target?.mode ?? \'\'"></div>'
 }
+
+const AccountTableFiltersStub = {
+  props: ['groups'],
+  template: '<div data-test="account-group-options">{{ groups.map(group => group.name).join(",") }}</div>'
+}
+
+const accountsViewStubs = {
+  AppLayout: { template: '<div><slot /></div>' },
+  TablePageLayout: {
+    template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
+  },
+  DataTable: DataTableStub,
+  Pagination: true,
+  ConfirmDialog: true,
+  AccountTableActions: AccountTableActionsStub,
+  AccountTableFilters: AccountTableFiltersStub,
+  AccountBulkActionsBar: AccountBulkActionsBarStub,
+  AccountActionMenu: true,
+  ImportDataModal: true,
+  ReAuthAccountModal: true,
+  AccountTestModal: true,
+  AccountStatsModal: true,
+  ScheduledTestsPanel: true,
+  SyncFromCrsModal: true,
+  TempUnschedStatusModal: true,
+  ErrorPassthroughRulesModal: true,
+  TLSFingerprintProfilesModal: true,
+  CreateAccountModal: true,
+  EditAccountModal: true,
+  BulkEditAccountModal: BulkEditAccountModalStub,
+  PlatformTypeBadge: true,
+  AccountCapacityCell: true,
+  AccountStatusIndicator: true,
+  AccountTodayStatsCell: true,
+  AccountGroupsCell: true,
+  AccountUsageCell: true,
+  Icon: true
+}
+
+const mountAccountsView = () => mount(AccountsView, {
+  global: { stubs: accountsViewStubs }
+})
+
+const InactiveView = defineComponent({
+  name: 'InactiveView',
+  setup: () => () => h('div')
+})
+
+const CachedAccountsHost = defineComponent({
+  props: {
+    showAccounts: { type: Boolean, required: true }
+  },
+  setup(props) {
+    return () => h(KeepAlive, null, {
+      default: () => props.showAccounts
+        ? h(AccountsView, { key: 'accounts' })
+        : h(InactiveView, { key: 'inactive' })
+    })
+  }
+})
 
 describe('admin AccountsView bulk edit scope', () => {
   beforeEach(() => {
@@ -140,42 +201,7 @@ describe('admin AccountsView bulk edit scope', () => {
   })
 
   it('opens bulk edit in filtered-results mode from the bulk actions dropdown', async () => {
-    const wrapper = mount(AccountsView, {
-      global: {
-        stubs: {
-          AppLayout: { template: '<div><slot /></div>' },
-          TablePageLayout: {
-            template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
-          },
-          DataTable: DataTableStub,
-          Pagination: true,
-          ConfirmDialog: true,
-          AccountTableActions: AccountTableActionsStub,
-          AccountTableFilters: { template: '<div></div>' },
-          AccountBulkActionsBar: AccountBulkActionsBarStub,
-          AccountActionMenu: true,
-          ImportDataModal: true,
-          ReAuthAccountModal: true,
-          AccountTestModal: true,
-          AccountStatsModal: true,
-          ScheduledTestsPanel: true,
-          SyncFromCrsModal: true,
-          TempUnschedStatusModal: true,
-          ErrorPassthroughRulesModal: true,
-          TLSFingerprintProfilesModal: true,
-          CreateAccountModal: true,
-          EditAccountModal: true,
-          BulkEditAccountModal: BulkEditAccountModalStub,
-          PlatformTypeBadge: true,
-          AccountCapacityCell: true,
-          AccountStatusIndicator: true,
-          AccountTodayStatsCell: true,
-          AccountGroupsCell: true,
-          AccountUsageCell: true,
-          Icon: true
-        }
-      }
-    })
+    const wrapper = mountAccountsView()
 
     await flushPromises()
     await wrapper.get('[data-test="edit-filtered"]').trigger('click')
@@ -199,52 +225,53 @@ describe('admin AccountsView bulk edit scope', () => {
         { id: 285, name: 'Kimi', platform: 'newapi' }
       ])
 
-    const wrapper = mount(AccountsView, {
-      global: {
-        stubs: {
-          AppLayout: { template: '<div><slot /></div>' },
-          TablePageLayout: {
-            template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
-          },
-          DataTable: DataTableStub,
-          Pagination: true,
-          ConfirmDialog: true,
-          AccountTableActions: AccountTableActionsStub,
-          AccountTableFilters: { template: '<div></div>' },
-          AccountBulkActionsBar: AccountBulkActionsBarStub,
-          AccountActionMenu: true,
-          ImportDataModal: true,
-          ReAuthAccountModal: true,
-          AccountTestModal: true,
-          AccountStatsModal: true,
-          ScheduledTestsPanel: true,
-          SyncFromCrsModal: true,
-          TempUnschedStatusModal: true,
-          ErrorPassthroughRulesModal: true,
-          TLSFingerprintProfilesModal: true,
-          CreateAccountModal: true,
-          EditAccountModal: true,
-          BulkEditAccountModal: BulkEditAccountModalStub,
-          PlatformTypeBadge: true,
-          AccountCapacityCell: true,
-          AccountStatusIndicator: true,
-          AccountTodayStatsCell: true,
-          AccountGroupsCell: true,
-          AccountUsageCell: true,
-          Icon: true
-        }
-      }
-    })
+    const wrapper = mountAccountsView()
 
     await flushPromises()
     expect(getAllGroups).toHaveBeenCalledTimes(1)
     expect(getAllIncludingInactive).toHaveBeenCalledTimes(1)
+    expect(wrapper.get('[data-test="account-group-options"]').text()).not.toContain('Kimi')
 
     await wrapper.get('[data-test="refresh-accounts"]').trigger('click')
     await flushPromises()
 
     expect(getAllGroups).toHaveBeenCalledTimes(2)
     expect(getAllIncludingInactive).toHaveBeenCalledTimes(2)
+    expect(wrapper.get('[data-test="account-group-options"]').text()).toContain('Kimi')
+  })
+
+  it('reloads account group choices when the kept-alive page is reactivated', async () => {
+    getAllGroups
+      .mockResolvedValueOnce([{ id: 19, name: 'china', platform: 'newapi' }])
+      .mockResolvedValueOnce([
+        { id: 19, name: 'china', platform: 'newapi' },
+        { id: 285, name: 'Kimi', platform: 'newapi' }
+      ])
+    getAllIncludingInactive
+      .mockResolvedValueOnce([{ id: 19, name: 'china', platform: 'newapi' }])
+      .mockResolvedValueOnce([
+        { id: 19, name: 'china', platform: 'newapi' },
+        { id: 285, name: 'Kimi', platform: 'newapi' }
+      ])
+
+    const wrapper = mount(CachedAccountsHost, {
+      props: { showAccounts: true },
+      global: { stubs: accountsViewStubs }
+    })
+
+    await flushPromises()
+    expect(getAllGroups).toHaveBeenCalledTimes(1)
+    expect(getAllIncludingInactive).toHaveBeenCalledTimes(1)
+
+    await wrapper.setProps({ showAccounts: false })
+    await flushPromises()
+    await wrapper.setProps({ showAccounts: true })
+    await flushPromises()
+
+    expect(getAllGroups).toHaveBeenCalledTimes(2)
+    expect(getAllIncludingInactive).toHaveBeenCalledTimes(2)
+    expect(listAccounts).toHaveBeenCalledTimes(1)
+    expect(wrapper.get('[data-test="account-group-options"]').text()).toContain('Kimi')
   })
 
   it('uses the compact account operation columns by default', async () => {
@@ -267,42 +294,7 @@ describe('admin AccountsView bulk edit scope', () => {
       pages: 1
     })
 
-    const wrapper = mount(AccountsView, {
-      global: {
-        stubs: {
-          AppLayout: { template: '<div><slot /></div>' },
-          TablePageLayout: {
-            template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
-          },
-          DataTable: DataTableStub,
-          Pagination: true,
-          ConfirmDialog: true,
-          AccountTableActions: AccountTableActionsStub,
-          AccountTableFilters: { template: '<div></div>' },
-          AccountBulkActionsBar: AccountBulkActionsBarStub,
-          AccountActionMenu: true,
-          ImportDataModal: true,
-          ReAuthAccountModal: true,
-          AccountTestModal: true,
-          AccountStatsModal: true,
-          ScheduledTestsPanel: true,
-          SyncFromCrsModal: true,
-          TempUnschedStatusModal: true,
-          ErrorPassthroughRulesModal: true,
-          TLSFingerprintProfilesModal: true,
-          CreateAccountModal: true,
-          EditAccountModal: true,
-          BulkEditAccountModal: BulkEditAccountModalStub,
-          PlatformTypeBadge: true,
-          AccountCapacityCell: true,
-          AccountStatusIndicator: true,
-          AccountTodayStatsCell: true,
-          AccountGroupsCell: true,
-          AccountUsageCell: true,
-          Icon: true
-        }
-      }
-    })
+    const wrapper = mountAccountsView()
 
     await flushPromises()
 
@@ -342,42 +334,7 @@ describe('admin AccountsView bulk edit scope', () => {
       pages: 0
     })
 
-    const wrapper = mount(AccountsView, {
-      global: {
-        stubs: {
-          AppLayout: { template: '<div><slot /></div>' },
-          TablePageLayout: {
-            template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
-          },
-          DataTable: DataTableStub,
-          Pagination: true,
-          ConfirmDialog: true,
-          AccountTableActions: AccountTableActionsStub,
-          AccountTableFilters: { template: '<div></div>' },
-          AccountBulkActionsBar: AccountBulkActionsBarStub,
-          AccountActionMenu: true,
-          ImportDataModal: true,
-          ReAuthAccountModal: true,
-          AccountTestModal: true,
-          AccountStatsModal: true,
-          ScheduledTestsPanel: true,
-          SyncFromCrsModal: true,
-          TempUnschedStatusModal: true,
-          ErrorPassthroughRulesModal: true,
-          TLSFingerprintProfilesModal: true,
-          CreateAccountModal: true,
-          EditAccountModal: true,
-          BulkEditAccountModal: BulkEditAccountModalStub,
-          PlatformTypeBadge: true,
-          AccountCapacityCell: true,
-          AccountStatusIndicator: true,
-          AccountTodayStatsCell: true,
-          AccountGroupsCell: true,
-          AccountUsageCell: true,
-          Icon: true
-        }
-      }
-    })
+    const wrapper = mountAccountsView()
 
     await flushPromises()
 
@@ -429,42 +386,7 @@ describe('admin AccountsView bulk edit scope', () => {
       pages: 1
     })
 
-    const wrapper = mount(AccountsView, {
-      global: {
-        stubs: {
-          AppLayout: { template: '<div><slot /></div>' },
-          TablePageLayout: {
-            template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
-          },
-          DataTable: DataTableStub,
-          Pagination: true,
-          ConfirmDialog: true,
-          AccountTableActions: AccountTableActionsStub,
-          AccountTableFilters: { template: '<div></div>' },
-          AccountBulkActionsBar: AccountBulkActionsBarStub,
-          AccountActionMenu: true,
-          ImportDataModal: true,
-          ReAuthAccountModal: true,
-          AccountTestModal: true,
-          AccountStatsModal: true,
-          ScheduledTestsPanel: true,
-          SyncFromCrsModal: true,
-          TempUnschedStatusModal: true,
-          ErrorPassthroughRulesModal: true,
-          TLSFingerprintProfilesModal: true,
-          CreateAccountModal: true,
-          EditAccountModal: true,
-          BulkEditAccountModal: BulkEditAccountModalStub,
-          PlatformTypeBadge: true,
-          AccountCapacityCell: true,
-          AccountStatusIndicator: true,
-          AccountTodayStatsCell: true,
-          AccountGroupsCell: true,
-          AccountUsageCell: true,
-          Icon: true
-        }
-      }
-    })
+    const wrapper = mountAccountsView()
 
     await flushPromises()
     listEdgeAccounts.mockClear()


### PR DESCRIPTION
## 摘要
- 修复 Accounts 页面被 KeepAlive 后分组列表只在首次挂载加载的问题。
- 首次进入、返回 Accounts 页面和手动刷新现在复用同一依赖加载函数，编辑账号时可立即看到新建分组。
- 增加手动刷新与 KeepAlive 重新激活的回归测试，并同步内嵌前端 source hash。
- xj-review 修复 R-001..R-002：用真实 KeepAlive 生命周期覆盖事故入口，并收敛重复的 AccountsView 测试挂载配置。

sentinel-registry-reviewed

## 风险
- 低风险；仅增加管理端页面激活和手动刷新时的只读依赖请求。
- 不改变 API、数据库、权限或调度契约。

## 验证
- `pnpm exec vitest run src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts --reporter=verbose`
- `pnpm exec eslint src/views/admin/AccountsView.vue src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts`
- `pnpm run build`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

## 提交
- `2e0f8db32 fix(frontend): 刷新账号页分组选项`
- `b09855742 test(frontend): address R-001..R-002 account refresh coverage`

最新提交：`b09855742`