### PR TITLE
fix(gateway): /v1/messages 长推理阶段尽早下发 thinking SSE

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -854,25 +854,20 @@ func TestStreamingReasoning(t *testing.T) {
 		OutputIndex: 0,
 		Item:        &ResponsesOutput{Type: "reasoning"},
 	}, state)
-	// TK: resToAnthHandleOutputItemAdded for reasoning returns nil (delays
-	// content_block_start until the first non-empty summary delta arrives).
-	// Upstream emits an eager content_block_start with empty thinking content;
-	// see Wei-Shaw/sub2api commit e9a25e7b. TK keeps the deferred-open behavior
-	// to avoid forcing consumers to handle an immediate-empty thinking block.
-	require.Len(t, events, 0)
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_start", events[0].Type)
+	assert.Equal(t, "thinking", events[0].ContentBlock.Type)
+	assert.Equal(t, "", events[0].ContentBlock.Thinking)
 
 	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.reasoning_summary_text.delta",
 		OutputIndex: 0,
 		Delta:       "Let me think...",
 	}, state)
-	require.Len(t, events, 2)
-	assert.Equal(t, "content_block_start", events[0].Type)
-	assert.Equal(t, "thinking", events[0].ContentBlock.Type)
-	assert.Equal(t, "", events[0].ContentBlock.Thinking)
-	assert.Equal(t, "content_block_delta", events[1].Type)
-	assert.Equal(t, "thinking_delta", events[1].Delta.Type)
-	assert.Equal(t, "Let me think...", events[1].Delta.Thinking)
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_delta", events[0].Type)
+	assert.Equal(t, "thinking_delta", events[0].Delta.Type)
+	assert.Equal(t, "Let me think...", events[0].Delta.Thinking)
 
 	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.reasoning_summary_text.delta",
@@ -904,12 +899,15 @@ func TestStreamingReasoning_NoSummaryText(t *testing.T) {
 		OutputIndex: 0,
 		Item:        &ResponsesOutput{Type: "reasoning"},
 	}, state)
-	require.Len(t, events, 0)
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_start", events[0].Type)
+	assert.Equal(t, "thinking", events[0].ContentBlock.Type)
 
 	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type: "response.reasoning_summary_text.done",
 	}, state)
-	require.Len(t, events, 0)
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_stop", events[0].Type)
 
 	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.output_item.done",
@@ -926,7 +924,7 @@ func TestStreamingReasoning_NoSummaryText(t *testing.T) {
 	require.Len(t, events, 2)
 	assert.Equal(t, "content_block_start", events[0].Type)
 	assert.Equal(t, "text", events[0].ContentBlock.Type)
-	assert.Equal(t, 0, *events[0].Index)
+	assert.Equal(t, 1, *events[0].Index)
 	assert.Equal(t, "content_block_delta", events[1].Type)
 }
 
@@ -938,20 +936,79 @@ func TestStreamingReasoning_EmptyDeltasOnly(t *testing.T) {
 		Response: &ResponsesResponse{ID: "resp_empty_deltas", Model: "gpt-5.2"},
 	}, state)
 
-	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.output_item.added",
 		OutputIndex: 0,
 		Item:        &ResponsesOutput{Type: "reasoning"},
 	}, state)
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_start", events[0].Type)
+	assert.True(t, state.ContentBlockOpen)
+	assert.True(t, state.EmittedAnyContentBlock)
 
-	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.reasoning_summary_text.delta",
 		OutputIndex: 0,
 		Delta:       "",
 	}, state)
 	require.Len(t, events, 0)
