### PR TITLE
fix(frontend): 优化工具接入/模型市场/API 密钥页布局并隐藏 probe 密钥

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 642,
-  "hash": "75542801675ee092d074313e6b95c29f5c2b0ec86793e5b58cbdbe0f60da45e8",
+  "file_count": 643,
+  "hash": "1f444b5f527dd75a0813f4ec06f20c795274a28c003c339fc7a818772d7e100c",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 641,
-  "hash": "c0d52e9cc318d8a232a7afe0f268090992f821bc338f62cdb49f12b3b45a7e2b",
+  "hash": "73452dc7950f2a2f059874a8999d0d015e8aed64a596b67af84cb73e6cbd5ebe",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 641,
-  "hash": "73452dc7950f2a2f059874a8999d0d015e8aed64a596b67af84cb73e6cbd5ebe",
+  "file_count": 642,
+  "hash": "75542801675ee092d074313e6b95c29f5c2b0ec86793e5b58cbdbe0f60da45e8",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/e2e/pr1459-ui-acceptance.e2e.ts
+++ b/frontend/e2e/pr1459-ui-acceptance.e2e.ts
@@ -1,0 +1,92 @@
+import { test, expect, type Page } from '@playwright/test'
+
+const EMAIL = process.env.E2E_EMAIL || 'admin@sub2api.local'
+const PASS = process.env.E2E_PASSWORD || 'Admin12345!'
+
+async function login(page: Page): Promise<void> {
+  await page.goto('/login')
+  await page.locator('input[type=email]').first().fill(EMAIL)
+  await page.locator('input[type=password]').first().fill(PASS)
+  await page.locator('button[type=submit]').first().click()
+  await page.waitForURL((u) => !u.pathname.includes('/login'), { timeout: 30_000 })
+}
+
+test.describe('PR #1459 UI acceptance', () => {
+  test('quickstart: no decorative top border on key section', async ({ page }) => {
+    await login(page)
+    await page.goto('/quickstart')
+    await expect(page.locator('[data-tk="quickstart-key-select"]')).toBeVisible({ timeout: 30_000 })
+    await expect(page.locator('section.border-y')).toHaveCount(0)
+  })
+
+  test('models browse: switcher shares toolbar row with search (authed)', async ({ page, baseURL }) => {
+    await login(page)
+    await page.goto('/models')
+    await expect(page.locator('[data-tk="catalog-hub-authed"]')).toBeVisible({ timeout: 20_000 })
+    await expect(page.locator('[data-tk="catalog-hub-authed-toolbar"]')).toHaveCount(0)
+
+    const switcher = page.locator('[data-tk="catalog-view-switcher"]')
+    const search = page.locator('input[placeholder*="搜索"], input[placeholder*="Search"]').first()
+    await expect(switcher).toBeVisible({ timeout: 20_000 })
+    await expect(search).toBeVisible()
+
+    const switcherBox = await switcher.boundingBox()
+    const searchBox = await search.boundingBox()
+    expect(switcherBox).toBeTruthy()
+    expect(searchBox).toBeTruthy()
+    const rowDelta = Math.abs((switcherBox!.y + switcherBox!.height / 2) - (searchBox!.y + searchBox!.height / 2))
+    expect(rowDelta).toBeLessThan(40)
+  })
+
+  test('models browse card links to quickstart when authed', async ({ page, baseURL }) => {
+    const res = await fetch(`${baseURL}/api/v1/public/pricing`)
+    test.skip(!res.ok, 'public catalog unavailable')
+    const body = (await res.json()) as { data?: { model_id: string }[] }
+    const modelId = body.data?.[0]?.model_id
+    test.skip(!modelId, 'empty catalog')
+
+    await login(page)
+    await page.goto('/models')
+    const card = page.locator(`[data-tk="models-marketplace-card-${modelId}"]`)
+    await expect(card).toBeVisible({ timeout: 20_000 })
+
+    const href = await card.getAttribute('href')
+    expect(href).toContain('/quickstart')
+    expect(href).toContain(`model=${encodeURIComponent(modelId)}`)
+    expect(href).not.toContain('view=pricing')
+
+    await card.click()
+    await page.waitForURL((u) => u.pathname === '/quickstart', { timeout: 20_000 })
+    expect(new URL(page.url()).searchParams.get('model')).toBe(modelId)
+  })
+
+  test('keys page: filters and actions share one toolbar row', async ({ page }) => {
+    await login(page)
+    await page.goto('/keys')
+    await page.waitForLoadState('networkidle')
+
+    const search = page.locator('input[placeholder*="搜索"], input[placeholder*="Search"]').first()
+    const createBtn = page.locator('[data-tour="keys-create-btn"]')
+    await expect(search).toBeVisible({ timeout: 20_000 })
+    await expect(createBtn).toBeVisible()
+
+    const searchBox = await search.boundingBox()
+    const createBox = await createBtn.boundingBox()
+    expect(searchBox).toBeTruthy()
+    expect(createBox).toBeTruthy()
+    const rowDelta = Math.abs((searchBox!.y + searchBox!.height / 2) - (createBox!.y + createBox!.height / 2))
+    expect(rowDelta).toBeLessThan(32)
+  })
+
+  test('quickstart key picker hides __tk_probe_* names when present', async ({ page }) => {
+    await login(page)
+    await page.goto('/quickstart')
+    const select = page.locator('[data-tk="quickstart-key-select"]')
+    await expect(select).toBeVisible({ timeout: 30_000 })
+
+    const options = await select.locator('option').allTextContents()
+    for (const label of options) {
+      expect(label).not.toMatch(/__tk_probe_/)
+    }
+  })
+})

