### PR TITLE
fix(ops): GHA OIDC 权限补齐 QA raw archive 诊断 (#1621)

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -147,9 +147,29 @@ Resources:
                 Effect: Allow
                 Action:
                   - cloudformation:DescribeStacks
+                  - cloudformation:DescribeStackResources
                 Resource:
                   - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/tokenkey-cicd-oidc/*"
                   - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/tokenkey-prod-stage0/*"
+                  - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/tokenkey-prod-qa-raw-archive/*"
+              - Sid: ReadQaRawArchiveIamContract
+                # ops/qa/verify_raw_archive_iam_contract.py on the GHA runner (OIDC
+                # creds) needs read-only bucket policy + S3 gateway route checks.
+                Effect: Allow
+                Action:
+                  - s3:GetBucketPolicy
+                Resource:
+                  - !Sub "arn:aws:s3:::tokenkey-prod-qa-raw-archive-${AWS::AccountId}"
+              - Sid: ReadQaRawArchiveNetworkForDiagnostics
+                Effect: Allow
+                Action:
+                  - ec2:DescribeVpcEndpoints
+                  - ec2:DescribeRouteTables
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    "aws:RequestedRegion":
+                      - !Ref AWS::Region
               - Sid: ReadEbsSnapshotsForDiagnostics
                 # ops-daily-diagnostics data_layer_snapshot_signal.sh runs on the
                 # GHA runner (OIDC creds), not via SSM — needs direct EC2 read.

--- a/scripts/checks/diagnostics-oidc-perm-coverage.py
+++ b/scripts/checks/diagnostics-oidc-perm-coverage.py
@@ -16,6 +16,22 @@ EXPECTED_BASE_ACTIONS: list[tuple[str, str]] = [
         "ec2:DescribeSnapshots",
         "ops/observability/data_layer_snapshot_signal.sh on prod diagnostics (#1554)",
     ),
+    (
+        "cloudformation:DescribeStackResources",
+        "ops/qa/verify_raw_archive_iam_contract.py stack resource lookup (#1621)",
+    ),
+    (
+        "s3:GetBucketPolicy",
+        "ops/qa/verify_raw_archive_iam_contract.py bucket policy read (#1621)",
+    ),
+    (
+        "ec2:DescribeVpcEndpoints",
+        "ops/qa/verify_raw_archive_iam_contract.py S3 gateway endpoint check (#1620)",
+    ),
+    (
+        "ec2:DescribeRouteTables",
+        "ops/qa/verify_raw_archive_iam_contract.py route table gateway route check (#1620)",
+    ),
 ]
 
 


### PR DESCRIPTION
## 摘要

- 扩展 `deploy/aws/cloudformation/cicd-oidc.yaml`：为 GHA OIDC role 增加 `DescribeStackResources`、`s3:GetBucketPolicy`、`ec2:DescribeVpcEndpoints`、`ec2:DescribeRouteTables`（限定 qa-raw-archive stack / bucket）
- 同步 `scripts/checks/diagnostics-oidc-perm-coverage.py` 机械门禁
- 根因：`ops/qa/verify_raw_archive_iam_contract.py` 在 GHA runner 上以 OIDC 凭证运行时 AccessDenied，误报 `qa_raw_archive_iam_contract` drift，并级联触发 #1620/#1627–#1629 观测面失败

Fixes #1621

## 风险

- 低风险：只读诊断权限，不含写操作
- **合并后仍需人工**：在 prod 账户 deploy `tokenkey-cicd-oidc` stack，下一趟 `ops-daily-diagnostics` 才会消除假阳性
- #1627–#1629 telemetry archive heartbeat 累积 failed=5 可能还需 prod app 重启 + 已合入的 archive fix 发版（#1631）才能完全清零

## 验证

- `python3 scripts/checks/diagnostics-oidc-perm-coverage.py` → ok
- `./scripts/preflight.sh` → PASS
- 本地 admin 视角 `python3 ops/qa/verify_raw_archive_iam_contract.py --json` → `{"ok": true, "status": "applied"}`

## 提交

- 9d3094f4d fix(ops): grant GHA OIDC read access for QA raw archive diagnostics

最新提交：9d3094f4d

Made with [Cursor](https://cursor.com)