### PR TITLE
fix(kiro): 避免镜像 502 误触发冷却并保留原始错误

### DIFF
--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -115,7 +115,7 @@ func (s *KiroGatewayService) Forward(
 		}
 		return result, err
 	}
-	result, err := s.forwardNonStreaming(ctx, c, doer, kiroAcct, payload, &req, requestID, model, startTime)
+	result, err := s.forwardNonStreaming(ctx, c, account, doer, kiroAcct, payload, &req, requestID, model, startTime)
 	if err == nil {
 		PersistKiroProfileArnIfChanged(ctx, s.accountRepo, account, kiroAcct)
 	}
@@ -127,6 +127,7 @@ func (s *KiroGatewayService) Forward(
 func (s *KiroGatewayService) forwardNonStreaming(
 	ctx context.Context,
 	c *gin.Context,
+	account *Account,
 	doer kiroproto.HTTPDoer,
 	kiroAcct *kiroproto.Account,
 	payload *kiroproto.KiroPayload,
@@ -176,17 +177,17 @@ func (s *KiroGatewayService) forwardNonStreaming(
 	}
 
 	if err := kiroproto.CallKiroAPIWithDoerContext(ctx, doer, kiroAcct, payload, callback); err != nil {
-		return nil, classifyKiroForwardError(err, model)
+		return nil, classifyAndRecordKiroForwardError(c, account, err, model)
 	}
 	if callbackErr != nil {
-		return nil, classifyKiroForwardError(callbackErr, model)
+		return nil, classifyAndRecordKiroForwardError(c, account, callbackErr, model)
 	}
 	if visible, inlineThinking := redactor.Flush(); visible != "" || inlineThinking != "" {
 		textBuf += visible
 		thinkingBuf += inlineThinking
 	}
 	if textBuf == "" && thinkingBuf == "" && len(toolUses) == 0 {
-		return nil, classifyKiroForwardError(errKiroEmptyResponse, model)
+		return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
 	}
 
 	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
@@ -345,7 +346,7 @@ func (s *KiroGatewayService) forwardStreaming(
 	// classifyKiroForwardError maps a recognized HTTP 400 INVALID_MODEL_ID into
 	// a typed *KiroInvalidModelError so the handler can return a clean 400.
 	if callErr != nil && !enc.started {
-		return nil, classifyKiroForwardError(callErr, model)
+		return nil, classifyAndRecordKiroForwardError(c, account, callErr, model)
 	}
 	if callErr != nil {
 		msg := "upstream stream disconnected: " + sanitizeStreamError(callErr)
@@ -354,7 +355,7 @@ func (s *KiroGatewayService) forwardStreaming(
 		return nil, fmt.Errorf("kiro stream read error: %w", callErr)
 	}
 	if callbackErr != nil && !enc.started {
-		return nil, classifyKiroForwardError(callbackErr, model)
+		return nil, classifyAndRecordKiroForwardError(c, account, callbackErr, model)
 	}
 	if callbackErr != nil {
 		msg := "upstream stream disconnected: " + sanitizeStreamError(callbackErr)
@@ -363,7 +364,7 @@ func (s *KiroGatewayService) forwardStreaming(
 		return nil, fmt.Errorf("kiro stream callback error: %w", callbackErr)
 	}
 	if !enc.started && textBuf == "" && thinkingBuf == "" && len(toolUses) == 0 {
-		return nil, classifyKiroForwardError(errKiroEmptyResponse, model)
+		return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
 	}
 
 	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -500,7 +500,7 @@ func TestKiroGatewayService_Forward_EmptyEventStreamExceptionPreservesFailoverCl
 }
 
 func TestClassifyKiroForwardError_EventStreamValidationDoesNotFailover(t *testing.T) {
-	err := classifyKiroForwardError(
+	_, err := classifyKiroForwardError(
 		fmt.Errorf(`kiro event stream error: ValidationException: {"message":"invalid tool schema"}`),
 		"claude-sonnet-4",
 	)
@@ -514,7 +514,7 @@ func TestClassifyKiroForwardError_EventStreamValidationDoesNotFailover(t *testin
 }
 
 func TestClassifyKiroForwardError_EventStreamInputTooLongDoesNotFailover(t *testing.T) {
-	err := classifyKiroForwardError(
+	_, err := classifyKiroForwardError(
 		fmt.Errorf(`kiro event stream error: CONTENT_LENGTH_EXCEEDS_THRESHOLD: {"message":"Your input exceeds the context window of this model. Please adjust your input and try again."}`),
 		"claude-sonnet-4-6",
 	)
@@ -528,7 +528,7 @@ func TestClassifyKiroForwardError_EventStreamInputTooLongDoesNotFailover(t *test
 }
 
 func TestClassifyKiroForwardError_EventStreamProviderExceptionWinsOverInputTooLongText(t *testing.T) {
-	err := classifyKiroForwardError(
+	_, err := classifyKiroForwardError(
 		fmt.Errorf(`kiro event stream error: InternalServerException: {"message":"upstream failed while checking whether input exceeds the context window"}`),
 		"claude-sonnet-4-6",
 	)
@@ -568,7 +568,7 @@ func TestKiroGatewayService_Forward_NonStreaming_InvalidModel(t *testing.T) {
 
 func TestClassifyKiroForwardError(t *testing.T) {
 	// 400 + INVALID_MODEL_ID → typed error.
-	err := classifyKiroForwardError(
+	_, err := classifyKiroForwardError(
 		fmt.Errorf("HTTP 400 from CodeWhisperer: {\"reason\":\"INVALID_MODEL_ID\"}"),
 		"claude-haiku-4.5",
 	)
@@ -577,7 +577,7 @@ func TestClassifyKiroForwardError(t *testing.T) {
 	require.Equal(t, "claude-haiku-4.5", invalidModelErr.Model)
 
 	// 400 without the INVALID_MODEL_ID marker → failover error, NOT typed invalid-model.
-	other := classifyKiroForwardError(
+	_, other := classifyKiroForwardError(
 		fmt.Errorf("HTTP 400 from CodeWhisperer: {\"reason\":\"THROTTLED\"}"),
 		"claude-haiku-4.5",
 	)
@@ -586,7 +586,7 @@ func TestClassifyKiroForwardError(t *testing.T) {
 	require.ErrorAs(t, other, &failoverErr)
 	require.Equal(t, http.StatusBadRequest, failoverErr.StatusCode)
 
-	validation := classifyKiroForwardError(
+	_, validation := classifyKiroForwardError(
 		fmt.Errorf("HTTP 400 from CodeWhisperer: {\"__type\":\"ValidationException\",\"message\":\"invalid tool schema\"}"),
 		"claude-sonnet-4",
 	)
@@ -595,7 +595,7 @@ func TestClassifyKiroForwardError(t *testing.T) {
 	require.Equal(t, "invalid tool schema", invalidRequestErr.ClientMessage())
 	require.NotErrorAs(t, other, &invalidModelErr)
 
-	inputTooLong := classifyKiroForwardError(
+	_, inputTooLong := classifyKiroForwardError(
 		fmt.Errorf("HTTP 400 from CodeWhisperer: {\"reason\":\"CONTENT_LENGTH_EXCEEDS_THRESHOLD\",\"message\":\"Input is too long.\"}"),
 		"claude-sonnet-4-6",
 	)
@@ -605,7 +605,7 @@ func TestClassifyKiroForwardError(t *testing.T) {
 	require.NotErrorAs(t, inputTooLong, &failoverErr)
 
 	// 500 with the marker substring → still not classified as invalid-model.
-	notFourHundred := classifyKiroForwardError(
+	_, notFourHundred := classifyKiroForwardError(
 		fmt.Errorf("HTTP 500 from CodeWhisperer: INVALID_MODEL_ID"),
 		"claude-haiku-4.5",
 	)
@@ -613,7 +613,7 @@ func TestClassifyKiroForwardError(t *testing.T) {
 	require.ErrorAs(t, notFourHundred, &failoverErr)
 	require.Equal(t, http.StatusInternalServerError, failoverErr.StatusCode)
 
-	unauthorized := classifyKiroForwardError(
+	_, unauthorized := classifyKiroForwardError(
 		fmt.Errorf("HTTP 401 from CodeWhisperer: Invalid bearer token"),
 		"claude-sonnet-4",
 	)
@@ -621,7 +621,7 @@ func TestClassifyKiroForwardError(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, failoverErr.StatusCode)
 	require.Equal(t, "Invalid bearer token", string(failoverErr.ResponseBody))
 
-	wrappedUnauthorized := classifyKiroForwardError(
+	_, wrappedUnauthorized := classifyKiroForwardError(
 		fmt.Errorf("resolve profileArn: HTTP 401 from management: Invalid bearer token"),
 		"claude-sonnet-4",
 	)
@@ -629,9 +629,10 @@ func TestClassifyKiroForwardError(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, failoverErr.StatusCode)
 
 	// nil passes through.
-	require.NoError(t, classifyKiroForwardError(nil, "m"))
+	_, nilErr := classifyKiroForwardError(nil, "m")
+	require.NoError(t, nilErr)
 
-	quota := classifyKiroForwardError(fmt.Errorf("quota exhausted on AmazonQ"), "claude-sonnet-4-5")
+	_, quota := classifyKiroForwardError(fmt.Errorf("quota exhausted on AmazonQ"), "claude-sonnet-4-5")
 	var quotaErr *KiroEndpointQuotaExhaustedError
 	require.ErrorAs(t, quota, &quotaErr)
 	require.Equal(t, tkKiroEndpointQuotaExhaustedClient, quotaErr.ClientMessage())

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -237,6 +237,15 @@ func TestKiroGatewayService_Forward_EmptyResponseTriggersFailover(t *testing.T) 
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
 	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	rawEvents, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	events, ok := rawEvents.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.Len(t, events, 1)
+	require.Equal(t, "response_error", events[0].Kind)
+	require.Equal(t, "empty_response", events[0].Reason)
+	require.Equal(t, "kiro upstream returned an empty response", events[0].Message)
+	require.Equal(t, int64(99), events[0].AccountID)
 }
 
 func TestKiroGatewayService_Forward_NonStreaming_ReadFailureRetriesWithoutPartialOutput(t *testing.T) {
@@ -371,6 +380,14 @@ func TestKiroGatewayService_Forward_Streaming_PreContentReadErrorTriggersFailove
 	require.ErrorAs(t, err, &failoverErr)
 	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
 	require.Empty(t, rec.Body.String(), "no SSE bytes may be written before failover")
+	rawEvents, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	events, ok := rawEvents.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.Len(t, events, 1)
+	require.Equal(t, "response_error", events[0].Kind)
+	require.Equal(t, "unexpected_eof", events[0].Reason)
+	require.Equal(t, "unexpected EOF", events[0].Message)
 }
 
 // kiroStatusUpstream returns a canned non-200 response with a fixed body,
@@ -621,19 +638,44 @@ func TestClassifyKiroForwardError(t *testing.T) {
 }
 
 func TestClassifyKiroForwardError_TransportFailureTriggersFailover(t *testing.T) {
-	err := classifyKiroForwardError(fmt.Errorf("dial tcp 10.0.0.1:443: connect: connection refused"), "claude-sonnet-4")
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	account := newKiroAccountForTest()
+	err := classifyAndRecordKiroForwardError(
+		c,
+		account,
+		fmt.Errorf("GET https://q.us-east-1.amazonaws.com/generate?access_token=secret: dial tcp 10.0.0.1:443: connect: connection refused"),
+		"claude-sonnet-4",
+	)
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
 	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
 	require.JSONEq(t, `{"error":{"type":"upstream_error","message":"Upstream request failed"}}`, string(failoverErr.ResponseBody))
+
+	rawEvents, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	events, ok := rawEvents.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.Len(t, events, 1)
+	require.Equal(t, "request_error", events[0].Kind)
+	require.Equal(t, "connection_refused", events[0].Reason)
+	require.Contains(t, events[0].Message, "dial tcp 10.0.0.1:443: connect: connection refused")
+	require.Contains(t, events[0].Message, "access_token=***")
+	require.NotContains(t, events[0].Message, "access_token=secret")
+	require.Equal(t, PlatformKiro, events[0].Platform)
+	require.Equal(t, account.ID, events[0].AccountID)
 }
 
 func TestClassifyKiroForwardError_ContextCanceledDoesNotTriggerFailover(t *testing.T) {
-	err := classifyKiroForwardError(context.Canceled, "claude-sonnet-4")
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	err := classifyAndRecordKiroForwardError(c, newKiroAccountForTest(), context.Canceled, "claude-sonnet-4")
 	var failoverErr *UpstreamFailoverError
 	require.Error(t, err)
 	require.NotErrorAs(t, err, &failoverErr)
 	require.ErrorIs(t, err, context.Canceled)
+	_, recorded := c.Get(OpsUpstreamErrorsKey)
+	require.False(t, recorded, "client cancellation must not be recorded as a Kiro upstream failure")
 }
 
 func TestGatewayService_Forward_Kiro401TriggersRateLimitRefresh(t *testing.T) {

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -109,38 +109,33 @@ func isKiroEndpointQuotaExhaustedError(msg string) bool {
 	return strings.Contains(strings.ToLower(strings.TrimSpace(msg)), "quota exhausted on")
 }
 
-func classifyKiroForwardError(err error, model string) error {
-	classified, _ := classifyKiroForwardErrorWithObservation(err, model)
-	return classified
-}
-
 type kiroForwardErrorObservation struct {
 	Kind   string
 	Reason string
 }
 
 func classifyAndRecordKiroForwardError(c *gin.Context, account *Account, err error, model string) error {
-	classified, observation := classifyKiroForwardErrorWithObservation(err, model)
+	observation, classified := classifyKiroForwardError(err, model)
 	if observation != nil {
 		recordKiroForwardError(c, account, err, *observation)
 	}
 	return classified
 }
 
-func classifyKiroForwardErrorWithObservation(err error, model string) (error, *kiroForwardErrorObservation) {
+func classifyKiroForwardError(err error, model string) (*kiroForwardErrorObservation, error) {
 	if err == nil {
 		return nil, nil
 	}
 	msg := err.Error()
 	if isKiroEndpointQuotaExhaustedError(msg) {
-		return &KiroEndpointQuotaExhaustedError{Body: msg}, nil
+		return nil, &KiroEndpointQuotaExhaustedError{Body: msg}
 	}
 	if isKiroInvalidModelError(msg) {
-		return &KiroInvalidModelError{
+		return nil, &KiroInvalidModelError{
 			StatusCode: 400,
 			Model:      model,
 			Body:       msg,
-		}, nil
+		}
 	}
 	if statusCode, body, ok := parseKiroHTTPError(msg); ok {
 		if statusCode == http.StatusBadRequest && isKiroValidationErrorBody(body) && !isKiroProfileArnError(msg) {
@@ -148,44 +143,44 @@ func classifyKiroForwardErrorWithObservation(err error, model string) (error, *k
 			if message == "" {
 				message = "Kiro rejected the request"
 			}
-			return &KiroInvalidRequestError{StatusCode: statusCode, Message: message, Body: msg}, nil
+			return nil, &KiroInvalidRequestError{StatusCode: statusCode, Message: message, Body: msg}
 		}
-		return &UpstreamFailoverError{
+		return nil, &UpstreamFailoverError{
 			StatusCode:   statusCode,
 			ResponseBody: body,
-		}, nil
+		}
 	}
 	if statusCode, body, ok := parseKiroEventStreamError(msg); ok {
 		if statusCode == http.StatusBadRequest && strings.Contains(strings.ToUpper(msg), "INVALID_MODEL_ID") {
-			return &KiroInvalidModelError{
+			return nil, &KiroInvalidModelError{
 				StatusCode: statusCode,
 				Model:      model,
 				Body:       msg,
-			}, nil
+			}
 		}
 		if statusCode == http.StatusBadRequest && !isKiroProfileArnError(msg) {
 			message := strings.TrimSpace(extractUpstreamErrorMessage(body))
 			if message == "" {
 				message = "Kiro rejected the request"
 			}
-			return &KiroInvalidRequestError{StatusCode: statusCode, Message: message, Body: msg}, nil
+			return nil, &KiroInvalidRequestError{StatusCode: statusCode, Message: message, Body: msg}
 		}
-		return &UpstreamFailoverError{
+		return nil, &UpstreamFailoverError{
 			StatusCode:   statusCode,
 			ResponseBody: body,
-		}, nil
+		}
 	}
 	// A transport failure means this Kiro account/egress could not reach the
 	// upstream at all. Return the same failover shape as other gateway
 	// transports so the handler can try another account instead of immediately
 	// exposing a client-side "connection refused" error.
 	if observation, ok := classifyKiroOpaqueFailure(err); ok {
-		return &UpstreamFailoverError{
+		return &observation, &UpstreamFailoverError{
 			StatusCode:   http.StatusBadGateway,
 			ResponseBody: append([]byte(nil), kiroTransportFailoverBody...),
-		}, &observation
+		}
 	}
-	return fmt.Errorf("kiro upstream call failed: %w", err), nil
+	return nil, fmt.Errorf("kiro upstream call failed: %w", err)
 }
 
 func classifyKiroOpaqueFailure(err error) (kiroForwardErrorObservation, bool) {

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/gin-gonic/gin"
 )
 
 var kiroTransportFailoverBody = []byte(`{"error":{"type":"upstream_error","message":"Upstream request failed"}}`)
@@ -108,19 +110,37 @@ func isKiroEndpointQuotaExhaustedError(msg string) bool {
 }
 
 func classifyKiroForwardError(err error, model string) error {
+	classified, _ := classifyKiroForwardErrorWithObservation(err, model)
+	return classified
+}
+
+type kiroForwardErrorObservation struct {
+	Kind   string
+	Reason string
+}
+
+func classifyAndRecordKiroForwardError(c *gin.Context, account *Account, err error, model string) error {
+	classified, observation := classifyKiroForwardErrorWithObservation(err, model)
+	if observation != nil {
+		recordKiroForwardError(c, account, err, *observation)
+	}
+	return classified
+}
+
+func classifyKiroForwardErrorWithObservation(err error, model string) (error, *kiroForwardErrorObservation) {
 	if err == nil {
-		return nil
+		return nil, nil
 	}
 	msg := err.Error()
 	if isKiroEndpointQuotaExhaustedError(msg) {
-		return &KiroEndpointQuotaExhaustedError{Body: msg}
+		return &KiroEndpointQuotaExhaustedError{Body: msg}, nil
 	}
 	if isKiroInvalidModelError(msg) {
 		return &KiroInvalidModelError{
 			StatusCode: 400,
 			Model:      model,
 			Body:       msg,
-		}
+		}, nil
 	}
 	if statusCode, body, ok := parseKiroHTTPError(msg); ok {
 		if statusCode == http.StatusBadRequest && isKiroValidationErrorBody(body) && !isKiroProfileArnError(msg) {
@@ -128,12 +148,12 @@ func classifyKiroForwardError(err error, model string) error {
 			if message == "" {
 				message = "Kiro rejected the request"
 			}
-			return &KiroInvalidRequestError{StatusCode: statusCode, Message: message, Body: msg}
+			return &KiroInvalidRequestError{StatusCode: statusCode, Message: message, Body: msg}, nil
 		}
 		return &UpstreamFailoverError{
 			StatusCode:   statusCode,
 			ResponseBody: body,
-		}
+		}, nil
 	}
 	if statusCode, body, ok := parseKiroEventStreamError(msg); ok {
 		if statusCode == http.StatusBadRequest && strings.Contains(strings.ToUpper(msg), "INVALID_MODEL_ID") {
@@ -141,37 +161,100 @@ func classifyKiroForwardError(err error, model string) error {
 				StatusCode: statusCode,
 				Model:      model,
 				Body:       msg,
-			}
+			}, nil
 		}
 		if statusCode == http.StatusBadRequest && !isKiroProfileArnError(msg) {
 			message := strings.TrimSpace(extractUpstreamErrorMessage(body))
 			if message == "" {
 				message = "Kiro rejected the request"
 			}
-			return &KiroInvalidRequestError{StatusCode: statusCode, Message: message, Body: msg}
+			return &KiroInvalidRequestError{StatusCode: statusCode, Message: message, Body: msg}, nil
 		}
 		return &UpstreamFailoverError{
 			StatusCode:   statusCode,
 			ResponseBody: body,
-		}
+		}, nil
 	}
 	// A transport failure means this Kiro account/egress could not reach the
 	// upstream at all. Return the same failover shape as other gateway
 	// transports so the handler can try another account instead of immediately
 	// exposing a client-side "connection refused" error.
+	if observation, ok := classifyKiroOpaqueFailure(err); ok {
+		return &UpstreamFailoverError{
+			StatusCode:   http.StatusBadGateway,
+			ResponseBody: append([]byte(nil), kiroTransportFailoverBody...),
+		}, &observation
+	}
+	return fmt.Errorf("kiro upstream call failed: %w", err), nil
+}
+
+func classifyKiroOpaqueFailure(err error) (kiroForwardErrorObservation, bool) {
+	switch {
+	case errors.Is(err, errKiroEmptyResponse):
+		return kiroForwardErrorObservation{Kind: "response_error", Reason: "empty_response"}, true
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		return kiroForwardErrorObservation{Kind: "response_error", Reason: "unexpected_eof"}, true
+	case errors.Is(err, io.EOF):
+		return kiroForwardErrorObservation{Kind: "response_error", Reason: "eof"}, true
+	case errors.Is(err, context.DeadlineExceeded):
+		return kiroForwardErrorObservation{Kind: "request_error", Reason: "deadline_exceeded"}, true
+	case errors.Is(err, syscall.ECONNREFUSED):
+		return kiroForwardErrorObservation{Kind: "request_error", Reason: "connection_refused"}, true
+	case errors.Is(err, syscall.ECONNRESET):
+		return kiroForwardErrorObservation{Kind: "request_error", Reason: "connection_reset"}, true
+	case errors.Is(err, syscall.EHOSTUNREACH):
+		return kiroForwardErrorObservation{Kind: "request_error", Reason: "host_unreachable"}, true
+	case errors.Is(err, syscall.ENETUNREACH):
+		return kiroForwardErrorObservation{Kind: "request_error", Reason: "network_unreachable"}, true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return kiroForwardErrorObservation{Kind: "request_error", Reason: "network_timeout"}, true
+	}
+
+	lower := strings.ToLower(err.Error())
+	for _, match := range []struct {
+		marker string
+		reason string
+	}{
+		{marker: "connection refused", reason: "connection_refused"},
+		{marker: "connection reset by peer", reason: "connection_reset"},
+		{marker: "no route to host", reason: "host_unreachable"},
+		{marker: "network is unreachable", reason: "network_unreachable"},
+		{marker: "no such host", reason: "dns_error"},
+		{marker: "tls handshake timeout", reason: "tls_handshake_timeout"},
+		{marker: "i/o timeout", reason: "io_timeout"},
+	} {
+		if strings.Contains(lower, match.marker) {
+			return kiroForwardErrorObservation{Kind: "request_error", Reason: match.reason}, true
+		}
+	}
 	if isKiroTransportError(err) {
-		return &UpstreamFailoverError{
-			StatusCode:   http.StatusBadGateway,
-			ResponseBody: append([]byte(nil), kiroTransportFailoverBody...),
-		}
+		return kiroForwardErrorObservation{Kind: "request_error", Reason: "transport_error"}, true
 	}
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, errKiroEmptyResponse) {
-		return &UpstreamFailoverError{
-			StatusCode:   http.StatusBadGateway,
-			ResponseBody: append([]byte(nil), kiroTransportFailoverBody...),
-		}
+	return kiroForwardErrorObservation{}, false
+}
+
+func recordKiroForwardError(c *gin.Context, account *Account, err error, observation kiroForwardErrorObservation) {
+	if c == nil || err == nil {
+		return
 	}
-	return fmt.Errorf("kiro upstream call failed: %w", err)
+	safeErr := truncateString(sanitizeUpstreamErrorMessage(err.Error()), 2048)
+	setOpsUpstreamError(c, 0, safeErr, "")
+	event := OpsUpstreamErrorEvent{
+		Platform:           PlatformKiro,
+		UpstreamStatusCode: 0,
+		Kind:               observation.Kind,
+		Reason:             observation.Reason,
+		Message:            safeErr,
+	}
+	if account != nil {
+		event.Platform = account.Platform
+		event.AccountID = account.ID
+		event.AccountName = account.Name
+	}
+	appendOpsUpstreamError(c, event)
 }
 
 func isKiroProfileArnError(msg string) bool {

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -1224,6 +1224,20 @@ func (s *RateLimitService) handleAnthropicUpstreamError(ctx context.Context, acc
 	if tkIsKiroMirrorStub(account) && tkIsKiroEndpointQuotaExhausted(upstreamMsg, responseBody) {
 		return s.tkHandleKiroEndpointQuotaExhausted(ctx, account, upstreamMsg)
 	}
+	// TK (prod incident 2026-07-20): Kiro edges wrap their exhausted upstream
+	// request path in a stable TokenKey 502 "Upstream service temporarily
+	// unavailable" envelope. The prod Kiro account is only a relay stub, so
+	// advancing its Anthropic 3/3 health fuse duplicates the edge failure and
+	// can cool the entire Kiro mirror pool. Fail over and retain bounded
+	// saturation preference, but leave relay health untouched. Raw infra 502s
+	// do not match the parsed message and continue through the fuse below.
+	if tkSkipDownstreamKiroServiceUnavailablePenalty(account, statusCode, upstreamMsg, responseBody) {
+		slog.Info("anthropic_downstream_kiro_service_unavailable_skip_penalty",
+			"account_id", account.ID,
+			"status_code", statusCode)
+		s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "kiro_service_unavailable")
+		return true
+	}
 	// TK (prod incident 2026-05-31): a 503 whose body is the downstream gateway's
 	// own "no available accounts" pool-exhaustion signal is a transient capacity
 	// blip on the *forwarded-to* pool (e.g. a thin edge bursting on parallel haiku

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
@@ -108,6 +108,25 @@ func tkIsKiroMirrorStub(account *Account) bool {
 	return strings.EqualFold(strings.TrimSpace(account.GetCredential("mirror_platform")), string(PlatformKiro))
 }
 
+const tkDownstreamKiroServiceUnavailableMessage = "upstream service temporarily unavailable"
+
+// tkSkipDownstreamKiroServiceUnavailablePenalty identifies the stable TokenKey
+// 502 envelope emitted by an edge after its Kiro request path failed upstream.
+// The prod account is only a relay stub; cooling it repeats the downstream
+// failure at the prod layer and can remove every otherwise healthy Kiro route.
+// Keep raw proxy/infra 502s eligible for the stub-health fuse by requiring the
+// parsed application message to match exactly.
+func tkSkipDownstreamKiroServiceUnavailablePenalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool {
+	if statusCode != http.StatusBadGateway || !tkIsKiroMirrorStub(account) {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(upstreamMsg), tkDownstreamKiroServiceUnavailableMessage) {
+		return true
+	}
+	bodyMsg := extractUpstreamErrorMessage(responseBody)
+	return strings.EqualFold(strings.TrimSpace(bodyMsg), tkDownstreamKiroServiceUnavailableMessage)
+}
+
 // tkSkipDownstreamKiroOAuthAuthRejectPenalty identifies a Kiro edge OAuth auth
 // rejection that crossed the prod mirror boundary as an Anthropic api-key error.
 // The prod stub is only a relay; it has no Kiro OAuth token to refresh. The edge

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
@@ -64,6 +64,26 @@ func TestTkSkipDownstreamKiroOAuthAuthRejectPenalty(t *testing.T) {
 	require.False(t, tkSkipDownstreamKiroOAuthAuthRejectPenalty(openaiMirror, http.StatusForbidden, "Invalid bearer token", nil))
 }
 
+func TestTkSkipDownstreamKiroServiceUnavailablePenalty(t *testing.T) {
+	stub := &Account{
+		ID:       66,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": "kiro",
+		},
+	}
+	body := []byte(`{"error":{"message":"Upstream service temporarily unavailable","type":"upstream_error"}}`)
+
+	require.True(t, tkSkipDownstreamKiroServiceUnavailablePenalty(stub, http.StatusBadGateway, "", body))
+	require.True(t, tkSkipDownstreamKiroServiceUnavailablePenalty(stub, http.StatusBadGateway, "UPSTREAM SERVICE TEMPORARILY UNAVAILABLE", nil))
+	require.False(t, tkSkipDownstreamKiroServiceUnavailablePenalty(stub, http.StatusServiceUnavailable, "Upstream service temporarily unavailable", nil))
+	require.False(t, tkSkipDownstreamKiroServiceUnavailablePenalty(stub, http.StatusBadGateway, "", []byte(`<html>502 Bad Gateway</html>`)))
+
+	plainAnthropic := &Account{ID: 67, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	require.False(t, tkSkipDownstreamKiroServiceUnavailablePenalty(plainAnthropic, http.StatusBadGateway, "", body))
+}
+
 // prod incident 2026-05-31: a downstream edge stub returning 503 "no available
 // accounts" (a transient edge pool-capacity blip) must fail the request over to
 // the next stub WITHOUT advancing the per-account cooldown counter or cooling the
@@ -242,6 +262,50 @@ func TestRateLimitService_HandleUpstreamError_KiroMirrorGeneric403_FailoverOnly(
 	require.Equal(t, 0, repo.tempCalls, "403 must not enter the stub-health 3/3 fuse")
 	require.Empty(t, counter.incrementIDs)
 	require.Equal(t, []int64{66}, sat.incrementIDs, "transient relay blip feeds bounded de-prioritization")
+}
+
+func TestRateLimitService_HandleUpstreamError_KiroMirrorServiceUnavailable_DoesNotCoolRelay(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	ladder := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1, 2, 3, 4}}
+	sat := &fakeSaturationCounterRL{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(ladder)
+	service.SetAnthropicSaturationCounter(sat)
+	account := &Account{
+		ID:       69,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"mirror_platform": "kiro",
+			"pool_mode":       true,
+		},
+	}
+	body := []byte(`{"error":{"message":"Upstream service temporarily unavailable","type":"upstream_error"}}`)
+
+	for i := 0; i < 4; i++ {
+		require.True(t, service.HandleUpstreamError(context.Background(), account, http.StatusBadGateway, http.Header{}, body))
+	}
+
+	require.Equal(t, 0, repo.tempCalls, "downstream Kiro 502 must not temp-unschedule the prod relay")
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Empty(t, ladder.incrementIDs, "downstream Kiro 502 must not advance the Anthropic 3/3 fuse")
+	require.Equal(t, []int64{69, 69, 69, 69}, sat.incrementIDs, "failed Kiro edge still receives bounded de-prioritization")
+}
+
+func TestRateLimitService_HandleUpstreamError_PlainAnthropicServiceUnavailable_StillCounts(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	ladder := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1, 2, 3}, tierCounts: []int64{1}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(ladder)
+	account := &Account{ID: 67, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	body := []byte(`{"error":{"message":"Upstream service temporarily unavailable","type":"upstream_error"}}`)
+
+	require.False(t, service.HandleUpstreamError(context.Background(), account, http.StatusBadGateway, http.Header{}, body))
+	require.False(t, service.HandleUpstreamError(context.Background(), account, http.StatusBadGateway, http.Header{}, body))
+	require.True(t, service.HandleUpstreamError(context.Background(), account, http.StatusBadGateway, http.Header{}, body))
+
+	require.Equal(t, 1, repo.tempCalls, "real Anthropic 502 keeps the relay-health fuse")
+	require.Equal(t, []int64{67, 67, 67}, ladder.incrementIDs)
 }
 
 func TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsError(t *testing.T) {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -415,28 +415,33 @@
         "func tkIsDownstreamAllAccountsExhausted(upstreamMsg string, responseBody []byte) bool",
         "func tkSkipDownstreamFailoverExhaustedPenalty(statusCode int, upstreamMsg string, responseBody []byte) bool",
         "func tkIsKiroMirrorStub(account *Account) bool",
+        "func tkSkipDownstreamKiroServiceUnavailablePenalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool",
         "func tkSkipDownstreamKiroOAuthAuthRejectPenalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool",
         "statusCode != http.StatusUnauthorized && statusCode != http.StatusForbidden",
         "if statusCode == http.StatusForbidden {",
         "all available accounts exhausted",
         "ErrNoAvailableAccounts.Error()",
         "mirror_platform",
+        "upstream service temporarily unavailable",
         "invalid bearer token",
         "upstream request failed"
       ],
-      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and 'all available accounts exhausted' (G2 narrow, 429/5xx, downstream failover loop ran dry) are both TokenKey-generated downstream-capacity strings the real provider APIs never emit; a healthy forwarding stub must fail over without advancing the 3/3 ladder. Both skips match ONLY these TokenKey phrases, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. G5 Kiro mirror OAuth auth rejection: a prod Anthropic API-key mirror stub whose credentials.mirror_platform=kiro may receive the edge Kiro OAuth account's 401/403 invalid-bearer wrapper, but prod has no OAuth identity to refresh and must not SetError or ladder-cool the relay stub after edge self-heals. 401 keeps the existing TokenKey wrapper compatibility; 403 must require the invalid-bearer signal to mirror #970 and must not skip a generic upstream_request_failed wrapper. Dropping the Kiro mirror predicate or auth-reject helper silently reintroduces stale prod stub errors after a successful edge force-refresh. Widening the match beyond Kiro mirror stubs would weaken real Anthropic API-key 401 protection and generic Anthropic 403 route-away handling. Prod incidents 2026-05-31 / 2026-06 were both this misattribution class: downstream edge state punished as prod stub health."
+      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and 'all available accounts exhausted' (G2 narrow, 429/5xx, downstream failover loop ran dry) are both TokenKey-generated downstream-capacity strings the real provider APIs never emit; a healthy forwarding stub must fail over without advancing the 3/3 ladder. Both skips match ONLY these TokenKey phrases, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. G5 Kiro mirror OAuth auth rejection: a prod Anthropic API-key mirror stub whose credentials.mirror_platform=kiro may receive the edge Kiro OAuth account's 401/403 invalid-bearer wrapper, but prod has no OAuth identity to refresh and must not SetError or ladder-cool the relay stub after edge self-heals. G6 Kiro service-unavailable applies the same ownership boundary to the exact TokenKey 502 envelope emitted after an edge Kiro transport/read failure: prod must fail over and de-prioritize the stub without duplicating the edge failure into the prod 3/3 fuse. Raw proxy HTML 502s, plain Anthropic accounts, and other mirror platforms remain eligible for their existing health handling. Dropping either Kiro helper silently restores stale prod stub errors or whole-pool mirror cooldown from downstream-owned failures."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
         "tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, statusCode, upstreamMsg, responseBody)",
         "tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, http.StatusForbidden, upstreamMsg, responseBody)",
+        "tkSkipDownstreamKiroServiceUnavailablePenalty(account, statusCode, upstreamMsg, responseBody)",
         "anthropic_downstream_kiro_oauth_401_skip_penalty",
         "anthropic_downstream_kiro_oauth_403_skip_penalty",
+        "anthropic_downstream_kiro_service_unavailable_skip_penalty",
         "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"kiro_oauth_401\")",
-        "s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, \"kiro_oauth_403\")"
+        "s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, \"kiro_oauth_403\")",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"kiro_service_unavailable\")"
       ],
-      "rationale": "G5 Kiro mirror OAuth auth-reject injection points. The 401 branch must run before the generic API-key SetError path, and the 403 branch must run before handle403's generic Anthropic 403 ladder / permanent-disable checks, so relayed edge Kiro OAuth invalid-bearer errors fail over and feed bounded mirror de-prioritization while leaving prod mirror stub health untouched. If an upstream merge rewrites either call site, edge self-heal can clear the real OAuth account while prod keeps a stale API-key mirror SetError or ladder cooldown."
+      "rationale": "G5/G6 Kiro mirror downstream-failure injection points. The 401 branch must run before the generic API-key SetError path, the 403 branch before handle403's generic ladder / permanent-disable checks, and the exact service-unavailable 502 branch before handleAnthropicUpstreamError advances the 3/3 fuse. These relayed edge-owned failures must fail over and feed bounded mirror de-prioritization while leaving prod mirror stub health untouched. If an upstream merge rewrites any call site, edge self-heal can clear the real account while prod keeps a stale SetError/ladder cooldown or collapses every Kiro mirror relay."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go",
@@ -445,10 +450,13 @@
         "TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth401_DoesNotSetError",
         "TestRateLimitService_HandleUpstreamError_KiroMirrorOAuth403_DoesNotSetError",
         "TestRateLimitService_HandleUpstreamError_KiroMirrorGeneric403_FailoverOnly",
+        "TestTkSkipDownstreamKiroServiceUnavailablePenalty",
+        "TestRateLimitService_HandleUpstreamError_KiroMirrorServiceUnavailable_DoesNotCoolRelay",
+        "TestRateLimitService_HandleUpstreamError_PlainAnthropicServiceUnavailable_StillCounts",
         "TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey401_StillSetsError",
         "TestRateLimitService_HandleUpstreamError_PlainAnthropicAPIKey403_PermanentlyDisables"
       ],
-      "rationale": "Focused regressions proving the G5 boundary: Kiro mirror-stub 401/403 invalid-bearer wrappers are skipped without SetError or ladder cooldown, a generic Kiro mirror upstream_error 403 failovers with bounded saturation only, a plain Anthropic API-key 401 still permanently disables, and a plain Anthropic API-key invalid-bearer 403 still permanently disables via the auth-fatal classifier."
+      "rationale": "Focused regressions proving the G5/G6 boundary: Kiro mirror-stub 401/403 invalid-bearer wrappers and the exact Kiro service-unavailable 502 are skipped without SetError or ladder cooldown, while failures still feed bounded saturation. Raw HTML 502s and a plain Anthropic service-unavailable 502 retain the real relay-health fuse; plain Anthropic API-key 401/403 errors retain permanent-disable handling."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_request_too_large_test.go",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -221,10 +221,10 @@
         "BillingTier:   kiroproto.KiroEstimatedBillingTier",
         "callErr != nil && !enc.started",
         "textBuf == \"\" && thinkingBuf == \"\" && len(toolUses) == 0",
-        "classifyKiroForwardError",
+        "classifyAndRecordKiroForwardError",
         "publishKiroInternalThinkingSideChannel"
       ],
-      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream. It estimates token usage locally (EstimateInputTokens/EstimateOutputTokens) and stamps ForwardResult.BillingTier=\"kiro-estimated\", because the Kiro upstream reports credits only — without these calls both forward paths return Usage{0,0} and kiro bills as 100% free. The context-aware call and ResetForRetry callbacks are load-bearing: non-streaming retries clear all partial buffers, while streaming retries are rejected after enc.started to prevent duplicated client output. The `callErr != nil && !enc.started` guard + classifyKiroForwardError keep pre-content failures visible instead of returning an empty 200 stream. An upstream merge that drops any of these guards silently regresses reliability, billing, or response integrity."
+      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream. It estimates token usage locally (EstimateInputTokens/EstimateOutputTokens) and stamps ForwardResult.BillingTier=\"kiro-estimated\", because the Kiro upstream reports credits only — without these calls both forward paths return Usage{0,0} and kiro bills as 100% free. The context-aware call and ResetForRetry callbacks are load-bearing: non-streaming retries clear all partial buffers, while streaming retries are rejected after enc.started to prevent duplicated client output. The `callErr != nil && !enc.started` guard + classifyAndRecordKiroForwardError keep pre-content failures visible instead of returning an empty 200 stream and retain the sanitized original transport/read cause in ops upstream_errors. An upstream merge that drops any of these guards silently regresses reliability, billing, response integrity, or incident diagnosability."
     },
     {
       "path": "backend/internal/service/kiro_gateway_service_test.go",
@@ -237,11 +237,14 @@
         "TestKiroGatewayService_Forward_EmptyEventStreamExceptionPreservesFailoverClass",
         "TestClassifyKiroForwardError_EventStreamInputTooLongDoesNotFailover",
         "TestClassifyKiroForwardError_EventStreamProviderExceptionWinsOverInputTooLongText",
+        "TestClassifyKiroForwardError_TransportFailureTriggersFailover",
+        "access_token=***",
+        "client cancellation must not be recorded as a Kiro upstream failure",
         "committed stream must not be retried",
         "discard me",
         "recovered"
       ],
-      "rationale": "Service-layer regression evidence for both sides of the truncated-response contract: non-streaming partial state is fully discarded before fallback, while a stream that already committed output emits an SSE error and never calls another upstream endpoint. It also pins Kiro's content-length validation as a client-owned non-failover error so context overflow cannot regress to provider 502 churn."
+      "rationale": "Service-layer regression evidence for both sides of the truncated-response contract: non-streaming partial state is fully discarded before fallback, while a stream that already committed output emits an SSE error and never calls another upstream endpoint. It also pins Kiro's content-length validation as a client-owned non-failover error so context overflow cannot regress to provider 502 churn. The transport regression preserves the sanitized original cause and stable classification for ops while proving query secrets are redacted and client cancellation is not misreported as an upstream failure."
     },
     {
       "path": "backend/internal/service/kiro_sse_encoder.go",
@@ -353,6 +356,9 @@
         "type KiroInvalidRequestError",
         "type KiroEndpointQuotaExhaustedError",
         "func classifyKiroForwardError",
+        "func classifyAndRecordKiroForwardError",
+        "func classifyKiroOpaqueFailure",
+        "func recordKiroForwardError",
         "func parseKiroEventStreamError",
         "func isKiroInputTooLongError",
         "func isKiroTransportError",
@@ -360,7 +366,7 @@
         "quota exhausted on",
         "INVALID_MODEL_ID"
       ],
-      "rationale": "TK-only typed error + classifier for Kiro request rejections, including INVALID_MODEL_ID and CONTENT_LENGTH_EXCEEDS_THRESHOLD. classifyKiroForwardError is called from both forwardStreaming and forwardNonStreaming; the handler maps typed invalid model/request errors to client-owned 400 responses without cross-account failover. Losing this file makes Kiro validation errors fall back to the generic forward-error path (opaque 502 / unwanted failover / polluted SLA)."
+      "rationale": "TK-only typed error + classifier for Kiro request rejections, including INVALID_MODEL_ID and CONTENT_LENGTH_EXCEEDS_THRESHOLD. classifyAndRecordKiroForwardError is called from both forwardStreaming and forwardNonStreaming; it preserves a sanitized, categorized transport/read/empty-response cause in ops upstream_errors while the client still receives the generic 502 envelope. The handler maps typed invalid model/request errors to client-owned 400 responses without cross-account failover. Losing this file makes Kiro validation errors fall back to the generic forward-error path or restores opaque 502s with no recoverable root cause."
     },
     {
       "path": "backend/internal/service/wire.go",


### PR DESCRIPTION
## 摘要

- 修复 prod Kiro mirror 将 edge 通用 502 重复计入 Anthropic relay health fuse、导致整个镜像池被临时不可调度的问题。
- 仅对 `mirror_platform=kiro` 且错误消息精确为 `Upstream service temporarily unavailable` 的 502 跳过 relay 冷却；原始代理 502、普通 Anthropic 账号及其他平台行为不变。
- 将 Kiro 传输、读取和空响应的脱敏原始错误写入 `ops_error_logs.upstream_errors`，附带真实账号和稳定 `reason` 分类；客户端仍返回统一 502。
- 补齐 Kiro 错误分类器的生产调用和 lint 约束，并将冷却豁免、原始错误保留及正负回归测试登记到 sentinel registry。

## 风险

- 行为范围受平台、状态码和错误消息三重约束，避免放宽其他 502 的健康熔断。
- 原始错误仅写内部运维日志，常见 secret query 参数会脱敏，消息限制为 2048 字节。
- 客户端取消不会记为上游故障。
- Web impact: none。
- sentinel-registry-reviewed：已新增真实实现入口、关键调用点及正负回归测试的语义锚点，防止后续 upstream merge 静默覆盖。

## 验证

- `go test -tags=unit ./internal/service -run 'Kiro|DownstreamKiro' -count=1`
- `go test -tags=unit ./internal/service -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./... --concurrency=4 --timeout=30m`（0 issues）
- `PREFLIGHT_BASE=origin/main ./scripts/preflight.sh`（完整项目扩展门禁通过）

## 提交

- `c3bd1d534 fix(kiro): prevent mirror 502 cooldown and retain causes`
- `d8b9df4bb fix(review): address R-001..R-002 - close lint and sentinel gaps`
- 最新提交：`d8b9df4bb`