### PR TITLE
fix(quickstart): 修复模型持久化并优化工具接入页

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 653,
-  "hash": "3c94971e14b6476a64356cb88edb3320a5125faab81bfa04eba77edd1ac22530",
+  "hash": "3bfdddde37a5fca4f1f5639d1a29022f9f9cfdd9b5c4cb2c0b604851da5d33bf",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 653,
-  "hash": "3bfdddde37a5fca4f1f5639d1a29022f9f9cfdd9b5c4cb2c0b604851da5d33bf",
+  "hash": "ce5b68c01344e055349239636e8a6c05ca8f1e5fcab6b045c2d064efe053e8aa",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/keys/QuickstartClientPicker.vue
+++ b/frontend/src/components/keys/QuickstartClientPicker.vue
@@ -1,41 +1,33 @@
 <template>
   <div data-tk="quickstart-client-picker" class="space-y-3">
-    <div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+    <div class="flex flex-wrap items-baseline gap-x-4 gap-y-1">
       <h2 class="text-sm font-semibold text-gray-900 dark:text-white">
         {{ heading }}
       </h2>
-    </div>
 
-    <details
-      data-tk="quickstart-support-legend"
-      class="group rounded-md border border-gray-200 bg-white px-3 py-2 text-xs text-gray-500 dark:border-dark-600 dark:bg-dark-800 dark:text-gray-400"
-    >
-      <summary class="cursor-pointer select-none font-medium text-gray-600 dark:text-gray-300">
-        {{ t('quickstart.legendToggle') }}
-      </summary>
-      <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1">
+      <div
+        data-tk="quickstart-support-legend"
+        class="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] leading-snug text-gray-500 dark:text-gray-400"
+      >
         <span
-          v-for="tier in supportTierOrder"
+          v-for="(tier, index) in supportTierOrder"
           :key="tier"
           class="inline-flex items-center gap-1"
         >
+          <span v-if="index > 0" aria-hidden="true" class="text-gray-300 dark:text-dark-500">·</span>
           <span
-            v-if="tier === 'verified'"
-            class="inline-flex items-center rounded-md bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-700 dark:bg-emerald-900/25 dark:text-emerald-300"
+            class="inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide"
+            :class="[
+              supportMeta[tier].badgeClass,
+              tier === 'verified' ? 'uppercase' : '',
+            ]"
           >
             {{ supportMeta[tier].label }}
           </span>
-          <Icon
-            v-else
-            :name="supportMeta[tier].icon"
-            size="xs"
-            aria-hidden="true"
-            :class="supportMeta[tier].className"
-          />
           <span>{{ supportMeta[tier].detail }}</span>
         </span>
       </div>
-    </details>
+    </div>
 
     <p
       v-if="hasUnavailableClients"
@@ -84,10 +76,13 @@
               <Icon :name="client.icon" size="sm" aria-hidden="true" class="shrink-0" />
               <span class="min-w-0 flex-1 whitespace-nowrap">{{ client.name }}</span>
               <span
-                v-if="client.supportTier === 'verified'"
-                class="inline-flex shrink-0 items-center rounded-md bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-700 dark:bg-emerald-900/25 dark:text-emerald-300"
+                class="inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide"
+                :class="[
+                  supportMeta[client.supportTier].badgeClass,
+                  client.supportTier === 'verified' ? 'uppercase' : '',
+                ]"
               >
-                {{ supportMeta.verified.label }}
+                {{ supportMeta[client.supportTier].label }}
               </span>
             </button>
 
@@ -157,10 +152,9 @@ const emit = defineEmits<{
 }>()
 
 type PickerSupportMeta = Record<QuickstartClientSupportTier, {
-  icon: QuickstartClientIconName
   label: string
   detail: string
-  className: string
+  badgeClass: string
 }>
 
 const supportTierOrder: QuickstartClientSupportTier[] = ['verified', 'import', 'compatible']
