### PR TITLE
fix(billing): 修复 Imagen overlay 在 token 结算路径漏计费

### DIFF
--- a/backend/internal/service/gateway_priced_serving_gate_tk.go
+++ b/backend/internal/service/gateway_priced_serving_gate_tk.go
@@ -253,6 +253,7 @@ func tkLogAndNotifyPricedServingGateRejection(
 	}
 	if apiKey != nil {
 		ev.APIKeyID = apiKey.ID
+		ev.UserID = apiKey.UserID
 	}
 	if group != nil {
 		ev.GroupID = group.ID

--- a/backend/internal/service/gateway_service_tk_served_zero_cost.go
+++ b/backend/internal/service/gateway_service_tk_served_zero_cost.go
@@ -86,6 +86,7 @@ func tkNotifyServedAtFallback(
 	}
 	if apiKey != nil {
 		ev.APIKeyID = apiKey.ID
+		ev.UserID = apiKey.UserID
 		if apiKey.Group != nil {
 			ev.GroupID = apiKey.Group.ID
 			ev.GroupName = apiKey.Group.Name
@@ -159,6 +160,7 @@ func (s *GatewayService) tkNotifyServedZeroCost(
 	}
 	if apiKey != nil {
 		ev.APIKeyID = apiKey.ID
+		ev.UserID = apiKey.UserID
 		if apiKey.Group != nil {
 			ev.GroupID = apiKey.Group.ID
 			ev.GroupName = apiKey.Group.Name

--- a/backend/internal/service/model_pricing_resolver.go
+++ b/backend/internal/service/model_pricing_resolver.go
@@ -87,6 +87,22 @@ func (r *ModelPricingResolver) Resolve(ctx context.Context, input PricingInput) 
 	// 1. 获取基础定价
 	basePricing, source := r.resolveBasePricing(input.Model)
 
+	// TK: image-only overlay rows (imagen-*, TokenPricingAbsent) fail-closed in
+	// GetModelPricing but must still bill when settlement hits the token path
+	// (ImageCount not propagated). Resolve them as per-image/per-request here.
+	if basePricing == nil {
+		if media := r.tkResolveOverlayMediaPerRequest(input.Model); media != nil {
+			if chPricing != nil {
+				media.Source = PricingSourceChannel
+				media.channelPricing = chPricing
+				if chPricing.BillingMode == BillingModePerRequest || chPricing.BillingMode == BillingModeImage {
+					r.applyRequestTierOverrides(chPricing, media)
+				}
+			}
+			return media
+		}
+	}
+
 	resolved := &ResolvedPricing{
 		Mode:                   BillingModeToken,
 		BasePricing:            basePricing,

--- a/backend/internal/service/model_pricing_resolver_tk_overlay_media.go
+++ b/backend/internal/service/model_pricing_resolver_tk_overlay_media.go
@@ -1,0 +1,33 @@
+package service
+
+// model_pricing_resolver_tk_overlay_media.go — image/video-only overlay → per-request resolver.
+//
+// BillingService.GetModelPricing intentionally fail-closes on TokenPricingAbsent
+// entries (imagen-*/veo-* overlay rows) so token traffic cannot silently bill $0.
+// When imagen traffic lands on the OpenAI token settlement path anyway (missing
+// ImageCount from a non-/images/generations shape, or bridge accounting gap),
+// ModelPricingResolver must still resolve a billable price from PricingService's
+// OutputCostPerImage instead of returning an empty token BasePricing → $0
+// served_zero_cost.
+
+// tkResolveOverlayMediaPerRequest returns per-request/image resolved pricing when
+// the model is priced only via OutputCostPerImage (TokenPricingAbsent) in
+// PricingService. nil when not applicable.
+func (r *ModelPricingResolver) tkResolveOverlayMediaPerRequest(model string) *ResolvedPricing {
+	if r == nil || r.billingService == nil || r.billingService.pricingService == nil {
+		return nil
+	}
+	lp := r.billingService.pricingService.GetModelPricing(model)
+	if lp == nil || !lp.TokenPricingAbsent || lp.OutputCostPerImage <= 0 {
+		return nil
+	}
+	mode := BillingModePerRequest
+	if lp.Mode == "image_generation" {
+		mode = BillingModeImage
+	}
+	return &ResolvedPricing{
+		Mode:                   mode,
+		DefaultPerRequestPrice: lp.OutputCostPerImage,
+		Source:                 PricingSourceLiteLLM,
+	}
+}

--- a/backend/internal/service/model_pricing_resolver_tk_overlay_media_test.go
+++ b/backend/internal/service/model_pricing_resolver_tk_overlay_media_test.go
@@ -1,0 +1,114 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelPricingResolver_TkResolveOverlayMediaPerRequest(t *testing.T) {
+	pricingSvc := &PricingService{}
+	data, err := pricingSvc.parsePricingData([]byte(`{
+		"imagen-4.0-generate-001": {
+			"output_cost_per_image": 0.04,
+			"mode": "image_generation",
+			"litellm_provider": "vertex_ai"
+		},
+		"gpt-4o-mini": {
+			"input_cost_per_token": 0.00000015,
+			"output_cost_per_token": 0.0000006
+		}
+	}`))
+	require.NoError(t, err)
+	pricingSvc.pricingData = data
+
+	billing := NewBillingService(nil, pricingSvc)
+	resolver := NewModelPricingResolver(nil, billing)
+
+	media := resolver.tkResolveOverlayMediaPerRequest("imagen-4.0-generate-001")
+	require.NotNil(t, media)
+	require.Equal(t, BillingModeImage, media.Mode)
+	require.InDelta(t, 0.04, media.DefaultPerRequestPrice, 1e-12)
+	require.Equal(t, PricingSourceLiteLLM, media.Source)
+
+	require.Nil(t, resolver.tkResolveOverlayMediaPerRequest("gpt-4o-mini"))
+	require.Nil(t, resolver.tkResolveOverlayMediaPerRequest("unknown-model"))
+}
+
+func TestModelPricingResolver_Resolve_ImageOnlyOverlayOnTokenPath(t *testing.T) {
+	pricingSvc := &PricingService{}
+	data, err := pricingSvc.parsePricingData([]byte(`{
+		"imagen-4.0-fast-generate-001": {
+			"output_cost_per_image": 0.02,
+			"mode": "image_generation",
+			"litellm_provider": "vertex_ai"
+		}
+	}`))
+	require.NoError(t, err)
+	pricingSvc.pricingData = data
+
+	billing := NewBillingService(nil, pricingSvc)
+	resolver := NewModelPricingResolver(nil, billing)
+
+	resolved := resolver.Resolve(context.Background(), PricingInput{Model: "imagen-4.0-fast-generate-001"})
+	require.NotNil(t, resolved)
+	require.Equal(t, BillingModeImage, resolved.Mode)
+	require.InDelta(t, 0.02, resolved.DefaultPerRequestPrice, 1e-12)
+	require.Equal(t, PricingSourceLiteLLM, resolved.Source)
+
+	cost, err := billing.CalculateCostUnified(CostInput{
+		Model:          "imagen-4.0-fast-generate-001",
+		RequestCount:   1,
+		RateMultiplier: 1.0,
+		Resolver:       resolver,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cost)
+	require.InDelta(t, 0.02, cost.TotalCost, 1e-12)
+	require.InDelta(t, 0.02, cost.ActualCost, 1e-12)
+}
+
+func TestOpenAIGatewayService_CalculateRecordUsageCost_ImagenTokenPathUsesOverlayPerImage(t *testing.T) {
+	pricingSvc := &PricingService{}
+	data, err := pricingSvc.parsePricingData([]byte(`{
+		"imagen-4.0-generate-001": {
+			"output_cost_per_image": 0.04,
+			"mode": "image_generation",
+			"litellm_provider": "vertex_ai"
+		}
+	}`))
+	require.NoError(t, err)
+	pricingSvc.pricingData = data
+
+	billing := NewBillingService(nil, pricingSvc)
+	resolver := NewModelPricingResolver(nil, billing)
+	svc := &OpenAIGatewayService{billingService: billing, resolver: resolver}
+
+	apiKey := &APIKey{Group: &Group{ID: 16, Platform: PlatformNewAPI}}
+	result := &OpenAIForwardResult{
+		Model:         "imagen-4.0-generate-001",
+		UpstreamModel: "imagen-4.0-generate-001",
+		Usage: OpenAIUsage{
+			InputTokens:  200,
+			OutputTokens: 58,
+		},
+		ImageCount: 0,
+	}
+
+	cost, err := svc.calculateOpenAIRecordUsageCost(
+		context.Background(),
+		result,
+		apiKey,
+		[]string{"imagen-4.0-generate-001"},
+		1.0, 1.0, 1.0, 1.0,
+		UsageTokens{InputTokens: 200, OutputTokens: 58},
+		"", false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cost)
+	require.InDelta(t, 0.04, cost.TotalCost, 1e-12)
+	require.Equal(t, string(BillingModeImage), cost.BillingMode)
+}

--- a/backend/internal/service/openai_gateway_service_tk_served_zero_cost.go
+++ b/backend/internal/service/openai_gateway_service_tk_served_zero_cost.go
@@ -70,6 +70,7 @@ func (s *OpenAIGatewayService) tkNotifyServedZeroCost(
 	}
 	if apiKey != nil {
 		ev.APIKeyID = apiKey.ID
+		ev.UserID = apiKey.UserID
 		if apiKey.Group != nil {
 			ev.GroupID = apiKey.Group.ID
 			ev.GroupName = apiKey.Group.Name

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -427,7 +427,14 @@ func (s *OpenAIGatewayService) calculateOpenAIRecordUsageCost(
 	}
 	if result != nil && result.ImageCount > 0 {
 		// 渠道定价为 token 计费时走 token 路径，否则走图片计费
-		if resolved := s.resolveOpenAIChannelPricing(ctx, billingModel, apiKey); resolved == nil || resolved.Mode != BillingModeToken {
+		resolved := s.resolveOpenAIChannelPricing(ctx, billingModel, apiKey)
+		useTokenPath := resolved != nil && resolved.Mode == BillingModeToken
+		// TK: imagen-* overlay rows are image-only; channel token mode must not
+		// force token settlement (would bill $0).
+		if useTokenPath && s.resolver != nil && s.resolver.tkResolveOverlayMediaPerRequest(billingModel) != nil {
+			useTokenPath = false
+		}
+		if !useTokenPath {
 			return s.calculateOpenAIImageCost(ctx, billingModel, apiKey, result, imageMultiplier), nil
 		}
 	}

--- a/backend/internal/service/pricing_missing_notifier_tk.go
+++ b/backend/internal/service/pricing_missing_notifier_tk.go
@@ -66,6 +66,7 @@ type PricingMissingEvent struct {
 	GroupID        int64
 	GroupName      string
 	APIKeyID       int64
+	UserID         int64 // api key 所属用户（运维定位）
 	Tokens         int64 // 本次未计费计费单元估算（token 总量或图片张数）
 }
 
@@ -379,7 +380,11 @@ func buildPricingMissingFirstSeenText(site string, ev PricingMissingEvent, platf
 	if ev.GroupID > 0 {
 		group = pricingMissingGroupLabel(ev.GroupID, ev.GroupName)
 	}
-	return fmt.Sprintf("**节点**：%s\n**原因**：%s\n**平台**：%s\n**计费模型**：%s\n**请求模型**：%s\n**上游模型**：%s\n**组**：%s\n**api_key**：#%d\n**本次计费单元**：%d\n**时间**：%s\n\n%s（24h 内同模型不再即时提醒，后续进周期摘要）。\n\n%s\n%s",
+	user := "-"
+	if ev.UserID > 0 {
+		user = fmt.Sprintf("#%d", ev.UserID)
+	}
+	return fmt.Sprintf("**节点**：%s\n**原因**：%s\n**平台**：%s\n**计费模型**：%s\n**请求模型**：%s\n**上游模型**：%s\n**组**：%s\n**user**：%s\n**api_key**：#%d\n**本次计费单元**：%d\n**时间**：%s\n\n%s（24h 内同模型不再即时提醒，后续进周期摘要）。\n\n%s\n%s",
 		escapeFeishuText(site),
 		escapeFeishuText(pricingMissingReasonLabel(ev.Reason)),
 		escapeFeishuText(platform),
@@ -387,6 +392,7 @@ func buildPricingMissingFirstSeenText(site string, ev PricingMissingEvent, platf
 		escapeFeishuText(requested),
 		escapeFeishuText(upstream),
 		escapeFeishuText(group),
+		escapeFeishuText(user),
 		ev.APIKeyID,
 		ev.Tokens,
 		escapeFeishuText(formatAlertTime(now)),

--- a/backend/internal/service/pricing_missing_notifier_tk_test.go
+++ b/backend/internal/service/pricing_missing_notifier_tk_test.go
@@ -40,6 +40,7 @@ func samplePricingMissingEvent() PricingMissingEvent {
 		GroupID:        3,
 		GroupName:      "vertex-pool",
 		APIKeyID:       42,
+		UserID:         16,
 		Tokens:         1500,
 	}
 }
@@ -55,6 +56,7 @@ func TestPricingMissingNotifier_FirstSeenSendsOnce_ThenAggregates(t *testing.T) 
 	body := doer.lastBody()
 	require.Contains(t, body, "doubao-seedream-9", "first-seen card must name the model")
 	require.Contains(t, body, "newapi", "first-seen card must name the platform")
+	require.Contains(t, body, "**user**：#16", "first-seen card must name the user")
 	require.Contains(t, body, "已照常服务", "card must state service was NOT refused")
 	require.Contains(t, body, "apply-pricing-hotfix.py", "card must point at the hot-update runbook")
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1072,7 +1072,8 @@
       "must_contain": [
         "tkApplyChannelFlatOverridesAsFallback(chPricing, resolved)",
         "tkOverlayIntervalOntoBasePricing(resolved.BasePricing, iv, resolved.SupportsCacheBreakdown)",
-        "tkApplyOverlayIntervals(resolved)"
+        "tkApplyOverlayIntervals(resolved)",
+        "tkResolveOverlayMediaPerRequest(input.Model)"
       ],
       "rationale": "TK channel-pricing policy: applyTokenOverrides MUST delegate flat-default application to the TK companion regardless of whether intervals are configured (upstream #2107 — out-of-range fallback). GetIntervalPricing MUST delegate matched-interval pricing to the TK overlay helper instead of building a brand-new ModelPricing from interval fields only (upstream #2363 — in-range cache_read/cache_write/image_output preservation). Either revert silently re-introduces $0 or wrong-tier billing on the most cache-hit-heavy traffic that sticky-routing was designed to bank. ALSO: Resolve MUST call tkApplyOverlayIntervals(resolved) so overlay-defined interval (tiered) pricing reaches ResolvedPricing.Intervals when no channel override is present; an upstream merge dropping the call silently flattens every overlay-tiered model (qwen3-coder-plus/plus/flash, doubao-*/glm-4.7/deepseek-v3.2) to its tier-1 base price with no compile error."
     },
@@ -1099,6 +1100,25 @@
         "TestGetIntervalPricing_IntervalMatched_IntervalCacheReadOverridesFlat"
       ],
       "rationale": "Focused regressions for upstream #2107 (out-of-range path) and upstream #2363 (in-range path). The four tests jointly assert that channel flat defaults survive every interval lookup outcome (no intervals, no match, match overlapping interval, match disjoint from flat defaults) and that interval values take precedence in-range when both are set. Dropping any of these lets the symmetric pricing-dimension drop bugs return without unit-CI noticing."
+    },
+    {
+      "path": "backend/internal/service/model_pricing_resolver_tk_overlay_media.go",
+      "must_contain": [
+        "func (r *ModelPricingResolver) tkResolveOverlayMediaPerRequest(model string)",
+        "lp.TokenPricingAbsent",
+        "lp.OutputCostPerImage",
+        "BillingModeImage"
+      ],
+      "rationale": "Imagen/veo overlay rows are TokenPricingAbsent in GetModelPricing (fail-closed on token traffic) but must still bill per-image when settlement hits the OpenAI token path (ImageCount not propagated or bridge accounting gap). This companion resolves OutputCostPerImage into BillingModeImage/per-request ResolvedPricing. Dropping it silently restores served_zero_cost P0 on imagen-* newapi traffic with no compile error."
+    },
+    {
+      "path": "backend/internal/service/model_pricing_resolver_tk_overlay_media_test.go",
+      "must_contain": [
+        "TestModelPricingResolver_TkResolveOverlayMediaPerRequest",
+        "TestModelPricingResolver_Resolve_ImageOnlyOverlayOnTokenPath",
+        "TestOpenAIGatewayService_CalculateRecordUsageCost_ImagenTokenPathUsesOverlayPerImage"
+      ],
+      "rationale": "Focused regressions for imagen overlay per-image billing on the token settlement path: resolver helper, CalculateCostUnified, and calculateOpenAIRecordUsageCost with ImageCount=0 must charge overlay OutputCostPerImage instead of $0."
     },
     {
       "path": "backend/internal/repository/account_repo.go",
@@ -3395,6 +3415,13 @@
         "s.tkNotifyServedZeroCost(cost, result, apiKey, input, billingModels, actualInputTokens, multiplier, accountRateMultiplier)"
       ],
       "rationale": "Served-but-zero-cost -> Feishu P0 hook on the OpenAI-compat record-usage funnel (covers newapi fifth platform + image/video relays). The upstream-owned openai_usage.pricing_missing_record_zero_cost log line stays untouched; this adjacent result-side probe is the only feed into PricingMissingNotifier on this path (root-cause ②) and is compile-clean if dropped by an upstream merge."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_usage.go",
+      "must_contain": [
+        "tkResolveOverlayMediaPerRequest(billingModel)"
+      ],
+      "rationale": "Imagen overlay guard on calculateOpenAIRecordUsageCost: when channel pricing is token mode but the model is image-only overlay (TokenPricingAbsent), force image settlement instead of token path that would bill $0. Wired adjacent to the ImageCount>0 branch; dropping the hook silently restores zero-cost imagen traffic on newapi groups configured for token billing."
     },
     {
       "rationale": "Served-but-zero-cost -> Feishu P0 hook on the OpenAI-compat record-usage funnel (covers newapi fifth platform + image/video relays). The upstream-owned openai_usage.pricing_missing_record_zero_cost log line stays untouched; this adjacent result-side probe is the only feed into PricingMissingNotifier on this path (root-cause ②) and is compile-clean if dropped by an upstream merge.",


### PR DESCRIPTION
## 摘要

prod 告警：`imagen-4.0-generate-001` / `imagen-4.0-fast-generate-001`（platform=newapi，Google-Vertex #16）已服务但倍率前成本为 $0。

**计费修复**：两模型在 overlay 已有按张价，但 TokenPricingAbsent 条目在 token 结算路径 fail-closed → $0。本 PR 让 resolver 从 overlay 解析按张价，无需渠道 DB 配置。

**告警增强**：P0 首见飞书卡新增 **user** 字段（`api_key` 所属 user id），便于运维直接定位用户。

## 风险

- 常规风险：结算路径仅影响 imagen 等 image-only overlay 模型；告警卡片多一行 user id，无 API/契约变更。

## 验证

```bash
go test -tags=unit ./internal/service/ -run 'OverlayMedia|ImagenTokenPath|PricingMissing' -count=1
python3 scripts/checks/pricing-overlay.py --quiet
```

均已通过。

## 提交

- 63b1670b2 fix(billing): 让 imagen overlay 按张价在 token 结算路径生效
- 98a01d7aa fix(ops): P0 零计费告警卡片增加 user id

最新提交：98a01d7aa