### PR TITLE
fix(ops): 修复分区探针 stdin 传输

### DIFF
--- a/ops/observability/probe-data-layer-safety.sh
+++ b/ops/observability/probe-data-layer-safety.sh
@@ -2,7 +2,7 @@
 # Read-only host-side protection probe; verdict logic lives in the Python sibling.
 set -u
 
-PSQL=(docker exec -e 'PGOPTIONS=-c default_transaction_read_only=on -c lock_timeout=100ms -c statement_timeout=2s' tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
+PSQL=(docker exec -i -e 'PGOPTIONS=-c default_transaction_read_only=on -c lock_timeout=100ms -c statement_timeout=2s' tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1)
 APP_CONTAINER="${APP_CONTAINER:-auto}"
 
 # Canonical app-container resolver (ops/lib/resolve-app-container.sh) is the sole

--- a/ops/observability/test_probe_data_layer_safety.py
+++ b/ops/observability/test_probe_data_layer_safety.py
@@ -71,6 +71,14 @@ class ProbeDataLayerSafetyTest(unittest.TestCase):
                       if [[ "$*" == *telemetry_archive_shadow* ]]; then
                         printf '%s\n' 'TELEMETRYSTATS {"probe_ok":true,"enabled":true,"last_result":{"dropped":0,"failed":0}}'
                       else
+                        has_i=false
+                        for arg in "$@"; do
+                          if [ "$arg" = "-i" ]; then
+                            has_i=true
+                            break
+                          fi
+                        done
+                        [ "$has_i" = true ] || exit 2
                         query="$(cat)"
                         printf '%s' "$query" > "$FAKE_PARTITION_STDIN"
                         [ "${PARTITION_FAILURE:-false}" = true ] && exit 1
@@ -180,6 +188,7 @@ class ProbeDataLayerSafetyTest(unittest.TestCase):
             telemetry={"tokenkey": "false"},
         )
         self.assertEqual(partition, {"probe_ok": True})
+        self.assertIn("exec -i -e", calls)
         self.assertIn("PARTITION_SQL:", calls)
         self.assertIn("pg_get_expr(child.relpartbound, child.oid, true)", calls)
 


### PR DESCRIPTION
## 背景

v1.8.152 的分区覆盖 SQL 已按真实 PostgreSQL attached bounds 证明 UTC today + future 7 days，但 host probe 使用文件重定向把 SQL 交给容器内 `psql` 时，`docker exec` 缺少 stdin forwarding。`psql` 因此收到空输入并以 0 退出，daily diagnostics 只能对缺失 `PARTITIONSTATS` fail closed。

## 修改

- 为 data-layer probe 的 `docker exec` 增加 `-i`，确保共享 coverage SQL 真正进入容器。
- fake Docker 严格模拟 stdin boundary：partition SQL 路径缺少 `-i` 时失败。
- 回归测试同时断言 canonical exec 参数与共享 SQL 内容；SQL/verdict schema 不变。

## 风险与边界

- read-only observability 修复，不改变 partition、retention、cleanup、QA、pricing 或 edge 行为。
- 不执行 release、deploy、live probe 或数据/IAM mutation。
- `no-web-impact`

## 验证

- `python3 -m unittest ops.observability.test_probe_data_layer_safety`
- `./scripts/preflight.sh`
- `make test`

上述均通过。首次 `make test` 仅因新 worktree 缺 frontend `node_modules` 失败，执行 `pnpm -C frontend install --frozen-lockfile` 后完整重跑通过。

## 后续独立门禁

本 PR 不授权 merge、release 或 deploy。合并并发布到 prod 后，才以 canonical `run-probe.sh` + shared SQL 和 scheduled diagnostics 取得 live `PARTITIONSTATS` 证据；在此之前不声称生产闭环。

ai
