### PR TITLE
fix(gateway): 避免 Antigravity 空池写入 unsupported negative-cache

### DIFF
--- a/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
+++ b/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
@@ -133,7 +133,7 @@ func TestTkWrapSelectionFailure_DeprecatedModelBeatsRouting429(t *testing.T) {
 		ModelUnsupported: 4,
 		Unschedulable:    1,
 	}
-	err := tkWrapSelectionFailure("claude-3-5-sonnet-20241022", stats)
+	err := tkWrapSelectionFailure(PlatformAnthropic, "claude-3-5-sonnet-20241022", stats)
 	require.ErrorIs(t, err, ErrDeprecatedAnthropicModel)
 	require.False(t, errors.Is(err, ErrNoAvailableAccounts))
 	require.False(t, errors.Is(err, ErrUnsupportedModel))

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -222,7 +222,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 		return nil, err
 	}
 	if len(accounts) == 0 {
-		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(requestedModel, selectionFailureStats{}))
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(platform, requestedModel, selectionFailureStats{}))
 	}
 	ctx = s.withWindowCostPrefetch(ctx, accounts)
 	ctx = s.withRPMPrefetch(ctx, accounts)
@@ -694,7 +694,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 			)
 			return nil, ErrThinPoolAllExcluded
 		}
-		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(requestedModel, stats))
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(platform, requestedModel, stats))
 	}
 
 	accountLoads := make([]AccountWithConcurrency, 0, len(candidates))
@@ -786,7 +786,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 		})
 	}
 	stats := s.logDetailedSelectionFailure(ctx, groupID, sessionHash, requestedModel, platform, accounts, excludedIDs, useMixed)
-	return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(requestedModel, stats))
+	return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(platform, requestedModel, stats))
 }
 
 func (s *GatewayService) tryAcquireByLegacyOrder(ctx context.Context, candidates []*Account, groupID *int64, sessionHash string, preferOAuth bool) (*AccountSelectionResult, bool, error) {
@@ -1722,7 +1722,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 
 	if selected == nil {
 		stats := s.logDetailedSelectionFailure(ctx, groupID, sessionHash, requestedModel, platform, accounts, excludedIDs, false)
-		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(requestedModel, stats))
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(platform, requestedModel, stats))
 	}
 
 	// 4. 建立粘性绑定
@@ -1983,7 +1983,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 
 	if selected == nil {
 		stats := s.logDetailedSelectionFailure(ctx, groupID, sessionHash, requestedModel, nativePlatform, accounts, excludedIDs, true)
-		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(requestedModel, stats))
+		return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(nativePlatform, requestedModel, stats))
 	}
 
 	// 4. 建立粘性绑定

--- a/backend/internal/service/gateway_service_tk_unsupported_model.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model.go
@@ -74,22 +74,25 @@ func tkSelectionFailedDueToUnsupportedModel(stats selectionFailureStats) bool {
 		stats.Eligible == 0
 }
 
-// tkWrapSelectionFailure is the single exit point for the two terminal
-// "selected == nil" branches in SelectAccountWithLoadAwareness. It returns:
+// tkWrapSelectionFailure classifies terminal account-selection failures. It returns:
 //   - ErrNoAvailableAccounts as-is when no model was requested;
+//   - an Anthropic namespace error only when the resolved scheduling platform is
+//     Anthropic; Gemini/Antigravity model names must not be judged as claude-* names;
 //   - ErrUnsupportedModel (with the model name + stats) when the failure is
 //     purely an unsupported model name (caller fault → handler maps to HTTP 400);
 //   - otherwise the original ErrNoAvailableAccounts wrapped with the model + stats
 //     (transient capacity → 429), preserving prior behavior.
