### PR TITLE
fix(ops): probe_account_model 支持 ENDPOINT=embeddings

### DIFF
--- a/.cursor/skills/tokenkey-account-model-probe/SKILL.md
+++ b/.cursor/skills/tokenkey-account-model-probe/SKILL.md
@@ -21,6 +21,18 @@ bash ops/observability/run-probe.sh \
   --env ENDPOINT=messages
 ```
 
+Embedding models (must use `/v1/embeddings`, not chat):
+
+```bash
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/stage0/probe_account_model.sh \
+  --with ops/pricing/probe_reserved_resources.sh \
+  --env ACCOUNT_ID=<account_id> \
+  --env MODEL=bge-large-en \
+  --env ENDPOINT=embeddings
+```
+
 For an edge account:
 
 ```bash
@@ -96,7 +108,8 @@ The JSON result includes database-derived `account_platform` and effective
 
 Useful options:
 
-- `ENDPOINT=messages|chat|responses` chooses `/v1/messages`, `/v1/chat/completions`, or `/v1/responses`.
+- `ENDPOINT=messages|chat|responses|embeddings` chooses `/v1/messages`, `/v1/chat/completions`, `/v1/responses`, or `/v1/embeddings`.
+- Embedding SKUs (for example `bge-large-en`, `text-embedding-3-small`) must use `ENDPOINT=embeddings`. Do **not** probe them via `ENDPOINT=chat`; upstream returns 401 and TokenKey may mark the account `error`.
 - `MAX_TOKENS=16` keeps cost low.
 - `PROMPT_TEXT='Reply OK only.'` changes the prompt.
 - `REQUEST_EXTRA_JSON='{"temperature":0.7,"top_p":0.9}'` merges extra top-level JSON fields into the generated payload for request-shape compatibility probes.
@@ -111,7 +124,7 @@ Useful options:
 
 The script emits one JSON object. Treat these fields as the decision surface:
 
-- `verdict=servable`: HTTP 2xx and `usage_logs` confirms `account_id == ACCOUNT_ID`.
+- `verdict=servable`: HTTP 2xx and `usage_logs` confirms `account_id == ACCOUNT_ID` (chat/messages/responses), or for `ENDPOINT=embeddings`/`count_tokens` a valid endpoint-specific 2xx body.
 - `verdict=wrong_account`: request succeeded but usage correlation shows a different account. This means the probe pool was not isolated or sticky/routing interfered.
 - `verdict=gateway_rejected`: TokenKey rejected before upstream, usually model unsupported, no available accounts, billing/RPM, or request shape.
 - `verdict=upstream_rejected`: upstream reached but rejected auth/model/request.
@@ -150,7 +163,7 @@ account capability still has to return `verdict=servable`.
 - This is a live probe. It may consume a tiny amount of quota and can update normal usage tables.
 - Default reuse mode intentionally leaves at most one reserved probe group/key per platform on each target host, disables it after cleanup, and removes account binding after the request.
 - Probe groups must stay exclusive, grant `user_allowed_groups` only to the probe key owner, and remain direct probe-key only; they must not enter universal-key routing candidates.
-- Use `ENDPOINT=messages` for Anthropic/Kiro style accounts, `chat` for OpenAI-compatible chat, and `responses` for Codex/OpenAI responses.
+- Use `ENDPOINT=messages` for Anthropic/Kiro style accounts, `chat` for OpenAI-compatible chat, `responses` for Codex/OpenAI responses, and `embeddings` for OpenAI-compatible embedding models.
 - If the goal is "can the raw upstream credential serve this model", use the platform direct upstream probe. The default gateway probe remains the authoritative TokenKey-path proof.
 
 ## Follow-Up Checks

--- a/.cursor/skills/tokenkey-account-model-probe/SKILL.md
+++ b/.cursor/skills/tokenkey-account-model-probe/SKILL.md
@@ -124,8 +124,8 @@ Useful options:
 
 The script emits one JSON object. Treat these fields as the decision surface:
 
