### PR TITLE
fix(gateway): CloudWise #95 全协议中继与 probe-curated model_mapping floor

### DIFF
--- a/.cursor/skills/tokenkey-account-model-probe/SKILL.md
+++ b/.cursor/skills/tokenkey-account-model-probe/SKILL.md
@@ -101,6 +101,19 @@ bash ops/observability/run-probe.sh \
   --env MODEL=<candidate_model>
 ```
 
+For a CloudWise MaaS OpenAI apikey account (`base_url` under
+`api.cloudwise.ai` / `api-us.cloudwise.ai`), run the direct upstream protocol
+matrix (models list, chat, messages, responses, embeddings, images, videos).
+Output never includes `api_key`; use it to refresh probe-curated
+`openai_cloudwise_relay` catalog floors and `extra` capability flags:
+
+```bash
+bash ops/observability/run-probe.sh \
+  --target prod \
+  --script ops/stage0/probe_cloudwise_upstream_matrix.sh \
+  --env ACCOUNT_ID=95
+```
+
 The JSON result includes database-derived `account_platform` and effective
 `account_scope` (for example an Anthropic transport stub with
 `mirror_platform=kiro` reports `account_platform=anthropic`,

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1349,6 +1349,26 @@ func isTokenseaRelayBaseURL(raw string) bool {
 	return base == "https://agent.tokensea.ai"
 }
 
+// IsOpenAICloudwiseRelay reports prod OpenAI apikey accounts whose upstream is
+// CloudWise MaaS (api.cloudwise.ai or api-us.cloudwise.ai). They expose a
+// dual-stack OpenAI Chat + Anthropic Messages gateway but not /v1/responses.
+func (a *Account) IsOpenAICloudwiseRelay() bool {
+	if a == nil || !a.IsOpenAI() || a.Type != AccountTypeAPIKey {
+		return false
+	}
+	return isCloudwiseRelayBaseURL(a.GetCredential("base_url"))
+}
+
+func isCloudwiseRelayBaseURL(raw string) bool {
+	base := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(raw, "/")))
+	switch base {
+	case "https://api.cloudwise.ai/api", "https://api-us.cloudwise.ai/api":
+		return true
+	default:
+		return false
+	}
+}
+
 func (a *Account) GetOpenAIBaseURL() string {
 	if a == nil {
 		return ""

--- a/backend/internal/service/account_model_mapping_ssot_tk.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk.go
@@ -19,6 +19,7 @@ const (
 	accountModelMappingPlatformOpenAIAinzyRelay       = "openai_ainzy_relay"
 	accountModelMappingPlatformOpenAITokenseaRelay    = "openai_tokensea_relay"
 	accountModelMappingPlatformAnthropicTokenseaRelay = "anthropic_tokensea_relay"
+	accountModelMappingPlatformOpenAICloudwiseRelay   = "openai_cloudwise_relay"
 )
 
 // accountModelMappingRuntime is the hot runtime replacement layer for the
@@ -166,6 +167,9 @@ func accountModelMappingForAccount(ctx context.Context, account *Account, pricin
 		if account.IsOpenAITokenseaRelay() {
 			return openAITokenseaRelayAccountModelMappingFloor(ctx, pricing, availability), true
 		}
+		if account.IsOpenAICloudwiseRelay() {
+			return openAICloudwiseRelayAccountModelMappingFloor(ctx, pricing, availability), true
+		}
 		return openAICanonicalAccountModelMappingFloor(ctx, pricing, availability), true
 	case PlatformAnthropic, PlatformGemini:
 		if scope == PlatformAnthropic && account.IsAnthropicTokenseaRelay() {
@@ -247,6 +251,16 @@ func AccountModelMappingFloorForOps(ctx context.Context, runtimeRaw string) (*Ac
 	}, nil, nil, runtime)
 	if ok && len(tokenseaMapping) > 0 {
 		out.Platforms[accountModelMappingPlatformOpenAITokenseaRelay] = cloneStringMap(tokenseaMapping)
+	}
+	cloudwiseMapping, ok := accountModelMappingForAccount(ctx, &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api.cloudwise.ai/api",
+		},
+	}, nil, nil, runtime)
+	if ok && len(cloudwiseMapping) > 0 {
+		out.Platforms[accountModelMappingPlatformOpenAICloudwiseRelay] = cloneStringMap(cloudwiseMapping)
 	}
 	anthropicTokenseaMapping, ok := accountModelMappingForAccount(ctx, &Account{
 		Platform: PlatformAnthropic,
@@ -395,6 +409,14 @@ func openAIAinzyRelayAccountModelMappingFloor(ctx context.Context, pricing *Pric
 
 func openAITokenseaRelayAccountModelMappingFloor(ctx context.Context, pricing *PricingCatalogService, availability MePricingAvailability) map[string]string {
 	ids := supportedCatalogModelIDsFromMap(supportedOpenAITokenseaRelayCatalogModels)
+	if len(ids) == 0 {
+		return nil
+	}
+	return identityModelMapping(ids)
+}
+
+func openAICloudwiseRelayAccountModelMappingFloor(ctx context.Context, pricing *PricingCatalogService, availability MePricingAvailability) map[string]string {
+	ids := supportedCatalogModelIDsFromMap(supportedOpenAICloudwiseRelayCatalogModels)
 	if len(ids) == 0 {
 		return nil
 	}

--- a/backend/internal/service/account_model_mapping_ssot_tk_test.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk_test.go
@@ -137,6 +137,9 @@ func TestAccountModelMappingFloorForOps_ExportsAinzyRelayScope(t *testing.T) {
 	tokensea, ok := doc.Platforms[accountModelMappingPlatformOpenAITokenseaRelay]
 	require.True(t, ok)
 	requireIdentityMappingForIDs(t, tokensea, supportedCatalogModelIDsFromMap(supportedOpenAITokenseaRelayCatalogModels))
+	cloudwise, ok := doc.Platforms[accountModelMappingPlatformOpenAICloudwiseRelay]
+	require.True(t, ok)
+	requireIdentityMappingForIDs(t, cloudwise, supportedCatalogModelIDsFromMap(supportedOpenAICloudwiseRelayCatalogModels))
 	anthropicTokensea, ok := doc.Platforms[accountModelMappingPlatformAnthropicTokenseaRelay]
 	require.True(t, ok)
 	require.Equal(t, anthropicTokenseaRelayModelMappingFloor(), anthropicTokensea)

--- a/backend/internal/service/gateway_cloudwise_relay_test.go
+++ b/backend/internal/service/gateway_cloudwise_relay_test.go
@@ -1,0 +1,93 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func cloudwiseNativeMessagesAccount() *Account {
+	account := rawChatCompletionsTestAccount()
+	account.ID = 95
+	account.Credentials["base_url"] = "https://api.cloudwise.ai/api"
+	account.Extra = map[string]any{
+		openai_compat.ExtraKeyResponsesSupported:      false,
+		openai_compat.ExtraKeyNativeMessagesSupported: true,
+	}
+	return account
+}
+
+func TestAccount_IsOpenAICloudwiseRelay(t *testing.T) {
+	require.False(t, (*Account)(nil).IsOpenAICloudwiseRelay())
+
+	cloudwise := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api.cloudwise.ai/api",
+		},
+	}
+	require.True(t, cloudwise.IsOpenAICloudwiseRelay())
+
+	us := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api-us.cloudwise.ai/api/",
+		},
+	}
+	require.True(t, us.IsOpenAICloudwiseRelay())
+
+	other := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api.openai.com/v1",
+		},
+	}
+	require.False(t, other.IsOpenAICloudwiseRelay())
+}
+
+func TestOpenAICloudwiseRelayFloorIsProbeCuratedOnly(t *testing.T) {
+	mapping := openAICloudwiseRelayAccountModelMappingFloor(context.Background(), nil, nil)
+	requireIdentityMappingForIDs(t, mapping, supportedCatalogModelIDsFromMap(supportedOpenAICloudwiseRelayCatalogModels))
+}
+
+func TestForwardAsAnthropic_CloudwiseNativeMessagesPassthrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","max_tokens":8,"messages":[{"role":"user","content":"Reply OK only."}]}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"type":"message","model":"claude-sonnet-4-6","role":"assistant","content":[{"type":"text","text":"OK"}],"usage":{"input_tokens":7,"output_tokens":1}}`,
+		)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, cloudwiseNativeMessagesAccount(), body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/messages", upstream.lastReq.URL.String())
+	require.Equal(t, "claude-sonnet-4-6", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Contains(t, rec.Body.String(), "OK")
+}

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -186,6 +186,40 @@ var supportedAnthropicTokenseaRelayCatalogModels = map[string]struct{}{
 	"claude-sonnet-5":   {},
 }
 
