### PR TITLE
fix(modelops): honor account mapping overrides before channel floors

### DIFF
--- a/backend/internal/service/account_model_mapping_preset_tk.go
+++ b/backend/internal/service/account_model_mapping_preset_tk.go
@@ -3,14 +3,11 @@ package service
 import (
 	"context"
 	"sort"
-	"strconv"
 	"strings"
 
 	newapiconstant "github.com/QuantumNous/new-api/constant"
 	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 )
-
-const newAPIVolcEngineAgentPlanAccountID int64 = 88
 
 // AccountModelMappingPresetIDs returns TokenKey's empirically verified model IDs
 // for admin account model_mapping auto-fill (Create/Edit when mapping is empty).
@@ -96,7 +93,6 @@ func isNewAPIVolcEngineAgentPlanAccount(account *Account) bool {
 func accountModelMappingOverrideAccounts() []*Account {
 	return []*Account{
 		{
-			ID:          newAPIVolcEngineAgentPlanAccountID,
 			Platform:    PlatformNewAPI,
 			Type:        AccountTypeAPIKey,
 			ChannelType: newapiconstant.ChannelTypeVolcEngine,
@@ -114,7 +110,7 @@ func NewAPIModelMappingPresetIDsForAccount(account *Account) []string {
 		return nil
 	}
 	if isNewAPIVolcEngineAgentPlanAccount(account) {
-		ids := tkServedModelsManifestPresetIDsForAccount(strconv.FormatInt(account.ID, 10))
+		ids := tkServedModelsManifestPresetIDsForSelector(account.Platform, account.ChannelType, account.GetBaseURL())
 		sort.Strings(ids)
 		return ids
 	}
@@ -129,7 +125,7 @@ func NewAPIModelDisplayIDsForAccount(account *Account) []string {
 		return nil
 	}
 	if isNewAPIVolcEngineAgentPlanAccount(account) {
-		ids := tkServedModelsManifestDisplayPresetIDsForAccount(strconv.FormatInt(account.ID, 10))
+		ids := tkServedModelsManifestDisplayPresetIDsForSelector(account.Platform, account.ChannelType, account.GetBaseURL())
 		sort.Strings(ids)
 		return ids
 	}

--- a/backend/internal/service/account_model_mapping_preset_tk.go
+++ b/backend/internal/service/account_model_mapping_preset_tk.go
@@ -10,6 +10,8 @@ import (
 	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 )
 
+const newAPIVolcEngineAgentPlanAccountID int64 = 88
+
 // AccountModelMappingPresetIDs returns TokenKey's empirically verified model IDs
 // for admin account model_mapping auto-fill (Create/Edit when mapping is empty).
 // Native platforms share tkServableCandidateIDs with the group selector; grok/kiro
@@ -87,6 +89,22 @@ func isNewAPIVolcEngineAgentPlanAccount(account *Account) bool {
 		account.Platform == PlatformNewAPI &&
 		account.ChannelType == newapiconstant.ChannelTypeVolcEngine &&
 		newapiintegration.IsVolcEngineAgentPlanBaseURL(account.ChannelType, account.GetBaseURL())
+}
+
+// accountModelMappingOverrideAccounts declares account-specific mapping scopes
+// whose serving intent is narrower than their shared platform/channel floor.
+func accountModelMappingOverrideAccounts() []*Account {
+	return []*Account{
+		{
+			ID:          newAPIVolcEngineAgentPlanAccountID,
+			Platform:    PlatformNewAPI,
+			Type:        AccountTypeAPIKey,
+			ChannelType: newapiconstant.ChannelTypeVolcEngine,
+			Credentials: map[string]any{
+				"base_url": newapiintegration.VolcEngineAgentPlanBaseURL,
+			},
+		},
+	}
 }
 
 // NewAPIModelMappingPresetIDsForAccount preserves account-specific serving

--- a/backend/internal/service/account_model_mapping_ssot_tk.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk.go
@@ -35,14 +35,23 @@ type accountModelMappingRuntimeDoc struct {
 // AccountModelMappingFloorDoc is the ops-facing export of the effective
 // account model_mapping floor. Platform/newapi scopes are full replacements.
 type AccountModelMappingFloorDoc struct {
-	Platforms                     map[string]map[string]string `json:"platforms"`
-	NewAPIChannelTypes            map[string]map[string]string `json:"newapi_channel_types"`
-	AntigravityScopes             []string                     `json:"antigravity_group_scopes"`
-	ForbiddenModelMappingKeys     map[string][]string          `json:"forbidden_model_mapping_keys,omitempty"`
-	ForbiddenModelMappingPrefixes map[string][]string          `json:"forbidden_model_mapping_prefixes,omitempty"`
+	Platforms                     map[string]map[string]string           `json:"platforms"`
+	NewAPIChannelTypes            map[string]map[string]string           `json:"newapi_channel_types"`
+	AccountOverrides              map[string]AccountModelMappingOverride `json:"account_overrides"`
+	AntigravityScopes             []string                               `json:"antigravity_group_scopes"`
+	ForbiddenModelMappingKeys     map[string][]string                    `json:"forbidden_model_mapping_keys,omitempty"`
+	ForbiddenModelMappingPrefixes map[string][]string                    `json:"forbidden_model_mapping_prefixes,omitempty"`
 }
 
-const ModelSurfaceBundleSchemaVersion = 1
+// AccountModelMappingOverride is a full replacement for one account. The
+// identity fields make account-id reuse fail closed in rollout tooling.
+type AccountModelMappingOverride struct {
+	Platform     string            `json:"platform"`
+	ChannelType  int               `json:"channel_type,omitempty"`
+	ModelMapping map[string]string `json:"model_mapping"`
+}
+
+const ModelSurfaceBundleSchemaVersion = 2
 
 // ModelSurfaceBundle is the deterministic release artifact consumed by modelops.
 // The digest covers the Go-owned floor projection, not mutable release metadata.
@@ -177,6 +186,7 @@ func AccountModelMappingFloorForOps(ctx context.Context, runtimeRaw string) (*Ac
 	out := &AccountModelMappingFloorDoc{
 		Platforms:          make(map[string]map[string]string),
 		NewAPIChannelTypes: make(map[string]map[string]string),
+		AccountOverrides:   make(map[string]AccountModelMappingOverride),
 		AntigravityScopes:  append([]string(nil), canonicalAntigravityModelScopes...),
 		ForbiddenModelMappingKeys: map[string][]string{
 			// Kiro-backed Claude models remain public under the anthropic vendor,
@@ -236,6 +246,17 @@ func AccountModelMappingFloorForOps(ctx context.Context, runtimeRaw string) (*Ac
 		mapping, ok := accountModelMappingForAccount(ctx, &Account{Platform: PlatformNewAPI, ChannelType: ct}, nil, nil, runtime)
 		if ok && len(mapping) > 0 {
 			out.NewAPIChannelTypes[strconv.Itoa(ct)] = cloneStringMap(mapping)
+		}
+	}
+	for _, account := range accountModelMappingOverrideAccounts() {
+		mapping, ok := accountModelMappingForAccount(ctx, account, nil, nil, runtime)
+		if !ok || len(mapping) == 0 {
+			continue
+		}
+		out.AccountOverrides[strconv.FormatInt(account.ID, 10)] = AccountModelMappingOverride{
+			Platform:     account.Platform,
+			ChannelType:  account.ChannelType,
+			ModelMapping: cloneStringMap(mapping),
 		}
 	}
 	return out, nil

--- a/backend/internal/service/account_model_mapping_ssot_tk.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk.go
@@ -35,23 +35,25 @@ type accountModelMappingRuntimeDoc struct {
 // AccountModelMappingFloorDoc is the ops-facing export of the effective
 // account model_mapping floor. Platform/newapi scopes are full replacements.
 type AccountModelMappingFloorDoc struct {
-	Platforms                     map[string]map[string]string           `json:"platforms"`
-	NewAPIChannelTypes            map[string]map[string]string           `json:"newapi_channel_types"`
-	AccountOverrides              map[string]AccountModelMappingOverride `json:"account_overrides"`
-	AntigravityScopes             []string                               `json:"antigravity_group_scopes"`
-	ForbiddenModelMappingKeys     map[string][]string                    `json:"forbidden_model_mapping_keys,omitempty"`
-	ForbiddenModelMappingPrefixes map[string][]string                    `json:"forbidden_model_mapping_prefixes,omitempty"`
+	Platforms                     map[string]map[string]string  `json:"platforms"`
+	NewAPIChannelTypes            map[string]map[string]string  `json:"newapi_channel_types"`
+	AccountOverrides              []AccountModelMappingOverride `json:"account_overrides"`
+	AntigravityScopes             []string                      `json:"antigravity_group_scopes"`
+	ForbiddenModelMappingKeys     map[string][]string           `json:"forbidden_model_mapping_keys,omitempty"`
+	ForbiddenModelMappingPrefixes map[string][]string           `json:"forbidden_model_mapping_prefixes,omitempty"`
 }
 
-// AccountModelMappingOverride is a full replacement for one account. The
-// identity fields make account-id reuse fail closed in rollout tooling.
+// AccountModelMappingOverride is a full replacement for accounts matching the
+// platform/channel/base_url selector. It deliberately has no account-id key so
+// account identity remains property-based when an ID is reused.
 type AccountModelMappingOverride struct {
 	Platform     string            `json:"platform"`
 	ChannelType  int               `json:"channel_type,omitempty"`
+	BaseURL      string            `json:"base_url"`
 	ModelMapping map[string]string `json:"model_mapping"`
 }
 
-const ModelSurfaceBundleSchemaVersion = 2
+const ModelSurfaceBundleSchemaVersion = 3
 
 // ModelSurfaceBundle is the deterministic release artifact consumed by modelops.
 // The digest covers the Go-owned floor projection, not mutable release metadata.
@@ -186,7 +188,7 @@ func AccountModelMappingFloorForOps(ctx context.Context, runtimeRaw string) (*Ac
 	out := &AccountModelMappingFloorDoc{
 		Platforms:          make(map[string]map[string]string),
 		NewAPIChannelTypes: make(map[string]map[string]string),
-		AccountOverrides:   make(map[string]AccountModelMappingOverride),
+		AccountOverrides:   make([]AccountModelMappingOverride, 0),
 		AntigravityScopes:  append([]string(nil), canonicalAntigravityModelScopes...),
 		ForbiddenModelMappingKeys: map[string][]string{
 			// Kiro-backed Claude models remain public under the anthropic vendor,
@@ -250,16 +252,32 @@ func AccountModelMappingFloorForOps(ctx context.Context, runtimeRaw string) (*Ac
 	}
 	for _, account := range accountModelMappingOverrideAccounts() {
 		mapping, ok := accountModelMappingForAccount(ctx, account, nil, nil, runtime)
-		if !ok || len(mapping) == 0 {
+		baseURL := normalizeAccountModelMappingOverrideBaseURL(account.GetBaseURL())
+		if !ok || len(mapping) == 0 || baseURL == "" {
 			continue
 		}
-		out.AccountOverrides[strconv.FormatInt(account.ID, 10)] = AccountModelMappingOverride{
+		out.AccountOverrides = append(out.AccountOverrides, AccountModelMappingOverride{
 			Platform:     account.Platform,
 			ChannelType:  account.ChannelType,
+			BaseURL:      baseURL,
 			ModelMapping: cloneStringMap(mapping),
-		}
+		})
 	}
+	sort.Slice(out.AccountOverrides, func(i, j int) bool {
+		left, right := out.AccountOverrides[i], out.AccountOverrides[j]
+		if left.Platform != right.Platform {
+			return left.Platform < right.Platform
+		}
+		if left.ChannelType != right.ChannelType {
+			return left.ChannelType < right.ChannelType
+		}
+		return left.BaseURL < right.BaseURL
+	})
 	return out, nil
+}
+
+func normalizeAccountModelMappingOverrideBaseURL(raw string) string {
+	return strings.TrimRight(strings.ToLower(strings.TrimSpace(raw)), "/")
 }
 
 func kiroExclusiveModelIDs() []string {

--- a/backend/internal/service/account_model_mapping_ssot_tk_test.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk_test.go
@@ -119,6 +119,7 @@ func TestAccountModelMappingFloorForOps_ExportsAccountOverrides(t *testing.T) {
 	expectedAccounts := accountModelMappingOverrideAccounts()
 	require.Len(t, doc.AccountOverrides, len(expectedAccounts))
 	for _, account := range expectedAccounts {
+		require.Zero(t, account.ID, "property-scoped overrides must not carry an account-id selector")
 		baseURL := normalizeAccountModelMappingOverrideBaseURL(account.GetBaseURL())
 		var override AccountModelMappingOverride
 		var found bool

--- a/backend/internal/service/account_model_mapping_ssot_tk_test.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk_test.go
@@ -111,6 +111,54 @@ func TestAccountModelMappingFloorForOps_ExportsPolicyMetadata(t *testing.T) {
 	require.Contains(t, doc.ForbiddenModelMappingPrefixes[PlatformAntigravity], "gpt-oss-")
 }
 
+func TestAccountModelMappingFloorForOps_ExportsAccountOverrides(t *testing.T) {
+	t.Parallel()
+	doc, err := AccountModelMappingFloorForOps(context.Background(), "")
+	require.NoError(t, err)
+
+	expectedAccounts := accountModelMappingOverrideAccounts()
+	expectedIDs := make([]string, 0, len(expectedAccounts))
+	for _, account := range expectedAccounts {
+		accountID := fmt.Sprintf("%d", account.ID)
+		expectedIDs = append(expectedIDs, accountID)
+		override, ok := doc.AccountOverrides[accountID]
+		require.True(t, ok, "missing account override %s", accountID)
+		require.Equal(t, account.Platform, override.Platform)
+		require.Equal(t, account.ChannelType, override.ChannelType)
+
+		mapping, mappingOK := accountModelMappingForAccount(context.Background(), account, nil, nil, nil)
+		require.True(t, mappingOK)
+		require.Equal(t, mapping, override.ModelMapping)
+		require.NotEqual(t,
+			doc.NewAPIChannelTypes[fmt.Sprintf("%d", account.ChannelType)],
+			override.ModelMapping,
+			"account override must remain narrower than its shared channel floor",
+		)
+	}
+
+	actualIDs := make([]string, 0, len(doc.AccountOverrides))
+	for accountID := range doc.AccountOverrides {
+		actualIDs = append(actualIDs, accountID)
+	}
+	require.ElementsMatch(t, expectedIDs, actualIDs)
+}
+
+func TestAccountModelMappingFloorForOps_RuntimeDoesNotShadowAccountOverrides(t *testing.T) {
+	t.Parallel()
+	compiled, err := AccountModelMappingFloorForOps(context.Background(), "")
+	require.NoError(t, err)
+	runtime, err := AccountModelMappingFloorForOps(
+		context.Background(),
+		`{"newapi_channel_types":{"45":{"runtime-model":"runtime-target"}}}`,
+	)
+	require.NoError(t, err)
+	require.Equal(t, compiled.AccountOverrides, runtime.AccountOverrides)
+	require.Equal(t,
+		map[string]string{"runtime-model": "runtime-target"},
+		runtime.NewAPIChannelTypes["45"],
+	)
+}
+
 func TestModelSurfaceBundleForOps_DigestCoversCompleteFloor(t *testing.T) {
 	t.Parallel()
 	bundle, err := ModelSurfaceBundleForOps(context.Background(), "")

--- a/backend/internal/service/account_model_mapping_ssot_tk_test.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk_test.go
@@ -117,14 +117,24 @@ func TestAccountModelMappingFloorForOps_ExportsAccountOverrides(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedAccounts := accountModelMappingOverrideAccounts()
-	expectedIDs := make([]string, 0, len(expectedAccounts))
+	require.Len(t, doc.AccountOverrides, len(expectedAccounts))
 	for _, account := range expectedAccounts {
-		accountID := fmt.Sprintf("%d", account.ID)
-		expectedIDs = append(expectedIDs, accountID)
-		override, ok := doc.AccountOverrides[accountID]
-		require.True(t, ok, "missing account override %s", accountID)
+		baseURL := normalizeAccountModelMappingOverrideBaseURL(account.GetBaseURL())
+		var override AccountModelMappingOverride
+		var found bool
+		for _, candidate := range doc.AccountOverrides {
+			if candidate.Platform == account.Platform &&
+				candidate.ChannelType == account.ChannelType &&
+				candidate.BaseURL == baseURL {
+				override = candidate
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "missing account override for %s/%d/%s", account.Platform, account.ChannelType, baseURL)
 		require.Equal(t, account.Platform, override.Platform)
 		require.Equal(t, account.ChannelType, override.ChannelType)
+		require.Equal(t, baseURL, override.BaseURL)
 
 		mapping, mappingOK := accountModelMappingForAccount(context.Background(), account, nil, nil, nil)
 		require.True(t, mappingOK)
@@ -136,11 +146,6 @@ func TestAccountModelMappingFloorForOps_ExportsAccountOverrides(t *testing.T) {
 		)
 	}
 
-	actualIDs := make([]string, 0, len(doc.AccountOverrides))
-	for accountID := range doc.AccountOverrides {
-		actualIDs = append(actualIDs, accountID)
-	}
-	require.ElementsMatch(t, expectedIDs, actualIDs)
 }
 
 func TestAccountModelMappingFloorForOps_RuntimeDoesNotShadowAccountOverrides(t *testing.T) {

--- a/backend/internal/service/account_test_service_tk_newapi_volcagentplan_test.go
+++ b/backend/internal/service/account_test_service_tk_newapi_volcagentplan_test.go
@@ -34,7 +34,7 @@ func TestDefaultNewAPIAccountTestModel_AgentPlanUsesArkCodeLatest(t *testing.T) 
 func TestNewAPIAvailableModelPresetIDs_AgentPlan(t *testing.T) {
 	t.Parallel()
 	account := &Account{
-		ID:          88,
+		ID:          89,
 		Platform:    PlatformNewAPI,
 		Type:        AccountTypeAPIKey,
 		ChannelType: newapiconstant.ChannelTypeVolcEngine,
@@ -44,17 +44,38 @@ func TestNewAPIAvailableModelPresetIDs_AgentPlan(t *testing.T) {
 	}
 	got := NewAPIAvailableModelPresetIDs(account)
 	require.NotEmpty(t, got)
-	require.Equal(t, tkServedModelsManifestPresetIDsForAccount("88"), got)
+	require.Equal(t, tkServedModelsManifestPresetIDsForSelector(account.Platform, account.ChannelType, account.GetBaseURL()), got)
 	require.Contains(t, got, newapiintegration.VolcEngineAgentPlanDefaultTestModel)
 	display := NewAPIModelDisplayIDsForAccount(account)
 	require.ElementsMatch(t, got, display, "all verified Agent Plan models are displayable")
 	require.Contains(t, display, "minimax-m3")
 }
 
+func TestNewAPIModelMappingPresetIDs_AgentPlanUsesPropertiesNotAccountID(t *testing.T) {
+	t.Parallel()
+
+	makeAccount := func(id int64, baseURL string) *Account {
+		return &Account{
+			ID:          id,
+			Platform:    PlatformNewAPI,
+			Type:        AccountTypeAPIKey,
+			ChannelType: newapiconstant.ChannelTypeVolcEngine,
+			Credentials: map[string]any{"base_url": baseURL},
+		}
+	}
+	agentPlan := makeAccount(88, newapiintegration.VolcEngineAgentPlanBaseURL)
+	otherID := makeAccount(12345, newapiintegration.VolcEngineAgentPlanBaseURL)
+	payAsYouGo := makeAccount(88, "https://ark.cn-beijing.volces.com/api/v3")
+
+	require.Equal(t, NewAPIModelMappingPresetIDsForAccount(agentPlan), NewAPIModelMappingPresetIDsForAccount(otherID))
+	require.NotEqual(t, NewAPIModelMappingPresetIDsForAccount(agentPlan), NewAPIModelMappingPresetIDsForAccount(payAsYouGo))
+	require.NotContains(t, NewAPIModelMappingPresetIDsForAccount(payAsYouGo), "doubao-seed-2.0-pro")
+}
+
 func TestNativeAgentPlanUsesNewAPIKeyCredential(t *testing.T) {
 	t.Parallel()
 	account := &Account{
-		ID:          88,
+		ID:          89,
 		Platform:    PlatformNewAPI,
 		Type:        AccountTypeAPIKey,
 		ChannelType: newapiconstant.ChannelTypeVolcEngine,

--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -254,7 +254,7 @@ func (s *OpenAIGatewayService) buildInputTokensUpstreamRequest(
 		}
 		targetURL = grokURL
 	case account.Type == AccountTypeAPIKey:
-		if baseURL := account.GetOpenAIBaseURL(); strings.TrimSpace(baseURL) != "" {
+		if baseURL := nativeOpenAIBaseURLForAccount(account); strings.TrimSpace(baseURL) != "" {
 			validatedURL, err := s.validateUpstreamBaseURL(baseURL)
 			if err != nil {
 				return nil, err

--- a/backend/internal/service/openai_gateway_count_tokens_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_test.go
@@ -14,7 +14,9 @@ import (
 	"testing"
 	"time"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -83,6 +85,50 @@ func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_APIKeyUsesResponsesI
 	require.Equal(t, "gpt-5.3-codex", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.True(t, gjson.GetBytes(upstream.lastBody, "input").Exists())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "messages").Exists())
+}
+
+func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_AgentPlanUsesArkBaseURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"kimi-k3","messages":[{"role":"user","content":"hello"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"object":"response.input_tokens","input_tokens":17}`)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          8801,
+		Name:        "volcengine-agent-plan-property-scope",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeVolcEngine,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "ark-test",
+			"base_url": newapiintegration.VolcEngineAgentPlanBaseURL,
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	err := svc.ForwardCountTokensAsAnthropic(context.Background(), c, account, body, "kimi-k3")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"input_tokens":17}`, rec.Body.String())
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t,
+		newapiintegration.VolcEngineAgentPlanBaseURL+"/responses/input_tokens",
+		upstream.lastReq.URL.String())
+	require.Equal(t, "Bearer ark-test", upstream.lastReq.Header.Get("authorization"))
 }
 
 func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_OAuthFallsBackWhenPlatformEndpointUnsupported(t *testing.T) {

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -313,6 +313,14 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 	ctx = withTempUnschedulableModel(ctx, requestedModel)
 	customErrorCodesEnabled := account.IsCustomErrorCodesEnabled()
 
+	if tkIsNewAPIAgentPlanOpenAIProviderMismatch(account, statusCode, responseBody) {
+		slog.Error("newapi_agent_plan_provider_mismatch_skip_penalty",
+			"account_id", account.ID,
+			"status_code", statusCode,
+			"expected_base_url", nativeOpenAIBaseURLForAccount(account))
+		return false
+	}
+
 	if s.handleOpenAICompatDownstreamCapacityPenalty(ctx, account, statusCode, responseBody) {
 		return true
 	}

--- a/backend/internal/service/ratelimit_service_tk_provider_mismatch.go
+++ b/backend/internal/service/ratelimit_service_tk_provider_mismatch.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"net/http"
+	"strings"
+)
+
+// tkIsNewAPIAgentPlanOpenAIProviderMismatch identifies an impossible provider
+// response: an Agent Plan account was selected, but OpenAI's official API-key
+// help text came back. This is a gateway routing defect, not evidence that the
+// Ark credential is invalid, so account-health penalties must not persist it.
+func tkIsNewAPIAgentPlanOpenAIProviderMismatch(account *Account, statusCode int, responseBody []byte) bool {
+	if statusCode != http.StatusUnauthorized || !isNewAPIVolcEngineAgentPlanAccount(account) {
+		return false
+	}
+	body := strings.ToLower(string(responseBody))
+	return strings.Contains(body, "incorrect api key provided") &&
+		strings.Contains(body, "platform.openai.com/account/api-keys")
+}

--- a/backend/internal/service/ratelimit_service_tk_provider_mismatch_test.go
+++ b/backend/internal/service/ratelimit_service_tk_provider_mismatch_test.go
@@ -1,0 +1,68 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimitService_AgentPlanOpenAIProviderMismatchSkipsPermanentDisable(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := &RateLimitService{accountRepo: repo}
+	account := newAgentPlanRateLimitAccountForTest(newapiintegration.VolcEngineAgentPlanBaseURL)
+	body := []byte(`{"error":{"message":"Incorrect API key provided: ark-test. You can find your API key at https://platform.openai.com/account/api-keys."}}`)
+
+	shouldDisable := svc.HandleUpstreamError(
+		context.Background(), account, http.StatusUnauthorized, http.Header{}, body)
+
+	require.False(t, shouldDisable)
+	require.Zero(t, repo.setErrorCalls, "a provider-routing mismatch must not poison account health")
+}
+
+func TestRateLimitService_AgentPlanGenuineArk401StillPermanentlyDisables(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := &RateLimitService{accountRepo: repo}
+	account := newAgentPlanRateLimitAccountForTest(newapiintegration.VolcEngineAgentPlanBaseURL)
+	body := []byte(`{"error":{"message":"Invalid API key"}}`)
+
+	shouldDisable := svc.HandleUpstreamError(
+		context.Background(), account, http.StatusUnauthorized, http.Header{}, body)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.setErrorCalls, "a genuine Agent Plan credential failure must retain the auth guard")
+}
+
+func TestRateLimitService_VolcEnginePayAsYouGoOpenAI401StillPermanentlyDisables(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := &RateLimitService{accountRepo: repo}
+	account := newAgentPlanRateLimitAccountForTest("https://ark.cn-beijing.volces.com/api/v3")
+	body := []byte(`{"error":{"message":"Incorrect API key provided: ark-test. You can find your API key at https://platform.openai.com/account/api-keys."}}`)
+
+	shouldDisable := svc.HandleUpstreamError(
+		context.Background(), account, http.StatusUnauthorized, http.Header{}, body)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.setErrorCalls, "the exception must require the Agent Plan base_url property")
+}
+
+func newAgentPlanRateLimitAccountForTest(baseURL string) *Account {
+	return &Account{
+		ID:          8801,
+		Name:        "volcengine-agent-plan-property-scope",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeVolcEngine,
+		Credentials: map[string]any{
+			"api_key":  "ark-test",
+			"base_url": baseURL,
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+}

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -8,6 +8,7 @@
       "model_id": "the client-facing model id that must appear as a KEY in the served account's credentials.model_mapping whitelist (identity-mapped: key==value for these accounts).",
       "served_on": "string list of accounts.id (as strings) whose credentials.model_mapping MUST advertise model_id. This is a static drift-guard/evidence anchor, not the complete live serving pool; account membership can expand or shrink in runtime DB/admin config. New floors declare served-via-modelops-activation in notes; legacy rows may be evidenced by a migration or served-via-admin-ui marker.",
       "channel_type": "the newapi channel_type of the serving account (17=Ali/DashScope, 25=Moonshot, 43=DeepSeek, 45=VolcEngine; 26=ZhipuV4 only if a future direct GLM pool is re-provisioned). Documents the upstream adaptor; not asserted against DB (admin-UI editable) but recorded for the reconciler.",
+      "account_scope": "optional object with platform + channel_type + normalized base_url. When present, it adds a property-scoped serving pool; served_on remains evidence only.",
       "price_source": "one of 'overlay' (priced in tk_pricing_overlay.json), 'mirror' (priced by the runtime litellm/Wei-Shaw mirror under the bare key — overlay deliberately absent because the mirror already carries a non-zero price), 'channel' (priced via channel_model_pricing DB rows). The guard resolves price differently per source.",
       "price_key": "the key under which the price resolves in the named source (overlay JSON key, or mirror/litellm key, or channel pricing model id). Usually == model_id.",
       "display": "bool. true => this manifest-listed, priced, mapped model is allowed to appear in public /pricing and model-menu display surfaces. false keeps the runtime mapping/pricing intent but hides the model until the SSOT display gate proves it or entitlement/provisioning is fixed.",
@@ -23,6 +24,11 @@
         "88"
       ],
       "channel_type": 43,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "deepseek-v4-pro",
       "display": true,
@@ -36,6 +42,11 @@
         "88"
       ],
       "channel_type": 43,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "deepseek-v4-flash",
       "display": true,
@@ -85,6 +96,11 @@
         "88"
       ],
       "channel_type": 25,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "kimi-k2.6",
       "display": true,
@@ -98,6 +114,11 @@
         "88"
       ],
       "channel_type": 25,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "kimi-k2.7-code",
       "display": true,
@@ -123,6 +144,11 @@
         "88"
       ],
       "channel_type": 25,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "kimi-k3",
       "display": true,
@@ -725,6 +751,11 @@
         "88"
       ],
       "channel_type": 17,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "glm-5.2",
       "display": true,
@@ -815,6 +846,11 @@
         "88"
       ],
       "channel_type": 45,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "ark-code-latest",
       "display": true,
@@ -827,6 +863,11 @@
         "88"
       ],
       "channel_type": 45,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "doubao-seed-2.0-mini",
       "display": true,
@@ -839,6 +880,11 @@
         "88"
       ],
       "channel_type": 45,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "doubao-seed-2.0-lite",
       "display": true,
@@ -851,6 +897,11 @@
         "88"
       ],
       "channel_type": 45,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "doubao-seed-evolving",
       "display": true,
@@ -863,6 +914,11 @@
         "88"
       ],
       "channel_type": 45,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "doubao-seed-2.0-code",
       "display": true,
@@ -875,6 +931,11 @@
         "88"
       ],
       "channel_type": 45,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "doubao-seed-2.0-pro",
       "display": true,
@@ -887,6 +948,11 @@
         "88"
       ],
       "channel_type": 45,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "minimax-m2.7",
       "display": true,
@@ -899,6 +965,11 @@
         "88"
       ],
       "channel_type": 45,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3"
+      },
       "price_source": "overlay",
       "price_key": "minimax-m3",
       "display": true,

--- a/backend/internal/service/tk_served_models_manifest_tk.go
+++ b/backend/internal/service/tk_served_models_manifest_tk.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -150,7 +151,7 @@ func manifestEntryIsAgentPlanOnly(e tkServedModelsManifestEntry) bool {
 		return false
 	}
 	for _, accountID := range e.ServedOn {
-		if strings.TrimSpace(accountID) != "88" {
+		if strings.TrimSpace(accountID) != strconv.FormatInt(newAPIVolcEngineAgentPlanAccountID, 10) {
 			return false
 		}
 	}

--- a/backend/internal/service/tk_served_models_manifest_tk.go
+++ b/backend/internal/service/tk_served_models_manifest_tk.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	newapiconstant "github.com/QuantumNous/new-api/constant"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 )
 
 // TokenKey: runtime loader for tk_served_models.json — the curated newapi
@@ -28,10 +29,18 @@ type tkServedModelsManifestFile struct {
 }
 
 type tkServedModelsManifestEntry struct {
-	ModelID     string   `json:"model_id"`
-	ChannelType int      `json:"channel_type"`
-	Display     bool     `json:"display"`
-	ServedOn    []string `json:"served_on"`
+	Platform     string                       `json:"platform"`
+	ModelID      string                       `json:"model_id"`
+	ChannelType  int                          `json:"channel_type"`
+	AccountScope *tkServedModelsManifestScope `json:"account_scope"`
+	Display      bool                         `json:"display"`
+	ServedOn     []string                     `json:"served_on"`
+}
+
+type tkServedModelsManifestScope struct {
+	Platform    string `json:"platform"`
+	ChannelType int    `json:"channel_type"`
+	BaseURL     string `json:"base_url"`
 }
 
 var (
@@ -40,8 +49,8 @@ var (
 	tkServedModelsManifestDisplayIDs              map[string]struct{}
 	tkServedModelsManifestIDsByChannelType        map[int][]string
 	tkServedModelsManifestDisplayIDsByChannelType map[int][]string
-	tkServedModelsManifestIDsByAccount            map[string][]string
-	tkServedModelsManifestDisplayIDsByAccount     map[string][]string
+	tkServedModelsManifestIDsByScope              map[string][]string
+	tkServedModelsManifestDisplayIDsByScope       map[string][]string
 )
 
 func loadTkServedModelsManifestIDs() map[string]struct{} {
@@ -57,16 +66,16 @@ func loadTkServedModelsManifest() {
 			tkServedModelsManifestDisplayIDs = map[string]struct{}{}
 			tkServedModelsManifestIDsByChannelType = map[int][]string{}
 			tkServedModelsManifestDisplayIDsByChannelType = map[int][]string{}
-			tkServedModelsManifestIDsByAccount = map[string][]string{}
-			tkServedModelsManifestDisplayIDsByAccount = map[string][]string{}
+			tkServedModelsManifestIDsByScope = map[string][]string{}
+			tkServedModelsManifestDisplayIDsByScope = map[string][]string{}
 			return
 		}
 		out := make(map[string]struct{}, len(doc.Entries))
 		display := make(map[string]struct{}, len(doc.Entries))
 		byChannel := make(map[int]map[string]struct{})
 		displayByChannel := make(map[int]map[string]struct{})
-		byAccount := make(map[string]map[string]struct{})
-		displayByAccount := make(map[string]map[string]struct{})
+		byScope := make(map[string]map[string]struct{})
+		displayByScope := make(map[string]map[string]struct{})
 		for _, e := range doc.Entries {
 			if e.ModelID == "" {
 				continue
@@ -75,23 +84,22 @@ func loadTkServedModelsManifest() {
 			if e.Display {
 				display[e.ModelID] = struct{}{}
 			}
-			for _, accountID := range e.ServedOn {
-				accountID = strings.TrimSpace(accountID)
-				if accountID == "" {
+			if scope := manifestEntryScopeKey(e); scope != "" {
+				if byScope[scope] == nil {
+					byScope[scope] = make(map[string]struct{})
+				}
+				byScope[scope][e.ModelID] = struct{}{}
+				if e.Display {
+					if displayByScope[scope] == nil {
+						displayByScope[scope] = make(map[string]struct{})
+					}
+					displayByScope[scope][e.ModelID] = struct{}{}
+				}
+				if manifestEntryIsAgentPlanOnly(e) {
 					continue
 				}
-				if byAccount[accountID] == nil {
-					byAccount[accountID] = make(map[string]struct{})
-				}
-				byAccount[accountID][e.ModelID] = struct{}{}
-				if e.Display {
-					if displayByAccount[accountID] == nil {
-						displayByAccount[accountID] = make(map[string]struct{})
-					}
-					displayByAccount[accountID][e.ModelID] = struct{}{}
-				}
 			}
-			if e.ChannelType <= 0 || manifestEntryIsAgentPlanOnly(e) {
+			if e.ChannelType <= 0 {
 				continue
 			}
 			if byChannel[e.ChannelType] == nil {
@@ -125,49 +133,60 @@ func loadTkServedModelsManifest() {
 			sort.Strings(list)
 			tkServedModelsManifestDisplayIDsByChannelType[ct] = list
 		}
-		tkServedModelsManifestIDsByAccount = make(map[string][]string, len(byAccount))
-		for accountID, ids := range byAccount {
+		tkServedModelsManifestIDsByScope = make(map[string][]string, len(byScope))
+		for scope, ids := range byScope {
 			list := make([]string, 0, len(ids))
 			for id := range ids {
 				list = append(list, id)
 			}
 			sort.Strings(list)
-			tkServedModelsManifestIDsByAccount[accountID] = list
+			tkServedModelsManifestIDsByScope[scope] = list
 		}
-		tkServedModelsManifestDisplayIDsByAccount = make(map[string][]string, len(displayByAccount))
-		for accountID, ids := range displayByAccount {
+		tkServedModelsManifestDisplayIDsByScope = make(map[string][]string, len(displayByScope))
+		for scope, ids := range displayByScope {
 			list := make([]string, 0, len(ids))
 			for id := range ids {
 				list = append(list, id)
 			}
 			sort.Strings(list)
-			tkServedModelsManifestDisplayIDsByAccount[accountID] = list
+			tkServedModelsManifestDisplayIDsByScope[scope] = list
 		}
 	})
 }
 
 func manifestEntryIsAgentPlanOnly(e tkServedModelsManifestEntry) bool {
-	if e.ChannelType != newapiconstant.ChannelTypeVolcEngine || len(e.ServedOn) == 0 {
-		return false
-	}
-	for _, accountID := range e.ServedOn {
-		if strings.TrimSpace(accountID) != strconv.FormatInt(newAPIVolcEngineAgentPlanAccountID, 10) {
-			return false
-		}
-	}
-	return true
+	return strings.EqualFold(strings.TrimSpace(e.Platform), PlatformNewAPI) &&
+		e.AccountScope != nil &&
+		e.ChannelType == e.AccountScope.ChannelType &&
+		e.ChannelType == newapiconstant.ChannelTypeVolcEngine &&
+		newapiintegration.IsVolcEngineAgentPlanBaseURL(e.AccountScope.ChannelType, e.AccountScope.BaseURL)
 }
 
-// tkServedModelsManifestPresetIDsForAccount returns manifest model IDs whose
-// served_on anchor includes accountID. Used for pools that share a channel_type
-// with unrelated accounts (e.g. VolcEngine pay-as-you-go vs Agent Plan).
-func tkServedModelsManifestPresetIDsForAccount(accountID string) []string {
-	accountID = strings.TrimSpace(accountID)
-	if accountID == "" {
-		return nil
+func manifestEntryScopeKey(e tkServedModelsManifestEntry) string {
+	if e.AccountScope == nil ||
+		!strings.EqualFold(strings.TrimSpace(e.AccountScope.Platform), PlatformNewAPI) ||
+		!newapiintegration.IsVolcEngineAgentPlanBaseURL(e.AccountScope.ChannelType, e.AccountScope.BaseURL) {
+		return ""
 	}
+	return normalizeAccountModelMappingOverrideScope(
+		e.AccountScope.Platform,
+		e.AccountScope.ChannelType,
+		e.AccountScope.BaseURL,
+	)
+}
+
+func normalizeAccountModelMappingOverrideScope(platform string, channelType int, baseURL string) string {
+	platform = strings.ToLower(strings.TrimSpace(platform))
+	baseURL = normalizeAccountModelMappingOverrideBaseURL(baseURL)
+	if platform == "" || channelType <= 0 || baseURL == "" {
+		return ""
+	}
+	return platform + ":" + strconv.Itoa(channelType) + ":" + baseURL
+}
+
+func tkServedModelsManifestPresetIDsForSelector(platform string, channelType int, baseURL string) []string {
 	loadTkServedModelsManifest()
-	ids := tkServedModelsManifestIDsByAccount[accountID]
+	ids := tkServedModelsManifestIDsByScope[normalizeAccountModelMappingOverrideScope(platform, channelType, baseURL)]
 	if len(ids) == 0 {
 		return nil
 	}
@@ -176,13 +195,9 @@ func tkServedModelsManifestPresetIDsForAccount(accountID string) []string {
 	return out
 }
 
-func tkServedModelsManifestDisplayPresetIDsForAccount(accountID string) []string {
-	accountID = strings.TrimSpace(accountID)
-	if accountID == "" {
-		return nil
-	}
+func tkServedModelsManifestDisplayPresetIDsForSelector(platform string, channelType int, baseURL string) []string {
 	loadTkServedModelsManifest()
-	ids := tkServedModelsManifestDisplayIDsByAccount[accountID]
+	ids := tkServedModelsManifestDisplayIDsByScope[normalizeAccountModelMappingOverrideScope(platform, channelType, baseURL)]
 	if len(ids) == 0 {
 		return nil
 	}

--- a/backend/internal/service/tk_served_models_manifest_tk_test.go
+++ b/backend/internal/service/tk_served_models_manifest_tk_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -16,10 +17,18 @@ import (
 var tkServedModelsOwnerRawForTest []byte
 
 type tkServedModelsOwnerEntryForTest struct {
-	ModelID     string   `json:"model_id"`
-	ChannelType int      `json:"channel_type"`
-	Display     bool     `json:"display"`
-	ServedOn    []string `json:"served_on"`
+	Platform     string                           `json:"platform"`
+	ModelID      string                           `json:"model_id"`
+	ChannelType  int                              `json:"channel_type"`
+	AccountScope *tkServedModelsOwnerScopeForTest `json:"account_scope"`
+	Display      bool                             `json:"display"`
+	ServedOn     []string                         `json:"served_on"`
+}
+
+type tkServedModelsOwnerScopeForTest struct {
+	Platform    string `json:"platform"`
+	ChannelType int    `json:"channel_type"`
+	BaseURL     string `json:"base_url"`
 }
 
 type tkServedModelsOwnerProjectionForTest struct {
@@ -27,8 +36,8 @@ type tkServedModelsOwnerProjectionForTest struct {
 	displayIDs          map[string]struct{}
 	IDsByChannel        map[int][]string
 	displayIDsByChannel map[int][]string
-	IDsByAccount        map[string][]string
-	displayIDsByAccount map[string][]string
+	IDsByScope          map[string][]string
+	displayIDsByScope   map[string][]string
 	channelTypes        []int
 }
 
@@ -40,8 +49,8 @@ func TestTkServedModelsManifestProjectionsMatchRawOwner(t *testing.T) {
 	requireServedManifestProjectionEqualForTest(t, "display IDs", want.displayIDs, tkServedModelsManifestDisplayIDs)
 	requireServedManifestProjectionEqualForTest(t, "IDs by channel", want.IDsByChannel, tkServedModelsManifestIDsByChannelType)
 	requireServedManifestProjectionEqualForTest(t, "display IDs by channel", want.displayIDsByChannel, tkServedModelsManifestDisplayIDsByChannelType)
-	requireServedManifestProjectionEqualForTest(t, "IDs by account", want.IDsByAccount, tkServedModelsManifestIDsByAccount)
-	requireServedManifestProjectionEqualForTest(t, "display IDs by account", want.displayIDsByAccount, tkServedModelsManifestDisplayIDsByAccount)
+	requireServedManifestProjectionEqualForTest(t, "IDs by scope", want.IDsByScope, tkServedModelsManifestIDsByScope)
+	requireServedManifestProjectionEqualForTest(t, "display IDs by scope", want.displayIDsByScope, tkServedModelsManifestDisplayIDsByScope)
 	requireServedManifestProjectionEqualForTest(t, "channel types", want.channelTypes, NewAPIManifestPresetChannelTypes())
 
 	for modelID := range want.listedIDs {
@@ -115,8 +124,8 @@ func loadTkServedModelsOwnerProjectionForTest(t *testing.T) tkServedModelsOwnerP
 		displayIDs:          make(map[string]struct{}, len(doc.Entries)),
 		IDsByChannel:        make(map[int][]string),
 		displayIDsByChannel: make(map[int][]string),
-		IDsByAccount:        make(map[string][]string),
-		displayIDsByAccount: make(map[string][]string),
+		IDsByScope:          make(map[string][]string),
+		displayIDsByScope:   make(map[string][]string),
 	}
 	for key, entry := range doc.Entries {
 		if entry.ModelID == "" {
@@ -132,10 +141,10 @@ func loadTkServedModelsOwnerProjectionForTest(t *testing.T) tkServedModelsOwnerP
 		if entry.Display {
 			out.displayIDs[entry.ModelID] = struct{}{}
 		}
-		for _, accountID := range entry.ServedOn {
-			out.IDsByAccount[accountID] = append(out.IDsByAccount[accountID], entry.ModelID)
+		if scope := manifestScopeKeyForTest(entry); scope != "" {
+			out.IDsByScope[scope] = append(out.IDsByScope[scope], entry.ModelID)
 			if entry.Display {
-				out.displayIDsByAccount[accountID] = append(out.displayIDsByAccount[accountID], entry.ModelID)
+				out.displayIDsByScope[scope] = append(out.displayIDsByScope[scope], entry.ModelID)
 			}
 		}
 		if manifestEntryIsAgentPlanOnlyForTest(entry) {
@@ -155,28 +164,34 @@ func loadTkServedModelsOwnerProjectionForTest(t *testing.T) tkServedModelsOwnerP
 		sort.Strings(ids)
 		out.displayIDsByChannel[channelType] = ids
 	}
-	for accountID, ids := range out.IDsByAccount {
+	for scope, ids := range out.IDsByScope {
 		sort.Strings(ids)
-		out.IDsByAccount[accountID] = ids
+		out.IDsByScope[scope] = ids
 	}
-	for accountID, ids := range out.displayIDsByAccount {
+	for scope, ids := range out.displayIDsByScope {
 		sort.Strings(ids)
-		out.displayIDsByAccount[accountID] = ids
+		out.displayIDsByScope[scope] = ids
 	}
 	sort.Ints(out.channelTypes)
 	return out
 }
 
 func manifestEntryIsAgentPlanOnlyForTest(entry tkServedModelsOwnerEntryForTest) bool {
-	if entry.ChannelType != 45 || len(entry.ServedOn) == 0 {
-		return false
+	return entry.AccountScope != nil &&
+		entry.ChannelType == entry.AccountScope.ChannelType &&
+		manifestScopeKeyForTest(entry) != ""
+}
+
+func manifestScopeKeyForTest(entry tkServedModelsOwnerEntryForTest) string {
+	if entry.AccountScope == nil {
+		return ""
 	}
-	for _, accountID := range entry.ServedOn {
-		if accountID != "88" {
-			return false
-		}
+	baseURL := strings.TrimRight(strings.ToLower(strings.TrimSpace(entry.AccountScope.BaseURL)), "/")
+	if strings.ToLower(strings.TrimSpace(entry.AccountScope.Platform)) != "newapi" ||
+		entry.AccountScope.ChannelType != 45 || baseURL != "https://ark.cn-beijing.volces.com/api/plan/v3" {
+		return ""
 	}
-	return true
+	return "newapi:45:" + baseURL
 }
 
 func requireServedManifestProjectionEqualForTest(t *testing.T, name string, want, got any) {

--- a/docs/approved/model-surface-activation-contract.md
+++ b/docs/approved/model-surface-activation-contract.md
@@ -24,9 +24,10 @@ projections, not parallel model lists.
    required key with the required target and contains no forbidden entry. Other
    entries are compatible extras for preheat and rollback and must survive routine
    check/apply. There is no strict-vs-floor mode switch. An
-   `account_overrides` entry is a full replacement for its `account:<id>` scope
-   and takes precedence over the shared platform/channel scope; its platform and
-   channel metadata must match the live account before any apply is planned.
+   `account_overrides` entry is a full replacement for its property-based
+   `account_override:<platform>:<channel_type>:<base_url>` scope and takes
+   precedence over the shared platform/channel scope only when all selector
+   properties match the live account. Account IDs are not selector keys.
 2. **Build once.** CI/release generates a deterministic, checksummed model-surface
    bundle from the Go owner. Rollout tools consume that bundle and do not compile Go
    or discover a source checkout at rollout time.
@@ -55,9 +56,9 @@ projections, not parallel model lists.
 - Bundle generation is deterministic and preflight fails on generated drift.
 - Runtime tools can validate/check/apply from a bundle without Go or a sibling source
   checkout.
-- Account-specific bundle scopes override shared channel floors without producing a
-  false-positive drift finding, and selector mismatches fail closed without an apply
-  plan.
+- Property-selected account bundle scopes override shared channel floors without
+  producing a false-positive drift finding; same-platform/channel accounts with a
+  different base URL continue to use the shared floor.
 - Routine apply preserves compatible extras and removes forbidden entries.
 - Activation refuses missing/stale/mismatched probe or pricing evidence before any
   write, defaults to dry-run, and requires an explicit confirmation phrase to write.
@@ -102,11 +103,12 @@ mapping, and be no older than 24 hours. The probe result must come from a real
 account path; `account_scope` must exactly match the bundle mapping scope and
 must be a valid projection of `account_platform` (including explicit Anthropic
 transport scopes such as `kiro`, exact `newapi_channel_type:*` scopes, and
-`account:<id>` scopes). For an account scope, `account_id` must equal the scope
-id and `account_platform` must match the bundle override metadata. The account
-probe derives these fields from the target database; its `source` must differ
-from the pricing source. Repository tests and bundle membership are not probe
-evidence.
+property-based `account_override:*` scopes). For an account override scope,
+`account_platform` and normalized `account_base_url` must match the bundle
+selector. `account_id` remains provenance for the real probe path only; it is not
+used to select an override. The account probe derives these fields from the
+target database; its `source` must differ from the pricing source. Repository
+tests and bundle membership are not probe evidence.
 
 Without `--confirm`, activation validates evidence, renders the prod apply plan,
 and runs the prod release gate read-only. With

--- a/docs/approved/model-surface-activation-contract.md
+++ b/docs/approved/model-surface-activation-contract.md
@@ -23,7 +23,10 @@ projections, not parallel model lists.
    and forbidden keys/prefixes. A live mapping is valid when it contains every
    required key with the required target and contains no forbidden entry. Other
    entries are compatible extras for preheat and rollback and must survive routine
-   check/apply. There is no strict-vs-floor mode switch.
+   check/apply. There is no strict-vs-floor mode switch. An
+   `account_overrides` entry is a full replacement for its `account:<id>` scope
+   and takes precedence over the shared platform/channel scope; its platform and
+   channel metadata must match the live account before any apply is planned.
 2. **Build once.** CI/release generates a deterministic, checksummed model-surface
    bundle from the Go owner. Rollout tools consume that bundle and do not compile Go
    or discover a source checkout at rollout time.
@@ -52,6 +55,9 @@ projections, not parallel model lists.
 - Bundle generation is deterministic and preflight fails on generated drift.
 - Runtime tools can validate/check/apply from a bundle without Go or a sibling source
   checkout.
+- Account-specific bundle scopes override shared channel floors without producing a
+  false-positive drift finding, and selector mismatches fail closed without an apply
+  plan.
 - Routine apply preserves compatible extras and removes forbidden entries.
 - Activation refuses missing/stale/mismatched probe or pricing evidence before any
   write, defaults to dry-run, and requires an explicit confirmation phrase to write.
@@ -95,10 +101,12 @@ must bind the exact current and target digests, cover every added/retargeted
 mapping, and be no older than 24 hours. The probe result must come from a real
 account path; `account_scope` must exactly match the bundle mapping scope and
 must be a valid projection of `account_platform` (including explicit Anthropic
-transport scopes such as `kiro`, and exact `newapi_channel_type:*` scopes). The
-account probe derives both fields from the target database; its `source` must
-differ from the pricing source. Repository tests and bundle membership are not
-probe evidence.
+transport scopes such as `kiro`, exact `newapi_channel_type:*` scopes, and
+`account:<id>` scopes). For an account scope, `account_id` must equal the scope
+id and `account_platform` must match the bundle override metadata. The account
+probe derives these fields from the target database; its `source` must differ
+from the pricing source. Repository tests and bundle membership are not probe
+evidence.
 
 Without `--confirm`, activation validates evidence, renders the prod apply plan,
 and runs the prod release gate read-only. With

--- a/docs/global/agent-reference.md
+++ b/docs/global/agent-reference.md
@@ -54,7 +54,7 @@ Customer-visible serving is gated by three layers that must stay aligned on **pr
 
 1. **可展示** — `supported*CatalogModels` / `ServableClientFacingIDs` (public `/models`, `/pricing`, menu).
 2. **已定价** — channel pricing + `tk_pricing_overlay.json` (zero-price leak is an ops alert, not a customer block).
-3. **可服务 + prod 账号放行** — prod `accounts.credentials.model_mapping` (plus optional runtime replacement in `settings.tk_account_model_mapping_runtime`) must match the compiled Go floor for each managed platform.
+3. **可服务 + prod 账号放行** — prod `accounts.credentials.model_mapping` (plus optional runtime replacement in `settings.tk_account_model_mapping_runtime`) must match the compiled Go floor for each managed platform. Account-specific bundle overrides such as `account:88` take precedence over a shared newapi channel floor; the checker must use the account override before reporting drift.
 
 **Official upstream aliases are displayable when priced and servable.** For every
 TokenKey-managed native platform and newapi `channel_type`, if the provider's

--- a/docs/global/agent-reference.md
+++ b/docs/global/agent-reference.md
@@ -54,7 +54,7 @@ Customer-visible serving is gated by three layers that must stay aligned on **pr
 
 1. **可展示** — `supported*CatalogModels` / `ServableClientFacingIDs` (public `/models`, `/pricing`, menu).
 2. **已定价** — channel pricing + `tk_pricing_overlay.json` (zero-price leak is an ops alert, not a customer block).
-3. **可服务 + prod 账号放行** — prod `accounts.credentials.model_mapping` (plus optional runtime replacement in `settings.tk_account_model_mapping_runtime`) must match the compiled Go floor for each managed platform. Account-specific bundle overrides such as `account:88` take precedence over a shared newapi channel floor; the checker must use the account override before reporting drift.
+3. **可服务 + prod 账号放行** — prod `accounts.credentials.model_mapping` (plus optional runtime replacement in `settings.tk_account_model_mapping_runtime`) must match the compiled Go floor for each managed platform. Property-selected bundle overrides for the VolcEngine Agent Plan (`platform + channel_type + base_url`) take precedence over the shared newapi channel floor; account IDs are not used as selectors.
 
 **Official upstream aliases are displayable when priced and servable.** For every
 TokenKey-managed native platform and newapi `channel_type`, if the provider's

--- a/ops/pricing/README.md
+++ b/ops/pricing/README.md
@@ -158,9 +158,10 @@ the compiled floor.
 **prod-only SSOT check.** Public serving requires **可展示 + 已定价 + 可服务** to
 align on prod: catalog allowlists, pricing overlay/channel rows, and prod
 `accounts.credentials.model_mapping` (plus optional runtime replacement). When a
-bundle contains `account_overrides`, `account:<id>` is the required scope and
-overrides the shared platform/channel floor for that account; selector metadata
-must match before an apply plan is emitted.
+bundle contains `account_overrides`, the property-based
+`account_override:<platform>:<channel_type>:<base_url>` scope overrides the
+shared platform/channel floor only when all selector metadata matches; account IDs
+are not used as override selectors.
 Post-release diagnostics use `check-accounts` **without** `--include-edges`;
 its expected mappings and forbidden policy metadata come from the selected
 checksummed bundle.

--- a/ops/pricing/README.md
+++ b/ops/pricing/README.md
@@ -157,7 +157,10 @@ the compiled floor.
 
 **prod-only SSOT check.** Public serving requires **可展示 + 已定价 + 可服务** to
 align on prod: catalog allowlists, pricing overlay/channel rows, and prod
-`accounts.credentials.model_mapping` (plus optional runtime replacement).
+`accounts.credentials.model_mapping` (plus optional runtime replacement). When a
+bundle contains `account_overrides`, `account:<id>` is the required scope and
+overrides the shared platform/channel floor for that account; selector metadata
+must match before an apply plan is emitted.
 Post-release diagnostics use `check-accounts` **without** `--include-edges`;
 its expected mappings and forbidden policy metadata come from the selected
 checksummed bundle.

--- a/ops/pricing/manage-account-model-mapping-runtime.py
+++ b/ops/pricing/manage-account-model-mapping-runtime.py
@@ -27,7 +27,8 @@ always checks prod only. See ``docs/global/agent-reference.md`` § Model serving
 SSOT.
 
 Compiled ``account_overrides`` take precedence over platform and newapi
-channel-type floors. They are immutable bundle scopes and are not shadowed by
+channel-type floors when an account's platform, channel type, and normalized
+base URL all match. They are immutable bundle scopes and are not shadowed by
 the shared-scope runtime setting.
 
 Runtime JSON shape:
@@ -518,40 +519,38 @@ def _mapping_policy_violations(row: dict[str, Any], floor: dict[str, Any]) -> li
 def _desired_mapping_for_account(
     row: dict[str, Any],
     floor: dict[str, Any],
-) -> tuple[dict[str, str] | None, str, str | None]:
-    account_id = str(row.get("id") or "").strip()
-    override = (floor.get("account_overrides") or {}).get(account_id)
-    if isinstance(override, dict):
-        override_scope = f"account:{account_id}"
+) -> tuple[dict[str, str] | None, str]:
+    actual_platform = str(row.get("platform") or "").strip().lower()
+    try:
+        actual_channel_type = int(row.get("channel_type") or 0)
+    except (TypeError, ValueError):
+        actual_channel_type = 0
+    actual_base_url = _BUNDLE.normalize_account_override_base_url(row.get("base_url"))
+    for override in floor.get("account_overrides") or []:
+        if not isinstance(override, dict):
+            continue
         expected_platform = str(override.get("platform") or "").strip().lower()
-        actual_platform = str(row.get("platform") or "").strip().lower()
-        mismatches: list[str] = []
-        if actual_platform != expected_platform:
-            mismatches.append(f"platform={actual_platform!r} want {expected_platform!r}")
         expected_channel_type = override.get("channel_type")
-        if expected_channel_type is not None:
-            try:
-                actual_channel_type = int(row.get("channel_type") or 0)
-            except (TypeError, ValueError):
-                actual_channel_type = 0
-            if actual_channel_type != expected_channel_type:
-                mismatches.append(
-                    f"channel_type={actual_channel_type} want {expected_channel_type}"
-                )
-        if mismatches:
-            return None, override_scope, (
-                "account override identity mismatch (" + "; ".join(mismatches) + ")"
+        if (
+            actual_platform != expected_platform
+            or (expected_channel_type is not None and actual_channel_type != expected_channel_type)
+            or (
+                actual_base_url
+                != _BUNDLE.normalize_account_override_base_url(override.get("base_url"))
             )
+        ):
+            continue
         mapping = override.get("model_mapping")
-        return mapping if isinstance(mapping, dict) else None, override_scope, None
+        if isinstance(mapping, dict):
+            return mapping, _BUNDLE.account_override_scope(override)
 
     scope = _account_scope(row)
     if scope == "newapi":
         ct = str(row.get("channel_type") or "").strip()
         mapping = (floor.get("newapi_channel_types") or {}).get(ct)
-        return mapping if isinstance(mapping, dict) else None, f"newapi_channel_type:{ct or '0'}", None
+        return mapping if isinstance(mapping, dict) else None, f"newapi_channel_type:{ct or '0'}"
     mapping = (floor.get("platforms") or {}).get(scope)
-    return mapping if isinstance(mapping, dict) else None, scope, None
+    return mapping if isinstance(mapping, dict) else None, scope
 
 
 def _mapping_diff(
@@ -605,28 +604,7 @@ def _account_plan(
     row: dict[str, Any],
     floor: dict[str, Any],
 ) -> dict[str, Any] | None:
-    want, scope, override_error = _desired_mapping_for_account(row, floor)
-    if override_error:
-        got, mapping_error = _model_mapping(row)
-        return {
-            "kind": "account",
-            "id": row.get("id"),
-            "name": row.get("name"),
-            "platform": row.get("platform"),
-            "type": row.get("type"),
-            "scope": scope,
-            "reason": override_error,
-            "apply_blocked": True,
-            "diff": {
-                "missing_keys": [],
-                "forbidden_keys": [],
-                "compatible_extra_keys": [],
-                "bad_targets": [],
-                "current_count": len(got) if mapping_error is None else 0,
-                "desired_count": 0,
-            },
-            "desired_model_mapping": {},
-        }
+    want, scope = _desired_mapping_for_account(row, floor)
     if not want:
         return None
     got, err = _model_mapping(row)
@@ -800,10 +778,6 @@ def _collect_apply_plan(
     account_changes: list[dict[str, Any]] = []
     for row in bundle.get("accounts") or []:
         plan = _account_plan(row, floor)
-        if plan and plan.get("apply_blocked"):
-            raise RuntimeError(
-                f"{label} account {plan.get('id')} cannot be applied: {plan.get('reason')}"
-            )
         if plan and plan.get("desired_model_mapping"):
             plan["target"] = label
             account_changes.append(plan)
@@ -1477,13 +1451,14 @@ def cmd_selftest(_args) -> int:
         "newapi_channel_types": {
             "45": {"generic-model": "generic-model"},
         },
-        "account_overrides": {
-            "88": {
+        "account_overrides": [
+            {
                 "platform": "newapi",
                 "channel_type": 45,
+                "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3",
                 "model_mapping": {"agent-plan-model": "agent-plan-model"},
             },
-        },
+        ],
         "antigravity_group_scopes": ["claude", "gemini_text", "gemini_image"],
         "forbidden_model_mapping_keys": {
             "anthropic": ["claude-opus-5"],
@@ -1510,6 +1485,7 @@ def cmd_selftest(_args) -> int:
         "platform": "newapi",
         "type": "apikey",
         "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3/",
         "model_mapping": {"agent-plan-model": "agent-plan-model"},
     }
     assert _account_plan(account_override_row, floor) is None
@@ -1518,15 +1494,21 @@ def cmd_selftest(_args) -> int:
         "platform": "newapi",
         "type": "apikey",
         "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/v3",
         "model_mapping": {"agent-plan-model": "agent-plan-model"},
     }
     generic_channel_plan = _account_plan(generic_channel_row, floor)
     assert generic_channel_plan and generic_channel_plan["scope"] == "newapi_channel_type:45"
-    mismatched_override = dict(account_override_row, channel_type=17)
+    mismatched_override = dict(
+        account_override_row,
+        base_url="https://ark.cn-beijing.volces.com/api/v3",
+    )
     mismatch_plan = _account_plan(mismatched_override, floor)
-    assert mismatch_plan and "identity mismatch" in mismatch_plan["reason"]
-    assert mismatch_plan["apply_blocked"] is True
-    assert mismatch_plan["desired_model_mapping"] == {}
+    assert mismatch_plan and mismatch_plan["scope"] == "newapi_channel_type:45"
+    assert mismatch_plan["desired_model_mapping"] == {
+        "agent-plan-model": "agent-plan-model",
+        "generic-model": "generic-model",
+    }
     original_run_check_sql_json = globals()["_run_check_sql_json"]
     original_load_effective_floor = globals()["_load_effective_floor"]
     globals()["_run_check_sql_json"] = lambda _region, _instance_id, _label: {
@@ -1536,12 +1518,8 @@ def cmd_selftest(_args) -> int:
     }
     globals()["_load_effective_floor"] = lambda _raw: floor
     try:
-        try:
-            _collect_apply_plan("prod", "test-region", "i-test")
-        except RuntimeError as e:
-            assert "identity mismatch" in str(e)
-        else:
-            raise AssertionError("account override identity mismatch did not block apply")
+        apply_plan = _collect_apply_plan("prod", "test-region", "i-test")
+        assert apply_plan["account_changes"][0]["scope"] == "newapi_channel_type:45"
     finally:
         globals()["_run_check_sql_json"] = original_run_check_sql_json
         globals()["_load_effective_floor"] = original_load_effective_floor

--- a/ops/pricing/manage-account-model-mapping-runtime.py
+++ b/ops/pricing/manage-account-model-mapping-runtime.py
@@ -26,6 +26,10 @@ troubleshooting belongs to ``check-accounts --include-edges``; ``release-gate``
 always checks prod only. See ``docs/global/agent-reference.md`` § Model serving
 SSOT.
 
+Compiled ``account_overrides`` take precedence over platform and newapi
+channel-type floors. They are immutable bundle scopes and are not shadowed by
+the shared-scope runtime setting.
+
 Runtime JSON shape:
 
 {
@@ -511,25 +515,54 @@ def _mapping_policy_violations(row: dict[str, Any], floor: dict[str, Any]) -> li
     return _mapping_policy_violations_for_scope(scope, mm, floor)
 
 
-def _desired_mapping_for_account(row: dict[str, Any], floor: dict[str, Any]) -> tuple[dict[str, str] | None, str]:
+def _desired_mapping_for_account(
+    row: dict[str, Any],
+    floor: dict[str, Any],
+) -> tuple[dict[str, str] | None, str, str | None]:
+    account_id = str(row.get("id") or "").strip()
+    override = (floor.get("account_overrides") or {}).get(account_id)
+    if isinstance(override, dict):
+        override_scope = f"account:{account_id}"
+        expected_platform = str(override.get("platform") or "").strip().lower()
+        actual_platform = str(row.get("platform") or "").strip().lower()
+        mismatches: list[str] = []
+        if actual_platform != expected_platform:
+            mismatches.append(f"platform={actual_platform!r} want {expected_platform!r}")
+        expected_channel_type = override.get("channel_type")
+        if expected_channel_type is not None:
+            try:
+                actual_channel_type = int(row.get("channel_type") or 0)
+            except (TypeError, ValueError):
+                actual_channel_type = 0
+            if actual_channel_type != expected_channel_type:
+                mismatches.append(
+                    f"channel_type={actual_channel_type} want {expected_channel_type}"
+                )
+        if mismatches:
+            return None, override_scope, (
+                "account override identity mismatch (" + "; ".join(mismatches) + ")"
+            )
+        mapping = override.get("model_mapping")
+        return mapping if isinstance(mapping, dict) else None, override_scope, None
+
     scope = _account_scope(row)
     if scope == "newapi":
         ct = str(row.get("channel_type") or "").strip()
         mapping = (floor.get("newapi_channel_types") or {}).get(ct)
-        return mapping if isinstance(mapping, dict) else None, f"newapi_channel_type:{ct or '0'}"
+        return mapping if isinstance(mapping, dict) else None, f"newapi_channel_type:{ct or '0'}", None
     mapping = (floor.get("platforms") or {}).get(scope)
-    return mapping if isinstance(mapping, dict) else None, scope
+    return mapping if isinstance(mapping, dict) else None, scope, None
 
 
 def _mapping_diff(
-    scope: str,
+    policy_scope: str,
     got: dict[str, str],
     want: dict[str, str],
     floor: dict[str, Any],
 ) -> dict[str, Any]:
     missing = sorted(k for k in want if k not in got)
     bad = sorted(k for k in want if k in got and got[k] != want[k])
-    forbidden = _forbidden_mapping_entries(scope, got, floor)
+    forbidden = _forbidden_mapping_entries(policy_scope, got, floor)
     return {
         "missing_keys": missing,
         "forbidden_keys": forbidden,
@@ -572,7 +605,28 @@ def _account_plan(
     row: dict[str, Any],
     floor: dict[str, Any],
 ) -> dict[str, Any] | None:
-    want, scope = _desired_mapping_for_account(row, floor)
+    want, scope, override_error = _desired_mapping_for_account(row, floor)
+    if override_error:
+        got, mapping_error = _model_mapping(row)
+        return {
+            "kind": "account",
+            "id": row.get("id"),
+            "name": row.get("name"),
+            "platform": row.get("platform"),
+            "type": row.get("type"),
+            "scope": scope,
+            "reason": override_error,
+            "apply_blocked": True,
+            "diff": {
+                "missing_keys": [],
+                "forbidden_keys": [],
+                "compatible_extra_keys": [],
+                "bad_targets": [],
+                "current_count": len(got) if mapping_error is None else 0,
+                "desired_count": 0,
+            },
+            "desired_model_mapping": {},
+        }
     if not want:
         return None
     got, err = _model_mapping(row)
@@ -588,7 +642,7 @@ def _account_plan(
         }
         reason = f"{err}; will replace with SSOT (scope={scope}, desired_count={len(want)})"
     else:
-        diff = _mapping_diff(scope, got, want, floor)
+        diff = _mapping_diff(_account_scope(row), got, want, floor)
         if not _has_mapping_diff(diff):
             return None
         reason = _format_mapping_diff_reason(scope, diff)
@@ -746,6 +800,10 @@ def _collect_apply_plan(
     account_changes: list[dict[str, Any]] = []
     for row in bundle.get("accounts") or []:
         plan = _account_plan(row, floor)
+        if plan and plan.get("apply_blocked"):
+            raise RuntimeError(
+                f"{label} account {plan.get('id')} cannot be applied: {plan.get('reason')}"
+            )
         if plan and plan.get("desired_model_mapping"):
             plan["target"] = label
             account_changes.append(plan)
@@ -1416,7 +1474,16 @@ def cmd_selftest(_args) -> int:
                 "claude-opus-5": "claude-opus-5",
             },
         },
-        "newapi_channel_types": {},
+        "newapi_channel_types": {
+            "45": {"generic-model": "generic-model"},
+        },
+        "account_overrides": {
+            "88": {
+                "platform": "newapi",
+                "channel_type": 45,
+                "model_mapping": {"agent-plan-model": "agent-plan-model"},
+            },
+        },
         "antigravity_group_scopes": ["claude", "gemini_text", "gemini_image"],
         "forbidden_model_mapping_keys": {
             "anthropic": ["claude-opus-5"],
@@ -1438,6 +1505,46 @@ def cmd_selftest(_args) -> int:
         floor,
     )
     assert openai_plan and openai_plan["diff"]["missing_keys"] == ["gpt-5.6-sol"]
+    account_override_row = {
+        "id": 88,
+        "platform": "newapi",
+        "type": "apikey",
+        "channel_type": 45,
+        "model_mapping": {"agent-plan-model": "agent-plan-model"},
+    }
+    assert _account_plan(account_override_row, floor) is None
+    generic_channel_row = {
+        "id": 89,
+        "platform": "newapi",
+        "type": "apikey",
+        "channel_type": 45,
+        "model_mapping": {"agent-plan-model": "agent-plan-model"},
+    }
+    generic_channel_plan = _account_plan(generic_channel_row, floor)
+    assert generic_channel_plan and generic_channel_plan["scope"] == "newapi_channel_type:45"
+    mismatched_override = dict(account_override_row, channel_type=17)
+    mismatch_plan = _account_plan(mismatched_override, floor)
+    assert mismatch_plan and "identity mismatch" in mismatch_plan["reason"]
+    assert mismatch_plan["apply_blocked"] is True
+    assert mismatch_plan["desired_model_mapping"] == {}
+    original_run_check_sql_json = globals()["_run_check_sql_json"]
+    original_load_effective_floor = globals()["_load_effective_floor"]
+    globals()["_run_check_sql_json"] = lambda _region, _instance_id, _label: {
+        "runtime_setting": None,
+        "accounts": [mismatched_override],
+        "antigravity_groups": [],
+    }
+    globals()["_load_effective_floor"] = lambda _raw: floor
+    try:
+        try:
+            _collect_apply_plan("prod", "test-region", "i-test")
+        except RuntimeError as e:
+            assert "identity mismatch" in str(e)
+        else:
+            raise AssertionError("account override identity mismatch did not block apply")
+    finally:
+        globals()["_run_check_sql_json"] = original_run_check_sql_json
+        globals()["_load_effective_floor"] = original_load_effective_floor
     native_anthropic_plan = _account_plan({
         "platform": "anthropic",
         "type": "oauth",

--- a/ops/pricing/manage-account-model-mapping-runtime.py
+++ b/ops/pricing/manage-account-model-mapping-runtime.py
@@ -1481,7 +1481,7 @@ def cmd_selftest(_args) -> int:
     )
     assert openai_plan and openai_plan["diff"]["missing_keys"] == ["gpt-5.6-sol"]
     account_override_row = {
-        "id": 88,
+        "id": 12345,
         "platform": "newapi",
         "type": "apikey",
         "channel_type": 45,

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": 1,
-  "floor_sha256": "6c6827d2bf40f24102650200fedbdf8564d2058bb4127b232e82d8a7c7e7cfea",
+  "schema_version": 2,
+  "floor_sha256": "373da8d701e0ea9ee1ee7c7dbcf7e95f7e157149f79aa3dda3fcb46cc32cc515",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -202,6 +202,28 @@
         "doubao-seedream-4-0-250828": "doubao-seedream-4-0-250828",
         "doubao-seedream-4-5-251128": "doubao-seedream-4-5-251128",
         "doubao-seedream-5-0-260128": "doubao-seedream-5-0-260128"
+      }
+    },
+    "account_overrides": {
+      "88": {
+        "platform": "newapi",
+        "channel_type": 45,
+        "model_mapping": {
+          "ark-code-latest": "ark-code-latest",
+          "deepseek-v4-flash": "deepseek-v4-flash",
+          "deepseek-v4-pro": "deepseek-v4-pro",
+          "doubao-seed-2.0-code": "doubao-seed-2.0-code",
+          "doubao-seed-2.0-lite": "doubao-seed-2.0-lite",
+          "doubao-seed-2.0-mini": "doubao-seed-2.0-mini",
+          "doubao-seed-2.0-pro": "doubao-seed-2.0-pro",
+          "doubao-seed-evolving": "doubao-seed-evolving",
+          "glm-5.2": "glm-5.2",
+          "kimi-k2.6": "kimi-k2.6",
+          "kimi-k2.7-code": "kimi-k2.7-code",
+          "kimi-k3": "kimi-k3",
+          "minimax-m2.7": "minimax-m2.7",
+          "minimax-m3": "minimax-m3"
+        }
       }
     },
     "antigravity_group_scopes": [

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": 2,
-  "floor_sha256": "373da8d701e0ea9ee1ee7c7dbcf7e95f7e157149f79aa3dda3fcb46cc32cc515",
+  "schema_version": 3,
+  "floor_sha256": "4594d7d98acbf6b7735ad0d2c6f0f0745c53809468852676529b6a0f8d40327f",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -204,10 +204,11 @@
         "doubao-seedream-5-0-260128": "doubao-seedream-5-0-260128"
       }
     },
-    "account_overrides": {
-      "88": {
+    "account_overrides": [
+      {
         "platform": "newapi",
         "channel_type": 45,
+        "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3",
         "model_mapping": {
           "ark-code-latest": "ark-code-latest",
           "deepseek-v4-flash": "deepseek-v4-flash",
@@ -225,7 +226,7 @@
           "minimax-m3": "minimax-m3"
         }
       }
-    },
+    ],
     "antigravity_group_scopes": [
       "claude",
       "gemini_text",

--- a/ops/pricing/model_surface_bundle.py
+++ b/ops/pricing/model_surface_bundle.py
@@ -9,7 +9,7 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_BUNDLE_PATH = REPO_ROOT / "ops" / "pricing" / "model-surface-bundle.json"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 SUPPORTED_SCHEMA_VERSIONS = {1, SCHEMA_VERSION}
 BUNDLE_FIELDS = {
     "schema_version",
@@ -23,7 +23,7 @@ BASE_FLOOR_FIELDS = {
     "forbidden_model_mapping_keys",
     "forbidden_model_mapping_prefixes",
 }
-ACCOUNT_OVERRIDE_FIELDS = {"platform", "channel_type", "model_mapping"}
+ACCOUNT_OVERRIDE_FIELDS = {"platform", "channel_type", "base_url", "model_mapping"}
 
 
 def canonical_json(value: Any) -> str:
@@ -67,16 +67,29 @@ def _validate_policy_map(label: str, raw: Any) -> dict[str, list[str]]:
     return raw
 
 
-def _validate_account_overrides(raw: Any) -> dict[str, dict[str, Any]]:
-    if not isinstance(raw, dict):
-        raise RuntimeError("model surface bundle omitted account_model_mapping.account_overrides")
-    for account_id, override in raw.items():
-        label = f"account_model_mapping.account_overrides.{account_id}"
-        if not isinstance(account_id, str) or not account_id.isdigit() or int(account_id) <= 0:
-            raise RuntimeError(f"account_model_mapping.account_overrides has invalid key {account_id!r}")
+def normalize_account_override_base_url(raw: Any) -> str:
+    if not isinstance(raw, str):
+        return ""
+    return raw.strip().lower().rstrip("/")
+
+
+def account_override_scope(override: dict[str, Any]) -> str:
+    platform = str(override.get("platform") or "").strip().lower()
+    channel_type = override.get("channel_type")
+    channel = str(channel_type) if channel_type is not None else "0"
+    base_url = normalize_account_override_base_url(override.get("base_url"))
+    return f"account_override:{platform}:{channel}:{base_url}"
+
+
+def _validate_account_overrides(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        raise RuntimeError("model surface bundle omitted account_model_mapping.account_overrides array")
+    seen: set[str] = set()
+    for index, override in enumerate(raw):
+        label = f"account_model_mapping.account_overrides[{index}]"
         if not isinstance(override, dict):
             raise RuntimeError(f"{label} must be an object")
-        missing = sorted({"platform", "model_mapping"} - set(override))
+        missing = sorted({"platform", "base_url", "model_mapping"} - set(override))
         if missing:
             raise RuntimeError(f"{label} omitted fields: " + ", ".join(missing))
         unknown = sorted(set(override) - ACCOUNT_OVERRIDE_FIELDS)
@@ -85,6 +98,13 @@ def _validate_account_overrides(raw: Any) -> dict[str, dict[str, Any]]:
         platform = override.get("platform")
         if not isinstance(platform, str) or not platform.strip() or platform != platform.strip().lower():
             raise RuntimeError(f"{label}.platform must be a normalized non-empty string")
+        base_url = override.get("base_url")
+        if (
+            not isinstance(base_url, str)
+            or not base_url.strip()
+            or base_url != normalize_account_override_base_url(base_url)
+        ):
+            raise RuntimeError(f"{label}.base_url must be a normalized non-empty string")
         channel_type = override.get("channel_type")
         if platform == "newapi":
             if not isinstance(channel_type, int) or isinstance(channel_type, bool) or channel_type <= 0:
@@ -92,6 +112,10 @@ def _validate_account_overrides(raw: Any) -> dict[str, dict[str, Any]]:
         elif channel_type is not None:
             raise RuntimeError(f"{label}.channel_type is only valid for newapi")
         _validate_mapping(f"{label}.model_mapping", override.get("model_mapping"))
+        scope = account_override_scope(override)
+        if scope in seen:
+            raise RuntimeError(f"{label} duplicates selector {scope!r}")
+        seen.add(scope)
     return raw
 
 
@@ -166,7 +190,7 @@ def _validate_floor(floor: dict[str, Any], schema_version: int) -> None:
                 f"account_model_mapping.newapi_channel_types.{channel_type} requires forbidden keys: "
                 + ", ".join(conflicts)
             )
-    for account_id, override in account_overrides.items():
+    for override in account_overrides:
         scope = override["platform"]
         mapping = override["model_mapping"]
         blocked = set(forbidden_keys.get(scope) or [])
@@ -177,7 +201,8 @@ def _validate_floor(floor: dict[str, Any], schema_version: int) -> None:
         )
         if conflicts:
             raise RuntimeError(
-                f"account_model_mapping.account_overrides.{account_id}.model_mapping requires forbidden keys: "
+                f"account_model_mapping.account_overrides selector {account_override_scope(override)!r} "
+                "model_mapping requires forbidden keys: "
                 + ", ".join(conflicts)
             )
 

--- a/ops/pricing/model_surface_bundle.py
+++ b/ops/pricing/model_surface_bundle.py
@@ -9,19 +9,21 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_BUNDLE_PATH = REPO_ROOT / "ops" / "pricing" / "model-surface-bundle.json"
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+SUPPORTED_SCHEMA_VERSIONS = {1, SCHEMA_VERSION}
 BUNDLE_FIELDS = {
     "schema_version",
     "floor_sha256",
     "account_model_mapping",
 }
-FLOOR_FIELDS = {
+BASE_FLOOR_FIELDS = {
     "platforms",
     "newapi_channel_types",
     "antigravity_group_scopes",
     "forbidden_model_mapping_keys",
     "forbidden_model_mapping_prefixes",
 }
+ACCOUNT_OVERRIDE_FIELDS = {"platform", "channel_type", "model_mapping"}
 
 
 def canonical_json(value: Any) -> str:
@@ -65,11 +67,42 @@ def _validate_policy_map(label: str, raw: Any) -> dict[str, list[str]]:
     return raw
 
 
-def _validate_floor(floor: dict[str, Any]) -> None:
-    missing = sorted(FLOOR_FIELDS - set(floor))
+def _validate_account_overrides(raw: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(raw, dict):
+        raise RuntimeError("model surface bundle omitted account_model_mapping.account_overrides")
+    for account_id, override in raw.items():
+        label = f"account_model_mapping.account_overrides.{account_id}"
+        if not isinstance(account_id, str) or not account_id.isdigit() or int(account_id) <= 0:
+            raise RuntimeError(f"account_model_mapping.account_overrides has invalid key {account_id!r}")
+        if not isinstance(override, dict):
+            raise RuntimeError(f"{label} must be an object")
+        missing = sorted({"platform", "model_mapping"} - set(override))
+        if missing:
+            raise RuntimeError(f"{label} omitted fields: " + ", ".join(missing))
+        unknown = sorted(set(override) - ACCOUNT_OVERRIDE_FIELDS)
+        if unknown:
+            raise RuntimeError(f"{label} has unknown fields: " + ", ".join(unknown))
+        platform = override.get("platform")
+        if not isinstance(platform, str) or not platform.strip() or platform != platform.strip().lower():
+            raise RuntimeError(f"{label}.platform must be a normalized non-empty string")
+        channel_type = override.get("channel_type")
+        if platform == "newapi":
+            if not isinstance(channel_type, int) or isinstance(channel_type, bool) or channel_type <= 0:
+                raise RuntimeError(f"{label}.channel_type must be a positive integer for newapi")
+        elif channel_type is not None:
+            raise RuntimeError(f"{label}.channel_type is only valid for newapi")
+        _validate_mapping(f"{label}.model_mapping", override.get("model_mapping"))
+    return raw
+
+
+def _validate_floor(floor: dict[str, Any], schema_version: int) -> None:
+    floor_fields = set(BASE_FLOOR_FIELDS)
+    if schema_version >= 2:
+        floor_fields.add("account_overrides")
+    missing = sorted(floor_fields - set(floor))
     if missing:
         raise RuntimeError("model surface bundle omitted account_model_mapping fields: " + ", ".join(missing))
-    unknown = sorted(set(floor) - FLOOR_FIELDS)
+    unknown = sorted(set(floor) - floor_fields)
     if unknown:
         raise RuntimeError("model surface bundle has unknown account_model_mapping fields: " + ", ".join(unknown))
     platforms = floor.get("platforms")
@@ -87,6 +120,11 @@ def _validate_floor(floor: dict[str, Any]) -> None:
         if not isinstance(channel_type, str) or not channel_type.isdigit() or int(channel_type) <= 0:
             raise RuntimeError(f"account_model_mapping.newapi_channel_types has invalid key {channel_type!r}")
         _validate_mapping(f"account_model_mapping.newapi_channel_types.{channel_type}", mapping)
+
+    account_overrides = (
+        _validate_account_overrides(floor.get("account_overrides"))
+        if schema_version >= 2 else {}
+    )
 
     scopes = floor.get("antigravity_group_scopes")
     if not isinstance(scopes, list) or not scopes:
@@ -128,6 +166,20 @@ def _validate_floor(floor: dict[str, Any]) -> None:
                 f"account_model_mapping.newapi_channel_types.{channel_type} requires forbidden keys: "
                 + ", ".join(conflicts)
             )
+    for account_id, override in account_overrides.items():
+        scope = override["platform"]
+        mapping = override["model_mapping"]
+        blocked = set(forbidden_keys.get(scope) or [])
+        prefixes = forbidden_prefixes.get(scope) or []
+        conflicts = sorted(
+            key for key in mapping
+            if key in blocked or any(key.startswith(prefix) for prefix in prefixes)
+        )
+        if conflicts:
+            raise RuntimeError(
+                f"account_model_mapping.account_overrides.{account_id}.model_mapping requires forbidden keys: "
+                + ", ".join(conflicts)
+            )
 
 
 def load_bundle(path: Path) -> dict[str, Any]:
@@ -146,10 +198,15 @@ def load_bundle(path: Path) -> dict[str, Any]:
     unknown = sorted(set(bundle) - BUNDLE_FIELDS)
     if unknown:
         raise RuntimeError("model surface bundle has unknown fields: " + ", ".join(unknown))
-    if bundle.get("schema_version") != SCHEMA_VERSION:
+    schema_version = bundle.get("schema_version")
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version not in SUPPORTED_SCHEMA_VERSIONS
+    ):
         raise RuntimeError(
-            f"unsupported model surface bundle schema {bundle.get('schema_version')!r}; "
-            f"expected {SCHEMA_VERSION}"
+            f"unsupported model surface bundle schema {schema_version!r}; "
+            f"supported {sorted(SUPPORTED_SCHEMA_VERSIONS)}"
         )
     floor = bundle.get("account_model_mapping")
     if not isinstance(floor, dict):
@@ -160,5 +217,5 @@ def load_bundle(path: Path) -> dict[str, Any]:
             "model surface bundle floor_sha256 mismatch: "
             f"got {bundle.get('floor_sha256')!r}, computed {got_digest}"
         )
-    _validate_floor(floor)
+    _validate_floor(floor, schema_version)
     return bundle

--- a/ops/pricing/modelops.py
+++ b/ops/pricing/modelops.py
@@ -845,6 +845,9 @@ class ActivationError(RuntimeError):
 
 
 def _account_platform_allows_scope(account_platform: str, account_scope: str) -> bool:
+    if account_scope.startswith("account:"):
+        account_id = account_scope.removeprefix("account:")
+        return account_id.isdigit() and int(account_id) > 0
     if account_platform == account_scope:
         return True
     if account_platform == "anthropic":
@@ -881,6 +884,9 @@ def _bundle_mapping_scopes(bundle: dict[str, Any]) -> dict[str, dict[str, str]]:
     for channel_type, mapping in (floor.get("newapi_channel_types") or {}).items():
         if isinstance(mapping, dict):
             scopes[f"newapi_channel_type:{channel_type}"] = dict(mapping)
+    for account_id, override in (floor.get("account_overrides") or {}).items():
+        if isinstance(override, dict) and isinstance(override.get("model_mapping"), dict):
+            scopes[f"account:{account_id}"] = dict(override["model_mapping"])
     return scopes
 
 
@@ -1064,6 +1070,21 @@ def build_activation_context(
             missing_pricing.append("/".join(key))
         if probe_row and pricing_row and probe_row.get("source") == pricing_row.get("source"):
             shared_sources.append("/".join(key))
+        if probe_row and row["scope"].startswith("account:"):
+            account_id = row["scope"].removeprefix("account:")
+            override = (
+                target["account_model_mapping"].get("account_overrides") or {}
+            ).get(account_id) or {}
+            if str(probe_row.get("account_id") or "").strip() != account_id:
+                raise ActivationError(
+                    f"probe evidence account_id must match mapping scope {row['scope']!r}"
+                )
+            expected_platform = str(override.get("platform") or "").strip().lower()
+            if probe_row.get("account_platform") != expected_platform:
+                raise ActivationError(
+                    f"probe evidence account_platform {probe_row.get('account_platform')!r} "
+                    f"must match {row['scope']} platform {expected_platform!r}"
+                )
     if missing_probe:
         raise ActivationError("probe evidence missing servable verdicts: " + ", ".join(missing_probe))
     if missing_pricing:

--- a/ops/pricing/modelops.py
+++ b/ops/pricing/modelops.py
@@ -83,21 +83,34 @@ SELF_CHECK_EXEMPT = {
 
 
 class AccountPolicy:
-    __slots__ = ("account_id", "name", "platform", "channel_type")
+    __slots__ = ("account_id", "name", "platform", "channel_type", "base_url")
 
-    def __init__(self, account_id: str, name: str, platform: str, channel_type: int) -> None:
+    def __init__(
+        self,
+        account_id: str,
+        name: str,
+        platform: str,
+        channel_type: int,
+        base_url: str | None = None,
+    ) -> None:
         self.account_id = account_id
         self.name = name
         self.platform = platform
         self.channel_type = channel_type
+        self.base_url = (base_url or "").strip().lower().rstrip("/")
 
 
-# Historical guard tuples for curated long-tail seed accounts. This is not the
-# serving-pool membership source of truth: operators should pass a live snapshot
-# from snapshot-sql so name/platform/channel_type come from the runtime DB.
+# Historical metadata for curated long-tail seed accounts. Account IDs only
+# identify the legacy CLI seed; serving/probe scope comes from platform,
+# channel_type, and base_url (prefer a live snapshot from snapshot-sql).
 KNOWN_ACCOUNTS: dict[str, AccountPolicy] = {
-    "7": AccountPolicy("7", "volcengine", "newapi", 45),
-    "88": AccountPolicy("88", "volcengine-agent-plan", "newapi", 45),
+    "7": AccountPolicy(
+        "7", "volcengine", "newapi", 45, "https://ark.cn-beijing.volces.com/api/v3"
+    ),
+    "88": AccountPolicy(
+        "88", "volcengine-agent-plan", "newapi", 45,
+        "https://ark.cn-beijing.volces.com/api/plan/v3",
+    ),
     "39": AccountPolicy("39", "ds-官", "newapi", 43),
     "60": AccountPolicy("60", "Qwen", "newapi", 17),
     "72": AccountPolicy("72", "Qwen-2", "newapi", 17),
@@ -111,6 +124,7 @@ class ManifestEntry:
         "model_id",
         "served_on",
         "channel_type",
+        "account_scope",
         "price_source",
         "price_key",
         "display",
@@ -124,6 +138,7 @@ class ManifestEntry:
         model_id: str,
         served_on: tuple[str, ...],
         channel_type: int,
+        account_scope: dict[str, Any] | None,
         price_source: str,
         price_key: str,
         display: bool,
@@ -134,6 +149,7 @@ class ManifestEntry:
         self.model_id = model_id
         self.served_on = served_on
         self.channel_type = channel_type
+        self.account_scope = account_scope
         self.price_source = price_source
         self.price_key = price_key
         self.display = display
@@ -188,7 +204,7 @@ class ProbeAggregate:
 
 
 class AccountSnapshot:
-    __slots__ = ("account_id", "name", "platform", "channel_type", "model_mapping")
+    __slots__ = ("account_id", "name", "platform", "channel_type", "base_url", "model_mapping")
 
     def __init__(
         self,
@@ -197,11 +213,13 @@ class AccountSnapshot:
         platform: str | None = None,
         channel_type: int | None = None,
         model_mapping: dict[str, str] | None = None,
+        base_url: str | None = None,
     ) -> None:
         self.account_id = account_id
         self.name = name
         self.platform = platform
         self.channel_type = channel_type
+        self.base_url = (base_url or "").strip().lower().rstrip("/")
         self.model_mapping = model_mapping or {}
 
 
@@ -230,6 +248,11 @@ def load_manifest(path: Path = MANIFEST_PATH) -> list[ManifestEntry]:
             model_id=str(raw.get("model_id", "")),
             served_on=tuple(str(x) for x in raw.get("served_on", [])),
             channel_type=int(raw.get("channel_type", 0)),
+            account_scope=(
+                raw.get("account_scope")
+                if isinstance(raw.get("account_scope"), dict)
+                else None
+            ),
             price_source=str(raw.get("price_source", "")),
             price_key=str(raw.get("price_key", "")),
             display=bool(raw.get("display", False)),
@@ -414,6 +437,13 @@ def parse_live_mapping(data: Any) -> dict[str, AccountSnapshot]:
             name=row.get("name") if isinstance(row.get("name"), str) else None,
             platform=row.get("platform") if isinstance(row.get("platform"), str) else None,
             channel_type=ct,
+            base_url=(
+                row.get("base_url")
+                if isinstance(row.get("base_url"), str)
+                else credentials.get("base_url")
+                if isinstance(credentials.get("base_url"), str)
+                else None
+            ),
             model_mapping=mapping,
         )
     return out
@@ -443,6 +473,7 @@ def policy_for_account(account_id: str, snapshot: AccountSnapshot | None = None)
             name=snapshot.name or (known.name if known else f"account-{account_id}"),
             platform=snapshot.platform or (known.platform if known else "newapi"),
             channel_type=snapshot.channel_type or (known.channel_type if known else 0),
+            base_url=snapshot.base_url or (known.base_url if known else None),
         )
     return KNOWN_ACCOUNTS.get(account_id, AccountPolicy(account_id, f"account-{account_id}", "newapi", 0))
 
@@ -473,7 +504,7 @@ def probe_env_name(
     if policy.channel_type == 26:
         return None
     if policy.channel_type == 45:
-        if account_id == "88" or "agent-plan" in policy.name.lower():
+        if policy.base_url == "https://ark.cn-beijing.volces.com/api/plan/v3":
             return "VOLCENGINE_AGENT_PLAN_MODELS"
         mode = infer_mode(model_id, overlay)
         if mode == "image":
@@ -1353,7 +1384,7 @@ def _selftest() -> int:
         failures.append("infer_mode failed for image")
     if probe_env_name("60", "qwen-new", overlay) != "DASHSCOPE_CHAT_MODELS":
         failures.append("probe env failed for qwen")
-    dynamic_qwen = AccountSnapshot("17001", "Qwen runtime member", "newapi", 17, {})
+    dynamic_qwen = AccountSnapshot("17001", "Qwen runtime member", "newapi", 17, {}, None)
     if probe_env_name("17001", "qwen-new", overlay, dynamic_qwen) != "DASHSCOPE_CHAT_MODELS":
         failures.append("probe env failed for runtime qwen snapshot")
     if probe_env_name("67", "glm-5-turbo", overlay) is not None:
@@ -1362,6 +1393,29 @@ def _selftest() -> int:
         failures.append("probe env failed for ark image")
     if probe_env_name("88", "minimax-m3", overlay) != "VOLCENGINE_AGENT_PLAN_MODELS":
         failures.append("probe env failed for VolcEngine Agent Plan")
+    dynamic_agent_plan = AccountSnapshot(
+        "12345",
+        "renamed runtime account",
+        "newapi",
+        45,
+        {},
+        "https://ark.cn-beijing.volces.com/api/plan/v3",
+    )
+    if (
+        probe_env_name("12345", "minimax-m3", overlay, dynamic_agent_plan)
+        != "VOLCENGINE_AGENT_PLAN_MODELS"
+    ):
+        failures.append("probe env must select Agent Plan by base_url, not account id or name")
+    pay_as_you_go = AccountSnapshot(
+        "88",
+        "renamed runtime account",
+        "newapi",
+        45,
+        {},
+        "https://ark.cn-beijing.volces.com/api/v3",
+    )
+    if probe_env_name("88", "minimax-m3", overlay, pay_as_you_go) != "ARK_CHAT_MODELS":
+        failures.append("probe env must keep pay-as-you-go /api/v3 outside Agent Plan")
     agent_plan_command = run_probe_command("VOLCENGINE_AGENT_PLAN_MODELS", ["minimax-m3"])
     if "probe-volcengine-agent-plan-models.sh" not in agent_plan_command:
         failures.append("Agent Plan probe command did not use the dedicated probe")

--- a/ops/pricing/modelops.py
+++ b/ops/pricing/modelops.py
@@ -845,9 +845,18 @@ class ActivationError(RuntimeError):
 
 
 def _account_platform_allows_scope(account_platform: str, account_scope: str) -> bool:
-    if account_scope.startswith("account:"):
-        account_id = account_scope.removeprefix("account:")
-        return account_id.isdigit() and int(account_id) > 0
+    if account_scope.startswith("account_override:"):
+        selector = account_scope.split(":", 3)
+        return (
+            len(selector) == 4
+            and selector[1] == account_platform
+            and selector[2].isdigit()
+            and (
+                int(selector[2]) > 0
+                or (selector[2] == "0" and account_platform != "newapi")
+            )
+            and bool(selector[3])
+        )
     if account_platform == account_scope:
         return True
     if account_platform == "anthropic":
@@ -884,9 +893,9 @@ def _bundle_mapping_scopes(bundle: dict[str, Any]) -> dict[str, dict[str, str]]:
     for channel_type, mapping in (floor.get("newapi_channel_types") or {}).items():
         if isinstance(mapping, dict):
             scopes[f"newapi_channel_type:{channel_type}"] = dict(mapping)
-    for account_id, override in (floor.get("account_overrides") or {}).items():
+    for override in floor.get("account_overrides") or []:
         if isinstance(override, dict) and isinstance(override.get("model_mapping"), dict):
-            scopes[f"account:{account_id}"] = dict(override["model_mapping"])
+            scopes[_BUNDLE.account_override_scope(override)] = dict(override["model_mapping"])
     return scopes
 
 
@@ -1007,6 +1016,15 @@ def _load_activation_evidence(
                     f"{row_label}: account_scope {account_scope!r} must match "
                     f"mapping scope {values['scope']!r}"
                 )
+            if account_scope.startswith("account_override:"):
+                account_base_url = row.get("account_base_url")
+                if not isinstance(account_base_url, str) or not account_base_url.strip():
+                    raise ActivationError(
+                        f"{row_label}: account override probe evidence requires account_base_url"
+                    )
+                values["account_base_url"] = _BUNDLE.normalize_account_override_base_url(
+                    account_base_url
+                )
             if not _account_platform_allows_scope(account_platform, account_scope):
                 raise ActivationError(
                     f"{row_label}: account_platform {account_platform!r} cannot provide "
@@ -1070,20 +1088,32 @@ def build_activation_context(
             missing_pricing.append("/".join(key))
         if probe_row and pricing_row and probe_row.get("source") == pricing_row.get("source"):
             shared_sources.append("/".join(key))
-        if probe_row and row["scope"].startswith("account:"):
-            account_id = row["scope"].removeprefix("account:")
-            override = (
-                target["account_model_mapping"].get("account_overrides") or {}
-            ).get(account_id) or {}
-            if str(probe_row.get("account_id") or "").strip() != account_id:
-                raise ActivationError(
-                    f"probe evidence account_id must match mapping scope {row['scope']!r}"
-                )
+        if probe_row and row["scope"].startswith("account_override:"):
+            override = next(
+                (
+                    candidate
+                    for candidate in target["account_model_mapping"].get("account_overrides") or []
+                    if isinstance(candidate, dict)
+                    and _BUNDLE.account_override_scope(candidate) == row["scope"]
+                ),
+                None,
+            )
+            if not override:
+                raise ActivationError(f"target bundle is missing selector {row['scope']!r}")
             expected_platform = str(override.get("platform") or "").strip().lower()
+            expected_base_url = _BUNDLE.normalize_account_override_base_url(override.get("base_url"))
             if probe_row.get("account_platform") != expected_platform:
                 raise ActivationError(
                     f"probe evidence account_platform {probe_row.get('account_platform')!r} "
                     f"must match {row['scope']} platform {expected_platform!r}"
+                )
+            actual_base_url = _BUNDLE.normalize_account_override_base_url(
+                probe_row.get("account_base_url")
+            )
+            if actual_base_url != expected_base_url:
+                raise ActivationError(
+                    f"probe evidence account_base_url {actual_base_url!r} "
+                    f"must match {row['scope']} base_url {expected_base_url!r}"
                 )
     if missing_probe:
         raise ActivationError("probe evidence missing servable verdicts: " + ", ".join(missing_probe))

--- a/ops/pricing/test_model_activation.py
+++ b/ops/pricing/test_model_activation.py
@@ -38,6 +38,7 @@ class ModelActivationTest(unittest.TestCase):
         current_floor = {
             "platforms": {"openai": {"gpt-current": "gpt-current"}},
             "newapi_channel_types": {},
+            "account_overrides": {},
             "antigravity_group_scopes": ["claude"],
             "forbidden_model_mapping_keys": {},
             "forbidden_model_mapping_prefixes": {},
@@ -50,6 +51,7 @@ class ModelActivationTest(unittest.TestCase):
                 },
             },
             "newapi_channel_types": {},
+            "account_overrides": {},
             "antigravity_group_scopes": ["claude"],
             "forbidden_model_mapping_keys": {},
             "forbidden_model_mapping_prefixes": {},
@@ -82,6 +84,10 @@ class ModelActivationTest(unittest.TestCase):
         pricing_source: str = "prod-pricing-snapshot",
         account_platform: str = "openai",
         account_scope: str = "openai",
+        account_id: str = "test-account",
+        scope: str = "openai",
+        model_id: str = "gpt-new",
+        target: str = "gpt-new-upstream",
     ) -> None:
         common = {
             "schema_version": MODEL_OPS.ACTIVATION_EVIDENCE_SCHEMA_VERSION,
@@ -90,9 +96,9 @@ class ModelActivationTest(unittest.TestCase):
             "observed_at": (observed_at or self.now).isoformat().replace("+00:00", "Z"),
         }
         model = {
-            "scope": "openai",
-            "model_id": "gpt-new",
-            "target": "gpt-new-upstream",
+            "scope": scope,
+            "model_id": model_id,
+            "target": target,
         }
         self.probe_path.write_text(json.dumps({
             **common,
@@ -101,7 +107,7 @@ class ModelActivationTest(unittest.TestCase):
                 **model,
                 "verdict": "servable",
                 "source": probe_source,
-                "account_id": "test-account",
+                "account_id": account_id,
                 "account_platform": account_platform,
                 "account_scope": account_scope,
             }],
@@ -120,6 +126,18 @@ class ModelActivationTest(unittest.TestCase):
             pricing_evidence_path=self.pricing_path,
             now=self.now,
         )
+
+    def use_account_override_target(self) -> dict:
+        target_floor = json.loads(json.dumps(self.current["account_model_mapping"]))
+        target_floor["account_overrides"] = {
+            "88": {
+                "platform": "newapi",
+                "channel_type": 45,
+                "model_mapping": {"agent-plan-model": "agent-plan-model"},
+            },
+        }
+        self.target_path, self.target = self.write_bundle("target-account.json", target_floor)
+        return self.target
 
     def test_us035_valid_evidence_builds_activation_delta(self) -> None:
         context = self.build_context()
@@ -166,7 +184,57 @@ class ModelActivationTest(unittest.TestCase):
         self.assertTrue(MODEL_OPS._account_platform_allows_scope("kiro", "kiro"))
         self.assertTrue(MODEL_OPS._account_platform_allows_scope("anthropic", "kiro"))
         self.assertTrue(MODEL_OPS._account_platform_allows_scope("newapi", "newapi_channel_type:17"))
+        self.assertTrue(MODEL_OPS._account_platform_allows_scope("newapi", "account:88"))
         self.assertFalse(MODEL_OPS._account_platform_allows_scope("kiro", "anthropic"))
+
+    def test_us035_account_override_scope_is_part_of_activation_delta(self) -> None:
+        target = self.use_account_override_target()
+        delta = MODEL_OPS._activation_delta(self.current, target)
+        self.assertEqual(
+            [row["scope"] for row in delta["activated"]],
+            ["account:88"],
+        )
+
+    def test_us035_account_override_evidence_must_match_account_id(self) -> None:
+        self.use_account_override_target()
+        self.write_evidence(
+            scope="account:88",
+            model_id="agent-plan-model",
+            target="agent-plan-model",
+            account_id="89",
+            account_platform="newapi",
+            account_scope="account:88",
+        )
+        with self.assertRaisesRegex(MODEL_OPS.ActivationError, "account_id must match"):
+            self.build_context()
+
+    def test_us035_account_override_evidence_accepts_exact_account(self) -> None:
+        self.use_account_override_target()
+        self.write_evidence(
+            scope="account:88",
+            model_id="agent-plan-model",
+            target="agent-plan-model",
+            account_id="88",
+            account_platform="newapi",
+            account_scope="account:88",
+        )
+        context = self.build_context()
+        self.assertEqual(context["delta"]["activated"][0]["scope"], "account:88")
+
+    def test_us035_v1_current_bundle_remains_readable(self) -> None:
+        legacy_floor = json.loads(json.dumps(self.current["account_model_mapping"]))
+        legacy_floor.pop("account_overrides")
+        legacy_bundle = {
+            "schema_version": 1,
+            "floor_sha256": MODEL_OPS._BUNDLE.floor_sha256(legacy_floor),
+            "account_model_mapping": legacy_floor,
+        }
+        legacy_path = self.root / "legacy-v1.json"
+        legacy_path.write_text(json.dumps(legacy_bundle), encoding="utf-8")
+        self.assertEqual(
+            MODEL_OPS._BUNDLE.load_bundle(legacy_path)["schema_version"],
+            1,
+        )
 
     def test_us035_runtime_shadow_is_rejected(self) -> None:
         with self.assertRaisesRegex(MODEL_OPS.ActivationError, "shadowed"):
@@ -275,6 +343,7 @@ class ModelActivationTest(unittest.TestCase):
         bad_floor = {
             "platforms": {"openai": {"": "bad-target"}},
             "newapi_channel_types": {},
+            "account_overrides": {},
             "antigravity_group_scopes": ["claude"],
             "forbidden_model_mapping_keys": {},
             "forbidden_model_mapping_prefixes": {},

--- a/ops/pricing/test_model_activation.py
+++ b/ops/pricing/test_model_activation.py
@@ -38,7 +38,7 @@ class ModelActivationTest(unittest.TestCase):
         current_floor = {
             "platforms": {"openai": {"gpt-current": "gpt-current"}},
             "newapi_channel_types": {},
-            "account_overrides": {},
+            "account_overrides": [],
             "antigravity_group_scopes": ["claude"],
             "forbidden_model_mapping_keys": {},
             "forbidden_model_mapping_prefixes": {},
@@ -51,7 +51,7 @@ class ModelActivationTest(unittest.TestCase):
                 },
             },
             "newapi_channel_types": {},
-            "account_overrides": {},
+            "account_overrides": [],
             "antigravity_group_scopes": ["claude"],
             "forbidden_model_mapping_keys": {},
             "forbidden_model_mapping_prefixes": {},
@@ -85,6 +85,7 @@ class ModelActivationTest(unittest.TestCase):
         account_platform: str = "openai",
         account_scope: str = "openai",
         account_id: str = "test-account",
+        account_base_url: str | None = None,
         scope: str = "openai",
         model_id: str = "gpt-new",
         target: str = "gpt-new-upstream",
@@ -100,17 +101,20 @@ class ModelActivationTest(unittest.TestCase):
             "model_id": model_id,
             "target": target,
         }
+        probe_model = {
+            **model,
+            "verdict": "servable",
+            "source": probe_source,
+            "account_id": account_id,
+            "account_platform": account_platform,
+            "account_scope": account_scope,
+        }
+        if account_base_url is not None:
+            probe_model["account_base_url"] = account_base_url
         self.probe_path.write_text(json.dumps({
             **common,
             "kind": "model_activation_probe",
-            "models": [{
-                **model,
-                "verdict": "servable",
-                "source": probe_source,
-                "account_id": account_id,
-                "account_platform": account_platform,
-                "account_scope": account_scope,
-            }],
+            "models": [probe_model],
         }), encoding="utf-8")
         self.pricing_path.write_text(json.dumps({
             **common,
@@ -129,13 +133,14 @@ class ModelActivationTest(unittest.TestCase):
 
     def use_account_override_target(self) -> dict:
         target_floor = json.loads(json.dumps(self.current["account_model_mapping"]))
-        target_floor["account_overrides"] = {
-            "88": {
+        target_floor["account_overrides"] = [
+            {
                 "platform": "newapi",
                 "channel_type": 45,
+                "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3",
                 "model_mapping": {"agent-plan-model": "agent-plan-model"},
             },
-        }
+        ]
         self.target_path, self.target = self.write_bundle("target-account.json", target_floor)
         return self.target
 
@@ -184,7 +189,9 @@ class ModelActivationTest(unittest.TestCase):
         self.assertTrue(MODEL_OPS._account_platform_allows_scope("kiro", "kiro"))
         self.assertTrue(MODEL_OPS._account_platform_allows_scope("anthropic", "kiro"))
         self.assertTrue(MODEL_OPS._account_platform_allows_scope("newapi", "newapi_channel_type:17"))
-        self.assertTrue(MODEL_OPS._account_platform_allows_scope("newapi", "account:88"))
+        self.assertTrue(MODEL_OPS._account_platform_allows_scope(
+            "newapi", "account_override:newapi:45:https://ark.cn-beijing.volces.com/api/plan/v3"
+        ))
         self.assertFalse(MODEL_OPS._account_platform_allows_scope("kiro", "anthropic"))
 
     def test_us035_account_override_scope_is_part_of_activation_delta(self) -> None:
@@ -192,34 +199,38 @@ class ModelActivationTest(unittest.TestCase):
         delta = MODEL_OPS._activation_delta(self.current, target)
         self.assertEqual(
             [row["scope"] for row in delta["activated"]],
-            ["account:88"],
+            ["account_override:newapi:45:https://ark.cn-beijing.volces.com/api/plan/v3"],
         )
 
-    def test_us035_account_override_evidence_must_match_account_id(self) -> None:
+    def test_us035_account_override_evidence_must_match_base_url(self) -> None:
         self.use_account_override_target()
+        scope = "account_override:newapi:45:https://ark.cn-beijing.volces.com/api/plan/v3"
         self.write_evidence(
-            scope="account:88",
+            scope=scope,
             model_id="agent-plan-model",
             target="agent-plan-model",
             account_id="89",
             account_platform="newapi",
-            account_scope="account:88",
+            account_scope=scope,
+            account_base_url="https://ark.cn-beijing.volces.com/api/v3",
         )
-        with self.assertRaisesRegex(MODEL_OPS.ActivationError, "account_id must match"):
+        with self.assertRaisesRegex(MODEL_OPS.ActivationError, "account_base_url"):
             self.build_context()
 
-    def test_us035_account_override_evidence_accepts_exact_account(self) -> None:
+    def test_us035_account_override_evidence_accepts_selector_without_account_id_binding(self) -> None:
         self.use_account_override_target()
+        scope = "account_override:newapi:45:https://ark.cn-beijing.volces.com/api/plan/v3"
         self.write_evidence(
-            scope="account:88",
+            scope=scope,
             model_id="agent-plan-model",
             target="agent-plan-model",
-            account_id="88",
+            account_id="89",
             account_platform="newapi",
-            account_scope="account:88",
+            account_scope=scope,
+            account_base_url="https://ark.cn-beijing.volces.com/api/plan/v3/",
         )
         context = self.build_context()
-        self.assertEqual(context["delta"]["activated"][0]["scope"], "account:88")
+        self.assertEqual(context["delta"]["activated"][0]["scope"], scope)
 
     def test_us035_v1_current_bundle_remains_readable(self) -> None:
         legacy_floor = json.loads(json.dumps(self.current["account_model_mapping"]))
@@ -235,6 +246,24 @@ class ModelActivationTest(unittest.TestCase):
             MODEL_OPS._BUNDLE.load_bundle(legacy_path)["schema_version"],
             1,
         )
+
+    def test_us035_id_keyed_schema_v2_is_rejected(self) -> None:
+        legacy_floor = json.loads(json.dumps(self.current["account_model_mapping"]))
+        legacy_floor["account_overrides"] = {
+            "88": {
+                "platform": "newapi",
+                "channel_type": 45,
+                "model_mapping": {"agent-plan-model": "agent-plan-model"},
+            },
+        }
+        legacy_path = self.root / "legacy-v2-id-keyed.json"
+        legacy_path.write_text(json.dumps({
+            "schema_version": 2,
+            "floor_sha256": MODEL_OPS._BUNDLE.floor_sha256(legacy_floor),
+            "account_model_mapping": legacy_floor,
+        }), encoding="utf-8")
+        with self.assertRaisesRegex(RuntimeError, "unsupported model surface bundle schema"):
+            MODEL_OPS._BUNDLE.load_bundle(legacy_path)
 
     def test_us035_runtime_shadow_is_rejected(self) -> None:
         with self.assertRaisesRegex(MODEL_OPS.ActivationError, "shadowed"):
@@ -343,7 +372,7 @@ class ModelActivationTest(unittest.TestCase):
         bad_floor = {
             "platforms": {"openai": {"": "bad-target"}},
             "newapi_channel_types": {},
-            "account_overrides": {},
+            "account_overrides": [],
             "antigravity_group_scopes": ["claude"],
             "forbidden_model_mapping_keys": {},
             "forbidden_model_mapping_prefixes": {},

--- a/ops/stage0/probe_account_upstream_models.sh
+++ b/ops/stage0/probe_account_upstream_models.sh
@@ -31,6 +31,7 @@ from urllib.request import HTTPRedirectHandler, HTTPSHandler, Request, build_ope
 account_id, base_url, target_models_raw, model, timeout_raw = sys.argv[1:6]
 targets = target_models_raw.split()
 timeout = int(timeout_raw)
+VOLCENGINE_AGENT_PLAN_BASE_URL = "https://ark.cn-beijing.volces.com/api/plan/v3"
 
 def setup_error(message):
     print(json.dumps({"verdict": "setup_error", "error": message}, ensure_ascii=False))
@@ -125,6 +126,11 @@ def derive_account_scope(row):
     if platform == "newapi":
         channel_type = account.get("channel_type")
         if isinstance(channel_type, int) and channel_type > 0:
+            if (
+                channel_type == 45
+                and account_base_url == VOLCENGINE_AGENT_PLAN_BASE_URL
+            ):
+                return f"account_override:{platform}:{channel_type}:{account_base_url}"
             return f"newapi_channel_type:{channel_type}"
     return platform
 

--- a/ops/stage0/probe_account_upstream_models.sh
+++ b/ops/stage0/probe_account_upstream_models.sh
@@ -130,6 +130,7 @@ def derive_account_scope(row):
 
 
 account_platform = str(account.get("platform") or "").strip().lower()
+account_base_url = str(account.get("base_url") or "").strip().lower().rstrip("/")
 account_scope = derive_account_scope(account)
 if not account_platform or not account_scope:
     setup_error("account platform/scope metadata is incomplete")
@@ -187,6 +188,7 @@ if model:
         "probe": "account_test",
         "account_id": int(account_id),
         "account_platform": account_platform,
+        "account_base_url": account_base_url,
         "account_scope": account_scope,
         "model": model,
         "http_status": status,
@@ -214,6 +216,7 @@ out = {
     "verdict": verdict,
     "account_id": int(account_id),
     "account_platform": account_platform,
+    "account_base_url": account_base_url,
     "account_scope": account_scope,
     "http_status": status,
     "model_count": len(models),

--- a/ops/stage0/test_probe_account_upstream_models.py
+++ b/ops/stage0/test_probe_account_upstream_models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 import tempfile
 import threading
@@ -34,19 +35,37 @@ class _Server:
 
 
 class ProbeAccountUpstreamModelsTest(unittest.TestCase):
-    def run_probe(self, *, base_url: str, model: str = "", targets: str = "") -> dict:
+    def run_probe(
+        self,
+        *,
+        base_url: str,
+        model: str = "",
+        targets: str = "",
+        account_id: str = "19",
+        account: dict | None = None,
+    ) -> dict:
+        if account is None:
+            account = {
+                "name": "kiro-us3",
+                "platform": "anthropic",
+                "type": "apikey",
+                "channel_type": 0,
+                "mirror_platform": "kiro",
+                "base_url": "https://api-us3.tokenkey.dev",
+            }
+        bootstrap = json.dumps({"admin_key": "test-admin-key", "account": account})
         with tempfile.TemporaryDirectory() as tmp:
             fake_sudo = Path(tmp) / "sudo"
             fake_sudo.write_text(
                 "#!/bin/sh\n"
-                "printf '%s\\n' '{\"admin_key\":\"test-admin-key\",\"account\":{\"name\":\"kiro-us3\",\"platform\":\"anthropic\",\"type\":\"apikey\",\"channel_type\":0,\"mirror_platform\":\"kiro\",\"base_url\":\"https://api-us3.tokenkey.dev\"}}'\n",
+                f"printf '%s\\n' {shlex.quote(bootstrap)}\n",
                 encoding="utf-8",
             )
             fake_sudo.chmod(0o755)
             env = {
                 **os.environ,
                 "PATH": f"{tmp}:{os.environ.get('PATH', '')}",
-                "ACCOUNT_ID": "19",
+                "ACCOUNT_ID": account_id,
                 "BASE_URL": base_url,
                 "MODEL": model,
                 "TARGET_MODELS": targets,
@@ -103,6 +122,77 @@ class ProbeAccountUpstreamModelsTest(unittest.TestCase):
         self.assertEqual(got["account_scope"], "kiro")
         self.assertEqual(seen["key"], "test-admin-key")
         self.assertEqual(seen["path"], "/api/v1/admin/accounts/19/models/sync-upstream")
+
+    def test_agent_plan_scope_uses_properties_not_account_id(self):
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                payload = {"data": {"models": ["ark-code-latest"]}}
+                body = json.dumps(payload).encode()
+                self.send_response(200)
+                self.send_header("content-type", "application/json")
+                self.send_header("content-length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_args):
+                pass
+
+        account = {
+            "name": "volcengine-agent-plan-secondary",
+            "platform": "newapi",
+            "type": "apikey",
+            "channel_type": 45,
+            "mirror_platform": "",
+            "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3/",
+        }
+        with _Server(Handler) as server:
+            got = self.run_probe(
+                base_url=server.base_url,
+                targets="ark-code-latest",
+                account_id="89",
+                account=account,
+            )
+        self.assertEqual(got["account_id"], 89)
+        self.assertEqual(got["account_platform"], "newapi")
+        self.assertEqual(
+            got["account_scope"],
+            "account_override:newapi:45:https://ark.cn-beijing.volces.com/api/plan/v3",
+        )
+        self.assertEqual(
+            got["account_base_url"],
+            "https://ark.cn-beijing.volces.com/api/plan/v3",
+        )
+
+    def test_volcengine_payg_scope_stays_channel_floor(self):
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                payload = {"data": {"models": ["doubao-seed-1-6"]}}
+                body = json.dumps(payload).encode()
+                self.send_response(200)
+                self.send_header("content-type", "application/json")
+                self.send_header("content-length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_args):
+                pass
+
+        account = {
+            "name": "volcengine-payg-secondary",
+            "platform": "newapi",
+            "type": "apikey",
+            "channel_type": 45,
+            "mirror_platform": "",
+            "base_url": "https://ark.cn-beijing.volces.com/api/v3/",
+        }
+        with _Server(Handler) as server:
+            got = self.run_probe(
+                base_url=server.base_url,
+                targets="doubao-seed-1-6",
+                account_id="89",
+                account=account,
+            )
+        self.assertEqual(got["account_scope"], "newapi_channel_type:45")
 
     def test_direct_account_test_parses_successful_sse(self):
         class Handler(BaseHTTPRequestHandler):

--- a/scripts/checks/catalog-serving-drift.py
+++ b/scripts/checks/catalog-serving-drift.py
@@ -85,6 +85,7 @@ REQUIRED_FIELDS = {
     "display": bool,
 }
 VALID_PRICE_SOURCES = {"overlay", "mirror", "channel"}
+ACCOUNT_SCOPE_FIELDS = {"platform", "channel_type", "base_url"}
 
 
 # --------------------------------------------------------------------------- helpers
@@ -189,6 +190,44 @@ def evaluate(
                 f"{key}: price_source {entry['price_source']!r} not in {sorted(VALID_PRICE_SOURCES)}"
             )
             continue
+
+        account_scope = entry.get("account_scope")
+        if account_scope is not None:
+            if not isinstance(account_scope, dict):
+                errors.append(f"{key}: account_scope must be an object")
+                continue
+            missing_scope = sorted(ACCOUNT_SCOPE_FIELDS - set(account_scope))
+            unknown_scope = sorted(set(account_scope) - ACCOUNT_SCOPE_FIELDS)
+            if missing_scope:
+                errors.append(f"{key}: account_scope omitted fields: " + ", ".join(missing_scope))
+                continue
+            if unknown_scope:
+                errors.append(f"{key}: account_scope has unknown fields: " + ", ".join(unknown_scope))
+                continue
+            scope_platform = account_scope["platform"]
+            scope_channel_type = account_scope["channel_type"]
+            scope_base_url = account_scope["base_url"]
+            if (
+                not isinstance(scope_platform, str)
+                or not scope_platform.strip()
+                or scope_platform != scope_platform.strip().lower()
+            ):
+                errors.append(f"{key}: account_scope.platform must be a normalized non-empty string")
+                continue
+            if (
+                not isinstance(scope_channel_type, int)
+                or isinstance(scope_channel_type, bool)
+                or scope_channel_type <= 0
+            ):
+                errors.append(f"{key}: account_scope.channel_type must be a positive integer")
+                continue
+            if (
+                not isinstance(scope_base_url, str)
+                or not scope_base_url.strip()
+                or scope_base_url != scope_base_url.strip().lower().rstrip("/")
+            ):
+                errors.append(f"{key}: account_scope.base_url must be a normalized non-empty string")
+                continue
 
         platform = entry["platform"]
         model_id = entry["model_id"]
@@ -350,6 +389,10 @@ def _selftest() -> int:
             "platform": "newapi", "model_id": "activation-chat", "served_on": ["60"],
             "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
             "display": False, "notes": "pre-release served-via-modelops-activation",
+            "account_scope": {
+                "platform": "newapi", "channel_type": 45,
+                "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3",
+            },
         },
     }
     errs, warns = run(pass_entries)
@@ -370,6 +413,13 @@ def _selftest() -> int:
     }})
     if not any("must be int, got bool" in e for e in errs):
         failures.append("A0: channel_type bool-as-int not flagged")
+    errs, _ = run({"newapi/bad-scope": {
+        "platform": "newapi", "model_id": "good-chat", "served_on": ["60"],
+        "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
+        "display": False, "account_scope": {"platform": "newapi", "channel_type": 45},
+    }})
+    if not any("account_scope omitted fields" in e for e in errs):
+        failures.append("A0: incomplete account_scope not flagged")
 
     # --- A1: overlay price missing / zero --------------------------------------
     errs, _ = run({"newapi/absent": {

--- a/scripts/checks/ssot-delta-gate.py
+++ b/scripts/checks/ssot-delta-gate.py
@@ -175,7 +175,7 @@ def manifest_delta_models(base: str) -> set[str]:
         if not base_entry.get("display"):
             out.add(model_id)
             continue
-        for field in ("model_id", "served_on", "price_source", "price_key", "display"):
+        for field in ("model_id", "served_on", "channel_type", "account_scope", "price_source", "price_key", "display"):
             if base_entry.get(field) != head.get(field):
                 out.add(model_id)
                 break

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2191,6 +2191,7 @@
         "runtime.newAPIChannelTypes[account.ChannelType]",
         "ForbiddenModelMappingKeys",
         "ForbiddenModelMappingPrefixes",
+        "AccountOverrides",
         "ModelSurfaceBundleSchemaVersion",
         "func ModelSurfaceBundleForOps(",
         "func canonicalModelSurfaceFloorJSON(",
@@ -2367,6 +2368,7 @@
         "LOCK TABLE settings IN SHARE ROW EXCLUSIVE MODE",
         "def _command_with_bundle(",
         "forbidden_model_mapping_keys",
+        "account override identity mismatch",
         "\"account_bulk_changed\"",
         "\"group_changed\""
       ],
@@ -2375,7 +2377,7 @@
         "--ssot-repo-root",
         "--allow-extra-model-mapping"
       ],
-      "rationale": "Explicit ops check/apply surfaces for account model_mapping. The script must consume the checksummed bundle without Go/source discovery, use one required-floor + forbidden-policy rule, preserve compatible extras, keep check-accounts read-only, scope release-gate to explicit model activation, require confirmation before writes, update only model_mapping/group scopes, and enqueue scheduler outbox events. Activation pins the resolved prod instance and rechecks runtime-shadow absence under a settings-table lock before writes. Generic deploy wiring is prohibited by the workflow sentinel above, while direct Edge diagnostics/apply remain available."
+      "rationale": "Explicit ops check/apply surfaces for account model_mapping. The script must consume the checksummed bundle without Go/source discovery, prioritize account-specific overrides over shared platform/channel floors, fail closed on account identity mismatch, use one required-floor + forbidden-policy rule, preserve compatible extras, keep check-accounts read-only, scope release-gate to explicit model activation, require confirmation before writes, update only model_mapping/group scopes, and enqueue scheduler outbox events. Activation pins the resolved prod instance and rechecks runtime-shadow absence under a settings-table lock before writes. Generic deploy wiring is prohibited by the workflow sentinel above, while direct Edge diagnostics/apply remain available."
     },
     {
       "path": "backend/cmd/account-model-mapping/main.go",
@@ -2395,7 +2397,9 @@
     {
       "path": "ops/pricing/model_surface_bundle.py",
       "must_contain": [
-        "SCHEMA_VERSION = 1",
+        "SCHEMA_VERSION = 2",
+        "SUPPORTED_SCHEMA_VERSIONS",
+        "account_overrides",
         "def canonical_json(",
         "def floor_sha256(",
         "def _validate_floor(",
@@ -2413,6 +2417,7 @@
         "def build_activation_context(",
         "kind=\"model_activation_probe\"",
         "kind=\"model_activation_pricing\"",
+        "f\"account:{account_id}\"",
         "def _mapping_manager_command(",
         "\"apply-accounts\", \"--target\", \"prod\"",
         "def _require_unshadowed_activation_bundle(",
@@ -2427,13 +2432,17 @@
       "must_contain": [
         "test_us035_valid_evidence_builds_activation_delta",
         "test_us035_invalid_evidence_is_rejected",
+        "test_us035_account_override_scope_is_part_of_activation_delta",
+        "test_us035_account_override_evidence_must_match_account_id",
+        "test_us035_account_override_evidence_accepts_exact_account",
+        "test_us035_v1_current_bundle_remains_readable",
         "test_us035_runtime_shadow_is_rejected",
         "test_us035_runtime_shadow_stops_before_apply",
         "test_us035_commands_are_prod_only_and_confirmed",
         "test_us035_confirmed_apply_pins_instance_and_requires_post_gate",
         "test_us035_self_digested_invalid_bundle_is_rejected"
       ],
-      "rationale": "Focused offline Story tests for activation success, stale/mismatched/non-independent evidence, runtime shadow rejection, prod-only confirmed writes, and semantic bundle validation. Preflight executes this file directly."
+      "rationale": "Focused offline Story tests for activation success, stale/mismatched/non-independent evidence, account-specific scope/evidence binding, runtime shadow rejection, prod-only confirmed writes, and semantic bundle validation. Preflight executes this file directly."
     },
     {
       "path": ".github/workflows/release.yml",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2192,6 +2192,7 @@
         "ForbiddenModelMappingKeys",
         "ForbiddenModelMappingPrefixes",
         "AccountOverrides",
+        "BaseURL",
         "ModelSurfaceBundleSchemaVersion",
         "func ModelSurfaceBundleForOps(",
         "func canonicalModelSurfaceFloorJSON(",
@@ -2368,7 +2369,7 @@
         "LOCK TABLE settings IN SHARE ROW EXCLUSIVE MODE",
         "def _command_with_bundle(",
         "forbidden_model_mapping_keys",
-        "account override identity mismatch",
+        "_BUNDLE.account_override_scope",
         "\"account_bulk_changed\"",
         "\"group_changed\""
       ],
@@ -2377,7 +2378,7 @@
         "--ssot-repo-root",
         "--allow-extra-model-mapping"
       ],
-      "rationale": "Explicit ops check/apply surfaces for account model_mapping. The script must consume the checksummed bundle without Go/source discovery, prioritize account-specific overrides over shared platform/channel floors, fail closed on account identity mismatch, use one required-floor + forbidden-policy rule, preserve compatible extras, keep check-accounts read-only, scope release-gate to explicit model activation, require confirmation before writes, update only model_mapping/group scopes, and enqueue scheduler outbox events. Activation pins the resolved prod instance and rechecks runtime-shadow absence under a settings-table lock before writes. Generic deploy wiring is prohibited by the workflow sentinel above, while direct Edge diagnostics/apply remain available."
+      "rationale": "Explicit ops check/apply surfaces for account model_mapping. The script must consume the checksummed bundle without Go/source discovery, prioritize property-selected account overrides over shared platform/channel floors, select VolcEngine Agent Plan by platform/channel/base_url rather than account ID, use one required-floor + forbidden-policy rule, preserve compatible extras, keep check-accounts read-only, scope release-gate to explicit model activation, require confirmation before writes, update only model_mapping/group scopes, and enqueue scheduler outbox events. Activation pins the resolved prod instance and rechecks runtime-shadow absence under a settings-table lock before writes. Generic deploy wiring is prohibited by the workflow sentinel above, while direct Edge diagnostics/apply remain available."
     },
     {
       "path": "backend/cmd/account-model-mapping/main.go",
@@ -2397,7 +2398,7 @@
     {
       "path": "ops/pricing/model_surface_bundle.py",
       "must_contain": [
-        "SCHEMA_VERSION = 2",
+        "SCHEMA_VERSION = 3",
         "SUPPORTED_SCHEMA_VERSIONS",
         "account_overrides",
         "def canonical_json(",
@@ -2417,7 +2418,8 @@
         "def build_activation_context(",
         "kind=\"model_activation_probe\"",
         "kind=\"model_activation_pricing\"",
-        "f\"account:{account_id}\"",
+        "account_override_scope",
+        "account_base_url",
         "def _mapping_manager_command(",
         "\"apply-accounts\", \"--target\", \"prod\"",
         "def _require_unshadowed_activation_bundle(",
@@ -2433,8 +2435,9 @@
         "test_us035_valid_evidence_builds_activation_delta",
         "test_us035_invalid_evidence_is_rejected",
         "test_us035_account_override_scope_is_part_of_activation_delta",
-        "test_us035_account_override_evidence_must_match_account_id",
-        "test_us035_account_override_evidence_accepts_exact_account",
+        "test_us035_account_override_evidence_must_match_base_url",
+        "test_us035_account_override_evidence_accepts_selector_without_account_id_binding",
+        "test_us035_id_keyed_schema_v2_is_rejected",
         "test_us035_v1_current_bundle_remains_readable",
         "test_us035_runtime_shadow_is_rejected",
         "test_us035_runtime_shadow_stops_before_apply",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -316,7 +316,7 @@
         "parseWhitelistFromCredentials",
         "buildAccountFallbackEntry"
       ],
-      "rationale": "Post-#325/#326 bridge: /api/v1/me/pricing-catalog (Your Menu) falls back to account credentials when no channel pricing covers the target group. NewAPIModelDisplayIDsForAccount preserves the existing channel-type display projection while selecting Agent Plan rows by served_on account membership, preventing shared channel types from dropping valid account-88 models or leaking them into account 7."
+      "rationale": "Post-#325/#326 bridge: /api/v1/me/pricing-catalog (Your Menu) falls back to account credentials when no channel pricing covers the target group. NewAPIModelDisplayIDsForAccount preserves the existing channel-type display projection while selecting Agent Plan rows by platform/channel_type/base_url; served_on is historical evidence only. This prevents shared channel types from dropping valid Agent Plan models or leaking them into pay-as-you-go accounts."
     },
     {
       "path": "backend/internal/service/openai_account_scheduler.go",
@@ -576,7 +576,7 @@
         "VolcEngineAgentPlanBaseKey",
         "/api/plan/v3"
       ],
-      "rationale": "Canonicalizes Agent Plan /api/plan/* credential shapes to the doubao-agent-plan magic key consumed by new-api ChannelSpecialBases."
+      "rationale": "Canonicalizes legacy Agent Plan aliases and pasted /api/plan/* endpoint shapes to the native /api/plan/v3 root. TokenKey routing must not depend on a new-api fork or ChannelSpecialBases entry."
     },
     {
       "path": "backend/internal/service/account_model_mapping_preset_tk.go",
@@ -609,6 +609,31 @@
         "tkRespondNewAPIAgentPlanAvailableModelsWhenMappingEmpty"
       ],
       "rationale": "Admin GetAvailableModels empty-mapping path for Agent Plan accounts; keeps upstream account_handler.go to a one-line call site."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_count_tokens.go",
+      "must_contain": [
+        "nativeOpenAIBaseURLForAccount(account)",
+        "buildOpenAIResponsesInputTokensURL(validatedURL)"
+      ],
+      "rationale": "Anthropic-compatible count_tokens can select property-scoped Agent Plan accounts. It must reuse the native OpenAI-compatible base resolver so Ark credentials go to /api/plan/v3/responses/input_tokens instead of falling through to api.openai.com and producing a false credential failure."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_provider_mismatch.go",
+      "must_contain": [
+        "tkIsNewAPIAgentPlanOpenAIProviderMismatch",
+        "platform.openai.com/account/api-keys",
+        "isNewAPIVolcEngineAgentPlanAccount(account)"
+      ],
+      "rationale": "A property-scoped Agent Plan account receiving OpenAI's official API-key help text proves provider misrouting, not an invalid Ark credential. This classifier is the account-health safety interlock that prevents such routing defects from permanently disabling the account."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "tkIsNewAPIAgentPlanOpenAIProviderMismatch(account, statusCode, responseBody)",
+        "newapi_agent_plan_provider_mismatch_skip_penalty"
+      ],
+      "rationale": "HandleUpstreamError must consult the Agent Plan provider-mismatch interlock before generic 401 handling. Removing this call silently restores SetError plus the false permanent-auth Feishu alert even if the classifier file still compiles."
     }
   ]
 }

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -581,12 +581,11 @@
     {
       "path": "backend/internal/service/account_model_mapping_preset_tk.go",
       "must_contain": [
-        "newAPIVolcEngineAgentPlanAccountID",
         "accountModelMappingOverrideAccounts",
         "NewAPIModelDisplayIDsForAccount",
-        "tkServedModelsManifestPresetIDsForAccount"
+        "tkServedModelsManifestPresetIDsForSelector"
       ],
-      "rationale": "Agent Plan admin preset, model-surface account override, and default probe model derive from the account-aware registry plus manifest served_on projection, not hardcoded model lists or ch45 channel-wide presets that mix pay-as-you-go account 7."
+      "rationale": "Agent Plan admin preset, model-surface account override, and default probe model derive from the platform/channel/base_url property selector, not an account-id registry or ch45 channel-wide preset that mixes pay-as-you-go account 7."
     },
     {
       "path": "backend/internal/service/account_test_service_tk_newapi_volcagentplan.go",
@@ -598,10 +597,11 @@
     {
       "path": "backend/internal/service/tk_served_models_manifest_tk.go",
       "must_contain": [
-        "tkServedModelsManifestPresetIDsForAccount",
-        "tkServedModelsManifestDisplayPresetIDsForAccount"
+        "tkServedModelsManifestPresetIDsForSelector",
+        "tkServedModelsManifestDisplayPresetIDsForSelector",
+        "account_scope"
       ],
-      "rationale": "Account-specific manifest projections keep Agent Plan user menus aligned with served_on/display even when shared channel_type values describe another upstream adaptor."
+      "rationale": "Property-scoped manifest projections keep Agent Plan user menus aligned with platform/channel/base_url while served_on remains evidence only, even when canonical channel_type values describe another upstream adaptor."
     },
     {
       "path": "backend/internal/handler/admin/account_handler_tk_volcagentplan.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -581,10 +581,12 @@
     {
       "path": "backend/internal/service/account_model_mapping_preset_tk.go",
       "must_contain": [
+        "newAPIVolcEngineAgentPlanAccountID",
+        "accountModelMappingOverrideAccounts",
         "NewAPIModelDisplayIDsForAccount",
         "tkServedModelsManifestPresetIDsForAccount"
       ],
-      "rationale": "Agent Plan admin preset + default probe model derive from manifest served_on, not hardcoded lists or ch45 channel-wide presets that mix pay-as-you-go account 7."
+      "rationale": "Agent Plan admin preset, model-surface account override, and default probe model derive from the account-aware registry plus manifest served_on projection, not hardcoded model lists or ch45 channel-wide presets that mix pay-as-you-go account 7."
     },
     {
       "path": "backend/internal/service/account_test_service_tk_newapi_volcagentplan.go",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -103,7 +103,7 @@
         "func isTkCuratedNewAPIModelListed(",
         "func isTkCuratedNewAPIModelDisplayed(",
         "func tkServedModelsManifestDisplayPresetIDsByChannelType(",
-        "func tkServedModelsManifestDisplayPresetIDsForAccount(",
+        "func tkServedModelsManifestDisplayPresetIDsForSelector(",
         "func isTkCuratedNewAPICatalogRowDisplayed(",
         "func isNewAPILongTailCatalogVendor("
       ],


### PR DESCRIPTION
## 摘要
- 修复 model-surface bundle/checker 对 provider-property account override 的支持。
- `account_overrides` 不再按账号 ID 命中，改为同时匹配 `platform`、`channel_type` 和规范化后的 `base_url`。
- VolcEngine Agent Plan 使用 `newapi + channel_type:45 + https://ark.cn-beijing.volces.com/api/plan/v3` selector；账号 ID 仅保留为历史探测 evidence。
- 修复 Agent Plan 在 `/v1/messages/count_tokens` 被错误回退到 `api.openai.com` 的路由，统一使用原生 Ark base URL 与 API key resolver。
- 增加 provider-mismatch 安全保护：属性 scope 命中的 Agent Plan 若收到 OpenAI 官方 API-key 401 文案，只记录路由故障，不再永久禁用账号或触发错误的认证失效告警。
- bundle schema 升级到 v3；兼容读取 schema v1 current bundle，明确拒绝旧的 ID-keyed schema v2。
- 未修改 `new-api` 或 `.new-api-ref`，现有 fork pin 保持不变。

## 风险
- modelops override 仍是完整替换 scope；selector 不匹配时继续使用 channel floor，避免账号 ID 复用或共享 channel type 造成误命中。
- provider-mismatch 保护仅匹配 `newapi + VolcEngine ch45 + /api/plan/v3` 且响应同时包含 OpenAI 官方 key 错误和帮助 URL；真实 Ark 401 仍永久禁用。
- `docs/approved/model-surface-activation-contract.md` 的修改是有意的契约修订。
- 无 Web surface 变更（no-web-impact）。

## 验证
- `scripts/preflight.sh`：PASS。
- `go test -tags unit ./internal/service -count=1`：PASS。
- Agent Plan count-tokens 聚焦回归：Ark `/api/plan/v3/responses/input_tokens` 与 Bearer key 断言通过。
- 401 处罚回归：OpenAI provider-mismatch 不写 `SetError`；真实 Ark 401 和非 Agent Plan VolcEngine 401 仍写 `SetError`。
- modelops activation、bundle drift、sentinel、agent contract 等 preflight 子检查全部通过。
- 生产只读证据：`2026-07-31T03:18:34Z` 的失败入口为 `/v1/messages/count_tokens`，账号属性正确但上游返回 OpenAI 官方 401；未执行生产写入。

## 提交
- `d12784084` fix(modelops): honor account mapping overrides before channel floors (no-web-impact)
- `3c8d6c7da` fix(modelops): select account overrides by provider properties (no-web-impact)
- `6317929ec` fix(modelops): address R-001 with property-based Agent Plan probe scope (no-web-impact)
- `ff5410e38` fix(modelops): address R-002 with property-scoped Agent Plan SSOT (no-web-impact)
- `bc338cfc0` fix(newapi): prevent Agent Plan count-tokens auth poisoning (no-web-impact)
- 最新提交：`bc338cfc0`