### PR TITLE
feat(qa): Phase 1 Edge closeout 与 Phase 2 raw archive 骨架

### DIFF
--- a/.github/workflows/deploy-edge-lightsail-stage0.yml
+++ b/.github/workflows/deploy-edge-lightsail-stage0.yml
@@ -244,24 +244,14 @@ jobs:
           TK_FEISHU_SIGNING_SECRET: ${{ secrets.TK_FEISHU_SIGNING_SECRET }}
         run: bash ops/stage0/sync-feishu-config.sh --platform lightsail "${{ steps.edge.outputs.edge_id }}"
 
-      - name: Sync edge host units (disk-full alert + transitional QA cleanup)
-        # TRANSITIONAL / NON-SSOT: Phase 1 removes QA from this step after
-        # capture=false is verified. Do not extend this compatibility path.
-        # prod (deploy/aws/stage0/stage0-ec2-bootstrap.sh) installs AND enables
-        # tokenkey-disk-metrics.timer (#778 on-box disk alert) and
-        # tokenkey-qa-stale-cleanup.timer; the Lightsail user-data 14 KB cap means
-        # render-bootstrap can only ship the scripts, not wire the units, and
-        # deploy_via_ssm.sh never re-runs bootstrap. So existing edges silently
-        # lacked the disk alert (filled-disk crash with no notice) and QA cleanup
-        # (qa_records/qa_blobs grew unbounded). This SSM push reaches existing edges
-        # and new ones (after provision). Runs AFTER the Feishu step so the disk
-        # alert finds TOKENKEY_FEISHU_WEBHOOK_URL/_SECRET in .env on its first fire.
+      - name: Sync edge host units (disk-full alert + GHCR daily prune)
+        # prod installs tokenkey-disk-metrics.timer via bootstrap; Lightsail user-data
+        # cap means render-bootstrap ships scripts only. This SSM push backfills
+        # disk/memory alerts and GHCR prune on existing edges. Phase 1 removed QA.
         if: inputs.operation == 'provision' || inputs.operation == 'upgrade' || inputs.operation == 'rollback' || inputs.operation == 'smoke'
         env:
           INSTANCE_ID: ${{ steps.instance.outputs.managed_instance_id }}
           AWS_REGION: ${{ steps.edge.outputs.lightsail_region }}
-          # Compatibility value only; not the QA lifecycle policy.
-          TK_QA_STALE_RETENTION_DAYS: "1"
           STAGE0_SSM_OUTPUT_DIR: .
         run: bash ops/stage0/sync-edge-host-units-via-ssm.sh "$INSTANCE_ID" "edge-host-units edge=${{ steps.edge.outputs.edge_id }}"
 

--- a/deploy/aws/cloudformation/stage0-qa-raw-archive.yaml
+++ b/deploy/aws/cloudformation/stage0-qa-raw-archive.yaml
@@ -1,0 +1,169 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  tokenkey Stage 0 standalone QA raw archive bucket (Phase 2). Separate from
+  QaExportsBucket (user trajectory ZIP artifacts) and generic data-layer archive.
+  Lifecycle owner: docs/approved/design-prod-qa-24h-s3-lifecycle.md §8.1.
+
+Parameters:
+  ProjectName:
+    Type: String
+    Default: tokenkey
+  Environment:
+    Type: String
+    Default: prod
+  RawRetentionDays:
+    Type: Number
+    Default: 7
+    MinValue: 1
+    MaxValue: 30
+    Description: Days to keep committed raw/v1/ shard objects.
+  PartialRetentionDays:
+    Type: Number
+    Default: 1
+    MinValue: 1
+    MaxValue: 7
+    Description: Days to keep incomplete raw/partial/ shard objects.
+  AppInstanceRoleArn:
+    Type: String
+    Description: >
+      Prod app instance role allowed to write raw archive shards (PutObject/HeadObject
+      on raw/ prefixes). Same direct-role-ARN pattern as stage0-backups.yaml.
+  OpsRecoveryRoleArn:
+    Type: String
+    Default: ''
+    Description: >
+      Optional ops recovery role for audited GetObject/ListBucket on raw/ prefixes.
+
+Conditions:
+  HasOpsRecoveryRole: !Not [!Equals [!Ref OpsRecoveryRoleArn, '']]
+
+Resources:
+  QaRawArchiveKey:
+    Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Description: SSE-KMS key for tokenkey prod QA raw archive bucket
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowRootAccountAdmin
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+
+  QaRawArchiveKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub 'alias/${ProjectName}-${Environment}-qa-raw-archive'
+      TargetKeyId: !Ref QaRawArchiveKey
+
+  QaRawArchiveBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub '${ProjectName}-${Environment}-qa-raw-archive-${AWS::AccountId}'
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
+              KMSMasterKeyID: !GetAtt QaRawArchiveKey.Arn
+            BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Suspended
+      LifecycleConfiguration:
+        Rules:
+          - Id: expire-raw-v1-shards
+            Status: Enabled
+            Prefix: raw/v1/
+            ExpirationInDays: !Ref RawRetentionDays
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+          - Id: expire-raw-partial-shards
+            Status: Enabled
+            Prefix: raw/partial/
+            ExpirationInDays: !Ref PartialRetentionDays
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+
+  QaRawArchiveBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref QaRawArchiveBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !GetAtt QaRawArchiveBucket.Arn
+              - !Sub '${QaRawArchiveBucket.Arn}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
+          - Sid: AllowAppInstanceRoleWriteRaw
+            Effect: Allow
+            Principal:
+              AWS: !Ref AppInstanceRoleArn
+            Action:
+              - 's3:PutObject'
+              - 's3:GetObject'
+              - 's3:AbortMultipartUpload'
+              - 's3:ListMultipartUploadParts'
+            Resource:
+              - !Sub '${QaRawArchiveBucket.Arn}/raw/v1/*'
+              - !Sub '${QaRawArchiveBucket.Arn}/raw/partial/*'
+          - Sid: AllowAppInstanceRoleHeadRaw
+            Effect: Allow
+            Principal:
+              AWS: !Ref AppInstanceRoleArn
+            Action: 's3:GetObject'
+            Resource:
+              - !Sub '${QaRawArchiveBucket.Arn}/raw/v1/*'
+              - !Sub '${QaRawArchiveBucket.Arn}/raw/partial/*'
+          - Sid: AllowAppInstanceRoleListRawPrefix
+            Effect: Allow
+            Principal:
+              AWS: !Ref AppInstanceRoleArn
+            Action: 's3:ListBucket'
+            Resource: !GetAtt QaRawArchiveBucket.Arn
+            Condition:
+              StringLike:
+                's3:prefix':
+                  - 'raw/v1/*'
+                  - 'raw/partial/*'
+          - !If
+            - HasOpsRecoveryRole
+            - Sid: AllowOpsRecoveryRoleReadRaw
+              Effect: Allow
+              Principal:
+                AWS: !Ref OpsRecoveryRoleArn
+              Action:
+                - 's3:GetObject'
+                - 's3:ListBucket'
+              Resource:
+                - !GetAtt QaRawArchiveBucket.Arn
+                - !Sub '${QaRawArchiveBucket.Arn}/raw/*'
+            - !Ref AWS::NoValue
+
+Outputs:
+  QaRawArchiveBucketName:
+    Description: Prod QA raw archive bucket (7d committed / 1d partial lifecycle)
+    Value: !Ref QaRawArchiveBucket
+  QaRawArchiveBucketArn:
+    Value: !GetAtt QaRawArchiveBucket.Arn
+  QaRawArchiveKmsKeyArn:
+    Value: !GetAtt QaRawArchiveKey.Arn
+  QaRawArchiveS3Uri:
+    Value: !Sub 's3://${QaRawArchiveBucket}/raw/v1/'

