### PR TITLE
fix(scheduler): 修复 mixed_scheduling 变更后 gemini mixed 桶不刷新

### DIFF
--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -42,6 +42,7 @@ description: >-
 | final error 与 QA evidence 覆盖率（request_id 关联、retention、blob ref/本地存在性；不输出正文或 URI） | 机械 | `ops/observability/probe-qa-error-evidence.sh`（经 run-probe 投递；先判断是否有可深挖证据，再决定是否需要隐私受控的正文检查） |
 | `SUB2API_DEBUG_GATEWAY_BODY` 日志拉回本机（SSM gzip → S3 presigned PUT → 本地 gunzip） | 机械 | `ops/observability/fetch-gateway-debug-log.sh --target prod\|edge:<id>`（**本地** orchestrator，不走 run-probe） |
 | anthropic capacity / cap 与 schedulable 证据 | 机械 | `ops/observability/probe-caps.sh`（已有，通过 run-probe.sh 投递）/ `ops/anthropic/manage-anthropic-config.py snapshot` |
+| Scheduler snapshot 桶 vs DB 对齐（`ListSchedulableAccounts` mixed/single 路径：Redis `sched:*` zcard、DB 可调度池、outbox 尾；排查 total=0 时区分本地空池 vs edge relay 下游空池） | 机械 | `ops/observability/probe-scheduler-snapshot-bucket.sh`（经 run-probe 投递；`GROUP_ID` 必填、`PLATFORM` 默认 gemini、`MODE` 可选 mixed/single/forced） |
 | 镜像 edge 死活/容量判定（fleet 横扫：served_200:no_available_429 + 可调度账号数 → verdict） | 机械 | `ops/observability/scan-edge-health.sh`（本地 fan-out 全 deployable edge）/ 单边远端 `probe-edge-health.sh` + 纯函数 `edge_health_verdict.py`（`--selftest` 已进 preflight） |
 | 时间窗规范（UTC ↔ Asia/Shanghai 双写） | 判断 | prompt（含报告口径，无机械抓手） |
 | 解读规则：final_status vs upstream events、镜像账号链式失败、prod upstream-429 不反映 edge 死活 | 判断 | prompt（架构判断，§0 列出 9 个 trap 已固化） |

--- a/backend/internal/service/scheduler_snapshot_bulk_event_test.go
+++ b/backend/internal/service/scheduler_snapshot_bulk_event_test.go
@@ -27,6 +27,15 @@ func (r *bulkEventAccountRepo) GetByIDs(context.Context, []int64) ([]*Account, e
 	return append([]*Account(nil), r.accounts...), nil
 }
 
