### PR TITLE
fix(pricing): publish xAI long-context rates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,10 @@ docs/*
 !docs/ASYNC_IMAGE_TASKS.md
 !docs/legal/
 !docs/legal/*.md
+# Dated public pricing captures are review evidence for the executable registry.
+!docs/evidence/
+!docs/evidence/pricing/
+!docs/evidence/pricing/**
 # Release bump syncs docs/ops/endpoint-compat-baseline.md (release-bump-and-tag.sh);
 # must remain stageable despite upstream-shaped docs/* ignore above.
 !docs/ops/

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -1203,7 +1203,7 @@ func TestGetModelPricing_Grok45OfficialFallback(t *testing.T) {
 			require.NoError(t, err)
 			require.InDelta(t, 2e-6, pricing.InputPricePerToken, 1e-12)
 			require.InDelta(t, 6e-6, pricing.OutputPricePerToken, 1e-12)
-			require.InDelta(t, 0.5e-6, pricing.CacheReadPricePerToken, 1e-12)
+			require.InDelta(t, 0.3e-6, pricing.CacheReadPricePerToken, 1e-12)
 			require.False(t, pricing.SupportsCacheBreakdown)
 		})
 	}

--- a/backend/internal/service/billing_service_tk_xai_pricing_owner_test.go
+++ b/backend/internal/service/billing_service_tk_xai_pricing_owner_test.go
@@ -119,6 +119,29 @@ func TestGrokRegistryAliasesUseCanonicalOwners(t *testing.T) {
 	}
 }
 
+func TestGrokDirectRegistryRowsMatchSemanticOwners(t *testing.T) {
+	resetPricingRegistrySnapshot(t)
+	cases := map[string]string{
+		"grok-latest":           "grok-4.3",
+		"grok-4.3-latest":       "grok-4.3",
+		"grok-4.5-latest":       "grok-4.5",
+		"grok-build-latest":     "grok-4.5",
+		"grok-code-fast":        "grok-build-0.1",
+		"grok-code-fast-1":      "grok-build-0.1",
+		"grok-code-fast-1-0825": "grok-build-0.1",
+		"grok-4-fast-reasoning": "grok-4.3",
+	}
+	for directOwner, semanticOwner := range cases {
+		direct := tkRegistryAliasOwnerPricing(directOwner)
+		semantic := tkRegistryAliasOwnerPricing(semanticOwner)
+		require.NotNil(t, direct, directOwner)
+		require.NotNil(t, semantic, semanticOwner)
+		direct.registryOwner = ""
+		semantic.registryOwner = ""
+		require.Equal(t, semantic, direct, directOwner)
+	}
+}
+
 func TestGrokLongContextInclusiveBoundaryCosts(t *testing.T) {
 	svc := newTestBillingService()
 	card := &ModelPricing{

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -8067,7 +8067,11 @@
     "input_cost_per_token": 1.25e-06,
     "cache_read_input_token_cost": 2e-07,
     "output_cost_per_token": 2.5e-06,
-    "source": "xAI official model-retirement page (docs.x.ai/developers/migration/may-15-retirement, captured 2026-06-22) says retired grok-4-fast-reasoning redirects to grok-4.3 and is charged as grok-4.3: input $1.25/Mtok, cached input $0.20/Mtok, output $2.50/Mtok from docs.x.ai/developers/pricing. Live probe 2026-06-22 returned 200; priced for backward compatibility, not public-listed."
+    "source": "xAI May 15 retirement notice redirects retired reasoning IDs to grok-4.3 with low reasoning effort and bills grok-4.3 pricing; copied complete owner pricing captured 2026-08-15. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-4.20-0309-non-reasoning": {
     "litellm_provider": "xai",
@@ -8075,7 +8079,7 @@
     "input_cost_per_token": 1.25e-06,
     "cache_read_input_token_cost": 2e-07,
     "output_cost_per_token": 2.5e-06,
-    "source": "https://docs.x.ai/developers/models/grok-4.20-0309-non-reasoning",
+    "source": "xAI official pricing and https://docs.x.ai/developers/models/grok-4.20-0309-non-reasoning, captured 2026-08-15: input $1.25/Mtok, cached input $0.20/Mtok, output $2.50/Mtok below 200k; all three rates double when prompt reaches 200k. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
     "max_input_tokens": 1000000,
     "max_output_tokens": 1000000,
     "max_tokens": 1000000,
@@ -8084,7 +8088,11 @@
     "supports_response_schema": true,
     "supports_tool_choice": true,
     "supports_vision": true,
-    "supports_web_search": true
+    "supports_web_search": true,
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-4.20-0309-reasoning": {
     "litellm_provider": "xai",
@@ -8092,7 +8100,7 @@
     "input_cost_per_token": 1.25e-06,
     "cache_read_input_token_cost": 2e-07,
     "output_cost_per_token": 2.5e-06,
-    "source": "https://docs.x.ai/developers/models/grok-4.20-0309-reasoning",
+    "source": "xAI official pricing and https://docs.x.ai/developers/models/grok-4.20-0309-reasoning, captured 2026-08-15: input $1.25/Mtok, cached input $0.20/Mtok, output $2.50/Mtok below 200k; all three rates double when prompt reaches 200k. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
     "max_input_tokens": 1000000,
     "max_output_tokens": 1000000,
     "max_tokens": 1000000,
@@ -8102,7 +8110,11 @@
     "supports_response_schema": true,
     "supports_tool_choice": true,
     "supports_vision": true,
-    "supports_web_search": true
+    "supports_web_search": true,
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-4.20-multi-agent-0309": {
     "cache_read_input_token_cost": 2e-07,
@@ -8113,14 +8125,18 @@
     "max_tokens": 1000000,
     "mode": "chat",
     "output_cost_per_token": 2.5e-06,
-    "source": "https://docs.x.ai/developers/models/grok-4.20-multi-agent-0309",
+    "source": "xAI official pricing and https://docs.x.ai/developers/models/grok-4.20-multi-agent-0309, captured 2026-08-15: input $1.25/Mtok, cached input $0.20/Mtok, output $2.50/Mtok below 200k; all three rates double when prompt reaches 200k. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
     "supports_function_calling": true,
     "supports_prompt_caching": true,
     "supports_reasoning": true,
     "supports_response_schema": true,
     "supports_tool_choice": true,
     "supports_vision": true,
-    "supports_web_search": true
+    "supports_web_search": true,
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-4.3": {
     "litellm_provider": "xai",
@@ -8128,7 +8144,7 @@
     "input_cost_per_token": 1.25e-06,
     "cache_read_input_token_cost": 2e-07,
     "output_cost_per_token": 2.5e-06,
-    "source": "https://docs.x.ai/developers/models/grok-4.3",
+    "source": "xAI official pricing and https://docs.x.ai/developers/models/grok-4.3, captured 2026-08-15: input $1.25/Mtok, cached input $0.20/Mtok, output $2.50/Mtok below 200k; all three rates double when prompt reaches 200k. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
     "max_input_tokens": 1000000,
     "max_output_tokens": 1000000,
     "max_tokens": 1000000,
@@ -8138,7 +8154,11 @@
     "supports_response_schema": true,
     "supports_tool_choice": true,
     "supports_vision": true,
-    "supports_web_search": true
+    "supports_web_search": true,
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-4.3-latest": {
     "litellm_provider": "xai",
@@ -8146,18 +8166,22 @@
     "input_cost_per_token": 1.25e-06,
     "cache_read_input_token_cost": 2e-07,
     "output_cost_per_token": 2.5e-06,
-    "source": "xAI official model page alias (docs.x.ai/developers/models/grok-4.3, captured 2026-07-09): grok-4.3-latest maps to grok-4.3 at input $1.25/Mtok, cached $0.20/Mtok, output $2.50/Mtok. Direct xAI upstream probe 2026-07-10 via ops/stage0/probe_grok_upstream_model.sh on edge-us4 account 6 returned 200 with upstream model grok-4.3, so this alias is public-listable."
+    "source": "xAI official grok-4.3 model-page alias maps grok-4.3-latest to grok-4.3; copied complete owner pricing captured 2026-08-15. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-4.5": {
     "litellm_provider": "xai",
     "mode": "chat",
     "input_cost_per_token": 2e-06,
-    "cache_read_input_token_cost": 5e-07,
+    "cache_read_input_token_cost": 3e-07,
     "output_cost_per_token": 6e-06,
     "long_context_input_token_threshold": 200000,
     "long_context_input_cost_multiplier": 2,
     "long_context_output_cost_multiplier": 2,
-    "source": "https://docs.x.ai/developers/models/grok-4.5",
+    "source": "xAI official pricing and https://docs.x.ai/developers/models/grok-4.5, captured 2026-08-15: input $2/Mtok, cached input $0.30/Mtok, output $6/Mtok below 200k; all three rates double when prompt reaches 200k. Corrects the stale cached-input base rate $0.50/Mtok. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
     "max_input_tokens": 500000,
     "max_output_tokens": 500000,
     "max_tokens": 500000,
@@ -8167,15 +8191,20 @@
     "supports_response_schema": true,
     "supports_tool_choice": true,
     "supports_vision": true,
-    "supports_web_search": true
+    "supports_web_search": true,
+    "long_context_threshold_inclusive": true
   },
   "grok-4.5-latest": {
     "litellm_provider": "xai",
     "mode": "chat",
     "input_cost_per_token": 2e-06,
-    "cache_read_input_token_cost": 5e-07,
+    "cache_read_input_token_cost": 3e-07,
     "output_cost_per_token": 6e-06,
-    "source": "xAI official model page alias (docs.x.ai/developers/models/grok-4.5, captured 2026-07-09): grok-4.5-latest maps to grok-4.5 at input $2.00/Mtok, cached $0.50/Mtok, output $6.00/Mtok. Direct xAI upstream probe 2026-07-10 via ops/stage0/probe_grok_upstream_model.sh on edge-us4 account 6 returned 200 with upstream model grok-4.5, so this alias is public-listable."
+    "source": "xAI official grok-4.5 model-page alias maps grok-4.5-latest to grok-4.5; copied complete owner pricing captured 2026-08-15. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-build-0.1": {
     "litellm_provider": "xai",
@@ -8183,7 +8212,7 @@
     "input_cost_per_token": 1e-06,
     "cache_read_input_token_cost": 2e-07,
     "output_cost_per_token": 2e-06,
-    "source": "https://docs.x.ai/developers/models/grok-build-0.1",
+    "source": "xAI official pricing and https://docs.x.ai/developers/models/grok-build-0.1, captured 2026-08-15: input $1/Mtok, cached input $0.20/Mtok, output $2/Mtok below 200k; all three rates double when prompt reaches 200k. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
     "max_input_tokens": 256000,
     "max_output_tokens": 256000,
     "max_tokens": 256000,
@@ -8192,15 +8221,23 @@
     "supports_reasoning": true,
     "supports_response_schema": true,
     "supports_tool_choice": true,
-    "supports_vision": true
+    "supports_vision": true,
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-build-latest": {
     "litellm_provider": "xai",
     "mode": "chat",
     "input_cost_per_token": 2e-06,
-    "cache_read_input_token_cost": 5e-07,
+    "cache_read_input_token_cost": 3e-07,
     "output_cost_per_token": 6e-06,
-    "source": "xAI official model page alias (docs.x.ai/developers/models/grok-4.5, captured 2026-07-09): grok-build-latest maps to grok-4.5 at input $2.00/Mtok, cached $0.50/Mtok, output $6.00/Mtok. Direct xAI upstream probe 2026-07-10 via ops/stage0/probe_grok_upstream_model.sh on edge-us4 account 6 returned 200 with upstream model grok-4.5, so this alias is public-listable."
+    "source": "xAI official grok-4.5 model-page alias maps grok-build-latest to grok-4.5; copied complete owner pricing captured 2026-08-15. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-code-fast": {
     "litellm_provider": "xai",
@@ -8208,7 +8245,11 @@
     "input_cost_per_token": 1e-06,
     "cache_read_input_token_cost": 2e-07,
     "output_cost_per_token": 2e-06,
-    "source": "xAI official grok-build-0.1 model page alias (docs.x.ai/developers/models/grok-build-0.1, captured 2026-07-09): grok-code-fast maps to grok-build-0.1. Official pricing input $1/Mtok, cached $0.20/Mtok, output $2/Mtok. Direct xAI upstream probe 2026-07-10 via ops/stage0/probe_grok_upstream_model.sh on edge-us4 account 6 returned 200 with upstream model grok-build-0.1, so this alias is public-listable."
+    "source": "xAI official grok-build-0.1 model-page alias maps grok-code-fast to grok-build-0.1; copied complete owner pricing captured 2026-08-15. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-code-fast-1": {
     "litellm_provider": "xai",
@@ -8216,7 +8257,11 @@
     "input_cost_per_token": 1e-06,
     "cache_read_input_token_cost": 2e-07,
     "output_cost_per_token": 2e-06,
-    "source": "xAI official grok-build-0.1 model page (docs.x.ai/developers/models/grok-code-fast-1, captured 2026-06-22) lists grok-code-fast-1 as an alias of grok-build-0.1. Official pricing page lists grok-build-0.1 at input $1/Mtok, cached input $0.20/Mtok, output $2/Mtok. This replaces the older x.ai/news/grok-code-fast-1 promo/post-promo row, which would under-bill the current routed model."
+    "source": "xAI official grok-build-0.1 model-page alias maps grok-code-fast-1 to grok-build-0.1; copied complete owner pricing captured 2026-08-15. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-code-fast-1-0825": {
     "litellm_provider": "xai",
@@ -8224,7 +8269,11 @@
     "input_cost_per_token": 1e-06,
     "cache_read_input_token_cost": 2e-07,
     "output_cost_per_token": 2e-06,
-    "source": "xAI official grok-build-0.1 model page alias (docs.x.ai/developers/models/grok-build-0.1, captured 2026-07-09): grok-code-fast-1-0825 maps to grok-build-0.1. Official pricing input $1/Mtok, cached $0.20/Mtok, output $2/Mtok. Direct xAI upstream probe 2026-07-10 via ops/stage0/probe_grok_upstream_model.sh on edge-us4 account 6 returned 200 with upstream model grok-build-0.1, so this alias is public-listable."
+    "source": "xAI official grok-build-0.1 model-page alias maps grok-code-fast-1-0825 to grok-build-0.1; copied complete owner pricing captured 2026-08-15. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "grok-imagine-image": {
     "litellm_provider": "xai",
@@ -8294,7 +8343,11 @@
     "input_cost_per_token": 1.25e-06,
     "cache_read_input_token_cost": 2e-07,
     "output_cost_per_token": 2.5e-06,
-    "source": "xAI official model page alias (docs.x.ai/developers/models/grok-4.3, captured 2026-07-09): grok-latest maps to grok-4.3 at input $1.25/Mtok, cached $0.20/Mtok, output $2.50/Mtok. Live probe 2026-06-22 edge-us4 returned 200; public-listed as official xAI alias."
+    "source": "Existing xAI alias and direct-upstream probe evidence maps grok-latest to grok-4.3; copied complete owner pricing captured 2026-08-15. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
+    "long_context_input_token_threshold": 200000,
+    "long_context_threshold_inclusive": true,
+    "long_context_input_cost_multiplier": 2,
+    "long_context_output_cost_multiplier": 2
   },
   "imagen-3.0-capability-001": {
     "litellm_provider": "vertex_ai",
@@ -9991,7 +10044,7 @@
     "long_context_input_token_threshold": 200000,
     "long_context_input_cost_multiplier": 2,
     "long_context_output_cost_multiplier": 2,
-    "source": "https://docs.x.ai/developers/models/grok-4.6 (captured 2026-08-13). Official pricing: input $2/Mtok (<200k) or $4/Mtok (>=200k), cached input $0.50/Mtok or $1/Mtok, output $6/Mtok or $12/Mtok; requests whose prompt reaches 200k tokens are billed at the higher rate for all tokens. Direct xAI upstream probe 2026-08-13 via ops/stage0/probe_grok_upstream_model.sh on edge-us4 account 6 returned 200 with upstream model grok-4.6.",
+    "source": "xAI official pricing and https://docs.x.ai/developers/models/grok-4.6, captured 2026-08-15: input $2/Mtok, cached input $0.50/Mtok, output $6/Mtok below 200k; all three rates double when prompt reaches 200k. docs/evidence/pricing/xai_pricing_20260815.md; xAI 200k long-context billing SSOT.",
     "max_input_tokens": 500000,
     "max_output_tokens": 500000,
     "max_tokens": 500000,
@@ -10001,7 +10054,8 @@
     "supports_response_schema": true,
     "supports_tool_choice": true,
     "supports_vision": true,
-    "supports_web_search": true
+    "supports_web_search": true,
+    "long_context_threshold_inclusive": true
   },
   "glm-5.2-fast-preview": {
     "litellm_provider": "zhipu",

--- a/docs/evidence/pricing/README.md
+++ b/docs/evidence/pricing/README.md
@@ -14,4 +14,5 @@ fallback under `backend/resources/model-pricing/`.
 | [`aliyun_pricing_20260612.md`](aliyun_pricing_20260612.md) | Alibaba DashScope pricing capture used by existing overlay provenance. |
 | [`aliyun_pricing_20260701.md`](aliyun_pricing_20260701.md) | Later Alibaba DashScope pricing capture for modelops work. |
 | [`google_vertex_pricing_20260619.md`](google_vertex_pricing_20260619.md) | Google Vertex media pricing capture. |
+| [`xai_pricing_20260815.md`](xai_pricing_20260815.md) | xAI Grok token pricing, inclusive 200k long-context tiers, and local usage-normalization evidence. |
 | [`volcengine_pricing_20260611.md`](volcengine_pricing_20260611.md) | VolcEngine Ark pricing capture. |

--- a/docs/evidence/pricing/xai_pricing_20260815.md
+++ b/docs/evidence/pricing/xai_pricing_20260815.md
@@ -1,0 +1,97 @@
+# xAI Grok 官方定价与长上下文计费证据
+
+> 抓取日期：2026-08-15。价格会变化；本文件只保存当日官方快照，供 TokenKey registry 对账与代码审查使用，不是运行时价格 owner。
+> 运行时全局价格唯一 owner 仍是 `backend/internal/service/tk_pricing_overlay.json`。
+
+## 官方来源
+
+- 汇总定价页：<https://docs.x.ai/docs/pricing>
+- `grok-4.6`：<https://docs.x.ai/developers/models/grok-4.6>
+- `grok-4.5`：<https://docs.x.ai/developers/models/grok-4.5>
+- `grok-4.3`：<https://docs.x.ai/developers/models/grok-4.3>
+- `grok-build-0.1`：<https://docs.x.ai/developers/models/grok-build-0.1>
+- `grok-4.20-0309-reasoning`：<https://docs.x.ai/developers/models/grok-4.20-0309-reasoning>
+- `grok-4.20-0309-non-reasoning`：<https://docs.x.ai/developers/models/grok-4.20-0309-non-reasoning>
+- `grok-4.20-multi-agent-0309`：<https://docs.x.ai/developers/models/grok-4.20-multi-agent-0309>
+- Chat Completions usage schema：<https://docs.x.ai/api/endpoints#chat-completions>
+- 退役模型迁移：<https://docs.x.ai/developers/migration/may-15-retirement>
+
+## 长上下文语义
+
+官方定价页原文：
+
+> “Prices shown per million tokens. Models listed with two rows use long context pricing: requests whose prompt reaches the listed token threshold are billed at the higher rate for all tokens in the request.”
+
+表格的高价行标为 `>= 200k prompt tokens`。因此本次证据支持以下完整策略：
+
+- 阈值是 **inclusive**：正好 200,000 prompt tokens 即进入高价阶；
+- 达到阈值后，整次请求的 input、cached input 与 output 都按高价行结算；
+- 不是只对超过 200,000 的边际 token 加价。
+
+## 官方价格快照
+
+下表单位均为 USD / 1M tokens。
+
+| Registry canonical owner | Prompt tier | Input | Cached input | Output |
+| --- | --- | ---: | ---: | ---: |
+| `grok-4.6` | `< 200k` | $2.00 | $0.50 | $6.00 |
+| `grok-4.6` | `>= 200k` | $4.00 | $1.00 | $12.00 |
+| `grok-4.5` | `< 200k` | $2.00 | $0.30 | $6.00 |
+| `grok-4.5` | `>= 200k` | $4.00 | $0.60 | $12.00 |
+| `grok-4.3` | `< 200k` | $1.25 | $0.20 | $2.50 |
+| `grok-4.3` | `>= 200k` | $2.50 | $0.40 | $5.00 |
+| `grok-build-0.1` | `< 200k` | $1.00 | $0.20 | $2.00 |
+| `grok-build-0.1` | `>= 200k` | $2.00 | $0.40 | $4.00 |
+| `grok-4.20-0309-reasoning` | `< 200k` | $1.25 | $0.20 | $2.50 |
+| `grok-4.20-0309-reasoning` | `>= 200k` | $2.50 | $0.40 | $5.00 |
+| `grok-4.20-0309-non-reasoning` | `< 200k` | $1.25 | $0.20 | $2.50 |
+| `grok-4.20-0309-non-reasoning` | `>= 200k` | $2.50 | $0.40 | $5.00 |
+| `grok-4.20-multi-agent-0309` | `< 200k` | $1.25 | $0.20 | $2.50 |
+| `grok-4.20-multi-agent-0309` | `>= 200k` | $2.50 | $0.40 | $5.00 |
+
+这些 model page 也逐项重复了相同阈值原文，并分别列出 500k、1M 或 256k context window；本次 registry 变更依据的是逐项价格表，而不是从 context window 外推价阶。
+
+### 已证实的 direct alias
+
+已有 registry direct row 会优先于 Go canonical owner resolver，因此它必须复制其语义 owner 的完整计费维度。本次只采用官方 model page 或退役迁移页已明确的 alias：
+
+- `grok-4.3-latest` → `grok-4.3`；已有 `grok-latest` 也由既有官方 alias/probe 证据绑定到 `grok-4.3`；
+- `grok-4.5-latest`、`grok-build-latest` → `grok-4.5`；
+- `grok-code-fast`、`grok-code-fast-1`、`grok-code-fast-1-0825` → `grok-build-0.1`；
+- 退役迁移页说明 reasoning 类退役 ID 由 `grok-4.3`（low reasoning effort）提供并按 `grok-4.3` 价格计费，因此已有兼容 row `grok-4-fast-reasoning` 复制 `grok-4.3` 的完整维度。
+
+`grok-4.6-latest` 当前没有 direct registry row，由 Go routing/pricing owner resolver 读取 `grok-4.6`，不创建重复 owner。`grok-composer-2.5-fast` 没有公开独立价卡；本文件不为它制造官方价格声明。
+
+## Prompt token 口径与本地 normalization
+
+xAI Chat Completions usage schema 将 `prompt_tokens_details.text_tokens` 描述为总 text prompt tokens（包含 cached 与 non-cached text tokens），并将 `prompt_tokens_details.cached_tokens` 描述为此前请求复用的子集。官方文档没有把本地差分公式写成规范；TokenKey 必须由代码路径保证不重叠。
+
+本次仓库审计证明 Grok Chat 与 Responses、流式与非流式都收敛到同一 usage parser：
+
+- `backend/internal/service/openai_gateway_response_handling.go` 的 `extractOpenAIUsageFromJSONBytes` / `openAIUsageFromGJSON` 读取 envelope `input_tokens`（兼容回退 `prompt_tokens`）与 detail `cached_tokens` / `cache_write_tokens`；
+- Grok fixture 明确覆盖 `input_tokens=5, cached_tokens=2` 与 `prompt_tokens=1, cached_tokens=1`，保留了 total/subset 关系；
+- `backend/internal/service/openai_gateway_usage.go` 在结算前执行：
+
+  ```text
+  ordinary input = upstream total input - cache creation - cache read
+  ```
+
+  然后把 ordinary input、cache creation、cache read 放进三个互斥 `UsageTokens` bucket；
+- long-context threshold 使用三个 bucket 的和，因此重构后仍等于 upstream total input；
+- settlement 分别计算三个 bucket 的成本后相加，不重复计算。
+
+因此当前实现满足 data publication 门禁：
+
+```text
+ordinary input + cache creation + cache read = upstream prompt/input token total
+```
+
+xAI 当日公开价卡没有独立 cache-write 费率，当前仓库里的 xAI fixture 也没有产生 cache-creation token。registry 因此不写 `cache_creation_input_token_cost`：对当前已观测的 xAI payload，cache-creation bucket 为零，cache read 使用官方 cached-input 价格。通用 parser 虽能承载未来的 `cache_write_tokens`，但当前通用 registry 结算在缺少 cache-creation 价时会保留零价；若 xAI 日后实际返回该字段，必须先取得 provider 费率证据或明确的本地 billing policy，再启用该路径，不能推断为普通 input 价。
+
+## Registry 采用边界
+
+- 本证据只覆盖上表七个 canonical owner 及“已证实的 direct alias”段列出的已有 direct rows。
+- `grok-4.5` cached input 基础价应从旧 `$0.50/M` 纠正为官方 `$0.30/M`；高价阶通过 2x multiplier 得到 `$0.60/M`。
+- 所有上述 tiered rows 必须同时携带：threshold `200000`、input multiplier `2`、output multiplier `2`、`long_context_threshold_inclusive: true`。
+- 不把 provider/LiteLLM sensor、max context 或邻近型号当作定价事实。
+- 不采纳 Batch API 折扣；本 registry 结算的是普通在线请求。

--- a/scripts/checks/pricing-overlay.py
+++ b/scripts/checks/pricing-overlay.py
@@ -96,6 +96,7 @@ ANCHORS = {
 THINKING_ANCHORS = ("qwen3-8b", "qwen3-14b", "qwen3-32b")
 VIDEO_RESOLUTIONS = {"480p", "720p", "1080p", "4k"}
 VIDEO_SOURCE_CONTRACT = "video_price_tiers is the billing ssot"
+XAI_LONG_CONTEXT_SOURCE_CONTRACT = "xai 200k long-context billing ssot"
 STALE_VIDEO_SOURCE_PHRASES = (
     "tk bills a single",
     "tk's flat",
@@ -227,6 +228,28 @@ def validate_priced_dimension_completeness(model: str, pricing: dict) -> list[st
             f"{model}: long_context_threshold_inclusive requires a complete "
             "long-context policy"
         )
+
+    source = pricing.get("source")
+    source_lower = source.lower() if isinstance(source, str) else ""
+    if XAI_LONG_CONTEXT_SOURCE_CONTRACT in source_lower:
+        if pricing.get("long_context_input_token_threshold") != 200000:
+            errors.append(
+                f"{model}: {XAI_LONG_CONTEXT_SOURCE_CONTRACT} requires "
+                "long_context_input_token_threshold=200000"
+            )
+        if pricing.get("long_context_threshold_inclusive") is not True:
+            errors.append(
+                f"{model}: {XAI_LONG_CONTEXT_SOURCE_CONTRACT} requires "
+                "long_context_threshold_inclusive=true"
+            )
+        for field in (
+                "long_context_input_cost_multiplier",
+                "long_context_output_cost_multiplier"):
+            if not positive(field):
+                errors.append(
+                    f"{model}: {XAI_LONG_CONTEXT_SOURCE_CONTRACT} requires "
+                    f"positive {field}"
+                )
     return errors
 
 

--- a/scripts/checks/test_pricing_overlay.py
+++ b/scripts/checks/test_pricing_overlay.py
@@ -129,6 +129,67 @@ class LongContextThresholdInclusiveBoolShapeTest(unittest.TestCase):
                     self.assertTrue(errors, f"Expected error for value {bad!r}")
 
 
+class XAILongContextEvidenceContractTest(unittest.TestCase):
+    def base_row(self) -> dict:
+        return {
+            "mode": "chat",
+            "input_cost_per_token": 1e-6,
+            "output_cost_per_token": 2e-6,
+            "source": "Dated evidence; xAI 200k long-context billing SSOT.",
+        }
+
+    def errors(self, row: dict) -> list[str]:
+        return CHECK.validate_priced_dimension_completeness("grok-test", row)
+
+    def test_rejects_tagged_row_missing_inclusive_bool(self) -> None:
+        row = self.base_row()
+        row.update({
+            "long_context_input_token_threshold": 200000,
+            "long_context_input_cost_multiplier": 2,
+            "long_context_output_cost_multiplier": 2,
+        })
+        self.assertTrue(self.errors(row))
+
+    def test_rejects_tagged_row_with_explicit_false(self) -> None:
+        row = self.base_row()
+        row.update({
+            "long_context_input_token_threshold": 200000,
+            "long_context_input_cost_multiplier": 2,
+            "long_context_output_cost_multiplier": 2,
+            "long_context_threshold_inclusive": False,
+        })
+        self.assertTrue(self.errors(row))
+
+    def test_rejects_tagged_row_with_partial_policy(self) -> None:
+        row = self.base_row()
+        row.update({
+            "long_context_input_token_threshold": 200000,
+            "long_context_input_cost_multiplier": 2,
+            "long_context_threshold_inclusive": True,
+        })
+        self.assertTrue(self.errors(row))
+
+    def test_accepts_tagged_row_with_complete_inclusive_policy(self) -> None:
+        row = self.base_row()
+        row.update({
+            "long_context_input_token_threshold": 200000,
+            "long_context_input_cost_multiplier": 2,
+            "long_context_output_cost_multiplier": 2,
+            "long_context_threshold_inclusive": True,
+        })
+        self.assertFalse(self.errors(row))
+
+    def test_does_not_apply_contract_to_untagged_xai_row(self) -> None:
+        row = {
+            "mode": "chat",
+            "input_cost_per_token": 1e-6,
+            "output_cost_per_token": 2e-6,
+            "litellm_provider": "xai",
+            "source": "Official flat xAI pricing without a tier contract.",
+        }
+        self.assertFalse(self.errors(row))
+
+
 class PricingRegistryMigrationParityTest(unittest.TestCase):
     def test_reconstructs_legacy_fill_only_precedence(self) -> None:
         external = {


### PR DESCRIPTION
## Summary
- publish dated xAI evidence for seven Grok pricing owners and proven direct aliases
- make the official 200k long-context threshold inclusive in the global registry and correct Grok 4.5 cached-input pricing
- enforce the evidence-tagged policy mechanically and compare complete direct-owner billing dimensions

## Safety
- no runtime publication from the workstation; protected-main `pricing-registry-publish.yml` remains the only writer
- no cache-write price is inferred: current xAI fixtures emit no cache-creation tokens
- no web surface impact
- sentinel-registry-reviewed: existing pricing and Grok sentinel anchors remain sufficient; only registry data and focused tests changed

## Verification
- `python3 scripts/checks/test_pricing_overlay.py`
- `python3 scripts/checks/pricing-overlay.py`
- `python3 ops/pricing/test_pricing_registry_sensor.py`
- focused Grok billing unit tests
- `./scripts/preflight.sh`
- `make test`

ai