--- a/deploy/aws/cloudformation/stage0-qa-raw-archive.yaml
+++ b/deploy/aws/cloudformation/stage0-qa-raw-archive.yaml
@@ -54,6 +54,41 @@ Resources:
               AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
             Action: 'kms:*'
             Resource: '*'
+          - Sid: AllowAppInstanceRoleUseViaS3
+            Effect: Allow
+            Principal:
+              AWS: !Ref AppInstanceRoleArn
+            Action:
+              - 'kms:Encrypt'
+              - 'kms:Decrypt'
+              - 'kms:ReEncrypt*'
+              - 'kms:GenerateDataKey*'
+              - 'kms:DescribeKey'
+            Resource: '*'
+            Condition:
+              StringEquals:
+                kms:ViaService: !Sub 's3.${AWS::Region}.amazonaws.com'
+              StringLike:
+                kms:EncryptionContext:aws:s3:arn:
+                  - !Sub 'arn:${AWS::Partition}:s3:::${ProjectName}-${Environment}-qa-raw-archive-${AWS::AccountId}/raw/v1/*'
+                  - !Sub 'arn:${AWS::Partition}:s3:::${ProjectName}-${Environment}-qa-raw-archive-${AWS::AccountId}/raw/partial/*'
+          - !If
+            - HasOpsRecoveryRole
+            - Sid: AllowOpsRecoveryRoleReadViaS3
+              Effect: Allow
+              Principal:
+                AWS: !Ref OpsRecoveryRoleArn
+              Action:
+                - 'kms:Decrypt'
+                - 'kms:DescribeKey'
+              Resource: '*'
+              Condition:
+                StringEquals:
+                  kms:ViaService: !Sub 's3.${AWS::Region}.amazonaws.com'
+                StringLike:
+                  kms:EncryptionContext:aws:s3:arn:
+                    - !Sub 'arn:${AWS::Partition}:s3:::${ProjectName}-${Environment}-qa-raw-archive-${AWS::AccountId}/raw/*'
+            - !Ref AWS::NoValue
 
   QaRawArchiveKeyAlias:
     Type: AWS::KMS::Alias

--- a/docs/approved/design-prod-qa-24h-s3-lifecycle.md
+++ b/docs/approved/design-prod-qa-24h-s3-lifecycle.md
@@ -707,6 +707,13 @@ prod job creator 必须从服务端用户事实读取 `traj_export_enabled` 并�
 
 ### Phase 2：Prod raw archive-only
 
+Phase 2 的独立 deploy 入口为 `ops/qa/deploy_qa_raw_archive_cfn.sh`：它要求显式传入
+`APP_INSTANCE_ROLE_ARN`（可选 `OPS_RECOVERY_ROLE_ARN`）并以 `QA_RAW_ARCHIVE_CONFIRM=yes`
+作为人工门闩，部署 `deploy/aws/cloudformation/stage0-qa-raw-archive.yaml`。该模板的
+SSE-KMS key 必须与 bucket policy 同步授权：prod app role 仅可经 S3 访问 `raw/v1/` /
+`raw/partial/` 前缀，ops recovery role（若配置）仅可经 S3 只读 `raw/` 前缀，避免出现
+bucket 允许而 KMS 拒绝的半配置状态。
+
 1. 创建独立 raw bucket、KMS、VPC Endpoint、IAM、Lifecycle 和 CloudTrail Data Events；
 2. 部署 shard/control/manifest，但不删除本地数据；
 3. backfill 当前仍在线数据；

--- a/ops/qa/deploy_qa_raw_archive_cfn.sh
+++ b/ops/qa/deploy_qa_raw_archive_cfn.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Deploy the standalone QA raw archive CloudFormation stack (Phase 2 step 1).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="${ROOT}/deploy/aws/cloudformation/stage0-qa-raw-archive.yaml"
+STACK="${QA_RAW_ARCHIVE_STACK:-tokenkey-prod-qa-raw-archive}"
+# Prod Stage0 lives in us-east-1; raw archive must colocate with the app instance.
+REGION="${AWS_REGION:-us-east-1}"
+
+if [ -z "${APP_INSTANCE_ROLE_ARN:-}" ]; then
+  echo "APP_INSTANCE_ROLE_ARN is required (prod InstanceRole ARN)" >&2
+  exit 1
+fi
+
+args=(
+  cloudformation deploy
+  --region "${REGION}"
+  --stack-name "${STACK}"
+  --template-file "${TEMPLATE}"
+  --parameter-overrides
+  "AppInstanceRoleArn=${APP_INSTANCE_ROLE_ARN}"
+)
+if [ -n "${OPS_RECOVERY_ROLE_ARN:-}" ]; then
+  args+=("OpsRecoveryRoleArn=${OPS_RECOVERY_ROLE_ARN}")
+fi
+if [ "${QA_RAW_ARCHIVE_CONFIRM:-}" != "yes" ]; then
+  echo "Set QA_RAW_ARCHIVE_CONFIRM=yes to deploy ${STACK} in ${REGION}" >&2
+  exit 1
+fi
+
+aws "${args[@]}"
+
+aws cloudformation describe-stacks \
+  --region "${REGION}" \
+  --stack-name "${STACK}" \
+  --query 'Stacks[0].Outputs' \
+  --output table

