### PR TITLE
fix(ci): 修复 QA 日常诊断工作流解析失败

### DIFF
--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -212,6 +212,7 @@ jobs:
         if: steps.precheck.outputs.skip == 'false'
         env:
           AWS_REGION: ${{ matrix.region }}
+          QA_RAW_ARCHIVE_STACK: ${{ vars.QA_RAW_ARCHIVE_STACK || 'tokenkey-prod-qa-raw-archive' }}
         run: |
           set -euo pipefail
           OUT="prod-ops-targets/$TARGET_ID"
@@ -357,7 +358,7 @@ jobs:
               add_finding "qa_phase2_live_health" "warning" "warning" "QA Phase 2 live probe warning ($TARGET_ID)" "$PHASE2_WARNING" "qa-phase2-live-warning|$TARGET_ID|$PHASE2_WARNING"
             done < <(printf '%s' "$PHASE2_VERDICT" | jq -r '.warnings[]?')
 
-            if QA_BUNDLE_INFRA="$(QA_RAW_ARCHIVE_STACK="${{ vars.QA_RAW_ARCHIVE_STACK || 'tokenkey-prod-qa-raw-archive' }}" bash ops/qa/verify_qa_bundle_infra.sh 2>>"$STDERR")"; then
+            if QA_BUNDLE_INFRA="$(bash ops/qa/verify_qa_bundle_infra.sh 2>>"$STDERR")"; then
               printf 'qa_bundle_infra: %s\n' "$QA_BUNDLE_INFRA" >> "$STDOUT"
               add_finding "qa_bundle_infra" "ok" "info" "QA Bundle infrastructure passed ($TARGET_ID)" "Stack, bucket, queues, ECS capacity, DLQ, and worker image are ready." "qa-bundle-infra|$TARGET_ID"
             else

--- a/ops/observability/test_ops_daily_diagnostics_workflow.py
+++ b/ops/observability/test_ops_daily_diagnostics_workflow.py
@@ -15,10 +15,13 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ops-daily-diagnostics.yml"
 REPAIR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ops-repair-draft.yml"
 ISSUE_LIFECYCLE_NOW = dt.datetime(2026, 7, 23, 9, 0, tzinfo=dt.timezone.utc)
+GITHUB_ACTIONS_MAX_EXPRESSION_CHARS = 21_000
 
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -121,6 +124,26 @@ def run_issue_lifecycle(
 
 
 class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
+    def test_expression_interpolated_run_blocks_fit_github_limit(self) -> None:
+        workflow = yaml.safe_load(workflow_text())
+        oversized: list[str] = []
+
+        for job_name, job in workflow["jobs"].items():
+            for step in job.get("steps", []):
+                run = step.get("run")
+                if not isinstance(run, str) or "${{" not in run:
+                    continue
+                if len(run) >= GITHUB_ACTIONS_MAX_EXPRESSION_CHARS:
+                    oversized.append(
+                        f"{job_name}/{step.get('name', '<unnamed>')}={len(run)}"
+                    )
+
+        self.assertEqual(
+            oversized,
+            [],
+            "GitHub rejects expression-interpolated run blocks at 21000 characters",
+        )
+
     def test_data_layer_safety_is_independent_from_capacity(self) -> None:
         text = workflow_text()
         self.assertIn("probe-data-layer-safety.sh", text)


### PR DESCRIPTION
## 摘要

- 修复 #1686 合并后 `Ops Daily Diagnostics` 无法被 GitHub Actions 解析的问题；失败根因为 36091 字符的 `run` 标量内新增了 GitHub 表达式，超过平台 21000 字符限制。
- 将 `QA_RAW_ARCHIVE_STACK` 表达式上移到 step `env`，现有 QA Bundle 基础设施检查、真实 canary、触发条件和失败分类保持不变。
- 增加结构化 YAML 回归测试，阻止超限的表达式插值 `run` 块再次进入主分支。

## 风险

- 风险等级：高。变更触达生产日常诊断工作流，但只调整表达式求值位置，不改变权限、定时计划、SSM 调用或线上诊断行为。
- 高风险审批锚点：`docs/approved/design-prod-qa-24h-s3-lifecycle.md`。
- Web 影响：无。
- 本次仅提交代码和测试，未部署、未触发线上诊断、未写生产服务或生产数据。

## 验证

- `python3 -m unittest ops.observability.test_ops_daily_diagnostics_workflow -v`：20 项通过。
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：完整通过。
- 回归测试已完成红绿验证：修复前准确报告 `diagnose-targets/Run target diagnostics=36091`，修复后通过。
- `xj-review` 机械门禁：零 preflight finding、零 warn candidate。

## 提交

- `baedb8af7` fix(ci): keep ops diagnostics workflow parseable

最新提交：`baedb8af7`