--- a/frontend/e2e/pr1459-ui-acceptance.e2e.ts
+++ b/frontend/e2e/pr1459-ui-acceptance.e2e.ts
@@ -19,7 +19,7 @@ test.describe('PR #1459 UI acceptance', () => {
     await expect(page.locator('section.border-y')).toHaveCount(0)
   })
 
-  test('models browse: switcher shares toolbar row with search (authed)', async ({ page, baseURL }) => {
+  test('models browse: switcher shares toolbar row with search (authed)', async ({ page }) => {
     await login(page)
     await page.goto('/models')
     await expect(page.locator('[data-tk="catalog-hub-authed"]')).toBeVisible({ timeout: 20_000 })

--- a/frontend/src/utils/__tests__/catalogBrowseModelCardRoute.tk.spec.ts
+++ b/frontend/src/utils/__tests__/catalogBrowseModelCardRoute.tk.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { catalogBrowseModelCardRoute } from '../catalogBrowseModelCardRoute.tk'
+
+describe('catalogBrowseModelCardRoute.tk', () => {
+  it('routes authed users to quickstart with model only', () => {
+    expect(catalogBrowseModelCardRoute('gemini-2.5-flash', { isAuthenticated: true })).toEqual({
+      path: '/quickstart',
+      query: { model: 'gemini-2.5-flash' },
+    })
+  })
+
+  it('routes guests to pricing view with model preselected', () => {
+    expect(catalogBrowseModelCardRoute('gpt-4o-mini', { isAuthenticated: false })).toEqual({
+      path: '/models',
+      query: { view: 'pricing', model: 'gpt-4o-mini' },
+    })
+  })
+})

--- a/frontend/src/utils/__tests__/reservedProbeKey.tk.spec.ts
+++ b/frontend/src/utils/__tests__/reservedProbeKey.tk.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  filterUserSelectableApiKeys,
+  isReservedProbeApiKeyName,
+  isUserSelectableApiKey,
+} from '../reservedProbeKey.tk'
+
+describe('reservedProbeKey.tk', () => {
+  it('detects reserved probe key names', () => {
+    expect(isReservedProbeApiKeyName('__tk_probe_openai_key')).toBe(true)
+    expect(isReservedProbeApiKeyName('TK_FULLTEST_KEY')).toBe(false)
+    expect(isReservedProbeApiKeyName('')).toBe(false)
+  })
+
+  it('filters inactive and probe keys from user pickers', () => {
+    const keys = [
+      { name: '__tk_probe_newapi_srcgrp_16_key', status: 'active' as const },
+      { name: 'trial', status: 'active' as const },
+      { name: 'China', status: 'inactive' as const },
+    ]
+    expect(isUserSelectableApiKey(keys[0])).toBe(false)
+    expect(isUserSelectableApiKey(keys[1])).toBe(true)
+    expect(isUserSelectableApiKey(keys[2])).toBe(false)
+    expect(filterUserSelectableApiKeys(keys)).toEqual([keys[1]])
+  })
+})

--- a/frontend/src/utils/catalogBrowseModelCardRoute.tk.ts
+++ b/frontend/src/utils/catalogBrowseModelCardRoute.tk.ts
@@ -1,0 +1,10 @@
+/** Browse-tab model card: authed users integrate; guests inspect pricing first. */
+export function catalogBrowseModelCardRoute(
+  modelId: string,
+  options: { isAuthenticated: boolean },
+): { path: string; query: Record<string, string> } {
+  if (options.isAuthenticated) {
+    return { path: '/quickstart', query: { model: modelId } }
+  }
+  return { path: '/models', query: { view: 'pricing', model: modelId } }
+}

--- a/frontend/src/utils/reservedProbeKey.tk.ts
+++ b/frontend/src/utils/reservedProbeKey.tk.ts
@@ -1,0 +1,17 @@
+import type { ApiKey } from '@/types'
+
+/** Reserved ops/debug namespace — must not appear in user-facing key pickers. */
+export const RESERVED_PROBE_KEY_PREFIX = '__tk_probe_'
+
+export function isReservedProbeApiKeyName(name: string | null | undefined): boolean {
+  return !!name && name.startsWith(RESERVED_PROBE_KEY_PREFIX)
+}
+
+/** Keys eligible for Quickstart / Studio / pricing pickers (not ops probe fixtures). */
+export function isUserSelectableApiKey(key: Pick<ApiKey, 'name' | 'status'>): boolean {
+  return key.status === 'active' && !isReservedProbeApiKeyName(key.name)
+}
+
+export function filterUserSelectableApiKeys<T extends Pick<ApiKey, 'name' | 'status'>>(keys: T[]): T[] {
+  return keys.filter(isUserSelectableApiKey)
+}

--- a/frontend/src/views/CatalogHubView.vue
+++ b/frontend/src/views/CatalogHubView.vue
@@ -30,20 +30,13 @@
       </div>
     </template>
 
-    <div
-      v-if="isAuthenticated"
-      class="mb-4 flex shrink-0 flex-wrap items-center gap-3 border-b border-gray-200/80 pb-3 dark:border-dark-800"
-      data-tk="catalog-hub-authed-toolbar"
-    >
-      <CatalogViewSwitcher />
-    </div>
-
     <div class="catalog-hub-panel flex min-h-0 flex-1 flex-col">
       <KeepAlive>
         <ModelMarketplaceCatalog
           v-if="!isPricingView"
           key="browse"
           :show-bottom-cta="!isAuthenticated"
+          :show-view-switcher="isAuthenticated"
         />
         <PricingView v-else key="pricing" />
       </KeepAlive>

--- a/frontend/src/views/ModelMarketplaceCatalog.vue
+++ b/frontend/src/views/ModelMarketplaceCatalog.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="space-y-6">
-    <!-- Search + Filter Bar -->
-    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-      <!-- Search -->
-      <div class="relative flex-1 sm:max-w-sm">
+    <!-- View switcher + search + category filters on one row (authed console). -->
+    <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:gap-4">
+      <CatalogViewSwitcher v-if="showViewSwitcher" class="shrink-0" />
+
+      <div class="relative min-w-0 flex-1 lg:max-w-md">
         <svg
           class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
           fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
@@ -18,8 +19,7 @@
         />
       </div>
 
-      <!-- Category Filter Pills -->
-      <div class="flex flex-wrap gap-2">
+      <div class="flex shrink-0 flex-wrap gap-2 lg:ml-auto">
         <button
           v-for="filter in categoryFilters"
           :key="filter.key"
@@ -229,13 +229,16 @@ import {
   normalizeCatalogVendorSlug,
 } from '@/utils/catalogVendorIcon.tk'
 import ModelIcon from '@/components/common/ModelIcon.vue'
+import CatalogViewSwitcher from '@/components/catalog/CatalogViewSwitcher.vue'
 
 withDefaults(
   defineProps<{
     /** Guest landing keeps the signup CTA; authed console users already have quickstart in nav. */
     showBottomCta?: boolean
+    /** Logged-in /models hub: browse/pricing tabs share the search toolbar row. */
+    showViewSwitcher?: boolean
   }>(),
-  { showBottomCta: true },
+  { showBottomCta: true, showViewSwitcher: false },
 )
 
 const { t, te } = useI18n()

--- a/frontend/src/views/ModelMarketplaceCatalog.vue
+++ b/frontend/src/views/ModelMarketplaceCatalog.vue
@@ -128,7 +128,7 @@
             v-for="model in filteredModels"
             :key="model.model_id"
             :data-tk="`models-marketplace-card-${model.model_id}`"
-            :to="{ path: '/models', query: { view: 'pricing', model: model.model_id } }"
+            :to="catalogBrowseModelCardRoute(model.model_id, { isAuthenticated: isAuthenticated })"
             class="group rounded-xl border border-gray-200/60 bg-white p-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary-300 hover:shadow-lg hover:shadow-primary-500/10 dark:border-dark-700/60 dark:bg-dark-800 dark:hover:border-primary-700"
           >
             <!-- Model Name + Vendor -->
@@ -228,6 +228,7 @@ import {
   formatCatalogVendorLabel,
   normalizeCatalogVendorSlug,
 } from '@/utils/catalogVendorIcon.tk'
+import { catalogBrowseModelCardRoute } from '@/utils/catalogBrowseModelCardRoute.tk'
 import ModelIcon from '@/components/common/ModelIcon.vue'
 import CatalogViewSwitcher from '@/components/catalog/CatalogViewSwitcher.vue'
 

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -5,9 +5,10 @@
     data-tk="pricing-panel"
   >
     <div
-      class="mb-3 flex flex-wrap items-center justify-between gap-3 border-b border-gray-200/80 pb-3 dark:border-dark-800"
+      class="mb-3 flex flex-wrap items-center gap-3"
       :data-tk="isAuthenticated ? 'pricing-authed-toolbar' : 'pricing-page-header'"
     >
+      <CatalogViewSwitcher v-if="isAuthenticated" class="shrink-0" />
       <p
         v-if="!loading && !errorMessage && rowTotal > 0"
         class="min-w-0 flex-1 truncate text-[11px] tabular-nums text-gray-500 dark:text-dark-400 sm:text-xs"
@@ -67,7 +68,7 @@
                 >
                   <option :value="0">{{ t('pricing.filters.keyPlaceholder') }}</option>
                   <option
-                    v-for="k in myCatalog?.my_keys ?? []"
+                    v-for="k in selectableMyKeys"
                     :key="k.id"
                     :value="k.id"
                   >
@@ -526,6 +527,7 @@ import {
 } from '@/api/me-pricing'
 import Icon from '@/components/icons/Icon.vue'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
+import CatalogViewSwitcher from '@/components/catalog/CatalogViewSwitcher.vue'
 import { useAuthStore } from '@/stores/auth'
 import { useAppStore } from '@/stores/app'
 import { formatCurrency } from '@/utils/format'
@@ -539,7 +541,7 @@ import {
   type PricingCatalogModality
 } from '@/utils/pricingCatalogPresentation.tk'
 import { exportPricingCsv } from '@/composables/useTkPricingExport'
-
+import { filterUserSelectableApiKeys } from '@/utils/reservedProbeKey.tk'
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
@@ -646,6 +648,11 @@ const publicCatalog = ref<PublicCatalogResponse | null>(null)
 
 // My catalog state.
 const myCatalog = ref<MePricingCatalogResponse | null>(null)
+const selectableMyKeys = computed(() =>
+  filterUserSelectableApiKeys(
+    (myCatalog.value?.my_keys ?? []).map((k) => ({ ...k, status: 'active' as const })),
+  ),
+)
 const selectedKeyId = ref<number>(0)
 const selectedGroupId = ref<number>(0)
 
@@ -823,7 +830,7 @@ const hasFilterActive = hasClientFilterActive
 
 const emptyTitle = computed(() => {
   if (viewMode.value === 'my' && myCatalog.value) {
-    return myCatalog.value.my_keys.length === 0 && myCatalog.value.accessible_groups.length === 0
+    return selectableMyKeys.value.length === 0 && myCatalog.value.accessible_groups.length === 0
       ? t('pricing.my.empty.noAccess.title')
       : t('pricing.my.empty.noModels.title')
   }
@@ -832,7 +839,7 @@ const emptyTitle = computed(() => {
 
 const emptyHint = computed(() => {
   if (viewMode.value === 'my' && myCatalog.value) {
-    return myCatalog.value.my_keys.length === 0 && myCatalog.value.accessible_groups.length === 0
+    return selectableMyKeys.value.length === 0 && myCatalog.value.accessible_groups.length === 0
       ? t('pricing.my.empty.noAccess.hint')
       : t('pricing.my.empty.noModels.hint')
   }
@@ -888,7 +895,7 @@ const activeCatalogLabel = computed(() => {
   if (viewMode.value === 'public') return t('pricing.filters.activePublic')
   const group = myCatalog.value?.target_group?.name
   if (!group) return t('pricing.my.title')
-  const key = myCatalog.value?.my_keys.find((k) => k.id === displayKeyId.value)
+  const key = selectableMyKeys.value.find((k) => k.id === displayKeyId.value)
   return key
     ? t('pricing.filters.activeKeyGroup', { key: key.name, group })
     : t('pricing.filters.activeGroup', { group })
@@ -904,7 +911,7 @@ const exploreBanner = computed<ExploreBanner | null>(() => {
   if (viewMode.value !== 'my' || !myCatalog.value) return null
   const tg = myCatalog.value.target_group
   if (!tg?.id) return null
-  const currentKeysInTarget = myCatalog.value.my_keys.some((k) => k.group_id === tg.id)
+  const currentKeysInTarget = selectableMyKeys.value.some((k) => k.group_id === tg.id)
   if (currentKeysInTarget) return null
   // User is viewing a group they don't hold a key in → upgrade-CTA banner.
   return {
@@ -1011,10 +1018,10 @@ async function loadInitialCatalog(): Promise<void> {
 const displayKeyId = computed<number>(() => {
   if (viewMode.value === 'public' || selectedGroupId.value > 0) return 0
   if (selectedKeyId.value > 0) return selectedKeyId.value
-  if (!myCatalog.value || myCatalog.value.my_keys.length === 0) return 0
+  if (!myCatalog.value || selectableMyKeys.value.length === 0) return 0
   const tgID = myCatalog.value.target_group.id
-  const match = myCatalog.value.my_keys.find((k) => k.group_id === tgID)
-  return match?.id ?? myCatalog.value.my_keys[0].id
+  const match = selectableMyKeys.value.find((k) => k.group_id === tgID)
+  return match?.id ?? selectableMyKeys.value[0].id
 })
 
 function onPickKey(e: Event): void {

--- a/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
+++ b/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
@@ -84,7 +84,7 @@ function mountMarketplace() {
     global: {
       stubs: {
         AppLayout: { template: '<div data-test="app-layout"><slot /></div>' },
-        RouterLink: { props: ['to'], template: '<a><slot /></a>' },
+        RouterLink: { props: ['to'], template: '<a :data-to="JSON.stringify(to)"><slot /></a>' },
       },
     },
   })
@@ -279,5 +279,31 @@ describe('CatalogHubView', () => {
     expect(card.exists()).toBe(true)
     expect(card.find('svg.model-icon').exists()).toBe(true)
     expect(card.text()).toContain('OpenAI')
+  })
+
+  it('links browse cards to pricing for guests', async () => {
+    authState.isAuthenticated = false
+    getPublicPricing.mockResolvedValue(catalog([model('gpt-4o-mini', 'OpenAI')]))
+
+    const wrapper = mountMarketplace()
+    await flushPromises()
+
+    const card = wrapper.get('[data-tk="models-marketplace-card-gpt-4o-mini"]')
+    expect(card.attributes('data-to')).toBe(
+      JSON.stringify({ path: '/models', query: { view: 'pricing', model: 'gpt-4o-mini' } }),
+    )
+  })
+
+  it('links browse cards to quickstart for authenticated users', async () => {
+    authState.isAuthenticated = true
+    getPublicPricing.mockResolvedValue(catalog([model('gemini-2.5-flash', 'Google')]))
+
+    const wrapper = mountMarketplace()
+    await flushPromises()
+
+    const card = wrapper.get('[data-tk="models-marketplace-card-gemini-2.5-flash"]')
+    expect(card.attributes('data-to')).toBe(
+      JSON.stringify({ path: '/quickstart', query: { model: 'gemini-2.5-flash' } }),
+    )
   })
 })

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -344,7 +344,8 @@ describe('PricingView', () => {
 
     expect(wrapper.find('[data-test="app-layout"]').exists()).toBe(true)
     expect(wrapper.find('[data-tk="catalog-hub-authed"]').exists()).toBe(true)
-    expect(wrapper.find('[data-tk="catalog-hub-authed-toolbar"]').exists()).toBe(true)
+    expect(wrapper.find('[data-tk="catalog-hub-authed-toolbar"]').exists()).toBe(false)
+    expect(wrapper.find('[data-tk="catalog-view-switcher"]').exists()).toBe(true)
     expect(wrapper.find('[data-tk="pricing-authed-toolbar"]').exists()).toBe(true)
     expect(wrapper.find('[data-tk="pricing-page-header"]').exists()).toBe(false)
     expect(wrapper.find('h1').exists()).toBe(false)

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -3,80 +3,79 @@
     <TablePageLayout>
       <template #filters>
         <div class="flex flex-col gap-3">
-          <div class="flex flex-wrap items-center gap-3">
-            <SearchInput
-              v-model="filterSearch"
-              :placeholder="t('keys.searchPlaceholder')"
-              class="w-full sm:w-64"
-              @search="onFilterChange"
-            />
-            <Select
-              :model-value="filterGroupId"
-              class="w-40"
-              :options="groupFilterOptions"
-              @update:model-value="onGroupFilterChange"
-            />
-            <Select
-              :model-value="filterStatus"
-              class="w-40"
-              :options="statusFilterOptions"
-              @update:model-value="onStatusFilterChange"
-            />
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div class="flex flex-wrap items-center gap-3">
+              <SearchInput
+                v-model="filterSearch"
+                :placeholder="t('keys.searchPlaceholder')"
+                class="w-full sm:w-64"
+                @search="onFilterChange"
+              />
+              <Select
+                :model-value="filterGroupId"
+                class="w-40"
+                :options="groupFilterOptions"
+                @update:model-value="onGroupFilterChange"
+              />
+              <Select
+                :model-value="filterStatus"
+                class="w-40"
+                :options="statusFilterOptions"
+                @update:model-value="onStatusFilterChange"
+              />
+            </div>
+            <div class="flex shrink-0 gap-3">
+              <button
+                @click="loadApiKeys"
+                :disabled="loading"
+                class="btn btn-secondary"
+                :title="t('common.refresh')"
+              >
+                <Icon name="refresh" size="md" :class="loading ? 'animate-spin' : ''" />
+              </button>
+              <div class="relative" ref="columnDropdownRef">
+                <button
+                  @click="showColumnDropdown = !showColumnDropdown"
+                  class="btn btn-secondary px-2 md:px-3"
+                  :title="t('keys.columnSettings')"
+                >
+                  <svg class="h-4 w-4 md:mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125z" />
+                  </svg>
+                  <span class="hidden md:inline">{{ t('keys.columnSettings') }}</span>
+                </button>
+                <div
+                  v-if="showColumnDropdown"
+                  class="absolute right-0 top-full z-50 mt-1 max-h-80 w-48 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-dark-600 dark:bg-dark-800"
+                >
+                  <button
+                    v-for="col in toggleableColumns"
+                    :key="col.key"
+                    @click="toggleColumn(col.key)"
+                    class="flex w-full items-center justify-between px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-dark-700"
+                  >
+                    <span>{{ col.label }}</span>
+                    <Icon
+                      v-if="isColumnVisible(col.key)"
+                      name="check"
+                      size="sm"
+                      class="text-primary-500"
+                      :stroke-width="2"
+                    />
+                  </button>
+                </div>
+              </div>
+              <button @click="showCreateModal = true" class="btn btn-primary" data-tour="keys-create-btn">
+                <Icon name="plus" size="md" class="mr-2" />
+                {{ t('keys.createKey') }}
+              </button>
+            </div>
           </div>
           <EndpointPopover
             v-if="publicSettings?.api_base_url || (publicSettings?.custom_endpoints?.length ?? 0) > 0"
             :api-base-url="publicSettings?.api_base_url || ''"
             :custom-endpoints="publicSettings?.custom_endpoints || []"
           />
-        </div>
-      </template>
-
-      <template #actions>
-        <div class="flex justify-end gap-3">
-          <button
-            @click="loadApiKeys"
-            :disabled="loading"
-            class="btn btn-secondary"
-            :title="t('common.refresh')"
-          >
-            <Icon name="refresh" size="md" :class="loading ? 'animate-spin' : ''" />
-          </button>
-          <div class="relative" ref="columnDropdownRef">
-            <button
-              @click="showColumnDropdown = !showColumnDropdown"
-              class="btn btn-secondary px-2 md:px-3"
-              :title="t('keys.columnSettings')"
-            >
-              <svg class="h-4 w-4 md:mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125z" />
-              </svg>
-              <span class="hidden md:inline">{{ t('keys.columnSettings') }}</span>
-            </button>
-            <div
-              v-if="showColumnDropdown"
-              class="absolute right-0 top-full z-50 mt-1 max-h-80 w-48 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-dark-600 dark:bg-dark-800"
-            >
-              <button
-                v-for="col in toggleableColumns"
-                :key="col.key"
-                @click="toggleColumn(col.key)"
-                class="flex w-full items-center justify-between px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-dark-700"
-              >
-                <span>{{ col.label }}</span>
-                <Icon
-                  v-if="isColumnVisible(col.key)"
-                  name="check"
-                  size="sm"
-                  class="text-primary-500"
-                  :stroke-width="2"
-                />
-              </button>
-            </div>
-          </div>
-          <button @click="showCreateModal = true" class="btn btn-primary" data-tour="keys-create-btn">
-            <Icon name="plus" size="md" class="mr-2" />
-            {{ t('keys.createKey') }}
-          </button>
         </div>
       </template>
 

--- a/frontend/src/views/user/QuickstartView.vue
+++ b/frontend/src/views/user/QuickstartView.vue
@@ -1,7 +1,7 @@
 <template>
   <AppLayout>
-    <div class="mx-auto max-w-6xl space-y-6 py-4">
-      <section class="border-y border-gray-200 py-5 dark:border-dark-700">
+    <div class="mx-auto max-w-6xl space-y-6">
+      <section>
         <div v-if="keysLoading" class="flex items-center justify-center py-6">
           <LoadingSpinner />
         </div>
@@ -203,6 +203,7 @@ import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import * as keysAPI from '@/api/keys'
 import type { ApiKey } from '@/types'
+import { filterUserSelectableApiKeys } from '@/utils/reservedProbeKey.tk'
 import { isUniversalKey } from '@/utils/studioUniversalKey.tk'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
@@ -461,8 +462,8 @@ async function loadKeys() {
   keysLoading.value = true
   keysError.value = ''
   try {
-    const result = await keysAPI.list(1, 100)
-    keys.value = result.items ?? []
+    const result = await keysAPI.list(1, 100, { status: 'active' })
+    keys.value = filterUserSelectableApiKeys(result.items ?? [])
     if (!keys.value.length) {
       const created = await keysAPI.create(
         'Quick Start',

--- a/frontend/src/views/user/__tests__/QuickstartView.pageChrome.spec.ts
+++ b/frontend/src/views/user/__tests__/QuickstartView.pageChrome.spec.ts
@@ -117,4 +117,9 @@ describe('QuickstartView page chrome', () => {
     const wrapper = await mountView()
     expect(wrapper.find('h1').exists()).toBe(false)
   })
+
+  it('does not render a decorative top border on the key picker section', async () => {
+    const wrapper = await mountView()
+    expect(wrapper.find('section.border-y').exists()).toBe(false)
+  })
 })

--- a/frontend/src/views/user/__tests__/QuickstartView.spec.ts
+++ b/frontend/src/views/user/__tests__/QuickstartView.spec.ts
@@ -154,6 +154,24 @@ describe('QuickstartView', () => {
     expect((wrapper.get('select').element as HTMLSelectElement).value).toBe('42')
   })
 
+  it('hides reserved __tk_probe_* keys from the picker', async () => {
+    listKeys.mockResolvedValue({
+      items: [
+        { ...universalKey(), id: 7, name: '__tk_probe_openai_key' },
+        universalKey(),
+      ],
+      total: 2,
+      page: 1,
+      page_size: 100,
+      pages: 1,
+    })
+    const wrapper = await mountView()
+    const options = wrapper.get('select').findAll('option')
+    expect(options).toHaveLength(1)
+    expect(options[0].text()).toContain('Test')
+    expect(listKeys).toHaveBeenCalledWith(1, 100, { status: 'active' })
+  })
+
   it('syncs selected key to router query when user changes selection', async () => {
     listKeys.mockResolvedValue({
       items: [universalKey(), { ...universalKey(), id: 99, name: 'Other' }],

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -177,6 +177,7 @@ import {
 import { useAppStore } from '@/stores/app'
 import { useAuthStore } from '@/stores/auth'
 import type { ApiKey } from '@/types'
+import { filterUserSelectableApiKeys } from '@/utils/reservedProbeKey.tk'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -444,7 +445,7 @@ async function bootstrap(): Promise<void> {
   gatewayBase.value = resolveGatewayBaseUrl(appStore.apiBaseUrl || appStore.cachedPublicSettings?.api_base_url)
   try {
     const page = await keysAPI.list(1, 50, { status: 'active' })
-    keys.value = (page.items || []).filter((k) => !!k.key)
+    keys.value = filterUserSelectableApiKeys((page.items || []).filter((k) => !!k.key))
     const trial = keys.value.find((k) => k.name?.toLowerCase() === 'trial')
     const seed = (trial || keys.value[0])?.id ?? null
     if (seed == null) {


### PR DESCRIPTION
## 摘要

- 工具接入：去掉内容区顶部 `border-y` 空白分割线，页面更紧凑。
- 模型市场：登录态下「浏览 / 价格表」与搜索框、分类筛选合并为同一行；去掉多余 toolbar 分割线。
- 模型市场浏览卡片：已登录用户点击卡片 → `/quickstart?model=…`（由 quickstart 自动选 Key 与 client）；访客仍 → `/models?view=pricing&model=…`。
- API 密钥：搜索/筛选与刷新/列设置/创建按钮对齐到同一行。
- 工具接入 / Studio / 定价页 Key 选择器：统一过滤 `__tk_probe_*` 运维探测密钥。
- Playwright：`e2e/pr1459-ui-acceptance.e2e.ts` 覆盖上述布局与跳转行为。

## 风险

常规风险，纯前端布局与导航/ picker 过滤；API 密钥管理页仍完整展示所有密钥（含 probe），便于运维排查。

sentinel-registry-reviewed upstream-touch-trivial

## 验证

- `pnpm exec vitest run src/utils/__tests__/reservedProbeKey.tk.spec.ts src/utils/__tests__/catalogBrowseModelCardRoute.tk.spec.ts src/views/__tests__/ModelMarketplaceView.spec.ts src/views/user/__tests__/QuickstartView.spec.ts src/views/user/__tests__/QuickstartView.pageChrome.spec.ts src/views/__tests__/PricingView.spec.ts` — 全绿
- `E2E_BASE_URL=http://127.0.0.1:8080 pnpm exec playwright test e2e/pr1459-ui-acceptance.e2e.ts` — 5/5（本地 `go run -tags embed ./cmd/server`）
- `pnpm --dir frontend run build` — 通过
- `./scripts/preflight.sh` — PASS

## 提交

- dc95f381a fix(frontend): 收紧工具接入/模型市场布局并隐藏 probe 密钥
- 53355cd2b fix(frontend): 浏览模型卡片登录态跳转工具接入
- 542dae07b fix(frontend): 同步 embedded web dist 与当前 frontend 源码
- 36fd4c04c test(e2e): 补 PR1459 布局与 quickstart 跳转 Playwright 验收

最新提交：36fd4c04c