### PR TITLE
fix(archive): 修复 cleanup hold release 的 admin API 301 重定向（轨道 A 收尾）

### DIFF
--- a/ops/archive/data_layer_archive_cleanup_hold_remote.py
+++ b/ops/archive/data_layer_archive_cleanup_hold_remote.py
@@ -16,7 +16,8 @@ from collections.abc import Iterable
 from typing import Any
 
 
-ADMIN_URL = "https://api.tokenkey.dev/api/v1/admin/ops/advanced-settings"
+# api.tokenkey.dev 301 → tokenkey.dev；urllib 对 PUT 不跟随重定向，必须直连 canonical host
+ADMIN_URL = "https://tokenkey.dev/api/v1/admin/ops/advanced-settings"
 HOLD_CONFIRMATION = "tokenkey-prod-archive-cleanup-hold-v1"
 RELEASE_CONFIRMATION = "tokenkey-prod-archive-cleanup-release-v1"
 PG_CONTAINER = "tokenkey-postgres"


### PR DESCRIPTION
## 摘要

轨道 A closeout 完成后，官方 `data_layer_archive_cleanup_hold.py release` 在 prod 上失败：`api.tokenkey.dev` 对 `PUT /api/v1/admin/ops/advanced-settings` 返回 **301 → tokenkey.dev**，而 urllib 对 PUT **不跟随重定向**。本次将 remote 脚本的 `ADMIN_URL` 改为直连 canonical host `tokenkey.dev`。

轨道 A 运维本身已在 prod 完成（export/promote/closeout/cleanup release）；本 PR 仅固化脚本修复，避免后续 release/apply 再次踩坑。

## 风险

- 低风险：仅 ops remote 脚本 URL 变更，无运行时业务逻辑改动
- GET plan/verify 此前能工作（GET 可跟随 301）；PUT release/apply 受影响

## 验证

- `python3 ops/archive/test_data_layer_archive_cleanup_hold.py` — 16 tests OK
- `./scripts/preflight.sh` — PASS
- prod 侧 release 已用手工 PUT（tokenkey.dev）完成；merge 后可用 CLI 复验 plan

## 提交

- b68750ea6 fix(archive): 修复 prod cleanup hold release 的 admin API 301 重定向

最新提交：b68750ea6

Made with [Cursor](https://cursor.com)