### PR TITLE
feat(qa): Phase 1 关闭 Edge QA capture

### DIFF
--- a/ops/qa/edge_phase1_baseline.py
+++ b/ops/qa/edge_phase1_baseline.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Read-only edge QA Phase 1 baseline probe (capture env, timer, blob footprint)."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "ops" / "stage0"))
+from edge_ssm_execution import resolve_edge_execution_identity  # noqa: E402
+
+REMOTE = r"""set -euo pipefail
+cd /var/lib/tokenkey
+tag=$(sudo docker compose -f docker-compose.yml --env-file .env ps --format json 2>/dev/null | python3 -c "import json,sys; rows=[json.loads(l) for l in sys.stdin if l.strip()]; imgs=[r.get('Image','') for r in rows if r.get('Service')=='tokenkey']; print(imgs[0].split(':')[-1] if imgs else 'unknown')" 2>/dev/null || echo unknown)
+qa_env=$(grep -E '^(QA_CAPTURE_ENABLED|QA_CAPTURE_EXPORT_STORAGE_)' .env 2>/dev/null | tr '\n' ';' || true)
+qa_timer=$(systemctl is-active tokenkey-qa-stale-cleanup.timer 2>/dev/null || echo inactive)
+qa_cap=$(sudo docker compose -f docker-compose.yml --env-file .env exec -T tokenkey printenv QA_CAPTURE_ENABLED 2>/dev/null || echo missing)
+blob_count=0
+blob_bytes=0
+if [ -d qa_blobs ] || [ -d qa_dlq ]; then
+  blob_count=$(find qa_blobs qa_dlq -type f 2>/dev/null | wc -l | tr -d ' ')
+  blob_bytes=$(du -sb qa_blobs qa_dlq 2>/dev/null | awk '{s+=$1} END {print s+0}')
+fi
+printf 'TAG=%s\nQA_ENV=%s\nQA_TIMER=%s\nCONTAINER_QA_CAPTURE_ENABLED=%s\nBLOB_FILES=%s\nBLOB_BYTES=%s\n' "$tag" "$qa_env" "$qa_timer" "$qa_cap" "$blob_count" "$blob_bytes"
+"""
+
+
+def _send(region: str, instance_id: str, edge_id: str, comment: str) -> str:
+    args = ["aws", "ssm", "send-command", "--region", region]
+    if instance_id.startswith("mi-"):
+        args.extend(
+            [
+                "--targets",
+                f"Key=tag:EdgeId,Values={edge_id}",
+                "Key=tag:Platform,Values=lightsail",
+            ]
+        )
+    else:
+        args.extend(["--instance-ids", instance_id])
+    args.extend(
+        [
+            "--document-name",
+            "AWS-RunShellScript",
+            "--comment",
+            comment,
+            "--parameters",
+            json.dumps({"commands": [REMOTE]}),
+            "--query",
+            "Command.CommandId",
+            "--output",
+            "text",
+        ]
+    )
+    completed = subprocess.run(args, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise SystemExit(completed.stderr.strip() or "ssm send-command failed")
+    return completed.stdout.strip()
+
+
+def _resolve_instance_id(region: str, command_id: str, fallback: str) -> str:
+    for _ in range(60):
+        inv = subprocess.run(
+            [
+                "aws",
+                "ssm",
+                "list-command-invocations",
+                "--region",
+                region,
+                "--command-id",
+                command_id,
+                "--output",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if inv.returncode != 0:
+            time.sleep(2)
+            continue
+        rows = json.loads(inv.stdout).get("CommandInvocations") or []
+        if len(rows) == 1:
+            resolved = str(rows[0].get("InstanceId") or "").strip()
+            if resolved:
+                return resolved
+        time.sleep(2)
+    return fallback
+
+
+def _poll(region: str, command_id: str, instance_id: str) -> tuple[str, str, str]:
+    effective_id = _resolve_instance_id(region, command_id, instance_id)
+    for _ in range(40):
+        time.sleep(3)
+        inv = subprocess.run(
+            [
+                "aws",
+                "ssm",
+                "get-command-invocation",
+                "--region",
+                region,
+                "--command-id",
+                command_id,
+                "--instance-id",
+                effective_id,
+                "--output",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if inv.returncode != 0:
+            continue
+        data = json.loads(inv.stdout)
+        status = data.get("Status", "")
+        if status in {"Success", "Failed", "Cancelled", "TimedOut"}:
+            return status, data.get("StandardOutputContent", ""), data.get("StandardErrorContent", "")
+    raise SystemExit("ssm poll timeout")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--edge-id", required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    ident = resolve_edge_execution_identity(ROOT, args.edge_id)
+    command_id = _send(ident.region, ident.instance_id, ident.edge_id, f"edge qa phase1 baseline {ident.edge_id}")
+    status, stdout, stderr = _poll(ident.region, command_id, ident.instance_id)
+    payload = {
+        "edge_id": ident.edge_id,
+        "region": ident.region,
+        "instance_id": ident.instance_id,
+        "command_id": command_id,
+        "status": status,
+        "stdout": stdout.strip(),
+        "stderr": stderr.strip(),
+    }
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=True, sort_keys=True))
+    else:
+        print(f"edge={ident.edge_id} status={status}")
+        print(stdout.strip())
+        if stderr.strip():
+            print(stderr.strip(), file=sys.stderr)
+    return 0 if status == "Success" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/qa/policy.yaml
+++ b/ops/qa/policy.yaml
@@ -1,0 +1,35 @@
+schema_version: 1
+
+prod:
+  capture_enabled: true
+  online_window_hours: 24
+  maintenance_schedule_utc: "*:15"
+  physical_cleanup_max_lag_minutes: 75
+
+  archive:
+    enabled: true
+    scope: all_users_all_api_keys
+    shard_minutes: 60
+    seal_delay_minutes: 15
+    s3_retention_days: 7
+    raw_user_access: false
+
+  user_export:
+    entitlement: users.traj_export_enabled
+    source: s3_raw_archive
+    compute: ecs_fargate
+    download: direct_s3
+    prod_fallback: forbidden
+
+  disk_emergency:
+    used_percent: 80
+    free_gib: 10
+    cleanup_target_percent: 70
+    pause_capture: false
+
+edge:
+  capture_enabled: false
+  archive_enabled: false
+  cleanup_enabled: false
+  export_enabled: false
+  s3_access: false

--- a/ops/stage0/deploy_via_ssm.sh
+++ b/ops/stage0/deploy_via_ssm.sh
@@ -220,6 +220,29 @@ fi
 # going live, when sustained large-body generation traffic becomes likely. All
 # three knobs are env-overridable. Prod-only (EC2 `i-*`); edges (Lightsail `mi-*`)
 # never serve generation and get [] (byte-identical command list as before).
+# --- Edge QA capture off (Lightsail mi-* only) -------------------------------
+# Phase 1 of docs/approved/design-prod-qa-24h-s3-lifecycle.md: edges must not
+# capture, archive, export, or retain QA. Prod-only blocks above stay gated to
+# EC2 i-*; this block is the symmetric edge gate. Values derive from ops/qa/policy.yaml.
+edge_qa_capture_cmds='[]'
+if [[ "${INSTANCE_ID}" == mi-* ]]; then
+  edge_qa_capture_cmds="$(jq -n \
+    --arg tag "${TAG}" '
+    [
+      ( "if grep -q '\''^QA_CAPTURE_ENABLED='\'' /var/lib/tokenkey/.env; then"
+        + " sudo sed -i '\''s|^QA_CAPTURE_ENABLED=.*|QA_CAPTURE_ENABLED=false|'\'' /var/lib/tokenkey/.env; echo ensured-QA_CAPTURE_ENABLED=false;"
+        + " else echo QA_CAPTURE_ENABLED=false | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo ensured-QA_CAPTURE_ENABLED=false; fi" ),
+      ( "CF=/var/lib/tokenkey/docker-compose.yml; if [ -f \"$CF\" ]; then"
+        + " if ! grep -q \"QA_CAPTURE_ENABLED=\" \"$CF\"; then"
+        + " sudo cp -a \"$CF\" \"$CF.edge-qa-capture-before-" + $tag + "\";"
+        + " sudo sed -i '\''/^      - SERVER_FRONTEND_URL=/a\\      - QA_CAPTURE_ENABLED=${QA_CAPTURE_ENABLED:-}'\'' \"$CF\";"
+        + " fi;"
+        + " if grep -q \"QA_CAPTURE_ENABLED=\" \"$CF\"; then echo ensured-compose-QA_CAPTURE_ENABLED-mapping;"
+        + " else echo '\''::warning::failed to insert compose QA_CAPTURE_ENABLED mapping'\''; fi;"
+        + " else echo compose-file-missing-skip-QA_CAPTURE_ENABLED; fi" )
+    ]')"
+fi
+
 image_concurrency_cmds='[]'
 if [[ "${INSTANCE_ID}" == i-* ]]; then
   image_concurrency_cmds="$(jq -n \
@@ -244,7 +267,7 @@ if [[ "${INSTANCE_ID}" == i-* ]]; then
     ]')"
 fi
 
-jq -n --arg tag "${TAG}" --argjson qa_cmds "${qa_export_cmds}" --argjson media_cmds "${media_storage_cmds}" --argjson ic_cmds "${image_concurrency_cmds}" '{
+jq -n --arg tag "${TAG}" --argjson qa_cmds "${qa_export_cmds}" --argjson media_cmds "${media_storage_cmds}" --argjson ic_cmds "${image_concurrency_cmds}" --argjson edge_qa_cmds "${edge_qa_capture_cmds}" '{
   commands: ([
     "set -euo pipefail",
     ("echo === deploy stage0 to tag=" + $tag + " ==="),
@@ -260,7 +283,7 @@ jq -n --arg tag "${TAG}" --argjson qa_cmds "${qa_export_cmds}" --argjson media_c
     "if ! grep -q '\''^SERVER_FRONTEND_URL='\'' /var/lib/tokenkey/.env; then d=$(sed -n '\''s/^API_DOMAIN=//p'\'' /var/lib/tokenkey/.env | head -1); if [ -n \"$d\" ]; then echo \"SERVER_FRONTEND_URL=https://$d\" | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo \"ensured SERVER_FRONTEND_URL=https://$d\"; else echo \"API_DOMAIN empty; skip SERVER_FRONTEND_URL backfill\"; fi; else echo \"SERVER_FRONTEND_URL already present\"; fi",
     "if ! grep -q '\''^TOKENKEY_GHCR_KEEP_TAGS='\'' /var/lib/tokenkey/.env; then echo '\''TOKENKEY_GHCR_KEEP_TAGS=3'\'' | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo '\''ensured TOKENKEY_GHCR_KEEP_TAGS=3'\''; else echo '\''TOKENKEY_GHCR_KEEP_TAGS already present'\''; fi",
     ("if [ -f /var/lib/tokenkey/docker-compose.yml ] && ! grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then sudo cp -a /var/lib/tokenkey/docker-compose.yml /var/lib/tokenkey/docker-compose.yml.compose-before-" + $tag + "; sudo sed -i '\''/^      - TZ=/a\\      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}'\'' /var/lib/tokenkey/docker-compose.yml; if grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then echo ensured-compose-SERVER_FRONTEND_URL-mapping; else echo '\''::warning::failed to insert compose SERVER_FRONTEND_URL mapping'\''; fi; else echo compose-SERVER_FRONTEND_URL-mapping-present-or-no-compose; fi")
-  ] + $qa_cmds + $media_cmds + $ic_cmds + [
+  ] + $qa_cmds + $media_cmds + $ic_cmds + $edge_qa_cmds + [
     "echo \"=== pull new image BEFORE drain (old container keeps serving 100% traffic) ===\"",
     "cd /var/lib/tokenkey && sudo docker compose --env-file .env pull tokenkey",
     "echo \"=== pre-drain: SIGUSR1 + wait in_flight=0 (only when outgoing container healthy) ===\"",

--- a/ops/stage0/edge_post_deploy_smoke.sh
+++ b/ops/stage0/edge_post_deploy_smoke.sh
@@ -95,6 +95,9 @@ run_infra_smoke() {
     "cd /var/lib/tokenkey"
     "sudo docker compose version"
     "sudo docker compose -f docker-compose.yml --env-file .env ps"
+    'qa_cap=$(sudo docker compose -f docker-compose.yml --env-file .env exec -T tokenkey printenv QA_CAPTURE_ENABLED 2>/dev/null || echo missing)'
+    'echo "tk_edge_post_deploy_smoke: container QA_CAPTURE_ENABLED=${qa_cap}"'
+    'if [ "${qa_cap}" != "false" ]; then echo "tk_edge_post_deploy_smoke: edge QA capture must be disabled (QA_CAPTURE_ENABLED=false)" >&2; exit 1; fi'
     "sudo docker compose -f docker-compose.yml --env-file .env exec -T tokenkey wget -qO- http://localhost:8080/health"
   )
 

--- a/ops/stage0/test_deploy_via_ssm_edge_qa_capture.py
+++ b/ops/stage0/test_deploy_via_ssm_edge_qa_capture.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Tests for edge-only QA capture disable injection in deploy_via_ssm.sh."""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent / "deploy_via_ssm.sh"
+_PROD_IID = "i-0prod000000000000"
+_EDGE_IID = "mi-0edge000000000000"
+
+
+def _render(instance_id: str, tag: str = "1.8.99", env_extra: dict | None = None):
+    out_dir = tempfile.mkdtemp(prefix="edge-qa-capture-render-")
+    env = {**os.environ, "STAGE0_RENDER_ONLY": "1", "STAGE0_SSM_OUTPUT_DIR": out_dir}
+    if env_extra:
+        env.update(env_extra)
+    proc = subprocess.run(
+        ["bash", str(_SCRIPT), tag, instance_id],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    params = json.loads((pathlib.Path(out_dir) / "ssm-params.json").read_text())
+    return proc, params["commands"]
+
+
+def _edge_qa_cmds(commands: list[str]) -> list[str]:
+    return [c for c in commands if "QA_CAPTURE_ENABLED" in c]
+
+
+class EdgeQACaptureDisableRenderTest(unittest.TestCase):
+    def test_edge_injects_exactly_two_guarded_commands(self) -> None:
+        proc, commands = _render(_EDGE_IID, env_extra={"EDGE_ID": "us6"})
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        edge_cmds = _edge_qa_cmds(commands)
+        self.assertEqual(len(edge_cmds), 2, msg=edge_cmds)
+        env_cmd, compose_cmd = edge_cmds
+        self.assertIn("QA_CAPTURE_ENABLED=false", env_cmd)
+        self.assertIn("sed -i", env_cmd)
+        self.assertIn("SERVER_FRONTEND_URL", compose_cmd)
+        self.assertIn("QA_CAPTURE_ENABLED=${QA_CAPTURE_ENABLED:-}", compose_cmd)
+
+    def test_prod_gets_no_edge_qa_capture_injection(self) -> None:
+        proc, commands = _render(_PROD_IID)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_edge_qa_cmds(commands), [])
+
+    def test_prod_minus_edge_counts_prod_only_and_edge_only_blocks(self) -> None:
+        _, prod = _render(_PROD_IID)
+        _, edge = _render(_EDGE_IID, env_extra={"EDGE_ID": "us6"})
+        prod_only = sum(
+            1
+            for c in prod
+            if "QA_CAPTURE_EXPORT_STORAGE" in c
+            or "MEDIA_STORAGE_" in c
+            or "GATEWAY_IMAGE_CONCURRENCY" in c
+        )
+        edge_only = len(_edge_qa_cmds(edge))
+        self.assertEqual(prod_only, 6)
+        self.assertEqual(edge_only, 2)
+        self.assertEqual(len(prod) - len(edge), prod_only - edge_only)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/stage0/test_deploy_via_ssm_qa_export.py
+++ b/ops/stage0/test_deploy_via_ssm_qa_export.py
@@ -86,11 +86,16 @@ class QAExportInjectionRenderTest(unittest.TestCase):
         self.assertIn('grep -q "${key}=" "$CF"', compose_cmd)    # guarded insertion
 
     def test_edge_gets_no_qa_injection(self) -> None:
-        # mi-* + EDGE_ID is the edge arm: the command list must be byte-identical
-        # to the pre-change baseline (empty injection array).
+        # mi-* + EDGE_ID is the edge arm: no prod QA export/storage injection.
         proc, commands = _render(_EDGE_IID, env_extra={"EDGE_ID": "us2"})
         self.assertEqual(proc.returncode, 0, msg=proc.stderr)
         self.assertEqual(_qa_cmds(commands), [])
+
+    def test_edge_gets_qa_capture_disable_not_export(self) -> None:
+        proc, commands = _render(_EDGE_IID, env_extra={"EDGE_ID": "us2"})
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        capture_cmds = [c for c in commands if "QA_CAPTURE_ENABLED" in c]
+        self.assertEqual(len(capture_cmds), 2)
 
     def test_prod_minus_edge_is_only_the_prod_only_injections(self) -> None:
         # The only difference between prod and edge is the prod-only injected
@@ -106,7 +111,9 @@ class QAExportInjectionRenderTest(unittest.TestCase):
             or "GATEWAY_IMAGE_CONCURRENCY" in c
         )
         self.assertEqual(injected, 6)
-        self.assertEqual(len(prod) - len(edge), injected)
+        edge_capture = sum(1 for c in edge if "QA_CAPTURE_ENABLED" in c)
+        self.assertEqual(edge_capture, 2)
+        self.assertEqual(len(prod) - len(edge), injected - edge_capture)
 
     def test_values_are_env_overridable(self) -> None:
         proc, commands = _render(_PROD_IID, env_extra={

--- a/scripts/checks/qa-lifecycle-ssot.py
+++ b/scripts/checks/qa-lifecycle-ssot.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SSOT = Path("docs/approved/design-prod-qa-24h-s3-lifecycle.md")
+POLICY = Path("ops/qa/policy.yaml")
 
 MUST_BE_ABSENT = (
     Path("docs/qa-export-s3-and-auto-archive.md"),
@@ -60,6 +61,15 @@ REQUIRED_BY_FILE = {
         "status: approved",
         "### 8.5 四类存储与备份边界",
         "### 18.1 现状 owner → 唯一目标 owner → 退役门禁",
+    ),
+    POLICY: (
+        "schema_version: 1",
+        "capture_enabled: false",
+        "edge:",
+    ),
+    Path("ops/stage0/deploy_via_ssm.sh"): (
+        "edge_qa_capture_cmds",
+        "QA_CAPTURE_ENABLED=false",
     ),
     Path("ops/archive/data_layer_archive_rehearsal.py"): (
         'DATASETS = ("usage", "ops")',

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1231,6 +1231,20 @@ else
     echo "  ok: one approved QA lifecycle owner; retired conflicts remain absent"
 fi
 
+# ---- sub2api: QA Phase 1 edge baseline probe (read-only ops) ---------------
+# Owner: ops/qa/edge_phase1_baseline.py — soak verification for edge capture=false.
+echo ""
+echo "=== sub2api: QA Phase 1 edge baseline probe ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by edge_phase1_baseline.py)"
+    errors=$((errors + 1))
+elif ! python3 -m py_compile ./ops/qa/edge_phase1_baseline.py; then
+    echo "  FAIL: edge_phase1_baseline.py does not compile"
+    errors=$((errors + 1))
+else
+    echo "  ok: edge_phase1_baseline.py present (Phase 1 soak probe wired)"
+fi
+
 # ---- sub2api: QA evidence dataset validator ----------------------------------------
 # Source of truth: scripts/checks/qa-evidence-dataset.py. Verifies that the standalone
 # QA evidence dataset gate remains executable from repo root and the regression


### PR DESCRIPTION
## 摘要

- 启动轨道 B Phase 1：Lightsail edge 部署时强制 `QA_CAPTURE_ENABLED=false`，并在 infra smoke 断言容器侧已关闭。
- 新增 `ops/qa/policy.yaml` 作为 QA lifecycle 数值 SSOT；`qa-lifecycle-ssot.py` 与 deploy 注入路径纳入机械门禁。
- 新增只读探针 `ops/qa/edge_phase1_baseline.py`，用于 soak 前后对比 blob/ env / timer 状态。
- us6 canary 已在 `1.8.135` 验证：部署后容器 `QA_CAPTURE_ENABLED=false`，infra smoke 与 `/health` 正常。

## 风险

- 常规风险：仅影响 edge QA capture，prod 与 gateway 主路径不变；edge 存量 QA 数据与 stale cleanup timer 本 PR 不删除（Phase 1 后续步骤）。
- 回滚：edge redeploy 时将 `QA_CAPTURE_ENABLED` 改回 true 即可恢复 capture（不建议，与设计 SSOT 冲突）。

## 验证

- `python3 ops/stage0/test_deploy_via_ssm_edge_qa_capture.py`：通过
- `python3 ops/stage0/test_deploy_via_ssm_qa_export.py`：通过
- `python3 scripts/checks/qa-lifecycle-ssot.py`：通过
- us6 canary（pre-PR 本地 `deploy_via_ssm.sh 1.8.135`）：`ensured-QA_CAPTURE_ENABLED=false`，smoke OK，`https://api-us6.tokenkey.dev/health` → 200

## 提交

- `b34e2afde` feat(qa): Phase 1 关闭 Edge QA capture 并固化部署门禁

最新提交：b34e2afde

Made with [Cursor](https://cursor.com)