### PR TITLE
fix(openai): 修复 OpenAI OAuth 5h 用量窗口长期显示 0%

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -626,7 +626,7 @@ func (s *AccountUsageService) getPassiveUsageForAccount(ctx context.Context, acc
 	case accountUsageWindowAdapterOpenAI:
 		// OpenAI OAuth（codex）账号：从 Extra 的 codex_*_used_percent 被动采样重建
 		// 5h/7d 窗口，绝不调用上游 /responses 探测。
-		info := s.buildPassiveOpenAIUsage(account)
+		info := s.buildPassiveOpenAIUsage(ctx, account)
 		attachUpstreamQuotaForAccount(account, info)
 		return info, nil
 	case accountUsageWindowAdapterKiro:
@@ -672,11 +672,10 @@ func (s *AccountUsageService) getPassiveUsageForAccount(ctx context.Context, acc
 // /responses 探测——这正是它与 getOpenAIUsage 的区别：后者会按条件主动探测，
 // 而被动列表端点（edge accounts overview）跨全部账号扇出，渲染概览时不能打上游。
 //
-// 刻意不补本地 usage 日志的窗口统计：edge 概览的 DTO（toEdgeUsageWindows）只取
-// utilization + reset，per-window 统计由前端从 today_stats 单独提供；没有任何调用
-// 方会读这里的 WindowStats，补了即死代码。无 codex 采样时窗口留空（cell 显示
-// "-"），与 anthropic 被动路径（buildPassiveWindow 无采样即 nil）同口径。
-func (s *AccountUsageService) buildPassiveOpenAIUsage(account *Account) *UsageInfo {
+// 当上游 codex 快照过期（窗口已 roll 但未收到新 x-codex 头）时，used% 会被丢弃，
+// 改由本地 usage 日志的 rolling 5h/7d WindowStats 让运营仍能看到近期 TokenKey 侧
+// 计费活动——与 getOpenAIUsage 主动路径同口径，避免「今日统计很高、5h 条却 0%」。
+func (s *AccountUsageService) buildPassiveOpenAIUsage(ctx context.Context, account *Account, preloaded ...*localWindowStatsForPassive) *UsageInfo {
 	now := time.Now()
 	usage := &UsageInfo{Source: "passive", UpdatedAt: &now}
 	if account == nil {
@@ -690,6 +689,11 @@ func (s *AccountUsageService) buildPassiveOpenAIUsage(account *Account) *UsageIn
 		usage.SevenDay = progress
 	}
 
+	if len(preloaded) > 0 && preloaded[0] != nil {
+		applyPreloadedCodexWindowStats(usage, preloaded[0])
+	} else {
+		s.attachOpenAICodexWindowStats(ctx, account, usage, now)
+	}
 	return usage
 }
 
@@ -844,21 +848,26 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 		return usage, nil
 	}
 
+	s.attachOpenAICodexWindowStats(ctx, account, usage, now)
+	return usage, nil
+}
+
+func (s *AccountUsageService) attachOpenAICodexWindowStats(ctx context.Context, account *Account, usage *UsageInfo, now time.Time) {
+	if s == nil || s.usageLogRepo == nil || account == nil || usage == nil {
+		return
+	}
 	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.FiveHour, 5*time.Hour, now)); err == nil {
 		if usage.FiveHour == nil {
 			usage.FiveHour = &UsageProgress{Utilization: 0}
 		}
 		usage.FiveHour.WindowStats = windowStatsFromAccountStats(stats)
 	}
-
 	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.SevenDay, 7*24*time.Hour, now)); err == nil {
 		if usage.SevenDay == nil {
 			usage.SevenDay = &UsageProgress{Utilization: 0}
 		}
 		usage.SevenDay.WindowStats = windowStatsFromAccountStats(stats)
 	}
-
-	return usage, nil
 }
 
 func shouldRefreshOpenAICodexSnapshot(account *Account, usage *UsageInfo, now time.Time) bool {
@@ -873,6 +882,11 @@ func shouldRefreshOpenAICodexSnapshot(account *Account, usage *UsageInfo, now ti
 	}
 	if account.IsRateLimited() {
 		return true
+	}
+	if account.Extra != nil {
+		if openAIQuotaWindowReset(account.Extra, "5h", now) || openAIQuotaWindowReset(account.Extra, "7d", now) {
+			return true
+		}
 	}
 	return isOpenAICodexSnapshotStale(account, now)
 }
@@ -1530,9 +1544,11 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 		}
 	}
 
