### PR TITLE
fix(kiro): 终止计量空响应的镜像扩散

### DIFF
--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 |---|---|---|
 | 解析 prod / edge target（region / instance_id / domain） | 机械 | edge 经 `ops/stage0/edge_ssm_execution.py`（Lightsail tag-SSM `EdgeId`/`Platform=lightsail` → `mi-*`）/ `resolve-edge-lightsail-target.py`；prod 经 CFN `describe-stacks` |
 | SSM base64 投递 + send-command + poll | 机械 | `ops/observability/run-probe.sh --target prod\|edge:<id> --script <probe.sh>` |
-| `ops_error_logs` 标准聚合（schema + by_status + upstream_events + 429-by-minute） | 机械 | `ops/observability/ops-error-triage.sh`（通过 run-probe.sh 投递） |
+| `ops_error_logs` 标准聚合（schema + by_status + upstream_events，保留 reason/截断 message + 429-by-minute） | 机械 | `ops/observability/ops-error-triage.sh`（通过 run-probe.sh 投递） |
 | final-429 / 5xx 分类（config-cap vs 空池 #575 vs 真上游：by error_type/owner/phase + by group·model·account + 5min 桶） | 机械 | `ops/observability/probe-429-classify.sh`（通过 run-probe.sh 投递；`WINDOW_HOURS` 默认 3；§4 triage 的分类深挖） |
 | SLA Dashboard 等价拆解（success/error_total/error_sla/client_faults + by_status owner 口径 + top SLA messages） | 机械 | `ops/observability/probe-sla-breakdown.sh`（通过 run-probe.sh 投递；`WINDOW_HOURS` 默认 24；对齐 Admin Ops `error_owner` SLA 公式） |
 | ⚠写侧止血：恢复 anthropic 可调度 / 清陈旧冷却（`MODE=edge-oauth-pool` 恢复 OAuth 池+补 group_id / `prod-mirror-cooldown` 清 cc-·kiro- 镜像冷却；before/after 自证） | 机械(写) | `ops/observability/remediate-schedulable-pool.sh`（经 run-probe 投递；§10 交接修复时用，非只读、须先有结论） |
@@ -38,6 +38,7 @@ description: >-
 | Gateway UA/TLS / usage_logs / ops / docker 指纹交叉对比（窄时间窗） | 机械 | `ops/observability/probe-gateway-ua-tls-compare.sh`（通过 run-probe.sh 投递；`WINDOW_MINUTES` 收窄 DB 窗） |
 | OpenAI/Python ingress → edge OAuth mimic 出站（HTTP 头 + system，非 UA-only） | 机械 | `ops/observability/probe-oauth-mimicry-chain.sh`（edge + `PLATFORM=anthropic`）；日志 `gateway.anthropic_oauth_mimic_egress` |
 | `ops_error_logs.request_body` 顶层参数形状聚合（若线上 schema 保留 body，则只输出 top-level keys / deprecated sampling key 存在性；若无 body 列则输出 schema-unavailable + 错误样本） | 机械 | `ops/observability/probe-ops-error-request-shape.sh`（经 run-probe 投递；用于确认错误请求是否携带 `temperature` / `top_p` / `top_k` 等字段，不输出 prompt/body 原文） |
