### PR TITLE
feat(billing): 对齐 DeepSeek 官方峰谷分时计费

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 )
 
 // APIKeyRateLimitCacheData holds rate limit usage data cached in Redis.
@@ -858,6 +859,9 @@ type CostInput struct {
 	Resolver                  *ModelPricingResolver // 定价解析器
 	Resolved                  *ResolvedPricing      // 可选：预解析的定价结果（避免重复 Resolve 调用）
 	LongContextBillingEnabled *bool
+	// BillingAt is the wall-clock instant used for provider time-of-day pricing
+	// (DeepSeek peak-valley). Zero → timezone.Now() at billing time.
+	BillingAt time.Time
 }
 
 // CalculateCostUnified 统一计费入口，支持三种计费模式。
@@ -919,7 +923,12 @@ func (s *BillingService) calculateTokenCost(resolved *ResolvedPricing, input Cos
 		return nil, fmt.Errorf("no pricing available for model: %s: %w", input.Model, ErrModelPricingUnavailable)
 	}
 
+	at := input.BillingAt
+	if at.IsZero() {
+		at = timezone.Now()
+	}
 	pricing = s.applyModelSpecificPricingPolicy(input.Model, pricing)
+	pricing = tkApplyDeepSeekPeakValleyPricing(input.Model, pricing, at, resolved.Source)
 
 	// 长上下文定价仅在无区间定价时应用（区间定价已包含上下文分层）
 	applyLongCtx := len(resolved.Intervals) == 0
@@ -1132,6 +1141,13 @@ func (s *BillingService) calculateCostInternalWithPolicy(
 	if err != nil {
 		return nil, err
 	}
+
+	source := PricingSourceLiteLLM
+	if channelPricing != nil {
+		source = PricingSourceChannel
+	}
+	pricing = s.applyModelSpecificPricingPolicy(model, pricing)
+	pricing = tkApplyDeepSeekPeakValleyPricing(model, pricing, timezone.Now(), source)
 
 	// 旧路径始终检查长上下文定价（无区间定价概念）。该路径不携带 enable_thinking
 	// （仅 CalculateCostUnified/CostInput 链路透传思考模式），故按非思考计费。

--- a/backend/internal/service/pricing_catalog_tk.go
+++ b/backend/internal/service/pricing_catalog_tk.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -109,6 +110,22 @@ type PublicCatalogPricing struct {
 	// their first-tier price only — the ladder lived only in the compiled-in
 	// tk_pricing_overlay.json. Omitted for flat-priced models.
 	Tiers []PublicCatalogTier `json:"tiers,omitempty"`
+	// PeakValley, when present, documents provider time-of-day peak pricing on top
+	// of the flat fields above (currently DeepSeek direct API). Billing applies
+	// PeakMultiplier during the listed windows in Timezone; flat prices are
+	// off-peak (谷时).
+	PeakValley *PublicCatalogPeakValley `json:"peak_valley,omitempty"`
+}
+
+// PublicCatalogPeakValley surfaces off-peak vs peak list prices for models with
+// upstream time-of-day multipliers. Peak* fields are flat × PeakMultiplier.
+type PublicCatalogPeakValley struct {
+	Timezone          string   `json:"timezone"`
+	Windows           []string `json:"windows"`
+	PeakMultiplier    float64  `json:"peak_multiplier"`
+	InputPer1KTokens  float64  `json:"input_per_1k_tokens"`
+	OutputPer1KTokens float64  `json:"output_per_1k_tokens"`
+	CacheReadPer1K    float64  `json:"cache_read_per_1k,omitempty"`
 }
 
 // PublicCatalogTier is one input-token bracket of a tiered (阶梯) price. MinTokens
@@ -242,6 +259,7 @@ func (s *PricingCatalogService) BuildPublicCatalog(ctx context.Context) *PublicC
 		applyCatalogOverlayPricing(resp)
 		attachCatalogOverlayTiers(resp)
 		applyCatalogOfficialListBaseTax(resp)
+		attachCatalogDeepSeekPeakValley(resp)
 	}
 
 	s.mu.Lock()
