### PR TITLE
fix(billing): align Grok owners and context boundary

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -551,6 +551,16 @@ func (s *BillingService) initFallbackPricing() {
 		LongContextInputMultiplier:    2,
 		LongContextOutputMultiplier:   2,
 	}
+	// Legacy-only numeric fixtures for canonical Grok 4.20 rows. Alias lineage
+	// still resolves each model to its own registry owner; these shared pointers
+	// merely preserve the non-registry test path's historical dimensions.
+	for _, model := range []string{
+		"grok-4.20-0309-reasoning",
+		"grok-4.20-0309-non-reasoning",
+		"grok-4.20-multi-agent-0309",
+	} {
+		s.fallbackPrices[model] = s.fallbackPrices["grok-4.3"]
+	}
 	// xAI Grok Build 0.1 (official docs: $1 input / $0.20 cached input /
 	// $2 output per MTok). Composer is available only through Grok Build and
 	// has no standalone public API rate card, so its aliases use this coding
@@ -780,20 +790,11 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 		return s.fallbackPrices["gpt-5.4"]
 	}
 
-	switch modelLower {
-	case "grok", "grok-latest", "grok-4.6", "grok-4.6-latest":
-		return s.fallbackPrices["grok-4.6"]
-	case "grok-4.5", "grok-4.5-latest":
-		return s.fallbackPrices["grok-4.5"]
-	case "grok-4.3",
-		"grok-4.20-0309-reasoning",
-		"grok-4.20-0309-non-reasoning",
-		"grok-4.20-multi-agent-0309",
-		"grok-4.20-reasoning",
-		"grok-4.20-non-reasoning":
-		return s.fallbackPrices["grok-4.3"]
-	case "grok-build", "grok-build-latest", "grok-build-0.1", "grok-composer", "grok-composer-2.5-fast", "composer-2.5":
-		return s.fallbackPrices["grok-build-0.1"]
+	// xAI known aliases: resolve via the shared xai/models.go SSOT. Known aliases
+	// without a public pricing owner fail closed instead of inheriting the unknown
+	// family floor below.
+	if grokOwner, known := resolveGrokTextPricingOwner(modelLower); known {
+		return s.fallbackPrices[grokOwner]
 	}
 
 	// Unknown Grok text IDs (grok-5, dated snapshots, provider-prefixed) inherit
@@ -825,6 +826,7 @@ func tkModelPricingFromLiteLLM(p *LiteLLMModelPricing) *ModelPricing {
 		CacheCreation1hPrice:               price1h,
 		SupportsCacheBreakdown:             price1h > 0 && price1h > price5m,
 		LongContextInputThreshold:          p.LongContextInputTokenThreshold,
+		LongContextThresholdInclusive:      p.LongContextThresholdInclusive,
 		LongContextInputMultiplier:         p.LongContextInputCostMultiplier,
 		LongContextOutputMultiplier:        p.LongContextOutputCostMultiplier,
 		ImageInputPricePerToken:            p.InputCostPerImageToken,

--- a/backend/internal/service/billing_service_tk_hold.go
+++ b/backend/internal/service/billing_service_tk_hold.go
@@ -53,7 +53,11 @@ func (s *BillingService) EstimateTokenHold(model, serviceTier string, promptToke
 	)
 
 	lcIn, lcOut := 1.0, 1.0
-	if pricing.LongContextInputThreshold > 0 && promptTokens > pricing.LongContextInputThreshold {
+	longContextApplies := promptTokens > pricing.LongContextInputThreshold
+	if pricing.LongContextThresholdInclusive {
+		longContextApplies = promptTokens >= pricing.LongContextInputThreshold
+	}
+	if pricing.LongContextInputThreshold > 0 && longContextApplies {
 		if pricing.LongContextInputMultiplier > 1 {
 			lcIn = pricing.LongContextInputMultiplier
 		}

--- a/backend/internal/service/billing_service_tk_hold_test.go
+++ b/backend/internal/service/billing_service_tk_hold_test.go
@@ -54,6 +54,33 @@ func TestEstimateTokenHold_IsUpperBoundOverDistributions(t *testing.T) {
 	}
 }
 
+func TestEstimateTokenHold_HonorsInclusiveLongContextBoundary(t *testing.T) {
+	s := NewBillingService(&config.Config{}, nil)
+	pricing := s.fallbackPrices["grok-4.6"]
+	pricing.LongContextThresholdInclusive = true
+	const (
+		prompt = 200000
+		maxOut = 1000
+	)
+
+	hold, err := s.EstimateTokenHold("grok-4.6", "", prompt, maxOut, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, err := s.CalculateCostWithServiceTier(
+		"grok-4.6",
+		UsageTokens{InputTokens: prompt, OutputTokens: maxOut},
+		1,
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual.ActualCost > hold {
+		t.Fatalf("inclusive threshold hold must cover settlement: actual=%.12f hold=%.12f", actual.ActualCost, hold)
+	}
+}
+
 func TestEstimateTokenHold_ScalesWithRateMultiplier(t *testing.T) {
 	s := NewBillingService(&config.Config{}, nil)
 	h1, err := s.EstimateTokenHold("claude-sonnet-4", "", 1000, 500, 1.0)

--- a/backend/internal/service/billing_service_tk_registry_alias.go
+++ b/backend/internal/service/billing_service_tk_registry_alias.go
@@ -36,6 +36,14 @@ func (s *BillingService) getRegistryAliasPricing(model string) *ModelPricing {
 		return direct
 	}
 
+	// xAI: resolve known aliases via their routing canonical → pricing owner.
+	// This sits before the legacy matcher so direct registry rows (above) still
+	// take precedence, and known aliases without a public pricing owner fail
+	// closed rather than inheriting the unknown-model floor.
+	if grokOwner, known := resolveGrokTextPricingOwner(lower); known {
+		return tkRegistryAliasOwnerPricing(grokOwner)
+	}
+
 	// This compatibility SKU routes to ordinary GPT-5.5. A provider-advertised
 	// Pro row is sensor evidence only and is not a serving/billing owner.
 	if normalizeOpenAIBillingModel(lower) == "gpt-5.5-pro" {

--- a/backend/internal/service/billing_service_tk_xai_pricing_owner.go
+++ b/backend/internal/service/billing_service_tk_xai_pricing_owner.go
@@ -1,0 +1,51 @@
+package service
+
+// TK xAI pricing-owner resolver.
+//
+// Single source of truth: backend/internal/pkg/xai/models.go
+// (IsGrokTextResponsesModelID / ResolveGrokTextResponsesModelID).
+//
+// This helper maps a known Grok text alias → its canonical routing target →
+// the canonical pricing owner. Direct registry rows still take precedence; this
+// resolver is only consulted when no direct row exists.
+//
+// Design invariants:
+//   - Composer models have no standalone public pricing; they bill at grok-build-0.1.
+//   - grok-3-mini/fast have no public pricing; known aliases → "" (fail closed).
+//   - Truly unknown future Grok text IDs are NOT handled here; they fall through
+//     to grokUnknownTextFamilyFallback which uses the 4.6 floor.
+
+import (
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+)
+
+// grokCanonicalPricingOwner maps each routing-canonical model ID to its billing
+// owner. Canonical models keep their own registry row; Composer is the sole
+// cross-owner policy exception because it has no standalone public price card.
+// Absent entries signal "known model, no public pricing" and must fail closed.
+var grokCanonicalPricingOwner = map[string]string{
+	"grok-4.6":                     "grok-4.6",
+	"grok-4.5":                     "grok-4.5",
+	"grok-4.3":                     "grok-4.3",
+	"grok-build-0.1":               "grok-build-0.1",
+	"grok-composer-2.5-fast":       "grok-build-0.1", // no standalone price card; Composer bills at the coding model rate
+	"grok-4.20-0309-reasoning":     "grok-4.20-0309-reasoning",
+	"grok-4.20-0309-non-reasoning": "grok-4.20-0309-non-reasoning",
+	"grok-4.20-multi-agent-0309":   "grok-4.20-multi-agent-0309",
+	// grok-3-mini, grok-3-mini-fast: deliberately absent = fail closed.
+}
+
+// resolveGrokTextPricingOwner returns the canonical pricing-registry owner and
+// whether model is a known Grok text alias. A known alias with an empty owner
+// must fail closed; the boolean keeps it distinct from a truly unknown future
+// Grok ID, which may use the family floor.
+//
+// The resolver always uses the compile-time DefaultTextModel for resolution so
+// pricing is deterministic regardless of runtime settings.
+func resolveGrokTextPricingOwner(model string) (owner string, known bool) {
+	if !xai.IsGrokTextResponsesModelID(model) {
+		return "", false
+	}
+	canonical := xai.ResolveGrokTextResponsesModelID(model, xai.DefaultTextModel)
+	return grokCanonicalPricingOwner[canonical], true
+}

--- a/backend/internal/service/billing_service_tk_xai_pricing_owner_test.go
+++ b/backend/internal/service/billing_service_tk_xai_pricing_owner_test.go
@@ -1,0 +1,218 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/stretchr/testify/require"
+)
+
+func expectedGrokPricingOwner(canonical string) (string, bool) {
+	switch canonical {
+	case "grok-4.6", "grok-4.5", "grok-4.3", "grok-build-0.1":
+		return canonical, true
+	case "grok-composer-2.5-fast":
+		return "grok-build-0.1", true
+	case "grok-4.20-0309-reasoning", "grok-4.20-0309-non-reasoning", "grok-4.20-multi-agent-0309":
+		return canonical, true
+	case "grok-3-mini", "grok-3-mini-fast":
+		return "", true
+	default:
+		return "", false
+	}
+}
+
+func TestGrokPricingOwnersFollowRoutingSSOT(t *testing.T) {
+	mapping := xai.ModelMappingWithOptions(xai.ModelMappingOptions{
+		DefaultText:          xai.DefaultTextModel,
+		EnableCrossClientMap: false,
+	})
+
+	for alias := range mapping {
+		if !xai.IsGrokTextResponsesModelID(alias) {
+			continue
+		}
+		canonical := xai.ResolveGrokTextResponsesModelID(alias, xai.DefaultTextModel)
+		expected, covered := expectedGrokPricingOwner(canonical)
+		require.Truef(t, covered, "routing canonical %q for alias %q has no pricing policy", canonical, alias)
+		owner, known := resolveGrokTextPricingOwner(alias)
+		require.Truef(t, known, "routing-known alias %q was not recognized", alias)
+		require.Equalf(t, expected, owner, "alias=%q canonical=%q", alias, canonical)
+
+		if !strings.Contains(alias, "/") {
+			for _, prefix := range []string{"xai/", "x-ai/", "grok/"} {
+				prefixedOwner, prefixedKnown := resolveGrokTextPricingOwner(prefix + alias)
+				require.True(t, prefixedKnown, prefix+alias)
+				require.Equal(t, expected, prefixedOwner, prefix+alias)
+			}
+		}
+	}
+
+	required := map[string]string{
+		"grok-latest":       "grok-4.3",
+		"grok-build-latest": "grok-4.5",
+		"grok-composer":     "grok-build-0.1",
+	}
+	for alias, expected := range required {
+		owner, known := resolveGrokTextPricingOwner(alias)
+		require.True(t, known, alias)
+		require.Equal(t, expected, owner, alias)
+	}
+}
+
+func TestGrokPricingOwnerKnownUnpricedFailsClosed(t *testing.T) {
+	svc := newTestBillingService()
+	for _, model := range []string{
+		"grok-3-mini", "grok-3-mini-fast", "xai/grok-3-mini", "x-ai/grok-3-mini-fast",
+	} {
+		owner, known := resolveGrokTextPricingOwner(model)
+		require.True(t, known, model)
+		require.Empty(t, owner, model)
+		require.Nil(t, svc.getFallbackPricing(model), model)
+	}
+
+	for _, model := range []string{"grok-5", "grok-5-latest", "x-ai/grok-7", "grok-4.7-beta"} {
+		owner, known := resolveGrokTextPricingOwner(model)
+		require.False(t, known, model)
+		require.Empty(t, owner, model)
+		require.NotNil(t, svc.getFallbackPricing(model), model)
+	}
+}
+
+func TestGrokRegistryAliasesUseCanonicalOwners(t *testing.T) {
+	resetPricingRegistrySnapshot(t)
+	billing := NewBillingService(&config.Config{}, NewPricingService(&config.Config{}, nil))
+
+	cases := map[string]string{
+		"grok-latest":             "grok-latest", // direct registry row remains the data owner
+		"grok-build-latest":       "grok-build-latest",
+		"xai/grok-latest":         "grok-4.3",
+		"x-ai/grok-build-latest":  "grok-4.5",
+		"grok/grok-composer":      "grok-build-0.1",
+		"grok-4.20-reasoning":     "grok-4.20-0309-reasoning",
+		"grok-4.20-non-reasoning": "grok-4.20-0309-non-reasoning",
+		"grok-4.20-multi-agent":   "grok-4.20-multi-agent-0309",
+		"grok-composer-2.5-fast":  "grok-build-0.1",
+	}
+	for alias, expectedOwner := range cases {
+		pricing := billing.getRegistryAliasPricing(alias)
+		require.NotNil(t, pricing, alias)
+		require.Equal(t, expectedOwner, pricing.registryOwner, alias)
+		ownerPricing := tkRegistryAliasOwnerPricing(expectedOwner)
+		require.NotNil(t, ownerPricing, expectedOwner)
+		require.Equal(t, ownerPricing.InputPricePerToken, pricing.InputPricePerToken, alias)
+		require.Equal(t, ownerPricing.CacheReadPricePerToken, pricing.CacheReadPricePerToken, alias)
+		require.Equal(t, ownerPricing.OutputPricePerToken, pricing.OutputPricePerToken, alias)
+		require.Equal(t, ownerPricing.LongContextInputThreshold, pricing.LongContextInputThreshold, alias)
+		require.Equal(t, ownerPricing.LongContextThresholdInclusive, pricing.LongContextThresholdInclusive, alias)
+		require.Equal(t, ownerPricing.LongContextInputMultiplier, pricing.LongContextInputMultiplier, alias)
+		require.Equal(t, ownerPricing.LongContextOutputMultiplier, pricing.LongContextOutputMultiplier, alias)
+	}
+
+	for _, model := range []string{"grok-3-mini", "xai/grok-3-mini-fast"} {
+		require.Nil(t, billing.getRegistryAliasPricing(model), model)
+	}
+}
+
+func TestGrokLongContextInclusiveBoundaryCosts(t *testing.T) {
+	svc := newTestBillingService()
+	card := &ModelPricing{
+		InputPricePerToken:            2e-6,
+		OutputPricePerToken:           6e-6,
+		CacheCreationPricePerToken:    2e-6,
+		CacheReadPricePerToken:        0.5e-6,
+		LongContextInputThreshold:     200000,
+		LongContextThresholdInclusive: true,
+		LongContextInputMultiplier:    2,
+		LongContextOutputMultiplier:   2,
+	}
+
+	cases := []struct {
+		name     string
+		tokens   UsageTokens
+		elevated bool
+	}{
+		{"199999", UsageTokens{InputTokens: 199999, OutputTokens: 7}, false},
+		{"200000", UsageTokens{InputTokens: 200000, OutputTokens: 7}, true},
+		{"200001", UsageTokens{InputTokens: 200001, OutputTokens: 7}, true},
+		{"cache_creation_reaches_200000", UsageTokens{InputTokens: 100000, CacheCreationTokens: 100000, OutputTokens: 7}, true},
+		{"cache_read_reaches_200000", UsageTokens{InputTokens: 50000, CacheCreationTokens: 50000, CacheReadTokens: 100000, OutputTokens: 7}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := svc.computeTokenBreakdown(card, tc.tokens, 1, "", false, true)
+			multiplier := 1.0
+			if tc.elevated {
+				multiplier = 2
+			}
+			require.InDelta(t, float64(tc.tokens.InputTokens)*card.InputPricePerToken*multiplier, got.InputCost, 1e-12)
+			require.InDelta(t, float64(tc.tokens.CacheCreationTokens)*card.CacheCreationPricePerToken*multiplier, got.CacheCreationCost, 1e-12)
+			require.InDelta(t, float64(tc.tokens.CacheReadTokens)*card.CacheReadPricePerToken*multiplier, got.CacheReadCost, 1e-12)
+			require.InDelta(t, float64(tc.tokens.OutputTokens)*card.OutputPricePerToken*multiplier, got.OutputCost, 1e-12)
+			require.Equal(t, tc.elevated, got.LongContextBillingApplied)
+		})
+	}
+}
+
+func TestGrokLongContextLegacyStrictBoundary(t *testing.T) {
+	svc := newTestBillingService()
+	card := &ModelPricing{
+		InputPricePerToken:          2e-6,
+		OutputPricePerToken:         6e-6,
+		LongContextInputThreshold:   200000,
+		LongContextInputMultiplier:  2,
+		LongContextOutputMultiplier: 2,
+	}
+	require.False(t, svc.computeTokenBreakdown(card, UsageTokens{InputTokens: 199999, OutputTokens: 1}, 1, "", false, true).LongContextBillingApplied)
+	require.False(t, svc.computeTokenBreakdown(card, UsageTokens{InputTokens: 200000, OutputTokens: 1}, 1, "", false, true).LongContextBillingApplied)
+	require.True(t, svc.computeTokenBreakdown(card, UsageTokens{InputTokens: 200001, OutputTokens: 1}, 1, "", false, true).LongContextBillingApplied)
+}
+
+func TestGrokLongContextGroupOptOut(t *testing.T) {
+	svc := newTestBillingService()
+	resolver := NewModelPricingResolver(nil, svc)
+	for _, inputTokens := range []int{200000, 200001} {
+		off := &Group{LongContextPricingEnabled: false}
+		got, err := svc.CalculateCostUnified(CostInput{
+			Ctx: context.Background(), Model: "grok-4.6", Group: off,
+			Tokens:         UsageTokens{InputTokens: inputTokens, OutputTokens: 1},
+			RateMultiplier: 1, Resolver: resolver,
+		})
+		require.NoError(t, err)
+		require.False(t, got.LongContextBillingApplied)
+		require.InDelta(t, float64(inputTokens)*2e-6, got.InputCost, 1e-12)
+		require.InDelta(t, 6e-6, got.OutputCost, 1e-12)
+	}
+}
+
+func TestGrokLongContextInclusiveSchemaPropagation(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		field string
+		want  bool
+	}{
+		{"absent", "", false},
+		{"explicit_false", `,"long_context_threshold_inclusive":false`, false},
+		{"explicit_true", `,"long_context_threshold_inclusive":true`, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := `{"grok-test":{"mode":"chat","input_cost_per_token":0.000001,` +
+				`"output_cost_per_token":0.000002,"long_context_input_token_threshold":200000,` +
+				`"long_context_input_cost_multiplier":2,"long_context_output_cost_multiplier":2` + tc.field + `}}`
+			doc, err := parseTKOverlayDocument([]byte(raw))
+			require.NoError(t, err)
+			immutable := doc.Models["grok-test"]
+			require.NotNil(t, immutable)
+			require.Equal(t, tc.want, immutable.LongContextThresholdInclusive)
+
+			got := tkModelPricingFromLiteLLM(immutable)
+			require.NotNil(t, got)
+			require.Equal(t, tc.want, got.LongContextThresholdInclusive)
+		})
+	}
+}

--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -49,6 +49,7 @@ type LiteLLMModelPricing struct {
 	LongContextInputTokenThreshold      int     `json:"long_context_input_token_threshold,omitempty"`
 	LongContextInputCostMultiplier      float64 `json:"long_context_input_cost_multiplier,omitempty"`
 	LongContextOutputCostMultiplier     float64 `json:"long_context_output_cost_multiplier,omitempty"`
+	LongContextThresholdInclusive       bool    `json:"long_context_threshold_inclusive,omitempty"` // >= threshold; false = legacy strict >
 	SupportsServiceTier                 bool    `json:"supports_service_tier"`
 	LiteLLMProvider                     string  `json:"litellm_provider"`
 	Mode                                string  `json:"mode"`
@@ -118,6 +119,7 @@ type LiteLLMRawEntry struct {
 	LongContextInputTokenThreshold      *int     `json:"long_context_input_token_threshold"`
 	LongContextInputCostMultiplier      *float64 `json:"long_context_input_cost_multiplier"`
 	LongContextOutputCostMultiplier     *float64 `json:"long_context_output_cost_multiplier"`
+	LongContextThresholdInclusive       *bool    `json:"long_context_threshold_inclusive"`
 	SupportsServiceTier                 bool     `json:"supports_service_tier"`
 	LiteLLMProvider                     string   `json:"litellm_provider"`
 	Mode                                string   `json:"mode"`
@@ -502,6 +504,9 @@ func (s *PricingService) parsePricingData(body []byte) (map[string]*LiteLLMModel
 		}
 		if entry.LongContextOutputCostMultiplier != nil {
 			pricing.LongContextOutputCostMultiplier = *entry.LongContextOutputCostMultiplier
+		}
+		if entry.LongContextThresholdInclusive != nil {
+			pricing.LongContextThresholdInclusive = *entry.LongContextThresholdInclusive
 		}
 		if entry.OutputCostPerImage != nil {
 			pricing.OutputCostPerImage = *entry.OutputCostPerImage

--- a/backend/internal/service/pricing_service_tk_overlay.go
+++ b/backend/internal/service/pricing_service_tk_overlay.go
@@ -198,6 +198,9 @@ func parseTKOverlayDocument(data []byte) (*tkPricingOverlayDocument, error) {
 		if e.LongContextOutputCostMultiplier != nil {
 			p.LongContextOutputCostMultiplier = *e.LongContextOutputCostMultiplier
 		}
+		if e.LongContextThresholdInclusive != nil {
+			p.LongContextThresholdInclusive = *e.LongContextThresholdInclusive
+		}
 		tkNormalizeAbove272KPricing(p, e)
 		// TK: input-token interval (tiered) pricing. LiteLLMRawEntry has no
 		// "intervals" field (it is TK-overlay-only), so parse the raw entry a

--- a/ops/pricing/pricing-registry-sensor.py
+++ b/ops/pricing/pricing-registry-sensor.py
@@ -42,6 +42,7 @@ CANDIDATE_FIELDS = frozenset({
     "long_context_input_token_threshold",
     "long_context_input_cost_multiplier",
     "long_context_output_cost_multiplier",
+    "long_context_threshold_inclusive",
     "input_cost_per_token_above_272k_tokens",
     "output_cost_per_token_above_272k_tokens",
     "cache_read_input_token_cost_above_272k_tokens",

--- a/ops/pricing/test_pricing_registry_sensor.py
+++ b/ops/pricing/test_pricing_registry_sensor.py
@@ -55,6 +55,7 @@ class PricingRegistrySensorTests(unittest.TestCase):
             "model-a": {
                 "litellm_provider": "provider-a",
                 "input_cost_per_token": 4e-6,
+                "long_context_threshold_inclusive": True,
                 "supports_vision": True,
                 "provider_private_metadata": "ignore",
             },
@@ -68,6 +69,7 @@ class PricingRegistrySensorTests(unittest.TestCase):
         candidate, owners = sensor.build_candidate_registry(self.registry, report)
         self.assertEqual(owners, ["model-a"])
         self.assertEqual(candidate["model-a"]["input_cost_per_token"], 4e-6)
+        self.assertTrue(candidate["model-a"]["long_context_threshold_inclusive"])
         self.assertFalse(candidate["model-a"]["supports_vision"])
         self.assertEqual(candidate["model-a"]["source"], "human-approved")
         self.assertNotIn("new-model", candidate)

--- a/scripts/checks/pricing-overlay.py
+++ b/scripts/checks/pricing-overlay.py
@@ -72,7 +72,7 @@ RUNTIME_BOOL_FIELDS = (
     "supports_service_tier", "supports_prompt_caching", "supports_vision",
     "supports_tool_choice", "supports_function_calling", "supports_reasoning",
     "supports_response_schema", "supports_pdf_input", "supports_web_search",
-    "explicit_free",
+    "explicit_free", "long_context_threshold_inclusive",
 )
 INTERVAL_FLOAT_FIELDS = (
     "input_cost_per_token", "output_cost_per_token", "cache_read_input_token_cost",
@@ -221,6 +221,12 @@ def validate_priced_dimension_completeness(model: str, pricing: dict) -> list[st
             errors.append(
                 f"{model}: partial long-context policy; missing positive {missing}"
             )
+    if "long_context_threshold_inclusive" in pricing and not any(
+            field in pricing for field in long_context_fields):
+        errors.append(
+            f"{model}: long_context_threshold_inclusive requires a complete "
+            "long-context policy"
+        )
     return errors
 
 

--- a/scripts/checks/test_pricing_overlay.py
+++ b/scripts/checks/test_pricing_overlay.py
@@ -75,6 +75,60 @@ class PricingRegistryGateTest(unittest.TestCase):
         }))
 
 
+class LongContextThresholdInclusiveBoolShapeTest(unittest.TestCase):
+    """Validate that long_context_threshold_inclusive is treated as a boolean."""
+
+    def test_absent_field_passes(self) -> None:
+        row = {"mode": "chat", "input_cost_per_token": 1e-6,
+               "output_cost_per_token": 2e-6}
+        errors = CHECK.validate_runtime_owner_shape("model-no-inclusive", row)
+        self.assertFalse(errors)
+
+    def test_explicit_false_passes_with_complete_policy(self) -> None:
+        row = {"mode": "chat", "input_cost_per_token": 1e-6,
+               "output_cost_per_token": 2e-6,
+               "long_context_input_token_threshold": 200000,
+               "long_context_input_cost_multiplier": 2.0,
+               "long_context_output_cost_multiplier": 2.0,
+               "long_context_threshold_inclusive": False}
+        errors = CHECK.validate_runtime_owner_shape("model-false", row)
+        self.assertFalse(errors)
+
+    def test_bool_without_policy_is_rejected(self) -> None:
+        for value in (False, True):
+            with self.subTest(value=value):
+                row = {"mode": "chat", "input_cost_per_token": 1e-6,
+                       "output_cost_per_token": 2e-6,
+                       "long_context_threshold_inclusive": value}
+                shape_errors = CHECK.validate_runtime_owner_shape("model-partial", row)
+                policy_errors = CHECK.validate_priced_dimension_completeness("model-partial", row)
+                self.assertFalse(shape_errors)
+                self.assertTrue(policy_errors)
+
+    def test_explicit_true_passes(self) -> None:
+        row = {"mode": "chat", "input_cost_per_token": 1e-6,
+               "output_cost_per_token": 2e-6,
+               "long_context_threshold_inclusive": True,
+               "long_context_input_token_threshold": 200000,
+               "long_context_input_cost_multiplier": 2.0,
+               "long_context_output_cost_multiplier": 2.0}
+        errors = CHECK.validate_runtime_owner_shape("model-true", row)
+        self.assertFalse(errors)
+
+    def test_non_bool_value_rejected(self) -> None:
+        for bad in (1, 0, "true", "false", None):
+            with self.subTest(value=bad):
+                row = {"mode": "chat", "input_cost_per_token": 1e-6,
+                       "output_cost_per_token": 2e-6,
+                       "long_context_threshold_inclusive": bad}
+                errors = CHECK.validate_runtime_owner_shape("model-bad", row)
+                # None is treated as absent by the validator (field present but None skipped)
+                if bad is None:
+                    self.assertFalse(errors)
+                else:
+                    self.assertTrue(errors, f"Expected error for value {bad!r}")
+
+
 class PricingRegistryMigrationParityTest(unittest.TestCase):
     def test_reconstructs_legacy_fill_only_precedence(self) -> None:
         external = {


### PR DESCRIPTION
## Summary
- derive Grok alias billing owners from the xAI routing SSOT while preserving direct registry ownership and the explicit Composer policy exception
- distinguish known unpriced models from truly unknown future families so unsupported aliases fail closed
- propagate an explicit long-context inclusive threshold through registry parsing and settlement, with validator and sensor support
- lock routing owner parity, 199999/200000/200001 settlement, cache-token accounting, group opt-out, legacy strict behavior, and parser propagation in focused tests

## Scope
- no pricing registry data is changed in this PR; evidence-backed xAI row updates remain a separate protected publication

## Verification
- `go test -tags=unit ./internal/service -run TestGrok -count=1`
- `python3 scripts/checks/test_pricing_overlay.py`
- `python3 ops/pricing/test_pricing_registry_sensor.py`
- `./scripts/preflight.sh`
- `make test`

no-web-impact
sentinel-registry-reviewed

ai
