### PR TITLE
fix(gateway): OR image 推理纳入 antigravity universal 候选

### DIFF
--- a/backend/internal/service/universal_routing_tk_endpoint_map.go
+++ b/backend/internal/service/universal_routing_tk_endpoint_map.go
@@ -137,6 +137,15 @@ func universalCandidatePlatforms(shape UniversalShape, forcedPlatform string, ha
 		if universalModelPlatformHint(model) == PlatformGrok {
 			out = append(out, PlatformGrok)
 		}
+		// Gemini-native image models (gemini-*-image) ride antigravity generateContent,
+		// same as chat completions — without antigravity in candidates, universal keys
+		// on /openrouter/v1/images or /v1/images/generations get universal_no_entitled_group.
+		if antigravity.IsImageModel(model) {
+			out = append(out, PlatformAntigravity)
+		}
+		if universalModelPlatformHint(model) == PlatformGemini {
+			out = append(out, PlatformGemini)
+		}
 		return out
 	case ShapeOpenAIImagesEdit:
 		return []string{PlatformOpenAI, PlatformGrok}

--- a/backend/internal/service/universal_routing_tk_resolver_test.go
+++ b/backend/internal/service/universal_routing_tk_resolver_test.go
@@ -156,6 +156,10 @@ func TestUniversalCandidatePlatforms(t *testing.T) {
 	if !contains(imageGrok, PlatformGrok) {
 		t.Errorf("grok image should include grok platform: %v", imageGrok)
 	}
+	imageGeminiNative := universalCandidatePlatforms(ShapeOpenAIImages, "", false, "gemini-2.5-flash-image")
+	if !contains(imageGeminiNative, PlatformAntigravity) {
+		t.Errorf("gemini-native image should include antigravity: %v", imageGeminiNative)
+	}
 	imageEdit := universalCandidatePlatforms(ShapeOpenAIImagesEdit, "", false, "")
 	if !contains(imageEdit, PlatformOpenAI) || !contains(imageEdit, PlatformGrok) {
 		t.Errorf("image edits should include openai and grok platforms: %v", imageEdit)

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -381,6 +381,23 @@ func TestResolve_GeminiNativeImageChatPicksAntigravity(t *testing.T) {
 	}
 }
 
+// OpenRouter seller POST /openrouter/v1/images uses the same antigravity pool as chat.
+func TestResolve_GeminiNativeImageOpenRouterImagesPicksAntigravity(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(2, PlatformOpenAI, 5, false),
+		grp(21, PlatformAntigravity, 10, false),
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetAvailableModelsProvider(servedProvider(map[int64][]string{
+		21: {"gemini-2.5-flash-image", "gemini-3.1-flash-image"},
+	}))
+	g, err := r.Resolve(ctx, universalKey(32), ShapeOpenAIImages, "gemini-2.5-flash-image", "")
+	if err != nil || g == nil || g.ID != 21 {
+		t.Fatalf("gemini-native image on /openrouter/v1/images 应落 antigravity gid=21, got=%v err=%v", g, err)
+	}
+}
+
 // imagen 走 newapi google-vertex 组(显式声明),不落 openai 组。
 func TestResolve_ImagenPicksVertexNewapiGroup(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## 摘要

- 修复 OpenRouter seller `POST /openrouter/v1/images` 在 universal key 上返回 `universal_no_entitled_group` 的问题。
- `ShapeOpenAIImages` 候选平台补齐与 chat 一致的 **antigravity / gemini** 路径，使 `gemini-*-image` 模型能落到 Google-Antigravity 组（prod gid=21）。

## 风险

- 常规风险：仅扩展 universal routing 候选集合，影响 `/openrouter/v1/images` 与 `/v1/images/generations` 的 gemini-native image 模型解析；不改变 catalog/chat 行为。

## 验证

```bash
go test -tags=unit ./backend/internal/service -run 'GeminiNativeImage|UniversalCandidatePlatforms'
PREFLIGHT_BASE=origin/main ./scripts/preflight.sh
```

发版后 prod smoke：`POST https://api.tokenkey.dev/openrouter/v1/images` + inference key + `tokenkey/gemini-2.5-flash-image` 应返回 JSON（非 `universal_no_entitled_group`）。

## 提交

- `425578b82` fix(gateway): route OR image inference through antigravity universal pool

最新提交：`425578b82`

Made with [Cursor](https://cursor.com)