### PR TITLE
feat(ops): extract observability probes from superseded #1398

### DIFF
--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 |---|---|---|
 | 解析 prod / edge target（region / instance_id / domain） | 机械 | edge 经 `ops/stage0/edge_ssm_execution.py`（Lightsail tag-SSM `EdgeId`/`Platform=lightsail` → `mi-*`）/ `resolve-edge-lightsail-target.py`；prod 经 CFN `describe-stacks` |
 | SSM base64 投递 + send-command + poll | 机械 | `ops/observability/run-probe.sh --target prod\|edge:<id> --script <probe.sh>` |
-| `ops_error_logs` 标准聚合（schema + by_status + upstream_events + 429-by-minute） | 机械 | `ops/observability/ops-error-triage.sh`（通过 run-probe.sh 投递） |
+| `ops_error_logs` 标准聚合（schema + by_status + upstream_events，保留 reason/截断 message + 429-by-minute） | 机械 | `ops/observability/ops-error-triage.sh`（通过 run-probe.sh 投递） |
 | final-429 / 5xx 分类（config-cap vs 空池 #575 vs 真上游：by error_type/owner/phase + by group·model·account + 5min 桶） | 机械 | `ops/observability/probe-429-classify.sh`（通过 run-probe.sh 投递；`WINDOW_HOURS` 默认 3；§4 triage 的分类深挖） |
 | SLA Dashboard 等价拆解（success/error_total/error_sla/client_faults + by_status owner 口径 + top SLA messages） | 机械 | `ops/observability/probe-sla-breakdown.sh`（通过 run-probe.sh 投递；`WINDOW_HOURS` 默认 24；对齐 Admin Ops `error_owner` SLA 公式） |
 | ⚠写侧止血：恢复 anthropic 可调度 / 清陈旧冷却（`MODE=edge-oauth-pool` 恢复 OAuth 池+补 group_id / `prod-mirror-cooldown` 清 cc-·kiro- 镜像冷却；before/after 自证） | 机械(写) | `ops/observability/remediate-schedulable-pool.sh`（经 run-probe 投递；§10 交接修复时用，非只读、须先有结论） |
@@ -38,6 +38,7 @@ description: >-
 | Gateway UA/TLS / usage_logs / ops / docker 指纹交叉对比（窄时间窗） | 机械 | `ops/observability/probe-gateway-ua-tls-compare.sh`（通过 run-probe.sh 投递；`WINDOW_MINUTES` 收窄 DB 窗） |
 | OpenAI/Python ingress → edge OAuth mimic 出站（HTTP 头 + system，非 UA-only） | 机械 | `ops/observability/probe-oauth-mimicry-chain.sh`（edge + `PLATFORM=anthropic`）；日志 `gateway.anthropic_oauth_mimic_egress` |
 | `ops_error_logs.request_body` 顶层参数形状聚合（若线上 schema 保留 body，则只输出 top-level keys / deprecated sampling key 存在性；若无 body 列则输出 schema-unavailable + 错误样本） | 机械 | `ops/observability/probe-ops-error-request-shape.sh`（经 run-probe 投递；用于确认错误请求是否携带 `temperature` / `top_p` / `top_k` 等字段，不输出 prompt/body 原文） |
+| final error 与 QA evidence 覆盖率（request_id 关联、retention、blob ref/本地存在性；不输出正文或 URI） | 机械 | `ops/observability/probe-qa-error-evidence.sh`（经 run-probe 投递；先判断是否有可深挖证据，再决定是否需要隐私受控的正文检查） |
 | `SUB2API_DEBUG_GATEWAY_BODY` 日志拉回本机（SSM gzip → S3 presigned PUT → 本地 gunzip） | 机械 | `ops/observability/fetch-gateway-debug-log.sh --target prod\|edge:<id>`（**本地** orchestrator，不走 run-probe） |
 | anthropic capacity / cap 与 schedulable 证据 | 机械 | `ops/observability/probe-caps.sh`（已有，通过 run-probe.sh 投递）/ `ops/anthropic/manage-anthropic-config.py snapshot` |
 | 镜像 edge 死活/容量判定（fleet 横扫：served_200:no_available_429 + 可调度账号数 → verdict） | 机械 | `ops/observability/scan-edge-health.sh`（本地 fan-out 全 deployable edge）/ 单边远端 `probe-edge-health.sh` + 纯函数 `edge_health_verdict.py`（`--selftest` 已进 preflight） |

