### PR TITLE
fix(gemini): 修复新 Vertex Flash 模型的 global 路由

### DIFF
--- a/backend/internal/service/gateway_bridge_dispatch.go
+++ b/backend/internal/service/gateway_bridge_dispatch.go
@@ -96,7 +96,7 @@ func (s *GatewayService) ForwardAsChatCompletionsDispatched(
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
 	body = rewriteNewAPIBridgeBodyModel(account, body, "")
 	auth := bridgeAuthFromGin(c)
-	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
+	in := newAPIBridgeChannelInputForBody(account, auth.UserID, auth.GroupName, body)
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()
 		return nil, &NewAPIRelayError{Err: errBridgeMissingCredential("api_key")}
@@ -148,7 +148,7 @@ func (s *GatewayService) ForwardAsResponsesDispatched(
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
 	body = rewriteNewAPIBridgeBodyModel(account, body, "")
 	auth := bridgeAuthFromGin(c)
-	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
+	in := newAPIBridgeChannelInputForBody(account, auth.UserID, auth.GroupName, body)
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()
 		return nil, &NewAPIRelayError{Err: errBridgeMissingCredential("api_key")}

--- a/backend/internal/service/newapi_bridge_usage.go
+++ b/backend/internal/service/newapi_bridge_usage.go
@@ -9,6 +9,7 @@ import (
 	newapitypes "github.com/QuantumNous/new-api/types"
 	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
+	"github.com/tidwall/gjson"
 )
 
 // NewAPIRelayError wraps a New API adaptor error for handler-level JSON rendering.
@@ -60,6 +61,14 @@ func openAIUsageFromNewAPIDTO(u *dto.Usage) OpenAIUsage {
 }
 
 func newAPIBridgeChannelInput(account *Account, userID int64, groupLabel string) bridge.ChannelContextInput {
+	return newAPIBridgeChannelInputForModel(account, userID, groupLabel, "")
+}
+
+func newAPIBridgeChannelInputForBody(account *Account, userID int64, groupLabel string, body []byte) bridge.ChannelContextInput {
+	return newAPIBridgeChannelInputForModel(account, userID, groupLabel, gjson.GetBytes(body, "model").String())
+}
+
+func newAPIBridgeChannelInputForModel(account *Account, userID int64, groupLabel, model string) bridge.ChannelContextInput {
 	var mappingJSON string
 	if m := account.GetModelMapping(); len(m) > 0 {
 		if b, err := json.Marshal(m); err == nil {
@@ -95,7 +104,7 @@ func newAPIBridgeChannelInput(account *Account, userID int64, groupLabel string)
 		if saJSON := account.VertexServiceAccountJSON(); saJSON != "" {
 			apiKey = saJSON
 			vertexKeyType = string(dto.VertexKeyTypeJSON)
-			vertexLocation = account.VertexLocation("")
+			vertexLocation = account.VertexLocation(model)
 		}
 	}
 

--- a/backend/internal/service/newapi_bridge_usage_test.go
+++ b/backend/internal/service/newapi_bridge_usage_test.go
@@ -3,6 +3,8 @@ package service
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewAPIBridgeChannelInput_WiresForwardingCredentials pins the contract
@@ -128,6 +130,23 @@ func TestNewAPIBridgeChannelInput_VertexServiceAccount(t *testing.T) {
 	if in.APIKey != saJSON {
 		t.Fatalf("APIKey must carry the service-account JSON, got %q", in.APIKey)
 	}
+}
+
+func TestNewAPIBridgeChannelInputForBody_VertexUsesMappedModelLocation(t *testing.T) {
+	saJSON := `{"type":"service_account","project_id":"tk-proj","client_email":"x@tk-proj.iam.gserviceaccount.com","private_key":"-----BEGIN PRIVATE KEY-----\nAAA\n-----END PRIVATE KEY-----\n"}`
+	account := &Account{
+		ID:          9,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeServiceAccount,
+		ChannelType: 41,
+		Credentials: map[string]any{
+			"service_account_json": saJSON,
+			"location":             "us-central1",
+		},
+	}
+
+	in := newAPIBridgeChannelInputForBody(account, 1, "google", []byte(`{"model":"gemini-3.6-flash"}`))
+	require.Equal(t, vertexGlobalLocation, in.VertexLocation)
 }
 
 // TestNewAPIBridgeChannelInput_NonVertexUntouched ensures a non-vertex account (ch24,

--- a/backend/internal/service/openai_gateway_bridge_dispatch.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch.go
@@ -45,7 +45,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletionsDispatched(
 	body = rewriteNewAPIBridgeBodyModel(account, body, defaultMappedModel)
 	body = applyNewAPIQwenNonStreamingShape(gjson.GetBytes(body, "model").String(), body)
 	auth := bridgeAuthFromGin(c)
-	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
+	in := newAPIBridgeChannelInputForBody(account, auth.UserID, auth.GroupName, body)
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()
 		return nil, &NewAPIRelayError{Err: errBridgeMissingCredential("api_key")}
@@ -93,7 +93,7 @@ func dispatchNewAPIAccountTestChatCompletions(
 ) error {
 	recordBridgeDispatch()
 	body = rewriteNewAPIBridgeBodyModel(account, body, "")
-	in := newAPIBridgeChannelInput(account, 0, "")
+	in := newAPIBridgeChannelInputForBody(account, 0, "", body)
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()
 		return &NewAPIRelayError{Err: errBridgeMissingCredential("api_key")}
@@ -120,7 +120,7 @@ func (s *OpenAIGatewayService) ForwardAsResponsesDispatched(
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
 	body = rewriteNewAPIBridgeBodyModel(account, body, "")
 	auth := bridgeAuthFromGin(c)
-	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
+	in := newAPIBridgeChannelInputForBody(account, auth.UserID, auth.GroupName, body)
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()
 		return nil, &NewAPIRelayError{Err: errBridgeMissingCredential("api_key")}
@@ -193,7 +193,7 @@ func (s *OpenAIGatewayService) ForwardAsEmbeddingsDispatched(
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
 	body = rewriteNewAPIBridgeBodyModel(account, body, defaultMappedModel)
 	auth := bridgeAuthFromGin(c)
-	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
+	in := newAPIBridgeChannelInputForBody(account, auth.UserID, auth.GroupName, body)
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()
 		return nil, &NewAPIRelayError{Err: errBridgeMissingCredential("api_key")}
@@ -245,7 +245,7 @@ func (s *OpenAIGatewayService) ForwardAsImageGenerationsDispatched(
 	body = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, body, "")
 	body = rewriteNewAPIBridgeBodyModel(account, body, defaultMappedModel)
 	auth := bridgeAuthFromGin(c)
-	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
+	in := newAPIBridgeChannelInputForBody(account, auth.UserID, auth.GroupName, body)
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()
 		return nil, &NewAPIRelayError{Err: errBridgeMissingCredential("api_key")}

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
@@ -63,7 +63,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropicDispatched(
 	// 4. Prepare bridge channel input
 	chatBody = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, chatBody, upstreamModel)
 	auth := bridgeAuthFromGin(c)
-	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
+	in := newAPIBridgeChannelInputForBody(account, auth.UserID, auth.GroupName, chatBody)
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()
 		return nil, &NewAPIRelayError{Err: errBridgeMissingCredential("api_key")}

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping_test.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping_test.go
@@ -83,6 +83,47 @@ func TestForwardAsChatCompletionsDispatched_RewritesGLMDatedModelBeforeBridge(t 
 	}
 }
 
+func TestForwardAsChatCompletionsDispatched_VertexLocationUsesMappedModel(t *testing.T) {
+	oldDispatch := dispatchNewAPIChatCompletions
+	t.Cleanup(func() { dispatchNewAPIChatCompletions = oldDispatch })
+
+	var capturedInput bridge.ChannelContextInput
+	var capturedBody []byte
+	dispatchNewAPIChatCompletions = func(_ context.Context, _ *gin.Context, in bridge.ChannelContextInput, body []byte) (*bridge.DispatchOutcome, *newapitypes.NewAPIError) {
+		capturedInput = in
+		capturedBody = append([]byte(nil), body...)
+		return &bridge.DispatchOutcome{Model: "gemini-3.6-flash"}, nil
+	}
+
+	account := &Account{
+		ID:          47,
+		Platform:    PlatformNewAPI,
+		ChannelType: 41,
+		Type:        AccountTypeServiceAccount,
+		Credentials: map[string]any{
+			"service_account_json": `{"type":"service_account","project_id":"tk-proj","client_email":"x@tk-proj.iam.gserviceaccount.com","private_key":"test"}`,
+			"location":             "us-central1",
+			"model_mapping": map[string]any{
+				"gemini-next": "gemini-3.6-flash",
+			},
+		},
+	}
+	svc := &OpenAIGatewayService{}
+	c, _ := gin.CreateTestContext(nil)
+	body := []byte(`{"model":"gemini-next","messages":[{"role":"user","content":"hi"}]}`)
+
+	_, err := svc.ForwardAsChatCompletionsDispatched(context.Background(), c, account, body, "", "")
+	if err != nil {
+		t.Fatalf("ForwardAsChatCompletionsDispatched: %v", err)
+	}
+	if model := gjson.GetBytes(capturedBody, "model").String(); model != "gemini-3.6-flash" {
+		t.Fatalf("bridge body model = %q, want gemini-3.6-flash", model)
+	}
+	if capturedInput.VertexLocation != vertexGlobalLocation {
+		t.Fatalf("bridge VertexLocation = %q, want %q", capturedInput.VertexLocation, vertexGlobalLocation)
+	}
+}
+
 func TestForwardAsChatCompletionsDispatched_QwenNonStreamingDisablesThinking(t *testing.T) {
 	oldDispatch := dispatchNewAPIChatCompletions
 	t.Cleanup(func() { dispatchNewAPIChatCompletions = oldDispatch })

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go
@@ -70,7 +70,7 @@ func (s *OpenAIGatewayService) ForwardAsVideoSubmitDispatched(
 	}
 	recordBridgeDispatch()
 	auth := bridgeAuthFromGin(c)
-	in := newAPIBridgeChannelInput(account, auth.UserID, auth.GroupName)
+	in := newAPIBridgeChannelInputForBody(account, auth.UserID, auth.GroupName, body)
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()
 		return nil, &NewAPIRelayError{Err: errBridgeMissingCredential("api_key")}

--- a/backend/internal/service/vertex_service_account.go
+++ b/backend/internal/service/vertex_service_account.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	vertexDefaultLocation         = "us-central1"
+	vertexGlobalLocation          = "global"
 	vertexDefaultTokenURL         = "https://oauth2.googleapis.com/token"
 	vertexCloudPlatformScope      = "https://www.googleapis.com/auth/cloud-platform"
 	vertexServiceAccountCacheSkew = 5 * time.Minute
@@ -83,6 +84,9 @@ func (a *Account) VertexLocation(model string) string {
 			}
 		}
 	}
+	if vertexModelUsesGlobalLocation(model) {
+		return vertexGlobalLocation
+	}
 	if v := strings.TrimSpace(a.GetCredential("location")); v != "" {
 		return v
 	}
@@ -90,6 +94,16 @@ func (a *Account) VertexLocation(model string) string {
 		return v
 	}
 	return vertexDefaultLocation
+}
+
+func vertexModelUsesGlobalLocation(model string) bool {
+	model = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(model), "models/"))
+	switch model {
+	case "gemini-3.5-flash-lite", "gemini-3.6-flash":
+		return true
+	default:
+		return false
+	}
 }
 
 // VertexServiceAccountJSON returns the raw service-account JSON string, whether the

--- a/backend/internal/service/vertex_service_account_test.go
+++ b/backend/internal/service/vertex_service_account_test.go
@@ -30,6 +30,25 @@ func TestBuildVertexGeminiURLUsesGlobalEndpointHost(t *testing.T) {
 	require.Equal(t, "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global/publishers/google/models/gemini-3-flash-preview:streamGenerateContent?alt=sse", got)
 }
 
+func TestVertexLocationUsesGlobalForGlobalOnlyGeminiModels(t *testing.T) {
+	account := &Account{Credentials: map[string]any{"location": "us-central1"}}
+
+	require.Equal(t, vertexGlobalLocation, account.VertexLocation("gemini-3.5-flash-lite"))
+	require.Equal(t, vertexGlobalLocation, account.VertexLocation("models/gemini-3.6-flash"))
+	require.Equal(t, "us-central1", account.VertexLocation("gemini-2.5-flash"))
+}
+
+func TestVertexLocationExplicitModelOverrideWins(t *testing.T) {
+	account := &Account{Credentials: map[string]any{
+		"location": "us-central1",
+		"vertex_model_locations": map[string]any{
+			"gemini-3.6-flash": "europe-west4",
+		},
+	}}
+
+	require.Equal(t, "europe-west4", account.VertexLocation("gemini-3.6-flash"))
+}
+
 func TestBuildVertexAnthropicURL(t *testing.T) {
 	got, err := buildVertexAnthropicURL("my-project", "us-east5", "claude-sonnet-4-5@20250929", false)
 	require.NoError(t, err)


### PR DESCRIPTION
## 摘要

- 修复 `gemini-3.6-flash` 与 `gemini-3.5-flash-lite` 已在 Vertex global 可用、但 NewAPI bridge 仍发往账号默认 `us-central1` 导致线上 404 的问题。
- bridge 从完成 `model_mapping` 后的请求体读取最终模型，并统一通过 `Account.VertexLocation` 选择 location。
- per-model 账号显式配置保持最高优先级；其他 Vertex 模型仍沿用账号默认 region。

## 风险

- 影响仅限 channel_type 41 的两个 global-only Gemini 模型；现有区域模型行为不变。
- no-web-impact：定价、模型列表与前端展示不变，本 PR 仅修复后端出站 location。
- sentinel-registry-reviewed：已复核 gateway/newapi sentinel，既有 owner 与注入锚点仍完整，无需新增 registry 条目。

## 验证

- `go test -tags=unit ./internal/service -count=1`
- `bash scripts/preflight.sh`
- 回归测试覆盖映射后模型选择 global、旧模型保留 us-central1、显式 per-model override 优先。

## 提交

- `f67606f73 fix(gemini): route global-only Vertex models correctly`
- 最新提交：f67606f73