### PR TITLE
fix(newapi): DashScope 欠费 disable+failover，对齐 402 惩罚

### DIFF
--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -84,12 +84,16 @@ type incidentClass struct {
 	advice      string // 运营建议动作
 }
 
+// tkUpstreamStandingDisableRecoveryAdvice is shared by bridge upstream standing
+// failures (402 balance, DashScope Arrearage 400, etc.) after SetError disable.
+const tkUpstreamStandingDisableRecoveryAdvice = "账号已永久停调度;充值/余额或凭证恢复后须运营在 Admin 手动清除 error 并重测后再恢复调度"
+
 // classifyIncident 把底层 reason 字符串映射成 (形态, 去重类, 中文文案, 建议)。
 // reason 精确匹配优先（覆盖全部已知挂钩点）;未知 reason 时用显式 kind + until 兜底。
 func classifyIncident(reason string, until time.Time, kind AccountIncidentKind) incidentClass {
 	switch strings.TrimSpace(strings.ToLower(reason)) {
 	case "auth_error":
-		return incidentClass{true, IncidentKindPermanentDisable, "auth", "账号永久失效（认证失败）", "立即重新 OAuth 授权该账号"}
+		return incidentClass{true, IncidentKindPermanentDisable, "auth", "账号永久失效（认证失败）", "检查上游认证/余额/凭证;" + tkUpstreamStandingDisableRecoveryAdvice}
 	case "custom_error_code":
 		return incidentClass{true, IncidentKindPermanentDisable, "custom_code", "账号被自定义错误码罚下", "检查命中的自定义错误码规则与上游响应"}
 	case "stream_timeout_error":
@@ -106,14 +110,11 @@ func classifyIncident(reason string, until time.Time, kind AccountIncidentKind) 
 		return incidentClass{true, IncidentKindTemporaryCooldown, "temp", "临时不可调度", "观察是否自愈"}
 	case "newapi_arrears":
 		// TK (prod 2026-06-12, account 60 "Qwen" / DashScope arrears): an upstream
-		// account-standing / 欠费 failure that arrives as a 400 ("Arrearage"). The
-		// account is COOLED (not hard-disabled) so a recharge auto-recovers, but
-		// the ALERT must be IMMEDIATE + actionable — arrears is persistent until a
-		// human recharges, so it must NOT fold into the #730 default-OFF temporary
-		// digest. Route it through the permanent (immediate P0 card) path with the
-		// 1h per-account dedupe so a persistently-arrears account fires at most
-		// once per window instead of one card per request.
-		return incidentClass{true, IncidentKindPermanentDisable, "newapi_arrears", "上游账号欠费", "DashScope 等上游账号欠费(Arrearage),需在对应控制台(如阿里云百炼)充值/还款;账号已临时摘出轮换,充值后冷却到期自动恢复"}
+		// account-standing / 欠费 failure that arrives as a 400 ("Arrearage"). Same
+		// penalty shape as bridge 402 (SetError disable) — recharge does NOT auto-
+		// recover scheduling. The ALERT must be IMMEDIATE + actionable; route through
+		// the permanent (immediate P0 card) path with the 1h per-account dedupe.
+		return incidentClass{true, IncidentKindPermanentDisable, "newapi_arrears", "上游账号欠费", "DashScope 等上游账号欠费(Arrearage),需在对应控制台(如阿里云百炼)充值/还款;" + tkUpstreamStandingDisableRecoveryAdvice}
 	case "kiro_quota_limit":
 		// TK (prod 2026-06-25, edge-us4 account 9): Kiro OAuth subscription quota
 		// exhaustion is HTTP 402 + "You have reached the limit." — not an auth

--- a/backend/internal/service/newapi_bridge_arrears_tk.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -121,12 +122,15 @@ func tkBridgeArrearsDetail(apiErr *newapitypes.NewAPIError) string {
 	if apiErr == nil {
 		return ""
 	}
-	body := tkBridgeUpstreamErrorBody(apiErr)
-	code := strings.TrimSpace(gjson.GetBytes(body, "error.code").String())
-	if code == "" {
-		code = strings.TrimSpace(gjson.GetBytes(body, "error.type").String())
+	oai, ok := tkBridgeUpstreamOpenAIError(apiErr)
+	if !ok {
+		return ""
 	}
-	msg := strings.TrimSpace(gjson.GetBytes(body, "error.message").String())
+	code := strings.TrimSpace(fmt.Sprint(oai.Code))
+	if code == "" || code == "<nil>" {
+		code = strings.TrimSpace(oai.Type)
+	}
+	msg := strings.TrimSpace(oai.Message)
 	if code == "" && msg == "" {
 		return ""
 	}

--- a/backend/internal/service/newapi_bridge_arrears_tk.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk.go
@@ -24,7 +24,7 @@ import (
 //
 // TokenKey classifies a bridge 400 as CLIENT-induced (see
 // tkBridgePenaltyStatusEligible — 400 is excluded from the penalty allowlist
-// precisely so a malformed caller request can never cool a shared account, the
+// precisely so a malformed caller request can never disable a shared account, the
 // #617 lesson). That is correct for validation / bad-param / oversized-body
 // 400s, but an arrears 400 is an ACCOUNT-standing failure that is persistent
 // until a human recharges the upstream console. Left as a pass-through 400 the
@@ -38,11 +38,10 @@ import (
 //   - Part A (penalty): the arrears signal is matched conservatively (upstream
 //     provider error code/type == "Arrearage" case-insensitive, OR message
 //     containing "account is in good standing" / "overdue" / "arrear"). On a
-//     match the account is COOLED (SetTempUnschedulable, a few minutes) — not
-//     hard-disabled — so a recharge lets it auto-recover after the cooldown
-//     expires and the account is re-probed. Cooling (not pass-through) takes the
-//     dead account out of rotation, enabling failover or a clean "no available
-//     accounts" response instead of a wall of identical 400s.
+//     match the account is DISABLED (SetError, same as bridge 402 balance) so
+//     recharge alone does not auto-recover — ops must clear error + re-test in
+//     Admin. Disabling takes the dead account out of rotation, enabling failover
+//     or a clean "no available accounts" response instead of a wall of 400s.
 //   - Part B (alert): the same path routes the incident through the IMMEDIATE
 //     P0 Feishu card (classifyIncident "newapi_arrears" → IncidentKindPermanent
 //     Disable), NOT the self-healing temporary-cooldown digest that #730 made
@@ -51,16 +50,8 @@ import (
 //     window inside handlePermanent) keeps a persistently-arrears account from
 //     spamming one card per request.
 //
-// Narrowness is the whole point: a false positive cools + alerts on a healthy
+// Narrowness is the whole point: a false positive disables + alerts on a healthy
 // account, so the matcher must NEVER fire on a generic / legitimate client 400.
-
-// tkBridgeArrearsCooldownDuration is the account-level cooldown applied on an
-// upstream arrears 400. A few minutes: long enough to take the dead account out
-// of rotation and stop the identical-400 wall, short enough that a fresh
-// recharge auto-recovers on the next re-probe without admin intervention. The
-// immediate Feishu card is what actually prompts the human recharge; the
-// cooldown is just the stop-the-bleeding rotation removal.
-const tkBridgeArrearsCooldownDuration = 5 * time.Minute
 
 // tkBridgeArrearsIncidentReason is the stable reason string classifyIncident
 // maps to the immediate "上游账号欠费" P0 card (NOT the temporary digest).
@@ -156,32 +147,28 @@ func tkHandleBridgeArrearsPenalty(ctx context.Context, rls *RateLimitService, ac
 	if !tkIsBridgeUpstreamArrears(apiErr) {
 		return false
 	}
-	until := time.Now().Add(tkBridgeArrearsCooldownDuration)
 	detail := tkBridgeArrearsDetail(apiErr)
+	errorMsg := "Account arrears (400): insufficient balance or billing issue"
+	if detail != "" {
+		errorMsg = "Account arrears (400): " + detail
+	}
 
 	stateCtx, cancel := openAIAccountStateContext(ctx)
 	defer cancel()
 
-	// Account-level cooldown (rotation removal), NOT hard-disable: a recharge
-	// auto-recovers after expiry + re-probe.
-	reasonMsg := "Upstream account arrears (" + tkBridgeArrearsIncidentReason + ")"
-	if detail != "" {
-		reasonMsg = reasonMsg + ": " + detail
-	}
-	if err := rls.accountRepo.SetTempUnschedulable(stateCtx, account.ID, until, reasonMsg); err != nil {
-		slog.Warn("newapi_bridge_arrears_set_temp_unschedulable_failed",
+	// Same penalty shape as bridge 402: permanent disable until ops clears error.
+	rls.notifyAccountSchedulingBlocked(account, time.Time{}, tkBridgeArrearsIncidentReason, errorMsg)
+	if err := rls.accountRepo.SetError(stateCtx, account.ID, errorMsg); err != nil {
+		slog.Warn("newapi_bridge_arrears_set_error_failed",
 			"account_id", account.ID, "error", err)
+		return true
 	}
-	// Funnel: runtime-block + immediate P0 Feishu card (classifyIncident maps
-	// "newapi_arrears" → IncidentKindPermanentDisable) + pool-exhaustion check.
-	rls.notifyAccountSchedulingBlocked(account, until, tkBridgeArrearsIncidentReason, detail)
-
-	slog.Warn("newapi_bridge_upstream_arrears_penalty",
+	slog.Warn("account_disabled_newapi_arrears",
 		"account_id", account.ID,
 		"platform", account.Platform,
 		"channel_type", account.ChannelType,
 		"status_code", apiErr.StatusCode,
-		"cooldown_until", until.Format(time.RFC3339),
+		"error", errorMsg,
 	)
 	return true
 }

--- a/backend/internal/service/newapi_bridge_arrears_tk_test.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk_test.go
@@ -227,5 +227,9 @@ func TestTkBridgeArrearsDetail_CarriesCodeAndMessage(t *testing.T) {
 	detail := tkBridgeArrearsDetail(arrearsBridgeError(400, dashscopeArrearsMessage, "Arrearage", "Arrearage"))
 	require.Contains(t, detail, "Arrearage")
 	require.Contains(t, detail, "upstream code=Arrearage")
+	require.Contains(t, detail, "https://help.aliyun.com/zh/model-studio/error-code#overdue-payment",
+		"Feishu detail must keep the upstream help URL verbatim (MaskSensitiveInfo+lark_md would corrupt it)")
+	require.NotContains(t, detail, "https://***.com")
+	require.NotContains(t, detail, "https://.com")
 	require.Empty(t, tkBridgeArrearsDetail(nil))
 }

--- a/backend/internal/service/newapi_bridge_arrears_tk_test.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk_test.go
@@ -88,11 +88,10 @@ func TestTkIsBridgeUpstreamArrears_NonArrearsNeverMatch(t *testing.T) {
 	}
 }
 
-// Part A: an arrears 400 must COOL the account (SetTempUnschedulable, NOT
-// SetError/hard-disable) and route the incident with reason "newapi_arrears" to
-// the notifier so it fails over / surfaces "no available accounts" instead of a
-// pass-through 400.
-func TestTkHandleBridgeArrearsPenalty_CoolsAccountAndAlerts(t *testing.T) {
+// Part A: an arrears 400 must DISABLE the account (SetError, same as bridge 402)
+// and route the incident with reason "newapi_arrears" to the notifier so it fails
+// over / surfaces "no available accounts" instead of a pass-through 400.
+func TestTkHandleBridgeArrearsPenalty_DisablesAccountAndAlerts(t *testing.T) {
 	svc, repo, blocker, incidents := newBridgePenaltyTestService()
 	account := newQwenArrearsAccount()
 
@@ -100,14 +99,14 @@ func TestTkHandleBridgeArrearsPenalty_CoolsAccountAndAlerts(t *testing.T) {
 		account, arrearsBridgeError(400, dashscopeArrearsMessage, "Arrearage", "Arrearage"))
 
 	require.True(t, handled, "arrears must be handled (not passed through)")
-	require.Equal(t, 1, repo.tempCalls, "arrears must COOL via SetTempUnschedulable")
-	require.Zero(t, repo.setErrorCalls, "arrears must NOT hard-disable (recharge auto-recovers)")
-	require.Contains(t, repo.lastTempReason, tkBridgeArrearsIncidentReason)
+	require.Equal(t, 1, repo.setErrorCalls, "arrears must DISABLE via SetError (same as 402)")
+	require.Zero(t, repo.tempCalls, "arrears must NOT temp-cool (recharge requires manual recovery)")
 
 	require.Equal(t, []string{tkBridgeArrearsIncidentReason}, blocker.reasons)
 	require.Equal(t, []string{tkBridgeArrearsIncidentReason}, incidents.reasons)
 	require.Len(t, incidents.details, 1)
-	require.Contains(t, incidents.details[0], "Arrearage", "Feishu detail must carry the upstream verdict")
+	require.Contains(t, incidents.details[0], "Account arrears (400)",
+		"Feishu detail must carry the upstream verdict")
 }
 
 // Part A NEGATIVE: a genuine client 400 must NOT be handled by the arrears path
@@ -127,7 +126,7 @@ func TestTkHandleBridgeArrearsPenalty_ClientBadRequestNotHandled(t *testing.T) {
 }
 
 // Part A integration: the bridge penalty entrypoint must route an arrears 400
-// through the arrears path (cool + alert) even though 400 is excluded from the
+// through the arrears path (disable + alert) even though 400 is excluded from the
 // generic tkBridgePenaltyStatusEligible allowlist — i.e. the arrears exception
 // runs BEFORE the allowlist skip.
 func TestTkHandleBridgeUpstreamPenalty_ArrearsExceptionBeforeAllowlist(t *testing.T) {
@@ -140,7 +139,7 @@ func TestTkHandleBridgeUpstreamPenalty_ArrearsExceptionBeforeAllowlist(t *testin
 	tkHandleBridgeUpstreamPenalty(context.Background(), svc, account,
 		arrearsBridgeError(400, dashscopeArrearsMessage, "Arrearage", "Arrearage"))
 
-	require.Equal(t, 1, repo.tempCalls, "arrears 400 must cool via the exception path")
+	require.Equal(t, 1, repo.setErrorCalls, "arrears 400 must disable via the exception path")
 	require.Equal(t, []string{tkBridgeArrearsIncidentReason}, incidents.reasons)
 }
 
@@ -170,7 +169,7 @@ func TestTkHandleBridgeArrearsPenalty_SurvivesCanceledContext(t *testing.T) {
 		arrearsBridgeError(400, dashscopeArrearsMessage, "Arrearage", "Arrearage"))
 
 	require.True(t, handled)
-	require.Equal(t, 1, repo.tempCalls)
+	require.Equal(t, 1, repo.setErrorCalls)
 }
 
 // nil safety: best-effort glue on the error path must never panic.
@@ -186,15 +185,13 @@ func TestTkHandleBridgeArrearsPenalty_NilSafety(t *testing.T) {
 // (IncidentKindPermanentDisable), NOT the #730 default-OFF temporary digest, and
 // carry the actionable recharge advice + the "上游账号欠费" label.
 func TestClassifyIncident_NewAPIArrearsIsImmediateNotDigest(t *testing.T) {
-	// until is non-zero (the account is cooled, not permanently disabled), but
-	// the reason exact-match forces the immediate kind regardless of until — the
-	// alert must not self-heal-silently like a temporary cooldown.
-	cls := classifyIncident(tkBridgeArrearsIncidentReason, time.Now().Add(5*time.Minute), IncidentKindUnknown)
+	cls := classifyIncident(tkBridgeArrearsIncidentReason, time.Time{}, IncidentKindUnknown)
 	require.True(t, cls.alert)
 	require.Equal(t, IncidentKindPermanentDisable, cls.kind,
 		"arrears must use the immediate P0 path, NOT the temporary digest")
 	require.Equal(t, "上游账号欠费", cls.kindZh)
 	require.Contains(t, cls.advice, "充值")
+	require.Contains(t, cls.advice, "手动清除 error")
 }
 
 // Part B: the immediate (permanent) path is per-account deduped to once-per-hour
@@ -204,7 +201,7 @@ func TestClassifyIncident_NewAPIArrearsIsImmediateNotDigest(t *testing.T) {
 func TestHandlePermanent_NewAPIArrearsDedupedPerAccountWindow(t *testing.T) {
 	notifier := newTKAccountIncidentNotifier(nil, "prod")
 	account := newQwenArrearsAccount()
-	cls := classifyIncident(tkBridgeArrearsIncidentReason, time.Now().Add(5*time.Minute), IncidentKindUnknown)
+	cls := classifyIncident(tkBridgeArrearsIncidentReason, time.Time{}, IncidentKindUnknown)
 
 	base := time.Now()
 	notifier.now = func() time.Time { return base }

--- a/backend/internal/service/newapi_bridge_failover_tk.go
+++ b/backend/internal/service/newapi_bridge_failover_tk.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"context"
+	"net/http"
+
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+)
+
+// tkBridgeUpstreamShouldFailoverAfterPenalty reports whether a bridge upstream
+// error should trigger the handler's existing failedAccountIDs failover loop
+// after the account-level penalty has been applied. Only account-standing /
+// credential / capacity failures qualify — never client-induced 400/404 or 5xx
+// provider outages (#617 pool-drain class).
+func tkBridgeUpstreamShouldFailoverAfterPenalty(apiErr *newapitypes.NewAPIError) bool {
+	if apiErr == nil {
+		return false
+	}
+	if tkIsBridgeUpstreamArrears(apiErr) {
+		return true
+	}
+	return tkBridgePenaltyStatusEligible(apiErr.StatusCode)
+}
+
+func tkNewAPIBridgeUpstreamFailoverError(c *gin.Context, apiErr *newapitypes.NewAPIError) *UpstreamFailoverError {
+	statusCode := http.StatusBadGateway
+	var body []byte
+	if apiErr != nil {
+		statusCode = apiErr.StatusCode
+		body = tkBridgeUpstreamErrorBody(apiErr)
+		if c != nil {
+			TkRecordBridgeUpstreamError(c, statusCode, apiErr)
+		}
+	}
+	return &UpstreamFailoverError{
+		StatusCode:        statusCode,
+		ResponseBody:      body,
+		NextAccountAction: NextAccountRetry,
+	}
+}
+
+func bridgeWrapRelayErrorAfterPenalty(
+	ctx context.Context,
+	rls *RateLimitService,
+	c *gin.Context,
+	account *Account,
+	apiErr *newapitypes.NewAPIError,
+) error {
+	tkHandleBridgeUpstreamPenalty(ctx, rls, account, apiErr)
+	if tkBridgeUpstreamShouldFailoverAfterPenalty(apiErr) {
+		return tkNewAPIBridgeUpstreamFailoverError(c, apiErr)
+	}
+	return tkWrapBridgeRelayError(c, apiErr)
+}

--- a/backend/internal/service/newapi_bridge_failover_tk_test.go
+++ b/backend/internal/service/newapi_bridge_failover_tk_test.go
@@ -1,0 +1,119 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkBridgeUpstreamShouldFailoverAfterPenalty_AccountLevelStatuses(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		err  *newapitypes.NewAPIError
+	}{
+		{"402 insufficient balance", upstreamBridgeError(402, "Insufficient Balance")},
+		{"401 auth", upstreamBridgeError(401, "Authentication Fails")},
+		{"429 rate limit", upstreamBridgeError(429, "Requests rate limit exceeded")},
+		{"arrears 400", arrearsBridgeError(400, dashscopeArrearsMessage, "Arrearage", "Arrearage")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.True(t, tkBridgeUpstreamShouldFailoverAfterPenalty(tc.err))
+		})
+	}
+}
+
+func TestTkBridgeUpstreamShouldFailoverAfterPenalty_ClientAndOutageNeverMatch(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		err  *newapitypes.NewAPIError
+	}{
+		{"client 400", upstreamBridgeError(400, "The supported API model names are ...")},
+		{"model not found 404", upstreamBridgeError(404, "model_not_found")},
+		{"server 500", upstreamBridgeError(500, "internal error")},
+		{"server 502", upstreamBridgeError(502, "bad gateway")},
+		{"nil", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.False(t, tkBridgeUpstreamShouldFailoverAfterPenalty(tc.err))
+		})
+	}
+}
+
+func TestBridgeWrapRelayErrorAfterPenalty_AccountLevelReturnsFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	account := newNewAPIBridgeAccount()
+	apiErr := upstreamBridgeError(402, "Insufficient Balance")
+
+	err := bridgeWrapRelayErrorAfterPenalty(context.Background(), nil, c, account, apiErr)
+	require.Error(t, err)
+
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.Equal(t, 402, failoverErr.StatusCode)
+	require.Equal(t, NextAccountRetry, failoverErr.NextAccountAction)
+	require.True(t, failoverErr.ShouldRetryNextAccount())
+	require.Contains(t, string(failoverErr.ResponseBody), "Insufficient Balance")
+
+	var relayErr *NewAPIRelayError
+	require.False(t, errors.As(err, &relayErr))
+}
+
+func TestBridgeWrapRelayErrorAfterPenalty_ArrearsReturnsFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	account := newQwenArrearsAccount()
+	apiErr := arrearsBridgeError(400, dashscopeArrearsMessage, "Arrearage", "Arrearage")
+
+	err := bridgeWrapRelayErrorAfterPenalty(context.Background(), nil, c, account, apiErr)
+	require.Error(t, err)
+
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.Equal(t, 400, failoverErr.StatusCode)
+	require.True(t, failoverErr.ShouldRetryNextAccount())
+}
+
+func TestBridgeWrapRelayErrorAfterPenalty_Client400ReturnsRelayError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	account := newNewAPIBridgeAccount()
+	apiErr := upstreamBridgeError(400, "The supported API model names are ...")
+
+	err := bridgeWrapRelayErrorAfterPenalty(context.Background(), nil, c, account, apiErr)
+	require.Error(t, err)
+
+	var relayErr *NewAPIRelayError
+	require.True(t, errors.As(err, &relayErr))
+	require.Equal(t, 400, relayErr.Err.StatusCode)
+
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+}
+
+func TestOpenAIGatewayService_TkWrapBridgeRelayErrorWithPenalty_402Failover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	svc := &OpenAIGatewayService{}
+	account := newNewAPIBridgeAccount()
+
+	err := svc.tkWrapBridgeRelayErrorWithPenalty(context.Background(), c, account, upstreamBridgeError(402, "Insufficient Balance"))
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.True(t, failoverErr.ShouldRetryNextAccount())
+}

--- a/backend/internal/service/newapi_bridge_penalty_tk.go
+++ b/backend/internal/service/newapi_bridge_penalty_tk.go
@@ -99,6 +99,18 @@ func tkBridgeUpstreamErrorBody(apiErr *newapitypes.NewAPIError) []byte {
 	return body
 }
 
+// tkBridgeUpstreamOpenAIError returns the raw upstream OpenAI-style envelope
+// stored on RelayError before ToOpenAIError() applies MaskSensitiveInfo. Alert
+// detail lines must use this: masking turns help.aliyun.com URLs into
+// https://***.com/***/***/***, which Feishu lark_md then renders as https://.com///.
+func tkBridgeUpstreamOpenAIError(apiErr *newapitypes.NewAPIError) (newapitypes.OpenAIError, bool) {
+	if apiErr == nil {
+		return newapitypes.OpenAIError{}, false
+	}
+	oai, ok := apiErr.RelayError.(newapitypes.OpenAIError)
+	return oai, ok
+}
+
 // tkWrapBridgeRelayErrorWithPenalty is the OpenAIGatewayService dispatch-site
 // chokepoint: apply the account penalty for real upstream bridge errors, then
 // record + wrap exactly like tkWrapBridgeRelayError. Use at every dispatch site

--- a/backend/internal/service/newapi_bridge_penalty_tk.go
+++ b/backend/internal/service/newapi_bridge_penalty_tk.go
@@ -50,7 +50,7 @@ func tkHandleBridgeUpstreamPenalty(ctx context.Context, rls *RateLimitService, a
 	// account-standing / arrears 400 ("Arrearage") is an ACCOUNT-level failure
 	// disguised as a client 400. It must be caught BEFORE the status allowlist
 	// below (which deliberately excludes 400 to avoid the #617 client-400
-	// pool-drain). This narrow exception cools the account + fires an immediate
+	// pool-drain). This narrow exception disables the account + fires an immediate
 	// P0 Feishu card. See newapi_bridge_arrears_tk.go.
 	if tkHandleBridgeArrearsPenalty(ctx, rls, account, apiErr) {
 		return
@@ -113,26 +113,25 @@ func tkBridgeUpstreamOpenAIError(apiErr *newapitypes.NewAPIError) (newapitypes.O
 
 // tkWrapBridgeRelayErrorWithPenalty is the OpenAIGatewayService dispatch-site
 // chokepoint: apply the account penalty for real upstream bridge errors, then
-// record + wrap exactly like tkWrapBridgeRelayError. Use at every dispatch site
-// that wraps a REAL bridge upstream error and has the selected account in hand
+// return UpstreamFailoverError for account-level faults (401/402/429 + arrears)
+// or NewAPIRelayError for client/outage errors. Use at every dispatch site that
+// wraps a REAL bridge upstream error and has the selected account in hand
 // (NOT for synthetic missing-credential / unsupported-channel errors, and NOT
 // for the account-agnostic video fetch path).
-func (s *OpenAIGatewayService) tkWrapBridgeRelayErrorWithPenalty(ctx context.Context, c *gin.Context, account *Account, apiErr *newapitypes.NewAPIError) *NewAPIRelayError {
+func (s *OpenAIGatewayService) tkWrapBridgeRelayErrorWithPenalty(ctx context.Context, c *gin.Context, account *Account, apiErr *newapitypes.NewAPIError) error {
 	var rls *RateLimitService
 	if s != nil {
 		rls = s.rateLimitService
 	}
-	tkHandleBridgeUpstreamPenalty(ctx, rls, account, apiErr)
-	return tkWrapBridgeRelayError(c, apiErr)
+	return bridgeWrapRelayErrorAfterPenalty(ctx, rls, c, account, apiErr)
 }
 
 // tkWrapBridgeRelayErrorWithPenalty is the GatewayService sibling (the Anthropic
 // gateway's chat-completions/responses bridge boundary in gateway_bridge_dispatch.go).
-func (s *GatewayService) tkWrapBridgeRelayErrorWithPenalty(ctx context.Context, c *gin.Context, account *Account, apiErr *newapitypes.NewAPIError) *NewAPIRelayError {
+func (s *GatewayService) tkWrapBridgeRelayErrorWithPenalty(ctx context.Context, c *gin.Context, account *Account, apiErr *newapitypes.NewAPIError) error {
 	var rls *RateLimitService
 	if s != nil {
 		rls = s.rateLimitService
 	}
-	tkHandleBridgeUpstreamPenalty(ctx, rls, account, apiErr)
-	return tkWrapBridgeRelayError(c, apiErr)
+	return bridgeWrapRelayErrorAfterPenalty(ctx, rls, c, account, apiErr)
 }

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -402,9 +402,20 @@
         "tkHandleBridgeUpstreamPenalty",
         "tkWrapBridgeRelayErrorWithPenalty",
         "tkBridgePenaltyStatusEligible",
-        "tkHandleBridgeArrearsPenalty(ctx, rls, account, apiErr)"
+        "tkHandleBridgeArrearsPenalty(ctx, rls, account, apiErr)",
+        "bridgeWrapRelayErrorAfterPenalty"
       ],
-      "rationale": "TK companion that routes real bridge.Dispatch* upstream errors (401/402/429 allowlist) into RateLimitService.HandleUpstreamError so newapi accounts get disabled/cooled and the Feishu account-incident alert fires. Without it the fifth platform regresses to the 2026-06-11 prod incident: a 402 'Insufficient Balance' DeepSeek account stayed schedulable=true while the gateway hammered the exhausted upstream 6946 times in 2h with zero alerts. The narrow status allowlist is itself load-bearing: it is what keeps client-induced 400/404 (and the synthetic missing-credential/unsupported-channel 400s) from draining the pool (the #617 class). The tkHandleBridgeArrearsPenalty call MUST run BEFORE the tkBridgePenaltyStatusEligible allowlist (which excludes 400): an upstream DashScope arrears 400 ('Arrearage') is an account-standing failure disguised as a client 400 and must cool+alert, not pass through. Reordering it after the allowlist (or dropping it) silently re-opens the 2026-06-12 prod incident where account 60 'Qwen' stayed schedulable with confusing 400s and no recharge alert."
+      "rationale": "TK companion that routes real bridge.Dispatch* upstream errors (401/402/429 allowlist) into RateLimitService.HandleUpstreamError so newapi accounts get disabled/cooled and the Feishu account-incident alert fires. Without it the fifth platform regresses to the 2026-06-11 prod incident: a 402 'Insufficient Balance' DeepSeek account stayed schedulable=true while the gateway hammered the exhausted upstream 6946 times in 2h with zero alerts. The narrow status allowlist is itself load-bearing: it is what keeps client-induced 400/404 (and the synthetic missing-credential/unsupported-channel 400s) from draining the pool (the #617 class). The tkHandleBridgeArrearsPenalty call MUST run BEFORE the tkBridgePenaltyStatusEligible allowlist (which excludes 400): an upstream DashScope arrears 400 ('Arrearage') is an account-standing failure disguised as a client 400 and must disable+alert (SetError, same as 402), not pass through. Reordering it after the allowlist (or dropping it) silently re-opens the 2026-06-12 prod incident where account 60 'Qwen' stayed schedulable with confusing 400s and no recharge alert. bridgeWrapRelayErrorAfterPenalty must turn those penalized account-level faults into UpstreamFailoverError so the handler can retry on a sibling account in the same request."
+    },
+    {
+      "path": "backend/internal/service/newapi_bridge_failover_tk.go",
+      "must_contain": [
+        "tkBridgeUpstreamShouldFailoverAfterPenalty",
+        "tkNewAPIBridgeUpstreamFailoverError",
+        "bridgeWrapRelayErrorAfterPenalty",
+        "NextAccountRetry"
+      ],
+      "rationale": "TK companion that converts penalized newapi bridge account-level faults (401/402/429 + upstream arrears 400/403) into UpstreamFailoverError for the existing handler failedAccountIDs loop. Client-induced 400/404 and 5xx outages must stay on NewAPIRelayError to avoid the #617 pool-drain. Dropping this file regresses prod Qwen arrears / DeepSeek 402 cases where a healthy sibling account exists but the first selected account's error was returned immediately."
     },
     {
       "path": "backend/internal/service/newapi_bridge_arrears_tk.go",
@@ -414,7 +425,7 @@
         "tkBridgeArrearsIncidentReason",
         "arrearage"
       ],
-      "rationale": "TK companion implementing the narrow upstream account-standing / arrears (欠费) classifier + account-level penalty + immediate Feishu alert for the fifth platform. tkIsBridgeUpstreamArrears matches ONLY the DashScope/百炼 arrears verdict (provider code/type == 'Arrearage' case-insensitive, OR message containing 'account is in good standing' / 'overdue' / 'arrear') — never a generic client 400, which would re-open the #617 pool-drain. tkHandleBridgeArrearsPenalty cools the account (SetTempUnschedulable, NOT hard-disable, so a recharge auto-recovers) and funnels the incident through notifyAccountSchedulingBlocked with reason 'newapi_arrears'. Dropping any symbol or weakening the matcher regresses the 2026-06-12 prod incident (account 60 'Qwen' arrears → confusing pass-through 400 + no alert) or, if widened, drains the pool on legitimate client 400s."
+      "rationale": "TK companion implementing the narrow upstream account-standing / arrears (欠费) classifier + account-level penalty + immediate Feishu alert for the fifth platform. tkIsBridgeUpstreamArrears matches ONLY the DashScope/百炼 arrears verdict (provider code/type == 'Arrearage' case-insensitive, OR message containing 'account is in good standing' / 'overdue' / 'arrear') — never a generic client 400, which would re-open the #617 pool-drain. tkHandleBridgeArrearsPenalty disables the account (SetError, same as bridge 402 balance — recharge alone does NOT auto-recover; ops must clear error in Admin) and funnels the incident through notifyAccountSchedulingBlocked with reason 'newapi_arrears'. Dropping any symbol or weakening the matcher regresses the 2026-06-12 prod incident (account 60 'Qwen' arrears → confusing pass-through 400 + no alert) or, if widened, drains the pool on legitimate client 400s."
     },
     {
       "path": "backend/internal/service/account_incident_notifier_tk.go",


### PR DESCRIPTION
## 摘要

- DashScope Arrearage 400 从 5min cooldown 改为 **SetError disable + P0 告警**，与 bridge 402 余额不足行为一致
- 告警建议统一提示：**充值/余额或凭证恢复后须运营在 Admin 手动清除 error 并重测**
- bridge 账号级故障（401/402/429 + 欠费 400）惩罚后返回 **UpstreamFailoverError**，同请求可 failover 到 healthy  sibling 账号
- 修复欠费告警详情中 DashScope 充值链接被 MaskSensitiveInfo 破坏的问题

## 风险

- 常规风险：仅影响 newapi bridge 上游账号级错误处置；客户端 400/404 仍不 penalize（#617 保护不变）
- 欠费/402 账号充值后**不会自动恢复调度**，需运营手动清 error — 告警文案已明确

## 验证

- `cd backend && go test -tags=unit ./internal/service/ -run 'Arrears|BridgeWrap|TkHandleBridge|ClassifyIncident_NewAPI|TkWrapBridgeRelayErrorWithPenalty' -count=1` — PASS
- `./scripts/preflight.sh` — PASS

## 提交

- `8f67bc853` fix(newapi): preserve arrears alert help URL before MaskSensitiveInfo
- `251835061` fix(newapi): align DashScope arrears with 402 disable and bridge failover

最新提交：`251835061`