+// supportedOpenAICloudwiseRelayCatalogModels — probe-curated IDs from prod account
+// 95 upstream GET /v1/models on 2026-08-12. Identity mapping; servability still
+// requires per-model gateway/upstream probes before catalog exposure.
+var supportedOpenAICloudwiseRelayCatalogModels = map[string]struct{}{
+	"MiniMax-M3":                       {},
+	"claude-fable-5":                   {},
+	"claude-opus-4-6":                  {},
+	"claude-opus-4-6-thinking":         {},
+	"claude-opus-4-7":                  {},
+	"claude-opus-4-7-thinking":         {},
+	"claude-opus-4-8":                  {},
+	"claude-sonnet-4-5":                {},
+	"claude-sonnet-4-6":                {},
+	"claude-sonnet-4-6-thinking":       {},
+	"deepseek-v3.2":                    {},
+	"deepseek-v4-flash":                {},
+	"deepseek-v4-pro":                  {},
+	"gemini-3-flash-preview":           {},
+	"gemini-3-pro-image-preview":       {},
+	"gemini-3-pro-image-preview-S":     {},
+	"gemini-3-pro-preview":             {},
+	"gemini-3.1-flash-image-preview":   {},
+	"gemini-3.1-flash-image-preview-S": {},
+	"gemini-3.1-flash-lite-preview":    {},
+	"gemini-3.1-pro-preview":           {},
+	"glm-5":                            {},
+	"glm-5.1":                          {},
+	"glm-5.2":                          {},
+	"gpt-5.2":                          {},
+	"gpt-5.3-codex":                    {},
+	"gpt-5.4":                          {},
+	"kimi-k3":                          {},
+}
+
 // supportedGeminiCatalogModels — gemini/Vertex IDs confirmed servable through
 // the prod Vertex pool. Gemini 3.5 Flash Lite and 3.6 Flash were confirmed on
 // accounts 47/57/58/59/74 via direct global generateContent on 2026-07-22.