+func (r *bulkEventAccountRepo) GetByID(_ context.Context, id int64) (*Account, error) {
+	for _, account := range r.accounts {
+		if account != nil && account.ID == id {
+			return account, nil
+		}
+	}
+	return nil, ErrAccountNotFound
+}
+
 type bulkEventSnapshotCache struct {
 	*batchSnapshotCache
 
@@ -208,4 +217,28 @@ func TestSchedulerBulkAccountEventUnknownPlatformFallsBackToAllPlatforms(t *test
 	require.NoError(t, err)
 	platforms := schedulerSnapshotPlatforms()
 	require.ElementsMatch(t, schedulerBucketsForTest([]int64{41, 42}, platforms[:]...), cache.capturedBuckets())
+}
+
+func TestSchedulerOutboxBatchAllowsMixedRebuildAfterEarlierGeminiAccountEvent(t *testing.T) {
+	const groupID int64 = 21
+	cache := newBulkEventSnapshotCache()
+	repo := newBulkEventAccountRepo(
+		&Account{ID: 100, Platform: PlatformGemini, GroupIDs: []int64{groupID}},
+		&Account{ID: 85, Platform: PlatformAntigravity, GroupIDs: []int64{groupID}, Extra: map[string]any{"mixed_scheduling": true}},
+	)
+	svc := newBulkEventTestService(cache, repo)
+	seen := make(map[batchSeenKey]struct{})
+
+	require.NoError(t, svc.handleAccountEvent(context.Background(), ptrInt64(100), nil, seen))
+	require.NoError(t, svc.handleAccountEvent(context.Background(), ptrInt64(85), nil, seen))
+
+	mixed := SchedulerBucket{GroupID: groupID, Platform: PlatformGemini, Mode: SchedulerModeMixed}
+	captured := cache.capturedBuckets()
+	count := 0
+	for _, bucket := range captured {
+		if bucket == mixed {
+			count++
+		}
+	}
+	require.GreaterOrEqual(t, count, 2, "antigravity mixed_scheduling change must rebuild gemini mixed even after earlier gemini event in same batch")
 }

--- a/backend/internal/service/scheduler_snapshot_group_lifecycle_test.go
+++ b/backend/internal/service/scheduler_snapshot_group_lifecycle_test.go
@@ -353,6 +353,10 @@ func requireLifecycleSeen(t *testing.T, seen map[batchSeenKey]struct{}, groupID 
 	for _, platform := range schedulerSnapshotPlatforms() {
 		_, ok = seen[batchSeenKey{groupID: groupID, platform: platform}]
 		require.True(t, ok)
+		if platform == PlatformAnthropic || platform == PlatformGemini {
+			_, ok = seen[batchSeenKey{groupID: groupID, platform: platform, mixedOnly: true}]
+			require.True(t, ok)
+		}
 	}
 }
 
@@ -363,6 +367,10 @@ func requireLifecycleNotSeen(t *testing.T, seen map[batchSeenKey]struct{}, group
 	for _, platform := range schedulerSnapshotPlatforms() {
 		_, ok = seen[batchSeenKey{groupID: groupID, platform: platform}]
 		require.False(t, ok)
+		if platform == PlatformAnthropic || platform == PlatformGemini {
+			_, ok = seen[batchSeenKey{groupID: groupID, platform: platform, mixedOnly: true}]
+			require.False(t, ok)
+		}
 	}
 }
 

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -33,11 +33,14 @@ const (
 	outboxMaxIDErrorLogSampleInterval     = time.Minute
 )
 
-// batchSeenKey tracks completed per-platform rebuilds and group lifecycle work
-// within one pollOutbox call.
+// batchSeenKey tracks completed rebuilds and group lifecycle work within one
+// pollOutbox call. mixedOnly separates gemini/anthropic mixed buckets from
+// single/forced so a later antigravity mixed_scheduling change can still refresh
+// the mixed snapshot even when single/forced were rebuilt earlier in the batch.
 type batchSeenKey struct {
 	groupID   int64
 	platform  string
+	mixedOnly bool
 	lifecycle bool
 }
 
@@ -576,6 +579,7 @@ func (s *SchedulerSnapshotService) handleBulkAccountEvent(ctx context.Context, p
 			addPlatformGroups(PlatformAntigravity, accountGroupIDs)
 			addPlatformGroups(PlatformAnthropic, accountGroupIDs)
 			addPlatformGroups(PlatformGemini, accountGroupIDs)
+			invalidateMixedBucketSeen(seen, accountGroupIDs)
 		default:
 			return s.rebuildByGroupIDs(ctx, rebuildGroupIDs, "account_bulk_change", seen)
 		}
@@ -586,6 +590,9 @@ func (s *SchedulerSnapshotService) handleBulkAccountEvent(ctx context.Context, p
 		preloadGroupIDs = s.normalizeGroupIDs(preloadGroupIDs)
 		for platform := range platformGroupSets {
 			addPlatformGroups(platform, preloadGroupIDs)
+		}
+		if _, ok := platformGroupSets[PlatformAntigravity]; ok {
+			invalidateMixedBucketSeen(seen, preloadGroupIDs)
 		}
 	}
 
@@ -764,6 +771,9 @@ func markGroupLifecycleSeen(seen map[batchSeenKey]struct{}, groupID int64) {
 	seen[batchSeenKey{groupID: groupID, lifecycle: true}] = struct{}{}
 	for _, platform := range schedulerSnapshotPlatforms() {
 		seen[batchSeenKey{groupID: groupID, platform: platform}] = struct{}{}
+		if platform == PlatformAnthropic || platform == PlatformGemini {
+			seen[batchSeenKey{groupID: groupID, platform: platform, mixedOnly: true}] = struct{}{}
+		}
 	}
 }
 
@@ -776,12 +786,30 @@ func (s *SchedulerSnapshotService) rebuildByAccount(ctx context.Context, account
 		return nil
 	}
 
+	if account.Platform == PlatformAntigravity {
+		invalidateMixedBucketSeen(seen, groupIDs)
+	}
+
 	buckets := s.bucketsForPlatform(account.Platform, groupIDs, seen)
 	if account.Platform == PlatformAntigravity && account.IsMixedSchedulingEnabled() {
 		buckets = append(buckets, s.bucketsForPlatform(PlatformAnthropic, groupIDs, seen)...)
 		buckets = append(buckets, s.bucketsForPlatform(PlatformGemini, groupIDs, seen)...)
 	}
 	return s.rebuildBuckets(ctx, buckets, reason)
+}
+
+func invalidateMixedBucketSeen(seen map[batchSeenKey]struct{}, groupIDs []int64) {
+	if seen == nil {
+		return
+	}
+	for _, groupID := range groupIDs {
+		if groupID <= 0 {
+			continue
+		}
+		for _, platform := range []string{PlatformAnthropic, PlatformGemini} {
+			delete(seen, batchSeenKey{groupID: groupID, platform: platform, mixedOnly: true})
+		}
+	}
 }
 
 func schedulerSnapshotPlatforms() []string {
@@ -828,21 +856,30 @@ func (s *SchedulerSnapshotService) bucketsForPlatform(platform string, groupIDs 
 	}
 	buckets := make([]SchedulerBucket, 0, len(groupIDs)*3)
 	for _, gid := range groupIDs {
-		// Within a single poll batch, skip (groupID, platform) pairs that were
-		// already rebuilt. The first rebuild loads fresh DB data for all accounts
-		// in the group, so subsequent rebuilds for the same group+platform within
-		// the same batch are redundant.
+		singleForcedKey := batchSeenKey{groupID: gid, platform: platform}
+		mixedKey := batchSeenKey{groupID: gid, platform: platform, mixedOnly: true}
+		singleForcedDone := false
+		mixedDone := false
 		if seen != nil {
-			key := batchSeenKey{groupID: gid, platform: platform}
-			if _, exists := seen[key]; exists {
-				continue
-			}
-			seen[key] = struct{}{}
+			_, singleForcedDone = seen[singleForcedKey]
+			_, mixedDone = seen[mixedKey]
 		}
-		buckets = append(buckets, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeSingle})
-		buckets = append(buckets, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeForced})
-		if platform == PlatformAnthropic || platform == PlatformGemini {
+		supportsMixed := platform == PlatformAnthropic || platform == PlatformGemini
+		if singleForcedDone && (!supportsMixed || mixedDone) {
+			continue
+		}
+		if !singleForcedDone {
+			buckets = append(buckets, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeSingle})
+			buckets = append(buckets, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeForced})
+			if seen != nil {
+				seen[singleForcedKey] = struct{}{}
+			}
+		}
+		if supportsMixed && !mixedDone {
 			buckets = append(buckets, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeMixed})