-	// 窗口已过期（resetAt 在 now 之前）→ 额度已重置，归零
+	// 窗口已过期（resetAt 在 now 之前）且快照未刷新：used% 属于上一窗口，丢弃以免
+	// 展示误导性的 0%（旧实现）或过期高利用率。运营侧 rolling 窗口统计由
+	// attachOpenAICodexWindowStats 从本地 usage 日志补全。
 	if progress.ResetsAt != nil && !now.Before(*progress.ResetsAt) {
-		progress.Utilization = 0
+		return nil
 	}
 
 	return progress

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -254,47 +254,6 @@ func TestAccountUsageService_GetPassiveUsage_OpenAIOAuthRebuildsCodexWindows(t *
 	}
 }
 
-func TestAccountUsageService_GetPassiveUsage_OpenAIOAuthExpiredCodexFallsBackToLocalWindowStats(t *testing.T) {
-	t.Parallel()
-
-	now := time.Now()
-	acct := Account{
-		ID:       56,
-		Platform: PlatformOpenAI,
-		Type:     AccountTypeOAuth,
-		Extra: map[string]any{
-			"codex_5h_used_percent": 42.0,
-			"codex_5h_reset_at":     now.Add(-2 * time.Hour).UTC().Format(time.RFC3339),
-			"codex_7d_used_percent": 34.0,
-			"codex_7d_reset_at":     now.Add(5 * 24 * time.Hour).UTC().Format(time.RFC3339),
-		},
-	}
-	logRepo := &passiveBatchUsageLogRepo{
-		cost: map[int64]float64{56: 9.5},
-	}
-	svc := &AccountUsageService{
-		accountRepo:  &passiveBatchAccountRepo{accounts: []Account{acct}},
-		usageLogRepo: logRepo,
-	}
-
-	usage, err := svc.GetPassiveUsage(context.Background(), 56)
-	if err != nil {
-		t.Fatalf("GetPassiveUsage() error = %v", err)
-	}
-	if usage.FiveHour == nil || usage.FiveHour.Utilization != 0 {
-		t.Fatalf("expired codex 5h must not surface stale used%%, got %#v", usage.FiveHour)
-	}
-	if usage.FiveHour.WindowStats == nil || usage.FiveHour.WindowStats.Requests != 1 {
-		t.Fatalf("FiveHour.WindowStats = %#v, want local rolling stats", usage.FiveHour.WindowStats)
-	}
-	if usage.FiveHour.WindowStats.Cost != 9.5 {
-		t.Fatalf("FiveHour.WindowStats.Cost = %v, want 9.5", usage.FiveHour.WindowStats.Cost)
-	}
-	if usage.SevenDay == nil || usage.SevenDay.Utilization != 34.0 {
-		t.Fatalf("SevenDay = %#v, want active upstream util=34", usage.SevenDay)
-	}
-}
-
 func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -64,6 +64,19 @@ func TestShouldRefreshOpenAICodexSnapshot(t *testing.T) {
 	}, usage, now) {
 		t.Fatal("expected stale ws snapshot to trigger refresh")
 	}
+
+	if !shouldRefreshOpenAICodexSnapshot(&Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"codex_5h_used_percent": 10.0,
+			"codex_5h_reset_at":     now.Add(-time.Hour).UTC().Format(time.RFC3339),
+			"codex_7d_used_percent": 20.0,
+			"codex_7d_reset_at":     now.Add(48 * time.Hour).UTC().Format(time.RFC3339),
+		},
+	}, usage, now) {
+		t.Fatal("expected expired 5h codex window to trigger refresh even when 7d is still active")
+	}
 }
 
 // TestShouldRefreshOpenAICodexSnapshot_SparkShadowIgnoresWSv2 外审第9轮 P1:spark 影子用量走
@@ -241,24 +254,59 @@ func TestAccountUsageService_GetPassiveUsage_OpenAIOAuthRebuildsCodexWindows(t *
 	}
 }
 