@@ -465,6 +483,44 @@ func applyCatalogOfficialListBaseTax(resp *PublicCatalogResponse) {
 	}
 	for i := range resp.Data {
 		tkApplyBaseTaxToPublicCatalogPricing(resp.Data[i].Vendor, &resp.Data[i].Pricing)
+	}
+}
+
+func attachCatalogDeepSeekPeakValley(resp *PublicCatalogResponse) {
+	policy := loadTkDeepSeekPeakValleyPolicy()
+	if resp == nil || policy == nil || policy.PeakMultiplier <= 1 {
+		return
+	}
+	windows := make([]string, 0, len(policy.Windows))
+	for _, w := range policy.Windows {
+		if w.Start != "" && w.End != "" {
+			windows = append(windows, w.Start+"-"+w.End)
+		}
+	}
+	tz := strings.TrimSpace(policy.Timezone)
+	if tz == "" {
+		tz = "Asia/Shanghai"
+	}
+	for i := range resp.Data {
+		modelID := resp.Data[i].ModelID
+		if !tkDeepSeekPeakValleyApplies(modelID, PricingSourceLiteLLM) {
+			continue
+		}
+		p := &resp.Data[i].Pricing
+		if p.InputPer1KTokens == 0 && p.OutputPer1KTokens == 0 {
+			continue
+		}
+		peak := PublicCatalogPeakValley{
+			Timezone:          tz,
+			Windows:           windows,
+			PeakMultiplier:    policy.PeakMultiplier,
+			InputPer1KTokens:  p.InputPer1KTokens * policy.PeakMultiplier,
+			OutputPer1KTokens: p.OutputPer1KTokens * policy.PeakMultiplier,
+		}
+		if p.CacheReadPer1K > 0 {
+			peak.CacheReadPer1K = p.CacheReadPer1K * policy.PeakMultiplier
+		}
+		p.PeakValley = &peak
 	}
 }
 

--- a/backend/internal/service/pricing_service_tk_overlay.go
+++ b/backend/internal/service/pricing_service_tk_overlay.go
@@ -52,17 +52,20 @@ import (
 var tkPricingOverlayRaw []byte
 
 type tkPricingOverlayExecutableConfig struct {
-	OfficialListBaseTax *tkOfficialListBaseTaxPolicy `json:"official_list_base_tax"`
+	OfficialListBaseTax  *tkOfficialListBaseTaxPolicy  `json:"official_list_base_tax"`
+	DeepSeekPeakValley   *tkDeepSeekPeakValleyPolicy   `json:"deepseek_peak_valley"`
 }
 
 type tkPricingOverlaySnapshot struct {
-	Models  map[string]*LiteLLMModelPricing
-	BaseTax tkOfficialListBaseTaxPolicy
+	Models             map[string]*LiteLLMModelPricing
+	BaseTax            tkOfficialListBaseTaxPolicy
+	DeepSeekPeakValley *tkDeepSeekPeakValleyPolicy
 }
 
 type tkPricingOverlayDocument struct {
-	Models  map[string]*LiteLLMModelPricing
-	BaseTax *tkOfficialListBaseTaxPolicy
+	Models             map[string]*LiteLLMModelPricing
+	BaseTax            *tkOfficialListBaseTaxPolicy
+	DeepSeekPeakValley *tkDeepSeekPeakValleyPolicy
 }
 
 // tkOverlayEffective is the live immutable snapshot = embedded ∪ runtime-settings
@@ -99,6 +102,13 @@ func parseTKOverlayDocument(data []byte) (*tkPricingOverlayDocument, error) {
 		}
 		policy := *config.OfficialListBaseTax
 		doc.BaseTax = &policy
+		if config.DeepSeekPeakValley != nil {
+			if err := config.DeepSeekPeakValley.validate(); err != nil {
+				return nil, fmt.Errorf("overlay _config.deepseek_peak_valley: %w", err)
+			}
+			peakPolicy := *config.DeepSeekPeakValley
+			doc.DeepSeekPeakValley = &peakPolicy
+		}
 	}
 
 	for name, rawEntry := range raw {
@@ -219,8 +229,16 @@ func buildTKPricingOverlaySnapshot(runtimeBytes []byte) (*tkPricingOverlaySnapsh
 			}
 			base.BaseTax = runtime.BaseTax
 		}
+		if runtime.DeepSeekPeakValley != nil {
+			base.DeepSeekPeakValley = runtime.DeepSeekPeakValley
+		}
 	}
-	return &tkPricingOverlaySnapshot{Models: base.Models, BaseTax: *base.BaseTax}, nil
+	snapshot := &tkPricingOverlaySnapshot{Models: base.Models, BaseTax: *base.BaseTax}
+	if base.DeepSeekPeakValley != nil {
+		policy := *base.DeepSeekPeakValley
+		snapshot.DeepSeekPeakValley = &policy
+	}
+	return snapshot, nil
 }
 
 // rebuildTKOverlayUnion recomputes the effective overlay = embedded ∪ runtime

