### PR TITLE
fix(ops): 将每日诊断 AI 预算收敛到修复候选

### DIFF
--- a/.github/actions/run-headless-agent/action.yml
+++ b/.github/actions/run-headless-agent/action.yml
@@ -2,13 +2,13 @@ name: Run headless Claude agent
 description: >-
   Single source of truth for the headless `claude -p` scaffold shared by the
   TokenKey agent workflows (pr-repair-agent, upstream-issue-watchdog,
-  upstream-merge-agent-daily, ops-daily-diagnostics). Installs the Claude Code
+  upstream-merge-agent-daily, ops-repair-draft). Installs the Claude Code
   CLI, stages the secret redactor from origin/main (fail-closed), and runs the
   agent with the canonical thinking-env, streaming the transcript through the
   redactor to an output file. Callers keep their own prompt construction, git /
   PR / issue logic, and artifact upload. Previously each workflow hand-copied
-  this block and the values had already drifted (ops-daily-diagnostics ran
-  MAX_THINKING_TOKENS=16000 and omitted set -o pipefail + autocompact).
+  this block and the values had already drifted before this action became the
+  shared owner.
 
 inputs:
   prompt_file:

--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -4,7 +4,8 @@ name: Ops Daily Diagnostics
 # Read-only diagnostics may reach prod/Edge through GHA → AWS STS (OIDC) → SSM.
 # Issue creation and repair dispatch are isolated from AWS credentials. This
 # workflow never deploys, rolls back, edits secrets, writes code, pushes
-# branches, or creates PRs; eligible repair work runs in ops-repair-draft.yml.
+# branches, or creates PRs. Daily classification is deterministic; eligible
+# repair work is the only AI-funded path and runs in ops-repair-draft.yml.
 
 on:
   schedule:
@@ -780,124 +781,9 @@ jobs:
             daily-error-report.json
             daily-error-report.md
 