+func TestAccountUsageService_GetPassiveUsage_OpenAIOAuthExpiredCodexFallsBackToLocalWindowStats(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	acct := Account{
+		ID:       56,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"codex_5h_used_percent": 42.0,
+			"codex_5h_reset_at":     now.Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+			"codex_7d_used_percent": 34.0,
+			"codex_7d_reset_at":     now.Add(5 * 24 * time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+	logRepo := &passiveBatchUsageLogRepo{
+		cost: map[int64]float64{56: 9.5},
+	}
+	svc := &AccountUsageService{
+		accountRepo:  &passiveBatchAccountRepo{accounts: []Account{acct}},
+		usageLogRepo: logRepo,
+	}
+
+	usage, err := svc.GetPassiveUsage(context.Background(), 56)
+	if err != nil {
+		t.Fatalf("GetPassiveUsage() error = %v", err)
+	}
+	if usage.FiveHour == nil || usage.FiveHour.Utilization != 0 {
+		t.Fatalf("expired codex 5h must not surface stale used%%, got %#v", usage.FiveHour)
+	}
+	if usage.FiveHour.WindowStats == nil || usage.FiveHour.WindowStats.Requests != 1 {
+		t.Fatalf("FiveHour.WindowStats = %#v, want local rolling stats", usage.FiveHour.WindowStats)
+	}
+	if usage.FiveHour.WindowStats.Cost != 9.5 {
+		t.Fatalf("FiveHour.WindowStats.Cost = %v, want 9.5", usage.FiveHour.WindowStats.Cost)
+	}
+	if usage.SevenDay == nil || usage.SevenDay.Utilization != 34.0 {
+		t.Fatalf("SevenDay = %#v, want active upstream util=34", usage.SevenDay)
+	}
+}
+
 func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
 
-	t.Run("expired 5h window zeroes utilization", func(t *testing.T) {
+	t.Run("expired 5h window drops stale upstream sample", func(t *testing.T) {
 		extra := map[string]any{
 			"codex_5h_used_percent": 42.0,
 			"codex_5h_reset_at":     "2026-03-16T10:00:00Z", // 2h ago
 		}
 		progress := buildCodexUsageProgressFromExtra(extra, "5h", now)
-		if progress == nil {
-			t.Fatal("expected non-nil progress")
-		}
-		if progress.Utilization != 0 {
-			t.Fatalf("expected Utilization=0 for expired window, got %v", progress.Utilization)
-		}
-		if progress.RemainingSeconds != 0 {
-			t.Fatalf("expected RemainingSeconds=0, got %v", progress.RemainingSeconds)
+		if progress != nil {
+			t.Fatalf("expected nil progress for expired window, got %#v", progress)
 		}
 	})
 
@@ -277,17 +325,14 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 		}
 	})
 
-	t.Run("expired 7d window zeroes utilization", func(t *testing.T) {
+	t.Run("expired 7d window drops stale upstream sample", func(t *testing.T) {
 		extra := map[string]any{
 			"codex_7d_used_percent": 88.0,
 			"codex_7d_reset_at":     "2026-03-15T00:00:00Z", // yesterday
 		}
 		progress := buildCodexUsageProgressFromExtra(extra, "7d", now)
-		if progress == nil {
-			t.Fatal("expected non-nil progress")
-		}
-		if progress.Utilization != 0 {
-			t.Fatalf("expected Utilization=0 for expired 7d window, got %v", progress.Utilization)
+		if progress != nil {
+			t.Fatalf("expected nil progress for expired 7d window, got %#v", progress)
 		}
 	})
 }

--- a/backend/internal/service/account_usage_service_tk_passive_batch.go
+++ b/backend/internal/service/account_usage_service_tk_passive_batch.go
@@ -54,6 +54,7 @@ func (s *AccountUsageService) GetPassiveUsageBatch(ctx context.Context, accountI
 	// GetAccountWindowStatsBatch，避免账号列表页退化成 per-account 聚合 SQL。
 	s.prefetchWindowStatsForPassive(ctx, accounts)
 	localWindows := s.loadLocalWindowStatsForPassive(ctx, accounts)
+	openAIWindows := s.loadOpenAICodexWindowStatsForPassive(ctx, accounts)
 
 	for _, account := range accounts {
 		if account == nil {
@@ -69,6 +70,9 @@ func (s *AccountUsageService) GetPassiveUsageBatch(ctx context.Context, accountI
 		if windows, ok := localWindows[account.ID]; ok {
 			now := time.Now()
 			usage = buildLocalWindowUsageFromStats(now, windows.fiveHour, windows.sevenDay)
+			attachUpstreamQuotaForAccount(account, usage)
+		} else if windows, ok := openAIWindows[account.ID]; ok {
+			usage = s.buildPassiveOpenAIUsage(ctx, account, &windows)
 			attachUpstreamQuotaForAccount(account, usage)
 		} else {
 			// TK perf: the account is already fully loaded (GetByIDs above), so build
@@ -196,4 +200,67 @@ func (s *AccountUsageService) loadLocalWindowStatsForPassive(ctx context.Context
 		result[id] = windows
 	}
 	return result
+}
+
+func (s *AccountUsageService) loadOpenAICodexWindowStatsForPassive(ctx context.Context, accounts []*Account) map[int64]localWindowStatsForPassive {
+	result := make(map[int64]localWindowStatsForPassive)
+	if s.usageLogRepo == nil || len(accounts) == 0 {
+		return result
+	}
+
+	ids := make([]int64, 0, len(accounts))
+	for _, account := range accounts {
+		if account == nil || accountUsageWindowAdapterFor(account) != accountUsageWindowAdapterOpenAI {
+			continue
+		}
+		ids = append(ids, account.ID)
+	}
+	if len(ids) == 0 {
+		return result
+	}
+
+	now := time.Now()
+	if batchReader, ok := s.usageLogRepo.(accountWindowStatsBatchReader); ok {
+		fiveHourByAccount, fiveErr := batchReader.GetAccountWindowStatsBatch(ctx, ids, now.Add(-5*time.Hour))
+		sevenDayByAccount, sevenErr := batchReader.GetAccountWindowStatsBatch(ctx, ids, now.Add(-7*24*time.Hour))
+		if fiveErr == nil && sevenErr == nil {
+			for _, id := range ids {
+				result[id] = localWindowStatsForPassive{
+					fiveHour: fiveHourByAccount[id],
+					sevenDay: sevenDayByAccount[id],
+				}
+			}
+			return result
+		}
+	}
+
+	for _, id := range ids {
+		var windows localWindowStatsForPassive
+		if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, id, now.Add(-5*time.Hour)); err == nil {
+			windows.fiveHour = stats
+		}
+		if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, id, now.Add(-7*24*time.Hour)); err == nil {
+			windows.sevenDay = stats
+		}
+		result[id] = windows
+	}
+	return result
+}
+
+func applyPreloadedCodexWindowStats(usage *UsageInfo, preloaded *localWindowStatsForPassive) {
+	if usage == nil || preloaded == nil {
+		return
+	}
+	if preloaded.fiveHour != nil {
+		if usage.FiveHour == nil {
+			usage.FiveHour = &UsageProgress{Utilization: 0}
+		}
+		usage.FiveHour.WindowStats = windowStatsFromAccountStats(preloaded.fiveHour)
+	}
+	if preloaded.sevenDay != nil {
+		if usage.SevenDay == nil {
+			usage.SevenDay = &UsageProgress{Utilization: 0}
+		}
+		usage.SevenDay.WindowStats = windowStatsFromAccountStats(preloaded.sevenDay)
+	}
 }

--- a/backend/internal/service/account_usage_service_tk_passive_batch_test.go
+++ b/backend/internal/service/account_usage_service_tk_passive_batch_test.go
@@ -140,6 +140,40 @@ func TestGetPassiveUsageBatch_EqualsSinglePerAccount(t *testing.T) {
 	require.Zero(t, logRepo.singleCalls.Load(), "prefetched cache must spare per-account window-stats single queries")
 }
 
+func TestAccountUsageService_GetPassiveUsage_OpenAIOAuthExpiredCodexFallsBackToLocalWindowStats(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	acct := Account{
+		ID:       56,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"codex_5h_used_percent": 42.0,
+			"codex_5h_reset_at":     now.Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+			"codex_7d_used_percent": 34.0,
+			"codex_7d_reset_at":     now.Add(5 * 24 * time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+	logRepo := &passiveBatchUsageLogRepo{
+		cost: map[int64]float64{56: 9.5},
+	}
+	svc := &AccountUsageService{
+		accountRepo:  &passiveBatchAccountRepo{accounts: []Account{acct}},
+		usageLogRepo: logRepo,
+	}
+
+	usage, err := svc.GetPassiveUsage(context.Background(), 56)
+	require.NoError(t, err)
+	require.NotNil(t, usage.FiveHour)
+	require.Zero(t, usage.FiveHour.Utilization, "expired codex 5h must not surface stale used%%")
+	require.NotNil(t, usage.FiveHour.WindowStats)
+	require.Equal(t, int64(1), usage.FiveHour.WindowStats.Requests)
+	require.Equal(t, 9.5, usage.FiveHour.WindowStats.Cost)
+	require.NotNil(t, usage.SevenDay)
+	require.Equal(t, 34.0, usage.SevenDay.Utilization)
+}
+
 func TestGetPassiveUsageBatch_IncludesGrokLocalWindows(t *testing.T) {
 	accounts := []Account{
 		{ID: 9, Platform: PlatformGrok, Type: AccountTypeAPIKey, Status: StatusActive},

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 678,
-  "hash": "ee8ad03cb25438f328cb6ce382f66f35e7168018985e7442f6b4524097f436f2",
+  "hash": "37c19c5d0d3be029ba796d6084d5a9e3e577d7197ba83e97ca33bf9c61d80a30",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/usage-cells/OpenAIUsageCell.vue
+++ b/frontend/src/components/account/usage-cells/OpenAIUsageCell.vue
@@ -8,7 +8,7 @@
         :utilization="usageInfo.five_hour.utilization"
         :resets-at="usageInfo.five_hour.resets_at"
         :window-stats="usageInfo.five_hour.window_stats"
-        :show-now-when-idle="true"
+        :show-now-when-idle="showNowWhenIdleForWindow(usageInfo.five_hour)"
         color="indigo"
       />
       <UsageProgressBar
@@ -17,7 +17,7 @@
         :utilization="usageInfo.seven_day.utilization"
         :resets-at="usageInfo.seven_day.resets_at"
         :window-stats="usageInfo.seven_day.window_stats"
-        :show-now-when-idle="true"
+        :show-now-when-idle="showNowWhenIdleForWindow(usageInfo.seven_day)"
         color="emerald"
       />
       <UpstreamQuotaSummary
@@ -99,4 +99,17 @@ const { loading, activeQueryLoading, usageInfo, loadActiveUsage } = useAccountUs
 const hasOpenAIUsageFallback = computed(() => {
   return !!usageInfo.value?.five_hour || !!usageInfo.value?.seven_day
 })
+
+/** Upstream codex % missing/stale but local rolling window stats show activity — don't show「现在」. */
+function showNowWhenIdleForWindow(
+  progress: { utilization?: number; resets_at?: string | null; window_stats?: { requests?: number; tokens?: number } | null } | null | undefined
+): boolean {
+  if (!progress) return true
+  const ws = progress.window_stats
+  const hasLocalActivity = !!(ws && ((ws.requests ?? 0) > 0 || (ws.tokens ?? 0) > 0))
+  if (progress.utilization != null && progress.utilization <= 0 && hasLocalActivity && !progress.resets_at) {
+    return false
+  }
+  return true
+}
 </script>


### PR DESCRIPTION
## 摘要

- 修复 OpenAI OAuth 账号在 5h codex 窗口 roll 后、未收到新 `x-codex-*` 响应头时，管理员面板 5h 条长期显示 **0% +「现在」**、与今日统计/7d 窗口严重脱节的问题。
- 过期 upstream `used%` 改为丢弃而非误归零；被动/批量 passive 路径补 rolling 5h/7d 本地 WindowStats；窗口过期时触发 codex 快照主动刷新。
- 前端：本地窗口有活动但 upstream % 缺失时，不再显示误导性「现在」。

sentinel-registry-reviewed — load-bearing 变更已由聚焦回归测试锚定（`TestBuildCodexUsageProgressFromExtra_*`、`TestAccountUsageService_GetPassiveUsage_OpenAIOAuthExpiredCodexFallsBackToLocalWindowStats`、`TestShouldRefreshOpenAICodexSnapshot`），无需新增 sentinel 条目。

## 风险

- 常规风险：仅影响 OpenAI OAuth 用量展示与 passive 刷新触发逻辑，不改变计费或调度限流行为。
- 5h 进度条上的 upstream 百分比仍依赖 codex 快照；本地 req/token/计费徽章来自 TokenKey usage 日志 rolling 窗口，与「今日统计」口径不同。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service/ -run 'TestBuildCodexUsageProgress|TestAccountUsageService_GetPassiveUsage_OpenAI|TestShouldRefreshOpenAICodexSnapshot|TestGetPassiveUsageBatch' -count=1
cd backend && go test ./internal/service/ -count=0  # golangci 默认 build tag 编译
cd frontend && pnpm build  # dist source stamp
```

结果：通过。

## 提交

- 6eecdc650 fix(openai): address review — test build tag, sync frontend dist
- 24aceff33 fix(openai): 修复 5h 用量窗口过期后长期显示 0% 的问题

最新提交：6eecdc650

Made with [Cursor](https://cursor.com)