--- a/backend/internal/service/pricing_service_tk_overlay.go
+++ b/backend/internal/service/pricing_service_tk_overlay.go
@@ -52,8 +52,8 @@ import (
 var tkPricingOverlayRaw []byte
 
 type tkPricingOverlayExecutableConfig struct {
-	OfficialListBaseTax  *tkOfficialListBaseTaxPolicy  `json:"official_list_base_tax"`
-	DeepSeekPeakValley   *tkDeepSeekPeakValleyPolicy   `json:"deepseek_peak_valley"`
+	OfficialListBaseTax *tkOfficialListBaseTaxPolicy `json:"official_list_base_tax"`
+	DeepSeekPeakValley  *tkDeepSeekPeakValleyPolicy  `json:"deepseek_peak_valley"`
 }
 
 type tkPricingOverlaySnapshot struct {

--- a/backend/internal/service/pricing_tk_deepseek_peak.go
+++ b/backend/internal/service/pricing_tk_deepseek_peak.go
@@ -1,0 +1,179 @@
+package service
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+)
+
+// tkDeepSeekPeakValleyWindow is one Beijing-time peak window [Start, End) in HH:MM.
+type tkDeepSeekPeakValleyWindow struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// tkDeepSeekPeakValleyPolicy is executable peak-valley pricing for DeepSeek direct
+// API models. Stored in tk_pricing_overlay.json::_config; overlay entries keep
+// off-peak (谷时) list prices and billing applies PeakMultiplier during windows.
+type tkDeepSeekPeakValleyPolicy struct {
+	Timezone       string                       `json:"timezone"`
+	PeakMultiplier float64                      `json:"peak_multiplier"`
+	Windows        []tkDeepSeekPeakValleyWindow `json:"windows"`
+	ModelContains  []string                     `json:"model_contains"`
+}
+
+func (p tkDeepSeekPeakValleyPolicy) validate() error {
+	if math.IsNaN(p.PeakMultiplier) || math.IsInf(p.PeakMultiplier, 0) || p.PeakMultiplier < 1 || p.PeakMultiplier > 4 {
+		return fmt.Errorf("deepseek_peak_valley.peak_multiplier must be within [1,4], got %v", p.PeakMultiplier)
+	}
+	if len(p.Windows) == 0 {
+		return fmt.Errorf("deepseek_peak_valley.windows must be non-empty")
+	}
+	if len(p.ModelContains) == 0 {
+		return fmt.Errorf("deepseek_peak_valley.model_contains must be non-empty")
+	}
+	for i, w := range p.Windows {
+		start, ok1 := parseMinutes(w.Start)
+		end, ok2 := parseMinutes(w.End)
+		if !ok1 {
+			return fmt.Errorf("deepseek_peak_valley.windows[%d].start invalid: %q", i, w.Start)
+		}
+		if !ok2 {
+			return fmt.Errorf("deepseek_peak_valley.windows[%d].end invalid: %q", i, w.End)
+		}
+		if start >= end {
+			return fmt.Errorf("deepseek_peak_valley.windows[%d] requires end > start (no cross-day windows)", i)
+		}
+	}
+	for i, substr := range p.ModelContains {
+		value := strings.TrimSpace(substr)
+		if value == "" || value != strings.ToLower(value) {
+			return fmt.Errorf("deepseek_peak_valley.model_contains[%d] must be normalized lowercase", i)
+		}
+	}
+	if tz := strings.TrimSpace(p.Timezone); tz != "" {
+		if _, err := time.LoadLocation(tz); err != nil {
+			return fmt.Errorf("deepseek_peak_valley.timezone invalid: %w", err)
+		}
+	}
+	return nil
+}
+
+func loadTkDeepSeekPeakValleyPolicy() *tkDeepSeekPeakValleyPolicy {
+	snapshot := loadTKPricingOverlaySnapshot()
+	if snapshot == nil || snapshot.DeepSeekPeakValley == nil {
+		return nil
+	}
+	policy := *snapshot.DeepSeekPeakValley
+	return &policy
+}
+
+func tkDeepSeekPeakValleyApplies(model string, pricingSource string) bool {
+	if pricingSource == PricingSourceChannel {
+		return false
+	}
+	policy := loadTkDeepSeekPeakValleyPolicy()
+	if policy == nil {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(model))
+	for _, substr := range policy.ModelContains {
+		if strings.Contains(lower, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// tkDeepSeekPeakMultiplierAt returns the DeepSeek upstream peak multiplier at `now`
+// (1.0 off-peak, policy.PeakMultiplier during configured windows). Windows are
+// evaluated in policy.Timezone (default Asia/Shanghai when empty).
+func tkDeepSeekPeakMultiplierAt(now time.Time) float64 {
+	policy := loadTkDeepSeekPeakValleyPolicy()
+	if policy == nil || len(policy.Windows) == 0 || policy.PeakMultiplier <= 1 {
+		return 1.0
+	}
+	loc := timezone.Location()
+	if tz := strings.TrimSpace(policy.Timezone); tz != "" {
+		if l, err := time.LoadLocation(tz); err == nil {
+			loc = l
+		}
+	}
+	t := now.In(loc)
+	cur := t.Hour()*60 + t.Minute()
+	for _, w := range policy.Windows {
+		start, ok1 := parseMinutes(w.Start)
+		end, ok2 := parseMinutes(w.End)
+		if !ok1 || !ok2 || start >= end {
+			continue
+		}
+		if cur >= start && cur < end {
+			return policy.PeakMultiplier
+		}
+	}
+	return 1.0
+}
+
+func tkApplyDeepSeekPeakValleyPricing(model string, pricing *ModelPricing, at time.Time, pricingSource string) *ModelPricing {
+	if pricing == nil || !tkDeepSeekPeakValleyApplies(model, pricingSource) {
+		return pricing
+	}
+	mult := tkDeepSeekPeakMultiplierAt(at)
+	if mult <= 1 {
+		return pricing
+	}
+	return tkScaleModelPricingByFactor(pricing, mult)
+}
+
+func tkScaleModelPricingByFactor(pricing *ModelPricing, factor float64) *ModelPricing {
+	if pricing == nil || factor == 1 {
+		return pricing
+	}
+	cloned := *pricing
+	scale := func(v float64) float64 {
+		if v == 0 {
+			return 0
+		}
+		return v * factor
+	}
+	cloned.InputPricePerToken = scale(cloned.InputPricePerToken)
+	cloned.InputPricePerTokenPriority = scale(cloned.InputPricePerTokenPriority)
+	cloned.ImageInputPricePerToken = scale(cloned.ImageInputPricePerToken)
+	cloned.OutputPricePerToken = scale(cloned.OutputPricePerToken)
+	cloned.OutputPricePerTokenPriority = scale(cloned.OutputPricePerTokenPriority)
+	cloned.ThinkingOutputPricePerToken = scale(cloned.ThinkingOutputPricePerToken)
+	cloned.CacheCreationPricePerToken = scale(cloned.CacheCreationPricePerToken)
+	cloned.CacheCreationPricePerTokenPriority = scale(cloned.CacheCreationPricePerTokenPriority)
+	cloned.CacheReadPricePerToken = scale(cloned.CacheReadPricePerToken)
+	cloned.CacheReadPricePerTokenPriority = scale(cloned.CacheReadPricePerTokenPriority)
+	cloned.CacheCreation5mPrice = scale(cloned.CacheCreation5mPrice)
+	cloned.CacheCreation1hPrice = scale(cloned.CacheCreation1hPrice)
+	cloned.ImageOutputPricePerToken = scale(cloned.ImageOutputPricePerToken)
+	if len(cloned.Intervals) > 0 {
+		intervals := make([]PricingInterval, len(cloned.Intervals))
+		copy(intervals, cloned.Intervals)
+		for i := range intervals {
+			if intervals[i].InputPrice != nil {
+				v := scale(*intervals[i].InputPrice)
+				intervals[i].InputPrice = &v
+			}
+			if intervals[i].OutputPrice != nil {
+				v := scale(*intervals[i].OutputPrice)
+				intervals[i].OutputPrice = &v
+			}
+			if intervals[i].CacheWritePrice != nil {
+				v := scale(*intervals[i].CacheWritePrice)
+				intervals[i].CacheWritePrice = &v
+			}
+			if intervals[i].CacheReadPrice != nil {
+				v := scale(*intervals[i].CacheReadPrice)
+				intervals[i].CacheReadPrice = &v
+			}
+		}
+		cloned.Intervals = intervals
+	}
+	return &cloned
+}

--- a/backend/internal/service/pricing_tk_deepseek_peak_test.go
+++ b/backend/internal/service/pricing_tk_deepseek_peak_test.go
@@ -1,0 +1,115 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+func atBJ(t *testing.T, h, m int) time.Time {
+	t.Helper()
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	require.NoError(t, err)
+	return time.Date(2026, 7, 21, h, m, 0, 0, loc)
+}
+
+func TestDeepSeekPeakMultiplierAt_Boundaries(t *testing.T) {
+	require.InDelta(t, 2.0, tkDeepSeekPeakMultiplierAt(atBJ(t, 9, 0)), 1e-9)
+	require.InDelta(t, 2.0, tkDeepSeekPeakMultiplierAt(atBJ(t, 11, 59)), 1e-9)
+	require.InDelta(t, 1.0, tkDeepSeekPeakMultiplierAt(atBJ(t, 12, 0)), 1e-9)
+	require.InDelta(t, 1.0, tkDeepSeekPeakMultiplierAt(atBJ(t, 13, 59)), 1e-9)
+	require.InDelta(t, 2.0, tkDeepSeekPeakMultiplierAt(atBJ(t, 14, 0)), 1e-9)
+	require.InDelta(t, 2.0, tkDeepSeekPeakMultiplierAt(atBJ(t, 17, 59)), 1e-9)
+	require.InDelta(t, 1.0, tkDeepSeekPeakMultiplierAt(atBJ(t, 18, 0)), 1e-9)
+	require.InDelta(t, 1.0, tkDeepSeekPeakMultiplierAt(atBJ(t, 8, 59)), 1e-9)
+}
+
+func TestCalculateCostUnified_DeepSeekPeakDoublesOffPeakBase(t *testing.T) {
+	svc := &PricingService{}
+	data, err := svc.parsePricingData([]byte(`{"gpt-5.4":{"input_cost_per_token":0.0000025,"output_cost_per_token":0.000015,"litellm_provider":"openai","mode":"chat"}}`))
+	require.NoError(t, err)
+	billing := NewBillingService(&config.Config{}, &PricingService{pricingData: data})
+	resolver := NewModelPricingResolver(nil, billing)
+
+	offPeak, err := billing.CalculateCostUnified(CostInput{
+		Model:          "deepseek-v4-pro",
+		Tokens:         UsageTokens{InputTokens: 1_000_000, OutputTokens: 1_000_000},
+		RateMultiplier: 1,
+		Resolver:       resolver,
+		BillingAt:      atBJ(t, 8, 0),
+	})
+	require.NoError(t, err)
+
+	peak, err := billing.CalculateCostUnified(CostInput{
+		Model:          "deepseek-v4-pro",
+		Tokens:         UsageTokens{InputTokens: 1_000_000, OutputTokens: 1_000_000},
+		RateMultiplier: 1,
+		Resolver:       resolver,
+		BillingAt:      atBJ(t, 10, 0),
+	})
+	require.NoError(t, err)
+
+	require.InDelta(t, offPeak.ActualCost*2, peak.ActualCost, 1e-9)
+}
+
+func TestCalculateCostUnified_DeepSeekPeakSkippedForChannelPricing(t *testing.T) {
+	svc := &PricingService{}
+	data, err := svc.parsePricingData([]byte(`{"gpt-5.4":{"input_cost_per_token":0.0000025,"output_cost_per_token":0.000015,"litellm_provider":"openai","mode":"chat"}}`))
+	require.NoError(t, err)
+	billing := NewBillingService(&config.Config{}, &PricingService{pricingData: data})
+	resolver := NewModelPricingResolver(nil, billing)
+	resolved := &ResolvedPricing{
+		Mode:   BillingModeToken,
+		Source: PricingSourceChannel,
+		BasePricing: &ModelPricing{
+			InputPricePerToken:  0.000001,
+			OutputPricePerToken: 0.000002,
+		},
+	}
+
+	offPeak, err := billing.CalculateCostUnified(CostInput{
+		Model:          "deepseek-v4-pro",
+		Tokens:         UsageTokens{InputTokens: 1_000_000},
+		RateMultiplier: 1,
+		Resolver:       resolver,
+		Resolved:       resolved,
+		BillingAt:      atBJ(t, 8, 0),
+	})
+	require.NoError(t, err)
+
+	peak, err := billing.CalculateCostUnified(CostInput{
+		Model:          "deepseek-v4-pro",
+		Tokens:         UsageTokens{InputTokens: 1_000_000},
+		RateMultiplier: 1,
+		Resolver:       resolver,
+		Resolved:       resolved,
+		BillingAt:      atBJ(t, 10, 0),
+	})
+	require.NoError(t, err)
+
+	require.InDelta(t, offPeak.ActualCost, peak.ActualCost, 1e-12,
+		"operator channel pricing must not receive automatic DeepSeek upstream peak scaling")
+}
+
+func TestAttachCatalogDeepSeekPeakValley(t *testing.T) {
+	resp := &PublicCatalogResponse{
+		Data: []PublicCatalogModel{{
+			ModelID: "deepseek-v4-flash",
+			Pricing: PublicCatalogPricing{
+				Currency:          "USD",
+				InputPer1KTokens:  0.14,
+				OutputPer1KTokens: 0.28,
+				CacheReadPer1K:    0.0028,
+			},
+		}},
+	}
+	attachCatalogDeepSeekPeakValley(resp)
+	require.NotNil(t, resp.Data[0].Pricing.PeakValley)
+	require.InDelta(t, 0.28, resp.Data[0].Pricing.PeakValley.InputPer1KTokens, 1e-9)
+	require.Contains(t, resp.Data[0].Pricing.PeakValley.Windows, "09:00-12:00")
+}

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -43,6 +43,17 @@
           ]
         }
       ]
+    },
+    "deepseek_peak_valley": {
+      "timezone": "Asia/Shanghai",
+      "peak_multiplier": 2,
+      "windows": [
+        {"start": "09:00", "end": "12:00"},
+        {"start": "14:00", "end": "18:00"}
+      ],
+      "model_contains": [
+        "deepseek"
+      ]
     }
   },
   "grok-imagine-image": {
@@ -260,7 +271,7 @@
     "output_cost_per_token": 2.8e-07,
     "cache_read_input_token_cost": 2.8e-09,
     "supports_prompt_caching": true,
-    "source": "https://api-docs.deepseek.com/quick_start/pricing (2026-06-04: in $0.14/M cache-miss, $0.0028/M cache-hit, out $0.28/M)"
+    "source": "https://api-docs.deepseek.com/zh-cn/quick_start/pricing (2026-07-21: off-peak 谷时 ¥1/M in, ¥0.02/M cache-hit, ¥2/M out; peak ×2 per deepseek_peak_valley windows)"
   },
   "deepseek-v4-pro": {
     "litellm_provider": "deepseek",
@@ -269,7 +280,7 @@
     "output_cost_per_token": 8.7e-07,
     "cache_read_input_token_cost": 3.625e-09,
     "supports_prompt_caching": true,
-    "source": "https://api-docs.deepseek.com/quick_start/pricing (2026-06-04: in $0.435/M cache-miss, $0.003625/M cache-hit, out $0.87/M)"
+    "source": "https://api-docs.deepseek.com/zh-cn/quick_start/pricing (2026-07-21: off-peak 谷时 ¥3/M in, ¥0.025/M cache-hit, ¥6/M out; peak ×2 per deepseek_peak_valley windows)"
   },
   "imagen-3.0-capability-001": {
     "litellm_provider": "vertex_ai",

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 608,
-  "hash": "2cbb63e7c1eac612a8c45e52418507f8c5365eceb225031d597858138ed1e78d",
+  "hash": "bd96b1cf4f5f388fad28f83dd35e6c8835b1207a91e4591212b9ac3cf1a6848d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/pricing.ts
+++ b/frontend/src/api/pricing.ts
@@ -31,6 +31,17 @@ export interface PublicPricing {
    *  GLM-4.7). The flat input/output fields carry the first (lowest) tier; this
    *  array carries the full ladder. Absent for flat-priced models. Per 1k tokens. */
   tiers?: PublicPricingTier[]
+  /** DeepSeek upstream peak-valley: flat fields are off-peak; peak_* are ×multiplier. */
+  peak_valley?: PublicPricingPeakValley
+}
+
+export interface PublicPricingPeakValley {
+  timezone: string
+  windows: string[]
+  peak_multiplier: number
+  input_per_1k_tokens: number
+  output_per_1k_tokens: number
+  cache_read_per_1k?: number
 }
 
 /** One input-token bracket of a tiered (阶梯) price. `min_tokens` inclusive,

--- a/frontend/src/i18n/tk/legacyMissing.tk.ts
+++ b/frontend/src/i18n/tk/legacyMissing.tk.ts
@@ -35,6 +35,8 @@ const en: LocaleOverlay = {
       "empty": "Public catalog is empty — nothing to export"
     },
     "tieredBadge": "Tiered ×{n}",
+    "peakValleyBadge": "Peak ×{mult}",
+    "peakValleyTooltip": "Off-peak (flat) price shown. Peak {windows} ({tz}): input {peakIn}/1K, output {peakOut}/1K (×{mult}).",
     "footer": {
       "total": "{count} models listed",
       "filtered": "Showing {shown} of {total} models"
@@ -923,6 +925,8 @@ const zh: LocaleOverlay = {
       "empty": "对外价目录为空，无可导出内容"
     },
     "tieredBadge": "阶梯 ×{n}",
+    "peakValleyBadge": "高峰 ×{mult}",
+    "peakValleyTooltip": "表格为谷时价。高峰 {windows}（{tz}）：输入 {peakIn}/1K，输出 {peakOut}/1K（×{mult}）。",
     "footer": {
       "total": "共 {count} 个模型",
       "filtered": "显示 {shown} / {total} 个模型"

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -402,6 +402,14 @@
                             >{{ t('pricing.tieredBadge', { n: row.tiers.length }) }}</span
                           >
                         </div>
+                        <div v-if="row.peakValley" class="mt-0.5">
+                          <span
+                            class="inline-flex cursor-help items-center rounded bg-sky-50 px-1 py-px text-[10px] font-medium text-sky-700 dark:bg-sky-500/10 dark:text-sky-300"
+                            :title="peakValleyTooltip(row)"
+                            data-tk="pricing-peak-valley-badge"
+                            >{{ t('pricing.peakValleyBadge', { mult: row.peakValley.peakMultiplier }) }}</span
+                          >
+                        </div>
                       </template>
                       <template v-else>—</template>
                     </td>
@@ -614,6 +622,14 @@ interface NormalizedRow {
   perSecond?: number | null
   /** Input-token interval (阶梯) ladder, normalized from either catalog source. */
   tiers?: NormalizedTier[]
