### PR TITLE
fix(grok): 统一 entitlement 403 canonical quarantine seam

### DIFF
--- a/backend/internal/service/grok_upstream_errors.go
+++ b/backend/internal/service/grok_upstream_errors.go
@@ -195,6 +195,9 @@ func (s *OpenAIGatewayService) shouldFailoverGrokUpstreamError(statusCode int, r
 	if isGrokContentPolicyRejection(statusCode, responseBody) {
 		return false
 	}
+	if tkIsGrokEntitlement403(statusCode, responseBody) {
+		return false
+	}
 	return s.shouldFailoverUpstreamError(statusCode)
 }
 

--- a/backend/internal/service/grok_upstream_errors_test.go
+++ b/backend/internal/service/grok_upstream_errors_test.go
@@ -242,21 +242,26 @@ func TestGrokContentPolicySSEErrorDoesNotMutateOrFailover(t *testing.T) {
 	require.False(t, svc.isOpenAIAccountRuntimeBlocked(account))
 }
 
-func TestHandleGrokAccountUpstreamErrorEntitlement403KeepsDefaultCooldown(t *testing.T) {
+func TestShouldFailoverGrokUpstreamErrorEntitlement403Terminal(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	body := []byte(`{"code":"forbidden","error":"You have either run out of available resources or do not have an active Grok subscription."}`)
+	require.False(t, svc.shouldFailoverGrokUpstreamError(http.StatusForbidden, body))
+}
+
+func TestHandleGrokAccountUpstreamErrorEntitlement403QuarantinesAccount(t *testing.T) {
 	repo := &grokQuotaAccountRepo{}
 	svc := &OpenAIGatewayService{accountRepo: repo}
 	account := &Account{ID: 4716, Platform: PlatformGrok, Type: AccountTypeOAuth}
 	before := time.Now()
+	body := []byte(`{"code":"forbidden","error":"You have either run out of available resources or do not have an active Grok subscription."}`)
 
-	svc.handleGrokAccountUpstreamError(
-		context.Background(), account, http.StatusForbidden, nil,
-		[]byte(`{"error":{"message":"subscription required"}}`),
-	)
+	svc.handleGrokAccountUpstreamError(context.Background(), account, http.StatusForbidden, nil, body)
 
 	require.Equal(t, 1, repo.tempUnschedCalls)
 	require.Equal(t, "grok access or entitlement denied", repo.lastTempUnschedReason)
-	require.Greater(t, repo.lastTempUnschedUntil, before.Add(29*time.Minute))
-	require.Less(t, repo.lastTempUnschedUntil, before.Add(31*time.Minute))
+	require.Greater(t, repo.lastTempUnschedUntil, before.Add(23*time.Hour))
+	require.Less(t, repo.lastTempUnschedUntil, before.Add(25*time.Hour))
+	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account))
 }
 
 func TestHandleGrokAccountUpstreamError403UsesConfiguredRule(t *testing.T) {

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -185,20 +185,17 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	if resp.StatusCode >= 400 {
 		respBody, upstreamMsg := s.readOpenAIUpstreamError(resp)
 		if account.Platform == PlatformGrok {
-			if tkIsGrokEntitlement403(resp.StatusCode, respBody) {
-				return s.handleChatCompletionsErrorResponse(resp, c, account, billingModel)
-			}
-			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-				Platform:           account.Platform,
-				AccountID:          account.ID,
-				AccountName:        account.Name,
-				UpstreamStatusCode: resp.StatusCode,
-				UpstreamRequestID:  firstNonEmpty(resp.Header.Get("x-request-id"), resp.Header.Get("xai-request-id")),
-				Kind:               "failover",
-				Message:            upstreamMsg,
-			})
 			s.handleGrokAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, upstreamModel)
