### PR TITLE
fix(cloudwise): 从 MaaS relay 账号移除 GPT 系列 model_mapping

### DIFF
--- a/backend/internal/service/gateway_cloudwise_relay_test.go
+++ b/backend/internal/service/gateway_cloudwise_relay_test.go
@@ -62,6 +62,9 @@ func TestAccount_IsOpenAICloudwiseRelay(t *testing.T) {
 func TestOpenAICloudwiseRelayFloorIsProbeCuratedOnly(t *testing.T) {
 	mapping := openAICloudwiseRelayAccountModelMappingFloor(context.Background(), nil, nil)
 	requireIdentityMappingForIDs(t, mapping, supportedCatalogModelIDsFromMap(supportedOpenAICloudwiseRelayCatalogModels))
+	for id := range supportedOpenAICloudwiseRelayCatalogModels {
+		require.False(t, strings.HasPrefix(id, "gpt-"), "cloudwise relay catalog must not list GPT ids: %s", id)
+	}
 }
 
 func TestForwardAsAnthropic_CloudwiseNativeMessagesPassthrough(t *testing.T) {

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -214,9 +214,6 @@ var supportedOpenAICloudwiseRelayCatalogModels = map[string]struct{}{
 	"glm-5":                            {},
 	"glm-5.1":                          {},
 	"glm-5.2":                          {},
-	"gpt-5.2":                          {},
-	"gpt-5.3-codex":                    {},
-	"gpt-5.4":                          {},
 	"kimi-k3":                          {},
 }
 

--- a/backend/migrations/tk_080_cloudwise_prune_gpt_model_mapping.sql
+++ b/backend/migrations/tk_080_cloudwise_prune_gpt_model_mapping.sql
@@ -1,0 +1,51 @@
+-- TokenKey: drop GPT-series ids from CloudWise relay account model_mapping floors.
+--
+-- CloudWise MaaS relays expose Claude/Gemini/DeepSeek/GLM/etc. via dual-stack
+-- chat + native messages, but GPT ids are not a supported routing surface for
+-- these accounts (count_tokens/input_tokens gaps caused prod #95 auth_error).
+-- Runtime SSOT (supportedOpenAICloudwiseRelayCatalogModels) no longer lists
+-- gpt-*; this migration prunes any persisted gpt-* whitelist keys.
+--
+-- Idempotent: re-running is a no-op when no gpt-* keys remain.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH cloudwise AS (
+    SELECT
+        a.id,
+        a.credentials,
+        COALESCE(
+            (
+                SELECT jsonb_object_agg(e.key, e.value)
+                FROM jsonb_each(a.credentials -> 'model_mapping') AS e(key, value)
+                WHERE e.key NOT LIKE 'gpt-%'
+            ),
+            '{}'::jsonb
+        ) AS new_mapping
+    FROM accounts AS a
+    WHERE a.deleted_at IS NULL
+      AND a.platform = 'openai'
+      AND a.type = 'apikey'
+      AND LOWER(TRIM(BOTH '/' FROM a.credentials->>'base_url')) IN (
+          'https://api.cloudwise.ai/api',
+          'https://api-us.cloudwise.ai/api'
+      )
+      AND jsonb_typeof(a.credentials -> 'model_mapping') = 'object'
+      AND EXISTS (
+          SELECT 1
+          FROM jsonb_object_keys(a.credentials -> 'model_mapping') AS k(key)
+          WHERE k.key LIKE 'gpt-%'
+      )
+),
+upd AS (
+    UPDATE accounts AS a
+    SET credentials = jsonb_set(a.credentials, '{model_mapping}', c.new_mapping, true),
+        updated_at = NOW()
+    FROM cloudwise AS c
+    WHERE a.id = c.id
+      AND a.credentials -> 'model_mapping' IS DISTINCT FROM c.new_mapping
+    RETURNING a.id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "floor_sha256": "c19d41f7c37492be9806c596dea39b3f24f2c5e0285db2c0da4ea68b23abeb4d",
+  "floor_sha256": "9927f7610927cc74bd9f3be0f98213dd0095b07a8c4559a6ba507d76662137f6",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -218,9 +218,6 @@
         "glm-5": "glm-5",
         "glm-5.1": "glm-5.1",
         "glm-5.2": "glm-5.2",
-        "gpt-5.2": "gpt-5.2",
-        "gpt-5.3-codex": "gpt-5.3-codex",
-        "gpt-5.4": "gpt-5.4",
         "kimi-k3": "kimi-k3"
       },
       "openai_tokensea_relay": {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1150,6 +1150,7 @@
       "must_contain": [
         "TestAccount_IsOpenAICloudwiseRelay",
         "TestOpenAICloudwiseRelayFloorIsProbeCuratedOnly",
+        "cloudwise relay catalog must not list GPT ids",
         "TestForwardAsAnthropic_CloudwiseNativeMessagesPassthrough",
         "TestForwardAsAnthropic_CloudwiseNonClaudeUsesChatFallback",
         "https://api.cloudwise.ai/api/v1/messages",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -84,6 +84,7 @@
         "func supportedCatalogModelIDsForPlatform(",
         "supportedAnthropicCatalogModels",
         "supportedOpenAICatalogModels",
+        "supportedOpenAICloudwiseRelayCatalogModels",
         "supportedGeminiCatalogModels",
         "supportedAntigravityCatalogModels",
         "supportedGrokCatalogModels",


### PR DESCRIPTION
## 摘要

- 从 `supportedOpenAICloudwiseRelayCatalogModels` SSOT 移除全部 GPT 系列（含 gpt-5.2/5.3-codex/5.4 及 gpt-5.5/gpt-5.6-*）
- 同步重生成 `ops/pricing/model-surface-bundle.json`（已 merge main 解决冲突）
- 新增 migration `tk_080`：prod CloudWise relay 账号 `credentials.model_mapping` 中所有 `gpt-*` 键一次性剔除
- sentinel：锚定 CloudWise catalog SSOT 与 no-GPT 回归断言

## 风险

- 常规风险：仅影响 CloudWise MaaS relay 的 GPT 路由面；Claude/Gemini/DeepSeek/GLM 等不变
- migration 为可逆 JSONB 键删除（非 schema 变更）
- 无 Web/API 契约变更（`Web impact: none`）

## 验证

- `go test -tags=unit ./internal/service -run Cloudwise`
- `python3 ops/pricing/model_surface_bundle.py --check ops/pricing/model-surface-bundle.json`
- `./scripts/preflight.sh` PASS

## 提交

- ccacf3c96 fix(cloudwise): 从 MaaS relay 账号移除 GPT 系列 model_mapping
- 8f7640b14 fix(cloudwise): address review — sentinel anchors and high-risk anchor
- 2df48ed66 merge(main): resolve model-surface-bundle conflict and clarify GPT exclusion

最新提交：2df48ed66