### PR TITLE
fix(kiro): 去重 completion 隐藏续跑回复

### DIFF
--- a/backend/internal/integration/kiro/claude_code_completion.go
+++ b/backend/internal/integration/kiro/claude_code_completion.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 )
 
-const claudeCodeCompletionContinuationPrompt = `The preceding assistant response ended without the required transport completion signal, so the Claude Code turn is still active. Continue the same task now. Use the normal Claude Code tools for every remaining action. When the requested work and verification are actually complete, or progress genuinely requires user input, finish by calling sub2apiClaudeCodeCompletion with the appropriate status and a complete user-facing message.`
+const claudeCodeCompletionContinuationPrompt = `The preceding assistant response ended without the required transport completion signal, so the Claude Code turn is still active. Continue the same task now. Do not repeat or restate text from the preceding assistant response. Use the normal Claude Code tools for every remaining action. When the requested work and verification are actually complete, or progress genuinely requires user input, finish by calling sub2apiClaudeCodeCompletion with the appropriate status and a complete user-facing message.`
 
 // ClaudeCodeCompletionSignal is emitted by the transport-private completion
 // tool. The Kiro gateway consumes it and never exposes the tool call itself to

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -170,10 +170,60 @@ func completionSignalTextDelta(visibleText string, signal *kiroproto.ClaudeCodeC
 	if visibleText == "" {
 		return message
 	}
-	if containsCompletionTextBlock(visibleText, message) {
+	if containsVisibleCompletionBlock(visibleText, message) {
 		return ""
 	}
 	return "\n\n" + message
+}
+
+// continuationTextDelta removes ordinary text that a hidden completion
+// continuation repeated verbatim from an earlier turn. Claude Code receives
+// the first turn while the gateway keeps subsequent turns internal; allowing
+// the model to restate that turn would make one assistant response appear two
+// or three times in the client transcript.
+func continuationTextDelta(visibleText, continuationText string) string {
+	if strings.TrimSpace(continuationText) == "" {
+		return ""
+	}
+	if strings.TrimSpace(visibleText) == "" {
+		return continuationText
+	}
+
+	trimmed := strings.TrimSpace(continuationText)
+	if containsVisibleCompletionBlock(visibleText, trimmed) {
+		return ""
+	}
+
+	// Models sometimes add a short recap/header around the repeated answer.
+	// Drop repeated paragraphs while retaining any genuinely new text.
+	paragraphs := strings.Split(continuationText, "\n\n")
+	kept := make([]string, 0, len(paragraphs))
+	for _, paragraph := range paragraphs {
+		if strings.TrimSpace(paragraph) == "" {
+			continue
+		}
+		block := strings.TrimSpace(paragraph)
+		if len([]rune(block)) >= 4 && containsVisibleCompletionBlock(visibleText, block) {
+			continue
+		}
+		kept = append(kept, paragraph)
+	}
+	if len(kept) == 0 {
+		return ""
+	}
+	return strings.Join(kept, "\n\n")
+}
+
+// containsVisibleCompletionBlock also tolerates markdown/list decoration
+// differences between repeated model turns (for example "• Done" versus
+// "Done"), while the underlying boundary-aware matcher prevents substring
+// false positives.
+func containsVisibleCompletionBlock(text, block string) bool {
+	if containsCompletionTextBlock(text, block) {
+		return true
+	}
+	stripped := strings.TrimLeft(block, "*#-• \t")
+	return stripped != block && strings.TrimSpace(stripped) != "" && containsCompletionTextBlock(text, stripped)
 }
 
 // containsCompletionTextBlock reports whether the private completion message
@@ -339,7 +389,8 @@ func (s *KiroGatewayService) forwardNonStreaming(
 	startTime time.Time,
 ) (*ForwardResult, error) {
 	var (
-		textBuf          string
+		textBuf          string // client-visible text across all turns
+		billingTextBuf   string // all model text, including hidden continuations
 		thinkingBuf      string
 		clientToolUses   []kiroproto.KiroToolUse
 		billingToolUses  []kiroproto.KiroToolUse
@@ -409,17 +460,25 @@ func (s *KiroGatewayService) forwardNonStreaming(
 			visibleToolUses, completionSignal = kiroproto.ConsumeClaudeCodeCompletionSignal(turnToolUses)
 		}
 		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, visibleToolUses, completionSignal)
-		if completionAccepted {
-			turnText += completionSignalTextDelta(textBuf+turnText, completionSignal)
+		visibleTurnText := turnText
+		if turn > 1 {
+			visibleTurnText = continuationTextDelta(textBuf, turnText)
 		}
-		if turnText == "" && turnThinking == "" && len(turnToolUses) == 0 && textBuf == "" && thinkingBuf == "" {
+		if completionAccepted {
+			visibleTurnText += completionSignalTextDelta(textBuf+visibleTurnText, completionSignal)
+		}
+		if visibleTurnText == "" && turnThinking == "" && len(turnToolUses) == 0 && textBuf == "" && thinkingBuf == "" {
 			if isKiroPolicyStopReason(stopReason) {
 				return nil, classifyAndRecordKiroForwardError(c, account, &KiroContentFilteredError{}, model)
 			}
 			return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
 		}
 
-		textBuf += turnText
+		textBuf += visibleTurnText
+		billingTextBuf += turnText
+		if completionAccepted {
+			billingTextBuf += strings.TrimSpace(completionSignal.Message)
+		}
 		thinkingBuf += turnThinking
 		billingToolUses = append(billingToolUses, turnToolUses...)
 
@@ -452,7 +511,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 
 	// Estimate output across every hidden completion turn, including the private
 	// completion tool call that is intentionally absent from the client response.
-	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, billingToolUses)
+	outputToks := kiroproto.EstimateOutputTokens(billingTextBuf, thinkingBuf, billingToolUses)
 
 	resp := kiroproto.KiroToClaudeResponse(
 		textBuf, thinkingBuf, false, clientToolUses, inputTokens, outputToks, model, mappedStopReason,
@@ -520,7 +579,8 @@ func (s *KiroGatewayService) forwardStreaming(
 
 	var (
 		mu               sync.Mutex
-		textBuf          string
+		textBuf          string // client-visible text across all turns
+		billingTextBuf   string // all model text, including hidden continuations
 		thinkingBuf      string
 		clientToolUses   []kiroproto.KiroToolUse
 		billingToolUses  []kiroproto.KiroToolUse
@@ -564,8 +624,13 @@ func (s *KiroGatewayService) forwardStreaming(
 				turnThinking += inlineThinking
 				if visible != "" {
 					turnText += visible
-					enc.writeTextDelta(visible)
-					callOutputCommitted = true
+					// Continuation turns are hidden until their terminal outcome is
+					// known, so repeated model text can be removed before it reaches
+					// the client. The first turn remains fully streamed.
+					if turn == 1 {
+						enc.writeTextDelta(visible)
+						callOutputCommitted = true
+					}
 				}
 			},
 			OnToolUse: func(toolUse kiroproto.KiroToolUse) {
@@ -643,8 +708,10 @@ func (s *KiroGatewayService) forwardStreaming(
 			turnThinking += inlineThinking
 			if visible != "" {
 				turnText += visible
-				enc.writeTextDelta(visible)
-				callOutputCommitted = true
+				if turn == 1 {
+					enc.writeTextDelta(visible)
+					callOutputCommitted = true
+				}
 			}
 		}
 
@@ -654,16 +721,25 @@ func (s *KiroGatewayService) forwardStreaming(
 			visibleToolUses, completionSignal = kiroproto.ConsumeClaudeCodeCompletionSignal(turnToolUses)
 		}
 		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, visibleToolUses, completionSignal)
+		visibleTurnText := turnText
+		if turn > 1 {
+			visibleTurnText = continuationTextDelta(textBuf, turnText)
+			if visibleTurnText != "" {
+				markFirstToken()
+				enc.writeTextDelta(visibleTurnText)
+				callOutputCommitted = true
+			}
+		}
 		if completionAccepted {
-			completionDelta := completionSignalTextDelta(textBuf+turnText, completionSignal)
+			completionDelta := completionSignalTextDelta(textBuf+visibleTurnText, completionSignal)
 			if completionDelta != "" {
-				turnText += completionDelta
+				visibleTurnText += completionDelta
 				markFirstToken()
 				enc.writeTextDelta(completionDelta)
 				callOutputCommitted = true
 			}
 		}
-		if turnText == "" && turnThinking == "" && len(turnToolUses) == 0 && textBuf == "" && thinkingBuf == "" {
+		if visibleTurnText == "" && turnThinking == "" && len(turnToolUses) == 0 && textBuf == "" && thinkingBuf == "" {
 			if isKiroPolicyStopReason(stopReason) {
 				mu.Unlock()
 				return nil, classifyAndRecordKiroForwardError(c, account, &KiroContentFilteredError{}, model)
@@ -672,7 +748,11 @@ func (s *KiroGatewayService) forwardStreaming(
 			return nil, classifyAndRecordKiroForwardError(c, account, errKiroEmptyResponse, model)
 		}
 
-		textBuf += turnText
+		textBuf += visibleTurnText
+		billingTextBuf += turnText
+		if completionAccepted {
+			billingTextBuf += strings.TrimSpace(completionSignal.Message)
+		}
 		thinkingBuf += turnThinking
 		billingToolUses = append(billingToolUses, turnToolUses...)
 
@@ -713,7 +793,7 @@ func (s *KiroGatewayService) forwardStreaming(
 		break
 	}
 
-	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, billingToolUses)
+	outputToks := kiroproto.EstimateOutputTokens(billingTextBuf, thinkingBuf, billingToolUses)
 
 	// Upstream succeeded but produced no content (enc.started still false):
 	// emit message_start lazily here so the closing events form a valid stream.

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -211,7 +211,7 @@ func continuationTextDelta(visibleText, continuationText string) string {
 	if len(kept) == 0 {
 		return ""
 	}
-	return strings.Join(kept, "\n\n")
+	return separateVisibleTextDelta(visibleText, strings.Join(kept, "\n\n"))
 }
 
 // containsVisibleCompletionBlock also tolerates markdown/list decoration
@@ -222,8 +222,57 @@ func containsVisibleCompletionBlock(text, block string) bool {
 	if containsCompletionTextBlock(text, block) {
 		return true
 	}
-	stripped := strings.TrimLeft(block, "*#-• \t")
-	return stripped != block && strings.TrimSpace(stripped) != "" && containsCompletionTextBlock(text, stripped)
+	stripped, ok := stripCompletionMarkdownPrefix(block)
+	return ok && containsCompletionTextBlock(text, stripped)
+}
+
+func stripCompletionMarkdownPrefix(block string) (string, bool) {
+	trimmed := strings.TrimLeftFunc(block, isHorizontalSpace)
+	if trimmed == "" {
+		return "", false
+	}
+
+	if trimmed[0] == '#' {
+		index := 0
+		for index < len(trimmed) && trimmed[index] == '#' {
+			index++
+		}
+		if index < len(trimmed) {
+			next, _ := utf8.DecodeRuneInString(trimmed[index:])
+			if isHorizontalSpace(next) {
+				stripped := strings.TrimLeftFunc(trimmed[index:], isHorizontalSpace)
+				return stripped, stripped != ""
+			}
+		}
+	}
+
+	marker, size := utf8.DecodeRuneInString(trimmed)
+	if marker != '*' && marker != '-' && marker != '•' {
+		return "", false
+	}
+	rest := trimmed[size:]
+	next, _ := utf8.DecodeRuneInString(rest)
+	if !isHorizontalSpace(next) {
+		return "", false
+	}
+	stripped := strings.TrimLeftFunc(rest, isHorizontalSpace)
+	return stripped, stripped != ""
+}
+
+func isHorizontalSpace(r rune) bool {
+	return r == ' ' || r == '\t'
+}
+
+func separateVisibleTextDelta(visibleText, delta string) string {
+	if delta == "" || strings.TrimSpace(visibleText) == "" {
+		return delta
+	}
+	before, _ := utf8.DecodeLastRuneInString(visibleText)
+	after, _ := utf8.DecodeRuneInString(delta)
+	if unicode.IsSpace(before) || unicode.IsSpace(after) {
+		return delta
+	}
+	return "\n\n" + delta
 }
 
 // containsCompletionTextBlock reports whether the private completion message
@@ -476,9 +525,6 @@ func (s *KiroGatewayService) forwardNonStreaming(
 
 		textBuf += visibleTurnText
 		billingTextBuf += turnText
-		if completionAccepted {
-			billingTextBuf += strings.TrimSpace(completionSignal.Message)
-		}
 		thinkingBuf += turnThinking
 		billingToolUses = append(billingToolUses, turnToolUses...)
 
@@ -609,7 +655,24 @@ func (s *KiroGatewayService) forwardStreaming(
 			stopReason          string
 			redactor            kiroproto.InlineThinkingRedactor
 			callOutputCommitted bool
+			bufferedTextOffset  int
+			visibleTurnText     string
 		)
+		flushContinuationText := func() {
+			if turn == 1 || bufferedTextOffset >= len(turnText) {
+				return
+			}
+			pendingText := turnText[bufferedTextOffset:]
+			bufferedTextOffset = len(turnText)
+			delta := continuationTextDelta(textBuf+visibleTurnText, pendingText)
+			if delta == "" {
+				return
+			}
+			visibleTurnText += delta
+			markFirstToken()
+			enc.writeTextDelta(delta)
+			callOutputCommitted = true
+		}
 
 		callback := &kiroproto.KiroStreamCallback{
 			OnText: func(text string, isThinking bool) {
@@ -640,6 +703,7 @@ func (s *KiroGatewayService) forwardStreaming(
 				if payload.ClaudeCodeCompletionProtocol && kiroproto.IsClaudeCodeCompletionToolUse(toolUse) {
 					return
 				}
+				flushContinuationText()
 				markFirstToken()
 				enc.writeToolUse(toolUse)
 				callOutputCommitted = true
@@ -672,6 +736,8 @@ func (s *KiroGatewayService) forwardStreaming(
 				stopReason = ""
 				redactor = kiroproto.InlineThinkingRedactor{}
 				firstTokMs = firstTokBeforeTurn
+				bufferedTextOffset = 0
+				visibleTurnText = ""
 				return true
 			},
 		}
@@ -721,14 +787,10 @@ func (s *KiroGatewayService) forwardStreaming(
 			visibleToolUses, completionSignal = kiroproto.ConsumeClaudeCodeCompletionSignal(turnToolUses)
 		}
 		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, visibleToolUses, completionSignal)
-		visibleTurnText := turnText
-		if turn > 1 {
-			visibleTurnText = continuationTextDelta(textBuf, turnText)
-			if visibleTurnText != "" {
-				markFirstToken()
-				enc.writeTextDelta(visibleTurnText)
-				callOutputCommitted = true
-			}
+		if turn == 1 {
+			visibleTurnText = turnText
+		} else {
+			flushContinuationText()
 		}
 		if completionAccepted {
 			completionDelta := completionSignalTextDelta(textBuf+visibleTurnText, completionSignal)
@@ -750,9 +812,6 @@ func (s *KiroGatewayService) forwardStreaming(
 
 		textBuf += visibleTurnText
 		billingTextBuf += turnText
-		if completionAccepted {
-			billingTextBuf += strings.TrimSpace(completionSignal.Message)
-		}
 		thinkingBuf += turnThinking
 		billingToolUses = append(billingToolUses, turnToolUses...)
 
@@ -799,7 +858,10 @@ func (s *KiroGatewayService) forwardStreaming(
 	// emit message_start lazily here so the closing events form a valid stream.
 	enc.writeMessageStart()
 	enc.closeOpenBlock()
-	enc.writeMessageDelta(outputToks, mappedStopReason)
+	// Repeat the final input total because hidden completion continuations add
+	// prompt tokens after message_start. Relay consumers merge this terminal
+	// usage into the same accumulator used for billing.
+	enc.writeMessageDelta(inputTokens, outputToks, mappedStopReason)
 	enc.writeMessageStop()
 	publishKiroInternalThinkingSideChannel(c, w, nil, thinkingBuf)
 	flusher.Flush()

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	kiroproto "github.com/Wei-Shaw/sub2api/internal/integration/kiro"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 )
 
@@ -687,7 +688,104 @@ func TestUS041_KiroGatewayService_ContinuationTextDoesNotRepeatAcrossTurns(t *te
 func TestContinuationTextDeltaKeepsOnlyNewRecapText(t *testing.T) {
 	visible := "清理完成，全程可回滚。\n\n## 做了什么\n\nmain 从 062c77b81 fast-forward 到 57f04ad4d。"
 	continuation := "recap: 已完成仓库清理。\n\n清理完成，全程可回滚。\n\n## 做了什么\n\nmain 从 062c77b81 fast-forward 到 57f04ad4d。"
-	require.Equal(t, "recap: 已完成仓库清理。", continuationTextDelta(visible, continuation))
+	require.Equal(t, "\n\nrecap: 已完成仓库清理。", continuationTextDelta(visible, continuation))
+}
+
+func TestContinuationTextDeltaKeepsParagraphBoundary(t *testing.T) {
+	visible := "A completed paragraph with enough text."
+	continuation := visible + "\n\nNew details from the continuation."
+	require.Equal(t, "\n\nNew details from the continuation.", continuationTextDelta(visible, continuation))
+}
+
+func TestCompletionSignalTextDeltaPreservesNegativeNumber(t *testing.T) {
+	signal := &kiroproto.ClaudeCodeCompletionSignal{Status: "complete", Message: "-10"}
+	require.Equal(t, "\n\n-10", completionSignalTextDelta("Earlier result: 10", signal))
+
+	markdownSignal := &kiroproto.ClaudeCodeCompletionSignal{Status: "complete", Message: "- Done and verified."}
+	require.Empty(t, completionSignalTextDelta("Done and verified.", markdownSignal))
+}
+
+func TestUS041_KiroGatewayService_ContinuationToolPreservesTextBeforeTool(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	toolTurn := buildKiroEventStreamMessage("assistantResponseEvent", []byte(`{"content":"new context before Read"}`))
+	toolTurn = append(toolTurn, kiroToolUseEvent("toolu_read", "Read", map[string]any{"file_path": "a.go"})...)
+	toolTurn = appendKiroTerminalStop(toolTurn, "TOOL_USE")
+	upstream := &kiroSequenceUpstream{bodies: [][]byte{
+		kiroTextStopStream("initial progress", "END_TURN"),
+		toolTurn,
+	}}
+
+	svc := NewKiroGatewayService(upstream, nil, nil)
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+		newKiroToolRequestForTest(true, true, "Read"), time.Now())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	out := rec.Body.String()
+	textIndex := strings.Index(out, "new context before Read")
+	toolIndex := strings.Index(out, `"name":"Read"`)
+	require.NotEqual(t, -1, textIndex)
+	require.NotEqual(t, -1, toolIndex)
+	require.Less(t, textIndex, toolIndex)
+	require.Contains(t, out, `"stop_reason":"tool_use"`)
+}
+
+func TestUS041_KiroGatewayService_CompletionBillingCountsPrivateToolOnce(t *testing.T) {
+	const message = "Implemented and verified the fix."
+	privateTool := kiroproto.KiroToolUse{
+		ToolUseID: "toolu_completion",
+		Name:      "sub2apiClaudeCodeCompletion",
+		Input: map[string]any{
+			"status":  "complete",
+			"message": message,
+		},
+	}
+	wantOutputTokens := kiroproto.EstimateOutputTokens("", "", []kiroproto.KiroToolUse{privateTool})
+
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroCompletionSignalStream("complete", message),
+			}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, wantOutputTokens, result.Usage.OutputTokens)
+			require.Contains(t, rec.Body.String(), message)
+		})
+	}
+}
+
+func TestUS041_KiroGatewayService_ContinuationStreamingReportsFinalInputUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	upstream := &kiroSequenceUpstream{bodies: [][]byte{
+		kiroTextStopStream("initial progress", "END_TURN"),
+		kiroCompletionSignalStream("complete", "Implemented and verified the fix."),
+	}}
+
+	svc := NewKiroGatewayService(upstream, nil, nil)
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+		newClaudeCodeKiroParsedRequestForTest(true), time.Now())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 2, upstream.calls)
+	require.Contains(t, rec.Body.String(), fmt.Sprintf(
+		`"usage":{"input_tokens":%d,"output_tokens":%d}`,
+		result.Usage.InputTokens,
+		result.Usage.OutputTokens,
+	))
 }
 
 func TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved(t *testing.T) {

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -659,6 +659,37 @@ func TestUS041_KiroGatewayService_ContinuationCompletionDoesNotRepeatPriorFinalT
 	}
 }
 
+func TestUS041_KiroGatewayService_ContinuationTextDoesNotRepeatAcrossTurns(t *testing.T) {
+	const summary = "清理完成，全程可回滚。\n\n## 做了什么\n\nmain 从 062c77b81 fast-forward 到 57f04ad4d。"
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroTextStopStream(summary, "END_TURN"),
+				kiroTextStopStream(summary, "END_TURN"),
+				kiroCompletionSignalStream("complete", summary),
+			}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 3, upstream.calls)
+			require.Equal(t, 1, strings.Count(rec.Body.String(), "清理完成"))
+			require.Equal(t, 1, strings.Count(rec.Body.String(), "57f04ad4d"))
+		})
+	}
+}
+
+func TestContinuationTextDeltaKeepsOnlyNewRecapText(t *testing.T) {
+	visible := "清理完成，全程可回滚。\n\n## 做了什么\n\nmain 从 062c77b81 fast-forward 到 57f04ad4d。"
+	continuation := "recap: 已完成仓库清理。\n\n清理完成，全程可回滚。\n\n## 做了什么\n\nmain 从 062c77b81 fast-forward 到 57f04ad4d。"
+	require.Equal(t, "recap: 已完成仓库清理。", continuationTextDelta(visible, continuation))
+}
+
 func TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved(t *testing.T) {
 	for _, stream := range []bool{false, true} {
 		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {

--- a/backend/internal/service/kiro_sse_encoder.go
+++ b/backend/internal/service/kiro_sse_encoder.go
@@ -164,14 +164,17 @@ func (e *kiroSSEEncoder) closeOpenBlock() {
 	e.blockIndex++
 }
 
-func (e *kiroSSEEncoder) writeMessageDelta(outputTokens int, stopReason string) {
+func (e *kiroSSEEncoder) writeMessageDelta(inputTokens, outputTokens int, stopReason string) {
 	e.writeEvent("message_delta", map[string]any{
 		"type": "message_delta",
 		"delta": map[string]any{
 			"stop_reason":   stopReason,
 			"stop_sequence": nil,
 		},
-		"usage": map[string]any{"output_tokens": outputTokens},
+		"usage": map[string]any{
+			"input_tokens":  inputTokens,
+			"output_tokens": outputTokens,
+		},
 	})
 }
 

--- a/backend/internal/service/kiro_sse_encoder_tk_input_tokens_test.go
+++ b/backend/internal/service/kiro_sse_encoder_tk_input_tokens_test.go
@@ -43,3 +43,16 @@ func TestKiroSSEEncoder_MessageStartZeroInputTokens(t *testing.T) {
 		t.Fatalf("unset inputTokens should render 0, got: %s", buf.String())
 	}
 }
+
+func TestKiroSSEEncoder_MessageDeltaCarriesFinalInputTokens(t *testing.T) {
+	var buf bytes.Buffer
+	enc := &kiroSSEEncoder{w: &buf, model: "claude-sonnet-4-6", msgID: "msg_z", inputTokens: 100}
+
+	enc.writeMessageStart()
+	enc.writeMessageDelta(250, 42, "end_turn")
+
+	out := buf.String()
+	if !strings.Contains(out, `"usage":{"input_tokens":250,"output_tokens":42}`) {
+		t.Fatalf("message_delta must carry final input and output usage, got: %s", out)
+	}
+}

--- a/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
+++ b/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
@@ -25,7 +25,7 @@ func TestKiroSSEEncoder_OpusStyleTextOnly_NoRedactedBlock(t *testing.T) {
 	}
 
 	enc.writeTextDelta("I am Claude.")
-	enc.writeMessageDelta(4, "end_turn")
+	enc.writeMessageDelta(0, 4, "end_turn")
 	enc.writeMessageStop()
 
 	out := rec.Body.String()

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -295,6 +295,8 @@
         "kiroproto.PrepareClaudeCodeCompletionContinuation",
         "completionSignalTextDelta",
         "continuationTextDelta",
+        "stripCompletionMarkdownPrefix",
+        "flushContinuationText",
         "billingTextBuf",
         "gateway.kiro_stop_reason",
         "gateway.kiro_completion_protocol",
@@ -302,7 +304,7 @@
         "classifyAndRecordKiroForwardError",
         "publishKiroInternalThinkingSideChannel"
       ],
-      "rationale": "The sixth-platform forwarder translates /v1/messages onto Kiro EventStream and estimates usage because upstream reports credits only. The context-aware call and ResetForRetry callbacks protect retry integrity. The stop-reason mapper preserves Kiro's authoritative terminal outcome; for positively identified Claude Code payloads, the private completion signal and bounded continuation loop separate model END_TURN from agent completion. completionSignalTextDelta prevents a private completion message from repeating a complete text block already visible in the same or an earlier hidden turn, while continuationTextDelta buffers and removes ordinary assistant text repeated by later hidden turns. Every private-tool consume/hide site is guarded by payload.ClaudeCodeCompletionProtocol so ordinary API clients retain same-name tools. billingTextBuf keeps hidden continuation output billable even when its duplicate presentation is suppressed. Both stop/completion actions remain observable, and the visible-text-aware pre-content error guard keeps failures visible instead of returning an empty 200 stream. Losing these anchors silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
+      "rationale": "The sixth-platform forwarder translates /v1/messages onto Kiro EventStream and estimates usage because upstream reports credits only. The context-aware call and ResetForRetry callbacks protect retry integrity. The stop-reason mapper preserves Kiro's authoritative terminal outcome; for positively identified Claude Code payloads, the private completion signal and bounded continuation loop separate model END_TURN from agent completion. completionSignalTextDelta prevents a private completion message from repeating a complete text block already visible in the same or an earlier hidden turn, while continuationTextDelta buffers and removes ordinary assistant text repeated by later hidden turns. stripCompletionMarkdownPrefix accepts only explicit marker-plus-space decoration so semantic prefixes such as negative signs survive. flushContinuationText preserves text-before-tool ordering in SSE. Every private-tool consume/hide site is guarded by payload.ClaudeCodeCompletionProtocol so ordinary API clients retain same-name tools. billingTextBuf keeps hidden continuation output billable even when its duplicate presentation is suppressed, while private completion input is counted exactly once through billingToolUses. Both stop/completion actions remain observable, and the visible-text-aware pre-content error guard keeps failures visible instead of returning an empty 200 stream. Losing these anchors silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
     },
     {
       "path": "backend/internal/service/kiro_gateway_service_test.go",
@@ -328,6 +330,11 @@
         "TestUS041_KiroGatewayService_ContinuationCompletionDoesNotRepeatPriorFinalText",
         "TestUS041_KiroGatewayService_ContinuationTextDoesNotRepeatAcrossTurns",
         "TestContinuationTextDeltaKeepsOnlyNewRecapText",
+        "TestContinuationTextDeltaKeepsParagraphBoundary",
+        "TestCompletionSignalTextDeltaPreservesNegativeNumber",
+        "TestUS041_KiroGatewayService_ContinuationToolPreservesTextBeforeTool",
+        "TestUS041_KiroGatewayService_CompletionBillingCountsPrivateToolOnce",
+        "TestUS041_KiroGatewayService_ContinuationStreamingReportsFinalInputUsage",
         "TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved",
         "TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolUseReturnsImmediately",
         "TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolWinsOverCompletionSignal",
@@ -355,9 +362,9 @@
         "message_start",
         "content_block_delta",
         "func (e *kiroSSEEncoder) ensureBlock",
-        "writeMessageDelta(outputTokens int, stopReason string)"
+        "writeMessageDelta(inputTokens, outputTokens int, stopReason string)"
       ],
-      "rationale": "Translates Kiro callbacks into the canonical Anthropic SSE event sequence. Losing it breaks streaming /v1/messages response shape for kiro accounts (clients hang or mis-parse). The explicit stopReason argument prevents the encoder from inventing end_turn when upstream actually stopped for a token limit or an unsupported outcome. ensureBlock (and writeToolUse) lazily call writeMessageStart on first content; writeMessageStart is idempotent (`if e.started { return }`). This laziness is what keeps enc.started false on a pre-content upstream 400 so the gateway service can surface the error instead of a clean empty 200 stream."
+      "rationale": "Translates Kiro callbacks into the canonical Anthropic SSE event sequence. Losing it breaks streaming /v1/messages response shape for kiro accounts (clients hang or mis-parse). writeMessageDelta carries the final input total as well as output tokens because hidden completion turns occur after message_start and relay billing merges terminal usage. The explicit stopReason argument prevents the encoder from inventing end_turn when upstream actually stopped for a token limit or an unsupported outcome. ensureBlock (and writeToolUse) lazily call writeMessageStart on first content; writeMessageStart is idempotent (`if e.started { return }`). This laziness is what keeps enc.started false on a pre-content upstream 400 so the gateway service can surface the error instead of a clean empty 200 stream."
     },
     {
       "path": "backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -122,9 +122,10 @@
         "func ConsumeClaudeCodeCompletionSignal",
         "func PrepareClaudeCodeCompletionContinuation",
         "ClaudeCodeCompletionProtocol",
+        "Do not repeat or restate text",
         "minLength"
       ],
