### PR TITLE
fix(release): bump 时 docs/ops baseline 无法 stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,10 @@ docs/*
 !docs/ASYNC_IMAGE_TASKS.md
 !docs/legal/
 !docs/legal/*.md
+# Release bump syncs docs/ops/endpoint-compat-baseline.md (release-bump-and-tag.sh);
+# must remain stageable despite upstream-shaped docs/* ignore above.
+!docs/ops/
+!docs/ops/**
 .serena/
 .codex/
 frontend/coverage/

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 637,
-  "hash": "bbe540e52ce3069a20c3f7fb42e638d99fb8eee9480e8f39d1a191859201607f",
+  "hash": "f65d9f6f656eec1d553b8b65cdcbc02bf792382ba7965744ce0d0e657c6dacb5",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,6 @@
     "@tanstack/vue-virtual": "^3.13.23",
     "@vueuse/core": "^10.7.0",
     "axios": "^1.18.1",
-    "axios": "^1.18.0",
     "chart.js": "^4.4.1",
     "dompurify": "^3.3.1",
     "driver.js": "^1.4.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         specifier: ^10.7.0
         version: 10.11.1(vue@3.5.40(typescript@5.6.3))
       axios:
-        specifier: ^1.18.0
+        specifier: ^1.18.1
         version: 1.18.1
       chart.js:
         specifier: ^4.4.1

--- a/scripts/release-bump-and-tag.sh
+++ b/scripts/release-bump-and-tag.sh
@@ -144,7 +144,9 @@ if [ "$ACTION" = "bump-and-tag" ]; then
   python3 "$WT_DIR/scripts/sync_endpoint_compat_baseline_anchor.py" \
     --version "$NEXT_VERSION" \
     --previous-deploy-tag "$CURRENT_TAG"
-  git -C "$WT_DIR" add backend/cmd/server/VERSION docs/ops/endpoint-compat-baseline.md
+  git -C "$WT_DIR" add backend/cmd/server/VERSION
+  # baseline lives under docs/ops/; force-add stays safe if docs/* ignore drifts again.
+  git -C "$WT_DIR" add -f docs/ops/endpoint-compat-baseline.md
   if ! python3 "$WT_DIR/scripts/check_endpoint_compat_baseline_freshness.py" >/dev/null; then
     echo "[release-bump-and-tag] ERROR: endpoint-compat baseline freshness check failed after sync" >&2
     python3 "$WT_DIR/scripts/check_endpoint_compat_baseline_freshness.py" >&2 || true

--- a/scripts/release-bump-via-pr.sh
+++ b/scripts/release-bump-via-pr.sh
@@ -114,7 +114,8 @@ if [ -z "$PR_NUM" ]; then
   python3 "$WT_DIR/scripts/sync_endpoint_compat_baseline_anchor.py" \
     --version "$NEXT_VERSION" \
     --previous-deploy-tag "$CURRENT_TAG"
-  git -C "$WT_DIR" add backend/cmd/server/VERSION docs/ops/endpoint-compat-baseline.md
+  git -C "$WT_DIR" add backend/cmd/server/VERSION
+  git -C "$WT_DIR" add -f docs/ops/endpoint-compat-baseline.md
   if ! python3 "$WT_DIR/scripts/check_endpoint_compat_baseline_freshness.py" >/dev/null; then
     echo "[release-bump-via-pr] ERROR: endpoint-compat baseline freshness check failed after sync" >&2
     python3 "$WT_DIR/scripts/check_endpoint_compat_baseline_freshness.py" >&2 || true

--- a/scripts/test_release_bump_and_tag.py
+++ b/scripts/test_release_bump_and_tag.py
@@ -105,6 +105,23 @@ class ReleaseBumpAndTagTest(unittest.TestCase):
         self.assertEqual(proc.returncode, 2, f"stdout:{proc.stdout}\nstderr:{proc.stderr}")
         self.assertIn("refusing to guess bump path", proc.stderr)
 
+    def test_docs_ops_baseline_not_gitignored(self) -> None:
+        """release bump must stage endpoint-compat baseline without git add -f."""
+        repo_root = pathlib.Path(__file__).resolve().parent.parent
+        baseline = repo_root / "docs/ops/endpoint-compat-baseline.md"
+        self.assertTrue(baseline.is_file(), f"missing {baseline}")
+        proc = subprocess.run(
+            ["git", "check-ignore", "-q", str(baseline.relative_to(repo_root))],
+            cwd=repo_root,
+            env=_clean_env(),
+            capture_output=True,
+        )
+        self.assertNotEqual(
+            proc.returncode,
+            0,
+            "docs/ops/endpoint-compat-baseline.md must not match docs/* gitignore",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要

回顾 v1.8.117 发版过程：`release-bump-and-tag.sh` 在 sync `docs/ops/endpoint-compat-baseline.md` 后执行 `git add` 失败（`docs/*` gitignore 拦截），需手工在 worktree 内 `git add -f` 才能完成 bump/tag。本 PR 从根因修复并顺带清理 upstream merge 残留的重复 `axios` 依赖键。

## 风险

- 低风险：仅影响发版脚本与 gitignore 白名单，不改变运行时网关行为
- `frontend/package.json` / lockfile 去重 axios → 同步 `frontend-source.json` hash

## 验证

```bash
python3 scripts/test_release_bump_and_tag.py -v
git check-ignore docs/ops/endpoint-compat-baseline.md  # 期望 exit 1（不被 ignore）
bash scripts/preflight.sh  # PASS
```

## 提交

- fcf3f4d9e fix(release): 修复 bump 时 docs/ops baseline 无法 stage 的问题

最新提交：fcf3f4d9e

Made with [Cursor](https://cursor.com)