### PR TITLE
fix(gemini): preserve public model across Antigravity relay

### DIFF
--- a/backend/internal/service/gemini_chat_completions_compat_service.go
+++ b/backend/internal/service/gemini_chat_completions_compat_service.go
@@ -83,10 +83,7 @@ func (s *GeminiMessagesCompatService) forwardClaudeBodyAsChatCompletions(
 		return nil, s.writeChatCompletionsError(c, http.StatusBadRequest, "invalid_request_error", "model is required")
 	}
 
-	mappedModel := req.Model
-	if account.Type == AccountTypeAPIKey || account.Type == AccountTypeServiceAccount {
-		mappedModel = account.GetMappedModel(req.Model)
-	}
+	mappedModel, requestModel := resolveGeminiForwardModels(account, req.Model)
 
 	// TK priced-serving gate (docs/approved/priced-or-it-doesnt-ship.md): reject
 	// unpriced models with a 404 BEFORE forward / stream start (SSE pre-flight).
@@ -120,6 +117,7 @@ func (s *GeminiMessagesCompatService) forwardClaudeBodyAsChatCompletions(
 	buildReq, requestIDHeader := s.buildGeminiChatCompletionsUpstreamRequestFunc(
 		account,
 		mappedModel,
+		requestModel,
 		geminiReq,
 		clientStream,
 		useUpstreamStream,
@@ -303,6 +301,7 @@ func (s *GeminiMessagesCompatService) forwardClaudeBodyAsChatCompletions(
 func (s *GeminiMessagesCompatService) buildGeminiChatCompletionsUpstreamRequestFunc(
 	account *Account,
 	mappedModel string,
+	requestModel string,
 	geminiReq []byte,
 	clientStream bool,
 	useUpstreamStream bool,
@@ -325,7 +324,7 @@ func (s *GeminiMessagesCompatService) buildGeminiChatCompletionsUpstreamRequestF
 			if clientStream {
 				action = "streamGenerateContent"
 			}
-			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), mappedModel, action)
+			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), requestModel, action)
 			if clientStream {
 				fullURL += "?alt=sse"
 			}

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -617,10 +617,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 			req.Model = mapped
 		}
 	}
-	mappedModel := req.Model
-	if account.Type == AccountTypeAPIKey || account.Type == AccountTypeServiceAccount {
-		mappedModel = account.GetMappedModel(req.Model)
-	}
+	mappedModel, requestModel := resolveGeminiForwardModels(account, req.Model)
 	// TK priced-serving gate (docs/approved/priced-or-it-doesnt-ship.md): reject
 	// unpriced models with a 404 BEFORE forward / stream start (SSE pre-flight).
 	// No-op unless account.Platform is in the enabled set (gemini ships first).
@@ -673,7 +670,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 			if req.Stream {
 				action = "streamGenerateContent"
 			}
-			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), mappedModel, action)
+			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), requestModel, action)
 			if req.Stream {
 				fullURL += "?alt=sse"
 			}
@@ -1182,10 +1179,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 	// `thoughtSignature` to avoid frequent INVALID_ARGUMENT 400s.
 	body = ensureGeminiFunctionCallThoughtSignatures(body)
 
-	mappedModel := originalModel
-	if account.Type == AccountTypeAPIKey || account.Type == AccountTypeServiceAccount {
-		mappedModel = account.GetMappedModel(originalModel)
-	}
+	mappedModel, requestModel := resolveGeminiForwardModels(account, originalModel)
 	// TK priced-serving gate (docs/approved/priced-or-it-doesnt-ship.md): reject unpriced
 	// models with a 404 BEFORE forward / stream start (SSE pre-flight). Native Gemini ingress
 	// (generateContent/streamGenerateContent) → Gemini 404 envelope. countTokens is EXEMPT
@@ -1231,7 +1225,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 				return nil, "", err
 			}
 
-			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), mappedModel, upstreamAction)
+			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), requestModel, upstreamAction)
 			if useUpstreamStream {
 				fullURL += "?alt=sse"
 			}

