### PR TITLE
feat(qa): 闭环历史过期零源 gap 决策

### DIFF
--- a/.testing/user-stories/stories/US-045-qa-phase2-production-integrity.md
+++ b/.testing/user-stories/stories/US-045-qa-phase2-production-integrity.md
@@ -24,6 +24,7 @@
 6. **AC-006（IAM 与 recovery）**：Given app archive role 与 ops recovery role，When渲染 policy 或从 workstation inspect/verify/restore，Then app 只有所需 suffix-scoped artifact 权限且无无界 list/partial read，recovery 不经过 prod 主机/API/数据库，正文恢复要求 privacy confirmation，并如实保留 shared-role 风险。
 7. **AC-007（cutover 排空与 export orphan）**：Given legacy stale cleanup 仅在 no-move cutover 排空期间运行，且 steady-state boundary 处理 export temp crash orphan，When plan/apply，Then只处理 effective mount 内 age/type/open-handle 全部合格且 exact plan-hash 未漂移的文件；durable same-T0 finalize receipt 原子切换 owner 后，legacy cleanup 必须停用，已知历史坏小时与 `qa_export_jobs` 保持不变。
 8. **AC-008（qa_records UTC 小时生命周期）**：Given `qa_records` 已切换为 UTC 小时 RANGE 分区且 archive/boundary 共用 `QAMA` 锁，When `*:00` boundary owner 运行，Then 仅基于 catalog bound 预建 `[current_hour, current_hour+72h)`、DROP `upper_bound <= retention_boundary` 的规范子分区，并在同一事务内完成 terminal gap 分类 + DROP + `source_dropped_at`；hot blob/DLQ 小时目录在 DROP 后幂等清理；稳态禁止 rehome/staging/copy/move 与逐行 QA retention；`archive_failed`、分区缺口、DEFAULT 稳态残留与 hot-file 残留必须 health failed。
+9. **AC-009（过期 gap 批量决策）**：Given 已过 24 小时、源行数为零、无 commit-ready segment、非 committed/terminal 且 recovery role 确认无 `commit.json` 的精确小时，When 生成 batch plan，Then hash 绑定 DB UTC anchor/cutoff/cutover/latest-normal、精确窗口、control window/update/segment fingerprint/commit-ready fact、bucket/role/recovery-run 与 S3 absence；When 使用精确 hash 与 approver apply，Then 在 `QAMA` 同一事务中重验证全部事实、通过 `qa_archive_shards` owner 写入 `failed/source_unavailable_after_retention` 并追加不可变 receipt；任一事实漂移整批拒绝，且不写 S3、不删/搬数据、不切 timer。
 
 ## Assertions
 
@@ -109,6 +110,20 @@
 - `backend/internal/repository/pgpartition_integration_test.go`::`TestPgPartition_EnsureHourlyCoversFutureHorizon`
 - `backend/internal/repository/pgpartition_integration_test.go`::`TestPgPartition_HourlyWriteRoutesToChildPartition`
 - `backend/internal/repository/pgpartition_integration_test.go`::`TestPgPartition_DropExpiredHourlyUsesCatalogUpperBound`
+- `backend/internal/observability/qa/archive/gap_decision_test.go`::`TestUS045_BuildGapDecisionPlanSelectsOnlyExpiredEmptyNonterminalHours`
+- `backend/internal/observability/qa/archive/gap_decision_test.go`::`TestUS045_CompleteGapDecisionPlanFromRecoveryStoreBindsEveryHeadResult`
+- `backend/internal/observability/qa/archive/gap_decision_test.go`::`TestUS045_ApplyGapDecisionRejectsSourceOrControlDriftAtomically`
+- `backend/internal/observability/qa/archive/gap_decision_test.go`::`TestUS045_ApplyGapDecisionRejectsSegmentFingerprintDrift`
+- `backend/internal/observability/qa/archive/gap_decision_test.go`::`TestUS045_ApplyGapDecisionPersistsTerminalRowsAndApprovalReceiptInOneTransaction`
+- `backend/internal/observability/qa/archive/gap_decision_integration_test.go`::`TestUS045_GapDecisionPlanJSONApplyIsAtomicAndIdempotentInPostgreSQL`
+- `backend/internal/observability/qa/archive/control_schema_test.go`::`TestUS045_QAArchiveGapDecisionReceiptsAreAppendOnlyAndNotASecondStateMachine`
+- `backend/cmd/qa-archive/main_test.go`::`TestUS045_GapDecisionS3PlanUsesOnlyWorkstationRecoveryStore`
+- `backend/cmd/qa-archive/main_test.go`::`TestUS045_GapDecisionApplyRequiresHashBoundConfirmationBeforeDependencies`
+- `backend/cmd/qa-archive/main_test.go`::`TestUS045_GapDecisionPlanTransportRejectsOversizedExpansion`
+- `ops/qa/test_prod_qa_archive_closeout.py`::`ProdQAGapDecisionOperatorTest.test_gap_plan_binds_db_recovery_facts_and_writes_secure_atomic_plan`
+- `ops/qa/test_prod_qa_archive_closeout.py`::`ProdQAGapDecisionOperatorTest.test_gap_apply_rejects_wrong_confirmation_before_remote_execution`
+- `ops/qa/test_prod_qa_archive_closeout.py`::`ProdQAGapDecisionOperatorTest.test_gap_db_plan_decodes_bounded_gzip_receipt`
+- `ops/qa/test_prod_qa_archive_closeout.py`::`ProdQAGapDecisionOperatorTest.test_gap_apply_refuses_oversized_ssm_transport_before_remote_call`
 
 运行命令：
 
@@ -119,8 +134,11 @@ go test -tags=unit -count=1 -run 'TestUS045_' ./cmd/server
 go test -tags=integration -count=1 -run 'TestUS045_' ./internal/observability/qa/archive
 go test -tags=unit -count=1 -run 'TestHourly|TestRetention|TestBuildCutover|TestRunBoundary|TestDropExpiredHour|TestApplyCutover|TestValidateHourDir' ./internal/pkg/pgpartition/... ./internal/observability/qa/lifecycle/...
 go test -tags=integration -count=1 -run 'TestQAHourlyCutover|TestPgPartition_EnsureHourly|TestPgPartition_Hourly|TestPgPartition_DropExpiredHourly' ./internal/repository/
+go test -tags=unit -count=1 -run 'TestUS045_.*GapDecision' ./internal/observability/qa/archive ./cmd/qa-archive
+go test -tags=integration -count=1 -run 'TestUS045_.*GapDecision' ./internal/observability/qa/archive
 cd ..
 python3 -m unittest ops.qa.test_qa_boundary_runtime ops.observability.test_probe_qa_phase2_live_health ops.qa.test_prod_phase2_live_health ops.qa.test_qa_maintenance_phase2_runtime ops.qa.test_qa_phase_ops
+python3 -m unittest ops.qa.test_prod_qa_archive_closeout
 python3 -m unittest ops.qa.test_prod_qa_stale_cleanup
 python3 scripts/checks/qa-lifecycle-ssot.py --self-test
 python3 -m unittest deploy.aws.cloudformation.test_stage0_qa_raw_archive_contract ops.qa.test_qa_archive_recovery_gate