--- a/backend/migrations/tk_078_cloudwise_relay_capability.sql
+++ b/backend/migrations/tk_078_cloudwise_relay_capability.sql
@@ -1,0 +1,16 @@
+-- CloudWise relay (account 95): upstream supports native /v1/messages and
+-- /v1/chat/completions but returns 400 on /v1/responses for probed models.
+-- 2026-08-12 prod matrix probe evidence.
+
+UPDATE accounts
+SET extra = COALESCE(extra, '{}'::jsonb)
+    || jsonb_build_object(
+        'openai_responses_supported', false,
+        'openai_native_messages_supported', true
+    )
+WHERE id = 95
+  AND deleted_at IS NULL
+  AND LOWER(TRIM(BOTH '/' FROM credentials->>'base_url')) IN (
+    'https://api.cloudwise.ai/api',
+    'https://api-us.cloudwise.ai/api'
+  );

--- a/ops/pricing/manage-account-model-mapping-runtime.py
+++ b/ops/pricing/manage-account-model-mapping-runtime.py
@@ -467,6 +467,15 @@ def _is_openai_tokensea_relay(row: dict[str, Any]) -> bool:
     return base == "https://agent.tokensea.ai"
 
 
+def _is_openai_cloudwise_relay(row: dict[str, Any]) -> bool:
+    if str(row.get("platform") or "").strip().lower() != "openai":
+        return False
+    if str(row.get("type") or "") != "apikey":
+        return False
+    base = str(row.get("base_url") or "").strip().lower().rstrip("/")
+    return base in {"https://api.cloudwise.ai/api", "https://api-us.cloudwise.ai/api"}
+
+
 def _is_anthropic_tokensea_relay(row: dict[str, Any]) -> bool:
     if str(row.get("platform") or "").strip().lower() != "anthropic":
         return False
