### PR TITLE
fix(ops): decision-and-issue 补 PYTHONPATH 修复 issue 关单步骤

### DIFF
--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -835,6 +835,7 @@ jobs:
       - name: Open, update, or close issues
         env:
           GH_TOKEN: ${{ github.token }}
+          PYTHONPATH: .
         run: |
           set -euo pipefail
           python3 ops/observability/open_prod_ops_issues.py \

--- a/ops/observability/test_ops_daily_diagnostics_workflow.py
+++ b/ops/observability/test_ops_daily_diagnostics_workflow.py
@@ -280,6 +280,13 @@ class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
         self.assertIn("decision-and-issue:", text)
         self.assertNotIn("from ops.observability.daily_error_report import issue_analysis_markdown", text)
 
+    def test_decision_and_issue_sets_pythonpath(self) -> None:
+        text = workflow_text()
+        start = text.index("decision-and-issue:")
+        block = text[start : start + 3000]
+        self.assertIn("PYTHONPATH: .", block)
+        self.assertIn("open_prod_ops_issues.py", block)
+
     def test_missing_target_reports_skipped_when_diagnose_cancelled(self) -> None:
         text = workflow_text()
         self.assertIn("DISCOVER_TARGETS_RESULT", text)


### PR DESCRIPTION
## 摘要

- **根因**：#1598 将 `open_prod_ops_issues.py` 改为 `from ops.observability...` 包导入，但 `ops-daily-diagnostics.yml` 的 `decision-and-issue` job 未设 `PYTHONPATH`，GHA 上触发 `ModuleNotFoundError: No module named 'ops'`。
- **影响**：run [31353339360](https://github.com/youxuanxue/sub2api/actions/runs/31353339360) 探针已通过但关单 job 失败；#1554 由本地补跑脚本关闭。
- **修复**：在 `decision-and-issue` 步骤 env 增加 `PYTHONPATH: .`；补 workflow 回归测试。

## 风险

- 低风险：仅 workflow env 一行 + 测试；无 IAM / 运行时行为变更。
- `Web impact: none`

## 验证

- `./scripts/preflight.sh` PASS
- `python3 -m unittest ops.observability.test_ops_daily_diagnostics_workflow.OpsDailyDiagnosticsWorkflowTest.test_decision_and_issue_sets_pythonpath` PASS

## 提交

- `cd2b137b` fix(ops): decision-and-issue 补 PYTHONPATH 修复 issue 关单步骤

最新提交：`cd2b137b`

Made with [Cursor](https://cursor.com)