### PR TITLE
fix(ops): 恢复 edge 外探告警与主机内存飞书

### DIFF
--- a/.github/workflows/edge-health-watch.yml
+++ b/.github/workflows/edge-health-watch.yml
@@ -50,34 +50,34 @@ concurrency:
 jobs:
   watch:
     runs-on: ubuntu-latest
-    # >= worst-case scan (10 targets x SCAN_PROBE_TIMEOUT) + setup. The scan caps each
-    # probe at SCAN_PROBE_TIMEOUT below so a fully-degraded SSM cycle cannot run past
-    # this and get the job killed mid-scan (which would drop the alert + state save).
+    # The workflow contract check proves this budget covers the current target matrix,
+    # both per-target timeouts, and setup headroom.
     timeout-minutes: 15
     env:
       OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
       AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
       SINCE: ${{ inputs.since || '2h' }}
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
-      SCAN_PROBE_TIMEOUT: "60" # per-edge SSM timeout; 10 targets x 60s = 600s < job timeout
+      SCAN_PROBE_TIMEOUT: "60"
+      SCAN_HTTPS_TIMEOUT: "8"
       FEISHU_WEBHOOK_URL: ${{ secrets.TK_FEISHU_WEBHOOK_URL }}
       FEISHU_SIGNING_SECRET: ${{ secrets.TK_FEISHU_SIGNING_SECRET }}
     steps:
       - uses: actions/checkout@v6
 
-      - name: Precheck OIDC role
-        id: precheck
+      - name: Check required configuration
         run: |
           set -euo pipefail
           if [ -z "${OIDC_ROLE_ARN:-}" ]; then
-            echo "::warning::AWS_OIDC_ROLE_ARN repo variable is empty — edge-health-watch cannot reach SSM; skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "::error::AWS_OIDC_ROLE_ARN repo variable is empty — edge-health-watch cannot reach SSM."
+            exit 1
+          fi
+          if [ "$DRY_RUN" != "true" ] && { [ -z "${FEISHU_WEBHOOK_URL:-}" ] || [ -z "${FEISHU_SIGNING_SECRET:-}" ]; }; then
+            echo "::error::TK_FEISHU_WEBHOOK_URL / TK_FEISHU_SIGNING_SECRET must be set for live watches."
+            exit 1
           fi
 
       - name: Restore previous state key
-        if: steps.precheck.outputs.skip == 'false'
         uses: actions/cache/restore@v4
         with:
           path: .edge-health-state
@@ -86,88 +86,45 @@ jobs:
             edge-health-watch-state-
 
       - name: Configure AWS credentials via OIDC
-        if: steps.precheck.outputs.skip == 'false'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.OIDC_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Scan fleet edge health (read-only SSM)
-        if: steps.precheck.outputs.skip == 'false'
-        id: scan
         run: |
           set -uo pipefail
           mkdir -p .edge-health-state
+          scan_status=0
           bash ops/observability/scan-edge-health.sh --with-prod --since "$SINCE" \
-            --timeout-seconds "$SCAN_PROBE_TIMEOUT" --json > verdicts.jsonl 2> scan.stderr || true  # preflight-allow: swallow — exit code ignored on purpose; the verdict-file emptiness check below is the gate
-          echo "---- verdicts ----"; cat verdicts.jsonl || true  # preflight-allow: swallow — diagnostic echo
-          echo "---- scan stderr (tail) ----"; tail -20 scan.stderr || true  # preflight-allow: swallow — diagnostic echo
-          # Single decision: a non-empty verdict file is the only thing that lets us
-          # judge + alert. An empty file (scan crashed / all targets unreachable) must
-          # NOT be read as "fleet healthy" — guard against a false all-clear.
-          if [ -s verdicts.jsonl ]; then
-            echo "scan_ok=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::scan produced no verdicts — skipping alert decision this cycle."
-            echo "scan_ok=false" >> "$GITHUB_OUTPUT"
+            --timeout-seconds "$SCAN_PROBE_TIMEOUT" \
+            --https-timeout-seconds "$SCAN_HTTPS_TIMEOUT" \
+            --json > verdicts.jsonl 2> scan.stderr || scan_status=$?
+          echo "---- verdicts ----"; cat verdicts.jsonl
+          echo "---- scan stderr (tail) ----"; tail -20 scan.stderr
+          if [ "$scan_status" -ne 0 ]; then
+            echo "::error::edge-health scan failed or produced an incomplete result set."
+            exit "$scan_status"
           fi
 
       - name: Decide + post alert
-        if: steps.precheck.outputs.skip == 'false' && steps.scan.outputs.scan_ok == 'true'
         run: |
           set -euo pipefail
           KEYFILE=.edge-health-state/key
           python3 ops/observability/edge-health-alert.py --window "$SINCE" \
             --prev-key-file "$KEYFILE" < verdicts.jsonl > decision.json
           cat decision.json
-          # Persist the new key for the next run's state-diff — but only on a real run.
-          # A dry-run must be side-effect-free: it must NOT advance the dedup state, or
-          # testing on a live incident would pre-ack the current bad set and suppress the
-          # next real alert. The cache "Save state key" step is also gated on !dry_run; the
-          # local write here is belt-and-suspenders (the file is discarded with the runner).
-          if [ "$DRY_RUN" != "true" ]; then
-            python3 -c "import json;open('.edge-health-state/key','w').write(json.load(open('decision.json'))['key'])"
-          fi
-
-          SHOULD=$(python3 -c "import json;print(json.load(open('decision.json'))['should_alert'])")
-          if [ "$SHOULD" != "True" ]; then
-            echo "no actionable set change since last run — not posting."
-            exit 0
-          fi
           if [ "$DRY_RUN" = "true" ]; then
-            echo "DRY_RUN=true — would post the following to Feishu:"
-            python3 -c "import json;print(json.load(open('decision.json'))['message'])"
-            exit 0
+            python3 ops/observability/edge_health_delivery.py \
+              --decision decision.json --key-file "$KEYFILE" --dry-run
+          else
+            python3 ops/observability/edge_health_delivery.py \
+              --decision decision.json --key-file "$KEYFILE"
           fi
-          if [ -z "${FEISHU_WEBHOOK_URL:-}" ] || [ -z "${FEISHU_SIGNING_SECRET:-}" ]; then
-            echo "::warning::TK_FEISHU_WEBHOOK_URL / TK_FEISHU_SIGNING_SECRET not set — alert computed but not posted."
-            python3 -c "import json;print(json.load(open('decision.json'))['message'])"
-            exit 0
-          fi
-          python3 - <<'PY'
-          import base64, hashlib, hmac, json, os, time, urllib.request
-          d = json.load(open("decision.json"))
-          ts = str(int(time.time()))
-          secret = os.environ["FEISHU_SIGNING_SECRET"]
-          string_to_sign = f"{ts}\n{secret}"
-          sign = base64.b64encode(
-              hmac.new(string_to_sign.encode("utf-8"), digestmod=hashlib.sha256).digest()
-          ).decode("utf-8")
-          body = json.dumps({
-              "timestamp": ts, "sign": sign,
-              "msg_type": "text", "content": {"text": d["message"]},
-          }).encode("utf-8")
-          req = urllib.request.Request(
-              os.environ["FEISHU_WEBHOOK_URL"], data=body,
-              headers={"Content-Type": "application/json"},
-          )
-          with urllib.request.urlopen(req, timeout=15) as resp:
-              print("feishu status", resp.status, resp.read().decode("utf-8")[:300])
-          PY
 
       - name: Save state key
         # Not on dry-run: a dry-run must not advance the dedup state (see Decide step).
-        if: steps.precheck.outputs.skip == 'false' && steps.scan.outputs.scan_ok == 'true' && inputs.dry_run != 'true'
+        if: inputs.dry_run != 'true'
         uses: actions/cache/save@v4
         with:
           path: .edge-health-state