--- a/backend/cmd/qa-archive/main.go
+++ b/backend/cmd/qa-archive/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -21,6 +24,9 @@ import (
 const (
 	restoreConfirmationPrefix        = "tokenkey-prod-qa-archive-restore-v1"
 	forwardCutoverConfirmationPrefix = "tokenkey-prod-qa-forward-cutover-v1"
+	gapDecisionConfirmationPrefix    = "tokenkey-prod-qa-gap-decision-v1"
+	maxGapDecisionPlanBytes          = 8 << 20
+	maxGapDecisionTransportChars     = 18000
 )
 
 type controlStatus struct {
@@ -34,26 +40,30 @@ type controlStatus struct {
 }
 
 type cliDeps struct {
-	loadConfig        func() (*config.Config, error)
-	openDB            func(string, string) (*sql.DB, error)
-	newObjectStore    func(context.Context, config.QACaptureStorageConfig) (archive.ObjectStore, error)
-	newRecoveryStore  func(context.Context, archive.WorkstationRecoveryConfig) (archive.ReadOnlyObjectStore, error)
-	verifyCommit      func(context.Context, archive.ReadOnlyObjectStore, string, string) (archive.VerifiedCommit, error)
-	inspectControl    func(context.Context, *sql.Conn, archive.Window) (controlStatus, error)
-	planSourceDelta   func(context.Context, *sql.Conn, archive.Window, archive.VerifiedCommit) (archive.SourceDeltaPlan, error)
-	setForwardCutover func(context.Context, *sql.Conn) (archive.ForwardCutover, error)
+	loadConfig             func() (*config.Config, error)
+	openDB                 func(string, string) (*sql.DB, error)
+	newObjectStore         func(context.Context, config.QACaptureStorageConfig) (archive.ObjectStore, error)
+	newRecoveryStore       func(context.Context, archive.WorkstationRecoveryConfig) (archive.ReadOnlyObjectStore, error)
+	verifyCommit           func(context.Context, archive.ReadOnlyObjectStore, string, string) (archive.VerifiedCommit, error)
+	inspectControl         func(context.Context, *sql.Conn, archive.Window) (controlStatus, error)
+	planSourceDelta        func(context.Context, *sql.Conn, archive.Window, archive.VerifiedCommit) (archive.SourceDeltaPlan, error)
+	setForwardCutover      func(context.Context, *sql.Conn) (archive.ForwardCutover, error)
+	buildGapDecisionDBPlan func(context.Context, *sql.DB) (archive.GapDecisionPlan, error)
+	applyGapDecisionPlan   func(context.Context, *sql.DB, archive.GapDecisionPlan, string) (archive.GapDecisionReceipt, error)
 }
 
 func defaultDeps() cliDeps {
 	return cliDeps{
-		loadConfig:        config.LoadForBootstrap,
-		openDB:            sql.Open,
-		newObjectStore:    archive.NewObjectStoreFromConfig,
-		newRecoveryStore:  archive.NewReadOnlyObjectStoreForWorkstation,
-		verifyCommit:      archive.VerifyCommit,
-		inspectControl:    defaultInspectControl,
-		planSourceDelta:   archive.PlanSourceDelta,
-		setForwardCutover: archive.NewSQLControlStore().SetApprovedForwardCutover,
+		loadConfig:             config.LoadForBootstrap,
+		openDB:                 sql.Open,
+		newObjectStore:         archive.NewObjectStoreFromConfig,
+		newRecoveryStore:       archive.NewReadOnlyObjectStoreForWorkstation,
+		verifyCommit:           archive.VerifyCommit,
+		inspectControl:         defaultInspectControl,
+		planSourceDelta:        archive.PlanSourceDelta,
+		setForwardCutover:      archive.NewSQLControlStore().SetApprovedForwardCutover,
+		buildGapDecisionDBPlan: archive.BuildGapDecisionDBPlan,
+		applyGapDecisionPlan:   archive.ApplyGapDecisionPlan,
 	}
 }
 
@@ -68,16 +78,205 @@ func main() {
 
 func runCLI(ctx context.Context, args []string, out io.Writer, deps cliDeps) error {
 	if len(args) == 0 {
-		return fmt.Errorf("command required: inspect, verify, restore, repair-plan, or set-forward-cutover")
+		return fmt.Errorf("command required: inspect, verify, restore, repair-plan, set-forward-cutover, gap-decision-db-plan, gap-decision-s3-plan, or gap-decision-apply")
 	}
 	switch args[0] {
 	case "inspect", "verify", "restore", "repair-plan":
 		return runWindowCommand(ctx, args[0], args[1:], out, deps)
 	case "set-forward-cutover":
 		return runSetForwardCutover(ctx, args[1:], out, deps)
+	case "gap-decision-db-plan":
+		return runGapDecisionDBPlan(ctx, args[1:], out, deps)
+	case "gap-decision-s3-plan":
+		return runGapDecisionS3Plan(ctx, args[1:], out, deps)
+	case "gap-decision-apply":
+		return runGapDecisionApply(ctx, args[1:], out, deps)
 	default:
 		return fmt.Errorf("unknown command %q", args[0])
 	}
+}
+
+func runGapDecisionS3Plan(ctx context.Context, args []string, out io.Writer, deps cliDeps) error {
+	fs := flag.NewFlagSet("gap-decision-s3-plan", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	dbPlanBase64 := fs.String("db-plan-gzip-base64", "", "gzip+base64 database gap plan")
+	region := fs.String("region", "", "AWS region")
+	bucket := fs.String("bucket", "", "raw archive bucket")
+	recoveryRoleARN := fs.String("recovery-role-arn", "", "dedicated recovery role ARN")
+	recoveryRunID := fs.String("recovery-run-id", "", "operator recovery observation id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments")
+	}
+	var dbPlan archive.GapDecisionPlan
+	if err := decodeGapDecisionPlanTransport(*dbPlanBase64, &dbPlan); err != nil {
+		return fmt.Errorf("decode database gap plan: %w", err)
+	}
+	if strings.TrimSpace(*region) == "" || strings.TrimSpace(*bucket) == "" ||
+		strings.TrimSpace(*recoveryRoleARN) == "" || !validRecoveryRunID(*recoveryRunID) {
+		return fmt.Errorf("gap-decision-s3-plan requires region, bucket, recovery role, and safe recovery run id")
+	}
+	deps = fillDefaults(deps)
+	store, err := deps.newRecoveryStore(ctx, archive.WorkstationRecoveryConfig{
+		Region: strings.TrimSpace(*region), Bucket: strings.TrimSpace(*bucket),
+		Prefix: archive.RawV1Prefix, RoleARN: strings.TrimSpace(*recoveryRoleARN),
+	})
+	if err != nil {
+		return fmt.Errorf("open workstation recovery store: %w", err)
+	}
+	plan, err := archive.CompleteGapDecisionPlanFromStore(
+		ctx, dbPlan, store, *region, *bucket, *recoveryRoleARN, *recoveryRunID,
+	)
+	if err != nil {
+		return err
+	}
+	return writeJSON(out, map[string]any{
+		"ok": true, "command": "gap-decision-s3-plan", "plan": plan,
+		"required_confirmation": gapDecisionConfirmationPrefix + ":" + plan.PlanHash,
+		"cleanup_eligible":      false, "deletion_authorized": false,
+	})
+}
+
+func runGapDecisionDBPlan(ctx context.Context, args []string, out io.Writer, deps cliDeps) error {
+	if len(args) != 0 {
+		return fmt.Errorf("gap-decision-db-plan accepts no arguments")
+	}
+	deps = fillDefaults(deps)
+	cfg, err := deps.loadConfig()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	db, err := deps.openDB("postgres", cfg.Database.DSNWithTimezone(cfg.Timezone))
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("ping database: %w", err)
+	}
+	plan, err := deps.buildGapDecisionDBPlan(ctx, db)
+	if err != nil {
+		return err
+	}
+	transport, rawBytes, err := encodeGapDecisionPlanTransport(plan)
+	if err != nil {
+		return err
+	}
+	return writeJSON(out, map[string]any{
+		"ok": true, "command": "gap-decision-db-plan",
+		"plan_gzip_base64": transport, "plan_uncompressed_bytes": rawBytes,
+		"window_count":     len(plan.Windows),
+		"cleanup_eligible": false, "deletion_authorized": false,
+	})
+}
+
+func runGapDecisionApply(ctx context.Context, args []string, out io.Writer, deps cliDeps) error {
+	fs := flag.NewFlagSet("gap-decision-apply", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	planBase64 := fs.String("plan-gzip-base64", "", "gzip+base64 canonical gap decision plan")
+	confirm := fs.String("confirm", "", "exact plan-hash confirmation")
+	approvedBy := fs.String("approved-by", "", "human approver identity")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments")
+	}
+	var plan archive.GapDecisionPlan
+	if err := decodeGapDecisionPlanTransport(*planBase64, &plan); err != nil {
+		return fmt.Errorf("decode gap decision plan: %w", err)
+	}
+	if *confirm != gapDecisionConfirmationPrefix+":"+plan.PlanHash {
+		return fmt.Errorf("exact plan-hash confirmation required")
+	}
+	if strings.TrimSpace(*approvedBy) == "" {
+		return fmt.Errorf("--approved-by is required")
+	}
+	deps = fillDefaults(deps)
+	cfg, err := deps.loadConfig()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	db, err := deps.openDB("postgres", cfg.Database.DSNWithTimezone(cfg.Timezone))
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("ping database: %w", err)
+	}
+	receipt, err := deps.applyGapDecisionPlan(ctx, db, plan, strings.TrimSpace(*approvedBy))
+	if err != nil {
+		return err
+	}
+	return writeJSON(out, map[string]any{
+		"ok": true, "command": "gap-decision-apply", "plan_hash": receipt.PlanHash,
+		"approved_by": receipt.ApprovedBy, "window_count": receipt.WindowCount,
+		"applied_at": receipt.AppliedAt, "already_applied": receipt.AlreadyApplied,
+		"cleanup_eligible": false, "deletion_authorized": false,
+	})
+}
+
+func encodeGapDecisionPlanTransport(plan archive.GapDecisionPlan) (string, int, error) {
+	raw, err := json.Marshal(plan)
+	if err != nil {
+		return "", 0, fmt.Errorf("encode gap decision plan: %w", err)
+	}
+	if len(raw) > maxGapDecisionPlanBytes {
+		return "", 0, fmt.Errorf("gap decision plan exceeds decompressed size limit")
+	}
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(raw); err != nil {
+		return "", 0, fmt.Errorf("compress gap decision plan: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return "", 0, fmt.Errorf("compress gap decision plan: %w", err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(compressed.Bytes())
+	if len(encoded) > maxGapDecisionTransportChars {
+		return "", 0, fmt.Errorf("gap decision plan exceeds SSM transport limit")
+	}
+	return encoded, len(raw), nil
+}
+
+func decodeGapDecisionPlanTransport(encoded string, plan *archive.GapDecisionPlan) error {
+	encoded = strings.TrimSpace(encoded)
+	if encoded == "" || len(encoded) > maxGapDecisionTransportChars {
+		return fmt.Errorf("invalid gzip+base64 transport")
+	}
+	compressed, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return fmt.Errorf("invalid gzip+base64 transport")
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		return fmt.Errorf("invalid gzip transport: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(reader, maxGapDecisionPlanBytes+1))
+	if err != nil {
+		return fmt.Errorf("decompress gap decision plan: %w", err)
+	}
+	if len(raw) > maxGapDecisionPlanBytes {
+		return fmt.Errorf("gap decision plan exceeds decompressed size limit")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(plan); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("gap decision plan contains trailing JSON")
+	}
+	return nil
 }
 
 func runSetForwardCutover(ctx context.Context, args []string, out io.Writer, deps cliDeps) error {
@@ -370,6 +569,12 @@ func fillDefaults(deps cliDeps) cliDeps {
 	}
 	if deps.setForwardCutover == nil {
 		deps.setForwardCutover = defaults.setForwardCutover
+	}
+	if deps.buildGapDecisionDBPlan == nil {
+		deps.buildGapDecisionDBPlan = defaults.buildGapDecisionDBPlan
+	}
+	if deps.applyGapDecisionPlan == nil {
+		deps.applyGapDecisionPlan = defaults.applyGapDecisionPlan
 	}
 	return deps
 }

--- a/backend/cmd/qa-archive/main_test.go
+++ b/backend/cmd/qa-archive/main_test.go
@@ -4,10 +4,13 @@ package main
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,6 +62,252 @@ func TestUS045_RepairApplyIsUnavailableBeforeDependencies(t *testing.T) {
 	if called {
 		t.Fatal("retired repair-apply touched dependencies")
 	}
+}
+
+func TestUS045_GapDecisionApplyRequiresHashBoundConfirmationBeforeDependencies(t *testing.T) {
+	plan := commandGapDecisionPlan(t)
+	encoded, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	deps := cliDeps{loadConfig: func() (*config.Config, error) {
+		called = true
+		return nil, errors.New("must not run")
+	}}
+	err = runCLI(context.Background(), []string{
+		"gap-decision-apply",
+		"--plan-gzip-base64", gzipBase64(t, encoded),
+		"--confirm", gapDecisionConfirmationPrefix,
+		"--approved-by", "feng",
+	}, &bytes.Buffer{}, deps)
+	if err == nil || !strings.Contains(err.Error(), "exact plan-hash confirmation") {
+		t.Fatalf("runCLI() error=%v", err)
+	}
+	if called {
+		t.Fatal("dependencies ran before gap decision confirmation validation")
+	}
+}
+
+func TestUS045_GapDecisionDBPlanUsesReadOnlyOwner(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	mock.ExpectPing()
+	mock.ExpectClose()
+	want := commandGapDecisionPlan(t)
+	want.Region, want.Bucket, want.RecoveryRoleARN, want.RecoveryRunID, want.PlanHash = "", "", "", "", ""
+	deps := cliDeps{
+		loadConfig: func() (*config.Config, error) {
+			return &config.Config{Timezone: "UTC", Database: config.DatabaseConfig{
+				Host: "postgres", Port: 5432, User: "tokenkey", DBName: "tokenkey", SSLMode: "disable",
+			}}, nil
+		},
+		openDB: func(string, string) (*sql.DB, error) { return db, nil },
+		buildGapDecisionDBPlan: func(context.Context, *sql.DB) (archive.GapDecisionPlan, error) {
+			return want, nil
+		},
+	}
+	out := &bytes.Buffer{}
+	if err := runCLI(context.Background(), []string{"gap-decision-db-plan"}, out, deps); err != nil {
+		t.Fatalf("runCLI()=%v", err)
+	}
+	var receipt struct {
+		OK                    bool   `json:"ok"`
+		Command               string `json:"command"`
+		PlanGzipBase64        string `json:"plan_gzip_base64"`
+		PlanUncompressedBytes int    `json:"plan_uncompressed_bytes"`
+		WindowCount           int    `json:"window_count"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	decoded := gunzipBase64(t, receipt.PlanGzipBase64)
+	var got archive.GapDecisionPlan
+	if err := json.Unmarshal(decoded, &got); err != nil {
+		t.Fatal(err)
+	}
+	if !receipt.OK || receipt.Command != "gap-decision-db-plan" || len(got.Windows) != 1 ||
+		receipt.PlanUncompressedBytes != len(decoded) || receipt.WindowCount != 1 {
+		t.Fatalf("receipt=%+v", receipt)
+	}
+	if strings.Contains(out.String(), `"plan":`) {
+		t.Fatal("database plan receipt leaked the uncompressed plan into SSM stdout")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUS045_GapDecisionS3PlanUsesOnlyWorkstationRecoveryStore(t *testing.T) {
+	dbPlan := commandGapDecisionPlan(t)
+	dbPlan.Region, dbPlan.Bucket, dbPlan.RecoveryRoleARN, dbPlan.RecoveryRunID, dbPlan.PlanHash = "", "", "", "", ""
+	encoded, err := json.Marshal(dbPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calledConfig := false
+	calledDB := false
+	calledRecovery := false
+	deps := cliDeps{
+		loadConfig: func() (*config.Config, error) { calledConfig = true; return nil, errors.New("must not run") },
+		openDB:     func(string, string) (*sql.DB, error) { calledDB = true; return nil, errors.New("must not run") },
+		newRecoveryStore: func(_ context.Context, input archive.WorkstationRecoveryConfig) (archive.ReadOnlyObjectStore, error) {
+			calledRecovery = true
+			if input.Region != "us-east-1" || input.Bucket != "tokenkey-prod-qa-raw-archive-123456789012" ||
+				input.RoleARN != "arn:aws:iam::123456789012:role/tokenkey-prod-qa-raw-recovery" || input.Prefix != archive.RawV1Prefix {
+				t.Fatalf("recovery input=%+v", input)
+			}
+			return archive.NewMemoryObjectStore(), nil
+		},
+	}
+	out := &bytes.Buffer{}
+	if err := runCLI(context.Background(), []string{
+		"gap-decision-s3-plan",
+		"--db-plan-gzip-base64", gzipBase64(t, encoded),
+		"--region", "us-east-1",
+		"--bucket", "tokenkey-prod-qa-raw-archive-123456789012",
+		"--recovery-role-arn", "arn:aws:iam::123456789012:role/tokenkey-prod-qa-raw-recovery",
+		"--recovery-run-id", "recovery-head-batch-20260812T050000Z",
+	}, out, deps); err != nil {
+		t.Fatalf("runCLI()=%v", err)
+	}
+	if !calledRecovery || calledConfig || calledDB {
+		t.Fatalf("recovery=%t config=%t db=%t", calledRecovery, calledConfig, calledDB)
+	}
+	var receipt struct {
+		OK   bool                    `json:"ok"`
+		Plan archive.GapDecisionPlan `json:"plan"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if !receipt.OK || receipt.Plan.PlanHash == "" || len(receipt.Plan.Windows) != 1 {
+		t.Fatalf("receipt=%+v", receipt)
+	}
+}
+
+func TestUS045_GapDecisionApplyInvokesAtomicOwnerWithExactPlan(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	mock.ExpectPing()
+	mock.ExpectClose()
+	plan := commandGapDecisionPlan(t)
+	encoded, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	deps := cliDeps{
+		loadConfig: func() (*config.Config, error) {
+			return &config.Config{Timezone: "UTC", Database: config.DatabaseConfig{
+				Host: "postgres", Port: 5432, User: "tokenkey", DBName: "tokenkey", SSLMode: "disable",
+			}}, nil
+		},
+		openDB: func(string, string) (*sql.DB, error) { return db, nil },
+		applyGapDecisionPlan: func(_ context.Context, gotDB *sql.DB, got archive.GapDecisionPlan, approvedBy string) (archive.GapDecisionReceipt, error) {
+			called = true
+			if gotDB != db || got.PlanHash != plan.PlanHash || approvedBy != "feng" {
+				t.Fatalf("db=%p plan=%+v approvedBy=%q", gotDB, got, approvedBy)
+			}
+			return archive.GapDecisionReceipt{PlanHash: got.PlanHash, ApprovedBy: approvedBy, WindowCount: len(got.Windows)}, nil
+		},
+	}
+	out := &bytes.Buffer{}
+	if err := runCLI(context.Background(), []string{
+		"gap-decision-apply",
+		"--plan-gzip-base64", gzipBase64(t, encoded),
+		"--confirm", gapDecisionConfirmationPrefix + ":" + plan.PlanHash,
+		"--approved-by", "feng",
+	}, out, deps); err != nil {
+		t.Fatalf("runCLI()=%v", err)
+	}
+	if !called {
+		t.Fatal("atomic gap decision owner was not called")
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(out.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt["ok"] != true || receipt["command"] != "gap-decision-apply" ||
+		receipt["plan_hash"] != plan.PlanHash || receipt["deletion_authorized"] != false {
+		t.Fatalf("receipt=%v", receipt)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUS045_GapDecisionPlanTransportRejectsOversizedExpansion(t *testing.T) {
+	oversized := bytes.Repeat([]byte("a"), maxGapDecisionPlanBytes+1)
+	encoded := gzipBase64(t, oversized)
+	var plan archive.GapDecisionPlan
+	err := decodeGapDecisionPlanTransport(encoded, &plan)
+	if err == nil || !strings.Contains(err.Error(), "exceeds decompressed size limit") {
+		t.Fatalf("decodeGapDecisionPlanTransport() error=%v", err)
+	}
+}
+
+func gzipBase64(t *testing.T, raw []byte) string {
+	t.Helper()
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(raw); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString(compressed.Bytes())
+}
+
+func gunzipBase64(t *testing.T, encoded string) []byte {
+	t.Helper()
+	compressed, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reader.Close() }()
+	raw, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func commandGapDecisionPlan(t *testing.T) archive.GapDecisionPlan {
+	t.Helper()
+	anchor := time.Date(2026, 8, 12, 5, 0, 0, 0, time.UTC)
+	window := time.Date(2026, 8, 8, 23, 0, 0, 0, time.UTC)
+	plan := archive.GapDecisionPlan{
+		SchemaVersion: archive.GapDecisionPlanSchemaVersion,
+		DBUTCAnchor:   anchor, RetentionCutoff: anchor.Add(-24 * time.Hour),
+		ForwardCutover:          archive.GapDecisionAnchor{WindowStart: time.Date(2026, 8, 7, 21, 0, 0, 0, time.UTC), WindowEnd: time.Date(2026, 8, 7, 22, 0, 0, 0, time.UTC)},
+		LatestNormalWindowStart: anchor.Add(-time.Hour),
+		Region:                  "us-east-1", Bucket: "tokenkey-prod-qa-raw-archive-123456789012",
+		RecoveryRoleARN: "arn:aws:iam::123456789012:role/tokenkey-prod-qa-raw-recovery",
+		RecoveryRunID:   "recovery-head-batch-20260812T050000Z",
+		Windows: []archive.GapDecisionWindow{{
+			WindowStart: window, WindowEnd: window.Add(time.Hour),
+			CommitKey:         archive.ShardPrefix(window) + "/commit.json",
+			SourceRecordCount: 0, Control: archive.GapDecisionControl{},
+		}},
+	}
+	hash, err := archive.HashGapDecisionPlan(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan.PlanHash = hash
+	return plan
 }
 
 func TestUS045_SetForwardCutoverUsesFixedApprovedWindow(t *testing.T) {

--- a/backend/internal/observability/qa/archive/control_schema_test.go
+++ b/backend/internal/observability/qa/archive/control_schema_test.go
@@ -157,6 +157,47 @@ RETURNING id`, start, start.Add(time.Hour), state, restoreAt).Scan(&id))
 	require.Error(t, err, "the established cutover must not be deleted")
 }
 
+func TestUS045_QAArchiveGapDecisionReceiptsAreAppendOnlyAndNotASecondStateMachine(t *testing.T) {
+	ctx := context.Background()
+	container, err := postgres.Run(
+		ctx,
+		"postgres:18.1-alpine3.23",
+		postgres.WithDatabase("qa_archive_gap_receipts"),
+		postgres.WithUsername("postgres"),
+		postgres.WithPassword("postgres"),
+		postgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		t.Skipf("start postgres: %v", err)
+	}
+	defer func() { _ = container.Terminate(ctx) }()
+
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
+	require.NoError(t, err)
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	applyMigration(t, ctx, db, "tk_069_create_qa_archive_shards.sql")
+	applyMigration(t, ctx, db, "tk_075_qa_archive_gap_decision_receipts.sql")
+	assertTable(t, db, "qa_archive_gap_decision_receipts")
+	assertTableAbsent(t, db, "qa_archive_gaps")
+
+	planHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	planJSON := `{"schema_version":"qa-archive-gap-decision-v1","plan_hash":"` + planHash + `","windows":[{}]}`
+	_, err = db.ExecContext(ctx, `
+INSERT INTO qa_archive_gap_decision_receipts
+    (plan_hash, plan_schema_version, plan_json, approved_by, window_count)
+VALUES ($1,'qa-archive-gap-decision-v1',$2::jsonb,'feng',1)`, planHash, planJSON)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `UPDATE qa_archive_gap_decision_receipts SET approved_by='other' WHERE plan_hash=$1`, planHash)
+	require.ErrorContains(t, err, "append-only")
+	_, err = db.ExecContext(ctx, `DELETE FROM qa_archive_gap_decision_receipts WHERE plan_hash=$1`, planHash)
+	require.ErrorContains(t, err, "append-only")
+	_, err = db.ExecContext(ctx, `TRUNCATE qa_archive_gap_decision_receipts`)
+	require.ErrorContains(t, err, "append-only")
+}
+
 func applyMigration(t *testing.T, ctx context.Context, db *sql.DB, name string) {
 	t.Helper()
 	body, err := migrations.FS.ReadFile(name)

--- a/backend/internal/observability/qa/archive/gap_decision.go
+++ b/backend/internal/observability/qa/archive/gap_decision.go
@@ -1,0 +1,594 @@
+package archive
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const GapDecisionPlanSchemaVersion = "qa-archive-gap-decision-v1"
+
+var gapDecisionHashPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+type GapDecisionControl struct {
+	Exists                bool      `json:"exists"`
+	ShardID               int64     `json:"shard_id,omitempty"`
+	WindowEnd             time.Time `json:"window_end"`
+	State                 string    `json:"state,omitempty"`
+	VerificationErrorCode string    `json:"verification_error_code,omitempty"`
+	UpdatedAt             time.Time `json:"updated_at,omitempty"`
+	SegmentFingerprint    string    `json:"segment_fingerprint"`
+	HasCommitReadySegment bool      `json:"has_commit_ready_segment"`
+}
+
+type GapDecisionWindow struct {
+	WindowStart       time.Time          `json:"window_start"`
+	WindowEnd         time.Time          `json:"window_end"`
+	CommitKey         string             `json:"commit_key"`
+	CommitExists      bool               `json:"commit_exists"`
+	SourceRecordCount int64              `json:"source_record_count"`
+	Control           GapDecisionControl `json:"control"`
+}
+
+type GapDecisionAnchor struct {
+	WindowStart time.Time `json:"window_start"`
+	WindowEnd   time.Time `json:"window_end"`
+}
+
+type GapDecisionPlan struct {
+	SchemaVersion           string              `json:"schema_version"`
+	DBUTCAnchor             time.Time           `json:"db_utc_anchor"`
+	RetentionCutoff         time.Time           `json:"retention_cutoff"`
+	ForwardCutover          GapDecisionAnchor   `json:"forward_cutover"`
+	LatestNormalWindowStart time.Time           `json:"latest_normal_window_start"`
+	Region                  string              `json:"region"`
+	Bucket                  string              `json:"bucket"`
+	RecoveryRoleARN         string              `json:"recovery_role_arn"`
+	RecoveryRunID           string              `json:"recovery_run_id"`
+	Windows                 []GapDecisionWindow `json:"windows"`
+	PlanHash                string              `json:"plan_hash"`
+}
+
+type GapDecisionReceipt struct {
+	PlanHash       string    `json:"plan_hash"`
+	ApprovedBy     string    `json:"approved_by"`
+	WindowCount    int       `json:"window_count"`
+	AppliedAt      time.Time `json:"applied_at"`
+	AlreadyApplied bool      `json:"already_applied"`
+}
+
+func BuildGapDecisionDBPlan(ctx context.Context, db *sql.DB) (GapDecisionPlan, error) {
+	if db == nil {
+		return GapDecisionPlan{}, fmt.Errorf("gap decision plan: nil database")
+	}
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return GapDecisionPlan{}, fmt.Errorf("gap decision plan: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := acquireGapDecisionLock(ctx, tx); err != nil {
+		return GapDecisionPlan{}, err
+	}
+
+	anchor, latestNormal, err := readGapDecisionAnchors(ctx, tx)
+	if err != nil {
+		return GapDecisionPlan{}, err
+	}
+	cutover, err := readGapDecisionCutover(ctx, tx)
+	if err != nil {
+		return GapDecisionPlan{}, err
+	}
+	cutoff := anchor.Add(-24 * time.Hour)
+	rows, err := tx.QueryContext(ctx, `
+WITH hours AS (
+    SELECT generate_series($1::timestamptz, $2::timestamptz - interval '1 hour', interval '1 hour') AS window_start
+)
+SELECT h.window_start, s.id, s.window_end, s.state, s.verification_error_code,
+	   s.updated_at,
+	   COALESCE((
+	       SELECT string_agg(
+	           seg.id::text || ':' || seg.state || ':' ||
+	           to_char(seg.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
+	           ',' ORDER BY seg.id
+	       )
+	       FROM qa_archive_segments seg WHERE seg.shard_id=s.id
+	   ), '') AS segment_fingerprint,
+	   COALESCE((
+	       SELECT bool_or(seg.state IN ('verified','committed'))
+	       FROM qa_archive_segments seg WHERE seg.shard_id=s.id
+	   ), false) AS has_commit_ready_segment,
+	   (SELECT count(*) FROM qa_records q
+        WHERE q.created_at >= h.window_start AND q.created_at < h.window_start + interval '1 hour') AS source_record_count
+FROM hours h
+LEFT JOIN qa_archive_shards s ON s.window_start=h.window_start AND s.generation=0
+WHERE h.window_start < $3
+ORDER BY h.window_start`, cutover.End, latestNormal, cutoff)
+	if err != nil {
+		return GapDecisionPlan{}, fmt.Errorf("gap decision plan: enumerate timeline: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	plan := GapDecisionPlan{
+		SchemaVersion: GapDecisionPlanSchemaVersion, DBUTCAnchor: anchor,
+		RetentionCutoff:         cutoff,
+		ForwardCutover:          GapDecisionAnchor{WindowStart: cutover.Start, WindowEnd: cutover.End},
+		LatestNormalWindowStart: latestNormal,
+	}
+	for rows.Next() {
+		var start time.Time
+		var shardID sql.NullInt64
+		var storedEnd sql.NullTime
+		var state, code sql.NullString
+		var updatedAt sql.NullTime
+		var segmentFingerprint string
+		var hasCommitReadySegment bool
+		var sourceCount int64
+		if err := rows.Scan(&start, &shardID, &storedEnd, &state, &code, &updatedAt, &segmentFingerprint, &hasCommitReadySegment, &sourceCount); err != nil {
+			return GapDecisionPlan{}, fmt.Errorf("gap decision plan: scan timeline: %w", err)
+		}
+		control := GapDecisionControl{
+			Exists: shardID.Valid, ShardID: shardID.Int64,
+			State: state.String, VerificationErrorCode: code.String,
+			SegmentFingerprint: segmentFingerprint, HasCommitReadySegment: hasCommitReadySegment,
+		}
+		if storedEnd.Valid {
+			control.WindowEnd = storedEnd.Time.UTC()
+		}
+		if updatedAt.Valid {
+			control.UpdatedAt = updatedAt.Time.UTC()
+		}
+		if sourceCount != 0 || !gapDecisionControlEligible(control) {
+			continue
+		}
+		start = start.UTC()
+		plan.Windows = append(plan.Windows, GapDecisionWindow{
+			WindowStart: start, WindowEnd: start.Add(time.Hour),
+			CommitKey:         ShardPrefix(start) + "/commit.json",
+			SourceRecordCount: sourceCount, Control: control,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return GapDecisionPlan{}, fmt.Errorf("gap decision plan: timeline: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return GapDecisionPlan{}, fmt.Errorf("gap decision plan: commit read snapshot: %w", err)
+	}
+	return plan, nil
+}
+
+func CompleteGapDecisionPlan(
+	dbPlan GapDecisionPlan,
+	region, bucket, recoveryRoleARN, recoveryRunID string,
+	commitExists map[string]bool,
+) (GapDecisionPlan, error) {
+	if err := validateGapDecisionDBPlan(dbPlan); err != nil {
+		return GapDecisionPlan{}, err
+	}
+	plan := dbPlan
+	plan.Region = strings.TrimSpace(region)
+	plan.Bucket = strings.TrimSpace(bucket)
+	plan.RecoveryRoleARN = strings.TrimSpace(recoveryRoleARN)
+	plan.RecoveryRunID = strings.TrimSpace(recoveryRunID)
+	plan.PlanHash = ""
+	confirmedMissing := make([]GapDecisionWindow, 0, len(plan.Windows))
+	for index := range plan.Windows {
+		exists, ok := commitExists[plan.Windows[index].CommitKey]
+		if !ok {
+			return GapDecisionPlan{}, fmt.Errorf("gap decision plan: missing S3 fact for %s", plan.Windows[index].CommitKey)
+		}
+		plan.Windows[index].CommitExists = exists
+		if !exists {
+			confirmedMissing = append(confirmedMissing, plan.Windows[index])
+		}
+	}
+	plan.Windows = confirmedMissing
+	if len(plan.Windows) == 0 {
+		return GapDecisionPlan{}, fmt.Errorf("gap decision plan: no confirmed missing commit windows")
+	}
+	if err := validateGapDecisionPlan(plan, false); err != nil {
+		return GapDecisionPlan{}, err
+	}
+	hash, err := HashGapDecisionPlan(plan)
+	if err != nil {
+		return GapDecisionPlan{}, err
+	}
+	plan.PlanHash = hash
+	return plan, nil
+}
+
+func CompleteGapDecisionPlanFromStore(
+	ctx context.Context,
+	dbPlan GapDecisionPlan,
+	store ReadOnlyObjectStore,
+	region, bucket, recoveryRoleARN, recoveryRunID string,
+) (GapDecisionPlan, error) {
+	if store == nil {
+		return GapDecisionPlan{}, fmt.Errorf("gap decision plan: nil recovery store")
+	}
+	if err := validateGapDecisionDBPlan(dbPlan); err != nil {
+		return GapDecisionPlan{}, err
+	}
+	commitExists := make(map[string]bool, len(dbPlan.Windows))
+	for _, window := range dbPlan.Windows {
+		key := strings.TrimPrefix(window.CommitKey, RawV1Prefix+"/")
+		if key == window.CommitKey || key == "" {
+			return GapDecisionPlan{}, fmt.Errorf("gap decision plan: commit key is outside raw/v1")
+		}
+		exists, err := store.Head(ctx, key)
+		if err != nil {
+			return GapDecisionPlan{}, fmt.Errorf("gap decision plan: inspect recovery commit %s: %w", window.CommitKey, err)
+		}
+		commitExists[window.CommitKey] = exists
+	}
+	return CompleteGapDecisionPlan(
+		dbPlan, region, bucket, recoveryRoleARN, recoveryRunID, commitExists,
+	)
+}
+
+func HashGapDecisionPlan(plan GapDecisionPlan) (string, error) {
+	plan.PlanHash = ""
+	encoded, err := json.Marshal(plan)
+	if err != nil {
+		return "", fmt.Errorf("gap decision plan: encode canonical facts: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var object map[string]any
+	if err := decoder.Decode(&object); err != nil {
+		return "", fmt.Errorf("gap decision plan: normalize canonical facts: %w", err)
+	}
+	canonical, err := json.Marshal(object)
+	if err != nil {
+		return "", fmt.Errorf("gap decision plan: encode normalized facts: %w", err)
+	}
+	digest := sha256.Sum256(canonical)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func ApplyGapDecisionPlan(ctx context.Context, db *sql.DB, plan GapDecisionPlan, approvedBy string) (GapDecisionReceipt, error) {
+	if db == nil {
+		return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: nil database")
+	}
+	approvedBy = strings.TrimSpace(approvedBy)
+	if approvedBy == "" {
+		return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: approved-by is required")
+	}
+	if err := validateGapDecisionPlan(plan, true); err != nil {
+		return GapDecisionReceipt{}, err
+	}
+	recomputed, err := HashGapDecisionPlan(plan)
+	if err != nil {
+		return GapDecisionReceipt{}, err
+	}
+	if recomputed != plan.PlanHash {
+		return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: plan hash drift")
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := acquireGapDecisionLock(ctx, tx); err != nil {
+		return GapDecisionReceipt{}, err
+	}
+	if receipt, ok, err := readGapDecisionReceipt(ctx, tx, plan.PlanHash); err != nil {
+		return GapDecisionReceipt{}, err
+	} else if ok {
+		if err := tx.Commit(); err != nil {
+			return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: commit replay: %w", err)
+		}
+		receipt.AlreadyApplied = true
+		return receipt, nil
+	}
+
+	anchor, latestNormal, err := readGapDecisionAnchors(ctx, tx)
+	if err != nil {
+		return GapDecisionReceipt{}, err
+	}
+	if !anchor.Equal(plan.DBUTCAnchor) || !anchor.Add(-24*time.Hour).Equal(plan.RetentionCutoff) ||
+		!latestNormal.Equal(plan.LatestNormalWindowStart) {
+		return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: database anchor or latest normal drift")
+	}
+	cutover, err := readGapDecisionCutover(ctx, tx)
+	if err != nil {
+		return GapDecisionReceipt{}, err
+	}
+	if !cutover.Start.Equal(plan.ForwardCutover.WindowStart) || !cutover.End.Equal(plan.ForwardCutover.WindowEnd) {
+		return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: forward cutover drift")
+	}
+
+	store := NewSQLControlStore()
+	for _, planned := range plan.Windows {
+		live, err := inspectGapDecisionControl(ctx, tx, planned.WindowStart)
+		if err != nil {
+			return GapDecisionReceipt{}, err
+		}
+		if !equalGapDecisionControl(live, planned.Control) {
+			return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: control drift for %s", planned.WindowStart.Format(time.RFC3339))
+		}
+		var sourceCount int64
+		if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM qa_records WHERE created_at >= $1 AND created_at < $2`,
+			planned.WindowStart, planned.WindowEnd).Scan(&sourceCount); err != nil {
+			return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: recount %s: %w", planned.WindowStart.Format(time.RFC3339), err)
+		}
+		if sourceCount != planned.SourceRecordCount {
+			return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: source row count drift for %s", planned.WindowStart.Format(time.RFC3339))
+		}
+		if _, err := store.PersistApprovedGapTerminal(ctx, tx, Window{Start: planned.WindowStart, End: planned.WindowEnd}); err != nil {
+			return GapDecisionReceipt{}, err
+		}
+	}
+	planJSON, err := json.Marshal(plan)
+	if err != nil {
+		return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: encode receipt plan: %w", err)
+	}
+	var appliedAt time.Time
+	if err := tx.QueryRowContext(ctx, `
+INSERT INTO qa_archive_gap_decision_receipts
+    (plan_hash, plan_schema_version, plan_json, approved_by, window_count)
+VALUES ($1,$2,$3,$4,$5)
+RETURNING applied_at`, plan.PlanHash, GapDecisionPlanSchemaVersion, planJSON, approvedBy, len(plan.Windows)).Scan(&appliedAt); err != nil {
+		return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: persist approval receipt: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return GapDecisionReceipt{}, fmt.Errorf("gap decision apply: commit: %w", err)
+	}
+	return GapDecisionReceipt{
+		PlanHash: plan.PlanHash, ApprovedBy: approvedBy, WindowCount: len(plan.Windows), AppliedAt: appliedAt.UTC(),
+	}, nil
+}
+
+func (s *SQLControlStore) PersistApprovedGapTerminal(ctx context.Context, tx *sql.Tx, window Window) (int64, error) {
+	window.Start = window.Start.UTC()
+	window.End = window.End.UTC()
+	if !window.End.Equal(window.Start.Add(time.Hour)) {
+		return 0, fmt.Errorf("approved gap: window must be one UTC hour")
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO qa_archive_shards (
+    window_start, window_end, generation, state, s3_prefix, first_attempt_at,
+    cleanup_eligible, created_at, updated_at
+) VALUES ($1,$2,0,$3,$4,now(),false,now(),now())
+ON CONFLICT (window_start, generation) DO NOTHING`, window.Start, window.End, StatePending, ShardPrefix(window.Start)); err != nil {
+		return 0, fmt.Errorf("approved gap: insert control: %w", err)
+	}
+	var shardID int64
+	var state string
+	var code sql.NullString
+	var restored sql.NullTime
+	if err := tx.QueryRowContext(ctx, `
+SELECT id, state, verification_error_code, restore_verified_at
+FROM qa_archive_shards
+WHERE window_start=$1 AND generation=0
+FOR UPDATE`, window.Start).Scan(&shardID, &state, &code, &restored); err != nil {
+		return 0, fmt.Errorf("approved gap: lock control: %w", err)
+	}
+	if state == StateFailed && code.String == IntegritySourceUnavailableAfterRetention {
+		return shardID, nil
+	}
+	if state == StateCommitted || (state == StateFailed && IsTerminalArchiveFailure(code.String)) {
+		return 0, fmt.Errorf("approved gap: immutable shard state=%s code=%s", state, code.String)
+	}
+	result, err := tx.ExecContext(ctx, `
+UPDATE qa_archive_shards SET
+    state=$1, verification_error_code=$2,
+    last_error='source unavailable after retention under approved gap decision',
+    last_reconciled_at=now(), cleanup_eligible=false, updated_at=now()
+WHERE id=$3 AND state IN ('pending','writing','verified','failed')`,
+		StateFailed, IntegritySourceUnavailableAfterRetention, shardID)
+	if err != nil {
+		return 0, fmt.Errorf("approved gap: update control: %w", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil || changed != 1 {
+		return 0, fmt.Errorf("approved gap: shard changed concurrently")
+	}
+	return shardID, nil
+}
+
+func acquireGapDecisionLock(ctx context.Context, tx *sql.Tx) error {
+	var locked bool
+	if err := tx.QueryRowContext(ctx, `SELECT pg_try_advisory_xact_lock($1)`, MaintenanceAdvisoryLockID).Scan(&locked); err != nil {
+		return fmt.Errorf("gap decision: acquire QAMA lock: %w", err)
+	}
+	if !locked {
+		return fmt.Errorf("gap decision: QAMA lock already held")
+	}
+	return nil
+}
+
+func readGapDecisionAnchors(ctx context.Context, tx *sql.Tx) (time.Time, time.Time, error) {
+	var anchor, latest time.Time
+	err := tx.QueryRowContext(ctx, `
+SELECT date_trunc('hour', clock_timestamp()), COALESCE(max(window_start), '-infinity'::timestamptz)
+FROM qa_archive_shards
+WHERE state='committed' AND restore_verified_at IS NOT NULL
+  AND window_start < date_trunc('hour', clock_timestamp())`).Scan(&anchor, &latest)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("gap decision: read database anchors: %w", err)
+	}
+	if latest.IsZero() || latest.Year() < 2000 {
+		return time.Time{}, time.Time{}, fmt.Errorf("gap decision: latest normal committed hour missing")
+	}
+	return anchor.UTC(), latest.UTC(), nil
+}
+
+func readGapDecisionCutover(ctx context.Context, tx *sql.Tx) (Window, error) {
+	var out Window
+	err := tx.QueryRowContext(ctx, `
+SELECT window_start, window_end
+FROM qa_archive_shards
+WHERE forward_cutover=true`).Scan(&out.Start, &out.End)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Window{}, fmt.Errorf("gap decision: forward cutover missing")
+	}
+	if err != nil {
+		return Window{}, fmt.Errorf("gap decision: read forward cutover: %w", err)
+	}
+	out.Start, out.End = out.Start.UTC(), out.End.UTC()
+	return out, nil
+}
+
+func inspectGapDecisionControl(ctx context.Context, tx *sql.Tx, start time.Time) (GapDecisionControl, error) {
+	var out GapDecisionControl
+	var code sql.NullString
+	var updatedAt time.Time
+	var segmentFingerprint string
+	err := tx.QueryRowContext(ctx, `
+SELECT s.id, s.window_end, s.state, s.verification_error_code, s.updated_at,
+	   COALESCE((
+	       SELECT string_agg(
+	           seg.id::text || ':' || seg.state || ':' ||
+	           to_char(seg.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
+	           ',' ORDER BY seg.id
+	       )
+	       FROM qa_archive_segments seg WHERE seg.shard_id=s.id
+	   ), '') AS segment_fingerprint,
+	   COALESCE((
+	       SELECT bool_or(seg.state IN ('verified','committed'))
+	       FROM qa_archive_segments seg WHERE seg.shard_id=s.id
+	   ), false) AS has_commit_ready_segment
+FROM qa_archive_shards s
+	WHERE s.window_start=$1 AND s.generation=0
+	FOR UPDATE OF s`, start).Scan(&out.ShardID, &out.WindowEnd, &out.State, &code, &updatedAt, &segmentFingerprint, &out.HasCommitReadySegment)
+	if errors.Is(err, sql.ErrNoRows) {
+		return GapDecisionControl{}, nil
+	}
+	if err != nil {
+		return GapDecisionControl{}, fmt.Errorf("gap decision apply: inspect control: %w", err)
+	}
+	out.Exists = true
+	out.VerificationErrorCode = code.String
+	out.UpdatedAt = updatedAt.UTC()
+	out.WindowEnd = out.WindowEnd.UTC()
+	out.SegmentFingerprint = segmentFingerprint
+	return out, nil
+}
+
+func readGapDecisionReceipt(ctx context.Context, tx *sql.Tx, planHash string) (GapDecisionReceipt, bool, error) {
+	var out GapDecisionReceipt
+	err := tx.QueryRowContext(ctx, `
+SELECT plan_hash, approved_by, window_count, applied_at
+FROM qa_archive_gap_decision_receipts
+WHERE plan_hash=$1`, planHash).Scan(&out.PlanHash, &out.ApprovedBy, &out.WindowCount, &out.AppliedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return GapDecisionReceipt{}, false, nil
+	}
+	if err != nil {
+		return GapDecisionReceipt{}, false, fmt.Errorf("gap decision apply: read receipt: %w", err)
+	}
+	out.AppliedAt = out.AppliedAt.UTC()
+	return out, true, nil
+}
+
+func gapDecisionControlEligible(control GapDecisionControl) bool {
+	if !control.Exists {
+		return true
+	}
+	if control.State == StateCommitted || (control.State == StateFailed && IsTerminalArchiveFailure(control.VerificationErrorCode)) {
+		return false
+	}
+	switch control.State {
+	case StatePending, StateWriting, StateVerified, StateFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateGapDecisionDBPlan(plan GapDecisionPlan) error {
+	if plan.Region != "" || plan.Bucket != "" || plan.RecoveryRoleARN != "" ||
+		plan.RecoveryRunID != "" || plan.PlanHash != "" {
+		return fmt.Errorf("gap decision plan: database plan contains recovery or hash facts")
+	}
+	return validateGapDecisionTimeline(plan)
+}
+
+func validateGapDecisionPlan(plan GapDecisionPlan, requireHash bool) error {
+	if strings.TrimSpace(plan.Region) == "" || strings.TrimSpace(plan.Bucket) == "" ||
+		!strings.HasPrefix(strings.TrimSpace(plan.RecoveryRoleARN), "arn:aws:iam::") ||
+		strings.TrimSpace(plan.RecoveryRunID) == "" {
+		return fmt.Errorf("gap decision plan: recovery scope is incomplete")
+	}
+	if requireHash && !gapDecisionHashPattern.MatchString(plan.PlanHash) {
+		return fmt.Errorf("gap decision plan: canonical SHA-256 is required")
+	}
+	return validateGapDecisionTimeline(plan)
+}
+
+func validateGapDecisionTimeline(plan GapDecisionPlan) error {
+	if plan.SchemaVersion != GapDecisionPlanSchemaVersion {
+		return fmt.Errorf("gap decision plan: unsupported schema version")
+	}
+	if !isExactUTCHour(plan.DBUTCAnchor) || !isExactUTCHour(plan.RetentionCutoff) ||
+		!isExactUTCHour(plan.ForwardCutover.WindowStart) || !isExactUTCHour(plan.ForwardCutover.WindowEnd) ||
+		!isExactUTCHour(plan.LatestNormalWindowStart) ||
+		!plan.RetentionCutoff.Equal(plan.DBUTCAnchor.Add(-24*time.Hour)) ||
+		!plan.ForwardCutover.WindowEnd.Equal(plan.ForwardCutover.WindowStart.Add(time.Hour)) ||
+		plan.LatestNormalWindowStart.Before(plan.ForwardCutover.WindowEnd) ||
+		!plan.LatestNormalWindowStart.Before(plan.DBUTCAnchor) || len(plan.Windows) == 0 {
+		return fmt.Errorf("gap decision plan: invalid timeline anchors")
+	}
+	ordered := append([]GapDecisionWindow(nil), plan.Windows...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].WindowStart.Before(ordered[j].WindowStart) })
+	for index, window := range plan.Windows {
+		if index > 0 && !plan.Windows[index-1].WindowStart.Before(window.WindowStart) {
+			return fmt.Errorf("gap decision plan: windows must be unique and sorted")
+		}
+		if !isExactUTCHour(window.WindowStart) || !isExactUTCHour(window.WindowEnd) ||
+			!window.WindowEnd.Equal(window.WindowStart.Add(time.Hour)) ||
+			window.WindowStart.Before(plan.ForwardCutover.WindowEnd) ||
+			!window.WindowStart.Before(plan.RetentionCutoff) ||
+			!window.WindowStart.Before(plan.LatestNormalWindowStart) ||
+			window.SourceRecordCount != 0 || window.CommitExists ||
+			window.CommitKey != ShardPrefix(window.WindowStart)+"/commit.json" ||
+			!validGapDecisionControl(window.Control) ||
+			(window.Control.Exists && !window.Control.WindowEnd.Equal(window.WindowEnd)) {
+			return fmt.Errorf("gap decision plan: ineligible window %s", window.WindowStart.Format(time.RFC3339))
+		}
+		if !ordered[index].WindowStart.Equal(window.WindowStart) {
+			return fmt.Errorf("gap decision plan: windows must be sorted")
+		}
+	}
+	return nil
+}
+
+func isExactUTCHour(value time.Time) bool {
+	if value.IsZero() || value.Year() < 2000 {
+		return false
+	}
+	_, offset := value.Zone()
+	return offset == 0 && value.Equal(value.UTC().Truncate(time.Hour))
+}
+
+func validGapDecisionControl(control GapDecisionControl) bool {
+	if !control.Exists {
+		return control.ShardID == 0 && control.State == "" && control.VerificationErrorCode == "" &&
+			control.WindowEnd.IsZero() && control.UpdatedAt.IsZero() && control.SegmentFingerprint == "" &&
+			!control.HasCommitReadySegment
+	}
+	if (control.State == StateFailed) != (strings.TrimSpace(control.VerificationErrorCode) != "") {
+		return false
+	}
+	return control.ShardID > 0 && isExactUTCHour(control.WindowEnd) && control.State != "" &&
+		!control.UpdatedAt.IsZero() && !control.HasCommitReadySegment &&
+		gapDecisionControlEligible(control)
+}
+
+func equalGapDecisionControl(left, right GapDecisionControl) bool {
+	return left.Exists == right.Exists && left.ShardID == right.ShardID && left.WindowEnd.Equal(right.WindowEnd) &&
+		left.State == right.State &&
+		left.VerificationErrorCode == right.VerificationErrorCode && left.UpdatedAt.Equal(right.UpdatedAt) &&
+		left.SegmentFingerprint == right.SegmentFingerprint &&
+		left.HasCommitReadySegment == right.HasCommitReadySegment
+}

--- a/backend/internal/observability/qa/archive/gap_decision_integration_test.go
+++ b/backend/internal/observability/qa/archive/gap_decision_integration_test.go
@@ -1,0 +1,164 @@
+//go:build integration
+
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/migrations"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+func TestUS045_GapDecisionPlanJSONApplyIsAtomicAndIdempotentInPostgreSQL(t *testing.T) {
+	ctx := context.Background()
+	container, err := postgres.Run(
+		ctx, "postgres:18.1-alpine3.23",
+		postgres.WithDatabase("qa_archive_gap_decision"),
+		postgres.WithUsername("postgres"), postgres.WithPassword("postgres"),
+		postgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		t.Skipf("start postgres: %v", err)
+	}
+	defer func() { _ = container.Terminate(ctx) }()
+
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
+	require.NoError(t, err)
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	for _, migration := range []string{
+		"tk_004_create_qa_records.sql",
+		"tk_069_create_qa_archive_shards.sql",
+		"tk_070_qa_archive_closeout_control.sql",
+		"tk_072_qa_archive_forward_cutover.sql",
+		"tk_075_qa_archive_gap_decision_receipts.sql",
+	} {
+		body, readErr := migrations.FS.ReadFile(migration)
+		require.NoError(t, readErr)
+		_, execErr := db.ExecContext(ctx, string(body))
+		require.NoError(t, execErr)
+	}
+
+	var anchor time.Time
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT date_trunc('hour', clock_timestamp())`).Scan(&anchor))
+	anchor = anchor.UTC()
+	cutoverStart := anchor.Add(-27 * time.Hour)
+	latestNormal := anchor.Add(-time.Hour)
+	_, err = db.ExecContext(ctx, `
+INSERT INTO qa_archive_shards (
+    window_start, window_end, generation, state, restore_verified_at, forward_cutover
+) VALUES
+    ($1,$2,0,'committed',$2,true),
+    ($3,$4,0,'committed',$4,false)`,
+		cutoverStart, cutoverStart.Add(time.Hour), latestNormal, latestNormal.Add(time.Hour))
+	require.NoError(t, err)
+
+	dbPlan, err := BuildGapDecisionDBPlan(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, dbPlan.Windows, 2)
+	require.Equal(t, anchor.Add(-26*time.Hour), dbPlan.Windows[0].WindowStart)
+	require.Equal(t, anchor.Add(-25*time.Hour), dbPlan.Windows[1].WindowStart)
+
+	commitExists := make(map[string]bool, len(dbPlan.Windows))
+	for _, window := range dbPlan.Windows {
+		commitExists[window.CommitKey] = false
+	}
+	plan, err := CompleteGapDecisionPlan(
+		dbPlan,
+		"us-east-1",
+		"tokenkey-prod-qa-raw-archive-123456789012",
+		"arn:aws:iam::123456789012:role/tokenkey-prod-qa-raw-recovery",
+		"recovery-head-batch-integration",
+		commitExists,
+	)
+	require.NoError(t, err)
+	encoded, err := json.Marshal(plan)
+	require.NoError(t, err)
+	var roundTripped GapDecisionPlan
+	require.NoError(t, json.Unmarshal(encoded, &roundTripped))
+	require.Equal(t, plan.PlanHash, roundTripped.PlanHash)
+
+	_, err = db.ExecContext(ctx, `
+CREATE FUNCTION reject_gap_decision_receipt_for_test()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'receipt write rejected for atomicity test';
+END;
+$$;
+CREATE TRIGGER reject_gap_decision_receipt_for_test
+BEFORE INSERT ON qa_archive_gap_decision_receipts
+FOR EACH ROW EXECUTE FUNCTION reject_gap_decision_receipt_for_test();`)
+	require.NoError(t, err)
+	_, err = ApplyGapDecisionPlan(ctx, db, roundTripped, "feng")
+	require.ErrorContains(t, err, "persist approval receipt")
+
+	var terminalCount, receiptCount int
+	require.NoError(t, db.QueryRowContext(ctx, `
+SELECT count(*) FROM qa_archive_shards
+WHERE window_start >= $1 AND window_start < $2`,
+		anchor.Add(-26*time.Hour), anchor.Add(-24*time.Hour)).Scan(&terminalCount))
+	require.Zero(t, terminalCount, "receipt failure must roll back every terminal shard")
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT count(*) FROM qa_archive_gap_decision_receipts`).Scan(&receiptCount))
+	require.Zero(t, receiptCount)
+
+	_, err = db.ExecContext(ctx, `
+DROP TRIGGER reject_gap_decision_receipt_for_test ON qa_archive_gap_decision_receipts;
+DROP FUNCTION reject_gap_decision_receipt_for_test();`)
+	require.NoError(t, err)
+	receipt, err := ApplyGapDecisionPlan(ctx, db, roundTripped, "feng")
+	require.NoError(t, err)
+	require.Equal(t, plan.PlanHash, receipt.PlanHash)
+	require.Equal(t, 2, receipt.WindowCount)
+	require.False(t, receipt.AlreadyApplied)
+	require.False(t, receipt.AppliedAt.IsZero())
+
+	rows, err := db.QueryContext(ctx, `
+SELECT state, verification_error_code, cleanup_eligible
+FROM qa_archive_shards
+WHERE window_start >= $1 AND window_start < $2
+ORDER BY window_start`, anchor.Add(-26*time.Hour), anchor.Add(-24*time.Hour))
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	seen := 0
+	for rows.Next() {
+		var state, code string
+		var cleanupEligible bool
+		require.NoError(t, rows.Scan(&state, &code, &cleanupEligible))
+		require.Equal(t, StateFailed, state)
+		require.Equal(t, IntegritySourceUnavailableAfterRetention, code)
+		require.False(t, cleanupEligible)
+		seen++
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, 2, seen)
+
+	var storedPlanHash, approvedBy string
+	var storedWindowCount int
+	var storedPlan []byte
+	require.NoError(t, db.QueryRowContext(ctx, `
+SELECT plan_hash, approved_by, window_count, plan_json
+FROM qa_archive_gap_decision_receipts`).Scan(
+		&storedPlanHash, &approvedBy, &storedWindowCount, &storedPlan,
+	))
+	require.Equal(t, plan.PlanHash, storedPlanHash)
+	require.Equal(t, "feng", approvedBy)
+	require.Equal(t, 2, storedWindowCount)
+	var persisted GapDecisionPlan
+	require.NoError(t, json.Unmarshal(storedPlan, &persisted))
+	require.Equal(t, plan.PlanHash, persisted.PlanHash)
+
+	replayed, err := ApplyGapDecisionPlan(ctx, db, roundTripped, "different-operator")
+	require.NoError(t, err)
+	require.True(t, replayed.AlreadyApplied)
+	require.Equal(t, "feng", replayed.ApprovedBy)
+	require.Equal(t, receipt.AppliedAt, replayed.AppliedAt)
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT count(*) FROM qa_archive_gap_decision_receipts`).Scan(&receiptCount))
+	require.Equal(t, 1, receiptCount)
+}

--- a/backend/internal/observability/qa/archive/gap_decision_test.go
+++ b/backend/internal/observability/qa/archive/gap_decision_test.go
@@ -1,0 +1,416 @@
+//go:build unit
+
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestUS045_BuildGapDecisionPlanSelectsOnlyExpiredEmptyNonterminalHours(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	anchor := time.Date(2026, 8, 12, 5, 0, 0, 0, time.UTC)
+	cutoverStart := time.Date(2026, 8, 7, 21, 0, 0, 0, time.UTC)
+	cutoverEnd := cutoverStart.Add(time.Hour)
+	missing := time.Date(2026, 8, 8, 23, 0, 0, 0, time.UTC)
+	pending := missing.Add(time.Hour)
+	terminal := pending.Add(time.Hour)
+	committed := terminal.Add(time.Hour)
+	sourcePresent := committed.Add(time.Hour)
+	pendingUpdatedAt := anchor.Add(-2 * time.Hour)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("pg_try_advisory_xact_lock").
+		WithArgs(MaintenanceAdvisoryLockID).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(true))
+	mock.ExpectQuery("date_trunc\\('hour', clock_timestamp\\(\\)\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"anchor", "latest_normal"}).AddRow(anchor, anchor.Add(-time.Hour)))
+	mock.ExpectQuery("WHERE forward_cutover=true").
+		WillReturnRows(sqlmock.NewRows([]string{"window_start", "window_end"}).AddRow(cutoverStart, cutoverEnd))
+	mock.ExpectQuery("generate_series").
+		WithArgs(cutoverEnd, anchor.Add(-time.Hour), anchor.Add(-24*time.Hour)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"window_start", "shard_id", "window_end", "state", "verification_error_code", "updated_at",
+			"segment_fingerprint", "has_commit_ready_segment", "source_record_count",
+		}).
+			AddRow(missing, nil, nil, nil, nil, nil, "", false, int64(0)).
+			AddRow(pending, int64(42), pending.Add(time.Hour), StatePending, nil, pendingUpdatedAt, "61:writing:2026-08-12T02:00:00.000000Z", false, int64(0)).
+			AddRow(terminal, int64(43), terminal.Add(time.Hour), StateFailed, IntegritySourceUnavailableAfterRetention, anchor, "", false, int64(0)).
+			AddRow(committed, int64(44), committed.Add(time.Hour), StateCommitted, nil, anchor, "", true, int64(0)).
+			AddRow(sourcePresent, int64(45), sourcePresent.Add(time.Hour), StatePending, nil, anchor, "", false, int64(1)))
+	mock.ExpectCommit()
+
+	plan, err := BuildGapDecisionDBPlan(context.Background(), db)
+	if err != nil {
+		t.Fatalf("BuildGapDecisionDBPlan() err=%v", err)
+	}
+	if !plan.DBUTCAnchor.Equal(anchor) || !plan.RetentionCutoff.Equal(anchor.Add(-24*time.Hour)) ||
+		!plan.ForwardCutover.WindowStart.Equal(cutoverStart) || !plan.LatestNormalWindowStart.Equal(anchor.Add(-time.Hour)) {
+		t.Fatalf("plan anchors=%+v", plan)
+	}
+	if len(plan.Windows) != 2 || !plan.Windows[0].WindowStart.Equal(missing) ||
+		plan.Windows[0].Control.Exists || plan.Windows[0].SourceRecordCount != 0 ||
+		!plan.Windows[1].WindowStart.Equal(pending) || plan.Windows[1].Control.ShardID != 42 ||
+		!plan.Windows[1].Control.WindowEnd.Equal(pending.Add(time.Hour)) ||
+		!plan.Windows[1].Control.UpdatedAt.Equal(pendingUpdatedAt) ||
+		plan.Windows[1].Control.SegmentFingerprint != "61:writing:2026-08-12T02:00:00.000000Z" {
+		t.Fatalf("plan windows=%+v", plan.Windows)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUS045_ApplyGapDecisionRejectsSourceOrControlDriftAtomically(t *testing.T) {
+	anchor := time.Date(2026, 8, 12, 5, 0, 0, 0, time.UTC)
+	window := time.Date(2026, 8, 8, 23, 0, 0, 0, time.UTC)
+	plan := testGapDecisionPlan(anchor, window)
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	mock.ExpectBegin()
+	mock.ExpectQuery("pg_try_advisory_xact_lock").
+		WithArgs(MaintenanceAdvisoryLockID).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(true))
+	mock.ExpectQuery("FROM qa_archive_gap_decision_receipts").
+		WithArgs(plan.PlanHash).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("date_trunc\\('hour', clock_timestamp\\(\\)\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"anchor", "latest_normal"}).AddRow(anchor, anchor.Add(-time.Hour)))
+	mock.ExpectQuery("WHERE forward_cutover=true").
+		WillReturnRows(sqlmock.NewRows([]string{"window_start", "window_end"}).
+			AddRow(plan.ForwardCutover.WindowStart, plan.ForwardCutover.WindowEnd))
+	mock.ExpectQuery("FROM qa_archive_shards").
+		WithArgs(window).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT count\\(\\*\\)").
+		WithArgs(window, window.Add(time.Hour)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+	mock.ExpectRollback()
+
+	_, err = ApplyGapDecisionPlan(context.Background(), db, plan, "feng")
+	if err == nil || !strings.Contains(err.Error(), "source row count drift") {
+		t.Fatalf("ApplyGapDecisionPlan() err=%v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUS045_ApplyGapDecisionRejectsSegmentFingerprintDrift(t *testing.T) {
+	anchor := time.Date(2026, 8, 12, 5, 0, 0, 0, time.UTC)
+	window := time.Date(2026, 8, 8, 23, 0, 0, 0, time.UTC)
+	plan := testGapDecisionPlan(anchor, window)
+	plan.Windows[0].Control = GapDecisionControl{
+		Exists: true, ShardID: 42, State: StatePending,
+		WindowEnd: window.Add(time.Hour), UpdatedAt: anchor.Add(-time.Hour), SegmentFingerprint: "",
+	}
+	plan.PlanHash, _ = HashGapDecisionPlan(plan)
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	mock.ExpectBegin()
+	mock.ExpectQuery("pg_try_advisory_xact_lock").WithArgs(MaintenanceAdvisoryLockID).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(true))
+	mock.ExpectQuery("FROM qa_archive_gap_decision_receipts").WithArgs(plan.PlanHash).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("date_trunc\\('hour', clock_timestamp\\(\\)\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"anchor", "latest_normal"}).AddRow(anchor, anchor.Add(-time.Hour)))
+	mock.ExpectQuery("WHERE forward_cutover=true").
+		WillReturnRows(sqlmock.NewRows([]string{"window_start", "window_end"}).
+			AddRow(plan.ForwardCutover.WindowStart, plan.ForwardCutover.WindowEnd))
+	mock.ExpectQuery("FROM qa_archive_shards").WithArgs(window).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "window_end", "state", "verification_error_code", "updated_at", "segment_fingerprint", "has_commit_ready_segment"}).
+			AddRow(int64(42), window.Add(time.Hour), StatePending, nil, anchor.Add(-time.Hour), "63:writing:2026-08-12T04:00:00.000000Z", false))
+	mock.ExpectRollback()
+
+	_, err = ApplyGapDecisionPlan(context.Background(), db, plan, "feng")
+	if err == nil || !strings.Contains(err.Error(), "control drift") {
+		t.Fatalf("ApplyGapDecisionPlan() err=%v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUS045_CompleteGapDecisionPlanExcludesHoursWithRecoveryCommit(t *testing.T) {
+	anchor := time.Date(2026, 8, 12, 5, 0, 0, 0, time.UTC)
+	first := time.Date(2026, 8, 8, 23, 0, 0, 0, time.UTC)
+	dbPlan := testGapDecisionPlan(anchor, first)
+	dbPlan.Region, dbPlan.Bucket, dbPlan.RecoveryRoleARN, dbPlan.RecoveryRunID, dbPlan.PlanHash = "", "", "", "", ""
+	second := dbPlan.Windows[0]
+	second.WindowStart = first.Add(time.Hour)
+	second.WindowEnd = second.WindowStart.Add(time.Hour)
+	second.CommitKey = ShardPrefix(second.WindowStart) + "/commit.json"
+	dbPlan.Windows = append(dbPlan.Windows, second)
+
+	plan, err := CompleteGapDecisionPlan(
+		dbPlan,
+		"us-east-1",
+		"tokenkey-prod-qa-raw-archive-123456789012",
+		"arn:aws:iam::123456789012:role/tokenkey-prod-qa-raw-recovery",
+		"recovery-head-batch-20260812T050000Z",
+		map[string]bool{
+			dbPlan.Windows[0].CommitKey: true,
+			dbPlan.Windows[1].CommitKey: false,
+		},
+	)
+	if err != nil {
+		t.Fatalf("CompleteGapDecisionPlan() err=%v", err)
+	}
+	if len(plan.Windows) != 1 || !plan.Windows[0].WindowStart.Equal(second.WindowStart) ||
+		!gapDecisionHashPattern.MatchString(plan.PlanHash) {
+		t.Fatalf("plan=%+v", plan)
+	}
+}
+
+func TestUS045_CompleteGapDecisionPlanFromRecoveryStoreBindsEveryHeadResult(t *testing.T) {
+	anchor := time.Date(2026, 8, 12, 5, 0, 0, 0, time.UTC)
+	window := time.Date(2026, 8, 8, 23, 0, 0, 0, time.UTC)
+	dbPlan := testGapDecisionPlan(anchor, window)
+	dbPlan.Region, dbPlan.Bucket, dbPlan.RecoveryRoleARN, dbPlan.RecoveryRunID, dbPlan.PlanHash = "", "", "", "", ""
+	store := NewMemoryObjectStore()
+
+	plan, err := CompleteGapDecisionPlanFromStore(
+		context.Background(), dbPlan, store,
+		"us-east-1", "tokenkey-prod-qa-raw-archive-123456789012",
+		"arn:aws:iam::123456789012:role/tokenkey-prod-qa-raw-recovery",
+		"recovery-head-batch-20260812T050000Z",
+	)
+	if err != nil {
+		t.Fatalf("CompleteGapDecisionPlanFromStore() err=%v", err)
+	}
+	if len(plan.Windows) != 1 || plan.Windows[0].CommitExists || plan.PlanHash == "" {
+		t.Fatalf("plan=%+v", plan)
+	}
+
+	dbPlan.PlanHash = ""
+	relativeKey := strings.TrimPrefix(dbPlan.Windows[0].CommitKey, RawV1Prefix+"/")
+	if err := store.Put(context.Background(), relativeKey, []byte(`{}`), "application/json"); err != nil {
+		t.Fatal(err)
+	}
+	_, err = CompleteGapDecisionPlanFromStore(
+		context.Background(), dbPlan, store,
+		"us-east-1", "tokenkey-prod-qa-raw-archive-123456789012",
+		"arn:aws:iam::123456789012:role/tokenkey-prod-qa-raw-recovery",
+		"recovery-head-batch-20260812T050000Z",
+	)
+	if err == nil || !strings.Contains(err.Error(), "no confirmed missing commit") {
+		t.Fatalf("CompleteGapDecisionPlanFromStore() err=%v", err)
+	}
+}
+
+func TestUS045_CompleteGapDecisionPlanRejectsInvalidTimelineBeforeRecoveryReads(t *testing.T) {
+	anchor := time.Date(2026, 8, 12, 5, 0, 0, 0, time.UTC)
+	validWindow := time.Date(2026, 8, 8, 23, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		mutate func(*GapDecisionPlan)
+	}{
+		{
+			name: "non UTC hour",
+			mutate: func(plan *GapDecisionPlan) {
+				plan.Windows[0].WindowStart = validWindow.Add(30 * time.Minute)
+				plan.Windows[0].WindowEnd = plan.Windows[0].WindowStart.Add(time.Hour)
+				plan.Windows[0].CommitKey = ShardPrefix(plan.Windows[0].WindowStart) + "/commit.json"
+			},
+		},
+		{
+			name: "before forward cutover end",
+			mutate: func(plan *GapDecisionPlan) {
+				plan.Windows[0].WindowStart = plan.ForwardCutover.WindowStart.Add(-time.Hour)
+				plan.Windows[0].WindowEnd = plan.Windows[0].WindowStart.Add(time.Hour)
+				plan.Windows[0].CommitKey = ShardPrefix(plan.Windows[0].WindowStart) + "/commit.json"
+			},
+		},
+		{
+			name: "existing control without bound window end",
+			mutate: func(plan *GapDecisionPlan) {
+				plan.Windows[0].Control = GapDecisionControl{
+					Exists: true, ShardID: 42, State: StatePending,
+					UpdatedAt: anchor.Add(-time.Hour), SegmentFingerprint: "",
+				}
+			},
+		},
+		{
+			name: "commit ready segment",
+			mutate: func(plan *GapDecisionPlan) {
+				plan.Windows[0].Control = GapDecisionControl{
+					Exists: true, ShardID: 42, State: StatePending,
+					WindowEnd:             plan.Windows[0].WindowEnd,
+					UpdatedAt:             anchor.Add(-time.Hour),
+					SegmentFingerprint:    "63:verified:2026-08-12T04:00:00.000000Z",
+					HasCommitReadySegment: true,
+				}
+			},
+		},
+		{
+			name: "control state and failure code conflict",
+			mutate: func(plan *GapDecisionPlan) {
+				plan.Windows[0].Control = GapDecisionControl{
+					Exists: true, ShardID: 42, WindowEnd: plan.Windows[0].WindowEnd,
+					State: StatePending, VerificationErrorCode: "archive_failed",
+					UpdatedAt: anchor.Add(-time.Hour), SegmentFingerprint: "",
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := testGapDecisionPlan(anchor, validWindow)
+			plan.Region, plan.Bucket, plan.RecoveryRoleARN, plan.RecoveryRunID, plan.PlanHash = "", "", "", "", ""
+			tt.mutate(&plan)
+			headCalls := 0
+			store := &headTrackingStore{inner: NewMemoryObjectStore(), headCalls: &headCalls}
+
+			_, err := CompleteGapDecisionPlanFromStore(
+				context.Background(), plan, store,
+				"us-east-1", "tokenkey-prod-qa-raw-archive-123456789012",
+				"arn:aws:iam::123456789012:role/tokenkey-prod-qa-raw-recovery",
+				"recovery-head-batch-20260812T050000Z",
+			)
+			if err == nil {
+				t.Fatal("CompleteGapDecisionPlanFromStore() accepted an invalid database plan")
+			}
+			if headCalls != 0 {
+				t.Fatalf("recovery store was read %d times before database plan validation", headCalls)
+			}
+		})
+	}
+}
+
+func TestUS045_GapDecisionCanonicalHashMatchesOperatorVector(t *testing.T) {
+	plan := testGapDecisionPlan(
+		time.Date(2026, 8, 12, 5, 0, 0, 0, time.UTC),
+		time.Date(2026, 8, 8, 23, 0, 0, 0, time.UTC),
+	)
+	const want = "c81fc61fe234f8364f59e09d5121f1389a6507a4cc755d4aae7182f4f252ab21"
+	if plan.PlanHash != want {
+		t.Fatalf("HashGapDecisionPlan()=%s want=%s", plan.PlanHash, want)
+	}
+}
+
+func TestUS045_ApplyGapDecisionRejectsPlanHashTamperingBeforeDatabase(t *testing.T) {
+	anchor := time.Date(2026, 8, 12, 5, 0, 0, 0, time.UTC)
+	plan := testGapDecisionPlan(anchor, time.Date(2026, 8, 8, 23, 0, 0, 0, time.UTC))
+	plan.RecoveryRunID = "reviewed-evidence"
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	_, err = ApplyGapDecisionPlan(context.Background(), db, plan, "feng")
+	if err == nil || !strings.Contains(err.Error(), "plan hash drift") {
+		t.Fatalf("ApplyGapDecisionPlan() err=%v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUS045_ApplyGapDecisionPersistsTerminalRowsAndApprovalReceiptInOneTransaction(t *testing.T) {
+	anchor := time.Date(2026, 8, 12, 5, 0, 0, 0, time.UTC)
+	window := time.Date(2026, 8, 8, 23, 0, 0, 0, time.UTC)
+	appliedAt := time.Date(2026, 8, 12, 5, 42, 0, 0, time.UTC)
+	plan := testGapDecisionPlan(anchor, window)
+	encodedPlan, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encodedPlan, &plan); err != nil {
+		t.Fatal(err)
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	mock.ExpectBegin()
+	mock.ExpectQuery("pg_try_advisory_xact_lock").
+		WithArgs(MaintenanceAdvisoryLockID).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(true))
+	mock.ExpectQuery("FROM qa_archive_gap_decision_receipts").
+		WithArgs(plan.PlanHash).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("date_trunc\\('hour', clock_timestamp\\(\\)\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"anchor", "latest_normal"}).AddRow(anchor, anchor.Add(-time.Hour)))
+	mock.ExpectQuery("WHERE forward_cutover=true").
+		WillReturnRows(sqlmock.NewRows([]string{"window_start", "window_end"}).
+			AddRow(plan.ForwardCutover.WindowStart, plan.ForwardCutover.WindowEnd))
+	mock.ExpectQuery("FROM qa_archive_shards").
+		WithArgs(window).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT count\\(\\*\\)").
+		WithArgs(window, window.Add(time.Hour)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
+	mock.ExpectExec("INSERT INTO qa_archive_shards").
+		WithArgs(window, window.Add(time.Hour), StatePending, ShardPrefix(window)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT id, state, verification_error_code, restore_verified_at").
+		WithArgs(window).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "verification_error_code", "restore_verified_at"}).
+			AddRow(int64(51), StatePending, nil, nil))
+	mock.ExpectExec("UPDATE qa_archive_shards SET").
+		WithArgs(StateFailed, IntegritySourceUnavailableAfterRetention, int64(51)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("INSERT INTO qa_archive_gap_decision_receipts").
+		WithArgs(plan.PlanHash, GapDecisionPlanSchemaVersion, sqlmock.AnyArg(), "feng", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"applied_at"}).AddRow(appliedAt))
+	mock.ExpectCommit()
+
+	receipt, err := ApplyGapDecisionPlan(context.Background(), db, plan, "feng")
+	if err != nil {
+		t.Fatalf("ApplyGapDecisionPlan() err=%v", err)
+	}
+	if receipt.PlanHash != plan.PlanHash || receipt.WindowCount != 1 || receipt.AlreadyApplied ||
+		!receipt.AppliedAt.Equal(appliedAt) {
+		t.Fatalf("receipt=%+v", receipt)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testGapDecisionPlan(anchor, window time.Time) GapDecisionPlan {
+	plan := GapDecisionPlan{
+		SchemaVersion:           GapDecisionPlanSchemaVersion,
+		DBUTCAnchor:             anchor,
+		RetentionCutoff:         anchor.Add(-24 * time.Hour),
+		ForwardCutover:          GapDecisionAnchor{WindowStart: time.Date(2026, 8, 7, 21, 0, 0, 0, time.UTC), WindowEnd: time.Date(2026, 8, 7, 22, 0, 0, 0, time.UTC)},
+		LatestNormalWindowStart: anchor.Add(-time.Hour),
+		Region:                  "us-east-1",
+		Bucket:                  "tokenkey-prod-qa-raw-archive-123456789012",
+		RecoveryRoleARN:         "arn:aws:iam::123456789012:role/tokenkey-prod-qa-raw-recovery",
+		RecoveryRunID:           "recovery-head-batch-20260812T050000Z",
+		Windows: []GapDecisionWindow{{
+			WindowStart: window, WindowEnd: window.Add(time.Hour),
+			CommitKey: ShardPrefix(window) + "/commit.json", CommitExists: false,
+			SourceRecordCount: 0, Control: GapDecisionControl{},
+		}},
+	}
+	hash, err := HashGapDecisionPlan(plan)
+	if err != nil {
+		panic(err)
+	}
+	plan.PlanHash = hash
+	return plan
+}

--- a/backend/migrations/tk_075_qa_archive_gap_decision_receipts.sql
+++ b/backend/migrations/tk_075_qa_archive_gap_decision_receipts.sql
@@ -1,0 +1,32 @@
+-- TK: immutable approval receipts for hash-bound QA archive gap decisions.
+-- Window outcome remains owned exclusively by qa_archive_shards.
+CREATE TABLE IF NOT EXISTS qa_archive_gap_decision_receipts (
+    plan_hash text PRIMARY KEY CHECK (plan_hash ~ '^[0-9a-f]{64}$'),
+    plan_schema_version text NOT NULL CHECK (plan_schema_version = 'qa-archive-gap-decision-v1'),
+    plan_json jsonb NOT NULL,
+    approved_by text NOT NULL CHECK (btrim(approved_by) <> ''),
+    window_count integer NOT NULL CHECK (window_count > 0),
+    applied_at timestamptz NOT NULL DEFAULT now(),
+    CHECK (plan_json->>'plan_hash' = plan_hash),
+    CHECK (plan_json->>'schema_version' = plan_schema_version),
+    CHECK (jsonb_array_length(plan_json->'windows') = window_count)
+);
+
+CREATE OR REPLACE FUNCTION tk_qa_archive_gap_decision_receipts_immutable()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'qa_archive_gap_decision_receipts are append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_qa_archive_gap_decision_receipts_immutable
+    ON qa_archive_gap_decision_receipts;
+CREATE TRIGGER trg_qa_archive_gap_decision_receipts_immutable
+BEFORE UPDATE OR DELETE ON qa_archive_gap_decision_receipts
+FOR EACH ROW EXECUTE FUNCTION tk_qa_archive_gap_decision_receipts_immutable();
+
+DROP TRIGGER IF EXISTS trg_qa_archive_gap_decision_receipts_no_truncate
+    ON qa_archive_gap_decision_receipts;
+CREATE TRIGGER trg_qa_archive_gap_decision_receipts_no_truncate
+BEFORE TRUNCATE ON qa_archive_gap_decision_receipts
+FOR EACH STATEMENT EXECUTE FUNCTION tk_qa_archive_gap_decision_receipts_immutable();

--- a/docs/approved/design-qa-phase2-archive-closeout.md
+++ b/docs/approved/design-qa-phase2-archive-closeout.md
@@ -3,7 +3,7 @@ title: QA Phase 2 Archive Closeout
 status: approved
 approved_by: "feng (conversation approvals 2026-08-07 through 2026-08-11; UTC-hour partition lifecycle and no-rehome cutover 2026-08-11)"
 date: 2026-08-07
-last_reviewed: 2026-08-11
+last_reviewed: 2026-08-12
 supersedes: null
 related:
   - docs/approved/design-prod-qa-24h-s3-lifecycle.md
@@ -96,8 +96,10 @@ artifact installation, self-test, or owner-state verification fails.
    phase may remove only an expired, catalog-validated UTC-hour partition and its exact
    matching hot-file directories under the lifecycle rules below.
 2. A shard with missing or corrupt evidence is not committed and is not cleanup eligible.
-3. `confirmed gap` requires a separate immutable approval receipt. Detection alone never
-   creates that receipt, and this rollout creates no confirmed-gap receipt.
+3. `confirmed gap` requires a separate immutable approval receipt. Detection and plan
+   generation never create that receipt. Only an exact hash-bound batch apply, after
+   explicit human approval, may create it and the matching terminal shard facts in one
+   database transaction.
 4. Once a base segment is referenced by a commit, late records create delta segments;
    they never replace or rewrite the base segment.
 5. S3 `commit.json` is the reader marker. A segment is invisible until an ETag-guarded
@@ -145,8 +147,8 @@ uses `accepted_terminal`:
   `healthy`. Any contradiction across the four sources is `failed` (fail closed).
 - **Rollout stop vs degraded:** `accepted_terminal` does **not** treat an already-terminal
   historical gap such as `2026-08-07 22:00 UTC` as a blocker for forward scheduled runs
-  once facts correlate. A **new** gap discovered during closeout still requires a separate
-  immutable gap decision before compensation can be retried; until then rollout remains
+  once facts correlate. A **new** gap discovered during closeout still requires the batch
+  decision below before compensation can skip it; until then rollout remains
   `observed_live_state: pending_live_reconciliation`.
 - **`strict` alternative:** inventory presence or any terminal gap fails correlated health
   and blocks rollout observation gates.
@@ -227,6 +229,32 @@ Do not create a parallel `qa_archive_gaps` vocabulary or a second cleanup-contro
 The hourly shard row is the control owner for both archive outcome and hot-source removal.
 Missing/corrupt evidence remains represented by shard verification failure and
 `cleanup_eligible=false`; cleanup eligibility does not grant or deny time-based retention.
+
+`qa_archive_gap_decision_receipts` is an append-only approval ledger, not a second gap
+state machine. It stores the canonical plan JSON, SHA-256, approver, window count, and apply
+time. Updates and deletes are rejected by schema trigger. Per-hour outcome remains only in
+`qa_archive_shards`; no receipt grants cleanup, DROP, rehome, copy, move, or S3 mutation.
+
+The batch plan is eligible only for exact UTC hours strictly after `forward_cutover`, before
+the latest committed normal window, and older than the database-derived 24-hour retention
+cutoff. Each hour must have zero live `qa_records`, a non-committed/non-terminal control
+fact, and no `commit.json` as observed through the dedicated workstation recovery role.
+The canonical hash binds the database UTC-hour anchor, retention cutoff, cutover, latest
+normal window, exact ordered windows, source counts, shard state/code/update time, segment
+fingerprint, stored shard window end, whether any segment is commit-ready, bucket,
+recovery-role ARN, recovery run ID, and every S3 absence result. A window with a
+`verified`/`committed` segment or contradictory shard state/error code is ineligible.
+
+Apply requires `tokenkey-prod-qa-gap-decision-v1:<plan_hash>` and an explicit approver.
+Under the shared `QAMA` transaction lock it rechecks the same database hour anchor, cutoff,
+cutover, latest normal, source counts, shard control, and segment fingerprint. Any drift
+rejects the whole batch. Because commit creation requires a commit-ready segment, binding
+that fact plus the segment fingerprint and shard update time closes the plan/apply race
+without an S3 read during apply. For each still-valid hour it uses the existing archive control
+owner to persist `failed/source_unavailable_after_retention`, then inserts the approval
+receipt in the same transaction. S3 is not read or written during apply; the reviewed
+recovery-role absence facts are immutable plan evidence. Repeating the identical applied
+hash is idempotent; a different or stale plan requires a new plan and approval.
 
 At `*:00`, the lifecycle boundary phase locks the QA lifecycle, resolves the exact expired
 hour from database time, and validates the child bound through the PostgreSQL catalog. If
@@ -351,6 +379,14 @@ Use the repo-owned Go CLI under `backend/cmd/qa-archive` for recovery reads:
 - `restore`: reconstruct records and evidence into an explicit local isolated directory;
 - `repair-plan`: remain a no-write diagnostic comparing control state, S3 commit, and
   current source identities.
+- `gap-decision-db-plan`: under the shared `QAMA` lock, emit the read-only database half
+  of one batch plan; it accepts no arbitrary window selector.
+- `gap-decision-s3-plan`: on an ops workstation, assume the dedicated recovery role,
+  HEAD every candidate commit, exclude any existing commit, and emit the canonical plan
+  and required SHA-256 confirmation.
+- `gap-decision-apply`: on the production host runner, consume only the complete plan,
+  exact plan-hash confirmation, and approver; atomically persist terminal shard facts and
+  the append-only receipt after database revalidation.
 
 `inspect`, `verify`, and `restore` gain an ops-workstation mode that assumes the dedicated
 recovery role and reads a specified S3 window directly, without prod SSH/SSM, API,
@@ -372,6 +408,16 @@ requires exact expected window/bucket/role values and a separate unexpired human
 approval record hash-bound to the evidence bytes and issued after the final receipt. The
 production receipts expire from this gate after 24 hours; changing a scope label or copying
 one command receipt cannot claim production success.
+
+`ops/qa/prod_qa_archive_closeout.py gap-plan` orchestrates the host database plan and the
+target-tag workstation binary's recovery-role S3 plan, then writes a mode-0600 plan file
+atomically. `gap-apply` requires a distinct receipt path and writes it atomically only after
+the remote receipt matches the reviewed hash, approver, and window count. Plan generation
+does not classify a gap; production apply remains a separate high-risk approval gate.
+The host DB-plan receipt and apply command transport only bounded `gzip+base64` plan bytes;
+raw plan JSON is never emitted into SSM stdout or embedded in the remote command. Both ends
+enforce the same compressed and decompressed limits before parsing, and the canonical hash
+continues to cover the uncompressed plan facts rather than transport bytes.
 
 After an independent workstation verify/restore succeeds, retire the transitional
 prod QA break-glass dump tooling. Before that gate it remained manual read-only break-glass and was not
@@ -716,25 +762,29 @@ phase remains disabled. No rollout step copies or moves source data.
    compensation attempt, and request a separate gap decision. Under `accepted_terminal`, an
    already-terminal 22:00 hour recorded in control rows does not block forward runs once
    the four-source health probe correlates; contradictory facts fail closed.
-7. From an ops workstation, assume the recovery role and verify/restore S3 directly; after
+7. For any remaining expired zero-source hours without recovery-role-visible commits,
+   generate one hash-bound batch plan. Review its exact windows and hash, then request a
+   separate high-risk approval before `gap-apply`. A changed database hour, source/control
+   fact, segment fingerprint, cutover, or latest normal rejects the entire batch.
+8. From an ops workstation, assume the recovery role and verify/restore S3 directly; after
    success retire the transitional prod QA break-glass dump tooling.
-8. Enable the `*:15` archive timer and observe at least two consecutive regular scheduled
+9. Enable the `*:15` archive timer and observe at least two consecutive regular scheduled
    runs while correlating systemd, host receipt, DB heartbeat/control, DB latency, WAL,
    scratch, RSS, CPU, and S3 objects.
-9. Apply the IAM tightening as the final CloudFormation change set and run an archive
+10. Apply the IAM tightening as the final CloudFormation change set and run an archive
    canary. On failure stop maintenance and restore the previous IAM policy; the pre-finalize
    legacy cutover drain remains active. A durable finalize receipt permanently closes it.
-10. Produce a read-only hourly-cutover inventory: exact child bounds, row counts by child
+11. Produce a read-only hourly-cutover inventory: exact child bounds, row counts by child
     and hour, future timestamps, overlapping monthly children, current/future coverage,
     DEFAULT age, and legacy blob/DLQ/export paths. Bind the decision-bearing inventory facts and chosen future
     `T0` to a separate high-risk approval.
-11. Under that approval, remove only empty overlapping monthly children and provision
+12. Under that approval, remove only empty overlapping monthly children and provision
     `[T0,T0+72h)`. Set the immutable application cutover hour to `T0`; PostgreSQL routes
     new rows and the capture writer uses hourly file paths from that boundary.
-12. Keep legacy age cleanup active for at least 25 hours. Abort if DEFAULT grows after
+13. Keep legacy age cleanup active for at least 25 hours. Abort if DEFAULT grows after
     `T0`, the current-hour child is missing, or archive/cleanup evidence contradicts. The
     initial activation horizon may decay during this drain; the boundary timer remains disabled.
-13. Through the boundary host runner, run `--qa-cutover-provision-only` with exact confirmation
+14. Through the boundary host runner, run `--qa-cutover-provision-only` with exact confirmation
     `tokenkey-prod-qa-cutover-provision-v1`. It requires the activate receipt, database time at
     or after T0, no finalize receipt, and provisions current-plus-72-hour coverage under the
     shared lock without DROP or cleanup. Then require fresh successful archive host receipt and
@@ -743,12 +793,12 @@ phase remains disabled. No rollout step copies or moves source data.
     legacy blob/DLQ files drained, the exact empty-monthly hash-bound set, and 72-hour coverage
     before atomically removing that monthly set plus DEFAULT and persisting the append-only
     finalize receipt.
-14. The owner-switch SSM workflow must read that durable finalize receipt before disabling
+15. The owner-switch SSM workflow must read that durable finalize receipt before disabling
     legacy DB/blob/DLQ cleanup and enabling the no-random-delay `*:00` boundary timer. If any
     enable/verification step fails, it keeps legacy disabled, best-effort leaves boundary enabled,
     and exits nonzero for hard intervention; finalized legacy cleanup is never a valid fallback.
     Export-orphan cleanup remains under the boundary runner.
-15. Observe the archive and boundary phases for at least 26 hours, including one real partition DROP,
+16. Observe the archive and boundary phases for at least 26 hours, including one real partition DROP,
     blob/DLQ directory cleanup, archive success or durable gap classification, and continuous
     future provisioning. Only then may rollout report the hourly lifecycle complete.
 

--- a/ops/qa/README.md
+++ b/ops/qa/README.md
@@ -15,6 +15,7 @@ Policy 数值不在此重复。Owner 表：
 | Cutover drain-only legacy cleanup | [`tokenkey-qa-stale-cleanup.sh`](../../deploy/aws/stage0/tokenkey-qa-stale-cleanup.sh) |
 | Direct workstation recovery | [`backend/cmd/qa-archive`](../../backend/cmd/qa-archive) |
 | Break-glass retirement evidence gate | [`qa_archive_recovery_gate.py`](qa_archive_recovery_gate.py) |
+| Hash-bound expired-gap operator | [`prod_qa_archive_closeout.py`](prod_qa_archive_closeout.py) |
 
 Generic usage/ops data-layer archive: [`ops/archive/README.md`](../archive/README.md).
 
@@ -87,3 +88,33 @@ receipt bundle. Production receipts must be no older than 24 hours and the appro
 postdate the final receipt. Break-glass prod QA dump tooling is retired after
 production workstation recovery evidence passes the gate. Gateway and maintenance still share the EC2 instance role, so the
 current bucket policy is not process-level isolation.
+
+Expired zero-source archive gaps use one batch path in the same operator; there is no
+arbitrary-window apply or second catch-up executable:
+
+```bash
+python3 ops/qa/prod_qa_archive_closeout.py gap-plan \
+  --output /tmp/qa-gap-plan.json \
+  --qa-archive-bin /path/to/target-tag/qa-archive \
+  --recovery-run-id gap-YYYYMMDDTHHMMSSZ
+
+python3 ops/qa/prod_qa_archive_closeout.py gap-apply \
+  --plan /tmp/qa-gap-plan.json \
+  --receipt-output /tmp/qa-gap-receipt.json \
+  --confirm tokenkey-prod-qa-gap-decision-v1:<plan_hash> \
+  --approved-by <approver>
+```
+
+`gap-plan` is read-only: the host emits database facts under `QAMA`, then the explicit
+target-tag workstation binary assumes the dedicated recovery role and HEADs each candidate
+`commit.json`. The SHA-256 binds DB anchors, exact windows, control/segment fingerprints,
+bucket/role/recovery-run identity, source count, and S3 absence. `gap-apply` is a separate
+high-risk approval gate; it revalidates all database facts under `QAMA`, writes only
+`failed/source_unavailable_after_retention` through the existing shard owner, and inserts
+the append-only approval receipt in the same transaction. It never reads or writes S3,
+deletes hot data, moves/copies rows, or changes timers.
+
+The host DB plan and apply command use bounded `gzip+base64` transport so a large historical
+batch cannot be silently truncated by SSM. The operator and Go CLI reject transport or
+decompressed-plan overflow before parsing; the reviewed SHA-256 still binds canonical
+uncompressed JSON.

--- a/ops/qa/prod_qa_archive_closeout.py
+++ b/ops/qa/prod_qa_archive_closeout.py
@@ -4,22 +4,35 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import datetime as dt
+import gzip
+import hashlib
+import io
 import json
+import os
 import pathlib
+import re
 import shlex
 import subprocess
 import sys
+import tempfile
 import time
 from typing import Any
 
 PROD_REGION = "us-east-1"
 PROD_STACK = "tokenkey-prod-stage0"
+RAW_ARCHIVE_STACK = "tokenkey-prod-qa-raw-archive"
 HOST_RUNNER = "/usr/local/bin/tokenkey-qa-maintenance.sh"
 RESTORE_CONFIRMATION_PREFIX = "tokenkey-prod-qa-archive-restore-v1"
+GAP_CONFIRMATION_PREFIX = "tokenkey-prod-qa-gap-decision-v1:"
+GAP_PLAN_SCHEMA = "qa-archive-gap-decision-v1"
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
 READ_COMMANDS = {"inspect", "verify", "repair-plan"}
 POLL_ATTEMPTS = 100
 POLL_INTERVAL_SECONDS = 3
+MAX_GAP_PLAN_BYTES = 8 << 20
+MAX_GAP_TRANSPORT_CHARS = 18000
 
 
 class QAArchiveCloseoutError(RuntimeError):
@@ -84,6 +97,299 @@ def _resolve_instance() -> str:
             if isinstance(value, str) and value.startswith("i-"):
                 return value
     raise QAArchiveCloseoutError("prod InstanceId missing")
+
+
+def _resolve_recovery_scope() -> tuple[str, str]:
+    payload = _aws_json([
+        "aws", "cloudformation", "describe-stacks", "--region", PROD_REGION,
+        "--stack-name", RAW_ARCHIVE_STACK, "--output", "json",
+    ])
+    stacks = payload.get("Stacks")
+    if not isinstance(stacks, list) or not stacks:
+        raise QAArchiveCloseoutError("raw archive stack missing")
+    outputs = {
+        item.get("OutputKey"): item.get("OutputValue")
+        for item in stacks[0].get("Outputs", [])
+        if isinstance(item, dict)
+    }
+    bucket = outputs.get("QaRawArchiveBucketName")
+    role = outputs.get("QaRawArchiveRecoveryRoleArn")
+    if not isinstance(bucket, str) or not bucket or not isinstance(role, str) or not role.startswith("arn:aws:iam::"):
+        raise QAArchiveCloseoutError("raw archive recovery outputs missing")
+    return bucket, role
+
+
+def _atomic_json(path: pathlib.Path, value: dict[str, Any]) -> None:
+    path = path.expanduser().resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        pathlib.Path(temporary).replace(path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except Exception:
+        pathlib.Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+def _parse_last_json(stdout: str) -> dict[str, Any]:
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        raise QAArchiveCloseoutError("remote command returned no receipt")
+    try:
+        value = json.loads(lines[-1])
+    except json.JSONDecodeError as exc:
+        raise QAArchiveCloseoutError("remote receipt is invalid JSON") from exc
+    if not isinstance(value, dict):
+        raise QAArchiveCloseoutError("remote receipt is not an object")
+    return value
+
+
+def _send_remote(instance_id: str, comment: str, remote: str) -> dict[str, Any]:
+    payload = _aws_json([
+        "aws", "ssm", "send-command", "--region", PROD_REGION,
+        "--instance-ids", instance_id, "--document-name", "AWS-RunShellScript",
+        "--comment", comment,
+        "--parameters", json.dumps({"commands": [remote]}, separators=(",", ":")),
+        "--output", "json",
+    ])
+    command_id = str(payload.get("Command", {}).get("CommandId", ""))
+    if not command_id:
+        raise QAArchiveCloseoutError("SSM command id missing")
+    return {
+        "command_id": command_id,
+        "stdout": _poll(command_id, instance_id),
+    }
+
+
+def _validate_gap_plan(value: Any) -> dict[str, Any]:
+    if (
+        not isinstance(value, dict)
+        or value.get("schema_version") != GAP_PLAN_SCHEMA
+        or SHA256_RE.fullmatch(str(value.get("plan_hash", ""))) is None
+        or not isinstance(value.get("windows"), list)
+        or not value["windows"]
+        or not isinstance(value.get("region"), str)
+        or not value["region"]
+        or not isinstance(value.get("bucket"), str)
+        or not value["bucket"]
+        or not str(value.get("recovery_role_arn", "")).startswith("arn:aws:iam::")
+        or not isinstance(value.get("recovery_run_id"), str)
+        or not value["recovery_run_id"]
+    ):
+        raise QAArchiveCloseoutError("gap decision plan failed validation")
+    for window in value["windows"]:
+        if (
+            not isinstance(window, dict)
+            or window.get("commit_exists") is not False
+            or window.get("source_record_count") != 0
+            or not str(window.get("commit_key", "")).startswith("raw/v1/date=")
+        ):
+            raise QAArchiveCloseoutError("gap decision window failed validation")
+    canonical = dict(value)
+    canonical["plan_hash"] = ""
+    encoded = json.dumps(
+        canonical, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode()
+    if hashlib.sha256(encoded).hexdigest() != value["plan_hash"]:
+        raise QAArchiveCloseoutError("gap decision canonical hash mismatch")
+    return value
+
+
+def _load_gap_plan(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.expanduser().resolve().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise QAArchiveCloseoutError("gap decision plan cannot be read") from exc
+    return _validate_gap_plan(value)
+
+
+def _encode_plan_transport(value: dict[str, Any]) -> str:
+    raw = json.dumps(
+        value, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode()
+    if len(raw) > MAX_GAP_PLAN_BYTES:
+        raise QAArchiveCloseoutError("gap decision plan exceeds decompressed size limit")
+    encoded = base64.b64encode(gzip.compress(raw, mtime=0)).decode()
+    if len(encoded) > MAX_GAP_TRANSPORT_CHARS:
+        raise QAArchiveCloseoutError("gap decision plan exceeds SSM transport limit")
+    return encoded
+
+
+def _decode_plan_transport(encoded: Any, expected_bytes: Any) -> dict[str, Any]:
+    if not isinstance(encoded, str) or not encoded or len(encoded) > MAX_GAP_TRANSPORT_CHARS:
+        raise QAArchiveCloseoutError("database gap plan transport is invalid")
+    try:
+        compressed = base64.b64decode(encoded, validate=True)
+        with gzip.GzipFile(fileobj=io.BytesIO(compressed)) as handle:
+            raw = handle.read(MAX_GAP_PLAN_BYTES + 1)
+    except (ValueError, OSError) as exc:
+        raise QAArchiveCloseoutError("database gap plan transport is invalid") from exc
+    if len(raw) > MAX_GAP_PLAN_BYTES:
+        raise QAArchiveCloseoutError("database gap plan exceeds decompressed size limit")
+    if not isinstance(expected_bytes, int) or expected_bytes != len(raw):
+        raise QAArchiveCloseoutError("database gap plan length mismatch")
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise QAArchiveCloseoutError("database gap plan is invalid JSON") from exc
+    if not isinstance(value, dict):
+        raise QAArchiveCloseoutError("database gap plan is not an object")
+    return value
+
+
+def _run_gap_db_plan(instance_id: str) -> dict[str, Any]:
+    result = _send_remote(
+        instance_id,
+        "TokenKey QA gap decision database plan",
+        "sudo " + shlex.join([HOST_RUNNER, "--qa-archive", "gap-decision-db-plan"]),
+    )
+    receipt = _parse_last_json(str(result["stdout"]))
+    plan = _decode_plan_transport(
+        receipt.get("plan_gzip_base64"), receipt.get("plan_uncompressed_bytes")
+    )
+    if (
+        receipt.get("ok") is not True
+        or receipt.get("command") != "gap-decision-db-plan"
+        or receipt.get("deletion_authorized") is not False
+        or receipt.get("cleanup_eligible") is not False
+        or not isinstance(plan, dict)
+        or receipt.get("window_count") != len(plan.get("windows", []))
+        or plan.get("schema_version") != GAP_PLAN_SCHEMA
+        or plan.get("plan_hash") not in {"", None}
+        or not isinstance(plan.get("windows"), list)
+        or not plan["windows"]
+    ):
+        raise QAArchiveCloseoutError("database gap plan failed validation")
+    return plan
+
+
+def _run_gap_s3_plan(
+    qa_archive_bin: str,
+    db_plan: dict[str, Any],
+    bucket: str,
+    recovery_role_arn: str,
+    recovery_run_id: str,
+) -> dict[str, Any]:
+    binary = pathlib.Path(qa_archive_bin).expanduser().resolve()
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        raise QAArchiveCloseoutError("executable target-tag qa-archive binary is required")
+    encoded = _encode_plan_transport(db_plan)
+    completed = subprocess.run(
+        [
+            str(binary), "gap-decision-s3-plan", "--db-plan-gzip-base64", encoded,
+            "--region", PROD_REGION, "--bucket", bucket,
+            "--recovery-role-arn", recovery_role_arn,
+            "--recovery-run-id", recovery_run_id,
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    if completed.returncode != 0:
+        raise QAArchiveCloseoutError((completed.stderr or completed.stdout or "gap S3 plan failed").strip()[:600])
+    receipt = _parse_last_json(completed.stdout)
+    if (
+        receipt.get("ok") is not True
+        or receipt.get("command") != "gap-decision-s3-plan"
+        or receipt.get("deletion_authorized") is not False
+        or receipt.get("cleanup_eligible") is not False
+    ):
+        raise QAArchiveCloseoutError("S3 gap plan receipt failed validation")
+    return _validate_gap_plan(receipt.get("plan"))
+
+
+def build_gap_decision_plan(
+    output_path: pathlib.Path,
+    *,
+    qa_archive_bin: str,
+    recovery_run_id: str,
+) -> dict[str, Any]:
+    if not recovery_run_id or len(recovery_run_id) > 128 or re.fullmatch(r"[A-Za-z0-9_.-]+", recovery_run_id) is None:
+        raise QAArchiveCloseoutError("safe recovery run id is required")
+    if output_path.expanduser().exists():
+        raise QAArchiveCloseoutError("gap decision plan path already exists")
+    instance_id = _resolve_instance()
+    bucket, role = _resolve_recovery_scope()
+    db_plan = _run_gap_db_plan(instance_id)
+    plan = _run_gap_s3_plan(qa_archive_bin, db_plan, bucket, role, recovery_run_id)
+    _atomic_json(output_path, plan)
+    return plan
+
+
+def _run_gap_apply(
+    instance_id: str,
+    plan: dict[str, Any],
+    plan_hash: str,
+    approved_by: str,
+) -> dict[str, Any]:
+    encoded = _encode_plan_transport(plan)
+    if len(encoded) > MAX_GAP_TRANSPORT_CHARS:
+        raise QAArchiveCloseoutError("gap decision plan exceeds SSM transport limit")
+    remote = "sudo " + shlex.join([
+        HOST_RUNNER, "--qa-archive", "gap-decision-apply",
+        "--plan-gzip-base64", encoded,
+        "--confirm", GAP_CONFIRMATION_PREFIX + plan_hash,
+        "--approved-by", approved_by,
+    ])
+    result = _send_remote(instance_id, "TokenKey QA approved gap decision apply", remote)
+    receipt = _parse_last_json(str(result["stdout"]))
+    already_applied = receipt.get("already_applied")
+    receipt_approver = receipt.get("approved_by")
+    if (
+        receipt.get("ok") is not True
+        or receipt.get("command") != "gap-decision-apply"
+        or receipt.get("plan_hash") != plan_hash
+        or not isinstance(already_applied, bool)
+        or not isinstance(receipt_approver, str)
+        or not receipt_approver.strip()
+        or (not already_applied and receipt_approver != approved_by)
+        or receipt.get("window_count") != len(plan["windows"])
+        or receipt.get("deletion_authorized") is not False
+        or receipt.get("cleanup_eligible") is not False
+    ):
+        raise QAArchiveCloseoutError("gap decision apply receipt failed validation")
+    return {"command_id": result["command_id"], "remote_receipt": receipt}
+
+
+def apply_gap_decision_plan(
+    plan_path: pathlib.Path,
+    receipt_path: pathlib.Path,
+    *,
+    confirmation: str,
+    approved_by: str,
+) -> dict[str, Any]:
+    if receipt_path.expanduser().exists():
+        raise QAArchiveCloseoutError("gap decision receipt path already exists")
+    try:
+        raw = json.loads(plan_path.expanduser().resolve().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise QAArchiveCloseoutError("gap decision plan cannot be read") from exc
+    plan_hash = str(raw.get("plan_hash", "")) if isinstance(raw, dict) else ""
+    if confirmation != GAP_CONFIRMATION_PREFIX + plan_hash or SHA256_RE.fullmatch(plan_hash) is None:
+        raise QAArchiveCloseoutError("gap decision confirmation mismatch")
+    if not approved_by or len(approved_by) > 128 or re.fullmatch(r"[A-Za-z0-9_.@ -]+", approved_by) is None:
+        raise QAArchiveCloseoutError("safe approved-by identity is required")
+    plan = _validate_gap_plan(raw)
+    instance_id = _resolve_instance()
+    result = _run_gap_apply(instance_id, plan, plan_hash, approved_by)
+    payload = {
+        "mode": "prod_qa_archive_gap_decision_apply",
+        "instance_id": instance_id,
+        "plan_hash": plan_hash,
+        **result,
+        "cleanup_eligible": False,
+        "deletion_authorized": False,
+    }
+    _atomic_json(receipt_path, payload)
+    return payload
 
 
 def _remote_command(command: str, window: dt.datetime, output: str, confirm: str) -> str:
@@ -159,13 +465,43 @@ def run(command: str, window_text: str, *, output: str = "", confirm: str = "") 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("command", choices=sorted(READ_COMMANDS | {"restore"}))
-    parser.add_argument("--window-start", required=True)
-    parser.add_argument("--output", default="")
-    parser.add_argument("--confirm", default="")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in sorted(READ_COMMANDS | {"restore"}):
+        child = subparsers.add_parser(command)
+        child.add_argument("--window-start", required=True)
+        child.add_argument("--output", default="")
+        child.add_argument("--confirm", default="")
+    gap_plan = subparsers.add_parser("gap-plan")
+    gap_plan.add_argument("--output", required=True, type=pathlib.Path)
+    gap_plan.add_argument("--qa-archive-bin", required=True)
+    gap_plan.add_argument("--recovery-run-id", required=True)
+    gap_apply = subparsers.add_parser("gap-apply")
+    gap_apply.add_argument("--plan", required=True, type=pathlib.Path)
+    gap_apply.add_argument("--receipt-output", required=True, type=pathlib.Path)
+    gap_apply.add_argument("--confirm", required=True)
+    gap_apply.add_argument("--approved-by", required=True)
     args = parser.parse_args()
     try:
-        result = run(args.command, args.window_start, output=args.output, confirm=args.confirm)
+        if args.command == "gap-plan":
+            result = build_gap_decision_plan(
+                args.output,
+                qa_archive_bin=args.qa_archive_bin,
+                recovery_run_id=args.recovery_run_id,
+            )
+        elif args.command == "gap-apply":
+            result = apply_gap_decision_plan(
+                args.plan,
+                args.receipt_output,
+                confirmation=args.confirm,
+                approved_by=args.approved_by,
+            )
+        else:
+            result = run(
+                args.command,
+                args.window_start,
+                output=args.output,
+                confirm=args.confirm,
+            )
     except QAArchiveCloseoutError as exc:
         print(f"qa archive closeout refused: {exc}", file=sys.stderr)
         return 2

--- a/ops/qa/test_prod_qa_archive_closeout.py
+++ b/ops/qa/test_prod_qa_archive_closeout.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import hashlib
+import io
+import json
+import gzip
+import base64
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "prod_qa_archive_closeout", ROOT / "ops/qa/prod_qa_archive_closeout.py"
+)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("cannot load prod_qa_archive_closeout")
+closeout = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(closeout)
+
+
+class ProdQAGapDecisionOperatorTest(unittest.TestCase):
+    @staticmethod
+    def _canonical_hash(plan: dict[str, object]) -> str:
+        canonical = dict(plan)
+        canonical["plan_hash"] = ""
+        encoded = json.dumps(
+            canonical, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+        ).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+    @classmethod
+    def _valid_plan(cls, plan_hash: str | None = None) -> dict[str, object]:
+        plan: dict[str, object] = {
+            "schema_version": "qa-archive-gap-decision-v1",
+            "db_utc_anchor": "2026-08-12T05:00:00Z",
+            "retention_cutoff": "2026-08-11T05:00:00Z",
+            "forward_cutover": {
+                "window_start": "2026-08-07T21:00:00Z",
+                "window_end": "2026-08-07T22:00:00Z",
+            },
+            "latest_normal_window_start": "2026-08-12T04:00:00Z",
+            "region": "us-east-1",
+            "bucket": "tokenkey-prod-qa-raw-archive-123456789012",
+            "recovery_role_arn": "arn:aws:iam::123456789012:role/tokenkey-prod-qa-raw-recovery",
+            "recovery_run_id": "recovery-head-batch-20260812T050000Z",
+            "windows": [
+                {
+                    "window_start": "2026-08-08T23:00:00Z",
+                    "window_end": "2026-08-09T00:00:00Z",
+                    "commit_key": "raw/v1/date=2026-08-08/hour=23/commit.json",
+                    "commit_exists": False,
+                    "source_record_count": 0,
+                    "control": {
+                        "exists": False,
+                        "window_end": "0001-01-01T00:00:00Z",
+                        "updated_at": "0001-01-01T00:00:00Z",
+                        "segment_fingerprint": "",
+                        "has_commit_ready_segment": False,
+                    },
+                }
+            ],
+            "plan_hash": "",
+        }
+        plan["plan_hash"] = plan_hash if plan_hash is not None else cls._canonical_hash(plan)
+        return plan
+
+    def test_gap_plan_binds_db_recovery_facts_and_writes_secure_atomic_plan(self) -> None:
+        db_plan = {
+            "schema_version": "qa-archive-gap-decision-v1",
+            "db_utc_anchor": "2026-08-12T05:00:00Z",
+            "retention_cutoff": "2026-08-11T05:00:00Z",
+            "forward_cutover": {
+                "window_start": "2026-08-07T21:00:00Z",
+                "window_end": "2026-08-07T22:00:00Z",
+            },
+            "latest_normal_window_start": "2026-08-12T04:00:00Z",
+            "region": "",
+            "bucket": "",
+            "recovery_role_arn": "",
+            "recovery_run_id": "",
+            "windows": [{"window_start": "2026-08-08T23:00:00Z"}],
+            "plan_hash": "",
+        }
+        final_plan = self._valid_plan()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = pathlib.Path(temp_dir) / "gap-plan.json"
+            with (
+                mock.patch.object(closeout, "_resolve_instance", return_value="i-0123456789abcdef0"),
+                mock.patch.object(
+                    closeout,
+                    "_resolve_recovery_scope",
+                    return_value=(
+                        "tokenkey-prod-qa-raw-archive-123456789012",
+                        "arn:aws:iam::123456789012:role/recovery",
+                    ),
+                ),
+                mock.patch.object(closeout, "_run_gap_db_plan", return_value=db_plan) as db_owner,
+                mock.patch.object(
+                    closeout, "_run_gap_s3_plan", return_value=final_plan
+                ) as s3_owner,
+            ):
+                result = closeout.build_gap_decision_plan(
+                    output,
+                    qa_archive_bin="/tmp/qa-archive-v1.8.148",
+                    recovery_run_id="gap-20260812T060000Z",
+                )
+
+            self.assertEqual(result["plan_hash"], final_plan["plan_hash"])
+            self.assertEqual(json.loads(output.read_text(encoding="utf-8")), final_plan)
+            self.assertEqual(output.stat().st_mode & 0o777, 0o600)
+            db_owner.assert_called_once_with("i-0123456789abcdef0")
+            s3_owner.assert_called_once_with(
+                "/tmp/qa-archive-v1.8.148",
+                db_plan,
+                "tokenkey-prod-qa-raw-archive-123456789012",
+                "arn:aws:iam::123456789012:role/recovery",
+                "gap-20260812T060000Z",
+            )
+
+    def test_gap_plan_hash_matches_go_operator_vector(self) -> None:
+        self.assertEqual(
+            self._valid_plan()["plan_hash"],
+            "c81fc61fe234f8364f59e09d5121f1389a6507a4cc755d4aae7182f4f252ab21",
+        )
+
+    def test_gap_apply_rejects_wrong_confirmation_before_remote_execution(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plan = pathlib.Path(temp_dir) / "plan.json"
+            plan.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "qa-archive-gap-decision-v1",
+                        "plan_hash": "b" * 64,
+                        "windows": [{"window_start": "2026-08-08T23:00:00Z"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(closeout, "_aws_json") as aws_json:
+                with self.assertRaisesRegex(
+                    closeout.QAArchiveCloseoutError, "confirmation"
+                ):
+                    closeout.apply_gap_decision_plan(
+                        plan,
+                        pathlib.Path(temp_dir) / "receipt.json",
+                        confirmation="wrong",
+                        approved_by="feng",
+                    )
+            aws_json.assert_not_called()
+
+    def test_gap_apply_rejects_noncanonical_hash_before_remote_execution(self) -> None:
+        plan_value = self._valid_plan("e" * 64)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            plan = root / "plan.json"
+            plan.write_text(json.dumps(plan_value), encoding="utf-8")
+            with (
+                mock.patch.object(closeout, "_resolve_instance") as resolve_instance,
+                mock.patch.object(closeout, "_run_gap_apply") as remote_apply,
+            ):
+                with self.assertRaisesRegex(
+                    closeout.QAArchiveCloseoutError, "canonical hash"
+                ):
+                    closeout.apply_gap_decision_plan(
+                        plan,
+                        root / "receipt.json",
+                        confirmation=closeout.GAP_CONFIRMATION_PREFIX + "e" * 64,
+                        approved_by="feng",
+                    )
+            resolve_instance.assert_not_called()
+            remote_apply.assert_not_called()
+
+    def test_gap_apply_persists_validated_remote_receipt(self) -> None:
+        plan_value = self._valid_plan()
+        plan_hash = str(plan_value["plan_hash"])
+        remote_receipt = {
+            "ok": True,
+            "command": "gap-decision-apply",
+            "plan_hash": plan_hash,
+            "approved_by": "feng",
+            "window_count": 1,
+            "already_applied": False,
+            "cleanup_eligible": False,
+            "deletion_authorized": False,
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            plan = root / "plan.json"
+            receipt = root / "receipt.json"
+            plan.write_text(json.dumps(plan_value), encoding="utf-8")
+            with (
+                mock.patch.object(closeout, "_resolve_instance", return_value="i-0123456789abcdef0"),
+                mock.patch.object(
+                    closeout,
+                    "_run_gap_apply",
+                    return_value={"command_id": "cmd-1", "remote_receipt": remote_receipt},
+                ) as remote,
+            ):
+                result = closeout.apply_gap_decision_plan(
+                    plan,
+                    receipt,
+                    confirmation=closeout.GAP_CONFIRMATION_PREFIX + plan_hash,
+                    approved_by="feng",
+                )
+
+            self.assertEqual(result["remote_receipt"], remote_receipt)
+            self.assertEqual(json.loads(receipt.read_text(encoding="utf-8")), result)
+            self.assertEqual(receipt.stat().st_mode & 0o777, 0o600)
+            remote.assert_called_once_with(
+                "i-0123456789abcdef0", plan_value, plan_hash, "feng"
+            )
+
+    def test_gap_db_plan_decodes_bounded_gzip_receipt(self) -> None:
+        db_plan = self._valid_plan()
+        db_plan["region"] = ""
+        db_plan["bucket"] = ""
+        db_plan["recovery_role_arn"] = ""
+        db_plan["recovery_run_id"] = ""
+        db_plan["plan_hash"] = ""
+        raw = json.dumps(db_plan, separators=(",", ":")).encode()
+        receipt = {
+            "ok": True,
+            "command": "gap-decision-db-plan",
+            "plan_gzip_base64": base64.b64encode(gzip.compress(raw)).decode(),
+            "plan_uncompressed_bytes": len(raw),
+            "window_count": 1,
+            "cleanup_eligible": False,
+            "deletion_authorized": False,
+        }
+        with mock.patch.object(
+            closeout,
+            "_send_remote",
+            return_value={"command_id": "cmd-1", "stdout": json.dumps(receipt)},
+        ):
+            self.assertEqual(closeout._run_gap_db_plan("i-0123456789abcdef0"), db_plan)
+
+    def test_gap_apply_refuses_oversized_ssm_transport_before_remote_call(self) -> None:
+        plan_value = self._valid_plan()
+        with mock.patch.object(
+            closeout, "_encode_plan_transport", return_value="x" * 20001
+        ), mock.patch.object(closeout, "_send_remote") as remote:
+            with self.assertRaisesRegex(closeout.QAArchiveCloseoutError, "SSM transport"):
+                closeout._run_gap_apply(
+                    "i-0123456789abcdef0",
+                    plan_value,
+                    str(plan_value["plan_hash"]),
+                    "feng",
+                )
+        remote.assert_not_called()
+
+    def test_gap_apply_accepts_same_hash_replay_with_stored_approver(self) -> None:
+        plan_value = self._valid_plan()
+        plan_hash = str(plan_value["plan_hash"])
+        remote_receipt = {
+            "ok": True,
+            "command": "gap-decision-apply",
+            "plan_hash": plan_hash,
+            "approved_by": "original-approver",
+            "window_count": 1,
+            "already_applied": True,
+            "cleanup_eligible": False,
+            "deletion_authorized": False,
+        }
+        with mock.patch.object(
+            closeout,
+            "_send_remote",
+            return_value={"command_id": "cmd-replay", "stdout": json.dumps(remote_receipt)},
+        ):
+            result = closeout._run_gap_apply(
+                "i-0123456789abcdef0", plan_value, plan_hash, "retrying-operator"
+            )
+        self.assertEqual(result["remote_receipt"], remote_receipt)
+
+    def test_main_routes_gap_plan_and_apply_without_legacy_window_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            with (
+                mock.patch.object(
+                    closeout,
+                    "build_gap_decision_plan",
+                    return_value=self._valid_plan("d" * 64),
+                ) as build,
+                mock.patch.object(sys, "argv", [
+                    "prod_qa_archive_closeout.py", "gap-plan",
+                    "--output", str(root / "plan.json"),
+                    "--qa-archive-bin", "/tmp/qa-archive-v1.8.148",
+                    "--recovery-run-id", "gap-20260812T060000Z",
+                ]),
+                mock.patch("sys.stdout", new_callable=io.StringIO),
+            ):
+                self.assertEqual(closeout.main(), 0)
+            build.assert_called_once_with(
+                root / "plan.json",
+                qa_archive_bin="/tmp/qa-archive-v1.8.148",
+                recovery_run_id="gap-20260812T060000Z",
+            )
+
+            with (
+                mock.patch.object(
+                    closeout,
+                    "apply_gap_decision_plan",
+                    return_value={"plan_hash": "d" * 64},
+                ) as apply,
+                mock.patch.object(sys, "argv", [
+                    "prod_qa_archive_closeout.py", "gap-apply",
+                    "--plan", str(root / "plan.json"),
+                    "--receipt-output", str(root / "receipt.json"),
+                    "--confirm", closeout.GAP_CONFIRMATION_PREFIX + "d" * 64,
+                    "--approved-by", "feng",
+                ]),
+                mock.patch("sys.stdout", new_callable=io.StringIO),
+            ):
+                self.assertEqual(closeout.main(), 0)
+            apply.assert_called_once_with(
+                root / "plan.json", root / "receipt.json",
+                confirmation=closeout.GAP_CONFIRMATION_PREFIX + "d" * 64,
+                approved_by="feng",
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(unittest.main())

--- a/scripts/checks/qa-lifecycle-ssot.py
+++ b/scripts/checks/qa-lifecycle-ssot.py
@@ -25,6 +25,9 @@ GO_MAINTENANCE = Path("backend/cmd/server/qa_maintenance.go")
 RAW_ARCHIVE_CFN = Path("deploy/aws/cloudformation/stage0-qa-raw-archive.yaml")
 RAW_ARCHIVE_DEPLOY = Path("ops/qa/deploy_qa_raw_archive_cfn.sh")
 ARCHIVE_CLI = Path("backend/cmd/qa-archive/main.go")
+GAP_DECISION_OWNER = Path("backend/internal/observability/qa/archive/gap_decision.go")
+GAP_DECISION_RECEIPTS = Path("backend/migrations/tk_075_qa_archive_gap_decision_receipts.sql")
+ARCHIVE_OPERATOR = Path("ops/qa/prod_qa_archive_closeout.py")
 RECOVERY_GATE = Path("ops/qa/qa_archive_recovery_gate.py")
 PREFLIGHT = Path("scripts/preflight.sh")
 ARCHIVE_STATE = Path("backend/internal/observability/qa/archive/state.go")
@@ -126,6 +129,9 @@ REQUIRED_BY_FILE = {
         "qa_exports_tmp",
         "--qa-cutover-provision-only",
         "tokenkey-prod-qa-cutover-provision-v1",
+        "qa_archive_gap_decision_receipts",
+        "tokenkey-prod-qa-gap-decision-v1:<plan_hash>",
+        "segment fingerprint",
     ),
     POLICY: (
         "schema_version: 1",
@@ -194,6 +200,9 @@ REQUIRED_BY_FILE = {
         "prod_qa_cutover_drain_plan",
         "--qa-cutover-provision-only",
         "tokenkey-prod-qa-cutover-provision-v1",
+        "gap-plan",
+        "gap-apply",
+        "failed/source_unavailable_after_retention",
     ),
     DEPLOY_GUIDE: (
         "tokenkey-qa-boundary.sh",
@@ -251,6 +260,40 @@ REQUIRED_BY_FILE = {
         "database_accessed",
         "shared_ec2_instance_role_no_process_isolation",
         "window-bound privacy confirmation required",
+        "gap-decision-db-plan",
+        "gap-decision-s3-plan",
+        "gap-decision-apply",
+        "exact plan-hash confirmation required",
+        "plan-gzip-base64",
+        "maxGapDecisionPlanBytes",
+    ),
+    GAP_DECISION_OWNER: (
+        "BuildGapDecisionDBPlan",
+        "CompleteGapDecisionPlanFromStore",
+        "ApplyGapDecisionPlan",
+        "pg_try_advisory_xact_lock",
+        "SegmentFingerprint",
+        "PersistApprovedGapTerminal",
+        "qa_archive_gap_decision_receipts",
+    ),
+    GAP_DECISION_RECEIPTS: (
+        "qa_archive_gap_decision_receipts",
+        "plan_json jsonb NOT NULL",
+        "approved_by text NOT NULL",
+        "BEFORE UPDATE OR DELETE",
+        "BEFORE TRUNCATE",
+        "append-only",
+    ),
+    ARCHIVE_OPERATOR: (
+        "gap-plan",
+        "gap-apply",
+        "GAP_CONFIRMATION_PREFIX",
+        "_run_gap_db_plan",
+        "_run_gap_s3_plan",
+        "_run_gap_apply",
+        "target-tag qa-archive binary",
+        "MAX_GAP_PLAN_BYTES",
+        "plan_gzip_base64",
     ),
     RECOVERY_GATE: (
         "planned_transition_authorized",
@@ -703,6 +746,18 @@ def _closeout_implementation_failures(root: Path) -> list[str]:
     rehome = root / "backend/internal/pkg/pgpartition/rehome_default.go"
     if rehome.is_file():
         failures.append("retired qa_records rehome implementation still present")
+    gap_owner = root / GAP_DECISION_OWNER
+    if gap_owner.is_file():
+        body = gap_owner.read_text(encoding="utf-8")
+        for forbidden in (
+            "qa_archive_gaps",
+            "DELETE FROM qa_records",
+            "DROP TABLE",
+            "s3:PutObject",
+            "RehomeDefaultMonthly",
+        ):
+            if forbidden in body:
+                failures.append(f"QA gap decision reintroduced a forbidden owner or mutation: {forbidden}")
     partition_maintenance = root / "backend/internal/pkg/partitionmaintenance/maintenance.go"
     if partition_maintenance.is_file():
         body = partition_maintenance.read_text(encoding="utf-8")

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1243,6 +1243,7 @@ if ! command -v python3 >/dev/null 2>&1; then
     errors=$((errors + 1))
 elif ! python3 -m py_compile \
     ./ops/qa/qa_archive_recovery_gate.py \
+    ./ops/qa/prod_qa_archive_closeout.py \
     ./ops/qa/prod_phase2_live_health.py \
     ./ops/qa/verify_raw_archive_iam_contract.py \
     ./ops/qa/qa_phase2_health.py \
@@ -1251,6 +1252,7 @@ elif ! python3 -m py_compile \
 elif ! python3 -m unittest \
     deploy.aws.cloudformation.test_stage0_qa_raw_archive_contract \
     ops.qa.test_qa_archive_recovery_gate \
+    ops.qa.test_prod_qa_archive_closeout \
     ops.qa.test_prod_phase2_live_health; then
     errors=$((errors + 1))
 else


### PR DESCRIPTION
## 摘要

- 为历史过期、零源且无 recovery commit 的 QA 小时窗口新增自动枚举、hash-bound 批量 plan/apply；不接受 arbitrary window。
- apply 在共享 QAMA 事务锁下重验 DB anchor、cutover、latest normal、source/control/segment facts，整批原子写入 `qa_archive_shards` terminal 状态与 append-only receipt。
- operator 使用目标 tag binary + dedicated recovery role 做只读 S3 HEAD，并以有界 gzip+base64 传输计划；现有 `design-qa-phase2-archive-closeout.md` 作为 SSOT。

## 风险

- 高风险数据库状态变更仍受 `tokenkey-prod-qa-gap-decision-v1:<plan_hash>` 与显式 approver 双门禁；生产 `gap-apply` 不在本 PR/本次操作范围，发布后须先只读生成精确 plan，再单独审批。
- 本实现不补数据、不创建空归档、不 rehome、不 copy/move、不 DROP、不切 timer、不读写线上服务。receipt 永不授予 cleanup；UPDATE/DELETE/TRUNCATE 均被 schema 拒绝。
- `backend/cmd/qa-archive/main.go` 的 load-bearing surface 已复核，由 QA lifecycle SSOT sentinel 覆盖，不需要 gateway registry 新 anchor。

no-web-impact
sentinel-registry-reviewed

## 验证

- `go test -tags=unit -count=1 ./internal/observability/qa/archive ./cmd/qa-archive`
- `TESTCONTAINERS_RYUK_DISABLED=true DOCKER_HOST=unix:///Users/feng/.colima/default/docker.sock go test -tags=integration -count=1 -run TestUS045_.*GapDecision ./internal/observability/qa/archive`
- `python3 -m unittest ops.qa.test_prod_qa_archive_closeout ops.qa.test_qa_phase_ops ops.qa.test_qa_maintenance_phase2_runtime`（77 tests）
- `python3 .testing/user-stories/verify_quality.py`
- `python3 scripts/checks/qa-lifecycle-ssot.py --self-test && python3 scripts/checks/qa-lifecycle-ssot.py`
- `./scripts/preflight.sh`（提交后 PASS）

## 提交

- `187278ecc feat(qa): bind expired archive gap decisions`
- 最新提交：187278ecc
