### PR TITLE
fix(ops): 账号容量异常只走飞书告警

### DIFF
--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -596,6 +596,9 @@ jobs:
                     issue_candidate)
                       add_finding "daily_error_report" "issue_candidate" "error" "Daily error anomalies detected for $TARGET_ID" "$DAILY_SUMMARY" "daily-errors|$TARGET_ID"
                       ;;
+                    alert_covered)
+                      add_finding "daily_error_report" "ok" "info" "Daily error anomalies are covered by Feishu for $TARGET_ID" "$DAILY_SUMMARY" "daily-errors|$TARGET_ID|feishu"
+                      ;;
                     skip)
                       add_finding "daily_error_report" "skip" "info" "Daily error report skipped for $TARGET_ID" "$DAILY_SUMMARY" "daily-errors|$TARGET_ID|skip"
                       ;;

--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -405,18 +405,18 @@ jobs:
 
           findings = []
           rules = [
-              ("gemini_drive_scope_403", 10, "error", "Gemini OAuth Drive API scope missing on {target_id}", "Gemini OAuth Drive API scope 403 appeared {count} times in tokenkey logs over {window}.", "log-signal|{target_id}|gemini-drive-scope-403"),
-              ("openai_previous_response_fallback", 50, "warning", "OpenAI-compatible previous_response fallback is frequent on {target_id}", "previous_response_id fallback appeared {count} times in tokenkey logs over {window}.", "log-signal|{target_id}|openai-previous-response-fallback"),
-              ("rate_limit_429_no_reset", 1, "warning", "429 cooldown skipped because reset time is missing on {target_id}", "rate_limit_429_no_reset_time_skipped appeared {count} times in tokenkey logs over {window}.", "log-signal|{target_id}|rate-limit-429-no-reset"),
+              ("gemini_drive_scope_403", 10, "warning", "error", "Gemini OAuth Drive API scope missing on {target_id}", "Gemini OAuth Drive API scope 403 appeared {count} times in tokenkey logs over {window}.", "log-signal|{target_id}|gemini-drive-scope-403"),
+              ("openai_previous_response_fallback", 50, "issue_candidate", "warning", "OpenAI-compatible previous_response fallback is frequent on {target_id}", "previous_response_id fallback appeared {count} times in tokenkey logs over {window}.", "log-signal|{target_id}|openai-previous-response-fallback"),
+              ("rate_limit_429_no_reset", 1, "warning", "warning", "429 cooldown skipped because reset time is missing on {target_id}", "rate_limit_429_no_reset_time_skipped appeared {count} times in tokenkey logs over {window}.", "log-signal|{target_id}|rate-limit-429-no-reset"),
           ]
