### PR TITLE
fix(kiro): require explicit Claude Code completion before end_turn

### DIFF
--- a/.testing/user-stories/stories/US-041-kiro-claude-code-completion-continuity.md
+++ b/.testing/user-stories/stories/US-041-kiro-claude-code-completion-continuity.md
@@ -45,6 +45,7 @@
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestMapKiroStopReason_PreservesTerminalOutcome`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeEndTurnContinuesUntilExplicitCompletion`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_EmptyCompletionSignalDoesNotFinish`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_EmptyCompletionMessageWithAssistantTextDoesNotFinish`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolUseReturnsImmediately`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolWinsOverCompletionSignal`

--- a/.testing/user-stories/stories/US-041-kiro-claude-code-completion-continuity.md
+++ b/.testing/user-stories/stories/US-041-kiro-claude-code-completion-continuity.md
@@ -7,22 +7,24 @@
   作为 **通过 TokenKey Kiro 节点使用 Claude Code 的开发者**，我希望 **Claude Code 收到真实的终止原因，并在实现或验证未完成时继续使用工具**，**以便** 终端不会把截断或未知结果显示成正常完成，也不需要我反复输入“继续”。
 - Trace:
   - 设计锚点：`docs/approved/kiro-claude-code-completion-continuity.md`
-  - Prompt 轴线：Claude Code system prompt 经共享 completion guard owner 幂等注入到 Kiro system priming。
-  - 协议轴线：Kiro `metadataEvent.stopReason` 显式映射到 Anthropic Messages JSON/SSE stop reason。
-  - 可观测轴线：成功映射记录 `gateway.kiro_stop_reason`；未知值 fail closed，不再伪造 `end_turn`。
+  - Prompt 轴线：Claude Code system prompt 经共享 completion guard owner 幂等注入到 Kiro system priming，并启用 transport-private completion tool。
+  - 协议轴线：Kiro `metadataEvent.stopReason` 显式映射到 Anthropic Messages JSON/SSE stop reason；模型任务完成由私有工具显式确认。
+  - 续跑轴线：缺少有效完成信号的 `END_TURN` 在同一客户端请求内有界续跑，普通工具调用仍交还 Claude Code。
+  - 可观测轴线：成功映射记录 `gateway.kiro_stop_reason`，完成协议记录 `gateway.kiro_completion_protocol`；未知值 fail closed。
 - Risk Focus:
-  - 逻辑错误：`MAX_TOKENS`、tool use 或未知终止态被错误合成为 `end_turn`。
-  - 行为回归：普通非 Claude Code prompt、Kiro 内容过滤契约和 OpenAI-compatible Messages 既有 guard 检测必须保持不变。
+  - 逻辑错误：模型级 `END_TURN` 被误认为 Agent 任务完成，或 `MAX_TOKENS`、tool use、policy/malformed 终止态被错误合成为 `end_turn`。
+  - 行为回归：普通非 Claude Code prompt、同名客户端工具、普通 Claude Code 工具、Kiro 内容过滤契约和 OpenAI-compatible Messages 既有 guard 检测必须保持不变。
   - 安全问题：日志仅记录截断后的 stop reason、模型和账号 ID，不记录 prompt、响应正文或凭证。
   - 运行时：流式响应已经产生内容后遇到未知终止态时必须发 error，不能再发成功的 `message_delta/message_stop`。
 
 ## Acceptance Criteria
 
-1. **AC-001（完成连续性）**：Given Claude Code system prompt，When 构建 Kiro payload，Then completion guard 位于 system priming 且只出现一次；已有 marker 时仍不重复。
-2. **AC-002（范围守卫）**：Given 普通 API system prompt，When 构建 Kiro system prompt，Then 不注入 Claude Code completion guard。
-3. **AC-003（截断语义）**：Given Kiro 返回 `MAX_TOKENS`，When 流式或非流式 gateway 完成转换，Then Anthropic stop reason 为 `max_tokens`，不得出现 `end_turn`。
-4. **AC-004（未知值 fail closed）**：Given Kiro 返回未知或空 stop reason，When gateway 处理，Then 非流式进入 502 failover；流式发送 `unsupported_stop_reason` error 且不发送成功终止事件。
-5. **AC-005（既有契约回归）**：Given `END_TURN`、tool use 或有输出的 `CONTENT_FILTERED`，When gateway 转换，Then分别保持 `end_turn`、`tool_use` 与既有可见拒答成功语义。
+1. **AC-001（显式完成协议）**：Given Claude Code system prompt，When 构建 Kiro payload，Then completion guard 与 transport-private completion tool 各只出现一次；有效 `complete/blocked` 信号被消费并转换为最终文本与 `end_turn`。
+2. **AC-002（未完成续跑）**：Given Kiro 返回文本与 `END_TURN` 但无有效完成信号，When 流式或非流式 gateway 处理，Then 在同一客户端请求内继续 Kiro turn，直到收到完成信号或达到确定性上限。
+3. **AC-003（范围与工具守卫）**：Given 普通 API 请求声明同名工具，When Kiro 调用该工具，Then 工具不得被吞；Given Claude Code 调用普通工具或同时产生普通工具与完成信号，Then 普通工具立即以 `tool_use` 返回并优先于完成信号。
+4. **AC-004（截断语义）**：Given Kiro 返回 `MAX_TOKENS` 或 `MODEL_CONTEXT_WINDOW_EXCEEDED`，When gateway 转换，Then保留对应 Anthropic stop reason，即使同一响应含私有完成信号也不得覆盖。
+5. **AC-005（policy 与 malformed 语义）**：Given Kiro 返回 policy refusal，When有可见文本时映射 `refusal`、无输出时返回客户端内容过滤错误；Given malformed/未知/空 stop reason，Then fail closed，不伪造成功结束。
+6. **AC-006（有界与计费）**：Given 模型持续不发完成信号，When达到内部续跑上限，Then停止追加 Kiro 请求；隐藏续跑的输入与隐藏工具输出计入估算用量。
 
 ## Assertions
 
@@ -30,14 +32,24 @@
 - 完整 Kiro payload 的 history 与 current message 合计只有一个 guard marker。
 - `mapKiroStopReason` 对已知值显式映射，对空值和未知值返回 typed error。
 - JSON 与 SSE wire 分别保留 `max_tokens`；未知流式终止态不包含 `message_stop`。
-- sentinel 锚定共享 owner、translator 注入点、stop-reason mapper、结构化日志与核心回归测试。
+- 私有工具只在 `ClaudeCodeCompletionProtocol` 为真时被消费；空消息、普通工具或非完成 stop reason 不能提前结束。
+- sentinel 锚定共享 owner、私有协议 owner、有界续跑、范围门禁、stop metadata、结构化日志与核心回归测试。
 
 ## Linked Tests
 
 - `backend/internal/pkg/claude/claude_code_completion_guard_test.go`::`TestEnsureClaudeCodeCompletionGuard_AppendsExactlyOnce`
 - `backend/internal/integration/kiro/prompt_filter_test.go`::`TestUS041_ClaudeToKiro_CompletionGuardAppearsOnceInSystemPriming`
 - `backend/internal/integration/kiro/prompt_filter_test.go`::`TestBuildClaudeSystemPrompt_NonClaudeCodeDoesNotAddCompletionGuard`
+- `backend/internal/integration/kiro/claude_code_completion_test.go`::`TestConsumeClaudeCodeCompletionSignal_StripsOnlyPrivateTool`
+- `backend/internal/integration/kiro/claude_code_completion_test.go`::`TestPrepareClaudeCodeCompletionContinuation_PreservesToolsAndMovesTurnToHistory`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestMapKiroStopReason_PreservesTerminalOutcome`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeEndTurnContinuesUntilExplicitCompletion`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_EmptyCompletionSignalDoesNotFinish`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolUseReturnsImmediately`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolWinsOverCompletionSignal`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_MaxTokensOverridesCompletionSignal`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeCompletionLoopIsBounded`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestKiroGatewayService_Forward_NonStreaming_PreservesMaxTokensStopReason`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestKiroGatewayService_Forward_Streaming_PreservesMaxTokensStopReason`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestKiroGatewayService_Forward_Streaming_UnknownStopReasonFailsClosed`

--- a/backend/internal/integration/kiro/claude_code_completion.go
+++ b/backend/internal/integration/kiro/claude_code_completion.go
@@ -1,0 +1,125 @@
+package kiro
+
+import (
+	"strings"
+
+	claudepkg "github.com/Wei-Shaw/sub2api/internal/pkg/claude"
+	"github.com/google/uuid"
+)
+
+const claudeCodeCompletionContinuationPrompt = `The preceding assistant response ended without the required transport completion signal, so the Claude Code turn is still active. Continue the same task now. Use the normal Claude Code tools for every remaining action. When the requested work and verification are actually complete, or progress genuinely requires user input, finish by calling sub2apiClaudeCodeCompletion with the appropriate status and a complete user-facing message.`
+
+// ClaudeCodeCompletionSignal is emitted by the transport-private completion
+// tool. The Kiro gateway consumes it and never exposes the tool call itself to
+// Claude Code.
+type ClaudeCodeCompletionSignal struct {
+	Status  string
+	Message string
+}
+
+// IsClaudeCodeCompletionToolUse reports whether a Kiro tool call belongs to
+// the transport-private completion protocol.
+func IsClaudeCodeCompletionToolUse(toolUse KiroToolUse) bool {
+	return toolUse.Name == claudepkg.ClaudeCodeCompletionToolName
+}
+
+// addClaudeCodeCompletionTool installs the transport-private completion tool.
+// A client tool collision disables the protocol instead of shadowing a real
+// Claude Code tool.
+func addClaudeCodeCompletionTool(tools []KiroToolWrapper) ([]KiroToolWrapper, bool) {
+	for i := range tools {
+		if tools[i].ToolSpecification.Name == claudepkg.ClaudeCodeCompletionToolName {
+			return tools, false
+		}
+	}
+
+	tool := KiroToolWrapper{}
+	tool.ToolSpecification.Name = claudepkg.ClaudeCodeCompletionToolName
+	tool.ToolSpecification.Description = "Report that the Claude Code task is complete or genuinely blocked on user input. This transport-only tool is the only valid way to end a text-only response. Do not call it while implementation, investigation, or verification remains."
+	tool.ToolSpecification.InputSchema = InputSchema{JSON: map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"status": map[string]any{
+				"type":        "string",
+				"enum":        []string{"complete", "blocked"},
+				"description": "Use complete only when all requested work and verification are done; use blocked only when user input is required.",
+			},
+			"message": map[string]any{
+				"type":        "string",
+				"minLength":   1,
+				"description": "The complete final answer shown to the user, or the exact blocker and question requiring user input.",
+			},
+		},
+		"required": []string{"status", "message"},
+	}}
+	return append(tools, tool), true
+}
+
+// ConsumeClaudeCodeCompletionSignal removes transport-private tool calls and
+// returns the first valid completion signal. Ordinary Claude Code tool calls
+// are preserved byte-for-byte for the Anthropic response.
+func ConsumeClaudeCodeCompletionSignal(toolUses []KiroToolUse) ([]KiroToolUse, *ClaudeCodeCompletionSignal) {
+	clientToolUses := make([]KiroToolUse, 0, len(toolUses))
+	var signal *ClaudeCodeCompletionSignal
+	for i := range toolUses {
+		toolUse := toolUses[i]
+		if !IsClaudeCodeCompletionToolUse(toolUse) {
+			clientToolUses = append(clientToolUses, toolUse)
+			continue
+		}
+		if signal != nil {
+			continue
+		}
+		status, _ := toolUse.Input["status"].(string)
+		status = strings.ToLower(strings.TrimSpace(status))
+		if status != "complete" && status != "blocked" {
+			continue
+		}
+		message, _ := toolUse.Input["message"].(string)
+		signal = &ClaudeCodeCompletionSignal{
+			Status:  status,
+			Message: strings.TrimSpace(message),
+		}
+	}
+	return clientToolUses, signal
+}
+
+// PrepareClaudeCodeCompletionContinuation turns the just-finished Kiro model
+// response into history and appends a private continuation instruction as the
+// next current message. It keeps the conversation ID and normal tool catalog,
+// but rotates the continuation ID and removes stale images/tool results.
+func PrepareClaudeCodeCompletionContinuation(payload *KiroPayload, assistantText string) {
+	if payload == nil || !payload.ClaudeCodeCompletionProtocol {
+		return
+	}
+
+	current := payload.ConversationState.CurrentMessage.UserInputMessage
+	tools := []KiroToolWrapper(nil)
+	if current.UserInputMessageContext != nil {
+		tools = current.UserInputMessageContext.Tools
+	}
+
+	history := append(payload.ConversationState.History, KiroHistoryMessage{
+		UserInputMessage: &current,
+	})
+	assistantText = strings.TrimSpace(assistantText)
+	if assistantText == "" {
+		assistantText = "[No completion signal was provided.]"
+	}
+	history = append(history, KiroHistoryMessage{
+		AssistantResponseMessage: &KiroAssistantResponseMessage{Content: assistantText},
+	})
+	payload.ConversationState.History = sanitizeKiroHistory(history, nil)
+
+	next := KiroUserInputMessage{
+		Content: claudeCodeCompletionContinuationPrompt,
+		ModelID: current.ModelID,
+		Origin:  current.Origin,
+	}
+	if len(tools) > 0 {
+		next.UserInputMessageContext = &UserInputMessageContext{Tools: tools}
+	}
+	payload.ConversationState.CurrentMessage.UserInputMessage = next
+	payload.ConversationState.AgentContinuationId = uuid.New().String()
+	truncatePayloadToLimit(payload, true)
+}

