### PR TITLE
fix(gateway): 修正 failover 终止错误信息

### DIFF
--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -192,7 +192,8 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				if fs.LastFailoverErr != nil {
 					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, streamStarted)
 				} else {
-					h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "All available accounts exhausted")
+					h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error",
+						service.GatewayFailoverClientMessage(http.StatusBadGateway))
 				}
 				return
 			}
@@ -367,5 +368,5 @@ func (h *GatewayHandler) handleCCFailoverExhausted(c *gin.Context, lastErr *serv
 		return
 	}
 	h.chatCompletionsErrorResponse(c, statusCode, "server_error",
-		service.TkEnrichClaudeIncidentMessage("All available accounts exhausted", statusCode))
+		service.GatewayFailoverClientMessage(statusCode))
 }

--- a/backend/internal/handler/gateway_handler_failover_message_test.go
+++ b/backend/internal/handler/gateway_handler_failover_message_test.go
@@ -1,0 +1,55 @@
+//go:build unit
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleCCFailoverExhaustedUsesTruthfulClientMessage(t *testing.T) {
+	message := recordGatewayFailoverMessage(t, func(c *gin.Context) {
+		(&GatewayHandler{}).handleCCFailoverExhausted(c, &service.UpstreamFailoverError{
+			StatusCode: http.StatusBadGateway,
+		}, false)
+	})
+
+	require.Contains(t, message, "Upstream request could not be completed")
+	require.NotContains(t, strings.ToLower(message), "all available accounts exhausted")
+}
+
+func TestHandleResponsesFailoverExhaustedUsesTruthfulClientMessage(t *testing.T) {
+	message := recordGatewayFailoverMessage(t, func(c *gin.Context) {
+		(&GatewayHandler{}).handleResponsesFailoverExhausted(c, &service.UpstreamFailoverError{
+			StatusCode: http.StatusBadGateway,
+		}, false)
+	})
+
+	require.Contains(t, message, "Upstream request could not be completed")
+	require.NotContains(t, strings.ToLower(message), "all available accounts exhausted")
+}
+
+func recordGatewayFailoverMessage(t *testing.T, write func(*gin.Context)) string {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+
+	write(c)
+
+	require.Equal(t, http.StatusBadGateway, recorder.Code)
+	var response struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	return response.Error.Message
+}

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -216,7 +216,8 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 				if fs.LastFailoverErr != nil {
 					h.handleResponsesFailoverExhausted(c, fs.LastFailoverErr, streamStarted)
 				} else {
-					h.responsesErrorResponse(c, http.StatusBadGateway, "server_error", "All available accounts exhausted")
+					h.responsesErrorResponse(c, http.StatusBadGateway, "server_error",
+						service.GatewayFailoverClientMessage(http.StatusBadGateway))
 				}
 				return
 			}
@@ -392,5 +393,5 @@ func (h *GatewayHandler) handleResponsesFailoverExhausted(c *gin.Context, lastEr
 		return
 	}
 	h.responsesErrorResponse(c, statusCode, "server_error",
-		service.TkEnrichClaudeIncidentMessage("All available accounts exhausted", statusCode))
+		service.GatewayFailoverClientMessage(statusCode))
 }

--- a/backend/internal/handler/ops_error_logger_tk_downstream_capacity.go
+++ b/backend/internal/handler/ops_error_logger_tk_downstream_capacity.go
@@ -4,19 +4,15 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-)
 
-// opsDownstreamFailoverExhaustedPhrase is the TokenKey-generated envelope emitted
-// when a downstream failover loop runs dry. It mirrors the service-layer constant
-// in ratelimit_service_tk_downstream_no_available.go (kept as a local copy so the
-// handler layer does not import a service internal); matched case-insensitively.
-const opsDownstreamFailoverExhaustedPhrase = "all available accounts exhausted"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
 
 // tkUpstreamDownstreamCapacity reports whether the captured upstream verdict is a
 // TokenKey *downstream-capacity* signal rather than provider health: an upstream
 // (typically a TokenKey edge reached via a cc-<edge> apikey mirror account) answered
 // 429/503/5xx with a body whose text is one of TokenKey's own pool-empty envelopes
-// ("no available accounts" / "all available accounts exhausted").
+// ("no available accounts" / the gateway failover-terminal message).
 //
 // WHY (mirror-edge metric pollution, 2026-06-06 yace load test): prod relays to the
 // edge via apikey mirror accounts (credentials.base_url=api-<edge>.tokenkey.dev);
@@ -54,8 +50,8 @@ func tkUpstreamDownstreamCapacity(c *gin.Context) bool {
 	if combined == "" {
 		return false
 	}
-	// isOpsNoAvailableAccountMessage already lowercases; the second check is the
-	// failover-exhausted envelope. Both are TokenKey-generated, never provider text.
+	// isOpsNoAvailableAccountMessage already lowercases; the second check uses the
+	// service-owned exact matcher for current and rolling-version failover envelopes.
 	return isOpsNoAvailableAccountMessage(combined) ||
-		strings.Contains(combined, opsDownstreamFailoverExhaustedPhrase)
+		service.IsGatewayFailoverMessage(msg, []byte(body))
 }