-func tkWrapSelectionFailure(requestedModel string, stats selectionFailureStats) error {
+func tkWrapSelectionFailure(platform, requestedModel string, stats selectionFailureStats) error {
 	if requestedModel == "" {
 		return ErrNoAvailableAccounts
 	}
 	if err := tkDeprecatedAnthropicSelectionFailure(requestedModel); err != nil {
 		return err
 	}
-	if err := tkAnthropicCrossVendorSelectionFailure(requestedModel); err != nil {
-		return err
+	if platform == PlatformAnthropic {
+		if err := tkAnthropicCrossVendorSelectionFailure(requestedModel); err != nil {
+			return err
+		}
 	}
 	if tkSelectionFailedDueToUnsupportedModel(stats) {
 		return fmt.Errorf("%w: %s (%s)", ErrUnsupportedModel, requestedModel, summarizeSelectionFailureStats(stats))

--- a/backend/internal/service/gateway_service_tk_unsupported_model_test.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model_test.go
@@ -3,6 +3,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -61,7 +62,7 @@ func TestTkSelectionFailedDueToUnsupportedModel(t *testing.T) {
 
 func TestTkWrapSelectionFailure(t *testing.T) {
 	t.Run("empty model returns bare ErrNoAvailableAccounts", func(t *testing.T) {
-		err := tkWrapSelectionFailure("", selectionFailureStats{Total: 3, ModelUnsupported: 3})
+		err := tkWrapSelectionFailure(PlatformAnthropic, "", selectionFailureStats{Total: 3, ModelUnsupported: 3})
 		if !errors.Is(err, ErrNoAvailableAccounts) {
 			t.Fatalf("want ErrNoAvailableAccounts, got %v", err)
 		}
@@ -71,7 +72,7 @@ func TestTkWrapSelectionFailure(t *testing.T) {
 	})
 
 	t.Run("pure unsupported model returns ErrUnsupportedModel with model name", func(t *testing.T) {
-		err := tkWrapSelectionFailure("opus", selectionFailureStats{Total: 5, ModelUnsupported: 5})
+		err := tkWrapSelectionFailure(PlatformAnthropic, "opus", selectionFailureStats{Total: 5, ModelUnsupported: 5})
 		if !errors.Is(err, ErrUnsupportedModel) {
 			t.Fatalf("want ErrUnsupportedModel, got %v", err)
 		}
@@ -89,7 +90,7 @@ func TestTkWrapSelectionFailure(t *testing.T) {
 	})
 
 	t.Run("capacity failure returns ErrNoAvailableAccounts (not unsupported)", func(t *testing.T) {
-		err := tkWrapSelectionFailure("claude-opus-4-8", selectionFailureStats{Total: 5, ModelUnsupported: 4, ModelRateLimited: 1})
+		err := tkWrapSelectionFailure(PlatformAnthropic, "claude-opus-4-8", selectionFailureStats{Total: 5, ModelUnsupported: 4, ModelRateLimited: 1})
 		if !errors.Is(err, ErrNoAvailableAccounts) {
 			t.Fatalf("want ErrNoAvailableAccounts, got %v", err)
 		}
@@ -104,7 +105,7 @@ func TestTkWrapSelectionFailure(t *testing.T) {
 			ModelUnsupported: 4,
 			Unschedulable:    1,
 		}
-		err := tkWrapSelectionFailure("gpt", stats)
+		err := tkWrapSelectionFailure(PlatformAnthropic, "gpt", stats)
 		if !errors.Is(err, ErrUnsupportedModel) {
 			t.Fatalf("want ErrUnsupportedModel for cross-vendor name, got %v", err)
 		}
@@ -112,6 +113,62 @@ func TestTkWrapSelectionFailure(t *testing.T) {
 			t.Fatalf("cross-vendor must not fall through to empty pool: %v", err)
 		}
 	})
+
+	t.Run("antigravity empty pool stays capacity-owned and does not populate unsupported cache", func(t *testing.T) {
+		err := tkWrapSelectionFailure(PlatformAntigravity, "gemini-3-flash", selectionFailureStats{})
+		if !errors.Is(err, ErrNoAvailableAccounts) {
+			t.Fatalf("want ErrNoAvailableAccounts for an empty Antigravity pool, got %v", err)
+		}
+		if errors.Is(err, ErrUnsupportedModel) {
+			t.Fatalf("Antigravity model must not be checked against the Anthropic namespace: %v", err)
+		}
+
+		cache := newTkGroupUnsupportedModelNegativeCache()
+		groupID := int64(17)
+		_ = tkGroupUnsupportedModelRecordErr(cache, &groupID, "gemini-3-flash", err)
+		if cache.get(groupID, "gemini-3-flash") {
+			t.Fatal("capacity failure must not populate the unsupported-model negative cache")
+		}
+	})
+}
+
+func TestSelectAccountWithLoadAwareness_AntigravityEmptyPoolStaysCapacityOwned(t *testing.T) {
+	groupID := int64(85)
+	unsupportedCache := newTkGroupUnsupportedModelNegativeCache()
+	cfg := testConfig()
+	cfg.Gateway.Scheduling.LoadBatchEnabled = true
+
+	svc := &GatewayService{
+		accountRepo: &mockAccountRepoForPlatform{},
+		groupRepo: &mockGroupRepoForGateway{
+			groups: map[int64]*Group{
+				groupID: {
+					ID:       groupID,
+					Platform: PlatformAntigravity,
+					Status:   StatusActive,
+					Hydrated: true,
+				},
+			},
+		},
+		cache:                   &mockGatewayCacheForPlatform{},
+		cfg:                     cfg,
+		concurrencyService:      NewConcurrencyService(&mockConcurrencyCache{}),
+		tkGroupUnsupportedCache: unsupportedCache,
+	}
+
+	result, err := svc.SelectAccountWithLoadAwareness(context.Background(), &groupID, "", "gemini-3-flash", nil, "", 0)
+	if result != nil {
+		t.Fatalf("expected no selection, got %+v", result)
+	}
+	if !errors.Is(err, ErrNoAvailableAccounts) {
+		t.Fatalf("want ErrNoAvailableAccounts, got %v", err)
+	}
+	if errors.Is(err, ErrUnsupportedModel) {
+		t.Fatalf("Antigravity empty pool must remain capacity-owned: %v", err)
+	}
+	if unsupportedCache.get(groupID, "gemini-3-flash") {
+		t.Fatal("capacity failure must not populate the unsupported-model negative cache")
+	}
 }
 
 func TestTkIsAnthropicCrossVendorModelName(t *testing.T) {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3142,7 +3142,7 @@
     {
       "path": "backend/internal/service/gateway_scheduling.go",
       "must_contain": [
-        "tkWrapSelectionFailure(requestedModel, stats)"
+        "tkWrapSelectionFailure(platform, requestedModel, stats)"
       ],
       "rationale": "Unsupported-model classification (prod 2026-06-06, user_id=16 sent the bare name 'opus'): both terminal 'selected == nil' branches in SelectAccountWithLoadAwareness route through tkWrapSelectionFailure, which returns service.ErrUnsupportedModel (handler -> HTTP 400 invalid_request_error) when selection failed PURELY because no account serves the requested model name (model_unsupported>0, model_rate_limited==0, unschedulable==0), and the original ErrNoAvailableAccounts (429) otherwise. An upstream merge that rewrites these return points back to the bare 'return nil, ErrNoAvailableAccounts' / fmt.Errorf shape silently reverts the fix: unsupported model names again surface as a misleading rate_limit_error/429 (the new gateway_service_tk_unsupported_model.go would still compile, just unused). This sentinel pins the call sites."
     },
@@ -3161,7 +3161,7 @@
     {
       "path": "backend/internal/service/gateway_scheduling.go",
       "must_contain": [
-        "return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(requestedModel, stats))"
+        "return nil, s.tkGroupUnsupportedModelRecordErr(groupID, requestedModel, tkWrapSelectionFailure(platform, requestedModel, stats))"
       ],
       "rationale": "Load-batch SelectAccountWithLoadAwareness empty-pool returns (zero schedulable accounts, Layer-2 no candidates, Layer-3 session-quota exhausted) must route through tkWrapSelectionFailure so retired Anthropic model IDs become ErrDeprecatedAnthropicModel instead of bare ErrNoAvailableAccounts → routing 429, and through tkGroupUnsupportedModelRecordErr so pure unsupported-model failures populate the per-group negative cache. PR #1255 fixed tkWrapSelectionFailure only; this sentinel pins the load-batch exit sites and their TokenKey cache side effect (#1257)."
     },
@@ -3208,9 +3208,10 @@
       "must_contain": [
         "tkDeprecatedAnthropicSelectionFailure(requestedModel)",
         "tkAnthropicCrossVendorSelectionFailure(requestedModel)",
+        "platform == PlatformAnthropic",
         "func TkIsAnthropicCrossVendorModelName"
       ],
-      "rationale": "tkWrapSelectionFailure must short-circuit retired Anthropic model names to ErrDeprecatedAnthropicModel and non-claude-* cross-vendor dirty names to ErrUnsupportedModel before empty-pool classification; otherwise mixed model_unsupported + unschedulable stats or load-batch bare ErrNoAvailableAccounts surface routing 429 for client-fault model names (prod 2026-07-07 user16 key121 model=gpt)."
+      "rationale": "tkWrapSelectionFailure must short-circuit retired Anthropic model names to ErrDeprecatedAnthropicModel and, only when the resolved scheduling platform is anthropic, non-claude-* cross-vendor dirty names to ErrUnsupportedModel before empty-pool classification. The platform guard prevents an empty Gemini/Antigravity pool from misclassifying gemini-* as an Anthropic namespace error and populating the group unsupported-model negative cache; the Anthropic branch still prevents mixed model_unsupported + unschedulable stats or load-batch bare ErrNoAvailableAccounts from surfacing routing 429 for client-fault model names (prod 2026-07-07 user16 key121 model=gpt)."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",


### PR DESCRIPTION
## 摘要

- 修复 Antigravity/Gemini 空账号池被 Anthropic `claude-*` 命名空间误判为 `ErrUnsupportedModel` 的问题。
- 让所有 Gateway 调度失败出口把 resolved platform 传入统一分类器，仅在 Anthropic 平台执行跨厂商模型名检查。
- 补充分类器与真实调度入口回归测试，并更新 gateway sentinel，防止后续 upstream merge 静默覆盖。

## 风险

- 常规风险：仅修正空池容量错误的归属；真正由账号模型能力导致的 pure unsupported 仍保持 HTTP 400 与 negative-cache 行为。
- no-web-impact：无 Web、配置、Schema 或前端契约变化。
- 未修改线上账号、缓存或配置，未执行部署。

## 验证

- `go test -tags=unit ./internal/service/... -count=1`
- 聚焦 Antigravity 空池、unsupported 分类与 negative-cache 回归测试
- `./scripts/preflight.sh`
- xj-review：merge-ready，零 medium+ finding

## 提交

- `4513e831e fix(gateway): scope unsupported-model checks by platform`
- 最新提交：`4513e831e`