-- `verdict=servable`: HTTP 2xx and `usage_logs` confirms `account_id == ACCOUNT_ID` (chat/messages/responses), or for `ENDPOINT=embeddings`/`count_tokens` a valid endpoint-specific 2xx body.
-- `verdict=wrong_account`: request succeeded but usage correlation shows a different account. This means the probe pool was not isolated or sticky/routing interfered.
+- `verdict=servable`: HTTP 2xx and `usage_logs` confirms `account_id == ACCOUNT_ID` (chat/messages/responses), or for `ENDPOINT=embeddings`/`count_tokens` a valid endpoint-specific 2xx body (embeddings may omit usage when logs lag).
+- `verdict=wrong_account`: request succeeded but `usage_logs` shows a different `account_id` (including `ENDPOINT=embeddings` when usage is present).
 - `verdict=gateway_rejected`: TokenKey rejected before upstream, usually model unsupported, no available accounts, billing/RPM, or request shape.
 - `verdict=upstream_rejected`: upstream reached but rejected auth/model/request.
 - `verdict=uncorrelated_success`: HTTP 2xx but no usage row was found in the poll window; inspect recent logs before trusting it.

--- a/ops/observability/run-probe.sh
+++ b/ops/observability/run-probe.sh
@@ -136,6 +136,12 @@ for _tk_resolver in \
     WITH_FILES+=("$_tk_resolver")
   fi
 done
+if [ "$(basename "$SCRIPT_PATH")" = "probe_account_model.sh" ]; then
+  _tk_probe_verdict="$REPO_ROOT/ops/stage0/probe_account_model_verdict.py"
+  if [ -f "$_tk_probe_verdict" ]; then
+    WITH_FILES+=("$_tk_probe_verdict")
+  fi
+fi
 
 # Local macOS/Homebrew preflight: catch the known aws/pyexpat loader breakage
 # before the first real AWS call. Diagnose only; repair stays explicit in the

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -4,6 +4,7 @@
 # (gateway_rejected, often "Unsupported model") from upstream account capability
 # rejection (upstream_rejected; exact text is platform-specific).
 # Batch Kiro Claude matrix: ops/stage0/probe_kiro_claude_models.sh (see tokenkey-account-model-probe skill).
+# Embedding models: use ENDPOINT=embeddings (/v1/embeddings), not chat — chat probes can 401 and mark accounts error.
 # Skill wrapper: .cursor/skills/tokenkey-account-model-probe/scripts/probe_account_model.sh
 set -euo pipefail
 
@@ -121,8 +122,8 @@ if [[ ! "$PROBE_LOCK_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || [[ "$PROBE_LOCK_TIMEOUT_
   fail_json "PROBE_LOCK_TIMEOUT_SECONDS must be a positive integer"
 fi
 case "$ENDPOINT" in
-  messages|count_tokens|chat|responses) ;;
-  *) fail_json "ENDPOINT must be messages, count_tokens, chat, or responses" ;;
+  messages|count_tokens|chat|responses|embeddings) ;;
+  *) fail_json "ENDPOINT must be messages, count_tokens, chat, responses, or embeddings" ;;
 esac
 
 PROBE_ID="tkprobe-${ACCOUNT_ID}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
@@ -426,6 +427,11 @@ if endpoint == "chat":
         "max_tokens": max_tokens,
         "messages": [{"role": "user", "content": prompt}],
     }
+elif endpoint == "embeddings":
+    payload = {
+        "model": model,
+        "input": prompt,
+    }
 elif endpoint == "count_tokens":
     payload = {
         "model": model,
@@ -466,6 +472,7 @@ case "$ENDPOINT" in
   messages) PATH_SUFFIX="/v1/messages"; AUTH_HEADER_NAME="x-api-key";;
   count_tokens) PATH_SUFFIX="/v1/messages/count_tokens"; AUTH_HEADER_NAME="x-api-key";;
   chat) PATH_SUFFIX="/v1/chat/completions"; AUTH_HEADER_NAME="Authorization";;
