### PR TITLE
fix(kiro): completion 最终回复只输出一次

### DIFF
--- a/.testing/user-stories/stories/US-041-kiro-claude-code-completion-continuity.md
+++ b/.testing/user-stories/stories/US-041-kiro-claude-code-completion-continuity.md
@@ -19,7 +19,7 @@
 
 ## Acceptance Criteria
 
-1. **AC-001（显式完成协议）**：Given Claude Code system prompt，When 构建 Kiro payload，Then completion guard 与 transport-private completion tool 各只出现一次；有效 `complete/blocked` 信号被消费并转换为最终文本与 `end_turn`。
+1. **AC-001（显式完成协议）**：Given Claude Code system prompt，When 构建 Kiro payload，Then completion guard 与 transport-private completion tool 各只出现一次；有效 `complete/blocked` 信号被消费并转换为最终文本与 `end_turn`；私有 completion message 已作为完整文本块出现在同一请求可见输出中时不得重复追加。
 2. **AC-002（未完成续跑）**：Given Kiro 返回文本与 `END_TURN` 但无有效完成信号，When 流式或非流式 gateway 处理，Then 在同一客户端请求内继续 Kiro turn，直到收到完成信号或达到确定性上限。
 3. **AC-003（范围与工具守卫）**：Given 普通 API 请求声明同名工具，When Kiro 调用该工具，Then 工具不得被吞；Given Claude Code 调用普通工具或同时产生普通工具与完成信号，Then 普通工具立即以 `tool_use` 返回并优先于完成信号。
 4. **AC-004（截断语义）**：Given Kiro 返回 `MAX_TOKENS` 或 `MODEL_CONTEXT_WINDOW_EXCEEDED`，When gateway 转换，Then保留对应 Anthropic stop reason，即使同一响应含私有完成信号也不得覆盖。
@@ -33,6 +33,7 @@
 - `mapKiroStopReason` 对已知值显式映射，对空值和未知值返回 typed error。
 - JSON 与 SSE wire 分别保留 `max_tokens`；未知流式终止态不包含 `message_stop`。
 - 私有工具只在 `ClaudeCodeCompletionProtocol` 为真时被消费；空消息、普通工具或非完成 stop reason 不能提前结束。
+- 流式与非流式输出在同轮及隐藏续跑跨轮均不得重复已经可见的完整 completion message；真正互补的进度文本与最终答复继续同时保留。
 - sentinel 锚定共享 owner、私有协议 owner、有界续跑、范围门禁、stop metadata、结构化日志与核心回归测试。
 
 ## Linked Tests
@@ -46,6 +47,9 @@
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeEndTurnContinuesUntilExplicitCompletion`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_EmptyCompletionSignalDoesNotFinish`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_EmptyCompletionMessageWithAssistantTextDoesNotFinish`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_CompletionSignalMessageIsPreservedAfterText`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_CompletionSignalDoesNotRepeatVisibleFinalText`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ContinuationCompletionDoesNotRepeatPriorFinalText`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolUseReturnsImmediately`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolWinsOverCompletionSignal`

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -159,29 +161,51 @@ func shouldContinueClaudeCodeCompletion(
 		acceptsClaudeCodeCompletionSignal(rawStopReason)
 }
 
