### PR TITLE
fix(kiro): 阻止 completion 续跑 recap 重复输出

### DIFF
--- a/.testing/user-stories/stories/US-041-kiro-claude-code-completion-continuity.md
+++ b/.testing/user-stories/stories/US-041-kiro-claude-code-completion-continuity.md
@@ -19,8 +19,8 @@
 
 ## Acceptance Criteria
 
-1. **AC-001（显式完成协议）**：Given Claude Code system prompt，When 构建 Kiro payload，Then completion guard 与 transport-private completion tool 各只出现一次；有效 `complete/blocked` 信号被消费并转换为最终文本与 `end_turn`；私有 completion message 已作为完整文本块出现在同一请求可见输出中时不得重复追加。
-2. **AC-002（未完成续跑）**：Given Kiro 返回文本与 `END_TURN` 但无有效完成信号，When 流式或非流式 gateway 处理，Then 在同一客户端请求内继续 Kiro turn，直到收到完成信号或达到确定性上限。
+1. **AC-001（显式完成协议）**：Given Claude Code system prompt，When 构建 Kiro payload，Then completion guard 与 transport-private completion tool 各只出现一次；有效 `complete/blocked` 信号被消费并转换为 `end_turn`；首轮 completion message 可补齐最终答复，隐藏续跑的 `complete` 在已有可见文本时只作为内部确认，不追加普通文本或私有 message。
+2. **AC-002（未完成续跑）**：Given Kiro 返回文本与 `END_TURN` 但无有效完成信号，When 流式或非流式 gateway 处理，Then 在同一客户端请求内继续 Kiro turn，直到收到完成信号或达到确定性上限；第二轮及之后 missing-signal 的 recap、语义改写及 tool output 摘要不得进入客户端输出。
 3. **AC-003（范围与工具守卫）**：Given 普通 API 请求声明同名工具，When Kiro 调用该工具，Then 工具不得被吞；Given Claude Code 调用普通工具或同时产生普通工具与完成信号，Then 普通工具立即以 `tool_use` 返回并优先于完成信号。
 4. **AC-004（截断语义）**：Given Kiro 返回 `MAX_TOKENS` 或 `MODEL_CONTEXT_WINDOW_EXCEEDED`，When gateway 转换，Then保留对应 Anthropic stop reason，即使同一响应含私有完成信号也不得覆盖。
 5. **AC-005（policy 与 malformed 语义）**：Given Kiro 返回 policy refusal，When有可见文本时映射 `refusal`、无输出时返回客户端内容过滤错误；Given malformed/未知/空 stop reason，Then fail closed，不伪造成功结束。
@@ -33,7 +33,7 @@
 - `mapKiroStopReason` 对已知值显式映射，对空值和未知值返回 typed error。
 - JSON 与 SSE wire 分别保留 `max_tokens`；未知流式终止态不包含 `message_stop`。
 - 私有工具只在 `ClaudeCodeCompletionProtocol` 为真时被消费；空消息、普通工具或非完成 stop reason 不能提前结束。
-- 流式与非流式输出在同轮及隐藏续跑跨轮均不得重复已经可见的完整 completion message；真正互补的进度文本与最终答复继续同时保留。
+- 流式与非流式输出在同轮不得重复已经可见的完整 completion message；隐藏续跑的 missing-signal/complete 文本是 transport-only，不得把 recap、语义改写或 tool output 摘要作为第二份答复。隐藏普通工具的 text-before-tool 与真实 `blocked` 问题仍须可见。
 - sentinel 锚定共享 owner、私有协议 owner、有界续跑、范围门禁、stop metadata、结构化日志与核心回归测试。
 
 ## Linked Tests
