### PR TITLE
fix(gateway): preserve Grok messages dispatch defaults

### DIFF
--- a/backend/internal/pkg/xai/models.go
+++ b/backend/internal/pkg/xai/models.go
@@ -11,8 +11,15 @@ var runtimeMappingOpts atomic.Value // ModelMappingOptions
 var runtimeMappingVersion atomic.Uint64
 
 func init() {
-	runtimeMappingOpts.Store(ModelMappingOptions{})
+	runtimeMappingOpts.Store(defaultRuntimeModelMappingOptions())
 	runtimeMappingVersion.Store(1)
+}
+
+func defaultRuntimeModelMappingOptions() ModelMappingOptions {
+	return ModelMappingOptions{
+		DefaultText:          DefaultTextModel,
+		EnableCrossClientMap: true,
+	}
 }
 
 // SetRuntimeModelMappingOptions updates process-wide defaults used by

--- a/backend/internal/pkg/xai/models_test.go
+++ b/backend/internal/pkg/xai/models_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDefaultModelMappingExcludesCrossClientWildcards(t *testing.T) {
+func TestDefaultModelMappingExcludesCrossClientWildcardsWhenDisabled(t *testing.T) {
 	original := RuntimeModelMappingOptions()
 	t.Cleanup(func() { SetRuntimeModelMappingOptions(original) })
-	SetRuntimeModelMappingOptions(ModelMappingOptions{})
+	SetRuntimeModelMappingOptions(ModelMappingOptions{EnableCrossClientMap: false})
 	mapping := DefaultModelMapping()
 
 	require.Equal(t, DefaultTextModel, mapping["grok"])
@@ -26,6 +26,13 @@ func TestDefaultModelMappingExcludesCrossClientWildcards(t *testing.T) {
 	_, hasClaude := mapping["claude-*"]
 	require.False(t, hasGPT)
 	require.False(t, hasClaude)
+}
+
+func TestDefaultRuntimeModelMappingOptionsEnableCrossClient(t *testing.T) {
+	t.Parallel()
+	opts := defaultRuntimeModelMappingOptions()
+	require.Equal(t, DefaultTextModel, opts.DefaultText)
+	require.True(t, opts.EnableCrossClientMap)
 }
 
 func TestModelMappingWithOptionsCrossClient(t *testing.T) {

--- a/backend/internal/pkg/xai/oauth_test.go
+++ b/backend/internal/pkg/xai/oauth_test.go
@@ -348,7 +348,7 @@ func TestRuntimeSanityReportsInvalidOverridesWithoutSecrets(t *testing.T) {
 func TestDefaultModelMappingIncludesGrokAliases(t *testing.T) {
 	original := RuntimeModelMappingOptions()
 	t.Cleanup(func() { SetRuntimeModelMappingOptions(original) })
-	SetRuntimeModelMappingOptions(ModelMappingOptions{})
+	SetRuntimeModelMappingOptions(ModelMappingOptions{EnableCrossClientMap: false})
 	mapping := DefaultModelMapping()
 	require.Equal(t, DefaultTextModel, mapping["grok"])
 	require.Equal(t, "grok-4.3", mapping["grok-latest"])

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -590,6 +590,17 @@ func (a *Account) GetModelMapping() map[string]string {
 	return mapping
 }
 
+func defaultGrokAccountModelMapping() map[string]string {
+	mapping := xai.DefaultModelMapping()
+	if !xai.RuntimeModelMappingOptions().EnableCrossClientMap {
+		return mapping
+	}
+	mapping["claude-opus-*"] = defaultMessagesDispatchMappedModelForPlatform(PlatformGrok, "opus")
+	mapping["claude-sonnet-*"] = defaultMessagesDispatchMappedModelForPlatform(PlatformGrok, "sonnet")
+	mapping["claude-haiku-*"] = defaultMessagesDispatchMappedModelForPlatform(PlatformGrok, "haiku")
+	return mapping
+}
+
 func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]string {
 	if a.Credentials == nil {
 		// Antigravity 平台使用默认映射
@@ -597,7 +608,7 @@ func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]stri
 			return domain.DefaultAntigravityModelMapping
 		}
 		if a.Platform == domain.PlatformGrok {
-			return xai.DefaultModelMapping()
+			return defaultGrokAccountModelMapping()
 		}
 		// Bedrock 默认映射由 forwardBedrock 统一处理（需配合 region prefix 调整）
 		return nil
@@ -608,7 +619,7 @@ func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]stri
 			return domain.DefaultAntigravityModelMapping
 		}
 		if a.Platform == domain.PlatformGrok {
-			return xai.DefaultModelMapping()
+			return defaultGrokAccountModelMapping()
 		}
 		return nil
 	}

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -14,14 +14,17 @@ func TestGrokAccountModelMappingCacheInvalidatesWithRuntimeSettings(t *testing.T
 	t.Cleanup(func() { xai.SetRuntimeModelMappingOptions(original) })
 	account := &Account{Platform: PlatformGrok, Credentials: map[string]any{}}
 
-	xai.SetRuntimeModelMappingOptions(xai.ModelMappingOptions{})
+	xai.SetRuntimeModelMappingOptions(xai.ModelMappingOptions{EnableCrossClientMap: false})
 	requireMappedModel(t, account, "claude-sonnet-4-5", "claude-sonnet-4-5")
 
 	xai.SetRuntimeModelMappingOptions(xai.ModelMappingOptions{
 		DefaultText:          "grok-build-0.1",
 		EnableCrossClientMap: true,
 	})
-	requireMappedModel(t, account, "claude-sonnet-4-5", "grok-build-0.1")
+	requireMappedModel(t, account, "claude-opus-4-8", "grok-4.6")
+	requireMappedModel(t, account, "claude-sonnet-4-6", "grok-4.5")
+	requireMappedModel(t, account, "claude-haiku-4-5", "grok-code-fast-1")
+	requireMappedModel(t, account, "claude-fable-5", "grok-build-0.1")
 }
 
 func requireMappedModel(t *testing.T, account *Account, requested, expected string) {

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -21,9 +21,17 @@ func TestGrokAccountModelMappingCacheInvalidatesWithRuntimeSettings(t *testing.T
 		DefaultText:          "grok-build-0.1",
 		EnableCrossClientMap: true,
 	})
-	requireMappedModel(t, account, "claude-opus-4-8", "grok-4.6")
-	requireMappedModel(t, account, "claude-sonnet-4-6", "grok-4.5")
-	requireMappedModel(t, account, "claude-haiku-4-5", "grok-code-fast-1")
+	claudeFamilyModels := map[string]string{
+		"claude-opus-4-8":   defaultMessagesDispatchMappedModelForPlatform(PlatformGrok, "opus"),
+		"claude-sonnet-4-6": defaultMessagesDispatchMappedModelForPlatform(PlatformGrok, "sonnet"),
+		"claude-haiku-4-5":  defaultMessagesDispatchMappedModelForPlatform(PlatformGrok, "haiku"),
+	}
+	for requested, expected := range claudeFamilyModels {
+		requireMappedModel(t, account, requested, expected)
+		if !account.IsModelSupported(requested) {
+			t.Fatalf("IsModelSupported(%q) = false, want true", requested)
+		}
+	}
 	requireMappedModel(t, account, "claude-fable-5", "grok-build-0.1")
 }
 

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "floor_sha256": "c19d41f7c37492be9806c596dea39b3f24f2c5e0285db2c0da4ea68b23abeb4d",
+  "floor_sha256": "4504c11c46eef69ecc38e2b30eb1e9d17cd8a1ffe8dd08e688d175b898b058d7",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -81,6 +81,9 @@
         "veo-3.1-generate-001": "veo-3.1-generate-001"
       },
       "grok": {
+        "claude-*": "grok-4.6",
+        "codex-*": "grok-4.6",
+        "gpt-*": "grok-4.6",
         "grok": "grok-4.6",
         "grok-4-fast-reasoning": "grok-4.3",
         "grok-4.20-0309-non-reasoning": "grok-4.20-0309-non-reasoning",
@@ -125,6 +128,9 @@
         "grok/grok-imagine-image-quality": "grok-imagine-image-quality",
         "grok/grok-imagine-video": "grok-imagine-video",
         "grok/grok-latest": "grok-4.3",
+        "o1*": "grok-4.6",
+        "o3*": "grok-4.6",
+        "o4*": "grok-4.6",
         "x-ai/grok": "grok-4.6",
         "x-ai/grok-4.20-0309-non-reasoning": "grok-4.20-0309-non-reasoning",
         "x-ai/grok-4.20-0309-reasoning": "grok-4.20-0309-reasoning",

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -250,7 +250,6 @@ SET
   model_routing = '{}'::jsonb,
   allow_messages_dispatch = true,
   supported_model_scopes = '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,
-  messages_dispatch_model_config = '{}'::jsonb,
   models_list_config = '{}'::jsonb,
   sort_order = 2147483000,
   rpm_limit = 0,


### PR DESCRIPTION
## Summary
- enable Grok default runtime model mapping from process init so empty-mapping accounts support cross-client routing before settings parse
- add family-specific Claude wildcard targets for Grok messages dispatch while preserving generic fallback mapping
- keep reused probe groups from clearing existing messages dispatch config
- regenerate ops/pricing/model-surface-bundle.json from the Go owner

## Live verification
- edge-us4 account 6 served claude-opus-4-8 via grok-4.6
- edge-us4 account 6 served claude-sonnet-4-6 via grok-4.5
- edge-us4 account 6 served claude-haiku-4-5 via grok-code-fast-1

## Tests
- go test -tags=unit ./internal/pkg/xai ./internal/service
- ./scripts/preflight.sh
- make test

ai

## Gate acknowledgements
- no-web-impact: backend/ops-only Grok default mapping and probe-script behavior; no frontend, config schema, public API contract, or Web surface changes.
- sentinel-registry-reviewed: account.go is already covered by the Grok/gateway sentinel registries, and this PR only adjusts the existing Grok default mapping surface plus its focused regression test.



<!-- required-check-refresh: marker payload includes sentinel-registry-reviewed and no-web-impact -->
