### PR TITLE
feat(ops): add focused SSOT closeout

### DIFF
--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      ssot_models:
+        description: "Optional comma/space-separated model IDs. smoke-only runs the focused universal-key SSOT gate for exactly these models; empty keeps the platform canary."
+        required: false
+        type: string
+        default: ""
 
 # Default to read-only. The deploy job explicitly opts into AWS OIDC and package
 # access; smoke-only cannot obtain either capability.
@@ -360,6 +365,7 @@ jobs:
       INPUT_TAG: ${{ inputs.tag }}
       TOKENKEY_BASE_URL: ${{ vars.PROD_API_URL || 'https://api.tokenkey.dev' }}
       TK_FULLTEST_BASE_URL: ${{ vars.PROD_API_URL || 'https://api.tokenkey.dev' }}
+      INPUT_SSOT_MODELS: ${{ inputs.ssot_models }}
       GATEWAY_SMOKE_SUITE: full
     steps:
       - uses: actions/checkout@v6
@@ -402,7 +408,11 @@ jobs:
           TK_FULLTEST_TIMEOUT: "15"
         run: |
           set -euo pipefail
-          bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout
+          if [[ -n "${INPUT_SSOT_MODELS//[[:space:]]/}" ]]; then
+            python3 scripts/checks/ssot-delta-gate.py focused --models "$INPUT_SSOT_MODELS"
+          else
+            bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout
+          fi
 
       - name: Job summary
         if: always()
@@ -418,5 +428,6 @@ jobs:
             echo "- api: ${TOKENKEY_BASE_URL}"
             echo "- gateway smoke: ${GATEWAY_SMOKE_OUTCOME:-not-run}"
             echo "- SSOT display gate: ${SSOT_GATE_OUTCOME:-not-run}"
+            echo "- focused SSOT models: ${INPUT_SSOT_MODELS:-platform-canary}"
             echo "- safety: no image or host state was changed"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/ops/stage0/test_deploy_stage0_workflow.py
+++ b/ops/stage0/test_deploy_stage0_workflow.py
@@ -40,6 +40,18 @@ class DeployStage0WorkflowTest(unittest.TestCase):
         self.assertIn("default: deploy", body)
         self.assertRegex(body, r"(?ms)options:\s*\n\s*- deploy\s*\n\s*- smoke-only\s*$")
 
+    def test_focused_ssot_input_is_optional_and_defaults_empty(self) -> None:
+        text = workflow_text()
+        focused = re.search(
+            r"(?ms)^      ssot_models:\n(?P<body>.*?)(?=^      [A-Za-z0-9_-]+:\n|^# Default)",
+            text,
+        )
+        self.assertIsNotNone(focused)
+        body = focused.group("body")
+        self.assertIn("required: false", body)
+        self.assertIn("type: string", body)
+        self.assertIn('default: ""', body)
+
     def test_deploy_job_retains_mutating_capabilities_and_canonical_gates(self) -> None:
         deploy = job_block("deploy")
         self.assertIn("if: inputs.operation == 'deploy'", deploy)
@@ -94,6 +106,11 @@ class DeployStage0WorkflowTest(unittest.TestCase):
             "bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout",
             smoke,
         )
+        self.assertIn(
+            'python3 scripts/checks/ssot-delta-gate.py focused --models "$INPUT_SSOT_MODELS"',
+            smoke,
+        )
+        self.assertIn("INPUT_SSOT_MODELS: ${{ inputs.ssot_models }}", smoke)
         self.assertIn("TK_SMOKE_API_KEY: ${{ secrets.TK_SMOKE_API_KEY }}", smoke)
         self.assertIn("TK_FULLTEST_KEY: ${{ secrets.TK_FULLTEST_KEY }}", smoke)
 

--- a/scripts/checks/ssot-delta-gate.py
+++ b/scripts/checks/ssot-delta-gate.py
@@ -43,6 +43,8 @@ ALLOWLIST_PLATFORMS = ("anthropic", "openai", "gemini", "antigravity", "grok")
 MATRIX = REPO / "ops/test/gateway_model_ssot_matrix.py"
 
 MODEL_ID_RE = re.compile(r'"([a-zA-Z0-9][a-zA-Z0-9._-]{0,127})"\s*:\s*"')
+MODEL_ID_FULL_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$")
+MAX_FOCUSED_MODELS = 50
 MIGRATION_ADDED_MODEL_RE = re.compile(
     r'^\+\s*"(?P<id>[a-zA-Z0-9][a-zA-Z0-9._-]{0,127})"\s*:\s*"(?P=id)"'
 )
