### PR TITLE
fix(cloudwise): 前缀 wildcard SSOT 收敛 MaaS relay 可服务模型族

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -804,12 +804,12 @@ func (a *Account) ResolveMappedModel(requestedModel string) (mappedModel string,
 		return requestedModel, false
 	}
 	if mappedModel, matched := resolveRequestedModelInMapping(mapping, requestedModel); matched {
-		return mappedModel, true
+		return applyOpenAICloudwiseRelayUpstreamModelID(a, mappedModel), true
 	}
 	normalized := normalizeRequestedModelForLookup(a.Platform, requestedModel)
 	if normalized != requestedModel {
 		if mappedModel, matched := resolveRequestedModelInMapping(mapping, normalized); matched {
-			return mappedModel, true
+			return applyOpenAICloudwiseRelayUpstreamModelID(a, mappedModel), true
 		}
 	}
 	return requestedModel, false

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -733,7 +733,7 @@ func resolveRequestedModelInMapping(mapping map[string]string, requestedModel st
 		return mappedModel, true
 	}
 	if lookupKey != "" && lookupKey != requestedModel {
-		if mappedModel, matched := matchNormalizedWildcardMappingResult(mapping, lookupKey); matched {
+		if mappedModel, matched := matchNormalizedWildcardMappingResult(mapping, lookupKey, requestedModel); matched {
 			return mappedModel, true
 		}
 	}
@@ -751,30 +751,6 @@ func sortedModelMappingKeys(mapping map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
-}
-
-func matchNormalizedWildcardMappingResult(mapping map[string]string, requestedModel string) (string, bool) {
-	type patternMatch struct {
-		pattern string
-		target  string
-	}
-	var matches []patternMatch
-	for pattern, target := range mapping {
-		normalizedPattern := normalizeModelMappingLookupKey(pattern)
-		if matchWildcard(normalizedPattern, requestedModel) {
-			matches = append(matches, patternMatch{pattern: pattern, target: target})
-		}
-	}
-	if len(matches) == 0 {
-		return requestedModel, false
-	}
-	sort.Slice(matches, func(i, j int) bool {
-		if len(matches[i].pattern) != len(matches[j].pattern) {
-			return len(matches[i].pattern) > len(matches[j].pattern)
-		}
-		return matches[i].pattern < matches[j].pattern
-	})
-	return matches[0].target, true
 }
 
 // IsModelSupported 检查模型是否在 model_mapping 中（支持通配符）
@@ -996,35 +972,6 @@ func matchAntigravityWildcard(pattern, str string) bool {
 // 复用 Antigravity 的通配符逻辑，供其他平台使用
 func matchWildcard(pattern, str string) bool {
 	return matchAntigravityWildcard(pattern, str)
-}
-
-func matchWildcardMappingResult(mapping map[string]string, requestedModel string) (string, bool) {
-	// 收集所有匹配的 pattern，按长度降序排序（最长优先）
-	type patternMatch struct {
-		pattern string
-		target  string
-	}
-	var matches []patternMatch
-
-	for pattern, target := range mapping {
-		if matchWildcard(pattern, requestedModel) {
-			matches = append(matches, patternMatch{pattern, target})
-		}
-	}
-
-	if len(matches) == 0 {
-		return requestedModel, false // 无匹配，返回原始模型名
-	}
-
-	// 按 pattern 长度降序排序
-	sort.Slice(matches, func(i, j int) bool {
-		if len(matches[i].pattern) != len(matches[j].pattern) {
-			return len(matches[i].pattern) > len(matches[j].pattern)
-		}
-		return matches[i].pattern < matches[j].pattern
-	})
-
-	return matches[0].target, true
 }
 
 func (a *Account) IsCustomErrorCodesEnabled() bool {

--- a/backend/internal/service/account_model_mapping_ssot_tk.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk.go
@@ -416,11 +416,10 @@ func openAITokenseaRelayAccountModelMappingFloor(ctx context.Context, pricing *P
 }
 
 func openAICloudwiseRelayAccountModelMappingFloor(ctx context.Context, pricing *PricingCatalogService, availability MePricingAvailability) map[string]string {
-	ids := supportedCatalogModelIDsFromMap(supportedOpenAICloudwiseRelayCatalogModels)
-	if len(ids) == 0 {
-		return nil
-	}
-	return identityModelMapping(ids)
+	_ = ctx
+	_ = pricing
+	_ = availability
+	return cloneStringMap(openAICloudwiseRelayWildcardModelMappingFloor())
 }
 
 func anthropicTokenseaRelayModelMappingFloor() map[string]string {

--- a/backend/internal/service/account_model_mapping_ssot_tk_test.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk_test.go
@@ -139,7 +139,7 @@ func TestAccountModelMappingFloorForOps_ExportsAinzyRelayScope(t *testing.T) {
 	requireIdentityMappingForIDs(t, tokensea, supportedCatalogModelIDsFromMap(supportedOpenAITokenseaRelayCatalogModels))
 	cloudwise, ok := doc.Platforms[accountModelMappingPlatformOpenAICloudwiseRelay]
 	require.True(t, ok)
-	requireIdentityMappingForIDs(t, cloudwise, supportedCatalogModelIDsFromMap(supportedOpenAICloudwiseRelayCatalogModels))
+	require.Equal(t, openAICloudwiseRelayWildcardModelMappingFloor(), cloudwise)
 	anthropicTokensea, ok := doc.Platforms[accountModelMappingPlatformAnthropicTokenseaRelay]
 	require.True(t, ok)
 	require.Equal(t, anthropicTokenseaRelayModelMappingFloor(), anthropicTokensea)

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -123,6 +123,17 @@ func TestMatchWildcardMappingResult(t *testing.T) {
 			matched:        true,
 		},
 
+		// identity wildcard passthrough (CloudWise prefix floor)
+		{
+			name: "identity wildcard passthrough",
+			mapping: map[string]string{
+				"claude-*": "claude-*",
+			},
+			requestedModel: "claude-sonnet-4-6",
+			expected:       "claude-sonnet-4-6",
+			matched:        true,
+		},
+
 		// 无匹配返回原始模型
 		{
 			name: "no match returns original",

--- a/backend/internal/service/account_wildcard_tk.go
+++ b/backend/internal/service/account_wildcard_tk.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"sort"
+	"strings"
+)
+
+// resolveWildcardMappingTarget returns the upstream model id for a wildcard rule.
+// Identity rules (pattern == target, or target is a matching wildcard) preserve
+// the client's requested spelling — needed for CloudWise floors like "minimax-*".
+func resolveWildcardMappingTarget(pattern, target, requestedModel string) string {
+	if target == pattern {
+		return requestedModel
+	}
+	if strings.HasSuffix(target, "*") && matchWildcard(target, requestedModel) {
+		return requestedModel
+	}
+	return target
+}
+
+func matchWildcardMappingResult(mapping map[string]string, requestedModel string) (string, bool) {
+	type patternMatch struct {
+		pattern string
+		target  string
+	}
+	var matches []patternMatch
+
+	for pattern, target := range mapping {
+		if matchWildcard(pattern, requestedModel) {
+			matches = append(matches, patternMatch{pattern, target})
+		}
+	}
+
+	if len(matches) == 0 {
+		return requestedModel, false
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		if len(matches[i].pattern) != len(matches[j].pattern) {
+			return len(matches[i].pattern) > len(matches[j].pattern)
+		}
+		return matches[i].pattern < matches[j].pattern
+	})
+
+	return resolveWildcardMappingTarget(matches[0].pattern, matches[0].target, requestedModel), true
+}
+
+func matchNormalizedWildcardMappingResult(mapping map[string]string, lookupKey, originalRequestedModel string) (string, bool) {
+	type patternMatch struct {
+		pattern string
+		target  string
+	}
+	var matches []patternMatch
+	for pattern, target := range mapping {
+		normalizedPattern := normalizeModelMappingLookupKey(pattern)
+		if matchWildcard(normalizedPattern, lookupKey) {
+			matches = append(matches, patternMatch{pattern: pattern, target: target})
+		}
+	}
+	if len(matches) == 0 {
+		return originalRequestedModel, false
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		if len(matches[i].pattern) != len(matches[j].pattern) {
+			return len(matches[i].pattern) > len(matches[j].pattern)
+		}
+		return matches[i].pattern < matches[j].pattern
+	})
+	return resolveWildcardMappingTarget(matches[0].pattern, matches[0].target, originalRequestedModel), true
+}

--- a/backend/internal/service/gateway_cloudwise_relay_test.go
+++ b/backend/internal/service/gateway_cloudwise_relay_test.go
@@ -59,14 +59,11 @@ func TestAccount_IsOpenAICloudwiseRelay(t *testing.T) {
 	require.False(t, other.IsOpenAICloudwiseRelay())
 }
 
-func TestOpenAICloudwiseRelayFloorIsProbeCuratedOnly(t *testing.T) {
+func TestOpenAICloudwiseRelayFloorUsesPrefixWildcards(t *testing.T) {
 	mapping := openAICloudwiseRelayAccountModelMappingFloor(context.Background(), nil, nil)
-	requireIdentityMappingForIDs(t, mapping, supportedCatalogModelIDsFromMap(supportedOpenAICloudwiseRelayCatalogModels))
-	for id := range supportedOpenAICloudwiseRelayCatalogModels {
-		require.False(t, strings.HasPrefix(id, "gpt-"), "cloudwise relay catalog must not list GPT ids: %s", id)
-	}
-	for _, excluded := range []string{"gpt-5.5", "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
-		require.NotContains(t, mapping, excluded, "cloudwise relay must not expose %s", excluded)
+	require.Equal(t, openAICloudwiseRelayWildcardModelMappingFloor(), mapping)
+	for _, excluded := range []string{"gpt-5.5", "gpt-5.6", "gemini-3-flash-preview"} {
+		require.NotContains(t, mapping, excluded)
 	}
 }
 

--- a/backend/internal/service/openai_cloudwise_relay_tk.go
+++ b/backend/internal/service/openai_cloudwise_relay_tk.go
@@ -24,3 +24,29 @@ func openAICloudwiseRelayWildcardModelMappingFloor() map[string]string {
 	}
 	return out
 }
+
+// openAICloudwiseRelayUpstreamModelID rewrites client model spellings to the exact
+// wire ids CloudWise upstream accepts. Prod account #95 probe (2026-08-13):
+// GET /v1/models lists MiniMax-M3; only that mixed-case id returns 200 on
+// /v1/chat/completions — lowercase minimax-m3 returns 400 "not supported".
+func openAICloudwiseRelayUpstreamModelID(modelID string) string {
+	normalized := strings.ToLower(strings.TrimSpace(modelID))
+	if !strings.HasPrefix(normalized, "minimax-") {
+		return modelID
+	}
+	suffix := strings.TrimPrefix(normalized, "minimax-")
+	if suffix == "" {
+		return modelID
+	}
+	if suffix[0] >= 'a' && suffix[0] <= 'z' {
+		suffix = strings.ToUpper(suffix[:1]) + suffix[1:]
+	}
+	return "MiniMax-" + suffix
+}
+
+func applyOpenAICloudwiseRelayUpstreamModelID(account *Account, modelID string) string {
+	if account == nil || !account.IsOpenAICloudwiseRelay() {
+		return modelID
+	}
+	return openAICloudwiseRelayUpstreamModelID(modelID)
+}

--- a/backend/internal/service/openai_cloudwise_relay_tk.go
+++ b/backend/internal/service/openai_cloudwise_relay_tk.go
@@ -1,0 +1,26 @@
+package service
+
+import "strings"
+
+// openAICloudwiseRelayAllowedModelPrefixes is the single SSOT for which model
+// families CloudWise MaaS relay accounts may serve. Adjust only here.
+var openAICloudwiseRelayAllowedModelPrefixes = []string{
+	"kimi-",
+	"claude-",
+	"glm-",
+	"minimax-",
+	"deepseek-",
+}
+
+func openAICloudwiseRelayWildcardModelMappingFloor() map[string]string {
+	out := make(map[string]string, len(openAICloudwiseRelayAllowedModelPrefixes))
+	for _, prefix := range openAICloudwiseRelayAllowedModelPrefixes {
+		prefix = strings.TrimSpace(prefix)
+		if prefix == "" {
+			continue
+		}
+		pattern := prefix + "*"
+		out[pattern] = pattern
+	}
+	return out
+}

--- a/backend/internal/service/openai_cloudwise_relay_tk_test.go
+++ b/backend/internal/service/openai_cloudwise_relay_tk_test.go
@@ -29,6 +29,23 @@ func TestOpenAICloudwiseRelayWildcardModelMappingFloor(t *testing.T) {
 	}, mapping)
 }
 
+func TestOpenAICloudwiseRelayUpstreamModelID(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{"MiniMax-M3", "MiniMax-M3"},
+		{"minimax-m3", "MiniMax-M3"},
+		{"MINIMAX-M3", "MiniMax-M3"},
+		{"MiniMax-m3", "MiniMax-M3"},
+		{"minimax-m2.7", "MiniMax-M2.7"},
+		{"claude-sonnet-4-6", "claude-sonnet-4-6"},
+		{"deepseek-v4-pro", "deepseek-v4-pro"},
+	} {
+		require.Equal(t, tc.want, openAICloudwiseRelayUpstreamModelID(tc.in), tc.in)
+	}
+}
+
 func TestCloudwiseRelayAccountSupportsPrefixFamiliesOnly(t *testing.T) {
 	account := &Account{
 		Platform: PlatformOpenAI,
@@ -43,6 +60,10 @@ func TestCloudwiseRelayAccountSupportsPrefixFamiliesOnly(t *testing.T) {
 	for _, model := range []string{"claude-opus-4-6", "kimi-k3", "glm-5", "MiniMax-M3", "deepseek-v4-flash"} {
 		require.True(t, account.IsModelSupported(model), model)
 		require.Equal(t, model, account.GetMappedModel(model), model)
+	}
+	for _, spell := range []string{"minimax-m3", "MINIMAX-M3", "MiniMax-m3"} {
+		require.True(t, account.IsModelSupported(spell), spell)
+		require.Equal(t, "MiniMax-M3", account.GetMappedModel(spell), spell)
 	}
 	for _, model := range []string{"gpt-5.4", "gemini-3-pro-preview", "qwen-plus"} {
 		require.False(t, account.IsModelSupported(model), model)

--- a/backend/internal/service/openai_cloudwise_relay_tk_test.go
+++ b/backend/internal/service/openai_cloudwise_relay_tk_test.go
@@ -1,0 +1,50 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAICloudwiseRelayAllowedModelPrefixes(t *testing.T) {
+	require.Equal(t, []string{
+		"kimi-",
+		"claude-",
+		"glm-",
+		"minimax-",
+		"deepseek-",
+	}, openAICloudwiseRelayAllowedModelPrefixes)
+}
+
+func TestOpenAICloudwiseRelayWildcardModelMappingFloor(t *testing.T) {
+	mapping := openAICloudwiseRelayWildcardModelMappingFloor()
+	require.Equal(t, map[string]string{
+		"kimi-*":     "kimi-*",
+		"claude-*":   "claude-*",
+		"glm-*":      "glm-*",
+		"minimax-*":  "minimax-*",
+		"deepseek-*": "deepseek-*",
+	}, mapping)
+}
+
+func TestCloudwiseRelayAccountSupportsPrefixFamiliesOnly(t *testing.T) {
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url":      "https://api.cloudwise.ai/api",
+			"model_mapping": modelMappingToAny(openAICloudwiseRelayWildcardModelMappingFloor()),
+		},
+	}
+	require.True(t, account.IsOpenAICloudwiseRelay())
+
+	for _, model := range []string{"claude-opus-4-6", "kimi-k3", "glm-5", "MiniMax-M3", "deepseek-v4-flash"} {
+		require.True(t, account.IsModelSupported(model), model)
+		require.Equal(t, model, account.GetMappedModel(model), model)
+	}
+	for _, model := range []string{"gpt-5.4", "gemini-3-pro-preview", "qwen-plus"} {
+		require.False(t, account.IsModelSupported(model), model)
+	}
+}

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -186,38 +186,7 @@ var supportedAnthropicTokenseaRelayCatalogModels = map[string]struct{}{
 	"claude-sonnet-5":   {},
 }
 
-// supportedOpenAICloudwiseRelayCatalogModels — probe-curated IDs from prod account
-// 95 upstream GET /v1/models on 2026-08-12. Identity mapping; servability still
-// requires per-model gateway/upstream probes before catalog exposure.
-// GPT ids (gpt-5.2 … gpt-5.6-* incl. gpt-5.5/gpt-5.6-sol) are intentionally
-// excluded: CloudWise relay has no reliable OpenAI GPT routing surface.
-var supportedOpenAICloudwiseRelayCatalogModels = map[string]struct{}{
-	"MiniMax-M3":                       {},
-	"claude-fable-5":                   {},
-	"claude-opus-4-6":                  {},
-	"claude-opus-4-6-thinking":         {},
-	"claude-opus-4-7":                  {},
-	"claude-opus-4-7-thinking":         {},
-	"claude-opus-4-8":                  {},
-	"claude-sonnet-4-5":                {},
-	"claude-sonnet-4-6":                {},
-	"claude-sonnet-4-6-thinking":       {},
-	"deepseek-v3.2":                    {},
-	"deepseek-v4-flash":                {},
-	"deepseek-v4-pro":                  {},
-	"gemini-3-flash-preview":           {},
-	"gemini-3-pro-image-preview":       {},
-	"gemini-3-pro-image-preview-S":     {},
-	"gemini-3-pro-preview":             {},
-	"gemini-3.1-flash-image-preview":   {},
-	"gemini-3.1-flash-image-preview-S": {},
-	"gemini-3.1-flash-lite-preview":    {},
-	"gemini-3.1-pro-preview":           {},
-	"glm-5":                            {},
-	"glm-5.1":                          {},
-	"glm-5.2":                          {},
-	"kimi-k3":                          {},
-}
+// CloudWise relay model families: openai_cloudwise_relay_tk.go (openAICloudwiseRelayAllowedModelPrefixes).
 
 // supportedGeminiCatalogModels — gemini/Vertex IDs confirmed servable through
 // the prod Vertex pool. Gemini 3.5 Flash Lite and 3.6 Flash were confirmed on

--- a/backend/migrations/tk_082_cloudwise_prefix_model_mapping.sql
+++ b/backend/migrations/tk_082_cloudwise_prefix_model_mapping.sql
@@ -1,0 +1,44 @@
+-- TokenKey: CloudWise relay model_mapping → prefix wildcard floor.
+--
+-- Runtime SSOT: backend/internal/service/openai_cloudwise_relay_tk.go
+-- (openAICloudwiseRelayAllowedModelPrefixes). Go owner derives the wildcard keys;
+-- this migration materializes the same floor for persisted CloudWise accounts.
+-- Only kimi/claude/glm/minimax/deepseek families are supported.
+--
+-- Idempotent: re-running is a no-op when mapping already matches the floor.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH want AS (
+    SELECT jsonb_build_object(
+        'kimi-*', 'kimi-*',
+        'claude-*', 'claude-*',
+        'glm-*', 'glm-*',
+        'minimax-*', 'minimax-*',
+        'deepseek-*', 'deepseek-*'
+    ) AS mapping
+),
+cloudwise AS (
+    SELECT a.id, w.mapping AS new_mapping
+    FROM accounts AS a
+    CROSS JOIN want AS w
+    WHERE a.deleted_at IS NULL
+      AND a.platform = 'openai'
+      AND a.type = 'apikey'
+      AND LOWER(TRIM(BOTH '/' FROM a.credentials->>'base_url')) IN (
+          'https://api.cloudwise.ai/api',
+          'https://api-us.cloudwise.ai/api'
+      )
+      AND COALESCE(a.credentials -> 'model_mapping', '{}'::jsonb) IS DISTINCT FROM w.mapping
+),
+upd AS (
+    UPDATE accounts AS a
+    SET credentials = jsonb_set(a.credentials, '{model_mapping}', c.new_mapping, true),
+        updated_at = NOW()
+    FROM cloudwise AS c
+    WHERE a.id = c.id
+    RETURNING a.id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "floor_sha256": "647d5f429a9bdce1ef78e217d06ef4b316cc249cc7b444a42ced018760998abe",
+  "floor_sha256": "4c36d1f83819e3b756483a8f362135a07d95a81b72a0b111b670fcbe74025614",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -200,31 +200,11 @@
         "gpt-5.5": "gpt-5.5"
       },
       "openai_cloudwise_relay": {
-        "MiniMax-M3": "MiniMax-M3",
-        "claude-fable-5": "claude-fable-5",
-        "claude-opus-4-6": "claude-opus-4-6",
-        "claude-opus-4-6-thinking": "claude-opus-4-6-thinking",
-        "claude-opus-4-7": "claude-opus-4-7",
-        "claude-opus-4-7-thinking": "claude-opus-4-7-thinking",
-        "claude-opus-4-8": "claude-opus-4-8",
-        "claude-sonnet-4-5": "claude-sonnet-4-5",
-        "claude-sonnet-4-6": "claude-sonnet-4-6",
-        "claude-sonnet-4-6-thinking": "claude-sonnet-4-6-thinking",
-        "deepseek-v3.2": "deepseek-v3.2",
-        "deepseek-v4-flash": "deepseek-v4-flash",
-        "deepseek-v4-pro": "deepseek-v4-pro",
-        "gemini-3-flash-preview": "gemini-3-flash-preview",
-        "gemini-3-pro-image-preview": "gemini-3-pro-image-preview",
-        "gemini-3-pro-image-preview-S": "gemini-3-pro-image-preview-S",
-        "gemini-3-pro-preview": "gemini-3-pro-preview",
-        "gemini-3.1-flash-image-preview": "gemini-3.1-flash-image-preview",
-        "gemini-3.1-flash-image-preview-S": "gemini-3.1-flash-image-preview-S",
-        "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite-preview",
-        "gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
-        "glm-5": "glm-5",
-        "glm-5.1": "glm-5.1",
-        "glm-5.2": "glm-5.2",
-        "kimi-k3": "kimi-k3"
+        "claude-*": "claude-*",
+        "deepseek-*": "deepseek-*",
+        "glm-*": "glm-*",
+        "kimi-*": "kimi-*",
+        "minimax-*": "minimax-*"
       },
       "openai_tokensea_relay": {
         "claude-fable-5": "claude-fable-5",

--- a/ops/stage0/probe_cloudwise_model_case.sh
+++ b/ops/stage0/probe_cloudwise_model_case.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Direct CloudWise upstream chat probe for one model spelling (case sensitivity).
+# Reads api_key/base_url from prod postgres; output never includes api_key.
+set -euo pipefail
+
+ACCOUNT_ID="${ACCOUNT_ID:?ACCOUNT_ID required}"
+MODEL="${MODEL:?MODEL required}"
+REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-45}"
+
+PSQL=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -q -A -t -v ON_ERROR_STOP=1)
+
+python3 - "$ACCOUNT_ID" "$MODEL" "$REQUEST_TIMEOUT_SECONDS" <<'PY'
+import json
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+account_id, model, timeout_raw = sys.argv[1:4]
+timeout = int(timeout_raw)
+
+sql = f"""
+SELECT json_build_object(
+  'id', a.id,
+  'name', a.name,
+  'base_url', COALESCE(a.credentials->>'base_url', ''),
+  'api_key', COALESCE(a.credentials->>'api_key', '')
+)::text
+FROM accounts a
+WHERE a.id={account_id} AND a.deleted_at IS NULL;
+"""
+psql = [
+    "sudo", "docker", "exec", "-i", "tokenkey-postgres", "psql",
+    "-U", "tokenkey", "-d", "tokenkey", "-X", "-q", "-A", "-t",
+    "-v", "ON_ERROR_STOP=1", "-c", sql,
+]
+try:
+    raw = subprocess.run(psql, check=True, text=True, capture_output=True).stdout.strip()
+    account = json.loads(raw)
+except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+    print(json.dumps({"verdict": "setup_error", "error": f"account lookup failed: {exc}"}, ensure_ascii=False))
+    raise SystemExit(0)
+
+api_key = str(account.get("api_key") or "").strip()
+base_url = str(account.get("base_url") or "").strip().rstrip("/")
+if not api_key or not base_url:
+    print(json.dumps({"verdict": "setup_error", "error": "missing api_key or base_url"}, ensure_ascii=False))
+    raise SystemExit(0)
+
+
+def join_path(base, suffix):
+    if suffix.startswith("/"):
+        suffix = suffix[1:]
+    if base.endswith("/"):
+        return base + suffix
+    return base + "/" + suffix
+
+
+def excerpt(raw, limit=320):
+    text = raw.decode("utf-8", errors="replace") if isinstance(raw, (bytes, bytearray)) else str(raw)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:limit]
+
+
+url = join_path(base_url, "v1/chat/completions")
+body = {
+    "model": model,
+    "messages": [{"role": "user", "content": "Reply OK only."}],
+    "max_tokens": 8,
+    "stream": False,
+}
+headers = {
+    "Authorization": f"Bearer {api_key}",
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+}
+req = urllib.request.Request(url, data=json.dumps(body).encode("utf-8"), method="POST", headers=headers)
+try:
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read(1 << 20)
+        status = resp.status
+except urllib.error.HTTPError as exc:
+    status = exc.code
+    raw = exc.read(4096)
+except Exception as exc:  # noqa: BLE001
+    print(json.dumps({
+        "verdict": "setup_error",
+        "error": str(exc),
+        "probe": {"account_id": int(account_id), "model": model, "endpoint": "chat_completions"},
+    }, ensure_ascii=False))
+    raise SystemExit(0)
+
+response_model = None
+try:
+    payload = json.loads(raw.decode("utf-8"))
+    if isinstance(payload, dict):
+        response_model = payload.get("model")
+except (UnicodeDecodeError, json.JSONDecodeError):
+    payload = None
+
+if 200 <= status < 300:
+    verdict = "servable"
+elif status in {401, 403}:
+    verdict = "upstream_auth_rejected"
+else:
+    verdict = "upstream_rejected"
+
+print(json.dumps({
+    "verdict": verdict,
+    "http_status": status,
+    "probe": {
+        "kind": "cloudwise_upstream_chat_case",
+        "account_id": int(account_id),
+        "account_name": account.get("name"),
+        "base_url": base_url,
+        "requested_model": model,
+        "endpoint": "chat_completions",
+    },
+    "response": {
+        "model_field": response_model,
+        "body_excerpt": excerpt(raw),
+    },
+}, ensure_ascii=False, indent=2))
+PY

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1149,6 +1149,7 @@
       "path": "backend/internal/service/openai_cloudwise_relay_tk.go",
       "must_contain": [
         "openAICloudwiseRelayAllowedModelPrefixes",
+        "openAICloudwiseRelayUpstreamModelID(",
         "openAICloudwiseRelayWildcardModelMappingFloor("
       ],
       "rationale": "Single SSOT for CloudWise MaaS relay supported model families (kimi/claude/glm/minimax/deepseek prefix policy). Adjust only openAICloudwiseRelayAllowedModelPrefixes; wildcard model_mapping floor derives from it."
@@ -5091,7 +5092,8 @@
         "func normalizeModelMappingLookupKey(model string) string",
         "return strings.ToLower(strings.TrimSpace(model))",
         "if normalizeModelMappingLookupKey(key) == lookupKey",
-        "matchNormalizedWildcardMappingResult(mapping, lookupKey, requestedModel)"
+        "matchNormalizedWildcardMappingResult(mapping, lookupKey, requestedModel)",
+        "applyOpenAICloudwiseRelayUpstreamModelID(a, mappedModel)"
       ],
       "rationale": "Account-level model_mapping lookup must treat client model-name casing variants as the same upstream capability while preserving explicit exact-spelling priority. This is load-bearing for universal and direct OpenAI-compatible routing: DeepSeek-V4-Pro / deepSeek-v4-pro must hit account mappings keyed as deepseek-v4-pro instead of emptying the pool into client-visible 403/400. account.go is upstream-shaped, so pin the normalization fallback call site and normalized wildcard path to prevent an upstream merge from silently reverting to case-sensitive lookup while the admin-visible raw model_mapping remains unchanged."
     },

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1146,17 +1146,24 @@
       "rationale": "Native Anthropic Messages passthrough for OpenAI-platform dual-stack relays (agent.tokensea.ai, cloudwise). Must forward claude-* /v1/messages directly with API key Bearer auth; non-Claude models stay on chat fallback."
     },
     {
+      "path": "backend/internal/service/openai_cloudwise_relay_tk.go",
+      "must_contain": [
+        "openAICloudwiseRelayAllowedModelPrefixes",
+        "openAICloudwiseRelayWildcardModelMappingFloor("
+      ],
+      "rationale": "Single SSOT for CloudWise MaaS relay supported model families (kimi/claude/glm/minimax/deepseek prefix policy). Adjust only openAICloudwiseRelayAllowedModelPrefixes; wildcard model_mapping floor derives from it."
+    },
+    {
       "path": "backend/internal/service/gateway_cloudwise_relay_test.go",
       "must_contain": [
         "TestAccount_IsOpenAICloudwiseRelay",
-        "TestOpenAICloudwiseRelayFloorIsProbeCuratedOnly",
-        "cloudwise relay catalog must not list GPT ids",
+        "TestOpenAICloudwiseRelayFloorUsesPrefixWildcards",
         "TestForwardAsAnthropic_CloudwiseNativeMessagesPassthrough",
         "TestForwardAsAnthropic_CloudwiseNonClaudeUsesChatFallback",
         "https://api.cloudwise.ai/api/v1/messages",
         "https://api.cloudwise.ai/api/v1/chat/completions"
       ],
-      "rationale": "Focused regressions for CloudWise MaaS relay (prod account #95): probe-curated model_mapping floor, native /v1/messages passthrough for claude-*, and chat fallback for MiniMax-M3."
+      "rationale": "Focused regressions for CloudWise MaaS relay (prod account #95): prefix wildcard model_mapping floor, native /v1/messages passthrough for claude-*, and chat fallback for MiniMax-M3."
     },
     {
       "path": "backend/internal/service/gateway_tokensea_anthropic_relay_test.go",
@@ -5070,14 +5077,23 @@
       "rationale": "Universal-key routing must use the same account-level model+protocol predicate as the direct schedulers before consulting the lossy group-level served-model union. This pins the provider type, the GatewayService implementation, the OpenAI-compatible pool/member + IsModelSupported path, endpoint-shape capability gates (including video-capable accounts), the native gateway path, and the alias-aware served-set fallback. Dropping any of these can make a universal key choose a different backing group than a direct key for the same model/protocol while existing /v1/models output still looks plausible."
     },
     {
+      "path": "backend/internal/service/account_wildcard_tk.go",
+      "must_contain": [
+        "func resolveWildcardMappingTarget(pattern, target, requestedModel string) string",
+        "func matchWildcardMappingResult(mapping map[string]string, requestedModel string)",
+        "func matchNormalizedWildcardMappingResult(mapping map[string]string, lookupKey, originalRequestedModel string)"
+      ],
+      "rationale": "TK companion for wildcard model_mapping passthrough (identity rules like claude-* -> claude-* preserve client spelling; mixed-case MiniMax-M3 via normalized lookup). Keeps upstream-shaped account.go diff minimal."
+    },
+    {
       "path": "backend/internal/service/account.go",
       "must_contain": [
         "func normalizeModelMappingLookupKey(model string) string",
         "return strings.ToLower(strings.TrimSpace(model))",
         "if normalizeModelMappingLookupKey(key) == lookupKey",
-        "func matchNormalizedWildcardMappingResult(mapping map[string]string, requestedModel string)"
+        "matchNormalizedWildcardMappingResult(mapping, lookupKey, requestedModel)"
       ],
-      "rationale": "Account-level model_mapping lookup must treat client model-name casing variants as the same upstream capability while preserving explicit exact-spelling priority. This is load-bearing for universal and direct OpenAI-compatible routing: DeepSeek-V4-Pro / deepSeek-v4-pro must hit account mappings keyed as deepseek-v4-pro instead of emptying the pool into client-visible 403/400. account.go is upstream-shaped, so pin the normalization fallback and normalized wildcard path to prevent an upstream merge from silently reverting to case-sensitive lookup while the admin-visible raw model_mapping remains unchanged."
+      "rationale": "Account-level model_mapping lookup must treat client model-name casing variants as the same upstream capability while preserving explicit exact-spelling priority. This is load-bearing for universal and direct OpenAI-compatible routing: DeepSeek-V4-Pro / deepSeek-v4-pro must hit account mappings keyed as deepseek-v4-pro instead of emptying the pool into client-visible 403/400. account.go is upstream-shaped, so pin the normalization fallback call site and normalized wildcard path to prevent an upstream merge from silently reverting to case-sensitive lookup while the admin-visible raw model_mapping remains unchanged."
     },
     {
       "path": "backend/internal/service/wire_tk.go",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -84,7 +84,7 @@
         "func supportedCatalogModelIDsForPlatform(",
         "supportedAnthropicCatalogModels",
         "supportedOpenAICatalogModels",
-        "supportedOpenAICloudwiseRelayCatalogModels",
+        "openAICloudwiseRelayAllowedModelPrefixes",
         "supportedGeminiCatalogModels",
         "supportedAntigravityCatalogModels",
         "supportedGrokCatalogModels",


### PR DESCRIPTION
## 摘要

CloudWise MaaS relay 改为 **五族前缀 wildcard SSOT**（`openAICloudwiseRelayAllowedModelPrefixes` 单点调整）。

- wildcard `model_mapping` floor + `tk_082` 迁移
- wildcard identity 透传在 `account_wildcard_tk.go`
- **MiniMax 大小写**：上游只认 `MiniMax-M3`；`ResolveMappedModel` 将 `minimax-*` 规范化为 `MiniMax-<Suffix>`
- 已 merge `origin/main`（#1651 xrtoken seedance）

## 风险

- **不可逆状态**：`tk_082` 覆盖 CloudWise persisted `model_mapping`
- **Web impact**: none

## 验证

- 本地 preflight PASS
- CI 全绿（backend-ci + preflight + ssot-delta-gate + marker-acknowledgement）

## 提交

- `77206668e` fix(cloudwise): 前缀 wildcard SSOT 收敛 MaaS relay 可服务模型族
- `7e5c3b6c2` fix(cloudwise): MiniMax 请求规范化为上游 canonical MiniMax-* wire id
- `dbf0e1a27` merge: origin/main into fix/cloudwise-drop-gemini-models

最新提交：`dbf0e1a27`