-  claude-issue-diagnosis:
-    needs: aggregate-report
-    if: needs.aggregate-report.outputs.needs_issue == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: prod-ops-report-${{ github.run_id }}
-          path: .
-
-      - name: Check Claude token
-        id: claude_token
-        env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-        run: |
-          if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            cat > issue-diagnosis.md <<'EOF'
-          # Claude Issue Diagnosis
-
-          skipped: ANTHROPIC_AUTH_TOKEN is not configured; using deterministic issue bodies.
-          EOF
-            jq -n '{status:"skipped", reason:"ANTHROPIC_AUTH_TOKEN missing", findings:[]}' > issue-diagnosis.json
-            : > claude-issue-diagnosis.jsonl
-          fi
-
-      - name: Build read-only diagnosis prompt
-        if: steps.claude_token.outputs.present == 'true'
-        run: |
-          cat > /tmp/claude-issue-prompt.txt <<'EOF'
-          你是 TokenKey Prod Ops 只读诊断助手。基于下面的 Prod Ops 结构化报告和当前仓库文件，生成更准确的 GitHub issue 诊断建议。
-
-          硬约束：
-          - 只做诊断和归因，不修改文件，不创建 PR，不运行命令，不访问 AWS，不 dispatch workflow。
-          - 不要求历史兼容；只基于当前已合并机制和当前仓库事实。
-          - 对每个 issue-worthy finding 输出：root_cause_hypothesis、evidence、suggested_owner_action、confidence、issue_title、issue_body。
-          - 如果证据不足，明确写 confidence=low 和需要人工确认的点。
-          - 输出 Markdown，便于直接放进 GitHub Issue。
-          EOF
-          printf '\n## ops-report.md\n\n' >> /tmp/claude-issue-prompt.txt
-          cat ops-report.md >> /tmp/claude-issue-prompt.txt
-          printf '\n\n## ops-report.json\n\n```json\n' >> /tmp/claude-issue-prompt.txt
-          cat ops-report.json >> /tmp/claude-issue-prompt.txt
-          printf '\n```\n' >> /tmp/claude-issue-prompt.txt
-          printf '\n\n## daily-error-report.md\n\n' >> /tmp/claude-issue-prompt.txt
-          cat daily-error-report.md >> /tmp/claude-issue-prompt.txt
-          printf '\n\n## daily-error-report.json\n\n```json\n' >> /tmp/claude-issue-prompt.txt
-          cat daily-error-report.json >> /tmp/claude-issue-prompt.txt
-          printf '\n```\n' >> /tmp/claude-issue-prompt.txt
-
-      - name: Run Claude read-only diagnosis
-        if: steps.claude_token.outputs.present == 'true'
-        id: claude_run
-        # continue-on-error stays: a failed diagnosis falls back to deterministic
-        # issue bodies. Via the shared action this now also gains set -o pipefail
-        # (previously omitted here, so a claude failure was masked by tee's exit
-        # code) and the canonical thinking-env (was MAX_THINKING_TOKENS=16000;
-        # the $1 budget still caps cost) + the origin/main fail-closed redactor.
-        continue-on-error: true
-        uses: ./.github/actions/run-headless-agent
-        with:
-          prompt_file: /tmp/claude-issue-prompt.txt
-          model: "opus[1m]"
-          max_budget_usd: "1.00"
-          allowed_tools: "Read Grep Glob"
-          auth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          output_file: claude-issue-diagnosis.jsonl
-
-      - name: Extract Claude diagnosis
-        if: steps.claude_token.outputs.present == 'true'
-        env:
-          CLAUDE_EXIT_CODE: ${{ steps.claude_run.outputs.exit_code }}
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          import json
-          import os
-          import pathlib
-
-          stream = pathlib.Path('claude-issue-diagnosis.jsonl')
-          texts = []
-          if stream.exists():
-              for line in stream.read_text(encoding='utf-8', errors='replace').splitlines():
-                  try:
-                      item = json.loads(line)
-                  except json.JSONDecodeError:
-                      continue
-                  if isinstance(item.get('result'), str):
-                      texts.append(item['result'])
-          body = '\n\n'.join(text for text in texts if text.strip()).strip()
-          exit_code = os.environ.get('CLAUDE_EXIT_CODE') or 'unknown'
-          status = 'ok' if exit_code == '0' and body else 'failed'
-          if status != 'ok':
-              body = f'Claude diagnosis unavailable (exit_code={exit_code}); deterministic findings remain authoritative.'
-          pathlib.Path('issue-diagnosis.md').write_text('# Claude Issue Diagnosis\n\n' + body + '\n', encoding='utf-8')
-          pathlib.Path('issue-diagnosis.json').write_text(json.dumps({'status':status, 'exit_code':exit_code, 'markdown': body}, indent=2) + '\n', encoding='utf-8')
-          PY
-
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: prod-ops-claude-diagnosis-${{ github.run_id }}
-          path: |
-            issue-diagnosis.json
-            issue-diagnosis.md
-            claude-issue-diagnosis.jsonl
-
   decision-and-issue:
-    needs:
-      - aggregate-report
-      - claude-issue-diagnosis
-    if: always() && needs.aggregate-report.result == 'success'
+    needs: aggregate-report
+    if: needs.aggregate-report.result == 'success' && needs.aggregate-report.outputs.needs_issue == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -909,12 +795,6 @@ jobs:
         with:
           name: prod-ops-report-${{ github.run_id }}
           path: .
-
-      - uses: actions/download-artifact@v4
-        if: needs.claude-issue-diagnosis.result == 'success'
-        with:
-          name: prod-ops-claude-diagnosis-${{ github.run_id }}
-          path: claude-diagnosis
 
       - name: Open or update issues
         env:
@@ -928,14 +808,10 @@ jobs:
           import re
           import subprocess
 
+          from ops.observability.daily_error_report import issue_analysis_markdown
+
           report = json.loads(pathlib.Path('ops-report.json').read_text(encoding='utf-8'))
