### PR TITLE
fix(kiro): 识别内容过滤终态避免误报 502

### DIFF
--- a/.testing/user-stories/index.md
+++ b/.testing/user-stories/index.md
@@ -40,3 +40,4 @@
 | US-035 | Model surface bundle activation 与 generic deploy 解耦 | InTest | `.testing/user-stories/stories/US-035-model-surface-bundle-activation.md` |
 | US-036 | Capacity-first 数据层安全原型 | InTest | `.testing/user-stories/stories/US-036-capacity-first-data-layer-safety.md` |
 | US-037 | Data-layer 非生产归档恢复演练 | InTest | `.testing/user-stories/stories/US-037-data-layer-archive-rehearsal.md` |
+| US-038 | Kiro CONTENT_FILTERED 返回客户端错误且不触发 failover | InTest | `.testing/user-stories/stories/US-038-kiro-content-filter-client-error.md` |

--- a/.testing/user-stories/stories/US-038-kiro-content-filter-client-error.md
+++ b/.testing/user-stories/stories/US-038-kiro-content-filter-client-error.md
@@ -1,0 +1,60 @@
+# US-038-kiro-content-filter-client-error
+
+- ID: US-038
+- Title: Kiro CONTENT_FILTERED returns a client-owned 400 without failover
+- Priority: P0 (production 502 root-cause correction)
+- As a / I want / So that:
+  作为 **TokenKey API 调用方与运维者**，我希望 **Kiro 的 `metadataEvent.stopReason=CONTENT_FILTERED` 被识别为最终客户端请求错误**，**以便** 调用方收到稳定的 400 契约，同时该结果不再触发跨账号/edge failover、账号惩罚或 provider/platform SLA 告警。
+- Trace:
+  - 根因轴线：Kiro 返回 HTTP 200 EventStream，只有 `metadataEvent(CONTENT_FILTERED)`、context usage 和 metering，没有 `assistantResponseEvent`；旧实现忽略 metadata 并把结果归为普通空响应 502。
+  - 对外契约轴线：`/v1/messages`、`/v1/chat/completions`、`/v1/responses` 分别返回既有协议兼容的 400 错误 envelope。
+  - 可观测轴线：最终归因固定为 `phase=request`、`error_owner=client`、`error_source=client_request`；此前账号尝试留下的 upstream evidence 可以保留，但不得覆盖最终归因。
+- Risk Focus:
+  - 逻辑错误：必须消费结构化 stop reason，且仅在没有 text/thinking/tool output 时转为内容过滤错误。
+  - 行为回归：普通未知空 EventStream 继续走 502 failover；已经产生拒答输出时继续返回成功响应。
+  - 安全问题：prod 只信任配置为 Kiro mirror stub 的固定 outcome header，不解析可变错误文案，也不在 header 中传递 prompt、响应正文或凭证。
+  - 运行时：内容过滤不得调用账号 cooldown、token refresh 或跨账号 retry；前序 failover context 不得把最终结果重新归为 provider/platform。
+
+## Acceptance Criteria
+
+1. **AC-001（根因复现）**：Given 真实帧序列包含 `metadataEvent.stopReason=CONTENT_FILTERED`、`contextUsageEvent`、`meteringEvent` 且无 assistant 输出，When parser 与 Kiro gateway 消费该流，Then 返回 typed content-filter error，不包装为 `UpstreamFailoverError`。
+2. **AC-002（多入口契约）**：Given 同一 typed outcome，When 从 Messages、Chat Completions、Responses 入口返回，Then 分别得到 400 `invalid_request_error`、400 `content_filter_error`、400 `content_filter`。
+3. **AC-003（无账号副作用）**：Given native Kiro 或可信 Kiro mirror 返回内容过滤，When gateway 处理结果，Then 不重试其他账号、不调用 rate-limit/account-health 惩罚逻辑，且 outcome 自身不创建 upstream error context。
+4. **AC-004（最终客户端归因）**：Given 当前请求已有一次 502 failover evidence，随后 Kiro 返回内容过滤，When ops logger 分类最终 400，Then 仍为 `request/client/client_request`，严重度为 P3；此前 evidence 可保留用于诊断。
+5. **AC-005（普通空响应回归）**：Given EventStream 没有输出且没有 `CONTENT_FILTERED`，When Kiro gateway 完成读取，Then 保持现有 502 failover 行为并记录 `empty_response`。
+6. **AC-006（已有输出回归）**：Given Kiro 先产生 assistant text 再携带相同 stop reason，When gateway 完成读取，Then 保留输出并返回成功，不标记客户端内容过滤错误。
+
+## Assertions
+
+- parser 的 `OnStopReason` 收到精确值 `CONTENT_FILTERED`。
+- typed error 与 `UpstreamFailoverError` 互斥，三入口 wire status 与 error type/code 符合 AC-002。
+- native/mirror 内容过滤路径设置结构化 ops marker，且 clean path 不产生 `OpsUpstreamErrorsKey` 或 upstream status/message。
+- 预置 502 upstream context 后，最终 content-filter marker 覆盖 SLA owner/source 分类但不删除既有 evidence。
+- ordinary empty response 仍记录 `response_error/empty_response`；有 assistant text 时不设置 content-filter marker。
+
+## Linked Tests
+
+- `backend/internal/integration/kiro/eventstream_test.go`::`TestParseEventStream_MetadataStopReason`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestKiroGatewayService_Forward_NonStreaming_ContentFilteredIsNotFailover`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestKiroGatewayService_Forward_Streaming_ContentFilteredIsNotFailover`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestKiroGatewayService_Forward_ContentFilteredWithAssistantTextRemainsSuccess`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestKiroGatewayService_Forward_EmptyResponseTriggersFailover`
+- `backend/internal/service/gateway_forward_kiro_content_filter_test.go`::`TestForwardAsChatCompletions_KiroMirrorContentFilteredReturns400WithoutFailover`
+- `backend/internal/service/gateway_forward_kiro_content_filter_test.go`::`TestForwardAsResponses_KiroMirrorContentFilteredReturns400WithoutFailover`
+- `backend/internal/handler/gateway_handler_kiro_content_filter_test.go`::`TestGatewayHandler_HandleKiroContentFilteredError`
+- `backend/internal/handler/ops_error_logger_tk_kiro_content_filter_test.go`::`TestClassifyOpsKiroContentFilterAfterPriorFailoverStillOwnedByClient`
+
+运行命令：
+
+```bash
+cd backend
+go test -tags=unit ./internal/integration/kiro ./internal/service ./internal/handler -count=1
+```
+
+## Evidence
+
+- 聚焦测试与项目 preflight 由 PR review 闭环执行并记录；线上原始帧根因与契约边界见 `docs/approved/kiro-content-filter-outcome.md`。
+
+## Status
+
+- [x] InTest — 实现与自动化回归已完成，等待 PR CI 与人工合并审批。

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1823,6 +1823,7 @@ func (h *GatewayHandler) handleKiroContentFilteredError(c *gin.Context, err erro
 	if !errors.As(err, &contentFilteredErr) {
 		return false
 	}
+	service.MarkOpsClientContentFiltered(c)
 	c.Header(service.KiroOutcomeHeader, service.KiroContentFilteredOutcome)
 	h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", service.KiroContentFilteredClientMessage())
 	return true

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -800,6 +800,10 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					return
 				}
 
+				if h.handleKiroContentFilteredError(c, err) {
+					return
+				}
+
 				// Kiro upstream rejected the model (HTTP 400 INVALID_MODEL_ID):
 				// return 400 immediately with a clear message, no failover (every
 				// Kiro account rejects the same unknown model identically).
@@ -1812,6 +1816,16 @@ func (h *GatewayHandler) errorResponse(c *gin.Context, status int, errType, mess
 			"message": message,
 		},
 	})
+}
+
+func (h *GatewayHandler) handleKiroContentFilteredError(c *gin.Context, err error) bool {
+	var contentFilteredErr *service.KiroContentFilteredError
+	if !errors.As(err, &contentFilteredErr) {
+		return false
+	}
+	c.Header(service.KiroOutcomeHeader, service.KiroContentFilteredOutcome)
+	h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", service.KiroContentFilteredClientMessage())
+	return true
 }
 
 // CountTokens handles token counting endpoint

