### PR TITLE
fix(ops): repair daily diagnostics live regressions

### DIFF
--- a/.github/actions/run-headless-agent/action.yml
+++ b/.github/actions/run-headless-agent/action.yml
@@ -12,7 +12,7 @@ description: >-
 
 inputs:
   prompt_file:
-    description: Path to the file holding the agent prompt (read via cat).
+    description: Path to the file streamed to the agent over stdin.
     required: true
   model:
     description: ANTHROPIC_MODEL / --model (e.g. "opus[1m]", "claude-sonnet-4-6"). No default — callers state it explicitly (CLAUDE.md §4).
@@ -102,31 +102,7 @@ runs:
         OUTPUT_FILE: ${{ inputs.output_file }}
         FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
       run: |
-        # claude CLI has no --output flag — pipe stdout. `set -o pipefail`
-        # propagates claude's exit code through the redactor pipeline.
-        # --allowedTools is REQUIRED in headless mode (without it `claude -p`
-        # defaults to interactive permission mode and rejects every tool call).
-        # --output-format stream-json --verbose lands the full transcript (tool
-        # calls / results / cost / errors) as JSONL. The redactor still scrubs
-        # token patterns inside JSON strings line-by-line.
-        # --exclude-dynamic-system-prompt-sections stabilizes the system-prompt
-        # prefix for ephemeral prompt-cache hits across runs.
-        set -o pipefail
-        set +e  # preflight-allow: swallow — deliberate exit-code capture; PIPESTATUS read below, then set -e restored
-        claude -p "$(cat "${PROMPT_FILE}")" \
-          --model "${ANTHROPIC_MODEL}" \
-          --max-budget-usd "${MAX_BUDGET_USD}" \
-          --allowedTools "${ALLOWED_TOOLS}" \
-          --output-format stream-json --verbose \
-          --exclude-dynamic-system-prompt-sections \
-          2>&1 \
-          | python3 "${RUNNER_TEMP}/redact-agent-stream.py" \
-          | tee "${OUTPUT_FILE}"
-        code=${PIPESTATUS[0]}
-        set -e
-        echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
-        echo "agent exited with code ${code}"
-        if [ "${FAIL_ON_ERROR}" = "true" ] && [ "${code}" -ne 0 ]; then
-          echo "::error::headless agent exited ${code}"
-          exit "${code}"
-        fi
+        # The runner streams PROMPT_FILE through stdin so reports larger than
+        # Linux MAX_ARG_STRLEN never become one oversized argv entry. It owns
+        # the claude -> redactor -> tee pipe and exports Claude's true exit code.
+        bash scripts/agent/run-headless-claude.sh

--- a/ops/observability/daily_error_report.py
+++ b/ops/observability/daily_error_report.py
@@ -158,9 +158,25 @@ def classify_cluster(item: dict[str, Any], max_count_5m: int, target_id: str) ->
     }
 
 
-def classify_access_cluster(item: dict[str, Any], target_id: str) -> dict[str, Any] | None:
-    current = as_int(item.get("current_count"))
+def access_coverage_key(item: dict[str, Any]) -> tuple[int, str, str]:
+    def dimension(value: Any) -> str:
+        text = clean_text(value).lower()
+        return "unknown" if text in {"unknown", "(unknown)"} else text
+
+    return (
+        as_int(item.get("status_code")),
+        dimension(item.get("model")),
+        dimension(item.get("endpoint")),
+    )
+
+
+def classify_access_cluster(
+    item: dict[str, Any], target_id: str, captured_count: int = 0
+) -> dict[str, Any] | None:
+    observed = as_int(item.get("current_count"))
     status = as_int(item.get("status_code"))
+    captured = min(max(captured_count, 0), observed)
+    current = observed - captured
     if current <= 0 or status < 400:
         return None
     key = cluster_key(item, source="access_log")