-          diagnosis_json = pathlib.Path('claude-diagnosis/issue-diagnosis.json')
-          diagnosis_path = pathlib.Path('claude-diagnosis/issue-diagnosis.md')
-          diagnosis = ''
-          if diagnosis_json.exists() and diagnosis_path.exists():
-              diagnosis_meta = json.loads(diagnosis_json.read_text(encoding='utf-8'))
-              if diagnosis_meta.get('status') == 'ok':
-                  diagnosis = diagnosis_path.read_text(encoding='utf-8')
+          daily_report = json.loads(pathlib.Path('daily-error-report.json').read_text(encoding='utf-8'))
           findings = report.get('issue_candidates') or []
           if not findings:
               print('No issue-worthy findings.')
@@ -994,8 +870,9 @@ jobs:
                   '',
                   f"See artifact `prod-ops-report-{report.get('run_id')}` for `ops-report.json` and per-target reports.",
               ]
-              if diagnosis:
-                  body_lines += ['', '## Claude read-only diagnosis', '', diagnosis]
+              analysis = issue_analysis_markdown(daily_report, target_id) if kind == 'daily_error_report' else ''
+              if analysis:
+                  body_lines += ['', '## Deterministic error analysis', '', analysis]
               body = '\n'.join(body_lines) + '\n'
               body_file = pathlib.Path(f'issue-{index}.md')
               body_file.write_text(body, encoding='utf-8')

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -864,8 +864,9 @@ GitHub Actions 不再用长期 AWS 凭证，**OIDC 临时换 STS** → `ssm:Send
 - 手动 target selector：`all`、`prod`、`edge:*`、`edge:<id>`；`deployable=false` 的 Edge 只进入 excluded summary。
 - 输出：每个目标上传 `prod-ops-target-<target>-<run_id>` artifact，汇总上传 `prod-ops-report-<run_id>`。
 - Issue 决策：`issue_candidate` / `manual_ops` findings 会创建或更新 GitHub Issue，使用 `ops-sig:*`、`target:*`、`finding:*` label 去重；error cluster 继续附带 `cluster-sig:*`。
-- 可选 Claude 诊断：`ANTHROPIC_AUTH_TOKEN` 存在时，workflow 可运行只读 Claude diagnosis 改善 issue 内容；该 job 无 AWS OIDC、无 repo 写权限，只允许 `Read/Grep/Glob`。
-- Graceful degradation：缺 `AWS_OIDC_ROLE_ARN` / 缺 `qa_records` / 缺 Claude token → skip 或 deterministic fallback，不让 cron 因非核心缺口脆断。
+- 确定性分类：`daily_error_report` Issue 按 target 附带 priority、state、owner/phase、HTTP、类型、平台/模型、endpoint、current/previous 与 confidence；daily workflow 不运行 AI。
+- 修复预算隔离：只有高置信、代码归属明确的候选才 dispatch 到 `ops-repair-draft.yml`，由独立 workflow 使用 AI 形成 Draft PR 等待人工 review。
+- Graceful degradation：缺 `AWS_OIDC_ROLE_ARN` / 缺 `qa_records` → skip 或 deterministic fallback，不让 cron 因非核心缺口脆断。
 - 验证手动跑：`gh workflow run ops-daily-diagnostics.yml -f operation=diagnostics -f target_selector=prod -f since_hours=24 -R youxuanxue/sub2api`
 
 ### Cloud Agent 拉取 Prod Ops 报告

--- a/ops/observability/daily_error_report.py
+++ b/ops/observability/daily_error_report.py
@@ -390,6 +390,49 @@ def aggregate_markdown(report: dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def issue_analysis_markdown(report: dict[str, Any], target_id: str, limit: int = 10) -> str:
+    """Render the highest-priority deterministic classifications for one target."""
+
+    def cell(value: Any, text_limit: int = 120) -> str:
+        return clean_text(value, text_limit).replace("|", "\\|").replace("`", "'")
+
+    target = clean_text(target_id, 80)
+    candidates = [
+        item
+        for item in (report.get("issue_candidates") or [])
+        if clean_text(item.get("target_id"), 80) == target
+    ]
+    candidates.sort(key=lambda row: (-as_int(row.get("priority")), clean_text(row.get("signature"), 120)))
+    if not candidates:
+        return ""
+
+    shown = candidates[: max(limit, 0)]
+    lines = [
+        "| Priority | State | Owner / phase | HTTP | Type | Platform / model | Endpoint | Current / previous | Confidence |",
+        "| ---: | --- | --- | ---: | --- | --- | --- | ---: | --- |",
+    ]
+    for item in shown:
+        lines.append(
+            "| {priority} | {state} | {owner} / {phase} | {status} | {error_type} | {platform} / {model} | {endpoint} | {current} / {previous} | {confidence} |".format(
+                priority=as_int(item.get("priority")),
+                state=cell(item.get("state"), 32),
+                owner=cell(item.get("owner"), 32),
+                phase=cell(item.get("phase"), 48),
+                status=as_int(item.get("status_code")),
+                error_type=cell(item.get("error_type"), 96),
+                platform=cell(item.get("platform"), 64),
+                model=cell(item.get("model")),
+                endpoint=cell(item.get("endpoint")),
+                current=as_int(item.get("current_count")),
+                previous=as_int(item.get("previous_count")),
+                confidence=cell(item.get("confidence"), 16),
+            )
+        )
+    if len(candidates) > len(shown):
+        lines += ["", f"Showing the top {len(shown)} of {len(candidates)} classifications by priority."]
+    return "\n".join(lines)
+
+
 def select_candidate(report: dict[str, Any], signature: str) -> dict[str, Any]:
     matches = [item for item in report.get("repair_candidates") or [] if item.get("signature") == signature]
     if len(matches) != 1:

