### PR TITLE
fix(openai): 上游无 5h 窗口时隐藏 OpenAI OAuth 用量条

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -940,10 +940,9 @@ func (s *AccountUsageService) attachOpenAICodexWindowStats(ctx context.Context, 
 		return
 	}
 	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.FiveHour, 5*time.Hour, now)); err == nil {
-		if usage.FiveHour == nil {
-			usage.FiveHour = &UsageProgress{Utilization: 0}
+		if usage.FiveHour != nil {
+			usage.FiveHour.WindowStats = windowStatsFromAccountStats(stats)
 		}
-		usage.FiveHour.WindowStats = windowStatsFromAccountStats(stats)
 	}
 	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.SevenDay, 7*24*time.Hour, now)); err == nil {
 		if usage.SevenDay == nil {
@@ -1571,6 +1570,23 @@ func windowStatsFromAccountStats(stats *usagestats.AccountStats) *WindowStats {
 	}
 }
 
+func codexExtraCanonicalWindowAbsent(extra map[string]any, window string) bool {
+	var wmKey string
+	switch window {
+	case "5h":
+		wmKey = "codex_5h_window_minutes"
+	case "7d":
+		wmKey = "codex_7d_window_minutes"
+	default:
+		return false
+	}
+	raw, ok := extra[wmKey]
+	if !ok {
+		return false
+	}
+	return parseExtraInt(raw) <= 0
+}
+
 func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now time.Time) *UsageProgress {
 	if len(extra) == 0 {
 		return nil
@@ -1597,6 +1613,9 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 
 	usedRaw, ok := extra[usedPercentKey]
 	if !ok {
+		return nil
+	}
+	if codexExtraCanonicalWindowAbsent(extra, window) {
 		return nil
 	}
 

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -288,10 +288,23 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 		extra := map[string]any{
 			"codex_7d_used_percent": 88.0,
 			"codex_7d_reset_at":     "2026-03-15T00:00:00Z", // yesterday
+			"codex_7d_window_minutes": 10080,
 		}
 		progress := buildCodexUsageProgressFromExtra(extra, "7d", now)
 		if progress != nil {
 			t.Fatalf("expected nil progress for expired 7d window, got %#v", progress)
+		}
+	})
+
+	t.Run("zero window minutes means upstream 5h absent", func(t *testing.T) {
+		extra := map[string]any{
+			"codex_5h_used_percent":   0.0,
+			"codex_5h_window_minutes": 0,
+			"codex_5h_reset_at":       now.Add(2 * time.Hour).Format(time.RFC3339),
+		}
+		progress := buildCodexUsageProgressFromExtra(extra, "5h", now)
+		if progress != nil {
+			t.Fatalf("expected nil progress when codex_5h_window_minutes=0, got %#v", progress)
 		}
 	})
 }

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -286,8 +286,8 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 
 	t.Run("expired 7d window drops stale upstream sample", func(t *testing.T) {
 		extra := map[string]any{
-			"codex_7d_used_percent": 88.0,
-			"codex_7d_reset_at":     "2026-03-15T00:00:00Z", // yesterday
+			"codex_7d_used_percent":   88.0,
+			"codex_7d_reset_at":       "2026-03-15T00:00:00Z", // yesterday
 			"codex_7d_window_minutes": 10080,
 		}
 		progress := buildCodexUsageProgressFromExtra(extra, "7d", now)

--- a/backend/internal/service/account_usage_service_tk_passive_batch.go
+++ b/backend/internal/service/account_usage_service_tk_passive_batch.go
@@ -251,10 +251,7 @@ func applyPreloadedCodexWindowStats(usage *UsageInfo, preloaded *localWindowStat
 	if usage == nil || preloaded == nil {
 		return
 	}
-	if preloaded.fiveHour != nil {
-		if usage.FiveHour == nil {
-			usage.FiveHour = &UsageProgress{Utilization: 0}
-		}
+	if preloaded.fiveHour != nil && usage.FiveHour != nil {
 		usage.FiveHour.WindowStats = windowStatsFromAccountStats(preloaded.fiveHour)
 	}
 	if preloaded.sevenDay != nil {

--- a/backend/internal/service/account_usage_service_tk_passive_batch_test.go
+++ b/backend/internal/service/account_usage_service_tk_passive_batch_test.go
@@ -149,11 +149,11 @@ func TestAccountUsageService_GetPassiveUsage_OpenAIOAuthExpiredCodexFallsBackToL
 		Platform: PlatformOpenAI,
 		Type:     AccountTypeOAuth,
 		Extra: map[string]any{
-			"codex_5h_used_percent": 42.0,
-			"codex_5h_reset_at":     now.Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+			"codex_5h_used_percent":   42.0,
+			"codex_5h_reset_at":       now.Add(-2 * time.Hour).UTC().Format(time.RFC3339),
 			"codex_5h_window_minutes": 0,
-			"codex_7d_used_percent": 34.0,
-			"codex_7d_reset_at":     now.Add(5 * 24 * time.Hour).UTC().Format(time.RFC3339),
+			"codex_7d_used_percent":   34.0,
+			"codex_7d_reset_at":       now.Add(5 * 24 * time.Hour).UTC().Format(time.RFC3339),
 			"codex_7d_window_minutes": 10080,
 		},
 	}

--- a/backend/internal/service/account_usage_service_tk_passive_batch_test.go
+++ b/backend/internal/service/account_usage_service_tk_passive_batch_test.go
@@ -151,8 +151,10 @@ func TestAccountUsageService_GetPassiveUsage_OpenAIOAuthExpiredCodexFallsBackToL
 		Extra: map[string]any{
 			"codex_5h_used_percent": 42.0,
 			"codex_5h_reset_at":     now.Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+			"codex_5h_window_minutes": 0,
 			"codex_7d_used_percent": 34.0,
 			"codex_7d_reset_at":     now.Add(5 * 24 * time.Hour).UTC().Format(time.RFC3339),
+			"codex_7d_window_minutes": 10080,
 		},
 	}
 	logRepo := &passiveBatchUsageLogRepo{
@@ -165,11 +167,7 @@ func TestAccountUsageService_GetPassiveUsage_OpenAIOAuthExpiredCodexFallsBackToL
 
 	usage, err := svc.GetPassiveUsage(context.Background(), 56)
 	require.NoError(t, err)
-	require.NotNil(t, usage.FiveHour)
-	require.Zero(t, usage.FiveHour.Utilization, "expired codex 5h must not surface stale used%%")
-	require.NotNil(t, usage.FiveHour.WindowStats)
-	require.Equal(t, int64(1), usage.FiveHour.WindowStats.Requests)
-	require.Equal(t, 9.5, usage.FiveHour.WindowStats.Cost)
+	require.Nil(t, usage.FiveHour, "expired/absent upstream 5h must not render a synthetic five_hour row")
 	require.NotNil(t, usage.SevenDay)
 	require.Equal(t, 34.0, usage.SevenDay.Utilization)
 }

--- a/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
@@ -323,3 +323,73 @@ func TestNormalize_ProdLayoutUsedPercentPassthrough(t *testing.T) {
 		}
 	})
 }
