### PR TITLE
fix(gateway): Vertex gemini-embedding-001 恢复 token 计量与计费

### DIFF
--- a/backend/internal/relay/bridge/embedding_relay_tk_vertex.go
+++ b/backend/internal/relay/bridge/embedding_relay_tk_vertex.go
@@ -120,7 +120,13 @@ func runVertexEmbeddingRelay(c *gin.Context, info *relaycommon.RelayInfo, reques
 		return nil, types.NewOpenAIError(readErr, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 	}
 
-	openAIResponse, usage, convErr := vertexEmbeddingPredictResponseToOpenAI(c, modelName, responseBody, info.GetEstimatePromptTokens())
+	promptTokens := vertexEmbeddingPromptTokens(inputs, modelName)
+	if estimated := info.GetEstimatePromptTokens(); estimated > promptTokens {
+		promptTokens = estimated
+	}
+	info.SetEstimatePromptTokens(promptTokens)
+
+	openAIResponse, usage, convErr := vertexEmbeddingPredictResponseToOpenAI(c, modelName, responseBody, promptTokens)
 	if convErr != nil {
 		return nil, types.NewOpenAIError(convErr, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 	}
@@ -131,6 +137,14 @@ func runVertexEmbeddingRelay(c *gin.Context, info *relaycommon.RelayInfo, reques
 	}
 	service.IOCopyBytesGracefully(c, resp, jsonResponse)
 	return usage, nil
+}
+
+func vertexEmbeddingPromptTokens(inputs []string, modelName string) int {
+	total := 0
+	for _, input := range inputs {
+		total += service.CountTokenInput(input, modelName)
+	}
+	return total
 }
 
 func buildVertexEmbeddingPredictPayload(inputs []string, dimensions *int) (map[string]any, error) {

--- a/backend/internal/relay/bridge/embedding_relay_tk_vertex_test.go
+++ b/backend/internal/relay/bridge/embedding_relay_tk_vertex_test.go
@@ -19,6 +19,20 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+func TestVertexEmbeddingPromptTokens_SingleAndBatch(t *testing.T) {
+	t.Parallel()
+
+	single := vertexEmbeddingPromptTokens([]string{"hello embedding"}, "gemini-embedding-001")
+	if single <= 0 {
+		t.Fatalf("single prompt tokens = %d, want > 0", single)
+	}
+
+	batch := vertexEmbeddingPromptTokens([]string{"hello", "world"}, "gemini-embedding-001")
+	if batch <= single {
+		t.Fatalf("batch prompt tokens = %d, want > single %d", batch, single)
+	}
+}
+
 func TestBuildVertexEmbeddingPredictPayload_SingleAndBatch(t *testing.T) {
 	t.Parallel()
 
@@ -168,6 +182,9 @@ func TestDispatchEmbeddings_VertexPredict_OK(t *testing.T) {
 	}
 	if !bytes.Contains(w.Body.Bytes(), []byte(`"object":"embedding"`)) {
 		t.Fatalf("response body missing OpenAI embedding object: %q", w.Body.Bytes())
+	}
+	if out.Usage == nil || out.Usage.PromptTokens <= 0 {
+		t.Fatalf("expected positive prompt token usage, got %#v", out.Usage)
 	}
 }
 

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -160,6 +160,8 @@
       "path": "backend/internal/relay/bridge/embedding_relay_tk_vertex.go",
       "must_contain": [
         "runVertexEmbeddingRelay",
+        "vertexEmbeddingPromptTokens",
+        "CountTokenInput",
         "buildVertexEmbeddingPredictPayload",
         "vertexEmbeddingPredictResponseToOpenAI",
         "vertex.BuildGoogleModelURL",
@@ -171,6 +173,7 @@
     {
       "path": "backend/internal/relay/bridge/embedding_relay_tk_vertex_test.go",
       "must_contain": [
+        "TestVertexEmbeddingPromptTokens_SingleAndBatch",
         "TestBuildVertexEmbeddingPredictPayload_SingleAndBatch",
         "TestVertexEmbeddingPredictResponseToOpenAI_EmptyPredictions",
         "TestDispatchEmbeddings_VertexPredict_OK"


### PR DESCRIPTION
## 摘要

- v1.8.139 实测 `POST /v1/embeddings` + `gemini-embedding-001` 功能正常，但 `usage.prompt_tokens` 与 `usage_logs.actual_cost` 均为 0
- 根因：Vertex bridge 路径依赖 `info.GetEstimatePromptTokens()`，而 bridge 未预先估算 token
- 修复：新增 `vertexEmbeddingPromptTokens`，对每条 input 累加 `service.CountTokenInput`，写回 `RelayInfo` 并用于 OpenAI usage 响应

## 风险

- 常规风险：仅影响 Vertex embedding 的 usage/计费字段，不改变 upstream 请求形态
- token 计数为本地估算（与 new-api 其他 embedding 路径一致），可能与 Google 账单存在微小偏差

## 验证

- `go test -tags=unit ./internal/relay/bridge/ -run 'Vertex|Embedding' -count=1` ✓
- `./scripts/preflight.sh` ✓
- merge 后 prod smoke：`curl .../v1/embeddings` 期望 `prompt_tokens > 0`，usage_logs `actual_cost > 0`

## 提交

- 3822a38ab fix(gateway): Vertex embedding 请求本地计 token 以恢复计费

最新提交：3822a38ab

Made with [Cursor](https://cursor.com)