### PR TITLE
fix(openrouter): OR seller image 走 antigravity generateContent 路径

### DIFF
--- a/backend/internal/handler/gateway_handler_tk_openrouter_provider_media.go
+++ b/backend/internal/handler/gateway_handler_tk_openrouter_provider_media.go
@@ -104,7 +104,7 @@ func (h *Handlers) OpenRouterProviderImages(c *gin.Context) {
 	route := service.OpenRouterProviderImageRoute(openRouterProviderGroupPlatform(c), model)
 
 	var (
-		forwardBody []byte
+		forwardBody       []byte
 		translateResponse func([]byte) ([]byte, error)
 		dispatch          func(*gin.Context)
 	)

--- a/backend/internal/handler/gateway_handler_tk_openrouter_provider_media.go
+++ b/backend/internal/handler/gateway_handler_tk_openrouter_provider_media.go
@@ -99,17 +99,39 @@ func (h *Handlers) OpenRouterProviderImages(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"message": "read request body", "code": 400}})
 		return
 	}
-	translated, err := service.TranslateOpenRouterImageRequestToOpenAI(body)
+
+	model := strings.TrimSpace(gjsonGetString(body, "model"))
+	route := service.OpenRouterProviderImageRoute(openRouterProviderGroupPlatform(c), model)
+
+	var (
+		forwardBody []byte
+		translateResponse func([]byte) ([]byte, error)
+		dispatch          func(*gin.Context)
+	)
+	switch route {
+	case service.OpenRouterImageRouteAntigravityChat:
+		forwardBody, err = service.TranslateOpenRouterImageToChatCompletions(body)
+		translateResponse = service.TranslateChatCompletionsImageResponseToOpenRouter
+		dispatch = h.Gateway.ChatCompletions
+	case service.OpenRouterImageRouteGrok:
+		forwardBody, err = service.TranslateOpenRouterImageRequestToOpenAI(body)
+		translateResponse = service.TranslateOpenAIImageResponseToOpenRouter
+		dispatch = h.OpenAIGateway.GrokImages
+	default:
+		forwardBody, err = service.TranslateOpenRouterImageRequestToOpenAI(body)
+		translateResponse = service.TranslateOpenAIImageResponseToOpenRouter
+		dispatch = h.OpenAIGateway.ImageGenerations
+	}
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"message": err.Error(), "code": 400}})
 		return
 	}
-	c.Request.Body = io.NopCloser(bytes.NewReader(translated))
-	c.Request.ContentLength = int64(len(translated))
+	c.Request.Body = io.NopCloser(bytes.NewReader(forwardBody))
+	c.Request.ContentLength = int64(len(forwardBody))
 
 	capture := &openRouterProviderResponseCapture{ResponseWriter: c.Writer}
 	c.Writer = capture
-	h.OpenAIGateway.ImageGenerations(c)
+	dispatch(c)
 	c.Writer = capture.ResponseWriter
 
 	status := capture.capturedStatus()
@@ -117,12 +139,20 @@ func (h *Handlers) OpenRouterProviderImages(c *gin.Context) {
 		writeCapturedResponse(c, capture)
 		return
 	}
-	orBody, err := service.TranslateOpenAIImageResponseToOpenRouter(capture.body.Bytes())
+	orBody, err := translateResponse(capture.body.Bytes())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": "translate image response", "code": 500}})
 		return
 	}
 	c.Data(status, "application/json", orBody)
+}
+
+func openRouterProviderGroupPlatform(c *gin.Context) string {
+	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
+	if !ok || apiKey == nil || apiKey.Group == nil {
+		return ""
+	}
+	return strings.TrimSpace(apiKey.Group.Platform)
 }
 
 // OpenRouterProviderVideoSubmit serves POST /openrouter/v1/videos for OpenRouter provider inference.

--- a/backend/internal/service/openrouter_provider_tk_media.go
+++ b/backend/internal/service/openrouter_provider_tk_media.go
@@ -145,9 +145,7 @@ func extractOpenRouterImagesFromChatContentParts(content gjson.Result) []map[str
 				items = append(items, entry)
 			}
 		case "text":
-			for _, item := range extractOpenRouterImagesFromChatContentString(part.Get("text").String()) {
-				items = append(items, item)
-			}
+			items = append(items, extractOpenRouterImagesFromChatContentString(part.Get("text").String())...)
 		}
 		return true
 	})

