### PR TITLE
fix(smoke): 人类/公开面探针走 apex（阶段二）

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -152,6 +152,8 @@ OAuth / 支付 webhook URL **保持** `api.tokenkey.dev`（与 Caddy `@machine` 
 
 正常 Stage0 发版即可；index.html meta 变更需新镜像才在用户侧生效。
 
+**deploy-stage0 smoke（阶段二）**：`TOKENKEY_BASE_URL` 仍为 `https://api.tokenkey.dev`（`/v1/*`、`/health`）；`/api/v1/settings/public` 与前端 `/assets/*` 由 `ops/stage0/smoke_lib.sh` 自动打 apex（`https://tokenkey.dev`）。`ops/observability/probe-release-control-plane.sh` 同理：`PROD_BASE_URL` 管 health，`settings/public` 走推导 apex。
+
 **回滚**：`sync_caddyfile` 从 backup 恢复阶段一 Caddyfile；Settings 改回；DNS 不动。
 
 ### 把 #811 的 swap + 内存压力告警落到「已经在跑」的 prod（不重建实例）
@@ -663,7 +665,7 @@ python3 scripts/stage0/check_smoke_config.py
 
 #### deploy-stage0 发版后网关烟测（强制）
 
-Workflow 在 `/health` 之后会执行 `ops/stage0/post_deploy_smoke.sh`（`GATEWAY_SMOKE_SUITE=full`）。必须在 **`prod`** Environment 配置上表 **`TK_SMOKE_API_KEY` secret**；未配置则 deploy **失败**。Secret 必须在 **`api.tokenkey.dev`（prod 栈）** 下有效。
+Workflow 在 `/health` 之后会执行 `ops/stage0/post_deploy_smoke.sh`（`GATEWAY_SMOKE_SUITE=full`）。必须在 **`prod`** Environment 配置上表 **`TK_SMOKE_API_KEY` secret**；未配置则 deploy **失败**。Secret 必须在 **`api.tokenkey.dev`（prod 栈）** 下有效。人类/公开面探针（`settings/public`、前端 assets）在 apex 阶段二后自动走 `https://tokenkey.dev`；gateway 探针仍用 `TOKENKEY_BASE_URL`（`api.*`）。
 
 本地复现（与 CI 同一套 `TK_SMOKE_*` 名字；**GitHub secret 值无法经 gh/API 读取**，须在本机 export 同名变量）：
 

--- a/ops/observability/probe-release-control-plane.sh
+++ b/ops/observability/probe-release-control-plane.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # probe-release-control-plane.sh — read-only post-release control-plane health.
 #
-# Checks prod /health + /api/v1/settings/public and each deployable Edge /health.
+# Checks prod /health (api.* gateway) + /api/v1/settings/public (apex human
+# surface after phase 2) and each deployable Edge /health.
 # This mechanizes the tokenkey-stage0-release-rollout follow-up control-plane
 # step so operators do not hand-roll jq/curl loops during a release.
 #
@@ -10,6 +11,8 @@
 #   - a final SUMMARY JSON object with ok/total/failures.
 #
 # Env:
+#   PROD_BASE_URL=https://api.tokenkey.dev  gateway /health (machine path)
+#   PROD_SITE_BASE_URL optional; defaults from PROD_BASE_URL (api.* → apex)
 #   EDGE_IDS=us3,us4 limits edges; EDGE_IDS=none checks prod only.
 #
 # Usage:
@@ -32,7 +35,11 @@ fi
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
+# shellcheck source=../stage0/smoke_lib.sh
+source "${REPO_ROOT}/ops/stage0/smoke_lib.sh"
+
 PROD_BASE_URL="${PROD_BASE_URL:-https://api.tokenkey.dev}"
+PROD_SITE_BASE_URL="$(smoke_human_base_url "${PROD_BASE_URL}")"
 CURL_TIMEOUT_SECONDS="${CURL_TIMEOUT_SECONDS:-10}"
 INCLUDE_SETTINGS_PUBLIC="${INCLUDE_SETTINGS_PUBLIC:-1}"
 EDGE_IDS="${EDGE_IDS:-}"
@@ -49,7 +56,7 @@ fi
 declare -a PROBES=()
 PROBES+=("prod health ${PROD_BASE_URL%/}/health")
 if [ "$INCLUDE_SETTINGS_PUBLIC" = "1" ]; then
-  PROBES+=("prod settings_public ${PROD_BASE_URL%/}/api/v1/settings/public")
+  PROBES+=("prod settings_public ${PROD_SITE_BASE_URL%/}/api/v1/settings/public")
 fi
 
 if [ "$EDGE_IDS" = "none" ]; then