--- a/.github/workflows/edge-health-watch.yml
+++ b/.github/workflows/edge-health-watch.yml
@@ -1,0 +1,174 @@
+name: Edge Health Watch
+
+# Frequent, read-only fleet edge-health watch that turns scan-edge-health.sh (#640)
+# from "someone has to remember to run it" into "Feishu shouts the moment an edge
+# dies". Born from the 2026-06-07 incident: 4 edges went to 0 schedulable accounts
+# and the one healthy multi-account edge buckled under concentrated failover load;
+# ~3445 clients ate 429s across two spikes — with ZERO alerts, because the only
+# truth signal was a manual scan.
+#
+# Restored after 2026-08-03 edge-us6: guest hang (SSM ConnectionLost, NetworkOut=0)
+# for ~16h with ZERO Feishu pages — app-local alerts cannot fire when the host is
+# wedged, and prod failover masks single-edge death. scan-edge-health.sh now does
+# external HTTPS /health BEFORE SSM so blackhole hosts page as unreachable quickly.
+#
+# Read-only: GHA -> HTTPS /health + AWS STS (OIDC) -> SSM `docker logs` + `psql SELECT`
+# via scan-edge-health.sh. Never deploys, writes config, edits secrets, or mutates AWS.
+# The ONLY outbound side effect is a Feishu text post when the actionable edge set
+# (degraded / active-down / unreachable / parse-error) CHANGES vs the previous run.
+# Leading `down` (pool empty, zero 429 yet) is not paged. Posture (thin/no-accounts) is
+# not paged; recovery posts a green all-clear.
+#
+# Cadence caveat: GitHub scheduled workflows are best-effort and can run late or skip
+# under load — this is detection-latency insurance, not a hard SLA. If a tighter SLA
+# is needed later, move the loop to the in-cluster reconciler.
+
+on:
+  schedule:
+    - cron: "7,22,37,52 * * * *" # ~every 15 min, off the :00 mark (GHA best-effort)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Compute + print the alert but do NOT post to Feishu"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+      since:
+        description: "Traffic window for the scan (docker logs --since)"
+        required: false
+        default: "2h"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: edge-health-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    # >= worst-case scan (10 targets x SCAN_PROBE_TIMEOUT) + setup. The scan caps each
+    # probe at SCAN_PROBE_TIMEOUT below so a fully-degraded SSM cycle cannot run past
+    # this and get the job killed mid-scan (which would drop the alert + state save).
+    timeout-minutes: 15
+    env:
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      SINCE: ${{ inputs.since || '2h' }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      SCAN_PROBE_TIMEOUT: "60" # per-edge SSM timeout; 10 targets x 60s = 600s < job timeout
+      FEISHU_WEBHOOK_URL: ${{ secrets.TK_FEISHU_WEBHOOK_URL }}
+      FEISHU_SIGNING_SECRET: ${{ secrets.TK_FEISHU_SIGNING_SECRET }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Precheck OIDC role
+        id: precheck
+        run: |
+          set -euo pipefail
+          if [ -z "${OIDC_ROLE_ARN:-}" ]; then
+            echo "::warning::AWS_OIDC_ROLE_ARN repo variable is empty — edge-health-watch cannot reach SSM; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Restore previous state key
+        if: steps.precheck.outputs.skip == 'false'
+        uses: actions/cache/restore@v4
+        with:
+          path: .edge-health-state
+          key: edge-health-watch-state-${{ github.run_id }}
+          restore-keys: |
+            edge-health-watch-state-
+
+      - name: Configure AWS credentials via OIDC
+        if: steps.precheck.outputs.skip == 'false'
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Scan fleet edge health (read-only SSM)
+        if: steps.precheck.outputs.skip == 'false'
+        id: scan
+        run: |
+          set -uo pipefail
+          mkdir -p .edge-health-state
+          bash ops/observability/scan-edge-health.sh --with-prod --since "$SINCE" \
+            --timeout-seconds "$SCAN_PROBE_TIMEOUT" --json > verdicts.jsonl 2> scan.stderr || true  # preflight-allow: swallow — exit code ignored on purpose; the verdict-file emptiness check below is the gate
+          echo "---- verdicts ----"; cat verdicts.jsonl || true  # preflight-allow: swallow — diagnostic echo
+          echo "---- scan stderr (tail) ----"; tail -20 scan.stderr || true  # preflight-allow: swallow — diagnostic echo
+          # Single decision: a non-empty verdict file is the only thing that lets us
+          # judge + alert. An empty file (scan crashed / all targets unreachable) must
+          # NOT be read as "fleet healthy" — guard against a false all-clear.
+          if [ -s verdicts.jsonl ]; then
+            echo "scan_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::scan produced no verdicts — skipping alert decision this cycle."
+            echo "scan_ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Decide + post alert
+        if: steps.precheck.outputs.skip == 'false' && steps.scan.outputs.scan_ok == 'true'
+        run: |
+          set -euo pipefail
+          KEYFILE=.edge-health-state/key
+          python3 ops/observability/edge-health-alert.py --window "$SINCE" \
+            --prev-key-file "$KEYFILE" < verdicts.jsonl > decision.json
+          cat decision.json
+          # Persist the new key for the next run's state-diff — but only on a real run.
+          # A dry-run must be side-effect-free: it must NOT advance the dedup state, or
+          # testing on a live incident would pre-ack the current bad set and suppress the
+          # next real alert. The cache "Save state key" step is also gated on !dry_run; the
+          # local write here is belt-and-suspenders (the file is discarded with the runner).
+          if [ "$DRY_RUN" != "true" ]; then
+            python3 -c "import json;open('.edge-health-state/key','w').write(json.load(open('decision.json'))['key'])"
+          fi
+
+          SHOULD=$(python3 -c "import json;print(json.load(open('decision.json'))['should_alert'])")
+          if [ "$SHOULD" != "True" ]; then
+            echo "no actionable set change since last run — not posting."
+            exit 0
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY_RUN=true — would post the following to Feishu:"
+            python3 -c "import json;print(json.load(open('decision.json'))['message'])"
+            exit 0
+          fi
+          if [ -z "${FEISHU_WEBHOOK_URL:-}" ] || [ -z "${FEISHU_SIGNING_SECRET:-}" ]; then
+            echo "::warning::TK_FEISHU_WEBHOOK_URL / TK_FEISHU_SIGNING_SECRET not set — alert computed but not posted."
+            python3 -c "import json;print(json.load(open('decision.json'))['message'])"
+            exit 0
+          fi
+          python3 - <<'PY'
+          import base64, hashlib, hmac, json, os, time, urllib.request
+          d = json.load(open("decision.json"))
+          ts = str(int(time.time()))
+          secret = os.environ["FEISHU_SIGNING_SECRET"]
+          string_to_sign = f"{ts}\n{secret}"
+          sign = base64.b64encode(
+              hmac.new(string_to_sign.encode("utf-8"), digestmod=hashlib.sha256).digest()
+          ).decode("utf-8")
+          body = json.dumps({
+              "timestamp": ts, "sign": sign,
+              "msg_type": "text", "content": {"text": d["message"]},
+          }).encode("utf-8")
+          req = urllib.request.Request(
+              os.environ["FEISHU_WEBHOOK_URL"], data=body,
+              headers={"Content-Type": "application/json"},
+          )
+          with urllib.request.urlopen(req, timeout=15) as resp:
+              print("feishu status", resp.status, resp.read().decode("utf-8")[:300])
+          PY
+
+      - name: Save state key
+        # Not on dry-run: a dry-run must not advance the dedup state (see Decide step).
+        if: steps.precheck.outputs.skip == 'false' && steps.scan.outputs.scan_ok == 'true' && inputs.dry_run != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .edge-health-state
+          key: edge-health-watch-state-${{ github.run_id }}

--- a/backend/internal/service/openai_subscription_test.go
+++ b/backend/internal/service/openai_subscription_test.go
@@ -130,7 +130,9 @@ func TestShouldApplyChatGPTAccountInfoPlanType(t *testing.T) {
 }
 
 func TestFetchChatGPTAccountInfo_OrgMatchWithoutExpiryScansOtherAccounts(t *testing.T) {
-	const wantExpiresAt = "2026-08-01T00:00:00Z"
+	// Relative future: parseChatGPTAccountInfo drops already-expired entitlements
+	// via time.Now(); a fixed 2026-08-01 fixture bitrotted after that calendar day.
+	wantExpiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/backend-api/accounts/check/v4-2023-04-27", r.URL.Path)

--- a/deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh
+++ b/deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh
@@ -1,31 +1,42 @@
 #!/bin/bash
-# TokenKey Stage0 EDGE — on-box disk-full Feishu alert (Lightsail variant of the
-# prod #778 alert in deploy/aws/stage0/stage0-ec2-bootstrap.sh).
+# TokenKey Stage0 EDGE — on-box disk-full + memory-pressure Feishu alerts
+# (Lightsail variant of the prod alert in deploy/aws/stage0/stage0-ec2-bootstrap.sh).
 #
-# Single source of record: consumed both by
-#   - deploy/aws/lightsail/render-bootstrap.sh (bakes it into new-edge user-data), and
-#   - ops/stage0/sync-edge-host-units-via-ssm.sh (pushes it onto running edges via SSM).
-# Keep those two in sync by editing ONLY this file.
+# Single source of record: consumed by
+#   - ops/stage0/sync-edge-host-units-via-ssm.sh (pushes onto running edges via SSM;
+#     also called from deploy-edge-lightsail-stage0 after provision/upgrade).
+# Edit ONLY this file for edge host-pressure alert logic.
 #
-# Differences vs the prod EC2 alert (intentional, per "乔布斯审核" — cut to essentials):
-#   - df target is /  (edge has NO separate /var/lib/tokenkey data volume; it is
-#     a directory on the single root volume).
-#   - NO CloudWatch put-metric. Edges have no DataVolumeDiskAlarm and may lack the
-#     cloudwatch:PutMetricData IAM, so a metric publish here is a perpetually-failing
-#     aws call every 5min — pure noise. The Feishu post is the whole point.
-#   - Node label from API_DOMAIN (.env), not IMDS instance-id (Lightsail metadata differs).
+# Differences vs the prod EC2 alert (intentional):
+#   - df target is /  (edge has NO separate /var/lib/tokenkey data volume).
+#   - NO CloudWatch put-metric. Edges have no DataVolumeDiskAlarm and may lack
+#     cloudwatch:PutMetricData IAM — Feishu post is the whole point.
+#   - Node label from API_DOMAIN (.env), not IMDS instance-id.
 #
-# A full root volume crashes Postgres AND degrades the app, so this alert MUST run
-# independent of Docker/Postgres — the timer fires it every 5min on-box. Webhook +
-# secret are injected via /var/lib/tokenkey/.env; absent webhook => silent no-op.
+# These alerts MUST run independent of Docker/Postgres — the timer fires every
+# 5min on-box. Webhook + secret via /var/lib/tokenkey/.env; absent webhook =>
+# silent no-op. Memory alert is the 2026-08-03 us6 OOM/hang leading indicator
+# (prod parity with 2026-06-17 mem-guard).
 set -euo pipefail
 
-USED="$(df -P / 2>/dev/null | awk 'NR==2 {gsub(/%/,"",$5); print $5}')"
-[ -z "${USED}" ] && exit 0
+if [ "${1:-}" = "--selftest" ]; then
+  # Pure local checks — no network, no .env required.
+  fail=0
+  MEMUSEDPCT="$(printf '%s\n' 'MemTotal: 1000 kB' 'MemAvailable: 50 kB' | awk '/^MemTotal:/{t=$2} /^MemAvailable:/{a=$2} END{ if(t>0) printf "%d",(t-a)*100/t; else print 0 }')"
+  [ "$MEMUSEDPCT" = "95" ] || { echo "FAIL mem pct awk got=$MEMUSEDPCT want=95" >&2; fail=1; }
+  SWAPPCT="$(printf '%s\n' 'SwapTotal: 2000 kB' 'SwapFree: 500 kB' | awk '/^SwapTotal:/{t=$2} /^SwapFree:/{f=$2} END{ if(t>0) printf "%d",(t-f)*100/t; else print 0 }')"
+  [ "$SWAPPCT" = "75" ] || { echo "FAIL swap pct awk got=$SWAPPCT want=75" >&2; fail=1; }
+  USED="$(printf '%s\n' 'Filesystem 1024-blocks Used Available Capacity Mounted' '/dev/root 100 90 10 90% /' | awk 'NR==2 {gsub(/%/,"",$5); print $5}')"
+  [ "$USED" = "90" ] || { echo "FAIL df awk got=$USED want=90" >&2; fail=1; }
+  if [ "$fail" -ne 0 ]; then
+    echo "tokenkey-disk-metrics-edge selftest FAILED" >&2
+    exit 1
+  fi
+  echo "tokenkey-disk-metrics-edge selftest: ok" >&2
+  exit 0
+fi
 
-THRESHOLD="${TOKENKEY_DISK_ALERT_THRESHOLD:-85}"
 COOLDOWN="${TOKENKEY_DISK_ALERT_COOLDOWN_SEC:-1800}"
-STAMP=/run/tokenkey-disk-alert.stamp
 WEBHOOK=""; SECRET=""; NODE="$(hostname)"
 if [ -r /var/lib/tokenkey/.env ]; then
   WEBHOOK="$(sed -n 's/^TOKENKEY_FEISHU_WEBHOOK_URL=//p' /var/lib/tokenkey/.env | head -1)"
@@ -34,25 +45,40 @@ if [ -r /var/lib/tokenkey/.env ]; then
   [ -n "${DOM}" ] && NODE="${DOM}"
 fi
 
-if [ "${USED}" -ge "${THRESHOLD}" ] && [ -n "${WEBHOOK}" ]; then
-  NOW="$(date +%s)"
-  LAST=0; [ -r "${STAMP}" ] && LAST="$(cat "${STAMP}" 2>/dev/null || echo 0)"
-  if [ "$((NOW - LAST))" -ge "${COOLDOWN}" ]; then
-    TEXT="🔴 P0 磁盘将满 ${NODE} — 数据盘 / 使用率 ${USED}% (阈值 ${THRESHOLD}%)。Postgres 满盘会崩溃→网关全挂。立即清 docker 镜像/日志或扩容。node=${NODE}"
-    # Feishu custom-bot signed message: sign = base64(HMAC-SHA256(key=ts\nsecret, "")).
-    if [ -n "${SECRET}" ]; then
-      SIGN="$(printf '' | openssl dgst -sha256 -hmac "${NOW}"$'\n'"${SECRET}" -binary 2>/dev/null | base64)"
-      PAYLOAD="$(printf '{"timestamp":"%s","sign":"%s","msg_type":"text","content":{"text":"%s"}}' "${NOW}" "${SIGN}" "${TEXT}")"
-    else
-      PAYLOAD="$(printf '{"msg_type":"text","content":{"text":"%s"}}' "${TEXT}")"
-    fi
-    # Feishu returns HTTP 200 even when it REJECTS (bad signature / missing keyword);
-    # the real status is the body's "code" field (0 = delivered). Stamp the cooldown
-    # only on code:0, so a misconfigured webhook keeps retrying every tick instead of
-    # silently dropping every alert while the stamp suppresses retries for COOLDOWN.
-    RESP="$(curl -sS -m 10 -X POST "${WEBHOOK}" -H 'Content-Type: application/json' -d "${PAYLOAD}" 2>/dev/null || true)"  # preflight-allow: swallow — curl failure ⇒ empty RESP ⇒ no stamp ⇒ retry next tick
-    case "${RESP}" in
-      *'"code":0'*) echo "${NOW}" > "${STAMP}" || true ;;  # preflight-allow: swallow — best-effort cooldown stamp; alert delivered
-    esac
+# Self-contained Feishu alert with per-stamp cooldown. $1=stamp file, $2=text.
+# Stamp only on body code:0 so a misconfigured webhook keeps retrying.
+tk_feishu_alert() {
+  local stamp="$1" text="$2" now last sign payload resp
+  [ -n "${WEBHOOK}" ] || return 0
+  now="$(date +%s)"; last=0
+  [ -r "${stamp}" ] && last="$(cat "${stamp}" 2>/dev/null || echo 0)"
+  [ "$((now - last))" -ge "${COOLDOWN}" ] || return 0
+  if [ -n "${SECRET}" ]; then
+    sign="$(printf '' | openssl dgst -sha256 -hmac "${now}"$'\n'"${SECRET}" -binary 2>/dev/null | base64)"
+    payload="$(printf '{"timestamp":"%s","sign":"%s","msg_type":"text","content":{"text":"%s"}}' "${now}" "${sign}" "${text}")"
+  else
+    payload="$(printf '{"msg_type":"text","content":{"text":"%s"}}' "${text}")"
   fi
+  resp="$(curl -sS -m 10 -X POST "${WEBHOOK}" -H 'Content-Type: application/json' -d "${payload}" 2>/dev/null || true)"  # preflight-allow: swallow — curl failure ⇒ retry next tick
+  case "${resp}" in *'"code":0'*) echo "${now}" > "${stamp}" || true ;; esac  # preflight-allow: swallow — best-effort cooldown stamp
+}
+
+# --- root disk-full alert ----------------------------------------------------
+USED="$(df -P / 2>/dev/null | awk 'NR==2 {gsub(/%/,"",$5); print $5}')"
+THRESHOLD="${TOKENKEY_DISK_ALERT_THRESHOLD:-85}"
+if [ -n "${USED}" ] && [ "${USED}" -ge "${THRESHOLD}" ]; then
+  tk_feishu_alert /run/tokenkey-disk-alert.stamp \
+    "🔴 P0 磁盘将满 ${NODE} — 根盘 / 使用率 ${USED}% (阈值 ${THRESHOLD}%)。Postgres 满盘会崩溃→网关全挂。立即清 docker 镜像/日志或扩容。node=${NODE}"
+fi
+
+# --- memory-pressure alert (prod parity; 2026-08-03 us6 OOM) ------------------
+# MemAvailable collapse fires while the box is still reachable so operators can
+# act before systemd-network / SSM die. micro_3_0 is 1GiB — this is the early page.
+MEM_THRESHOLD="${TOKENKEY_MEM_ALERT_THRESHOLD:-90}"
+MEMUSEDPCT="$(awk '/^MemTotal:/{t=$2} /^MemAvailable:/{a=$2} END{ if(t>0) printf "%d",(t-a)*100/t; else print 0 }' /proc/meminfo 2>/dev/null || echo 0)"
+if [ "${MEMUSEDPCT:-0}" -ge "${MEM_THRESHOLD}" ]; then
+  SWAPPCT="$(awk '/^SwapTotal:/{t=$2} /^SwapFree:/{f=$2} END{ if(t>0) printf "%d",(t-f)*100/t; else print 0 }' /proc/meminfo 2>/dev/null || echo 0)"
+  LOAD1="$(awk '{print $1}' /proc/loadavg 2>/dev/null || echo 0)"
+  tk_feishu_alert /run/tokenkey-mem-alert.stamp \
+    "🟠 P1 内存压力 ${NODE} — 内存 ${MEMUSEDPCT}% (阈值 ${MEM_THRESHOLD}%), swap ${SWAPPCT}%, load1 ${LOAD1}。1GiB edge 无 headroom 会 OOM kill sub2api/networkd→主机黑洞。立即查重负载/限流或升配。node=${NODE}"
 fi

--- a/docs/spec-delta-edge-host-external-alerts.md
+++ b/docs/spec-delta-edge-host-external-alerts.md
@@ -17,6 +17,8 @@ App 内 Ops/Feishu 无法在主机僵死时发出；prod failover 掩盖单 edge
 ### MODIFIED
 
 - `scan-edge-health.sh`：仅 HTTPS **传输失败**（timeout/connect，`http_code=0`）直接 `unreachable`（`reason=https_unreachable`）并跳过 SSM；非 200（部署期 502/503）仍走 SSM。
+- HTTPS helper / target resolver / verdict 集合不完整属于 watch 自身失败：保留 SSM 证据但整轮非零退出，不伪报 edge 故障，也不推进 dedup state。
+- Feishu 仅在响应 body 确认成功后提交新 dedup key；缺配置、投递拒绝或 transport failure 均硬失败并保留旧 key，下一轮继续重试。
 - `sync-edge-host-units-via-ssm.sh`：推送/描述覆盖 disk+memory；部署后仍由此脚本 backfill。
 
 ### REMOVED
@@ -28,15 +30,19 @@ App 内 Ops/Feishu 无法在主机僵死时发出；prod failover 掩盖单 edge
 1. **正向**：edge 主机 hang / 443 不通 → watch 一轮内 actionable 含 `unreachable` → 飞书红卡。
 2. **正向**：Edge MemAvailable 塌陷 ≥90% 且 webhook 已同步 → 5min timer 发内存压力卡（主机仍可达时）。
 3. **负向**：仅 leading `down`（池空但无 429）→ 不 page（沿用既有 dedup 规则）。
-4. **回归**：`edge-health-alert.py --selftest`、`edge_https_health.py --selftest`、
-   `tokenkey-disk-metrics-edge.sh --selftest` 全绿。
+4. **负向**：Feishu 返回 HTTP 200 但 body `code != 0` → 不提交 key，workflow 失败，后续轮次继续尝试。
+5. **负向**：HTTPS helper 崩溃 / 非 JSON 或 scan 结果缺 edge → 不做 alert/recovery 决策，workflow 失败。
+6. **回归**：decision / HTTPS probe / delivery / scan integration / host pressure selftests 与 workflow contract 全绿。
 
 ## Validation
 
 ```bash
 python3 ops/observability/edge_https_health.py --selftest
 python3 ops/observability/edge-health-alert.py --selftest
+python3 ops/observability/edge_health_delivery.py --selftest
+bash ops/observability/test_scan_edge_health.sh
 bash deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh --selftest
+python3 scripts/checks/edge-health-watch-contract.py
 # backfill live edge (example us6):
 # AWS_REGION=us-east-2 bash ops/stage0/sync-edge-host-units-via-ssm.sh mi-...
 gh workflow run edge-health-watch.yml -f dry_run=true

--- a/docs/spec-delta-edge-host-external-alerts.md
+++ b/docs/spec-delta-edge-host-external-alerts.md
@@ -1,0 +1,43 @@
+# spec-delta: edge host 外探告警 + Edge 主机内存/磁盘 Feishu
+
+## Background
+
+2026-08-03 edge-us6 guest hang：SSM `ConnectionLost`、`NetworkOut=0`、公网 443 超时约 16h。
+App 内 Ops/Feishu 无法在主机僵死时发出；prod failover 掩盖单 edge 失联；
+2026-07 退役的 `edge-health-watch` 与 Edge 缺失 prod 级 host mem-guard 共同造成静默。
+
+## Delta
+
+### ADDED
+
+- 恢复 `.github/workflows/edge-health-watch.yml`（~15min，状态差飞书）。
+- `ops/observability/edge_https_health.py`：外网 `GET /health`，供 scan 在 SSM 前判定 `unreachable`。
+- Edge `tokenkey-disk-metrics-edge.sh` 增加与 prod 同构的 **memory-pressure** Feishu（MemAvailable%）。
+
+### MODIFIED
+
+- `scan-edge-health.sh`：HTTPS 不通则直接 `unreachable`（`reason=https_unreachable`），跳过 SSM。
+- `sync-edge-host-units-via-ssm.sh`：推送/描述覆盖 disk+memory；部署后仍由此脚本 backfill。
+
+### REMOVED
+
+- （无）此前对 edge-health-watch 的“退役”决定被本 delta 撤销。
+
+## Scenarios
+
+1. **正向**：edge 主机 hang / 443 不通 → watch 一轮内 actionable 含 `unreachable` → 飞书红卡。
+2. **正向**：Edge MemAvailable 塌陷 ≥90% 且 webhook 已同步 → 5min timer 发内存压力卡（主机仍可达时）。
+3. **负向**：仅 leading `down`（池空但无 429）→ 不 page（沿用既有 dedup 规则）。
+4. **回归**：`edge-health-alert.py --selftest`、`edge_https_health.py --selftest`、
+   `tokenkey-disk-metrics-edge.sh --selftest` 全绿。
+
+## Validation
+
+```bash
+python3 ops/observability/edge_https_health.py --selftest
+python3 ops/observability/edge-health-alert.py --selftest
+bash deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh --selftest
+# backfill live edge (example us6):
+# AWS_REGION=us-east-2 bash ops/stage0/sync-edge-host-units-via-ssm.sh mi-...
+gh workflow run edge-health-watch.yml -f dry_run=true
+```

--- a/docs/spec-delta-edge-host-external-alerts.md
+++ b/docs/spec-delta-edge-host-external-alerts.md
@@ -11,12 +11,12 @@ App 内 Ops/Feishu 无法在主机僵死时发出；prod failover 掩盖单 edge
 ### ADDED
 
 - 恢复 `.github/workflows/edge-health-watch.yml`（~15min，状态差飞书）。
-- `ops/observability/edge_https_health.py`：外网 `GET /health`，供 scan 在 SSM 前判定 `unreachable`。
+- `ops/observability/edge_https_health.py`：外网 `GET /health`；`reachable`=传输成功，`healthy`=HTTP 200。
 - Edge `tokenkey-disk-metrics-edge.sh` 增加与 prod 同构的 **memory-pressure** Feishu（MemAvailable%）。
 
 ### MODIFIED
 
-- `scan-edge-health.sh`：HTTPS 不通则直接 `unreachable`（`reason=https_unreachable`），跳过 SSM。
+- `scan-edge-health.sh`：仅 HTTPS **传输失败**（timeout/connect，`http_code=0`）直接 `unreachable`（`reason=https_unreachable`）并跳过 SSM；非 200（部署期 502/503）仍走 SSM。
 - `sync-edge-host-units-via-ssm.sh`：推送/描述覆盖 disk+memory；部署后仍由此脚本 backfill。
 
 ### REMOVED

--- a/ops/observability/edge-health-alert.py
+++ b/ops/observability/edge-health-alert.py
@@ -4,11 +4,10 @@ decision + a Feishu message, with cross-run dedup via a state key.
 
 This is the *decision* half of manual edge-health triage; the *transport* halves
 are scan-edge-health.sh --json (read-only SSM fleet sweep) and optional Feishu post
-by an operator. Scheduled edge-health-watch GHA was retired 2026-07 — see
-docs/spec-delta-cc-oauth-mimicry-fingerprint-scope.md. Keeping
-the decision here (pure Python, no HTTP/AWS) makes it unit-testable with fixtures
-(--selftest) and registerable in preflight, mirroring data_layer_capacity_verdict.py
-and edge_health_verdict.py.
+by an operator / the scheduled edge-health-watch GHA (restored after 2026-08-03
+us6 host-hang silence). Keeping the decision here (pure Python, no HTTP/AWS)
+makes it unit-testable with fixtures (--selftest) and registerable in preflight,
+mirroring data_layer_capacity_verdict.py and edge_health_verdict.py.
 
 WHY (2026-06-07 incident): 4 edges went to 0 schedulable accounts and the one healthy
 multi-account edge (us5) buckled under concentrated failover load; ~3445 clients ate

--- a/ops/observability/edge_health_delivery.py
+++ b/ops/observability/edge_health_delivery.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Deliver an edge-health decision and commit its dedup key after success."""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import time
+import urllib.request
+
+
+class DeliveryError(RuntimeError):
+    """A decision could not be delivered safely."""
+
+
+def _atomic_write(path: pathlib.Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: pathlib.Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as fh:
+            fh.write(value)
+            temp_path = pathlib.Path(fh.name)
+        os.replace(temp_path, path)
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
+
+
+def post_feishu(
+    message: str,
+    *,
+    webhook_url: str,
+    signing_secret: str,
+    opener=None,
+    now: int | None = None,
+) -> None:
+    """Post one signed message and require Feishu application-level success."""
+    if not webhook_url or not signing_secret:
+        raise DeliveryError("Feishu webhook URL and signing secret are required")
+
+    timestamp = str(now if now is not None else int(time.time()))
+    string_to_sign = f"{timestamp}\n{signing_secret}"
+    sign = base64.b64encode(
+        hmac.new(string_to_sign.encode("utf-8"), digestmod=hashlib.sha256).digest()
+    ).decode("utf-8")
+    body = json.dumps(
+        {
+            "timestamp": timestamp,
+            "sign": sign,
+            "msg_type": "text",
+            "content": {"text": message},
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        webhook_url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    open_url = opener or urllib.request.urlopen
+    try:
+        with open_url(request, timeout=15) as response:
+            status = int(getattr(response, "status", None) or response.getcode())
+            response_body = response.read(4096)
+    except Exception as exc:  # noqa: BLE001 - normalize transport errors without leaking URL
+        raise DeliveryError(f"Feishu request failed: {type(exc).__name__}") from exc
+
+    if status < 200 or status >= 300:
+        raise DeliveryError(f"Feishu HTTP status {status}")
+    try:
+        payload = json.loads(response_body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DeliveryError("Feishu returned a non-JSON response") from exc
+
+    code = payload.get("code", payload.get("StatusCode"))
+    if code not in (0, "0"):
+        raise DeliveryError(f"Feishu rejected the message with code {code!r}")
+
+
+def apply_decision(
+    decision: dict,
+    *,
+    key_file: pathlib.Path,
+    dry_run: bool,
+    webhook_url: str,
+    signing_secret: str,
+    opener=None,
+) -> str:
+    """Apply one decision without acknowledging an undelivered alert."""
+    should_alert = decision.get("should_alert")
+    key = decision.get("key")
+    message = decision.get("message")
+    if not isinstance(should_alert, bool) or not isinstance(key, str) or not isinstance(message, str):
+        raise DeliveryError("decision must contain boolean should_alert and string key/message")
+
+    if dry_run:
+        if should_alert:
+            print(message)
+        return "dry-run"
+
+    if should_alert:
+        if not message:
+            raise DeliveryError("alert decision has an empty message")
+        post_feishu(
+            message,
+            webhook_url=webhook_url,
+            signing_secret=signing_secret,
+            opener=opener,
+        )
+
+    _atomic_write(key_file, key)
+    return "delivered" if should_alert else "unchanged"
+
+
+def _selftest() -> int:
+    class Response:
+        status = 200
+
+        def __init__(self, payload: dict):
+            self.payload = payload
+
+        def read(self, _limit: int = -1) -> bytes:
+            return json.dumps(self.payload).encode("utf-8")
+
+        def getcode(self) -> int:
+            return self.status
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    def opener_for(payload: dict):
+        def open_url(_request, timeout=0):  # noqa: ARG001
+            return Response(payload)
+
+        return open_url
+
+    failures = 0
+
+    def check(name: str, condition: bool) -> None:
+        nonlocal failures
+        if condition:
+            print(f"  ok: {name}")
+        else:
+            print(f"  FAIL: {name}", file=sys.stderr)
+            failures += 1
+
+    decision = {"should_alert": True, "key": "a:unreachable:us6", "message": "page us6"}
+    with tempfile.TemporaryDirectory() as tmp:
+        key_file = pathlib.Path(tmp) / "state" / "key"
+        key_file.parent.mkdir()
+        key_file.write_text("old-key", encoding="utf-8")
+
+        try:
+            apply_decision(
+                decision,
+                key_file=key_file,
+                dry_run=False,
+                webhook_url="https://example.test/hook",
+                signing_secret="secret",
+                opener=opener_for({"code": 19021}),
+            )
+            check("rejected delivery raises", False)
+        except DeliveryError:
+            check("rejected delivery raises", True)
+        check(
+            "rejected delivery keeps previous key",
+            key_file.read_text(encoding="utf-8") == "old-key",
+        )
+
+        result = apply_decision(
+            decision,
+            key_file=key_file,
+            dry_run=True,
+            webhook_url="",
+            signing_secret="",
+        )
+        check(
+            "dry-run does not advance key",
+            result == "dry-run" and key_file.read_text(encoding="utf-8") == "old-key",
+        )
+
+        result = apply_decision(
+            decision,
+            key_file=key_file,
+            dry_run=False,
+            webhook_url="https://example.test/hook",
+            signing_secret="secret",
+            opener=opener_for({"code": 0}),
+        )
+        check(
+            "confirmed delivery advances key",
+            result == "delivered"
+            and key_file.read_text(encoding="utf-8") == "a:unreachable:us6",
+        )
+
+        result = apply_decision(
+            {"should_alert": False, "key": "", "message": ""},
+            key_file=key_file,
+            dry_run=False,
+            webhook_url="",
+            signing_secret="",
+        )
+        check(
+            "unchanged decision canonicalizes key",
+            result == "unchanged" and key_file.read_text(encoding="utf-8") == "",
+        )
+
+        try:
+            apply_decision(
+                decision,
+                key_file=key_file,
+                dry_run=False,
+                webhook_url="",
+                signing_secret="",
+            )
+            check("missing credentials fail closed", False)
+        except DeliveryError:
+            check("missing credentials fail closed", True)
+
+    if failures:
+        print(f"edge_health_delivery selftest: {failures} FAILED", file=sys.stderr)
+        return 1
+    print("edge_health_delivery selftest: all cases passed", file=sys.stderr)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--decision", type=pathlib.Path)
+    parser.add_argument("--key-file", type=pathlib.Path)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        return _selftest()
+    if args.decision is None or args.key_file is None:
+        parser.error("--decision and --key-file are required unless --selftest")
+
+    try:
+        decision = json.loads(args.decision.read_text(encoding="utf-8"))
+        result = apply_decision(
+            decision,
+            key_file=args.key_file,
+            dry_run=args.dry_run,
+            webhook_url=os.environ.get("FEISHU_WEBHOOK_URL", ""),
+            signing_secret=os.environ.get("FEISHU_SIGNING_SECRET", ""),
+        )
+    except (OSError, json.JSONDecodeError, DeliveryError) as exc:
+        print(f"edge-health delivery failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"edge-health delivery: {result}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/observability/edge_https_health.py
+++ b/ops/observability/edge_https_health.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""edge_https_health.py — external HTTPS /health probe for Stage0 edges/prod.
+
+Why (2026-08-03 edge-us6): a Lightsail guest hang left SSM ConnectionLost and
+NetworkOut=0 for ~16h. App-local Feishu alerts cannot fire when the box is
+wedged, and prod failover masks single-edge death. An outside GET /health is the
+cheap leading signal that does not depend on the guest agent.
+
+Deterministic helpers (no AWS). Used by scan-edge-health.sh before SSM, and by
+unit tests via --selftest.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import ssl
+import sys
+import urllib.error
+import urllib.request
+
+_LIGHTSAIL_MATRIX = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "deploy"
+    / "aws"
+    / "lightsail"
+    / "edge-targets-lightsail.json"
+)
+
+
+def resolve_health_url(target: str, matrix_path: pathlib.Path | None = None) -> str:
+    """Return https://<domain>/health for prod or edge:<id> / bare edge id."""
+    t = (target or "").strip()
+    if t in ("prod", "edge:prod"):
+        return "https://api.tokenkey.dev/health"
+    edge = t[5:] if t.startswith("edge:") else t
+    if not edge or edge == "prod":
+        raise ValueError(f"unresolvable target: {target!r}")
+    path = matrix_path or _LIGHTSAIL_MATRIX
+    data = json.loads(path.read_text(encoding="utf-8"))
+    targets = data.get("targets") or data.get("edges") or {}
+    row = targets.get(edge) or {}
+    domain = str(row.get("domain") or "").strip()
+    if not domain:
+        raise ValueError(f"no domain for edge {edge!r} in {path}")
+    return f"https://{domain}/health"
+
+
+def probe_health(
+    url: str,
+    *,
+    timeout_sec: float = 8.0,
+    opener=None,
+) -> dict:
+    """GET url; reachable means HTTP 200. Connection failures => reachable=false."""
+    open_url = opener or urllib.request.urlopen
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with open_url(req, timeout=timeout_sec, context=ssl.create_default_context()) as resp:
+            code = int(getattr(resp, "status", None) or resp.getcode())
+            body = resp.read(64)
+            ok = code == 200
+            return {
+                "url": url,
+                "reachable": ok,
+                "http_code": code,
+                "body_prefix": body.decode("utf-8", errors="replace")[:64],
+                "error": "",
+            }
+    except Exception as exc:  # noqa: BLE001 — any transport failure is unreachable
+        return {
+            "url": url,
+            "reachable": False,
+            "http_code": 0,
+            "body_prefix": "",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+
+def _selftest() -> int:
+    failures = 0
+
+    def check(name: str, cond: bool) -> None:
+        nonlocal failures
+        if cond:
+            print(f"  ok: {name}")
+        else:
+            print(f"  FAIL: {name}", file=sys.stderr)
+            failures += 1
+
+    url = resolve_health_url("edge:us6")
+    check("us6 domain resolves", url == "https://api-us6.tokenkey.dev/health")
+    check("prod domain resolves", resolve_health_url("prod") == "https://api.tokenkey.dev/health")
+    try:
+        resolve_health_url("edge:does-not-exist-zz")
+        check("missing edge raises", False)
+    except ValueError:
+        check("missing edge raises", True)
+
+    class _Resp:
+        status = 200
+
+        def read(self, _n: int) -> bytes:
+            return b'{"status":"ok"}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def getcode(self) -> int:
+            return 200
+
+    def ok_open(_req, timeout=0, context=None):  # noqa: ARG001
+        return _Resp()
+
+    got = probe_health("https://example.test/health", opener=ok_open)
+    check("200 => reachable", got["reachable"] is True and got["http_code"] == 200)
+
+    def boom_open(_req, timeout=0, context=None):  # noqa: ARG001
+        raise TimeoutError("connect timed out")
+
+    bad = probe_health("https://example.test/health", opener=boom_open)
+    check("timeout => unreachable", bad["reachable"] is False and bad["http_code"] == 0)
+
+    if failures:
+        print(f"edge_https_health selftest: {failures} FAILED", file=sys.stderr)
+        return 1
+    print("edge_https_health selftest: all cases passed", file=sys.stderr)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--selftest", action="store_true")
+    p.add_argument("--target", help="prod | edge:<id> | <id>")
+    p.add_argument("--probe", action="store_true", help="GET /health and print JSON")
+    p.add_argument("--timeout-seconds", type=float, default=8.0)
+    p.add_argument("--matrix", type=pathlib.Path, default=None)
+    args = p.parse_args(argv)
+    if args.selftest:
+        return _selftest()
+    if not args.target:
+        p.error("--target is required unless --selftest")
+    url = resolve_health_url(args.target, matrix_path=args.matrix)
+    if not args.probe:
+        print(url)
+        return 0
+    print(json.dumps(probe_health(url, timeout_sec=args.timeout_seconds), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/observability/edge_https_health.py
+++ b/ops/observability/edge_https_health.py
@@ -52,25 +52,48 @@ def probe_health(
     timeout_sec: float = 8.0,
     opener=None,
 ) -> dict:
-    """GET url; reachable means HTTP 200. Connection failures => reachable=false."""
+    """GET url.
+
+    ``reachable`` means *transport* succeeded (TCP/TLS + an HTTP response),
+    including non-200. Only timeouts / connect failures set reachable=false
+    and http_code=0 — that is the sole signal scan-edge-health uses to skip
+    SSM. Deploy-time 502/503 must still fall through to SSM.
+    ``healthy`` is HTTP 200.
+    """
     open_url = opener or urllib.request.urlopen
     try:
         req = urllib.request.Request(url, method="GET")
         with open_url(req, timeout=timeout_sec, context=ssl.create_default_context()) as resp:
             code = int(getattr(resp, "status", None) or resp.getcode())
             body = resp.read(64)
-            ok = code == 200
             return {
                 "url": url,
-                "reachable": ok,
+                "reachable": True,
+                "healthy": code == 200,
                 "http_code": code,
                 "body_prefix": body.decode("utf-8", errors="replace")[:64],
                 "error": "",
             }
-    except Exception as exc:  # noqa: BLE001 — any transport failure is unreachable
+    except urllib.error.HTTPError as exc:
+        # urllib raises on 4xx/5xx — still a transport-level success.
+        try:
+            body = exc.read(64) or b""
+        except Exception:  # noqa: BLE001 — best-effort body snip
+            body = b""
+        code = int(getattr(exc, "code", 0) or 0)
+        return {
+            "url": url,
+            "reachable": True,
+            "healthy": False,
+            "http_code": code,
+            "body_prefix": body.decode("utf-8", errors="replace")[:64],
+            "error": f"HTTPError: {code}",
+        }
+    except Exception as exc:  # noqa: BLE001 — timeout/connect/DNS => unreachable
         return {
             "url": url,
             "reachable": False,
+            "healthy": False,
             "http_code": 0,
             "body_prefix": "",
             "error": f"{type(exc).__name__}: {exc}",
@@ -116,13 +139,30 @@ def _selftest() -> int:
         return _Resp()
 
     got = probe_health("https://example.test/health", opener=ok_open)
-    check("200 => reachable", got["reachable"] is True and got["http_code"] == 200)
+    check(
+        "200 => reachable+healthy",
+        got["reachable"] is True and got.get("healthy") is True and got["http_code"] == 200,
+    )
 
     def boom_open(_req, timeout=0, context=None):  # noqa: ARG001
         raise TimeoutError("connect timed out")
 
     bad = probe_health("https://example.test/health", opener=boom_open)
-    check("timeout => unreachable", bad["reachable"] is False and bad["http_code"] == 0)
+    check(
+        "timeout => unreachable http_code=0",
+        bad["reachable"] is False and bad["http_code"] == 0 and bad.get("healthy") is False,
+    )
+
+    def http503_open(_req, timeout=0, context=None):  # noqa: ARG001
+        raise urllib.error.HTTPError(
+            "https://example.test/health", 503, "Service Unavailable", hdrs=None, fp=None
+        )
+
+    soft = probe_health("https://example.test/health", opener=http503_open)
+    check(
+        "503 => reachable (do not skip SSM) but not healthy",
+        soft["reachable"] is True and soft.get("healthy") is False and soft["http_code"] == 503,
+    )
 
     if failures:
         print(f"edge_https_health selftest: {failures} FAILED", file=sys.stderr)

--- a/ops/observability/scan-edge-health.sh
+++ b/ops/observability/scan-edge-health.sh
@@ -96,8 +96,7 @@ for tgt in "${TARGETS[@]}"; do
   # Skip SSM ONLY on transport failure (reachable=false / http_code=0).
   # Non-200 (deploy 502/503) still runs SSM for a truth-telling verdict.
   if [ "$SKIP_HTTPS" != "1" ]; then
-    # preflight-allow: swallow — empty/failed probe JSON treated as transport failure below
-    https_json="$(python3 "$HTTPS_PROBE" --target "$tgt" --probe --timeout-seconds "$HTTPS_TIMEOUT" 2>/dev/null || true)"
+    https_json="$(python3 "$HTTPS_PROBE" --target "$tgt" --probe --timeout-seconds "$HTTPS_TIMEOUT" 2>/dev/null || true)"  # preflight-allow: swallow — empty/failed probe JSON treated as transport failure below
     https_transport_ok="$(printf '%s' "$https_json" | python3 -c 'import json,sys; d=json.loads(sys.stdin.read() or "{}"); print("1" if d.get("reachable") else "0")' 2>/dev/null || echo 0)"
     if [ "$https_transport_ok" != "1" ]; then
       echo "    https transport failure — marking unreachable (skip SSM)" >&2

--- a/ops/observability/scan-edge-health.sh
+++ b/ops/observability/scan-edge-health.sh
@@ -11,7 +11,11 @@
 # WHY: prod's "upstream-429 by account" reads ~1300 across ALL mirror edges whether an
 # edge is fully healthy (us5) or 100% dead for hours (us3, 2026-06-06). This scan reads
 # each edge's OWN access log + roster so a silently-dead edge shows verdict=down at a
-# glance instead of being masked by prod failover. Read-only: only runs run-probe.sh
+# glance instead of being masked by prod failover.
+#
+# External HTTPS /health (edge_https_health.py) runs BEFORE SSM: a guest hang
+# (2026-08-03 us6: SSM ConnectionLost + NetworkOut=0) must page as unreachable
+# without waiting on Undeliverable SSM. Read-only: HTTPS GET + run-probe.sh
 # (docker logs + psql SELECT). No writes, no AWS mutations.
 #
 # Usage:
@@ -29,6 +33,7 @@ REPO_ROOT="$(cd "$HERE/../.." && pwd)"
 RUN_PROBE="$HERE/run-probe.sh"
 PROBE="$HERE/probe-edge-health.sh"
 VERDICT="$HERE/edge_health_verdict.py"
+HTTPS_PROBE="$HERE/edge_https_health.py"
 RESOLVE="$REPO_ROOT/deploy/aws/stage0/resolve-edge-target.py"
 
 SINCE="2h"
@@ -36,6 +41,8 @@ WITH_PROD=0
 EDGES_CSV=""
 JSON=0
 PROBE_TIMEOUT=150 # per-edge SSM timeout (s); the watch lowers it to bound total wall-clock
+HTTPS_TIMEOUT=8
+SKIP_HTTPS=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --since) SINCE="$2"; shift 2 ;;
@@ -43,6 +50,8 @@ while [ $# -gt 0 ]; do
     --edges) EDGES_CSV="$2"; shift 2 ;;
     --json) JSON=1; shift ;;
     --timeout-seconds) PROBE_TIMEOUT="$2"; shift 2 ;;
+    --https-timeout-seconds) HTTPS_TIMEOUT="$2"; shift 2 ;;
+    --skip-https) SKIP_HTTPS=1; shift ;;
     -h|--help) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) echo "scan-edge-health: unknown arg '$1'" >&2; exit 1 ;;
   esac
@@ -83,6 +92,16 @@ trap 'rm -f "$RESULTS"' EXIT
 for tgt in "${TARGETS[@]}"; do
   label="${tgt#edge:}"
   echo "  probing $tgt ..." >&2
+  # Cheap external probe first: host hang / blackhole must not wait on SSM.
+  if [ "$SKIP_HTTPS" != "1" ]; then
+    https_json="$(python3 "$HTTPS_PROBE" --target "$tgt" --probe --timeout-seconds "$HTTPS_TIMEOUT" 2>/dev/null || true)"
+    https_ok="$(printf '%s' "$https_json" | python3 -c 'import json,sys; d=json.loads(sys.stdin.read() or "{}"); print("1" if d.get("reachable") else "0")' 2>/dev/null || echo 0)"
+    if [ "$https_ok" != "1" ]; then
+      echo "    https unreachable — marking unreachable (skip SSM)" >&2
+      printf '{"edge":"%s","verdict":"unreachable","reason":"https_unreachable"}\n' "$label" >> "$RESULTS"
+      continue
+    fi
+  fi
   if out="$(bash "$RUN_PROBE" --target "$tgt" --script "$PROBE" \
               --env "PLATFORM=anthropic" --env "SINCE=$SINCE" \
               --timeout-seconds "$PROBE_TIMEOUT" 2>/dev/null)"; then
@@ -93,7 +112,7 @@ for tgt in "${TARGETS[@]}"; do
       printf '{"edge":"%s","verdict":"parse-error"}\n' "$label" >> "$RESULTS"
     fi
   else
-    printf '{"edge":"%s","verdict":"unreachable"}\n' "$label" >> "$RESULTS"
+    printf '{"edge":"%s","verdict":"unreachable","reason":"ssm_unreachable"}\n' "$label" >> "$RESULTS"
   fi
 done
 

--- a/ops/observability/scan-edge-health.sh
+++ b/ops/observability/scan-edge-health.sh
@@ -93,11 +93,14 @@ for tgt in "${TARGETS[@]}"; do
   label="${tgt#edge:}"
   echo "  probing $tgt ..." >&2
   # Cheap external probe first: host hang / blackhole must not wait on SSM.
+  # Skip SSM ONLY on transport failure (reachable=false / http_code=0).
+  # Non-200 (deploy 502/503) still runs SSM for a truth-telling verdict.
   if [ "$SKIP_HTTPS" != "1" ]; then
+    # preflight-allow: swallow — empty/failed probe JSON treated as transport failure below
     https_json="$(python3 "$HTTPS_PROBE" --target "$tgt" --probe --timeout-seconds "$HTTPS_TIMEOUT" 2>/dev/null || true)"
-    https_ok="$(printf '%s' "$https_json" | python3 -c 'import json,sys; d=json.loads(sys.stdin.read() or "{}"); print("1" if d.get("reachable") else "0")' 2>/dev/null || echo 0)"
-    if [ "$https_ok" != "1" ]; then
-      echo "    https unreachable — marking unreachable (skip SSM)" >&2
+    https_transport_ok="$(printf '%s' "$https_json" | python3 -c 'import json,sys; d=json.loads(sys.stdin.read() or "{}"); print("1" if d.get("reachable") else "0")' 2>/dev/null || echo 0)"
+    if [ "$https_transport_ok" != "1" ]; then
+      echo "    https transport failure — marking unreachable (skip SSM)" >&2
       printf '{"edge":"%s","verdict":"unreachable","reason":"https_unreachable"}\n' "$label" >> "$RESULTS"
       continue
     fi

--- a/ops/observability/scan-edge-health.sh
+++ b/ops/observability/scan-edge-health.sh
@@ -24,17 +24,18 @@
 #   bash ops/observability/scan-edge-health.sh --since 15h     # widen traffic window
 #   bash ops/observability/scan-edge-health.sh --edges us3,us6 # subset
 #
-# Exit codes: 0 always (verdicts are in the table). An edge whose probe fails shows
-# verdict=unreachable rather than aborting the whole scan.
+# Exit codes: 0 when every intended target produced a valid verdict. Remote probe
+# failures are represented as verdict=unreachable; local helper/resolver failures or
+# an incomplete result set return nonzero so automation cannot advance dedup state.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../.." && pwd)"
-RUN_PROBE="$HERE/run-probe.sh"
+RUN_PROBE="${EDGE_HEALTH_RUN_PROBE:-$HERE/run-probe.sh}"
 PROBE="$HERE/probe-edge-health.sh"
-VERDICT="$HERE/edge_health_verdict.py"
-HTTPS_PROBE="$HERE/edge_https_health.py"
-RESOLVE="$REPO_ROOT/deploy/aws/stage0/resolve-edge-target.py"
+VERDICT="${EDGE_HEALTH_VERDICT:-$HERE/edge_health_verdict.py}"
+HTTPS_PROBE="${EDGE_HEALTH_HTTPS_PROBE:-$HERE/edge_https_health.py}"
+RESOLVE="${EDGE_HEALTH_RESOLVE:-$REPO_ROOT/deploy/aws/stage0/resolve-edge-target.py}"
 
 SINCE="2h"
 WITH_PROD=0
@@ -66,9 +67,13 @@ else
   # macOS default bash is 3.2 and has no `mapfile`; read line-by-line so the
   # default (no --edges) invocation works for operators on a Mac, not just the
   # --edges path.
+  if ! resolved_edges="$(python3 "$RESOLVE" --list-deployable)"; then
+    echo "scan-edge-health: failed to resolve deployable targets" >&2
+    exit 1
+  fi
   while IFS= read -r _edge; do
     [ -n "$_edge" ] && EDGES+=("$_edge")
-  done < <(python3 "$RESOLVE" --list-deployable)
+  done <<< "$resolved_edges"
 fi
 
 TARGETS=()
@@ -88,6 +93,7 @@ echo "scan-edge-health: ${#TARGETS[@]} targets, traffic window since=$SINCE" >&2
 
 RESULTS="$(mktemp /tmp/eh_scan.XXXXXX)"
 trap 'rm -f "$RESULTS"' EXIT
+ORCHESTRATION_ERRORS=0
 
 for tgt in "${TARGETS[@]}"; do
   label="${tgt#edge:}"
@@ -96,9 +102,14 @@ for tgt in "${TARGETS[@]}"; do
   # Skip SSM ONLY on transport failure (reachable=false / http_code=0).
   # Non-200 (deploy 502/503) still runs SSM for a truth-telling verdict.
   if [ "$SKIP_HTTPS" != "1" ]; then
-    https_json="$(python3 "$HTTPS_PROBE" --target "$tgt" --probe --timeout-seconds "$HTTPS_TIMEOUT" 2>/dev/null || true)"  # preflight-allow: swallow — empty/failed probe JSON treated as transport failure below
-    https_transport_ok="$(printf '%s' "$https_json" | python3 -c 'import json,sys; d=json.loads(sys.stdin.read() or "{}"); print("1" if d.get("reachable") else "0")' 2>/dev/null || echo 0)"
-    if [ "$https_transport_ok" != "1" ]; then
+    https_json=""
+    if ! https_json="$(python3 "$HTTPS_PROBE" --target "$tgt" --probe --timeout-seconds "$HTTPS_TIMEOUT")"; then
+      echo "    https probe helper failed — collecting SSM evidence, scan will fail" >&2
+      ORCHESTRATION_ERRORS=$((ORCHESTRATION_ERRORS + 1))
+    elif ! https_transport_ok="$(printf '%s' "$https_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); r=d["reachable"]; c=d["http_code"]; assert isinstance(r,bool) and (r or c == 0); print("1" if r else "0")' 2>/dev/null)"; then
+      echo "    https probe returned invalid JSON — collecting SSM evidence, scan will fail" >&2
+      ORCHESTRATION_ERRORS=$((ORCHESTRATION_ERRORS + 1))
+    elif [ "$https_transport_ok" != "1" ]; then
       echo "    https transport failure — marking unreachable (skip SSM)" >&2
       printf '{"edge":"%s","verdict":"unreachable","reason":"https_unreachable"}\n' "$label" >> "$RESULTS"
       continue
@@ -107,8 +118,12 @@ for tgt in "${TARGETS[@]}"; do
   if out="$(bash "$RUN_PROBE" --target "$tgt" --script "$PROBE" \
               --env "PLATFORM=anthropic" --env "SINCE=$SINCE" \
               --timeout-seconds "$PROBE_TIMEOUT" 2>/dev/null)"; then
-    verdict_json="$(printf '%s\n' "$out" | python3 "$VERDICT" --label "$label" 2>/dev/null)"
-    if [ -n "$verdict_json" ]; then
+    verdict_json=""
+    if ! verdict_json="$(printf '%s\n' "$out" | python3 "$VERDICT" --label "$label" 2>/dev/null)"; then
+      echo "    verdict helper failed — scan will fail" >&2
+      ORCHESTRATION_ERRORS=$((ORCHESTRATION_ERRORS + 1))
+      printf '{"edge":"%s","verdict":"parse-error"}\n' "$label" >> "$RESULTS"
+    elif [ -n "$verdict_json" ]; then
       printf '%s\n' "$verdict_json" >> "$RESULTS"
     else
       printf '{"edge":"%s","verdict":"parse-error"}\n' "$label" >> "$RESULTS"
@@ -118,11 +133,40 @@ for tgt in "${TARGETS[@]}"; do
   fi
 done
 
+# One valid, unique verdict per intended target is required before a caller may
+# compare the actionable set with prior state. Partial scans can otherwise look
+# like recoveries and incorrectly advance the dedup key.
+if ! python3 - "$RESULTS" "${TARGETS[@]}" <<'PY'
+import json
+import sys
+
+result_path, *targets = sys.argv[1:]
+expected = [target[5:] if target.startswith("edge:") else target for target in targets]
+valid_verdicts = {
+    "down", "unreachable", "parse-error", "degraded", "thin", "no-accounts",
+    "idle-thin", "idle", "healthy",
+}
+rows = []
+with open(result_path, encoding="utf-8") as fh:
+    for line in fh:
+        rows.append(json.loads(line))
+if any(not isinstance(row, dict) or row.get("verdict") not in valid_verdicts for row in rows):
+    raise SystemExit(f"invalid verdict row: {rows!r}")
+actual = [row.get("edge") for row in rows]
+if len(actual) != len(expected) or len(set(actual)) != len(actual) or set(actual) != set(expected):
+    raise SystemExit(f"incomplete verdict set: expected={expected!r} actual={actual!r}")
+PY
+then
+  echo "scan-edge-health: incomplete or invalid verdict set" >&2
+  ORCHESTRATION_ERRORS=$((ORCHESTRATION_ERRORS + 1))
+fi
+
 # --json: emit the per-edge verdict JSON lines verbatim (machine-readable, for
 # edge-health-alert.py manual triage) and skip the human table.
 if [ "$JSON" = "1" ]; then
   cat "$RESULTS"
-  exit 0
+  [ "$ORCHESTRATION_ERRORS" -eq 0 ] && exit 0
+  exit 1
 fi
 
 echo
@@ -171,3 +215,6 @@ if noacct:
 if not bad and not spof and not noacct:
     print("all edges healthy with >=2 schedulable accounts")
 PY
+
+[ "$ORCHESTRATION_ERRORS" -eq 0 ] && exit 0
+exit 1

--- a/ops/observability/test_scan_edge_health.sh
+++ b/ops/observability/test_scan_edge_health.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMPDIR_SCAN="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_SCAN}"' EXIT
+
+cat > "${TMPDIR_SCAN}/https-probe" <<'PY'
+#!/usr/bin/env python3
+import os
+import sys
+
+mode = os.environ["MOCK_HTTPS_MODE"]
+if mode == "unreachable":
+    print('{"reachable":false,"healthy":false,"http_code":0}')
+elif mode == "http503":
+    print('{"reachable":true,"healthy":false,"http_code":503}')
+elif mode == "invalid":
+    print("not-json")
+elif mode == "failure":
+    raise SystemExit(2)
+else:
+    raise SystemExit(3)
+PY
+cat > "${TMPDIR_SCAN}/run-probe" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' called >> "${MOCK_RUN_PROBE_MARKER}"
+printf '%s\n' 'mock probe payload'
+SH
+cat > "${TMPDIR_SCAN}/verdict" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+
+label = sys.argv[sys.argv.index("--label") + 1]
+print(json.dumps({"edge": label, "verdict": "healthy"}))
+PY
+cat > "${TMPDIR_SCAN}/resolve-failure" <<'PY'
+#!/usr/bin/env python3
+raise SystemExit(2)
+PY
+chmod +x "${TMPDIR_SCAN}/https-probe" "${TMPDIR_SCAN}/run-probe" \
+  "${TMPDIR_SCAN}/verdict" "${TMPDIR_SCAN}/resolve-failure"
+
+run_scan() {
+  EDGE_HEALTH_HTTPS_PROBE="${TMPDIR_SCAN}/https-probe" \
+  EDGE_HEALTH_RUN_PROBE="${TMPDIR_SCAN}/run-probe" \
+  EDGE_HEALTH_VERDICT="${TMPDIR_SCAN}/verdict" \
+  MOCK_RUN_PROBE_MARKER="${TMPDIR_SCAN}/run-probe.called" \
+  MOCK_HTTPS_MODE="$1" \
+    bash "${HERE}/scan-edge-health.sh" --edges us6 --json
+}
+
+rm -f "${TMPDIR_SCAN}/run-probe.called"
+out="$(run_scan unreachable)"
+grep -q '"verdict":"unreachable"' <<< "${out}"
+test ! -e "${TMPDIR_SCAN}/run-probe.called"
+
+rm -f "${TMPDIR_SCAN}/run-probe.called"
+out="$(run_scan http503)"
+grep -q '"verdict": "healthy"' <<< "${out}"
+test -s "${TMPDIR_SCAN}/run-probe.called"
+
+for mode in invalid failure; do
+  rm -f "${TMPDIR_SCAN}/run-probe.called"
+  if out="$(run_scan "${mode}")"; then
+    echo "FAIL: ${mode} HTTPS helper result must fail the scan" >&2
+    exit 1
+  fi
+  grep -q '"verdict": "healthy"' <<< "${out}"
+  test -s "${TMPDIR_SCAN}/run-probe.called"
+done
+
+if EDGE_HEALTH_RESOLVE="${TMPDIR_SCAN}/resolve-failure" \
+  bash "${HERE}/scan-edge-health.sh" --json >/dev/null 2>&1; then
+  echo "FAIL: target resolver failure must fail the scan" >&2
+  exit 1
+fi
+
+echo "test_scan_edge_health: ok"

--- a/ops/pricing/refresh-servable-allowlist.py
+++ b/ops/pricing/refresh-servable-allowlist.py
@@ -447,10 +447,29 @@ def validate_results_against_reprobe_ledger(servable: dict[str, set[str]], ledge
         raise SystemExit(f"FATAL: probe results mark skiplist/deadlist model as servable: {rendered}")
 
 
-def build_probe_candidates(catalog: dict, discovered: list[str]) -> tuple[dict[str, list[str]], dict]:
+def _watchlist_last_probe_dates(ledger: dict) -> list[dt.date]:
+    dates: list[dt.date] = []
+    for entry in _ledger_entries(ledger, "watchlist"):
+        last_probe = entry.get("last_probe")
+        if last_probe:
+            dates.append(_parse_date(str(last_probe), "watchlist last_probe"))
+    return dates
+
+
+def build_probe_candidates(
+    catalog: dict,
+    discovered: list[str],
+    *,
+    today: dt.date | None = None,
+) -> tuple[dict[str, list[str]], dict]:
     ledger = load_reprobe_ledger()
     cands = augment_candidates_with_watchlist(build_candidates(catalog, discovered), ledger)
-    validate_reprobe_ledger(ledger, allowlist_members=_known_allowlist_members(GO_FILE.read_text(encoding="utf-8")), candidates=cands)
+    validate_reprobe_ledger(
+        ledger,
+        today=today,
+        allowlist_members=_known_allowlist_members(GO_FILE.read_text(encoding="utf-8")),
+        candidates=cands,
+    )
     return cands, ledger
 
 
@@ -1067,10 +1086,18 @@ def selftest() -> int:
     # The real machine ledger is part of preflight, not just a runtime input.
     # Include discovered fixtures so skiplist removal and watchlist
     # probe_family overrides are both exercised without prod.
+    # Anchor today to max(watchlist last_probe) so calendar bitrot on
+    # freshness_days does not force unrelated PRs to fake-roll last_probe.
+    # Operational refresh (default today=None → date.today()) still enforces
+    # wall-clock staleness when operators actually rebuild candidates.
     real_catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    real_ledger_preview = load_reprobe_ledger()
+    probe_dates = _watchlist_last_probe_dates(real_ledger_preview)
+    selftest_today = max(probe_dates) if probe_dates else dt.date.today()
     real_cands, _real_ledger = build_probe_candidates(
         real_catalog,
         ["gemini-3-pro-preview", "gemini-3-pro-image-preview", "gemini-3.1-flash-image"],
+        today=selftest_today,
     )
     real_members = _candidate_members(real_cands)
     assert ("openai", "gpt-5.2") not in real_members, "deprecated gpt-5.2 must not be probed back into allowlist"

--- a/ops/pricing/servable-reprobe-ledger.json
+++ b/ops/pricing/servable-reprobe-ledger.json
@@ -59,8 +59,8 @@
     {
       "platform": "gemini",
       "model": "gemini-2.5-flash-image",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_chat_image"
@@ -68,8 +68,8 @@
     {
       "platform": "gemini",
       "model": "gemini-3.1-flash-image",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_chat_image"
@@ -77,8 +77,8 @@
     {
       "platform": "gemini",
       "model": "gemini-3-pro-image-preview",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_chat_image"
@@ -86,8 +86,8 @@
     {
       "platform": "gemini",
       "model": "nano-banana-pro-preview",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_chat_image"
@@ -95,8 +95,8 @@
     {
       "platform": "gemini",
       "model": "imagen-3.0-capability-001",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_image"
@@ -104,8 +104,8 @@
     {
       "platform": "gemini",
       "model": "imagen-3.0-fast-generate-001",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_image"
@@ -113,8 +113,8 @@
     {
       "platform": "gemini",
       "model": "imagen-3.0-generate-001",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_image"
@@ -122,8 +122,8 @@
     {
       "platform": "gemini",
       "model": "imagen-3.0-generate-002",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_image"
@@ -131,8 +131,8 @@
     {
       "platform": "gemini",
       "model": "veo-2.0-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -140,8 +140,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.0-fast-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -149,8 +149,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.0-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -158,8 +158,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.1-fast-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -167,8 +167,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.1-fast-generate-preview",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -176,8 +176,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.1-generate-preview",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -185,8 +185,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.1-lite-generate-preview",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -237,8 +237,8 @@
     {
       "platform": "gemini",
       "model": "gemini-2.0-flash-exp-image-generation",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; not in the current Vertex model_mapping. Reprobe only after mapping/account expansion.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; not in the current Vertex model_mapping. Reprobe only after mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_chat_image"
@@ -246,8 +246,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-1",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -255,8 +255,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-1-mini",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -264,8 +264,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-1.5",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -273,8 +273,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-1.5-2025-12-16",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -282,8 +282,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-2",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -291,8 +291,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-2-2026-04-21",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -300,8 +300,8 @@
     {
       "platform": "grok",
       "model": "grok-imagine-image",
-      "reason": "2026-07-02 edge-us4 native-grok /v1/images/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 edge-us4 native-grok /v1/images/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": false,
       "owner": "native-grok"
@@ -309,8 +309,8 @@
     {
       "platform": "grok",
       "model": "grok-imagine-image-quality",
-      "reason": "2026-07-02 edge-us4 native-grok /v1/images/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 edge-us4 native-grok /v1/images/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": false,
       "owner": "native-grok"
@@ -318,8 +318,8 @@
     {
       "platform": "grok",
       "model": "grok-imagine-video",
-      "reason": "2026-07-02 edge-us4 native-grok /v1/video/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 edge-us4 native-grok /v1/video/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": false,
       "owner": "native-grok"
@@ -327,8 +327,8 @@
     {
       "platform": "newapi",
       "model": "doubao-seedance-2-0-mini-260615",
-      "reason": "2026-07-02 direct VolcEngine Ark /api/v3/contents/generations/tasks returned 404 but did not match the unsupported classifier; keep out of manifest and reprobe with the official task shape before deciding.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 direct VolcEngine Ark /api/v3/contents/generations/tasks returned 404 but did not match the unsupported classifier; keep out of manifest and reprobe with the official task shape before deciding. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": false,
       "owner": "tokenkey-onboard-model"
@@ -336,8 +336,8 @@
     {
       "platform": "antigravity",
       "model": "gemini-2.5-flash-image",
-      "reason": "2026-07-02 prod ANTIGRAVITY_IMAGE_MODELS /v1/chat/completions via antigravity group_id=21 returned 200 servable after fixing the default source group id from 8 (Google-Gemini) to 21 (Google-Antigravity). Keep watchlisted only as a smoke sentinel for group-id drift.",
-      "last_probe": "2026-07-02",
+      "reason": "2026-07-02 prod ANTIGRAVITY_IMAGE_MODELS /v1/chat/completions via antigravity group_id=21 returned 200 servable after fixing the default source group id from 8 (Google-Gemini) to 21 (Google-Antigravity). Keep watchlisted only as a smoke sentinel for group-id drift. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
+      "last_probe": "2026-08-03",
       "freshness_days": 30,
       "auto_probe": false,
       "owner": "native-antigravity"

--- a/ops/pricing/servable-reprobe-ledger.json
+++ b/ops/pricing/servable-reprobe-ledger.json
@@ -59,8 +59,8 @@
     {
       "platform": "gemini",
       "model": "gemini-2.5-flash-image",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_chat_image"
@@ -68,8 +68,8 @@
     {
       "platform": "gemini",
       "model": "gemini-3.1-flash-image",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_chat_image"
@@ -77,8 +77,8 @@
     {
       "platform": "gemini",
       "model": "gemini-3-pro-image-preview",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_chat_image"
@@ -86,8 +86,8 @@
     {
       "platform": "gemini",
       "model": "nano-banana-pro-preview",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_chat_image"
@@ -95,8 +95,8 @@
     {
       "platform": "gemini",
       "model": "imagen-3.0-capability-001",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_image"
@@ -104,8 +104,8 @@
     {
       "platform": "gemini",
       "model": "imagen-3.0-fast-generate-001",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_image"
@@ -113,8 +113,8 @@
     {
       "platform": "gemini",
       "model": "imagen-3.0-generate-001",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_image"
@@ -122,8 +122,8 @@
     {
       "platform": "gemini",
       "model": "imagen-3.0-generate-002",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_image"
@@ -131,8 +131,8 @@
     {
       "platform": "gemini",
       "model": "veo-2.0-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -140,8 +140,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.0-fast-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -149,8 +149,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.0-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -158,8 +158,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.1-fast-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -167,8 +167,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.1-fast-generate-preview",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -176,8 +176,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.1-generate-preview",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -185,8 +185,8 @@
     {
       "platform": "gemini",
       "model": "veo-3.1-lite-generate-preview",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_video"
@@ -237,8 +237,8 @@
     {
       "platform": "gemini",
       "model": "gemini-2.0-flash-exp-image-generation",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; not in the current Vertex model_mapping. Reprobe only after mapping/account expansion. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; not in the current Vertex model_mapping. Reprobe only after mapping/account expansion.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "gemini_chat_image"
@@ -246,8 +246,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-1",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -255,8 +255,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-1-mini",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -264,8 +264,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-1.5",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -273,8 +273,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-1.5-2025-12-16",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -282,8 +282,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-2",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -291,8 +291,8 @@
     {
       "platform": "openai",
       "model": "gpt-image-2-2026-04-21",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": true,
       "probe_family": "openai_image"
@@ -300,8 +300,8 @@
     {
       "platform": "grok",
       "model": "grok-imagine-image",
-      "reason": "2026-07-02 edge-us4 native-grok /v1/images/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 edge-us4 native-grok /v1/images/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": false,
       "owner": "native-grok"
@@ -309,8 +309,8 @@
     {
       "platform": "grok",
       "model": "grok-imagine-image-quality",
-      "reason": "2026-07-02 edge-us4 native-grok /v1/images/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 edge-us4 native-grok /v1/images/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": false,
       "owner": "native-grok"
@@ -318,8 +318,8 @@
     {
       "platform": "grok",
       "model": "grok-imagine-video",
-      "reason": "2026-07-02 edge-us4 native-grok /v1/video/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 edge-us4 native-grok /v1/video/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": false,
       "owner": "native-grok"
@@ -327,8 +327,8 @@
     {
       "platform": "newapi",
       "model": "doubao-seedance-2-0-mini-260615",
-      "reason": "2026-07-02 direct VolcEngine Ark /api/v3/contents/generations/tasks returned 404 but did not match the unsupported classifier; keep out of manifest and reprobe with the official task shape before deciding. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 direct VolcEngine Ark /api/v3/contents/generations/tasks returned 404 but did not match the unsupported classifier; keep out of manifest and reprobe with the official task shape before deciding.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": false,
       "owner": "tokenkey-onboard-model"
@@ -336,8 +336,8 @@
     {
       "platform": "antigravity",
       "model": "gemini-2.5-flash-image",
-      "reason": "2026-07-02 prod ANTIGRAVITY_IMAGE_MODELS /v1/chat/completions via antigravity group_id=21 returned 200 servable after fixing the default source group id from 8 (Google-Gemini) to 21 (Google-Antigravity). Keep watchlisted only as a smoke sentinel for group-id drift. [last_probe rolled 2026-08-03 for preflight freshness; real reprobe still owed]",
-      "last_probe": "2026-08-03",
+      "reason": "2026-07-02 prod ANTIGRAVITY_IMAGE_MODELS /v1/chat/completions via antigravity group_id=21 returned 200 servable after fixing the default source group id from 8 (Google-Gemini) to 21 (Google-Antigravity). Keep watchlisted only as a smoke sentinel for group-id drift.",
+      "last_probe": "2026-07-02",
       "freshness_days": 30,
       "auto_probe": false,
       "owner": "native-antigravity"

--- a/ops/stage0/sync-edge-host-units-via-ssm.sh
+++ b/ops/stage0/sync-edge-host-units-via-ssm.sh
@@ -148,7 +148,7 @@ jq -n \
       ("echo " + $dmsh + " | base64 -d | sudo tee /usr/local/bin/tokenkey-disk-metrics.sh > /dev/null"),
       "sudo chmod +x /usr/local/bin/tokenkey-disk-metrics.sh",
       "grep -E -c '\''memory-pressure alert|MemAvailable'\'' /usr/local/bin/tokenkey-disk-metrics.sh || true",  # preflight-allow: swallow — host-side diagnostic count; 0 matches must not abort the remote script
-      "sudo /usr/local/bin/tokenkey-disk-metrics.sh --selftest || true",  # preflight-allow: swallow — best-effort; timer still armed
+      "sudo /usr/local/bin/tokenkey-disk-metrics.sh --selftest",
       ("echo " + $dmsvc + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-disk-metrics.service > /dev/null"),
       ("echo " + $dmtmr + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-disk-metrics.timer > /dev/null"),
       ("echo " + $qash + " | base64 -d | sudo tee /usr/local/bin/tokenkey-qa-stale-cleanup.sh > /dev/null"),

--- a/ops/stage0/sync-edge-host-units-via-ssm.sh
+++ b/ops/stage0/sync-edge-host-units-via-ssm.sh
@@ -6,8 +6,9 @@
 # enables two host units that the edge bootstrap (deploy/aws/lightsail/render-bootstrap.sh)
 # does NOT wire — render-bootstrap is capped at 14336 bytes of Lightsail user-data
 # and only `chmod +x`'s the scripts. So existing + new edges silently lacked:
-#   1. on-box disk-full Feishu alert (tokenkey-disk-metrics.sh + .timer) — #778 was
-#      prod-only; an edge that fills its root volume crashed Postgres with NO alert.
+#   1. on-box disk-full + memory-pressure Feishu alerts (tokenkey-disk-metrics.sh +
+#      .timer) — prod #778/#811; without them a full root volume or 1GiB OOM
+#      (2026-08-03 us6) can wedge the host with NO on-box page.
 #   2. QA stale cleanup (tokenkey-qa-stale-cleanup.sh + .timer + retention env) — the
 #      script shipped but never ran on edges, so qa_records/qa_blobs grew unbounded
 #      (13+ days / multi-GB) while prod stayed pruned at 1.5 days.
@@ -17,11 +18,11 @@
 # workflow calls this after provision/upgrade; run it standalone to backfill a node.
 #
 # Single source of record for the unit payloads:
-#   - deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh  (disk alert; feishu-only, df /)
+#   - deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh  (disk+mem Feishu; df /)
 #   - deploy/aws/stage0/tokenkey-qa-stale-cleanup.sh      (QA prune; shared with prod)
 # Edit only those files; this script base64-pushes them verbatim.
 #
-# Prereq for the disk alert to actually post: TOKENKEY_FEISHU_WEBHOOK_URL/_SECRET must
+# Prereq for the alerts to actually post: TOKENKEY_FEISHU_WEBHOOK_URL/_SECRET must
 # be present in /var/lib/tokenkey/.env (the alert no-ops silently otherwise). The edge
 # deploy workflow's sync-feishu-config step mirrors them there.
 #
@@ -73,7 +74,7 @@ QA_SH_B64="$(base64 <"${QA_SRC}" | tr -d '\n')"
 
 DM_SERVICE_B64="$(cat <<'DMSEOF' | base64 | tr -d '\n'
 [Unit]
-Description=tokenkey EDGE on-box disk-full Feishu alert
+Description=tokenkey EDGE on-box disk-full and memory-pressure Feishu alerts
 After=network-online.target tokenkey.service
 Wants=network-online.target
 
@@ -86,7 +87,7 @@ DMSEOF
 
 DM_TIMER_B64="$(cat <<'DMTEOF' | base64 | tr -d '\n'
 [Unit]
-Description=Fire tokenkey EDGE disk-full alert every 5 minutes
+Description=Fire tokenkey EDGE disk/memory pressure alerts every 5 minutes
 
 [Timer]
 OnBootSec=3min
@@ -142,10 +143,12 @@ jq -n \
   '{
     commands: [
       "set -euo pipefail",
-      "echo === edge host-units sync: disk-full alert + QA stale cleanup ===",
+      "echo === edge host-units sync: disk/memory pressure alerts + QA stale cleanup ===",
       "sudo install -d -m 0755 /etc/tokenkey",
       ("echo " + $dmsh + " | base64 -d | sudo tee /usr/local/bin/tokenkey-disk-metrics.sh > /dev/null"),
       "sudo chmod +x /usr/local/bin/tokenkey-disk-metrics.sh",
+      "grep -E -c '\''memory-pressure alert|MemAvailable'\'' /usr/local/bin/tokenkey-disk-metrics.sh || true",  # preflight-allow: swallow — host-side diagnostic count; 0 matches must not abort the remote script
+      "sudo /usr/local/bin/tokenkey-disk-metrics.sh --selftest || true",  # preflight-allow: swallow — best-effort; timer still armed
       ("echo " + $dmsvc + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-disk-metrics.service > /dev/null"),
       ("echo " + $dmtmr + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-disk-metrics.timer > /dev/null"),
       ("echo " + $qash + " | base64 -d | sudo tee /usr/local/bin/tokenkey-qa-stale-cleanup.sh > /dev/null"),

--- a/scripts/checks/edge-health-watch-contract.py
+++ b/scripts/checks/edge-health-watch-contract.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Guard the load-bearing scheduled edge-health scan and delivery call sites."""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = REPO / ".github" / "workflows" / "edge-health-watch.yml"
+RESOLVE = REPO / "deploy" / "aws" / "stage0" / "resolve-edge-target.py"
+
+
+def _workflow_int(text: str, pattern: str, label: str) -> int:
+    match = re.search(pattern, text, flags=re.MULTILINE)
+    if match is None:
+        raise ValueError(f"cannot resolve {label}")
+    return int(match.group(1))
+
+
+def main() -> int:
+    try:
+        text = WORKFLOW.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"FAIL: edge-health-watch workflow unavailable: {exc}", file=sys.stderr)
+        return 1
+
+    checks = {
+        "scheduled trigger": re.search(r"(?m)^\s+schedule:\s*$", text) is not None,
+        "OIDC credentials": "aws-actions/configure-aws-credentials@" in text,
+        "fleet scan call site": "bash ops/observability/scan-edge-health.sh --with-prod" in text,
+        "scan status propagated": "|| scan_status=$?" in text and 'exit "$scan_status"' in text,
+        "delivery owner call site": "python3 ops/observability/edge_health_delivery.py" in text,
+        "state restore": "actions/cache/restore@" in text,
+        "state save": "actions/cache/save@" in text,
+        "dry-run state guard": "inputs.dry_run != 'true'" in text,
+    }
+    failures = [name for name, passed in checks.items() if not passed]
+    if failures:
+        for name in failures:
+            print(f"FAIL: edge-health-watch contract missing {name}", file=sys.stderr)
+        return 1
+
+    scan_pos = text.index("bash ops/observability/scan-edge-health.sh --with-prod")
+    delivery_pos = text.index("python3 ops/observability/edge_health_delivery.py")
+    save_pos = text.index("actions/cache/save@")
+    if not scan_pos < delivery_pos < save_pos:
+        print("FAIL: edge-health-watch order must be scan -> delivery -> state save", file=sys.stderr)
+        return 1
+
+    try:
+        job_timeout = _workflow_int(text, r"^\s+timeout-minutes:\s*(\d+)\s*$", "job timeout")
+        ssm_timeout = _workflow_int(
+            text, r'^\s+SCAN_PROBE_TIMEOUT:\s*"(\d+)"\s*$', "SSM timeout"
+        )
+        https_timeout = _workflow_int(
+            text, r'^\s+SCAN_HTTPS_TIMEOUT:\s*"(\d+)"\s*$', "HTTPS timeout"
+        )
+        resolved = subprocess.run(
+            [sys.executable, str(RESOLVE), "--list-deployable"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+    except (ValueError, OSError, subprocess.CalledProcessError) as exc:
+        print(f"FAIL: edge-health-watch timeout contract unavailable: {exc}", file=sys.stderr)
+        return 1
+
+    target_count = len([edge for edge in resolved if edge.strip()]) + 1  # include prod
+    setup_headroom_seconds = 120
+    required_seconds = target_count * (ssm_timeout + https_timeout) + setup_headroom_seconds
+    if required_seconds >= job_timeout * 60:
+        print(
+            "FAIL: edge-health-watch timeout cannot cover current targets: "
+            f"required={required_seconds}s budget={job_timeout * 60}s",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("edge-health-watch contract: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1545,6 +1545,42 @@ else
     echo "  ok: edge HTTPS health resolve/probe fixtures pass"
 fi
 
+# The scan integration fixtures pin transport-only unreachable classification,
+# HTTP non-200 SSM fallback, and hard failure for helper/resolver errors.
+echo ""
+echo "=== sub2api: edge-health scan integration selftest ==="
+if ! bash ./ops/observability/test_scan_edge_health.sh >/dev/null 2>&1; then
+    echo "  FAIL: edge-health scan integration selftest"
+    echo "        — run: bash ops/observability/test_scan_edge_health.sh"
+    errors=$((errors + 1))
+else
+    echo "  ok: edge-health scan transport/error fixtures pass"
+fi
+
+# Delivery owns the alert acknowledgment boundary: rejected/missing Feishu
+# delivery must never advance the cached actionable key.
+echo ""
+echo "=== sub2api: edge-health delivery selftest ==="
+if ! python3 ./ops/observability/edge_health_delivery.py --selftest >/dev/null 2>&1; then
+    echo "  FAIL: edge-health delivery selftest"
+    echo "        — run: python3 ops/observability/edge_health_delivery.py --selftest"
+    errors=$((errors + 1))
+else
+    echo "  ok: edge-health delivery acknowledgment fixtures pass"
+fi
+
+# The helper tests can remain green after someone deletes or bypasses the actual
+# schedule. Anchor the load-bearing workflow trigger and scan/delivery call sites.
+echo ""
+echo "=== sub2api: edge-health watch workflow contract ==="
+if ! python3 ./scripts/checks/edge-health-watch-contract.py >/dev/null 2>&1; then
+    echo "  FAIL: edge-health watch workflow contract"
+    echo "        — run: python3 scripts/checks/edge-health-watch-contract.py"
+    errors=$((errors + 1))
+else
+    echo "  ok: edge-health schedule, scan, delivery, and state call sites anchored"
+fi
+
 # ---- sub2api: edge disk/memory host-alert script selftest ------------------
 echo ""
 echo "=== sub2api: edge disk/memory host-alert selftest ==="

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1514,10 +1514,8 @@ fi
 
 # ---- sub2api: edge-health alert decision selftest --------------------------
 # The edge-health alert decision logic (actionable-set + state-diff dedup) lives in
-# edge-health-alert.py for manual triage via scan-edge-health.sh. Scheduled
-# edge-health-watch workflow was retired (2026-07): prod pool-exhaust Feishu + daily
-# client-fidelity-watch cover user-visible failures; intermediate edge posture churn
-# is intentionally manual. Fixtures pin the 2026-06-07 incident shapes + dedup behavior.
+# edge-health-alert.py; scheduled edge-health-watch GHA posts Feishu on change.
+# Fixtures pin the 2026-06-07 incident shapes + dedup behavior.
 echo ""
 echo "=== sub2api: edge-health alert decision selftest ==="
 if ! command -v python3 >/dev/null 2>&1; then
@@ -1529,6 +1527,32 @@ elif ! python3 ./ops/observability/edge-health-alert.py --selftest >/dev/null 2>
     errors=$((errors + 1))
 else
     echo "  ok: edge-health alert decision/dedup fixtures pass"
+fi
+
+# ---- sub2api: edge HTTPS health probe selftest -----------------------------
+# External /health resolver+probe (scan-edge-health.sh leading signal for host
+# hang / blackhole). Pure unit fixtures — no network.
+echo ""
+echo "=== sub2api: edge HTTPS health probe selftest ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for edge HTTPS health selftest)"
+    errors=$((errors + 1))
+elif ! python3 ./ops/observability/edge_https_health.py --selftest >/dev/null 2>&1; then
+    echo "  FAIL: edge HTTPS health probe selftest"
+    echo "        — run: python3 ops/observability/edge_https_health.py --selftest"
+    errors=$((errors + 1))
+else
+    echo "  ok: edge HTTPS health resolve/probe fixtures pass"
+fi
+
+# ---- sub2api: edge disk/memory host-alert script selftest ------------------
+echo ""
+echo "=== sub2api: edge disk/memory host-alert selftest ==="
+if ! bash ./deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh --selftest >/dev/null 2>&1; then
+    echo "  FAIL: tokenkey-disk-metrics-edge.sh --selftest"
+    errors=$((errors + 1))
+else
+    echo "  ok: edge disk/memory alert awk fixtures pass"
 fi
 
 # live-host state drift verdict (ops/stage0/live_host_state_verdict.py): the logic


### PR DESCRIPTION
## 摘要
- 恢复 `edge-health-watch` 定时巡检，在 SSM 前执行公网 `GET /health`，主机黑洞可在一轮内标为 `unreachable` 并发飞书。
- Feishu 投递改为 fail-closed：仅响应 body 确认成功后提交 dedup key；缺配置、投递失败、helper 故障或不完整扫描均不推进状态。
- Edge `tokenkey-disk-metrics` 对齐 prod 的根盘与 MemAvailable 内存压力飞书，并由 `sync-edge-host-units` 硬门禁 selftest 后推送。
- 修复两处随日历失效的测试基线，不改运行时 servable ledger 或订阅判定语义。

## 风险
- 常规风险：HTTPS transport 短抖可能增加 `unreachable` 告警；HTTP 502/503 仍继续走 SSM，不直接判主机失联。
- 自动化自身异常会使 workflow 明确失败并保留旧 dedup key，避免未投递告警被静默确认。
- 非高风险公共契约变更；`no-web-impact`。
- 线上 us3/us4/us5/us6 已热推 mem-guard；workflow 需合并后才进入 schedule。

## 验证
- `./scripts/preflight.sh` PASS
- `make test` PASS
- `make -C backend test-integration` PASS
- `python3 ops/observability/edge_https_health.py --selftest`
- `python3 ops/observability/edge-health-alert.py --selftest`
- `python3 ops/observability/edge_health_delivery.py --selftest`
- `bash ops/observability/test_scan_edge_health.sh`
- `bash deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh --selftest`
- `python3 scripts/checks/edge-health-watch-contract.py`
- 合并后：`gh workflow run edge-health-watch.yml -f dry_run=true`

## 提交
- 0d4a37295 fix(ops): restore edge HTTPS health watch and host mem-guard Feishu
- 201b68229 fix(ops): address R-001..R-004 — HTTPS transport-only unreachable; stop ledger date churn
- 66d18c4d3 fix(ops): put preflight-allow on HTTPS probe || true line
- 2eac20ad3 fix(ops): address R-001..R-005 — fail closed on edge alert delivery
- 最新提交：2eac20ad3