### PR TITLE
fix(docs): restore endpoint-compat baseline anchor for release sync

### DIFF
--- a/docs/ops/endpoint-compat-baseline.md
+++ b/docs/ops/endpoint-compat-baseline.md
@@ -25,7 +25,7 @@ stable probe conclusions, evidence pointers, and the next probe focus.
 |---|---|
 | Baseline date | 2026-08-10 |
 | Target | prod (`https://api.tokenkey.dev`) |
-| Runtime code anchor | `v1.8.142` release (`backend/cmd/server/VERSION`); last live deploy pending `v1.8.142` (prod still on `v1.8.141` before Phase 2 live-ops follow-up). The 2026-07-05 focused Anthropic closeout also includes the live config remediation that set edge default Anthropic group `id=1` to `claude_code_only=false` on `us3/us4/us5/us6`. |
+| Runtime code anchor | `v1.8.142` release (`backend/cmd/server/VERSION`); last live deploy `v1.8.141`. v1.8.142 image built but canary deploy failed (duplicate route panic, #1611). The 2026-07-05 focused Anthropic closeout also includes the live config remediation that set edge default Anthropic group `id=1` to `claude_code_only=false` on `us3/us4/us5/us6`. |
 | Paid media probes | approved and rerun post-`v1.8.80` / #1207 for Imagen, Veo, and Grok media SSOT display gate plus direct-vs-universal parity; latest full displayed+priced paid media gate on 2026-07-05 returned `DISPLAY_KEEP=19 DISPLAY_BLOCK=0 REPROBE_REQUIRED=0 FAIL=0`. |
 | Direct route-gate command | `bash ops/observability/endpoint-compat-audit.sh --direct-route-gate` |
 | Universal matrix command | `bash ops/observability/endpoint-compat-audit.sh --universal-matrix --with-extras --skip-paid` |

--- a/scripts/check_endpoint_compat_baseline_freshness.py
+++ b/scripts/check_endpoint_compat_baseline_freshness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import re
 import sys
 from pathlib import Path
@@ -10,6 +11,21 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BASELINE = REPO_ROOT / "docs/ops/endpoint-compat-baseline.md"
 VERSION_FILE = REPO_ROOT / "backend/cmd/server/VERSION"
+_SYNC_ANCHOR = Path(__file__).resolve().parent / "sync_endpoint_compat_baseline_anchor.py"
+
+
+def _load_parse_runtime_anchor():
+    spec = importlib.util.spec_from_file_location(
+        "sync_endpoint_compat_baseline_anchor", _SYNC_ANCHOR
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {_SYNC_ANCHOR}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.parse_runtime_anchor
+
+
+parse_runtime_anchor = _load_parse_runtime_anchor()
 
 
 def read_version() -> str:
@@ -21,21 +37,49 @@ def read_version() -> str:
     return version
 
 
+def validate_baseline_freshness(baseline_text: str, version: str) -> str | None:
+    """Return an error message when the baseline is stale or not syncable."""
+    expected = f"v{version}"
+    try:
+        release_tag, _last_deploy = parse_runtime_anchor(baseline_text)
+    except ValueError as exc:
+        return str(exc)
+    if release_tag != expected:
+        return (
+            "docs/ops/endpoint-compat-baseline.md runtime anchor release tag "
+            f"{release_tag} != backend/cmd/server/VERSION {expected}"
+        )
+    return None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.parse_args()
+    parser.add_argument("--selftest", action="store_true", help="offline selftest")
+    args = parser.parse_args()
+
+    if args.selftest:
+        valid = (
+            "| Runtime code anchor | `v1.8.142` release (`backend/cmd/server/VERSION`); "
+            "last live deploy `v1.8.141`. note |\n"
+        )
+        broken = (
+            "| Runtime code anchor | `v1.8.142` release (`backend/cmd/server/VERSION`); "
+            "last live deploy pending `v1.8.142` (prod still on `v1.8.141`). |\n"
+        )
+        assert validate_baseline_freshness(valid, "1.8.142") is None
+        assert validate_baseline_freshness(valid, "1.8.141") is not None
+        assert validate_baseline_freshness(broken, "1.8.142") is not None
+        print("check_endpoint_compat_baseline_freshness selftest: ok")
+        return 0
 
     version = read_version()
     if not BASELINE.is_file():
         print(f"endpoint-compat baseline freshness: FAIL missing {BASELINE}", file=sys.stderr)
         return 1
 
-    if f"v{version}" not in BASELINE.read_text(encoding="utf-8"):
-        print(
-            "endpoint-compat baseline freshness: FAIL "
-            f"docs/ops/endpoint-compat-baseline.md must mention deployed runtime anchor v{version}",
-            file=sys.stderr,
-        )
+    err = validate_baseline_freshness(BASELINE.read_text(encoding="utf-8"), version)
+    if err:
+        print(f"endpoint-compat baseline freshness: FAIL {err}", file=sys.stderr)
         return 1
 
     print(f"endpoint-compat baseline freshness: ok (runtime anchor v{version})")

--- a/scripts/sync_endpoint_compat_baseline_anchor.py
+++ b/scripts/sync_endpoint_compat_baseline_anchor.py
@@ -15,7 +15,23 @@ VERSION_FILE = REPO_ROOT / "backend/cmd/server/VERSION"
 RUNTIME_ANCHOR_RE = re.compile(
     r"(\| Runtime code anchor \| `)v[\d.]+(` release \(`backend/cmd/server/VERSION`\); last live deploy `)v[\d.]+(`\.)"
 )
+RUNTIME_ANCHOR_ROW_RE = re.compile(
+    r"\| Runtime code anchor \| `(?P<release>v[\d.]+)` release \(`backend/cmd/server/VERSION`\); "
+    r"last live deploy `(?P<last_deploy>v[\d.]+)`\."
+)
 BASELINE_DATE_RE = re.compile(r"(\| Baseline date \| )[\d-]+( \|)")
+
+
+def parse_runtime_anchor(text: str) -> tuple[str, str]:
+    """Return (release_tag, last_deploy_tag) from the baseline runtime anchor row."""
+    if not RUNTIME_ANCHOR_RE.search(text):
+        raise ValueError(
+            "Runtime code anchor row not found or not syncable by release-bump-and-tag"
+        )
+    match = RUNTIME_ANCHOR_ROW_RE.search(text)
+    if match is None:
+        raise ValueError("Runtime code anchor row shape drifted from sync parser")
+    return match.group("release"), match.group("last_deploy")
 
 
 def normalize_tag(tag: str) -> str:
@@ -70,6 +86,7 @@ def main() -> int:
         out = sync_baseline_text(sample, "1.1.0", "v1.0.0")
         assert "`v1.1.0` release" in out and "last live deploy `v1.0.0`" in out
         assert "| Baseline date | " in out
+        assert parse_runtime_anchor(sample) == ("v1.0.0", "v0.9.9")
         print("sync_endpoint_compat_baseline_anchor selftest: ok")
         return 0
 

--- a/scripts/test_check_endpoint_compat_baseline_freshness.py
+++ b/scripts/test_check_endpoint_compat_baseline_freshness.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_endpoint_compat_baseline_freshness.py."""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+_CHECK = pathlib.Path(__file__).resolve().parent / "check_endpoint_compat_baseline_freshness.py"
+
+
+def _load_check_module():
+    spec = importlib.util.spec_from_file_location("check_endpoint_compat_baseline_freshness", _CHECK)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {_CHECK}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CheckEndpointCompatBaselineFreshnessTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mod = _load_check_module()
+
+    def test_valid_anchor_row_matches_version(self) -> None:
+        text = (
+            "| Runtime code anchor | `v1.8.142` release (`backend/cmd/server/VERSION`); "
+            "last live deploy `v1.8.141`. canary failed (#1611). |\n"
+        )
+        self.assertIsNone(self.mod.validate_baseline_freshness(text, "1.8.142"))
+
+    def test_pending_deploy_wording_fails_syncable_shape(self) -> None:
+        text = (
+            "| Runtime code anchor | `v1.8.142` release (`backend/cmd/server/VERSION`); "
+            "last live deploy pending `v1.8.142` (prod still on `v1.8.141`). |\n"
+        )
+        err = self.mod.validate_baseline_freshness(text, "1.8.142")
+        self.assertIsNotNone(err)
+        self.assertIn("not syncable", err)
+
+    def test_release_tag_must_match_version_file(self) -> None:
+        text = (
+            "| Runtime code anchor | `v1.8.141` release (`backend/cmd/server/VERSION`); "
+            "last live deploy `v1.8.140`. |\n"
+        )
+        err = self.mod.validate_baseline_freshness(text, "1.8.142")
+        self.assertIsNotNone(err)
+        self.assertIn("v1.8.141", err)
+        self.assertIn("v1.8.142", err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- 恢复 `endpoint-compat-baseline.md` Runtime code anchor 行格式，匹配 `sync_endpoint_compat_baseline_anchor.py` 正则
- `check_endpoint_compat_baseline_freshness.py` 复用同一 parser，preflight 会拒绝 `last live deploy pending` 等非 syncable 措辞
- 解除 `release-bump-and-tag.sh` 在 v1.8.143 bump 时的阻塞

sentinel-registry-reviewed

## 风险
- 低：仅文档 + preflight 脚本；无运行时行为变化

## 验证
- `python3 scripts/sync_endpoint_compat_baseline_anchor.py --selftest`
- `python3 scripts/check_endpoint_compat_baseline_freshness.py --selftest`
- `python3 -m unittest scripts.test_check_endpoint_compat_baseline_freshness -v`
- `python3 scripts/check_endpoint_compat_baseline_freshness.py`

## 提交
- ae4a7247e fix(docs): restore endpoint-compat baseline anchor row for release sync
- e7cc9e89c fix(ops): gate endpoint-compat baseline anchor row shape in preflight
- 最新提交：e7cc9e89c