### PR TITLE
fix(build): upgrade Go to 1.26.6

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -53,7 +53,7 @@ npm install -g pnpm
 
 ### CI 要求
 
-- Go 版本必须是 **1.26.5**：三个 workflow 都用 `go-version-file: backend/go.mod` 取版本，随后硬断言 `go version | grep -q 'go1.26.5'`。升级 Go 时要同时改 `backend/go.mod` 和 `backend-ci.yml`（两处）、`release.yml`、`security-scan.yml` 里的这句断言，否则 CI 会在版本校验步骤直接失败。
+- Go 版本由 `backend/go.mod` 唯一声明；workflows 通过 `go-version-file` 安装该版本，并动态校验实际 toolchain。Docker、工具模块和 README 镜像由 `scripts/checks/go-version-align.py` 在 preflight 中守卫。
 - 前端使用 `pnpm install --frozen-lockfile`，必须提交 `pnpm-lock.yaml`
 
 ### 本地测试命令

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # =============================================================================
 
 ARG NODE_IMAGE=node:24-alpine
-ARG GOLANG_IMAGE=golang:1.26.5-alpine
+ARG GOLANG_IMAGE=golang:1.26.6-alpine
 ARG ALPINE_IMAGE=alpine:3.21
 ARG POSTGRES_IMAGE=postgres:18-alpine
 ARG GOPROXY=https://goproxy.cn,direct

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Sub2API
 
