### PR TITLE
fix(pricing): repair runtime publication audit

### DIFF
--- a/.testing/user-stories/stories/US-043-pricing-registry-hot-reload.md
+++ b/.testing/user-stories/stories/US-043-pricing-registry-hot-reload.md
@@ -57,6 +57,7 @@
 - `ops/pricing/test_manage_overlay_runtime.py`::`test_remote_cas_uses_cte_and_conflict_exits_before_redis`
 - `ops/pricing/test_manage_overlay_runtime.py`::`test_check_is_read_only_and_reports_provenance_lag_as_healthy`
 - `ops/pricing/test_manage_overlay_runtime.py`::`test_sync_cas_success_verifies_exact_readback`
+- `ops/pricing/test_manage_overlay_runtime.py`::`test_sync_post_write_provenance_mismatch_fails_closed`
 - `ops/pricing/test_manage_overlay_runtime.py`::`test_sync_conflict_then_newer_source_refuses_retry`
 - `ops/pricing/test_pricing_registry_sensor.py`::`test_candidate_updates_only_existing_owner_billable_fields`
 - `scripts/checks/test_pricing_registry_publication.py`::`test_rejects_non_main_extra_event_or_extra_path`

--- a/.testing/user-stories/stories/US-043-pricing-registry-hot-reload.md
+++ b/.testing/user-stories/stories/US-043-pricing-registry-hot-reload.md
@@ -34,7 +34,8 @@
 - External parse/sync 可以保留用于 sensor 和上游兼容，但它的结果在 effective map 中被完整 registry 替换。
 - `channel_model_pricing` 只覆盖指定 scope，缺失维度继续遵循现有 resolver 契约。
 - deliberate-free 与 unknown-zero 必须可区分；unknown-zero 仍 fail closed。
-- publisher 写后必须读回并核对 source commit 与 digest。
+- publisher 写后必须以同一 PostgreSQL row version 分块读回，并核对 source commit、digest 与 exact registry bytes；截断或并发变化必须 fail closed。
+- read-only audit 以 exact digest/bytes 判定价格内容健康，并将 source commit 差异单独报告为 provenance lag；publisher no-op 仍要求 provenance 与内容都精确一致。
 
 ## Linked Tests
 
@@ -51,6 +52,10 @@
 - `backend/internal/service/billing_service_tk_image_token_settlement_test.go`::`TestUS043_BothGatewayImageFunnelsUseTokenSettlement`
 - `backend/internal/service/billing_service_tk_image_token_settlement_test.go`::`TestUS043_GatewayMissingImageTokensReturnsBillingError`
 - `backend/internal/service/pricing_catalog_tk_test.go`::`TestUS043_PublicCatalogSurfacesImageTokenSettlementDimensions`
+- `ops/pricing/test_manage_overlay_runtime.py`::`test_chunked_read_reassembles_payload_larger_than_ssm_stdout`
+- `ops/pricing/test_manage_overlay_runtime.py`::`test_runtime_xmin_change_exhausts_bounded_retries`
+- `ops/pricing/test_manage_overlay_runtime.py`::`test_remote_cas_uses_cte_and_conflict_exits_before_redis`
+- `ops/pricing/test_manage_overlay_runtime.py`::`test_check_is_read_only_and_reports_provenance_lag_as_healthy`
 - `ops/pricing/test_manage_overlay_runtime.py`::`test_sync_cas_success_verifies_exact_readback`
 - `ops/pricing/test_manage_overlay_runtime.py`::`test_sync_conflict_then_newer_source_refuses_retry`
 - `ops/pricing/test_pricing_registry_sensor.py`::`test_candidate_updates_only_existing_owner_billable_fields`

--- a/docs/approved/pricing-registry-hot-reload.md
+++ b/docs/approved/pricing-registry-hot-reload.md
@@ -104,7 +104,11 @@ scoped channel_model_pricing override
 
 The deploy workflow never writes the runtime price setting. Therefore an older
 application release cannot overwrite a newer active price snapshot. Deploy may
-audit the active snapshot but must not synchronize the deployed tag into it.
+audit the active snapshot but must not synchronize the deployed tag into it. A
+read-only audit treats exact registry digest and bytes as healthy even when an
+unrelated protected-main commit has advanced; it reports that source-commit
+difference separately as provenance lag. Publication no-op and post-write
+verification remain stricter and require exact provenance plus exact content.
 
 ## Protected publication and rollback
 
@@ -114,8 +118,12 @@ publisher has no second Environment approval gate. It fetches current
 `origin/main`, verifies that the local artifact is byte-identical to that head,
 runs the registry gate, builds the envelope, writes it through the existing SSM
 settings path, publishes `settings_updated`, and reads the row back to verify