-          for kind, threshold, severity, title_template, summary_template, signature_template in rules:
+          for kind, threshold, status, severity, title_template, summary_template, signature_template in rules:
               count = as_int(kind)
               if count < threshold:
                   continue
               findings.append({
                   "target_id": target_id,
                   "kind": kind,
-                  "status": "issue_candidate",
+                  "status": status,
                   "severity": severity,
                   "title": title_template.format(target_id=target_id),
                   "summary": summary_template.format(count=count, window=window),
@@ -558,7 +558,7 @@ jobs:
                         add_finding "error_clustering" "skip" "info" "Error clustering skipped for $TARGET_ID" "$SUMMARY" "error-clustering|$TARGET_ID|skip"
                       elif [ "${PERSISTENT:-0}" -gt 0 ]; then
                         SIG="$(jq -r '.persistent_clusters[0].signature // .clusters[0].signature // "no-sig"' "$OUT/error-report.json")"
-                        add_finding "error_cluster" "issue_candidate" "error" "Persistent error cluster detected for $TARGET_ID" "$SUMMARY" "error-cluster|$TARGET_ID|$SIG"
+                        add_finding "error_cluster" "warning" "warning" "Persistent legacy error cluster detected for $TARGET_ID" "$SUMMARY" "error-cluster|$TARGET_ID|$SIG"
                       else
                         add_finding "error_clustering" "ok" "info" "No persistent error cluster for $TARGET_ID" "$SUMMARY" "error-clustering|$TARGET_ID|ok"
                       fi

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -863,8 +863,8 @@ GitHub Actions 不再用长期 AWS 凭证，**OIDC 临时换 STS** → `ssm:Send
 - 默认 operation：`diagnostics`，覆盖 prod + `deploy/aws/lightsail/edge-targets-lightsail.json` 里 `deployable=true` 的 Lightsail Edge（edges 均为 Lightsail；`deploy/aws/stage0/edge-targets.json` 已清空为 stub）。
 - 手动 target selector：`all`、`prod`、`edge:*`、`edge:<id>`；`deployable=false` 的 Edge 只进入 excluded summary。
 - 输出：每个目标上传 `prod-ops-target-<target>-<run_id>` artifact，汇总上传 `prod-ops-report-<run_id>`。
-- Issue 决策：`issue_candidate` / `manual_ops` findings 会创建或更新 GitHub Issue，使用 `ops-sig:*`、`target:*`、`finding:*` label 去重；error cluster 继续附带 `cluster-sig:*`。
-- 确定性分类：`daily_error_report` Issue 按 target 附带 priority、state、owner/phase、HTTP、类型、平台/模型、endpoint、current/previous 与 confidence；daily workflow 不运行 AI。
+- Issue 决策：账号容量与 provider health 异常保留在日报并由现有飞书链路告警，不创建 GitHub Issue；其余 `issue_candidate` / `manual_ops` findings 才创建或更新 Issue，并使用 `ops-sig:*`、`target:*`、`finding:*` label 去重。
+- 确定性分类：日报按 target 展示 anomaly、Feishu 覆盖、GitHub Issue 候选和 repair 候选；GitHub Issue 仅附带未被飞书覆盖的 priority、state、owner/phase、HTTP、类型、平台/模型、endpoint、current/previous 与 confidence。daily workflow 不运行 AI。
 - 修复预算隔离：只有高置信、代码归属明确的候选才 dispatch 到 `ops-repair-draft.yml`，由独立 workflow 使用 AI 形成 Draft PR 等待人工 review。
 - Graceful degradation：缺 `AWS_OIDC_ROLE_ARN` / 缺 `qa_records` → skip 或 deterministic fallback，不让 cron 因非核心缺口脆断。
 - 验证手动跑：`gh workflow run ops-daily-diagnostics.yml -f operation=diagnostics -f target_selector=prod -f since_hours=24 -R youxuanxue/sub2api`

--- a/docs/approved/ops-unified-contract.md
+++ b/docs/approved/ops-unified-contract.md
@@ -3,7 +3,7 @@ title: Ops Unified Contract (QA + ErrorToIssue/PR)
 status: approved
 approved_by: youxuanxue
 approved_at: 2026-04-21
-updated_at: 2026-07-22
+updated_at: 2026-07-23
 created: 2026-04-21
 owners: [tk-platform]
 related_prs: ["#13", "#30"]
@@ -51,7 +51,9 @@ Required outcomes:
 - A sanitized `daily-error-report.{json,md}` combines SLA-equivalent totals from
   `usage_logs` and `ops_error_logs`, separates final failures from recovered
   upstream attempts, and classifies new/regressed/persistent/access-only clusters.
-- Optional Claude diagnosis may read the aggregate report and repository files to improve issue quality; it must not write files, run shell commands, access AWS, create branches, or create PRs.
+- Daily classification is deterministic. Account-capacity and provider-health
+  anomalies remain visible in the report but stay on the existing Feishu alert
+  path; they do not create or update GitHub Issues.
 
 Hard guardrails:
 
@@ -61,9 +63,13 @@ Hard guardrails:
 - `ops-repair-draft.yml` has repository write permissions but no AWS OIDC or
   production credentials. It may only create a Draft PR; it cannot merge,
   deploy, roll back, or change production configuration.
+- GitHub Issue candidates are limited to actionable anomalies not already owned
+  by Feishu. Provider-owned failures, 429s, account-auth failures, and routing
+  502/503 capacity signals remain report/Feishu evidence only.
 - Automatic repair is limited to repeated, platform-owned final 5xx clusters
   that are not classified as capacity, quota, rate-limit, auth, billing, or
-  provider failures. All other findings remain Issue/manual-ops signals.
+  provider failures. Probe/parsing failures and other manual-ops findings remain
+  GitHub Issue signals.
 - Before a Draft PR is opened, the repair agent must add a regression test,
   record a nonzero reproduction result before the fix and a zero result after
   it, rerun that command, pass `./scripts/preflight.sh`, and satisfy protected
@@ -74,7 +80,7 @@ Hard guardrails:
   size are revalidated after the reproduction command returns.
 - Signature cooldown / dedupe labels (`ops-sig:*`, plus `cluster-sig:*` for error clusters) avoid duplicate churn.
 - AWS diagnostics jobs have `id-token: write` but no repo write permissions.
-- Issue/Claude/repair-dispatch/repair jobs have no AWS OIDC permission.
+- Issue/repair-dispatch/repair jobs have no AWS OIDC permission.
 - Missing optional secret / missing required table => clean skip or deterministic fallback, not a brittle cron failure.
 
 Transport (since 2026-05-13):
@@ -109,6 +115,8 @@ Branch is aligned when:
 
 - Existing online/upstream capabilities remain available.
 - QA workflows degrade safely when `qa_records` is absent.
-- Prod/Edge diagnostics can flow to issue signals with AWS/issue permissions separated.
+- Prod/Edge diagnostics route each anomaly to one owner: Feishu for account or
+  provider capacity, GitHub Issue for actionable anomalies not covered by
+  Feishu, or the isolated Draft PR path for high-confidence code-owned failures.
 - A high-confidence code-owned report can flow to an isolated Draft PR with
   reproduction evidence, while provider/config/capacity findings cannot.

--- a/docs/approved/ops-unified-contract.md
+++ b/docs/approved/ops-unified-contract.md
@@ -54,6 +54,9 @@ Required outcomes:
 - Daily classification is deterministic. Account-capacity and provider-health
   anomalies remain visible in the report but stay on the existing Feishu alert
   path; they do not create or update GitHub Issues.
+- Legacy `qa_records` hash clustering is report-only evidence. It cannot create
+  an Issue independently because it does not carry the owner/phase semantics
+  required for deterministic triage.
 
 Hard guardrails:
 

--- a/docs/approved/ops-unified-contract.md
+++ b/docs/approved/ops-unified-contract.md
@@ -6,7 +6,7 @@ approved_at: 2026-04-21
 updated_at: 2026-07-23
 created: 2026-04-21
 owners: [tk-platform]
-related_prs: ["#13", "#30"]
+related_prs: ["#13", "#30", "#1433"]
 scope: "QA capture + ErrorToIssue/PR"
 ---
 

--- a/ops/observability/daily_error_report.py
+++ b/ops/observability/daily_error_report.py
@@ -17,6 +17,10 @@ REPAIR_EXCLUDED = re.compile(
     r"(?:rate.?limit|quota|capacity|no.?available|empty.?pool|cooldown|cancel|auth|permission|billing)",
     re.IGNORECASE,
 )
+FEISHU_ALERT_COVERED = re.compile(
+    r"(?:rate.?limit|quota|capacity|no.?available|empty.?pool|cooldown|auth|permission|billing)",
+    re.IGNORECASE,
+)
 
 
 class ReportError(ValueError):
@@ -33,6 +37,21 @@ def as_int(value: Any) -> int:
         return int(value or 0)
     except (TypeError, ValueError):
         return 0
+
+
+def feishu_covers_anomaly(item: dict[str, Any]) -> bool:
+    """Return whether the existing account/provider alert path owns this anomaly."""
+    owner = clean_text(item.get("owner"), 32).lower()
+    phase = clean_text(item.get("phase"), 48).lower()
+    status = as_int(item.get("status_code"))
+    searchable = f"{phase} {clean_text(item.get('error_type'), 96)}"
+    return (
+        owner == "provider"
+        or status == 429
+        or phase in {"account_auth", "auth"}
+        or (phase == "routing" and status in {502, 503})
+        or bool(FEISHU_ALERT_COVERED.search(searchable))
+    )
 
 
 def parse_probe(text: str) -> dict[str, list[dict[str, Any]]]:
@@ -123,6 +142,8 @@ def classify_cluster(item: dict[str, Any], max_count_5m: int, target_id: str) ->
             or (state == "persistent" and current >= 10)
             or (status >= 500 and current >= 3)
         )
+    feishu_alert_covered = anomaly and feishu_covers_anomaly(key)
+    github_issue_eligible = anomaly and not feishu_alert_covered
     severity = "error" if owner == "platform" and status >= 500 else "warning"
     priority = (
         (100 if repair_eligible else 0)
@@ -146,6 +167,9 @@ def classify_cluster(item: dict[str, Any], max_count_5m: int, target_id: str) ->
         "account_ids": [as_int(v) for v in (item.get("account_ids") or [])][:5],
         "group_ids": [as_int(v) for v in (item.get("group_ids") or [])][:5],
         "anomaly": anomaly,
+        "feishu_alert_covered": feishu_alert_covered,
+        "github_issue_eligible": github_issue_eligible,
+        "triage_channel": "feishu" if feishu_alert_covered else "github_issue" if github_issue_eligible else "report_only",
         "code_owned": code_owned,
         "confidence": confidence,
         "repair_eligible": repair_eligible,
@@ -198,6 +222,9 @@ def classify_access_cluster(
         "account_ids": [],
         "group_ids": [],
         "anomaly": anomaly,
+        "feishu_alert_covered": False,
+        "github_issue_eligible": anomaly,
+        "triage_channel": "github_issue" if anomaly else "report_only",
         "code_owned": False,
         "confidence": "low",
         "repair_eligible": False,
@@ -222,6 +249,8 @@ def build_report(probe_text: str, target_id: str) -> dict[str, Any]:
             "totals": {},
             "clusters": [],
             "recovered_upstream": [],
+            "anomaly_count": 0,
+            "feishu_covered_count": 0,
             "issue_candidates": [],
             "repair_candidates": [],
         }
@@ -249,23 +278,29 @@ def build_report(probe_text: str, target_id: str) -> dict[str, Any]:
             clusters.append(classified)
     clusters.sort(key=lambda row: (-as_int(row["priority"]), row["signature"]))
 
-    issues = [row for row in clusters if row["anomaly"]]
+    anomalies = [row for row in clusters if row["anomaly"]]
+    feishu_covered = [row for row in anomalies if row["feishu_alert_covered"]]
+    issues = [row for row in anomalies if row["github_issue_eligible"]]
     repairs = [row for row in clusters if row["repair_eligible"]]
     current_total = as_int(totals.get("current_request_total"))
     current_sla = as_int(totals.get("current_error_sla"))
     summary = (
         f"{as_int(meta.get('window_hours'))}h: requests={current_total}, "
-        f"sla_errors={current_sla}, anomalies={len(issues)}, repair_candidates={len(repairs)}"
+        f"sla_errors={current_sla}, anomalies={len(anomalies)}, feishu_covered={len(feishu_covered)}, "
+        f"github_issues={len(issues)}, repair_candidates={len(repairs)}"
     )
+    status = "issue_candidate" if issues else "alert_covered" if anomalies else "ok"
     return {
         "schema_version": 1,
         "target_id": meta["target_id"],
-        "status": "issue_candidate" if issues else "ok",
+        "status": status,
         "meta": meta,
         "summary": summary,
         "totals": totals,
         "clusters": clusters,
         "recovered_upstream": sections.get("recovered", []),
+        "anomaly_count": len(anomalies),
+        "feishu_covered_count": len(feishu_covered),
         "issue_candidates": issues,
         "repair_candidates": repairs,
     }
@@ -301,16 +336,17 @@ def markdown_report(report: dict[str, Any]) -> str:
         "",
         "## Error Clusters",
         "",
-        "| State | Owner | Status | Platform | Model | Endpoint | Current | Previous | Peak | Repair |",
-        "| --- | --- | ---: | --- | --- | --- | ---: | ---: | ---: | --- |",
+        "| State | Owner | Status | Platform | Model | Endpoint | Current | Previous | Peak | Triage | Repair |",
+        "| --- | --- | ---: | --- | --- | --- | ---: | ---: | ---: | --- | --- |",
     ]
     for row in (report.get("clusters") or [])[:30]:
         lines.append(
-            "| {state} | {owner} | {status} | {platform} | {model} | {endpoint} | {current} | {previous} | {peak} | {repair} |".format(
+            "| {state} | {owner} | {status} | {platform} | {model} | {endpoint} | {current} | {previous} | {peak} | {triage} | {repair} |".format(
                 state=cell(row.get("state")), owner=cell(row.get("owner")), status=as_int(row.get("status_code")),
                 platform=cell(row.get("platform")), model=cell(row.get("model")), endpoint=cell(row.get("endpoint")),
                 current=as_int(row.get("current_count")), previous=as_int(row.get("previous_count")),
-                peak=as_int(row.get("max_count_5m")), repair="yes" if row.get("repair_eligible") else "no",
+                peak=as_int(row.get("max_count_5m")), triage=cell(row.get("triage_channel"), 32),
+                repair="yes" if row.get("repair_eligible") else "no",
             )
         )
     lines.append("")
@@ -321,8 +357,12 @@ def aggregate_reports(paths: list[pathlib.Path], run_id: str, run_url: str) -> d
     reports = [json.loads(path.read_text(encoding="utf-8")) for path in sorted(paths)]
     issues = []
     repairs = []
+    anomaly_count = 0
+    feishu_covered_count = 0
     for report in reports:
         target_id = clean_text(report.get("target_id"), 80)
+        anomaly_count += sum(1 for item in report.get("clusters") or [] if item.get("anomaly"))
+        feishu_covered_count += sum(1 for item in report.get("clusters") or [] if item.get("feishu_alert_covered"))
         for item in report.get("issue_candidates") or []:
             issues.append({**item, "target_id": target_id})
         for item in report.get("repair_candidates") or []:
@@ -334,8 +374,13 @@ def aggregate_reports(paths: list[pathlib.Path], run_id: str, run_url: str) -> d
         "run_id": clean_text(run_id, 40),
         "run_url": clean_text(run_url, 240),
         "generated_at": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
-        "summary": f"targets={len(reports)}, anomalies={len(issues)}, repair_candidates={len(repairs)}",
+        "summary": (
+            f"targets={len(reports)}, anomalies={anomaly_count}, feishu_covered={feishu_covered_count}, "
+            f"github_issues={len(issues)}, repair_candidates={len(repairs)}"
+        ),
         "reports": reports,
+        "anomaly_count": anomaly_count,
+        "feishu_covered_count": feishu_covered_count,
         "issue_candidates": issues,
         "repair_candidates": repairs,
     }
@@ -350,26 +395,28 @@ def aggregate_markdown(report: dict[str, Any]) -> str:
         "",
         "## Targets",
         "",
-        "| Target | Status | Requests | SLA errors | Client faults | Recovered | Anomalies | Repair |",
-        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        "| Target | Status | Requests | SLA errors | Client faults | Recovered | Anomalies | Feishu | GitHub Issues | Repair |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
     for target in report.get("reports") or []:
         totals = target.get("totals") or {}
         lines.append(
-            "| {target} | {status} | {requests} | {sla} | {client} | {recovered} | {issues} | {repairs} |".format(
+            "| {target} | {status} | {requests} | {sla} | {client} | {recovered} | {anomalies} | {feishu} | {issues} | {repairs} |".format(
                 target=clean_text(target.get("target_id"), 80).replace("|", "\\|"),
                 status=clean_text(target.get("status"), 32),
                 requests=as_int(totals.get("current_request_total")),
                 sla=as_int(totals.get("current_error_sla")),
                 client=as_int(totals.get("current_client_faults")),
                 recovered=as_int(totals.get("current_recovered_requests")),
+                anomalies=sum(1 for item in target.get("clusters") or [] if item.get("anomaly")),
+                feishu=sum(1 for item in target.get("clusters") or [] if item.get("feishu_alert_covered")),
                 issues=len(target.get("issue_candidates") or []),
                 repairs=len(target.get("repair_candidates") or []),
             )
         )
     lines += [
         "",
-        "## Actionable Anomalies",
+        "## GitHub Issue Candidates",
         "",
         "| Target | State | Owner | Status | Type | Model | Endpoint | Count | Repair |",
         "| --- | --- | --- | ---: | --- | --- | --- | ---: | --- |",

--- a/ops/observability/test_daily_error_report.py
+++ b/ops/observability/test_daily_error_report.py
@@ -119,13 +119,69 @@ class DailyErrorReportTest(unittest.TestCase):
         provider = next(row for row in report["clusters"] if row["owner"] == "provider")
         self.assertEqual(provider["state"], "regressed")
         self.assertTrue(provider["anomaly"])
+        self.assertTrue(provider["feishu_alert_covered"])
+        self.assertFalse(provider["github_issue_eligible"])
+        self.assertNotIn(provider, report["issue_candidates"])
         self.assertFalse(provider["repair_eligible"])
 
         client = next(row for row in report["clusters"] if row["owner"] == "client")
         self.assertFalse(client["anomaly"])
         access = next(row for row in report["clusters"] if row["source"] == "access_log")
         self.assertTrue(access["anomaly"])
+        self.assertTrue(access["github_issue_eligible"])
         self.assertEqual(access["confidence"], "low")
+
+    def test_capacity_and_provider_anomalies_stay_in_report_without_github_issues(self) -> None:
+        rows = [
+            "=== meta ===",
+            json.dumps({"status": "ok", "window_hours": 24, "runtime_image": "sub2api:1.2.3"}),
+            "=== totals ===",
+            json.dumps({"current_request_total": 100, "current_error_sla": 20}),
+            "=== clusters ===",
+            json.dumps({
+                "status_code": 502,
+                "owner": "provider",
+                "phase": "upstream",
+                "error_type": "upstream_error",
+                "platform": "grok",
+                "model": "grok-build-0.1",
+                "endpoint": "/v1/chat/completions",
+                "current_count": 8,
+                "previous_count": 0,
+            }),
+            json.dumps({
+                "status_code": 429,
+                "owner": "platform",
+                "phase": "routing",
+                "error_type": "api_error",
+                "platform": "grok",
+                "model": "grok-build-0.1",
+                "endpoint": "/v1/chat/completions",
+                "current_count": 9,
+                "previous_count": 1,
+            }),
+            json.dumps({
+                "status_code": 503,
+                "owner": "provider",
+                "phase": "account_auth",
+                "error_type": "upstream_error",
+                "platform": "grok",
+                "model": "grok-build-0.1",
+                "endpoint": "/v1/chat/completions",
+                "current_count": 6,
+                "previous_count": 1,
+            }),
+        ]
+
+        report = build_report("\n".join(rows) + "\n", "prod")
+
+        self.assertEqual(report["status"], "alert_covered")
+        self.assertEqual(report["anomaly_count"], 3)
+        self.assertEqual(report["feishu_covered_count"], 3)
+        self.assertEqual(report["issue_candidates"], [])
+        self.assertEqual(report["repair_candidates"], [])
+        self.assertTrue(all(row["triage_channel"] == "feishu" for row in report["clusters"]))
+        self.assertIn("github_issues=0", report["summary"])
 
     def test_access_cluster_fully_covered_by_ops_error_is_not_duplicated(self) -> None:
         matching_access = json.dumps({
@@ -254,7 +310,7 @@ esac
             path.write_text(json.dumps(build_report(probe_fixture(), "prod")), encoding="utf-8")
             report = aggregate_reports([path], "123", "https://example.test/runs/123")
             markdown = aggregate_markdown(report)
-            self.assertIn("| prod | issue_candidate | 120 | 15 | 5 | 8 |", markdown)
+            self.assertIn("| prod | issue_candidate | 120 | 15 | 5 | 8 | 3 | 1 | 2 | 1 |", markdown)
             self.assertIn("dashboard_query_failed", markdown)
 
     def test_issue_analysis_is_target_scoped_and_actionable(self) -> None:

--- a/ops/observability/test_ops_daily_diagnostics_workflow.py
+++ b/ops/observability/test_ops_daily_diagnostics_workflow.py
@@ -121,6 +121,8 @@ class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
         self.assertIn("probe-daily-error-ledger.sh", text)
         self.assertIn("daily_error_report.py build", text)
         self.assertIn("daily_error_report.py aggregate", text)
+        self.assertIn("alert_covered)", text)
+        self.assertIn("Daily error anomalies are covered by Feishu", text)
         self.assertIn("top_repair_signature", text)
         self.assertIn("gh workflow run ops-repair-draft.yml", text)
 

--- a/ops/observability/test_ops_daily_diagnostics_workflow.py
+++ b/ops/observability/test_ops_daily_diagnostics_workflow.py
@@ -6,6 +6,8 @@ import contextlib
 import io
 import json
 import os
+import sys
+import tempfile
 import textwrap
 import unittest
 from pathlib import Path
@@ -37,6 +39,14 @@ def extract_runtime_params_commands() -> list[str]:
             os.environ.pop("DIAGNOSTICS_LOG_SINCE", None)
         else:
             os.environ["DIAGNOSTICS_LOG_SINCE"] = old_since
+
+
+def extract_log_signal_classifier() -> str:
+    marker = "          import json\n          import pathlib\n          import sys\n\n          counts_path"
+    text = workflow_text()
+    start = text.index(marker)
+    end = text.index("\n          PY", start)
+    return textwrap.dedent(text[start:end])
 
 
 class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
@@ -83,6 +93,33 @@ class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
         self.assertIn("caddy_access_error >= 10", text)
         self.assertNotIn('"kind": "caddy_incomplete_response"', text)
 
+    def test_feishu_owned_log_signals_do_not_become_issue_candidates(self) -> None:
+        script = extract_log_signal_classifier()
+        with tempfile.TemporaryDirectory() as tmp_raw:
+            root = Path(tmp_raw)
+            counts_path = root / "counts.json"
+            findings_path = root / "findings.jsonl"
+            counts_path.write_text(
+                json.dumps({
+                    "gemini_drive_scope_403": 10,
+                    "openai_previous_response_fallback": 50,
+                    "rate_limit_429_no_reset": 1,
+                }),
+                encoding="utf-8",
+            )
+            old_argv = sys.argv
+            sys.argv = ["log-signal-classifier", str(counts_path), str(findings_path), "prod", "24h"]
+            try:
+                exec(compile(script, str(WORKFLOW), "exec"), {})
+            finally:
+                sys.argv = old_argv
+
+            findings = [json.loads(line) for line in findings_path.read_text(encoding="utf-8").splitlines()]
+            statuses = {finding["kind"]: finding["status"] for finding in findings}
+            self.assertEqual(statuses["gemini_drive_scope_403"], "warning")
+            self.assertEqual(statuses["rate_limit_429_no_reset"], "warning")
+            self.assertEqual(statuses["openai_previous_response_fallback"], "issue_candidate")
+
     def test_missing_target_reports_skipped_when_diagnose_cancelled(self) -> None:
         text = workflow_text()
         self.assertIn("DISCOVER_TARGETS_RESULT", text)
@@ -123,6 +160,11 @@ class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
         self.assertIn("daily_error_report.py aggregate", text)
         self.assertIn("alert_covered)", text)
         self.assertIn("Daily error anomalies are covered by Feishu", text)
+        self.assertIn(
+            'add_finding "error_cluster" "warning" "warning" "Persistent legacy error cluster',
+            text,
+        )
+        self.assertNotIn('add_finding "error_cluster" "issue_candidate"', text)
         self.assertIn("top_repair_signature", text)
         self.assertIn("gh workflow run ops-repair-draft.yml", text)
 


### PR DESCRIPTION
## 摘要

- 将 provider health、HTTP 429、account-auth 和 routing 502/503 容量异常确定性路由到现有飞书告警，不再创建或更新 GitHub Issue。
- 日报继续保留全部 anomaly，并分别输出 Feishu 覆盖数、GitHub Issue 候选数和 repair 候选数；纯飞书覆盖的 target 状态为 `alert_covered`。
- legacy `qa_records` hash clustering 仅保留报告证据，不再绕过 canonical daily ledger 直接创建 Issue；该约束已写入 Ops SSOT。
- Gemini 账号权限与 429 无 reset 等飞书覆盖信号降为 report-only warning；平台兼容回退等可修复信号仍保留 GitHub Issue 路径。
- 平台内部 5xx、未归属的 access-only 5xx、probe/parsing 失败等仍保留 GitHub Issue 路径；高置信平台内部 5xx 的 Draft PR 路径不变。
- 同步修订已批准的 Ops contract 和 AWS 运维说明，明确每类异常只有一个处置 owner。

## 风险

- 内部 Ops workflow 行为调整，无 Web 影响。
- `docs/approved/ops-unified-contract.md` 的修订是对已确认运营决策的有意更新：账号容量和 provider health 由飞书负责，GitHub Issues 只承接未被飞书覆盖的 actionable anomalies。
- #1424–#1428 已作为历史重复告警关闭，并关联本 PR。
- 已合并当前 `origin/main`，恢复 main ancestry 门禁；PR 行为 diff 不包含主线上的 fingerprint 变更。

## 验证

- `python3 -m unittest ops.observability.test_ops_daily_diagnostics_workflow ops.observability.test_daily_error_report ops.observability.test_ops_repair_draft_workflow ops.observability.test_headless_agent_runner`：32 tests passed。
- 新增执行 workflow 内嵌 log-signal classifier 的行为测试：Gemini 账号权限与 429 信号为 `warning`，平台兼容回退仍为 `issue_candidate`。
- 使用产生 #1424–#1428 的 Run `29976650174` 五个真实 target artifact 回放：全部为 `status=alert_covered`、`github_issues=0`、`repair_candidates=0`，异常证据均保留在日报并归 Feishu。
- PyYAML 解析 `ops-daily-diagnostics.yml` 与 `ops-repair-draft.yml` 通过。
- 默认 `python3`（3.12.13）执行 `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS。
- `git merge-base --is-ancestor origin/main HEAD`：PASS。

## 提交

- 926791e8c fix(ops): keep capacity alerts out of GitHub issues
- 67efc2386 fix(ops): address R-001..R-002 — preserve Feishu ownership
- ad3f6ae35 docs(ops): make legacy clustering report-only explicit
- 85f8d7370 docs(ops): link capacity suppression to approved contract
- 5a7c097be chore: merge current main into ops capacity fix
- 最新提交：5a7c097be