-			if s.shouldFailoverUpstreamError(resp.StatusCode) {
+			if s.shouldFailoverGrokUpstreamError(resp.StatusCode, respBody) {
+				appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+					Platform:           account.Platform,
+					AccountID:          account.ID,
+					AccountName:        account.Name,
+					UpstreamStatusCode: resp.StatusCode,
+					UpstreamRequestID:  firstNonEmpty(resp.Header.Get("x-request-id"), resp.Header.Get("xai-request-id")),
+					Kind:               "failover",
+					Message:            upstreamMsg,
+				})
 				return nil, &UpstreamFailoverError{
 					StatusCode:             resp.StatusCode,
 					ResponseBody:           respBody,

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -1362,6 +1362,9 @@ func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Contex
 		if s.applyGrokForbiddenPolicy(ctx, account, responseBody) {
 			return
 		}
+		if s.tkHandleGrokEntitlement403AccountSideEffect(ctx, account, statusCode, responseBody) {
+			return
+		}
 		s.tempUnscheduleGrok(ctx, account, 30*time.Minute, "grok access or entitlement denied")
 	case http.StatusTooManyRequests:
 		if s.tkHandleGrok429UpstreamError(ctx, account, headers, responseBody, requestedModel...) {

--- a/backend/internal/service/openai_gateway_grok_chat_bridge.go
+++ b/backend/internal/service/openai_gateway_grok_chat_bridge.go
@@ -336,20 +336,17 @@ func (s *OpenAIGatewayService) forwardGrokChatCompletionsViaResponses(
 		if upstreamMsg == "" {
 			upstreamMsg = fmt.Sprintf("xAI upstream returned status %d", resp.StatusCode)
 		}
-		if tkIsGrokEntitlement403(resp.StatusCode, respBody) {
-			return s.handleChatCompletionsErrorResponse(resp, c, account, billingModel)
-		}
-		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-			Platform:           account.Platform,
-			AccountID:          account.ID,
-			AccountName:        account.Name,
-			UpstreamStatusCode: resp.StatusCode,
-			UpstreamRequestID:  firstNonEmpty(resp.Header.Get("x-request-id"), resp.Header.Get("xai-request-id")),
-			Kind:               "failover",
-			Message:            upstreamMsg,
-		})
 		s.handleGrokAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
-		if s.shouldFailoverUpstreamError(resp.StatusCode) {
+		if s.shouldFailoverGrokUpstreamError(resp.StatusCode, respBody) {
+			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+				Platform:           account.Platform,
+				AccountID:          account.ID,
+				AccountName:        account.Name,
+				UpstreamStatusCode: resp.StatusCode,
+				UpstreamRequestID:  firstNonEmpty(resp.Header.Get("x-request-id"), resp.Header.Get("xai-request-id")),
+				Kind:               "failover",
+				Message:            upstreamMsg,
+			})
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
 				ResponseBody:           respBody,

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -1838,4 +1839,47 @@ func TestIsGrokImageGenerationModel(t *testing.T) {
 			require.Equal(t, tt.want, isGrokImageGenerationModel(tt.model))
 		})
 	}
