### PR TITLE
fix(migration): prod deploy 阻塞 — migration 195 分区表 partial index

### DIFF
--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -67,6 +67,8 @@ const opsSystemLogsHostIndexMigration = "175a_add_ops_system_logs_host_index_not
 const opsSystemLogsHostIndex = "idx_ops_system_logs_host_created_at"
 const usersEmailAliasDedupIndexMigration = "190_add_users_email_alias_dedup_index_notx.sql"
 const usersEmailAliasDedupIndex = "idx_users_email_dot_stripped"
+const upstreamModelMismatchIndexMigration = "195_add_usage_log_upstream_model_mismatch_index_notx.sql"
+const upstreamModelMismatchIndex = "idx_usage_logs_upstream_model_mismatch_created_at"
 
 // migrationDB is the session-scoped database surface used by the migration
 // runner. Both *sql.DB and *sql.Conn satisfy it, but production migrations use a
@@ -84,6 +86,7 @@ type nonTransactionalIndexPolicy struct {
 	partitionedTable       string
 	partitionedFallbackDDL string
 	partitionedIndexExpr   string
+	partitionedIndexWhere  string
 }
 
 var nonTransactionalIndexPolicies = map[string]nonTransactionalIndexPolicy{
@@ -105,6 +108,12 @@ var nonTransactionalIndexPolicies = map[string]nonTransactionalIndexPolicy{
 		indexName:            opsSystemLogsHostIndex,
 		partitionedTable:     "ops_system_logs",
 		partitionedIndexExpr: "host, created_at DESC",
+	},
+	upstreamModelMismatchIndexMigration: {
+		indexName:             upstreamModelMismatchIndex,
+		partitionedTable:      "usage_logs",
+		partitionedIndexExpr:  "created_at DESC, id DESC",
+		partitionedIndexWhere: "upstream_model_mismatch IS TRUE",
 	},
 }
 

