### PR TITLE
feat(modelops): 百度千帆账号 90 SSOT 上架与分渠道 DeepSeek 定价

### DIFF
--- a/backend/internal/integration/newapi/qianfan.go
+++ b/backend/internal/integration/newapi/qianfan.go
@@ -1,0 +1,23 @@
+package newapi
+
+import (
+	"strings"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
+// QianfanBaseURL is the OpenAI-compatible Baidu Qianfan v2 API root.
+const QianfanBaseURL = "https://qianfan.baidubce.com"
+
+// IsQianfanBaseURL reports whether channelType/base resolve to the Baidu Qianfan v2 endpoint.
+func IsQianfanBaseURL(channelType int, base string) bool {
+	if channelType != newapiconstant.ChannelTypeBaiduV2 {
+		return false
+	}
+	base = strings.TrimSpace(base)
+	if base == "" {
+		return false
+	}
+	base = strings.TrimRight(strings.ToLower(base), "/")
+	return base == QianfanBaseURL
+}

--- a/backend/internal/integration/newapi/qianfan_test.go
+++ b/backend/internal/integration/newapi/qianfan_test.go
@@ -1,0 +1,28 @@
+package newapi
+
+import (
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
+func TestIsQianfanBaseURL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		channelType int
+		base        string
+		want        bool
+	}{
+		{newapiconstant.ChannelTypeBaiduV2, QianfanBaseURL, true},
+		{newapiconstant.ChannelTypeBaiduV2, QianfanBaseURL + "/", true},
+		{newapiconstant.ChannelTypeBaiduV2, QianfanBaseURL + "/v2", false},
+		{newapiconstant.ChannelTypeDeepSeek, QianfanBaseURL, false},
+		{newapiconstant.ChannelTypeVolcEngine, QianfanBaseURL, false},
+	}
+	for _, tc := range cases {
+		got := IsQianfanBaseURL(tc.channelType, tc.base)
+		if got != tc.want {
+			t.Fatalf("IsQianfanBaseURL(%d, %q) = %v, want %v", tc.channelType, tc.base, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/relay/bridge/embedding_relay.go
+++ b/backend/internal/relay/bridge/embedding_relay.go
@@ -9,6 +9,7 @@ import (
 	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	newapirelay "github.com/QuantumNous/new-api/relay"
+	"github.com/QuantumNous/new-api/relay/channel"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/service"
@@ -39,6 +40,9 @@ func RunEmbeddingRelay(c *gin.Context, info *relaycommon.RelayInfo) (*dto.Usage,
 	if info.ChannelType == newapiconstant.ChannelTypeVertexAi {
 		return runVertexEmbeddingRelay(c, info, request)
 	}
+	if info.ChannelType == newapiconstant.ChannelTypeBaiduV2 {
+		return runQianfanEmbeddingRelay(c, info, request)
+	}
 
 	adaptor := newapirelay.GetAdaptor(info.ApiType)
 	if adaptor == nil {
@@ -50,6 +54,10 @@ func RunEmbeddingRelay(c *gin.Context, info *relaycommon.RelayInfo) (*dto.Usage,
 	if err != nil {
 		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
 	}
+	return runAdaptorEmbeddingRelay(c, info, adaptor, convertedRequest)
+}
+
+func runAdaptorEmbeddingRelay(c *gin.Context, info *relaycommon.RelayInfo, adaptor channel.Adaptor, convertedRequest any) (*dto.Usage, *types.NewAPIError) {
 	relaycommon.AppendRequestConversionFromRequest(info, convertedRequest)
 	jsonData, err := common.Marshal(convertedRequest)
 	if err != nil {

--- a/backend/internal/relay/bridge/embedding_relay_tk_qianfan.go
+++ b/backend/internal/relay/bridge/embedding_relay_tk_qianfan.go
@@ -1,0 +1,32 @@
+package bridge
+
+import (
+	"fmt"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	newapirelay "github.com/QuantumNous/new-api/relay"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+// runQianfanEmbeddingRelay forwards OpenAI-shaped embedding requests to Baidu
+// Qianfan v2. Upstream new-api's baidu_v2 adaptor leaves ConvertEmbeddingRequest
+// unimplemented even though GetRequestURL targets /v2/embeddings.
+func runQianfanEmbeddingRelay(c *gin.Context, info *relaycommon.RelayInfo, request *dto.EmbeddingRequest) (*dto.Usage, *types.NewAPIError) {
+	if c == nil || info == nil || request == nil {
+		return nil, types.NewError(fmt.Errorf("qianfan embedding relay missing context"), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+	}
+	if info.ChannelType != newapiconstant.ChannelTypeBaiduV2 {
+		return nil, types.NewError(fmt.Errorf("qianfan embedding relay expected channel_type %d, got %d", newapiconstant.ChannelTypeBaiduV2, info.ChannelType), types.ErrorCodeInvalidRequest, types.ErrOptionWithSkipRetry())
+	}
+
+	adaptor := newapirelay.GetAdaptor(info.ApiType)
+	if adaptor == nil {
+		return nil, types.NewError(fmt.Errorf("invalid api type: %d", info.ApiType), types.ErrorCodeInvalidApiType, types.ErrOptionWithSkipRetry())
+	}
+	adaptor.Init(info)
+	return runAdaptorEmbeddingRelay(c, info, adaptor, request)
+}

--- a/backend/internal/relay/bridge/embedding_relay_tk_qianfan_test.go
+++ b/backend/internal/relay/bridge/embedding_relay_tk_qianfan_test.go
@@ -1,0 +1,88 @@
+//go:build unit
+
+package bridge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/gin-gonic/gin"
+)
+
+func TestDispatchEmbeddings_QianfanV2_OK(t *testing.T) {
+	ensureNewAPIDeps()
+
+	var gotPath string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		if r.Header.Get("Authorization") != "Bearer qf-test-key" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"object":"list",
+			"data":[{"object":"embedding","index":0,"embedding":[0.1,0.2,0.3]}],
+			"model":"bge-large-en",
+			"usage":{"prompt_tokens":3,"total_tokens":3}
+		}`))
+	}))
+	defer srv.Close()
+
+	body := mustJSONQianfanEmbeddingTest(t, map[string]any{
+		"model": "bge-large-en",
+		"input": "hello embedding",
+	})
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	in := ChannelContextInput{
+		ChannelType:      newapiconstant.ChannelTypeBaiduV2,
+		ChannelID:        90,
+		BaseURL:          srv.URL,
+		APIKey:           "qf-test-key",
+		ModelMappingJSON: string(mustJSONQianfanEmbeddingTest(t, map[string]string{"bge-large-en": "bge-large-en"})),
+	}
+
+	out, apiErr := DispatchEmbeddings(context.Background(), c, in, body)
+	if apiErr != nil {
+		t.Fatalf("DispatchEmbeddings returned error: %v", apiErr)
+	}
+	if out == nil || out.Model != "bge-large-en" {
+		t.Fatalf("unexpected outcome: %#v", out)
+	}
+	if gotPath != "/v2/embeddings" {
+		t.Fatalf("expected /v2/embeddings upstream path, got %q", gotPath)
+	}
+	if !bytes.Contains(gotBody, []byte("hello embedding")) {
+		t.Fatalf("upstream body missing input text: %q", gotBody)
+	}
+	if !strings.Contains(w.Body.String(), `"object":"embedding"`) {
+		t.Fatalf("response body missing OpenAI embedding object: %q", w.Body.Bytes())
+	}
+	if out.Usage == nil || out.Usage.PromptTokens <= 0 {
+		t.Fatalf("expected positive prompt token usage, got %#v", out.Usage)
+	}
+}
+
+func mustJSONQianfanEmbeddingTest(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	return b
+}

--- a/backend/internal/service/account_model_mapping_preset_tk.go
+++ b/backend/internal/service/account_model_mapping_preset_tk.go
@@ -88,6 +88,13 @@ func isNewAPIVolcEngineAgentPlanAccount(account *Account) bool {
 		newapiintegration.IsVolcEngineAgentPlanBaseURL(account.ChannelType, account.GetBaseURL())
 }
 
+func isNewAPIQianfanAccount(account *Account) bool {
+	return account != nil &&
+		account.Platform == PlatformNewAPI &&
+		account.ChannelType == newapiconstant.ChannelTypeBaiduV2 &&
+		newapiintegration.IsQianfanBaseURL(account.ChannelType, account.GetBaseURL())
+}
+
 // accountModelMappingOverrideAccounts declares account-specific mapping scopes
 // whose serving intent is narrower than their shared platform/channel floor.
 func accountModelMappingOverrideAccounts() []*Account {
@@ -98,6 +105,14 @@ func accountModelMappingOverrideAccounts() []*Account {
 			ChannelType: newapiconstant.ChannelTypeVolcEngine,
 			Credentials: map[string]any{
 				"base_url": newapiintegration.VolcEngineAgentPlanBaseURL,
+			},
+		},
+		{
+			Platform:    PlatformNewAPI,
+			Type:        AccountTypeAPIKey,
+			ChannelType: newapiconstant.ChannelTypeBaiduV2,
+			Credentials: map[string]any{
+				"base_url": newapiintegration.QianfanBaseURL,
 			},
 		},
 	}
@@ -114,6 +129,11 @@ func NewAPIModelMappingPresetIDsForAccount(account *Account) []string {
 		sort.Strings(ids)
 		return ids
 	}
+	if isNewAPIQianfanAccount(account) {
+		ids := newAPIQianfanModelMappingPresetIDs()
+		sort.Strings(ids)
+		return ids
+	}
 	return AccountModelMappingPresetIDs(context.Background(), account.Platform, account.ChannelType, nil)
 }
 
@@ -126,6 +146,11 @@ func NewAPIModelDisplayIDsForAccount(account *Account) []string {
 	}
 	if isNewAPIVolcEngineAgentPlanAccount(account) {
 		ids := tkServedModelsManifestDisplayPresetIDsForSelector(account.Platform, account.ChannelType, account.GetBaseURL())
+		sort.Strings(ids)
+		return ids
+	}
+	if isNewAPIQianfanAccount(account) {
+		ids := newAPIQianfanModelDisplayPresetIDs()
 		sort.Strings(ids)
 		return ids
 	}

--- a/backend/internal/service/account_model_mapping_preset_tk_qianfan_test.go
+++ b/backend/internal/service/account_model_mapping_preset_tk_qianfan_test.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNewAPIQianfanAccount(t *testing.T) {
+	t.Parallel()
+	require.True(t, isNewAPIQianfanAccount(&Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeBaiduV2,
+		Credentials: map[string]any{
+			"base_url": newapiintegration.QianfanBaseURL,
+		},
+	}))
+	require.False(t, isNewAPIQianfanAccount(&Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeBaiduV2,
+		Credentials: map[string]any{
+			"base_url": newapiintegration.QianfanBaseURL + "/v2",
+		},
+	}))
+}
+
+func TestNewAPIModelMappingPresetIDsForQianfanAccount(t *testing.T) {
+	t.Parallel()
+	account := &Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeBaiduV2,
+		Credentials: map[string]any{
+			"base_url": newapiintegration.QianfanBaseURL,
+		},
+	}
+	got := NewAPIModelMappingPresetIDsForAccount(account)
+	require.Equal(t, []string{
+		"deepseek-v3.2",
+		"deepseek-v3.2-think",
+		"deepseek-v4-flash",
+		"deepseek-v4-flash-0731",
+		"deepseek-v4-pro",
+		"ernie-4.5-turbo-vl-32k",
+		"glm-5.2",
+	}, got)
+
+	mapping, ok := accountModelMappingForAccount(context.Background(), account, nil, nil, nil)
+	require.True(t, ok)
+	require.Len(t, mapping, 7)
+	require.Equal(t, "deepseek-v4-pro", mapping["deepseek-v4-pro"])
+}
+
+func TestAccountModelMappingFloorForOpsIncludesQianfanOverride(t *testing.T) {
+	t.Parallel()
+	floor, err := AccountModelMappingFloorForOps(context.Background(), "")
+	require.NoError(t, err)
+	require.NotEmpty(t, floor.AccountOverrides)
+	found := false
+	for _, override := range floor.AccountOverrides {
+		if override.ChannelType == newapiconstant.ChannelTypeBaiduV2 &&
+			override.BaseURL == newapiintegration.QianfanBaseURL {
+			found = true
+			require.Contains(t, override.ModelMapping, "ernie-4.5-turbo-vl-32k")
+			require.Contains(t, override.ModelMapping, "deepseek-v4-pro")
+			require.Contains(t, override.ModelMapping, "glm-5.2")
+		}
+	}
+	require.True(t, found, "qianfan account override must be exported in bundle floor")
+}

--- a/backend/internal/service/account_model_mapping_preset_tk_qianfan_test.go
+++ b/backend/internal/service/account_model_mapping_preset_tk_qianfan_test.go
@@ -41,18 +41,42 @@ func TestNewAPIModelMappingPresetIDsForQianfanAccount(t *testing.T) {
 	}
 	got := NewAPIModelMappingPresetIDsForAccount(account)
 	require.Equal(t, []string{
+		"bge-large-en",
+		"bge-large-zh",
+		"deepseek-ocr",
 		"deepseek-v3.2",
 		"deepseek-v3.2-think",
 		"deepseek-v4-flash",
 		"deepseek-v4-flash-0731",
 		"deepseek-v4-pro",
+		"ernie-4.5-turbo-128k",
+		"ernie-4.5-turbo-20260402",
+		"ernie-4.5-turbo-32k",
+		"ernie-4.5-turbo-vl",
 		"ernie-4.5-turbo-vl-32k",
+		"ernie-5.0",
+		"ernie-5.0-thinking-preview",
+		"ernie-5.1",
+		"ernie-x1.1",
+		"ernie-x1.1-preview",
+		"glm-5",
+		"glm-5.1",
 		"glm-5.2",
+		"internvl3-38b",
+		"kimi-k2.6",
+		"qianfan-ocr",
+		"qwen3-embedding-0.6b",
+		"qwen3-embedding-4b",
+		"qwen3-embedding-8b",
+		"qwen3.5-122b-a10b",
+		"qwen3.5-27b",
+		"qwen3.5-35b-a3b",
+		"qwen3.5-397b-a17b",
 	}, got)
 
 	mapping, ok := accountModelMappingForAccount(context.Background(), account, nil, nil, nil)
 	require.True(t, ok)
-	require.Len(t, mapping, 7)
+	require.Len(t, mapping, 31)
 	require.Equal(t, "deepseek-v4-pro", mapping["deepseek-v4-pro"])
 }
 

--- a/backend/internal/service/account_model_mapping_preset_tk_qianfan_test.go
+++ b/backend/internal/service/account_model_mapping_preset_tk_qianfan_test.go
@@ -39,44 +39,14 @@ func TestNewAPIModelMappingPresetIDsForQianfanAccount(t *testing.T) {
 			"base_url": newapiintegration.QianfanBaseURL,
 		},
 	}
+	want := newAPIQianfanModelMappingPresetIDs()
+	require.NotEmpty(t, want, "manifest SSOT must expose qianfan ch46 preset ids")
 	got := NewAPIModelMappingPresetIDsForAccount(account)
-	require.Equal(t, []string{
-		"bge-large-en",
-		"bge-large-zh",
-		"deepseek-ocr",
-		"deepseek-v3.2",
-		"deepseek-v3.2-think",
-		"deepseek-v4-flash",
-		"deepseek-v4-flash-0731",
-		"deepseek-v4-pro",
-		"ernie-4.5-turbo-128k",
-		"ernie-4.5-turbo-20260402",
-		"ernie-4.5-turbo-32k",
-		"ernie-4.5-turbo-vl",
-		"ernie-4.5-turbo-vl-32k",
-		"ernie-5.0",
-		"ernie-5.0-thinking-preview",
-		"ernie-5.1",
-		"ernie-x1.1",
-		"ernie-x1.1-preview",
-		"glm-5",
-		"glm-5.1",
-		"glm-5.2",
-		"internvl3-38b",
-		"kimi-k2.6",
-		"qianfan-ocr",
-		"qwen3-embedding-0.6b",
-		"qwen3-embedding-4b",
-		"qwen3-embedding-8b",
-		"qwen3.5-122b-a10b",
-		"qwen3.5-27b",
-		"qwen3.5-35b-a3b",
-		"qwen3.5-397b-a17b",
-	}, got)
+	require.Equal(t, want, got)
 
 	mapping, ok := accountModelMappingForAccount(context.Background(), account, nil, nil, nil)
 	require.True(t, ok)
-	require.Len(t, mapping, 31)
+	require.Len(t, mapping, len(want))
 	require.Equal(t, "deepseek-v4-pro", mapping["deepseek-v4-pro"])
 }
 

--- a/backend/internal/service/account_model_mapping_ssot_tk.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk.go
@@ -133,6 +133,13 @@ func accountModelMappingForAccount(ctx context.Context, account *Account, pricin
 			}
 			return identityModelMapping(ids), true
 		}
+		if isNewAPIQianfanAccount(account) {
+			ids := NewAPIModelMappingPresetIDsForAccount(account)
+			if len(ids) == 0 {
+				return nil, false
+			}
+			return identityModelMapping(ids), true
+		}
 		if runtime != nil {
 			if mapping, ok := runtime.newAPIChannelTypes[account.ChannelType]; ok {
 				return cloneStringMap(mapping), true

--- a/backend/internal/service/billing_service_tk_qianfan.go
+++ b/backend/internal/service/billing_service_tk_qianfan.go
@@ -4,6 +4,14 @@ import "strings"
 
 const tkQianfanOverlayPricingSuffix = ".qianfan"
 
+// tkDeepSeekPeakValleyExcludedModels are overlay owners on Baidu Qianfan list
+// pricing, not DeepSeek official direct-API peak-valley windows.
+var tkDeepSeekPeakValleyExcludedModels = map[string]struct{}{
+	"deepseek-v3.2":          {},
+	"deepseek-v3.2-think":    {},
+	"deepseek-v4-flash-0731": {},
+}
+
 // tkQianfanScopedOverlayModels are client-facing model ids that share a global
 // overlay owner but bill at Baidu Qianfan list rates when served from account 90.
 var tkQianfanScopedOverlayModels = map[string]struct{}{

--- a/backend/internal/service/billing_service_tk_qianfan.go
+++ b/backend/internal/service/billing_service_tk_qianfan.go
@@ -1,0 +1,41 @@
+package service
+
+import "strings"
+
+const tkQianfanOverlayPricingSuffix = ".qianfan"
+
+// tkQianfanScopedOverlayModels are client-facing model ids that share a global
+// overlay owner but bill at Baidu Qianfan list rates when served from account 90.
+var tkQianfanScopedOverlayModels = map[string]struct{}{
+	"deepseek-v4-pro":   {},
+	"deepseek-v4-flash": {},
+}
+
+// tkQianfanScopedBillingModel maps billing to the Qianfan overlay owner when the
+// serving account is Baidu Qianfan (ch46). Public catalog and GetModelPricing
+// keep the global owner; only usage billing on account 90 switches keys.
+func tkQianfanScopedBillingModel(model string, account *Account) string {
+	model = strings.TrimSpace(model)
+	if model == "" || account == nil || !isNewAPIQianfanAccount(account) {
+		return model
+	}
+	if _, ok := tkQianfanScopedOverlayModels[model]; !ok {
+		return model
+	}
+	scoped := model + tkQianfanOverlayPricingSuffix
+	if tkOverlayModelPricing(scoped) != nil {
+		return scoped
+	}
+	return model
+}
+
+func tkMapQianfanScopedBillingModels(models []string, account *Account) []string {
+	if len(models) == 0 || account == nil {
+		return models
+	}
+	out := make([]string, len(models))
+	for i, model := range models {
+		out[i] = tkQianfanScopedBillingModel(model, account)
+	}
+	return out
+}

--- a/backend/internal/service/billing_service_tk_qianfan.go
+++ b/backend/internal/service/billing_service_tk_qianfan.go
@@ -17,6 +17,10 @@ var tkDeepSeekPeakValleyExcludedModels = map[string]struct{}{
 var tkQianfanScopedOverlayModels = map[string]struct{}{
 	"deepseek-v4-pro":   {},
 	"deepseek-v4-flash": {},
+	"glm-5":             {},
+	"glm-5.1":           {},
+	"glm-5.2":           {},
+	"kimi-k2.6":         {},
 }
 
 // tkQianfanScopedBillingModel maps billing to the Qianfan overlay owner when the

--- a/backend/internal/service/billing_service_tk_qianfan_test.go
+++ b/backend/internal/service/billing_service_tk_qianfan_test.go
@@ -39,6 +39,18 @@ func TestTkQianfanScopedBillingModel(t *testing.T) {
 	require.Equal(t, "deepseek-v3.2", tkQianfanScopedBillingModel("deepseek-v3.2", qianfan))
 }
 
+func TestTkQianfanOverlay_DeepSeekV32UsesTieredIntervals(t *testing.T) {
+	t.Parallel()
+	entry := loadTKPricingOverlay()["deepseek-v3.2"]
+	require.NotNil(t, entry)
+	require.Len(t, entry.Intervals, 2)
+	require.NotNil(t, entry.Intervals[0].MaxTokens)
+	require.Equal(t, 32000, *entry.Intervals[0].MaxTokens)
+	require.Nil(t, entry.Intervals[1].MaxTokens)
+	require.InDelta(t, 2.9850746268656716e-07, entry.InputCostPerToken, 1e-15)
+	require.InDelta(t, 5.970149253731343e-07, *entry.Intervals[1].InputPrice, 1e-15)
+}
+
 func TestTkQianfanScopedBillingModel_UsesQianfanRatesInCost(t *testing.T) {
 	t.Parallel()
 	svc := newTestBillingService()

--- a/backend/internal/service/billing_service_tk_qianfan_test.go
+++ b/backend/internal/service/billing_service_tk_qianfan_test.go
@@ -33,6 +33,8 @@ func TestTkQianfanScopedBillingModel(t *testing.T) {
 
 	require.Equal(t, "deepseek-v4-pro.qianfan", tkQianfanScopedBillingModel("deepseek-v4-pro", qianfan))
 	require.Equal(t, "deepseek-v4-flash.qianfan", tkQianfanScopedBillingModel("deepseek-v4-flash", qianfan))
+	require.Equal(t, "glm-5.2.qianfan", tkQianfanScopedBillingModel("glm-5.2", qianfan))
+	require.Equal(t, "kimi-k2.6.qianfan", tkQianfanScopedBillingModel("kimi-k2.6", qianfan))
 	require.Equal(t, "deepseek-v4-pro", tkQianfanScopedBillingModel("deepseek-v4-pro", official))
 	require.Equal(t, "deepseek-v3.2", tkQianfanScopedBillingModel("deepseek-v3.2", qianfan))
 }

--- a/backend/internal/service/billing_service_tk_qianfan_test.go
+++ b/backend/internal/service/billing_service_tk_qianfan_test.go
@@ -51,6 +51,17 @@ func TestTkQianfanOverlay_DeepSeekV32UsesTieredIntervals(t *testing.T) {
 	require.InDelta(t, 5.970149253731343e-07, *entry.Intervals[1].InputPrice, 1e-15)
 }
 
+func TestTkQianfanOverlay_ThinkSKUUsesIntervalOutputNotFlatThinkingRate(t *testing.T) {
+	t.Parallel()
+	entry := loadTKPricingOverlay()["deepseek-v3.2-think"]
+	require.NotNil(t, entry)
+	require.Zero(t, entry.ThinkingOutputCostPerToken,
+		"dedicated think SKU with intervals must not pin a flat thinking_output rate")
+	require.Len(t, entry.Intervals, 2)
+	require.NotNil(t, entry.Intervals[1].OutputPrice)
+	require.InDelta(t, 8.955223880597015e-07, *entry.Intervals[1].OutputPrice, 1e-15)
+}
+
 func TestTkQianfanScopedBillingModel_UsesQianfanRatesInCost(t *testing.T) {
 	t.Parallel()
 	svc := newTestBillingService()

--- a/backend/internal/service/billing_service_tk_qianfan_test.go
+++ b/backend/internal/service/billing_service_tk_qianfan_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkQianfanScopedBillingModel(t *testing.T) {
+	t.Parallel()
+	qianfan := &Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeBaiduV2,
+		Credentials: map[string]any{
+			"base_url": newapiintegration.QianfanBaseURL,
+		},
+	}
+	official := &Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDeepSeek,
+		Credentials: map[string]any{
+			"base_url": "https://api.deepseek.com",
+		},
+	}
+
+	require.Equal(t, "deepseek-v4-pro.qianfan", tkQianfanScopedBillingModel("deepseek-v4-pro", qianfan))
+	require.Equal(t, "deepseek-v4-flash.qianfan", tkQianfanScopedBillingModel("deepseek-v4-flash", qianfan))
+	require.Equal(t, "deepseek-v4-pro", tkQianfanScopedBillingModel("deepseek-v4-pro", official))
+	require.Equal(t, "deepseek-v3.2", tkQianfanScopedBillingModel("deepseek-v3.2", qianfan))
+}
+
+func TestTkQianfanScopedBillingModel_UsesQianfanRatesInCost(t *testing.T) {
+	t.Parallel()
+	svc := newTestBillingService()
+	qianfan := &Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeBaiduV2,
+		Credentials: map[string]any{
+			"base_url": newapiintegration.QianfanBaseURL,
+		},
+	}
+	billingModel := tkQianfanScopedBillingModel("deepseek-v4-pro", qianfan)
+	require.Equal(t, "deepseek-v4-pro.qianfan", billingModel)
+
+	qianfanOwner := loadTKPricingOverlay()["deepseek-v4-pro.qianfan"]
+	officialOwner := loadTKPricingOverlay()["deepseek-v4-pro"]
+	require.NotNil(t, qianfanOwner)
+	require.NotNil(t, officialOwner)
+	require.Greater(t, qianfanOwner.InputCostPerToken, officialOwner.InputCostPerToken)
+	require.Greater(t, qianfanOwner.OutputCostPerToken, officialOwner.OutputCostPerToken)
+
+	pricing, err := svc.GetModelPricing(billingModel)
+	require.NoError(t, err)
+	officialPricing, err := svc.GetModelPricing("deepseek-v4-pro")
+	require.NoError(t, err)
+	require.Greater(t, pricing.InputPricePerToken, officialPricing.InputPricePerToken)
+}

--- a/backend/internal/service/billing_service_tk_qianfan_test.go
+++ b/backend/internal/service/billing_service_tk_qianfan_test.go
@@ -1,10 +1,14 @@
+//go:build unit
+
 package service
 
 import (
 	"testing"
+	"time"
 
 	newapiconstant "github.com/QuantumNous/new-api/constant"
 	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,4 +63,17 @@ func TestTkQianfanScopedBillingModel_UsesQianfanRatesInCost(t *testing.T) {
 	officialPricing, err := svc.GetModelPricing("deepseek-v4-pro")
 	require.NoError(t, err)
 	require.Greater(t, pricing.InputPricePerToken, officialPricing.InputPricePerToken)
+}
+
+func TestTkQianfanScopedBillingModel_ExcludesDeepSeekPeakValley(t *testing.T) {
+	t.Parallel()
+	policy := loadTkDeepSeekPeakValleyPolicy()
+	require.NotNil(t, policy)
+	require.False(t, tkDeepSeekPeakValleyAppliesWithPolicy(policy, "deepseek-v4-pro.qianfan", PricingSourceLiteLLM))
+
+	at := time.Date(2026, 7, 21, 10, 0, 0, 0, timezone.Location())
+	base := &ModelPricing{InputPricePerToken: 0.012, OutputPricePerToken: 0.024}
+	scaled := tkApplyDeepSeekPeakValleyPricing("deepseek-v4-pro.qianfan", base, at, PricingSourceLiteLLM)
+	require.InDelta(t, base.InputPricePerToken, scaled.InputPricePerToken, 1e-12)
+	require.InDelta(t, base.OutputPricePerToken, scaled.OutputPricePerToken, 1e-12)
 }

--- a/backend/internal/service/billing_service_tk_qianfan_test.go
+++ b/backend/internal/service/billing_service_tk_qianfan_test.go
@@ -90,6 +90,26 @@ func TestTkQianfanScopedBillingModel_UsesQianfanRatesInCost(t *testing.T) {
 	require.Greater(t, pricing.InputPricePerToken, officialPricing.InputPricePerToken)
 }
 
+func TestTkQianfanOverlay_EmbeddingModelsUseEmbeddingMode(t *testing.T) {
+	t.Parallel()
+	for _, model := range []string{
+		"bge-large-en",
+		"bge-large-zh",
+		"qwen3-embedding-0.6b",
+		"qwen3-embedding-4b",
+		"qwen3-embedding-8b",
+	} {
+		t.Run(model, func(t *testing.T) {
+			t.Parallel()
+			entry := loadTKPricingOverlay()[model]
+			require.NotNil(t, entry, model)
+			require.Equal(t, "embedding", entry.Mode)
+			require.Greater(t, entry.InputCostPerToken, 0.0)
+			require.Zero(t, entry.OutputCostPerToken)
+		})
+	}
+}
+
 func TestTkQianfanScopedBillingModel_ExcludesDeepSeekPeakValley(t *testing.T) {
 	t.Parallel()
 	policy := loadTkDeepSeekPeakValleyPolicy()

--- a/backend/internal/service/billing_service_tk_qianfan_test.go
+++ b/backend/internal/service/billing_service_tk_qianfan_test.go
@@ -76,4 +76,5 @@ func TestTkQianfanScopedBillingModel_ExcludesDeepSeekPeakValley(t *testing.T) {
 	scaled := tkApplyDeepSeekPeakValleyPricing("deepseek-v4-pro.qianfan", base, at, PricingSourceLiteLLM)
 	require.InDelta(t, base.InputPricePerToken, scaled.InputPricePerToken, 1e-12)
 	require.InDelta(t, base.OutputPricePerToken, scaled.OutputPricePerToken, 1e-12)
+	require.False(t, tkDeepSeekPeakValleyAppliesWithPolicy(policy, "deepseek-v3.2-think", PricingSourceLiteLLM))
 }

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -701,6 +701,7 @@ func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsage
 	// 通用兜底（与 OpenAI 路径的 usageBillingModelCandidates 语义对齐）：
 	// 选定模型查不到任何价格时回退到实际转发的具体模型。已定价流量不受影响。
 	billingModel = s.billableModelWithFallback(ctx, apiKey, billingModel, result.UpstreamModel, result.Model)
+	billingModel = tkQianfanScopedBillingModel(billingModel, account)
 
 	// 确定 RequestedModel（渠道映射前的原始模型）
 	requestedModel := result.Model

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -205,6 +205,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		result.UpstreamModel,
 		result.Model,
 	)
+	billingModels = tkMapQianfanScopedBillingModels(billingModels, account)
 	serviceTier := ""
 	if result.ServiceTier != nil {
 		serviceTier = strings.TrimSpace(*result.ServiceTier)

--- a/backend/internal/service/pricing_catalog_tk_test.go
+++ b/backend/internal/service/pricing_catalog_tk_test.go
@@ -220,6 +220,10 @@ func TestPricingCatalogService_AppliesTKOverlayPricing(t *testing.T) {
 	assert.Equal(t, "anthropic", opus5.Vendor)
 	assert.ElementsMatch(t, []string{"vision", "tool_use", "prompt_caching", "reasoning", "response_schema", "pdf_input"}, opus5.Capabilities)
 
+	cnyPer1K := func(cny float64) float64 {
+		return tkCNYPerMTokToUSDPerToken(cny) * 1_000
+	}
+
 	pro, ok := byID["deepseek-v4-pro"]
 	require.True(t, ok, "overlay-only deepseek-v4-pro must surface in catalog")
 	assert.InDelta(t, 0.000435*tkOfficialListBaseTaxMultiplier(), pro.Pricing.InputPer1KTokens, 1e-9, "deepseek-v4-pro input = overlay official × base tax")
@@ -229,9 +233,6 @@ func TestPricingCatalogService_AppliesTKOverlayPricing(t *testing.T) {
 	glm52, ok := byID["glm-5.2"]
 	require.True(t, ok, "BigModel GLM overlay model must surface")
 	assert.Equal(t, PlatformNewAPI, inferPlatformFromVendor(glm52.Vendor), "zhipu provider must classify as newapi")
-	cnyPer1K := func(cny float64) float64 {
-		return tkCNYPerMTokToUSDPerToken(cny) * 1_000
-	}
 	assert.InDelta(t, cnyPer1K(8)*tkOfficialListBaseTaxMultiplier(), glm52.Pricing.InputPer1KTokens, 1e-12)
 	assert.InDelta(t, cnyPer1K(28)*tkOfficialListBaseTaxMultiplier(), glm52.Pricing.OutputPer1KTokens, 1e-12)
 	assert.InDelta(t, cnyPer1K(2)*tkOfficialListBaseTaxMultiplier(), glm52.Pricing.CacheReadPer1K, 1e-12)

--- a/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
@@ -250,7 +250,7 @@ func TestEmbeddedRegistryParsesAsCompleteFloor(t *testing.T) {
 	resetPricingRegistrySnapshot(t)
 	snapshot, err := buildTKPricingOverlaySnapshot(nil)
 	require.NoError(t, err)
-	require.Len(t, snapshot.Models, 340)
+	require.Len(t, snapshot.Models, 346)
 	require.Equal(t, "embedded", snapshot.Metadata.SourceCommit)
 	require.InDelta(t, 0.01, snapshot.WebSearchPrice, 1e-15)
 	require.True(t, snapshot.Models["glm-4.5-flash"].ExplicitFree)

--- a/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_runtime_test.go
@@ -250,7 +250,7 @@ func TestEmbeddedRegistryParsesAsCompleteFloor(t *testing.T) {
 	resetPricingRegistrySnapshot(t)
 	snapshot, err := buildTKPricingOverlaySnapshot(nil)
 	require.NoError(t, err)
-	require.Len(t, snapshot.Models, 346)
+	require.Len(t, snapshot.Models, 371)
 	require.Equal(t, "embedded", snapshot.Metadata.SourceCommit)
 	require.InDelta(t, 0.01, snapshot.WebSearchPrice, 1e-15)
 	require.True(t, snapshot.Models["glm-4.5-flash"].ExplicitFree)

--- a/backend/internal/service/pricing_tk_deepseek_peak.go
+++ b/backend/internal/service/pricing_tk_deepseek_peak.go
@@ -79,6 +79,9 @@ func tkDeepSeekPeakValleyAppliesWithPolicy(policy *tkDeepSeekPeakValleyPolicy, m
 		return false
 	}
 	lower := strings.ToLower(strings.TrimSpace(model))
+	if strings.HasSuffix(lower, tkQianfanOverlayPricingSuffix) {
+		return false
+	}
 	for _, substr := range policy.ModelContains {
 		if strings.Contains(lower, substr) {
 			return true

--- a/backend/internal/service/pricing_tk_deepseek_peak.go
+++ b/backend/internal/service/pricing_tk_deepseek_peak.go
@@ -82,6 +82,9 @@ func tkDeepSeekPeakValleyAppliesWithPolicy(policy *tkDeepSeekPeakValleyPolicy, m
 	if strings.HasSuffix(lower, tkQianfanOverlayPricingSuffix) {
 		return false
 	}
+	if _, excluded := tkDeepSeekPeakValleyExcludedModels[lower]; excluded {
+		return false
+	}
 	for _, substr := range policy.ModelContains {
 		if strings.Contains(lower, substr) {
 			return true

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1366,6 +1366,71 @@
     "supports_tool_choice": true,
     "supports_vision": false
   },
+  "deepseek-v4-flash.qianfan": {
+    "litellm_provider": "deepseek",
+    "mode": "chat",
+    "input_cost_per_token": 1.492537313432836e-07,
+    "output_cost_per_token": 2.985074626865672e-07,
+    "source": "Baidu Qianfan console 按量后付费, captured 2026-08-07: DeepSeek-V4-Flash ¥0.001/¥0.002 per 1k in/out; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_function_calling": true,
+    "supports_native_streaming": true,
+    "supports_reasoning": true,
+    "supports_system_messages": true,
+    "supports_tool_choice": true,
+    "supports_vision": false
+  },
+  "deepseek-v3.2": {
+    "litellm_provider": "deepseek",
+    "mode": "chat",
+    "input_cost_per_token": 5.970149253731343e-07,
+    "output_cost_per_token": 8.955223880597015e-07,
+    "source": "Baidu Qianfan console 按量后付费, captured 2026-08-07: DeepSeek-V3.2 tiered ¥0.002–0.004 in / ¥0.003–0.006 out per 1k; overlay uses UPPER tier (¥0.004/¥0.006); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_function_calling": true,
+    "supports_native_streaming": true,
+    "supports_reasoning": false,
+    "supports_system_messages": true,
+    "supports_tool_choice": true,
+    "supports_vision": false
+  },
+  "deepseek-v3.2-think": {
+    "litellm_provider": "deepseek",
+    "mode": "chat",
+    "input_cost_per_token": 5.970149253731343e-07,
+    "output_cost_per_token": 8.955223880597015e-07,
+    "thinking_output_cost_per_token": 8.955223880597015e-07,
+    "source": "Baidu Qianfan console 按量后付费, captured 2026-08-07: DeepSeek-V3.2-Think same tier table as deepseek-v3.2; overlay uses UPPER tier; CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_function_calling": true,
+    "supports_native_streaming": true,
+    "supports_reasoning": true,
+    "supports_system_messages": true,
+    "supports_tool_choice": true,
+    "supports_vision": false
+  },
+  "deepseek-v4-flash-0731": {
+    "litellm_provider": "deepseek",
+    "mode": "chat",
+    "input_cost_per_token": 1.492537313432836e-07,
+    "output_cost_per_token": 2.985074626865672e-07,
+    "source": "Baidu Qianfan console 按量后付费, captured 2026-08-07: DeepSeek-V4-Flash-0731 ¥0.001/¥0.002 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_function_calling": true,
+    "supports_native_streaming": true,
+    "supports_reasoning": true,
+    "supports_system_messages": true,
+    "supports_tool_choice": true,
+    "supports_vision": false
+  },
   "deepseek-v4-pro": {
     "litellm_provider": "deepseek",
     "mode": "chat",
@@ -1391,6 +1456,38 @@
     "supports_system_messages": true,
     "supports_tool_choice": true,
     "supports_vision": false
+  },
+  "deepseek-v4-pro.qianfan": {
+    "litellm_provider": "deepseek",
+    "mode": "chat",
+    "input_cost_per_token": 1.791044776119403e-06,
+    "output_cost_per_token": 3.582089552238806e-06,
+    "source": "Baidu Qianfan console 按量后付费, captured 2026-08-07: DeepSeek-V4-Pro ¥0.012/¥0.024 per 1k in/out; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_function_calling": true,
+    "supports_native_streaming": true,
+    "supports_reasoning": true,
+    "supports_system_messages": true,
+    "supports_tool_choice": true,
+    "supports_vision": false
+  },
+  "ernie-4.5-turbo-vl-32k": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 4.477611940298507e-07,
+    "output_cost_per_token": 1.343283582089552e-06,
+    "source": "Baidu Qianfan console 按量后付费, captured 2026-08-07: ERNIE-4.5-Turbo-VL-32K ¥0.003/¥0.009 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_function_calling": true,
+    "supports_native_streaming": true,
+    "supports_reasoning": false,
+    "supports_system_messages": true,
+    "supports_tool_choice": true,
+    "supports_vision": true
   },
   "doubao-1-5-lite-32k-250115": {
     "litellm_provider": "volcengine",

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1417,8 +1417,7 @@
     "mode": "chat",
     "input_cost_per_token": 2.9850746268656716e-07,
     "output_cost_per_token": 4.4776119402985074e-07,
-    "thinking_output_cost_per_token": 4.4776119402985074e-07,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.002–0.004 / output ¥0.003–0.006 per 1k (tiers ≤32k/>32k); overlay intervals by input tokens; CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.002–0.004 / output ¥0.003–0.006 per 1k (tiers ≤32k/>32k); dedicated think SKU bills via interval output_cost_per_token only (no flat thinking_output); CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -9638,12 +9637,11 @@
     "mode": "chat",
     "input_cost_per_token": 8.955223880597015e-07,
     "output_cost_per_token": 3.582089552238806e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.006–0.01 / output ¥0.024–0.04 per 1k (tiers ≤32k/>32k); overlay intervals by input tokens; CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.006–0.01 / output ¥0.024–0.04 per 1k (tiers ≤32k/>32k); dedicated think SKU bills via interval output_cost_per_token only (no flat thinking_output); CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
     "supports_reasoning": true,
-    "thinking_output_cost_per_token": 3.582089552238806e-06,
     "supports_vision": true,
     "intervals": [
       {

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -9522,29 +9522,25 @@
   },
   "bge-large-en": {
     "litellm_provider": "dashscope",
-    "mode": "chat",
+    "mode": "embedding",
     "input_cost_per_token": 7.462686567164179e-08,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/1k input; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
-      "/v1/embeddings",
-      "/v1/chat/completions"
+      "/v1/embeddings"
     ],
     "supports_reasoning": false,
-    "supports_vision": false,
-    "output_cost_per_token": 7.462686567164179e-08
+    "supports_vision": false
   },
   "bge-large-zh": {
     "litellm_provider": "dashscope",
-    "mode": "chat",
+    "mode": "embedding",
     "input_cost_per_token": 7.462686567164179e-08,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/1k input; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
-      "/v1/embeddings",
-      "/v1/chat/completions"
+      "/v1/embeddings"
     ],
     "supports_reasoning": false,
-    "supports_vision": false,
-    "output_cost_per_token": 7.462686567164179e-08
+    "supports_vision": false
   },
   "deepseek-ocr": {
     "litellm_provider": "deepseek",
@@ -9734,42 +9730,36 @@
   },
   "qwen3-embedding-0.6b": {
     "litellm_provider": "dashscope",
-    "mode": "chat",
+    "mode": "embedding",
     "input_cost_per_token": 7.462686567164179e-08,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/1k input; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
-      "/v1/embeddings",
-      "/v1/chat/completions"
+      "/v1/embeddings"
     ],
     "supports_reasoning": false,
-    "supports_vision": false,
-    "output_cost_per_token": 7.462686567164179e-08
+    "supports_vision": false
   },
   "qwen3-embedding-4b": {
     "litellm_provider": "dashscope",
-    "mode": "chat",
+    "mode": "embedding",
     "input_cost_per_token": 7.462686567164179e-08,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/1k input; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
-      "/v1/embeddings",
-      "/v1/chat/completions"
+      "/v1/embeddings"
     ],
     "supports_reasoning": false,
-    "supports_vision": false,
-    "output_cost_per_token": 7.462686567164179e-08
+    "supports_vision": false
   },
   "qwen3-embedding-8b": {
     "litellm_provider": "dashscope",
-    "mode": "chat",
+    "mode": "embedding",
     "input_cost_per_token": 7.462686567164179e-08,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/1k input; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
-      "/v1/embeddings",
-      "/v1/chat/completions"
+      "/v1/embeddings"
     ],
     "supports_reasoning": false,
-    "supports_vision": false,
-    "output_cost_per_token": 7.462686567164179e-08
+    "supports_vision": false
   },
   "qwen3.5-122b-a10b": {
     "litellm_provider": "dashscope",

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -9492,5 +9492,311 @@
       }
     ],
     "default_video_resolution": "1080p"
+  },
+  "bge-large-en": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 7.462686567164179e-08,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/embeddings",
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false,
+    "output_cost_per_token": 7.462686567164179e-08
+  },
+  "bge-large-zh": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 7.462686567164179e-08,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/embeddings",
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false,
+    "output_cost_per_token": 7.462686567164179e-08
+  },
+  "deepseek-ocr": {
+    "litellm_provider": "deepseek",
+    "mode": "chat",
+    "input_cost_per_token": 4.477611940298507e-08,
+    "output_cost_per_token": 1.7910447761194027e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0003/¥0.0012 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": true
+  },
+  "ernie-4.5-turbo-128k": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 1.1940298507462688e-07,
+    "output_cost_per_token": 4.776119402985075e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0008/¥0.0032 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false
+  },
+  "ernie-4.5-turbo-20260402": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 1.1940298507462688e-07,
+    "output_cost_per_token": 4.776119402985075e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0008/¥0.0032 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false
+  },
+  "ernie-4.5-turbo-32k": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 1.1940298507462688e-07,
+    "output_cost_per_token": 4.776119402985075e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0008/¥0.0032 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false
+  },
+  "ernie-4.5-turbo-vl": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 4.4776119402985074e-07,
+    "output_cost_per_token": 1.343283582089552e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.003/¥0.009 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": true
+  },
+  "ernie-5.0": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 1.492537313432836e-06,
+    "output_cost_per_token": 5.970149253731344e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.01/¥0.04 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": true
+  },
+  "ernie-5.0-thinking-preview": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 1.492537313432836e-06,
+    "output_cost_per_token": 5.970149253731344e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.01/¥0.04 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": true,
+    "thinking_output_cost_per_token": 5.970149253731344e-06,
+    "supports_vision": true
+  },
+  "ernie-5.1": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 8.955223880597015e-07,
+    "output_cost_per_token": 3.2835820895522387e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.006/¥0.022 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false
+  },
+  "ernie-x1.1": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 1.4925373134328358e-07,
+    "output_cost_per_token": 5.970149253731343e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.001/¥0.004 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": true,
+    "supports_vision": false
+  },
+  "ernie-x1.1-preview": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 1.4925373134328358e-07,
+    "output_cost_per_token": 5.970149253731343e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.001/¥0.004 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": true,
+    "supports_vision": false
+  },
+  "internvl3-38b": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 1.1940298507462686e-06,
+    "output_cost_per_token": 3.582089552238806e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.008/¥0.024 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": true
+  },
+  "qianfan-ocr": {
+    "litellm_provider": "wenxin",
+    "mode": "chat",
+    "input_cost_per_token": 6.71641791044776e-08,
+    "output_cost_per_token": 2.686567164179104e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.00045/¥0.0018 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": true
+  },
+  "qwen3-embedding-0.6b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 7.462686567164179e-08,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/embeddings",
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false,
+    "output_cost_per_token": 7.462686567164179e-08
+  },
+  "qwen3-embedding-4b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 7.462686567164179e-08,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/embeddings",
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false,
+    "output_cost_per_token": 7.462686567164179e-08
+  },
+  "qwen3-embedding-8b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 7.462686567164179e-08,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/embeddings",
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false,
+    "output_cost_per_token": 7.462686567164179e-08
+  },
+  "qwen3.5-122b-a10b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 2.9850746268656716e-07,
+    "output_cost_per_token": 2.3880597014925373e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.002/¥0.016 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": true
+  },
+  "qwen3.5-27b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 2.686567164179104e-07,
+    "output_cost_per_token": 2.1492537313432833e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0018/¥0.0144 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": true
+  },
+  "qwen3.5-35b-a3b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 2.3880597014925377e-07,
+    "output_cost_per_token": 1.91044776119403e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0016/¥0.0128 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": true
+  },
+  "qwen3.5-397b-a17b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 4.4776119402985074e-07,
+    "output_cost_per_token": 2.686567164179104e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.003/¥0.018 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": true
+  },
+  "glm-5.qianfan": {
+    "litellm_provider": "zhipu",
+    "mode": "chat",
+    "input_cost_per_token": 8.955223880597015e-07,
+    "output_cost_per_token": 3.2835820895522387e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.006/¥0.022 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false
+  },
+  "glm-5.1.qianfan": {
+    "litellm_provider": "zhipu",
+    "mode": "chat",
+    "input_cost_per_token": 1.1940298507462686e-06,
+    "output_cost_per_token": 4.17910447761194e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.008/¥0.028 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false
+  },
+  "glm-5.2.qianfan": {
+    "litellm_provider": "zhipu",
+    "mode": "chat",
+    "input_cost_per_token": 1.1940298507462686e-06,
+    "output_cost_per_token": 4.17910447761194e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.008/¥0.028 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": false
+  },
+  "kimi-k2.6.qianfan": {
+    "litellm_provider": "moonshot",
+    "mode": "chat",
+    "input_cost_per_token": 9.701492537313432e-07,
+    "output_cost_per_token": 4.029850746268657e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0065/¥0.027 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "supports_reasoning": false,
+    "supports_vision": true
   }
 }

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1385,9 +1385,9 @@
   "deepseek-v3.2": {
     "litellm_provider": "deepseek",
     "mode": "chat",
-    "input_cost_per_token": 5.970149253731343e-07,
-    "output_cost_per_token": 8.955223880597015e-07,
-    "source": "Baidu Qianfan console 按量后付费, captured 2026-08-07: DeepSeek-V3.2 tiered ¥0.002–0.004 in / ¥0.003–0.006 out per 1k; overlay uses UPPER tier (¥0.004/¥0.006); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "input_cost_per_token": 2.9850746268656716e-07,
+    "output_cost_per_token": 4.4776119402985074e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.002–0.004 / output ¥0.003–0.006 per 1k (tiers ≤32k/>32k); overlay intervals by input tokens; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -1396,15 +1396,29 @@
     "supports_reasoning": false,
     "supports_system_messages": true,
     "supports_tool_choice": true,
-    "supports_vision": false
+    "supports_vision": false,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 32000,
+        "input_cost_per_token": 2.9850746268656716e-07,
+        "output_cost_per_token": 4.4776119402985074e-07
+      },
+      {
+        "min_tokens": 32000,
+        "max_tokens": null,
+        "input_cost_per_token": 5.970149253731343e-07,
+        "output_cost_per_token": 8.955223880597015e-07
+      }
+    ]
   },
   "deepseek-v3.2-think": {
     "litellm_provider": "deepseek",
     "mode": "chat",
-    "input_cost_per_token": 5.970149253731343e-07,
-    "output_cost_per_token": 8.955223880597015e-07,
-    "thinking_output_cost_per_token": 8.955223880597015e-07,
-    "source": "Baidu Qianfan console 按量后付费, captured 2026-08-07: DeepSeek-V3.2-Think same tier table as deepseek-v3.2; overlay uses UPPER tier; CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "input_cost_per_token": 2.9850746268656716e-07,
+    "output_cost_per_token": 4.4776119402985074e-07,
+    "thinking_output_cost_per_token": 4.4776119402985074e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.002–0.004 / output ¥0.003–0.006 per 1k (tiers ≤32k/>32k); overlay intervals by input tokens; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -1413,7 +1427,21 @@
     "supports_reasoning": true,
     "supports_system_messages": true,
     "supports_tool_choice": true,
-    "supports_vision": false
+    "supports_vision": false,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 32000,
+        "input_cost_per_token": 2.9850746268656716e-07,
+        "output_cost_per_token": 4.4776119402985074e-07
+      },
+      {
+        "min_tokens": 32000,
+        "max_tokens": null,
+        "input_cost_per_token": 5.970149253731343e-07,
+        "output_cost_per_token": 8.955223880597015e-07
+      }
+    ]
   },
   "deepseek-v4-flash-0731": {
     "litellm_provider": "deepseek",
@@ -9497,7 +9525,7 @@
     "litellm_provider": "dashscope",
     "mode": "chat",
     "input_cost_per_token": 7.462686567164179e-08,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/embeddings",
       "/v1/chat/completions"
@@ -9510,7 +9538,7 @@
     "litellm_provider": "dashscope",
     "mode": "chat",
     "input_cost_per_token": 7.462686567164179e-08,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/embeddings",
       "/v1/chat/completions"
@@ -9524,7 +9552,7 @@
     "mode": "chat",
     "input_cost_per_token": 4.477611940298507e-08,
     "output_cost_per_token": 1.7910447761194027e-07,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0003/¥0.0012 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0003/¥0.0012 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -9536,7 +9564,7 @@
     "mode": "chat",
     "input_cost_per_token": 1.1940298507462688e-07,
     "output_cost_per_token": 4.776119402985075e-07,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0008/¥0.0032 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0008/¥0.0032 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -9548,7 +9576,7 @@
     "mode": "chat",
     "input_cost_per_token": 1.1940298507462688e-07,
     "output_cost_per_token": 4.776119402985075e-07,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0008/¥0.0032 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0008/¥0.0032 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -9560,7 +9588,7 @@
     "mode": "chat",
     "input_cost_per_token": 1.1940298507462688e-07,
     "output_cost_per_token": 4.776119402985075e-07,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0008/¥0.0032 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0008/¥0.0032 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -9572,7 +9600,7 @@
     "mode": "chat",
     "input_cost_per_token": 4.4776119402985074e-07,
     "output_cost_per_token": 1.343283582089552e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.003/¥0.009 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.003/¥0.009 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -9582,46 +9610,88 @@
   "ernie-5.0": {
     "litellm_provider": "wenxin",
     "mode": "chat",
-    "input_cost_per_token": 1.492537313432836e-06,
-    "output_cost_per_token": 5.970149253731344e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.01/¥0.04 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "input_cost_per_token": 8.955223880597015e-07,
+    "output_cost_per_token": 3.582089552238806e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.006–0.01 / output ¥0.024–0.04 per 1k (tiers ≤32k/>32k); overlay intervals by input tokens; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
     "supports_reasoning": false,
-    "supports_vision": true
+    "supports_vision": true,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 32000,
+        "input_cost_per_token": 8.955223880597015e-07,
+        "output_cost_per_token": 3.582089552238806e-06
+      },
+      {
+        "min_tokens": 32000,
+        "max_tokens": null,
+        "input_cost_per_token": 1.492537313432836e-06,
+        "output_cost_per_token": 5.970149253731344e-06
+      }
+    ]
   },
   "ernie-5.0-thinking-preview": {
     "litellm_provider": "wenxin",
     "mode": "chat",
-    "input_cost_per_token": 1.492537313432836e-06,
-    "output_cost_per_token": 5.970149253731344e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.01/¥0.04 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "input_cost_per_token": 8.955223880597015e-07,
+    "output_cost_per_token": 3.582089552238806e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.006–0.01 / output ¥0.024–0.04 per 1k (tiers ≤32k/>32k); overlay intervals by input tokens; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
     "supports_reasoning": true,
-    "thinking_output_cost_per_token": 5.970149253731344e-06,
-    "supports_vision": true
+    "thinking_output_cost_per_token": 3.582089552238806e-06,
+    "supports_vision": true,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 32000,
+        "input_cost_per_token": 8.955223880597015e-07,
+        "output_cost_per_token": 3.582089552238806e-06
+      },
+      {
+        "min_tokens": 32000,
+        "max_tokens": null,
+        "input_cost_per_token": 1.492537313432836e-06,
+        "output_cost_per_token": 5.970149253731344e-06
+      }
+    ]
   },
   "ernie-5.1": {
     "litellm_provider": "wenxin",
     "mode": "chat",
-    "input_cost_per_token": 8.955223880597015e-07,
-    "output_cost_per_token": 3.2835820895522387e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.006/¥0.022 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "input_cost_per_token": 5.970149253731343e-07,
+    "output_cost_per_token": 2.686567164179104e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.004–0.006 / output ¥0.018–0.022 per 1k (tiers ≤32k/>32k); overlay intervals by input tokens; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
     "supports_reasoning": false,
-    "supports_vision": false
+    "supports_vision": false,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 32000,
+        "input_cost_per_token": 5.970149253731343e-07,
+        "output_cost_per_token": 2.686567164179104e-06
+      },
+      {
+        "min_tokens": 32000,
+        "max_tokens": null,
+        "input_cost_per_token": 8.955223880597015e-07,
+        "output_cost_per_token": 3.2835820895522387e-06
+      }
+    ]
   },
   "ernie-x1.1": {
     "litellm_provider": "wenxin",
     "mode": "chat",
     "input_cost_per_token": 1.4925373134328358e-07,
     "output_cost_per_token": 5.970149253731343e-07,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.001/¥0.004 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.001/¥0.004 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -9633,7 +9703,7 @@
     "mode": "chat",
     "input_cost_per_token": 1.4925373134328358e-07,
     "output_cost_per_token": 5.970149253731343e-07,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.001/¥0.004 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.001/¥0.004 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -9645,7 +9715,7 @@
     "mode": "chat",
     "input_cost_per_token": 1.1940298507462686e-06,
     "output_cost_per_token": 3.582089552238806e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.008/¥0.024 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.008/¥0.024 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -9657,7 +9727,7 @@
     "mode": "chat",
     "input_cost_per_token": 6.71641791044776e-08,
     "output_cost_per_token": 2.686567164179104e-07,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.00045/¥0.0018 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.00045/¥0.0018 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -9668,7 +9738,7 @@
     "litellm_provider": "dashscope",
     "mode": "chat",
     "input_cost_per_token": 7.462686567164179e-08,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/embeddings",
       "/v1/chat/completions"
@@ -9681,7 +9751,7 @@
     "litellm_provider": "dashscope",
     "mode": "chat",
     "input_cost_per_token": 7.462686567164179e-08,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/embeddings",
       "/v1/chat/completions"
@@ -9694,7 +9764,7 @@
     "litellm_provider": "dashscope",
     "mode": "chat",
     "input_cost_per_token": 7.462686567164179e-08,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0005/¥0.0005 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/embeddings",
       "/v1/chat/completions"
@@ -9706,81 +9776,165 @@
   "qwen3.5-122b-a10b": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 2.9850746268656716e-07,
-    "output_cost_per_token": 2.3880597014925373e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.002/¥0.016 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "input_cost_per_token": 1.1940298507462688e-07,
+    "output_cost_per_token": 9.55223880597015e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.0008–0.002 / output ¥0.0064–0.016 per 1k (tiers ≤128k/>128k); overlay intervals by input tokens; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
     "supports_reasoning": false,
-    "supports_vision": true
+    "supports_vision": true,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 128000,
+        "input_cost_per_token": 1.1940298507462688e-07,
+        "output_cost_per_token": 9.55223880597015e-07
+      },
+      {
+        "min_tokens": 128000,
+        "max_tokens": null,
+        "input_cost_per_token": 2.9850746268656716e-07,
+        "output_cost_per_token": 2.3880597014925373e-06
+      }
+    ]
   },
   "qwen3.5-27b": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 2.686567164179104e-07,
-    "output_cost_per_token": 2.1492537313432833e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0018/¥0.0144 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "input_cost_per_token": 8.955223880597014e-08,
+    "output_cost_per_token": 7.164179104477611e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.0006–0.0018 / output ¥0.0048–0.0144 per 1k (tiers ≤128k/>128k); overlay intervals by input tokens; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
     "supports_reasoning": false,
-    "supports_vision": true
+    "supports_vision": true,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 128000,
+        "input_cost_per_token": 8.955223880597014e-08,
+        "output_cost_per_token": 7.164179104477611e-07
+      },
+      {
+        "min_tokens": 128000,
+        "max_tokens": null,
+        "input_cost_per_token": 2.686567164179104e-07,
+        "output_cost_per_token": 2.1492537313432833e-06
+      }
+    ]
   },
   "qwen3.5-35b-a3b": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 2.3880597014925377e-07,
-    "output_cost_per_token": 1.91044776119403e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0016/¥0.0128 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "input_cost_per_token": 5.970149253731344e-08,
+    "output_cost_per_token": 4.776119402985075e-07,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.0004–0.0016 / output ¥0.0032–0.0128 per 1k (tiers ≤128k/>128k); overlay intervals by input tokens; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
     "supports_reasoning": false,
-    "supports_vision": true
+    "supports_vision": true,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 128000,
+        "input_cost_per_token": 5.970149253731344e-08,
+        "output_cost_per_token": 4.776119402985075e-07
+      },
+      {
+        "min_tokens": 128000,
+        "max_tokens": null,
+        "input_cost_per_token": 2.3880597014925377e-07,
+        "output_cost_per_token": 1.91044776119403e-06
+      }
+    ]
   },
   "qwen3.5-397b-a17b": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 4.4776119402985074e-07,
-    "output_cost_per_token": 2.686567164179104e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.003/¥0.018 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Serving via account 90 ch46 only.",
+    "input_cost_per_token": 1.7910447761194027e-07,
+    "output_cost_per_token": 1.0746268656716416e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.0012–0.003 / output ¥0.0072–0.018 per 1k (tiers ≤128k/>128k); overlay intervals by input tokens; CNY/USD=6.7. Serving via account 90 ch46 only.",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
     "supports_reasoning": false,
-    "supports_vision": true
+    "supports_vision": true,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 128000,
+        "input_cost_per_token": 1.7910447761194027e-07,
+        "output_cost_per_token": 1.0746268656716416e-06
+      },
+      {
+        "min_tokens": 128000,
+        "max_tokens": null,
+        "input_cost_per_token": 4.4776119402985074e-07,
+        "output_cost_per_token": 2.686567164179104e-06
+      }
+    ]
   },
   "glm-5.qianfan": {
     "litellm_provider": "zhipu",
     "mode": "chat",
-    "input_cost_per_token": 8.955223880597015e-07,
-    "output_cost_per_token": 3.2835820895522387e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.006/¥0.022 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
+    "input_cost_per_token": 5.970149253731343e-07,
+    "output_cost_per_token": 2.686567164179104e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.004–0.006 / output ¥0.018–0.022 per 1k (tiers ≤32k/>32k); overlay intervals by input tokens; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
     "supports_reasoning": false,
-    "supports_vision": false
+    "supports_vision": false,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 32000,
+        "input_cost_per_token": 5.970149253731343e-07,
+        "output_cost_per_token": 2.686567164179104e-06
+      },
+      {
+        "min_tokens": 32000,
+        "max_tokens": null,
+        "input_cost_per_token": 8.955223880597015e-07,
+        "output_cost_per_token": 3.2835820895522387e-06
+      }
+    ]
   },
   "glm-5.1.qianfan": {
     "litellm_provider": "zhipu",
     "mode": "chat",
-    "input_cost_per_token": 1.1940298507462686e-06,
-    "output_cost_per_token": 4.17910447761194e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.008/¥0.028 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
+    "input_cost_per_token": 8.955223880597015e-07,
+    "output_cost_per_token": 3.582089552238806e-06,
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.006–0.008 / output ¥0.024–0.028 per 1k (tiers ≤32k/>32k); overlay intervals by input tokens; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
     "supports_reasoning": false,
-    "supports_vision": false
+    "supports_vision": false,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 32000,
+        "input_cost_per_token": 8.955223880597015e-07,
+        "output_cost_per_token": 3.582089552238806e-06
+      },
+      {
+        "min_tokens": 32000,
+        "max_tokens": null,
+        "input_cost_per_token": 1.1940298507462686e-06,
+        "output_cost_per_token": 4.17910447761194e-06
+      }
+    ]
   },
   "glm-5.2.qianfan": {
     "litellm_provider": "zhipu",
     "mode": "chat",
     "input_cost_per_token": 1.1940298507462686e-06,
     "output_cost_per_token": 4.17910447761194e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.008/¥0.028 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.008/¥0.028 per 1k in/out; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],
@@ -9792,7 +9946,7 @@
     "mode": "chat",
     "input_cost_per_token": 9.701492537313432e-07,
     "output_cost_per_token": 4.029850746268657e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0065/¥0.027 per 1k in/out (upper tier when tiered); CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
+    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0065/¥0.027 per 1k in/out; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
     "supported_endpoints": [
       "/v1/chat/completions"
     ],

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -21,7 +21,8 @@
       "model_id": "deepseek-v4-pro",
       "served_on": [
         "39",
-        "88"
+        "88",
+        "90"
       ],
       "channel_type": 43,
       "account_scope": {
@@ -32,14 +33,15 @@
       "price_source": "overlay",
       "price_key": "deepseek-v4-pro",
       "display": true,
-      "notes": "ds-官 account 39. Mapped by tk_022 (identity whitelist). Priced in overlay (litellm lags V4). served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN). Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30."
+      "notes": "ds-官 account 39. Mapped by tk_022 (identity whitelist). Priced in overlay from DeepSeek official list (https://api-docs.deepseek.com/quick_start/pricing). Baidu Qianfan account 90 bills via overlay owner deepseek-v4-pro.qianfan at runtime (¥0.012/¥0.024 per 1k). served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN). Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
     },
     "newapi/deepseek-v4-flash": {
       "platform": "newapi",
       "model_id": "deepseek-v4-flash",
       "served_on": [
         "39",
-        "88"
+        "88",
+        "90"
       ],
       "channel_type": 43,
       "account_scope": {
@@ -50,7 +52,7 @@
       "price_source": "overlay",
       "price_key": "deepseek-v4-flash",
       "display": true,
-      "notes": "ds-官 account 39. Mapped by tk_022. Priced in overlay; pricing-overlay.py anchor. served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN). Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30."
+      "notes": "ds-官 account 39. Mapped by tk_022. Priced in overlay from DeepSeek official list. Baidu Qianfan account 90 bills via overlay owner deepseek-v4-flash.qianfan at runtime (¥0.001/¥0.002 per 1k). served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN). Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
     },
     "newapi/deepseek-chat": {
       "platform": "newapi",
@@ -748,7 +750,8 @@
       "served_on": [
         "60",
         "72",
-        "88"
+        "88",
+        "90"
       ],
       "channel_type": 17,
       "account_scope": {
@@ -759,7 +762,7 @@
       "price_source": "overlay",
       "price_key": "glm-5.2",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); Qianfan console confirms ¥0.008/¥0.028 per 1k in/out; probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
     },
     "newapi/glm-5.1": {
       "platform": "newapi",
@@ -974,6 +977,74 @@
       "price_key": "minimax-m3",
       "display": true,
       "notes": "VolcEngine Agent Plan account 88. Mapped by tk_068. Overlay from MiniMax official list ($0.30/$1.20 per M tokens). /api/plan/v3 responses probe 200 on 2026-07-30."
+    },
+    "newapi/ernie-4.5-turbo-vl-32k": {
+      "platform": "newapi",
+      "model_id": "ernie-4.5-turbo-vl-32k",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "ernie-4.5-turbo-vl-32k",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). Probe 200 via account 90 + china group 19 on 2026-08-07. Priced from Qianfan console ¥0.003/¥0.009 per 1k tok in/out; CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/deepseek-v4-flash-0731": {
+      "platform": "newapi",
+      "model_id": "deepseek-v4-flash-0731",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "deepseek-v4-flash-0731",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 only (dated flash SKU). Probe 200 on 2026-08-07. Qianfan ¥0.001/¥0.002 per 1k; CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/deepseek-v3.2": {
+      "platform": "newapi",
+      "model_id": "deepseek-v3.2",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "deepseek-v3.2",
+      "display": true,
+      "notes": "Baidu Qianfan account 90. Probe 200 on 2026-08-07. Qianfan tiered ¥0.002–0.004 in / ¥0.003–0.006 out per 1k; overlay uses UPPER tier pending tiered billing support. served-via-modelops-activation."
+    },
+    "newapi/deepseek-v3.2-think": {
+      "platform": "newapi",
+      "model_id": "deepseek-v3.2-think",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "deepseek-v3.2-think",
+      "display": true,
+      "notes": "Baidu Qianfan account 90. Probe 200 on 2026-08-07 (reasoning path). Same Qianfan tier table as deepseek-v3.2; overlay uses upper tier + thinking_output_cost_per_token. served-via-modelops-activation."
     }
   }
 }

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -95,7 +95,8 @@
       "model_id": "kimi-k2.6",
       "served_on": [
         "83",
-        "88"
+        "88",
+        "90"
       ],
       "channel_type": 25,
       "account_scope": {
@@ -106,7 +107,7 @@
       "price_source": "overlay",
       "price_key": "kimi-k2.6",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20. Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30."
+      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20. Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
     },
     "newapi/kimi-k2.7-code": {
       "platform": "newapi",
@@ -769,26 +770,28 @@
       "model_id": "glm-5.1",
       "served_on": [
         "60",
-        "72"
+        "72",
+        "90"
       ],
       "channel_type": 17,
       "price_source": "overlay",
       "price_key": "glm-5.1",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time)."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
     },
     "newapi/glm-5": {
       "platform": "newapi",
       "model_id": "glm-5",
       "served_on": [
         "60",
-        "72"
+        "72",
+        "90"
       ],
       "channel_type": 17,
       "price_source": "overlay",
       "price_key": "glm-5",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time)."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
     },
     "newapi/glm-4.7": {
       "platform": "newapi",
@@ -1045,6 +1048,363 @@
       "price_key": "deepseek-v3.2-think",
       "display": true,
       "notes": "Baidu Qianfan account 90. Probe 200 on 2026-08-07 (reasoning path). Same Qianfan tier table as deepseek-v3.2; overlay uses upper tier + thinking_output_cost_per_token. served-via-modelops-activation."
+    },
+    "newapi/bge-large-en": {
+      "platform": "newapi",
+      "model_id": "bge-large-en",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "bge-large-en",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/bge-large-zh": {
+      "platform": "newapi",
+      "model_id": "bge-large-zh",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "bge-large-zh",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/deepseek-ocr": {
+      "platform": "newapi",
+      "model_id": "deepseek-ocr",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "deepseek-ocr",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/ernie-4.5-turbo-128k": {
+      "platform": "newapi",
+      "model_id": "ernie-4.5-turbo-128k",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "ernie-4.5-turbo-128k",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/ernie-4.5-turbo-20260402": {
+      "platform": "newapi",
+      "model_id": "ernie-4.5-turbo-20260402",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "ernie-4.5-turbo-20260402",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/ernie-4.5-turbo-32k": {
+      "platform": "newapi",
+      "model_id": "ernie-4.5-turbo-32k",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "ernie-4.5-turbo-32k",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/ernie-4.5-turbo-vl": {
+      "platform": "newapi",
+      "model_id": "ernie-4.5-turbo-vl",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "ernie-4.5-turbo-vl",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/ernie-5.0": {
+      "platform": "newapi",
+      "model_id": "ernie-5.0",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "ernie-5.0",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/ernie-5.0-thinking-preview": {
+      "platform": "newapi",
+      "model_id": "ernie-5.0-thinking-preview",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "ernie-5.0-thinking-preview",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/ernie-5.1": {
+      "platform": "newapi",
+      "model_id": "ernie-5.1",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "ernie-5.1",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/ernie-x1.1": {
+      "platform": "newapi",
+      "model_id": "ernie-x1.1",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "ernie-x1.1",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/ernie-x1.1-preview": {
+      "platform": "newapi",
+      "model_id": "ernie-x1.1-preview",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "ernie-x1.1-preview",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/internvl3-38b": {
+      "platform": "newapi",
+      "model_id": "internvl3-38b",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "internvl3-38b",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/qianfan-ocr": {
+      "platform": "newapi",
+      "model_id": "qianfan-ocr",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "qianfan-ocr",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/qwen3-embedding-0.6b": {
+      "platform": "newapi",
+      "model_id": "qwen3-embedding-0.6b",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "qwen3-embedding-0.6b",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/qwen3-embedding-4b": {
+      "platform": "newapi",
+      "model_id": "qwen3-embedding-4b",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "qwen3-embedding-4b",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/qwen3-embedding-8b": {
+      "platform": "newapi",
+      "model_id": "qwen3-embedding-8b",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "qwen3-embedding-8b",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/qwen3.5-122b-a10b": {
+      "platform": "newapi",
+      "model_id": "qwen3.5-122b-a10b",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "qwen3.5-122b-a10b",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/qwen3.5-27b": {
+      "platform": "newapi",
+      "model_id": "qwen3.5-27b",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "qwen3.5-27b",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/qwen3.5-35b-a3b": {
+      "platform": "newapi",
+      "model_id": "qwen3.5-35b-a3b",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "qwen3.5-35b-a3b",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+    },
+    "newapi/qwen3.5-397b-a17b": {
+      "platform": "newapi",
+      "model_id": "qwen3.5-397b-a17b",
+      "served_on": [
+        "90"
+      ],
+      "channel_type": 46,
+      "account_scope": {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com"
+      },
+      "price_source": "overlay",
+      "price_key": "qwen3.5-397b-a17b",
+      "display": true,
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
     }
   }
 }

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -1030,7 +1030,7 @@
       "price_source": "overlay",
       "price_key": "deepseek-v3.2",
       "display": true,
-      "notes": "Baidu Qianfan account 90. Probe 200 on 2026-08-07. Qianfan tiered ¥0.002–0.004 in / ¥0.003–0.006 out per 1k; overlay uses UPPER tier pending tiered billing support. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90. Probe 200 on 2026-08-07. Qianfan tiered ¥0.002–0.004 in / ¥0.003–0.006 out per 1k; overlay intervals from GET /v2/models tier table. served-via-modelops-activation."
     },
     "newapi/deepseek-v3.2-think": {
       "platform": "newapi",
@@ -1047,7 +1047,7 @@
       "price_source": "overlay",
       "price_key": "deepseek-v3.2-think",
       "display": true,
-      "notes": "Baidu Qianfan account 90. Probe 200 on 2026-08-07 (reasoning path). Same Qianfan tier table as deepseek-v3.2; overlay uses upper tier + thinking_output_cost_per_token. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90. Probe 200 on 2026-08-07 (reasoning path). Same Qianfan tier table as deepseek-v3.2; overlay intervals + thinking_output_cost_per_token from GET /v2/models tier table. served-via-modelops-activation."
     },
     "newapi/bge-large-en": {
       "platform": "newapi",
@@ -1064,7 +1064,7 @@
       "price_source": "overlay",
       "price_key": "bge-large-en",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/bge-large-zh": {
       "platform": "newapi",
@@ -1081,7 +1081,7 @@
       "price_source": "overlay",
       "price_key": "bge-large-zh",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/deepseek-ocr": {
       "platform": "newapi",
@@ -1098,7 +1098,7 @@
       "price_source": "overlay",
       "price_key": "deepseek-ocr",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/ernie-4.5-turbo-128k": {
       "platform": "newapi",
@@ -1115,7 +1115,7 @@
       "price_source": "overlay",
       "price_key": "ernie-4.5-turbo-128k",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/ernie-4.5-turbo-20260402": {
       "platform": "newapi",
@@ -1132,7 +1132,7 @@
       "price_source": "overlay",
       "price_key": "ernie-4.5-turbo-20260402",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/ernie-4.5-turbo-32k": {
       "platform": "newapi",
@@ -1149,7 +1149,7 @@
       "price_source": "overlay",
       "price_key": "ernie-4.5-turbo-32k",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/ernie-4.5-turbo-vl": {
       "platform": "newapi",
@@ -1166,7 +1166,7 @@
       "price_source": "overlay",
       "price_key": "ernie-4.5-turbo-vl",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/ernie-5.0": {
       "platform": "newapi",
@@ -1183,7 +1183,7 @@
       "price_source": "overlay",
       "price_key": "ernie-5.0",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/ernie-5.0-thinking-preview": {
       "platform": "newapi",
@@ -1200,7 +1200,7 @@
       "price_source": "overlay",
       "price_key": "ernie-5.0-thinking-preview",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/ernie-5.1": {
       "platform": "newapi",
@@ -1217,7 +1217,7 @@
       "price_source": "overlay",
       "price_key": "ernie-5.1",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/ernie-x1.1": {
       "platform": "newapi",
@@ -1234,7 +1234,7 @@
       "price_source": "overlay",
       "price_key": "ernie-x1.1",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/ernie-x1.1-preview": {
       "platform": "newapi",
@@ -1251,7 +1251,7 @@
       "price_source": "overlay",
       "price_key": "ernie-x1.1-preview",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/internvl3-38b": {
       "platform": "newapi",
@@ -1268,7 +1268,7 @@
       "price_source": "overlay",
       "price_key": "internvl3-38b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/qianfan-ocr": {
       "platform": "newapi",
@@ -1285,7 +1285,7 @@
       "price_source": "overlay",
       "price_key": "qianfan-ocr",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/qwen3-embedding-0.6b": {
       "platform": "newapi",
@@ -1302,7 +1302,7 @@
       "price_source": "overlay",
       "price_key": "qwen3-embedding-0.6b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/qwen3-embedding-4b": {
       "platform": "newapi",
@@ -1319,7 +1319,7 @@
       "price_source": "overlay",
       "price_key": "qwen3-embedding-4b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/qwen3-embedding-8b": {
       "platform": "newapi",
@@ -1336,7 +1336,7 @@
       "price_source": "overlay",
       "price_key": "qwen3-embedding-8b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/qwen3.5-122b-a10b": {
       "platform": "newapi",
@@ -1353,7 +1353,7 @@
       "price_source": "overlay",
       "price_key": "qwen3.5-122b-a10b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/qwen3.5-27b": {
       "platform": "newapi",
@@ -1370,7 +1370,7 @@
       "price_source": "overlay",
       "price_key": "qwen3.5-27b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/qwen3.5-35b-a3b": {
       "platform": "newapi",
@@ -1387,7 +1387,7 @@
       "price_source": "overlay",
       "price_key": "qwen3.5-35b-a3b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     },
     "newapi/qwen3.5-397b-a17b": {
       "platform": "newapi",
@@ -1404,7 +1404,7 @@
       "price_source": "overlay",
       "price_key": "qwen3.5-397b-a17b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing (upper tier when tiered); CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
     }
   }
 }

--- a/backend/internal/service/tk_served_models_manifest_tk.go
+++ b/backend/internal/service/tk_served_models_manifest_tk.go
@@ -228,7 +228,10 @@ func tkServedModelsManifestDisplayPresetIDsForSelector(platform string, channelT
 var qianfanSharedManifestModelIDs = []string{
 	"deepseek-v4-pro",
 	"deepseek-v4-flash",
+	"glm-5",
+	"glm-5.1",
 	"glm-5.2",
+	"kimi-k2.6",
 }
 
 func newAPIQianfanModelMappingPresetIDs() []string {

--- a/backend/internal/service/tk_served_models_manifest_tk.go
+++ b/backend/internal/service/tk_served_models_manifest_tk.go
@@ -95,7 +95,7 @@ func loadTkServedModelsManifest() {
 					}
 					displayByScope[scope][e.ModelID] = struct{}{}
 				}
-				if manifestEntryIsAgentPlanOnly(e) {
+				if manifestEntryIsAgentPlanOnly(e) || manifestEntryIsQianfanScopedOnly(e) {
 					continue
 				}
 			}
@@ -162,17 +162,34 @@ func manifestEntryIsAgentPlanOnly(e tkServedModelsManifestEntry) bool {
 		newapiintegration.IsVolcEngineAgentPlanBaseURL(e.AccountScope.ChannelType, e.AccountScope.BaseURL)
 }
 
+func manifestEntryIsQianfanScopedOnly(e tkServedModelsManifestEntry) bool {
+	return strings.EqualFold(strings.TrimSpace(e.Platform), PlatformNewAPI) &&
+		e.AccountScope != nil &&
+		e.ChannelType == e.AccountScope.ChannelType &&
+		e.ChannelType == newapiconstant.ChannelTypeBaiduV2 &&
+		newapiintegration.IsQianfanBaseURL(e.AccountScope.ChannelType, e.AccountScope.BaseURL)
+}
+
 func manifestEntryScopeKey(e tkServedModelsManifestEntry) string {
 	if e.AccountScope == nil ||
-		!strings.EqualFold(strings.TrimSpace(e.AccountScope.Platform), PlatformNewAPI) ||
-		!newapiintegration.IsVolcEngineAgentPlanBaseURL(e.AccountScope.ChannelType, e.AccountScope.BaseURL) {
+		!strings.EqualFold(strings.TrimSpace(e.AccountScope.Platform), PlatformNewAPI) {
 		return ""
 	}
-	return normalizeAccountModelMappingOverrideScope(
-		e.AccountScope.Platform,
-		e.AccountScope.ChannelType,
-		e.AccountScope.BaseURL,
-	)
+	if newapiintegration.IsVolcEngineAgentPlanBaseURL(e.AccountScope.ChannelType, e.AccountScope.BaseURL) {
+		return normalizeAccountModelMappingOverrideScope(
+			e.AccountScope.Platform,
+			e.AccountScope.ChannelType,
+			e.AccountScope.BaseURL,
+		)
+	}
+	if newapiintegration.IsQianfanBaseURL(e.AccountScope.ChannelType, e.AccountScope.BaseURL) {
+		return normalizeAccountModelMappingOverrideScope(
+			e.AccountScope.Platform,
+			e.AccountScope.ChannelType,
+			e.AccountScope.BaseURL,
+		)
+	}
+	return ""
 }
 
 func normalizeAccountModelMappingOverrideScope(platform string, channelType int, baseURL string) string {
@@ -203,6 +220,67 @@ func tkServedModelsManifestDisplayPresetIDsForSelector(platform string, channelT
 	}
 	out := make([]string, len(ids))
 	copy(out, ids)
+	return out
+}
+
+// qianfanSharedManifestModelIDs lists manifest rows also served on Baidu Qianfan
+// account 90 but indexed under other channel_type keys (manifest forbids duplicate model_id).
+var qianfanSharedManifestModelIDs = []string{
+	"deepseek-v4-pro",
+	"deepseek-v4-flash",
+	"glm-5.2",
+}
+
+func newAPIQianfanModelMappingPresetIDs() []string {
+	scoped := tkServedModelsManifestPresetIDsForSelector(
+		PlatformNewAPI,
+		newapiconstant.ChannelTypeBaiduV2,
+		newapiintegration.QianfanBaseURL,
+	)
+	return mergeSortedManifestModelIDs(scoped, qianfanSharedManifestModelIDs)
+}
+
+func newAPIQianfanModelDisplayPresetIDs() []string {
+	scoped := tkServedModelsManifestDisplayPresetIDsForSelector(
+		PlatformNewAPI,
+		newapiconstant.ChannelTypeBaiduV2,
+		newapiintegration.QianfanBaseURL,
+	)
+	return mergeSortedManifestModelIDs(scoped, qianfanSharedManifestModelIDs)
+}
+
+func mergeSortedManifestModelIDs(primary, extra []string) []string {
+	if len(primary) == 0 && len(extra) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(primary)+len(extra))
+	out := make([]string, 0, len(primary)+len(extra))
+	for _, id := range primary {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	for _, id := range extra {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/backend/internal/service/tk_served_models_manifest_tk_test.go
+++ b/backend/internal/service/tk_served_models_manifest_tk_test.go
@@ -147,7 +147,13 @@ func loadTkServedModelsOwnerProjectionForTest(t *testing.T) tkServedModelsOwnerP
 				out.displayIDsByScope[scope] = append(out.displayIDsByScope[scope], entry.ModelID)
 			}
 		}
-		if manifestEntryIsAgentPlanOnlyForTest(entry) {
+		if qScope := qianfanScopeKeyForTest(entry); qScope != "" {
+			out.IDsByScope[qScope] = append(out.IDsByScope[qScope], entry.ModelID)
+			if entry.Display {
+				out.displayIDsByScope[qScope] = append(out.displayIDsByScope[qScope], entry.ModelID)
+			}
+		}
+		if manifestEntryIsAgentPlanOnlyForTest(entry) || manifestEntryIsQianfanScopedOnlyForTest(entry) {
 			continue
 		}
 		out.IDsByChannel[entry.ChannelType] = append(out.IDsByChannel[entry.ChannelType], entry.ModelID)
@@ -179,7 +185,15 @@ func loadTkServedModelsOwnerProjectionForTest(t *testing.T) tkServedModelsOwnerP
 func manifestEntryIsAgentPlanOnlyForTest(entry tkServedModelsOwnerEntryForTest) bool {
 	return entry.AccountScope != nil &&
 		entry.ChannelType == entry.AccountScope.ChannelType &&
+		entry.ChannelType == 45 &&
 		manifestScopeKeyForTest(entry) != ""
+}
+
+func manifestEntryIsQianfanScopedOnlyForTest(entry tkServedModelsOwnerEntryForTest) bool {
+	return entry.AccountScope != nil &&
+		entry.ChannelType == entry.AccountScope.ChannelType &&
+		entry.ChannelType == 46 &&
+		qianfanScopeKeyForTest(entry) != ""
 }
 
 func manifestScopeKeyForTest(entry tkServedModelsOwnerEntryForTest) string {
@@ -192,6 +206,18 @@ func manifestScopeKeyForTest(entry tkServedModelsOwnerEntryForTest) string {
 		return ""
 	}
 	return "newapi:45:" + baseURL
+}
+
+func qianfanScopeKeyForTest(entry tkServedModelsOwnerEntryForTest) string {
+	if entry.AccountScope == nil {
+		return ""
+	}
+	baseURL := strings.TrimRight(strings.ToLower(strings.TrimSpace(entry.AccountScope.BaseURL)), "/")
+	if strings.ToLower(strings.TrimSpace(entry.AccountScope.Platform)) != "newapi" ||
+		entry.AccountScope.ChannelType != 46 || baseURL != "https://qianfan.baidubce.com" {
+		return ""
+	}
+	return "newapi:46:" + baseURL
 }
 
 func requireServedManifestProjectionEqualForTest(t *testing.T, name string, want, got any) {

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "floor_sha256": "70c40f4d42e0a126426fc98f800d4eb8301e64485b81faca7497a4df54b4721c",
+  "floor_sha256": "67349952acd4e382e8338dddbaf84ec699e40bf4232360ea9f6f2cebb9ac7c8f",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -233,13 +233,37 @@
         "channel_type": 46,
         "base_url": "https://qianfan.baidubce.com",
         "model_mapping": {
+          "bge-large-en": "bge-large-en",
+          "bge-large-zh": "bge-large-zh",
+          "deepseek-ocr": "deepseek-ocr",
           "deepseek-v3.2": "deepseek-v3.2",
           "deepseek-v3.2-think": "deepseek-v3.2-think",
           "deepseek-v4-flash": "deepseek-v4-flash",
           "deepseek-v4-flash-0731": "deepseek-v4-flash-0731",
           "deepseek-v4-pro": "deepseek-v4-pro",
+          "ernie-4.5-turbo-128k": "ernie-4.5-turbo-128k",
+          "ernie-4.5-turbo-20260402": "ernie-4.5-turbo-20260402",
+          "ernie-4.5-turbo-32k": "ernie-4.5-turbo-32k",
+          "ernie-4.5-turbo-vl": "ernie-4.5-turbo-vl",
           "ernie-4.5-turbo-vl-32k": "ernie-4.5-turbo-vl-32k",
-          "glm-5.2": "glm-5.2"
+          "ernie-5.0": "ernie-5.0",
+          "ernie-5.0-thinking-preview": "ernie-5.0-thinking-preview",
+          "ernie-5.1": "ernie-5.1",
+          "ernie-x1.1": "ernie-x1.1",
+          "ernie-x1.1-preview": "ernie-x1.1-preview",
+          "glm-5": "glm-5",
+          "glm-5.1": "glm-5.1",
+          "glm-5.2": "glm-5.2",
+          "internvl3-38b": "internvl3-38b",
+          "kimi-k2.6": "kimi-k2.6",
+          "qianfan-ocr": "qianfan-ocr",
+          "qwen3-embedding-0.6b": "qwen3-embedding-0.6b",
+          "qwen3-embedding-4b": "qwen3-embedding-4b",
+          "qwen3-embedding-8b": "qwen3-embedding-8b",
+          "qwen3.5-122b-a10b": "qwen3.5-122b-a10b",
+          "qwen3.5-27b": "qwen3.5-27b",
+          "qwen3.5-35b-a3b": "qwen3.5-35b-a3b",
+          "qwen3.5-397b-a17b": "qwen3.5-397b-a17b"
         }
       }
     ],

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "floor_sha256": "317dd23f2bdd0c4c041b0bb2d8f45d9986aa121621d8b5ab96735b9d687d3521",
+  "floor_sha256": "70c40f4d42e0a126426fc98f800d4eb8301e64485b81faca7497a4df54b4721c",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -226,6 +226,20 @@
           "kimi-k3": "kimi-k3",
           "minimax-m2.7": "minimax-m2.7",
           "minimax-m3": "minimax-m3"
+        }
+      },
+      {
+        "platform": "newapi",
+        "channel_type": 46,
+        "base_url": "https://qianfan.baidubce.com",
+        "model_mapping": {
+          "deepseek-v3.2": "deepseek-v3.2",
+          "deepseek-v3.2-think": "deepseek-v3.2-think",
+          "deepseek-v4-flash": "deepseek-v4-flash",
+          "deepseek-v4-flash-0731": "deepseek-v4-flash-0731",
+          "deepseek-v4-pro": "deepseek-v4-pro",
+          "ernie-4.5-turbo-vl-32k": "ernie-4.5-turbo-vl-32k",
+          "glm-5.2": "glm-5.2"
         }
       }
     ],

--- a/scripts/checks/catalog-serving-drift.py
+++ b/scripts/checks/catalog-serving-drift.py
@@ -59,6 +59,7 @@ MIGRATION_GLOB = "tk_*.sql"
 # Price mode -> the field(s) that MUST be > 0 for that mode (mirrors pricing-overlay.py
 # MODE_FIELDS so the overlay arm of A1 is byte-identical to a check already green).
 MODE_FIELDS = {
+    "embedding": ("input_cost_per_token",),
     "image_generation": ("output_cost_per_image",),
     "video_generation": ("output_cost_per_second",),
     "chat": ("input_cost_per_token", "output_cost_per_token"),
@@ -342,6 +343,16 @@ def _selftest() -> int:
             "input_cost_per_token": 1e-7,
             "output_cost_per_token": 2e-7,
         },
+        "good-embedding": {
+            "litellm_provider": "dashscope",
+            "mode": "embedding",
+            "input_cost_per_token": 1e-7,
+        },
+        "zero-embedding": {
+            "litellm_provider": "dashscope",
+            "mode": "embedding",
+            "input_cost_per_token": 0,
+        },
     }
     allowlist = {"anthropic": {"claude-opus-4-8"}, "openai": set(), "gemini": set(),
                  "antigravity": set()}
@@ -419,6 +430,20 @@ def _selftest() -> int:
     }})
     if not any("requires" in e and "> 0" in e for e in errs):
         failures.append("A1: $0 overlay price not flagged")
+    errs, _ = run({"newapi/emb": {
+        "platform": "newapi", "model_id": "good-embedding", "served_on": ["60"],
+        "channel_type": 46, "price_source": "overlay", "price_key": "good-embedding",
+        "display": False, "notes": "served-via-admin-ui",
+    }})
+    if errs:
+        failures.append(f"A1: valid embedding overlay flagged: {errs}")
+    errs, _ = run({"newapi/zero-emb": {
+        "platform": "newapi", "model_id": "zero-embedding", "served_on": ["60"],
+        "channel_type": 46, "price_source": "overlay", "price_key": "zero-embedding",
+        "display": False, "notes": "served-via-admin-ui",
+    }})
+    if not any("requires" in e and "> 0" in e for e in errs):
+        failures.append("A1: $0 embedding overlay price not flagged")
     # External mirrors are evidence only and cannot satisfy the runtime price gate.
     errs, _ = run({"newapi/mirror": {
         "platform": "newapi", "model_id": "good-chat", "served_on": ["60"],

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2723,9 +2723,42 @@
       "path": "backend/internal/service/openai_gateway_usage.go",
       "must_contain": [
         "isOpenAIVideoUsageResult(result)",
-        "tkTryCalculateOpenAIVideoUsageCost"
+        "tkTryCalculateOpenAIVideoUsageCost",
+        "tkMapQianfanScopedBillingModels(billingModels, account)"
       ],
-      "rationale": "Injection wiring from upstream-owned RecordUsage/calculateOpenAIRecordUsageCost into the TK video settlement companion. An upstream merge reverting these call sites leaves VideoSubmit billing on the token path again even if the companion file survives."
+      "rationale": "Injection wiring from upstream-owned RecordUsage/calculateOpenAIRecordUsageCost into TK settlement companions. VideoSubmit billing must stay on the video path; Qianfan account 90 must remap shared DeepSeek overlay ids to .qianfan billing owners before candidate resolution."
+    },
+    {
+      "path": "backend/internal/service/gateway_usage_billing.go",
+      "must_contain": [
+        "tkQianfanScopedBillingModel(billingModel, account)"
+      ],
+      "rationale": "Anthropic/generic RecordUsage funnel must switch shared DeepSeek models to .qianfan overlay owners when served from Baidu Qianfan account 90; dropping the call site restores official DeepSeek list pricing on a Qianfan channel."
+    },
+    {
+      "path": "backend/internal/service/billing_service_tk_qianfan.go",
+      "must_contain": [
+        "tkQianfanScopedBillingModel",
+        "tkMapQianfanScopedBillingModels",
+        "tkQianfanOverlayPricingSuffix"
+      ],
+      "rationale": "Per-account Qianfan billing key remap for deepseek-v4-pro/flash while public catalog keeps global DeepSeek owners. Companion isolates upstream gateway insertions to one-liners."
+    },
+    {
+      "path": "backend/internal/service/billing_service_tk_qianfan_test.go",
+      "must_contain": [
+        "TestTkQianfanScopedBillingModel_UsesQianfanRatesInCost",
+        "TestTkQianfanScopedBillingModel_ExcludesDeepSeekPeakValley"
+      ],
+      "rationale": "Focused regressions: Qianfan account remap and guard against applying DeepSeek official peak-valley multiplier to .qianfan overlay billing keys."
+    },
+    {
+      "path": "backend/internal/service/account_model_mapping_preset_tk_qianfan_test.go",
+      "must_contain": [
+        "TestNewAPIModelMappingPresetIDsForQianfanAccount",
+        "TestAccountModelMappingFloorForOpsIncludesQianfanOverride"
+      ],
+      "rationale": "Manifest preset and bundle floor export for Qianfan account 90; prevents upstream merge from dropping the seven-model identity mapping floor."
     },
     {
       "path": "backend/internal/service/openai_gateway_usage_tk_video_billing_test.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2758,7 +2758,7 @@
         "TestNewAPIModelMappingPresetIDsForQianfanAccount",
         "TestAccountModelMappingFloorForOpsIncludesQianfanOverride"
       ],
-      "rationale": "Manifest preset and bundle floor export for Qianfan account 90; prevents upstream merge from dropping the seven-model identity mapping floor."
+      "rationale": "Manifest preset and bundle floor export for Qianfan account 90; prevents upstream merge from dropping the v2-servable identity mapping floor (31 models as of 2026-08-07)."
     },
     {
       "path": "backend/internal/service/openai_gateway_usage_tk_video_billing_test.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -621,6 +621,21 @@
       "rationale": "Agent Plan base-url detection for VolcEngine ch45 accounts using /api/plan/v3 instead of pay-as-you-go /api/v3. Without it admin probes and preset selection fall back to wrong upstream paths (404 InvalidEndpointOrModel)."
     },
     {
+      "path": "backend/internal/integration/newapi/qianfan.go",
+      "must_contain": [
+        "QianfanBaseURL",
+        "IsQianfanBaseURL"
+      ],
+      "rationale": "Baidu Qianfan v2 base-url detection for ch46 accounts. Without it manifest scope, model-mapping preset, and per-account Qianfan billing keys cannot distinguish account 90 from other BaiduV2 channels."
+    },
+    {
+      "path": "backend/internal/integration/newapi/qianfan_test.go",
+      "must_contain": [
+        "TestIsQianfanBaseURL"
+      ],
+      "rationale": "Regression for Qianfan base-url normalization and channel-type guard; prevents silent misrouting when credentials omit or suffix the /v2 path."
+    },
+    {
       "path": "backend/internal/integration/newapi/ark_channel_base_url.go",
       "must_contain": [
         "VolcEngineAgentPlanBaseKey",
@@ -649,9 +664,11 @@
       "must_contain": [
         "tkServedModelsManifestPresetIDsForSelector",
         "tkServedModelsManifestDisplayPresetIDsForSelector",
-        "account_scope"
+        "account_scope",
+        "manifestEntryIsQianfanScopedOnly",
+        "newAPIQianfanModelMappingPresetIDs"
       ],
-      "rationale": "Property-scoped manifest projections keep Agent Plan user menus aligned with platform/channel/base_url while served_on remains evidence only, even when canonical channel_type values describe another upstream adaptor."
+      "rationale": "Property-scoped manifest projections keep Agent Plan and Qianfan user menus aligned with platform/channel/base_url while served_on remains evidence only, even when canonical channel_type values describe another upstream adaptor."
     },
     {
       "path": "backend/internal/handler/admin/account_handler_tk_volcagentplan.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -152,9 +152,11 @@
       "must_contain": [
         "RunEmbeddingRelay",
         "runVertexEmbeddingRelay",
-        "ChannelTypeVertexAi"
+        "ChannelTypeVertexAi",
+        "runQianfanEmbeddingRelay",
+        "ChannelTypeBaiduV2"
       ],
-      "rationale": "Bridge for POST /v1/embeddings on the newapi fifth platform. RunEmbeddingRelay must delegate channel_type 41 (Vertex SA) to runVertexEmbeddingRelay because upstream new-api's vertex adaptor leaves ConvertEmbeddingRequest unimplemented; dropping the injection line silently regresses every Vertex embedding request back to not implemented."
+      "rationale": "Bridge for POST /v1/embeddings on the newapi fifth platform. RunEmbeddingRelay must delegate channel_type 41 (Vertex SA) to runVertexEmbeddingRelay and channel_type 46 (Baidu Qianfan v2) to runQianfanEmbeddingRelay because upstream new-api adaptors leave ConvertEmbeddingRequest unimplemented; dropping either injection line silently regresses those embedding requests back to not implemented."
     },
     {
       "path": "backend/internal/relay/bridge/embedding_relay_tk_vertex.go",
@@ -179,6 +181,22 @@
         "TestDispatchEmbeddings_VertexPredict_OK"
       ],
       "rationale": "Focused bridge regressions for Vertex embedding request shaping, empty-prediction rejection, and DispatchEmbeddings end-to-end wiring through the ch41 companion path."
+    },
+    {
+      "path": "backend/internal/relay/bridge/embedding_relay_tk_qianfan.go",
+      "must_contain": [
+        "runQianfanEmbeddingRelay",
+        "ChannelTypeBaiduV2",
+        "runAdaptorEmbeddingRelay"
+      ],
+      "rationale": "TK companion that pass-through relays OpenAI /v1/embeddings to Baidu Qianfan /v2/embeddings for channel_type 46. Upstream baidu_v2.ConvertEmbeddingRequest is unimplemented even though GetRequestURL targets /v2/embeddings."
+    },
+    {
+      "path": "backend/internal/relay/bridge/embedding_relay_tk_qianfan_test.go",
+      "must_contain": [
+        "TestDispatchEmbeddings_QianfanV2_OK"
+      ],
+      "rationale": "Focused bridge regression for Qianfan embedding dispatch: upstream path /v2/embeddings, auth header, and OpenAI-shaped response + usage."
     },
     {
       "path": "backend/internal/server/routes/gateway_test.go",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -314,6 +314,7 @@
         "\"served_on\"",
         "\"display\"",
         "account 88",
+        "account 90",
         "served-via-modelops-activation"
       ],
       "rationale": "The served-models MANIFEST is the single declarative intent source consumed by the drift guard, onboarding skill, display projections, and generated account-mapping bundle. Pinning the schema keys plus the modelops activation declaration prevents an upstream merge from truncating the manifest or reverting new mapping floors to generic-deploy migrations while leaving compile/tests superficially green. Co-located with the overlay so the same preflight parses price and serving intent."


### PR DESCRIPTION
## 摘要

- 对账号 90 上游 `GET /v2/models` 全量逐模型探测：31 个 v2 可服务模型纳入 SSOT（manifest + overlay + bundle floor）。
- 9 个 OCR/VL 带图探测：7 个 servable；`paddleocr-vl-0.9b` / `pp-structurev3` / `qwen-image*` 未纳入。
- 阶梯价模型 overlay 使用 **intervals** 映射千帆 API tier（32k/128k 分界）；think SKU 移除冲突的 flat `thinking_output_cost_per_token`。
- 5 个 embedding 模型恢复 `mode: embedding`；ch46 bridge 补 `runQianfanEmbeddingRelay`（upstream `ConvertEmbeddingRequest` 未实现）。

## 风险

- 常规风险：merge + deploy 后须 `modelops activate` 写 live `model_mapping` 后公开 catalog 才生效。
- `ssot-delta-gate` CI 用 `--skip-live`；31 个模型 merge 后须补 live proof。

## 验证

- `./scripts/preflight.sh` PASS
- `python3 scripts/checks/catalog-serving-drift.py` + `pricing-overlay.py --quiet` PASS
- `go test -tags=unit ./internal/service/... -run 'Qianfan'` PASS
- `go test -tags=unit ./internal/relay/bridge/... -run 'Qianfan|Embedding'` PASS
- 直连千帆 `/v2/embeddings` 200；网关 embedding 需 deploy 后复验

## 提交

- 5332eb281 chore(qianfan): anchor embedding relay sentinels and SSOT preset test
- 77abb4929 fix(qianfan): restore embedding mode and bridge relay for ch46
- 1c5cd5e7f fix(modelops): 千帆 think SKU 阶梯价不再被 flat thinking_output 覆盖
- a6382bff8 fix(modelops): 千帆阶梯价改用 overlay intervals 而非 flat 上限档
- ec391fbc9 feat(modelops): 扩展百度千帆账号 90 至 v2 全量可服务 SSOT
- c9899a657 fix(modelops): exclude Qianfan overlay owners from DeepSeek peak-valley
- 3f84fe432 fix(modelops): address xj-review R-001..R-003 for qianfan PR
- c70cb5f05 feat(modelops): onboard Baidu Qianfan account 90 SSOT floor

最新提交：5332eb281