### PR TITLE
fix(frontend): 用户使用记录只展示实际费用

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 645,
-  "hash": "2eb450e619fc9d691b314e5e3b01083e4a0da8c248b17389f0406f4460b3560c",
+  "hash": "c6643d7a0c2c93e8664ce7ac937f415fdb33f63b3544b98c08e9bb2e67bd2898",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/admin/usage/UsageStatsCards.vue
+++ b/frontend/src/components/admin/usage/UsageStatsCards.vue
@@ -67,12 +67,12 @@
         <p class="text-xl font-bold text-green-600">
           ${{ (stats?.total_actual_cost || 0).toFixed(4) }}
         </p>
-        <p class="text-xs text-gray-400">
+        <p v-if="(showAccountCost && totalAccountCost != null) || showStandardCost" class="text-xs text-gray-400">
           <template v-if="showAccountCost && totalAccountCost != null">
             <span class="text-orange-500">{{ t('usage.accountCost') }} ${{ totalAccountCost.toFixed(4) }}</span>
-            <span> · </span>
+            <span v-if="showStandardCost"> · </span>
           </template>
-          <span>
+          <span v-if="showStandardCost">
             {{ t('usage.standardCost') }}
             <span :class="{ 'line-through': strikeStandardCost }">${{ (stats?.total_cost || 0).toFixed(4) }}</span>
           </span>
@@ -98,9 +98,11 @@ import Icon from '@/components/icons/Icon.vue'
 const props = withDefaults(defineProps<{
   stats: (AdminUsageStatsResponse | UsageStatsResponse) | null
   showAccountCost?: boolean
+  showStandardCost?: boolean
   strikeStandardCost?: boolean
 }>(), {
   showAccountCost: true,
+  showStandardCost: true,
   strikeStandardCost: false,
 })
 
@@ -111,6 +113,7 @@ const totalAccountCost = computed(() => {
   return stats?.total_account_cost ?? null
 })
 const showAccountCost = computed(() => props.showAccountCost)
+const showStandardCost = computed(() => props.showStandardCost)
 const strikeStandardCost = computed(() => props.strikeStandardCost)
 
 const formatDuration = (ms: number) =>

--- a/frontend/src/components/admin/usage/__tests__/UsageStatsCards.spec.ts
+++ b/frontend/src/components/admin/usage/__tests__/UsageStatsCards.spec.ts
@@ -64,4 +64,22 @@ describe('UsageStatsCards', () => {
     expect(text).toContain('Cache Read')
     expect(text).toContain('22')
   })
