### PR TITLE
fix(grok): 恢复 Chat Completions entitlement 403 守卫

### DIFF
--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -88,11 +88,11 @@ func (s *OpenAIGatewayService) failoverOpenAIUpstreamHTTPError(
 	upstreamMsg string,
 	upstreamModel string,
 ) *UpstreamFailoverError {
-	if account != nil && account.Platform == PlatformGrok {
-		s.handleGrokAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
-	}
 	if !s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMsg, respBody) {
 		return nil
+	}
+	if account != nil && account.Platform == PlatformGrok {
+		s.handleGrokAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 	}
 	upstreamDetail := ""
 	if s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody {

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -73,11 +73,9 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		return nil, err
 	}
 
-	// Grok（第七平台）：xAI/edge relay 走标准 OpenAI /v1/chat/completions，绝不经
-	// CC→Responses→Codex 转换（那条路写死 chatgpt.com/codex + chatgpt 专属头）。
-	// Grok OAuth 与 Grok API-key relay 都在 codex transform 之前分流到 raw 直转。
-	// 入口分流：APIKey 账号 + 强制或已探测确认上游不支持 Responses，走 CC 直转。
-	// 自动模式下标记缺失（未探测）按"现状即证据"原则继续走下方原 Responses 转换路径。
+	// Grok（第七平台）在 Codex transform 前进入专用 bridge：兼容且可缓存的
+	// grok-4.5 请求走 xAI /responses，其余请求走原生 /v1/chat/completions。
+	// 两条路径都不经过写死 chatgpt.com/codex 与 ChatGPT 专属头的 Codex 转换。
 	if account.IsGrok() {
 		return s.forwardGrokChatCompletionsViaResponses(ctx, c, account, body, promptCacheKey, defaultMappedModel)
 	}

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -185,6 +185,9 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	if resp.StatusCode >= 400 {
 		respBody, upstreamMsg := s.readOpenAIUpstreamError(resp)
 		if account.Platform == PlatformGrok {
+			if tkIsGrokEntitlement403(resp.StatusCode, respBody) {
+				return s.handleChatCompletionsErrorResponse(resp, c, account, billingModel)
+			}
 			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 				Platform:           account.Platform,
 				AccountID:          account.ID,

--- a/backend/internal/service/openai_gateway_grok_chat_bridge.go
+++ b/backend/internal/service/openai_gateway_grok_chat_bridge.go
@@ -336,6 +336,9 @@ func (s *OpenAIGatewayService) forwardGrokChatCompletionsViaResponses(
 		if upstreamMsg == "" {
 			upstreamMsg = fmt.Sprintf("xAI upstream returned status %d", resp.StatusCode)
 		}
+		if tkIsGrokEntitlement403(resp.StatusCode, respBody) {
+			return s.handleChatCompletionsErrorResponse(resp, c, account, billingModel)
+		}
 		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 			Platform:           account.Platform,
 			AccountID:          account.ID,

--- a/backend/internal/service/openai_gateway_grok_chat_bridge_test.go
+++ b/backend/internal/service/openai_gateway_grok_chat_bridge_test.go
@@ -352,6 +352,75 @@ func TestForwardGrokRawChat429PreservesRetryAfter(t *testing.T) {
 	require.Equal(t, xai.DefaultCLIBaseURL+"/chat/completions", upstream.lastReq.URL.String())
 }
 
+func TestForwardGrokChatEntitlement403DoesNotFailoverOrCoolAccount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		body         []byte
+		wantUpstream string
+	}{
+		{
+			name:         "responses bridge",
+			body:         []byte(`{"model":"grok","messages":[{"role":"user","content":"hi"}],"stream":false}`),
+			wantUpstream: xai.DefaultCLIBaseURL + "/responses",
+		},
+		{
+			name:         "raw chat completions",
+			body:         []byte(`{"model":"grok","messages":[{"role":"user","content":"hi"}],"stream":false,"stop":"done"}`),
+			wantUpstream: xai.DefaultCLIBaseURL + "/chat/completions",
+		},
+	}
+
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, grokChatRawEndpoint, bytes.NewReader(tt.body))
+			c.Set("api_key", &APIKey{ID: int64(7561 + index)})
+
+			account := grokChatBridgeTestAccount(int64(756 + index))
+			repo := &grokQuotaAccountRepo{mockAccountRepoForPlatform: &mockAccountRepoForPlatform{
+				accountsByID: map[int64]*Account{account.ID: account},
+			}}
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusForbidden,
+				Header: http.Header{
+					"Content-Type":   []string{"application/json"},
+					"Xai-Request-Id": []string{"xai-entitlement-403"},
+				},
+				Body: io.NopCloser(strings.NewReader(
+					`{"code":"forbidden","error":"You have either run out of available resources or do not have an active Grok subscription."}`,
+				)),
+			}}
+			svc := &OpenAIGatewayService{
+				httpUpstream:      upstream,
+				grokTokenProvider: NewGrokTokenProvider(repo, nil),
+				accountRepo:       repo,
+			}
+
+			result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, tt.body, "", "")
+
+			require.Error(t, err)
+			require.Nil(t, result)
+			var failoverErr *UpstreamFailoverError
+			require.False(t, errors.As(err, &failoverErr), "entitlement 403 must be terminal for this request")
+			require.Equal(t, tt.wantUpstream, upstream.lastReq.URL.String())
+			require.Equal(t, http.StatusForbidden, recorder.Code)
+			require.Equal(t, "permission_error", gjson.Get(recorder.Body.String(), "error.type").String())
+			require.Contains(t, gjson.Get(recorder.Body.String(), "error.message").String(), "SuperGrok Heavy")
+			require.Zero(t, repo.tempUnschedCalls)
+			require.False(t, svc.isOpenAIAccountRuntimeBlocked(account))
+
+			events := openAICompatOpsEvents(t, c)
+			require.Len(t, events, 1)
+			require.Equal(t, "http_error", events[0].Kind)
+			require.Equal(t, http.StatusForbidden, events[0].UpstreamStatusCode)
+			require.Equal(t, "xai-entitlement-403", events[0].UpstreamRequestID)
+		})
+	}
+}
+
 func TestForwardGrokRawChatErrorRecordsActualEndpoint(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -232,6 +232,11 @@ func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode i
 	if tkIsCapabilityScope401(statusCode, upstreamBody) {
 		return false
 	}
+	// A Grok entitlement 403 is terminal for the request. Retrying other
+	// accounts only cools the pool until routing reports no available accounts.
+	if tkIsGrokEntitlement403(statusCode, upstreamBody) {
+		return false
+	}
 	if s.shouldFailoverUpstreamError(statusCode) {
 		return true
 	}
@@ -327,6 +332,26 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 	}
 	setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, upstreamDetail)
 	logOpenAIInstructionsRequiredDebug(ctx, c, account, resp.StatusCode, upstreamMsg, requestBody, body)