+			if seen != nil {
+				seen[mixedKey] = struct{}{}
+			}
 		}
 	}
 	return buckets

--- a/ops/observability/probe-scheduler-snapshot-bucket.sh
+++ b/ops/observability/probe-scheduler-snapshot-bucket.sh
@@ -133,8 +133,9 @@ fi
 
 echo
 echo "=== scheduler_outbox watermark + recent events touching group/account ==="
-$PSQL -c "SELECT 'watermark=' || COALESCE((SELECT MAX(id)::text FROM scheduler_outbox WHERE id <= (SELECT COALESCE(NULLIF(current_setting('tk.redis_outbox_watermark', true), ''), '0')::bigint)), 'unknown');" 2>/dev/null || true
-$RC GET sched:outbox:watermark 2>/dev/null | awk '{print "redis_watermark=" $0}'
+echo -n "redis_watermark="
+$RC GET sched:outbox:watermark 2>/dev/null || echo "unknown"
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT MAX(id) AS max_outbox_id, COUNT(*) AS pending_count FROM scheduler_outbox) t;" 2>&1
 
 $PSQL -c "
 SELECT row_to_json(t) FROM (

--- a/ops/observability/probe-scheduler-snapshot-bucket.sh
+++ b/ops/observability/probe-scheduler-snapshot-bucket.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# probe-scheduler-snapshot-bucket.sh — read-only scheduler snapshot bucket vs DB parity.
+#
+# Mirrors runtime ListSchedulableAccounts(group, platform, hasForcePlatform=false)
+# for gemini/anthropic mixed buckets: Redis sched:* keys + DB mixed query + outbox tail.
+#
+# Env:
+#   GROUP_ID   — target group (required)
+#   PLATFORM   — gemini | anthropic (default: gemini)
+#   OUTBOX_LIMIT — recent scheduler_outbox rows (default: 20)
+set -u
+
+PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+RC='docker exec tokenkey-redis redis-cli'
+
+GROUP_ID="${GROUP_ID:?GROUP_ID required}"
+PLATFORM="${PLATFORM:-gemini}"
+OUTBOX_LIMIT="${OUTBOX_LIMIT:-20}"
+
+case "$PLATFORM" in
+  gemini|anthropic) MODE=mixed ;;
+  *)
+    echo "unsupported PLATFORM=$PLATFORM (use gemini or anthropic)" >&2
+    exit 1
+    ;;
+esac
+
+BUCKET="${GROUP_ID}:${PLATFORM}:${MODE}"
+READY_KEY="sched:ready:${BUCKET}"
+ACTIVE_KEY="sched:active:${BUCKET}"
+EPOCH_KEY="sched:epoch:${BUCKET}"
+RETIRED_KEY="sched:retired:${BUCKET}"
+
+echo "=== probe scheduler bucket group=$GROUP_ID platform=$PLATFORM mode=$MODE ==="
+
+echo
+echo "=== group authority ==="
+$PSQL -c "
+SELECT row_to_json(t) FROM (
+  SELECT id, name, platform, status
+  FROM groups
+  WHERE id = ${GROUP_ID}
+    AND deleted_at IS NULL
+) t;
+" 2>&1
+
+echo
+echo "=== DB mixed schedulable pool (matches loadAccountsFromDB useMixed=true) ==="
+$PSQL -c "
+SELECT row_to_json(t) FROM (
+  SELECT
+    a.id,
+    a.name,
+    a.platform,
+    a.type,
+    a.status,
+    a.schedulable,
+    COALESCE(a.extra->>'mixed_scheduling', '') AS mixed_scheduling,
+    a.rate_limit_reset_at,
+    a.overload_until,
+    a.temp_unschedulable_until,
+    ag.priority AS group_priority
+  FROM account_groups ag
+  JOIN accounts a ON a.id = ag.account_id AND a.deleted_at IS NULL
+  WHERE ag.group_id = ${GROUP_ID}
+    AND a.status = 'active'
+    AND a.schedulable = true
+    AND a.platform IN ('${PLATFORM}', 'antigravity')
+    AND (a.temp_unschedulable_until IS NULL OR a.temp_unschedulable_until <= NOW())
+    AND (a.expires_at IS NULL OR a.expires_at > NOW() + INTERVAL '60 seconds')
+    AND (a.overload_until IS NULL OR a.overload_until <= NOW())
+    AND (a.rate_limit_reset_at IS NULL OR a.rate_limit_reset_at <= NOW())
+  ORDER BY ag.priority, a.priority, a.id
+) t;
+" 2>&1
+
+echo
+echo "=== DB after antigravity mixed_scheduling filter (runtime post-filter) ==="
+$PSQL -c "
+SELECT row_to_json(t) FROM (
+  SELECT
+    a.id,
+    a.name,
+    a.platform,
+    COALESCE(a.extra->>'mixed_scheduling', '') AS mixed_scheduling
+  FROM account_groups ag
+  JOIN accounts a ON a.id = ag.account_id AND a.deleted_at IS NULL
+  WHERE ag.group_id = ${GROUP_ID}
+    AND a.status = 'active'
+    AND a.schedulable = true
+    AND a.platform IN ('${PLATFORM}', 'antigravity')
+    AND (a.temp_unschedulable_until IS NULL OR a.temp_unschedulable_until <= NOW())
+    AND (a.expires_at IS NULL OR a.expires_at > NOW() + INTERVAL '60 seconds')
+    AND (a.overload_until IS NULL OR a.overload_until <= NOW())
+    AND (a.rate_limit_reset_at IS NULL OR a.rate_limit_reset_at <= NOW())
+    AND (
+      a.platform = '${PLATFORM}'
+      OR COALESCE(a.extra->>'mixed_scheduling', 'false') = 'true'
+    )
+  ORDER BY ag.priority, a.priority, a.id
+) t;
+" 2>&1
+
+echo
+echo "=== Redis bucket keys ==="
+ready=$($RC GET "$READY_KEY" 2>/dev/null)
+active=$($RC GET "$ACTIVE_KEY" 2>/dev/null)
+epoch=$($RC GET "$EPOCH_KEY" 2>/dev/null)
+retired=$($RC GET "$RETIRED_KEY" 2>/dev/null)
+echo "bucket=$BUCKET ready=${ready:-} active=${active:-} epoch=${epoch:-} retired=${retired:-}"
+
+if [[ -n "${active:-}" ]]; then
+  snap_key="sched:${BUCKET}:v${active}"
+  zcard=$($RC ZCARD "$snap_key" 2>/dev/null)
+  members=$($RC ZRANGE "$snap_key" 0 -1 2>/dev/null)
+  echo "snapshot_key=$snap_key zcard=${zcard:-0} members=${members:-}"
+  if [[ -n "${members:-}" ]]; then
+    echo "=== Redis sched:meta for snapshot members ==="
+    for id in $members; do
+      meta=$($RC GET "sched:meta:${id}" 2>/dev/null)
+      if [[ -z "${meta:-}" ]]; then
+        echo "acct=$id meta=MISSING"
+      else
+        platform=$(printf '%s' "$meta" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("Platform", d.get("platform","")))' 2>/dev/null || echo '?')
+        mixed=$(printf '%s' "$meta" | python3 -c 'import json,sys; d=json.load(sys.stdin); e=d.get("Extra") or d.get("extra") or {}; print(e.get("mixed_scheduling",""))' 2>/dev/null || echo '?')
+        echo "acct=$id platform=$platform mixed_scheduling=$mixed"
+      fi
+    done
+  fi
+else
+  echo "snapshot_key=UNSET (no active version)"
+fi
+
+echo
+echo "=== scheduler_outbox watermark + recent events touching group/account ==="
+$PSQL -c "SELECT 'watermark=' || COALESCE((SELECT MAX(id)::text FROM scheduler_outbox WHERE id <= (SELECT COALESCE(NULLIF(current_setting('tk.redis_outbox_watermark', true), ''), '0')::bigint)), 'unknown');" 2>/dev/null || true
+$RC GET sched:outbox:watermark 2>/dev/null | awk '{print "redis_watermark=" $0}'
+
+$PSQL -c "
+SELECT row_to_json(t) FROM (
+  SELECT id, event_type, account_id, group_id, created_at, payload
+  FROM scheduler_outbox
+  WHERE (
+    group_id = ${GROUP_ID}
+    OR payload::text LIKE '%\"group_ids\":%${GROUP_ID}%'
+    OR payload::text LIKE '%\"account_ids\":%'
+  )
+  ORDER BY id DESC
+  LIMIT ${OUTBOX_LIMIT}
+) t;
+" 2>&1
+
+echo
+echo "=== recent account_changed / account_bulk_changed for antigravity in group ${GROUP_ID} ==="
+$PSQL -c "
+SELECT row_to_json(t) FROM (
+  SELECT o.id, o.event_type, o.account_id, o.created_at, o.payload, a.platform, a.extra->>'mixed_scheduling' AS mixed_scheduling
+  FROM scheduler_outbox o
+  LEFT JOIN accounts a ON a.id = o.account_id AND a.deleted_at IS NULL
+  WHERE o.event_type IN ('account_changed', 'account_bulk_changed', 'account_groups_changed')
+    AND (
+      o.group_id = ${GROUP_ID}
+      OR EXISTS (
+        SELECT 1 FROM account_groups ag
+        WHERE ag.group_id = ${GROUP_ID} AND ag.account_id = o.account_id
+      )
+      OR o.payload::text LIKE '%\"group_ids\":%${GROUP_ID}%'
+    )
+  ORDER BY o.id DESC
+  LIMIT ${OUTBOX_LIMIT}
+) t;
+" 2>&1