--- a/backend/internal/service/openrouter_provider_tk_media.go
+++ b/backend/internal/service/openrouter_provider_tk_media.go
@@ -3,14 +3,156 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
 const openRouterProviderDefaultVideoQuoteSeconds = 8
+
+// OpenRouterImageRoute selects the downstream handler family for OR seller POST /v1/images.
+type OpenRouterImageRoute string
+
+const (
+	OpenRouterImageRouteAntigravityChat OpenRouterImageRoute = "antigravity_chat"
+	OpenRouterImageRouteGrok            OpenRouterImageRoute = "grok"
+	OpenRouterImageRouteOpenAICompat    OpenRouterImageRoute = "openai_compat"
+)
+
+var openRouterChatCompletionDataURIRe = regexp.MustCompile(`data:([^;)\s]+);base64,([A-Za-z0-9+/=]+)`)
+
+// OpenRouterProviderImageRoute picks the backend pipeline after universal routing has
+// bound the inference key to a concrete group platform.
+func OpenRouterProviderImageRoute(platform, model string) OpenRouterImageRoute {
+	platform = strings.TrimSpace(platform)
+	model = strings.TrimSpace(model)
+	switch {
+	case platform == PlatformAntigravity && antigravity.IsImageModel(model):
+		return OpenRouterImageRouteAntigravityChat
+	case platform == PlatformGrok && isGrokImageGenerationModel(model):
+		return OpenRouterImageRouteGrok
+	default:
+		return OpenRouterImageRouteOpenAICompat
+	}
+}
+
+// TranslateOpenRouterImageToChatCompletions maps OR POST /v1/images to OpenAI chat
+// completions for antigravity-native gemini-*-image models (generateContent path).
+func TranslateOpenRouterImageToChatCompletions(body []byte) ([]byte, error) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return nil, fmt.Errorf("invalid openrouter image request body")
+	}
+	model := strings.TrimSpace(gjson.GetBytes(body, "model").String())
+	if model == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+	prompt := strings.TrimSpace(gjson.GetBytes(body, "prompt").String())
+	if prompt == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+	out := map[string]any{
+		"model": model,
+		"messages": []map[string]any{
+			{"role": "user", "content": prompt},
+		},
+		"stream": false,
+	}
+	if aspectRatio := strings.TrimSpace(gjson.GetBytes(body, "aspect_ratio").String()); aspectRatio != "" {
+		out["extra_body"] = map[string]any{
+			"google": map[string]any{
+				"image_config": map[string]any{
+					"aspect_ratio": aspectRatio,
+				},
+			},
+		}
+	}
+	return json.Marshal(out)
+}
+
+// TranslateChatCompletionsImageResponseToOpenRouter extracts inline images from a
+// chat-completions JSON payload and maps them to OR ImageGenerationResponse.
+func TranslateChatCompletionsImageResponseToOpenRouter(body []byte) ([]byte, error) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body, nil
+	}
+	if gjson.GetBytes(body, "error").Exists() {
+		return body, nil
+	}
+	items := extractOpenRouterImagesFromChatCompletions(body)
+	if len(items) == 0 {
+		return nil, fmt.Errorf("chat completion response missing image data")
+	}
+	out := map[string]any{
+		"created": time.Now().Unix(),
+		"data":    items,
+	}
+	if usage := gjson.GetBytes(body, "usage"); usage.Exists() {
+		out["usage"] = json.RawMessage(usage.Raw)
+	}
+	return json.Marshal(out)
+}
+
+func extractOpenRouterImagesFromChatCompletions(body []byte) []map[string]string {
+	content := gjson.GetBytes(body, "choices.0.message.content")
+	if !content.Exists() {
+		return nil
+	}
+	switch content.Type {
+	case gjson.String:
+		return extractOpenRouterImagesFromChatContentString(content.String())
+	case gjson.JSON:
+		if content.IsArray() {
+			return extractOpenRouterImagesFromChatContentParts(content)
+		}
+	}
+	return nil
+}
+
+func extractOpenRouterImagesFromChatContentString(content string) []map[string]string {
+	matches := openRouterChatCompletionDataURIRe.FindAllStringSubmatch(content, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	items := make([]map[string]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+		items = append(items, map[string]string{
+			"b64_json":   match[2],
+			"media_type": strings.TrimSpace(match[1]),
+		})
+	}
+	return items
+}
+
+func extractOpenRouterImagesFromChatContentParts(content gjson.Result) []map[string]string {
+	items := make([]map[string]string, 0)
+	content.ForEach(func(_, part gjson.Result) bool {
+		partType := strings.TrimSpace(part.Get("type").String())
+		switch partType {
+		case "image_url":
+			url := strings.TrimSpace(part.Get("image_url.url").String())
+			if mt, payload, ok := parseDataURI(url); ok && payload != "" {
+				entry := map[string]string{"b64_json": payload}
+				if mt != "" {
+					entry["media_type"] = mt
+				}
+				items = append(items, entry)
+			}
+		case "text":
+			for _, item := range extractOpenRouterImagesFromChatContentString(part.Get("text").String()) {
+				items = append(items, item)
+			}
+		}
+		return true
+	})
+	return items
+}
 
 // TranslateOpenRouterImageRequestToOpenAI maps OpenRouter POST /v1/images JSON to
 // TokenKey's OpenAI-compatible POST /v1/images/generations body.

--- a/backend/internal/service/openrouter_provider_tk_media_test.go
+++ b/backend/internal/service/openrouter_provider_tk_media_test.go
@@ -6,6 +6,80 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func TestOpenRouterProviderImageRoute(t *testing.T) {
+	if got := OpenRouterProviderImageRoute(PlatformAntigravity, "gemini-2.5-flash-image"); got != OpenRouterImageRouteAntigravityChat {
+		t.Fatalf("antigravity gemini image=%q", got)
+	}
+	if got := OpenRouterProviderImageRoute(PlatformGrok, "grok-imagine-image"); got != OpenRouterImageRouteGrok {
+		t.Fatalf("grok image=%q", got)
+	}
+	if got := OpenRouterProviderImageRoute(PlatformNewAPI, "imagen-4.0-fast-generate-001"); got != OpenRouterImageRouteOpenAICompat {
+		t.Fatalf("imagen=%q", got)
+	}
+	if got := OpenRouterProviderImageRoute(PlatformAntigravity, "gemini-2.5-flash"); got != OpenRouterImageRouteOpenAICompat {
+		t.Fatalf("antigravity text=%q", got)
+	}
+}
+
+func TestTranslateOpenRouterImageToChatCompletions(t *testing.T) {
+	body := []byte(`{"model":"gemini-2.5-flash-image","prompt":"a cat","aspect_ratio":"16:9"}`)
+	out, err := TranslateOpenRouterImageToChatCompletions(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gjson.GetBytes(out, "model").String() != "gemini-2.5-flash-image" {
+		t.Fatalf("model=%q", gjson.GetBytes(out, "model").String())
+	}
+	if gjson.GetBytes(out, "messages.0.content").String() != "a cat" {
+		t.Fatalf("prompt=%q", gjson.GetBytes(out, "messages.0.content").String())
+	}
+	if gjson.GetBytes(out, "extra_body.google.image_config.aspect_ratio").String() != "16:9" {
+		t.Fatalf("aspect_ratio=%q", gjson.GetBytes(out, "extra_body.google.image_config.aspect_ratio").String())
+	}
+	if gjson.GetBytes(out, "stream").Bool() {
+		t.Fatal("stream must be false")
+	}
+}
+
+func TestTranslateOpenRouterImageToChatCompletions_RequiresPrompt(t *testing.T) {
+	_, err := TranslateOpenRouterImageToChatCompletions([]byte(`{"model":"gemini-2.5-flash-image"}`))
+	if err == nil {
+		t.Fatal("expected prompt required error")
+	}
+}
+
+func TestTranslateChatCompletionsImageResponseToOpenRouter(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"content":"rendered:\n![image](data:image/png;base64,aGVsbG8=)"}}],"usage":{"total_tokens":12}}`)
+	out, err := TranslateChatCompletionsImageResponseToOpenRouter(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gjson.GetBytes(out, "data.0.b64_json").String() != "aGVsbG8=" {
+		t.Fatalf("b64=%q", gjson.GetBytes(out, "data.0.b64_json").String())
+	}
+	if gjson.GetBytes(out, "data.0.media_type").String() != "image/png" {
+		t.Fatalf("media_type=%q", gjson.GetBytes(out, "data.0.media_type").String())
+	}
+}
+
+func TestTranslateChatCompletionsImageResponseToOpenRouter_ImageURLPart(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"content":[{"type":"image_url","image_url":{"url":"data:image/webp;base64,d2VicA=="}}]}}]}`)
+	out, err := TranslateChatCompletionsImageResponseToOpenRouter(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gjson.GetBytes(out, "data.0.b64_json").String() != "d2VicA==" {
+		t.Fatalf("b64=%q", gjson.GetBytes(out, "data.0.b64_json").String())
+	}
+}
+
+func TestTranslateChatCompletionsImageResponseToOpenRouter_MissingImage(t *testing.T) {
+	_, err := TranslateChatCompletionsImageResponseToOpenRouter([]byte(`{"choices":[{"message":{"content":"text only"}}]}`))
+	if err == nil {
+		t.Fatal("expected missing image error")
+	}
+}
+
 func TestTranslateOpenRouterImageRequestToOpenAI_ForcesB64JSON(t *testing.T) {
 	body := []byte(`{"model":"tokenkey/imagen-4","prompt":"a cat","resolution":"2K","aspect_ratio":"16:9","n":2}`)
 	out, err := TranslateOpenRouterImageRequestToOpenAI(body)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -5527,20 +5527,25 @@
         "OpenRouterProviderImages",
         "OpenRouterProviderVideoSubmit",
         "OpenRouterProviderVideoFetch",
+        "OpenRouterProviderImageRoute",
+        "openRouterProviderGroupPlatform",
         "TranslateOpenRouterImageRequestToOpenAI",
         "BuildOpenRouterVideoSubmitResponse"
       ],