+	if account != nil && account.IsGrok() && tkIsGrokEntitlement403(resp.StatusCode, body) {
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: resp.StatusCode,
+			UpstreamRequestID:  firstNonEmpty(resp.Header.Get("x-request-id"), resp.Header.Get("xai-request-id")),
+			Kind:               "http_error",
+			Message:            upstreamMsg,
+			Detail:             upstreamDetail,
+		})
+		MarkResponseCommitted(c)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": gin.H{
+				"type":    "permission_error",
+				"message": tkGrokEntitlement403ClientMessage(upstreamMsg),
+			},
+		})
+		return nil, fmt.Errorf("upstream error: %d (grok entitlement 403)", resp.StatusCode)
+	}
 
 	if s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody {
 		logger.LegacyPrintf("service.openai_gateway",
@@ -565,6 +590,21 @@ func (s *OpenAIGatewayService) handleCompatErrorResponse(
 		upstreamDetail = truncateString(string(body), maxBytes)
 	}
 	setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, upstreamDetail)
+	if account != nil && account.IsGrok() && tkIsGrokEntitlement403(resp.StatusCode, body) {
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: resp.StatusCode,
+			UpstreamRequestID:  firstNonEmpty(resp.Header.Get("x-request-id"), resp.Header.Get("xai-request-id")),
+			Kind:               "http_error",
+			Message:            upstreamMsg,
+			Detail:             upstreamDetail,
+		})
+		MarkResponseCommitted(c)
+		writeError(c, http.StatusForbidden, "permission_error", tkGrokEntitlement403ClientMessage(upstreamMsg))
+		return nil, fmt.Errorf("upstream error: %d (grok entitlement 403)", resp.StatusCode)
+	}
 
 	// Apply error passthrough rules
 	if status, errType, errMsg, matched := applyErrorPassthroughRule(

--- a/backend/internal/service/ratelimit_service_tk_grok_entitlement_403.go
+++ b/backend/internal/service/ratelimit_service_tk_grok_entitlement_403.go
@@ -19,8 +19,8 @@ import (
 // empty-pool 429, and the generic 403→502 mask would hide the real cause from the
 // operator. So a grok entitlement-403 must:
 //  1. NOT trigger account failover (shouldFailoverOpenAIUpstreamResponse=false),
-//  2. NOT cool/disable the account (no failover ⇒ HandleUpstreamError is not
-//     reached on the native chat/image path),
+//  2. NOT cool/disable the account (every forwarding path must classify or
+//     guard it before invoking account-error side effects),
 //  3. surface a clean, actionable client error (NOT a masked 502).
 //
 // Kept in a TK-only companion file so future upstream merges of

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -68,7 +68,9 @@
     {
       "path": "backend/internal/service/openai_gateway_service.go",
       "must_contain": [
-        "if account.Platform == PlatformGrok {"
+        "if account.Platform == PlatformGrok {",
+        "grokTokenProvider.GetAccessToken(ctx, account)",
+        "account.GetCredential(\"api_key\")"
       ],
       "rationale": "The grok credential arms of getRequestCredential: OAuth returns the xAI Bearer through GrokTokenProvider, while API-key relay stubs use their configured api_key. This file no longer owns upstream error classification; the Heavy-403 guards are pinned to their current owner files below."
     },

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -70,7 +70,22 @@
       "must_contain": [
         "if account.Platform == PlatformGrok {"
       ],
-      "rationale": "The grok OAuth arm of GetAccessToken (returns the xAI OAuth Bearer instead of routing through the IsOpenAI-gated ChatGPT/Codex token provider) AND the wiring of the Heavy-403 honesty guard into shouldFailoverOpenAIUpstreamResponse (no failover) and the error mapper (clean client 403, not a masked 502). Losing the IsGrokOAuth() branch makes grok OAuth unable to fetch a token; using broad IsGrok() here would steal first-class grok API-key relay stubs from the api_key branch. Losing the tkIsGrokEntitlement403 wiring re-arms the pool-wide 403 failover amplifier and re-masks the entitlement error as 502."
+      "rationale": "The grok credential arms of getRequestCredential: OAuth returns the xAI Bearer through GrokTokenProvider, while API-key relay stubs use their configured api_key. This file no longer owns upstream error classification; the Heavy-403 guards are pinned to their current owner files below."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_upstream_errors.go",
+      "must_contain": [
+        "if tkIsGrokEntitlement403(statusCode, upstreamBody) {",
+        "tkGrokEntitlement403ClientMessage(upstreamMsg)"
+      ],
+      "rationale": "The shared OpenAI-compatible failover classifier must keep Grok entitlement 403 terminal, and both native/compat error handlers must surface the clean permission_error without invoking account error side effects. Losing either anchor re-arms pool-wide failover or account cooling."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_cc_pipeline.go",
+      "must_contain": [
+        "if !s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMsg, respBody) {\n\t\treturn nil\n\t}\n\tif account != nil && account.Platform == PlatformGrok {"
+      ],
+      "rationale": "The shared Chat Completions HTTP pipeline must decide failover and return before applying Grok account side effects. The contiguous anchor deliberately pins that ordering so a terminal entitlement 403 can never reach the account cooldown handler."
     },
     {
       "path": "backend/internal/service/openai_gateway_request_body.go",
@@ -102,17 +117,26 @@
     {
       "path": "backend/internal/service/openai_gateway_chat_completions.go",
       "must_contain": [
-        "account.IsGrok()"
+        "return s.forwardGrokChatCompletionsViaResponses(ctx, c, account, body, promptCacheKey, defaultMappedModel)"
       ],
-      "rationale": "The chat dispatch seam: grok+OAuth is routed to the RAW CC forwarder (plain Bearer + api.x.ai base_url) BEFORE the CC→Responses→Codex transform, which is hardwired to chatgpt.com. Losing this arm sends grok through the Codex path and every grok chat request fails."
+      "rationale": "The Chat Completions dispatch seam routes Grok into its dedicated bridge before the Codex transform. The bridge selects native /v1/responses for compatible cacheable requests and raw /v1/chat/completions otherwise; losing this exact call sends Grok through the ChatGPT/Codex path."
     },
     {
       "path": "backend/internal/service/openai_gateway_chat_completions_raw.go",
       "must_contain": [
         "account.IsGrokOAuth()",
-        "validateUpstreamBaseURLForAccount(account, baseURL)"
+        "validateUpstreamBaseURLForAccount(account, baseURL)",
+        "tkIsGrokEntitlement403(resp.StatusCode, respBody)"
       ],
-      "rationale": "The raw CC forwarder resolves the grok OAuth Bearer + api.x.ai base_url here; first-class grok API-key relay stubs intentionally use GetOpenAIApiKey/GetOpenAIBaseURL and the edge base_url. Losing this arm makes grok OAuth forward with an empty credential / wrong base URL; broadening it back to IsGrok() breaks grok API-key relay stubs."
+      "rationale": "The raw CC forwarder resolves the grok OAuth Bearer + api.x.ai base_url here; first-class grok API-key relay stubs intentionally use GetOpenAIApiKey/GetOpenAIBaseURL and the edge base_url. It must intercept entitlement 403 before recording failover or applying the 30-minute Grok cooldown."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_grok_chat_bridge.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) forwardGrokChatCompletionsViaResponses(",
+        "tkIsGrokEntitlement403(resp.StatusCode, respBody)"
+      ],
+      "rationale": "Cacheable Chat Completions requests use the Grok Responses bridge rather than the raw CC forwarder. This path needs the same terminal entitlement-403 guard before failover logging and account cooldown side effects."
     },
     {
       "path": "backend/internal/service/openai_gateway_v1_forward.go",
@@ -307,6 +331,13 @@
         "TestGrokTokenRefresher_CanRefreshNeedsRefresh"
       ],
       "rationale": "Load-bearing QA evidence for the Heavy-403 entitlement classifier (the pool-kill-amplifier guard) and the refresher gating/expiry-window logic. Losing it removes the regression guard around grok's two most failure-prone pure-logic surfaces."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_grok_chat_bridge_test.go",
+      "must_contain": [
+        "TestForwardGrokChatEntitlement403DoesNotFailoverOrCoolAccount"
+      ],
+      "rationale": "Full Chat Completions regression coverage for both Grok upstream routes: the Responses bridge and raw /v1/chat/completions. It proves a real xAI entitlement envelope returns permission_error 403 without failover, durable cooldown, or runtime scheduling block."
     },
     {
       "path": "backend/internal/handler/admin/group_handler.go",


### PR DESCRIPTION
## 摘要

- 恢复 Grok entitlement 403 的终态处理，在 failover 和账号冷却副作用前直接返回 `403 permission_error`。
- 覆盖 Grok Responses 桥接与原生 `/v1/chat/completions` 两条真实转发路径。
- 修正 Grok sentinel，使其锚定当前错误处理 owner、执行顺序、完整链路回归测试，以及 OAuth/API-key 两个唯一凭证调用点。
- 对齐 Chat bridge 路由与 entitlement 无副作用不变量的代码注释。
- 保持现有飞书告警策略：最终成功的容灾请求仍不产生用户可见失败告警。
- Web impact: none

## 风险

- entitlement 403 将按既定语义成为当前请求的终态 403，不再尝试并冷却池内其他账号。
- 非 entitlement 403、429 限流和其他 OpenAI-compatible failover 行为保持不变。
- 无数据库迁移、路由增删或告警配置变更。
- upstream-conflict-surface-accepted
- `backend/internal/service/openai_gateway_grok_chat_bridge.go` 是当前真实 Chat bridge owner；本次接受未来 upstream merge 成本，且已由 sentinel 与真实链路回归测试覆盖。

## 验证

- `make test-unit`
- `make test-integration`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run --concurrency=4 --timeout=30m`
- `python3 scripts/sentinels/check-grok.py`
- `python3 scripts/export_agent_contract.py --check`
- `./scripts/preflight.sh`

## 提交

- `5234d3c4d` fix(grok): restore entitlement 403 guard
- `9f86815ce` fix(grok): address R-001..R-003 review findings
- 最新提交：`9f86815ce`
