### PR TITLE
fix(gateway): 百度千帆 401 invalid_model 不再永久禁用 newapi 账号

### DIFF
--- a/backend/internal/service/newapi_bridge_penalty_tk_test.go
+++ b/backend/internal/service/newapi_bridge_penalty_tk_test.go
@@ -113,6 +113,30 @@ func TestTkHandleBridgeUpstreamPenalty_401DisablesAccount(t *testing.T) {
 	require.Contains(t, repo.lastErrorMsg, "Authentication failed (401)")
 }
 
+// 401 + invalid_model on a newapi account is a model-routing mismatch (Baidu
+// Qianfan prod 2026-08-07); must NOT permanently disable the account.
+func TestTkHandleBridgeUpstreamPenalty_401ModelNotFoundSkipsPenalty(t *testing.T) {
+	svc, repo, blocker, incidents := newBridgePenaltyTestService()
+	account := &Account{
+		ID:          90,
+		Name:        "百度",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: 46,
+	}
+	body := []byte(`{"error":{"code":"invalid_model","message":"The model does not exist or you do not have access to it."}}`)
+	tkHandleBridgeUpstreamPenalty(context.Background(), svc, account,
+		newapitypes.NewErrorWithStatusCode(errors.New("invalid_model: The model does not exist or you do not have access to it."), newapitypes.ErrorCode("invalid_model"), 401))
+
+	require.Zero(t, repo.setErrorCalls, "model-not-found 401 must not SetError")
+	require.Zero(t, repo.setRateLimitedCalls)
+	require.Empty(t, blocker.reasons)
+	require.Empty(t, incidents.reasons)
+
+	shouldDisable := svc.HandleUpstreamError(context.Background(), account, 401, http.Header{}, body)
+	require.False(t, shouldDisable)
+}
+
 // Client-induced statuses must NEVER penalize the account (the #617 lesson:
 // cooling accounts on client 400s drains the pool). 404 model-not-found and
 // the synthetic 400 bridge errors are all out of the allowlist.

--- a/backend/internal/service/newapi_model_not_found_tk.go
+++ b/backend/internal/service/newapi_model_not_found_tk.go
@@ -9,10 +9,12 @@ import (
 )
 
 // IsOpenAICompatModelNotFound404 reports whether an OpenAI-compatible / newapi
-// upstream 404 is a CALLER-fault "the requested model does not exist / is not
+// upstream response is a CALLER-fault "the requested model does not exist / is not
 // accessible on this channel" rather than a provider-health failure. The newapi
-// fifth-platform sibling of IsAnthropicModelNotFound404. Two real upstream shapes
-// (both captured by direct probe, 2026-06-10):
+// fifth-platform sibling of IsAnthropicModelNotFound404. Matched primarily by
+// message/code (status-agnostic): some vendors (Baidu Qianfan channel_type=46)
+// return HTTP 401 + invalid_model with the same prose VolcEngine/DashScope use
+// on 404. Two canonical upstream shapes (direct probe, 2026-06-10):
 //
 //	VolcEngine Ark (channel_type=45): un-activated / retired model →
 //	  {"error":{"code":"InvalidEndpointOrModel.NotFound",
@@ -44,10 +46,11 @@ func IsOpenAICompatModelNotFound404(responseBody []byte, upstreamMsg string) boo
 	}
 	if strings.Contains(combined, "invalidendpointormodel.notfound") ||
 		strings.Contains(combined, "model_not_found") ||
+		strings.Contains(combined, "invalid_model") ||
 		strings.Contains(combined, "does not exist or you do not have access") {
 		return true
 	}
-	if code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.code").String())); code == "invalidendpointormodel.notfound" || code == "model_not_found" {
+	if code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.code").String())); code == "invalidendpointormodel.notfound" || code == "model_not_found" || code == "invalid_model" {
 		return true
 	}
 	return false

--- a/backend/internal/service/newapi_model_not_found_tk_test.go
+++ b/backend/internal/service/newapi_model_not_found_tk_test.go
@@ -29,6 +29,7 @@ func TestIsOpenAICompatModelNotFound404(t *testing.T) {
 		// and the structured code, so a vendor reword of either still classifies.
 		{"dashscope model_not_found JSON body", `{"error":{"message":"The model ` + "`qwen-x`" + ` does not exist or you do not have access to it.","type":"invalid_request_error","code":"model_not_found"}}`, "", true},
 		{"dashscope code-prefixed message (bridge path)", "", "model_not_found: The model `qwen-x` does not exist or you do not have access to it.", true},
+		{"baidu qianfan 401 invalid_model (prod account 90 incident)", `{"error":{"code":"invalid_model","message":"The model does not exist or you do not have access to it."}}`, "invalid_model: The model does not exist or you do not have access to it.", true},
 		{"model_not_found structured code alone (prose reworded)", `{"error":{"code":"model_not_found","message":"whatever wording the vendor uses"}}`, "", true},
 		{"genuine 5xx is NOT model-not-found", `{"error":{"message":"upstream service temporarily unavailable"}}`, "Upstream request failed", false},
 		{"rate limit is NOT model-not-found", "", "Upstream rate limit exceeded, please retry later", false},

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -442,6 +442,19 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 				"account_id", account.ID, "platform", account.Platform, "message", upstreamMsg)
 			return false
 		}
