### PR TITLE
fix(openai): Claude Code gpt-5.5[1m] 上下文别名 strip + 使用指南

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -550,6 +550,9 @@ func stringifyCodexContentText(value any) string {
 
 func normalizeCodexModel(model string) string {
 	model = strings.TrimSpace(model)
+	if bare, stripped := applyOpenAICompatContextWindowModelAlias(model); stripped {
+		model = bare
+	}
 	if model == "" {
 		return "gpt-5.4"
 	}

--- a/backend/internal/service/openai_compat_context_window_alias_tk.go
+++ b/backend/internal/service/openai_compat_context_window_alias_tk.go
@@ -1,0 +1,30 @@
+package service
+
+// TokenKey: strip Claude Code / Codex context-window model alias suffixes (e.g.
+// "gpt-5.5[1m]") from OpenAI-compat inbound model ids before routing, Codex
+// transform, and upstream forward.
+//
+// Why this lives on the OpenAI-compat path
+// ----------------------------------------
+// Claude Code denotes the 1M-context variant with a trailing "[1m]" alias on
+// BOTH Anthropic ids (claude-opus-4-8[1m]) and OpenAI-compat dispatch ids
+// (gpt-5.5[1m]). CC uses the suffix locally to pick a 1M client window; the
+// upstream Codex/OpenAI model id must stay bare ("gpt-5.5").
+//
+// Without stripping on the /v1/messages → OpenAI Responses bridge:
+//   - upstream may reject the bracketed id or silently cap to ~200K;
+//   - billing/routing resolve a non-catalog alias;
+//   - CC shows 200K while the user selected a "1M context" custom model.
+//
+// The Anthropic direct forward path already strips via gateway_anthropic_
+// context_window_alias_tk.go. This companion applies the same pure stripper to
+// the OpenAI-compat normalization seam (NormalizeOpenAICompatRequestedModel,
+// applyOpenAICompatModelNormalization, normalizeCodexModel, messages-dispatch
+// mapped-model normalization).
+//
+// Safety contract: identical to tkStripContextWindowModelAlias — trailing
+// bracketed alias only, idempotent, bare ids are byte-for-byte no-ops.
+
+func applyOpenAICompatContextWindowModelAlias(model string) (string, bool) {
+	return tkStripContextWindowModelAlias(model)
+}

--- a/backend/internal/service/openai_compat_context_window_alias_tk_test.go
+++ b/backend/internal/service/openai_compat_context_window_alias_tk_test.go
@@ -1,0 +1,65 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyOpenAICompatContextWindowModelAlias(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{in: "gpt-5.5[1m]", want: "gpt-5.5", ok: true},
+		{in: "gpt-5.5[1M]", want: "gpt-5.5", ok: true},
+		{in: "gpt-5.4[200k]", want: "gpt-5.4", ok: true},
+		{in: "gpt-5.5", want: "gpt-5.5", ok: false},
+		{in: "claude-opus-4-8[1m]", want: "claude-opus-4-8", ok: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, stripped := applyOpenAICompatContextWindowModelAlias(tc.in)
+			require.Equal(t, tc.want, got)
+			require.Equal(t, tc.ok, stripped)
+		})
+	}
+}
+
+func TestNormalizeOpenAICompatRequestedModel_StripsContextWindowAlias(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "gpt-5.5", NormalizeOpenAICompatRequestedModel("gpt-5.5[1m]"))
+	require.Equal(t, "gpt-5.4", NormalizeOpenAICompatRequestedModel("gpt-5.4-xhigh[1m]"))
+}
+
+func TestApplyOpenAICompatModelNormalization_StripsContextWindowAliasBeforeReasoning(t *testing.T) {
+	t.Parallel()
+
+	req := &apicompat.AnthropicRequest{Model: "gpt-5.5-xhigh[1m]"}
+
+	applyOpenAICompatModelNormalization(req)
+
+	require.Equal(t, "gpt-5.5", req.Model)
+	require.NotNil(t, req.OutputConfig)
+	require.Equal(t, "max", req.OutputConfig.Effort)
+}
+
+func TestNormalizeOpenAIMessagesDispatchMappedModel_StripsContextWindowAlias(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "gpt-5.5", normalizeOpenAIMessagesDispatchMappedModel("gpt-5.5[1m]"))
+}
+
+func TestNormalizeCodexModel_StripsContextWindowAlias(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "gpt-5.5", normalizeCodexModel("gpt-5.5[1m]"))
+}

