### PR TITLE
fix(routes): remove duplicate usage/batch route panic on startup

### DIFF
--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -401,7 +401,9 @@ func registerAccountRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAu
 		accounts.POST("/:id/revert-proxy-fallback", h.Admin.Account.RevertProxyFallback)
 		accounts.GET("/:id/usage", h.Admin.Account.GetUsage)
 		accounts.GET("/:id/today-stats", h.Admin.Account.GetTodayStats)
-		accounts.POST("/usage/batch", h.Admin.Account.GetBatchUsage)
+		// TK: POST /usage/batch is registered by registerTKAccountUsageBatchRoutes
+		// (GetBatchPassiveUsage). Upstream GetBatchUsage shares the same path and
+		// must not be registered here — Gin panics on duplicate handlers.
 		accounts.POST("/today-stats/batch", h.Admin.Account.GetBatchTodayStats)
 		accounts.POST("/:id/clear-rate-limit", h.Admin.Account.ClearRateLimit)
 		accounts.POST("/:id/reset-quota", h.Admin.Account.ResetQuota)

--- a/backend/internal/server/routes/admin_tk_account_usage_batch_routes_test.go
+++ b/backend/internal/server/routes/admin_tk_account_usage_batch_routes_test.go
@@ -1,0 +1,31 @@
+package routes
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/handler"
+	adminhandler "github.com/Wei-Shaw/sub2api/internal/handler/admin"
+	servermiddleware "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+func TestRegisterAdminRoutesUsageBatchDoesNotDuplicateHandlers(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	v1 := router.Group("/api/v1")
+
+	// Duplicate POST /admin/accounts/usage/batch registration panics at startup.
+	RegisterAdminRoutes(
+		v1,
+		&handler.Handlers{
+			Admin: &handler.AdminHandlers{
+				Account: &adminhandler.AccountHandler{},
+			},
+		},
+		servermiddleware.AdminAuthMiddleware(func(c *gin.Context) { c.Next() }),
+		servermiddleware.AuditLogMiddleware(func(c *gin.Context) { c.Next() }),
+		servermiddleware.StepUpAuthMiddleware(func(c *gin.Context) { c.Next() }),
+		nil,
+		nil,
+	)
+}


### PR DESCRIPTION
## 摘要
- 移除 upstream merge 在 `admin.go` 中对 `POST /admin/accounts/usage/batch` 的重复注册
- 保留 TK companion `GetBatchPassiveUsage` 为唯一 handler
- 补回归测试，防止 Gin 启动 panic 再次进入镜像

sentinel-registry-reviewed

## 风险
- 低：仅删除重复路由行；前端账号列表用的是 `getBatchPassiveUsage`

## 验证
- `go test -tags=unit ./internal/server/routes/ -run TestRegisterAdminRoutesUsageBatchDoesNotDuplicateHandlers`

## 提交
- ef8fc022c fix(routes): remove duplicate POST /admin/accounts/usage/batch registration
- 最新提交：ef8fc022c