### PR TITLE
fix(admin): 修复 Antigravity 账号测试模型与空响应

### DIFF
--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -1085,21 +1085,15 @@ func (s *AccountTestService) reconcileOpenAI429State(ctx context.Context, accoun
 func (s *AccountTestService) testGeminiAccountConnection(c *gin.Context, account *Account, modelID string, prompt string) error {
 	ctx := c.Request.Context()
 
-	// Determine the model to use
-	testModelID := modelID
-	if testModelID == "" {
-		testModelID = geminicli.DefaultTestModel
+	requestedModelID := modelID
+	if requestedModelID == "" {
+		requestedModelID = geminicli.DefaultTestModel
 	}
 
-	// For static upstream credentials with model mapping, map the model
-	if account.Type == AccountTypeAPIKey || account.Type == AccountTypeServiceAccount {
-		mapping := account.GetModelMapping()
-		if len(mapping) > 0 {
-			if mappedModel, exists := mapping[testModelID]; exists {
-				testModelID = mappedModel
-			}
-		}
-	}
+	// Keep the client-facing ID across a prod -> Edge Antigravity relay hop.
+	// The Edge owns the final public-to-wire mapping; direct static upstream
+	// accounts still receive the mapped provider ID.
+	mappedModelID, requestModelID := resolveGeminiForwardModels(account, requestedModelID)
 
 	// Set SSE headers
 	c.Writer.Header().Set("Content-Type", "text/event-stream")
@@ -1109,7 +1103,7 @@ func (s *AccountTestService) testGeminiAccountConnection(c *gin.Context, account
 	c.Writer.Flush()
 
 	// Create test payload (Gemini format)
-	payload := createGeminiTestPayload(testModelID, prompt)
+	payload := createGeminiTestPayload(mappedModelID, prompt)
 
 	// Build request based on account type
 	var req *http.Request
@@ -1117,11 +1111,11 @@ func (s *AccountTestService) testGeminiAccountConnection(c *gin.Context, account
 
 	switch account.Type {
 	case AccountTypeAPIKey:
-		req, err = s.buildGeminiAPIKeyRequest(ctx, account, testModelID, payload)
+		req, err = s.buildGeminiAPIKeyRequest(ctx, account, requestModelID, payload)
 	case AccountTypeOAuth:
-		req, err = s.buildGeminiOAuthRequest(ctx, account, testModelID, payload)
+		req, err = s.buildGeminiOAuthRequest(ctx, account, requestModelID, payload)
 	case AccountTypeServiceAccount:
-		req, err = s.buildGeminiServiceAccountRequest(ctx, account, testModelID, payload)
+		req, err = s.buildGeminiServiceAccountRequest(ctx, account, requestModelID, payload)
 	default:
 		return s.sendErrorAndEnd(c, fmt.Sprintf("Unsupported account type: %s", account.Type))
 	}
@@ -1131,7 +1125,7 @@ func (s *AccountTestService) testGeminiAccountConnection(c *gin.Context, account
 	}
 
 	// Send test_start event
-	s.sendEvent(c, TestEvent{Type: "test_start", Model: testModelID})
+	s.sendEvent(c, TestEvent{Type: "test_start", Model: requestedModelID})
 
 	// Get proxy and execute request
 	proxyURL := ""
@@ -1196,13 +1190,19 @@ func (s *AccountTestService) testAntigravityAccountConnection(c *gin.Context, ac
 		return s.sendErrorAndEnd(c, err.Error())
 	}
 
-	// 发送响应内容
-	if result.Text != "" {
-		s.sendEvent(c, TestEvent{Type: "content", Text: result.Text})
-	}
-
-	s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+	s.completeAntigravityAccountTest(c, result.Text)
 	return nil
+}
+
+const antigravityEmptyTextStatus = "Connected successfully; upstream returned no text content."
+
+func (s *AccountTestService) completeAntigravityAccountTest(c *gin.Context, text string) {
+	if strings.TrimSpace(text) == "" {
+		s.sendEvent(c, TestEvent{Type: "status", Text: antigravityEmptyTextStatus})
+	} else {
+		s.sendEvent(c, TestEvent{Type: "content", Text: text})
+	}
+	s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
 }
 
 // buildGeminiAPIKeyRequest builds request for Gemini API Key accounts

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -1212,10 +1212,7 @@ func (s *AccountTestService) buildGeminiAPIKeyRequest(ctx context.Context, accou
 		return nil, fmt.Errorf("no API key available")
 	}
 
-	baseURL := account.GetCredential("base_url")
-	if baseURL == "" {
-		baseURL = geminicli.AIStudioBaseURL
-	}
+	baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)
 	normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/account_test_service_antigravity_test.go
+++ b/backend/internal/service/account_test_service_antigravity_test.go
@@ -4,8 +4,12 @@ package service
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,4 +34,41 @@ func TestMapAntigravityModel_LiveAccountAllowsOnlyLiveClaudeSubset(t *testing.T)
 func TestAntigravityDefaultTestModelID_IsGeminiWire(t *testing.T) {
 	require.True(t, len(AntigravityDefaultTestModelID) > len("gemini-"))
 	require.Contains(t, AntigravityDefaultTestModelID, "gemini-")
+}
+
+func TestBuildGeminiTestRequest_LeavesBudgetForVisibleText(t *testing.T) {
+	payload, err := (&AntigravityGatewayService{}).buildGeminiTestRequest("project-1", "gemini-3.6-flash-tiered")
+	require.NoError(t, err)
+
+	var wrapped struct {
+		Request struct {
+			Contents []struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"contents"`
+			GenerationConfig struct {
+				MaxOutputTokens int `json:"maxOutputTokens"`
+			} `json:"generationConfig"`
+		} `json:"request"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &wrapped))
+	require.Equal(t, defaultGeminiTextTestPrompt, wrapped.Request.Contents[0].Parts[0].Text)
+	require.Equal(t, antigravityConnectionTestMaxOutputTokens, wrapped.Request.GenerationConfig.MaxOutputTokens)
+	require.Greater(t, wrapped.Request.GenerationConfig.MaxOutputTokens, 1)
+}
+
+func TestCompleteAntigravityAccountTest_ReportsSuccessfulEmptyResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/5/test", nil)
+
+	(&AccountTestService{}).completeAntigravityAccountTest(ctx, "")
+
+	body := recorder.Body.String()
+	require.Contains(t, body, `"type":"status"`)
+	require.Contains(t, body, antigravityEmptyTextStatus)
+	require.Contains(t, body, `"type":"test_complete"`)
+	require.NotContains(t, body, `"type":"content"`)
 }

--- a/backend/internal/service/account_test_service_gemini_test.go
+++ b/backend/internal/service/account_test_service_gemini_test.go
@@ -4,12 +4,31 @@ package service
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+type geminiAccountTestUpstream struct {
+	request  *http.Request
+	response *http.Response
+}
+
+func (u *geminiAccountTestUpstream) Do(req *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+	u.request = req
+	return u.response, nil
+}
+
+func (u *geminiAccountTestUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, concurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, concurrency)
+}
 
 func TestCreateGeminiTestPayload_ImageModel(t *testing.T) {
 	t.Parallel()
@@ -56,4 +75,58 @@ func TestProcessGeminiStream_EmitsImageEvent(t *testing.T) {
 	require.Contains(t, body, "\"type\":\"image\"")
 	require.Contains(t, body, "\"image_url\":\"data:image/png;base64,QUJD\"")
 	require.Contains(t, body, "\"mime_type\":\"image/png\"")
+}
+
+func TestGeminiAccountConnection_UsesPublicModelOnlyForAntigravityRelayHop(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		publicModel = "gemini-3.6-flash"
+		wireModel   = "gemini-3.6-flash-tiered"
+	)
+	tests := []struct {
+		name         string
+		platform     string
+		wantURLModel string
+	}{
+		{name: "Antigravity Edge relay", platform: PlatformAntigravity, wantURLModel: publicModel},
+		{name: "direct Gemini API key", platform: PlatformGemini, wantURLModel: wireModel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := &geminiAccountTestUpstream{
+				response: &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}]}\n\n",
+					)),
+				},
+			}
+			svc := &AccountTestService{httpUpstream: upstream, cfg: &config.Config{}}
+			account := &Account{
+				ID:          61,
+				Platform:    tt.platform,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"api_key":  "test-key",
+					"base_url": "https://edge.example.com",
+					"model_mapping": map[string]any{
+						publicModel: wireModel,
+					},
+				},
+			}
+			recorder := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(recorder)
+			ctx.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/61/test", nil)
+
+			require.NoError(t, svc.testGeminiAccountConnection(ctx, account, publicModel, "hi"))
+			require.NotNil(t, upstream.request)
+			require.Contains(t, upstream.request.URL.Path, "/models/"+tt.wantURLModel+":streamGenerateContent")
+			require.NotContains(t, recorder.Body.String(), "\"model\":\""+wireModel+"\"")
+			require.Contains(t, recorder.Body.String(), "\"model\":\""+publicModel+"\"")
+			require.Contains(t, recorder.Body.String(), "\"text\":\"ok\"")
+		})
+	}
 }

