### PR TITLE
fix(frontend): 升级 Axios 1.18.1 修复安全公告

### DIFF
--- a/.github/actions/pnpm-audit/action.yml
+++ b/.github/actions/pnpm-audit/action.yml
@@ -7,6 +7,8 @@ runs:
     - name: Set up pnpm audit runner
       uses: pnpm/action-setup@v6
       with:
+        # Keep setup-node's pnpm 9 cache path alive through post-job cleanup.
+        dest: ~/setup-pnpm-audit
         # pnpm 9/10 still call npm's retired quick-audit endpoint (HTTP 410).
         # Keep project install/lockfile operations on pnpm 9; only audit uses 11.
         version: 11.7.0

--- a/.github/audit-exceptions.yml
+++ b/.github/audit-exceptions.yml
@@ -28,10 +28,3 @@ exceptions:
     mitigation: "No user-controlled template strings; plan to migrate to native JS alternatives"
     expires_on: "2026-07-02"
     owner: "security@your-domain"
-  - package: axios
-    advisory: "GHSA-3p68-rc4w-qgx5"
-    severity: critical
-    reason: "NO_PROXY bypass not exploitable; all API calls go to known endpoints via server-side proxy"
-    mitigation: "Proxy configuration not user-controlled; upgrade when axios releases fix"
-    expires_on: "2026-07-10"
-    owner: "security@your-domain"

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 608,
-  "hash": "814e73ee84a0bddf7943a5809743520538860527439626f8629dcebcd4a03b10",
+  "hash": "1bc44ef4a1ce9c755e0259f9c3659b39b3971ef5b61e1c2b449df4fe8a4e7dfc",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@stripe/stripe-js": "^9.0.1",
     "@tanstack/vue-virtual": "^3.13.23",
     "@vueuse/core": "^10.7.0",
-    "axios": "^1.16.0",
+    "axios": "^1.18.1",
     "chart.js": "^4.4.1",
     "dompurify": "^3.3.1",
     "driver.js": "^1.4.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^10.7.0
         version: 10.11.1(vue@3.5.26(typescript@5.6.3))
       axios:
-        specifier: ^1.16.0
-        version: 1.16.0
+        specifier: ^1.18.1
+        version: 1.18.1
       chart.js:
         specifier: ^4.4.1
         version: 4.5.1
@@ -1792,6 +1792,10 @@ packages:
     resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
     engines: {node: '>=0.8'}
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1879,8 +1883,8 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
@@ -2646,6 +2650,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
@@ -2755,6 +2760,10 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -4409,6 +4418,7 @@ packages:
   vue-i18n@9.14.5:
     resolution: {integrity: sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==}
     engines: {node: '>= 16'}
+    deprecated: v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html
     peerDependencies:
       vue: ^3.0.0
 
@@ -6392,6 +6402,12 @@ snapshots:
 
   adler-32@1.3.1: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ahooks@3.9.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
@@ -6534,13 +6550,15 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  axios@1.16.0:
+  axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -7568,6 +7586,13 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color

--- a/scripts/checks/pnpm-audit-contract.py
+++ b/scripts/checks/pnpm-audit-contract.py
@@ -14,6 +14,7 @@ WORKFLOWS = (
 )
 ACTION_REF = "uses: ./.github/actions/pnpm-audit"
 ACTION_ANCHORS = (
+    "dest: ~/setup-pnpm-audit",
     "version: 11.7.0",
     "--registry=https://registry.npmjs.org/",
     '("advisories", "vulnerabilities", "metadata")',


### PR DESCRIPTION
## 摘要

- 将前端 Axios 从 1.16.0 升级到 1.18.1，修复 GHSA-gcfj-64vw-6mp9。
- 删除已过期且不再需要的 Axios audit exception。
- 将 pnpm 11 audit runner 放入独立目录，避免覆盖 pnpm 9 的 setup-node cache 路径，并把该约束固化进 owner contract。
- 更新 pnpm 锁文件与嵌入式前端来源指纹。

## 风险

- 低风险依赖与 CI 修复，不改变公共 API、页面功能或后端行为。
- Web impact：浏览器请求链保持原契约；主要安全修复位于 Node HTTP adapter，现有前端类型检查、关键测试与生产构建均已验证。
- CI 变更只隔离 audit runner 安装目录，不改变 registry、audit level、JSON 校验或 exception checker。
- 未修改 xlsx 既有例外，也未引入新的 audit exception。

## 验证

- `make test-frontend`：10 个关键测试文件、114 个断言通过。
- `pnpm --dir frontend build`：通过，来源指纹已更新。
- pnpm 11.7 production audit + exception checker：Axios advisory 消失，仅保留已登记的 xlsx 例外。
- `python3 scripts/checks/pnpm-audit-contract.py`：PASS，独立 audit runner 目录已纳入机械契约。
- 组合 action YAML 解析：PASS。
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS。
- 补充诊断：非 CI 的 `client.spec.ts` 仍有 5 个既有 UI header 断言失败；相关源码未在本 PR 修改，`clientTk.spec.ts` 与 `adminUIRequest.spec.ts` 均通过。

## 提交

- `e9bca0c9c` fix(frontend): 升级 Axios 修复安全公告
- `1fa6575bf` fix(ci): 隔离 pnpm audit runner 缓存路径
- 最新提交：`1fa6575bf`