+  peakValley?: {
+    timezone: string
+    windows: string[]
+    peakMultiplier: number
+    inputPer1K: number
+    outputPer1K: number
+    cacheReadPer1K?: number
+  }
   /** Accessible groups that can serve this model — "授权分组" column when logged in. */
   authorizedGroups?: MePricingModelGroup[]
 }
@@ -789,6 +805,16 @@ const normalizedRows = computed<NormalizedRow[]>(() => {
         inputPer1K: tt.input_per_1k_tokens ?? null,
         outputPer1K: tt.output_per_1k_tokens ?? null
       })),
+      peakValley: m.pricing.peak_valley
+        ? {
+            timezone: m.pricing.peak_valley.timezone,
+            windows: m.pricing.peak_valley.windows,
+            peakMultiplier: m.pricing.peak_valley.peak_multiplier,
+            inputPer1K: m.pricing.peak_valley.input_per_1k_tokens,
+            outputPer1K: m.pricing.peak_valley.output_per_1k_tokens,
+            cacheReadPer1K: m.pricing.peak_valley.cache_read_per_1k
+          }
+        : undefined,
       authorizedGroups: authorizedGroupsByModel.value[m.model_id] ?? []
     }))
   }
@@ -964,6 +990,18 @@ function tierTooltip(row: NormalizedRow): string {
       return `${range}: ${t('pricing.columns.input')} ${inp} / ${t('pricing.columns.output')} ${out} ${unit}`
     })
     .join('\n')