@@ -50,6 +50,9 @@
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_CompletionSignalMessageIsPreservedAfterText`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_CompletionSignalDoesNotRepeatVisibleFinalText`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ContinuationCompletionDoesNotRepeatPriorFinalText`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_HiddenCompletionSuppressesSemanticRecapAndToolOutputSummary`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_HiddenBlockedMessageRemainsVisible`
+- `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_HiddenMaxTokensTextRemainsVisible`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_NonClaudeCodeCompletionNamedToolIsPreserved`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolUseReturnsImmediately`
 - `backend/internal/service/kiro_gateway_service_test.go`::`TestUS041_KiroGatewayService_ClaudeCodeOrdinaryToolWinsOverCompletionSignal`

--- a/backend/internal/integration/kiro/claude_code_completion.go
+++ b/backend/internal/integration/kiro/claude_code_completion.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 )
 
-const claudeCodeCompletionContinuationPrompt = `The preceding assistant response ended without the required transport completion signal, so the Claude Code turn is still active. Continue the same task now. Do not repeat or restate text from the preceding assistant response. Use the normal Claude Code tools for every remaining action. When the requested work and verification are actually complete, or progress genuinely requires user input, finish by calling sub2apiClaudeCodeCompletion with the appropriate status and a complete user-facing message.`
+const claudeCodeCompletionContinuationPrompt = `The preceding assistant response ended without the required transport completion signal, so the Claude Code turn is still active. Continue the same task now. This repair turn is transport-only unless you call a normal Claude Code tool. Do not emit a recap or repeat or restate text from the preceding assistant response. Use the normal Claude Code tools for every remaining action. If the preceding response already completed the requested work and verification, emit no additional assistant text and call sub2apiClaudeCodeCompletion with status complete, reusing the preceding user-facing answer verbatim as its message. If progress genuinely requires user input, call it with status blocked and the exact blocker question.`
 
 // ClaudeCodeCompletionSignal is emitted by the transport-private completion
 // tool. The Kiro gateway consumes it and never exposes the tool call itself to

--- a/backend/internal/integration/kiro/claude_code_completion_test.go
+++ b/backend/internal/integration/kiro/claude_code_completion_test.go
@@ -48,6 +48,9 @@ func TestPrepareClaudeCodeCompletionContinuation_PreservesToolsAndMovesTurnToHis
 
 	require.NotEqual(t, "old-continuation", payload.ConversationState.AgentContinuationId)
 	require.Contains(t, payload.ConversationState.CurrentMessage.UserInputMessage.Content, "still active")
+	require.Contains(t, payload.ConversationState.CurrentMessage.UserInputMessage.Content, "repair turn is transport-only")
+	require.Contains(t, payload.ConversationState.CurrentMessage.UserInputMessage.Content, "Do not emit a recap")
+	require.Contains(t, payload.ConversationState.CurrentMessage.UserInputMessage.Content, "reusing the preceding user-facing answer verbatim")
 	require.Len(t, payload.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext.Tools, 1)
 	require.Equal(t, claudepkg.ClaudeCodeCompletionToolName,
 		payload.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext.Tools[0].ToolSpecification.Name)

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -161,6 +161,36 @@ func shouldContinueClaudeCodeCompletion(
 		acceptsClaudeCodeCompletionSignal(rawStopReason)
 }
 
+// shouldExposeClaudeCodeContinuationText keeps transport-only completion
+// repair turns private. A continuation may expose its ordinary assistant text
+// only when it returns a real client tool or terminates for a non-completion
+// reason such as max_tokens/refusal. Missing-signal turns and accepted private
+// completion turns remain internal.
+func shouldExposeClaudeCodeContinuationText(
+	rawStopReason string,
+	clientToolUses []kiroproto.KiroToolUse,
+	completionAccepted bool,
+) bool {
+	return len(clientToolUses) > 0 ||
+		(!completionAccepted && !acceptsClaudeCodeCompletionSignal(rawStopReason))
+}
+
+// shouldExposeClaudeCodeCompletionMessage preserves the normal first-turn
+// final answer and genuine blocker questions. A later complete signal is only
+// a transport acknowledgement when client-visible text already exists, so its
+// recap/message must not become a second user-facing answer.
+func shouldExposeClaudeCodeCompletionMessage(
+	turn int,
+	visibleText string,
+	signal *kiroproto.ClaudeCodeCompletionSignal,
+	completionAccepted bool,
+) bool {
+	if !completionAccepted || signal == nil {
+		return false
+	}
+	return turn == 1 || signal.Status == "blocked" || strings.TrimSpace(visibleText) == ""
+}
+
 func completionSignalTextDelta(visibleText string, signal *kiroproto.ClaudeCodeCompletionSignal) string {
 	if signal == nil || strings.TrimSpace(signal.Message) == "" {
 		return ""
@@ -176,11 +206,9 @@ func completionSignalTextDelta(visibleText string, signal *kiroproto.ClaudeCodeC
 	return "\n\n" + message
 }
 
-// continuationTextDelta removes ordinary text that a hidden completion
-// continuation repeated verbatim from an earlier turn. Claude Code receives
-// the first turn while the gateway keeps subsequent turns internal; allowing
-// the model to restate that turn would make one assistant response appear two
-// or three times in the client transcript.
+// continuationTextDelta removes earlier text from the continuation content
+// that must remain visible before a real client tool or non-completion terminal
+// outcome. Completion-only repair text is screened before this helper runs.
 func continuationTextDelta(visibleText, continuationText string) string {
 	if strings.TrimSpace(continuationText) == "" {
 		return ""
@@ -511,9 +539,12 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, visibleToolUses, completionSignal)
 		visibleTurnText := turnText
 		if turn > 1 {
-			visibleTurnText = continuationTextDelta(textBuf, turnText)
+			visibleTurnText = ""
+			if shouldExposeClaudeCodeContinuationText(stopReason, visibleToolUses, completionAccepted) {
+				visibleTurnText = continuationTextDelta(textBuf, turnText)
+			}
 		}
-		if completionAccepted {
+		if shouldExposeClaudeCodeCompletionMessage(turn, textBuf+visibleTurnText, completionSignal, completionAccepted) {
 			visibleTurnText += completionSignalTextDelta(textBuf+visibleTurnText, completionSignal)
 		}
 		if visibleTurnText == "" && turnThinking == "" && len(turnToolUses) == 0 && textBuf == "" && thinkingBuf == "" {
@@ -789,10 +820,10 @@ func (s *KiroGatewayService) forwardStreaming(
 		completionAccepted := isAcceptedClaudeCodeCompletion(stopReason, visibleToolUses, completionSignal)
 		if turn == 1 {
 			visibleTurnText = turnText
-		} else {
+		} else if shouldExposeClaudeCodeContinuationText(stopReason, visibleToolUses, completionAccepted) {
 			flushContinuationText()
 		}
-		if completionAccepted {
+		if shouldExposeClaudeCodeCompletionMessage(turn, textBuf+visibleTurnText, completionSignal, completionAccepted) {
 			completionDelta := completionSignalTextDelta(textBuf+visibleTurnText, completionSignal)
 			if completionDelta != "" {
 				visibleTurnText += completionDelta

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -468,8 +468,8 @@ func TestUS041_KiroGatewayService_ClaudeCodeEndTurnContinuesUntilExplicitComplet
 			rec := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(rec)
 			upstream := &kiroSequenceUpstream{bodies: [][]byte{
-				kiroTextStopStream("I found the relevant code. ", "END_TURN"),
-				kiroCompletionSignalStream("complete", "Implemented and verified the fix."),
+				kiroTextStopStream("Implemented and verified the fix. ", "END_TURN"),
+				kiroCompletionSignalStream("complete", "recap: Implemented and verified the fix."),
 			}}
 
 			svc := NewKiroGatewayService(upstream, nil, nil)
@@ -477,14 +477,14 @@ func TestUS041_KiroGatewayService_ClaudeCodeEndTurnContinuesUntilExplicitComplet
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
-			require.Equal(t, 2, upstream.calls, "unfinished END_TURN must be continued inside the same client request")
+			require.Equal(t, 2, upstream.calls, "END_TURN without explicit completion must continue inside the same client request")
 			require.Len(t, upstream.requests, 2)
 			require.Contains(t, string(upstream.requests[1]), "preceding assistant response ended without the required transport completion signal")
-			require.Contains(t, string(upstream.requests[1]), "I found the relevant code.")
+			require.Contains(t, string(upstream.requests[1]), "Implemented and verified the fix.")
 
 			out := rec.Body.String()
-			require.Contains(t, out, "I found the relevant code.")
-			require.Contains(t, out, "Implemented and verified the fix.")
+			require.Equal(t, 1, strings.Count(out, "Implemented and verified the fix."))
+			require.NotContains(t, out, "recap:", "hidden complete message is transport-only once text is visible")
 			require.Contains(t, out, `"stop_reason":"end_turn"`)
 			require.NotContains(t, out, "sub2apiClaudeCodeCompletion", "private completion tool must not leak to Claude Code")
 		})
@@ -522,14 +522,14 @@ func TestUS041_KiroGatewayService_EmptyCompletionMessageWithAssistantTextDoesNot
 			gin.SetMode(gin.TestMode)
 			rec := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(rec)
-			body := buildKiroEventStreamMessage("assistantResponseEvent", []byte(`{"content":"partial progress only"}`))
+			body := buildKiroEventStreamMessage("assistantResponseEvent", []byte(`{"content":"Implemented and verified the fix."}`))
 			body = append(body, kiroToolUseEvent("toolu_completion", "sub2apiClaudeCodeCompletion", map[string]any{
 				"status": "complete", "message": "",
 			})...)
 			body = appendKiroTerminalStop(body, "TOOL_USE")
 			upstream := &kiroSequenceUpstream{bodies: [][]byte{
 				body,
-				kiroCompletionSignalStream("complete", "Implemented and verified the fix."),
+				kiroCompletionSignalStream("complete", "recap: completion confirmed."),
 			}}
 
 			svc := NewKiroGatewayService(upstream, nil, nil)
@@ -540,8 +540,8 @@ func TestUS041_KiroGatewayService_EmptyCompletionMessageWithAssistantTextDoesNot
 			require.NotNil(t, result)
 			require.Equal(t, 2, upstream.calls, "assistant text must not substitute for an empty private completion message")
 			out := rec.Body.String()
-			require.Contains(t, out, "partial progress only")
 			require.Contains(t, out, "Implemented and verified the fix.")
+			require.NotContains(t, out, "recap:", "later complete message must not become a second answer")
 			require.Contains(t, out, `"stop_reason":"end_turn"`)
 		})
 	}
@@ -660,8 +660,97 @@ func TestUS041_KiroGatewayService_ContinuationCompletionDoesNotRepeatPriorFinalT
 	}
 }
 
+func TestUS041_KiroGatewayService_HiddenCompletionSuppressesSemanticRecapAndToolOutputSummary(t *testing.T) {
+	const visibleAnswer = "盯盘已运行，当前无需进一步动作。"
+	const hiddenRecap = "recap: 已完成三窗检查。user 1 请求 57，计费 2.2547；另有 2 条客户端 400。"
+	const hiddenMessage = "三窗结果正常，定时任务下次在 :43 自动运行。"
+
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			hiddenTurn := buildKiroEventStreamMessage("assistantResponseEvent", []byte(fmt.Sprintf(`{"content":%q}`, hiddenRecap)))
+			hiddenTurn = append(hiddenTurn, kiroToolUseEvent("toolu_completion", "sub2apiClaudeCodeCompletion", map[string]any{
+				"status": "complete", "message": hiddenMessage,
+			})...)
+			hiddenTurn = appendKiroTerminalStop(hiddenTurn, "TOOL_USE")
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroTextStopStream(visibleAnswer, "END_TURN"),
+				hiddenTurn,
+			}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, 2, upstream.calls)
+			out := rec.Body.String()
+			require.Equal(t, 1, strings.Count(out, visibleAnswer))
+			require.NotContains(t, out, "recap:")
+			require.NotContains(t, out, "user 1 请求 57")
+			require.NotContains(t, out, hiddenMessage)
+			require.Contains(t, out, `"stop_reason":"end_turn"`)
+		})
+	}
+}
+
+func TestUS041_KiroGatewayService_HiddenBlockedMessageRemainsVisible(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroTextStopStream("已完成安全检查。", "END_TURN"),
+				kiroCompletionSignalStream("blocked", "需要你确认是否部署到生产。"),
+			}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			out := rec.Body.String()
+			require.Contains(t, out, "已完成安全检查。")
+			require.Contains(t, out, "需要你确认是否部署到生产。")
+			require.Contains(t, out, `"stop_reason":"end_turn"`)
+		})
+	}
+}
+
+func TestUS041_KiroGatewayService_HiddenMaxTokensTextRemainsVisible(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroTextStopStream("已开始处理。", "END_TURN"),
+				kiroTextStopStream("达到本轮输出上限前的有效结果。", "MAX_TOKENS"),
+			}}
+
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newClaudeCodeKiroParsedRequestForTest(stream), time.Now())
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			out := rec.Body.String()
+			require.Contains(t, out, "已开始处理。")
+			require.Contains(t, out, "达到本轮输出上限前的有效结果。")
+			require.Contains(t, out, `"stop_reason":"max_tokens"`)
+		})
+	}
+}
+
 func TestUS041_KiroGatewayService_ContinuationTextDoesNotRepeatAcrossTurns(t *testing.T) {
 	const summary = "清理完成，全程可回滚。\n\n## 做了什么\n\nmain 从 062c77b81 fast-forward 到 57f04ad4d。"
+	const hiddenRecap = "recap: 仓库清理已经完成；git output 显示 main 已更新到 57f04ad4d。"
+	const hiddenMessage = "最终确认：仓库状态正常。"
 	for _, stream := range []bool{false, true} {
 		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
 			gin.SetMode(gin.TestMode)
@@ -669,8 +758,8 @@ func TestUS041_KiroGatewayService_ContinuationTextDoesNotRepeatAcrossTurns(t *te
 			c, _ := gin.CreateTestContext(rec)
 			upstream := &kiroSequenceUpstream{bodies: [][]byte{
 				kiroTextStopStream(summary, "END_TURN"),
-				kiroTextStopStream(summary, "END_TURN"),
-				kiroCompletionSignalStream("complete", summary),
+				kiroTextStopStream(hiddenRecap, "END_TURN"),
+				kiroCompletionSignalStream("complete", hiddenMessage),
 			}}
 
 			svc := NewKiroGatewayService(upstream, nil, nil)
@@ -681,14 +770,17 @@ func TestUS041_KiroGatewayService_ContinuationTextDoesNotRepeatAcrossTurns(t *te
 			require.Equal(t, 3, upstream.calls)
 			require.Equal(t, 1, strings.Count(rec.Body.String(), "清理完成"))
 			require.Equal(t, 1, strings.Count(rec.Body.String(), "57f04ad4d"))
+			require.NotContains(t, rec.Body.String(), "recap:")
+			require.NotContains(t, rec.Body.String(), "git output")
+			require.NotContains(t, rec.Body.String(), hiddenMessage)
 		})
 	}
 }
 
-func TestContinuationTextDeltaKeepsOnlyNewRecapText(t *testing.T) {
+func TestContinuationTextDeltaKeepsOnlyNewToolContext(t *testing.T) {
 	visible := "清理完成，全程可回滚。\n\n## 做了什么\n\nmain 从 062c77b81 fast-forward 到 57f04ad4d。"
-	continuation := "recap: 已完成仓库清理。\n\n清理完成，全程可回滚。\n\n## 做了什么\n\nmain 从 062c77b81 fast-forward 到 57f04ad4d。"
-	require.Equal(t, "\n\nrecap: 已完成仓库清理。", continuationTextDelta(visible, continuation))
+	continuation := "调用 Read 前补充新上下文。\n\n清理完成，全程可回滚。\n\n## 做了什么\n\nmain 从 062c77b81 fast-forward 到 57f04ad4d。"
+	require.Equal(t, "\n\n调用 Read 前补充新上下文。", continuationTextDelta(visible, continuation))
 }
 
 func TestContinuationTextDeltaKeepsParagraphBoundary(t *testing.T) {
@@ -706,30 +798,34 @@ func TestCompletionSignalTextDeltaPreservesNegativeNumber(t *testing.T) {
 }
 
 func TestUS041_KiroGatewayService_ContinuationToolPreservesTextBeforeTool(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
-	toolTurn := buildKiroEventStreamMessage("assistantResponseEvent", []byte(`{"content":"new context before Read"}`))
-	toolTurn = append(toolTurn, kiroToolUseEvent("toolu_read", "Read", map[string]any{"file_path": "a.go"})...)
-	toolTurn = appendKiroTerminalStop(toolTurn, "TOOL_USE")
-	upstream := &kiroSequenceUpstream{bodies: [][]byte{
-		kiroTextStopStream("initial progress", "END_TURN"),
-		toolTurn,
-	}}
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			toolTurn := buildKiroEventStreamMessage("assistantResponseEvent", []byte(`{"content":"new context before Read"}`))
+			toolTurn = append(toolTurn, kiroToolUseEvent("toolu_read", "Read", map[string]any{"file_path": "a.go"})...)
+			toolTurn = appendKiroTerminalStop(toolTurn, "TOOL_USE")
+			upstream := &kiroSequenceUpstream{bodies: [][]byte{
+				kiroTextStopStream("initial progress", "END_TURN"),
+				toolTurn,
+			}}
 
-	svc := NewKiroGatewayService(upstream, nil, nil)
-	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
-		newKiroToolRequestForTest(true, true, "Read"), time.Now())
+			svc := NewKiroGatewayService(upstream, nil, nil)
+			result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(),
+				newKiroToolRequestForTest(stream, true, "Read"), time.Now())
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	out := rec.Body.String()
-	textIndex := strings.Index(out, "new context before Read")
-	toolIndex := strings.Index(out, `"name":"Read"`)
-	require.NotEqual(t, -1, textIndex)
-	require.NotEqual(t, -1, toolIndex)
-	require.Less(t, textIndex, toolIndex)
-	require.Contains(t, out, `"stop_reason":"tool_use"`)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			out := rec.Body.String()
+			textIndex := strings.Index(out, "new context before Read")
+			toolIndex := strings.Index(out, `"name":"Read"`)
+			require.NotEqual(t, -1, textIndex)
+			require.NotEqual(t, -1, toolIndex)
+			require.Less(t, textIndex, toolIndex)
+			require.Contains(t, out, `"stop_reason":"tool_use"`)
+		})
+	}
 }
 
 func TestUS041_KiroGatewayService_CompletionBillingCountsPrivateToolOnce(t *testing.T) {

--- a/docs/approved/kiro-claude-code-completion-continuity.md
+++ b/docs/approved/kiro-claude-code-completion-continuity.md
@@ -47,8 +47,10 @@ Claude Code 对 Anthropic stop reason 的消费语义不同：`end_turn`、
 
 - Claude Code system prompt 由共享 owner 注入完成连续性守卫：实现与验证尚未完成时继续调用工具，多步骤任务保持 task/todo 状态真实，只有需要用户输入的真实 blocker 才能提前停止。
 - Kiro system priming 对已识别的 Claude Code prompt 只注入一次共享守卫，并注入 transport-private completion tool；普通 API prompt 不启用该协议。客户端已声明同名工具时禁用私有协议，绝不遮蔽客户端工具。
-- 模型必须通过私有工具显式报告 `complete` 或 `blocked`，并提供非空的最终答复或 blocker 问题。该工具及其参数不暴露给 Claude Code。
+- 模型必须通过私有工具显式报告 `complete` 或 `blocked`，并提供非空的最终答复或 blocker 问题。该工具及其参数不暴露给 Claude Code；首轮完成信号仍可补齐尚未输出的最终答复。
 - 未收到有效完成信号的 Claude Code `END_TURN` 或只有无效私有工具的 `TOOL_USE`，在同一客户端 HTTP 请求内进入有界 Kiro 续跑；续跑上限由 service 常量统一控制，禁止无限 Agent loop。
+- 第二轮及之后属于 transport-only completion repair：缺少完成信号的普通 assistant 文本只进入续跑历史与计费，不进入客户端输出；已有首轮可见文本时，后续 `complete` 的普通文本与私有 message 都只作为内部完成证据，禁止把 recap、语义改写或 tool output 摘要拼成第二份答复。
+- 隐藏续跑产生普通 Claude Code 工具时，工具前的新文本与工具调用仍按原顺序返回客户端；`blocked` 的具体问题仍可见。隐藏续跑以 `MAX_TOKENS`、policy refusal 等非 completion 原因终止时也保留其应有的客户端错误/文本语义。
 - 普通 Claude Code 工具调用立即以 `tool_use` 返回客户端。私有完成信号与普通工具同时出现时，普通工具优先；`MAX_TOKENS` 等非完成终止原因也始终优先。
 - `CONTENT_FILTERED` 与 `GUARDRAIL_INTERVENED` 无输出时沿用客户端内容过滤错误契约；已有可见拒答文本时返回 Anthropic `refusal`。
 - 空值或未知 stop reason 不得伪造成 `end_turn`。非流式请求进入 502 failover；已开始的流式响应发送 SSE error，并且不发送成功终止事件。
@@ -82,7 +84,8 @@ Claude Code system prompt
 
 - 共享守卫幂等，并保留旧 marker 兼容既有 bridge 检测。
 - 完整 `ClaudeToKiro` payload 的 system priming 与私有工具只出现一次；普通 prompt 及同名客户端工具不受影响。
-- 流式与非流式 Claude Code 请求在首次 `END_TURN` 缺少完成信号时内部续跑，收到有效信号后只返回聚合文本与 `end_turn`。
+- 流式与非流式 Claude Code 请求在首次 `END_TURN` 缺少完成信号时内部续跑；收到隐藏 `complete` 后只保留此前已展示的答复与 `end_turn`，隐藏 recap、语义改写、tool output 摘要及 completion message 均不得追加。
+- 隐藏 `blocked` 必须保留具体问题；隐藏普通工具必须保留 text-before-tool 顺序；没有首轮可见文本时允许 completion message 作为唯一兜底答复。
 - 普通客户端工具立即返回；普通工具与完成信号并存时普通工具优先；空完成消息不能结束任务。
 - 流式与非流式 `MAX_TOKENS` 均返回 `max_tokens`；context window、policy refusal 与不支持的官方值按上表处理。
 - 未知 stop reason 在流式与非流式路径都 fail closed，且成功终止事件不会泄漏；续跑达到上限时确定性停止。

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -122,10 +122,11 @@
         "func ConsumeClaudeCodeCompletionSignal",
         "func PrepareClaudeCodeCompletionContinuation",
         "ClaudeCodeCompletionProtocol",
-        "Do not repeat or restate text",
+        "repair turn is transport-only",
+        "Do not emit a recap",
         "minLength"
       ],
-      "rationale": "Single owner for Kiro's transport-private Claude Code completion handshake. It defines the non-empty completion schema, strips only valid private signals, and creates the bounded continuation payload while preserving the normal tool catalog and explicitly forbidding restatement of prior assistant text. Losing this owner returns completion judgment to lossy stop-reason guessing, leaks private tool calls to Claude Code, or invites repeated final replies during hidden continuation."
+      "rationale": "Single owner for Kiro's transport-private Claude Code completion handshake. It defines the non-empty completion schema, strips only valid private signals, and creates the bounded continuation payload while preserving the normal tool catalog. The repair prompt explicitly keeps completion-only turns transport-private, forbids recap text, and asks an already-complete model to reuse the preceding answer verbatim. Losing this owner returns completion judgment to lossy stop-reason guessing, leaks private tool calls to Claude Code, or invites repeated final replies during hidden continuation."
     },
     {
       "path": "backend/internal/integration/kiro/claude_code_completion_test.go",
@@ -293,6 +294,8 @@
         "payload.ClaudeCodeCompletionProtocol",
         "kiroproto.ConsumeClaudeCodeCompletionSignal",
         "kiroproto.PrepareClaudeCodeCompletionContinuation",
+        "shouldExposeClaudeCodeContinuationText",
+        "shouldExposeClaudeCodeCompletionMessage",
         "completionSignalTextDelta",
         "continuationTextDelta",
         "stripCompletionMarkdownPrefix",
@@ -304,7 +307,7 @@
         "classifyAndRecordKiroForwardError",
         "publishKiroInternalThinkingSideChannel"
       ],
-      "rationale": "The sixth-platform forwarder translates /v1/messages onto Kiro EventStream and estimates usage because upstream reports credits only. The context-aware call and ResetForRetry callbacks protect retry integrity. The stop-reason mapper preserves Kiro's authoritative terminal outcome; for positively identified Claude Code payloads, the private completion signal and bounded continuation loop separate model END_TURN from agent completion. completionSignalTextDelta prevents a private completion message from repeating a complete text block already visible in the same or an earlier hidden turn, while continuationTextDelta buffers and removes ordinary assistant text repeated by later hidden turns. stripCompletionMarkdownPrefix accepts only explicit marker-plus-space decoration so semantic prefixes such as negative signs survive. flushContinuationText preserves text-before-tool ordering in SSE. Every private-tool consume/hide site is guarded by payload.ClaudeCodeCompletionProtocol so ordinary API clients retain same-name tools. billingTextBuf keeps hidden continuation output billable even when its duplicate presentation is suppressed, while private completion input is counted exactly once through billingToolUses. Both stop/completion actions remain observable, and the visible-text-aware pre-content error guard keeps failures visible instead of returning an empty 200 stream. Losing these anchors silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
+      "rationale": "The sixth-platform forwarder translates /v1/messages onto Kiro EventStream and estimates usage because upstream reports credits only. The context-aware call and ResetForRetry callbacks protect retry integrity. The stop-reason mapper preserves Kiro's authoritative terminal outcome; for positively identified Claude Code payloads, the private completion signal and bounded continuation loop separate model END_TURN from agent completion. shouldExposeClaudeCodeContinuationText and shouldExposeClaudeCodeCompletionMessage make repair turns deterministic control-plane traffic: missing-signal and later complete recap/message text stays hidden, while ordinary client tools, non-completion terminal outcomes, first-turn answers, empty-visible-output fallbacks, and blocked questions remain visible. completionSignalTextDelta and continuationTextDelta still protect same-turn and text-before-tool boundaries; stripCompletionMarkdownPrefix accepts only explicit marker-plus-space decoration so semantic prefixes such as negative signs survive. flushContinuationText preserves text-before-tool ordering in SSE. Every private-tool consume/hide site is guarded by payload.ClaudeCodeCompletionProtocol so ordinary API clients retain same-name tools. billingTextBuf keeps hidden continuation output billable even when presentation is suppressed, while private completion input is counted exactly once through billingToolUses. Both stop/completion actions remain observable, and the visible-text-aware pre-content error guard keeps failures visible instead of returning an empty 200 stream. Losing these anchors silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
     },
     {
       "path": "backend/internal/service/kiro_gateway_service_test.go",
@@ -328,8 +331,11 @@
         "TestUS041_KiroGatewayService_CompletionSignalMessageIsPreservedAfterText",
         "TestUS041_KiroGatewayService_CompletionSignalDoesNotRepeatVisibleFinalText",
         "TestUS041_KiroGatewayService_ContinuationCompletionDoesNotRepeatPriorFinalText",
+        "TestUS041_KiroGatewayService_HiddenCompletionSuppressesSemanticRecapAndToolOutputSummary",
+        "TestUS041_KiroGatewayService_HiddenBlockedMessageRemainsVisible",
+        "TestUS041_KiroGatewayService_HiddenMaxTokensTextRemainsVisible",
         "TestUS041_KiroGatewayService_ContinuationTextDoesNotRepeatAcrossTurns",
-        "TestContinuationTextDeltaKeepsOnlyNewRecapText",
+        "TestContinuationTextDeltaKeepsOnlyNewToolContext",
         "TestContinuationTextDeltaKeepsParagraphBoundary",
         "TestCompletionSignalTextDeltaPreservesNegativeNumber",
         "TestUS041_KiroGatewayService_ContinuationToolPreservesTextBeforeTool",


### PR DESCRIPTION
## 摘要

- 补强 #1499、#1503 后的 Kiro completion 修复续跑：首轮已有可见答案时，不再把后续 recap、tool output 摘要或 complete message 再输出给 Claude Code。
- 保留真实 blocked 问题、普通客户端工具、工具前文本以及 MAX_TOKENS 等非 completion 终止结果；隐藏内容仍正常计费。
- 收紧续跑提示词，并同步回归测试、Story、审批基线与 Kiro sentinel。

## 风险

- 改动覆盖流式和非流式输出筛选；主要风险是误隐藏真实续跑内容，已用可见工具、blocked、非 completion stop reason 等反向场景约束。
- docs/approved 变更是有意的行为基线修订，请 reviewer 一并确认。
- no-web-impact：仅修改 Kiro 到 Claude Code 的后端传输行为，不涉及 Web 页面、配置或前端契约。

## 验证

- PREFLIGHT_BASE=origin/main bash scripts/preflight.sh
- Kiro sentinel 81/81 通过。
- internal/pkg/claude、internal/integration/kiro、internal/service 相关 Go 测试通过。
- Story quality、agent contract export/check 通过。

## 提交

- 366cd53a9 fix(kiro): 隐藏 completion 续跑 recap (no-web-impact)

最新提交：366cd53a9