### PR TITLE
chore(fingerprint): 对齐 Grok CLI 0.2.111 与 Kiro IDE 1.0.203

### DIFF
--- a/backend/internal/pkg/kiro/constants.go
+++ b/backend/internal/pkg/kiro/constants.go
@@ -41,7 +41,7 @@ const (
 // defaults remain tied to the last on-wire baseline. The vendored integration
 // layer derives its IDE default from this owner so both User-Agent paths stay in sync.
 const (
-	DefaultKiroIDEVersion = "1.0.165"
+	DefaultKiroIDEVersion = "1.0.203"
 	// DefaultKiroCLIVersion tracks Homebrew cask kiro-cli (distinct semver from Kiro IDE).
 	DefaultKiroCLIVersion = "2.14.0"
 	DefaultSystemVersion  = "darwin#24.0.0"

--- a/backend/internal/pkg/xai/oauth.go
+++ b/backend/internal/pkg/xai/oauth.go
@@ -41,7 +41,7 @@ const (
 	// DefaultGrokCLIVersion is the upstream grok-cli semver TokenKey watches for OAuth relay
 	// fingerprint drift (npm @xai-official/grok). Bump via tokenkey-grok-fingerprint-alignment.
 	// Watch-only today — on-wire grok-cli/* UA lives in openai_gateway_grok.go, not this const.
-	DefaultGrokCLIVersion = "0.2.108"
+	DefaultGrokCLIVersion = "0.2.111"
 )
 
 var (

--- a/deploy/aws/stage0/tk_canonical_kiro_ide.json
+++ b/deploy/aws/stage0/tk_canonical_kiro_ide.json
@@ -72,12 +72,12 @@
     "source": "passive-pcap"
   },
   "expected_http": {
-    "kiro_ide_version": "1.0.165",
+    "kiro_ide_version": "1.0.203",
     "streaming_sdk_version": "1.0.34",
     "node_version": "22.22.0",
     "system_version": "darwin#24.0.0",
-    "user_agent": "aws-sdk-js/1.0.34 ua/2.1 os/darwin#24.0.0 lang/js md/nodejs#22.22.0 api/codewhispererstreaming#1.0.34 m/E KiroIDE-1.0.165",
-    "x_amz_user_agent": "aws-sdk-js/1.0.34 KiroIDE-1.0.165",
+    "user_agent": "aws-sdk-js/1.0.34 ua/2.1 os/darwin#24.0.0 lang/js md/nodejs#22.22.0 api/codewhispererstreaming#1.0.34 m/E KiroIDE-1.0.203",
+    "x_amz_user_agent": "aws-sdk-js/1.0.34 KiroIDE-1.0.203",
     "source": "repo-constants"
   }
 }

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -54,7 +54,8 @@
         "StreamingUserAgent",
         "BuildUserAgent",
         "DefaultKiroIDEVersion",
-        "DefaultKiroAccountPriority"
+        "DefaultKiroAccountPriority",
+        "1.0.203"
       ],
       "rationale": "TK-side canonical KiroIDE client identity + User-Agent builder used for fingerprint mimicry. If dropped, kiro egress loses its KiroIDE-<ver> UA and is trivially distinguishable from the real client. DefaultKiroAccountPriority is the creation-time default for native Kiro accounts when callers omit priority."
     },


### PR DESCRIPTION
## 摘要

- **#1421 Grok CLI**：npm `@xai-official/grok` 最新 `0.2.111`，本机安装并通过 `capture-grok-fingerprint.sh check` 验证后 bump `DefaultGrokCLIVersion`。
- **#1422 Kiro IDE**：Homebrew cask `kiro` 最新 `1.0.203`，本机重装确认版本后 bump `DefaultKiroIDEVersion` 与 `tk_canonical_kiro_ide.json` 的 `expected_http` UA 字段。
- Kiro TLS `observed.ja3_*` 沿用 1.0.165 被动抓包证据（与 #1369 相同策略：IDE 小版本 bump 不推断 JA3）。
- `scripts/sentinels/kiro.json` 同步 anchor `1.0.203`，满足 registry update gate。
- 无 gateway 转发/计费/鉴权行为变化。
- Web impact: none

## 风险

- 低风险：仅更新 client-release watch pin 与 canonical HTTP 期望快照。
- Kiro TLS 开闸 profile 未改；若后续 Kiro 升级 Electron/OpenSSL 栈，需补 passive pcap 再刷新 `observed.ja3_hash`。

## 验证

- `bash ops/xai/capture-grok-fingerprint.sh check`：pinned=installed=0.2.111 ✓
- `bash ops/kiro/probe-runtime-gateway.sh --dry-run --header-style tokenkey runtime-chat`：UA `KiroIDE-1.0.203` ✓
- `go test -tags=unit ./internal/pkg/xai/... ./internal/pkg/kiro/... ./internal/integration/kiro/...`：PASS
- `python3 -m unittest discover -s ops/kiro -p 'test_*.py'`：28 tests PASS
- `./scripts/preflight.sh`：PASS

## 提交

- `f97b20518` chore(grok): 对齐 Grok CLI OAuth pin 至上游 0.2.111
- `2447fb3b1` chore(kiro): 对齐 Kiro IDE UA pin 至 Homebrew 1.0.203
- `d6cefb10e` chore: refresh PR #1432 head sync
- `2a0f6e91f` chore: trigger CI after sentinel-registry-reviewed PR body update
- `1ec88a157` chore(kiro): anchor IDE 1.0.203 in sentinel registry
- 最新提交：`1ec88a157`

Fixes #1421
Fixes #1422