### PR TITLE
feat(dashboard): 仪表盘展示网关中转延迟

### DIFF
--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -1885,6 +1885,7 @@ var (
 		{Name: "billing_type", Type: field.TypeInt8, Default: 0},
 		{Name: "stream", Type: field.TypeBool, Default: false},
 		{Name: "duration_ms", Type: field.TypeInt, Nullable: true},
+		{Name: "gateway_latency_ms", Type: field.TypeInt, Nullable: true},
 		{Name: "first_token_ms", Type: field.TypeInt, Nullable: true},
 		{Name: "user_agent", Type: field.TypeString, Nullable: true, Size: 512},
 		{Name: "ip_address", Type: field.TypeString, Nullable: true, Size: 45},
@@ -1911,31 +1912,31 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "usage_logs_api_keys_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[39]},
+				Columns:    []*schema.Column{UsageLogsColumns[40]},
 				RefColumns: []*schema.Column{APIKeysColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "usage_logs_accounts_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[40]},
+				Columns:    []*schema.Column{UsageLogsColumns[41]},
 				RefColumns: []*schema.Column{AccountsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "usage_logs_groups_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[41]},
+				Columns:    []*schema.Column{UsageLogsColumns[42]},
 				RefColumns: []*schema.Column{GroupsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "usage_logs_users_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[42]},
+				Columns:    []*schema.Column{UsageLogsColumns[43]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "usage_logs_user_subscriptions_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[43]},
+				Columns:    []*schema.Column{UsageLogsColumns[44]},
 				RefColumns: []*schema.Column{UserSubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -1944,32 +1945,32 @@ var (
 			{
 				Name:    "usagelog_user_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[42]},
+				Columns: []*schema.Column{UsageLogsColumns[43]},
 			},
 			{
 				Name:    "usagelog_api_key_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[39]},
+				Columns: []*schema.Column{UsageLogsColumns[40]},
 			},
 			{
 				Name:    "usagelog_account_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[40]},
+				Columns: []*schema.Column{UsageLogsColumns[41]},
 			},
 			{
 				Name:    "usagelog_group_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[41]},
+				Columns: []*schema.Column{UsageLogsColumns[42]},
 			},
 			{
 				Name:    "usagelog_subscription_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[43]},
+				Columns: []*schema.Column{UsageLogsColumns[44]},
 			},
 			{
 				Name:    "usagelog_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[38]},
+				Columns: []*schema.Column{UsageLogsColumns[39]},
 			},
 			{
 				Name:    "usagelog_model",
@@ -1989,17 +1990,17 @@ var (
 			{
 				Name:    "usagelog_user_id_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[42], UsageLogsColumns[38]},
+				Columns: []*schema.Column{UsageLogsColumns[43], UsageLogsColumns[39]},
 			},
 			{
 				Name:    "usagelog_api_key_id_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[39], UsageLogsColumns[38]},
+				Columns: []*schema.Column{UsageLogsColumns[40], UsageLogsColumns[39]},
 			},
 			{
 				Name:    "usagelog_group_id_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[41], UsageLogsColumns[38]},
+				Columns: []*schema.Column{UsageLogsColumns[42], UsageLogsColumns[39]},
 			},
 		},
 	}

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -53403,6 +53403,8 @@ type UsageLogMutation struct {
 	stream                       *bool
 	duration_ms                  *int
 	addduration_ms               *int
+	gateway_latency_ms           *int
+	addgateway_latency_ms        *int
 	first_token_ms               *int
 	addfirst_token_ms            *int
 	user_agent                   *string
@@ -55121,6 +55123,76 @@ func (m *UsageLogMutation) ResetDurationMs() {
 	delete(m.clearedFields, usagelog.FieldDurationMs)
 }
 
+// SetGatewayLatencyMs sets the "gateway_latency_ms" field.
+func (m *UsageLogMutation) SetGatewayLatencyMs(i int) {
+	m.gateway_latency_ms = &i
+	m.addgateway_latency_ms = nil
+}
+
+// GatewayLatencyMs returns the value of the "gateway_latency_ms" field in the mutation.
+func (m *UsageLogMutation) GatewayLatencyMs() (r int, exists bool) {
+	v := m.gateway_latency_ms
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldGatewayLatencyMs returns the old "gateway_latency_ms" field's value of the UsageLog entity.
+// If the UsageLog object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UsageLogMutation) OldGatewayLatencyMs(ctx context.Context) (v *int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldGatewayLatencyMs is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldGatewayLatencyMs requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldGatewayLatencyMs: %w", err)
+	}
+	return oldValue.GatewayLatencyMs, nil
+}
+
+// AddGatewayLatencyMs adds i to the "gateway_latency_ms" field.
+func (m *UsageLogMutation) AddGatewayLatencyMs(i int) {
+	if m.addgateway_latency_ms != nil {
+		*m.addgateway_latency_ms += i
+	} else {
+		m.addgateway_latency_ms = &i
+	}
+}
+
+// AddedGatewayLatencyMs returns the value that was added to the "gateway_latency_ms" field in this mutation.
+func (m *UsageLogMutation) AddedGatewayLatencyMs() (r int, exists bool) {
+	v := m.addgateway_latency_ms
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearGatewayLatencyMs clears the value of the "gateway_latency_ms" field.
+func (m *UsageLogMutation) ClearGatewayLatencyMs() {
+	m.gateway_latency_ms = nil
+	m.addgateway_latency_ms = nil
+	m.clearedFields[usagelog.FieldGatewayLatencyMs] = struct{}{}
+}
+
+// GatewayLatencyMsCleared returns if the "gateway_latency_ms" field was cleared in this mutation.
+func (m *UsageLogMutation) GatewayLatencyMsCleared() bool {
+	_, ok := m.clearedFields[usagelog.FieldGatewayLatencyMs]
+	return ok
+}
+
+// ResetGatewayLatencyMs resets all changes to the "gateway_latency_ms" field.
+func (m *UsageLogMutation) ResetGatewayLatencyMs() {
+	m.gateway_latency_ms = nil
+	m.addgateway_latency_ms = nil
+	delete(m.clearedFields, usagelog.FieldGatewayLatencyMs)
+}
+
 // SetFirstTokenMs sets the "first_token_ms" field.
 func (m *UsageLogMutation) SetFirstTokenMs(i int) {
 	m.first_token_ms = &i
@@ -55901,7 +55973,7 @@ func (m *UsageLogMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UsageLogMutation) Fields() []string {
-	fields := make([]string, 0, 43)
+	fields := make([]string, 0, 44)
 	if m.user != nil {
 		fields = append(fields, usagelog.FieldUserID)
 	}
@@ -55994,6 +56066,9 @@ func (m *UsageLogMutation) Fields() []string {
 	}
 	if m.duration_ms != nil {
 		fields = append(fields, usagelog.FieldDurationMs)
+	}
+	if m.gateway_latency_ms != nil {
+		fields = append(fields, usagelog.FieldGatewayLatencyMs)
 	}
 	if m.first_token_ms != nil {
 		fields = append(fields, usagelog.FieldFirstTokenMs)
@@ -56101,6 +56176,8 @@ func (m *UsageLogMutation) Field(name string) (ent.Value, bool) {
 		return m.Stream()
 	case usagelog.FieldDurationMs:
 		return m.DurationMs()
+	case usagelog.FieldGatewayLatencyMs:
+		return m.GatewayLatencyMs()
 	case usagelog.FieldFirstTokenMs:
 		return m.FirstTokenMs()
 	case usagelog.FieldUserAgent:
@@ -56196,6 +56273,8 @@ func (m *UsageLogMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldStream(ctx)
 	case usagelog.FieldDurationMs:
 		return m.OldDurationMs(ctx)
+	case usagelog.FieldGatewayLatencyMs:
+		return m.OldGatewayLatencyMs(ctx)
 	case usagelog.FieldFirstTokenMs:
 		return m.OldFirstTokenMs(ctx)
 	case usagelog.FieldUserAgent:
@@ -56446,6 +56525,13 @@ func (m *UsageLogMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetDurationMs(v)
 		return nil
+	case usagelog.FieldGatewayLatencyMs:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetGatewayLatencyMs(v)
+		return nil
 	case usagelog.FieldFirstTokenMs:
 		v, ok := value.(int)
 		if !ok {
@@ -56589,6 +56675,9 @@ func (m *UsageLogMutation) AddedFields() []string {
 	if m.addduration_ms != nil {
 		fields = append(fields, usagelog.FieldDurationMs)
 	}
+	if m.addgateway_latency_ms != nil {
+		fields = append(fields, usagelog.FieldGatewayLatencyMs)
+	}
 	if m.addfirst_token_ms != nil {
 		fields = append(fields, usagelog.FieldFirstTokenMs)
 	}
@@ -56640,6 +56729,8 @@ func (m *UsageLogMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedBillingType()
 	case usagelog.FieldDurationMs:
 		return m.AddedDurationMs()
+	case usagelog.FieldGatewayLatencyMs:
+		return m.AddedGatewayLatencyMs()
 	case usagelog.FieldFirstTokenMs:
 		return m.AddedFirstTokenMs()
 	case usagelog.FieldImageCount:
@@ -56774,6 +56865,13 @@ func (m *UsageLogMutation) AddField(name string, value ent.Value) error {
 		}
 		m.AddDurationMs(v)
 		return nil
+	case usagelog.FieldGatewayLatencyMs:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddGatewayLatencyMs(v)
+		return nil
 	case usagelog.FieldFirstTokenMs:
 		v, ok := value.(int)
 		if !ok {
@@ -56832,6 +56930,9 @@ func (m *UsageLogMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(usagelog.FieldDurationMs) {
 		fields = append(fields, usagelog.FieldDurationMs)
+	}
+	if m.FieldCleared(usagelog.FieldGatewayLatencyMs) {
+		fields = append(fields, usagelog.FieldGatewayLatencyMs)
 	}
 	if m.FieldCleared(usagelog.FieldFirstTokenMs) {
 		fields = append(fields, usagelog.FieldFirstTokenMs)
@@ -56903,6 +57004,9 @@ func (m *UsageLogMutation) ClearField(name string) error {
 		return nil
 	case usagelog.FieldDurationMs:
 		m.ClearDurationMs()
+		return nil
+	case usagelog.FieldGatewayLatencyMs:
+		m.ClearGatewayLatencyMs()
 		return nil
 	case usagelog.FieldFirstTokenMs:
 		m.ClearFirstTokenMs()
@@ -57031,6 +57135,9 @@ func (m *UsageLogMutation) ResetField(name string) error {
 		return nil
 	case usagelog.FieldDurationMs:
 		m.ResetDurationMs()
+		return nil
+	case usagelog.FieldGatewayLatencyMs:
+		m.ResetGatewayLatencyMs()
 		return nil
 	case usagelog.FieldFirstTokenMs:
 		m.ResetFirstTokenMs()

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -2387,39 +2387,39 @@ func init() {
 	// usagelog.DefaultStream holds the default value on creation for the stream field.
 	usagelog.DefaultStream = usagelogDescStream.Default.(bool)
 	// usagelogDescUserAgent is the schema descriptor for user_agent field.
-	usagelogDescUserAgent := usagelogFields[32].Descriptor()
+	usagelogDescUserAgent := usagelogFields[33].Descriptor()
 	// usagelog.UserAgentValidator is a validator for the "user_agent" field. It is called by the builders before save.
 	usagelog.UserAgentValidator = usagelogDescUserAgent.Validators[0].(func(string) error)
 	// usagelogDescIPAddress is the schema descriptor for ip_address field.
-	usagelogDescIPAddress := usagelogFields[33].Descriptor()
+	usagelogDescIPAddress := usagelogFields[34].Descriptor()
 	// usagelog.IPAddressValidator is a validator for the "ip_address" field. It is called by the builders before save.
 	usagelog.IPAddressValidator = usagelogDescIPAddress.Validators[0].(func(string) error)
 	// usagelogDescImageCount is the schema descriptor for image_count field.
-	usagelogDescImageCount := usagelogFields[34].Descriptor()
+	usagelogDescImageCount := usagelogFields[35].Descriptor()
 	// usagelog.DefaultImageCount holds the default value on creation for the image_count field.
 	usagelog.DefaultImageCount = usagelogDescImageCount.Default.(int)
 	// usagelogDescImageSize is the schema descriptor for image_size field.
-	usagelogDescImageSize := usagelogFields[35].Descriptor()
+	usagelogDescImageSize := usagelogFields[36].Descriptor()
 	// usagelog.ImageSizeValidator is a validator for the "image_size" field. It is called by the builders before save.
 	usagelog.ImageSizeValidator = usagelogDescImageSize.Validators[0].(func(string) error)
 	// usagelogDescImageInputSize is the schema descriptor for image_input_size field.
-	usagelogDescImageInputSize := usagelogFields[36].Descriptor()
+	usagelogDescImageInputSize := usagelogFields[37].Descriptor()
 	// usagelog.ImageInputSizeValidator is a validator for the "image_input_size" field. It is called by the builders before save.
 	usagelog.ImageInputSizeValidator = usagelogDescImageInputSize.Validators[0].(func(string) error)
 	// usagelogDescImageOutputSize is the schema descriptor for image_output_size field.
-	usagelogDescImageOutputSize := usagelogFields[37].Descriptor()
+	usagelogDescImageOutputSize := usagelogFields[38].Descriptor()
 	// usagelog.ImageOutputSizeValidator is a validator for the "image_output_size" field. It is called by the builders before save.
 	usagelog.ImageOutputSizeValidator = usagelogDescImageOutputSize.Validators[0].(func(string) error)
 	// usagelogDescImageSizeSource is the schema descriptor for image_size_source field.
-	usagelogDescImageSizeSource := usagelogFields[38].Descriptor()
+	usagelogDescImageSizeSource := usagelogFields[39].Descriptor()
 	// usagelog.ImageSizeSourceValidator is a validator for the "image_size_source" field. It is called by the builders before save.
 	usagelog.ImageSizeSourceValidator = usagelogDescImageSizeSource.Validators[0].(func(string) error)
 	// usagelogDescCacheTTLOverridden is the schema descriptor for cache_ttl_overridden field.
-	usagelogDescCacheTTLOverridden := usagelogFields[41].Descriptor()
+	usagelogDescCacheTTLOverridden := usagelogFields[42].Descriptor()
 	// usagelog.DefaultCacheTTLOverridden holds the default value on creation for the cache_ttl_overridden field.
 	usagelog.DefaultCacheTTLOverridden = usagelogDescCacheTTLOverridden.Default.(bool)
 	// usagelogDescCreatedAt is the schema descriptor for created_at field.
-	usagelogDescCreatedAt := usagelogFields[42].Descriptor()
+	usagelogDescCreatedAt := usagelogFields[43].Descriptor()
 	// usagelog.DefaultCreatedAt holds the default value on creation for the created_at field.
 	usagelog.DefaultCreatedAt = usagelogDescCreatedAt.Default.(func() time.Time)
 	userMixin := schema.User{}.Mixin()

--- a/backend/ent/schema/usage_log.go
+++ b/backend/ent/schema/usage_log.go
@@ -118,6 +118,10 @@ func (UsageLog) Fields() []ent.Field {
 		field.Int("duration_ms").
 			Optional().
 			Nillable(),
+		field.Int("gateway_latency_ms").
+			Optional().
+			Nillable().
+			Comment("TokenKey gateway transfer latency (auth+routing+response tail), excluding upstream wait, streaming pump, and queue waits"),
 		field.Int("first_token_ms").
 			Optional().
 			Nillable(),

--- a/backend/ent/usagelog.go
+++ b/backend/ent/usagelog.go
@@ -85,6 +85,8 @@ type UsageLog struct {
 	Stream bool `json:"stream,omitempty"`
 	// DurationMs holds the value of the "duration_ms" field.
 	DurationMs *int `json:"duration_ms,omitempty"`
+	// TokenKey gateway transfer latency (auth+routing+response tail), excluding upstream wait, streaming pump, and queue waits
+	GatewayLatencyMs *int `json:"gateway_latency_ms,omitempty"`
 	// FirstTokenMs holds the value of the "first_token_ms" field.
 	FirstTokenMs *int `json:"first_token_ms,omitempty"`
 	// UserAgent holds the value of the "user_agent" field.
@@ -198,7 +200,7 @@ func (*UsageLog) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case usagelog.FieldInputCost, usagelog.FieldOutputCost, usagelog.FieldCacheCreationCost, usagelog.FieldCacheReadCost, usagelog.FieldTotalCost, usagelog.FieldActualCost, usagelog.FieldRateMultiplier, usagelog.FieldAccountRateMultiplier:
 			values[i] = new(sql.NullFloat64)
-		case usagelog.FieldID, usagelog.FieldUserID, usagelog.FieldAPIKeyID, usagelog.FieldAccountID, usagelog.FieldChannelID, usagelog.FieldGroupID, usagelog.FieldSubscriptionID, usagelog.FieldInputTokens, usagelog.FieldOutputTokens, usagelog.FieldCacheCreationTokens, usagelog.FieldCacheReadTokens, usagelog.FieldCacheCreation5mTokens, usagelog.FieldCacheCreation1hTokens, usagelog.FieldBillingType, usagelog.FieldDurationMs, usagelog.FieldFirstTokenMs, usagelog.FieldImageCount, usagelog.FieldVideoDurationSeconds:
+		case usagelog.FieldID, usagelog.FieldUserID, usagelog.FieldAPIKeyID, usagelog.FieldAccountID, usagelog.FieldChannelID, usagelog.FieldGroupID, usagelog.FieldSubscriptionID, usagelog.FieldInputTokens, usagelog.FieldOutputTokens, usagelog.FieldCacheCreationTokens, usagelog.FieldCacheReadTokens, usagelog.FieldCacheCreation5mTokens, usagelog.FieldCacheCreation1hTokens, usagelog.FieldBillingType, usagelog.FieldDurationMs, usagelog.FieldGatewayLatencyMs, usagelog.FieldFirstTokenMs, usagelog.FieldImageCount, usagelog.FieldVideoDurationSeconds:
 			values[i] = new(sql.NullInt64)
 		case usagelog.FieldRequestID, usagelog.FieldModel, usagelog.FieldRequestedModel, usagelog.FieldUpstreamModel, usagelog.FieldModelMappingChain, usagelog.FieldBillingTier, usagelog.FieldBillingMode, usagelog.FieldUserAgent, usagelog.FieldIPAddress, usagelog.FieldImageSize, usagelog.FieldImageInputSize, usagelog.FieldImageOutputSize, usagelog.FieldImageSizeSource:
 			values[i] = new(sql.NullString)
@@ -420,6 +422,13 @@ func (_m *UsageLog) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.DurationMs = new(int)
 				*_m.DurationMs = int(value.Int64)
+			}
+		case usagelog.FieldGatewayLatencyMs:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field gateway_latency_ms", values[i])
+			} else if value.Valid {
+				_m.GatewayLatencyMs = new(int)
+				*_m.GatewayLatencyMs = int(value.Int64)
 			}
 		case usagelog.FieldFirstTokenMs:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -674,6 +683,11 @@ func (_m *UsageLog) String() string {
 	builder.WriteString(", ")
 	if v := _m.DurationMs; v != nil {
 		builder.WriteString("duration_ms=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	if v := _m.GatewayLatencyMs; v != nil {
+		builder.WriteString("gateway_latency_ms=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
 	}
 	builder.WriteString(", ")

--- a/backend/ent/usagelog/usagelog.go
+++ b/backend/ent/usagelog/usagelog.go
@@ -76,6 +76,8 @@ const (
 	FieldStream = "stream"
 	// FieldDurationMs holds the string denoting the duration_ms field in the database.
 	FieldDurationMs = "duration_ms"
+	// FieldGatewayLatencyMs holds the string denoting the gateway_latency_ms field in the database.
+	FieldGatewayLatencyMs = "gateway_latency_ms"
 	// FieldFirstTokenMs holds the string denoting the first_token_ms field in the database.
 	FieldFirstTokenMs = "first_token_ms"
 	// FieldUserAgent holds the string denoting the user_agent field in the database.
@@ -183,6 +185,7 @@ var Columns = []string{
 	FieldBillingType,
 	FieldStream,
 	FieldDurationMs,
+	FieldGatewayLatencyMs,
 	FieldFirstTokenMs,
 	FieldUserAgent,
 	FieldIPAddress,
@@ -435,6 +438,11 @@ func ByStream(opts ...sql.OrderTermOption) OrderOption {
 // ByDurationMs orders the results by the duration_ms field.
 func ByDurationMs(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDurationMs, opts...).ToFunc()
+}
+
+// ByGatewayLatencyMs orders the results by the gateway_latency_ms field.
+func ByGatewayLatencyMs(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldGatewayLatencyMs, opts...).ToFunc()
 }
 
 // ByFirstTokenMs orders the results by the first_token_ms field.

--- a/backend/ent/usagelog/where.go
+++ b/backend/ent/usagelog/where.go
@@ -210,6 +210,11 @@ func DurationMs(v int) predicate.UsageLog {
 	return predicate.UsageLog(sql.FieldEQ(FieldDurationMs, v))
 }
 
+// GatewayLatencyMs applies equality check predicate on the "gateway_latency_ms" field. It's identical to GatewayLatencyMsEQ.
+func GatewayLatencyMs(v int) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldEQ(FieldGatewayLatencyMs, v))
+}
+
 // FirstTokenMs applies equality check predicate on the "first_token_ms" field. It's identical to FirstTokenMsEQ.
 func FirstTokenMs(v int) predicate.UsageLog {
 	return predicate.UsageLog(sql.FieldEQ(FieldFirstTokenMs, v))
@@ -1618,6 +1623,56 @@ func DurationMsIsNil() predicate.UsageLog {
 // DurationMsNotNil applies the NotNil predicate on the "duration_ms" field.
 func DurationMsNotNil() predicate.UsageLog {
 	return predicate.UsageLog(sql.FieldNotNull(FieldDurationMs))
+}
+
+// GatewayLatencyMsEQ applies the EQ predicate on the "gateway_latency_ms" field.
+func GatewayLatencyMsEQ(v int) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldEQ(FieldGatewayLatencyMs, v))
+}
+
+// GatewayLatencyMsNEQ applies the NEQ predicate on the "gateway_latency_ms" field.
+func GatewayLatencyMsNEQ(v int) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldNEQ(FieldGatewayLatencyMs, v))
+}
+
+// GatewayLatencyMsIn applies the In predicate on the "gateway_latency_ms" field.
+func GatewayLatencyMsIn(vs ...int) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldIn(FieldGatewayLatencyMs, vs...))
+}
+
+// GatewayLatencyMsNotIn applies the NotIn predicate on the "gateway_latency_ms" field.
+func GatewayLatencyMsNotIn(vs ...int) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldNotIn(FieldGatewayLatencyMs, vs...))
+}
+
+// GatewayLatencyMsGT applies the GT predicate on the "gateway_latency_ms" field.
+func GatewayLatencyMsGT(v int) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldGT(FieldGatewayLatencyMs, v))
+}
+
+// GatewayLatencyMsGTE applies the GTE predicate on the "gateway_latency_ms" field.
+func GatewayLatencyMsGTE(v int) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldGTE(FieldGatewayLatencyMs, v))
+}
+
+// GatewayLatencyMsLT applies the LT predicate on the "gateway_latency_ms" field.
+func GatewayLatencyMsLT(v int) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldLT(FieldGatewayLatencyMs, v))
+}
+
+// GatewayLatencyMsLTE applies the LTE predicate on the "gateway_latency_ms" field.
+func GatewayLatencyMsLTE(v int) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldLTE(FieldGatewayLatencyMs, v))
+}
+
+// GatewayLatencyMsIsNil applies the IsNil predicate on the "gateway_latency_ms" field.
+func GatewayLatencyMsIsNil() predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldIsNull(FieldGatewayLatencyMs))
+}
+
+// GatewayLatencyMsNotNil applies the NotNil predicate on the "gateway_latency_ms" field.
+func GatewayLatencyMsNotNil() predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldNotNull(FieldGatewayLatencyMs))
 }
 
 // FirstTokenMsEQ applies the EQ predicate on the "first_token_ms" field.

--- a/backend/ent/usagelog_create.go
+++ b/backend/ent/usagelog_create.go
@@ -421,6 +421,20 @@ func (_c *UsageLogCreate) SetNillableDurationMs(v *int) *UsageLogCreate {
 	return _c
 }
 
+// SetGatewayLatencyMs sets the "gateway_latency_ms" field.
+func (_c *UsageLogCreate) SetGatewayLatencyMs(v int) *UsageLogCreate {
+	_c.mutation.SetGatewayLatencyMs(v)
+	return _c
+}
+
+// SetNillableGatewayLatencyMs sets the "gateway_latency_ms" field if the given value is not nil.
+func (_c *UsageLogCreate) SetNillableGatewayLatencyMs(v *int) *UsageLogCreate {
+	if v != nil {
+		_c.SetGatewayLatencyMs(*v)
+	}
+	return _c
+}
+
 // SetFirstTokenMs sets the "first_token_ms" field.
 func (_c *UsageLogCreate) SetFirstTokenMs(v int) *UsageLogCreate {
 	_c.mutation.SetFirstTokenMs(v)
@@ -997,6 +1011,10 @@ func (_c *UsageLogCreate) createSpec() (*UsageLog, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.DurationMs(); ok {
 		_spec.SetField(usagelog.FieldDurationMs, field.TypeInt, value)
 		_node.DurationMs = &value
+	}
+	if value, ok := _c.mutation.GatewayLatencyMs(); ok {
+		_spec.SetField(usagelog.FieldGatewayLatencyMs, field.TypeInt, value)
+		_node.GatewayLatencyMs = &value
 	}
 	if value, ok := _c.mutation.FirstTokenMs(); ok {
 		_spec.SetField(usagelog.FieldFirstTokenMs, field.TypeInt, value)
@@ -1714,6 +1732,30 @@ func (u *UsageLogUpsert) AddDurationMs(v int) *UsageLogUpsert {
 // ClearDurationMs clears the value of the "duration_ms" field.
 func (u *UsageLogUpsert) ClearDurationMs() *UsageLogUpsert {
 	u.SetNull(usagelog.FieldDurationMs)
+	return u
+}
+
+// SetGatewayLatencyMs sets the "gateway_latency_ms" field.
+func (u *UsageLogUpsert) SetGatewayLatencyMs(v int) *UsageLogUpsert {
+	u.Set(usagelog.FieldGatewayLatencyMs, v)
+	return u
+}
+
+// UpdateGatewayLatencyMs sets the "gateway_latency_ms" field to the value that was provided on create.
+func (u *UsageLogUpsert) UpdateGatewayLatencyMs() *UsageLogUpsert {
+	u.SetExcluded(usagelog.FieldGatewayLatencyMs)
+	return u
+}
+
+// AddGatewayLatencyMs adds v to the "gateway_latency_ms" field.
+func (u *UsageLogUpsert) AddGatewayLatencyMs(v int) *UsageLogUpsert {
+	u.Add(usagelog.FieldGatewayLatencyMs, v)
+	return u
+}
+
+// ClearGatewayLatencyMs clears the value of the "gateway_latency_ms" field.
+func (u *UsageLogUpsert) ClearGatewayLatencyMs() *UsageLogUpsert {
+	u.SetNull(usagelog.FieldGatewayLatencyMs)
 	return u
 }
 
@@ -2586,6 +2628,34 @@ func (u *UsageLogUpsertOne) UpdateDurationMs() *UsageLogUpsertOne {
 func (u *UsageLogUpsertOne) ClearDurationMs() *UsageLogUpsertOne {
 	return u.Update(func(s *UsageLogUpsert) {
 		s.ClearDurationMs()
+	})
+}
+
+// SetGatewayLatencyMs sets the "gateway_latency_ms" field.
+func (u *UsageLogUpsertOne) SetGatewayLatencyMs(v int) *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.SetGatewayLatencyMs(v)
+	})
+}
+
+// AddGatewayLatencyMs adds v to the "gateway_latency_ms" field.
+func (u *UsageLogUpsertOne) AddGatewayLatencyMs(v int) *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.AddGatewayLatencyMs(v)
+	})
+}
+
+// UpdateGatewayLatencyMs sets the "gateway_latency_ms" field to the value that was provided on create.
+func (u *UsageLogUpsertOne) UpdateGatewayLatencyMs() *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.UpdateGatewayLatencyMs()
+	})
+}
+
+// ClearGatewayLatencyMs clears the value of the "gateway_latency_ms" field.
+func (u *UsageLogUpsertOne) ClearGatewayLatencyMs() *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.ClearGatewayLatencyMs()
 	})
 }
 
