### PR TITLE
fix(openai): Spark bengalfox 429 改走 model 级限流

### DIFF
--- a/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
@@ -1,9 +1,23 @@
 package service
 
 import (
+	"net/http"
 	"testing"
 	"time"
 )
+
+func TestParseCodexRateLimitHeaders_IgnoresBengalfoxActiveLimit(t *testing.T) {
+	h := http.Header{}
+	h.Set("x-codex-active-limit", "codex_bengalfox")
+	h.Set("x-codex-primary-used-percent", "100")
+	h.Set("x-codex-primary-window-minutes", "10080")
+	if got := ParseCodexRateLimitHeaders(h); got != nil {
+		t.Fatalf("expected nil snapshot for codex_bengalfox active limit, got %+v", got)
+	}
+	if got := calculateOpenAI429ResetTime(h); got != nil {
+		t.Fatalf("expected nil reset for codex_bengalfox active limit, got %v", *got)
+	}
+}
 
 func TestCodexSnapshotBaseTime(t *testing.T) {
 	fallback := time.Date(2026, 2, 20, 9, 0, 0, 0, time.UTC)

--- a/backend/internal/service/openai_gateway_service_tk_codex_usage_snapshot.go
+++ b/backend/internal/service/openai_gateway_service_tk_codex_usage_snapshot.go
@@ -396,8 +396,29 @@ func (s *OpenAIGatewayService) withOpenAIQuotaAutoPauseContext(ctx context.Conte
 	return withOpenAIQuotaAutoPauseSettings(ctx, s.settingService.GetOpenAIQuotaAutoPauseSettings(ctx))
 }
 
+const (
+	codexActiveLimitHeader    = "x-codex-active-limit"
+	codexBengalfoxActiveLimit = "codex_bengalfox"
+)
+
+// isCodexBengalfoxActiveLimit reports when upstream marks the active quota as the
+// Spark (codex_bengalfox) metered sub-limit. On those 429s the generic
+// x-codex-primary-* headers mirror the spark window (often primary=100%,
+// window=10080) — NOT the account-wide codex window that /wham/usage reports.
+// ParseCodexRateLimitHeaders and calculateOpenAI429ResetTime must ignore them so
+// spark exhaustion routes to model-scoped cooldown instead of whole-account.
+func isCodexBengalfoxActiveLimit(headers http.Header) bool {
+	if headers == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(headers.Get(codexActiveLimitHeader)), codexBengalfoxActiveLimit)
+}
+
 // Exported for use in ratelimit_service when handling OpenAI 429 responses.
 func ParseCodexRateLimitHeaders(headers http.Header) *OpenAICodexUsageSnapshot {
+	if isCodexBengalfoxActiveLimit(headers) {
+		return nil
+	}
 	snapshot := &OpenAICodexUsageSnapshot{}
 	hasData := false
 

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
@@ -377,6 +377,23 @@ func codexGeneralWindowHeaders(used5h, used7d int) http.Header {
 	return h
 }
 
+// codexSparkBengalfox429Headers mirrors prod GPT-pro3/pro4 spark 429 captures
+// (2026-07-29): x-codex-active-limit=codex_bengalfox with generic primary=100%
+// /10080min that must NOT be treated as account-wide 7d exhaustion.
+func codexSparkBengalfox429Headers() http.Header {
+	h := http.Header{}
+	h.Set("x-codex-active-limit", "codex_bengalfox")
+	h.Set("x-codex-plan-type", "pro")
+	h.Set("x-codex-primary-used-percent", "100")
+	h.Set("x-codex-secondary-used-percent", "0")
+	h.Set("x-codex-primary-window-minutes", "10080")
+	h.Set("x-codex-secondary-window-minutes", "0")
+	h.Set("x-codex-primary-reset-after-seconds", "527898")
+	h.Set("x-codex-bengalfox-primary-used-percent", "100")
+	h.Set("x-codex-bengalfox-limit-name", "GPT-5.3-Codex-Spark")
+	return h
+}
+
 const codexSparkModel = "gpt-5.3-codex-spark"
 
 // usage_limit_reached body carrying the (spark sub-window) reset.
@@ -439,13 +456,34 @@ func TestCodexSpark429_GeneralWindowNearCapNotExhausted_ModelScoped(t *testing.T
 	require.Equal(t, 0, repo.setRateLimitedCalls)
 }
 
+func TestCodexSpark429_BengalfoxActiveLimit_ModelScopedDespitePrimary100(t *testing.T) {
+	// Prod regression (GPT-pro3/pro4, 2026-07-29): spark 429 carries
+	// x-codex-active-limit=codex_bengalfox while generic primary=100%/10080min.
+	// That must model-scope spark, not whole-account cool gpt-5.5 capacity.
+	repo := &rateLimitAccountRepoStub{}
+	svc := newG4RateLimitService(repo)
+	account := newOpenAICodexAccount(1073, AccountTypeOAuth)
+
+	svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		codexSparkBengalfox429Headers(),
+		codexUsageLimitBody,
+		codexSparkModel,
+	)
+
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, codexSparkModel, repo.modelRateLimitCalls[0].scope)
+	require.Equal(t, 0, repo.setRateLimitedCalls)
+	require.Zero(t, repo.updateExtraCalls,
+		"bengalfox 429 headers must not persist account-wide codex_7d=100%")
+}
+
 func TestCodexSpark429_GeneralWindowExhausted_WholeAccountViaPath1(t *testing.T) {
-	// When a general window actually reads >=100% AND carries its reset, path 1
-	// (calculateOpenAI429ResetTime) cools the WHOLE account before the model-scope
-	// helper is reached — this is the only fact-based account-wide signal. Also
-	// the header-semantics self-protection: if the x-codex-* headers ever
-	// reflected the spark window at 100% instead of the account-wide one, this
-	// same path catches it. No model-scoped write.
+	// When a general window actually reads >=100% AND carries its reset (without
+	// x-codex-active-limit=codex_bengalfox), path 1 cools the WHOLE account
+	// before the model-scope helper is reached.
 	repo := &rateLimitAccountRepoStub{}
 	svc := newG4RateLimitService(repo)
 	account := newOpenAICodexAccount(1003, AccountTypeOAuth)
@@ -581,4 +619,8 @@ func TestTkShouldOpenAICodex429BeModelScoped(t *testing.T) {
 	exhausted := codexGeneralWindowHeaders(100, 1)
 	exhausted.Set("x-codex-primary-reset-after-seconds", "7620")
 	require.False(t, tkShouldOpenAICodex429BeModelScoped(account, exhausted, body, codexSparkModel))
+
+	require.True(t, tkShouldOpenAICodex429BeModelScoped(
+		account, codexSparkBengalfox429Headers(), body, codexSparkModel),
+		"bengalfox active-limit spark 429 must model-scope despite primary=100%")
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -5066,11 +5066,13 @@
       "must_contain": [
         "type OpenAICodexUsageSnapshot struct",
         "func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits",
+        "func isCodexBengalfoxActiveLimit(headers http.Header) bool",
+        "codexBengalfoxActiveLimit",
         "func ParseCodexRateLimitHeaders(headers http.Header) *OpenAICodexUsageSnapshot",
         "func (s *OpenAIGatewayService) UpdateCodexUsageSnapshotFromHeaders(ctx context.Context, accountID int64, headers http.Header)",
         "func shouldAutoPauseOpenAIAccountByQuota(ctx context.Context, account *Account) (bool, openAIQuotaAutoPauseDecision)"
       ],
-      "rationale": "TK Codex usage snapshot companion: Codex rate-limit header parsing, 5h/7d window normalization, quota auto-pause logic, and snapshot persistence with write throttle. Extracted from openai_gateway_service.go to reduce upstream merge surface. ParseCodexRateLimitHeaders is called from ratelimit_service; UpdateCodexUsageSnapshotFromHeaders from the /responses handler; shouldAutoPauseOpenAIAccountByQuota from the account scheduler; dropping the companion breaks compilation across multiple packages."
+      "rationale": "TK Codex usage snapshot companion: Codex rate-limit header parsing, 5h/7d window normalization, quota auto-pause logic, and snapshot persistence with write throttle. ParseCodexRateLimitHeaders must ignore x-codex-active-limit=codex_bengalfox spark 429 headers (prod GPT-pro3/pro4 2026-07-29) so spark sub-limit exhaustion routes to model-scoped cooldown instead of whole-account SetRateLimited and codex_7d pollution. Extracted from openai_gateway_service.go to reduce upstream merge surface."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_image_input_sanitize.go",


### PR DESCRIPTION
## 摘要

- Spark 429 时上游返回 `x-codex-active-limit: codex_bengalfox`，但 generic `x-codex-primary-*` 会镜像 Spark 子窗口（primary=100%/10080min），导致 Path 1 误判账号级 7d 耗尽并整账号冷却，gpt-5.5 等常规模型被误伤。
- `ParseCodexRateLimitHeaders` 在 active-limit=bengalfox 时返回 nil，Spark 429 改走 Path 2 写 `model_rate_limits[spark]`，不再 `SetRateLimited` 整账号，也不再污染 `codex_7d_used_percent`。
- 回归测试使用 prod GPT-pro3/pro4（2026-07-29）抓到的 header 形状；sentinel 已锚定 `isCodexBengalfoxActiveLimit`。

## 风险

- 常规风险：仅影响 OpenAI OAuth Spark 429 的限流路径；真实账号级 7d/5h 耗尽（无 bengalfox active-limit 头）仍走整账号冷却，行为不变。
- 部署后需观察：Spark 429 账号应出现 `model_rate_limits`，`rate_limit_reset_at` 不再因 Spark 单独刷新；gpt-5.5 网关探测应可 servable。

## 验证

```bash
go test -tags=unit ./backend/internal/service/ -run 'TestCodexSpark429_Bengalfox|TestParseCodexRateLimitHeaders_Ignores|TestTkShouldOpenAICodex429BeModelScoped' -v
./scripts/preflight.sh
```

- 上述 targeted tests 与 preflight 均已通过（本地）。

## 提交

- e92bd68ae fix(openai): Spark bengalfox 429 改走 model 级限流而非整账号冷却

最新提交：e92bd68ae

Made with [Cursor](https://cursor.com)