--- a/backend/internal/integration/kiro/claude_code_completion_test.go
+++ b/backend/internal/integration/kiro/claude_code_completion_test.go
@@ -1,0 +1,56 @@
+//go:build unit
+
+package kiro
+
+import (
+	"testing"
+
+	claudepkg "github.com/Wei-Shaw/sub2api/internal/pkg/claude"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumeClaudeCodeCompletionSignal_StripsOnlyPrivateTool(t *testing.T) {
+	visible, signal := ConsumeClaudeCodeCompletionSignal([]KiroToolUse{
+		{ToolUseID: "toolu_read", Name: "Read", Input: map[string]any{"file_path": "a.go"}},
+		{ToolUseID: "toolu_done", Name: claudepkg.ClaudeCodeCompletionToolName, Input: map[string]any{
+			"status":  "complete",
+			"message": "Done and verified.",
+		}},
+	})
+
+	require.Len(t, visible, 1)
+	require.Equal(t, "Read", visible[0].Name)
+	require.Equal(t, &ClaudeCodeCompletionSignal{Status: "complete", Message: "Done and verified."}, signal)
+}
+
+func TestPrepareClaudeCodeCompletionContinuation_PreservesToolsAndMovesTurnToHistory(t *testing.T) {
+	payload := &KiroPayload{ClaudeCodeCompletionProtocol: true}
+	payload.ConversationState.AgentContinuationId = "old-continuation"
+	payload.ConversationState.History = []KiroHistoryMessage{
+		{UserInputMessage: &KiroUserInputMessage{Content: "system priming", ModelID: "claude-sonnet-4.5", Origin: "AI_EDITOR"}},
+		{AssistantResponseMessage: &KiroAssistantResponseMessage{Content: "I will follow these instructions."}},
+	}
+	completionTool, enabled := addClaudeCodeCompletionTool(nil)
+	require.True(t, enabled)
+	inputSchema := completionTool[0].ToolSpecification.InputSchema.JSON.(map[string]any)
+	messageSchema := inputSchema["properties"].(map[string]any)["message"].(map[string]any)
+	require.Equal(t, 1, messageSchema["minLength"])
+	payload.ConversationState.CurrentMessage.UserInputMessage = KiroUserInputMessage{
+		Content: "implement the fix",
+		ModelID: "claude-sonnet-4.5",
+		Origin:  "AI_EDITOR",
+		UserInputMessageContext: &UserInputMessageContext{
+			Tools: completionTool,
+		},
+	}
+
+	PrepareClaudeCodeCompletionContinuation(payload, "I found the relevant file.")
+
+	require.NotEqual(t, "old-continuation", payload.ConversationState.AgentContinuationId)
+	require.Contains(t, payload.ConversationState.CurrentMessage.UserInputMessage.Content, "still active")
+	require.Len(t, payload.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext.Tools, 1)
+	require.Equal(t, claudepkg.ClaudeCodeCompletionToolName,
+		payload.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext.Tools[0].ToolSpecification.Name)
+	require.Equal(t, "implement the fix", payload.ConversationState.History[len(payload.ConversationState.History)-2].UserInputMessage.Content)
+	require.Equal(t, "I found the relevant file.", payload.ConversationState.History[len(payload.ConversationState.History)-1].AssistantResponseMessage.Content)
+}

--- a/backend/internal/integration/kiro/client.go
+++ b/backend/internal/integration/kiro/client.go
@@ -163,6 +163,11 @@ type KiroPayload struct {
 	// in tool_use responses so the client can match them to its tool registry.
 	// Not serialized to the Kiro API request body.
 	ToolNameMap map[string]string `json:"-"`
+
+	// ClaudeCodeCompletionProtocol marks payloads whose system prompt was
+	// positively identified as Claude Code and whose tool list contains the
+	// transport-private completion signal. It is service-side state only.
+	ClaudeCodeCompletionProtocol bool `json:"-"`
 }
 
 type KiroUserInputMessage struct {
@@ -236,6 +241,7 @@ type KiroStreamCallback struct {
 	OnText         func(text string, isThinking bool)
 	OnToolUse      func(toolUse KiroToolUse)
 	OnStopReason   func(stopReason string)
+	OnStopMetadata func(metadata KiroStopMetadata)
 	OnComplete     func(inputTokens, outputTokens int)
 	OnError        func(err error)
 	OnCredits      func(credits float64)
@@ -244,6 +250,23 @@ type KiroStreamCallback struct {
 	// Returning true permits retrying the next endpoint; false preserves the
 	// error, which is required once streaming output has been committed.
 	ResetForRetry func() bool
+}
+
+// KiroStopMetadata preserves the terminal metadataEvent payload that carries
+// model-level refusal details in current Kiro clients.
+type KiroStopMetadata struct {
+	StopReason  string           `json:"stopReason"`
+	StopDetails *KiroStopDetails `json:"stopDetails,omitempty"`
+}
+
+type KiroStopDetails struct {
+	Refusal *KiroRefusalDetails `json:"refusal,omitempty"`
+}
+
+type KiroRefusalDetails struct {
+	Category         string `json:"category,omitempty"`
+	Explanation      string `json:"explanation,omitempty"`
+	RecommendedModel string `json:"recommendedModel,omitempty"`
 }
 
 // ==================== API Call ====================
@@ -565,6 +588,18 @@ func parseEventStream(body io.Reader, callback *KiroStreamCallback) error {
 		case "metadataEvent":
 			if stopReason, ok := event["stopReason"].(string); ok && stopReason != "" {
 				sawTerminalStop = true
+				if callback.OnStopMetadata != nil {
+					metadata := KiroStopMetadata{StopReason: stopReason}
+					if rawDetails, exists := event["stopDetails"]; exists && rawDetails != nil {
+						if encoded, err := json.Marshal(rawDetails); err == nil {
+							var details KiroStopDetails
+							if json.Unmarshal(encoded, &details) == nil {
+								metadata.StopDetails = &details
+							}
+						}
+					}
+					callback.OnStopMetadata(metadata)
+				}
 				if callback.OnStopReason != nil {
 					callback.OnStopReason(stopReason)
 				}

--- a/backend/internal/integration/kiro/estimate.go
+++ b/backend/internal/integration/kiro/estimate.go
@@ -108,6 +108,65 @@ func EstimateInputTokens(req *ClaudeRequest) int {
 	return total
 }
 
+// EstimatePayloadInputTokens estimates a translated Kiro payload. It is used
+// for hidden completion-continuation calls, whose extra prompt cost is absent
+// from the original Claude request and must not be silently left unbilled.
+func EstimatePayloadInputTokens(payload *KiroPayload) int {
+	if payload == nil {
+		return 0
+	}
+	parts := make([]string, 0, len(payload.ConversationState.History)*2+2)
+	appendUser := func(message *KiroUserInputMessage) {
+		if message == nil {
+			return
+		}
+		if message.Content != "" {
+			parts = append(parts, message.Content)
+		}
+		if message.UserInputMessageContext != nil {
+			for _, result := range message.UserInputMessageContext.ToolResults {
+				for _, content := range result.Content {
+					if content.Text != "" {
+						parts = append(parts, content.Text)
+					}
+				}
+			}
+		}
+	}
+	for i := range payload.ConversationState.History {
+		message := payload.ConversationState.History[i]
+		appendUser(message.UserInputMessage)
+		if message.AssistantResponseMessage == nil {
+			continue
+		}
+		if message.AssistantResponseMessage.Content != "" {
+			parts = append(parts, message.AssistantResponseMessage.Content)
+		}
+		for _, toolUse := range message.AssistantResponseMessage.ToolUses {
+			parts = append(parts, toolUse.Name, toolUse.ToolUseID)
+			if js := marshalJSONForEstimate(toolUse.Input); js != "" {
+				parts = append(parts, js)
+			}
+		}
+	}
+	current := &payload.ConversationState.CurrentMessage.UserInputMessage
+	appendUser(current)
+
+	total := countTokens(strings.Join(parts, "\n"))
+	if current.UserInputMessageContext != nil {
+		toolParts := make([]string, 0, len(current.UserInputMessageContext.Tools)*3)
+		for _, tool := range current.UserInputMessageContext.Tools {
+			spec := tool.ToolSpecification
+			toolParts = append(toolParts, spec.Name, spec.Description)
+			if js := marshalJSONForEstimate(spec.InputSchema.JSON); js != "" {
+				toolParts = append(toolParts, js)
+			}
+		}
+		total += countTokens(strings.Join(toolParts, "\n"))
+	}
+	return total
+}
+
 // appendMessageContentForEstimate flattens one message's content into parts for
 // estimation. It handles the string form and the []ContentBlock form, pulling
 // text, tool_result text, and tool_use Input JSON; image blocks are skipped.

--- a/backend/internal/integration/kiro/eventstream_test.go
+++ b/backend/internal/integration/kiro/eventstream_test.go
@@ -98,12 +98,16 @@ func TestParseEventStream_TerminalStopIgnoresTruncatedTrailingFrame(t *testing.T
 }
 
 func TestParseEventStream_MetadataStopReason(t *testing.T) {
-	frame := buildEventStreamMessage("metadataEvent", []byte(`{"stopReason":"CONTENT_FILTERED"}`))
+	frame := buildEventStreamMessage("metadataEvent", []byte(`{"stopReason":"CONTENT_FILTERED","stopDetails":{"refusal":{"category":"policy","explanation":"not allowed","recommendedModel":"claude-sonnet-4.5"}}}`))
 
 	var got string
+	var gotMetadata KiroStopMetadata
 	cb := &KiroStreamCallback{
 		OnStopReason: func(stopReason string) {
 			got = stopReason
+		},
+		OnStopMetadata: func(metadata KiroStopMetadata) {
+			gotMetadata = metadata
 		},
 	}
 
@@ -112,5 +116,11 @@ func TestParseEventStream_MetadataStopReason(t *testing.T) {
 	}
 	if got != "CONTENT_FILTERED" {
 		t.Fatalf("expected stop reason %q, got %q", "CONTENT_FILTERED", got)
+	}
+	if gotMetadata.StopDetails == nil || gotMetadata.StopDetails.Refusal == nil {
+		t.Fatalf("expected refusal stop details, got %#v", gotMetadata)
+	}
+	if gotMetadata.StopDetails.Refusal.Category != "policy" {
+		t.Fatalf("expected refusal category %q, got %q", "policy", gotMetadata.StopDetails.Refusal.Category)
 	}
 }

--- a/backend/internal/integration/kiro/prompt_filter_test.go
+++ b/backend/internal/integration/kiro/prompt_filter_test.go
@@ -97,6 +97,7 @@ func TestUS041_ClaudeToKiro_CompletionGuardAppearsOnceInSystemPriming(t *testing
 			}, false)
 
 			require.NotNil(t, payload)
+			require.True(t, payload.ClaudeCodeCompletionProtocol)
 			require.NotEmpty(t, payload.ConversationState.History)
 			require.NotNil(t, payload.ConversationState.History[0].UserInputMessage)
 			require.Contains(t, payload.ConversationState.History[0].UserInputMessage.Content, claudepkg.ClaudeCodeCompletionGuardMarker)
@@ -109,6 +110,33 @@ func TestUS041_ClaudeToKiro_CompletionGuardAppearsOnceInSystemPriming(t *testing
 			}
 			wireText.WriteString(payload.ConversationState.CurrentMessage.UserInputMessage.Content)
 			require.Equal(t, 1, strings.Count(wireText.String(), claudepkg.ClaudeCodeCompletionGuardMarker))
+
+			ctx := payload.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext
+			require.NotNil(t, ctx)
+			completionTools := 0
+			for _, tool := range ctx.Tools {
+				if tool.ToolSpecification.Name == claudepkg.ClaudeCodeCompletionToolName {
+					completionTools++
+				}
+			}
+			require.Equal(t, 1, completionTools)
 		})
+	}
+}
+
+func TestClaudeToKiro_NonClaudeCodeDoesNotEnableCompletionProtocol(t *testing.T) {
+	payload := ClaudeToKiro(&ClaudeRequest{
+		Model:    "claude-sonnet-4-5",
+		System:   "You are a concise support assistant.",
+		Messages: []ClaudeMessage{{Role: "user", Content: "hello"}},
+	}, false)
+
+	require.False(t, payload.ClaudeCodeCompletionProtocol)
+	ctx := payload.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext
+	if ctx == nil {
+		return
+	}
+	for _, tool := range ctx.Tools {
+		require.NotEqual(t, claudepkg.ClaudeCodeCompletionToolName, tool.ToolSpecification.Name)
 	}
 }

