### PR TITLE
fix(qa): 补齐 rollback 与归档证据闭环

### DIFF
--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -106,6 +106,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: bash ops/stage0/verify_ghcr_manifest.sh "$INPUT_TAG" "$INPUT_OVERRIDE"
 
+      - name: Checkout target-tag QA host artifacts
+        uses: actions/checkout@v6
+        with:
+          ref: v${{ inputs.tag }}
+          path: qa-host-runtime
+          fetch-depth: 1
+
+      - name: Verify target-tag QA host artifacts
+        id: qa_host_artifacts
+        run: |
+          set -euo pipefail
+          test "$(git -C qa-host-runtime describe --tags --exact-match)" = "v${INPUT_TAG}"
+          test -f qa-host-runtime/deploy/aws/stage0/tokenkey-qa-maintenance.sh
+          test -f qa-host-runtime/deploy/aws/stage0/tokenkey-qa-boundary.sh
+          SHA="$(git -C qa-host-runtime rev-parse HEAD)"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "QA host artifacts resolved from v${INPUT_TAG}@${SHA}"
+
       - name: Blue/green migration safety gate
         # The target app can apply migrations while the old app is still serving
         # existing requests on the same prod DB. Advisory locks serialize
@@ -193,6 +211,24 @@ jobs:
         env:
           API_URL: ${{ steps.instance.outputs.api_url }}
         run: bash ops/stage0/external_health.sh "$API_URL"
+
+      - name: Sync QA maintenance host runner
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+          QA_MAINTENANCE_TIMER_STATE: enabled
+          QA_HOST_ARTIFACT_ROOT: qa-host-runtime
+          QA_HOST_ARTIFACT_SHA: ${{ steps.qa_host_artifacts.outputs.sha }}
+          STAGE0_SSM_OUTPUT_DIR: .qa-maintenance-sync
+        run: bash ops/stage0/sync-qa-maintenance-timer-via-ssm.sh "$INSTANCE_ID" "deploy-stage0 qa-maintenance host artifact"
+
+      - name: Sync QA boundary host runner and restore durable owner
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+          QA_BOUNDARY_TIMER_STATE: auto
+          QA_HOST_ARTIFACT_ROOT: qa-host-runtime
+          QA_HOST_ARTIFACT_SHA: ${{ steps.qa_host_artifacts.outputs.sha }}
+          STAGE0_SSM_OUTPUT_DIR: .qa-boundary-sync
+        run: bash ops/stage0/sync-qa-boundary-timer-via-ssm.sh "$INSTANCE_ID" "deploy-stage0 qa-boundary host artifact"
 
       - name: Audit pricing registry runtime (read-only)
         # Price publication is owned only by pricing-registry-publish.yml after a

--- a/backend/cmd/server/qa_maintenance.go
+++ b/backend/cmd/server/qa_maintenance.go
@@ -77,6 +77,22 @@ type qaMaintenanceCycleResult struct {
 	FailureCode           string
 }
 
+type qaMaintenanceCommandReceipt struct {
+	ReceiptVersion     int                `json:"receipt_version"`
+	Mode               string             `json:"mode"`
+	OK                 bool               `json:"ok"`
+	JobName            string             `json:"job_name"`
+	RunID              string             `json:"run_id"`
+	Trigger            string             `json:"trigger"`
+	CompletedAt        time.Time          `json:"completed_at"`
+	Plan               qaMaintenancePlan  `json:"plan"`
+	Compensation       *qaMaintenancePlan `json:"compensation,omitempty"`
+	FailureStage       string             `json:"failure_stage,omitempty"`
+	FailureCode        string             `json:"failure_code,omitempty"`
+	DeletionAuthorized bool               `json:"deletion_authorized"`
+	UploadAuthorized   bool               `json:"upload_authorized"`
+}
+
 func runQAMaintenanceArchiveCycle(
 	ctx context.Context,
 	normal archive.Window,
@@ -380,6 +396,19 @@ func runQAMaintenanceCommand(
 				plan.VerificationErrorCode = cycle.FailureCode
 			}
 			failureLastResult = qaMaintenanceCycleLastResult("failed", runID, trigger, plan, compensationPlan, cycle.FailureStage, cycle.FailureCode)
+			if !cycle.Normal.WindowStart.IsZero() {
+				receipt := qaMaintenanceCommandReceipt{
+					ReceiptVersion: qaMaintenanceReceiptVersion,
+					Mode:           qaMaintenanceReceiptModeUpload,
+					OK:             false, JobName: qaMaintenanceJobName, RunID: runID, Trigger: trigger,
+					CompletedAt: deps.now().UTC(), Plan: plan, Compensation: compensationPlan,
+					FailureStage: cycle.FailureStage, FailureCode: cycle.FailureCode,
+					DeletionAuthorized: false, UploadAuthorized: true,
+				}
+				if encodeErr := json.NewEncoder(out).Encode(receipt); encodeErr != nil {
+					return fmt.Errorf("%w; encode qa maintenance failure receipt: %v", cycleErr, encodeErr)
+				}
+			}
 			return cycleErr
 		}
 		uploadAuthorized = true
@@ -428,19 +457,7 @@ func runQAMaintenanceCommand(
 	}
 	heartbeatWritten = true
 