-      "rationale": "Single owner for Kiro's transport-private Claude Code completion handshake. It defines the non-empty completion schema, strips only valid private signals, and creates the bounded continuation payload while preserving the normal tool catalog. Losing this owner returns completion judgment to lossy stop-reason guessing or leaks private tool calls to Claude Code."
+      "rationale": "Single owner for Kiro's transport-private Claude Code completion handshake. It defines the non-empty completion schema, strips only valid private signals, and creates the bounded continuation payload while preserving the normal tool catalog and explicitly forbidding restatement of prior assistant text. Losing this owner returns completion judgment to lossy stop-reason guessing, leaks private tool calls to Claude Code, or invites repeated final replies during hidden continuation."
     },
     {
       "path": "backend/internal/integration/kiro/claude_code_completion_test.go",
@@ -281,7 +282,7 @@
         "kiroproto.EstimateOutputTokens",
         "BillingTier:   kiroproto.KiroEstimatedBillingTier",
         "callErr != nil && !enc.started",
-        "turnText == \"\" && turnThinking == \"\" && len(turnToolUses) == 0",
+        "visibleTurnText == \"\" && turnThinking == \"\" && len(turnToolUses) == 0",
         "KiroContentFilteredError",
         "KiroPostOutputStreamDisconnectError",
         "classifyKiroPostOutputStreamError",
@@ -293,13 +294,15 @@
         "kiroproto.ConsumeClaudeCodeCompletionSignal",
         "kiroproto.PrepareClaudeCodeCompletionContinuation",
         "completionSignalTextDelta",
+        "continuationTextDelta",
+        "billingTextBuf",
         "gateway.kiro_stop_reason",
         "gateway.kiro_completion_protocol",
         "unsupported_stop_reason",
         "classifyAndRecordKiroForwardError",
         "publishKiroInternalThinkingSideChannel"
       ],