+| final error 与 QA evidence 覆盖率（request_id 关联、retention、blob ref/本地存在性；不输出正文或 URI） | 机械 | `ops/observability/probe-qa-error-evidence.sh`（经 run-probe 投递；先判断是否有可深挖证据，再决定是否需要隐私受控的正文检查） |
 | `SUB2API_DEBUG_GATEWAY_BODY` 日志拉回本机（SSM gzip → S3 presigned PUT → 本地 gunzip） | 机械 | `ops/observability/fetch-gateway-debug-log.sh --target prod\|edge:<id>`（**本地** orchestrator，不走 run-probe） |
 | anthropic capacity / cap 与 schedulable 证据 | 机械 | `ops/observability/probe-caps.sh`（已有，通过 run-probe.sh 投递）/ `ops/anthropic/manage-anthropic-config.py snapshot` |
 | 镜像 edge 死活/容量判定（fleet 横扫：served_200:no_available_429 + 可调度账号数 → verdict） | 机械 | `ops/observability/scan-edge-health.sh`（本地 fan-out 全 deployable edge）/ 单边远端 `probe-edge-health.sh` + 纯函数 `edge_health_verdict.py`（`--selftest` 已进 preflight） |

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -792,6 +792,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				accountReleaseFunc()
 			}
 			if err != nil {
+				if h.handleKiroSilentRefusalMessages(c, err, streamStarted) {
+					return
+				}
 				// Beta policy block: return 400 immediately, no failover
 				var betaBlockedErr *service.BetaBlockedError
 				if errors.As(err, &betaBlockedErr) {

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -264,6 +264,9 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		}
 
 		if err != nil {
+			if h.handleKiroSilentRefusalChatCompletions(c, err) {
+				return
+			}
 			var failoverErr *service.UpstreamFailoverError
 			if errors.As(err, &failoverErr) {
 				if c.Writer.Size() != writerSizeBeforeForward {

--- a/backend/internal/handler/gateway_handler_tk_kiro_silent_refusal.go
+++ b/backend/internal/handler/gateway_handler_tk_kiro_silent_refusal.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+func (h *GatewayHandler) handleKiroSilentRefusalMessages(c *gin.Context, err error, streamStarted bool) bool {
+	var silentRefusalErr *service.KiroSilentRefusalError
+	if !errors.As(err, &silentRefusalErr) {
+		return false
+	}
+	c.Header(service.KiroOutcomeHeader, service.KiroSilentRefusalOutcome)
+	h.handleStreamingAwareError(
+		c,
+		http.StatusBadGateway,
+		"upstream_error",
+		service.KiroSilentRefusalClientMessage(),
+		streamStarted,
+	)
+	return true
+}
+
+func (h *GatewayHandler) handleKiroSilentRefusalChatCompletions(c *gin.Context, err error) bool {
+	var silentRefusalErr *service.KiroSilentRefusalError
+	if !errors.As(err, &silentRefusalErr) {
+		return false
+	}
+	c.Header(service.KiroOutcomeHeader, service.KiroSilentRefusalOutcome)
+	h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "All available accounts exhausted")
+	return true
+}

--- a/backend/internal/handler/gateway_handler_tk_kiro_silent_refusal_test.go
+++ b/backend/internal/handler/gateway_handler_tk_kiro_silent_refusal_test.go
@@ -1,0 +1,51 @@
+//go:build unit
+
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleKiroSilentRefusalMessagesPreservesGeneric502Contract(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	handled := (&GatewayHandler{}).handleKiroSilentRefusalMessages(c, &service.KiroSilentRefusalError{}, false)
+
+	require.True(t, handled)
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Equal(t, service.KiroSilentRefusalOutcome, rec.Header().Get(service.KiroOutcomeHeader))
+	require.JSONEq(t, `{"type":"error","error":{"type":"upstream_error","message":"Upstream service temporarily unavailable"}}`, rec.Body.String())
+}
+
+func TestHandleKiroSilentRefusalChatCompletionsPreservesGeneric502Contract(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	handled := (&GatewayHandler{}).handleKiroSilentRefusalChatCompletions(c, &service.KiroSilentRefusalError{})
+
+	require.True(t, handled)
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Equal(t, service.KiroSilentRefusalOutcome, rec.Header().Get(service.KiroOutcomeHeader))
+	require.JSONEq(t, `{"error":{"type":"server_error","message":"All available accounts exhausted"}}`, rec.Body.String())
+}
+
+func TestHandleKiroSilentRefusalIgnoresUnrelatedErrors(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	require.False(t, (&GatewayHandler{}).handleKiroSilentRefusalMessages(c, errors.New("other"), false))
+	require.False(t, (&GatewayHandler{}).handleKiroSilentRefusalChatCompletions(c, errors.New("other")))
+	require.False(t, rec.Result().Header.Get(service.KiroOutcomeHeader) != "")
+	require.Empty(t, rec.Body.String())
+}

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -828,6 +828,11 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 				break
 			}
 		}
+		if err, terminal := kiroSilentRefusalFromRelay(c, account, resp.Header, resp.StatusCode); terminal {
+			_, _ = s.readUpstreamErrorBody(resp)
+			_ = resp.Body.Close()
+			return nil, err
+		}
 
 		// 检查是否需要通用重试（排除400，因为400已经在上面特殊处理过了）
 		if resp.StatusCode >= 400 && resp.StatusCode != 400 && s.shouldRetryUpstreamError(account, resp.StatusCode) {

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -198,6 +198,9 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+		if terminalErr, terminal := kiroSilentRefusalFromRelay(c, account, resp.Header, resp.StatusCode); terminal {
+			return nil, terminalErr
+		}
 
 		if s.shouldFailoverUpstreamError(resp.StatusCode) {
 			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -140,6 +140,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		thinkingBuf string
 		toolUses    []kiroproto.KiroToolUse
 		callbackErr error
+		metered     bool
 		redactor    kiroproto.InlineThinkingRedactor
 	)
 
@@ -161,6 +162,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
 		// We estimate token usage locally below instead of trusting these values.
 		OnCredits: func(credits float64) {
+			metered = metered || credits > 0
 			logKiroCredits(kiroAcct, model, credits)
 		},
 		OnError: func(err error) {
@@ -171,6 +173,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 			thinkingBuf = ""
 			toolUses = nil
 			callbackErr = nil
+			metered = false
 			redactor = kiroproto.InlineThinkingRedactor{}
 			return true
 		},
@@ -187,6 +190,9 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		thinkingBuf += inlineThinking
 	}
 	if textBuf == "" && thinkingBuf == "" && len(toolUses) == 0 {
+		if metered {
+			return nil, classifyAndRecordKiroForwardError(c, account, &KiroSilentRefusalError{}, model)
+		}
 		return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
 	}
 
@@ -264,6 +270,7 @@ func (s *KiroGatewayService) forwardStreaming(
 		thinkingBuf string
 		toolUses    []kiroproto.KiroToolUse
 		callbackErr error
+		metered     bool
 		firstTokMs  *int
 		redactor    kiroproto.InlineThinkingRedactor
 	)
@@ -309,6 +316,9 @@ func (s *KiroGatewayService) forwardStreaming(
 		// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
 		// We estimate token usage locally below instead of trusting these values.
 		OnCredits: func(credits float64) {
+			mu.Lock()
+			defer mu.Unlock()
+			metered = metered || credits > 0
 			logKiroCredits(kiroAcct, model, credits)
 		},
 		OnError: func(err error) {
@@ -326,6 +336,7 @@ func (s *KiroGatewayService) forwardStreaming(
 			thinkingBuf = ""
 			toolUses = nil
 			callbackErr = nil
+			metered = false
 			firstTokMs = nil
 			redactor = kiroproto.InlineThinkingRedactor{}
 			return true
@@ -363,13 +374,6 @@ func (s *KiroGatewayService) forwardStreaming(
 		writeKiroStreamError(c, flusher, "stream_read_error", msg)
 		return nil, fmt.Errorf("kiro stream callback error: %w", callbackErr)
 	}
-	if !enc.started && textBuf == "" && thinkingBuf == "" && len(toolUses) == 0 {
-		return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
-	}
-
-	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
-	// inputTokens was already computed for the encoder (message_start.usage); reuse
-	// it for the ForwardResult so the two never drift.
 	if visible, inlineThinking := redactor.Flush(); visible != "" || inlineThinking != "" {
 		if inlineThinking != "" {
 			thinkingBuf += inlineThinking
@@ -379,6 +383,16 @@ func (s *KiroGatewayService) forwardStreaming(
 			enc.writeTextDelta(visible)
 		}
 	}
+	if !enc.started && textBuf == "" && thinkingBuf == "" && len(toolUses) == 0 {
+		if metered {
+			return nil, classifyAndRecordKiroForwardError(c, account, &KiroSilentRefusalError{}, model)
+		}
+		return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
+	}
+
+	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
+	// inputTokens was already computed for the encoder (message_start.usage); reuse
+	// it for the ForwardResult so the two never drift.
 	inputTokens := enc.inputTokens
 	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, toolUses)
 

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -248,6 +248,65 @@ func TestKiroGatewayService_Forward_EmptyResponseTriggersFailover(t *testing.T) 
 	require.Equal(t, int64(99), events[0].AccountID)
 }
 
+func TestKiroGatewayService_Forward_NonStreamingMeteringWithoutOutputIsTerminal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	frame := buildKiroEventStreamMessage("meteringEvent", []byte(`{"usage":0.25}`))
+	svc := NewKiroGatewayService(&kiroFakeUpstream{body: frame}, nil, nil)
+	body, _ := json.Marshal(map[string]any{
+		"model":    "claude-sonnet-4-5",
+		"messages": []map[string]any{{"role": "user", "content": "policy-sensitive request"}},
+		"stream":   false,
+	})
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-sonnet-4-5", Stream: false}
+
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), parsed, time.Now())
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	var silentRefusalErr *KiroSilentRefusalError
+	require.ErrorAs(t, err, &silentRefusalErr)
+	var failoverErr *UpstreamFailoverError
+	require.NotErrorAs(t, err, &failoverErr)
+	require.Empty(t, rec.Body.String())
+	events := opsUpstreamErrorsForTest(c)
+	require.Len(t, events, 1)
+	require.Equal(t, "silent_refusal", events[0].Kind)
+	require.Equal(t, "metering_without_output", events[0].Reason)
+	require.Equal(t, int64(99), events[0].AccountID)
+}
+
+func TestKiroGatewayService_Forward_StreamingMeteringWithoutOutputIsTerminal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	frame := buildKiroEventStreamMessage("meteringEvent", []byte(`{"usage":0.25}`))
+	svc := NewKiroGatewayService(&kiroFakeUpstream{body: frame}, nil, nil)
+	body, _ := json.Marshal(map[string]any{
+		"model":    "claude-sonnet-4-5",
+		"messages": []map[string]any{{"role": "user", "content": "policy-sensitive request"}},
+		"stream":   true,
+	})
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-sonnet-4-5", Stream: true}
+
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), parsed, time.Now())
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	var silentRefusalErr *KiroSilentRefusalError
+	require.ErrorAs(t, err, &silentRefusalErr)
+	var failoverErr *UpstreamFailoverError
+	require.NotErrorAs(t, err, &failoverErr)
+	require.Empty(t, rec.Body.String(), "terminal refusal must not commit a successful SSE stream")
+	events := opsUpstreamErrorsForTest(c)
+	require.Len(t, events, 1)
+	require.Equal(t, "silent_refusal", events[0].Kind)
+	require.Equal(t, "metering_without_output", events[0].Reason)
+}
+
 func TestKiroGatewayService_Forward_NonStreaming_ReadFailureRetriesWithoutPartialOutput(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -18,6 +18,32 @@ var kiroTransportFailoverBody = []byte(`{"error":{"type":"upstream_error","messa
 
 var errKiroEmptyResponse = errors.New("kiro upstream returned an empty response")
 
+const (
+	KiroOutcomeHeader              = "X-TokenKey-Kiro-Outcome"
+	KiroSilentRefusalOutcome       = "silent_refusal"
+	kiroSilentRefusalReason        = "metering_without_output"
+	kiroSilentRefusalClientMessage = "Upstream service temporarily unavailable"
+)
+
+// KiroSilentRefusalError marks a request-owned Kiro outcome: the upstream
+// accepted and metered the request but emitted no assistant content. Retrying
+// another account cannot change that request, so handlers must terminate the
+// failover loop while preserving the existing generic 502 client contract.
+type KiroSilentRefusalError struct{}
+
+func (e *KiroSilentRefusalError) Error() string {
+	return "kiro upstream metered the request without assistant output"
+}
+
+func KiroSilentRefusalClientMessage() string {
+	return kiroSilentRefusalClientMessage
+}
+
+func IsKiroSilentRefusalRelayResponse(account *Account, header http.Header) bool {
+	return account != nil && account.IsKiroMirrorStub() &&
+		strings.EqualFold(strings.TrimSpace(header.Get(KiroOutcomeHeader)), KiroSilentRefusalOutcome)
+}
+
 // KiroInvalidModelError is a typed, status-carrying error raised when the Kiro
 // (sixth platform) upstream rejects a request with HTTP 400 INVALID_MODEL_ID —
 // i.e. the requested model is not one the Kiro/CodeWhisperer backend serves.
@@ -110,8 +136,9 @@ func isKiroEndpointQuotaExhaustedError(msg string) bool {
 }
 
 type kiroForwardErrorObservation struct {
-	Kind   string
-	Reason string
+	Kind               string
+	Reason             string
+	UpstreamStatusCode int
 }
 
 func classifyAndRecordKiroForwardError(c *gin.Context, account *Account, err error, model string) error {
@@ -125,6 +152,10 @@ func classifyAndRecordKiroForwardError(c *gin.Context, account *Account, err err
 func classifyKiroForwardError(err error, model string) (*kiroForwardErrorObservation, error) {
 	if err == nil {
 		return nil, nil
+	}
+	var silentRefusalErr *KiroSilentRefusalError
+	if errors.As(err, &silentRefusalErr) {
+		return &kiroForwardErrorObservation{Kind: "silent_refusal", Reason: kiroSilentRefusalReason}, silentRefusalErr
 	}
 	msg := err.Error()
 	if isKiroEndpointQuotaExhaustedError(msg) {
@@ -236,20 +267,35 @@ func recordKiroForwardError(c *gin.Context, account *Account, err error, observa
 		return
 	}
 	safeErr := truncateString(sanitizeUpstreamErrorMessage(err.Error()), 2048)
-	setOpsUpstreamError(c, 0, safeErr, "")
+	setOpsUpstreamError(c, observation.UpstreamStatusCode, safeErr, "")
 	event := OpsUpstreamErrorEvent{
 		Platform:           PlatformKiro,
-		UpstreamStatusCode: 0,
+		UpstreamStatusCode: observation.UpstreamStatusCode,
 		Kind:               observation.Kind,
 		Reason:             observation.Reason,
 		Message:            safeErr,
 	}
 	if account != nil {
-		event.Platform = account.Platform
+		if !account.IsKiroMirrorStub() {
+			event.Platform = account.Platform
+		}
 		event.AccountID = account.ID
 		event.AccountName = account.Name
 	}
 	appendOpsUpstreamError(c, event)
+}
+
+func kiroSilentRefusalFromRelay(c *gin.Context, account *Account, header http.Header, statusCode int) (error, bool) {
+	if !IsKiroSilentRefusalRelayResponse(account, header) {
+		return nil, false
+	}
+	err := &KiroSilentRefusalError{}
+	recordKiroForwardError(c, account, err, kiroForwardErrorObservation{
+		Kind:               "silent_refusal",
+		Reason:             kiroSilentRefusalReason,
+		UpstreamStatusCode: statusCode,
+	})
+	return err, true
 }
 
 func isKiroProfileArnError(msg string) bool {

--- a/backend/internal/service/kiro_gateway_silent_refusal_relay_test.go
+++ b/backend/internal/service/kiro_gateway_silent_refusal_relay_test.go
@@ -1,0 +1,110 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func newKiroMirrorStubForSilentRefusalTest() *Account {
+	return &Account{
+		ID:          660,
+		Name:        "kiro-us4",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":         "edge-relay-key",
+			"base_url":        "https://api-us4.tokenkey.dev",
+			"mirror_platform": PlatformKiro,
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+}
+
+func newKiroSilentRefusalRelayResponse() *http.Response {
+	header := make(http.Header)
+	header.Set(KiroOutcomeHeader, KiroSilentRefusalOutcome)
+	header.Set("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Header:     header,
+		Body: io.NopCloser(bytes.NewBufferString(
+			`{"type":"error","error":{"type":"upstream_error","message":"Upstream service temporarily unavailable"}}`,
+		)),
+	}
+}
+
+func assertTerminalKiroSilentRefusal(t *testing.T, c *gin.Context, result *ForwardResult, err error) {
+	t.Helper()
+	require.Error(t, err)
+	require.Nil(t, result)
+	var silentRefusalErr *KiroSilentRefusalError
+	require.ErrorAs(t, err, &silentRefusalErr)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "request-owned refusal must not trigger mirror failover")
+	events := opsUpstreamErrorsForTest(c)
+	require.Len(t, events, 1)
+	require.Equal(t, PlatformKiro, events[0].Platform)
+	require.Equal(t, "silent_refusal", events[0].Kind)
+	require.Equal(t, "metering_without_output", events[0].Reason)
+	require.Equal(t, http.StatusBadGateway, events[0].UpstreamStatusCode)
+}
+
+func TestGatewayService_Forward_KiroMirrorSilentRefusalStopsBeforeRetry(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	upstream := &httpUpstreamRecorder{resp: newKiroSilentRefusalRelayResponse()}
+	svc := &GatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{
+			URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+		}},
+		httpUpstream: upstream,
+	}
+	body := []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"policy-sensitive request"}],"stream":false}`)
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-sonnet-4-5", Stream: false}
+
+	result, err := svc.Forward(context.Background(), c, newKiroMirrorStubForSilentRefusalTest(), parsed)
+
+	assertTerminalKiroSilentRefusal(t, c, result, err)
+	require.Len(t, upstream.requests, 1, "terminal relay outcome must skip same-account retry")
+	require.Empty(t, rec.Body.String())
+}
+
+func TestGatewayService_ForwardAsChatCompletions_KiroMirrorSilentRefusalStopsFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	upstream := &httpUpstreamRecorder{resp: newKiroSilentRefusalRelayResponse()}
+	svc := &GatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{
+			URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+		}},
+		httpUpstream: upstream,
+	}
+	body := []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"policy-sensitive request"}],"stream":false}`)
+
+	result, err := svc.ForwardAsChatCompletions(
+		context.Background(), c, newKiroMirrorStubForSilentRefusalTest(), body, nil,
+	)
+
+	assertTerminalKiroSilentRefusal(t, c, result, err)
+	require.Len(t, upstream.requests, 1)
+	require.Empty(t, rec.Body.String())
+}

--- a/ops/observability/ops-error-triage.sh
+++ b/ops/observability/ops-error-triage.sh
@@ -139,6 +139,9 @@ WITH bounds AS (
 SELECT row_to_json(t) FROM (
   SELECT
     COALESCE(ev->>'kind','')                  AS kind,
+    COALESCE(ev->>'reason','')                AS reason,
+    left(regexp_replace(COALESCE(ev->>'message',''), E'[\\n\\r]+', ' ', 'g'), 160)
+                                                AS message,
     COALESCE(ev->>'platform','')              AS platform,
     COALESCE(ev->>'account_id','')            AS account_id,
     COALESCE(ev->>'account_name','')          AS account_name,
@@ -148,7 +151,7 @@ SELECT row_to_json(t) FROM (
     to_char(MIN(created_at) AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS first_at_utc,
     to_char(MAX(created_at) AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS last_at_utc
   FROM events
-  GROUP BY kind, platform, account_id, account_name, upstream_status, final_status
+  GROUP BY kind, reason, message, platform, account_id, account_name, upstream_status, final_status
   ORDER BY n DESC, kind, final_status
   LIMIT ${TOP_KIND_LIMIT}
 ) t;

--- a/ops/observability/probe-ops-error-request-shape.sh
+++ b/ops/observability/probe-ops-error-request-shape.sh
@@ -124,8 +124,8 @@ SELECT row_to_json(t) FROM (
 " 2>&1
 
   echo
-  echo "=== fallback_samples ==="
-  $PSQL -c "
+echo "=== fallback_samples ==="
+$PSQL -c "
 WITH base AS (
   SELECT l.*
   FROM ops_error_logs l
@@ -149,6 +149,11 @@ SELECT row_to_json(t) FROM (
     account_id,
     group_id,
     request_path,
+    stream,
+    left(COALESCE(user_agent,''), 120) AS user_agent,
+    inbound_endpoint,
+    upstream_endpoint,
+    request_type,
     COALESCE(requested_model, model) AS model,
     error_phase,
     error_type,
@@ -165,6 +170,7 @@ SELECT row_to_json(t) FROM (
     (
       SELECT string_agg(
         concat_ws(':', ordinality::text, COALESCE(ev->>'kind',''),
+                  COALESCE(ev->>'reason',''),
                   COALESCE(NULLIF(ev->>'upstream_status_code',''),'0'),
                   left(COALESCE(ev->>'message',''), 80)),
         ' | ' ORDER BY ordinality
@@ -179,6 +185,43 @@ SELECT row_to_json(t) FROM (
   FROM base
   ORDER BY created_at DESC
   LIMIT ${LIMIT}
+) t;
+" 2>&1
+
+  echo
+  echo "=== fallback_upstream_request_body_presence ==="
+  $PSQL -c "
+WITH base AS (
+  SELECT l.*
+  FROM ops_error_logs l
+  WHERE l.created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+    AND l.status_code = ${STATUS_CODE}
+    AND ('${USER_ID}' = '' OR l.user_id = NULLIF('${USER_ID}','')::bigint)
+    AND ('${API_KEY_ID}' = '' OR l.api_key_id = NULLIF('${API_KEY_ID}','')::bigint)
+    AND ('${ACCOUNT_ID}' = '' OR l.account_id = NULLIF('${ACCOUNT_ID}','')::bigint)
+    AND ('${MODEL_SQL}' = '' OR l.requested_model = '${MODEL_SQL}' OR l.model = '${MODEL_SQL}')
+    AND ('${REQUEST_PATH_SQL}' = '' OR l.request_path = '${REQUEST_PATH_SQL}')
+    AND ('${ERROR_MESSAGE_LIKE_SQL}' = '' OR l.error_message ILIKE '%' || '${ERROR_MESSAGE_LIKE_SQL}' || '%')
+), events AS (
+  SELECT e.value AS ev
+  FROM base l
+  CROSS JOIN LATERAL jsonb_array_elements(
+    CASE WHEN jsonb_typeof(l.upstream_errors) = 'array'
+         THEN l.upstream_errors
+         ELSE '[]'::jsonb END
+  ) AS e(value)
+), bodies AS (
+  SELECT COALESCE(ev->>'upstream_request_body','') AS body
+  FROM events
+)
+SELECT row_to_json(t) FROM (
+  SELECT
+    COUNT(*) AS upstream_events,
+    COUNT(*) FILTER (WHERE body <> '') AS events_with_request_body,
+    COUNT(*) FILTER (WHERE left(ltrim(body), 1) = '{') AS object_like_bodies,
+    MIN(octet_length(body)) FILTER (WHERE body <> '') AS min_body_bytes,
+    MAX(octet_length(body)) FILTER (WHERE body <> '') AS max_body_bytes
+  FROM bodies
 ) t;
 " 2>&1
   exit 0

--- a/ops/observability/probe-qa-error-evidence.sh
+++ b/ops/observability/probe-qa-error-evidence.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# probe-qa-error-evidence.sh - correlate final ops errors with QA captures.
+#
+# This probe never prints request/response bodies or blob URIs. It reports
+# whether matching QA metadata and evidence blobs still exist, so operators can
+# decide whether a privacy-scoped deep inspection is possible.
+#
+# Env:
+#   WINDOW_MINUTES  lookback window, default 1440
+#   STATUS_CODE     final client status, default 502
+#   MODEL           optional exact requested model
+#   REQUEST_PATH    optional exact request path
+#   USER_AGENT_LIKE optional user-agent substring
+set -eu
+
+PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+WINDOW_MINUTES="${WINDOW_MINUTES:-1440}"
+STATUS_CODE="${STATUS_CODE:-502}"
+MODEL="${MODEL:-}"
+REQUEST_PATH="${REQUEST_PATH:-}"
+USER_AGENT_LIKE="${USER_AGENT_LIKE:-}"
+
+for name in WINDOW_MINUTES STATUS_CODE; do
+  value="${!name}"
+  case "$value" in
+    ''|*[!0-9]*) echo "[probe-qa-error-evidence] ERROR: $name must be a non-negative integer" >&2; exit 2 ;;
+  esac
+done
+
+sql_quote() {
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+MODEL_SQL=$(sql_quote "$MODEL")
+REQUEST_PATH_SQL=$(sql_quote "$REQUEST_PATH")
+USER_AGENT_LIKE_SQL=$(sql_quote "$USER_AGENT_LIKE")
+
+HAS_TABLE=$($PSQL -c "SELECT to_regclass('public.qa_records') IS NOT NULL;" 2>/dev/null | tr -d '[:space:]')
+if [ "$HAS_TABLE" != "t" ]; then
+  printf '%s\n' '{"qa_records_available":false,"note":"qa_records table is absent"}'
+  exit 0
+fi
+
+echo "=== coverage ==="
+$PSQL -c "
+WITH errors AS (
+  SELECT DISTINCT request_id
+  FROM ops_error_logs
+  WHERE created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+    AND status_code = ${STATUS_CODE}
+    AND ('${MODEL_SQL}' = '' OR requested_model = '${MODEL_SQL}' OR model = '${MODEL_SQL}')
+    AND ('${REQUEST_PATH_SQL}' = '' OR request_path = '${REQUEST_PATH_SQL}')
+    AND ('${USER_AGENT_LIKE_SQL}' = '' OR user_agent ILIKE '%' || '${USER_AGENT_LIKE_SQL}' || '%')
+), joined AS (
+  SELECT e.request_id, q.id AS qa_id, q.blob_uri, q.capture_status,
+         q.retention_until, q.created_at, q.request_sha256
+  FROM errors e
+  LEFT JOIN LATERAL (
+    SELECT id, blob_uri, capture_status, retention_until, created_at, request_sha256
+    FROM qa_records q
+    WHERE q.request_id = e.request_id
+    ORDER BY q.created_at DESC
+    LIMIT 1
+  ) q ON true
+)
+SELECT row_to_json(t) FROM (
+  SELECT
+    COUNT(*) AS error_requests,
+    COUNT(qa_id) AS qa_records,
+    COUNT(*) FILTER (WHERE blob_uri IS NOT NULL AND blob_uri <> '') AS qa_blob_refs,
+    COUNT(*) FILTER (WHERE request_sha256 <> '') AS request_hashes,
+    COUNT(DISTINCT NULLIF(request_sha256, '')) AS distinct_request_hashes,
+    COALESCE((
+      SELECT MAX(repeats)
+      FROM (
+        SELECT COUNT(*) AS repeats
+        FROM joined
+        WHERE request_sha256 <> ''
+        GROUP BY request_sha256
+      ) grouped_hashes
+    ), 0) AS max_same_request_repeats,
+    COUNT(*) FILTER (WHERE retention_until > now()) AS retention_active,
+    COUNT(*) FILTER (WHERE retention_until <= now()) AS retention_expired,
+    to_char(MIN(created_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS first_qa_at_utc,
+    to_char(MAX(created_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS last_qa_at_utc
+  FROM joined
+) t;
+"
+
+echo "=== capture_status ==="
+$PSQL -c "
+WITH errors AS (
+  SELECT DISTINCT request_id
+  FROM ops_error_logs
+  WHERE created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+    AND status_code = ${STATUS_CODE}
+    AND ('${MODEL_SQL}' = '' OR requested_model = '${MODEL_SQL}' OR model = '${MODEL_SQL}')
+    AND ('${REQUEST_PATH_SQL}' = '' OR request_path = '${REQUEST_PATH_SQL}')
+    AND ('${USER_AGENT_LIKE_SQL}' = '' OR user_agent ILIKE '%' || '${USER_AGENT_LIKE_SQL}' || '%')
+)
+SELECT row_to_json(t) FROM (
+  SELECT COALESCE(q.capture_status, 'missing') AS capture_status, COUNT(*) AS rows
+  FROM errors e
+  LEFT JOIN qa_records q ON q.request_id = e.request_id
+  GROUP BY 1
+  ORDER BY rows DESC, capture_status
+) t;
+"
+
+echo "=== replay_outcomes ==="
+$PSQL -c "
+WITH error_requests AS (
+  SELECT DISTINCT request_id
+  FROM ops_error_logs
+  WHERE created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+    AND status_code = ${STATUS_CODE}
+    AND ('${MODEL_SQL}' = '' OR requested_model = '${MODEL_SQL}' OR model = '${MODEL_SQL}')
+    AND ('${REQUEST_PATH_SQL}' = '' OR request_path = '${REQUEST_PATH_SQL}')
+    AND ('${USER_AGENT_LIKE_SQL}' = '' OR user_agent ILIKE '%' || '${USER_AGENT_LIKE_SQL}' || '%')
+), error_hashes AS (
+  SELECT q.request_sha256, COUNT(*) AS matching_error_rows
+  FROM error_requests e
+  JOIN qa_records q ON q.request_id = e.request_id
+  WHERE q.request_sha256 <> ''
+  GROUP BY q.request_sha256
+), outcomes AS (
+  SELECT
+    h.request_sha256,
+    h.matching_error_rows,
+    COUNT(q.*) FILTER (WHERE q.status_code >= 200 AND q.status_code < 400) AS success_rows,
+    COUNT(q.*) FILTER (WHERE q.status_code = ${STATUS_CODE}) AS same_status_rows,
+    COUNT(q.*) FILTER (WHERE q.status_code >= 400 AND q.status_code <> ${STATUS_CODE}) AS other_error_rows
+  FROM error_hashes h
+  LEFT JOIN qa_records q
+    ON q.request_sha256 = h.request_sha256
+   AND q.created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+  GROUP BY h.request_sha256, h.matching_error_rows
+)
+SELECT row_to_json(t) FROM (
+  SELECT
+    COUNT(*) AS distinct_error_request_hashes,
+    COUNT(*) FILTER (WHERE success_rows > 0) AS hashes_with_success,
+    COALESCE(SUM(success_rows), 0) AS success_rows,
+    COALESCE(SUM(same_status_rows), 0) AS same_status_rows,
+    COALESCE(SUM(other_error_rows), 0) AS other_error_rows,
+    MAX(matching_error_rows) AS max_matching_error_repeats
+  FROM outcomes
+) t;
+"
+
+echo "=== blob_storage ==="
+TMP_ROWS=$(mktemp)
+TMP_PATHS=$(mktemp)
+trap 'rm -f "$TMP_ROWS" "$TMP_PATHS"' EXIT
+$PSQL -F $'\t' -c "
+WITH errors AS (
+  SELECT DISTINCT request_id
+  FROM ops_error_logs
+  WHERE created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+    AND status_code = ${STATUS_CODE}
+    AND ('${MODEL_SQL}' = '' OR requested_model = '${MODEL_SQL}' OR model = '${MODEL_SQL}')
+    AND ('${REQUEST_PATH_SQL}' = '' OR request_path = '${REQUEST_PATH_SQL}')
+    AND ('${USER_AGENT_LIKE_SQL}' = '' OR user_agent ILIKE '%' || '${USER_AGENT_LIKE_SQL}' || '%')
+)
+SELECT DISTINCT q.request_id, q.blob_uri
+FROM errors e
+JOIN qa_records q ON q.request_id = e.request_id
+WHERE q.blob_uri IS NOT NULL AND q.blob_uri <> '';
+" > "$TMP_ROWS"
+
+local_refs=0
+local_present=0
+local_missing=0
+remote_refs=0
+app_container=""
+if [ -r /var/lib/tokenkey/active-color ]; then
+  color=$(tr -d '[:space:]' < /var/lib/tokenkey/active-color 2>/dev/null || true)  # preflight-allow: swallow -- fallback below
+  case "$color" in
+    blue|green)
+      if docker inspect "tokenkey-$color" >/dev/null 2>&1; then
+        app_container="tokenkey-$color"
+      fi
+      ;;
+  esac
+fi
+if [ -z "$app_container" ]; then
+  for candidate in tokenkey tokenkey-blue tokenkey-green; do
+    if docker inspect "$candidate" >/dev/null 2>&1; then
+      app_container="$candidate"
+      break
+    fi
+  done
+fi
+while IFS=$'\t' read -r _request_id blob_uri; do
+  [ -n "${blob_uri:-}" ] || continue
+  case "$blob_uri" in
+    file://*)
+      local_refs=$((local_refs + 1))
+      printf '%s\n' "${blob_uri#file://}" >> "$TMP_PATHS"
+      ;;
+    *) remote_refs=$((remote_refs + 1)) ;;
+  esac
+done < "$TMP_ROWS"
+if [ "$local_refs" -gt 0 ] && [ -n "$app_container" ]; then
+  counts=$(docker exec -i "$app_container" sh -c '
+    present=0
+    missing=0
+    while IFS= read -r path; do
+      if [ -f "$path" ]; then
+        present=$((present + 1))
+      else
+        missing=$((missing + 1))
+      fi
+    done
+    printf "%s\t%s\n" "$present" "$missing"
+  ' < "$TMP_PATHS")
+  IFS=$'\t' read -r local_present local_missing <<EOF
+$counts
+EOF
+else
+  local_missing=$local_refs
+fi
+printf '{"local_refs":%d,"local_present":%d,"local_missing":%d,"remote_refs":%d}\n' \
+  "$local_refs" "$local_present" "$local_missing" "$remote_refs"

--- a/ops/observability/test_ops_error_triage.py
+++ b/ops/observability/test_ops_error_triage.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import pathlib
 import subprocess
+import tempfile
 import unittest
 
 _SCRIPT = pathlib.Path(__file__).resolve().parent / "ops-error-triage.sh"
@@ -42,6 +43,33 @@ class OpsErrorTriageTest(unittest.TestCase):
         )
         self.assertEqual(proc.returncode, 2)
         self.assertIn("WINDOW_HOURS not positive int", proc.stderr)
+
+    def test_upstream_event_query_keeps_reason_and_bounded_message(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_docker = pathlib.Path(tmp) / "docker"
+            fake_docker.write_text(
+                "#!/bin/sh\n"
+                "case \"$*\" in\n"
+                "  *\"ev->>'reason'\"*\"ev->>'message'\"*)\n"
+                "    printf '%s\\n' '{\"kind\":\"response_error\",\"reason\":\"empty_response\",\"message\":\"kiro upstream returned an empty response\"}' ;;\n"
+                "  *) printf '%s\\n' '{}' ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            fake_docker.chmod(0o755)
+            proc = subprocess.run(
+                ["/bin/bash", str(_SCRIPT)],
+                env={"PATH": f"{tmp}:/usr/bin:/bin", "WINDOW_MINUTES": "5"},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        upstream_section = proc.stdout.split("=== upstream_events ===", 1)[1]
+        upstream_section = upstream_section.split("=== by_minute_429 ===", 1)[0]
+        self.assertIn('"reason":"empty_response"', upstream_section)
+        self.assertIn('"message":"kiro upstream returned an empty response"', upstream_section)
 
 
 if __name__ == "__main__":

--- a/ops/observability/test_probe_qa_error_evidence.py
+++ b/ops/observability/test_probe_qa_error_evidence.py
@@ -1,0 +1,95 @@
+import os
+import pathlib
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "ops" / "observability" / "probe-qa-error-evidence.sh"
+
+
+class QAErrorEvidenceProbeTest(unittest.TestCase):
+    def run_probe(self, docker_script: str, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_bin = pathlib.Path(tmp)
+            docker = fake_bin / "docker"
+            docker.write_text(textwrap.dedent(docker_script), encoding="utf-8")
+            docker.chmod(docker.stat().st_mode | stat.S_IXUSR)
+            env = os.environ.copy()
+            env.update(env_overrides)
+            env["PATH"] = f"{fake_bin}:{env['PATH']}"
+            return subprocess.run(
+                ["bash", str(SCRIPT)],
+                cwd=ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+    def test_reports_metadata_replay_and_batched_blob_presence(self) -> None:
+        proc = self.run_probe(
+            r"""
+            #!/bin/sh
+            if [ "$1" = "inspect" ]; then
+              [ "$2" = "tokenkey-blue" ] && exit 0
+              exit 1
+            fi
+            if [ "$1" = "exec" ] && [ "$2" = "tokenkey-postgres" ]; then
+              case "$*" in
+                *to_regclass*) echo t ;;
+                *distinct_error_request_hashes*) echo '{"distinct_error_request_hashes":2,"hashes_with_success":0}' ;;
+                *distinct_request_hashes*) echo '{"error_requests":3,"qa_records":3,"distinct_request_hashes":2}' ;;
+                *COALESCE\(q.capture_status*) echo '{"capture_status":"captured","rows":3}' ;;
+                *"SELECT DISTINCT q.request_id, q.blob_uri"*)
+                  printf 'r1\tfile:///app/data/qa_blobs/r1.zst\n'
+                  printf 'r2\tfile:///app/data/qa_blobs/r2.zst\n'
+                  ;;
+              esac
+              exit 0
+            fi
+            if [ "$1" = "exec" ] && [ "$2" = "-i" ] && [ "$3" = "tokenkey-blue" ]; then
+              cat >/dev/null
+              printf '1\t1\n'
+              exit 0
+            fi
+            exit 1
+            """,
+            MODEL="claude-sonnet-4-5",
+            REQUEST_PATH="/v1/chat/completions",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn('"error_requests":3', proc.stdout)
+        self.assertIn('"hashes_with_success":0', proc.stdout)
+        self.assertIn('"capture_status":"captured"', proc.stdout)
+        self.assertIn(
+            '{"local_refs":2,"local_present":1,"local_missing":1,"remote_refs":0}',
+            proc.stdout,
+        )
+        self.assertNotIn("qa_blobs/r1", proc.stdout)
+
+    def test_reports_missing_qa_table(self) -> None:
+        proc = self.run_probe(
+            r"""
+            #!/bin/sh
+            if [ "$1" = "exec" ] && [ "$2" = "tokenkey-postgres" ]; then
+              echo f
+              exit 0
+            fi
+            exit 1
+            """
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn('"qa_records_available":false', proc.stdout)
+
+    def test_rejects_invalid_numeric_filter_before_docker(self) -> None:
+        proc = self.run_probe("#!/bin/sh\nexit 99\n", WINDOW_MINUTES="1 hour")
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("WINDOW_MINUTES must be a non-negative integer", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -937,9 +937,11 @@
       "must_contain": [
         "if account.IsKiro() {",
         "forwardAsChatCompletionsViaKiro(",
+        "kiroSilentRefusalFromRelay(c, account, resp.Header, resp.StatusCode)",
+        "isAnthropicMessagesJSONResponse(resp)",
         "!account.IsKiro()"
       ],
-      "rationale": "Kiro OAuth accounts on /v1/chat/completions must not fall through to buildUpstreamRequest + Anthropic HTTP after CC→Anthropic conversion — that path 401s because Kiro credentials are not Anthropic API keys. The early branch routes through kiroGateway.Forward and reuses the Anthropic SSE→Chat Completions bridge; skipping OAuth mimicry for Kiro is anchored via !account.IsKiro(). Dropping the hook compiles cleanly but leaves every edge Kiro CC request failing with upstream_rejected 401 while /v1/messages on the same account succeeds."
+      "rationale": "Kiro OAuth accounts on /v1/chat/completions must route through kiroGateway.Forward instead of Anthropic HTTP. Kiro mirror stubs must recognize silent-refusal relay markers before failover, while non-streaming JSON responses use the Anthropic JSON converter. Dropping these hooks either restores 401s, cross-account amplification, or invalid response parsing."
     },
     {
       "path": "backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -221,10 +221,12 @@
         "BillingTier:   kiroproto.KiroEstimatedBillingTier",
         "callErr != nil && !enc.started",
         "textBuf == \"\" && thinkingBuf == \"\" && len(toolUses) == 0",
+        "metered = metered || credits > 0",
+        "&KiroSilentRefusalError{}",
         "classifyAndRecordKiroForwardError",
         "publishKiroInternalThinkingSideChannel"
       ],
-      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream. It estimates token usage locally (EstimateInputTokens/EstimateOutputTokens) and stamps ForwardResult.BillingTier=\"kiro-estimated\", because the Kiro upstream reports credits only — without these calls both forward paths return Usage{0,0} and kiro bills as 100% free. The context-aware call and ResetForRetry callbacks are load-bearing: non-streaming retries clear all partial buffers, while streaming retries are rejected after enc.started to prevent duplicated client output. The `callErr != nil && !enc.started` guard + classifyAndRecordKiroForwardError keep pre-content failures visible instead of returning an empty 200 stream and retain the sanitized original transport/read cause in ops upstream_errors. An upstream merge that drops any of these guards silently regresses reliability, billing, response integrity, or incident diagnosability."
+      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream. It estimates token usage locally (EstimateInputTokens/EstimateOutputTokens) and stamps ForwardResult.BillingTier=\"kiro-estimated\", because the Kiro upstream reports credits only — without these calls both forward paths return Usage{0,0} and kiro bills as 100% free. The context-aware call and ResetForRetry callbacks are load-bearing: non-streaming retries clear all partial buffers, while streaming retries are rejected after enc.started to prevent duplicated client output. The `callErr != nil && !enc.started` guard + classifyAndRecordKiroForwardError keep pre-content failures visible instead of returning an empty 200 stream. Positive metering with no text/thinking/tool output is classified as a request-owned KiroSilentRefusalError so the same payload is not amplified across the mirror pool. An upstream merge that drops any of these guards silently regresses reliability, billing, response integrity, or incident diagnosability."
     },
     {
       "path": "backend/internal/service/kiro_gateway_service_test.go",
@@ -232,6 +234,8 @@
         "TestKiroGatewayService_Forward_NonStreaming_ReadFailureRetriesWithoutPartialOutput",
         "TestKiroGatewayService_Forward_Streaming_MidStreamReadErrorSendsSSEError",
         "TestKiroGatewayService_Forward_EmptyResponseTriggersFailover",
+        "TestKiroGatewayService_Forward_NonStreamingMeteringWithoutOutputIsTerminal",
+        "TestKiroGatewayService_Forward_StreamingMeteringWithoutOutputIsTerminal",
         "TestKiroGatewayService_Forward_Streaming_PreContentReadErrorTriggersFailover",
         "TestKiroGatewayService_Forward_EventStreamThrottlingTriggersFailover",
         "TestKiroGatewayService_Forward_EmptyEventStreamExceptionPreservesFailoverClass",
@@ -244,7 +248,7 @@
         "discard me",
         "recovered"
       ],
-      "rationale": "Service-layer regression evidence for both sides of the truncated-response contract: non-streaming partial state is fully discarded before fallback, while a stream that already committed output emits an SSE error and never calls another upstream endpoint. It also pins Kiro's content-length validation as a client-owned non-failover error so context overflow cannot regress to provider 502 churn. The transport regression preserves the sanitized original cause and stable classification for ops while proving query secrets are redacted and client cancellation is not misreported as an upstream failure."
+      "rationale": "Service-layer regression evidence for both sides of the truncated-response contract: non-streaming partial state is fully discarded before fallback, while a stream that already committed output emits an SSE error and never calls another upstream endpoint. It also pins metered empty output as a terminal silent refusal in both response modes and Kiro's content-length validation as a client-owned non-failover error. The transport regression preserves the sanitized original cause and stable classification for ops while proving query secrets are redacted and client cancellation is not misreported as an upstream failure."
     },
     {
       "path": "backend/internal/service/kiro_sse_encoder.go",
@@ -342,16 +346,47 @@
       "path": "backend/internal/handler/gateway_handler.go",
       "must_contain": [
         "account.IsKiro()",
+        "h.handleKiroSilentRefusalMessages(c, err, streamStarted)",
         "service.KiroInvalidModelError",
         "service.KiroInvalidRequestError",
         "service.KiroEndpointQuotaExhaustedError",
         "service.KiroEndpointQuotaExhaustedRetryAfterSeconds()"
       ],
-      "rationale": "The RPM-increment gate (both the streaming and non-streaming paths) admits kiro accounts via `|| account.IsKiro()`. An upstream merge that rewrites these gates must preserve the kiro arm, or kiro accounts skip RPM accounting and bypass the per-account rate limit. The KiroInvalidModelError errors.As branch returns a clean 400 invalid_request_error (no cross-account failover) when the Kiro upstream rejects the model; losing it reverts to the silent empty-200 / failover-churn behavior. The KiroEndpointQuotaExhaustedError branch returns 429+Retry-After:10 instead of a generic 502 when all Kiro upstream endpoints hit quota exhaustion."
+      "rationale": "The RPM-increment gate admits kiro accounts via `|| account.IsKiro()`. The silent-refusal branch terminates a request-owned metered-empty outcome before the generic account failover loop. The KiroInvalidModelError branch returns a clean 400 invalid_request_error, and the KiroEndpointQuotaExhaustedError branch returns 429+Retry-After:10. Losing these anchors restores account churn, incorrect RPM accounting, or opaque client errors."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_chat_completions.go",
+      "must_contain": [
+        "h.handleKiroSilentRefusalChatCompletions(c, err)"
+      ],
+      "rationale": "The Chat Completions failover loop must terminate typed Kiro silent refusals before treating them as account health failures. Dropping this injection restores cross-account amplification for content-specific metered-empty outcomes."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_tk_kiro_silent_refusal.go",
+      "must_contain": [
+        "func (h *GatewayHandler) handleKiroSilentRefusalMessages",
+        "func (h *GatewayHandler) handleKiroSilentRefusalChatCompletions",
+        "service.KiroOutcomeHeader",
+        "service.KiroSilentRefusalClientMessage()"
+      ],
+      "rationale": "TK-only handler companion for the Kiro silent-refusal contract. It propagates the bounded edge-to-prod outcome marker while preserving the existing generic 502 envelopes for Messages and Chat Completions."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_tk_kiro_silent_refusal_test.go",
+      "must_contain": [
+        "TestHandleKiroSilentRefusalMessagesPreservesGeneric502Contract",
+        "TestHandleKiroSilentRefusalChatCompletionsPreservesGeneric502Contract",
+        "TestHandleKiroSilentRefusalIgnoresUnrelatedErrors"
+      ],
+      "rationale": "Regression evidence that typed Kiro silent refusals preserve both external 502 response shapes and do not intercept unrelated errors."
     },
     {
       "path": "backend/internal/service/kiro_gateway_service_tk_errors.go",
       "must_contain": [
+        "type KiroSilentRefusalError",
+        "KiroOutcomeHeader",
+        "KiroSilentRefusalOutcome",
+        "func kiroSilentRefusalFromRelay",
         "type KiroInvalidModelError",
         "type KiroInvalidRequestError",
         "type KiroEndpointQuotaExhaustedError",
@@ -366,7 +401,30 @@
         "quota exhausted on",
         "INVALID_MODEL_ID"
       ],
-      "rationale": "TK-only typed error + classifier for Kiro request rejections, including INVALID_MODEL_ID and CONTENT_LENGTH_EXCEEDS_THRESHOLD. classifyAndRecordKiroForwardError is called from both forwardStreaming and forwardNonStreaming; it preserves a sanitized, categorized transport/read/empty-response cause in ops upstream_errors while the client still receives the generic 502 envelope. The handler maps typed invalid model/request errors to client-owned 400 responses without cross-account failover. Losing this file makes Kiro validation errors fall back to the generic forward-error path or restores opaque 502s with no recoverable root cause."
+      "rationale": "TK-only typed errors and classifiers for Kiro request rejections, including silent refusal, INVALID_MODEL_ID, and CONTENT_LENGTH_EXCEEDS_THRESHOLD. The relay marker carries a metered-empty outcome from edge to prod without changing the generic response body, while ops records a stable kind/reason. Losing this file restores opaque 502s, cross-account amplification, or incorrect failover of client-owned validation failures."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward.go",
+      "must_contain": [
+        "kiroSilentRefusalFromRelay(c, account, resp.Header, resp.StatusCode)"
+      ],
+      "rationale": "The Anthropic Messages mirror path must recognize the Kiro edge outcome marker before generic same-account retries and failover handling. This injection is the prod-side stop point for request-owned silent refusals."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
+      "must_contain": [
+        "kiroSilentRefusalFromRelay(c, account, resp.Header, resp.StatusCode)"
+      ],
+      "rationale": "The Chat Completions mirror path must recognize the Kiro edge outcome marker before generic account failover and cooldown logic. Dropping this injection restores the observed multi-account amplification."
+    },
+    {
+      "path": "backend/internal/service/kiro_gateway_silent_refusal_relay_test.go",
+      "must_contain": [
+        "TestGatewayService_Forward_KiroMirrorSilentRefusalStopsBeforeRetry",
+        "TestGatewayService_ForwardAsChatCompletions_KiroMirrorSilentRefusalStopsFailover",
+        "metering_without_output"
+      ],
+      "rationale": "Cross-hop regression evidence that a Kiro edge silent-refusal marker becomes a terminal typed error on prod for both Messages and Chat Completions, before same-account retry or mirror failover."
     },
     {
       "path": "backend/internal/service/wire.go",


### PR DESCRIPTION
## 摘要

- 将 Kiro 已产生正向 `meteringEvent`、但没有 text/thinking/tool 输出的结果分类为请求级 `silent_refusal`。
- edge 通过固定枚举 outcome header 传递给 prod；prod 在同账号重试、跨 mirror failover 和账号惩罚前终止扩散。
- 保持现有外部错误契约：Messages 仍返回通用 502 `Upstream service temporarily unavailable`，Chat Completions 仍返回通用 502 `All available accounts exhausted`。
- 补充 `ops_error_logs` 分类、请求形状探针和 QA evidence 覆盖探针；探针不输出请求正文、响应正文或 blob URI。

## 风险

- QA 只读证据显示，失败请求是内容相关且跨账号稳定复现，不是账号健康故障：失败请求哈希在窗口内没有成功记录；同窗口大量结构相同的 Kiro 多轮请求正常成功。
- 正向计量但零输出被视为请求级终态，因此不会再尝试其他 Kiro 账号；该判断由失败哈希跨账号无成功样本和回归测试共同保护。
- outcome header 只携带固定枚举，不含 prompt、账号凭证或上游正文。
- 已 rebase 到包含 #1396 Kiro 非流式桥接修复及 #1397 Axios 1.18.1 安全修复的最新 `main`。
- Web impact: none
- sentinel-registry-reviewed
- 本 PR 不包含部署、重启或线上配置修改。

## 验证

- `go test -tags=unit ./internal/service ./internal/handler ./internal/integration/kiro -count=1`
- `python3 -m unittest ops.observability.test_ops_error_triage ops.observability.test_probe_qa_error_evidence -v`
- `bash -n ops/observability/ops-error-triage.sh ops/observability/probe-ops-error-request-shape.sh ops/observability/probe-qa-error-evidence.sh`
- `git diff --check origin/main...HEAD`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- 生产 QA 只读对照：31 种失败请求均有在保留期内的 evidence，失败哈希无成功样本；同窗口 1,120 种 Kiro Chat 成功请求覆盖相同的 system、多轮历史和 `temperature=0` 结构。

## 提交

- 73a2341b3 fix(kiro): 终止计量空响应的镜像扩散
- 最新提交：73a2341b3
