### PR TITLE
refactor(pricing): 统一税率策略与 overlay 价格 SSOT

### DIFF
--- a/.cursor/skills/tokenkey-onboard-model/SKILL.md
+++ b/.cursor/skills/tokenkey-onboard-model/SKILL.md
@@ -108,7 +108,8 @@ bash ops/observability/run-probe.sh --target prod \
 
 Moonshot 国内站与国际站 key/价格相互独立；账号 `base_url=api.moonshot.cn` 时，overlay 必须取
 `platform.kimi.com/docs/pricing/*` 国内 RMB 表并按 TokenKey `CNY/USD=6.7` 换算。overlay 保存税前价，
-billing 与公开 `/pricing` 通过 `litellm_provider=moonshot` 统一叠加 `tkOfficialListBaseTaxMultiplier=1.06`。
+billing、公开 `/pricing` 与 fallback 通过 overlay `_config.official_list_base_tax` 的 `moonshot` rule 统一叠加
+配置中的 multiplier；provider、matcher、multiplier 都不得在 Go 或测试里维护第二份清单。
 
 ### 2) 写 manifest 条目（单一意图源，**先于**投影）
 

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -196,33 +196,6 @@ func NewBillingService(cfg *config.Config, pricingService *PricingService) *Bill
 	return s
 }
 
