### PR TITLE
fix(accounts): 修复创建账号单次提交产生两条记录

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 641,
-  "hash": "3fbe781711e65dee356321450ee98add4e3458e349e0cd66b6db94b7765f4172",
+  "hash": "c0d52e9cc318d8a232a7afe0f268090992f821bc338f62cdb49f12b3b45a7e2b",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -4894,8 +4894,7 @@ const submitCreateAccount = async (payload: CreateAccountRequest) => {
   const finalPayload = withAccountEmail(payload, accountEmail.value)
   submitting.value = true
   try {
-    await adminAPI.accounts.create(withAntigravityConfirmFlag(finalPayload))
-    const account = await adminAPI.accounts.create(withAntigravityConfirmFlag(payload))
+    const account = await adminAPI.accounts.create(withAntigravityConfirmFlag(finalPayload))
     if (
       payload.platform === 'openai' &&
       payload.type === 'apikey' &&


### PR DESCRIPTION
## 摘要

- 根因：`CreateAccountModal.vue` 的 `submitCreateAccount` 在 d2585097f（上游计费探测）中连续调用了两次 `adminAPI.accounts.create`，单次「创建」会插入 ID 连续的两条账号（如 86/87）。
- 修复：删除多余调用，仅保留一次 create，并使用带 `account_email` 的 `finalPayload` 获取返回值供 `probeUpstreamBilling` 使用。
- 已 rebase 到最新 main，解决 `frontend-source.json` 冲突并更新 source hash。
- 已有单测 `CreateAccountModal.spec.ts` 断言 `create` 只调用 1 次，修复后全部通过。

## 风险

- 常规风险：仅影响管理后台「添加账号」提交流程，不改变 API 契约。
- 已产生的重复账号需人工删除其中一条（本 PR 不做数据清理）。
- sentinel-registry-reviewed：纯回归修复（删除重复 API 调用），`CreateAccountModal.vue` 已有单测锚点，无需新增 sentinel anchor。

## 验证

```bash
cd frontend && pnpm exec vitest run src/components/account/__tests__/CreateAccountModal.spec.ts
# 20 passed
PREFLIGHT_BASE=origin/main bash scripts/preflight.sh
# PASS
```

## 提交

- 7827887b0 fix(accounts): 修复创建账号时重复调用 create API 导致双行记录

最新提交：7827887b0

Made with [Cursor](https://cursor.com)