### PR TITLE
fix(ops): OpenAI context-window 502 不再计入 upstream_error_rate

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1122,11 +1122,13 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 				}
 				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
 				wroteFallback := h.ensureAnthropicErrorResponse(c, streamStarted)
-				reqLog.Warn("openai_messages.forward_failed",
+				forwardFailedFields := append(
+					service.OpenAICompatMessagesOpsLogFields(c),
 					zap.Int64("account_id", account.ID),
 					zap.Bool("fallback_error_response_written", wroteFallback),
 					zap.Error(err),
 				)
+				reqLog.Warn("openai_messages.forward_failed", forwardFailedFields...)
 				return
 			}
 		}

--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
@@ -38,6 +38,16 @@ func tkUpstreamClientInducedRejection(c *gin.Context, clientErrType string) bool
 	if tkOpsHasUpstreamEventKind(c, service.OpsUpstreamKindClientToolContextCorrupt) {
 		return true
 	}
+	// Prod P0 2026-07-21 (upstream_error_rate=25%): user 6 hammered gpt-5.5 on
+	// /v1/messages with prompts over the model window. OpenAI answers with
+	// upstream_error + "Your input exceeds the context window…"; the gateway maps
+	// that to final 502 and skips failover (isOpenAIContextWindowError), but
+	// classifyOpsErrorLog still owned it to provider because tkUpstreamClientInducedRejection
+	// only treated 400/422/404/413 as caller-fault. Reuse the SAME predicate as
+	// the gateway so context-window rejections drop out of upstream_error_rate.
+	if body, msg := tkOpsUpstreamErrorText(c); service.IsOpenAIContextWindowError(msg, []byte(body)) {
+		return true
+	}
 	status := tkOpsUpstreamStatusCode(c)
 	// 413 request_too_large is always caller-fault: the body cleared TokenKey's
 	// local body-limit middleware (handler.request_body_limit) but exceeded the

--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
@@ -54,6 +54,21 @@ func TestClassifyOpsUpstreamClientInducedRejectionOwnedByClient(t *testing.T) {
 		require.Equal(t, "client_request", errorSource)
 	})
 
+	t.Run("openai context window exceeded surfaced as upstream_error 502 owned by client", func(t *testing.T) {
+		// Prod P0 2026-07-21: gpt-5.5 /v1/messages buffered_response_failed with
+		// upstream_status=502 and the canonical context-window message. Gateway skips
+		// failover; ops must classify client-owned so upstream_error_rate is not flooded.
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		contextWindowMsg := "Your input exceeds the context window of this model. Please adjust your input and try again."
+		service.SetOpsUpstreamError(c, http.StatusBadGateway, contextWindowMsg, "")
+
+		phase, errorOwner, _ := classifyOpsErrorLog(c, "upstream_error", contextWindowMsg, "", http.StatusBadGateway)
+
+		require.Equal(t, "request", phase)
+		require.Equal(t, "client", errorOwner)
+	})
+
 	t.Run("openai /v1/responses unsupported-model surfaced as wrapped upstream_error (msg-only signal)", func(t *testing.T) {
 		// On /v1/responses the surfaced envelope type is upstream_error and the
 		// final status is 502; the only client-induced signal is the upstream

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -99,6 +99,11 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 			compatReplayTrimmedByPolicy = compatReplayTrimmed
 		}
 	}
+	SetOpenAICompatMessagesOpsContext(c, OpenAICompatMessagesOpsSnapshot{
+		PreviousResponseIDAttached: previousResponseID != "",
+		MessagesCompactionApplied:  compatReplayTrimmedByPolicy,
+		EstimatedInputTokens:       estimateAnthropicRequestInputTokens(&anthropicReq),
+	})
 
 	// 3. Convert Anthropic → Responses after compatibility-only replay guard.
 	responsesReq, err := apicompat.AnthropicToResponses(&anthropicReq)

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -164,6 +164,13 @@ func isOpenAITransientProcessingError(upstreamStatusCode int, upstreamMsg string
 	return match(string(upstreamBody))
 }
 