-commit and digest. A workflow-only change intentionally reconciles the current
-snapshot and becomes an idempotent no-op when it is already exact.
+commit, digest and exact registry bytes. Readback uses bounded byte chunks tied
+to one PostgreSQL row version, so an SSM inline-output limit or concurrent row
+change cannot turn a partial document into successful verification. A
+workflow-only change intentionally reconciles the current snapshot and becomes
+an idempotent no-op only when both protected-main provenance and content are
+already exact.
 
 New runs supersede obsolete waiting or running workflow jobs, but cancellation
 is not the write-safety boundary because an older runner may already have issued

--- a/ops/pricing/manage-overlay-runtime.py
+++ b/ops/pricing/manage-overlay-runtime.py
@@ -36,6 +36,9 @@ SETTING_KEY = "tk_pricing_overlay_runtime"
 SCHEMA_VERSION = 1
 MAX_REGISTRY_BYTES = 8 << 20
 CAS_MAX_ATTEMPTS = 3
+READ_MAX_ATTEMPTS = 3
+RUNTIME_CHUNK_BYTES = 12 << 10
+MAX_RUNTIME_DOCUMENT_BYTES = 12 << 20
 
 PSQL = "sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1"
 REDISCLI = "env -u REDISCLI_AUTH sudo docker exec tokenkey-redis redis-cli"
@@ -84,6 +87,13 @@ class RuntimeInspection:
         return (
             self.state == "valid"
             and self.source_commit == expected.source_commit
+            and self.registry_sha256 == expected.registry_sha256
+            and self.registry_bytes == expected.registry_bytes
+        )
+
+    def is_content_current(self, expected: RegistryArtifact) -> bool:
+        return (
+            self.state == "valid"
             and self.registry_sha256 == expected.registry_sha256
             and self.registry_bytes == expected.registry_bytes
         )
@@ -222,43 +232,128 @@ def load_origin_main_artifact(*, require_publishable_checkout: bool) -> Registry
     return RegistryArtifact(source_commit=source_commit, registry_bytes=registry_bytes)
 
 
-def _decode_runtime_value(output: str) -> RuntimeDocument:
-    output = output.strip()
-    if not output:
-        raise ValueError("runtime settings read returned no versioned result")
-    payload = json.loads(gzip.decompress(base64.b64decode(output)).decode("utf-8"))
-    if not isinstance(payload, dict) or set(payload) != {"version", "value"}:
-        raise ValueError("runtime settings read must contain exactly version and value")
-    version = payload["version"]
-    value = payload["value"]
-    if not isinstance(version, str) or not version:
-        raise ValueError("runtime settings version must be a non-empty string")
-    if not isinstance(value, dict):
-        raise ValueError("runtime settings value must be a JSON object")
-    if version == "absent" and value != {}:
-        raise ValueError("absent runtime settings row must have an empty value")
-    if version != "absent" and not version.isdigit():
-        raise ValueError("runtime settings row version must be a PostgreSQL xmin")
-    return RuntimeDocument(value=value, version=version)
+def _run_pricing_shell(instance_id: str, shell: str, comment: str) -> str:
+    shell_b64 = base64.b64encode(shell.encode("utf-8")).decode("ascii")
+    return _SSM.run_shell_b64(instance_id, shell_b64, comment)
+
+
+def _read_runtime_metadata(instance_id: str) -> tuple[str, int] | None:
+    query = (
+        "SELECT COALESCE((SELECT CASE "
+        "WHEN value IS NULL OR octet_length(convert_to(value, 'UTF8')) = 0 "
+        "THEN 'ROW_INVALID' ELSE 'ROW_PRESENT|' || xmin::text || '|' || "
+        "octet_length(convert_to(value, 'UTF8'))::text END "
+        f"FROM settings WHERE key='{SETTING_KEY}'), 'ROW_ABSENT');"
+    )
+    output = _run_pricing_shell(
+        instance_id,
+        f'{PSQL} -c "{query}"',
+        "pricing registry: read runtime snapshot metadata",
+    ).strip()
+    if output == "ROW_ABSENT":
+        return None
+    if output == "ROW_INVALID":
+        fail("runtime settings row has a null or empty value")
+    parts = output.split("|")
+    if len(parts) != 3 or parts[0] != "ROW_PRESENT":
+        fail(f"runtime settings metadata returned an invalid marker: {output!r}")
+    version, raw_total = parts[1:]
+    if not version.isdigit():
+        fail("runtime settings metadata returned an invalid PostgreSQL xmin")
+    if not raw_total.isdigit():
+        fail("runtime settings metadata returned an invalid byte length")
+    total_bytes = int(raw_total)
+    if not 0 < total_bytes <= MAX_RUNTIME_DOCUMENT_BYTES:
+        fail(
+            "runtime settings document size is outside the supported range: "
+            f"{total_bytes} bytes"
+        )
+    return version, total_bytes
+
+
+def _read_runtime_chunk(
+    instance_id: str, version: str, offset: int, expected_bytes: int
+) -> bytes | None:
+    if not version.isdigit():
+        fail("runtime chunk read requires a PostgreSQL xmin")
+    query = (
+        "SELECT COALESCE((SELECT 'CHUNK|' || "
+        "octet_length(chunk_bytes)::text || '|' || encode(chunk_bytes, 'base64') "
+        "FROM (SELECT substring(convert_to(value, 'UTF8') "
+        f"FROM {offset} FOR {expected_bytes}) AS chunk_bytes FROM settings "
+        f"WHERE key='{SETTING_KEY}' AND xmin='{version}'::xid) AS chunk_row), "
+        "'CHUNK_STALE');"
+    )
+    output = _run_pricing_shell(
+        instance_id,
+        f'{PSQL} -c "{query}" | tr -d \'\\n\'',
+        "pricing registry: read runtime snapshot chunk",
+    ).strip()
+    if output == "CHUNK_STALE":
+        return None
+    parts = output.split("|", 2)
+    if len(parts) != 3 or parts[0] != "CHUNK":
+        fail(f"runtime settings chunk returned an invalid marker: {output!r}")
+    if not parts[1].isdigit():
+        fail("runtime settings chunk returned an invalid byte length")
+    reported_bytes = int(parts[1])
+    if reported_bytes != expected_bytes:
+        fail(
+            "runtime settings chunk length mismatch: "
+            f"expected {expected_bytes}, got {reported_bytes}"
+        )
+    try:
+        chunk = base64.b64decode(parts[2], validate=True)
+    except ValueError as exc:
+        fail(f"runtime settings chunk base64 decode failed: {exc}")
+    if len(chunk) != expected_bytes:
+        fail(
+            "runtime settings decoded chunk length mismatch: "
+            f"expected {expected_bytes}, got {len(chunk)}"
+        )
+    return chunk
 
 
 def read_runtime_document(instance_id: str) -> RuntimeDocument:
-    shell = (
-        f"{PSQL} -c \"SELECT json_build_object("
-        "'version', COALESCE((SELECT xmin::text FROM settings "
-        f"WHERE key='{SETTING_KEY}'), 'absent'), "
-        "'value', COALESCE((SELECT value::json FROM settings "
-        f"WHERE key='{SETTING_KEY}'), '{{}}'::json))::text;\""
-        " | gzip -c | base64 | tr -d '\\n'"
+    for attempt in range(1, READ_MAX_ATTEMPTS + 1):
+        metadata = _read_runtime_metadata(instance_id)
+        if metadata is None:
+            return RuntimeDocument(value={}, version="absent")
+        version, total_bytes = metadata
+        chunks: list[bytes] = []
+        stale = False
+        for start in range(0, total_bytes, RUNTIME_CHUNK_BYTES):
+            expected_bytes = min(RUNTIME_CHUNK_BYTES, total_bytes - start)
+            chunk = _read_runtime_chunk(
+                instance_id, version, start + 1, expected_bytes
+            )
+            if chunk is None:
+                stale = True
+                break
+            chunks.append(chunk)
+        if stale:
+            print(
+                f"runtime snapshot changed during read attempt {attempt}; "
+                "restarting from metadata."
+            )
+            continue
+        payload = b"".join(chunks)
+        if len(payload) != total_bytes:
+            fail(
+                "runtime settings document length mismatch: "
+                f"expected {total_bytes}, got {len(payload)}"
+            )
+        try:
+            value = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            fail(f"runtime settings document decode failed: {exc}")
+        if not isinstance(value, dict):
+            fail("runtime settings value must be a JSON object")
+        return RuntimeDocument(value=value, version=version)
+    fail(
+        f"runtime snapshot changed during {READ_MAX_ATTEMPTS} read attempts; "
+        "refusing an inconsistent document"
     )
-    shell_b64 = base64.b64encode(shell.encode()).decode()
-    output = _SSM.run_shell_b64(
-        instance_id, shell_b64, "pricing registry: read runtime snapshot"
-    )
-    try:
-        return _decode_runtime_value(output)
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        fail(f"runtime settings blob decode failed: {exc}")
 
 
 def _run_registry_gate() -> None:
@@ -276,6 +371,13 @@ def _print_inspection(expected: RegistryArtifact, inspection: RuntimeInspection)
     if inspection.is_current(expected):
         print("OK: runtime snapshot is the exact protected-main registry artifact.")
         return
+    if inspection.is_content_current(expected):
+        print("OK: runtime snapshot has the exact protected-main registry content.")
+        print(
+            "NOTE: runtime snapshot provenance lag: "
+            f"runtime={inspection.source_commit} origin/main={expected.source_commit}."
+        )
+        return
     if inspection.state == "valid":
         print(
             "DRIFT: runtime snapshot is valid but differs from protected main "
@@ -291,7 +393,7 @@ def cmd_check(_args: argparse.Namespace) -> int:
     instance_id = _SSM.resolve_prod_instance()
     inspection = inspect_runtime_document(read_runtime_document(instance_id).value)
     _print_inspection(expected, inspection)
-    return 0 if inspection.is_current(expected) else 1
+    return 0 if inspection.is_content_current(expected) else 1
 
 
 def _write_runtime_document(
@@ -305,22 +407,31 @@ def _write_runtime_document(
     raw_b64_len = len(base64.b64encode(envelope_bytes))
     if expected_version == "absent":
         mutation = (
-            f"INSERT INTO settings (key, value, updated_at) VALUES "
+            "WITH mutation AS (INSERT INTO settings (key, value, updated_at) VALUES "
             f"('{SETTING_KEY}', convert_from(decode('$JSON_B64','base64'),'UTF8'), NOW()) "
-            "ON CONFLICT (key) DO NOTHING RETURNING 1"
+            "ON CONFLICT (key) DO NOTHING RETURNING 1) "
+            "SELECT CASE WHEN EXISTS (SELECT 1 FROM mutation) "
+            "THEN 'CAS_APPLIED' ELSE 'CAS_CONFLICT' END"
         )
     else:
         mutation = (
-            f"UPDATE settings SET value=convert_from(decode('$JSON_B64','base64'),'UTF8'), "
+            "WITH mutation AS (UPDATE settings SET "
+            "value=convert_from(decode('$JSON_B64','base64'),'UTF8'), "
             f"updated_at=NOW() WHERE key='{SETTING_KEY}' "
-            f"AND xmin='{expected_version}'::xid RETURNING 1"
+            f"AND xmin='{expected_version}'::xid RETURNING 1) "
+            "SELECT CASE WHEN EXISTS (SELECT 1 FROM mutation) "
+            "THEN 'CAS_APPLIED' ELSE 'CAS_CONFLICT' END"
         )
     shell = (
         "set -euo pipefail\n"
         f"JSON_B64=\"$(echo {gz_b64} | base64 -d | gunzip | base64 | tr -d '\\n')\"\n"
         f"test \"${{#JSON_B64}}\" -eq {raw_b64_len}\n"
         f"CAS_RESULT=\"$({PSQL} -c \"{mutation};\")\"\n"
-        "if [ \"$CAS_RESULT\" != \"1\" ]; then echo CAS_CONFLICT; exit 0; fi\n"
+        "case \"$CAS_RESULT\" in\n"
+        "  CAS_APPLIED) ;;\n"
+        "  CAS_CONFLICT) echo CAS_CONFLICT; exit 0 ;;\n"
+        "  *) echo \"ERROR: unexpected runtime CAS result: $CAS_RESULT\" >&2; exit 1 ;;\n"
+        "esac\n"
         f"{PSQL} -c \"SELECT key || '|' || length(value)::text || '|' || md5(value) "
         f"FROM settings WHERE key='{SETTING_KEY}';\"\n"
         "echo CAS_APPLIED\n"
@@ -334,12 +445,14 @@ def _write_runtime_document(
         instance_id, shell_b64, "pricing registry: publish protected-main snapshot"
     )
     print(output)
-    if "CAS_CONFLICT" in output:
-        if "CAS_APPLIED" in output:
-            fail("runtime CAS returned conflicting terminal markers")
+    lines = output.splitlines()
+    markers = [line for line in lines if line in {"CAS_APPLIED", "CAS_CONFLICT"}]
+    if markers == ["CAS_CONFLICT"]:
         return False
+    if markers != ["CAS_APPLIED"]:
+        fail(f"runtime CAS returned invalid terminal markers: {markers!r}")
     expected_line = f"{SETTING_KEY}|{expected_len}|{expected_md5}"
-    if "CAS_APPLIED" not in output or expected_line not in output:
+    if expected_line not in lines:
         fail(f"runtime CAS read-back mismatch; expected {expected_line!r}")
     return True
 

--- a/ops/pricing/test_manage_overlay_runtime.py
+++ b/ops/pricing/test_manage_overlay_runtime.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import copy
-import gzip
 import hashlib
 import importlib.util
+import io
 import json
 import pathlib
 import sys
@@ -78,24 +79,119 @@ class PricingRegistryRuntimeTests(unittest.TestCase):
         )
         self.assertFalse(other_commit.is_current(expected))
 
-    def test_decode_ssm_readback_requires_document_and_version(self) -> None:
-        large_registry = json.dumps({"model": {"source": "x" * 100_000}}).encode()
-        envelope = runtime.build_runtime_envelope(large_registry, self.COMMIT)
-        payload = json.dumps({"version": "42", "value": envelope}).encode()
-        encoded = base64.b64encode(gzip.compress(payload)).decode()
-        self.assertEqual(
-            runtime._decode_runtime_value(encoded),
-            runtime.RuntimeDocument(value=envelope, version="42"),
+    @staticmethod
+    def chunk_marker(chunk: bytes) -> str:
+        return f"CHUNK|{len(chunk)}|{base64.b64encode(chunk).decode('ascii')}"
+
+    def test_chunked_read_reassembles_payload_larger_than_ssm_stdout(self) -> None:
+        models = {
+            f"model-{index:05d}": hashlib.sha256(str(index).encode()).hexdigest()
+            for index in range(1_200)
+        }
+        registry = json.dumps({"models": models}, sort_keys=True).encode()
+        envelope = runtime.build_runtime_envelope(registry, self.COMMIT)
+        payload = json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode()
+        legacy_transport = base64.b64encode(payload).decode("ascii")
+        self.assertGreater(len(legacy_transport), 24_000)
+
+        outputs = [f"ROW_PRESENT|42|{len(payload)}"]
+        chunks = [
+            payload[start:start + runtime.RUNTIME_CHUNK_BYTES]
+            for start in range(0, len(payload), runtime.RUNTIME_CHUNK_BYTES)
+        ]
+        outputs.extend(self.chunk_marker(chunk) for chunk in chunks)
+        self.assertGreater(len(chunks), 1)
+        self.assertTrue(all(len(output) < 24_000 for output in outputs))
+        shells: list[str] = []
+
+        def fake_run(_instance: str, encoded: str, _comment: str) -> str:
+            shells.append(base64.b64decode(encoded).decode())
+            return outputs.pop(0)
+
+        with mock.patch.object(runtime._SSM, "run_shell_b64", side_effect=fake_run):
+            document = runtime.read_runtime_document("i-" + "1" * 17)
+        self.assertEqual(document, self.document(envelope))
+        self.assertFalse(outputs)
+        self.assertIn("FROM 1 FOR 12288", shells[1])
+        self.assertIn("xmin='42'::xid", shells[1])
+        self.assertIn("convert_to(value, 'UTF8')", shells[1])
+
+    def test_runtime_read_only_accepts_explicit_absence(self) -> None:
+        with mock.patch.object(
+            runtime._SSM, "run_shell_b64", return_value="ROW_ABSENT"
+        ):
+            self.assertEqual(
+                runtime.read_runtime_document("i-" + "1" * 17),
+                self.document({}, "absent"),
+            )
+
+    def test_runtime_metadata_invalid_states_fail_closed(self) -> None:
+        invalid_outputs = (
+            "",
+            "ROW_INVALID",
+            "ROW_PRESENT|bad-xmin|10",
+            "ROW_PRESENT|42|bad-size",
+            "ROW_PRESENT|42|0",
+            f"ROW_PRESENT|42|{runtime.MAX_RUNTIME_DOCUMENT_BYTES + 1}",
+            "ROW_ABSENT|42|10",
         )
-        absent = base64.b64encode(
-            gzip.compress(b'{"version":"absent","value":{}}')
-        ).decode()
-        self.assertEqual(
-            runtime._decode_runtime_value(absent),
-            runtime.RuntimeDocument(value={}, version="absent"),
+        for output in invalid_outputs:
+            with self.subTest(output=output), mock.patch.object(
+                runtime._SSM, "run_shell_b64", return_value=output
+            ), self.assertRaisesRegex(SystemExit, "2"):
+                runtime.read_runtime_document("i-" + "1" * 17)
+
+    def test_runtime_chunk_corruption_fails_closed(self) -> None:
+        corrupt_outputs = (
+            "",
+            "CHUNK|4|%%%not-base64%%%",
+            f"CHUNK|3|{base64.b64encode(b'abcd').decode()}",
+            f"CHUNK|4|{base64.b64encode(b'abc').decode()}",
+            "CHUNK_UNKNOWN|4|YWJjZA==",
         )
-        with self.assertRaisesRegex(ValueError, "no versioned result"):
-            runtime._decode_runtime_value("")
+        for output in corrupt_outputs:
+            with self.subTest(output=output), mock.patch.object(
+                runtime._SSM, "run_shell_b64", return_value=output
+            ), self.assertRaisesRegex(SystemExit, "2"):
+                runtime._read_runtime_chunk("i-" + "1" * 17, "42", 1, 4)
+
+    def test_runtime_total_length_mismatch_fails_closed(self) -> None:
+        with mock.patch.object(
+            runtime, "_read_runtime_metadata", return_value=("42", 4)
+        ), mock.patch.object(
+            runtime, "_read_runtime_chunk", return_value=b"abc"
+        ), self.assertRaisesRegex(SystemExit, "2"):
+            runtime.read_runtime_document("i-" + "1" * 17)
+
+    def test_runtime_xmin_change_restarts_from_metadata(self) -> None:
+        payload = json.dumps(
+            runtime.build_runtime_envelope(self.REGISTRY, self.COMMIT),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        outputs = [
+            f"ROW_PRESENT|42|{len(payload)}",
+            "CHUNK_STALE",
+            f"ROW_PRESENT|43|{len(payload)}",
+            self.chunk_marker(payload),
+        ]
+        with mock.patch.object(
+            runtime._SSM, "run_shell_b64", side_effect=outputs
+        ), contextlib.redirect_stdout(io.StringIO()) as stdout:
+            document = runtime.read_runtime_document("i-" + "1" * 17)
+        self.assertEqual(document.version, "43")
+        self.assertIn("changed during read attempt 1", stdout.getvalue())
+
+    def test_runtime_xmin_change_exhausts_bounded_retries(self) -> None:
+        outputs: list[str] = []
+        for version in range(runtime.READ_MAX_ATTEMPTS):
+            outputs.extend((f"ROW_PRESENT|{42 + version}|4", "CHUNK_STALE"))
+        with mock.patch.object(
+            runtime._SSM, "run_shell_b64", side_effect=outputs
+        ), contextlib.redirect_stdout(io.StringIO()), self.assertRaisesRegex(
+            SystemExit, "2"
+        ):
+            runtime.read_runtime_document("i-" + "1" * 17)
 
     def test_sync_dry_run_requires_publishable_checkout_and_skips_aws(self) -> None:
         artifact = runtime.RegistryArtifact(self.COMMIT, self.REGISTRY)
@@ -123,6 +219,28 @@ class PricingRegistryRuntimeTests(unittest.TestCase):
                 mock.patch.object(runtime, "_write_runtime_document") as write:
             self.assertEqual(runtime.cmd_sync_runtime(args), 0)
         write.assert_not_called()
+
+    def test_sync_republishes_same_content_with_different_source(self) -> None:
+        artifact = runtime.RegistryArtifact(self.COMMIT, self.REGISTRY)
+        args = type("Args", (), {"dry_run": False})()
+        old_source = "b" * 40
+        stale = runtime.build_runtime_envelope(self.REGISTRY, old_source)
+        exact = runtime.build_runtime_envelope(self.REGISTRY, self.COMMIT)
+        with mock.patch.object(
+            runtime, "load_origin_main_artifact", return_value=artifact
+        ), mock.patch.object(runtime, "_run_registry_gate"), mock.patch.object(
+            runtime._SSM, "resolve_prod_instance", return_value="i-" + "1" * 17
+        ), mock.patch.object(
+            runtime, "read_runtime_document",
+            side_effect=[self.document(stale), self.document(exact, "43")],
+        ), mock.patch.object(
+            runtime, "_git_is_ancestor", return_value=True
+        ) as ancestry, mock.patch.object(
+            runtime, "_write_runtime_document", return_value=True
+        ) as write:
+            self.assertEqual(runtime.cmd_sync_runtime(args), 0)
+        ancestry.assert_called_once_with(old_source, self.COMMIT)
+        write.assert_called_once_with(mock.ANY, mock.ANY, "42")
 
     def test_sync_cas_success_verifies_exact_readback(self) -> None:
         artifact = runtime.RegistryArtifact(self.COMMIT, self.REGISTRY)
@@ -196,7 +314,7 @@ class PricingRegistryRuntimeTests(unittest.TestCase):
                 runtime.cmd_sync_runtime(args)
         self.assertEqual(write.call_count, runtime.CAS_MAX_ATTEMPTS)
 
-    def test_remote_cas_conflict_does_not_publish_redis(self) -> None:
+    def test_remote_cas_uses_cte_and_conflict_exits_before_redis(self) -> None:
         captured_shell = ""
 
         def fake_run(_instance: str, encoded: str, _comment: str) -> str:
@@ -208,9 +326,52 @@ class PricingRegistryRuntimeTests(unittest.TestCase):
             self.assertFalse(
                 runtime._write_runtime_document("i-" + "1" * 17, b"{}", "42")
             )
-        conflict_index = captured_shell.index("CAS_CONFLICT")
+        self.assertIn("WITH mutation AS (UPDATE settings", captured_shell)
+        self.assertIn("SELECT CASE WHEN EXISTS (SELECT 1 FROM mutation)", captured_shell)
+        case_index = captured_shell.index('case "$CAS_RESULT" in')
         redis_index = captured_shell.index("PUBLISH settings_updated")
-        self.assertIn("exit 0", captured_shell[conflict_index:redis_index])
+        self.assertIn(
+            "CAS_CONFLICT) echo CAS_CONFLICT; exit 0",
+            captured_shell[case_index:redis_index],
+        )
+
+    def test_remote_absent_cas_uses_insert_cte(self) -> None:
+        captured_shell = ""
+
+        def fake_run(_instance: str, encoded: str, _comment: str) -> str:
+            nonlocal captured_shell
+            captured_shell = base64.b64decode(encoded).decode()
+            return "CAS_CONFLICT\n"
+
+        with mock.patch.object(runtime._SSM, "run_shell_b64", side_effect=fake_run):
+            self.assertFalse(
+                runtime._write_runtime_document("i-" + "1" * 17, b"{}", "absent")
+            )
+        self.assertIn("WITH mutation AS (INSERT INTO settings", captured_shell)
+        self.assertIn("ON CONFLICT (key) DO NOTHING RETURNING 1)", captured_shell)
+
+    def test_remote_cas_applied_requires_exact_readback(self) -> None:
+        payload = b"{}"
+        expected = (
+            f"{runtime.SETTING_KEY}|2|{hashlib.md5(payload).hexdigest()}\nCAS_APPLIED\n"
+        )
+        with mock.patch.object(
+            runtime._SSM, "run_shell_b64", return_value=expected
+        ):
+            self.assertTrue(
+                runtime._write_runtime_document("i-" + "1" * 17, payload, "42")
+            )
+        with mock.patch.object(
+            runtime._SSM, "run_shell_b64", return_value="CAS_APPLIED\n"
+        ), self.assertRaisesRegex(SystemExit, "2"):
+            runtime._write_runtime_document("i-" + "1" * 17, payload, "42")
+
+    def test_old_psql_returning_shape_and_unknown_markers_fail_closed(self) -> None:
+        for output in ("1\nUPDATE 1\n", "CAS_APPLIED\nCAS_CONFLICT\n"):
+            with self.subTest(output=output), mock.patch.object(
+                runtime._SSM, "run_shell_b64", return_value=output
+            ), self.assertRaisesRegex(SystemExit, "2"):
+                runtime._write_runtime_document("i-" + "1" * 17, b"{}", "42")
 
     def test_sync_allows_new_descendant_for_git_revert_publication(self) -> None:
         artifact = runtime.RegistryArtifact(self.COMMIT, self.REGISTRY)
@@ -233,19 +394,36 @@ class PricingRegistryRuntimeTests(unittest.TestCase):
         ancestry.assert_called_once_with("b" * 40, self.COMMIT)
         write.assert_called_once_with(mock.ANY, mock.ANY, "42")
 
-    def test_check_is_read_only_and_reports_drift(self) -> None:
+    def test_check_is_read_only_and_reports_provenance_lag_as_healthy(self) -> None:
         artifact = runtime.RegistryArtifact(self.COMMIT, self.REGISTRY)
-        stale = runtime.build_runtime_envelope(self.REGISTRY, "b" * 40)
+        stale_source = runtime.build_runtime_envelope(self.REGISTRY, "b" * 40)
         with mock.patch.object(
             runtime, "load_origin_main_artifact", return_value=artifact
         ) as load_artifact, mock.patch.object(
             runtime._SSM, "resolve_prod_instance", return_value="i-" + "1" * 17
         ), mock.patch.object(
-            runtime, "read_runtime_document", return_value=self.document(stale)
-        ), mock.patch.object(runtime, "_write_runtime_document") as write:
-            self.assertEqual(runtime.cmd_check(type("Args", (), {})()), 1)
+            runtime, "read_runtime_document", return_value=self.document(stale_source)
+        ), mock.patch.object(
+            runtime, "_write_runtime_document"
+        ) as write, contextlib.redirect_stdout(io.StringIO()) as stdout:
+            self.assertEqual(runtime.cmd_check(type("Args", (), {})()), 0)
+        self.assertIn("provenance lag", stdout.getvalue())
+        self.assertIn("runtime=" + "b" * 40, stdout.getvalue())
         load_artifact.assert_called_once_with(require_publishable_checkout=False)
         write.assert_not_called()
+
+    def test_check_reports_content_drift(self) -> None:
+        artifact = runtime.RegistryArtifact(self.COMMIT, self.REGISTRY)
+        drifted = runtime.build_runtime_envelope(self.REGISTRY + b" ", "b" * 40)
+        with mock.patch.object(
+            runtime, "load_origin_main_artifact", return_value=artifact
+        ), mock.patch.object(
+            runtime._SSM, "resolve_prod_instance", return_value="i-" + "1" * 17
+        ), mock.patch.object(
+            runtime, "read_runtime_document", return_value=self.document(drifted)
+        ), contextlib.redirect_stdout(io.StringIO()) as stdout:
+            self.assertEqual(runtime.cmd_check(type("Args", (), {})()), 1)
+        self.assertIn("DRIFT", stdout.getvalue())
 
 
 if __name__ == "__main__":

--- a/ops/pricing/test_manage_overlay_runtime.py
+++ b/ops/pricing/test_manage_overlay_runtime.py
@@ -259,6 +259,29 @@ class PricingRegistryRuntimeTests(unittest.TestCase):
             self.assertEqual(runtime.cmd_sync_runtime(args), 0)
         write.assert_called_once_with(mock.ANY, mock.ANY, "absent")
 
+    def test_sync_post_write_provenance_mismatch_fails_closed(self) -> None:
+        artifact = runtime.RegistryArtifact(self.COMMIT, self.REGISTRY)
+        args = type("Args", (), {"dry_run": False})()
+        other_source = "b" * 40
+        same_content = runtime.build_runtime_envelope(self.REGISTRY, other_source)
+        with mock.patch.object(
+            runtime, "load_origin_main_artifact", return_value=artifact
+        ), mock.patch.object(runtime, "_run_registry_gate"), mock.patch.object(
+            runtime._SSM, "resolve_prod_instance", return_value="i-" + "1" * 17
+        ), mock.patch.object(
+            runtime, "read_runtime_document",
+            side_effect=[self.document({}, "absent"), self.document(same_content, "43")],
+        ), mock.patch.object(
+            runtime, "_write_runtime_document", return_value=True
+        ) as write, mock.patch.object(
+            runtime, "_git_is_ancestor", return_value=True
+        ) as ancestry, self.assertRaisesRegex(
+            SystemExit, "2"
+        ):
+            runtime.cmd_sync_runtime(args)
+        write.assert_called_once_with(mock.ANY, mock.ANY, "absent")
+        ancestry.assert_called_once_with(other_source, self.COMMIT)
+
     def test_sync_conflict_then_exact_current_succeeds_without_second_write(self) -> None:
         artifact = runtime.RegistryArtifact(self.COMMIT, self.REGISTRY)
         args = type("Args", (), {"dry_run": False})()

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -355,9 +355,10 @@
         "def _git_is_ancestor",
         "refusing pricing snapshot downgrade",
         "def cmd_sync_runtime",
-        "inspection.is_current(expected)"
+        "inspection.is_current(expected)",
+        "post.is_current(expected)"
       ],
-      "rationale": "Protected publisher contract: sync-runtime must load the exact current origin/main registry, require HEAD and workspace bytes to match, build a schema/commit/exact-byte digest envelope, and verify the stored readback. Arbitrary local files and unmerged branches cannot become global runtime owners."
+      "rationale": "Protected publisher contract: sync-runtime must load the exact current origin/main registry, require HEAD and workspace bytes to match, build a schema/commit/exact-byte digest envelope, and verify post-write provenance plus exact content with post.is_current. Read-only audit may accept content-current provenance lag, but publisher no-op and post-write success remain strict. Arbitrary local files and unmerged branches cannot become global runtime owners."
     },
     {
       "path": "backend/internal/service/pricing_service_tk_overlay_runtime.go",


### PR DESCRIPTION
## 问题

Pricing publisher 的生产写入曾成功落库，却因两处传输/结果歧义报告失败：完整 runtime envelope 超过 SSM inline stdout 上限而被截断；`psql UPDATE ... RETURNING` 同时输出 row 与 command tag，被 shell 误判为 CAS 冲突。与此同时，无关的 `main` 提交会让内容完全相同的只读审计报告 drift。

## 修复

- 将 runtime readback 改为 metadata + PostgreSQL `xmin` 绑定的 12 KiB chunks，严格校验 marker、base64、分块长度、总长度、UTF-8、JSON 与 exact registry bytes；行版本变化时整轮有界重试，截断或畸形输出 fail closed。
- 将 INSERT/UPDATE CAS 改为 writable CTE，只允许唯一终态 `CAS_APPLIED` / `CAS_CONFLICT`；只有 applied 才进入 exact readback 与 Redis invalidation。
- 保留 publisher 的严格语义：source commit、digest、bytes 全部一致才 no-op；只读 audit 则以 exact digest/bytes 判定内容健康，并把 source commit 差异单独报告为 provenance lag。
- 保留 protected-main-only publication、Git ancestry 防降级、Git revert 可发布以及三次 CAS retry。

## 验证

- Pricing/registry 聚合回归：47/47 通过；覆盖大于 SSM stdout 上限的重组、`xmin` 并发变化、畸形/截断输出、CAS 唯一 marker、exact readback、provenance lag 与内容 drift。
- Publication boundary：7/7 通过。
- Complete registry gate：374 个完整 owner 有效。
- `bash scripts/preflight.sh`：PASS；包括 pricing publisher、migration immutability、ARM release、sentinel、上游冲突面与无 upstream-owned backend deletion 门禁。
- 生产只读 pricing audit：exit 0；protected main `9d1993b434b2c904e60e1704c45412d873d15d14`，registry SHA-256 `f83744be7aae86fc3aafa85b0f2156c6723ad87053017a527eb00669ebc5a4f9`，runtime exact content 一致；runtime source `91cb52e12f7403a9ddf322c16cc2d465a8457e47` 仅为 provenance lag。
- Prod + 全部 deployable Edge 控制面：6/6 healthy。
- Release impact check：`v1.8.151..origin/main` 仍为中风险发布面，建议保持 Edge canary -> prod -> 其余 Edge 的既定顺序；本 PR 只解除 pricing 发布/审计 blocker。

## 审批与边界

`docs/approved/pricing-registry-hot-reload.md` 的修改是有意的批准契约澄清：补充 bounded exact-byte readback，并明确 publisher exact-current 与 read-only audit content-current 的边界；不改变已批准目标。

本 PR 未写生产 pricing runtime，未修改 pricing registry 数据或 VERSION，未创建/推送 tag，未 dispatch release/deploy workflow，未部署或回滚。无 Web surface 变更。

sentinel-registry-reviewed

no-web-impact

ai