-      "rationale": "The sixth-platform forwarder translates /v1/messages onto Kiro EventStream and estimates usage because upstream reports credits only. The context-aware call and ResetForRetry callbacks protect retry integrity. The stop-reason mapper preserves Kiro's authoritative terminal outcome; for positively identified Claude Code payloads, the private completion signal and bounded continuation loop separate model END_TURN from agent completion. completionSignalTextDelta prevents a private completion message from repeating a complete text block already visible in the same or an earlier hidden turn while preserving genuinely complementary final text. Every private-tool consume/hide site is guarded by payload.ClaudeCodeCompletionProtocol so ordinary API clients retain same-name tools. Hidden continuation usage is billed and both stop/completion actions are observable. The pre-content error guard keeps failures visible instead of returning an empty 200 stream. Losing these anchors silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
+      "rationale": "The sixth-platform forwarder translates /v1/messages onto Kiro EventStream and estimates usage because upstream reports credits only. The context-aware call and ResetForRetry callbacks protect retry integrity. The stop-reason mapper preserves Kiro's authoritative terminal outcome; for positively identified Claude Code payloads, the private completion signal and bounded continuation loop separate model END_TURN from agent completion. completionSignalTextDelta prevents a private completion message from repeating a complete text block already visible in the same or an earlier hidden turn, while continuationTextDelta buffers and removes ordinary assistant text repeated by later hidden turns. Every private-tool consume/hide site is guarded by payload.ClaudeCodeCompletionProtocol so ordinary API clients retain same-name tools. billingTextBuf keeps hidden continuation output billable even when its duplicate presentation is suppressed. Both stop/completion actions remain observable, and the visible-text-aware pre-content error guard keeps failures visible instead of returning an empty 200 stream. Losing these anchors silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
     },
     {
       "path": "backend/internal/service/kiro_gateway_service_test.go",
@@ -323,6 +326,8 @@
         "TestUS041_KiroGatewayService_CompletionSignalMessageIsPreservedAfterText",
         "TestUS041_KiroGatewayService_CompletionSignalDoesNotRepeatVisibleFinalText",
         "TestUS041_KiroGatewayService_ContinuationCompletionDoesNotRepeatPriorFinalText",
+        "TestUS041_KiroGatewayService_ContinuationTextDoesNotRepeatAcrossTurns",
+        "TestContinuationTextDeltaKeepsOnlyNewRecapText",
         "TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved",
         "TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolUseReturnsImmediately",
         "TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolWinsOverCompletionSignal",


### PR DESCRIPTION
## 摘要

- 修复 #1499 / #1503 后仍出现的 Kiro completion 隐藏续跑重复回复：第二轮及之后的普通 assistant 文本先缓冲，并按已展示内容去重；续跑提示同时要求模型不要复述上一轮。
- 保留真正新增的续跑段落与 text-before-tool 顺序，并为新增内容补齐段落边界；Markdown 去重只识别“标记 + 空白”，避免把 `-10` 等语义内容误判为装饰。
- 分离可见文本与计费文本：隐藏续跑输出继续计费，私有 completion tool input 只计一次；流式 `message_delta` 回传最终输入/输出 usage，保证 relay 解析 SSE 与本地 `ForwardResult` 计费一致。
- 同步 Kiro sentinel，锚定去重、事件顺序与计费语义。

no-web-impact：仅调整 Kiro 后端响应聚合、SSE usage 与回归测试，不影响 Web 页面、配置或前端契约。

## 风险

- 续跑轮次的普通文本会在该轮终止信息或普通 tool use 到达时提交；首轮流式延迟不变，普通 tool use 前的文本顺序保持不变。
- 去重只匹配完整边界块、重复段落及明确的 Markdown/列表装饰，不做短子串模糊删除。
- 终止 `message_delta.usage` 新增最终 `input_tokens`；现有 relay parser 会将非零终止值合并并覆盖首轮估算值。

## 验证

- `go test -tags=unit ./internal/service ./internal/integration/kiro ./internal/pkg/claude`
- 聚焦回归测试：重复文本、段落边界、负数前缀、text-before-tool、私有 tool 单次计费、续跑最终 SSE usage
- `python3 scripts/sentinels/check-kiro.py`（81/81 intact）
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

## 提交

- `763e7abce` fix(kiro): 避免隐藏续跑重复最终回复 (no-web-impact)
- `5092c46e3` fix(kiro): address R-001..R-005 - 收紧续跑去重与计费语义 (no-web-impact)

最新提交：5092c46e3