--- a/backend/internal/integration/kiro/translator.go
+++ b/backend/internal/integration/kiro/translator.go
@@ -216,6 +216,7 @@ const kiroClaudeIdentityOverride = `Kiro mirror identity override:
 func ClaudeToKiro(req *ClaudeRequest, thinking bool) *KiroPayload {
 	modelID := MapModel(req.Model)
 	origin := "AI_EDITOR"
+	isClaudeCode := isClaudeCodeSystemPrompt(extractSystemPrompt(req.System))
 
 	// 提取系统提示
 	systemPrompt := buildClaudeSystemPrompt(req.System, thinking)
@@ -316,10 +317,15 @@ func ClaudeToKiro(req *ClaudeRequest, thinking bool) *KiroPayload {
 
 	// 转换工具
 	kiroTools, toolNameMap := convertClaudeTools(req.Tools)
+	completionProtocol := false
+	if isClaudeCode {
+		kiroTools, completionProtocol = addClaudeCodeCompletionTool(kiroTools)
+	}
 
 	// 构建 payload
 	payload := &KiroPayload{}
 	payload.ToolNameMap = toolNameMap
+	payload.ClaudeCodeCompletionProtocol = completionProtocol
 	payload.ConversationState.ChatTriggerType = "MANUAL"
 	payload.ConversationState.AgentTaskType = "vibe"
 	payload.ConversationState.AgentContinuationId = uuid.New().String()

--- a/backend/internal/pkg/claude/claude_code_completion_guard.go
+++ b/backend/internal/pkg/claude/claude_code_completion_guard.go
@@ -7,10 +7,16 @@ const (
 	// OpenAI-compat-only guard so existing bridge detection keeps working while
 	// Kiro and future Messages backends consume the same policy text.
 	ClaudeCodeCompletionGuardMarker = "<sub2api-claude-code-todo-guard>"
-	ClaudeCodeCompletionGuardText   = ClaudeCodeCompletionGuardMarker + `
+	// ClaudeCodeCompletionToolName is a transport-private Kiro tool. It is
+	// never exposed to Claude Code; the Kiro bridge consumes it as explicit
+	// evidence that the agent may hand control back to the user.
+	ClaudeCodeCompletionToolName  = "sub2apiClaudeCodeCompletion"
+	ClaudeCodeCompletionGuardText = ClaudeCodeCompletionGuardMarker + `
 You are operating as the model backend for Claude Code. Keep working in the same turn until the user's requested implementation and verification are complete. Do not send a final answer, completion claim, or progress summary as an end state while requested work remains.
 
 For multi-step work, use the available task or todo tracking tools before editing and keep their state accurate. If any item remains in_progress or pending, continue using tools. Only stop early for a genuine blocker that requires user input, and state that blocker explicitly. Before ending, verify the requested result and leave no item in_progress.
+
+If the transport-only ` + ClaudeCodeCompletionToolName + ` tool is available, it is the only valid way to finish a text-only response. Call it with status complete only after the requested work and verification are done, or with status blocked only when progress genuinely requires user input. Put the complete user-facing final answer or blocker question in its message argument. Do not call it for progress updates. If work remains, use the normal Claude Code tools instead.
 </sub2api-claude-code-todo-guard>`
 )
 

