### PR TITLE
feat(frontend): 用户控制台持久 UserShell 修复侧栏滚动回顶

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 643,
-  "hash": "1f444b5f527dd75a0813f4ec06f20c795274a28c003c339fc7a818772d7e100c",
+  "file_count": 645,
+  "hash": "d2750b48401cc76059e9a1c4e1c64914048e0c5c2f58179942480c8a72f7369d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 645,
-  "hash": "d2750b48401cc76059e9a1c4e1c64914048e0c5c2f58179942480c8a72f7369d",
+  "hash": "2eb450e619fc9d691b314e5e3b01083e4a0da8c248b17389f0406f4460b3560c",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/e2e/sidebar-scroll-local.e2e.ts
+++ b/frontend/e2e/sidebar-scroll-local.e2e.ts
@@ -1,0 +1,102 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test'
+
+const BASE = process.env.E2E_BASE_URL || 'http://127.0.0.1:8089'
+const LOGIN_EMAIL = process.env.E2E_LOGIN_EMAIL || 'admin@sub2api.local'
+const LOGIN_PASSWORD = process.env.E2E_LOGIN_PASSWORD || 'Admin12345!'
+
+async function loginSession(request: APIRequestContext) {
+  const loginResp = await request.post(`${BASE}/api/v1/auth/login`, {
+    data: { email: LOGIN_EMAIL, password: LOGIN_PASSWORD },
+  })
+  expect(loginResp.ok(), `login failed: ${loginResp.status()}`).toBeTruthy()
+  const loginBody = await loginResp.json()
+  expect(loginBody.code, `login API error: ${loginBody.message}`).toBe(0)
+
+  const token = loginBody.data.access_token as string
+  const meResp = await request.get(`${BASE}/api/v1/auth/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  expect(meResp.ok(), `auth/me failed: ${meResp.status()}`).toBeTruthy()
+  const meBody = await meResp.json()
+  expect(meBody.code).toBe(0)
+
+  return { token, user: meBody.data as Record<string, unknown> }
+}
+
+async function seedAuth(page: Page, token: string, user: Record<string, unknown>) {
+  await page.setViewportSize({ width: 1280, height: 520 })
+  const userWithTour = {
+    ...user,
+    onboarding_tour_seen_at:
+      (user.onboarding_tour_seen_at as string | undefined) || new Date().toISOString(),
+  }
+  await page.addInitScript(
+    ({ token, user }) => {
+      localStorage.setItem('auth_token', token)
+      localStorage.setItem('auth_user', JSON.stringify(user))
+      const uid = typeof user.id === 'number' ? user.id : 0
+      const role = typeof user.role === 'string' ? user.role : 'user'
+      if (uid > 0) {
+        const guideKey =
+          role === 'admin'
+            ? `admin_guide_${uid}_admin_v4_interactive`
+            : `user_guide_${uid}_user_v4_interactive`
+        localStorage.setItem(guideKey, 'true')
+      }
+    },
+    { token, user: userWithTour },
+  )
+}
+
+async function dismissOnboardingOverlay(page: Page): Promise<void> {
+  const overlay = page.locator('.driver-overlay')
+  if ((await overlay.count()) === 0) return
+  await page.keyboard.press('Escape')
+  await overlay.waitFor({ state: 'hidden', timeout: 10_000 }).catch(async () => {
+    await page.evaluate(() => {
+      document.querySelector('.driver-overlay')?.remove()
+      document.querySelector('.driver-popover')?.remove()
+    })
+  })
+}
+
+async function sidebarScrollTop(page: Page): Promise<number> {
+  return page.locator('nav.sidebar-nav').evaluate((el) => el.scrollTop)
+}
+
+async function scrollSidebarDown(page: Page): Promise<number> {
+  const max = await page.locator('nav.sidebar-nav').evaluate((el) => Math.max(0, el.scrollHeight - el.clientHeight))
+  expect(max, 'sidebar must be tall enough to scroll in this viewport').toBeGreaterThan(120)
+  const delta = Math.min(max, 280)
+  await page.locator('nav.sidebar-nav').evaluate((el, d) => {
+    el.scrollTop = d
+  }, delta)
+  await page.waitForTimeout(150)
+  return sidebarScrollTop(page)
+}
+
+async function clickSidebarLink(page: Page, href: string): Promise<void> {
+  await dismissOnboardingOverlay(page)
+  const link = page.locator(`nav.sidebar-nav a.sidebar-link[href="${href}"]`).first()
+  await expect(link).toBeVisible()
+  await link.click()
+  await page.waitForURL((u) => u.pathname === href || u.pathname.startsWith(`${href}/`), { timeout: 20_000 })
+  await page.waitForTimeout(300)
+}
+
+test.describe('sidebar scroll preservation (local deploy)', () => {
+  test('keeps sidebar scroll across console routes against real backend', async ({ page, request }) => {
+    const { token, user } = await loginSession(request)
+    await seedAuth(page, token, user)
+
+    await page.goto('/profile')
+    await page.locator('nav.sidebar-nav').waitFor({ timeout: 30_000 })
+    await dismissOnboardingOverlay(page)
+    expect(await scrollSidebarDown(page)).toBeGreaterThan(100)
+
+    for (const href of ['/usage', '/monitor', '/models', '/keys', '/studio', '/quickstart']) {
+      await clickSidebarLink(page, href)
+      expect(await sidebarScrollTop(page), `${href} must not jump back to top`).toBeGreaterThan(50)
+    }
+  })
+})

--- a/frontend/e2e/sidebar-scroll.e2e.ts
+++ b/frontend/e2e/sidebar-scroll.e2e.ts
@@ -1,0 +1,108 @@
+import { expect, test, type Page, type Route } from '@playwright/test'
+
+const USER = {
+  id: 42,
+  username: 'sidebar-e2e',
+  email: 'sidebar-e2e@tokenkey.local',
+  role: 'user',
+  balance: 10,
+  concurrency: 5,
+  status: 'active',
+  allowed_groups: null,
+  balance_notify_enabled: false,
+  balance_notify_threshold: null,
+  balance_notify_extra_emails: [],
+  created_at: '2026-07-16T00:00:00Z',
+  updated_at: '2026-07-16T00:00:00Z',
+  onboarding_tour_seen_at: '2026-07-16T00:00:00Z',
+}
+
+function success(data: unknown): string {
+  return JSON.stringify({ code: 0, message: 'success', data })
+}
+
+async function fulfillJSON(route: Route, data: unknown): Promise<void> {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: success(data),
+  })
+}
+
+async function prepareAuthedUser(page: Page): Promise<void> {
+  await page.setViewportSize({ width: 1280, height: 520 })
+  await page.addInitScript((user) => {
+    localStorage.setItem('auth_token', 'e2e-sidebar-token')
+    localStorage.setItem('auth_user', JSON.stringify(user))
+    localStorage.setItem('user_guide_42_user_v4_interactive', 'true')
+  }, USER)
+
+  await page.route('**/setup/status', (route) => fulfillJSON(route, { needs_setup: false, step: '' }))
+  await page.route('**/api/v1/auth/me', (route) => fulfillJSON(route, USER))
+  await page.route('**/api/v1/settings/public', (route) =>
+    fulfillJSON(route, {
+      site_name: 'TokenKey',
+      backend_mode_enabled: false,
+      custom_menu_items: [],
+      channel_monitor_enabled: true,
+      payment_enabled: true,
+      available_channels_enabled: true,
+      affiliate_enabled: true,
+    }),
+  )
+  await page.route('**/api/v1/subscriptions/active', (route) => fulfillJSON(route, []))
+  await page.route('**/api/v1/announcements*', (route) => fulfillJSON(route, []))
+  await page.route('**/api/v1/keys*', (route) =>
+    fulfillJSON(route, { items: [], total: 0, page: 1, page_size: 100, pages: 0 }),
+  )
+  await page.route('**/api/v1/user/group-rates*', (route) => fulfillJSON(route, []))
+  await page.route('**/api/v1/user/groups*', (route) => fulfillJSON(route, []))
+  await page.route('**/api/v1/usage*', (route) =>
+    fulfillJSON(route, { items: [], total: 0, page: 1, page_size: 20, pages: 0 }),
+  )
+  await page.route('**/api/v1/monitor*', (route) => fulfillJSON(route, { items: [], total: 0 }))
+  await page.route('**/api/v1/models*', (route) => fulfillJSON(route, { items: [], total: 0 }))
+  await page.route('**/api/v1/pricing*', (route) => fulfillJSON(route, { items: [], total: 0 }))
+  await page.route('**/api/v1/studio*', (route) => fulfillJSON(route, { items: [], total: 0 }))
+  await page.route('**/api/v1/quickstart*', (route) => fulfillJSON(route, { keys: [], groups: [] }))
+}
+
+async function sidebarScrollTop(page: Page): Promise<number> {
+  return page.locator('nav.sidebar-nav').evaluate((el) => el.scrollTop)
+}
+
+async function scrollSidebarDown(page: Page): Promise<number> {
+  const max = await page.locator('nav.sidebar-nav').evaluate((el) => Math.max(0, el.scrollHeight - el.clientHeight))
+  expect(max, 'sidebar must be tall enough to scroll in this viewport').toBeGreaterThan(120)
+  const delta = Math.min(max, 280)
+  await page.locator('nav.sidebar-nav').evaluate((el, d) => {
+    el.scrollTop = d
+  }, delta)
+  await page.waitForTimeout(150)
+  return sidebarScrollTop(page)
+}
+
+async function clickSidebarLink(page: Page, href: string): Promise<void> {
+  const link = page.locator(`nav.sidebar-nav a.sidebar-link[href="${href}"]`).first()
+  await expect(link).toBeVisible()
+  await link.click()
+  await page.waitForURL((u) => u.pathname === href || u.pathname.startsWith(`${href}/`), { timeout: 20_000 })
+  await page.waitForTimeout(300)
+}
+
+test.describe('sidebar scroll preservation (UserShellView)', () => {
+  test.beforeEach(async ({ page }) => {
+    await prepareAuthedUser(page)
+  })
+
+  test('does not reset sidebar scroll to top across console routes', async ({ page }) => {
+    await page.goto('/profile')
+    await page.locator('nav.sidebar-nav').waitFor()
+    expect(await scrollSidebarDown(page)).toBeGreaterThan(100)
+
+    for (const href of ['/usage', '/monitor', '/models', '/keys', '/studio', '/quickstart']) {
+      await clickSidebarLink(page, href)
+      expect(await sidebarScrollTop(page), `${href} must not jump back to top`).toBeGreaterThan(50)
+    }
+  })
+})

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,21 +11,6 @@ import { useAppStore, useAuthStore, useSubscriptionStore, useAnnouncementStore, 
 import { getSetupStatus } from '@/api/setup'
 import { isNetworkError } from '@/api/client.tk'
 
-/**
- * User-side views to keep alive across navigations.
- * Names must match the defineOptions({ name }) in each view component.
- * Admin views are cached separately inside AdminShellView.
- * Payment result/callback pages are intentionally excluded — they must
- * always fetch fresh state.
- */
-const cachedUserViews = [
-  'UserDashboardView',
-  'UserUsageView',
-  'UserKeysView',
-  'UserProfileView',
-  'UserStudioView',
-  'KeyUsageView',
-]
 import { updateFavicon } from '@/utils/branding'
 
 const router = useRouter()
@@ -156,11 +141,7 @@ onMounted(async () => {
 
 <template>
   <NavigationProgress />
-  <RouterView v-slot="{ Component }">
-    <KeepAlive :include="cachedUserViews">
-      <component :is="Component" />
-    </KeepAlive>
-  </RouterView>
+  <RouterView />
   <Toast />
   <AnnouncementPopup />
   <AdminComplianceDialog />

--- a/frontend/src/components/catalog/CatalogHubShell.vue
+++ b/frontend/src/components/catalog/CatalogHubShell.vue
@@ -1,11 +1,6 @@
 <template>
-  <AppLayout v-if="isAuthenticated">
-    <div :class="contentClass" :data-tk="authedDataTk">
-      <slot />
-    </div>
-  </AppLayout>
   <div
-    v-else
+    v-if="!isAuthenticated"
     class="relative flex min-h-screen flex-col bg-gradient-to-br from-gray-50 via-primary-50/30 to-gray-100 dark:from-dark-950 dark:via-dark-900 dark:to-dark-950"
     :class="guestRootClass"
   >
@@ -16,12 +11,14 @@
       </div>
     </main>
   </div>
+  <div v-else :class="contentClass" :data-tk="authedDataTk">
+    <slot />
+  </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useAuthStore } from '@/stores/auth'
-import AppLayout from '@/components/layout/AppLayout.vue'
 
 withDefaults(
   defineProps<{

--- a/frontend/src/components/catalog/__tests__/catalogHub.spec.ts
+++ b/frontend/src/components/catalog/__tests__/catalogHub.spec.ts
@@ -78,14 +78,15 @@ describe('CatalogHubShell', () => {
     authState.isAuthenticated = false
   })
 
-  it('uses AppLayout when authenticated', () => {
+  it('renders authenticated content without AppLayout (UserShellView owns chrome)', () => {
     authState.isAuthenticated = true
     const wrapper = mount(CatalogHubShell, {
       props: { authedDataTk: 'catalog-authed' },
       slots: { default: '<p data-test="body">content</p>' },
     })
-    expect(wrapper.find('[data-test="app-layout"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="app-layout"]').exists()).toBe(false)
     expect(wrapper.find('[data-tk="catalog-authed"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="body"]').exists()).toBe(true)
   })
 
   it('renders guest chrome slot when logged out', () => {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -15,6 +15,7 @@ import { resolveCompletedSetupRedirectPath } from './setupRedirect'
 import { resolveRouteDocumentTitle } from './title'
 import { scrollBehavior } from './scrollBehavior'
 import { adminRoutes } from './admin.tk'
+import { userRoutes } from './user.tk'
 
 /**
  * Route definitions with lazy loading
@@ -169,17 +170,6 @@ const routes: RouteRecordRaw[] = [
     }
   },
   {
-    path: '/models',
-    name: 'ModelMarketplace',
-    component: () => import('@/views/CatalogHubView.vue'),
-    meta: {
-      requiresAuth: false,
-      title: 'Model Marketplace',
-      titleKey: 'models.title',
-      descriptionKey: 'models.subtitle'
-    }
-  },
-  {
     path: '/pricing',
     name: 'Pricing',
     redirect: (to) => ({
@@ -198,187 +188,9 @@ const routes: RouteRecordRaw[] = [
     }
   },
 
-  // ==================== User Routes ====================
-  {
-    path: '/',
-    redirect: '/home'
-  },
-  {
-    path: '/dashboard',
-    name: 'Dashboard',
-    component: () => import('@/views/user/DashboardView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Dashboard',
-      titleKey: 'dashboard.title',
-      descriptionKey: 'dashboard.welcomeMessage'
-    }
-  },
-  {
-    // TK: /playground was merged into the Studio as its Chat modality. Keep the
-    // path as a redirect so old deep-links / bookmarks land on the chat tab.
-    path: '/playground',
-    redirect: { path: '/studio', query: { mode: 'chat' } }
-  },
-  {
-    path: '/studio',
-    name: 'Studio',
-    component: () => import('@/views/user/studio/MediaStudioView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Studio',
-      titleKey: 'studio.title',
-      descriptionKey: 'studio.subtitle'
-    }
-  },
-  {
-    path: '/quickstart',
-    name: 'Quickstart',
-    component: () => import('@/views/user/QuickstartView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Tool Integrations',
-      titleKey: 'quickstart.title',
-      descriptionKey: 'quickstart.subtitle'
-    }
-  },
-  {
-    path: '/keys',
-    name: 'Keys',
-    component: () => import('@/views/user/KeysView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'API Keys',
-      titleKey: 'keys.title',
-      descriptionKey: 'keys.description'
-    }
-  },
-  {
-    path: '/batch-image',
-    name: 'BatchImageGuide',
-    alias: '/docs/batch-image',
-    component: () => import('@/views/user/BatchImageGuideView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Batch Image Guide',
-      titleKey: 'batchImageGuide.title',
-      descriptionKey: 'batchImageGuide.description'
-    }
-  },
-  {
-    path: '/usage',
-    name: 'Usage',
-    component: () => import('@/views/user/UsageView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Usage Records',
-      titleKey: 'usage.title',
-      descriptionKey: 'usage.description'
-    }
-  },
-  {
-    path: '/redeem',
-    name: 'Redeem',
-    component: () => import('@/views/user/RedeemView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Redeem Code',
-      titleKey: 'redeem.title',
-      descriptionKey: 'redeem.description'
-    }
-  },
-  {
-    path: '/affiliate',
-    name: 'Affiliate',
-    component: () => import('@/views/user/AffiliateView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Affiliate',
-      titleKey: 'affiliate.title',
-      descriptionKey: 'affiliate.description'
-    }
-  },
-  {
-    path: '/available-channels',
-    name: 'UserAvailableChannels',
-    component: () => import('@/views/user/AvailableChannelsView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Available Channels',
-      titleKey: 'availableChannels.title',
-      descriptionKey: 'availableChannels.description'
-    }
-  },
-  {
-    path: '/profile',
-    name: 'Profile',
-    component: () => import('@/views/user/ProfileView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Profile',
-      titleKey: 'profile.title',
-      descriptionKey: 'profile.description'
-    }
-  },
-  {
-    path: '/subscriptions',
-    name: 'Subscriptions',
-    component: () => import('@/views/user/SubscriptionsView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'My Subscriptions',
-      titleKey: 'userSubscriptions.title',
-      descriptionKey: 'userSubscriptions.description'
-    }
-  },
-  {
-    path: '/purchase',
-    name: 'PurchaseSubscription',
-    component: () => import('@/views/user/PaymentView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Purchase Subscription',
-      titleKey: 'nav.buySubscription',
-      descriptionKey: 'purchase.description',
-      requiresPayment: true
-    }
-  },
-  {
-    path: '/orders',
-    name: 'OrderList',
-    component: () => import('@/views/user/UserOrdersView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'My Orders',
-      titleKey: 'nav.myOrders',
-      requiresPayment: true
-    }
-  },
-  {
-    path: '/payment/qrcode',
-    name: 'PaymentQRCode',
-    component: () => import('@/views/user/PaymentQRCodeView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Payment',
-      titleKey: 'payment.qr.scanToPay',
-      requiresPayment: true
-    }
-  },
+  // ==================== User Routes (TK: nested user tree lives in ./user.tk.ts) ====================
+  ...userRoutes,
+
   {
     path: '/payment/result',
     name: 'PaymentResult',
@@ -426,31 +238,9 @@ const routes: RouteRecordRaw[] = [
       requiresPayment: false
     }
   },
-  {
-    path: '/custom/:id',
-    name: 'CustomPage',
-    component: () => import('@/views/user/CustomPageView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Custom Page',
-      titleKey: 'customPage.title',
-    }
-  },
 
   // ==================== Admin Routes (TK: nested admin tree lives in ./admin.tk.ts) ====================
   ...adminRoutes,
-  {
-    path: '/monitor',
-    name: 'ChannelStatus',
-    component: () => import('@/views/user/ChannelStatusView.vue'),
-    meta: {
-      requiresAuth: true,
-      requiresAdmin: false,
-      title: 'Channel Status',
-      titleKey: 'nav.channelStatus'
-    }
-  },
 
   // ==================== 404 Not Found ====================
   {
@@ -533,6 +323,17 @@ router.beforeEach(async (to, _from, next) => {
   // Check if route requires authentication
   const requiresAuth = to.meta.requiresAuth !== false // Default to true
   const requiresAdmin = to.meta.requiresAdmin === true
+
+  if (to.path === '/') {
+    next(
+      authStore.isAuthenticated
+        ? authStore.isAdmin
+          ? '/admin/dashboard'
+          : '/dashboard'
+        : '/home',
+    )
+    return
+  }
 
   if (to.path === '/setup') {
     try {

--- a/frontend/src/router/user.tk.ts
+++ b/frontend/src/router/user.tk.ts
@@ -1,0 +1,230 @@
+/**
+ * TK user route subtree — persistent UserShellView shell (mirrors admin.tk.ts / PR #935).
+ *
+ * WHY: Per-view <AppLayout> + App.vue KeepAlive cached whole pages (sidebar included),
+ * so sidebar scroll reset on /keys and /studio. Hoist layout into UserShellView and
+ * nest console pages as children so AppSidebar stays mounted.
+ *
+ * Guard: scripts/checks/user-shell-layout.py asserts user views render inside
+ * UserShellView (no per-view <AppLayout>).
+ */
+
+import type { RouteRecordRaw } from 'vue-router'
+
+const userShellChildren: RouteRecordRaw[] = [
+  {
+    path: 'dashboard',
+    name: 'Dashboard',
+    component: () => import('@/views/user/DashboardView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Dashboard',
+      titleKey: 'dashboard.title',
+      descriptionKey: 'dashboard.welcomeMessage',
+    },
+  },
+  {
+    path: 'playground',
+    redirect: { path: '/studio', query: { mode: 'chat' } },
+  },
+  {
+    path: 'studio',
+    name: 'Studio',
+    component: () => import('@/views/user/studio/MediaStudioView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Studio',
+      titleKey: 'studio.title',
+      descriptionKey: 'studio.subtitle',
+    },
+  },
+  {
+    path: 'quickstart',
+    name: 'Quickstart',
+    component: () => import('@/views/user/QuickstartView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Tool Integrations',
+      titleKey: 'quickstart.title',
+      descriptionKey: 'quickstart.subtitle',
+    },
+  },
+  {
+    path: 'keys',
+    name: 'Keys',
+    component: () => import('@/views/user/KeysView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'API Keys',
+      titleKey: 'keys.title',
+      descriptionKey: 'keys.description',
+    },
+  },
+  {
+    path: 'batch-image',
+    name: 'BatchImageGuide',
+    alias: '/docs/batch-image',
+    component: () => import('@/views/user/BatchImageGuideView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Batch Image Guide',
+      titleKey: 'batchImageGuide.title',
+      descriptionKey: 'batchImageGuide.description',
+    },
+  },
+  {
+    path: 'usage',
+    name: 'Usage',
+    component: () => import('@/views/user/UsageView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Usage Records',
+      titleKey: 'usage.title',
+      descriptionKey: 'usage.description',
+    },
+  },
+  {
+    path: 'redeem',
+    name: 'Redeem',
+    component: () => import('@/views/user/RedeemView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Redeem Code',
+      titleKey: 'redeem.title',
+      descriptionKey: 'redeem.description',
+    },
+  },
+  {
+    path: 'affiliate',
+    name: 'Affiliate',
+    component: () => import('@/views/user/AffiliateView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Affiliate',
+      titleKey: 'affiliate.title',
+      descriptionKey: 'affiliate.description',
+    },
+  },
+  {
+    path: 'available-channels',
+    name: 'UserAvailableChannels',
+    component: () => import('@/views/user/AvailableChannelsView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Available Channels',
+      titleKey: 'availableChannels.title',
+      descriptionKey: 'availableChannels.description',
+    },
+  },
+  {
+    path: 'profile',
+    name: 'Profile',
+    component: () => import('@/views/user/ProfileView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Profile',
+      titleKey: 'profile.title',
+      descriptionKey: 'profile.description',
+    },
+  },
+  {
+    path: 'subscriptions',
+    name: 'Subscriptions',
+    component: () => import('@/views/user/SubscriptionsView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'My Subscriptions',
+      titleKey: 'userSubscriptions.title',
+      descriptionKey: 'userSubscriptions.description',
+    },
+  },
+  {
+    path: 'purchase',
+    name: 'PurchaseSubscription',
+    component: () => import('@/views/user/PaymentView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Purchase Subscription',
+      titleKey: 'nav.buySubscription',
+      descriptionKey: 'purchase.description',
+      requiresPayment: true,
+    },
+  },
+  {
+    path: 'orders',
+    name: 'OrderList',
+    component: () => import('@/views/user/UserOrdersView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'My Orders',
+      titleKey: 'nav.myOrders',
+      requiresPayment: true,
+    },
+  },
+  {
+    path: 'payment/qrcode',
+    name: 'PaymentQRCode',
+    component: () => import('@/views/user/PaymentQRCodeView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Payment',
+      titleKey: 'payment.qr.scanToPay',
+      requiresPayment: true,
+    },
+  },
+  {
+    path: 'custom/:id',
+    name: 'CustomPage',
+    component: () => import('@/views/user/CustomPageView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Custom Page',
+      titleKey: 'customPage.title',
+    },
+  },
+  {
+    path: 'monitor',
+    name: 'ChannelStatus',
+    component: () => import('@/views/user/ChannelStatusView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Channel Status',
+      titleKey: 'nav.channelStatus',
+    },
+  },
+  {
+    path: 'models',
+    name: 'ModelMarketplace',
+    component: () => import('@/views/CatalogHubView.vue'),
+    meta: {
+      requiresAuth: false,
+      title: 'Model Marketplace',
+      titleKey: 'models.title',
+      descriptionKey: 'models.subtitle',
+    },
+  },
+]
+
+export const userRoutes: RouteRecordRaw[] = [
+  {
+    path: '/',
+    component: () => import('@/views/user/UserShellView.vue'),
+    children: userShellChildren,
+  },
+]

--- a/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
+++ b/frontend/src/views/__tests__/ModelMarketplaceView.spec.ts
@@ -246,14 +246,14 @@ describe('CatalogHubView', () => {
     expect(wrapper.text()).not.toContain('gpt-4o-mini')
   })
 
-  it('uses the authenticated app shell instead of the guest landing chrome', async () => {
+  it('uses authenticated catalog shell content without guest landing chrome', async () => {
     authState.isAuthenticated = true
     getPublicPricing.mockResolvedValue(catalog([model('gpt-4o-mini', 'OpenAI')]))
 
     const wrapper = mountMarketplace()
     await flushPromises()
 
-    expect(wrapper.find('[data-test="app-layout"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="app-layout"]').exists()).toBe(false)
     expect(wrapper.find('[data-tk="catalog-hub-authed"]').exists()).toBe(true)
     expect(wrapper.find('h1').exists()).toBe(false)
     expect(wrapper.find('[data-tk="catalog-view-switcher"]').exists()).toBe(true)

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -325,7 +325,7 @@ describe('PricingView', () => {
     expect(wrapper.find('h1').exists()).toBe(false)
   })
 
-  it('uses AppLayout and in-page toolbar when authenticated', async () => {
+  it('renders authenticated catalog content without AppLayout (UserShellView owns chrome)', async () => {
     authState.isAuthenticated = true
     routeState.query = { view: 'pricing' }
     getPublicPricing.mockResolvedValue(publicCatalog([publicModel('gpt-4o-mini')]))
@@ -342,7 +342,7 @@ describe('PricingView', () => {
     })
     await flushPromises()
 
-    expect(wrapper.find('[data-test="app-layout"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="app-layout"]').exists()).toBe(false)
     expect(wrapper.find('[data-tk="catalog-hub-authed"]').exists()).toBe(true)
     expect(wrapper.find('[data-tk="catalog-hub-authed-toolbar"]').exists()).toBe(false)
     expect(wrapper.find('[data-tk="catalog-view-switcher"]').exists()).toBe(true)

--- a/frontend/src/views/user/AffiliateView.vue
+++ b/frontend/src/views/user/AffiliateView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="space-y-6">
       <div v-if="loading" class="flex justify-center py-12">
         <div
@@ -136,13 +135,11 @@
         </div>
       </template>
     </div>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import userAPI from '@/api/user'
 import type { UserAffiliateDetail } from '@/types'

--- a/frontend/src/views/user/AirwallexPaymentView.vue
+++ b/frontend/src/views/user/AirwallexPaymentView.vue
@@ -1,4 +1,5 @@
 <template>
+  <AppLayout>
     <div class="mx-auto max-w-lg space-y-6 py-8">
       <div v-if="loading" class="flex items-center justify-center py-20">
         <div class="h-8 w-8 animate-spin rounded-full border-4 border-emerald-500 border-t-transparent"></div>
@@ -20,12 +21,14 @@
         </div>
       </div>
     </div>
+  </AppLayout>
 </template>
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
+import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import {
   PAYMENT_RECOVERY_STORAGE_KEY,

--- a/frontend/src/views/user/AirwallexPaymentView.vue
+++ b/frontend/src/views/user/AirwallexPaymentView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="mx-auto max-w-lg space-y-6 py-8">
       <div v-if="loading" class="flex items-center justify-center py-20">
         <div class="h-8 w-8 animate-spin rounded-full border-4 border-emerald-500 border-t-transparent"></div>
@@ -21,14 +20,12 @@
         </div>
       </div>
     </div>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import {
   PAYMENT_RECOVERY_STORAGE_KEY,

--- a/frontend/src/views/user/AvailableChannelsView.vue
+++ b/frontend/src/views/user/AvailableChannelsView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <TablePageLayout>
       <template #filters>
         <div class="flex flex-col justify-between gap-4 lg:flex-row lg:items-start">
@@ -45,13 +44,11 @@
         />
       </template>
     </TablePageLayout>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import TablePageLayout from '@/components/layout/TablePageLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import AvailableChannelsTable from '@/components/channels/AvailableChannelsTable.vue'

--- a/frontend/src/views/user/BatchImageGuideView.vue
+++ b/frontend/src/views/user/BatchImageGuideView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <TablePageLayout>
       <template #filters>
         <div class="flex flex-col gap-3">
@@ -748,13 +747,11 @@
         </div>
       </template>
     </BaseDialog>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import TablePageLayout from '@/components/layout/TablePageLayout.vue'
 import DataTable from '@/components/common/DataTable.vue'
 import BaseDialog from '@/components/common/BaseDialog.vue'

--- a/frontend/src/views/user/ChannelStatusView.vue
+++ b/frontend/src/views/user/ChannelStatusView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <MonitorHero
       :overall-status="overallStatus"
       :interval-seconds="DEFAULT_INTERVAL_SECONDS"
@@ -25,7 +24,6 @@
       :title="detailTitle"
       @close="closeDetail"
     />
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
@@ -39,7 +37,6 @@ import {
   type UserMonitorView,
   type UserMonitorDetail,
 } from '@/api/channelMonitor'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import MonitorHero, {
   type MonitorWindow,
   type OverallStatus,

--- a/frontend/src/views/user/CustomPageView.vue
+++ b/frontend/src/views/user/CustomPageView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="custom-page-layout">
       <div class="card flex-1 min-h-0 overflow-hidden">
         <div v-if="loading" class="flex h-full items-center justify-center py-12">
@@ -112,7 +111,6 @@
         </div>
       </div>
     </div>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
@@ -122,7 +120,6 @@ import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores'
 import { useAuthStore } from '@/stores/auth'
 import { useAdminSettingsStore } from '@/stores/adminSettings'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { buildApiUrl } from '@/api/client'
 import { buildEmbeddedUrl, detectTheme } from '@/utils/embedded-url'

--- a/frontend/src/views/user/DashboardView.vue
+++ b/frontend/src/views/user/DashboardView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="space-y-6">
       <div v-if="loading" class="flex items-center justify-center py-12"><LoadingSpinner /></div>
       <template v-else-if="stats">
@@ -11,14 +10,13 @@
         </div>
       </template>
     </div>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onActivated } from 'vue'; import { useAuthStore } from '@/stores/auth'; import { usageAPI, type UserDashboardStats as UserStatsType } from '@/api/usage'
 
 defineOptions({ name: 'UserDashboardView' })
-import AppLayout from '@/components/layout/AppLayout.vue'; import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
+import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import UserDashboardStats from '@/components/user/dashboard/UserDashboardStats.vue'; import UserDashboardCharts from '@/components/user/dashboard/UserDashboardCharts.vue'
 import UserDashboardRecentUsage from '@/components/user/dashboard/UserDashboardRecentUsage.vue'; import UserDashboardQuickActions from '@/components/user/dashboard/UserDashboardQuickActions.vue'
 import type { UsageLog, TrendDataPoint, ModelStat, PlatformQuotaItem } from '@/types'

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <TablePageLayout>
       <template #filters>
         <div class="flex flex-col gap-3">
@@ -1159,7 +1158,6 @@
         </div>
       </div>
     </Teleport>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
@@ -1178,7 +1176,6 @@ const route = useRoute()
 const router = useRouter()
 import { keysAPI, authAPI, usageAPI, userGroupsAPI } from '@/api'
 import { useAuthStore } from '@/stores/auth'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import TablePageLayout from '@/components/layout/TablePageLayout.vue'
 	import DataTable from '@/components/common/DataTable.vue'
 	import Pagination from '@/components/common/Pagination.vue'

--- a/frontend/src/views/user/PaymentQRCodeView.vue
+++ b/frontend/src/views/user/PaymentQRCodeView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="mx-auto flex max-w-md flex-col items-center space-y-6 py-8">
       <h2 class="text-xl font-semibold text-gray-900 dark:text-white">
         {{ qrUrl ? scanTitle : t('payment.qr.payInNewWindow') }}
@@ -29,14 +28,12 @@
         {{ cancelling ? t('common.processing') : t('payment.qr.cancelOrder') }}
       </button>
     </div>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import { usePaymentStore } from '@/stores/payment'
 import { paymentAPI } from '@/api/payment'
 import { extractI18nErrorMessage } from '@/utils/apiError'

--- a/frontend/src/views/user/PaymentView.vue
+++ b/frontend/src/views/user/PaymentView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="mx-auto max-w-4xl space-y-6">
       <div v-if="loading" class="flex items-center justify-center py-20">
         <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"></div>
@@ -248,7 +247,6 @@
         </div>
       </Transition>
     </Teleport>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
@@ -264,7 +262,6 @@ import { extractApiErrorMessage, extractI18nErrorMessage } from '@/utils/apiErro
 import { isMobileDevice } from '@/utils/device'
 import { hasPeakRate, formatPeakRateWindow, serverTimezoneLabel, type PeakRateFields } from '@/utils/peak-rate'
 import type { SubscriptionPlan, CheckoutInfoResponse, CreateOrderResult, OrderType } from '@/types/payment'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import AmountInput from '@/components/payment/AmountInput.vue'
 import PaymentMethodSelector from '@/components/payment/PaymentMethodSelector.vue'
 import { METHOD_ORDER, getPaymentPopupFeatures, isBuiltInAlipayMethod, isBuiltInWxpayMethod } from '@/components/payment/providerConfig'

--- a/frontend/src/views/user/ProfileView.vue
+++ b/frontend/src/views/user/ProfileView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div
       data-testid="profile-shell"
       class="mx-auto max-w-[950px] space-y-6"
@@ -45,7 +44,6 @@
 
       <ProfileTotpCard />
     </div>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
@@ -54,7 +52,6 @@ import { useI18n } from 'vue-i18n'
 
 defineOptions({ name: 'UserProfileView' })
 import { Icon } from '@/components/icons'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import ProfileBalanceNotifyCard from '@/components/user/profile/ProfileBalanceNotifyCard.vue'
 import ProfileInfoCard from '@/components/user/profile/ProfileInfoCard.vue'
 import ProfilePasswordForm from '@/components/user/profile/ProfilePasswordForm.vue'

--- a/frontend/src/views/user/QuickstartView.vue
+++ b/frontend/src/views/user/QuickstartView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="mx-auto max-w-6xl space-y-6">
       <section>
         <div v-if="keysLoading" class="flex items-center justify-center py-6">
@@ -193,7 +192,6 @@
         <router-link to="/studio" class="btn btn-primary text-sm">{{ t('quickstart.tryStudio') }}</router-link>
       </div>
     </div>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
@@ -205,7 +203,6 @@ import * as keysAPI from '@/api/keys'
 import type { ApiKey } from '@/types'
 import { filterUserSelectableApiKeys } from '@/utils/reservedProbeKey.tk'
 import { isUniversalKey } from '@/utils/studioUniversalKey.tk'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import GroupBadge from '@/components/common/GroupBadge.vue'
 import Icon from '@/components/icons/Icon.vue'

--- a/frontend/src/views/user/RedeemView.vue
+++ b/frontend/src/views/user/RedeemView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="mx-auto max-w-2xl space-y-6">
       <!-- Current Balance Card -->
       <div class="card overflow-hidden">
@@ -338,7 +337,6 @@
         </div>
       </div>
     </div>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
@@ -348,7 +346,6 @@ import { useAuthStore } from '@/stores/auth'
 import { useAppStore } from '@/stores/app'
 import { useSubscriptionStore } from '@/stores/subscriptions'
 import { redeemAPI, authAPI, type RedeemHistoryItem } from '@/api'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { formatDateTime } from '@/utils/format'
 

--- a/frontend/src/views/user/StripePaymentView.vue
+++ b/frontend/src/views/user/StripePaymentView.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="isPopup ? 'div' : AppLayout" :class="isPopup ? 'min-h-screen bg-gray-50 dark:bg-dark-900' : ''">
+  <component :is="isPopup ? 'div' : 'template'" :class="isPopup ? 'min-h-screen bg-gray-50 dark:bg-dark-900' : undefined">
     <div class="mx-auto max-w-lg space-y-6 py-8" :class="isPopup ? 'px-4' : ''">
       <div v-if="loading" class="flex items-center justify-center py-20">
         <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"></div>
@@ -105,7 +105,6 @@ import { formatPaymentAmount, normalizePaymentCurrency } from '@/components/paym
 import { PAYMENT_RECOVERY_STORAGE_KEY, readPaymentRecoverySnapshot } from '@/components/payment/paymentFlow'
 import type { PaymentOrder } from '@/types/payment'
 import type { Stripe, StripeElements } from '@stripe/stripe-js'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 
 const i18n = useI18n()
@@ -114,7 +113,7 @@ const route = useRoute()
 const router = useRouter()
 const paymentStore = usePaymentStore()
 
-// 弹窗模式：指定支付宝或微信方式时跳过 AppLayout
+// 弹窗模式：指定支付宝或微信方式时使用独立全屏容器（UserShellView 已提供常规布局）
 const isPopup = computed(() => !!route.query.method)
 
 const loading = ref(true)

--- a/frontend/src/views/user/StripePaymentView.vue
+++ b/frontend/src/views/user/StripePaymentView.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="isPopup ? 'div' : 'template'" :class="isPopup ? 'min-h-screen bg-gray-50 dark:bg-dark-900' : undefined">
+  <component :is="isPopup ? 'div' : AppLayout" :class="isPopup ? 'min-h-screen bg-gray-50 dark:bg-dark-900' : ''">
     <div class="mx-auto max-w-lg space-y-6 py-8" :class="isPopup ? 'px-4' : ''">
       <div v-if="loading" class="flex items-center justify-center py-20">
         <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"></div>
@@ -105,6 +105,7 @@ import { formatPaymentAmount, normalizePaymentCurrency } from '@/components/paym
 import { PAYMENT_RECOVERY_STORAGE_KEY, readPaymentRecoverySnapshot } from '@/components/payment/paymentFlow'
 import type { PaymentOrder } from '@/types/payment'
 import type { Stripe, StripeElements } from '@stripe/stripe-js'
+import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 
 const i18n = useI18n()
@@ -113,7 +114,7 @@ const route = useRoute()
 const router = useRouter()
 const paymentStore = usePaymentStore()
 
-// 弹窗模式：指定支付宝或微信方式时使用独立全屏容器（UserShellView 已提供常规布局）
+// 弹窗模式：指定支付宝或微信方式时跳过 AppLayout；/payment/stripe 在 UserShell 外，非弹窗仍自带布局
 const isPopup = computed(() => !!route.query.method)
 
 const loading = ref(true)

--- a/frontend/src/views/user/SubscriptionsView.vue
+++ b/frontend/src/views/user/SubscriptionsView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="space-y-6">
       <!-- Loading State -->
       <div v-if="loading" class="flex justify-center py-12">
@@ -244,7 +243,6 @@
         </div>
       </div>
     </div>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
@@ -254,7 +252,6 @@ import { useRouter } from 'vue-router'
 import { useAppStore } from '@/stores/app'
 import subscriptionsAPI from '@/api/subscriptions'
 import type { UserSubscription } from '@/types'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { formatDateTimeToMinute } from '@/utils/format'
 import { hasPeakRate, formatPeakRateWindow, serverTimezoneLabel } from '@/utils/peak-rate'

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="space-y-6">
       <UsageStatsCards :stats="usageStats" :show-account-cost="false" :strike-standard-cost="true" />
 
@@ -208,7 +207,6 @@
         @ipGeoBatchFailed="handleIpGeoBatchFailed"
       />
     </div>
-  </AppLayout>
 
 </template>
 
@@ -219,7 +217,6 @@ import { useI18n } from 'vue-i18n'
 defineOptions({ name: 'UserUsageView' })
 import { useAppStore } from '@/stores/app'
 import { keysAPI, usageAPI, userGroupsAPI } from '@/api'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import Pagination from '@/components/common/Pagination.vue'
 import Select, { type SelectOption } from '@/components/common/Select.vue'
 import DateRangePicker from '@/components/common/DateRangePicker.vue'

--- a/frontend/src/views/user/UserOrdersView.vue
+++ b/frontend/src/views/user/UserOrdersView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="space-y-4">
       <!-- Filters -->
       <div class="card p-4">
@@ -77,7 +76,6 @@
         </div>
       </template>
     </BaseDialog>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
@@ -88,7 +86,6 @@ import { useAppStore } from '@/stores'
 import { paymentAPI } from '@/api/payment'
 import { extractI18nErrorMessage } from '@/utils/apiError'
 import type { PaymentOrder } from '@/types/payment'
-import AppLayout from '@/components/layout/AppLayout.vue'
 import Pagination from '@/components/common/Pagination.vue'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import Select from '@/components/common/Select.vue'

--- a/frontend/src/views/user/UserShellView.vue
+++ b/frontend/src/views/user/UserShellView.vue
@@ -1,0 +1,39 @@
+<template>
+  <AppLayout v-if="useChrome">
+    <RouterView v-slot="{ Component }">
+      <KeepAlive :include="cachedUserViews">
+        <component :is="Component" />
+      </KeepAlive>
+    </RouterView>
+  </AppLayout>
+  <RouterView v-else v-slot="{ Component }">
+    <KeepAlive :include="cachedUserViews">
+      <component :is="Component" />
+    </KeepAlive>
+  </RouterView>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { RouterView } from 'vue-router'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import { useAuthStore } from '@/stores/auth'
+
+/**
+ * User console views to keep alive across navigations within the user shell.
+ * Names must match defineOptions({ name }) in each view component.
+ * KeepAlive applies to page content only — AppLayout / AppSidebar stay mounted.
+ */
+const cachedUserViews = [
+  'UserDashboardView',
+  'UserUsageView',
+  'UserKeysView',
+  'UserProfileView',
+  'UserStudioView',
+  'KeyUsageView',
+]
+
+const authStore = useAuthStore()
+/** Guest-facing shell children (e.g. /models) render without sidebar chrome. */
+const useChrome = computed(() => authStore.isAuthenticated)
+</script>

--- a/frontend/src/views/user/__tests__/AirwallexPaymentView.spec.ts
+++ b/frontend/src/views/user/__tests__/AirwallexPaymentView.spec.ts
@@ -64,7 +64,7 @@ function mountView() {
   return shallowMount(AirwallexPaymentView, {
     global: {
       stubs: {
-        AppLayout: { template: '<div><slot /></div>' },
+        AppLayout: { template: '<div data-testid="app-layout"><slot /></div>' },
         Icon: true,
       },
     },
@@ -82,6 +82,11 @@ describe('AirwallexPaymentView', () => {
     })
     redirectToCheckout.mockReset()
     window.localStorage.clear()
+  })
+
+  it('在 UserShell 外仍通过 AppLayout 提供控制台 chrome', () => {
+    const wrapper = mountView()
+    expect(wrapper.find('[data-testid="app-layout"]').exists()).toBe(true)
   })
 
   it('从本地恢复快照读取支付参数，避免在 URL 中暴露 client_secret', async () => {

--- a/frontend/src/views/user/__tests__/StripePaymentView.spec.ts
+++ b/frontend/src/views/user/__tests__/StripePaymentView.spec.ts
@@ -87,7 +87,7 @@ function mountView() {
   return shallowMount(StripePaymentView, {
     global: {
       stubs: {
-        AppLayout: { template: '<div><slot /></div>' },
+        AppLayout: { template: '<div data-testid="app-layout"><slot /></div>' },
         Icon: true,
       },
     },
@@ -116,6 +116,12 @@ describe('StripePaymentView', () => {
     stripeInstance.confirmAlipayPayment.mockReset()
     stripeInstance.confirmWechatPayPayment.mockReset()
     window.localStorage.clear()
+  })
+
+  it('非弹窗 /payment/stripe 路由在 UserShell 外，仍渲染 AppLayout', () => {
+    routeState.query = { order_id: '42', client_secret: 'pi_secret_42' }
+    const wrapper = mountView()
+    expect(wrapper.find('[data-testid="app-layout"]').exists()).toBe(true)
   })
 
   it('本地恢复快照缺失时使用订单接口返回的 Stripe 币种展示金额', async () => {

--- a/frontend/src/views/user/__tests__/UserShellView.spec.ts
+++ b/frontend/src/views/user/__tests__/UserShellView.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, reactive } from 'vue'
+
+import UserShellView from '../UserShellView.vue'
+
+const authState = reactive({ isAuthenticated: true })
+
+vi.mock('vue-router', () => ({
+  RouterView: defineComponent({ name: 'RouterView', template: '<div data-testid="router-view" />' }),
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => authState,
+}))
+
+vi.mock('@/components/layout/AppLayout.vue', () => ({
+  default: defineComponent({
+    name: 'AppLayout',
+    template: '<div data-testid="app-layout"><slot /></div>',
+  }),
+}))
+
+describe('UserShellView', () => {
+  it('wraps authenticated routes in AppLayout', () => {
+    authState.isAuthenticated = true
+    const wrapper = mount(UserShellView)
+    expect(wrapper.find('[data-testid="app-layout"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="router-view"]').exists()).toBe(true)
+  })
+
+  it('renders guest shell children without AppLayout chrome', () => {
+    authState.isAuthenticated = false
+    const wrapper = mount(UserShellView)
+    expect(wrapper.find('[data-testid="app-layout"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="router-view"]').exists()).toBe(true)
+  })
+})

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -1,5 +1,4 @@
 <template>
-  <AppLayout>
     <div class="mx-auto flex max-w-6xl flex-col gap-5 px-4 py-6 lg:px-6">
       <!-- No key: gate to /keys (login itself is enforced by the router guard). -->
       <div
@@ -139,7 +138,6 @@
         @modality-change="onBakeoffModalityChange"
       />
     </div>
-  </AppLayout>
 </template>
 
 <script setup lang="ts">
@@ -148,7 +146,6 @@ import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
 defineOptions({ name: 'UserStudioView' })
-import AppLayout from '@/components/layout/AppLayout.vue'
 import ChatStudio from '@/views/user/studio/ChatStudio.vue'
 import ImageStudio from '@/views/user/studio/ImageStudio.vue'
 import VideoStudio from '@/views/user/studio/VideoStudio.vue'

--- a/scripts/checks/admin-shell-layout.py
+++ b/scripts/checks/admin-shell-layout.py
@@ -15,8 +15,8 @@ This check fails on either, turning the recurring "strip <AppLayout> from new ad
 views" merge chore into a mechanical gate instead of a thing to remember.
 
 Scope: frontend/src/views/admin/**/*.vue. AdminShellView.vue is the ONE allowed
-owner of AppLayout. Non-admin user views (frontend/src/views/user/**) legitimately
-keep their own AppLayout and are out of scope.
+owner of AppLayout for admin pages. User console pages use UserShellView instead
+(guarded by scripts/checks/user-shell-layout.py).
 """
 
 from __future__ import annotations

--- a/scripts/checks/user-shell-layout.py
+++ b/scripts/checks/user-shell-layout.py
@@ -8,7 +8,8 @@ modes this catches:
   1. A user view ships wrapped in its own <AppLayout> → doubled layout / sidebar remount.
   2. UserShellView stops rendering AppLayout for authenticated chrome.
 
-Scope: frontend/src/views/user/**/*.vue except UserShellView.vue.
+Scope: frontend/src/views/user/**/*.vue except UserShellView.vue and shell-external
+views that router/index.ts mounts outside UserShell (they must keep their own AppLayout).
 """
 
 from __future__ import annotations
@@ -21,6 +22,13 @@ from pathlib import Path
 
 SHELL_REL = "frontend/src/views/user/UserShellView.vue"
 USER_VIEWS_REL = "frontend/src/views/user"
+# Routed from router/index.ts outside UserShellView — must own AppLayout when chrome is needed.
+SHELL_EXTERNAL_APPLAYOUT_OK = frozenset(
+    {
+        "frontend/src/views/user/StripePaymentView.vue",
+        "frontend/src/views/user/AirwallexPaymentView.vue",
+    }
+)
 
 APPLAYOUT_RE = re.compile(r"<AppLayout(?=[\s/>])")
 
@@ -42,9 +50,11 @@ def scan(repo_root: Path) -> list[str]:
     for vue in sorted(user_views.rglob("*.vue")):
         if vue.resolve() == shell.resolve():
             continue
+        rel = vue.relative_to(repo_root).as_posix()
+        if rel in SHELL_EXTERNAL_APPLAYOUT_OK:
+            continue
         text = vue.read_text(encoding="utf-8", errors="replace")
         if APPLAYOUT_RE.search(text):
-            rel = vue.relative_to(repo_root)
             errors.append(
                 f"{rel}: user views must NOT wrap <AppLayout> (layout comes from "
                 f"UserShellView). Strip the wrapper and register the route under "
@@ -70,6 +80,11 @@ def _selftest() -> int:
             failures.append("view wrapping AppLayout should fail")
         bad.unlink()
 
+        exempt = root / "frontend/src/views/user/StripePaymentView.vue"
+        exempt.write_text("<template>\n  <AppLayout><div/></AppLayout>\n</template>\n")
+        if scan(root):
+            failures.append("shell-external AppLayout owner should be exempt")
+
         shell.write_text("<template>\n  <div/>\n</template>\n")
         if not scan(root):
             failures.append("shell without AppLayout should fail")
@@ -78,7 +93,7 @@ def _selftest() -> int:
         print(f"SELFTEST FAIL: {f}", file=sys.stderr)
     if failures:
         return 1
-    print("ok: user-shell-layout selftest (3/3 cases passed)")
+    print("ok: user-shell-layout selftest (4/4 cases passed)")
     return 0
 
 

--- a/scripts/checks/user-shell-layout.py
+++ b/scripts/checks/user-shell-layout.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Guard the user persistent-shell layout invariant (UserShellView / router/user.tk.ts).
+
+UserShellView hoists <AppLayout> into a single persistent shell and nests console
+pages as children (router/user.tk.ts), mirroring AdminShellView (PR #935). Failure
+modes this catches:
+
+  1. A user view ships wrapped in its own <AppLayout> → doubled layout / sidebar remount.
+  2. UserShellView stops rendering AppLayout for authenticated chrome.
+
+Scope: frontend/src/views/user/**/*.vue except UserShellView.vue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+SHELL_REL = "frontend/src/views/user/UserShellView.vue"
+USER_VIEWS_REL = "frontend/src/views/user"
+
+APPLAYOUT_RE = re.compile(r"<AppLayout(?=[\s/>])")
+
+
+def scan(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    shell = repo_root / SHELL_REL
+    if not shell.is_file():
+        return [f"{SHELL_REL}: persistent user shell is missing"]
+
+    shell_text = shell.read_text(encoding="utf-8", errors="replace")
+    if "AppLayout" not in shell_text:
+        errors.append(
+            f"{SHELL_REL}: user shell no longer references AppLayout — "
+            f"the persistent shell must own authenticated layout chrome"
+        )
+
+    user_views = repo_root / USER_VIEWS_REL
+    for vue in sorted(user_views.rglob("*.vue")):
+        if vue.resolve() == shell.resolve():
+            continue
+        text = vue.read_text(encoding="utf-8", errors="replace")
+        if APPLAYOUT_RE.search(text):
+            rel = vue.relative_to(repo_root)
+            errors.append(
+                f"{rel}: user views must NOT wrap <AppLayout> (layout comes from "
+                f"UserShellView). Strip the wrapper and register the route under "
+                f"frontend/src/router/user.tk.ts"
+            )
+    return errors
+
+
+def _selftest() -> int:
+    failures = []
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / USER_VIEWS_REL).mkdir(parents=True)
+        shell = root / SHELL_REL
+        shell.write_text("<template>\n  <AppLayout />\n</template>\n")
+        (root / USER_VIEWS_REL / "GoodView.vue").write_text("<template>\n  <div/>\n</template>\n")
+        if scan(root):
+            failures.append("baseline should pass")
+
+        bad = root / USER_VIEWS_REL / "BadView.vue"
+        bad.write_text("<template>\n  <AppLayout>\n    <div/>\n  </AppLayout>\n</template>\n")
+        if not scan(root):
+            failures.append("view wrapping AppLayout should fail")
+        bad.unlink()
+
+        shell.write_text("<template>\n  <div/>\n</template>\n")
+        if not scan(root):
+            failures.append("shell without AppLayout should fail")
+
+    for f in failures:
+        print(f"SELFTEST FAIL: {f}", file=sys.stderr)
+    if failures:
+        return 1
+    print("ok: user-shell-layout selftest (3/3 cases passed)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (defaults to two levels up from this script)",
+    )
+    parser.add_argument("--selftest", action="store_true", help="run built-in fixtures and exit")
+    args = parser.parse_args()
+
+    if args.selftest:
+        return _selftest()
+
+    errors = scan(args.repo_root)
+    if errors:
+        for err in errors:
+            print(f"FAIL: {err}", file=sys.stderr)
+        return 1
+    print("ok: user views rely on the UserShellView persistent shell (no per-view <AppLayout>)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1286,6 +1286,21 @@ else
     echo "  ok: admin views rely on AdminShellView persistent shell (no per-view <AppLayout>)"
 fi
 
+# ---- sub2api: user persistent-shell layout invariant -------------------------
+echo ""
+echo "=== sub2api: user persistent-shell layout ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required to run user-shell-layout check)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/user-shell-layout.py --selftest >/dev/null; then
+    echo "  FAIL: user-shell-layout selftest failed"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/user-shell-layout.py; then
+    errors=$((errors + 1))
+else
+    echo "  ok: user views rely on UserShellView persistent shell (no per-view <AppLayout>)"
+fi
+
 # ---- sub2api: post-deploy smoke script (syntax only; no live HTTP) ----------
 echo ""
 echo "=== sub2api: post-deploy smoke script syntax ==="

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -84,10 +84,27 @@
     {
       "path": "frontend/src/router/index.ts",
       "must_contain": [
-        "redirect: { path: '/studio', query: { mode: 'chat' } }",
+        "...userRoutes",
         "...adminRoutes"
       ],
-      "rationale": "Two router invariants. (1) The retired /playground route 301-redirects to the Studio Chat modality (playground was folded in as the fourth Studio tab). This redirect is the only thing keeping old /playground bookmarks/links from 404-ing; a router-table rewrite could silently drop it. (2) The admin route subtree is isolated in router/admin.tk.ts and spread in via `...adminRoutes` to keep index.ts close to upstream shape; an upstream merge that rewrites the route table could drop the spread, silently removing the entire admin area. Anchor both so neither guarantee regresses unnoticed."
+      "rationale": "TK route subtrees are isolated in router/user.tk.ts and router/admin.tk.ts and spread into index.ts via `...userRoutes` / `...adminRoutes` to keep index.ts close to upstream shape. An upstream merge that rewrites the route table could drop either spread, silently removing the entire user console or admin area. Anchor both spreads so neither guarantee regresses unnoticed."
+    },
+    {
+      "path": "frontend/src/router/user.tk.ts",
+      "must_contain": [
+        "export const userRoutes: RouteRecordRaw[]",
+        "@/views/user/UserShellView.vue",
+        "redirect: { path: '/studio', query: { mode: 'chat' } }"
+      ],
+      "rationale": "TK-isolated user route subtree (mirrors admin.tk.ts / PR #935). The `userRoutes` export is the contract index.ts spreads; the UserShellView import is the persistent-shell nesting that user-shell-layout.py depends on. The /playground redirect keeps old bookmarks from 404-ing after playground folded into Studio Chat. Anchor all three so a refactor or merge that flattens the shell, breaks the export, or drops the redirect is caught at preflight time rather than in prod."
+    },
+    {
+      "path": "frontend/src/views/user/UserShellView.vue",
+      "must_contain": [
+        "<AppLayout v-if=\"useChrome\">",
+        "cachedUserViews"
+      ],
+      "rationale": "Persistent user shell owns AppLayout once for authenticated /admin-style console routes; KeepAlive wraps page content only so AppSidebar stays mounted and sidebar scroll is preserved across /keys ↔ /studio navigation. An upstream merge that rewrites this file or moves KeepAlive back to App.vue could silently reintroduce sidebar scroll-to-top on cached routes."
     },
     {
       "path": "frontend/src/router/admin.tk.ts",
@@ -1594,10 +1611,13 @@
     {
       "path": "frontend/src/App.vue",
       "must_contain": [
+        "<RouterView />"
+      ],
+      "must_not_contain": [
         "cachedUserViews",
         "<KeepAlive :include=\"cachedUserViews\">"
       ],
-      "rationale": "TK wraps the RouterView in a KeepAlive with an explicit include list (cachedUserViews) so user-facing views (Dashboard, Usage, Keys, Profile, Studio, KeyUsage) preserve component state across navigation instead of re-mounting. Upstream App.vue has no KeepAlive; an upstream merge that replaces the template block drops the wrapper silently, causing every navigation to remount and lose in-progress form/filter state on all cached views."
+      "rationale": "User console KeepAlive moved to UserShellView (page body only) so AppLayout/AppSidebar stay mounted; App.vue stays a thin root shell with a bare RouterView. must_not_contain blocks an upstream merge from re-hoisting KeepAlive here, which would cache whole pages including sidebar and regress sidebar scroll on /keys ↔ /studio."
     },
     {
       "path": "frontend/src/types/index.ts",


### PR DESCRIPTION
## 摘要

- 新增 `UserShellView` + `router/user.tk.ts`，将用户控制台路由嵌套到持久 shell 下（对齐 `AdminShellView` 模式）。
- 从 `App.vue` 移除顶层 `KeepAlive`；`KeepAlive` 仅缓存页面 body，侧栏在 `/keys`、`/studio` 等切换时保持挂载，修复侧栏滚动回顶。
- 18 个 user view 去掉各自 `<AppLayout>`；新增 `user-shell-layout.py` 机械门禁。
- 新增 `e2e/sidebar-scroll.e2e.ts`（mock 鉴权）与 `e2e/sidebar-scroll-local.e2e.ts`（真实 API 登录，本地 `go run -tags embed` 验证）。

## 风险

- 常规风险：路由结构 flat → nested；支付回调等无 chrome 路由仍在 shell 外。
- review 已修复：`/payment/stripe`、`/payment/airwallex` 在 UserShell 外须保留自有 `AppLayout`。
- 本地 Playwright（真实后端）已通过；prod 未实测。

## 验证

- `./scripts/preflight.sh` — PASS
- `pnpm --dir frontend run build && pnpm typecheck` — PASS
- Playwright mock：`E2E_BASE_URL=http://127.0.0.1:4173 pnpm exec playwright test e2e/sidebar-scroll.e2e.ts`（vite preview）
- Playwright 本地部署：`E2E_BASE_URL=http://127.0.0.1:8089 pnpm exec playwright test e2e/sidebar-scroll-local.e2e.ts` — PASS（`go run -tags embed` + 已有 postgres/redis dev 栈）

## 提交

- 6ab3f85e7 feat(frontend): 用户控制台持久 UserShell 修复侧栏滚动回顶
- 132c07606 fix(frontend): 恢复 UserShell 外支付页的 AppLayout
- f604748f1 test(frontend): 新增本地部署 Playwright 侧栏滚动验证

最新提交：f604748f1