-	assert.False(t, state.ContentBlockOpen)
-	assert.False(t, state.EmittedAnyContentBlock)
+	assert.True(t, state.ContentBlockOpen)
+}
+
+func TestStreamingReasoning_SummaryPartOpensBeforeDelta(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_part_first", Model: "gpt-5.6"},
+	}, state)
+
+	// Upstream may emit structure frames only during a long reasoning phase.
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item:        &ResponsesOutput{Type: "reasoning", ID: "rs_1", Status: "in_progress"},
+	}, state)
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_start", events[0].Type)
+
+	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:         "response.reasoning_summary_part.added",
+		OutputIndex:  0,
+		SummaryIndex: 0,
+		ItemID:       "rs_1",
+		Part:         &ResponsesContentPart{Type: "summary_text"},
+	}, state)
+	require.Len(t, events, 0, "thinking block already open from output_item.added")
+
+	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.reasoning_summary_text.delta",
+		OutputIndex: 0,
+		Delta:       "First visible token",
+	}, state)
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_delta", events[0].Type)
+	assert.Equal(t, "First visible token", events[0].Delta.Thinking)
+}
+
+func TestStreamingReasoning_SummaryPartAddedOpensBlock(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_part_only", Model: "gpt-5.6"},
+	}, state)
+
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:         "response.reasoning_summary_part.added",
+		OutputIndex:  0,
+		SummaryIndex: 0,
+		ItemID:       "rs_2",
+		Part:         &ResponsesContentPart{Type: "summary_text"},
+	}, state)
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_start", events[0].Type)
+	assert.Equal(t, "thinking", events[0].ContentBlock.Type)
 }
 
 func TestStreamingIncomplete(t *testing.T) {

--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -245,6 +245,10 @@ func ResponsesEventToAnthropicEvents(
 		return resToAnthHandleFuncArgsDone(evt, state)
 	case "response.output_item.done":
 		return resToAnthHandleOutputItemDone(evt, state)
+	case "response.reasoning_summary_part.added":
+		return resToAnthEnsureReasoningBlockOpen(state, evt.OutputIndex)
+	case "response.reasoning_summary_part.done":
+		return resToAnthHandleBlockDone(state)
 	case "response.reasoning_summary_text.delta",
 		// 原始推理文本增量，与 reasoning summary 一样映射为 thinking。
 		"response.reasoning_text.delta":
@@ -401,8 +405,9 @@ func resToAnthHandleOutputItemAdded(evt *ResponsesStreamEvent, state *ResponsesE
 		return events
 
 	case "reasoning":
-		// Open the thinking block only after a non-empty summary delta arrives.
-		return nil
+		// Open thinking immediately so /v1/messages clients (claude-cli) receive
+		// content_block_start during long upstream reasoning before the first delta.
+		return resToAnthEnsureReasoningBlockOpen(state, evt.OutputIndex)
 
 	case "message":
 		return nil
@@ -540,34 +545,40 @@ func resToAnthHandleFuncArgsDone(evt *ResponsesStreamEvent, state *ResponsesEven
 	return events
 }
 
+func resToAnthEnsureReasoningBlockOpen(state *ResponsesEventToAnthropicState, outputIndex int) []AnthropicStreamEvent {
+	if _, ok := state.OutputIndexToBlockIdx[outputIndex]; ok {
+		return nil
+	}
+
+	var events []AnthropicStreamEvent
+	events = append(events, closeCurrentBlock(state)...)
+
+	blockIdx := state.ContentBlockIndex
+	state.OutputIndexToBlockIdx[outputIndex] = blockIdx
+	state.ContentBlockOpen = true
+	state.CurrentBlockType = "thinking"
+	state.EmittedAnyContentBlock = true
+
+	events = append(events, AnthropicStreamEvent{
+		Type:  "content_block_start",
+		Index: &blockIdx,
+		ContentBlock: &AnthropicContentBlock{
+			Type:     "thinking",
+			Thinking: "",
+		},
+	})
+	return events
+}
+
 func resToAnthHandleReasoningDelta(evt *ResponsesStreamEvent, state *ResponsesEventToAnthropicState) []AnthropicStreamEvent {
 	if evt.Delta == "" {
 		return nil
 	}
 
 	var events []AnthropicStreamEvent
+	events = append(events, resToAnthEnsureReasoningBlockOpen(state, evt.OutputIndex)...)
 
-	// Avoid emitting empty thinking blocks when upstream has no summary text.
-	blockIdx, ok := state.OutputIndexToBlockIdx[evt.OutputIndex]
-	if !ok {
-		events = append(events, closeCurrentBlock(state)...)
-
-		blockIdx = state.ContentBlockIndex
-		state.OutputIndexToBlockIdx[evt.OutputIndex] = blockIdx
-		state.ContentBlockOpen = true
-		state.CurrentBlockType = "thinking"
-		state.EmittedAnyContentBlock = true
-
-		events = append(events, AnthropicStreamEvent{
-			Type:  "content_block_start",
-			Index: &blockIdx,
-			ContentBlock: &AnthropicContentBlock{
-				Type:     "thinking",
-				Thinking: "",
-			},
-		})
-	}
-
+	blockIdx := state.OutputIndexToBlockIdx[evt.OutputIndex]
 	events = append(events, AnthropicStreamEvent{
 		Type:  "content_block_delta",
 		Index: &blockIdx,

--- a/backend/internal/service/openai_gateway_messages_reasoning_progress_test.go
+++ b/backend/internal/service/openai_gateway_messages_reasoning_progress_test.go
@@ -1,0 +1,79 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestHandleAnthropicStreamingResponse_ReasoningStructureFramesBeforeDelta verifies
+// that /v1/messages HTTP forwarding opens a thinking content block as soon as
+// upstream emits reasoning lifecycle frames, without waiting for the first summary delta.
+func TestHandleAnthropicStreamingResponse_ReasoningStructureFramesBeforeDelta(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstreamSSE := strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_reasoning","model":"gpt-5.6"}}`,
+		``,
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_1","status":"in_progress"}}`,
+		``,
+		`data: {"type":"response.reasoning_summary_part.added","output_index":0,"summary_index":0,"item_id":"rs_1","part":{"type":"summary_text"}}`,
+		``,
+		`data: {"type":"response.reasoning_summary_text.delta","output_index":0,"summary_index":0,"delta":"First token"}`,
+		``,
+		`data: {"type":"response.reasoning_summary_text.done","output_index":0,"summary_index":0}`,
+		``,
+		`data: {"type":"response.output_text.delta","output_index":1,"delta":"Answer"}`,
+		``,
+		`data: {"type":"response.completed","response":{"id":"resp_reasoning","status":"completed","usage":{"input_tokens":10,"output_tokens":5}}}`,
+		``,
+	}, "\n")
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"X-Request-Id": []string{"req-reasoning-progress"}},
+		Body:       io.NopCloser(bytes.NewBufferString(upstreamSSE)),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	svc := &OpenAIGatewayService{}
+	result, err := svc.handleAnthropicStreamingResponse(
+		resp, c, nil, "gpt-5.6", "gpt-5.6", "gpt-5.6", time.Now(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	body := rec.Body.String()
+	t.Logf("rendered SSE:\n%s", body)
+
+	assertSSEContainsEvent(t, body, "content_block_start", func(data string) bool {
+		return gjson.Get(data, "content_block.type").String() == "thinking" &&
+			gjson.Get(data, "index").Int() == 0
+	}, "thinking block must open before first delta")
+
+	thinkingStartIdx := strings.Index(body, `"type":"thinking"`)
+	thinkingDeltaIdx := strings.Index(body, `"type":"thinking_delta"`)
+	require.NotEqual(t, -1, thinkingStartIdx)
+	require.NotEqual(t, -1, thinkingDeltaIdx)
+	assert.Less(t, thinkingStartIdx, thinkingDeltaIdx,
+		"thinking content_block_start must precede first thinking_delta")
+
+	assertSSEContainsEvent(t, body, "content_block_delta", func(data string) bool {
+		return gjson.Get(data, "delta.type").String() == "thinking_delta" &&
+			gjson.Get(data, "delta.thinking").String() == "First token"
+	}, "first reasoning delta must map to thinking_delta")
+}


### PR DESCRIPTION
## 摘要

- prod 实证受影响用户 100% 走 HTTP `POST /v1/messages`（非 WS）；长 GPT 推理时上游常先发 `output_item.added` / `reasoning_summary_part.added` 结构帧，首个 `reasoning_summary_text.delta` 可能很晚才到。
- 旧逻辑 defer 了 thinking `content_block_start`，且丢弃 `reasoning_summary_part.*`，导致 claude-cli 本地显示「Thought for X min」但长时间收不到 Anthropic thinking SSE，界面 token 不动。
- 修复：在 `responses_to_anthropic.go` 收到 reasoning 结构帧即幂等打开 thinking block，并补齐 `reasoning_summary_part.added/done` 处理；WS 路径未改。

## 风险

- 常规风险：仅影响 OpenAI Responses→Anthropic 流式转换语义；无 reasoning 的请求行为不变。
- 空 reasoning（无 summary 文本）会先开再关空 thinking block，随后正常 text block；与 ChatCompletions bridge 的 summary-part 生命周期对齐。
- Web impact: none（纯 backend apicompat + 测试）。

## 验证

```bash
cd backend && go test -tags=unit ./internal/pkg/apicompat/... -run 'TestStreamingReasoning' -count=1
cd backend && go test -tags=unit ./internal/service/... -run 'TestHandleAnthropicStreamingResponse_ReasoningStructureFramesBeforeDelta' -count=1
```

- 上述测试已通过。
- preflight：除分支名前缀 advisory 外其余检查通过。

## 提交

- a8ec01730 fix(gateway): /v1/messages 长推理阶段尽早下发 thinking SSE

最新提交：a8ec01730

Made with [Cursor](https://cursor.com)