### PR TITLE
fix(admin): 修复创建用户时密码已填仍报「请填写此字段」

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 653,
-  "hash": "7d61d184abe68d36df06ddece8a115d651c365879406b52328c18019ca87a149",
+  "hash": "243a4f1ab1798a11c01b952a28c809da8b7951d2fd6e2f9f7a0c9ed038b83b1f",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/admin/UsersView.vue
+++ b/frontend/src/views/admin/UsersView.vue
@@ -767,9 +767,6 @@
     <UserCreateModal v-if="lazyMount('create', showCreateModal)" :show="showCreateModal" @close="showCreateModal = false" @success="loadUsers" />
     <InviteTrialModal v-if="lazyMount('invite', showInviteTrialModal)" :show="showInviteTrialModal" :seed="inviteSeed" @close="showInviteTrialModal = false" @success="loadUsers" />
     <UserEditModal v-if="lazyMount('edit', showEditModal)" :show="showEditModal" :user="editingUser" @close="closeEditModal" @success="loadUsers" />
-    <ConfirmDialog :show="showDeleteDialog" :title="t('admin.users.deleteUser')" :message="t('admin.users.deleteConfirm', { email: deletingUser?.email })" :danger="true" @confirm="confirmDelete" @cancel="showDeleteDialog = false" />
-    <UserCreateModal :show="showCreateModal" @close="showCreateModal = false" @success="loadUsers" />
-    <UserEditModal :show="showEditModal" :user="editingUser" @close="closeEditModal" @success="loadUsers" />
     <BulkEditUserModal
       :show="showBulkEditModal"
       :selected-ids="selectedIds"

--- a/frontend/src/views/admin/__tests__/UsersView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsersView.spec.ts
@@ -369,4 +369,47 @@ describe('admin UsersView', () => {
     expect(wrapper.find('[data-test="bulk-edit-limits"]').exists()).toBe(false)
     expect(wrapper.get('[data-test="selected-keys"]').text()).toBe('')
   })
+
+  it('mounts a single create-user form when opening the create modal', async () => {
+    const wrapper = mount(UsersView, {
+      attachTo: document.body,
+      global: {
+        stubs: {
+          AppLayout: { template: '<div><slot /></div>' },
+          TablePageLayout: {
+            template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
+          },
+          DataTable: DataTableStub,
+          Pagination: true,
+          ConfirmDialog: true,
+          EmptyState: true,
+          GroupBadge: true,
+          Select: true,
+          UserAttributesConfigModal: true,
+          UserConcurrencyCell: true,
+          UserEditModal: true,
+          BulkEditUserModal: BulkEditUserModalStub,
+          UserPlatformQuotaModal: true,
+          UserApiKeysModal: true,
+          UserAllowedGroupsModal: true,
+          UserBalanceModal: true,
+          UserBalanceHistoryModal: true,
+          GroupReplaceModal: true,
+          InviteTrialModal: true,
+          TotpStepUpDialog: true,
+          Icon: true,
+          Teleport: true
+        }
+      }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-testid="user-create-btn"]').trigger('click')
+    await flushPromises()
+
+    expect(document.querySelectorAll('#create-user-form').length).toBe(1)
+
+    wrapper.unmount()
+    document.body.innerHTML = ''
+  })
 })


### PR DESCRIPTION
## 摘要

- 移除 `UsersView.vue` 中 lazy-mount 引入后遗留的重复 `UserCreateModal` / `UserEditModal` / `ConfirmDialog`。
- 根因：两个 `UserCreateModal` 共用 `id="create-user-form"`，用户填写可见表单，但提交按钮关联到第一个空表单，触发浏览器 HTML5 必填校验。
- 新增回归测试：打开创建用户弹窗时 DOM 内仅存在一个 `#create-user-form`。
- 同步刷新 embedded frontend dist source manifest。

upstream-touch-trivial

## 风险

- 低风险，仅删除重复挂载的旧弹窗，保留 lazy-mount 版本，行为与 AccountsView 一致。
- 同时修复编辑用户、删除确认弹窗的潜在重复挂载问题。

## 验证

```bash
cd frontend && pnpm test:run src/views/admin/__tests__/UsersView.spec.ts
pnpm --dir frontend run build
python3 ./scripts/checks/frontend-dist-freshness.py --check ./backend/internal/web/dist
```

结果：4 passed；dist manifest 已刷新。

## 提交

- 3c13ec9e6 fix(admin): 移除 UsersView 重复弹窗以修复创建用户校验失败
- 1e84e7946 chore(frontend): refresh embedded dist source manifest after UsersView fix

最新提交：1e84e7946