### PR TITLE
fix(kiro): /v1/chat/completions 走 Kiro gateway 桥接

### DIFF
--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -77,6 +77,11 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		if normalized != originalModel {
 			mappedModel = normalized
 		}
+	} else if mappedModel == originalModel && account.IsKiro() {
+		normalized := claude.NormalizeModelID(originalModel)
+		if normalized != originalModel {
+			mappedModel = normalized
+		}
 	}
 	anthropicReq.Model = mappedModel
 
@@ -110,7 +115,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 	// 否则会被 Anthropic 判为第三方应用并扣 extra usage。
 	// 见 applyClaudeCodeOAuthMimicryToBody 的 godoc。
 	isClaudeCode := false
-	shouldMimicClaudeCode := account.IsOAuth() && !isClaudeCode
+	shouldMimicClaudeCode := account.IsOAuth() && !isClaudeCode && !account.IsKiro()
 
 	if shouldMimicClaudeCode {
 		anthropicBody = s.applyClaudeCodeOAuthMimicryToBody(ctx, c, account, anthropicBody, anthropicReq.System, mappedModel)
@@ -124,6 +129,13 @@ func (s *GatewayService) ForwardAsChatCompletions(
 	// aspect_ratio) from the raw CC body onto the relayed Anthropic body; the antigravity
 	// Gemini transform consumes it downstream. No-op for non-image / ratio-less requests.
 	anthropicBody = tkInjectGeminiImageAspectRatio(body, anthropicBody)
+
+	if account.IsKiro() {
+		return s.forwardAsChatCompletionsViaKiro(
+			ctx, c, account, body, originalModel, mappedModel, anthropicBody,
+			clientStream, includeUsage, startTime,
+		)
+	}
 
 	// 8. Get access token
 	token, tokenType, err := s.GetAccessToken(ctx, account)

--- a/backend/internal/service/gateway_forward_as_chat_completions_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -188,4 +190,77 @@ data: {"type":"message_stop"}
 	require.Equal(t, "E2E-OPENAI-OK", gjson.GetBytes(rec.Body.Bytes(), "choices.0.message.content").String())
 	require.Equal(t, "stop", gjson.GetBytes(rec.Body.Bytes(), "choices.0.finish_reason").String())
 	require.True(t, gjson.GetBytes(rec.Body.Bytes(), "usage").Exists())
+}
+
+type kiroCCUpstreamRecorder struct {
+	lastReq *http.Request
+}
+
+func (u *kiroCCUpstreamRecorder) Do(*http.Request, string, int64, int) (*http.Response, error) {
+	return nil, fmt.Errorf("unexpected Do call")
+}
+
+func (u *kiroCCUpstreamRecorder) DoWithTLS(req *http.Request, _ string, _ int64, _ int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	u.lastReq = req
+	frame := buildKiroEventStreamMessage("assistantResponseEvent",
+		[]byte(`{"content":"KIRO-CC-OK","inputTokens":4,"outputTokens":5}`))
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(frame)),
+	}, nil
+}
+
+func TestForwardAsChatCompletions_KiroAccountBridgesViaKiroGateway(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hi"}],"max_tokens":32,"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &kiroCCUpstreamRecorder{}
+	kiroGW := NewKiroGatewayService(upstream, nil, nil)
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+		kiroGateway:  kiroGW,
+	}
+	account := newKiroAccountForTest()
+	account.ID = 15
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "claude-sonnet-4-5", result.Model)
+	require.False(t, result.Stream)
+	require.Equal(t, "kiro-estimated", result.BillingTier)
+	require.Positive(t, result.Usage.InputTokens)
+	require.Positive(t, result.Usage.OutputTokens)
+
+	require.NotNil(t, upstream.lastReq)
+	require.Contains(t, upstream.lastReq.URL.String(), "generateAssistantResponse")
+	require.NotContains(t, upstream.lastReq.URL.Host, "anthropic.com")
+	require.True(t, gjson.GetBytes(upstream.lastReqBody(), "conversationState").Exists())
+	require.True(t, gjson.GetBytes(upstream.lastReqBody(), "profileArn").Exists())
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "chat.completion", gjson.GetBytes(rec.Body.Bytes(), "object").String())
+	require.Equal(t, "claude-sonnet-4-5", gjson.GetBytes(rec.Body.Bytes(), "model").String())
+	require.Equal(t, "KIRO-CC-OK", gjson.GetBytes(rec.Body.Bytes(), "choices.0.message.content").String())
+	require.Equal(t, "stop", gjson.GetBytes(rec.Body.Bytes(), "choices.0.finish_reason").String())
+	require.True(t, gjson.GetBytes(rec.Body.Bytes(), "usage").Exists())
+}
+
+func (u *kiroCCUpstreamRecorder) lastReqBody() []byte {
+	if u.lastReq == nil || u.lastReq.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(u.lastReq.Body)
+	if err != nil {
+		return nil
+	}
+	u.lastReq.Body = io.NopCloser(bytes.NewReader(body))
+	return body
 }

