### PR TITLE
fix(ops): OIDC 补 ec2:DescribeSnapshots 修复 #1554 快照探针假阳性

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -150,6 +150,17 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/tokenkey-cicd-oidc/*"
                   - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/tokenkey-prod-stage0/*"
+              - Sid: ReadEbsSnapshotsForDiagnostics
+                # ops-daily-diagnostics data_layer_snapshot_signal.sh runs on the
+                # GHA runner (OIDC creds), not via SSM — needs direct EC2 read.
+                Effect: Allow
+                Action:
+                  - ec2:DescribeSnapshots
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    "aws:RequestedRegion":
+                      - !Ref AWS::Region
       Tags:
         - Key: Project
           Value: tokenkey

--- a/ops/observability/data_layer_safety_verdict.py
+++ b/ops/observability/data_layer_safety_verdict.py
@@ -113,7 +113,15 @@ def compute_verdict(signals: dict[str, Any]) -> dict[str, Any]:
         )
 
     snapshot_at = _timestamp(snapshot.get("latest_snapshot_at")) if isinstance(snapshot, dict) else None
-    if not _fresh(snapshot_at, now, SNAPSHOT_MAX_AGE):
+    if isinstance(snapshot, dict) and snapshot.get("probe_ok") is False:
+        probe_error = str(snapshot.get("probe_error") or "snapshot query failed").strip()
+        findings.append(
+            _finding(
+                "ebs_snapshot_freshness",
+                f"EBS snapshot probe failed: {probe_error}",
+            )
+        )
+    elif not _fresh(snapshot_at, now, SNAPSHOT_MAX_AGE):
         findings.append(
             _finding(
                 "ebs_snapshot_freshness",

--- a/ops/observability/data_layer_snapshot_signal.sh
+++ b/ops/observability/data_layer_snapshot_signal.sh
@@ -7,38 +7,50 @@ STACK_NAME="${2:-}"
 
 emit_signal() {
   local value="${1:-}"
-  jq -cn --arg value "$value" '{latest_snapshot_at:(if $value == "" or $value == "None" or $value == "null" then null else $value end)}'
+  local probe_error="${2:-}"
+  jq -cn \
+    --arg value "$value" \
+    --arg err "$probe_error" \
+    '{
+      latest_snapshot_at: (if $value == "" or $value == "None" or $value == "null" then null else $value end),
+      probe_ok: (if $err == "" then true else false end),
+      probe_error: (if $err == "" then null else $err end)
+    }'
 }
 
 if [[ -z "$REGION" || -z "$STACK_NAME" ]]; then
-  emit_signal ""
+  emit_signal "" "missing region or stack name"
   exit 0
 fi
 
+cfn_err="$(mktemp)"
+trap 'rm -f "$cfn_err"' EXIT
 if ! data_volume_id="$(aws cloudformation describe-stacks \
   --region "$REGION" \
   --stack-name "$STACK_NAME" \
   --query 'Stacks[0].Outputs[?OutputKey==`DataVolumeId`].OutputValue | [0]' \
-  --output text 2>/dev/null)"; then
-  emit_signal ""
+  --output text 2>"$cfn_err")"; then
+  emit_signal "" "$(head -1 "$cfn_err" | tr -d '\n' | cut -c1-240)"
   exit 0
 fi
 
 case "$data_volume_id" in
   ""|None|null)
-    emit_signal ""
+    emit_signal "" "DataVolumeId stack output is empty"
     exit 0
     ;;
 esac
 
+snap_err="$(mktemp)"
+trap 'rm -f "$cfn_err" "$snap_err"' EXIT
 if ! snapshot_at="$(aws ec2 describe-snapshots \
   --region "$REGION" \
   --owner-ids self \
   --filters "Name=volume-id,Values=$data_volume_id" "Name=status,Values=completed" \
   --query 'reverse(sort_by(Snapshots,&StartTime))[0].StartTime' \
-  --output text 2>/dev/null)"; then
-  emit_signal ""
+  --output text 2>"$snap_err")"; then
+  emit_signal "" "$(head -1 "$snap_err" | tr -d '\n' | cut -c1-240)"
   exit 0
 fi
 
-emit_signal "$snapshot_at"
+emit_signal "$snapshot_at" ""

--- a/ops/observability/test_data_layer_safety_verdict.py
+++ b/ops/observability/test_data_layer_safety_verdict.py
@@ -130,6 +130,21 @@ class DataLayerSafetyVerdictTest(unittest.TestCase):
         self.assertIn("partition_maintenance_error", kinds)
         self.assertIn("archive_lag", kinds)
 
+    def test_snapshot_probe_failure_surfaces_access_error(self) -> None:
+        signals = _signals()
+        signals["SNAPSHOTSTATS"] = {
+            "latest_snapshot_at": None,
+            "probe_ok": False,
+            "probe_error": "AccessDenied when calling DescribeSnapshots",
+        }
+        result = verdict.compute_verdict(signals)
+        snapshot_findings = [
+            f for f in result["findings"] if f["kind"] == "ebs_snapshot_freshness"
+        ]
+        self.assertEqual(len(snapshot_findings), 1)
+        self.assertIn("probe failed", snapshot_findings[0]["summary"])
+        self.assertIn("AccessDenied", snapshot_findings[0]["summary"])
+
     def test_future_dated_freshness_evidence_fails_closed(self) -> None:
         cases = (
             ("heartbeat", "PARTITIONSTATS", "partition_maintenance_last_success_at", "partition_maintenance_heartbeat"),

--- a/ops/observability/test_data_layer_snapshot_signal.py
+++ b/ops/observability/test_data_layer_snapshot_signal.py
@@ -63,24 +63,73 @@ class DataLayerSnapshotSignalTest(unittest.TestCase):
     def test_queries_latest_completed_snapshot_for_stack_data_volume(self) -> None:
         proc, calls = self.run_signal(volume_id="vol-data")
         self.assertEqual(proc.returncode, 0, msg=proc.stderr + proc.stdout)
-        self.assertEqual(json.loads(proc.stdout), {"latest_snapshot_at": "2026-08-04T01:02:03Z"})
+        self.assertEqual(
+            json.loads(proc.stdout),
+            {
+                "latest_snapshot_at": "2026-08-04T01:02:03Z",
+                "probe_ok": True,
+                "probe_error": None,
+            },
+        )
         self.assertTrue(any("OutputKey==`DataVolumeId`" in call for call in calls), msg=calls)
         snapshot_call = next(call for call in calls if call.startswith("ec2 describe-snapshots"))
         self.assertIn("Name=volume-id,Values=vol-data", snapshot_call)
         self.assertIn("Name=status,Values=completed", snapshot_call)
         self.assertFalse(any("describe-instances" in call for call in calls))
 
-    def test_missing_data_volume_is_null_without_snapshot_query(self) -> None:
+    def test_missing_data_volume_reports_probe_error(self) -> None:
         proc, calls = self.run_signal(volume_id="None")
         self.assertEqual(proc.returncode, 0, msg=proc.stderr + proc.stdout)
-        self.assertEqual(json.loads(proc.stdout), {"latest_snapshot_at": None})
+        body = json.loads(proc.stdout)
+        self.assertIsNone(body["latest_snapshot_at"])
+        self.assertFalse(body["probe_ok"])
+        self.assertIn("DataVolumeId", body["probe_error"])
         self.assertFalse(any("describe-snapshots" in call for call in calls), msg=calls)
 
     def test_missing_completed_snapshot_is_null(self) -> None:
         proc, calls = self.run_signal(volume_id="vol-data", snapshot_at="None")
         self.assertEqual(proc.returncode, 0, msg=proc.stderr + proc.stdout)
-        self.assertEqual(json.loads(proc.stdout), {"latest_snapshot_at": None})
+        body = json.loads(proc.stdout)
+        self.assertIsNone(body["latest_snapshot_at"])
+        self.assertTrue(body["probe_ok"])
+        self.assertIsNone(body["probe_error"])
         self.assertTrue(any("describe-snapshots" in call for call in calls), msg=calls)
+
+    def test_describe_snapshots_access_denied_reports_probe_error(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            fakebin = root / "bin"
+            fakebin.mkdir()
+            aws = fakebin / "aws"
+            aws.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    if [ "$1 $2" = "cloudformation describe-stacks" ]; then
+                      echo vol-data
+                      exit 0
+                    fi
+                    if [ "$1 $2" = "ec2 describe-snapshots" ]; then
+                      echo "An error occurred (AccessDenied) when calling the DescribeSnapshots operation" >&2
+                      exit 254
+                    fi
+                    exit 2
+                    """
+                ),
+                encoding="utf-8",
+            )
+            aws.chmod(0o755)
+            proc = subprocess.run(
+                ["bash", str(_SCRIPT), "us-east-1", "tokenkey-prod-stage0"],
+                env={**os.environ, "PATH": f"{fakebin}:{os.environ.get('PATH', '')}"},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        body = json.loads(proc.stdout)
+        self.assertIsNone(body["latest_snapshot_at"])
+        self.assertFalse(body["probe_ok"])
+        self.assertIn("AccessDenied", body["probe_error"])
 
 
 if __name__ == "__main__":

--- a/scripts/checks/diagnostics-oidc-perm-coverage.py
+++ b/scripts/checks/diagnostics-oidc-perm-coverage.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Ensure ops-daily-diagnostics AWS calls are granted by the base OIDC role."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+BASE_CFN = REPO_ROOT / "deploy/aws/cloudformation/cicd-oidc.yaml"
+
+# Actions issued on the GHA runner with OIDC creds (not via SSM).
+EXPECTED_BASE_ACTIONS: list[tuple[str, str]] = [
+    (
+        "ec2:DescribeSnapshots",
+        "ops/observability/data_layer_snapshot_signal.sh on prod diagnostics (#1554)",
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args()
+    try:
+        base_text = BASE_CFN.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"FAIL: cannot read {BASE_CFN.relative_to(REPO_ROOT)}: {exc}", file=sys.stderr)
+        return 2
+
+    missing = [
+        (action, notes)
+        for action, notes in EXPECTED_BASE_ACTIONS
+        if action not in base_text
+    ]
+    if not missing:
+        msg = f"ok: diagnostics OIDC perm coverage ({len(EXPECTED_BASE_ACTIONS)} actions)"
+        print(msg if args.quiet else f"{msg} in {BASE_CFN.relative_to(REPO_ROOT)}")
+        return 0
+
+    print("FAIL: ops-daily-diagnostics actions missing from base OIDC policy:", file=sys.stderr)
+    for action, notes in missing:
+        print(f"  - {action} ({notes})", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/checks/test_diagnostics_oidc_perm_coverage.py
+++ b/scripts/checks/test_diagnostics_oidc_perm_coverage.py
@@ -1,0 +1,51 @@
+"""Tests for scripts/checks/diagnostics-oidc-perm-coverage.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts/checks/diagnostics-oidc-perm-coverage.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("diagnostics_perm_coverage", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class DiagnosticsOidcPermCoverageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = _load_module()
+
+    def test_expected_actions_include_describe_snapshots(self) -> None:
+        actions = {action for action, _ in self.mod.EXPECTED_BASE_ACTIONS}
+        self.assertIn("ec2:DescribeSnapshots", actions)
+
+    def test_missing_action_detected(self) -> None:
+        missing = [
+            action
+            for action, _ in self.mod.EXPECTED_BASE_ACTIONS
+            if action not in "(empty policy)"
+        ]
+        self.assertEqual(len(missing), len(self.mod.EXPECTED_BASE_ACTIONS))
+
+    def test_real_repo_passes(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--quiet"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr + proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2365,6 +2365,16 @@ elif ! python3 ./scripts/checks/lightsail-oidc-perm-coverage.py --quiet; then
     errors=$((errors + 1))
 fi
 
+# ---- sub2api: diagnostics OIDC perm coverage -------------------------------
+echo ""
+echo "=== sub2api: diagnostics OIDC perm coverage ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for diagnostics OIDC perm coverage check)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/diagnostics-oidc-perm-coverage.py --quiet; then
+    errors=$((errors + 1))
+fi
+
 # ---- sub2api: edge platform exclusivity -------------------------------------
 # EC2 Edge and Lightsail Edge intentionally share the same <edge_id> namespace,
 # the same GitHub Environment edge-<id>, and the same DNS domain


### PR DESCRIPTION
## 摘要

- **根因**：`ops-daily-diagnostics` 在 GHA runner（OIDC 凭证）上跑 `data_layer_snapshot_signal.sh`；`tokenkey-gha-us-east-1-error-clustering` 有 `cloudformation:DescribeStacks` 但缺 `ec2:DescribeSnapshots` → 探针 fail-closed 返回 `null` → #1554 假阳性（prod DLM 快照实际 daily 正常）。
- **代码**：`cicd-oidc.yaml` 增加 region-scoped `ReadEbsSnapshotsForDiagnostics`；探针 JSON 增加 `probe_ok` / `probe_error`；verdict 区分 IAM/查询失败 vs 真无快照。
- **门禁**：`scripts/checks/diagnostics-oidc-perm-coverage.py` + preflight 段，防止再次漏配。

## 风险

- 常规风险：IAM 仅新增只读 `ec2:DescribeSnapshots`（同 region 条件），无写权限。
- **合并后仍需人工步骤**：对 live 栈 `tokenkey-cicd-oidc` 做 CFN update/apply，GHA 才会拿到新权限；仅 merge 代码不会立即消 #1554。
- `Web impact: none`

## 验证

- `./scripts/preflight.sh` PASS
- `python3 -m unittest ops.observability.test_data_layer_snapshot_signal ops.observability.test_data_layer_safety_verdict scripts.checks.test_diagnostics_oidc_perm_coverage` PASS

## 上线后

1. CFN apply `tokenkey-cicd-oidc`（us-east-1）
2. 手动 dispatch `ops-daily-diagnostics` 或等 cron
3. 预期 #1554 在信号清除后由 auto-close 逻辑关闭（#1598 已合并）

## 提交

- `a4472860` fix(ops): OIDC 补 ec2:DescribeSnapshots 修复 #1554 快照探针假阳性

最新提交：`a4472860`

Made with [Cursor](https://cursor.com)