--- a/ops/observability/test_daily_error_report.py
+++ b/ops/observability/test_daily_error_report.py
@@ -21,6 +21,7 @@ build_report = MODULE.build_report
 select_candidate = MODULE.select_candidate
 aggregate_reports = MODULE.aggregate_reports
 aggregate_markdown = MODULE.aggregate_markdown
+issue_analysis_markdown = MODULE.issue_analysis_markdown
 
 
 def probe_fixture() -> str:
@@ -255,6 +256,29 @@ esac
             markdown = aggregate_markdown(report)
             self.assertIn("| prod | issue_candidate | 120 | 15 | 5 | 8 |", markdown)
             self.assertIn("dashboard_query_failed", markdown)
+
+    def test_issue_analysis_is_target_scoped_and_actionable(self) -> None:
+        prod = build_report(probe_fixture(), "prod")
+        edge = build_report(probe_fixture(), "edge-us5-ls")
+        edge["issue_candidates"][0]["error_type"] = "edge_only_failure"
+        aggregate = aggregate_reports([], "123", "https://example.test/runs/123")
+        aggregate["issue_candidates"] = [
+            {**item, "target_id": "prod"} for item in prod["issue_candidates"]
+        ] + [
+            {**item, "target_id": "edge-us5-ls"} for item in edge["issue_candidates"]
+        ]
+
+        markdown = issue_analysis_markdown(aggregate, "prod")
+
+        self.assertIn("| Priority | State | Owner / phase |", markdown)
+        self.assertIn("platform / internal", markdown)
+        self.assertIn("dashboard_query_failed", markdown)
+        self.assertIn("7 / 0", markdown)
+        self.assertNotIn("edge_only_failure", markdown)
+
+    def test_issue_analysis_is_empty_for_unmatched_target(self) -> None:
+        report = aggregate_reports([], "123", "https://example.test/runs/123")
+        self.assertEqual(issue_analysis_markdown(report, "prod"), "")
 
     def test_same_cluster_on_two_targets_has_unique_selectable_signatures(self) -> None:
         prod = build_report(probe_fixture(), "prod")

