### PR TITLE
fix(ops): 修复每日诊断误报与关闭签名重建

### DIFF
--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -892,10 +892,16 @@ jobs:
                   sh(['gh', 'issue', 'comment', number, '--body-file', str(body_file)])
                   print(f'updated issue #{number} for {ops_label}')
               elif decision['action'] == 'suppress':
-                  print(
-                      f"suppressed {ops_label}: issue #{decision['number']} was closed at "
-                      f"{decision['closed_at']} and remains in the 7-day cooldown"
-                  )
+                  if decision.get('closed_at') == 'unknown':
+                      print(
+                          f"suppressed {ops_label}: issue #{decision['number']} is closed with "
+                          f"unknown closedAt; fail-closed suppress until timestamp is available"
+                      )
+                  else:
+                      print(
+                          f"suppressed {ops_label}: issue #{decision['number']} was closed at "
+                          f"{decision['closed_at']} and remains in the 7-day cooldown"
+                      )
               else:
                   sh(['gh', 'issue', 'create', '--title', title, '--body-file', str(body_file), '--label', ','.join(labels)])
                   print(f'created issue for {ops_label}')

--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -439,10 +439,10 @@ jobs:
               findings.append({
                   "target_id": target_id,
                   "kind": "caddy_access_error",
-                  "status": "issue_candidate",
+                  "status": "warning",
                   "severity": "warning",
                   "title": f"Caddy error-level access entries on {target_id}",
-                  "summary": f"Caddy logged {caddy_access_error} error-level access entries over {window} (incomplete aborts={caddy_incomplete}, tracked separately).",
+                  "summary": f"Caddy logged {caddy_access_error} error-level access entries over {window} (incomplete aborts={caddy_incomplete}, tracked separately); the canonical daily ledger owns actionable error classification.",
                   "signature": f"log-signal|{target_id}|caddy-access-error",
               })
 
@@ -811,7 +811,9 @@ jobs:
           import re
           import subprocess
 
+          # Lifecycle policy owner: ops/observability/prod_ops_issue_decision.py
           from ops.observability.daily_error_report import issue_analysis_markdown
+          from ops.observability.prod_ops_issue_decision import decide_issue_action
 
           report = json.loads(pathlib.Path('ops-report.json').read_text(encoding='utf-8'))
           daily_report = json.loads(pathlib.Path('daily-error-report.json').read_text(encoding='utf-8'))
@@ -880,10 +882,20 @@ jobs:
               body_file = pathlib.Path(f'issue-{index}.md')
               body_file.write_text(body, encoding='utf-8')
 
