### PR TITLE
feat(ops): 将 ops 日志切换为日分区

### DIFF
--- a/backend/cmd/server/partition_maintenance_test.go
+++ b/backend/cmd/server/partition_maintenance_test.go
@@ -85,8 +85,8 @@ func TestPartitionMaintenanceSuccessUsesStrictBoundedPath(t *testing.T) {
 				t.Fatalf("unexpected ensure args: db=%T now=%s mode=%d", gotDB, now, mode)
 			}
 			return partitionmaintenance.Result{Tables: []partitionmaintenance.TableResult{
-				{Table: "ops_system_logs", RangeCount: 4},
-				{Table: "ops_error_logs", RangeCount: 4},
+				{Table: "ops_system_logs", RangeCount: 8},
+				{Table: "ops_error_logs", RangeCount: 8},
 				{Table: "usage_logs", RangeCount: 8},
 			}}, nil
 		},

--- a/backend/internal/pkg/partitionmaintenance/maintenance.go
+++ b/backend/internal/pkg/partitionmaintenance/maintenance.go
@@ -16,8 +16,7 @@ import (
 const (
 	JobName = "ops_partition_maintenance"
 
-	opsMonthsAhead = 3
-	usageDaysAhead = 7
+	daysAhead = 7
 )
 
 // Options controls optional maintainer behavior.
@@ -50,23 +49,15 @@ func (r Result) String() string {
 	return strings.Join(parts, ",")
 }
 
-type cadence uint8
-
-const (
-	cadenceMonthly cadence = iota
-	cadenceDaily
-)
-
 type target struct {
-	table   string
-	cadence cadence
-	ahead   int
+	table string
+	ahead int
 }
 
 var targets = [...]target{
-	{table: "ops_system_logs", cadence: cadenceMonthly, ahead: opsMonthsAhead},
-	{table: "ops_error_logs", cadence: cadenceMonthly, ahead: opsMonthsAhead},
-	{table: "usage_logs", cadence: cadenceDaily, ahead: usageDaysAhead},
+	{table: "ops_system_logs", ahead: daysAhead},
+	{table: "ops_error_logs", ahead: daysAhead},
+	{table: "usage_logs", ahead: daysAhead},
 }
 
 type partitionRange struct {
@@ -102,14 +93,7 @@ func Ensure(
 		}
 
 		ranges := targetRanges(target, now)
-		switch target.cadence {
-		case cadenceMonthly:
-			err = pgpartition.EnsureMonthly(ctx, db, target.table, now, target.ahead)
-		case cadenceDaily:
-			err = pgpartition.EnsureDaily(ctx, db, target.table, now, target.ahead)
-		default:
-			err = fmt.Errorf("unsupported cadence %d", target.cadence)
-		}
+		err = pgpartition.EnsureDaily(ctx, db, target.table, now, target.ahead)
 		if err != nil {
 			return result, fmt.Errorf("partitionmaintenance: ensure %s: %w", target.table, err)
 		}
@@ -134,22 +118,12 @@ func Ensure(
 
 func targetRanges(target target, now time.Time) []partitionRange {
 	u := now.UTC()
-	var base time.Time
-	if target.cadence == cadenceMonthly {
-		base = time.Date(u.Year(), u.Month(), 1, 0, 0, 0, 0, time.UTC)
-	} else {
-		base = time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
-	}
+	base := time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
 
 	ranges := make([]partitionRange, 0, target.ahead+1)
 	for offset := 0; offset <= target.ahead; offset++ {
 		start := base.AddDate(0, 0, offset)
-		end := start.AddDate(0, 0, 1)
-		if target.cadence == cadenceMonthly {
-			start = base.AddDate(0, offset, 0)
-			end = start.AddDate(0, 1, 0)
-		}
-		ranges = append(ranges, partitionRange{start: start, end: end})
+		ranges = append(ranges, partitionRange{start: start, end: start.AddDate(0, 0, 1)})
 	}
 	return ranges
 }

--- a/backend/internal/pkg/partitionmaintenance/maintenance_test.go
+++ b/backend/internal/pkg/partitionmaintenance/maintenance_test.go
@@ -42,8 +42,8 @@ func TestEnsureStrictCreatesAndVerifiesAllTargets(t *testing.T) {
 		table string
 		count int
 	}{
-		{"ops_system_logs", 4},
-		{"ops_error_logs", 4},
+		{"ops_system_logs", 8},
+		{"ops_error_logs", 8},
 		{"usage_logs", 8},
 	} {
 		expectPartitioned(mock, target.table, true)
@@ -56,8 +56,8 @@ func TestEnsureStrictCreatesAndVerifiesAllTargets(t *testing.T) {
 		t.Fatalf("Ensure: %v", err)
 	}
 	want := []TableResult{
-		{Table: "ops_system_logs", RangeCount: 4},
-		{Table: "ops_error_logs", RangeCount: 4},
+		{Table: "ops_system_logs", RangeCount: 8},
+		{Table: "ops_error_logs", RangeCount: 8},
 		{Table: "usage_logs", RangeCount: 8},
 	}
 	if len(result.Tables) != len(want) {
@@ -98,15 +98,15 @@ func TestEnsureAllowUnpartitionedSkipsCompatibilityTarget(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 	expectPartitioned(mock, "ops_system_logs", false)
 	expectPartitioned(mock, "ops_error_logs", true)
-	expectCreates(mock, 4)
-	expectCoverage(mock, "ops_error_logs", 4)
+	expectCreates(mock, 8)
+	expectCoverage(mock, "ops_error_logs", 8)
 	expectPartitioned(mock, "usage_logs", false)
 
 	result, err := Ensure(context.Background(), db, maintenanceNow, ModeAllowUnpartitioned, Options{})
 	if err != nil {
 		t.Fatalf("Ensure: %v", err)
 	}
-	if len(result.Tables) != 1 || result.Tables[0] != (TableResult{Table: "ops_error_logs", RangeCount: 4}) {
+	if len(result.Tables) != 1 || result.Tables[0] != (TableResult{Table: "ops_error_logs", RangeCount: 8}) {
 		t.Fatalf("unexpected result: %+v", result)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -124,11 +124,11 @@ func TestEnsureRejectsUncoveredOverlap(t *testing.T) {
 	mock.ExpectExec("CREATE TABLE IF NOT EXISTS").WillReturnError(
 		&pq.Error{Code: pq.ErrorCode("42P17")},
 	)
-	expectCreates(mock, 3)
-	expectCoverage(mock, "ops_system_logs", 3)
+	expectCreates(mock, 7)
+	expectCoverage(mock, "ops_system_logs", 7)
 
 	_, err = Ensure(context.Background(), db, maintenanceNow, ModeRequireAllPartitioned, Options{})
-	if err == nil || !strings.Contains(err.Error(), "covers 3 of 4 required ranges") {
+	if err == nil || !strings.Contains(err.Error(), "covers 7 of 8 required ranges") {
 		t.Fatalf("expected uncovered range error, got %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/backend/internal/pkg/pgpartition/partition.go
+++ b/backend/internal/pkg/pgpartition/partition.go
@@ -1,5 +1,5 @@
-// Package pgpartition provides a small, table-agnostic monthly RANGE-partition
-// retention mechanism: keep N future months provisioned and DROP whole partitions
+// Package pgpartition provides small, table-agnostic RANGE-partition
+// retention mechanisms: keep future ranges provisioned and DROP whole partitions
 // once their data is fully past the retention cutoff. It is the reusable core behind
 // the data-layer partition program (WAVE 1: ops_system_logs; later: ops_error_logs,
 // usage_logs) — replacing bloat-generating chunked DELETE retention with instant
@@ -204,27 +204,58 @@ func DropExpired(ctx context.Context, db DropExecutor, table string, cutoff time
 // ListStraddling returns remaining child partitions that contain rows older than the
 // cutoff. Callers invoke it after DropExpired, so these are bound-straddling partitions
 // (notably the wide legacy partition) that cannot yet be dropped as a whole and need a
-// capped row-level reclaim. Checking min(timeCol) also catches a surviving partition
-// whose current rows are all expired while its declared upper bound is still in-window.
+// capped row-level reclaim. Finite lower bounds at or after the cutoff prove that a
+// current/future daily child cannot contain expired rows, avoiding one min query per day.
 func ListStraddling(ctx context.Context, db DB, table, timeCol string, cutoff time.Time) ([]string, error) {
 	const listQ = `
-		SELECT c.relname
+		SELECT
+			n.nspname,
+			c.relname,
+			pg_get_expr(c.relpartbound, c.oid, true) AS bound_expr,
+			pg_get_expr(c.relpartbound, c.oid, true) LIKE 'FOR VALUES FROM (MINVALUE)%' AS lower_unbounded,
+			substring(
+				pg_get_expr(c.relpartbound, c.oid, true)
+				FROM $$FROM \('([^']+)'\)$$
+			)::timestamptz AS lower_bound
 		FROM pg_inherits i
 		JOIN pg_class c ON c.oid = i.inhrelid
-		JOIN pg_class p ON p.oid = i.inhparent
-		WHERE p.relname = $1`
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE i.inhparent = to_regclass($1)
+		ORDER BY n.nspname, c.relname`
 	rows, err := db.QueryContext(ctx, listQ, table)
 	if err != nil {
 		return nil, fmt.Errorf("pgpartition: list partitions of %s: %w", table, err)
 	}
-	var children []string
+	type childPartition struct {
+		schema         string
+		name           string
+		boundExpr      string
+		lowerUnbounded bool
+		lower          sql.NullTime
+	}
+	var candidates []childPartition
 	for rows.Next() {
-		var name string
-		if scanErr := rows.Scan(&name); scanErr != nil {
+		var child childPartition
+		if scanErr := rows.Scan(
+			&child.schema,
+			&child.name,
+			&child.boundExpr,
+			&child.lowerUnbounded,
+			&child.lower,
+		); scanErr != nil {
 			_ = rows.Close()
-			return nil, fmt.Errorf("pgpartition: scan partition name: %w", scanErr)
+			return nil, fmt.Errorf("pgpartition: scan partition lower bound: %w", scanErr)
 		}
-		children = append(children, name)
+		if !child.lowerUnbounded && !child.lower.Valid {
+			_ = rows.Close()
+			return nil, fmt.Errorf(
+				"pgpartition: partition %s.%s has no finite timestamptz lower bound: %s",
+				child.schema, child.name, child.boundExpr,
+			)
+		}
+		if child.lowerUnbounded || child.lower.Time.Before(cutoff) {
+			candidates = append(candidates, child)
+		}
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {
 		_ = rows.Close()
@@ -233,19 +264,19 @@ func ListStraddling(ctx context.Context, db DB, table, timeCol string, cutoff ti
 	_ = rows.Close()
 
 	var straddling []string
-	for _, name := range children {
+	for _, child := range candidates {
 		var minT sql.NullTime
-		q := fmt.Sprintf("SELECT min(%s) FROM %s", pq.QuoteIdentifier(timeCol), pq.QuoteIdentifier(name))
+		qualifiedName := pq.QuoteIdentifier(child.schema) + "." + pq.QuoteIdentifier(child.name)
+		q := fmt.Sprintf("SELECT min(%s) FROM %s", pq.QuoteIdentifier(timeCol), qualifiedName)
 		if err := db.QueryRowContext(ctx, q).Scan(&minT); err != nil {
-			return nil, fmt.Errorf("pgpartition: min(%s) on %s: %w", timeCol, name, err)
+			return nil, fmt.Errorf("pgpartition: min(%s) on %s: %w", timeCol, qualifiedName, err)
 		}
 		if minT.Valid && minT.Time.Before(cutoff) {
-			straddling = append(straddling, name)
+			straddling = append(straddling, child.name)
 		}
 	}
 	return straddling, nil
 }
-
 func isOverlap(err error) bool {
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) {

--- a/backend/internal/pkg/pgpartition/partition_test.go
+++ b/backend/internal/pkg/pgpartition/partition_test.go
@@ -210,6 +210,61 @@ func TestDropExpired_UsesBoundsAndKeepsEmptyFuturePartition(t *testing.T) {
 	}
 }
 
+func TestListStraddling_PrunesFutureDailyChildren(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	cutoff := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{"schema_name", "partition_name", "bound_expr", "lower_unbounded", "lower_bound"}).
+		AddRow("public", "ops_system_logs_legacy", "FOR VALUES FROM (MINVALUE) TO ('2026-09-01 00:00:00+00')", true, nil).
+		AddRow("public", "ops_system_logs_20260803", "FOR VALUES FROM ('2026-08-03 00:00:00+00') TO ('2026-08-04 00:00:00+00')", false, time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)).
+		AddRow("public", "ops_system_logs_20260804", "FOR VALUES FROM ('2026-08-04 00:00:00+00') TO ('2026-08-05 00:00:00+00')", false, time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC))
+	mock.ExpectQuery(`(?s)SELECT.*lower_unbounded.*FROM pg_inherits`).
+		WithArgs("ops_system_logs").
+		WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT min("created_at") FROM "public"."ops_system_logs_legacy"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(cutoff.Add(-48 * time.Hour)))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT min("created_at") FROM "public"."ops_system_logs_20260803"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(cutoff.Add(-time.Hour)))
+
+	got, err := ListStraddling(context.Background(), db, "ops_system_logs", "created_at", cutoff)
+	if err != nil {
+		t.Fatalf("ListStraddling: %v", err)
+	}
+	want := []string{"ops_system_logs_legacy", "ops_system_logs_20260803"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("straddling=%v want %v", got, want)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("future child must not trigger min query: %v", err)
+	}
+}
+
+func TestListStraddling_UnparseableLowerBoundFailsBeforeMin(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	rows := sqlmock.NewRows([]string{"schema_name", "partition_name", "bound_expr", "lower_unbounded", "lower_bound"}).
+		AddRow("public", "ops_system_logs_default", "DEFAULT", false, nil)
+	mock.ExpectQuery(`(?s)SELECT.*lower_unbounded.*FROM pg_inherits`).
+		WithArgs("ops_system_logs").
+		WillReturnRows(rows)
+
+	_, err = ListStraddling(context.Background(), db, "ops_system_logs", "created_at", time.Now())
+	if err == nil || !strings.Contains(err.Error(), "has no finite timestamptz lower bound") {
+		t.Fatalf("expected fail-closed lower-bound error, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unparseable bound must fail before min query: %v", err)
+	}
+}
+
 func TestDropExpired_RejectsQARecordsHourlyOwner(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/backend/internal/repository/dashboard_aggregation_repo_cleanup_test.go
+++ b/backend/internal/repository/dashboard_aggregation_repo_cleanup_test.go
@@ -32,9 +32,10 @@ func TestCleanupUsageLogs_PartitionedReclaimsStraddlingLegacy(t *testing.T) {
 	)
 
 	mock.ExpectQuery("FROM pg_inherits i").WillReturnRows(
-		sqlmock.NewRows([]string{"relname"}).AddRow("usage_logs_legacy"),
+		sqlmock.NewRows([]string{"nspname", "relname", "bound_expr", "lower_unbounded", "lower_bound"}).
+			AddRow("public", "usage_logs_legacy", "FOR VALUES FROM (MINVALUE) TO ('2026-08-10')", true, nil),
 	)
-	mock.ExpectQuery("SELECT min\\(\"created_at\"\\) FROM \"usage_logs_legacy\"").
+	mock.ExpectQuery("SELECT min\\(\"created_at\"\\) FROM \"public\"\\.\"usage_logs_legacy\"").
 		WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(time.Date(2026, 5, 9, 0, 0, 0, 0, time.UTC)))
 
 	mock.ExpectExec("DELETE FROM \"usage_logs_legacy\"").

--- a/backend/internal/repository/ops_daily_partition_migration_integration_test.go
+++ b/backend/internal/repository/ops_daily_partition_migration_integration_test.go
@@ -1,0 +1,298 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	dbmigrations "github.com/Wei-Shaw/sub2api/migrations"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+var opsDailyCutoverNow = time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+
+func TestOpsDailyPartitionMigration_SuccessFreshAndIdempotent(t *testing.T) {
+	ctx := context.Background()
+	schema := setupOpsDailyMigrationSchema(t, "ops_daily_success", 2)
+	migrationSQL := readOpsDailyMigration(t)
+
+	var currentOID uint32
+	require.NoError(t, integrationDB.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT %s::regclass::oid`, pq.QuoteLiteral(schema+".ops_system_logs_legacy"))).Scan(&currentOID))
+	_, err := integrationDB.ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO %s.ops_system_logs (created_at, level, message)
+		VALUES ('2026-08-13T12:00:00Z', 'info', 'preserve-current')`, pq.QuoteIdentifier(schema)))
+	require.NoError(t, err)
+
+	runOpsDailyMigration(t, schema, migrationSQL)
+	assertOpsDailyMigrationResult(t, schema, currentOID)
+
+	before := partitionOIDSnapshot(t, schema)
+	runOpsDailyMigration(t, schema, migrationSQL)
+	require.Equal(t, before, partitionOIDSnapshot(t, schema), "an idempotent rerun must not replace daily children")
+}
+
+func TestOpsDailyPartitionMigration_RejectsUnsafeTopologyAtomically(t *testing.T) {
+	migrationSQL := readOpsDailyMigration(t)
+
+	t.Run("non-empty future monthly", func(t *testing.T) {
+		ctx := context.Background()
+		schema := setupOpsDailyMigrationSchema(t, "ops_daily_nonempty", 3)
+		qSchema := pq.QuoteIdentifier(schema)
+		_, err := integrationDB.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO %s.ops_error_logs (created_at, error_phase, error_type)
+			VALUES ('2026-09-15T00:00:00Z', 'test', 'test')`, qSchema))
+		require.NoError(t, err)
+
+		before := partitionOIDSnapshot(t, schema)
+		err = execOpsDailyMigration(ctx, schema, migrationSQL)
+		require.ErrorContains(t, err, "refusing to replace non-empty future child")
+		require.Equal(t, before, partitionOIDSnapshot(t, schema), "the failed migration must leave both parents unchanged")
+		assertNoUnexpectedDailyTables(t, schema)
+	})
+
+	t.Run("partial daily month", func(t *testing.T) {
+		ctx := context.Background()
+		schema := setupOpsDailyMigrationSchema(t, "ops_daily_partial", 0)
+		qSchema := pq.QuoteIdentifier(schema)
+		_, err := integrationDB.ExecContext(ctx, fmt.Sprintf(`
+			CREATE TABLE %s.ops_system_logs_20260901
+			PARTITION OF %s.ops_system_logs
+			FOR VALUES FROM ('2026-09-01T00:00:00Z') TO ('2026-09-02T00:00:00Z')`, qSchema, qSchema))
+		require.NoError(t, err)
+
+		before := partitionOIDSnapshot(t, schema)
+		err = execOpsDailyMigration(ctx, schema, migrationSQL)
+		require.ErrorContains(t, err, "partial or unexpected coverage")
+		require.Equal(t, before, partitionOIDSnapshot(t, schema))
+		assertNoUnexpectedDailyTables(t, schema)
+	})
+
+	t.Run("default partition", func(t *testing.T) {
+		ctx := context.Background()
+		schema := setupOpsDailyMigrationSchema(t, "ops_daily_default", 0)
+		qSchema := pq.QuoteIdentifier(schema)
+		_, err := integrationDB.ExecContext(ctx, fmt.Sprintf(
+			`CREATE TABLE %s.ops_error_logs_default PARTITION OF %s.ops_error_logs DEFAULT`, qSchema, qSchema))
+		require.NoError(t, err)
+
+		before := partitionOIDSnapshot(t, schema)
+		err = execOpsDailyMigration(ctx, schema, migrationSQL)
+		require.ErrorContains(t, err, "DEFAULT, MAXVALUE, or unparseable child bounds")
+		require.Equal(t, before, partitionOIDSnapshot(t, schema))
+		assertNoUnexpectedDailyTables(t, schema)
+	})
+}
+
+func TestOpsDailyPartitionMigration_LockContract(t *testing.T) {
+	migrationSQL := readOpsDailyMigration(t)
+
+	t.Run("current writer times out atomically under required parent lock", func(t *testing.T) {
+		ctx := context.Background()
+		schema := setupOpsDailyMigrationSchema(t, "ops_daily_current_dml", 3)
+		holder, err := integrationDB.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		defer func() { _ = holder.Rollback() }()
+		_, err = holder.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO %s.ops_system_logs (created_at, level, message)
+			VALUES ('2026-08-13T12:00:00Z', 'info', 'held-current-write')`, pq.QuoteIdentifier(schema)))
+		require.NoError(t, err)
+
+		before := partitionOIDSnapshot(t, schema)
+		err = execOpsDailyMigration(ctx, schema, migrationSQL)
+		require.Error(t, err)
+		require.Contains(t, strings.ToLower(err.Error()), "lock timeout")
+		require.Equal(t, before, partitionOIDSnapshot(t, schema),
+			"PostgreSQL DROP PARTITION conflicts with a parent writer, so timeout must preserve the old topology")
+		assertNoUnexpectedDailyTables(t, schema)
+	})
+
+	t.Run("future child reader fails closed", func(t *testing.T) {
+		ctx := context.Background()
+		schema := setupOpsDailyMigrationSchema(t, "ops_daily_future_lock", 3)
+		holder, err := integrationDB.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		defer func() { _ = holder.Rollback() }()
+		_, err = holder.ExecContext(ctx, fmt.Sprintf(
+			`SELECT 1 FROM %s.ops_error_logs_202609 LIMIT 1`, pq.QuoteIdentifier(schema)))
+		require.NoError(t, err)
+
+		before := partitionOIDSnapshot(t, schema)
+		started := time.Now()
+		err = execOpsDailyMigration(ctx, schema, migrationSQL)
+		require.Error(t, err)
+		require.Contains(t, strings.ToLower(err.Error()), "lock timeout")
+		require.Less(t, time.Since(started), 10*time.Second)
+		require.Equal(t, before, partitionOIDSnapshot(t, schema))
+		assertNoUnexpectedDailyTables(t, schema)
+	})
+}
+
+func setupOpsDailyMigrationSchema(t *testing.T, schema string, futureMonths int) string {
+	t.Helper()
+	ctx := context.Background()
+	qSchema := pq.QuoteIdentifier(schema)
+	_, err := integrationDB.ExecContext(ctx, "DROP SCHEMA IF EXISTS "+qSchema+" CASCADE")
+	require.NoError(t, err)
+	_, err = integrationDB.ExecContext(ctx, "CREATE SCHEMA "+qSchema)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = integrationDB.ExecContext(context.Background(), "DROP SCHEMA IF EXISTS "+qSchema+" CASCADE")
+	})
+
+	for _, table := range []string{"ops_error_logs", "ops_system_logs"} {
+		columns := "id BIGSERIAL, created_at TIMESTAMPTZ NOT NULL"
+		if table == "ops_error_logs" {
+			columns += ", error_phase TEXT, error_type TEXT"
+		} else {
+			columns += ", level TEXT, message TEXT"
+		}
+		_, err = integrationDB.ExecContext(ctx, fmt.Sprintf(`
+			CREATE TABLE %s.%s (%s, PRIMARY KEY (id, created_at)) PARTITION BY RANGE (created_at);
+			CREATE INDEX %s ON %s.%s (created_at DESC);
+			CREATE TABLE %s.%s PARTITION OF %s.%s
+			FOR VALUES FROM (MINVALUE) TO ('2026-09-01T00:00:00Z');`,
+			qSchema, pq.QuoteIdentifier(table), columns,
+			pq.QuoteIdentifier("idx_"+table+"_created_at"), qSchema, pq.QuoteIdentifier(table),
+			qSchema, pq.QuoteIdentifier(table+"_legacy"), qSchema, pq.QuoteIdentifier(table)))
+		require.NoError(t, err)
+
+		monthStart := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+		for month := 0; month < futureMonths; month++ {
+			start := monthStart.AddDate(0, month, 0)
+			end := start.AddDate(0, 1, 0)
+			name := table + "_" + start.Format("200601")
+			_, err = integrationDB.ExecContext(ctx, fmt.Sprintf(
+				`CREATE TABLE %s.%s PARTITION OF %s.%s FOR VALUES FROM (%s) TO (%s)`,
+				qSchema, pq.QuoteIdentifier(name), qSchema, pq.QuoteIdentifier(table),
+				pq.QuoteLiteral(start.Format(time.RFC3339)), pq.QuoteLiteral(end.Format(time.RFC3339))))
+			require.NoError(t, err)
+		}
+	}
+	return schema
+}
+
+func readOpsDailyMigration(t *testing.T) string {
+	t.Helper()
+	migrationSQL, err := dbmigrations.FS.ReadFile("tk_080_ops_daily_partition_cutover.sql")
+	require.NoError(t, err)
+	return string(migrationSQL)
+}
+
+func runOpsDailyMigration(t *testing.T, schema, migrationSQL string) {
+	t.Helper()
+	require.NoError(t, execOpsDailyMigration(context.Background(), schema, migrationSQL))
+}
+
+func execOpsDailyMigration(ctx context.Context, schema, migrationSQL string) error {
+	tx, err := integrationDB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err = tx.ExecContext(ctx, "SET LOCAL search_path = "+pq.QuoteIdentifier(schema)); err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, "SET LOCAL tokenkey.ops_daily_cutover_now = "+pq.QuoteLiteral(opsDailyCutoverNow.Format(time.RFC3339))); err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, migrationSQL); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func assertOpsDailyMigrationResult(t *testing.T, schema string, currentOID uint32) {
+	t.Helper()
+	ctx := context.Background()
+	for _, table := range []string{"ops_error_logs", "ops_system_logs"} {
+		var preservedOID uint32
+		require.NoError(t, integrationDB.QueryRowContext(ctx, fmt.Sprintf(
+			`SELECT %s::regclass::oid`, pq.QuoteLiteral(schema+"."+table+"_legacy"))).Scan(&preservedOID))
+		if table == "ops_system_logs" {
+			require.Equal(t, currentOID, preservedOID)
+			var rows int
+			require.NoError(t, integrationDB.QueryRowContext(ctx, fmt.Sprintf(
+				`SELECT count(*) FROM %s.ops_system_logs_legacy WHERE message = 'preserve-current'`, pq.QuoteIdentifier(schema))).Scan(&rows))
+			require.Equal(t, 1, rows)
+		}
+
+		var dailyChildren int
+		require.NoError(t, integrationDB.QueryRowContext(ctx, `
+			SELECT count(*)
+			FROM pg_inherits inheritance
+			JOIN pg_class child ON child.oid = inheritance.inhrelid
+			JOIN pg_namespace namespace ON namespace.oid = child.relnamespace
+			WHERE inheritance.inhparent = to_regclass($1)
+			  AND namespace.nspname = $2
+			  AND child.relname ~ $3`, schema+"."+table, schema, "^"+table+"_2026(09|10|11)[0-9]{2}$").Scan(&dailyChildren))
+		require.Equal(t, 91, dailyChildren)
+
+		var missingIndexChildren int
+		require.NoError(t, integrationDB.QueryRowContext(ctx, `
+			SELECT count(*)
+			FROM pg_inherits table_inheritance
+			JOIN pg_class child ON child.oid = table_inheritance.inhrelid
+			WHERE table_inheritance.inhparent = to_regclass($1)
+			  AND child.relname ~ $2
+			  AND NOT EXISTS (
+				SELECT 1 FROM pg_index child_index WHERE child_index.indrelid = child.oid
+			  )`, schema+"."+table, "^"+table+"_2026(09|10|11)[0-9]{2}$").Scan(&missingIndexChildren))
+		require.Zero(t, missingIndexChildren)
+	}
+
+	qSchema := pq.QuoteIdentifier(schema)
+	_, err := integrationDB.ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO %s.ops_system_logs (created_at, level, message)
+		VALUES ('2026-09-01T00:00:00Z', 'info', 'daily-boundary')`, qSchema))
+	require.NoError(t, err)
+	var routedRows int
+	require.NoError(t, integrationDB.QueryRowContext(ctx, fmt.Sprintf(
+		`SELECT count(*) FROM %s.ops_system_logs_20260901 WHERE message = 'daily-boundary'`, qSchema)).Scan(&routedRows))
+	require.Equal(t, 1, routedRows)
+}
+
+func partitionOIDSnapshot(t *testing.T, schema string) map[string]uint32 {
+	t.Helper()
+	rows, err := integrationDB.QueryContext(context.Background(), `
+		SELECT parent.relname || '/' || child.relname, child.oid
+		FROM pg_inherits inheritance
+		JOIN pg_class parent ON parent.oid = inheritance.inhparent
+		JOIN pg_namespace parent_namespace ON parent_namespace.oid = parent.relnamespace
+		JOIN pg_class child ON child.oid = inheritance.inhrelid
+		WHERE parent_namespace.nspname = $1
+		  AND parent.relname IN ('ops_error_logs', 'ops_system_logs')
+		ORDER BY 1`, schema)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	result := make(map[string]uint32)
+	for rows.Next() {
+		var name string
+		var oid uint32
+		require.NoError(t, rows.Scan(&name, &oid))
+		result[name] = oid
+	}
+	require.NoError(t, rows.Err())
+	return result
+}
+
+func assertNoUnexpectedDailyTables(t *testing.T, schema string) {
+	t.Helper()
+	var count int
+	require.NoError(t, integrationDB.QueryRowContext(context.Background(), `
+		SELECT count(*)
+		FROM pg_class relation
+		JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+		WHERE namespace.nspname = $1
+		  AND relation.relname ~ '^ops_(error|system)_logs_2026(09|10|11)[0-9]{2}$'
+		  AND NOT EXISTS (
+			SELECT 1 FROM pg_inherits inheritance WHERE inheritance.inhrelid = relation.oid
+		  )`, schema).Scan(&count))
+	require.Zero(t, count, "failed migration must not leave detached staging relations")
+}

--- a/backend/internal/repository/ops_daily_partition_migration_integration_test.go
+++ b/backend/internal/repository/ops_daily_partition_migration_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/pgpartition"
 	dbmigrations "github.com/Wei-Shaw/sub2api/migrations"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
@@ -31,6 +32,10 @@ func TestOpsDailyPartitionMigration_SuccessFreshAndIdempotent(t *testing.T) {
 
 	runOpsDailyMigration(t, schema, migrationSQL)
 	assertOpsDailyMigrationResult(t, schema, currentOID)
+	beforeCompatibilityCheck := partitionOIDSnapshot(t, schema)
+	assertPreviousMonthlyOwnerCompatibility(t, schema)
+	require.Equal(t, beforeCompatibilityCheck, partitionOIDSnapshot(t, schema),
+		"the previous monthly owner compatibility check must leave the daily topology unchanged")
 
 	before := partitionOIDSnapshot(t, schema)
 	runOpsDailyMigration(t, schema, migrationSQL)
@@ -255,6 +260,60 @@ func assertOpsDailyMigrationResult(t *testing.T, schema string, currentOID uint3
 	require.NoError(t, integrationDB.QueryRowContext(ctx, fmt.Sprintf(
 		`SELECT count(*) FROM %s.ops_system_logs_20260901 WHERE message = 'daily-boundary'`, qSchema)).Scan(&routedRows))
 	require.Equal(t, 1, routedRows)
+}
+
+func assertPreviousMonthlyOwnerCompatibility(t *testing.T, schema string) {
+	t.Helper()
+	ctx := context.Background()
+	qSchema := pq.QuoteIdentifier(schema)
+	conn, err := integrationDB.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.ExecContext(ctx, "SET search_path = "+qSchema)
+	require.NoError(t, err)
+	defer func() { _, _ = conn.ExecContext(context.Background(), "RESET search_path") }()
+
+	for _, table := range []string{"ops_error_logs", "ops_system_logs"} {
+		qualifiedTable := qSchema + "." + pq.QuoteIdentifier(table)
+		require.NoError(t, pgpartition.EnsureMonthly(ctx, conn, table, opsDailyCutoverNow, 3),
+			"the previous monthly owner must treat complete daily month coverage as benign overlap")
+
+		var covered int
+		require.NoError(t, conn.QueryRowContext(ctx, `
+			WITH child_bounds AS (
+			  SELECT pg_get_expr(child.relpartbound, child.oid, true) AS bound_expr
+			  FROM pg_inherits inheritance
+			  JOIN pg_class child ON child.oid = inheritance.inhrelid
+			  WHERE inheritance.inhparent = to_regclass($1)
+			), parsed_bounds AS (
+			  SELECT
+			    bound_expr LIKE 'FOR VALUES FROM (MINVALUE)%' AS lower_unbounded,
+			    substring(bound_expr FROM $$FROM \('([^']+)'$$)::timestamptz AS lower_bound,
+			    substring(bound_expr FROM $$TO \('([^']+)'$$)::timestamptz AS upper_bound
+			  FROM child_bounds
+			), covered_union AS (
+			  SELECT range_agg(tstzrange(
+			    CASE WHEN lower_unbounded THEN NULL ELSE lower_bound END,
+			    upper_bound,
+			    '[)'
+			  )) AS ranges
+			  FROM parsed_bounds
+			  WHERE (lower_unbounded OR lower_bound IS NOT NULL) AND upper_bound IS NOT NULL
+			), required_ranges AS (
+			  SELECT month_start, month_start + interval '1 month' AS month_end
+			  FROM generate_series(
+			    date_trunc('month', $2::timestamptz),
+			    date_trunc('month', $2::timestamptz) + interval '3 months',
+			    interval '1 month'
+			  ) AS month_start
+			)
+			SELECT count(*)
+			FROM required_ranges, covered_union
+			WHERE covered_union.ranges @> tstzrange(month_start, month_end, '[)')`,
+			qualifiedTable, opsDailyCutoverNow).Scan(&covered))
+		require.Equal(t, 4, covered,
+			"the previous owner must prove current month plus three complete future months")
+	}
 }
 
 func partitionOIDSnapshot(t *testing.T, schema string) map[string]uint32 {

--- a/backend/internal/repository/ops_daily_partition_migration_integration_test.go
+++ b/backend/internal/repository/ops_daily_partition_migration_integration_test.go
@@ -184,7 +184,7 @@ func setupOpsDailyMigrationSchema(t *testing.T, schema string, futureMonths int)
 
 func readOpsDailyMigration(t *testing.T) string {
 	t.Helper()
-	migrationSQL, err := dbmigrations.FS.ReadFile("tk_080_ops_daily_partition_cutover.sql")
+	migrationSQL, err := dbmigrations.FS.ReadFile("tk_081_ops_daily_partition_cutover.sql")
 	require.NoError(t, err)
 	return string(migrationSQL)
 }

--- a/backend/internal/repository/partitionmaintenance_coverage_integration_test.go
+++ b/backend/internal/repository/partitionmaintenance_coverage_integration_test.go
@@ -64,7 +64,7 @@ func TestPartitionMaintenance_CoverageAcceptsAttachedLegacyPartition(t *testing.
 		verified[table.Table] = table.RangeCount
 	}
 	for _, table := range []string{"ops_system_logs", "ops_error_logs"} {
-		require.Equal(t, 4, verified[table],
-			"%s must prove the current month plus three future months are covered", table)
+		require.Equal(t, 8, verified[table],
+			"%s must prove today plus seven future UTC days are covered", table)
 	}
 }

--- a/backend/internal/service/ops_cleanup_service_test.go
+++ b/backend/internal/service/ops_cleanup_service_test.go
@@ -168,12 +168,12 @@ func TestOpsCleanupScheduled_DisabledStillMaintainsPartitionsWithoutCleanupHeart
 	for _, table := range []string{"ops_system_logs", "ops_error_logs"} {
 		mock.ExpectQuery("pg_partitioned_table").WithArgs(table).
 			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
-		for i := 0; i < 4; i++ {
+		for i := 0; i < 8; i++ {
 			mock.ExpectExec("CREATE TABLE IF NOT EXISTS").WillReturnResult(sqlmock.NewResult(0, 0))
 		}
 		mock.ExpectQuery("(?s)pg_get_expr.*pg_inherits").
 			WithArgs(table, sqlmock.AnyArg(), sqlmock.AnyArg()).
-			WillReturnRows(sqlmock.NewRows([]string{"covered_ranges"}).AddRow(4))
+			WillReturnRows(sqlmock.NewRows([]string{"covered_ranges"}).AddRow(8))
 	}
 	mock.ExpectQuery("pg_partitioned_table").WithArgs("usage_logs").
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))

--- a/backend/migrations/tk_080_ops_daily_partition_cutover.sql
+++ b/backend/migrations/tk_080_ops_daily_partition_cutover.sql
@@ -1,0 +1,344 @@
+-- tk_080_ops_daily_partition_cutover.sql
+-- Replace only empty future monthly ops partitions with complete UTC daily coverage.
+-- The current-month writer partition and all historical partitions remain untouched.
+--
+-- bluegreen-safe-destructive-ok: DROP TABLE is limited to future monthly children
+-- re-checked as empty under a 2s parent lock timeout. Complete daily month coverage
+-- keeps the previous monthly owner compatible throughout the blue/green window.
+
+SET LOCAL TIME ZONE 'UTC';
+SET LOCAL lock_timeout = '2s';
+SET LOCAL statement_timeout = '120s';
+
+DO $migration$
+DECLARE
+  schema_name text := current_schema();
+  cutover_now timestamptz := COALESCE(current_setting('tokenkey.ops_daily_cutover_now', true), transaction_timestamp()::text)::timestamptz;
+  parent_name text;
+  parent_oid oid;
+  current_start timestamptz;
+  next_start timestamptz;
+  horizon_end timestamptz;
+  month_start timestamptz;
+  month_end timestamptz;
+  day_start timestamptz;
+  day_end timestamptz;
+  child_name text;
+  expected_name text;
+  current_rec record;
+  current_child_oid oid;
+  current_bound_expr text;
+  target_rec record;
+  attached_rec record;
+  relation_kind "char";
+  has_rows boolean;
+  invalid_count integer;
+  matching_count integer;
+  expected_days integer;
+  attached_days integer;
+BEGIN
+  current_start := date_trunc('month', cutover_now);
+  next_start := current_start + interval '1 month';
+  horizon_end := current_start + interval '4 months';
+
+  CREATE TEMP TABLE tk_ops_daily_current_state (
+    parent_name text PRIMARY KEY,
+    child_oid oid NOT NULL,
+    bound_expr text NOT NULL
+  ) ON COMMIT DROP;
+
+  CREATE TEMP TABLE tk_ops_daily_target_state (
+    parent_name text NOT NULL,
+    month_start timestamptz NOT NULL,
+    month_end timestamptz NOT NULL,
+    state text NOT NULL CHECK (state IN ('absent', 'monthly', 'daily')),
+    monthly_child_oid oid,
+    monthly_child_name text,
+    PRIMARY KEY (parent_name, month_start)
+  ) ON COMMIT DROP;
+
+  -- Validate the complete pre-cutover topology before creating detached tables.
+  FOREACH parent_name IN ARRAY ARRAY['ops_error_logs', 'ops_system_logs'] LOOP
+    SELECT c.oid
+      INTO parent_oid
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_partitioned_table pt ON pt.partrelid = c.oid
+     WHERE n.nspname = schema_name
+       AND c.relname = parent_name
+       AND pt.partstrat = 'r'
+       AND pt.partnatts = 1
+       AND pg_get_partkeydef(c.oid) = 'RANGE (created_at)';
+    IF parent_oid IS NULL THEN
+      RAISE EXCEPTION 'tk_080: %.% must be RANGE (created_at) partitioned', schema_name, parent_name;
+    END IF;
+
+    SELECT count(*)
+      INTO invalid_count
+      FROM (
+        SELECT pg_get_expr(child.relpartbound, child.oid, true) AS bound_expr,
+               pg_get_expr(child.relpartbound, child.oid, true) LIKE 'FOR VALUES FROM (MINVALUE)%' AS lower_unbounded,
+               substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz AS lower_bound,
+               substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz AS upper_bound
+          FROM pg_inherits inheritance
+          JOIN pg_class child ON child.oid = inheritance.inhrelid
+         WHERE inheritance.inhparent = parent_oid
+      ) bounds
+     WHERE bound_expr = 'DEFAULT'
+        OR bound_expr LIKE '%MAXVALUE%'
+        OR upper_bound IS NULL
+        OR (NOT lower_unbounded AND lower_bound IS NULL);
+    IF invalid_count <> 0 THEN
+      RAISE EXCEPTION 'tk_080: %.% has DEFAULT, MAXVALUE, or unparseable child bounds', schema_name, parent_name;
+    END IF;
+
+    SELECT count(*), min(child_oid), min(bound_expr)
+      INTO matching_count, current_child_oid, current_bound_expr
+      FROM (
+        SELECT child.oid AS child_oid,
+               pg_get_expr(child.relpartbound, child.oid, true) AS bound_expr,
+               pg_get_expr(child.relpartbound, child.oid, true) LIKE 'FOR VALUES FROM (MINVALUE)%' AS lower_unbounded,
+               substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz AS lower_bound,
+               substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz AS upper_bound
+          FROM pg_inherits inheritance
+          JOIN pg_class child ON child.oid = inheritance.inhrelid
+         WHERE inheritance.inhparent = parent_oid
+      ) bounds
+     WHERE (lower_unbounded OR lower_bound <= current_start)
+       AND upper_bound >= next_start;
+    IF matching_count <> 1 OR current_child_oid IS NULL THEN
+      RAISE EXCEPTION 'tk_080: %.% must have exactly one child covering the current UTC month', schema_name, parent_name;
+    END IF;
+    INSERT INTO tk_ops_daily_current_state VALUES (parent_name, current_child_oid, current_bound_expr);
+
+    -- Anything beginning in the future must fit wholly inside the three-month owner horizon.
+    SELECT count(*)
+      INTO invalid_count
+      FROM (
+        SELECT pg_get_expr(child.relpartbound, child.oid, true) AS bound_expr,
+               substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz AS lower_bound,
+               substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz AS upper_bound
+          FROM pg_inherits inheritance
+          JOIN pg_class child ON child.oid = inheritance.inhrelid
+         WHERE inheritance.inhparent = parent_oid
+      ) bounds
+     WHERE lower_bound >= next_start
+       AND (upper_bound IS NULL OR lower_bound IS NULL OR upper_bound > horizon_end);
+    IF invalid_count <> 0 THEN
+      RAISE EXCEPTION 'tk_080: %.% has a future child outside the three-month horizon', schema_name, parent_name;
+    END IF;
+
+    month_start := next_start;
+    WHILE month_start < horizon_end LOOP
+      month_end := month_start + interval '1 month';
+      expected_name := parent_name || '_' || to_char(month_start, 'YYYYMM');
+
+      CREATE TEMP TABLE tk_ops_daily_month_children ON COMMIT DROP AS
+      SELECT child.oid AS child_oid,
+             child.relname AS child_name,
+             pg_get_expr(child.relpartbound, child.oid, true) AS bound_expr,
+             substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz AS lower_bound,
+             substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz AS upper_bound
+        FROM pg_inherits inheritance
+        JOIN pg_class child ON child.oid = inheritance.inhrelid
+       WHERE inheritance.inhparent = parent_oid
+         AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz < month_end
+         AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz > month_start;
+
+      SELECT count(*) INTO matching_count FROM tk_ops_daily_month_children;
+      IF matching_count = 0 THEN
+        INSERT INTO tk_ops_daily_target_state VALUES (parent_name, month_start, month_end, 'absent', NULL, NULL);
+      ELSIF matching_count = 1 AND EXISTS (
+        SELECT 1 FROM tk_ops_daily_month_children month_child
+         WHERE month_child.child_name = expected_name
+           AND month_child.lower_bound = month_start
+           AND month_child.upper_bound = month_end
+      ) THEN
+        SELECT month_child.child_oid, month_child.child_name INTO attached_rec
+          FROM tk_ops_daily_month_children month_child;
+        INSERT INTO tk_ops_daily_target_state
+        VALUES (parent_name, month_start, month_end, 'monthly', attached_rec.child_oid, attached_rec.child_name);
+      ELSE
+        expected_days := (month_end::date - month_start::date);
+        SELECT count(*) INTO attached_days
+          FROM tk_ops_daily_month_children month_child
+         WHERE month_child.child_name = parent_name || '_' || to_char(month_child.lower_bound, 'YYYYMMDD')
+           AND month_child.lower_bound >= month_start
+           AND month_child.upper_bound = month_child.lower_bound + interval '1 day'
+           AND month_child.upper_bound <= month_end;
+        IF matching_count = expected_days AND attached_days = expected_days THEN
+          INSERT INTO tk_ops_daily_target_state VALUES (parent_name, month_start, month_end, 'daily', NULL, NULL);
+        ELSE
+          RAISE EXCEPTION 'tk_080: %.% has partial or unexpected coverage for month %', schema_name, parent_name, month_start;
+        END IF;
+      END IF;
+      DROP TABLE tk_ops_daily_month_children;
+      month_start := month_end;
+    END LOOP;
+  END LOOP;
+
+  -- Build detached final-name tables and their local indexes before the short parent-lock phase.
+  FOR target_rec IN
+    SELECT * FROM tk_ops_daily_target_state
+     WHERE state IN ('absent', 'monthly')
+     ORDER BY parent_name, month_start
+  LOOP
+    day_start := target_rec.month_start;
+    WHILE day_start < target_rec.month_end LOOP
+      day_end := day_start + interval '1 day';
+      child_name := target_rec.parent_name || '_' || to_char(day_start, 'YYYYMMDD');
+
+      SELECT c.relkind INTO relation_kind
+        FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = schema_name AND c.relname = child_name;
+      IF relation_kind IS NOT NULL THEN
+        RAISE EXCEPTION 'tk_080: relation %.% already exists outside expected daily topology', schema_name, child_name;
+      END IF;
+
+      EXECUTE format('CREATE TABLE %I.%I (LIKE %I.%I INCLUDING ALL)',
+                     schema_name, child_name, schema_name, target_rec.parent_name);
+      EXECUTE format(
+        'ALTER TABLE %I.%I ADD CONSTRAINT %I CHECK (created_at >= %L::timestamptz AND created_at < %L::timestamptz)',
+        schema_name, child_name, child_name || '_utc_day_check', day_start, day_end
+      );
+      day_start := day_end;
+    END LOOP;
+  END LOOP;
+
+  -- The catalog cutover is intentionally short: all table/index construction is complete.
+  LOCK TABLE ops_error_logs IN ACCESS EXCLUSIVE MODE;
+  LOCK TABLE ops_system_logs IN ACCESS EXCLUSIVE MODE;
+  FOR target_rec IN
+    SELECT * FROM tk_ops_daily_target_state
+     WHERE state = 'monthly'
+     ORDER BY parent_name, month_start
+  LOOP
+    EXECUTE format('LOCK TABLE %I.%I IN ACCESS EXCLUSIVE MODE', schema_name, target_rec.monthly_child_name);
+  END LOOP;
+
+  -- PostgreSQL DROP/ATTACH PARTITION requires ACCESS EXCLUSIVE on the parent.
+  -- The short lock timeout makes an active writer a fail-closed retry condition.
+  -- Re-check every load-bearing precondition under the parent and candidate-child locks.
+  FOR current_rec IN SELECT * FROM tk_ops_daily_current_state ORDER BY parent_name LOOP
+    SELECT count(*) INTO matching_count
+      FROM pg_inherits inheritance
+      JOIN pg_class child ON child.oid = inheritance.inhrelid
+     WHERE inheritance.inhparent = to_regclass(format('%I.%I', schema_name, current_rec.parent_name))
+       AND child.oid = current_rec.child_oid
+       AND pg_get_expr(child.relpartbound, child.oid, true) = current_rec.bound_expr;
+    IF matching_count <> 1 THEN
+      RAISE EXCEPTION 'tk_080: current writer partition changed for %.%', schema_name, current_rec.parent_name;
+    END IF;
+  END LOOP;
+
+  FOR target_rec IN SELECT * FROM tk_ops_daily_target_state ORDER BY parent_name, month_start LOOP
+    parent_oid := to_regclass(format('%I.%I', schema_name, target_rec.parent_name));
+    SELECT count(*) INTO matching_count
+      FROM pg_inherits inheritance
+      JOIN pg_class child ON child.oid = inheritance.inhrelid
+     WHERE inheritance.inhparent = parent_oid
+       AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz < target_rec.month_end
+       AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz > target_rec.month_start;
+
+    IF target_rec.state = 'monthly' THEN
+      IF matching_count <> 1 OR NOT EXISTS (
+        SELECT 1
+          FROM pg_inherits inheritance
+          JOIN pg_class child ON child.oid = inheritance.inhrelid
+         WHERE inheritance.inhparent = parent_oid
+           AND child.oid = target_rec.monthly_child_oid
+           AND child.relname = target_rec.monthly_child_name
+           AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz = target_rec.month_start
+           AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz = target_rec.month_end
+      ) THEN
+        RAISE EXCEPTION 'tk_080: future monthly child changed for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
+      END IF;
+      EXECUTE format('SELECT EXISTS (SELECT 1 FROM %I.%I LIMIT 1)', schema_name, target_rec.monthly_child_name)
+        INTO has_rows;
+      IF has_rows THEN
+        RAISE EXCEPTION 'tk_080: refusing to replace non-empty future child %.%', schema_name, target_rec.monthly_child_name;
+      END IF;
+    ELSIF target_rec.state = 'absent' AND matching_count <> 0 THEN
+      RAISE EXCEPTION 'tk_080: future topology appeared for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
+    ELSIF target_rec.state = 'daily' THEN
+      expected_days := (target_rec.month_end::date - target_rec.month_start::date);
+      IF matching_count <> expected_days THEN
+        RAISE EXCEPTION 'tk_080: daily topology changed for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- Drop only locked, exactly-bounded, empty future monthly children.
+  FOR target_rec IN
+    SELECT * FROM tk_ops_daily_target_state
+     WHERE state = 'monthly'
+     ORDER BY parent_name, month_start
+  LOOP
+    EXECUTE format('DROP TABLE %I.%I', schema_name, target_rec.monthly_child_name);
+  END LOOP;
+
+  -- Attach every prebuilt day, preserving complete coverage for old and new owners.
+  FOR target_rec IN
+    SELECT * FROM tk_ops_daily_target_state
+     WHERE state IN ('absent', 'monthly')
+     ORDER BY parent_name, month_start
+  LOOP
+    day_start := target_rec.month_start;
+    WHILE day_start < target_rec.month_end LOOP
+      day_end := day_start + interval '1 day';
+      child_name := target_rec.parent_name || '_' || to_char(day_start, 'YYYYMMDD');
+      EXECUTE format(
+        'ALTER TABLE %I.%I ATTACH PARTITION %I.%I FOR VALUES FROM (%L) TO (%L)',
+        schema_name, target_rec.parent_name, schema_name, child_name, day_start, day_end
+      );
+      day_start := day_end;
+    END LOOP;
+  END LOOP;
+
+  -- Final proof: every target month is made solely of exact, indexed UTC daily children.
+  FOR target_rec IN SELECT * FROM tk_ops_daily_target_state ORDER BY parent_name, month_start LOOP
+    parent_oid := to_regclass(format('%I.%I', schema_name, target_rec.parent_name));
+    expected_days := (target_rec.month_end::date - target_rec.month_start::date);
+    SELECT count(*) INTO attached_days
+      FROM pg_inherits inheritance
+      JOIN pg_class child ON child.oid = inheritance.inhrelid
+     WHERE inheritance.inhparent = parent_oid
+       AND child.relname = target_rec.parent_name || '_' || to_char(
+             substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz,
+             'YYYYMMDD'
+           )
+       AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz >= target_rec.month_start
+       AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz <= target_rec.month_end
+       AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz =
+           substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz + interval '1 day';
+    IF attached_days <> expected_days THEN
+      RAISE EXCEPTION 'tk_080: incomplete daily coverage for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
+    END IF;
+
+    -- PostgreSQL ATTACH automatically attaches or creates matching child indexes.
+    IF EXISTS (
+      SELECT 1
+        FROM pg_index parent_index_meta
+        JOIN pg_class parent_index ON parent_index.oid = parent_index_meta.indexrelid
+       WHERE parent_index_meta.indrelid = parent_oid
+         AND parent_index.relkind = 'I'
+         AND EXISTS (
+           SELECT 1
+             FROM pg_inherits table_inheritance
+             JOIN pg_class child ON child.oid = table_inheritance.inhrelid
+            WHERE table_inheritance.inhparent = parent_oid
+              AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz >= target_rec.month_start
+              AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz <= target_rec.month_end
+              AND NOT EXISTS (
+                SELECT 1
+                  FROM pg_inherits index_inheritance
+                  JOIN pg_index child_index_meta ON child_index_meta.indexrelid = index_inheritance.inhrelid
+                 WHERE index_inheritance.inhparent = parent_index.oid
+                   AND child_index_meta.indrelid = child.oid
+              )
+         )
+    ) THEN
+      RAISE EXCEPTION 'tk_080: child index attachment incomplete for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
+    END IF;
+  END LOOP;
+END $migration$;

--- a/backend/migrations/tk_081_ops_daily_partition_cutover.sql
+++ b/backend/migrations/tk_081_ops_daily_partition_cutover.sql
@@ -1,4 +1,4 @@
--- tk_080_ops_daily_partition_cutover.sql
+-- tk_081_ops_daily_partition_cutover.sql
 -- Replace only empty future monthly ops partitions with complete UTC daily coverage.
 -- The current-month writer partition and all historical partitions remain untouched.
 --
@@ -70,7 +70,7 @@ BEGIN
        AND pt.partnatts = 1
        AND pg_get_partkeydef(c.oid) = 'RANGE (created_at)';
     IF parent_oid IS NULL THEN
-      RAISE EXCEPTION 'tk_080: %.% must be RANGE (created_at) partitioned', schema_name, parent_name;
+      RAISE EXCEPTION 'tk_081: %.% must be RANGE (created_at) partitioned', schema_name, parent_name;
     END IF;
 
     SELECT count(*)
@@ -89,7 +89,7 @@ BEGIN
         OR upper_bound IS NULL
         OR (NOT lower_unbounded AND lower_bound IS NULL);
     IF invalid_count <> 0 THEN
-      RAISE EXCEPTION 'tk_080: %.% has DEFAULT, MAXVALUE, or unparseable child bounds', schema_name, parent_name;
+      RAISE EXCEPTION 'tk_081: %.% has DEFAULT, MAXVALUE, or unparseable child bounds', schema_name, parent_name;
     END IF;
 
     SELECT count(*), min(child_oid), min(bound_expr)
@@ -107,7 +107,7 @@ BEGIN
      WHERE (lower_unbounded OR lower_bound <= current_start)
        AND upper_bound >= next_start;
     IF matching_count <> 1 OR current_child_oid IS NULL THEN
-      RAISE EXCEPTION 'tk_080: %.% must have exactly one child covering the current UTC month', schema_name, parent_name;
+      RAISE EXCEPTION 'tk_081: %.% must have exactly one child covering the current UTC month', schema_name, parent_name;
     END IF;
     INSERT INTO tk_ops_daily_current_state VALUES (parent_name, current_child_oid, current_bound_expr);
 
@@ -125,7 +125,7 @@ BEGIN
      WHERE lower_bound >= next_start
        AND (upper_bound IS NULL OR lower_bound IS NULL OR upper_bound > horizon_end);
     IF invalid_count <> 0 THEN
-      RAISE EXCEPTION 'tk_080: %.% has a future child outside the three-month horizon', schema_name, parent_name;
+      RAISE EXCEPTION 'tk_081: %.% has a future child outside the three-month horizon', schema_name, parent_name;
     END IF;
 
     month_start := next_start;
@@ -169,7 +169,7 @@ BEGIN
         IF matching_count = expected_days AND attached_days = expected_days THEN
           INSERT INTO tk_ops_daily_target_state VALUES (parent_name, month_start, month_end, 'daily', NULL, NULL);
         ELSE
-          RAISE EXCEPTION 'tk_080: %.% has partial or unexpected coverage for month %', schema_name, parent_name, month_start;
+          RAISE EXCEPTION 'tk_081: %.% has partial or unexpected coverage for month %', schema_name, parent_name, month_start;
         END IF;
       END IF;
       DROP TABLE tk_ops_daily_month_children;
@@ -192,7 +192,7 @@ BEGIN
         FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
        WHERE n.nspname = schema_name AND c.relname = child_name;
       IF relation_kind IS NOT NULL THEN
-        RAISE EXCEPTION 'tk_080: relation %.% already exists outside expected daily topology', schema_name, child_name;
+        RAISE EXCEPTION 'tk_081: relation %.% already exists outside expected daily topology', schema_name, child_name;
       END IF;
 
       EXECUTE format('CREATE TABLE %I.%I (LIKE %I.%I INCLUDING ALL)',
@@ -227,7 +227,7 @@ BEGIN
        AND child.oid = current_rec.child_oid
        AND pg_get_expr(child.relpartbound, child.oid, true) = current_rec.bound_expr;
     IF matching_count <> 1 THEN
-      RAISE EXCEPTION 'tk_080: current writer partition changed for %.%', schema_name, current_rec.parent_name;
+      RAISE EXCEPTION 'tk_081: current writer partition changed for %.%', schema_name, current_rec.parent_name;
     END IF;
   END LOOP;
 
@@ -251,19 +251,19 @@ BEGIN
            AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz = target_rec.month_start
            AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz = target_rec.month_end
       ) THEN
-        RAISE EXCEPTION 'tk_080: future monthly child changed for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
+        RAISE EXCEPTION 'tk_081: future monthly child changed for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
       END IF;
       EXECUTE format('SELECT EXISTS (SELECT 1 FROM %I.%I LIMIT 1)', schema_name, target_rec.monthly_child_name)
         INTO has_rows;
       IF has_rows THEN
-        RAISE EXCEPTION 'tk_080: refusing to replace non-empty future child %.%', schema_name, target_rec.monthly_child_name;
+        RAISE EXCEPTION 'tk_081: refusing to replace non-empty future child %.%', schema_name, target_rec.monthly_child_name;
       END IF;
     ELSIF target_rec.state = 'absent' AND matching_count <> 0 THEN
-      RAISE EXCEPTION 'tk_080: future topology appeared for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
+      RAISE EXCEPTION 'tk_081: future topology appeared for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
     ELSIF target_rec.state = 'daily' THEN
       expected_days := (target_rec.month_end::date - target_rec.month_start::date);
       IF matching_count <> expected_days THEN
-        RAISE EXCEPTION 'tk_080: daily topology changed for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
+        RAISE EXCEPTION 'tk_081: daily topology changed for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
       END IF;
     END IF;
   END LOOP;
@@ -312,7 +312,7 @@ BEGIN
        AND substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$TO \('([^']+)'$$)::timestamptz =
            substring(pg_get_expr(child.relpartbound, child.oid, true) FROM $$FROM \('([^']+)'$$)::timestamptz + interval '1 day';
     IF attached_days <> expected_days THEN
-      RAISE EXCEPTION 'tk_080: incomplete daily coverage for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
+      RAISE EXCEPTION 'tk_081: incomplete daily coverage for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
     END IF;
 
     -- PostgreSQL ATTACH automatically attaches or creates matching child indexes.
@@ -338,7 +338,7 @@ BEGIN
               )
          )
     ) THEN
-      RAISE EXCEPTION 'tk_080: child index attachment incomplete for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
+      RAISE EXCEPTION 'tk_081: child index attachment incomplete for %.% month %', schema_name, target_rec.parent_name, target_rec.month_start;
     END IF;
   END LOOP;
 END $migration$;

--- a/docs/approved/design-data-layer-phase1-closeout.md
+++ b/docs/approved/design-data-layer-phase1-closeout.md
@@ -4,6 +4,7 @@ status: approved
 approved_by: "xuejiao (phase 1 items 1/2/3 approval, 2026-08-03)"
 approved_at: 2026-08-03
 authors: [agent]
+related_prs: [1653]
 ---
 
 # Data-layer 第一阶段收尾
@@ -28,9 +29,10 @@ cron + leader lock
   -> cleanup_enabled=true  -> retention/drop/delete -> ops_cleanup heartbeat
 ```
 
-关闭 cleanup 只关闭删除，不再关闭 cron。分区维护为分区化的 ops 表创建当前月和未来月；
-`usage_logs` 完成显式切换后创建当前日和未来日。维护失败只写维护心跳，不伪造 cleanup
-运行记录；cleanup hold 期间 `ops_cleanup` heartbeat 必须保持不动。
+关闭 cleanup 只关闭删除，不再关闭 cron。分区维护为 `ops_system_logs`、
+`ops_error_logs` 与 `usage_logs` 创建当前 UTC 日和未来 7 日（共 8 个日范围）。ops 两表从下一个
+完整 UTC 月起使用日分区；切换前的 current month 与历史 child 保持不动。维护失败只写维护
+心跳，不伪造 cleanup 运行记录；cleanup hold 期间 `ops_cleanup` heartbeat 必须保持不动。
 
 日常诊断 fail closed：当前或未来分区缺失、分区维护心跳过期、pgdump 或 EBS snapshot
 过期、归档 ledger 落后、cleanup hold 长期未收口、恢复演练证据过期，均产生独立 finding。
@@ -46,8 +48,8 @@ Archive closeout 继续证明冷数据可恢复，但不再作为年龄 retentio
 
 **Prod 终态**由 repo 证据 + `python3 ops/observability/data_layer_archive_health.py` 定义：
 `closeout_complete`、`tail_export_complete`、`cleanup_release_complete` 均为 true，且
-`evidence_errors` 为空。日常回收唯一 owner 是 `OpsCleanupService`（ops 月分区在
-`upper_bound <= now-30d` 时整分区 DROP；跨边界宽分区 capped 行级 DELETE；
+`evidence_errors` 为空。日常回收唯一 owner 是 `OpsCleanupService`（ops 日分区在
+`upper_bound <= retention cutoff` 时整分区 DROP；跨边界宽分区 capped 行级 DELETE；
 `usage_logs_legacy` 走 attach-legacy + 90d DELETE/DropExpired）。promote ledger 的
 `drop_ready` 只证明 export 证据齐全，**不授权**删除。
 

--- a/docs/approved/design-prod-archive-bucket.md
+++ b/docs/approved/design-prod-archive-bucket.md
@@ -5,7 +5,7 @@ approved_by: "xuejiao (archive bucket approval, 2026-07-23)"
 approved_at: 2026-07-23
 authors: [agent]
 created: 2026-07-22
-related_prs: [1401]
+related_prs: [1401, 1653]
 ---
 
 # 生产 ops 长期 archive bucket 与 promote
@@ -13,7 +13,7 @@ related_prs: [1401]
 ## 决策
 
 export staging（`tokenkey-stage0-backups` / `prod/pgdump/archive-export/`）仅 **7 天**
-周转；长期归档使用 **独立 S3 桶**，一条 canonical promote 路径。ops 月分区回收前 export/promote
+周转；长期归档使用 **独立 S3 桶**，一条 canonical promote 路径。ops 分区回收前 export/promote
 证据须齐全（`drop_ready` 仍不授权删除）；steady state 下 physical DROP 由 `OpsCleanupService`
 执行；终态与 re-export 例外路径见 `ops/archive/README.md`。
 
@@ -39,8 +39,8 @@ export staging（`tokenkey-stage0-backups` / `prod/pgdump/archive-export/`）仅
 
 ### 分区回收门禁（本文件不实现 drop；执行 owner 为 `OpsCleanupService`）
 
-以下 **全部** 满足后，ops **月分区** 才可在 bound 到期时做整分区 DROP（由 daily cleanup 的
-`pgpartition.DropExpired` 自动执行，**不是**本目录 operator CLI）：
+以下 **全部** 满足后，ops **日分区** 才可在 `upper_bound <= retention cutoff` 时做整分区
+DROP（由 daily cleanup 的 `pgpartition.DropExpired` 自动执行，**不是**本目录 operator CLI）：
 
 1. 对应表 export ledger：`more_cold_rows_remaining=false`
 2. ledger 中 **每个** `batch_id` 有 promote receipt，且 archive 前缀 manifest
@@ -48,7 +48,7 @@ export staging（`tokenkey-stage0-backups` / `prod/pgdump/archive-export/`）仅
 3. `cleanup_release_complete=true`（`data_layer_archive_health.py`）；`drop_ready`
    **不是**删除授权
 
-`usage_logs_legacy`（attach-legacy，90d 热层）与 ops 月分区模型不同：回收走行级 DELETE 与
+`usage_logs_legacy`（attach-legacy，90d 热层）与 ops 日分区模型不同：回收走行级 DELETE 与
 DropExpired，不由本 promote 路径手工 DROP。
 
 ## 状态机

--- a/ops/migration/test_data_layer_partition_maintenance.py
+++ b/ops/migration/test_data_layer_partition_maintenance.py
@@ -25,8 +25,8 @@ def remote_receipt() -> dict[str, object]:
         "job_name": "ops_partition_maintenance",
         "completed_at": "2026-08-04T12:00:00Z",
         "tables": [
-            {"table": "ops_system_logs", "range_count": 4},
-            {"table": "ops_error_logs", "range_count": 4},
+            {"table": "ops_system_logs", "range_count": 8},
+            {"table": "ops_error_logs", "range_count": 8},
             {"table": "usage_logs", "range_count": 8},
         ],
         "deletion_authorized": False,

--- a/scripts/sentinels/perf-query-shape.json
+++ b/scripts/sentinels/perf-query-shape.json
@@ -64,9 +64,11 @@
         "pg_get_expr(c.relpartbound, c.oid, true) AS bound_expr",
         "WHERE i.inhparent = to_regclass($1)",
         "if !child.upper.After(cutoff)",
-        "has no finite timestamptz upper bound"
+        "has no finite timestamptz upper bound",
+        "child.lowerUnbounded || child.lower.Time.Before(cutoff)",
+        "has no finite timestamptz lower bound"
       ],
-      "rationale": "Partition retention must use PostgreSQL's declared exclusive upper bound, never max(data) or a filename suffix. This preserves empty future partitions, reclaims empty expired partitions, handles legacy names, and fails before any DROP when a finite time bound cannot be proven. A data-based regression can delete newly provisioned empty partitions immediately while every populated-partition test stays green."
+      "rationale": "Partition retention must use PostgreSQL's declared exclusive upper bound, never max(data) or a filename suffix. This preserves empty future partitions, reclaims empty expired partitions, handles legacy names, and fails before any DROP when a finite time bound cannot be proven. A data-based regression can delete newly provisioned empty partitions immediately while every populated-partition test stays green. ListStraddling must also prune children whose declared lower bound is at/after cutoff before issuing min(created_at), or daily partitioning creates one cleanup round-trip per current/future day."
     },
     {
       "path": "backend/internal/service/ops_cleanup_executor.go",
@@ -100,7 +102,8 @@
         "{table: \"ops_system_logs\"",
         "{table: \"ops_error_logs\"",
         "{table: \"usage_logs\"",
-        "pgpartition.EnsureMonthly(ctx, db, target.table, now, target.ahead)",
+        "{table: \"ops_system_logs\", ahead: daysAhead}",
+        "{table: \"ops_error_logs\", ahead: daysAhead}",
         "pgpartition.EnsureDaily(ctx, db, target.table, now, target.ahead)",
         "ModeRequireAllPartitioned",
         "pg_get_expr(child.relpartbound, child.oid, true)",


### PR DESCRIPTION
## 摘要

- 新增事务型 migration `tk_081_ops_daily_partition_cutover.sql`，从下一个完整 UTC 月起把 `ops_system_logs` / `ops_error_logs` 的未来月分区切成日分区。
- current month 与历史 child 不动；仅替换锁内再次精确证明为空、边界与名称完全匹配的 future monthly children。
- fresh DB 缺月、exact monthly、already-complete daily 三种合法拓扑均可处理；partial/mixed/default/MAXVALUE/非空/并发锁冲突全部 fail closed 并整笔回滚。
- 唯一 `partitionmaintenance` owner 收敛为三表 daily `today + 7 days`，receipt count 从 `4/4/8` 变为 `8/8/8`，不新增 scheduler 或 heartbeat。
- `ListStraddling` 先按 catalog lower bound 剪枝，仅对可能跨 cutoff 的 child 查询 `min(created_at)`，避免日分区放大 cleanup N+1。
- 直接修正现有批准文档中的 ops 月分区旧基线，使分区维护、retention 与 archive 门禁统一以 ops 日分区为准；不新增重复批准文档。

## 风险

- migration 需要对两个 parent 取得 PostgreSQL `ACCESS EXCLUSIVE`；`lock_timeout=2s`，活跃 writer 或 future child reader 会使 migration 快速失败且事务回滚，部署应重试而不是等待线上流量。
- 初始蓝绿窗口兼容旧 monthly owner：完整 daily month union 可通过旧 coverage proof，重叠创建继续按既有 `42P17` benign skip；integration test 直接运行旧 `EnsureMonthly` 并证明拓扑不变。
- daily retention 开始逐日 drop 后不保证回滚到只认识完整月 coverage 的旧 binary；该阶段应 fix-forward。
- retention、cleanup cap/顺序、QA owner、archive/raw telemetry、UI 与线上配置均未改变；本 PR 不授权部署、清理或任何 live mutation。

## 验证

- `PREFLIGHT_BASE=origin/main ./scripts/preflight.sh`
- `make test`
- `go -C backend test -tags=unit ./internal/pkg/partitionmaintenance ./internal/pkg/pgpartition ./cmd/server ./internal/service`
- `DOCKER_HOST=unix:///Users/feng/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock go -C backend test -tags=integration ./internal/repository -run 'Test.*(OpsDailyPartition|PartitionMaintenance|PgPartition)' -count=1`
- `PYTHONPATH=ops/migration python3 -m unittest ops.migration.test_data_layer_partition_maintenance`

真实 PostgreSQL integration 覆盖：fresh/缺月切换、current child OID 与数据保留、91 日 child/表、边界路由、index attachment、幂等、非空/partial/default 拒绝、current writer/future reader lock timeout 后拓扑不变，以及旧 monthly owner 对完整 daily month union 的兼容性。

## 提交

- `784f90927 feat(ops): migrate ops logs to daily partitions`
- `62e226adf test(partitions): prove monthly owner compatibility`
- `b1280c198 docs(ops): align approved partition baseline`
- `ba59e28bb fix(migrations): avoid latest main number collision`
- `4ee835316 Merge origin/main into feature/ops-daily-partitions`

最新提交：`4ee835316`

no-web-impact

sentinel-registry-reviewed: updated perf query-shape anchors for the daily owner and lower-bound pruning.
