### PR TITLE
fix: 非 Grok 异步视频 submit 走 tier 视频结算路径

### DIFF
--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -117,7 +117,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	user := input.User
 	account := input.Account
 	subscription := input.Subscription
-	if !isGrokVideoUsageResult(result, nil) {
+	if !isOpenAIVideoUsageResult(result) {
 		ApplyOpenAIImageBillingResolution(result)
 	}
 
@@ -281,7 +281,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		ImageSizeSource:     optionalTrimmedStringPtr(result.ImageSizeSource),
 		ImageSizeBreakdown:  result.ImageSizeBreakdown,
 	}
-	isVideoUsage := isGrokVideoUsageResult(result, billingModels)
+	isVideoUsage := isOpenAIVideoUsageResult(result)
 	if isVideoUsage {
 		usageLog.VideoCount = result.VideoCount
 		resolution := NormalizeVideoBillingResolutionForModel(billingModel, result.VideoResolution)
@@ -421,10 +421,8 @@ func (s *OpenAIGatewayService) calculateOpenAIRecordUsageCost(
 		//（用户专属 > 分组 rate_multiplier > 系统默认），与分组表单的价格预览承诺一致。
 		return s.billingService.CalculateWebSearchCost(result.WebSearchCalls, webSearchPricePerCallFromAPIKey(apiKey), webSearchMultiplier), nil
 	}
-	if isGrokVideoUsageResult(result, billingModels) {
-		if resolved := s.resolveOpenAIChannelPricing(ctx, billingModel, apiKey); resolved == nil || resolved.Mode != BillingModeToken {
-			return s.calculateOpenAIVideoCost(ctx, billingModel, apiKey, result, videoMultiplier), nil
-		}
+	if cost, ok := s.tkTryCalculateOpenAIVideoUsageCost(ctx, result, apiKey, billingModels, videoMultiplier); ok {
+		return cost, nil
 	}
 	if result != nil && result.ImageCount > 0 {
 		// 渠道定价为 token 计费时走 token 路径，否则走图片计费
@@ -466,24 +464,6 @@ func (s *OpenAIGatewayService) calculateOpenAIRecordUsageCost(
 		lastErr = errors.New("no non-empty billing model candidates")
 	}
 	return nil, fmt.Errorf("calculate OpenAI usage cost failed for billing models %s: %w", strings.Join(billingModels, ","), lastErr)
-}
-
-func isGrokVideoBillingModel(model string) bool {
-	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "grok-imagine-video")
-}
-
-func isGrokVideoUsageResult(result *OpenAIForwardResult, billingModels []string) bool {
-	if result == nil || result.VideoCount <= 0 {
-		return false
-	}
-	candidates := append([]string{}, billingModels...)
-	candidates = append(candidates, result.BillingModel, result.Model, result.UpstreamModel)
-	for _, candidate := range candidates {
-		if isGrokVideoBillingModel(candidate) {
-			return true
-		}
-	}
-	return false
 }
 
 func isUsagePricingUnavailableError(err error) bool {

--- a/backend/internal/service/openai_gateway_usage_tk_video_billing.go
+++ b/backend/internal/service/openai_gateway_usage_tk_video_billing.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"context"
+	"strings"
+)
+
+// isOpenAIVideoUsageResult reports video-generation settlement inputs.
+// VideoCount>0 is stamped by VideoSubmit (seedance/veo/newapi bridge) and Grok
+// native /videos/* handlers. The prior grok-model-name gate dropped non-grok
+// async video submits into the token pricing funnel → pricing_missing_record_zero_cost.
+func isOpenAIVideoUsageResult(result *OpenAIForwardResult) bool {
+	return result != nil && result.VideoCount > 0
+}
+
+func isGrokVideoBillingModel(model string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "grok-imagine-video")
+}
+
+// tkTryCalculateOpenAIVideoUsageCost routes per-second video settlement when
+// applicable. Returns (cost, true) when the video path owns billing; (nil, false)
+// when the caller should fall through (e.g. grok + channel token pricing).
+func (s *OpenAIGatewayService) tkTryCalculateOpenAIVideoUsageCost(
+	ctx context.Context,
+	result *OpenAIForwardResult,
+	apiKey *APIKey,
+	billingModels []string,
+	videoMultiplier float64,
+) (*CostBreakdown, bool) {
+	if !isOpenAIVideoUsageResult(result) {
+		return nil, false
+	}
+	billingModel := firstUsageBillingModel(billingModels)
+	resolved := s.resolveOpenAIChannelPricing(ctx, billingModel, apiKey)
+	if resolved != nil && resolved.Mode == BillingModeToken {
+		if isGrokVideoBillingModel(billingModel) {
+			return nil, false
+		}
+		resolution := NormalizeVideoBillingResolutionForModel(billingModel, result.VideoResolution)
+		if _, ok := tkVideoUnitPriceUSD(billingModel, resolution, videoBillingOptionsFromForwardResult(result)); !ok {
+			return nil, false
+		}
+	}
+	return s.calculateOpenAIVideoCost(ctx, billingModel, apiKey, result, videoMultiplier), true
+}

