### PR TITLE
fix(gateway): Bedrock 账号在 /v1/chat/completions 走 Bedrock 上游

### DIFF
--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -61,11 +61,12 @@ func (s *GatewayService) ForwardAsChatCompletions(
 	// 3. Upstream streaming shape. Native Anthropic upstreams are forced to SSE
 	// even for non-streaming CC clients so handleCCBufferedFromAnthropic can
 	// assemble the response. Kiro (native + prod mirror stubs relaying to edge)
-	// must preserve stream=false — forced SSE on multi-turn agent payloads was
-	// timing out (~32s) with upstream 502 before any content arrived.
+	// and Bedrock must preserve stream=false — forced SSE on multi-turn agent
+	// payloads was timing out (~32s) with upstream 502 before any content arrived;
+	// Bedrock non-stream invoke returns JSON directly.
 	reqStream := clientStream
 	anthropicReq.Stream = clientStream
-	if !tkCCPreservesKiroUpstreamStream(account, clientStream) {
+	if !tkCCPreservesKiroUpstreamStream(account, clientStream) && !account.IsBedrock() {
 		anthropicReq.Stream = true
 		reqStream = true
 	}
@@ -140,6 +141,13 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 	if account.IsKiro() {
 		return s.forwardAsChatCompletionsViaKiro(
+			ctx, c, account, body, originalModel, mappedModel, anthropicBody,
+			clientStream, includeUsage, startTime,
+		)
+	}
+
+	if account.IsBedrock() {
+		return s.forwardAsChatCompletionsViaBedrock(
 			ctx, c, account, body, originalModel, mappedModel, anthropicBody,
 			clientStream, includeUsage, startTime,
 		)

--- a/backend/internal/service/gateway_forward_as_chat_completions_tk_bedrock.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_tk_bedrock.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/sjson"
+)
+
+// forwardAsChatCompletionsViaBedrock routes CC→Anthropic converted bodies through
+// the Bedrock upstream (SigV4 or Bedrock API Key) instead of the Anthropic HTTP API,
+// then converts the captured Anthropic response back to Chat Completions.
+func (s *GatewayService) forwardAsChatCompletionsViaBedrock(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	ccBody []byte,
+	originalModel, mappedModel string,
+	anthropicBody []byte,
+	clientStream bool,
+	includeUsage bool,
+	startTime time.Time,
+) (*ForwardResult, error) {
+	upstreamStream := clientStream
+	var err error
+	if upstreamStream {
+		anthropicBody, err = sjson.SetBytes(anthropicBody, "stream", true)
+	} else {
+		anthropicBody, err = sjson.SetBytes(anthropicBody, "stream", false)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("set anthropic stream for bedrock bridge: %w", err)
+	}
+
+	bedrockParsed := &ParsedRequest{
+		Body:   NewRequestBodyRef(anthropicBody),
+		Model:  originalModel,
+		Stream: upstreamStream,
+	}
+	if bedrockParsed.Model == "" {
+		bedrockParsed.Model = mappedModel
+	}
+
+	var captureBuf bytes.Buffer
+	captureWriter := newBridgeCaptureWriter(&captureBuf)
+	origWriter := c.Writer
+	c.Writer = captureWriter
+
+	fwdResult, err := s.forwardBedrock(ctx, c, account, bedrockParsed, startTime)
+	c.Writer = origWriter
+	if err != nil {
+		if s.rateLimitService != nil {
+			var failoverErr *UpstreamFailoverError
+			if errors.As(err, &failoverErr) {
+				s.rateLimitService.HandleUpstreamError(ctx, account, failoverErr.StatusCode, failoverErr.ResponseHeaders, failoverErr.ResponseBody)
+			}
+		}
+		return nil, err
+	}
+
+	upstreamResp := &http.Response{
+		StatusCode: captureWriter.statusCode,
+		Header:     captureWriter.header.Clone(),
+		Body:       io.NopCloser(bytes.NewReader(captureBuf.Bytes())),
+	}
+	if upstreamResp.StatusCode == 0 {
+		upstreamResp.StatusCode = http.StatusOK
+	}
+
+	reasoningEffort := ExtractChatCompletionsReasoningEffortFromBody(ccBody)
+	reasoningEffort = ApplyThinkingEnabledFallback(reasoningEffort, ccBody, mappedModel)
+
+	var result *ForwardResult
+	if clientStream {
+		result, err = s.handleCCStreamingFromAnthropic(upstreamResp, c, originalModel, mappedModel, reasoningEffort, startTime, includeUsage)
+	} else if isAnthropicMessagesJSONResponse(upstreamResp) {
+		result, err = s.handleCCBufferedFromAnthropicJSON(upstreamResp, c, originalModel, mappedModel, reasoningEffort, startTime)
+	} else {
+		result, err = s.handleCCBufferedFromAnthropic(upstreamResp, c, originalModel, mappedModel, reasoningEffort, startTime)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if result != nil && fwdResult != nil {
+		if fwdResult.BillingTier != "" {
+			result.BillingTier = fwdResult.BillingTier
+		}
+		if fwdResult.RequestID != "" {
+			result.RequestID = fwdResult.RequestID
+		}
+		if fwdResult.Usage.InputTokens > 0 || fwdResult.Usage.OutputTokens > 0 {
+			result.Usage = fwdResult.Usage
+		}
+		if fwdResult.UpstreamModel != "" {
+			result.UpstreamModel = fwdResult.UpstreamModel
+		}
+	}
+	return result, nil
+}

--- a/backend/internal/service/gateway_forward_as_chat_completions_tk_bedrock_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_tk_bedrock_test.go
@@ -1,0 +1,161 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type bedrockCCUpstreamMock struct {
+	lastReq *http.Request
+}
+
+func (u *bedrockCCUpstreamMock) Do(req *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+	return u.doWithTLS(req)
+}
+
+func (u *bedrockCCUpstreamMock) DoWithTLS(req *http.Request, _ string, _ int64, _ int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.doWithTLS(req)
+}
+
+func (u *bedrockCCUpstreamMock) doWithTLS(req *http.Request) (*http.Response, error) {
+	u.lastReq = req
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "application/json")
+	rec.Header().Set("x-amzn-requestid", "bedrock-req-1")
+	rec.WriteHeader(http.StatusOK)
+	_, _ = rec.WriteString(`{
+		"id":"msg_bedrock_cc",
+		"type":"message",
+		"role":"assistant",
+		"content":[{"type":"text","text":"BEDROCK-CC-OK"}],
+		"model":"claude-sonnet-4-6",
+		"stop_reason":"end_turn",
+		"usage":{"input_tokens":7,"output_tokens":8}
+	}`)
+	return rec.Result(), nil
+}
+
+func TestForwardAsChatCompletions_BedrockAccountBridgesViaBedrockUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := &bedrockCCUpstreamMock{}
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"max_tokens":32,"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:       91,
+		Name:     "bedrock-2",
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeBedrock,
+		Credentials: map[string]any{
+			"auth_mode":        "apikey",
+			"api_key":          "bedrock-test-key",
+			"aws_region":       "us-east-1",
+			"aws_force_global": "true",
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "claude-sonnet-4-6", result.Model)
+	require.False(t, result.Stream)
+	require.Equal(t, 7, result.Usage.InputTokens)
+	require.Equal(t, 8, result.Usage.OutputTokens)
+
+	require.NotNil(t, upstream.lastReq)
+	require.Contains(t, upstream.lastReq.URL.Host, "bedrock-runtime.")
+	require.Contains(t, upstream.lastReq.URL.Path, "/model/")
+	require.NotContains(t, upstream.lastReq.URL.Host, "anthropic.com")
+	require.Equal(t, "Bearer bedrock-test-key", upstream.lastReq.Header.Get("Authorization"))
+	require.Empty(t, upstream.lastReq.Header.Get("x-api-key"))
+
+	reqBody, err := io.ReadAll(upstream.lastReq.Body)
+	require.NoError(t, err)
+	require.Equal(t, "bedrock-2023-05-31", gjson.GetBytes(reqBody, "anthropic_version").String())
+	require.False(t, gjson.GetBytes(reqBody, "stream").Bool())
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "chat.completion", gjson.GetBytes(rec.Body.Bytes(), "object").String())
+	require.Equal(t, "BEDROCK-CC-OK", gjson.GetBytes(rec.Body.Bytes(), "choices.0.message.content").String())
+}
+
+func TestForwardAsChatCompletions_BedrockAccountDoesNotUseAnthropicAPIKeyAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := &bedrockCCUpstreamMock{}
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:       91,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeBedrock,
+		Credentials: map[string]any{
+			"auth_mode":  "apikey",
+			"api_key":    "bedrock-test-key",
+			"aws_region": "us-east-1",
+		},
+	}
+
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"max_tokens":16,"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+
+	_, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, nil)
+	require.NoError(t, err)
+	require.NotContains(t, upstream.lastReq.URL.Host, "anthropic.com")
+	require.NotContains(t, upstream.lastReq.URL.Path, "/v1/messages")
+}
+
+func TestHandleCCBufferedFromAnthropicJSON_BedrockBridgeRegression(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	resp := &http.Response{
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+			"x-request-id": []string{"bedrock-json"},
+		},
+		Body: io.NopCloser(strings.NewReader(`{
+			"id":"bedrock-json",
+			"type":"message",
+			"role":"assistant",
+			"content":[{"type":"text","text":"bedrock-json-ok"}],
+			"model":"claude-sonnet-4-6",
+			"stop_reason":"end_turn",
+			"usage":{"input_tokens":3,"output_tokens":4}
+		}`)),
+	}
+
+	svc := &GatewayService{}
+	result, err := svc.handleCCBufferedFromAnthropicJSON(resp, c, "claude-sonnet-4-6", "claude-sonnet-4-6", nil, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "bedrock-json-ok", gjson.GetBytes(rec.Body.Bytes(), "choices.0.message.content").String())
+}


### PR DESCRIPTION
## 摘要

- `ForwardAsChatCompletions` 此前将 Bedrock 账号误路由到 Anthropic HTTP API，且 token 为空，导致 false `auth_error` 并触发账号永久禁用。
- 新增 `forwardAsChatCompletionsViaBedrock` companion，将 CC→Anthropic 转换后的请求经 Bedrock 上游（SigV4 / Bedrock API Key）转发，再把 Anthropic 响应转回 Chat Completions 格式。
- 补充正向/负向单元测试覆盖 Bedrock 路由分支。

## 风险

- 常规风险：仅影响 Bedrock 账号在 `/v1/chat/completions` 桥接路径；Anthropic 直连与其他平台路径不变。
- Web impact: none

sentinel-registry-reviewed

## 验证

- `./scripts/preflight.sh` — PASS
- `go test -tags=unit ./internal/service/ -run 'Bedrock|ChatCompletions' -count=1` — PASS

## 提交

- `2f53469e8` fix(gateway): route Bedrock accounts through Bedrock on /v1/chat/completions

最新提交：`2f53469e8`

Made with [Cursor](https://cursor.com)