@@ -3658,6 +3728,34 @@ func (u *UsageLogUpsertBulk) UpdateDurationMs() *UsageLogUpsertBulk {
 func (u *UsageLogUpsertBulk) ClearDurationMs() *UsageLogUpsertBulk {
 	return u.Update(func(s *UsageLogUpsert) {
 		s.ClearDurationMs()
+	})
+}
+
+// SetGatewayLatencyMs sets the "gateway_latency_ms" field.
+func (u *UsageLogUpsertBulk) SetGatewayLatencyMs(v int) *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.SetGatewayLatencyMs(v)
+	})
+}
+
+// AddGatewayLatencyMs adds v to the "gateway_latency_ms" field.
+func (u *UsageLogUpsertBulk) AddGatewayLatencyMs(v int) *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.AddGatewayLatencyMs(v)
+	})
+}
+
+// UpdateGatewayLatencyMs sets the "gateway_latency_ms" field to the value that was provided on create.
+func (u *UsageLogUpsertBulk) UpdateGatewayLatencyMs() *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.UpdateGatewayLatencyMs()
+	})
+}
+
+// ClearGatewayLatencyMs clears the value of the "gateway_latency_ms" field.
+func (u *UsageLogUpsertBulk) ClearGatewayLatencyMs() *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.ClearGatewayLatencyMs()
 	})
 }
 

--- a/backend/ent/usagelog_update.go
+++ b/backend/ent/usagelog_update.go
@@ -645,6 +645,33 @@ func (_u *UsageLogUpdate) ClearDurationMs() *UsageLogUpdate {
 	return _u
 }
 