+		// TK (prod 2026-08-07, account 90 百度/BaiduV2): Qianfan answers HTTP 401 +
+		// invalid_model when the client asks for a model this channel cannot serve
+		// (e.g. qwen3-8b routed to a Baidu apikey). Credentials are fine; this is a
+		// model-routing mismatch. Reuse the openai-compat model-not-found classifier
+		// (message/code based, status-agnostic) so failover can continue without
+		// permanently disabling the account.
+		if account.Platform == PlatformNewAPI && IsOpenAICompatModelNotFound404(responseBody, upstreamMsg) {
+			slog.Info("newapi_model_not_found_401_skip_auth_penalty",
+				"account_id", account.ID,
+				"channel_type", account.ChannelType,
+				"message", upstreamMsg)
+			return false
+		}
 		// 外审第9轮:Spark 影子无独立凭据,401 是母账号 token 问题——失效缓存 / refresh_token 判断 /
 		// 永久禁用 / 临时不可调度都必须落到凭据 owner(母账号),否则影子(无 refresh_token)必中
 		// "refresh_token missing"永久禁用分支、母账号 token cache 也不会被清,把母账号可恢复的 token

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4434,9 +4434,11 @@
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
         "tkIsCapabilityScope401(statusCode, responseBody)",
-        "capability_scope_401_skip_penalty"
+        "capability_scope_401_skip_penalty",
+        "IsOpenAICompatModelNotFound404(responseBody, upstreamMsg)",
+        "newapi_model_not_found_401_skip_auth_penalty"
       ],
-      "rationale": "Injection point: HandleUpstreamError case 401 short-circuits a capability-scope 401 to shouldDisable=false BEFORE any temp_unschedulable / SetError path, so the account stays schedulable for every other model. Anchors the no-cooldown guard against silent upstream-merge reversion (paired with ratelimit_service_tk_capability_scope_401.go)."
+      "rationale": "Injection point: HandleUpstreamError case 401 short-circuits (a) capability-scope 401 and (b) newapi openai-compat model-not-found on 401 (Baidu Qianfan invalid_model, prod 2026-08-07 account 90) to shouldDisable=false BEFORE any temp_unschedulable / SetError path, so the account stays schedulable for every other model. Anchors the no-cooldown guards against silent upstream-merge reversion (paired with ratelimit_service_tk_capability_scope_401.go and newapi_model_not_found_tk.go)."
     },
     {
       "rationale": "Injection points: shouldFailoverOpenAIUpstreamResponse suppresses failover for a capability-scope 401 (every pool account shares the missing scope), and the non-failover handleErrorResponse/handleCompatErrorResponse 401 sites map it to a client 400 invalid_request_error. Anchors the no-failover + client-400 guards against silent upstream-merge reversion.",


### PR DESCRIPTION
## 摘要

- **prod 事件**：2026-08-07 06:31 北京时间，账号 #90（百度/newapi/china）因 `auth_error` 被永久禁用
- **根因**：`TK_FULLTEST_KEY` 请求 `qwen3-8b` → universal 路由选中百度账号 → 千帆返回 **401 + invalid_model**（模型不存在/无权限），与 VolcEngine/DashScope 404 同类 prose，但现有 `IsOpenAICompatModelNotFound404` 只在 404 路径跳过惩罚，401 仍走 `handleAuthError` 永久下线
- **运维恢复**：已通过 SSM 将 #90 恢复为 `active` + `schedulable`
- **代码修复**：401 分支对 `PlatformNewAPI` + model-not-found 分类器命中时跳过 auth 惩罚；扩展分类器识别 `invalid_model` code

## 风险

- 常规风险：仅影响 newapi 平台 401 惩罚判定，真实凭证失效仍走原有永久禁用路径
- 若上游把真实 auth 失败也包装成 `invalid_model`，可能漏禁用（与现有 404 路径同类 trade-off）

## 验证

```bash
cd backend && go test -tags=unit ./internal/service/ -run 'TestIsOpenAICompatModelNotFound404|TestTkHandleBridgeUpstreamPenalty_401ModelNotFoundSkipsPenalty' -count=1
./scripts/preflight.sh
```

- 单元测试通过
- preflight 全绿

## 提交

- 94c1495 fix(gateway): 百度千帆 401 invalid_model 不再永久禁用 newapi 账号

最新提交：94c1495

Made with [Cursor](https://cursor.com)