### PR TITLE
fix(ops): ghcr-prune-timer workflow YAML 重复 env 块

### DIFF
--- a/.github/workflows/ops-stage0-ghcr-prune-timer.yml
+++ b/.github/workflows/ops-stage0-ghcr-prune-timer.yml
@@ -105,12 +105,11 @@ jobs:
     if: inputs.target == 'all-deployable-edges' && needs.discover-edges.outputs.has_targets == 'true'
     runs-on: ubuntu-latest
     environment: prod
-    env:
-      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.discover-edges.outputs.matrix) }}
     env:
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
       EDGE_ID: ${{ matrix.edge_id }}
       AWS_REGION: ${{ matrix.region }}
     steps:


### PR DESCRIPTION
## 摘要

- 修复 `ops-stage0-ghcr-prune-timer.yml` 中 `all-deployable-edges` job 重复声明 `env:` 导致 GitHub workflow 校验失败、无法 workflow_dispatch 的问题。
- 合并为单一 job-level `env`（OIDC + matrix 字段），与 `ops-daily-diagnostics.yml` 模式一致。

## 风险

- 低风险：纯 workflow YAML 修复，无运行时行为变化。

## 验证

```bash
python3 dev-rules/scripts/check_workflow_yaml.py
```

## 提交

- ef88e19df fix(ops): merge duplicate env blocks in ghcr-prune-timer workflow

最新提交：ef88e19df

Made with [Cursor](https://cursor.com)