### PR TITLE
feat(auth): 父域 tk_refresh cookie 支持 apex 切换免重登

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -119,6 +119,7 @@ func (h *AuthHandler) respondWithTokenPair(c *gin.Context, user *service.User) {
 		})
 		return
 	}
+	h.setTkRefreshSessionCookie(c, tokenPair.RefreshToken)
 	response.Success(c, AuthResponse{
 		AccessToken:  tokenPair.AccessToken,
 		RefreshToken: tokenPair.RefreshToken,
@@ -651,7 +652,7 @@ func (h *AuthHandler) ResetPassword(c *gin.Context) {
 
 // RefreshTokenRequest 刷新Token请求
 type RefreshTokenRequest struct {
-	RefreshToken string `json:"refresh_token" binding:"required"`
+	RefreshToken string `json:"refresh_token"`
 }
 
 // RefreshTokenResponse 刷新Token响应
@@ -666,17 +667,22 @@ type RefreshTokenResponse struct {
 // POST /api/v1/auth/refresh
 func (h *AuthHandler) RefreshToken(c *gin.Context) {
 	var req RefreshTokenRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
+	// 允许空 body：浏览器可用 HttpOnly tk_refresh cookie 续期。
+	_ = c.ShouldBindJSON(&req)
+
+	refreshToken, err := h.resolveRefreshTokenForRequest(c, req.RefreshToken)
+	if err != nil || strings.TrimSpace(refreshToken) == "" {
 		response.InvalidRequest(c)
 		return
 	}
 
-	result, err := h.authService.RefreshTokenPair(c.Request.Context(), req.RefreshToken)
+	result, err := h.authService.RefreshTokenPair(c.Request.Context(), refreshToken)
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return
 	}
 
+	h.setTkRefreshSessionCookie(c, result.RefreshToken)
 	response.Success(c, RefreshTokenResponse{
 		AccessToken:  result.AccessToken,
 		RefreshToken: result.RefreshToken,
@@ -702,13 +708,14 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 	// 允许空请求体（向后兼容）
 	_ = c.ShouldBindJSON(&req)
 
-	// 如果提供了Refresh Token，撤销它
-	if req.RefreshToken != "" {
-		if err := h.authService.RevokeRefreshToken(c.Request.Context(), req.RefreshToken); err != nil {
-			slog.Debug("failed to revoke refresh token", "error", err)
+	refreshToken, err := h.resolveRefreshTokenForRequest(c, req.RefreshToken)
+	if err == nil && strings.TrimSpace(refreshToken) != "" {
+		if revokeErr := h.authService.RevokeRefreshToken(c.Request.Context(), refreshToken); revokeErr != nil {
+			slog.Debug("failed to revoke refresh token", "error", revokeErr)
 			// 不影响登出流程
 		}
 	}
+	h.clearTkRefreshSessionCookie(c)
 	h.consumePendingOAuthSessionOnLogout(c)
 	clearOAuthLogoutCookies(c)
 
@@ -736,6 +743,8 @@ func (h *AuthHandler) RevokeAllSessions(c *gin.Context) {
 		response.InternalError(c, "Failed to revoke sessions")
 		return
 	}
+
+	h.clearTkRefreshSessionCookie(c)
 
 	response.Success(c, RevokeAllSessionsResponse{
 		Message: "All sessions have been revoked. Please log in again.",

--- a/backend/internal/handler/auth_session_cookie_tk.go
+++ b/backend/internal/handler/auth_session_cookie_tk.go
@@ -1,0 +1,140 @@
+package handler
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	tkRefreshSessionCookieName = "tk_refresh"
+	tkRefreshSessionCookiePath = "/api/v1/auth"
+)
+
+func tkRefreshSessionCookieMaxAgeSec(h *AuthHandler) int {
+	if h == nil || h.cfg == nil {
+		return 7 * 24 * 60 * 60
+	}
+	days := h.cfg.JWT.RefreshTokenExpireDays
+	if days <= 0 {
+		days = 7
+	}
+	return days * 24 * 60 * 60
+}
+
+func registrableParentDomain(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" || host == "localhost" || net.ParseIP(host) != nil {
+		return ""
+	}
+
+	parts := strings.Split(host, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	if len(parts) == 2 {
+		return host
+	}
+	return strings.Join(parts[len(parts)-2:], ".")
+}
+
+func hostFromAbsoluteURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(u.Hostname()))
+}
+
+func requestHost(c *gin.Context) string {
+	if c == nil || c.Request == nil {
+		return ""
+	}
+	host := strings.ToLower(strings.TrimSpace(c.Request.Host))
+	if idx := strings.Index(host, ":"); idx >= 0 {
+		host = host[:idx]
+	}
+	return host
+}
+
+func (h *AuthHandler) tkRefreshSessionCookieDomain(c *gin.Context) string {
+	host := hostFromAbsoluteURL(h.tkFrontendBaseURL())
+	if host == "" && c != nil {
+		host = requestHost(c)
+	}
+	return registrableParentDomain(host)
+}
+
+func (h *AuthHandler) tkFrontendBaseURL() string {
+	if h == nil || h.cfg == nil {
+		return ""
+	}
+	return strings.TrimSpace(h.cfg.Server.FrontendURL)
+}
+
+func (h *AuthHandler) setTkRefreshSessionCookie(c *gin.Context, refreshToken string) {
+	refreshToken = strings.TrimSpace(refreshToken)
+	if refreshToken == "" || c == nil {
+		return
+	}
+
+	secure := isRequestHTTPS(c)
+	cookie := &http.Cookie{
+		Name:     tkRefreshSessionCookieName,
+		Value:    encodeCookieValue(refreshToken),
+		Path:     tkRefreshSessionCookiePath,
+		MaxAge:   tkRefreshSessionCookieMaxAgeSec(h),
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	}
+	if domain := h.tkRefreshSessionCookieDomain(c); domain != "" {
+		cookie.Domain = domain
+	}
+	http.SetCookie(c.Writer, cookie)
+}
+
+func clearTkRefreshSessionCookie(c *gin.Context, domain string) {
+	if c == nil {
+		return
+	}
+
+	secure := isRequestHTTPS(c)
+	cookie := &http.Cookie{
+		Name:     tkRefreshSessionCookieName,
+		Value:    "",
+		Path:     tkRefreshSessionCookiePath,
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	}
+	domain = strings.TrimSpace(domain)
+	if domain != "" {
+		cookie.Domain = domain
+	}
+	http.SetCookie(c.Writer, cookie)
+}
+
+func (h *AuthHandler) clearTkRefreshSessionCookie(c *gin.Context) {
+	clearTkRefreshSessionCookie(c, h.tkRefreshSessionCookieDomain(c))
+}
+
+func readTkRefreshSessionCookie(c *gin.Context) (string, error) {
+	return readCookieDecoded(c, tkRefreshSessionCookieName)
+}
+
+func (h *AuthHandler) resolveRefreshTokenForRequest(c *gin.Context, bodyToken string) (string, error) {
+	bodyToken = strings.TrimSpace(bodyToken)
+	if bodyToken != "" {
+		return bodyToken, nil
+	}
+	return readTkRefreshSessionCookie(c)
+}

--- a/backend/internal/handler/auth_session_cookie_tk_test.go
+++ b/backend/internal/handler/auth_session_cookie_tk_test.go
@@ -1,0 +1,146 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistrableParentDomain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		host string
+		want string
+	}{
+		{host: "tokenkey.dev", want: "tokenkey.dev"},
+		{host: "api.tokenkey.dev", want: "tokenkey.dev"},
+		{host: "edge-uk.tokenkey.dev", want: "tokenkey.dev"},
+		{host: "localhost", want: ""},
+		{host: "127.0.0.1", want: ""},
+		{host: "internal", want: ""},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.host, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, registrableParentDomain(tc.host))
+		})
+	}
+}
+
+func TestSetTkRefreshSessionCookieUsesParentDomainFromFrontendURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := &AuthHandler{
+		cfg: &config.Config{
+			Server: config.ServerConfig{
+				FrontendURL: "https://tokenkey.dev",
+			},
+			JWT: config.JWTConfig{
+				RefreshTokenExpireDays: 7,
+			},
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "https://api.tokenkey.dev/api/v1/auth/login", nil)
+	ginCtx.Request.Header.Set("X-Forwarded-Proto", "https")
+
+	handler.setTkRefreshSessionCookie(ginCtx, "refresh-token-value")
+
+	cookie := findCookie(recorder.Result().Cookies(), tkRefreshSessionCookieName)
+	require.NotNil(t, cookie)
+	require.Equal(t, "tokenkey.dev", cookie.Domain)
+	require.Equal(t, tkRefreshSessionCookiePath, cookie.Path)
+	require.True(t, cookie.HttpOnly)
+	require.True(t, cookie.Secure)
+	require.Equal(t, http.SameSiteLaxMode, cookie.SameSite)
+
+	decoded, err := decodeCookieValue(cookie.Value)
+	require.NoError(t, err)
+	require.Equal(t, "refresh-token-value", decoded)
+}
+
+func TestClearTkRefreshSessionCookieClearsParentDomainCookie(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := &AuthHandler{
+		cfg: &config.Config{
+			Server: config.ServerConfig{
+				FrontendURL: "https://tokenkey.dev",
+			},
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "https://tokenkey.dev/api/v1/auth/logout", nil)
+	ginCtx.Request.Header.Set("X-Forwarded-Proto", "https")
+
+	handler.clearTkRefreshSessionCookie(ginCtx)
+
+	cookie := findCookie(recorder.Result().Cookies(), tkRefreshSessionCookieName)
+	require.NotNil(t, cookie)
+	require.Equal(t, "tokenkey.dev", cookie.Domain)
+	require.Equal(t, -1, cookie.MaxAge)
+	require.Equal(t, "", cookie.Value)
+}
+
+func TestResolveRefreshTokenForRequestPrefersBodyOverCookie(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := &AuthHandler{
+		cfg: &config.Config{
+			Server: config.ServerConfig{
+				FrontendURL: "https://tokenkey.dev",
+			},
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "https://tokenkey.dev/api/v1/auth/refresh", nil)
+	ginCtx.Request.Header.Set("X-Forwarded-Proto", "https")
+	ginCtx.Request.AddCookie(&http.Cookie{
+		Name:  tkRefreshSessionCookieName,
+		Value: encodeCookieValue("cookie-token"),
+		Path:  tkRefreshSessionCookiePath,
+	})
+
+	token, err := handler.resolveRefreshTokenForRequest(ginCtx, "body-token")
+	require.NoError(t, err)
+	require.Equal(t, "body-token", token)
+}
+
+func TestResolveRefreshTokenForRequestFallsBackToCookie(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := &AuthHandler{
+		cfg: &config.Config{
+			Server: config.ServerConfig{
+				FrontendURL: "https://tokenkey.dev",
+			},
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "https://tokenkey.dev/api/v1/auth/refresh", nil)
+	ginCtx.Request.Header.Set("X-Forwarded-Proto", "https")
+	ginCtx.Request.AddCookie(&http.Cookie{
+		Name:  tkRefreshSessionCookieName,
+		Value: encodeCookieValue("cookie-token"),
+		Path:  tkRefreshSessionCookiePath,
+	})
+
+	token, err := handler.resolveRefreshTokenForRequest(ginCtx, "")
+	require.NoError(t, err)
+	require.Equal(t, "cookie-token", token)
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 653,
-  "hash": "b6095e8948a09d0be41c7de5ea196ade02c33a690164961e98a611bc2703798b",
+  "hash": "3c94971e14b6476a64356cb88edb3320a5125faab81bfa04eba77edd1ac22530",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -164,13 +164,10 @@ export async function getCurrentUser() {
 export async function logout(): Promise<void> {
   const refreshToken = getRefreshToken()
 
-  // Try to revoke the refresh token on the server
-  if (refreshToken) {
-    try {
-      await apiClient.post('/auth/logout', { refresh_token: refreshToken })
-    } catch {
-      // Ignore errors - we still want to clear local state
-    }
+  try {
+    await apiClient.post('/auth/logout', refreshToken ? { refresh_token: refreshToken } : {})
+  } catch {
+    // Ignore errors - we still want to clear local state
   }
 
   clearAuthToken()
@@ -294,18 +291,19 @@ export async function prepareOAuthBindAccessTokenCookie(): Promise<void> {
  */
 export async function refreshToken(): Promise<RefreshTokenResponse> {
   const currentRefreshToken = getRefreshToken()
-  if (!currentRefreshToken) {
-    throw new Error('No refresh token available')
+  const payload = currentRefreshToken ? { refresh_token: currentRefreshToken } : {}
+
+  const { data } = await apiClient.post<RefreshTokenResponse>('/auth/refresh', payload)
+
+  if (data.access_token) {
+    setAuthToken(data.access_token)
   }
-
-  const { data } = await apiClient.post<RefreshTokenResponse>('/auth/refresh', {
-    refresh_token: currentRefreshToken
-  })
-
-  // Update tokens in localStorage
-  setAuthToken(data.access_token)
-  setRefreshToken(data.refresh_token)
-  setTokenExpiresAt(data.expires_in)
+  if (data.refresh_token) {
+    setRefreshToken(data.refresh_token)
+  }
+  if (data.expires_in) {
+    setTokenExpiresAt(data.expires_in)
+  }
 
   return data
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -156,8 +156,8 @@ apiClient.interceptors.response.use(
         const isAuthEndpoint =
           url.includes('/auth/login') || url.includes('/auth/register') || url.includes('/auth/refresh')
 
-        // If we have a refresh token and this is not an auth endpoint, try to refresh
-        if (refreshToken && !isAuthEndpoint) {
+        // Try refresh for protected endpoints; body token preferred, HttpOnly cookie fallback.
+        if (!isAuthEndpoint) {
           if (isRefreshing) {
             // Wait for the ongoing refresh to complete
             return new Promise((resolve, reject) => {
@@ -190,10 +190,10 @@ apiClient.interceptors.response.use(
             // Call refresh endpoint directly to avoid circular dependency
             const refreshResponse = await axios.post(
               `${getAPIBaseURL()}/auth/refresh`,
-              { refresh_token: refreshToken },
+              refreshToken ? { refresh_token: refreshToken } : {},
               // 显式设置超时：裸 axios 默认无限等待，若刷新请求挂起会导致 isRefreshing
               // 永远为 true，所有排队的 401 重试请求永久卡死，页面 loading 无法恢复。
-              { headers: { 'Content-Type': 'application/json' }, timeout: 30000 }
+              { headers: { 'Content-Type': 'application/json' }, timeout: 30000, withCredentials: true }
             )
 
             const refreshData = refreshResponse.data as ApiResponse<{

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -307,7 +307,7 @@ router.beforeEach(async (to, _from, next) => {
 
   // Restore auth state from localStorage on first navigation (page refresh)
   if (!authInitialized) {
-    authStore.checkAuth()
+    await authStore.checkAuth()
     authInitialized = true
   }
 

--- a/frontend/src/stores/__tests__/auth.spec.ts
+++ b/frontend/src/stores/__tests__/auth.spec.ts
@@ -161,7 +161,7 @@ describe('useAuthStore', () => {
   // --- checkAuth ---
 
   describe('checkAuth', () => {
-    it('从 localStorage 恢复持久化状态', () => {
+    it('从 localStorage 恢复持久化状态', async () => {
       localStorage.setItem('auth_token', 'saved-token')
       localStorage.setItem('auth_user', JSON.stringify(fakeUser))
 
@@ -169,35 +169,50 @@ describe('useAuthStore', () => {
       mockGetCurrentUser.mockResolvedValue({ data: fakeUser })
 
       const store = useAuthStore()
-      store.checkAuth()
+      await store.checkAuth()
 
       expect(store.token).toBe('saved-token')
       expect(store.user).toEqual(fakeUser)
       expect(store.isAuthenticated).toBe(true)
     })
 
-    it('localStorage 无数据时保持未认证状态', () => {
+    it('localStorage 无数据时保持未认证状态', async () => {
+      mockRefreshToken.mockRejectedValue(new Error('no cookie session'))
       const store = useAuthStore()
-      store.checkAuth()
+      await store.checkAuth()
 
       expect(store.token).toBeNull()
       expect(store.user).toBeNull()
       expect(store.isAuthenticated).toBe(false)
     })
 
-    it('localStorage 中用户数据损坏时清除状态', () => {
+    it('localStorage 无数据时可通过 HttpOnly cookie 恢复会话', async () => {
+      mockRefreshToken.mockResolvedValue(fakeAuthResponse)
+      mockGetCurrentUser.mockResolvedValue({ data: fakeUser })
+
+      const store = useAuthStore()
+      await store.checkAuth()
+
+      expect(mockRefreshToken).toHaveBeenCalledTimes(1)
+      expect(store.token).toBe('test-token-123')
+      expect(store.user).toEqual(fakeUser)
+      expect(store.isAuthenticated).toBe(true)
+      expect(localStorage.getItem('auth_token')).toBe('test-token-123')
+    })
+
+    it('localStorage 中用户数据损坏时清除状态', async () => {
       localStorage.setItem('auth_token', 'saved-token')
       localStorage.setItem('auth_user', 'invalid-json{{{')
 
       const store = useAuthStore()
-      store.checkAuth()
+      await store.checkAuth()
 
       expect(store.token).toBeNull()
       expect(store.user).toBeNull()
       expect(localStorage.getItem('auth_token')).toBeNull()
     })
 
-    it('恢复 refresh token 和过期时间', () => {
+    it('恢复 refresh token 和过期时间', async () => {
       const futureTs = String(Date.now() + 3600_000)
       localStorage.setItem('auth_token', 'saved-token')
       localStorage.setItem('auth_user', JSON.stringify(fakeUser))
@@ -207,19 +222,19 @@ describe('useAuthStore', () => {
       mockGetCurrentUser.mockResolvedValue({ data: fakeUser })
 
       const store = useAuthStore()
-      store.checkAuth()
+      await store.checkAuth()
 
       expect(store.isAuthenticated).toBe(true)
     })
 
-    it('离线恢复会保留本地会话且不立即请求用户接口', () => {
+    it('离线恢复会保留本地会话且不立即请求用户接口', async () => {
       localStorage.setItem('auth_token', 'saved-token')
       localStorage.setItem('auth_user', JSON.stringify(fakeUser))
       const onLine = vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false)
 
       try {
         const store = useAuthStore()
-        store.checkAuth()
+        await store.checkAuth()
 
         expect(store.isAuthenticated).toBe(true)
         expect(mockGetCurrentUser).not.toHaveBeenCalled()
@@ -238,7 +253,7 @@ describe('useAuthStore', () => {
 
       try {
         const store = useAuthStore()
-        store.checkAuth()
+        await store.checkAuth()
         onLine.mockReturnValue(true)
         mockGetCurrentUser.mockClear()
         window.dispatchEvent(new Event('online'))
@@ -263,7 +278,7 @@ describe('useAuthStore', () => {
 
       try {
         const store = useAuthStore()
-        store.checkAuth()
+        await store.checkAuth()
         onLine.mockReturnValue(true)
         window.dispatchEvent(new Event('online'))
         await Promise.resolve()
@@ -276,7 +291,7 @@ describe('useAuthStore', () => {
       }
     })
 
-    it('恢复持久化 pending auth session', () => {
+    it('恢复持久化 pending auth session', async () => {
       localStorage.setItem(
         'pending_auth_session',
         JSON.stringify({
@@ -286,9 +301,10 @@ describe('useAuthStore', () => {
           redirect: '/profile',
         })
       )
+      mockRefreshToken.mockRejectedValue(new Error('no cookie session'))
 
       const store = useAuthStore()
-      store.checkAuth()
+      await store.checkAuth()
 
       expect(store.hasPendingAuthSession).toBe(true)
       expect(store.pendingAuthSession).toEqual({
@@ -325,7 +341,7 @@ describe('useAuthStore', () => {
       expect(localStorage.getItem('pending_auth_session')).toBeNull()
     })
 
-    it('restores a persisted pending oauth session without requiring a token value', () => {
+    it('restores a persisted pending oauth session without requiring a token value', async () => {
       const firstStore = useAuthStore()
 
       firstStore.setPendingAuthSession({
@@ -339,7 +355,8 @@ describe('useAuthStore', () => {
 
       setActivePinia(createPinia())
       const restoredStore = useAuthStore()
-      restoredStore.checkAuth()
+      mockRefreshToken.mockRejectedValue(new Error('no cookie session'))
+      await restoredStore.checkAuth()
 
       expect(restoredStore.isAuthenticated).toBe(false)
       expect(restoredStore.hasPendingAuthSession).toBe(true)

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -115,7 +115,7 @@ export const useAuthStore = defineStore('auth', () => {
    * Call this on app startup to restore session
    * Also starts auto-refresh and immediately fetches latest user data
    */
-  function checkAuth(): void {
+  async function checkAuth(): Promise<void> {
     const savedToken = localStorage.getItem(AUTH_TOKEN_KEY)
     const savedUser = localStorage.getItem(AUTH_USER_KEY)
     const savedRefreshToken = localStorage.getItem(REFRESH_TOKEN_KEY)
@@ -150,6 +150,38 @@ export const useAuthStore = defineStore('auth', () => {
         console.error('Failed to parse saved user data:', error)
         clearAuth({ preservePendingAuthSession: true })
       }
+      return
+    }
+
+    if (!isBrowserOffline()) {
+      await bootstrapSessionFromCookie()
+    }
+  }
+
+  async function bootstrapSessionFromCookie(): Promise<void> {
+    try {
+      const response = await authAPI.refreshToken()
+      token.value = response.access_token
+      refreshTokenValue.value = response.refresh_token
+      localStorage.setItem(AUTH_TOKEN_KEY, response.access_token)
+      localStorage.setItem(REFRESH_TOKEN_KEY, response.refresh_token)
+
+      const meResponse = await authAPI.getCurrentUser()
+      const me = meResponse.data
+      if (me.run_mode) {
+        runMode.value = me.run_mode
+      }
+      const { run_mode: _run_mode, ...userData } = me
+      user.value = userData
+      localStorage.setItem(AUTH_USER_KEY, JSON.stringify(userData))
+      clearPendingAuthSession()
+
+      startAutoRefresh()
+      if (response.expires_in) {
+        scheduleTokenRefresh(response.expires_in)
+      }
+    } catch {
+      // No cross-subdomain session cookie; user stays logged out.
     }
   }
 


### PR DESCRIPTION
## 摘要

- 登录/刷新/OAuth 完成时，后端额外写入 HttpOnly `tk_refresh` cookie（`Domain=tokenkey.dev`、`Path=/api/v1/auth`）。
- `POST /auth/refresh` 支持 body 优先、cookie 兜底；登出与 revoke-all 同步清 cookie。
- 前端 `checkAuth()` 在 localStorage 为空时静默 cookie 续期，401 拦截器同样支持 cookie fallback。

配合 apex 域名阶段二：用户在 `api.tokenkey.dev` 上任意一次有效会话即可种下父域 cookie，切到 `tokenkey.dev` 后免重新登录。

## 风险

- 常规风险：仅 Web 会话层，Bearer + localStorage 主路径不变；CLI/API Key 无影响。
- `localhost`/纯 IP 环境不设置父域 cookie（行为与现网一致）。
- 建议在阶段二 Caddy 切换前先 merge 本 PR 并发 prod，给用户几天被动种 cookie 窗口。

## 验证

- `go test -tags=unit ./internal/handler -run 'TestRegistrableParentDomain|TestSetTkRefreshSessionCookie|TestClearTkRefreshSessionCookie|TestResolveRefreshToken'`
- `pnpm exec vitest run src/stores/__tests__/auth.spec.ts`（25 passed）
- `pnpm typecheck`
- `./scripts/preflight.sh` PASS
- 未验证：prod 现网 api→apex 跨子域手工验收（merge 后建议 spot check）

## 提交

- `0bad5168f` feat(auth): 父域 tk_refresh cookie 支持 apex/api 子域会话共享
- 最新提交：`0bad5168f`

upstream-touch-trivial sentinel-registry-reviewed