--- a/ops/observability/ops-error-triage.sh
+++ b/ops/observability/ops-error-triage.sh
@@ -139,6 +139,9 @@ WITH bounds AS (
 SELECT row_to_json(t) FROM (
   SELECT
     COALESCE(ev->>'kind','')                  AS kind,
+    COALESCE(ev->>'reason','')                AS reason,
+    left(regexp_replace(COALESCE(ev->>'message',''), E'[\\n\\r]+', ' ', 'g'), 160)
+                                                AS message,
     COALESCE(ev->>'platform','')              AS platform,
     COALESCE(ev->>'account_id','')            AS account_id,
     COALESCE(ev->>'account_name','')          AS account_name,
@@ -148,7 +151,7 @@ SELECT row_to_json(t) FROM (
     to_char(MIN(created_at) AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS first_at_utc,
     to_char(MAX(created_at) AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS last_at_utc
   FROM events
-  GROUP BY kind, platform, account_id, account_name, upstream_status, final_status
+  GROUP BY kind, reason, message, platform, account_id, account_name, upstream_status, final_status
   ORDER BY n DESC, kind, final_status
   LIMIT ${TOP_KIND_LIMIT}
 ) t;

--- a/ops/observability/probe-ops-error-request-shape.sh
+++ b/ops/observability/probe-ops-error-request-shape.sh
@@ -149,6 +149,11 @@ SELECT row_to_json(t) FROM (
     account_id,
     group_id,
     request_path,
+    stream,
+    left(COALESCE(user_agent,''), 120) AS user_agent,
+    inbound_endpoint,
+    upstream_endpoint,
+    request_type,
     COALESCE(requested_model, model) AS model,
     error_phase,
     error_type,
@@ -165,6 +170,7 @@ SELECT row_to_json(t) FROM (
     (
       SELECT string_agg(
         concat_ws(':', ordinality::text, COALESCE(ev->>'kind',''),
+                  COALESCE(ev->>'reason',''),
                   COALESCE(NULLIF(ev->>'upstream_status_code',''),'0'),
                   left(COALESCE(ev->>'message',''), 80)),
         ' | ' ORDER BY ordinality
@@ -179,6 +185,43 @@ SELECT row_to_json(t) FROM (
   FROM base
   ORDER BY created_at DESC
   LIMIT ${LIMIT}
+) t;
+" 2>&1
+
+  echo
+  echo "=== fallback_upstream_request_body_presence ==="
+  $PSQL -c "
+WITH base AS (
+  SELECT l.*
+  FROM ops_error_logs l
+  WHERE l.created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+    AND l.status_code = ${STATUS_CODE}
+    AND ('${USER_ID}' = '' OR l.user_id = NULLIF('${USER_ID}','')::bigint)
+    AND ('${API_KEY_ID}' = '' OR l.api_key_id = NULLIF('${API_KEY_ID}','')::bigint)
+    AND ('${ACCOUNT_ID}' = '' OR l.account_id = NULLIF('${ACCOUNT_ID}','')::bigint)
+    AND ('${MODEL_SQL}' = '' OR l.requested_model = '${MODEL_SQL}' OR l.model = '${MODEL_SQL}')
+    AND ('${REQUEST_PATH_SQL}' = '' OR l.request_path = '${REQUEST_PATH_SQL}')
+    AND ('${ERROR_MESSAGE_LIKE_SQL}' = '' OR l.error_message ILIKE '%' || '${ERROR_MESSAGE_LIKE_SQL}' || '%')
+), events AS (
+  SELECT e.value AS ev
+  FROM base l
+  CROSS JOIN LATERAL jsonb_array_elements(
+    CASE WHEN jsonb_typeof(l.upstream_errors) = 'array'
+         THEN l.upstream_errors
+         ELSE '[]'::jsonb END
+  ) AS e(value)
+), bodies AS (
+  SELECT COALESCE(ev->>'upstream_request_body','') AS body
+  FROM events
+)
+SELECT row_to_json(t) FROM (
+  SELECT
+    COUNT(*) AS upstream_events,
+    COUNT(*) FILTER (WHERE body <> '') AS events_with_request_body,
+    COUNT(*) FILTER (WHERE left(ltrim(body), 1) = '{') AS object_like_bodies,
+    MIN(octet_length(body)) FILTER (WHERE body <> '') AS min_body_bytes,
+    MAX(octet_length(body)) FILTER (WHERE body <> '') AS max_body_bytes
+  FROM bodies
 ) t;
 " 2>&1
   exit 0

--- a/ops/observability/probe-qa-error-evidence.sh
+++ b/ops/observability/probe-qa-error-evidence.sh
@@ -52,11 +52,14 @@ WITH errors AS (
     AND ('${REQUEST_PATH_SQL}' = '' OR request_path = '${REQUEST_PATH_SQL}')
     AND ('${USER_AGENT_LIKE_SQL}' = '' OR user_agent ILIKE '%' || '${USER_AGENT_LIKE_SQL}' || '%')
 ), joined AS (
-  SELECT e.request_id, q.id AS qa_id, q.blob_uri, q.capture_status,
+  SELECT e.request_id, q.id AS qa_id, q.blob_uri,
+         q.request_blob_uri, q.response_blob_uri, q.stream_blob_uri,
+         q.capture_status,
          q.retention_until, q.created_at, q.request_sha256
   FROM errors e
   LEFT JOIN LATERAL (
-    SELECT id, blob_uri, capture_status, retention_until, created_at, request_sha256
+    SELECT id, blob_uri, request_blob_uri, response_blob_uri, stream_blob_uri,
+           capture_status, retention_until, created_at, request_sha256
     FROM qa_records q
     WHERE q.request_id = e.request_id
     ORDER BY q.created_at DESC
@@ -67,7 +70,10 @@ SELECT row_to_json(t) FROM (
   SELECT
     COUNT(*) AS error_requests,
     COUNT(qa_id) AS qa_records,
-    COUNT(*) FILTER (WHERE blob_uri IS NOT NULL AND blob_uri <> '') AS qa_blob_refs,
+    COUNT(*) FILTER (WHERE NULLIF(blob_uri, '') IS NOT NULL
+                          OR NULLIF(request_blob_uri, '') IS NOT NULL
+                          OR NULLIF(response_blob_uri, '') IS NOT NULL
+                          OR NULLIF(stream_blob_uri, '') IS NOT NULL) AS qa_blob_refs,
     COUNT(*) FILTER (WHERE request_sha256 <> '') AS request_hashes,
     COUNT(DISTINCT NULLIF(request_sha256, '')) AS distinct_request_hashes,
     COALESCE((
@@ -97,11 +103,20 @@ WITH errors AS (
     AND ('${MODEL_SQL}' = '' OR requested_model = '${MODEL_SQL}' OR model = '${MODEL_SQL}')
     AND ('${REQUEST_PATH_SQL}' = '' OR request_path = '${REQUEST_PATH_SQL}')
     AND ('${USER_AGENT_LIKE_SQL}' = '' OR user_agent ILIKE '%' || '${USER_AGENT_LIKE_SQL}' || '%')
+), latest AS (
+  SELECT e.request_id, q.capture_status
+  FROM errors e
+  LEFT JOIN LATERAL (
+    SELECT capture_status
+    FROM qa_records q
+    WHERE q.request_id = e.request_id
+    ORDER BY q.created_at DESC
+    LIMIT 1
+  ) q ON true
 )
 SELECT row_to_json(t) FROM (
-  SELECT COALESCE(q.capture_status, 'missing') AS capture_status, COUNT(*) AS rows
-  FROM errors e
-  LEFT JOIN qa_records q ON q.request_id = e.request_id
+  SELECT COALESCE(capture_status, 'missing') AS capture_status, COUNT(*) AS rows
+  FROM latest
   GROUP BY 1
   ORDER BY rows DESC, capture_status
 ) t;
@@ -161,11 +176,30 @@ WITH errors AS (
     AND ('${MODEL_SQL}' = '' OR requested_model = '${MODEL_SQL}' OR model = '${MODEL_SQL}')
     AND ('${REQUEST_PATH_SQL}' = '' OR request_path = '${REQUEST_PATH_SQL}')
     AND ('${USER_AGENT_LIKE_SQL}' = '' OR user_agent ILIKE '%' || '${USER_AGENT_LIKE_SQL}' || '%')
+), latest AS (
+  SELECT e.request_id, q.blob_uri, q.request_blob_uri,
+         q.response_blob_uri, q.stream_blob_uri
+  FROM errors e
+  JOIN LATERAL (
+    SELECT blob_uri, request_blob_uri, response_blob_uri, stream_blob_uri
+    FROM qa_records q
+    WHERE q.request_id = e.request_id
+    ORDER BY q.created_at DESC
+    LIMIT 1
+  ) q ON true
+), refs AS (
+  SELECT latest.request_id, ref.blob_uri
+  FROM latest
+  CROSS JOIN LATERAL (VALUES
+    (latest.blob_uri),
+    (latest.request_blob_uri),
+    (latest.response_blob_uri),
+    (latest.stream_blob_uri)
+  ) AS ref(blob_uri)
+  WHERE NULLIF(ref.blob_uri, '') IS NOT NULL
 )
-SELECT DISTINCT q.request_id, q.blob_uri
-FROM errors e
-JOIN qa_records q ON q.request_id = e.request_id
-WHERE q.blob_uri IS NOT NULL AND q.blob_uri <> '';
+SELECT DISTINCT refs.request_id, refs.blob_uri
+FROM refs;
 " > "$TMP_ROWS"
 
 local_refs=0

--- a/ops/observability/probe-qa-error-evidence.sh
+++ b/ops/observability/probe-qa-error-evidence.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# probe-qa-error-evidence.sh - correlate final ops errors with QA captures.
+#
+# This probe never prints request/response bodies or blob URIs. It reports
+# whether matching QA metadata and evidence blobs still exist, so operators can
+# decide whether a privacy-scoped deep inspection is possible.
+#
+# Env:
+#   WINDOW_MINUTES  lookback window, default 1440
+#   STATUS_CODE     final client status, default 502
+#   MODEL           optional exact requested model
+#   REQUEST_PATH    optional exact request path
+#   USER_AGENT_LIKE optional user-agent substring
+set -eu
+
+PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+WINDOW_MINUTES="${WINDOW_MINUTES:-1440}"
+STATUS_CODE="${STATUS_CODE:-502}"
+MODEL="${MODEL:-}"
+REQUEST_PATH="${REQUEST_PATH:-}"
+USER_AGENT_LIKE="${USER_AGENT_LIKE:-}"
+
+for name in WINDOW_MINUTES STATUS_CODE; do
+  value="${!name}"
+  case "$value" in
+    ''|*[!0-9]*) echo "[probe-qa-error-evidence] ERROR: $name must be a non-negative integer" >&2; exit 2 ;;
+  esac
+done
+
+sql_quote() {
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+MODEL_SQL=$(sql_quote "$MODEL")
+REQUEST_PATH_SQL=$(sql_quote "$REQUEST_PATH")
+USER_AGENT_LIKE_SQL=$(sql_quote "$USER_AGENT_LIKE")
+
+HAS_TABLE=$($PSQL -c "SELECT to_regclass('public.qa_records') IS NOT NULL;" 2>/dev/null | tr -d '[:space:]')
+if [ "$HAS_TABLE" != "t" ]; then
+  printf '%s\n' '{"qa_records_available":false,"note":"qa_records table is absent"}'
+  exit 0
+fi
+
+echo "=== coverage ==="
+$PSQL -c "
+WITH errors AS (
+  SELECT DISTINCT request_id
+  FROM ops_error_logs
+  WHERE created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+    AND status_code = ${STATUS_CODE}
+    AND ('${MODEL_SQL}' = '' OR requested_model = '${MODEL_SQL}' OR model = '${MODEL_SQL}')
+    AND ('${REQUEST_PATH_SQL}' = '' OR request_path = '${REQUEST_PATH_SQL}')
+    AND ('${USER_AGENT_LIKE_SQL}' = '' OR user_agent ILIKE '%' || '${USER_AGENT_LIKE_SQL}' || '%')
+), joined AS (
+  SELECT e.request_id, q.id AS qa_id, q.blob_uri, q.capture_status,
+         q.retention_until, q.created_at, q.request_sha256
+  FROM errors e
+  LEFT JOIN LATERAL (
+    SELECT id, blob_uri, capture_status, retention_until, created_at, request_sha256
+    FROM qa_records q
+    WHERE q.request_id = e.request_id
+    ORDER BY q.created_at DESC
+    LIMIT 1
+  ) q ON true
+)
+SELECT row_to_json(t) FROM (
+  SELECT
+    COUNT(*) AS error_requests,
+    COUNT(qa_id) AS qa_records,
+    COUNT(*) FILTER (WHERE blob_uri IS NOT NULL AND blob_uri <> '') AS qa_blob_refs,
+    COUNT(*) FILTER (WHERE request_sha256 <> '') AS request_hashes,
+    COUNT(DISTINCT NULLIF(request_sha256, '')) AS distinct_request_hashes,
+    COALESCE((
+      SELECT MAX(repeats)
+      FROM (
+        SELECT COUNT(*) AS repeats
+        FROM joined
+        WHERE request_sha256 <> ''
+        GROUP BY request_sha256
+      ) grouped_hashes
+    ), 0) AS max_same_request_repeats,
+    COUNT(*) FILTER (WHERE retention_until > now()) AS retention_active,
+    COUNT(*) FILTER (WHERE retention_until <= now()) AS retention_expired,
+    to_char(MIN(created_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS first_qa_at_utc,
+    to_char(MAX(created_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS last_qa_at_utc
+  FROM joined
+) t;
+"
+
+echo "=== capture_status ==="
+$PSQL -c "
+WITH errors AS (
+  SELECT DISTINCT request_id
+  FROM ops_error_logs
+  WHERE created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+    AND status_code = ${STATUS_CODE}
+    AND ('${MODEL_SQL}' = '' OR requested_model = '${MODEL_SQL}' OR model = '${MODEL_SQL}')
+    AND ('${REQUEST_PATH_SQL}' = '' OR request_path = '${REQUEST_PATH_SQL}')
+    AND ('${USER_AGENT_LIKE_SQL}' = '' OR user_agent ILIKE '%' || '${USER_AGENT_LIKE_SQL}' || '%')
+)
+SELECT row_to_json(t) FROM (
+  SELECT COALESCE(q.capture_status, 'missing') AS capture_status, COUNT(*) AS rows
+  FROM errors e
+  LEFT JOIN qa_records q ON q.request_id = e.request_id
+  GROUP BY 1
+  ORDER BY rows DESC, capture_status
+) t;
+"
+
+echo "=== replay_outcomes ==="
+$PSQL -c "
+WITH error_requests AS (
+  SELECT DISTINCT request_id
+  FROM ops_error_logs
+  WHERE created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+    AND status_code = ${STATUS_CODE}
+    AND ('${MODEL_SQL}' = '' OR requested_model = '${MODEL_SQL}' OR model = '${MODEL_SQL}')
+    AND ('${REQUEST_PATH_SQL}' = '' OR request_path = '${REQUEST_PATH_SQL}')
+    AND ('${USER_AGENT_LIKE_SQL}' = '' OR user_agent ILIKE '%' || '${USER_AGENT_LIKE_SQL}' || '%')
+), error_hashes AS (
+  SELECT q.request_sha256, COUNT(*) AS matching_error_rows
+  FROM error_requests e
+  JOIN qa_records q ON q.request_id = e.request_id
+  WHERE q.request_sha256 <> ''
+  GROUP BY q.request_sha256
+), outcomes AS (
+  SELECT
+    h.request_sha256,
+    h.matching_error_rows,
+    COUNT(q.*) FILTER (WHERE q.status_code >= 200 AND q.status_code < 400) AS success_rows,
+    COUNT(q.*) FILTER (WHERE q.status_code = ${STATUS_CODE}) AS same_status_rows,
+    COUNT(q.*) FILTER (WHERE q.status_code >= 400 AND q.status_code <> ${STATUS_CODE}) AS other_error_rows
+  FROM error_hashes h
+  LEFT JOIN qa_records q
+    ON q.request_sha256 = h.request_sha256
+   AND q.created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+  GROUP BY h.request_sha256, h.matching_error_rows
+)
+SELECT row_to_json(t) FROM (
+  SELECT
+    COUNT(*) AS distinct_error_request_hashes,
+    COUNT(*) FILTER (WHERE success_rows > 0) AS hashes_with_success,
+    COALESCE(SUM(success_rows), 0) AS success_rows,
+    COALESCE(SUM(same_status_rows), 0) AS same_status_rows,
+    COALESCE(SUM(other_error_rows), 0) AS other_error_rows,
+    MAX(matching_error_rows) AS max_matching_error_repeats
+  FROM outcomes
+) t;
+"
+
+echo "=== blob_storage ==="
+TMP_ROWS=$(mktemp)
+TMP_PATHS=$(mktemp)
+trap 'rm -f "$TMP_ROWS" "$TMP_PATHS"' EXIT
+$PSQL -F $'\t' -c "
+WITH errors AS (
+  SELECT DISTINCT request_id
+  FROM ops_error_logs
+  WHERE created_at >= now() - interval '${WINDOW_MINUTES} minutes'
+    AND status_code = ${STATUS_CODE}
+    AND ('${MODEL_SQL}' = '' OR requested_model = '${MODEL_SQL}' OR model = '${MODEL_SQL}')
+    AND ('${REQUEST_PATH_SQL}' = '' OR request_path = '${REQUEST_PATH_SQL}')
+    AND ('${USER_AGENT_LIKE_SQL}' = '' OR user_agent ILIKE '%' || '${USER_AGENT_LIKE_SQL}' || '%')
+)
+SELECT DISTINCT q.request_id, q.blob_uri
+FROM errors e
+JOIN qa_records q ON q.request_id = e.request_id
+WHERE q.blob_uri IS NOT NULL AND q.blob_uri <> '';
+" > "$TMP_ROWS"
+
+local_refs=0
+local_present=0
+local_missing=0
+remote_refs=0
+app_container=""
+if [ -r /var/lib/tokenkey/active-color ]; then
+  color=$(tr -d '[:space:]' < /var/lib/tokenkey/active-color 2>/dev/null || true)  # preflight-allow: swallow -- fallback below
+  case "$color" in
+    blue|green)
+      if docker inspect "tokenkey-$color" >/dev/null 2>&1; then
+        app_container="tokenkey-$color"
+      fi
+      ;;
+  esac
+fi
+if [ -z "$app_container" ]; then
+  for candidate in tokenkey tokenkey-blue tokenkey-green; do
+    if docker inspect "$candidate" >/dev/null 2>&1; then
+      app_container="$candidate"
+      break
+    fi
+  done
+fi
+while IFS=$'\t' read -r _request_id blob_uri; do
+  [ -n "${blob_uri:-}" ] || continue
+  case "$blob_uri" in
+    file://*)
+      local_refs=$((local_refs + 1))
+      printf '%s\n' "${blob_uri#file://}" >> "$TMP_PATHS"
+      ;;
+    *) remote_refs=$((remote_refs + 1)) ;;
+  esac
+done < "$TMP_ROWS"
+if [ "$local_refs" -gt 0 ] && [ -n "$app_container" ]; then
+  counts=$(docker exec -i "$app_container" sh -c '
+    present=0
+    missing=0
+    while IFS= read -r path; do
+      if [ -f "$path" ]; then
+        present=$((present + 1))
+      else
+        missing=$((missing + 1))
+      fi
+    done
+    printf "%s\t%s\n" "$present" "$missing"
+  ' < "$TMP_PATHS")
+  IFS=$'\t' read -r local_present local_missing <<EOF
+$counts
+EOF
+else
+  local_missing=$local_refs
+fi
+printf '{"local_refs":%d,"local_present":%d,"local_missing":%d,"remote_refs":%d}\n' \
+  "$local_refs" "$local_present" "$local_missing" "$remote_refs"

--- a/ops/observability/test_ops_error_triage.py
+++ b/ops/observability/test_ops_error_triage.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import pathlib
 import subprocess
+import tempfile
 import unittest
 
 _SCRIPT = pathlib.Path(__file__).resolve().parent / "ops-error-triage.sh"
@@ -42,6 +43,33 @@ class OpsErrorTriageTest(unittest.TestCase):
         )
         self.assertEqual(proc.returncode, 2)
         self.assertIn("WINDOW_HOURS not positive int", proc.stderr)
+
+    def test_upstream_event_query_keeps_reason_and_bounded_message(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_docker = pathlib.Path(tmp) / "docker"
+            fake_docker.write_text(
+                "#!/bin/sh\n"
+                "case \"$*\" in\n"
+                "  *\"ev->>'reason'\"*\"ev->>'message'\"*)\n"
+                "    printf '%s\\n' '{\"kind\":\"response_error\",\"reason\":\"empty_response\",\"message\":\"kiro upstream returned an empty response\"}' ;;\n"
+                "  *) printf '%s\\n' '{}' ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            fake_docker.chmod(0o755)
+            proc = subprocess.run(
+                ["/bin/bash", str(_SCRIPT)],
+                env={"PATH": f"{tmp}:/usr/bin:/bin", "WINDOW_MINUTES": "5"},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        upstream_section = proc.stdout.split("=== upstream_events ===", 1)[1]
+        upstream_section = upstream_section.split("=== by_minute_429 ===", 1)[0]
+        self.assertIn('"reason":"empty_response"', upstream_section)
+        self.assertIn('"message":"kiro upstream returned an empty response"', upstream_section)
 
 
 if __name__ == "__main__":

--- a/ops/observability/test_probe_qa_error_evidence.py
+++ b/ops/observability/test_probe_qa_error_evidence.py
@@ -1,0 +1,95 @@
+import os
+import pathlib
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "ops" / "observability" / "probe-qa-error-evidence.sh"
+
+
+class QAErrorEvidenceProbeTest(unittest.TestCase):
+    def run_probe(self, docker_script: str, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_bin = pathlib.Path(tmp)
+            docker = fake_bin / "docker"
+            docker.write_text(textwrap.dedent(docker_script), encoding="utf-8")
+            docker.chmod(docker.stat().st_mode | stat.S_IXUSR)
+            env = os.environ.copy()
+            env.update(env_overrides)
+            env["PATH"] = f"{fake_bin}:{env['PATH']}"
+            return subprocess.run(
+                ["bash", str(SCRIPT)],
+                cwd=ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+    def test_reports_metadata_replay_and_batched_blob_presence(self) -> None:
+        proc = self.run_probe(
+            r"""
+            #!/bin/sh
+            if [ "$1" = "inspect" ]; then
+              [ "$2" = "tokenkey-blue" ] && exit 0
+              exit 1
+            fi
+            if [ "$1" = "exec" ] && [ "$2" = "tokenkey-postgres" ]; then
+              case "$*" in
+                *to_regclass*) echo t ;;
+                *distinct_error_request_hashes*) echo '{"distinct_error_request_hashes":2,"hashes_with_success":0}' ;;
+                *distinct_request_hashes*) echo '{"error_requests":3,"qa_records":3,"distinct_request_hashes":2}' ;;
+                *COALESCE\(q.capture_status*) echo '{"capture_status":"captured","rows":3}' ;;
+                *"SELECT DISTINCT q.request_id, q.blob_uri"*)
+                  printf 'r1\tfile:///app/data/qa_blobs/r1.zst\n'
+                  printf 'r2\tfile:///app/data/qa_blobs/r2.zst\n'
+                  ;;
+              esac
+              exit 0
+            fi
+            if [ "$1" = "exec" ] && [ "$2" = "-i" ] && [ "$3" = "tokenkey-blue" ]; then
+              cat >/dev/null
+              printf '1\t1\n'
+              exit 0
+            fi
+            exit 1
+            """,
+            MODEL="claude-sonnet-4-5",
+            REQUEST_PATH="/v1/chat/completions",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn('"error_requests":3', proc.stdout)
+        self.assertIn('"hashes_with_success":0', proc.stdout)
+        self.assertIn('"capture_status":"captured"', proc.stdout)
+        self.assertIn(
+            '{"local_refs":2,"local_present":1,"local_missing":1,"remote_refs":0}',
+            proc.stdout,
+        )
+        self.assertNotIn("qa_blobs/r1", proc.stdout)
+
+    def test_reports_missing_qa_table(self) -> None:
+        proc = self.run_probe(
+            r"""
+            #!/bin/sh
+            if [ "$1" = "exec" ] && [ "$2" = "tokenkey-postgres" ]; then
+              echo f
+              exit 0
+            fi
+            exit 1
+            """
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn('"qa_records_available":false', proc.stdout)
+
+    def test_rejects_invalid_numeric_filter_before_docker(self) -> None:
+        proc = self.run_probe("#!/bin/sh\nexit 99\n", WINDOW_MINUTES="1 hour")
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("WINDOW_MINUTES must be a non-negative integer", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/observability/test_probe_qa_error_evidence.py
+++ b/ops/observability/test_probe_qa_error_evidence.py
@@ -43,10 +43,12 @@ class QAErrorEvidenceProbeTest(unittest.TestCase):
                 *to_regclass*) echo t ;;
                 *distinct_error_request_hashes*) echo '{"distinct_error_request_hashes":2,"hashes_with_success":0}' ;;
                 *distinct_request_hashes*) echo '{"error_requests":3,"qa_records":3,"distinct_request_hashes":2}' ;;
-                *COALESCE\(q.capture_status*) echo '{"capture_status":"captured","rows":3}' ;;
-                *"SELECT DISTINCT q.request_id, q.blob_uri"*)
-                  printf 'r1\tfile:///app/data/qa_blobs/r1.zst\n'
-                  printf 'r2\tfile:///app/data/qa_blobs/r2.zst\n'
+                *LATERAL*COALESCE\(capture_status*) echo '{"capture_status":"captured","rows":3}' ;;
+                *COALESCE\(q.capture_status*) echo '{"capture_status":"stale-query","rows":99}' ;;
+                *request_blob_uri*response_blob_uri*stream_blob_uri*"SELECT DISTINCT refs.request_id, refs.blob_uri"*)
+                  printf 'r1\tfile:///app/data/qa_blobs/r1-request.zst\n'
+                  printf 'r1\tfile:///app/data/qa_blobs/r1-response.zst\n'
+                  printf 'r2\thttps://s3.example/r2.zst\n'
                   ;;
               esac
               exit 0
@@ -66,7 +68,7 @@ class QAErrorEvidenceProbeTest(unittest.TestCase):
         self.assertIn('"hashes_with_success":0', proc.stdout)
         self.assertIn('"capture_status":"captured"', proc.stdout)
         self.assertIn(
-            '{"local_refs":2,"local_present":1,"local_missing":1,"remote_refs":0}',
+            '{"local_refs":2,"local_present":1,"local_missing":1,"remote_refs":1}',
             proc.stdout,
         )
         self.assertNotIn("qa_blobs/r1", proc.stdout)


### PR DESCRIPTION
## Summary

Extract the independent operations observability work from superseded PR #1398.

- Include upstream event `reason` and bounded `message` in triage output.
- Expand request-shape fallback samples with request metadata, event reasons, and upstream request-body presence counts.
- Add the read-only QA evidence coverage/replay/blob-presence probe and regression tests.
- Update the online troubleshooting skill index.

This PR intentionally contains no Kiro gateway, failover, relay-marker, account-penalty, or sentinel behavior. PR #1407 is the sole implementation for `CONTENT_FILTERED` terminal handling.

## Validation

- `bash -n ops/observability/ops-error-triage.sh ops/observability/probe-ops-error-request-shape.sh ops/observability/probe-qa-error-evidence.sh`
- `python3 -m unittest ops.observability.test_ops_error_triage ops.observability.test_probe_qa_error_evidence -v`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

Closes the observability portion of #1398 without bringing back its superseded silent-refusal failover behavior.
