### PR TITLE
feat(gateway): 通过 API key 访问 Vertex gemini-embedding-001

### DIFF
--- a/backend/internal/relay/bridge/embedding_relay.go
+++ b/backend/internal/relay/bridge/embedding_relay.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/QuantumNous/new-api/common"
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	newapirelay "github.com/QuantumNous/new-api/relay"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -33,6 +34,10 @@ func RunEmbeddingRelay(c *gin.Context, info *relaycommon.RelayInfo) (*dto.Usage,
 	err = helper.ModelMappedHelper(c, info, request)
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeChannelModelMappedError, types.ErrOptionWithSkipRetry())
+	}
+
+	if info.ChannelMeta != nil && info.ChannelMeta.ChannelType == newapiconstant.ChannelTypeVertexAi {
+		return runVertexEmbeddingRelay(c, info, request)
 	}
 
 	adaptor := newapirelay.GetAdaptor(info.ApiType)

--- a/backend/internal/relay/bridge/embedding_relay.go
+++ b/backend/internal/relay/bridge/embedding_relay.go
@@ -36,7 +36,7 @@ func RunEmbeddingRelay(c *gin.Context, info *relaycommon.RelayInfo) (*dto.Usage,
 		return nil, types.NewError(err, types.ErrorCodeChannelModelMappedError, types.ErrOptionWithSkipRetry())
 	}
 