+
+  it('hides standard cost subtitle for user-facing usage stats', () => {
+    const wrapper = mount(UsageStatsCards, {
+      props: {
+        stats,
+        showAccountCost: false,
+        showStandardCost: false,
+      },
+      global: {
+        stubs: {
+          Icon: true,
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Total Cost')
+    expect(wrapper.text()).not.toContain('Standard')
+  })
 })

--- a/frontend/src/components/charts/EndpointDistributionChart.vue
+++ b/frontend/src/components/charts/EndpointDistributionChart.vue
@@ -82,8 +82,8 @@
               <th class="pb-2 text-left">{{ t('usage.endpoint') }}</th>
               <th class="pb-2 text-right">{{ t('admin.dashboard.requests') }}</th>
               <th class="pb-2 text-right">{{ t('admin.dashboard.tokens') }}</th>
-              <th class="pb-2 text-right">{{ t('admin.dashboard.actual') }}</th>
-              <th class="pb-2 text-right">{{ t('admin.dashboard.standard') }}</th>
+              <th class="pb-2 text-right">{{ costColumnLabel }}</th>
+              <th v-if="showStandardCost" class="pb-2 text-right">{{ t('admin.dashboard.standard') }}</th>
             </tr>
           </thead>
           <tbody>
@@ -109,12 +109,12 @@
                 <td class="py-1.5 text-right text-green-600 dark:text-green-400">
                   ${{ formatCost(item.actual_cost) }}
                 </td>
-                <td class="py-1.5 text-right text-gray-400 dark:text-gray-500">
+                <td v-if="showStandardCost" class="py-1.5 text-right text-gray-400 dark:text-gray-500">
                   ${{ formatCost(item.cost) }}
                 </td>
               </tr>
               <tr v-if="expandedKey === item.endpoint">
-                <td colspan="5" class="p-0">
+                <td :colspan="distributionColspan" class="p-0">
                   <UserBreakdownSubTable
                     :items="breakdownItems"
                     :loading="breakdownLoading"
@@ -161,6 +161,7 @@ const props = withDefaults(
     showMetricToggle?: boolean
     showSourceToggle?: boolean
     enableBreakdown?: boolean
+    showStandardCost?: boolean
     startDate?: string
     endDate?: string
     startTs?: number
@@ -176,9 +177,16 @@ const props = withDefaults(
     source: 'inbound',
     showMetricToggle: false,
     showSourceToggle: false,
-    enableBreakdown: true
+    enableBreakdown: true,
+    showStandardCost: true,
   }
 )
+
+const showStandardCost = computed(() => props.showStandardCost)
+const costColumnLabel = computed(() =>
+  showStandardCost.value ? t('admin.dashboard.actual') : t('usage.cost')
+)
+const distributionColspan = computed(() => 4 + (showStandardCost.value ? 1 : 0))
 
 const emit = defineEmits<{
   'update:metric': [value: DistributionMetric]

--- a/frontend/src/components/charts/GroupDistributionChart.vue
+++ b/frontend/src/components/charts/GroupDistributionChart.vue
@@ -44,9 +44,9 @@
               <th class="pb-2 text-left">{{ t('admin.dashboard.group') }}</th>
               <th class="pb-2 text-right">{{ t('admin.dashboard.requests') }}</th>
               <th class="pb-2 text-right">{{ t('admin.dashboard.tokens') }}</th>
-              <th class="pb-2 text-right">{{ t('admin.dashboard.actual') }}</th>
+              <th class="pb-2 text-right">{{ costColumnLabel }}</th>
               <th v-if="showAccountCost" class="pb-2 text-right">{{ t('admin.dashboard.accountCost') }}</th>
-              <th class="pb-2 text-right">{{ t('admin.dashboard.standard') }}</th>
+              <th v-if="showStandardCost" class="pb-2 text-right">{{ t('admin.dashboard.standard') }}</th>
             </tr>
           </thead>
           <tbody>
@@ -79,7 +79,7 @@
                 <td v-if="showAccountCost" class="py-1.5 text-right text-orange-500 dark:text-orange-400">
                   ${{ formatCost(group.account_cost) }}
                 </td>
-                <td class="py-1.5 text-right text-gray-400 dark:text-gray-500">
+                <td v-if="showStandardCost" class="py-1.5 text-right text-gray-400 dark:text-gray-500">
                   ${{ formatCost(group.cost) }}
                 </td>
               </tr>
@@ -130,6 +130,7 @@ const props = withDefaults(defineProps<{
   showMetricToggle?: boolean
   enableBreakdown?: boolean
   showAccountCost?: boolean
+  showStandardCost?: boolean
   startDate?: string
   endDate?: string
   startTs?: number
@@ -141,6 +142,7 @@ const props = withDefaults(defineProps<{
   showMetricToggle: false,
   enableBreakdown: true,
   showAccountCost: true,
+  showStandardCost: true,
 })
 
 const emit = defineEmits<{
@@ -151,7 +153,13 @@ const expandedKey = ref<string | null>(null)
 const breakdownItems = ref<UserBreakdownItem[]>([])
 const breakdownLoading = ref(false)
 const showAccountCost = computed(() => props.showAccountCost)
-const distributionColspan = computed(() => showAccountCost.value ? 6 : 5)
+const showStandardCost = computed(() => props.showStandardCost)
+const costColumnLabel = computed(() =>
+  showStandardCost.value ? t('admin.dashboard.actual') : t('usage.cost')
+)
+const distributionColspan = computed(() =>
+  4 + (showAccountCost.value ? 1 : 0) + (showStandardCost.value ? 1 : 0)
+)
 
 const toggleBreakdown = async (type: string, id: number | string) => {
   const key = `${type}-${id}`

--- a/frontend/src/components/charts/ModelDistributionChart.vue
+++ b/frontend/src/components/charts/ModelDistributionChart.vue
@@ -113,9 +113,9 @@
               <th class="pb-2 text-left">{{ t('admin.dashboard.model') }}</th>
               <th class="pb-2 text-right">{{ t('admin.dashboard.requests') }}</th>
               <th class="pb-2 text-right">{{ t('admin.dashboard.tokens') }}</th>
-              <th class="pb-2 text-right">{{ t('admin.dashboard.actual') }}</th>
+              <th class="pb-2 text-right">{{ costColumnLabel }}</th>
               <th v-if="showAccountCost" class="pb-2 text-right">{{ t('admin.dashboard.accountCost') }}</th>
-              <th class="pb-2 text-right">{{ t('admin.dashboard.standard') }}</th>
+              <th v-if="showStandardCost" class="pb-2 text-right">{{ t('admin.dashboard.standard') }}</th>
             </tr>
           </thead>
           <tbody>
@@ -148,7 +148,7 @@
                 <td v-if="showAccountCost" class="py-1.5 text-right text-orange-500 dark:text-orange-400">
                   ${{ formatCost(model.account_cost) }}
                 </td>
-                <td class="py-1.5 text-right text-gray-400 dark:text-gray-500">
+                <td v-if="showStandardCost" class="py-1.5 text-right text-gray-400 dark:text-gray-500">
                   ${{ formatCost(model.cost) }}
                 </td>
               </tr>
@@ -275,6 +275,7 @@ const props = withDefaults(defineProps<{
   showMetricToggle?: boolean
   enableBreakdown?: boolean
   showAccountCost?: boolean
+  showStandardCost?: boolean
   rankingLoading?: boolean
   rankingError?: boolean
   startDate?: string
@@ -297,6 +298,7 @@ const props = withDefaults(defineProps<{
   showMetricToggle: false,
   enableBreakdown: true,
   showAccountCost: true,
+  showStandardCost: true,
   rankingLoading: false,
   rankingError: false
 })
@@ -340,7 +342,13 @@ const emit = defineEmits<{
 
 const enableRankingView = computed(() => props.enableRankingView)
 const showAccountCost = computed(() => props.showAccountCost)
-const distributionColspan = computed(() => showAccountCost.value ? 6 : 5)
+const showStandardCost = computed(() => props.showStandardCost)
+const costColumnLabel = computed(() =>
+  showStandardCost.value ? t('admin.dashboard.actual') : t('usage.cost')
+)
+const distributionColspan = computed(() =>
+  4 + (showAccountCost.value ? 1 : 0) + (showStandardCost.value ? 1 : 0)
+)
 const activeView = ref<'model_distribution' | 'spending_ranking'>('model_distribution')
 
 const chartColors = [

--- a/frontend/src/components/charts/__tests__/GroupDistributionChart.spec.ts
+++ b/frontend/src/components/charts/__tests__/GroupDistributionChart.spec.ts
@@ -11,6 +11,7 @@ const messages: Record<string, string> = {
   'admin.dashboard.tokens': 'Tokens',
   'admin.dashboard.actual': 'Actual',
   'admin.dashboard.accountCost': 'Account Cost',
+  'usage.cost': 'Cost',
   'admin.dashboard.standard': 'Standard',
   'admin.dashboard.metricTokens': 'By Tokens',
   'admin.dashboard.metricActualCost': 'By Actual Cost',
@@ -131,5 +132,25 @@ describe('GroupDistributionChart', () => {
     expect(wrapper.text()).not.toContain('Account Cost')
     expect(wrapper.findAll('thead th')).toHaveLength(5)
     expect(wrapper.findAll('tbody tr')[0].findAll('td')).toHaveLength(5)
+  })
+
+  it('can hide standard cost for user usage stats', () => {
+    const wrapper = mount(GroupDistributionChart, {
+      props: {
+        groupStats,
+        showAccountCost: false,
+        showStandardCost: false,
+      },
+      global: {
+        stubs: {
+          LoadingSpinner: true,
+        },
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('Standard')
+    expect(wrapper.text()).toContain('Cost')
+    expect(wrapper.findAll('thead th')).toHaveLength(4)
+    expect(wrapper.findAll('tbody tr')[0].findAll('td')).toHaveLength(4)
   })
 })

--- a/frontend/src/components/charts/__tests__/ModelDistributionChart.spec.ts
+++ b/frontend/src/components/charts/__tests__/ModelDistributionChart.spec.ts
@@ -18,6 +18,7 @@ const messages: Record<string, string> = {
   'admin.dashboard.tokens': 'Tokens',
   'admin.dashboard.actual': 'Actual',
   'admin.dashboard.accountCost': 'Account Cost',
+  'usage.cost': 'Cost',
   'admin.dashboard.standard': 'Standard',
   'admin.dashboard.metricTokens': 'By Tokens',
   'admin.dashboard.metricActualCost': 'By Actual Cost',
@@ -145,6 +146,26 @@ describe('ModelDistributionChart', () => {
     expect(wrapper.text()).not.toContain('Account Cost')
     expect(wrapper.findAll('thead th')).toHaveLength(5)
     expect(wrapper.findAll('tbody tr')[0].findAll('td')).toHaveLength(5)
+  })
+
+  it('can hide standard cost for user usage stats', () => {
+    const wrapper = mount(ModelDistributionChart, {
+      props: {
+        modelStats,
+        showAccountCost: false,
+        showStandardCost: false,
+      },
+      global: {
+        stubs: {
+          LoadingSpinner: true,
+        },
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('Standard')
+    expect(wrapper.text()).toContain('Cost')
+    expect(wrapper.findAll('thead th')).toHaveLength(4)
+    expect(wrapper.findAll('tbody tr')[0].findAll('td')).toHaveLength(4)
   })
 
   it('renders Others in the spending ranking table and uses a dedicated chart color', async () => {

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="space-y-6">
-      <UsageStatsCards :stats="usageStats" :show-account-cost="false" :strike-standard-cost="true" />
+      <UsageStatsCards :stats="usageStats" :show-account-cost="false" :show-standard-cost="false" />
 
       <div class="space-y-4">
         <div class="card p-4">
@@ -31,6 +31,7 @@
             :show-metric-toggle="true"
             :enable-breakdown="false"
             :show-account-cost="false"
+            :show-standard-cost="false"
             :start-date="startDate"
             :end-date="endDate"
           />
@@ -41,6 +42,7 @@
             :show-metric-toggle="true"
             :enable-breakdown="false"
             :show-account-cost="false"
+            :show-standard-cost="false"
             :start-date="startDate"
             :end-date="endDate"
           />
@@ -57,6 +59,7 @@
             :show-source-toggle="false"
             :show-metric-toggle="true"
             :enable-breakdown="false"
+            :show-standard-cost="false"
             :title="t('usage.endpointDistribution')"
             :start-date="startDate"
             :end-date="endDate"

--- a/frontend/src/views/user/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/user/__tests__/UsageView.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import UsageView from '../UsageView.vue'
@@ -96,6 +97,23 @@ vi.mock('vue-i18n', async () => {
 const simpleStub = { template: '<div><slot /></div>' }
 const chartStub = { template: '<div />' }
 
+function propCaptureStub(
+  testId: string,
+  sink: Record<string, Record<string, unknown>>,
+  propNames: string[],
+) {
+  return defineComponent({
+    name: `Capture${testId}`,
+    props: propNames,
+    setup(props) {
+      sink[testId] = Object.fromEntries(
+        propNames.map((name) => [name, (props as Record<string, unknown>)[name]]),
+      )
+      return () => h('div', { 'data-testid': testId })
+    },
+  })
+}
+
 const usageLog = {
   id: 1,
   request_id: 'req-user-export',
@@ -127,7 +145,10 @@ const usageLog = {
   stream: false,
 }
 
-function mountUsageView() {
+function mountUsageView(options?: {
+  billingSurfaceProps?: Record<string, Record<string, unknown>>
+}) {
+  const billingSurfaceProps = options?.billingSurfaceProps ?? {}
   return mount(UsageView, {
     global: {
       stubs: {
@@ -136,12 +157,24 @@ function mountUsageView() {
         Select: true,
         DateRangePicker: true,
         Icon: true,
-        UsageStatsCards: chartStub,
         UsageTable: chartStub,
-        ModelDistributionChart: chartStub,
-        GroupDistributionChart: chartStub,
-        EndpointDistributionChart: chartStub,
         TokenUsageTrend: chartStub,
+        UsageStatsCards: propCaptureStub('usage-stats-cards', billingSurfaceProps, [
+          'stats',
+          'showAccountCost',
+          'showStandardCost',
+        ]),
+        ModelDistributionChart: propCaptureStub('model-distribution-chart', billingSurfaceProps, [
+          'showAccountCost',
+          'showStandardCost',
+        ]),
+        GroupDistributionChart: propCaptureStub('group-distribution-chart', billingSurfaceProps, [
+          'showAccountCost',
+          'showStandardCost',
+        ]),
+        EndpointDistributionChart: propCaptureStub('endpoint-distribution-chart', billingSurfaceProps, [
+          'showStandardCost',
+        ]),
       },
     },
   })
@@ -206,6 +239,29 @@ describe('user UsageView', () => {
     }))
     expect(list).toHaveBeenCalledWith(1, 100)
     expect(getAvailable).toHaveBeenCalled()
+  })
+
+  it('passes showStandardCost=false to usage summary and distribution charts', async () => {
+    const billingSurfaceProps: Record<string, Record<string, unknown>> = {}
+    mountUsageView({ billingSurfaceProps })
+    await flushPromises()
+
+    expect(billingSurfaceProps['usage-stats-cards']).toEqual({
+      stats: expect.any(Object),
+      showAccountCost: false,
+      showStandardCost: false,
+    })
+    expect(billingSurfaceProps['model-distribution-chart']).toEqual({
+      showAccountCost: false,
+      showStandardCost: false,
+    })
+    expect(billingSurfaceProps['group-distribution-chart']).toEqual({
+      showAccountCost: false,
+      showStandardCost: false,
+    })
+    expect(billingSurfaceProps['endpoint-distribution-chart']).toEqual({
+      showStandardCost: false,
+    })
   })
 
   it('exports csv with current filters and without admin-only fields', async () => {

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1090,13 +1090,14 @@
       "must_contain": [
         "'Billed Cost',",
         "(log.actual_cost ?? 0).toFixed(8)",
-        ":show-account-billing=\"false\""
+        ":show-account-billing=\"false\"",
+        ":show-standard-cost=\"false\""
       ],
       "must_not_contain": [
         "'Rate Multiplier',",
         "'Original Cost',"
       ],
-      "rationale": "PR #718 + upstream merge 2026-07: the user usage CSV exports Billed Cost only and the user page disables account billing details in the shared UsageTable. Upstream merges of this large upstream-shaped view tend to restore raw multiplier/original-cost columns."
+      "rationale": "PR #718 + upstream merge 2026-07: the user usage CSV exports Billed Cost only and the user page disables account billing details in the shared UsageTable. PR #1463 extends the same actual-only billing policy to summary cards and model/group/endpoint distribution charts via showStandardCost=false wiring on UsageStatsCards and the three distribution chart components. Upstream merges of this large upstream-shaped view tend to restore raw multiplier/original-cost columns or the standard-cost distribution columns."
     },
     {
       "path": "frontend/src/utils/billingMode.ts",


### PR DESCRIPTION
## 摘要
- 用户「使用记录」页的统计卡片、模型/分组/端点分布表不再展示「标准」计费列
- 费用列统一为「费用」，数据仍来自 `actual_cost`（用户实际消耗）
- 管理端行为不变，仍保留实际/标准/账号成本对比
- 扩展 `frontend-tk.json` UsageView sentinel + `UsageView.spec.ts` 行为测试，防止 upstream merge 恢复标准列 wiring

## 风险
- 低风险，仅影响用户侧 WebUI 展示
- 无 API / 后端行为变更

## 验证
- `./scripts/preflight.sh` 通过
- `pnpm exec vitest run src/views/user/__tests__/UsageView.spec.ts` 通过（4 tests）
- `pnpm exec vitest run src/components/charts/__tests__/ModelDistributionChart.spec.ts src/components/charts/__tests__/GroupDistributionChart.spec.ts src/components/admin/usage/__tests__/UsageStatsCards.spec.ts` 通过（11 tests）

## 提交
- dc706baf1 fix(frontend): 用户使用记录只展示实际费用，隐藏标准计费列
- 3ec6a40ba test(frontend): 锚定用户 UsageView 隐藏标准计费的 upstream 防护
- 最新提交：3ec6a40ba

upstream-touch-trivial sentinel-registry-reviewed