--- a/backend/internal/service/gemini_relay_model_tk.go
+++ b/backend/internal/service/gemini_relay_model_tk.go
@@ -1,0 +1,23 @@
+package service
+
+import "strings"
+
+// resolveGeminiForwardModels separates the final provider model from the model
+// used for the current HTTP hop. Antigravity API-key accounts with a base URL
+// are edge relays, so the edge must receive the public mapping key and apply
+// its own mapping before calling the provider.
+func resolveGeminiForwardModels(account *Account, requestedModel string) (mappedModel, requestModel string) {
+	mappedModel = requestedModel
+	if account != nil && (account.Type == AccountTypeAPIKey || account.Type == AccountTypeServiceAccount) {
+		mappedModel = account.GetMappedModel(requestedModel)
+	}
+
+	requestModel = mappedModel
+	if account != nil &&
+		account.Platform == PlatformAntigravity &&
+		account.Type == AccountTypeAPIKey &&
+		strings.TrimSpace(account.GetCredential("base_url")) != "" {
+		requestModel = requestedModel
+	}
+	return mappedModel, requestModel
+}

--- a/backend/internal/service/gemini_relay_model_tk_test.go
+++ b/backend/internal/service/gemini_relay_model_tk_test.go
@@ -1,0 +1,176 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveGeminiForwardModels_AntigravityRelayPreservesPublicModelForHop(t *testing.T) {
+	t.Parallel()
+
+	relay := &Account{
+		Platform: PlatformAntigravity,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://edge.example.com",
+			"model_mapping": map[string]any{
+				"gemini-3.6-flash": "gemini-3.6-flash-tiered",
+			},
+		},
+	}
+	mappedModel, requestModel := resolveGeminiForwardModels(relay, "gemini-3.6-flash")
+	require.Equal(t, "gemini-3.6-flash-tiered", mappedModel)
+	require.Equal(t, "gemini-3.6-flash", requestModel)
+}
+
+func TestResolveGeminiForwardModels_NonRelayUsesMappedModelForHop(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		account *Account
+	}{
+		{
+			name: "antigravity API key without relay base URL",
+			account: &Account{
+				Platform: PlatformAntigravity,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{"gemini-3.6-flash": "gemini-3.6-flash-tiered"},
+				},
+			},
+		},
+		{
+			name: "Gemini API key with custom base URL",
+			account: &Account{
+				Platform: PlatformGemini,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"base_url":      "https://gemini-proxy.example.com",
+					"model_mapping": map[string]any{"gemini-3.6-flash": "gemini-3.6-flash-tiered"},
+				},
+			},
+		},
+		{
+			name: "Vertex service account",
+			account: &Account{
+				Platform: PlatformGemini,
+				Type:     AccountTypeServiceAccount,
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{"gemini-3.6-flash": "gemini-3.6-flash-tiered"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mappedModel, requestModel := resolveGeminiForwardModels(tt.account, "gemini-3.6-flash")
+			require.Equal(t, "gemini-3.6-flash-tiered", mappedModel)
+			require.Equal(t, mappedModel, requestModel)
+		})
+	}
+}
+
+func TestGeminiCompat_AntigravityRelayUsesPublicModelAcrossIngresses(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		publicModel = "gemini-3.6-flash"
+		wireModel   = "gemini-3.6-flash-tiered"
+		wantURL     = "https://edge.example.com/antigravity/v1beta/models/gemini-3.6-flash:generateContent"
+	)
+
+	tests := []struct {
+		name       string
+		requestURL string
+		body       []byte
+		forward    func(*GeminiMessagesCompatService, *gin.Context, *Account, []byte) (*ForwardResult, error)
+	}{
+		{
+			name:       "messages",
+			requestURL: "/v1/messages",
+			body:       []byte(`{"model":"gemini-3.6-flash","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`),
+			forward: func(svc *GeminiMessagesCompatService, c *gin.Context, account *Account, body []byte) (*ForwardResult, error) {
+				return svc.Forward(context.Background(), c, account, body)
+			},
+		},
+		{
+			name:       "native",
+			requestURL: "/antigravity/v1beta/models/gemini-3.6-flash:generateContent",
+			body:       []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`),
+			forward: func(svc *GeminiMessagesCompatService, c *gin.Context, account *Account, body []byte) (*ForwardResult, error) {
+				return svc.ForwardNative(context.Background(), c, account, publicModel, "generateContent", false, body)
+			},
+		},
+		{
+			name:       "chat completions",
+			requestURL: "/v1/chat/completions",
+			body:       []byte(`{"model":"gemini-3.6-flash","messages":[{"role":"user","content":"hi"}]}`),
+			forward: func(svc *GeminiMessagesCompatService, c *gin.Context, account *Account, body []byte) (*ForwardResult, error) {
+				return svc.ForwardAsChatCompletions(context.Background(), c, account, body)
+			},
+		},
+		{
+			name:       "responses",
+			requestURL: "/v1/responses",
+			body:       []byte(`{"model":"gemini-3.6-flash","input":"hi"}`),
+			forward: func(svc *GeminiMessagesCompatService, c *gin.Context, account *Account, body []byte) (*ForwardResult, error) {
+				return svc.ForwardAsResponses(context.Background(), c, account, body)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpStub := &geminiCompatHTTPUpstreamStub{
+				response: &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body: io.NopCloser(strings.NewReader(
+						`{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1}}`,
+					)),
+				},
+			}
+			svc := &GeminiMessagesCompatService{httpUpstream: httpStub, cfg: &config.Config{}}
+			account := &Account{
+				ID:          61,
+				Platform:    PlatformAntigravity,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"api_key":  "relay-key",
+					"base_url": "https://edge.example.com",
+					"model_mapping": map[string]any{
+						publicModel: wireModel,
+					},
+				},
+			}
+
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, tt.requestURL, bytes.NewReader(tt.body))
+
+			result, err := tt.forward(svc, c, account, tt.body)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, publicModel, result.Model)
+			require.Equal(t, wireModel, result.UpstreamModel)
+			require.NotNil(t, httpStub.lastReq)
+			require.Equal(t, wantURL, httpStub.lastReq.URL.String())
+			require.NotContains(t, httpStub.lastReq.URL.String(), wireModel)
+		})
+	}
+}

--- a/backend/internal/service/gemini_responses_compat_service.go
+++ b/backend/internal/service/gemini_responses_compat_service.go
@@ -74,10 +74,7 @@ func (s *GeminiMessagesCompatService) forwardClaudeBodyAsResponses(
 		return nil, s.writeResponsesCompatError(c, http.StatusBadRequest, "invalid_request_error", "model is required")
 	}
 
-	mappedModel := req.Model
-	if account.Type == AccountTypeAPIKey || account.Type == AccountTypeServiceAccount {
-		mappedModel = account.GetMappedModel(req.Model)
-	}
+	mappedModel, requestModel := resolveGeminiForwardModels(account, req.Model)
 
 	// OpenAI /v1/responses ingress must keep OpenAI envelope on pricing-gate errors.
 	if !s.tkPricedServingGate(ctx, c, tkGateWireOpenAI, account.Platform, originalModel, originalModel) {
@@ -103,6 +100,7 @@ func (s *GeminiMessagesCompatService) forwardClaudeBodyAsResponses(
 	buildReq, requestIDHeader := s.buildGeminiChatCompletionsUpstreamRequestFunc(
 		account,
 		mappedModel,
+		requestModel,
 		geminiReq,
 		clientStream,
 		useUpstreamStream,

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -113,6 +113,52 @@
       "rationale": "Code Assist 429 fallback-model protection depends on upstream-file hooks plus precise reset-delay extraction. Forwarding must store resolved upstream Gemini model in context, upstream 429 handling must delegate to the TK companion before account-level SetRateLimited, and ParseGeminiRateLimitResetTime must keep structured RetryInfo retryDelay parsing. Dropping any of these reintroduces whole-account long cooldown when upstream already provides a short retry window. The handleGeminiUpstreamError fallback branch must route all Gemini OAuth accounts (google_one + aistudio OAuth + code_assist) through tier cooldown — only API Key accounts may fall through to PST-midnight reset (see upstream #641). Also locks the TkEnrichForbiddenMessage hook in writeGeminiMappedError's case-403 branch so the 403 client message keeps body-size context instead of regressing to the unhelpful default."
     },
     {
+      "path": "backend/internal/service/gemini_relay_model_tk.go",
+      "must_contain": [
+        "func resolveGeminiForwardModels(account *Account, requestedModel string) (mappedModel, requestModel string)",
+        "account.Platform == PlatformAntigravity",
+        "strings.TrimSpace(account.GetCredential(\"base_url\")) != \"\"",
+        "requestModel = requestedModel"
+      ],
+      "rationale": "Antigravity API-key accounts with a base URL are prod-to-edge relays. The relay hop must keep the public model key so the edge can apply its own canonical mapping; sending the prod-mapped wire target makes edge scheduling reject hidden targets such as gemini-3.6-flash-tiered before upstream. This companion owns that distinction while preserving mappedModel for provider attribution and every non-relay account."
+    },
+    {
+      "path": "backend/internal/service/gemini_relay_model_tk_test.go",
+      "must_contain": [
+        "TestResolveGeminiForwardModels_AntigravityRelayPreservesPublicModelForHop",
+        "TestResolveGeminiForwardModels_NonRelayUsesMappedModelForHop",
+        "TestGeminiCompat_AntigravityRelayUsesPublicModelAcrossIngresses"
+      ],
+      "rationale": "Regression coverage pins both sides of the relay boundary and the actual URL emitted by messages, native Gemini, Chat Completions, and Responses ingress. It also asserts that result attribution keeps the final tiered wire model while the current relay URL remains public."
+    },
+    {
+      "path": "backend/internal/service/gemini_messages_compat_service.go",
+      "must_contain": [
+        "mappedModel, requestModel := resolveGeminiForwardModels(account, req.Model)",
+        "mappedModel, requestModel := resolveGeminiForwardModels(account, originalModel)",
+        "strings.TrimRight(normalizedBaseURL, \"/\"), requestModel, action",
+        "strings.TrimRight(normalizedBaseURL, \"/\"), requestModel, upstreamAction"
+      ],
+      "rationale": "Load-bearing wiring for the Antigravity relay-model owner on Anthropic messages and native Gemini ingress. Both API-key URL builders must use requestModel, while OAuth/Vertex request bodies and ForwardResult keep mappedModel. Dropping either call site silently restores edge rejection on one ingress."
+    },
+    {
+      "path": "backend/internal/service/gemini_chat_completions_compat_service.go",
+      "must_contain": [
+        "mappedModel, requestModel := resolveGeminiForwardModels(account, req.Model)",
+        "mappedModel string,\n\trequestModel string,",
+        "strings.TrimRight(normalizedBaseURL, \"/\"), requestModel, action"
+      ],
+      "rationale": "Load-bearing wiring for OpenAI Chat Completions over the Gemini-native Antigravity relay. The shared upstream-request builder must receive both model identities and use only requestModel for the API-key URL, otherwise the hidden wire target is rejected by edge scheduling."
+    },
+    {
+      "path": "backend/internal/service/gemini_responses_compat_service.go",
+      "must_contain": [
+        "mappedModel, requestModel := resolveGeminiForwardModels(account, req.Model)",
+        "mappedModel,\n\t\trequestModel,"
+      ],
+      "rationale": "Load-bearing wiring for OpenAI Responses over the Gemini-native Antigravity relay. Responses shares the Chat Completions request builder and must pass its public relay-hop model separately from the final mapped provider model."
+    },
+    {
       "path": "backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit.go",
       "must_contain": [
         "withGeminiCodeAssistMappedModel",


### PR DESCRIPTION
## 摘要
- 修复 prod Antigravity API-key relay 将账号映射后的隐藏 wire ID 提前发送给 Edge，导致 Edge 调度拒绝的问题。
- 由共享 `resolveGeminiForwardModels` 同时持有最终上游模型与当前 HTTP hop 模型，统一覆盖 messages、Gemini native、Chat Completions、Responses。
- 将 helper、四条注入路径和行为测试登记到 gateway-tk sentinel，防止后续上游合并静默回归。

## 风险
- 仅 `platform=antigravity + type=apikey + base_url 非空` 的 Edge relay hop 改为发送公开模型 ID；直连 Gemini API key、OAuth、Vertex service account 保持原映射语义。
- `ForwardResult.UpstreamModel` 仍记录最终 wire ID，定价、catalog、Menu 与日志归因不变。
- no-web-impact：内部网关中继修复，不改变 Web、价格或公开模型契约。

## 验证
- `go test -tags=unit ./internal/service -run 'TestResolveGeminiForwardModels|TestGeminiCompat_AntigravityRelayUsesPublicModelAcrossIngresses|TestDefaultAntigravityModelMapping_Gemini36TieredBoundary' -count=1`
- `go test -tags=unit ./internal/service -count=1`
- `python3 scripts/sentinels/check-gateway-tk.py`
- `./scripts/preflight.sh`

## 提交
- `d286106aa fix(gemini): preserve public model across Antigravity relay`
- 最新提交：`d286106aa`