-	if info.ChannelMeta != nil && info.ChannelMeta.ChannelType == newapiconstant.ChannelTypeVertexAi {
+	if info.ChannelType == newapiconstant.ChannelTypeVertexAi {
 		return runVertexEmbeddingRelay(c, info, request)
 	}
 

--- a/backend/internal/relay/bridge/embedding_relay_tk_vertex.go
+++ b/backend/internal/relay/bridge/embedding_relay_tk_vertex.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
-	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/channel/vertex"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/types"
 	"github.com/gin-gonic/gin"

--- a/backend/internal/relay/bridge/embedding_relay_tk_vertex.go
+++ b/backend/internal/relay/bridge/embedding_relay_tk_vertex.go
@@ -1,0 +1,180 @@
+package bridge
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relay/channel/vertex"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/samber/lo"
+)
+
+type vertexEmbeddingPredictResponse struct {
+	Predictions []vertexEmbeddingPrediction `json:"predictions"`
+}
+
+type vertexEmbeddingPrediction struct {
+	Embeddings struct {
+		Values []float64 `json:"values"`
+	} `json:"embeddings"`
+}
+
+var vertexEmbeddingAcquireAccessToken = func(creds vertex.Credentials, proxy string) (string, error) {
+	return vertex.AcquireAccessToken(creds, proxy)
+}
+
+// runVertexEmbeddingRelay implements Vertex AI text embedding via the :predict
+// surface. Upstream new-api's vertex adaptor leaves ConvertEmbeddingRequest
+// unimplemented; TokenKey owns this path for channel_type 41 service accounts.
+func runVertexEmbeddingRelay(c *gin.Context, info *relaycommon.RelayInfo, request *dto.EmbeddingRequest) (*dto.Usage, *types.NewAPIError) {
+	if c == nil || info == nil || request == nil {
+		return nil, types.NewError(errors.New("vertex embedding relay missing context"), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+	}
+	if info.ChannelMeta == nil {
+		info.InitChannelMeta(c)
+	}
+	if strings.TrimSpace(info.ApiKey) == "" {
+		return nil, types.NewError(errors.New("vertex service account credentials missing"), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+	}
+
+	var creds vertex.Credentials
+	if err := common.Unmarshal([]byte(info.ApiKey), &creds); err != nil {
+		return nil, types.NewError(fmt.Errorf("decode vertex service account json: %w", err), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+	}
+	if strings.TrimSpace(creds.ProjectID) == "" || strings.TrimSpace(creds.ClientEmail) == "" || strings.TrimSpace(creds.PrivateKey) == "" {
+		return nil, types.NewError(errors.New("vertex service account json missing project_id, client_email, or private_key"), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+	}
+
+	inputs := request.ParseInput()
+	if len(inputs) == 0 {
+		return nil, types.NewError(errors.New("input is empty"), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+	}
+
+	modelName := strings.TrimSpace(info.UpstreamModelName)
+	if modelName == "" {
+		modelName = strings.TrimSpace(request.Model)
+	}
+	if modelName == "" {
+		return nil, types.NewError(errors.New("model is required"), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+	}
+
+	region := vertex.GetModelRegion(info.ApiVersion, modelName)
+	predictURL := vertex.BuildGoogleModelURL(info.ChannelBaseUrl, vertex.DefaultAPIVersion, creds.ProjectID, region, modelName, "predict")
+
+	payload, err := buildVertexEmbeddingPredictPayload(inputs, request.Dimensions)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+	}
+	jsonData, err := common.Marshal(payload)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+	}
+
+	proxy := ""
+	if info.ChannelSetting.Proxy != "" {
+		proxy = info.ChannelSetting.Proxy
+	}
+	token, err := vertexEmbeddingAcquireAccessToken(creds, proxy)
+	if err != nil {
+		return nil, types.NewOpenAIError(fmt.Errorf("vertex access token: %w", err), types.ErrorCodeDoRequestFailed, http.StatusBadGateway)
+	}
+
+	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodPost, predictURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := service.GetHttpClient().Do(req)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError)
+	}
+	defer service.CloseResponseBodyGracefully(resp)
+
+	statusCodeMappingStr := c.GetString("status_code_mapping")
+	if resp.StatusCode != http.StatusOK {
+		newAPIError := service.RelayErrorHandler(c.Request.Context(), resp, false)
+		service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+		return nil, newAPIError
+	}
+
+	responseBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, types.NewOpenAIError(readErr, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+
+	openAIResponse, usage, convErr := vertexEmbeddingPredictResponseToOpenAI(c, modelName, responseBody, info.GetEstimatePromptTokens())
+	if convErr != nil {
+		return nil, types.NewOpenAIError(convErr, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+
+	jsonResponse, jsonErr := common.Marshal(openAIResponse)
+	if jsonErr != nil {
+		return nil, types.NewOpenAIError(jsonErr, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+	service.IOCopyBytesGracefully(c, resp, jsonResponse)
+	return usage, nil
+}
+
+func buildVertexEmbeddingPredictPayload(inputs []string, dimensions *int) (map[string]any, error) {
+	if len(inputs) == 0 {
+		return nil, errors.New("input is empty")
+	}
+	instances := make([]map[string]any, 0, len(inputs))
+	for _, input := range inputs {
+		text := strings.TrimSpace(input)
+		if text == "" {
+			return nil, errors.New("input contains empty string")
+		}
+		instances = append(instances, map[string]any{
+			"task_type": "RETRIEVAL_QUERY",
+			"content":   text,
+		})
+	}
+	payload := map[string]any{"instances": instances}
+	if dims := lo.FromPtrOr(dimensions, 0); dims > 0 {
+		payload["parameters"] = map[string]any{"outputDimensionality": dims}
+	}
+	return payload, nil
+}
+
+func vertexEmbeddingPredictResponseToOpenAI(c *gin.Context, modelName string, body []byte, promptTokens int) (*dto.OpenAIEmbeddingResponse, *dto.Usage, error) {
+	var parsed vertexEmbeddingPredictResponse
+	if err := common.Unmarshal(body, &parsed); err != nil {
+		return nil, nil, fmt.Errorf("decode vertex embedding response: %w", err)
+	}
+	if len(parsed.Predictions) == 0 {
+		return nil, nil, errors.New("vertex embedding response missing predictions")
+	}
+
+	openAIResponse := &dto.OpenAIEmbeddingResponse{
+		Object: "list",
+		Model:  modelName,
+		Data:   make([]dto.OpenAIEmbeddingResponseItem, 0, len(parsed.Predictions)),
+	}
+	for i, prediction := range parsed.Predictions {
+		if len(prediction.Embeddings.Values) == 0 {
+			return nil, nil, fmt.Errorf("vertex embedding prediction %d missing values", i)
+		}
+		openAIResponse.Data = append(openAIResponse.Data, dto.OpenAIEmbeddingResponseItem{
+			Object:    "embedding",
+			Embedding: prediction.Embeddings.Values,
+			Index:     i,
+		})
+	}
+
+	usage := service.ResponseText2Usage(c, "", modelName, promptTokens)
+	openAIResponse.Usage = *usage
+	return openAIResponse, usage, nil
+}

--- a/backend/internal/relay/bridge/embedding_relay_tk_vertex.go
+++ b/backend/internal/relay/bridge/embedding_relay_tk_vertex.go
@@ -78,6 +78,12 @@ func runVertexEmbeddingRelay(c *gin.Context, info *relaycommon.RelayInfo, reques
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
 	}
+	if len(info.ParamOverride) > 0 {
+		jsonData, err = relaycommon.ApplyParamOverrideWithRelayInfo(jsonData, info)
+		if err != nil {
+			return nil, newAPIErrorFromParamOverride(err)
+		}
+	}
 
 	proxy := ""
 	if info.ChannelSetting.Proxy != "" {

--- a/backend/internal/relay/bridge/embedding_relay_tk_vertex_test.go
+++ b/backend/internal/relay/bridge/embedding_relay_tk_vertex_test.go
@@ -1,0 +1,193 @@
+//go:build unit
+
+package bridge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relay/channel/vertex"
+	"github.com/gin-gonic/gin"
+)
+
+func TestBuildVertexEmbeddingPredictPayload_SingleAndBatch(t *testing.T) {
+	t.Parallel()
+
+	single, err := buildVertexEmbeddingPredictPayload([]string{"hello"}, nil)
+	if err != nil {
+		t.Fatalf("build single payload: %v", err)
+	}
+	instances, ok := single["instances"].([]map[string]any)
+	if !ok {
+		t.Fatalf("instances type = %T", single["instances"])
+	}
+	if len(instances) != 1 {
+		t.Fatalf("instances len = %d, want 1", len(instances))
+	}
+	if instances[0]["content"] != "hello" || instances[0]["task_type"] != "RETRIEVAL_QUERY" {
+		t.Fatalf("unexpected instance: %#v", instances[0])
+	}
+	if _, hasParams := single["parameters"]; hasParams {
+		t.Fatal("expected no parameters without dimensions")
+	}
+
+	dims := 768
+	batch, err := buildVertexEmbeddingPredictPayload([]string{"a", "b"}, &dims)
+	if err != nil {
+		t.Fatalf("build batch payload: %v", err)
+	}
+	batchInstances, ok := batch["instances"].([]map[string]any)
+	if !ok || len(batchInstances) != 2 {
+		t.Fatalf("batch instances = %#v", batch["instances"])
+	}
+	params, ok := batch["parameters"].(map[string]any)
+	if !ok || params["outputDimensionality"] != 768 {
+		t.Fatalf("parameters = %#v", batch["parameters"])
+	}
+}
+
+func TestBuildVertexEmbeddingPredictPayload_RejectsEmptyInput(t *testing.T) {
+	t.Parallel()
+	if _, err := buildVertexEmbeddingPredictPayload(nil, nil); err == nil {
+		t.Fatal("expected error for empty inputs")
+	}
+	if _, err := buildVertexEmbeddingPredictPayload([]string{" "}, nil); err == nil {
+		t.Fatal("expected error for blank input string")
+	}
+}
+
+func TestVertexEmbeddingPredictResponseToOpenAI_OK(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	body := []byte(`{"predictions":[{"embeddings":{"values":[0.1,0.2,0.3]}},{"embeddings":{"values":[0.4,0.5]}}]}`)
+	resp, usage, err := vertexEmbeddingPredictResponseToOpenAI(c, "gemini-embedding-001", body, 12)
+	if err != nil {
+		t.Fatalf("convert response: %v", err)
+	}
+	if len(resp.Data) != 2 || resp.Model != "gemini-embedding-001" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+	if usage == nil || usage.PromptTokens == 0 {
+		t.Fatalf("expected usage with prompt tokens, got %#v", usage)
+	}
+}
+
+func TestVertexEmbeddingPredictResponseToOpenAI_EmptyPredictions(t *testing.T) {
+	t.Parallel()
+	_, _, err := vertexEmbeddingPredictResponseToOpenAI(nil, "gemini-embedding-001", []byte(`{"predictions":[]}`), 1)
+	if err == nil {
+		t.Fatal("expected error for empty predictions")
+	}
+}
+
+func TestRunVertexEmbeddingRelay_InvalidCredentials(t *testing.T) {
+	t.Parallel()
+	ensureNewAPIDeps()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/embeddings", strings.NewReader(`{"model":"gemini-embedding-001","input":"hi"}`))
+
+	info := newVertexEmbeddingRelayInfo(`{not-json`, "gemini-embedding-001")
+
+	_, apiErr := runVertexEmbeddingRelay(c, info, info.Request.(*dto.EmbeddingRequest))
+	if apiErr == nil {
+		t.Fatal("expected invalid credentials error")
+	}
+}
+
+func TestDispatchEmbeddings_VertexPredict_OK(t *testing.T) {
+	ensureNewAPIDeps()
+
+	const saJSON = `{
+		"project_id":"proj-test",
+		"private_key_id":"key-id",
+		"private_key":"-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7\n-----END PRIVATE KEY-----\n",
+		"client_email":"vertex@test.iam.gserviceaccount.com",
+		"client_id":"123"
+	}`
+
+	var gotPredictBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, ":predict") {
+			http.NotFound(w, r)
+			return
+		}
+		gotPredictBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"predictions":[{"embeddings":{"values":[0.1,0.2,0.3]}}]}`))
+	}))
+	defer srv.Close()
+
+	oldTokenFn := vertexEmbeddingAcquireAccessToken
+	vertexEmbeddingAcquireAccessToken = func(_ vertex.Credentials, _ string) (string, error) {
+		return "tok-test", nil
+	}
+	defer func() { vertexEmbeddingAcquireAccessToken = oldTokenFn }()
+
+	body := mustJSONVertexTest(t, map[string]any{
+		"model": "gemini-embedding-001",
+		"input": "hello embedding",
+	})
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	in := ChannelContextInput{
+		ChannelType:      newapiconstant.ChannelTypeVertexAi,
+		ChannelID:        47,
+		BaseURL:          srv.URL,
+		APIKey:           saJSON,
+		VertexKeyType:    "json",
+		VertexLocation:   "us-central1",
+		ModelMappingJSON: string(mustJSONVertexTest(t, map[string]string{"gemini-embedding-001": "gemini-embedding-001"})),
+	}
+
+	out, apiErr := DispatchEmbeddings(context.Background(), c, in, body)
+	if apiErr != nil {
+		t.Fatalf("DispatchEmbeddings returned error: %v", apiErr)
+	}
+	if out == nil || out.Model != "gemini-embedding-001" {
+		t.Fatalf("unexpected outcome: %#v", out)
+	}
+	if !bytes.Contains(gotPredictBody, []byte("hello embedding")) {
+		t.Fatalf("predict body missing input text: %q", gotPredictBody)
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte(`"object":"embedding"`)) {
+		t.Fatalf("response body missing OpenAI embedding object: %q", w.Body.Bytes())
+	}
+}
+
+func mustJSONVertexTest(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	return b
+}
+
+func newVertexEmbeddingRelayInfo(saJSON, model string) *relaycommon.RelayInfo {
+	return &relaycommon.RelayInfo{
+		Request: &dto.EmbeddingRequest{Model: model, Input: "hi"},
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelType:       newapiconstant.ChannelTypeVertexAi,
+			ApiKey:            saJSON,
+			UpstreamModelName: model,
+			ApiVersion:        "us-central1",
+		},
+	}
+}

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -52,6 +52,8 @@ import (
 //     predict surface; re-probe via chat to add them). veo-3.1-generate-001 was
 //     added after the 2026-07-04 post-#1198 paid gate returned direct/universal
 //     200 queued video for the Vertex group.
+//   - gemini-embedding-001 (2026-08-07 direct upstream probe on prod Vertex
+//     accounts 47/57/58/59/74): :predict returned 200 with embedding values.
 //
 // Maintenance: this is an empirical snapshot, refreshed by re-running the
 // probe (ops/observability/run-probe.sh) when the served fleet changes. An
@@ -168,6 +170,7 @@ var supportedGeminiCatalogModels = map[string]struct{}{
 	"imagen-4.0-generate-001":       {},
 	"imagen-4.0-ultra-generate-001": {},
 	"veo-3.1-generate-001":          {},
+	"gemini-embedding-001":          {},
 	// servable-allowlist:end gemini
 }
 

--- a/backend/internal/service/universal_routing_tk_endpoint_map.go
+++ b/backend/internal/service/universal_routing_tk_endpoint_map.go
@@ -239,6 +239,12 @@ func universalRequestPlatformHint(shape UniversalShape, model string) string {
 		if strings.HasPrefix(m, "imagen") || strings.HasPrefix(m, "veo") {
 			return PlatformNewAPI
 		}
+	case ShapeOpenAIEmbeddings:
+		// gemini-embedding-* is probed/served through Google-Vertex (newapi ch41),
+		// not native PlatformGemini groups.
+		if strings.HasPrefix(m, "gemini-embedding") {
+			return PlatformNewAPI
+		}
 	}
 	return universalModelPlatformHint(model)
 }

--- a/backend/internal/service/universal_routing_tk_resolver_test.go
+++ b/backend/internal/service/universal_routing_tk_resolver_test.go
@@ -220,6 +220,9 @@ func TestUniversalRequestPlatformHint_OpenAICompatVertexMedia(t *testing.T) {
 	if got := universalRequestPlatformHint(ShapeOpenAIChat, "gemini-3.5-flash"); got != PlatformAntigravity {
 		t.Fatalf("antigravity-only chat model should hint antigravity, got %q", got)
 	}
+	if got := universalRequestPlatformHint(ShapeOpenAIEmbeddings, "gemini-embedding-001"); got != PlatformNewAPI {
+		t.Fatalf("gemini-embedding on OpenAI embeddings should hint newapi vertex, got %q", got)
+	}
 }
 
 func TestResolve_PicksByPlatformAndHint(t *testing.T) {

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -415,6 +415,45 @@ func TestResolve_ImagenPicksVertexNewapiGroup(t *testing.T) {
 	}
 }
 
+func TestResolve_GeminiEmbeddingPicksVertexNewapiGroup(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(2, PlatformOpenAI, 5, false),
+		grp(16, PlatformNewAPI, 10, false),
+	}
+	embeddingMapping := map[string]any{"gemini-embedding-001": "gemini-embedding-001"}
+	svc := &GatewayService{
+		accountRepo: groupAwareStubOpenAIAccountRepo{stubOpenAIAccountRepo{accounts: []Account{
+			{
+				ID:          63,
+				GroupIDs:    []int64{2},
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Schedulable: true,
+				ChannelType: 0,
+			},
+			{
+				ID:          47,
+				GroupIDs:    []int64{16},
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeServiceAccount,
+				Status:      StatusActive,
+				Schedulable: true,
+				ChannelType: 41,
+				Credentials: map[string]any{"model_mapping": embeddingMapping},
+			},
+		}}},
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetModelSupportProvider(svc.UniversalGroupSupportsRequest)
+
+	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIEmbeddings, "gemini-embedding-001", "")
+	if err != nil || g == nil || g.ID != 16 {
+		t.Fatalf("gemini-embedding universal must pick vertex gid=16, got=%v err=%v", g, err)
+	}
+}
+
 func TestResolve_ImagenServiceAccountPicksVertexWithDirectSchedulerSupport(t *testing.T) {
 	ctx := context.Background()
 	span := []Group{

--- a/backend/migrations/tk_071_vertex_embedding_model_mapping.sql
+++ b/backend/migrations/tk_071_vertex_embedding_model_mapping.sql
@@ -1,0 +1,35 @@
+-- Migration: tk_071_vertex_embedding_model_mapping
+--
+-- Enable gemini-embedding-001 on Google-Vertex (group 16) Vertex AI accounts.
+-- Direct upstream :predict probes returned 200 on accounts 47/57/58/59/74
+-- (2026-08-07). Merges the channel_type=41 SSOT floor subset without dropping
+-- existing chat/image/video rows.
+--
+-- Raw-SQL account mutations bypass Ent hooks — enqueue scheduler_outbox refresh.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH upd AS (
+    UPDATE accounts a
+    SET credentials = jsonb_set(
+            a.credentials,
+            '{model_mapping}',
+            COALESCE(a.credentials -> 'model_mapping', '{}'::jsonb) || '{
+                "gemini-embedding-001": "gemini-embedding-001"
+            }'::jsonb
+        ),
+        updated_at = NOW()
+    FROM account_groups ag
+    JOIN groups g ON g.id = ag.group_id
+    WHERE a.id = ag.account_id
+      AND g.id = 16
+      AND g.name = 'Google-Vertex'
+      AND g.platform = 'newapi'
+      AND a.platform = 'newapi'
+      AND a.channel_type = 41
+      AND a.deleted_at IS NULL
+    RETURNING a.id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "floor_sha256": "4594d7d98acbf6b7735ad0d2c6f0f0745c53809468852676529b6a0f8d40327f",
+  "floor_sha256": "317dd23f2bdd0c4c041b0bb2d8f45d9986aa121621d8b5ab96735b9d687d3521",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -63,6 +63,7 @@
         "gemini-2.5-pro": "gemini-2.5-pro",
         "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
         "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-embedding-001": "gemini-embedding-001",
         "imagen-4.0-fast-generate-001": "imagen-4.0-fast-generate-001",
         "imagen-4.0-generate-001": "imagen-4.0-generate-001",
         "imagen-4.0-ultra-generate-001": "imagen-4.0-ultra-generate-001",
@@ -164,6 +165,7 @@
         "gemini-2.5-pro": "gemini-2.5-pro",
         "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
         "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-embedding-001": "gemini-embedding-001",
         "imagen-4.0-fast-generate-001": "imagen-4.0-fast-generate-001",
         "imagen-4.0-generate-001": "imagen-4.0-generate-001",
         "imagen-4.0-ultra-generate-001": "imagen-4.0-ultra-generate-001",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -5017,9 +5017,11 @@
         "hint == PlatformGemini",
         "universalAntigravityTextModel(model)",
         "engine.CapabilityForEndpoint(bridgeEndpoint)",
-        "func universalModelPlatformHint("
+        "func universalModelPlatformHint(",
+        "ShapeOpenAIEmbeddings",
+        "gemini-embedding"
       ],
-      "rationale": "Universal Key endpoint-shape -> candidate-platforms map. Candidate sets are DERIVED from engine single-source (OpenAICompatPlatforms / engine.CapabilityForEndpoint) so a sixth compat platform flows through automatically and the preflight newapi compat-pool drift guard stays satisfied. count_tokens must stay anthropic/antigravity-only; the model->platform hint biases grok/openai/newapi within the openai-compat shape. An upstream refactor hardcoding platform slices here would silently break grok routing and trip the drift guard."
+      "rationale": "Universal Key endpoint-shape -> candidate-platforms map. Candidate sets are DERIVED from engine single-source (OpenAICompatPlatforms / engine.CapabilityForEndpoint) so a sixth compat platform flows through automatically and the preflight newapi compat-pool drift guard stays satisfied. count_tokens must stay anthropic/antigravity-only; the model->platform hint biases grok/openai/newapi within the openai-compat shape. gemini-embedding-* on /v1/embeddings must hint newapi (Google-Vertex ch41 bridge), matching imagen/veo on image/video shapes. An upstream refactor hardcoding platform slices here would silently break grok routing and trip the drift guard."
     },
     {
       "path": "backend/internal/server/middleware/universal_routing_tk.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -148,6 +148,36 @@
       "rationale": "Focused bridge regressions prove that public resolution/size/audio dimensions become the exact adaptor metadata values used upstream, including conflict precedence and metadata-only audio aliases."
     },
     {
+      "path": "backend/internal/relay/bridge/embedding_relay.go",
+      "must_contain": [
+        "RunEmbeddingRelay",
+        "runVertexEmbeddingRelay",
+        "ChannelTypeVertexAi"
+      ],
+      "rationale": "Bridge for POST /v1/embeddings on the newapi fifth platform. RunEmbeddingRelay must delegate channel_type 41 (Vertex SA) to runVertexEmbeddingRelay because upstream new-api's vertex adaptor leaves ConvertEmbeddingRequest unimplemented; dropping the injection line silently regresses every Vertex embedding request back to not implemented."
+    },
+    {
+      "path": "backend/internal/relay/bridge/embedding_relay_tk_vertex.go",
+      "must_contain": [
+        "runVertexEmbeddingRelay",
+        "buildVertexEmbeddingPredictPayload",
+        "vertexEmbeddingPredictResponseToOpenAI",
+        "vertex.BuildGoogleModelURL",
+        "RETRIEVAL_QUERY",
+        "ApplyParamOverrideWithRelayInfo"
+      ],
+      "rationale": "TK companion that implements Vertex AI text embedding via the :predict surface for channel_type 41 service accounts. Converts OpenAI /v1/embeddings requests to Vertex instances+parameters, exchanges SA JSON for OAuth, and writes OpenAI-shaped embedding JSON + usage. ParamOverride parity with the generic embedding relay path must survive upstream merges."
+    },
+    {
+      "path": "backend/internal/relay/bridge/embedding_relay_tk_vertex_test.go",
+      "must_contain": [
+        "TestBuildVertexEmbeddingPredictPayload_SingleAndBatch",
+        "TestVertexEmbeddingPredictResponseToOpenAI_EmptyPredictions",
+        "TestDispatchEmbeddings_VertexPredict_OK"
+      ],
+      "rationale": "Focused bridge regressions for Vertex embedding request shaping, empty-prediction rejection, and DispatchEmbeddings end-to-end wiring through the ch41 companion path."
+    },
+    {
       "path": "backend/internal/server/routes/gateway_test.go",
       "must_contain": [
         "TestGatewayRoutesNewAPICountTokensPathIsRegistered",


### PR DESCRIPTION
## 摘要

- 在 bridge 层实现 Vertex channel_type 41 的 `/v1/embeddings` relay（`:predict` → OpenAI embedding JSON），绕过 new-api vertex adaptor 未实现的 `ConvertEmbeddingRequest`。
- 将 `gemini-embedding-001` 加入 Gemini allowlist / model-surface bundle，并通过 migration `tk_071` 合并到 Google-Vertex（group 16）账号 `model_mapping`。
- Universal key：`gemini-embedding-*` 在 embeddings 形状下 hint 到 `newapi`，与 imagen/veo 对齐，确保授权 group 16 的 universal key 能正确路由。

## 风险

- 常规风险：公共 API 行为新增（`/v1/embeddings` 对 Vertex 账号可用）；仅 `gemini-embedding-001` 经 prod 直连 probe 验证。
- 需部署 migration `tk_071` 后 prod 账号 mapping 才生效；未跑 migration 前仍会 400 Unsupported model。
- Volcengine embedding 不在本次范围。

## 验证

```bash
cd backend && go test -tags=unit ./internal/relay/bridge/ -run 'Vertex|Embedding' -count=1
cd backend && go test -tags=unit ./internal/service/ -run 'GeminiEmbedding|UniversalRequestPlatformHint' -count=1
./scripts/preflight.sh  # 代码项全绿；worktree 分支名检查可忽略
```

- Bridge 单元测试：请求/响应转换、无效凭证、DispatchEmbeddings 端到端 mock
- Universal routing：`TestResolve_GeminiEmbeddingPicksVertexNewapiGroup`

## 提交

- 4ab86a341 feat(gateway): enable Vertex gemini-embedding-001 via API key

最新提交：4ab86a341

Made with [Cursor](https://cursor.com)