-[![Go](https://img.shields.io/badge/Go-1.26.5-00ADD8.svg)](https://golang.org/)
+[![Go](https://img.shields.io/badge/Go-1.26.6-00ADD8.svg)](https://golang.org/)
 [![Vue](https://img.shields.io/badge/Vue-3.4+-4FC08D.svg)](https://vuejs.org/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-336791.svg)](https://www.postgresql.org/)
 [![Redis](https://img.shields.io/badge/Redis-7+-DC382D.svg)](https://redis.io/)
@@ -196,7 +196,7 @@ Community projects that extend or integrate with Sub2API:
 
 | Component | Technology |
 |-----------|------------|
-| Backend | Go 1.26.5, Gin, Ent |
+| Backend | Go 1.26.6, Gin, Ent |
 | Frontend | Vue 3.4+, Vite 5+, TailwindCSS |
 | Database | PostgreSQL 15+ |
 | Cache/Queue | Redis 7+ |

--- a/README_CN.md
+++ b/README_CN.md
@@ -4,7 +4,7 @@
 
 # Sub2API
 
-[![Go](https://img.shields.io/badge/Go-1.26.5-00ADD8.svg)](https://golang.org/)
+[![Go](https://img.shields.io/badge/Go-1.26.6-00ADD8.svg)](https://golang.org/)
 [![Vue](https://img.shields.io/badge/Vue-3.4+-4FC08D.svg)](https://vuejs.org/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-336791.svg)](https://www.postgresql.org/)
 [![Redis](https://img.shields.io/badge/Redis-7+-DC382D.svg)](https://redis.io/)
@@ -198,7 +198,7 @@ Sub2API 是一个 AI API 网关平台，用于分发和管理 AI 产品订阅的
 
 | 组件 | 技术 |
 |------|------|
-| 后端 | Go 1.26.5, Gin, Ent |
+| 后端 | Go 1.26.6, Gin, Ent |
 | 前端 | Vue 3.4+, Vite 5+, TailwindCSS |
 | 数据库 | PostgreSQL 15+ |
 | 缓存/队列 | Redis 7+ |

--- a/README_JA.md
+++ b/README_JA.md
@@ -4,7 +4,7 @@
 
 # Sub2API
 
-[![Go](https://img.shields.io/badge/Go-1.26.5-00ADD8.svg)](https://golang.org/)
+[![Go](https://img.shields.io/badge/Go-1.26.6-00ADD8.svg)](https://golang.org/)
 [![Vue](https://img.shields.io/badge/Vue-3.4+-4FC08D.svg)](https://vuejs.org/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-336791.svg)](https://www.postgresql.org/)
 [![Redis](https://img.shields.io/badge/Redis-7+-DC382D.svg)](https://redis.io/)
@@ -197,7 +197,7 @@ Sub2API を拡張・統合するコミュニティプロジェクト:
 
 | コンポーネント | 技術 |
 |-----------|------------|
-| バックエンド | Go 1.26.5, Gin, Ent |
+| バックエンド | Go 1.26.6, Gin, Ent |
 | フロントエンド | Vue 3.4+, Vite 5+, TailwindCSS |
 | データベース | PostgreSQL 15+ |
 | キャッシュ/キュー | Redis 7+ |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine
+FROM golang:1.26.6-alpine
 
 WORKDIR /app
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/Wei-Shaw/sub2api
 
-go 1.26.5
+go 1.26.6
 
 require (
 	entgo.io/ent v0.14.5

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -7,7 +7,7 @@
 # =============================================================================
 
 ARG NODE_IMAGE=node:24-alpine
-ARG GOLANG_IMAGE=golang:1.26.5-alpine
+ARG GOLANG_IMAGE=golang:1.26.6-alpine
 ARG ALPINE_IMAGE=alpine:3.20
 ARG GOPROXY=https://goproxy.cn,direct
 ARG GOSUMDB=sum.golang.google.cn

--- a/scripts/checks/go-version-align.py
+++ b/scripts/checks/go-version-align.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Keep all Go toolchain pins aligned with backend/go.mod."""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+VERSION = r"(\d+\.\d+\.\d+)"
+
+SINGLE_PIN_PATTERNS = {
+    "Dockerfile": re.compile(rf"^ARG GOLANG_IMAGE=golang:{VERSION}-alpine$", re.MULTILINE),
+    "backend/Dockerfile": re.compile(rf"^FROM golang:{VERSION}-alpine$", re.MULTILINE),
+    "deploy/Dockerfile": re.compile(rf"^ARG GOLANG_IMAGE=golang:{VERSION}-alpine$", re.MULTILINE),
+    "tools/error_clustering/go.mod": re.compile(rf"^go {VERSION}$", re.MULTILINE),
+}
+README_PATTERNS = (
+    re.compile(rf"img\.shields\.io/badge/Go-{VERSION}-00ADD8\.svg"),
+    re.compile(rf"\|[^\n|]+\| Go {VERSION}, Gin, Ent \|"),
+)
+READMES = ("README.md", "README_CN.md", "README_JA.md")
+OWNER_PATTERN = re.compile(rf"^go {VERSION}$", re.MULTILINE)
+
+
+def read(path: Path) -> str:
+    if not path.is_file():
+        raise ValueError(f"missing required file: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def one_version(root: Path, rel: str, pattern: re.Pattern[str]) -> str:
+    matches = pattern.findall(read(root / rel))
+    if len(matches) != 1:
+        raise ValueError(f"{rel}: expected exactly one Go version pin, found {len(matches)}")
+    return matches[0]
+
+
+def check(root: Path) -> list[str]:
+    owner = one_version(root, "backend/go.mod", OWNER_PATTERN)
+    failures: list[str] = []
+
+    for rel, pattern in SINGLE_PIN_PATTERNS.items():
+        try:
+            actual = one_version(root, rel, pattern)
+        except ValueError as exc:
+            failures.append(str(exc))
+            continue
+        if actual != owner:
+            failures.append(f"{rel}: Go {actual} != backend/go.mod Go {owner}")
+
+    for rel in READMES:
+        text = read(root / rel)
+        for pattern in README_PATTERNS:
+            matches = pattern.findall(text)
+            if len(matches) != 1:
+                failures.append(
+                    f"{rel}: expected exactly one match for {pattern.pattern!r}, found {len(matches)}"
+                )
+                continue
+            if matches[0] != owner:
+                failures.append(f"{rel}: Go {matches[0]} != backend/go.mod Go {owner}")
+
+    return failures
+
+
+def write_fixture(root: Path, owner: str, docker: str | None = None) -> None:
+    docker = docker or owner
+    files = {
+        "backend/go.mod": f"module example.test/app\n\ngo {owner}\n",
+        "Dockerfile": f"ARG GOLANG_IMAGE=golang:{docker}-alpine\n",
+        "backend/Dockerfile": f"FROM golang:{owner}-alpine\n",
+        "deploy/Dockerfile": f"ARG GOLANG_IMAGE=golang:{owner}-alpine\n",
+        "tools/error_clustering/go.mod": f"module example.test/tool\n\ngo {owner}\n",
+    }
+    readme = (
+        f"[![Go](https://img.shields.io/badge/Go-{owner}-00ADD8.svg)](https://golang.org/)\n"
+        f"| Backend | Go {owner}, Gin, Ent |\n"
+    )
+    files.update({rel: readme for rel in READMES})
+    for rel, content in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def selftest() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_fixture(root, "1.26.6")
+        if check(root):
+            print("go-version-align selftest: aligned fixture failed", file=sys.stderr)
+            return 1
+        write_fixture(root, "1.26.6", docker="1.26.5")
+        failures = check(root)
+        if not any("Dockerfile: Go 1.26.5" in failure for failure in failures):
+            print("go-version-align selftest: drift fixture passed", file=sys.stderr)
+            return 1
+    print("go-version-align selftest: OK")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--quiet", action="store_true")
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    try:
+        failures = check(args.root.resolve())
+    except (OSError, ValueError) as exc:
+        print(f"go-version-align: {exc}", file=sys.stderr)
+        return 2
+
+    if failures:
+        print("go-version-align: Go toolchain pins drifted from backend/go.mod:", file=sys.stderr)
+        for failure in failures:
+            print(f"  FAIL: {failure}", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        owner = one_version(args.root.resolve(), "backend/go.mod", OWNER_PATTERN)
+        print(f"go-version-align: OK — all pins match Go {owner}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2789,6 +2789,23 @@ else
     echo "  ok: CI setup-node majors match Dockerfile NODE_IMAGE"
 fi
 
+# ---- sub2api: Go version alignment -------------------------------------------
+# backend/go.mod owns the CI toolchain version. Docker builders, standalone Go
+# tools, and user-facing version declarations must mirror it exactly.
+echo ""
+echo "=== sub2api: Go version alignment ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by go-version-align.py)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/go-version-align.py --selftest >/dev/null; then
+    echo "  FAIL: go-version-align.py self-test failed"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/go-version-align.py --quiet; then
+    errors=$((errors + 1))
+else
+    echo "  ok: Go toolchain pins match backend/go.mod"
+fi
+
 # ---- sub2api: platform registry drift ----------------------------------------
 # Go ↔ TS platform registry lockstep: OpenAI-compat list, dispatch-config
 # platforms, Platform constant universe, Ent enum coverage, and admin UI style

--- a/tools/error_clustering/go.mod
+++ b/tools/error_clustering/go.mod
@@ -1,5 +1,5 @@
 module tokenkey.dev/tools/error_clustering
 
-go 1.26.5
+go 1.26.6
 
 require github.com/lib/pq v1.10.9


### PR DESCRIPTION
## Summary

- upgrade the canonical Go toolchain and all Docker builders from 1.26.5 to 1.26.6
- align the standalone error-clustering module and three user-facing README mirrors
- add a deterministic preflight check that derives all mirrored pins from `backend/go.mod`
- correct `DEV_GUIDE.md`: workflow version checks are dynamic, not hardcoded

## Why

The post-merge CI run for #1661 failed only in `backend-security`: `govulncheck` found six reachable standard-library vulnerabilities in Go 1.26.5. All are fixed in Go 1.26.6. The remaining unit, integration, frontend, preflight, lint, and watchdog jobs passed.

Affected advisories: GO-2026-6218, GO-2026-6090, GO-2026-6089, GO-2026-6088, GO-2026-5972, GO-2026-5026.

## Verification

- `govulncheck ./...`: 0 reachable vulnerabilities
- `python3 scripts/checks/go-version-align.py --selftest`
- `python3 scripts/checks/go-version-align.py`
- `go test ./...` in `tools/error_clustering`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `PATH="$(go env GOPATH)/bin:$PATH" make test`
- verified `golang:1.26.6-alpine` multi-architecture manifest exists

Web impact: none

sentinel-registry-reviewed: the Dockerfile edits only advance the Go builder patch tag. The new `go-version-align.py` preflight gate covers the load-bearing version parity; no brand sentinel anchor is required.

ai