### PR TITLE
fix(gateway): tokensea #92 messages/responses 选号与 dispatch 对齐 chat

### DIFF
--- a/backend/internal/handler/openai_gateway_count_tokens.go
+++ b/backend/internal/handler/openai_gateway_count_tokens.go
@@ -151,9 +151,6 @@ func (h *OpenAIGatewayHandler) CountTokens(c *gin.Context) {
 	c.Request = c.Request.WithContext(service.WithOpenAIProfitControlSuppressed(c.Request.Context()))
 	sessionHash := h.gatewayService.GenerateSessionHash(c, body)
 	currentRoutingModel := routingModel
-	if preferredMappedModel != "" {
-		currentRoutingModel = preferredMappedModel
-	}
 	selection, _, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
 		c.Request.Context(),
 		apiKey.GroupID,

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -380,12 +380,8 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	if channelMapping.Mapped && h.rejectDeprecatedOpenAICompatMappedModel(c, apiKey, channelMapping.MappedModel, false) {
 		return
 	}
-	// TK: /v1/responses 入口补套 group messages-dispatch 模型映射（claude 家族名 →
-	// 配置的 gpt 模型），与 /v1/messages、/v1/chat/completions 同源。否则裸 claude 名
-	// 透传 Codex/ChatGPT 后端会被上游拒为 400 "model not supported"。
-	// 见 openai_gateway_handler_tk_responses_dispatch.go。
-	forwardBody = tkApplyResponsesDispatchModelMapping(apiKey, forwardBody, h.gatewayService.ReplaceModelInBody)
-	if h.rejectDeprecatedOpenAICompatMappedModel(c, apiKey, gjson.GetBytes(forwardBody, "model").String(), false) {
+	dispatchMappedModel := resolveOpenAIMessagesDispatchMappedModel(apiKey, reqModel)
+	if h.rejectDeprecatedOpenAICompatMappedModel(c, apiKey, dispatchMappedModel, false) {
 		return
 	}
 
@@ -454,11 +450,10 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	var oauth429FailoverState service.OpenAIOAuth429FailoverState
 	var passthroughFailoverState openAIPassthroughFailoverState
 
-	// TK: route account selection on the same dispatch-mapped model that the forward
-	// body carries (claude 家族名 → 配置 gpt 模型），与 /v1/messages 对齐，避免
-	// scheduler 的渠道计价/模型限制与粘性按一个永不真打到上游的 claude 名判定。
-	// 见 openai_gateway_handler_tk_responses_dispatch.go。
-	selectionModel := tkResolveResponsesSelectionModel(apiKey, reqModel)
+	// TK: account selection routes on the client-requested model (canonicalized),
+	// matching /v1/chat/completions. Group dispatch mapping applies per-account at
+	// forward time for OAuth/Codex paths; tokensea relays keep Claude wire IDs.
+	selectionModel := service.CanonicalizeOpenAICompatRoutingModel(reqModel)
 	// 生图意图的 /v1/responses 请求必须调度到确实支持 Responses API 的账号，否则
 	// 会在 forward 阶段被静默降级为无法生图的 Chat Completions 直转（#4417）。
 	// 仅对 OpenAI 平台生效：Grok 生图走独立的 forwardGrokResponses 路径，不应被过滤。
@@ -572,6 +567,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		// Channel model mapping is already applied to forwardBody before the loop.
 		writerSizeBeforeForward := service.OpenAICompactKeepaliveAdjustedWrittenSize(c)
 		dispatchBody := forwardBody
+		if tkShouldApplyMessagesDispatchBodyMapping(account) {
+			dispatchBody = tkApplyResponsesDispatchModelMapping(apiKey, forwardBody, h.gatewayService.ReplaceModelInBody)
+		}
 		if len(failedAccountIDs) > 0 {
 			dispatchBody = service.TkStripEncryptedReasoningForFailover(dispatchBody)
 		}
@@ -1091,10 +1089,10 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		if failoverClientGone(c) {
 			return
 		}
+		// Route selection on the client-requested model (same as /v1/chat/completions).
+		// effectiveMappedModel is still passed to ForwardAsAnthropic as the OAuth/CC
+		// dispatch fallback when account-level mapping does not match.
 		currentRoutingModel := routingModel
-		if effectiveMappedModel != "" {
-			currentRoutingModel = effectiveMappedModel
-		}
 		reqLog.Debug("openai_messages.account_selecting", zap.Int("excluded_account_count", len(failedAccountIDs)))
 		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
 			c.Request.Context(),

--- a/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch.go
@@ -42,18 +42,3 @@ func tkApplyResponsesDispatchModelMapping(
 	}
 	return replace(forwardBody, mapped)
 }
-
-// tkResolveResponsesSelectionModel returns the model name the /v1/responses
-// account-selection step should route on. When the requested model is a claude
-// family name it returns the group dispatch-mapped gpt model (parity with
-// /v1/messages, which selects on its preferredMappedModel), so the scheduler's
-// channel-pricing / model-restriction filtering and load/sticky decisions see the
-// real upstream-bound model rather than a claude name that never reaches the
-// upstream. Non-claude models (mapping returns "") and nil apiKey fall through to
-// the original requested model unchanged.
-func tkResolveResponsesSelectionModel(apiKey *service.APIKey, requestedModel string) string {
-	if mapped := resolveOpenAIMessagesDispatchMappedModel(apiKey, requestedModel); mapped != "" {
-		return service.CanonicalizeOpenAICompatRoutingModel(mapped)
-	}
-	return service.CanonicalizeOpenAICompatRoutingModel(requestedModel)
-}

--- a/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch_test.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch_test.go
@@ -89,35 +89,3 @@ func Test_tkApplyResponsesDispatchModelMapping(t *testing.T) {
 		}
 	})
 }