--- a/ops/observability/test_probe_release_control_plane.py
+++ b/ops/observability/test_probe_release_control_plane.py
@@ -102,6 +102,52 @@ class ProbeReleaseControlPlaneTest(unittest.TestCase):
             self.assertIn("https://prod.example.test/api/v1/settings/public", urls)
             self.assertIn("https://api-us9.example.test/health", urls)
 
+    def test_prod_settings_public_uses_apex_when_gateway_is_api_subdomain(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            fakebin = tmp / "bin"
+            fakebin.mkdir()
+            (fakebin / "curl").write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    out=""
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        -o) out="$2"; shift 2 ;;
+                        -w) shift 2 ;;
+                        --max-time) shift 2 ;;
+                        -sS) shift ;;
+                        *) url="$1"; shift ;;
+                      esac
+                    done
+                    [ -n "$out" ] && printf '{"status":"ok"}' > "$out"
+                    printf '200 0.123'
+                    """
+                ),
+            )
+            (fakebin / "curl").chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{fakebin}:{os.environ.get('PATH', '')}",
+                "EDGE_IDS": "none",
+                "PROD_BASE_URL": "https://api.prod.example.test",
+            }
+            proc = subprocess.run(
+                ["bash", str(_SCRIPT)],
+                cwd=_REPO,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stderr + proc.stdout)
+            rows = [json.loads(line) for line in proc.stdout.splitlines() if line.startswith("{")]
+            urls = {row.get("url") for row in rows if "url" in row}
+            self.assertIn("https://api.prod.example.test/health", urls)
+            self.assertIn("https://prod.example.test/api/v1/settings/public", urls)
+            self.assertNotIn("https://api.prod.example.test/api/v1/settings/public", urls)
+
     def test_failure_exits_nonzero_and_summarizes(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp = pathlib.Path(td)

--- a/ops/stage0/gateway_smoke.sh
+++ b/ops/stage0/gateway_smoke.sh
@@ -16,8 +16,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=smoke_lib.sh
+source "${SCRIPT_DIR}/smoke_lib.sh"
 BASE="${TOKENKEY_BASE_URL:-${TK_GATEWAY_URL:-}}"
 BASE="${BASE%/}"
+HUMAN_BASE="$(smoke_human_base_url "${BASE}")"
 
 if [[ -z "${BASE}" ]]; then
   echo "tk_gateway_smoke: set TOKENKEY_BASE_URL (or TK_GATEWAY_URL)." >&2
@@ -37,7 +40,7 @@ fi
 command -v curl >/dev/null 2>&1 || { echo "tk_gateway_smoke: curl not on PATH" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "tk_gateway_smoke: jq not on PATH" >&2; exit 1; }
 
-PUB="${BASE}/api/v1/settings/public"
+PUB="${HUMAN_BASE}/api/v1/settings/public"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 

--- a/ops/stage0/post_deploy_smoke.sh
+++ b/ops/stage0/post_deploy_smoke.sh
@@ -54,6 +54,7 @@ source "${SCRIPT_DIR}/smoke_env.sh"
 
 BASE="${TOKENKEY_BASE_URL:-${TK_GATEWAY_URL:-}}"
 BASE="${BASE%/}"
+HUMAN_BASE="$(smoke_human_base_url "${BASE}")"
 
 API_KEY="${TK_SMOKE_API_KEY:-}"
 
@@ -72,10 +73,10 @@ command -v jq >/dev/null 2>&1 || { echo "tk_post_deploy_smoke: jq not on PATH" >
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
-echo "tk_post_deploy_smoke: base_url=${BASE} suite=${GATEWAY_SMOKE_SUITE} key=configured"
+echo "tk_post_deploy_smoke: gateway_base_url=${BASE} human_base_url=${HUMAN_BASE} suite=${GATEWAY_SMOKE_SUITE} key=configured"
 
-# --- 1) Public settings (cold path) ---
-pub_http=$(curl -sS -o "$tmpdir/pub.json" -w "%{http_code}" "${BASE}/api/v1/settings/public")
+# --- 1) Public settings (cold path; human-facing → apex after phase 2) ---
+pub_http=$(curl -sS -o "$tmpdir/pub.json" -w "%{http_code}" "${HUMAN_BASE}/api/v1/settings/public")
 echo "tk_post_deploy_smoke: GET .../api/v1/settings/public -> HTTP ${pub_http}"
 if [[ "${pub_http}" != "200" ]]; then
   echo "tk_post_deploy_smoke: public settings failed" >&2
@@ -100,7 +101,7 @@ if smoke_suite_runs frontend && [[ "${TK_SMOKE_SKIP_FRONTEND:-}" != "1" ]]; then
   repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   check_script="${repo_root}/scripts/checks/frontend-release-assets.py"
   if [[ -f "${check_script}" ]]; then
-    python3 "${check_script}" --url "${BASE}"
+    python3 "${check_script}" --url "${HUMAN_BASE}"
   else
     echo "tk_post_deploy_smoke: missing ${check_script}" >&2
     exit 1
@@ -109,7 +110,7 @@ if smoke_suite_runs frontend && [[ "${TK_SMOKE_SKIP_FRONTEND:-}" != "1" ]]; then
   missing_asset_headers="$tmpdir/missing-asset.headers"
   missing_asset_body="$tmpdir/missing-asset.body"
   missing_asset_http=$(curl -sS -o "$missing_asset_body" -D "$missing_asset_headers" -w "%{http_code}" \
-    "${BASE}/assets/TokenKeyMissingAsset-smoke.js")
+    "${HUMAN_BASE}/assets/TokenKeyMissingAsset-smoke.js")
   echo "tk_post_deploy_smoke: GET .../assets/TokenKeyMissingAsset-smoke.js -> HTTP ${missing_asset_http}"
   if [[ "${missing_asset_http}" != "404" ]]; then
     echo "tk_post_deploy_smoke: missing static asset should return HTTP 404" >&2

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -52,6 +52,31 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
     printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.220 (external, cli)}"
   }
 
+  # smoke_human_base_url GATEWAY_BASE
+  # Human-facing / public SPA paths (settings/public, /assets/*) follow apex
+  # after Caddy apex-domain phase 2. Gateway machine paths (/v1/*, /health) stay
+  # on TOKENKEY_BASE_URL (typically api.*). Explicit override:
+  #   TOKENKEY_SITE_BASE_URL / TK_SMOKE_SITE_BASE_URL / PROD_SITE_BASE_URL
+  smoke_human_base_url() {
+    local gateway_base="${1:-}"
+    gateway_base="${gateway_base%/}"
+    local explicit="${TOKENKEY_SITE_BASE_URL:-${TK_SMOKE_SITE_BASE_URL:-${PROD_SITE_BASE_URL:-}}}"
+    explicit="${explicit%/}"
+    if [[ -n "${explicit}" ]]; then
+      printf '%s' "${explicit}"
+      return 0
+    fi
+    if [[ "${gateway_base}" =~ ^https://api\.(.+)$ ]]; then
+      printf 'https://%s' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+    if [[ "${gateway_base}" =~ ^http://api\.(.+)$ ]]; then
+      printf 'http://%s' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+    printf '%s' "${gateway_base}"
+  }
+
   # smoke_model_list RAW DEFAULT
   # Prints a newline-delimited model list. RAW may be comma or whitespace
   # separated so GitHub Environment vars can stay compact.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -233,7 +233,7 @@ if command -v python3 >/dev/null 2>&1; then
     _bg_spawn redactor_test bash ./scripts/agent/redact-stream_test.sh
     _bg_spawn smoke_unittest python3 -m unittest scripts.test_smoke_suite \
         scripts.test_edge_smoke_phase_contract scripts.test_smoke_env \
-        scripts.test_load_smoke_github_env -q
+        scripts.test_smoke_lib scripts.test_load_smoke_github_env -q
 fi
 _bg_spawn ssm_parse bash ./scripts/checks/check-stage0-ssm-host-parse.sh
 

--- a/scripts/stage0/smoke_env.py
+++ b/scripts/stage0/smoke_env.py
@@ -6,6 +6,7 @@ import os
 from scripts.stage0.load_smoke_github_env import apply_github_env
 
 DEFAULT_PROD_BASE_URL = "https://api.tokenkey.dev"
+DEFAULT_PROD_SITE_BASE_URL = "https://tokenkey.dev"
 DEFAULT_EDGE_LOCAL_ANTHROPIC_MODEL = "claude-sonnet-4-6"
 
 
@@ -48,6 +49,22 @@ def _split_models(raw: str, default: list[str]) -> list[str]:
 
 def edge_canary_base_url() -> str:
     return _env("TK_SMOKE_EDGE_CANARY_BASE_URL") or DEFAULT_PROD_BASE_URL
+
+
+def human_base_url(gateway_base: str | None = None) -> str:
+    explicit = (
+        _env("TOKENKEY_SITE_BASE_URL")
+        or _env("TK_SMOKE_SITE_BASE_URL")
+        or _env("PROD_SITE_BASE_URL")
+    )
+    if explicit:
+        return explicit.rstrip("/")
+    base = (gateway_base or _env("TOKENKEY_BASE_URL") or _env("TK_GATEWAY_URL") or DEFAULT_PROD_BASE_URL).rstrip("/")
+    for prefix in ("https://api.", "http://api."):
+        if base.startswith(prefix):
+            scheme = prefix.split("://", 1)[0]
+            return f"{scheme}://{base[len(prefix):]}"
+    return base
 
 
 def edge_local_chat_model() -> str:

--- a/scripts/test_smoke_env.py
+++ b/scripts/test_smoke_env.py
@@ -31,6 +31,7 @@ class SmokeEnvTest(unittest.TestCase):
     def test_edge_defaults_when_unset(self) -> None:
         with mock.patch.dict(os.environ, {}, clear=True):
             self.assertEqual(smoke_env.edge_canary_base_url(), smoke_env.DEFAULT_PROD_BASE_URL)
+            self.assertEqual(smoke_env.human_base_url(), smoke_env.DEFAULT_PROD_SITE_BASE_URL)
             self.assertEqual(smoke_env.gemini_models(), [])
             self.assertEqual(
                 smoke_env.edge_local_chat_model(),

--- a/scripts/test_smoke_lib.py
+++ b/scripts/test_smoke_lib.py
@@ -13,11 +13,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SMOKE_LIB = REPO_ROOT / "ops" / "stage0" / "smoke_lib.sh"
 
 
-def _run_helper(fn: str, models_file: Path, model: str) -> subprocess.CompletedProcess[str]:
+def _run_bash(source: str) -> subprocess.CompletedProcess[str]:
     script = f"""
 set -euo pipefail
 source "{SMOKE_LIB}"