+}
+
+func TestForwardGrokResponsesEntitlement403QuarantinesWithoutFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	body := []byte(`{"input":"hi","model":"grok-build-0.1","stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Set("api_key", &APIKey{ID: 8802})
+
+	account := healthyGrokOAuthGatewayTestAccount(88, "access-token")
+	repo := &grokQuotaAccountRepo{
+		mockAccountRepoForPlatform: &mockAccountRepoForPlatform{
+			accountsByID: map[int64]*Account{88: account},
+		},
+	}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header: http.Header{
+			"Content-Type":   []string{"application/json"},
+			"Xai-Request-Id": []string{"xai-responses-entitlement-403"},
+		},
+		Body: io.NopCloser(strings.NewReader(
+			`{"code":"forbidden","error":"You have either run out of available resources or do not have an active Grok subscription."}`,
+		)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:               rawChatCompletionsTestConfig(),
+		httpUpstream:      upstream,
+		grokTokenProvider: NewGrokTokenProvider(repo, nil),
+		accountRepo:       repo,
+	}
+
+	result, err := svc.forwardGrokResponses(context.Background(), c, account, body, "grok-build-0.1", false, time.Now())
+	require.Error(t, err)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "entitlement 403 must be terminal for responses")
+	require.Equal(t, 1, repo.tempUnschedCalls)
+	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account))
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Equal(t, "permission_error", gjson.Get(recorder.Body.String(), "error.type").String())
 }

--- a/backend/internal/service/openai_gateway_grok_video_tk.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk.go
@@ -163,7 +163,7 @@ func (s *OpenAIGatewayService) grokNativeVideoSubmit(
 		return nil, herr
 	}
 	if status >= 400 {
-		return nil, s.grokVideoUpstreamError(status, respBody)
+		return nil, s.grokVideoUpstreamError(ctx, account, status, respBody)
 	}
 	upstreamTaskID := gjson.GetBytes(respBody, "request_id").String()
 	if upstreamTaskID == "" {
@@ -231,7 +231,7 @@ func (s *OpenAIGatewayService) grokNativeVideoFetch(
 		return nil, herr
 	}
 	if status >= 400 {
-		return nil, s.grokVideoUpstreamError(status, respBody)
+		return nil, s.grokVideoUpstreamError(ctx, account, status, respBody)
 	}
 
 	xaiStatus := gjson.GetBytes(respBody, "status").String()
@@ -343,9 +343,15 @@ func buildGrokVideoFetchURL(base, upstreamTaskID string) string {
 // grokVideoUpstreamError maps an xAI video error response to a client error.
 // A Heavy-only entitlement 403 is surfaced as a clean honesty-403 (skip-retry,
 // no penalty), identical to the grok chat posture; other statuses pass through.
-func (s *OpenAIGatewayService) grokVideoUpstreamError(status int, body []byte) error {
+func (s *OpenAIGatewayService) grokVideoUpstreamError(
+	ctx context.Context,
+	account *Account,
+	status int,
+	body []byte,
+) error {
 	msg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(body)))
 	if tkIsGrokEntitlement403(status, body) {
+		s.tkHandleGrokEntitlement403AccountSideEffect(ctx, account, status, body)
 		return &NewAPIRelayError{Err: newapitypes.NewErrorWithStatusCode(
 			errors.New(tkGrokEntitlement403ClientMessage(msg)),
 			newapitypes.ErrorCodeInvalidRequest,

--- a/backend/internal/service/openai_gateway_grok_video_tk_test.go
+++ b/backend/internal/service/openai_gateway_grok_video_tk_test.go
@@ -3,12 +3,16 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveGrokVideoCredential(t *testing.T) {
@@ -292,4 +296,20 @@ func TestBuildGrokVideoSubmitResponse(t *testing.T) {
 	if got.CreatedAt <= 0 {
 		t.Fatalf("created_at = %d, want a positive unix timestamp", got.CreatedAt)
 	}
+}
+
+func TestGrokVideoUpstreamErrorEntitlement403QuarantinesAccount(t *testing.T) {
+	repo := &grokQuotaAccountRepo{}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+	account := &Account{ID: 8801, Platform: PlatformGrok, Type: AccountTypeOAuth}
+	before := time.Now()
+	body := []byte(`{"code":"forbidden","error":"You have either run out of available resources or do not have an active Grok subscription."}`)
+
+	err := svc.grokVideoUpstreamError(context.Background(), account, http.StatusForbidden, body)
+	require.Error(t, err)
+	require.Equal(t, 1, repo.tempUnschedCalls)
+	require.Equal(t, "grok access or entitlement denied", repo.lastTempUnschedReason)
+	require.Greater(t, repo.lastTempUnschedUntil, before.Add(23*time.Hour))
+	require.Less(t, repo.lastTempUnschedUntil, before.Add(25*time.Hour))
+	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account))
 }

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -386,7 +386,6 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 	setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, upstreamDetail)
 	logOpenAIInstructionsRequiredDebug(ctx, c, account, resp.StatusCode, upstreamMsg, requestBody, body)
 	if account != nil && account.IsGrok() && tkIsGrokEntitlement403(resp.StatusCode, body) {
-		s.tkQuarantineGrokEntitlement403Account(c.Request.Context(), account)
 		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 			Platform:           account.Platform,
 			AccountID:          account.ID,
@@ -675,7 +674,6 @@ func (s *OpenAIGatewayService) handleCompatErrorResponse(
 	}
 	setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, upstreamDetail)
 	if account != nil && account.IsGrok() && tkIsGrokEntitlement403(resp.StatusCode, body) {
-		s.tkQuarantineGrokEntitlement403Account(c.Request.Context(), account)
 		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 			Platform:           account.Platform,
 			AccountID:          account.ID,

--- a/backend/internal/service/ratelimit_service_tk_grok_entitlement_403.go
+++ b/backend/internal/service/ratelimit_service_tk_grok_entitlement_403.go
@@ -111,3 +111,20 @@ func (s *OpenAIGatewayService) tkQuarantineGrokEntitlement403Account(ctx context
 	s.tempUnscheduleGrok(ctx, account, tkGrokEntitlement403QuarantineCooldown,
 		"grok access or entitlement denied")
 }
+
+// tkHandleGrokEntitlement403AccountSideEffect quarantines the account when xAI
+// returns the Heavy-only OAuth entitlement gate. Callers keep owning the client
+// response shape; this is the single scheduling side-effect seam for every grok
+// surface (chat, responses, media, video).
+func (s *OpenAIGatewayService) tkHandleGrokEntitlement403AccountSideEffect(
+	ctx context.Context,
+	account *Account,
+	statusCode int,
+	body []byte,
+) bool {
+	if !tkIsGrokEntitlement403(statusCode, body) {
+		return false
+	}
+	s.tkQuarantineGrokEntitlement403Account(ctx, account)
+	return true
+}

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -106,9 +106,18 @@
       "path": "backend/internal/service/ratelimit_service_tk_grok_entitlement_403.go",
       "must_contain": [
         "func tkIsGrokEntitlement403",
-        "func tkGrokEntitlement403ClientMessage"
+        "func tkGrokEntitlement403ClientMessage",
+        "func (s *OpenAIGatewayService) tkHandleGrokEntitlement403AccountSideEffect"
       ],
-      "rationale": "The xAI Heavy-only entitlement-403 classifier + clean client message. Without it a grok 403 (standard/expired/downgraded Heavy) fails over pool-wide and is masked into a 502 — the single xAI policy change that would silently kill a thin grok pool (the marquee sharp edge)."
+      "rationale": "The xAI Heavy-only entitlement-403 classifier + clean client message + canonical quarantine side-effect seam. Without it a grok 403 (standard/expired/downgraded Heavy) fails over pool-wide and is masked into a 502 — the single xAI policy change that would silently kill a thin grok pool (the marquee sharp edge)."
+    },
+    {
+      "path": "backend/internal/service/grok_upstream_errors.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) shouldFailoverGrokUpstreamError",
+        "tkIsGrokEntitlement403(statusCode, responseBody)"
+      ],
+      "rationale": "Grok failover must treat xAI OAuth entitlement 403 as terminal on every surface (responses/media/cc failover), not only chat pre-checks. Losing this line re-poisons the grok pool on /v1/responses entitlement failures."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_openai_downstream.go",
@@ -132,17 +141,19 @@
       "must_contain": [
         "account.IsGrokOAuth()",
         "validateUpstreamBaseURLForAccount(account, baseURL)",
-        "tkIsGrokEntitlement403(resp.StatusCode, respBody)"
+        "shouldFailoverGrokUpstreamError(resp.StatusCode, respBody)",
+        "handleGrokAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, upstreamModel)"
       ],
-      "rationale": "The raw CC forwarder resolves the grok OAuth Bearer + api.x.ai base_url here; first-class grok API-key relay stubs intentionally use GetOpenAIApiKey/GetOpenAIBaseURL and the edge base_url. It must intercept entitlement 403 before recording failover or applying the 30-minute Grok cooldown."
+      "rationale": "The raw CC forwarder resolves the grok OAuth Bearer + api.x.ai base_url here; first-class grok API-key relay stubs intentionally use GetOpenAIApiKey/GetOpenAIBaseURL and the edge base_url. Entitlement 403 must route through the canonical grok account side-effect seam before any pool failover."
     },
     {
       "path": "backend/internal/service/openai_gateway_grok_chat_bridge.go",
       "must_contain": [
         "func (s *OpenAIGatewayService) forwardGrokChatCompletionsViaResponses(",
-        "tkIsGrokEntitlement403(resp.StatusCode, respBody)"
+        "shouldFailoverGrokUpstreamError(resp.StatusCode, respBody)",
+        "handleGrokAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)"
       ],
-      "rationale": "Cacheable Chat Completions requests use the Grok Responses bridge rather than the raw CC forwarder. This path needs the same terminal entitlement-403 guard before failover logging and account cooldown side effects."
+      "rationale": "Cacheable Chat Completions requests use the Grok Responses bridge rather than the raw CC forwarder. Entitlement 403 must use the canonical account side-effect seam and terminal failover guard before pool failover logging."
     },
     {
       "path": "backend/internal/service/openai_gateway_v1_forward.go",
@@ -419,7 +430,8 @@
       "must_contain": [
         "TestResolveGrokVideoCredential",
         "TestNormalizeGrokVideoStatus",
-        "TestBuildGrokVideoSubmitResponse"
+        "TestBuildGrokVideoSubmitResponse",
+        "TestGrokVideoUpstreamErrorEntitlement403QuarantinesAccount"
       ],
       "rationale": "Load-bearing QA evidence for the grok-native video arm: resolveGrokVideoCredential pins OAuth vs prod→edge relay api_key (revert to access_token-only silently re-breaks prod grok-us4 video submit), the xAI status-enum -> videoTerminalOutcome mapping (drift would skip terminal-success retention or terminal-failure refund), and the submit acknowledgement shape (must carry TK's public task id, not the upstream request_id)."
     },
@@ -506,7 +518,8 @@
         "TestForwardGrokResponsesAPIKeyRelayUsesEdgeResponsesURL",
         "TestResolveGrokResponsesUpstreamAPIKeyRelayUsesEdgeOpenAIResponses",
         "TestForwardAsAnthropic_GrokAPIKeyRelayUsesEdgeChatCompletionsURL",
-        "TestHandleGrokAccountUpstreamError_DownstreamCapacitySkipsRelayCooldown"
+        "TestHandleGrokAccountUpstreamError_DownstreamCapacitySkipsRelayCooldown",
+        "TestForwardGrokResponsesEntitlement403QuarantinesWithoutFailover"
       ],
       "rationale": "Load-bearing QA for grok apikey relay and Anthropic-shaped /v1/messages prod->edge path: native-catalog SKUs must forward to edge /v1/chat/completions with Bearer api_key (SSOT provision path), and TokenKey downstream capacity envelopes must not runtime-block/temp-unschedule relay stubs. Revert to OAuth-only, responses-first routing, or treating relay capacity as xAI account health passes other tests but breaks prod grok clients."
     },


### PR DESCRIPTION
## 摘要

- **P0**：在 `shouldFailoverGrokUpstreamError` 与 `tkHandleGrokEntitlement403AccountSideEffect` 收口 xAI OAuth entitlement 403——全 grok 面（responses / media / cc failover / video）统一为「不 failover sibling + 24h quarantine」。
- **P1**：`grokVideoUpstreamError` 在 entitlement 403 时调用 canonical quarantine seam。
- **P2**：删除 chat bridge/raw 的 scatter `tkIsGrokEntitlement403` pre-check 与 error handler 二次 quarantine；终端错误只经 `handleChatCompletionsErrorResponse` / `handleErrorResponse` 写客户端文案，调度副作用只走 seam。

## 风险

- 常规风险：仅 Grok OAuth 错误处理与调度隔离语义；不改变 upstream 路由或 billing 门控。
- entitlement 403 的 30min 泛化 cooldown 仍保留给**非** xAI Heavy-gate 的其它 403。

## 验证

- `go test -tags=unit ./internal/service/ -run 'Grok|grok|Entitlement403|ShouldFailoverGrok'`
- `./scripts/preflight.sh` → PASS

## 提交

- aa168695f fix(grok): 统一 entitlement 403 的 canonical quarantine seam

最新提交：aa168695f

sentinel-registry-reviewed

Made with [Cursor](https://cursor.com)