### PR TITLE
docs(skill): sync Codex fingerprint skills to codex-tui identity

### DIFF
--- a/.cursor/skills/tokenkey-codex-fingerprint-alignment/SKILL.md
+++ b/.cursor/skills/tokenkey-codex-fingerprint-alignment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tokenkey-codex-fingerprint-alignment
 description: >-
-  Align the TokenKey OpenAI-platform Codex client fingerprint to the locally-installed Codex CLI. Use when `codex` upgrades and the forged UA / `version` header / probe version need a version bump, or to diff the TK version owner and derived aliases against the installed CLI. Reads the installed binary (no mitmproxy); updates only `DefaultOpenAICodexVersion`, never treats admin-UI examples as fingerprint pins, never auto-changes the non-version pins (originator=codex_cli_rs, OpenAI-Beta), and keeps the OS/terminal UA segment verbatim.
+  Align the TokenKey OpenAI-platform Codex client fingerprint to the locally-installed Codex CLI. Use when `codex` upgrades and the forged UA / `version` header / probe version need a version bump, or to diff the TK version owner and derived aliases against the installed CLI. Reads the installed binary (no mitmproxy); updates only `DefaultOpenAICodexVersion`, never treats admin-UI examples as fingerprint pins, never auto-changes the non-version pins (originator=codex-tui, OpenAI-Beta), and keeps the OS/terminal UA segment verbatim.
 ---
 
 # TokenKey：Codex 指纹对齐（读本机 codex CLI → diff 常量 → 改常量 → PR）
@@ -22,13 +22,16 @@ description: >-
 - **Codex 的指纹直接随 CLI 本地发行**：承重信号就是 codex 的**版本号**（嵌在 UA、`version`
   请求头、用量探测 `Version` 头里）。所以 ground truth = `codex --version` + native 二进制
   strings，**不需要抓任何网络流量**。这是最简单的一条引擎。
-- **OS / 终端段不承重**：UA 里的 `Mac OS 26.3.1; arm64` / `iTerm.app/3.6.11` 是采集机器的
-  **参考环境**，引擎只把 **codex 版本 token** 当对齐目标，bump 时其余字面量**原样保留**
+- **OS / 终端段不承重**：规范兜底 UA 后缀当前为 `Ubuntu 22.4.0; x86_64` / `xterm-256color`
+  （见 `openai_gateway_service.go` `codexCLIUserAgentSuffix`）；官方客户端透传时仍可能带
+  Mac/iTerm 等真实环境。引擎只把 **codex 版本 token** 当对齐目标，bump 时其余字面量**原样保留**
   （除非你主动想刷新参考环境——那是手工判断，不是漂移）。
-- **非版本钉死项只读不改**：`originator=codex_cli_rs`、`OpenAI-Beta: responses=experimental`
-  是 TK 故意钉死的，引擎拿二进制 strings 做**正向确认**（best-effort），但**绝不**因为
-  strings 里没搜到就判漂移——Rust 二进制可能在运行时拼接该值。真要变只有上游开始 400 拒
-  伪造请求时才查（见下「非版本漂移」）。
+- **非版本钉死项只读不改**：`originator=codex-tui`（`openai.CodexDefaultOriginator`）、
+  `OpenAI-Beta: responses=experimental` 是 TK 故意钉死的，引擎拿二进制 strings 做**正向确认**
+  （best-effort），但**绝不**因为 strings 里没搜到就判漂移——Rust 二进制可能在运行时拼接该值。
+  真要变只有上游开始 400 拒伪造请求时才查（见下「非版本漂移」）。
+- **messages 桥接例外**：`/v1/messages` compat 路径会显式删除 `originator` / `OpenAI-Beta`，
+  使 `enforceCodexIdentityHeaders` 不补回；这与 OAuth 强制统一出口不同，不算指纹漂移。
 
 ## 对齐靶（一个可编辑 owner + 派生 aliases，无 baseline JSON）
 
@@ -38,7 +41,7 @@ description: >-
 | `ua_default` | 同文件 `DefaultOpenAICodexUserAgent` | 从 owner 派生的强制 / 兜底 UA 与后台设置默认值 |
 | `gateway_version` | 同文件 `codexCLIVersion` | 从 owner 派生的上游 `version` 请求头 |
 | `probe_version` | 同文件 `openAICodexProbeVersion` | 从 owner 派生的用量探测 `Version` 请求头 |
-| originator（非版本）| `openai_gateway_scheduling.go` `resolveOpenAIUpstreamOriginator` | `codex_cli_rs`（只读确认，不 bump）|
+| originator（非版本）| `internal/pkg/openai/request.go` `CodexDefaultOriginator` | `codex-tui`（只读确认，不 bump）|
 | OpenAI-Beta（非版本）| `openai_gateway_forward.go` / `openai_gateway_passthrough.go` | `responses=experimental`（只读确认，不 bump）|
 
 `frontend/src/i18n/locales/{en,zh}/admin/settings.ts` 的 `openaiCodexUserAgentPlaceholder` 是 UI

--- a/.cursor/skills/tokenkey-fingerprint-alignment-all/SKILL.md
+++ b/.cursor/skills/tokenkey-fingerprint-alignment-all/SKILL.md
@@ -59,7 +59,7 @@ bash ops/fingerprint/capture-all-fingerprints.sh \
 - codex 漂移：`bash ops/openai/capture-codex-fingerprint.sh emit-edits`（或带 `--version X.Y.Z`）
   bump 唯一版本 owner `DefaultOpenAICodexVersion`；UA、`version` header 与探测版本必须继续从
   owner 派生，en/zh placeholder 只是 UI 示例，不参与对齐。非版本 pin
-  （`originator=codex_cli_rs`、`OpenAI-Beta`）从不自动改；`preflight` 的 codex fingerprint
+  （`originator=codex-tui`、`OpenAI-Beta`）从不自动改；`preflight` 的 codex fingerprint
   pin consistency 守住 owner / aliases 派生契约。
 
 然后 `scripts/preflight.sh` 全绿 → 一个分支、一个 PR 覆盖各平台的产物变更。


### PR DESCRIPTION
## 摘要

- 将 `tokenkey-codex-fingerprint-alignment` 与 `tokenkey-fingerprint-alignment-all` 中非版本 pin 从 `codex_cli_rs` 更新为 `codex-tui`，与 upstream merge #1569 及 `ops/openai/capture_codex_fingerprint.py` 一致
- 补充规范兜底 UA 后缀（Ubuntu/xterm-256color）与 `/v1/messages` 桥接不带 originator 的说明

## 风险

低风险，仅 skill 文档；无代码/契约/行为变更。

## 验证

- `./scripts/preflight.sh` PASS
- 全仓 `.cursor/skills` 已无 `codex_cli_rs` 残留

## 提交

- `04a6bbee6` docs(skill): sync Codex fingerprint skills to codex-tui identity
- 最新提交：`04a6bbee6`

Made with [Cursor](https://cursor.com)