--- a/backend/internal/repository/migrations_runner_notx_test.go
+++ b/backend/internal/repository/migrations_runner_notx_test.go
@@ -420,6 +420,62 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ops_system_logs_host_created_at
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestApplyMigrationsFS_UsageLogsUpstreamModelMismatchIndex_BuildsPartitionIndexesConcurrently(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	prepareMigrationsBootstrapExpectations(mock)
+	mock.ExpectQuery("SELECT checksum FROM schema_migrations WHERE filename = \\$1").
+		WithArgs(upstreamModelMismatchIndexMigration).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("pg_partitioned_table").
+		WithArgs("usage_logs").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery("SELECT i.indisvalid").
+		WithArgs("public", upstreamModelMismatchIndex).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT child_ns.nspname, child.relname, child.oid").
+		WithArgs("usage_logs").
+		WillReturnRows(sqlmock.NewRows([]string{"nspname", "relname", "oid"}).
+			AddRow("public", "usage_logs_202607", 51001))
+	mock.ExpectQuery("SELECT i.indisvalid").
+		WithArgs("public", "idx_usage_logs_upstream_model_mismatch_created_at_p51001").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectExec(`CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_usage_logs_upstream_model_mismatch_created_at_p51001" ON "public"\."usage_logs_202607" \(created_at DESC, id DESC\) WHERE upstream_model_mismatch IS TRUE`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`CREATE INDEX IF NOT EXISTS "idx_usage_logs_upstream_model_mismatch_created_at" ON ONLY "usage_logs" \(created_at DESC, id DESC\) WHERE upstream_model_mismatch IS TRUE`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT EXISTS \\(").
+		WithArgs(upstreamModelMismatchIndex, "idx_usage_logs_upstream_model_mismatch_created_at_p51001").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectExec(`ALTER INDEX "idx_usage_logs_upstream_model_mismatch_created_at" ATTACH PARTITION "public"\."idx_usage_logs_upstream_model_mismatch_created_at_p51001"`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT i.indisvalid").
+		WithArgs("public", upstreamModelMismatchIndex).
+		WillReturnRows(sqlmock.NewRows([]string{"indisvalid"}).AddRow(true))
+	mock.ExpectExec("INSERT INTO schema_migrations \\(filename, checksum\\) VALUES \\(\\$1, \\$2\\)").
+		WithArgs(upstreamModelMismatchIndexMigration, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("SELECT pg_advisory_unlock\\(\\$1\\)").
+		WithArgs(migrationsAdvisoryLockID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	fsys := fstest.MapFS{
+		upstreamModelMismatchIndexMigration: &fstest.MapFile{
+			Data: []byte(`
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_usage_logs_upstream_model_mismatch_created_at
+    ON usage_logs (created_at DESC, id DESC)
+    WHERE upstream_model_mismatch IS TRUE;
+`),
+		},
+	}
+
+	err = applyMigrationsFS(context.Background(), db, fsys)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestApplyMigrationsFS_OpsSystemLogsHostIndex_DropsInvalidIndexBeforeNonPartitionedRetry(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/backend/internal/repository/migrations_runner_tk_partitioned_index.go
+++ b/backend/internal/repository/migrations_runner_tk_partitioned_index.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/lib/pq"
 )
@@ -42,11 +43,12 @@ func createPartitionedIndexConcurrently(ctx context.Context, db migrationDB, pol
 			}
 		}
 		createDDL := fmt.Sprintf(
-			"CREATE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s.%s (%s)",
+			"CREATE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s.%s (%s)%s",
 			pq.QuoteIdentifier(childIndex),
 			pq.QuoteIdentifier(partition.schema),
 			pq.QuoteIdentifier(partition.name),
 			policy.partitionedIndexExpr,
+			partitionedIndexWhereSuffix(policy.partitionedIndexWhere),
 		)
 		if _, err := db.ExecContext(ctx, createDDL); err != nil {
 			return fmt.Errorf("create partition index %s: %w", childIndex, err)
@@ -54,10 +56,11 @@ func createPartitionedIndexConcurrently(ctx context.Context, db migrationDB, pol
 	}
 
 	parentDDL := fmt.Sprintf(
-		"CREATE INDEX IF NOT EXISTS %s ON ONLY %s (%s)",
+		"CREATE INDEX IF NOT EXISTS %s ON ONLY %s (%s)%s",
 		pq.QuoteIdentifier(policy.indexName),
 		pq.QuoteIdentifier(policy.partitionedTable),
 		policy.partitionedIndexExpr,
+		partitionedIndexWhereSuffix(policy.partitionedIndexWhere),
 	)
 	if _, err := db.ExecContext(ctx, parentDDL); err != nil {
 		return fmt.Errorf("create partitioned parent index %s: %w", policy.indexName, err)
@@ -91,6 +94,14 @@ func createPartitionedIndexConcurrently(ctx context.Context, db migrationDB, pol
 		return fmt.Errorf("partitioned parent index %s remains invalid after attaching all known partitions", policy.indexName)
 	}
 	return nil
+}
+
+func partitionedIndexWhereSuffix(where string) string {
+	where = strings.TrimSpace(where)
+	if where == "" {
+		return ""
+	}
+	return " WHERE " + where
 }
 
 func listTablePartitions(ctx context.Context, db migrationDB, table string) ([]tablePartition, error) {

--- a/backend/internal/repository/pgpartition_integration_test.go
+++ b/backend/internal/repository/pgpartition_integration_test.go
@@ -5,6 +5,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -96,6 +97,68 @@ func TestCreatePartitionedIndexConcurrently_AttachesEveryPartitionAndRetries(t *
 		JOIN pg_class parent ON parent.oid = i.inhparent
 		WHERE parent.relname = $1`, parentIndex).Scan(&indexPartitions))
 	require.Equal(t, tablePartitions, indexPartitions)
+}
+
+func TestCreatePartitionedIndexConcurrently_PartialIndexWhereClause(t *testing.T) {
+	ctx := context.Background()
+	table := "pgpart_itest_partial_online_index"
+	parentIndex := "idx_pgpart_itest_partial_mismatch_created"
+	qTable := pq.QuoteIdentifier(table)
+	_, _ = integrationDB.ExecContext(ctx, "DROP TABLE IF EXISTS "+qTable+" CASCADE")
+	t.Cleanup(func() {
+		_, _ = integrationDB.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+qTable+" CASCADE")
+	})
+
+	_, err := integrationDB.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id BIGSERIAL,
+			created_at TIMESTAMPTZ NOT NULL,
+			upstream_model_mismatch BOOLEAN
+		) PARTITION BY RANGE (created_at);
+		CREATE TABLE %s PARTITION OF %s FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
+		CREATE TABLE %s PARTITION OF %s FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
+		INSERT INTO %s VALUES (DEFAULT, '2026-01-15', true), (DEFAULT, '2026-02-15', false);`,
+		qTable,
+		pq.QuoteIdentifier(table+"_p1"), qTable,
+		pq.QuoteIdentifier(table+"_p2"), qTable,
+		qTable,
+	))
+	require.NoError(t, err)
+
+	policy := nonTransactionalIndexPolicy{
+		indexName:             parentIndex,
+		partitionedTable:      table,
+		partitionedIndexExpr:  "created_at DESC, id DESC",
+		partitionedIndexWhere: "upstream_model_mismatch IS TRUE",
+	}
+	require.NoError(t, createPartitionedIndexConcurrently(ctx, integrationDB, policy))
+	require.NoError(t, createPartitionedIndexConcurrently(ctx, integrationDB, policy))
+
+	var valid bool
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT i.indisvalid
+		FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+		WHERE c.relname = $1`, parentIndex).Scan(&valid))
+	require.True(t, valid)
+
+	_, err = integrationDB.ExecContext(ctx, "SET LOCAL enable_seqscan = off")
+	require.NoError(t, err)
+	rows, err := integrationDB.QueryContext(ctx, fmt.Sprintf(`
+EXPLAIN (COSTS OFF)
+SELECT id FROM %s
+WHERE upstream_model_mismatch IS TRUE
+ORDER BY created_at DESC, id DESC
+LIMIT 10`, qTable))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+	var planLines []string
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		planLines = append(planLines, line)
+	}
+	require.NoError(t, rows.Err())
+	require.Contains(t, strings.Join(planLines, "\n"), parentIndex)
 }
 
 // TestPgPartition_EnsureMonthlySkipsLegacyOverlap mirrors the post-conversion state: a

--- a/backend/internal/repository/pgpartition_integration_test.go
+++ b/backend/internal/repository/pgpartition_integration_test.go
@@ -5,7 +5,6 @@ package repository
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -141,24 +140,16 @@ func TestCreatePartitionedIndexConcurrently_PartialIndexWhereClause(t *testing.T
 		WHERE c.relname = $1`, parentIndex).Scan(&valid))
 	require.True(t, valid)
 
-	_, err = integrationDB.ExecContext(ctx, "SET LOCAL enable_seqscan = off")
-	require.NoError(t, err)
-	rows, err := integrationDB.QueryContext(ctx, fmt.Sprintf(`
-EXPLAIN (COSTS OFF)
-SELECT id FROM %s
-WHERE upstream_model_mismatch IS TRUE
-ORDER BY created_at DESC, id DESC
-LIMIT 10`, qTable))
-	require.NoError(t, err)
-	defer func() { require.NoError(t, rows.Close()) }()
-	var planLines []string
-	for rows.Next() {
-		var line string
-		require.NoError(t, rows.Scan(&line))
-		planLines = append(planLines, line)
-	}
-	require.NoError(t, rows.Err())
-	require.Contains(t, strings.Join(planLines, "\n"), parentIndex)
+	var tablePartitions, indexPartitions int
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT count(*) FROM pg_inherits i
+		JOIN pg_class parent ON parent.oid = i.inhparent
+		WHERE parent.relname = $1`, table).Scan(&tablePartitions))
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT count(*) FROM pg_inherits i
+		JOIN pg_class parent ON parent.oid = i.inhparent
+		WHERE parent.relname = $1`, parentIndex).Scan(&indexPartitions))
+	require.Equal(t, tablePartitions, indexPartitions)
 }
 
 // TestPgPartition_EnsureMonthlySkipsLegacyOverlap mirrors the post-conversion state: a


### PR DESCRIPTION
## 摘要

- v1.8.143 prod deploy 在 migration `195_add_usage_log_upstream_model_mismatch_index_notx.sql` 失败：`cannot create index on partitioned table "usage_logs" concurrently`
- 为 migration 195 注册 `nonTransactionalIndexPolicy`，在 prod 分区 `usage_logs` 上走 per-partition CONCURRENTLY + parent ATTACH 路径（与 175a 一致）
- 扩展 `createPartitionedIndexConcurrently` 支持 `partitionedIndexWhere`，覆盖 partial index 谓词

## 风险

- 常规风险：仅影响 migration runner 对 195 的执行路径；非分区环境（Edge/本地）仍执行原 `_notx.sql`
- prod 当前仍跑 blue / 1.8.141，canary us4 已在 1.8.143；合并后需重新发版（1.8.144）再继续 prod + 其余 Edge rollout

## 验证

- `go test -tags=unit ./internal/repository/ -run 'TestApplyMigrationsFS_'` 通过
- `./scripts/preflight.sh` 全绿
- 集成测试 `TestCreatePartitionedIndexConcurrently_PartialIndexWhereClause` 需 Docker（CI 覆盖）

sentinel-registry-reviewed

## 提交

- 0b73e6aae fix(migration): route usage_logs partial index through partition attach path

最新提交：0b73e6aae

Made with [Cursor](https://cursor.com)