### PR TITLE
chore(qa): 记录 prod Phase 2 closeout 与 rollout SSOT 对齐

### DIFF
--- a/deploy/aws/stage0/tokenkey-qa-maintenance.sh
+++ b/deploy/aws/stage0/tokenkey-qa-maintenance.sh
@@ -348,7 +348,7 @@ run_selftest() {
   local sentinel="${QA_MAINTENANCE_HOST_SCRATCH}/.qa-maintenance-selftest"
   rm -f -- "${sentinel}"
   run_selftest_container "tokenkey-qa-maintenance-selftest-create-$$" /bin/sh -ceu \
-    'printf %s qa-maintenance-selftest-ok > /app/data/qa_archive_tmp/.qa-maintenance-selftest; test "$(cat /app/data/qa_archive_tmp/.qa-maintenance-selftest)" = qa-maintenance-selftest-ok # qa-maintenance-selftest-create'
+    'umask 077; printf %s qa-maintenance-selftest-ok > /app/data/qa_archive_tmp/.qa-maintenance-selftest; test "$(cat /app/data/qa_archive_tmp/.qa-maintenance-selftest)" = qa-maintenance-selftest-ok # qa-maintenance-selftest-create'
   if [ ! -f "${sentinel}" ] || [ "$(cat "${sentinel}")" != qa-maintenance-selftest-ok ]; then
     cleanup_runtime_files
     qa_fail selftest_host_visibility_failed 48 "selftest sentinel is not visible on the host"

--- a/ops/qa/deploy_rollout.yaml
+++ b/ops/qa/deploy_rollout.yaml
@@ -10,10 +10,10 @@ prod:
     policy_target: prod.archive.enabled
     target_deploy_inject_default: true
     enable_after: docs/approved/design-qa-phase2-archive-closeout.md#production-rollout
-    closeout_state: repository_ready_production_pending
+    closeout_state: production_closeout_verified
   tokenkey_qa_maintenance_timer:
-    observed_live_state: recently_enabled_requires_recloseout
-    closeout_deploy_state: disabled
+    observed_live_state: production_recloseout_verified
+    closeout_deploy_state: enabled
     policy_target_state: enabled
     min_consecutive_scheduled_runs: 2
     host_runner: /usr/local/bin/tokenkey-qa-maintenance.sh
@@ -29,13 +29,13 @@ prod:
     export_orphan_plan_command: /usr/local/bin/tokenkey-qa-stale-cleanup.sh --plan
     export_orphan_apply_command: /usr/local/bin/tokenkey-qa-stale-cleanup.sh --apply-export-orphans
     export_orphan_activation_marker: /var/lib/tokenkey/qa-export-orphan-cleanup-activated.json
-    activation_state: pending_production_exact_plan
+    activation_state: production_export_orphan_activated
   QA_CAPTURE_ENABLED:
     deploy_inject: edge_only_false
     policy_target: prod.capture_enabled
   raw_archive_recovery:
     repository_state: ready
-    production_iam_state: pending_apply
+    production_iam_state: applied
     independent_evidence_state: pending
     recovery_cli: backend/cmd/qa-archive
     retirement_gate: ops/qa/qa_archive_recovery_gate.py

--- a/scripts/checks/qa-lifecycle-ssot.py
+++ b/scripts/checks/qa-lifecycle-ssot.py
@@ -128,7 +128,7 @@ REQUIRED_BY_FILE = {
         "schema_version: 1",
         "deploy_inject_default: false",
         "target_deploy_inject_default: true",
-        "closeout_state: repository_ready_production_pending",
+        "closeout_state: production_closeout_verified",
         "min_consecutive_scheduled_runs: 2",
         "host_runner: /usr/local/bin/tokenkey-qa-maintenance.sh",
         "health_evaluator: ops/qa/qa_phase2_health.py",
@@ -419,13 +419,15 @@ def _rollout_failures(root: Path) -> list[str]:
             failures.append("rollout prod.QA_ARCHIVE_ENABLED.policy_target drift")
         if prod_archive.get("target_deploy_inject_default") is not True:
             failures.append("rollout prod.QA_ARCHIVE_ENABLED target must become true after closeout")
-        if prod_archive.get("closeout_state") != "repository_ready_production_pending":
+        if prod_archive.get("closeout_state") != "production_closeout_verified":
             failures.append("rollout prod.QA_ARCHIVE_ENABLED closeout state drift")
     if not isinstance(prod_timer, dict):
         failures.append("rollout prod.tokenkey_qa_maintenance_timer must be a mapping")
     else:
-        if prod_timer.get("closeout_deploy_state") != "disabled":
-            failures.append("rollout maintenance timer must stay disabled during closeout deploy")
+        if prod_timer.get("closeout_deploy_state") != "enabled":
+            failures.append("rollout maintenance timer closeout deploy state drift")
+        if prod_timer.get("observed_live_state") != "production_recloseout_verified":
+            failures.append("rollout maintenance timer observed live state drift")
         if prod_timer.get("policy_target_state") != "enabled":
             failures.append("rollout maintenance timer target drift")
         if prod_timer.get("min_consecutive_scheduled_runs") != 2:
@@ -441,7 +443,7 @@ def _rollout_failures(root: Path) -> list[str]:
             failures.append("rollout stale cleanup target drift")
         if prod_cleanup.get("archive_independent") is not True:
             failures.append("rollout stale cleanup must remain archive-independent")
-        if prod_cleanup.get("activation_state") != "pending_production_exact_plan":
+        if prod_cleanup.get("activation_state") != "production_export_orphan_activated":
             failures.append("rollout export orphan activation evidence drift")
     if not isinstance(edge_capture, dict):
         failures.append("rollout edge.QA_CAPTURE_ENABLED must be a mapping")
@@ -450,7 +452,7 @@ def _rollout_failures(root: Path) -> list[str]:
     recovery = prod.get("raw_archive_recovery")
     if not isinstance(recovery, dict) or recovery != {
         "repository_state": "ready",
-        "production_iam_state": "pending_apply",
+        "production_iam_state": "applied",
         "independent_evidence_state": "pending",
         "recovery_cli": "backend/cmd/qa-archive",
         "retirement_gate": "ops/qa/qa_archive_recovery_gate.py",


### PR DESCRIPTION
## 摘要

- 将 prod 上已完成的 QA Phase 2 re-closeout、age retention first apply、export orphan 激活事实写入 `deploy_rollout.yaml`
- 同步 `qa-lifecycle-ssot.py` 期望状态，避免 rollout 文档与 live 漂移
- 修复 `tokenkey-qa-maintenance.sh` selftest：真实容器默认 umask 会写出 0644 sentinel，导致 prod selftest 失败

## 风险

- 低：主要为 rollout SSOT 与 host runner selftest 单行修复；无 API/DB schema 变更
- prod 侧 closeout / cleanup 已在 SSM 执行完成，本 PR 是仓库事实对齐，不重复触发生产操作

## 验证

- `./scripts/preflight.sh` PASS（含 `qa-lifecycle-ssot.py`）
- prod 证据（本 PR 外已执行）：Phase 2 连续 2 次 timer run healthy；age retention 删除 109714 行；export orphan 删除 `traj-export-4288971549.zip`（~993MB）；stale cleanup timer enabled

## 提交

- 31903207c chore(qa): record prod Phase 2 closeout in rollout SSOT

最新提交：31903207c

Made with [Cursor](https://cursor.com)