### PR TITLE
fix(usage): 将取消的 Dashboard 查询归类为 499

### DIFF
--- a/backend/internal/handler/admin/ops_realtime_handler.go
+++ b/backend/internal/handler/admin/ops_realtime_handler.go
@@ -1,14 +1,13 @@
 package admin
 
 import (
-	"context"
-	"errors"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 )
@@ -168,16 +167,7 @@ func (h *OpsHandler) GetAccountAvailability(c *gin.Context) {
 }
 
 func isOpsRealtimeRequestCanceled(c *gin.Context, err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, context.Canceled) {
-		return true
-	}
-	if c != nil && c.Request != nil && errors.Is(c.Request.Context().Err(), context.Canceled) {
-		return true
-	}
-	return strings.Contains(err.Error(), "canceling statement due to user request")
+	return middleware2.IsClientClosedRequestError(c, err)
 }
 
 func parseOpsRealtimeWindow(v string) (time.Duration, string, bool) {

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -664,6 +664,10 @@ func (h *UsageHandler) DashboardAPIKeysUsage(c *gin.Context) {
 
 	validAPIKeyIDs, err := h.apiKeyService.VerifyOwnership(c.Request.Context(), subject.UserID, req.APIKeyIDs)
 	if err != nil {
+		if middleware2.IsClientClosedRequestError(c, err) {
+			middleware2.AbortClientClosedRequest(c, err)
+			return
+		}
 		response.ErrorFrom(c, err)
 		return
 	}
@@ -682,6 +686,10 @@ func (h *UsageHandler) DashboardAPIKeysUsage(c *gin.Context) {
 
 	stats, err := h.usageService.GetBatchAPIKeyUsageStats(c.Request.Context(), validAPIKeyIDs, startTime, endTime)
 	if err != nil {
+		if middleware2.IsClientClosedRequestError(c, err) {
+			middleware2.AbortClientClosedRequest(c, err)
+			return
+		}
 		response.ErrorFrom(c, err)
 		return
 	}

--- a/backend/internal/handler/usage_handler_dashboard_cancel_test.go
+++ b/backend/internal/handler/usage_handler_dashboard_cancel_test.go
@@ -1,0 +1,79 @@
+//go:build unit
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type dashboardCancelAPIKeyRepo struct {
+	service.APIKeyRepository
+}
+
+func (dashboardCancelAPIKeyRepo) VerifyOwnership(_ context.Context, _ int64, apiKeyIDs []int64) ([]int64, error) {
+	return apiKeyIDs, nil
+}
+
+type dashboardCancelUsageRepo struct {
+	service.UsageLogRepository
+	err error
+}
+
+func (r dashboardCancelUsageRepo) GetBatchAPIKeyUsageStats(
+	_ context.Context,
+	_ []int64,
+	_, _ time.Time,
+) (map[int64]*usagestats.BatchAPIKeyUsageStats, error) {
+	return nil, r.err
+}
+
+func runDashboardAPIKeysUsageErrorTest(t *testing.T, queryErr error) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	apiKeyService := service.NewAPIKeyService(
+		dashboardCancelAPIKeyRepo{}, nil, nil, nil, nil, nil, &config.Config{},
+	)
+	usageService := service.NewUsageService(dashboardCancelUsageRepo{err: queryErr}, nil, nil, nil)
+	h := NewUsageHandler(usageService, apiKeyService, nil, nil)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/usage/dashboard/api-keys-usage",
+		bytes.NewBufferString(`{"api_key_ids":[9]}`),
+	)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 7})
+
+	h.DashboardAPIKeysUsage(c)
+	return recorder
+}
+
+func TestDashboardAPIKeysUsage_PostgresCallerCancellationReturns499(t *testing.T) {
+	recorder := runDashboardAPIKeysUsageErrorTest(t, errors.New("pq: canceling statement due to user request"))
+
+	require.Equal(t, middleware2.StatusClientClosedRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "CLIENT_CLOSED_REQUEST")
+}
+
+func TestDashboardAPIKeysUsage_DatabaseFailureRemains500(t *testing.T) {
+	recorder := runDashboardAPIKeysUsageErrorTest(t, errors.New("database unavailable"))
+
+	require.Equal(t, http.StatusInternalServerError, recorder.Code)
+	require.NotContains(t, recorder.Body.String(), "database unavailable")
+}

