### PR TITLE
fix(quickstart): 修复浏览器连通性探测 CORS Failed to fetch

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 665,
-  "hash": "604af8e9acb6b84c4278e379ae1f725ac927cfa6ec3b502d1c8a520726b8e46e",
+  "hash": "9570c25813b8876b92a3c5f8ecac76391db5b5ee68b0823923ff5551279014cc",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 665,
-  "hash": "b35ee870aef9d70a518e193d907f6aded02e7a6974e83fd771af77aae23cd7be",
+  "hash": "604af8e9acb6b84c4278e379ae1f725ac927cfa6ec3b502d1c8a520726b8e46e",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/__tests__/playground.spec.ts
+++ b/frontend/src/api/__tests__/playground.spec.ts
@@ -25,6 +25,11 @@ function mockFetchCapturing(): () => Record<string, unknown> {
   return () => body
 }
 
+/** Gateway URL assertions use arbitrary hosts; disable browser same-origin rewrite. */
+function stubNonBrowserGatewayEnv(): void {
+  vi.stubGlobal('window', undefined)
+}
+
 describe('resolveBrowserGatewayFetchBaseUrl', () => {
   afterEach(() => vi.unstubAllGlobals())
 
@@ -46,9 +51,32 @@ describe('resolveBrowserGatewayFetchBaseUrl', () => {
   })
 })
 