+  embeddings) PATH_SUFFIX="/v1/embeddings"; AUTH_HEADER_NAME="Authorization";;
   responses) PATH_SUFFIX="/v1/responses"; AUTH_HEADER_NAME="Authorization";;
 esac
 
@@ -594,6 +601,20 @@ def classify(code: str, body_text: str, usage_row, curl_err: str):
     if 200 <= n < 300:
         if endpoint == "count_tokens":
             return "servable"
+        if endpoint == "embeddings":
+            try:
+                parsed = json.loads(body_text)
+                data = parsed.get("data")
+                if (
+                    isinstance(data, list)
+                    and data
+                    and isinstance(data[0], dict)
+                    and "embedding" in data[0]
+                ):
+                    return "servable"
+            except Exception:
+                pass
+            return "uncorrelated_success"
         if usage_row and int(usage_row.get("account_id") or 0) == int(target["id"]):
             return "servable"
         if usage_row:

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -111,6 +111,9 @@ fi
 if [[ -z "$MODEL" ]]; then
   fail_json "MODEL is required"
 fi
+if [[ ! -f "$SCRIPT_DIR/probe_account_model_verdict.py" ]]; then
+  fail_json "missing probe_account_model_verdict.py companion beside probe_account_model.sh"
+fi
 if [[ ! "$REQUEST_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || [[ "$REQUEST_TIMEOUT_SECONDS" -lt 1 ]]; then
   fail_json "REQUEST_TIMEOUT_SECONDS must be a positive integer"
 fi
@@ -485,6 +488,7 @@ printf '%s' "$payload" >"$tmp_payload"
 
 PROBE_STARTED_AT="$("${PSQL[@]}" -c "SELECT to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"');" | tr -d '\n')"
 CLIENT_REQUEST_ID="$PROBE_ID"
+export PROBE_SCRIPT_DIR="$SCRIPT_DIR"
 http_code=""
 http_output=""
 if [[ "$AUTH_HEADER_NAME" == "x-api-key" ]]; then
@@ -591,47 +595,21 @@ try:
 except Exception:
     request_extra = {}
 
+import os
+import sys
+
+sys.path.insert(0, os.environ.get("PROBE_SCRIPT_DIR", "."))
+from probe_account_model_verdict import classify_probe_verdict
+
 def classify(code: str, body_text: str, usage_row, curl_err: str):
-    if not code or code == "000":
-        if curl_err:
-            return "setup_error"
-        return "gateway_rejected"
-    n = int(code)
-    low = body_text.lower()
-    if 200 <= n < 300:
-        if endpoint == "count_tokens":
-            return "servable"
-        if endpoint == "embeddings":
-            try:
-                parsed = json.loads(body_text)
-                data = parsed.get("data")
-                if (
-                    isinstance(data, list)
-                    and data
-                    and isinstance(data[0], dict)
-                    and "embedding" in data[0]
-                ):
-                    return "servable"
-            except Exception:
-                pass
-            return "uncorrelated_success"
-        if usage_row and int(usage_row.get("account_id") or 0) == int(target["id"]):
-            return "servable"
-        if usage_row:
-            return "wrong_account"
-        return "uncorrelated_success"
-    if n in (401, 403):
-        return "upstream_rejected"
-    if n == 429 and "no available accounts" in low:
-        return "gateway_rejected"
-    # Keep "Unsupported model: X" (TokenKey local floor/model_mapping rejection)
-    # as gateway_rejected. Platform-specific "not supported" errors mean the
-    # upstream path was reached and rejected the account/model/request.
-    if n in (400, 404) and any(s in low for s in ["invalid model", "model_not_found", "not supported", "does not exist", "not a valid"]):
-        return "upstream_rejected"
-    if n >= 500:
-        return "gateway_rejected"
-    return "gateway_rejected"
+    return classify_probe_verdict(
+        endpoint=endpoint,
+        http_code=code,
+        body_text=body_text,
+        target_account_id=int(target["id"]),
+        usage_row=usage_row,
+        curl_err=curl_err,
+    )
 
 log_lines = []
 for line in logs.splitlines():

--- a/ops/stage0/probe_account_model_verdict.py
+++ b/ops/stage0/probe_account_model_verdict.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Verdict classification for probe_account_model.sh (unit-testable SSOT)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def embedding_response_valid(body_text: str) -> bool:
+    try:
+        parsed = json.loads(body_text)
+    except json.JSONDecodeError:
+        return False
+    data = parsed.get("data")
+    return (
+        isinstance(data, list)
+        and bool(data)
+        and isinstance(data[0], dict)
+        and "embedding" in data[0]
+    )
+
+
+def classify_probe_verdict(
+    *,
+    endpoint: str,
+    http_code: str,
+    body_text: str,
+    target_account_id: int,
+    usage_row: dict[str, Any] | None,
+    curl_err: str,
+) -> str:
+    if not http_code or http_code == "000":
+        if curl_err:
+            return "setup_error"
+        return "gateway_rejected"
+
+    status = int(http_code)
+    low = body_text.lower()
+
+    if 200 <= status < 300:
+        if endpoint == "count_tokens":
+            return "servable"
+        if endpoint == "embeddings":
+            if not embedding_response_valid(body_text):
+                return "uncorrelated_success"
+            usage_account_id = int((usage_row or {}).get("account_id") or 0)
+            if usage_row and usage_account_id == target_account_id:
+                return "servable"
+            if usage_row:
+                return "wrong_account"
+            return "servable"
+        usage_account_id = int((usage_row or {}).get("account_id") or 0)
+        if usage_row and usage_account_id == target_account_id:
+            return "servable"
+        if usage_row:
+            return "wrong_account"
+        return "uncorrelated_success"
+
+    if status in (401, 403):
+        return "upstream_rejected"
+    if status == 429 and "no available accounts" in low:
+        return "gateway_rejected"
+    if status in (400, 404) and any(
+        token in low
+        for token in (
+            "invalid model",
+            "model_not_found",
+            "not supported",
+            "does not exist",
+            "not a valid",
+        )
+    ):
+        return "upstream_rejected"
+    if status >= 500:
+        return "gateway_rejected"
+    return "gateway_rejected"

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -66,15 +66,16 @@ class ProbeAccountModelTest(unittest.TestCase):
         bind_at = script.index("INSERT INTO account_groups (account_id, group_id, priority, created_at)")
         self.assertLess(unbind_at, bind_at)
 
-    def test_embeddings_endpoint_uses_v1_embeddings_and_embedding_body_verdict(self) -> None:
+    def test_probe_script_wires_verdict_module_and_embeddings_endpoint(self) -> None:
         script = _SCRIPT.read_text()
 
         self.assertIn("messages|count_tokens|chat|responses|embeddings", script)
         self.assertIn('elif endpoint == "embeddings":', script)
         self.assertIn('"input": prompt', script)
         self.assertIn('embeddings) PATH_SUFFIX="/v1/embeddings"', script)
-        self.assertIn('if endpoint == "embeddings":', script)
-        self.assertIn('"embedding" in data[0]', script)
+        self.assertIn("PROBE_SCRIPT_DIR", script)
+        self.assertIn("from probe_account_model_verdict import classify_probe_verdict", script)
+        self.assertIn("probe_account_model_verdict.py", script)
 
 
 if __name__ == "__main__":

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -66,6 +66,16 @@ class ProbeAccountModelTest(unittest.TestCase):
         bind_at = script.index("INSERT INTO account_groups (account_id, group_id, priority, created_at)")
         self.assertLess(unbind_at, bind_at)
 
+    def test_embeddings_endpoint_uses_v1_embeddings_and_embedding_body_verdict(self) -> None:
+        script = _SCRIPT.read_text()
+
+        self.assertIn("messages|count_tokens|chat|responses|embeddings", script)
+        self.assertIn('elif endpoint == "embeddings":', script)
+        self.assertIn('"input": prompt', script)
+        self.assertIn('embeddings) PATH_SUFFIX="/v1/embeddings"', script)
+        self.assertIn('if endpoint == "embeddings":', script)
+        self.assertIn('"embedding" in data[0]', script)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ops/stage0/test_probe_account_model_verdict.py
+++ b/ops/stage0/test_probe_account_model_verdict.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Behavioral tests for probe_account_model_verdict.classify_probe_verdict."""
+
+from __future__ import annotations
+
+import unittest
+
+from probe_account_model_verdict import classify_probe_verdict, embedding_response_valid
+
+
+class ProbeAccountModelVerdictTest(unittest.TestCase):
+    def test_embedding_response_valid_requires_data_embedding(self) -> None:
+        body = '{"object":"list","data":[{"object":"embedding","embedding":[0.1]}]}'
+        self.assertTrue(embedding_response_valid(body))
+        self.assertFalse(embedding_response_valid('{"data":[]}'))
+        self.assertFalse(embedding_response_valid('{"data":[{"object":"embedding"}]}'))
+
+    def test_embeddings_servable_without_usage_when_body_valid(self) -> None:
+        body = '{"data":[{"object":"embedding","embedding":[0.1]}]}'
+        verdict = classify_probe_verdict(
+            endpoint="embeddings",
+            http_code="200",
+            body_text=body,
+            target_account_id=90,
+            usage_row=None,
+            curl_err="",
+        )
+        self.assertEqual(verdict, "servable")
+
+    def test_embeddings_wrong_account_when_usage_points_elsewhere(self) -> None:
+        body = '{"data":[{"object":"embedding","embedding":[0.1]}]}'
+        verdict = classify_probe_verdict(
+            endpoint="embeddings",
+            http_code="200",
+            body_text=body,
+            target_account_id=90,
+            usage_row={"account_id": 39},
+            curl_err="",
+        )
+        self.assertEqual(verdict, "wrong_account")
+
+    def test_embeddings_servable_when_usage_matches_target(self) -> None:
+        body = '{"data":[{"object":"embedding","embedding":[0.1]}]}'
+        verdict = classify_probe_verdict(
+            endpoint="embeddings",
+            http_code="200",
+            body_text=body,
+            target_account_id=90,
+            usage_row={"account_id": 90},
+            curl_err="",
+        )
+        self.assertEqual(verdict, "servable")
+
+    def test_chat_wrong_account_unchanged(self) -> None:
+        verdict = classify_probe_verdict(
+            endpoint="chat",
+            http_code="200",
+            body_text='{"choices":[{"message":{"content":"ok"}}]}',
+            target_account_id=90,
+            usage_row={"account_id": 39},
+            curl_err="",
+        )
+        self.assertEqual(verdict, "wrong_account")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- `probe_account_model.sh` 新增 `ENDPOINT=embeddings`，走 `/v1/embeddings` 探测 embedding SKU
- verdict 在 2xx 且响应体含 `data[].embedding` 时判为 `servable`
- 更新 `tokenkey-account-model-probe` skill：明确 embedding 模型禁止用 chat endpoint

## 风险

- 低风险，仅 ops 探测脚本与 skill 文档；无后端/API 行为变更

## 验证

- `python3 ops/stage0/test_probe_account_model.py -v` 全绿
- `./scripts/preflight.sh` PASS

## 提交

- 24c53acbd fix(ops): probe_account_model 支持 ENDPOINT=embeddings
- 最新提交：24c53acbd

Made with [Cursor](https://cursor.com)