### PR TITLE
fix(ops): Grok entitlement 403 不再误杀 deploy SSOT gate

### DIFF
--- a/ops/test/gateway_model_ssot_matrix.py
+++ b/ops/test/gateway_model_ssot_matrix.py
@@ -576,6 +576,14 @@ def classify(code: int, body_text: str, ok: bool) -> tuple[str, str]:
             return "SKIP", "not authorized for platform/group"
         if re.search(r"does not have access to responses api|accessdenied", haystack):
             return "SKIP", "model/protocol not provisioned"
+        # Grok OAuth entitlement 403 (tkIsGrokEntitlement403): subscription tier lacks API
+        # access — gateway behavior is correct; smoke key account may not be SuperGrok Heavy.
+        if re.search(
+            r"permission_error|supergrok heavy|grok subscription|run out of available resources|"
+            r"not entitled to api access",
+            haystack,
+        ):
+            return "SKIP", "not authorized for platform/group (grok entitlement)"
         return "FAIL", "unexpected 403"
     if code == 429:
         if re.search(r"no available accounts|available accounts exhausted", haystack):
@@ -842,6 +850,16 @@ def cmd_selftest(_args) -> int:
     assert classify(429, '{"error":"No available accounts"}', False)[0] == "SKIP"
     assert classify(403, '{"error":"universal_no_entitled_group"}', False)[0] == "SKIP"
     assert classify(403, '{"error":{"message":"does not have access to responses api"}}', False)[0] == "SKIP"
+    assert classify(
+        403,
+        '{"error":{"type":"permission_error","message":"SuperGrok Heavy required"}}',
+        False,
+    )[0] == "SKIP"
+    assert classify(
+        403,
+        '{"error":{"message":"The Grok (xAI) subscription backing this request is not entitled to API access"}}',
+        False,
+    )[0] == "SKIP"
     assert classify(400, '{"error":{"message":"Upstream rejected the request"}}', False)[0] == "SKIP"
     assert classify(400, '{"error":{"message":"This model only support stream mode"}}', False)[0] == "SKIP"
     assert shape_ok("chat", 200, {}, "data: {\"choices\":[]}\n\ndata: [DONE]\n")


### PR DESCRIPTION
## 摘要

- `deploy-stage0` 的 SSOT display gate（`--deploy-canary --deploy-closeout`）在 `grok-code-fast-1` 收到 Grok OAuth entitlement **403** 时标为 `FAIL`，导致 v1.8.116 prod deploy workflow 红（gateway smoke 已通过）。
- #1423 后网关对无 entitlement 账号返回 `permission_error` 403 是**预期行为**；gate 的 `classify()` 现将其归类为 `SKIP`（与 universal 403 授权不足同档），`deploy-closeout` 不再因此 fail。

## 风险

- 常规风险：仅改 ops 探针分类逻辑，不改 gateway 运行时行为。
- 若 Grok 403 来自真实路由/鉴权 bug（非 entitlement），gate 可能少报一条 FAIL——现有 selftest 覆盖 entitlement 文案边界。

## 验证

- `python3 ops/test/gateway_model_ssot_matrix.py selftest` → PASS
- `./scripts/preflight.sh` → PASS（提交前本地已跑）
- 合并后建议重跑：`gh workflow run deploy-stage0.yml -f tag=1.8.116`，确认 SSOT gate 段绿

## 提交

- 987897e95 fix(ops): classify Grok entitlement 403 as SSOT gate SKIP
- 最新提交：987897e95

Made with [Cursor](https://cursor.com)