### PR TITLE
fix(codex): align docs, ops probes, and sentinels with codex-tui identity

### DIFF
--- a/.cursor/skills/tokenkey-codex-fingerprint-alignment/SKILL.md
+++ b/.cursor/skills/tokenkey-codex-fingerprint-alignment/SKILL.md
@@ -89,11 +89,12 @@ python3 -m unittest discover -s ops/openai -p 'test_*.py' -t ops/openai
 - **仅版本漂移（最常见）**：按 `emit-edits` 更新 `DefaultOpenAICodexVersion`；UA、gateway version
   与 probe version 自动继承。i18n placeholders 以及 `request.go` / `request_test.go` 中的版本号
   都是格式示例 / 前缀匹配测试，与当前版本无关，**不改**。
-- **OS / 终端段刷新（少见，可选）**：只有你想把参考环境换到新机器时才改 UA 的
-  `(Mac OS …; arch) <terminal>/<ver>` 段；这是手工判断，不是漂移，`emit-edits` 不碰它。
+- **OS / 终端段刷新（少见，可选）**：只有你想把规范兜底 UA 的
+  `(Ubuntu …; arch) <terminal>` 段换到新参考环境时才改；官方客户端透传仍可能带 Mac/iTerm。
+  这是手工判断，不是漂移，`emit-edits` 不碰它。
 - **非版本漂移（罕见，需人判断，不自动 bump）**：只有当上游开始对伪造请求返回 4xx，或
   `diff` 的非版本行显示 originator / beta 在新 codex 里**确实换了值**时，才动
-  `resolveOpenAIUpstreamOriginator` / `OpenAI-Beta` 常量。binary-strings「not found」是
+  `openai.CodexDefaultOriginator` / `OpenAI-Beta` 常量。binary-strings「not found」是
   **不确定**信号（Rust 可能运行时拼接），**不是**漂移证据——不要据此改钉死项。
 
 ## 验证 / PR

