### PR TITLE
fix(modelops): 从 ainzy #76 mapping floor 移除 gpt-5.3-codex-spark

### DIFF
--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -150,14 +150,13 @@ var supportedOpenAICatalogModels = map[string]struct{}{
 
 // supportedOpenAIAinzyRelayCatalogModels — gpt IDs kept in the compiled
 // model_mapping floor for prod account 76 (api.ainzy.net/v1). Mirrors the
-// operator-applied 2026-07-09 runtime mapping so deploys do not re-narrow the
-// account back to a stale floor. codex-auto-review excluded — see
-// supportedOpenAICatalogModels.
+// operator-applied runtime mapping so deploys do not re-narrow the account
+// back to a stale floor. gpt-5.3-codex-spark excluded: 2026-07-28 prod probe
+// showed api.ainzy.net returns 404 for spark; OAuth/edge accounts serve it.
 var supportedOpenAIAinzyRelayCatalogModels = map[string]struct{}{
-	"gpt-5.3-codex-spark": {},
-	"gpt-5.4":             {},
-	"gpt-5.4-mini":        {},
-	"gpt-5.5":             {},
+	"gpt-5.4":      {},
+	"gpt-5.4-mini": {},
+	"gpt-5.5":      {},
 }
 
 // supportedGeminiCatalogModels — gemini/Vertex IDs confirmed servable through

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "floor_sha256": "ea117224b8d0cecf825b918da5f1b54280f132e689d796dbb29e326b91a3c1ef",
+  "floor_sha256": "903b2cf3ae800027b8807881e907debc8f909eaea9c84bd448f57d2fe25edffc",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -112,7 +112,6 @@
         "gpt-5.6-terra": "gpt-5.6-terra"
       },
       "openai_ainzy_relay": {
-        "gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
         "gpt-5.4": "gpt-5.4",
         "gpt-5.4-mini": "gpt-5.4-mini",
         "gpt-5.5": "gpt-5.5"


### PR DESCRIPTION
## 摘要

- prod 告警根因：账号 #76（`api.ainzy.net/v1` 第三方 apikey）的 `model_mapping` 含 `gpt-5.3-codex-spark`，但该厂商 API 实际返回 404；调度器仍会选中 #76，导致 GPT 专线对该模型的失败率飙升。
- 已从 `supportedOpenAIAinzyRelayCatalogModels` SSOT 移除 spark，并同步 `ops/pricing/model-surface-bundle.json`，避免下次 deploy 把错误 mapping floor 写回 #76。
- prod 侧已手工从 #76 运行时 mapping 去掉 spark（scheduler outbox 已触发）；本 PR 固化代码/契约，防止漂移。

## 风险

- 低风险：仅收窄 account #76（ainzy）的 compiled mapping floor，不影响 canonical OpenAI OAuth/edge 池对 spark 的服务能力。
- 若 ainzy 日后支持 spark，需 probe 确认 200 后再加回 SSOT + 运行时 mapping。

## 验证

- `./scripts/preflight.sh` — PASS
- `go test -tags=unit ./internal/service/... -run 'Ainzy|OpenAIAinzyRelayFloor'` — PASS
- prod 热修后观测：`gpt-5.3-codex-spark` 的 404/`account_id=76` 错误洪峰已停止（2026-07-28）

## 提交

- 5e8df3269 fix(modelops): drop spark from ainzy account-76 mapping floor

最新提交：5e8df3269

sentinel-registry-reviewed: 已从 ainzy SSOT 删除 empirically-404 的 spark 行；`pricing-availability.json` 锚点仍为 allowlist 函数/结构，无需随单行删除更新。