-func completionSignalText(text string, signal *kiroproto.ClaudeCodeCompletionSignal) string {
+func completionSignalTextDelta(visibleText string, signal *kiroproto.ClaudeCodeCompletionSignal) string {
 	if signal == nil || strings.TrimSpace(signal.Message) == "" {
-		return text
-	}
-	message := strings.TrimSpace(signal.Message)
-	if strings.TrimSpace(text) == "" {
-		return message
-	}
-	if strings.TrimSpace(text) == message {
-		return text
-	}
-	return text + "\n\n" + message
-}
-
-func completionSignalTextDelta(text string, signal *kiroproto.ClaudeCodeCompletionSignal) string {
-	merged := completionSignalText(text, signal)
-	if merged == text {
 		return ""
 	}
-	if strings.HasPrefix(merged, text) {
-		return merged[len(text):]
+	message := strings.TrimSpace(signal.Message)
+	visibleText = strings.TrimSpace(visibleText)
+	if visibleText == "" {
+		return message
 	}
-	return merged
+	if containsCompletionTextBlock(visibleText, message) {
+		return ""
+	}
+	return "\n\n" + message
+}
+
+// containsCompletionTextBlock reports whether the private completion message
+// is already present as a complete whitespace- or punctuation-delimited block
+// in client-visible text. Boundary checks avoid treating short messages such as
+// "OK" as present merely because they occur inside another word.
+func containsCompletionTextBlock(text, block string) bool {
+	for offset := 0; offset <= len(text)-len(block); {
+		relative := strings.Index(text[offset:], block)
+		if relative < 0 {
+			return false
+		}
+		start := offset + relative
+		end := start + len(block)
+		beforeBoundary := start == 0 || isCompletionTextBoundaryBefore(text, start)
+		afterBoundary := end == len(text) || isCompletionTextBoundaryAfter(text, end)
+		if beforeBoundary && afterBoundary {
+			return true
+		}
+		offset = start + 1
+	}
+	return false
+}
+
+func isCompletionTextBoundaryBefore(text string, index int) bool {
+	r, _ := utf8.DecodeLastRuneInString(text[:index])
+	return unicode.IsSpace(r) || unicode.IsPunct(r)
+}
+
+func isCompletionTextBoundaryAfter(text string, index int) bool {
+	r, _ := utf8.DecodeRuneInString(text[index:])
+	return unicode.IsSpace(r) || unicode.IsPunct(r)
 }
 
 func logKiroCompletionProtocol(account *Account, model string, turn int, action, status string) {
@@ -386,7 +410,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		}
 		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, visibleToolUses, completionSignal)
 		if completionAccepted {
-			turnText = completionSignalText(turnText, completionSignal)
+			turnText += completionSignalTextDelta(textBuf+turnText, completionSignal)
 		}
 		if turnText == "" && turnThinking == "" && len(turnToolUses) == 0 && textBuf == "" && thinkingBuf == "" {
 			if isKiroPolicyStopReason(stopReason) {
@@ -631,15 +655,12 @@ func (s *KiroGatewayService) forwardStreaming(
 		}
 		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, visibleToolUses, completionSignal)
 		if completionAccepted {
-			completionText := completionSignalText(turnText, completionSignal)
-			if completionText != turnText {
-				completionDelta := completionSignalTextDelta(turnText, completionSignal)
-				turnText = completionText
-				if completionDelta != "" {
-					markFirstToken()
-					enc.writeTextDelta(completionDelta)
-					callOutputCommitted = true
-				}
+			completionDelta := completionSignalTextDelta(textBuf+turnText, completionSignal)
+			if completionDelta != "" {
+				turnText += completionDelta
+				markFirstToken()
+				enc.writeTextDelta(completionDelta)
+				callOutputCommitted = true
 			}
 		}
 		if turnText == "" && turnThinking == "" && len(turnToolUses) == 0 && textBuf == "" && thinkingBuf == "" {

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -603,6 +603,62 @@ func TestUS041_KiroGatewayService_CompletionSignalMessageIsPreservedAfterText(t 
 	}
 }
 
+func TestUS041_KiroGatewayService_CompletionSignalDoesNotRepeatVisibleFinalText(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			body := buildKiroEventStreamMessage("assistantResponseEvent", []byte(`{"content":"Workspace is clean。PR #1501 is ready.\nChecks passed."}`))
+			body = append(body, kiroToolUseEvent("toolu_completion", "sub2apiClaudeCodeCompletion", map[string]any{
+				"status": "complete", "message": "PR #1501 is ready.\nChecks passed.",
+			})...)
+			body = appendKiroTerminalStop(body, "TOOL_USE")
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{body}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 1, upstream.calls)
+			out := rec.Body.String()
+			require.Equal(t, 1, strings.Count(out, "PR #1501 is ready."))
+			require.Equal(t, 1, strings.Count(out, "Checks passed."))
+			require.Contains(t, out, "Workspace is clean。")
+			require.Contains(t, out, `"stop_reason":"end_turn"`)
+			require.NotContains(t, out, "sub2apiClaudeCodeCompletion")
+		})
+	}
+}
+
+func TestUS041_KiroGatewayService_ContinuationCompletionDoesNotRepeatPriorFinalText(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroTextStopStream("Workspace is clean。PR #1501 is ready.\nChecks passed.", "END_TURN"),
+				kiroCompletionSignalStream("complete", "PR #1501 is ready.\nChecks passed."),
+			}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 2, upstream.calls)
+			out := rec.Body.String()
+			require.Equal(t, 1, strings.Count(out, "PR #1501 is ready."))
+			require.Equal(t, 1, strings.Count(out, "Checks passed."))
+			require.Contains(t, out, "Workspace is clean。")
+			require.Contains(t, out, `"stop_reason":"end_turn"`)
+			require.NotContains(t, out, "sub2apiClaudeCodeCompletion")
+		})
+	}
+}
+
 func TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved(t *testing.T) {
 	for _, stream := range []bool{false, true} {
 		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -292,13 +292,14 @@
         "payload.ClaudeCodeCompletionProtocol",
         "kiroproto.ConsumeClaudeCodeCompletionSignal",
         "kiroproto.PrepareClaudeCodeCompletionContinuation",
+        "completionSignalTextDelta",
         "gateway.kiro_stop_reason",
         "gateway.kiro_completion_protocol",
         "unsupported_stop_reason",
         "classifyAndRecordKiroForwardError",
         "publishKiroInternalThinkingSideChannel"
       ],
-      "rationale": "The sixth-platform forwarder translates /v1/messages onto Kiro EventStream and estimates usage because upstream reports credits only. The context-aware call and ResetForRetry callbacks protect retry integrity. The stop-reason mapper preserves Kiro's authoritative terminal outcome; for positively identified Claude Code payloads, the private completion signal and bounded continuation loop separate model END_TURN from agent completion. Every private-tool consume/hide site is guarded by payload.ClaudeCodeCompletionProtocol so ordinary API clients retain same-name tools. Hidden continuation usage is billed and both stop/completion actions are observable. The pre-content error guard keeps failures visible instead of returning an empty 200 stream. Losing these anchors silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
+      "rationale": "The sixth-platform forwarder translates /v1/messages onto Kiro EventStream and estimates usage because upstream reports credits only. The context-aware call and ResetForRetry callbacks protect retry integrity. The stop-reason mapper preserves Kiro's authoritative terminal outcome; for positively identified Claude Code payloads, the private completion signal and bounded continuation loop separate model END_TURN from agent completion. completionSignalTextDelta prevents a private completion message from repeating a complete text block already visible in the same or an earlier hidden turn while preserving genuinely complementary final text. Every private-tool consume/hide site is guarded by payload.ClaudeCodeCompletionProtocol so ordinary API clients retain same-name tools. Hidden continuation usage is billed and both stop/completion actions are observable. The pre-content error guard keeps failures visible instead of returning an empty 200 stream. Losing these anchors silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
     },
     {
       "path": "backend/internal/service/kiro_gateway_service_test.go",
@@ -319,6 +320,9 @@
         "TestUS041_KiroGatewayService_ClaudeCodeEndTurnContinuesUntilExplicitCompletion",
         "TestUS041_KiroGatewayService_EmptyCompletionSignalDoesNotFinish",
         "TestUS041_KiroGatewayService_EmptyCompletionMessageWithAssistantTextDoesNotFinish",
+        "TestUS041_KiroGatewayService_CompletionSignalMessageIsPreservedAfterText",
+        "TestUS041_KiroGatewayService_CompletionSignalDoesNotRepeatVisibleFinalText",
+        "TestUS041_KiroGatewayService_ContinuationCompletionDoesNotRepeatPriorFinalText",
         "TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved",
         "TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolUseReturnsImmediately",
         "TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolWinsOverCompletionSignal",


### PR DESCRIPTION
## 摘要

- 基于最新 origin/main 增量修复 #1499 引入的 completion 最终回复重复问题。
- 私有 completion message 已作为完整文本块出现在当前或前序隐藏 turn 的可见输出中时，不再作为 JSON/SSE delta 重复追加。
- 保留真正互补的进度文本与最终答复，并保持 completion handshake、隐藏续跑和 end_turn 映射不变。
- 对齐 US-041 与 Kiro sentinel。no-web-impact。

## 风险

- 影响范围仅限识别为 Claude Code 的 Kiro /v1/messages 私有 completion 协议。
- 去重只匹配带 Unicode 空白或标点边界的完整文本块，避免把普通单词内部的短字符串误判为已输出。
- 普通 Kiro 请求、客户端工具、计费、调度和 Web surface 不变。

## 验证

- go test -tags=unit -count=1 ./internal/pkg/claude ./internal/integration/kiro ./internal/service
- python3 ./scripts/sentinels/check-kiro.py
- python3 .testing/user-stories/verify_quality.py
- ./scripts/preflight.sh

## 提交

- 46d8d2e65 fix(kiro): 去重 completion 最终回复

最新提交：46d8d2e65