+}
+
+function peakValleyTooltip(row: NormalizedRow): string {
+  const pv = row.peakValley
+  if (!pv) return ''
+  return t('pricing.peakValleyTooltip', {
+    windows: pv.windows.join(', '),
+    tz: pv.timezone,
+    peakIn: formatPrice(pv.inputPer1K),
+    peakOut: formatPrice(pv.outputPer1K),
+    mult: pv.peakMultiplier
+  })
 }
 
 function formatBillingMode(mode: string): string {

--- a/scripts/checks/pricing-overlay.py
+++ b/scripts/checks/pricing-overlay.py
@@ -72,7 +72,7 @@ def validate_official_list_base_tax(data: dict) -> list[str]:
     config = data.get("_config")
     if not isinstance(config, dict):
         return ["_config must be an object"]
-    unknown_config = sorted(set(config) - {"official_list_base_tax"})
+    unknown_config = sorted(set(config) - {"official_list_base_tax", "deepseek_peak_valley"})
     if unknown_config:
         errors.append(f"_config has unknown fields: {unknown_config}")
     policy = config.get("official_list_base_tax")
@@ -133,6 +133,67 @@ def validate_official_list_base_tax(data: dict) -> list[str]:
     return errors
 
 
+def _valid_hhmm(value: object) -> bool:
+    if not isinstance(value, str) or len(value) != 5 or value[2] != ":":
+        return False
+    try:
+        hour = int(value[:2])
+        minute = int(value[3:])
+    except ValueError:
+        return False
+    return 0 <= hour <= 23 and 0 <= minute <= 59
+
+
+def validate_deepseek_peak_valley(data: dict) -> list[str]:
+    errors: list[str] = []
+    config = data.get("_config")
+    if not isinstance(config, dict):
+        return errors
+    policy = config.get("deepseek_peak_valley")
+    if policy is None:
+        return errors
+    if not isinstance(policy, dict):
+        return errors + ["_config.deepseek_peak_valley must be an object"]
+    unknown = sorted(set(policy) - {"timezone", "peak_multiplier", "windows", "model_contains"})
+    if unknown:
+        errors.append(f"deepseek_peak_valley has unknown fields: {unknown}")
+    multiplier = policy.get("peak_multiplier")
+    if (not isinstance(multiplier, (int, float)) or isinstance(multiplier, bool)
+            or not math.isfinite(multiplier) or multiplier < 1 or multiplier > 4):
+        errors.append(f"deepseek_peak_valley.peak_multiplier must be within [1,4], got {multiplier!r}")
+    windows = policy.get("windows")
+    if not isinstance(windows, list) or not windows:
+        return errors + ["deepseek_peak_valley.windows must be a non-empty array"]
+    for idx, window in enumerate(windows):
+        label = f"deepseek_peak_valley.windows[{idx}]"
+        if not isinstance(window, dict):
+            errors.append(f"{label} must be an object")
+            continue
+        start = window.get("start")
+        end = window.get("end")
+        if not _valid_hhmm(start):
+            errors.append(f"{label}.start must be HH:MM, got {start!r}")
+            continue
+        if not _valid_hhmm(end):
+            errors.append(f"{label}.end must be HH:MM, got {end!r}")
+            continue
+        sh, sm = int(start[:2]), int(start[3:])
+        eh, em = int(end[:2]), int(end[3:])
+        if sh * 60 + sm >= eh * 60 + em:
+            errors.append(f"{label} requires end > start")
+    contains = policy.get("model_contains")
+    if not isinstance(contains, list) or not contains:
+        errors.append("deepseek_peak_valley.model_contains must be a non-empty array")
+    elif contains:
+        for idx, value in enumerate(contains):
+            if not isinstance(value, str) or not value or value != value.strip().lower():
+                errors.append(f"deepseek_peak_valley.model_contains[{idx}] must be normalized lowercase")
+    tz = policy.get("timezone", "")
+    if tz != "" and not isinstance(tz, str):
+        errors.append("deepseek_peak_valley.timezone must be a string when present")
+    return errors
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--quiet", action="store_true", help="suppress success output")
@@ -157,6 +218,7 @@ def main() -> int:
     # provenance, not pricing.
     entries = {k: v for k, v in data.items() if not k.startswith("_")}
     errors: list[str] = validate_official_list_base_tax(data)
+    errors.extend(validate_deepseek_peak_valley(data))
 
     if not entries:
         errors.append("overlay has zero pricing entries")

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -180,6 +180,7 @@
         "func applyCatalogOverlayPricing",
         "tkOverlayOverridesLitellmSource",
         "applyCatalogOverlayPricing(resp)",
+        "attachCatalogDeepSeekPeakValley(resp)",
         "func (s *PricingCatalogService) InvalidateCache"
       ],
       "rationale": "Display-side TK pricing-overlay merge. BuildPublicCatalog reads the trimmed litellm price file (model_pricing.json) and, unlike the billing path (GetModelPricing → applyTKPricingOverlay), did NOT apply the overlay — so every model priced ONLY in tk_pricing_overlay.json (the VolcEngine fifth-platform doubao-* batch, plus deepseek-v4-pro; GLM chat is DashScope-first as glm-4.7, not VolcEngine glm-4-7-251222) showed empty/missing prices in the public /pricing catalog AND Your-Menu (me_pricing_catalog reads BuildPublicCatalog as metaByID), even though billing was correct. applyCatalogOverlayPricing fill-merges the overlay's token-priced models into the catalog so display matches billing, with absent-or-zero semantics: a real non-zero file price wins, an all-zero placeholder row gets its displayed price replaced (same predicate family as billing's tkIsEffectivelyUnpriced). Channel pricing stays a strictly higher tier upstream; the merge is gated behind a non-degraded catalog (len(resp.Data)>0) to preserve the AC-005 degraded→empty contract. An upstream merge refactoring BuildPublicCatalog could silently drop the applyCatalogOverlayPricing(resp) call, regressing every overlay-only model back to an empty price row."