-func tkGLMPricing(inputCNY, outputCNY, cacheReadCNY float64, intervals ...PricingInterval) *ModelPricing {
-	return &ModelPricing{
-		InputPricePerToken:     tkCNYPerMTokToUSDPerToken(inputCNY),
-		OutputPricePerToken:    tkCNYPerMTokToUSDPerToken(outputCNY),
-		CacheReadPricePerToken: tkCNYPerMTokToUSDPerToken(cacheReadCNY),
-		Intervals:              intervals,
-		SupportsCacheBreakdown: false,
-	}
-}
-
-func tkGLMInterval(min int, max *int, inputCNY, outputCNY, cacheReadCNY float64) PricingInterval {
-	input := tkCNYPerMTokToUSDPerToken(inputCNY)
-	output := tkCNYPerMTokToUSDPerToken(outputCNY)
-	cacheRead := tkCNYPerMTokToUSDPerToken(cacheReadCNY)
-	return PricingInterval{
-		MinTokens:      min,
-		MaxTokens:      max,
-		InputPrice:     &input,
-		OutputPrice:    &output,
-		CacheReadPrice: &cacheRead,
-	}
-}
-
-func tkIntPtr(v int) *int {
-	return &v
-}
-
 // initFallbackPricing 初始化硬编码回退价格（当动态价格不可用时使用）
 // 价格单位：USD per token（与LiteLLM格式一致）
 func (s *BillingService) initFallbackPricing() {
@@ -404,68 +377,12 @@ func (s *BillingService) initFallbackPricing() {
 		SupportsCacheBreakdown:         false,
 	}
 
-	// ============================================================
-	// 国产 LLM 兜底定价（数据源：各家官方定价页，必要时按 CNY/USD=6.7 换算）
-	// 顺序：DeepSeek → 智谱 GLM → 月之暗面 Kimi → MiniMax
-	// 覆盖逻辑见同文件 getFallbackPricing()
-	// ============================================================
+	// DeepSeek V4 and paid GLM official prices live only in
+	// tk_pricing_overlay.json. getFallbackPricing retains compatibility matching,
+	// but resolves those aliases to the live overlay instead of a numeric Go copy.
 
-	// ---- DeepSeek V4 系列 ----
-	// Source: https://api-docs.deepseek.com/quick_start/pricing
-	// （deepseek-chat / deepseek-reasoner 为 deepseek-v4-flash 的兼容别名，2026/07/24 弃用）
-	s.fallbackPrices["deepseek-v4-pro"] = &ModelPricing{
-		InputPricePerToken:     4.35e-7,  // $0.435 per MTok (cache miss)
-		OutputPricePerToken:    8.7e-7,   // $0.87 per MTok
-		CacheReadPricePerToken: 3.625e-9, // $0.003625 per MTok (cache hit)
-		SupportsCacheBreakdown: false,
-	}
-	s.fallbackPrices["deepseek-v4-flash"] = &ModelPricing{
-		InputPricePerToken:     1.4e-7, // $0.14 per MTok (cache miss)
-		OutputPricePerToken:    2.8e-7, // $0.28 per MTok
-		CacheReadPricePerToken: 2.8e-9, // $0.0028 per MTok (cache hit)
-		SupportsCacheBreakdown: false,
-	}
-
-	// ---- 智谱 GLM（BigModel）----
-	// Source: https://bigmodel.cn/pricing (人民币/百万 tokens，统一 CNY/USD=6.7).
-	// 这里存税前官方价；GetModelPricing 末尾通过 tkApplyOfficialListBaseTaxForModel
-	// 对 glm/zhipu 默认叠加 1.06。CacheReadPricePerToken 即"缓存命中"价格，
-	// CacheCreationPricePerToken 留空（官方页缓存存储为限时免费）。
-	s.fallbackPrices["glm-5.2"] = tkGLMPricing(8, 28, 2)
-	s.fallbackPrices["glm-5.1"] = tkGLMPricing(6, 24, 1.3,
-		tkGLMInterval(0, tkIntPtr(32000), 6, 24, 1.3),
-		tkGLMInterval(32000, nil, 8, 28, 2),
-	)
-	s.fallbackPrices["glm-5"] = tkGLMPricing(4, 18, 1,
-		tkGLMInterval(0, tkIntPtr(32000), 4, 18, 1),
-		tkGLMInterval(32000, nil, 6, 22, 1.5),
-	)
-	s.fallbackPrices["glm-5-turbo"] = tkGLMPricing(5, 22, 1.2,
-		tkGLMInterval(0, tkIntPtr(32000), 5, 22, 1.2),
-		tkGLMInterval(32000, nil, 7, 26, 1.8),
-	)
-	// GLM-4.7/4.5-Air have output-length subtiers in the 0-32K input bracket.
-	// Runtime intervals only tier by input tokens, so use the higher reachable
-	// output>0.2K row for that bracket to avoid under-billing.
-	s.fallbackPrices["glm-4.7"] = tkGLMPricing(3, 14, 0.6,
-		tkGLMInterval(0, tkIntPtr(32000), 3, 14, 0.6),
-		tkGLMInterval(32000, nil, 4, 16, 0.8),
-	)
-	s.fallbackPrices["glm-4.7-flashx"] = tkGLMPricing(0.5, 3, 0.1)
-	// BigModel's current pricing page no longer lists separate GLM-4.6/4.5 text
-	// rows; keep legacy requests priced to the current GLM-4.7 paid ladder.
-	s.fallbackPrices["glm-4.6"] = tkGLMPricing(3, 14, 0.6,
-		tkGLMInterval(0, tkIntPtr(32000), 3, 14, 0.6),
-		tkGLMInterval(32000, nil, 4, 16, 0.8),
-	)
-	s.fallbackPrices["glm-4.5"] = tkGLMPricing(3, 14, 0.6,
-		tkGLMInterval(0, tkIntPtr(32000), 3, 14, 0.6),
-		tkGLMInterval(32000, nil, 4, 16, 0.8),
-	)
-	s.fallbackPrices["glm-4.5-air"] = tkGLMPricing(0.8, 6, 0.16,
-		tkGLMInterval(0, tkIntPtr(32000), 0.8, 6, 0.16),
-		tkGLMInterval(32000, nil, 1.2, 8, 0.24),
-	)
+	// BigModel's free GLM rows intentionally remain compatibility-only fallbacks;
+	// they are not public catalog entries and therefore do not belong in overlay.
 	// GLM-4.5-Flash / GLM-4.7-Flash 在 BigModel 当前页为 free，
 	// 保留 zero-cost entry 防止未知 alias 误计费。
 	s.fallbackPrices["glm-4.5-flash"] = &ModelPricing{
@@ -480,29 +397,9 @@ func (s *BillingService) initFallbackPricing() {
 	}
 
 	// ---- 月之暗面 Kimi（K 系列）----
-	// Source: https://platform.moonshot.cn/docs/pricing/overview (元/百万 tokens 口径)
-	//       交叉验证：https://www.tmtpost.com/7961404.html (USD 口径)
-	// Moonshot V1 (¥2/¥5/¥10 多 tier) 公开页未直接标注 USD 价，本分支不覆盖，避免误计价。
-	// K2-0905 / K2-0711 官方页面未保留定价，不覆盖。
-	s.fallbackPrices["kimi-k2.6"] = &ModelPricing{
-		InputPricePerToken:     0.95e-6, // $0.95 per MTok (cache miss)
-		OutputPricePerToken:    4e-6,    // $4.00 per MTok
-		CacheReadPricePerToken: 0.15e-6, // $0.15 per MTok (cache hit, ¥1.10)
-		SupportsCacheBreakdown: false,
-	}
-	// kimi-for-coding 走 Kimi Coding endpoint，按当前 K2.6 coding 档位兜底计费。
-	s.fallbackPrices["kimi-for-coding"] = &ModelPricing{
-		InputPricePerToken:     0.95e-6,
-		OutputPricePerToken:    4e-6,
-		CacheReadPricePerToken: 0.15e-6,
-		SupportsCacheBreakdown: false,
-	}
-	s.fallbackPrices["kimi-k2.5"] = &ModelPricing{
-		InputPricePerToken:     0.60e-6, // $0.60 per MTok
-		OutputPricePerToken:    3e-6,    // $3.00 per MTok
-		CacheReadPricePerToken: 0.098e-6,
-		SupportsCacheBreakdown: false,
-	}
+	// K2.5/K2.6 official prices live only in tk_pricing_overlay.json. The exact
+	// degraded path and compatible aliases below resolve those live overlay rows,
+	// so a pricing hot-push cannot drift from a second Go numeric table.
 	// TK: ¥→USD 统一用 TokenKey 口径 CNY/USD=6.7（与 tk_pricing_overlay.json 一致），
 	// 不沿用上游的 ÷7.14。
 	s.fallbackPrices["kimi-k2-thinking"] = &ModelPricing{
@@ -658,13 +555,13 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	// DeepSeek V4 系列：仅匹配已知 V4 Pro/Flash 与官方兼容别名
 	// （deepseek-chat / deepseek-reasoner → V4 Flash），未知 deepseek-* 型号不回退，避免误计价。
 	if strings.Contains(modelLower, "deepseek-v4-flash") {
-		return s.fallbackPrices["deepseek-v4-flash"]
+		return tkOverlayModelPricing("deepseek-v4-flash")
 	}
 	if strings.Contains(modelLower, "deepseek-v4-pro") {
-		return s.fallbackPrices["deepseek-v4-pro"]
+		return tkOverlayModelPricing("deepseek-v4-pro")
 	}
 	if strings.Contains(modelLower, "deepseek-chat") || strings.Contains(modelLower, "deepseek-reasoner") {
-		return s.fallbackPrices["deepseek-v4-flash"]
+		return tkOverlayModelPricing("deepseek-v4-flash")
 	}
 
 	// ---- 国产 LLM 兜底匹配 ----
@@ -674,33 +571,33 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	// 智谱 GLM：定价源只用 BigModel 官方 pricing 页；可服务路径仍是 Qwen/DashScope 池。
 	// 匹配顺序：先判别最高 tier，再依次降级。
 	if canonical := normalizeGLMVolcengineDatedModelID(modelLower); canonical != "" {
-		if pricing := s.fallbackPrices[canonical]; pricing != nil {
+		if pricing := tkOverlayModelPricing(canonical); pricing != nil {
 			return pricing
 		}
 	}
 	if strings.Contains(modelLower, "glm-5.2") {
-		return s.fallbackPrices["glm-5.2"]
+		return tkOverlayModelPricing("glm-5.2")
 	}
 	if strings.Contains(modelLower, "glm-5.1") {
-		return s.fallbackPrices["glm-5.1"]
+		return tkOverlayModelPricing("glm-5.1")
 	}
 	if strings.Contains(modelLower, "glm-5-turbo") || strings.Contains(modelLower, "glm-5turbo") {
-		return s.fallbackPrices["glm-5-turbo"]
+		return tkOverlayModelPricing("glm-5-turbo")
 	}
 	if strings.Contains(modelLower, "glm-5") {
-		return s.fallbackPrices["glm-5"]
+		return tkOverlayModelPricing("glm-5")
 	}
 	if strings.Contains(modelLower, "glm-4.7-flashx") {
-		return s.fallbackPrices["glm-4.7-flashx"]
+		return tkOverlayModelPricing("glm-4.7-flashx")
 	}
 	if strings.Contains(modelLower, "glm-4.7-flash") {
 		return s.fallbackPrices["glm-4.7-flash"]
 	}
 	if strings.Contains(modelLower, "glm-4.7") {
-		return s.fallbackPrices["glm-4.7"]
+		return tkOverlayModelPricing("glm-4.7")
 	}
 	if strings.Contains(modelLower, "glm-4.6") {
-		return s.fallbackPrices["glm-4.6"]
+		return tkOverlayModelPricing("glm-4.6")
 	}
 	if strings.Contains(modelLower, "glm-4.5-flash") {
 		return s.fallbackPrices["glm-4.5-flash"]
@@ -710,22 +607,22 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 		return nil
 	}
 	if strings.Contains(modelLower, "glm-4.5-air") || strings.Contains(modelLower, "glm-4.5air") {
-		return s.fallbackPrices["glm-4.5-air"]
+		return tkOverlayModelPricing("glm-4.5-air")
 	}
 	if strings.Contains(modelLower, "glm-4.5") {
-		return s.fallbackPrices["glm-4.5"]
+		return tkOverlayModelPricing("glm-4.5")
 	}
 
 	// 月之暗面 Kimi（kimi-k2.6 / kimi-for-coding / kimi-k2.5 / kimi-k2-thinking / kimi-k2）
 	// K2-0905 / K2-0711 官方未保留定价，不进入 fallback。
 	if strings.Contains(modelLower, "kimi-for-coding") {
-		return s.fallbackPrices["kimi-for-coding"]
+		return tkOverlayModelPricing("kimi-k2.6")
 	}
 	if strings.Contains(modelLower, "kimi-k2.6") || strings.Contains(modelLower, "kimi-k2-6") {
-		return s.fallbackPrices["kimi-k2.6"]
+		return tkOverlayModelPricing("kimi-k2.6")
 	}
 	if strings.Contains(modelLower, "kimi-k2.5") || strings.Contains(modelLower, "kimi-k2-5") {
-		return s.fallbackPrices["kimi-k2.5"]
+		return tkOverlayModelPricing("kimi-k2.5")
 	}
 	if strings.Contains(modelLower, "kimi-k2-thinking") || strings.Contains(modelLower, "kimi-k2-thinking-") {
 		return s.fallbackPrices["kimi-k2-thinking"]
@@ -817,6 +714,37 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	return nil
 }
 
+func tkModelPricingFromLiteLLM(p *LiteLLMModelPricing) *ModelPricing {
+	if p == nil || p.TokenPricingAbsent || tkIsEffectivelyUnpriced(p) {
+		return nil
+	}
+	price5m := p.CacheCreationInputTokenCost
+	price1h := p.CacheCreationInputTokenCostAbove1hr
+	return &ModelPricing{
+		InputPricePerToken:                 p.InputCostPerToken,
+		InputPricePerTokenPriority:         p.InputCostPerTokenPriority,
+		OutputPricePerToken:                p.OutputCostPerToken,
+		OutputPricePerTokenPriority:        p.OutputCostPerTokenPriority,
+		ThinkingOutputPricePerToken:        p.ThinkingOutputCostPerToken,
+		CacheCreationPricePerToken:         p.CacheCreationInputTokenCost,
+		CacheCreationPricePerTokenPriority: p.CacheCreationInputTokenCostPriority,
+		CacheReadPricePerToken:             p.CacheReadInputTokenCost,
+		CacheReadPricePerTokenPriority:     p.CacheReadInputTokenCostPriority,
+		CacheCreation5mPrice:               price5m,
+		CacheCreation1hPrice:               price1h,
+		SupportsCacheBreakdown:             price1h > 0 && price1h > price5m,
+		LongContextInputThreshold:          p.LongContextInputTokenThreshold,
+		LongContextInputMultiplier:         p.LongContextInputCostMultiplier,
+		LongContextOutputMultiplier:        p.LongContextOutputCostMultiplier,
+		ImageOutputPricePerToken:           p.OutputCostPerImageToken,
+		Intervals:                          p.Intervals,
+	}
+}
+
+func tkOverlayModelPricing(model string) *ModelPricing {
+	return tkModelPricingFromLiteLLM(loadTKPricingOverlay()[strings.ToLower(strings.TrimSpace(model))])
+}
+
 // IsServedViaFamilyFloor reports whether `model` bills via a Go FAMILY-FLOOR fallback rather than a
 // real price (litellm mirror / overlay). True = the real price source has no (effective) entry for
 // the model BUT getFallbackPricing supplies a family floor — i.e. the request is being served at an
@@ -854,34 +782,12 @@ func (s *BillingService) GetModelPricing(model string) (*ModelPricing, error) {
 			litellmPricing = nil
 		}
 		if litellmPricing != nil && !tkIsEffectivelyUnpriced(litellmPricing) {
-			// 启用 5m/1h 分类计费的条件：
-			// 1. 存在 1h 价格
-			// 2. 1h 价格 > 5m 价格（防止 LiteLLM 数据错误导致少收费）
-			price5m := litellmPricing.CacheCreationInputTokenCost
-			price1h := litellmPricing.CacheCreationInputTokenCostAbove1hr
-			enableBreakdown := price1h > 0 && price1h > price5m
-			return s.applyModelSpecificPricingPolicy(model, &ModelPricing{
-				InputPricePerToken:             litellmPricing.InputCostPerToken,
-				InputPricePerTokenPriority:     litellmPricing.InputCostPerTokenPriority,
-				OutputPricePerToken:            litellmPricing.OutputCostPerToken,
-				OutputPricePerTokenPriority:    litellmPricing.OutputCostPerTokenPriority,
-				ThinkingOutputPricePerToken:    litellmPricing.ThinkingOutputCostPerToken,
-				CacheCreationPricePerToken:     litellmPricing.CacheCreationInputTokenCost,
-				CacheReadPricePerToken:         litellmPricing.CacheReadInputTokenCost,
-				CacheReadPricePerTokenPriority: litellmPricing.CacheReadInputTokenCostPriority,
-				CacheCreation5mPrice:           price5m,
-				CacheCreation1hPrice:           price1h,
-				SupportsCacheBreakdown:         enableBreakdown,
-				LongContextInputThreshold:      litellmPricing.LongContextInputTokenThreshold,
-				LongContextInputMultiplier:     litellmPricing.LongContextInputCostMultiplier,
-				LongContextOutputMultiplier:    litellmPricing.LongContextOutputCostMultiplier,
-				ImageOutputPricePerToken:       litellmPricing.OutputCostPerImageToken,
-				Intervals:                      litellmPricing.Intervals,
-			}), nil
+			return s.applyModelSpecificPricingPolicy(model, tkModelPricingFromLiteLLM(litellmPricing)), nil
 		}
 	}
 
-	// 2. 使用硬编码回退价格
+	// 2. 使用兼容别名 / 家族回退价格。已在 overlay 定价的兼容分支只
+	// 保存 alias → price_key 关系，不在 Go 中重复价格数值。
 	fallback := s.getFallbackPricing(model)
 	if fallback != nil {
 		// 按模型名去重:每个模型每进程最多打一条 warn,避免热路径每请求刷屏（issue #3394）。

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -34,7 +34,7 @@ func newTestBillingService() *BillingService {
 }
 
 func glmCNYPerMTokWithTax(cny float64) float64 {
-	return tkCNYPerMTokToUSDPerToken(cny) * tkOfficialListBaseTaxMultiplier
+	return tkCNYPerMTokToUSDPerToken(cny) * tkOfficialListBaseTaxMultiplier()
 }
 
 func glmCNYPerMTokPreTax(cny float64) float64 {
@@ -149,14 +149,15 @@ func TestGetModelPricing_FallbackWarnLoggedOncePerModel(t *testing.T) {
 	svc := newTestBillingService()
 	buf := captureStdLog(t)
 
-	// glm-5.2 不在 LiteLLM,经 strings.Contains 命中 glm-5 兜底价 → 触发 fallback warn。
+	// 使用没有精确定价的 Claude 变体，确保它走家族 floor 并触发 fallback warn。
+	const model = "claude-unknown-warning-a"
 	for i := 0; i < 5; i++ {
-		pricing, err := svc.GetModelPricing("glm-5.2")
+		pricing, err := svc.GetModelPricing(model)
 		require.NoError(t, err)
 		require.NotNil(t, pricing)
 	}
 
-	got := strings.Count(buf.String(), "Using fallback pricing for model: glm-5.2")
+	got := strings.Count(buf.String(), "Using fallback pricing for model: "+model)
 	require.Equal(t, 1, got, "同一模型的 fallback warn 应只打一条,实际日志:\n%s", buf.String())
 }
 
@@ -166,18 +167,19 @@ func TestGetModelPricing_FallbackWarnPerModelNotGlobal(t *testing.T) {
 	buf := captureStdLog(t)
 
 	for i := 0; i < 3; i++ {
-		_, _ = svc.GetModelPricing("glm-5.2")
-		_, _ = svc.GetModelPricing("GLM-5.2") // 与上一行同模型(ToLower 后),去重后不再打
-		_, _ = svc.GetModelPricing("glm-4.6")
+		_, _ = svc.GetModelPricing("claude-unknown-warning-a")
+		_, _ = svc.GetModelPricing("CLAUDE-UNKNOWN-WARNING-A") // ToLower 后视为同一条目
+		_, _ = svc.GetModelPricing("claude-unknown-warning-b")
 	}
 
 	out := buf.String()
-	require.Equal(t, 1, strings.Count(out, "model: glm-5.2"), out)
-	require.Equal(t, 1, strings.Count(out, "model: glm-4.6"), out)
-	require.Equal(t, 0, strings.Count(out, "model: GLM-5.2"), out) // 大写经 ToLower 归一,不应单独成行
+	require.Equal(t, 1, strings.Count(out, "model: claude-unknown-warning-a"), out)
+	require.Equal(t, 1, strings.Count(out, "model: claude-unknown-warning-b"), out)
+	require.Equal(t, 0, strings.Count(out, "model: CLAUDE-UNKNOWN-WARNING-A"), out)
 }
 
-// 回归:glm-5.2 命中独立兜底价(先于 glm-5 前缀匹配),防止 family 顺序回归。
+// 回归：即使 PricingService 不可用，glm-5.2 仍从 overlay 精确价恢复，
+// 不会落到更宽的 glm-5 兼容分支。
 func TestGetModelPricing_GLM52UsesBigModelPriceWithBaseTax(t *testing.T) {
 	svc := newTestBillingService()
 
@@ -645,23 +647,23 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 		{
 			name:              "kimi k2.6 flagship",
 			model:             "kimi-k2.6",
-			expectedInput:     0.95e-6,
-			expectedOutput:    floatPtr(4e-6),
-			expectedCacheRead: floatPtr(0.15e-6),
+			expectedInput:     tkCNYPerMTokToUSDPerToken(6.5),
+			expectedOutput:    floatPtr(tkCNYPerMTokToUSDPerToken(27)),
+			expectedCacheRead: floatPtr(tkCNYPerMTokToUSDPerToken(1.1)),
 		},
 		{
 			name:              "kimi for coding explicit alias",
 			model:             "kimi-for-coding",
-			expectedInput:     0.95e-6,
-			expectedOutput:    floatPtr(4e-6),
-			expectedCacheRead: floatPtr(0.15e-6),
+			expectedInput:     tkCNYPerMTokToUSDPerToken(6.5),
+			expectedOutput:    floatPtr(tkCNYPerMTokToUSDPerToken(27)),
+			expectedCacheRead: floatPtr(tkCNYPerMTokToUSDPerToken(1.1)),
 		},
 		{
 			name:              "kimi k2.5",
 			model:             "kimi-k2.5",
-			expectedInput:     0.60e-6,
-			expectedOutput:    floatPtr(3e-6),
-			expectedCacheRead: floatPtr(0.098e-6),
+			expectedInput:     tkCNYPerMTokToUSDPerToken(4),
+			expectedOutput:    floatPtr(tkCNYPerMTokToUSDPerToken(21)),
+			expectedCacheRead: floatPtr(tkCNYPerMTokToUSDPerToken(0.7)),
 		},
 		{
 			name:              "kimi k2-thinking",
@@ -681,9 +683,9 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 		{
 			name:              "kimi k2.6 vs k2 ordering",
 			model:             "kimi-k2.6",
-			expectedInput:     0.95e-6, // = k2.6 不是 k2 的人民币换算价
-			expectedOutput:    floatPtr(4e-6),
-			expectedCacheRead: floatPtr(0.15e-6),
+			expectedInput:     tkCNYPerMTokToUSDPerToken(6.5), // = k2.6 不是 k2 的旧 ¥4 档
+			expectedOutput:    floatPtr(tkCNYPerMTokToUSDPerToken(27)),
+			expectedCacheRead: floatPtr(tkCNYPerMTokToUSDPerToken(1.1)),
 		},
 		{
 			name:              "kimi k2 thinking hyphenated variant",
@@ -802,8 +804,8 @@ func TestGetModelPricing_DoubaoEmbeddingVisionImageInputRate(t *testing.T) {
 		pricing, err := svc.GetModelPricing(model)
 		require.NoError(t, err, "model %s should resolve fallback pricing", model)
 		require.NotNil(t, pricing)
-		require.InDelta(t, tkCNYPerMTokToUSDPerToken(0.7)*tkOfficialListBaseTaxMultiplier, pricing.InputPricePerToken, 1e-12, "text input rate for %s", model)
-		require.InDelta(t, tkCNYPerMTokToUSDPerToken(1.8)*tkOfficialListBaseTaxMultiplier, pricing.ImageInputPricePerToken, 1e-12, "image input rate for %s", model)
+		require.InDelta(t, tkCNYPerMTokToUSDPerToken(0.7)*tkOfficialListBaseTaxMultiplier(), pricing.InputPricePerToken, 1e-12, "text input rate for %s", model)
+		require.InDelta(t, tkCNYPerMTokToUSDPerToken(1.8)*tkOfficialListBaseTaxMultiplier(), pricing.ImageInputPricePerToken, 1e-12, "image input rate for %s", model)
 		require.Zero(t, pricing.OutputPricePerToken, "embedding has no output cost for %s", model)
 	}
 }
@@ -817,8 +819,8 @@ func TestCalculateCost_DoubaoEmbeddingVisionDifferentialInput(t *testing.T) {
 	mixed := UsageTokens{InputTokens: 1340, ImageInputTokens: 28}
 	cost, err := svc.CalculateCost("doubao-embedding-vision", mixed, 1.0)
 	require.NoError(t, err)
-	textRate := tkCNYPerMTokToUSDPerToken(0.7) * tkOfficialListBaseTaxMultiplier
-	imageRate := tkCNYPerMTokToUSDPerToken(1.8) * tkOfficialListBaseTaxMultiplier
+	textRate := tkCNYPerMTokToUSDPerToken(0.7) * tkOfficialListBaseTaxMultiplier()
+	imageRate := tkCNYPerMTokToUSDPerToken(1.8) * tkOfficialListBaseTaxMultiplier()
 	wantMixed := float64(1312)*textRate + float64(28)*imageRate
 	require.InDelta(t, wantMixed, cost.InputCost, 1e-15)
 	require.InDelta(t, wantMixed, cost.TotalCost, 1e-15)

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -752,9 +752,9 @@ func TestBuildForUser_ChannelGLM52UsesCatalogOfficialPrice(t *testing.T) {
 			mkPublicCatalogModel(
 				"glm-5.2",
 				"zhipu",
-				tkCNYPerMTokToUSDPerToken(8)*tkOfficialListBaseTaxMultiplier*1000,
-				tkCNYPerMTokToUSDPerToken(28)*tkOfficialListBaseTaxMultiplier*1000,
-				tkCNYPerMTokToUSDPerToken(2)*tkOfficialListBaseTaxMultiplier*1000,
+				tkCNYPerMTokToUSDPerToken(8)*tkOfficialListBaseTaxMultiplier()*1000,
+				tkCNYPerMTokToUSDPerToken(28)*tkOfficialListBaseTaxMultiplier()*1000,
+				tkCNYPerMTokToUSDPerToken(2)*tkOfficialListBaseTaxMultiplier()*1000,
 			),
 		},
 	}
@@ -773,9 +773,9 @@ func TestBuildForUser_ChannelGLM52UsesCatalogOfficialPrice(t *testing.T) {
 	require.NotNil(t, row.YourPrice.InputPer1K)
 	require.NotNil(t, row.YourPrice.OutputPer1K)
 	require.NotNil(t, row.YourPrice.CacheReadPer1K)
-	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(8)*tkOfficialListBaseTaxMultiplier*1000, *row.YourPrice.InputPer1K, 1e-12)
-	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(28)*tkOfficialListBaseTaxMultiplier*1000, *row.YourPrice.OutputPer1K, 1e-12)
-	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(2)*tkOfficialListBaseTaxMultiplier*1000, *row.YourPrice.CacheReadPer1K, 1e-12)
+	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(8)*tkOfficialListBaseTaxMultiplier()*1000, *row.YourPrice.InputPer1K, 1e-12)
+	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(28)*tkOfficialListBaseTaxMultiplier()*1000, *row.YourPrice.OutputPer1K, 1e-12)
+	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(2)*tkOfficialListBaseTaxMultiplier()*1000, *row.YourPrice.CacheReadPer1K, 1e-12)
 }
 
 // TestBuildForUser_AuthorizedGroups_CrossGroup pins the "授权分组" column: each

--- a/backend/internal/service/model_pricing_resolver_tk_overlay_intervals_test.go
+++ b/backend/internal/service/model_pricing_resolver_tk_overlay_intervals_test.go
@@ -81,7 +81,7 @@ func TestOverlayIntervalPricing_CoderPlusWholeRequestTier(t *testing.T) {
 	require.Len(t, resolved.Intervals, 4, "overlay intervals must populate ResolvedPricing.Intervals when no channel")
 	require.Equal(t, PricingSourceLiteLLM, resolved.Source)
 
-	tax := tkOfficialListBaseTaxMultiplier
+	tax := tkOfficialListBaseTaxMultiplier()
 	withTax := func(cny float64) float64 {
 		return tax * tkCNYPerMTokToUSDPerToken(cny)
 	}
@@ -114,7 +114,7 @@ func TestOverlayIntervalPricing_PlusFlashTwoTier(t *testing.T) {
 
 	plus := r.Resolve(context.Background(), PricingInput{Model: "qwen3.7-plus"})
 	require.Len(t, plus.Intervals, 2)
-	tax := tkOfficialListBaseTaxMultiplier
+	tax := tkOfficialListBaseTaxMultiplier()
 	withTax := func(cny float64) float64 {
 		return tax * tkCNYPerMTokToUSDPerToken(cny)
 	}
@@ -134,7 +134,7 @@ func TestOverlayIntervalPricing_GLMUsesBigModelTiersAndBaseTax(t *testing.T) {
 	require.NotNil(t, resolved.BasePricing)
 	require.Len(t, resolved.Intervals, 2)
 
-	tax := tkOfficialListBaseTaxMultiplier
+	tax := tkOfficialListBaseTaxMultiplier()
 	withTax := func(cny float64) float64 {
 		return tax * tkCNYPerMTokToUSDPerToken(cny)
 	}
@@ -153,7 +153,7 @@ func TestOverlayIntervals_FlatModelUnaffected(t *testing.T) {
 	resolved := r.Resolve(context.Background(), PricingInput{Model: "qwen3.7-max"})
 	require.Empty(t, resolved.Intervals, "flat overlay model must not gain intervals")
 	require.NotNil(t, resolved.BasePricing)
-	tax := tkOfficialListBaseTaxMultiplier
+	tax := tkOfficialListBaseTaxMultiplier()
 	withTax := func(cny float64) float64 {
 		return tax * tkCNYPerMTokToUSDPerToken(cny)
 	}

--- a/backend/internal/service/pricing_catalog_tk_test.go
+++ b/backend/internal/service/pricing_catalog_tk_test.go
@@ -179,8 +179,8 @@ func TestPricingCatalogService_AppliesTKOverlayPricing(t *testing.T) {
 	// overlay-only models surface with their overlay price (per-token ×1000 = per-1K).
 	pro, ok := byID["deepseek-v4-pro"]
 	require.True(t, ok, "overlay-only deepseek-v4-pro must surface in catalog")
-	assert.InDelta(t, 0.000435*tkOfficialListBaseTaxMultiplier, pro.Pricing.InputPer1KTokens, 1e-9, "deepseek-v4-pro input = overlay official × base tax")
-	assert.InDelta(t, 0.00087*tkOfficialListBaseTaxMultiplier, pro.Pricing.OutputPer1KTokens, 1e-9, "deepseek-v4-pro output = overlay official × base tax")
+	assert.InDelta(t, 0.000435*tkOfficialListBaseTaxMultiplier(), pro.Pricing.InputPer1KTokens, 1e-9, "deepseek-v4-pro input = overlay official × base tax")
+	assert.InDelta(t, 0.00087*tkOfficialListBaseTaxMultiplier(), pro.Pricing.OutputPer1KTokens, 1e-9, "deepseek-v4-pro output = overlay official × base tax")
 	_, ok = byID["doubao-seed-2-0-pro-260215"]
 	assert.True(t, ok, "doubao overlay model must surface")
 	glm52, ok := byID["glm-5.2"]
@@ -189,9 +189,9 @@ func TestPricingCatalogService_AppliesTKOverlayPricing(t *testing.T) {
 	cnyPer1K := func(cny float64) float64 {
 		return tkCNYPerMTokToUSDPerToken(cny) * 1_000
 	}
-	assert.InDelta(t, cnyPer1K(8)*tkOfficialListBaseTaxMultiplier, glm52.Pricing.InputPer1KTokens, 1e-12)
-	assert.InDelta(t, cnyPer1K(28)*tkOfficialListBaseTaxMultiplier, glm52.Pricing.OutputPer1KTokens, 1e-12)
-	assert.InDelta(t, cnyPer1K(2)*tkOfficialListBaseTaxMultiplier, glm52.Pricing.CacheReadPer1K, 1e-12)
+	assert.InDelta(t, cnyPer1K(8)*tkOfficialListBaseTaxMultiplier(), glm52.Pricing.InputPer1KTokens, 1e-12)
+	assert.InDelta(t, cnyPer1K(28)*tkOfficialListBaseTaxMultiplier(), glm52.Pricing.OutputPer1KTokens, 1e-12)
+	assert.InDelta(t, cnyPer1K(2)*tkOfficialListBaseTaxMultiplier(), glm52.Pricing.CacheReadPer1K, 1e-12)
 
 	veo, ok := byID["veo-3.1-generate-001"]
 	require.True(t, ok, "Veo overlay media row must surface in catalog")
@@ -219,7 +219,7 @@ func TestPricingCatalogService_AppliesTKOverlayPricing(t *testing.T) {
 	// fill-only: a model present in BOTH source and overlay keeps the SOURCE price.
 	flash, ok := byID["deepseek-v4-flash"]
 	require.True(t, ok)
-	assert.InDelta(t, 999.0*tkOfficialListBaseTaxMultiplier, flash.Pricing.InputPer1KTokens, 1e-6,
+	assert.InDelta(t, 999.0*tkOfficialListBaseTaxMultiplier(), flash.Pricing.InputPer1KTokens, 1e-6,
 		"source price wins over overlay (fill-only); base tax applies on top of source")
 }
 
@@ -252,9 +252,9 @@ func TestPricingCatalogService_GLMLitellmMirrorOverriddenByBigModelOverlay(t *te
 	cnyPer1K := func(cny float64) float64 {
 		return tkCNYPerMTokToUSDPerToken(cny) * 1_000
 	}
-	assert.InDelta(t, cnyPer1K(8)*tkOfficialListBaseTaxMultiplier, glm52.Pricing.InputPer1KTokens, 1e-12)
-	assert.InDelta(t, cnyPer1K(28)*tkOfficialListBaseTaxMultiplier, glm52.Pricing.OutputPer1KTokens, 1e-12)
-	assert.InDelta(t, cnyPer1K(2)*tkOfficialListBaseTaxMultiplier, glm52.Pricing.CacheReadPer1K, 1e-12)
+	assert.InDelta(t, cnyPer1K(8)*tkOfficialListBaseTaxMultiplier(), glm52.Pricing.InputPer1KTokens, 1e-12)
+	assert.InDelta(t, cnyPer1K(28)*tkOfficialListBaseTaxMultiplier(), glm52.Pricing.OutputPer1KTokens, 1e-12)
+	assert.InDelta(t, cnyPer1K(2)*tkOfficialListBaseTaxMultiplier(), glm52.Pricing.CacheReadPer1K, 1e-12)
 }
 
 // TestPricingCatalogService_AttachesOverlayTiers pins that input-token interval
@@ -286,8 +286,8 @@ func TestPricingCatalogService_AttachesOverlayTiers(t *testing.T) {
 	assert.Equal(t, 0, pro.Pricing.Tiers[0].MinTokens)
 	require.NotNil(t, pro.Pricing.Tiers[0].MaxTokens)
 	assert.Equal(t, 32000, *pro.Pricing.Tiers[0].MaxTokens)
-	assert.InDelta(t, 0.000477612*tkOfficialListBaseTaxMultiplier, pro.Pricing.Tiers[0].InputPer1KTokens, 1e-9)
-	assert.InDelta(t, 0.002388060*tkOfficialListBaseTaxMultiplier, pro.Pricing.Tiers[0].OutputPer1KTokens, 1e-9)
+	assert.InDelta(t, 0.000477612*tkOfficialListBaseTaxMultiplier(), pro.Pricing.Tiers[0].InputPer1KTokens, 1e-9)
+	assert.InDelta(t, 0.002388060*tkOfficialListBaseTaxMultiplier(), pro.Pricing.Tiers[0].OutputPer1KTokens, 1e-9)
 
 	// top tier is open-ended (MaxTokens nil) and costs more than tier 1.
 	assert.Nil(t, pro.Pricing.Tiers[2].MaxTokens, "top tier must be unbounded")
@@ -351,10 +351,10 @@ func TestPricingCatalogService_ZeroPlaceholderRowGetsOverlayPrice(t *testing.T) 
 
 	pro, ok := byID["deepseek-v4-pro"]
 	require.True(t, ok)
-	assert.InDelta(t, 0.000435*tkOfficialListBaseTaxMultiplier, pro.Pricing.InputPer1KTokens, 1e-9,
+	assert.InDelta(t, 0.000435*tkOfficialListBaseTaxMultiplier(), pro.Pricing.InputPer1KTokens, 1e-9,
 		"zero placeholder row must display the overlay deepseek-v4-pro price with base tax")
-	assert.InDelta(t, 0.00087*tkOfficialListBaseTaxMultiplier, pro.Pricing.OutputPer1KTokens, 1e-9)
-	assert.InDelta(t, 0.000003625*tkOfficialListBaseTaxMultiplier, pro.Pricing.CacheReadPer1K, 1e-12)
+	assert.InDelta(t, 0.00087*tkOfficialListBaseTaxMultiplier(), pro.Pricing.OutputPer1KTokens, 1e-9)
+	assert.InDelta(t, 0.000003625*tkOfficialListBaseTaxMultiplier(), pro.Pricing.CacheReadPer1K, 1e-12)
 	assert.Equal(t, 65536, pro.ContextWindow, "file-source row metadata must be preserved")
 	assert.Equal(t, 8192, pro.MaxOutputTokens)
 

--- a/backend/internal/service/pricing_service_tk_overlay.go
+++ b/backend/internal/service/pricing_service_tk_overlay.go
@@ -180,16 +180,6 @@ func parseTKOverlayDocument(data []byte) (*tkPricingOverlayDocument, error) {
 	return doc, nil
 }
 
-// parseTKOverlayBytes retains the map-only helper used by focused tests and
-// callers that do not need executable policy.
-func parseTKOverlayBytes(data []byte) (map[string]*LiteLLMModelPricing, error) {
-	doc, err := parseTKOverlayDocument(data)
-	if err != nil {
-		return nil, err
-	}
-	return doc.Models, nil
-}
-
 func validateRuntimeBaseTaxCoverage(embedded, runtime tkOfficialListBaseTaxPolicy) error {
 	runtimeProviders := make(map[string]struct{}, len(runtime.Rules))
 	for _, rule := range runtime.Rules {

--- a/backend/internal/service/pricing_service_tk_overlay.go
+++ b/backend/internal/service/pricing_service_tk_overlay.go
@@ -38,8 +38,10 @@ package service
 // provider-aware sync.
 
 import (
+	"bytes"
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -49,30 +51,56 @@ import (
 //go:embed tk_pricing_overlay.json
 var tkPricingOverlayRaw []byte
 
-// tkOverlayEffective is the live overlay map = embedded ∪ runtime-settings
-// (runtime wins on key conflict), rebuilt by rebuildTKOverlayUnion. The embedded
-// JSON is the FLOOR (offline self-consistent); the runtime settings blob
-// (SettingKeyTKPricingOverlayRuntime) is the hot override that lets a model be
-// priced without a release. Guarded by tkOverlayMu so the hot swap is safe under
-// concurrent loadTKPricingOverlay reads. See pricing_service_tk_overlay_runtime.go.
+type tkPricingOverlayExecutableConfig struct {
+	OfficialListBaseTax *tkOfficialListBaseTaxPolicy `json:"official_list_base_tax"`
+}
+
+type tkPricingOverlaySnapshot struct {
+	Models  map[string]*LiteLLMModelPricing
+	BaseTax tkOfficialListBaseTaxPolicy
+}
+
+type tkPricingOverlayDocument struct {
+	Models  map[string]*LiteLLMModelPricing
+	BaseTax *tkOfficialListBaseTaxPolicy
+}
+
+// tkOverlayEffective is the live immutable snapshot = embedded ∪ runtime-settings
+// (runtime wins on model conflicts and may replace executable policy). Model prices
+// and tax policy swap under one lock so billing, /pricing, and fallback classification
+// never read policy from a different runtime generation.
 var (
 	tkOverlayMu        sync.RWMutex
-	tkOverlayEffective map[string]*LiteLLMModelPricing
+	tkOverlayEffective *tkPricingOverlaySnapshot
 )
 
-// parseTKOverlayBytes parses an overlay JSON object (the embedded file OR the
-// runtime settings blob — identical shape) into the pricing map. It deliberately
-// does NOT call parsePricingData (that would recurse, since applyTKPricingOverlay
-// is invoked from inside parsePricingData) — it parses the small fixed file
-// directly. Keys starting with "_" (e.g. "_meta") are provenance, not pricing,
-// and are skipped. Returns an error only when the top-level JSON is unparseable
-// (a single malformed entry is skipped, not fatal).
-func parseTKOverlayBytes(data []byte) (map[string]*LiteLLMModelPricing, error) {
+// parseTKOverlayDocument parses an overlay JSON object (the embedded file OR the
+// runtime settings blob) into model prices plus optional executable configuration.
+// Runtime blobs may omit _config and inherit the embedded policy; when present,
+// _config is strict and invalid policy rejects the whole runtime swap.
+func parseTKOverlayDocument(data []byte) (*tkPricingOverlayDocument, error) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, err
 	}
-	out := make(map[string]*LiteLLMModelPricing, len(raw))
+	doc := &tkPricingOverlayDocument{Models: make(map[string]*LiteLLMModelPricing, len(raw))}
+	if rawConfig, ok := raw["_config"]; ok {
+		var config tkPricingOverlayExecutableConfig
+		decoder := json.NewDecoder(bytes.NewReader(rawConfig))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&config); err != nil {
+			return nil, fmt.Errorf("parse overlay _config: %w", err)
+		}
+		if config.OfficialListBaseTax == nil {
+			return nil, fmt.Errorf("overlay _config.official_list_base_tax is required")
+		}
+		if err := config.OfficialListBaseTax.validate(); err != nil {
+			return nil, err
+		}
+		policy := *config.OfficialListBaseTax
+		doc.BaseTax = &policy
+	}
+
 	for name, rawEntry := range raw {
 		if strings.HasPrefix(name, "_") {
 			continue
@@ -85,6 +113,8 @@ func parseTKOverlayBytes(data []byte) (map[string]*LiteLLMModelPricing, error) {
 			LiteLLMProvider:       e.LiteLLMProvider,
 			Mode:                  e.Mode,
 			SupportsPromptCaching: e.SupportsPromptCaching,
+			SupportsServiceTier:   e.SupportsServiceTier,
+			TokenPricingAbsent:    e.InputCostPerToken == nil && e.OutputCostPerToken == nil,
 		}
 		if e.OutputCostPerImage != nil {
 			p.OutputCostPerImage = *e.OutputCostPerImage
@@ -98,8 +128,14 @@ func parseTKOverlayBytes(data []byte) (map[string]*LiteLLMModelPricing, error) {
 		if e.InputCostPerToken != nil {
 			p.InputCostPerToken = *e.InputCostPerToken
 		}
+		if e.InputCostPerTokenPriority != nil {
+			p.InputCostPerTokenPriority = *e.InputCostPerTokenPriority
+		}
 		if e.OutputCostPerToken != nil {
 			p.OutputCostPerToken = *e.OutputCostPerToken
+		}
+		if e.OutputCostPerTokenPriority != nil {
+			p.OutputCostPerTokenPriority = *e.OutputCostPerTokenPriority
 		}
 		if e.ThinkingOutputCostPerToken != nil {
 			p.ThinkingOutputCostPerToken = *e.ThinkingOutputCostPerToken
@@ -107,11 +143,26 @@ func parseTKOverlayBytes(data []byte) (map[string]*LiteLLMModelPricing, error) {
 		if e.CacheCreationInputTokenCost != nil {
 			p.CacheCreationInputTokenCost = *e.CacheCreationInputTokenCost
 		}
+		if e.CacheCreationInputTokenCostPriority != nil {
+			p.CacheCreationInputTokenCostPriority = *e.CacheCreationInputTokenCostPriority
+		}
 		if e.CacheCreationInputTokenCostAbove1hr != nil {
 			p.CacheCreationInputTokenCostAbove1hr = *e.CacheCreationInputTokenCostAbove1hr
 		}
 		if e.CacheReadInputTokenCost != nil {
 			p.CacheReadInputTokenCost = *e.CacheReadInputTokenCost
+		}
+		if e.CacheReadInputTokenCostPriority != nil {
+			p.CacheReadInputTokenCostPriority = *e.CacheReadInputTokenCostPriority
+		}
+		if e.LongContextInputTokenThreshold != nil {
+			p.LongContextInputTokenThreshold = *e.LongContextInputTokenThreshold
+		}
+		if e.LongContextInputCostMultiplier != nil {
+			p.LongContextInputCostMultiplier = *e.LongContextInputCostMultiplier
+		}
+		if e.LongContextOutputCostMultiplier != nil {
+			p.LongContextOutputCostMultiplier = *e.LongContextOutputCostMultiplier
 		}
 		// TK: input-token interval (tiered) pricing. LiteLLMRawEntry has no
 		// "intervals" field (it is TK-overlay-only), so parse the raw entry a
@@ -124,9 +175,62 @@ func parseTKOverlayBytes(data []byte) (map[string]*LiteLLMModelPricing, error) {
 		if err := json.Unmarshal(rawEntry, &ext); err == nil && len(ext.Intervals) > 0 {
 			p.Intervals = tkBuildOverlayIntervals(ext.Intervals)
 		}
-		out[name] = p
+		doc.Models[name] = p
 	}
-	return out, nil
+	return doc, nil
+}
+
+// parseTKOverlayBytes retains the map-only helper used by focused tests and
+// callers that do not need executable policy.
+func parseTKOverlayBytes(data []byte) (map[string]*LiteLLMModelPricing, error) {
+	doc, err := parseTKOverlayDocument(data)
+	if err != nil {
+		return nil, err
+	}
+	return doc.Models, nil
+}
+
+func validateRuntimeBaseTaxCoverage(embedded, runtime tkOfficialListBaseTaxPolicy) error {
+	runtimeProviders := make(map[string]struct{}, len(runtime.Rules))
+	for _, rule := range runtime.Rules {
+		runtimeProviders[rule.Provider] = struct{}{}
+	}
+	var missing []string
+	for _, rule := range embedded.Rules {
+		if _, ok := runtimeProviders[rule.Provider]; !ok {
+			missing = append(missing, rule.Provider)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("runtime official_list_base_tax drops embedded providers: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func buildTKPricingOverlaySnapshot(runtimeBytes []byte) (*tkPricingOverlaySnapshot, error) {
+	base, err := parseTKOverlayDocument(tkPricingOverlayRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parse embedded TK overlay: %w", err)
+	}
+	if base.BaseTax == nil {
+		return nil, fmt.Errorf("embedded TK overlay missing _config.official_list_base_tax")
+	}
+	if len(runtimeBytes) > 0 {
+		runtime, err := parseTKOverlayDocument(runtimeBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse runtime TK overlay: %w", err)
+		}
+		for k, v := range runtime.Models {
+			base.Models[k] = v
+		}
+		if runtime.BaseTax != nil {
+			if err := validateRuntimeBaseTaxCoverage(*base.BaseTax, *runtime.BaseTax); err != nil {
+				return nil, err
+			}
+			base.BaseTax = runtime.BaseTax
+		}
+	}
+	return &tkPricingOverlaySnapshot{Models: base.Models, BaseTax: *base.BaseTax}, nil
 }
 
 // rebuildTKOverlayUnion recomputes the effective overlay = embedded ∪ runtime
@@ -136,44 +240,57 @@ func parseTKOverlayBytes(data []byte) (map[string]*LiteLLMModelPricing, error) {
 //   - The embedded JSON is parsed fresh each call as the FLOOR. If the embedded
 //     itself fails to parse (should be impossible — it is gated by
 //     pricing-overlay.py), the previous effective map is KEPT, not blanked.
-//   - A nil / empty / UNPARSEABLE runtimeBytes yields embedded-only; a corrupt
-//     runtime blob can never drop the effective map below the embedded floor.
+//   - A nil / empty runtimeBytes yields embedded-only. An invalid runtime keeps
+//     the previous snapshot; on first load it still establishes the embedded
+//     floor, so a corrupt setting can never leave the effective map empty.
 func rebuildTKOverlayUnion(runtimeBytes []byte) {
-	base, err := parseTKOverlayBytes(tkPricingOverlayRaw)
+	snapshot, err := buildTKPricingOverlaySnapshot(runtimeBytes)
 	if err != nil {
-		// Embedded must always parse; if it somehow does not, keep whatever the
-		// effective map already held rather than blanking prices.
-		logger.LegacyPrintf("service.pricing", "[Pricing] embedded TK overlay parse failed (keeping current effective map): %v", err)
-		return
-	}
-	if len(runtimeBytes) > 0 {
-		if rt, err := parseTKOverlayBytes(runtimeBytes); err != nil {
-			logger.LegacyPrintf("service.pricing", "[Pricing] runtime TK overlay parse failed (using embedded floor only): %v", err)
-		} else {
-			for k, v := range rt {
-				base[k] = v // runtime wins on conflict
+		tkOverlayMu.RLock()
+		hasCurrent := tkOverlayEffective != nil
+		tkOverlayMu.RUnlock()
+		if !hasCurrent {
+			floor, floorErr := buildTKPricingOverlaySnapshot(nil)
+			if floorErr == nil {
+				tkOverlayMu.Lock()
+				if tkOverlayEffective == nil {
+					tkOverlayEffective = floor
+				}
+				tkOverlayMu.Unlock()
 			}
 		}
+		// Invalid runtime keeps the previous immutable snapshot. If this is the
+		// first load, the embedded-only build above establishes the pricing floor.
+		logger.LegacyPrintf("service.pricing", "[Pricing] TK overlay snapshot build failed (keeping current effective map): %v", err)
+		return
 	}
 	tkOverlayMu.Lock()
-	tkOverlayEffective = base
+	tkOverlayEffective = snapshot
 	tkOverlayMu.Unlock()
+}
+
+func loadTKPricingOverlaySnapshot() *tkPricingOverlaySnapshot {
+	tkOverlayMu.RLock()
+	snapshot := tkOverlayEffective
+	tkOverlayMu.RUnlock()
+	if snapshot != nil {
+		return snapshot
+	}
+	rebuildTKOverlayUnion(nil)
+	tkOverlayMu.RLock()
+	defer tkOverlayMu.RUnlock()
+	return tkOverlayEffective
 }
 
 // loadTKPricingOverlay returns the live effective overlay (embedded ∪ runtime).
 // First call before any explicit rebuild lazily builds the embedded-only floor,
 // so a process that never loads a runtime blob behaves exactly as before.
 func loadTKPricingOverlay() map[string]*LiteLLMModelPricing {
-	tkOverlayMu.RLock()
-	m := tkOverlayEffective
-	tkOverlayMu.RUnlock()
-	if m != nil {
-		return m
+	snapshot := loadTKPricingOverlaySnapshot()
+	if snapshot == nil {
+		return nil
 	}
-	rebuildTKOverlayUnion(nil)
-	tkOverlayMu.RLock()
-	defer tkOverlayMu.RUnlock()
-	return tkOverlayEffective
+	return snapshot.Models
 }
 
 // tkOverlayOverridesLitellmSource reports whether a TK overlay row is the

--- a/backend/internal/service/pricing_service_tk_overlay_runtime.go
+++ b/backend/internal/service/pricing_service_tk_overlay_runtime.go
@@ -74,6 +74,9 @@ func (s *PricingService) reloadTKOverlayRuntime(ctx context.Context) (bool, erro
 	if s == nil {
 		return false, nil
 	}
+	// Establish the embedded floor before consulting runtime state. A corrupt
+	// setting on the process's first reload must not leave the global snapshot nil.
+	loadTKPricingOverlaySnapshot()
 	s.overlayMu.Lock()
 	getter := s.overlayRuntimeGetter
 	prevHash := s.overlayRuntimeHash
@@ -97,7 +100,7 @@ func (s *PricingService) reloadTKOverlayRuntime(ctx context.Context) (bool, erro
 
 	// Validate before swapping: a corrupt blob must not disturb the live map.
 	if blob != "" {
-		if _, err := parseTKOverlayBytes([]byte(blob)); err != nil {
+		if _, err := buildTKPricingOverlaySnapshot([]byte(blob)); err != nil {
 			// Keep prevHash so a later corrected blob still triggers a reload.
 			return false, err
 		}

--- a/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
@@ -282,15 +282,14 @@ func TestCatalogInvalidateCache_PicksUpHotOverlay(t *testing.T) {
 // guard against accidental JSON shape drift in the embedded overlay used as floor.
 func TestEmbeddedOverlayParsesAsFloor(t *testing.T) {
 	resetOverlayUnion(t)
-	m, err := parseTKOverlayBytes(tkPricingOverlayRaw)
+	doc, err := parseTKOverlayDocument(tkPricingOverlayRaw)
 	if err != nil {
 		t.Fatalf("embedded overlay must parse: %v", err)
 	}
+	m := doc.Models
 	if len(m) == 0 {
 		t.Fatal("embedded overlay parsed to zero entries")
 	}
-	doc, err := parseTKOverlayDocument(tkPricingOverlayRaw)
-	require.NoError(t, err)
 	require.NotNil(t, doc.BaseTax)
 	require.NoError(t, doc.BaseTax.validate())
 	// _meta / provenance keys are skipped.

--- a/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
 )
 
 // embeddedQwen8bInput is the embedded floor price for qwen3-8b — the assertion
@@ -19,6 +20,7 @@ const embeddedQwen8bInput = 7.462686567164179e-08
 func resetOverlayUnion(t *testing.T) {
 	t.Helper()
 	rebuildTKOverlayUnion(nil) // embedded-only floor
+	t.Cleanup(func() { rebuildTKOverlayUnion(nil) })
 }
 
 func TestRebuildTKOverlayUnion_RuntimeWins(t *testing.T) {
@@ -57,6 +59,18 @@ func TestRebuildTKOverlayUnion_CorruptRuntimeKeepsEmbeddedFloor(t *testing.T) {
 	}
 }
 
+func TestRebuildTKOverlayUnion_CorruptFirstLoadEstablishesEmbeddedFloor(t *testing.T) {
+	tkOverlayMu.Lock()
+	tkOverlayEffective = nil
+	tkOverlayMu.Unlock()
+	t.Cleanup(func() { rebuildTKOverlayUnion(nil) })
+
+	rebuildTKOverlayUnion([]byte("{ this is not valid json"))
+	eff := loadTKPricingOverlay()
+	require.NotNil(t, eff["qwen3-8b"])
+	require.InDelta(t, embeddedQwen8bInput, eff["qwen3-8b"].InputCostPerToken, 1e-18)
+}
+
 func TestRebuildTKOverlayUnion_EmptyFallsBackToEmbedded(t *testing.T) {
 	resetOverlayUnion(t)
 	rebuildTKOverlayUnion([]byte(`{"qwen3-8b":{"input_cost_per_token":5e-06,"litellm_provider":"dashscope"}}`))
@@ -67,6 +81,51 @@ func TestRebuildTKOverlayUnion_EmptyFallsBackToEmbedded(t *testing.T) {
 	if loadTKPricingOverlay()["qwen3-8b"].InputCostPerToken != embeddedQwen8bInput {
 		t.Fatal("empty runtime must fall back to embedded floor")
 	}
+}
+
+func runtimeTaxPolicyBlob(t *testing.T, multiplier float64, dropFirstProvider bool) string {
+	t.Helper()
+	policy := loadTkOfficialListBaseTaxPolicy()
+	policy.Multiplier = multiplier
+	if dropFirstProvider {
+		require.NotEmpty(t, policy.Rules)
+		policy.Rules = policy.Rules[1:]
+	}
+	payload, err := json.Marshal(map[string]any{
+		"_config": map[string]any{"official_list_base_tax": policy},
+	})
+	require.NoError(t, err)
+	return string(payload)
+}
+
+func TestRebuildTKOverlayUnion_RuntimeTaxPolicyWinsAndModelOnlyInheritsFloor(t *testing.T) {
+	resetOverlayUnion(t)
+	embeddedMultiplier := tkOfficialListBaseTaxMultiplier()
+	runtime := runtimeTaxPolicyBlob(t, 1.07, false)
+	rebuildTKOverlayUnion([]byte(runtime))
+	require.InDelta(t, 1.07, tkOfficialListBaseTaxMultiplier(), 1e-12)
+	for _, rule := range loadTkOfficialListBaseTaxPolicy().Rules {
+		litellm := tkPresentLiteLLMModelPricing(&LiteLLMModelPricing{
+			LiteLLMProvider:    rule.Provider,
+			InputCostPerToken:  1,
+			OutputCostPerToken: 2,
+		})
+		require.InDelta(t, 1.07, litellm.InputCostPerToken, 1e-12, rule.Provider)
+
+		catalog := PublicCatalogPricing{InputPer1KTokens: 1, OutputPer1KTokens: 2}
+		tkApplyBaseTaxToPublicCatalogPricing(rule.Provider, &catalog)
+		require.InDelta(t, 1.07, catalog.InputPer1KTokens, 1e-12, rule.Provider)
+
+		fallback := tkApplyOfficialListBaseTaxForModel(
+			sampleModelForTaxRule(t, rule),
+			&ModelPricing{InputPricePerToken: 1, OutputPricePerToken: 2},
+		)
+		require.InDelta(t, 1.07, fallback.InputPricePerToken, 1e-12, rule.Provider)
+	}
+
+	// A model-only runtime blob inherits the embedded policy rather than clearing it.
+	rebuildTKOverlayUnion([]byte(`{"qwen3-8b":{"input_cost_per_token":5e-06,"litellm_provider":"dashscope"}}`))
+	require.InDelta(t, embeddedMultiplier, tkOfficialListBaseTaxMultiplier(), 1e-12)
 }
 
 func newTestPricingService() *PricingService {
@@ -114,6 +173,33 @@ func TestReloadTKOverlayRuntime_CorruptKeepsCurrent(t *testing.T) {
 	}
 }
 
+func TestReloadTKOverlayRuntime_RejectsTaxPolicyThatDropsEmbeddedProvider(t *testing.T) {
+	resetOverlayUnion(t)
+	s := newTestPricingService()
+	blob := runtimeTaxPolicyBlob(t, 1.07, true)
+	s.SetOverlayRuntimeDeps(func(context.Context) (string, bool) { return blob, true }, nil)
+
+	changed, err := s.reloadTKOverlayRuntime(context.Background())
+	require.Error(t, err)
+	require.False(t, changed)
+	require.InDelta(t, 1.06, tkOfficialListBaseTaxMultiplier(), 1e-12)
+}
+
+func TestParseTKOverlayDocument_RejectsInvalidTaxPolicy(t *testing.T) {
+	tests := map[string]string{
+		"unknown config field":    `{"_config":{"unexpected":{}}}`,
+		"out of range multiplier": `{"_config":{"official_list_base_tax":{"multiplier":0.99,"rules":[{"provider":"dashscope","model_prefixes":["qwen"]}]}}}`,
+		"unknown rule field":      `{"_config":{"official_list_base_tax":{"multiplier":1.06,"rules":[{"provider":"dashscope","model_prefixes":["qwen"],"unexpected":true}]}}}`,
+		"missing matcher":         `{"_config":{"official_list_base_tax":{"multiplier":1.06,"rules":[{"provider":"dashscope"}]}}}`,
+	}
+	for name, blob := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseTKOverlayDocument([]byte(blob))
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestReloadTKOverlayRuntime_EmptyGetterIsEmbeddedFloor(t *testing.T) {
 	resetOverlayUnion(t)
 	s := newTestPricingService()
@@ -141,6 +227,7 @@ func TestConcurrentOverlayReadDuringSwap(t *testing.T) {
 					return
 				default:
 					_ = loadTKPricingOverlay()["qwen3-8b"]
+					_ = tkOfficialListBaseTaxMultiplier()
 				}
 			}
 		}()
@@ -202,6 +289,10 @@ func TestEmbeddedOverlayParsesAsFloor(t *testing.T) {
 	if len(m) == 0 {
 		t.Fatal("embedded overlay parsed to zero entries")
 	}
+	doc, err := parseTKOverlayDocument(tkPricingOverlayRaw)
+	require.NoError(t, err)
+	require.NotNil(t, doc.BaseTax)
+	require.NoError(t, doc.BaseTax.validate())
 	// _meta / provenance keys are skipped.
 	var raw map[string]json.RawMessage
 	_ = json.Unmarshal(tkPricingOverlayRaw, &raw)

--- a/backend/internal/service/pricing_service_tk_overlay_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_test.go
@@ -69,9 +69,42 @@ func TestTKPricingOverlay_FillsMoonshotChinaModels(t *testing.T) {
 	billing := NewBillingService(&config.Config{}, &PricingService{pricingData: data})
 	k3, err := billing.GetModelPricing("kimi-k3")
 	require.NoError(t, err)
-	require.InDelta(t, data["kimi-k3"].InputCostPerToken*tkOfficialListBaseTaxMultiplier, k3.InputPricePerToken, 1e-15)
-	require.InDelta(t, data["kimi-k3"].OutputCostPerToken*tkOfficialListBaseTaxMultiplier, k3.OutputPricePerToken, 1e-15)
-	require.InDelta(t, data["kimi-k3"].CacheReadInputTokenCost*tkOfficialListBaseTaxMultiplier, k3.CacheReadPricePerToken, 1e-15)
+	require.InDelta(t, data["kimi-k3"].InputCostPerToken*tkOfficialListBaseTaxMultiplier(), k3.InputPricePerToken, 1e-15)
+	require.InDelta(t, data["kimi-k3"].OutputCostPerToken*tkOfficialListBaseTaxMultiplier(), k3.OutputPricePerToken, 1e-15)
+	require.InDelta(t, data["kimi-k3"].CacheReadInputTokenCost*tkOfficialListBaseTaxMultiplier(), k3.CacheReadPricePerToken, 1e-15)
+}
+
+func TestBillingOverlayBackedFallbackUsesPricingSSOT(t *testing.T) {
+	billing := NewBillingService(&config.Config{}, nil)
+	pricing, err := billing.GetModelPricing("kimi-k2.6")
+	require.NoError(t, err)
+	require.InDelta(t,
+		tkCNYPerMTokToUSDPerToken(6.5)*tkOfficialListBaseTaxMultiplier(),
+		pricing.InputPricePerToken,
+		1e-15,
+	)
+	require.InDelta(t,
+		tkCNYPerMTokToUSDPerToken(27)*tkOfficialListBaseTaxMultiplier(),
+		pricing.OutputPricePerToken,
+		1e-15,
+	)
+	require.InDelta(t,
+		tkCNYPerMTokToUSDPerToken(1.1)*tkOfficialListBaseTaxMultiplier(),
+		pricing.CacheReadPricePerToken,
+		1e-15,
+	)
+}
+
+func TestBillingOverlayMediaOnlyPricingRemainsTokenAbsent(t *testing.T) {
+	svc := &PricingService{}
+	data, err := svc.parsePricingData([]byte(`{
+		"gpt-5.4": {"input_cost_per_token": 0.0000025, "output_cost_per_token": 0.000015, "litellm_provider": "openai", "mode": "chat"}
+	}`))
+	require.NoError(t, err)
+	billing := NewBillingService(&config.Config{}, &PricingService{pricingData: data})
+	pricing, err := billing.GetModelPricing("grok-imagine-image")
+	require.ErrorIs(t, err, ErrModelPricingUnavailable)
+	require.Nil(t, pricing)
 }
 
 // TestTKPricingOverlay_FillOnlySourceWins verifies the overlay never overwrites

--- a/backend/internal/service/pricing_tk_base_tax.go
+++ b/backend/internal/service/pricing_tk_base_tax.go
@@ -1,122 +1,190 @@
 package service
 
-import "strings"
-
-// tkOfficialListBaseTaxMultiplier is applied to official list prices for CN-origin
-// providers whose upstream quotes exclude the base VAT layer TokenKey absorbs.
-// Overlay JSON and the litellm mirror store pre-tax official rates; billing and
-// /pricing apply this multiplier at presentation/resolution time so display matches
-// charge. Channel (DB) pricing sits above this layer and is never re-taxed.
-const tkOfficialListBaseTaxMultiplier = 1.06
+import (
+	"fmt"
+	"math"
+	"strings"
+)
 
 type tkOfficialListBaseTaxRule struct {
-	provider      string
-	modelPrefixes []string
-	modelContains []string
+	Provider      string   `json:"provider"`
+	ModelPrefixes []string `json:"model_prefixes"`
+	ModelContains []string `json:"model_contains"`
 }
 
-// tkOfficialListBaseTaxRules is the single owner for both provider/vendor tax
-// eligibility and bare-model fallback classification. Keep row order stable so
-// overlapping future model matchers resolve deterministically.
-var tkOfficialListBaseTaxRules = []tkOfficialListBaseTaxRule{
-	{provider: "deepseek", modelContains: []string{"deepseek"}},
-	{provider: "dashscope", modelPrefixes: []string{"qwen"}},
-	{provider: "moonshot", modelPrefixes: []string{"kimi-", "kimi/", "moonshot-"}},
-	{provider: "volcengine", modelPrefixes: []string{"doubao", "seedream", "seedance"}},
-	{provider: "zhipu", modelPrefixes: []string{"glm"}},
+// tkOfficialListBaseTaxPolicy is executable pricing policy loaded from
+// tk_pricing_overlay.json::_config. The embedded document is the compile floor;
+// tk_pricing_overlay_runtime may replace this policy atomically with model prices.
+type tkOfficialListBaseTaxPolicy struct {
+	Multiplier float64                     `json:"multiplier"`
+	Rules      []tkOfficialListBaseTaxRule `json:"rules"`
 }
 
-func tkLitellmProviderHasBaseTax(provider string) bool {
-	provider = strings.ToLower(strings.TrimSpace(provider))
-	for _, rule := range tkOfficialListBaseTaxRules {
-		if provider == rule.provider {
-			return true
+func (p tkOfficialListBaseTaxPolicy) validate() error {
+	if math.IsNaN(p.Multiplier) || math.IsInf(p.Multiplier, 0) || p.Multiplier < 1 || p.Multiplier > 2 {
+		return fmt.Errorf("official_list_base_tax.multiplier must be within [1,2], got %v", p.Multiplier)
+	}
+	if len(p.Rules) == 0 {
+		return fmt.Errorf("official_list_base_tax.rules must be non-empty")
+	}
+	providers := make(map[string]struct{}, len(p.Rules))
+	matchers := make(map[string]string)
+	for i, rule := range p.Rules {
+		provider := strings.TrimSpace(rule.Provider)
+		if provider == "" || provider != strings.ToLower(provider) {
+			return fmt.Errorf("official_list_base_tax.rules[%d].provider must be normalized lowercase", i)
+		}
+		if _, exists := providers[provider]; exists {
+			return fmt.Errorf("official_list_base_tax provider %q is duplicated", provider)
+		}
+		providers[provider] = struct{}{}
+		if len(rule.ModelPrefixes) == 0 && len(rule.ModelContains) == 0 {
+			return fmt.Errorf("official_list_base_tax provider %q requires a fallback model matcher", provider)
+		}
+		for _, matcherSet := range []struct {
+			kind   string
+			values []string
+		}{
+			{kind: "prefix", values: rule.ModelPrefixes},
+			{kind: "contains", values: rule.ModelContains},
+		} {
+			kind, values := matcherSet.kind, matcherSet.values
+			seen := make(map[string]struct{}, len(values))
+			for _, value := range values {
+				if value == "" || value != strings.TrimSpace(value) || value != strings.ToLower(value) {
+					return fmt.Errorf("official_list_base_tax provider %q has invalid %s matcher %q", provider, kind, value)
+				}
+				if _, exists := seen[value]; exists {
+					return fmt.Errorf("official_list_base_tax provider %q duplicates %s matcher %q", provider, kind, value)
+				}
+				seen[value] = struct{}{}
+				key := kind + ":" + value
+				if owner, exists := matchers[key]; exists {
+					return fmt.Errorf("official_list_base_tax %s matcher %q belongs to both %q and %q", kind, value, owner, provider)
+				}
+				matchers[key] = provider
+			}
 		}
 	}
-	return false
+	return nil
+}
+
+func loadTkOfficialListBaseTaxPolicy() tkOfficialListBaseTaxPolicy {
+	snapshot := loadTKPricingOverlaySnapshot()
+	if snapshot == nil {
+		return tkOfficialListBaseTaxPolicy{}
+	}
+	return snapshot.BaseTax
+}
+
+func tkOfficialListBaseTaxMultiplier() float64 {
+	return loadTkOfficialListBaseTaxPolicy().Multiplier
+}
+
+func (p tkOfficialListBaseTaxPolicy) multiplierForProvider(provider string) (float64, bool) {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	for _, rule := range p.Rules {
+		if provider == rule.Provider {
+			return p.Multiplier, true
+		}
+	}
+	return 0, false
+}
+
+func tkBaseTaxMultiplierForProvider(provider string) (float64, bool) {
+	return loadTkOfficialListBaseTaxPolicy().multiplierForProvider(provider)
 }
 
 // tkInferBaseTaxProvider maps a bare model id to a provider when only the model
 // name is known (billing fallbackPrices path — those entries carry no vendor).
-func tkInferBaseTaxProvider(model string) string {
+func (p tkOfficialListBaseTaxPolicy) inferProvider(model string) string {
 	m := strings.ToLower(strings.TrimSpace(model))
-	for _, rule := range tkOfficialListBaseTaxRules {
-		for _, prefix := range rule.modelPrefixes {
+	for _, rule := range p.Rules {
+		for _, prefix := range rule.ModelPrefixes {
 			if strings.HasPrefix(m, prefix) {
-				return rule.provider
+				return rule.Provider
 			}
 		}
-		for _, fragment := range rule.modelContains {
+		for _, fragment := range rule.ModelContains {
 			if strings.Contains(m, fragment) {
-				return rule.provider
+				return rule.Provider
 			}
 		}
 	}
 	return ""
 }
 
-func tkApplyBaseTaxMultiplier(v float64) float64 {
+func tkInferBaseTaxProvider(model string) string {
+	return loadTkOfficialListBaseTaxPolicy().inferProvider(model)
+}
+
+func tkApplyBaseTaxMultiplier(v, multiplier float64) float64 {
 	if v <= 0 {
 		return v
 	}
-	return v * tkOfficialListBaseTaxMultiplier
+	return v * multiplier
 }
 
-func tkApplyBaseTaxToPricingInterval(iv PricingInterval) PricingInterval {
+func tkApplyBaseTaxToPricingInterval(iv PricingInterval, multiplier float64) PricingInterval {
 	out := iv
 	if out.InputPrice != nil {
-		v := tkApplyBaseTaxMultiplier(*out.InputPrice)
+		v := tkApplyBaseTaxMultiplier(*out.InputPrice, multiplier)
 		out.InputPrice = &v
 	}
 	if out.OutputPrice != nil {
-		v := tkApplyBaseTaxMultiplier(*out.OutputPrice)
+		v := tkApplyBaseTaxMultiplier(*out.OutputPrice, multiplier)
 		out.OutputPrice = &v
 	}
 	if out.CacheWritePrice != nil {
-		v := tkApplyBaseTaxMultiplier(*out.CacheWritePrice)
+		v := tkApplyBaseTaxMultiplier(*out.CacheWritePrice, multiplier)
 		out.CacheWritePrice = &v
 	}
 	if out.CacheReadPrice != nil {
-		v := tkApplyBaseTaxMultiplier(*out.CacheReadPrice)
+		v := tkApplyBaseTaxMultiplier(*out.CacheReadPrice, multiplier)
 		out.CacheReadPrice = &v
 	}
 	if out.PerRequestPrice != nil {
-		v := tkApplyBaseTaxMultiplier(*out.PerRequestPrice)
+		v := tkApplyBaseTaxMultiplier(*out.PerRequestPrice, multiplier)
 		out.PerRequestPrice = &v
 	}
 	return out
 }
 
-func tkApplyBaseTaxToPricingIntervals(intervals []PricingInterval) []PricingInterval {
+func tkApplyBaseTaxToPricingIntervals(intervals []PricingInterval, multiplier float64) []PricingInterval {
 	if len(intervals) == 0 {
 		return intervals
 	}
 	out := make([]PricingInterval, len(intervals))
 	for i := range intervals {
-		out[i] = tkApplyBaseTaxToPricingInterval(intervals[i])
+		out[i] = tkApplyBaseTaxToPricingInterval(intervals[i], multiplier)
 	}
 	return out
 }
 
 func tkApplyBaseTaxToLiteLLMModelPricingClone(p *LiteLLMModelPricing) *LiteLLMModelPricing {
-	if p == nil || !tkLitellmProviderHasBaseTax(p.LiteLLMProvider) {
+	if p == nil {
+		return p
+	}
+	multiplier, ok := tkBaseTaxMultiplierForProvider(p.LiteLLMProvider)
+	if !ok {
 		return p
 	}
 	c := *p
-	c.InputCostPerToken = tkApplyBaseTaxMultiplier(c.InputCostPerToken)
-	c.InputCostPerTokenPriority = tkApplyBaseTaxMultiplier(c.InputCostPerTokenPriority)
-	c.OutputCostPerToken = tkApplyBaseTaxMultiplier(c.OutputCostPerToken)
-	c.OutputCostPerTokenPriority = tkApplyBaseTaxMultiplier(c.OutputCostPerTokenPriority)
-	c.ThinkingOutputCostPerToken = tkApplyBaseTaxMultiplier(c.ThinkingOutputCostPerToken)
-	c.CacheCreationInputTokenCost = tkApplyBaseTaxMultiplier(c.CacheCreationInputTokenCost)
-	c.CacheCreationInputTokenCostAbove1hr = tkApplyBaseTaxMultiplier(c.CacheCreationInputTokenCostAbove1hr)
-	c.CacheReadInputTokenCost = tkApplyBaseTaxMultiplier(c.CacheReadInputTokenCost)
-	c.CacheReadInputTokenCostPriority = tkApplyBaseTaxMultiplier(c.CacheReadInputTokenCostPriority)
-	c.OutputCostPerImage = tkApplyBaseTaxMultiplier(c.OutputCostPerImage)
-	c.OutputCostPerImageToken = tkApplyBaseTaxMultiplier(c.OutputCostPerImageToken)
-	c.OutputCostPerSecond = tkApplyBaseTaxMultiplier(c.OutputCostPerSecond)
+	c.InputCostPerToken = tkApplyBaseTaxMultiplier(c.InputCostPerToken, multiplier)
+	c.InputCostPerTokenPriority = tkApplyBaseTaxMultiplier(c.InputCostPerTokenPriority, multiplier)
+	c.OutputCostPerToken = tkApplyBaseTaxMultiplier(c.OutputCostPerToken, multiplier)
+	c.OutputCostPerTokenPriority = tkApplyBaseTaxMultiplier(c.OutputCostPerTokenPriority, multiplier)
+	c.ThinkingOutputCostPerToken = tkApplyBaseTaxMultiplier(c.ThinkingOutputCostPerToken, multiplier)
+	c.CacheCreationInputTokenCost = tkApplyBaseTaxMultiplier(c.CacheCreationInputTokenCost, multiplier)
+	c.CacheCreationInputTokenCostPriority = tkApplyBaseTaxMultiplier(c.CacheCreationInputTokenCostPriority, multiplier)
+	c.CacheCreationInputTokenCostAbove1hr = tkApplyBaseTaxMultiplier(c.CacheCreationInputTokenCostAbove1hr, multiplier)
+	c.CacheReadInputTokenCost = tkApplyBaseTaxMultiplier(c.CacheReadInputTokenCost, multiplier)
+	c.CacheReadInputTokenCostPriority = tkApplyBaseTaxMultiplier(c.CacheReadInputTokenCostPriority, multiplier)
+	c.OutputCostPerImage = tkApplyBaseTaxMultiplier(c.OutputCostPerImage, multiplier)
+	c.OutputCostPerImageToken = tkApplyBaseTaxMultiplier(c.OutputCostPerImageToken, multiplier)
+	c.OutputCostPerSecond = tkApplyBaseTaxMultiplier(c.OutputCostPerSecond, multiplier)
 	if len(c.Intervals) > 0 {
-		c.Intervals = tkApplyBaseTaxToPricingIntervals(c.Intervals)
+		c.Intervals = tkApplyBaseTaxToPricingIntervals(c.Intervals, multiplier)
 	}
 	return &c
 }
@@ -125,45 +193,50 @@ func tkPresentLiteLLMModelPricing(p *LiteLLMModelPricing) *LiteLLMModelPricing {
 	return tkApplyBaseTaxToLiteLLMModelPricingClone(p)
 }
 
-func tkApplyBaseTaxToModelPricingClone(p *ModelPricing) *ModelPricing {
+func tkApplyBaseTaxToModelPricingClone(p *ModelPricing, multiplier float64) *ModelPricing {
 	if p == nil {
 		return nil
 	}
 	c := *p
-	c.InputPricePerToken = tkApplyBaseTaxMultiplier(c.InputPricePerToken)
-	c.InputPricePerTokenPriority = tkApplyBaseTaxMultiplier(c.InputPricePerTokenPriority)
-	c.ImageInputPricePerToken = tkApplyBaseTaxMultiplier(c.ImageInputPricePerToken)
-	c.OutputPricePerToken = tkApplyBaseTaxMultiplier(c.OutputPricePerToken)
-	c.OutputPricePerTokenPriority = tkApplyBaseTaxMultiplier(c.OutputPricePerTokenPriority)
-	c.ThinkingOutputPricePerToken = tkApplyBaseTaxMultiplier(c.ThinkingOutputPricePerToken)
-	c.CacheCreationPricePerToken = tkApplyBaseTaxMultiplier(c.CacheCreationPricePerToken)
-	c.CacheReadPricePerToken = tkApplyBaseTaxMultiplier(c.CacheReadPricePerToken)
-	c.CacheReadPricePerTokenPriority = tkApplyBaseTaxMultiplier(c.CacheReadPricePerTokenPriority)
-	c.CacheCreation5mPrice = tkApplyBaseTaxMultiplier(c.CacheCreation5mPrice)
-	c.CacheCreation1hPrice = tkApplyBaseTaxMultiplier(c.CacheCreation1hPrice)
-	c.ImageOutputPricePerToken = tkApplyBaseTaxMultiplier(c.ImageOutputPricePerToken)
+	c.InputPricePerToken = tkApplyBaseTaxMultiplier(c.InputPricePerToken, multiplier)
+	c.InputPricePerTokenPriority = tkApplyBaseTaxMultiplier(c.InputPricePerTokenPriority, multiplier)
+	c.ImageInputPricePerToken = tkApplyBaseTaxMultiplier(c.ImageInputPricePerToken, multiplier)
+	c.OutputPricePerToken = tkApplyBaseTaxMultiplier(c.OutputPricePerToken, multiplier)
+	c.OutputPricePerTokenPriority = tkApplyBaseTaxMultiplier(c.OutputPricePerTokenPriority, multiplier)
+	c.ThinkingOutputPricePerToken = tkApplyBaseTaxMultiplier(c.ThinkingOutputPricePerToken, multiplier)
+	c.CacheCreationPricePerToken = tkApplyBaseTaxMultiplier(c.CacheCreationPricePerToken, multiplier)
+	c.CacheCreationPricePerTokenPriority = tkApplyBaseTaxMultiplier(c.CacheCreationPricePerTokenPriority, multiplier)
+	c.CacheReadPricePerToken = tkApplyBaseTaxMultiplier(c.CacheReadPricePerToken, multiplier)
+	c.CacheReadPricePerTokenPriority = tkApplyBaseTaxMultiplier(c.CacheReadPricePerTokenPriority, multiplier)
+	c.CacheCreation5mPrice = tkApplyBaseTaxMultiplier(c.CacheCreation5mPrice, multiplier)
+	c.CacheCreation1hPrice = tkApplyBaseTaxMultiplier(c.CacheCreation1hPrice, multiplier)
+	c.ImageOutputPricePerToken = tkApplyBaseTaxMultiplier(c.ImageOutputPricePerToken, multiplier)
 	if len(c.Intervals) > 0 {
-		c.Intervals = tkApplyBaseTaxToPricingIntervals(c.Intervals)
+		c.Intervals = tkApplyBaseTaxToPricingIntervals(c.Intervals, multiplier)
 	}
 	return &c
 }
 
 func tkApplyBaseTaxToPublicCatalogPricing(vendor string, p *PublicCatalogPricing) {
-	if p == nil || !tkLitellmProviderHasBaseTax(vendor) {
+	if p == nil {
 		return
 	}
-	p.InputPer1KTokens = tkApplyBaseTaxMultiplier(p.InputPer1KTokens)
-	p.OutputPer1KTokens = tkApplyBaseTaxMultiplier(p.OutputPer1KTokens)
-	p.ThinkingOutputPer1KTokens = tkApplyBaseTaxMultiplier(p.ThinkingOutputPer1KTokens)
-	p.CacheReadPer1K = tkApplyBaseTaxMultiplier(p.CacheReadPer1K)
-	p.CacheWritePer1K = tkApplyBaseTaxMultiplier(p.CacheWritePer1K)
-	p.OutputCostPerImage = tkApplyBaseTaxMultiplier(p.OutputCostPerImage)
-	p.OutputCostPerSecond = tkApplyBaseTaxMultiplier(p.OutputCostPerSecond)
+	multiplier, ok := tkBaseTaxMultiplierForProvider(vendor)
+	if !ok {
+		return
+	}
+	p.InputPer1KTokens = tkApplyBaseTaxMultiplier(p.InputPer1KTokens, multiplier)
+	p.OutputPer1KTokens = tkApplyBaseTaxMultiplier(p.OutputPer1KTokens, multiplier)
+	p.ThinkingOutputPer1KTokens = tkApplyBaseTaxMultiplier(p.ThinkingOutputPer1KTokens, multiplier)
+	p.CacheReadPer1K = tkApplyBaseTaxMultiplier(p.CacheReadPer1K, multiplier)
+	p.CacheWritePer1K = tkApplyBaseTaxMultiplier(p.CacheWritePer1K, multiplier)
+	p.OutputCostPerImage = tkApplyBaseTaxMultiplier(p.OutputCostPerImage, multiplier)
+	p.OutputCostPerSecond = tkApplyBaseTaxMultiplier(p.OutputCostPerSecond, multiplier)
 	if len(p.Tiers) > 0 {
 		for i := range p.Tiers {
-			p.Tiers[i].InputPer1KTokens = tkApplyBaseTaxMultiplier(p.Tiers[i].InputPer1KTokens)
-			p.Tiers[i].OutputPer1KTokens = tkApplyBaseTaxMultiplier(p.Tiers[i].OutputPer1KTokens)
-			p.Tiers[i].CacheReadPer1K = tkApplyBaseTaxMultiplier(p.Tiers[i].CacheReadPer1K)
+			p.Tiers[i].InputPer1KTokens = tkApplyBaseTaxMultiplier(p.Tiers[i].InputPer1KTokens, multiplier)
+			p.Tiers[i].OutputPer1KTokens = tkApplyBaseTaxMultiplier(p.Tiers[i].OutputPer1KTokens, multiplier)
+			p.Tiers[i].CacheReadPer1K = tkApplyBaseTaxMultiplier(p.Tiers[i].CacheReadPer1K, multiplier)
 		}
 	}
 }
@@ -172,8 +245,10 @@ func tkApplyOfficialListBaseTaxForModel(model string, pricing *ModelPricing) *Mo
 	if pricing == nil {
 		return nil
 	}
-	if !tkLitellmProviderHasBaseTax(tkInferBaseTaxProvider(model)) {
+	policy := loadTkOfficialListBaseTaxPolicy()
+	multiplier, ok := policy.multiplierForProvider(policy.inferProvider(model))
+	if !ok {
 		return pricing
 	}
-	return tkApplyBaseTaxToModelPricingClone(pricing)
+	return tkApplyBaseTaxToModelPricingClone(pricing, multiplier)
 }

--- a/backend/internal/service/pricing_tk_base_tax.go
+++ b/backend/internal/service/pricing_tk_base_tax.go
@@ -114,10 +114,6 @@ func (p tkOfficialListBaseTaxPolicy) inferProvider(model string) string {
 	return ""
 }
 
-func tkInferBaseTaxProvider(model string) string {
-	return loadTkOfficialListBaseTaxPolicy().inferProvider(model)
-}
-
 func tkApplyBaseTaxMultiplier(v, multiplier float64) float64 {
 	if v <= 0 {
 		return v

--- a/backend/internal/service/pricing_tk_base_tax_test.go
+++ b/backend/internal/service/pricing_tk_base_tax_test.go
@@ -73,14 +73,14 @@ func TestTkInferBaseTaxProvider(t *testing.T) {
 	for _, rule := range policy.Rules {
 		for _, prefix := range rule.ModelPrefixes {
 			model := prefix + "ssot-probe"
-			assert.Equal(t, rule.Provider, tkInferBaseTaxProvider(model), model)
+			assert.Equal(t, rule.Provider, policy.inferProvider(model), model)
 		}
 		for _, fragment := range rule.ModelContains {
 			model := "ssot-" + fragment + "-probe"
-			assert.Equal(t, rule.Provider, tkInferBaseTaxProvider(model), model)
+			assert.Equal(t, rule.Provider, policy.inferProvider(model), model)
 		}
 	}
-	assert.Empty(t, tkInferBaseTaxProvider("openai/gpt-5.4"))
+	assert.Empty(t, policy.inferProvider("openai/gpt-5.4"))
 }
 
 func sampleModelForTaxRule(t *testing.T, rule tkOfficialListBaseTaxRule) string {

--- a/backend/internal/service/pricing_tk_base_tax_test.go
+++ b/backend/internal/service/pricing_tk_base_tax_test.go
@@ -12,26 +12,23 @@ import (
 func TestTkOfficialListBaseTax_AppliesToTargetProvidersOnly(t *testing.T) {
 	in := 1.0
 	out := 2.0
-	p := &LiteLLMModelPricing{
-		LiteLLMProvider:    "deepseek",
-		InputCostPerToken:  in,
-		OutputCostPerToken: out,
+	policy := loadTkOfficialListBaseTaxPolicy()
+	require.NoError(t, policy.validate())
+	require.InDelta(t, 1.06, policy.Multiplier, 1e-12, "behavior-preserving migration from the former Go constant")
+	for _, rule := range policy.Rules {
+		p := &LiteLLMModelPricing{
+			LiteLLMProvider:                     rule.Provider,
+			InputCostPerToken:                   in,
+			OutputCostPerToken:                  out,
+			CacheCreationInputTokenCostPriority: 3,
+		}
+		taxed := tkPresentLiteLLMModelPricing(p)
+		require.NotSame(t, p, taxed, rule.Provider+" lookup must clone, not mutate cache")
+		assert.InDelta(t, in*policy.Multiplier, taxed.InputCostPerToken, 1e-12, rule.Provider)
+		assert.InDelta(t, out*policy.Multiplier, taxed.OutputCostPerToken, 1e-12, rule.Provider)
+		assert.InDelta(t, 3*policy.Multiplier, taxed.CacheCreationInputTokenCostPriority, 1e-12, rule.Provider)
+		assert.InDelta(t, in, p.InputCostPerToken, 1e-12, rule.Provider+" cache entry changed")
 	}
-	taxed := tkPresentLiteLLMModelPricing(p)
-	require.NotSame(t, p, taxed, "taxed lookup must clone, not mutate cache")
-	assert.InDelta(t, in*tkOfficialListBaseTaxMultiplier, taxed.InputCostPerToken, 1e-12)
-	assert.InDelta(t, out*tkOfficialListBaseTaxMultiplier, taxed.OutputCostPerToken, 1e-12)
-	assert.InDelta(t, in, p.InputCostPerToken, 1e-12, "cache entry unchanged")
-
-	moonshot := &LiteLLMModelPricing{
-		LiteLLMProvider:    "moonshot",
-		InputCostPerToken:  in,
-		OutputCostPerToken: out,
-	}
-	moonshotTaxed := tkPresentLiteLLMModelPricing(moonshot)
-	require.NotSame(t, moonshot, moonshotTaxed)
-	assert.InDelta(t, in*tkOfficialListBaseTaxMultiplier, moonshotTaxed.InputCostPerToken, 1e-12)
-	assert.InDelta(t, out*tkOfficialListBaseTaxMultiplier, moonshotTaxed.OutputCostPerToken, 1e-12)
 
 	openai := &LiteLLMModelPricing{
 		LiteLLMProvider:    "openai",
@@ -42,7 +39,9 @@ func TestTkOfficialListBaseTax_AppliesToTargetProvidersOnly(t *testing.T) {
 }
 
 func TestTkOfficialListBaseTax_PublicCatalogAndBillingStayAligned(t *testing.T) {
-	for _, vendor := range []string{"dashscope", "moonshot"} {
+	policy := loadTkOfficialListBaseTaxPolicy()
+	for _, rule := range policy.Rules {
+		vendor := rule.Provider
 		catalog := PublicCatalogPricing{
 			Currency:          "USD",
 			InputPer1KTokens:  0.001,
@@ -52,85 +51,78 @@ func TestTkOfficialListBaseTax_PublicCatalogAndBillingStayAligned(t *testing.T) 
 			},
 		}
 		tkApplyBaseTaxToPublicCatalogPricing(vendor, &catalog)
-		assert.InDelta(t, 0.001*tkOfficialListBaseTaxMultiplier, catalog.InputPer1KTokens, 1e-12, vendor)
-		assert.InDelta(t, 0.002*tkOfficialListBaseTaxMultiplier, catalog.OutputPer1KTokens, 1e-12, vendor)
+		assert.InDelta(t, 0.001*policy.Multiplier, catalog.InputPer1KTokens, 1e-12, vendor)
+		assert.InDelta(t, 0.002*policy.Multiplier, catalog.OutputPer1KTokens, 1e-12, vendor)
 		assert.InDelta(t, catalog.InputPer1KTokens, catalog.Tiers[0].InputPer1KTokens, 1e-12, vendor)
 	}
 
 	mp := &ModelPricing{
-		InputPricePerToken:  0.000001,
-		OutputPricePerToken: 0.000002,
+		InputPricePerToken:                 0.000001,
+		OutputPricePerToken:                0.000002,
+		CacheCreationPricePerTokenPriority: 0.000003,
 	}
-	taxed := tkApplyBaseTaxToModelPricingClone(mp)
+	taxed := tkApplyBaseTaxToModelPricingClone(mp, tkOfficialListBaseTaxMultiplier())
 	require.NotNil(t, taxed)
-	assert.InDelta(t, 0.000001*tkOfficialListBaseTaxMultiplier, taxed.InputPricePerToken, 1e-12)
-	assert.InDelta(t, 0.000002*tkOfficialListBaseTaxMultiplier, taxed.OutputPricePerToken, 1e-12)
+	assert.InDelta(t, 0.000001*tkOfficialListBaseTaxMultiplier(), taxed.InputPricePerToken, 1e-12)
+	assert.InDelta(t, 0.000002*tkOfficialListBaseTaxMultiplier(), taxed.OutputPricePerToken, 1e-12)
+	assert.InDelta(t, 0.000003*tkOfficialListBaseTaxMultiplier(), taxed.CacheCreationPricePerTokenPriority, 1e-12)
 }
 
 func TestTkInferBaseTaxProvider(t *testing.T) {
-	assert.Equal(t, "deepseek", tkInferBaseTaxProvider("deepseek-chat"))
-	assert.Equal(t, "dashscope", tkInferBaseTaxProvider("qwen-plus"))
-	assert.Equal(t, "volcengine", tkInferBaseTaxProvider("doubao-seed-2-0-pro-260215"))
-	assert.Equal(t, "zhipu", tkInferBaseTaxProvider("glm-4.7"))
-	assert.Equal(t, "moonshot", tkInferBaseTaxProvider("kimi-k3"))
-	assert.Equal(t, "moonshot", tkInferBaseTaxProvider("kimi/k2"))
-	assert.Equal(t, "moonshot", tkInferBaseTaxProvider("moonshot-v1-auto"))
+	policy := loadTkOfficialListBaseTaxPolicy()
+	for _, rule := range policy.Rules {
+		for _, prefix := range rule.ModelPrefixes {
+			model := prefix + "ssot-probe"
+			assert.Equal(t, rule.Provider, tkInferBaseTaxProvider(model), model)
+		}
+		for _, fragment := range rule.ModelContains {
+			model := "ssot-" + fragment + "-probe"
+			assert.Equal(t, rule.Provider, tkInferBaseTaxProvider(model), model)
+		}
+	}
 	assert.Empty(t, tkInferBaseTaxProvider("openai/gpt-5.4"))
 }
 
-func TestPricingService_GetModelPricing_AppliesBaseTaxOnLookup(t *testing.T) {
-	svc := &PricingService{}
-	data, err := svc.parsePricingData([]byte(`{
-		"deepseek-v4-pro": {
-			"input_cost_per_token": 1e-6,
-			"output_cost_per_token": 2e-6,
-			"litellm_provider": "deepseek",
-			"mode": "chat"
-		},
-		"glm-5.2": {
-			"input_cost_per_token": 3e-6,
-			"output_cost_per_token": 4e-6,
-			"litellm_provider": "zhipu",
-			"mode": "chat"
-		},
-		"moonshot-tax-test": {
-			"input_cost_per_token": 5e-6,
-			"output_cost_per_token": 6e-6,
-			"litellm_provider": "moonshot",
-			"mode": "chat"
-		}
-	}`))
-	require.NoError(t, err)
-	svc.pricingData = data
-
-	got := svc.GetModelPricing("deepseek-v4-pro")
-	require.NotNil(t, got)
-	assert.InDelta(t, 1e-6*tkOfficialListBaseTaxMultiplier, got.InputCostPerToken, 1e-15)
-	assert.InDelta(t, 2e-6*tkOfficialListBaseTaxMultiplier, got.OutputCostPerToken, 1e-15)
-	assert.InDelta(t, 1e-6, data["deepseek-v4-pro"].InputCostPerToken, 1e-15, "cached map stays pre-tax")
-
-	glm := svc.GetModelPricing("glm-5.2")
-	require.NotNil(t, glm)
-	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(8)*tkOfficialListBaseTaxMultiplier, glm.InputCostPerToken, 1e-15,
-		"manifest-listed GLM uses BigModel overlay, not litellm mirror")
-	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(28)*tkOfficialListBaseTaxMultiplier, glm.OutputCostPerToken, 1e-15)
-	assert.InDelta(t, tkCNYPerMTokToUSDPerToken(8), data["glm-5.2"].InputCostPerToken, 1e-15,
-		"parsePricingData overlay replaces litellm glm row with BigModel pre-tax rate")
-
-	moonshot := svc.GetModelPricing("moonshot-tax-test")
-	require.NotNil(t, moonshot)
-	assert.InDelta(t, 5e-6*tkOfficialListBaseTaxMultiplier, moonshot.InputCostPerToken, 1e-15)
-	assert.InDelta(t, 6e-6*tkOfficialListBaseTaxMultiplier, moonshot.OutputCostPerToken, 1e-15)
-	assert.InDelta(t, 5e-6, data["moonshot-tax-test"].InputCostPerToken, 1e-15,
-		"cached Moonshot price stays pre-tax")
+func sampleModelForTaxRule(t *testing.T, rule tkOfficialListBaseTaxRule) string {
+	t.Helper()
+	if len(rule.ModelPrefixes) > 0 {
+		return rule.ModelPrefixes[0] + "tax-policy-probe"
+	}
+	require.NotEmpty(t, rule.ModelContains)
+	return "tax-policy-" + rule.ModelContains[0] + "-probe"
 }
 
-func TestBillingFallback_MoonshotModelNamesApplyBaseTax(t *testing.T) {
+func TestPricingService_GetModelPricing_AppliesBaseTaxOnLookup(t *testing.T) {
+	policy := loadTkOfficialListBaseTaxPolicy()
+	data := make(map[string]*LiteLLMModelPricing, len(policy.Rules))
+	for _, rule := range policy.Rules {
+		model := sampleModelForTaxRule(t, rule)
+		data[model] = &LiteLLMModelPricing{
+			LiteLLMProvider:    rule.Provider,
+			InputCostPerToken:  1e-6,
+			OutputCostPerToken: 2e-6,
+		}
+	}
+	svc := &PricingService{pricingData: data}
+
+	for _, rule := range policy.Rules {
+		model := sampleModelForTaxRule(t, rule)
+		got := svc.GetModelPricing(model)
+		require.NotNil(t, got, rule.Provider)
+		assert.InDelta(t, 1e-6*policy.Multiplier, got.InputCostPerToken, 1e-15, rule.Provider)
+		assert.InDelta(t, 2e-6*policy.Multiplier, got.OutputCostPerToken, 1e-15, rule.Provider)
+		assert.InDelta(t, 1e-6, data[model].InputCostPerToken, 1e-15, rule.Provider+" cached map stays pre-tax")
+	}
+}
+
+func TestBillingFallback_ConfiguredModelMatchersApplyBaseTax(t *testing.T) {
 	base := &ModelPricing{InputPricePerToken: 1e-6, OutputPricePerToken: 2e-6}
-	for _, model := range []string{"kimi-k2.6", "moonshot-v1-128k"} {
+	policy := loadTkOfficialListBaseTaxPolicy()
+	for _, rule := range policy.Rules {
+		model := sampleModelForTaxRule(t, rule)
 		taxed := tkApplyOfficialListBaseTaxForModel(model, base)
 		require.NotSame(t, base, taxed, model)
-		assert.InDelta(t, 1e-6*tkOfficialListBaseTaxMultiplier, taxed.InputPricePerToken, 1e-15, model)
-		assert.InDelta(t, 2e-6*tkOfficialListBaseTaxMultiplier, taxed.OutputPricePerToken, 1e-15, model)
+		assert.InDelta(t, 1e-6*policy.Multiplier, taxed.InputPricePerToken, 1e-15, model)
+		assert.InDelta(t, 2e-6*policy.Multiplier, taxed.OutputPricePerToken, 1e-15, model)
 	}
 }

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1,8 +1,49 @@
 {
   "_meta": {
-    "note": "TK-owned pricing overlay for models the runtime price source lacks. Merged into PricingService AFTER any source load (Wei-Shaw remote OR disk fallback); an entry below applies when the source key is ABSENT or the source entry is EFFECTIVELY UNPRICED (every cost field 0.0 — litellm's 'unknown', not 'free'; see tkIsEffectivelyUnpriced). Entries store pre-tax official list prices; billing and public /pricing apply tkOfficialListBaseTaxMultiplier (1.06) at resolution time for deepseek, dashscope, moonshot, volcengine, and zhipu so display matches charge. Channel (DB) pricing overrides sit above this layer and are never re-taxed. The Wei-Shaw runtime mirror is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries, so imagen-*/veo-* resolve to nothing there; litellm itself also lags new provider models (deepseek-v4-*) or carries them as zero placeholders (deepseek-v3-2-251201), which then bill $0. Media price = vertex_ai provider (TK media flow routes through Vertex ch41); falls back to gemini only when no vertex variant exists. Text price = provider official list price. Self-deprecating: the day the source carries a real (non-zero) price under the bare key, the source value wins and the entry below is ignored. The overlay cannot CORRECT wrong NON-ZERO source prices (deepseek-chat/reasoner still carry the pre-V4 rate in the mirror) — use channel pricing (DB) for that. Video entries MUST declare failure_billing (currently only 'success_only' is legal): TokenKey refunds the user in full when a video task ends failed, which is only loss-free if the provider does not charge for failed tasks — the person pricing a new video model verifies that on the official page and declares it here; scripts/checks/pricing-overlay.py enforces the field, and any other value must first change the refund design.",
+    "note": "TK-owned pricing overlay for models the runtime price source lacks. Merged into PricingService AFTER any source load (Wei-Shaw remote OR disk fallback); an entry below applies when the source key is ABSENT or the source entry is EFFECTIVELY UNPRICED (every cost field 0.0 — litellm's 'unknown', not 'free'; see tkIsEffectivelyUnpriced). Entries store pre-tax official list prices; billing and public /pricing apply the executable _config.official_list_base_tax policy at resolution time (provider, fallback matchers, and multiplier are data-owned) so display matches charge. Channel (DB) pricing overrides sit above this layer and are never re-taxed. The Wei-Shaw runtime mirror is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries, so imagen-*/veo-* resolve to nothing there; litellm itself also lags new provider models (deepseek-v4-*) or carries them as zero placeholders (deepseek-v3-2-251201), which then bill $0. Media price = vertex_ai provider (TK media flow routes through Vertex ch41); falls back to gemini only when no vertex variant exists. Text price = provider official list price. Self-deprecating: the day the source carries a real (non-zero) price under the bare key, the source value wins and the entry below is ignored. The overlay cannot CORRECT wrong NON-ZERO source prices (deepseek-chat/reasoner still carry the pre-V4 rate in the mirror) — use channel pricing (DB) for that. Video entries MUST declare failure_billing (currently only 'success_only' is legal): TokenKey refunds the user in full when a video task ends failed, which is only loss-free if the provider does not charge for failed tasks — the person pricing a new video model verifies that on the official page and declares it here; scripts/checks/pricing-overlay.py enforces the field, and any other value must first change the refund design.",
     "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); Moonshot/Kimi account 83: official China model pages under https://platform.kimi.com/docs/pricing/, captured 2026-07-20, CNY/USD=6.7; moonshot-v1-auto intentionally uses the fixed 128K V1 rate because the alias may select the highest tier; volcengine doubao-*/deepseek-v3-2-251201: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=6.7); GLM text rows: PRICING SOURCE ONLY = BigModel official pricing page https://bigmodel.cn/pricing, captured 2026-07-09, CNY/USD=6.7; SERVING for manifest-listed GLM remains the configured Alibaba DashScope/Qwen pool (channel_type=17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct; qwen3.7-max* / qwen3.7-plus / qwen3.6-flash / qwen3-coder-plus / qwen-max / qwen-plus: Alibaba DashScope China-mainland (Beijing) RMB list ÷ 6.7, docs/evidence/pricing/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source; the qwen3.7-* / qwen3.6-flash / qwen3-coder-plus values were corrected 2026-06-13 from a prior USD-list basis ≈÷7.27 to the table's canonical CNY/USD=6.7); qwen2.5-coder-32b/7b: retired & absent from current Alibaba list — proxy-filled from lineage successors qwen3-coder-plus / qwen3-coder-flash, Beijing RMB list ÷ 6.7, docs/evidence/pricing/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source); seedream/seedance media: VolcEngine Ark official model-pricing page (https://www.volcengine.com/docs/82379/1099320), captured 2026-06-12/2026-07-02, CNY/USD=6.7 — per-image flat price; per-second video price derived at each model's max supported tier (1080p@24fps; 2.0-fast 720p), online standard rate, derivation formula in per-entry source; only IDs present in the live configured Ark account and priced from official sources are served — seedream-4.5/5.0 need separate 2K activation probes/pricing before serving, seedance-1.0-lite and wan2.1 returned unsupported on 2026-07-02; video failure_billing evidence: seedance entries carry the verified official Ark wording (success-only, captured 2026-06-12); veo entries are metric-inferred (billed per generated output second) with the official Google sentence still pending capture",
     "regen": "manual curation; no auto-sync (entries are few + slow-moving). If they proliferate, add provider-aware sync."
+  },
+  "_config": {
+    "official_list_base_tax": {
+      "multiplier": 1.06,
+      "rules": [
+        {
+          "provider": "deepseek",
+          "model_contains": [
+            "deepseek"
+          ]
+        },
+        {
+          "provider": "dashscope",
+          "model_prefixes": [
+            "qwen"
+          ]
+        },
+        {
+          "provider": "moonshot",
+          "model_prefixes": [
+            "kimi-",
+            "kimi/",
+            "moonshot-"
+          ]
+        },
+        {
+          "provider": "volcengine",
+          "model_prefixes": [
+            "doubao",
+            "seedream",
+            "seedance"
+          ]
+        },
+        {
+          "provider": "zhipu",
+          "model_prefixes": [
+            "glm"
+          ]
+        }
+      ]
+    }
   },
   "grok-imagine-image": {
     "litellm_provider": "xai",
@@ -1340,7 +1381,7 @@
         "cache_read_input_token_cost": 2.9850746268656716e-07
       }
     ],
-    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09: GLM-5.1 input tiers 0-32K ¥6/Mtok, 32K+ ¥8/Mtok; output ¥24/¥28; cache-hit ¥1.3/¥2. CNY/USD=6.7; pre-tax overlay, zhipu base-tax 1.06 applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct. Whole-request input-tier via overlay intervals. Cache storage is listed as limited-time free."
+    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09: GLM-5.1 input tiers 0-32K ¥6/Mtok, 32K+ ¥8/Mtok; output ¥24/¥28; cache-hit ¥1.3/¥2. CNY/USD=6.7; pre-tax overlay, overlay official_list_base_tax policy applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct. Whole-request input-tier via overlay intervals. Cache storage is listed as limited-time free."
   },
   "glm-5": {
     "litellm_provider": "zhipu",
@@ -1364,7 +1405,7 @@
         "cache_read_input_token_cost": 2.2388059701492537e-07
       }
     ],
-    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09: GLM-5 input tiers 0-32K ¥4/Mtok, 32K+ ¥6/Mtok; output ¥18/¥22; cache-hit ¥1/¥1.5. CNY/USD=6.7; pre-tax overlay, zhipu base-tax 1.06 applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct. Whole-request input-tier via overlay intervals. Cache storage is listed as limited-time free."
+    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09: GLM-5 input tiers 0-32K ¥4/Mtok, 32K+ ¥6/Mtok; output ¥18/¥22; cache-hit ¥1/¥1.5. CNY/USD=6.7; pre-tax overlay, overlay official_list_base_tax policy applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct. Whole-request input-tier via overlay intervals. Cache storage is listed as limited-time free."
   },
   "glm-5-turbo": {
     "litellm_provider": "zhipu",
@@ -1388,7 +1429,7 @@
         "cache_read_input_token_cost": 2.6865671641791046e-07
       }
     ],
-    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09: GLM-5-Turbo input tiers 0-32K ¥5/Mtok, 32K+ ¥7/Mtok; output ¥22/¥26; cache-hit ¥1.2/¥1.8. CNY/USD=6.7; pre-tax overlay, zhipu base-tax 1.06 applies at resolution/catalog time. Whole-request input-tier via overlay intervals. Cache storage is listed as limited-time free. Pricing source only; no current manifest serving path after GLM direct account/group removal. If served later, serving must be separately mapped through the DashScope/Qwen path unless explicitly approved otherwise."
+    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09: GLM-5-Turbo input tiers 0-32K ¥5/Mtok, 32K+ ¥7/Mtok; output ¥22/¥26; cache-hit ¥1.2/¥1.8. CNY/USD=6.7; pre-tax overlay, overlay official_list_base_tax policy applies at resolution/catalog time. Whole-request input-tier via overlay intervals. Cache storage is listed as limited-time free. Pricing source only; no current manifest serving path after GLM direct account/group removal. If served later, serving must be separately mapped through the DashScope/Qwen path unless explicitly approved otherwise."
   },
   "glm-4.7": {
     "litellm_provider": "zhipu",
@@ -1412,7 +1453,7 @@
         "cache_read_input_token_cost": 1.1940298507462686e-07
       }
     ],
-    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09: GLM-4.7 has a short-output 0-32K row (¥2/M input, ¥8/M output, ¥0.4/M cache-hit) and a 0-32K output>0.2K row (¥3/M input, ¥14/M output, ¥0.6/M cache-hit). TK tiers only by input length, so the 0-32K tier uses the higher reachable output>0.2K row to avoid under-billing; 32K+ uses ¥4/M input, ¥16/M output, ¥0.8/M cache-hit. CNY/USD=6.7; pre-tax overlay, zhipu base-tax 1.06 applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct. Cache storage is listed as limited-time free."
+    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09: GLM-4.7 has a short-output 0-32K row (¥2/M input, ¥8/M output, ¥0.4/M cache-hit) and a 0-32K output>0.2K row (¥3/M input, ¥14/M output, ¥0.6/M cache-hit). TK tiers only by input length, so the 0-32K tier uses the higher reachable output>0.2K row to avoid under-billing; 32K+ uses ¥4/M input, ¥16/M output, ¥0.8/M cache-hit. CNY/USD=6.7; pre-tax overlay, overlay official_list_base_tax policy applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct. Cache storage is listed as limited-time free."
   },
   "glm-4.7-flashx": {
     "litellm_provider": "zhipu",
@@ -1444,7 +1485,7 @@
         "cache_read_input_token_cost": 1.1940298507462686e-07
       }
     ],
-    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09 no longer lists a separate GLM-4.6 text row. Priced to the current GLM-4.7 paid ladder so legacy glm-4.6 traffic does not retain the old USD-source rate or bill below the current GLM public paid tier. CNY/USD=6.7; pre-tax overlay, zhipu base-tax 1.06 applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct."
+    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09 no longer lists a separate GLM-4.6 text row. Priced to the current GLM-4.7 paid ladder so legacy glm-4.6 traffic does not retain the old USD-source rate or bill below the current GLM public paid tier. CNY/USD=6.7; pre-tax overlay, overlay official_list_base_tax policy applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct."
   },
   "glm-4.5": {
     "litellm_provider": "zhipu",
@@ -1468,7 +1509,7 @@
         "cache_read_input_token_cost": 1.1940298507462686e-07
       }
     ],
-    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09 no longer lists a separate GLM-4.5 text row. Priced to the current GLM-4.7 paid ladder so legacy glm-4.5 traffic does not retain the old USD-source rate or bill below the current GLM public paid tier. CNY/USD=6.7; pre-tax overlay, zhipu base-tax 1.06 applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct."
+    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09 no longer lists a separate GLM-4.5 text row. Priced to the current GLM-4.7 paid ladder so legacy glm-4.5 traffic does not retain the old USD-source rate or bill below the current GLM public paid tier. CNY/USD=6.7; pre-tax overlay, overlay official_list_base_tax policy applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct."
   },
   "glm-4.5-air": {
     "litellm_provider": "zhipu",
@@ -1492,7 +1533,7 @@
         "cache_read_input_token_cost": 3.582089552238805e-08
       }
     ],
-    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09: GLM-4.5-Air has a short-output 0-32K row (¥0.8/M input, ¥2/M output, ¥0.16/M cache-hit) and a 0-32K output>0.2K row (¥0.8/M input, ¥6/M output, ¥0.16/M cache-hit). TK tiers only by input length, so the 0-32K tier uses the higher reachable output>0.2K row to avoid under-billing; 32K+ uses ¥1.2/M input, ¥8/M output, ¥0.24/M cache-hit. CNY/USD=6.7; pre-tax overlay, zhipu base-tax 1.06 applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct. Cache storage is listed as limited-time free."
+    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-07-09: GLM-4.5-Air has a short-output 0-32K row (¥0.8/M input, ¥2/M output, ¥0.16/M cache-hit) and a 0-32K output>0.2K row (¥0.8/M input, ¥6/M output, ¥0.16/M cache-hit). TK tiers only by input length, so the 0-32K tier uses the higher reachable output>0.2K row to avoid under-billing; 32K+ uses ¥1.2/M input, ¥8/M output, ¥0.24/M cache-hit. CNY/USD=6.7; pre-tax overlay, overlay official_list_base_tax policy applies at resolution/catalog time. Pricing source only: serving remains the configured Alibaba DashScope/Qwen pool (ch17; account membership is runtime DB/config, not pricing truth), not BigModel/Zhipu direct. Cache storage is listed as limited-time free."
   },
   "gpt-5.6-sol": {
     "litellm_provider": "openai",

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -722,7 +722,7 @@
       "price_source": "overlay",
       "price_key": "glm-5.2",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, zhipu base-tax 1.06 applies at resolution/catalog time)."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time)."
     },
     "newapi/glm-5.1": {
       "platform": "newapi",
@@ -735,7 +735,7 @@
       "price_source": "overlay",
       "price_key": "glm-5.1",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, zhipu base-tax 1.06 applies at resolution/catalog time)."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time)."
     },
     "newapi/glm-5": {
       "platform": "newapi",
@@ -748,7 +748,7 @@
       "price_source": "overlay",
       "price_key": "glm-5",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, zhipu base-tax 1.06 applies at resolution/catalog time)."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time)."
     },
     "newapi/glm-4.7": {
       "platform": "newapi",
@@ -761,7 +761,7 @@
       "price_source": "overlay",
       "price_key": "glm-4.7",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, zhipu base-tax 1.06 applies at resolution/catalog time)."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time)."
     },
     "newapi/glm-4.6": {
       "platform": "newapi",
@@ -774,7 +774,7 @@
       "price_source": "overlay",
       "price_key": "glm-4.6",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; current page does not list a separate GLM-4.6 text row, so legacy traffic is priced to the current GLM-4.7 paid ladder; CNY/USD=6.7, zhipu base-tax 1.06 applies at resolution/catalog time)."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; current page does not list a separate GLM-4.6 text row, so legacy traffic is priced to the current GLM-4.7 paid ladder; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time)."
     },
     "newapi/glm-4.5": {
       "platform": "newapi",
@@ -787,7 +787,7 @@
       "price_source": "overlay",
       "price_key": "glm-4.5",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; current page does not list a separate GLM-4.5 text row, so legacy traffic is priced to the current GLM-4.7 paid ladder; CNY/USD=6.7, zhipu base-tax 1.06 applies at resolution/catalog time). Excludes free glm-4.5-flash so no zero-price model becomes visible."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; current page does not list a separate GLM-4.5 text row, so legacy traffic is priced to the current GLM-4.7 paid ladder; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Excludes free glm-4.5-flash so no zero-price model becomes visible."
     },
     "newapi/glm-4.5-air": {
       "platform": "newapi",
@@ -800,7 +800,7 @@
       "price_source": "overlay",
       "price_key": "glm-4.5-air",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, zhipu base-tax 1.06 applies at resolution/catalog time)."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time)."
     }
   }
 }

--- a/ops/pricing/manage-overlay-runtime.py
+++ b/ops/pricing/manage-overlay-runtime.py
@@ -64,8 +64,8 @@ def fail(msg: str) -> NoReturn:
 # --- pure drift logic (selftest-covered, no I/O) ------------------------------
 
 def overlay_entries(doc: dict) -> dict:
-    """Drop provenance keys ("_meta"/"_doc"/...) — only real model entries."""
-    return {k: v for k, v in doc.items() if not k.startswith("_")}
+    """Return runtime-owned model rows plus executable config; drop provenance."""
+    return {k: v for k, v in doc.items() if not k.startswith("_") or k == "_config"}
 
 
 def _canon(entry) -> str:
@@ -250,20 +250,30 @@ def cmd_sync_runtime(args) -> int:
 def cmd_selftest(_args) -> int:
     repo = {
         "_meta": {"note": "provenance"},
+        "_config": {"official_list_base_tax": {"multiplier": 1.06, "rules": [
+            {"provider": "dashscope", "model_prefixes": ["qwen"]},
+        ]}},
         "qwen3-8b": {"input_cost_per_token": 1.0, "litellm_provider": "dashscope"},
         "qwen3-32b": {"input_cost_per_token": 2.0, "litellm_provider": "dashscope"},
         "qwen3-235b-a22b": {"input_cost_per_token": 3.0, "litellm_provider": "dashscope"},
     }
     cases = [
-        ("clean", repo, {"qwen3-8b": repo["qwen3-8b"], "qwen3-32b": repo["qwen3-32b"],
+        ("clean", repo, {"_config": repo["_config"], "qwen3-8b": repo["qwen3-8b"], "qwen3-32b": repo["qwen3-32b"],
                          "qwen3-235b-a22b": repo["qwen3-235b-a22b"]},
          {"pending": [], "shadow": [], "orphan": []}),
         ("pending", repo, {"qwen3-8b": repo["qwen3-8b"]},
-         {"pending": ["qwen3-235b-a22b", "qwen3-32b"], "shadow": [], "orphan": []}),
+         {"pending": ["_config", "qwen3-235b-a22b", "qwen3-32b"], "shadow": [], "orphan": []}),
         ("shadow", repo,
-         {"qwen3-8b": {"input_cost_per_token": 9.9, "litellm_provider": "dashscope"},
+         {"_config": repo["_config"],
+          "qwen3-8b": {"input_cost_per_token": 9.9, "litellm_provider": "dashscope"},
           "qwen3-32b": repo["qwen3-32b"], "qwen3-235b-a22b": repo["qwen3-235b-a22b"]},
          {"pending": [], "shadow": ["qwen3-8b"], "orphan": []}),
+        ("config-shadow", repo,
+         {**{k: v for k, v in overlay_entries(repo).items()},
+          "_config": {"official_list_base_tax": {"multiplier": 1.07, "rules": [
+              {"provider": "dashscope", "model_prefixes": ["qwen"]},
+          ]}}},
+         {"pending": [], "shadow": ["_config"], "orphan": []}),
         ("orphan", repo,
          {**{k: v for k, v in overlay_entries(repo).items()},
           "ghost-model": {"input_cost_per_token": 1.0}},

--- a/ops/pricing/manage-overlay-runtime.py
+++ b/ops/pricing/manage-overlay-runtime.py
@@ -55,6 +55,11 @@ _ssm_spec = importlib.util.spec_from_file_location(
 _SSM = importlib.util.module_from_spec(_ssm_spec)
 _ssm_spec.loader.exec_module(_SSM)
 
+_gate_spec = importlib.util.spec_from_file_location(
+    "tk_pricing_overlay_gate", OVERLAY_GATE)
+_OVERLAY_GATE = importlib.util.module_from_spec(_gate_spec)
+_gate_spec.loader.exec_module(_OVERLAY_GATE)
+
 
 def fail(msg: str) -> NoReturn:
     print(f"ERROR: {msg}", file=sys.stderr)
@@ -141,6 +146,27 @@ def load_repo_overlay(path: Path = OVERLAY_PATH) -> dict:
         fail(f"cannot read repo overlay {path}: {e}")
 
 
+def runtime_config_errors(doc: dict, embedded: dict | None = None) -> list[str]:
+    """Validate executable config when present; legacy rollback docs may omit it."""
+    if "_config" not in doc:
+        return []
+    errors = _OVERLAY_GATE.validate_official_list_base_tax(doc)
+    if errors:
+        return errors
+    if embedded is None:
+        embedded = load_repo_overlay()
+    embedded_policy = embedded["_config"]["official_list_base_tax"]
+    runtime_policy = doc["_config"]["official_list_base_tax"]
+    embedded_providers = {rule["provider"] for rule in embedded_policy["rules"]}
+    runtime_providers = {rule["provider"] for rule in runtime_policy["rules"]}
+    missing = sorted(embedded_providers - runtime_providers)
+    if missing:
+        errors.append(
+            "runtime official_list_base_tax drops embedded providers: " + ", ".join(missing)
+        )
+    return errors
+
+
 # --- subcommands --------------------------------------------------------------
 
 def cmd_check(_args) -> int:
@@ -180,6 +206,9 @@ def cmd_sync_runtime(args) -> int:
     doc = json.loads(overlay_bytes)
     if not overlay_entries(doc):
         fail("repo overlay has no model entries; refusing to push")
+    config_errors = runtime_config_errors(doc)
+    if config_errors:
+        fail("runtime overlay executable config is invalid: " + "; ".join(config_errors))
 
     if args.dry_run:
         print(f"DRY-RUN: would UPSERT settings[{SETTING_KEY}] on prod "
@@ -302,6 +331,24 @@ def cmd_selftest(_args) -> int:
     except AssertionError:
         ok = False
         print("  FAIL decode-runtime-value gzip read-back round-trip")
+    try:
+        legacy = {"qwen3-8b": repo["qwen3-8b"]}
+        assert runtime_config_errors(legacy, repo) == []
+        invalid = {**legacy, "_config": {"official_list_base_tax": {
+            "multiplier": 0.99,
+            "rules": [{"provider": "dashscope", "model_prefixes": ["qwen"]}],
+        }}}
+        assert runtime_config_errors(invalid, repo)
+        dropped = json.loads(json.dumps(repo))
+        dropped["_config"]["official_list_base_tax"]["rules"] = [
+            {"provider": "moonshot", "model_prefixes": ["kimi-"]},
+        ]
+        assert "drops embedded providers" in runtime_config_errors(dropped, repo)[0]
+        assert runtime_config_errors(repo, repo) == []
+        print("  PASS optional executable config validation")
+    except AssertionError:
+        ok = False
+        print("  FAIL optional executable config validation")
     print("selftest ok" if ok else "selftest FAILED")
     return 0 if ok else 1
 

--- a/scripts/checks/pricing-overlay.py
+++ b/scripts/checks/pricing-overlay.py
@@ -25,6 +25,8 @@ a soft rule that bit us once becomes a mechanical gate). It asserts:
        image_generation -> output_cost_per_image
        video_generation -> output_cost_per_second
        chat             -> input_cost_per_token AND output_cost_per_token
+  4. `_config.official_list_base_tax` is a valid executable policy: one bounded
+     multiplier, unique normalized providers, and non-duplicated fallback matchers.
 
 Usage: python3 scripts/checks/pricing-overlay.py [--quiet]
 Exit 0 ok, 1 violation, 2 missing dep / file / unparseable.
@@ -34,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import pathlib
 import sys
 
@@ -64,6 +67,72 @@ ANCHORS = {
 THINKING_ANCHORS = ("qwen3-8b", "qwen3-14b", "qwen3-32b")
 
 
+def validate_official_list_base_tax(data: dict) -> list[str]:
+    errors: list[str] = []
+    config = data.get("_config")
+    if not isinstance(config, dict):
+        return ["_config must be an object"]
+    unknown_config = sorted(set(config) - {"official_list_base_tax"})
+    if unknown_config:
+        errors.append(f"_config has unknown fields: {unknown_config}")
+    policy = config.get("official_list_base_tax")
+    if not isinstance(policy, dict):
+        return errors + ["_config.official_list_base_tax must be an object"]
+    unknown_policy = sorted(set(policy) - {"multiplier", "rules"})
+    if unknown_policy:
+        errors.append(f"official_list_base_tax has unknown fields: {unknown_policy}")
+    multiplier = policy.get("multiplier")
+    if (not isinstance(multiplier, (int, float)) or isinstance(multiplier, bool)
+            or not math.isfinite(multiplier) or multiplier < 1 or multiplier > 2):
+        errors.append(f"official_list_base_tax.multiplier must be within [1,2], got {multiplier!r}")
+    rules = policy.get("rules")
+    if not isinstance(rules, list) or not rules:
+        return errors + ["official_list_base_tax.rules must be a non-empty array"]
+
+    providers: set[str] = set()
+    matchers: dict[tuple[str, str], str] = {}
+    allowed_rule_fields = {"provider", "model_prefixes", "model_contains"}
+    for idx, rule in enumerate(rules):
+        label = f"official_list_base_tax.rules[{idx}]"
+        if not isinstance(rule, dict):
+            errors.append(f"{label} must be an object")
+            continue
+        unknown = sorted(set(rule) - allowed_rule_fields)
+        if unknown:
+            errors.append(f"{label} has unknown fields: {unknown}")
+        provider = rule.get("provider")
+        if not isinstance(provider, str) or not provider or provider != provider.strip().lower():
+            errors.append(f"{label}.provider must be normalized lowercase")
+            continue
+        if provider in providers:
+            errors.append(f"official_list_base_tax provider {provider!r} is duplicated")
+        providers.add(provider)
+        prefixes = rule.get("model_prefixes", [])
+        contains = rule.get("model_contains", [])
+        if not prefixes and not contains:
+            errors.append(f"official_list_base_tax provider {provider!r} requires a fallback matcher")
+        for kind, values in (("prefix", prefixes), ("contains", contains)):
+            if not isinstance(values, list):
+                errors.append(f"{label}.model_{kind} values must be an array")
+                continue
+            seen: set[str] = set()
+            for value in values:
+                if not isinstance(value, str) or not value or value != value.strip().lower():
+                    errors.append(f"{label} has invalid {kind} matcher {value!r}")
+                    continue
+                if value in seen:
+                    errors.append(f"{label} duplicates {kind} matcher {value!r}")
+                seen.add(value)
+                key = (kind, value)
+                if key in matchers:
+                    errors.append(
+                        f"official_list_base_tax {kind} matcher {value!r} belongs to both "
+                        f"{matchers[key]!r} and {provider!r}"
+                    )
+                matchers[key] = provider
+    return errors
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--quiet", action="store_true", help="suppress success output")
@@ -87,7 +156,7 @@ def main() -> int:
     # Entries are bare model -> pricing dict; keys starting with "_" (e.g. _meta) are
     # provenance, not pricing.
     entries = {k: v for k, v in data.items() if not k.startswith("_")}
-    errors: list[str] = []
+    errors: list[str] = validate_official_list_base_tax(data)
 
     if not entries:
         errors.append("overlay has zero pricing entries")

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -264,7 +264,6 @@
     {
       "path": "backend/internal/service/pricing_service_tk_overlay.go",
       "must_contain": [
-        "func parseTKOverlayBytes",
         "func parseTKOverlayDocument",
         "func buildTKPricingOverlaySnapshot",
         "func validateRuntimeBaseTaxCoverage",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -281,9 +281,11 @@
       "must_contain": [
         "k == \"_config\"",
         "config-shadow",
-        "compute_overlay_drift"
+        "compute_overlay_drift",
+        "config_errors = runtime_config_errors(doc)",
+        "runtime official_list_base_tax drops embedded providers"
       ],
-      "rationale": "Runtime drift and sync must treat executable _config as owned state while continuing to ignore _meta provenance. Otherwise tax changes could be filtered out of pending/shadow checks even though model price hot-pushes remain visible."
+      "rationale": "Runtime drift and sync must treat executable _config as owned state while continuing to ignore _meta provenance. Before any prod UPSERT, a custom --overlay-path must reuse the executable policy validator and retain every embedded provider; otherwise the tool can report byte-level sync success while all replicas reject the snapshot and keep last-known-good."
     },
     {
       "path": "backend/internal/service/pricing_service_tk_overlay_runtime.go",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -139,23 +139,40 @@
     {
       "path": "backend/internal/service/pricing_tk_base_tax.go",
       "must_contain": [
-        "var tkOfficialListBaseTaxRules",
-        "{provider: \"moonshot\", modelPrefixes: []string{\"kimi-\", \"kimi/\", \"moonshot-\"}}",
-        "for _, rule := range tkOfficialListBaseTaxRules",
-        "tkLitellmProviderHasBaseTax(tkInferBaseTaxProvider(model))"
+        "func loadTkOfficialListBaseTaxPolicy",
+        "loadTKPricingOverlaySnapshot()",
+        "func tkBaseTaxMultiplierForProvider",
+        "func (p tkOfficialListBaseTaxPolicy) inferProvider",
+        "policy.multiplierForProvider(policy.inferProvider(model))",
+        "for _, rule := range p.Rules",
+        "tkApplyBaseTaxToModelPricingClone(pricing, multiplier)"
       ],
-      "rationale": "Single owner for the 1.06 official-list base-tax provider eligibility and bare-model fallback classification. Overlay/litellm billing and public /pricing classify by provider/vendor through tkLitellmProviderHasBaseTax; hardcoded fallback classifies a bare requested model through tkInferBaseTaxProvider and then the same eligibility helper. Both helpers must derive from tkOfficialListBaseTaxRules so adding a CN provider such as Moonshot cannot update display tax while silently leaving fallback billing untaxed (or vice versa). Channel DB pricing remains outside this mechanism and is never re-taxed."
+      "rationale": "Interpreter for the data-owned official-list base-tax policy. Provider/vendor eligibility, multiplier, and bare-model fallback classification must all read the same immutable overlay snapshot; no provider/rate table may return to Go. Billing, public /pricing, and family fallback therefore change together on a validated runtime hot swap. Channel DB pricing remains outside this mechanism and is never re-taxed."
+    },
+    {
+      "path": "backend/internal/service/tk_pricing_overlay.json",
+      "must_contain": [
+        "\"official_list_base_tax\"",
+        "\"multiplier\": 1.06",
+        "\"provider\": \"deepseek\"",
+        "\"provider\": \"dashscope\"",
+        "\"provider\": \"moonshot\"",
+        "\"provider\": \"volcengine\"",
+        "\"provider\": \"zhipu\""
+      ],
+      "rationale": "Executable SSOT for all currently taxed official-list providers. The embedded overlay is the compile floor and the same full document is hot-pushed to tk_pricing_overlay_runtime. Pinning all five behavior-preserving provider rows and the multiplier prevents an upstream merge from silently dropping one tax family while model prices continue to parse. New providers are added here, not in Go."
     },
     {
       "path": "backend/internal/service/pricing_tk_base_tax_test.go",
       "must_contain": [
+        "TestTkOfficialListBaseTax_AppliesToTargetProvidersOnly",
+        "for _, rule := range policy.Rules",
+        "for _, prefix := range rule.ModelPrefixes",
+        "for _, fragment := range rule.ModelContains",
         "TestPricingService_GetModelPricing_AppliesBaseTaxOnLookup",
-        "TestBillingFallback_MoonshotModelNamesApplyBaseTax",
-        "moonshot-tax-test",
-        "tkCNYPerMTokToUSDPerToken(8)",
-        "manifest-listed GLM uses BigModel overlay"
+        "TestBillingFallback_ConfiguredModelMatchersApplyBaseTax"
       ],
-      "rationale": "Pins billing/catalog base-tax lookup regression for CN-origin providers, including the GLM authoritative-overlay path and Moonshot's provider plus bare-model fallback paths. GetModelPricing must apply the shared 1.06 rule without mutating cached pre-tax overlay data, and fallback billing must classify kimi-/moonshot- names through the same registry."
+      "rationale": "Pins provider billing, catalog presentation, and bare-model fallback behavior by deriving exhaustive providers and model matchers from the executable overlay policy. Tests retain only independent negative boundaries, so adding a provider or matcher changes the SSOT rather than requiring a second hand-maintained test list."
     },
     {
       "path": "backend/internal/service/pricing_catalog_tk.go",
@@ -171,13 +188,19 @@
       "path": "backend/internal/service/billing_service.go",
       "must_contain": [
         "tkIsEffectivelyUnpriced",
-        "litellmPricing.Intervals",
-        "litellmPricing.ThinkingOutputCostPerToken",
+        "func tkModelPricingFromLiteLLM",
+        "ThinkingOutputPricePerToken:        p.ThinkingOutputCostPerToken",
+        "Intervals:                          p.Intervals",
         "pricing.ThinkingOutputPricePerToken",
         "tkIsFlatPerImageModel(model)",
-        "normalizeOpenAIBillingModel"
+        "normalizeOpenAIBillingModel",
+        "func tkOverlayModelPricing",
+        "loadTKPricingOverlay()[strings.ToLower(strings.TrimSpace(model))]",
+        "tkOverlayModelPricing(\"deepseek-v4-flash\")",
+        "tkOverlayModelPricing(\"glm-5.2\")",
+        "tkOverlayModelPricing(\"kimi-k2.6\")"
       ],
-      "rationale": "BillingService.GetModelPricing carries a 1-line TK hook: a litellm entry whose every cost field is zero (litellm's 'cost unknown' placeholder — e.g. deepseek-v3-2-251201 under volcengine) is treated as pricing-missing instead of a successful $0 lookup, falling through to fallback / ErrModelPricingUnavailable so the existing zero-cost record + Feishu pricing-missing funnel fires. Without this hook, zero-placeholder models silently bill $0 with no alert (683 prod requests leaked through 2026-06-10 before it existed). An upstream merge restructuring GetModelPricing could drop the `&& !tkIsEffectivelyUnpriced(...)` guard without any compile error. The predicate itself lives in pricing_service_tk_overlay.go (shared with the overlay absent-or-zero fill). SECOND hook on the same constructor: GetModelPricing MUST copy `Intervals: litellmPricing.Intervals` onto ModelPricing so overlay interval (tiered) pricing is carried into billing (consumed downstream via ResolvedPricing.Intervals -> GetIntervalPricing); dropping the copy silently flattens every overlay-tiered model to its base-tier price with no compile error. THIRD + FOURTH hooks (Qwen3 dense thinking-mode pricing): GetModelPricing MUST copy `ThinkingOutputPricePerToken: litellmPricing.ThinkingOutputCostPerToken`, and computeTokenBreakdown MUST keep the `pricing.ThinkingOutputPricePerToken` selection that bills output at the thinking rate when enable_thinking is active. Alibaba DashScope qwen3-8b/14b/32b are one model id with two output rates (非思考/思考) switched by enable_thinking, which DEFAULTS to true — so dropping either hook in an upstream merge silently reverts the DEFAULT traffic from the thinking rate (¥5/M for 8b) to the non-thinking rate (¥2/M), under-billing with no compile error. The non-thinking base price + the thinking rate value live in tk_pricing_overlay.json (guarded by scripts/checks/pricing-overlay.py THINKING_ANCHORS); these two needles guard the code path that consumes them. FIFTH hook (Imagen flat pricing): getDefaultImagePrice MUST keep the `tkIsFlatPerImageModel(model)` early-return that bills Imagen at its FLAT official per-image price, BEFORE the 2K→×1.5 / 4K→×2 size-tier multiplier. Imagen requests carry ratio codes (no size) → default 2K → were silently marked up ×1.5 (an upstream-owned multiplier, real only for genuine pixel-size tiers like Seedream). An upstream merge restructuring getDefaultImagePrice could drop this guard with no compile error, silently re-introducing a 50% overcharge on every Imagen image. The predicate lives in billing_service_tk_flat_image.go (separately pinned); this needle guards the call site."
+      "rationale": "BillingService pricing hooks: zero placeholders fall through, interval/thinking/media fields survive conversion, Imagen keeps flat billing, and billing aliases normalize. DeepSeek V4, paid GLM, and Kimi K2.5/K2.6 compatibility branches resolve tkOverlayModelPricing instead of maintaining a second numeric Go fallback table. This deliberately does not make every overlay row a new family fallback; dropping the scoped alias hooks would reintroduce price drift while broadening them would change fail-closed behavior for unrelated models."
     },
     {
       "path": "backend/internal/service/billing_service_tk_flat_image.go",
@@ -201,9 +224,11 @@
       "must_contain": [
         "failure_billing",
         "grok-4.3",
-        "grok-build-0.1"
+        "grok-build-0.1",
+        "def validate_official_list_base_tax",
+        "official_list_base_tax.multiplier must be within [1,2]"
       ],
-      "rationale": "The failure_billing declaration check is the human-judgment anchor of the video pricing workflow: TokenKey refunds users in full on terminal-failed video tasks, which is only loss-free when the provider does not charge for failures — whoever prices a video model must verify and declare that. Dropping this block from the check silently removes the forced verification while overlay entries keep parsing fine. The grok-4.3 / grok-build-0.1 anchors keep xAI's two current chat price roots pinned in the same overlay gate, so a future edit cannot re-create the served-zero-cost grok chat hole while leaving media anchors intact."
+      "rationale": "The overlay gate validates media failure billing, critical price anchors, and executable base-tax policy. Tax config must have a bounded multiplier, unique normalized providers, and valid non-duplicated fallback matchers before either an embedded release or runtime sync can consume it."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_media_unpriced_guard_contract_test.go",
@@ -240,13 +265,26 @@
       "path": "backend/internal/service/pricing_service_tk_overlay.go",
       "must_contain": [
         "func parseTKOverlayBytes",
+        "func parseTKOverlayDocument",
+        "func buildTKPricingOverlaySnapshot",
+        "func validateRuntimeBaseTaxCoverage",
         "func tkOverlayOverridesLitellmSource",
         "func applyTKPricingOverlay",
         "func rebuildTKOverlayUnion",
+        "TokenPricingAbsent:    e.InputCostPerToken == nil && e.OutputCostPerToken == nil",
         "tkOverlayMu",
         "tkOverlayEffective"
       ],
-      "rationale": "The overlay loader was converted from a sync.Once compile-only singleton into a re-runnable, RWMutex-guarded union (embedded ∪ runtime-settings, runtime wins) so a model can be priced WITHOUT a release (the runtime hot-push path). parseTKOverlayBytes is the shared pure parser for both the embedded floor and the runtime settings blob; rebuildTKOverlayUnion atomically swaps the effective map and is the ONLY place that can blank it (it never does — a corrupt runtime blob keeps the embedded floor, the never-serve-$0 invariant). An upstream merge or refactor that reverts this back to a sync.Once singleton (or drops the mutex) would silently re-freeze pricing to compile-time and reintroduce the per-model release dependency this whole change removes. Pinning these symbols makes that revert fail CI instead of going unnoticed."
+      "rationale": "The overlay loader builds one immutable snapshot containing model prices plus executable tax policy. Runtime model rows merge over the embedded floor; runtime policy may add providers or change rates/matchers but must retain every embedded provider. Validation precedes the snapshot swap, so corrupt/partial config keeps last-known-good, while a corrupt first load still establishes the embedded floor. TokenPricingAbsent preserves the fail-closed token-billing boundary when media-only overlay rows are merged into PricingService."
+    },
+    {
+      "path": "ops/pricing/manage-overlay-runtime.py",
+      "must_contain": [
+        "k == \"_config\"",
+        "config-shadow",
+        "compute_overlay_drift"
+      ],
+      "rationale": "Runtime drift and sync must treat executable _config as owned state while continuing to ignore _meta provenance. Otherwise tax changes could be filtered out of pending/shadow checks even though model price hot-pushes remain visible."
     },
     {
       "path": "backend/internal/service/pricing_service_tk_overlay_runtime.go",


### PR DESCRIPTION
## 摘要

- 将 `official_list_base_tax` 的 multiplier、provider 与 bare-model matcher 统一迁入 `tk_pricing_overlay.json::_config`，覆盖 deepseek、dashscope、moonshot、volcengine、zhipu。
- billing、公开 `/pricing` 与 fallback 统一读取同一热更新策略；运行时坏配置保持 last-known-good，首次坏配置仍建立 embedded floor。
- 测试从策略与 manifest 派生完整集合；DeepSeek V4、付费 GLM、Kimi K2.5/K2.6 的兼容 fallback 只保留 alias 映射，价格数值由 overlay 唯一拥有。
- runtime 工具对默认或自定义 overlay 中携带的可执行税策略复用同一 validator，并在写 prod 前拒绝删除 embedded 已知 provider 的配置。

## 设计

- `tk_pricing_overlay.json` 是税前官方价与基础税策略的 owner；`tk_served_models.json` 只声明服务/价格引用意图，`model-surface-bundle.json` 仍是生成的映射投影且不复制定价值。
- runtime `_config` 可热更新 multiplier、matcher 和新增 provider，但不得删除 embedded 已知 provider。模型价格与税策略通过同一 immutable snapshot 发布。
- `manage-overlay-runtime.py` 将 `_config` 纳入 pending/shadow/orphan 对账，并在任何 prod UPSERT 前复用 `pricing-overlay.py` 的策略校验；历史 rollback 文件可省略 `_config` 以继承 embedded 策略。

## 风险

- 高风险计费链路变更；embedded 有效税率保持 `1.06`，渠道 DB 定价仍位于更高优先级且不会重复加税。
- 热更新会同步影响 billing、公开价格与 fallback 分类；通过范围校验、last-known-good、并发测试和 sentinel 防止部分生效。
- sentinel-registry-reviewed：已核对被改测试文件仅更新动态 multiplier 调用或新增 pricing SSOT 行为断言，`pricing-availability.json` 已锚定 owner、解释器、fallback、runtime validator 与生产调用点，无需在 gateway/newapi registry 重复登记。
- Web impact: none。

## 验证

- `go test -tags=unit ./internal/service -count=1`
- `DOCKER_HOST=unix:///Users/feng/.colima/default/docker.sock TESTCONTAINERS_RYUK_DISABLED=true make test-integration`
- `python3 scripts/checks/pricing-overlay.py`
- `python3 ops/pricing/manage-overlay-runtime.py --selftest`
- `python3 scripts/sentinels/check-pricing-availability.py`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

## 提交

- `893a22a79 refactor(pricing): unify tax policy and overlay prices`
- `9b40c744f fix(pricing): remove test-only policy wrappers`
- `9566ec144 fix(pricing): address R-001 runtime policy validation`

最新提交：`9566ec144`