+
+// TestNormalize_7dOnlyLayoutOmits5h pins the 2026-08 prod header shape: primary=7d
+// (10080min) with secondary window_minutes=0 must not synthesize a 5h bucket.
+func TestNormalize_7dOnlyLayoutOmits5h(t *testing.T) {
+	win7d := 10080
+	zeroWin := 0
+	used7d := 37.0
+	usedSecondary := 0.0
+	secondaryReset := 0
+
+	snapshot := &OpenAICodexUsageSnapshot{
+		PrimaryUsedPercent:         &used7d,
+		PrimaryWindowMinutes:       &win7d,
+		PrimaryResetAfterSeconds:   intPtrCodexTest(436970),
+		SecondaryUsedPercent:       &usedSecondary,
+		SecondaryWindowMinutes:     &zeroWin,
+		SecondaryResetAfterSeconds: &secondaryReset,
+	}
+
+	n := snapshot.Normalize()
+	if n == nil {
+		t.Fatal("expected non-nil normalized")
+	}
+	if n.Used5hPercent != nil || n.Window5hMinutes != nil {
+		t.Fatalf("expected no 5h fields, got Used5hPercent=%v Window5hMinutes=%v", n.Used5hPercent, n.Window5hMinutes)
+	}
+	if n.Used7dPercent == nil || *n.Used7dPercent != 37.0 {
+		t.Fatalf("Used7dPercent = %v, want 37", n.Used7dPercent)
+	}
+	if n.Window7dMinutes == nil || *n.Window7dMinutes != 10080 {
+		t.Fatalf("Window7dMinutes = %v, want 10080", n.Window7dMinutes)
+	}
+}
+
+func TestBuildCodexUsageExtraUpdates_7dOnlyLayoutOmits5hFields(t *testing.T) {
+	win7d := 10080
+	zeroWin := 0
+	used7d := 37.0
+	usedSecondary := 0.0
+	secondaryReset := 0
+	reset7d := 436970
+
+	snapshot := &OpenAICodexUsageSnapshot{
+		PrimaryUsedPercent:         &used7d,
+		PrimaryWindowMinutes:       &win7d,
+		PrimaryResetAfterSeconds:   &reset7d,
+		SecondaryUsedPercent:       &usedSecondary,
+		SecondaryWindowMinutes:     &zeroWin,
+		SecondaryResetAfterSeconds: &secondaryReset,
+		UpdatedAt:                  "2026-08-12T23:39:13Z",
+	}
+
+	updates := buildCodexUsageExtraUpdates(snapshot, time.Date(2026, 8, 12, 23, 39, 13, 0, time.UTC))
+	if updates == nil {
+		t.Fatal("expected non-nil updates")
+	}
+	if _, ok := updates["codex_5h_used_percent"]; ok {
+		t.Fatalf("did not expect codex_5h_used_percent: %v", updates["codex_5h_used_percent"])
+	}
+	if _, ok := updates["codex_5h_reset_at"]; ok {
+		t.Fatalf("did not expect codex_5h_reset_at: %v", updates["codex_5h_reset_at"])
+	}
+	if got := updates["codex_7d_used_percent"]; got != 37.0 {
+		t.Fatalf("codex_7d_used_percent = %v, want 37", got)
+	}
+}
+
+func intPtrCodexTest(v int) *int {
+	return &v
+}