--- a/ops/observability/test_ops_daily_diagnostics_workflow.py
+++ b/ops/observability/test_ops_daily_diagnostics_workflow.py
@@ -135,7 +135,10 @@ class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
     def test_daily_triage_is_deterministic_and_agent_budget_is_repair_only(self) -> None:
         text = workflow_text()
         self.assertNotIn("run-headless-agent", text)
+        self.assertNotIn("setup-claude-code", text)
+        self.assertNotRegex(text, r"\bclaude\s+(?:-p|--print)\b")
         self.assertNotIn("ANTHROPIC_AUTH_TOKEN", text)
+        self.assertNotIn("CLAUDE_CODE_OAUTH_TOKEN", text)
         self.assertNotIn("max_budget_usd:", text)
         self.assertIn("issue_analysis_markdown", text)
         self.assertIn("## Deterministic error analysis", text)

--- a/ops/observability/test_ops_daily_diagnostics_workflow.py
+++ b/ops/observability/test_ops_daily_diagnostics_workflow.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ops-daily-diagnostics.yml"
+REPAIR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ops-repair-draft.yml"
 
 
 def workflow_text() -> str:
@@ -131,12 +132,18 @@ class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
         self.assertNotIn("id-token: write", queue)
         self.assertNotIn("aws ", queue)
 
-    def test_failed_claude_run_cannot_publish_partial_thoughts_as_diagnosis(self) -> None:
+    def test_daily_triage_is_deterministic_and_agent_budget_is_repair_only(self) -> None:
         text = workflow_text()
-        self.assertIn("CLAUDE_EXIT_CODE", text)
-        self.assertIn("status = 'ok' if exit_code == '0' and body else 'failed'", text)
-        self.assertNotIn("message.get('content')", text)
-        self.assertIn("if diagnosis_meta.get('status') == 'ok':", text)
+        self.assertNotIn("run-headless-agent", text)
+        self.assertNotIn("ANTHROPIC_AUTH_TOKEN", text)
+        self.assertNotIn("max_budget_usd:", text)
+        self.assertIn("issue_analysis_markdown", text)
+        self.assertIn("## Deterministic error analysis", text)
+        self.assertIn("needs.aggregate-report.outputs.needs_issue == 'true'", text)
+
+        repair = REPAIR_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("uses: ./.github/actions/run-headless-agent", repair)
+        self.assertIn('max_budget_usd: "8.00"', repair)
 
 
 if __name__ == "__main__":

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2351,14 +2351,14 @@ echo "=== sub2api: headless-agent composite sharing ==="
 # The headless `claude -p` scaffold is owned by ONE composite action plus its
 # file-backed runner (CLI install + origin/main redactor staging + canonical
 # thinking-env + claude->redact->tee), so agent workflows can't re-grow
-# divergent copies (they had already
-# drifted: ops-daily-diagnostics ran MAX_THINKING_TOKENS=16000 + omitted
-# set -o pipefail). Fail closed if any agent workflow re-inlines `claude -p` or
-# stops using the action, or if the composite loses its single-source
-# thinking-env / pipeline status capture / fail-closed redactor.
+# divergent copies. Fail closed if any agent workflow re-inlines `claude -p`
+# or stops using the action, or if the composite loses its single-source
+# thinking-env / pipeline status capture / fail-closed redactor. Daily
+# diagnostics stays deterministic; AI budget belongs to eligible repair work.
 _hac_action=".github/actions/run-headless-agent/action.yml"
 _hac_runner="scripts/agent/run-headless-claude.sh"
-_hac_files=".github/workflows/pr-repair-agent.yml .github/workflows/upstream-issue-watchdog.yml .github/workflows/upstream-merge-agent-daily.yml .github/workflows/ops-daily-diagnostics.yml .github/workflows/ops-repair-draft.yml"
+_hac_files=".github/workflows/pr-repair-agent.yml .github/workflows/upstream-issue-watchdog.yml .github/workflows/upstream-merge-agent-daily.yml .github/workflows/ops-repair-draft.yml"
+_hac_daily=".github/workflows/ops-daily-diagnostics.yml"
 _hac_ok=1
 if [ ! -f "$_hac_action" ]; then
     echo "  FAIL: $_hac_action missing (the shared headless-agent scaffold)"
