### PR TITLE
fix(gateway): estimate OpenAI count tokens on transient errors

### DIFF
--- a/backend/internal/service/openai_gateway_count_tokens_fallback.go
+++ b/backend/internal/service/openai_gateway_count_tokens_fallback.go
@@ -57,7 +57,26 @@ func classifyOpenAIInputTokensFallback(account *Account, statusCode int, body []
 	if isMaaSRelayInputTokensAuthGap(account, statusCode) {
 		return openAIInputTokensFallbackDecision{Kind: openAIInputTokensFallbackAnthropicEstimate, UpstreamMessage: upstreamMsg}
 	}
+	if isOpenAIAPIKeyInputTokensTransientFailure(account, statusCode) {
+		return openAIInputTokensFallbackDecision{Kind: openAIInputTokensFallbackPreparedEstimate, UpstreamMessage: upstreamMsg}
+	}
 	return openAIInputTokensFallbackDecision{Kind: openAIInputTokensFallbackNone, UpstreamMessage: upstreamMsg}
+}
+
+func isOpenAIAPIKeyInputTokensTransientFailure(account *Account, statusCode int) bool {
+	if account == nil || account.Platform != PlatformOpenAI || account.Type != AccountTypeAPIKey {
+		return false
+	}
+	switch statusCode {
+	case http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+		529:
+		return true
+	default:
+		return false
+	}
 }
 
 // isMaaSRelayInputTokensAuthGap reports CloudWise/tokensea dual-stack relays that

--- a/backend/internal/service/openai_gateway_count_tokens_fallback_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_fallback_test.go
@@ -121,6 +121,27 @@ func TestClassifyOpenAIInputTokensFallback(t *testing.T) {
 			body:       `{"error":{"message":"invalid api key"}}`,
 			want:       openAIInputTokensFallbackNone,
 		},
+		{
+			name:       "openai_apikey_502_uses_prepared_estimate",
+			account:    &Account{Type: AccountTypeAPIKey, Platform: PlatformOpenAI},
+			statusCode: http.StatusBadGateway,
+			body:       `{"error":{"message":"temporarily unavailable"}}`,
+			want:       openAIInputTokensFallbackPreparedEstimate,
+		},
+		{
+			name:       "openai_oauth_502_stays_upstream_error",
+			account:    &Account{Type: AccountTypeOAuth, Platform: PlatformOpenAI},
+			statusCode: http.StatusBadGateway,
+			body:       `{"error":{"message":"temporarily unavailable"}}`,
+			want:       openAIInputTokensFallbackNone,
+		},
+		{
+			name:       "newapi_apikey_502_stays_upstream_error",
+			account:    &Account{Type: AccountTypeAPIKey, Platform: PlatformNewAPI},
+			statusCode: http.StatusBadGateway,
+			body:       `{"error":{"message":"temporarily unavailable"}}`,
+			want:       openAIInputTokensFallbackNone,
+		},
 	}
 
 	for _, tt := range cases {

--- a/backend/internal/service/openai_gateway_count_tokens_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_test.go
@@ -673,6 +673,50 @@ func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_InputTokensPolicy403
 	require.NotNil(t, upstream.lastReq)
 }
 
+func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_OpenAIAPIKey502UsesLocalEstimate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.6","messages":[{"role":"user","content":"hello"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"temporarily unavailable"}}`)),
+	}}
+
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+			Enabled:           false,
+			AllowInsecureHTTP: true,
+		}}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          68,
+		Name:        "openai-us4",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "http://upstream.example",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	err := svc.ForwardCountTokensAsAnthropic(context.Background(), c, account, body, "gpt-5.6")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Greater(t, int(gjson.GetBytes(rec.Body.Bytes(), "input_tokens").Int()), 0)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "http://upstream.example/v1/responses/input_tokens", upstream.lastReq.URL.String())
+}
+
 func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_MissingInputTokensUsesLocalEstimate(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Summary

- Return the prepared local token estimate when an OpenAI API-key account receives HTTP 500, 502, 503, 504, or 529 from `/v1/responses/input_tokens`.
- Keep OpenAI OAuth, NewAPI, other platforms, and authentication failures on their existing error paths.
- Add a service regression for production-shaped account 68 and `gpt-5.6`, plus classifier boundary tests.

## Production evidence

- Account 68 serves `gpt-5.6` through `/v1/messages` with correct usage attribution.
- `/v1/messages/count_tokens` returned HTTP 502 for both `gpt-5.6` and the `gpt-5.5` control, isolating the gap to the optional OpenAI input-tokens endpoint rather than model capability.
- The count-tokens endpoint is informational and already uses local estimates for upstream capability gaps; this change covers transient HTTP failures for the same API-key path.

## Validation

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `make test`
- Focused and full `internal/service` unit tests

no-web-impact

ai