+// IsOpenAIContextWindowError reports whether upstream text indicates the caller
+// exceeded the model context window. Shared by the OpenAI gateway (failover /
+// passthrough) and ops error classification so upstream_error_rate cannot drift.
+func IsOpenAIContextWindowError(upstreamMsg string, upstreamBody []byte) bool {
+	return isOpenAIContextWindowError(upstreamMsg, upstreamBody)
+}
+
 func isOpenAIContextWindowError(upstreamMsg string, upstreamBody []byte) bool {
 	match := func(text string) bool {
 		lower := strings.ToLower(strings.TrimSpace(text))

--- a/backend/internal/service/openai_messages_ops_context_tk.go
+++ b/backend/internal/service/openai_messages_ops_context_tk.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+const openAICompatMessagesOpsContextKey = "openai_compat_messages_ops"
+
+// OpenAICompatMessagesOpsSnapshot captures /v1/messages compat forwarding
+// decisions for ops indexing (ops_system_logs on forward_failed).
+type OpenAICompatMessagesOpsSnapshot struct {
+	PreviousResponseIDAttached bool
+	MessagesCompactionApplied  bool
+	EstimatedInputTokens       int
+}
+
+func SetOpenAICompatMessagesOpsContext(c *gin.Context, snapshot OpenAICompatMessagesOpsSnapshot) {
+	if c == nil {
+		return
+	}
+	c.Set(openAICompatMessagesOpsContextKey, snapshot)
+}
+
+func OpenAICompatMessagesOpsLogFields(c *gin.Context) []zap.Field {
+	if c == nil {
+		return openAICompatMessagesOpsLogFields(OpenAICompatMessagesOpsSnapshot{})
+	}
+	value, ok := c.Get(openAICompatMessagesOpsContextKey)
+	if !ok {
+		return openAICompatMessagesOpsLogFields(OpenAICompatMessagesOpsSnapshot{})
+	}
+	snapshot, ok := value.(OpenAICompatMessagesOpsSnapshot)
+	if !ok {
+		return openAICompatMessagesOpsLogFields(OpenAICompatMessagesOpsSnapshot{})
+	}
+	return openAICompatMessagesOpsLogFields(snapshot)
+}
+
+func openAICompatMessagesOpsLogFields(snapshot OpenAICompatMessagesOpsSnapshot) []zap.Field {
+	return []zap.Field{
+		zap.Bool("compat_previous_response_id_attached", snapshot.PreviousResponseIDAttached),
+		zap.Bool("compat_messages_compaction_applied", snapshot.MessagesCompactionApplied),
+		zap.Int("compat_estimated_input_tokens", snapshot.EstimatedInputTokens),
+	}
+}

--- a/backend/internal/service/openai_messages_ops_context_tk_test.go
+++ b/backend/internal/service/openai_messages_ops_context_tk_test.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func encodeZapField(field zap.Field) map[string]any {
+	enc := zapcore.NewMapObjectEncoder()
+	field.AddTo(enc)
+	return enc.Fields
+}
+
+func TestOpenAICompatMessagesOpsContextLogFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("defaults when unset", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+
+		fields := OpenAICompatMessagesOpsLogFields(c)
+		require.Len(t, fields, 3)
+		require.Equal(t, false, encodeZapField(fields[0])["compat_previous_response_id_attached"])
+		require.Equal(t, false, encodeZapField(fields[1])["compat_messages_compaction_applied"])
+		require.Equal(t, int64(0), encodeZapField(fields[2])["compat_estimated_input_tokens"])
+	})
+
+	t.Run("reflects snapshot", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		SetOpenAICompatMessagesOpsContext(c, OpenAICompatMessagesOpsSnapshot{
+			PreviousResponseIDAttached: true,
+			MessagesCompactionApplied:  true,
+			EstimatedInputTokens:       181000,
+		})
+
+		fields := OpenAICompatMessagesOpsLogFields(c)
+		require.Equal(t, true, encodeZapField(fields[0])["compat_previous_response_id_attached"])
+		require.Equal(t, true, encodeZapField(fields[1])["compat_messages_compaction_applied"])
+		require.Equal(t, int64(181000), encodeZapField(fields[2])["compat_estimated_input_tokens"])
+	})
+}


### PR DESCRIPTION
## 摘要

- 在 `tkUpstreamClientInducedRejection` 中复用 gateway 层 `IsOpenAIContextWindowError`，将 OpenAI「上下文超限」类 upstream 502 重分类为 `error_phase=request` / `error_owner=client`。
- 导出 `service.IsOpenAIContextWindowError` 供 ops 分类与 gateway 共用同一谓词，避免指标漂移。
- `/v1/messages` 的 `forward_failed` 写入 `compat_previous_response_id_attached` / `compat_messages_compaction_applied` / `compat_estimated_input_tokens`，便于 ops_system_logs 区分 session 满 vs 首包撞窗。
- 背景：prod P0（2026-07-21 21:37）`upstream_error_rate=25%`，主因 gpt-5.5 context window exceeded；gateway 已不做 failover，但 ops 仍计为 provider 故障。

## 风险

- 常规风险：仅影响 ops 错误归属、`upstream_error_rate` 分子与失败日志字段；不改变客户端可见 502 响应。
- 真上游 502（非 context window 文案）仍保持 provider-owned。

## 验证

- `go test -tags=unit ./internal/handler/... -run 'TestClassifyOpsUpstreamClientInducedRejectionOwnedByClient|TestClassifyOpsGenuineUpstreamErrorsStayProvider'`
- `go test -tags=unit ./internal/service/... -run 'TestOpenAICompatMessagesOpsContextLogFields|TestIsOpenAIContextWindowError'`
- `./scripts/preflight.sh` 全绿

sentinel-registry-reviewed：变更仅为 ops 分类 + 失败日志字段；未改 gateway 调度/计费/路由语义，无需新增 sentinel anchor。

## 提交

- 61be738 fix(ops): classify OpenAI context-window 502 as client-owned
- cf69ebc3 fix(ops): index compat session fields on messages forward_failed
- 最新提交：cf69ebc3

Made with [Cursor](https://cursor.com)