@@ -275,6 +277,21 @@ def run_focused_gate(models: set[str], *, base_url: str, key: str) -> int:
     return proc.returncode
 
 
+def parse_explicit_models(raw: str) -> set[str]:
+    values = [value for value in re.split(r"[\s,]+", raw.strip()) if value]
+    if not values:
+        raise ValueError("at least one model id is required")
+    invalid = sorted({value for value in values if not MODEL_ID_FULL_RE.fullmatch(value)})
+    if invalid:
+        raise ValueError("invalid model id(s): " + ", ".join(invalid))
+    models = set(values)
+    if len(models) > MAX_FOCUSED_MODELS:
+        raise ValueError(
+            f"focused gate accepts at most {MAX_FOCUSED_MODELS} unique model ids"
+        )
+    return models
+
+
 def cmd_paths_changed(args) -> int:
     if not _base_resolves(args.base):
         print("false")
@@ -335,6 +352,25 @@ def cmd_check(args) -> int:
     rc = run_focused_gate(models, base_url=base_url, key=key)
     if rc == 0:
         print("ssot-delta-gate: ok (focused live gate passed)")
+    return rc
+
+
+def cmd_focused(args) -> int:
+    try:
+        models = parse_explicit_models(args.models)
+    except ValueError as exc:
+        print(f"ssot-delta-gate: error: {exc}", file=sys.stderr)
+        return 2
+    key = args.key or os.environ.get("TK_FULLTEST_KEY", "")
+    if not key:
+        print("ssot-delta-gate: error: TK_FULLTEST_KEY required for live gate", file=sys.stderr)
+        return 2
+    base_url = args.base_url or os.environ.get(
+        "TK_FULLTEST_BASE_URL", "https://api.tokenkey.dev"
+    )
+    rc = run_focused_gate(models, base_url=base_url, key=key)
+    if rc == 0:
+        print("ssot-delta-gate: ok (explicit focused live gate passed)")
     return rc
 
 
@@ -400,6 +436,20 @@ def cmd_selftest(_args) -> int:
         },
         {"shown-priced", "shown-free"},
     ) == {"shown-priced"}
+    assert parse_explicit_models("model-a, model-b\nmodel-a") == {"model-a", "model-b"}
+    for invalid in ("", "model/a", "model;echo", "-leading"):
+        try:
+            parse_explicit_models(invalid)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"accepted invalid explicit model input: {invalid!r}")
+    try:
+        parse_explicit_models(" ".join(f"model-{i}" for i in range(MAX_FOCUSED_MODELS + 1)))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("accepted an unbounded focused model set")
 
     print("ssot-delta-gate selftest: PASS")
     return 0
@@ -420,6 +470,13 @@ def main() -> int:
             p.add_argument("--key", default="", help="override TK_FULLTEST_KEY")
             p.add_argument("--base-url", default="", help="override TK_FULLTEST_BASE_URL")
         p.set_defaults(func=globals()[f"cmd_{name.replace('-', '_')}"])
+    focused = sub.add_parser(
+        "focused", help="run a focused live gate for explicit comma/space-separated model ids"
+    )
+    focused.add_argument("--models", required=True)
+    focused.add_argument("--key", default="", help="override TK_FULLTEST_KEY")
+    focused.add_argument("--base-url", default="", help="override TK_FULLTEST_BASE_URL")
+    focused.set_defaults(func=cmd_focused)
     st = sub.add_parser("selftest")
     st.set_defaults(func=cmd_selftest)
     args = ap.parse_args()


### PR DESCRIPTION
## Summary

- add an optional `ssot_models` input to the existing read-only Stage0 `smoke-only` operation
- run the universal-key SSOT matrix with required rows for exactly the requested model IDs
- keep the existing platform canary unchanged when the input is empty
- validate model IDs centrally and cap focused runs at 50 unique models

## Safety

- `smoke-only` remains bound to the `prod` Environment with `contents: read` only
- no AWS OIDC, SSM, package, Docker, deploy, pricing, mapping, or runtime mutation capability is added
- workflow input is passed through a quoted environment variable and validated before subprocess construction
- sentinel-registry-reviewed: existing workflow and contract-test anchors cover this read-only dispatch branch; no new upstream-merge semantic anchor is required

## Verification

- `python3 scripts/checks/ssot-delta-gate.py selftest`
- `python3 -m unittest ops.stage0.test_deploy_stage0_workflow`
- `bash scripts/preflight.sh`
- `go test -tags=unit ./...`
- `golangci-lint run ./... --concurrency=4`
- `pnpm lint:check`
- `pnpm typecheck`

no-web-impact

ai