-{fn} "{models_file}" "{model}"
+{source}
 """
     return subprocess.run(
         ["bash", "-c", script],
@@ -25,6 +25,41 @@ source "{SMOKE_LIB}"
         capture_output=True,
         check=False,
     )
+
+
+def _run_helper(fn: str, models_file: Path, model: str) -> subprocess.CompletedProcess[str]:
+    return _run_bash(f'{fn} "{models_file}" "{model}"')
+
+
+class SmokeLibHumanBaseURLTest(unittest.TestCase):
+    def test_derives_apex_from_api_subdomain(self) -> None:
+        proc = _run_bash('smoke_human_base_url "https://api.tokenkey.dev"')
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "https://tokenkey.dev")
+
+    def test_keeps_localhost_single_host(self) -> None:
+        proc = _run_bash('smoke_human_base_url "http://127.0.0.1:8088"')
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "http://127.0.0.1:8088")
+
+    def test_respects_explicit_site_override(self) -> None:
+        proc = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"""
+set -euo pipefail
+source "{SMOKE_LIB}"
+export TOKENKEY_SITE_BASE_URL=https://custom.example.test
+smoke_human_base_url "https://api.tokenkey.dev"
+""",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "https://custom.example.test")
 
 
 class SmokeLibAnthropicModelListTest(unittest.TestCase):


### PR DESCRIPTION
## 摘要

- apex 阶段二后，`api.*` 上非 `@machine` 的 `/api/v1/settings/public` 会 301 到 apex，导致 `deploy-stage0` 冒烟失败
- 新增 `smoke_human_base_url()`：`TOKENKEY_BASE_URL` / `PROD_BASE_URL` 仍用于 `/v1/*`、`/health`；人类/公开面（`settings/public`、前端 `/assets/*`）自动打 apex
- 同步更新 `probe-release-control-plane.sh` 与单元测试

## 风险

- 常规风险：仅 ops smoke / 观测脚本，无后端行为变更
- Edge / localhost 单 host 场景：`api.` 前缀不存在时 human base 与 gateway base 相同，行为不变

## 验证

```bash
bash -n ops/stage0/smoke_lib.sh ops/stage0/post_deploy_smoke.sh ops/stage0/gateway_smoke.sh ops/observability/probe-release-control-plane.sh
python3 -m unittest scripts.test_smoke_lib scripts.test_smoke_env ops.observability.test_probe_release_control_plane -q
# Ran 18 tests — OK
```

合并后可 re-dispatch `deploy-stage0.yml` 验证 v1.8.123 smoke 全绿。

## 提交

- 85b8db9d7 fix(smoke): probe human/public paths on apex after phase 2

最新提交：85b8db9d7

Made with [Cursor](https://cursor.com)