+// SetGatewayLatencyMs sets the "gateway_latency_ms" field.
+func (_u *UsageLogUpdate) SetGatewayLatencyMs(v int) *UsageLogUpdate {
+	_u.mutation.ResetGatewayLatencyMs()
+	_u.mutation.SetGatewayLatencyMs(v)
+	return _u
+}
+
+// SetNillableGatewayLatencyMs sets the "gateway_latency_ms" field if the given value is not nil.
+func (_u *UsageLogUpdate) SetNillableGatewayLatencyMs(v *int) *UsageLogUpdate {
+	if v != nil {
+		_u.SetGatewayLatencyMs(*v)
+	}
+	return _u
+}
+
+// AddGatewayLatencyMs adds value to the "gateway_latency_ms" field.
+func (_u *UsageLogUpdate) AddGatewayLatencyMs(v int) *UsageLogUpdate {
+	_u.mutation.AddGatewayLatencyMs(v)
+	return _u
+}
+
+// ClearGatewayLatencyMs clears the value of the "gateway_latency_ms" field.
+func (_u *UsageLogUpdate) ClearGatewayLatencyMs() *UsageLogUpdate {
+	_u.mutation.ClearGatewayLatencyMs()
+	return _u
+}
+
 // SetFirstTokenMs sets the "first_token_ms" field.
 func (_u *UsageLogUpdate) SetFirstTokenMs(v int) *UsageLogUpdate {
 	_u.mutation.ResetFirstTokenMs()
@@ -1196,6 +1223,15 @@ func (_u *UsageLogUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if _u.mutation.DurationMsCleared() {
 		_spec.ClearField(usagelog.FieldDurationMs, field.TypeInt)
+	}
+	if value, ok := _u.mutation.GatewayLatencyMs(); ok {
+		_spec.SetField(usagelog.FieldGatewayLatencyMs, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedGatewayLatencyMs(); ok {
+		_spec.AddField(usagelog.FieldGatewayLatencyMs, field.TypeInt, value)
+	}
+	if _u.mutation.GatewayLatencyMsCleared() {
+		_spec.ClearField(usagelog.FieldGatewayLatencyMs, field.TypeInt)
 	}
 	if value, ok := _u.mutation.FirstTokenMs(); ok {
 		_spec.SetField(usagelog.FieldFirstTokenMs, field.TypeInt, value)
@@ -2044,6 +2080,33 @@ func (_u *UsageLogUpdateOne) ClearDurationMs() *UsageLogUpdateOne {
 	return _u
 }
 
+// SetGatewayLatencyMs sets the "gateway_latency_ms" field.
+func (_u *UsageLogUpdateOne) SetGatewayLatencyMs(v int) *UsageLogUpdateOne {
+	_u.mutation.ResetGatewayLatencyMs()
+	_u.mutation.SetGatewayLatencyMs(v)
+	return _u
+}
+
+// SetNillableGatewayLatencyMs sets the "gateway_latency_ms" field if the given value is not nil.
+func (_u *UsageLogUpdateOne) SetNillableGatewayLatencyMs(v *int) *UsageLogUpdateOne {
+	if v != nil {
+		_u.SetGatewayLatencyMs(*v)
+	}
+	return _u
+}
+
+// AddGatewayLatencyMs adds value to the "gateway_latency_ms" field.
+func (_u *UsageLogUpdateOne) AddGatewayLatencyMs(v int) *UsageLogUpdateOne {
+	_u.mutation.AddGatewayLatencyMs(v)
+	return _u
+}
+
+// ClearGatewayLatencyMs clears the value of the "gateway_latency_ms" field.
+func (_u *UsageLogUpdateOne) ClearGatewayLatencyMs() *UsageLogUpdateOne {
+	_u.mutation.ClearGatewayLatencyMs()
+	return _u
+}
+
 // SetFirstTokenMs sets the "first_token_ms" field.
 func (_u *UsageLogUpdateOne) SetFirstTokenMs(v int) *UsageLogUpdateOne {
 	_u.mutation.ResetFirstTokenMs()
@@ -2625,6 +2688,15 @@ func (_u *UsageLogUpdateOne) sqlSave(ctx context.Context) (_node *UsageLog, err 
 	}
 	if _u.mutation.DurationMsCleared() {
 		_spec.ClearField(usagelog.FieldDurationMs, field.TypeInt)
+	}
+	if value, ok := _u.mutation.GatewayLatencyMs(); ok {
+		_spec.SetField(usagelog.FieldGatewayLatencyMs, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedGatewayLatencyMs(); ok {
+		_spec.AddField(usagelog.FieldGatewayLatencyMs, field.TypeInt, value)
+	}
+	if _u.mutation.GatewayLatencyMsCleared() {
+		_spec.ClearField(usagelog.FieldGatewayLatencyMs, field.TypeInt)
 	}
 	if value, ok := _u.mutation.FirstTokenMs(); ok {
 		_spec.SetField(usagelog.FieldFirstTokenMs, field.TypeInt, value)

--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -130,9 +130,9 @@ func (h *DashboardHandler) GetStats(c *gin.Context) {
 		"today_actual_cost":           stats.TodayActualCost, // 今日实际扣除
 
 		// 系统运行统计
-		"average_duration_ms": stats.AverageDurationMs,
+		"average_duration_ms":        stats.AverageDurationMs,
 		"average_gateway_latency_ms": stats.AverageGatewayLatencyMs,
-		"uptime":              uptime,
+		"uptime":                     uptime,
 
 		// 性能指标
 		"rpm": stats.Rpm,

--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -131,6 +131,7 @@ func (h *DashboardHandler) GetStats(c *gin.Context) {
 
 		// 系统运行统计
 		"average_duration_ms": stats.AverageDurationMs,
+		"average_gateway_latency_ms": stats.AverageGatewayLatencyMs,
 		"uptime":              uptime,
 
 		// 性能指标

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -243,7 +243,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 	// 获取订阅信息（可能为nil）- 提前获取用于后续检查
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 
-	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
+	tkRecordAuthLatency(c, requestStart)
 
 	// 1. 首先获取用户并发槽位
 	userReleaseFunc, err := h.concurrencyHelper.AcquireUserSlotWithWait(c, subject.UserID, subject.Concurrency, reqStream, &streamStarted)
@@ -482,7 +482,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			// 账号槽位/等待计数需要在超时或断开时安全回收
 			accountReleaseFunc = wrapReleaseOnDone(c.Request.Context(), accountReleaseFunc)
 
-			service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
+			tkRecordRoutingLatency(c, routingStart)
 
 			// 转发请求 - 根据账号平台分流
 			var result *service.ForwardResult
@@ -511,7 +511,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				c.Set(service.TKGeminiDispatchGroupContextKey, apiKey.Group)
 				result, err = h.geminiCompatService.Forward(requestCtx, c, account, body)
 			}
-			service.RecordOpsResponseTransferLatencyMs(c, time.Since(forwardStart).Milliseconds())
+			tkRecordForwardResponseTail(c, forwardStart)
 			if accountReleaseFunc != nil {
 				accountReleaseFunc()
 			}
@@ -601,7 +601,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			forceCacheBilling := fs.ForceCacheBilling
 			quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
 			sessionID := service.ExtractClientSessionID(c)
-			gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+			gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 			h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 				if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
 					Result:             result,
@@ -872,7 +872,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			}
 			attemptBody := attemptParsedReq.Body.Bytes()
 
-			service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
+			tkRecordRoutingLatency(c, routingStart)
 
 			// 转发请求 - 根据账号平台分流
 			c.Set("parsed_request", attemptParsedReq)
@@ -892,7 +892,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			} else {
 				result, err = h.gatewayService.Forward(requestCtx, c, account, attemptParsedReq)
 			}
-			service.RecordOpsResponseTransferLatencyMs(c, time.Since(forwardStart).Milliseconds())
+			tkRecordForwardResponseTail(c, forwardStart)
 
 			// 兜底释放串行锁（正常情况已通过回调提前释放）
 			if queueRelease != nil {
@@ -933,7 +933,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				forceCacheBilling := fs.ForceCacheBilling
 				quotaPlatform := service.QuotaPlatform(c.Request.Context(), currentAPIKey)
 				sessionID := service.ExtractClientSessionID(c)
-				gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+				gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 				h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 					if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
 						Result:             result,

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -124,6 +124,8 @@ func NewGatewayHandler(
 // Messages handles Claude API compatible messages endpoint
 // POST /v1/messages
 func (h *GatewayHandler) Messages(c *gin.Context) {
+	requestStart := time.Now()
+
 	// 从context获取apiKey和user（ApiKeyAuth中间件已设置）
 	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
 	if !ok {
@@ -241,6 +243,8 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 	// 获取订阅信息（可能为nil）- 提前获取用于后续检查
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 
+	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
+
 	// 1. 首先获取用户并发槽位
 	userReleaseFunc, err := h.concurrencyHelper.AcquireUserSlotWithWait(c, subject.UserID, subject.Concurrency, reqStream, &streamStarted)
 	if err != nil {
@@ -341,6 +345,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 		}
 
 		for {
+			routingStart := time.Now()
 			selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, sessionKey, reqModel, fs.FailedAccountIDs, "", int64(0)) // Gemini 不使用会话限制
 			if err != nil {
 				if len(fs.FailedAccountIDs) == 0 {
@@ -477,6 +482,8 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			// 账号槽位/等待计数需要在超时或断开时安全回收
 			accountReleaseFunc = wrapReleaseOnDone(c.Request.Context(), accountReleaseFunc)
 
+			service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
+
 			// 转发请求 - 根据账号平台分流
 			var result *service.ForwardResult
 			requestCtx := c.Request.Context()
@@ -485,6 +492,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			}
 			// 记录 Forward 前已写入字节数，Forward 后若增加则说明 SSE 内容已发，禁止 failover
 			writerSizeBeforeForward := c.Writer.Size()
+			forwardStart := time.Now()
 			if account.Platform == service.PlatformAntigravity {
 				result, err = h.antigravityGatewayService.ForwardGemini(
 					requestCtx,
@@ -503,6 +511,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				c.Set(service.TKGeminiDispatchGroupContextKey, apiKey.Group)
 				result, err = h.geminiCompatService.Forward(requestCtx, c, account, body)
 			}
+			service.RecordOpsResponseTransferLatencyMs(c, time.Since(forwardStart).Milliseconds())
 			if accountReleaseFunc != nil {
 				accountReleaseFunc()
 			}
@@ -592,6 +601,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			forceCacheBilling := fs.ForceCacheBilling
 			quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
 			sessionID := service.ExtractClientSessionID(c)
+			gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 			h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 				if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
 					Result:             result,
@@ -609,6 +619,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					RequestPayloadHash: requestPayloadHash,
 					ForceCacheBilling:  forceCacheBilling,
 					APIKeyService:      h.apiKeyService,
+					GatewayLatencyMs:   gatewayLatencyMs,
 					ChannelUsageFields: clientRequestedUsageFields(c, channelMapping, reqModel, result.UpstreamModel),
 				}); err != nil {
 					logger.L().With(
@@ -649,6 +660,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 		retryWithFallback := false
 
 		for {
+			routingStart := time.Now()
 			attemptParsedReq, err := parsedReq.CloneForBody(body)
 			if err != nil {
 				h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
@@ -860,6 +872,8 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			}
 			attemptBody := attemptParsedReq.Body.Bytes()
 
+			service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
+
 			// 转发请求 - 根据账号平台分流
 			c.Set("parsed_request", attemptParsedReq)
 			var result *service.ForwardResult
@@ -872,11 +886,13 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			}
 			// 记录 Forward 前已写入字节数，Forward 后若增加则说明 SSE 内容已发，禁止 failover
 			writerSizeBeforeForward := c.Writer.Size()
+			forwardStart := time.Now()
 			if account.Platform == service.PlatformAntigravity && account.Type != service.AccountTypeAPIKey {
 				result, err = h.antigravityGatewayService.Forward(requestCtx, c, account, attemptBody, hasBoundSession)
 			} else {
 				result, err = h.gatewayService.Forward(requestCtx, c, account, attemptParsedReq)
 			}
+			service.RecordOpsResponseTransferLatencyMs(c, time.Since(forwardStart).Milliseconds())
 
 			// 兜底释放串行锁（正常情况已通过回调提前释放）
 			if queueRelease != nil {
@@ -917,6 +933,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				forceCacheBilling := fs.ForceCacheBilling
 				quotaPlatform := service.QuotaPlatform(c.Request.Context(), currentAPIKey)
 				sessionID := service.ExtractClientSessionID(c)
+				gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 				h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 					if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
 						Result:             result,
@@ -934,6 +951,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						RequestPayloadHash: requestPayloadHash,
 						ForceCacheBilling:  forceCacheBilling,
 						APIKeyService:      h.apiKeyService,
+						GatewayLatencyMs:   gatewayLatencyMs,
 						ChannelUsageFields: clientRequestedUsageFields(c, channelMapping, reqModel, result.UpstreamModel),
 					}); err != nil {
 						logger.L().With(

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -316,7 +316,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		} else {
 			result, err = h.gatewayService.ForwardAsChatCompletions(c.Request.Context(), c, account, forwardBody, parsedReq)
 		}
-		service.RecordOpsResponseTransferLatencyMs(c, time.Since(forwardStart).Milliseconds())
+		tkRecordForwardResponseTail(c, forwardStart)
 
 		if accountReleaseFunc != nil {
 			accountReleaseFunc()
@@ -368,7 +368,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 
 		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
 		sessionID := service.ExtractClientSessionID(c)
-		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+		gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
 				Result:             result,

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -185,6 +185,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 	}
 
 	for {
+		routingStart := time.Now()
 		if c.Request.Context().Err() != nil {
 			return
 		}
@@ -282,8 +283,11 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 			continue
 		}
 
+		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
+
 		// 5. Forward request
 		writerSizeBeforeForward := c.Writer.Size()
+		forwardStart := time.Now()
 		forwardBody := body
 		if channelMapping.Mapped {
 			forwardBody = h.gatewayService.ReplaceModelInBody(body, channelMapping.MappedModel)
@@ -312,6 +316,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		} else {
 			result, err = h.gatewayService.ForwardAsChatCompletions(c.Request.Context(), c, account, forwardBody, parsedReq)
 		}
+		service.RecordOpsResponseTransferLatencyMs(c, time.Since(forwardStart).Milliseconds())
 
 		if accountReleaseFunc != nil {
 			accountReleaseFunc()
@@ -363,6 +368,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 
 		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
 		sessionID := service.ExtractClientSessionID(c)
+		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
 				Result:             result,
@@ -379,6 +385,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				RequestPayloadHash: requestPayloadHash,
 				APIKeyService:      h.apiKeyService,
 				SessionID:          sessionID,
+				GatewayLatencyMs:   gatewayLatencyMs,
 				ChannelUsageFields: clientRequestedUsageFields(c, channelMapping, reqModel, result.UpstreamModel),
 			}); err != nil {
 				reqLog.Error("gateway.cc.record_usage_failed",

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -341,7 +341,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		} else {
 			result, err = h.gatewayService.ForwardAsResponses(requestCtx, c, account, forwardBody, parsedReq)
 		}
-		service.RecordOpsResponseTransferLatencyMs(c, time.Since(forwardStart).Milliseconds())
+		tkRecordForwardResponseTail(c, forwardStart)
 
 		if accountReleaseFunc != nil {
 			accountReleaseFunc()
@@ -394,7 +394,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 
 		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
 		sessionID := service.ExtractClientSessionID(c)
-		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+		gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
 				Result:             result,

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -208,6 +208,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 	}
 
 	for {
+		routingStart := time.Now()
 		if requestCtx.Err() != nil {
 			return
 		}
@@ -307,8 +308,11 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 			continue
 		}
 
+		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
+
 		// 5. Forward request
 		writerSizeBeforeForward := c.Writer.Size()
+		forwardStart := time.Now()
 		forwardBody := body
 		if channelMapping.Mapped {
 			forwardBody = h.gatewayService.ReplaceModelInBody(body, channelMapping.MappedModel)
@@ -337,6 +341,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		} else {
 			result, err = h.gatewayService.ForwardAsResponses(requestCtx, c, account, forwardBody, parsedReq)
 		}
+		service.RecordOpsResponseTransferLatencyMs(c, time.Since(forwardStart).Milliseconds())
 
 		if accountReleaseFunc != nil {
 			accountReleaseFunc()
@@ -389,6 +394,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 
 		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
 		sessionID := service.ExtractClientSessionID(c)
+		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
 				Result:             result,
@@ -405,6 +411,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 				RequestPayloadHash: requestPayloadHash,
 				APIKeyService:      h.apiKeyService,
 				SessionID:          sessionID,
+				GatewayLatencyMs:   gatewayLatencyMs,
 				ChannelUsageFields: clientRequestedUsageFields(c, channelMapping, reqModel, result.UpstreamModel),
 			}); err != nil {
 				reqLog.Error("gateway.responses.record_usage_failed",

--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -307,7 +307,7 @@ func (h *ConcurrencyHelper) acquireUserSlotWithWaitTimeout(c *gin.Context, userI
 	if err != nil {
 		return nil, err
 	}
-	service.AddOpsGatewayQueueWaitMs(c, time.Since(waitStart).Milliseconds())
+	tkRecordGatewayQueueWait(c, waitStart)
 	return h.withAPIKeySlotFromGin(c, releaseFunc), nil
 }
 
@@ -359,7 +359,7 @@ func (h *ConcurrencyHelper) AcquireAccountSlotWithWait(c *gin.Context, accountID
 	if err != nil {
 		return nil, err
 	}
-	service.AddOpsGatewayQueueWaitMs(c, time.Since(waitStart).Milliseconds())
+	tkRecordGatewayQueueWait(c, waitStart)
 	return releaseFunc, nil
 }
 
@@ -463,7 +463,7 @@ func (h *ConcurrencyHelper) AcquireAccountSlotWithWaitTimeout(c *gin.Context, ac
 	if err != nil {
 		return nil, err
 	}
-	service.AddOpsGatewayQueueWaitMs(c, time.Since(waitStart).Milliseconds())
+	tkRecordGatewayQueueWait(c, waitStart)
 	return releaseFunc, nil
 }
 

--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -302,10 +302,12 @@ func (h *ConcurrencyHelper) acquireUserSlotWithWaitTimeout(c *gin.Context, userI
 	defer h.DecrementWaitCount(ctx, userID)
 
 	// Need to wait - handle streaming ping if needed
+	waitStart := time.Now()
 	releaseFunc, err = h.waitForSlotWithPingTimeout(c, "user", userID, maxConcurrency, timeout, isStream, streamStarted, false)
 	if err != nil {
 		return nil, err
 	}
+	service.AddOpsGatewayQueueWaitMs(c, time.Since(waitStart).Milliseconds())
 	return h.withAPIKeySlotFromGin(c, releaseFunc), nil
 }
 
@@ -352,7 +354,13 @@ func (h *ConcurrencyHelper) AcquireAccountSlotWithWait(c *gin.Context, accountID
 	}
 
 	// Need to wait - handle streaming ping if needed
-	return h.waitForSlotWithPing(c, "account", accountID, maxConcurrency, isStream, streamStarted)
+	waitStart := time.Now()
+	releaseFunc, err = h.waitForSlotWithPing(c, "account", accountID, maxConcurrency, isStream, streamStarted)
+	if err != nil {
+		return nil, err
+	}
+	service.AddOpsGatewayQueueWaitMs(c, time.Since(waitStart).Milliseconds())
+	return releaseFunc, nil
 }
 
 // waitForSlotWithPing waits for a concurrency slot, sending ping events for streaming requests.
@@ -450,7 +458,13 @@ func (h *ConcurrencyHelper) waitForSlotWithPingTimeout(c *gin.Context, slotType 
 
 // AcquireAccountSlotWithWaitTimeout acquires an account slot with a custom timeout (keeps SSE ping).
 func (h *ConcurrencyHelper) AcquireAccountSlotWithWaitTimeout(c *gin.Context, accountID int64, maxConcurrency int, timeout time.Duration, isStream bool, streamStarted *bool) (func(), error) {
-	return h.waitForSlotWithPingTimeout(c, "account", accountID, maxConcurrency, timeout, isStream, streamStarted, true)
+	waitStart := time.Now()
+	releaseFunc, err := h.waitForSlotWithPingTimeout(c, "account", accountID, maxConcurrency, timeout, isStream, streamStarted, true)
+	if err != nil {
+		return nil, err
+	}
+	service.AddOpsGatewayQueueWaitMs(c, time.Since(waitStart).Milliseconds())
+	return releaseFunc, nil
 }
 
 // nextBackoff 计算下一次退避时间

--- a/backend/internal/handler/grok_media.go
+++ b/backend/internal/handler/grok_media.go
@@ -323,13 +323,7 @@ func (h *OpenAIGatewayHandler) handleGrokMedia(c *gin.Context, endpoint service.
 			return h.gatewayService.ForwardGrokMedia(requestCtx, c, account, endpoint, requestID, body, contentType)
 		}()
 
-		forwardDurationMs := time.Since(forwardStart).Milliseconds()
-		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
-		responseLatencyMs := forwardDurationMs
-		if upstreamLatencyMs > 0 && forwardDurationMs > upstreamLatencyMs {
-			responseLatencyMs = forwardDurationMs - upstreamLatencyMs
-		}
-		service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, responseLatencyMs)
+		tkRecordForwardResponseTail(c, forwardStart)
 
 		if err != nil {
 			var failoverErr *service.UpstreamFailoverError
@@ -494,7 +488,7 @@ func recordGrokMediaUsage(
 		ChannelMappedModel: requestModel,
 	}
 	h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
-		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+		gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 		if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 			Result:             result,
 			APIKey:             apiKey,

--- a/backend/internal/handler/grok_media.go
+++ b/backend/internal/handler/grok_media.go
@@ -494,6 +494,7 @@ func recordGrokMediaUsage(
 		ChannelMappedModel: requestModel,
 	}
 	h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
+		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 		if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 			Result:             result,
 			APIKey:             apiKey,
@@ -508,6 +509,7 @@ func recordGrokMediaUsage(
 			APIKeyService:      h.apiKeyService,
 			QuotaPlatform:      quotaPlatform,
 			SessionID:          sessionID,
+			GatewayLatencyMs:   gatewayLatencyMs,
 			ChannelUsageFields: channelUsageFields,
 		}); err != nil {
 			logger.L().With(

--- a/backend/internal/handler/handler_tk_gateway_latency.go
+++ b/backend/internal/handler/handler_tk_gateway_latency.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+func tkRecordAuthLatency(c *gin.Context, requestStart time.Time) {
+	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
+}
+
+func tkRecordRoutingLatency(c *gin.Context, routingStart time.Time) {
+	service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
+}
+
+func tkRecordForwardResponseTail(c *gin.Context, forwardStart time.Time) {
+	service.RecordOpsResponseTransferLatencyMs(c, time.Since(forwardStart).Milliseconds())
+}
+
+func tkSnapshotGatewayTransferLatencyMs(c *gin.Context) *int {
+	return service.SnapshotGatewayTransferLatencyMs(c)
+}
+
+func tkRecordGatewayQueueWait(c *gin.Context, waitStart time.Time) {
+	service.AddOpsGatewayQueueWaitMs(c, time.Since(waitStart).Milliseconds())
+}

--- a/backend/internal/handler/openai_alpha_search.go
+++ b/backend/internal/handler/openai_alpha_search.go
@@ -179,7 +179,7 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 			}
 			return h.gatewayService.ForwardAlphaSearch(c.Request.Context(), c, account, forwardBody)
 		}()
-		service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, time.Since(forwardStart).Milliseconds())
+		tkRecordForwardResponseTail(c, forwardStart)
 
 		if err == nil {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(requestedModel), true, nil)
@@ -252,7 +252,7 @@ func (h *OpenAIGatewayHandler) recordAlphaSearchUsage(
 	inboundEndpoint := GetInboundEndpoint(c)
 	upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
 	quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
-	gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+	gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 
 	h.submitMandatoryUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 		if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{

--- a/backend/internal/handler/openai_alpha_search.go
+++ b/backend/internal/handler/openai_alpha_search.go
@@ -252,6 +252,7 @@ func (h *OpenAIGatewayHandler) recordAlphaSearchUsage(
 	inboundEndpoint := GetInboundEndpoint(c)
 	upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
 	quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
+	gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 
 	h.submitMandatoryUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 		if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
@@ -268,6 +269,7 @@ func (h *OpenAIGatewayHandler) recordAlphaSearchUsage(
 			APIKeyService:      h.apiKeyService,
 			QuotaPlatform:      quotaPlatform,
 			SessionID:          sessionID,
+			GatewayLatencyMs:   gatewayLatencyMs,
 			ChannelUsageFields: channelMapping.ToUsageFields(requestedModel, result.UpstreamModel),
 			PricingAt:          service.OpenAIPricingAtFromContext(c.Request.Context()),
 		}); err != nil {

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -280,13 +280,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		}
 		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyChat, clientRequestedUsageFields(c, channelMapping, reqModel, ""), service.HashUsageRequestPayload(body))
 
-		forwardDurationMs := time.Since(forwardStart).Milliseconds()
-		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
-		responseLatencyMs := forwardDurationMs
-		if upstreamLatencyMs > 0 && forwardDurationMs > upstreamLatencyMs {
-			responseLatencyMs = forwardDurationMs - upstreamLatencyMs
-		}
-		service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, responseLatencyMs)
+		tkRecordForwardResponseTail(c, forwardStart)
 		if err == nil && result != nil && result.FirstTokenMs != nil {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
@@ -429,7 +423,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 
 		tkHoldRequestID := hold.HandOffToSettlement()
 		cyberBlocked := service.GetOpsCyberPolicy(c) != nil
-		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+		gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -429,6 +429,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 
 		tkHoldRequestID := hold.HandOffToSettlement()
 		cyberBlocked := service.GetOpsCyberPolicy(c) != nil
+		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,
@@ -444,6 +445,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 				TkHoldRequestID:    tkHoldRequestID,
 				QuotaPlatform:      quotaPlatform,
 				SessionID:          sessionID,
+				GatewayLatencyMs:   gatewayLatencyMs,
 				ChannelUsageFields: clientRequestedUsageFields(c, channelMapping, reqModel, result.UpstreamModel),
 				PricingAt:          pricingAt,
 				CyberBlocked:       cyberBlocked,

--- a/backend/internal/handler/openai_gateway_embeddings_images.go
+++ b/backend/internal/handler/openai_gateway_embeddings_images.go
@@ -304,6 +304,7 @@ func (h *OpenAIGatewayHandler) embeddings(c *gin.Context) {
 
 		tkHoldRequestID := hold.HandOffToSettlement()
 		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
+		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			upstreamModelForUsage := ""
 			if result != nil {
@@ -322,6 +323,7 @@ func (h *OpenAIGatewayHandler) embeddings(c *gin.Context) {
 				APIKeyService:      h.apiKeyService,
 				TkHoldRequestID:    tkHoldRequestID,
 				QuotaPlatform:      quotaPlatform,
+				GatewayLatencyMs:   gatewayLatencyMs,
 				ChannelUsageFields: channelMapping.ToUsageFields(reqModel, upstreamModelForUsage),
 			}); err != nil {
 				logger.L().With(
@@ -631,6 +633,7 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 
 		tkHoldRequestID := hold.HandOffToSettlement()
 		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
+		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			upstreamModelForUsage := ""
 			if result != nil {
@@ -649,6 +652,7 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 				APIKeyService:      h.apiKeyService,
 				TkHoldRequestID:    tkHoldRequestID,
 				QuotaPlatform:      quotaPlatform,
+				GatewayLatencyMs:   gatewayLatencyMs,
 				ChannelUsageFields: channelMapping.ToUsageFields(reqModel, upstreamModelForUsage),
 			}); err != nil {
 				logger.L().With(

--- a/backend/internal/handler/openai_gateway_embeddings_images.go
+++ b/backend/internal/handler/openai_gateway_embeddings_images.go
@@ -223,16 +223,10 @@ func (h *OpenAIGatewayHandler) embeddings(c *gin.Context) {
 		TkSetBridgeGinAuth(c, subject.UserID, groupName)
 		result, err := h.gatewayService.ForwardAsEmbeddingsDispatched(c.Request.Context(), c, account, forwardBody, defaultMappedModel)
 
-		forwardDurationMs := time.Since(forwardStart).Milliseconds()
 		if accountReleaseFunc != nil {
 			accountReleaseFunc()
 		}
-		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
-		responseLatencyMs := forwardDurationMs
-		if upstreamLatencyMs > 0 && forwardDurationMs > upstreamLatencyMs {
-			responseLatencyMs = forwardDurationMs - upstreamLatencyMs
-		}
-		service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, responseLatencyMs)
+		tkRecordForwardResponseTail(c, forwardStart)
 
 		if err != nil {
 			var failoverErr *service.UpstreamFailoverError
@@ -304,7 +298,7 @@ func (h *OpenAIGatewayHandler) embeddings(c *gin.Context) {
 
 		tkHoldRequestID := hold.HandOffToSettlement()
 		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
-		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+		gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			upstreamModelForUsage := ""
 			if result != nil {
@@ -552,16 +546,10 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 		logOpenAIImageGenerationRequestAudit(c, apiKey, subject.UserID, account, body, forwardBody)
 		result, err := h.gatewayService.ForwardAsImageGenerationsDispatched(c.Request.Context(), c, account, forwardBody, defaultMappedModel)
 
-		forwardDurationMs := time.Since(forwardStart).Milliseconds()
 		if accountReleaseFunc != nil {
 			accountReleaseFunc()
 		}
-		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
-		responseLatencyMs := forwardDurationMs
-		if upstreamLatencyMs > 0 && forwardDurationMs > upstreamLatencyMs {
-			responseLatencyMs = forwardDurationMs - upstreamLatencyMs
-		}
-		service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, responseLatencyMs)
+		tkRecordForwardResponseTail(c, forwardStart)
 
 		if err != nil {
 			var failoverErr *service.UpstreamFailoverError
@@ -633,7 +621,7 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 
 		tkHoldRequestID := hold.HandOffToSettlement()
 		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
-		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+		gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			upstreamModelForUsage := ""
 			if result != nil {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -750,6 +750,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		// 使用量记录通过有界 worker 池提交，避免请求热路径创建无界 goroutine。
 		tkHoldRequestID := hold.HandOffToSettlement()
 		cyberBlocked := service.GetOpsCyberPolicy(c) != nil
+		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,
@@ -766,6 +767,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				TkHoldRequestID:    tkHoldRequestID,
 				QuotaPlatform:      quotaPlatform,
 				SessionID:          sessionID,
+				GatewayLatencyMs:   gatewayLatencyMs,
 				ChannelUsageFields: clientRequestedUsageFields(c, channelMapping, reqModel, result.UpstreamModel),
 				PricingAt:          pricingAt,
 				CyberBlocked:       cyberBlocked,
@@ -1293,6 +1295,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 
 		tkHoldRequestID := hold.HandOffToSettlement()
 		cyberBlocked := service.GetOpsCyberPolicy(c) != nil
+		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,
@@ -1309,6 +1312,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 				TkHoldRequestID:    tkHoldRequestID,
 				QuotaPlatform:      quotaPlatform,
 				SessionID:          sessionID,
+				GatewayLatencyMs:   gatewayLatencyMs,
 				ChannelUsageFields: clientRequestedUsageFields(c, channelMappingMsg, reqModel, result.UpstreamModel),
 				PricingAt:          pricingAt,
 				CyberBlocked:       cyberBlocked,

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -2487,28 +2487,6 @@ func (h *OpenAIGatewayHandler) missingResponsesDependencies() []string {
 	return missing
 }
 
-func getContextInt64(c *gin.Context, key string) (int64, bool) {
-	if c == nil || key == "" {
-		return 0, false
-	}
-	v, ok := c.Get(key)
-	if !ok {
-		return 0, false
-	}
-	switch t := v.(type) {
-	case int64:
-		return t, true
-	case int:
-		return int64(t), true
-	case int32:
-		return int64(t), true
-	case float64:
-		return int64(t), true
-	default:
-		return 0, false
-	}
-}
-
 func (h *OpenAIGatewayHandler) submitUsageRecordTask(parent context.Context, task service.UsageRecordTask) {
 	if task == nil {
 		return

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -592,13 +592,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			cyberBlockKeyHTTP = service.CyberSessionBlockKey(apiKey.ID, c, sessionHashBody)
 		}
 		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyHTTP, clientRequestedUsageFields(c, channelMapping, reqModel, ""), service.HashUsageRequestPayload(body))
-		forwardDurationMs := time.Since(forwardStart).Milliseconds()
-		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
-		responseLatencyMs := forwardDurationMs
-		if upstreamLatencyMs > 0 && forwardDurationMs > upstreamLatencyMs {
-			responseLatencyMs = forwardDurationMs - upstreamLatencyMs
-		}
-		service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, responseLatencyMs)
+		tkRecordForwardResponseTail(c, forwardStart)
 		if err == nil && result != nil && result.FirstTokenMs != nil {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
@@ -750,7 +744,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		// 使用量记录通过有界 worker 池提交，避免请求热路径创建无界 goroutine。
 		tkHoldRequestID := hold.HandOffToSettlement()
 		cyberBlocked := service.GetOpsCyberPolicy(c) != nil
-		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+		gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,
@@ -1181,13 +1175,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			cyberBlockKeyMsg = service.CyberSessionBlockKey(apiKey.ID, c, body)
 		}
 		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyMsg, clientRequestedUsageFields(c, channelMappingMsg, reqModel, ""), service.HashUsageRequestPayload(body))
-		forwardDurationMs := time.Since(forwardStart).Milliseconds()
-		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
-		responseLatencyMs := forwardDurationMs
-		if upstreamLatencyMs > 0 && forwardDurationMs > upstreamLatencyMs {
-			responseLatencyMs = forwardDurationMs - upstreamLatencyMs
-		}
-		service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, responseLatencyMs)
+		tkRecordForwardResponseTail(c, forwardStart)
 		if err == nil && result != nil && result.FirstTokenMs != nil {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
@@ -1295,7 +1283,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 
 		tkHoldRequestID := hold.HandOffToSettlement()
 		cyberBlocked := service.GetOpsCyberPolicy(c) != nil
-		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+		gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -275,6 +275,7 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 	// conservative max so we never under-charge when the field is omitted.
 	videoSeconds := videoRequestedSeconds(body)
 	tkHoldRequestID := hold.HandOffToSettlement()
+	gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 	h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 		if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 			Result: &service.OpenAIForwardResult{
@@ -299,6 +300,7 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 			IPAddress:        clientIP,
 			APIKeyService:    h.apiKeyService,
 			TkHoldRequestID:  tkHoldRequestID,
+			GatewayLatencyMs: gatewayLatencyMs,
 		}); err != nil {
 			logger.L().With(
 				zap.String("component", "handler.openai_gateway.video_submit"),

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -201,8 +201,7 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 
 	TkSetBridgeGinAuth(c, subject.UserID, groupName)
 	outcome, err := h.gatewayService.ForwardAsVideoSubmitDispatched(c.Request.Context(), c, account, publicTaskID, body)
-	forwardDurationMs := time.Since(forwardStart).Milliseconds()
-	service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, forwardDurationMs)
+	tkRecordForwardResponseTail(c, forwardStart)
 
 	if err != nil {
 		if TkTryWriteNewAPIRelayErrorJSON(c, err, false, 0) {
@@ -275,7 +274,7 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 	// conservative max so we never under-charge when the field is omitted.
 	videoSeconds := videoRequestedSeconds(body)
 	tkHoldRequestID := hold.HandOffToSettlement()
-	gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+	gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 	h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 		if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 			Result: &service.OpenAIForwardResult{

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -413,6 +413,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		}
 		tkHoldRequestID := hold.HandOffToSettlement()
 		sessionID := service.ExtractClientSessionID(c)
+		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
 		h.submitMandatoryUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,
@@ -429,6 +430,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 				TkHoldRequestID:    tkHoldRequestID,
 				QuotaPlatform:      quotaPlatform,
 				SessionID:          sessionID,
+				GatewayLatencyMs:   gatewayLatencyMs,
 				ChannelUsageFields: clientRequestedUsageFields(c, channelMapping, requestModel, upstreamModel),
 			}); err != nil {
 				logger.L().With(

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -276,13 +276,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 			}()
 			return h.gatewayService.ForwardImages(requestCtx, c, account, body, parsed, channelMapping.MappedModel)
 		}()
-		forwardDurationMs := time.Since(forwardStart).Milliseconds()
-		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
-		responseLatencyMs := forwardDurationMs
-		if upstreamLatencyMs > 0 && forwardDurationMs > upstreamLatencyMs {
-			responseLatencyMs = forwardDurationMs - upstreamLatencyMs
-		}
-		service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, responseLatencyMs)
+		tkRecordForwardResponseTail(c, forwardStart)
 		if result != nil && result.FirstTokenMs != nil {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
@@ -413,7 +407,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		}
 		tkHoldRequestID := hold.HandOffToSettlement()
 		sessionID := service.ExtractClientSessionID(c)
-		gatewayLatencyMs := service.SnapshotGatewayTransferLatencyMs(c)
+		gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 		h.submitMandatoryUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,

--- a/backend/internal/handler/user_msg_queue_helper.go
+++ b/backend/internal/handler/user_msg_queue_helper.go
@@ -59,6 +59,7 @@ func (h *UserMsgQueueHelper) AcquireWithWait(
 
 	if result.Acquired {
 		// 获取成功，执行 RPM 自适应延迟
+		delayStart := time.Now()
 		if err := h.queueService.EnforceDelay(ctx, accountID, baseRPM); err != nil {
 			if ctx.Err() != nil {
 				// 延迟期间 context 取消，释放锁
@@ -68,12 +69,19 @@ func (h *UserMsgQueueHelper) AcquireWithWait(
 				return nil, ctx.Err()
 			}
 		}
+		service.AddOpsGatewayQueueWaitMs(c, time.Since(delayStart).Milliseconds())
 		reqLog.Debug("gateway.umq_lock_acquired", zap.Int64("account_id", accountID))
 		return h.makeReleaseFunc(accountID, result.RequestID, reqLog), nil
 	}
 
 	// 需要等待：指数退避轮询
-	return h.waitForLockWithPing(c, ctx, accountID, baseRPM, isStream, streamStarted, reqLog)
+	waitStart := time.Now()
+	releaseFunc, err = h.waitForLockWithPing(c, ctx, accountID, baseRPM, isStream, streamStarted, reqLog)
+	if err != nil {
+		return nil, err
+	}
+	service.AddOpsGatewayQueueWaitMs(c, time.Since(waitStart).Milliseconds())
+	return releaseFunc, nil
 }
 
 // waitForLockWithPing 等待获取锁，流式请求期间发送 SSE ping
@@ -133,6 +141,7 @@ func (h *UserMsgQueueHelper) waitForLockWithPing(
 			}
 			if result.Acquired {
 				// 获取成功，执行 RPM 自适应延迟
+				delayStart := time.Now()
 				if delayErr := h.queueService.EnforceDelay(ctx, accountID, baseRPM); delayErr != nil {
 					if ctx.Err() != nil {
 						bgCtx, bgCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -141,6 +150,7 @@ func (h *UserMsgQueueHelper) waitForLockWithPing(
 						return nil, ctx.Err()
 					}
 				}
+				service.AddOpsGatewayQueueWaitMs(c, time.Since(delayStart).Milliseconds())
 				reqLog.Debug("gateway.umq_lock_acquired", zap.Int64("account_id", accountID))
 				return h.makeReleaseFunc(accountID, result.RequestID, reqLog), nil
 			}
@@ -187,6 +197,11 @@ func (h *UserMsgQueueHelper) ThrottleWithPing(
 	if delay <= 0 {
 		return nil
 	}
+
+	throttleStart := time.Now()
+	defer func() {
+		service.AddOpsGatewayQueueWaitMs(c, time.Since(throttleStart).Milliseconds())
+	}()
 
 	reqLog.Debug("gateway.umq_throttle_delay",
 		zap.Int64("account_id", accountID),

--- a/backend/internal/handler/user_msg_queue_helper.go
+++ b/backend/internal/handler/user_msg_queue_helper.go
@@ -69,7 +69,7 @@ func (h *UserMsgQueueHelper) AcquireWithWait(
 				return nil, ctx.Err()
 			}
 		}
-		service.AddOpsGatewayQueueWaitMs(c, time.Since(delayStart).Milliseconds())
+		tkRecordGatewayQueueWait(c, delayStart)
 		reqLog.Debug("gateway.umq_lock_acquired", zap.Int64("account_id", accountID))
 		return h.makeReleaseFunc(accountID, result.RequestID, reqLog), nil
 	}
@@ -80,7 +80,7 @@ func (h *UserMsgQueueHelper) AcquireWithWait(
 	if err != nil {
 		return nil, err
 	}
-	service.AddOpsGatewayQueueWaitMs(c, time.Since(waitStart).Milliseconds())
+	tkRecordGatewayQueueWait(c, waitStart)
 	return releaseFunc, nil
 }
 
@@ -150,7 +150,7 @@ func (h *UserMsgQueueHelper) waitForLockWithPing(
 						return nil, ctx.Err()
 					}
 				}
-				service.AddOpsGatewayQueueWaitMs(c, time.Since(delayStart).Milliseconds())
+				tkRecordGatewayQueueWait(c, delayStart)
 				reqLog.Debug("gateway.umq_lock_acquired", zap.Int64("account_id", accountID))
 				return h.makeReleaseFunc(accountID, result.RequestID, reqLog), nil
 			}
@@ -200,7 +200,7 @@ func (h *UserMsgQueueHelper) ThrottleWithPing(
 
 	throttleStart := time.Now()
 	defer func() {
-		service.AddOpsGatewayQueueWaitMs(c, time.Since(throttleStart).Milliseconds())
+		tkRecordGatewayQueueWait(c, throttleStart)
 	}()
 
 	reqLog.Debug("gateway.umq_throttle_delay",

--- a/backend/internal/pkg/usagestats/usage_log_types.go
+++ b/backend/internal/pkg/usagestats/usage_log_types.go
@@ -85,8 +85,8 @@ type DashboardStats struct {
 	TodayAccountCost         float64 `json:"today_account_cost"` // 今日账号成本
 
 	// 系统运行统计
-	AverageDurationMs        float64 `json:"average_duration_ms"`         // 平均端到端响应时间
-	AverageGatewayLatencyMs  float64 `json:"average_gateway_latency_ms"`  // 平均网关中转延迟（auth+路由+响应收尾，不含上游/排队）
+	AverageDurationMs       float64 `json:"average_duration_ms"`        // 平均端到端响应时间
+	AverageGatewayLatencyMs float64 `json:"average_gateway_latency_ms"` // 平均网关中转延迟（auth+路由+响应收尾，不含上游/排队）
 
 	// 性能指标
 	Rpm int64 `json:"rpm"` // 近5分钟平均每分钟请求数

--- a/backend/internal/pkg/usagestats/usage_log_types.go
+++ b/backend/internal/pkg/usagestats/usage_log_types.go
@@ -85,7 +85,8 @@ type DashboardStats struct {
 	TodayAccountCost         float64 `json:"today_account_cost"` // 今日账号成本
 
 	// 系统运行统计
-	AverageDurationMs float64 `json:"average_duration_ms"` // 平均响应时间
+	AverageDurationMs        float64 `json:"average_duration_ms"`         // 平均端到端响应时间
+	AverageGatewayLatencyMs  float64 `json:"average_gateway_latency_ms"`  // 平均网关中转延迟（auth+路由+响应收尾，不含上游/排队）
 
 	// 性能指标
 	Rpm int64 `json:"rpm"` // 近5分钟平均每分钟请求数

--- a/backend/internal/repository/dashboard_aggregation_repo.go
+++ b/backend/internal/repository/dashboard_aggregation_repo.go
@@ -377,7 +377,9 @@ func (r *dashboardAggregationRepository) upsertHourlyAggregates(ctx context.Cont
 				COALESCE(SUM(total_cost), 0) AS total_cost,
 				COALESCE(SUM(actual_cost), 0) AS actual_cost,
 				COALESCE(SUM(COALESCE(account_stats_cost, total_cost) * COALESCE(account_rate_multiplier, 1)), 0) AS account_cost,
-				COALESCE(SUM(COALESCE(duration_ms, 0)), 0) AS total_duration_ms
+				COALESCE(SUM(COALESCE(duration_ms, 0)), 0) AS total_duration_ms,
+				COALESCE(SUM(gateway_latency_ms) FILTER (WHERE gateway_latency_ms IS NOT NULL), 0) AS total_gateway_latency_ms,
+				COUNT(gateway_latency_ms) FILTER (WHERE gateway_latency_ms IS NOT NULL) AS gateway_latency_samples
 			FROM usage_logs
 			WHERE created_at >= $1 AND created_at < $2
 			GROUP BY 1
@@ -399,6 +401,8 @@ func (r *dashboardAggregationRepository) upsertHourlyAggregates(ctx context.Cont
 			actual_cost,
 			account_cost,
 			total_duration_ms,
+			total_gateway_latency_ms,
+			gateway_latency_samples,
 			active_users,
 			computed_at
 		)
@@ -413,6 +417,8 @@ func (r *dashboardAggregationRepository) upsertHourlyAggregates(ctx context.Cont
 			hourly.actual_cost,
 			hourly.account_cost,
 			hourly.total_duration_ms,
+			hourly.total_gateway_latency_ms,
+			hourly.gateway_latency_samples,
 			COALESCE(user_counts.active_users, 0) AS active_users,
 			NOW()
 		FROM hourly
@@ -428,6 +434,8 @@ func (r *dashboardAggregationRepository) upsertHourlyAggregates(ctx context.Cont
 			actual_cost = EXCLUDED.actual_cost,
 			account_cost = EXCLUDED.account_cost,
 			total_duration_ms = EXCLUDED.total_duration_ms,
+			total_gateway_latency_ms = EXCLUDED.total_gateway_latency_ms,
+			gateway_latency_samples = EXCLUDED.gateway_latency_samples,
 			active_users = EXCLUDED.active_users,
 			computed_at = EXCLUDED.computed_at
 	`
@@ -449,7 +457,9 @@ func (r *dashboardAggregationRepository) upsertDailyAggregates(ctx context.Conte
 				COALESCE(SUM(total_cost), 0) AS total_cost,
 				COALESCE(SUM(actual_cost), 0) AS actual_cost,
 				COALESCE(SUM(account_cost), 0) AS account_cost,
-				COALESCE(SUM(total_duration_ms), 0) AS total_duration_ms
+				COALESCE(SUM(total_duration_ms), 0) AS total_duration_ms,
+				COALESCE(SUM(total_gateway_latency_ms), 0) AS total_gateway_latency_ms,
+				COALESCE(SUM(gateway_latency_samples), 0) AS gateway_latency_samples
 			FROM usage_dashboard_hourly
 			WHERE bucket_start >= $1 AND bucket_start < $2
 			GROUP BY (bucket_start AT TIME ZONE $5)::date
@@ -471,6 +481,8 @@ func (r *dashboardAggregationRepository) upsertDailyAggregates(ctx context.Conte
 			actual_cost,
 			account_cost,
 			total_duration_ms,
+			total_gateway_latency_ms,
+			gateway_latency_samples,
 			active_users,
 			computed_at
 		)
@@ -485,6 +497,8 @@ func (r *dashboardAggregationRepository) upsertDailyAggregates(ctx context.Conte
 			daily.actual_cost,
 			daily.account_cost,
 			daily.total_duration_ms,
+			daily.total_gateway_latency_ms,
+			daily.gateway_latency_samples,
 			COALESCE(user_counts.active_users, 0) AS active_users,
 			NOW()
 		FROM daily
@@ -500,6 +514,8 @@ func (r *dashboardAggregationRepository) upsertDailyAggregates(ctx context.Conte
 			actual_cost = EXCLUDED.actual_cost,
 			account_cost = EXCLUDED.account_cost,
 			total_duration_ms = EXCLUDED.total_duration_ms,
+			total_gateway_latency_ms = EXCLUDED.total_gateway_latency_ms,
+			gateway_latency_samples = EXCLUDED.gateway_latency_samples,
 			active_users = EXCLUDED.active_users,
 			computed_at = EXCLUDED.computed_at
 	`

--- a/backend/internal/repository/usage_log_repo_dashboard.go
+++ b/backend/internal/repository/usage_log_repo_dashboard.go
@@ -203,10 +203,14 @@ func (r *usageLogRepository) fillDashboardUsageStatsAggregated(ctx context.Conte
 			COALESCE(SUM(total_cost), 0) as total_cost,
 			COALESCE(SUM(actual_cost), 0) as total_actual_cost,
 			COALESCE(SUM(account_cost), 0) as total_account_cost,
-			COALESCE(SUM(total_duration_ms), 0) as total_duration_ms
+			COALESCE(SUM(total_duration_ms), 0) as total_duration_ms,
+			COALESCE(SUM(total_gateway_latency_ms), 0) as total_gateway_latency_ms,
+			COALESCE(SUM(gateway_latency_samples), 0) as gateway_latency_samples
 		FROM usage_dashboard_daily
 	`
 	var totalDurationMs int64
+	var totalGatewayLatencyMs int64
+	var gatewayLatencySamples int64
 	if err := scanSingleRow(
 		ctx,
 		r.sql,
@@ -221,12 +225,17 @@ func (r *usageLogRepository) fillDashboardUsageStatsAggregated(ctx context.Conte
 		&stats.TotalActualCost,
 		&stats.TotalAccountCost,
 		&totalDurationMs,
+		&totalGatewayLatencyMs,
+		&gatewayLatencySamples,
 	); err != nil {
 		return err
 	}
 	stats.TotalTokens = stats.TotalInputTokens + stats.TotalOutputTokens + stats.TotalCacheCreationTokens + stats.TotalCacheReadTokens
 	if stats.TotalRequests > 0 {
 		stats.AverageDurationMs = float64(totalDurationMs) / float64(stats.TotalRequests)
+	}
+	if gatewayLatencySamples > 0 {
+		stats.AverageGatewayLatencyMs = float64(totalGatewayLatencyMs) / float64(gatewayLatencySamples)
 	}
 
 	todayStatsQuery := `
@@ -292,7 +301,8 @@ func (r *usageLogRepository) fillDashboardUsageStatsFromUsageLogs(ctx context.Co
 				total_cost,
 				actual_cost,
 				COALESCE(account_stats_cost, total_cost) * COALESCE(account_rate_multiplier, 1) AS account_cost,
-				COALESCE(duration_ms, 0) AS duration_ms
+				COALESCE(duration_ms, 0) AS duration_ms,
+				gateway_latency_ms
 			FROM usage_logs
 			WHERE created_at >= LEAST($1::timestamptz, $3::timestamptz)
 				AND created_at < GREATEST($2::timestamptz, $4::timestamptz)
@@ -307,6 +317,8 @@ func (r *usageLogRepository) fillDashboardUsageStatsFromUsageLogs(ctx context.Co
 			COALESCE(SUM(actual_cost) FILTER (WHERE created_at >= $1::timestamptz AND created_at < $2::timestamptz), 0) AS total_actual_cost,
 			COALESCE(SUM(account_cost) FILTER (WHERE created_at >= $1::timestamptz AND created_at < $2::timestamptz), 0) AS total_account_cost,
 			COALESCE(SUM(duration_ms) FILTER (WHERE created_at >= $1::timestamptz AND created_at < $2::timestamptz), 0) AS total_duration_ms,
+			COALESCE(SUM(gateway_latency_ms) FILTER (WHERE created_at >= $1::timestamptz AND created_at < $2::timestamptz AND gateway_latency_ms IS NOT NULL), 0) AS total_gateway_latency_ms,
+			COUNT(gateway_latency_ms) FILTER (WHERE created_at >= $1::timestamptz AND created_at < $2::timestamptz AND gateway_latency_ms IS NOT NULL) AS gateway_latency_samples,
 			COUNT(*) FILTER (WHERE created_at >= $3::timestamptz AND created_at < $4::timestamptz) AS today_requests,
 			COALESCE(SUM(input_tokens) FILTER (WHERE created_at >= $3::timestamptz AND created_at < $4::timestamptz), 0) AS today_input_tokens,
 			COALESCE(SUM(output_tokens) FILTER (WHERE created_at >= $3::timestamptz AND created_at < $4::timestamptz), 0) AS today_output_tokens,
@@ -318,6 +330,8 @@ func (r *usageLogRepository) fillDashboardUsageStatsFromUsageLogs(ctx context.Co
 		FROM scoped
 	`
 	var totalDurationMs int64
+	var totalGatewayLatencyMs int64
+	var gatewayLatencySamples int64
 	if err := scanSingleRow(
 		ctx,
 		r.sql,
@@ -332,6 +346,8 @@ func (r *usageLogRepository) fillDashboardUsageStatsFromUsageLogs(ctx context.Co
 		&stats.TotalActualCost,
 		&stats.TotalAccountCost,
 		&totalDurationMs,
+		&totalGatewayLatencyMs,
+		&gatewayLatencySamples,
 		&stats.TodayRequests,
 		&stats.TodayInputTokens,
 		&stats.TodayOutputTokens,
@@ -346,6 +362,9 @@ func (r *usageLogRepository) fillDashboardUsageStatsFromUsageLogs(ctx context.Co
 	stats.TotalTokens = stats.TotalInputTokens + stats.TotalOutputTokens + stats.TotalCacheCreationTokens + stats.TotalCacheReadTokens
 	if stats.TotalRequests > 0 {
 		stats.AverageDurationMs = float64(totalDurationMs) / float64(stats.TotalRequests)
+	}
+	if gatewayLatencySamples > 0 {
+		stats.AverageGatewayLatencyMs = float64(totalGatewayLatencyMs) / float64(gatewayLatencySamples)
 	}
 
 	stats.TodayTokens = stats.TodayInputTokens + stats.TodayOutputTokens + stats.TodayCacheCreationTokens + stats.TodayCacheReadTokens

--- a/backend/internal/repository/usage_log_repo_dashboard_gateway_latency_test.go
+++ b/backend/internal/repository/usage_log_repo_dashboard_gateway_latency_test.go
@@ -1,0 +1,139 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFillDashboardUsageStatsFromUsageLogs_AverageGatewayLatencyMs(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
+
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db, db: db}
+
+	startUTC := time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC)
+	endUTC := time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC)
+	todayUTC := time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC)
+	todayEnd := todayUTC.Add(24 * time.Hour)
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery("FROM scoped").
+		WithArgs(startUTC, endUTC, todayUTC, todayEnd).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total_requests", "total_input_tokens", "total_output_tokens",
+			"total_cache_creation_tokens", "total_cache_read_tokens",
+			"total_cost", "total_actual_cost", "total_account_cost", "total_duration_ms",
+			"total_gateway_latency_ms", "gateway_latency_samples",
+			"today_requests", "today_input_tokens", "today_output_tokens",
+			"today_cache_creation_tokens", "today_cache_read_tokens",
+			"today_cost", "today_actual_cost", "today_account_cost",
+		}).AddRow(
+			int64(4), int64(0), int64(0), int64(0), int64(0),
+			0.0, 0.0, 0.0, int64(4000),
+			int64(600), int64(2),
+			int64(1), int64(0), int64(0), int64(0), int64(0),
+			0.0, 0.0, 0.0,
+		))
+
+	hourStart := now.UTC().Truncate(time.Hour)
+	hourEnd := hourStart.Add(time.Hour)
+	mock.ExpectQuery("active_users").
+		WithArgs(todayUTC, todayEnd, hourStart, hourEnd).
+		WillReturnRows(sqlmock.NewRows([]string{"active_users", "hourly_active_users"}).AddRow(int64(1), int64(1)))
+
+	stats := &DashboardStats{}
+	err := repo.fillDashboardUsageStatsFromUsageLogs(context.Background(), stats, startUTC, endUTC, todayUTC, now)
+	require.NoError(t, err)
+	require.InDelta(t, 300.0, stats.AverageGatewayLatencyMs, 1e-9)
+	require.InDelta(t, 1000.0, stats.AverageDurationMs, 1e-9)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFillDashboardUsageStatsFromUsageLogs_AverageGatewayLatencyMsIgnoresNullSamples(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
+
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db, db: db}
+
+	startUTC := time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC)
+	endUTC := time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC)
+	todayUTC := time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC)
+	todayEnd := todayUTC.Add(24 * time.Hour)
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery("FROM scoped").
+		WithArgs(startUTC, endUTC, todayUTC, todayEnd).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total_requests", "total_input_tokens", "total_output_tokens",
+			"total_cache_creation_tokens", "total_cache_read_tokens",
+			"total_cost", "total_actual_cost", "total_account_cost", "total_duration_ms",
+			"total_gateway_latency_ms", "gateway_latency_samples",
+			"today_requests", "today_input_tokens", "today_output_tokens",
+			"today_cache_creation_tokens", "today_cache_read_tokens",
+			"today_cost", "today_actual_cost", "today_account_cost",
+		}).AddRow(
+			int64(3), int64(0), int64(0), int64(0), int64(0),
+			0.0, 0.0, 0.0, int64(900),
+			int64(0), int64(0),
+			int64(0), int64(0), int64(0), int64(0), int64(0),
+			0.0, 0.0, 0.0,
+		))
+
+	hourStart := now.UTC().Truncate(time.Hour)
+	hourEnd := hourStart.Add(time.Hour)
+	mock.ExpectQuery("active_users").
+		WithArgs(todayUTC, todayEnd, hourStart, hourEnd).
+		WillReturnRows(sqlmock.NewRows([]string{"active_users", "hourly_active_users"}).AddRow(int64(0), int64(0)))
+
+	stats := &DashboardStats{}
+	err := repo.fillDashboardUsageStatsFromUsageLogs(context.Background(), stats, startUTC, endUTC, todayUTC, now)
+	require.NoError(t, err)
+	require.Zero(t, stats.AverageGatewayLatencyMs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFillDashboardUsageStatsAggregated_AverageGatewayLatencyMs(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
+
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db, db: db}
+
+	todayUTC := time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery("FROM usage_dashboard_daily").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total_requests", "total_input_tokens", "total_output_tokens",
+			"total_cache_creation_tokens", "total_cache_read_tokens",
+			"total_cost", "total_actual_cost", "total_account_cost", "total_duration_ms",
+			"total_gateway_latency_ms", "gateway_latency_samples",
+		}).AddRow(
+			int64(5), int64(0), int64(0), int64(0), int64(0),
+			0.0, 0.0, 0.0, int64(5000),
+			int64(1000), int64(5),
+		))
+
+	mock.ExpectQuery("WHERE bucket_date = \\$1").
+		WithArgs(todayUTC).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"today_requests", "today_input_tokens", "today_output_tokens",
+			"today_cache_creation_tokens", "today_cache_read_tokens",
+			"today_cost", "today_actual_cost", "today_account_cost", "active_users",
+		}).AddRow(int64(1), int64(0), int64(0), int64(0), int64(0), 0.0, 0.0, 0.0, int64(1)))
+
+	hourStart := now.UTC().Truncate(time.Hour)
+	mock.ExpectQuery("FROM usage_dashboard_hourly").
+		WithArgs(hourStart).
+		WillReturnRows(sqlmock.NewRows([]string{"hourly_active_users"}).AddRow(int64(1)))
+
+	stats := &DashboardStats{}
+	err := repo.fillDashboardUsageStatsAggregated(context.Background(), stats, todayUTC, now)
+	require.NoError(t, err)
+	require.InDelta(t, 200.0, stats.AverageGatewayLatencyMs, 1e-9)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/backend/internal/repository/usage_log_repo_insert.go
+++ b/backend/internal/repository/usage_log_repo_insert.go
@@ -57,6 +57,7 @@ var usageLogInsertArgTypes = [...]string{
 	"boolean",     // stream
 	"boolean",     // openai_ws_mode
 	"integer",     // duration_ms
+	"integer",     // gateway_latency_ms
 	"integer",     // first_token_ms
 	"text",        // user_agent
 	"text",        // ip_address
@@ -271,6 +272,7 @@ func cloneUsageLog(log *service.UsageLog) *service.UsageLog {
 	snapshot.AccountRateMultiplier = cloneUsageLogValue(log.AccountRateMultiplier)
 	snapshot.AccountStatsCost = cloneUsageLogValue(log.AccountStatsCost)
 	snapshot.DurationMs = cloneUsageLogValue(log.DurationMs)
+	snapshot.GatewayLatencyMs = cloneUsageLogValue(log.GatewayLatencyMs)
 	snapshot.FirstTokenMs = cloneUsageLogValue(log.FirstTokenMs)
 	snapshot.UserAgent = cloneUsageLogValue(log.UserAgent)
 	snapshot.IPAddress = cloneUsageLogValue(log.IPAddress)
@@ -391,6 +393,7 @@ func (r *usageLogRepository) createSinglePrepared(
 			stream,
 			openai_ws_mode,
 			duration_ms,
+			gateway_latency_ms,
 			first_token_ms,
 			user_agent,
 			ip_address,
@@ -958,6 +961,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			stream,
 			openai_ws_mode,
 			duration_ms,
+			gateway_latency_ms,
 			first_token_ms,
 			user_agent,
 			ip_address,
@@ -1206,6 +1210,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			stream,
 			openai_ws_mode,
 			duration_ms,
+			gateway_latency_ms,
 			first_token_ms,
 			user_agent,
 			ip_address,
@@ -1291,6 +1296,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			stream,
 			openai_ws_mode,
 			duration_ms,
+			gateway_latency_ms,
 			first_token_ms,
 			user_agent,
 			ip_address,
@@ -1350,6 +1356,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			stream,
 			openai_ws_mode,
 			duration_ms,
+			gateway_latency_ms,
 			first_token_ms,
 			user_agent,
 			ip_address,
@@ -1417,6 +1424,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			stream,
 			openai_ws_mode,
 			duration_ms,
+			gateway_latency_ms,
 			first_token_ms,
 			user_agent,
 			ip_address,
@@ -1478,6 +1486,7 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 	groupID := nullInt64(log.GroupID)
 	subscriptionID := nullInt64(log.SubscriptionID)
 	duration := nullInt(log.DurationMs)
+	gatewayLatency := nullInt(log.GatewayLatencyMs)
 	firstToken := nullInt(log.FirstTokenMs)
 	userAgent := nullString(log.UserAgent)
 	ipAddress := nullString(log.IPAddress)
@@ -1546,6 +1555,7 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 			log.Stream,
 			log.OpenAIWSMode,
 			duration,
+			gatewayLatency,
 			firstToken,
 			userAgent,
 			ipAddress,

--- a/backend/internal/repository/usage_log_repo_insert.go
+++ b/backend/internal/repository/usage_log_repo_insert.go
@@ -425,7 +425,7 @@ func (r *usageLogRepository) createSinglePrepared(
 			$10, $11, $12, $13,
 			$14, $15, $16, $17,
 			$18, $19, $20, $21, $22, $23,
-			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57
+			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58
 		)
 		ON CONFLICT DO NOTHING
 		RETURNING id, created_at
@@ -989,7 +989,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			created_at
 		) AS (VALUES `)
 
-	// Each batch row prepends the synthetic input_index before the 57
+	// Each batch row prepends the synthetic input_index before the 58
 	// usage-log column values.
 	args := make([]any, 0, len(keys)*58)
 	argPos := 1
@@ -1052,6 +1052,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				stream,
 				openai_ws_mode,
 				duration_ms,
+				gateway_latency_ms,
 				first_token_ms,
 				user_agent,
 				ip_address,
@@ -1111,6 +1112,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				stream,
 				openai_ws_mode,
 				duration_ms,
+				gateway_latency_ms,
 				first_token_ms,
 				user_agent,
 				ip_address,
@@ -1238,7 +1240,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			created_at
 		) AS (VALUES `)
 
-	args := make([]any, 0, len(preparedList)*57)
+	args := make([]any, 0, len(preparedList)*58)
 	argPos := 1
 	for idx, prepared := range preparedList {
 		if idx > 0 {
@@ -1456,7 +1458,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			$10, $11, $12, $13,
 			$14, $15, $16, $17,
 			$18, $19, $20, $21, $22, $23,
-			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57
+			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58
 		)
 		ON CONFLICT DO NOTHING
 		`, prepared.args...)

--- a/backend/internal/repository/usage_log_repo_query.go
+++ b/backend/internal/repository/usage_log_repo_query.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
-const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, image_input_tokens, image_input_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, video_count, video_resolution, video_duration_seconds, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, long_context_billing_applied, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, session_id, created_at"
+const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, image_input_tokens, image_input_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, gateway_latency_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, video_count, video_resolution, video_duration_seconds, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, long_context_billing_applied, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, session_id, created_at"
 
 func (r *usageLogRepository) GetByID(ctx context.Context, id int64) (log *service.UsageLog, err error) {
 	query := "SELECT " + usageLogSelectColumns + " FROM usage_logs WHERE id = $1"
@@ -462,6 +462,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		stream                    bool
 		openaiWSMode              bool
 		durationMs                sql.NullInt64
+		gatewayLatencyMs          sql.NullInt64
 		firstTokenMs              sql.NullInt64
 		userAgent                 sql.NullString
 		ipAddress                 sql.NullString
@@ -523,6 +524,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		&stream,
 		&openaiWSMode,
 		&durationMs,
+		&gatewayLatencyMs,
 		&firstTokenMs,
 		&userAgent,
 		&ipAddress,
@@ -605,6 +607,10 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 	if durationMs.Valid {
 		value := int(durationMs.Int64)
 		log.DurationMs = &value
+	}
+	if gatewayLatencyMs.Valid {
+		value := int(gatewayLatencyMs.Int64)
+		log.GatewayLatencyMs = &value
 	}
 	if firstTokenMs.Valid {
 		value := int(firstTokenMs.Int64)

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -1294,8 +1294,8 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullFloat64{}, // account_rate_multiplier
 			int16(service.BillingTypeBalance),
 			int16(service.RequestTypeWSV2),
-			false, // legacy stream
-			false, // legacy openai ws
+			false,            // legacy stream
+			false,            // legacy openai ws
 			sql.NullInt64{},  // duration_ms
 			sql.NullInt64{},  // gateway_latency_ms
 			sql.NullInt64{},  // first_token_ms

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -74,6 +74,7 @@ func TestUsageLogRepositoryCreateSyncRequestTypeAndLegacyFields(t *testing.T) {
 			true,
 			true,
 			sqlmock.AnyArg(), // duration_ms
+			sqlmock.AnyArg(), // gateway_latency_ms
 			sqlmock.AnyArg(), // first_token_ms
 			sqlmock.AnyArg(), // user_agent
 			sqlmock.AnyArg(), // ip_address
@@ -163,12 +164,13 @@ func TestUsageLogRepositoryCreate_PersistsServiceTier(t *testing.T) {
 			int16(service.RequestTypeSync),
 			false,
 			false,
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
+			sqlmock.AnyArg(), // duration_ms
+			sqlmock.AnyArg(), // gateway_latency_ms
+			sqlmock.AnyArg(), // first_token_ms
+			sqlmock.AnyArg(), // user_agent
+			sqlmock.AnyArg(), // ip_address
 			log.ImageCount,
-			sqlmock.AnyArg(),
+			sqlmock.AnyArg(), // image_size
 			sqlmock.AnyArg(), // image_input_size
 			sqlmock.AnyArg(), // image_output_size
 			sqlmock.AnyArg(), // image_size_source
@@ -276,11 +278,11 @@ func TestPrepareUsageLogInsert_PersistsImageSizeMetadata(t *testing.T) {
 		CreatedAt:          time.Date(2025, 1, 6, 12, 0, 0, 0, time.UTC),
 	})
 
-	require.Equal(t, sql.NullString{String: imageSize, Valid: true}, prepared.args[36])
-	require.Equal(t, sql.NullString{String: inputSize, Valid: true}, prepared.args[37])
-	require.Equal(t, sql.NullString{String: outputSize, Valid: true}, prepared.args[38])
-	require.Equal(t, sql.NullString{String: source, Valid: true}, prepared.args[39])
-	breakdownJSON, ok := prepared.args[40].(string)
+	require.Equal(t, sql.NullString{String: imageSize, Valid: true}, prepared.args[37])
+	require.Equal(t, sql.NullString{String: inputSize, Valid: true}, prepared.args[38])
+	require.Equal(t, sql.NullString{String: outputSize, Valid: true}, prepared.args[39])
+	require.Equal(t, sql.NullString{String: source, Valid: true}, prepared.args[40])
+	breakdownJSON, ok := prepared.args[41].(string)
 	require.True(t, ok)
 	require.JSONEq(t, `{"1K":1,"4K":1}`, breakdownJSON)
 }
@@ -1220,6 +1222,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			false,
 			sql.NullInt64{},
 			sql.NullInt64{},
+			sql.NullInt64{},
 			sql.NullString{},
 			sql.NullString{},
 			2,
@@ -1293,12 +1296,13 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			int16(service.RequestTypeWSV2),
 			false, // legacy stream
 			false, // legacy openai ws
-			sql.NullInt64{},
-			sql.NullInt64{},
-			sql.NullString{},
-			sql.NullString{},
-			0,
-			sql.NullString{},
+			sql.NullInt64{},  // duration_ms
+			sql.NullInt64{},  // gateway_latency_ms
+			sql.NullInt64{},  // first_token_ms
+			sql.NullString{}, // user_agent
+			sql.NullString{}, // ip_address
+			0,                // image_count
+			sql.NullString{}, // image_size
 			sql.NullString{}, // image_input_size
 			sql.NullString{}, // image_output_size
 			sql.NullString{}, // image_size_source
@@ -1351,6 +1355,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			int16(service.RequestTypeUnknown),
 			true,
 			false,
+			sql.NullInt64{},
 			sql.NullInt64{},
 			sql.NullInt64{},
 			sql.NullString{},
@@ -1409,6 +1414,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			int16(service.RequestTypeSync),
 			false,
 			false,
+			sql.NullInt64{},
 			sql.NullInt64{},
 			sql.NullInt64{},
 			sql.NullString{},

--- a/backend/internal/repository/usage_log_session_id_unit_test.go
+++ b/backend/internal/repository/usage_log_session_id_unit_test.go
@@ -32,7 +32,7 @@ func newSessionIDUsageLog(sessionID *string) *service.UsageLog {
 // arg slice / arg-type table so the five INSERT column lists stay in sync. session_id
 // is the penultimate arg (created_at is always last).
 func TestPrepareUsageLogInsert_SessionIDArgWiring(t *testing.T) {
-	require.Len(t, usageLogInsertArgTypes, 57, "arg-type table must include session_id")
+	require.Len(t, usageLogInsertArgTypes, 58, "arg-type table must include gateway_latency_ms and session_id")
 
 	sessionID := "sess-persisted-123"
 	prepared := prepareUsageLogInsert(newSessionIDUsageLog(&sessionID))

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -607,7 +607,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 					retryReq, retryWireBody, buildErr := s.buildUpstreamRequest(retryCtx, c, account, filteredBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 					releaseRetryCtx()
 					if buildErr == nil {
-						retryResp, retryErr := s.doForwardUpstreamWithLatency(c,retryReq, proxyURL, account, tlsProfile)
+						retryResp, retryErr := s.doForwardUpstreamWithLatency(c, retryReq, proxyURL, account, tlsProfile)
 						if retryErr == nil {
 							if retryResp.StatusCode < 400 {
 								// 重试请求被上游接受后同步 ParsedRequest，保证 usage/日志看到真实请求体。
@@ -649,7 +649,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 									retryReq2, retryWireBody2, buildErr2 := s.buildUpstreamRequest(retryCtx2, c, account, filteredBody2, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 									releaseRetryCtx2()
 									if buildErr2 == nil {
-										retryResp2, retryErr2 := s.doForwardUpstreamWithLatency(c,retryReq2, proxyURL, account, tlsProfile)
+										retryResp2, retryErr2 := s.doForwardUpstreamWithLatency(c, retryReq2, proxyURL, account, tlsProfile)
 										if retryErr2 == nil {
 											if retryResp2.StatusCode < 400 {
 												// 二阶段工具块降级成功时也必须更新当前 body。
@@ -727,7 +727,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 						betaRetryReq, betaWireBody, buildErr := s.buildUpstreamRequest(betaRetryCtx, c, account, body, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 						releaseBetaRetryCtx()
 						if buildErr == nil {
-							betaRetryResp, retryErr := s.doForwardUpstreamWithLatency(c,betaRetryReq, proxyURL, account, tlsProfile)
+							betaRetryResp, retryErr := s.doForwardUpstreamWithLatency(c, betaRetryReq, proxyURL, account, tlsProfile)
 							if retryErr == nil {
 								if betaRetryResp.StatusCode < 400 {
 									lastWireBody = betaWireBody
@@ -783,7 +783,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 						adaptiveRetryReq, adaptiveWireBody, buildErr := s.buildUpstreamRequest(adaptiveRetryCtx, c, account, rectifiedBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 						releaseAdaptiveRetryCtx()
 						if buildErr == nil {
-							adaptiveRetryResp, retryErr := s.doForwardUpstreamWithLatency(c,adaptiveRetryReq, proxyURL, account, tlsProfile)
+							adaptiveRetryResp, retryErr := s.doForwardUpstreamWithLatency(c, adaptiveRetryReq, proxyURL, account, tlsProfile)
 							if retryErr == nil {
 								if adaptiveRetryResp.StatusCode < 400 {
 									lastWireBody = adaptiveWireBody
@@ -830,7 +830,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 						budgetRetryReq, budgetWireBody, buildErr := s.buildUpstreamRequest(budgetRetryCtx, c, account, rectifiedBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 						releaseBudgetRetryCtx()
 						if buildErr == nil {
-							budgetRetryResp, retryErr := s.doForwardUpstreamWithLatency(c,budgetRetryReq, proxyURL, account, tlsProfile)
+							budgetRetryResp, retryErr := s.doForwardUpstreamWithLatency(c, budgetRetryReq, proxyURL, account, tlsProfile)
 							if retryErr == nil {
 								if budgetRetryResp.StatusCode < 400 {
 									// budget 修正请求成功后，ParsedRequest 也要描述被接受的修正版。

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 
 	"github.com/gin-gonic/gin"
 )
@@ -83,6 +84,19 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 	case <-timer.C:
 		return nil
 	}
+}
+
+func (s *GatewayService) doForwardUpstreamWithLatency(
+	c *gin.Context,
+	req *http.Request,
+	proxyURL string,
+	account *Account,
+	tlsProfile *tlsfingerprint.Profile,
+) (*http.Response, error) {
+	upstreamStart := time.Now()
+	resp, err := s.httpUpstream.DoWithTLS(req, proxyURL, account.ID, account.Concurrency, tlsProfile)
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
+	return resp, err
 }
 
 // Forward 转发请求到Claude API
@@ -498,7 +512,9 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 
 		// 发送请求
 		hwka := s.beginHeaderWaitKeepalive(c, reqStream)
+		upstreamStart := time.Now()
 		resp, err = s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, tlsProfile)
+		SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
 		hwka.stop()
 		if err != nil {
 			if resp != nil && resp.Body != nil {
@@ -591,7 +607,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 					retryReq, retryWireBody, buildErr := s.buildUpstreamRequest(retryCtx, c, account, filteredBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 					releaseRetryCtx()
 					if buildErr == nil {
-						retryResp, retryErr := s.httpUpstream.DoWithTLS(retryReq, proxyURL, account.ID, account.Concurrency, tlsProfile)
+						retryResp, retryErr := s.doForwardUpstreamWithLatency(c,retryReq, proxyURL, account, tlsProfile)
 						if retryErr == nil {
 							if retryResp.StatusCode < 400 {
 								// 重试请求被上游接受后同步 ParsedRequest，保证 usage/日志看到真实请求体。
@@ -633,7 +649,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 									retryReq2, retryWireBody2, buildErr2 := s.buildUpstreamRequest(retryCtx2, c, account, filteredBody2, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 									releaseRetryCtx2()
 									if buildErr2 == nil {
-										retryResp2, retryErr2 := s.httpUpstream.DoWithTLS(retryReq2, proxyURL, account.ID, account.Concurrency, tlsProfile)
+										retryResp2, retryErr2 := s.doForwardUpstreamWithLatency(c,retryReq2, proxyURL, account, tlsProfile)
 										if retryErr2 == nil {
 											if retryResp2.StatusCode < 400 {
 												// 二阶段工具块降级成功时也必须更新当前 body。
@@ -711,7 +727,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 						betaRetryReq, betaWireBody, buildErr := s.buildUpstreamRequest(betaRetryCtx, c, account, body, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 						releaseBetaRetryCtx()
 						if buildErr == nil {
-							betaRetryResp, retryErr := s.httpUpstream.DoWithTLS(betaRetryReq, proxyURL, account.ID, account.Concurrency, tlsProfile)
+							betaRetryResp, retryErr := s.doForwardUpstreamWithLatency(c,betaRetryReq, proxyURL, account, tlsProfile)
 							if retryErr == nil {
 								if betaRetryResp.StatusCode < 400 {
 									lastWireBody = betaWireBody
@@ -767,7 +783,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 						adaptiveRetryReq, adaptiveWireBody, buildErr := s.buildUpstreamRequest(adaptiveRetryCtx, c, account, rectifiedBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 						releaseAdaptiveRetryCtx()
 						if buildErr == nil {
-							adaptiveRetryResp, retryErr := s.httpUpstream.DoWithTLS(adaptiveRetryReq, proxyURL, account.ID, account.Concurrency, tlsProfile)
+							adaptiveRetryResp, retryErr := s.doForwardUpstreamWithLatency(c,adaptiveRetryReq, proxyURL, account, tlsProfile)
 							if retryErr == nil {
 								if adaptiveRetryResp.StatusCode < 400 {
 									lastWireBody = adaptiveWireBody
@@ -814,7 +830,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 						budgetRetryReq, budgetWireBody, buildErr := s.buildUpstreamRequest(budgetRetryCtx, c, account, rectifiedBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 						releaseBudgetRetryCtx()
 						if buildErr == nil {
-							budgetRetryResp, retryErr := s.httpUpstream.DoWithTLS(budgetRetryReq, proxyURL, account.ID, account.Concurrency, tlsProfile)
+							budgetRetryResp, retryErr := s.doForwardUpstreamWithLatency(c,budgetRetryReq, proxyURL, account, tlsProfile)
 							if retryErr == nil {
 								if budgetRetryResp.StatusCode < 400 {
 									// budget 修正请求成功后，ParsedRequest 也要描述被接受的修正版。

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -33,6 +33,9 @@ type RecordUsageInput struct {
 	QuotaPlatform      string             // user×platform 配额计量平台：handler 在请求 ctx 内经 QuotaPlatform() 算定后传入（后扣运行在 worker 池 background ctx 上，取不到 ForcePlatform）
 
 	ChannelUsageFields // 渠道映射信息（由 handler 在 Forward 前解析）
+
+	// GatewayLatencyMs is TokenKey transfer latency (auth+routing+response tail), excluding upstream wait and queue waits.
+	GatewayLatencyMs *int
 }
 
 // APIKeyQuotaUpdater defines the interface for updating API Key quota and rate limit usage
@@ -562,6 +565,7 @@ func (s *GatewayService) RecordUsage(ctx context.Context, input *RecordUsageInpu
 		APIKeyService:      input.APIKeyService,
 		QuotaPlatform:      input.QuotaPlatform,
 		ChannelUsageFields: input.ChannelUsageFields,
+		GatewayLatencyMs:   input.GatewayLatencyMs,
 	}, &recordUsageOpts{})
 }
 
@@ -631,6 +635,7 @@ type recordUsageCoreInput struct {
 	APIKeyService      APIKeyQuotaUpdater
 	QuotaPlatform      string
 	ChannelUsageFields
+	GatewayLatencyMs *int
 }
 
 // recordUsageCore 是 RecordUsage 和 RecordUsageWithLongContext 的统一实现。
@@ -1031,6 +1036,7 @@ func (s *GatewayService) buildRecordUsageLog(
 		BillingMode:           resolveBillingMode(result, cost),
 		Stream:                result.Stream,
 		DurationMs:            &durationMs,
+		GatewayLatencyMs:      input.GatewayLatencyMs,
 		FirstTokenMs:          result.FirstTokenMs,
 		ImageCount:            result.ImageCount,
 		ImageSize:             optionalTrimmedStringPtr(result.ImageSize),

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -39,6 +39,8 @@ type OpenAIRecordUsageInput struct {
 	// CyberBlocked 为 true 时把该用量行标记为 cyber（request_type=cyber），计费逻辑不变。
 	CyberBlocked bool
 	ChannelUsageFields
+	// GatewayLatencyMs is TokenKey transfer latency (auth+routing+response tail), excluding upstream wait and queue waits.
+	GatewayLatencyMs *int
 }
 
 // CyberPolicyUsageInput 是 cyber 拒绝、未走正常 RecordUsage 的请求记录用量的入参。
@@ -341,6 +343,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	}
 	usageLog.OpenAIWSMode = result.OpenAIWSMode
 	usageLog.DurationMs = &durationMs
+	usageLog.GatewayLatencyMs = input.GatewayLatencyMs
 	usageLog.FirstTokenMs = result.FirstTokenMs
 	usageLog.CreatedAt = time.Now()
 	// 设置渠道信息

--- a/backend/internal/service/ops_gateway_latency.go
+++ b/backend/internal/service/ops_gateway_latency.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// SnapshotGatewayTransferLatencyMs derives TokenKey gateway transfer latency from
+// auth, routing, and response tail timings on the gin context. It excludes upstream
+// provider wait, streaming body pump time, and queue/throttle waits.
+//
+// Returns nil when no usable stage timing remains (excluded from dashboard average).
+func SnapshotGatewayTransferLatencyMs(c *gin.Context) *int {
+	if c == nil {
+		return nil
+	}
+	authMs, hasAuth := contextLatencyMs(c, OpsAuthLatencyMsKey)
+	routingMs, hasRouting := contextLatencyMs(c, OpsRoutingLatencyMsKey)
+	responseMs, hasResponse := contextLatencyMs(c, OpsResponseLatencyMsKey)
+	if !hasAuth && !hasRouting && !hasResponse {
+		return nil
+	}
+	sum := authMs + routingMs + responseMs
+	queueMs, _ := contextLatencyMs(c, OpsGatewayQueueWaitMsKey)
+	wsQueueMs, _ := contextLatencyMs(c, OpsOpenAIWSQueueWaitMsKey)
+	sum -= queueMs + wsQueueMs
+	if sum <= 0 {
+		return nil
+	}
+	v := int(sum)
+	return &v
+}
+
+// RecordOpsResponseTransferLatencyMs stores gateway response tail latency as the
+// post-upstream portion of forward time (format conversion, flush, billing hooks).
+func RecordOpsResponseTransferLatencyMs(c *gin.Context, forwardDurationMs int64) {
+	if c == nil || forwardDurationMs < 0 {
+		return
+	}
+	responseMs := forwardDurationMs
+	upstreamMs, hasUpstream := contextLatencyMs(c, OpsUpstreamLatencyMsKey)
+	if hasUpstream && forwardDurationMs > upstreamMs {
+		responseMs = forwardDurationMs - upstreamMs
+	}
+	SetOpsLatencyMs(c, OpsResponseLatencyMsKey, responseMs)
+}
+
+func contextLatencyMs(c *gin.Context, key string) (int64, bool) {
+	if c == nil {
+		return 0, false
+	}
+	v, ok := c.Get(key)
+	if !ok {
+		return 0, false
+	}
+	var ms int64
+	switch t := v.(type) {
+	case int:
+		ms = int64(t)
+	case int32:
+		ms = int64(t)
+	case int64:
+		ms = t
+	case float64:
+		ms = int64(t)
+	default:
+		return 0, false
+	}
+	if ms < 0 {
+		return 0, false
+	}
+	return ms, true
+}

--- a/backend/internal/service/ops_gateway_latency_test.go
+++ b/backend/internal/service/ops_gateway_latency_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotGatewayTransferLatencyMs_SumsAuthRoutingAndResponseTail(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	SetOpsLatencyMs(c, OpsAuthLatencyMsKey, 12)
+	SetOpsLatencyMs(c, OpsRoutingLatencyMsKey, 34)
+	SetOpsLatencyMs(c, OpsResponseLatencyMsKey, 56)
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, 9999)
+
+	got := SnapshotGatewayTransferLatencyMs(c)
+	require.NotNil(t, got)
+	require.Equal(t, 102, *got)
+}
+
+func TestSnapshotGatewayTransferLatencyMs_SubtractsQueueWait(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	SetOpsLatencyMs(c, OpsAuthLatencyMsKey, 100)
+	SetOpsLatencyMs(c, OpsRoutingLatencyMsKey, 2500)
+	AddOpsGatewayQueueWaitMs(c, 2400)
+
+	got := SnapshotGatewayTransferLatencyMs(c)
+	require.NotNil(t, got)
+	require.Equal(t, 200, *got)
+}
+
+func TestSnapshotGatewayTransferLatencyMs_SubtractsOpenAIWSQueueWait(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	SetOpsLatencyMs(c, OpsAuthLatencyMsKey, 20)
+	SetOpsLatencyMs(c, OpsRoutingLatencyMsKey, 520)
+	SetOpsLatencyMs(c, OpsOpenAIWSQueueWaitMsKey, 500)
+
+	got := SnapshotGatewayTransferLatencyMs(c)
+	require.NotNil(t, got)
+	require.Equal(t, 40, *got)
+}
+
+func TestRecordOpsResponseTransferLatencyMs_UsesForwardMinusUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, 9000)
+	RecordOpsResponseTransferLatencyMs(c, 9050)
+
+	responseMs, ok := contextLatencyMs(c, OpsResponseLatencyMsKey)
+	require.True(t, ok)
+	require.Equal(t, int64(50), responseMs)
+}
+
+func TestSnapshotGatewayTransferLatencyMs_ReturnsNilWhenUnknown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	require.Nil(t, SnapshotGatewayTransferLatencyMs(c))
+	require.Nil(t, SnapshotGatewayTransferLatencyMs(nil))
+}
+
+func TestSnapshotGatewayTransferLatencyMs_ReturnsNilWhenOnlyQueueWait(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	SetOpsLatencyMs(c, OpsAuthLatencyMsKey, 100)
+	AddOpsGatewayQueueWaitMs(c, 100)
+
+	require.Nil(t, SnapshotGatewayTransferLatencyMs(c))
+}

--- a/backend/internal/service/ops_upstream_context.go
+++ b/backend/internal/service/ops_upstream_context.go
@@ -59,6 +59,9 @@ const (
 	OpsUpstreamLatencyMsKey  = "ops_upstream_latency_ms"
 	OpsResponseLatencyMsKey  = "ops_response_latency_ms"
 	OpsTimeToFirstTokenMsKey = "ops_time_to_first_token_ms"
+	// OpsGatewayQueueWaitMsKey accumulates concurrency-slot and user-message-queue
+	// wait time excluded from gateway transfer latency dashboards.
+	OpsGatewayQueueWaitMsKey = "ops_gateway_queue_wait_ms"
 	// OpenAI WS 关键观测字段
 	OpsOpenAIWSQueueWaitMsKey = "ops_openai_ws_queue_wait_ms"
 	OpsOpenAIWSConnPickMsKey  = "ops_openai_ws_conn_pick_ms"
@@ -116,6 +119,18 @@ func SetOpsLatencyMs(c *gin.Context, key string, value int64) {
 		return
 	}
 	c.Set(key, value)
+}
+
+func AddOpsLatencyMs(c *gin.Context, key string, delta int64) {
+	if c == nil || strings.TrimSpace(key) == "" || delta <= 0 {
+		return
+	}
+	existing, _ := contextLatencyMs(c, key)
+	SetOpsLatencyMs(c, key, existing+delta)
+}
+
+func AddOpsGatewayQueueWaitMs(c *gin.Context, waitMs int64) {
+	AddOpsLatencyMs(c, OpsGatewayQueueWaitMsKey, waitMs)
 }
 
 func setOpsUpstreamRequestBody(c *gin.Context, body []byte) {

--- a/backend/internal/service/usage_log.go
+++ b/backend/internal/service/usage_log.go
@@ -162,15 +162,15 @@ type UsageLog struct {
 	// AccountStatsCost 账号统计定价预计算费用（nil = 使用默认公式 total_cost × account_rate_multiplier）
 	AccountStatsCost *float64
 
-	BillingType  int8
-	RequestType  RequestType
-	Stream       bool
-	OpenAIWSMode bool
-	DurationMs        *int
-	GatewayLatencyMs  *int
-	FirstTokenMs      *int
-	UserAgent    *string
-	IPAddress    *string
+	BillingType      int8
+	RequestType      RequestType
+	Stream           bool
+	OpenAIWSMode     bool
+	DurationMs       *int
+	GatewayLatencyMs *int
+	FirstTokenMs     *int
+	UserAgent        *string
+	IPAddress        *string
 	// SessionID is the explicit client-provided request correlation identifier
 	// (e.g. the session_id / X-Session-Id headers). Nil when the client sent no
 	// valid session header. It is never derived from prompt_cache_key or content.

--- a/backend/internal/service/usage_log.go
+++ b/backend/internal/service/usage_log.go
@@ -166,8 +166,9 @@ type UsageLog struct {
 	RequestType  RequestType
 	Stream       bool
 	OpenAIWSMode bool
-	DurationMs   *int
-	FirstTokenMs *int
+	DurationMs        *int
+	GatewayLatencyMs  *int
+	FirstTokenMs      *int
 	UserAgent    *string
 	IPAddress    *string
 	// SessionID is the explicit client-provided request correlation identifier

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 678,
-  "hash": "bb3e1cd8f7ef25021ebbc1635b4997eed3d5ff49cf75e7b905e1d581d16dbf81",
+  "hash": "dfd94429c59f5e4e0e1bef38bb1ef70c241bf4c2f413ed9a62f4524f12620a75",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/migrations/tk_071_add_usage_logs_gateway_latency_ms.sql
+++ b/backend/migrations/tk_071_add_usage_logs_gateway_latency_ms.sql
@@ -1,0 +1,21 @@
+-- Persist per-request gateway transfer latency for admin dashboard observability.
+-- gateway_latency_ms = auth + routing + response tail, excluding upstream wait, streaming pump, and queue/throttle waits.
+-- bluegreen-safe-destructive-ok: nullable usage_logs column + aggregate totals with DEFAULT 0 only (expand phase).
+
+ALTER TABLE usage_logs
+    ADD COLUMN IF NOT EXISTS gateway_latency_ms INT;
+
+COMMENT ON COLUMN usage_logs.gateway_latency_ms IS
+    'TokenKey gateway transfer latency in ms (auth+routing+response tail), excluding upstream provider inference/network wait, streaming body pump, and queue/throttle waits. NULL when not measured.';
+
+ALTER TABLE usage_dashboard_hourly
+    ADD COLUMN IF NOT EXISTS total_gateway_latency_ms BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE usage_dashboard_hourly
+    ADD COLUMN IF NOT EXISTS gateway_latency_samples BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE usage_dashboard_daily
+    ADD COLUMN IF NOT EXISTS total_gateway_latency_ms BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE usage_dashboard_daily
+    ADD COLUMN IF NOT EXISTS gateway_latency_samples BIGINT NOT NULL DEFAULT 0;

--- a/frontend/e2e/dashboard-cache.e2e.ts
+++ b/frontend/e2e/dashboard-cache.e2e.ts
@@ -150,6 +150,7 @@ const DASHBOARD_STATS = {
   today_actual_cost: 4,
   today_account_cost: 3.5,
   average_duration_ms: 250,
+  average_gateway_latency_ms: 45,
   uptime: 3_600,
   rpm: 12,
   tpm: 25_000,

--- a/frontend/src/i18n/locales/en/admin/overview.ts
+++ b/frontend/src/i18n/locales/en/admin/overview.ts
@@ -23,6 +23,7 @@ export default {
       cacheToday: 'Cache (Today)',
       performance: 'Performance',
       avgResponse: 'Avg Response',
+      avgGatewayLatency: 'Gateway transfer latency',
       averageTime: 'Average Time',
       active: 'active',
       ok: 'ok',

--- a/frontend/src/i18n/locales/zh/admin/overview.ts
+++ b/frontend/src/i18n/locales/zh/admin/overview.ts
@@ -27,6 +27,7 @@ export default {
       cacheToday: '今日缓存',
       performance: '性能指标',
       avgResponse: '平均响应',
+      avgGatewayLatency: '网关中转延迟',
       averageTime: '平均时间',
       active: '活跃',
       ok: '正常',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1915,7 +1915,8 @@ export interface DashboardStats {
   today_account_cost: number // 今日账号成本
 
   // 系统运行统计
-  average_duration_ms: number // 平均响应时间
+  average_duration_ms: number // 平均端到端响应时间
+  average_gateway_latency_ms: number // 平均网关中转延迟（auth+路由+响应收尾，不含上游/排队）
   uptime: number // 系统运行时间(秒)
 
   // 性能指标

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -194,7 +194,7 @@
             </div>
           </div>
 
-          <!-- Avg Response Time -->
+          <!-- Gateway transfer latency -->
           <div class="card p-4">
             <div class="flex items-center gap-3">
               <div class="rounded-lg bg-rose-100 p-2 dark:bg-rose-900/30">
@@ -202,10 +202,10 @@
               </div>
               <div>
                 <p class="text-xs font-medium text-gray-500 dark:text-gray-400">
-                  {{ t('admin.dashboard.avgResponse') }}
+                  {{ t('admin.dashboard.avgGatewayLatency') }}
                 </p>
                 <p class="text-xl font-bold text-gray-900 dark:text-white">
-                  {{ formatDuration(stats.average_duration_ms) }}
+                  {{ formatDuration(stats.average_gateway_latency_ms) }}
                 </p>
                 <p class="text-xs text-gray-500 dark:text-gray-400">
                   {{ stats.active_users }} {{ t('admin.dashboard.activeUsers') }}

--- a/frontend/src/views/admin/__tests__/DashboardView.daterange-repro.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.daterange-repro.spec.ts
@@ -55,7 +55,7 @@ const createStats = () =>
       'total_cache_read_tokens', 'total_tokens', 'total_cost', 'total_actual_cost',
       'total_account_cost', 'today_requests', 'today_input_tokens', 'today_output_tokens',
       'today_cache_creation_tokens', 'today_cache_read_tokens', 'today_tokens',
-      'today_cost', 'today_actual_cost', 'today_account_cost', 'average_duration_ms',
+      'today_cost', 'today_actual_cost', 'today_account_cost', 'average_duration_ms', 'average_gateway_latency_ms',
       'uptime', 'rpm', 'tpm'
     ].map((k) => [k, 0])
   )

--- a/frontend/src/views/admin/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.spec.ts
@@ -97,6 +97,7 @@ const createDashboardStats = (): DashboardStats => ({
   today_actual_cost: 0,
   today_account_cost: 0,
   average_duration_ms: 0,
+  average_gateway_latency_ms: 0,
   uptime: 0,
   rpm: 0,
   tpm: 0

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1691,7 +1691,9 @@
         "const promptCacheOverview = computed(() => {",
         "cache_telemetry_unavailable_input_tokens",
         "data-testid=\"prompt-cache-overall-status\"",
-        "include_group_stats: true"
+        "include_group_stats: true",
+        "stats.average_gateway_latency_ms",
+        "admin.dashboard.avgGatewayLatency"
       ],
       "rationale": "The admin Dashboard's own requests carry the TK window via dashboardWindowParams(): rolling presets use absolute epoch-ms and calendar presets use a server-TZ range token. Drilldowns deliberately reuse the exact successfully loaded rolling window because /admin/usage consumes absolute start_ts/end_ts, not range. The same snapshot group facet owns the prompt-cache overview: it excludes Kiro-estimated unavailable input, ranks the top five groups by prompt-token impact, and avoids an extra endpoint. These anchors prevent an upstream-shaped Dashboard rewrite from silently restoring timezone drift, widening drilldowns, or dropping cache observability while still compiling."
     },

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6000,6 +6000,57 @@
       "path": "backend/internal/observability/qa/archive/verifier.go",
       "must_contain": ["func VerifyCommit", "manifest.BlobMissingCount != 0", "IntegrityCorruptArtifact", "verifyCommitIdentities"],
       "rationale": "Every visible QA commit must pass read-after-write checksum, manifest integrity, missing-evidence, and duplicate-identity verification."
+    },
+    {
+      "path": "backend/internal/service/ops_gateway_latency.go",
+      "must_contain": [
+        "func SnapshotGatewayTransferLatencyMs",
+        "func RecordOpsResponseTransferLatencyMs",
+        "OpsGatewayQueueWaitMsKey",
+        "sum -= queueMs + wsQueueMs"
+      ],
+      "rationale": "Single owner for admin dashboard gateway transfer latency: auth+routing+response tail minus queue/throttle waits. Dropping the queue subtraction or response-tail derivation silently restores end-to-end duration semantics on the dashboard card."
+    },
+    {
+      "path": "backend/internal/service/ops_gateway_latency_test.go",
+      "must_contain": [
+        "TestSnapshotGatewayTransferLatencyMs_SubtractsQueueWait",
+        "TestRecordOpsResponseTransferLatencyMs_UsesForwardMinusUpstream"
+      ],
+      "rationale": "Focused regressions for queue-wait exclusion and forward-minus-upstream response tail derivation."
+    },
+    {
+      "path": "backend/internal/handler/handler_tk_gateway_latency.go",
+      "must_contain": [
+        "func tkRecordAuthLatency",
+        "func tkRecordRoutingLatency",
+        "func tkRecordForwardResponseTail",
+        "func tkSnapshotGatewayTransferLatencyMs",
+        "func tkRecordGatewayQueueWait"
+      ],
+      "rationale": "TK companion owning gateway latency stage hooks so upstream-shaped handler files keep one-line call sites that survive merge review."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler.go",
+      "must_contain": [
+        "tkRecordAuthLatency(c, requestStart)"
+      ],
+      "rationale": "Messages auth stage timing injection must stay before user-slot acquisition; upstream merges that rewrite Messages() can drop it without a compile error while dashboard latency loses the auth component."
+    },
+    {
+      "path": "backend/internal/handler/admin/dashboard_handler.go",
+      "must_contain": [
+        "\"average_gateway_latency_ms\": stats.AverageGatewayLatencyMs"
+      ],
+      "rationale": "Admin dashboard API exposes gateway transfer latency separately from end-to-end average_duration_ms; losing this field silently reverts the card binding even when usage_logs.gateway_latency_ms is populated."
+    },
+    {
+      "path": "backend/internal/repository/usage_log_repo_dashboard_gateway_latency_test.go",
+      "must_contain": [
+        "TestFillDashboardUsageStatsFromUsageLogs_AverageGatewayLatencyMs",
+        "TestFillDashboardUsageStatsAggregated_AverageGatewayLatencyMs"
+      ],
+      "rationale": "Dashboard mean must divide by gateway_latency_samples (non-NULL rows only), not total_requests; this regression guards the SQL aggregation wiring."
     }
   ]
 }


### PR DESCRIPTION
## 摘要

- 管理控制台「平均响应」改为「网关中转延迟」，绑定 `average_gateway_latency_ms`。
- 新口径：`auth + routing + 响应收尾（forward − upstream）`，并扣除用户/账号并发槽、UMQ、OpenAI WS 排队等待。
- 新增 `usage_logs.gateway_latency_ms` 及 hourly/daily 聚合字段；instrumentation 收敛到 `handler_tk_gateway_latency.go` companion。

## 风险

- 常规风险：需执行迁移 `tk_071_add_usage_logs_gateway_latency_ms.sql`；历史数据在新字段为 NULL，仪表盘均值随新流量逐步收敛。
- 公共契约：Dashboard API 新增 `average_gateway_latency_ms`（保留 `average_duration_ms` 供其它用途）。
- 迁移为 expand-only（可空列 + DEFAULT 0 聚合列），已标注 `bluegreen-safe-destructive-ok`。
- sentinel-registry-reviewed：已更新 `gateway-tk.json` / `frontend-tk.json` 锚点。

## 验证

- `./scripts/preflight.sh` PASS
- `go test -tags=unit ./internal/handler/ ./internal/repository/ ./internal/service/ -count=1` PASS
- `go test -tags=unit ./internal/repository/ -run 'TestFillDashboardUsageStats' -count=1` PASS
- R-004 统一后删除 dead `getContextInt64`（golangci-lint unused）

## 提交

- cb5593031 feat(dashboard): 仪表盘改用网关中转延迟替代平均响应
- 7b94825dc fix(dashboard): 修复 gateway_latency_ms 写入占位符与测试 fixture
- 2b05b5033 fix(dashboard): 收口 review R001-R005 门禁与网关延迟 instrumentation
- 7391acd50 fix(dashboard): 删除 R-004 统一后未使用的 getContextInt64
- 最新提交：7391acd50