@@ -168,10 +162,9 @@ const supportTierOrder: QuickstartClientSupportTier[] = ['verified', 'import', '
 const supportMeta = computed<PickerSupportMeta>(() =>
   supportTierOrder.reduce<PickerSupportMeta>((result, tier) => {
     result[tier] = {
-      icon: TK_CLIENT_SUPPORT_META[tier].icon,
       label: t(TK_CLIENT_SUPPORT_META[tier].labelKey),
       detail: t(TK_CLIENT_SUPPORT_META[tier].detailKey),
-      className: TK_CLIENT_SUPPORT_META[tier].legendClass,
+      badgeClass: TK_CLIENT_SUPPORT_META[tier].badgeClass,
     }
     return result
   }, {} as PickerSupportMeta),
@@ -191,10 +184,8 @@ function selectedUnavailableInGroup(group: QuickstartClientGroup): QuickstartCli
 
 function clientTitle(client: QuickstartClientOption): string {
   if (client.disabled) return client.disabledReason || t('quickstart.unavailableProtocol')
-  if (client.supportTier === 'verified') {
-    return `${client.name} - ${supportMeta.value.verified.label}`
-  }
-  return `${client.name} - ${supportMeta.value[client.supportTier].detail}`
+  const meta = supportMeta.value[client.supportTier]
+  return `${client.name} - ${meta.label}: ${meta.detail}`
 }
 
 function reasonId(groupId: string, clientId: string): string {

--- a/frontend/src/components/keys/QuickstartClientPicker.vue
+++ b/frontend/src/components/keys/QuickstartClientPicker.vue
@@ -15,16 +15,14 @@
           class="inline-flex items-center gap-1"
         >
           <span v-if="index > 0" aria-hidden="true" class="text-gray-300 dark:text-dark-500">·</span>
-          <span
-            class="inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide"
-            :class="[
-              supportMeta[tier].badgeClass,
-              tier === 'verified' ? 'uppercase' : '',
-            ]"
-          >
-            {{ supportMeta[tier].label }}
-          </span>
-          <span>{{ supportMeta[tier].detail }}</span>
+          <Icon
+            :name="supportMeta[tier].icon"
+            size="xs"
+            aria-hidden="true"
+            :class="supportMeta[tier].iconClass"
+          />
+          <span>{{ supportMeta[tier].label }}</span>
+          <span class="text-gray-400 dark:text-gray-500">— {{ supportMeta[tier].detail }}</span>
         </span>
       </div>
     </div>
@@ -74,15 +72,19 @@
               @click="selectClient(client)"
             >
               <Icon :name="client.icon" size="sm" aria-hidden="true" class="shrink-0" />
-              <span class="min-w-0 flex-1 whitespace-nowrap">{{ client.name }}</span>
+              <span class="min-w-0 flex-1 truncate">{{ client.name }}</span>
               <span
-                class="inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide"
-                :class="[
-                  supportMeta[client.supportTier].badgeClass,
-                  client.supportTier === 'verified' ? 'uppercase' : '',
-                ]"
+                data-tk="quickstart-tier-badge"
+                class="inline-flex shrink-0 items-center justify-center rounded-md p-1"
+                :class="supportMeta[client.supportTier].badgeClass"
+                :aria-label="`${supportMeta[client.supportTier].label}: ${supportMeta[client.supportTier].detail}`"
+                :title="`${supportMeta[client.supportTier].label}: ${supportMeta[client.supportTier].detail}`"
               >
-                {{ supportMeta[client.supportTier].label }}
+                <Icon
+                  :name="supportMeta[client.supportTier].icon"
+                  size="xs"
+                  aria-hidden="true"
+                />
               </span>
             </button>
 
@@ -152,8 +154,10 @@ const emit = defineEmits<{
 }>()
 
 type PickerSupportMeta = Record<QuickstartClientSupportTier, {
+  icon: QuickstartClientIconName
   label: string
   detail: string
+  iconClass: string
   badgeClass: string
 }>
 
@@ -162,8 +166,10 @@ const supportTierOrder: QuickstartClientSupportTier[] = ['verified', 'import', '
 const supportMeta = computed<PickerSupportMeta>(() =>
   supportTierOrder.reduce<PickerSupportMeta>((result, tier) => {
     result[tier] = {
+      icon: TK_CLIENT_SUPPORT_META[tier].icon,
       label: t(TK_CLIENT_SUPPORT_META[tier].labelKey),
       detail: t(TK_CLIENT_SUPPORT_META[tier].detailKey),
+      iconClass: TK_CLIENT_SUPPORT_META[tier].legendClass,
       badgeClass: TK_CLIENT_SUPPORT_META[tier].badgeClass,
     }
     return result

--- a/frontend/src/components/keys/QuickstartConnectionHealth.vue
+++ b/frontend/src/components/keys/QuickstartConnectionHealth.vue
@@ -1,49 +1,91 @@
 <template>
   <div
     data-tk="quickstart-connection-health"
-    class="rounded-lg border px-4 py-3"
-    :class="panelClass"
+    :class="rootClass"
   >
-    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-      <div class="flex min-w-0 items-start gap-2.5">
-        <span
-          class="mt-0.5 inline-flex h-2.5 w-2.5 shrink-0 rounded-full"
-          :class="dotClass"
-          aria-hidden="true"
-        />
-        <div class="min-w-0">
-          <p class="text-sm font-medium" :class="titleClass">
+    <template v-if="layout === 'inline'">
+      <div class="flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:gap-3">
+        <div class="flex shrink-0 flex-wrap gap-2">
+          <button
+            v-if="showTestButton"
+            type="button"
+            data-tk="quickstart-send-test"
+            class="btn btn-primary inline-flex items-center gap-1.5 text-sm"
+            :disabled="testDisabled"
+            @click="emit('runTest')"
+          >
+            <Icon v-if="testState?.status === 'running'" name="refresh" size="sm" class="animate-spin" />
+            <span>{{ testButtonLabel }}</span>
+          </button>
+          <button
+            v-if="showChangeKey"
+            type="button"
+            data-tk="quickstart-change-key"
+            class="btn btn-secondary text-sm"
+            @click="emit('changeKey')"
+          >
+            {{ t('quickstart.changeKey') }}
+          </button>
+        </div>
+
+        <div class="ml-auto flex min-w-0 items-center gap-2">
+          <span
+            class="inline-flex h-2 w-2 shrink-0 rounded-full"
+            :class="dotClass"
+            aria-hidden="true"
+          />
+          <p class="truncate text-sm font-medium" :class="titleClass">
             {{ statusTitle }}
-          </p>
-          <p v-if="statusDetail" class="mt-0.5 text-xs" :class="detailClass">
-            {{ statusDetail }}
+            <span v-if="statusDetail" class="font-normal" :class="detailClass">
+              · {{ statusDetail }}
+            </span>
           </p>
         </div>
       </div>
+    </template>
 
-      <div class="flex shrink-0 flex-wrap gap-2">
-        <button
-          v-if="showTestButton"
-          type="button"
-          data-tk="quickstart-send-test"
-          class="btn btn-primary inline-flex items-center gap-1.5 text-sm"
-          :disabled="testDisabled"
-          @click="emit('runTest')"
-        >
-          <Icon v-if="testState?.status === 'running'" name="refresh" size="sm" class="animate-spin" />
-          <span>{{ testButtonLabel }}</span>
-        </button>
-        <button
-          v-if="showChangeKey"
-          type="button"
-          data-tk="quickstart-change-key"
-          class="btn btn-secondary text-sm"
-          @click="emit('changeKey')"
-        >
-          {{ t('quickstart.changeKey') }}
-        </button>
+    <template v-else>
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex min-w-0 items-start gap-2.5">
+          <span
+            class="mt-0.5 inline-flex h-2.5 w-2.5 shrink-0 rounded-full"
+            :class="dotClass"
+            aria-hidden="true"
+          />
+          <div class="min-w-0">
+            <p class="text-sm font-medium" :class="titleClass">
+              {{ statusTitle }}
+            </p>
+            <p v-if="statusDetail" class="mt-0.5 text-xs" :class="detailClass">
+              {{ statusDetail }}
+            </p>
+          </div>
+        </div>
+
+        <div class="flex shrink-0 flex-wrap gap-2">
+          <button
+            v-if="showTestButton"
+            type="button"
+            data-tk="quickstart-send-test"
+            class="btn btn-primary inline-flex items-center gap-1.5 text-sm"
+            :disabled="testDisabled"
+            @click="emit('runTest')"
+          >
+            <Icon v-if="testState?.status === 'running'" name="refresh" size="sm" class="animate-spin" />
+            <span>{{ testButtonLabel }}</span>
+          </button>
+          <button
+            v-if="showChangeKey"
+            type="button"
+            data-tk="quickstart-change-key"
+            class="btn btn-secondary text-sm"
+            @click="emit('changeKey')"
+          >
+            {{ t('quickstart.changeKey') }}
+          </button>
+        </div>
       </div>
-    </div>
+    </template>
   </div>
 </template>
 
@@ -53,11 +95,15 @@ import { useI18n } from 'vue-i18n'
 import Icon from '@/components/icons/Icon.vue'
 import type { TestState } from '@/composables/useTkUseKey'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   testState: TestState | null
   setupBlocked?: boolean
   setupBlockedReason?: string
-}>()
+  /** inline: same row as transport/protocol picker; banner: standalone panel */
+  layout?: 'inline' | 'banner'
+}>(), {
+  layout: 'banner',
+})
 
 const emit = defineEmits<{
   runTest: []
@@ -105,19 +151,23 @@ const statusDetail = computed(() => {
   return ''
 })
 
-const panelClass = computed(() => {
+const rootClass = computed(() => {
+  if (props.layout === 'inline') {
+    return 'min-w-0 flex-1'
+  }
+  const panel = 'rounded-lg border px-4 py-3'
   if (props.setupBlocked) {
-    return 'border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/20'
+    return `${panel} border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/20`
   }
   switch (effectiveStatus.value) {
     case 'ok':
-      return 'border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-900/20'
+      return `${panel} border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-900/20`
     case 'error':
-      return 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20'
+      return `${panel} border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20`
     case 'running':
-      return 'border-primary-200 bg-primary-50 dark:border-primary-800 dark:bg-primary-900/20'
+      return `${panel} border-primary-200 bg-primary-50 dark:border-primary-800 dark:bg-primary-900/20`
     default:
-      return 'border-gray-200 bg-gray-50 dark:border-dark-600 dark:bg-dark-800/50'
+      return `${panel} border-gray-200 bg-gray-50 dark:border-dark-600 dark:bg-dark-800/50`
   }
 })
 

--- a/frontend/src/components/keys/UseKeyGuide.vue
+++ b/frontend/src/components/keys/UseKeyGuide.vue
@@ -400,30 +400,52 @@ const tk = useTkUseKey({
   baseRoot,
 })
 
-// (Re)load the live servable model menu whenever the key changes.
+// Reload the live servable model menu only when the key changes. Deep-link
+// model query updates must not re-fetch — loadModels() clears picks and the
+// temporary fallback to the first catalog entry was overwriting URL state.
 watch(
-  () => [props.apiKeyId, props.initialModel] as const,
-  async ([id, initialModel]) => {
+  () => props.apiKeyId,
+  async (id) => {
     if (id == null) return
     keyRevealed.value = false
     tk.testState.value = { status: 'idle' }
     await tk.loadModels()
-    const flavor = tk.applyInitialModel(initialModel)
-    if (!props.selectedClient) {
-      if (flavor === 'anthropic') activeClientTab.value = 'claude'
-      else if (flavor === 'gemini') activeClientTab.value = 'gemini'
-      else if (flavor === 'openai') activeClientTab.value = 'codex'
-    }
+    applyInitialModelSelection(props.initialModel)
   },
   { immediate: true },
 )
 
+watch(
+  () => props.initialModel,
+  (initialModel) => {
+    if (props.apiKeyId == null || tk.modelsLoading.value || !tk.modelsLoaded.value) return
+    applyInitialModelSelection(initialModel)
+  },
+)
+
+function applyInitialModelSelection(initialModel: string | null | undefined): void {
+  const flavor = tk.applyInitialModel(initialModel)
+  if (!props.selectedClient) {
+    if (flavor === 'anthropic') activeClientTab.value = 'claude'
+    else if (flavor === 'gemini') activeClientTab.value = 'gemini'
+    else if (flavor === 'openai') activeClientTab.value = 'codex'
+  }
+}
+
+// Template-facing refs (top-level so they auto-unwrap in the template).
+const tkModelsLoading = tk.modelsLoading
+const tkTestState = tk.testState
+watch(tkTestState, (state) => {
+  emit('testStateChange', { ...state })
+}, { deep: true, immediate: true })
+const tkIsCCOnly = tk.isClaudeCodeOnly
+
 // Models offered in the picker for the current flavor.
 const pickerModels = computed(() => (activeFlavor.value ? tk.modelsForFlavor(activeFlavor.value) : []))
 const selectedModel = computed(() => (activeFlavor.value ? tk.effectiveModel(activeFlavor.value) : ''))
-watch(selectedModel, (model) => {
-  if (model) emit('modelChange', model)
-}, { immediate: true })
+watch([selectedModel, tkModelsLoading], ([model, loading]) => {
+  if (model && !loading) emit('modelChange', model)
+})
 const showModelsCatalogEmpty = computed(() =>
   activeFlavor.value ? tk.shouldWarnModelsEmpty(activeFlavor.value) : false,
 )
@@ -437,16 +459,11 @@ const testErrorMessage = computed(() => tkTestState.value.reason === 'missing_to
 )
 function onPickModel(e: Event): void {
   const id = (e.target as HTMLSelectElement).value
-  if (activeFlavor.value) tk.setModel(activeFlavor.value, id)
+  if (activeFlavor.value) {
+    tk.setModel(activeFlavor.value, id)
+    emit('modelChange', id)
+  }
 }
-
-// Template-facing refs (top-level so they auto-unwrap in the template).
-const tkModelsLoading = tk.modelsLoading
-const tkTestState = tk.testState
-watch(tkTestState, (state) => {
-  emit('testStateChange', { ...state })
-}, { deep: true, immediate: true })
-const tkIsCCOnly = tk.isClaudeCodeOnly
 
 const maskedKey = computed(() => {
   const k = props.apiKey || ''

--- a/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
+++ b/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
@@ -497,3 +497,55 @@ describe('UseKeyModal — universal keys', () => {
     expect(wrapper.find('[data-tk="use-key-model-select"]').exists()).toBe(true)
   })
 })
+
+describe('UseKeyGuide — model picker persistence', () => {
+  it('keeps a manually picked model when the URL deep-link prop catches up', async () => {
+    getMePricingCatalog.mockResolvedValue({
+      models: [
+        { model_id: 'claude-fable-5', capabilities: [] },
+        { model_id: 'claude-sonnet-4-6', capabilities: [] },
+      ],
+    })
+
+    const wrapper = mountQuickstartGuide({
+      selectedClient: 'claude-code',
+      platform: 'anthropic',
+      routingMode: 'direct',
+      initialModel: null,
+    })
+    await flushPromises()
+
+    const select = wrapper.get('[data-tk="use-key-model-select"]')
+    expect((select.element as HTMLSelectElement).value).toBe('claude-fable-5')
+
+    await select.setValue('claude-sonnet-4-6')
+    await flushPromises()
+    expect((select.element as HTMLSelectElement).value).toBe('claude-sonnet-4-6')
+
+    await wrapper.setProps({ initialModel: 'claude-sonnet-4-6' })
+    await flushPromises()
+    expect((select.element as HTMLSelectElement).value).toBe('claude-sonnet-4-6')
+    expect(wrapper.emitted('modelChange')?.at(-1)).toEqual(['claude-sonnet-4-6'])
+  })
+
+  it('restores a deep-linked anthropic model after the live catalog loads', async () => {
+    getMePricingCatalog.mockResolvedValue({
+      models: [
+        { model_id: 'claude-fable-5', capabilities: [] },
+        { model_id: 'claude-sonnet-4-6', capabilities: [] },
+      ],
+    })
+
+    const wrapper = mountQuickstartGuide({
+      selectedClient: 'claude-code',
+      platform: 'anthropic',
+      routingMode: 'direct',
+      initialModel: 'claude-sonnet-4-6',
+    })
+    await flushPromises()
+
+    const select = wrapper.get('[data-tk="use-key-model-select"]')
+    expect((select.element as HTMLSelectElement).value).toBe('claude-sonnet-4-6')
+    expect(wrapper.emitted('modelChange')?.at(-1)).toEqual(['claude-sonnet-4-6'])
+  })
+})

--- a/frontend/src/constants/__tests__/clientIntegrations.tk.spec.ts
+++ b/frontend/src/constants/__tests__/clientIntegrations.tk.spec.ts
@@ -116,6 +116,16 @@ describe('resolveTkClientIntegrationUrl', () => {
 })
 
 describe('TokenKey client catalog', () => {
+  it('keeps every client docsUrl on https and off known-unstable hosts', () => {
+    for (const client of TK_CLIENT_CATALOG) {
+      expect(client.docsUrl, client.id).toMatch(/^https:\/\//)
+      // developers.openai.com/codex/* often 403 outside US egress (Vercel WAF).
+      expect(client.docsUrl, client.id).not.toMatch(/developers\.openai\.com\/codex/)
+      // qwenlm.github.io paths drift; prefer official GitHub repo.
+      expect(client.docsUrl, client.id).not.toMatch(/qwenlm\.github\.io/)
+    }
+  })
+
   it('has unique ids and one owner for Quickstart and Studio integrations', () => {
     expect(new Set(TK_CLIENT_CATALOG.map((client) => client.id)).size).toBe(TK_CLIENT_CATALOG.length)
     expect(TK_CLIENT_INTEGRATIONS.every((integration) =>

--- a/frontend/src/constants/clientIntegrations.tk.ts
+++ b/frontend/src/constants/clientIntegrations.tk.ts
@@ -116,7 +116,8 @@ export const TK_CLIENT_CATALOG: TkClientCatalogEntry[] = [
     supportTier: 'verified',
     action: 'copy-config',
     protocols: ['openai'],
-    docsUrl: 'https://developers.openai.com/codex/cli',
+    // Official OpenAI repo; developers.openai.com/codex/* is often 403/timeouts behind Vercel WAF.
+    docsUrl: 'https://github.com/openai/codex',
     surfaces: ['quickstart'],
     secretTransport: 'config',
     guideMode: 'native',
@@ -132,7 +133,7 @@ export const TK_CLIENT_CATALOG: TkClientCatalogEntry[] = [
     supportTier: 'compatible',
     action: 'copy-config',
     protocols: ['anthropic', 'openai'],
-    docsUrl: 'https://qwenlm.github.io/qwen-code-docs/en/users/configuration/model-providers',
+    docsUrl: 'https://github.com/QwenLM/qwen-code',
     surfaces: ['quickstart'],
     secretTransport: 'env-file',
     guideMode: 'qwen',

--- a/frontend/src/views/user/QuickstartView.vue
+++ b/frontend/src/views/user/QuickstartView.vue
@@ -22,14 +22,6 @@
             data-tk="quickstart-config-workspace"
             class="space-y-6 border-t border-gray-200 pt-6 dark:border-dark-700"
           >
-            <QuickstartConnectionHealth
-              :test-state="connectionTestState"
-              :setup-blocked="Boolean(selectedClientDisabledReason)"
-              :setup-blocked-reason="selectedClientDisabledReason || undefined"
-              @run-test="runConnectionTest"
-              @change-key="openAdvancedKeyOptions"
-            />
-
             <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div class="min-w-0">
                 <div class="flex flex-wrap items-center gap-2">
@@ -37,10 +29,14 @@
                     {{ selectedClient.name }}
                   </h2>
                   <span
-                    v-if="selectedClient.supportTier === 'verified'"
-                    class="inline-flex items-center rounded-md bg-emerald-50 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-emerald-700 dark:bg-emerald-900/25 dark:text-emerald-300"
+                    v-if="selectedClientSupportBadge"
+                    class="inline-flex items-center rounded-md px-2 py-0.5 text-xs font-semibold tracking-wide"
+                    :class="[
+                      selectedClientSupportBadge.badgeClass,
+                      selectedClientSupportBadge.tier === 'verified' ? 'uppercase' : '',
+                    ]"
                   >
-                    {{ t('quickstart.supportVerified') }}
+                    {{ selectedClientSupportBadge.label }}
                   </span>
                 </div>
                 <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
@@ -128,61 +124,82 @@
               </div>
             </details>
 
-            <template v-if="selectedKey && !selectedClientDisabledReason">
-              <div v-if="selectedClient.id === 'qwen-code'" class="flex flex-wrap items-center gap-3">
-                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('quickstart.protocol') }}</span>
-                <div
-                  data-tk="quickstart-protocol-picker"
-                  role="group"
-                  :aria-label="t('quickstart.protocol')"
-                  class="inline-flex rounded-lg border border-gray-200 p-1 dark:border-dark-600"
-                >
-                  <button
-                    v-for="protocol in qwenProtocols"
-                    :key="protocol.id"
-                    type="button"
-                    :data-tk="`quickstart-protocol-${protocol.id}`"
-                    :aria-pressed="selectedProtocol === protocol.id"
-                    :disabled="protocol.disabled"
-                    :title="protocol.disabled ? t('quickstart.unavailableProtocol') : undefined"
-                    :class="[
-                      selectedProtocol === protocol.id ? selectedOptionClass : idleOptionClass,
-                      protocol.disabled ? 'cursor-not-allowed opacity-45' : '',
-                    ]"
-                    class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
-                    @click="!protocol.disabled && onProtocolSelected(protocol.id)"
-                  >
-                    {{ protocol.label }}
-                  </button>
-                </div>
-              </div>
+            <QuickstartConnectionHealth
+              v-if="selectedClientDisabledReason"
+              layout="banner"
+              :test-state="connectionTestState"
+              setup-blocked
+              :setup-blocked-reason="selectedClientDisabledReason || undefined"
+              @change-key="openAdvancedKeyOptions"
+            />
 
-              <div v-if="selectedClient.id === 'codex-cli'" class="flex flex-wrap items-center gap-3">
-                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('quickstart.transport') }}</span>
-                <div
-                  data-tk="quickstart-transport-picker"
-                  role="group"
-                  :aria-label="t('quickstart.transport')"
-                  class="inline-flex rounded-lg border border-gray-200 p-1 dark:border-dark-600"
-                >
-                  <button
-                    v-for="transport in codexTransports"
-                    :key="transport.id"
-                    type="button"
-                    :data-tk="`quickstart-transport-${transport.id}`"
-                    :aria-pressed="selectedTransport === transport.id"
-                    :disabled="transport.disabled"
-                    :title="transport.disabled ? t('quickstart.websocketUnavailable') : undefined"
-                    :class="[
-                      selectedTransport === transport.id ? selectedOptionClass : idleOptionClass,
-                      transport.disabled ? 'cursor-not-allowed opacity-45' : '',
-                    ]"
-                    class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
-                    @click="!transport.disabled && onTransportSelected(transport.id)"
+            <template v-if="selectedKey && !selectedClientDisabledReason">
+              <div
+                data-tk="quickstart-connection-row"
+                class="flex w-full flex-wrap items-center gap-x-3 gap-y-2"
+              >
+                <div v-if="selectedClient.id === 'qwen-code'" class="flex flex-wrap items-center gap-3">
+                  <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('quickstart.protocol') }}</span>
+                  <div
+                    data-tk="quickstart-protocol-picker"
+                    role="group"
+                    :aria-label="t('quickstart.protocol')"
+                    class="inline-flex rounded-lg border border-gray-200 p-1 dark:border-dark-600"
                   >
-                    {{ transport.label }}
-                  </button>
+                    <button
+                      v-for="protocol in qwenProtocols"
+                      :key="protocol.id"
+                      type="button"
+                      :data-tk="`quickstart-protocol-${protocol.id}`"
+                      :aria-pressed="selectedProtocol === protocol.id"
+                      :disabled="protocol.disabled"
+                      :title="protocol.disabled ? t('quickstart.unavailableProtocol') : undefined"
+                      :class="[
+                        selectedProtocol === protocol.id ? selectedOptionClass : idleOptionClass,
+                        protocol.disabled ? 'cursor-not-allowed opacity-45' : '',
+                      ]"
+                      class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+                      @click="!protocol.disabled && onProtocolSelected(protocol.id)"
+                    >
+                      {{ protocol.label }}
+                    </button>
+                  </div>
                 </div>
+
+                <div v-if="selectedClient.id === 'codex-cli'" class="flex flex-wrap items-center gap-3">
+                  <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('quickstart.transport') }}</span>
+                  <div
+                    data-tk="quickstart-transport-picker"
+                    role="group"
+                    :aria-label="t('quickstart.transport')"
+                    class="inline-flex rounded-lg border border-gray-200 p-1 dark:border-dark-600"
+                  >
+                    <button
+                      v-for="transport in codexTransports"
+                      :key="transport.id"
+                      type="button"
+                      :data-tk="`quickstart-transport-${transport.id}`"
+                      :aria-pressed="selectedTransport === transport.id"
+                      :disabled="transport.disabled"
+                      :title="transport.disabled ? t('quickstart.websocketUnavailable') : undefined"
+                      :class="[
+                        selectedTransport === transport.id ? selectedOptionClass : idleOptionClass,
+                        transport.disabled ? 'cursor-not-allowed opacity-45' : '',
+                      ]"
+                      class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+                      @click="!transport.disabled && onTransportSelected(transport.id)"
+                    >
+                      {{ transport.label }}
+                    </button>
+                  </div>
+                </div>
+
+                <QuickstartConnectionHealth
+                  layout="inline"
+                  :test-state="connectionTestState"
+                  @run-test="runConnectionTest"
+                  @change-key="openAdvancedKeyOptions"
+                />
               </div>
 
               <UseKeyGuide
@@ -245,6 +262,7 @@ import type { TestState } from '@/composables/useTkUseKey'
 import {
   resolveTkClientIntegrationUrl,
   TK_QUICKSTART_CLIENTS,
+  TK_CLIENT_SUPPORT_META,
   type TkClientCatalogEntry,
 } from '@/constants/clientIntegrations.tk'
 import { flavorOfModel } from '@/composables/useTkUseKey'
@@ -315,6 +333,17 @@ const selectedClient = computed(() =>
 const selectedClientDescription = computed(() =>
   selectedClient.value ? t(`quickstart.clientDescriptions.${selectedClient.value.guideId}`) : '',
 )
+
+const selectedClientSupportBadge = computed(() => {
+  const client = selectedClient.value
+  if (!client) return null
+  const meta = TK_CLIENT_SUPPORT_META[client.supportTier]
+  return {
+    tier: client.supportTier,
+    label: t(meta.labelKey),
+    badgeClass: meta.badgeClass,
+  }
+})
 
 function maskKey(key: string) {
   if (key.length <= 14) return key

--- a/frontend/src/views/user/__tests__/QuickstartView.spec.ts
+++ b/frontend/src/views/user/__tests__/QuickstartView.spec.ts
@@ -231,8 +231,9 @@ describe('QuickstartView', () => {
     }
   })
 
-  it('renders connection health and collapsible advanced key options', async () => {
+  it('renders connection health inline with transport/protocol and collapsible advanced key options', async () => {
     const wrapper = await mountView()
+    expect(wrapper.find('[data-tk="quickstart-connection-row"]').exists()).toBe(true)
     expect(wrapper.find('[data-tk="quickstart-connection-health"]').exists()).toBe(true)
     expect(wrapper.find('[data-tk="quickstart-advanced-options"]').exists()).toBe(true)
     expect(wrapper.find('[data-tk="quickstart-send-test"]').exists()).toBe(true)
@@ -294,6 +295,15 @@ describe('QuickstartView', () => {
     for (const id of ['qwen-code', 'opencode', 'curl', 'python']) {
       expect(wrapper.get(`[data-tk="quickstart-client-${id}"]`).attributes('data-unavailable')).toBe('true')
     }
+  })
+
+  it('shows a support-tier badge on every client card, not only verified ones', async () => {
+    const wrapper = await mountView()
+    expect(wrapper.get('[data-tk="quickstart-client-claude-code"]').text()).toContain('quickstart.supportVerified')
+    expect(wrapper.get('[data-tk="quickstart-client-qwen-code"]').text()).toContain('quickstart.supportCompatible')
+    await wrapper.get('[data-tk="quickstart-client-qwen-code"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('quickstart.supportCompatible')
   })
 
   it('writes the selected model back to the URL without exposing the API key', async () => {

--- a/frontend/src/views/user/__tests__/QuickstartView.spec.ts
+++ b/frontend/src/views/user/__tests__/QuickstartView.spec.ts
@@ -297,10 +297,10 @@ describe('QuickstartView', () => {
     }
   })
 
-  it('shows a support-tier badge on every client card, not only verified ones', async () => {
+  it('shows a support-tier icon badge on every client card, not only verified ones', async () => {
     const wrapper = await mountView()
-    expect(wrapper.get('[data-tk="quickstart-client-claude-code"]').text()).toContain('quickstart.supportVerified')
-    expect(wrapper.get('[data-tk="quickstart-client-qwen-code"]').text()).toContain('quickstart.supportCompatible')
+    expect(wrapper.get('[data-tk="quickstart-client-claude-code"] [data-tk="quickstart-tier-badge"]').attributes('aria-label')).toContain('quickstart.supportVerified')
+    expect(wrapper.get('[data-tk="quickstart-client-qwen-code"] [data-tk="quickstart-tier-badge"]').attributes('aria-label')).toContain('quickstart.supportCompatible')
     await wrapper.get('[data-tk="quickstart-client-qwen-code"]').trigger('click')
     await nextTick()
     expect(wrapper.text()).toContain('quickstart.supportCompatible')


### PR DESCRIPTION
upstream-touch-trivial
sentinel-registry-reviewed

## 摘要

- 修复工具接入页选择模型后刷新被重置为 catalog 首项（`claude-fable-5`）的问题：`UseKeyGuide` 仅在 API Key 变更时重载 catalog，加载期间抑制 `modelChange` 回写 URL
- 连接测试按钮与状态移至「连接方式」同一行；图例内联于标题旁
- 工具卡片 supportTier 改为图标徽章（✓ / ↓ / 🔗），图例保留完整文字说明；选中工具标题区仍显示文字徽章
- 修正 Codex CLI / Qwen Code 客户端文档链接（`developers.openai.com/codex/*` 在亚太出口常 403；旧 qwenlm.github.io 路径已 404），改为官方 GitHub 仓库

## 风险

- 常规风险，仅影响用户端 Quickstart 页面 UI 与外链，无 API/Schema 变更
- 文档 URL 静态策略测试禁止回退到已知不稳定 host
- QuickstartClientPicker / QuickstartConnectionHealth 为 TK 专用组件，无 upstream 合并回退风险；UseKeyGuide / QuickstartView / clientIntegrations 变更落在既有 sentinel 锚点语义内

## 验证

- `./scripts/preflight.sh` PASS
- `pnpm exec vitest run src/views/user/__tests__/QuickstartView.spec.ts -t "support-tier"` PASS
- `pnpm exec vitest run src/constants/__tests__/clientIntegrations.tk.spec.ts` PASS
- prod SSM curl：`developers.openai.com/codex/cli` 200（us-east-1）；本地同 URL 403（Vercel WAF）

## 提交

- fcc350f68 fix(quickstart): 修复模型持久化并优化工具接入页布局与文档链接
- 832e8d2b3 fix(quickstart): 工具卡片 supportTier 改用图标徽章
- 最新提交：832e8d2b3