@@ -170,11 +186,13 @@ def classify_access_cluster(item: dict[str, Any], target_id: str) -> dict[str, A
         "signature": signature_for(key, target_id),
         "state": "observed",
         "severity": "warning",
+        "observed_count": observed,
+        "captured_count": captured,
         "current_count": current,
         "previous_count": 0,
         "baseline_7d_count": 0,
         "active_days_7d": 0,
-        "max_count_5m": as_int(item.get("max_count_1m")),
+        "max_count_5m": min(as_int(item.get("max_count_1m")), current),
         "first_seen_7d": None,
         "last_seen": None,
         "account_ids": [],
@@ -215,12 +233,18 @@ def build_report(probe_text: str, target_id: str) -> dict[str, Any]:
         burst_by_signature[sig] = max(burst_by_signature.get(sig, 0), as_int(burst.get("max_count_5m")))
 
     clusters = []
+    captured_by_surface: dict[tuple[int, str, str], int] = defaultdict(int)
     for raw in sections.get("clusters", []):
         sig = signature_for(cluster_key(raw), target_id)
         peak = max(as_int(raw.get("max_count_5m")), burst_by_signature.get(sig, 0))
-        clusters.append(classify_cluster(raw, peak, target_id))
+        classified = classify_cluster(raw, peak, target_id)
+        clusters.append(classified)
+        captured_by_surface[access_coverage_key(classified)] += as_int(classified.get("current_count"))
     for raw in sections.get("access_clusters", []):
-        classified = classify_access_cluster(raw, target_id)
+        surface = access_coverage_key(raw)
+        covered = min(captured_by_surface.get(surface, 0), as_int(raw.get("current_count")))
+        captured_by_surface[surface] -= covered
+        classified = classify_access_cluster(raw, target_id, covered)
         if classified:
             clusters.append(classified)
     clusters.sort(key=lambda row: (-as_int(row["priority"]), row["signature"]))

--- a/ops/observability/test_daily_error_report.py
+++ b/ops/observability/test_daily_error_report.py
@@ -126,6 +126,46 @@ class DailyErrorReportTest(unittest.TestCase):
         self.assertTrue(access["anomaly"])
         self.assertEqual(access["confidence"], "low")
 
+    def test_access_cluster_fully_covered_by_ops_error_is_not_duplicated(self) -> None:
+        matching_access = json.dumps({
+            "status": "ok",
+            "status_code": 502,
+            "endpoint": "/v1/responses",
+            "model": "gpt-5",
+            "current_count": 12,
+            "max_count_1m": 6,
+        })
+        report = build_report(probe_fixture() + matching_access + "\n", "prod")
+
+        matches = [
+            row for row in report["clusters"]
+            if row["status_code"] == 502
+            and row["model"] == "gpt-5"
+            and row["endpoint"] == "/v1/responses"
+        ]
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0]["source"], "ops_error_logs")
+
+    def test_access_cluster_reports_only_uncaptured_residual(self) -> None:
+        matching_access = json.dumps({
+            "status": "ok",
+            "status_code": 502,
+            "endpoint": "/v1/responses",
+            "model": "gpt-5",
+            "current_count": 15,
+            "max_count_1m": 6,
+        })
+        report = build_report(probe_fixture() + matching_access + "\n", "prod")
+
+        access = next(
+            row for row in report["clusters"]
+            if row["source"] == "access_log" and row["endpoint"] == "/v1/responses"
+        )
+        self.assertEqual(access["observed_count"], 15)
+        self.assertEqual(access["captured_count"], 12)
+        self.assertEqual(access["current_count"], 3)
+        self.assertEqual(access["max_count_5m"], 3)
+
     def test_operational_platform_error_is_not_repair_eligible(self) -> None:
         text = probe_fixture().replace("dashboard_query_failed", "no_available_accounts")
         report = build_report(text, "prod")

