### PR TITLE
feat(modelops): refresh verified model surface

### DIFF
--- a/backend/internal/handler/admin/channel_handler_tk_vertex_models_test.go
+++ b/backend/internal/handler/admin/channel_handler_tk_vertex_models_test.go
@@ -34,8 +34,9 @@ func TestListChannelTypeModels_VertexAIUsesTokenKeyServablePreset(t *testing.T) 
 	require.NotEmpty(t, resp.Data["41"])
 	require.ElementsMatch(t, resp.Data["41"], service.VertexNewAPIChannelServableModelIDs())
 	require.Contains(t, resp.Data["41"], "gemini-2.5-flash")
-	require.Contains(t, resp.Data["41"], "imagen-4.0-fast-generate-001")
 	require.Contains(t, resp.Data["41"], "veo-3.1-generate-001")
+	require.NotContains(t, resp.Data["41"], "imagen-4.0-fast-generate-001",
+		"unknown ch41 accounts must be provisioned with the shared floor, not the public union")
 }
 
 func TestListChannelTypeModels_ManifestChannelsUseTokenKeyPresets(t *testing.T) {

--- a/backend/internal/integration/newapi/fetch_upstream_models.go
+++ b/backend/internal/integration/newapi/fetch_upstream_models.go
@@ -71,8 +71,10 @@ func FetchUpstreamModelList(ctx context.Context, baseURL string, channelType int
 	}
 
 	switch channelType {
+	case newapiconstant.ChannelTypeAli:
+		return fetchOpenAICompatModels(ctx, base+"/compatible-mode/v1/models", key)
 	case newapiconstant.ChannelTypeVolcEngine, newapiconstant.ChannelTypeDoubaoVideo:
-		modelsURL, err := volcEngineModelsURL(base)
+		modelsURL, err := volcEngineModelsURL(channelType, base)
 		if err != nil {
 			return nil, err
 		}
@@ -109,7 +111,10 @@ func FetchUpstreamModelList(ctx context.Context, baseURL string, channelType int
 	}
 }
 
-func volcEngineModelsURL(base string) (string, error) {
+func volcEngineModelsURL(channelType int, base string) (string, error) {
+	if IsXRTokenBaseURL(channelType, base) {
+		return XRTokenBaseURL + "/v1/models", nil
+	}
 	if IsVolcEngineAgentPlanBaseURL(newapiconstant.ChannelTypeVolcEngine, base) {
 		return strings.TrimRight(VolcEngineAgentPlanBaseURL, "/") + "/models", nil
 	}

--- a/backend/internal/integration/newapi/fetch_upstream_models_test.go
+++ b/backend/internal/integration/newapi/fetch_upstream_models_test.go
@@ -54,10 +54,48 @@ func TestFetchUpstreamModelList_TrimsTrailingV1FromBase(t *testing.T) {
 	}
 }
 
+func TestFetchUpstreamModelList_UsesDashScopeCompatibleModelsPath(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/compatible-mode/v1/models" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]string{{"id": "qwen3.7-max"}},
+		})
+	}))
+	t.Cleanup(ts.Close)
+
+	models, err := FetchUpstreamModelList(context.Background(), ts.URL, newapiconstant.ChannelTypeAli, "sk-test")
+	if err != nil {
+		t.Fatalf("FetchUpstreamModelList: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "qwen3.7-max" {
+		t.Fatalf("models = %#v", models)
+	}
+}
+
+func TestVolcEngineModelsURL_ResolvesXRTokenPublicCatalog(t *testing.T) {
+	t.Parallel()
+
+	for _, base := range []string{XRTokenBaseURL, XRTokenBaseURL + "/v1"} {
+		got, err := volcEngineModelsURL(newapiconstant.ChannelTypeDoubaoVideo, base)
+		if err != nil {
+			t.Fatalf("volcEngineModelsURL(%q): %v", base, err)
+		}
+		if got != XRTokenBaseURL+"/v1/models" {
+			t.Fatalf("volcEngineModelsURL(%q) = %q", base, got)
+		}
+	}
+}
+
 func TestVolcEngineModelsURL_ResolvesAgentPlanSpecialBase(t *testing.T) {
 	t.Parallel()
 
-	got, err := volcEngineModelsURL(VolcEngineAgentPlanBaseURL)
+	got, err := volcEngineModelsURL(newapiconstant.ChannelTypeVolcEngine, VolcEngineAgentPlanBaseURL)
 	if err != nil {
 		t.Fatalf("volcEngineModelsURL: %v", err)
 	}

--- a/backend/internal/service/account_model_mapping_preset_tk.go
+++ b/backend/internal/service/account_model_mapping_preset_tk.go
@@ -24,7 +24,7 @@ func AccountModelMappingPresetIDs(ctx context.Context, platform string, channelT
 		ids = kiroModelMappingPresetIDs()
 	case PlatformNewAPI:
 		if channelType == newapiconstant.ChannelTypeVertexAi {
-			ids = supportedCatalogModelIDsForPlatform(PlatformGemini)
+			ids = vertexSharedModelMappingPresetIDs()
 		} else {
 			ids = tkServedModelsManifestPresetIDsByChannelType(channelType)
 		}
@@ -147,6 +147,10 @@ func accountModelMappingOverrideAccounts() []*Account {
 func NewAPIModelMappingPresetIDsForAccount(account *Account) []string {
 	if account == nil {
 		return nil
+	}
+	if account.ChannelType == newapiconstant.ChannelTypeVertexAi {
+		ids, _ := vertexCapabilityProfileModelMappingIDs(account.VertexCapabilityProfile())
+		return ids
 	}
 	if isNewAPIVolcEngineAgentPlanAccount(account) {
 		ids := tkServedModelsManifestPresetIDsForSelector(account.Platform, account.ChannelType, account.GetBaseURL())

--- a/backend/internal/service/account_model_mapping_preset_tk_test.go
+++ b/backend/internal/service/account_model_mapping_preset_tk_test.go
@@ -20,10 +20,13 @@ func TestAccountModelMappingPresetIDs_KiroUsesAdminTestModels(t *testing.T) {
 	require.ElementsMatch(t, kiroAdminTestModelIDsForPresetTest(), ids)
 }
 
-func TestAccountModelMappingPresetIDs_NewAPIVertexMatchesGeminiServable(t *testing.T) {
+func TestAccountModelMappingPresetIDs_NewAPIVertexUsesSharedFloor(t *testing.T) {
 	t.Parallel()
 	ids := AccountModelMappingPresetIDs(context.Background(), PlatformNewAPI, newapiconstant.ChannelTypeVertexAi, nil)
-	require.ElementsMatch(t, supportedCatalogModelIDsForPlatform(PlatformGemini), ids)
+	require.ElementsMatch(t, vertexSharedModelMappingPresetIDs(), ids)
+	require.Subset(t, NewAPIModelDisplayIDsForChannelType(newapiconstant.ChannelTypeVertexAi), ids)
+	require.NotElementsMatch(t, supportedCatalogModelIDsForPlatform(PlatformGemini), ids,
+		"admin empty mapping must not prefill the public union onto an unknown Vertex account")
 }
 
 func TestAccountModelMappingPresetIDs_NewAPIMoonshotUsesManifest(t *testing.T) {

--- a/backend/internal/service/account_model_mapping_reconciler.go
+++ b/backend/internal/service/account_model_mapping_reconciler.go
@@ -109,10 +109,11 @@ func (r *AccountModelMappingReconciler) reconcileAccountBatch(ctx context.Contex
 	mappingBySig := make(map[string]map[string]string)
 	for i := range accounts {
 		account := &accounts[i]
-		want, ok := accountModelMappingForAccount(ctx, account, r.pricing, r.availability, runtime)
-		if !ok || len(want) == 0 {
+		required, ok := accountModelMappingForAccount(ctx, account, r.pricing, r.availability, runtime)
+		if !ok || len(required) == 0 {
 			continue
 		}
+		want := reconciledAccountModelMapping(account, required)
 		if modelMappingsEqual(accountRawModelMapping(account), want) {
 			continue
 		}

--- a/backend/internal/service/account_model_mapping_reconciler_test.go
+++ b/backend/internal/service/account_model_mapping_reconciler_test.go
@@ -118,7 +118,7 @@ func TestAccountModelMappingForAccount_KiroBedrockAndNewAPI(t *testing.T) {
 		ChannelType: newapiconstant.ChannelTypeVertexAi,
 	}, nil, nil, nil)
 	require.True(t, ok)
-	requireIdentityMappingForIDs(t, vertex, NewAPIModelDisplayIDsForChannelType(newapiconstant.ChannelTypeVertexAi))
+	requireIdentityMappingForIDs(t, vertex, vertexSharedModelMappingPresetIDs())
 }
 
 func TestAccountModelMappingRuntimeOverride(t *testing.T) {
@@ -126,7 +126,7 @@ func TestAccountModelMappingRuntimeOverride(t *testing.T) {
 
 	grokID := firstStringSortedForReconcilerTest(t, supportedCatalogModelIDsForPlatform(PlatformGrok))
 	anthropicID := firstStringSortedForReconcilerTest(t, supportedCatalogModelIDsForPlatform(PlatformAnthropic))
-	vertexID := firstStringSortedForReconcilerTest(t, NewAPIModelDisplayIDsForChannelType(newapiconstant.ChannelTypeVertexAi))
+	vertexID := "runtime-only-vertex-model"
 	raw := runtimeOverrideRawForReconcilerTest(t, accountModelMappingRuntimeDoc{
 		Platforms: map[string]map[string]string{
 			"grok":   {grokID: grokID},
@@ -152,7 +152,9 @@ func TestAccountModelMappingRuntimeOverride(t *testing.T) {
 		ChannelType: newapiconstant.ChannelTypeVertexAi,
 	}, nil, nil, runtime)
 	require.True(t, ok)
-	require.Equal(t, map[string]string{vertexID: vertexID}, vertex)
+	requireIdentityMappingForIDs(t, vertex, vertexSharedModelMappingPresetIDs())
+	require.NotContains(t, vertex, vertexID,
+		"runtime channel replacement must not erase the ch41 profile/shared capability contract")
 }
 
 func TestAccountModelMappingReconciler_RewritesDriftedAccountsAcrossPlatforms(t *testing.T) {
@@ -183,6 +185,62 @@ func TestAccountModelMappingReconciler_RewritesDriftedAccountsAcrossPlatforms(t 
 		require.NotEmpty(t, mm)
 	}
 	require.ElementsMatch(t, []int64{1, 2, 3}, touched)
+}
+
+func TestAccountModelMappingReconciler_PreservesCompatibleExtrasAndRepairsRequiredFloor(t *testing.T) {
+	shared := identityModelMapping(vertexSharedModelMappingPresetIDs())
+	account57Mapping := cloneStringMap(shared)
+	account57Mapping["gemini-2.5-pro"] = "gemini-2.5-pro"
+	account57Mapping["gemini-2.5-flash"] = "wrong-target"
+	account57Mapping["compatible-future-model"] = "compatible-future-model"
+
+	acc := &reconcilerAccountStub{
+		byPlatform: map[string][]Account{
+			PlatformNewAPI: {
+				{
+					ID:          57,
+					Platform:    PlatformNewAPI,
+					ChannelType: newapiconstant.ChannelTypeVertexAi,
+					Credentials: map[string]any{
+						VertexCapabilityProfileCredentialKey: vertexCapabilityProfileCoreImagenUltra,
+						"model_mapping":                      modelMappingToAny(account57Mapping),
+					},
+				},
+			},
+		},
+	}
+	r := NewAccountModelMappingReconciler(acc, nil, nil, nil, nil)
+	r.runOnce(context.Background())
+
+	require.Len(t, acc.bulkCalls, 1)
+	require.Equal(t, []int64{57}, acc.bulkCalls[0].ids)
+	got, ok := acc.bulkCalls[0].updates.Credentials["model_mapping"].(map[string]any)
+	require.True(t, ok)
+	profileIDs, known := vertexCapabilityProfileModelMappingIDs(vertexCapabilityProfileCoreImagenUltra)
+	require.True(t, known)
+	for _, id := range profileIDs {
+		require.Equal(t, id, got[id])
+	}
+	require.Equal(t, "gemini-2.5-pro", got["gemini-2.5-pro"],
+		"account 57 Pro result is inconclusive and must survive as a compatible extra")
+	require.Equal(t, "compatible-future-model", got["compatible-future-model"])
+}
+
+func TestReconciledAccountModelMapping_RemovesForbiddenEntries(t *testing.T) {
+	t.Parallel()
+
+	account := &Account{
+		Platform: PlatformAntigravity,
+		Credentials: map[string]any{"model_mapping": map[string]any{
+			"required":                          "wrong-target",
+			"compatible-extra":                  "compatible-extra",
+			"gpt-oss-forbidden-prefix-boundary": "gpt-oss-forbidden-prefix-boundary",
+		}},
+	}
+	got := reconciledAccountModelMapping(account, map[string]string{"required": "required-target"})
+	require.Equal(t, "required-target", got["required"])
+	require.Equal(t, "compatible-extra", got["compatible-extra"])
+	require.NotContains(t, got, "gpt-oss-forbidden-prefix-boundary")
 }
 
 func TestAccountModelMappingReconciler_RuntimeOverrideFromSettings(t *testing.T) {

--- a/backend/internal/service/account_model_mapping_ssot_tk.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk.go
@@ -41,6 +41,7 @@ type AccountModelMappingFloorDoc struct {
 	Platforms                     map[string]map[string]string  `json:"platforms"`
 	NewAPIChannelTypes            map[string]map[string]string  `json:"newapi_channel_types"`
 	AccountOverrides              []AccountModelMappingOverride `json:"account_overrides"`
+	VertexCapabilityProfiles      map[string]map[string]string  `json:"vertex_capability_profiles"`
 	AntigravityScopes             []string                      `json:"antigravity_group_scopes"`
 	ForbiddenModelMappingKeys     map[string][]string           `json:"forbidden_model_mapping_keys,omitempty"`
 	ForbiddenModelMappingPrefixes map[string][]string           `json:"forbidden_model_mapping_prefixes,omitempty"`
@@ -56,7 +57,7 @@ type AccountModelMappingOverride struct {
 	ModelMapping map[string]string `json:"model_mapping"`
 }
 
-const ModelSurfaceBundleSchemaVersion = 3
+const ModelSurfaceBundleSchemaVersion = 4
 
 // ModelSurfaceBundle is the deterministic release artifact consumed by modelops.
 // The digest covers the Go-owned floor projection, not mutable release metadata.
@@ -129,6 +130,10 @@ func accountModelMappingForAccount(ctx context.Context, account *Account, pricin
 		return nil, false
 	}
 	if scope == PlatformNewAPI {
+		if account.ChannelType == newapiconstant.ChannelTypeVertexAi {
+			mapping, _ := vertexModelMappingForAccount(account)
+			return mapping, len(mapping) > 0
+		}
 		if isNewAPIVolcEngineAgentPlanAccount(account) {
 			ids := NewAPIModelMappingPresetIDsForAccount(account)
 			if len(ids) == 0 {
@@ -222,23 +227,13 @@ func AccountModelMappingFloorForOps(ctx context.Context, runtimeRaw string) (*Ac
 		return nil, err
 	}
 	out := &AccountModelMappingFloorDoc{
-		Platforms:          make(map[string]map[string]string),
-		NewAPIChannelTypes: make(map[string]map[string]string),
-		AccountOverrides:   make([]AccountModelMappingOverride, 0),
-		AntigravityScopes:  append([]string(nil), canonicalAntigravityModelScopes...),
-		ForbiddenModelMappingKeys: map[string][]string{
-			// Kiro-backed Claude models remain public under the anthropic vendor,
-			// but native Anthropic accounts must not inherit Kiro-only capability.
-			// Kiro mirror stubs resolve to PlatformKiro before this policy applies.
-			PlatformAnthropic: kiroExclusiveModelIDs(),
-			PlatformAntigravity: append(
-				domain.AntigravityStructuralDeadModelMappingKeys(),
-				domain.AntigravityUnpricedModelMappingKeys()...,
-			),
-		},
-		ForbiddenModelMappingPrefixes: map[string][]string{
-			PlatformAntigravity: {"gpt-oss-"},
-		},
+		Platforms:                     make(map[string]map[string]string),
+		NewAPIChannelTypes:            make(map[string]map[string]string),
+		AccountOverrides:              make([]AccountModelMappingOverride, 0),
+		VertexCapabilityProfiles:      vertexCapabilityProfileMappingsForOps(),
+		AntigravityScopes:             append([]string(nil), canonicalAntigravityModelScopes...),
+		ForbiddenModelMappingKeys:     accountModelMappingForbiddenKeysByScope(),
+		ForbiddenModelMappingPrefixes: accountModelMappingForbiddenPrefixesByScope(),
 	}
 	for _, keys := range out.ForbiddenModelMappingKeys {
 		sort.Strings(keys)
@@ -344,6 +339,25 @@ func AccountModelMappingFloorForOps(ctx context.Context, runtimeRaw string) (*Ac
 
 func normalizeAccountModelMappingOverrideBaseURL(raw string) string {
 	return strings.TrimRight(strings.ToLower(strings.TrimSpace(raw)), "/")
+}
+
+func accountModelMappingForbiddenKeysByScope() map[string][]string {
+	return map[string][]string{
+		// Kiro-backed Claude models remain public under the anthropic vendor,
+		// but native Anthropic accounts must not inherit Kiro-only capability.
+		// Kiro mirror stubs resolve to PlatformKiro before this policy applies.
+		PlatformAnthropic: kiroExclusiveModelIDs(),
+		PlatformAntigravity: append(
+			domain.AntigravityStructuralDeadModelMappingKeys(),
+			domain.AntigravityUnpricedModelMappingKeys()...,
+		),
+	}
+}
+
+func accountModelMappingForbiddenPrefixesByScope() map[string][]string {
+	return map[string][]string{
+		PlatformAntigravity: {"gpt-oss-"},
+	}
 }
 
 func kiroExclusiveModelIDs() []string {
@@ -582,6 +596,33 @@ func accountRawModelMapping(account *Account) map[string]string {
 		return nil
 	}
 	return stringMappingFromRaw(account.Credentials["model_mapping"])
+}
+
+func reconciledAccountModelMapping(account *Account, required map[string]string) map[string]string {
+	current := accountRawModelMapping(account)
+	scope := accountModelMappingScopeForAccount(account)
+	forbiddenKeys := stringSet(accountModelMappingForbiddenKeysByScope()[scope])
+	forbiddenPrefixes := accountModelMappingForbiddenPrefixesByScope()[scope]
+	out := make(map[string]string, len(current)+len(required))
+	for key, target := range current {
+		if _, forbidden := forbiddenKeys[key]; forbidden {
+			continue
+		}
+		blocked := false
+		for _, prefix := range forbiddenPrefixes {
+			if strings.HasPrefix(key, prefix) {
+				blocked = true
+				break
+			}
+		}
+		if !blocked {
+			out[key] = target
+		}
+	}
+	for key, target := range required {
+		out[key] = target
+	}
+	return out
 }
 
 func modelMappingsEqual(a, b map[string]string) bool {

--- a/backend/internal/service/account_model_mapping_ssot_tk_test.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk_test.go
@@ -148,6 +148,21 @@ func TestAccountModelMappingFloorForOps_ExportsAinzyRelayScope(t *testing.T) {
 	requireIdentityMappingForIDs(t, canonical, supportedCatalogModelIDsForPlatform(PlatformOpenAI))
 }
 
+func TestAccountModelMappingFloorForOps_ExportsVertexSharedAndProfileFloors(t *testing.T) {
+	t.Parallel()
+
+	doc, err := AccountModelMappingFloorForOps(context.Background(), "")
+	require.NoError(t, err)
+	shared := doc.NewAPIChannelTypes["41"]
+	requireIdentityMappingForIDs(t, shared, vertexSharedModelMappingPresetIDs())
+	require.Equal(t, vertexCapabilityProfileMappingsForOps(), doc.VertexCapabilityProfiles)
+	for profile, mapping := range doc.VertexCapabilityProfiles {
+		for id, target := range shared {
+			require.Equal(t, target, mapping[id], "profile %s must contain shared model %s", profile, id)
+		}
+	}
+}
+
 func TestAccountModelMappingFloorForOps_ExportsPolicyMetadata(t *testing.T) {
 	t.Parallel()
 	doc, err := AccountModelMappingFloorForOps(context.Background(), "")
@@ -199,6 +214,20 @@ func TestAccountModelMappingFloorForOps_ExportsAccountOverrides(t *testing.T) {
 		)
 	}
 
+}
+
+func TestAccountModelMappingFloorForOps_RuntimeDoesNotShadowVertexProfiles(t *testing.T) {
+	t.Parallel()
+
+	compiled, err := AccountModelMappingFloorForOps(context.Background(), "")
+	require.NoError(t, err)
+	runtime, err := AccountModelMappingFloorForOps(
+		context.Background(),
+		`{"newapi_channel_types":{"41":{"runtime-model":"runtime-target"}}}`,
+	)
+	require.NoError(t, err)
+	require.Equal(t, compiled.NewAPIChannelTypes["41"], runtime.NewAPIChannelTypes["41"])
+	require.Equal(t, compiled.VertexCapabilityProfiles, runtime.VertexCapabilityProfiles)
 }
 
 func TestAccountModelMappingFloorForOps_RuntimeDoesNotShadowAccountOverrides(t *testing.T) {

--- a/backend/internal/service/account_model_mapping_vertex_tk.go
+++ b/backend/internal/service/account_model_mapping_vertex_tk.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"sort"
+	"strings"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
+// VertexCapabilityProfileCredentialKey is the only account capability profile
+// selector in TokenKey. It is intentionally limited to newapi Vertex ch41,
+// whose service-account projects expose different model sets.
+const VertexCapabilityProfileCredentialKey = "vertex_capability_profile"
+
+const (
+	vertexCapabilityProfileCorePro                   = "core-pro"
+	vertexCapabilityProfileCoreProImagenStandard     = "core-pro-imagen-standard"
+	vertexCapabilityProfileCoreProImagenFastStandard = "core-pro-imagen-fast-standard"
+	vertexCapabilityProfileCoreImagenUltra           = "core-imagen-ultra"
+)
+
+var vertexSharedModelMappingIDs = []string{
+	"gemini-2.5-flash",
+	"gemini-2.5-flash-lite",
+	"gemini-3.5-flash-lite",
+	"gemini-3.6-flash",
+	"gemini-embedding-001",
+	"veo-3.1-generate-001",
+}
+
+var vertexCapabilityProfileExtraIDs = map[string][]string{
+	vertexCapabilityProfileCorePro: {
+		"gemini-2.5-pro",
+	},
+	vertexCapabilityProfileCoreProImagenStandard: {
+		"gemini-2.5-pro",
+		"imagen-4.0-generate-001",
+	},
+	vertexCapabilityProfileCoreProImagenFastStandard: {
+		"gemini-2.5-pro",
+		"imagen-4.0-fast-generate-001",
+		"imagen-4.0-generate-001",
+	},
+	vertexCapabilityProfileCoreImagenUltra: {
+		"imagen-4.0-ultra-generate-001",
+	},
+}
+
+// VertexCapabilityProfile returns the normalized ch41 capability selector.
+// It never interprets account identity or name as capability evidence.
+func (a *Account) VertexCapabilityProfile() string {
+	if a == nil || a.Platform != PlatformNewAPI || a.ChannelType != newapiconstant.ChannelTypeVertexAi {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(a.GetCredential(VertexCapabilityProfileCredentialKey)))
+}
+
+func vertexSharedModelMappingPresetIDs() []string {
+	return append([]string(nil), vertexSharedModelMappingIDs...)
+}
+
+func vertexCapabilityProfileModelMappingIDs(profile string) ([]string, bool) {
+	profile = strings.ToLower(strings.TrimSpace(profile))
+	extra, ok := vertexCapabilityProfileExtraIDs[profile]
+	if !ok {
+		ids := vertexSharedModelMappingPresetIDs()
+		sort.Strings(ids)
+		return ids, false
+	}
+	ids := append(vertexSharedModelMappingPresetIDs(), extra...)
+	sort.Strings(ids)
+	return ids, true
+}
+
+func vertexCapabilityProfileMappingsForOps() map[string]map[string]string {
+	profiles := make(map[string]map[string]string, len(vertexCapabilityProfileExtraIDs))
+	for profile := range vertexCapabilityProfileExtraIDs {
+		ids, _ := vertexCapabilityProfileModelMappingIDs(profile)
+		profiles[profile] = identityModelMapping(ids)
+	}
+	return profiles
+}
+
+func vertexModelMappingForAccount(account *Account) (map[string]string, bool) {
+	ids, known := vertexCapabilityProfileModelMappingIDs(account.VertexCapabilityProfile())
+	return identityModelMapping(ids), known
+}

--- a/backend/internal/service/account_model_mapping_vertex_tk_test.go
+++ b/backend/internal/service/account_model_mapping_vertex_tk_test.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVertexCapabilityProfilesPartitionPublicUnion(t *testing.T) {
+	t.Parallel()
+
+	shared := stringSet(vertexSharedModelMappingPresetIDs())
+	publicIDs := NewAPIModelDisplayIDsForChannelType(newapiconstant.ChannelTypeVertexAi)
+	public := stringSet(publicIDs)
+	require.NotEmpty(t, shared)
+	require.NotEmpty(t, public)
+
+	served := make(map[string]struct{}, len(public))
+	for profile, mapping := range vertexCapabilityProfileMappingsForOps() {
+		require.NotContains(t, profile, "47")
+		require.NotContains(t, profile, "57")
+		for id := range shared {
+			require.Equal(t, id, mapping[id], "profile %s must contain shared model %s", profile, id)
+		}
+		for id, target := range mapping {
+			require.Equal(t, id, target, "Vertex profile mappings are identity floors")
+			require.Contains(t, public, id, "profile %s must stay inside public union", profile)
+			served[id] = struct{}{}
+		}
+	}
+	require.ElementsMatch(t, publicIDs, mapKeysForVertexProfileTest(served),
+		"every public ch41 model must have a shared/profile serving path")
+}
+
+func TestVertexCapabilityProfileSelectionIsCh41OnlyAndFailsSafe(t *testing.T) {
+	t.Parallel()
+
+	known := &Account{
+		Platform:    PlatformNewAPI,
+		ChannelType: newapiconstant.ChannelTypeVertexAi,
+		Credentials: map[string]any{VertexCapabilityProfileCredentialKey: " CORE-PRO "},
+	}
+	require.Equal(t, vertexCapabilityProfileCorePro, known.VertexCapabilityProfile())
+	mapping, ok := accountModelMappingForAccount(context.Background(), known, nil, nil, nil)
+	require.True(t, ok)
+	ids, profileKnown := vertexCapabilityProfileModelMappingIDs(vertexCapabilityProfileCorePro)
+	require.True(t, profileKnown)
+	requireIdentityMappingForIDs(t, mapping, ids)
+
+	for _, account := range []*Account{
+		{Platform: PlatformNewAPI, ChannelType: newapiconstant.ChannelTypeVertexAi},
+		{
+			Platform:    PlatformNewAPI,
+			ChannelType: newapiconstant.ChannelTypeVertexAi,
+			Credentials: map[string]any{VertexCapabilityProfileCredentialKey: "unknown-profile"},
+		},
+	} {
+		mapping, ok := accountModelMappingForAccount(context.Background(), account, nil, nil, nil)
+		require.True(t, ok)
+		requireIdentityMappingForIDs(t, mapping, vertexSharedModelMappingPresetIDs())
+	}
+
+	nonVertex := &Account{
+		Platform:    PlatformNewAPI,
+		ChannelType: newapiconstant.ChannelTypeMoonshot,
+		Credentials: map[string]any{VertexCapabilityProfileCredentialKey: vertexCapabilityProfileCorePro},
+	}
+	require.Empty(t, nonVertex.VertexCapabilityProfile())
+	native := &Account{
+		Platform:    PlatformGemini,
+		ChannelType: newapiconstant.ChannelTypeVertexAi,
+		Credentials: map[string]any{VertexCapabilityProfileCredentialKey: vertexCapabilityProfileCorePro},
+	}
+	require.Empty(t, native.VertexCapabilityProfile())
+}
+
+func mapKeysForVertexProfileTest(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	return out
+}

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -10002,5 +10002,91 @@
     "supports_tool_choice": true,
     "supports_vision": true,
     "supports_web_search": true
+  },
+  "glm-5.2-fast-preview": {
+    "litellm_provider": "zhipu",
+    "mode": "chat",
+    "input_cost_per_token": 2.3880597014925373e-06,
+    "output_cost_per_token": 8.35820895522388e-06,
+    "cache_read_input_token_cost": 2.3880597014925373e-06,
+    "source": "Alibaba DashScope official China-mainland pricing https://help.aliyun.com/zh/model-studio/model-pricing, captured 2026-08-14: glm-5.2-fast-preview input ¥16/Mtok, output ¥56/Mtok; CNY/USD=6.7. Pricing and serving both use the configured Alibaba DashScope/Qwen pool (channel_type=17). Overlay stores pre-tax official list rates; TokenKey applies the official_list_base_tax zhipu multiplier at resolution/catalog time. Cache discount not separately listed, so cache-read conservatively equals input."
+  },
+  "qwen3.7-flash": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 2.9850746268656714e-08,
+    "output_cost_per_token": 1.1940298507462686e-07,
+    "cache_read_input_token_cost": 2.9850746268656714e-08,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 32000,
+        "input_cost_per_token": 2.9850746268656714e-08,
+        "output_cost_per_token": 1.1940298507462686e-07,
+        "cache_read_input_token_cost": 2.9850746268656714e-08
+      },
+      {
+        "min_tokens": 32000,
+        "max_tokens": 256000,
+        "input_cost_per_token": 8.955223880597015e-08,
+        "output_cost_per_token": 3.582089552238806e-07,
+        "cache_read_input_token_cost": 8.955223880597015e-08
+      },
+      {
+        "min_tokens": 256000,
+        "max_tokens": 1000000,
+        "input_cost_per_token": 1.791044776119403e-07,
+        "output_cost_per_token": 7.164179104477612e-07,
+        "cache_read_input_token_cost": 1.791044776119403e-07
+      }
+    ],
+    "source": "Alibaba DashScope official China-mainland pricing https://help.aliyun.com/zh/model-studio/model-pricing, captured 2026-08-14; tiered by input tokens (0<Token≤32K in ¥0.2/M out ¥0.8/M; 32K<Token≤256K in ¥0.6/M out ¥2.4/M; 256K<Token≤1M in ¥1.2/M out ¥4.8/M), CNY/USD=6.7. Pre-tax official list rates; overlay official_list_base_tax policy applies at resolution/catalog time. Whole-request input-tier via overlay intervals; cache discount not separately listed, so cache-read conservatively equals input."
+  },
+  "qwen3.7-flash-2026-07-15": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 2.9850746268656714e-08,
+    "output_cost_per_token": 1.1940298507462686e-07,
+    "cache_read_input_token_cost": 2.9850746268656714e-08,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 32000,
+        "input_cost_per_token": 2.9850746268656714e-08,
+        "output_cost_per_token": 1.1940298507462686e-07,
+        "cache_read_input_token_cost": 2.9850746268656714e-08
+      },
+      {
+        "min_tokens": 32000,
+        "max_tokens": 256000,
+        "input_cost_per_token": 8.955223880597015e-08,
+        "output_cost_per_token": 3.582089552238806e-07,
+        "cache_read_input_token_cost": 8.955223880597015e-08
+      },
+      {
+        "min_tokens": 256000,
+        "max_tokens": 1000000,
+        "input_cost_per_token": 1.791044776119403e-07,
+        "output_cost_per_token": 7.164179104477612e-07,
+        "cache_read_input_token_cost": 1.791044776119403e-07
+      }
+    ],
+    "source": "Alibaba DashScope official China-mainland pricing https://help.aliyun.com/zh/model-studio/model-pricing, captured 2026-08-14; tiered by input tokens (0<Token≤32K in ¥0.2/M out ¥0.8/M; 32K<Token≤256K in ¥0.6/M out ¥2.4/M; 256K<Token≤1M in ¥1.2/M out ¥4.8/M), CNY/USD=6.7. Pre-tax official list rates; overlay official_list_base_tax policy applies at resolution/catalog time. Whole-request input-tier via overlay intervals; cache discount not separately listed, so cache-read conservatively equals input. Dated snapshot uses the same official family price as qwen3.7-flash."
+  },
+  "qwen3.8-2.4t-a95b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 1.7910447761194032e-06,
+    "output_cost_per_token": 5.373134328358209e-06,
+    "cache_read_input_token_cost": 1.7910447761194032e-06,
+    "source": "Alibaba DashScope qwen3.8-2.4t-a95b official China-mainland pricing https://help.aliyun.com/zh/model-studio/model-pricing, captured 2026-08-14: input ¥12/Mtok, output ¥36/Mtok; CNY/USD=6.7. Pre-tax official list rates; overlay official_list_base_tax policy applies at resolution/catalog time. Cache discount not separately listed, so cache-read conservatively equals input."
+  },
+  "qwen3.8-max": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 1.7910447761194032e-06,
+    "output_cost_per_token": 5.373134328358209e-06,
+    "cache_read_input_token_cost": 1.7910447761194032e-06,
+    "source": "Alibaba DashScope qwen3.8-max official China-mainland pricing https://help.aliyun.com/zh/model-studio/model-pricing, captured 2026-08-14: input ¥12/Mtok, output ¥36/Mtok; CNY/USD=6.7. Pre-tax official list rates; overlay official_list_base_tax policy applies at resolution/catalog time. Cache discount not separately listed, so cache-read conservatively equals input."
   }
 }

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -314,6 +314,62 @@
       "display": true,
       "notes": "Qwen channel_type=17 pool; served_on account 60 is static mapping evidence, not complete live pool membership. Mapped by tk_024. Tiered (overlay intervals)."
     },
+    "newapi/qwen3.7-flash": {
+      "platform": "newapi",
+      "model_id": "qwen3.7-flash",
+      "served_on": [
+        "60",
+        "72",
+        "77"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3.7-flash",
+      "display": true,
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14. Tiered (overlay intervals)."
+    },
+    "newapi/qwen3.7-flash-2026-07-15": {
+      "platform": "newapi",
+      "model_id": "qwen3.7-flash-2026-07-15",
+      "served_on": [
+        "60",
+        "72",
+        "77"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3.7-flash-2026-07-15",
+      "display": true,
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77 are static mapping evidence, not complete live pool membership. Dated snapshot of qwen3.7-flash. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14. Tiered (overlay intervals)."
+    },
+    "newapi/qwen3.8-2.4t-a95b": {
+      "platform": "newapi",
+      "model_id": "qwen3.8-2.4t-a95b",
+      "served_on": [
+        "60",
+        "72",
+        "77"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3.8-2.4t-a95b",
+      "display": true,
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14."
+    },
+    "newapi/qwen3.8-max": {
+      "platform": "newapi",
+      "model_id": "qwen3.8-max",
+      "served_on": [
+        "60",
+        "72",
+        "77"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3.8-max",
+      "display": true,
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14."
+    },
     "newapi/qwen3.6-flash": {
       "platform": "newapi",
       "model_id": "qwen3.6-flash",
@@ -823,6 +879,20 @@
       "price_key": "glm-5.2",
       "display": true,
       "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); Qianfan console confirms ¥0.008/¥0.028 per 1k in/out; probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
+    },
+    "newapi/glm-5.2-fast-preview": {
+      "platform": "newapi",
+      "model_id": "glm-5.2-fast-preview",
+      "served_on": [
+        "60",
+        "72",
+        "77"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "glm-5.2-fast-preview",
+      "display": true,
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on accounts 60,72,77 are static mapping-evidence anchors, while live account membership comes from runtime DB/admin config. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14. Overlay uses Alibaba DashScope official China-mainland pricing (https://help.aliyun.com/zh/model-studio/model-pricing, captured 2026-08-14; CNY/USD=6.7)."
     },
     "newapi/glm-5.1": {
       "platform": "newapi",

--- a/docs/agent_integration.md
+++ b/docs/agent_integration.md
@@ -504,6 +504,16 @@ explicitly apply reviewed SSOT diffs to live accounts
 - `--bundle`: generated model-surface bundle to apply
 - `--parallel` (default: `3`): parallel SSM workers
 
+#### `manage-account-model-mapping-runtime.py assign-vertex-profiles`
+
+guardedly assign ch41 capability profiles on prod without changing model_mapping
+
+- `--file` (required):
+- `--confirm`: required for writes: yes-assign-vertex-capability-profiles
+- `--dry-run`: verify selectors and print profile-only changes
+- `--prod-instance-id`: pin prod planning and apply to this EC2 instance id
+- `--bundle`: generated model-surface bundle whose profile names are allowed
+
 #### `manage-account-model-mapping-runtime.py sync-runtime`
 
 hot-push a JSON file to runtime settings

--- a/docs/approved/model-surface-activation-contract.md
+++ b/docs/approved/model-surface-activation-contract.md
@@ -27,7 +27,13 @@ projections, not parallel model lists.
    `account_overrides` entry is a full replacement for its property-based
    `account_override:<platform>:<channel_type>:<base_url>` scope and takes
    precedence over the shared platform/channel scope only when all selector
-   properties match the live account. Account IDs are not selector keys.
+   properties match the live account. Account IDs are not selector keys. Vertex
+   `newapi/channel_type=41` is the only capability-profile exception: its public
+   catalog is the verified account union, its shared channel floor is the strict
+   successful intersection, and `vertex_capability_profile` selects a complete
+   named account floor. Missing or unknown profiles fall back to the shared floor
+   and are reported as violations; the selector is never inferred from account ID
+   or name. No other platform/channel may introduce per-account capability profiles.
 2. **Build once.** CI/release generates a deterministic, checksummed model-surface
    bundle from the Go owner. Rollout tools consume that bundle and do not compile Go
    or discover a source checkout at rollout time.
@@ -60,6 +66,10 @@ projections, not parallel model lists.
   producing a false-positive drift finding; same-platform/channel accounts with a
   different base URL continue to use the shared floor.
 - Routine apply preserves compatible extras and removes forbidden entries.
+- Guarded ch41 profile assignment is prod-only, verifies
+  `id + name + platform + channel_type + current profile`, writes only
+  `vertex_capability_profile`, performs no empty write, and verifies the read-back;
+  account mapping changes remain a separate activation/apply operation.
 - Activation refuses missing/stale/mismatched probe or pricing evidence before any
   write, defaults to dry-run, and requires an explicit confirmation phrase to write.
 - Admin model option tests assert the exact cross-platform response contract.
@@ -102,8 +112,9 @@ must bind the exact current and target digests, cover every added/retargeted
 mapping, and be no older than 24 hours. The probe result must come from a real
 account path; `account_scope` must exactly match the bundle mapping scope and
 must be a valid projection of `account_platform` (including explicit Anthropic
-transport scopes such as `kiro`, exact `newapi_channel_type:*` scopes, and
-property-based `account_override:*` scopes). For an account override scope,
+transport scopes such as `kiro`, exact `newapi_channel_type:*` scopes,
+exact `newapi_vertex_profile:*` scopes, and property-based
+`account_override:*` scopes). For an account override scope,
 `account_platform` and normalized `account_base_url` must match the bundle
 selector. `account_id` remains provenance for the real probe path only; it is not
 used to select an override. The account probe derives these fields from the

--- a/docs/global/agent-reference.md
+++ b/docs/global/agent-reference.md
@@ -62,7 +62,7 @@ Customer-visible serving is gated by three layers that must stay aligned on **pr
 
 1. **可展示** — `supported*CatalogModels` / `ServableClientFacingIDs` (public `/models`, `/pricing`, menu).
 2. **已定价** — channel pricing + `tk_pricing_overlay.json` (zero-price leak is an ops alert, not a customer block).
-3. **可服务 + prod 账号放行** — prod `accounts.credentials.model_mapping` (plus optional runtime replacement in `settings.tk_account_model_mapping_runtime`) must match the compiled Go floor for each managed platform. Property-selected bundle overrides for the VolcEngine Agent Plan (`platform + channel_type + base_url`) take precedence over the shared newapi channel floor; account IDs are not used as selectors.
+3. **可服务 + prod 账号放行** — prod `accounts.credentials.model_mapping` (plus optional runtime replacement in `settings.tk_account_model_mapping_runtime`) must match the compiled Go floor for each managed platform. Property-selected bundle overrides for the VolcEngine Agent Plan (`platform + channel_type + base_url`) take precedence over the shared newapi channel floor; account IDs are not used as selectors. Vertex `newapi/channel_type=41` is the only account-varying capability scope: its public catalog is the verified union, its shared floor is the strict successful intersection, and `vertex_capability_profile` selects a complete named profile floor. Missing/unknown profiles fail safe to the shared floor and are configuration violations; other platform/channel scopes remain shared.
 
 **Official upstream aliases are displayable when priced and servable.** For every
 TokenKey-managed native platform and newapi `channel_type`, if the provider's
@@ -79,7 +79,10 @@ python3 ops/pricing/manage-account-model-mapping-runtime.py check-accounts --jso
 ```
 
 Default scope is prod only. A violation is a yellow configuration-drift finding:
-review the Go-SSOT-derived diff and converge prod via:
+review the Go-SSOT-derived diff and converge prod via. For ch41, assign the
+reviewed profile first with the separate prod-only `assign-vertex-profiles`
+dry-run/confirmed flow; that operation writes only the profile property and does
+not change `model_mapping` in the same transaction.
 
 ```bash
 python3 ops/pricing/manage-account-model-mapping-runtime.py apply-accounts --target prod --dry-run

--- a/ops/pricing/README.md
+++ b/ops/pricing/README.md
@@ -35,6 +35,7 @@ hand-maintained empirical sets in the same file.
 | `reconcile-served-models.py` | Compatibility wrapper for `modelops.py`. New runbooks should call `modelops.py`. |
 | `model-surface-bundle.json` | Deterministic, checksummed release projection generated once from the Go model owner and published as a release asset. |
 | `model_surface_bundle.py` | Shared stdlib-only schema and digest validator used by rollout tools; it owns no model list. |
+| `model-surface-refresh-report.py` | Offline/read-only evidence normalizer. It consumes saved account inventory, authoritative candidate discovery, direct-upstream/gateway/traffic evidence, the bundle, pricing overlay, and reprobe ledger; emits per-shared-scope deltas plus the Vertex ch41 intersection/union/profile clusters. It never probes or writes. |
 | `manage-account-model-mapping-runtime.py` | Consumes a generated bundle without compiling Go, hot-pushes optional runtime replacement scopes, checks required floor + forbidden policy while preserving compatible extras, keeps Edge diagnostics available, and applies reviewed account/group diffs only through explicit confirmation. |
 | `pricing-registry-sensor.py` | Compares provider/LiteLLM evidence with the complete registry and prepares a registry-only draft PR candidate. It never publishes or changes serving. |
 | `manage-overlay-runtime.py` | Publishes or audits the exact protected-main registry envelope. `sync-runtime` is reserved for the protected publisher workflow; operators use `check` for read-only drift inspection. |
@@ -104,6 +105,31 @@ It logs exactly what it skipped, for human review:
   logged); the query additionally requires real generation (tokens / image / video)
   so a `$0` placeholder row never counts as proof.
 
+## Offline model-surface refresh report
+
+Keep discovery and probing in the existing platform-specific tools. Once their
+outputs are saved, normalize them without network or runtime writes:
+
+```bash
+python3 ops/pricing/model-surface-refresh-report.py generate \
+  --inventory /tmp/model-account-inventory.json \
+  --candidates /tmp/model-candidates.json \
+  --raw-probe /tmp/raw-provider-results.json \
+  --gateway-probe /tmp/gateway-results.json \
+  --traffic-evidence /tmp/traffic.tsv \
+  --format text
+
+python3 ops/pricing/model-surface-refresh-report.py --selftest
+```
+
+Candidate JSON should carry `observed_at`, `authoritative: true`, and a `scopes`
+object. JSON probe rows should carry `observed_at`; gateway successes additionally
+need matching `account_id` and `usage_account_id`. Legacy TSV inputs use the file
+mtime as their evidence time and therefore expire after 24 hours. Missing/stale
+candidate authority, non-ch41 account divergence, inconclusive 429/5xx, local
+mapping-floor rejection, missing price, and unapproved paid-media evidence all
+block `proposed_add` rather than inferring support.
+
 ## Modelops plan and activation
 
 **Operator entry:** skill `tokenkey-modelops-planner` (`.cursor/skills/tokenkey-modelops-planner/SKILL.md`).
@@ -164,7 +190,12 @@ align on prod: catalog allowlists, active registry/scoped channel rows, and prod
 bundle contains `account_overrides`, the property-based
 `account_override:<platform>:<channel_type>:<base_url>` scope overrides the
 shared platform/channel floor only when all selector metadata matches; account IDs
-are not used as override selectors.
+are not used as override selectors. Vertex `newapi/channel_type=41` is the one
+capability-profile exception: public display is the verified union, the shared
+channel floor is the strict successful intersection, and a normalized
+`vertex_capability_profile` selects a complete named profile floor. Missing or
+unknown profiles use the shared floor and produce a check violation; no other
+platform/channel has account-level profiles.
 Post-release diagnostics use `check-accounts` **without** `--include-edges`;
 its expected mappings and forbidden policy metadata come from the selected
 checksummed bundle.
@@ -205,7 +236,18 @@ python3 ops/pricing/manage-account-model-mapping-runtime.py check-accounts --jso
 # explicit modelops/model-activation floor precheck; never a generic deploy/rollback dependency:
 python3 ops/pricing/manage-account-model-mapping-runtime.py release-gate
 
-# after reviewing the diff, explicitly apply account/group changes:
+# ch41 only: verify id/name/platform/channel/current-profile, then assign the
+# profile property on prod without changing model_mapping in the same operation:
+python3 ops/pricing/manage-account-model-mapping-runtime.py assign-vertex-profiles \
+  --file /tmp/vertex-profile-assignments.json \
+  --bundle /tmp/model-surface-bundle.json \
+  --dry-run
+python3 ops/pricing/manage-account-model-mapping-runtime.py assign-vertex-profiles \
+  --file /tmp/vertex-profile-assignments.json \
+  --bundle /tmp/model-surface-bundle.json \
+  --confirm yes-assign-vertex-capability-profiles
+
+# after reviewing the separate mapping diff, explicitly apply account/group changes:
 python3 ops/pricing/manage-account-model-mapping-runtime.py apply-accounts \
   --target prod \
   --bundle /tmp/model-surface-bundle.json \

--- a/ops/pricing/README.md
+++ b/ops/pricing/README.md
@@ -123,10 +123,12 @@ python3 ops/pricing/model-surface-refresh-report.py --selftest
 ```
 
 Candidate JSON should carry `observed_at`, `authoritative: true`, and a `scopes`
-object. JSON probe rows should carry `observed_at`; gateway successes additionally
-need matching `account_id` and `usage_account_id`. Legacy TSV inputs use the file
-mtime as their evidence time and therefore expire after 24 hours. Missing/stale
-candidate authority, non-ch41 account divergence, inconclusive 429/5xx, local
+object. JSON probe rows should carry `observed_at`; a promotion requires direct and
+gateway success for the same active account, and the gateway row additionally needs
+matching `account_id` and `usage_account_id`. Legacy TSV inputs cannot prove that
+same-account join and therefore remain classification-only; their file mtime is used
+as the evidence time and expires after 24 hours. Missing/stale
+candidate authority, non-ch41 account divergence, inconclusive 401/403/429/5xx, local
 mapping-floor rejection, missing price, and unapproved paid-media evidence all
 block `proposed_add` rather than inferring support.
 

--- a/ops/pricing/manage-account-model-mapping-runtime.py
+++ b/ops/pricing/manage-account-model-mapping-runtime.py
@@ -74,6 +74,8 @@ _bundle_spec.loader.exec_module(_BUNDLE)
 PSQL = "sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1"
 REDISCLI = "env -u REDISCLI_AUTH sudo docker exec tokenkey-redis redis-cli"
 APPLY_CONFIRM = "yes-apply-account-model-mapping"
+VERTEX_PROFILE_ASSIGN_CONFIRM = "yes-assign-vertex-capability-profiles"
+VERTEX_PROFILE_CREDENTIAL_KEY = "vertex_capability_profile"
 DEFAULT_BUNDLE_PATH = _BUNDLE.DEFAULT_BUNDLE_PATH
 BUNDLE_SCHEMA_VERSION = _BUNDLE.SCHEMA_VERSION
 DEFAULT_RUNTIME_TARGET = "all-deployable-and-prod"
@@ -92,7 +94,8 @@ SELECT jsonb_build_object(
       'model_mapping', a.credentials->'model_mapping',
       'mirror_platform', a.credentials->>'mirror_platform',
       'base_url', a.credentials->>'base_url',
-      'auth_mode', a.credentials->>'auth_mode'
+      'auth_mode', a.credentials->>'auth_mode',
+      'vertex_capability_profile', a.credentials->>'vertex_capability_profile'
     ) ORDER BY a.platform, a.id)
     FROM accounts a
     WHERE a.deleted_at IS NULL
@@ -529,7 +532,7 @@ def _forbidden_mapping_entries(
     mapping: dict[str, str],
     floor: dict[str, Any],
 ) -> list[str]:
-    if scope.startswith("newapi_channel_type:"):
+    if scope.startswith("newapi_channel_type:") or scope.startswith("newapi_vertex_profile:"):
         scope = "newapi"
     forbidden_by_scope = floor.get("forbidden_model_mapping_keys") or {}
     forbidden = set(forbidden_by_scope.get(scope) or [])
@@ -580,6 +583,12 @@ def _desired_mapping_for_account(
     scope = _account_scope(row)
     if scope == "newapi":
         ct = str(row.get("channel_type") or "").strip()
+        if ct == "41":
+            profile = str(row.get("vertex_capability_profile") or "").strip().lower()
+            profiles = floor.get("vertex_capability_profiles") or {}
+            mapping = profiles.get(profile) if profile else None
+            if isinstance(mapping, dict):
+                return mapping, f"newapi_vertex_profile:{profile}"
         mapping = (floor.get("newapi_channel_types") or {}).get(ct)
         return mapping if isinstance(mapping, dict) else None, f"newapi_channel_type:{ct or '0'}"
     mapping = (floor.get("platforms") or {}).get(scope)
@@ -631,6 +640,27 @@ def _format_mapping_diff_reason(scope: str, diff: dict[str, Any]) -> str:
     if diff["compatible_extra_keys"]:
         parts.append("preserved_extras: " + _short_list(diff["compatible_extra_keys"]))
     return "; ".join(parts)
+
+
+def _vertex_profile_issue(row: dict[str, Any], floor: dict[str, Any]) -> str | None:
+    if str(row.get("platform") or "").strip().lower() != "newapi":
+        return None
+    try:
+        channel_type = int(row.get("channel_type") or 0)
+    except (TypeError, ValueError):
+        return None
+    if channel_type != 41:
+        return None
+    profile = str(row.get("vertex_capability_profile") or "").strip().lower()
+    profiles = floor.get("vertex_capability_profiles") or {}
+    if not profile:
+        return "missing vertex_capability_profile; fail-safe shared channel_type 41 floor applies"
+    if profile not in profiles:
+        return (
+            f"unknown vertex_capability_profile {profile!r}; "
+            "fail-safe shared channel_type 41 floor applies"
+        )
+    return None
 
 
 def _account_plan(
@@ -723,6 +753,12 @@ def _runtime_policy_conflict(doc: dict[str, Any], floor: dict[str, Any]) -> str 
 
     effective_channel_types = floor.get("newapi_channel_types") or {}
     for channel_type in (doc.get("newapi_channel_types") or {}):
+        if channel_type == "41":
+            conflicts.append(
+                "newapi_channel_types.41: ch41 is owned by the shared/profile capability contract; "
+                "runtime channel replacement is not allowed"
+            )
+            continue
         desired = effective_channel_types.get(channel_type)
         if not isinstance(desired, dict):
             continue
@@ -774,10 +810,20 @@ def _check_target(
     floor = _load_effective_floor(runtime_raw)
     for row in bundle.get("accounts") or []:
         plan = _account_plan(row, floor)
-        if not plan:
-            continue
-        plan["target"] = label
-        violations.append(plan)
+        if plan:
+            plan["target"] = label
+            violations.append(plan)
+        profile_issue = _vertex_profile_issue(row, floor)
+        if profile_issue:
+            violations.append({
+                "target": label,
+                "kind": "vertex_capability_profile",
+                "id": row.get("id"),
+                "name": row.get("name"),
+                "platform": row.get("platform"),
+                "scope": "newapi_channel_type:41",
+                "reason": profile_issue,
+            })
     for row in bundle.get("antigravity_groups") or []:
         reason = _group_violation(row, floor)
         if reason:
@@ -852,6 +898,186 @@ def _ids_sql(ids: list[int]) -> str:
 def _json_b64(doc: Any) -> str:
     raw = json.dumps(doc, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return base64.b64encode(raw).decode("ascii")
+
+
+def _load_vertex_profile_assignments(path: Path, floor: dict[str, Any]) -> list[dict[str, Any]]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as e:
+        fail(f"cannot read {path}: {e}")
+    except json.JSONDecodeError as e:
+        fail(f"invalid JSON {path}: {e}")
+    if not isinstance(raw, dict) or set(raw) != {"assignments"}:
+        fail("profile assignment file must contain only an assignments array")
+    assignments = raw.get("assignments")
+    if not isinstance(assignments, list) or not assignments:
+        fail("profile assignment file assignments must be a non-empty array")
+    profiles = floor.get("vertex_capability_profiles") or {}
+    out: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for index, assignment in enumerate(assignments):
+        label = f"assignments[{index}]"
+        if not isinstance(assignment, dict):
+            fail(f"{label} must be an object")
+        expected_fields = {"id", "name", "platform", "channel_type", "current_profile", "profile"}
+        if set(assignment) != expected_fields:
+            fail(f"{label} must contain exactly: " + ", ".join(sorted(expected_fields)))
+        try:
+            account_id = int(assignment.get("id"))
+            channel_type = int(assignment.get("channel_type"))
+        except (TypeError, ValueError):
+            fail(f"{label}: id and channel_type must be integers")
+        if account_id <= 0 or account_id in seen:
+            fail(f"{label}: id must be unique and positive")
+        seen.add(account_id)
+        name = str(assignment.get("name") or "").strip()
+        platform = str(assignment.get("platform") or "").strip().lower()
+        current_profile = str(assignment.get("current_profile") or "").strip().lower()
+        profile = str(assignment.get("profile") or "").strip().lower()
+        if not name:
+            fail(f"{label}: name must be non-empty")
+        if platform != "newapi" or channel_type != 41:
+            fail(f"{label}: selector must be platform=newapi and channel_type=41")
+        if profile not in profiles:
+            fail(f"{label}: unknown Vertex capability profile {profile!r}")
+        if current_profile and current_profile not in profiles:
+            fail(f"{label}: current_profile {current_profile!r} is not a known profile")
+        out.append({
+            "id": account_id,
+            "name": name,
+            "platform": platform,
+            "channel_type": channel_type,
+            "current_profile": current_profile,
+            "profile": profile,
+        })
+    return sorted(out, key=lambda row: row["id"])
+
+
+def _collect_vertex_profile_assignment_plan(
+    label: str,
+    region: str,
+    instance_id: str,
+    assignments: list[dict[str, Any]],
+) -> dict[str, Any]:
+    live = _run_check_sql_json(region, instance_id, label)
+    rows = {int(row.get("id") or 0): row for row in (live.get("accounts") or [])}
+    changes: list[dict[str, Any]] = []
+    for assignment in assignments:
+        account_id = assignment["id"]
+        row = rows.get(account_id)
+        if row is None:
+            raise RuntimeError(f"account {account_id}: not found in active managed prod inventory")
+        actual_name = str(row.get("name") or "")
+        actual_platform = str(row.get("platform") or "").strip().lower()
+        try:
+            actual_channel_type = int(row.get("channel_type") or 0)
+        except (TypeError, ValueError):
+            actual_channel_type = 0
+        actual_profile = str(row.get(VERTEX_PROFILE_CREDENTIAL_KEY) or "").strip().lower()
+        expected_selector = (
+            assignment["name"], assignment["platform"], assignment["channel_type"],
+            assignment["current_profile"],
+        )
+        actual_selector = (actual_name, actual_platform, actual_channel_type, actual_profile)
+        if actual_selector != expected_selector:
+            raise RuntimeError(
+                f"account {account_id}: selector drift; expected "
+                f"name={assignment['name']!r} platform={assignment['platform']} "
+                f"channel_type={assignment['channel_type']} current_profile={assignment['current_profile']!r}; "
+                f"got name={actual_name!r} platform={actual_platform} "
+                f"channel_type={actual_channel_type} current_profile={actual_profile!r}"
+            )
+        if actual_profile == assignment["profile"]:
+            continue
+        changes.append({**assignment, "target": label})
+    return {
+        "target": label,
+        "region": region,
+        "instance_id": instance_id,
+        "changes": changes,
+    }
+
+
+def _render_vertex_profile_assignment_sql(plan: dict[str, Any]) -> str:
+    changes = plan.get("changes") or []
+    if not changes:
+        return ""
+    lines = ["BEGIN;", "SET LOCAL statement_timeout = '30s';"]
+    changed_ids: list[int] = []
+    for change in changes:
+        payload_b64 = _json_b64({VERTEX_PROFILE_CREDENTIAL_KEY: change["profile"]})
+        expected_name_b64 = base64.b64encode(change["name"].encode("utf-8")).decode("ascii")
+        current_profile_b64 = base64.b64encode(change["current_profile"].encode("utf-8")).decode("ascii")
+        account_id = int(change["id"])
+        changed_ids.append(account_id)
+        lines.extend([
+            "DO $tk_vertex_profile$ DECLARE changed bigint; BEGIN ",
+            "UPDATE accounts SET credentials = COALESCE(credentials, '{}'::jsonb) "
+            f"|| convert_from(decode('{payload_b64}', 'base64'), 'UTF8')::jsonb, updated_at = NOW() "
+            f"WHERE id = {account_id} AND deleted_at IS NULL AND status = 'active' "
+            "AND platform = 'newapi' AND channel_type = 41 "
+            f"AND name = convert_from(decode('{expected_name_b64}', 'base64'), 'UTF8') "
+            f"AND COALESCE(credentials->>'{VERTEX_PROFILE_CREDENTIAL_KEY}', '') = "
+            f"convert_from(decode('{current_profile_b64}', 'base64'), 'UTF8'); ",
+            "GET DIAGNOSTICS changed = ROW_COUNT; "
+            f"IF changed <> 1 THEN RAISE EXCEPTION 'account {account_id} selector changed before profile assignment'; "
+            "END IF; END $tk_vertex_profile$;",
+        ])
+    payload = json.dumps({"account_ids": sorted(changed_ids)}, separators=(",", ":"))
+    lines.extend([
+        "INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload) "
+        f"VALUES ('account_bulk_changed', NULL, NULL, '{payload}'::jsonb);",
+        "COMMIT;",
+        "SELECT 'PROFILE_ASSIGN_OK' AS status;",
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def _apply_vertex_profile_assignment_plan(plan: dict[str, Any]) -> str:
+    sql = _render_vertex_profile_assignment_sql(plan)
+    if not sql:
+        return "PROFILE_ASSIGN_OK"
+    shell = (
+        "set -euo pipefail\n"
+        f"PSQL='{PSQL}'\n"
+        f"echo {base64.b64encode(sql.encode('utf-8')).decode('ascii')} | base64 -d | $PSQL\n"
+        "echo PROFILE_ASSIGN_OK\n"
+    )
+    return _ssm_run_shell_b64_region(
+        plan["region"], plan["instance_id"],
+        base64.b64encode(shell.encode("utf-8")).decode("ascii"),
+        "assign Vertex capability profiles",
+    )
+
+
+def cmd_assign_vertex_profiles(args) -> int:
+    _set_bundle_path(getattr(args, "bundle", None))
+    floor = _load_bundle()["account_model_mapping"]
+    assignments = _load_vertex_profile_assignments(args.file, floor)
+    if not args.dry_run and args.confirm != VERTEX_PROFILE_ASSIGN_CONFIRM:
+        fail(f"assign-vertex-profiles requires --confirm {VERTEX_PROFILE_ASSIGN_CONFIRM}")
+    target = _resolve_apply_targets("prod", prod_instance_id=getattr(args, "prod_instance_id", None))[0]
+    plan = _collect_vertex_profile_assignment_plan(*target, assignments)
+    report = {
+        "bundle": str(_BUNDLE_PATH),
+        "target": "prod",
+        "assignment_count": len(assignments),
+        "change_count": len(plan["changes"]),
+        "changes": plan["changes"],
+    }
+    if args.dry_run or not plan["changes"]:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+        return 0
+    out = _apply_vertex_profile_assignment_plan(plan)
+    if "PROFILE_ASSIGN_OK" not in out:
+        raise RuntimeError("remote SQL did not report PROFILE_ASSIGN_OK")
+    verified = _collect_vertex_profile_assignment_plan(*target, [
+        {**change, "current_profile": change["profile"]} for change in plan["changes"]
+    ])
+    if verified["changes"]:
+        raise RuntimeError("post-assignment read-back still reports profile changes")
+    print(json.dumps({**report, "applied": True, "verified": True}, ensure_ascii=False, indent=2))
+    return 0
 
 
 def _render_apply_sql(plan: dict[str, Any]) -> str:
@@ -1482,7 +1708,12 @@ def cmd_selftest(_args) -> int:
             },
         },
         "newapi_channel_types": {
+            "41": {"vertex-shared": "vertex-shared"},
             "45": {"generic-model": "generic-model"},
+        },
+        "vertex_capability_profiles": {
+            "core-pro": {"vertex-shared": "vertex-shared", "vertex-pro": "vertex-pro"},
+            "core-ultra": {"vertex-shared": "vertex-shared", "vertex-ultra": "vertex-ultra"},
         },
         "account_overrides": [
             {
@@ -1578,6 +1809,36 @@ def cmd_selftest(_args) -> int:
         "type": "oauth",
         "model_mapping": {},
     }, floor)
+    vertex_known = {
+        "id": 47,
+        "name": "vertex-47",
+        "platform": "newapi",
+        "type": "apikey",
+        "channel_type": 41,
+        "vertex_capability_profile": "core-pro",
+        "model_mapping": {
+            "vertex-shared": "vertex-shared",
+            "vertex-pro": "vertex-pro",
+        },
+    }
+    assert _desired_mapping_for_account(vertex_known, floor)[1] == "newapi_vertex_profile:core-pro"
+    assert _account_plan(vertex_known, floor) is None
+    vertex_missing = dict(vertex_known, vertex_capability_profile="", model_mapping={"vertex-shared": "vertex-shared"})
+    assert _desired_mapping_for_account(vertex_missing, floor)[1] == "newapi_channel_type:41"
+    assert _vertex_profile_issue(vertex_missing, floor)
+    vertex_unknown = dict(vertex_missing, vertex_capability_profile="unknown")
+    assert _vertex_profile_issue(vertex_unknown, floor)
+    vertex57 = dict(
+        vertex_known,
+        id=57,
+        vertex_capability_profile="core-ultra",
+        model_mapping={
+            "vertex-shared": "vertex-shared",
+            "vertex-ultra": "vertex-ultra",
+            "vertex-pro": "vertex-pro",
+        },
+    )
+    assert _account_plan(vertex57, floor) is None
     compatible_extra_row = {
         "id": 3,
         "platform": "openai",
@@ -1662,10 +1923,51 @@ def cmd_selftest(_args) -> int:
     assert "LOCK TABLE settings IN SHARE ROW EXCLUSIVE MODE" in guarded_sql
     assert f"{SETTING_KEY} appeared before activation write" in guarded_sql
     assert guarded_sql.index("LOCK TABLE settings") < guarded_sql.index("UPDATE accounts")
+    with tempfile.TemporaryDirectory() as profile_temp_dir:
+        profile_path = Path(profile_temp_dir) / "vertex-profiles.json"
+        profile_path.write_text(json.dumps({"assignments": [{
+            "id": 47,
+            "name": "vertex-47",
+            "platform": "newapi",
+            "channel_type": 41,
+            "current_profile": "",
+            "profile": "core-pro",
+        }]}), encoding="utf-8")
+        profile_assignments = _load_vertex_profile_assignments(profile_path, floor)
+        original_run_check_sql_json = globals()["_run_check_sql_json"]
+        globals()["_run_check_sql_json"] = lambda _region, _instance_id, _label: {
+            "runtime_setting": None,
+            "accounts": [{
+                "id": 47,
+                "name": "vertex-47",
+                "platform": "newapi",
+                "channel_type": 41,
+                "vertex_capability_profile": None,
+                "model_mapping": {"vertex-shared": "vertex-shared"},
+            }],
+            "antigravity_groups": [],
+        }
+        try:
+            profile_plan = _collect_vertex_profile_assignment_plan(
+                "prod", "test-region", "i-test", profile_assignments)
+            assert len(profile_plan["changes"]) == 1
+            profile_sql = _render_vertex_profile_assignment_sql(profile_plan)
+            assert VERTEX_PROFILE_CREDENTIAL_KEY in profile_sql
+            assert "model_mapping" not in profile_sql
+            assert "name = convert_from" in profile_sql
+            assert "channel_type = 41" in profile_sql
+            assert profile_sql.count("'account_bulk_changed'") == 1
+            assert '"account_ids":[47]' in profile_sql
+            assert "PROFILE_ASSIGN_OK" in profile_sql
+        finally:
+            globals()["_run_check_sql_json"] = original_run_check_sql_json
     assert _group_violation({"scopes": ["gemini_text"]}, floor)
     assert _group_violation({"scopes": ["claude", "gemini_text", "gemini_image"]}, floor) is None
     assert _runtime_setting_violation('{"platforms":{"grok":{}}}')
     assert _runtime_setting_violation('{"platforms":{"grok":{"grok":"grok-4.3"}}}') is None
+    assert _runtime_setting_violation(
+        '{"newapi_channel_types":{"41":{"vertex-shared":"vertex-shared"}}}'
+    )
     assert _runtime_setting_violation(None) is None
     effective_floor = _load_effective_floor(None)
     real_policy_samples: list[tuple[str, str]] = []
@@ -1835,6 +2137,11 @@ def cmd_selftest(_args) -> int:
         else:
             raise AssertionError("release-gate accepted edge scope")
     assert parser.parse_args(["check-accounts", "--include-edges"]).include_edges
+    profile_args = parser.parse_args([
+        "assign-vertex-profiles", "--file", "profiles.json", "--dry-run",
+    ])
+    assert profile_args.dry_run
+    assert not hasattr(profile_args, "target"), "profile assignment must be prod-only with no target escape hatch"
     selected_bundle_args = ["--bundle", str(DEFAULT_BUNDLE_PATH)]
     assert parser.parse_args(["validate", "--file", "runtime.json", *selected_bundle_args]).bundle
     assert parser.parse_args(["sync-runtime", "--file", "runtime.json", *selected_bundle_args]).bundle
@@ -1935,6 +2242,15 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--activation-floor-sha256", help=argparse.SUPPRESS)
     sp.add_argument("--bundle", help="generated model-surface bundle to apply")
     sp.add_argument("--parallel", type=int, default=3, help="parallel SSM workers")
+    sp = sub.add_parser(
+        "assign-vertex-profiles",
+        help="guardedly assign ch41 capability profiles on prod without changing model_mapping",
+    )
+    sp.add_argument("--file", type=Path, required=True)
+    sp.add_argument("--confirm", help=f"required for writes: {VERTEX_PROFILE_ASSIGN_CONFIRM}")
+    sp.add_argument("--dry-run", action="store_true", help="verify selectors and print profile-only changes")
+    sp.add_argument("--prod-instance-id", help="pin prod planning and apply to this EC2 instance id")
+    sp.add_argument("--bundle", help="generated model-surface bundle whose profile names are allowed")
     sp = sub.add_parser("sync-runtime", help="hot-push a JSON file to runtime settings")
     sp.add_argument("--file", type=Path, required=True)
     sp.add_argument("--target", default=DEFAULT_RUNTIME_TARGET, help="prod, edge:<id>, or all-deployable-and-prod")
@@ -1964,6 +2280,8 @@ def main() -> int:
         return cmd_release_gate(args)
     if args.cmd == "apply-accounts":
         return cmd_apply_accounts(args)
+    if args.cmd == "assign-vertex-profiles":
+        return cmd_assign_vertex_profiles(args)
     if args.cmd == "sync-runtime":
         return cmd_sync_runtime(args)
     if args.cmd == "clear-runtime":

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": 3,
-  "floor_sha256": "c88637d9acdff48026bcfe5b62ee443de49eca431ba07391279b0b3d308fd353",
+  "schema_version": 4,
+  "floor_sha256": "09eb39ad73902a2f01190389fa9ae66a2f81553aa72c6cd88000ae0a3e00968f",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -231,6 +231,7 @@
         "glm-5": "glm-5",
         "glm-5.1": "glm-5.1",
         "glm-5.2": "glm-5.2",
+        "glm-5.2-fast-preview": "glm-5.2-fast-preview",
         "qwen-max": "qwen-max",
         "qwen-plus": "qwen-plus",
         "qwen-turbo": "qwen-turbo",
@@ -241,12 +242,16 @@
         "qwen3-coder-plus": "qwen3-coder-plus",
         "qwen3.6-27b": "qwen3.6-27b",
         "qwen3.6-flash": "qwen3.6-flash",
+        "qwen3.7-flash": "qwen3.7-flash",
+        "qwen3.7-flash-2026-07-15": "qwen3.7-flash-2026-07-15",
         "qwen3.7-max": "qwen3.7-max",
         "qwen3.7-max-2026-05-17": "qwen3.7-max-2026-05-17",
         "qwen3.7-max-2026-05-20": "qwen3.7-max-2026-05-20",
         "qwen3.7-max-2026-06-08": "qwen3.7-max-2026-06-08",
         "qwen3.7-max-preview": "qwen3.7-max-preview",
-        "qwen3.7-plus": "qwen3.7-plus"
+        "qwen3.7-plus": "qwen3.7-plus",
+        "qwen3.8-2.4t-a95b": "qwen3.8-2.4t-a95b",
+        "qwen3.8-max": "qwen3.8-max"
       },
       "25": {
         "kimi-k2.5": "kimi-k2.5",
@@ -265,13 +270,9 @@
       "41": {
         "gemini-2.5-flash": "gemini-2.5-flash",
         "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
-        "gemini-2.5-pro": "gemini-2.5-pro",
         "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
         "gemini-3.6-flash": "gemini-3.6-flash",
         "gemini-embedding-001": "gemini-embedding-001",
-        "imagen-4.0-fast-generate-001": "imagen-4.0-fast-generate-001",
-        "imagen-4.0-generate-001": "imagen-4.0-generate-001",
-        "imagen-4.0-ultra-generate-001": "imagen-4.0-ultra-generate-001",
         "veo-3.1-generate-001": "veo-3.1-generate-001"
       },
       "43": {
@@ -382,6 +383,47 @@
         }
       }
     ],
+    "vertex_capability_profiles": {
+      "core-imagen-ultra": {
+        "gemini-2.5-flash": "gemini-2.5-flash",
+        "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+        "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
+        "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-embedding-001": "gemini-embedding-001",
+        "imagen-4.0-ultra-generate-001": "imagen-4.0-ultra-generate-001",
+        "veo-3.1-generate-001": "veo-3.1-generate-001"
+      },
+      "core-pro": {
+        "gemini-2.5-flash": "gemini-2.5-flash",
+        "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+        "gemini-2.5-pro": "gemini-2.5-pro",
+        "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
+        "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-embedding-001": "gemini-embedding-001",
+        "veo-3.1-generate-001": "veo-3.1-generate-001"
+      },
+      "core-pro-imagen-fast-standard": {
+        "gemini-2.5-flash": "gemini-2.5-flash",
+        "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+        "gemini-2.5-pro": "gemini-2.5-pro",
+        "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
+        "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-embedding-001": "gemini-embedding-001",
+        "imagen-4.0-fast-generate-001": "imagen-4.0-fast-generate-001",
+        "imagen-4.0-generate-001": "imagen-4.0-generate-001",
+        "veo-3.1-generate-001": "veo-3.1-generate-001"
+      },
+      "core-pro-imagen-standard": {
+        "gemini-2.5-flash": "gemini-2.5-flash",
+        "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+        "gemini-2.5-pro": "gemini-2.5-pro",
+        "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
+        "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-embedding-001": "gemini-embedding-001",
+        "imagen-4.0-generate-001": "imagen-4.0-generate-001",
+        "veo-3.1-generate-001": "veo-3.1-generate-001"
+      }
+    },
     "antigravity_group_scopes": [
       "claude",
       "gemini_text",

--- a/ops/pricing/model-surface-refresh-report.py
+++ b/ops/pricing/model-surface-refresh-report.py
@@ -363,6 +363,8 @@ def _evidence_class(row: dict[str, Any], kind: str) -> str:
         status = int(status_raw)
     except ValueError:
         status = 0
+    if status in {401, 403}:
+        return "inconclusive"
     if status == 429 or status >= 500:
         return "inconclusive"
     if verdict in {"unsupported", "unsupported_or_denied", "upstream_rejected"} and 400 <= status < 500:
@@ -559,6 +561,7 @@ def build_report(
         "traffic": defaultdict(lambda: defaultdict(set)),
     }
     raw_by_account: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    gateway_by_account: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
     modality: dict[tuple[str, str], str] = {}
     paid_approval: dict[tuple[str, str], bool] = {}
     for kind, rows in (("raw", fresh_raw), ("gateway", fresh_gateway), ("traffic", fresh_traffic)):
@@ -576,8 +579,11 @@ def build_report(
             if row.get("paid_probe_approved") is True:
                 paid_approval[(scope, model)] = True
             account_id = str(row.get("account_id") or "").strip()
-            if kind == "raw" and account_id:
-                raw_by_account[account_id][klass].add(model)
+            if account_id in account_by_id:
+                if kind == "raw":
+                    raw_by_account[account_id][klass].add(model)
+                elif kind == "gateway":
+                    gateway_by_account[account_id][klass].add(model)
 
     all_scopes = set(floors) | set(candidates) | set(accounts_by_scope)
     for kind in evidence.values():
@@ -648,7 +654,14 @@ def build_report(
             model for model in listed | raw_capable | gateway_served
             if _mapping_covers_model(current_coverage, model)
         }
-        proposed = (listed & raw_capable & gateway_served) - already_required - price_missing
+        paired_account_success = set().union(*(
+            raw_by_account[account_id].get("servable", set())
+            & gateway_by_account[account_id].get("servable", set())
+            for account_id in accounts_by_scope.get(scope, [])
+        )) if accounts_by_scope.get(scope) else set()
+        proposed = (
+            listed & raw_capable & gateway_served & paired_account_success
+        ) - already_required - price_missing
         paid_pending = set()
         for model in list(proposed):
             model_modality = modality.get((scope, model), candidates.get(scope, {}).get(model, "chat"))
@@ -665,6 +678,7 @@ def build_report(
             "traffic_proven": _sorted(traffic),
             "raw_capable": _sorted(raw_capable),
             "gateway_served": _sorted(gateway_served),
+            "same_account_proven": _sorted(paired_account_success),
             "unsupported": _sorted(unsupported),
             "inconclusive": _sorted(inconclusive),
             "local_floor_blocked": _sorted(local_blocked),
@@ -825,7 +839,10 @@ def _selftest() -> int:
     assert report["scopes"]["openai"]["inconclusive"] == ["unpriced"]
     assert _evidence_class(
         {"status": 401, "verdict": "unsupported_or_denied"}, "raw",
-    ) == "unsupported"
+    ) == "inconclusive"
+    assert _evidence_class(
+        {"status": 403, "verdict": "upstream_rejected"}, "raw",
+    ) == "inconclusive"
 
     report_accounts, _ = _active_accounts(inventory, bundle_floor)
     account_by_id = {row["account_id"]: row for row in report_accounts}
@@ -908,6 +925,22 @@ def _selftest() -> int:
     assert divergent["scopes"]["openai"]["account_divergence"]
     assert divergent["scopes"]["openai"]["proposed_add"] == []
 
+    split_account_gateway = [{
+        "scope": "openai", "account_id": 2, "usage_account_id": 2,
+        "model": "new-text", "status": 200, "verdict": "servable",
+        "observed_at": observed,
+    }]
+    split_account = build_report(
+        bundle=bundle, overlay=overlay, ledger={}, inventory=inventory,
+        candidates_raw=candidates,
+        raw_rows=[raw[0]], gateway_rows=split_account_gateway,
+        traffic_rows=[], as_of=as_of,
+    )
+    assert split_account["scopes"]["openai"]["raw_capable"] == ["new-text"]
+    assert split_account["scopes"]["openai"]["gateway_served"] == ["new-text"]
+    assert split_account["scopes"]["openai"]["same_account_proven"] == []
+    assert split_account["scopes"]["openai"]["proposed_add"] == []
+
     listed_divergent_candidates = dict(candidates)
     listed_divergent_candidates["account_lists"] = {
         "openai": {
@@ -933,7 +966,11 @@ def _selftest() -> int:
         "observed_at": "2026-08-14T10:00:00Z", "authoritative": True,
         "scopes": {"openai": [{"model": "paid-image", "modality": "image"}]},
     }
-    paid_raw = [{"scope": "openai", "model": "paid-image", "modality": "image", "status": 200, "verdict": "servable", "observed_at": observed}]
+    paid_raw = [{
+        "scope": "openai", "account_id": 1, "model": "paid-image",
+        "modality": "image", "status": 200, "verdict": "servable",
+        "observed_at": observed,
+    }]
     paid_gateway = [{
         "scope": "openai", "account_id": 1, "usage_account_id": 1,
         "model": "paid-image", "modality": "image", "status": 200,

--- a/ops/pricing/model-surface-refresh-report.py
+++ b/ops/pricing/model-surface-refresh-report.py
@@ -1,0 +1,1067 @@
+#!/usr/bin/env python3
+"""Build an offline, read-only model-surface evidence report.
+
+The report deliberately does not discover models, call a provider, query TokenKey,
+or write repository/runtime state. Existing platform-specific tools remain the owners
+of those operations; this file only normalizes their saved evidence and computes
+fail-closed deltas.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import importlib.util
+import json
+import sys
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_BUNDLE = REPO_ROOT / "ops" / "pricing" / "model-surface-bundle.json"
+DEFAULT_OVERLAY = REPO_ROOT / "backend" / "internal" / "service" / "tk_pricing_overlay.json"
+DEFAULT_LEDGER = REPO_ROOT / "ops" / "pricing" / "servable-reprobe-ledger.json"
+REPORT_SCHEMA_VERSION = 1
+EVIDENCE_MAX_AGE = dt.timedelta(hours=24)
+LIST_MAX_AGE = dt.timedelta(days=7)
+PAID_MODALITIES = {"image", "video"}
+LOCAL_FLOOR_VERDICTS = {"gateway_rejected", "local_floor_blocked", "not_allowlisted"}
+INCONCLUSIVE_VERDICTS = {
+    "auth_error", "config_error", "inconclusive", "setup_error", "transport_error",
+    "uncorrelated_success", "wrong_account",
+}
+FAMILY_SCOPE = {
+    "anthropic": "anthropic",
+    "openai_chat": "openai",
+    "openai_responses": "openai",
+    "openai_image": "openai",
+    "gemini_chat": "gemini",
+    "gemini_chat_image": "gemini",
+    "gemini_image": "gemini",
+    "gemini_video": "gemini",
+    "grok": "grok",
+}
+FAMILY_MODALITY = {
+    "openai_image": "image",
+    "gemini_chat_image": "image",
+    "gemini_image": "image",
+    "gemini_video": "video",
+}
+
+_bundle_spec = importlib.util.spec_from_file_location(
+    "tk_model_surface_bundle_report", REPO_ROOT / "ops" / "pricing" / "model_surface_bundle.py")
+_BUNDLE = importlib.util.module_from_spec(_bundle_spec)
+_bundle_spec.loader.exec_module(_BUNDLE)
+
+# This module owns no SQL. These names document that property for ops SQL coverage.
+SELF_CHECK_EXEMPT: dict[str, str] = {}
+
+
+def iter_self_check_sql() -> list[tuple[str, str]]:
+    return []
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RuntimeError(f"cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"invalid JSON in {path}: {exc}") from exc
+
+
+def _parse_time(raw: Any, label: str) -> dt.datetime | None:
+    if raw in (None, ""):
+        return None
+    if not isinstance(raw, str):
+        raise RuntimeError(f"{label} must be an ISO-8601 string")
+    value = raw.strip()
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise RuntimeError(f"{label} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _parse_as_of(raw: str | None) -> dt.datetime:
+    if raw:
+        parsed = _parse_time(raw, "--as-of")
+        assert parsed is not None
+        return parsed
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _clean_model(raw: Any) -> str:
+    return raw.strip() if isinstance(raw, str) else ""
+
+
+def _clean_scope(raw: Any) -> str:
+    return raw.strip().lower() if isinstance(raw, str) else ""
+
+
+def _sorted(values: Iterable[str]) -> list[str]:
+    return sorted(set(values))
+
+
+def _scope_floor(bundle: dict[str, Any]) -> dict[str, set[str]]:
+    floor = bundle["account_model_mapping"]
+    out = {
+        scope: set(mapping)
+        for scope, mapping in floor["platforms"].items()
+    }
+    out.update({
+        f"newapi_channel_type:{channel_type}": set(mapping)
+        for channel_type, mapping in floor["newapi_channel_types"].items()
+    })
+    for override in floor.get("account_overrides") or []:
+        out[_BUNDLE.account_override_scope(override)] = set(override["model_mapping"])
+    return out
+
+
+def _mapping_covers_model(mapping_keys: set[str], model: str) -> bool:
+    if model in mapping_keys:
+        return True
+    return any(key.endswith("*") and model.startswith(key[:-1]) for key in mapping_keys)
+
+
+def _normalize_base_url(raw: Any) -> str:
+    return _BUNDLE.normalize_account_override_base_url(raw)
+
+
+def _account_shared_scope(row: dict[str, Any], floor: dict[str, Any]) -> str:
+    platform = _clean_scope(row.get("platform"))
+    account_type = _clean_scope(row.get("type"))
+    base_url = _normalize_base_url(row.get("base_url"))
+    channel_type = str(row.get("channel_type") or "").strip()
+
+    for override in floor.get("account_overrides") or []:
+        if platform != _clean_scope(override.get("platform")):
+            continue
+        expected_channel = override.get("channel_type")
+        if expected_channel is not None and channel_type != str(expected_channel):
+            continue
+        if base_url != _normalize_base_url(override.get("base_url")):
+            continue
+        return _BUNDLE.account_override_scope(override)
+
+    if platform == "openai" and account_type == "apikey":
+        if base_url in {"https://api.ainzy.net", "https://api.ainzy.net/v1"}:
+            return "openai_ainzy_relay"
+        if base_url == "https://agent.tokensea.ai":
+            return "openai_tokensea_relay"
+        if base_url in {"https://api.cloudwise.ai/api", "https://api-us.cloudwise.ai/api"}:
+            return "openai_cloudwise_relay"
+    if platform == "anthropic" and account_type == "apikey":
+        if base_url == "https://agent.tokensea.ai":
+            return "anthropic_tokensea_relay"
+        if _clean_scope(row.get("mirror_platform")) == "kiro":
+            return "kiro"
+    if platform == "anthropic" and account_type == "bedrock":
+        return "bedrock"
+    if platform == "newapi":
+        return f"newapi_channel_type:{channel_type or '0'}"
+    return platform
+
+
+def _active_accounts(inventory: Any, floor: dict[str, Any]) -> tuple[list[dict[str, Any]], list[str]]:
+    rows = inventory.get("accounts") if isinstance(inventory, dict) else None
+    if not isinstance(rows, list):
+        raise RuntimeError("inventory must contain an accounts array")
+    accounts: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for raw in rows:
+        if not isinstance(raw, dict):
+            continue
+        if _clean_scope(raw.get("status") or "active") != "active":
+            continue
+        if raw.get("schedulable") is False:
+            continue
+        row = dict(raw)
+        row["account_id"] = str(raw.get("id") or raw.get("account_id") or "").strip()
+        if not row["account_id"]:
+            warnings.append("inventory row without account id was ignored")
+            continue
+        row["shared_scope"] = _account_shared_scope(row, floor)
+        if row["shared_scope"] == "newapi_channel_type:41":
+            row["vertex_capability_profile"] = _clean_scope(
+                row.get("vertex_capability_profile"))
+        accounts.append(row)
+    return accounts, warnings
+
+
+def _normalize_candidates(raw: Any) -> tuple[dict[str, dict[str, str]], dict[str, Any]]:
+    """Return scope -> model -> modality and candidate-list metadata.
+
+    Preferred shape:
+      {"observed_at": "...", "authoritative": true,
+       "scopes": {"anthropic": [{"model": "...", "modality": "chat"}]},
+       "account_lists": {"grok": {"65": ["grok-4.6"], "79": ["grok-4.6"]}}}
+
+    ``account_lists`` preserves per-account listing differences. Those lists
+    remain candidate evidence, not capability proof, but any difference outside
+    Vertex channel_type 41 blocks shared-scope promotion.
+
+    The existing refresh-servable-allowlist family map is accepted as a safe
+    compatibility input, but is non-authoritative unless wrapped with metadata.
+    """
+    if not isinstance(raw, dict):
+        raise RuntimeError("candidate discovery must be a JSON object")
+    authoritative = raw.get("authoritative") is True
+    observed_at = raw.get("observed_at")
+    scopes_raw = raw.get("scopes")
+    if scopes_raw is None:
+        scopes_raw = raw
+    if not isinstance(scopes_raw, dict):
+        raise RuntimeError("candidate discovery scopes must be an object")
+    out: dict[str, dict[str, str]] = defaultdict(dict)
+    for source_scope, items in scopes_raw.items():
+        if str(source_scope).startswith("_") or source_scope in {
+            "account_lists", "authoritative", "observed_at", "source", "scopes",
+        }:
+            continue
+        scope = FAMILY_SCOPE.get(str(source_scope), _clean_scope(source_scope))
+        if not scope or not isinstance(items, list):
+            continue
+        default_modality = FAMILY_MODALITY.get(str(source_scope), "chat")
+        for item in items:
+            if isinstance(item, str):
+                model = _clean_model(item)
+                modality = default_modality
+            elif isinstance(item, dict):
+                model = _clean_model(item.get("model") or item.get("model_id") or item.get("id"))
+                modality = _clean_scope(item.get("modality")) or default_modality
+            else:
+                continue
+            if model:
+                out[scope][model] = modality
+    account_lists: dict[str, dict[str, set[str]]] = defaultdict(dict)
+    account_lists_raw = raw.get("account_lists")
+    if account_lists_raw is not None:
+        if not isinstance(account_lists_raw, dict):
+            raise RuntimeError("candidate discovery account_lists must be an object")
+        for source_scope, accounts_raw in account_lists_raw.items():
+            scope = FAMILY_SCOPE.get(str(source_scope), _clean_scope(source_scope))
+            if not scope or not isinstance(accounts_raw, dict):
+                continue
+            for account_id_raw, models_raw in accounts_raw.items():
+                account_id = str(account_id_raw).strip()
+                if not account_id or not isinstance(models_raw, list):
+                    continue
+                account_lists[scope][account_id] = {
+                    model for item in models_raw
+                    if (model := _clean_model(
+                        item.get("model") or item.get("model_id") or item.get("id")
+                        if isinstance(item, dict) else item
+                    ))
+                }
+    return dict(out), {
+        "authoritative": authoritative,
+        "observed_at": observed_at,
+        "source": raw.get("source") if isinstance(raw.get("source"), str) else "",
+        "account_lists": {
+            scope: {account_id: set(models) for account_id, models in accounts.items()}
+            for scope, accounts in account_lists.items()
+        },
+    }
+
+
+def _decode_json_values(text: str) -> list[Any]:
+    decoder = json.JSONDecoder()
+    values: list[Any] = []
+    offset = 0
+    while offset < len(text):
+        while offset < len(text) and text[offset].isspace():
+            offset += 1
+        if offset >= len(text):
+            break
+        value, offset = decoder.raw_decode(text, offset)
+        values.append(value)
+    return values
+
+
+def _normalize_evidence_row(row: dict[str, Any], observed_at: str) -> dict[str, Any]:
+    normalized = dict(row)
+    probe = row.get("probe") if isinstance(row.get("probe"), dict) else {}
+    target = row.get("target_account") if isinstance(row.get("target_account"), dict) else {}
+    usage = row.get("usage_match") if isinstance(row.get("usage_match"), dict) else {}
+    normalized.setdefault("model", probe.get("model"))
+    normalized.setdefault("account_id", target.get("id"))
+    normalized.setdefault("platform", probe.get("platform") or target.get("platform"))
+    normalized.setdefault(
+        "scope",
+        row.get("account_scope") or target.get("scope"),
+    )
+    normalized.setdefault("channel_type", target.get("channel_type"))
+    normalized.setdefault("status", row.get("http_status") or row.get("http_code"))
+    normalized.setdefault("usage_match_account_id", usage.get("account_id"))
+    normalized.setdefault("modality", probe.get("endpoint"))
+    normalized.setdefault("observed_at", probe.get("probe_started_at_utc") or observed_at)
+    return normalized
+
+
+def _read_evidence(paths: list[Path], kind: str) -> tuple[list[dict[str, Any]], list[str]]:
+    rows: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for path in paths:
+        expanded = path.expanduser()
+        text = expanded.read_text(encoding="utf-8")
+        file_observed_at = dt.datetime.fromtimestamp(
+            expanded.stat().st_mtime, tz=dt.timezone.utc).isoformat()
+        try:
+            decoded = _decode_json_values(text)
+        except json.JSONDecodeError:
+            decoded = []
+        if decoded:
+            for raw in decoded:
+                default_observed_at = raw.get("observed_at") if isinstance(raw, dict) else None
+                values = raw.get("results") if isinstance(raw, dict) and "results" in raw else raw
+                if isinstance(values, dict):
+                    values = [values]
+                elif not isinstance(values, list):
+                    raise RuntimeError(
+                        f"{path}: evidence JSON values must be objects, arrays, or contain results arrays")
+                for value in values:
+                    if isinstance(value, dict):
+                        rows.append(_normalize_evidence_row(
+                            value, default_observed_at or file_observed_at))
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            parts = line.split("\t")
+            if kind == "traffic" and len(parts) == 3:
+                scope, model, hits = (part.strip() for part in parts)
+                rows.append({
+                    "scope": scope, "model": model, "hits": hits,
+                    "observed_at": file_observed_at,
+                })
+            elif kind != "traffic" and len(parts) == 4:
+                scope, model, status, verdict = (part.strip() for part in parts)
+                rows.append({
+                    "scope": scope, "model": model, "status": status,
+                    "verdict": verdict, "observed_at": file_observed_at,
+                })
+            else:
+                warnings.append(f"{path}:{lineno}: ignored malformed evidence row")
+    return rows, warnings
+
+
+def _evidence_class(row: dict[str, Any], kind: str) -> str:
+    if kind == "traffic":
+        return "traffic-proven"
+    verdict = _clean_scope(row.get("verdict"))
+    status_raw = str(
+        row.get("status") or row.get("http_status") or row.get("code") or ""
+    ).strip()
+    try:
+        status = int(status_raw)
+    except ValueError:
+        status = 0
+    if status == 429 or status >= 500:
+        return "inconclusive"
+    if verdict in {"unsupported", "unsupported_or_denied", "upstream_rejected"} and 400 <= status < 500:
+        return "unsupported"
+    if verdict in INCONCLUSIVE_VERDICTS:
+        return "inconclusive"
+    if kind == "gateway" and verdict in LOCAL_FLOOR_VERDICTS:
+        return "local-floor-blocked"
+    if verdict == "servable" and 200 <= status < 300:
+        if kind == "gateway":
+            expected = str(row.get("account_id") or "").strip()
+            actual = str(row.get("usage_account_id") or row.get("usage_match_account_id") or "").strip()
+            if not expected or actual != expected:
+                return "inconclusive"
+        return "servable"
+    return "inconclusive"
+
+
+def _fresh_rows(
+    rows: list[dict[str, Any]], kind: str, as_of: dt.datetime,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    fresh: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for row in rows:
+        observed = _parse_time(row.get("observed_at"), f"{kind} evidence observed_at")
+        label = (
+            f"{_clean_scope(row.get('scope') or row.get('platform'))}/"
+            f"{_clean_model(row.get('model'))}"
+        )
+        if observed is None:
+            warnings.append(f"undated {kind} evidence ignored: {label}")
+            continue
+        if as_of - observed > EVIDENCE_MAX_AGE or observed > as_of + dt.timedelta(minutes=5):
+            warnings.append(f"stale {kind} evidence ignored: {label}")
+            continue
+        fresh.append(row)
+    return fresh, warnings
+
+
+def _normalize_row_scope(row: dict[str, Any], account_by_id: dict[str, dict[str, Any]]) -> str:
+    scope = _clean_scope(row.get("scope") or row.get("platform"))
+    account_id = str(row.get("account_id") or "").strip()
+    if account_id and account_id in account_by_id:
+        account = account_by_id[account_id]
+        account_scope = account["shared_scope"]
+        family_scope = FAMILY_SCOPE.get(scope, scope)
+        account_platform = _clean_scope(account.get("platform"))
+        if not scope or scope == "gemini" or family_scope == account_platform:
+            return account_scope
+    if scope == "newapi" and row.get("channel_type") is not None:
+        return f"newapi_channel_type:{row.get('channel_type')}"
+    return FAMILY_SCOPE.get(scope, scope)
+
+
+def _price_entry(overlay: dict[str, Any], model: str) -> Any:
+    entry = overlay.get(model)
+    if entry is not None:
+        return entry
+    normalized = model.lower()
+    return overlay.get(normalized) if normalized != model else None
+
+
+def _positive_price(entry: Any) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    mode = entry.get("mode")
+    fields = {
+        "chat": ("input_cost_per_token", "output_cost_per_token"),
+        "embedding": ("input_cost_per_token",),
+        "image_generation": ("output_cost_per_image",),
+        "video_generation": ("output_cost_per_second",),
+    }.get(mode)
+    if not fields:
+        return False
+    return all(
+        isinstance(entry.get(field), (int, float))
+        and not isinstance(entry.get(field), bool)
+        and entry[field] > 0
+        for field in fields
+    )
+
+
+def _watchlist_status(ledger: Any, as_of: dt.datetime) -> dict[str, Any]:
+    watchlist = ledger.get("watchlist") if isinstance(ledger, dict) else []
+    skiplist = ledger.get("skiplist") if isinstance(ledger, dict) else []
+    deadlist = ledger.get("deadlist") if isinstance(ledger, dict) else []
+    stale: list[str] = []
+    for row in watchlist if isinstance(watchlist, list) else []:
+        if not isinstance(row, dict):
+            continue
+        last = row.get("last_probe")
+        days = row.get("freshness_days")
+        if not isinstance(last, str) or not isinstance(days, int):
+            stale.append(f"{row.get('platform', '')}/{row.get('model', '')}")
+            continue
+        try:
+            expires = dt.date.fromisoformat(last) + dt.timedelta(days=days)
+        except ValueError:
+            stale.append(f"{row.get('platform', '')}/{row.get('model', '')}")
+            continue
+        if expires < as_of.date():
+            stale.append(f"{row.get('platform', '')}/{row.get('model', '')}")
+    return {
+        "watchlist_count": len(watchlist) if isinstance(watchlist, list) else 0,
+        "stale": sorted(stale),
+        "skiplist_count": len(skiplist) if isinstance(skiplist, list) else 0,
+        "deadlist_count": len(deadlist) if isinstance(deadlist, list) else 0,
+    }
+
+
+def _capability_clusters(
+    account_ids: list[str], raw_by_account: dict[str, dict[str, set[str]]],
+    profiles: dict[str, dict[str, str]], candidate_models: set[str],
+) -> dict[str, Any]:
+    sets: dict[str, set[str]] = {
+        account_id: set(raw_by_account.get(account_id, {}).get("servable", set()))
+        for account_id in account_ids
+    }
+    observed_by_account = {
+        account_id: set().union(*raw_by_account.get(account_id, {}).values())
+        if raw_by_account.get(account_id) else set()
+        for account_id in account_ids
+    }
+    complete = bool(account_ids) and bool(candidate_models) and all(
+        candidate_models <= observed_by_account[account_id]
+        for account_id in account_ids
+    )
+    intersection = set.intersection(*sets.values()) if complete and sets else set()
+    union = set().union(*sets.values()) if sets else set()
+    profile_sets = {profile: set(mapping) for profile, mapping in profiles.items()}
+    grouped: dict[tuple[str, ...], list[str]] = defaultdict(list)
+    if complete:
+        for account_id, models in sets.items():
+            grouped[tuple(sorted(models))].append(account_id)
+    suggestions: list[dict[str, Any]] = []
+    for shape, members in sorted(grouped.items()):
+        models = set(shape)
+        known = next((name for name, expected in profile_sets.items() if expected == models), "")
+        digest = hashlib.sha256("\n".join(shape).encode("utf-8")).hexdigest()[:10]
+        suggestions.append({
+            "profile": known or f"candidate-{digest}",
+            "existing_profile": bool(known),
+            "account_ids": sorted(members),
+            "models": list(shape),
+        })
+    return {
+        "complete_account_coverage": complete,
+        "account_capabilities": {key: _sorted(value) for key, value in sorted(sets.items())},
+        "strict_intersection": _sorted(intersection),
+        "public_union": _sorted(union),
+        "profile_suggestions": suggestions,
+    }
+
+
+def build_report(
+    *,
+    bundle: dict[str, Any],
+    overlay: dict[str, Any],
+    ledger: dict[str, Any],
+    inventory: dict[str, Any],
+    candidates_raw: dict[str, Any],
+    raw_rows: list[dict[str, Any]],
+    gateway_rows: list[dict[str, Any]],
+    traffic_rows: list[dict[str, Any]],
+    as_of: dt.datetime,
+) -> dict[str, Any]:
+    floor = bundle["account_model_mapping"]
+    floors = _scope_floor(bundle)
+    accounts, warnings = _active_accounts(inventory, floor)
+    account_by_id = {row["account_id"]: row for row in accounts}
+    accounts_by_scope: dict[str, list[str]] = defaultdict(list)
+    for row in accounts:
+        accounts_by_scope[row["shared_scope"]].append(row["account_id"])
+
+    candidates, candidate_meta = _normalize_candidates(candidates_raw)
+    observed = _parse_time(candidate_meta.get("observed_at"), "candidate discovery observed_at")
+    list_fresh = observed is not None and dt.timedelta(0) <= as_of - observed <= LIST_MAX_AGE
+    authoritative_list = bool(candidate_meta["authoritative"] and list_fresh)
+    if not candidate_meta["authoritative"]:
+        warnings.append("candidate discovery is not marked authoritative; proposed additions are blocked")
+    elif not list_fresh:
+        warnings.append("candidate discovery is missing, stale, or future-dated; proposed additions are blocked")
+
+    fresh_raw, row_warnings = _fresh_rows(raw_rows, "raw", as_of)
+    warnings.extend(row_warnings)
+    fresh_gateway, row_warnings = _fresh_rows(gateway_rows, "gateway", as_of)
+    warnings.extend(row_warnings)
+    fresh_traffic, row_warnings = _fresh_rows(traffic_rows, "traffic", as_of)
+    warnings.extend(row_warnings)
+
+    evidence: dict[str, dict[str, dict[str, set[str]]]] = {
+        "raw": defaultdict(lambda: defaultdict(set)),
+        "gateway": defaultdict(lambda: defaultdict(set)),
+        "traffic": defaultdict(lambda: defaultdict(set)),
+    }
+    raw_by_account: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    modality: dict[tuple[str, str], str] = {}
+    paid_approval: dict[tuple[str, str], bool] = {}
+    for kind, rows in (("raw", fresh_raw), ("gateway", fresh_gateway), ("traffic", fresh_traffic)):
+        for row in rows:
+            model = _clean_model(row.get("model") or row.get("model_id"))
+            scope = _normalize_row_scope(row, account_by_id)
+            if not model or not scope:
+                warnings.append(f"{kind} evidence without scope/model was ignored")
+                continue
+            klass = _evidence_class(row, kind)
+            evidence[kind][scope][klass].add(model)
+            row_modality = _clean_scope(row.get("modality"))
+            if row_modality:
+                modality[(scope, model)] = row_modality
+            if row.get("paid_probe_approved") is True:
+                paid_approval[(scope, model)] = True
+            account_id = str(row.get("account_id") or "").strip()
+            if kind == "raw" and account_id:
+                raw_by_account[account_id][klass].add(model)
+
+    all_scopes = set(floors) | set(candidates) | set(accounts_by_scope)
+    for kind in evidence.values():
+        all_scopes.update(kind)
+    scope_docs: dict[str, Any] = {}
+    violations: list[str] = []
+    for scope in sorted(all_scopes):
+        listed = set(candidates.get(scope, {}))
+        current = set(floors.get(scope, set()))
+        current_coverage = set(current)
+        if scope == "newapi_channel_type:41":
+            for mapping in (floor.get("vertex_capability_profiles") or {}).values():
+                current_coverage.update(mapping)
+        traffic = set(evidence["traffic"][scope].get("traffic-proven", set()))
+        raw_capable = set(evidence["raw"][scope].get("servable", set()))
+        gateway_served = set(evidence["gateway"][scope].get("servable", set()))
+        unsupported = (
+            set(evidence["raw"][scope].get("unsupported", set()))
+            | set(evidence["gateway"][scope].get("unsupported", set()))
+        ) - raw_capable - gateway_served
+        inconclusive = (
+            set(evidence["raw"][scope].get("inconclusive", set()))
+            | set(evidence["gateway"][scope].get("inconclusive", set()))
+        ) - raw_capable - gateway_served
+        local_blocked = set(evidence["gateway"][scope].get("local-floor-blocked", set()))
+        candidate_universe = listed | raw_capable | gateway_served | traffic
+        price_missing = {
+            model for model in candidate_universe
+            if not _positive_price(_price_entry(overlay, model))
+        }
+
+        divergence: list[dict[str, Any]] = []
+        if scope != "newapi_channel_type:41":
+            listed_by_account = candidate_meta["account_lists"].get(scope, {})
+            if len(listed_by_account) > 1:
+                listed_universe = set().union(*listed_by_account.values())
+                for model in sorted(listed_universe):
+                    present = sorted(
+                        account_id for account_id, models in listed_by_account.items()
+                        if model in models
+                    )
+                    absent = sorted(set(listed_by_account) - set(present))
+                    if present and absent:
+                        divergence.append({
+                            "model": model,
+                            "kind": "account-list",
+                            "listed_account_ids": present,
+                            "missing_account_ids": absent,
+                        })
+
+            conclusive: dict[str, dict[str, str]] = defaultdict(dict)
+            for account_id in accounts_by_scope.get(scope, []):
+                for klass in ("servable", "unsupported"):
+                    for model in raw_by_account.get(account_id, {}).get(klass, set()):
+                        conclusive[model][account_id] = klass
+            for model, verdicts in sorted(conclusive.items()):
+                if len(set(verdicts.values())) > 1:
+                    divergence.append({
+                        "model": model,
+                        "kind": "capability",
+                        "account_verdicts": dict(sorted(verdicts.items())),
+                    })
+            if divergence:
+                violations.append(
+                    f"{scope}: account discovery/capability divergence is not allowed outside Vertex channel_type 41")
+
+        already_required = {
+            model for model in listed | raw_capable | gateway_served
+            if _mapping_covers_model(current_coverage, model)
+        }
+        proposed = (listed & raw_capable & gateway_served) - already_required - price_missing
+        paid_pending = set()
+        for model in list(proposed):
+            model_modality = modality.get((scope, model), candidates.get(scope, {}).get(model, "chat"))
+            if model_modality in PAID_MODALITIES and not paid_approval.get((scope, model), False):
+                proposed.remove(model)
+                paid_pending.add(model)
+        if not authoritative_list or divergence:
+            proposed.clear()
+        scope_docs[scope] = {
+            "account_ids": sorted(accounts_by_scope.get(scope, [])),
+            "current_required": _sorted(current),
+            "already_required": _sorted(already_required),
+            "listed": _sorted(listed),
+            "traffic_proven": _sorted(traffic),
+            "raw_capable": _sorted(raw_capable),
+            "gateway_served": _sorted(gateway_served),
+            "unsupported": _sorted(unsupported),
+            "inconclusive": _sorted(inconclusive),
+            "local_floor_blocked": _sorted(local_blocked),
+            "price_missing": _sorted(price_missing),
+            "paid_probe_approval_missing": _sorted(paid_pending),
+            "proposed_add": _sorted(proposed),
+            "account_divergence": divergence,
+        }
+
+    vertex_scope = "newapi_channel_type:41"
+    vertex_account_ids = sorted(accounts_by_scope.get(vertex_scope, []))
+    vertex = _capability_clusters(
+        vertex_account_ids,
+        raw_by_account,
+        floor.get("vertex_capability_profiles") or {},
+        set(candidates.get(vertex_scope, {})),
+    )
+    if vertex_account_ids and not vertex["complete_account_coverage"]:
+        violations.append("newapi_channel_type:41: raw evidence does not cover every active schedulable account")
+
+    watchlist = _watchlist_status(ledger, as_of)
+    if watchlist["stale"]:
+        warnings.append(f"{len(watchlist['stale'])} reprobe watchlist entries are stale")
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "as_of": as_of.isoformat().replace("+00:00", "Z"),
+        "bundle": {
+            "schema_version": bundle["schema_version"],
+            "floor_sha256": bundle["floor_sha256"],
+        },
+        "candidate_discovery": {
+            **{key: value for key, value in candidate_meta.items() if key != "account_lists"},
+            "account_list_scope_count": len(candidate_meta["account_lists"]),
+            "fresh": list_fresh,
+            "usable_for_additions": authoritative_list,
+            "scope_count": len(candidates),
+            "model_count": sum(len(models) for models in candidates.values()),
+        },
+        "inventory": {
+            "active_schedulable_account_count": len(accounts),
+            "accounts_by_scope": {scope: sorted(ids) for scope, ids in sorted(accounts_by_scope.items())},
+        },
+        "scopes": scope_docs,
+        "vertex_channel_type_41": vertex,
+        "reprobe_ledger": watchlist,
+        "violations": sorted(set(violations)),
+        "warnings": sorted(set(warnings)),
+        "commands": {
+            "writes": [],
+            "note": "report is offline/read-only; review evidence before using existing platform probe or modelops activation commands",
+        },
+    }
+
+
+def _render_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"model-surface refresh report {report['as_of']}",
+        f"bundle {report['bundle']['floor_sha256']}",
+    ]
+    for scope, row in report["scopes"].items():
+        lines.append(
+            f"{scope}: listed={len(row['listed'])} raw={len(row['raw_capable'])} "
+            f"gateway={len(row['gateway_served'])} price_missing={len(row['price_missing'])} "
+            f"proposed_add={len(row['proposed_add'])}")
+        if row["proposed_add"]:
+            lines.append("  proposed_add: " + ", ".join(row["proposed_add"]))
+        if row["account_divergence"]:
+            lines.append("  BLOCKED: shared-scope account divergence")
+    vertex = report["vertex_channel_type_41"]
+    lines.append(
+        "vertex ch41: intersection=" + ", ".join(vertex["strict_intersection"])
+        + " | union=" + ", ".join(vertex["public_union"]))
+    for violation in report["violations"]:
+        lines.append("VIOLATION: " + violation)
+    for warning in report["warnings"]:
+        lines.append("WARNING: " + warning)
+    return "\n".join(lines) + "\n"
+
+
+def _write_fixture(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _selftest() -> int:
+    as_of = dt.datetime(2026, 8, 14, 12, tzinfo=dt.timezone.utc)
+    shared = {"shared": "shared"}
+    bundle_floor = {
+        "platforms": {"openai": shared},
+        "newapi_channel_types": {"41": shared},
+        "account_overrides": [],
+        "vertex_capability_profiles": {
+            "core-pro": {"shared": "shared", "pro": "pro"},
+            "core-image": {"shared": "shared", "image": "image"},
+        },
+        "antigravity_group_scopes": ["claude"],
+        "forbidden_model_mapping_keys": {},
+        "forbidden_model_mapping_prefixes": {},
+    }
+    bundle = {
+        "schema_version": 4,
+        "floor_sha256": _BUNDLE.floor_sha256(bundle_floor),
+        "account_model_mapping": bundle_floor,
+    }
+    overlay = {
+        "embedding": {"mode": "embedding", "input_cost_per_token": 1, "output_cost_per_token": 0},
+        "new-text": {"mode": "chat", "input_cost_per_token": 1, "output_cost_per_token": 1},
+        "image": {"mode": "image_generation", "output_cost_per_image": 1},
+        "pro": {"mode": "chat", "input_cost_per_token": 1, "output_cost_per_token": 1},
+        "shared": {"mode": "chat", "input_cost_per_token": 1, "output_cost_per_token": 1},
+    }
+    assert _positive_price(overlay["embedding"])
+    overlay["lowercase-price"] = overlay["new-text"]
+    assert _positive_price(_price_entry(overlay, "LOWERCASE-PRICE"))
+    inventory = {"accounts": [
+        {"id": 1, "platform": "openai", "status": "active", "schedulable": True},
+        {"id": 2, "platform": "openai", "status": "active", "schedulable": True},
+        {
+            "id": 3, "platform": "openai", "type": "apikey",
+            "base_url": "https://api.cloudwise.ai/api",
+            "status": "active", "schedulable": True,
+        },
+        {"id": 47, "platform": "newapi", "channel_type": 41, "status": "active", "schedulable": True},
+        {"id": 57, "platform": "newapi", "channel_type": 41, "status": "active", "schedulable": True},
+    ]}
+    candidates = {
+        "observed_at": "2026-08-14T10:00:00Z", "authoritative": True,
+        "scopes": {
+            "openai": ["new-text", "unpriced", {"model": "paid-image", "modality": "image"}],
+            "newapi_channel_type:41": ["shared", "pro", {"model": "image", "modality": "image"}],
+        },
+    }
+    observed = "2026-08-14T11:00:00Z"
+    raw = [
+        {"scope": "openai", "account_id": 1, "model": "new-text", "status": 200, "verdict": "servable", "observed_at": observed},
+        {"scope": "openai", "account_id": 2, "model": "new-text", "status": 200, "verdict": "servable", "observed_at": observed},
+        {"scope": "openai", "account_id": 1, "model": "unpriced", "status": 429, "verdict": "unsupported", "observed_at": observed},
+        {"scope": "newapi", "account_id": 47, "model": "shared", "status": 200, "verdict": "servable", "observed_at": observed},
+        {"scope": "newapi", "account_id": 47, "model": "pro", "status": 200, "verdict": "servable", "observed_at": observed},
+        {"scope": "newapi", "account_id": 47, "model": "image", "status": 404, "verdict": "unsupported", "modality": "image", "observed_at": observed},
+        {"scope": "newapi", "account_id": 57, "model": "shared", "status": 200, "verdict": "servable", "observed_at": observed},
+        {"scope": "newapi", "account_id": 57, "model": "pro", "status": 404, "verdict": "unsupported", "observed_at": observed},
+        {"scope": "newapi", "account_id": 57, "model": "image", "status": 200, "verdict": "servable", "modality": "image", "paid_probe_approved": True, "observed_at": observed},
+    ]
+    gateway = [
+        {"scope": "openai", "account_id": 1, "usage_account_id": 1, "model": "new-text", "status": 200, "verdict": "servable", "observed_at": observed},
+        {"scope": "openai", "model": "unpriced", "status": 503, "verdict": "unsupported", "observed_at": observed},
+        {"scope": "openai", "model": "paid-image", "status": 400, "verdict": "gateway_rejected", "observed_at": observed},
+        {"scope": "newapi", "account_id": 47, "usage_account_id": 47, "model": "pro", "status": 200, "verdict": "servable", "observed_at": observed},
+        {"scope": "newapi", "account_id": 57, "usage_account_id": 57, "model": "image", "status": 200, "verdict": "servable", "modality": "image", "observed_at": observed},
+    ]
+    ledger = {"watchlist": [{
+        "platform": "openai", "model": "old", "last_probe": "2026-01-01", "freshness_days": 30,
+    }], "skiplist": [], "deadlist": []}
+    report = build_report(
+        bundle=bundle, overlay=overlay, ledger=ledger, inventory=inventory,
+        candidates_raw=candidates, raw_rows=raw, gateway_rows=gateway, traffic_rows=[], as_of=as_of)
+    assert report["scopes"]["openai"]["proposed_add"] == ["new-text"]
+    assert report["scopes"]["openai"]["inconclusive"] == ["unpriced"]
+    assert _evidence_class(
+        {"status": 401, "verdict": "unsupported_or_denied"}, "raw",
+    ) == "unsupported"
+
+    report_accounts, _ = _active_accounts(inventory, bundle_floor)
+    account_by_id = {row["account_id"]: row for row in report_accounts}
+    assert _normalize_row_scope(
+        {"scope": "openai", "account_id": 3}, account_by_id,
+    ) == "openai_cloudwise_relay"
+    assert _normalize_row_scope(
+        {"scope": "openai_chat", "account_id": 3}, account_by_id,
+    ) == "openai_cloudwise_relay"
+    assert _normalize_row_scope(
+        {"scope": "different-scope", "account_id": 3}, account_by_id,
+    ) == "different-scope"
+
+    wildcard_floor = dict(bundle_floor)
+    wildcard_floor["platforms"] = {"openai": {"glm-*": "glm-*"}}
+    wildcard_bundle = {
+        "schema_version": 4,
+        "floor_sha256": _BUNDLE.floor_sha256(wildcard_floor),
+        "account_model_mapping": wildcard_floor,
+    }
+    wildcard_candidates = {
+        "observed_at": "2026-08-14T10:00:00Z", "authoritative": True,
+        "scopes": {"openai": ["glm-5.2"]},
+    }
+    wildcard_raw = [
+        {"scope": "openai", "account_id": 1, "model": "glm-5.2", "status": 200, "verdict": "servable", "observed_at": observed},
+        {"scope": "openai", "account_id": 2, "model": "glm-5.2", "status": 200, "verdict": "servable", "observed_at": observed},
+    ]
+    wildcard_gateway = [{
+        "scope": "openai", "account_id": 1, "usage_account_id": 1,
+        "model": "glm-5.2", "status": 200, "verdict": "servable", "observed_at": observed,
+    }]
+    wildcard = build_report(
+        bundle=wildcard_bundle, overlay={"glm-5.2": overlay["new-text"]}, ledger={},
+        inventory=inventory, candidates_raw=wildcard_candidates, raw_rows=wildcard_raw,
+        gateway_rows=wildcard_gateway, traffic_rows=[], as_of=as_of)
+    assert wildcard["scopes"]["openai"]["already_required"] == ["glm-5.2"]
+    assert wildcard["scopes"]["openai"]["proposed_add"] == []
+    assert report["scopes"]["openai"]["local_floor_blocked"] == ["paid-image"]
+    assert report["reprobe_ledger"]["stale"] == ["openai/old"]
+    assert report["scopes"]["newapi_channel_type:41"]["already_required"] == [
+        "image", "pro", "shared",
+    ]
+    assert report["scopes"]["newapi_channel_type:41"]["proposed_add"] == []
+    vertex = report["vertex_channel_type_41"]
+    assert vertex["strict_intersection"] == ["shared"]
+    assert vertex["public_union"] == ["image", "pro", "shared"]
+    assert {row["profile"] for row in vertex["profile_suggestions"]} == {"core-image", "core-pro"}
+
+    partial_vertex_raw = [
+        row for row in raw
+        if not (row.get("account_id") == 57 and row.get("model") == "image")
+    ]
+    partial_vertex = build_report(
+        bundle=bundle, overlay=overlay, ledger={}, inventory=inventory,
+        candidates_raw=candidates, raw_rows=partial_vertex_raw,
+        gateway_rows=gateway, traffic_rows=[], as_of=as_of)
+    assert partial_vertex["vertex_channel_type_41"]["complete_account_coverage"] is False
+    assert partial_vertex["vertex_channel_type_41"]["strict_intersection"] == []
+    assert partial_vertex["vertex_channel_type_41"]["profile_suggestions"] == []
+    assert any(
+        violation.startswith("newapi_channel_type:41: raw evidence does not cover")
+        for violation in partial_vertex["violations"]
+    )
+
+    no_authority = dict(candidates)
+    no_authority["authoritative"] = False
+    blocked = build_report(
+        bundle=bundle, overlay=overlay, ledger={}, inventory=inventory,
+        candidates_raw=no_authority, raw_rows=raw, gateway_rows=gateway, traffic_rows=[], as_of=as_of)
+    assert blocked["scopes"]["openai"]["proposed_add"] == []
+
+    divergent_raw = raw + [
+        {"scope": "openai", "account_id": 2, "model": "split", "status": 404, "verdict": "unsupported", "observed_at": observed},
+        {"scope": "openai", "account_id": 1, "model": "split", "status": 200, "verdict": "servable", "observed_at": observed},
+    ]
+    divergent = build_report(
+        bundle=bundle, overlay=overlay, ledger={}, inventory=inventory,
+        candidates_raw=candidates, raw_rows=divergent_raw, gateway_rows=gateway, traffic_rows=[], as_of=as_of)
+    assert divergent["scopes"]["openai"]["account_divergence"]
+    assert divergent["scopes"]["openai"]["proposed_add"] == []
+
+    listed_divergent_candidates = dict(candidates)
+    listed_divergent_candidates["account_lists"] = {
+        "openai": {
+            "1": ["shared-list", "account-one-only"],
+            "2": ["shared-list", "account-two-only"],
+        },
+    }
+    listed_divergent = build_report(
+        bundle=bundle, overlay=overlay, ledger={}, inventory=inventory,
+        candidates_raw=listed_divergent_candidates, raw_rows=raw,
+        gateway_rows=gateway, traffic_rows=[], as_of=as_of)
+    listed_divergence = listed_divergent["scopes"]["openai"]["account_divergence"]
+    assert {row["model"] for row in listed_divergence} == {
+        "account-one-only", "account-two-only",
+    }
+    assert all(row["kind"] == "account-list" for row in listed_divergence)
+    assert any(
+        violation.startswith("openai: account discovery/capability divergence")
+        for violation in listed_divergent["violations"]
+    )
+
+    paid_candidates = {
+        "observed_at": "2026-08-14T10:00:00Z", "authoritative": True,
+        "scopes": {"openai": [{"model": "paid-image", "modality": "image"}]},
+    }
+    paid_raw = [{"scope": "openai", "model": "paid-image", "modality": "image", "status": 200, "verdict": "servable", "observed_at": observed}]
+    paid_gateway = [{
+        "scope": "openai", "account_id": 1, "usage_account_id": 1,
+        "model": "paid-image", "modality": "image", "status": 200,
+        "verdict": "servable", "observed_at": observed,
+    }]
+    paid_overlay = dict(overlay)
+    paid_overlay["paid-image"] = {"mode": "image_generation", "output_cost_per_image": 1}
+    paid = build_report(
+        bundle=bundle, overlay=paid_overlay, ledger={}, inventory=inventory,
+        candidates_raw=paid_candidates, raw_rows=paid_raw, gateway_rows=paid_gateway,
+        traffic_rows=[], as_of=as_of)
+    assert paid["scopes"]["openai"]["paid_probe_approval_missing"] == ["paid-image"]
+    assert paid["scopes"]["openai"]["proposed_add"] == []
+
+    empty = build_report(
+        bundle=bundle, overlay=overlay, ledger={}, inventory={"accounts": []},
+        candidates_raw={"observed_at": "2026-08-14T10:00:00Z", "authoritative": True, "scopes": {}},
+        raw_rows=[], gateway_rows=[], traffic_rows=[], as_of=as_of)
+    assert empty["candidate_discovery"]["model_count"] == 0
+    assert empty["violations"] == []
+
+    stale = build_report(
+        bundle=bundle, overlay=overlay, ledger={}, inventory=inventory,
+        candidates_raw={"observed_at": "2026-07-01T00:00:00Z", "authoritative": True, "scopes": {"openai": ["new-text"]}},
+        raw_rows=raw, gateway_rows=gateway, traffic_rows=[], as_of=as_of)
+    assert stale["candidate_discovery"]["usable_for_additions"] is False
+    assert stale["scopes"]["openai"]["proposed_add"] == []
+
+    undated = build_report(
+        bundle=bundle, overlay=overlay, ledger={}, inventory=inventory,
+        candidates_raw=candidates,
+        raw_rows=[{"scope": "openai", "account_id": 1, "model": "new-text", "status": 200, "verdict": "servable"}],
+        gateway_rows=[], traffic_rows=[], as_of=as_of)
+    assert undated["scopes"]["openai"]["raw_capable"] == []
+    assert any(warning.startswith("undated raw evidence ignored") for warning in undated["warnings"])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        evidence_path = Path(temp_dir) / "gateway.json"
+        nested = {
+            "http_code": "200",
+            "probe": {
+                "model": "new-text", "platform": "openai", "endpoint": "responses",
+                "probe_started_at_utc": observed,
+            },
+            "target_account": {"id": 1, "platform": "openai"},
+            "usage_match": {"account_id": 1},
+            "verdict": "servable",
+        }
+        blocked_nested = {
+            "http_code": "400",
+            "probe": {
+                "model": "blocked", "platform": "openai", "endpoint": "chat",
+                "probe_started_at_utc": observed,
+            },
+            "target_account": {"id": 1, "platform": "openai"},
+            "usage_match": None,
+            "verdict": "gateway_rejected",
+        }
+        evidence_path.write_text(
+            json.dumps(nested) + "\n" + json.dumps(blocked_nested), encoding="utf-8")
+        nested_rows, nested_warnings = _read_evidence([evidence_path], "gateway")
+        assert nested_warnings == []
+        assert len(nested_rows) == 2
+        assert nested_rows[0]["model"] == "new-text"
+        assert str(nested_rows[0]["account_id"]) == "1"
+        assert str(nested_rows[0]["usage_match_account_id"]) == "1"
+        assert nested_rows[0]["status"] == "200"
+        assert nested_rows[0]["modality"] == "responses"
+        assert _evidence_class(nested_rows[0], "gateway") == "servable"
+        assert _evidence_class(nested_rows[1], "gateway") == "local-floor-blocked"
+
+        output = Path(temp_dir) / "report.json"
+        output.write_text(json.dumps(report, sort_keys=True), encoding="utf-8")
+        assert json.loads(output.read_text(encoding="utf-8"))["schema_version"] == REPORT_SCHEMA_VERSION
+    print("selftest ok")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--selftest", action="store_true")
+    subparsers = parser.add_subparsers(dest="command")
+    generate = subparsers.add_parser("generate", help="build an offline evidence report")
+    generate.add_argument("--bundle", type=Path, default=DEFAULT_BUNDLE)
+    generate.add_argument("--overlay", type=Path, default=DEFAULT_OVERLAY)
+    generate.add_argument("--reprobe-ledger", type=Path, default=DEFAULT_LEDGER)
+    generate.add_argument("--inventory", type=Path, required=True)
+    generate.add_argument("--candidates", type=Path, required=True)
+    generate.add_argument("--raw-probe", type=Path, action="append", default=[])
+    generate.add_argument("--gateway-probe", type=Path, action="append", default=[])
+    generate.add_argument("--traffic-evidence", type=Path, action="append", default=[])
+    generate.add_argument("--as-of", help="ISO-8601 clock for deterministic freshness checks")
+    generate.add_argument("--format", choices=("json", "text"), default="json")
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    if args.selftest:
+        return _selftest()
+    if args.command != "generate":
+        _build_parser().print_help(sys.stderr)
+        return 2
+    bundle = _BUNDLE.load_bundle(args.bundle)
+    overlay = _load_json(args.overlay)
+    ledger = _load_json(args.reprobe_ledger)
+    inventory = _load_json(args.inventory)
+    candidates = _load_json(args.candidates)
+    raw_rows, warnings = _read_evidence(args.raw_probe, "raw")
+    gateway_rows, more = _read_evidence(args.gateway_probe, "gateway")
+    warnings.extend(more)
+    traffic_rows, more = _read_evidence(args.traffic_evidence, "traffic")
+    warnings.extend(more)
+    report = build_report(
+        bundle=bundle, overlay=overlay, ledger=ledger, inventory=inventory,
+        candidates_raw=candidates, raw_rows=raw_rows, gateway_rows=gateway_rows,
+        traffic_rows=traffic_rows, as_of=_parse_as_of(args.as_of))
+    report["warnings"] = sorted(set(report["warnings"] + warnings))
+    if args.format == "json":
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(_render_text(report), end="")
+    return 1 if report["violations"] else 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc

--- a/ops/pricing/model_surface_bundle.py
+++ b/ops/pricing/model_surface_bundle.py
@@ -9,8 +9,8 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_BUNDLE_PATH = REPO_ROOT / "ops" / "pricing" / "model-surface-bundle.json"
-SCHEMA_VERSION = 3
-SUPPORTED_SCHEMA_VERSIONS = {1, SCHEMA_VERSION}
+SCHEMA_VERSION = 4
+SUPPORTED_SCHEMA_VERSIONS = {1, 3, SCHEMA_VERSION}
 BUNDLE_FIELDS = {
     "schema_version",
     "floor_sha256",
@@ -123,6 +123,8 @@ def _validate_floor(floor: dict[str, Any], schema_version: int) -> None:
     floor_fields = set(BASE_FLOOR_FIELDS)
     if schema_version >= 2:
         floor_fields.add("account_overrides")
+    if schema_version >= 4:
+        floor_fields.add("vertex_capability_profiles")
     missing = sorted(floor_fields - set(floor))
     if missing:
         raise RuntimeError("model surface bundle omitted account_model_mapping fields: " + ", ".join(missing))
@@ -149,6 +151,41 @@ def _validate_floor(floor: dict[str, Any], schema_version: int) -> None:
         _validate_account_overrides(floor.get("account_overrides"))
         if schema_version >= 2 else {}
     )
+
+    vertex_profiles: dict[str, dict[str, str]] = {}
+    if schema_version >= 4:
+        raw_profiles = floor.get("vertex_capability_profiles")
+        if not isinstance(raw_profiles, dict) or not raw_profiles:
+            raise RuntimeError(
+                "model surface bundle account_model_mapping.vertex_capability_profiles must be non-empty"
+            )
+        shared = channel_types.get("41")
+        if not isinstance(shared, dict) or not shared:
+            raise RuntimeError(
+                "vertex_capability_profiles require a non-empty newapi channel_type 41 shared floor"
+            )
+        public_profile_names: set[str] = set()
+        for profile, mapping in raw_profiles.items():
+            if (
+                not isinstance(profile, str)
+                or not profile.strip()
+                or profile != profile.strip().lower()
+            ):
+                raise RuntimeError("vertex_capability_profiles contains an invalid profile name")
+            if profile in public_profile_names:
+                raise RuntimeError(f"vertex_capability_profiles duplicates profile {profile!r}")
+            public_profile_names.add(profile)
+            clean = _validate_mapping(
+                f"account_model_mapping.vertex_capability_profiles.{profile}", mapping)
+            missing_shared = sorted(
+                key for key, target in shared.items() if clean.get(key) != target
+            )
+            if missing_shared:
+                raise RuntimeError(
+                    f"vertex_capability_profiles.{profile} does not contain the complete shared floor: "
+                    + ", ".join(missing_shared)
+                )
+            vertex_profiles[profile] = clean
 
     scopes = floor.get("antigravity_group_scopes")
     if not isinstance(scopes, list) or not scopes:
@@ -188,6 +225,16 @@ def _validate_floor(floor: dict[str, Any], schema_version: int) -> None:
         if conflicts:
             raise RuntimeError(
                 f"account_model_mapping.newapi_channel_types.{channel_type} requires forbidden keys: "
+                + ", ".join(conflicts)
+            )
+    for profile, mapping in vertex_profiles.items():
+        conflicts = sorted(
+            key for key in mapping
+            if key in blocked or any(key.startswith(prefix) for prefix in prefixes)
+        )
+        if conflicts:
+            raise RuntimeError(
+                f"account_model_mapping.vertex_capability_profiles.{profile} requires forbidden keys: "
                 + ", ".join(conflicts)
             )
     for override in account_overrides:

--- a/ops/pricing/modelops.py
+++ b/ops/pricing/modelops.py
@@ -893,7 +893,10 @@ def _account_platform_allows_scope(account_platform: str, account_scope: str) ->
     if account_platform == "openai":
         return account_scope in {"openai_ainzy_relay", "openai_tokensea_relay", "openai_cloudwise_relay"}
     if account_platform == "newapi":
-        return account_scope.startswith("newapi_channel_type:")
+        return (
+            account_scope.startswith("newapi_channel_type:")
+            or account_scope.startswith("newapi_vertex_profile:")
+        )
     return False
 
 
@@ -922,6 +925,9 @@ def _bundle_mapping_scopes(bundle: dict[str, Any]) -> dict[str, dict[str, str]]:
     for channel_type, mapping in (floor.get("newapi_channel_types") or {}).items():
         if isinstance(mapping, dict):
             scopes[f"newapi_channel_type:{channel_type}"] = dict(mapping)
+    for profile, mapping in (floor.get("vertex_capability_profiles") or {}).items():
+        if isinstance(mapping, dict):
+            scopes[f"newapi_vertex_profile:{profile}"] = dict(mapping)
     for override in floor.get("account_overrides") or []:
         if isinstance(override, dict) and isinstance(override.get("model_mapping"), dict):
             scopes[_BUNDLE.account_override_scope(override)] = dict(override["model_mapping"])

--- a/ops/pricing/test_model_activation.py
+++ b/ops/pricing/test_model_activation.py
@@ -37,7 +37,10 @@ class ModelActivationTest(unittest.TestCase):
         self.now = dt.datetime(2026, 7, 15, 8, 0, tzinfo=dt.timezone.utc)
         current_floor = {
             "platforms": {"openai": {"gpt-current": "gpt-current"}},
-            "newapi_channel_types": {},
+            "newapi_channel_types": {"41": {"vertex-shared": "vertex-shared"}},
+            "vertex_capability_profiles": {
+                "core-pro": {"vertex-shared": "vertex-shared"},
+            },
             "account_overrides": [],
             "antigravity_group_scopes": ["claude"],
             "forbidden_model_mapping_keys": {},
@@ -50,7 +53,10 @@ class ModelActivationTest(unittest.TestCase):
                     "gpt-new": "gpt-new-upstream",
                 },
             },
-            "newapi_channel_types": {},
+            "newapi_channel_types": {"41": {"vertex-shared": "vertex-shared"}},
+            "vertex_capability_profiles": {
+                "core-pro": {"vertex-shared": "vertex-shared"},
+            },
             "account_overrides": [],
             "antigravity_group_scopes": ["claude"],
             "forbidden_model_mapping_keys": {},
@@ -190,9 +196,43 @@ class ModelActivationTest(unittest.TestCase):
         self.assertTrue(MODEL_OPS._account_platform_allows_scope("anthropic", "kiro"))
         self.assertTrue(MODEL_OPS._account_platform_allows_scope("newapi", "newapi_channel_type:17"))
         self.assertTrue(MODEL_OPS._account_platform_allows_scope(
+            "newapi", "newapi_vertex_profile:core-pro"
+        ))
+        self.assertTrue(MODEL_OPS._account_platform_allows_scope(
             "newapi", "account_override:newapi:45:https://ark.cn-beijing.volces.com/api/plan/v3"
         ))
         self.assertFalse(MODEL_OPS._account_platform_allows_scope("kiro", "anthropic"))
+
+    def test_vertex_profile_scope_is_part_of_activation_delta_and_evidence(self) -> None:
+        target_floor = json.loads(json.dumps(self.current["account_model_mapping"]))
+        target_floor["vertex_capability_profiles"]["core-pro"]["gemini-pro"] = "gemini-pro"
+        self.target_path, self.target = self.write_bundle("target-vertex-profile.json", target_floor)
+        scope = "newapi_vertex_profile:core-pro"
+        self.write_evidence(
+            scope=scope,
+            model_id="gemini-pro",
+            target="gemini-pro",
+            account_id="47",
+            account_platform="newapi",
+            account_scope=scope,
+        )
+        context = self.build_context()
+        self.assertEqual([row["scope"] for row in context["delta"]["activated"]], [scope])
+
+    def test_vertex_profile_evidence_must_match_exact_profile_scope(self) -> None:
+        target_floor = json.loads(json.dumps(self.current["account_model_mapping"]))
+        target_floor["vertex_capability_profiles"]["core-pro"]["gemini-pro"] = "gemini-pro"
+        self.target_path, self.target = self.write_bundle("target-vertex-profile-bad.json", target_floor)
+        self.write_evidence(
+            scope="newapi_vertex_profile:core-pro",
+            model_id="gemini-pro",
+            target="gemini-pro",
+            account_id="47",
+            account_platform="newapi",
+            account_scope="newapi_channel_type:41",
+        )
+        with self.assertRaisesRegex(MODEL_OPS.ActivationError, "must match mapping scope"):
+            self.build_context()
 
     def test_us035_account_override_scope_is_part_of_activation_delta(self) -> None:
         target = self.use_account_override_target()
@@ -235,6 +275,7 @@ class ModelActivationTest(unittest.TestCase):
     def test_us035_v1_current_bundle_remains_readable(self) -> None:
         legacy_floor = json.loads(json.dumps(self.current["account_model_mapping"]))
         legacy_floor.pop("account_overrides")
+        legacy_floor.pop("vertex_capability_profiles")
         legacy_bundle = {
             "schema_version": 1,
             "floor_sha256": MODEL_OPS._BUNDLE.floor_sha256(legacy_floor),
@@ -246,6 +287,25 @@ class ModelActivationTest(unittest.TestCase):
             MODEL_OPS._BUNDLE.load_bundle(legacy_path)["schema_version"],
             1,
         )
+
+    def test_schema_v3_bundle_remains_readable(self) -> None:
+        legacy_floor = json.loads(json.dumps(self.current["account_model_mapping"]))
+        legacy_floor.pop("vertex_capability_profiles")
+        legacy_bundle = {
+            "schema_version": 3,
+            "floor_sha256": MODEL_OPS._BUNDLE.floor_sha256(legacy_floor),
+            "account_model_mapping": legacy_floor,
+        }
+        legacy_path = self.root / "legacy-v3.json"
+        legacy_path.write_text(json.dumps(legacy_bundle), encoding="utf-8")
+        self.assertEqual(MODEL_OPS._BUNDLE.load_bundle(legacy_path)["schema_version"], 3)
+
+    def test_schema_v4_profile_must_contain_shared_floor(self) -> None:
+        bad_floor = json.loads(json.dumps(self.current["account_model_mapping"]))
+        bad_floor["vertex_capability_profiles"]["core-pro"] = {"profile-only": "profile-only"}
+        bad_path, _ = self.write_bundle("bad-vertex-profile.json", bad_floor)
+        with self.assertRaisesRegex(RuntimeError, "complete shared floor"):
+            MODEL_OPS._BUNDLE.load_bundle(bad_path)
 
     def test_us035_id_keyed_schema_v2_is_rejected(self) -> None:
         legacy_floor = json.loads(json.dumps(self.current["account_model_mapping"]))
@@ -371,7 +431,10 @@ class ModelActivationTest(unittest.TestCase):
     def test_us035_self_digested_invalid_bundle_is_rejected(self) -> None:
         bad_floor = {
             "platforms": {"openai": {"": "bad-target"}},
-            "newapi_channel_types": {},
+            "newapi_channel_types": {"41": {"vertex-shared": "vertex-shared"}},
+            "vertex_capability_profiles": {
+                "core-pro": {"vertex-shared": "vertex-shared"},
+            },
             "account_overrides": [],
             "antigravity_group_scopes": ["claude"],
             "forbidden_model_mapping_keys": {},

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -209,6 +209,8 @@ cleanup() {
 	DELETE FROM account_groups WHERE group_id = ${GROUP_ID};
 	UPDATE api_keys SET status='disabled', updated_at=NOW() WHERE group_id = ${GROUP_ID} AND name = '$(sql_escape "$KEY_NAME")' AND deleted_at IS NULL;
 	UPDATE groups SET status='disabled', updated_at=NOW() WHERE id = ${GROUP_ID} AND name = '$(sql_escape "$GROUP_NAME")' AND deleted_at IS NULL;
+	INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+	VALUES ('group_changed', NULL, ${GROUP_ID}, NULL);
 	" >/dev/null 2>&1 || true # preflight-allow: swallow
     else
       "${PSQL[@]}" -c "
@@ -321,6 +323,8 @@ DELETE FROM account_groups WHERE group_id = ${GROUP_ID};
 INSERT INTO account_groups (account_id, group_id, priority, created_at)
 VALUES (${ACCOUNT_ID}, ${GROUP_ID}, 1, NOW())
 ON CONFLICT (account_id, group_id) DO NOTHING;
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+VALUES ('group_changed', NULL, ${GROUP_ID}, NULL);
 " >/dev/null
 
 if [[ "$PROBE_REUSE_MODE" == "1" ]]; then

--- a/ops/stage0/probe_account_upstream_models.sh
+++ b/ops/stage0/probe_account_upstream_models.sh
@@ -19,6 +19,7 @@ if [[ ! "$REQUEST_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || [[ "$REQUEST_TIMEOUT_SECOND
 fi
 
 python3 - "$ACCOUNT_ID" "$BASE_URL" "$TARGET_MODELS" "$MODEL" "$REQUEST_TIMEOUT_SECONDS" <<'PY'
+import ipaddress
 import json
 import re
 import ssl
@@ -49,13 +50,26 @@ def validate_base_url(raw):
         setup_error("BASE_URL must not contain userinfo, query, or fragment")
     if parsed.path.rstrip("/") != "/api/v1":
         setup_error("BASE_URL path must be /api/v1")
-    is_loopback = hostname in {"127.0.0.1", "localhost", "::1"}
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        address = None
+    is_loopback = hostname == "localhost" or bool(address and address.is_loopback)
+    private_networks = (
+        ipaddress.ip_network("10.0.0.0/8"),
+        ipaddress.ip_network("172.16.0.0/12"),
+        ipaddress.ip_network("192.168.0.0/16"),
+    )
+    is_private_literal = bool(
+        address and address.version == 4
+        and any(address in network for network in private_networks)
+    )
     is_tokenkey_api = re.fullmatch(r"api(?:-[a-z0-9]+(?:-[a-z0-9]+)*)?\.tokenkey\.dev", hostname)
-    if parsed.scheme == "http" and is_loopback:
+    if parsed.scheme == "http" and (is_loopback or is_private_literal):
         return raw.rstrip("/")
     if parsed.scheme == "https" and is_tokenkey_api and port in {None, 443}:
         return raw.rstrip("/")
-    setup_error("BASE_URL must use loopback HTTP or a TokenKey API HTTPS host")
+    setup_error("BASE_URL must use private/loopback literal HTTP or a TokenKey API HTTPS host")
 
 
 class NoRedirect(HTTPRedirectHandler):

--- a/ops/stage0/probe_grok_upstream_model.sh
+++ b/ops/stage0/probe_grok_upstream_model.sh
@@ -8,6 +8,7 @@ ACCOUNT_ID="${ACCOUNT_ID:?ACCOUNT_ID required}"
 MODEL="${MODEL:?MODEL required}"
 MAX_TOKENS="${MAX_TOKENS:-16}"
 PROMPT_TEXT="${PROMPT_TEXT:-Reply OK only.}"
+ENDPOINT="${ENDPOINT:-chat}"
 UPSTREAM_BASE="${UPSTREAM_BASE:-https://api.x.ai/v1}"
 
 PSQL=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -q -A -t -v ON_ERROR_STOP=1)
@@ -25,6 +26,9 @@ if [[ ! "$ACCOUNT_ID" =~ ^[0-9]+$ ]]; then
 fi
 if [[ ! "$MAX_TOKENS" =~ ^[0-9]+$ ]] || [[ "$MAX_TOKENS" -lt 1 ]]; then
   fail_json "MAX_TOKENS must be a positive integer"
+fi
+if [[ "$ENDPOINT" != "chat" && "$ENDPOINT" != "responses" ]]; then
+  fail_json "ENDPOINT must be chat or responses"
 fi
 
 psql_err="$(mktemp)"
@@ -59,16 +63,35 @@ if [[ -n "${UPSTREAM_BASE}" ]]; then
   BASE_URL="${UPSTREAM_BASE%/}"
 fi
 
-payload="$(python3 - "$MODEL" "$MAX_TOKENS" "$PROMPT_TEXT" <<'PY'
+payload="$(python3 - "$MODEL" "$MAX_TOKENS" "$PROMPT_TEXT" "$ENDPOINT" <<'PY'
 import json, sys
-print(json.dumps({
-    "model": sys.argv[1],
-    "messages": [{"role": "user", "content": sys.argv[3]}],
-    "max_tokens": int(sys.argv[2]),
-    "stream": False,
-}, ensure_ascii=False))
+model, max_tokens, prompt, endpoint = sys.argv[1:5]
+if endpoint == "responses":
+    payload = {
+        "model": model,
+        "instructions": "You are a terse probe responder.",
+        "input": [{
+            "type": "message", "role": "user",
+            "content": [{"type": "input_text", "text": prompt}],
+        }],
+        "max_output_tokens": int(max_tokens),
+        "stream": False,
+    }
+else:
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": int(max_tokens),
+        "stream": False,
+    }
+print(json.dumps(payload, ensure_ascii=False))
 PY
 )"
+if [[ "$ENDPOINT" == "responses" ]]; then
+  PROBE_PATH="/responses"
+else
+  PROBE_PATH="/chat/completions"
+fi
 
 tmp_body="$(mktemp)"
 tmp_hdr="$(mktemp)"
@@ -78,7 +101,7 @@ http_code="$(
     -H "Authorization: Bearer ${ACCESS_TOKEN}" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -X POST "${BASE_URL}/chat/completions" \
+    -X POST "${BASE_URL}${PROBE_PATH}" \
     --data-binary "$payload" || echo "000"
 )"
 
@@ -98,10 +121,10 @@ PY
 
 rm -f "$tmp_body" "$tmp_hdr"
 
-python3 - "$ACCOUNT_ID" "$ACCOUNT_NAME" "$PLATFORM" "$MODEL" "$BASE_URL" "$http_code" "$body_excerpt" <<'PY'
+python3 - "$ACCOUNT_ID" "$ACCOUNT_NAME" "$PLATFORM" "$MODEL" "$BASE_URL" "$http_code" "$body_excerpt" "$PROBE_PATH" <<'PY'
 import json, sys
 
-account_id, account_name, platform, model, base_url, http_code, body_excerpt = sys.argv[1:8]
+account_id, account_name, platform, model, base_url, http_code, body_excerpt, endpoint = sys.argv[1:9]
 http_code = str(http_code)
 verdict = "setup_error"
 if http_code.startswith("2"):
@@ -125,7 +148,7 @@ print(json.dumps({
         "platform": platform,
         "model": model,
         "upstream_base": base_url,
-        "endpoint": "chat/completions",
+        "endpoint": endpoint.lstrip("/"),
     },
     "response": {"body_excerpt": body_excerpt},
 }, ensure_ascii=False, indent=2))

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -66,6 +66,22 @@ class ProbeAccountModelTest(unittest.TestCase):
         bind_at = script.index("INSERT INTO account_groups (account_id, group_id, priority, created_at)")
         self.assertLess(unbind_at, bind_at)
 
+    def test_rebinding_group_notifies_scheduler_snapshot(self) -> None:
+        script = _SCRIPT.read_text()
+        bind_at = script.index("INSERT INTO account_groups (account_id, group_id, priority, created_at)")
+        key_at = script.index('if [[ "$PROBE_REUSE_MODE" == "1" ]]; then\n  NEW_API_KEY=', bind_at)
+        binding_sql = script[bind_at:key_at]
+
+        self.assertIn("INSERT INTO scheduler_outbox", binding_sql)
+        self.assertIn("'group_changed'", binding_sql)
+        self.assertIn("${GROUP_ID}", binding_sql)
+
+        cleanup_at = script.index("cleanup() {")
+        trap_at = script.index("trap cleanup EXIT", cleanup_at)
+        cleanup_sql = script[cleanup_at:trap_at]
+        self.assertIn("INSERT INTO scheduler_outbox", cleanup_sql)
+        self.assertIn("'group_changed'", cleanup_sql)
+
     def test_probe_script_wires_verdict_module_and_embeddings_endpoint(self) -> None:
         script = _SCRIPT.read_text()
 

--- a/ops/stage0/test_probe_account_upstream_models.py
+++ b/ops/stage0/test_probe_account_upstream_models.py
@@ -89,12 +89,20 @@ class ProbeAccountUpstreamModelsTest(unittest.TestCase):
             "https://api-us4.tokenkey.dev:8443/api/v1",
             "https://api-us4.tokenkey.dev/api/v1?next=evil",
             "https://api-us4.tokenkey.dev/not-api/v1",
+            "http://example.test/api/v1",
+            "http://0.0.0.0/api/v1",
+            "http://169.254.169.254/api/v1",
         ]
         for base_url in unsafe:
             with self.subTest(base_url=base_url):
                 got = self.run_probe(base_url=base_url)
                 self.assertEqual(got["verdict"], "setup_error")
                 self.assertIn("BASE_URL", got["error"])
+
+    def test_allows_private_ipv4_literal_for_container_network(self):
+        script = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn('ipaddress.ip_network("172.16.0.0/12")', script)
+        self.assertIn('parsed.scheme == "http" and (is_loopback or is_private_literal)', script)
 
     def test_lists_models_from_an_allowed_loopback_target(self):
         seen = {}

--- a/ops/stage0/test_probe_grok_upstream_model.py
+++ b/ops/stage0/test_probe_grok_upstream_model.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("probe_grok_upstream_model.sh")
+
+
+class _Server:
+    def __init__(self, handler):
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.httpd.server_port}/v1"
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_args):
+        self.httpd.shutdown()
+        self.thread.join(timeout=2)
+        self.httpd.server_close()
+
+
+class ProbeGrokUpstreamModelTest(unittest.TestCase):
+    def run_probe(self, *, base_url: str, endpoint: str | None = None) -> dict:
+        row = "test-token\thttps://api.x.ai/v1\tgrok-test\tgrok"
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_sudo = Path(tmp) / "sudo"
+            fake_sudo.write_text(
+                "#!/bin/sh\n" f"printf '%s\\n' {shlex.quote(row)}\n",
+                encoding="utf-8",
+            )
+            fake_sudo.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{tmp}:{os.environ.get('PATH', '')}",
+                "ACCOUNT_ID": "65",
+                "MODEL": "grok-4.20-multi-agent-0309",
+                "UPSTREAM_BASE": base_url,
+            }
+            if endpoint is not None:
+                env["ENDPOINT"] = endpoint
+            proc = subprocess.run(
+                ["bash", str(SCRIPT)],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+        return json.loads(proc.stdout)
+
+    def test_responses_uses_responses_request_shape(self):
+        seen = {}
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                seen["path"] = self.path
+                seen["authorization"] = self.headers.get("authorization")
+                length = int(self.headers.get("content-length", "0"))
+                seen["body"] = json.loads(self.rfile.read(length))
+                body = json.dumps({"id": "resp-test", "output": []}).encode()
+                self.send_response(200)
+                self.send_header("content-type", "application/json")
+                self.send_header("content-length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_args):
+                pass
+
+        with _Server(Handler) as server:
+            result = self.run_probe(base_url=server.base_url, endpoint="responses")
+        self.assertEqual(result["verdict"], "servable")
+        self.assertEqual(result["probe"]["endpoint"], "responses")
+        self.assertEqual(seen["path"], "/v1/responses")
+        self.assertEqual(seen["authorization"], "Bearer test-token")
+        self.assertNotIn("messages", seen["body"])
+        self.assertEqual(seen["body"]["input"][0]["content"][0]["type"], "input_text")
+        self.assertEqual(seen["body"]["max_output_tokens"], 16)
+
+    def test_default_remains_chat_completions(self):
+        seen = {}
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                seen["path"] = self.path
+                length = int(self.headers.get("content-length", "0"))
+                seen["body"] = json.loads(self.rfile.read(length))
+                body = json.dumps({"choices": []}).encode()
+                self.send_response(200)
+                self.send_header("content-length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_args):
+                pass
+
+        with _Server(Handler) as server:
+            result = self.run_probe(base_url=server.base_url)
+        self.assertEqual(result["probe"]["endpoint"], "chat/completions")
+        self.assertEqual(seen["path"], "/v1/chat/completions")
+        self.assertIn("messages", seen["body"])
+        self.assertNotIn("input", seen["body"])
+
+    def test_rejects_unknown_endpoint(self):
+        result = self.run_probe(base_url="http://127.0.0.1:1/v1", endpoint="video")
+        self.assertEqual(result["verdict"], "setup_error")
+        self.assertIn("ENDPOINT", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/checks/catalog-serving-drift.py
+++ b/scripts/checks/catalog-serving-drift.py
@@ -66,7 +66,7 @@ MODE_FIELDS = {
 }
 
 # Native platforms that actually have a Go servable-allowlist map.
-ALLOWLIST_PLATFORMS = ("anthropic", "openai", "gemini", "antigravity")
+ALLOWLIST_PLATFORMS = ("anthropic", "openai", "gemini", "antigravity", "grok")
 
 # A4 advisory: overlay vendors whose chat models are the manifest's curated long-tail.
 ENUMERATION_PROVIDERS = {"dashscope", "deepseek", "moonshot", "volcengine", "zhipu", "bigmodel", "zai"}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2602,9 +2602,10 @@
     {
       "path": "ops/pricing/model_surface_bundle.py",
       "must_contain": [
-        "SCHEMA_VERSION = 3",
+        "SCHEMA_VERSION = 4",
         "SUPPORTED_SCHEMA_VERSIONS",
         "account_overrides",
+        "vertex_capability_profiles",
         "def canonical_json(",
         "def floor_sha256(",
         "def _validate_floor(",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -723,6 +723,17 @@
       "rationale": "Canonicalizes legacy Agent Plan aliases and pasted /api/plan/* endpoint shapes to the native /api/plan/v3 root. TokenKey routing must not depend on a new-api fork or ChannelSpecialBases entry."
     },
     {
+      "path": "backend/internal/service/account_model_mapping_vertex_tk.go",
+      "must_contain": [
+        "VertexCapabilityProfileCredentialKey",
+        "vertexSharedModelMappingIDs",
+        "vertexCapabilityProfileExtraIDs",
+        "vertexCapabilityProfileModelMappingIDs",
+        "vertexCapabilityProfileMappingsForOps"
+      ],
+      "rationale": "Vertex channel_type 41 is the sole account-varying capability scope. This owner separates the verified public union from the strict shared intersection and complete named profile floors. Its selector is a non-secret credential property, never an account ID/name; unknown or missing profiles fail safe to the shared floor. Losing this companion would either over-provision unknown Vertex service-account projects with the union or make profile-specific activation impossible to express in the immutable bundle."
+    },
+    {
       "path": "backend/internal/service/account_model_mapping_preset_tk.go",
       "must_contain": [
         "accountModelMappingOverrideAccounts",


### PR DESCRIPTION
## Summary

- refresh the verified model surface from configured upstream accounts while keeping serving, display, pricing, runtime mapping, and the generated bundle aligned
- constrain account capability profiles to the sole exception, Vertex `newapi/channel_type=41`: public display uses the verified account union, the unknown-account floor uses the strict shared intersection, and named capability profiles add only verified account-class extras
- preserve compatible mapping extras while repairing required keys and removing explicitly forbidden keys/prefixes
- promote five DashScope China models with official regional pricing and verified runtime attribution:
  - `qwen3.7-flash`
  - `qwen3.7-flash-2026-07-15`
  - `qwen3.8-2.4t-a95b`
  - `qwen3.8-max`
  - `glm-5.2-fast-preview`
- add read-only refresh reporting and upstream-list/probe support, including scheduler snapshot invalidation when reusable probe groups are rebound

## Live evidence

- DashScope accounts 60, 72, and 77 passed all 15 exact-account gateway probes: 5 models × 3 accounts, with HTTP 2xx and `usage_match.account_id` equal to the expected account
- pricing uses official Alibaba DashScope China-mainland rates; the registry stores pre-tax list prices and the existing provider tax policy remains the runtime owner
- Vertex channel 41 floors/profiles derive from direct per-account evidence; unknown or invalid profiles fail safe to the shared floor
- Ark account 88 models and mappings are unchanged; this PR removes no Ark model
- XRToken and CloudWise capability findings were diagnostic only and do not alter their mappings in this PR

## Safety and contracts

- non-channel-41 account divergence fails closed; profile mechanics do not spread to other platforms/channels
- gateway rejection before account attribution is not treated as raw-provider unsupported
- reusable probe binding and cleanup now emit `scheduler_outbox` `group_changed`, preventing stale scheduler snapshots from routing a supposedly exclusive probe to another account
- generated model-surface bundle is schema 4 and is checked against the Go owner
- the approved model-surface activation contract update is intentional
- no credentials, release, deployment, runtime activation, or Edge mapping changes are included

## Verification

- `git diff --check origin/main...HEAD`
- `bash scripts/preflight.sh`
- `make test`
  - Go unit tests passed
  - golangci-lint: 0 issues
  - frontend lint and typecheck passed
  - frontend: 14 files / 175 tests passed

`sentinel-registry-reviewed`: reviewed the edited catalog-serving drift checker; its existing pricing-availability ownership remains sufficient and no new anchor is required.

ai
