### PR TITLE
fix(gateway): CloudWise /v1/responses chat fallback 保留 Claude 上游模型

### DIFF
--- a/backend/internal/service/account_openai_dual_stack_relay_tk.go
+++ b/backend/internal/service/account_openai_dual_stack_relay_tk.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/gin-gonic/gin"
+)
+
+// IsOpenAIDualStackClaudeRelay reports OpenAI apikey accounts whose upstream is a
+// dual-stack relay (native /v1/messages + /v1/chat/completions) such as CloudWise
+// MaaS or agent.tokensea.ai.
+func (a *Account) IsOpenAIDualStackClaudeRelay() bool {
+	if a == nil || !a.IsOpenAI() || a.Type != AccountTypeAPIKey {
+		return false
+	}
+	if !openai_compat.ShouldUseNativeAnthropicMessagesAPI(a.Extra) {
+		return false
+	}
+	return a.IsOpenAICloudwiseRelay() || a.IsOpenAITokenseaRelay()
+}
+
+func (a *Account) openAIDualStackRelaySupportsModel(model string) bool {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false
+	}
+	switch {
+	case a.IsOpenAICloudwiseRelay():
+		_, ok := supportedOpenAICloudwiseRelayCatalogModels[model]
+		return ok
+	case a.IsOpenAITokenseaRelay():
+		_, ok := supportedOpenAITokenseaRelayCatalogModels[model]
+		return ok
+	default:
+		return false
+	}
+}
+
+// ResolveOpenAIResponsesChatFallbackBillingModel undoes group messages-dispatch
+// claude→gpt remapping for dual-stack relay accounts. Handler-level
+// tkApplyResponsesDispatchModelMapping runs before account selection, so
+// /v1/responses bodies may carry gpt-5.6-* while OpsModelKey still holds the
+// client's claude family name. Chat-fallback relays must forward the claude ID
+// the upstream actually serves.
+func (a *Account) ResolveOpenAIResponsesChatFallbackBillingModel(c *gin.Context, bodyModel string) string {
+	bodyModel = strings.TrimSpace(bodyModel)
+	if bodyModel == "" || !a.IsOpenAIDualStackClaudeRelay() {
+		return bodyModel
+	}
+	clientModel := bodyModel
+	if c != nil {
+		if opsModel := strings.TrimSpace(c.GetString(OpsModelKey)); opsModel != "" {
+			clientModel = opsModel
+		}
+	}
+	if clientModel == bodyModel {
+		return bodyModel
+	}
+	if claudeMessagesDispatchFamily(clientModel) == "" {
+		return bodyModel
+	}
+	if !a.openAIDualStackRelaySupportsModel(clientModel) {
+		return bodyModel
+	}
+	return clientModel
+}

--- a/backend/internal/service/account_openai_dual_stack_relay_tk_test.go
+++ b/backend/internal/service/account_openai_dual_stack_relay_tk_test.go
@@ -1,0 +1,30 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccount_ResolveOpenAIResponsesChatFallbackBillingModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+	c.Set(OpsModelKey, "claude-sonnet-4-6")
+
+	cloudwise := cloudwiseNativeMessagesAccount()
+	require.Equal(t, "claude-sonnet-4-6", cloudwise.ResolveOpenAIResponsesChatFallbackBillingModel(c, "gpt-5.6-terra"))
+
+	oauth := rawChatCompletionsTestAccount()
+	oauth.Extra = map[string]any{openai_compat.ExtraKeyResponsesSupported: true}
+	require.Equal(t, "gpt-5.6-terra", oauth.ResolveOpenAIResponsesChatFallbackBillingModel(c, "gpt-5.6-terra"))
+
+	require.Equal(t, "gpt-5.6-terra", cloudwise.ResolveOpenAIResponsesChatFallbackBillingModel(nil, "gpt-5.6-terra"))
+
+	cGPT, _ := gin.CreateTestContext(nil)
+	cGPT.Set(OpsModelKey, "gpt-5.4")
+	require.Equal(t, "gpt-5.4", cloudwise.ResolveOpenAIResponsesChatFallbackBillingModel(cGPT, "gpt-5.4"))
+}

