### PR TITLE
fix(openai): SSOT OAuth 429 runtime block 与 DB 漂移 reconcile

### DIFF
--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -1997,16 +1997,18 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 }
 
 type selectionFailureStats struct {
-	Total              int
-	Eligible           int
-	Excluded           int
-	Unschedulable      int
-	PlatformFiltered   int
-	ModelUnsupported   int
-	ModelRateLimited   int
-	SamplePlatformIDs  []int64
-	SampleMappingIDs   []int64
-	SampleRateLimitIDs []string
+	Total                   int
+	Eligible                int
+	Excluded                int
+	Unschedulable           int
+	PlatformFiltered        int
+	ModelUnsupported        int
+	ModelRateLimited        int
+	RuntimeBlocked          int
+	SamplePlatformIDs       []int64
+	SampleMappingIDs        []int64
+	SampleRateLimitIDs      []string
+	SampleRuntimeBlockedIDs []int64
 }
 
 type selectionFailureDiagnosis struct {
@@ -2157,7 +2159,7 @@ func appendSelectionFailureRateSample(samples []string, accountID int64, remaini
 
 func summarizeSelectionFailureStats(stats selectionFailureStats) string {
 	return fmt.Sprintf(
-		"total=%d eligible=%d excluded=%d unschedulable=%d platform_filtered=%d model_unsupported=%d model_rate_limited=%d",
+		"total=%d eligible=%d excluded=%d unschedulable=%d platform_filtered=%d model_unsupported=%d model_rate_limited=%d runtime_blocked=%d",
 		stats.Total,
 		stats.Eligible,
 		stats.Excluded,
@@ -2165,6 +2167,7 @@ func summarizeSelectionFailureStats(stats selectionFailureStats) string {
 		stats.PlatformFiltered,
 		stats.ModelUnsupported,
 		stats.ModelRateLimited,
+		stats.RuntimeBlocked,
 	)
 }
 

--- a/backend/internal/service/grok_credential_failure.go
+++ b/backend/internal/service/grok_credential_failure.go
@@ -569,18 +569,18 @@ func (s *OpenAIGatewayService) blockGrokCredentialRuntime(account *Account, unti
 	mu := s.openAIAccountRuntimeBlockLock(account.ID)
 	mu.Lock()
 	before, hadBefore := s.openaiAccountRuntimeBlockUntil.Load(account.ID)
+	beforeEntry, hadBeforeEntry := loadOpenAIAccountRuntimeBlockEntry(before)
 	installedGeneration, changed := s.blockAccountSchedulingLocked(account, until, reason)
 	installed, installedOK := s.openaiAccountRuntimeBlockUntil.Load(account.ID)
-	installedUntil, isTime := installed.(time.Time)
+	installedEntry, installedValid := loadOpenAIAccountRuntimeBlockEntry(installed)
 	mu.Unlock()
-	if !changed || !installedOK || !isTime {
+	if !changed || !installedOK || !installedValid {
 		return func() {}
 	}
-	if hadBefore {
-		if beforeUntil, ok := before.(time.Time); ok && beforeUntil.Equal(installedUntil) {
-			return func() {}
-		}
+	if hadBefore && hadBeforeEntry && beforeEntry.Until.Equal(installedEntry.Until) {
+		return func() {}
 	}
+	installedUntil := installedEntry.Until
 	return func() {
 		mu.Lock()
 		defer mu.Unlock()
@@ -589,8 +589,8 @@ func (s *OpenAIGatewayService) blockGrokCredentialRuntime(account *Account, unti
 			return
 		}
 		current, ok := s.openaiAccountRuntimeBlockUntil.Load(account.ID)
-		currentUntil, isTime := current.(time.Time)
-		if !ok || !isTime || !currentUntil.Equal(installedUntil) {
+		currentEntry, currentValid := loadOpenAIAccountRuntimeBlockEntry(current)
+		if !ok || !currentValid || !currentEntry.Until.Equal(installedUntil) {
 			return
 		}
 		if hadBefore {

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -10,13 +10,19 @@ import (
 )
 
 const (
-	openAIAccountStateUpdateTimeout       = 5 * time.Second
-	openAIOAuth429FallbackCooldown        = 5 * time.Second
-	openAIStopSchedulingBridgeCooldown    = 2 * time.Minute
-	openAIOAuth429StormWindow             = 10 * time.Second
-	openAIOAuth429StormThreshold          = 20
-	openAIOAuth429StormMaxAccountSwitches = 1
+	openAIAccountStateUpdateTimeout        = 5 * time.Second
+	openAIOAuth429FallbackCooldown         = 5 * time.Second
+	openAIStopSchedulingBridgeCooldown     = 2 * time.Minute
+	openAIOAuth429StormWindow              = 10 * time.Second
+	openAIOAuth429StormThreshold           = 20
+	openAIOAuth429StormMaxAccountSwitches  = 1
+	openAIRuntimeBlockRateLimitDriftGrace  = 30 * time.Minute
 )
+
+type openAIAccountRuntimeBlockEntry struct {
+	Until  time.Time
+	Reason string
+}
 
 // OpenAIOAuth429FailoverState tracks the request-local follow-up budget after
 // the first Grok OAuth 429. Once that 429 occurs, exactly one different account
@@ -73,10 +79,13 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 		return false
 	}
 
-	if s == nil || account == nil || s.rateLimitService == nil {
-		if statusCode == http.StatusTooManyRequests {
-			s.markOpenAIOAuth429RateLimited(stateCtx, account, headers, responseBody, canonicalModel...)
-		}
+	if s == nil || account == nil {
+		return false
+	}
+	if statusCode == http.StatusTooManyRequests {
+		s.noteOpenAIOAuth429ForScheduling(stateCtx, account, headers, responseBody, canonicalModel...)
+	}
+	if s.rateLimitService == nil {
 		return false
 	}
 	stateCtx = withTempUnschedulableModel(stateCtx, canonicalModel)
@@ -89,9 +98,6 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 	if statusCode != http.StatusUnauthorized && len(canonicalModel) > 0 && strings.TrimSpace(canonicalModel[0]) != "" &&
 		s.rateLimitService.HandleTempUnschedulable(stateCtx, account, statusCode, responseBody, canonicalModel[0]) {
 		return true
-	}
-	if statusCode == http.StatusTooManyRequests {
-		s.markOpenAIOAuth429RateLimited(stateCtx, account, headers, responseBody, canonicalModel...)
 	}
 	shouldDisable := s.rateLimitService.HandleUpstreamError(stateCtx, account, statusCode, headers, responseBody, canonicalModel...)
 	modelTempMatched := statusCode != http.StatusUnauthorized && tempUnschedulableModel(stateCtx, nil) != "" &&
@@ -153,7 +159,12 @@ func (s *OpenAIGatewayService) handleOpenAICompatRelayDownstreamCapacityError(ct
 	return true
 }
 
-func (s *OpenAIGatewayService) markOpenAIOAuth429RateLimited(ctx context.Context, account *Account, headers http.Header, responseBody []byte, requestedModel ...string) {
+// noteOpenAIOAuth429ForScheduling records OAuth 429 storm state before durable
+// handling. Whole-account runtime blocks for 429 are owned exclusively by
+// RateLimitService.notifyAccountSchedulingBlocked (HandleUpstreamError path).
+// When rateLimitService is unavailable, a short degraded fallback block is
+// written here so failover does not immediately re-select the same account.
+func (s *OpenAIGatewayService) noteOpenAIOAuth429ForScheduling(ctx context.Context, account *Account, headers http.Header, responseBody []byte, requestedModel ...string) {
 	if s == nil || !isOpenAIOAuthAccount(account) {
 		return
 	}
@@ -173,20 +184,11 @@ func (s *OpenAIGatewayService) markOpenAIOAuth429RateLimited(ctx context.Context
 		return
 	}
 	s.recordOpenAIOAuth429()
-
-	cooldownUntil := time.Now().Add(openAIOAuth429FallbackCooldown)
 	if s.rateLimitService != nil {
-		if resetAt := s.rateLimitService.calculateOpenAI429ResetTime(headers); resetAt != nil && resetAt.After(time.Now()) {
-			cooldownUntil = *resetAt
-		} else if resetUnix := parseOpenAIRateLimitResetTime(responseBody); resetUnix != nil {
-			if resetAt := time.Unix(*resetUnix, 0); resetAt.After(time.Now()) {
-				cooldownUntil = resetAt
-			}
-		} else if cooldown, ok := s.rateLimitService.get429FallbackCooldown(ctx, account); ok && cooldown > 0 {
-			cooldownUntil = time.Now().Add(cooldown)
-		}
+		return
 	}
-	s.BlockAccountScheduling(account, cooldownUntil, "429")
+	s.BlockAccountScheduling(account, time.Now().Add(openAIOAuth429FallbackCooldown), "429")
+	_ = ctx
 }
 
 func (s *OpenAIGatewayService) BlockAccountScheduling(account *Account, until time.Time, reason string) {
@@ -209,7 +211,21 @@ func (s *OpenAIGatewayService) openAIAccountRuntimeBlockLock(accountID int64) *s
 	return mu
 }
 
-func (s *OpenAIGatewayService) blockAccountSchedulingLocked(account *Account, until time.Time, _ string) (uint64, bool) {
+func loadOpenAIAccountRuntimeBlockEntry(value any) (openAIAccountRuntimeBlockEntry, bool) {
+	switch entry := value.(type) {
+	case openAIAccountRuntimeBlockEntry:
+		return entry, true
+	case time.Time:
+		if entry.IsZero() {
+			return openAIAccountRuntimeBlockEntry{}, false
+		}
+		return openAIAccountRuntimeBlockEntry{Until: entry, Reason: ""}, true
+	default:
+		return openAIAccountRuntimeBlockEntry{}, false
+	}
+}
+
+func (s *OpenAIGatewayService) blockAccountSchedulingLocked(account *Account, until time.Time, reason string) (uint64, bool) {
 	generation := s.openaiAccountRuntimeBlockSequence.Add(1)
 	s.openaiAccountRuntimeBlockGeneration.Store(account.ID, generation)
 	now := time.Now()
@@ -217,31 +233,60 @@ func (s *OpenAIGatewayService) blockAccountSchedulingLocked(account *Account, un
 	if blockUntil.IsZero() || !blockUntil.After(now) {
 		blockUntil = now.Add(openAIStopSchedulingBridgeCooldown)
 	}
+	next := openAIAccountRuntimeBlockEntry{Until: blockUntil, Reason: strings.TrimSpace(reason)}
 
 	for {
 		current, loaded := s.openaiAccountRuntimeBlockUntil.Load(account.ID)
 		if !loaded {
-			actual, stored := s.openaiAccountRuntimeBlockUntil.LoadOrStore(account.ID, blockUntil)
+			actual, stored := s.openaiAccountRuntimeBlockUntil.LoadOrStore(account.ID, next)
 			if !stored {
 				return generation, true
 			}
 			current = actual
 		}
 
-		currentUntil, ok := current.(time.Time)
-		if !ok || currentUntil.IsZero() {
-			if s.openaiAccountRuntimeBlockUntil.CompareAndSwap(account.ID, current, blockUntil) {
+		currentEntry, ok := loadOpenAIAccountRuntimeBlockEntry(current)
+		if !ok || currentEntry.Until.IsZero() {
+			if s.openaiAccountRuntimeBlockUntil.CompareAndSwap(account.ID, current, next) {
 				return generation, true
 			}
 			continue
 		}
-		if !blockUntil.After(currentUntil) {
+		if !next.Until.After(currentEntry.Until) {
 			return generation, false
 		}
-		if s.openaiAccountRuntimeBlockUntil.CompareAndSwap(account.ID, current, blockUntil) {
+		if s.openaiAccountRuntimeBlockUntil.CompareAndSwap(account.ID, current, next) {
 			return generation, true
 		}
 	}
+}
+
+func (s *OpenAIGatewayService) reconcileOpenAIAccountRuntimeBlockWithDB(account *Account, entry openAIAccountRuntimeBlockEntry) (openAIAccountRuntimeBlockEntry, bool) {
+	if account == nil || entry.Until.IsZero() {
+		return entry, false
+	}
+	now := time.Now()
+	if !now.Before(entry.Until) {
+		return entry, false
+	}
+	resetAt := account.RateLimitResetAt
+	if resetAt == nil || !now.After(*resetAt) {
+		return entry, false
+	}
+	reason := entry.Reason
+	if reason != "" && reason != "429" && reason != "429_fallback" {
+		return entry, false
+	}
+	if !entry.Until.After(resetAt.Add(openAIRuntimeBlockRateLimitDriftGrace)) {
+		return entry, false
+	}
+	slog.Info("openai_account_runtime_block_cleared_rate_limit_drift",
+		"account_id", account.ID,
+		"memory_until", entry.Until,
+		"db_reset_at", resetAt,
+		"reason", reason,
+	)
+	return openAIAccountRuntimeBlockEntry{}, true
 }
 
 func (s *OpenAIGatewayService) ClearAccountSchedulingBlock(accountID int64) {
@@ -266,13 +311,18 @@ func (s *OpenAIGatewayService) isOpenAIAccountRuntimeBlocked(account *Account) b
 	if !ok {
 		return false
 	}
-	cooldownUntil, ok := value.(time.Time)
-	if !ok || cooldownUntil.IsZero() {
+	entry, ok := loadOpenAIAccountRuntimeBlockEntry(value)
+	if !ok || entry.Until.IsZero() {
 		s.openaiAccountRuntimeBlockUntil.Delete(account.ID)
 		s.openaiAccountRuntimeBlockGeneration.Store(account.ID, s.openaiAccountRuntimeBlockSequence.Add(1))
 		return false
 	}
-	if time.Now().Before(cooldownUntil) {
+	if _, cleared := s.reconcileOpenAIAccountRuntimeBlockWithDB(account, entry); cleared {
+		s.openaiAccountRuntimeBlockUntil.Delete(account.ID)
+		s.openaiAccountRuntimeBlockGeneration.Store(account.ID, s.openaiAccountRuntimeBlockSequence.Add(1))
+		return false
+	}
+	if time.Now().Before(entry.Until) {
 		return true
 	}
 	s.openaiAccountRuntimeBlockUntil.Delete(account.ID)

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -10,13 +10,13 @@ import (
 )
 
 const (
-	openAIAccountStateUpdateTimeout        = 5 * time.Second
-	openAIOAuth429FallbackCooldown         = 5 * time.Second
-	openAIStopSchedulingBridgeCooldown     = 2 * time.Minute
-	openAIOAuth429StormWindow              = 10 * time.Second
-	openAIOAuth429StormThreshold           = 20
-	openAIOAuth429StormMaxAccountSwitches  = 1
-	openAIRuntimeBlockRateLimitDriftGrace  = 30 * time.Minute
+	openAIAccountStateUpdateTimeout       = 5 * time.Second
+	openAIOAuth429FallbackCooldown        = 5 * time.Second
+	openAIStopSchedulingBridgeCooldown    = 2 * time.Minute
+	openAIOAuth429StormWindow             = 10 * time.Second
+	openAIOAuth429StormThreshold          = 20
+	openAIOAuth429StormMaxAccountSwitches = 1
+	openAIRuntimeBlockRateLimitDriftGrace = 30 * time.Minute
 )
 
 type openAIAccountRuntimeBlockEntry struct {

--- a/backend/internal/service/openai_account_runtime_block_fastpath_test.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath_test.go
@@ -5,12 +5,28 @@ package service
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/stretchr/testify/require"
 )
+
+func newOpenAIGatewayWithRateLimit(repo *rateLimitAccountRepoStub) (*OpenAIGatewayService, *RateLimitService) {
+	gateway := &OpenAIGatewayService{}
+	rls := newG4RateLimitService(repo)
+	rls.settingService = settingServiceWithMaxCooldown("")
+	rls.SetAccountRuntimeBlocker(gateway)
+	gateway.rateLimitService = rls
+	return gateway, rls
+}
+
+func codex7dExhaustedHeaders(reset7dSeconds int) http.Header {
+	h := codexGeneralWindowHeaders(1, 100)
+	h.Set("x-codex-secondary-reset-after-seconds", strconv.Itoa(reset7dSeconds))
+	return h
+}
 
 func TestOpenAI429FastPath_MarksOAuthAccountCoolingDown(t *testing.T) {
 	svc := &OpenAIGatewayService{}
@@ -29,7 +45,8 @@ func TestOpenAI429FastPath_MarksOAuthAccountCoolingDown(t *testing.T) {
 // TestOpenAI429FastPath_SkipsSparkShadow 外审第8轮 P1:spark 影子被选中后若 /responses 返回 429,
 // 不得按 global x-codex-* 信号写内存运行时熔断(否则 spark 被冷却到 global reset、单影子场景无可用账号)。
 func TestOpenAI429FastPath_SkipsSparkShadow(t *testing.T) {
-	svc := &OpenAIGatewayService{}
+	repo := &rateLimitAccountRepoStub{}
+	gateway, _ := newOpenAIGatewayWithRateLimit(repo)
 	parentID := int64(800)
 	shadow := &Account{
 		ID:              801,
@@ -45,11 +62,11 @@ func TestOpenAI429FastPath_SkipsSparkShadow(t *testing.T) {
 	headers.Set("x-codex-primary-reset-after-seconds", "18000")
 	headers.Set("x-codex-primary-window-minutes", "300")
 
-	svc.markOpenAIOAuth429RateLimited(context.Background(), shadow, headers, nil)
-	svc.markOpenAIOAuth429RateLimited(context.Background(), normal, headers, nil)
+	gateway.handleOpenAIAccountUpstreamError(context.Background(), shadow, http.StatusTooManyRequests, headers, nil, "gpt-5.4")
+	gateway.handleOpenAIAccountUpstreamError(context.Background(), normal, http.StatusTooManyRequests, headers, nil, "gpt-5.4")
 
-	require.False(t, svc.isOpenAIAccountRuntimeBlocked(shadow), "spark shadow must not be runtime-blocked by /responses global 429")
-	require.True(t, svc.isOpenAIAccountRuntimeBlocked(normal), "normal OpenAI OAuth account should still be runtime-blocked")
+	require.False(t, gateway.isOpenAIAccountRuntimeBlocked(shadow), "spark shadow must not be runtime-blocked by /responses global 429")
+	require.True(t, gateway.isOpenAIAccountRuntimeBlocked(normal), "normal OpenAI OAuth account should still be runtime-blocked")
 }
 
 func TestOpenAIRuntimeBlock_AppliesToOpenAIAPIKeyWhenRateLimitServiceStopsScheduling(t *testing.T) {
@@ -256,9 +273,9 @@ func TestOpenAIRuntimeBlock_DoesNotShortenExistingBlock(t *testing.T) {
 
 	value, ok := svc.openaiAccountRuntimeBlockUntil.Load(account.ID)
 	require.True(t, ok)
-	actualUntil, ok := value.(time.Time)
+	actualEntry, ok := loadOpenAIAccountRuntimeBlockEntry(value)
 	require.True(t, ok)
-	require.WithinDuration(t, longUntil, actualUntil, time.Second)
+	require.WithinDuration(t, longUntil, actualEntry.Until, time.Second)
 }
 
 func TestOpenAIRuntimeBlock_ClearAccountSchedulingBlock(t *testing.T) {
@@ -324,9 +341,7 @@ func TestShouldStopOpenAIOAuth429Failover_TracksOneGrokFollowupAttempt(t *testin
 // SetRateLimited — so gpt-5.4/5.5 keep scheduling on the same OAuth account.
 func TestHandleOpenAIAccountUpstreamError_Spark429HealthyWindow_ModelScopedOnly(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
-	svc := &OpenAIGatewayService{
-		rateLimitService: newG4RateLimitService(repo),
-	}
+	svc, _ := newOpenAIGatewayWithRateLimit(repo)
 	account := newOpenAICodexAccount(9, AccountTypeOAuth)
 	body := []byte(`{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"pro","resets_at":1783336071,"resets_in_seconds":14903}}`)
 
@@ -348,9 +363,7 @@ func TestHandleOpenAIAccountUpstreamError_Spark429HealthyWindow_ModelScopedOnly(
 
 func TestHandleOpenAIAccountUpstreamError_Spark429GeneralWindowExhausted_WholeAccount(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
-	svc := &OpenAIGatewayService{
-		rateLimitService: newG4RateLimitService(repo),
-	}
+	svc, _ := newOpenAIGatewayWithRateLimit(repo)
 	account := newOpenAICodexAccount(9, AccountTypeOAuth)
 	body := codexUsageLimitBody
 	headers := codexGeneralWindowHeaders(100, 1)
@@ -373,9 +386,7 @@ func TestHandleOpenAIAccountUpstreamError_Spark429GeneralWindowExhausted_WholeAc
 
 func TestPersistOpenAIWSRateLimitSignal_Spark429HealthyWindow_ModelScopedOnly(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
-	svc := &OpenAIGatewayService{
-		rateLimitService: newG4RateLimitService(repo),
-	}
+	svc, _ := newOpenAIGatewayWithRateLimit(repo)
 	account := newOpenAICodexAccount(9, AccountTypeOAuth)
 	body := []byte(`{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"pro","resets_at":1783336071,"resets_in_seconds":14903}}`)
 
@@ -394,4 +405,75 @@ func TestPersistOpenAIWSRateLimitSignal_Spark429HealthyWindow_ModelScopedOnly(t 
 	require.Len(t, repo.modelRateLimitCalls, 1, "WS spark cooldown must be model-scoped")
 	require.Equal(t, codexSparkModel, repo.modelRateLimitCalls[0].scope)
 	require.Zero(t, repo.setRateLimitedCalls, "healthy general window must not SetRateLimited whole account")
+}
+
+// Prod incident 2026-07-28 (GPT-pro3/4): unclamped 7d header reset written by the
+// fast-path outlived the clamped DB cooldown. Runtime blocks must follow the same
+// notifyAccountSchedulingBlocked funnel as SetRateLimited.
+func TestHandleOpenAIAccountUpstreamError_7d429_RuntimeBlockMatchesClampedDB(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	gateway, _ := newOpenAIGatewayWithRateLimit(repo)
+	account := newOpenAICodexAccount(73, AccountTypeOAuth)
+	headers := codex7dExhaustedHeaders(562950)
+
+	before := time.Now()
+	shouldDisable := gateway.handleOpenAIAccountUpstreamError(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		headers,
+		[]byte(`{"error":{"type":"usage_limit_reached","message":"limit reached"}}`),
+		"gpt-5.4",
+	)
+
+	require.False(t, shouldDisable)
+	require.Equal(t, 1, repo.setRateLimitedCalls)
+	require.WithinDuration(t, time.Now().Add(5*time.Hour), repo.lastRateLimitedResetAt, 3*time.Second)
+
+	require.True(t, gateway.isOpenAIAccountRuntimeBlocked(account))
+	value, ok := gateway.openaiAccountRuntimeBlockUntil.Load(account.ID)
+	require.True(t, ok)
+	entry, ok := loadOpenAIAccountRuntimeBlockEntry(value)
+	require.True(t, ok)
+	require.Equal(t, "429", entry.Reason)
+	require.WithinDuration(t, repo.lastRateLimitedResetAt, entry.Until, time.Second)
+	require.Less(t, entry.Until.Sub(before), 6*time.Hour)
+}
+
+func TestReconcileOpenAIAccountRuntimeBlockWithDB_ClearsStale429Drift(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	pastReset := time.Now().Add(-time.Hour)
+	account := &Account{
+		ID:               73,
+		Platform:         PlatformOpenAI,
+		Type:             AccountTypeOAuth,
+		RateLimitResetAt: &pastReset,
+	}
+	driftUntil := time.Now().Add(7 * 24 * time.Hour)
+	svc.openaiAccountRuntimeBlockUntil.Store(account.ID, openAIAccountRuntimeBlockEntry{
+		Until:  driftUntil,
+		Reason: "429",
+	})
+
+	require.False(t, svc.isOpenAIAccountRuntimeBlocked(account))
+	_, ok := svc.openaiAccountRuntimeBlockUntil.Load(account.ID)
+	require.False(t, ok)
+}
+
+func TestReconcileOpenAIAccountRuntimeBlockWithDB_PreservesShortOAuth401Block(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	pastReset := time.Now().Add(-time.Hour)
+	account := &Account{
+		ID:               73,
+		Platform:         PlatformOpenAI,
+		Type:             AccountTypeOAuth,
+		RateLimitResetAt: &pastReset,
+	}
+	oauthUntil := time.Now().Add(10 * time.Minute)
+	svc.openaiAccountRuntimeBlockUntil.Store(account.ID, openAIAccountRuntimeBlockEntry{
+		Until:  oauthUntil,
+		Reason: "oauth_401",
+	})
+
+	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account))
 }

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -1412,10 +1412,12 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 		// the requested model name, surface ErrUnsupportedModel (→ HTTP 400) instead
 		// of an empty-pool 429. See openAICompatNoCandidateError (TK companion).
 		return nil, 0, 0, 0, s.service.tkGroupUnsupportedModelRecordErr(req.GroupID, req.RequestedModel, openAICompatNoCandidateError(req.RequestedModel, req.GroupPlatform, false, accounts, req.ExcludedIDs, &openAICompatNoCandidateEval{
-			ctx:            ctx,
-			svc:            s.service,
-			groupID:        req.GroupID,
-			requireCompact: req.RequireCompact,
+			ctx:                ctx,
+			svc:                s.service,
+			groupID:            req.GroupID,
+			platform:           req.GroupPlatform,
+			requireCompact:     req.RequireCompact,
+			requiredCapability: req.RequiredCapability,
 		}))
 	}
 

--- a/backend/internal/service/openai_account_scheduler_tk_errors.go
+++ b/backend/internal/service/openai_account_scheduler_tk_errors.go
@@ -56,10 +56,12 @@ func openAICompatErrorPlatformLabel(groupPlatform string) string {
 // When nil, collectOpenAICompatSelectionFailureStats falls back to account-level
 // model_mapping only (legacy unit tests).
 type openAICompatNoCandidateEval struct {
-	ctx            context.Context
-	svc            *OpenAIGatewayService
-	groupID        *int64
-	requireCompact bool
+	ctx                context.Context
+	svc                *OpenAIGatewayService
+	groupID            *int64
+	platform           string
+	requireCompact     bool
+	requiredCapability OpenAIEndpointCapability
 }
 
 // tkOpenAICompatChannelPricingRestrictionError reports that the requested model is
@@ -83,8 +85,10 @@ func openAICompatNoCandidateError(requestedModel, groupPlatform string, compactB
 			stats = eval.svc.collectOpenAICompatSelectionFailureStatsForRequest(
 				eval.ctx,
 				eval.groupID,
+				eval.platform,
 				requestedModel,
 				eval.requireCompact,
+				eval.requiredCapability,
 				accounts,
 				excludedIDs,
 			)
@@ -97,6 +101,9 @@ func openAICompatNoCandidateError(requestedModel, groupPlatform string, compactB
 				err = eval.svc.tkGroupUnsupportedModelRecordErr(eval.groupID, requestedModel, err)
 			}
 			return err
+		}
+		if eval != nil && eval.svc != nil && eval.ctx != nil {
+			eval.svc.logOpenAICompatSelectionFailure(eval.ctx, eval, requestedModel, stats)
 		}
 	}
 	if groupPlatform != "" && groupPlatform != PlatformOpenAI {
@@ -120,41 +127,6 @@ func collectOpenAICompatSelectionFailureStats(accounts []Account, requestedModel
 			}
 		}
 		if requestedModel != "" && !acc.IsModelSupported(requestedModel) {
-			stats.ModelUnsupported++
-			stats.SampleMappingIDs = appendSelectionFailureSampleID(stats.SampleMappingIDs, acc.ID)
-			continue
-		}
-		stats.Unschedulable++
-	}
-	return stats
-}
-
-// collectOpenAICompatSelectionFailureStatsForRequest mirrors the scheduler's
-// model-servability axis: account model_mapping AND per-account upstream channel
-// restrictions (BillingModelSourceUpstream). Prod 2026-07: a Qwen-group direct
-// key hammering gpt-5.4-mini produced routing/platform 429s because passthrough
-// accounts reported IsModelSupported=true while channel upstream pricing excluded
-// the upstream model — those accounts must count as model_unsupported (client
-// fault), not unschedulable capacity.
-func (s *OpenAIGatewayService) collectOpenAICompatSelectionFailureStatsForRequest(
-	ctx context.Context,
-	groupID *int64,
-	requestedModel string,
-	requireCompact bool,
-	accounts []Account,
-	excludedIDs map[int64]struct{},
-) selectionFailureStats {
-	stats := selectionFailureStats{Total: len(accounts)}
-	needsUpstreamCheck := s != nil && s.needsUpstreamChannelRestrictionCheck(ctx, groupID)
-	for i := range accounts {
-		acc := &accounts[i]
-		if excludedIDs != nil {
-			if _, excluded := excludedIDs[acc.ID]; excluded {
-				stats.Unschedulable++
-				continue
-			}
-		}
-		if requestedModel != "" && s.isOpenAICompatModelUnservableForRequest(ctx, groupID, acc, requestedModel, requireCompact, needsUpstreamCheck) {
 			stats.ModelUnsupported++
 			stats.SampleMappingIDs = appendSelectionFailureSampleID(stats.SampleMappingIDs, acc.ID)
 			continue

--- a/backend/internal/service/openai_account_scheduler_tk_errors_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_errors_test.go
@@ -144,8 +144,10 @@ func TestCollectOpenAICompatSelectionFailureStatsForRequest_UpstreamChannelRestr
 	stats := svc.collectOpenAICompatSelectionFailureStatsForRequest(
 		ctx,
 		&groupID,
+		PlatformNewAPI,
 		"gpt-5.4-mini",
 		false,
+		OpenAIEndpointCapabilityChatCompletions,
 		[]Account{*newAPIAccount(18011, 7)},
 		nil,
 	)

--- a/backend/internal/service/openai_account_scheduler_tk_selection_diag.go
+++ b/backend/internal/service/openai_account_scheduler_tk_selection_diag.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+)
+
+type openAICompatSelectionFailureDiagnosis struct {
+	Category string
+	Detail   string
+}
+
+func (s *OpenAIGatewayService) collectOpenAICompatSelectionFailureStatsForRequest(
+	ctx context.Context,
+	groupID *int64,
+	platform string,
+	requestedModel string,
+	requireCompact bool,
+	requiredCapability OpenAIEndpointCapability,
+	accounts []Account,
+	excludedIDs map[int64]struct{},
+) selectionFailureStats {
+	stats := selectionFailureStats{Total: len(accounts)}
+	needsUpstreamCheck := s != nil && s.needsUpstreamChannelRestrictionCheck(ctx, groupID)
+	for i := range accounts {
+		acc := &accounts[i]
+		diagnosis := s.diagnoseOpenAICompatSelectionFailure(
+			ctx,
+			groupID,
+			platform,
+			acc,
+			requestedModel,
+			requireCompact,
+			requiredCapability,
+			excludedIDs,
+			needsUpstreamCheck,
+		)
+		switch diagnosis.Category {
+		case "excluded":
+			stats.Excluded++
+		case "runtime_blocked":
+			stats.RuntimeBlocked++
+			stats.SampleRuntimeBlockedIDs = appendSelectionFailureSampleID(stats.SampleRuntimeBlockedIDs, acc.ID)
+		case "model_unsupported":
+			stats.ModelUnsupported++
+			stats.SampleMappingIDs = appendSelectionFailureSampleID(stats.SampleMappingIDs, acc.ID)
+		case "model_rate_limited":
+			stats.ModelRateLimited++
+			remaining := acc.GetRateLimitRemainingTimeWithContext(ctx, requestedModel).Truncate(0)
+			stats.SampleRateLimitIDs = appendSelectionFailureRateSample(stats.SampleRateLimitIDs, acc.ID, remaining)
+		case "unschedulable":
+			stats.Unschedulable++
+		default:
+			stats.Eligible++
+		}
+	}
+	return stats
+}
+
+func (s *OpenAIGatewayService) diagnoseOpenAICompatSelectionFailure(
+	ctx context.Context,
+	groupID *int64,
+	platform string,
+	acc *Account,
+	requestedModel string,
+	requireCompact bool,
+	requiredCapability OpenAIEndpointCapability,
+	excludedIDs map[int64]struct{},
+	needsUpstreamCheck bool,
+) openAICompatSelectionFailureDiagnosis {
+	if acc == nil {
+		return openAICompatSelectionFailureDiagnosis{Category: "unschedulable", Detail: "account_nil"}
+	}
+	if excludedIDs != nil {
+		if _, excluded := excludedIDs[acc.ID]; excluded {
+			return openAICompatSelectionFailureDiagnosis{Category: "excluded"}
+		}
+	}
+	platform = normalizeOpenAICompatiblePlatform(platform)
+	if requestedModel != "" && s.isOpenAICompatModelUnservableForRequest(ctx, groupID, acc, requestedModel, requireCompact, needsUpstreamCheck) {
+		return openAICompatSelectionFailureDiagnosis{
+			Category: "model_unsupported",
+			Detail:   "model_or_channel",
+		}
+	}
+	if !isOpenAICompatibleAccountEligibleForRequest(ctx, acc, platform, requestedModel, requireCompact, requiredCapability) {
+		if requestedModel != "" && !acc.IsSchedulableForModelWithContext(ctx, requestedModel) {
+			remaining := acc.GetRateLimitRemainingTimeWithContext(ctx, requestedModel)
+			if remaining > 0 {
+				return openAICompatSelectionFailureDiagnosis{
+					Category: "model_rate_limited",
+					Detail:   remaining.String(),
+				}
+			}
+		}
+		return openAICompatSelectionFailureDiagnosis{Category: "unschedulable", Detail: "eligibility"}
+	}
+	if s.isOpenAIAccountRuntimeBlocked(acc) {
+		return openAICompatSelectionFailureDiagnosis{Category: "runtime_blocked", Detail: "whole_account"}
+	}
+	return openAICompatSelectionFailureDiagnosis{Category: "eligible"}
+}
+
+func (s *OpenAIGatewayService) logOpenAICompatSelectionFailure(
+	ctx context.Context,
+	eval *openAICompatNoCandidateEval,
+	requestedModel string,
+	stats selectionFailureStats,
+) {
+	if s == nil || eval == nil {
+		return
+	}
+	platform := strings.TrimSpace(eval.platform)
+	if platform == "" {
+		platform = PlatformOpenAI
+	}
+	slog.Warn("openai_account_selection_failed",
+		"group_id", derefGroupID(eval.groupID),
+		"model", requestedModel,
+		"platform", platform,
+		"total", stats.Total,
+		"eligible", stats.Eligible,
+		"excluded", stats.Excluded,
+		"unschedulable", stats.Unschedulable,
+		"runtime_blocked", stats.RuntimeBlocked,
+		"model_unsupported", stats.ModelUnsupported,
+		"model_rate_limited", stats.ModelRateLimited,
+		"sample_runtime_blocked", stats.SampleRuntimeBlockedIDs,
+		"sample_model_unsupported", stats.SampleMappingIDs,
+		"sample_model_rate_limited", stats.SampleRateLimitIDs,
+	)
+	_ = ctx
+}

--- a/backend/internal/service/openai_account_scheduler_tk_selection_diag_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_selection_diag_test.go
@@ -1,0 +1,80 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectOpenAICompatSelectionFailureStatsForRequest_RuntimeBlocked(t *testing.T) {
+	ctx := context.Background()
+	gateway := &OpenAIGatewayService{}
+	groupID := int64(2)
+	account := &Account{
+		ID:       73,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"gpt-5.4": "gpt-5.4"},
+		},
+	}
+	gateway.BlockAccountScheduling(account, time.Now().Add(time.Minute), "429")
+
+	stats := gateway.collectOpenAICompatSelectionFailureStatsForRequest(
+		ctx,
+		&groupID,
+		PlatformOpenAI,
+		"gpt-5.4",
+		false,
+		OpenAIEndpointCapabilityChatCompletions,
+		[]Account{*account},
+		nil,
+	)
+
+	require.Equal(t, 1, stats.Total)
+	require.Equal(t, 0, stats.Eligible)
+	require.Equal(t, 1, stats.RuntimeBlocked)
+	require.Equal(t, []int64{73}, stats.SampleRuntimeBlockedIDs)
+}
+
+func TestOpenAICompatNoCandidateError_LogsCapacityStats(t *testing.T) {
+	ctx := context.Background()
+	gateway := &OpenAIGatewayService{}
+	groupID := int64(2)
+	account := &Account{
+		ID:          75,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"gpt-5.4": "gpt-5.4"},
+		},
+	}
+	gateway.BlockAccountScheduling(account, time.Now().Add(time.Minute), "429")
+
+	err := openAICompatNoCandidateError(
+		"gpt-5.4",
+		PlatformOpenAI,
+		false,
+		[]Account{*account},
+		nil,
+		&openAICompatNoCandidateEval{
+			ctx:                ctx,
+			svc:                gateway,
+			groupID:            &groupID,
+			platform:           PlatformOpenAI,
+			requiredCapability: OpenAIEndpointCapabilityChatCompletions,
+		},
+	)
+
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrUnsupportedModel))
+}

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -1880,9 +1880,9 @@ func TestHandleGrokAccountUpstreamErrorDoesNotShortenExistingPause(t *testing.T)
 	require.Zero(t, repo.tempUnschedCalls)
 	value, ok := svc.openaiAccountRuntimeBlockUntil.Load(account.ID)
 	require.True(t, ok)
-	runtimeUntil, ok := value.(time.Time)
+	entry, ok := loadOpenAIAccountRuntimeBlockEntry(value)
 	require.True(t, ok)
-	require.WithinDuration(t, existingUntil, runtimeUntil, time.Second)
+	require.WithinDuration(t, existingUntil, entry.Until, time.Second)
 }
 
 func TestUpdateGrokUsageSnapshotExhaustedSuccessBypassesThrottleAndSetsRateLimited(t *testing.T) {

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -358,10 +358,12 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 
 	if selected == nil {
 		return nil, openAICompatNoCandidateError(requestedModel, platform, compactBlocked, accounts, excludedIDs, &openAICompatNoCandidateEval{
-			ctx:            ctx,
-			svc:            s,
-			groupID:        groupID,
-			requireCompact: requireCompact,
+			ctx:                ctx,
+			svc:                s,
+			groupID:            groupID,
+			platform:           platform,
+			requireCompact:     requireCompact,
+			requiredCapability: requiredCapability,
 		})
 	}
 
@@ -616,10 +618,12 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	if len(accounts) == 0 {
 		evidence := s.listOpenAICompatSchedulableAccountEvidence(ctx, groupID, platform)
 		return nil, openAICompatNoCandidateError(requestedModel, platform, false, evidence, excludedIDs, &openAICompatNoCandidateEval{
-			ctx:            ctx,
-			svc:            s,
-			groupID:        groupID,
-			requireCompact: requireCompact,
+			ctx:                ctx,
+			svc:                s,
+			groupID:            groupID,
+			platform:           platform,
+			requireCompact:     requireCompact,
+			requiredCapability: requiredCapability,
 		})
 	}
 
@@ -724,10 +728,12 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 
 	if len(candidates) == 0 {
 		return nil, openAICompatNoCandidateError(requestedModel, platform, false, accounts, excludedIDs, &openAICompatNoCandidateEval{
-			ctx:            ctx,
-			svc:            s,
-			groupID:        groupID,
-			requireCompact: requireCompact,
+			ctx:                ctx,
+			svc:                s,
+			groupID:            groupID,
+			platform:           platform,
+			requireCompact:     requireCompact,
+			requiredCapability: requiredCapability,
 		})
 	}
 	rateOrder := openAILegacyUpstreamRateOrder{}
@@ -920,10 +926,12 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		return nil, ErrNoAvailableCompactAccounts
 	}
 	return nil, openAICompatNoCandidateError(requestedModel, platform, false, accounts, excludedIDs, &openAICompatNoCandidateEval{
-		ctx:            ctx,
-		svc:            s,
-		groupID:        groupID,
-		requireCompact: requireCompact,
+		ctx:                ctx,
+		svc:                s,
+		groupID:            groupID,
+		platform:           platform,
+		requireCompact:     requireCompact,
+		requiredCapability: requiredCapability,
 	})
 }
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -287,7 +287,7 @@ type OpenAIGatewayService struct {
 	openaiProxyStreamCircuit      *openAIProxyStreamCircuit
 
 	openaiWSFallbackUntil               sync.Map // key: int64(accountID), value: time.Time
-	openaiAccountRuntimeBlockUntil      sync.Map // key: int64(accountID), value: time.Time
+	openaiAccountRuntimeBlockUntil      sync.Map // key: int64(accountID), value: openAIAccountRuntimeBlockEntry (legacy time.Time tolerated)
 	openaiAccountRuntimeBlockLocks      sync.Map // key: int64(accountID), value: *sync.Mutex
 	openaiAccountRuntimeBlockGeneration sync.Map // key: int64(accountID), value: uint64
 	openaiAccountRuntimeBlockSequence   atomic.Uint64

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -251,7 +251,9 @@ func (s *RateLimitService) notifyAccountSchedulingBlocked(account *Account, unti
 	if s == nil || s.runtimeBlocker == nil || account == nil {
 		return
 	}
-	s.runtimeBlocker.BlockAccountScheduling(account, until, reason)
+	if isWholeAccountRuntimeBlockReason(reason) {
+		s.runtimeBlocker.BlockAccountScheduling(account, until, reason)
+	}
 	// TK: 同一汇聚点上报账号失效事件给飞书（kind 由 reason 在 classifyIncident 内精确派生）。
 	s.notifyAccountIncident(account, until, reason, IncidentKindUnknown, detail...)
 	// TK: 池级检查——若这是该平台最后一个可调度账号,即时发全池不可调度 P0。

--- a/backend/internal/service/ratelimit_service_tk_incident.go
+++ b/backend/internal/service/ratelimit_service_tk_incident.go
@@ -10,7 +10,7 @@ import (
 // cooldown reasons only persist model_rate_limits and incident telemetry.
 func isWholeAccountRuntimeBlockReason(reason string) bool {
 	switch strings.TrimSpace(reason) {
-	case "429_codex_metered", "429_model_class", "429_mirror_class_downstream_empty", tkOpenAIMirrorDownstreamEmptyReason:
+	case "429_codex_metered", "429_model_class", "429_mirror_class_downstream_empty", "429_openai_mirror_downstream_empty":
 		return false
 	default:
 		return true

--- a/backend/internal/service/ratelimit_service_tk_incident.go
+++ b/backend/internal/service/ratelimit_service_tk_incident.go
@@ -1,6 +1,21 @@
 package service
 
-import "time"
+import (
+	"strings"
+	"time"
+)
+
+// isWholeAccountRuntimeBlockReason reports whether a notifyAccountSchedulingBlocked
+// reason should also write the in-memory whole-account runtime blocker. Model-scoped
+// cooldown reasons only persist model_rate_limits and incident telemetry.
+func isWholeAccountRuntimeBlockReason(reason string) bool {
+	switch strings.TrimSpace(reason) {
+	case "429_codex_metered", "429_model_class", "429_mirror_class_downstream_empty", tkOpenAIMirrorDownstreamEmptyReason:
+		return false
+	default:
+		return true
+	}
+}
 
 // TK: 账号失效事件 → 飞书告警的挂钩 glue。核心实现在 account_incident_notifier_tk.go。
 //

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1415,9 +1415,12 @@
         "shouldDisable := s.rateLimitService.HandleUpstreamError(stateCtx, account, statusCode, headers, responseBody, canonicalModel...)",
         "tkShouldOpenAICodex429BeModelScoped(account, headers, responseBody, reqModel)",
         "s.BlockAccountScheduling(account, time.Time{}, \"upstream_disable\")",
-        "openAIOAuth429StormThreshold"
+        "openAIOAuth429StormThreshold",
+        "noteOpenAIOAuth429ForScheduling",
+        "reconcileOpenAIAccountRuntimeBlockWithDB",
+        "openai_account_runtime_block_cleared_rate_limit_drift"
       ],
-      "rationale": "OPC companion for upstream OpenAI cooldown scheduling (#2698 / 1e406fed): centralizes HandleUpstreamError + BlockAccountScheduling + OAuth 429 storm guard so openai_gateway_service.go and openai_account_scheduler.go stay thin. HandleUpstreamError MUST receive requestedModel so spark usage_limit_reached 429s hit model_rate_limits (path 2) instead of whole-account SetRateLimited while the account-wide codex window is healthy (prod GPT-pro1 2026-07-06). tkShouldOpenAICodex429BeModelScoped gates markOpenAIOAuth429RateLimited so model-scoped spark cooldowns do not whole-account BlockAccountScheduling. Pinning shouldDisable capture and upstream_disable block path prevents silent reversion to `_ =` side-effect-only handling. OAuth 429 storm threshold anchors the TK failover guard that limits account switches during burst 429s."
+      "rationale": "OPC companion for upstream OpenAI cooldown scheduling (#2698 / 1e406fed): centralizes HandleUpstreamError + BlockAccountScheduling + OAuth 429 storm guard so openai_gateway_service.go and openai_account_scheduler.go stay thin. HandleUpstreamError MUST receive requestedModel so spark usage_limit_reached 429s hit model_rate_limits (path 2) instead of whole-account SetRateLimited while the account-wide codex window is healthy (prod GPT-pro1 2026-07-06). tkShouldOpenAICodex429BeModelScoped gates noteOpenAIOAuth429ForScheduling so model-scoped spark cooldowns do not whole-account BlockAccountScheduling. Prod 2026-07-28 (GPT-pro3/4): whole-account runtime blocks for OAuth 429 MUST follow notifyAccountSchedulingBlocked only — noteOpenAIOAuth429ForScheduling records storm state but must NOT write unclamped 7d header reset when rateLimitService is present; reconcileOpenAIAccountRuntimeBlockWithDB clears in-memory 429 drift after DB rate_limit_reset_at expires. Pinning shouldDisable capture and upstream_disable block path prevents silent reversion to `_ =` side-effect-only handling. OAuth 429 storm threshold anchors the TK failover guard that limits account switches during burst 429s."
     },
     {
       "path": "backend/internal/service/openai_oauth_passthrough_test.go",
@@ -2624,9 +2627,10 @@
     {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
-        "s.notifyAccountIncident(account, until, reason, IncidentKindUnknown, detail...)"
+        "s.notifyAccountIncident(account, until, reason, IncidentKindUnknown, detail...)",
+        "isWholeAccountRuntimeBlockReason(reason)"
       ],
-      "rationale": "账号失效 → 飞书告警的唯一挂钩点。notifyAccountSchedulingBlocked 是所有 13 个账号失效/冷却场景（auth_error / oauth_401 / 429 / 529 / 403temp / temp / custom / stream_timeout）的汇聚点；这一行把失效事件上报给 AccountIncidentNotifier（永久失效即时 P0 红头卡片、临时冷却聚合低频橙头摘要）。末尾的 detail... 透传上游限流维度提示（Anthropic 5h/7d 用量窗口、被限流的模型类）进飞书摘要，变参故非 enriched 挂钩点不受影响。上游合并若重写 notifyAccountSchedulingBlocked 并丢掉此行，会让账号失效告警静默失效——运营再也收不到『某账号该重新 OAuth / 查 bug』，且无编译错误、极难发现。本 sentinel 捕获该 revert。"
+      "rationale": "账号失效 → 飞书告警的唯一挂钩点。notifyAccountSchedulingBlocked 是所有 13 个账号失效/冷却场景（auth_error / oauth_401 / 429 / 529 / 403temp / temp / custom / stream_timeout）的汇聚点；这一行把失效事件上报给 AccountIncidentNotifier（永久失效即时 P0 红头卡片、临时冷却聚合低频橙头摘要）。末尾的 detail... 透传上游限流维度提示（Anthropic 5h/7d 用量窗口、被限流的模型类）进飞书摘要，变参故非 enriched 挂钩点不受影响。isWholeAccountRuntimeBlockReason gates in-memory BlockAccountScheduling so model-scoped cooldown reasons (429_codex_metered / 429_model_class) do not whole-account runtime-block — SSOT with notifyAccountSchedulingBlocked for OAuth 429 (prod GPT-pro3/4 2026-07-28).上游合并若重写 notifyAccountSchedulingBlocked 并丢掉此行，会让账号失效告警静默失效——运营再也收不到『某账号该重新 OAuth / 查 bug』，且无编译错误、极难发现。本 sentinel 捕获该 revert。"
     },
     {
       "path": "backend/internal/service/account_incident_notifier_tk.go",
@@ -2649,9 +2653,10 @@
       "must_contain": [
         "func (s *RateLimitService) SetAccountIncidentNotifier(",
         "func (s *RateLimitService) notifyAccountIncident(",
-        "func (s *RateLimitService) notifyAccountRecovered("
+        "func (s *RateLimitService) notifyAccountRecovered(",
+        "func isWholeAccountRuntimeBlockReason(reason string) bool"
       ],
-      "rationale": "把 AccountIncidentNotifier 注入 RateLimitService 的 glue：wire ProvideTKAccountIncidentNotifier 在构造后调 SetAccountIncidentNotifier 回填，挂钩点（ratelimit_service.go）经 notifyAccountIncident 转发。notifyAccountRecovered 是恢复绿卡的转发包装，由 notifyAccountSchedulingBlockCleared(ClearRateLimit/RecoverAccountState 真实清除事件)调用。删掉会让挂钩行编译失败或静默 no-op，账号失效/恢复告警链路断裂。"
+      "rationale": "把 AccountIncidentNotifier 注入 RateLimitService 的 glue：wire ProvideTKAccountIncidentNotifier 在构造后调 SetAccountIncidentNotifier 回填，挂钩点（ratelimit_service.go）经 notifyAccountIncident 转发。notifyAccountRecovered 是恢复绿卡的转发包装，由 notifyAccountSchedulingBlockCleared(ClearRateLimit/RecoverAccountState 真实清除事件)调用。isWholeAccountRuntimeBlockReason is the SSOT predicate for whether notifyAccountSchedulingBlocked also writes the in-memory whole-account runtime blocker (model-scoped 429 reasons excluded).删掉会让挂钩行编译失败或静默 no-op，账号失效/恢复告警链路断裂。"
     },
     {
       "path": "backend/internal/service/openai_account_scheduler.go",
@@ -3012,6 +3017,30 @@
         "collectOpenAICompatSelectionFailureStatsForRequest"
       ],
       "rationale": "Regression coverage for prod 2026-07 wrong-key/wrong-group model requests: upstream channel restriction on passthrough accounts and Qwen-only groups must surface ErrUnsupportedModel instead of routing/platform 429."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler_tk_selection_diag.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) collectOpenAICompatSelectionFailureStatsForRequest(",
+        "openai_account_selection_failed",
+        "runtime_blocked"
+      ],
+      "rationale": "Prod 2026-07-28 GPT-pro3/4 incident observability: when OpenAI-compat selection empties the pool, log openai_account_selection_failed with per-account rejection axes including runtime_blocked (in-memory block vs DB schedulable drift). collectOpenAICompatSelectionFailureStatsForRequest mirrors scheduler eligibility ordering so ops can distinguish client-fault unsupported model from whole-account runtime block without restart."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler_tk_selection_diag_test.go",
+      "must_contain": [
+        "TestCollectOpenAICompatSelectionFailureStatsForRequest_RuntimeBlocked"
+      ],
+      "rationale": "Regression: runtime-blocked OAuth accounts must count as runtime_blocked (not unschedulable) in selection failure stats so openai_account_selection_failed surfaces the prod GPT-pro3/4 drift signature."
+    },
+    {
+      "path": "backend/internal/service/openai_account_runtime_block_fastpath_test.go",
+      "must_contain": [
+        "TestHandleOpenAIAccountUpstreamError_7d429_RuntimeBlockMatchesClampedDB",
+        "TestReconcileOpenAIAccountRuntimeBlockWithDB_ClearsStale429Drift"
+      ],
+      "rationale": "Prod 2026-07-28 GPT-pro3/4: OAuth 429 with 7d codex header must write runtime block matching clamped DB reset (5h), not unclamped header; reconcile must clear stale in-memory 429 drift after DB rate_limit_reset_at expires without wiping short oauth_401 blocks."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_group_unsupported_cache.go",


### PR DESCRIPTION
## 摘要

- 修复 prod GPT 专线（GPT-pro3/4）在 DB/Redis 已恢复可调度后仍 429 的根因：`markOpenAIOAuth429RateLimited` 曾用未 clamp 的 7d reset 写内存，而 `SetRateLimited` 只写 5h clamp，且内存 block 不可缩短。
- **SSOT**：整账号 runtime block 仅经 `notifyAccountSchedulingBlocked` 写入；OAuth 429 fast-path 只做 storm 计数。模型级 cooldown（`429_codex_metered` 等）不再误写整账号内存 block。
- **漂移 reconcile**：DB `rate_limit_reset_at` 过期后，若 429 内存 block 仍显著超出 DB 权威，自动清除。
- **可观测性**：OpenAI 选号池滤空时输出 `openai_account_selection_failed`，含 `runtime_blocked` 等维度。

## 风险

- sentinel-registry-reviewed（OpenAI runtime block SSOT / Grok rollback / selection diag；gateway-tk sentinel 已补锚点）

- 常规风险：仅后端调度/ratelimit 路径，无 schema/API 契约变更。
- 已部署进程上历史漂移 block 会在下次选号检查时 lazy 清除，无需重启。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service -run 'TestHandleOpenAIAccountUpstreamError_7d429|TestReconcileOpenAIAccountRuntimeBlock|TestCollectOpenAICompatSelectionFailureStats|TestOpenAICompatNoCandidateError' -count=1
```

- 上述测试全绿（本地已跑）。
- 更广 OpenAI/runtime block 相关 unit 测试集全绿。

## 提交
- `19f6dfe55` fix(sentinel): anchor OpenAI OAuth 429 runtime-block SSOT
- `e6958fc09` fix(openai): align Grok runtime rollback with block entry SSOT

- `46a9faa5f` fix(openai): SSOT OAuth 429 runtime block 与 DB 漂移 reconcile

最新提交：`e6958fc09`

Made with [Cursor](https://cursor.com)
