### PR TITLE
fix(ops): 飞书告警保留 DashScope help.aliyun 文档链接

### DIFF
--- a/backend/internal/service/newapi_bridge_penalty_tk.go
+++ b/backend/internal/service/newapi_bridge_penalty_tk.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	newapitypes "github.com/QuantumNous/new-api/types"
 	"github.com/gin-gonic/gin"
@@ -86,17 +87,46 @@ func tkBridgePenaltyStatusEligible(statusCode int) bool {
 // tkBridgeUpstreamErrorBody synthesizes an OpenAI-style error envelope from the
 // bridge relay error so RateLimitService body parsers (extractUpstreamErrorMessage,
 // parseOpenAIRateLimitResetTime, …) see the upstream message/code. NewAPIError
-// does not retain the raw upstream response body; ToOpenAIError() is the closest
-// faithful projection (it preserves the upstream message and structured code).
+// does not retain the raw upstream response body; prefer the raw RelayError
+// OpenAIError (before ToOpenAIError MaskSensitiveInfo) so ops/alert paths keep
+// public DashScope help URLs intact.
 func tkBridgeUpstreamErrorBody(apiErr *newapitypes.NewAPIError) []byte {
 	if apiErr == nil {
 		return nil
 	}
-	body, err := json.Marshal(map[string]any{"error": apiErr.ToOpenAIError()})
+	var envelope any
+	if oai, ok := tkBridgeUpstreamOpenAIError(apiErr); ok {
+		envelope = oai
+	} else {
+		envelope = apiErr.ToOpenAIError()
+	}
+	body, err := json.Marshal(map[string]any{"error": envelope})
 	if err != nil {
 		return nil
 	}
 	return body
+}
+
+// tkBridgeUpstreamRelayMessage returns the upstream message for ops_error_logs /
+// alert root-cause lines. ToOpenAIError() and MaskSensitiveInfo turn public
+// help.aliyun.com URLs into https://***.com/***/***/***, which Feishu lark_md
+// then renders as https://.com/// — use the raw RelayError envelope instead.
+func tkBridgeUpstreamRelayMessage(apiErr *newapitypes.NewAPIError) string {
+	if apiErr == nil {
+		return ""
+	}
+	code := strings.TrimSpace(string(apiErr.GetErrorCode()))
+	msg := ""
+	if oai, ok := tkBridgeUpstreamOpenAIError(apiErr); ok {
+		msg = strings.TrimSpace(oai.Message)
+	}
+	if msg == "" {
+		msg = strings.TrimSpace(apiErr.Error())
+	}
+	if code != "" && msg != "" {
+		return code + ": " + msg
+	}
+	return msg
 }
 
 // tkBridgeUpstreamOpenAIError returns the raw upstream OpenAI-style envelope

--- a/backend/internal/service/newapi_bridge_penalty_tk_test.go
+++ b/backend/internal/service/newapi_bridge_penalty_tk_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -176,6 +177,23 @@ func TestTkBridgeUpstreamErrorBody_OpenAIEnvelope(t *testing.T) {
 	require.Contains(t, string(body), `"error"`)
 	require.Contains(t, string(body), "Insufficient Balance")
 	require.Nil(t, tkBridgeUpstreamErrorBody(nil))
+}
+
+func TestTkBridgeUpstreamRelayMessage_PreservesDashScopeHelpURL(t *testing.T) {
+	const rateLimitMsg = "limit_requests: You have exceeded your current request limit. For details, see: " + dashScopeHelpURLRateLimit
+	err := newapitypes.WithOpenAIError(newapitypes.OpenAIError{
+		Message: rateLimitMsg,
+		Type:    "rate_limit_error",
+		Code:    "limit_requests",
+	}, http.StatusTooManyRequests)
+
+	got := tkBridgeUpstreamRelayMessage(err)
+	require.Contains(t, got, dashScopeHelpURLRateLimit)
+	require.NotContains(t, got, maskedPublicHelpURL)
+
+	body := string(tkBridgeUpstreamErrorBody(err))
+	require.Contains(t, body, dashScopeHelpURLRateLimit)
+	require.NotContains(t, body, maskedPublicHelpURL)
 }
 
 // The permanent Feishu card must render the upstream detail line when present

--- a/backend/internal/service/newapi_model_not_found_tk.go
+++ b/backend/internal/service/newapi_model_not_found_tk.go
@@ -74,12 +74,8 @@ func TkRecordBridgeUpstreamError(c *gin.Context, upstreamStatusCode int, err *ne
 	if c == nil || err == nil {
 		return
 	}
-	code := strings.TrimSpace(string(err.GetErrorCode()))
-	msg := strings.TrimSpace(err.Error())
-	if code != "" {
-		msg = code + ": " + msg
-	}
-	SetOpsUpstreamError(c, upstreamStatusCode, msg, code)
+	msg := tkBridgeUpstreamRelayMessage(err)
+	SetOpsUpstreamError(c, upstreamStatusCode, msg, strings.TrimSpace(string(err.GetErrorCode())))
 }
 
 // tkWrapBridgeRelayError records the real upstream status of a New API bridge

--- a/backend/internal/service/newapi_model_not_found_tk_test.go
+++ b/backend/internal/service/newapi_model_not_found_tk_test.go
@@ -69,3 +69,22 @@ func TestTkRecordBridgeUpstreamError_RecordsRealUpstream404(t *testing.T) {
 	require.True(t, IsOpenAICompatModelNotFound404(nil, msg.(string)),
 		"recorded message must be recognized as a model-not-found")
 }
+
+func TestTkRecordBridgeUpstreamError_PreservesDashScopeHelpURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	const want = dashScopeHelpURLRateLimit
+	apiErr := newapitypes.WithOpenAIError(newapitypes.OpenAIError{
+		Message: "You have exceeded your current request limit. For details, see: " + want,
+		Type:    "rate_limit_error",
+		Code:    "limit_requests",
+	}, http.StatusTooManyRequests)
+	TkRecordBridgeUpstreamError(c, apiErr.StatusCode, apiErr)
+
+	msg, ok := c.Get(OpsUpstreamErrorMessageKey)
+	require.True(t, ok)
+	require.Contains(t, msg.(string), want)
+	require.NotContains(t, msg.(string), maskedPublicHelpURL)
+}