--- a/backend/internal/handler/ops_error_logger_tk_downstream_capacity_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_downstream_capacity_test.go
@@ -21,7 +21,7 @@ import (
 // upstream_error_rate useless for telling a dead edge from a healthy one.
 //
 // These tests pin the corrected classification: a relayed downstream-capacity
-// verdict ("no available accounts" / "all available accounts exhausted") is owned as
+// verdict ("no available accounts" / gateway failover-terminal) is owned as
 // routing (phase=routing, error_owner=platform) so it stays out of
 // upstream_error_rate while still counting in SLA numerator; genuine provider 429
 // (rate_limit_error) and raw 5xx
@@ -55,7 +55,16 @@ func TestClassifyOpsDownstreamCapacityOwnedAsRouting(t *testing.T) {
 			errMsg: "Upstream request failed",
 		},
 		{
-			name: "downstream failover exhausted 503",
+			name: "downstream failover stopped 503",
+			event: &service.OpsUpstreamErrorEvent{
+				UpstreamStatusCode:   503,
+				Kind:                 "http_error",
+				UpstreamResponseBody: `{"error":{"message":"Upstream request could not be completed","type":"api_error"}}`,
+			},
+			errMsg: "Upstream request could not be completed",
+		},
+		{
+			name: "legacy downstream failover message 503",
 			event: &service.OpsUpstreamErrorEvent{
 				UpstreamStatusCode:   503,
 				Kind:                 "http_error",
@@ -147,6 +156,7 @@ func TestTkUpstreamDownstreamCapacityPredicate(t *testing.T) {
 	}
 
 	require.True(t, tkUpstreamDownstreamCapacity(mk(429, "No available accounts", "")))
+	require.True(t, tkUpstreamDownstreamCapacity(mk(503, `{"error":{"message":"Upstream request could not be completed"}}`, "")))
 	require.True(t, tkUpstreamDownstreamCapacity(mk(503, "all available accounts exhausted", "")))
 	require.True(t, tkUpstreamDownstreamCapacity(mk(502, "", "No available accounts: no available accounts")))
 	// status 0 (pure transport) is owned by tkUpstreamClientCanceled, not here.

--- a/backend/internal/service/gateway_failover_message_tk.go
+++ b/backend/internal/service/gateway_failover_message_tk.go
@@ -1,0 +1,47 @@
+package service
+
+import "strings"
+
+const (
+	gatewayFailoverClientMessage       = "Upstream request could not be completed"
+	legacyGatewayFailoverClientMessage = "All available accounts exhausted"
+)
+
+// GatewayFailoverClientMessage returns the client-facing message used when the
+// gateway stops failover without completing the request. Stopping does not prove
+// that every schedulable account was attempted: the loop may hit its switch
+// budget or stop on a request-owned/non-retryable error.
+func GatewayFailoverClientMessage(upstreamStatusCode int) string {
+	return TkEnrichClaudeIncidentMessage(gatewayFailoverClientMessage, upstreamStatusCode)
+}
+
+// IsGatewayFailoverMessage identifies TokenKey's failover-terminal envelope.
+// The legacy message remains accepted while prod and edge gateways may run
+// different versions. Matching is exact after extracting the JSON message; the
+// only accepted suffix is the incident context added by
+// TkEnrichClaudeIncidentMessage.
+func IsGatewayFailoverMessage(upstreamMsg string, responseBody []byte) bool {
+	if isGatewayFailoverClientMessage(upstreamMsg) {
+		return true
+	}
+	bodyMsg := strings.TrimSpace(extractUpstreamErrorMessage(responseBody))
+	if bodyMsg == "" {
+		bodyMsg = strings.TrimSpace(string(responseBody))
+	}
+	return isGatewayFailoverClientMessage(bodyMsg)
+}
+
+func isGatewayFailoverClientMessage(message string) bool {
+	message = strings.TrimSpace(message)
+	for _, candidate := range []string{gatewayFailoverClientMessage, legacyGatewayFailoverClientMessage} {
+		if strings.EqualFold(message, candidate) {
+			return true
+		}
+		incidentPrefix := candidate + " (Anthropic upstream incident:"
+		if strings.HasPrefix(strings.ToLower(message), strings.ToLower(incidentPrefix)) &&
+			strings.Contains(message, claudeStatusPageURL) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/service/gateway_failover_message_tk_test.go
+++ b/backend/internal/service/gateway_failover_message_tk_test.go
@@ -1,0 +1,53 @@
+//go:build unit
+
+package service
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatewayFailoverClientMessageDoesNotClaimEveryAccountWasAttempted(t *testing.T) {
+	setClaudeStatusForTest(t, ClaudeStatusSnapshot{Status: "operational", FetchedAt: time.Now()})
+	message := GatewayFailoverClientMessage(502)
+
+	require.Equal(t, gatewayFailoverClientMessage, message)
+	require.NotContains(t, strings.ToLower(message), "all available accounts exhausted")
+}
+
+func TestIsGatewayFailoverMessageSupportsRollingVersionCompatibility(t *testing.T) {
+	newBody := []byte(`{"error":{"type":"server_error","message":"Upstream request could not be completed"}}`)
+	legacyBody := []byte(`{"error":{"type":"server_error","message":"All available accounts exhausted"}}`)
+
+	require.True(t, IsGatewayFailoverMessage("", newBody))
+	require.True(t, IsGatewayFailoverMessage("", legacyBody))
+	require.True(t, IsGatewayFailoverMessage("upstream request could not be completed", nil))
+	require.True(t, IsGatewayFailoverMessage("ALL AVAILABLE ACCOUNTS EXHAUSTED", nil))
+}
+
+func TestIsGatewayFailoverMessageAcceptsControlledIncidentSuffix(t *testing.T) {
+	setClaudeStatusForTest(t, ClaudeStatusSnapshot{
+		IsIncident: true,
+		Status:     "partial_outage",
+		FetchedAt:  time.Now(),
+	})
+	message := GatewayFailoverClientMessage(502)
+
+	require.Contains(t, message, claudeStatusPageURL)
+	require.True(t, IsGatewayFailoverMessage(message, nil))
+}
+
+func TestIsGatewayFailoverMessageRejectsSubstringAndProviderErrors(t *testing.T) {
+	require.False(t, IsGatewayFailoverMessage(
+		"provider says: Upstream request could not be completed",
+		nil,
+	))
+	require.False(t, IsGatewayFailoverMessage(
+		"",
+		[]byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`),
+	))
+	require.False(t, IsGatewayFailoverMessage("", []byte(`<html>502 Bad Gateway</html>`)))
+}

--- a/backend/internal/service/ratelimit_service_tk_downstream_exhausted_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_exhausted_test.go
@@ -11,23 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTkIsDownstreamAllAccountsExhausted(t *testing.T) {
-	// Downstream gateway failover-exhausted envelope (server_error, HTTP 502).
-	require.True(t, tkIsDownstreamAllAccountsExhausted("", []byte(`{"error":{"type":"server_error","message":"All available accounts exhausted"}}`)))
-	// Already-parsed message, case-insensitive.
-	require.True(t, tkIsDownstreamAllAccountsExhausted("ALL AVAILABLE ACCOUNTS EXHAUSTED", nil))
-	// Raw infra 5xx and genuine provider errors must NOT match (route-away preserved).
-	require.False(t, tkIsDownstreamAllAccountsExhausted("", []byte(`<html><body>502 Bad Gateway</body></html>`)))
-	require.False(t, tkIsDownstreamAllAccountsExhausted("", []byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`)))
-	require.False(t, tkIsDownstreamAllAccountsExhausted("", []byte(`{}`)))
-}
-
 func TestTkSkipDownstreamFailoverExhaustedPenalty(t *testing.T) {
-	body := []byte(`{"error":{"type":"server_error","message":"All available accounts exhausted"}}`)
+	body := []byte(`{"error":{"type":"server_error","message":"Upstream request could not be completed"}}`)
+	legacyBody := []byte(`{"error":{"type":"server_error","message":"All available accounts exhausted"}}`)
 	// The envelope is written as 502; also accept 429 / other 5xx defensively.
 	require.True(t, tkSkipDownstreamFailoverExhaustedPenalty(http.StatusBadGateway, "", body))
 	require.True(t, tkSkipDownstreamFailoverExhaustedPenalty(http.StatusTooManyRequests, "", body))
 	require.True(t, tkSkipDownstreamFailoverExhaustedPenalty(http.StatusGatewayTimeout, "", body))
+	// Rolling-version compatibility: a legacy edge may still emit the old text.
+	require.True(t, tkSkipDownstreamFailoverExhaustedPenalty(http.StatusBadGateway, "", legacyBody))
 	// Non-server status → not in scope.
 	require.False(t, tkSkipDownstreamFailoverExhaustedPenalty(http.StatusBadRequest, "", body))
 	// Raw infra 5xx with no capacity phrase → NOT skipped (keeps route-away count).
@@ -36,8 +28,8 @@ func TestTkSkipDownstreamFailoverExhaustedPenalty(t *testing.T) {
 	require.False(t, tkSkipDownstreamFailoverExhaustedPenalty(http.StatusTooManyRequests, "", []byte(`{"error":{"type":"rate_limit_error"}}`)))
 }
 
-// G2 (narrow): a forwarded "all available accounts exhausted" 502 reaching an
-// Anthropic mirror stub is a downstream-pool capacity blip, not stub health.
+// G2 (narrow): a forwarded TokenKey failover-terminal 502 reaching an Anthropic
+// mirror stub is a downstream-owned failure, not forwarding-stub health.
 // Repeated hits must fail over without advancing the 3/3 ladder.
 func TestRateLimitService_HandleUpstreamError_DownstreamFailoverExhausted_DoesNotPenalizeStub(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
@@ -46,7 +38,7 @@ func TestRateLimitService_HandleUpstreamError_DownstreamFailoverExhausted_DoesNo
 	service.SetAnthropicUpstreamErrorCounterCache(counter)
 	stub := &Account{ID: 5252, Platform: PlatformAnthropic, Type: AccountTypeAPIKey, Credentials: map[string]any{"pool_mode": true}}
 
-	body := []byte(`{"error":{"type":"server_error","message":"All available accounts exhausted"}}`)
+	body := []byte(`{"error":{"type":"server_error","message":"Upstream request could not be completed"}}`)
 	for i := 0; i < 5; i++ {
 		require.True(t, service.HandleUpstreamError(context.Background(), stub, http.StatusBadGateway, http.Header{}, body),
 			"iteration %d: downstream failover-exhausted must fail over to the next stub", i)

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
@@ -54,49 +54,24 @@ func tkSkipDownstreamNoAvailableAccountsPenalty(statusCode int, upstreamMsg stri
 	return tkIsDownstreamNoAvailableAccounts(upstreamMsg, responseBody)
 }
 
-// tkDownstreamAllAccountsExhaustedNeedle is TokenKey's own failover-exhausted
-// client message (handler.handleCCFailoverExhausted / handleResponsesFailoverExhausted
-// and the chat/responses select-failure fallbacks), emitted as "server_error" /
-// "upstream_error" with HTTP 502 when a downstream gateway's failover loop ran out
-// of candidates. Like ErrNoAvailableAccounts it is a TokenKey-generated string the
-// real provider APIs never emit.
-const tkDownstreamAllAccountsExhaustedNeedle = "all available accounts exhausted"
-
-// tkIsDownstreamAllAccountsExhausted reports whether an error is the downstream
-// gateway's own failover-exhausted capacity signal — the sibling of
-// tkIsDownstreamNoAvailableAccounts. "no available accounts" means the downstream
-// pool had nothing schedulable to even try; "all available accounts exhausted"
-// means its failover loop tried every candidate and they were all (transiently)
-// unavailable. Both are TokenKey-internal *downstream capacity* signals, not a
-// health problem with THIS forwarding stub and not a genuine provider error.
-func tkIsDownstreamAllAccountsExhausted(upstreamMsg string, responseBody []byte) bool {
-	if strings.Contains(strings.ToLower(upstreamMsg), tkDownstreamAllAccountsExhaustedNeedle) {
-		return true
-	}
-	return strings.Contains(strings.ToLower(string(responseBody)), tkDownstreamAllAccountsExhaustedNeedle)
-}
-
 // tkSkipDownstreamFailoverExhaustedPenalty (TK — G2, narrow) generalises the
 // no-available skip to the second downstream capacity envelope. It is the only
 // addition over the pre-existing no-available skip: a forwarding stub that
-// receives the downstream gateway's own "all available accounts exhausted" signal
-// must fail over to the next stub without advancing the per-account
-// anthropic_upstream_error 3/3 ladder — the stub itself is healthy; the
-// forwarded-to edge pool transiently ran dry.
+// receives the downstream gateway's own failover-terminal signal must fail over
+// to the next stub without advancing the per-account anthropic_upstream_error
+// ladder. The forwarding stub did not originate the downstream failure.
 //
 // Status set is deliberately wider than the no-available skip (429 OR any 5xx):
-// the failover-exhausted envelope is written as HTTP 502, whereas the empty-pool
-// fast-fail is 429 (or legacy 503). Crucially this matches ONLY on TokenKey's own
-// capacity string — a raw edge-infra 5xx (Caddy 502 HTML, connection reset) or a
-// genuine provider error carries no such phrase, so it still flows through the
-// tiered cooldown and keeps the beneficial "route away from a broken edge"
-// behaviour (PR #333 / 2026-05-21). This is the explicit scope chosen for G2:
-// exempt TokenKey downstream *capacity* signals, never genuine failures.
+// the failover-terminal envelope is normally written as HTTP 502, whereas the
+// empty-pool fast-fail is 429 (or legacy 503). Crucially this matches ONLY
+// TokenKey's exact current/legacy client messages — a raw edge-infra 5xx (Caddy
+// 502 HTML, connection reset) or a genuine provider error still flows through
+// the tiered cooldown and keeps the beneficial route-away behavior.
 func tkSkipDownstreamFailoverExhaustedPenalty(statusCode int, upstreamMsg string, responseBody []byte) bool {
 	if statusCode != http.StatusTooManyRequests && statusCode < 500 {
 		return false
 	}
-	return tkIsDownstreamAllAccountsExhausted(upstreamMsg, responseBody)
+	return IsGatewayFailoverMessage(upstreamMsg, responseBody)
 }
 
 // tkIsKiroMirrorStub reports whether this local account is a prod Anthropic

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
@@ -159,8 +159,8 @@ func TestRateLimitService_DownstreamNoAvailable_FeedsSaturationButNotLadder(t *t
 	for i := 0; i < 3; i++ {
 		require.True(t, service.HandleUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, noAvail))
 	}
-	// 502 failover-exhausted (sibling capacity signal).
-	exhausted := []byte(`{"type":"error","error":{"type":"server_error","message":"all available accounts exhausted"}}`)
+	// 502 failover-terminal (sibling downstream signal).
+	exhausted := []byte(`{"type":"error","error":{"type":"server_error","message":"Upstream request could not be completed"}}`)
 	for i := 0; i < 2; i++ {
 		require.True(t, service.HandleUpstreamError(context.Background(), account, http.StatusBadGateway, http.Header{}, exhausted))
 	}

--- a/backend/internal/service/ratelimit_service_tk_mirror_class_429_test.go
+++ b/backend/internal/service/ratelimit_service_tk_mirror_class_429_test.go
@@ -145,7 +145,7 @@ func TestMirrorClass429_NonAuthoritative429Branch_WritesCooldown(t *testing.T) {
 	account := &Account{ID: 54, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
 
 	// Header-less 429 whose body is NOT a TK capacity needle ("no available
-	// accounts" / "all available accounts exhausted") — the cc-us7 relayed
+	// accounts" / the TokenKey failover-terminal envelope) — the cc-us7 relayed
 	// "Upstream rate limit exceeded" envelope.
 	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Upstream rate limit exceeded, please retry later"}}`)
 	for i := 0; i < 5; i++ {
@@ -174,7 +174,7 @@ func TestMirrorClass429_FailoverExhaustedBody429_WritesCooldown(t *testing.T) {
 	account := &Account{ID: 54, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
 
 	// 429 whose body is TokenKey's own failover-exhausted capacity phrase.
-	body := []byte(`{"type":"error","error":{"type":"server_error","message":"all available accounts exhausted"}}`)
+	body := []byte(`{"type":"error","error":{"type":"server_error","message":"Upstream request could not be completed"}}`)
 	for i := 0; i < 5; i++ {
 		require.True(t, svc.HandleUpstreamError(context.Background(), account,
 			http.StatusTooManyRequests, http.Header{}, body, "claude-sonnet-4-5"))
@@ -197,7 +197,7 @@ func TestMirrorClass429_Genuine502_LegacyPath_NoMirrorClassCooldown(t *testing.T
 	svc, _ := newMirrorClass429Service(repo)
 	account := &Account{ID: 54, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
 
-	body := []byte(`{"type":"error","error":{"type":"server_error","message":"all available accounts exhausted"}}`)
+	body := []byte(`{"type":"error","error":{"type":"server_error","message":"Upstream request could not be completed"}}`)
 	for i := 0; i < 5; i++ {
 		// 502 → default: → legacy handleAnthropicUpstreamError (no requestedModel).
 		require.True(t, svc.HandleUpstreamError(context.Background(), account,

--- a/backend/internal/service/ratelimit_service_tk_nonauthoritative_429.go
+++ b/backend/internal/service/ratelimit_service_tk_nonauthoritative_429.go
@@ -19,7 +19,7 @@ import (
 // capacity / failover envelopes relayed back to a prod cc-<edge> stub:
 //
 //   - "No available accounts: no available accounts"      (empty-pool fast-fail, 429) → tkSkipDownstreamNoAvailableAccountsPenalty
-//   - "all available accounts exhausted"                  (failover-exhausted, 502)   → tkSkipDownstreamFailoverExhaustedPenalty
+//   - TokenKey failover-terminal envelope                  (normally 502)              → tkSkipDownstreamFailoverExhaustedPenalty
 //   - "Upstream rate limit exceeded, please retry later"  (rate-limit failover-       → NEITHER needle matched → fell through and
 //                                                          exhausted, 429)               advanced the per-account anthropic_upstream_error
 //                                                                                        3/3 ladder, cooling a HEALTHY mirror stub

--- a/backend/internal/service/ratelimit_service_tk_openai_downstream.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_downstream.go
@@ -40,6 +40,7 @@ func tkOpenAICompatDownstreamCapacityReason(statusCode int, upstreamMsg string, 
 	case tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody):
 		return "no_available_accounts"
 	case tkSkipDownstreamFailoverExhaustedPenalty(statusCode, upstreamMsg, responseBody):
+		// Historical metrics key; keep it stable across the client-message change.
 		return "all_available_accounts_exhausted"
 	case tkIsDownstreamRateLimitEnvelope(statusCode, upstreamMsg, responseBody):
 		return "upstream_rate_limit_exhausted"

--- a/backend/internal/service/ratelimit_service_tk_saturation.go
+++ b/backend/internal/service/ratelimit_service_tk_saturation.go
@@ -11,7 +11,7 @@ import (
 // "stub" accounts (cc-us2 / cc-uk1 / …) that forward to the matching Edge
 // gateway, where a SINGLE OAuth account is common (SPOF). When that edge's one
 // account is upstream-rate-limited (~47-min window), the edge returns TokenKey's
-// own "No available accounts" 429 (or "all available accounts exhausted" 502).
+// own "No available accounts" 429 (or its failover-terminal envelope).
 // tkSkipDownstreamNoAvailableAccountsPenalty / ...FailoverExhaustedPenalty
 // correctly SKIP penalty + fail over (so users see no failures) but DELIBERATELY
 // keep the stub fully schedulable — counting these toward the 3/3 ladder once
@@ -33,7 +33,7 @@ func (s *RateLimitService) SetAnthropicSaturationCounter(cache AnthropicSaturati
 // recordAnthropicStubSaturation increments the per-stub saturation counter for a
 // downstream-capacity hit. Called only from the two skip-penalty branches in
 // HandleUpstreamError (anthropic stub received our own "no available accounts" /
-// "all available accounts exhausted" envelope). Best-effort: Redis errors are
+// failover-terminal envelope). Best-effort: Redis errors are
 // logged and swallowed — selection must never fail because the preference
 // counter is unavailable. Logs at threshold crossing only (low-volume), so ops
 // can see a stub entering the de-prioritized state.

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -130,11 +130,11 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
         ;;
       *)
         case "${err_msg}" in
-          # Pool exhaustion is a runtime resource state, not a control-plane
-          # regression. Two distinct gateway phrasings reach here:
+          # A gateway capacity/failover terminal is a runtime state, not a
+          # control-plane response-shape regression. These phrasings reach here:
           #   "no available accounts"        — empty/throttled pool on the
           #                                    directly-bound group.
-          #   "All available accounts exhausted" — the CC-only fallback path
+          #   "Upstream request could not be completed" — the CC-only fallback path
           #                                    (PR #740): a claude_code_only key
           #                                    routes /v1/chat|/v1/responses to
           #                                    its fallback_group_id, and that
@@ -146,10 +146,12 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
           #                                    turned an unchanged pool state into
           #                                    a hard smoke failure. /v1/messages
           #                                    stays the canonical signal for this key.
-          *"no available accounts"*|*"available accounts exhausted"*)
-            echo "::warning::tk_post_deploy_smoke: ${label} returned HTTP ${http} with a pool-exhaustion message ('no available accounts' / 'All available accounts exhausted') — pool exhausted, not a control-plane regression." >&2
+          # The old "All available accounts exhausted" wording remains accepted
+          # while prod and edge gateways can run different release versions.
+          *"no available accounts"*|*"Upstream request could not be completed"*|*"available accounts exhausted"*)
+            echo "::warning::tk_post_deploy_smoke: ${label} returned HTTP ${http} with a gateway capacity/failover message — runtime state, not a control-plane regression." >&2
             jq . "${resp_file}" >&2 2>/dev/null || cat "${resp_file}" >&2
-            echo "tk_post_deploy_smoke: ${label} section soft-skipped (pool exhausted)"
+            echo "tk_post_deploy_smoke: ${label} section soft-skipped (gateway runtime state)"
             return 1
             ;;
           *"No platform in your plan can serve"*|*universal_no_entitled*)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -408,25 +408,46 @@
       "rationale": "Mechanical proof that the stub-health fuse allowlist stays narrow: predicate unit tests plus regressions that extra-usage / no-SetRateLimited 429 must not feed the 3/3 counter while authoritative 429 still does."
     },
     {
+      "path": "backend/internal/service/gateway_failover_message_tk.go",
+      "must_contain": [
+        "gatewayFailoverClientMessage       = \"Upstream request could not be completed\"",
+        "legacyGatewayFailoverClientMessage = \"All available accounts exhausted\"",
+        "func GatewayFailoverClientMessage(upstreamStatusCode int) string",
+        "func IsGatewayFailoverMessage(upstreamMsg string, responseBody []byte) bool",
+        "TkEnrichClaudeIncidentMessage(gatewayFailoverClientMessage, upstreamStatusCode)",
+        "extractUpstreamErrorMessage(responseBody)"
+      ],
+      "rationale": "SSOT for the Chat Completions and Responses failover-terminal client message. Failover may stop because the switch budget was reached or because an error is request-owned/non-retryable, so the response must not claim every available account was attempted. The exact matcher accepts the truthful current message plus the legacy wording during rolling prod/edge upgrades, including only the controlled Claude incident suffix; broad substring matching would misclassify provider errors as TokenKey fleet capacity."
+    },
+    {
+      "path": "backend/internal/service/gateway_failover_message_tk_test.go",
+      "must_contain": [
+        "TestGatewayFailoverClientMessageDoesNotClaimEveryAccountWasAttempted",
+        "TestIsGatewayFailoverMessageSupportsRollingVersionCompatibility",
+        "TestIsGatewayFailoverMessageAcceptsControlledIncidentSuffix",
+        "TestIsGatewayFailoverMessageRejectsSubstringAndProviderErrors"
+      ],
+      "rationale": "Behavioral proof for the truthful failover message and its narrow mixed-version classifier: current and legacy TokenKey envelopes match, controlled incident enrichment matches, provider text and broad substring collisions do not."
+    },
+    {
       "path": "backend/internal/service/ratelimit_service_tk_downstream_no_available.go",
       "must_contain": [
         "func tkIsDownstreamNoAvailableAccounts(upstreamMsg string, responseBody []byte) bool",
         "func tkSkipDownstreamNoAvailableAccountsPenalty(statusCode int, upstreamMsg string, responseBody []byte) bool",
-        "func tkIsDownstreamAllAccountsExhausted(upstreamMsg string, responseBody []byte) bool",
         "func tkSkipDownstreamFailoverExhaustedPenalty(statusCode int, upstreamMsg string, responseBody []byte) bool",
+        "IsGatewayFailoverMessage(upstreamMsg, responseBody)",
         "func tkIsKiroMirrorStub(account *Account) bool",
         "func tkSkipDownstreamKiroServiceUnavailablePenalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool",
         "func tkSkipDownstreamKiroOAuthAuthRejectPenalty(account *Account, statusCode int, upstreamMsg string, responseBody []byte) bool",
         "statusCode != http.StatusUnauthorized && statusCode != http.StatusForbidden",
         "if statusCode == http.StatusForbidden {",
-        "all available accounts exhausted",
         "ErrNoAvailableAccounts.Error()",
         "mirror_platform",
         "upstream service temporarily unavailable",
         "invalid bearer token",
         "upstream request failed"
       ],
-      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and 'all available accounts exhausted' (G2 narrow, 429/5xx, downstream failover loop ran dry) are both TokenKey-generated downstream-capacity strings the real provider APIs never emit; a healthy forwarding stub must fail over without advancing the 3/3 ladder. Both skips match ONLY these TokenKey phrases, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. G5 Kiro mirror OAuth auth rejection: a prod Anthropic API-key mirror stub whose credentials.mirror_platform=kiro may receive the edge Kiro OAuth account's 401/403 invalid-bearer wrapper, but prod has no OAuth identity to refresh and must not SetError or ladder-cool the relay stub after edge self-heals. G6 Kiro service-unavailable applies the same ownership boundary to the exact TokenKey 502 envelope emitted after an edge Kiro transport/read failure: prod must fail over and de-prioritize the stub without duplicating the edge failure into the prod 3/3 fuse. Raw proxy HTML 502s, plain Anthropic accounts, and other mirror platforms remain eligible for their existing health handling. Dropping either Kiro helper silently restores stale prod stub errors or whole-pool mirror cooldown from downstream-owned failures."
+      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and the service-owned failover-terminal envelope (G2 narrow, 429/5xx) are TokenKey-generated downstream signals; a healthy forwarding stub must fail over without advancing the 3/3 ladder. The failover classifier accepts the truthful current message and legacy wording exactly for mixed-version rollout, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. G5 Kiro mirror OAuth auth rejection: a prod Anthropic API-key mirror stub whose credentials.mirror_platform=kiro may receive the edge Kiro OAuth account's 401/403 invalid-bearer wrapper, but prod has no OAuth identity to refresh and must not SetError or ladder-cool the relay stub after edge self-heals. G6 Kiro service-unavailable applies the same ownership boundary to the exact TokenKey 502 envelope emitted after an edge Kiro transport/read failure: prod must fail over and de-prioritize the stub without duplicating the edge failure into the prod 3/3 fuse. Raw proxy HTML 502s, plain Anthropic accounts, and other mirror platforms remain eligible for their existing health handling. Dropping either Kiro helper silently restores stale prod stub errors or whole-pool mirror cooldown from downstream-owned failures."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",
@@ -469,10 +490,11 @@
     {
       "path": "backend/internal/service/ratelimit_service_tk_downstream_exhausted_test.go",
       "must_contain": [
+        "TestTkSkipDownstreamFailoverExhaustedPenalty",
         "TestRateLimitService_HandleUpstreamError_DownstreamFailoverExhausted_DoesNotPenalizeStub",
         "TestRateLimitService_HandleUpstreamError_RawInfra502_StillCountsAndRoutesAway"
       ],
-      "rationale": "Focused regressions proving G2 (narrow): the 'all available accounts exhausted' downstream envelope is skipped, while a raw infra 502 with no TokenKey capacity phrase STILL counts and routes away (PR #333 preserved). The pair is the load-bearing boundary — dropping the first re-arms the amplifier, dropping the second would let a future broad refactor silently weaken route-away."
+      "rationale": "Focused regressions proving G2 (narrow): current and legacy TokenKey failover-terminal envelopes are skipped, while a raw infra 502 with no TokenKey message still counts and routes away (PR #333 preserved). This is the load-bearing boundary between downstream-owned failover and genuine relay/provider failure."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_openai_cf_challenge_test.go",
@@ -3193,9 +3215,9 @@
         "func tkUpstreamDownstreamCapacity(c *gin.Context) bool",
         "if status != 429 && status < 500 {",
         "isOpsNoAvailableAccountMessage(combined)",
-        "opsDownstreamFailoverExhaustedPhrase"
+        "service.IsGatewayFailoverMessage(msg, []byte(body))"
       ],
-      "rationale": "Mirror-edge metric pollution (2026-06-06 yace load test): prod relays to Edge stacks via cc-<edge> apikey mirror accounts; an empty edge pool returns 429/503 with a TokenKey 'No available accounts' body (tkNoAvailableAccounts, PR #575). Because that 429 carries a definitive upstream status, tkUpstreamClientCanceled (status-0 gate) deliberately skips it and classifyOpsErrorLog counted it as phase=upstream/provider — so a dead single-account edge (us3: served_200=0, no_available_429=33748) and a healthy 3-account edge (us5: 2251x200, 77x429) both read ~1300 upstream-429 on prod, making the provider-health metric unable to tell a dead edge from a healthy one. This predicate detects a relayed TokenKey downstream-capacity verdict (status 429 or >=500 AND body text 'no available accounts' / 'all available accounts exhausted') so classifyOpsErrorLog can fold it into routingCapacityLimited and own it as routing (out of upstream_error_rate), exactly like a LOCAL empty pool and mirroring the cooldown-ladder skip in ratelimit_service_tk_downstream_no_available.go. Boundary (anthropic_amplifier_exemption_boundary): the status gate keeps status-0 transport errors with tkUpstreamClientCanceled, and ONLY the TokenKey-generated phrases match — a real Anthropic 429 (rate_limit_error) or raw 5xx carries no such phrase and stays provider-owned. Dropping the predicate (or broadening it past the TK phrases) re-arms the mirror-edge false P0 / blinds provider health."
+      "rationale": "Mirror-edge metric pollution (2026-06-06 yace load test): prod relays to Edge stacks via cc-<edge> apikey mirror accounts; an empty edge pool returns 429/503 with a TokenKey 'No available accounts' body. This predicate detects a relayed TokenKey downstream verdict (status 429 or >=500 AND either the no-available signal or the service-owned current/legacy failover-terminal envelope) so classifyOpsErrorLog owns it as routing instead of provider health. Boundary: status 0 stays client-cancel owned, and the failover matcher is exact; real provider 429s and raw 5xx remain provider-owned."
     },
     {
       "path": "backend/internal/handler/ops_error_logger_tk_downstream_capacity_test.go",
@@ -3204,7 +3226,7 @@
         "TestClassifyOpsGenuineUpstreamStaysProviderDespiteCapacityHelper",
         "TestTkUpstreamDownstreamCapacityPredicate"
       ],
-      "rationale": "Focused regressions proving the mirror-edge boundary: (1) a relayed edge 'no available accounts' 429 (with and without a trailing client-cancel) and an 'all available accounts exhausted' 503 classify as phase=routing / error_owner=platform / businessLimited (out of upstream_error_rate); (2) a genuine provider 429 (rate_limit_error) and a raw 5xx with no TokenKey phrase stay phase=upstream / error_owner=provider so they keep counting; (3) the predicate status gate (status 0 owned by client-cancel) and phrase boundary hold. Dropping these lets an upstream merge silently revert the mirror-edge upstream-429 exclusion through the classifier."
+      "rationale": "Focused regressions proving the mirror-edge boundary: relayed no-available plus current and legacy failover-terminal envelopes classify as routing/platform, while genuine provider 429s and raw 5xx stay upstream/provider. The predicate status gate keeps status 0 client-cancel owned."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_header_wait_keepalive.go",
@@ -3545,16 +3567,28 @@
     {
       "path": "backend/internal/handler/gateway_handler_chat_completions.go",
       "must_contain": [
-        "h.tkResolveCCOnlyFallback(c, apiKey, reqLog, writeForbidden, writeBillingError)"
+        "h.tkResolveCCOnlyFallback(c, apiKey, reqLog, writeForbidden, writeBillingError)",
+        "service.GatewayFailoverClientMessage(http.StatusBadGateway)",
+        "service.GatewayFailoverClientMessage(statusCode)"
       ],
-      "rationale": "Thin injection point for CC-only fallback routing in the upstream-shaped /v1/chat/completions handler. The bare CC-only 403 was replaced by a call into the TK companion (gateway_handler_tk_cc_only_fallback.go) that, on a valid fallback_group_id, re-binds apiKey to the fallback group and continues the request. An upstream merge that copies the old bare-403 shape back over this hook silently reverts the fallback feature."
+      "rationale": "Thin injection points for CC-only fallback routing and the shared truthful failover-terminal message in /v1/chat/completions. An upstream merge must not restore the bare CC-only 403 or the misleading claim that every available account was attempted."
     },
     {
       "path": "backend/internal/handler/gateway_handler_responses.go",
       "must_contain": [
-        "h.tkResolveCCOnlyFallback(c, apiKey, reqLog, writeForbidden, writeBillingError)"
+        "h.tkResolveCCOnlyFallback(c, apiKey, reqLog, writeForbidden, writeBillingError)",
+        "service.GatewayFailoverClientMessage(http.StatusBadGateway)",
+        "service.GatewayFailoverClientMessage(statusCode)"
       ],
-      "rationale": "Thin injection point for CC-only fallback routing in the upstream-shaped /v1/responses handler. Mirrors the /v1/chat/completions hook: the bare CC-only 403 delegates to the TK companion so a valid fallback_group_id routes non-CC traffic to the fallback group instead of rejecting it. Anchors the hook against an upstream merge silently restoring the bare 403."
+      "rationale": "Thin injection points for CC-only fallback routing and the shared truthful failover-terminal message in /v1/responses. This mirrors Chat Completions and prevents either API surface from drifting back to the misleading all-accounts claim."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_failover_message_test.go",
+      "must_contain": [
+        "TestHandleCCFailoverExhaustedUsesTruthfulClientMessage",
+        "TestHandleResponsesFailoverExhaustedUsesTruthfulClientMessage"
+      ],
+      "rationale": "Focused behavioral regressions proving both OpenAI-compatible API shapes return the shared neutral message and never claim all accounts were exhausted."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_media_unpriced_guard.go",

--- a/scripts/test_smoke_suite.py
+++ b/scripts/test_smoke_suite.py
@@ -132,6 +132,20 @@ class SoftDegradeOrExitTest(unittest.TestCase):
         self.assertEqual(rc, 0, out)
         self.assertIn("MARKER=softskip", out)
 
+    def test_full_403_failover_terminal_soft_skips(self) -> None:
+        rc, out = self._run(
+            "full", "403", {"error": {"message": "Upstream request could not be completed"}},
+        )
+        self.assertEqual(rc, 0, out)
+        self.assertIn("MARKER=softskip", out)
+
+    def test_full_403_legacy_failover_terminal_soft_skips(self) -> None:
+        rc, out = self._run(
+            "full", "403", {"error": {"message": "All available accounts exhausted"}},
+        )
+        self.assertEqual(rc, 0, out)
+        self.assertIn("MARKER=softskip", out)
+
     def test_full_200_continues(self) -> None:
         rc, out = self._run("full", "200", {"ok": True})
         self.assertEqual(rc, 0, out)


### PR DESCRIPTION
## 摘要

- 将 `/v1/chat/completions` 与 `/v1/responses` 的 failover 终止提示统一为 `Upstream request could not be completed`，不再错误声称所有可用账号均已耗尽。
- 在 service 层集中维护消息与识别逻辑；prod/edge 混跑期间精确兼容新旧两种 TokenKey 信封及受控的 Claude incident 后缀。
- 同步限流豁免、ops 错误归类、部署 smoke 和 upstream-merge sentinel，保持状态码、failover 行为与历史指标 reason key 不变。

## 风险

- 对外 `error.message` 文本发生变化；HTTP 状态码、错误类型/代码、账号切换、冷却和计费逻辑不变。
- 旧版 edge 文案继续被识别，滚动升级不会误罚镜像账号或污染 provider 指标。
- Web impact: none

## 验证

- `go test -tags=unit ./internal/service`
- `go test -tags=unit ./internal/handler`
- `python3 -m unittest scripts.test_smoke_suite`
- `bash -n ops/stage0/smoke_lib.sh`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `xj-review`: normal / concise，零 medium+ finding

## 提交

- `76c1894f5 fix(gateway): 修正 failover 终止错误信息`

最新提交：76c1894f5