--- a/ops/qa/edge_phase1_closeout.py
+++ b/ops/qa/edge_phase1_closeout.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Read-only edge QA Phase 1 baseline probe (capture env, timer, blob footprint)."""
+"""One-shot Edge QA Phase 1 closeout: purge stale QA data and remove host QA wiring."""
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import subprocess
 import sys
@@ -15,21 +16,69 @@ from edge_ssm_execution import resolve_edge_execution_identity  # noqa: E402
 
 REMOTE = r"""set -euo pipefail
 cd /var/lib/tokenkey
-tag=$(sudo docker compose -f docker-compose.yml --env-file .env ps --format json 2>/dev/null | python3 -c "import json,sys; rows=[json.loads(l) for l in sys.stdin if l.strip()]; imgs=[r.get('Image','') for r in rows if r.get('Service')=='tokenkey']; print(imgs[0].split(':')[-1] if imgs else 'unknown')" 2>/dev/null || echo unknown)
-qa_env=$(grep -E '^(QA_CAPTURE_ENABLED|QA_CAPTURE_EXPORT_STORAGE_)' .env 2>/dev/null | tr '\n' ';' || true)
+apply="__APPLY__"
+if [ "${apply}" != "true" ]; then
+  qa_timer=$(systemctl show -p ActiveState --value tokenkey-qa-stale-cleanup.timer 2>/dev/null || echo missing)
+  qa_cap=$(sudo docker compose -f docker-compose.yml --env-file .env exec -T tokenkey printenv QA_CAPTURE_ENABLED 2>/dev/null || echo missing)
+  rec_count=0
+  if sudo docker ps --format '{{.Names}}' | grep -qx tokenkey-postgres; then
+    PGPASS="$(sudo grep '^POSTGRES_PASSWORD=' /var/lib/tokenkey/.env | cut -d= -f2- || true)"
+    NET="$(sudo docker inspect tokenkey-postgres --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}' 2>/dev/null || true)"
+    if [ -n "${PGPASS}" ] && [ -n "${NET}" ]; then
+      rec_count=$(sudo docker run --rm --network "${NET}" -e PGPASSWORD="${PGPASS}" postgres:16-alpine \
+        psql -h tokenkey-postgres -U tokenkey -d tokenkey -Atqc "SELECT COUNT(*) FROM qa_records;" 2>/dev/null || echo 0)
+    fi
+  fi
+  blob_count=0
+  for d in qa_blobs qa_dlq qa_exports_tmp; do
+    [ -d "$d" ] || continue
+    blob_count=$((blob_count + $(find "$d" -type f 2>/dev/null | wc -l | tr -d ' ')))
+  done
+  printf 'DRY_RUN=true\nQA_TIMER=%s\nCONTAINER_QA_CAPTURE_ENABLED=%s\nQA_RECORDS=%s\nBLOB_FILES=%s\n' \
+    "$qa_timer" "$qa_cap" "$rec_count" "$blob_count"
+  exit 0
+fi
+sudo systemctl stop tokenkey-qa-stale-cleanup.timer 2>/dev/null || true
+sudo systemctl disable tokenkey-qa-stale-cleanup.timer 2>/dev/null || true
+sudo systemctl stop tokenkey-qa-stale-cleanup.service 2>/dev/null || true
+sudo rm -f /etc/systemd/system/tokenkey-qa-stale-cleanup.service /etc/systemd/system/tokenkey-qa-stale-cleanup.timer
+sudo rm -f /usr/local/bin/tokenkey-qa-stale-cleanup.sh /etc/tokenkey/qa-stale-retention.env
+sudo systemctl daemon-reload
+sudo systemctl reset-failed tokenkey-qa-stale-cleanup.service 2>/dev/null || true
+if sudo docker ps --format '{{.Names}}' | grep -qx tokenkey-postgres; then
+  PGPASS="$(sudo grep '^POSTGRES_PASSWORD=' /var/lib/tokenkey/.env | cut -d= -f2-)"
+  NET="$(sudo docker inspect tokenkey-postgres --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}')"
+  if [ -n "${PGPASS}" ] && [ -n "${NET}" ]; then
+    sudo docker run --rm --network "${NET}" -e PGPASSWORD="${PGPASS}" postgres:16-alpine \
+      psql -h tokenkey-postgres -U tokenkey -d tokenkey -v ON_ERROR_STOP=1 \
+      -c "TRUNCATE qa_records;"
+  fi
+fi
+sudo rm -rf qa_blobs qa_dlq qa_exports_tmp
+sudo install -d -m 0755 qa_blobs qa_dlq 2>/dev/null || true
 qa_timer=$(systemctl show -p ActiveState --value tokenkey-qa-stale-cleanup.timer 2>/dev/null || echo missing)
 qa_cap=$(sudo docker compose -f docker-compose.yml --env-file .env exec -T tokenkey printenv QA_CAPTURE_ENABLED 2>/dev/null || echo missing)