--- a/backend/internal/service/openai_gateway_service_tk_codex_usage_snapshot.go
+++ b/backend/internal/service/openai_gateway_service_tk_codex_usage_snapshot.go
@@ -48,6 +48,10 @@ type NormalizedCodexLimits struct {
 // 99% used cannot coexist with a 7d that is 1% used. 5h is now passed through
 // like 7d. Do NOT reintroduce a 100-raw inversion without a fresh raw-header
 // capture proving remaining% semantics.
+//
+// Upstream layout drift (2026-08 prod): OpenAI may send only a 7d primary window
+// (10080min) with secondary window_minutes=0 — treat zero-minute windows as
+// absent, not as an exhausted 5h bucket at 0%.
 // Returns nil if snapshot is nil or has no useful data.
 func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 	if s == nil {
@@ -58,16 +62,13 @@ func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 
 	primaryMins := 0
 	secondaryMins := 0
-	hasPrimaryWindow := false
-	hasSecondaryWindow := false
-
-	if s.PrimaryWindowMinutes != nil {
+	hasPrimaryWindow := codexSnapshotWindowMinutesActive(s.PrimaryWindowMinutes)
+	hasSecondaryWindow := codexSnapshotWindowMinutesActive(s.SecondaryWindowMinutes)
+	if hasPrimaryWindow {
 		primaryMins = *s.PrimaryWindowMinutes
-		hasPrimaryWindow = true
 	}
-	if s.SecondaryWindowMinutes != nil {
+	if hasSecondaryWindow {
 		secondaryMins = *s.SecondaryWindowMinutes
-		hasSecondaryWindow = true
 	}
 
 	// Determine mapping based on window_minutes
@@ -107,19 +108,31 @@ func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 		result.Used5hPercent = s.PrimaryUsedPercent
 		result.Reset5hSeconds = s.PrimaryResetAfterSeconds
 		result.Window5hMinutes = s.PrimaryWindowMinutes
-		result.Used7dPercent = s.SecondaryUsedPercent
-		result.Reset7dSeconds = s.SecondaryResetAfterSeconds
-		result.Window7dMinutes = s.SecondaryWindowMinutes
+		if hasSecondaryWindow {
+			result.Used7dPercent = s.SecondaryUsedPercent
+			result.Reset7dSeconds = s.SecondaryResetAfterSeconds
+			result.Window7dMinutes = s.SecondaryWindowMinutes
+		}
 	} else if use7dFromPrimary {
 		result.Used7dPercent = s.PrimaryUsedPercent
 		result.Reset7dSeconds = s.PrimaryResetAfterSeconds
 		result.Window7dMinutes = s.PrimaryWindowMinutes
-		result.Used5hPercent = s.SecondaryUsedPercent
-		result.Reset5hSeconds = s.SecondaryResetAfterSeconds
-		result.Window5hMinutes = s.SecondaryWindowMinutes
+		if hasSecondaryWindow {
+			result.Used5hPercent = s.SecondaryUsedPercent
+			result.Reset5hSeconds = s.SecondaryResetAfterSeconds
+			result.Window5hMinutes = s.SecondaryWindowMinutes
+		}
 	}
 
 	return result
+}
+
+func codexSnapshotWindowMinutesActive(mins *int) bool {
+	return mins != nil && *mins > 0
+}
+
+func codexNormalizedWindowActive(mins *int) bool {
+	return codexSnapshotWindowMinutesActive(mins)
 }
 
 type accountWriteThrottle struct {
@@ -546,29 +559,33 @@ func buildCodexUsageExtraUpdates(snapshot *OpenAICodexUsageSnapshot, fallbackNow
 
 	// 归一化到 5h/7d 规范字段
 	if normalized := snapshot.Normalize(); normalized != nil {
-		if normalized.Used5hPercent != nil {
-			updates["codex_5h_used_percent"] = *normalized.Used5hPercent
+		if codexNormalizedWindowActive(normalized.Window5hMinutes) {
+			if normalized.Used5hPercent != nil {
+				updates["codex_5h_used_percent"] = *normalized.Used5hPercent
+			}
+			if normalized.Reset5hSeconds != nil {
+				updates["codex_5h_reset_after_seconds"] = *normalized.Reset5hSeconds
+			}
+			if normalized.Window5hMinutes != nil {
+				updates["codex_5h_window_minutes"] = *normalized.Window5hMinutes
+			}
+			if reset5hAt := codexResetAtRFC3339(baseTime, normalized.Reset5hSeconds); reset5hAt != nil {
+				updates["codex_5h_reset_at"] = *reset5hAt
+			}
 		}
-		if normalized.Reset5hSeconds != nil {
-			updates["codex_5h_reset_after_seconds"] = *normalized.Reset5hSeconds
-		}
-		if normalized.Window5hMinutes != nil {
-			updates["codex_5h_window_minutes"] = *normalized.Window5hMinutes
-		}
-		if normalized.Used7dPercent != nil {
-			updates["codex_7d_used_percent"] = *normalized.Used7dPercent
-		}
-		if normalized.Reset7dSeconds != nil {
-			updates["codex_7d_reset_after_seconds"] = *normalized.Reset7dSeconds
-		}
-		if normalized.Window7dMinutes != nil {
-			updates["codex_7d_window_minutes"] = *normalized.Window7dMinutes
-		}
-		if reset5hAt := codexResetAtRFC3339(baseTime, normalized.Reset5hSeconds); reset5hAt != nil {
-			updates["codex_5h_reset_at"] = *reset5hAt
-		}
-		if reset7dAt := codexResetAtRFC3339(baseTime, normalized.Reset7dSeconds); reset7dAt != nil {
-			updates["codex_7d_reset_at"] = *reset7dAt
+		if codexNormalizedWindowActive(normalized.Window7dMinutes) {
+			if normalized.Used7dPercent != nil {
+				updates["codex_7d_used_percent"] = *normalized.Used7dPercent
+			}
+			if normalized.Reset7dSeconds != nil {
+				updates["codex_7d_reset_after_seconds"] = *normalized.Reset7dSeconds
+			}
+			if normalized.Window7dMinutes != nil {
+				updates["codex_7d_window_minutes"] = *normalized.Window7dMinutes
+			}
+			if reset7dAt := codexResetAtRFC3339(baseTime, normalized.Reset7dSeconds); reset7dAt != nil {
+				updates["codex_7d_reset_at"] = *reset7dAt
+			}
 		}
 	}
 

--- a/backend/internal/service/openai_gateway_service_tk_codex_usage_snapshot.go
+++ b/backend/internal/service/openai_gateway_service_tk_codex_usage_snapshot.go
@@ -117,10 +117,12 @@ func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 		result.Used7dPercent = s.PrimaryUsedPercent
 		result.Reset7dSeconds = s.PrimaryResetAfterSeconds
 		result.Window7dMinutes = s.PrimaryWindowMinutes
-		if hasSecondaryWindow {
+		if codexSnapshotSecondaryQuotaPresent(s) {
 			result.Used5hPercent = s.SecondaryUsedPercent
 			result.Reset5hSeconds = s.SecondaryResetAfterSeconds
-			result.Window5hMinutes = s.SecondaryWindowMinutes
+			if hasSecondaryWindow {
+				result.Window5hMinutes = s.SecondaryWindowMinutes
+			}
 		}
 	}
 
@@ -129,6 +131,19 @@ func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 
 func codexSnapshotWindowMinutesActive(mins *int) bool {
 	return mins != nil && *mins > 0
+}
+
+// codexSnapshotSecondaryQuotaPresent is true when secondary carries quota signal
+// and is not explicitly absent (window_minutes=0 on a present primary 7d layout).
+func codexSnapshotSecondaryQuotaPresent(s *OpenAICodexUsageSnapshot) bool {
+	if s == nil {
+		return false
+	}
+	if s.SecondaryWindowMinutes != nil && *s.SecondaryWindowMinutes <= 0 {
+		return false
+	}
+	return s.SecondaryUsedPercent != nil || s.SecondaryResetAfterSeconds != nil ||
+		codexSnapshotWindowMinutesActive(s.SecondaryWindowMinutes)
 }
 
 func codexNormalizedWindowActive(mins *int) bool {

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 693,
-  "hash": "5026a8c28c17540fee35d09263b3dc26307cb3870fb91d07567e945ad10d20a8",
+  "hash": "72efc0bfdeb7205712bfc637a509543eceff1192dcad3b29138059b20b6a9c12",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -650,6 +650,58 @@ describe('AccountUsageCell', () => {
     expect(getUsage).not.toHaveBeenCalled()
   })
 
+  it('OpenAI OAuth 上游仅 7d 时不渲染 5h 进度条', async () => {
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 89,
+          platform: 'openai',
+          type: 'oauth',
+          extra: {}
+        }),
+        usageOverride: {
+          source: 'passive',
+          five_hour: null,
+          seven_day: {
+            utilization: 37,
+            resets_at: '2099-03-07T12:00:00Z',
+            remaining_seconds: 3600,
+            window_stats: {
+              requests: 44076,
+              tokens: 1_806_601_032,
+              cost: 1659.74,
+              standard_cost: 1659.74,
+              user_cost: 387.12
+            }
+          }
+        },
+        todayStats: {
+          requests: 4501,
+          tokens: 100_354_973,
+          cost: 80.74,
+          standard_cost: 80.74,
+          user_cost: 19.99
+        }
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'windowStats'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ windowStats?.requests }}</div>'
+          },
+          OpenAIQuotaResetCell: true,
+          UpstreamQuotaSummary: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('5h|')
+    expect(wrapper.text()).toContain('7d|37|44076')
+    expect(wrapper.text()).toContain('4.5K req')
+  })
+
   it('OpenAI OAuth 用量窗口同时展示今日 req/token/account/user 统计', async () => {
     const wrapper = mount(AccountUsageCell, {
       props: {

--- a/frontend/src/components/account/usage-cells/OpenAIUsageCell.vue
+++ b/frontend/src/components/account/usage-cells/OpenAIUsageCell.vue
@@ -86,7 +86,6 @@ const props = withDefaults(defineProps<AccountUsageCellProps>(), accountUsageCel
 const { t } = useI18n()
 const rootRef = ref<HTMLElement | null>(null)
 const upstreamQuotaWindowDimensionKeys = [
-  'openai_codex_5h',
   'openai_codex_7d'
 ]
 

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -304,10 +304,10 @@
         ":stats=\"todayStats\"",
         ":loading=\"todayStatsLoading\"",
         ":hidden-dimension-keys=\"upstreamQuotaWindowDimensionKeys\"",
-        "openai_codex_5h",
+        "usageInfo?.five_hour",
         "openai_codex_7d"
       ],
-      "rationale": "OpenAI Codex OAuth usage windows mirror the Anthropic display contract: TodayStatsBadges owns current-day request/token/account-cost/user-cost badges, the 5h and 7d progress bars own Codex quota windows, and UpstreamQuotaSummary is only for supplemental quota facts. Anchors keep upstream merges from silently dropping the generic usage badges on OAuth-only accounts or restoring duplicate Codex window chips."
+      "rationale": "OpenAI Codex OAuth usage windows mirror the Anthropic display contract: TodayStatsBadges owns current-day request/token/account-cost/user-cost badges, the 5h bar renders only when upstream reports an active codex 5h window (usageInfo.five_hour), the 7d bar owns the Codex 7d quota window, and UpstreamQuotaSummary is only for supplemental quota facts. Anchors keep upstream merges from silently dropping the generic usage badges on OAuth-only accounts or restoring duplicate Codex window chips."
     },
     {
       "path": "frontend/src/components/account/usage-cells/KiroUsageCell.vue",


### PR DESCRIPTION
## 摘要

- OpenAI codex 2026-08 响应头仅上报 7d（`primary_window=10080`，`secondary_window=0`），不再把 `window_minutes=0` 当成有效 5h 窗口。
- 后端 `Normalize()` / `buildCodexUsageExtraUpdates()` / passive usage 路径：上游无 active 5h 时不写入 `five_hour`，避免 UI 显示误导性 **5h 0%**。
- 前端 `OpenAIUsageCell` 仅在 `usageInfo.five_hour` 存在时渲染 5h 条；7d-only 账号只展示 7d 进度条与今日统计。

sentinel-registry-reviewed

## 风险

- 常规风险：仅影响 OpenAI OAuth 管理员用量展示语义；7d 配额与今日统计不变。
- 若 OpenAI 未来恢复 5h 头（`window_minutes > 0`），5h 条会自动重新出现。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service/ -run 'TestNormalize_7dOnly|TestBuildCodexUsageExtraUpdates_7dOnly|TestBuildCodexUsageProgress|TestAccountUsageService_GetPassiveUsage_OpenAI' -count=1
cd frontend && pnpm vitest run src/components/account/__tests__/AccountUsageCell.spec.ts -t 'OpenAI OAuth 上游仅 7d'
./scripts/preflight.sh  # PASS
```

## 提交

- f9731bc2b fix(openai): 上游无 5h 窗口时隐藏用量条
- 1617ff06f chore(sentinels): anchor OpenAI 5h bar as conditional upstream window
- b1a7fa193 style: gofmt OpenAI 5h absent tests

最新提交：b1a7fa193

Made with [Cursor](https://cursor.com)