@@ -2412,8 +2412,15 @@ for _f in $_hac_files; do
         errors=$((errors + 1)); _hac_ok=0
     fi
 done
+if [ ! -f "$_hac_daily" ]; then
+    echo "  FAIL: $_hac_daily missing (the deterministic daily triage workflow)"
+    errors=$((errors + 1)); _hac_ok=0
+elif grep -Eq 'run-headless-agent|ANTHROPIC_AUTH_TOKEN|max_budget_usd:' "$_hac_daily"; then
+    echo "  FAIL: $_hac_daily must keep daily triage deterministic and reserve AI budget for repair"
+    errors=$((errors + 1)); _hac_ok=0
+fi
 [ "$_hac_ok" = 1 ] && echo "  ok: agent workflows share the run-headless-agent composite (single-source scaffold)"
-unset _hac_action _hac_runner _hac_files _hac_ok _f
+unset _hac_action _hac_runner _hac_files _hac_daily _hac_ok _f
 
 echo ""
 echo "=== sub2api: skip-ci marker (local commits) ==="

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2415,7 +2415,7 @@ done
 if [ ! -f "$_hac_daily" ]; then
     echo "  FAIL: $_hac_daily missing (the deterministic daily triage workflow)"
     errors=$((errors + 1)); _hac_ok=0
-elif grep -Eq 'run-headless-agent|ANTHROPIC_AUTH_TOKEN|max_budget_usd:' "$_hac_daily"; then
+elif grep -Eq 'run-headless-agent|setup-claude-code|(^|[^[:alnum:]_-])claude[[:space:]]+(-p|--print)([[:space:]]|$)|ANTHROPIC_AUTH_TOKEN|CLAUDE_CODE_OAUTH_TOKEN|max_budget_usd:' "$_hac_daily"; then
     echo "  FAIL: $_hac_daily must keep daily triage deterministic and reserve AI budget for repair"
     errors=$((errors + 1)); _hac_ok=0
 fi


### PR DESCRIPTION
## 摘要

- 移除 ops-daily-diagnostics 中连续触发预算上限、但不参与 Issue 或 repair 决策的 Claude advisory job，使每日固定模型成本归零。
- 将 daily-error-report 已有的 priority、state、owner/phase、HTTP、类型、平台/模型、endpoint、current/previous 和 confidence 按 target 确定性写入对应 Issue。
- 保留 ops-repair-draft 的 Opus 预算门禁，仅对高置信、代码归属明确且可形成 Draft PR 的候选使用模型预算。
- 增加 preflight sentinel 和聚焦测试，阻止 daily workflow 重新引入共享 action、直接 Claude print mode、Claude token 或模型预算。
- 同步运维 runbook，明确 daily 确定性分类与 repair-only AI 预算边界。

## 风险

- 内部 Ops workflow 行为调整，无 Web 影响。
- daily 不再上传 Claude diagnosis artifact；Issue 分类和 repair dispatch 均继续由原确定性报告驱动。
- ops-repair-draft 的候选筛选、预算和人工 Review 门禁不变。

## 验证

- `python3 -m unittest ops.observability.test_daily_error_report ops.observability.test_ops_daily_diagnostics_workflow ops.observability.test_ops_repair_draft_workflow ops.observability.test_headless_agent_runner`：30 tests passed。
- 使用 Run 29980836642 的真实 `daily-error-report.json` 回放 prod Issue 分类表，输出 4 条 target-scoped 异常且无跨 target 混入。
- PyYAML 解析 `ops-daily-diagnostics.yml` 与 `ops-repair-draft.yml` 通过。
- Python 3.12 环境执行 `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS。

## 提交

- 02ce28df5 fix(ops): reserve agent budget for repair candidates
- f4f876fa3 fix(ops): address review budget guard gaps
- 最新提交：f4f876fa3
