### PR TITLE
fix(retention): partitioned usage_logs legacy straddle reclaim

### DIFF
--- a/backend/internal/repository/dashboard_aggregation_repo.go
+++ b/backend/internal/repository/dashboard_aggregation_repo.go
@@ -3,7 +3,9 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pgpartition"
@@ -18,6 +20,9 @@ type dashboardAggregationRepository struct {
 
 const usageLogsCleanupBatchSize = 10000
 const usageBillingDedupCleanupBatchSize = 10000
+// usageLogsStraddleReclaimMaxRowsPerRun caps expired-row DELETE from bound-straddling
+// partitions (notably usage_logs_legacy) in one retention pass.
+const usageLogsStraddleReclaimMaxRowsPerRun = 1_000_000
 const dashboardHistoricalBackfillMinRemaining = 5 * time.Minute
 
 // NewDashboardAggregationRepository 创建仪表盘预聚合仓储。
@@ -276,8 +281,7 @@ func (r *dashboardAggregationRepository) CleanupUsageLogs(ctx context.Context, c
 		return err
 	}
 	if isPartitioned {
-		_, err := pgpartition.DropExpired(ctx, r.sql, "usage_logs", cutoff.UTC())
-		return err
+		return r.cleanupPartitionedUsageLogs(ctx, cutoff.UTC())
 	}
 	for {
 		res, err := r.sql.ExecContext(ctx, `
@@ -301,6 +305,91 @@ func (r *dashboardAggregationRepository) CleanupUsageLogs(ctx context.Context, c
 			return nil
 		}
 	}
+}
+
+func (r *dashboardAggregationRepository) cleanupPartitionedUsageLogs(ctx context.Context, cutoff time.Time) error {
+	db, ok := r.sql.(pgpartition.DB)
+	if !ok {
+		_, err := pgpartition.DropExpired(ctx, r.sql, "usage_logs", cutoff)
+		return err
+	}
+	if _, err := pgpartition.DropExpired(ctx, db, "usage_logs", cutoff); err != nil {
+		return err
+	}
+	straddling, err := pgpartition.ListStraddling(ctx, db, "usage_logs", "created_at", cutoff)
+	if err != nil {
+		return err
+	}
+	remaining := usageLogsStraddleReclaimMaxRowsPerRun
+	for _, child := range straddling {
+		if remaining <= 0 {
+			break
+		}
+		n, delErr := deleteOldUsageLogRowsByID(ctx, db, child, cutoff, usageLogsCleanupBatchSize, remaining)
+		if delErr != nil {
+			return delErr
+		}
+		remaining -= int(n)
+	}
+	return nil
+}
+
+func deleteOldUsageLogRowsByID(
+	ctx context.Context,
+	db pgpartition.DropExecutor,
+	table string,
+	cutoff time.Time,
+	batchSize int,
+	maxRows int,
+) (int64, error) {
+	if db == nil {
+		return 0, nil
+	}
+	if batchSize <= 0 {
+		batchSize = usageLogsCleanupBatchSize
+	}
+	qTable := pq.QuoteIdentifier(table)
+	q := fmt.Sprintf(`
+WITH batch AS (
+  SELECT id FROM %s
+  WHERE created_at < $1
+  ORDER BY id
+  LIMIT $2
+)
+DELETE FROM %s
+WHERE id IN (SELECT id FROM batch)
+`, qTable, qTable)
+
+	var total int64
+	for {
+		res, err := db.ExecContext(ctx, q, cutoff, batchSize)
+		if err != nil {
+			if isMissingUsageLogsRelationError(err) {
+				return total, nil
+			}
+			return total, err
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return total, err
+		}
+		total += affected
+		if affected == 0 {
+			break
+		}
+		if maxRows > 0 && total >= int64(maxRows) {
+			break
+		}
+	}
+	return total, nil
+}
+
+func isMissingUsageLogsRelationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "does not exist") && strings.Contains(s, "relation")
 }
 
 func (r *dashboardAggregationRepository) CleanupUsageBillingDedup(ctx context.Context, cutoff time.Time) error {

--- a/backend/internal/repository/dashboard_aggregation_repo.go
+++ b/backend/internal/repository/dashboard_aggregation_repo.go
@@ -20,6 +20,7 @@ type dashboardAggregationRepository struct {
 
 const usageLogsCleanupBatchSize = 10000
 const usageBillingDedupCleanupBatchSize = 10000
+
 // usageLogsStraddleReclaimMaxRowsPerRun caps expired-row DELETE from bound-straddling
 // partitions (notably usage_logs_legacy) in one retention pass.
 const usageLogsStraddleReclaimMaxRowsPerRun = 1_000_000

--- a/backend/internal/repository/dashboard_aggregation_repo_cleanup_test.go
+++ b/backend/internal/repository/dashboard_aggregation_repo_cleanup_test.go
@@ -1,0 +1,94 @@
+//go:build unit
+
+package repository
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupUsageLogs_PartitionedReclaimsStraddlingLegacy(t *testing.T) {
+	db, mock := newSQLMock(t)
+	repo := newDashboardAggregationRepositoryWithSQL(db)
+	cutoff := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT EXISTS(
+			SELECT 1
+			FROM pg_partitioned_table pt
+			JOIN pg_class c ON c.oid = pt.partrelid
+			WHERE c.relname = 'usage_logs'
+		)
+	`)).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	mock.ExpectQuery("FROM pg_inherits i").WillReturnRows(
+		sqlmock.NewRows([]string{"nspname", "relname", "bound_expr", "upper_bound", "estimated_rows"}).
+			AddRow("public", "usage_logs_legacy", "FOR VALUES FROM (MINVALUE) TO ('2026-08-10')", time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC), int64(1000)),
+	)
+
+	mock.ExpectQuery("FROM pg_inherits i").WillReturnRows(
+		sqlmock.NewRows([]string{"relname"}).AddRow("usage_logs_legacy"),
+	)
+	mock.ExpectQuery("SELECT min\\(\"created_at\"\\) FROM \"usage_logs_legacy\"").
+		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(time.Date(2026, 5, 9, 0, 0, 0, 0, time.UTC)))
+
+	mock.ExpectExec("DELETE FROM \"usage_logs_legacy\"").
+		WithArgs(cutoff, usageLogsCleanupBatchSize).
+		WillReturnResult(sqlmock.NewResult(0, 3))
+	mock.ExpectExec("DELETE FROM \"usage_logs_legacy\"").
+		WithArgs(cutoff, usageLogsCleanupBatchSize).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.CleanupUsageLogs(context.Background(), cutoff)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDeleteOldUsageLogRowsByID_RespectsMaxRows(t *testing.T) {
+	db, mock := newSQLMock(t)
+	cutoff := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectExec("DELETE FROM \"usage_logs_legacy\"").
+		WithArgs(cutoff, usageLogsCleanupBatchSize).
+		WillReturnResult(sqlmock.NewResult(0, 5))
+
+	deleted, err := deleteOldUsageLogRowsByID(
+		context.Background(),
+		db,
+		"usage_logs_legacy",
+		cutoff,
+		usageLogsCleanupBatchSize,
+		5,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), deleted)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCleanupUsageLogs_NonPartitionedUsesChunkedDelete(t *testing.T) {
+	db, mock := newSQLMock(t)
+	repo := newDashboardAggregationRepositoryWithSQL(db)
+	cutoff := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+		SELECT EXISTS(
+			SELECT 1
+			FROM pg_partitioned_table pt
+			JOIN pg_class c ON c.oid = pt.partrelid
+			WHERE c.relname = 'usage_logs'
+		)
+	`)).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	mock.ExpectExec("DELETE FROM usage_logs").
+		WithArgs(cutoff, usageLogsCleanupBatchSize).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+
+	err := repo.CleanupUsageLogs(context.Background(), cutoff)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4883,9 +4883,12 @@
         "if err := r.upsertGroupDailyAggregates(ctx, dayStart, dayEnd); err != nil {",
         "if err := r.deleteUserPlatformDailyRange(ctx, dayStart, dayEnd); err != nil {",
         "if err := r.deleteGroupDailyRange(ctx, dayStart, dayEnd); err != nil {",
-        "if err := r.cleanupUserPlatformDaily(ctx, dailyCutoffUTC); err != nil {"
+        "if err := r.cleanupUserPlatformDaily(ctx, dailyCutoffUTC); err != nil {",
+        "func (r *dashboardAggregationRepository) cleanupPartitionedUsageLogs(",
+        "pgpartition.ListStraddling(ctx, db, \"usage_logs\", \"created_at\", cutoff)",
+        "usageLogsStraddleReclaimMaxRowsPerRun"
       ],
-      "rationale": "Thin injection of TK rollup feeders into the upstream-shaped aggregation repo: user-platform and group daily upsert calls live in both aggregateRangeInTx and recomputeRangeInTx, range deletes prevent stale rows after recompute, user-platform retention prune follows the daily cutoff, and group metrics backfill runs before group distribution trusts the extended table. These are single-line hooks into upstream-shaped functions; an upstream merge resolving DashboardAggregationService could silently drop them, leaving rollups unpopulated and admin pages reading stale/empty history or raw-scanning again."
+      "rationale": "Thin injection of TK rollup feeders into the upstream-shaped aggregation repo: user-platform and group daily upsert calls live in both aggregateRangeInTx and recomputeRangeInTx, range deletes prevent stale rows after recompute, user-platform retention prune follows the daily cutoff, and group metrics backfill runs before group distribution trusts the extended table. Partitioned usage_logs retention must also reclaim expired rows from bound-straddling partitions (notably usage_logs_legacy) via ListStraddling and capped id-ordered DELETE after DropExpired; without these hooks an upstream merge can revert to drop-only retention and leave legacy rows past the 90d window undeleted. These are single-line hooks into upstream-shaped functions; an upstream merge resolving DashboardAggregationService could silently drop them, leaving rollups unpopulated and admin pages reading stale/empty history or raw-scanning again."
     },
     {
       "path": "backend/internal/repository/usage_log_repo_tk_user_platform_rollup.go",


### PR DESCRIPTION
## 摘要

分区化 `usage_logs` 的 retention 原先只做整分区 `DropExpired`，`usage_logs_legacy` 宽分区里已超过 90 天的行不会被删（prod 上约 2 万行积压）。本 PR 对齐 `OpsCleanupService` 策略：先 DROP 到期日分区，再对 straddling 分区做 capped 行级 DELETE（单次上限 100 万行）。

## 风险

常规风险。行为变更限于 dashboard aggregation retention 路径；不改变 API/CLI 契约。legacy 内约 670 万行会在后续 ~90 天内逐日过期并按 cap 分批删除，单日 workload 约 7 万行，低于 ops straddle 已验证量级。

## 验证

- `go test -tags=unit ./internal/repository -run 'TestCleanupUsageLogs|TestDeleteOldUsageLogRowsByID'`
- `go test -tags=unit ./internal/repository/... ./internal/service/... -run 'DashboardAggregation|CleanupUsage'`
- `./scripts/preflight.sh` PASS
- `scripts/sentinels/check-registry-update-gate.py --base origin/main` PASS

## 提交

- 164430b22 fix(retention): reclaim expired rows from partitioned usage_logs legacy
- 4da695da0 chore(sentinel): anchor partitioned usage_logs straddle reclaim
- 9426cc0eb style(repository): gofmt usage_logs straddle reclaim constants
- 8c9b76600 chore(ci): retrigger backend-ci after preflight flake

最新提交：8c9b76600