@@ -481,6 +490,8 @@ def _account_scope(row: dict[str, Any]) -> str:
         return "openai_ainzy_relay"
     if _is_openai_tokensea_relay(row):
         return "openai_tokensea_relay"
+    if _is_openai_cloudwise_relay(row):
+        return "openai_cloudwise_relay"
     if _is_anthropic_tokensea_relay(row):
         return "anthropic_tokensea_relay"
     if _is_kiro_scope(row):

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "floor_sha256": "395b9b3e33b9a14225c4dd2ad25643425f05cc800ef41bb4990533ecc77f203a",
+  "floor_sha256": "c859340998691fb37c6b1943515fb1d3ec0d293362eed750e04f757b22284443",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -188,6 +188,36 @@
         "gpt-5.4": "gpt-5.4",
         "gpt-5.4-mini": "gpt-5.4-mini",
         "gpt-5.5": "gpt-5.5"
+      },
+      "openai_cloudwise_relay": {
+        "MiniMax-M3": "MiniMax-M3",
+        "claude-fable-5": "claude-fable-5",
+        "claude-opus-4-6": "claude-opus-4-6",
+        "claude-opus-4-6-thinking": "claude-opus-4-6-thinking",
+        "claude-opus-4-7": "claude-opus-4-7",
+        "claude-opus-4-7-thinking": "claude-opus-4-7-thinking",
+        "claude-opus-4-8": "claude-opus-4-8",
+        "claude-sonnet-4-5": "claude-sonnet-4-5",
+        "claude-sonnet-4-6": "claude-sonnet-4-6",
+        "claude-sonnet-4-6-thinking": "claude-sonnet-4-6-thinking",
+        "deepseek-v3.2": "deepseek-v3.2",
+        "deepseek-v4-flash": "deepseek-v4-flash",
+        "deepseek-v4-pro": "deepseek-v4-pro",
+        "gemini-3-flash-preview": "gemini-3-flash-preview",
+        "gemini-3-pro-image-preview": "gemini-3-pro-image-preview",
+        "gemini-3-pro-image-preview-S": "gemini-3-pro-image-preview-S",
+        "gemini-3-pro-preview": "gemini-3-pro-preview",
+        "gemini-3.1-flash-image-preview": "gemini-3.1-flash-image-preview",
+        "gemini-3.1-flash-image-preview-S": "gemini-3.1-flash-image-preview-S",
+        "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
+        "glm-5": "glm-5",
+        "glm-5.1": "glm-5.1",
+        "glm-5.2": "glm-5.2",
+        "gpt-5.2": "gpt-5.2",
+        "gpt-5.3-codex": "gpt-5.3-codex",
+        "gpt-5.4": "gpt-5.4",
+        "kimi-k3": "kimi-k3"
       },
       "openai_tokensea_relay": {
         "claude-fable-5": "claude-fable-5",

--- a/ops/pricing/modelops.py
+++ b/ops/pricing/modelops.py
@@ -891,7 +891,7 @@ def _account_platform_allows_scope(account_platform: str, account_scope: str) ->
     if account_platform == "anthropic":
         return account_scope in {"kiro", "bedrock", "anthropic_tokensea_relay"}
     if account_platform == "openai":
-        return account_scope in {"openai_ainzy_relay", "openai_tokensea_relay"}
+        return account_scope in {"openai_ainzy_relay", "openai_tokensea_relay", "openai_cloudwise_relay"}
     if account_platform == "newapi":
         return account_scope.startswith("newapi_channel_type:")
     return False

--- a/ops/stage0/probe_account_upstream_models.sh
+++ b/ops/stage0/probe_account_upstream_models.sh
@@ -125,6 +125,11 @@ def derive_account_scope(row):
         return "openai_ainzy_relay"
     if platform == "openai" and account_type == "apikey" and account_base_url == "https://agent.tokensea.ai":
         return "openai_tokensea_relay"
+    if platform == "openai" and account_type == "apikey" and account_base_url in {
+        "https://api.cloudwise.ai/api",
+        "https://api-us.cloudwise.ai/api",
+    }:
+        return "openai_cloudwise_relay"
     if platform == "anthropic" and account_type == "apikey" and account_base_url == "https://agent.tokensea.ai":
         return "anthropic_tokensea_relay"
     if platform == "newapi":

--- a/ops/stage0/probe_cloudwise_upstream_matrix.sh
+++ b/ops/stage0/probe_cloudwise_upstream_matrix.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# Direct CloudWise upstream capability matrix for one TokenKey OpenAI apikey account.
+# Reads credentials from prod postgres; output never includes api_key.
+set -euo pipefail
+
+ACCOUNT_ID="${ACCOUNT_ID:?ACCOUNT_ID required}"
+REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-45}"
+
+PSQL=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -q -A -t -v ON_ERROR_STOP=1)
+
+python3 - "$ACCOUNT_ID" "$REQUEST_TIMEOUT_SECONDS" <<'PY'
+import json
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from urllib.parse import urljoin
+
+account_id, timeout_raw = sys.argv[1:3]
+timeout = int(timeout_raw)
+
+sql = f"""
+SELECT json_build_object(
+  'id', a.id,
+  'name', a.name,
+  'platform', a.platform,
+  'type', a.type,
+  'channel_type', a.channel_type,
+  'api_key', COALESCE(a.credentials->>'api_key', ''),
+  'base_url', COALESCE(a.credentials->>'base_url', ''),
+  'model_mapping', COALESCE(a.extra->'model_mapping', '{{}}'::jsonb)
+)::text
+FROM accounts a
+WHERE a.id={account_id} AND a.deleted_at IS NULL;
+"""
+psql = [
+    "sudo", "docker", "exec", "-i", "tokenkey-postgres", "psql",
+    "-U", "tokenkey", "-d", "tokenkey", "-X", "-q", "-A", "-t",
+    "-v", "ON_ERROR_STOP=1", "-c", sql,
+]
+try:
+    raw = subprocess.run(psql, check=True, text=True, capture_output=True).stdout.strip()
+    account = json.loads(raw)
+except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+    print(json.dumps({"verdict": "setup_error", "error": f"account lookup failed: {exc}"}, ensure_ascii=False))
+    raise SystemExit(0)
+
+if not isinstance(account, dict):
+    print(json.dumps({"verdict": "setup_error", "error": "account not found"}, ensure_ascii=False))
+    raise SystemExit(0)
+
+api_key = str(account.get("api_key") or "").strip()
+base_url = str(account.get("base_url") or "").strip().rstrip("/")
+
+if not api_key:
+    print(json.dumps({"verdict": "setup_error", "error": "missing api_key on account"}, ensure_ascii=False))
+    raise SystemExit(0)
+if not base_url:
+    print(json.dumps({"verdict": "setup_error", "error": "missing base_url on account"}, ensure_ascii=False))
+    raise SystemExit(0)
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+opener = urllib.request.build_opener(NoRedirect())
+
+
+def request(method, url, body_obj=None, extra_headers=None):
+    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+    if extra_headers:
+        headers.update(extra_headers)
+    data = None
+    if body_obj is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(body_obj).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with opener.open(req, timeout=timeout) as resp:
+            raw = resp.read(2 << 20)
+            return resp.status, dict(resp.headers), raw
+    except urllib.error.HTTPError as exc:
+        raw = exc.read(4096)
+        return exc.code, dict(exc.headers), raw
+    except Exception as exc:  # noqa: BLE001
+        return None, {}, str(exc).encode("utf-8")
+
+
+def join_path(base, suffix):
+    if suffix.startswith("/"):
+        suffix = suffix[1:]
+    if base.endswith("/"):
+        return base + suffix
+    return base + "/" + suffix
+
+
+def parse_models(raw):
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return []
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        return []
+    out = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        model_id = str(item.get("id") or "").strip()
+        if not model_id:
+            continue
+        arch = item.get("architecture") if isinstance(item.get("architecture"), dict) else {}
+        modality = str(arch.get("modality") or "")
+        out.append({"id": model_id, "modality": modality})
+    return out
+
+
+def pick_probe_models(models):
+    text = next((m["id"] for m in models if "text->text" in m.get("modality", "") or m.get("modality", "").endswith("->text")), None)
+    image = next((m["id"] for m in models if "->text+image" in m.get("modality", "") or "image" in m.get("modality", "")), None)
+    if not text and models:
+        text = models[0]["id"]
+    return text, image
+
+
+def excerpt(raw, limit=240):
+    text = raw.decode("utf-8", errors="replace") if isinstance(raw, (bytes, bytearray)) else str(raw)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:limit]
+
+
+models_url = join_path(base_url, "v1/models")
+status, headers, raw = request("GET", models_url)
+models = parse_models(raw) if status and 200 <= status < 300 else []
+text_model, image_model = pick_probe_models(models)
+
+mapping = account.get("model_mapping") if isinstance(account.get("model_mapping"), dict) else {}
+mapped_models = sorted(str(k) for k in mapping.keys())
+
+protocols = []
+
+# models list
+protocols.append({
+    "protocol": "models_list",
+    "method": "GET",
+    "path": "/v1/models",
+    "url": models_url,
+    "http_status": status,
+    "supported": bool(status and 200 <= status < 300 and models),
+    "model_count": len(models),
+    "location": headers.get("Location") or headers.get("location"),
+    "error_excerpt": None if status and 200 <= status < 300 else excerpt(raw),
+})
+
+chat_model = mapped_models[0] if mapped_models else text_model
+if chat_model:
+    chat_url = join_path(base_url, "v1/chat/completions")
+    body = {
+        "model": chat_model,
+        "messages": [{"role": "user", "content": "Reply OK only."}],
+        "max_tokens": 8,
+        "stream": False,
+    }
+    status, _, raw = request("POST", chat_url, body)
+    protocols.append({
+        "protocol": "chat_completions",
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "url": chat_url,
+        "probe_model": chat_model,
+        "http_status": status,
+        "supported": bool(status and 200 <= status < 300),
+        "error_excerpt": None if status and 200 <= status < 300 else excerpt(raw),
+    })
+
+if chat_model:
+    resp_url = join_path(base_url, "v1/responses")
+    body = {
+        "model": chat_model,
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "Reply OK only."}]}],
+        "max_output_tokens": 8,
+        "stream": False,
+    }
+    status, _, raw = request("POST", resp_url, body)
+    protocols.append({
+        "protocol": "responses",
+        "method": "POST",
+        "path": "/v1/responses",
+        "url": resp_url,
+        "probe_model": chat_model,
+        "http_status": status,
+        "supported": bool(status and 200 <= status < 300),
+        "error_excerpt": None if status and 200 <= status < 300 else excerpt(raw),
+    })
+
+if chat_model:
+    emb_url = join_path(base_url, "v1/embeddings")
+    body = {"model": chat_model, "input": "hello"}
+    status, _, raw = request("POST", emb_url, body)
+    protocols.append({
+        "protocol": "embeddings",
+        "method": "POST",
+        "path": "/v1/embeddings",
+        "url": emb_url,
+        "probe_model": chat_model,
+        "http_status": status,
+        "supported": bool(status and 200 <= status < 300),
+        "error_excerpt": None if status and 200 <= status < 300 else excerpt(raw),
+    })
+
+if image_model or chat_model:
+    img_model = image_model or chat_model
+    img_url = join_path(base_url, "v1/images/generations")
+    body = {"model": img_model, "prompt": "a red circle", "n": 1, "size": "512x512"}
+    status, _, raw = request("POST", img_url, body)
+    protocols.append({
+        "protocol": "images_generations",
+        "method": "POST",
+        "path": "/v1/images/generations",
+        "url": img_url,
+        "probe_model": img_model,
+        "http_status": status,
+        "supported": bool(status and 200 <= status < 300),
+        "error_excerpt": None if status and 200 <= status < 300 else excerpt(raw),
+    })
+
+vid_url = join_path(base_url, "v1/videos/generations")
+vid_model = image_model or chat_model or "sora-2"
+body = {"model": vid_model, "prompt": "a cat walking", "duration": 2}
+status, _, raw = request("POST", vid_url, body)
+protocols.append({
+    "protocol": "videos_generations",
+    "method": "POST",
+    "path": "/v1/videos/generations",
+    "url": vid_url,
+    "probe_model": vid_model,
+    "http_status": status,
+    "supported": bool(status and 200 <= status < 300),
+    "error_excerpt": None if status and 200 <= status < 300 else excerpt(raw),
+})
+
+if chat_model:
+    msg_url = join_path(base_url, "v1/messages")
+    body = {
+        "model": chat_model,
+        "max_tokens": 8,
+        "messages": [{"role": "user", "content": "Reply OK only."}],
+    }
+    status, _, raw = request("POST", msg_url, body, {"anthropic-version": "2023-06-01"})
+    protocols.append({
+        "protocol": "anthropic_messages",
+        "method": "POST",
+        "path": "/v1/messages",
+        "url": msg_url,
+        "probe_model": chat_model,
+        "http_status": status,
+        "supported": bool(status and 200 <= status < 300),
+        "error_excerpt": None if status and 200 <= status < 300 else excerpt(raw),
+    })
+
+# modality breakdown
+modality_counts = {}
+for m in models:
+    mod = m.get("modality") or "unknown"
+    modality_counts[mod] = modality_counts.get(mod, 0) + 1
+
+print(json.dumps({
+    "verdict": "ok" if models else "partial",
+    "account": {
+        "id": int(account_id),
+        "name": account.get("name"),
+        "platform": account.get("platform"),
+        "type": account.get("type"),
+        "channel_type": account.get("channel_type"),
+        "base_url": base_url,
+    },
+    "upstream_models": {
+        "count": len(models),
+        "modality_counts": modality_counts,
+        "ids": [m["id"] for m in models],
+        "details": models,
+    },
+    "model_mapping_keys": mapped_models,
+    "protocols": protocols,
+}, ensure_ascii=False, indent=2))
+PY

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1142,6 +1142,16 @@
       "rationale": "Native Anthropic Messages passthrough for OpenAI-platform dual-stack relays (agent.tokensea.ai). Must forward /v1/messages directly with API key Bearer auth and wire model mapping instead of converting through Responses or CC bridges."
     },
     {
+      "path": "backend/internal/service/gateway_cloudwise_relay_test.go",
+      "must_contain": [
+        "TestAccount_IsOpenAICloudwiseRelay",
+        "TestOpenAICloudwiseRelayFloorIsProbeCuratedOnly",
+        "TestForwardAsAnthropic_CloudwiseNativeMessagesPassthrough",
+        "https://api.cloudwise.ai/api/v1/messages"
+      ],
+      "rationale": "Focused regressions for CloudWise MaaS relay (prod account #95): probe-curated model_mapping floor and native /v1/messages passthrough for CC clients."
+    },
+    {
       "path": "backend/internal/service/gateway_tokensea_anthropic_relay_test.go",
       "must_contain": [
         "TestAnthropicTokenseaRelayFloorMapsShortNamesToWireIDs",
@@ -2378,14 +2388,17 @@
         "accountModelMappingPlatformOpenAIAinzyRelay",
         "accountModelMappingPlatformOpenAITokenseaRelay",
         "accountModelMappingPlatformAnthropicTokenseaRelay",
+        "accountModelMappingPlatformOpenAICloudwiseRelay",
         "IsOpenAITokenseaRelay()",
         "openAITokenseaRelayAccountModelMappingFloor(",
         "IsAnthropicTokenseaRelay()",
         "anthropicTokenseaRelayModelMappingFloor(",
+        "IsOpenAICloudwiseRelay()",
+        "openAICloudwiseRelayAccountModelMappingFloor(",
         "func antigravityAccountModelMappingFloor(",
         "func grokAccountModelMappingFloor("
       ],
-      "rationale": "Single SSOT selector for account model_mapping. It applies runtime replacement scopes first, then derives explicit native mappings from served+priced+displayable catalogs, platform compatibility owners, Kiro presets, Bedrock defaults, and newapi channel display presets. Losing any branch silently breaks the all-platform explicit model_mapping policy or drops owner-declared compatibility aliases. ModelSurfaceBundleForOps emits the deterministic checksummed release projection once; rollout tools consume that artifact instead of compiling this package. Tokensea relay scopes (openai_tokensea_relay / anthropic_tokensea_relay) must stay wired so prod accounts #92/#93 keep probe-curated floors and short-name→wire-id mapping."
+      "rationale": "Single SSOT selector for account model_mapping. It applies runtime replacement scopes first, then derives explicit native mappings from served+priced+displayable catalogs, platform compatibility owners, Kiro presets, Bedrock defaults, and newapi channel display presets. Losing any branch silently breaks the all-platform explicit model_mapping policy or drops owner-declared compatibility aliases. ModelSurfaceBundleForOps emits the deterministic checksummed release projection once; rollout tools consume that artifact instead of compiling this package. Tokensea relay scopes (openai_tokensea_relay / anthropic_tokensea_relay) and CloudWise relay scope (openai_cloudwise_relay) must stay wired so prod relay accounts keep probe-curated floors."
     },
     {
       "path": "backend/internal/service/account_model_mapping_reconciler_test.go",
@@ -2603,7 +2616,8 @@
         "def cmd_activate(",
         "post_activation_gate",
         "anthropic_tokensea_relay",
-        "openai_tokensea_relay"
+        "openai_tokensea_relay",
+        "openai_cloudwise_relay"
       ],
       "rationale": "The single prod model-surface activation entry validates current/target bundle digests, rejects stale or incomplete independent probe/pricing evidence, defaults to a reviewed mapping dry-run, requires a fixed outer confirmation before the inner mapping apply, and fails unless the post-apply prod release gate passes. It deliberately never targets Edge; direct Edge diagnostics/apply remain a separate mapping-manager capability."
     },