-              existing = sh(['gh', 'issue', 'list', '--label', ops_label, '--state', 'open', '--json', 'number', '--limit', '1', '--jq', '.[0].number // empty']).stdout.strip()
-              if existing:
-                  sh(['gh', 'issue', 'comment', existing, '--body-file', str(body_file)])
-                  print(f'updated issue #{existing} for {ops_label}')
+              existing = json.loads(sh([
+                  'gh', 'issue', 'list', '--label', ops_label, '--state', 'all',
+                  '--json', 'number,state,closedAt,createdAt', '--limit', '100',
+              ]).stdout or '[]')
+              decision = decide_issue_action(existing)
+              if decision['action'] == 'update':
+                  number = str(decision['number'])
+                  sh(['gh', 'issue', 'comment', number, '--body-file', str(body_file)])
+                  print(f'updated issue #{number} for {ops_label}')
+              elif decision['action'] == 'suppress':
+                  print(
+                      f"suppressed {ops_label}: issue #{decision['number']} was closed at "
+                      f"{decision['closed_at']} and remains in the 7-day cooldown"
+                  )
               else:
                   sh(['gh', 'issue', 'create', '--title', title, '--body-file', str(body_file), '--label', ','.join(labels)])
                   print(f'created issue for {ops_label}')

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -863,7 +863,7 @@ GitHub Actions 不再用长期 AWS 凭证，**OIDC 临时换 STS** → `ssm:Send
 - 默认 operation：`diagnostics`，覆盖 prod + `deploy/aws/lightsail/edge-targets-lightsail.json` 里 `deployable=true` 的 Lightsail Edge（edges 均为 Lightsail；`deploy/aws/stage0/edge-targets.json` 已清空为 stub）。
 - 手动 target selector：`all`、`prod`、`edge:*`、`edge:<id>`；`deployable=false` 的 Edge 只进入 excluded summary。
 - 输出：每个目标上传 `prod-ops-target-<target>-<run_id>` artifact，汇总上传 `prod-ops-report-<run_id>`。
-- Issue 决策：账号容量与 provider health 异常保留在日报并由现有飞书链路告警，不创建 GitHub Issue；其余 `issue_candidate` / `manual_ops` findings 才创建或更新 Issue，并使用 `ops-sig:*`、`target:*`、`finding:*` label 去重。
+- Issue 决策：账号容量与 provider health 异常保留在日报并由现有飞书链路告警，不创建 GitHub Issue；Caddy error-level access 粗计数仅作 report-only 证据，由 canonical daily ledger 负责可行动错误分类；其余 `issue_candidate` / `manual_ops` findings 才创建或更新 Issue，并使用 `ops-sig:*`、`target:*`、`finding:*` label 去重。开放签名追加评论，最近 7 天内已关闭的签名处于冷却期，不重新建单。
 - 确定性分类：日报按 target 展示 anomaly、Feishu 覆盖、GitHub Issue 候选和 repair 候选；GitHub Issue 仅附带未被飞书覆盖的 priority、state、owner/phase、HTTP、类型、平台/模型、endpoint、current/previous 与 confidence。daily workflow 不运行 AI。
 - 修复预算隔离：只有高置信、代码归属明确的候选才 dispatch 到 `ops-repair-draft.yml`，由独立 workflow 使用 AI 形成 Draft PR 等待人工 review。
 - Graceful degradation：缺 `AWS_OIDC_ROLE_ARN` / 缺 `qa_records` → skip 或 deterministic fallback，不让 cron 因非核心缺口脆断。

--- a/docs/approved/ops-unified-contract.md
+++ b/docs/approved/ops-unified-contract.md
@@ -6,7 +6,7 @@ approved_at: 2026-04-21
 updated_at: 2026-07-23
 created: 2026-04-21
 owners: [tk-platform]
-related_prs: ["#13", "#30", "#1433"]
+related_prs: ["#13", "#30", "#1433", "#1444"]
 scope: "QA capture + ErrorToIssue/PR"
 ---
 

--- a/docs/approved/ops-unified-contract.md
+++ b/docs/approved/ops-unified-contract.md
@@ -57,6 +57,9 @@ Required outcomes:
 - Legacy `qa_records` hash clustering is report-only evidence. It cannot create
   an Issue independently because it does not carry the owner/phase semantics
   required for deterministic triage.
+- Coarse Caddy error-level access counts are report-only evidence. The canonical
+  daily ledger owns actionable final-error classification so the same traffic
+  cannot create a second Issue through an ownership-free log counter.
 
 Hard guardrails:
 
@@ -81,7 +84,7 @@ Hard guardrails:
   endpoint values never enter the write-capable agent. Test execution goes
   through the repository-owned command validator, and protected paths plus diff
   size are revalidated after the reproduction command returns.
-- Signature cooldown / dedupe labels (`ops-sig:*`, plus `cluster-sig:*` for error clusters) avoid duplicate churn.
+- Signature cooldown / dedupe labels (`ops-sig:*`, plus `cluster-sig:*` for error clusters) avoid duplicate churn. Open signatures are updated; a signature closed within the previous 7 days suppresses recreation.
 - AWS diagnostics jobs have `id-token: write` but no repo write permissions.
 - Issue/repair-dispatch/repair jobs have no AWS OIDC permission.
 - Missing optional secret / missing required table => clean skip or deterministic fallback, not a brittle cron failure.

--- a/ops/observability/daily_error_report.py
+++ b/ops/observability/daily_error_report.py
@@ -307,8 +307,8 @@ def build_report(probe_text: str, target_id: str) -> dict[str, Any]:
 
 
 def markdown_report(report: dict[str, Any]) -> str:
-    def cell(value: Any) -> str:
-        return clean_text(value, 120).replace("|", "\\|")
+    def cell(value: Any, text_limit: int = 120) -> str:
+        return clean_text(value, text_limit).replace("|", "\\|")
 
     lines = [
         "# Daily Error Report",
@@ -523,13 +523,15 @@ def main() -> int:
     try:
         if args.command == "build":
             report = build_report(args.probe.read_text(encoding="utf-8", errors="replace"), args.target_id)
+            markdown = markdown_report(report)
+            args.output_markdown.write_text(markdown, encoding="utf-8")
             write_json(args.output_json, report)
-            args.output_markdown.write_text(markdown_report(report), encoding="utf-8")
         elif args.command == "aggregate":
             paths = list(args.root.glob("**/daily-error-report.json"))
             report = aggregate_reports(paths, args.run_id, args.run_url)
+            markdown = aggregate_markdown(report)
+            args.output_markdown.write_text(markdown, encoding="utf-8")
             write_json(args.output_json, report)
-            args.output_markdown.write_text(aggregate_markdown(report), encoding="utf-8")
         else:
             report = json.loads(args.report.read_text(encoding="utf-8"))
             write_json(args.output, select_candidate(report, args.signature))

--- a/ops/observability/prod_ops_issue_decision.py
+++ b/ops/observability/prod_ops_issue_decision.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Deterministic GitHub Issue lifecycle decisions for Prod Ops findings."""
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+ISSUE_COOLDOWN = dt.timedelta(days=7)
+
+
+def _timestamp(value: Any) -> dt.datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def decide_issue_action(
+    issues: list[dict[str, Any]],
+    *,
+    now: dt.datetime | None = None,
+    cooldown: dt.timedelta = ISSUE_COOLDOWN,
+) -> dict[str, Any]:
+    """Choose update, suppress, or create for one stable finding signature."""
+    current = now or dt.datetime.now(dt.timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=dt.timezone.utc)
+    current = current.astimezone(dt.timezone.utc)
+
+    open_issues = [item for item in issues if str(item.get("state") or "").upper() == "OPEN"]
+    if open_issues:
+        existing = max(open_issues, key=lambda item: int(item.get("number") or 0))
+        return {"action": "update", "number": int(existing.get("number") or 0)}
+
+    cutoff = current - cooldown
+    recent_closed: list[tuple[dt.datetime, dict[str, Any]]] = []
+    unknown_closed: list[dict[str, Any]] = []
+    for item in issues:
+        if str(item.get("state") or "").upper() != "CLOSED":
+            continue
+        closed_at = _timestamp(item.get("closedAt"))
+        if closed_at is None:
+            unknown_closed.append(item)
+        elif closed_at >= cutoff:
+            recent_closed.append((closed_at, item))
+    if recent_closed:
+        closed_at, existing = max(recent_closed, key=lambda pair: pair[0])
+        return {
+            "action": "suppress",
+            "number": int(existing.get("number") or 0),
+            "closed_at": closed_at.isoformat().replace("+00:00", "Z"),
+        }
+    if unknown_closed:
+        existing = max(unknown_closed, key=lambda item: int(item.get("number") or 0))
+        return {
+            "action": "suppress",
+            "number": int(existing.get("number") or 0),
+            "closed_at": "unknown",
+        }
+
+    return {"action": "create"}

--- a/ops/observability/test_daily_error_report.py
+++ b/ops/observability/test_daily_error_report.py
@@ -256,6 +256,68 @@ class DailyErrorReportTest(unittest.TestCase):
         self.assertNotIn("\\nprevious", serialized)
         self.assertNotIn("\\tinstructions", serialized)
 
+    def test_build_cli_renders_target_markdown_before_publishing_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_raw:
+            root = pathlib.Path(tmp_raw)
+            probe = root / "probe.txt"
+            report_json = root / "daily-error-report.json"
+            report_markdown = root / "daily-error-report.md"
+            probe.write_text(probe_fixture(), encoding="utf-8")
+
+            proc = subprocess.run(
+                [
+                    str(REPORTER),
+                    "build",
+                    "--probe",
+                    str(probe),
+                    "--target-id",
+                    "prod",
+                    "--output-json",
+                    str(report_json),
+                    "--output-markdown",
+                    str(report_markdown),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            report = json.loads(report_json.read_text(encoding="utf-8"))
+            markdown = report_markdown.read_text(encoding="utf-8")
+            self.assertEqual(report["status"], "issue_candidate")
+            self.assertIn("| Triage | Repair |", markdown)
+            self.assertIn("| github_issue |", markdown)
+            self.assertIn("| feishu |", markdown)
+
+    def test_build_cli_does_not_publish_json_when_markdown_write_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_raw:
+            root = pathlib.Path(tmp_raw)
+            probe = root / "probe.txt"
+            report_json = root / "daily-error-report.json"
+            missing_markdown = root / "missing" / "daily-error-report.md"
+            probe.write_text(probe_fixture(), encoding="utf-8")
+
+            proc = subprocess.run(
+                [
+                    str(REPORTER),
+                    "build",
+                    "--probe",
+                    str(probe),
+                    "--target-id",
+                    "prod",
+                    "--output-json",
+                    str(report_json),
+                    "--output-markdown",
+                    str(missing_markdown),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(proc.returncode, 2, proc.stderr)
+            self.assertIn("[daily-error-report] ERROR:", proc.stderr)
+            self.assertFalse(report_json.exists())
+
     def test_probe_resolves_active_blue_green_container_and_access_errors(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_raw:
             tmp = pathlib.Path(tmp_raw)

--- a/ops/observability/test_ops_daily_diagnostics_workflow.py
+++ b/ops/observability/test_ops_daily_diagnostics_workflow.py
@@ -104,6 +104,8 @@ class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
                     "gemini_drive_scope_403": 10,
                     "openai_previous_response_fallback": 50,
                     "rate_limit_429_no_reset": 1,
+                    "caddy_incomplete_response": 100,
+                    "caddy_access_error": 100,
                 }),
                 encoding="utf-8",
             )
@@ -118,7 +120,18 @@ class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
             statuses = {finding["kind"]: finding["status"] for finding in findings}
             self.assertEqual(statuses["gemini_drive_scope_403"], "warning")
             self.assertEqual(statuses["rate_limit_429_no_reset"], "warning")
+            self.assertEqual(statuses["caddy_access_error"], "warning")
             self.assertEqual(statuses["openai_previous_response_fallback"], "issue_candidate")
+            self.assertEqual(list(statuses.values()).count("issue_candidate"), 1)
+
+    def test_issue_lifecycle_updates_open_and_cools_down_closed_signatures(self) -> None:
+        text = workflow_text()
+        self.assertIn("from ops.observability.prod_ops_issue_decision import decide_issue_action", text)
+        self.assertIn("'--state', 'all'", text)
+        self.assertIn("'number,state,closedAt,createdAt'", text)
+        self.assertIn("decision['action'] == 'update'", text)
+        self.assertIn("decision['action'] == 'suppress'", text)
+        self.assertIn("remains in the 7-day cooldown", text)
 
     def test_missing_target_reports_skipped_when_diagnose_cancelled(self) -> None:
         text = workflow_text()

--- a/ops/observability/test_ops_daily_diagnostics_workflow.py
+++ b/ops/observability/test_ops_daily_diagnostics_workflow.py
@@ -3,18 +3,22 @@
 from __future__ import annotations
 
 import contextlib
+import datetime as dt
 import io
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ops-daily-diagnostics.yml"
 REPAIR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ops-repair-draft.yml"
+ISSUE_LIFECYCLE_NOW = dt.datetime(2026, 7, 23, 9, 0, tzinfo=dt.timezone.utc)
 
 
 def workflow_text() -> str:
@@ -47,6 +51,72 @@ def extract_log_signal_classifier() -> str:
     start = text.index(marker)
     end = text.index("\n          PY", start)
     return textwrap.dedent(text[start:end])
+
+
+def extract_issue_lifecycle_script() -> str:
+    marker = "          # Lifecycle policy owner: ops/observability/prod_ops_issue_decision.py\n"
+    text = workflow_text()
+    start = text.rindex("          import hashlib", 0, text.index(marker))
+    end = text.index("\n          PY", start)
+    return textwrap.dedent(text[start:end])
+
+
+def run_issue_lifecycle(
+    *,
+    issue_candidates: list[dict],
+    gh_issues: list[dict],
+) -> tuple[list[list[str]], str]:
+    script = extract_issue_lifecycle_script()
+    finding = {
+        "target_id": "prod",
+        "kind": "openai_previous_response_fallback",
+        "signature": "log-signal|prod|openai-previous-response-fallback",
+        "title": "OpenAI previous response fallback",
+        "status": "issue_candidate",
+        "severity": "high",
+        "summary": "fallback count exceeded threshold",
+    }
+    candidates = issue_candidates or [finding]
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(args, 0, stdout=json.dumps(gh_issues))
+        if args[:3] == ["gh", "issue", "comment"]:
+            return subprocess.CompletedProcess(args, 0, stdout="")
+        if args[:3] == ["gh", "issue", "create"]:
+            return subprocess.CompletedProcess(args, 0, stdout="https://github.com/example/issues/99")
+        if args[:2] == ["gh", "label"]:
+            return subprocess.CompletedProcess(args, 0, stdout="")
+        raise AssertionError(f"unexpected subprocess.run: {args!r}")
+
+    with tempfile.TemporaryDirectory() as tmp_raw:
+        root = Path(tmp_raw)
+        root.joinpath("ops-report.json").write_text(
+            json.dumps({"run_url": "https://example/run", "run_id": "123", "issue_candidates": candidates}),
+            encoding="utf-8",
+        )
+        root.joinpath("daily-error-report.json").write_text("{}", encoding="utf-8")
+        old_cwd = Path.cwd()
+        stdout = io.StringIO()
+        from ops.observability.prod_ops_issue_decision import decide_issue_action as real_decide_issue_action
+
+        def fixed_decide_issue_action(issues: list[dict]) -> dict:
+            return real_decide_issue_action(issues, now=ISSUE_LIFECYCLE_NOW)
+
+        try:
+            os.chdir(root)
+            with mock.patch("subprocess.run", fake_run):
+                with mock.patch(
+                    "ops.observability.prod_ops_issue_decision.decide_issue_action",
+                    fixed_decide_issue_action,
+                ):
+                    with contextlib.redirect_stdout(stdout):
+                        exec(compile(script, str(WORKFLOW), "exec"), {})
+        finally:
+            os.chdir(old_cwd)
+    return calls, stdout.getvalue()
 
 
 class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
@@ -124,14 +194,45 @@ class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
             self.assertEqual(statuses["openai_previous_response_fallback"], "issue_candidate")
             self.assertEqual(list(statuses.values()).count("issue_candidate"), 1)
 
-    def test_issue_lifecycle_updates_open_and_cools_down_closed_signatures(self) -> None:
-        text = workflow_text()
-        self.assertIn("from ops.observability.prod_ops_issue_decision import decide_issue_action", text)
-        self.assertIn("'--state', 'all'", text)
-        self.assertIn("'number,state,closedAt,createdAt'", text)
-        self.assertIn("decision['action'] == 'update'", text)
-        self.assertIn("decision['action'] == 'suppress'", text)
-        self.assertIn("remains in the 7-day cooldown", text)
+    def test_issue_lifecycle_comments_on_open_signature(self) -> None:
+        calls, output = run_issue_lifecycle(
+            issue_candidates=[],
+            gh_issues=[{"number": 42, "state": "OPEN", "closedAt": None, "createdAt": "2026-07-20T08:00:00Z"}],
+        )
+        self.assertTrue(any(call[:4] == ["gh", "issue", "list", "--label"] for call in calls))
+        self.assertEqual(
+            [call for call in calls if call[:3] == ["gh", "issue", "comment"]],
+            [["gh", "issue", "comment", "42", "--body-file", "issue-1.md"]],
+        )
+        self.assertNotIn(["gh", "issue", "create"], [call[:3] for call in calls])
+        self.assertIn("updated issue #42 for ops-sig:", output)
+
+    def test_issue_lifecycle_suppresses_recently_closed_signature(self) -> None:
+        calls, output = run_issue_lifecycle(
+            issue_candidates=[],
+            gh_issues=[{"number": 43, "state": "CLOSED", "closedAt": "2026-07-23T08:15:33Z", "createdAt": "2026-07-20T08:00:00Z"}],
+        )
+        self.assertFalse(any(call[:3] == ["gh", "issue", "comment"] for call in calls))
+        self.assertFalse(any(call[:3] == ["gh", "issue", "create"] for call in calls))
+        self.assertIn("suppressed ops-sig:", output)
+        self.assertIn("remains in the 7-day cooldown", output)
+
+    def test_issue_lifecycle_creates_when_closed_signature_expired(self) -> None:
+        calls, output = run_issue_lifecycle(
+            issue_candidates=[],
+            gh_issues=[{"number": 44, "state": "CLOSED", "closedAt": "2026-07-01T08:00:00Z", "createdAt": "2026-06-28T08:00:00Z"}],
+        )
+        self.assertTrue(any(call[:3] == ["gh", "issue", "create"] for call in calls))
+        self.assertNotIn(["gh", "issue", "comment"], [call[:3] for call in calls])
+        self.assertIn("created issue for ops-sig:", output)
+
+    def test_issue_lifecycle_fail_closed_when_closed_at_unknown(self) -> None:
+        calls, output = run_issue_lifecycle(
+            issue_candidates=[],
+            gh_issues=[{"number": 45, "state": "CLOSED", "closedAt": "invalid", "createdAt": "2026-07-20T08:00:00Z"}],
+        )
+        self.assertFalse(any(call[:3] == ["gh", "issue", "create"] for call in calls))
+        self.assertIn("unknown closedAt; fail-closed suppress", output)
 
     def test_missing_target_reports_skipped_when_diagnose_cancelled(self) -> None:
         text = workflow_text()

--- a/ops/observability/test_prod_ops_issue_decision.py
+++ b/ops/observability/test_prod_ops_issue_decision.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime as dt
+import unittest
+
+from ops.observability.prod_ops_issue_decision import decide_issue_action
+
+
+class ProdOpsIssueDecisionTest(unittest.TestCase):
+    NOW = dt.datetime(2026, 7, 23, 8, 30, tzinfo=dt.timezone.utc)
+
+    def test_open_signature_is_updated(self) -> None:
+        decision = decide_issue_action(
+            [
+                {"number": 10, "state": "OPEN", "closedAt": None},
+                {"number": 9, "state": "CLOSED", "closedAt": "2026-07-22T08:30:00Z"},
+            ],
+            now=self.NOW,
+        )
+
+        self.assertEqual(decision, {"action": "update", "number": 10})
+
+    def test_recently_closed_signature_is_suppressed(self) -> None:
+        decision = decide_issue_action(
+            [{"number": 11, "state": "CLOSED", "closedAt": "2026-07-23T08:15:33Z"}],
+            now=self.NOW,
+        )
+
+        self.assertEqual(decision["action"], "suppress")
+        self.assertEqual(decision["number"], 11)
+        self.assertEqual(decision["closed_at"], "2026-07-23T08:15:33Z")
+
+    def test_expired_closed_signature_allows_creation(self) -> None:
+        decision = decide_issue_action(
+            [{"number": 12, "state": "CLOSED", "closedAt": "2026-07-15T08:29:59Z"}],
+            now=self.NOW,
+        )
+
+        self.assertEqual(decision, {"action": "create"})
+
+    def test_invalid_closed_timestamp_fails_closed(self) -> None:
+        decision = decide_issue_action(
+            [{"number": 13, "state": "CLOSED", "closedAt": "invalid"}],
+            now=self.NOW,
+        )
+
+        self.assertEqual(
+            decision,
+            {"action": "suppress", "number": 13, "closed_at": "unknown"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- 修复 target 日报 Markdown 的 `cell()` 参数错误，并仅在 Markdown 成功写入后发布 `daily-error-report.json` 完成标记。
- 将缺少 owner/phase 语义的 Caddy error-level access 粗计数降为 report-only，由 canonical daily ledger 负责可行动错误分类。
- Issue 去重改为同时检查 open/closed 状态：开放签名追加评论，最近 7 天内已关闭签名抑制重建。
- 增加 CLI 构建、半成品阻断、Caddy 分类和 Issue 生命周期回归测试。

## 风险

- 常规风险：改变 Prod Ops Issue 生命周期，但不修改线上服务、数据或 AWS 配置。
- 冷却超过 7 天后，持续存在的真实 actionable signature 仍可重新建单。
- 有意修订 `docs/approved/ops-unified-contract.md`，使批准契约与已验证行为一致。
- Web impact: none。

## 验证

- `python3 -m unittest ops.observability.test_daily_error_report ops.observability.test_prod_ops_issue_decision ops.observability.test_ops_daily_diagnostics_workflow`：29 tests passed。
- `python3 -m unittest discover -s ops/observability -p test_*.py`：140 tests passed。
- `./scripts/preflight.sh`：PASS（重放到最新 main 并补齐 contract PR 锚点后复跑通过）。
- 真实 `gh issue list --state all` 查询可同时返回已关闭 #1331 与开放 #1442。

## 提交

- `0e815551b` fix(ops): 阻止每日诊断误报重建
- `40dc1d0ca` docs(ops): 关联每日诊断修复 PR

最新提交：`40dc1d0ca`