--- a/backend/internal/service/openai_compat_model.go
+++ b/backend/internal/service/openai_compat_model.go
@@ -11,6 +11,9 @@ func NormalizeOpenAICompatRequestedModel(model string) string {
 	if trimmed == "" {
 		return ""
 	}
+	if bare, stripped := applyOpenAICompatContextWindowModelAlias(trimmed); stripped {
+		trimmed = bare
+	}
 
 	normalized, _, ok := splitOpenAICompatReasoningModel(trimmed)
 	if !ok || normalized == "" {
@@ -27,6 +30,10 @@ func applyOpenAICompatModelNormalization(req *apicompat.AnthropicRequest) {
 	originalModel := strings.TrimSpace(req.Model)
 	if originalModel == "" {
 		return
+	}
+	if bare, stripped := applyOpenAICompatContextWindowModelAlias(originalModel); stripped {
+		originalModel = bare
+		req.Model = bare
 	}
 
 	normalizedModel, derivedEffort, hasReasoningSuffix := splitOpenAICompatReasoningModel(originalModel)

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -77,6 +77,8 @@ func TestNormalizeOpenAICompatRequestedModel(t *testing.T) {
 	}{
 		{name: "gpt reasoning alias strips xhigh", input: "gpt-5.4-xhigh", want: "gpt-5.4"},
 		{name: "gpt reasoning alias strips none", input: "gpt-5.4-none", want: "gpt-5.4"},
+		{name: "gpt context alias strips 1m", input: "gpt-5.5[1m]", want: "gpt-5.5"},
+		{name: "gpt reasoning and context alias", input: "gpt-5.5-xhigh[1m]", want: "gpt-5.5"},
 		{name: "codex max model stays intact", input: "gpt-5.1-codex-max", want: "gpt-5.1-codex-max"},
 		{name: "non openai model unchanged", input: "claude-opus-4-6", want: "claude-opus-4-6"},
 	}
@@ -120,6 +122,15 @@ func TestApplyOpenAICompatModelNormalization(t *testing.T) {
 		applyOpenAICompatModelNormalization(req)
 
 		require.Equal(t, "claude-opus-4-6", req.Model)
+		require.Nil(t, req.OutputConfig)
+	})
+
+	t.Run("openai context alias strips before upstream mapping", func(t *testing.T) {
+		req := &apicompat.AnthropicRequest{Model: "gpt-5.5[1m]"}
+
+		applyOpenAICompatModelNormalization(req)
+
+		require.Equal(t, "gpt-5.5", req.Model)
 		require.Nil(t, req.OutputConfig)
 	})
 }

--- a/backend/internal/service/openai_messages_dispatch.go
+++ b/backend/internal/service/openai_messages_dispatch.go
@@ -9,7 +9,11 @@ const (
 )
 
 func normalizeOpenAIMessagesDispatchMappedModel(model string) string {
-	model = NormalizeOpenAICompatRequestedModel(strings.TrimSpace(model))
+	model = strings.TrimSpace(model)
+	if bare, stripped := applyOpenAICompatContextWindowModelAlias(model); stripped {
+		model = bare
+	}
+	model = NormalizeOpenAICompatRequestedModel(model)
 	return strings.TrimSpace(model)
 }
 

--- a/frontend/src/components/keys/UseKeyGuide.vue
+++ b/frontend/src/components/keys/UseKeyGuide.vue
@@ -245,6 +245,7 @@ import {
   useTkUseKey,
   capabilityLabel,
   anthropicEnvModel,
+  claudeCodeEnvModel,
   flavorOfModel,
   type UseKeyFlavor,
   type UseKeyServableModel,
@@ -336,6 +337,12 @@ const baseRoot = computed(() =>
 
 // The single-model "flavor" the current client tab speaks. opencode is a
 // multi-model catalog (no single pick), so it has no flavor.
+const isOpenAIMessagesDispatchClaudeTab = computed(() =>
+  activeClientTab.value === 'claude'
+  && props.allowMessagesDispatch === true
+  && (props.platform === PLATFORM_OPENAI || props.platform === PLATFORM_NEWAPI || props.platform === PLATFORM_GROK),
+)
+
 const activeFlavor = computed<UseKeyFlavor | null>(() => {
   const tab = activeClientTab.value
   if (selectedClientEntry.value?.guideMode === 'qwen') {
@@ -343,7 +350,10 @@ const activeFlavor = computed<UseKeyFlavor | null>(() => {
   }
   if (selectedClientEntry.value?.guideMode === 'openai-fields') return 'openai'
   if (tab === 'opencode') return null
-  if (tab === 'claude') return 'anthropic'
+  if (tab === 'claude') {
+    if (isOpenAIMessagesDispatchClaudeTab.value) return 'openai'
+    return 'anthropic'
+  }
   if (tab === 'gemini') return 'gemini'
   if (tab === 'codex' || tab === 'codex-ws') return 'openai'
   if (tab === 'curl' || tab === 'python') {
@@ -855,7 +865,7 @@ const currentFiles = computed((): FileConfig[] => {
   switch (platformForFiles()) {
     case 'openai':
       if (activeClientTab.value === 'claude') {
-        return generateAnthropicFiles(baseUrl, apiKey, model)
+        return generateAnthropicFiles(baseUrl, apiKey, model, isOpenAIMessagesDispatchClaudeTab.value)
       }
       if (activeClientTab.value === 'codex-ws') {
         return generateOpenAIWsFiles(baseUrl, apiKey, model)
@@ -867,7 +877,7 @@ const currentFiles = computed((): FileConfig[] => {
       // in their tabs). claude tab only appears when the group enables messages
       // dispatch. grok (xAI) is OpenAI-compatible, so it shares the openai files.
       if (activeClientTab.value === 'claude') {
-        return generateAnthropicFiles(baseUrl, apiKey, model)
+        return generateAnthropicFiles(baseUrl, apiKey, model, isOpenAIMessagesDispatchClaudeTab.value)
       }
       return generateOpenAIFiles(baseUrl, apiKey, model)
     case 'gemini':
@@ -882,10 +892,17 @@ const currentFiles = computed((): FileConfig[] => {
   }
 })
 
-function generateAnthropicFiles(baseUrl: string, apiKey: string, model: string): FileConfig[] {
-  // Picker-injected model, with the 1M-window [1m] alias re-applied for opus.
-  const envModel = anthropicEnvModel(model)
-  // Recommended defaults (TokenKey + Claude Code; see code.claude.com env docs):
+function generateAnthropicFiles(
+  baseUrl: string,
+  apiKey: string,
+  model: string,
+  openaiMessagesDispatch = false,
+): FileConfig[] {
+  const envModel = claudeCodeEnvModel(model, { openaiMessagesDispatch })
+  // Picker-injected model, with the 1M-window [1m] alias re-applied:
+  //   - Anthropic direct: claude-opus-4-8 → claude-opus-4-8[1m]
+  //   - OpenAI messages dispatch: gpt-5.5 → gpt-5.5[1m]
+  // Gateway strips the suffix before upstream forward while CC keeps the 1M client window.
   //   - model claude-opus-4-8[1m] + DISABLE_ADAPTIVE_THINKING + fixed MAX_THINKING_TOKENS: 稳定思考预算
   //     NOTE: the model id MUST be a real, empirically-servable Anthropic id
   //     (see backend supportedAnthropicCatalogModels, regenerated from a live

--- a/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
+++ b/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
@@ -204,7 +204,7 @@ describe('UseKeyModal — preserved snippet correctness', () => {
     const joined = wrapper.findAll('pre code').map((c) => c.text()).join('\n')
     expect(joined).toContain('CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING')
     expect(joined).toContain('31999')
-    expect(joined).toContain('claude-opus-4-8[1m]')
+    expect(joined).toContain('gpt-5.5[1m]')
     const activeBlocks = wrapper.findAll('pre code').map((c) => c.text())
       .filter((s) => /^\s*export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1\s*$/m.test(s))
     expect(activeBlocks).toHaveLength(0)

--- a/frontend/src/composables/__tests__/useTkUseKey.spec.ts
+++ b/frontend/src/composables/__tests__/useTkUseKey.spec.ts
@@ -14,7 +14,7 @@ vi.mock('@/api/pricing', () => ({
   getPublicPricing: (...args: unknown[]) => getPublicPricingMock(...args),
 }))
 
-import { useTkUseKey } from '@/composables/useTkUseKey'
+import { useTkUseKey, anthropicEnvModel, openaiCompatContextWindowEnvModel, claudeCodeEnvModel } from '@/composables/useTkUseKey'
 
 function createUseKey(apiKeyId = ref<number | null>(42)) {
   return useTkUseKey({
@@ -31,6 +31,26 @@ afterEach(() => {
   vi.unstubAllGlobals()
   getMePricingCatalogMock.mockReset()
   getPublicPricingMock.mockReset()
+})
+
+describe('claudeCodeEnvModel helpers', () => {
+  it('applies [1m] for opus-class Anthropic ids', () => {
+    expect(anthropicEnvModel('claude-opus-4-8')).toBe('claude-opus-4-8[1m]')
+    expect(anthropicEnvModel('claude-opus-4-8[1m]')).toBe('claude-opus-4-8[1m]')
+    expect(anthropicEnvModel('claude-sonnet-4-6')).toBe('claude-sonnet-4-6')
+  })
+
+  it('applies [1m] for 1M OpenAI-compat dispatch ids', () => {
+    expect(openaiCompatContextWindowEnvModel('gpt-5.5')).toBe('gpt-5.5[1m]')
+    expect(openaiCompatContextWindowEnvModel('gpt-5.4')).toBe('gpt-5.4[1m]')
+    expect(openaiCompatContextWindowEnvModel('gpt-5.5[1m]')).toBe('gpt-5.5[1m]')
+    expect(openaiCompatContextWindowEnvModel('gpt-5.4-mini')).toBe('gpt-5.4-mini')
+  })
+
+  it('routes messages-dispatch Claude Code picks through the OpenAI helper', () => {
+    expect(claudeCodeEnvModel('gpt-5.5', { openaiMessagesDispatch: true })).toBe('gpt-5.5[1m]')
+    expect(claudeCodeEnvModel('claude-opus-4-8', { openaiMessagesDispatch: false })).toBe('claude-opus-4-8[1m]')
+  })
 })
 
 describe('useTkUseKey model loading', () => {

--- a/frontend/src/composables/useTkUseKey.ts
+++ b/frontend/src/composables/useTkUseKey.ts
@@ -109,6 +109,26 @@ export function anthropicEnvModel(id: string): string {
   return id
 }
 
+/**
+ * Claude Code on OpenAI-compat messages dispatch uses the same trailing [1m]
+ * alias for 1M-window GPT picks (gpt-5.5 → gpt-5.5[1m]). The gateway strips
+ * the suffix before Codex forward (openai_compat_context_window_alias_tk.go).
+ */
+export function openaiCompatContextWindowEnvModel(id: string): string {
+  if (/\[1m\]$/i.test(id)) return id
+  const bare = id.replace(/-(low|medium|high|xhigh)$/i, '')
+  if (/^gpt-5\.(?:4|5)$/i.test(bare)) return `${bare}[1m]`
+  return id
+}
+
+export function claudeCodeEnvModel(
+  id: string,
+  opts: { openaiMessagesDispatch?: boolean } = {},
+): string {
+  if (opts.openaiMessagesDispatch) return openaiCompatContextWindowEnvModel(id)
+  return anthropicEnvModel(id)
+}
+
 interface UseTkUseKeyArgs {
   apiKeyId: Ref<number | null | undefined>
   apiKey: Ref<string>

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -869,9 +869,10 @@
     {
       "path": "frontend/src/components/keys/UseKeyGuide.vue",
       "must_contain": [
-        "claude-opus-4-8[1m]"
+        "claude-opus-4-8[1m]",
+        "gpt-5.5[1m]"
       ],
-      "rationale": "The 'Use API Key' guide recommends ANTHROPIC_MODEL for Claude Code. The base id MUST be an empirically-servable Anthropic model (backend supportedAnthropicCatalogModels, regenerated from a live prod probe — PR #608), NOT a bare alias. The gateway strips the trailing [1m] context-window suffix (gateway_anthropic_context_window_alias_tk.go), so a bare 'opus[1m]' collapses to 'opus' and is rejected as a non-servable model name → 400 invalid_request (PR #617), while the user silently never gets 1M context. Pinning the servable id catches a regression back to the bare alias on upstream merge or careless edit. Advance this needle (and the guide's export/settings strings) together when the servable opus generation moves past claude-opus-4-8. Canonical surface moved from UseKeyModal.vue to UseKeyGuide.vue (quickstart SSOT)."
+      "rationale": "The 'Use API Key' guide recommends ANTHROPIC_MODEL for Claude Code. Anthropic direct groups use claude-opus-4-8[1m]; OpenAI messages-dispatch groups use gpt-5.5[1m]. The gateway strips trailing [1m] on both paths (gateway_anthropic_context_window_alias_tk.go + openai_compat_context_window_alias_tk.go) while CC keeps the 1M client window. Pin both needles so upstream merge cannot silently revert to bare ids and re-expose 200K / 502 regressions."
     },
     {
       "path": "frontend/src/components/keys/UseKeyGuide.vue",
@@ -1108,7 +1109,8 @@
         "export function useTkUseKey(",
         "getMePricingCatalog({ apiKeyId: id })",
         "function runTest(",
-        "export function anthropicEnvModel("
+        "export function anthropicEnvModel(",
+        "export function openaiCompatContextWindowEnvModel("
       ],
       "rationale": "PR #788: brain of the redesigned 'Use API Key' modal. The model picker draws ONLY the key's live servable menu via getMePricingCatalog (no hand-typed/retired/bare ids), runTest fires a canonical-correct gateway request routed per platform/flavor (/v1/messages · /v1/chat/completions · :generateContent), and anthropicEnvModel re-applies the [1m] 1M-window alias for opus. TK-only module with no upstream counterpart — an upstream merge that deletes/replaces it would silently revert the modal to hardcoded model hints and drop the live test, re-opening the ~950/wk wrong-model and ~2808/wk invalid-key error classes this redesign was built (from prod ops_error_logs) to kill. Anchors the servable-menu data source + the per-platform test routing entrypoint + the [1m] helper."
     },

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2726,6 +2726,35 @@
       "rationale": "Pure, fork-only Claude Code context-window model-alias stripper (claude-code #60913 / #50803 / #53031 / #55504 / #34143), kept in a *_tk_*.go companion out of upstream-owned gateway_service.go (rule §5). tkStripContextWindowModelAlias removes a trailing bracketed alias such as '[1m]' that cc serializes verbatim into the API model field on resume/continue/compact — Anthropic answers 404 not_found_error and the client silently falls back to the bare 200K model (paid 1M context lost, no error surfaced). The trailing-anchored regexp keeps a legitimate id (never contains brackets) a byte-for-byte no-op; the context-1m beta header flows through separately so the bare id still activates the 1M window. Anchor the pure function + the regexp guard so an upstream refactor that consolidates model normalization cannot delete this surface and silently re-expose the 404 + 200K downgrade. Exhaustively covered by gateway_anthropic_context_window_alias_tk_test.go."
     },
     {
+      "path": "backend/internal/service/openai_compat_context_window_alias_tk.go",
+      "must_contain": [
+        "func applyOpenAICompatContextWindowModelAlias(model string) (string, bool) {",
+        "return tkStripContextWindowModelAlias(model)"
+      ],
+      "rationale": "OpenAI-compat companion to gateway_anthropic_context_window_alias_tk.go: Claude Code serializes gpt-5.5[1m] on messages-dispatch / Codex paths; without stripping, upstream rejects or caps to ~200K while CC shows a paid 1M window. Pure wrapper around tkStripContextWindowModelAlias so the OpenAI seam stays merge-safe in *_tk_*.go."
+    },
+    {
+      "path": "backend/internal/service/openai_compat_model.go",
+      "must_contain": [
+        "applyOpenAICompatContextWindowModelAlias(trimmed)"
+      ],
+      "rationale": "NormalizeOpenAICompatRequestedModel / applyOpenAICompatModelNormalization must strip Claude Code [1m] aliases before reasoning-suffix normalization and upstream forward on the /v1/messages OpenAI-compat bridge."
+    },
+    {
+      "path": "backend/internal/service/openai_messages_dispatch.go",
+      "must_contain": [
+        "applyOpenAICompatContextWindowModelAlias(model)"
+      ],
+      "rationale": "Messages-dispatch mapped models (gpt-5.5 family defaults and exact overrides) must strip inbound [1m] aliases so scheduling, billing, and Codex forward see bare servable ids."
+    },
+    {
+      "path": "backend/internal/service/openai_codex_transform.go",
+      "must_contain": [
+        "applyOpenAICompatContextWindowModelAlias(model)"
+      ],
+      "rationale": "normalizeCodexModel is the last-mile Codex id normalizer; dropping the [1m] strip re-exposes context-window 502s when CC resumes with gpt-5.5[1m]."
+    },
+    {
       "path": "backend/internal/service/openai_gateway_service_tk_codex_usage_snapshot.go",
       "must_contain": [
         "result.Used5hPercent = s.PrimaryUsedPercent",


### PR DESCRIPTION
## 摘要

- OpenAI messages dispatch / Codex 路径补齐 `[1m]` 后缀 strip（与 Anthropic 直连同构），避免 CC resume 时 `gpt-5.5[1m]` 无法正确路由。
- UseKeyGuide 对 OpenAI 分组 + Claude Code tab 推荐 `gpt-5.5[1m]`，模型选择器改用 openai 风味（`gpt-5.5`）。
- 用户需把 CC 模型从 plain `gpt-5.5` 改为 `gpt-5.5[1m]` 才能拿到 1M 客户端窗口；OAuth Codex 上游实际硬顶仍约 ~270k input。

## 风险

- 常规风险：网关模型归一化 + 前端配置引导，无 schema/鉴权变更。
- OAuth Codex 账号无法提供 catalog 级 1M；本次修复解决 200k 误选与 strip 缺失，不承诺上游真 1M。

## 验证

- `go test -tags=unit ./backend/internal/service/ -run 'ContextWindow|OpenAICompat'`
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`
- `python3 scripts/sentinels/check-frontend-tk.py --quiet`
- 前端 vitest 未跑（本机 `frontend/node_modules` 缺失）

## 提交

- 86f3c0320 fix(openai): strip CC [1m] alias on Codex messages dispatch path

最新提交：86f3c0320

Made with [Cursor](https://cursor.com)