### PR TITLE
fix(qa): Phase 2 运营控制面闭环（maintenance / live health / SSOT）

### DIFF
--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -323,6 +323,36 @@ jobs:
             fi
           fi
 
+          if [ "$TARGET_ID" = "prod" ]; then
+            PHASE2_PROBE="$(bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-qa-phase2-live-health.sh --with ops/lib/resolve-app-container.sh --comment "daily qa phase2 live health" --timeout-seconds 120 2>>"$STDERR" || true)" # preflight-allow: swallow — probe failure becomes explicit finding
+            PHASE2_VERDICT="$(printf '%s' "$PHASE2_PROBE" | python3 ops/qa/prod_phase2_live_health.py --from-probe-stdin --json 2>>"$STDERR" || echo '{"health":{"status":"failed","reasons":["qa_phase2_live_health_eval_failed"]},"iam_contract":{"ok":false,"status":"unknown"}}')"
+            printf 'qa_phase2_live_health: %s\n' "$PHASE2_VERDICT" >> "$STDOUT"
+            PHASE2_STATUS="$(printf '%s' "$PHASE2_VERDICT" | jq -r '.health.status // "failed"')"
+            PHASE2_REASONS="$(printf '%s' "$PHASE2_VERDICT" | jq -r '[.health.reasons[]?] | join("; ")')"
+            PHASE2_IAM_OK="$(printf '%s' "$PHASE2_VERDICT" | jq -r '.iam_contract.ok // false')"
+            case "$PHASE2_STATUS" in
+              healthy)
+                add_finding "qa_phase2_live_health" "ok" "info" "QA Phase 2 live maintenance health passed ($TARGET_ID)" "Forward archive systemd/receipt/heartbeat/control facts are correlated." "qa-phase2-live-health|$TARGET_ID"
+                ;;
+              degraded)
+                add_finding "qa_phase2_live_health" "warning" "warning" "QA Phase 2 live maintenance health degraded ($TARGET_ID)" "$PHASE2_REASONS" "qa-phase2-live-health|$TARGET_ID"
+                ;;
+              *)
+                add_finding "qa_phase2_live_health" "issue_candidate" "error" "QA Phase 2 live maintenance health failed ($TARGET_ID)" "$PHASE2_REASONS" "qa-phase2-live-health|$TARGET_ID"
+                ;;
+            esac
+            if [ "$PHASE2_IAM_OK" != "true" ]; then
+              PHASE2_IAM_FAIL="$(printf '%s' "$PHASE2_VERDICT" | jq -r '[.iam_contract.failures[]?] | join("; ")')"
+              add_finding "qa_raw_archive_iam_contract" "issue_candidate" "error" "QA raw archive IAM contract drift ($TARGET_ID)" "$PHASE2_IAM_FAIL" "qa-raw-archive-iam|$TARGET_ID"
+            else
+              add_finding "qa_raw_archive_iam_contract" "ok" "info" "QA raw archive IAM contract matches repository ($TARGET_ID)" "Live bucket policy matches suffix-scoped app role contract." "qa-raw-archive-iam|$TARGET_ID"
+            fi
+            while IFS= read -r PHASE2_WARNING; do
+              [ -n "$PHASE2_WARNING" ] || continue
+              add_finding "qa_phase2_live_health" "warning" "warning" "QA Phase 2 live probe warning ($TARGET_ID)" "$PHASE2_WARNING" "qa-phase2-live-warning|$TARGET_ID|$PHASE2_WARNING"
+            done < <(printf '%s' "$PHASE2_VERDICT" | jq -r '.warnings[]?')
+          fi
+
           if [ "$TARGET_KIND" = "edge" ] && [ -n "$API_URL" ]; then
             BLOCKED_CODE="$(curl -sS -o "$OUT/edge-blocked.json" -w '%{http_code}' -H 'Authorization: Bearer tk_edge_smoke_should_not_work' "$API_URL/v1/models" 2>>"$STDERR" || echo 000)"
             if [ "$BLOCKED_CODE" = "403" ]; then

--- a/backend/cmd/qa-archive/main.go
+++ b/backend/cmd/qa-archive/main.go
@@ -220,6 +220,7 @@ func runWindowCommand(ctx context.Context, command string, args []string, out io
 		}
 		defer func() { _ = verified.Close() }()
 		if err := validateSecureRestoreTree(filepath.Clean(*outputDir)); err != nil {
+			_ = os.RemoveAll(filepath.Clean(*outputDir))
 			return err
 		}
 		receipt := verifiedReceipt(command, commitKey, verified)

--- a/backend/cmd/qa-archive/main_test.go
+++ b/backend/cmd/qa-archive/main_test.go
@@ -338,6 +338,38 @@ func TestUS045_WorkstationRecoveryRestoreUsesExplicitLocalRootAndSecureModes(t *
 	}
 }
 