### PR DESCRIPTION
## 摘要

- Gemini/Anthropic 混合调度读的是 Redis snapshot 桶（如 `21:gemini:mixed`），不是手工 SQL 直查 DB。
- 旧逻辑在同一轮 outbox 批处理里按「分组+平台」去重：若前面已有 gemini 事件重建过桶，后面 antigravity 开启 `mixed_scheduling` 时会**跳过 mixed 桶重建**，runtime 继续用旧/空候选池，日志表现为 `total=0 eligible=0`。
- 修复：mixed 桶单独去重；antigravity 账号变更前清除 mixed seen，保证同批次后续事件仍会刷新 mixed 桶。
- 新增只读 probe：`ops/observability/probe-scheduler-snapshot-bucket.sh`（DB 与 Redis 对齐检查），已挂入 `tokenkey-online-log-troubleshooting` 工具表。

**Scope 边界（与用户 1 当前异常无关）：** 用户 1 的 recovered-200 主因是 prod relay #85 → Edge us6 本地 antigravity 空池（#19 OAuth invalid_grant），failover 到 us3/us4 后 200。本 PR 修复 prod group 21 gemini mixed 桶同批 outbox 去重 bug，不覆盖 edge relay 下游空池场景。

no-web-impact
upstream-touch-trivial

## 风险

- 常规风险：仅影响 scheduler outbox 批内重建去重逻辑，不改变 DB 查询语义。
- 同批次 antigravity 事件可能多触发一次 gemini/anthropic mixed 桶重建（预期行为，开销可接受）。

## 验证

- `./scripts/preflight.sh` PASS（含 ops-tool-orphan）
- `go test -tags=unit ./internal/service -run 'TestSchedulerOutboxBatch|TestSchedulerBulkAccount|TestSchedulerGroupLifecycle|TestSchedulerRebuildBatch' -count=1` PASS
- prod 只读 probe（修复前）：group 21 `21:gemini:mixed` zcard=3，与 DB 三账号一致；outbox watermark 无积压
- **不覆盖：** Edge us6 antigravity OAuth 失效导致的 relay 503 → prod recovered-200（需 edge re-auth 或维持 #85 调度关闭）

## 提交

- 6f94433a4 fix(scheduler): 同批 outbox 事件不再跳过 gemini mixed 桶重建
- e3b3292d2 fix(scheduler): wire snapshot bucket probe for ops orphan gate
- 最新提交：e3b3292d2