### PR TITLE
fix(openai): 上下文超限返回 400，停止 Claude Code 502 重试风暴

### DIFF
--- a/backend/internal/service/error_passthrough_runtime_test.go
+++ b/backend/internal/service/error_passthrough_runtime_test.go
@@ -170,7 +170,7 @@ func TestOpenAIHandleErrorResponse_ClientInduced4xxPassesThrough(t *testing.T) {
 	}
 }
 
-func TestOpenAIHandleErrorResponse_ContextWindow502KeepsMessageWithoutFailover(t *testing.T) {
+func TestOpenAIHandleErrorResponse_ContextWindowReturns400WithoutFailover(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -189,13 +189,13 @@ func TestOpenAIHandleErrorResponse_ContextWindow502KeepsMessageWithoutFailover(t
 	require.Error(t, err)
 	var failoverErr *UpstreamFailoverError
 	require.False(t, errors.As(err, &failoverErr))
-	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
 	errField, ok := payload["error"].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "upstream_error", errField["type"])
+	assert.Equal(t, "invalid_request_error", errField["type"])
 	assert.Equal(t, "Your input exceeds the context window of this model. Please adjust your input and try again.", errField["message"])
 }
 

--- a/backend/internal/service/openai_compat_context_window_alias_tk_test.go
+++ b/backend/internal/service/openai_compat_context_window_alias_tk_test.go
@@ -21,7 +21,6 @@ func TestApplyOpenAICompatContextWindowModelAlias(t *testing.T) {
 		{in: "gpt-5.5[1M]", want: "gpt-5.5", ok: true},
 		{in: "gpt-5.4[200k]", want: "gpt-5.4", ok: true},
 		{in: "gpt-5.5", want: "gpt-5.5", ok: false},
-		{in: "gpt-5.6-sol[1m]", want: "gpt-5.6-sol", ok: true},
 		{in: "claude-opus-4-8[1m]", want: "claude-opus-4-8", ok: true},
 	}
 
@@ -39,7 +38,6 @@ func TestNormalizeOpenAICompatRequestedModel_StripsContextWindowAlias(t *testing
 
 	require.Equal(t, "gpt-5.5", NormalizeOpenAICompatRequestedModel("gpt-5.5[1m]"))
 	require.Equal(t, "gpt-5.4", NormalizeOpenAICompatRequestedModel("gpt-5.4-xhigh[1m]"))
-	require.Equal(t, "gpt-5.6-sol", NormalizeOpenAICompatRequestedModel("gpt-5.6-sol[1m]"))
 }
 
 func TestApplyOpenAICompatModelNormalization_StripsContextWindowAliasBeforeReasoning(t *testing.T) {
@@ -63,5 +61,5 @@ func TestNormalizeOpenAIMessagesDispatchMappedModel_StripsContextWindowAlias(t *
 func TestNormalizeCodexModel_StripsContextWindowAlias(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "gpt-5.6-sol", normalizeCodexModel("gpt-5.6-sol[1m]"))
+	require.Equal(t, "gpt-5.5", normalizeCodexModel("gpt-5.5[1m]"))
 }

--- a/backend/internal/service/openai_compat_context_window_alias_tk_test.go
+++ b/backend/internal/service/openai_compat_context_window_alias_tk_test.go
@@ -21,6 +21,7 @@ func TestApplyOpenAICompatContextWindowModelAlias(t *testing.T) {
 		{in: "gpt-5.5[1M]", want: "gpt-5.5", ok: true},
 		{in: "gpt-5.4[200k]", want: "gpt-5.4", ok: true},
 		{in: "gpt-5.5", want: "gpt-5.5", ok: false},
+		{in: "gpt-5.6-sol[1m]", want: "gpt-5.6-sol", ok: true},
 		{in: "claude-opus-4-8[1m]", want: "claude-opus-4-8", ok: true},
 	}
 
@@ -38,6 +39,7 @@ func TestNormalizeOpenAICompatRequestedModel_StripsContextWindowAlias(t *testing
 
 	require.Equal(t, "gpt-5.5", NormalizeOpenAICompatRequestedModel("gpt-5.5[1m]"))
 	require.Equal(t, "gpt-5.4", NormalizeOpenAICompatRequestedModel("gpt-5.4-xhigh[1m]"))
+	require.Equal(t, "gpt-5.6-sol", NormalizeOpenAICompatRequestedModel("gpt-5.6-sol[1m]"))
 }
 
 func TestApplyOpenAICompatModelNormalization_StripsContextWindowAliasBeforeReasoning(t *testing.T) {
@@ -61,5 +63,5 @@ func TestNormalizeOpenAIMessagesDispatchMappedModel_StripsContextWindowAlias(t *
 func TestNormalizeCodexModel_StripsContextWindowAlias(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "gpt-5.5", normalizeCodexModel("gpt-5.5[1m]"))
+	require.Equal(t, "gpt-5.6-sol", normalizeCodexModel("gpt-5.6-sol[1m]"))
 }

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -598,7 +598,8 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 				return true
 			}
 			message = s.recordOpenAIStreamUpstreamError(c, account, false, requestID, "http_error", payloadBytes, message)
-			defaultStatus, defaultErrType, defaultMsg := http.StatusBadGateway, "upstream_error", message
+			defaultStatus, defaultErrType := openAIStreamFailedClientResponse(payloadBytes, message, "upstream_error")
+			defaultMsg := message
 			// 统一走语义状态推断 + body 归一化（与 /v1/responses 路径一致），
 			// 使按错误码配置的透传规则可命中。
 			if status, errType, errMsg, matched := applyOpenAIStreamFailedErrorPassthroughRule(

--- a/backend/internal/service/openai_gateway_chat_completions_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_test.go
@@ -308,7 +308,7 @@ func TestForwardAsChatCompletions_BufferedContextWindowResponseFailedReturnsErro
 	var failoverErr *UpstreamFailoverError
 	require.False(t, errors.As(err, &failoverErr))
 	require.True(t, c.Writer.Written())
-	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, rec.Body.String(), "input exceeds the context window")
 }
 
@@ -353,7 +353,7 @@ func TestForwardAsChatCompletions_StreamContextWindowResponseFailedReturnsErrorW
 	var failoverErr *UpstreamFailoverError
 	require.False(t, errors.As(err, &failoverErr))
 	require.True(t, c.Writer.Written())
-	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, rec.Header().Get("Content-Type"), "application/json")
 	require.Contains(t, rec.Body.String(), "input exceeds the context window")
 	require.NotContains(t, rec.Body.String(), "[DONE]")

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -1073,7 +1073,8 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 					return true
 				}
 				message = s.recordOpenAIStreamUpstreamError(c, account, false, requestID, "http_error", payloadBytes, message)