-blob_count=0
-blob_bytes=0
-if [ -d qa_blobs ] || [ -d qa_dlq ]; then
-  blob_count=$(find qa_blobs qa_dlq -type f 2>/dev/null | wc -l | tr -d ' ')
-  blob_bytes=$(du -sb qa_blobs qa_dlq 2>/dev/null | awk '{s+=$1} END {print s+0}')
+rec_count=0
+if sudo docker ps --format '{{.Names}}' | grep -qx tokenkey-postgres; then
+  PGPASS="$(sudo grep '^POSTGRES_PASSWORD=' /var/lib/tokenkey/.env | cut -d= -f2- || true)"
+  NET="$(sudo docker inspect tokenkey-postgres --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}' 2>/dev/null || true)"
+  if [ -n "${PGPASS}" ] && [ -n "${NET}" ]; then
+    rec_count=$(sudo docker run --rm --network "${NET}" -e PGPASSWORD="${PGPASS}" postgres:16-alpine \
+      psql -h tokenkey-postgres -U tokenkey -d tokenkey -Atqc "SELECT COUNT(*) FROM qa_records;" 2>/dev/null || echo 0)
+  fi
 fi
-printf 'TAG=%s\nQA_ENV=%s\nQA_TIMER=%s\nCONTAINER_QA_CAPTURE_ENABLED=%s\nBLOB_FILES=%s\nBLOB_BYTES=%s\n' "$tag" "$qa_env" "$qa_timer" "$qa_cap" "$blob_count" "$blob_bytes"
+blob_count=0
+for d in qa_blobs qa_dlq qa_exports_tmp; do
+  [ -d "$d" ] || continue
+  blob_count=$((blob_count + $(find "$d" -type f 2>/dev/null | wc -l | tr -d ' ')))
+done
+printf 'DRY_RUN=false\nQA_TIMER=%s\nCONTAINER_QA_CAPTURE_ENABLED=%s\nQA_RECORDS=%s\nBLOB_FILES=%s\n' \
+  "$qa_timer" "$qa_cap" "$rec_count" "$blob_count"
 """
 
 
-def _send(region: str, instance_id: str, edge_id: str, comment: str) -> str:
+def _send(region: str, instance_id: str, edge_id: str, apply: bool, comment: str) -> str:
+    remote = REMOTE.replace("__APPLY__", "true" if apply else "false")
     args = ["aws", "ssm", "send-command", "--region", region]
     if instance_id.startswith("mi-"):
         args.extend(
@@ -48,7 +97,7 @@ def _send(region: str, instance_id: str, edge_id: str, comment: str) -> str:
             "--comment",
             comment,
             "--parameters",
-            json.dumps({"commands": [REMOTE]}),
+            json.dumps({"commands": [remote]}),
             "--query",
             "Command.CommandId",
             "--output",
@@ -125,17 +174,26 @@ def _poll(region: str, command_id: str, instance_id: str) -> tuple[str, str, str
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--edge-id", required=True)
+    parser.add_argument("--apply", action="store_true", help="execute closeout (default is dry-run)")
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
 
     ident = resolve_edge_execution_identity(ROOT, args.edge_id)
-    command_id = _send(ident.region, ident.instance_id, ident.edge_id, f"edge qa phase1 baseline {ident.edge_id}")
+    mode = "apply" if args.apply else "dry-run"
+    command_id = _send(
+        ident.region,
+        ident.instance_id,
+        ident.edge_id,
+        args.apply,
+        f"edge qa phase1 closeout {mode} {ident.edge_id}",
+    )
     status, stdout, stderr = _poll(ident.region, command_id, ident.instance_id)
     payload = {
         "edge_id": ident.edge_id,
         "region": ident.region,
         "instance_id": ident.instance_id,
         "command_id": command_id,
+        "apply": args.apply,
         "status": status,
         "stdout": stdout.strip(),
         "stderr": stderr.strip(),
@@ -143,7 +201,7 @@ def main() -> int:
     if args.json:
         print(json.dumps(payload, ensure_ascii=True, sort_keys=True))
     else:
-        print(f"edge={ident.edge_id} status={status}")
+        print(f"edge={ident.edge_id} mode={mode} status={status}")
         print(stdout.strip())
         if stderr.strip():
             print(stderr.strip(), file=sys.stderr)

--- a/ops/qa/prod_phase2_baseline.py
+++ b/ops/qa/prod_phase2_baseline.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Read-only prod QA Phase 2 baseline probe (local QA footprint + raw archive bucket)."""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "ops" / "stage0"))
+from ssm_execution import PROD_REGION, resolve_prod_instance, run_shell_b64  # noqa: E402
+
+REMOTE = r"""set -uo pipefail
+cd /var/lib/tokenkey
+app_container=tokenkey
+if [ -r active-color ]; then
+  color=$(sed -n '1p' active-color 2>/dev/null | tr -d '[:space:]')
+  case "${color}" in
+    blue|green) app_container="tokenkey-${color}" ;;
+  esac
+fi
+qa_cap=$(sudo docker exec "${app_container}" printenv QA_CAPTURE_ENABLED 2>/dev/null || true)
+if [ -z "${qa_cap}" ]; then
+  qa_cap=$(grep -E '^QA_CAPTURE_ENABLED=' .env 2>/dev/null | cut -d= -f2- || echo missing)
+fi
+[ -n "${qa_cap}" ] || qa_cap=missing
+qa_archive=$(sudo docker exec "${app_container}" printenv QA_ARCHIVE_ENABLED 2>/dev/null || echo missing)
+export_driver=$(sudo docker exec "${app_container}" printenv QA_CAPTURE_EXPORT_STORAGE_DRIVER 2>/dev/null || echo missing)
+export_bucket=$(sudo docker exec "${app_container}" printenv QA_CAPTURE_EXPORT_STORAGE_BUCKET 2>/dev/null || echo missing)
+rec_count=0
+rec_oldest=
+rec_newest=
+blob_bytes=0
+if sudo docker ps --format '{{.Names}}' | grep -qx tokenkey-postgres; then
+  PGPASS="$(sudo grep '^POSTGRES_PASSWORD=' /var/lib/tokenkey/.env | cut -d= -f2- || true)"
+  NET="$(sudo docker inspect tokenkey-postgres --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}' 2>/dev/null || true)"
+  if [ -n "${PGPASS}" ] && [ -n "${NET}" ]; then
+    rec_count=$(sudo docker run --rm --network "${NET}" -e PGPASSWORD="${PGPASS}" postgres:16-alpine \
+      psql -h tokenkey-postgres -U tokenkey -d tokenkey -Atqc "SELECT COUNT(*) FROM qa_records;" 2>/dev/null || echo 0)
+    rec_oldest=$(sudo docker run --rm --network "${NET}" -e PGPASSWORD="${PGPASS}" postgres:16-alpine \
+      psql -h tokenkey-postgres -U tokenkey -d tokenkey -Atq -c "SELECT MIN(created_at) FROM qa_records;" 2>/dev/null | head -1)
+    rec_newest=$(sudo docker run --rm --network "${NET}" -e PGPASSWORD="${PGPASS}" postgres:16-alpine \
+      psql -h tokenkey-postgres -U tokenkey -d tokenkey -Atq -c "SELECT MAX(created_at) FROM qa_records;" 2>/dev/null | head -1)
+  fi
+fi
+if [ -d qa_blobs ] || [ -d qa_dlq ]; then
+  blob_bytes=$(du -sb qa_blobs qa_dlq 2>/dev/null | awk '{s+=$1} END {print s+0}')
+fi
+printf 'QA_CAPTURE_ENABLED=%s\nQA_ARCHIVE_ENABLED=%s\nEXPORT_DRIVER=%s\nEXPORT_BUCKET=%s\nQA_RECORDS=%s\nQA_OLDEST=%s\nQA_NEWEST=%s\nBLOB_BYTES=%s\n' \
+  "$qa_cap" "$qa_archive" "$export_driver" "$export_bucket" "$rec_count" "$rec_oldest" "$rec_newest" "$blob_bytes"
+"""
+
+
+def _account_id() -> str:
+    out = subprocess.check_output(
+        ["aws", "sts", "get-caller-identity", "--query", "Account", "--output", "text"],
+        text=True,
+    ).strip()
+    if not re.fullmatch(r"\d{12}", out):
+        raise SystemExit(f"unexpected aws account id: {out!r}")
+    return out
+
+
+def _raw_bucket_status(account_id: str) -> dict[str, str]:
+    bucket = f"tokenkey-prod-qa-raw-archive-{account_id}"
+    probe = subprocess.run(
+        ["aws", "s3api", "head-bucket", "--bucket", bucket],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if probe.returncode == 0:
+        return {"bucket": bucket, "status": "exists"}
+    err = (probe.stderr or probe.stdout or "").strip()
+    if "404" in err or "Not Found" in err or "NoSuchBucket" in err:
+        return {"bucket": bucket, "status": "missing"}
+    return {"bucket": bucket, "status": "unknown", "error": err[:500]}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    account_id = _account_id()
+    bucket = _raw_bucket_status(account_id)
+    instance_id = resolve_prod_instance()
+    remote_out = run_shell_b64(
+        instance_id,
+        base64.b64encode(REMOTE.encode()).decode(),
+        "prod qa phase2 baseline",
+    )
+    payload = {
+        "region": PROD_REGION,
+        "instance_id": instance_id,
+        "account_id": account_id,
+        "raw_archive_bucket": bucket,
+        "stdout": remote_out.strip(),
+    }
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=True, sort_keys=True))
+    else:
+        print(f"prod instance={instance_id} account={account_id}")
+        print(f"raw_archive: {bucket}")
+        print(remote_out.strip())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/qa/test_qa_phase_ops.py
+++ b/ops/qa/test_qa_phase_ops.py
@@ -50,6 +50,15 @@ class TestQAPhaseOps(unittest.TestCase):
         self.assertIn("raw/v1/", body)
         self.assertIn("raw/partial/", body)
 