--- a/backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go
@@ -1,0 +1,101 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/sjson"
+)
+
+// forwardAsChatCompletionsViaKiro routes CC→Anthropic converted bodies through
+// the Kiro gateway (EventStream upstream) instead of the Anthropic HTTP API,
+// then converts the captured Anthropic SSE back to Chat Completions for the client.
+func (s *GatewayService) forwardAsChatCompletionsViaKiro(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	ccBody []byte,
+	originalModel, mappedModel string,
+	anthropicBody []byte,
+	clientStream bool,
+	includeUsage bool,
+	startTime time.Time,
+) (*ForwardResult, error) {
+	if s.kiroGateway == nil {
+		return nil, fmt.Errorf("kiro gateway service not configured")
+	}
+
+	anthropicBody, err := sjson.SetBytes(anthropicBody, "stream", true)
+	if err != nil {
+		return nil, fmt.Errorf("force anthropic stream for kiro bridge: %w", err)
+	}
+
+	kiroParsed := &ParsedRequest{
+		Body:   NewRequestBodyRef(anthropicBody),
+		Model:  mappedModel,
+		Stream: true,
+	}
+	if kiroParsed.Model == "" {
+		kiroParsed.Model = originalModel
+	}
+
+	var captureBuf bytes.Buffer
+	captureWriter := newBridgeCaptureWriter(&captureBuf)
+	origWriter := c.Writer
+	c.Writer = captureWriter
+
+	fwdResult, err := s.kiroGateway.Forward(ctx, c, account, kiroParsed, startTime)
+	c.Writer = origWriter
+	if err != nil {
+		if s.rateLimitService != nil {
+			var failoverErr *UpstreamFailoverError
+			if errors.As(err, &failoverErr) {
+				s.rateLimitService.HandleUpstreamError(ctx, account, failoverErr.StatusCode, failoverErr.ResponseHeaders, failoverErr.ResponseBody)
+			}
+		}
+		return nil, err
+	}
+
+	upstreamResp := &http.Response{
+		StatusCode: captureWriter.statusCode,
+		Header:     captureWriter.header.Clone(),
+		Body:       io.NopCloser(bytes.NewReader(captureBuf.Bytes())),
+	}
+	if upstreamResp.StatusCode == 0 {
+		upstreamResp.StatusCode = http.StatusOK
+	}
+
+	reasoningEffort := extractCCReasoningEffortFromBody(ccBody)
+	reasoningEffort = ApplyThinkingEnabledFallback(reasoningEffort, ccBody, mappedModel)
+
+	var result *ForwardResult
+	if clientStream {
+		result, err = s.handleCCStreamingFromAnthropic(upstreamResp, c, originalModel, mappedModel, reasoningEffort, startTime, includeUsage)
+	} else {
+		result, err = s.handleCCBufferedFromAnthropic(upstreamResp, c, originalModel, mappedModel, reasoningEffort, startTime)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if result != nil && fwdResult != nil {
+		if fwdResult.BillingTier != "" {
+			result.BillingTier = fwdResult.BillingTier
+		}
+		if fwdResult.RequestID != "" {
+			result.RequestID = fwdResult.RequestID
+		}
+		if fwdResult.Usage.InputTokens > 0 || fwdResult.Usage.OutputTokens > 0 {
+			result.Usage = fwdResult.Usage
+		}
+		if fwdResult.UpstreamModel != "" {
+			result.UpstreamModel = fwdResult.UpstreamModel
+		}
+	}
+	return result, nil
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -935,7 +935,7 @@
     {
       "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
       "must_contain": [
-        "account.IsKiro()",
+        "if account.IsKiro() {",
         "forwardAsChatCompletionsViaKiro(",
         "!account.IsKiro()"
       ],

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -933,6 +933,34 @@
       "rationale": "Focused regression anchor for upstream #1311 extended scope (Anthropic-backed Chat Completions path) proving the buffered JSON body does not inherit the upstream SSE Content-Type."
     },
     {
+      "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
+      "must_contain": [
+        "account.IsKiro()",
+        "forwardAsChatCompletionsViaKiro(",
+        "!account.IsKiro()"
+      ],
+      "rationale": "Kiro OAuth accounts on /v1/chat/completions must not fall through to buildUpstreamRequest + Anthropic HTTP after CC→Anthropic conversion — that path 401s because Kiro credentials are not Anthropic API keys. The early branch routes through kiroGateway.Forward and reuses the Anthropic SSE→Chat Completions bridge; skipping OAuth mimicry for Kiro is anchored via !account.IsKiro(). Dropping the hook compiles cleanly but leaves every edge Kiro CC request failing with upstream_rejected 401 while /v1/messages on the same account succeeds."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go",
+      "must_contain": [
+        "func (s *GatewayService) forwardAsChatCompletionsViaKiro(",
+        "s.kiroGateway.Forward(",
+        "newBridgeCaptureWriter",
+        "handleCCBufferedFromAnthropic",
+        "handleCCStreamingFromAnthropic"
+      ],
+      "rationale": "Kiro /v1/chat/completions bridge: capture Anthropic SSE from kiroGateway.Forward via bridgeCaptureWriter, restore the client writer, then feed handleCCBufferedFromAnthropic / handleCCStreamingFromAnthropic so OpenAI-compat clients receive chat.completion shape. Without this companion the IsKiro() call site in gateway_forward_as_chat_completions.go has nowhere to delegate and the CC path regresses to Anthropic HTTP."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_as_chat_completions_test.go",
+      "must_contain": [
+        "TestForwardAsChatCompletions_KiroAccountBridgesViaKiroGateway",
+        "generateAssistantResponse"
+      ],
+      "rationale": "Regression: ForwardAsChatCompletions on a Kiro account must hit the Kiro EventStream upstream (generateAssistantResponse) and return a chat.completion body, not anthropic.com /v1/messages."
+    },
+    {
       "path": "backend/internal/service/openai_images_responses.go",
       "must_contain": [
         "Wei-Shaw/sub2api#1311",


### PR DESCRIPTION
## 摘要

- Edge Kiro 账号在 `POST /v1/chat/completions` 上会将 CC 请求转成 Anthropic 形态后误打 Anthropic HTTP API，触发 401 failover；同账号 `/v1/messages` 正常。
- 对 `account.IsKiro()` 早退到 `kiroGateway.Forward`，捕获 Anthropic SSE 后再经现有 `handleCC*` 转回 Chat Completions 响应。
- 跳过 Kiro 账号上的 Anthropic OAuth mimicry；补充 sentinel 锚点与单元测试。

## 风险

- 常规风险：仅影响 Kiro 平台的 `/v1/chat/completions` 转发路径；非 Kiro / Anthropic 直打路径不变。
- Web impact: none

## 验证

- [x] `go test -tags=unit ./internal/service/... -run 'ForwardAsChatCompletions_Kiro|ForwardAsChatCompletions_Anthropic' -count=1`
- [ ] 发版后在 edge 跑 probe：`ENDPOINT=chat MODEL=claude-sonnet-4-5`

## 提交

- c81bdad2b fix(kiro): route chat/completions through Kiro gateway for Kiro accounts

最新提交：c81bdad2b

Made with [Cursor](https://cursor.com)