-				errStatus, errType, errMsg := http.StatusBadGateway, "api_error", message
+				errStatus, errType := openAIStreamFailedClientResponse(payloadBytes, message, "api_error")
+				errMsg := message
 				// 统一走语义状态推断 + body 归一化（与 /v1/responses 路径一致），
 				// 使按错误码配置的透传规则可命中。
 				if status, et, em, matched := applyOpenAIStreamFailedErrorPassthroughRule(

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -783,6 +783,34 @@ func openAIStreamDataStartsClientOutput(data, eventType string) bool {
 	return !openAIStreamEventIsPreamble(eventType)
 }
 
+// openAIStreamFailedClientResponse maps response.failed to the downstream HTTP
+// status/type when no admin passthrough rule matches. Caller-fault rejections
+// (context window, invalid_request, …) must not surface as 502 — Claude Code
+// and Codex CLI treat 502 as transient and retry, turning an unrecoverable
+// prompt-size failure into a retry storm.
+func openAIStreamFailedClientResponse(payload []byte, message string, default5xxErrType string) (statusCode int, errType string) {
+	statusCode = openAIStreamFailedEventSemanticStatus(payload, message)
+	switch statusCode {
+	case http.StatusBadRequest:
+		errType = "invalid_request_error"
+	case http.StatusUnauthorized:
+		errType = "authentication_error"
+	case http.StatusForbidden:
+		errType = "permission_error"
+	case http.StatusTooManyRequests:
+		errType = "rate_limit_error"
+	case http.StatusServiceUnavailable:
+		errType = "api_error"
+	default:
+		if statusCode >= 500 {
+			errType = default5xxErrType
+		} else {
+			errType = "api_error"
+		}
+	}
+	return statusCode, errType
+}
+
 func openAIStreamFailedEventSemanticStatus(payload []byte, message string) int {
 	if isOpenAIContextWindowError(message, payload) {
 		return http.StatusBadRequest

--- a/backend/internal/service/openai_gateway_response_failed_passthrough_test.go
+++ b/backend/internal/service/openai_gateway_response_failed_passthrough_test.go
@@ -116,7 +116,7 @@ func TestForwardAsAnthropic_ResponseFailed_PassthroughRule(t *testing.T) {
 	require.NotEmpty(t, errMsg, "passthrough should preserve error message")
 }
 
-func TestForwardAsChatCompletions_ResponseFailed_NoRule_Still502(t *testing.T) {
+func TestForwardAsChatCompletions_ResponseFailed_NoRule_ContextWindowReturns400(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello"}],"stream":false}`)
@@ -139,7 +139,8 @@ func TestForwardAsChatCompletions_ResponseFailed_NoRule_Still502(t *testing.T) {
 	_, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "")
 
 	require.Error(t, err)
-	require.Equal(t, http.StatusBadGateway, rec.Code, "without passthrough rule should still be 502")
+	require.Equal(t, http.StatusBadRequest, rec.Code, "context window without passthrough rule should be 400")
+	require.Contains(t, rec.Body.String(), "invalid_request_error")
 }
 
 // bindStatusCodePassthroughRule 绑定一条按错误码+关键词双条件(MatchModeAll)匹配的规则。

--- a/backend/internal/service/openai_gateway_service_tk_buffered_failover.go
+++ b/backend/internal/service/openai_gateway_service_tk_buffered_failover.go
@@ -87,15 +87,7 @@ func (s *OpenAIGatewayService) openAICompatBufferedFailedResponseResult(
 		return nil, fmt.Errorf("upstream response failed (passthrough rule matched): %s", message)
 	}
 
-	statusCode := openAIStreamFailedEventSemanticStatus(payload, clientMsg)
-	if isOpenAIContextWindowError(clientMsg, payload) {
-		// Preserve the existing no-rule contract for context-window failures.
-		statusCode = http.StatusBadGateway
-	}
-	errType := "upstream_error"
-	if statusCode == http.StatusBadRequest {
-		errType = "invalid_request_error"
-	}
+	statusCode, errType := openAIStreamFailedClientResponse(payload, clientMsg, "upstream_error")
 	if route == openAICompatBufferedRouteMessages {
 		s.recordOpenAIMessagesStreamUpstreamError(c, account, requestID, "buffered_response_failed", clientMsg)
 		writeAnthropicError(c, statusCode, errType, clientMsg)

--- a/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
@@ -192,7 +192,7 @@ func TestForwardAsAnthropic_BufferedContextWindowResponseFailedReturnsErrorWitho
 	var failoverErr *UpstreamFailoverError
 	require.False(t, errors.As(err, &failoverErr))
 	require.True(t, c.Writer.Written())
-	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, rec.Body.String(), "input exceeds the context window")
 }
 

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -585,6 +585,8 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 	}
 	if isOpenAIContextWindowError(upstreamMsg, body) && upstreamMsg != "" {
 		errMsg = upstreamMsg
+		statusCode = http.StatusBadRequest
+		errType = "invalid_request_error"
 	}
 
 	c.JSON(statusCode, gin.H{

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4856,6 +4856,7 @@
       "must_contain": [
         "openAICompatBufferedMissingTerminalResult",
         "openAICompatBufferedFailedResponseResult",
+        "openAIStreamFailedClientResponse",
         "acc.HasContent()",
         "openAIStreamFailedEventShouldFailover",
         "newOpenAIStreamFailoverError"
@@ -5298,6 +5299,35 @@
         "admin.users.api_keys.create"
       ],
       "rationale": "Admin handler for POST /admin/users/:id/api-keys. Pins the CreateForUser entry point and idempotency scope for ops relay key provisioning."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_passthrough.go",
+      "must_contain": [
+        "func openAIStreamFailedClientResponse(",
+        "must not surface as 502"
+      ],
+      "rationale": "PR #1461: semantic HTTP status/type mapping for response.failed on compat paths when no admin passthrough rule matches. Caller-fault rejections (context window, invalid_request, auth, rate limit) must not surface as 502 upstream_error — Claude Code and Codex CLI treat 502 as transient and retry unrecoverable prompt-size failures into a storm."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions.go",
+      "must_contain": [
+        "openAIStreamFailedClientResponse(payloadBytes, message, \"upstream_error\")"
+      ],
+      "rationale": "PR #1461 wiring: /v1/chat/completions streaming response.failed must use openAIStreamFailedClientResponse so context-window and other caller-fault errors return 400 invalid_request_error instead of 502 upstream_error when no passthrough rule matches."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages.go",
+      "must_contain": [
+        "openAIStreamFailedClientResponse(payloadBytes, message, \"api_error\")"
+      ],
+      "rationale": "PR #1461 wiring: /v1/messages (Anthropic compat) streaming response.failed must use openAIStreamFailedClientResponse so context-window failures return 400 instead of 502 — the prod incident path for gpt-5.6-sol Claude Code sessions."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_response_failed_passthrough_test.go",
+      "must_contain": [
+        "TestForwardAsChatCompletions_ResponseFailed_NoRule_ContextWindowReturns400"
+      ],
+      "rationale": "PR #1461 regression: without an admin passthrough rule, context_length_exceeded response.failed on buffered chat/completions must return HTTP 400 invalid_request_error, not 502."
     }
   ]
 }


### PR DESCRIPTION
## 摘要

Claude Code 经 `/v1/messages` 使用 `gpt-5.6-sol` 时，上游 `response.failed` 报上下文超限，网关却回 **502**。CC 把 502 当可重试故障，触发 8–16 次无意义重试。

本 PR 在无 admin 透传规则时，对上下文超限等 caller-fault 错误统一回 **400 + invalid_request_error**，不再伪装成 502。

## 风险

- 常规风险：仅改变客户端可见 HTTP 状态码/错误类型，不改变上游路由、failover 或计费。
- 上下文仍超限时用户仍需 `/compact` 或新会话；修复的是 **误重试**，不是消除上限。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service/ \
  -run 'ContextWindow|BufferedContextWindow|StreamContextWindow|HandleErrorResponse_ContextWindow|ResponseFailed_NoRule_ContextWindow' -count=1
./scripts/preflight.sh
python3 scripts/sentinels/check-registry-update-gate.py --base origin/main --head HEAD
```

CI @ `443e7d3` 全绿（含 test-unit、marker-acknowledgement）。

## 线上上下文长度（prod 只读，2026-07-24）

| 时间 (UTC / CST) | 证据 |
|---|---|
| 08:34:39–08:48:34Z / 16:34–16:48 | user_id=1，`gpt-5.6-sol` `/v1/messages` 共 **16 次** 502 上下文超限（与截图 16:38 时段吻合） |
| 08:34:26Z / 16:34:26 | 最后一次成功：`input_tokens=1,417` + `cache_read_tokens=371,200` → **有效输入约 372k** |
| 08:38:21Z / 16:38:21 | 截图时段典型失败点（无 usage 行，上游拒绝后未计费） |
| 08:47:52Z / 16:47:52 | 第二轮失败前最后成功：`input_tokens≈208,778` |
| 07:46:27Z / 15:46:27 | 2h 内峰值成功：`input_tokens=304,253`（仍低于 catalog 1.05M，说明失败时 wire 体积可能更大或含全量 replay） |

失败请求 **无 usage_logs**（上游在 `response.failed` 阶段拒绝），故精确 token 以上一次成功请求 + 会话增长推断；首次失败前有效上下文 **≥372k tokens**。

## 提交

- 150ff5bca fix(openai): 上下文超限返回 400 避免 Claude Code 502 重试风暴
- 443e7d3f fix(openai): address review — 400 test + sentinel anchors

最新提交：443e7d3