--- a/backend/internal/service/account_test_service_gemini_test.go
+++ b/backend/internal/service/account_test_service_gemini_test.go
@@ -85,12 +85,20 @@ func TestGeminiAccountConnection_UsesPublicModelOnlyForAntigravityRelayHop(t *te
 		wireModel   = "gemini-3.6-flash-tiered"
 	)
 	tests := []struct {
-		name         string
-		platform     string
-		wantURLModel string
+		name     string
+		platform string
+		wantPath string
 	}{
-		{name: "Antigravity Edge relay", platform: PlatformAntigravity, wantURLModel: publicModel},
-		{name: "direct Gemini API key", platform: PlatformGemini, wantURLModel: wireModel},
+		{
+			name:     "Antigravity Edge relay",
+			platform: PlatformAntigravity,
+			wantPath: "/antigravity/v1beta/models/" + publicModel + ":streamGenerateContent",
+		},
+		{
+			name:     "direct Gemini API key",
+			platform: PlatformGemini,
+			wantPath: "/v1beta/models/" + wireModel + ":streamGenerateContent",
+		},
 	}
 
 	for _, tt := range tests {
@@ -123,7 +131,8 @@ func TestGeminiAccountConnection_UsesPublicModelOnlyForAntigravityRelayHop(t *te
 
 			require.NoError(t, svc.testGeminiAccountConnection(ctx, account, publicModel, "hi"))
 			require.NotNil(t, upstream.request)
-			require.Contains(t, upstream.request.URL.Path, "/models/"+tt.wantURLModel+":streamGenerateContent")
+			require.Equal(t, tt.wantPath, upstream.request.URL.Path)
+			require.Equal(t, "sse", upstream.request.URL.Query().Get("alt"))
 			require.NotContains(t, recorder.Body.String(), "\"model\":\""+wireModel+"\"")
 			require.Contains(t, recorder.Body.String(), "\"model\":\""+publicModel+"\"")
 			require.Contains(t, recorder.Body.String(), "\"text\":\"ok\"")

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -343,6 +343,8 @@ type TestConnectionResult struct {
 	MappedModel string // 实际使用的模型
 }
 
+const antigravityConnectionTestMaxOutputTokens = 64
+
 // TestConnection 测试 Antigravity 账号连接。
 // 复用 antigravityRetryLoop 的完整重试 / credits overages / 智能重试逻辑，
 // 与真实调度行为一致。差异：不做账号切换（测试指定账号）、不记录 ops 错误。
@@ -445,14 +447,15 @@ func testConnectionHandleError(
 }
 
 // buildGeminiTestRequest 构建 Gemini 格式测试请求
-// 使用最小 token 消耗：输入 "." + maxOutputTokens: 1
+// Keep the probe small while leaving enough output budget for thinking-capable
+// Gemini models to produce visible text.
 func (s *AntigravityGatewayService) buildGeminiTestRequest(projectID, model string) ([]byte, error) {
 	payload := map[string]any{
 		"contents": []map[string]any{
 			{
 				"role": "user",
 				"parts": []map[string]any{
-					{"text": "."},
+					{"text": defaultGeminiTextTestPrompt},
 				},
 			},
 		},
@@ -463,7 +466,7 @@ func (s *AntigravityGatewayService) buildGeminiTestRequest(projectID, model stri
 			},
 		},
 		"generationConfig": map[string]any{
-			"maxOutputTokens": 1,
+			"maxOutputTokens": antigravityConnectionTestMaxOutputTokens,
 		},
 	}
 	payloadBytes, _ := json.Marshal(payload)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -132,6 +132,32 @@
       "rationale": "Regression coverage pins both sides of the relay boundary and the actual URL emitted by messages, native Gemini, Chat Completions, and Responses ingress. It also asserts that result attribution keeps the final tiered wire model while the current relay URL remains public."
     },
     {
+      "path": "backend/internal/service/account_test_service.go",
+      "must_contain": [
+        "mappedModelID, requestModelID := resolveGeminiForwardModels(account, requestedModelID)",
+        "s.buildGeminiAPIKeyRequest(ctx, account, requestModelID, payload)",
+        "s.sendEvent(c, TestEvent{Type: \"test_start\", Model: requestedModelID})",
+        "s.completeAntigravityAccountTest(c, result.Text)",
+        "TestEvent{Type: \"status\", Text: antigravityEmptyTextStatus}"
+      ],
+      "rationale": "Admin account tests share the same public-model relay boundary as production Gemini ingress. The prod-to-Edge request URL must use requestModelID while the operator-visible test_start event keeps requestedModelID; otherwise selecting gemini-3.6-flash is rewritten to the hidden gemini-3.6-flash-tiered target and rejected by the Edge Anthropic namespace. Successful Antigravity OAuth probes with no extracted text must also emit a visible status instead of completing with a blank response."
+    },
+    {
+      "path": "backend/internal/service/account_test_service_gemini_test.go",
+      "must_contain": [
+        "TestGeminiAccountConnection_UsesPublicModelOnlyForAntigravityRelayHop"
+      ],
+      "rationale": "Regression coverage proves the admin account-test URL keeps the public Gemini ID only for Antigravity Edge relays while direct Gemini API-key accounts still receive the mapped provider wire ID."
+    },
+    {
+      "path": "backend/internal/service/account_test_service_antigravity_test.go",
+      "must_contain": [
+        "TestBuildGeminiTestRequest_LeavesBudgetForVisibleText",
+        "TestCompleteAntigravityAccountTest_ReportsSuccessfulEmptyResponse"
+      ],
+      "rationale": "Regression coverage keeps the Antigravity Gemini connection probe large enough for thinking-capable models to emit visible text and requires an explicit status event if a successful upstream response still contains no text."
+    },
+    {
       "path": "backend/internal/service/gemini_messages_compat_service.go",
       "must_contain": [
         "mappedModel, requestModel := resolveGeminiForwardModels(account, req.Model)",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -136,18 +136,19 @@
       "must_contain": [
         "mappedModelID, requestModelID := resolveGeminiForwardModels(account, requestedModelID)",
         "s.buildGeminiAPIKeyRequest(ctx, account, requestModelID, payload)",
+        "baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)",
         "s.sendEvent(c, TestEvent{Type: \"test_start\", Model: requestedModelID})",
         "s.completeAntigravityAccountTest(c, result.Text)",
         "TestEvent{Type: \"status\", Text: antigravityEmptyTextStatus}"
       ],
-      "rationale": "Admin account tests share the same public-model relay boundary as production Gemini ingress. The prod-to-Edge request URL must use requestModelID while the operator-visible test_start event keeps requestedModelID; otherwise selecting gemini-3.6-flash is rewritten to the hidden gemini-3.6-flash-tiered target and rejected by the Edge Anthropic namespace. Successful Antigravity OAuth probes with no extracted text must also emit a visible status instead of completing with a blank response."
+      "rationale": "Admin account tests share the same public-model relay boundary and Gemini base-URL owner as production ingress. The prod-to-Edge request URL must use the /antigravity namespace with requestModelID while the operator-visible test_start event keeps requestedModelID; otherwise selecting gemini-3.6-flash reaches the Edge Anthropic namespace or is rewritten to the hidden gemini-3.6-flash-tiered target before Edge scheduling. Successful Antigravity OAuth probes with no extracted text must also emit a visible status instead of completing with a blank response."
     },
     {
       "path": "backend/internal/service/account_test_service_gemini_test.go",
       "must_contain": [
         "TestGeminiAccountConnection_UsesPublicModelOnlyForAntigravityRelayHop"
       ],
-      "rationale": "Regression coverage proves the admin account-test URL keeps the public Gemini ID only for Antigravity Edge relays while direct Gemini API-key accounts still receive the mapped provider wire ID."
+      "rationale": "Regression coverage proves the admin account-test URL uses the Antigravity namespace with the public Gemini ID for Edge relays while direct Gemini API-key accounts stay in the root namespace with the mapped provider wire ID."
     },
     {
       "path": "backend/internal/service/account_test_service_antigravity_test.go",


### PR DESCRIPTION
## 摘要
- 修复 prod Antigravity API-key relay 账号测试过早把公开模型 `gemini-3.6-flash` 映射成内部 wire ID `gemini-3.6-flash-tiered`，导致 Edge 在 Anthropic namespace 调度前拒绝请求的问题。
- 账号测试复用生产转发的 `resolveGeminiForwardModels` SSOT：prod→Edge 使用公开 ID，直连 Gemini API-key / Vertex 仍使用映射后的 provider ID。
- Antigravity OAuth 连接探针从 1 token 的极小输出预算调整为 64 token，并使用真实 `hi` 输入；若上游 2xx 仍无文本，SSE 明确输出成功但无文本的状态，不再显示空白响应。
- 将新增承重接线和回归测试登记到 `gateway-tk` sentinel。未部署，未执行生产或 Edge 写操作。

## 风险
- 低风险、局部账号测试行为修复，不改变公开 API/SSE 事件契约。
- OAuth 连接探针单次最大输出从 1 增至 64 token，仍是小额诊断请求；换取思考型 Gemini 模型可见文本。
- no-web-impact: 现有两个 `AccountTestModal` 已共同消费 `content/status/test_complete`，无需前端代码或契约变更。

## 验证
- `go test -tags=unit ./internal/service ./internal/handler/admin`
- 聚焦回归：relay 公开 ID、直连 wire ID、OAuth 文本预算、空文本状态、admin Antigravity 模型列表
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`
- `python3 scripts/sentinels/check-registry-update-gate.py`
- `./scripts/preflight.sh`

## 提交
- `246c510f7 fix(admin): preserve public Gemini IDs in account tests`

最新提交：`246c510f7`