### PR TITLE
fix(openai): 修复部分 OAuth 账号缺失订阅到期时间

### DIFF
--- a/backend/internal/service/openai_oauth_service.go
+++ b/backend/internal/service/openai_oauth_service.go
@@ -269,24 +269,38 @@ func (s *OpenAIOAuthService) enrichTokenInfo(ctx context.Context, tokenInfo *Ope
 			orgID = atClaims.OpenAIAuth.POID
 		}
 	}
-	if info := fetchChatGPTAccountInfo(ctx, s.privacyClientFactory, tokenInfo.AccessToken, proxyURL, orgID); info != nil {
-		// chatgpt_plan_type from the ID token is the canonical personal-plan value.
-		// accounts/check is a multi-account/workspace endpoint; inactive team or
-		// business workspaces can otherwise overwrite Pro/Free with internal
-		// workspace billing plan names such as self_serve_business_usage_based.
-		if shouldApplyChatGPTAccountInfoPlanType(tokenInfo.PlanType, info.PlanType) {
-			tokenInfo.PlanType = info.PlanType
+	if accounts := fetchChatGPTAccountsCheck(ctx, s.privacyClientFactory, tokenInfo.AccessToken, proxyURL); accounts != nil {
+		if info := parseChatGPTAccountInfo(accounts, orgID); info != nil {
+			// chatgpt_plan_type from the ID token is the canonical personal-plan value.
+			// accounts/check is a multi-account/workspace endpoint; inactive team or
+			// business workspaces can otherwise overwrite Pro/Free with internal
+			// workspace billing plan names such as self_serve_business_usage_based.
+			if shouldApplyChatGPTAccountInfoPlanType(tokenInfo.PlanType, info.PlanType) {
+				tokenInfo.PlanType = info.PlanType
+			}
+			if info.SubscriptionExpiresAt != "" {
+				tokenInfo.SubscriptionExpiresAt = info.SubscriptionExpiresAt
+			}
+			if tokenInfo.Email == "" && info.Email != "" {
+				tokenInfo.Email = info.Email
+			}
 		}
-		if info.SubscriptionExpiresAt != "" {
-			tokenInfo.SubscriptionExpiresAt = info.SubscriptionExpiresAt
-		}
-		if tokenInfo.Email == "" && info.Email != "" {
-			tokenInfo.Email = info.Email
-		}
-	}
-	if strings.TrimSpace(tokenInfo.SubscriptionExpiresAt) == "" {
-		if expiresAt := fetchChatGPTSubscriptionExpiresAt(ctx, s.privacyClientFactory, tokenInfo.AccessToken, proxyURL, resolveChatGPTSubscriptionAccountID(tokenInfo, orgID)); expiresAt != "" {
-			tokenInfo.SubscriptionExpiresAt = expiresAt
+		if strings.TrimSpace(tokenInfo.SubscriptionExpiresAt) == "" {
+			candidates := collectChatGPTSubscriptionAccountIDCandidates(
+				tokenInfo.ChatGPTAccountID,
+				tokenInfo.OrganizationID,
+				orgID,
+				accounts,
+			)
+			if expiresAt := fetchChatGPTSubscriptionExpiresAtWithCandidates(
+				ctx,
+				s.privacyClientFactory,
+				tokenInfo.AccessToken,
+				proxyURL,
+				candidates,
+			); expiresAt != "" {
+				tokenInfo.SubscriptionExpiresAt = expiresAt
+			}
 		}
 	}
 
@@ -296,19 +310,6 @@ func (s *OpenAIOAuthService) enrichTokenInfo(ctx context.Context, tokenInfo *Ope
 
 func shouldApplyChatGPTAccountInfoPlanType(current, candidate string) bool {
 	return strings.TrimSpace(candidate) != "" && strings.TrimSpace(current) == ""
-}
-
-func resolveChatGPTSubscriptionAccountID(tokenInfo *OpenAITokenInfo, orgID string) string {
-	for _, candidate := range []string{
-		tokenInfo.ChatGPTAccountID,
-		tokenInfo.OrganizationID,
-		orgID,
-	} {
-		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
 }
 
 // RefreshAccountToken refreshes token for an OpenAI OAuth account

--- a/backend/internal/service/openai_privacy_service.go
+++ b/backend/internal/service/openai_privacy_service.go
@@ -156,19 +156,10 @@ func fetchChatGPTAccountsCheck(ctx context.Context, clientFactory PrivacyClientF
 	return accounts
 }
 
-// fetchChatGPTAccountInfo calls ChatGPT backend-api to get account info (plan_type, etc.).
-// Used as fallback when id_token doesn't contain these fields (e.g., Mobile RT).
-// orgID is used to match the correct account when multiple accounts exist (e.g., personal + team).
-// Returns nil on any failure (best-effort, non-blocking).
-func fetchChatGPTAccountInfo(ctx context.Context, clientFactory PrivacyClientFactory, accessToken, proxyURL, orgID string) *ChatGPTAccountInfo {
-	accounts := fetchChatGPTAccountsCheck(ctx, clientFactory, accessToken, proxyURL)
+func parseChatGPTAccountInfo(accounts map[string]any, orgID string) *ChatGPTAccountInfo {
 	if accounts == nil {
 		return nil
 	}
-	return parseChatGPTAccountInfo(accounts, orgID)
-}
-
-func parseChatGPTAccountInfo(accounts map[string]any, orgID string) *ChatGPTAccountInfo {
 	info := &ChatGPTAccountInfo{}
 	now := time.Now()
 

--- a/backend/internal/service/openai_privacy_service.go
+++ b/backend/internal/service/openai_privacy_service.go
@@ -113,11 +113,8 @@ var (
 	chatGPTSubscriptionsURL = "https://chatgpt.com/backend-api/subscriptions"
 )
 
-// fetchChatGPTAccountInfo calls ChatGPT backend-api to get account info (plan_type, etc.).
-// Used as fallback when id_token doesn't contain these fields (e.g., Mobile RT).
-// orgID is used to match the correct account when multiple accounts exist (e.g., personal + team).
-// Returns nil on any failure (best-effort, non-blocking).
-func fetchChatGPTAccountInfo(ctx context.Context, clientFactory PrivacyClientFactory, accessToken, proxyURL, orgID string) *ChatGPTAccountInfo {
+// fetchChatGPTAccountsCheck loads the accounts/check payload (best-effort).
+func fetchChatGPTAccountsCheck(ctx context.Context, clientFactory PrivacyClientFactory, accessToken, proxyURL string) map[string]any {
 	if accessToken == "" || clientFactory == nil {
 		return nil
 	}
@@ -151,19 +148,35 @@ func fetchChatGPTAccountInfo(ctx context.Context, clientFactory PrivacyClientFac
 		return nil
 	}
 
-	info := &ChatGPTAccountInfo{}
-
 	accounts, ok := result["accounts"].(map[string]any)
 	if !ok {
 		slog.Debug("chatgpt_account_check_no_accounts", "body", truncate(resp.String(), 300))
 		return nil
 	}
+	return accounts
+}
+
+// fetchChatGPTAccountInfo calls ChatGPT backend-api to get account info (plan_type, etc.).
+// Used as fallback when id_token doesn't contain these fields (e.g., Mobile RT).
+// orgID is used to match the correct account when multiple accounts exist (e.g., personal + team).
+// Returns nil on any failure (best-effort, non-blocking).
+func fetchChatGPTAccountInfo(ctx context.Context, clientFactory PrivacyClientFactory, accessToken, proxyURL, orgID string) *ChatGPTAccountInfo {
+	accounts := fetchChatGPTAccountsCheck(ctx, clientFactory, accessToken, proxyURL)
+	if accounts == nil {
+		return nil
+	}
+	return parseChatGPTAccountInfo(accounts, orgID)
+}
+
+func parseChatGPTAccountInfo(accounts map[string]any, orgID string) *ChatGPTAccountInfo {
+	info := &ChatGPTAccountInfo{}
+	now := time.Now()
 
 	// 优先匹配 orgID 对应的账号（access_token JWT 中的 poid）
 	if orgID != "" {
 		if acctRaw, ok := accounts[orgID]; ok {
 			if acct, ok := acctRaw.(map[string]any); ok {
-				if isUsableChatGPTAccountCandidate(acct, time.Now()) {
+				if isUsableChatGPTAccountCandidate(acct, now) {
 					fillAccountInfo(info, acct)
 				}
 			}
@@ -182,7 +195,7 @@ func fetchChatGPTAccountInfo(ctx context.Context, clientFactory PrivacyClientFac
 			if !ok {
 				continue
 			}
-			if !isUsableChatGPTAccountCandidate(acct, time.Now()) {
+			if !isUsableChatGPTAccountCandidate(acct, now) {
 				continue
 			}
 			planType := extractPlanType(acct)
@@ -213,13 +226,146 @@ func fetchChatGPTAccountInfo(ctx context.Context, clientFactory PrivacyClientFac
 		}
 	}
 
+	// orgID 命中时 plan_type 可能已有值但 entitlement.expires_at 为空（Plus/Pro 常见）。
+	// 此时上面的遍历会被跳过，仍需扫描其它 workspace 的 entitlement 或留给 subscriptions 回退。
+	if info.SubscriptionExpiresAt == "" {
+		info.SubscriptionExpiresAt = findBestSubscriptionExpiresAtFromAccounts(accounts, now)
+	}
+
 	if info.PlanType == "" {
-		slog.Debug("chatgpt_account_check_no_plan_type", "body", truncate(resp.String(), 300))
+		slog.Debug("chatgpt_account_check_no_plan_type", "org_id", orgID)
 		return nil
 	}
 
 	slog.Info("chatgpt_account_check_success", "plan_type", info.PlanType, "subscription_expires_at", info.SubscriptionExpiresAt, "org_id", orgID)
 	return info
+}
+
+func findBestSubscriptionExpiresAtFromAccounts(accounts map[string]any, now time.Time) string {
+	type candidate struct {
+		expiresAt string
+		paid      bool
+		defaulted bool
+	}
+	var best candidate
+	for _, acctRaw := range accounts {
+		acct, ok := acctRaw.(map[string]any)
+		if !ok || !isUsableChatGPTAccountCandidate(acct, now) {
+			continue
+		}
+		expiresAt := strings.TrimSpace(extractEntitlementExpiresAt(acct))
+		if expiresAt == "" {
+			continue
+		}
+		if _, err := time.Parse(time.RFC3339, expiresAt); err != nil {
+			continue
+		}
+		planType := extractPlanType(acct)
+		isPaid := planType != "" && !strings.EqualFold(planType, "free") && !strings.EqualFold(planType, "basic")
+		isDefault := false
+		if account, ok := acct["account"].(map[string]any); ok {
+			isDefault, _ = account["is_default"].(bool)
+		}
+		cur := candidate{expiresAt: expiresAt, paid: isPaid, defaulted: isDefault}
+		if best.expiresAt == "" ||
+			(cur.defaulted && !best.defaulted) ||
+			(cur.defaulted == best.defaulted && cur.paid && !best.paid) {
+			best = cur
+		}
+	}
+	return best.expiresAt
+}
+
+func collectChatGPTSubscriptionAccountIDCandidates(
+	chatGPTAccountID, organizationID, orgID string,
+	accounts map[string]any,
+) []string {
+	seen := make(map[string]struct{})
+	add := func(ids []string, id string) []string {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return ids
+		}
+		if _, ok := seen[id]; ok {
+			return ids
+		}
+		seen[id] = struct{}{}
+		return append(ids, id)
+	}
+
+	candidates := make([]string, 0, 4)
+	for _, id := range []string{chatGPTAccountID, organizationID, orgID} {
+		candidates = add(candidates, id)
+	}
+
+	if accounts != nil {
+		type keyed struct {
+			id        string
+			paid      bool
+			defaulted bool
+		}
+		var keyedAccounts []keyed
+		for accountID, acctRaw := range accounts {
+			acct, ok := acctRaw.(map[string]any)
+			if !ok || !isUsableChatGPTAccountCandidate(acct, time.Now()) {
+				continue
+			}
+			planType := extractPlanType(acct)
+			isPaid := planType != "" && !strings.EqualFold(planType, "free") && !strings.EqualFold(planType, "basic")
+			isDefault := false
+			if account, ok := acct["account"].(map[string]any); ok {
+				isDefault, _ = account["is_default"].(bool)
+			}
+			keyedAccounts = append(keyedAccounts, keyed{id: accountID, paid: isPaid, defaulted: isDefault})
+		}
+		for _, preferPaid := range []bool{true, false} {
+			for _, preferDefault := range []bool{true, false} {
+				for _, item := range keyedAccounts {
+					if preferPaid && !item.paid {
+						continue
+					}
+					if preferDefault && !item.defaulted {
+						continue
+					}
+					candidates = add(candidates, item.id)
+				}
+			}
+		}
+	}
+	return candidates
+}
+
+func fetchChatGPTSubscriptionExpiresAtWithCandidates(
+	ctx context.Context,
+	clientFactory PrivacyClientFactory,
+	accessToken, proxyURL string,
+	accountIDs []string,
+) string {
+	for _, accountID := range accountIDs {
+		if expiresAt := fetchChatGPTSubscriptionExpiresAt(ctx, clientFactory, accessToken, proxyURL, accountID); expiresAt != "" {
+			return expiresAt
+		}
+	}
+	return ""
+}
+
+// fetchOpenAISubscriptionExpiresAt resolves subscription expiry for a stored OpenAI OAuth account.
+func fetchOpenAISubscriptionExpiresAt(
+	ctx context.Context,
+	clientFactory PrivacyClientFactory,
+	accessToken, proxyURL, chatGPTAccountID, organizationID, orgID string,
+) string {
+	if accessToken == "" || clientFactory == nil {
+		return ""
+	}
+
+	accounts := fetchChatGPTAccountsCheck(ctx, clientFactory, accessToken, proxyURL)
+	if info := parseChatGPTAccountInfo(accounts, orgID); info != nil && info.SubscriptionExpiresAt != "" {
+		return info.SubscriptionExpiresAt
+	}
+
+	candidates := collectChatGPTSubscriptionAccountIDCandidates(chatGPTAccountID, organizationID, orgID, accounts)
+	return fetchChatGPTSubscriptionExpiresAtWithCandidates(ctx, clientFactory, accessToken, proxyURL, candidates)
 }
 
 // fetchChatGPTSubscriptionExpiresAt reads the lightweight subscription endpoint used by

--- a/backend/internal/service/openai_subscription_test.go
+++ b/backend/internal/service/openai_subscription_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package service
 
 import (
@@ -8,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/imroc/req/v3"
 	"github.com/stretchr/testify/require"
 )
@@ -124,4 +127,154 @@ func TestShouldApplyChatGPTAccountInfoPlanType(t *testing.T) {
 	require.False(t, shouldApplyChatGPTAccountInfoPlanType("free", "team"))
 	require.False(t, shouldApplyChatGPTAccountInfoPlanType("", ""))
 	require.True(t, shouldApplyChatGPTAccountInfoPlanType("", "pro"))
+}
+
+func TestFetchChatGPTAccountInfo_OrgMatchWithoutExpiryScansOtherAccounts(t *testing.T) {
+	const wantExpiresAt = "2026-08-01T00:00:00Z"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/backend-api/accounts/check/v4-2023-04-27", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accounts": map[string]any{
+				"org-pro-no-expiry": map[string]any{
+					"account": map[string]any{
+						"plan_type": "pro",
+					},
+				},
+				"personal-pro": map[string]any{
+					"account": map[string]any{
+						"plan_type": "pro",
+					},
+					"entitlement": map[string]any{
+						"expires_at": wantExpiresAt,
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	oldURL := chatGPTAccountsCheckURL
+	chatGPTAccountsCheckURL = server.URL + "/backend-api/accounts/check/v4-2023-04-27"
+	t.Cleanup(func() { chatGPTAccountsCheckURL = oldURL })
+
+	got := fetchChatGPTAccountInfo(context.Background(), func(proxyURL string) (*req.Client, error) {
+		return req.C().SetTimeout(5 * time.Second), nil
+	}, "access-token", "", "org-pro-no-expiry")
+
+	require.NotNil(t, got)
+	require.Equal(t, "pro", got.PlanType)
+	require.Equal(t, wantExpiresAt, got.SubscriptionExpiresAt)
+}
+
+func TestFetchChatGPTSubscriptionExpiresAtWithCandidates_TriesFallbackAccountID(t *testing.T) {
+	const wantExpiresAt = "2026-09-01T00:00:00Z"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/backend-api/subscriptions", r.URL.Path)
+		switch r.URL.Query().Get("account_id") {
+		case "wrong-id":
+			w.WriteHeader(http.StatusNotFound)
+			return
+		case "personal-pro":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"plan_type":    "pro",
+				"active_until": wantExpiresAt,
+				"will_renew":   true,
+			})
+		default:
+			t.Fatalf("unexpected account_id=%q", r.URL.Query().Get("account_id"))
+		}
+	}))
+	defer server.Close()
+
+	oldURL := chatGPTSubscriptionsURL
+	chatGPTSubscriptionsURL = server.URL + "/backend-api/subscriptions"
+	t.Cleanup(func() { chatGPTSubscriptionsURL = oldURL })
+
+	got := fetchChatGPTSubscriptionExpiresAtWithCandidates(context.Background(), func(proxyURL string) (*req.Client, error) {
+		return req.C().SetTimeout(5 * time.Second), nil
+	}, "access-token", "", []string{"wrong-id", "personal-pro"})
+
+	require.Equal(t, wantExpiresAt, got)
+}
+
+func TestTokenRefreshService_ensureOpenAISubscriptionExpiry_PersistsExpiry(t *testing.T) {
+	const wantExpiresAt = "2026-10-01T00:00:00Z"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/backend-api/accounts/check/v4-2023-04-27":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"accounts": map[string]any{
+					"org-pro": map[string]any{
+						"account": map[string]any{"plan_type": "pro"},
+					},
+				},
+			})
+		case "/backend-api/subscriptions":
+			switch r.URL.Query().Get("account_id") {
+			case "wrong-id":
+				w.WriteHeader(http.StatusNotFound)
+				return
+			case "org-pro":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"plan_type":    "pro",
+					"active_until": wantExpiresAt,
+				})
+			default:
+				t.Fatalf("unexpected account_id=%q", r.URL.Query().Get("account_id"))
+			}
+		default:
+			t.Fatalf("unexpected path=%q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	oldCheckURL := chatGPTAccountsCheckURL
+	oldSubURL := chatGPTSubscriptionsURL
+	chatGPTAccountsCheckURL = server.URL + "/backend-api/accounts/check/v4-2023-04-27"
+	chatGPTSubscriptionsURL = server.URL + "/backend-api/subscriptions"
+	t.Cleanup(func() {
+		chatGPTAccountsCheckURL = oldCheckURL
+		chatGPTSubscriptionsURL = oldSubURL
+	})
+
+	repo := &subscriptionExpiryAccountRepo{}
+	service := NewTokenRefreshService(repo, nil, nil, nil, nil, nil, nil, &config.Config{}, nil)
+	service.SetPrivacyDeps(func(proxyURL string) (*req.Client, error) {
+		return req.C().SetTimeout(5 * time.Second), nil
+	}, nil)
+
+	account := &Account{
+		ID:       303,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token":       "access-token",
+			"plan_type":          "pro",
+			"organization_id":    "org-pro",
+			"chatgpt_account_id": "wrong-id",
+		},
+	}
+
+	service.ensureOpenAISubscriptionExpiry(context.Background(), account)
+
+	require.Equal(t, wantExpiresAt, account.Credentials["subscription_expires_at"])
+	require.Equal(t, wantExpiresAt, repo.updatedCredentials["subscription_expires_at"])
+}
+
+type subscriptionExpiryAccountRepo struct {
+	mockAccountRepoForGemini
+	updatedCredentials map[string]any
+}
+
+func (r *subscriptionExpiryAccountRepo) UpdateCredentials(_ context.Context, id int64, credentials map[string]any) error {
+	r.updatedCredentials = shallowCopyMap(credentials)
+	return nil
 }

--- a/backend/internal/service/openai_subscription_test.go
+++ b/backend/internal/service/openai_subscription_test.go
@@ -77,9 +77,9 @@ func TestFetchChatGPTAccountInfo_SkipsExpiredWorkspaceCandidate(t *testing.T) {
 	chatGPTAccountsCheckURL = server.URL + "/backend-api/accounts/check/v4-2023-04-27"
 	t.Cleanup(func() { chatGPTAccountsCheckURL = oldURL })
 
-	got := fetchChatGPTAccountInfo(context.Background(), func(proxyURL string) (*req.Client, error) {
+	got := parseChatGPTAccountInfo(fetchChatGPTAccountsCheck(context.Background(), func(proxyURL string) (*req.Client, error) {
 		return req.C().SetTimeout(5 * time.Second), nil
-	}, "access-token", "", "org-expired-workspace")
+	}, "access-token", ""), "org-expired-workspace")
 
 	require.NotNil(t, got)
 	require.Equal(t, "free", got.PlanType)
@@ -114,9 +114,9 @@ func TestFetchChatGPTAccountInfo_SkipsDeactivatedWorkspaceCandidate(t *testing.T
 	chatGPTAccountsCheckURL = server.URL + "/backend-api/accounts/check/v4-2023-04-27"
 	t.Cleanup(func() { chatGPTAccountsCheckURL = oldURL })
 
-	got := fetchChatGPTAccountInfo(context.Background(), func(proxyURL string) (*req.Client, error) {
+	got := parseChatGPTAccountInfo(fetchChatGPTAccountsCheck(context.Background(), func(proxyURL string) (*req.Client, error) {
 		return req.C().SetTimeout(5 * time.Second), nil
-	}, "access-token", "", "org-deactivated-workspace")
+	}, "access-token", ""), "org-deactivated-workspace")
 
 	require.NotNil(t, got)
 	require.Equal(t, "pro", got.PlanType)
@@ -160,9 +160,9 @@ func TestFetchChatGPTAccountInfo_OrgMatchWithoutExpiryScansOtherAccounts(t *test
 	chatGPTAccountsCheckURL = server.URL + "/backend-api/accounts/check/v4-2023-04-27"
 	t.Cleanup(func() { chatGPTAccountsCheckURL = oldURL })
 
-	got := fetchChatGPTAccountInfo(context.Background(), func(proxyURL string) (*req.Client, error) {
+	got := parseChatGPTAccountInfo(fetchChatGPTAccountsCheck(context.Background(), func(proxyURL string) (*req.Client, error) {
 		return req.C().SetTimeout(5 * time.Second), nil
-	}, "access-token", "", "org-pro-no-expiry")
+	}, "access-token", ""), "org-pro-no-expiry")
 
 	require.NotNil(t, got)
 	require.Equal(t, "pro", got.PlanType)

--- a/backend/internal/service/token_refresh_service.go
+++ b/backend/internal/service/token_refresh_service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/util/logredact"
 )
 
@@ -1200,6 +1201,8 @@ func (s *TokenRefreshService) postRefreshActions(ctx context.Context, account *A
 	s.postRefreshStateSync(ctx, account)
 	// OpenAI OAuth: 刷新成功后，检查是否已设置 privacy_mode，未设置则尝试关闭训练数据共享
 	s.ensureOpenAIPrivacy(ctx, account)
+	// OpenAI OAuth: 付费账号缺失 subscription_expires_at 时补抓（不依赖 token 是否刚刷新字段）
+	s.ensureOpenAISubscriptionExpiry(ctx, account)
 	// Antigravity OAuth: 刷新成功后，检查是否已设置 privacy_mode，未设置则调用 setUserSettings
 	s.ensureAntigravityPrivacy(ctx, account)
 }
@@ -1477,6 +1480,83 @@ func (s *TokenRefreshService) ensureOpenAIPrivacy(ctx context.Context, account *
 			"privacy_mode", mode,
 		)
 	}
+}
+
+func isOpenAIPaidPlanType(planType string) bool {
+	switch strings.ToLower(strings.TrimSpace(planType)) {
+	case "", "free", "basic":
+		return false
+	default:
+		return true
+	}
+}
+
+// ensureOpenAISubscriptionExpiry backfills credentials.subscription_expires_at for paid
+// OpenAI OAuth accounts when enrichment missed it (e.g. orgID matched a workspace
+// without entitlement.expires_at, or the subscriptions fallback used a wrong account_id).
+func (s *TokenRefreshService) ensureOpenAISubscriptionExpiry(ctx context.Context, account *Account) {
+	if account == nil || account.IsCredentialShadow() {
+		return
+	}
+	if account.Platform != PlatformOpenAI || account.Type != AccountTypeOAuth || account.IsOpenAIPersonalAccessToken() {
+		return
+	}
+	if s.privacyClientFactory == nil || s.accountRepo == nil {
+		return
+	}
+	if !isOpenAIPaidPlanType(account.GetCredential("plan_type")) {
+		return
+	}
+	if strings.TrimSpace(account.GetCredential("subscription_expires_at")) != "" {
+		return
+	}
+
+	token := account.GetCredential("access_token")
+	if token == "" {
+		return
+	}
+
+	var proxyURL string
+	if account.ProxyID != nil && s.proxyRepo != nil {
+		if p, err := s.proxyRepo.GetByID(ctx, *account.ProxyID); err == nil && p != nil {
+			proxyURL = p.URL()
+		}
+	}
+
+	orgID := account.GetCredential("organization_id")
+	if orgID == "" {
+		if atClaims, err := openai.DecodeIDToken(token); err == nil && atClaims.OpenAIAuth != nil {
+			orgID = atClaims.OpenAIAuth.POID
+		}
+	}
+
+	expiresAt := fetchOpenAISubscriptionExpiresAt(
+		ctx,
+		s.privacyClientFactory,
+		token,
+		proxyURL,
+		account.GetCredential("chatgpt_account_id"),
+		account.GetCredential("organization_id"),
+		orgID,
+	)
+	if expiresAt == "" {
+		return
+	}
+
+	merged := MergeCredentials(account.Credentials, map[string]any{
+		"subscription_expires_at": expiresAt,
+	})
+	if err := persistAccountCredentials(ctx, s.accountRepo, account, merged); err != nil {
+		slog.Warn("token_refresh.update_subscription_expires_at_failed",
+			"account_id", account.ID,
+			"error", err,
+		)
+		return
+	}
+	slog.Info("token_refresh.subscription_expires_at_set",
+		"account_id", account.ID,
+		"subscription_expires_at", expiresAt,
+	)
 }
 
 // ensureAntigravityPrivacy 后台刷新中检查 Antigravity OAuth 账号隐私状态。


### PR DESCRIPTION
## 摘要

- 根因：`accounts/check` 按 orgID 命中 workspace 时若该 workspace 无 `entitlement.expires_at`，旧逻辑因已有 `plan_type` 而跳过全量扫描；`/backend-api/subscriptions` 回退也只尝试单个 `account_id`（常为错误的 org/chatgpt id），导致 Pro/Plus 账号 `credentials.subscription_expires_at` 为空，前端 `PlatformTypeBadge` 不显示「到期」。
- 修复：orgID 命中后仍扫描其它 workspace 的 entitlement；subscriptions 回退按 token 字段 + accounts/check 全部 key 依次尝试；token 刷新成功后对缺失到期时间的付费 OAuth 账号补抓并持久化。

## 风险

- 常规风险：仅 best-effort 补全逻辑，ChatGPT API 不可达时仍可能为空（与原先一致）。
- 每次 token 刷新周期可能对缺失字段的付费账号多一次 accounts/check + subscriptions 请求。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service -run 'TestFetchChatGPT|TestTokenRefreshService_ensureOpenAISubscription|TestShouldApplyChatGPT' -count=1
./scripts/preflight.sh
```

- 新增用例覆盖：orgID 命中无 expiry 时从其它 workspace 取 expiry；subscriptions 多 account_id 回退；token refresh 补写 credentials。

## 提交

- fix(openai): backfill missing subscription expiry for OAuth accounts
- fix(openai): drop unused fetchChatGPTAccountInfo wrapper

最新提交：a92ec00ed

upstream-touch-trivial

sentinel-registry-reviewed