--- a/backend/internal/server/middleware/middleware.go
+++ b/backend/internal/server/middleware/middleware.go
@@ -15,6 +15,8 @@ import (
 
 const middlewareInternalErrorDetailMaxLen = 1024
 
+const postgresCanceledByCallerMessage = "canceling statement due to user request"
+
 // StatusClientClosedRequest mirrors nginx's 499: the caller disconnected before
 // the gateway could finish local auth/body handling. net/http has no constant.
 const StatusClientClosedRequest = 499
@@ -114,13 +116,25 @@ func AbortClientClosedRequest(c *gin.Context, internalErr error) {
 }
 
 func IsClientClosedRequestError(c *gin.Context, err error) bool {
+	// A server-side deadline is not caller-owned even when the database driver
+	// reports a cancellation while unwinding the query.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
 	if errors.Is(err, context.Canceled) {
 		return true
 	}
-	if c == nil || c.Request == nil {
-		return false
+	if c != nil && c.Request != nil {
+		switch requestErr := c.Request.Context().Err(); {
+		case errors.Is(requestErr, context.DeadlineExceeded):
+			return false
+		case errors.Is(requestErr, context.Canceled):
+			return true
+		}
 	}
-	return errors.Is(c.Request.Context().Err(), context.Canceled)
+	// lib/pq returns a PostgreSQL 57014 error instead of wrapping
+	// context.Canceled after database/sql sends the cancellation request.
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), postgresCanceledByCallerMessage)
 }
 
 // sanitizeMiddlewareInternalErrorDetail trims and length-caps an internal error

--- a/backend/internal/server/middleware/middleware_internal_error_detail_test.go
+++ b/backend/internal/server/middleware/middleware_internal_error_detail_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -67,6 +68,21 @@ func TestAbortClientClosedRequest_SetsOpsMarkerAndDetail(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "context canceled", v)
 	require.Contains(t, rec.Body.String(), "CLIENT_CLOSED_REQUEST")
+}
+
+func TestIsClientClosedRequestError_PostgresCancellation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/usage/dashboard/api-keys-usage", nil)
+
+	require.True(t, IsClientClosedRequestError(c, errors.New("pq: canceling statement due to user request")))
+	require.False(t, IsClientClosedRequestError(c, errors.New("pq: canceling statement due to statement timeout")))
+
+	deadlineCtx, cancel := context.WithDeadline(context.Background(), time.Unix(1, 0))
+	defer cancel()
+	c.Request = c.Request.WithContext(deadlineCtx)
+	require.False(t, IsClientClosedRequestError(c, errors.New("pq: canceling statement due to user request")),
+		"server-side deadlines must remain platform errors")
 }
 
 func TestAPIKeyAuth_500_SetsOpsInternalErrorDetail(t *testing.T) {


### PR DESCRIPTION
## 摘要

- 将 lib/pq 返回的 `canceling statement due to user request` 纳入已有 caller-cancel 单一判定。
- 用户 API Key Dashboard 的 ownership/usage 查询在客户端取消时返回 499，不再误记为 500。
- Admin 实时统计复用同一判定，移除重复的取消字符串逻辑。

## 风险

- 低风险：只改变已取消请求的终态分类；`context deadline exceeded` 和真实数据库错误仍保持平台错误/500。
- Web impact: none。客户端已经断开，没有可见响应变化。
- sentinel-registry-reviewed：已核对 middleware 变更未新增、删除或迁移 load-bearing 路由/注入点，无需新增 sentinel anchor。
- upstream-touch-trivial：唯一未被 sentinel 固定的 upstream-shaped 改动只是让 Admin helper 委托既有共享判定；即使被上游覆盖，也只恢复原重复实现，不影响本 PR 的用户 Dashboard 修复。

## 验证

- `go test -tags=unit ./internal/server/middleware ./internal/handler -count=1`
- `./scripts/preflight.sh`
- 线上只读复核：最近 1 小时 3,391 成功、27 个客户端错误、0 个 SLA 错误，SLA 100%；唯一 access-log 5xx 是本修复对应的历史 Dashboard 取消误报。

## 提交

- `03b3a34ca fix(usage): classify canceled dashboard queries as 499`

最新提交：`03b3a34ca`