### PR TITLE
fix(obs): usage_logs cutover 后 retention inventory 按 leaf 分区统计

### DIFF
--- a/ops/observability/probe-data-layer-retention-inventory.sh
+++ b/ops/observability/probe-data-layer-retention-inventory.sh
@@ -8,8 +8,8 @@
 # supports physical filesystem reclamation.
 #
 # Tagged output:
-#   RETENTIONSTATS  one row per whitelisted table
-#   RETENTIONUSAGE  relation metadata for non-partitioned usage logs
+#   RETENTIONSTATS  one row per whitelisted table (usage + ops leaf partitions)
+#   RETENTIONUSAGE  usage_logs leaf-partition rollup (same bytes/rows as RETENTIONSTATS)
 #   RETENTIONUSAGE_EXACT  bounded exact usage cutoff count
 #   RETENTIONPLAN   planner estimates without reading matching rows
 #   RETPARTITION   one row per leaf partition
@@ -43,6 +43,7 @@ WITH cfg AS (
 ), objects(table_name, dataset, cutoff, retention_days) AS (
   SELECT 'ops_system_logs', 'ops', ops_cutoff, :'ops_days'::int FROM cfg
   UNION ALL SELECT 'ops_error_logs', 'ops', ops_cutoff, :'ops_days'::int FROM cfg
+  UNION ALL SELECT 'usage_logs', 'usage', usage_cutoff, :'usage_days'::int FROM cfg
 ), leaves AS (
   SELECT
     o.table_name,
@@ -86,17 +87,9 @@ WITH cfg AS (
   FROM bounded b
   GROUP BY b.table_name, b.dataset, b.cutoff
 ), expired AS (
-  SELECT
-    'ops_system_logs' AS table_name,
-    NULL::bigint AS expired_rows,
-    NULL::bigint AS expired_blob_refs
-  FROM cfg
-  UNION ALL
-  SELECT
-    'ops_error_logs',
-    NULL::bigint,
-    NULL::bigint
-  FROM cfg
+  SELECT 'ops_system_logs' AS table_name, NULL::bigint AS expired_rows, NULL::bigint AS expired_blob_refs FROM cfg
+  UNION ALL SELECT 'ops_error_logs', NULL::bigint, NULL::bigint FROM cfg
+  UNION ALL SELECT 'usage_logs', NULL::bigint, NULL::bigint FROM cfg
 )
 SELECT 'RETENTIONSTATS '||row_to_json(result)::text
 FROM (
@@ -136,41 +129,94 @@ then
   echo 'RETENTIONSTATS {"inventory_probe_ok":false,"reason":"retention SQL timed out, was blocked, or schema was incomplete"}'
 fi
 
-echo "=== RETENTIONUSAGE (non-partitioned usage relation) ==="
-if usage_meta=$(docker exec -i -e "PGOPTIONS=$PGOPTIONS_VALUE" tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1 -tAc "
+echo "=== RETENTIONUSAGE (usage_logs leaf partitions) ==="
+if ! "${PSQL[@]}" \
+  -v usage_days="$USAGE_RETENTION_DAYS" \
+  -tA 2>&1 <<'SQL'
+WITH cfg AS (
+  SELECT
+    clock_timestamp() AS as_of,
+    clock_timestamp() - make_interval(days := :'usage_days'::int) AS usage_cutoff
+), leaves AS (
+  SELECT
+    c.relname AS relation_name,
+    pg_total_relation_size(tree.relid) AS relation_bytes,
+    COALESCE(s.n_live_tup::bigint, 0) AS live_rows,
+    pg_get_expr(c.relpartbound, c.oid) AS partition_bound
+  FROM pg_partition_tree(to_regclass('usage_logs')) tree
+  JOIN pg_class c ON c.oid = tree.relid
+  LEFT JOIN pg_stat_all_tables s ON s.relid = c.oid
+  WHERE tree.isleaf
+), bounded AS (
+  SELECT
+    l.*,
+    CASE
+      WHEN l.partition_bound ~ $$TO \('([^']+)'\)$$
+      THEN substring(l.partition_bound FROM $$TO \('([^']+)'\)$$)::timestamptz
+      ELSE NULL
+    END AS upper_bound
+  FROM leaves l
+), agg AS (
+  SELECT
+    bool_or(b.partition_bound IS NOT NULL) AS partitioned,
+    sum(b.relation_bytes)::bigint AS relation_bytes,
+    sum(b.live_rows)::bigint AS live_rows,
+    COALESCE(sum(b.relation_bytes) FILTER (
+      WHERE b.upper_bound IS NOT NULL AND b.upper_bound <= (SELECT usage_cutoff FROM cfg)
+    ), 0)::bigint AS physically_droppable_bytes,
+    COALESCE(sum(b.relation_bytes) FILTER (
+      WHERE b.partition_bound IS NOT NULL
+        AND (b.upper_bound IS NULL OR b.upper_bound > (SELECT usage_cutoff FROM cfg))
+    ), 0)::bigint AS straddling_partition_bytes
+  FROM bounded b
+)
 SELECT 'RETENTIONUSAGE '||row_to_json(t)::text
 FROM (
   SELECT
     true AS inventory_probe_ok,
     'usage_logs' AS table_name,
-    pg_total_relation_size('usage_logs')::bigint AS relation_bytes,
-    COALESCE((SELECT n_live_tup::bigint FROM pg_stat_user_tables
-      WHERE relid = 'usage_logs'::regclass), 0) AS live_rows,
-    $USAGE_RETENTION_DAYS::int AS retention_days,
-    now() - make_interval(days := $USAGE_RETENTION_DAYS::int) AS cutoff,
-    'pg_total_relation_size + pg_stat_user_tables; no row scan' AS evidence,
-    'non-partitioned relation: expired bytes require a separate bounded export/delete rehearsal' AS space_semantics
+    'usage' AS dataset,
+    (SELECT as_of FROM cfg) AS as_of,
+    (SELECT usage_cutoff FROM cfg) AS cutoff,
+    a.partitioned,
+    a.live_rows,
+    a.relation_bytes,
+    a.physically_droppable_bytes,
+    a.straddling_partition_bytes,
+    :'usage_days'::int AS retention_days,
+    'pg_partition_tree leaf sum + pg_stat; no row scan' AS evidence,
+    'whole partitions only; estimates do not prove df reclaim' AS space_semantics
+  FROM agg a
 ) t;
-" 2>/dev/null); then
-  printf '%s\n' "$usage_meta"
-else
-  echo 'RETENTIONUSAGE {"inventory_probe_ok":false,"reason":"usage relation metadata unavailable"}'
+SQL
+then
+  echo 'RETENTIONUSAGE {"inventory_probe_ok":false,"reason":"usage partition inventory timed out, was blocked, or schema was incomplete"}'
 fi
 
 echo "=== RETENTIONUSAGE_EXACT (bounded indexed count) ==="
 if usage_expired=$(docker exec -i -e "PGOPTIONS=$PGOPTIONS_VALUE" tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1 -tAc "
+WITH leaf_stats AS (
+  SELECT
+    COALESCE(sum(pg_total_relation_size(tree.relid)), 0)::bigint AS relation_bytes,
+    COALESCE(sum(s.n_live_tup), 0)::bigint AS live_rows
+  FROM pg_partition_tree(to_regclass('usage_logs')) tree
+  LEFT JOIN pg_stat_all_tables s ON s.relid = tree.relid
+  WHERE tree.isleaf
+)
 SELECT 'RETENTIONUSAGE_EXACT '||row_to_json(t)::text
 FROM (
   SELECT
     true AS inventory_probe_ok,
-    count(*)::bigint AS expired_rows,
-    pg_total_relation_size('usage_logs')::bigint AS relation_bytes,
-    COALESCE((SELECT n_live_tup::bigint FROM pg_stat_user_tables
-      WHERE relid = 'usage_logs'::regclass), 0) AS live_rows,
+    (
+      SELECT count(*)::bigint
+      FROM usage_logs
+      WHERE created_at < now() - make_interval(days := $USAGE_RETENTION_DAYS::int)
+    ) AS expired_rows,
+    leaf_stats.relation_bytes,
+    leaf_stats.live_rows,
     $USAGE_RETENTION_DAYS::int AS retention_days,
     now() - make_interval(days := $USAGE_RETENTION_DAYS::int) AS cutoff
-  FROM usage_logs
-  WHERE created_at < now() - make_interval(days := $USAGE_RETENTION_DAYS::int)
+  FROM leaf_stats
 ) t;
 " 2>/dev/null); then
   printf '%s\n' "$usage_expired"
@@ -206,6 +252,7 @@ WITH cfg AS (
 ), objects(table_name, dataset, cutoff, retention_days) AS (
   SELECT 'ops_system_logs', 'ops', ops_cutoff, :'ops_days'::int FROM cfg
   UNION ALL SELECT 'ops_error_logs', 'ops', ops_cutoff, :'ops_days'::int FROM cfg
+  UNION ALL SELECT 'usage_logs', 'usage', usage_cutoff, :'usage_days'::int FROM cfg
 ), parts AS (
   SELECT
     o.table_name,

--- a/ops/observability/test_data_layer_retention_inventory.py
+++ b/ops/observability/test_data_layer_retention_inventory.py
@@ -42,9 +42,13 @@ class DataLayerRetentionInventorySafetyTest(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, body.upper())
         self.assertIn("RETENTIONSTATS", body)
+        self.assertIn("RETENTIONUSAGE", body)
         self.assertIn("RETENTIONUSAGE_EXACT", body)
         self.assertIn("RETENTIONPLAN", body)
         self.assertIn("RETPARTITION", body)
+        self.assertIn("pg_partition_tree(to_regclass('usage_logs'))", body)
+        self.assertNotIn("non-partitioned usage", body)
+        self.assertNotIn("non-partitioned relation", body)
         self.assertNotIn("RETBLOB", body)
         self.assertIn('for value in "$USAGE_RETENTION_DAYS" "$OPS_RETENTION_DAYS"', body)
 


### PR DESCRIPTION
## 摘要

- `probe-data-layer-retention-inventory.sh` 在 usage_logs 日分区 cutover 后仍读 parent 表，导致 `relation_bytes=0` / `live_rows=0` 误导运维。
- 将 `usage_logs` 纳入 `RETENTIONSTATS` / `RETPARTITION`，`RETENTIONUSAGE` / `RETENTIONUSAGE_EXACT` 改为 `pg_partition_tree` leaf 聚合，与 ops 表口径一致。

## 风险

- 低风险：只读 probe 输出形状变更；`RETENTIONUSAGE` 字段增加 `dataset` / `partitioned` / droppable 分类，不再宣称 non-partitioned。
- 无 prod 写操作、无 schema 变更。

## 验证

```bash
python3 ops/observability/test_data_layer_retention_inventory.py
./scripts/preflight.sh
bash ops/observability/run-probe.sh --target prod \
  --script ops/observability/probe-data-layer-retention-inventory.sh
```

prod 实测：`RETENTIONSTATS usage_logs relation_bytes≈7GB`、`RETENTIONUSAGE_EXACT expired_rows=686`，`RETPARTITION` 含 `usage_logs_legacy` 与日分区。

## 提交

- 71bbefe56 fix(obs): usage_logs 日分区 cutover 后 retention inventory 按 leaf 统计

最新提交：71bbefe56

no-web-impact

Made with [Cursor](https://cursor.com)