-	receipt := struct {
-		ReceiptVersion     int                `json:"receipt_version"`
-		Mode               string             `json:"mode"`
-		OK                 bool               `json:"ok"`
-		JobName            string             `json:"job_name"`
-		RunID              string             `json:"run_id"`
-		Trigger            string             `json:"trigger"`
-		CompletedAt        time.Time          `json:"completed_at"`
-		Plan               qaMaintenancePlan  `json:"plan"`
-		Compensation       *qaMaintenancePlan `json:"compensation,omitempty"`
-		DeletionAuthorized bool               `json:"deletion_authorized"`
-		UploadAuthorized   bool               `json:"upload_authorized"`
-	}{
+	receipt := qaMaintenanceCommandReceipt{
 		ReceiptVersion:     qaMaintenanceReceiptVersion,
 		Mode:               mode,
 		OK:                 true,

--- a/backend/cmd/server/qa_maintenance_phase2_test.go
+++ b/backend/cmd/server/qa_maintenance_phase2_test.go
@@ -382,8 +382,31 @@ func TestUS045_QAMaintenanceCommandFailsClosedOnTerminalCatchupGap(t *testing.T)
 	if !strings.Contains(*heartbeat.LastResult, "normal_commit_etag=normal-etag") {
 		t.Fatalf("heartbeat result %q missing normal success fact", *heartbeat.LastResult)
 	}
-	if out.Len() > 0 {
-		t.Fatalf("unexpected success receipt on terminal compensation: %s", out.String())
+	var failureReceipt struct {
+		OK           bool              `json:"ok"`
+		RunID        string            `json:"run_id"`
+		Trigger      string            `json:"trigger"`
+		Plan         qaMaintenancePlan `json:"plan"`
+		Compensation qaMaintenancePlan `json:"compensation"`
+		FailureStage string            `json:"failure_stage"`
+		FailureCode  string            `json:"failure_code"`
+	}
+	if decodeErr := json.Unmarshal(out.Bytes(), &failureReceipt); decodeErr != nil {
+		t.Fatalf("decode failure receipt: %v; output=%s", decodeErr, out.String())
+	}
+	if failureReceipt.OK || failureReceipt.RunID != "run-terminal-045" || failureReceipt.Trigger != "timer" {
+		t.Fatalf("failure receipt identity=%+v", failureReceipt)
+	}
+	if failureReceipt.Plan.CommitETag != "normal-etag" || !failureReceipt.Plan.RestoreVerified {
+		t.Fatalf("failure receipt lost normal success: %+v", failureReceipt.Plan)
+	}
+	if failureReceipt.Compensation.WindowStart != terminal.Start ||
+		failureReceipt.Compensation.VerificationErrorCode != archive.IntegritySourceUnavailableAfterRetention {
+		t.Fatalf("failure receipt lost terminal compensation: %+v", failureReceipt.Compensation)
+	}
+	if failureReceipt.FailureStage != "compensation_terminal" ||
+		failureReceipt.FailureCode != archive.IntegritySourceUnavailableAfterRetention {
+		t.Fatalf("failure receipt code=%+v", failureReceipt)
 	}
 	if err := mockDB.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)

--- a/deploy/aws/stage0/tokenkey-qa-maintenance.sh
+++ b/deploy/aws/stage0/tokenkey-qa-maintenance.sh
@@ -231,7 +231,15 @@ if child_path and child_path.is_file():
         except json.JSONDecodeError:
             continue
         if isinstance(candidate, dict):
-            child = candidate
+            if (
+                candidate.get("receipt_version") == 2
+                and candidate.get("job_name") == "qa-maintenance"
+                and candidate.get("run_id") == os.environ["QA_RECEIPT_RUN_ID"]
+                and candidate.get("trigger") == os.environ["QA_RECEIPT_TRIGGER"]
+                and candidate.get("deletion_authorized") is False
+                and isinstance(candidate.get("plan"), dict)
+            ):
+                child = candidate
 
 payload = {
     "schema_version": os.environ["QA_RECEIPT_SCHEMA"],
@@ -245,6 +253,8 @@ payload = {
     "runner_gid": int(os.environ["QA_RECEIPT_GID"]),
     "normal": child.get("plan") if child else None,
     "compensation": child.get("compensation") if child else None,
+    "failure_stage": child.get("failure_stage") if child else None,
+    "failure_code": child.get("failure_code") if child else None,
     "child_exit_code": int(os.environ["QA_RECEIPT_CHILD_EXIT"]),
     "runner_exit_code": int(os.environ["QA_RECEIPT_RUNNER_EXIT"]),
     "error_code": os.environ["QA_RECEIPT_ERROR_CODE"],
@@ -323,6 +333,7 @@ run_qa_maintenance() {
   set -e
   cat "${CHILD_STDOUT}"
   if [ "${CHILD_EXIT_CODE}" -ne 0 ]; then
+    cat "${CHILD_STDERR}" >&2
     ERROR_CODE=child_failed
     qa_log "archive_failed run_id=${RUN_ID} child_exit=${CHILD_EXIT_CODE}"
     return "${CHILD_EXIT_CODE}"

--- a/docs/approved/design-qa-phase2-archive-closeout.md
+++ b/docs/approved/design-qa-phase2-archive-closeout.md
@@ -37,6 +37,17 @@ after the normal window succeeds. It also assigns stale export-temp cleanup and 
 the honest shared-EC2-role IAM boundary. This revision does not reopen historical
 backfill, Phase 3 user export, or Phase 5 emergency work.
 
+Every production image deploy resolves both QA host-runner artifacts from the exact target
+release tag before changing the production image, then synchronizes those artifacts after
+the application health check. Maintenance is restored enabled. Boundary owner state is
+derived from durable lifecycle receipts: before activate it remains disabled; during drain
+the legacy timer remains enabled and boundary remains disabled; after finalize boundary is
+enabled and legacy remains disabled. Synchronization stops new timer starts and waits for an
+already-running oneshot service to finish before replacing artifacts. A failure restores the
+pre-sync timer state before finalize; after finalize it must preserve boundary enabled and
+legacy disabled. A deploy or rollback fails if target-tag resolution, bounded service drain,
+artifact installation, self-test, or owner-state verification fails.
+
 ## Scope
 
 ### Included
@@ -421,7 +432,10 @@ a mode-0600 temporary file, `fsync`, and rename. It contains a schema version, r
 trigger, timestamps, active container/image, runner UID/GID, normal result, optional
 compensation result, child and runner exit codes, and redacted error codes. The runner
 writes it even when image/mount/scratch preflight fails before the Go process can update
-the database. A host receipt may prove an attempted failure; it never proves a commit.
+the database. When normal succeeds but compensation fails, the child emits a structured
+failure receipt and the host receipt preserves both the committed normal result and the
+failed compensation result; the overall run remains nonzero. A host receipt may prove an
+attempted failure; it never proves a commit without matching heartbeat and control facts.
 
 The boundary host runner independently writes `/var/lib/tokenkey/qa-boundary-last-run.json`
 with the same atomic mode-0600 temporary-file, `fsync`, rename, and parent-directory `fsync`

--- a/ops/qa/deploy_rollout.yaml
+++ b/ops/qa/deploy_rollout.yaml
@@ -18,6 +18,10 @@ prod:
     observed_live_state: pending_live_reconciliation
     closeout_deploy_state: enabled
     policy_target_state: enabled
+    host_artifact_sync_on_prod_deploy: required
+    host_artifact_source: target_release_tag
+    sync_active_service_policy: bounded_drain_then_replace
+    sync_failure_restore_policy: pre_sync_timer_state
     min_consecutive_scheduled_runs: 2
     host_runner: /usr/local/bin/tokenkey-qa-maintenance.sh
     health_evaluator: ops/qa/qa_phase2_health.py
@@ -38,6 +42,11 @@ prod:
     repository_closeout_state: implementation_ready_pending_live_verification
     observed_live_state: pending_live_reconciliation
     policy_target_state: enabled_after_finalize
+    host_artifact_sync_on_prod_deploy: required
+    host_artifact_source: target_release_tag
+    sync_active_service_policy: bounded_drain_then_replace
+    sync_failure_restore_policy: pre_finalize_snapshot_or_finalized_boundary
+    deploy_owner_restore_mode: durable_finalize_receipt
     schedule_utc: "*:00"
     randomized_delay_minutes: 0
     host_runner: /usr/local/bin/tokenkey-qa-boundary.sh

--- a/ops/qa/qa_phase2_health.py
+++ b/ops/qa/qa_phase2_health.py
@@ -389,6 +389,31 @@ def _terminal_inventory(archive: dict[str, Any]) -> list[dict[str, Any]]:
     return [item for item in terminal if isinstance(item, dict)]
 
 
+def _is_correlatable_terminal_catchup_attempt(
+    receipt: dict[str, Any] | None,
+    heartbeat: dict[str, str],
+) -> bool:
+    if receipt is None:
+        return False
+    normal = _mapping(receipt.get("normal"))
+    compensation = _mapping(receipt.get("compensation"))
+    return bool(
+        receipt.get("failure_stage") == "compensation_terminal"
+        and receipt.get("failure_code") == TERMINAL_CATCHUP_ERROR
+        and receipt.get("error_code") == "child_failed"
+        and receipt.get("runner_exit_code") != 0
+        and receipt.get("child_exit_code") != 0
+        and normal is not None
+        and normal.get("state") == "committed"
+        and normal.get("restore_verified") is True
+        and compensation is not None
+        and _is_terminal_compensation(compensation)
+        and heartbeat.get("status") == "failed"
+        and heartbeat.get("stage") == "compensation_terminal"
+        and heartbeat.get("error_code") == TERMINAL_CATCHUP_ERROR
+    )
+
+
 def _evaluate_terminal_compensation(
     reasons: list[str],
     compensation: dict[str, Any],
@@ -535,6 +560,8 @@ def evaluate(
     database = _mapping(snapshot.get("database_heartbeat"))
     archive = _mapping(snapshot.get("archive_control"))
     qa_records = _mapping(snapshot.get("qa_records"))
+    heartbeat = _last_result(database.get("last_result")) if database is not None else {}
+    terminal_catchup_attempt = _is_correlatable_terminal_catchup_attempt(receipt, heartbeat)
     if systemd is None:
         forward_reasons.append("systemd_missing")
     else:
@@ -542,7 +569,7 @@ def evaluate(
             forward_reasons.append("timer_not_enabled")
         if systemd.get("timer_active") is not True:
             forward_reasons.append("timer_not_active")
-        if systemd.get("service_result") != "success":
+        if systemd.get("service_result") != "success" and not terminal_catchup_attempt:
             forward_reasons.append("systemd_service_failed")
             failed = True
     if receipt is None:
@@ -577,22 +604,21 @@ def evaluate(
             forward_reasons.append("host_receipt_stale")
         elif started is not None and started > finished:
             forward_reasons.append("host_receipt_time_order_invalid")
-        if receipt.get("runner_exit_code") != 0:
+        if receipt.get("runner_exit_code") != 0 and not terminal_catchup_attempt:
             forward_reasons.append("host_runner_failed")
             failed = True
-        if receipt.get("child_exit_code") != 0:
+        if receipt.get("child_exit_code") != 0 and not terminal_catchup_attempt:
             forward_reasons.append("maintenance_child_failed")
             failed = True
-        if receipt.get("error_code") not in {None, ""}:
+        if receipt.get("error_code") not in {None, ""} and not terminal_catchup_attempt:
             forward_reasons.append("host_receipt_success_has_error")
             failed = True
     else:
         started = None
         finished = None
 
-    heartbeat = _last_result(database.get("last_result")) if database is not None else {}
     if database is not None:
-        if heartbeat.get("status") != "committed":
+        if heartbeat.get("status") != "committed" and not terminal_catchup_attempt:
             forward_reasons.append("database_heartbeat_not_committed")
             failed = True
         if heartbeat.get("deletion_authorized") != "false":
@@ -612,11 +638,19 @@ def evaluate(
         heartbeat_success = _timestamp(database.get("last_success_at"))
         if heartbeat_success is None:
             forward_reasons.append("database_last_success_invalid")
-        elif finished is not None and abs(finished - heartbeat_success) > MAX_CORRELATION_SKEW:
+        elif (
+            finished is not None
+            and not terminal_catchup_attempt
+            and abs(finished - heartbeat_success) > MAX_CORRELATION_SKEW
+        ):
             forward_reasons.append("receipt_heartbeat_time_mismatch")
             failed = True
         last_error = _timestamp(database.get("last_error_at"))
-        if last_error is not None and (heartbeat_success is None or last_error > heartbeat_success):
+        if terminal_catchup_attempt:
+            if last_error is None or finished is None or abs(finished - last_error) > MAX_CORRELATION_SKEW:
+                forward_reasons.append("terminal_catchup_failure_time_mismatch")
+                failed = True
+        elif last_error is not None and (heartbeat_success is None or last_error > heartbeat_success):
             forward_reasons.append("database_has_newer_failure")
             failed = True
 

--- a/ops/qa/test_qa_maintenance_phase2_runtime.py
+++ b/ops/qa/test_qa_maintenance_phase2_runtime.py
@@ -76,6 +76,9 @@ if [ "${1:-}" = run ]; then
     exit 0
 	  fi
 	  if [[ "$*" == *'/app/sub2api'* ]]; then
+	    if [ -n "${TEST_CHILD_STDERR:-}" ]; then
+	      printf '%s\n' "$TEST_CHILD_STDERR" >&2
+	    fi
 	    if [ -n "${TEST_CHILD_JSON:-}" ]; then
 	      run_id=""
 	      trigger=""
@@ -266,6 +269,89 @@ esac
                 self.assertEqual(payload["runner_exit_code"], proc.returncode)
                 self.assertIs(payload["deletion_authorized"], False)
                 self.assertEqual(stat.S_IMODE(receipt.stat().st_mode), 0o600)
+
+    def test_runner_returns_child_stderr_when_archive_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env, receipt, _, _, _ = self._sandbox(Path(temp_dir), child_rc=23)
+            env["TEST_CHILD_STDERR"] = "normal reconcile: source unavailable after retention"
+
+            proc = subprocess.run(
+                ["bash", str(RUNNER), "--trigger=operator"],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 23, (proc.stdout, proc.stderr))
+            self.assertIn("normal reconcile: source unavailable after retention", proc.stderr)
+            payload = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertEqual(payload["error_code"], "child_failed")
+            self.assertNotIn("source unavailable", receipt.read_text(encoding="utf-8"))
+
+    def test_runner_preserves_structured_child_facts_when_compensation_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env, receipt, _, _, _ = self._sandbox(Path(temp_dir), child_rc=1)
+            child = json.loads(env["TEST_CHILD_JSON"])
+            child.update(
+                ok=False,
+                failure_stage="compensation_terminal",
+                failure_code="source_unavailable_after_retention",
+            )
+            child["compensation"].update(
+                state="failed",
+                commit_etag="",
+                restore_verified=False,
+                verification_error_code="source_unavailable_after_retention",
+            )
+            env["TEST_CHILD_JSON"] = json.dumps(child, separators=(",", ":"))
+
+            proc = subprocess.run(
+                ["bash", str(RUNNER), "--trigger=timer"],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 1, (proc.stdout, proc.stderr))
+            payload = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertEqual(payload["normal"]["commit_etag"], "normal-etag")
+            self.assertEqual(
+                payload["compensation"]["verification_error_code"],
+                "source_unavailable_after_retention",
+            )
+            self.assertEqual(payload["failure_stage"], "compensation_terminal")
+            self.assertEqual(payload["failure_code"], "source_unavailable_after_retention")
+            self.assertEqual(payload["child_exit_code"], 1)
+            self.assertEqual(payload["runner_exit_code"], 1)
+
+    def test_runner_rejects_uncorrelated_failure_json_as_host_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env, receipt, _, _, _ = self._sandbox(Path(temp_dir), child_rc=1)
+            child = json.loads(env["TEST_CHILD_JSON"])
+            child.update(
+                ok=False,
+                run_id="different-run",
+                failure_stage="compensation_terminal",
+                failure_code="source_unavailable_after_retention",
+            )
+            env["TEST_CHILD_JSON"] = json.dumps(child, separators=(",", ":"))
+
+            proc = subprocess.run(
+                ["bash", str(RUNNER), "--trigger=timer"],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 1, (proc.stdout, proc.stderr))
+            payload = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertIsNone(payload["normal"])
+            self.assertIsNone(payload["compensation"])
+            self.assertIsNone(payload["failure_stage"])
+            self.assertIsNone(payload["failure_code"])
 
     def test_us045_runner_rejects_zero_exit_without_correlated_child_receipt(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -871,6 +957,67 @@ class QAPhase2OperatorAndHealthTest(unittest.TestCase):
                 self.assertIs(verdict["healthy"], False, verdict)
                 self.assertEqual(verdict["status"], "failed", verdict)
                 self.assertTrue(verdict["reasons"], verdict)
+
+    def test_terminal_compensation_failure_keeps_forward_health_and_degrades_catchup(self) -> None:
+        health = _load_module("qa_phase2_health_terminal_run", "ops/qa/qa_phase2_health.py")
+        snapshot, now = self._healthy_snapshot()
+        terminal_window = "2026-08-07T22:00:00Z"
+        snapshot["systemd"]["service_result"] = "exit-code"
+        snapshot["host_receipt"].update(
+            child_exit_code=1,
+            runner_exit_code=1,
+            error_code="child_failed",
+            failure_stage="compensation_terminal",
+            failure_code="source_unavailable_after_retention",
+            compensation={
+                "window_start": terminal_window,
+                "state": "failed",
+                "commit_etag": "",
+                "restore_verified": False,
+                "verification_error_code": "source_unavailable_after_retention",
+                "cleanup_eligible": False,
+            },
+        )
+        snapshot["database_heartbeat"].update(
+            last_success_at="2026-08-08T22:16:03Z",
+            last_error_at="2026-08-08T22:16:03Z",
+            last_result=(
+                "status=failed run_id=run-045 trigger=timer "
+                "stage=compensation_terminal error_code=source_unavailable_after_retention "
+                "normal_window=2026-08-08T20:00:00Z normal_state=committed "
+                "normal_commit_etag=etag-045 normal_restore_verified=true "
+                f"compensation_window={terminal_window} compensation_state=failed "
+                "compensation_error_code=source_unavailable_after_retention "
+                "deletion_authorized=false"
+            ),
+        )
+        snapshot["archive_control"].update(
+            compensation={
+                "window_start": terminal_window,
+                "state": "failed",
+                "commit_etag": None,
+                "restore_verified": False,
+                "verification_error_code": "source_unavailable_after_retention",
+                "cleanup_eligible": False,
+            },
+            terminal_failures_after_cutover=[
+                {
+                    "window_start": terminal_window,
+                    "verification_error_code": "source_unavailable_after_retention",
+                }
+            ],
+        )
+
+        verdict = health.evaluate(snapshot, now=now, catchup_gap_policy="accepted_terminal")
+
+        self.assertEqual(verdict["status"], "degraded", verdict)
+        self.assertEqual(verdict["forward_reasons"], [], verdict)
+        self.assertEqual(verdict["catchup_reasons"], ["catchup_terminal_gaps_present"], verdict)
+
+        snapshot["host_receipt"]["failure_code"] = "archive_failed"
+        failed = health.evaluate(snapshot, now=now, catchup_gap_policy="accepted_terminal")
+        self.assertEqual(failed["status"], "failed", failed)
+        self.assertTrue(failed["forward_reasons"], failed)
 
     def test_us045_boundary_health_requires_matching_three_source_success(self) -> None:
         health = _load_module("qa_phase2_health_boundary", "ops/qa/qa_phase2_health.py")

--- a/ops/qa/test_qa_phase_ops.py
+++ b/ops/qa/test_qa_phase_ops.py
@@ -7,6 +7,7 @@ import base64
 import gzip
 import importlib.util
 import json
+import os
 import re
 import shlex
 import subprocess
@@ -550,6 +551,52 @@ delete_rows_before 2026-08-06T12:00:00.000000Z
             iam_contract._aws_json = original
         self.assertEqual(failures, [])
 
+    def test_verify_raw_archive_iam_contract_accepts_live_gateway_endpoint_shape(self) -> None:
+        iam_contract = _load_module(
+            "verify_raw_archive_iam_contract", "ops/qa/verify_raw_archive_iam_contract.py"
+        )
+
+        def fake_aws_json(args: list[str]) -> dict:
+            if "describe-vpc-endpoints" in args:
+                return {
+                    "VpcEndpoints": [
+                        {
+                            "VpcId": "vpc-abc",
+                            "State": "available",
+                            "VpcEndpointType": "Gateway",
+                            "ServiceName": "com.amazonaws.us-east-1.s3",
+                            "PrefixListId": None,
+                            "RouteTableIds": ["rtb-public"],
+                        }
+                    ]
+                }
+            if "describe-route-tables" in args:
+                return {
+                    "RouteTables": [
+                        {
+                            "Routes": [
+                                {
+                                    "GatewayId": "vpce-qa",
+                                    "DestinationPrefixListId": "pl-s3",
+                                }
+                            ]
+                        }
+                    ]
+                }
+            raise AssertionError(f"unexpected aws call: {args}")
+
+        original = iam_contract._aws_json
+        iam_contract._aws_json = fake_aws_json
+        try:
+            failures = iam_contract._verify_s3_gateway_endpoint(
+                vpc_id="vpc-abc",
+                route_table_ids=["rtb-public"],
+                endpoint_id="vpce-qa",
+            )
+        finally:
+            iam_contract._aws_json = original
+        self.assertEqual(failures, [])
+
     def test_verify_raw_archive_iam_contract_rejects_non_gateway_endpoint(self) -> None:
         iam_contract = _load_module(
             "verify_raw_archive_iam_contract", "ops/qa/verify_raw_archive_iam_contract.py"
@@ -719,6 +766,24 @@ exit 0
             "! sudo systemctl is-active --quiet tokenkey-qa-maintenance.service",
             commands,
         )
+        restore = next(command for command in commands if "qa_sync_restore" in command)
+        self.assertIn("trap qa_sync_restore EXIT", restore)
+        self.assertIn("qa_timer_enabled", restore)
+        self.assertIn("qa_timer_active", restore)
+        drain = next(
+            command
+            for command in commands
+            if "timeout draining tokenkey-qa-maintenance.service" in command
+        )
+        self.assertIn(
+            "while sudo systemctl is-active --quiet tokenkey-qa-maintenance.service",
+            drain,
+        )
+        self.assertLess(commands.index(restore), commands.index(quiesce_timer))
+        self.assertGreater(
+            commands.index("qa_sync_committed=1"),
+            commands.index("sudo systemctl disable --now tokenkey-qa-maintenance.timer"),
+        )
         resolver_install = next(
             command
             for command in commands
@@ -747,6 +812,9 @@ exit 0
         self.assertFalse(
             any("/var/lib/tokenkey/data/qa_archive_tmp" in command for command in commands)
         )
+        for command in commands:
+            parsed = subprocess.run(["bash", "-n"], input=command, text=True, capture_output=True)
+            self.assertEqual(parsed.returncode, 0, (command, parsed.stderr))
 
     def test_qa_maintenance_sync_explicit_enable_starts_and_verifies_timer(self) -> None:
         script = ROOT / "ops/stage0/sync-qa-maintenance-timer-via-ssm.sh"
@@ -791,6 +859,85 @@ exit 0
             'test "$(sudo systemctl is-active tokenkey-qa-maintenance.timer)" = "active"',
             payload["commands"],
         )
+
+    def test_qa_boundary_sync_auto_derives_owner_from_finalize_receipt(self) -> None:
+        script = ROOT / "ops/stage0/sync-qa-boundary-timer-via-ssm.sh"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            fake_bin = root / "bin"
+            output = root / "output"
+            fake_bin.mkdir()
+            fake_aws = fake_bin / "aws"
+            fake_aws.write_text(
+                """#!/usr/bin/env bash
+case " $* " in
+  *" ssm send-command "*) printf '%s\n' command-auto ;;
+  *" --query Status "*) printf '%s\n' Success ;;
+  *" --query ResponseCode "*) printf '%s\n' 0 ;;
+  *) printf '\n' ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_aws.chmod(0o755)
+            proc = subprocess.run(
+                ["bash", str(script), "i-0123456789abcdef0"],
+                env={
+                    **os.environ,
+                    "PATH": f"{fake_bin}:/opt/homebrew/bin:/usr/bin:/bin",
+                    "QA_BOUNDARY_TIMER_STATE": "auto",
+                    "STAGE0_SSM_OUTPUT_DIR": str(output),
+                },
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, (proc.stdout, proc.stderr))
+            payload = json.loads((output / "ssm-params.json").read_text(encoding="utf-8"))
+
+        owner = next(
+            command
+            for command in payload["commands"]
+            if "invalid QA lifecycle receipt counts" in command
+        )
+        self.assertIn("qa_lifecycle_receipts", owner)
+        self.assertIn("f.phase=concat", owner)
+        self.assertIn('case "${counts}" in 0:0)', owner)
+        self.assertIn("1:0)", owner)
+        self.assertIn("1:1)", owner)
+        self.assertNotIn("systemctl enable --now tokenkey-qa-stale-cleanup.timer", owner)
+        self.assertIn("systemctl is-enabled tokenkey-qa-stale-cleanup.timer", owner)
+        self.assertIn("systemctl disable --now tokenkey-qa-stale-cleanup.timer", owner)
+        self.assertIn("systemctl enable --now tokenkey-qa-boundary.timer", owner)
+        commands = payload["commands"]
+        restore = next(command for command in commands if "qa_sync_restore" in command)
+        self.assertIn("trap qa_sync_restore EXIT", restore)
+        for state in (
+            "qa_boundary_enabled",
+            "qa_boundary_active",
+            "qa_legacy_enabled",
+            "qa_legacy_active",
+            "qa_finalized",
+        ):
+            self.assertIn(state, restore)
+        finalized_restore = restore[restore.index('if [ "${qa_finalized}" = 1 ]'):]
+        self.assertIn("enable tokenkey-qa-boundary.timer", finalized_restore)
+        self.assertIn("start tokenkey-qa-boundary.timer", finalized_restore)
+        self.assertIn("disable tokenkey-qa-stale-cleanup.timer", finalized_restore)
+        self.assertIn("stop tokenkey-qa-stale-cleanup.timer", finalized_restore)
+        drain = next(
+            command
+            for command in commands
+            if "timeout draining tokenkey-qa-boundary.service" in command
+        )
+        self.assertIn(
+            "while sudo systemctl is-active --quiet tokenkey-qa-boundary.service",
+            drain,
+        )
+        self.assertGreater(commands.index("qa_sync_committed=1"), commands.index(owner))
+        for command in commands:
+            parsed = subprocess.run(["bash", "-n"], input=command, text=True, capture_output=True)
+            self.assertEqual(parsed.returncode, 0, (command, parsed.stderr))
 
     def test_raw_archive_cfn_keeps_app_and_recovery_permissions_separate(self) -> None:
         body = (ROOT / "deploy/aws/cloudformation/stage0-qa-raw-archive.yaml").read_text(

--- a/ops/qa/verify_raw_archive_iam_contract.py
+++ b/ops/qa/verify_raw_archive_iam_contract.py
@@ -273,11 +273,14 @@ def _verify_s3_gateway_endpoint(
         for route in routes:
             if not isinstance(route, dict):
                 continue
-            if (
-                route.get("GatewayId") == endpoint_id
-                and isinstance(prefix_list_id, str)
-                and route.get("DestinationPrefixListId") == prefix_list_id
-            ):
+            destination_prefix_list_id = route.get("DestinationPrefixListId")
+            prefix_matches = (
+                destination_prefix_list_id == prefix_list_id
+                if isinstance(prefix_list_id, str) and prefix_list_id
+                else isinstance(destination_prefix_list_id, str)
+                and bool(destination_prefix_list_id)
+            )
+            if route.get("GatewayId") == endpoint_id and prefix_matches:
                 has_gateway_route = True
                 break
         if not has_gateway_route:

--- a/ops/stage0/sync-qa-boundary-timer-via-ssm.sh
+++ b/ops/stage0/sync-qa-boundary-timer-via-ssm.sh
@@ -5,11 +5,14 @@ set -euo pipefail
 INSTANCE_ID="${1:-${INSTANCE_ID:-}}"
 COMMENT="${2:-${SSM_COMMENT:-ops-qa-boundary-timer-sync}}"
 TIMEOUT_SECONDS="${STAGE0_SSM_TIMEOUT_SECONDS:-300}"
+DRAIN_TIMEOUT_SECONDS="${QA_SYNC_DRAIN_TIMEOUT_SECONDS:-300}"
 OUTPUT_DIR="${STAGE0_SSM_OUTPUT_DIR:-.}"
 TIMER_STATE="${QA_BOUNDARY_TIMER_STATE:-disabled}"
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
 
+# QA_BOUNDARY_TIMER_STATE: disabled | enabled | auto
 [[ "${INSTANCE_ID}" =~ ^i-[0-9a-f]{17}$ ]] || { echo "valid instance id required" >&2; exit 1; }
+[[ "${DRAIN_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]] || { echo "QA_SYNC_DRAIN_TIMEOUT_SECONDS must be a positive integer" >&2; exit 1; }
 case "${TIMER_STATE}" in
   disabled)
     owner_command="sudo systemctl disable --now tokenkey-qa-boundary.timer"
@@ -19,16 +22,25 @@ case "${TIMER_STATE}" in
     owner_command="sudo bash -c 'set -euo pipefail; rollback() { local rc=\$?; trap - ERR; systemctl disable --now tokenkey-qa-stale-cleanup.timer || true; systemctl enable --now tokenkey-qa-boundary.timer || true; return \"\${rc}\"; }; trap rollback ERR; finalize_count=\$(docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1 -c \"SELECT count(*) FROM qa_lifecycle_receipts f JOIN qa_lifecycle_receipts a ON a.t0_utc=f.t0_utc AND a.phase=concat(chr(97),chr(99),chr(116),chr(105),chr(118),chr(97),chr(116),chr(101)) WHERE f.phase=concat(chr(102),chr(105),chr(110),chr(97),chr(108),chr(105),chr(122),chr(101))\" | tr -d \"[:space:]\"); test \"\${finalize_count}\" = 1; systemctl disable --now tokenkey-qa-stale-cleanup.timer; systemctl enable --now tokenkey-qa-boundary.timer; test \"\$(systemctl is-enabled tokenkey-qa-boundary.timer)\" = enabled; test \"\$(systemctl is-active tokenkey-qa-boundary.timer)\" = active; test \"\$(systemctl is-enabled tokenkey-qa-stale-cleanup.timer)\" = disabled; test \"\$(systemctl is-active tokenkey-qa-stale-cleanup.timer)\" = inactive; trap - ERR'"
     boundary_active=active
     ;;
+  auto)
+    owner_command="sudo bash -c 'set -euo pipefail; counts=\$(docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -F : -v ON_ERROR_STOP=1 -c \"SELECT (SELECT count(*) FROM qa_lifecycle_receipts WHERE phase=concat(chr(97),chr(99),chr(116),chr(105),chr(118),chr(97),chr(116),chr(101))), (SELECT count(*) FROM qa_lifecycle_receipts f JOIN qa_lifecycle_receipts a ON a.t0_utc=f.t0_utc AND a.phase=concat(chr(97),chr(99),chr(116),chr(105),chr(118),chr(97),chr(116),chr(101)) WHERE f.phase=concat(chr(102),chr(105),chr(110),chr(97),chr(108),chr(105),chr(122),chr(101)))\" | tr -d \"[:space:]\"); case \"\${counts}\" in 0:0) systemctl disable --now tokenkey-qa-boundary.timer; test \"\$(systemctl is-enabled tokenkey-qa-boundary.timer)\" = disabled; test \"\$(systemctl is-active tokenkey-qa-boundary.timer)\" = inactive ;; 1:0) systemctl disable --now tokenkey-qa-boundary.timer; test \"\$(systemctl is-enabled tokenkey-qa-boundary.timer)\" = disabled; test \"\$(systemctl is-active tokenkey-qa-boundary.timer)\" = inactive; test \"\$(systemctl is-enabled tokenkey-qa-stale-cleanup.timer)\" = enabled; test \"\$(systemctl is-active tokenkey-qa-stale-cleanup.timer)\" = active ;; 1:1) systemctl disable --now tokenkey-qa-stale-cleanup.timer; systemctl enable --now tokenkey-qa-boundary.timer; test \"\$(systemctl is-enabled tokenkey-qa-boundary.timer)\" = enabled; test \"\$(systemctl is-active tokenkey-qa-boundary.timer)\" = active; test \"\$(systemctl is-enabled tokenkey-qa-stale-cleanup.timer)\" = disabled; test \"\$(systemctl is-active tokenkey-qa-stale-cleanup.timer)\" = inactive ;; *) echo \"invalid QA lifecycle receipt counts: \${counts}\" >&2; exit 1 ;; esac'"
+    boundary_active=auto
+    ;;
   *)
-    echo "QA_BOUNDARY_TIMER_STATE must be disabled or enabled" >&2
+    echo "QA_BOUNDARY_TIMER_STATE must be disabled, enabled, or auto" >&2
     exit 1
     ;;
 esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BOUNDARY_SRC="${SCRIPT_DIR}/../../deploy/aws/stage0/tokenkey-qa-boundary.sh"
-HELPER_SRC="${SCRIPT_DIR}/../../deploy/aws/stage0/tokenkey-qa-export-orphan.py"
-RESOLVER_SRC="${SCRIPT_DIR}/../lib/resolve-app-container.sh"
+if [ -n "${QA_HOST_ARTIFACT_ROOT:-}" ]; then
+  ARTIFACT_ROOT="$(cd "${QA_HOST_ARTIFACT_ROOT}" && pwd)"
+else
+  ARTIFACT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+fi
+BOUNDARY_SRC="${ARTIFACT_ROOT}/deploy/aws/stage0/tokenkey-qa-boundary.sh"
+HELPER_SRC="${ARTIFACT_ROOT}/deploy/aws/stage0/tokenkey-qa-export-orphan.py"
+RESOLVER_SRC="${ARTIFACT_ROOT}/ops/lib/resolve-app-container.sh"
 for source in "${BOUNDARY_SRC}" "${HELPER_SRC}" "${RESOLVER_SRC}"; do
   [[ -f "${source}" ]] || { echo "missing ${source}" >&2; exit 1; }
 done
@@ -36,6 +48,7 @@ done
 boundary_payload="$(gzip -9n -c "${BOUNDARY_SRC}" | base64 | tr -d '\n')"
 helper_payload="$(gzip -9n -c "${HELPER_SRC}" | base64 | tr -d '\n')"
 resolver_payload="$(gzip -9n -c "${RESOLVER_SRC}" | base64 | tr -d '\n')"
+artifact_sha="${QA_HOST_ARTIFACT_SHA:-${GITHUB_SHA:-local}}"
 mkdir -p "${OUTPUT_DIR}"
 params="${OUTPUT_DIR}/ssm-params.json"
 stdout="${OUTPUT_DIR}/stdout.txt"
@@ -47,7 +60,9 @@ jq -n \
   --arg resolver "${resolver_payload}" \
   --arg owner_command "${owner_command}" \
   --arg timer_state "${TIMER_STATE}" \
-  --arg boundary_active "${boundary_active}" '
+  --arg boundary_active "${boundary_active}" \
+  --arg artifact_sha "${artifact_sha}" \
+  --argjson drain_timeout "${DRAIN_TIMEOUT_SECONDS}" '
   def atomic_install($artifact; $destination; $mode):
     "sudo bash -c " + (
       (
@@ -61,7 +76,9 @@ jq -n \
     );
   {commands:[
     "set -euo pipefail",
+    "qa_finalized=$(docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1 -c \"SELECT count(*) FROM qa_lifecycle_receipts f JOIN qa_lifecycle_receipts a ON a.t0_utc=f.t0_utc AND a.phase=concat(chr(97),chr(99),chr(116),chr(105),chr(118),chr(97),chr(116),chr(101)) WHERE f.phase=concat(chr(102),chr(105),chr(110),chr(97),chr(108),chr(105),chr(122),chr(101))\" | tr -d \"[:space:]\"); case \"${qa_finalized}\" in 0|1) ;; *) echo \"invalid finalized receipt count: ${qa_finalized}\" >&2; exit 1 ;; esac; if sudo systemctl is-enabled --quiet tokenkey-qa-boundary.timer; then qa_boundary_enabled=1; else qa_boundary_enabled=0; fi; if sudo systemctl is-active --quiet tokenkey-qa-boundary.timer; then qa_boundary_active=1; else qa_boundary_active=0; fi; if sudo systemctl is-enabled --quiet tokenkey-qa-stale-cleanup.timer; then qa_legacy_enabled=1; else qa_legacy_enabled=0; fi; if sudo systemctl is-active --quiet tokenkey-qa-stale-cleanup.timer; then qa_legacy_active=1; else qa_legacy_active=0; fi; qa_sync_committed=0; qa_sync_restore() { qa_sync_rc=$?; trap - EXIT; if [ \"${qa_sync_committed}\" != 1 ]; then if [ \"${qa_finalized}\" = 1 ]; then sudo systemctl enable tokenkey-qa-boundary.timer >/dev/null 2>&1 || true; sudo systemctl start tokenkey-qa-boundary.timer >/dev/null 2>&1 || true; sudo systemctl disable tokenkey-qa-stale-cleanup.timer >/dev/null 2>&1 || true; sudo systemctl stop tokenkey-qa-stale-cleanup.timer >/dev/null 2>&1 || true; else if [ \"${qa_boundary_enabled}\" = 1 ]; then sudo systemctl enable tokenkey-qa-boundary.timer >/dev/null 2>&1 || true; else sudo systemctl disable tokenkey-qa-boundary.timer >/dev/null 2>&1 || true; fi; if [ \"${qa_boundary_active}\" = 1 ]; then sudo systemctl start tokenkey-qa-boundary.timer >/dev/null 2>&1 || true; else sudo systemctl stop tokenkey-qa-boundary.timer >/dev/null 2>&1 || true; fi; if [ \"${qa_legacy_enabled}\" = 1 ]; then sudo systemctl enable tokenkey-qa-stale-cleanup.timer >/dev/null 2>&1 || true; else sudo systemctl disable tokenkey-qa-stale-cleanup.timer >/dev/null 2>&1 || true; fi; if [ \"${qa_legacy_active}\" = 1 ]; then sudo systemctl start tokenkey-qa-stale-cleanup.timer >/dev/null 2>&1 || true; else sudo systemctl stop tokenkey-qa-stale-cleanup.timer >/dev/null 2>&1 || true; fi; fi; fi; exit \"${qa_sync_rc}\"; }; trap qa_sync_restore EXIT",
     "if sudo systemctl list-unit-files tokenkey-qa-boundary.timer --no-legend 2>/dev/null | grep -q \"^tokenkey-qa-boundary[.]timer\"; then sudo systemctl disable --now tokenkey-qa-boundary.timer; fi",
+    ("qa_sync_deadline=$(( $(date +%s) + " + ($drain_timeout | tostring) + " )); while sudo systemctl is-active --quiet tokenkey-qa-boundary.service; do if [ \"$(date +%s)\" -ge \"${qa_sync_deadline}\" ]; then echo \"timeout draining tokenkey-qa-boundary.service\" >&2; exit 1; fi; sleep 2; done"),
     "! sudo systemctl is-active --quiet tokenkey-qa-boundary.service",
     atomic_install($resolver; "/usr/local/lib/tokenkey/resolve-app-container.sh"; "0644"),
     atomic_install($helper; "/usr/local/lib/tokenkey/qa-export-orphan.py"; "0755"),
@@ -72,8 +89,15 @@ jq -n \
     "sudo /usr/local/bin/tokenkey-qa-boundary.sh --install-units",
     "sudo systemctl daemon-reload",
     $owner_command,
-    ("test \"$(sudo systemctl is-enabled tokenkey-qa-boundary.timer)\" = \"" + $timer_state + "\""),
-    ("test \"$(sudo systemctl is-active tokenkey-qa-boundary.timer)\" = \"" + $boundary_active + "\"")
+    (if $timer_state == "auto" then empty else
+      "test \"$(sudo systemctl is-enabled tokenkey-qa-boundary.timer)\" = \"" + $timer_state + "\""
+    end),
+    (if $timer_state == "auto" then empty else
+      "test \"$(sudo systemctl is-active tokenkey-qa-boundary.timer)\" = \"" + $boundary_active + "\""
+    end),
+    "qa_sync_committed=1",
+    "trap - EXIT",
+    ("echo Live qa-boundary units now match deploy/aws@" + $artifact_sha + " timer=" + $timer_state + " on $(hostname)")
   ]}' >"${params}"
 
 command_id="$(aws --region "${REGION}" ssm send-command \

--- a/ops/stage0/sync-qa-maintenance-timer-via-ssm.sh
+++ b/ops/stage0/sync-qa-maintenance-timer-via-ssm.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 INSTANCE_ID="${1:-${INSTANCE_ID:-}}"
 COMMENT="${2:-${SSM_COMMENT:-ops-qa-maintenance-timer-sync}}"
 TIMEOUT_SECONDS="${STAGE0_SSM_TIMEOUT_SECONDS:-300}"
+DRAIN_TIMEOUT_SECONDS="${QA_SYNC_DRAIN_TIMEOUT_SECONDS:-300}"
 OUTPUT_DIR="${STAGE0_SSM_OUTPUT_DIR:-.}"
 TIMER_STATE="${QA_MAINTENANCE_TIMER_STATE:-disabled}"
 
@@ -19,6 +20,10 @@ if [ -z "${INSTANCE_ID}" ]; then
   echo "sync_qa_maintenance_timer_via_ssm: instance id is required" >&2
   exit 1
 fi
+[[ "${DRAIN_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]] || {
+  echo "QA_SYNC_DRAIN_TIMEOUT_SECONDS must be a positive integer" >&2
+  exit 1
+}
 case "${TIMER_STATE}" in
   disabled)
     timer_command="sudo systemctl disable --now tokenkey-qa-maintenance.timer"
@@ -43,14 +48,19 @@ stdout_file="${OUTPUT_DIR}/stdout.txt"
 stderr_file="${OUTPUT_DIR}/stderr.txt"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MAINT_SRC="${SCRIPT_DIR}/../../deploy/aws/stage0/tokenkey-qa-maintenance.sh"
-RESOLVER_SRC="${SCRIPT_DIR}/../lib/resolve-app-container.sh"
+if [ -n "${QA_HOST_ARTIFACT_ROOT:-}" ]; then
+  ARTIFACT_ROOT="$(cd "${QA_HOST_ARTIFACT_ROOT}" && pwd)"
+else
+  ARTIFACT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+fi
+MAINT_SRC="${ARTIFACT_ROOT}/deploy/aws/stage0/tokenkey-qa-maintenance.sh"
+RESOLVER_SRC="${ARTIFACT_ROOT}/ops/lib/resolve-app-container.sh"
 [[ -f "${MAINT_SRC}" ]] || { echo "missing ${MAINT_SRC}" >&2; exit 1; }
 [[ -f "${RESOLVER_SRC}" ]] || { echo "missing ${RESOLVER_SRC}" >&2; exit 1; }
 
 MAINT_SH_B64="$(base64 <"${MAINT_SRC}" | tr -d '\n')"
 RESOLVER_SH_B64="$(base64 <"${RESOLVER_SRC}" | tr -d '\n')"
-TEMPLATE_SHA="${GITHUB_SHA:-local}"
+TEMPLATE_SHA="${QA_HOST_ARTIFACT_SHA:-${GITHUB_SHA:-local}}"
 
 jq -n \
   --arg maint "${MAINT_SH_B64}" \
@@ -59,12 +69,15 @@ jq -n \
   --arg timer_command "${timer_command}" \
   --arg timer_state "${TIMER_STATE}" \
   --arg timer_active_state "${timer_active_state}" \
+  --argjson drain_timeout "${DRAIN_TIMEOUT_SECONDS}" \
   '{
     commands: [
       "set -euo pipefail",
       "echo === qa-maintenance timer sync ===",
+      "if sudo systemctl is-enabled --quiet tokenkey-qa-maintenance.timer; then qa_timer_enabled=1; else qa_timer_enabled=0; fi; if sudo systemctl is-active --quiet tokenkey-qa-maintenance.timer; then qa_timer_active=1; else qa_timer_active=0; fi; qa_sync_committed=0; qa_sync_restore() { qa_sync_rc=$?; trap - EXIT; if [ \"${qa_sync_committed}\" != 1 ]; then if [ \"${qa_timer_enabled}\" = 1 ]; then sudo systemctl enable tokenkey-qa-maintenance.timer >/dev/null 2>&1 || true; else sudo systemctl disable tokenkey-qa-maintenance.timer >/dev/null 2>&1 || true; fi; if [ \"${qa_timer_active}\" = 1 ]; then sudo systemctl start tokenkey-qa-maintenance.timer >/dev/null 2>&1 || true; else sudo systemctl stop tokenkey-qa-maintenance.timer >/dev/null 2>&1 || true; fi; fi; exit \"${qa_sync_rc}\"; }; trap qa_sync_restore EXIT",
       "if sudo systemctl list-unit-files tokenkey-qa-maintenance.timer --no-legend 2>/dev/null | grep -q \"^tokenkey-qa-maintenance[.]timer\"; then sudo systemctl disable --now tokenkey-qa-maintenance.timer; fi",
       "! sudo systemctl is-active --quiet tokenkey-qa-maintenance.timer",
+      ("qa_sync_deadline=$(( $(date +%s) + " + ($drain_timeout | tostring) + " )); while sudo systemctl is-active --quiet tokenkey-qa-maintenance.service; do if [ \"$(date +%s)\" -ge \"${qa_sync_deadline}\" ]; then echo \"timeout draining tokenkey-qa-maintenance.service\" >&2; exit 1; fi; sleep 2; done"),
       "! sudo systemctl is-active --quiet tokenkey-qa-maintenance.service",
       ("echo " + $maint + " | base64 -d | sudo tee /usr/local/bin/tokenkey-qa-maintenance.sh > /dev/null"),
       "sudo chmod +x /usr/local/bin/tokenkey-qa-maintenance.sh",
@@ -78,6 +91,8 @@ jq -n \
       $timer_command,
       ("test \"$(sudo systemctl is-enabled tokenkey-qa-maintenance.timer)\" = \"" + $timer_state + "\""),
       ("test \"$(sudo systemctl is-active tokenkey-qa-maintenance.timer)\" = \"" + $timer_active_state + "\""),
+      "qa_sync_committed=1",
+      "trap - EXIT",
       "sudo systemctl list-timers tokenkey-qa-maintenance.timer --no-pager || true",
       ("echo Live qa-maintenance units now match deploy/aws@" + $sha + " timer=" + $timer_state + " on $(hostname)")
     ]

--- a/ops/stage0/test_deploy_stage0_workflow.py
+++ b/ops/stage0/test_deploy_stage0_workflow.py
@@ -47,10 +47,33 @@ class DeployStage0WorkflowTest(unittest.TestCase):
         self.assertIn("id-token: write", deploy)
         self.assertIn("packages: read", deploy)
         self.assertIn("deploy_via_ssm_bluegreen.sh", deploy)
+        self.assertIn("QA_MAINTENANCE_TIMER_STATE: enabled", deploy)
+        self.assertIn("sync-qa-maintenance-timer-via-ssm.sh", deploy)
+        self.assertIn("QA_BOUNDARY_TIMER_STATE: auto", deploy)
+        self.assertIn("sync-qa-boundary-timer-via-ssm.sh", deploy)
         self.assertIn("bash ops/stage0/post_deploy_smoke.sh", deploy)
         self.assertIn(
             "bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout",
             deploy,
+        )
+
+    def test_qa_host_artifacts_are_bound_to_target_tag_before_prod_mutation(self) -> None:
+        deploy = job_block("deploy")
+        target_checkout = deploy.index("name: Checkout target-tag QA host artifacts")
+        image_mutation = deploy.index("name: Deploy via SSM Run-Command")
+
+        self.assertLess(target_checkout, image_mutation)
+        target_block = deploy[target_checkout:image_mutation]
+        self.assertIn("ref: v${{ inputs.tag }}", target_block)
+        self.assertIn("path: qa-host-runtime", target_block)
+        self.assertIn("id: qa_host_artifacts", target_block)
+        self.assertIn("git -C qa-host-runtime rev-parse HEAD", target_block)
+        self.assertEqual(deploy.count("QA_HOST_ARTIFACT_ROOT: qa-host-runtime"), 2)
+        self.assertEqual(
+            deploy.count(
+                "QA_HOST_ARTIFACT_SHA: ${{ steps.qa_host_artifacts.outputs.sha }}"
+            ),
+            2,
         )
 
     def test_smoke_only_job_is_read_only_and_uses_prod_environment(self) -> None:

--- a/scripts/checks/qa-lifecycle-ssot.py
+++ b/scripts/checks/qa-lifecycle-ssot.py
@@ -557,6 +557,14 @@ def _rollout_failures(root: Path) -> list[str]:
             failures.append("rollout maintenance timer observed live state drift")
         if prod_timer.get("policy_target_state") != "enabled":
             failures.append("rollout maintenance timer target drift")
+        if prod_timer.get("host_artifact_sync_on_prod_deploy") != "required":
+            failures.append("rollout maintenance host artifact sync drift")
+        if prod_timer.get("host_artifact_source") != "target_release_tag":
+            failures.append("rollout maintenance host artifact source drift")
+        if prod_timer.get("sync_active_service_policy") != "bounded_drain_then_replace":
+            failures.append("rollout maintenance active-service sync policy drift")
+        if prod_timer.get("sync_failure_restore_policy") != "pre_sync_timer_state":
+            failures.append("rollout maintenance sync failure restore drift")
         if prod_timer.get("min_consecutive_scheduled_runs") != 2:
             failures.append("rollout maintenance timer observation gate drift")
         if prod_timer.get("catchup_gap_policy") != "accepted_terminal":
@@ -587,6 +595,11 @@ def _rollout_failures(root: Path) -> list[str]:
             "repository_closeout_state": "implementation_ready_pending_live_verification",
             "observed_live_state": "pending_live_reconciliation",
             "policy_target_state": "enabled_after_finalize",
+            "host_artifact_sync_on_prod_deploy": "required",
+            "host_artifact_source": "target_release_tag",
+            "sync_active_service_policy": "bounded_drain_then_replace",
+            "sync_failure_restore_policy": "pre_finalize_snapshot_or_finalized_boundary",
+            "deploy_owner_restore_mode": "durable_finalize_receipt",
             "schedule_utc": "*:00",
             "randomized_delay_minutes": 0,
             "host_runner": "/usr/local/bin/tokenkey-qa-boundary.sh",


### PR DESCRIPTION
## 摘要

- 将 prod deploy 的 QA host artifacts 绑定到目标 release tag，rollback 不再混用 workflow 当前 checkout 的新 runner。
- maintenance/boundary 同步遇到正在运行的 oneshot 时有界排空；同步失败恢复原 timer 状态，finalize 后强制保持 boundary owner。
- normal 已成功、terminal catchup 失败时输出并保留结构化失败 receipt；严格四源一致时仅将 catchup 标为 degraded，普通失败仍 fail closed。
- 修复 S3 gateway endpoint `PrefixListId=null` 的线上 verifier 假阴性，并将既有 QA 批准文档、rollout 与 sentinel 归口一致。

## 风险

- 变更触及 prod deploy workflow、systemd timer owner 恢复和 QA health 判定；已用失败恢复、receipt 相关性和普通失败反例覆盖。
- 本 PR 不执行 finalize、DROP、owner switch 或历史 gap 决策，线上闭环仍需发版后真实证据。
- sentinel-registry-reviewed：`qa_maintenance.go` 仅扩展既有 QA maintenance receipt，不新增或删除 gateway 注入点，无需新增 gateway sentinel。
- Web impact: none

## 验证

- `./scripts/preflight.sh`
- `go test -tags=unit ./cmd/server -run 'QA(Maintenance|Boundary)|US045' -count=1`
- `go test ./internal/observability/qa/... -count=1`
- QA Python 聚焦套件：107 tests passed
- `python3 scripts/checks/qa-lifecycle-ssot.py --self-test`
- `python3 scripts/checks/qa-lifecycle-ssot.py`
- 生产只读探测：T0 后 DEFAULT rows=0，03:00 normal committed/restore-verified，IAM/network contract applied。

## 提交

- `f49958409 fix(qa): preserve rollback-safe lifecycle evidence`
- 最新提交：f49958409