-      "rationale": "OpenRouter seller image/video inference adapters: OR JSON ↔ internal OpenAI-compat handlers with OR response shapes (b64_json images, 202 video submit + poll)."
+      "rationale": "OpenRouter seller image/video inference adapters: OR JSON ↔ internal handlers with platform dispatch (antigravity chat for gemini-*-image, grok/openai-compat otherwise) and OR response shapes (b64_json images, 202 video submit + poll)."
     },
     {
       "path": "backend/internal/service/openrouter_provider_tk_media.go",
       "must_contain": [
+        "OpenRouterProviderImageRoute",
+        "TranslateOpenRouterImageToChatCompletions",
+        "TranslateChatCompletionsImageResponseToOpenRouter",
         "TranslateOpenRouterImageRequestToOpenAI",
         "TranslateOpenAIImageResponseToOpenRouter",
         "TranslateOpenRouterVideoRequestToOpenAI",
         "TranslateOpenAIVideoFetchToOpenRouter"
       ],
-      "rationale": "Pure translation layer for OpenRouter provider image/video protocol compliance; handlers must not re-encode this mapping inline."
+      "rationale": "Pure translation layer for OpenRouter provider image/video protocol compliance; gemini-native image maps OR /v1/images ↔ antigravity chat generateContent, other models stay on OpenAI-compat paths."
     },
     {
       "path": "backend/internal/service/openrouter_provider_tk_policy.go",


### PR DESCRIPTION
## 摘要

修复 prod `POST /openrouter/v1/images` + universal inference key + `tokenkey/gemini-2.5-flash-image` 返回 429（OpenAI 空池）的问题：handler 按 universal 解析后的 `group.platform` 分流，gemini-native image 走 antigravity `ChatCompletions`（generateContent），grok/imagen 路径不变。

## 风险

- 常规风险：仅影响 OpenRouter seller image 推理路径的分发逻辑
- universal 候选补 antigravity 已在 main 落地（rebase 时跳过重复 commit）

## 验证

- `go test -tags=unit ./internal/service -run 'OpenRouterProviderImage|TranslateOpenRouterImageToChat|TranslateChatCompletionsImage'`
- `go test -tags=unit ./internal/handler -run 'OpenRouterProvider'`
- `./scripts/preflight.sh` PASS
- CI 全绿（head `6d4aa4bff`）

发版后 smoke：
```text
POST /openrouter/v1/images + inference key + tokenkey/gemini-2.5-flash-image → 200 + data[].b64_json
POST /openrouter/v1/images + tokenkey/imagen-4.0-fast-generate-001 → 200（回归）
monitor key → 403（不变）
```

## 提交

- `ce448077` fix(openrouter): dispatch OR gemini image via antigravity chat path
- `6d4aa4bf` fix(openrouter): address R-001..R-005 — gofmt, staticcheck, sentinel anchors

最新提交：`6d4aa4bf`