### PR TITLE
fix(ops): 按时间索引选取日志清理批次

### DIFF
--- a/backend/internal/service/ops_cleanup_executor.go
+++ b/backend/internal/service/ops_cleanup_executor.go
@@ -151,12 +151,12 @@ func deleteOldRowsByID(
 WITH batch AS (
   SELECT id FROM %s
   WHERE %s
-  ORDER BY id
+  ORDER BY %s, id
   LIMIT $2
 )
 DELETE FROM %s
 WHERE id IN (SELECT id FROM batch)
-`, table, where, table)
+`, table, where, timeColumn, table)
 
 	var total int64
 	for {

--- a/backend/internal/service/ops_cleanup_reclaim_test.go
+++ b/backend/internal/service/ops_cleanup_reclaim_test.go
@@ -10,6 +10,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDeleteOldRowsByID_OrdersByTimeColumnThenID(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	cutoff := time.Unix(0, 0).UTC()
+	mock.ExpectExec(`(?s)SELECT id FROM ops_test\s+WHERE created_at < \$1\s+ORDER BY created_at, id\s+LIMIT \$2`).
+		WithArgs(cutoff, 5000).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	total, err := deleteOldRowsByID(context.Background(), db, "ops_test", "created_at", cutoff, 5000, false, 0)
+	require.NoError(t, err)
+	require.Zero(t, total)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 // Guards the D1 straddling-partition reclaim's per-run cap: the chunked DELETE
 // must stop once it has removed maxRows, so the first reclaim of a large legacy
 // backlog cannot turn into a runaway delete that hammers prod in a single cleanup

--- a/backend/internal/service/ops_cleanup_service.go
+++ b/backend/internal/service/ops_cleanup_service.go
@@ -356,7 +356,7 @@ func (s *OpsCleanupService) runCleanupOnce(ctx context.Context) (opsCleanupDelet
 
 	targets := []opsCleanupTarget{
 		{policy.errorLogRetentionDays, "ops_error_logs", "created_at", false, &out.errorLogs},
-		{policy.errorLogRetentionDays, "ops_alert_events", "created_at", false, &out.alertEvents},
+		{policy.errorLogRetentionDays, "ops_alert_events", "fired_at", false, &out.alertEvents},
 		{policy.systemLogRetentionDays, "ops_system_logs", "created_at", false, &out.systemLogs},
 		{policy.systemLogRetentionDays, "ops_system_log_cleanup_audits", "created_at", false, &out.logAudits},
 		{effective.MinuteMetricsRetentionDays, "ops_system_metrics", "created_at", false, &out.systemMetrics},

--- a/backend/internal/service/ops_cleanup_service_test.go
+++ b/backend/internal/service/ops_cleanup_service_test.go
@@ -38,7 +38,7 @@ func cutoffMatchesDays(t time.Time, days int) bool {
 	return age >= want-time.Minute && age <= want+time.Minute
 }
 
-func expectCleanupTable(t *testing.T, mock sqlmock.Sqlmock, table string, cutoffDays int, deleted int64) {
+func expectCleanupTable(t *testing.T, mock sqlmock.Sqlmock, table, timeColumn string, cutoffDays int, deleted int64) {
 	t.Helper()
 	// opsCleanupRunOne first checks whether the table is partitioned; a plain table
 	// (false) falls through to the chunked DELETE below. (A partitioned table would
@@ -47,10 +47,10 @@ func expectCleanupTable(t *testing.T, mock sqlmock.Sqlmock, table string, cutoff
 	mock.ExpectQuery("pg_partitioned_table").
 		WithArgs(table).
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
-	mock.ExpectExec(table).
+	mock.ExpectExec(`(?s)SELECT id FROM `+table+`\s+WHERE `+timeColumn+` < \$1\s+ORDER BY `+timeColumn+`, id\s+LIMIT \$2`).
 		WithArgs(cutoffDaysArg{days: cutoffDays}, 5000).
 		WillReturnResult(sqlmock.NewResult(0, deleted))
-	mock.ExpectExec(table).
+	mock.ExpectExec(`(?s)SELECT id FROM `+table+`\s+WHERE `+timeColumn+` < \$1\s+ORDER BY `+timeColumn+`, id\s+LIMIT \$2`).
 		WithArgs(cutoffDaysArg{days: cutoffDays}, 5000).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 }
@@ -87,10 +87,10 @@ func TestOpsCleanupServiceRunCleanupOnceUsesSeparateLogRetentions(t *testing.T) 
 
 	// Upstream Wei-Shaw/sub2api commit 2eb622f2 dropped ops_retry_attempts
 	// alongside the retry/replay feature; the cleanup loop no longer touches it.
-	expectCleanupTable(t, mock, "ops_error_logs", 14, 3)
-	expectCleanupTable(t, mock, "ops_alert_events", 14, 1)
-	expectCleanupTable(t, mock, "ops_system_logs", 7, 5)
-	expectCleanupTable(t, mock, "ops_system_log_cleanup_audits", 7, 4)
+	expectCleanupTable(t, mock, "ops_error_logs", "created_at", 14, 3)
+	expectCleanupTable(t, mock, "ops_alert_events", "fired_at", 14, 1)
+	expectCleanupTable(t, mock, "ops_system_logs", "created_at", 7, 5)
+	expectCleanupTable(t, mock, "ops_system_log_cleanup_audits", "created_at", 7, 4)
 
 	counts, err := svc.runCleanupOnce(context.Background())
 	if err != nil {

--- a/scripts/sentinels/perf-query-shape.json
+++ b/scripts/sentinels/perf-query-shape.json
@@ -78,11 +78,12 @@
         "opsStraddleReclaimMaxRowsPerRun",
         "remaining := maxRows - int(total)",
         "limit = min(limit, remaining)",
+        "ORDER BY %s, id",
         "usageLogs     string",
         "billingDedup  string",
         "usage_logs=%s billing_dedup=%s"
       ],
-      "rationale": "Each partitioned cleanup first drops only fully expired bounds, then caps row-level reclaim from a surviving wide legacy partition that still contains expired rows. The SQL LIMIT must use min(batchSize, remaining), not merely stop after a full batch, or the advertised hard cap can overshoot by almost one batch. Removing either bound-driven call or the exact remaining-budget clamp can yield green cleanup heartbeats while disk or lock pressure exceeds the online-safety contract. The shared cleanup heartbeat must also report usage_logs and billing-dedup states now that OpsCleanupService owns those datasets; without the fields, a lifecycle run can look green while omitting the newly transferred owners from its operator-visible result. Partition provisioning is separately guarded by the shared partitionmaintenance owner."
+      "rationale": "Each partitioned cleanup first drops only fully expired bounds, then caps row-level reclaim from a surviving wide legacy partition that still contains expired rows. Batches must sort by the retention time column and then ID so the existing composite time index is used; reverting to ID-only ordering scans and sorts nearly the full legacy wide partition, returns the same result, but runs until the overall cleanup timeout. The SQL LIMIT must use min(batchSize, remaining), not merely stop after a full batch, or the advertised hard cap can overshoot by almost one batch. Removing either bound-driven call or the exact remaining-budget clamp can yield green cleanup heartbeats while disk or lock pressure exceeds the online-safety contract. The shared cleanup heartbeat must also report usage_logs and billing-dedup states now that OpsCleanupService owns those datasets; without the fields, a lifecycle run can look green while omitting the newly transferred owners from its operator-visible result. Partition provisioning is separately guarded by the shared partitionmaintenance owner."
     },
     {
       "path": "backend/internal/repository/dashboard_aggregation_repo.go",

--- a/scripts/sentinels/perf-query-shape.json
+++ b/scripts/sentinels/perf-query-shape.json
@@ -86,6 +86,13 @@
       "rationale": "Each partitioned cleanup first drops only fully expired bounds, then caps row-level reclaim from a surviving wide legacy partition that still contains expired rows. Batches must sort by the retention time column and then ID so the existing composite time index is used; reverting to ID-only ordering scans and sorts nearly the full legacy wide partition, returns the same result, but runs until the overall cleanup timeout. The SQL LIMIT must use min(batchSize, remaining), not merely stop after a full batch, or the advertised hard cap can overshoot by almost one batch. Removing either bound-driven call or the exact remaining-budget clamp can yield green cleanup heartbeats while disk or lock pressure exceeds the online-safety contract. The shared cleanup heartbeat must also report usage_logs and billing-dedup states now that OpsCleanupService owns those datasets; without the fields, a lifecycle run can look green while omitting the newly transferred owners from its operator-visible result. Partition provisioning is separately guarded by the shared partitionmaintenance owner."
     },
     {
+      "path": "backend/internal/service/ops_cleanup_service.go",
+      "must_contain": [
+        "{policy.errorLogRetentionDays, \"ops_alert_events\", \"fired_at\", false, &out.alertEvents}"
+      ],
+      "rationale": "Alert-event retention must use fired_at, the event-time column already indexed and used by alert queries. Using created_at with the shared time-ordered cleanup batch has no supporting index, so a large expired backlog must be sorted before LIMIT and can recreate the cleanup timeout this registry guards against."
+    },
+    {
       "path": "backend/internal/repository/dashboard_aggregation_repo.go",
       "must_contain": [
         "remaining := maxRows - int(total)",


### PR DESCRIPTION
## 摘要

- 将 ops 日志清理批次从按 id 排序改为按 retention 时间列和 id 排序，使 PostgreSQL 使用既有时间索引，避免 us6 旧分区清理超时。
- 将告警事件 retention 对齐到领域时间 `fired_at` 及其既有索引，避免通用批次排序在该表产生无索引排序。
- 新增 SQL 行为回归测试与 perf query-shape sentinel。
- no-web-impact：仅后端清理 SQL 的批次选取顺序和告警事件 retention 时间列变化，无 Web 行为或契约变化。

## 风险

- 低风险。批次大小、每次最多 100 万行、30 分钟超时和错误传播均不变。告警事件由写入时间 `created_at` 改为按业务发生时间 `fired_at` 判断 retention；若存在延迟写入的历史事件，会按实际事件年龄清理，这与告警查询的时间语义一致。

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `make test`
- `go test -tags=unit ./internal/service -run "^(TestDeleteOldRowsByID_|TestOpsCleanupServiceRunCleanupOnceUsesSeparateLogRetentions$)" -count=1`
- `scripts/sentinels/check-perf-query-shape.py`

## 提交

- `fca08540b fix(ops): use retention index for cleanup batches`
- `6ff7215bb fix(ops): address R-001 alert cleanup index`
- 最新提交：`6ff7215bb`