-
-// Test_tkResolveResponsesSelectionModel pins that account selection routes on the
-// dispatch-mapped gpt model for claude family names (parity with /v1/messages) and
-// leaves non-claude names / nil apiKey unchanged.
-func Test_tkResolveResponsesSelectionModel(t *testing.T) {
-	openaiDefaults, ok := service.TkMessagesDispatchPlatformDefaults(service.PlatformOpenAI)
-	if !ok {
-		t.Fatal("openai platform_defaults missing from tk_messages_dispatch_family_registry.json")
-	}
-	keyWith := func(cfg service.OpenAIMessagesDispatchModelConfig) *service.APIKey {
-		return &service.APIKey{Group: &service.Group{ID: 2, Platform: service.PlatformOpenAI, MessagesDispatchModelConfig: cfg}}
-	}
-
-	cases := []struct {
-		name      string
-		apiKey    *service.APIKey
-		requested string
-		want      string
-	}{
-		{"claude opus routes on configured gpt", keyWith(service.OpenAIMessagesDispatchModelConfig{OpusMappedModel: "gpt-5.5"}), "claude-opus-4-7", "gpt-5.5"},
-		{"claude opus routes on default gpt when unset", keyWith(service.OpenAIMessagesDispatchModelConfig{}), "claude-opus-4-7", openaiDefaults.OpusMappedModel},
-		{"non-claude model routes unchanged", keyWith(service.OpenAIMessagesDispatchModelConfig{OpusMappedModel: "gpt-5.5"}), "gpt-5.5", "gpt-5.5"},
-		{"nil apiKey routes unchanged", nil, "claude-opus-4-7", "claude-opus-4-7"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := tkResolveResponsesSelectionModel(tc.apiKey, tc.requested); got != tc.want {
-				t.Fatalf("selection model = %q, want %q", got, tc.want)
-			}
-		})
-	}
-}