--- a/backend/internal/service/gateway_cloudwise_relay_test.go
+++ b/backend/internal/service/gateway_cloudwise_relay_test.go
@@ -64,6 +64,36 @@ func TestOpenAICloudwiseRelayFloorIsProbeCuratedOnly(t *testing.T) {
 	requireIdentityMappingForIDs(t, mapping, supportedCatalogModelIDsFromMap(supportedOpenAICloudwiseRelayCatalogModels))
 }
 
+func TestForwardResponses_CloudwiseRelayPreservesClaudeModelOnChatFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.6-terra","input":"Reply OK only.","stream":false,"max_output_tokens":8}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Set(OpsModelKey, "claude-sonnet-4-6")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"chatcmpl-cw","object":"chat.completion","model":"claude-sonnet-4-6","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":1,"total_tokens":9}}`,
+		)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.Forward(context.Background(), c, cloudwiseNativeMessagesAccount(), body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/chat/completions", upstream.lastReq.URL.String())
+	require.Equal(t, "claude-sonnet-4-6", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "claude-sonnet-4-6", result.UpstreamModel)
+	require.Equal(t, "gpt-5.6-terra", result.Model)
+}
+
 func TestForwardAsAnthropic_CloudwiseNativeMessagesPassthrough(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_gateway_responses_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback.go
@@ -59,7 +59,8 @@ func (s *OpenAIGatewayService) forwardResponsesViaRawChatCompletions(
 		return nil, fmt.Errorf("convert responses to chat completions: %w", err)
 	}
 
-	billingModel := resolveOpenAIForwardModel(account, originalModel, "")
+	bodyBillingModel := account.ResolveOpenAIResponsesChatFallbackBillingModel(c, originalModel)
+	billingModel := resolveOpenAIForwardModel(account, bodyBillingModel, "")
 	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
 	reasoningEffort := extractOpenAIReasoningEffortFromBody(body, upstreamModel, billingModel, originalModel)
 	// 国产模型默认 effort 补充：需要 mappedModel 判定，推迟到 billingModel 算出之后。

--- a/ops/stage0/probe_cloudwise_upstream_matrix.sh
+++ b/ops/stage0/probe_cloudwise_upstream_matrix.sh
@@ -29,7 +29,7 @@ SELECT json_build_object(
   'channel_type', a.channel_type,
   'api_key', COALESCE(a.credentials->>'api_key', ''),
   'base_url', COALESCE(a.credentials->>'base_url', ''),
-  'model_mapping', COALESCE(a.extra->'model_mapping', '{{}}'::jsonb)
+  'model_mapping', COALESCE(a.credentials->'model_mapping', '{{}}'::jsonb)
 )::text
 FROM accounts a
 WHERE a.id={account_id} AND a.deleted_at IS NULL;

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1146,6 +1146,7 @@
       "must_contain": [
         "TestAccount_IsOpenAICloudwiseRelay",
         "TestOpenAICloudwiseRelayFloorIsProbeCuratedOnly",
+        "TestForwardResponses_CloudwiseRelayPreservesClaudeModelOnChatFallback",
         "TestForwardAsAnthropic_CloudwiseNativeMessagesPassthrough",
         "https://api.cloudwise.ai/api/v1/messages"
       ],


### PR DESCRIPTION
## 摘要

- 修复 CloudWise/Tokensea 双栈 relay 在 `/v1/responses` → chat fallback 路径上被 group messages-dispatch 误映射为 `gpt-5.6-terra` 的问题；通过 `OpsModelKey` 还原客户端 Claude 模型再转发上游。
- 补充回归测试与 sentinel 锚点；修正 `probe_cloudwise_upstream_matrix.sh` 从 `credentials.model_mapping` 读取（此前误读 `extra`）。

## 风险

- **行为变更**：仅影响 `openai_native_messages_supported=true` 且 `openai_responses_supported=false` 的 OpenAI apikey 双栈 relay（CloudWise #95、Tokensea #92 同类）；Codex OAuth 账号 dispatch 映射不变。
- **无 schema / 无 migration**；`no-web-impact`。

## 验证

- `go test -tags=unit ./internal/service/ -run 'CloudwiseRelayPreserves|ResolveOpenAIResponsesChatFallback|DualStack' -count=1` 通过
- `./scripts/preflight.sh` PASS

## 提交

- b00cc9ef8 fix(gateway): CloudWise /v1/responses chat fallback 保留 Claude 上游模型

最新提交：b00cc9ef8

Made with [Cursor](https://cursor.com)