### PR TITLE
fix(gateway): preserve Grok messages dispatch defaults

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1000,7 +1000,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		return
 	}
 	bindOpenAIReasoningEffortPolicyForMessagesRequest(c, apiKey, body)
-	routingModel := service.NormalizeOpenAICompatRequestedModel(reqModel)
+	routingModel := service.CanonicalizeOpenAICompatRoutingModel(service.NormalizeOpenAICompatRequestedModel(reqModel))
 	preferredMappedModel := resolveOpenAIMessagesDispatchMappedModel(apiKey, reqModel)
 	if h.rejectDeprecatedOpenAICompatMappedModel(c, apiKey, preferredMappedModel, true) {
 		return

--- a/backend/internal/pkg/xai/models.go
+++ b/backend/internal/pkg/xai/models.go
@@ -11,8 +11,15 @@ var runtimeMappingOpts atomic.Value // ModelMappingOptions
 var runtimeMappingVersion atomic.Uint64
 
 func init() {
-	runtimeMappingOpts.Store(ModelMappingOptions{})
+	runtimeMappingOpts.Store(defaultRuntimeModelMappingOptions())
 	runtimeMappingVersion.Store(1)
+}
+
+func defaultRuntimeModelMappingOptions() ModelMappingOptions {
+	return ModelMappingOptions{
+		DefaultText:          DefaultTextModel,
+		EnableCrossClientMap: true,
+	}
 }
 
 // SetRuntimeModelMappingOptions updates process-wide defaults used by

--- a/backend/internal/pkg/xai/models_test.go
+++ b/backend/internal/pkg/xai/models_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDefaultModelMappingExcludesCrossClientWildcards(t *testing.T) {
+func TestDefaultModelMappingExcludesCrossClientWildcardsWhenDisabled(t *testing.T) {
 	original := RuntimeModelMappingOptions()
 	t.Cleanup(func() { SetRuntimeModelMappingOptions(original) })
-	SetRuntimeModelMappingOptions(ModelMappingOptions{})
+	SetRuntimeModelMappingOptions(ModelMappingOptions{EnableCrossClientMap: false})
 	mapping := DefaultModelMapping()
 
 	require.Equal(t, DefaultTextModel, mapping["grok"])
@@ -26,6 +26,13 @@ func TestDefaultModelMappingExcludesCrossClientWildcards(t *testing.T) {
 	_, hasClaude := mapping["claude-*"]
 	require.False(t, hasGPT)
 	require.False(t, hasClaude)
+}
+
+func TestDefaultRuntimeModelMappingOptionsEnableCrossClient(t *testing.T) {
+	t.Parallel()
+	opts := defaultRuntimeModelMappingOptions()
+	require.Equal(t, DefaultTextModel, opts.DefaultText)
+	require.True(t, opts.EnableCrossClientMap)
 }
 
 func TestModelMappingWithOptionsCrossClient(t *testing.T) {

--- a/backend/internal/pkg/xai/oauth_test.go
+++ b/backend/internal/pkg/xai/oauth_test.go
@@ -348,7 +348,7 @@ func TestRuntimeSanityReportsInvalidOverridesWithoutSecrets(t *testing.T) {
 func TestDefaultModelMappingIncludesGrokAliases(t *testing.T) {
 	original := RuntimeModelMappingOptions()
 	t.Cleanup(func() { SetRuntimeModelMappingOptions(original) })
-	SetRuntimeModelMappingOptions(ModelMappingOptions{})
+	SetRuntimeModelMappingOptions(ModelMappingOptions{EnableCrossClientMap: false})
 	mapping := DefaultModelMapping()
 	require.Equal(t, DefaultTextModel, mapping["grok"])
 	require.Equal(t, "grok-4.3", mapping["grok-latest"])

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -1842,6 +1842,7 @@ func (r *accountRepository) ClearError(ctx context.Context, id int64) error {
 		Where(dbaccount.IDEQ(id)).
 		SetStatus(service.StatusActive).
 		SetErrorMessage("").
+		SetSchedulable(true).
 		Save(ctx)
 	if err != nil {
 		return err

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -1536,10 +1536,11 @@ func (s *AccountRepoSuite) TestUpdateErrorStatusUnschedulesAccount() {
 
 func (s *AccountRepoSuite) TestClearError_SyncSchedulerSnapshotOnRecovery() {
 	account := mustCreateAccount(s.T(), s.client, &service.Account{
-		Name:         "acc-clear-err",
-		Status:       service.StatusError,
-		ErrorMessage: "temporary error",
+		Name:        "acc-clear-err",
+		Status:      service.StatusActive,
+		Schedulable: true,
 	})
+	s.Require().NoError(s.repo.SetError(s.ctx, account.ID, "temporary error"))
 	cacheRecorder := &schedulerCacheRecorder{}
 	s.repo.schedulerCache = cacheRecorder
 
@@ -1549,9 +1550,11 @@ func (s *AccountRepoSuite) TestClearError_SyncSchedulerSnapshotOnRecovery() {
 	s.Require().NoError(err)
 	s.Require().Equal(service.StatusActive, got.Status)
 	s.Require().Empty(got.ErrorMessage)
+	s.Require().True(got.Schedulable)
 	s.Require().Len(cacheRecorder.setAccounts, 1)
 	s.Require().Equal(account.ID, cacheRecorder.setAccounts[0].ID)
 	s.Require().Equal(service.StatusActive, cacheRecorder.setAccounts[0].Status)
+	s.Require().True(cacheRecorder.setAccounts[0].Schedulable)
 }
 
 // --- UpdateSessionWindow ---

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -590,6 +590,17 @@ func (a *Account) GetModelMapping() map[string]string {
 	return mapping
 }
 
+func defaultGrokAccountModelMapping() map[string]string {
+	mapping := xai.DefaultModelMapping()
+	if !xai.RuntimeModelMappingOptions().EnableCrossClientMap {
+		return mapping
+	}
+	mapping["claude-opus-*"] = defaultMessagesDispatchMappedModelForPlatform(PlatformGrok, "opus")
+	mapping["claude-sonnet-*"] = defaultMessagesDispatchMappedModelForPlatform(PlatformGrok, "sonnet")
+	mapping["claude-haiku-*"] = defaultMessagesDispatchMappedModelForPlatform(PlatformGrok, "haiku")
+	return mapping
+}
+
 func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]string {
 	if a.Credentials == nil {
 		// Antigravity 平台使用默认映射
@@ -597,7 +608,7 @@ func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]stri
 			return domain.DefaultAntigravityModelMapping
 		}
 		if a.Platform == domain.PlatformGrok {
-			return xai.DefaultModelMapping()
+			return defaultGrokAccountModelMapping()
 		}
 		// Bedrock 默认映射由 forwardBedrock 统一处理（需配合 region prefix 调整）
 		return nil
@@ -608,7 +619,7 @@ func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]stri
 			return domain.DefaultAntigravityModelMapping
 		}
 		if a.Platform == domain.PlatformGrok {
-			return xai.DefaultModelMapping()
+			return defaultGrokAccountModelMapping()
 		}
 		return nil
 	}

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -14,14 +14,17 @@ func TestGrokAccountModelMappingCacheInvalidatesWithRuntimeSettings(t *testing.T
 	t.Cleanup(func() { xai.SetRuntimeModelMappingOptions(original) })
 	account := &Account{Platform: PlatformGrok, Credentials: map[string]any{}}
 
-	xai.SetRuntimeModelMappingOptions(xai.ModelMappingOptions{})
+	xai.SetRuntimeModelMappingOptions(xai.ModelMappingOptions{EnableCrossClientMap: false})
 	requireMappedModel(t, account, "claude-sonnet-4-5", "claude-sonnet-4-5")
 
 	xai.SetRuntimeModelMappingOptions(xai.ModelMappingOptions{
 		DefaultText:          "grok-build-0.1",
 		EnableCrossClientMap: true,
 	})
-	requireMappedModel(t, account, "claude-sonnet-4-5", "grok-build-0.1")
+	requireMappedModel(t, account, "claude-opus-4-8", "grok-4.6")
+	requireMappedModel(t, account, "claude-sonnet-4-6", "grok-4.5")
+	requireMappedModel(t, account, "claude-haiku-4-5", "grok-code-fast-1")
+	requireMappedModel(t, account, "claude-fable-5", "grok-build-0.1")
 }
 
 func requireMappedModel(t *testing.T, account *Account, requested, expected string) {

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -428,6 +428,9 @@ func buildAccountForCreate(input *CreateAccountInput, accountExtra map[string]an
 		if !isUpstreamBillingProbeAccount(account) {
 			return nil, ErrUpstreamBillingProbeAccountInvalid
 		}
+		if !upstreamBillingProbeSupportsSub2APIBilling(account) {
+			return nil, ErrUpstreamBillingProbeAccountInvalid
+		}
 		if account.Extra == nil {
 			account.Extra = make(map[string]any)
 		}
@@ -735,6 +738,9 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 		if !isUpstreamBillingProbeAccount(account) {
 			return nil, ErrUpstreamBillingProbeAccountInvalid
 		}
+		if requestedProbeEnabledUpdate != nil && *requestedProbeEnabledUpdate && !upstreamBillingProbeSupportsSub2APIBilling(account) {
+			return nil, ErrUpstreamBillingProbeAccountInvalid
+		}
 	}
 	if account.Extra == nil && (requestedProbeEnabledUpdate != nil || requestedRateSyncEnabledUpdate != nil) {
 		account.Extra = make(map[string]any)
@@ -1008,6 +1014,9 @@ func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUp
 				return nil, ErrAccountNotFound
 			}
 			if !isUpstreamBillingProbeAccount(account) {
+				return nil, ErrUpstreamBillingProbeAccountInvalid
+			}
+			if *input.ProbeEnabled && !upstreamBillingProbeSupportsSub2APIBilling(account) {
 				return nil, ErrUpstreamBillingProbeAccountInvalid
 			}
 		}

--- a/backend/internal/service/admin_service_clear_error_test.go
+++ b/backend/internal/service/admin_service_clear_error_test.go
@@ -28,6 +28,7 @@ func (r *accountRepoStubForClearAccountError) ClearError(ctx context.Context, id
 	r.clearErrorCalls++
 	r.account.Status = StatusActive
 	r.account.ErrorMessage = ""
+	r.account.Schedulable = true
 	return nil
 }
 

--- a/backend/internal/service/composite_platform.go
+++ b/backend/internal/service/composite_platform.go
@@ -133,6 +133,11 @@ func DetectModelPlatform(model string) (string, bool) {
 		return PlatformGemini, true
 	case normalized == "grok" || strings.HasPrefix(normalized, "grok-"):
 		return PlatformGrok, true
+	case strings.HasPrefix(normalized, "minimax-"),
+		strings.HasPrefix(normalized, "glm-"),
+		strings.HasPrefix(normalized, "deepseek-"),
+		strings.HasPrefix(normalized, "qwen"):
+		return PlatformOpenAI, true
 	default:
 		return "", false
 	}

--- a/backend/internal/service/composite_platform_test.go
+++ b/backend/internal/service/composite_platform_test.go
@@ -25,6 +25,10 @@ func TestDetectModelPlatform(t *testing.T) {
 		{name: "learnlm", model: "learnlm-2.0-flash-experimental", platform: PlatformGemini, ok: true},
 		{name: "grok", model: "grok-4", platform: PlatformGrok, ok: true},
 		{name: "xai prefix", model: "xai/grok-4", platform: PlatformGrok, ok: true},
+		{name: "minimax", model: "MiniMax-M3", platform: PlatformOpenAI, ok: true},
+		{name: "glm", model: "glm-5", platform: PlatformOpenAI, ok: true},
+		{name: "deepseek", model: "deepseek-chat", platform: PlatformOpenAI, ok: true},
+		{name: "qwen", model: "qwen-max", platform: PlatformOpenAI, ok: true},
 		{name: "unknown", model: "llama-4-maverick", ok: false},
 	}
 

--- a/backend/internal/service/gateway_cloudwise_relay_test.go
+++ b/backend/internal/service/gateway_cloudwise_relay_test.go
@@ -91,3 +91,31 @@ func TestForwardAsAnthropic_CloudwiseNativeMessagesPassthrough(t *testing.T) {
 	require.Equal(t, "claude-sonnet-4-6", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.Contains(t, rec.Body.String(), "OK")
 }
+
+func TestForwardAsAnthropic_CloudwiseNonClaudeUsesChatFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"MiniMax-M3","max_tokens":8,"messages":[{"role":"user","content":"Reply OK only."}]}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"chatcmpl-test","object":"chat.completion","model":"MiniMax-M3","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":1,"total_tokens":8}}`,
+		)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, cloudwiseNativeMessagesAccount(), body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/chat/completions", upstream.lastReq.URL.String())
+	require.Equal(t, "MiniMax-M3", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Contains(t, rec.Body.String(), "OK")
+}

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -41,9 +41,14 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	// 入口分流：APIKey 账号 + 上游原生 /v1/messages → 直转；否则不支持
 	// Responses 时走 CC 回退。缺少 native 分流时会将 /v1/messages 错误地转为
 	// Responses 或 CC，浪费双栈中继的原生 Anthropic 能力。
+	// 双栈 relay 的非 claude-* 模型（如 MiniMax-M3）走 chat 回退，与 /v1/responses
+	// fallback 一致，避免 native passthrough 在选号/转发链路上的不一致。
 	if account.Type == AccountTypeAPIKey {
 		if openai_compat.ShouldUseNativeAnthropicMessagesAPI(account.Extra) {
-			return s.forwardAnthropicViaNativeMessages(ctx, c, account, body, defaultMappedModel)
+			if shouldForwardNativeAnthropicMessagesForModel(body) {
+				return s.forwardAnthropicViaNativeMessages(ctx, c, account, body, defaultMappedModel)
+			}
+			return s.forwardAnthropicViaRawChatCompletions(ctx, c, account, body, defaultMappedModel)
 		}
 		if !openai_compat.ShouldUseResponsesAPI(account.Extra) {
 			return s.forwardAnthropicViaRawChatCompletions(ctx, c, account, body, defaultMappedModel)

--- a/backend/internal/service/openai_gateway_messages_native.go
+++ b/backend/internal/service/openai_gateway_messages_native.go
@@ -17,6 +17,11 @@ import (
 	"go.uber.org/zap"
 )
 
+func shouldForwardNativeAnthropicMessagesForModel(body []byte) bool {
+	model := strings.TrimSpace(gjson.GetBytes(body, "model").String())
+	return tkIsForwardableAnthropicModelName(model)
+}
+
 // forwardAnthropicViaNativeMessages serves /v1/messages clients by passthrough
 // to an upstream that natively exposes Anthropic Messages (dual-stack OpenAI
 // relays such as agent.tokensea.ai).

--- a/backend/internal/service/upstream_billing_probe.go
+++ b/backend/internal/service/upstream_billing_probe.go
@@ -365,7 +365,7 @@ func (s *UpstreamBillingProbeService) RunDue(ctx context.Context) error {
 	due := make([]Account, 0, len(accounts))
 	for i := range accounts {
 		account := accounts[i]
-		if !isUpstreamBillingProbeAccount(&account) || !account.IsActive() || !upstreamBillingProbeEnabled(&account) {
+		if !isUpstreamBillingProbeAccount(&account) || !account.IsActive() || !upstreamBillingProbeEnabled(&account) || !upstreamBillingProbeSupportsSub2APIBilling(&account) {
 			continue
 		}
 		snapshot := decodeUpstreamBillingProbeSnapshot(account.Extra)
@@ -468,6 +468,9 @@ func (s *UpstreamBillingProbeService) probeAccountWithMode(ctx context.Context, 
 			return nil, loadErr
 		}
 		if !isUpstreamBillingProbeAccount(account) {
+			return nil, ErrUpstreamBillingProbeAccountInvalid
+		}
+		if !upstreamBillingProbeSupportsSub2APIBilling(account) {
 			return nil, ErrUpstreamBillingProbeAccountInvalid
 		}
 		if requireEnabled {
@@ -578,6 +581,9 @@ func (s *UpstreamBillingProbeService) SetAccountEnabled(ctx context.Context, acc
 	if !isUpstreamBillingProbeAccount(account) {
 		return ErrUpstreamBillingProbeAccountInvalid
 	}
+	if enabled && !upstreamBillingProbeSupportsSub2APIBilling(account) {
+		return ErrUpstreamBillingProbeAccountInvalid
+	}
 	updates := map[string]any{UpstreamBillingProbeEnabledExtraKey: enabled}
 	if !enabled {
 		updates[UpstreamBillingRateSyncEnabledExtraKey] = false
@@ -589,6 +595,9 @@ func (s *UpstreamBillingProbeService) probeLoadedAccount(ctx context.Context, ac
 	now := s.currentTime().UTC()
 	if s.accountTestService == nil || s.accountTestService.httpUpstream == nil {
 		return s.persistProbeFailure(ctx, account, intervalMinutes, now, 0, "transport_unavailable", 0)
+	}
+	if !upstreamBillingProbeSupportsSub2APIBilling(account) {
+		return s.persistProbeFailure(ctx, account, intervalMinutes, now, 0, "unsupported", 0)
 	}
 	// 平台放宽后取数直读 credentials：所有 API-key 平台的密钥与自定义上游
 	// 统一存放在 credentials.api_key / credentials.base_url。
@@ -987,6 +996,19 @@ func IsUpstreamBillingProbeIdentity(platform, accountType string) bool {
 
 func isUpstreamBillingProbeAccount(account *Account) bool {
 	return account != nil && IsUpstreamBillingProbeIdentity(account.Platform, account.Type)
+}
+
+// upstreamBillingProbeSupportsSub2APIBilling reports whether the account upstream
+// exposes TokenKey's /v1/sub2api/billing probe. MaaS dual-stack relays such as
+// CloudWise and tokensea do not implement that endpoint.
+func upstreamBillingProbeSupportsSub2APIBilling(account *Account) bool {
+	if account == nil {
+		return false
+	}
+	if account.IsOpenAICloudwiseRelay() || account.IsOpenAITokenseaRelay() {
+		return false
+	}
+	return true
 }
 
 // upstreamBillingProbeOfficialAPIDomains lists the root domains of official

--- a/backend/internal/service/upstream_billing_probe_multiplatform_test.go
+++ b/backend/internal/service/upstream_billing_probe_multiplatform_test.go
@@ -77,6 +77,48 @@ func TestUpstreamBillingProbeGrokAccountPersistsSnapshot(t *testing.T) {
 	require.Equal(t, UpstreamBillingProbeStatusOK, persisted.Status)
 }
 
+func TestUpstreamBillingProbeCloudwiseRelayManualProbeRejectsAccount(t *testing.T) {
+	account := &Account{
+		ID:       95,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"api_key":  "sk-cloudwise",
+			"base_url": "https://api.cloudwise.ai/api",
+		},
+		Extra: map[string]any{
+			"upstream_billing_probe_enabled": true,
+		},
+	}
+	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{account.ID: account}}
+	upstream := &httpUpstreamRecorder{}
+	svc := newUpstreamBillingProbeTestService(repo, upstream, &upstreamBillingProbeSettingRepo{})
+
+	snapshot, err := svc.ProbeAccount(context.Background(), account.ID)
+	require.ErrorIs(t, err, ErrUpstreamBillingProbeAccountInvalid)
+	require.Nil(t, snapshot)
+	require.Nil(t, upstream.lastReq)
+}
+
+func TestUpstreamBillingProbeCloudwiseRelaySetEnabledRejects(t *testing.T) {
+	account := &Account{
+		ID:       95,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"api_key":  "sk-cloudwise",
+			"base_url": "https://api.cloudwise.ai/api",
+		},
+	}
+	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{account.ID: account}}
+	svc := newUpstreamBillingProbeTestService(repo, &httpUpstreamRecorder{}, &upstreamBillingProbeSettingRepo{})
+
+	err := svc.SetAccountEnabled(context.Background(), account.ID, true)
+	require.ErrorIs(t, err, ErrUpstreamBillingProbeAccountInvalid)
+}
+
 // 非 OpenAI 平台没有自定义 base_url 时，上游是各自官方 API，必无
 // /v1/sub2api/billing：不发请求，直接落 unsupported。
 func TestUpstreamBillingProbeNonOpenAIWithoutBaseURLIsUnsupportedWithoutRequest(t *testing.T) {

--- a/backend/migrations/tk_079_cloudwise_ops_recovery.sql
+++ b/backend/migrations/tk_079_cloudwise_ops_recovery.sql
@@ -1,0 +1,23 @@
+-- CloudWise/tokensea MaaS relays do not expose /v1/sub2api/billing; disable probe
+-- noise. Repair active accounts left schedulable=false after 402 ClearError gaps.
+
+UPDATE accounts
+SET extra = (COALESCE(extra, '{}'::jsonb) - 'upstream_billing_probe')
+    || jsonb_build_object('upstream_billing_probe_enabled', false),
+    updated_at = NOW()
+WHERE deleted_at IS NULL
+  AND (
+    LOWER(TRIM(BOTH '/' FROM credentials->>'base_url')) IN (
+      'https://api.cloudwise.ai/api',
+      'https://api-us.cloudwise.ai/api',
+      'https://agent.tokensea.ai'
+    )
+  );
+
+UPDATE accounts
+SET schedulable = true,
+    updated_at = NOW()
+WHERE deleted_at IS NULL
+  AND status = 'active'
+  AND schedulable = false
+  AND COALESCE(error_message, '') = '';

--- a/backend/migrations/tk_079_cloudwise_ops_recovery.sql
+++ b/backend/migrations/tk_079_cloudwise_ops_recovery.sql
@@ -20,4 +20,9 @@ SET schedulable = true,
 WHERE deleted_at IS NULL
   AND status = 'active'
   AND schedulable = false
-  AND COALESCE(error_message, '') = '';
+  AND COALESCE(error_message, '') = ''
+  AND LOWER(TRIM(BOTH '/' FROM credentials->>'base_url')) IN (
+    'https://api.cloudwise.ai/api',
+    'https://api-us.cloudwise.ai/api',
+    'https://agent.tokensea.ai'
+  );

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "floor_sha256": "c19d41f7c37492be9806c596dea39b3f24f2c5e0285db2c0da4ea68b23abeb4d",
+  "floor_sha256": "4504c11c46eef69ecc38e2b30eb1e9d17cd8a1ffe8dd08e688d175b898b058d7",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -81,6 +81,9 @@
         "veo-3.1-generate-001": "veo-3.1-generate-001"
       },
       "grok": {
+        "claude-*": "grok-4.6",
+        "codex-*": "grok-4.6",
+        "gpt-*": "grok-4.6",
         "grok": "grok-4.6",
         "grok-4-fast-reasoning": "grok-4.3",
         "grok-4.20-0309-non-reasoning": "grok-4.20-0309-non-reasoning",
@@ -125,6 +128,9 @@
         "grok/grok-imagine-image-quality": "grok-imagine-image-quality",
         "grok/grok-imagine-video": "grok-imagine-video",
         "grok/grok-latest": "grok-4.3",
+        "o1*": "grok-4.6",
+        "o3*": "grok-4.6",
+        "o4*": "grok-4.6",
         "x-ai/grok": "grok-4.6",
         "x-ai/grok-4.20-0309-non-reasoning": "grok-4.20-0309-non-reasoning",
         "x-ai/grok-4.20-0309-reasoning": "grok-4.20-0309-reasoning",

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -250,7 +250,6 @@ SET
   model_routing = '{}'::jsonb,
   allow_messages_dispatch = true,
   supported_model_scopes = '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,
-  messages_dispatch_model_config = '{}'::jsonb,
   models_list_config = '{}'::jsonb,
   sort_order = 2147483000,
   rpm_limit = 0,

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1128,18 +1128,22 @@
         "Wei-Shaw/sub2api#1322",
         "\"response.cancelled\", \"response.canceled\"",
         "ShouldUseNativeAnthropicMessagesAPI",
-        "forwardAnthropicViaNativeMessages"
+        "shouldForwardNativeAnthropicMessagesForModel",
+        "forwardAnthropicViaNativeMessages",
+        "forwardAnthropicViaRawChatCompletions"
       ],
-      "rationale": "Non-stream /v1/messages uses the same buffered Responses SSE -> JSON conversion root cause as /v1/chat/completions; it must also override Content-Type after WriteFilteredHeaders so JSON bodies are not labeled text/event-stream. The buffered terminal reader must use openAICompatSSEFrameParser to recognise typed completion events when the stream closes without a standalone [DONE] (upstream PR #2530). isOpenAICompatResponsesTerminalEvent — used by both the Messages and Chat Completions streaming handlers — must keep response.cancelled / response.canceled in its terminal set so legitimate upstream cancellations close the stream cleanly instead of degenerating to 'stream usage incomplete: missing terminal event' (upstream #1322). OpenAI APIKey dual-stack relays (tokensea) must branch to native /v1/messages passthrough when extra.openai_native_messages_supported is true; dropping the hook silently routes /v1/messages through Responses/CC conversion and breaks Anthropic clients on agent.tokensea.ai."
+      "rationale": "Non-stream /v1/messages uses the same buffered Responses SSE -> JSON conversion root cause as /v1/chat/completions; it must also override Content-Type after WriteFilteredHeaders so JSON bodies are not labeled text/event-stream. The buffered terminal reader must use openAICompatSSEFrameParser to recognise typed completion events when the stream closes without a standalone [DONE] (upstream PR #2530). isOpenAICompatResponsesTerminalEvent — used by both the Messages and Chat Completions streaming handlers — must keep response.cancelled / response.canceled in its terminal set so legitimate upstream cancellations close the stream cleanly instead of degenerating to 'stream usage incomplete: missing terminal event' (upstream #1322). OpenAI APIKey dual-stack relays (tokensea/cloudwise) branch to native /v1/messages passthrough only for claude-* models when extra.openai_native_messages_supported is true; non-Claude models (MiniMax-M3, glm-5) must fall back to raw chat completions like /v1/responses."
     },
     {
       "path": "backend/internal/service/openai_gateway_messages_native.go",
       "must_contain": [
         "func (s *OpenAIGatewayService) forwardAnthropicViaNativeMessages(",
         "nativeAnthropicMessagesTargetURL",
-        "nativeOpenAIApiKeyForAccount"
+        "nativeOpenAIApiKeyForAccount",
+        "shouldForwardNativeAnthropicMessagesForModel",
+        "tkIsForwardableAnthropicModelName"
       ],
-      "rationale": "Native Anthropic Messages passthrough for OpenAI-platform dual-stack relays (agent.tokensea.ai). Must forward /v1/messages directly with API key Bearer auth and wire model mapping instead of converting through Responses or CC bridges."
+      "rationale": "Native Anthropic Messages passthrough for OpenAI-platform dual-stack relays (agent.tokensea.ai, cloudwise). Must forward claude-* /v1/messages directly with API key Bearer auth; non-Claude models stay on chat fallback."
     },
     {
       "path": "backend/internal/service/gateway_cloudwise_relay_test.go",
@@ -1147,9 +1151,11 @@
         "TestAccount_IsOpenAICloudwiseRelay",
         "TestOpenAICloudwiseRelayFloorIsProbeCuratedOnly",
         "TestForwardAsAnthropic_CloudwiseNativeMessagesPassthrough",
-        "https://api.cloudwise.ai/api/v1/messages"
+        "TestForwardAsAnthropic_CloudwiseNonClaudeUsesChatFallback",
+        "https://api.cloudwise.ai/api/v1/messages",
+        "https://api.cloudwise.ai/api/v1/chat/completions"
       ],
-      "rationale": "Focused regressions for CloudWise MaaS relay (prod account #95): probe-curated model_mapping floor and native /v1/messages passthrough for CC clients."
+      "rationale": "Focused regressions for CloudWise MaaS relay (prod account #95): probe-curated model_mapping floor, native /v1/messages passthrough for claude-*, and chat fallback for MiniMax-M3."
     },
     {
       "path": "backend/internal/service/gateway_tokensea_anthropic_relay_test.go",
@@ -6304,6 +6310,23 @@
         "s.syncSystemLogSinkEnabled()"
       ],
       "rationale": "Runtime monitoring settings must drive the already-running system-log sink without a poller or restart. The sync helper and call sites keep initialization, refresh, and admin setting changes on the same gate; losing this seam leaves static startup state diverged from the runtime control plane."
+    },
+    {
+      "path": "backend/internal/service/upstream_billing_probe.go",
+      "must_contain": [
+        "upstreamBillingProbeSupportsSub2APIBilling",
+        "IsOpenAICloudwiseRelay()",
+        "IsOpenAITokenseaRelay()"
+      ],
+      "rationale": "MaaS dual-stack relays (CloudWise, tokensea) do not expose /v1/sub2api/billing. Runner, manual probe, and admin enable paths must skip/reject them so prod accounts stop accumulating failed probe snapshots."
+    },
+    {
+      "path": "backend/internal/service/upstream_billing_probe_multiplatform_test.go",
+      "must_contain": [
+        "TestUpstreamBillingProbeCloudwiseRelayManualProbeRejectsAccount",
+        "TestUpstreamBillingProbeCloudwiseRelaySetEnabledRejects"
+      ],
+      "rationale": "Regression: CloudWise relay accounts must not probe or enable upstream billing probe."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- enable Grok default runtime model mapping from process init so empty-mapping accounts support cross-client routing before settings parse
- add family-specific Claude wildcard targets for Grok messages dispatch while preserving generic fallback mapping
- keep reused probe groups from clearing existing messages dispatch config
- regenerate ops/pricing/model-surface-bundle.json from the Go owner

## Live verification
- edge-us4 account 6 served claude-opus-4-8 via grok-4.6
- edge-us4 account 6 served claude-sonnet-4-6 via grok-4.5
- edge-us4 account 6 served claude-haiku-4-5 via grok-code-fast-1

## Tests
- go test -tags=unit ./internal/pkg/xai ./internal/service
- ./scripts/preflight.sh
- make test

ai