+func TestUS045_WorkstationRecoveryRestoreRemovesOutputWhenSecureValidationFails(t *testing.T) {
+	restoreRoot := filepath.Join(t.TempDir(), "workstation-restore-root")
+	output := filepath.Join(restoreRoot, "window-20260807T0100Z")
+	deps := cliDeps{
+		loadConfig: func() (*config.Config, error) { return nil, errors.New("must not run") },
+		openDB:     func(string, string) (*sql.DB, error) { return nil, errors.New("must not run") },
+		newRecoveryStore: func(context.Context, archive.WorkstationRecoveryConfig) (archive.ReadOnlyObjectStore, error) {
+			return archive.NewMemoryObjectStore(), nil
+		},
+		verifyCommit: func(_ context.Context, _ archive.ReadOnlyObjectStore, _ string, restoreDir string) (archive.VerifiedCommit, error) {
+			if err := os.Mkdir(restoreDir, 0o700); err != nil {
+				return archive.VerifiedCommit{}, err
+			}
+			if err := os.Symlink("/etc/passwd", filepath.Join(restoreDir, "leak")); err != nil {
+				return archive.VerifiedCommit{}, err
+			}
+			return archive.VerifiedCommit{Document: archive.CommitDocument{WindowStart: testWindow, WindowEnd: testWindow.Add(time.Hour)}, ETag: "restore-etag"}, nil
+		},
+	}
+	args := append(workstationArgs("restore"),
+		"--restore-root", restoreRoot, "--output", output,
+		"--confirm", windowConfirmation(restoreConfirmationPrefix, testWindow),
+	)
+	err := runCLI(context.Background(), args, &bytes.Buffer{}, deps)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("runCLI() error=%v", err)
+	}
+	if _, statErr := os.Stat(output); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("output dir still exists after failed secure validation: statErr=%v", statErr)
+	}
+}
+
 func TestUS045_WorkstationRecoveryRestoreRejectsMissingPrivacyConfirmationBeforeDependencies(t *testing.T) {
 	called := false
 	args := append(workstationArgs("restore"), "--restore-root", t.TempDir(), "--output", filepath.Join(t.TempDir(), "restore"))

--- a/backend/cmd/server/qa_maintenance.go
+++ b/backend/cmd/server/qa_maintenance.go
@@ -105,12 +105,8 @@ func runQAMaintenanceArchiveCycle(
 	}
 	result.CompensationSelection = &selection
 	if selection.Disposition == archive.CatchupDispositionSourceUnavailableAfterRetention {
-		return failQAMaintenanceCycle(
-			result,
-			"compensation_select",
-			archive.IntegritySourceUnavailableAfterRetention,
-			fmt.Errorf("compensation %s: %s", selection.Window.Start.Format(time.RFC3339), archive.IntegritySourceUnavailableAfterRetention),
-		)
+		// Terminal catchup gap is recorded during select; the sealed normal hour stands alone.
+		return result, nil
 	}
 	if selection.Disposition != archive.CatchupDispositionReconcile {
 		return failQAMaintenanceCycle(
@@ -362,6 +358,9 @@ func runQAMaintenanceCommand(
 			}
 			if cycle.Compensation != nil {
 				candidate = qaMaintenancePlanFromReceipt(*cycle.Compensation, true)
+			} else if cycle.CompensationSelection.Disposition == archive.CatchupDispositionSourceUnavailableAfterRetention {
+				candidate.State = archive.StateFailed
+				candidate.VerificationErrorCode = archive.IntegritySourceUnavailableAfterRetention
 			} else {
 				candidate.State = archive.StateFailed
 				candidate.VerificationErrorCode = cycle.FailureCode

--- a/backend/cmd/server/qa_maintenance_phase2_test.go
+++ b/backend/cmd/server/qa_maintenance_phase2_test.go
@@ -321,6 +321,85 @@ func TestUS045_QAMaintenanceCommandReportsCommittedNormalAndCompensationFacts(t 
 	}
 }
 
+func TestUS045_QAMaintenanceCommandSucceedsWithTerminalCatchupGap(t *testing.T) {
+	t.Setenv("QA_MAINTENANCE_RUN_ID", "run-terminal-045")
+	t.Setenv("QA_MAINTENANCE_TRIGGER", "timer")
+	db, mockDB, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	mockDB.ExpectPing()
+	mockDB.ExpectExec("SET lock_timeout = '100ms'").WillReturnResult(sqlmock.NewResult(0, 0))
+	mockDB.ExpectExec("SET statement_timeout = '120s'").WillReturnResult(sqlmock.NewResult(0, 0))
+	mockDB.ExpectClose()
+
+	normal := us045Window(3)
+	terminal := us045Window(1)
+	now := normal.End.Add(15 * time.Minute)
+	reconcileCalls := 0
+	var heartbeat *service.OpsUpsertJobHeartbeatInput
+	deps := us045CommandDeps(db, now)
+	deps.reconcileShard = func(_ context.Context, _ *sql.Conn, _ archive.ObjectStore, window archive.Window, _, _ string) (archive.ReconcileReceipt, error) {
+		reconcileCalls++
+		if window != normal {
+			t.Fatalf("reconcile window=%+v", window)
+		}
+		return us045Receipt(normal, "normal-etag"), nil
+	}
+	deps.selectOldest = func(_ context.Context, _ *sql.Conn, gotNormal archive.Window, _ time.Time) (archive.CatchupSelection, bool, error) {
+		if gotNormal != normal {
+			t.Fatalf("normal=%+v", gotNormal)
+		}
+		return archive.CatchupSelection{
+			Window:      terminal,
+			ShardID:     46,
+			Disposition: archive.CatchupDispositionSourceUnavailableAfterRetention,
+		}, true, nil
+	}
+	deps.writeHeartbeat = func(_ context.Context, _ *sql.DB, input *service.OpsUpsertJobHeartbeatInput) error {
+		heartbeat = input
+		return nil
+	}
+
+	out := &bytes.Buffer{}
+	if err := runQAMaintenanceCommand(context.Background(), []string{
+		"--qa-maintenance-once", "--confirm", qaMaintenanceConfirmation,
+	}, out, deps); err != nil {
+		t.Fatal(err)
+	}
+	if reconcileCalls != 1 {
+		t.Fatalf("reconcileCalls=%d", reconcileCalls)
+	}
+	if heartbeat == nil || heartbeat.LastResult == nil || !strings.Contains(*heartbeat.LastResult, "status=committed") {
+		t.Fatalf("heartbeat=%+v", heartbeat)
+	}
+	if !strings.Contains(*heartbeat.LastResult, "compensation_error_code="+archive.IntegritySourceUnavailableAfterRetention) {
+		t.Fatalf("heartbeat result %q missing terminal compensation fact", *heartbeat.LastResult)
+	}
+	var receipt struct {
+		OK           bool `json:"ok"`
+		Plan         struct {
+			CommitETag string `json:"commit_etag"`
+		} `json:"plan"`
+		Compensation *struct {
+			State                 string `json:"state"`
+			VerificationErrorCode string `json:"verification_error_code"`
+		} `json:"compensation"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if !receipt.OK || receipt.Plan.CommitETag != "normal-etag" || receipt.Compensation == nil ||
+		receipt.Compensation.State != archive.StateFailed ||
+		receipt.Compensation.VerificationErrorCode != archive.IntegritySourceUnavailableAfterRetention {
+		t.Fatalf("receipt=%+v", receipt)
+	}
+	if err := mockDB.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestUS045_QAMaintenanceCommandFailureHeartbeatPreservesNormalSuccess(t *testing.T) {
 	t.Setenv("QA_MAINTENANCE_RUN_ID", "run-failure-045")
 	t.Setenv("QA_MAINTENANCE_TRIGGER", "timer")

--- a/backend/cmd/server/qa_maintenance_phase2_test.go
+++ b/backend/cmd/server/qa_maintenance_phase2_test.go
@@ -159,21 +159,23 @@ func TestUS045_NormalFirstBoundedCompensationReportsSelectionAndTerminalFailures
 	for _, test := range []struct {
 		name            string
 		selectCandidate func(context.Context, archive.Window, time.Time) (archive.CatchupSelection, bool, error)
-		want            string
+		wantErr         bool
+		wantContains    string
 	}{
 		{
 			name: "selection failure",
 			selectCandidate: func(context.Context, archive.Window, time.Time) (archive.CatchupSelection, bool, error) {
 				return archive.CatchupSelection{}, false, errors.New("cutover unavailable")
 			},
-			want: "select compensation",
+			wantErr:      true,
+			wantContains: "select compensation",
 		},
 		{
 			name: "terminal classification",
 			selectCandidate: func(context.Context, archive.Window, time.Time) (archive.CatchupSelection, bool, error) {
 				return archive.CatchupSelection{Window: us045Window(1), ShardID: 46, Disposition: archive.CatchupDispositionSourceUnavailableAfterRetention}, true, nil
 			},
-			want: archive.IntegritySourceUnavailableAfterRetention,
+			wantErr: false,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -185,11 +187,20 @@ func TestUS045_NormalFirstBoundedCompensationReportsSelectionAndTerminalFailures
 				},
 				selectOldest: test.selectCandidate,
 			})
-			if err == nil || !strings.Contains(err.Error(), test.want) {
+			if test.wantErr {
+				if err == nil || !strings.Contains(err.Error(), test.wantContains) {
+					t.Fatalf("err=%v", err)
+				}
+			} else if err != nil {
 				t.Fatalf("err=%v", err)
 			}
 			if reconcileCalls != 1 || result.Normal.CommitETag != "normal-etag" {
 				t.Fatalf("calls=%d result=%+v", reconcileCalls, result)
+			}
+			if !test.wantErr &&
+				(result.CompensationSelection == nil ||
+					result.CompensationSelection.Disposition != archive.CatchupDispositionSourceUnavailableAfterRetention) {
+				t.Fatalf("result=%+v", result)
 			}
 		})
 	}

--- a/ops/observability/probe-qa-phase2-live-health.sh
+++ b/ops/observability/probe-qa-phase2-live-health.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Read-only prod QA Phase 2 live health snapshot for ops-daily-diagnostics.
+set -u
+
+PSQL=(docker exec -e 'PGOPTIONS=-c default_transaction_read_only=on -c lock_timeout=100ms -c statement_timeout=5s' tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
+RECEIPT="${QA_MAINTENANCE_RECEIPT:-/var/lib/tokenkey/qa-maintenance-last-run.json}"
+
+timer_enabled=false
+timer_active=false
+if systemctl is-enabled tokenkey-qa-maintenance.timer >/dev/null 2>&1; then
+  timer_enabled=true
+fi
+if systemctl is-active tokenkey-qa-maintenance.timer >/dev/null 2>&1; then
+  timer_active=true
+fi
+service_result="$(systemctl show tokenkey-qa-maintenance.service -p Result --value 2>/dev/null || true)"
+service_finished="$(systemctl show tokenkey-qa-maintenance.service -p ExecMainExitTimestamp --value 2>/dev/null || true)"
+if [ -z "${service_result}" ]; then
+  service_result=unknown
+fi
+export TK_TIMER_ENABLED="${timer_enabled}"
+export TK_TIMER_ACTIVE="${timer_active}"
+export TK_SERVICE_RESULT="${service_result}"
+export TK_SERVICE_FINISHED="${service_finished}"
+
+python3 - <<'PY'
+import json
+import os
+
+def _finished_at() -> str | None:
+    value = os.environ.get("TK_SERVICE_FINISHED", "").strip()
+    return value or None
+
+payload = {
+    "timer_enabled": os.environ.get("TK_TIMER_ENABLED") == "true",
+    "timer_active": os.environ.get("TK_TIMER_ACTIVE") == "true",
+    "service_result": os.environ.get("TK_SERVICE_RESULT", "unknown"),
+    "finished_at": _finished_at(),
+}
+print("PHASE2SYSTEMD " + json.dumps(payload, ensure_ascii=True, sort_keys=True))
+PY
+
+if [ -r "${RECEIPT}" ]; then
+  python3 - "${RECEIPT}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+try:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    payload = None
+print("PHASE2RECEIPT " + (json.dumps(payload, ensure_ascii=True, sort_keys=True) if payload is not None else "null"))
+PY
+else
+  printf 'PHASE2RECEIPT null\n'
+fi
+
+"${PSQL[@]}" -c "
+WITH heartbeat AS (
+  SELECT last_run_at, last_success_at, last_error_at, last_result
+  FROM ops_job_heartbeats
+  WHERE job_name = 'qa-maintenance'
+  LIMIT 1
+), cutover AS (
+  SELECT window_start
+  FROM qa_archive_shards
+  WHERE forward_cutover IS TRUE
+  ORDER BY window_start
+  LIMIT 1
+), latest_normal AS (
+  SELECT s.window_start, s.state, s.commit_etag, s.cleanup_eligible,
+         (s.restore_verified_at IS NOT NULL) AS restore_verified
+  FROM qa_archive_shards s
+  CROSS JOIN cutover c
+  WHERE s.generation = 0
+    AND s.window_start >= c.window_start
+  ORDER BY s.window_start DESC
+  LIMIT 1
+), latest_comp AS (
+  SELECT s.window_start, s.state, s.commit_etag, s.cleanup_eligible,
+         (s.restore_verified_at IS NOT NULL) AS restore_verified
+  FROM qa_archive_shards s
+  CROSS JOIN cutover c
+  CROSS JOIN latest_normal n
+  WHERE s.generation = 0
+    AND s.window_start >= c.window_start
+    AND s.window_start < n.window_start
+    AND s.state <> 'committed'
+  ORDER BY s.window_start ASC
+  LIMIT 1
+), terminal AS (
+  SELECT COALESCE(
+    json_agg(
+      json_build_object(
+        'window_start', to_char(s.window_start AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"'),
+        'verification_error_code', s.verification_error_code
+      )
+      ORDER BY s.window_start
+    ),
+    '[]'::json
+  ) AS items
+  FROM qa_archive_shards s
+  CROSS JOIN cutover c
+  CROSS JOIN latest_normal n
+  WHERE s.generation = 0
+    AND s.window_start >= c.window_start
+    AND s.window_start < n.window_start
+    AND s.state = 'failed'
+    AND s.verification_error_code IS NOT NULL
+), qa_parts AS (
+  SELECT EXISTS (
+    SELECT 1
+    FROM pg_inherits i
+    JOIN pg_class parent ON parent.oid = i.inhparent
+    JOIN pg_class child ON child.oid = i.inhrelid
+    WHERE parent.relname = 'qa_records'
+      AND child.relname <> 'qa_records_default'
+  ) AS has_non_default_partitions
+)
+SELECT 'PHASE2HEARTBEAT ' || COALESCE((SELECT row_to_json(h)::text FROM heartbeat h), 'null')
+UNION ALL
+SELECT 'PHASE2ARCHIVE ' || row_to_json(v)::text
+FROM (
+  SELECT
+    (SELECT row_to_json(n) FROM (
+      SELECT to_char(window_start AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS window_start,
+             state, commit_etag, cleanup_eligible, restore_verified
+      FROM latest_normal
+    ) n) AS normal,
+    (SELECT row_to_json(c) FROM (
+      SELECT to_char(window_start AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS window_start,
+             state, commit_etag, cleanup_eligible, restore_verified
+      FROM latest_comp
+    ) c) AS compensation,
+    (SELECT items FROM terminal) AS terminal_failures_after_cutover
+) v
+UNION ALL
+SELECT 'PHASE2QARECORDS ' || row_to_json(v)::text
+FROM (
+  SELECT CASE WHEN has_non_default_partitions THEN 'partitioned' ELSE 'default_only' END AS partition_owner
+  FROM qa_parts
+) v;
+"

--- a/ops/observability/test_ops_daily_diagnostics_workflow.py
+++ b/ops/observability/test_ops_daily_diagnostics_workflow.py
@@ -136,6 +136,14 @@ class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
         self.assertNotIn("BlockDeviceMappings[0]", snapshot_block)
         self.assertNotIn("describe-snapshots", snapshot_block)
 
+    def test_qa_phase2_live_health_probe_is_wired_for_prod(self) -> None:
+        text = workflow_text()
+        self.assertIn("probe-qa-phase2-live-health.sh", text)
+        self.assertIn("prod_phase2_live_health.py --from-probe-stdin", text)
+        self.assertIn("qa-phase2-live-health|$TARGET_ID", text)
+        self.assertIn("qa-raw-archive-iam|$TARGET_ID", text)
+        self.assertLess(text.index("SAFETY_VERDICT="), text.index("PHASE2_PROBE="))
+
     def test_internal_health_probe_uses_drain_immune_live_endpoint(self) -> None:
         commands = extract_runtime_params_commands()
         internal_start = commands.index("echo ===INTERNAL_HEALTH===")

--- a/ops/qa/deploy_rollout.yaml
+++ b/ops/qa/deploy_rollout.yaml
@@ -3,6 +3,7 @@ schema_version: 1
 # Target runtime policy values: ops/qa/policy.yaml (SSOT).
 # Rollout gates keep deploy defaults conservative until the approved Phase 2 production-
 # integrity closeout is implemented and verified; document approval alone does not open the gate.
+# Repository states describe code/design readiness; observed_* fields are reconciled by live probes.
 
 prod:
   QA_ARCHIVE_ENABLED:
@@ -10,14 +11,19 @@ prod:
     policy_target: prod.archive.enabled
     target_deploy_inject_default: true
     enable_after: docs/approved/design-qa-phase2-archive-closeout.md#production-rollout
-    closeout_state: production_closeout_verified
+    repository_closeout_state: production_closeout_verified
+    observed_live_state: pending_live_reconciliation
   tokenkey_qa_maintenance_timer:
-    observed_live_state: production_recloseout_verified
+    repository_closeout_state: production_recloseout_verified
+    observed_live_state: pending_live_reconciliation
     closeout_deploy_state: enabled
     policy_target_state: enabled
     min_consecutive_scheduled_runs: 2
     host_runner: /usr/local/bin/tokenkey-qa-maintenance.sh
     health_evaluator: ops/qa/qa_phase2_health.py
+    live_health_probe: ops/observability/probe-qa-phase2-live-health.sh
+    live_health_evaluator: ops/qa/prod_phase2_live_health.py
+    catchup_gap_policy: accepted_terminal
     health_evidence:
       - systemd
       - host_receipt
@@ -30,12 +36,20 @@ prod:
     export_orphan_apply_command: /usr/local/bin/tokenkey-qa-stale-cleanup.sh --apply-export-orphans
     export_orphan_activation_marker: /var/lib/tokenkey/qa-export-orphan-cleanup-activated.json
     activation_state: production_export_orphan_activated
+  qa_records:
+    partition_owner_repository: default_only
+    partition_owner_observed: pending_live_probe
+  user_export:
+    phase3_worker_repository_state: approved_fargate_worker
+    phase3_worker_observed_state: transitional_in_prod
   QA_CAPTURE_ENABLED:
     deploy_inject: edge_only_false
     policy_target: prod.capture_enabled
   raw_archive_recovery:
     repository_state: ready
-    production_iam_state: applied
+    repository_iam_state: contract_ready
+    observed_iam_state: pending_live_verification
+    iam_contract_verifier: ops/qa/verify_raw_archive_iam_contract.py
     independent_evidence_state: production_workstation_recovery_verified
     recovery_cli: backend/cmd/qa-archive
     retirement_gate: ops/qa/qa_archive_recovery_gate.py

--- a/ops/qa/policy.yaml
+++ b/ops/qa/policy.yaml
@@ -15,6 +15,7 @@ prod:
     shard_minutes: 60
     seal_delay_minutes: 15
     max_catchup_windows_per_run: 1
+    catchup_gap_policy: accepted_terminal
     s3_retention_days: 7
     raw_user_access: false
     runner_uid: 1000

--- a/ops/qa/prod_phase2_live_health.py
+++ b/ops/qa/prod_phase2_live_health.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Collect prod QA Phase 2 live facts and evaluate correlated health + IAM contract."""
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "ops" / "stage0"))
+sys.path.insert(0, str(ROOT / "ops" / "qa"))
+
+from ssm_execution import PROD_REGION, resolve_prod_instance, run_shell_b64  # noqa: E402
+import qa_phase2_health  # noqa: E402
+import verify_raw_archive_iam_contract as iam_contract  # noqa: E402
+
+PROBE = ROOT / "ops" / "observability/probe-qa-phase2-live-health.sh"
+POLICY = ROOT / "ops/qa/policy.yaml"
+
+
+def _load_catchup_gap_policy() -> str:
+    try:
+        import yaml
+
+        policy = yaml.safe_load(POLICY.read_text(encoding="utf-8"))
+        archive = policy.get("prod", {}).get("archive", {}) if isinstance(policy, dict) else {}
+        value = archive.get("catchup_gap_policy") if isinstance(archive, dict) else None
+        if value in {"accepted_terminal", "strict"}:
+            return value
+    except (OSError, ImportError, ValueError):
+        pass
+    return qa_phase2_health.DEFAULT_CATCHUP_GAP_POLICY
+
+
+def _parse_probe_output(text: str) -> dict[str, Any]:
+    snapshot: dict[str, Any] = {}
+    qa_records: dict[str, Any] | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        prefix, _, payload = line.partition(" ")
+        if prefix == "PHASE2SYSTEMD":
+            snapshot["systemd"] = json.loads(payload)
+        elif prefix == "PHASE2RECEIPT":
+            snapshot["host_receipt"] = None if payload == "null" else json.loads(payload)
+        elif prefix == "PHASE2HEARTBEAT":
+            snapshot["database_heartbeat"] = None if payload == "null" else json.loads(payload)
+        elif prefix == "PHASE2ARCHIVE":
+            snapshot["archive_control"] = json.loads(payload)
+        elif prefix == "PHASE2QARECORDS":
+            qa_records = json.loads(payload)
+    if qa_records is not None:
+        snapshot["qa_records"] = qa_records
+    return snapshot
+
+
+def evaluate_snapshot(
+    snapshot: dict[str, Any],
+    *,
+    skip_iam: bool = False,
+    now: dt.datetime | None = None,
+) -> dict[str, Any]:
+    catchup_gap_policy = _load_catchup_gap_policy()
+    health = qa_phase2_health.evaluate(snapshot, now=now, catchup_gap_policy=catchup_gap_policy)
+    warnings: list[str] = []
+    qa_records = snapshot.get("qa_records")
+    if isinstance(qa_records, dict) and qa_records.get("partition_owner") == "default_only":
+        warnings.append("qa_records_partition_owner_default_only")
+    if skip_iam:
+        iam: dict[str, Any] = {"ok": True, "status": "skipped", "failures": []}
+    else:
+        try:
+            account_id = iam_contract._account_id()
+            bucket = f"tokenkey-prod-qa-raw-archive-{account_id}"
+            app_role_arn = iam_contract._stack_output(iam_contract.STACK, "InstanceRoleArn")
+            iam = iam_contract.evaluate(bucket=bucket, app_role_arn=app_role_arn)
+        except RuntimeError as exc:
+            iam = {"ok": False, "status": "unknown", "failures": [str(exc)]}
+        if not iam.get("ok"):
+            health.setdefault("reasons", []).append("raw_archive_iam_contract_drift")
+            health["reasons"] = sorted(set(health["reasons"]))
+            if health.get("status") == "healthy":
+                health["status"] = "degraded"
+            health["healthy"] = False
+    return {
+        "health": health,
+        "iam_contract": iam,
+        "warnings": warnings,
+        "catchup_gap_policy": catchup_gap_policy,
+        "snapshot": snapshot,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot-file", type=Path, help="evaluate an existing probe snapshot JSON")
+    parser.add_argument(
+        "--from-probe-stdin",
+        action="store_true",
+        help="read probe-qa-phase2-live-health.sh stdout from stdin",
+    )
+    parser.add_argument("--skip-iam", action="store_true", help="skip live IAM contract verification")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    if args.snapshot_file is not None:
+        snapshot = json.loads(args.snapshot_file.read_text(encoding="utf-8"))
+        payload = evaluate_snapshot(snapshot, skip_iam=args.skip_iam)
+    elif args.from_probe_stdin:
+        snapshot = _parse_probe_output(sys.stdin.read())
+        payload = evaluate_snapshot(snapshot, skip_iam=args.skip_iam)
+    else:
+        probe_script = PROBE.read_text(encoding="utf-8")
+        instance_id = resolve_prod_instance()
+        remote_out = run_shell_b64(
+            instance_id,
+            base64.b64encode(probe_script.encode()).decode(),
+            "prod qa phase2 live health",
+        )
+        snapshot = _parse_probe_output(remote_out)
+        payload = {
+            "region": PROD_REGION,
+            "instance_id": instance_id,
+            **evaluate_snapshot(snapshot, skip_iam=args.skip_iam),
+        }
+    print(json.dumps(payload, ensure_ascii=True, sort_keys=True))
+    health_status = payload["health"].get("status", "failed")
+    if not args.skip_iam and not payload.get("iam_contract", {}).get("ok", False):
+        return 2
+    return 0 if health_status == "healthy" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/qa/prod_phase2_live_health.py
+++ b/ops/qa/prod_phase2_live_health.py
@@ -6,7 +6,6 @@ import argparse
 import base64
 import datetime as dt
 import json
-import subprocess
 import sys
 from pathlib import Path
 from typing import Any

--- a/ops/qa/qa_archive_recovery_gate.py
+++ b/ops/qa/qa_archive_recovery_gate.py
@@ -42,6 +42,7 @@ def _production_approval_failures(
     expected_bucket: str,
     expected_recovery_role_arn: str,
     latest_receipt_at: datetime | None,
+    expected_approval_issuer: str = "",
 ) -> list[str]:
     if approval_path is None:
         return ["production_approval"]
@@ -73,6 +74,12 @@ def _production_approval_failures(
         failures.append("production_approval.receipt_order")
     if expires_at is None or expires_at <= now or (approved_at is not None and expires_at <= approved_at):
         failures.append("production_approval.expires_at")
+    issuer = approval.get("approval_issuer")
+    if expected_approval_issuer:
+        if issuer != expected_approval_issuer:
+            failures.append("production_approval.approval_issuer")
+    elif issuer not in {None, ""} and not isinstance(issuer, str):
+        failures.append("production_approval.approval_issuer")
     try:
         if approval_path.stat().st_mode & 0o022:
             failures.append("production_approval.permissions")
@@ -87,6 +94,7 @@ def evaluate(
     expected_window_start: str = "",
     expected_bucket: str = "",
     expected_recovery_role_arn: str = "",
+    expected_approval_issuer: str = "",
 ) -> tuple[int, dict[str, Any]]:
     result: dict[str, Any] = {
         "ok": False,
@@ -186,6 +194,7 @@ def evaluate(
             expected_bucket,
             expected_recovery_role_arn,
             latest_receipt_at,
+            expected_approval_issuer,
         ))
         if failures:
             result["error"] = "production recovery evidence is not independently approved"
@@ -220,6 +229,7 @@ def main() -> int:
     plan.add_argument("--expected-window-start", default="")
     plan.add_argument("--expected-bucket", default="")
     plan.add_argument("--expected-recovery-role-arn", default="")
+    plan.add_argument("--expected-approval-issuer", default="")
     args = parser.parse_args()
     code, result = evaluate(
         args.evidence,
@@ -227,6 +237,7 @@ def main() -> int:
         args.expected_window_start,
         args.expected_bucket,
         args.expected_recovery_role_arn,
+        args.expected_approval_issuer,
     )
     print(json.dumps(result, sort_keys=True, separators=(",", ":")))
     return code

--- a/ops/qa/qa_phase2_health.py
+++ b/ops/qa/qa_phase2_health.py
@@ -12,6 +12,7 @@ from typing import Any
 
 MAX_RECEIPT_AGE = dt.timedelta(hours=2)
 MAX_CORRELATION_SKEW = dt.timedelta(minutes=5)
+DEFAULT_CATCHUP_GAP_POLICY = "accepted_terminal"
 
 
 def _mapping(value: Any) -> dict[str, Any] | None:
@@ -73,71 +74,117 @@ def _same_fact(
         reasons.append(f"{label}_cleanup_not_denied")
 
 
-def evaluate(snapshot: dict[str, Any], *, now: dt.datetime | None = None) -> dict[str, Any]:
+def _evaluate_catchup(
+    reasons: list[str],
+    *,
+    receipt: dict[str, Any] | None,
+    heartbeat: dict[str, str],
+    archive: dict[str, Any],
+    catchup_gap_policy: str,
+) -> bool:
+    failed = False
+    raw_compensation = receipt.get("compensation") if receipt is not None else None
+    compensation = _mapping(raw_compensation)
+    if compensation is not None:
+        _same_fact(reasons, "compensation", compensation, heartbeat, _mapping(archive.get("compensation")))
+    elif raw_compensation is not None:
+        reasons.append("compensation_receipt_invalid")
+        failed = True
+    else:
+        if archive.get("compensation") is not None:
+            reasons.append("compensation_control_without_receipt")
+            failed = True
+        if any(key.startswith("compensation_") for key in heartbeat):
+            reasons.append("compensation_heartbeat_without_receipt")
+            failed = True
+
+    terminal = archive.get("terminal_failures_after_cutover")
+    if not isinstance(terminal, list):
+        reasons.append("terminal_failure_inventory_missing")
+        failed = True
+    elif terminal:
+        if catchup_gap_policy == "accepted_terminal":
+            reasons.append("catchup_terminal_gaps_present")
+        else:
+            reasons.append("terminal_failures_after_cutover")
+            failed = True
+    return failed
+
+
+def evaluate(
+    snapshot: dict[str, Any],
+    *,
+    now: dt.datetime | None = None,
+    catchup_gap_policy: str = DEFAULT_CATCHUP_GAP_POLICY,
+) -> dict[str, Any]:
     now = (now or dt.datetime.now(dt.timezone.utc)).astimezone(dt.timezone.utc)
-    reasons: list[str] = []
+    forward_reasons: list[str] = []
+    catchup_reasons: list[str] = []
     failed = False
     if not isinstance(snapshot, dict):
-        return {"healthy": False, "status": "failed", "reasons": ["snapshot_invalid"]}
+        return {
+            "healthy": False,
+            "status": "failed",
+            "reasons": ["snapshot_invalid"],
+            "forward_reasons": ["snapshot_invalid"],
+            "catchup_reasons": [],
+        }
 
     systemd = _mapping(snapshot.get("systemd"))
     receipt = _mapping(snapshot.get("host_receipt"))
     database = _mapping(snapshot.get("database_heartbeat"))
     archive = _mapping(snapshot.get("archive_control"))
     if systemd is None:
-        reasons.append("systemd_missing")
+        forward_reasons.append("systemd_missing")
     else:
         if systemd.get("timer_enabled") is not True:
-            reasons.append("timer_not_enabled")
+            forward_reasons.append("timer_not_enabled")
         if systemd.get("timer_active") is not True:
-            reasons.append("timer_not_active")
+            forward_reasons.append("timer_not_active")
         if systemd.get("service_result") != "success":
-            reasons.append("systemd_service_failed")
+            forward_reasons.append("systemd_service_failed")
             failed = True
     if receipt is None:
-        reasons.append("host_receipt_missing")
+        forward_reasons.append("host_receipt_missing")
     if database is None:
-        reasons.append("database_heartbeat_missing")
+        forward_reasons.append("database_heartbeat_missing")
     if archive is None:
-        reasons.append("archive_control_missing")
+        forward_reasons.append("archive_control_missing")
 
     if receipt is not None:
         if receipt.get("schema_version") != "qa-maintenance-runner-v1":
-            reasons.append("host_receipt_schema_invalid")
+            forward_reasons.append("host_receipt_schema_invalid")
         if not isinstance(receipt.get("run_id"), str) or not receipt.get("run_id"):
-            reasons.append("host_receipt_run_id_missing")
+            forward_reasons.append("host_receipt_run_id_missing")
         if receipt.get("trigger") != "timer":
-            reasons.append("host_receipt_trigger_not_timer")
-        if not isinstance(receipt.get("active_container"), str) or not receipt.get(
-            "active_container"
-        ):
-            reasons.append("host_receipt_container_missing")
-        if not isinstance(receipt.get("image"), str) or not receipt.get("image", "").startswith(
-            "sha256:"
-        ):
-            reasons.append("host_receipt_image_invalid")
+            forward_reasons.append("host_receipt_trigger_not_timer")
+        if not isinstance(receipt.get("active_container"), str) or not receipt.get("active_container"):
+            forward_reasons.append("host_receipt_container_missing")
+        if not isinstance(receipt.get("image"), str) or not receipt.get("image", "").startswith("sha256:"):
+            forward_reasons.append("host_receipt_image_invalid")
         if receipt.get("runner_uid") != 1000 or receipt.get("runner_gid") != 1000:
-            reasons.append("host_receipt_runner_identity_invalid")
+            forward_reasons.append("host_receipt_runner_identity_invalid")
         if receipt.get("deletion_authorized") is not False:
-            reasons.append("host_receipt_deletion_not_denied")
+            forward_reasons.append("host_receipt_deletion_not_denied")
         started = _timestamp(receipt.get("started_at"))
         if started is None:
-            reasons.append("host_receipt_started_at_invalid")
+            forward_reasons.append("host_receipt_started_at_invalid")
         finished = _timestamp(receipt.get("finished_at"))
         if finished is None:
-            reasons.append("host_receipt_finished_at_invalid")
+            forward_reasons.append("host_receipt_finished_at_invalid")
         elif finished > now or now - finished > MAX_RECEIPT_AGE:
-            reasons.append("host_receipt_stale")
+            forward_reasons.append("host_receipt_stale")
         elif started is not None and started > finished:
-            reasons.append("host_receipt_time_order_invalid")
+            forward_reasons.append("host_receipt_time_order_invalid")
         if receipt.get("runner_exit_code") != 0:
-            reasons.append("host_runner_failed")
+            forward_reasons.append("host_runner_failed")
             failed = True
         if receipt.get("child_exit_code") != 0:
-            reasons.append("maintenance_child_failed")
+            forward_reasons.append("maintenance_child_failed")
             failed = True
         if receipt.get("error_code") not in {None, ""}:
-            reasons.append("host_receipt_success_has_error")
+            forward_reasons.append("host_receipt_success_has_error")
+            failed = True
     else:
         started = None
         finished = None
@@ -145,79 +192,93 @@ def evaluate(snapshot: dict[str, Any], *, now: dt.datetime | None = None) -> dic
     heartbeat = _last_result(database.get("last_result")) if database is not None else {}
     if database is not None:
         if heartbeat.get("status") != "committed":
-            reasons.append("database_heartbeat_not_committed")
+            forward_reasons.append("database_heartbeat_not_committed")
+            failed = True
         if heartbeat.get("deletion_authorized") != "false":
-            reasons.append("database_heartbeat_deletion_not_denied")
+            forward_reasons.append("database_heartbeat_deletion_not_denied")
         if receipt is not None and heartbeat.get("run_id") != receipt.get("run_id"):
-            reasons.append("run_id_mismatch")
+            forward_reasons.append("run_id_mismatch")
+            failed = True
         if receipt is not None and heartbeat.get("trigger") != receipt.get("trigger"):
-            reasons.append("trigger_mismatch")
+            forward_reasons.append("trigger_mismatch")
+            failed = True
         heartbeat_run = _timestamp(database.get("last_run_at"))
         if heartbeat_run is None:
-            reasons.append("database_last_run_invalid")
+            forward_reasons.append("database_last_run_invalid")
         elif started is not None and abs(started - heartbeat_run) > MAX_CORRELATION_SKEW:
-            reasons.append("receipt_heartbeat_run_time_mismatch")
+            forward_reasons.append("receipt_heartbeat_run_time_mismatch")
+            failed = True
         heartbeat_success = _timestamp(database.get("last_success_at"))
         if heartbeat_success is None:
-            reasons.append("database_last_success_invalid")
+            forward_reasons.append("database_last_success_invalid")
         elif finished is not None and abs(finished - heartbeat_success) > MAX_CORRELATION_SKEW:
-            reasons.append("receipt_heartbeat_time_mismatch")
+            forward_reasons.append("receipt_heartbeat_time_mismatch")
+            failed = True
         last_error = _timestamp(database.get("last_error_at"))
         if last_error is not None and (heartbeat_success is None or last_error > heartbeat_success):
-            reasons.append("database_has_newer_failure")
+            forward_reasons.append("database_has_newer_failure")
             failed = True
 
     if systemd is not None and finished is not None:
         systemd_finished = _timestamp(systemd.get("finished_at"))
         if systemd_finished is None:
-            reasons.append("systemd_finished_at_invalid")
+            forward_reasons.append("systemd_finished_at_invalid")
         elif abs(systemd_finished - finished) > MAX_CORRELATION_SKEW:
-            reasons.append("systemd_receipt_time_mismatch")
+            forward_reasons.append("systemd_receipt_time_mismatch")
+            failed = True
 
     if receipt is not None and archive is not None:
         normal = _mapping(receipt.get("normal"))
         if normal is None:
-            reasons.append("normal_receipt_missing")
+            forward_reasons.append("normal_receipt_missing")
+            failed = True
         else:
-            _same_fact(reasons, "normal", normal, heartbeat, _mapping(archive.get("normal")))
-        raw_compensation = receipt.get("compensation")
-        compensation = _mapping(raw_compensation)
-        if compensation is not None:
-            _same_fact(
-                reasons,
-                "compensation",
-                compensation,
-                heartbeat,
-                _mapping(archive.get("compensation")),
-            )
-        elif raw_compensation is not None:
-            reasons.append("compensation_receipt_invalid")
-        else:
-            if archive.get("compensation") is not None:
-                reasons.append("compensation_control_without_receipt")
-            if any(key.startswith("compensation_") for key in heartbeat):
-                reasons.append("compensation_heartbeat_without_receipt")
-        terminal = archive.get("terminal_failures_after_cutover")
-        if not isinstance(terminal, list):
-            reasons.append("terminal_failure_inventory_missing")
-        elif terminal:
-            reasons.append("terminal_failures_after_cutover")
+            _same_fact(forward_reasons, "normal", normal, heartbeat, _mapping(archive.get("normal")))
+            if any(reason.startswith("normal_") for reason in forward_reasons):
+                failed = True
+        if _evaluate_catchup(
+            catchup_reasons,
+            receipt=receipt,
+            heartbeat=heartbeat,
+            archive=archive,
+            catchup_gap_policy=catchup_gap_policy,
+        ):
+            failed = True
 
-    reasons = sorted(set(reasons))
-    status = "healthy" if not reasons else ("failed" if failed else "degraded")
-    return {"healthy": not reasons, "status": status, "reasons": reasons}
+    forward_reasons = sorted(set(forward_reasons))
+    catchup_reasons = sorted(set(catchup_reasons))
+    reasons = sorted(set(forward_reasons + catchup_reasons))
+    if not reasons:
+        status = "healthy"
+    elif failed:
+        status = "failed"
+    else:
+        status = "degraded"
+    return {
+        "healthy": not reasons,
+        "status": status,
+        "reasons": reasons,
+        "forward_reasons": forward_reasons,
+        "catchup_reasons": catchup_reasons,
+    }
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("snapshot", type=pathlib.Path, help="structured Phase 2 health snapshot JSON")
+    parser.add_argument(
+        "--catchup-gap-policy",
+        default=DEFAULT_CATCHUP_GAP_POLICY,
+        choices=("accepted_terminal", "strict"),
+        help="accepted_terminal downgrades historical terminal gaps to degraded",
+    )
     args = parser.parse_args()
     try:
         snapshot = json.loads(args.snapshot.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         print(json.dumps({"healthy": False, "status": "failed", "reasons": [str(exc)]}))
         return 2
-    verdict = evaluate(snapshot)
+    verdict = evaluate(snapshot, catchup_gap_policy=args.catchup_gap_policy)
     print(json.dumps(verdict, ensure_ascii=True, sort_keys=True))
     return 0 if verdict["healthy"] else 2
 

--- a/ops/qa/test_prod_phase2_live_health.py
+++ b/ops/qa/test_prod_phase2_live_health.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+import datetime as dt
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "ops" / "qa"))
+
+import prod_phase2_live_health as live_health  # noqa: E402
+import verify_raw_archive_iam_contract as iam_contract  # noqa: E402
+
+
+def _load_runtime_case():
+    spec = importlib.util.spec_from_file_location(
+        "qa_phase2_runtime_case",
+        ROOT / "ops/qa/test_qa_maintenance_phase2_runtime.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.QAPhase2OperatorAndHealthTest()
+
+
+def _fresh_snapshot() -> tuple[dict, dt.datetime]:
+    now = dt.datetime.now(dt.timezone.utc)
+    snapshot, _ = _load_runtime_case()._healthy_snapshot()
+    finished = now - dt.timedelta(seconds=30)
+    started = finished - dt.timedelta(seconds=30)
+    iso = lambda value: value.strftime("%Y-%m-%dT%H:%M:%SZ")
+    snapshot["systemd"]["finished_at"] = iso(finished)
+    snapshot["host_receipt"]["started_at"] = iso(started)
+    snapshot["host_receipt"]["finished_at"] = iso(finished)
+    snapshot["database_heartbeat"]["last_run_at"] = iso(started)
+    snapshot["database_heartbeat"]["last_success_at"] = iso(finished)
+    return snapshot, now
+
+
+class ProdPhase2LiveHealthTest(unittest.TestCase):
+    def _healthy_probe_text(self) -> str:
+        snapshot, _ = _fresh_snapshot()
+        return "\n".join(
+            [
+                "PHASE2SYSTEMD " + json.dumps(snapshot["systemd"], sort_keys=True),
+                "PHASE2RECEIPT " + json.dumps(snapshot["host_receipt"], sort_keys=True),
+                "PHASE2HEARTBEAT " + json.dumps(snapshot["database_heartbeat"], sort_keys=True),
+                "PHASE2ARCHIVE " + json.dumps(snapshot["archive_control"], sort_keys=True),
+                "PHASE2QARECORDS " + json.dumps({"partition_owner": "default_only"}, sort_keys=True),
+            ]
+        )
+
+    def test_parse_probe_output_builds_snapshot(self) -> None:
+        snapshot = live_health._parse_probe_output(self._healthy_probe_text())
+        self.assertIn("systemd", snapshot)
+        self.assertIn("host_receipt", snapshot)
+        self.assertEqual(snapshot["qa_records"]["partition_owner"], "default_only")
+
+    def test_evaluate_snapshot_marks_default_only_partition_warning(self) -> None:
+        snapshot, now = _fresh_snapshot()
+        snapshot["qa_records"] = {"partition_owner": "default_only"}
+        payload = live_health.evaluate_snapshot(snapshot, skip_iam=True, now=now)
+        self.assertIn("qa_records_partition_owner_default_only", payload["warnings"])
+        self.assertEqual(payload["health"]["status"], "healthy")
+
+    def test_cli_from_probe_stdin(self) -> None:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "ops/qa/prod_phase2_live_health.py"),
+                "--from-probe-stdin",
+                "--skip-iam",
+            ],
+            input=self._healthy_probe_text(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["health"]["status"], "healthy")
+
+
+class VerifyRawArchiveIAMContractTest(unittest.TestCase):
+    def test_rejects_list_bucket_on_app_role(self) -> None:
+        role = "arn:aws:iam::123456789012:role/app"
+        statements = [
+            {
+                "Sid": "AllowAppInstanceRoleWriteRaw",
+                "Principal": {"AWS": role},
+                "Action": ["s3:PutObject"],
+                "Resource": [
+                    "arn:aws:s3:::tokenkey-prod-qa-raw-archive-123456789012/raw/v1/date=*/hour=*/commit.json"
+                ],
+            },
+            {
+                "Sid": "AllowAppInstanceRoleVerifyRaw",
+                "Principal": {"AWS": role},
+                "Action": "s3:GetObject",
+                "Resource": [
+                    "arn:aws:s3:::tokenkey-prod-qa-raw-archive-123456789012/raw/v1/date=*/hour=*/commit.json"
+                ],
+            },
+            {
+                "Sid": "AllowAppInstanceRoleList",
+                "Principal": {"AWS": role},
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::tokenkey-prod-qa-raw-archive-123456789012",
+            },
+        ]
+        verdict = iam_contract.evaluate(
+            bucket="tokenkey-prod-qa-raw-archive-123456789012",
+            app_role_arn=role,
+            statements=statements,
+        )
+        self.assertFalse(verdict["ok"])
+        self.assertIn("AllowAppInstanceRoleList:forbidden_action:s3:ListBucket", verdict["failures"])
+
+    def test_accepts_suffix_scoped_app_role(self) -> None:
+        role = "arn:aws:iam::123456789012:role/app"
+        bucket = "tokenkey-prod-qa-raw-archive-123456789012"
+        suffix_resources = [
+            f"arn:aws:s3:::{bucket}/raw/v1/date=*/hour=*/{suffix}"
+            for suffix in iam_contract.EXPECTED_SUFFIXES
+        ]
+        statements = [
+            {
+                "Sid": "AllowAppInstanceRoleWriteRaw",
+                "Principal": {"AWS": role},
+                "Action": ["s3:PutObject", "s3:AbortMultipartUpload", "s3:ListMultipartUploadParts"],
+                "Resource": suffix_resources,
+            },
+            {
+                "Sid": "AllowAppInstanceRoleVerifyRaw",
+                "Principal": {"AWS": role},
+                "Action": "s3:GetObject",
+                "Resource": suffix_resources,
+            },
+        ]
+        verdict = iam_contract.evaluate(bucket=bucket, app_role_arn=role, statements=statements)
+        self.assertTrue(verdict["ok"], verdict)
+
+
+if __name__ == "__main__":
+    raise SystemExit(unittest.main())

--- a/ops/qa/test_qa_maintenance_phase2_runtime.py
+++ b/ops/qa/test_qa_maintenance_phase2_runtime.py
@@ -622,6 +622,21 @@ class QAPhase2OperatorAndHealthTest(unittest.TestCase):
                 " compensation_window=2026-08-07T22:00:00Z"
             )
 
+        for name, mutation, policy, want_healthy, want_status in (
+            ("terminal failure strict", mutate_terminal_failure, "strict", False, "failed"),
+            ("terminal failure accepted", mutate_terminal_failure, "accepted_terminal", False, "degraded"),
+        ):
+            with self.subTest(name=name):
+                snapshot = copy.deepcopy(baseline)
+                mutation(snapshot)
+                verdict = health.evaluate(snapshot, now=now, catchup_gap_policy=policy)
+                self.assertIs(verdict["healthy"], want_healthy, verdict)
+                self.assertEqual(verdict["status"], want_status, verdict)
+                if policy == "accepted_terminal":
+                    self.assertIn("catchup_terminal_gaps_present", verdict["catchup_reasons"], verdict)
+                else:
+                    self.assertIn("terminal_failures_after_cutover", verdict["catchup_reasons"], verdict)
+
         for name, mutation in (
             ("missing receipt", mutate_missing_receipt),
             ("stale receipt", mutate_stale_receipt),
@@ -634,7 +649,6 @@ class QAPhase2OperatorAndHealthTest(unittest.TestCase):
             ("window mismatch", mutate_window_mismatch),
             ("etag mismatch", mutate_etag_mismatch),
             ("newer host failure", mutate_newer_host_failure),
-            ("terminal failure", mutate_terminal_failure),
             ("phantom control compensation", mutate_phantom_control_compensation),
             ("phantom heartbeat compensation", mutate_phantom_heartbeat_compensation),
         ):

--- a/ops/qa/verify_raw_archive_iam_contract.py
+++ b/ops/qa/verify_raw_archive_iam_contract.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Compare live prod QA raw archive bucket policy against repository IAM contract."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+PROD_REGION = "us-east-1"
+STACK = "tokenkey-prod-stage0"
+RAW_ARCHIVE_STACK = "tokenkey-prod-qa-raw-archive"
+
+APP_WRITE_SID = "AllowAppInstanceRoleWriteRaw"
+APP_VERIFY_SID = "AllowAppInstanceRoleVerifyRaw"
+FORBIDDEN_APP_ACTIONS = {"s3:ListBucket", "s3:ListBucketMultipartUploads", "s3:GetBucketLocation"}
+EXPECTED_SUFFIXES = [
+    "commit.json",
+    "manifest.json",
+    "records.parquet",
+    "evidence.pack",
+    "evidence-index.jsonl.zst",
+    "orphan-evidence-index.jsonl.zst",
+]
+
+
+def _aws_json(args: list[str]) -> dict[str, Any]:
+    completed = subprocess.run(args, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError((completed.stderr or completed.stdout or "aws failed").strip()[:600])
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, dict):
+        raise RuntimeError("aws json is not an object")
+    return payload
+
+
+def _account_id() -> str:
+    out = subprocess.check_output(
+        ["aws", "sts", "get-caller-identity", "--query", "Account", "--output", "text"],
+        text=True,
+    ).strip()
+    if not re.fullmatch(r"\d{12}", out):
+        raise RuntimeError(f"unexpected aws account id: {out!r}")
+    return out
+
+
+def _stack_output(stack_name: str, key: str) -> str:
+    payload = _aws_json(
+        [
+            "aws",
+            "cloudformation",
+            "describe-stacks",
+            "--region",
+            PROD_REGION,
+            "--stack-name",
+            stack_name,
+            "--output",
+            "json",
+        ]
+    )
+    stacks = payload.get("Stacks")
+    if not isinstance(stacks, list) or not stacks:
+        raise RuntimeError(f"stack missing: {stack_name}")
+    for item in stacks[0].get("Outputs", []):
+        if isinstance(item, dict) and item.get("OutputKey") == key:
+            value = item.get("OutputValue")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    raise RuntimeError(f"{stack_name} output missing: {key}")
+
+
+def _live_bucket_policy(bucket: str) -> list[dict[str, Any]]:
+    payload = _aws_json(
+        [
+            "aws",
+            "s3api",
+            "get-bucket-policy",
+            "--bucket",
+            bucket,
+            "--output",
+            "json",
+        ]
+    )
+    policy = json.loads(payload["Policy"])
+    statements = policy.get("Statement")
+    if not isinstance(statements, list):
+        raise RuntimeError("bucket policy has no statements")
+    return [item for item in statements if isinstance(item, dict)]
+
+
+def _statement_for_principal(statements: list[dict[str, Any]], principal_arn: str) -> dict[str, dict[str, Any]]:
+    matched: dict[str, dict[str, Any]] = {}
+    for statement in statements:
+        principal = statement.get("Principal")
+        if isinstance(principal, dict):
+            aws_principal = principal.get("AWS")
+        else:
+            aws_principal = principal
+        candidates = aws_principal if isinstance(aws_principal, list) else [aws_principal]
+        if principal_arn not in {str(item) for item in candidates}:
+            continue
+        sid = statement.get("Sid")
+        if isinstance(sid, str) and sid:
+            matched[sid] = statement
+    return matched
+
+
+def evaluate(
+    *,
+    bucket: str,
+    app_role_arn: str,
+    statements: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    failures: list[str] = []
+    if statements is None:
+        try:
+            statements = _live_bucket_policy(bucket)
+        except RuntimeError as exc:
+            return {"ok": False, "status": "unknown", "failures": [str(exc)], "bucket": bucket}
+
+    app = _statement_for_principal(statements, app_role_arn)
+    missing_sids = {APP_WRITE_SID, APP_VERIFY_SID} - set(app)
+    if missing_sids:
+        failures.extend(f"missing_app_sid:{sid}" for sid in sorted(missing_sids))
+
+    for sid, statement in app.items():
+        actions = statement.get("Action")
+        action_set = {actions} if isinstance(actions, str) else set(actions or [])
+        forbidden = sorted(action_set & FORBIDDEN_APP_ACTIONS)
+        if forbidden:
+            failures.append(f"{sid}:forbidden_action:{','.join(forbidden)}")
+        resources = statement.get("Resource")
+        resource_list = resources if isinstance(resources, list) else [resources]
+        for resource in resource_list:
+            if not isinstance(resource, str):
+                failures.append(f"{sid}:invalid_resource")
+                continue
+            if "raw/partial/" in resource:
+                failures.append(f"{sid}:partial_prefix_allowed")
+            if sid == APP_VERIFY_SID and resource.endswith("/*"):
+                failures.append(f"{sid}:broad_raw_prefix_read")
+
+    if APP_WRITE_SID in app and APP_VERIFY_SID in app:
+        write_resources = app[APP_WRITE_SID].get("Resource")
+        verify_resources = app[APP_VERIFY_SID].get("Resource")
+        write_list = write_resources if isinstance(write_resources, list) else [write_resources]
+        verify_list = verify_resources if isinstance(verify_resources, list) else [verify_resources]
+        for statement_resources in (write_list, verify_list):
+            suffixes = [resource.rsplit("/", 1)[-1] for resource in statement_resources if isinstance(resource, str)]
+            if suffixes != EXPECTED_SUFFIXES:
+                failures.append("app_suffix_scope_drift")
+                break
+            if not all("raw/v1/date=*/hour=*" in resource for resource in statement_resources if isinstance(resource, str)):
+                failures.append("app_hour_prefix_drift")
+
+    status = "applied" if not failures else "drift"
+    return {
+        "ok": not failures,
+        "status": status,
+        "bucket": bucket,
+        "app_role_arn": app_role_arn,
+        "failures": failures,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    account_id = _account_id()
+    bucket = f"tokenkey-prod-qa-raw-archive-{account_id}"
+    app_role_arn = _stack_output(STACK, "InstanceRoleArn")
+    verdict = evaluate(bucket=bucket, app_role_arn=app_role_arn)
+    print(json.dumps(verdict, ensure_ascii=True, sort_keys=True))
+    return 0 if verdict["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/checks/qa-lifecycle-ssot.py
+++ b/scripts/checks/qa-lifecycle-ssot.py
@@ -128,12 +128,21 @@ REQUIRED_BY_FILE = {
         "schema_version: 1",
         "deploy_inject_default: true",
         "target_deploy_inject_default: true",
-        "closeout_state: production_closeout_verified",
+        "repository_closeout_state: production_closeout_verified",
+        "observed_live_state: pending_live_reconciliation",
         "min_consecutive_scheduled_runs: 2",
         "host_runner: /usr/local/bin/tokenkey-qa-maintenance.sh",
         "health_evaluator: ops/qa/qa_phase2_health.py",
+        "live_health_probe: ops/observability/probe-qa-phase2-live-health.sh",
+        "live_health_evaluator: ops/qa/prod_phase2_live_health.py",
+        "catchup_gap_policy: accepted_terminal",
         "export_orphan_activation_marker: /var/lib/tokenkey/qa-export-orphan-cleanup-activated.json",
         "policy_target: prod.archive.enabled",
+        "repository_iam_state: contract_ready",
+        "observed_iam_state: pending_live_verification",
+        "iam_contract_verifier: ops/qa/verify_raw_archive_iam_contract.py",
+        "partition_owner_repository: default_only",
+        "phase3_worker_observed_state: transitional_in_prod",
         "design-qa-phase2-archive-closeout.md",
     ),
     QA_README: (
@@ -280,6 +289,7 @@ def _policy_failures(root: Path) -> list[str]:
         ("prod", "archive", "shard_minutes"): 60,
         ("prod", "archive", "seal_delay_minutes"): 15,
         ("prod", "archive", "max_catchup_windows_per_run"): 1,
+        ("prod", "archive", "catchup_gap_policy"): "accepted_terminal",
         ("prod", "archive", "s3_retention_days"): 7,
         ("prod", "archive", "runner_uid"): 1000,
         ("prod", "archive", "runner_gid"): 1000,
@@ -416,19 +426,29 @@ def _rollout_failures(root: Path) -> list[str]:
             failures.append("rollout prod.QA_ARCHIVE_ENABLED.policy_target drift")
         if prod_archive.get("target_deploy_inject_default") is not True:
             failures.append("rollout prod.QA_ARCHIVE_ENABLED target must become true after closeout")
-        if prod_archive.get("closeout_state") != "production_closeout_verified":
-            failures.append("rollout prod.QA_ARCHIVE_ENABLED closeout state drift")
+        if prod_archive.get("repository_closeout_state") != "production_closeout_verified":
+            failures.append("rollout prod.QA_ARCHIVE_ENABLED repository closeout state drift")
+        if prod_archive.get("observed_live_state") != "pending_live_reconciliation":
+            failures.append("rollout prod.QA_ARCHIVE_ENABLED observed live state drift")
     if not isinstance(prod_timer, dict):
         failures.append("rollout prod.tokenkey_qa_maintenance_timer must be a mapping")
     else:
         if prod_timer.get("closeout_deploy_state") != "enabled":
             failures.append("rollout maintenance timer closeout deploy state drift")
-        if prod_timer.get("observed_live_state") != "production_recloseout_verified":
+        if prod_timer.get("repository_closeout_state") != "production_recloseout_verified":
+            failures.append("rollout maintenance timer repository closeout state drift")
+        if prod_timer.get("observed_live_state") != "pending_live_reconciliation":
             failures.append("rollout maintenance timer observed live state drift")
         if prod_timer.get("policy_target_state") != "enabled":
             failures.append("rollout maintenance timer target drift")
         if prod_timer.get("min_consecutive_scheduled_runs") != 2:
             failures.append("rollout maintenance timer observation gate drift")
+        if prod_timer.get("catchup_gap_policy") != "accepted_terminal":
+            failures.append("rollout maintenance catchup gap policy drift")
+        if prod_timer.get("live_health_probe") != "ops/observability/probe-qa-phase2-live-health.sh":
+            failures.append("rollout maintenance live health probe drift")
+        if prod_timer.get("live_health_evaluator") != "ops/qa/prod_phase2_live_health.py":
+            failures.append("rollout maintenance live health evaluator drift")
         if prod_timer.get("health_evidence") != [
             "systemd", "host_receipt", "database_heartbeat", "archive_control_rows"
         ]:
@@ -447,16 +467,28 @@ def _rollout_failures(root: Path) -> list[str]:
     elif edge_capture.get("deploy_inject_default") is not False:
         failures.append("rollout edge.QA_CAPTURE_ENABLED.deploy_inject_default must be false")
     recovery = prod.get("raw_archive_recovery")
-    if not isinstance(recovery, dict) or recovery != {
+    expected_recovery = {
         "repository_state": "ready",
-        "production_iam_state": "applied",
+        "repository_iam_state": "contract_ready",
+        "observed_iam_state": "pending_live_verification",
+        "iam_contract_verifier": "ops/qa/verify_raw_archive_iam_contract.py",
         "independent_evidence_state": "production_workstation_recovery_verified",
         "recovery_cli": "backend/cmd/qa-archive",
         "retirement_gate": "ops/qa/qa_archive_recovery_gate.py",
         "break_glass_state": "retired",
         "shared_role_boundary": "shared_ec2_instance_role_no_process_isolation",
-    }:
+    }
+    if not isinstance(recovery, dict) or recovery != expected_recovery:
         failures.append("rollout raw archive recovery contract drift")
+    qa_records = prod.get("qa_records")
+    if not isinstance(qa_records, dict) or qa_records != {
+        "partition_owner_repository": "default_only",
+        "partition_owner_observed": "pending_live_probe",
+    }:
+        failures.append("rollout qa_records partition owner contract drift")
+    user_export = prod.get("user_export")
+    if not isinstance(user_export, dict) or user_export.get("phase3_worker_observed_state") != "transitional_in_prod":
+        failures.append("rollout user export phase3 observed state drift")
     return failures
 
 
@@ -549,6 +581,7 @@ prod:
     shard_minutes: 60
     seal_delay_minutes: 15
     max_catchup_windows_per_run: 1
+    catchup_gap_policy: accepted_terminal
     s3_retention_days: 7
     runner_uid: 1000
     runner_gid: 1000

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1239,11 +1239,15 @@ if ! command -v python3 >/dev/null 2>&1; then
     errors=$((errors + 1))
 elif ! python3 -m py_compile \
     ./ops/qa/qa_archive_recovery_gate.py \
+    ./ops/qa/prod_phase2_live_health.py \
+    ./ops/qa/verify_raw_archive_iam_contract.py \
+    ./ops/qa/qa_phase2_health.py \
     ./deploy/aws/cloudformation/test_stage0_qa_raw_archive_contract.py; then
     errors=$((errors + 1))
 elif ! python3 -m unittest \
     deploy.aws.cloudformation.test_stage0_qa_raw_archive_contract \
-    ops.qa.test_qa_archive_recovery_gate; then
+    ops.qa.test_qa_archive_recovery_gate \
+    ops.qa.test_prod_phase2_live_health; then
     errors=$((errors + 1))
 else
     echo "  ok: exact QA IAM sets and approval-bound workstation recovery gate pass"

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6034,9 +6034,11 @@
         "deletion_authorized=false",
         "archive.NewReconciler",
         "aggregate_record_count",
-        "lockAcquired"
+        "lockAcquired",
+        "CatchupDispositionSourceUnavailableAfterRetention",
+        "Terminal catchup gap is recorded during select"
       ],
-      "rationale": "Prod QA maintenance must retain sealed-window selection, the single verified reconciler owner, failure-safe locking, committed aggregate heartbeat, and hard denial of deletion."
+      "rationale": "Prod QA maintenance must retain sealed-window selection, the single verified reconciler owner, failure-safe locking, committed aggregate heartbeat, hard denial of deletion, and terminal catchup gaps that do not fail the sealed normal hour."
     },
     {
       "path": "backend/internal/observability/qa/archive/segment_builder.go",


### PR DESCRIPTION
## 摘要

- maintenance：`source_unavailable_after_retention` 不再拖垮整轮；normal 前向归档可独立成功（heartbeat + host receipt + exit 0）
- 新增 prod Phase 2 live 探针与评估器，接入 `ops-daily-diagnostics`（含 IAM 合约 drift finding）
- `qa_phase2_health.py` 拆分 forward/catchup；`accepted_terminal` 策略下历史 terminal gap 降为 degraded
- `deploy_rollout.yaml` 诚实拆分 repository vs observed 状态；`qa-lifecycle-ssot.py` 机械对齐
- restore 校验失败时清理输出目录；recovery gate 支持可选 `approval_issuer`
- xj-review 修复：rebase 到最新 main；gateway-tk sentinel 锚定 terminal catchup 语义；补 command 级回归测试

## 风险

- 合并后 prod maintenance 在仍有历史 terminal gap 时 systemd 应从 failed 恢复为 success/degraded（需等下一小时 timer 或手动观察）
- 每日诊断会对 live IAM 漂移开 issue（若 prod 尚未 apply 收紧 policy，预期出现 `qa_raw_archive_iam_contract` finding）
- 未做 qa_records 日分区迁移与 Phase 3 Fargate 全量实现（SSOT 已标 transitional/pending）

## 验证

- `./scripts/preflight.sh` PASS（rebase 后）
- `go test -tags=unit ./cmd/server -run TestUS045_QAMaintenanceCommandSucceedsWithTerminalCatchupGap`
- `go test -tags=unit ./cmd/server -run TestUS045_NormalFirstBoundedCompensation`
- `go test -tags=unit ./cmd/qa-archive -run TestUS045_WorkstationRecoveryRestoreRemovesOutput`
- `python3 -m unittest ops.qa.test_prod_phase2_live_health ops.qa.test_qa_maintenance_phase2_runtime.QAPhase2OperatorAndHealthTest scripts.checks.qa-lifecycle-ssot`

## 提交

- 64806aa96 fix(qa): close Phase 2 ops control-plane gaps in one pass
- 10306f15d fix(qa): anchor terminal catchup success path for xj-review

最新提交：10306f15d