--- a/backend/internal/pkg/claude/claude_code_completion_guard_test.go
+++ b/backend/internal/pkg/claude/claude_code_completion_guard_test.go
@@ -17,6 +17,8 @@ func TestEnsureClaudeCodeCompletionGuard_AppendsExactlyOnce(t *testing.T) {
 
 	require.Contains(t, guarded, "requested implementation and verification are complete")
 	require.Contains(t, guarded, "If any item remains in_progress or pending, continue using tools")
+	require.Contains(t, guarded, ClaudeCodeCompletionToolName)
+	require.Contains(t, guarded, "the only valid way to finish a text-only response")
 	require.Equal(t, 1, strings.Count(guarded, ClaudeCodeCompletionGuardMarker))
 	require.Equal(t, guarded, guardedAgain)
 }

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -161,10 +161,28 @@ func shouldContinueClaudeCodeCompletion(
 }
 
 func completionSignalText(text string, signal *kiroproto.ClaudeCodeCompletionSignal) string {
-	if strings.TrimSpace(text) != "" || signal == nil {
+	if signal == nil || strings.TrimSpace(signal.Message) == "" {
 		return text
 	}
-	return signal.Message
+	message := strings.TrimSpace(signal.Message)
+	if strings.TrimSpace(text) == "" {
+		return message
+	}
+	if strings.TrimSpace(text) == message {
+		return text
+	}
+	return text + "\n\n" + message
+}
+
+func completionSignalTextDelta(text string, signal *kiroproto.ClaudeCodeCompletionSignal) string {
+	merged := completionSignalText(text, signal)
+	if merged == text {
+		return ""
+	}
+	if strings.HasPrefix(merged, text) {
+		return merged[len(text):]
+	}
+	return merged
 }
 
 func logKiroCompletionProtocol(account *Account, model string, turn int, action, status string) {
@@ -390,10 +408,8 @@ func (s *KiroGatewayService) forwardNonStreaming(
 				continue
 			}
 			logKiroCompletionProtocol(account, model, turn, "exhausted", "missing_signal")
-			if normalizeKiroStopReason(stopReason) == "TOOL_USE" {
-				err := fmt.Errorf("%w: invalid Claude Code completion signal", errKiroUnsupportedStopReason)
-				return nil, classifyAndRecordKiroForwardError(c, account, err, model)
-			}
+			err := fmt.Errorf("%w after %d turns", errKiroCompletionExhausted, maxClaudeCodeCompletionTurns)
+			return nil, classifyAndRecordKiroForwardError(c, account, err, model)
 		}
 
 		clientToolUses = visibleToolUses
@@ -618,10 +634,11 @@ func (s *KiroGatewayService) forwardStreaming(
 		if completionAccepted {
 			completionText := completionSignalText(turnText, completionSignal)
 			if completionText != turnText {
+				completionDelta := completionSignalTextDelta(turnText, completionSignal)
 				turnText = completionText
-				if turnText != "" {
+				if completionDelta != "" {
 					markFirstToken()
-					enc.writeTextDelta(turnText)
+					enc.writeTextDelta(completionDelta)
 					callOutputCommitted = true
 				}
 			}
@@ -648,14 +665,12 @@ func (s *KiroGatewayService) forwardStreaming(
 				continue
 			}
 			logKiroCompletionProtocol(account, model, turn, "exhausted", "missing_signal")
-			if normalizeKiroStopReason(stopReason) == "TOOL_USE" {
-				err := fmt.Errorf("%w: invalid Claude Code completion signal", errKiroUnsupportedStopReason)
-				msg := sanitizeStreamError(err)
-				recordKiroStreamError(c, account, msg)
-				writeKiroStreamError(c, flusher, "unsupported_stop_reason", msg)
-				mu.Unlock()
-				return nil, fmt.Errorf("kiro stream stop reason error: %w", err)
-			}
+			err := fmt.Errorf("%w after %d turns", errKiroCompletionExhausted, maxClaudeCodeCompletionTurns)
+			msg := sanitizeStreamError(err)
+			recordKiroStreamError(c, account, msg)
+			writeKiroStreamError(c, flusher, "completion_exhausted", msg)
+			mu.Unlock()
+			return nil, fmt.Errorf("kiro stream completion error: %w", err)
 		}
 
 		clientToolUses = visibleToolUses

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -35,6 +35,12 @@ type KiroGatewayService struct {
 	accountRepo         AccountRepository
 }
 
+// maxClaudeCodeCompletionTurns bounds the number of Kiro model calls inside a
+// single Claude Code HTTP request. The private completion protocol normally
+// terminates on the first call; the remaining calls recover text-only model
+// stops without creating an unbounded agent loop.
+const maxClaudeCodeCompletionTurns = 3
+
 // KiroPostOutputStreamDisconnectError marks an incomplete upstream stream after
 // response content has already been sent. The current request cannot be replayed
 // safely; the handler uses this marker to exclude the account once on the
@@ -77,7 +83,7 @@ func classifyKiroPostOutputStreamError(kind string, err error) error {
 // into end_turn, which would make Claude Code report an incomplete task as
 // successfully completed.
 func mapKiroStopReason(raw string, hasToolUse bool) (string, error) {
-	normalized := strings.ToUpper(strings.ReplaceAll(strings.TrimSpace(raw), "-", "_"))
+	normalized := normalizeKiroStopReason(raw)
 	switch normalized {
 	case "END_TURN":
 		if hasToolUse {
@@ -89,14 +95,90 @@ func mapKiroStopReason(raw string, hasToolUse bool) (string, error) {
 	case "MAX_TOKENS":
 		return "max_tokens", nil
 	case "STOP_SEQUENCE":
-		return "stop_sequence", nil
-	case "CONTENT_FILTERED":
-		// Empty filtered responses are rejected before this mapper. If Kiro
-		// returned visible refusal text, retain the historical success behavior.
-		return "end_turn", nil
+		// Kiro exposes no matched sequence in metadataEvent.stopDetails. An
+		// Anthropic stop_sequence response without that value is malformed, so
+		// fail closed instead of emitting stop_sequence:null.
+		return "", fmt.Errorf("%w: STOP_SEQUENCE without matched sequence", errKiroUnsupportedStopReason)
+	case "MODEL_CONTEXT_WINDOW_EXCEEDED":
+		return "model_context_window_exceeded", nil
+	case "CONTENT_FILTERED", "GUARDRAIL_INTERVENED":
+		// Empty filtered responses are rejected before this mapper. Visible
+		// refusal text uses Anthropic's refusal terminal outcome rather than
+		// masquerading as a successful end_turn.
+		return "refusal", nil
+	case "MALFORMED_MODEL_OUTPUT", "MALFORMED_TOOL_USE":
+		return "", fmt.Errorf("%w: %s", errKiroUnsupportedStopReason, normalized)
 	default:
 		return "", fmt.Errorf("%w: %q", errKiroUnsupportedStopReason, truncateString(raw, 64))
 	}
+}
+
+func normalizeKiroStopReason(raw string) string {
+	return strings.ToUpper(strings.ReplaceAll(strings.TrimSpace(raw), "-", "_"))
+}
+
+func acceptsClaudeCodeCompletionSignal(raw string) bool {
+	switch normalizeKiroStopReason(raw) {
+	case "END_TURN", "TOOL_USE":
+		return true
+	default:
+		return false
+	}
+}
+
+func isKiroPolicyStopReason(raw string) bool {
+	switch normalizeKiroStopReason(raw) {
+	case "CONTENT_FILTERED", "GUARDRAIL_INTERVENED":
+		return true
+	default:
+		return false
+	}
+}
+
+func isAcceptedClaudeCodeCompletion(
+	rawStopReason string,
+	assistantText string,
+	clientToolUses []kiroproto.KiroToolUse,
+	signal *kiroproto.ClaudeCodeCompletionSignal,
+) bool {
+	return signal != nil &&
+		len(clientToolUses) == 0 &&
+		acceptsClaudeCodeCompletionSignal(rawStopReason) &&
+		(strings.TrimSpace(assistantText) != "" || signal.Message != "")
+}
+
+func shouldContinueClaudeCodeCompletion(
+	payload *kiroproto.KiroPayload,
+	rawStopReason string,
+	clientToolUses []kiroproto.KiroToolUse,
+	completionAccepted bool,
+) bool {
+	return payload != nil &&
+		payload.ClaudeCodeCompletionProtocol &&
+		len(clientToolUses) == 0 &&
+		!completionAccepted &&
+		acceptsClaudeCodeCompletionSignal(rawStopReason)
+}
+
+func completionSignalText(text string, signal *kiroproto.ClaudeCodeCompletionSignal) string {
+	if strings.TrimSpace(text) != "" || signal == nil {
+		return text
+	}
+	return signal.Message
+}
+
+func logKiroCompletionProtocol(account *Account, model string, turn int, action, status string) {
+	accountID := int64(0)
+	if account != nil {
+		accountID = account.ID
+	}
+	slog.Info("gateway.kiro_completion_protocol",
+		slog.Int64("account_id", accountID),
+		slog.String("model", model),
+		slog.Int("turn", turn),
+		slog.String("action", action),
+		slog.String("status", status),
+	)
 }
 
 func logKiroStopReason(account *Account, model, raw, mapped string, stream bool) {
@@ -216,79 +298,125 @@ func (s *KiroGatewayService) forwardNonStreaming(
 	startTime time.Time,
 ) (*ForwardResult, error) {
 	var (
-		textBuf     string
-		thinkingBuf string
-		toolUses    []kiroproto.KiroToolUse
-		callbackErr error
-		stopReason  string
-		redactor    kiroproto.InlineThinkingRedactor
+		textBuf          string
+		thinkingBuf      string
+		clientToolUses   []kiroproto.KiroToolUse
+		billingToolUses  []kiroproto.KiroToolUse
+		mappedStopReason string
 	)
-
-	callback := &kiroproto.KiroStreamCallback{
-		OnText: func(text string, isThinking bool) {
-			if isThinking {
-				thinkingBuf += text
-			} else {
-				visible, inlineThinking := redactor.Push(text)
-				if inlineThinking != "" {
-					thinkingBuf += inlineThinking
-				}
-				textBuf += visible
-			}
-		},
-		OnToolUse: func(tu kiroproto.KiroToolUse) {
-			toolUses = append(toolUses, tu)
-		},
-		OnStopReason: func(reason string) {
-			stopReason = reason
-		},
-		// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
-		// We estimate token usage locally below instead of trusting these values.
-		OnCredits: func(credits float64) {
-			logKiroCredits(kiroAcct, model, credits)
-		},
-		OnError: func(err error) {
-			callbackErr = err
-		},
-		ResetForRetry: func() bool {
-			textBuf = ""
-			thinkingBuf = ""
-			toolUses = nil
-			callbackErr = nil
-			stopReason = ""
-			redactor = kiroproto.InlineThinkingRedactor{}
-			return true
-		},
-	}
-
-	if err := kiroproto.CallKiroAPIWithDoerContext(ctx, doer, kiroAcct, payload, callback); err != nil {
-		return nil, classifyAndRecordKiroForwardError(c, account, err, model)
-	}
-	if callbackErr != nil {
-		return nil, classifyAndRecordKiroForwardError(c, account, callbackErr, model)
-	}
-	if visible, inlineThinking := redactor.Flush(); visible != "" || inlineThinking != "" {
-		textBuf += visible
-		thinkingBuf += inlineThinking
-	}
-	if textBuf == "" && thinkingBuf == "" && len(toolUses) == 0 {
-		if strings.EqualFold(stopReason, "CONTENT_FILTERED") {
-			return nil, classifyAndRecordKiroForwardError(c, account, &KiroContentFilteredError{}, model)
-		}
-		return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
-	}
-
-	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
 	inputTokens := kiroproto.EstimateInputTokens(req)
-	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, toolUses)
-	mappedStopReason, err := mapKiroStopReason(stopReason, len(toolUses) > 0)
-	if err != nil {
-		return nil, classifyAndRecordKiroForwardError(c, account, err, model)
+
+	for turn := 1; turn <= maxClaudeCodeCompletionTurns; turn++ {
+		var (
+			turnText     string
+			turnThinking string
+			turnToolUses []kiroproto.KiroToolUse
+			callbackErr  error
+			stopReason   string
+			redactor     kiroproto.InlineThinkingRedactor
+		)
+
+		callback := &kiroproto.KiroStreamCallback{
+			OnText: func(text string, isThinking bool) {
+				if isThinking {
+					turnThinking += text
+					return
+				}
+				visible, inlineThinking := redactor.Push(text)
+				turnText += visible
+				turnThinking += inlineThinking
+			},
+			OnToolUse: func(toolUse kiroproto.KiroToolUse) {
+				turnToolUses = append(turnToolUses, toolUse)
+			},
+			OnStopReason: func(reason string) {
+				stopReason = reason
+			},
+			// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
+			// We estimate token usage locally below instead of trusting these values.
+			OnCredits: func(credits float64) {
+				logKiroCredits(kiroAcct, model, credits)
+			},
+			OnError: func(err error) {
+				callbackErr = err
+			},
+			ResetForRetry: func() bool {
+				turnText = ""
+				turnThinking = ""
+				turnToolUses = nil
+				callbackErr = nil
+				stopReason = ""
+				redactor = kiroproto.InlineThinkingRedactor{}
+				return true
+			},
+		}
+
+		if err := kiroproto.CallKiroAPIWithDoerContext(ctx, doer, kiroAcct, payload, callback); err != nil {
+			return nil, classifyAndRecordKiroForwardError(c, account, err, model)
+		}
+		if callbackErr != nil {
+			return nil, classifyAndRecordKiroForwardError(c, account, callbackErr, model)
+		}
+		if visible, inlineThinking := redactor.Flush(); visible != "" || inlineThinking != "" {
+			turnText += visible
+			turnThinking += inlineThinking
+		}
+
+		visibleToolUses := turnToolUses
+		var completionSignal *kiroproto.ClaudeCodeCompletionSignal
+		if payload.ClaudeCodeCompletionProtocol {
+			visibleToolUses, completionSignal = kiroproto.ConsumeClaudeCodeCompletionSignal(turnToolUses)
+		}
+		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, turnText, visibleToolUses, completionSignal)
+		if completionAccepted {
+			turnText = completionSignalText(turnText, completionSignal)
+		}
+		if turnText == "" && turnThinking == "" && len(turnToolUses) == 0 && textBuf == "" && thinkingBuf == "" {
+			if isKiroPolicyStopReason(stopReason) {
+				return nil, classifyAndRecordKiroForwardError(c, account, &KiroContentFilteredError{}, model)
+			}
+			return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
+		}
+
+		textBuf += turnText
+		thinkingBuf += turnThinking
+		billingToolUses = append(billingToolUses, turnToolUses...)
+
+		if shouldContinueClaudeCodeCompletion(payload, stopReason, visibleToolUses, completionAccepted) {
+			if turn < maxClaudeCodeCompletionTurns {
+				logKiroCompletionProtocol(account, model, turn, "continue", "missing_signal")
+				kiroproto.PrepareClaudeCodeCompletionContinuation(payload, turnText)
+				inputTokens += kiroproto.EstimatePayloadInputTokens(payload)
+				continue
+			}
+			logKiroCompletionProtocol(account, model, turn, "exhausted", "missing_signal")
+			if normalizeKiroStopReason(stopReason) == "TOOL_USE" {
+				err := fmt.Errorf("%w: invalid Claude Code completion signal", errKiroUnsupportedStopReason)
+				return nil, classifyAndRecordKiroForwardError(c, account, err, model)
+			}
+		}
+
+		clientToolUses = visibleToolUses
+		if completionAccepted {
+			mappedStopReason = "end_turn"
+			logKiroCompletionProtocol(account, model, turn, "finish", completionSignal.Status)
+		} else {
+			var err error
+			mappedStopReason, err = mapKiroStopReason(stopReason, len(clientToolUses) > 0)
+			if err != nil {
+				return nil, classifyAndRecordKiroForwardError(c, account, err, model)
+			}
+		}
+		logKiroStopReason(account, model, stopReason, mappedStopReason, false)
+		break
 	}
-	logKiroStopReason(account, model, stopReason, mappedStopReason, false)
+
+	// Estimate output across every hidden completion turn, including the private
+	// completion tool call that is intentionally absent from the client response.
+	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, billingToolUses)
 
 	resp := kiroproto.KiroToClaudeResponse(
-		textBuf, thinkingBuf, false, toolUses, inputTokens, outputToks, model, mappedStopReason,
+		textBuf, thinkingBuf, false, clientToolUses, inputTokens, outputToks, model, mappedStopReason,
 	)
 	resp.ID = requestID
 
@@ -352,14 +480,13 @@ func (s *KiroGatewayService) forwardStreaming(
 	}
 
 	var (
-		mu          sync.Mutex
-		textBuf     string
-		thinkingBuf string
-		toolUses    []kiroproto.KiroToolUse
-		callbackErr error
-		stopReason  string
-		firstTokMs  *int
-		redactor    kiroproto.InlineThinkingRedactor
+		mu               sync.Mutex
+		textBuf          string
+		thinkingBuf      string
+		clientToolUses   []kiroproto.KiroToolUse
+		billingToolUses  []kiroproto.KiroToolUse
+		mappedStopReason string
+		firstTokMs       *int
 	)
 
 	markFirstToken := func() {
@@ -369,129 +496,189 @@ func (s *KiroGatewayService) forwardStreaming(
 		}
 	}
 
-	// message_start is emitted lazily on first content (see kiroSSEEncoder
-	// ensureBlock / writeToolUse). Emitting it eagerly here would set
-	// enc.started=true before the upstream call, defeating the post-call
-	// `!enc.started` guard and turning an upstream 400 (e.g. INVALID_MODEL_ID)
-	// into a clean empty 200 stream that the handler never sees as an error.
-
-	callback := &kiroproto.KiroStreamCallback{
-		OnText: func(text string, isThinking bool) {
-			mu.Lock()
-			defer mu.Unlock()
-			markFirstToken()
-			if isThinking {
-				thinkingBuf += text
-			} else {
-				visible, inlineThinking := redactor.Push(text)
-				if inlineThinking != "" {
-					thinkingBuf += inlineThinking
-				}
-				if visible != "" {
-					textBuf += visible
-					enc.writeTextDelta(visible)
-				}
-			}
-		},
-		OnToolUse: func(tu kiroproto.KiroToolUse) {
-			mu.Lock()
-			defer mu.Unlock()
-			markFirstToken()
-			toolUses = append(toolUses, tu)
-			enc.writeToolUse(tu)
-		},
-		OnStopReason: func(reason string) {
-			mu.Lock()
-			defer mu.Unlock()
-			stopReason = reason
-		},
-		// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
-		// We estimate token usage locally below instead of trusting these values.
-		OnCredits: func(credits float64) {
-			logKiroCredits(kiroAcct, model, credits)
-		},
-		OnError: func(err error) {
-			mu.Lock()
-			defer mu.Unlock()
-			callbackErr = err
-		},
-		ResetForRetry: func() bool {
-			mu.Lock()
-			defer mu.Unlock()
-			if enc.started {
-				return false
-			}
-			textBuf = ""
-			thinkingBuf = ""
-			toolUses = nil
-			callbackErr = nil
-			stopReason = ""
-			firstTokMs = nil
-			redactor = kiroproto.InlineThinkingRedactor{}
-			return true
-		},
-	}
-
-	callErr := kiroproto.CallKiroAPIWithDoerContext(ctx, doer, kiroAcct, payload, callback)
-
-	mu.Lock()
-	defer mu.Unlock()
-
-	// If the upstream failed before producing any content, surface the error so
-	// the handler can decide on failover instead of emitting a half-finished
-	// SSE stream. Once content has begun, SSE has no resume/failover point; send
-	// a protocol-level error event instead of forging message_delta/message_stop,
-	// otherwise clients such as Claude Code treat an incomplete Kiro stream as a
-	// successful assistant turn.
-	// classifyKiroForwardError maps a recognized HTTP 400 INVALID_MODEL_ID into
-	// a typed *KiroInvalidModelError so the handler can return a clean 400.
-	if callErr != nil && !enc.started {
-		return nil, classifyAndRecordKiroForwardError(c, account, callErr, model)
-	}
-	if callErr != nil {
-		msg := "upstream stream disconnected: " + sanitizeStreamError(callErr)
-		recordKiroStreamError(c, account, msg)
-		writeKiroStreamError(c, flusher, "stream_read_error", msg)
-		return nil, classifyKiroPostOutputStreamError("read", callErr)
-	}
-	if callbackErr != nil && !enc.started {
-		return nil, classifyAndRecordKiroForwardError(c, account, callbackErr, model)
-	}
-	if callbackErr != nil {
-		msg := "upstream stream disconnected: " + sanitizeStreamError(callbackErr)
-		recordKiroStreamError(c, account, msg)
-		writeKiroStreamError(c, flusher, "stream_read_error", msg)
-		return nil, classifyKiroPostOutputStreamError("callback", callbackErr)
-	}
-	if visible, inlineThinking := redactor.Flush(); visible != "" || inlineThinking != "" {
-		if inlineThinking != "" {
-			thinkingBuf += inlineThinking
-		}
-		if visible != "" {
-			textBuf += visible
-			enc.writeTextDelta(visible)
-		}
-	}
-	if !enc.started && textBuf == "" && thinkingBuf == "" && len(toolUses) == 0 {
-		if strings.EqualFold(stopReason, "CONTENT_FILTERED") {
-			return nil, classifyAndRecordKiroForwardError(c, account, &KiroContentFilteredError{}, model)
-		}
-		return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
-	}
-
-	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
-	// inputTokens was already computed for the encoder (message_start.usage); reuse
-	// it for the ForwardResult so the two never drift.
+	// message_start is emitted lazily on first client-visible content (see
+	// kiroSSEEncoder ensureBlock / writeToolUse). The transport-private
+	// completion tool is never committed to the Anthropic stream.
 	inputTokens := enc.inputTokens
-	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, toolUses)
-	mappedStopReason, err := mapKiroStopReason(stopReason, len(toolUses) > 0)
-	if err != nil {
-		msg := sanitizeStreamError(err)
-		recordKiroStreamError(c, account, msg)
-		writeKiroStreamError(c, flusher, "unsupported_stop_reason", msg)
-		return nil, fmt.Errorf("kiro stream stop reason error: %w", err)
+	for turn := 1; turn <= maxClaudeCodeCompletionTurns; turn++ {
+		firstTokBeforeTurn := firstTokMs
+		var (
+			turnText            string
+			turnThinking        string
+			turnToolUses        []kiroproto.KiroToolUse
+			callbackErr         error
+			stopReason          string
+			redactor            kiroproto.InlineThinkingRedactor
+			callOutputCommitted bool
+		)
+
+		callback := &kiroproto.KiroStreamCallback{
+			OnText: func(text string, isThinking bool) {
+				mu.Lock()
+				defer mu.Unlock()
+				markFirstToken()
+				if isThinking {
+					turnThinking += text
+					return
+				}
+				visible, inlineThinking := redactor.Push(text)
+				turnThinking += inlineThinking
+				if visible != "" {
+					turnText += visible
+					enc.writeTextDelta(visible)
+					callOutputCommitted = true
+				}
+			},
+			OnToolUse: func(toolUse kiroproto.KiroToolUse) {
+				mu.Lock()
+				defer mu.Unlock()
+				turnToolUses = append(turnToolUses, toolUse)
+				if payload.ClaudeCodeCompletionProtocol && kiroproto.IsClaudeCodeCompletionToolUse(toolUse) {
+					return
+				}
+				markFirstToken()
+				enc.writeToolUse(toolUse)
+				callOutputCommitted = true
+			},
+			OnStopReason: func(reason string) {
+				mu.Lock()
+				defer mu.Unlock()
+				stopReason = reason
+			},
+			// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
+			// We estimate token usage locally below instead of trusting these values.
+			OnCredits: func(credits float64) {
+				logKiroCredits(kiroAcct, model, credits)
+			},
+			OnError: func(err error) {
+				mu.Lock()
+				defer mu.Unlock()
+				callbackErr = err
+			},
+			ResetForRetry: func() bool {
+				mu.Lock()
+				defer mu.Unlock()
+				if callOutputCommitted {
+					return false
+				}
+				turnText = ""
+				turnThinking = ""
+				turnToolUses = nil
+				callbackErr = nil
+				stopReason = ""
+				redactor = kiroproto.InlineThinkingRedactor{}
+				firstTokMs = firstTokBeforeTurn
+				return true
+			},
+		}
+
+		callErr := kiroproto.CallKiroAPIWithDoerContext(ctx, doer, kiroAcct, payload, callback)
+
+		mu.Lock()
+		// If the upstream failed before producing any client-visible content,
+		// surface the error for account failover. Once any prior/current turn was
+		// committed, SSE has no replay point and must end with an error event.
+		if callErr != nil && !enc.started {
+			mu.Unlock()
+			return nil, classifyAndRecordKiroForwardError(c, account, callErr, model)
+		}
+		if callErr != nil {
+			msg := "upstream stream disconnected: " + sanitizeStreamError(callErr)
+			recordKiroStreamError(c, account, msg)
+			writeKiroStreamError(c, flusher, "stream_read_error", msg)
+			mu.Unlock()
+			return nil, classifyKiroPostOutputStreamError("read", callErr)
+		}
+		if callbackErr != nil && !enc.started {
+			mu.Unlock()
+			return nil, classifyAndRecordKiroForwardError(c, account, callbackErr, model)
+		}
+		if callbackErr != nil {
+			msg := "upstream stream disconnected: " + sanitizeStreamError(callbackErr)
+			recordKiroStreamError(c, account, msg)
+			writeKiroStreamError(c, flusher, "stream_read_error", msg)
+			mu.Unlock()
+			return nil, classifyKiroPostOutputStreamError("callback", callbackErr)
+		}
+		if visible, inlineThinking := redactor.Flush(); visible != "" || inlineThinking != "" {
+			turnThinking += inlineThinking
+			if visible != "" {
+				turnText += visible
+				enc.writeTextDelta(visible)
+				callOutputCommitted = true
+			}
+		}
+
+		visibleToolUses := turnToolUses
+		var completionSignal *kiroproto.ClaudeCodeCompletionSignal
+		if payload.ClaudeCodeCompletionProtocol {
+			visibleToolUses, completionSignal = kiroproto.ConsumeClaudeCodeCompletionSignal(turnToolUses)
+		}
+		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, turnText, visibleToolUses, completionSignal)
+		if completionAccepted {
+			completionText := completionSignalText(turnText, completionSignal)
+			if completionText != turnText {
+				turnText = completionText
+				if turnText != "" {
+					markFirstToken()
+					enc.writeTextDelta(turnText)
+					callOutputCommitted = true
+				}
+			}
+		}
+		if turnText == "" && turnThinking == "" && len(turnToolUses) == 0 && textBuf == "" && thinkingBuf == "" {
+			if isKiroPolicyStopReason(stopReason) {
+				mu.Unlock()
+				return nil, classifyAndRecordKiroForwardError(c, account, &KiroContentFilteredError{}, model)
+			}
+			mu.Unlock()
+			return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
+		}
+
+		textBuf += turnText
+		thinkingBuf += turnThinking
+		billingToolUses = append(billingToolUses, turnToolUses...)
+
+		if shouldContinueClaudeCodeCompletion(payload, stopReason, visibleToolUses, completionAccepted) {
+			if turn < maxClaudeCodeCompletionTurns {
+				logKiroCompletionProtocol(account, model, turn, "continue", "missing_signal")
+				kiroproto.PrepareClaudeCodeCompletionContinuation(payload, turnText)
+				inputTokens += kiroproto.EstimatePayloadInputTokens(payload)
+				mu.Unlock()
+				continue
+			}
+			logKiroCompletionProtocol(account, model, turn, "exhausted", "missing_signal")
+			if normalizeKiroStopReason(stopReason) == "TOOL_USE" {
+				err := fmt.Errorf("%w: invalid Claude Code completion signal", errKiroUnsupportedStopReason)
+				msg := sanitizeStreamError(err)
+				recordKiroStreamError(c, account, msg)
+				writeKiroStreamError(c, flusher, "unsupported_stop_reason", msg)
+				mu.Unlock()
+				return nil, fmt.Errorf("kiro stream stop reason error: %w", err)
+			}
+		}
+
+		clientToolUses = visibleToolUses
+		if completionAccepted {
+			mappedStopReason = "end_turn"
+			logKiroCompletionProtocol(account, model, turn, "finish", completionSignal.Status)
+		} else {
+			var err error
+			mappedStopReason, err = mapKiroStopReason(stopReason, len(clientToolUses) > 0)
+			if err != nil {
+				msg := sanitizeStreamError(err)
+				recordKiroStreamError(c, account, msg)
+				writeKiroStreamError(c, flusher, "unsupported_stop_reason", msg)
+				mu.Unlock()
+				return nil, fmt.Errorf("kiro stream stop reason error: %w", err)
+			}
+		}
+		logKiroStopReason(account, model, stopReason, mappedStopReason, true)
+		mu.Unlock()
+		break
 	}
-	logKiroStopReason(account, model, stopReason, mappedStopReason, true)
+
+	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, billingToolUses)
 
 	// Upstream succeeded but produced no content (enc.started still false):
 	// emit message_start lazily here so the closing events form a valid stream.

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -137,14 +137,13 @@ func isKiroPolicyStopReason(raw string) bool {
 
 func isAcceptedClaudeCodeCompletion(
 	rawStopReason string,
-	assistantText string,
 	clientToolUses []kiroproto.KiroToolUse,
 	signal *kiroproto.ClaudeCodeCompletionSignal,
 ) bool {
 	return signal != nil &&
 		len(clientToolUses) == 0 &&
 		acceptsClaudeCodeCompletionSignal(rawStopReason) &&
-		(strings.TrimSpace(assistantText) != "" || signal.Message != "")
+		signal.Message != ""
 }
 
 func shouldContinueClaudeCodeCompletion(
@@ -385,7 +384,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		if payload.ClaudeCodeCompletionProtocol {
 			visibleToolUses, completionSignal = kiroproto.ConsumeClaudeCodeCompletionSignal(turnToolUses)
 		}
-		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, turnText, visibleToolUses, completionSignal)
+		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, visibleToolUses, completionSignal)
 		if completionAccepted {
 			turnText = completionSignalText(turnText, completionSignal)
 		}
@@ -630,7 +629,7 @@ func (s *KiroGatewayService) forwardStreaming(
 		if payload.ClaudeCodeCompletionProtocol {
 			visibleToolUses, completionSignal = kiroproto.ConsumeClaudeCodeCompletionSignal(turnToolUses)
 		}
-		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, turnText, visibleToolUses, completionSignal)
+		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, visibleToolUses, completionSignal)
 		if completionAccepted {
 			completionText := completionSignalText(turnText, completionSignal)
 			if completionText != turnText {

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -515,6 +515,37 @@ func TestUS041_KiroGatewayService_EmptyCompletionSignalDoesNotFinish(t *testing.
 	}
 }
 
+func TestUS041_KiroGatewayService_EmptyCompletionMessageWithAssistantTextDoesNotFinish(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			body := buildKiroEventStreamMessage("assistantResponseEvent", []byte(`{"content":"partial progress only"}`))
+			body = append(body, kiroToolUseEvent("toolu_completion", "sub2apiClaudeCodeCompletion", map[string]any{
+				"status": "complete", "message": "",
+			})...)
+			body = appendKiroTerminalStop(body, "TOOL_USE")
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				body,
+				kiroCompletionSignalStream("complete", "Implemented and verified the fix."),
+			}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 2, upstream.calls, "assistant text must not substitute for an empty private completion message")
+			out := rec.Body.String()
+			require.Contains(t, out, "partial progress only")
+			require.Contains(t, out, "Implemented and verified the fix.")
+			require.Contains(t, out, `"stop_reason":"end_turn"`)
+		})
+	}
+}
+
 func TestUS041_KiroGatewayService_ClaudeCodeCompletionLoopIsBounded(t *testing.T) {
 	for _, stream := range []bool{false, true} {
 		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -516,20 +516,60 @@ func TestUS041_KiroGatewayService_EmptyCompletionSignalDoesNotFinish(t *testing.
 }
 
 func TestUS041_KiroGatewayService_ClaudeCodeCompletionLoopIsBounded(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
-	upstream := &kiroSequenceUpstream{bodies: [][]byte{
-		kiroTextStopStream("still only a progress update\n", "END_TURN"),
-	}}
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroTextStopStream("still only a progress update\n", "END_TURN"),
+			}}
 
-	svc := NewKiroGatewayService(upstream, nil, nil)
-	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), newClaudeCodeKiroParsedRequestForTest(false), time.Now())
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Equal(t, maxClaudeCodeCompletionTurns, upstream.calls)
-	require.Contains(t, rec.Body.String(), `"stop_reason":"end_turn"`)
+			require.Error(t, err)
+			require.Nil(t, result)
+			require.Equal(t, maxClaudeCodeCompletionTurns, upstream.calls)
+			if stream {
+				require.Contains(t, rec.Body.String(), `"type":"completion_exhausted"`)
+				require.Contains(t, rec.Body.String(), "event: error")
+				require.NotContains(t, rec.Body.String(), "event: message_stop")
+				return
+			}
+			require.Empty(t, rec.Body.String())
+			var failoverErr *UpstreamFailoverError
+			require.ErrorAs(t, err, &failoverErr)
+			require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+		})
+	}
+}
+
+func TestUS041_KiroGatewayService_CompletionSignalMessageIsPreservedAfterText(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			body := buildKiroEventStreamMessage("assistantResponseEvent", []byte(`{"content":"progress before final signal"}`))
+			body = append(body, kiroToolUseEvent("toolu_completion", "sub2apiClaudeCodeCompletion", map[string]any{
+				"status": "complete", "message": "complete final answer",
+			})...)
+			body = appendKiroTerminalStop(body, "TOOL_USE")
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{body}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			out := rec.Body.String()
+			require.Contains(t, out, "progress before final signal")
+			require.Contains(t, out, "complete final answer")
+			require.Equal(t, 1, strings.Count(out, "progress before final signal"))
+			require.NotContains(t, out, "sub2apiClaudeCodeCompletion")
+		})
+	}
 }
 
 func TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved(t *testing.T) {

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -128,15 +129,20 @@ type kiroFakeUpstream struct {
 }
 
 type kiroSequenceUpstream struct {
-	bodies [][]byte
-	calls  int
+	bodies   [][]byte
+	calls    int
+	requests [][]byte
 }
 
 func (u *kiroSequenceUpstream) Do(*http.Request, string, int64, int) (*http.Response, error) {
 	return nil, fmt.Errorf("unexpected Do call")
 }
 
-func (u *kiroSequenceUpstream) DoWithTLS(_ *http.Request, _ string, _ int64, _ int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+func (u *kiroSequenceUpstream) DoWithTLS(req *http.Request, _ string, _ int64, _ int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	if req != nil && req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		u.requests = append(u.requests, body)
+	}
 	index := u.calls
 	u.calls++
 	if index >= len(u.bodies) {
@@ -200,8 +206,12 @@ func TestMapKiroStopReason_PreservesTerminalOutcome(t *testing.T) {
 		{name: "end turn with tool", raw: "END_TURN", hasToolUse: true, want: "tool_use"},
 		{name: "tool use", raw: "TOOL_USE", want: "tool_use"},
 		{name: "max tokens", raw: "MAX_TOKENS", want: "max_tokens"},
-		{name: "stop sequence", raw: "STOP_SEQUENCE", want: "stop_sequence"},
-		{name: "filtered refusal text", raw: "CONTENT_FILTERED", want: "end_turn"},
+		{name: "context window", raw: "MODEL_CONTEXT_WINDOW_EXCEEDED", want: "model_context_window_exceeded"},
+		{name: "stop sequence without matched value fails closed", raw: "STOP_SEQUENCE", wantErr: true},
+		{name: "filtered refusal text", raw: "CONTENT_FILTERED", want: "refusal"},
+		{name: "guardrail refusal text", raw: "GUARDRAIL_INTERVENED", want: "refusal"},
+		{name: "malformed model output fails closed", raw: "MALFORMED_MODEL_OUTPUT", wantErr: true},
+		{name: "malformed tool use fails closed", raw: "MALFORMED_TOOL_USE", wantErr: true},
 		{name: "unknown fails closed", raw: "MODEL_LIMIT", wantErr: true},
 		{name: "missing fails closed", raw: "", wantErr: true},
 	}
@@ -378,6 +388,253 @@ func newKiroParsedRequestForTest(stream bool) *ParsedRequest {
 	return &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-sonnet-4-5", Stream: stream}
 }
 
+func newClaudeCodeKiroParsedRequestForTest(stream bool) *ParsedRequest {
+	body, _ := json.Marshal(map[string]any{
+		"model": "claude-sonnet-4-5",
+		"system": strings.Join([]string{
+			"You are Claude Code, Anthropic's official CLI for Claude.",
+			"You are an interactive agent that helps users with software engineering tasks.",
+			"# doing tasks",
+			"# using your tools",
+		}, "\n"),
+		"messages":   []map[string]any{{"role": "user", "content": "implement and verify the change"}},
+		"max_tokens": 1024,
+		"stream":     stream,
+	})
+	return &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-sonnet-4-5", Stream: stream}
+}
+
+func newKiroToolRequestForTest(stream, claudeCode bool, toolNames ...string) *ParsedRequest {
+	system := "You are a general API assistant."
+	if claudeCode {
+		system = strings.Join([]string{
+			"You are Claude Code, Anthropic's official CLI for Claude.",
+			"You are an interactive agent that helps users with software engineering tasks.",
+			"# doing tasks",
+			"# using your tools",
+		}, "\n")
+	}
+	tools := make([]map[string]any, 0, len(toolNames))
+	for _, name := range toolNames {
+		tools = append(tools, map[string]any{
+			"name":         name,
+			"description":  "test tool",
+			"input_schema": map[string]any{"type": "object"},
+		})
+	}
+	body, _ := json.Marshal(map[string]any{
+		"model":      "claude-sonnet-4-5",
+		"system":     system,
+		"messages":   []map[string]any{{"role": "user", "content": "use the requested tool"}},
+		"max_tokens": 1024,
+		"stream":     stream,
+		"tools":      tools,
+	})
+	return &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-sonnet-4-5", Stream: stream}
+}
+
+func kiroTextStopStream(text, reason string) []byte {
+	stream := buildKiroEventStreamMessage("assistantResponseEvent", []byte(fmt.Sprintf(`{"content":%q}`, text)))
+	return appendKiroTerminalStop(stream, reason)
+}
+
+func kiroCompletionSignalStream(status, message string) []byte {
+	return kiroToolUseStream("toolu_completion", "sub2apiClaudeCodeCompletion", map[string]any{
+		"status":  status,
+		"message": message,
+	})
+}
+
+func kiroToolUseStream(id, name string, input map[string]any) []byte {
+	stream := kiroToolUseEvent(id, name, input)
+	return appendKiroTerminalStop(stream, "TOOL_USE")
+}
+
+func kiroToolUseEvent(id, name string, input map[string]any) []byte {
+	payload, _ := json.Marshal(map[string]any{
+		"toolUseId": id,
+		"name":      name,
+		"input":     input,
+		"stop":      true,
+	})
+	return buildKiroEventStreamMessage("toolUseEvent", payload)
+}
+
+func TestUS041_KiroGatewayService_ClaudeCodeEndTurnContinuesUntilExplicitCompletion(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroTextStopStream("I found the relevant code. ", "END_TURN"),
+				kiroCompletionSignalStream("complete", "Implemented and verified the fix."),
+			}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 2, upstream.calls, "unfinished END_TURN must be continued inside the same client request")
+			require.Len(t, upstream.requests, 2)
+			require.Contains(t, string(upstream.requests[1]), "preceding assistant response ended without the required transport completion signal")
+			require.Contains(t, string(upstream.requests[1]), "I found the relevant code.")
+
+			out := rec.Body.String()
+			require.Contains(t, out, "I found the relevant code.")
+			require.Contains(t, out, "Implemented and verified the fix.")
+			require.Contains(t, out, `"stop_reason":"end_turn"`)
+			require.NotContains(t, out, "sub2apiClaudeCodeCompletion", "private completion tool must not leak to Claude Code")
+		})
+	}
+}
+
+func TestUS041_KiroGatewayService_EmptyCompletionSignalDoesNotFinish(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroCompletionSignalStream("complete", " "),
+				kiroCompletionSignalStream("complete", "Implemented and verified the fix."),
+			}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 2, upstream.calls, "an empty private signal must not become an empty successful response")
+			out := rec.Body.String()
+			require.Contains(t, out, "Implemented and verified the fix.")
+			require.Contains(t, out, `"stop_reason":"end_turn"`)
+		})
+	}
+}
+
+func TestUS041_KiroGatewayService_ClaudeCodeCompletionLoopIsBounded(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	upstream := &kiroSequenceUpstream{bodies: [][]byte{
+		kiroTextStopStream("still only a progress update\n", "END_TURN"),
+	}}
+
+	svc := NewKiroGatewayService(upstream, nil, nil)
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), newClaudeCodeKiroParsedRequestForTest(false), time.Now())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, maxClaudeCodeCompletionTurns, upstream.calls)
+	require.Contains(t, rec.Body.String(), `"stop_reason":"end_turn"`)
+}
+
+func TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroCompletionSignalStream("complete", "client-owned tool result"),
+			}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newKiroToolRequestForTest(stream, false, "sub2apiClaudeCodeCompletion"), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 1, upstream.calls)
+			out := rec.Body.String()
+			require.Contains(t, out, `"name":"sub2apiClaudeCodeCompletion"`)
+			require.Contains(t, out, `"stop_reason":"tool_use"`)
+		})
+	}
+}
+
+func TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolUseReturnsImmediately(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroToolUseStream("toolu_read", "Read", map[string]any{"file_path": "a.go"}),
+			}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newKiroToolRequestForTest(stream, true, "Read"), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 1, upstream.calls, "ordinary Claude Code tools must return control to the client")
+			out := rec.Body.String()
+			require.Contains(t, out, `"name":"Read"`)
+			require.Contains(t, out, `"stop_reason":"tool_use"`)
+		})
+	}
+}
+
+func TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolWinsOverCompletionSignal(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			mixed := kiroToolUseEvent("toolu_completion", "sub2apiClaudeCodeCompletion", map[string]any{
+				"status": "complete", "message": "premature completion",
+			})
+			mixed = append(mixed, kiroToolUseEvent("toolu_read", "Read", map[string]any{"file_path": "a.go"})...)
+			mixed = appendKiroTerminalStop(mixed, "TOOL_USE")
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{mixed}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newKiroToolRequestForTest(stream, true, "Read"), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 1, upstream.calls)
+			out := rec.Body.String()
+			require.Contains(t, out, `"name":"Read"`)
+			require.NotContains(t, out, "premature completion")
+			require.NotContains(t, out, `"name":"sub2apiClaudeCodeCompletion"`)
+			require.Contains(t, out, `"stop_reason":"tool_use"`)
+		})
+	}
+}
+
+func TestUS041_KiroGatewayService_MaxTokensOverridesCompletionSignal(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			body := kiroToolUseEvent("toolu_completion", "sub2apiClaudeCodeCompletion", map[string]any{
+				"status": "complete", "message": "not authoritative for max tokens",
+			})
+			body = appendKiroTerminalStop(body, "MAX_TOKENS")
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{body}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 1, upstream.calls)
+			out := rec.Body.String()
+			require.NotContains(t, out, "not authoritative for max tokens")
+			require.Contains(t, out, `"stop_reason":"max_tokens"`)
+		})
+	}
+}
+
 func requireKiroContentFilteredError(t *testing.T, c *gin.Context, rec *httptest.ResponseRecorder, result *ForwardResult, err error) {
 	t.Helper()
 	require.Nil(t, result)
@@ -416,6 +673,23 @@ func TestKiroGatewayService_Forward_Streaming_ContentFilteredIsNotFailover(t *te
 	requireKiroContentFilteredError(t, c, rec, result, err)
 }
 
+func TestKiroGatewayService_Forward_GuardrailIntervenedIsNotFailover(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			body := appendKiroTerminalStop(nil, "GUARDRAIL_INTERVENED")
+			svc := NewKiroGatewayService(&kiroFakeUpstream{body: body}, nil, nil)
+
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newKiroParsedRequestForTest(stream), time.Now())
+
+			requireKiroContentFilteredError(t, c, rec, result, err)
+		})
+	}
+}
+
 func TestKiroGatewayService_Forward_ContentFilteredWithAssistantTextRemainsSuccess(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
@@ -429,6 +703,7 @@ func TestKiroGatewayService_Forward_ContentFilteredWithAssistantTextRemainsSucce
 	require.NotNil(t, result)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), "I cannot help with that request.")