--- a/backend/internal/handler/openai_gateway_handler_tk_tokensea_routing.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_tokensea_routing.go
@@ -1,0 +1,31 @@
+package handler
+
+import (
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// tkShouldApplyMessagesDispatchBodyMapping reports whether group-level
+// messages-dispatch claude→gpt body rewrite should run for this account on
+// /v1/responses forward attempts.
+//
+// Tokensea-style OpenAI API-key relays expose native /v1/messages and CC-only
+// upstreams: rewriting claude family names to configured gpt dispatch models
+// breaks account selection (scheduler sees gpt IDs absent from relay mapping)
+// and forward (upstream expects Claude wire IDs). OAuth Codex accounts still
+// need the rewrite so ChatGPT backends do not reject raw claude names.
+func tkShouldApplyMessagesDispatchBodyMapping(account *service.Account) bool {
+	if account == nil {
+		return true
+	}
+	if account.Type != service.AccountTypeAPIKey {
+		return true
+	}
+	if openai_compat.ShouldUseNativeAnthropicMessagesAPI(account.Extra) {
+		return false
+	}
+	if !openai_compat.ShouldUseResponsesAPI(account.Extra) {
+		return false
+	}
+	return true
+}

--- a/backend/internal/handler/openai_gateway_handler_tk_tokensea_routing_test.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_tokensea_routing_test.go
@@ -1,0 +1,114 @@
+//go:build unit
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/tidwall/gjson"
+)
+
+func Test_tkShouldApplyMessagesDispatchBodyMapping(t *testing.T) {
+	tokenseaExtra := map[string]any{
+		openai_compat.ExtraKeyNativeMessagesSupported: true,
+		openai_compat.ExtraKeyResponsesSupported:      false,
+	}
+	ccOnlyExtra := map[string]any{
+		openai_compat.ExtraKeyResponsesSupported: false,
+	}
+
+	cases := []struct {
+		name    string
+		account *service.Account
+		want    bool
+	}{
+		{
+			name:    "nil account keeps dispatch mapping",
+			account: nil,
+			want:    true,
+		},
+		{
+			name: "oauth account keeps dispatch mapping",
+			account: &service.Account{
+				Type: service.AccountTypeOAuth,
+			},
+			want: true,
+		},
+		{
+			name: "tokensea native messages relay skips dispatch mapping",
+			account: &service.Account{
+				Type:  service.AccountTypeAPIKey,
+				Extra: tokenseaExtra,
+			},
+			want: false,
+		},
+		{
+			name: "api key cc-only relay skips dispatch mapping",
+			account: &service.Account{
+				Type:  service.AccountTypeAPIKey,
+				Extra: ccOnlyExtra,
+			},
+			want: false,
+		},
+		{
+			name: "generic api key relay keeps dispatch mapping",
+			account: &service.Account{
+				Type: service.AccountTypeAPIKey,
+				Extra: map[string]any{
+					openai_compat.ExtraKeyResponsesSupported: true,
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tkShouldApplyMessagesDispatchBodyMapping(tc.account); got != tc.want {
+				t.Fatalf("tkShouldApplyMessagesDispatchBodyMapping() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_tkApplyResponsesDispatchModelMapping_skippedForTokenseaRelay(t *testing.T) {
+	openaiDefaults, ok := service.TkMessagesDispatchPlatformDefaults(service.PlatformOpenAI)
+	if !ok {
+		t.Fatal("openai platform_defaults missing from tk_messages_dispatch_family_registry.json")
+	}
+	apiKey := &service.APIKey{Group: &service.Group{
+		ID:       2,
+		Platform: service.PlatformOpenAI,
+	}}
+	body := []byte(`{"model":"claude-haiku-4-5-20251001","input":[]}`)
+	replace := func(body []byte, newModel string) []byte {
+		return service.ReplaceModelInBody(body, newModel)
+	}
+
+	tokensea := &service.Account{
+		Type: service.AccountTypeAPIKey,
+		Extra: map[string]any{
+			openai_compat.ExtraKeyNativeMessagesSupported: true,
+			openai_compat.ExtraKeyResponsesSupported:      false,
+		},
+	}
+
+	dispatchBody := body
+	if tkShouldApplyMessagesDispatchBodyMapping(tokensea) {
+		dispatchBody = tkApplyResponsesDispatchModelMapping(apiKey, body, replace)
+	}
+	if got := gjson.GetBytes(dispatchBody, "model").String(); got != "claude-haiku-4-5-20251001" {
+		t.Fatalf("tokensea forward model = %q, want claude-haiku-4-5-20251001", got)
+	}
+
+	oauth := &service.Account{Type: service.AccountTypeOAuth}
+	dispatchBody = body
+	if tkShouldApplyMessagesDispatchBodyMapping(oauth) {
+		dispatchBody = tkApplyResponsesDispatchModelMapping(apiKey, body, replace)
+	}
+	if got := gjson.GetBytes(dispatchBody, "model").String(); got != openaiDefaults.HaikuMappedModel {
+		t.Fatalf("oauth forward model = %q, want %q", got, openaiDefaults.HaikuMappedModel)
+	}
+}

--- a/backend/internal/handler/openai_gateway_handler_tk_tokensea_routing_test.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_tokensea_routing_test.go
@@ -73,7 +73,7 @@ func Test_tkShouldApplyMessagesDispatchBodyMapping(t *testing.T) {
 	}
 }
 
-func Test_tkApplyResponsesDispatchModelMapping_skippedForTokenseaRelay(t *testing.T) {
+func Test_tkApplyResponsesDispatchModelMapping_skippedForAPIKeyRelays(t *testing.T) {
 	openaiDefaults, ok := service.TkMessagesDispatchPlatformDefaults(service.PlatformOpenAI)
 	if !ok {
 		t.Fatal("openai platform_defaults missing from tk_messages_dispatch_family_registry.json")
@@ -87,24 +87,46 @@ func Test_tkApplyResponsesDispatchModelMapping_skippedForTokenseaRelay(t *testin
 		return service.ReplaceModelInBody(body, newModel)
 	}
 
-	tokensea := &service.Account{
-		Type: service.AccountTypeAPIKey,
-		Extra: map[string]any{
-			openai_compat.ExtraKeyNativeMessagesSupported: true,
-			openai_compat.ExtraKeyResponsesSupported:      false,
+	relayCases := []struct {
+		name    string
+		account *service.Account
+	}{
+		{
+			name: "tokensea native messages relay",
+			account: &service.Account{
+				Type: service.AccountTypeAPIKey,
+				Extra: map[string]any{
+					openai_compat.ExtraKeyNativeMessagesSupported: true,
+					openai_compat.ExtraKeyResponsesSupported:      false,
+				},
+			},
+		},
+		{
+			name: "cloudwise native messages relay",
+			account: &service.Account{
+				Type: service.AccountTypeAPIKey,
+				Extra: map[string]any{
+					openai_compat.ExtraKeyNativeMessagesSupported: true,
+					openai_compat.ExtraKeyResponsesSupported:      false,
+				},
+			},
 		},
 	}
 
-	dispatchBody := body
-	if tkShouldApplyMessagesDispatchBodyMapping(tokensea) {
-		dispatchBody = tkApplyResponsesDispatchModelMapping(apiKey, body, replace)
-	}
-	if got := gjson.GetBytes(dispatchBody, "model").String(); got != "claude-haiku-4-5-20251001" {
-		t.Fatalf("tokensea forward model = %q, want claude-haiku-4-5-20251001", got)
+	for _, tc := range relayCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatchBody := body
+			if tkShouldApplyMessagesDispatchBodyMapping(tc.account) {
+				dispatchBody = tkApplyResponsesDispatchModelMapping(apiKey, body, replace)
+			}
+			if got := gjson.GetBytes(dispatchBody, "model").String(); got != "claude-haiku-4-5-20251001" {
+				t.Fatalf("relay forward model = %q, want claude-haiku-4-5-20251001", got)
+			}
+		})
 	}
 
 	oauth := &service.Account{Type: service.AccountTypeOAuth}
-	dispatchBody = body
+	dispatchBody := body
 	if tkShouldApplyMessagesDispatchBodyMapping(oauth) {
 		dispatchBody = tkApplyResponsesDispatchModelMapping(apiKey, body, replace)
 	}

--- a/ops/stage0/probe_cloudwise_upstream_matrix.sh
+++ b/ops/stage0/probe_cloudwise_upstream_matrix.sh
@@ -29,7 +29,7 @@ SELECT json_build_object(
   'channel_type', a.channel_type,
   'api_key', COALESCE(a.credentials->>'api_key', ''),
   'base_url', COALESCE(a.credentials->>'base_url', ''),
-  'model_mapping', COALESCE(a.extra->'model_mapping', '{{}}'::jsonb)
+  'model_mapping', COALESCE(a.credentials->'model_mapping', '{{}}'::jsonb)
 )::text
 FROM accounts a
 WHERE a.id={account_id} AND a.deleted_at IS NULL;

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4708,19 +4708,28 @@
     {
       "path": "backend/internal/handler/openai_gateway_handler.go",
       "must_contain": [
-        "forwardBody = tkApplyResponsesDispatchModelMapping(apiKey, forwardBody, h.gatewayService.ReplaceModelInBody)",
-        "selectionModel := tkResolveResponsesSelectionModel(apiKey, reqModel)"
+        "selectionModel := service.CanonicalizeOpenAICompatRoutingModel(reqModel)",
+        "if tkShouldApplyMessagesDispatchBodyMapping(account) {",
+        "dispatchBody = tkApplyResponsesDispatchModelMapping(apiKey, forwardBody, h.gatewayService.ReplaceModelInBody)",
+        "// effectiveMappedModel is still passed to ForwardAsAnthropic"
       ],
-      "rationale": "TK fix (PR #809): the two thin injection points that make the /v1/responses inbound handler apply the group messages_dispatch_model_config mapping (claude family name -> configured gpt model), at parity with /v1/messages and /v1/chat/completions. (1) tkApplyResponsesDispatchModelMapping rewrites the forward-body model before dispatch so a claude model name (e.g. claude-opus-4-7) is not sent raw to the Codex/ChatGPT backend, which rejects it with upstream 400 'model not supported when using Codex with a ChatGPT account'. (2) tkResolveResponsesSelectionModel routes account selection on the same mapped model so the scheduler's channel-pricing / model-restriction filtering and load/sticky decisions see the real upstream-bound model instead of a claude name that never reaches the upstream. service.Forward resolves the upstream model via account-level GetMappedModel + codex normalization and never consults the group dispatch config, so the body must be rewritten here. An upstream merge that rewrites the Responses handler forward-body construction or the account-selection loop would silently drop either hook and regress the fix. Pairs with the openai_gateway_handler_tk_responses_dispatch.go sentinel."
+      "rationale": "TK /v1/responses routing: account selection uses the client-requested model (parity with /v1/chat/completions) so tokensea relays whose model_mapping lists Claude wire IDs remain selectable. Per-account forward attempts apply tkApplyResponsesDispatchModelMapping only when tkShouldApplyMessagesDispatchBodyMapping(account) is true (OAuth/Codex paths); tokensea API-key relays skip the claude→gpt rewrite so CC fallback keeps Claude upstream IDs. An upstream merge that restores global pre-loop dispatch mapping or dispatch-mapped selection silently breaks tokensea #92 responses/messages. Pairs with openai_gateway_handler_tk_tokensea_routing.go and openai_gateway_handler_tk_responses_dispatch.go sentinels."
     },
     {
       "path": "backend/internal/handler/openai_gateway_handler_tk_responses_dispatch.go",
       "must_contain": [
-        "func tkApplyResponsesDispatchModelMapping(",
-        "func tkResolveResponsesSelectionModel(",
-        "CanonicalizeOpenAICompatRoutingModel"
+        "func tkApplyResponsesDispatchModelMapping("
       ],
-      "rationale": "TK companion (PR #809) holding the /v1/responses dispatch model-mapping helpers: forward-body rewrite (tkApplyResponsesDispatchModelMapping) and account-selection model (tkResolveResponsesSelectionModel). tkResolveResponsesSelectionModel must canonicalize via CanonicalizeOpenAICompatRoutingModel so gpt alias spellings hit the same restriction/negative-cache keys as /v1/chat/completions (newapi GLM/Qwen/Doubao responses SSOT parity). Load-bearing: deleting the file silently regresses /v1/responses for claude model names (upstream 400) and the responses<->messages selection parity. Anchored so an upstream merge or refactor cannot remove the companion without tripping the sentinel; pairs with the openai_gateway_handler.go injection-site sentinel above."
+      "rationale": "TK companion (PR #809) holding tkApplyResponsesDispatchModelMapping: rewrites /v1/responses forward-body claude family names to group messages_dispatch_model_config gpt models for OAuth/Codex upstreams. Invoked per-account from openai_gateway_handler.go when tkShouldApplyMessagesDispatchBodyMapping(account) is true. Deleting the helper silently regresses Codex /v1/responses for claude model names (upstream 400). Pairs with the openai_gateway_handler.go injection-site sentinel."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_handler_tk_tokensea_routing.go",
+      "must_contain": [
+        "func tkShouldApplyMessagesDispatchBodyMapping(",
+        "ShouldUseNativeAnthropicMessagesAPI",
+        "ShouldUseResponsesAPI"
+      ],
+      "rationale": "TK tokensea relay guard: skips group messages-dispatch claude→gpt body rewrite for API-key accounts with native /v1/messages and/or CC-only upstream (openai_responses_supported=false). Without this companion, /v1/responses would rewrite Claude wire IDs to gpt dispatch models before forwardResponsesViaRawChatCompletions, breaking agent.tokensea.ai relays. Pairs with openai_gateway_handler.go per-account dispatch injection sentinel."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_kiro_mirror_scheduling.go",


### PR DESCRIPTION
## 摘要

- 修复 prod OpenAI API-key relay 账号（tokensea #92 / CloudWise 类 native messages relay）在 `/v1/messages` 与 `/v1/responses` 因 dispatch 模型污染导致的 `Unsupported model` 问题
- 根因：messages/responses 早于账号选择使用 group dispatch 的 claude→gpt 模型；API-key relay 的 `credentials.model_mapping` 与上游 wire ID 需要 Claude 原名，OAuth/Codex 路径才需要 GPT dispatch 名
- 变更：选号与 `/v1/chat/completions` 对齐，使用 canonical client-requested model；`/v1/responses` body rewrite 改为按选中账号条件应用，OAuth/Codex 保留 dispatch，native messages / CC-only API-key relay 跳过 dispatch
- 折入 #1637 的必要部分：CloudWise upstream matrix probe 改读 `credentials.model_mapping`，并补 CloudWise relay 覆盖；未保留服务层 fallback resolver，避免在下游补救已可在 handler 根治的问题

## 风险

- 常规风险：OpenAI 分组内混合 OAuth/Codex 与 API-key relay 时，账号选择统一走请求模型；当前与 chat completions 行为一致，且 scheduler 内部会再次 canonicalize
- OAuth `/v1/responses` 仍会在 forward body 阶段应用 dispatch 映射，避免 ChatGPT/Codex 上游收到 raw Claude family ID
- API-key relay 若声明 native messages 或 CC-only responses fallback，则保持 Claude wire ID 直传上游，避免与账号 `model_mapping` 语义错位

## 验证

- `go test -tags=unit ./internal/handler/ -run 'Test_tkShouldApplyMessagesDispatchBodyMapping|Test_tkApplyResponsesDispatchModelMapping' -count=1` — PASS
- PR CI — PASS：unit / integration / frontend / preflight / golangci-lint / security / shell / registry drift / ancestry guard
- 合并发版后建议重跑 prod probe：
  ```bash
  bash ops/observability/run-probe.sh --target prod     --script ops/stage0/probe_account_model.sh     --with ops/pricing/probe_reserved_resources.sh     --env ACCOUNT_ID=92 --env MODEL=claude-haiku-4-5-20251001     --env ENDPOINT=messages --env MAX_TOKENS=16
  ```

## 提交

- e889751f2 fix(gateway): align tokensea relay routing with chat selection
- b213e6475 fix(gateway): fold cloudwise relay guard into tokensea routing

最新提交：b213e6475

Made with [Cursor](https://cursor.com)