### PR DESCRIPTION
## 摘要

- 对齐 #1635 tokensea 模式，为 CloudWise MaaS（prod 账号 #95，`base_url=https://api.cloudwise.ai/api`）补齐 OpenAI 兼容聚合网关能力识别。
- 新增 `IsOpenAICloudwiseRelay()`、28 模型 probe-curated catalog floor（`openai_cloudwise_relay` scope）及 migration `tk_078`：写入 `openai_native_messages_supported=true`、`openai_responses_supported=false`。
- 补充 modelops / runtime mapping / stage0 探针脚本与单元测试；`no-web-impact`。

## 风险

- **高风险锚点**：`tk_078` 仅修正 prod #95 的 extra capability 字段，不改 schema。
- **行为变更**：CloudWise 账号走 CC/Anthropic 客户端时将优先 `/v1/messages` 直通，不再误触 `/v1/responses`（上游实测 400）。
- **未覆盖**：embeddings/images/videos 协议上游仍异常；admin sync-upstream 对 CloudWise 返回 301，catalog floor 不依赖该按钮。

## 验证

- `go test -tags=unit ./internal/service/ -run 'Cloudwise|OpenAICloudwise' -count=1` 通过
- `go test -tags=unit ./internal/service/ -run TestExportAccountModelMappingSSOT -count=1` 通过
- `./scripts/preflight.sh` PASS
- `cd backend && go run ./cmd/account-model-mapping bundle --check` 通过

## 提交

- 40d84638d fix(gateway): CloudWise #95 全协议中继与 probe-curated mapping floor

最新提交：40d84638d

Made with [Cursor](https://cursor.com)