@@ -197,10 +198,20 @@
         "func tkOverlayModelPricing",
         "loadTKPricingOverlay()[strings.ToLower(strings.TrimSpace(model))]",
         "tkOverlayModelPricing(\"deepseek-v4-flash\")",
+        "tkApplyDeepSeekPeakValleyPricing",
         "tkOverlayModelPricing(\"glm-5.2\")",
         "tkOverlayModelPricing(\"kimi-k2.6\")"
       ],
       "rationale": "BillingService pricing hooks: zero placeholders fall through, interval/thinking/media fields survive conversion, Imagen keeps flat billing, and billing aliases normalize. DeepSeek V4, paid GLM, and Kimi K2.5/K2.6 compatibility branches resolve tkOverlayModelPricing instead of maintaining a second numeric Go fallback table. This deliberately does not make every overlay row a new family fallback; dropping the scoped alias hooks would reintroduce price drift while broadening them would change fail-closed behavior for unrelated models."
+    },
+    {
+      "path": "backend/internal/service/pricing_tk_deepseek_peak.go",
+      "must_contain": [
+        "func tkDeepSeekPeakMultiplierAt",
+        "func tkApplyDeepSeekPeakValleyPricing",
+        "deepseek_peak_valley"
+      ],
+      "rationale": "DeepSeek upstream peak-valley billing (Beijing 09:00-12:00 + 14:00-18:00, ×2). Overlay stores off-peak list prices; calculateTokenCost scales unit prices at BillingAt. Dropping this companion reverts to flat off-peak billing during upstream peak windows (≈50% under-charge vs DeepSeek direct API)."
     },
     {
       "path": "backend/internal/service/billing_service_tk_flat_image.go",


### PR DESCRIPTION
## 摘要

- 在 `tk_pricing_overlay.json` 增加 `_config.deepseek_peak_valley`：北京时间 09:00–12:00、14:00–18:00 高峰窗口，单价 ×2；overlay 仍存谷时官方价。
- 计费路径（`CalculateCostUnified` / `calculateTokenCost`）按 `BillingAt`（默认 `timezone.Now()`）对 DeepSeek 模型单价缩放；渠道 DB 定价不叠加峰谷。
- 公开 `/pricing` 返回 `peak_valley` 子对象；价目页展示「高峰 ×2」徽章与 tooltip。

## 风险

- 常规风险：仅影响 `deepseek*` 模型且非 channel override 的 token 计费；与订阅组 `peak_rate` 独立叠加。
- 高峰边界按左闭右开 `[start, end)` 判定，与官方图示一致。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service/ -run 'DeepSeek|AttachCatalogDeepSeek'
python3 scripts/checks/pricing-overlay.py --quiet
python3 scripts/checks/frontend-dist-freshness.py --check ./backend/internal/web/dist
```

- 上述测试与 overlay 校验均已通过。
- CI 修复：gofmt、frontend-source.json freshness、sentinel-registry-reviewed。

sentinel-registry-reviewed

## 提交

- d835ea430 feat(billing): 对齐 DeepSeek 官方峰谷分时计费
- 4adb2053c fix(billing): 修复 DeepSeek 峰谷 PR 的 CI 门禁

最新提交：4adb2053c