--- a/backend/internal/handler/gateway_handler_kiro_content_filter_test.go
+++ b/backend/internal/handler/gateway_handler_kiro_content_filter_test.go
@@ -1,0 +1,39 @@
+//go:build unit
+
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestGatewayHandler_HandleKiroContentFilteredError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	h := &GatewayHandler{}
+
+	handled := h.handleKiroContentFilteredError(c, &service.KiroContentFilteredError{})
+	require.True(t, handled)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, service.KiroContentFilteredOutcome, rec.Header().Get(service.KiroOutcomeHeader))
+	require.Equal(t, "error", gjson.GetBytes(rec.Body.Bytes(), "type").String())
+	require.Equal(t, "invalid_request_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+	require.Equal(t, service.KiroContentFilteredClientMessage(), gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+}
+
+func TestGatewayHandler_HandleKiroContentFilteredError_IgnoresOtherErrors(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	h := &GatewayHandler{}
+
+	require.False(t, h.handleKiroContentFilteredError(c, errors.New("other")))
+	require.Empty(t, rec.Body.String())
+}

--- a/backend/internal/handler/gateway_handler_kiro_content_filter_test.go
+++ b/backend/internal/handler/gateway_handler_kiro_content_filter_test.go
@@ -27,6 +27,7 @@ func TestGatewayHandler_HandleKiroContentFilteredError(t *testing.T) {
 	require.Equal(t, "error", gjson.GetBytes(rec.Body.Bytes(), "type").String())
 	require.Equal(t, "invalid_request_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
 	require.Equal(t, service.KiroContentFilteredClientMessage(), gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+	require.True(t, service.HasOpsClientContentFiltered(c))
 }
 
 func TestGatewayHandler_HandleKiroContentFilteredError_IgnoresOtherErrors(t *testing.T) {

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1323,6 +1323,7 @@ func guessPlatformFromPath(path string) string {
 func isKnownOpsErrorType(t string) bool {
 	switch t {
 	case "invalid_request_error",
+		"content_filter_error",
 		"authentication_error",
 		"rate_limit_error",
 		"billing_error",
@@ -1372,7 +1373,7 @@ func classifyOpsPhase(errType, message, code string) string {
 			return "request"
 		}
 		return "upstream"
-	case "invalid_request_error":
+	case "invalid_request_error", "content_filter_error":
 		return "request"
 	case "upstream_error", "overloaded_error":
 		return "upstream"

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1339,6 +1339,11 @@ func isKnownOpsErrorType(t string) bool {
 }
 
 func normalizeOpsErrorType(errType string, code string) string {
+	trimmedType := strings.TrimSpace(errType)
+	if (trimmedType == "" || strings.EqualFold(trimmedType, "api_error")) &&
+		strings.EqualFold(strings.TrimSpace(code), "content_filter") {
+		return "content_filter_error"
+	}
 	if errType != "" && isKnownOpsErrorType(errType) {
 		return errType
 	}
@@ -1389,7 +1394,7 @@ func classifyOpsPhase(errType, message, code string) string {
 
 func classifyOpsSeverity(errType string, status int) string {
 	switch errType {
-	case "invalid_request_error", "authentication_error", "billing_error", "subscription_error":
+	case "invalid_request_error", "content_filter_error", "authentication_error", "billing_error", "subscription_error":
 		return "P3"
 	}
 	if status >= 500 {
@@ -1410,6 +1415,7 @@ func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status i
 	routingCapacityLimited := isOpsRoutingCapacityLimited(c) || (upstreamError && tkUpstreamDownstreamCapacity(c))
 	accountAuthFailure := hasOpsAccountAuthFailure(c)
 	clientPolicyDenied := service.HasOpsClientPolicyDenied(c)
+	clientContentFiltered := service.HasOpsClientContentFiltered(c)
 	clientClosedRequest := service.HasOpsClientClosedRequest(c)
 	clientInducedUpstream := upstreamError && tkUpstreamClientInducedRejection(c, errType)
 	clientCanceledUpstream := upstreamError && tkUpstreamClientCanceled(c)
@@ -1436,6 +1442,12 @@ func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status i
 	}
 	if routingCapacityLimited {
 		phase = "routing"
+	}
+	// The final structured content-filter outcome is authoritative. Earlier
+	// failed account attempts remain available as evidence, but must not turn
+	// the final client-owned rejection into a provider/platform SLA fault.
+	if clientContentFiltered {
+		phase = "request"
 	}
 	msg := strings.ToLower(message)
 	if !upstreamError {

--- a/backend/internal/handler/ops_error_logger_tk_client_validation.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_validation.go
@@ -48,6 +48,7 @@ func tkOpsFinalClientValidationAPIError(errType, message, code string, status in
 func tkOpsClientValidationCode(code string) bool {
 	switch code {
 	case "bad_request",
+		"content_filter",
 		"invalid_request",
 		"invalid_request_error",
 		"invalid_parameter",

--- a/backend/internal/handler/ops_error_logger_tk_kiro_content_filter_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_kiro_content_filter_test.go
@@ -1,0 +1,48 @@
+//go:build unit
+
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyOpsKiroContentFilterOwnedByClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "messages invalid_request_error",
+			body: []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Request was blocked by upstream content filtering"}}`),
+		},
+		{
+			name: "chat completions content_filter_error",
+			body: []byte(`{"error":{"type":"content_filter_error","message":"Request was blocked by upstream content filtering"}}`),
+		},
+		{
+			name: "responses content_filter code",
+			body: []byte(`{"error":{"code":"content_filter","message":"Request was blocked by upstream content filtering"}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			parsed := parseOpsErrorResponse(tt.body)
+			errType := normalizeOpsErrorType(parsed.ErrorType, parsed.Code)
+
+			phase, owner, source := classifyOpsErrorLog(c, errType, parsed.Message, parsed.Code, http.StatusBadRequest)
+
+			require.False(t, hasOpsUpstreamErrorContext(c))
+			require.Equal(t, "request", phase)
+			require.Equal(t, "client", owner)
+			require.Equal(t, "client_request", source)
+		})
+	}
+}

--- a/backend/internal/handler/ops_error_logger_tk_kiro_content_filter_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_kiro_content_filter_test.go
@@ -7,42 +7,86 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 
-func TestClassifyOpsKiroContentFilterOwnedByClient(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	tests := []struct {
-		name string
-		body []byte
-	}{
+type kiroContentFilterOpsCase struct {
+	name       string
+	body       []byte
+	normalized string
+}
+
+func kiroContentFilterOpsCases() []kiroContentFilterOpsCase {
+	return []kiroContentFilterOpsCase{
 		{
-			name: "messages invalid_request_error",
-			body: []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Request was blocked by upstream content filtering"}}`),
+			name:       "messages invalid_request_error",
+			body:       []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Request was blocked by upstream content filtering"}}`),
+			normalized: "invalid_request_error",
 		},
 		{
-			name: "chat completions content_filter_error",
-			body: []byte(`{"error":{"type":"content_filter_error","message":"Request was blocked by upstream content filtering"}}`),
+			name:       "chat completions content_filter_error",
+			body:       []byte(`{"error":{"type":"content_filter_error","message":"Request was blocked by upstream content filtering"}}`),
+			normalized: "content_filter_error",
 		},
 		{
-			name: "responses content_filter code",
-			body: []byte(`{"error":{"code":"content_filter","message":"Request was blocked by upstream content filtering"}}`),
+			name:       "responses content_filter code",
+			body:       []byte(`{"error":{"code":"content_filter","message":"Request was blocked by upstream content filtering"}}`),
+			normalized: "content_filter_error",
 		},
 	}
+}
 
-	for _, tt := range tests {
+func TestClassifyOpsKiroContentFilterOwnedByClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, tt := range kiroContentFilterOpsCases() {
 		t.Run(tt.name, func(t *testing.T) {
 			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			service.MarkOpsClientContentFiltered(c)
 			parsed := parseOpsErrorResponse(tt.body)
 			errType := normalizeOpsErrorType(parsed.ErrorType, parsed.Code)
 
 			phase, owner, source := classifyOpsErrorLog(c, errType, parsed.Message, parsed.Code, http.StatusBadRequest)
 
 			require.False(t, hasOpsUpstreamErrorContext(c))
+			require.Equal(t, tt.normalized, errType)
+			require.Equal(t, "request", phase)
+			require.Equal(t, "client", owner)
+			require.Equal(t, "client_request", source)
+			require.Equal(t, "P3", classifyOpsSeverity(errType, http.StatusBadRequest))
+		})
+	}
+}
+
+func TestClassifyOpsKiroContentFilterAfterPriorFailoverStillOwnedByClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, tt := range kiroContentFilterOpsCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Set(service.OpsUpstreamStatusCodeKey, http.StatusBadGateway)
+			c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{{
+				Platform:           service.PlatformKiro,
+				UpstreamStatusCode: http.StatusBadGateway,
+				Kind:               "failover",
+				Message:            "edge unavailable",
+			}})
+			service.MarkOpsClientContentFiltered(c)
+			parsed := parseOpsErrorResponse(tt.body)
+			errType := normalizeOpsErrorType(parsed.ErrorType, parsed.Code)
+
+			phase, owner, source := classifyOpsErrorLog(c, errType, parsed.Message, parsed.Code, http.StatusBadRequest)
+
+			require.True(t, hasOpsUpstreamErrorContext(c), "prior failover evidence must remain available")
+			require.Equal(t, tt.normalized, errType)
 			require.Equal(t, "request", phase)
 			require.Equal(t, "client", owner)
 			require.Equal(t, "client_request", source)
 		})
 	}
+}
+
+func TestNormalizeOpsContentFilterCodeDoesNotOverrideExplicitErrorType(t *testing.T) {
+	require.Equal(t, "authentication_error", normalizeOpsErrorType("authentication_error", "content_filter"))
 }

--- a/backend/internal/integration/kiro/client.go
+++ b/backend/internal/integration/kiro/client.go
@@ -235,6 +235,7 @@ type InferenceConfig struct {
 type KiroStreamCallback struct {
 	OnText         func(text string, isThinking bool)
 	OnToolUse      func(toolUse KiroToolUse)
+	OnStopReason   func(stopReason string)
 	OnComplete     func(inputTokens, outputTokens int)
 	OnError        func(err error)
 	OnCredits      func(credits float64)
@@ -549,6 +550,10 @@ func parseEventStream(body io.Reader, callback *KiroStreamCallback) error {
 			}
 		case "toolUseEvent":
 			currentToolUse = handleToolUseEvent(event, currentToolUse, callback)
+		case "metadataEvent":
+			if stopReason, ok := event["stopReason"].(string); ok && stopReason != "" && callback.OnStopReason != nil {
+				callback.OnStopReason(stopReason)
+			}
 		case "meteringEvent":
 			if usage, ok := event["usage"].(float64); ok {
 				totalCredits += usage

--- a/backend/internal/integration/kiro/eventstream_test.go
+++ b/backend/internal/integration/kiro/eventstream_test.go
@@ -75,3 +75,21 @@ func TestParseEventStream_AssistantResponse(t *testing.T) {
 		t.Fatalf("expected non-thinking text for assistantResponseEvent, got isThinking=true")
 	}
 }
+
+func TestParseEventStream_MetadataStopReason(t *testing.T) {
+	frame := buildEventStreamMessage("metadataEvent", []byte(`{"stopReason":"CONTENT_FILTERED"}`))
+
+	var got string
+	cb := &KiroStreamCallback{
+		OnStopReason: func(stopReason string) {
+			got = stopReason
+		},
+	}
+
+	if err := parseEventStream(bytes.NewReader(frame), cb); err != nil {
+		t.Fatalf("parseEventStream returned error: %v", err)
+	}
+	if got != "CONTENT_FILTERED" {
+		t.Fatalf("expected stop reason %q, got %q", "CONTENT_FILTERED", got)
+	}
+}

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -190,6 +190,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 	if resp.StatusCode >= 400 {
 		if IsKiroContentFilteredRelayResponse(account, resp.Header) {
 			_ = resp.Body.Close()
+			MarkOpsClientContentFiltered(c)
 			writeGatewayCCError(c, http.StatusBadRequest, "content_filter_error", KiroContentFilteredClientMessage())
 			return nil, &KiroContentFilteredError{}
 		}

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -188,6 +188,11 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 	// 12. Handle error response with failover
 	if resp.StatusCode >= 400 {
+		if IsKiroContentFilteredRelayResponse(account, resp.Header) {
+			_ = resp.Body.Close()
+			writeGatewayCCError(c, http.StatusBadRequest, "content_filter_error", KiroContentFilteredClientMessage())
+			return nil, &KiroContentFilteredError{}
+		}
 		respBody, _ := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))

--- a/backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go
@@ -68,6 +68,12 @@ func (s *GatewayService) forwardAsChatCompletionsViaKiro(
 	fwdResult, err := s.kiroGateway.Forward(ctx, c, account, kiroParsed, startTime)
 	c.Writer = origWriter
 	if err != nil {
+		var contentFilteredErr *KiroContentFilteredError
+		if errors.As(err, &contentFilteredErr) {
+			c.Header(KiroOutcomeHeader, KiroContentFilteredOutcome)
+			writeGatewayCCError(c, http.StatusBadRequest, "content_filter_error", KiroContentFilteredClientMessage())
+			return nil, contentFilteredErr
+		}
 		if s.rateLimitService != nil {
 			var failoverErr *UpstreamFailoverError
 			if errors.As(err, &failoverErr) {

--- a/backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go
@@ -70,6 +70,7 @@ func (s *GatewayService) forwardAsChatCompletionsViaKiro(
 	if err != nil {
 		var contentFilteredErr *KiroContentFilteredError
 		if errors.As(err, &contentFilteredErr) {
+			MarkOpsClientContentFiltered(c)
 			c.Header(KiroOutcomeHeader, KiroContentFilteredOutcome)
 			writeGatewayCCError(c, http.StatusBadRequest, "content_filter_error", KiroContentFilteredClientMessage())
 			return nil, contentFilteredErr

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -164,6 +164,7 @@ func (s *GatewayService) ForwardAsResponses(
 	if resp.StatusCode >= 400 {
 		if IsKiroContentFilteredRelayResponse(account, resp.Header) {
 			_ = resp.Body.Close()
+			MarkOpsClientContentFiltered(c)
 			writeResponsesError(c, http.StatusBadRequest, "content_filter", KiroContentFilteredClientMessage())
 			return nil, &KiroContentFilteredError{}
 		}

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -162,6 +162,11 @@ func (s *GatewayService) ForwardAsResponses(
 
 	// 12. Handle error response with failover
 	if resp.StatusCode >= 400 {
+		if IsKiroContentFilteredRelayResponse(account, resp.Header) {
+			_ = resp.Body.Close()
+			writeResponsesError(c, http.StatusBadRequest, "content_filter", KiroContentFilteredClientMessage())
+			return nil, &KiroContentFilteredError{}
+		}
 		respBody, _ := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))

--- a/backend/internal/service/gateway_forward_kiro_content_filter_test.go
+++ b/backend/internal/service/gateway_forward_kiro_content_filter_test.go
@@ -41,6 +41,7 @@ func TestForwardAsChatCompletions_KiroContentFilteredReturns400(t *testing.T) {
 	require.Equal(t, "content_filter_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
 	require.Equal(t, KiroContentFilteredClientMessage(), gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
 	require.Equal(t, KiroContentFilteredOutcome, rec.Header().Get(KiroOutcomeHeader))
+	require.True(t, HasOpsClientContentFiltered(c))
 }
 
 func newKiroMirrorStubForContentFilterTest() *Account {
@@ -88,6 +89,7 @@ func TestForwardAsChatCompletions_KiroMirrorContentFilteredReturns400WithoutFail
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Equal(t, "content_filter_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
 	require.Equal(t, KiroContentFilteredClientMessage(), gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+	require.True(t, HasOpsClientContentFiltered(c))
 }
 
 func TestForwardAsResponses_KiroMirrorContentFilteredReturns400WithoutFailover(t *testing.T) {
@@ -109,4 +111,5 @@ func TestForwardAsResponses_KiroMirrorContentFilteredReturns400WithoutFailover(t
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Equal(t, "content_filter", gjson.GetBytes(rec.Body.Bytes(), "error.code").String())
 	require.Equal(t, KiroContentFilteredClientMessage(), gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+	require.True(t, HasOpsClientContentFiltered(c))
 }

--- a/backend/internal/service/gateway_forward_kiro_content_filter_test.go
+++ b/backend/internal/service/gateway_forward_kiro_content_filter_test.go
@@ -1,0 +1,112 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestForwardAsChatCompletions_KiroContentFilteredReturns400(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hi"}],"max_tokens":32,"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+
+	upstream := &kiroFakeUpstream{body: kiroContentFilteredEventStream()}
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+		kiroGateway:  NewKiroGatewayService(upstream, nil, nil),
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, newKiroAccountForTest(), body, nil)
+	require.Nil(t, result)
+	var contentFilteredErr *KiroContentFilteredError
+	require.ErrorAs(t, err, &contentFilteredErr)
+	var failoverErr *UpstreamFailoverError
+	require.NotErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "content_filter_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+	require.Equal(t, KiroContentFilteredClientMessage(), gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+	require.Equal(t, KiroContentFilteredOutcome, rec.Header().Get(KiroOutcomeHeader))
+}
+
+func newKiroMirrorStubForContentFilterTest() *Account {
+	return &Account{
+		ID:          66,
+		Name:        "kiro-us6",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":         "relay-key",
+			"base_url":        "https://api-us6.tokenkey.dev",
+			"mirror_platform": PlatformKiro,
+		},
+	}
+}
+
+func newKiroContentFilteredRelayResponse() *http.Response {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	header.Set(KiroOutcomeHeader, KiroContentFilteredOutcome)
+	return &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     header,
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"edge wording must not be parsed"}}`))),
+	}
+}
+
+func TestForwardAsChatCompletions_KiroMirrorContentFilteredReturns400WithoutFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hi"}],"max_tokens":32,"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	upstream := &httpUpstreamRecorder{resp: newKiroContentFilteredRelayResponse()}
+	svc := &GatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, newKiroMirrorStubForContentFilterTest(), body, nil)
+	require.Nil(t, result)
+	var contentFilteredErr *KiroContentFilteredError
+	require.True(t, errors.As(err, &contentFilteredErr))
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.Len(t, upstream.requests, 1)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "content_filter_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+	require.Equal(t, KiroContentFilteredClientMessage(), gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+}
+
+func TestForwardAsResponses_KiroMirrorContentFilteredReturns400WithoutFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"claude-sonnet-4-5","input":"hi","stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	upstream := &httpUpstreamRecorder{resp: newKiroContentFilteredRelayResponse()}
+	svc := &GatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+
+	result, err := svc.ForwardAsResponses(context.Background(), c, newKiroMirrorStubForContentFilterTest(), body, nil)
+	require.Nil(t, result)
+	var contentFilteredErr *KiroContentFilteredError
+	require.True(t, errors.As(err, &contentFilteredErr))
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.Len(t, upstream.requests, 1)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "content_filter", gjson.GetBytes(rec.Body.Bytes(), "error.code").String())
+	require.Equal(t, KiroContentFilteredClientMessage(), gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+}

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -140,6 +141,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		thinkingBuf string
 		toolUses    []kiroproto.KiroToolUse
 		callbackErr error
+		stopReason  string
 		redactor    kiroproto.InlineThinkingRedactor
 	)
 
@@ -158,6 +160,9 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		OnToolUse: func(tu kiroproto.KiroToolUse) {
 			toolUses = append(toolUses, tu)
 		},
+		OnStopReason: func(reason string) {
+			stopReason = reason
+		},
 		// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
 		// We estimate token usage locally below instead of trusting these values.
 		OnCredits: func(credits float64) {
@@ -171,6 +176,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 			thinkingBuf = ""
 			toolUses = nil
 			callbackErr = nil
+			stopReason = ""
 			redactor = kiroproto.InlineThinkingRedactor{}
 			return true
 		},
@@ -187,6 +193,9 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		thinkingBuf += inlineThinking
 	}
 	if textBuf == "" && thinkingBuf == "" && len(toolUses) == 0 {
+		if strings.EqualFold(stopReason, "CONTENT_FILTERED") {
+			return nil, classifyAndRecordKiroForwardError(c, account, &KiroContentFilteredError{}, model)
+		}
 		return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
 	}
 
@@ -264,6 +273,7 @@ func (s *KiroGatewayService) forwardStreaming(
 		thinkingBuf string
 		toolUses    []kiroproto.KiroToolUse
 		callbackErr error
+		stopReason  string
 		firstTokMs  *int
 		redactor    kiroproto.InlineThinkingRedactor
 	)
@@ -306,6 +316,11 @@ func (s *KiroGatewayService) forwardStreaming(
 			toolUses = append(toolUses, tu)
 			enc.writeToolUse(tu)
 		},
+		OnStopReason: func(reason string) {
+			mu.Lock()
+			defer mu.Unlock()
+			stopReason = reason
+		},
 		// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
 		// We estimate token usage locally below instead of trusting these values.
 		OnCredits: func(credits float64) {
@@ -326,6 +341,7 @@ func (s *KiroGatewayService) forwardStreaming(
 			thinkingBuf = ""
 			toolUses = nil
 			callbackErr = nil
+			stopReason = ""
 			firstTokMs = nil
 			redactor = kiroproto.InlineThinkingRedactor{}
 			return true
@@ -363,13 +379,6 @@ func (s *KiroGatewayService) forwardStreaming(
 		writeKiroStreamError(c, flusher, "stream_read_error", msg)
 		return nil, fmt.Errorf("kiro stream callback error: %w", callbackErr)
 	}
-	if !enc.started && textBuf == "" && thinkingBuf == "" && len(toolUses) == 0 {
-		return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
-	}
-
-	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
-	// inputTokens was already computed for the encoder (message_start.usage); reuse
-	// it for the ForwardResult so the two never drift.
 	if visible, inlineThinking := redactor.Flush(); visible != "" || inlineThinking != "" {
 		if inlineThinking != "" {
 			thinkingBuf += inlineThinking
@@ -379,6 +388,16 @@ func (s *KiroGatewayService) forwardStreaming(
 			enc.writeTextDelta(visible)
 		}
 	}
+	if !enc.started && textBuf == "" && thinkingBuf == "" && len(toolUses) == 0 {
+		if strings.EqualFold(stopReason, "CONTENT_FILTERED") {
+			return nil, classifyAndRecordKiroForwardError(c, account, &KiroContentFilteredError{}, model)
+		}
+		return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
+	}
+
+	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
+	// inputTokens was already computed for the encoder (message_start.usage); reuse
+	// it for the ForwardResult so the two never drift.
 	inputTokens := enc.inputTokens
 	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, toolUses)
 

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -275,14 +275,12 @@ func requireKiroContentFilteredError(t *testing.T, c *gin.Context, rec *httptest
 	require.NotErrorAs(t, err, &failoverErr)
 	require.Empty(t, rec.Body.String())
 
-	rawEvents, ok := c.Get(OpsUpstreamErrorsKey)
-	require.True(t, ok)
-	events, ok := rawEvents.([]*OpsUpstreamErrorEvent)
-	require.True(t, ok)
-	require.Len(t, events, 1)
-	require.Equal(t, http.StatusOK, events[0].UpstreamStatusCode)
-	require.Equal(t, "policy_error", events[0].Kind)
-	require.Equal(t, KiroContentFilteredOutcome, events[0].Reason)
+	_, recorded := c.Get(OpsUpstreamErrorsKey)
+	require.False(t, recorded, "client-owned content filtering must not create an upstream error event")
+	_, recorded = c.Get(OpsUpstreamStatusCodeKey)
+	require.False(t, recorded, "client-owned content filtering must not set upstream status context")
+	_, recorded = c.Get(OpsUpstreamErrorMessageKey)
+	require.False(t, recorded, "client-owned content filtering must not set upstream error context")
 }
 
 func TestKiroGatewayService_Forward_NonStreaming_ContentFilteredIsNotFailover(t *testing.T) {

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -281,6 +281,7 @@ func requireKiroContentFilteredError(t *testing.T, c *gin.Context, rec *httptest
 	require.False(t, recorded, "client-owned content filtering must not set upstream status context")
 	_, recorded = c.Get(OpsUpstreamErrorMessageKey)
 	require.False(t, recorded, "client-owned content filtering must not set upstream error context")
+	require.True(t, HasOpsClientContentFiltered(c))
 }
 
 func TestKiroGatewayService_Forward_NonStreaming_ContentFilteredIsNotFailover(t *testing.T) {
@@ -318,6 +319,7 @@ func TestKiroGatewayService_Forward_ContentFilteredWithAssistantTextRemainsSucce
 	require.Contains(t, rec.Body.String(), "I cannot help with that request.")
 	_, recorded := c.Get(OpsUpstreamErrorsKey)
 	require.False(t, recorded)
+	require.False(t, HasOpsClientContentFiltered(c))
 }
 
 func TestKiroGatewayService_Forward_NonStreaming_ReadFailureRetriesWithoutPartialOutput(t *testing.T) {

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -248,6 +248,80 @@ func TestKiroGatewayService_Forward_EmptyResponseTriggersFailover(t *testing.T) 
 	require.Equal(t, int64(99), events[0].AccountID)
 }
 
+func kiroContentFilteredEventStream() []byte {
+	var stream []byte
+	stream = append(stream, buildKiroEventStreamMessage("metadataEvent", []byte(`{"stopReason":"CONTENT_FILTERED"}`))...)
+	stream = append(stream, buildKiroEventStreamMessage("contextUsageEvent", []byte(`{"contextUsagePercentage":0.01}`))...)
+	stream = append(stream, buildKiroEventStreamMessage("meteringEvent", []byte(`{"usage":1}`))...)
+	return stream
+}
+
+func newKiroParsedRequestForTest(stream bool) *ParsedRequest {
+	body, _ := json.Marshal(map[string]any{
+		"model":      "claude-sonnet-4-5",
+		"messages":   []map[string]any{{"role": "user", "content": "hi"}},
+		"max_tokens": 16,
+		"stream":     stream,
+	})
+	return &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-sonnet-4-5", Stream: stream}
+}
+
+func requireKiroContentFilteredError(t *testing.T, c *gin.Context, rec *httptest.ResponseRecorder, result *ForwardResult, err error) {
+	t.Helper()
+	require.Nil(t, result)
+	var contentFilteredErr *KiroContentFilteredError
+	require.ErrorAs(t, err, &contentFilteredErr)
+	var failoverErr *UpstreamFailoverError
+	require.NotErrorAs(t, err, &failoverErr)
+	require.Empty(t, rec.Body.String())
+
+	rawEvents, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	events, ok := rawEvents.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.Len(t, events, 1)
+	require.Equal(t, http.StatusOK, events[0].UpstreamStatusCode)
+	require.Equal(t, "policy_error", events[0].Kind)
+	require.Equal(t, KiroContentFilteredOutcome, events[0].Reason)
+}
+
+func TestKiroGatewayService_Forward_NonStreaming_ContentFilteredIsNotFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	svc := NewKiroGatewayService(&kiroFakeUpstream{body: kiroContentFilteredEventStream()}, nil, nil)
+
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), newKiroParsedRequestForTest(false), time.Now())
+	requireKiroContentFilteredError(t, c, rec, result, err)
+}
+
+func TestKiroGatewayService_Forward_Streaming_ContentFilteredIsNotFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	svc := NewKiroGatewayService(&kiroFakeUpstream{body: kiroContentFilteredEventStream()}, nil, nil)
+
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), newKiroParsedRequestForTest(true), time.Now())
+	requireKiroContentFilteredError(t, c, rec, result, err)
+}
+
+func TestKiroGatewayService_Forward_ContentFilteredWithAssistantTextRemainsSuccess(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	stream := buildKiroEventStreamMessage("assistantResponseEvent", []byte(`{"content":"I cannot help with that request."}`))
+	stream = append(stream, kiroContentFilteredEventStream()...)
+	svc := NewKiroGatewayService(&kiroFakeUpstream{body: stream}, nil, nil)
+
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), newKiroParsedRequestForTest(false), time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "I cannot help with that request.")
+	_, recorded := c.Get(OpsUpstreamErrorsKey)
+	require.False(t, recorded)
+}
+
 func TestKiroGatewayService_Forward_NonStreaming_ReadFailureRetriesWithoutPartialOutput(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -142,6 +142,10 @@ type kiroForwardErrorObservation struct {
 
 func classifyAndRecordKiroForwardError(c *gin.Context, account *Account, err error, model string) error {
 	observation, classified := classifyKiroForwardError(err, model)
+	var contentFilteredErr *KiroContentFilteredError
+	if errors.As(classified, &contentFilteredErr) {
+		MarkOpsClientContentFiltered(c)
+	}
 	if observation != nil {
 		recordKiroForwardError(c, account, err, *observation)
 	}

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -30,7 +30,7 @@ const (
 type KiroContentFilteredError struct{}
 
 func (*KiroContentFilteredError) Error() string {
-	return "kiro upstream content filtered the request"
+	return "kiro content filter rejected the request"
 }
 
 func KiroContentFilteredClientMessage() string {
@@ -136,9 +136,8 @@ func isKiroEndpointQuotaExhaustedError(msg string) bool {
 }
 
 type kiroForwardErrorObservation struct {
-	UpstreamStatusCode int
-	Kind               string
-	Reason             string
+	Kind   string
+	Reason string
 }
 
 func classifyAndRecordKiroForwardError(c *gin.Context, account *Account, err error, model string) error {
@@ -155,11 +154,7 @@ func classifyKiroForwardError(err error, model string) (*kiroForwardErrorObserva
 	}
 	var contentFilteredErr *KiroContentFilteredError
 	if errors.As(err, &contentFilteredErr) {
-		return &kiroForwardErrorObservation{
-			UpstreamStatusCode: http.StatusOK,
-			Kind:               "policy_error",
-			Reason:             KiroContentFilteredOutcome,
-		}, contentFilteredErr
+		return nil, contentFilteredErr
 	}
 	msg := err.Error()
 	if isKiroEndpointQuotaExhaustedError(msg) {
@@ -271,10 +266,10 @@ func recordKiroForwardError(c *gin.Context, account *Account, err error, observa
 		return
 	}
 	safeErr := truncateString(sanitizeUpstreamErrorMessage(err.Error()), 2048)
-	setOpsUpstreamError(c, observation.UpstreamStatusCode, safeErr, "")
+	setOpsUpstreamError(c, 0, safeErr, "")
 	event := OpsUpstreamErrorEvent{
 		Platform:           PlatformKiro,
-		UpstreamStatusCode: observation.UpstreamStatusCode,
+		UpstreamStatusCode: 0,
 		Kind:               observation.Kind,
 		Reason:             observation.Reason,
 		Message:            safeErr,

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -18,6 +18,32 @@ var kiroTransportFailoverBody = []byte(`{"error":{"type":"upstream_error","messa
 
 var errKiroEmptyResponse = errors.New("kiro upstream returned an empty response")
 
+const (
+	KiroOutcomeHeader             = "X-TokenKey-Kiro-Outcome"
+	KiroContentFilteredOutcome    = "content_filtered"
+	kiroContentFilteredClientText = "Request was blocked by upstream content filtering"
+)
+
+// KiroContentFilteredError represents Kiro's successful HTTP transport with a
+// policy terminal outcome and no assistant output. Retrying another account
+// cannot change the request-level policy decision.
+type KiroContentFilteredError struct{}
+
+func (*KiroContentFilteredError) Error() string {
+	return "kiro upstream content filtered the request"
+}
+
+func KiroContentFilteredClientMessage() string {
+	return kiroContentFilteredClientText
+}
+
+// IsKiroContentFilteredRelayResponse accepts the internal relay outcome only
+// from an account configured as a Kiro mirror stub.
+func IsKiroContentFilteredRelayResponse(account *Account, header http.Header) bool {
+	return account != nil && account.IsKiroMirrorStub() &&
+		strings.EqualFold(strings.TrimSpace(header.Get(KiroOutcomeHeader)), KiroContentFilteredOutcome)
+}
+
 // KiroInvalidModelError is a typed, status-carrying error raised when the Kiro
 // (sixth platform) upstream rejects a request with HTTP 400 INVALID_MODEL_ID —
 // i.e. the requested model is not one the Kiro/CodeWhisperer backend serves.
@@ -110,8 +136,9 @@ func isKiroEndpointQuotaExhaustedError(msg string) bool {
 }
 
 type kiroForwardErrorObservation struct {
-	Kind   string
-	Reason string
+	UpstreamStatusCode int
+	Kind               string
+	Reason             string
 }
 
 func classifyAndRecordKiroForwardError(c *gin.Context, account *Account, err error, model string) error {
@@ -125,6 +152,14 @@ func classifyAndRecordKiroForwardError(c *gin.Context, account *Account, err err
 func classifyKiroForwardError(err error, model string) (*kiroForwardErrorObservation, error) {
 	if err == nil {
 		return nil, nil
+	}
+	var contentFilteredErr *KiroContentFilteredError
+	if errors.As(err, &contentFilteredErr) {
+		return &kiroForwardErrorObservation{
+			UpstreamStatusCode: http.StatusOK,
+			Kind:               "policy_error",
+			Reason:             KiroContentFilteredOutcome,
+		}, contentFilteredErr
 	}
 	msg := err.Error()
 	if isKiroEndpointQuotaExhaustedError(msg) {
@@ -236,10 +271,10 @@ func recordKiroForwardError(c *gin.Context, account *Account, err error, observa
 		return
 	}
 	safeErr := truncateString(sanitizeUpstreamErrorMessage(err.Error()), 2048)
-	setOpsUpstreamError(c, 0, safeErr, "")
+	setOpsUpstreamError(c, observation.UpstreamStatusCode, safeErr, "")
 	event := OpsUpstreamErrorEvent{
 		Platform:           PlatformKiro,
-		UpstreamStatusCode: 0,
+		UpstreamStatusCode: observation.UpstreamStatusCode,
 		Kind:               observation.Kind,
 		Reason:             observation.Reason,
 		Message:            safeErr,

--- a/backend/internal/service/ops_upstream_context.go
+++ b/backend/internal/service/ops_upstream_context.go
@@ -83,6 +83,10 @@ const (
 	OpsClientPolicyDeniedReasonLocalFeatureGate       = "local_feature_gate"
 	OpsClientPolicyDeniedReasonLocalPolicyDenied      = "local_policy_denied"
 
+	// OpsClientContentFilteredKey marks a final content-filter outcome as
+	// client-owned even when an earlier account attempt left upstream evidence.
+	OpsClientContentFilteredKey = "ops_client_content_filtered"
+
 	// OpsClientClosedRequestKey marks local failures caused by the caller closing
 	// the inbound request context before gateway auth/body handling completed.
 	OpsClientClosedRequestKey = "ops_client_closed_request"
@@ -150,6 +154,25 @@ func HasOpsClientPolicyDenied(c *gin.Context) bool {
 		return false
 	}
 	v, ok := c.Get(OpsClientPolicyDeniedKey)
+	if !ok {
+		return false
+	}
+	marked, _ := v.(bool)
+	return marked
+}
+
+func MarkOpsClientContentFiltered(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	c.Set(OpsClientContentFilteredKey, true)
+}
+
+func HasOpsClientContentFiltered(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	v, ok := c.Get(OpsClientContentFilteredKey)
 	if !ok {
 		return false
 	}

--- a/docs/approved/kiro-content-filter-outcome.md
+++ b/docs/approved/kiro-content-filter-outcome.md
@@ -5,7 +5,7 @@ approved_by: "user (implementation directive after root-cause review, 2026-07-21
 approved_at: 2026-07-21
 authors: [agent]
 created: 2026-07-21
-related_prs: [1398]
+related_prs: [1398, 1407]
 related_commits: []
 ---
 
@@ -55,9 +55,10 @@ must not infer this outcome from mutable error text.
   shape changes.
 - The change intentionally alters public error status and body only for the
   previously misclassified Kiro content-filter terminal outcome.
-- Ops records the final 400 as `phase=request`, `error_owner=client`, and
-  `error_source=client_request`. It does not populate upstream error events or
-  upstream status context for this client-owned outcome.
+- Ops records the final 400 as P3 with `phase=request`, `error_owner=client`,
+  and `error_source=client_request`, even if an earlier account attempt left
+  upstream failover evidence. The content-filter outcome itself does not
+  populate upstream error events or upstream status context.
 
 ## Verification
 
@@ -70,4 +71,6 @@ must not infer this outcome from mutable error text.
   without retrying or penalizing the account.
 - Messages, Chat Completions, and Responses error envelopes all classify as a
   client request error rather than a provider/platform fault.
+- A prior failed account attempt does not override the final client ownership;
+  its upstream evidence remains available for diagnosis.
 - Ordinary empty EventStreams retain the existing 502 failover behavior.

--- a/docs/approved/kiro-content-filter-outcome.md
+++ b/docs/approved/kiro-content-filter-outcome.md
@@ -23,7 +23,8 @@ not consume Kiro's authoritative terminal outcome.
 ## Approved Behavior
 
 When Kiro reports `CONTENT_FILTERED` and no assistant text, reasoning, or tool
-output was produced, the request is a non-retryable upstream policy rejection:
+output was produced, the request is a non-retryable, client-owned content-filter
+rejection:
 
 | Client API | HTTP status | Error type/code |
 | --- | --- | --- |
@@ -54,8 +55,9 @@ must not infer this outcome from mutable error text.
   shape changes.
 - The change intentionally alters public error status and body only for the
   previously misclassified Kiro content-filter terminal outcome.
-- Ops evidence records `policy_error/content_filtered` with upstream status
-  200, matching the actual Kiro transport response.
+- Ops records the final 400 as `phase=request`, `error_owner=client`, and
+  `error_source=client_request`. It does not populate upstream error events or
+  upstream status context for this client-owned outcome.
 
 ## Verification
 
@@ -66,4 +68,6 @@ must not infer this outcome from mutable error text.
 - Native Chat Completions maps the typed error to 400.
 - Kiro mirror Chat Completions and Responses map the trusted header to 400
   without retrying or penalizing the account.
+- Messages, Chat Completions, and Responses error envelopes all classify as a
+  client request error rather than a provider/platform fault.
 - Ordinary empty EventStreams retain the existing 502 failover behavior.

--- a/docs/approved/kiro-content-filter-outcome.md
+++ b/docs/approved/kiro-content-filter-outcome.md
@@ -1,0 +1,69 @@
+---
+title: Kiro Content Filter Outcome Contract
+status: approved
+approved_by: "user (implementation directive after root-cause review, 2026-07-21)"
+approved_at: 2026-07-21
+authors: [agent]
+created: 2026-07-21
+related_prs: [1398]
+related_commits: []
+---
+
+# Kiro Content Filter Outcome Contract
+
+## Root Cause
+
+Kiro can return HTTP 200 AWS EventStream with
+`metadataEvent.stopReason=CONTENT_FILTERED`, followed by usage events, but no
+`assistantResponseEvent`. The gateway ignored `metadataEvent`, classified the
+result as an opaque empty response, returned 502, and triggered account/edge
+failover. PR #1398 only adds a fallback for a metered empty response; it does
+not consume Kiro's authoritative terminal outcome.
+
+## Approved Behavior
+
+When Kiro reports `CONTENT_FILTERED` and no assistant text, reasoning, or tool
+output was produced, the request is a non-retryable upstream policy rejection:
+
+| Client API | HTTP status | Error type/code |
+| --- | --- | --- |
+| `/v1/messages` | 400 | `invalid_request_error` |
+| `/v1/chat/completions` | 400 | `content_filter_error` |
+| `/v1/responses` | 400 | `content_filter` |
+
+All three surfaces use the client message `Request was blocked by upstream
+content filtering`. The outcome must not trigger account failover, account
+cooldown, token refresh, or other account-health penalties.
+
+If Kiro emits assistant text, reasoning, or tool output before the same stop
+reason, the gateway preserves that output as a normal successful response. An
+ordinary empty response without `CONTENT_FILTERED` retains the existing 502
+failover behavior.
+
+## Mirror Contract
+
+The edge `/v1/messages` response carries the internal header
+`X-TokenKey-Kiro-Outcome: content_filtered`. Prod trusts this header only for a
+configured Kiro mirror stub, then maps it to the client-facing Chat Completions
+or Responses error shape before failover and rate-limit handling. Relay logic
+must not infer this outcome from mutable error text.
+
+## Risk Boundaries
+
+- No route, request schema, authentication, billing, quota, or persistent data
+  shape changes.
+- The change intentionally alters public error status and body only for the
+  previously misclassified Kiro content-filter terminal outcome.
+- Ops evidence records `policy_error/content_filtered` with upstream status
+  200, matching the actual Kiro transport response.
+
+## Verification
+
+- Protocol parser callback receives `metadataEvent.stopReason`.
+- Native non-streaming and streaming Kiro paths return the typed policy error
+  without response bytes or failover wrapping.
+- A filtered outcome with assistant output remains successful.
+- Native Chat Completions maps the typed error to 400.
+- Kiro mirror Chat Completions and Responses map the trusted header to 400
+  without retrying or penalizing the account.
+- Ordinary empty EventStreams retain the existing 502 failover behavior.

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -395,7 +395,7 @@
         "quota exhausted on",
         "INVALID_MODEL_ID"
       ],
-      "rationale": "TK-only typed errors + classifier for Kiro request rejections, including CONTENT_FILTERED, INVALID_MODEL_ID and CONTENT_LENGTH_EXCEEDS_THRESHOLD. classifyAndRecordKiroForwardError is called from both forwardStreaming and forwardNonStreaming; it records CONTENT_FILTERED as policy_error/content_filtered with the real upstream HTTP 200 and preserves sanitized transport/read/empty-response causes while clients receive stable protocol envelopes. The handler maps request-owned outcomes to 400 without cross-account failover. Losing this file makes Kiro policy/validation outcomes fall back to generic forwarding errors or restores opaque 502s with no recoverable root cause."
+      "rationale": "TK-only typed errors + classifier for Kiro request rejections, including CONTENT_FILTERED, INVALID_MODEL_ID and CONTENT_LENGTH_EXCEEDS_THRESHOLD. classifyAndRecordKiroForwardError is called from both forwardStreaming and forwardNonStreaming; CONTENT_FILTERED returns a typed client-owned error without creating upstream error context, while real transport/read/empty-response causes retain sanitized upstream evidence. The handler maps request-owned outcomes to 400 without cross-account failover. Losing this file makes Kiro policy/validation outcomes fall back to generic forwarding errors or restores opaque 502s with no recoverable root cause."
     },
     {
       "path": "backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go",
@@ -430,6 +430,29 @@
         "TestForwardAsResponses_KiroMirrorContentFilteredReturns400WithoutFailover"
       ],
       "rationale": "Wire-contract evidence for native and mirrored Kiro content filtering across Chat Completions and Responses, including no UpstreamFailoverError and a single mirror attempt."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger.go",
+      "must_contain": [
+        "\"content_filter_error\""
+      ],
+      "rationale": "Chat Completions content_filter_error must remain a recognized request-phase type so Kiro filtering is owned by the client, never provider/platform."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger_tk_client_validation.go",
+      "must_contain": [
+        "\"content_filter\""
+      ],
+      "rationale": "Responses uses error.code=content_filter without an error.type; this code anchor keeps the flattened api_error classified as request/client."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger_tk_kiro_content_filter_test.go",
+      "must_contain": [
+        "TestClassifyOpsKiroContentFilterOwnedByClient",
+        "require.Equal(t, \"client\", owner)",
+        "require.False(t, hasOpsUpstreamErrorContext(c))"
+      ],
+      "rationale": "End-to-end ops attribution evidence for the Messages, Chat Completions, and Responses content-filter envelopes: request/client ownership with no upstream error context."
     },
     {
       "path": "backend/internal/service/wire.go",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -127,6 +127,8 @@
         "func CallKiroAPIWithDoerContext",
         "func callKiroAPIOnce",
         "ResetForRetry func() bool",
+        "OnStopReason",
+        "case \"metadataEvent\":",
         "stale profileArn",
         "func parseEventStream",
         "extractEventStreamHeaderValue",
@@ -136,7 +138,15 @@
         "runtime.us-east-1.kiro.dev",
         "q.us-east-1.amazonaws.com"
       ],
-      "rationale": "Streaming call entry + hand-rolled AWS EventStream binary decoder + the HTTPDoer injection seam that lets the TK gateway supply a TLS/proxy-aware doer. CallKiroAPIWithDoerContext binds upstream attempts to the customer request lifetime, while ResetForRetry permits response-read failover only when the consumer can discard all partial state. Losing parseEventStream breaks all streaming responses; losing the HTTPDoer seam breaks fingerprint/proxy egress. The endpoint anchors pin the official current runtime host followed only by Kiro's explicitly transitional q host; an upstream merge must not restore undocumented codewhisperer or alternate AmazonQ protocol retries."
+      "rationale": "Streaming call entry + hand-rolled AWS EventStream binary decoder + the HTTPDoer injection seam that lets the TK gateway supply a TLS/proxy-aware doer. CallKiroAPIWithDoerContext binds upstream attempts to the customer request lifetime, while ResetForRetry permits response-read failover only when the consumer can discard all partial state. OnStopReason and the metadataEvent dispatch preserve Kiro's authoritative terminal outcome; losing them turns CONTENT_FILTERED back into an opaque empty-response 502. Losing parseEventStream breaks all streaming responses; losing the HTTPDoer seam breaks fingerprint/proxy egress. The endpoint anchors pin the official current runtime host followed only by Kiro's explicitly transitional q host; an upstream merge must not restore undocumented codewhisperer or alternate AmazonQ protocol retries."
+    },
+    {
+      "path": "backend/internal/integration/kiro/eventstream_test.go",
+      "must_contain": [
+        "TestParseEventStream_MetadataStopReason",
+        "CONTENT_FILTERED"
+      ],
+      "rationale": "Protocol-level evidence that metadataEvent.stopReason survives EventStream decoding. Without this callback the service cannot distinguish an upstream content-policy terminal outcome from a broken empty response."
     },
     {
       "path": "backend/internal/integration/kiro/client_endpoints_test.go",
@@ -221,6 +231,8 @@
         "BillingTier:   kiroproto.KiroEstimatedBillingTier",
         "callErr != nil && !enc.started",
         "textBuf == \"\" && thinkingBuf == \"\" && len(toolUses) == 0",
+        "KiroContentFilteredError",
+        "CONTENT_FILTERED",
         "classifyAndRecordKiroForwardError",
         "publishKiroInternalThinkingSideChannel"
       ],
@@ -232,6 +244,9 @@
         "TestKiroGatewayService_Forward_NonStreaming_ReadFailureRetriesWithoutPartialOutput",
         "TestKiroGatewayService_Forward_Streaming_MidStreamReadErrorSendsSSEError",
         "TestKiroGatewayService_Forward_EmptyResponseTriggersFailover",
+        "TestKiroGatewayService_Forward_NonStreaming_ContentFilteredIsNotFailover",
+        "TestKiroGatewayService_Forward_Streaming_ContentFilteredIsNotFailover",
+        "TestKiroGatewayService_Forward_ContentFilteredWithAssistantTextRemainsSuccess",
         "TestKiroGatewayService_Forward_Streaming_PreContentReadErrorTriggersFailover",
         "TestKiroGatewayService_Forward_EventStreamThrottlingTriggersFailover",
         "TestKiroGatewayService_Forward_EmptyEventStreamExceptionPreservesFailoverClass",
@@ -342,16 +357,30 @@
       "path": "backend/internal/handler/gateway_handler.go",
       "must_contain": [
         "account.IsKiro()",
+        "handleKiroContentFilteredError",
         "service.KiroInvalidModelError",
         "service.KiroInvalidRequestError",
         "service.KiroEndpointQuotaExhaustedError",
         "service.KiroEndpointQuotaExhaustedRetryAfterSeconds()"
       ],
-      "rationale": "The RPM-increment gate (both the streaming and non-streaming paths) admits kiro accounts via `|| account.IsKiro()`. An upstream merge that rewrites these gates must preserve the kiro arm, or kiro accounts skip RPM accounting and bypass the per-account rate limit. The KiroInvalidModelError errors.As branch returns a clean 400 invalid_request_error (no cross-account failover) when the Kiro upstream rejects the model; losing it reverts to the silent empty-200 / failover-churn behavior. The KiroEndpointQuotaExhaustedError branch returns 429+Retry-After:10 instead of a generic 502 when all Kiro upstream endpoints hit quota exhaustion."
+      "rationale": "The RPM-increment gate (both the streaming and non-streaming paths) admits kiro accounts via `|| account.IsKiro()`. An upstream merge that rewrites these gates must preserve the kiro arm, or kiro accounts skip RPM accounting and bypass the per-account rate limit. handleKiroContentFilteredError maps Kiro's policy terminal outcome to 400 invalid_request_error and emits the trusted mirror outcome header without failover. The KiroInvalidModelError errors.As branch returns a clean 400 invalid_request_error (no cross-account failover) when the Kiro upstream rejects the model; losing it reverts to the silent empty-200 / failover-churn behavior. The KiroEndpointQuotaExhaustedError branch returns 429+Retry-After:10 instead of a generic 502 when all Kiro upstream endpoints hit quota exhaustion."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_kiro_content_filter_test.go",
+      "must_contain": [
+        "TestGatewayHandler_HandleKiroContentFilteredError",
+        "invalid_request_error",
+        "KiroOutcomeHeader"
+      ],
+      "rationale": "Messages API wire-contract evidence for the Kiro content-filter outcome: HTTP 400 Anthropic error envelope plus the internal mirror header."
     },
     {
       "path": "backend/internal/service/kiro_gateway_service_tk_errors.go",
       "must_contain": [
+        "type KiroContentFilteredError",
+        "KiroOutcomeHeader",
+        "KiroContentFilteredOutcome",
+        "func IsKiroContentFilteredRelayResponse",
         "type KiroInvalidModelError",
         "type KiroInvalidRequestError",
         "type KiroEndpointQuotaExhaustedError",
@@ -366,7 +395,41 @@
         "quota exhausted on",
         "INVALID_MODEL_ID"
       ],
-      "rationale": "TK-only typed error + classifier for Kiro request rejections, including INVALID_MODEL_ID and CONTENT_LENGTH_EXCEEDS_THRESHOLD. classifyAndRecordKiroForwardError is called from both forwardStreaming and forwardNonStreaming; it preserves a sanitized, categorized transport/read/empty-response cause in ops upstream_errors while the client still receives the generic 502 envelope. The handler maps typed invalid model/request errors to client-owned 400 responses without cross-account failover. Losing this file makes Kiro validation errors fall back to the generic forward-error path or restores opaque 502s with no recoverable root cause."
+      "rationale": "TK-only typed errors + classifier for Kiro request rejections, including CONTENT_FILTERED, INVALID_MODEL_ID and CONTENT_LENGTH_EXCEEDS_THRESHOLD. classifyAndRecordKiroForwardError is called from both forwardStreaming and forwardNonStreaming; it records CONTENT_FILTERED as policy_error/content_filtered with the real upstream HTTP 200 and preserves sanitized transport/read/empty-response causes while clients receive stable protocol envelopes. The handler maps request-owned outcomes to 400 without cross-account failover. Losing this file makes Kiro policy/validation outcomes fall back to generic forwarding errors or restores opaque 502s with no recoverable root cause."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go",
+      "must_contain": [
+        "KiroContentFilteredError",
+        "content_filter_error",
+        "KiroOutcomeHeader"
+      ],
+      "rationale": "Native Kiro Chat Completions mapping must turn the typed content-policy outcome into a committed HTTP 400 content_filter_error before rate-limit handling."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
+      "must_contain": [
+        "IsKiroContentFilteredRelayResponse(account, resp.Header)",
+        "content_filter_error"
+      ],
+      "rationale": "Prod Kiro mirror Chat Completions mapping consumes the trusted edge outcome before generic failover/account-penalty logic."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_as_responses.go",
+      "must_contain": [
+        "IsKiroContentFilteredRelayResponse(account, resp.Header)",
+        "KiroContentFilteredClientMessage()"
+      ],
+      "rationale": "Prod Kiro mirror Responses mapping consumes the trusted edge outcome before generic failover/account-penalty logic and writes the Responses content_filter code."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_kiro_content_filter_test.go",
+      "must_contain": [
+        "TestForwardAsChatCompletions_KiroContentFilteredReturns400",
+        "TestForwardAsChatCompletions_KiroMirrorContentFilteredReturns400WithoutFailover",
+        "TestForwardAsResponses_KiroMirrorContentFilteredReturns400WithoutFailover"
+      ],
+      "rationale": "Wire-contract evidence for native and mirrored Kiro content filtering across Chat Completions and Responses, including no UpstreamFailoverError and a single mirror attempt."
     },
     {
       "path": "backend/internal/service/wire.go",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -358,6 +358,7 @@
       "must_contain": [
         "account.IsKiro()",
         "handleKiroContentFilteredError",
+        "service.MarkOpsClientContentFiltered(c)",
         "service.KiroInvalidModelError",
         "service.KiroInvalidRequestError",
         "service.KiroEndpointQuotaExhaustedError",
@@ -369,6 +370,7 @@
       "path": "backend/internal/handler/gateway_handler_kiro_content_filter_test.go",
       "must_contain": [
         "TestGatewayHandler_HandleKiroContentFilteredError",
+        "service.HasOpsClientContentFiltered(c)",
         "invalid_request_error",
         "KiroOutcomeHeader"
       ],
@@ -386,6 +388,7 @@
         "type KiroEndpointQuotaExhaustedError",
         "func classifyKiroForwardError",
         "func classifyAndRecordKiroForwardError",
+        "MarkOpsClientContentFiltered(c)",
         "func classifyKiroOpaqueFailure",
         "func recordKiroForwardError",
         "func parseKiroEventStreamError",
@@ -402,6 +405,7 @@
       "must_contain": [
         "KiroContentFilteredError",
         "content_filter_error",
+        "MarkOpsClientContentFiltered(c)",
         "KiroOutcomeHeader"
       ],
       "rationale": "Native Kiro Chat Completions mapping must turn the typed content-policy outcome into a committed HTTP 400 content_filter_error before rate-limit handling."
@@ -410,6 +414,7 @@
       "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
       "must_contain": [
         "IsKiroContentFilteredRelayResponse(account, resp.Header)",
+        "MarkOpsClientContentFiltered(c)",
         "content_filter_error"
       ],
       "rationale": "Prod Kiro mirror Chat Completions mapping consumes the trusted edge outcome before generic failover/account-penalty logic."
@@ -418,6 +423,7 @@
       "path": "backend/internal/service/gateway_forward_as_responses.go",
       "must_contain": [
         "IsKiroContentFilteredRelayResponse(account, resp.Header)",
+        "MarkOpsClientContentFiltered(c)",
         "KiroContentFilteredClientMessage()"
       ],
       "rationale": "Prod Kiro mirror Responses mapping consumes the trusted edge outcome before generic failover/account-penalty logic and writes the Responses content_filter code."
@@ -427,32 +433,46 @@
       "must_contain": [
         "TestForwardAsChatCompletions_KiroContentFilteredReturns400",
         "TestForwardAsChatCompletions_KiroMirrorContentFilteredReturns400WithoutFailover",
-        "TestForwardAsResponses_KiroMirrorContentFilteredReturns400WithoutFailover"
+        "TestForwardAsResponses_KiroMirrorContentFilteredReturns400WithoutFailover",
+        "HasOpsClientContentFiltered(c)"
       ],
       "rationale": "Wire-contract evidence for native and mirrored Kiro content filtering across Chat Completions and Responses, including no UpstreamFailoverError and a single mirror attempt."
     },
     {
       "path": "backend/internal/handler/ops_error_logger.go",
       "must_contain": [
-        "\"content_filter_error\""
+        "\"content_filter_error\"",
+        "service.HasOpsClientContentFiltered(c)"
       ],
-      "rationale": "Chat Completions content_filter_error must remain a recognized request-phase type so Kiro filtering is owned by the client, never provider/platform."
+      "rationale": "All content-filter envelopes must remain request-phase/P3 client errors. The structured final-outcome marker takes precedence over stale upstream evidence from an earlier account attempt, so Kiro filtering never becomes a provider/platform SLA fault."
+    },
+    {
+      "path": "backend/internal/service/ops_upstream_context.go",
+      "must_contain": [
+        "OpsClientContentFilteredKey",
+        "func MarkOpsClientContentFiltered",
+        "func HasOpsClientContentFiltered"
+      ],
+      "rationale": "Cross-layer structured marker for the final client-owned content-filter outcome. Losing it lets prior failover context override the final request/client attribution."
     },
     {
       "path": "backend/internal/handler/ops_error_logger_tk_client_validation.go",
       "must_contain": [
         "\"content_filter\""
       ],
-      "rationale": "Responses uses error.code=content_filter without an error.type; this code anchor keeps the flattened api_error classified as request/client."
+      "rationale": "Responses uses error.code=content_filter without an error.type; this code anchor normalizes it to content_filter_error so classification and P3 severity match the other client-owned surfaces."
     },
     {
       "path": "backend/internal/handler/ops_error_logger_tk_kiro_content_filter_test.go",
       "must_contain": [
         "TestClassifyOpsKiroContentFilterOwnedByClient",
+        "TestClassifyOpsKiroContentFilterAfterPriorFailoverStillOwnedByClient",
+        "TestNormalizeOpsContentFilterCodeDoesNotOverrideExplicitErrorType",
+        "service.MarkOpsClientContentFiltered(c)",
         "require.Equal(t, \"client\", owner)",
         "require.False(t, hasOpsUpstreamErrorContext(c))"
       ],
-      "rationale": "End-to-end ops attribution evidence for the Messages, Chat Completions, and Responses content-filter envelopes: request/client ownership with no upstream error context."
+      "rationale": "End-to-end ops attribution evidence for Messages, Chat Completions, and Responses: request/client ownership on a clean path and after prior failover evidence."
     },
     {
       "path": "backend/internal/service/wire.go",


### PR DESCRIPTION
## 摘要

- 修复 Kiro HTTP 200 EventStream 中 `metadataEvent.stopReason=CONTENT_FILTERED` 被忽略的根因；旧逻辑因没有 `assistantResponseEvent` 将其误判为普通空响应，转成 502 并触发跨账号/edge failover，最终表现为 `All available accounts exhausted`。
- 将无 text/thinking/tool 输出的内容过滤终态建模为不可重试的 typed error；已有明确拒答输出时仍正常返回，未知空响应仍保留原 502 failover 行为。
- 按入口返回稳定的客户端错误契约：Messages 为 400 `invalid_request_error`，Chat Completions 为 400 `content_filter_error`，Responses 为 400 `content_filter`。
- Ops 将最终结果记录为 P3、`phase=request`、`error_owner=client`、`error_source=client_request`。即使前一个账号尝试留下 5xx failover evidence，也不会把最终内容过滤重新归为 provider/platform；内容过滤自身不创建 upstream error context。
- Edge 通过固定枚举 `X-TokenKey-Kiro-Outcome: content_filtered` 向 Kiro mirror 传递终态；prod 只信任已配置的 Kiro mirror stub，并在 failover 与账号惩罚前终止处理。
- 本 PR supersedes #1398：#1398 是基于 metering/no-output 的事后兜底，本 PR 直接消费 Kiro 的权威 `CONTENT_FILTERED` 协议信号；不会自动关闭或合并 #1398。

## 风险

- 公共行为只在此前被误分类的 Kiro 内容过滤终态上由 502 改为 400；认证、计费、配额、持久化结构和路由不变。
- 内容过滤不会触发跨账号重试、账号冷却、token refresh 或其他账号健康惩罚；既有前序 failover evidence 仅保留用于诊断。
- Mirror outcome 使用固定枚举且只对 `IsKiroMirrorStub()` 生效，不依赖可变错误文案，也不携带 prompt、响应正文或凭证。
- `upstream-touch-guarded`：所有 upstream-shaped 接线与 ops marker 均已登记 Kiro sentinel；未新增 upstream conflict 文件。
- `sentinel-registry-reviewed`
- `no-web-impact`；Web impact: none
- 本 PR 不包含部署、重启、线上配置修改或合并操作。

## 验证

- `go test -tags=unit ./internal/integration/kiro ./internal/service ./internal/handler -count=1`
- 回归覆盖真实帧序列：`metadataEvent(CONTENT_FILTERED) + contextUsageEvent + meteringEvent`。
- 覆盖 native Kiro 非流式/流式、已有拒答文本、Messages、native Chat、mirror Chat、mirror Responses、普通空响应继续 502，以及前序 5xx 后最终内容过滤仍归客户端。
- `.testing/user-stories/verify_quality.py`：38 stories 对齐通过；新增 `US-038` 作为本次高风险契约验收锚点。
- `git diff --check`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：提交后 PASS。

## 提交

- `297c99a6b fix(kiro): 识别内容过滤终态避免误报 502`
- `0703b99f4 fix(ops): 将 Kiro 内容过滤归为客户端错误`
- `70cf9c81e fix(ops): 防止历史 failover 污染内容过滤归因`
- 最新提交：`70cf9c81e`
- Web impact: none
