### PR TITLE
fix(newapi): serve qwen3.8 stream-only protocols

### DIFF
--- a/backend/internal/service/openai_gateway_bridge_responses_fallback.go
+++ b/backend/internal/service/openai_gateway_bridge_responses_fallback.go
@@ -122,9 +122,9 @@ func applyNewAPIResponsesChatFallbackShape(model string, chatBody []byte) []byte
 	}
 
 	requiresStream := isNewAPIResponsesChatFallbackStreamModel(trimmedModel)
-	isQwenPreview := isNewAPIResponsesQwen37PreviewVariant(trimmedModel)
+	requiresThinking := isNewAPIResponsesQwenStreamThinkingVariant(trimmedModel)
 	isQwen3 := isNewAPIQwen3Model(trimmedModel)
-	if !requiresStream && !isQwenPreview && !isQwen3 {
+	if !requiresStream && !requiresThinking && !isQwen3 {
 		return chatBody
 	}
 
@@ -136,7 +136,7 @@ func applyNewAPIResponsesChatFallbackShape(model string, chatBody []byte) []byte
 	if requiresStream {
 		payload["stream"] = true
 	}
-	if isQwenPreview {
+	if requiresThinking {
 		payload["enable_thinking"] = true
 	}
 	normalizeNewAPIQwenNonStreamingPayload(trimmedModel, payload)
@@ -178,7 +178,11 @@ func ensureNewAPIChatFallbackStreamOptions(chatBody []byte) []byte {
 func isNewAPIResponsesChatFallbackStreamModel(model string) bool {
 	return model == "glm-4.5" ||
 		model == "glm-4.5-air" ||
-		isNewAPIResponsesQwen37PreviewVariant(model)
+		isNewAPIResponsesQwenStreamThinkingVariant(model)
+}
+
+func isNewAPIResponsesQwenStreamThinkingVariant(model string) bool {
+	return isNewAPIResponsesQwen37PreviewVariant(model) || model == "qwen3.8-2.4t-a95b"
 }
 
 func isNewAPIResponsesQwen37PreviewVariant(model string) bool {

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
@@ -301,7 +301,7 @@ func TestForwardAsResponsesDispatched_ProactiveChatFallbackSkipsResponsesAdaptor
 	require.Equal(t, "response", gjson.Get(rec.Body.String(), "object").String())
 }
 
-func TestForwardAsResponsesDispatched_NewAPIStreamOnlyModelBuffersNonStreamingClient(t *testing.T) {
+func TestForwardAsResponsesDispatched_Qwen38StreamOnlyModelBuffersNonStreamingClient(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	oldResponses := dispatchNewAPIResponses
@@ -321,24 +321,24 @@ func TestForwardAsResponsesDispatched_NewAPIStreamOnlyModelBuffersNonStreamingCl
 		c.Writer.Header().Set("Content-Type", "text/event-stream")
 		c.Writer.WriteHeader(http.StatusOK)
 		_, _ = c.Writer.Write([]byte(strings.Join([]string{
-			`data: {"id":"chatcmpl_glm","object":"chat.completion.chunk","model":"glm-4.5","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}`,
+			`data: {"id":"chatcmpl_qwen38","object":"chat.completion.chunk","model":"qwen3.8-2.4t-a95b","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}`,
 			"",
-			`data: {"id":"chatcmpl_glm","object":"chat.completion.chunk","model":"glm-4.5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			`data: {"id":"chatcmpl_qwen38","object":"chat.completion.chunk","model":"qwen3.8-2.4t-a95b","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
 			"",
-			`data: {"id":"chatcmpl_glm","object":"chat.completion.chunk","model":"glm-4.5","choices":[],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`,
+			`data: {"id":"chatcmpl_qwen38","object":"chat.completion.chunk","model":"qwen3.8-2.4t-a95b","choices":[],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`,
 			"",
 			"data: [DONE]",
 			"",
 		}, "\n")))
 		return &bridge.DispatchOutcome{
 			Usage:         &newapidto.Usage{PromptTokens: 4, CompletionTokens: 2, TotalTokens: 6},
-			Model:         "glm-4.5",
-			UpstreamModel: "glm-4.5",
+			Model:         "qwen3.8-2.4t-a95b",
+			UpstreamModel: "qwen3.8-2.4t-a95b",
 			Stream:        true,
 		}, nil
 	}
 
-	body := []byte(`{"model":"glm-4.5","input":"hello","stream":false}`)
+	body := []byte(`{"model":"qwen3.8-2.4t-a95b","input":"hello","stream":false}`)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
@@ -347,7 +347,7 @@ func TestForwardAsResponsesDispatched_NewAPIStreamOnlyModelBuffersNonStreamingCl
 	svc := &OpenAIGatewayService{}
 	account := &Account{
 		ID:          4302,
-		Name:        "newapi-glm",
+		Name:        "newapi-qwen38",
 		Platform:    PlatformNewAPI,
 		Type:        AccountTypeAPIKey,
 		ChannelType: 43,
@@ -366,6 +366,7 @@ func TestForwardAsResponsesDispatched_NewAPIStreamOnlyModelBuffersNonStreamingCl
 	require.Equal(t, "response", gjson.Get(rec.Body.String(), "object").String())
 	require.Equal(t, "ok", gjson.Get(rec.Body.String(), "output.0.content.0.text").String())
 	require.True(t, gjson.GetBytes(capturedChatBody, "stream").Bool())
+	require.True(t, gjson.GetBytes(capturedChatBody, "enable_thinking").Bool())
 	require.True(t, gjson.GetBytes(capturedChatBody, "stream_options.include_usage").Bool())
 	require.False(t, result.Stream)
 	require.Equal(t, 4, result.Usage.InputTokens)
@@ -500,6 +501,18 @@ func TestApplyNewAPIResponsesChatFallbackShape(t *testing.T) {
 		shaped := applyNewAPIResponsesChatFallbackShape("qwen3.7-max-2026-05-17", baseBody)
 		require.Equal(t, true, gjson.GetBytes(shaped, "stream").Bool())
 		require.Equal(t, true, gjson.GetBytes(shaped, "enable_thinking").Bool())
+	})
+
+	t.Run("qwen3.8 large variant sets stream and thinking", func(t *testing.T) {
+		shaped := applyNewAPIResponsesChatFallbackShape("qwen3.8-2.4t-a95b", baseBody)
+		require.True(t, gjson.GetBytes(shaped, "stream").Bool())
+		require.True(t, gjson.GetBytes(shaped, "enable_thinking").Bool())
+	})
+
+	t.Run("qwen3.8 near miss keeps generic non-streaming shape", func(t *testing.T) {
+		shaped := applyNewAPIResponsesChatFallbackShape("qwen3.8-32b", baseBody)
+		require.False(t, gjson.GetBytes(shaped, "stream").Bool())
+		require.False(t, gjson.GetBytes(shaped, "enable_thinking").Bool())
 	})
 
 	t.Run("glm-4.5 forces stream true", func(t *testing.T) {

--- a/ops/test/gateway_model_ssot_matrix.py
+++ b/ops/test/gateway_model_ssot_matrix.py
@@ -496,7 +496,11 @@ def compact_body(protocol: str, model: str) -> dict[str, Any]:
         body: dict[str, Any] = {"model": model, "max_tokens": 8, "messages": [{"role": "user", "content": "hi"}]}
         if chat_requires_stream(model):
             body["stream"] = True
-        if model in {"qwen3.7-max-preview", "qwen3.7-max-2026-05-17"}:
+        if model in {
+            "qwen3.7-max-preview",
+            "qwen3.7-max-2026-05-17",
+            "qwen3.8-2.4t-a95b",
+        }:
             body["enable_thinking"] = True
         elif re.match(r"qwen3[-.]", model):
             body["enable_thinking"] = False
@@ -537,6 +541,7 @@ def chat_requires_stream(model: str) -> bool:
         "glm-4.5-air",
         "qwen3.7-max-preview",
         "qwen3.7-max-2026-05-17",
+        "qwen3.8-2.4t-a95b",
     }
 
 
@@ -846,6 +851,10 @@ def cmd_selftest(_args) -> int:
     assert compact_body("chat", "qwen3-8b")["enable_thinking"] is False
     assert compact_body("chat", "qwen3.7-max-preview")["stream"] is True
     assert compact_body("chat", "qwen3.7-max-preview")["enable_thinking"] is True
+    assert compact_body("chat", "qwen3.8-2.4t-a95b")["stream"] is True
+    assert compact_body("chat", "qwen3.8-2.4t-a95b")["enable_thinking"] is True
+    assert compact_body("chat", "qwen3.8-32b")["enable_thinking"] is False
+    assert "stream" not in compact_body("chat", "qwen3.8-32b")
     assert compact_body("chat", "glm-4.5")["stream"] is True
     assert classify(429, '{"error":"No available accounts"}', False)[0] == "SKIP"
     assert classify(403, '{"error":"universal_no_entitled_group"}', False)[0] == "SKIP"


### PR DESCRIPTION
## Summary
- classify `qwen3.8-2.4t-a95b` as a narrow NewAPI stream+thinking variant for Responses chat fallback
- preserve non-streaming Responses client semantics by buffering the forced upstream SSE path
- send the focused universal-key chat probe with the provider-supported `stream=true` and `enable_thinking=true` shape

## Evidence
- merged focused closeout run 31800428644 exercised 20 rows: 18 passed; only this model's chat and responses rows returned deterministic 400 protocol-shape rejections
- the same model's messages and count_tokens rows passed
- direct/provider evidence established the accepted request shape as `stream=true` plus `enable_thinking=true`

## Validation
- `go test -tags=unit ./internal/service`
- `python3 ops/test/gateway_model_ssot_matrix.py selftest`
- `python3 scripts/checks/ssot-delta-gate.py selftest`
- `bash scripts/preflight.sh`
- `make test` backend unit suite and golangci-lint
- `pnpm lint:check`
- `pnpm typecheck`

## Closeout
After release and prod rollout, re-run the five-model focused universal-key SSOT gate and require all 20 rows to pass.

sentinel-registry-reviewed: existing NewAPI fallback and matrix owners remain the load-bearing anchors; this PR adds exact-model regression coverage and no new dispatch entry point.

ai