--- a/ops/observability/test_headless_agent_runner.py
+++ b/ops/observability/test_headless_agent_runner.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+RUNNER = ROOT / "scripts" / "agent" / "run-headless-claude.sh"
+REDACTOR = ROOT / "scripts" / "agent" / "redact-stream.py"
+
+
+class HeadlessAgentRunnerTest(unittest.TestCase):
+    def test_large_prompt_is_streamed_over_stdin(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_raw:
+            tmp = pathlib.Path(tmp_raw)
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            prompt = tmp / "prompt.txt"
+            captured = tmp / "captured-prompt.txt"
+            args = tmp / "claude-args.txt"
+            output = tmp / "agent.jsonl"
+            github_output = tmp / "github-output"
+            prompt.write_bytes(b"large-prompt-line\n" * 13_000)
+            shutil.copyfile(REDACTOR, tmp / "redact-agent-stream.py")
+
+            claude = bin_dir / "claude"
+            claude.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$@" > "$CLAUDE_ARGS_FILE"
+cat > "$CLAUDE_STDIN_FILE"
+printf '%s\\n' '{"type":"result","result":"ok"}'
+exit "${CLAUDE_STUB_EXIT:-0}"
+""",
+                encoding="utf-8",
+            )
+            claude.chmod(0o755)
+
+            env = {
+                "PATH": f"{bin_dir}:{os.environ['PATH']}",
+                "PROMPT_FILE": str(prompt),
+                "ANTHROPIC_MODEL": "test-model",
+                "MAX_BUDGET_USD": "1.00",
+                "ALLOWED_TOOLS": "Read Grep Glob",
+                "OUTPUT_FILE": str(output),
+                "RUNNER_TEMP": str(tmp),
+                "GITHUB_OUTPUT": str(github_output),
+                "FAIL_ON_ERROR": "true",
+                "CLAUDE_ARGS_FILE": str(args),
+                "CLAUDE_STDIN_FILE": str(captured),
+            }
+            proc = subprocess.run(
+                ["bash", str(RUNNER)],
+                cwd=ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertGreater(prompt.stat().st_size, 131_072)
+            self.assertEqual(captured.read_bytes(), prompt.read_bytes())
+            self.assertEqual(
+                args.read_text(encoding="utf-8").splitlines(),
+                [
+                    "-p",
+                    "--model",
+                    "test-model",
+                    "--max-budget-usd",
+                    "1.00",
+                    "--allowedTools",
+                    "Read Grep Glob",
+                    "--input-format",
+                    "text",
+                    "--output-format",
+                    "stream-json",
+                    "--verbose",
+                    "--exclude-dynamic-system-prompt-sections",
+                ],
+            )
+            self.assertEqual(output.read_text(encoding="utf-8"), '{"type":"result","result":"ok"}\n')
+            self.assertEqual(github_output.read_text(encoding="utf-8"), "exit_code=0\n")
+
+    def test_nonzero_exit_is_exported_when_failure_is_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_raw:
+            tmp = pathlib.Path(tmp_raw)
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            prompt = tmp / "prompt.txt"
+            prompt.write_text("test", encoding="utf-8")
+            shutil.copyfile(REDACTOR, tmp / "redact-agent-stream.py")
+            claude = bin_dir / "claude"
+            claude.write_text(
+                "#!/usr/bin/env bash\ncat >/dev/null\nexit 7\n",
+                encoding="utf-8",
+            )
+            claude.chmod(0o755)
+            github_output = tmp / "github-output"
+            env = {
+                "PATH": f"{bin_dir}:{os.environ['PATH']}",
+                "PROMPT_FILE": str(prompt),
+                "ANTHROPIC_MODEL": "test-model",
+                "MAX_BUDGET_USD": "1.00",
+                "ALLOWED_TOOLS": "Read",
+                "OUTPUT_FILE": str(tmp / "agent.jsonl"),
+                "RUNNER_TEMP": str(tmp),
+                "GITHUB_OUTPUT": str(github_output),
+                "FAIL_ON_ERROR": "false",
+            }
+            proc = subprocess.run(
+                ["bash", str(RUNNER)], cwd=ROOT, env=env, capture_output=True, text=True, check=False
+            )
+
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(github_output.read_text(encoding="utf-8"), "exit_code=7\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/observability/test_headless_agent_runner.py
+++ b/ops/observability/test_headless_agent_runner.py
@@ -119,6 +119,77 @@ exit "${CLAUDE_STUB_EXIT:-0}"
             self.assertEqual(proc.returncode, 0, proc.stderr)
             self.assertEqual(github_output.read_text(encoding="utf-8"), "exit_code=7\n")
 
+    def test_redactor_failure_is_fail_closed_when_claude_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_raw:
+            tmp = pathlib.Path(tmp_raw)
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            prompt = tmp / "prompt.txt"
+            prompt.write_text("test", encoding="utf-8")
+            (tmp / "redact-agent-stream.py").write_text(
+                "raise SystemExit(9)\n",
+                encoding="utf-8",
+            )
+            claude = bin_dir / "claude"
+            claude.write_text(
+                "#!/usr/bin/env bash\ncat >/dev/null\nexit 0\n",
+                encoding="utf-8",
+            )
+            claude.chmod(0o755)
+            github_output = tmp / "github-output"
+            env = {
+                "PATH": f"{bin_dir}:{os.environ['PATH']}",
+                "PROMPT_FILE": str(prompt),
+                "ANTHROPIC_MODEL": "test-model",
+                "MAX_BUDGET_USD": "1.00",
+                "ALLOWED_TOOLS": "Read",
+                "OUTPUT_FILE": str(tmp / "agent.jsonl"),
+                "RUNNER_TEMP": str(tmp),
+                "GITHUB_OUTPUT": str(github_output),
+                "FAIL_ON_ERROR": "false",
+            }
+            proc = subprocess.run(
+                ["bash", str(RUNNER)], cwd=ROOT, env=env, capture_output=True, text=True, check=False
+            )
+
+            self.assertEqual(proc.returncode, 9, proc.stderr)
+            self.assertIn("headless agent redactor exited 9", proc.stdout)
+            self.assertEqual(github_output.read_text(encoding="utf-8"), "exit_code=0\n")
+
+    def test_output_failure_is_not_masked_when_claude_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_raw:
+            tmp = pathlib.Path(tmp_raw)
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            prompt = tmp / "prompt.txt"
+            prompt.write_text("test", encoding="utf-8")
+            shutil.copyfile(REDACTOR, tmp / "redact-agent-stream.py")
+            claude = bin_dir / "claude"
+            claude.write_text(
+                "#!/usr/bin/env bash\ncat >/dev/null\nexit 0\n",
+                encoding="utf-8",
+            )
+            claude.chmod(0o755)
+            github_output = tmp / "github-output"
+            env = {
+                "PATH": f"{bin_dir}:{os.environ['PATH']}",
+                "PROMPT_FILE": str(prompt),
+                "ANTHROPIC_MODEL": "test-model",
+                "MAX_BUDGET_USD": "1.00",
+                "ALLOWED_TOOLS": "Read",
+                "OUTPUT_FILE": str(tmp),
+                "RUNNER_TEMP": str(tmp),
+                "GITHUB_OUTPUT": str(github_output),
+                "FAIL_ON_ERROR": "false",
+            }
+            proc = subprocess.run(
+                ["bash", str(RUNNER)], cwd=ROOT, env=env, capture_output=True, text=True, check=False
+            )
+
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("headless agent output writer exited", proc.stdout)
+            self.assertEqual(github_output.read_text(encoding="utf-8"), "exit_code=0\n")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/agent/run-headless-claude.sh
+++ b/scripts/agent/run-headless-claude.sh
@@ -32,12 +32,24 @@ claude -p \
   2>&1 \
   | python3 "$RUNNER_TEMP/redact-agent-stream.py" \
   | tee "$OUTPUT_FILE"
-code=${PIPESTATUS[0]}
+pipeline_status=("${PIPESTATUS[@]}")
 set -e
 
-echo "exit_code=$code" >> "$GITHUB_OUTPUT"
-echo "agent exited with code $code"
-if [ "${FAIL_ON_ERROR:-true}" = "true" ] && [ "$code" -ne 0 ]; then
-  echo "::error::headless agent exited $code"
-  exit "$code"
+claude_code=${pipeline_status[0]}
+redactor_code=${pipeline_status[1]}
+tee_code=${pipeline_status[2]}
+echo "exit_code=$claude_code" >> "$GITHUB_OUTPUT"
+echo "agent exited with code $claude_code"
+
+if [ "$redactor_code" -ne 0 ]; then
+  echo "::error::headless agent redactor exited $redactor_code"
+  exit "$redactor_code"
+fi
+if [ "$tee_code" -ne 0 ]; then
+  echo "::error::headless agent output writer exited $tee_code"
+  exit "$tee_code"
+fi
+if [ "${FAIL_ON_ERROR:-true}" = "true" ] && [ "$claude_code" -ne 0 ]; then
+  echo "::error::headless agent exited $claude_code"
+  exit "$claude_code"
 fi

--- a/scripts/agent/run-headless-claude.sh
+++ b/scripts/agent/run-headless-claude.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Run Claude Code with a file-backed prompt and preserve its pipeline exit code.
+
+set -uo pipefail
+
+: "${PROMPT_FILE:?PROMPT_FILE is required}"
+: "${ANTHROPIC_MODEL:?ANTHROPIC_MODEL is required}"
+: "${MAX_BUDGET_USD:?MAX_BUDGET_USD is required}"
+: "${ALLOWED_TOOLS:?ALLOWED_TOOLS is required}"
+: "${OUTPUT_FILE:?OUTPUT_FILE is required}"
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+if [ ! -f "$PROMPT_FILE" ]; then
+  echo "headless agent prompt file not found: $PROMPT_FILE" >&2
+  exit 2
+fi
+if [ ! -f "$RUNNER_TEMP/redact-agent-stream.py" ]; then
+  echo "headless agent redactor not found in RUNNER_TEMP" >&2
+  exit 2
+fi
+
+set +e  # preflight-allow: swallow - PIPESTATUS captures Claude's exit below
+claude -p \
+  --model "$ANTHROPIC_MODEL" \
+  --max-budget-usd "$MAX_BUDGET_USD" \
+  --allowedTools "$ALLOWED_TOOLS" \
+  --input-format text \
+  --output-format stream-json --verbose \
+  --exclude-dynamic-system-prompt-sections \
+  < "$PROMPT_FILE" \
+  2>&1 \
+  | python3 "$RUNNER_TEMP/redact-agent-stream.py" \
+  | tee "$OUTPUT_FILE"
+code=${PIPESTATUS[0]}
+set -e
+
+echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+echo "agent exited with code $code"
+if [ "${FAIL_ON_ERROR:-true}" = "true" ] && [ "$code" -ne 0 ]; then
+  echo "::error::headless agent exited $code"
+  exit "$code"
+fi

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2348,14 +2348,16 @@ fi
 
 echo ""
 echo "=== sub2api: headless-agent composite sharing ==="
-# The headless `claude -p` scaffold (CLI install + origin/main redactor staging +
-# canonical thinking-env + claude->redact->tee) lives in ONE composite action so
-# the agent workflows can't re-grow divergent copies (they had already
+# The headless `claude -p` scaffold is owned by ONE composite action plus its
+# file-backed runner (CLI install + origin/main redactor staging + canonical
+# thinking-env + claude->redact->tee), so agent workflows can't re-grow
+# divergent copies (they had already
 # drifted: ops-daily-diagnostics ran MAX_THINKING_TOKENS=16000 + omitted
 # set -o pipefail). Fail closed if any agent workflow re-inlines `claude -p` or
 # stops using the action, or if the composite loses its single-source
 # thinking-env / pipefail / fail-closed redactor.
 _hac_action=".github/actions/run-headless-agent/action.yml"
+_hac_runner="scripts/agent/run-headless-claude.sh"
 _hac_files=".github/workflows/pr-repair-agent.yml .github/workflows/upstream-issue-watchdog.yml .github/workflows/upstream-merge-agent-daily.yml .github/workflows/ops-daily-diagnostics.yml .github/workflows/ops-repair-draft.yml"
 _hac_ok=1
 if [ ! -f "$_hac_action" ]; then
@@ -2365,14 +2367,29 @@ else
     grep -q 'MAX_THINKING_TOKENS: "31999"' "$_hac_action" || {
         echo "  FAIL: $_hac_action lost the canonical MAX_THINKING_TOKENS=31999 single source"
         errors=$((errors + 1)); _hac_ok=0; }
-    grep -q 'set -o pipefail' "$_hac_action" || {
-        echo "  FAIL: $_hac_action lost set -o pipefail (claude exit code would be masked by tee)"
-        errors=$((errors + 1)); _hac_ok=0; }
     grep -q 'refusing to run the agent unredacted' "$_hac_action" || {
         echo "  FAIL: $_hac_action redactor lost its fail-closed refusal"
         errors=$((errors + 1)); _hac_ok=0; }
+    grep -q 'bash scripts/agent/run-headless-claude.sh' "$_hac_action" || {
+        echo "  FAIL: $_hac_action must delegate execution to the file-backed runner"
+        errors=$((errors + 1)); _hac_ok=0; }
     if grep -q 'for line in sys.stdin' "$_hac_action"; then
         echo "  FAIL: $_hac_action redactor reintroduced a passthrough fallback (must stay fail-closed)"
+        errors=$((errors + 1)); _hac_ok=0
+    fi
+fi
+if [ ! -f "$_hac_runner" ]; then
+    echo "  FAIL: $_hac_runner missing (the file-backed headless-agent runner)"
+    errors=$((errors + 1)); _hac_ok=0
+else
+    grep -q 'set -uo pipefail' "$_hac_runner" || {
+        echo "  FAIL: $_hac_runner lost pipefail (claude exit code would be masked by tee)"
+        errors=$((errors + 1)); _hac_ok=0; }
+    grep -q '< "$PROMPT_FILE"' "$_hac_runner" || {
+        echo "  FAIL: $_hac_runner must stream PROMPT_FILE over stdin"
+        errors=$((errors + 1)); _hac_ok=0; }
+    if grep -q '\$(cat .*PROMPT_FILE' "$_hac_runner"; then
+        echo "  FAIL: $_hac_runner passed PROMPT_FILE through argv (large prompts exceed MAX_ARG_STRLEN)"
         errors=$((errors + 1)); _hac_ok=0
     fi
 fi
@@ -2387,7 +2404,7 @@ for _f in $_hac_files; do
     fi
 done
 [ "$_hac_ok" = 1 ] && echo "  ok: agent workflows share the run-headless-agent composite (single-source scaffold)"
-unset _hac_action _hac_files _hac_ok _f
+unset _hac_action _hac_runner _hac_files _hac_ok _f
 
 echo ""
 echo "=== sub2api: skip-ci marker (local commits) ==="

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2355,7 +2355,7 @@ echo "=== sub2api: headless-agent composite sharing ==="
 # drifted: ops-daily-diagnostics ran MAX_THINKING_TOKENS=16000 + omitted
 # set -o pipefail). Fail closed if any agent workflow re-inlines `claude -p` or
 # stops using the action, or if the composite loses its single-source
-# thinking-env / pipefail / fail-closed redactor.
+# thinking-env / pipeline status capture / fail-closed redactor.
 _hac_action=".github/actions/run-headless-agent/action.yml"
 _hac_runner="scripts/agent/run-headless-claude.sh"
 _hac_files=".github/workflows/pr-repair-agent.yml .github/workflows/upstream-issue-watchdog.yml .github/workflows/upstream-merge-agent-daily.yml .github/workflows/ops-daily-diagnostics.yml .github/workflows/ops-repair-draft.yml"
@@ -2384,6 +2384,15 @@ if [ ! -f "$_hac_runner" ]; then
 else
     grep -q 'set -uo pipefail' "$_hac_runner" || {
         echo "  FAIL: $_hac_runner lost pipefail (claude exit code would be masked by tee)"
+        errors=$((errors + 1)); _hac_ok=0; }
+    grep -q 'pipeline_status=("${PIPESTATUS\[@\]}")' "$_hac_runner" || {
+        echo "  FAIL: $_hac_runner must capture every pipeline exit code immediately"
+        errors=$((errors + 1)); _hac_ok=0; }
+    grep -q 'headless agent redactor exited' "$_hac_runner" || {
+        echo "  FAIL: $_hac_runner must fail closed when the redactor exits non-zero"
+        errors=$((errors + 1)); _hac_ok=0; }
+    grep -q 'headless agent output writer exited' "$_hac_runner" || {
+        echo "  FAIL: $_hac_runner must surface tee/output failures"
         errors=$((errors + 1)); _hac_ok=0; }
     grep -q '< "$PROMPT_FILE"' "$_hac_runner" || {
         echo "  FAIL: $_hac_runner must stream PROMPT_FILE over stdin"


### PR DESCRIPTION
## 摘要

- 将 headless Claude 的 prompt 从单个 argv 参数改为通过 stdin 流式输入，避免 186 KiB 日报触发 Linux `Argument list too long`。
- 按 `(status_code, model, endpoint)` 保守匹配 `ops_error_logs` 与 access log，只把未捕获残差标为 `uncaptured_access_error`，避免 anomaly 重复计数。
- 对 `claude → redactor → tee` 三段 pipeline 分别保存退出状态：继续对外暴露 Claude 的 `exit_code`，但 redactor 或 output writer 失败时始终 fail closed。
- 新增 runner 行为测试与 preflight 回归守卫，防止 prompt 回退到 argv 或 pipeline 错误再次被静默吞掉。

## 风险

- 常规风险：修改共享 headless-agent 执行入口和日报分类逻辑，但不改变业务 API、计费、鉴权或数据状态。
- access 覆盖仅在三个维度完全匹配时扣减；不确定或不匹配的错误仍保留为低置信度 access residual。
- `fail_on_error=false` 仍只放行 Claude 自身的非零退出；redactor/tee 属于基础设施失败，现改为无条件硬失败。
- no-web-impact：仅涉及 GitHub Actions 运维自动化与离线诊断报告，无 Web surface 变化。

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS（使用本机 Python 3.12；系统 Python 3.9 不支持基线测试使用的 `tarfile.extractall(filter=...)`）。
- `python3.12 -m unittest discover -s ops/observability -p "test_*.py"`：131 tests passed。
- `bash -n scripts/agent/run-headless-claude.sh scripts/preflight.sh`：PASS。
- `git diff --check`：PASS。
- 回放线上 run 29976650174：anomalies 从 27 降为 18，9 条重复 access candidates 消失；targets、SLA totals 与 repair eligibility 不变。

## 提交

- `26205abab` fix(ops): repair daily diagnostics live regressions
- `c5d643fb0` fix(ops): fail closed on agent pipeline errors

最新提交：`c5d643fb0`