--- a/backend/internal/service/ops_alert_top_cause_tk.go
+++ b/backend/internal/service/ops_alert_top_cause_tk.go
@@ -440,7 +440,7 @@ func formatUserVisibleFailureRoot(roots []*OpsUserVisibleFailureRoot) string {
 		if r.AccountID > 0 {
 			seg += fmt.Sprintf(" / account #%d", r.AccountID)
 		}
-		if msg := sanitizeFeishuLabel(r.Message); msg != "" {
+		if msg := sanitizeFeishuUpstreamRootMessage(r.Message); msg != "" {
 			seg += " / " + msg
 		}
 		parts = append(parts, fmt.Sprintf("%s ×%d", seg, r.Count))
@@ -481,6 +481,42 @@ var feishuLabelSanitizer = strings.NewReplacer(
 // trims surrounding whitespace. Returns "" for an all-blank/empty name.
 func sanitizeFeishuLabel(s string) string {
 	return strings.TrimSpace(feishuLabelSanitizer.Replace(s))
+}
+
+const (
+	dashScopeHelpURLRateLimit = "https://help.aliyun.com/zh/model-studio/error-code#rate-limit"
+	dashScopeHelpURLOverdue   = "https://help.aliyun.com/zh/model-studio/error-code#overdue-payment"
+	maskedPublicHelpURL       = "https://***.com/***/***/***"
+)
+
+// restoreDashScopeHelpURL reverses new-api MaskSensitiveInfo on public Aliyun
+// documentation links already persisted in ops_error_logs. Safe to call on
+// unmasked messages (no-op when the placeholder is absent).
+func restoreDashScopeHelpURL(msg string) string {
+	if msg == "" || !strings.Contains(msg, "https://***.com") {
+		return msg
+	}
+	lower := strings.ToLower(msg)
+	replacement := dashScopeHelpURLRateLimit
+	switch {
+	case strings.Contains(lower, "good standing"), strings.Contains(lower, "arrear"), strings.Contains(lower, "overdue"):
+		replacement = dashScopeHelpURLOverdue
+	case strings.Contains(lower, "limit_requests"), strings.Contains(lower, "request limit"), strings.Contains(lower, "rate limit"):
+		replacement = dashScopeHelpURLRateLimit
+	}
+	return strings.ReplaceAll(msg, maskedPublicHelpURL, replacement)
+}
+
+// sanitizeFeishuUpstreamRootMessage prepares provider-owned upstream error text
+// for lark_md cards. Unlike sanitizeFeishuLabel it keeps URL punctuation intact
+// and defangs asterisks so MaskSensitiveInfo placeholders are not eaten as bold.
+func sanitizeFeishuUpstreamRootMessage(msg string) string {
+	msg = strings.TrimSpace(restoreDashScopeHelpURL(msg))
+	if msg == "" {
+		return ""
+	}
+	msg = strings.ReplaceAll(msg, "*", "＊")
+	return escapeFeishuText(msg)
 }
 
 // truncateRunes shortens s to at most max runes (rune-safe for multibyte key

--- a/backend/internal/service/ops_alert_top_cause_tk_test.go
+++ b/backend/internal/service/ops_alert_top_cause_tk_test.go
@@ -304,3 +304,22 @@ func TestFormatRoutingRejectionByPlatform(t *testing.T) {
 		require.Contains(t, got, "#7")
 	})
 }
+
+func TestSanitizeFeishuUpstreamRootMessage_RestoresMaskedDashScopeHelpURL(t *testing.T) {
+	masked := "limit_requests: You have exceeded your current request limit. For details, see: " + maskedPublicHelpURL
+	got := sanitizeFeishuUpstreamRootMessage(masked)
+	require.Contains(t, got, dashScopeHelpURLRateLimit)
+	require.NotContains(t, got, maskedPublicHelpURL)
+	require.NotContains(t, got, "*")
+}
+
+func TestFormatUserVisibleFailureRoot_PreservesDashScopeHelpURL(t *testing.T) {
+	const upstreamMsg = "You have exceeded your current request limit. For details, see: " + dashScopeHelpURLRateLimit
+	got := formatUserVisibleFailureRoot([]*OpsUserVisibleFailureRoot{{
+		Phase: "upstream", Owner: "provider", Platform: "newapi", Model: "qwen3-14b",
+		AccountID: 60, Message: upstreamMsg, Count: 36,
+	}})
+	require.Contains(t, got, dashScopeHelpURLRateLimit)
+	require.NotContains(t, got, maskedPublicHelpURL)
+	require.Contains(t, got, "account #60")
+}


### PR DESCRIPTION
## 摘要

- 修复 `user_visible_failure_count` 告警「根因在哪」里 DashScope 文档链接被 mask + lark_md 渲染成 `https://.com///` 的问题
- ops 写入路径：`TkRecordBridgeUpstreamError` / `tkBridgeUpstreamErrorBody` 改用未 mask 的 RelayError 原文（与此前 arrears incident 卡片同一策略）
- 展示路径：`formatUserVisibleFailureRoot` 对上游 message 使用专用 sanitizer，还原历史 `https://***.com/***/***/***` 占位并避免 `*` 被 lark_md 当加粗吃掉

## 风险

- 常规风险：仅影响 ops 错误记录与飞书告警文案，不改变面向用户的 API 错误响应
- 暴露的是阿里云公开文档 URL，不含凭证

## 验证

- `go test -tags=unit ./internal/service/ -run 'TestTkBridgeUpstreamRelayMessage|TestTkRecordBridgeUpstreamError_Preserves|TestSanitizeFeishuUpstreamRootMessage|TestFormatUserVisibleFailureRoot_Preserves|TestTkBridgeArrearsDetail'`
- `./scripts/preflight.sh` 全绿

## 提交

- c8e2593d1 fix(ops): 保留 DashScope 文档链接，避免飞书告警根因显示空 URL

最新提交：c8e2593d1

## 门禁说明

- sentinel-registry-reviewed：已确认 `newapi_bridge_penalty_tk.go` 仅扩展 ops/告警写入路径，未删除 sentinel 锚点函数
- no-web-impact：仅改 ops 错误记录与飞书告警文案，无 WebUI/API 契约变化