### PR TITLE
fix(openrouter): update-config 补全 exclude/stream 列表并修复串行 smoke import

### DIFF
--- a/ops/pricing/manage-openrouter-provider-config.py
+++ b/ops/pricing/manage-openrouter-provider-config.py
@@ -225,6 +225,12 @@ print(json.dumps({
     )
 
 
+_EXAMPLE_LIST_FIELDS = (
+    "catalog_excluded_model_ids",
+    "stream_only_model_ids",
+)
+
+
 def _load_default_config() -> dict:
     example = REPO_ROOT / "ops/pricing/examples/openrouter-provider-config.example.json"
     cfg = json.loads(example.read_text(encoding="utf-8"))
@@ -233,6 +239,17 @@ def _load_default_config() -> dict:
     cfg.pop("allowed_api_key_ids", None)
     cfg.pop("monitor_api_key_ids", None)
     return cfg
+
+
+def _merge_missing_list_fields(cfg: dict[str, Any], example: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Backfill list SSOT fields from example when live settings omit or null them."""
+    if example is None:
+        example = _load_default_config()
+    merged = dict(cfg)
+    for key in _EXAMPLE_LIST_FIELDS:
+        if key not in merged or merged[key] is None:
+            merged[key] = list(example.get(key) or [])
+    return merged
 
 
 def _resolve_group_id(instance_id: str, group_id: int | None, create_group: bool) -> int:
@@ -384,7 +401,7 @@ def cmd_update_config(args) -> int:
     cfg_sql = f"SELECT value FROM settings WHERE key = {_sql_literal(SETTING_KEY)} LIMIT 1;"
     existing_raw = _decode_settings_value(_run_psql_query(inst, cfg_sql, "or-provider update: config"))
     if existing_raw:
-        cfg = json.loads(existing_raw)
+        cfg = _merge_missing_list_fields(json.loads(existing_raw))
     else:
         cfg = _load_default_config()
 

--- a/ops/pricing/openrouter-provider-onboarding.md
+++ b/ops/pricing/openrouter-provider-onboarding.md
@@ -29,7 +29,7 @@ Prod bootstrap (creates group/keys/config; prints ids only, never key secrets):
 
 ```bash
 python3 ops/pricing/manage-openrouter-provider-config.py snapshot
-python3 ops/pricing/manage-openrouter-provider-config.py update-config  # upsert 6 group_ids + existing keys
+python3 ops/pricing/manage-openrouter-provider-config.py update-config  # upsert 6 group_ids + existing keys; backfills missing catalog_excluded_model_ids / stream_only_model_ids from example JSON
 ```
 
 Required fields:

--- a/ops/pricing/probe-openrouter-provider-inference-serial.py
+++ b/ops/pricing/probe-openrouter-provider-inference-serial.py
@@ -28,8 +28,6 @@ DEFAULT_SLEEP_S = 1.0
 
 
 def load_chain_probe():
-    import sys
-
     name = "or_chain_probe"
     spec = importlib.util.spec_from_file_location(name, CHAIN_PROBE)
     mod = importlib.util.module_from_spec(spec)

--- a/ops/pricing/probe-openrouter-provider-inference-serial.py
+++ b/ops/pricing/probe-openrouter-provider-inference-serial.py
@@ -28,8 +28,12 @@ DEFAULT_SLEEP_S = 1.0
 
 
 def load_chain_probe():
-    spec = importlib.util.spec_from_file_location("or_chain_probe", CHAIN_PROBE)
+    import sys
+
+    name = "or_chain_probe"
+    spec = importlib.util.spec_from_file_location(name, CHAIN_PROBE)
     mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
     spec.loader.exec_module(mod)
     return mod
 

--- a/ops/pricing/test_manage_openrouter_provider_config.py
+++ b/ops/pricing/test_manage_openrouter_provider_config.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Unit tests for manage-openrouter-provider-config list-field merge helpers."""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+_MOD_PATH = pathlib.Path(__file__).resolve().parent / "manage-openrouter-provider-config.py"
+_spec = importlib.util.spec_from_file_location("manage_openrouter_provider_config", _MOD_PATH)
+mgr = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+sys.modules[_spec.name] = mgr
+_spec.loader.exec_module(mgr)
+
+
+class MergeMissingListFieldsTest(unittest.TestCase):
+    EXAMPLE = mgr._load_default_config()
+
+    def test_fills_missing_and_null_from_example(self) -> None:
+        live = {"enabled": True, "catalog_excluded_model_ids": None}
+        merged = mgr._merge_missing_list_fields(live, self.EXAMPLE)
+        self.assertEqual(merged["catalog_excluded_model_ids"], self.EXAMPLE["catalog_excluded_model_ids"])
+        self.assertEqual(merged["stream_only_model_ids"], self.EXAMPLE["stream_only_model_ids"])
+        self.assertTrue(merged["enabled"])
+
+    def test_preserves_explicit_empty_lists(self) -> None:
+        live = {
+            "catalog_excluded_model_ids": [],
+            "stream_only_model_ids": [],
+        }
+        merged = mgr._merge_missing_list_fields(live, self.EXAMPLE)
+        self.assertEqual(merged["catalog_excluded_model_ids"], [])
+        self.assertEqual(merged["stream_only_model_ids"], [])
+
+    def test_preserves_explicit_ops_overrides(self) -> None:
+        live = {
+            "catalog_excluded_model_ids": ["custom-exclude"],
+            "stream_only_model_ids": ["custom-stream"],
+        }
+        merged = mgr._merge_missing_list_fields(live, self.EXAMPLE)
+        self.assertEqual(merged["catalog_excluded_model_ids"], ["custom-exclude"])
+        self.assertEqual(merged["stream_only_model_ids"], ["custom-stream"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/pricing/test_probe_openrouter_provider_inference_serial.py
+++ b/ops/pricing/test_probe_openrouter_provider_inference_serial.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Regression tests for the serial OpenRouter inference probe."""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import unittest
+
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent / "probe-openrouter-provider-inference-serial.py"
+
+
+class SerialProbeStartupTest(unittest.TestCase):
+    def test_help_loads_chain_probe_before_parsing(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--help"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("--via-ssm", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- `manage-openrouter-provider-config.py update-config`：当 prod 已有 settings 缺少或为 null 的 `catalog_excluded_model_ids` / `stream_only_model_ids` 时，从 example JSON 回填；显式空列表或 ops 自定义列表不覆盖
- `probe-openrouter-provider-inference-serial.py`：importlib 加载 chain probe 前注册 `sys.modules`，修复 `AttributeError: 'NoneType' object has no attribute '__dict__'`
- 新增配置合并和串行 probe 启动回归测试；onboarding 文档补充 update-config 行为说明

## 风险

常规风险 / ops 脚本。不改变 Go 运行时逻辑；仅让 update-config 与 #1513 后的 example SSOT 对齐，避免发版后需手工 SSM patch 列表字段。

## 验证

```bash
python3 -m unittest discover -s ops/pricing -p 'test_*openrouter*.py' -v
PREFLIGHT_BASE=origin/main bash scripts/preflight.sh
```

- 聚焦单测：4/4 通过
- preflight：PASS

## 提交

- 2b3ca51ef fix(openrouter): update-config 补全 exclude/stream 列表并修复串行 smoke import
- 97f7a3a0c fix(openrouter): address R-001..R-002 - cover serial loader

最新提交：97f7a3a0c

Made with [Cursor](https://cursor.com)