+describe('gatewayListModels browser fetch base', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('uses same-origin base when the display gateway host is cross-origin', async () => {
+    vi.stubGlobal('window', { location: { origin: 'https://tokenkey.dev', href: 'https://tokenkey.dev/studio' } })
+    let sentUrl = ''
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        sentUrl = url
+        return new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      })
+    )
+    const { gatewayListModels } = await import('@/api/playground')
+    await gatewayListModels('sk-test', 'https://api.tokenkey.dev')
+    expect(sentUrl).toBe('https://tokenkey.dev/v1/models')
+  })
+})
+
 describe('gatewayImageGenerations payload', () => {
   let getBody: () => Record<string, unknown>
   beforeEach(() => {
+    stubNonBrowserGatewayEnv()
     getBody = mockFetchCapturing()
   })
   afterEach(() => vi.unstubAllGlobals())
@@ -94,6 +122,9 @@ describe('gatewayImageGenerations payload', () => {
 })
 
 describe('gatewayImagePresign', () => {
+  beforeEach(() => {
+    stubNonBrowserGatewayEnv()
+  })
   afterEach(() => vi.unstubAllGlobals())
 
   it('POSTs the key and returns the re-minted url', async () => {
@@ -130,6 +161,7 @@ describe('gatewayImagePresign', () => {
 describe('gatewayVideoSubmit payload', () => {
   let getBody: () => Record<string, unknown>
   beforeEach(() => {
+    stubNonBrowserGatewayEnv()
     getBody = mockFetchCapturing()
   })
   afterEach(() => vi.unstubAllGlobals())
@@ -166,6 +198,7 @@ describe('gatewayVideoSubmit payload', () => {
 describe('gatewayGeminiImageViaChat payload (image-to-image)', () => {
   let getBody: () => Record<string, unknown>
   beforeEach(() => {
+    stubNonBrowserGatewayEnv()
     getBody = mockFetchCapturing()
   })
   afterEach(() => vi.unstubAllGlobals())
@@ -194,6 +227,9 @@ describe('gatewayGeminiImageViaChat payload (image-to-image)', () => {
 })
 
 describe('gatewayImageToPrompt', () => {
+  beforeEach(() => {
+    stubNonBrowserGatewayEnv()
+  })
   afterEach(() => vi.unstubAllGlobals())
 
   it('sends the image as multimodal content and returns the assistant text', async () => {

--- a/frontend/src/api/__tests__/playground.spec.ts
+++ b/frontend/src/api/__tests__/playground.spec.ts
@@ -5,6 +5,7 @@ import {
   gatewayVideoSubmit,
   gatewayGeminiImageViaChat,
   gatewayImageToPrompt,
+  resolveBrowserGatewayFetchBaseUrl,
 } from '@/api/playground'
 
 // Capture the JSON body each builder sends so we can assert the wire shape:
@@ -23,6 +24,27 @@ function mockFetchCapturing(): () => Record<string, unknown> {
   )
   return () => body
 }
+
+describe('resolveBrowserGatewayFetchBaseUrl', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns the configured base when it matches the page origin', () => {
+    vi.stubGlobal('window', { location: { origin: 'https://tokenkey.dev', href: 'https://tokenkey.dev/quickstart' } })
+    expect(resolveBrowserGatewayFetchBaseUrl('https://tokenkey.dev/')).toBe('https://tokenkey.dev')
+  })
+
+  it('falls back to same-origin when the configured gateway host is cross-origin', () => {
+    vi.stubGlobal('window', { location: { origin: 'https://tokenkey.dev', href: 'https://tokenkey.dev/quickstart' } })
+    expect(resolveBrowserGatewayFetchBaseUrl('https://api.tokenkey.dev')).toBe('https://tokenkey.dev')
+  })
+
+  it('returns the configured base outside the browser', () => {
+    const originalWindow = globalThis.window
+    vi.stubGlobal('window', undefined)
+    expect(resolveBrowserGatewayFetchBaseUrl('https://api.tokenkey.dev')).toBe('https://api.tokenkey.dev')
+    vi.stubGlobal('window', originalWindow)
+  })
+})
 
 describe('gatewayImageGenerations payload', () => {
   let getBody: () => Record<string, unknown>

--- a/frontend/src/api/playground.ts
+++ b/frontend/src/api/playground.ts
@@ -77,6 +77,33 @@ export function resolveGatewayBaseUrl(apiBaseFromSettings: string | undefined): 
   return ''
 }
 
+/**
+ * Gateway base for browser `fetch()` probes (Quickstart live test, Studio).
+ *
+ * Copy-paste snippets keep the public gateway host (e.g. api.tokenkey.dev), but
+ * the web UI runs on the apex host (tokenkey.dev) which reverse-proxies /v1/*.
+ * Cross-origin fetch to the API host fails CORS preflight when allowed_origins
+ * is unset, surfacing as "Failed to fetch" even though curl/clients work.
+ */
+export function resolveBrowserGatewayFetchBaseUrl(displayGatewayBaseUrl: string): string {
+  const display = stripTrailingSlashes(displayGatewayBaseUrl.trim())
+  if (typeof window === 'undefined') {
+    return display
+  }
+  if (!display) {
+    return stripTrailingSlashes(window.location.origin)
+  }
+  try {
+    const configured = new URL(display)
+    if (configured.origin === window.location.origin) {
+      return display
+    }
+  } catch {
+    return display
+  }
+  return stripTrailingSlashes(window.location.origin)
+}
+
 export async function gatewayListModels(
   apiKey: string,
   gatewayBaseUrl: string,

--- a/frontend/src/api/playground.ts
+++ b/frontend/src/api/playground.ts
@@ -78,7 +78,7 @@ export function resolveGatewayBaseUrl(apiBaseFromSettings: string | undefined): 
 }
 
 /**
- * Gateway base for browser `fetch()` probes (Quickstart live test, Studio).
+ * Gateway base for browser `fetch()` probes (Quickstart live test, Studio gateway calls).
  *
  * Copy-paste snippets keep the public gateway host (e.g. api.tokenkey.dev), but
  * the web UI runs on the apex host (tokenkey.dev) which reverse-proxies /v1/*.
@@ -104,12 +104,17 @@ export function resolveBrowserGatewayFetchBaseUrl(displayGatewayBaseUrl: string)
   return stripTrailingSlashes(window.location.origin)
 }
 
+/** Display gateway base → browser-safe fetch root (same-origin when CORS would block). */
+function browserGatewayFetchRoot(displayGatewayBaseUrl: string): string {
+  return stripTrailingSlashes(resolveBrowserGatewayFetchBaseUrl(displayGatewayBaseUrl))
+}
+
 export async function gatewayListModels(
   apiKey: string,
   gatewayBaseUrl: string,
   signal?: AbortSignal
 ): Promise<GatewayModelsResponse> {
-  const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/models`
+  const url = `${browserGatewayFetchRoot(gatewayBaseUrl)}/v1/models`
   const res = await fetch(url, {
     method: 'GET',
     headers: {
@@ -203,7 +208,7 @@ export async function gatewayChatCompletion(
   body: ChatCompletionRequest,
   signal?: AbortSignal
 ): Promise<unknown> {
-  const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/chat/completions`
+  const url = `${browserGatewayFetchRoot(gatewayBaseUrl)}/v1/chat/completions`
   return gatewayRequestJSON(
     apiKey,
     url,
@@ -241,7 +246,7 @@ export async function gatewayImageGenerations(
   signal?: AbortSignal,
   trace?: GatewayRequestTrace
 ): Promise<unknown> {
-  const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/images/generations`
+  const url = `${browserGatewayFetchRoot(gatewayBaseUrl)}/v1/images/generations`
   const payload: Record<string, unknown> = { model: body.model, prompt: body.prompt }
   if (body.size) payload.size = body.size
   if (body.n && body.n > 0) payload.n = body.n
@@ -266,7 +271,7 @@ export async function gatewayImagePresign(
   key: string,
   signal?: AbortSignal
 ): Promise<string> {
-  const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/images/presign`
+  const url = `${browserGatewayFetchRoot(gatewayBaseUrl)}/v1/images/presign`
   const resp = (await gatewayRequestJSON(
     apiKey,
     url,
@@ -333,7 +338,7 @@ export async function gatewayGeminiImageViaChat(
   signal?: AbortSignal,
   trace?: GatewayRequestTrace
 ): Promise<unknown> {
-  const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/chat/completions`
+  const url = `${browserGatewayFetchRoot(gatewayBaseUrl)}/v1/chat/completions`
   const payload: Record<string, unknown> = {
     model: body.model,
     messages: [userMessage(body.prompt, body.inputImage)],
@@ -371,7 +376,7 @@ export async function gatewayImageToPrompt(
   body: ImageToPromptRequest,
   signal?: AbortSignal
 ): Promise<string> {
-  const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/chat/completions`
+  const url = `${browserGatewayFetchRoot(gatewayBaseUrl)}/v1/chat/completions`
   const instruction =
     body.instruction ||
     'Describe this image as a concise, vivid text-to-image generation prompt. Output only the prompt, no preamble.'
@@ -435,7 +440,7 @@ export async function gatewayVideoSubmit(
   body: VideoGenerationRequest,
   signal?: AbortSignal
 ): Promise<unknown> {
-  const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/video/generations`
+  const url = `${browserGatewayFetchRoot(gatewayBaseUrl)}/v1/video/generations`
   const payload: Record<string, unknown> = { model: body.model, prompt: body.prompt }
   if (body.duration) payload.duration = body.duration
   if (body.aspectRatio) payload.aspect_ratio = body.aspectRatio
@@ -462,7 +467,7 @@ export async function gatewayVideoFetch(
   taskId: string,
   signal?: AbortSignal
 ): Promise<unknown> {
-  const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/video/generations/${encodeURIComponent(taskId)}`
+  const url = `${browserGatewayFetchRoot(gatewayBaseUrl)}/v1/video/generations/${encodeURIComponent(taskId)}`
   // 180s, not 30s: the terminal SUCCESS body is a 10–20 MB inline base64 clip
   // (see PLAYGROUND_VIDEO_FETCH_TIMEOUT_MS) — a short timeout aborts mid-download
   // and the poll then mis-reports the (actually generated) video as failed.

--- a/frontend/src/composables/__tests__/useTkUseKey.spec.ts
+++ b/frontend/src/composables/__tests__/useTkUseKey.spec.ts
@@ -127,6 +127,7 @@ describe('useTkUseKey model loading', () => {
 
 describe('useTkUseKey tool-call probe', () => {
   it('forces a side-effect-free function and verifies the returned tool call', async () => {
+    vi.stubGlobal('window', { location: { origin: 'https://api.tokenkey.test', href: 'https://api.tokenkey.test/' } })
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       choices: [{
         message: {
@@ -152,6 +153,21 @@ describe('useTkUseKey tool-call probe', () => {
       function: { name: 'tokenkey_quickstart_probe' },
     })
     expect(tk.testState.value).toMatchObject({ status: 'ok', httpStatus: 200, toolCall: true })
+  })
+
+  it('uses same-origin fetch base when the display gateway host is cross-origin', async () => {
+    vi.stubGlobal('window', { location: { origin: 'https://tokenkey.dev', href: 'https://tokenkey.dev/quickstart' } })
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      choices: [{ message: { content: 'pong' } }],
+    }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const tk = createUseKey()
+    await tk.runTest('openai')
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe('https://tokenkey.dev/v1/chat/completions')
   })
 
   it('does not treat a plain 200 response as a successful tool-call verification', async () => {

--- a/frontend/src/composables/useTkUseKey.ts
+++ b/frontend/src/composables/useTkUseKey.ts
@@ -22,6 +22,7 @@
  */
 
 import { computed, ref, type Ref } from 'vue'
+import { resolveBrowserGatewayFetchBaseUrl } from '@/api/playground'
 import { getMePricingCatalog, type MePricingModel } from '@/api/me-pricing'
 import { getPublicPricing } from '@/api/pricing'
 import type { GroupPlatform, KeyRoutingMode } from '@/types'
@@ -248,7 +249,7 @@ export function useTkUseKey(args: UseTkUseKeyArgs) {
    */
   async function runTest(flavor: UseKeyFlavor, options: RunTestOptions = {}): Promise<void> {
     cancelTest()
-    const root = stripTrailingSlashes(args.baseRoot.value)
+    const root = stripTrailingSlashes(resolveBrowserGatewayFetchBaseUrl(args.baseRoot.value))
     const key = args.apiKey.value
     const model = effectiveModel(flavor)
     const ctrl = new AbortController()

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1184,6 +1184,7 @@
         "export function useTkUseKey(",
         "getMePricingCatalog({ apiKeyId: id })",
         "function runTest(",
+        "resolveBrowserGatewayFetchBaseUrl",
         "export function anthropicEnvModel(",
         "export function openaiCompatContextWindowEnvModel("
       ],


### PR DESCRIPTION
## 摘要

- Quickstart / WorkBuddy 接入页在 `tokenkey.dev` 上向 `api.tokenkey.dev` 发跨域 `fetch` 时，CORS 预检返回 403，浏览器报 **Failed to fetch**；curl 与桌面客户端不受影响。
- 新增 `resolveBrowserGatewayFetchBaseUrl`：复制/展示仍用 `api.tokenkey.dev`，浏览器内 live test 与 Studio 全部 `gateway*` fetch 自动回退到当前页面 origin（Caddy 已反代 `/v1/*`）。
- 已 rebase 到最新 `main`；与 #1481 fingerprint pin 重叠的 chore 提交已丢弃。

## 风险

- 常规风险：仅影响 Web UI 浏览器内 gateway fetch URL，不改变对外网关契约或 models.json 生成逻辑。
- 本地 dev（前后端同 origin）行为不变；生产 apex UI + api 子域场景受益。

## 验证

```bash
cd frontend && pnpm exec vitest run src/api/__tests__/playground.spec.ts src/composables/__tests__/useTkUseKey.spec.ts
# 24 passed
./scripts/preflight.sh
# PASS
```

- curl：`POST https://tokenkey.dev/v1/chat/completions` + `gpt-5.6-luna` → HTTP 200
- curl 对照：`OPTIONS https://api.tokenkey.dev/v1/chat/completions` + `Origin: https://tokenkey.dev` → HTTP 403

## 提交

- `4217b75c8` fix(quickstart): 浏览器连通性探测改走同源网关，避免 CORS Failed to fetch
- `0e4a8c88b` fix(quickstart): extend same-origin gateway fetch to Studio and sentinel

最新提交：`0e4a8c88b`