--- a/backend/internal/service/openai_gateway_usage_tk_video_billing_test.go
+++ b/backend/internal/service/openai_gateway_usage_tk_video_billing_test.go
@@ -1,0 +1,101 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsOpenAIVideoUsageResult(t *testing.T) {
+	require.False(t, isOpenAIVideoUsageResult(nil))
+	require.False(t, isOpenAIVideoUsageResult(&OpenAIForwardResult{}))
+	require.True(t, isOpenAIVideoUsageResult(&OpenAIForwardResult{VideoCount: 1}))
+}
+
+func TestOpenAIGatewayServiceRecordUsage_SeedanceVideoSubmitUsesTierPricing(t *testing.T) {
+	const model = "doubao-seedance-2-0-260128"
+	groupID := int64(1901)
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	svc := newOpenAIRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{}, nil)
+
+	err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+		Result: &OpenAIForwardResult{
+			RequestID:            "seedance-tier-settle",
+			Model:                model,
+			BillingModel:         model,
+			UpstreamModel:        model,
+			VideoCount:           1,
+			VideoResolution:      VideoBillingResolution480P,
+			VideoDurationSeconds: 5,
+			Duration:             time.Second,
+		},
+		APIKey: &APIKey{
+			ID:      501901,
+			GroupID: i64p(groupID),
+			Group: &Group{
+				ID:             groupID,
+				Platform:       PlatformNewAPI,
+				RateMultiplier: 1,
+			},
+		},
+		User:    &User{ID: 601901},
+		Account: &Account{ID: 701901, Platform: PlatformNewAPI},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	unit480, ok := tkOverlayVideoUnitPriceUSD(model, VideoBillingResolution480P, nil)
+	require.True(t, ok)
+	require.InDelta(t, unit480*5, usageRepo.lastLog.TotalCost, 1e-9)
+	require.InDelta(t, unit480*5, usageRepo.lastLog.ActualCost, 1e-9)
+	require.NotNil(t, usageRepo.lastLog.BillingMode)
+	require.Equal(t, string(BillingModeVideo), *usageRepo.lastLog.BillingMode)
+	require.Equal(t, 1, usageRepo.lastLog.VideoCount)
+	require.NotNil(t, usageRepo.lastLog.VideoResolution)
+	require.Equal(t, VideoBillingResolution480P, *usageRepo.lastLog.VideoResolution)
+	require.NotNil(t, usageRepo.lastLog.VideoDurationSeconds)
+	require.Equal(t, int64(5), *usageRepo.lastLog.VideoDurationSeconds)
+}
+
+func TestOpenAIGatewayServiceRecordUsage_SeedanceVideoOverlayOverridesTokenChannel(t *testing.T) {
+	const model = "doubao-seedance-2-0-260128"
+	groupID := int64(1903)
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	svc := newOpenAIRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{}, nil)
+	svc.resolver = newOpenAITokenImageChannelPricingResolverForTest(t, groupID, model)
+
+	err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+		Result: &OpenAIForwardResult{
+			RequestID:            "seedance-token-channel-overlay",
+			Model:                model,
+			BillingModel:         model,
+			VideoCount:           1,
+			VideoResolution:      VideoBillingResolution480P,
+			VideoDurationSeconds: 5,
+			Duration:             time.Second,
+		},
+		APIKey: &APIKey{
+			ID:      501903,
+			GroupID: i64p(groupID),
+			Group: &Group{
+				ID:             groupID,
+				Platform:       PlatformNewAPI,
+				RateMultiplier: 1,
+			},
+		},
+		User:    &User{ID: 601903},
+		Account: &Account{ID: 701903, Platform: PlatformNewAPI},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	unit480, ok := tkOverlayVideoUnitPriceUSD(model, VideoBillingResolution480P, nil)
+	require.True(t, ok)
+	require.NotNil(t, usageRepo.lastLog.BillingMode)
+	require.Equal(t, string(BillingModeVideo), *usageRepo.lastLog.BillingMode)
+	require.InDelta(t, unit480*5, usageRepo.lastLog.ActualCost, 1e-9)
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2554,6 +2554,33 @@
       "rationale": "Focused settlement regressions lock the same request precedence and TaskSubmitReq size conversion used by the bridge, preventing the held/recorded tier from diverging from the generated tier."
     },
     {
+      "path": "backend/internal/service/openai_gateway_usage_tk_video_billing.go",
+      "must_contain": [
+        "func isOpenAIVideoUsageResult",
+        "func (s *OpenAIGatewayService) tkTryCalculateOpenAIVideoUsageCost",
+        "result.VideoCount > 0",
+        "tkVideoUnitPriceUSD"
+      ],
+      "rationale": "RecordUsage video settlement gate: VideoCount>0 must route seedance/veo/newapi VideoSubmit traffic into calculateOpenAIVideoCost instead of the token funnel (pricing_missing_record_zero_cost). Companion keeps upstream openai_gateway_usage.go edits minimal; dropping this file restores the grok-model-name-only gate."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_usage.go",
+      "must_contain": [
+        "isOpenAIVideoUsageResult(result)",
+        "tkTryCalculateOpenAIVideoUsageCost"
+      ],
+      "rationale": "Injection wiring from upstream-owned RecordUsage/calculateOpenAIRecordUsageCost into the TK video settlement companion. An upstream merge reverting these call sites leaves VideoSubmit billing on the token path again even if the companion file survives."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_usage_tk_video_billing_test.go",
+      "must_contain": [
+        "TestIsOpenAIVideoUsageResult",
+        "TestOpenAIGatewayServiceRecordUsage_SeedanceVideoSubmitUsesTierPricing",
+        "TestOpenAIGatewayServiceRecordUsage_SeedanceVideoOverlayOverridesTokenChannel"
+      ],
+      "rationale": "Focused regressions: VideoCount>0 detection and non-grok async video submit must bill overlay tier video; overlay must override misconfigured token channel pricing."
+    },
+    {
       "path": "backend/internal/handler/openai_gateway_tk_video.go",
       "must_contain": [
         "tkVideoFastPathFromS3",


### PR DESCRIPTION
## 摘要

- **根因**：`RecordUsage` 里旧 `isGrokVideoUsageResult` 除 `VideoCount>0` 外还要求模型名前缀为 `grok-imagine-video`。Seedance/Veo 等 `VideoSubmit` 虽写入 `VideoCount=1`，仍落入 token 定价漏斗 → `pricing_missing_record_zero_cost` → **$0 结算**（prod 实测 user_id=1）。
- **修复**：以 `VideoCount>0` 作为视频结算 canonical 信号；Grok + 渠道 token 定价的既有行为保留；overlay 有 per-second 价的非 Grok 模型在误配 token 渠道时仍强制走视频路径。
- **门禁**：`gateway-tk.json` 新增 companion + 注入点 + 回归测试锚点。

## 风险

- 常规风险：仅影响 `VideoCount>0` 的结算分支；Grok token 渠道回归测试仍通过。
- 无 Web/API 契约变更；`no-web-impact`。

## 验证

```bash
cd backend && go test -tags=unit -run 'TestIsOpenAIVideoUsageResult|TestOpenAIGatewayServiceRecordUsage_Seedance|TestOpenAIGatewayServiceRecordUsage_GrokVideoWithTokenChannel' ./internal/service/ -v
python3 scripts/sentinels/check-gateway-tk.py
./scripts/preflight.sh
```

- 新增：`TestOpenAIGatewayServiceRecordUsage_SeedanceVideoSubmitUsesTierPricing`（480p×5s = overlay tier 价）
- 新增：`TestOpenAIGatewayServiceRecordUsage_SeedanceVideoOverlayOverridesTokenChannel`（负向：token 渠道不误吸 overlay 视频模型）
- 回归：`TestOpenAIGatewayServiceRecordUsage_GrokVideoWithTokenChannelPricingKeepsVideoMetadata` PASS
- gateway-tk sentinels PASS

## 提交

- 0f895fd13 fix: settle seedance/veo video submits on tier video path
- 1acd8da50 chore: anchor non-grok video settlement companion in gateway-tk sentinels

最新提交：1acd8da50