+    def test_raw_archive_cfn_grants_kms_to_bucket_principals(self) -> None:
+        body = (ROOT / "deploy/aws/cloudformation/stage0-qa-raw-archive.yaml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("AllowAppInstanceRoleUseViaS3", body)
+        self.assertIn("kms:GenerateDataKey*", body)
+        self.assertIn("kms:ViaService", body)
+        self.assertIn("AllowOpsRecoveryRoleReadViaS3", body)
+
 
 if __name__ == "__main__":
     raise SystemExit(unittest.main())

--- a/ops/qa/test_qa_phase_ops.py
+++ b/ops/qa/test_qa_phase_ops.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Regression checks for QA Phase 1 closeout and Phase 2 baseline artifacts."""
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestQAPhaseOps(unittest.TestCase):
+    def test_closeout_script_compiles(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, "-m", "py_compile", str(ROOT / "ops/qa/edge_phase1_closeout.py")],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_phase2_baseline_compiles(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, "-m", "py_compile", str(ROOT / "ops/qa/prod_phase2_baseline.py")],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_edge_host_units_sync_has_no_qa_wiring(self) -> None:
+        body = (ROOT / "ops/stage0/sync-edge-host-units-via-ssm.sh").read_text(encoding="utf-8")
+        for needle in (
+            "tokenkey-qa-stale-cleanup",
+            "qa-stale-retention.env",
+            "TK_QA_STALE_RETENTION_DAYS",
+        ):
+            self.assertNotIn(needle, body, f"unexpected QA wiring: {needle}")
+
+    def test_closeout_purges_qa_and_removes_timer(self) -> None:
+        body = (ROOT / "ops/qa/edge_phase1_closeout.py").read_text(encoding="utf-8")
+        self.assertIn("TRUNCATE qa_records", body)
+        self.assertIn("tokenkey-qa-stale-cleanup.timer", body)
+        self.assertIn("--apply", body)
+
+    def test_raw_archive_cfn_has_lifecycle_prefixes(self) -> None:
+        body = (ROOT / "deploy/aws/cloudformation/stage0-qa-raw-archive.yaml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("QaRawArchiveBucket", body)
+        self.assertIn("raw/v1/", body)
+        self.assertIn("raw/partial/", body)
+
+
+if __name__ == "__main__":
+    raise SystemExit(unittest.main())

--- a/ops/stage0/remediate-edge-disk-via-ssm.sh
+++ b/ops/stage0/remediate-edge-disk-via-ssm.sh
@@ -114,13 +114,6 @@ if ! sudo journalctl --vacuum-size=100M 2>/dev/null; then
   echo "WARN: journal vacuum failed" >&2
   cleanup_failures=$((cleanup_failures + 1))
 fi
-# TRANSITIONAL / NON-SSOT: Phase 1 removes this QA action with Edge QA wiring.
-if [ -x /usr/local/bin/tokenkey-qa-stale-cleanup.sh ]; then
-  if ! sudo /usr/local/bin/tokenkey-qa-stale-cleanup.sh; then
-    echo "WARN: QA stale cleanup failed" >&2
-    cleanup_failures=$((cleanup_failures + 1))
-  fi
-fi
 echo "=== df after ==="
 if ! df -h /; then echo "WARN: df after failed" >&2; fi
 if ! docker system df 2>/dev/null; then echo "WARN: docker system df failed" >&2; fi

--- a/ops/stage0/sync-edge-host-units-via-ssm.sh
+++ b/ops/stage0/sync-edge-host-units-via-ssm.sh
@@ -1,41 +1,18 @@
 #!/usr/bin/env bash
 # Bring a running Lightsail EDGE's host-level systemd units up to prod parity via
 # SSM Run-Command. Mirrors ops/stage0/pg_dump_refresh_via_ssm.sh.
-# TRANSITIONAL / NON-SSOT: Phase 1 must remove all QA payload/env/unit wiring
-# after edge capture=false is verified. Do not extend the QA path here.
 #
-# Why this exists: prod (deploy/aws/stage0/stage0-ec2-bootstrap.sh) installs AND
-# enables two host units that the edge bootstrap (deploy/aws/lightsail/render-bootstrap.sh)
-# does NOT wire — render-bootstrap is capped at 14336 bytes of Lightsail user-data
-# and only `chmod +x`'s the scripts. So existing + new edges silently lacked:
-#   1. on-box disk-full + memory-pressure Feishu alerts (tokenkey-disk-metrics.sh +
-#      .timer) — prod #778/#811; without them a full root volume or 1GiB OOM
-#      (2026-08-03 us6) can wedge the host with NO on-box page.
-#   2. QA stale cleanup (tokenkey-qa-stale-cleanup.sh + .timer + retention env) — the
-#      script shipped but never ran on edges, so qa_records/qa_blobs grew unbounded
-#      (13+ days / multi-GB) while prod stayed pruned at 1.5 days.
-#   3. Daily GHCR tag prune (tokenkey-ghcr-prune-daily.sh + .timer) — deploy-time
-#      prune alone is insufficient when edges go days without a deploy; mirrors prod
-#      bootstrap timer at 05:00 UTC (after QA 04:15).
-# render-bootstrap can't grow (user-data cap), and deploy_via_ssm.sh does not re-run
-# bootstrap, so this SSM push is the path that reaches existing edges (the same
-# situation #778 solved for prod with pg_dump_refresh_via_ssm.sh). The edge deploy
-# workflow calls this after provision/upgrade; run it standalone to backfill a node.
+# Phase 1 closeout removed all Edge QA wiring (capture=false, no QA timer/script).
+# This script now pushes only non-QA host units:
+#   1. on-box disk-full + memory-pressure Feishu alerts (tokenkey-disk-metrics.sh)
+#   2. Daily GHCR tag prune (tokenkey-ghcr-prune-daily.sh)
 #
 # Single source of record for the unit payloads:
-#   - deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh  (disk+mem Feishu; df /)
-#   - deploy/aws/stage0/tokenkey-qa-stale-cleanup.sh      (QA prune; shared with prod)
-#   - deploy/aws/stage0/tokenkey-ghcr-prune-daily.sh      (GHCR tag prune; shared with prod)
-# Edit only those files; this script base64-pushes them verbatim.
-#
-# Prereq for the alerts to actually post: TOKENKEY_FEISHU_WEBHOOK_URL/_SECRET must
-# be present in /var/lib/tokenkey/.env (the alert no-ops silently otherwise). The edge
-# deploy workflow's sync-feishu-config step mirrors them there.
+#   - deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh
+#   - deploy/aws/stage0/tokenkey-ghcr-prune-daily.sh
 #
 # Usage:
 #   bash ops/stage0/sync-edge-host-units-via-ssm.sh <instance-id|mi-...> [comment]
-#   AWS_REGION=us-east-2 TK_QA_STALE_RETENTION_DAYS=<transitional-value> \
-#     bash ops/stage0/sync-edge-host-units-via-ssm.sh mi-...
 
 set -euo pipefail
 
@@ -43,16 +20,9 @@ INSTANCE_ID="${1:-${INSTANCE_ID:-}}"
 COMMENT="${2:-${SSM_COMMENT:-ops-edge-host-units-sync}}"
 TIMEOUT_SECONDS="${STAGE0_SSM_TIMEOUT_SECONDS:-300}"
 OUTPUT_DIR="${STAGE0_SSM_OUTPUT_DIR:-.}"
-# Transitional Edge QA retention compatibility only. The value is not policy;
-# Phase 1 replaces this entire QA path with capture=false and no QA unit.
-QA_RETENTION_DAYS="${TK_QA_STALE_RETENTION_DAYS:-1}"
 
 if [ -z "${INSTANCE_ID}" ]; then
   echo "stage0_sync_edge_host_units_via_ssm: instance id is required" >&2
-  exit 1
-fi
-if ! printf '%s' "${QA_RETENTION_DAYS}" | grep -Eq '^(0|[1-9][0-9]*)(\.[0-9]+)?$'; then
-  echo "stage0_sync_edge_host_units_via_ssm: invalid TK_QA_STALE_RETENTION_DAYS=${QA_RETENTION_DAYS}" >&2
   exit 1
 fi
 
@@ -68,16 +38,11 @@ stderr_file="${OUTPUT_DIR}/stderr.txt"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DM_SRC="${SCRIPT_DIR}/../../deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh"
-QA_SRC="${SCRIPT_DIR}/../../deploy/aws/stage0/tokenkey-qa-stale-cleanup.sh"
 GHCR_SRC="${SCRIPT_DIR}/../../deploy/aws/stage0/tokenkey-ghcr-prune-daily.sh"
 [[ -f "${DM_SRC}" ]] || { echo "missing ${DM_SRC}" >&2; exit 1; }
-[[ -f "${QA_SRC}" ]] || { echo "missing ${QA_SRC}" >&2; exit 1; }
 [[ -f "${GHCR_SRC}" ]] || { echo "missing ${GHCR_SRC}" >&2; exit 1; }
 
-# Encode each payload to single-line base64 so embedding into the JSON command
-# array is shell-quoting-safe. tr -d strips both GNU and BSD base64 wrapping.
 DM_SH_B64="$(base64 <"${DM_SRC}" | tr -d '\n')"
-QA_SH_B64="$(base64 <"${QA_SRC}" | tr -d '\n')"
 GHCR_SH_B64="$(base64 <"${GHCR_SRC}" | tr -d '\n')"
 
 DM_SERVICE_B64="$(cat <<'DMSEOF' | base64 | tr -d '\n'
@@ -108,76 +73,35 @@ WantedBy=timers.target
 DMTEOF
 )"
 
-QA_SERVICE_B64="$(cat <<'QASEOF' | base64 | tr -d '\n'
-[Unit]
-Description=Prune QA records and blob trees older than retention
-After=network-online.target tokenkey.service
-Wants=network-online.target
-Requires=tokenkey.service
-
-[Service]
-Type=oneshot
-EnvironmentFile=-/etc/tokenkey/qa-stale-retention.env
-ExecStart=/usr/local/bin/tokenkey-qa-stale-cleanup.sh
-QASEOF
-)"
-
-QA_TIMER_B64="$(cat <<'QATEOF' | base64 | tr -d '\n'
-[Unit]
-Description=Daily QA stale cleanup (low-traffic window)
-
-[Timer]
-OnCalendar=*-*-* 04:15:00
-RandomizedDelaySec=30min
-Persistent=true
-
-[Install]
-WantedBy=timers.target
-QATEOF
-)"
-
-# In-place sync trace: which commit the live units are now aligned to.
 TEMPLATE_SHA="${GITHUB_SHA:-local}"
 
 jq -n \
   --arg dmsh "${DM_SH_B64}" \
   --arg dmsvc "${DM_SERVICE_B64}" \
   --arg dmtmr "${DM_TIMER_B64}" \
-  --arg qash "${QA_SH_B64}" \
-  --arg qasvc "${QA_SERVICE_B64}" \
-  --arg qatmr "${QA_TIMER_B64}" \
   --arg ghcrs "${GHCR_SH_B64}" \
-  --arg qadays "${QA_RETENTION_DAYS}" \
   --arg sha "${TEMPLATE_SHA}" \
   '{
     commands: [
       "set -euo pipefail",
-      "echo === edge host-units sync: disk/memory pressure alerts + QA stale cleanup + GHCR daily prune ===",
+      "echo === edge host-units sync: disk/memory pressure alerts + GHCR daily prune, no QA ===",
       "sudo install -d -m 0755 /etc/tokenkey",
       ("echo " + $dmsh + " | base64 -d | sudo tee /usr/local/bin/tokenkey-disk-metrics.sh > /dev/null"),
       "sudo chmod +x /usr/local/bin/tokenkey-disk-metrics.sh",
-      "grep -E -c '\''memory-pressure alert|MemAvailable|磁盘压力已恢复'\'' /usr/local/bin/tokenkey-disk-metrics.sh || true",  # preflight-allow: swallow — host-side diagnostic count; 0 matches must not abort the remote script
+      "grep -E -c '\''memory-pressure alert|MemAvailable|磁盘压力已恢复'\'' /usr/local/bin/tokenkey-disk-metrics.sh || true",
       "sudo /usr/local/bin/tokenkey-disk-metrics.sh --selftest",
       ("echo " + $dmsvc + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-disk-metrics.service > /dev/null"),
       ("echo " + $dmtmr + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-disk-metrics.timer > /dev/null"),
-      ("echo " + $qash + " | base64 -d | sudo tee /usr/local/bin/tokenkey-qa-stale-cleanup.sh > /dev/null"),
-      "sudo chmod +x /usr/local/bin/tokenkey-qa-stale-cleanup.sh",
-      ("echo " + $qasvc + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-qa-stale-cleanup.service > /dev/null"),
-      ("echo " + $qatmr + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-qa-stale-cleanup.timer > /dev/null"),
       ("echo " + $ghcrs + " | base64 -d | sudo tee /usr/local/bin/tokenkey-ghcr-prune-daily.sh > /dev/null"),
       "sudo chmod +x /usr/local/bin/tokenkey-ghcr-prune-daily.sh",
       "sudo /usr/local/bin/tokenkey-ghcr-prune-daily.sh --selftest",
       "sudo /usr/local/bin/tokenkey-ghcr-prune-daily.sh --install-units",
-      ("printf '\''TOKENKEY_QA_STALE_RETENTION_DAYS=%s\\n'\'' " + $qadays + " | sudo tee /etc/tokenkey/qa-stale-retention.env > /dev/null"),
       "sudo systemctl daemon-reload",
       "sudo systemctl enable --now tokenkey-disk-metrics.timer",
-      "sudo systemctl enable --now tokenkey-qa-stale-cleanup.timer",
       "sudo systemctl enable --now tokenkey-ghcr-prune-daily.timer",
-      "sudo systemctl restart tokenkey-disk-metrics.timer tokenkey-qa-stale-cleanup.timer tokenkey-ghcr-prune-daily.timer",
+      "sudo systemctl restart tokenkey-disk-metrics.timer tokenkey-ghcr-prune-daily.timer",
       "echo --- timers ---",
-      "sudo systemctl list-timers tokenkey-disk-metrics.timer tokenkey-qa-stale-cleanup.timer tokenkey-ghcr-prune-daily.timer --no-pager || true",
-      "echo --- retention env ---",
-      "cat /etc/tokenkey/qa-stale-retention.env || true",
+      "sudo systemctl list-timers tokenkey-disk-metrics.timer tokenkey-ghcr-prune-daily.timer --no-pager || true",
       "echo --- feishu webhook present in .env -- disk alert no-ops without it --",
       "grep -cE '\''^TOKENKEY_FEISHU_WEBHOOK_URL='\'' /var/lib/tokenkey/.env || true",
       ("echo Live edge host units now match deploy/aws@" + $sha + " on $(hostname)")

--- a/ops/stage0/test_remediate_edge_disk.sh
+++ b/ops/stage0/test_remediate_edge_disk.sh
@@ -133,7 +133,6 @@ for needle in \
   'remediate-edge-disk-via-ssm.sh' \
   'get-instance-access-details' \
   'tokenkey-prune-ghcr-app-tags-core.sh' \
-  'tokenkey-qa-stale-cleanup.sh' \
   'edge_ssm_execution.py' \
   'all-deployable'; do
   if ! printf '%s' "${text}" | grep -F -e "${needle}" >/dev/null; then

--- a/scripts/checks/qa-lifecycle-ssot.py
+++ b/scripts/checks/qa-lifecycle-ssot.py
@@ -54,6 +54,14 @@ FORBIDDEN_BY_FILE = {
         "RETBLOB",
         "TOKENKEY_QA_BLOB_DIR",
     ),
+    Path("ops/stage0/sync-edge-host-units-via-ssm.sh"): (
+        "tokenkey-qa-stale-cleanup",
+        "qa-stale-retention.env",
+        "TK_QA_STALE_RETENTION_DAYS",
+    ),
+    Path("ops/stage0/remediate-edge-disk-via-ssm.sh"): (
+        "tokenkey-qa-stale-cleanup",
+    ),
 }
 
 REQUIRED_BY_FILE = {
@@ -70,6 +78,19 @@ REQUIRED_BY_FILE = {
     Path("ops/stage0/deploy_via_ssm.sh"): (
         "edge_qa_capture_cmds",
         "QA_CAPTURE_ENABLED=false",
+    ),
+    Path("ops/qa/edge_phase1_closeout.py"): (
+        "TRUNCATE qa_records",
+        "tokenkey-qa-stale-cleanup.timer",
+    ),
+    Path("ops/qa/prod_phase2_baseline.py"): (
+        "tokenkey-prod-qa-raw-archive",
+        "QA_CAPTURE_ENABLED",
+    ),
+    Path("deploy/aws/cloudformation/stage0-qa-raw-archive.yaml"): (
+        "QaRawArchiveBucket",
+        "raw/v1/",
+        "raw/partial/",
     ),
     Path("ops/archive/data_layer_archive_rehearsal.py"): (
         'DATASETS = ("usage", "ops")',

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1245,6 +1245,21 @@ else
     echo "  ok: edge_phase1_baseline.py present (Phase 1 soak probe wired)"
 fi
 
+# ---- sub2api: QA Phase 1 closeout + Phase 2 baseline ops -------------------
+echo ""
+echo "=== sub2api: QA Phase 1 closeout + Phase 2 baseline ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by QA phase ops scripts)"
+    errors=$((errors + 1))
+elif ! python3 -m py_compile ./ops/qa/edge_phase1_closeout.py ./ops/qa/prod_phase2_baseline.py; then
+    echo "  FAIL: QA phase ops scripts do not compile"
+    errors=$((errors + 1))
+elif ! python3 ./ops/qa/test_qa_phase_ops.py; then
+    errors=$((errors + 1))
+else
+    echo "  ok: Phase 1 closeout + Phase 2 baseline artifacts compile and regression tests pass"
+fi
+
 # ---- sub2api: QA evidence dataset validator ----------------------------------------
 # Source of truth: scripts/checks/qa-evidence-dataset.py. Verifies that the standalone
 # QA evidence dataset gate remains executable from repo root and the regression


### PR DESCRIPTION
## 摘要

- **Phase 1 closeout**：新增 `edge_phase1_closeout.py`，从 Edge host 移除 QA timer/wiring 并清空 `qa_records`/blob 树；`sync-edge-host-units-via-ssm.sh`、remediate 与 deploy workflow 不再推送/调用 QA cleanup。
- **Phase 2 骨架**：新增 `stage0-qa-raw-archive.yaml`（独立 raw bucket + KMS + lifecycle）、`deploy_qa_raw_archive_cfn.sh` 与 `prod_phase2_baseline.py` 只读探针。
- **门禁**：扩展 `qa-lifecycle-ssot.py`、preflight 与 `test_qa_phase_ops.py` 回归。

## 风险

- 常规风险：仅 ops/CFN 与 Edge host 单元，不改 prod 应用 capture/archive 行为。
- Edge closeout 已在 us3–us6 实跑验证（`QA_RECORDS=0`、`QA_TIMER=inactive`）；本 PR 合入后新 deploy 不会再 reinstall QA timer。
- Phase 2 CFN **尚未**在 prod 成功落地：`us-east-1` stack 曾因误删 global bucket 后立刻重建触发 S3 409，当前 `ROLLBACK_COMPLETE`；合入后需按 PR 说明重试 deploy（不阻塞 Phase 1 closeout 代码）。

## 验证

```bash
python3 ./scripts/checks/qa-lifecycle-ssot.py
python3 ./ops/qa/test_qa_phase_ops.py
bash ./scripts/checks/check-stage0-ssm-host-parse.sh
```

线上（已执行，合入前 evidence）：

```bash
python3 ops/qa/edge_phase1_closeout.py --edge-id us3 --apply   # us3–us6 均已 apply
python3 ops/qa/edge_phase1_baseline.py --edge-id us3           # QA_RECORDS=0, capture=false
python3 ops/qa/prod_phase2_baseline.py                         # ~510k qa_records; raw bucket 待 deploy
```

Phase 2 CFN 重试（合入后 / merge 后运维）：

```bash
aws cloudformation delete-stack --region us-east-1 --stack-name tokenkey-prod-qa-raw-archive
aws cloudformation wait stack-delete-complete --region us-east-1 --stack-name tokenkey-prod-qa-raw-archive
AWS_REGION=us-east-1 QA_RAW_ARCHIVE_CONFIRM=yes \
  APP_INSTANCE_ROLE_ARN='arn:aws:iam::682751977094:role/tokenkey-prod-stage0-InstanceRole-8WDNQenLojCf' \
  bash ops/qa/deploy_qa_raw_archive_cfn.sh
```

## 提交

- `ba7dc3f9f` feat(qa): Phase 1 Edge closeout 与 Phase 2 raw archive 骨架

最新提交：`ba7dc3f9f`

Made with [Cursor](https://cursor.com)