### PR TITLE
fix(cloudwise): count_tokens 401 不再误杀 MaaS relay 账号

### DIFF
--- a/backend/internal/service/openai_gateway_count_tokens_fallback.go
+++ b/backend/internal/service/openai_gateway_count_tokens_fallback.go
@@ -54,7 +54,21 @@ func classifyOpenAIInputTokensFallback(account *Account, statusCode int, body []
 	if isOpenAICompatInputTokensCapabilityGap(account, statusCode, upstreamMsg, body) {
 		return openAIInputTokensFallbackDecision{Kind: openAIInputTokensFallbackAnthropicEstimate, UpstreamMessage: upstreamMsg}
 	}
+	if isMaaSRelayInputTokensAuthGap(account, statusCode) {
+		return openAIInputTokensFallbackDecision{Kind: openAIInputTokensFallbackAnthropicEstimate, UpstreamMessage: upstreamMsg}
+	}
 	return openAIInputTokensFallbackDecision{Kind: openAIInputTokensFallbackNone, UpstreamMessage: upstreamMsg}
+}
+
+// isMaaSRelayInputTokensAuthGap reports CloudWise/tokensea dual-stack relays that
+// reject OpenAI /v1/responses/input_tokens with 401 even while chat/messages
+// remain healthy. count_tokens must local-estimate instead of permanently
+// disabling the apikey account (prod #95 incident 2026-08-13).
+func isMaaSRelayInputTokensAuthGap(account *Account, statusCode int) bool {
+	if account == nil || account.Type != AccountTypeAPIKey || statusCode != http.StatusUnauthorized {
+		return false
+	}
+	return account.IsOpenAICloudwiseRelay() || account.IsOpenAITokenseaRelay()
 }
 
 func isOpenAIInputTokensUnsupported(statusCode int, body []byte) bool {

--- a/backend/internal/service/openai_gateway_count_tokens_fallback_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_fallback_test.go
@@ -88,6 +88,39 @@ func TestClassifyOpenAIInputTokensFallback(t *testing.T) {
 			body:       `{"error":{"code":"InvalidAction","message":"The specified action is invalid: /api/v3/models","type":"NotFound"}}`,
 			want:       openAIInputTokensFallbackNone,
 		},
+		{
+			name: "cloudwise_relay_401_uses_anthropic_estimate",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformOpenAI,
+				Credentials: map[string]any{"base_url": "https://api.cloudwise.ai/api"},
+			},
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":{"message":"invalid or expired credentials"}}`,
+			want:       openAIInputTokensFallbackAnthropicEstimate,
+		},
+		{
+			name: "tokensea_relay_401_uses_anthropic_estimate",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformOpenAI,
+				Credentials: map[string]any{"base_url": "https://agent.tokensea.ai"},
+			},
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":{"message":"invalid authorization"}}`,
+			want:       openAIInputTokensFallbackAnthropicEstimate,
+		},
+		{
+			name: "plain_openai_apikey_401_stays_upstream_error",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformOpenAI,
+				Credentials: map[string]any{"base_url": "https://api.openai.com/v1"},
+			},
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":{"message":"invalid api key"}}`,
+			want:       openAIInputTokensFallbackNone,
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
## 摘要

- prod #95 于 2026-08-13 14:39 因 `POST /v1/messages/count_tokens`（model=gpt-5.5）上游 `/v1/responses/input_tokens` 返回 401 被永久标 `auth_error`；直连 CloudWise 探针证实 chat/messages 凭证仍有效
- CloudWise/tokensea MaaS relay 的 count_tokens 401 改走本地 token 估算，不再调用 `HandleUpstreamError` 永久禁用账号

upstream-touch-trivial

## 风险

- 常规风险：仅影响 OpenAI count_tokens 桥接对 CloudWise/tokensea 的 401 处理；plain OpenAI apikey 401 行为不变
- 无 Web/API 契约变更（`Web impact: none`）

## 验证

- `go test -tags=unit ./internal/service -run TestClassifyOpenAIInputTokensFallback`
- prod 运维复验：clear-error + schedulable 后 #95 messages 探针 servable（发版前已手动恢复）

## 提交

- 9fa016f04 fix(cloudwise): count_tokens 401 不再误杀 MaaS relay 账号

最新提交：9fa016f04

Made with [Cursor](https://cursor.com)