+	require.Contains(t, rec.Body.String(), `"stop_reason":"refusal"`)
 	_, recorded := c.Get(OpsUpstreamErrorsKey)
 	require.False(t, recorded)
 	require.False(t, HasOpsClientContentFiltered(c))

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -19,6 +19,7 @@ var kiroTransportFailoverBody = []byte(`{"error":{"type":"upstream_error","messa
 var (
 	errKiroEmptyResponse         = errors.New("kiro upstream returned an empty response")
 	errKiroUnsupportedStopReason = errors.New("kiro upstream returned an unsupported stop reason")
+	errKiroCompletionExhausted   = errors.New("kiro Claude Code completion protocol exhausted without a valid signal")
 )
 
 const (
@@ -226,6 +227,8 @@ func classifyKiroOpaqueFailure(err error) (kiroForwardErrorObservation, bool) {
 		return kiroForwardErrorObservation{Kind: "response_error", Reason: "empty_response"}, true
 	case errors.Is(err, errKiroUnsupportedStopReason):
 		return kiroForwardErrorObservation{Kind: "response_error", Reason: "unsupported_stop_reason"}, true
+	case errors.Is(err, errKiroCompletionExhausted):
+		return kiroForwardErrorObservation{Kind: "response_error", Reason: "completion_exhausted"}, true
 	case errors.Is(err, io.ErrUnexpectedEOF):
 		return kiroForwardErrorObservation{Kind: "response_error", Reason: "unexpected_eof"}, true
 	case errors.Is(err, io.EOF):

--- a/docs/approved/kiro-claude-code-completion-continuity.md
+++ b/docs/approved/kiro-claude-code-completion-continuity.md
@@ -15,40 +15,75 @@ related_commits: []
 
 Claude Code 经 TokenKey 的 Kiro 节点调用 Claude Opus 时，模型可能在实现或验证尚未完成时返回文本。网关此前无条件把 Kiro 的终止结果合成为 Anthropic `end_turn`；即使真实原因是 token 上限或未知终止态，Claude Code 终端也会把这一轮显示成正常结束，用户只能反复输入“继续”。
 
+#1488 修复了第一层问题：Kiro 模型终止原因不再被统一伪造成
+`end_turn`。但 Kiro 的 `END_TURN` 只表示模型自然结束当前生成，不能证明
+Claude Code 的多步骤 Agent 任务已经完成。Claude Code 对合法 `end_turn` 会直接
+交还控制权，因此单纯保真 stop reason 仍会复现“实现未完成却需要用户输入继续”。
+
+## Stop Reason Contract
+
+当前 Kiro 客户端把 `metadataEvent.stopReason` 定义为开放字符串，并原样保留到
+Agent turn metadata；其 AWS runtime 标准词汇及本桥接处理如下：
+
+| Kiro value | 官方语义 | Anthropic / gateway 处理 |
+| --- | --- | --- |
+| `END_TURN` | 模型自然结束当前 turn | 普通请求映射 `end_turn`；Claude Code 还需完成握手 |
+| `TOOL_USE` | 模型请求调用工具 | 有客户端工具时映射 `tool_use`；私有完成工具由网关消费 |
+| `MAX_TOKENS` | 达到本次生成 token 上限 | 映射 `max_tokens` |
+| `STOP_SEQUENCE` | 命中调用方配置的 stop sequence | Kiro 未回传实际命中串，不能构造合法 Anthropic 响应，fail closed |
+| `GUARDRAIL_INTERVENED` | AWS guardrail 介入 | 有可见拒答时映射 `refusal`；空响应走客户端内容过滤错误 |
+| `CONTENT_FILTERED` | 内容过滤器拒绝生成 | 有可见拒答时映射 `refusal`；空响应走客户端内容过滤错误 |
+| `MALFORMED_MODEL_OUTPUT` | 模型输出结构无效 | 无安全等价 stop reason，fail closed |
+| `MALFORMED_TOOL_USE` | 模型生成的工具调用无效 | 不伪造成合法 `tool_use`，fail closed |
+| `MODEL_CONTEXT_WINDOW_EXCEEDED` | 模型上下文窗口耗尽 | 映射 `model_context_window_exceeded` |
+
+Claude Code 对 Anthropic stop reason 的消费语义不同：`end_turn`、
+`stop_sequence` 与 `pause_turn` 都会结束当前 CLI turn；`max_tokens` 与
+`model_context_window_exceeded` 会触发客户端恢复；`tool_use` 只有同时存在合法
+工具块才会继续；`refusal` 会作为 API error 结束。因此禁止用 `pause_turn`、空
+`tool_use` 或虚构的 `max_tokens` 代替任务完成判定。
+
 ## Approved Behavior
 
 - Claude Code system prompt 由共享 owner 注入完成连续性守卫：实现与验证尚未完成时继续调用工具，多步骤任务保持 task/todo 状态真实，只有需要用户输入的真实 blocker 才能提前停止。
-- Kiro system priming 对已识别的 Claude Code prompt 只注入一次共享守卫；普通 API prompt 不注入。
-- Kiro `END_TURN`、`TOOL_USE`、`MAX_TOKENS`、`STOP_SEQUENCE` 映射到对应 Anthropic Messages stop reason。响应包含 tool use 时以 `tool_use` 为准。
-- `CONTENT_FILTERED` 无输出时沿用既有客户端错误契约；已有可见拒答文本时沿用既有成功响应契约。
+- Kiro system priming 对已识别的 Claude Code prompt 只注入一次共享守卫，并注入 transport-private completion tool；普通 API prompt 不启用该协议。客户端已声明同名工具时禁用私有协议，绝不遮蔽客户端工具。
+- 模型必须通过私有工具显式报告 `complete` 或 `blocked`，并提供非空的最终答复或 blocker 问题。该工具及其参数不暴露给 Claude Code。
+- 未收到有效完成信号的 Claude Code `END_TURN` 或只有无效私有工具的 `TOOL_USE`，在同一客户端 HTTP 请求内进入有界 Kiro 续跑；续跑上限由 service 常量统一控制，禁止无限 Agent loop。
+- 普通 Claude Code 工具调用立即以 `tool_use` 返回客户端。私有完成信号与普通工具同时出现时，普通工具优先；`MAX_TOKENS` 等非完成终止原因也始终优先。
+- `CONTENT_FILTERED` 与 `GUARDRAIL_INTERVENED` 无输出时沿用客户端内容过滤错误契约；已有可见拒答文本时返回 Anthropic `refusal`。
 - 空值或未知 stop reason 不得伪造成 `end_turn`。非流式请求进入 502 failover；已开始的流式响应发送 SSE error，并且不发送成功终止事件。
-- 每个成功映射记录脱敏结构化 marker `gateway.kiro_stop_reason`，用于确认原始与 Anthropic stop reason 的关系。
+- 隐藏续跑的额外输入与所有隐藏工具输出计入 Kiro 估算用量。每个成功映射记录脱敏结构化 marker `gateway.kiro_stop_reason`；完成协议动作记录 `gateway.kiro_completion_protocol`。
 
 ## Ownership and Flow
 
 ```text
 Claude Code system prompt
   -> shared completion guard owner
-  -> Kiro system priming (exactly once)
+  -> Kiro system priming + private completion tool (exactly once)
   -> Kiro EventStream metadataEvent.stopReason
-  -> fail-closed stop-reason mapper
+  -> valid completion signal? -- no --> bounded internal continuation
+                             -- yes -> strip private tool
+  -> fail-closed stop-reason mapper / explicit completion
   -> Anthropic JSON/SSE terminal outcome
   -> Claude Code continues or finishes according to the real outcome
 ```
 
-共享守卫 owner 位于 `backend/internal/pkg/claude/claude_code_completion_guard.go`。OpenAI-compatible Messages 与 Kiro translator 只调用 owner，不复制策略文本。Kiro stop reason 的 wire owner 位于 `backend/internal/service/kiro_gateway_service.go`，SSE encoder 只接收已经验证过的结果。
+共享守卫与私有工具名的 owner 位于 `backend/internal/pkg/claude/claude_code_completion_guard.go`；Kiro 私有协议、tool schema 与 continuation payload owner 位于 `backend/internal/integration/kiro/claude_code_completion.go`。OpenAI-compatible Messages 与 Kiro translator 只调用共享 owner，不复制策略文本。Kiro stop reason 与有界续跑的 wire owner 位于 `backend/internal/service/kiro_gateway_service.go`，SSE encoder 只接收已经验证过的结果。
 
 ## Risk Boundaries
 
 - 不改变路由、认证、计费、模型目录、账号调度或持久化数据。
-- 不在服务端持久化 Claude Code 的 task/todo 状态；任务完成判断仍由客户端 Agent 执行。
+- 不在服务端持久化 Claude Code 的 task/todo 状态；完成判定由同一模型通过私有协议显式声明，网关只验证信号形状与终止态。
 - 不部署、不重启、不修改 kiro-us3/4/5/6 节点配置；上线由独立 release/rollout 审批处理。
-- 行为变化仅限已识别的 Claude Code prompt 注入，以及 Kiro Messages 终止态的真实映射或 fail-closed 处理。
+- 行为变化仅限已识别的 Claude Code prompt、私有完成协议，以及 Kiro Messages 终止态的真实映射或 fail-closed 处理。
+- 单个客户端请求可能产生额外 Kiro 调用、延迟与估算费用，但由确定性上限约束；达到上限后不再内部续跑。
 
 ## Verification
 
 - 共享守卫幂等，并保留旧 marker 兼容既有 bridge 检测。
-- 完整 `ClaudeToKiro` payload 的 system priming 中守卫只出现一次，普通 prompt 不受影响。
-- 流式与非流式 `MAX_TOKENS` 均返回 `max_tokens`，不再伪造成 `end_turn`。
-- 未知 stop reason 在流式与非流式路径都 fail closed，且成功终止事件不会泄漏。
+- 完整 `ClaudeToKiro` payload 的 system priming 与私有工具只出现一次；普通 prompt 及同名客户端工具不受影响。
+- 流式与非流式 Claude Code 请求在首次 `END_TURN` 缺少完成信号时内部续跑，收到有效信号后只返回聚合文本与 `end_turn`。
+- 普通客户端工具立即返回；普通工具与完成信号并存时普通工具优先；空完成消息不能结束任务。
+- 流式与非流式 `MAX_TOKENS` 均返回 `max_tokens`；context window、policy refusal 与不支持的官方值按上表处理。
+- 未知 stop reason 在流式与非流式路径都 fail closed，且成功终止事件不会泄漏；续跑达到上限时确定性停止。
 - Kiro、共享 Claude package 与相关 service 单元测试，以及 sentinel/preflight 门禁全部通过后才允许提交和推送。

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -109,15 +109,38 @@
       "must_contain": [
         "func ClaudeToKiro",
         "func KiroToClaudeResponse",
-        "EnsureClaudeCodeCompletionGuard"
+        "EnsureClaudeCodeCompletionGuard",
+        "addClaudeCodeCompletionTool",
+        "payload.ClaudeCodeCompletionProtocol = completionProtocol"
       ],
-      "rationale": "Anthropic <-> Kiro request/response translation. Without it the /v1/messages -> CodeWhisperer bridge cannot build a payload or decode the reply. EnsureClaudeCodeCompletionGuard keeps recognized Claude Code sessions working until implementation and verification are complete without duplicating policy text in this vendored-shaped layer."
+      "rationale": "Anthropic <-> Kiro request/response translation. Without it the /v1/messages -> CodeWhisperer bridge cannot build a payload or decode the reply. EnsureClaudeCodeCompletionGuard keeps recognized Claude Code sessions working until implementation and verification are complete without duplicating policy text in this vendored-shaped layer. The completion protocol flag is enabled only when the private tool was actually added, which prevents a client-owned same-name tool from being shadowed or swallowed."
+    },
+    {
+      "path": "backend/internal/integration/kiro/claude_code_completion.go",
+      "must_contain": [
+        "func addClaudeCodeCompletionTool",
+        "func ConsumeClaudeCodeCompletionSignal",
+        "func PrepareClaudeCodeCompletionContinuation",
+        "ClaudeCodeCompletionProtocol",
+        "minLength"
+      ],
+      "rationale": "Single owner for Kiro's transport-private Claude Code completion handshake. It defines the non-empty completion schema, strips only valid private signals, and creates the bounded continuation payload while preserving the normal tool catalog. Losing this owner returns completion judgment to lossy stop-reason guessing or leaks private tool calls to Claude Code."
+    },
+    {
+      "path": "backend/internal/integration/kiro/claude_code_completion_test.go",
+      "must_contain": [
+        "TestConsumeClaudeCodeCompletionSignal_StripsOnlyPrivateTool",
+        "TestPrepareClaudeCodeCompletionContinuation_PreservesToolsAndMovesTurnToHistory",
+        "minLength"
+      ],
+      "rationale": "Focused regression evidence for private-signal parsing, non-empty completion messages, ordinary-tool preservation, and continuation history/tool-catalog integrity."
     },
     {
       "path": "backend/internal/pkg/claude/claude_code_completion_guard.go",
       "must_contain": [
         "ClaudeCodeCompletionGuardMarker",
         "ClaudeCodeCompletionGuardText",
+        "ClaudeCodeCompletionToolName",
         "func EnsureClaudeCodeCompletionGuard"
       ],
       "rationale": "Shared SSOT for Claude Code completion continuity across OpenAI-compatible Messages and Kiro. Losing or duplicating this owner lets a backend present unfinished work as a completed turn or makes the two bridge paths drift."
@@ -134,6 +157,7 @@
       "path": "backend/internal/integration/kiro/estimate.go",
       "must_contain": [
         "func EstimateInputTokens",
+        "func EstimatePayloadInputTokens",
         "func EstimateOutputTokens",
         "KiroEstimatedBillingTier"
       ],
@@ -147,6 +171,9 @@
         "func callKiroAPIOnce",
         "ResetForRetry func() bool",
         "OnStopReason",
+        "OnStopMetadata",
+        "KiroStopMetadata",
+        "KiroRefusalDetails",
         "case \"metadataEvent\":",
         "stale profileArn",
         "func parseEventStream",
@@ -159,7 +186,7 @@
         "runtime.us-east-1.kiro.dev",
         "q.us-east-1.amazonaws.com"
       ],
-      "rationale": "Streaming call entry + hand-rolled AWS EventStream binary decoder + the HTTPDoer injection seam that lets the TK gateway supply a TLS/proxy-aware doer. CallKiroAPIWithDoerContext binds upstream attempts to the customer request lifetime, while ResetForRetry permits response-read failover only when the consumer can discard all partial state. OnStopReason and the metadataEvent dispatch preserve Kiro's authoritative terminal outcome; losing them turns CONTENT_FILTERED back into an opaque empty-response 502. Losing parseEventStream breaks all streaming responses; losing the HTTPDoer seam breaks fingerprint/proxy egress. The endpoint anchors pin the official current runtime host followed only by Kiro's explicitly transitional q host; an upstream merge must not restore undocumented codewhisperer or alternate AmazonQ protocol retries."
+      "rationale": "Streaming call entry + hand-rolled AWS EventStream binary decoder + the HTTPDoer injection seam that lets the TK gateway supply a TLS/proxy-aware doer. CallKiroAPIWithDoerContext binds upstream attempts to the customer request lifetime, while ResetForRetry permits response-read failover only when the consumer can discard all partial state. OnStopReason plus KiroStopMetadata preserve Kiro's authoritative terminal outcome and structured refusal details; losing them turns policy outcomes back into opaque empty-response 502s. Losing parseEventStream breaks all streaming responses; losing the HTTPDoer seam breaks fingerprint/proxy egress. The endpoint anchors pin the official current runtime host followed only by Kiro's explicitly transitional q host; an upstream merge must not restore undocumented codewhisperer or alternate AmazonQ protocol retries."
     },
     {
       "path": "backend/internal/integration/kiro/eventstream_test.go",
@@ -167,6 +194,7 @@
         "TestParseEventStream_MetadataStopReason",
         "TestParseEventStream_FrameAlignedEOFWithoutStopReasonFails",
         "TestParseEventStream_TerminalStopIgnoresTruncatedTrailingFrame",
+        "KiroStopMetadata",
         "CONTENT_FILTERED"
       ],
       "rationale": "Protocol-level evidence that metadataEvent.stopReason survives EventStream decoding. Without this callback the service cannot distinguish an upstream content-policy terminal outcome from a broken empty response."
@@ -253,19 +281,24 @@
         "kiroproto.EstimateOutputTokens",
         "BillingTier:   kiroproto.KiroEstimatedBillingTier",
         "callErr != nil && !enc.started",
-        "textBuf == \"\" && thinkingBuf == \"\" && len(toolUses) == 0",
+        "turnText == \"\" && turnThinking == \"\" && len(turnToolUses) == 0",
         "KiroContentFilteredError",
         "KiroPostOutputStreamDisconnectError",
         "classifyKiroPostOutputStreamError",
         "recordKiroStreamError",
         "CONTENT_FILTERED",
         "mapKiroStopReason",
+        "maxClaudeCodeCompletionTurns",
+        "payload.ClaudeCodeCompletionProtocol",
+        "kiroproto.ConsumeClaudeCodeCompletionSignal",
+        "kiroproto.PrepareClaudeCodeCompletionContinuation",
         "gateway.kiro_stop_reason",
+        "gateway.kiro_completion_protocol",
         "unsupported_stop_reason",
         "classifyAndRecordKiroForwardError",
         "publishKiroInternalThinkingSideChannel"
       ],
-      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream. It estimates token usage locally (EstimateInputTokens/EstimateOutputTokens) and stamps ForwardResult.BillingTier=\"kiro-estimated\", because the Kiro upstream reports credits only — without these calls both forward paths return Usage{0,0} and kiro bills as 100% free. The context-aware call and ResetForRetry callbacks are load-bearing: non-streaming retries clear all partial buffers, while streaming retries are rejected after enc.started to prevent duplicated client output. The stop-reason mapper and structured marker preserve Kiro's authoritative terminal outcome; unknown values fail closed instead of forging end_turn. The `callErr != nil && !enc.started` guard + classifyAndRecordKiroForwardError keep pre-content failures visible instead of returning an empty 200 stream and retain the sanitized original transport/read cause in ops upstream_errors. An upstream merge that drops any of these guards silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
+      "rationale": "The sixth-platform forwarder translates /v1/messages onto Kiro EventStream and estimates usage because upstream reports credits only. The context-aware call and ResetForRetry callbacks protect retry integrity. The stop-reason mapper preserves Kiro's authoritative terminal outcome; for positively identified Claude Code payloads, the private completion signal and bounded continuation loop separate model END_TURN from agent completion. Every private-tool consume/hide site is guarded by payload.ClaudeCodeCompletionProtocol so ordinary API clients retain same-name tools. Hidden continuation usage is billed and both stop/completion actions are observable. The pre-content error guard keeps failures visible instead of returning an empty 200 stream. Losing these anchors silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
     },
     {
       "path": "backend/internal/service/kiro_gateway_service_test.go",
@@ -283,6 +316,14 @@
         "TestKiroGatewayService_Forward_Streaming_PreservesMaxTokensStopReason",
         "TestKiroGatewayService_Forward_Streaming_UnknownStopReasonFailsClosed",
         "TestKiroGatewayService_Forward_NonStreaming_UnknownStopReasonFailsOver",
+        "TestUS041_KiroGatewayService_ClaudeCodeEndTurnContinuesUntilExplicitCompletion",
+        "TestUS041_KiroGatewayService_EmptyCompletionSignalDoesNotFinish",
+        "TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved",
+        "TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolUseReturnsImmediately",
+        "TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolWinsOverCompletionSignal",
+        "TestUS041_KiroGatewayService_MaxTokensOverridesCompletionSignal",
+        "TestUS041_KiroGatewayService_ClaudeCodeCompletionLoopIsBounded",
+        "TestKiroGatewayService_Forward_GuardrailIntervenedIsNotFailover",
         "TestKiroGatewayService_Forward_Streaming_PreContentReadErrorTriggersFailover",
         "TestKiroGatewayService_Forward_EventStreamThrottlingTriggersFailover",
         "TestKiroGatewayService_Forward_EmptyEventStreamExceptionPreservesFailoverClass",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -318,6 +318,7 @@
         "TestKiroGatewayService_Forward_NonStreaming_UnknownStopReasonFailsOver",
         "TestUS041_KiroGatewayService_ClaudeCodeEndTurnContinuesUntilExplicitCompletion",
         "TestUS041_KiroGatewayService_EmptyCompletionSignalDoesNotFinish",
+        "TestUS041_KiroGatewayService_EmptyCompletionMessageWithAssistantTextDoesNotFinish",
         "TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved",
         "TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolUseReturnsImmediately",
         "TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolWinsOverCompletionSignal",


### PR DESCRIPTION
## 摘要

- #1488 已修复 Kiro 模型层 stop reason 保真；本 PR 补齐模型 stop 与 Claude Code Agent 任务完成之间的语义层。
- 对正向识别的 Claude Code 请求注入 transport-private completion tool，模型必须显式报告 `complete` 或 `blocked`。
- 缺少完成信号的 `END_TURN` 在同一客户端请求内进行有界续跑；私有工具不泄漏给 Claude Code。
- 普通 Claude Code 工具立即返回；普通 API 即使声明同名工具也不会被误吞。
- 补齐 Kiro 官方 stop reason 的 fail-closed/拒答/context-window 映射与 stop metadata 保真。

## 设计

- 共享 completion guard owner：`backend/internal/pkg/claude/claude_code_completion_guard.go`。
- Kiro 私有协议 owner：`backend/internal/integration/kiro/claude_code_completion.go`。
- 只有 `ClaudeCodeCompletionProtocol=true` 时才消费/隐藏私有工具。
- 普通工具与完成信号并存时普通工具优先；`MAX_TOKENS` 等非完成终止原因优先。
- 续跑次数有确定性上限，隐藏续跑的估算用量纳入计费。

## 契约

- Kiro `END_TURN` 不再被解释为 Claude Code Agent 已完成；需显式完成握手。
- `MAX_TOKENS` → `max_tokens`，`MODEL_CONTEXT_WINDOW_EXCEEDED` → `model_context_window_exceeded`。
- `CONTENT_FILTERED`/`GUARDRAIL_INTERVENED` 有可见拒答时 → `refusal`，无输出保留客户端内容过滤错误。
- 缺少 stop sequence 实际匹配串、malformed 或未知 stop reason 均 fail closed。

## 风险

- 仅影响 Kiro `/v1/messages`，不改路由、认证、模型目录、账号调度或生产部署。
- Claude Code 请求可能产生额外的有界 Kiro 调用与延迟；普通 API 请求不启用该协议。
- `docs/approved/kiro-claude-code-completion-continuity.md` 的修订是本 PR 的有意审批基线更新。
- no-web-impact。

## 验证

- `go test -tags=unit -count=1 ./internal/pkg/claude ./internal/integration/kiro ./internal/service`
- `python3 scripts/sentinels/check-kiro.py`
- `.testing/user-stories/verify_quality.py`
- `./scripts/preflight.sh`（PASS；Docker Caddy gate 按本机环境跳过，CI enforced）

## 提交

- `3baf1a838 fix(kiro): require explicit Claude Code completion before end_turn (no-web-impact)`
- 最新提交：`3baf1a838`