--- a/backend/internal/pkg/openai/request.go
+++ b/backend/internal/pkg/openai/request.go
@@ -47,7 +47,7 @@ const codexOfficialClientFamilyPrefix = "codex "
 // 伪造绕过（gate 仍需 UA 双因子佐证）。新官方/合作客户端经 allowed_client.go 命名预设放行，
 // 或在 bump context/codex 时同步补入本集合。
 var codexOfficialClientOriginators = map[string]bool{
-	"codex_cli_rs":          true, // CLI 默认 DEFAULT_ORIGINATOR
+	"codex_cli_rs":          true, // legacy Rust CLI originator; gateway default is codex-tui
 	"codex-tui":             true, // 交互式 TUI（连字符，真实流量占比最高）
 	"codex_vscode":          true, // VSCode/Cursor 扩展
 	"codex_vscode_copilot":  true, // 扩展 GitHub Copilot 集成模式

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -990,7 +990,7 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
 	req.Header.Set("OpenAI-Beta", "responses=experimental")
-	req.Header.Set("Originator", "codex_cli_rs")
+	req.Header.Set("Originator", openai.CodexDefaultOriginator)
 	req.Header.Set("User-Agent", codexCLIUserAgent)
 	req.Header.Set("Version", codexCLIVersion)
 	probeSessionID := compactProbeSessionID(account.ID)

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -363,10 +363,10 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	}
 	if account.Type == AccountTypeOAuth && account.Platform != PlatformGrok {
 		// Anthropic Messages compatibility uses the ChatGPT Codex SSE endpoint.
-		// Match airgate-openai's request shape: the SSE endpoint does not need
-		// the Responses experimental beta header. Keep originator so ChatGPT
-		// classifies the request under the official Codex surface instead of
-		// Uncategorized.
+		// Match upstream request shape: the SSE endpoint does not need the
+		// Responses experimental beta header. compatMessagesBridge paths also
+		// strip originator in openai_gateway_forward.go so enforceCodexIdentityHeaders
+		// does not re-inject it on the Anthropic bridge.
 		upstreamReq.Header.Del("OpenAI-Beta")
 	}
 	if account.IsOpenAIOAuth() && promptCacheKey != "" && strings.TrimSpace(c.GetHeader("conversation_id")) == "" {

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -281,7 +281,7 @@ gateway:
   #
   # 注意：开启后会影响所有客户端的行为（不仅限于 VS Code / Codex CLI），请谨慎开启。
   force_codex_cli: false
-  # Stop rewriting load-shed Codex originators to the official CLI identity.
+  # Stop rewriting load-shed Codex originators to the official TUI identity (codex-tui).
   # 关闭「把落在上游降载桶的 Codex originator 改写为官方 TUI 身份（codex-tui）」。
   #
   # 上游 /backend-api/codex 按 originator 分桶调度容量：命中降载桶的请求即使 HTTP 200，

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -282,7 +282,7 @@ gateway:
   # 注意：开启后会影响所有客户端的行为（不仅限于 VS Code / Codex CLI），请谨慎开启。
   force_codex_cli: false
   # Stop rewriting load-shed Codex originators to the official CLI identity.
-  # 关闭「把落在上游降载桶的 Codex originator 改写为官方 CLI 身份（codex_cli_rs）」。
+  # 关闭「把落在上游降载桶的 Codex originator 改写为官方 TUI 身份（codex-tui）」。
   #
   # 上游 /backend-api/codex 按 originator 分桶调度容量：命中降载桶的请求即使 HTTP 200，
   # 也会立刻推 server_is_overloaded 错误事件，网关据此判定瞬时上游故障并冷却账号，

--- a/ops/openai/capture-codex-fingerprint.sh
+++ b/ops/openai/capture-codex-fingerprint.sh
@@ -7,7 +7,7 @@
 # binary (`codex --version` + native-binary strings). There is no client traffic
 # to intercept — the load-bearing signal is the codex VERSION embedded in the UA /
 # `version` header / probe header, plus the stable non-version pins
-# (originator=codex_cli_rs, OpenAI-Beta: responses=experimental).
+# (originator=codex-tui, OpenAI-Beta: responses=experimental).
 #
 # Deterministic parse / diff / gate is delegated to capture_codex_fingerprint.py;
 # this shell is only a thin dispatcher.

--- a/ops/stage0/probe_openai_upstream_model.sh
+++ b/ops/stage0/probe_openai_upstream_model.sh
@@ -116,7 +116,7 @@ curl_args=(
   -H "Content-Type: application/json"
   -H "Accept: text/event-stream"
   -H "OpenAI-Beta: responses=experimental"
-  -H "Originator: codex_cli_rs"
+  -H "Originator: codex-tui"
   -H "Version: ${CODEX_VERSION}"
   -H "User-Agent: ${CODEX_USER_AGENT}"
   -X POST "$UPSTREAM_URL"

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -5258,7 +5258,7 @@
       "rationale": "The PAT /responses hosted web-search fallback is a Codex Responses request and must enforce the same canonical identity triple as other OAuth Responses traffic. The native SearchClient alpha/search builder remains a distinct wire protocol; this anchor applies only to the fallback request path."
     },
     {
-      "rationale": "OpenAI OAuth upstream Codex fingerprint normalization (prod GPT-pro1 id=9, 2026-06-25). Non-Codex OAuth ingress (python-requests/urllib/SDK) must be re-presented upstream as official Codex: applyOpenAICodexUserAgent sets a Codex UA (precedence ForceCodexCLI > account custom UA > preserve-real-Codex-ingress > admin setting > built-in default) and resolveOpenAIUpstreamOriginator only preserves an inbound originator when IsCodexOfficialClientOriginator() accepts it, otherwise forces codex_cli_rs. Dropping these helpers/wiring silently reverts to forwarding arbitrary client identity, which OpenAI categorizes as Uncategorized and which degrades account health/risk-control — and unit tests on unrelated paths can still stay green. NOTE: anchors structural behavior only, never the codex-tui UA version literal (that is a fingerprint value governed by tokenkey-cc/openai fingerprint-alignment and is meant to drift).",
+      "rationale": "OpenAI OAuth upstream Codex fingerprint normalization (prod GPT-pro1 id=9, 2026-06-25). Non-Codex OAuth ingress (python-requests/urllib/SDK) must be re-presented upstream as official Codex: applyOpenAICodexUserAgent sets a Codex UA (precedence ForceCodexCLI > account custom UA > preserve-real-Codex-ingress > admin setting > built-in default) and resolveOpenAIUpstreamOriginator only preserves an inbound originator when IsCodexOfficialClientOriginator() accepts it, otherwise forces openai.CodexDefaultOriginator (codex-tui). Dropping these helpers/wiring silently reverts to forwarding arbitrary client identity, which OpenAI categorizes as Uncategorized and which degrades account health/risk-control — and unit tests on unrelated paths can still stay green. NOTE: anchors structural behavior only, never the codex-tui UA version literal (that is a fingerprint value governed by tokenkey-cc/openai fingerprint-alignment and is meant to drift).",
       "path": "backend/internal/service/openai_client_restriction_detector.go",
       "must_contain": [
         "openai.IsCodexOfficialClientOriginator(originator)"
@@ -5267,9 +5267,9 @@
     {
       "path": "backend/internal/service/openai_gateway_messages.go",
       "must_contain": [
-        "classifies the request under the official Codex surface"
+        "strip originator in openai_gateway_forward.go"
       ],
-      "rationale": "Anthropic Messages -> Codex SSE bridge must KEEP the originator header (set to codex_cli_rs upstream) so ChatGPT classifies the request under the official Codex surface, NOT delete it. This reverses the earlier req.Header.Del(\"originator\") that the prior code carried; that exact spot has proven TK<->upstream churn, so an upstream merge re-adding the Del would silently re-introduce Uncategorized classification. Anchoring the rationale comment forces any revert to also drop the comment, surfacing the change in preflight + the upstream-merge PR shape check. Paired regression tests live in openai_compat_model_test.go (TestForwardAsAnthropic_* assert originator==codex_cli_rs)."
+      "rationale": "Anthropic Messages -> Codex SSE bridge must NOT carry OpenAI-Beta and must NOT re-inject originator on compat bridge paths. Upstream merge #5351 (2026-08) aligned with upstream: compatMessagesBridge deletes originator/OpenAI-Beta in openai_gateway_forward.go so enforceCodexIdentityHeaders stays no-op. Re-adding originator on bridge paths has proven TK<->upstream churn; this anchor ties the rationale comment to the forward-path Del. Paired regression: openai_compat_model_test.go requireOpenAIMessagesCodexIdentity asserts empty originator."
     },
     {
       "path": "backend/internal/pkg/openai/request.go",
@@ -5283,7 +5283,7 @@
       "must_contain": [
         "TestOpenAIGatewayService_OAuthUpstreamHeadersNormalizeNonCodexIngress"
       ],
-      "rationale": "Regression anchor for the Codex fingerprint normalization: non-Codex OAuth ingress (python-requests / Python-urllib / claude-cli) across /v1/responses, /v1/chat/completions, /v1/messages must reach upstream with a Codex UA and originator==codex_cli_rs, never the inbound client identity. Pins the test so an upstream refactor cannot silently drop the only end-to-end guard for the mimicry behavior."
+      "rationale": "Regression anchor for Codex fingerprint normalization on OAuth responses/chat paths: non-Codex ingress (python-requests / Python-urllib / claude-cli) must reach upstream with canonical Codex UA and originator==openai.CodexDefaultOriginator (codex-tui), never the inbound client identity. Messages compat bridge empty-originator behavior is covered separately in openai_compat_model_test.go."
     },
     {
       "path": "backend/internal/handler/admin/dashboard_handler_tk_window.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -5272,6 +5272,14 @@
       "rationale": "Anthropic Messages -> Codex SSE bridge must NOT carry OpenAI-Beta and must NOT re-inject originator on compat bridge paths. Upstream merge #5351 (2026-08) aligned with upstream: compatMessagesBridge deletes originator/OpenAI-Beta in openai_gateway_forward.go so enforceCodexIdentityHeaders stays no-op. Re-adding originator on bridge paths has proven TK<->upstream churn; this anchor ties the rationale comment to the forward-path Del. Paired regression: openai_compat_model_test.go requireOpenAIMessagesCodexIdentity asserts empty originator."
     },
     {
+      "path": "backend/internal/service/openai_gateway_forward.go",
+      "must_contain": [
+        "if compatMessagesBridge {",
+        "req.Header.Del(\"originator\")"
+      ],
+      "rationale": "Structural anchor for compatMessagesBridge OAuth header shaping: originator and OpenAI-Beta must be deleted before upstream so enforceCodexIdentityHeaders does not re-inject on Anthropic Messages bridge traffic. Comment-only anchors can drift; this pins the Del call site. Paired regression: openai_compat_model_test.go requireOpenAIMessagesCodexIdentity."
+    },
+    {
       "path": "backend/internal/pkg/openai/request.go",
       "must_contain": [
         "\"codex-tui/\","


### PR DESCRIPTION
## 摘要

- 收口 upstream #1569 / #1576 后残留的 `codex_cli_rs` 文档与运维引用：ops 脚本、skill、config 注释、sentinel rationale
- 修正 `openai_gateway_messages.go` 过时注释（messages 桥接由 forward 路径删除 originator）
- 账号探测请求统一使用 `openai.CodexDefaultOriginator`（`account_test_service.go`）

## 风险

低风险。无公共 API 契约变更；账号探测出站 originator 与生产 OAuth 路径一致（`codex-tui`）。测试里保留的 `codex_cli_rs` 样本仍用于 legacy 客户端识别/regression，刻意未改。

## 验证

- `./scripts/preflight.sh` PASS（含 sentinel registry）
- 非测试/非 legacy 识别代码路径已无过时 `codex_cli_rs` 默认值

## 提交

- `5a5c42fe8` fix(codex): align docs, ops probes, and sentinels with codex-tui identity
- 最新提交：`5a5c42fe8`

Made with [Cursor](https://cursor.com)